### PR TITLE
docs(cli): each extraction states the reason that is true of it

### DIFF
--- a/packages/cli/commands/exec.ts
+++ b/packages/cli/commands/exec.ts
@@ -61,8 +61,11 @@ export interface ExecCommandOptions {
  * the caller has configured, so a token that omitted it would suggest a
  * command that reads a different cell.
  *
- * Extracted from the action body so it is unit-coverable: command action
- * bodies never execute under the unit suite (docs/development/COVERAGE.md).
+ * Standing apart from the action is what lets a test state a result of each
+ * shape and read what came out of the two sinks, rather than mounting a file
+ * and dispatching to it three times. The action body does run under the unit
+ * suite, so what the separation buys is reaching the three outcomes, not
+ * reaching the lines.
  */
 export function renderExecOutcome(
   result: ExecutedMountedCallableFile,
@@ -103,9 +106,10 @@ export function renderExecOutcome(
  * A selection that fails against a RESULT is the other case, and that one does
  * name them.
  *
- * Extracted from the action body for the same reason `renderExecOutcome` is:
- * command action bodies never execute under the unit suite
- * (docs/development/COVERAGE.md).
+ * A named export with a `deps` seam rather than a `try` inside the action:
+ * the exit ends the process, so a malformed selection reached through argv
+ * is read off a stubbed `Deno.exit`, while a direct call reads the report
+ * off the seam the exit contract is written against.
  */
 export async function parseExecSelection(
   options: ExecCommandOptions,
@@ -137,9 +141,11 @@ export async function parseExecSelection(
  * a caller decide rather than guess. The session completing the pair is
  * already on stderr, announced at dispatch.
  *
- * A named export rather than catch-block prose because the action body only
- * runs under Cliffy and is unreachable from a unit test; the seams let a test
- * observe the exact exit contract, and the action's catch calls THIS function.
+ * A named export rather than catch-block prose because the phase is what
+ * chooses between those two reports, and as a parameter a test names it —
+ * reaching the second one through the action would take a mounted callable
+ * that fails after it has dispatched. The seams let a test observe the exact
+ * exit contract, and the action's catch calls THIS function.
  */
 export function exitExecFailure(
   error: unknown,

--- a/packages/cli/commands/invocation-session.ts
+++ b/packages/cli/commands/invocation-session.ts
@@ -8,9 +8,10 @@ import { newSessionId } from "../lib/session.ts";
  * the id is the whole output, so `$(cf invocation-session new)` captures
  * exactly it.
  *
- * The `write` seam is the unit-test hold on the command's output — a command
- * action body only ever runs under Cliffy, and is therefore unreachable from
- * the unit suite. Runtime callers use the default.
+ * The `write` seam is the unit-test hold on the command's output: the id is
+ * random, so what a test can check is the token itself and that two runs
+ * produce different ones, which the seam hands over rather than leaving it
+ * to be scraped off stdout. Runtime callers use the default.
  */
 export function renderNewSession(write: (text: string) => void = render): void {
   write(newSessionId());

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -778,9 +778,10 @@ export function exitWithDataError(
 /**
  * Turn a failed `cf call` into its stderr report, or re-throw.
  *
- * A named function rather than an inline `.catch` in the command action: the
- * action body only ever runs under Cliffy, so anything written there is
- * unreachable from a unit test. The `deps` seam is `exitWithDataError`'s,
+ * A named function rather than an inline `.catch` in the command action:
+ * which of the two it does is decided by the error alone, so a test states
+ * the error and reads the answer instead of provoking one out of a payload
+ * a resolved callable rejects. The `deps` seam is `exitWithDataError`'s,
  * threaded so a test can observe the report without a real process exit.
  *
  * `observer` is the call's phase observer: this exit bypasses the action's
@@ -813,9 +814,11 @@ export function reportVerbInputErrorOrRethrow(
  * the retry key, before exiting 1. A wait-bound expiry additionally writes
  * the Invocation JSON with that phase as its `status` to stdout — the same
  * machine surface as a settled call, so a script parses one shape either
- * way. A named export rather than catch-block prose because the action body
- * only runs under Cliffy and is unreachable from a unit test; the seams let
- * a test observe the exact exit contract, and the action's catch calls THIS
+ * way. A named export rather than catch-block prose because the error and
+ * the phase together pick which of those reports comes out, and both are
+ * parameters a test names — a wait-bound expiry at a chosen phase is
+ * otherwise a call held open until its bound passes. The seams let a test
+ * observe the exact exit contract, and the action's catch calls THIS
  * function, so what the tests observe is what a user gets.
  */
 export function exitPieceCallFailure(
@@ -3007,8 +3010,11 @@ export interface PieceCellCommandDependencies {
  * decides which the positionals name), and either spelling may end in
  * `#argument`, which reads the arguments cell the way `--input` does.
  *
- * A named export with seams rather than an inline action body because action
- * bodies never execute under the unit suite (docs/development/COVERAGE.md).
+ * A named export with seams rather than an arrow function at the `.action()`
+ * call: what the intake decided is the thing under test — which spelling
+ * named the target, the path segments it merged, the read options it
+ * settled — and a caller supplying its own `getCellValue` reads all three
+ * off the call it receives, with no runtime, socket, or server behind it.
  */
 export async function getCellValueFromCommand(
   options: PieceGetCLIOptions,


### PR DESCRIPTION
## Why

Six doc comments in `packages/cli/commands/` explained why a function was
extracted from its command action by asserting that command action bodies
never execute under the unit suite. Four cited
`docs/development/COVERAGE.md` for it.

Neither half is true, and the tests that disprove it sit in the same package:

- `packages/cli/test/verb-section.test.ts` parses a built command in process.
  `packages/cli/test/wish-command.test.ts` says so in its own header —
  "Drives the `cf wish` action body in-process". A measurement taken while
  extracting `callFromCommand` (#6682) put the `cf call` action body at 9
  uncovered lines out of roughly 130.
- COVERAGE.md's rule is about **filenames**: `deno coverage` treats any source
  path ending in `test.ts` as a test file and drops it from the report, so a
  well-tested file scores as entirely uncovered. That is why the `cf test`
  command lives in `commands/test-command.ts`. It says nothing about action
  bodies.

A false reason repeated in six places is worse than no reason: it is the
premise the next extraction gets justified by, and `commands/exec.ts` — the
sibling command with the same grammar — carried it twice.

## What Changed

Comments only. No behavior, no signatures, no moved code.

Each site now states the reason that is true **of that function**, because
they differ. The extractions are worth having; what they buy is reaching the
cases directly rather than reaching lines that were already reached:

- `exitPieceCallFailure` — the error and the phase together choose which
  report comes out, and both are parameters a test names. Reaching the second
  through the action would mean holding a call open until its wait bound
  passes.
- `reportVerbInputErrorOrRethrow` — which of the two things it does is decided
  by the error alone, so a test states the error instead of provoking one out
  of a payload a resolved callable rejects.
- `getCellValueFromCommand` — what the intake decided is the thing under test:
  which spelling named the target, the path segments it merged, the read
  options it settled.
- `renderExecOutcome` — a test states a result of each shape and reads the two
  sinks, rather than mounting a file and dispatching to it three times.
- `parseExecSelection`, `exitExecFailure`, `renderNewSession` — likewise, each
  in its own terms.

Where COVERAGE.md is still cited, it is cited for what it actually says.

## Test plan

`deno fmt --check`, `deno lint`, `deno task check`, and `deno task test` in
`packages/cli` — exit 0, 1758 parallel + 210 serial, 0 failed. No test needed
changing, which is the point: nothing executable moved.

`grep` for the three phrasings across `packages/cli/**/*.ts` returns nothing
after this change. The test-file comments that document driving an action body
in-process are left alone — they are accurate, and they are the evidence.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6705?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

