### PR TITLE
test(cli): let the FUSE suite be asked for part of itself

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -1227,6 +1227,11 @@ jobs:
         env:
           TOOLSHED_PORT: ${{ matrix.toolshed_port }}
           FUSE_DEEP_ENTITY_PROBE: "0"
+          # The section of fuse-exec.sh's dispatch table this leg runs, which
+          # `all` makes every phase of it. packages/cli/test/fuse-sections.test.ts
+          # reads this line and holds it to naming an arm the script defines and
+          # to covering every selectable phase between the sections named here.
+          CF_FUSE_INTEGRATION_SECTION: all
           # Single source for the outer step bound: 'timeout' enforces it, and the
           # script's waits give up a few minutes before it (see
           # FUSE_EXEC_OVERALL_TIMEOUT_SECONDS in integration/fuse-exec.sh) so a

--- a/docs/plans/pull-request-test-selection.md
+++ b/docs/plans/pull-request-test-selection.md
@@ -434,8 +434,8 @@ are, since they only ever ran on `main`.
 phase it goes through, through the `cf_test_step_begin` markers
 `integration.sh` also uses. Each marker leads the phase it names, so a
 phase that fails is the record that carries the failure, and the two
-phases that bring the mount up record like the rest, so a mount that never
-comes up is reported as the mount. Scoring, the flake rate and the
+phases that bring the mount up and wait for it to hydrate record like the
+rest, so a mount that never comes up is reported as the mount. Scoring, the flake rate and the
 60-second ratchet each get a number per phase where they had one covering
 a FUSE mount, a Toolshed server and everything the script does with them.
 
@@ -443,7 +443,7 @@ The script also takes a section, so a lane can be pointed at part of it.
 Which phases can stand alone was a question about the script rather than
 about selection — the same independence question [asked of unit
 tests](#skipping-assumes-tests-do-not-lean-on-each-other) — and the answer
-is four sections rather than 25. A section is a group of phases over one
+is four sections rather than one per phase. A section is a group of phases over one
 mount rather than a phase on its own, because the mount, the daemon and
 the piece cost more than every phase together and each section needs all
 three. Four phases therefore run whichever section was asked for, and are

--- a/docs/plans/pull-request-test-selection.md
+++ b/docs/plans/pull-request-test-selection.md
@@ -429,31 +429,39 @@ become suites. They are not tests; they are setup, and they become
 capability providers. The deploy and attestation jobs stay exactly as they
 are, since they only ever ran on `main`.
 
-**`cli-fuse` must gain fine granularity, and this is not optional.**
-`packages/cli/integration/fuse-exec.sh` is 1,062 lines that record a
-single identity for the entire run, through one
-`cf_test_record_with_status` at the end. Twenty-three `success` markers
-inside it name the phases it goes through, and not one of them reaches the
-store. So the suite's whole cost — a FUSE mount, a Toolshed server and
-everything the script does with them — hangs off one identity that can
-only be scored as a unit, run as a unit, and skipped as a unit. That is
-the worst shape in the topology, and leaving it would mean a single record
-deciding whether several minutes of work runs.
+**`cli-fuse` carries the fine granularity the rest of this depends on.**
+`packages/cli/integration/fuse-exec.sh` records 25 identities, one for each
+phase it goes through, through the `cf_test_step_begin` markers
+`integration.sh` also uses. Each marker leads the phase it names, so a
+phase that fails is the record that carries the failure, and the two
+phases that bring the mount up record like the rest, so a mount that never
+comes up is reported as the mount. Scoring, the flake rate and the
+60-second ratchet each get a number per phase where they had one covering
+a FUSE mount, a Toolshed server and everything the script does with them.
 
-The change has two halves and they are not equally hard. The cheap half is
-step records: the 23 `success` markers become `cf_test_step_begin`
-markers, exactly as `integration.sh` already uses, and the suite goes from
-one identity to 23 without changing what runs. That is worth doing on its
-own, because scoring, the flake rate and the 60-second ratchet all get
-something to work with where today they get one number.
+The script also takes a section, so a lane can be pointed at part of it.
+Which phases can stand alone was a question about the script rather than
+about selection — the same independence question [asked of unit
+tests](#skipping-assumes-tests-do-not-lean-on-each-other) — and the answer
+is four sections rather than 25. A section is a group of phases over one
+mount rather than a phase on its own, because the mount, the daemon and
+the piece cost more than every phase together and each section needs all
+three. Four phases therefore run whichever section was asked for, and are
+not selectable.
 
-The second half is section dispatch, so the script can be asked for a
-subset the way `integration.sh` can. That one is not purely mechanical: a
-linear script builds up a mount, a daemon and a set of pieces, so which
-phases can stand alone is a question about the script rather than about
-selection, and it is the same independence question [asked of unit
-tests](#skipping-assumes-tests-do-not-lean-on-each-other). The answer may
-well be a handful of sections rather than 23, and a handful is enough.
+Two dependencies decide where the boundaries fall, and both are about
+state a phase leaves behind. The handler phases assert `messageCount` as
+an absolute count up from the piece's initial zero, so they stay together
+and in order. The source update ends by asserting `lastMessage` is the
+empty string the truncate phase left, so it sits in the section holding
+that phase. A third ordering is why the entity listing is one of the
+phases that always runs: its assertion is that no entity payload has
+crossed the memory proxy, read from a trace that accumulates over the
+whole run, so nothing may hydrate the piece before it.
+
+`packages/cli/test/fuse-sections.test.ts` holds the dispatch table to
+those orderings, and to every phase being reachable — from `all`, from a
+section smaller than `all`, and from what the workflow dispatches.
 
 `pattern-reload` needs nothing done to it, and is not a special case
 either. `packages/patterns/integration/reload/` holds a single file with a
@@ -635,8 +643,8 @@ mechanism is a skip list rather than a selection list.
 
 ### Every invocation unit, and the identities inside it
 
-There are eight kinds of invocation unit across the topology, and only one
-of them holds more than one identity today. That one holds almost everything:
+There are eight kinds of invocation unit across the topology, and two of
+them hold more than one identity. One of the two holds almost everything:
 the workspace and runner unit shards alone carry 15,997 of the reference
 build's 17,999 executions.
 
@@ -649,14 +657,15 @@ build's 17,999 executions.
 | One gate command | `repo-gates` | One, named for the gate that ran | Nothing to reach. |
 | One `deno check` invocation | `typecheck` | One, named for the path group it checked, which the task records itself | Nothing to reach. |
 | A whole task carrying one record | `cfcheck`, `pattern-vintage` | One, for everything the task did | Nothing to reach, and nothing finer exists: the suite is its own identity. |
-| A script recording one identity for its whole run | `cli-fuse` | One today, 23 once its `success` markers become step markers | Not reachable until the script is split, which [it must be](#todays-jobs-as-suites). This is the one row the topology is not allowed to leave as it is. |
+| A section of `fuse-exec.sh` | `cli-fuse` | The four phases every section runs, and the phases that section selects | Nothing to reach below the section. A mount comes up for the section, not for the phase, so its phases run or are skipped together. |
 
-Six of the eight rows are already one identity per invocation, which is
-why this change is smaller than removing a concept sounds. The topology
-does not gain a mechanism for them; they simply stop being described as
-items holding one identity each and start being described as identities.
-The seventh, `cli-fuse`, is one identity only because nothing finer was
-ever recorded, and it is the row this plan requires somebody to fix.
+Six of the eight rows are one identity per invocation, which is why this
+change is smaller than removing a concept sounds. The topology does not
+gain a mechanism for them; they simply stop being described as items
+holding one identity each and start being described as identities. The
+seventh, `cli-fuse`, holds the phases of whichever section ran, and there
+is nothing finer for the topology to reach, since a mount comes up for the
+section rather than for the phase.
 
 `pattern-reload` is in the first row and not in a row of its own, which is
 worth saying because the plan used to treat it as a special case. It runs
@@ -774,9 +783,9 @@ What the enum was reaching for does survive, one level down. Whether the
 identities inside an invocation unit can be skipped is a property of that
 unit rather than of the suite around it, and the [table
 above](#every-invocation-unit-and-the-identities-inside-it) is where it is
-written down. `cli-fuse` is the illustration: once its 23 phases record
-separately, a section holding four of them will not be able to skip one of
-the four, while a `deno test` file with 23 tests will. Those two suites
+written down. `cli-fuse` is the illustration: its phases record
+separately, and a section holding four of them cannot skip one of the
+four, while a `deno test` file with four tests can. Those two suites
 would have carried the same declaration under the old field and behaved
 differently, which is the sign the field was in the wrong place.
 
@@ -3032,18 +3041,21 @@ exercised on the branch on its own.
       `tasks/server-execution-on-skips.ts`: whole-file entries are declared
       unavailable and omitted from enumeration, while step entries exclude
       only the named leaf identity from unknown and coverage rules.
-- [ ] Give `packages/cli/integration/fuse-exec.sh` fine granularity.
-  - [x] Its 23 `success` markers record, so the suite records 23
-        identities rather than one. The markers trail their phases where
-        `integration.sh`'s lead theirs, so they close a step rather than
-        opening one, through a `cf_test_step_done` beside
-        `cf_test_step_begin`. What that leaves is failure attribution: a
-        phase that fails never reaches its marker, so the failure is
-        carried by the script's own record rather than by a step. Moving
-        each marker ahead of its phase is what buys that back, and is the
-        same reading of the script the dispatch needs.
-  - [ ] It gains a section dispatch over whichever groups of phases can
+- [x] Give `packages/cli/integration/fuse-exec.sh` fine granularity.
+  - [x] Every phase records, so the suite records 25 identities rather
+        than one. Each marker leads the phase it names, through the same
+        `cf_test_step_begin` `integration.sh` uses, so a phase that fails
+        is the record that carries the failure rather than the script's own
+        record carrying it. The two phases that bring the mount up are the
+        identities this adds beyond the 23 the phases already named.
+  - [x] It gains a section dispatch over the four groups of phases that
         stand alone, so `cli-fuse` becomes an item suite like its sibling.
+        A section is a group of phases over one mount, and the
+        dependencies deciding where the boundaries fall are named in
+        [today's jobs as suites](#todays-jobs-as-suites).
+        `packages/cli/test/fuse-sections.test.ts` holds the dispatch table
+        to the properties that make a section schedulable, the way
+        `integration-sections.test.ts` holds its sibling's.
 - [x] Split the `piece-call` CLI integration dispatch into its eight
       recorded steps. Seven already had an arm of their own; the missing
       one for `run_piece_call` is added, and so are the two the

--- a/packages/cli/integration/fuse-exec.sh
+++ b/packages/cli/integration/fuse-exec.sh
@@ -8,10 +8,20 @@ export CF_FUSE_DEBUG=1
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 
-# This sectionless script is one recorded test. The record is written from
-# the existing cleanup trap, which owns EXIT; registering a second trap
-# would replace it. With recording off this initializes nothing, so the
-# suite carries no dependency on the timing helper.
+# The phases to run. A CI leg or a lane asks for one; a bare run does all of
+# them. The variable is this suite's own: CF_CLI_INTEGRATION_SECTION names
+# integration.sh's sections, which are a different set, and neither script
+# accepts the other's.
+SECTION="${CF_FUSE_INTEGRATION_SECTION:-${1:-all}}"
+
+# The script records as one test named "fuse-exec.sh", and each phase below
+# records as its own test named "fuse-exec.sh <phase>". The script's record is
+# written from the existing cleanup trap, which owns EXIT; registering a
+# second trap would replace it. Neither name carries the dispatched section:
+# which section scheduled a phase is run context, and the same phase joins
+# across a CI section leg and a local `all` run. With recording off this
+# initializes nothing, so the suite carries no dependency on the timing
+# helper.
 source "$SCRIPT_DIR/test-records.sh"
 CF_TEST_RECORD_NAME="fuse-exec.sh"
 CF_TEST_RECORD_START_MS=0
@@ -41,10 +51,10 @@ dump_mount_state() {
   local pieces_dir="$MOUNTPOINT/$SPACE/pieces"
   >&2 echo "--- mount state dump ---"
   if path_exists "$pieces_dir" 2; then
-    >&2 run_bounded 5 ls -la "$pieces_dir" 2>&1 || true
+    >&2 bounded 5 ls -la "$pieces_dir" 2>&1 || true
     if path_exists "$pieces_dir/pieces.json" 2; then
       >&2 echo "--- pieces.json ---"
-      >&2 run_bounded 5 cat "$pieces_dir/pieces.json" 2>&1 || true
+      >&2 bounded 5 cat "$pieces_dir/pieces.json" 2>&1 || true
     fi
   else
     >&2 echo "(pieces dir not reachable: $pieces_dir)"
@@ -127,14 +137,14 @@ dump_daemon_state() {
   >&2 echo "--- end daemon state dump ---"
 }
 
-# Each phase of this script announces itself here when it finishes, so
-# each announcement is also the record of one test named for it. Without
-# them the whole script — a FUSE mount, a daemon, and everything done with
-# them — is one identity that can only be scored, run, and skipped as a
-# unit.
-success() {
-  echo "✓ $1"
-  cf_test_step_done "$1"
+# Each phase announces itself here before it runs, so each announcement is
+# also the record of one test named for it, and a phase that fails is the
+# record that carries the failure. Without them the whole script — a FUSE
+# mount, a daemon, and everything done with them — is one identity that can
+# only be scored, run, and skipped as a unit.
+phase() {
+  echo "→ $1"
+  cf_test_step_begin "$1"
 }
 
 if [ -n "${CF_CLI_INTEGRATION_USE_LOCAL:-}" ]; then
@@ -198,7 +208,7 @@ assert_not_exists() {
 # signal. macOS local dev has no 'timeout'; there the command runs unbounded,
 # which is acceptable because the daemon hang this guards against is a CI (Linux)
 # failure mode and not seen on local FUSE-T.
-run_bounded() {
+bounded() {
   local seconds="$1"
   shift
 
@@ -214,7 +224,7 @@ path_exists() {
   local path="$1"
   local probe_timeout="${2:-3}"
 
-  run_bounded "$probe_timeout" test -e "$path" >/dev/null 2>&1
+  bounded "$probe_timeout" test -e "$path" >/dev/null 2>&1
 }
 
 assert_json_eq() {
@@ -548,18 +558,18 @@ kill_fuse_daemon() {
 force_detach() {
   local path="${MOUNTPOINT_REAL:-$1}"
   if [ "$(uname)" = "Darwin" ]; then
-    run_bounded 15 umount -f "$path"
+    bounded 15 umount -f "$path"
   elif command -v fusermount3 >/dev/null 2>&1; then
-    run_bounded 15 fusermount3 -u -z "$path"
+    bounded 15 fusermount3 -u -z "$path"
   else
-    run_bounded 15 umount -l "$path"
+    bounded 15 umount -l "$path"
   fi
 }
 
 # Unmount, bounded by the shared outer deadline (WAIT_DEADLINE_EPOCH) rather than a
 # fixed duration, so a slow-but-succeeding unmount is never cut short — the bound is
 # whatever is left before the CI step's 'timeout' fires, minutes more than an
-# unmount ever needs. Only a genuinely hung teardown reaches it. run_bounded's
+# unmount ever needs. Only a genuinely hung teardown reaches it. bounded's
 # 'timeout' cannot exec a shell function, and local dev's 'cf' is one, so only an
 # external 'cf' (the compiled binary CI runs) is bounded; a 'cf' function runs
 # unbounded, the same as the no-'timeout' local path.
@@ -568,7 +578,7 @@ unmount_until_deadline() {
   remaining=$((WAIT_DEADLINE_EPOCH - $(date +%s)))
   [ "$remaining" -ge 1 ] || remaining=1
   if [ "$(type -t cf)" = "file" ]; then
-    run_bounded "$remaining" cf fuse unmount "$1" >/dev/null 2>&1
+    bounded "$remaining" cf fuse unmount "$1" >/dev/null 2>&1
   else
     cf fuse unmount "$1" >/dev/null 2>&1
   fi
@@ -579,6 +589,10 @@ cleanup() {
   # whether the test has already failed.
   local exit_code=$?
   set +e
+  # Close the step that was running with the body's own status, before the
+  # teardown below adds its time to the clock. A wedged teardown lands on
+  # the script's record further down.
+  cf_test_step_close "$exit_code"
   local can_remove_mountpoint=true
   local wedge_confirmed=false
   # Gate on MOUNTPOINT being set, not on '[ -d "$MOUNTPOINT" ]': that is a getattr
@@ -634,9 +648,6 @@ cleanup() {
   if [ -n "${MEMORY_PROXY_STATE:-}" ]; then
     rmdir "$MEMORY_PROXY_STATE" 2>/dev/null || true
   fi
-  if [ -n "${NO_ARG_HANDLER_ERR:-}" ]; then
-    rm -f "$NO_ARG_HANDLER_ERR"
-  fi
   if [ -n "${INCOMPATIBLE_PATTERN_SRC:-}" ]; then
     rm -f "$INCOMPATIBLE_PATTERN_SRC"
   fi
@@ -666,277 +677,346 @@ if [ -z "${API_URL:-}" ]; then
   error "API_URL must be defined."
 fi
 
-SPACE=$(mktemp -u XXXXXXXXXX)
-IDENTITY=$(mktemp)
-MOUNTPOINT=$(mktemp -d)
-# Resolve the mountpoint's physical path now, while it is still an empty plain
-# directory. After 'cf fuse mount' it is the mount root, and resolving it then
-# would 'cd' across the mount and block on a wedged daemon. The resolved path does
-# not move when the mount appears over it, and it is what 'mount' output and the
-# unmount tools use, so cleanup can test and detach against it without ever
-# touching the mount.
-MOUNTPOINT_REAL=$(cd -P -- "$MOUNTPOINT" 2>/dev/null && pwd)
-SPACE_ARGS="--api-url=$API_URL --identity=$IDENTITY --space=$SPACE"
-PATTERN_SRC="$SCRIPT_DIR/pattern/fuse-exec.tsx"
-CUSTOM_EXPORT="customPatternExport"
+# What every phase runs against: an identity, a stepped piece, the memory
+# proxy that records what the daemon transfers, and a background FUSE mount
+# over a fresh space.
+# Brings the mount up, and everything the mount is of: an identity, a space
+# holding one stepped piece, and the memory proxy the entity listing reads. It
+# records like any other phase, so a mount that never comes up is reported as
+# the mount rather than as the script.
+run_mount() {
+  phase "A background FUSE daemon mounts a space holding one stepped piece"
+  SPACE=$(mktemp -u XXXXXXXXXX)
+  IDENTITY=$(mktemp)
+  MOUNTPOINT=$(mktemp -d)
+  # Resolve the mountpoint's physical path now, while it is still an empty plain
+  # directory. After 'cf fuse mount' it is the mount root, and resolving it then
+  # would 'cd' across the mount and block on a wedged daemon. The resolved path does
+  # not move when the mount appears over it, and it is what 'mount' output and the
+  # unmount tools use, so cleanup can test and detach against it without ever
+  # touching the mount.
+  MOUNTPOINT_REAL=$(cd -P -- "$MOUNTPOINT" 2>/dev/null && pwd)
+  SPACE_ARGS="--api-url=$API_URL --identity=$IDENTITY --space=$SPACE"
+  PATTERN_SRC="$SCRIPT_DIR/pattern/fuse-exec.tsx"
+  CUSTOM_EXPORT="customPatternExport"
+  ENTITY_DEEP_PROBE="${FUSE_DEEP_ENTITY_PROBE:-0}"
 
-# The deadline for every wait that fails the test (see wait_deadline_reached).
-# The default overall bound matches the CI step's 'timeout' in
-# .github/workflows/deno.yml, which sets FUSE_EXEC_OVERALL_TIMEOUT_SECONDS to keep
-# the two in step; the waits give up a few minutes before it so error() can print
-# the daemon's state before the step is cancelled. The floor guards a
-# misconfigured tiny outer bound from making every wait fire at once.
-OVERALL_TIMEOUT_SECONDS="${FUSE_EXEC_OVERALL_TIMEOUT_SECONDS:-480}"
-WAIT_BUDGET_SECONDS=$((OVERALL_TIMEOUT_SECONDS - 300))
-[ "$WAIT_BUDGET_SECONDS" -ge 30 ] || WAIT_BUDGET_SECONDS=$((OVERALL_TIMEOUT_SECONDS / 2 + 1))
-WAIT_DEADLINE_EPOCH=$(($(date +%s) + WAIT_BUDGET_SECONDS))
+  # The deadline for every wait that fails the test (see wait_deadline_reached).
+  # The default overall bound matches the CI step's 'timeout' in
+  # .github/workflows/deno.yml, which sets FUSE_EXEC_OVERALL_TIMEOUT_SECONDS to keep
+  # the two in step; the waits give up a few minutes before it so error() can print
+  # the daemon's state before the step is cancelled. The floor guards a
+  # misconfigured tiny outer bound from making every wait fire at once.
+  OVERALL_TIMEOUT_SECONDS="${FUSE_EXEC_OVERALL_TIMEOUT_SECONDS:-480}"
+  WAIT_BUDGET_SECONDS=$((OVERALL_TIMEOUT_SECONDS - 300))
+  [ "$WAIT_BUDGET_SECONDS" -ge 30 ] || WAIT_BUDGET_SECONDS=$((OVERALL_TIMEOUT_SECONDS / 2 + 1))
+  WAIT_DEADLINE_EPOCH=$(($(date +%s) + WAIT_BUDGET_SECONDS))
 
-echo "API_URL=$API_URL"
-echo "SPACE=$SPACE"
-echo "IDENTITY=$IDENTITY"
-echo "MOUNTPOINT=$MOUNTPOINT"
+  echo "API_URL=$API_URL"
+  echo "SPACE=$SPACE"
+  echo "IDENTITY=$IDENTITY"
+  echo "MOUNTPOINT=$MOUNTPOINT"
 
-cf id new >"$IDENTITY"
+  cf id new >"$IDENTITY"
 
-PIECE_ID=$(cf piece new --main-export "$CUSTOM_EXPORT" $SPACE_ARGS "$PATTERN_SRC")
-echo "Created piece: $PIECE_ID"
-cf piece step $SPACE_ARGS --piece "$PIECE_ID"
-echo "Stepped piece: $PIECE_ID"
-ENTITY_PAYLOAD_MARKER="FUSE_ENTITY_LIST_PAYLOAD_50c21a1f"
-printf '{"lastMessage":"%s","messageCount":0,"legacyCount":0,"messages":[]}\n' \
-  "$ENTITY_PAYLOAD_MARKER" |
-  cf set $SPACE_ARGS --piece "$PIECE_ID" "" --input
+  PIECE_ID=$(cf piece new --main-export "$CUSTOM_EXPORT" $SPACE_ARGS "$PATTERN_SRC")
+  echo "Created piece: $PIECE_ID"
+  cf piece step $SPACE_ARGS --piece "$PIECE_ID"
+  echo "Stepped piece: $PIECE_ID"
+  ENTITY_PAYLOAD_MARKER="FUSE_ENTITY_LIST_PAYLOAD_50c21a1f"
+  printf '{"lastMessage":"%s","messageCount":0,"legacyCount":0,"messages":[]}\n' \
+    "$ENTITY_PAYLOAD_MARKER" |
+    cf set $SPACE_ARGS --piece "$PIECE_ID" "" --input
 
-MEMORY_PROXY_STATE=$(mktemp -d)
-MEMORY_TRACE="$MEMORY_PROXY_STATE/frames"
-MEMORY_PROXY_READY="$MEMORY_PROXY_STATE/ready"
-mkfifo "$MEMORY_PROXY_READY"
-deno run --allow-net --allow-write="$MEMORY_TRACE" \
-  "$SCRIPT_DIR/fuse-memory-proxy.ts" "$API_URL" "$MEMORY_TRACE" \
-  >"$MEMORY_PROXY_READY" &
-MEMORY_PROXY_PID=$!
-if ! IFS= read -r FUSE_API_URL <"$MEMORY_PROXY_READY"; then
-  error "FUSE memory proxy exited before reporting its listening address."
-fi
-rm -f "$MEMORY_PROXY_READY"
-MEMORY_PROXY_READY=""
+  MEMORY_PROXY_STATE=$(mktemp -d)
+  MEMORY_TRACE="$MEMORY_PROXY_STATE/frames"
+  MEMORY_PROXY_READY="$MEMORY_PROXY_STATE/ready"
+  mkfifo "$MEMORY_PROXY_READY"
+  deno run --allow-net --allow-write="$MEMORY_TRACE" \
+    "$SCRIPT_DIR/fuse-memory-proxy.ts" "$API_URL" "$MEMORY_TRACE" \
+    >"$MEMORY_PROXY_READY" &
+  MEMORY_PROXY_PID=$!
+  if ! IFS= read -r FUSE_API_URL <"$MEMORY_PROXY_READY"; then
+    error "FUSE memory proxy exited before reporting its listening address."
+  fi
+  rm -f "$MEMORY_PROXY_READY"
+  MEMORY_PROXY_READY=""
 
-MOUNT_OUTPUT=$(cf fuse mount "$MOUNTPOINT" --api-url="$FUSE_API_URL" --identity="$IDENTITY" --space="$SPACE" --background --dangerously-allow-incompatible-schema)
-echo "$MOUNT_OUTPUT"
+  MOUNT_OUTPUT=$(cf fuse mount "$MOUNTPOINT" --api-url="$FUSE_API_URL" --identity="$IDENTITY" --space="$SPACE" --background --dangerously-allow-incompatible-schema)
+  echo "$MOUNT_OUTPUT"
 
-MOUNT_PID="${MOUNT_OUTPUT#*PID }"
-if [ "$MOUNT_PID" = "$MOUNT_OUTPUT" ]; then
-  error "Could not parse fuse daemon PID from mount output."
-fi
-
-MOUNT_PID="${MOUNT_PID%%)*}"
-case "$MOUNT_PID" in
-  ''|*[!0-9]*)
+  MOUNT_PID="${MOUNT_OUTPUT#*PID }"
+  if [ "$MOUNT_PID" = "$MOUNT_OUTPUT" ]; then
     error "Could not parse fuse daemon PID from mount output."
-    ;;
-esac
+  fi
 
-# The background mount prints a 'log:' line pointing at the daemon's log file (see
-# packages/cli/commands/fuse.ts). That file lives off the mount, so it stays
-# readable even when the mount itself is wedged, and the trace assertions and the
-# failure-path daemon dump both read it. It is required, so a parse miss is fatal.
-DAEMON_LOG=$(printf '%s\n' "$MOUNT_OUTPUT" | sed -n 's/^[[:space:]]*log:[[:space:]]*//p')
-if [ -z "$DAEMON_LOG" ]; then
-  error "Could not parse fuse daemon log path from mount output."
-fi
+  MOUNT_PID="${MOUNT_PID%%)*}"
+  case "$MOUNT_PID" in
+    ''|*[!0-9]*)
+      error "Could not parse fuse daemon PID from mount output."
+      ;;
+  esac
 
-# 'cf fuse mount --background' returns only after the daemon has reported the
-# 'mounted' supervisor state and been confirmed alive. The daemon reports that
-# just before it enters its FUSE session loop, and mounted paths hydrate lazily,
-# so the wait_for_path calls below cover the rest.
-if ! kill -0 "$MOUNT_PID" >/dev/null 2>&1; then
-  error "Fuse daemon exited immediately after reporting mount readiness."
-fi
+  # The background mount prints a 'log:' line pointing at the daemon's log file (see
+  # packages/cli/commands/fuse.ts). That file lives off the mount, so it stays
+  # readable even when the mount itself is wedged, and the trace assertions and the
+  # failure-path daemon dump both read it. It is required, so a parse miss is fatal.
+  DAEMON_LOG=$(printf '%s\n' "$MOUNT_OUTPUT" | sed -n 's/^[[:space:]]*log:[[:space:]]*//p')
+  if [ -z "$DAEMON_LOG" ]; then
+    error "Could not parse fuse daemon log path from mount output."
+  fi
 
-ENTITIES_DIR="$MOUNTPOINT/$SPACE/entities"
-wait_for_path "$ENTITIES_DIR"
-MOUNTED_ENTITY_DIRS=$(find "$ENTITIES_DIR" -mindepth 1 -maxdepth 1 -type d -print)
-if [ -z "$MOUNTED_ENTITY_DIRS" ]; then
-  error "Mounted entities directory did not contain any entity directories."
-fi
-if ! grep -Fq "$PIECE_ID" "$MEMORY_TRACE"; then
-  error "Listing mounted entity directories did not transfer the known entity identifier."
-fi
-if grep -Fq "$ENTITY_PAYLOAD_MARKER" "$MEMORY_TRACE"; then
-  error "Listing mounted entity directories transferred entity payload bytes."
-fi
-success "Listing every mounted entity directory transfers identifiers without entity payload bytes"
+  # 'cf fuse mount --background' returns only after the daemon has reported the
+  # 'mounted' supervisor state and been confirmed alive. The daemon reports that
+  # just before it enters its FUSE session loop, and mounted paths hydrate lazily,
+  # so the wait_for_path calls below cover the rest.
+  if ! kill -0 "$MOUNT_PID" >/dev/null 2>&1; then
+    error "Fuse daemon exited immediately after reporting mount readiness."
+  fi
 
-wait_for_path "$MOUNTPOINT/$SPACE/pieces"
+  # The layout of the mounted tree, named once so every phase addresses the
+  # same paths whichever section reached it.
+  ENTITIES_DIR="$MOUNTPOINT/$SPACE/entities"
+  STATUS_FILE="$MOUNTPOINT/.status"
+  PIECE_NAME="Fuse-Exec-Fixture"
+  PIECE_DIR="$MOUNTPOINT/$SPACE/pieces/$PIECE_NAME"
+  INPUT_DIR="$PIECE_DIR/input"
+  INPUT_LAST_MESSAGE="$INPUT_DIR/lastMessage"
+  RESULT_DIR="$PIECE_DIR/result"
+  RESULT_JSON="$PIECE_DIR/result.json"
+  META_JSON="$PIECE_DIR/meta.json"
+  HANDLER_FILE="$RESULT_DIR/recordMessage.handler"
+  LEGACY_HANDLER_FILE="$RESULT_DIR/legacyWrite.handler"
+  TOOL_FILE="$RESULT_DIR/search.tool"
 
-PIECE_NAME="Fuse-Exec-Fixture"
-PIECE_DIR="$MOUNTPOINT/$SPACE/pieces/$PIECE_NAME"
-INPUT_DIR="$PIECE_DIR/input"
-INPUT_LAST_MESSAGE="$INPUT_DIR/lastMessage"
-RESULT_DIR="$PIECE_DIR/result"
-RESULT_JSON="$PIECE_DIR/result.json"
-META_JSON="$PIECE_DIR/meta.json"
-wait_for_path "$PIECE_DIR"
-wait_for_path "$RESULT_DIR"
-wait_for_path "$RESULT_JSON"
-wait_for_path "$META_JSON"
+  wait_for_path "$ENTITIES_DIR"
+}
 
-ENTITY_ID=$(jq -r '.entityId' "$META_JSON")
-if [ -z "$ENTITY_ID" ] || [ "$ENTITY_ID" = "null" ]; then
-  error "Mounted meta.json did not include an entityId."
-fi
+# Runs before any phase reads a piece: the assertion is that nothing but
+# identifiers has crossed the memory proxy, and reading a piece transfers
+# its payload. Every section runs it, ahead of the phases it selected.
+run_entity_listing() {
+  phase "Listing every mounted entity directory transfers identifiers without entity payload bytes"
+  MOUNTED_ENTITY_DIRS=$(find "$ENTITIES_DIR" -mindepth 1 -maxdepth 1 -type d -print)
+  if [ -z "$MOUNTED_ENTITY_DIRS" ]; then
+    error "Mounted entities directory did not contain any entity directories."
+  fi
+  if ! grep -Fq "$PIECE_ID" "$MEMORY_TRACE"; then
+    error "Listing mounted entity directories did not transfer the known entity identifier."
+  fi
+  if grep -Fq "$ENTITY_PAYLOAD_MARKER" "$MEMORY_TRACE"; then
+    error "Listing mounted entity directories transferred entity payload bytes."
+  fi
+}
 
-ENTITY_BARE_ID="${ENTITY_ID#of:}"
-ENTITY_DEEP_PROBE="${FUSE_DEEP_ENTITY_PROBE:-0}"
-ENTITY_DIR=$(resolve_entity_dir "$ENTITIES_DIR" "$ENTITY_ID" || true)
-if [ -z "$ENTITY_DIR" ]; then
-  error "Timed out waiting for entity directory entry for $ENTITY_ID."
-fi
+# The lazily hydrated part of the mounted tree, which every phase below the
+# entity listing addresses. It records for the same reason the mount does.
+run_piece_paths() {
+  phase "The mounted piece's directory and documents hydrate"
+  wait_for_path "$MOUNTPOINT/$SPACE/pieces"
+  wait_for_path "$PIECE_DIR"
+  wait_for_path "$RESULT_DIR"
+  wait_for_path "$RESULT_JSON"
+  wait_for_path "$META_JSON"
 
-# A single read is enough to prove the generated file is served as one coherent
-# document through a real getattr and read. That the counters it carries are
-# fresh and advance is settled deterministically by the CellBridge.status unit
-# tests; asserting it here would mean polling out the macOS NFS attribute cache,
-# and this suite adds no waits it can avoid.
-STATUS_FILE="$MOUNTPOINT/.status"
-path_exists "$STATUS_FILE" || error ".status was not mounted at the mount root."
-cat "$STATUS_FILE" | jq -e . >/dev/null ||
-  error ".status did not read back as a whole JSON document."
-success ".status reads as a whole JSON document"
+  ENTITY_ID=$(jq -r '.entityId' "$META_JSON")
+  if [ -z "$ENTITY_ID" ] || [ "$ENTITY_ID" = "null" ]; then
+    error "Mounted meta.json did not include an entityId."
+  fi
+}
 
-HANDLER_FILE="$RESULT_DIR/recordMessage.handler"
-LEGACY_HANDLER_FILE="$RESULT_DIR/legacyWrite.handler"
-TOOL_FILE="$RESULT_DIR/search.tool"
+run_entities_entry() {
+  phase "Entities namespace exposes matching entry for mounted piece"
+  ENTITY_DIR=$(resolve_entity_dir "$ENTITIES_DIR" "$ENTITY_ID" || true)
+  if [ -z "$ENTITY_DIR" ]; then
+    error "Timed out waiting for entity directory entry for $ENTITY_ID."
+  fi
+}
 
-wait_for_path "$HANDLER_FILE"
-wait_for_path "$LEGACY_HANDLER_FILE"
-wait_for_path "$TOOL_FILE"
+run_status_document() {
+  phase ".status reads as a whole JSON document"
+  # A single read is enough to prove the generated file is served as one coherent
+  # document through a real getattr and read. That the counters it carries are
+  # fresh and advance is settled deterministically by the CellBridge.status unit
+  # tests; asserting it here would mean polling out the macOS NFS attribute cache,
+  # and this suite adds no waits it can avoid.
+  path_exists "$STATUS_FILE" || error ".status was not mounted at the mount root."
+  cat "$STATUS_FILE" | jq -e . >/dev/null ||
+    error ".status did not read back as a whole JSON document."
+}
 
-path_exists "$HANDLER_FILE" || error "recordMessage.handler was not mounted."
-path_exists "$LEGACY_HANDLER_FILE" || error "legacyWrite.handler was not mounted."
-path_exists "$TOOL_FILE" || error "search.tool was not mounted."
-success "Mounted callable entries exist"
-success "Entities namespace exposes matching entry for mounted piece"
+# The waits here are what puts the callable files in place for the phases
+# that run them, so every section using one runs this phase first.
+run_callable_entries() {
+  phase "Mounted callable entries exist"
+  wait_for_path "$HANDLER_FILE"
+  wait_for_path "$LEGACY_HANDLER_FILE"
+  wait_for_path "$TOOL_FILE"
 
-assert_not_exists "$RESULT_DIR/search" "Pattern tool internals should not be exposed as a directory."
-wait_for_json "$RESULT_JSON" '.recordMessage == {"/handler":"recordMessage"}' \
-  "result.json should render recordMessage as a handler sigil"
-wait_for_json "$RESULT_JSON" '.legacyWrite == {"/handler":"legacyWrite"}' \
-  "result.json should render legacyWrite as a handler sigil"
-wait_for_json "$RESULT_JSON" '.search == {"/tool":"search"}' \
-  "result.json should render search as a tool sigil"
-success "Mounted JSON surface hides callable internals"
+  path_exists "$HANDLER_FILE" || error "recordMessage.handler was not mounted."
+  path_exists "$LEGACY_HANDLER_FILE" || error "legacyWrite.handler was not mounted."
+  path_exists "$TOOL_FILE" || error "search.tool was not mounted."
+}
 
-HANDLER_FIRST_LINE=$(head -n 1 "$HANDLER_FILE")
-TOOL_FIRST_LINE=$(head -n 1 "$TOOL_FILE")
-test -x "$HANDLER_FILE" || error "Handler file should be executable."
-test -x "$TOOL_FILE" || error "Tool file should be executable."
-assert_contains "$HANDLER_FIRST_LINE" "#!" "Handler file should start with a shebang."
-assert_contains "$HANDLER_FIRST_LINE" " exec" "Handler shebang should invoke cf exec."
-assert_contains "$TOOL_FIRST_LINE" "#!" "Tool file should start with a shebang."
-assert_contains "$TOOL_FIRST_LINE" " exec" "Tool shebang should invoke cf exec."
-success "Callable files are executable and expose cf exec shebangs"
+run_callable_json_surface() {
+  phase "Mounted JSON surface hides callable internals"
+  assert_not_exists "$RESULT_DIR/search" "Pattern tool internals should not be exposed as a directory."
+  wait_for_json "$RESULT_JSON" '.recordMessage == {"/handler":"recordMessage"}' \
+    "result.json should render recordMessage as a handler sigil"
+  wait_for_json "$RESULT_JSON" '.legacyWrite == {"/handler":"legacyWrite"}' \
+    "result.json should render legacyWrite as a handler sigil"
+  wait_for_json "$RESULT_JSON" '.search == {"/tool":"search"}' \
+    "result.json should render search as a tool sigil"
+}
 
-COUNT_BEFORE_HELP=$(read_piece_value_or_default "messageCount" "0")
-HANDLER_HELP=$(cf exec "$HANDLER_FILE" --help)
-TOOL_HELP=$(cf exec "$TOOL_FILE" --help)
-TOOL_HELP_JSON=$(cf exec "$TOOL_FILE" --help --json)
-DIRECT_HANDLER_HELP=$("$HANDLER_FILE" --help)
-assert_contains "$HANDLER_HELP" "cf exec" "cf exec help should describe the cf exec call form."
-assert_contains "$HANDLER_HELP" "[invoke] --message <string>" "Handler help should show the optional invoke verb."
-assert_contains "$HANDLER_HELP" "--message <string>" "Handler help should expand schema-derived flags."
-assert_contains "$HANDLER_HELP" "Required." "Handler help should mark required flags."
-# A handler's help says nothing about output rather than asserting there is
-# none: a verb declared `Stream<E, R>` does return a result, and this page
-# cannot see the declaration.
-assert_not_contains "$HANDLER_HELP" "Output:" "Handler help should carry no Output section."
-assert_contains "$HANDLER_HELP" "Alternatively, write JSON to this file to invoke the handler." "Handler help should mention write-through invocation."
-assert_contains "$TOOL_HELP" "[run] --query <string>" "Tool help should show the optional run verb."
-assert_contains "$TOOL_HELP" "--query <string>" "Tool help should expand schema-derived flags."
-assert_contains "$TOOL_HELP" "JSON on success:" "Tool help should show JSON output."
-assert_contains "$TOOL_HELP" "--help --json" "Tool help should mention machine-readable schema help."
-assert_contains "$DIRECT_HANDLER_HELP" "[invoke] --message <string>" "Direct help should show the optional invoke verb."
-assert_contains "$DIRECT_HANDLER_HELP" "$HANDLER_FILE" "Direct help should mention the mounted file path."
-assert_contains "$DIRECT_HANDLER_HELP" "--message <string>" "Direct help should show the mounted file call form."
-if [[ "$DIRECT_HANDLER_HELP" == *"cf exec $HANDLER_FILE"* ]]; then
-  error "Direct help should hide the cf exec call form."
-fi
-printf '%s\n' "$TOOL_HELP_JSON" | jq -e '.inputSchema.required == ["query"]' >/dev/null ||
-  error "Machine-readable help should include the input schema."
-printf '%s\n' "$TOOL_HELP_JSON" | jq -e '.outputSchema.properties.summary.type == "string"' >/dev/null ||
-  error "Machine-readable help should include the output schema."
-COUNT_AFTER_HELP=$(read_piece_value_or_default "messageCount" "0")
-if [ "$COUNT_AFTER_HELP" != "$COUNT_BEFORE_HELP" ]; then
-  error "Top-level cf exec --help should not mutate messageCount. Expected: $COUNT_BEFORE_HELP, got: $COUNT_AFTER_HELP"
-fi
-success "Top-level and direct --help print agent-oriented callable help without invoking callables"
+run_callable_shebangs() {
+  phase "Callable files are executable and expose cf exec shebangs"
+  HANDLER_FIRST_LINE=$(head -n 1 "$HANDLER_FILE")
+  TOOL_FIRST_LINE=$(head -n 1 "$TOOL_FILE")
+  test -x "$HANDLER_FILE" || error "Handler file should be executable."
+  test -x "$TOOL_FILE" || error "Tool file should be executable."
+  assert_contains "$HANDLER_FIRST_LINE" "#!" "Handler file should start with a shebang."
+  assert_contains "$HANDLER_FIRST_LINE" " exec" "Handler shebang should invoke cf exec."
+  assert_contains "$TOOL_FIRST_LINE" "#!" "Tool file should start with a shebang."
+  assert_contains "$TOOL_FIRST_LINE" " exec" "Tool shebang should invoke cf exec."
+}
 
-"$HANDLER_FILE" --message "piece-direct"
-wait_for_piece_value "lastMessage" '"piece-direct"'
-wait_for_piece_value "messageCount" "1"
-DIRECT_TOOL=$("$TOOL_FILE" --query "direct" --help "via-shebang")
-assert_json_eq \
-  "$DIRECT_TOOL" \
-  '{"help":"via-shebang","query":"direct","source":"bound-source","summary":"bound-source:direct:via-shebang"}' \
-  "Direct tool execution returned unexpected JSON"
-success "Mounted callables can be executed directly through their shebangs"
+run_callable_help() {
+  phase "Top-level and direct --help print agent-oriented callable help without invoking callables"
+  COUNT_BEFORE_HELP=$(read_piece_value_or_default "messageCount" "0")
+  HANDLER_HELP=$(cf exec "$HANDLER_FILE" --help)
+  TOOL_HELP=$(cf exec "$TOOL_FILE" --help)
+  TOOL_HELP_JSON=$(cf exec "$TOOL_FILE" --help --json)
+  DIRECT_HANDLER_HELP=$("$HANDLER_FILE" --help)
+  assert_contains "$HANDLER_HELP" "cf exec" "cf exec help should describe the cf exec call form."
+  assert_contains "$HANDLER_HELP" "[invoke] --message <string>" "Handler help should show the optional invoke verb."
+  assert_contains "$HANDLER_HELP" "--message <string>" "Handler help should expand schema-derived flags."
+  assert_contains "$HANDLER_HELP" "Required." "Handler help should mark required flags."
+  # A handler's help says nothing about output rather than asserting there is
+  # none: a verb declared `Stream<E, R>` does return a result, and this page
+  # cannot see the declaration.
+  assert_not_contains "$HANDLER_HELP" "Output:" "Handler help should carry no Output section."
+  assert_contains "$HANDLER_HELP" "Alternatively, write JSON to this file to invoke the handler." "Handler help should mention write-through invocation."
+  assert_contains "$TOOL_HELP" "[run] --query <string>" "Tool help should show the optional run verb."
+  assert_contains "$TOOL_HELP" "--query <string>" "Tool help should expand schema-derived flags."
+  assert_contains "$TOOL_HELP" "JSON on success:" "Tool help should show JSON output."
+  assert_contains "$TOOL_HELP" "--help --json" "Tool help should mention machine-readable schema help."
+  assert_contains "$DIRECT_HANDLER_HELP" "[invoke] --message <string>" "Direct help should show the optional invoke verb."
+  assert_contains "$DIRECT_HANDLER_HELP" "$HANDLER_FILE" "Direct help should mention the mounted file path."
+  assert_contains "$DIRECT_HANDLER_HELP" "--message <string>" "Direct help should show the mounted file call form."
+  if [[ "$DIRECT_HANDLER_HELP" == *"cf exec $HANDLER_FILE"* ]]; then
+    error "Direct help should hide the cf exec call form."
+  fi
+  printf '%s\n' "$TOOL_HELP_JSON" | jq -e '.inputSchema.required == ["query"]' >/dev/null ||
+    error "Machine-readable help should include the input schema."
+  printf '%s\n' "$TOOL_HELP_JSON" | jq -e '.outputSchema.properties.summary.type == "string"' >/dev/null ||
+    error "Machine-readable help should include the output schema."
+  COUNT_AFTER_HELP=$(read_piece_value_or_default "messageCount" "0")
+  if [ "$COUNT_AFTER_HELP" != "$COUNT_BEFORE_HELP" ]; then
+    error "Top-level cf exec --help should not mutate messageCount. Expected: $COUNT_BEFORE_HELP, got: $COUNT_AFTER_HELP"
+  fi
+}
 
-printf '{"message":"stdin-handler"}' | cf exec "$HANDLER_FILE" --json
-wait_for_piece_value "lastMessage" '"stdin-handler"'
-wait_for_piece_value "messageCount" "2"
-success "cf exec reads handler JSON input from stdin"
+# This phase and the three handler phases after it read messageCount as an
+# absolute count, from the zero the piece starts at, so the four run together
+# and in this order. The tool phases between them leave the count alone.
+run_handler_direct_exec() {
+  phase "Mounted callables can be executed directly through their shebangs"
+  "$HANDLER_FILE" --message "piece-direct"
+  wait_for_piece_value "lastMessage" '"piece-direct"'
+  wait_for_piece_value "messageCount" "1"
+  DIRECT_TOOL=$("$TOOL_FILE" --query "direct" --help "via-shebang")
+  assert_json_eq \
+    "$DIRECT_TOOL" \
+    '{"help":"via-shebang","query":"direct","source":"bound-source","summary":"bound-source:direct:via-shebang"}' \
+    "Direct tool execution returned unexpected JSON"
+}
 
-DIRECT_TOOL_STDIN=$(printf '{"query":"stdin-tool","help":"stdin-help"}' | "$TOOL_FILE" --json)
-assert_json_eq \
-  "$DIRECT_TOOL_STDIN" \
-  '{"help":"stdin-help","query":"stdin-tool","source":"bound-source","summary":"bound-source:stdin-tool:stdin-help"}' \
-  "Direct tool execution with stdin JSON returned unexpected JSON"
-success "Mounted tools read JSON input from stdin"
+run_handler_stdin() {
+  phase "cf exec reads handler JSON input from stdin"
+  printf '{"message":"stdin-handler"}' | cf exec "$HANDLER_FILE" --json
+  wait_for_piece_value "lastMessage" '"stdin-handler"'
+  wait_for_piece_value "messageCount" "2"
+}
 
-cf exec "$HANDLER_FILE" --message "piece-explicit"
-wait_for_piece_value "lastMessage" '"piece-explicit"'
-wait_for_piece_value "messageCount" "3"
-success "cf exec invokes mounted handlers with schema-derived flags"
+run_tool_stdin() {
+  phase "Mounted tools read JSON input from stdin"
+  DIRECT_TOOL_STDIN=$(printf '{"query":"stdin-tool","help":"stdin-help"}' | "$TOOL_FILE" --json)
+  assert_json_eq \
+    "$DIRECT_TOOL_STDIN" \
+    '{"help":"stdin-help","query":"stdin-tool","source":"bound-source","summary":"bound-source:stdin-tool:stdin-help"}' \
+    "Direct tool execution with stdin JSON returned unexpected JSON"
+}
 
-cf exec "$HANDLER_FILE" --message "piece-implicit"
-wait_for_piece_value "lastMessage" '"piece-implicit"'
-wait_for_piece_value "messageCount" "4"
-success "cf exec invokes mounted handlers without an explicit verb"
+run_handler_flags() {
+  phase "cf exec invokes mounted handlers with schema-derived flags"
+  cf exec "$HANDLER_FILE" --message "piece-explicit"
+  wait_for_piece_value "lastMessage" '"piece-explicit"'
+  wait_for_piece_value "messageCount" "3"
+}
 
-TOOL_EXPLICIT=$(cf exec "$TOOL_FILE" --query "explicit" --help "schema-field")
-assert_json_eq \
-  "$TOOL_EXPLICIT" \
-  '{"help":"schema-field","query":"explicit","source":"bound-source","summary":"bound-source:explicit:schema-field"}' \
-  "Explicit tool execution returned unexpected JSON"
-success "cf exec runs mounted tools with schema-derived flags"
+run_handler_implicit_verb() {
+  phase "cf exec invokes mounted handlers without an explicit verb"
+  cf exec "$HANDLER_FILE" --message "piece-implicit"
+  wait_for_piece_value "lastMessage" '"piece-implicit"'
+  wait_for_piece_value "messageCount" "4"
+}
 
-HELP_FIELD_OUTPUT=$(cf exec "$TOOL_FILE" --help "literal-help" --query "help-field")
-assert_json_eq \
-  "$HELP_FIELD_OUTPUT" \
-  '{"help":"literal-help","query":"help-field","source":"bound-source","summary":"bound-source:help-field:literal-help"}' \
-  "Top-level --help with a value should be parsed as the tool schema field"
-success "Top-level --help with a value is parsed as the schema field when present"
+run_tool_flags() {
+  phase "cf exec runs mounted tools with schema-derived flags"
+  TOOL_EXPLICIT=$(cf exec "$TOOL_FILE" --query "explicit" --help "schema-field")
+  assert_json_eq \
+    "$TOOL_EXPLICIT" \
+    '{"help":"schema-field","query":"explicit","source":"bound-source","summary":"bound-source:explicit:schema-field"}' \
+    "Explicit tool execution returned unexpected JSON"
+}
 
-TOOL_IMPLICIT=$(cf exec "$TOOL_FILE" --query "implicit" --help "")
-assert_json_eq \
-  "$TOOL_IMPLICIT" \
-  '{"help":"","query":"implicit","source":"bound-source","summary":"bound-source:implicit:"}' \
-  "Implicit tool execution returned unexpected JSON"
-success "cf exec runs mounted tools without an explicit verb"
+run_tool_help_field() {
+  phase "Top-level --help with a value is parsed as the schema field when present"
+  HELP_FIELD_OUTPUT=$(cf exec "$TOOL_FILE" --help "literal-help" --query "help-field")
+  assert_json_eq \
+    "$HELP_FIELD_OUTPUT" \
+    '{"help":"literal-help","query":"help-field","source":"bound-source","summary":"bound-source:help-field:literal-help"}' \
+    "Top-level --help with a value should be parsed as the tool schema field"
+}
 
-LEGACY_COUNT_BEFORE_EXEC=$(read_piece_value_or_default "legacyCount" "0")
-cf exec "$LEGACY_HANDLER_FILE"
-wait_for_piece_value "legacyCount" "$((LEGACY_COUNT_BEFORE_EXEC + 1))"
-cf exec "$LEGACY_HANDLER_FILE" invoke
-wait_for_piece_value "legacyCount" "$((LEGACY_COUNT_BEFORE_EXEC + 2))"
-success "Empty-object handlers run without an explicit verb, and invoke still works"
+run_tool_implicit_verb() {
+  phase "cf exec runs mounted tools without an explicit verb"
+  TOOL_IMPLICIT=$(cf exec "$TOOL_FILE" --query "implicit" --help "")
+  assert_json_eq \
+    "$TOOL_IMPLICIT" \
+    '{"help":"","query":"implicit","source":"bound-source","summary":"bound-source:implicit:"}' \
+    "Implicit tool execution returned unexpected JSON"
+}
 
-COUNT_BEFORE_PIECES_SHARED=$(read_piece_value_or_default "messageCount" "0")
-cf exec "$HANDLER_FILE" --message "shared-message"
-wait_for_piece_value "lastMessage" '"shared-message"'
-wait_for_piece_value "messageCount" "$((COUNT_BEFORE_PIECES_SHARED + 1))"
+run_empty_object_handler() {
+  phase "Empty-object handlers run without an explicit verb, and invoke still works"
+  LEGACY_COUNT_BEFORE_EXEC=$(read_piece_value_or_default "legacyCount" "0")
+  cf exec "$LEGACY_HANDLER_FILE"
+  wait_for_piece_value "legacyCount" "$((LEGACY_COUNT_BEFORE_EXEC + 1))"
+  cf exec "$LEGACY_HANDLER_FILE" invoke
+  wait_for_piece_value "legacyCount" "$((LEGACY_COUNT_BEFORE_EXEC + 2))"
+}
 
-if [ "$ENTITY_DEEP_PROBE" = "1" ]; then
+# The deep probe compares the two namespaces and is off by default. The
+# pieces-side invocation is the baseline the entities-side one is compared
+# against and runs whichever way FUSE_DEEP_ENTITY_PROBE is set; which phase
+# owns it is what the probe decides.
+run_shared_backing_cell() {
+  if [ "$ENTITY_DEEP_PROBE" = "1" ]; then
+    phase "Handler execution through pieces/ and entities/ reaches the same backing cell"
+  else
+    phase "Deep entities callable probe skipped"
+  fi
+  COUNT_BEFORE_PIECES_SHARED=$(read_piece_value_or_default "messageCount" "0")
+  cf exec "$HANDLER_FILE" --message "shared-message"
+  wait_for_piece_value "lastMessage" '"shared-message"'
+  wait_for_piece_value "messageCount" "$((COUNT_BEFORE_PIECES_SHARED + 1))"
+
+  if [ "$ENTITY_DEEP_PROBE" != "1" ]; then
+    return 0
+  fi
+
   ENTITY_RESULT_DIR="$ENTITY_DIR/result"
   ENTITY_HANDLER_FILE="$ENTITY_RESULT_DIR/recordMessage.handler"
   ENTITY_TOOL_FILE="$ENTITY_RESULT_DIR/search.tool"
@@ -948,121 +1028,205 @@ if [ "$ENTITY_DEEP_PROBE" = "1" ]; then
   cf exec "$ENTITY_HANDLER_FILE" --message "shared-message"
   wait_for_piece_value "lastMessage" '"shared-message"'
   wait_for_piece_value "messageCount" "$((COUNT_BEFORE_ENTITIES_SHARED + 1))"
-  success "Handler execution through pieces/ and entities/ reaches the same backing cell"
 
+  phase "Tool execution through pieces/ and entities/ is identical"
   PIECES_TOOL_SHARED=$(cf exec "$TOOL_FILE" --query "shared-tool" --help "entity-compare")
   ENTITIES_TOOL_SHARED=$(cf exec "$ENTITY_TOOL_FILE" --query "shared-tool" --help "entity-compare")
   assert_json_eq \
     "$PIECES_TOOL_SHARED" \
     "$ENTITIES_TOOL_SHARED" \
     "Tool output should match between pieces/ and entities/ paths"
-  success "Tool execution through pieces/ and entities/ is identical"
-else
-  success "Deep entities callable probe skipped"
-fi
+}
 
-LEGACY_COUNT_BEFORE=$(read_piece_value_or_default "legacyCount" "0")
-echo '{}' > "$LEGACY_HANDLER_FILE"
-wait_for_piece_value "legacyCount" "$((LEGACY_COUNT_BEFORE + 1))"
-success "Legacy handler write-through still works"
+run_legacy_write_through() {
+  phase "Legacy handler write-through still works"
+  LEGACY_COUNT_BEFORE=$(read_piece_value_or_default "legacyCount" "0")
+  echo '{}' > "$LEGACY_HANDLER_FILE"
+  wait_for_piece_value "legacyCount" "$((LEGACY_COUNT_BEFORE + 1))"
+}
 
-wait_for_path "$INPUT_LAST_MESSAGE"
+run_truncate_disarm() {
+  phase "Path truncate disarms an already-open descriptor's buffered write"
+  wait_for_path "$INPUT_LAST_MESSAGE"
 
-# `handles.write` overlays the buffer the open seeded from the file, so the
-# stale value is this content over whatever tail of the old value outlives it.
-# The assertions below read the daemon's trace and do not depend on which.
-STALE_CONTENT="open-stale-descriptor"
-STALE_TRACE_MARK=$(trace_line_count)
+  # `handles.write` overlays the buffer the open seeded from the file, so the
+  # stale value is this content over whatever tail of the old value outlives it.
+  # The assertions below read the daemon's trace and do not depend on which.
+  STALE_CONTENT="open-stale-descriptor"
+  STALE_TRACE_MARK=$(trace_line_count)
 
-# Write and truncate under one sustained redirect of fd 9. On Linux the kernel
-# sends FUSE flush on every close(), and `printf >&9` closes a dup of fd 9 when
-# the redirect ends — which would flush the descriptor's buffered write before
-# the truncate ever runs, defeating the point of the test. Redirecting the whole
-# group keeps fd 9's buffered write on the handle until the group ends, so every
-# flush of it happens after the truncate has disarmed it.
-exec 9<> "$INPUT_LAST_MESSAGE"
-{
-  printf '%s' "$STALE_CONTENT"
-  : > "$INPUT_LAST_MESSAGE"
-} >&9
-exec 9>&-
+  # Write and truncate under one sustained redirect of fd 9. On Linux the kernel
+  # sends FUSE flush on every close(), and `printf >&9` closes a dup of fd 9 when
+  # the redirect ends — which would flush the descriptor's buffered write before
+  # the truncate ever runs, defeating the point of the test. Redirecting the whole
+  # group keeps fd 9's buffered write on the handle until the group ends, so every
+  # flush of it happens after the truncate has disarmed it.
+  exec 9<> "$INPUT_LAST_MESSAGE"
+  {
+    printf '%s' "$STALE_CONTENT"
+    : > "$INPUT_LAST_MESSAGE"
+  } >&9
+  exec 9>&-
 
-# The write above leaves fd 9's handle holding the stale content and marked
-# dirty. The truncate empties the buffer of every descriptor open on this inode
-# and clears `dirty` on all of them, and leaves `truncatePending` set only on
-# the truncating handle. `dirty || truncatePending` is what `flushHandle`,
-# `flushCb` and `releaseCb` gate on, so clearing both is what makes fd 9's
-# handle inert.
+  # The write above leaves fd 9's handle holding the stale content and marked
+  # dirty. The truncate empties the buffer of every descriptor open on this inode
+  # and clears `dirty` on all of them, and leaves `truncatePending` set only on
+  # the truncating handle. `dirty || truncatePending` is what `flushHandle`,
+  # `flushCb` and `releaseCb` gate on, so clearing both is what makes fd 9's
+  # handle inert.
+  #
+  # `releaseCb` traces the handle's state before deciding anything, so its line
+  # reports whether close() found the descriptor armed, on either truncate path
+  # and whichever callback does the flushing. The cell value cannot report that;
+  # `docs/development/waiting-in-tests-rationale.md` records why.
+  STALE_FH=$(resolve_traced_write_fh "$STALE_TRACE_MARK" "${#STALE_CONTENT}") ||
+    error "Could not resolve the handle the daemon assigned to fd 9."
+
+  wait_for_trace_line "$STALE_TRACE_MARK" "[write-trace] release fh=$STALE_FH "
+  STALE_RELEASE_LINE=$(trace_release_line "$STALE_TRACE_MARK" "$STALE_FH")
+
+  if [[ "$STALE_RELEASE_LINE" != *" pending="* ]] ||
+    [[ "$STALE_RELEASE_LINE" != *" flushing="* ]]; then
+    error "Daemon release trace no longer reports flushing/pending: $STALE_RELEASE_LINE"
+  fi
+
+  # `pending` is `dirty || truncatePending`, the pair every flush path gates on.
+  if [[ "$STALE_RELEASE_LINE" != *" pending=false"* ]]; then
+    error "Truncate left the open descriptor armed at close(). Daemon traced: $STALE_RELEASE_LINE"
+  fi
+
+  # A flush already in flight carries the buffer it copied when it started, which
+  # the truncate cannot recall.
+  if [[ "$STALE_RELEASE_LINE" != *" flushing=false"* ]]; then
+    error "A flush was already in flight for the descriptor at close(). Daemon traced: $STALE_RELEASE_LINE"
+  fi
+
+  # The release line alone would miss a descriptor whose flush had already
+  # finished by the time release arrived, which clears the same fields the disarm
+  # does. `flushCb` traces `flush-fire` only for a handle that got past the gate,
+  # so its absence rules that out. close() sends flush before release and the
+  # daemon runs its callbacks on one thread, so a traced release means the flush
+  # decision is already traced too.
+  assert_trace_line_absent "$STALE_TRACE_MARK" \
+    "[write-trace] flush-fire fh=$STALE_FH" \
+    "Truncate left the open descriptor armed: the daemon flushed fh=$STALE_FH on close()"
+}
+
+# Reads the cell through the value run_truncate_disarm emptied, so it runs
+# after that phase rather than on its own.
+run_truncate_clears() {
+  phase "Path truncate clears stale open write handles"
+  wait_for_piece_value "lastMessage" '""'
+}
+
+# The closing assertion is that the update leaves lastMessage as the empty
+# string run_truncate_clears saw, so this phase runs after that one rather
+# than on its own.
+run_source_update() {
+  phase "FUSE source writes can explicitly authorize an incompatible schema update"
+  FUSE_PATTERN_SRC="$PIECE_DIR/.src/fuse-exec.tsx"
+  wait_for_path "$FUSE_PATTERN_SRC"
+  PATTERN_IDENTITY_BEFORE_SOURCE_WRITE=$(piece_pattern_identity)
+  if [ -z "$PATTERN_IDENTITY_BEFORE_SOURCE_WRITE" ]; then
+    error "Could not read the piece pattern identity before the FUSE source update."
+  fi
+
+  INCOMPATIBLE_PATTERN_SRC=$(mktemp)
+  awk '
+    /^interface Output \{/ { in_output = 1 }
+    in_output && /^  lastMessage: string;$/ {
+      print "  lastMessage: string | number;"
+      in_output = 0
+      next
+    }
+    { print }
+  ' "$PATTERN_SRC" >"$INCOMPATIBLE_PATTERN_SRC"
+  if ! grep -q '^  lastMessage: string | number;$' "$INCOMPATIBLE_PATTERN_SRC"; then
+    error "Failed to build the incompatible FUSE source update fixture."
+  fi
+
+  tee "$FUSE_PATTERN_SRC" <"$INCOMPATIBLE_PATTERN_SRC" >/dev/null
+  PATTERN_IDENTITY_AFTER_SOURCE_WRITE=$(
+    wait_for_pattern_identity_change "$PATTERN_IDENTITY_BEFORE_SOURCE_WRITE"
+  )
+  if [ "$PATTERN_IDENTITY_AFTER_SOURCE_WRITE" = "$PATTERN_IDENTITY_BEFORE_SOURCE_WRITE" ]; then
+    error "Dangerously authorized FUSE source write did not update the piece."
+  fi
+  wait_for_piece_value "lastMessage" '""'
+}
+
+# Every phase runs whichever section was asked for. The mount is what this
+# suite costs, and each of these is a precondition of everything below it: the
+# entity listing reads a memory-proxy trace that accumulates over the run, so
+# nothing may hydrate the piece before it, and the two after it put the
+# mounted tree in place. They record like any other phase and are not
+# selectable.
+PRELUDE=(mount entity-listing piece-paths entities-entry)
+
+# The phases each section runs, in the order `all` runs them. A section is a
+# group of phases over one mount rather than a phase on its own: the mount,
+# the daemon and the piece cost more than every phase together, and each
+# section needs all three. What a section can assume is what the prelude above
+# leaves behind — a mounted space holding one stepped piece, with the piece's
+# paths named and its entity directory resolved.
 #
-# `releaseCb` traces the handle's state before deciding anything, so its line
-# reports whether close() found the descriptor armed, on either truncate path
-# and whichever callback does the flushing. The cell value cannot report that;
-# `docs/development/waiting-in-tests-rationale.md` records why.
-STALE_FH=$(resolve_traced_write_fh "$STALE_TRACE_MARK" "${#STALE_CONTENT}") ||
-  error "Could not resolve the handle the daemon assigned to fd 9."
+# Two dependencies decide where the boundaries fall. The four handler phases
+# assert `messageCount` as an absolute count up from the piece's initial zero,
+# so they stay together and in order. And the source update ends by asserting
+# `lastMessage` is the empty string the truncate phase left behind, so it sits
+# in the section holding that phase.
+#
+# `callable-entries` is a precondition rather than a boundary: it puts the
+# callable files in place, so every section that runs one of them runs it
+# first, and `all` runs it once.
+#
+# This table is read as well as run. packages/cli/test/fuse-sections.test.ts
+# holds it to reaching every phase, from `all` and from what
+# .github/workflows/deno.yml dispatches, and to naming phases the script
+# defines. Choosing the arm here, before the mount, is what makes an unknown
+# section cost a second rather than a mount.
+case "$SECTION" in
+  all)
+    PHASES=(
+      status-document callable-entries callable-json-surface
+      callable-shebangs callable-help handler-direct-exec handler-stdin
+      tool-stdin handler-flags handler-implicit-verb tool-flags
+      tool-help-field tool-implicit-verb empty-object-handler
+      shared-backing-cell legacy-write-through truncate-disarm
+      truncate-clears source-update
+    )
+    ;;
+  status)
+    PHASES=(status-document)
+    ;;
+  callables)
+    PHASES=(
+      callable-entries callable-json-surface callable-shebangs callable-help
+    )
+    ;;
+  exec)
+    PHASES=(
+      callable-entries handler-direct-exec handler-stdin tool-stdin
+      handler-flags handler-implicit-verb tool-flags tool-help-field
+      tool-implicit-verb empty-object-handler shared-backing-cell
+    )
+    ;;
+  writes)
+    PHASES=(
+      callable-entries legacy-write-through truncate-disarm truncate-clears
+      source-update
+    )
+    ;;
+  *)
+    error "Unknown FUSE integration section: $SECTION"
+    ;;
+esac
 
-wait_for_trace_line "$STALE_TRACE_MARK" "[write-trace] release fh=$STALE_FH "
-STALE_RELEASE_LINE=$(trace_release_line "$STALE_TRACE_MARK" "$STALE_FH")
+# A phase's function is its name with dashes turned into underscores. Each
+# opens its own record, and the cleanup trap closes whichever was open, so a
+# phase that fails is the one recorded as failing.
+for PHASE in "${PRELUDE[@]}" "${PHASES[@]}"; do
+  "run_${PHASE//-/_}"
+done
 
-if [[ "$STALE_RELEASE_LINE" != *" pending="* ]] ||
-  [[ "$STALE_RELEASE_LINE" != *" flushing="* ]]; then
-  error "Daemon release trace no longer reports flushing/pending: $STALE_RELEASE_LINE"
-fi
-
-# `pending` is `dirty || truncatePending`, the pair every flush path gates on.
-if [[ "$STALE_RELEASE_LINE" != *" pending=false"* ]]; then
-  error "Truncate left the open descriptor armed at close(). Daemon traced: $STALE_RELEASE_LINE"
-fi
-
-# A flush already in flight carries the buffer it copied when it started, which
-# the truncate cannot recall.
-if [[ "$STALE_RELEASE_LINE" != *" flushing=false"* ]]; then
-  error "A flush was already in flight for the descriptor at close(). Daemon traced: $STALE_RELEASE_LINE"
-fi
-
-# The release line alone would miss a descriptor whose flush had already
-# finished by the time release arrived, which clears the same fields the disarm
-# does. `flushCb` traces `flush-fire` only for a handle that got past the gate,
-# so its absence rules that out. close() sends flush before release and the
-# daemon runs its callbacks on one thread, so a traced release means the flush
-# decision is already traced too.
-assert_trace_line_absent "$STALE_TRACE_MARK" \
-  "[write-trace] flush-fire fh=$STALE_FH" \
-  "Truncate left the open descriptor armed: the daemon flushed fh=$STALE_FH on close()"
-success "Path truncate disarms an already-open descriptor's buffered write"
-
-wait_for_piece_value "lastMessage" '""'
-success "Path truncate clears stale open write handles"
-
-FUSE_PATTERN_SRC="$PIECE_DIR/.src/fuse-exec.tsx"
-wait_for_path "$FUSE_PATTERN_SRC"
-PATTERN_IDENTITY_BEFORE_SOURCE_WRITE=$(piece_pattern_identity)
-if [ -z "$PATTERN_IDENTITY_BEFORE_SOURCE_WRITE" ]; then
-  error "Could not read the piece pattern identity before the FUSE source update."
-fi
-
-INCOMPATIBLE_PATTERN_SRC=$(mktemp)
-awk '
-  /^interface Output \{/ { in_output = 1 }
-  in_output && /^  lastMessage: string;$/ {
-    print "  lastMessage: string | number;"
-    in_output = 0
-    next
-  }
-  { print }
-' "$PATTERN_SRC" >"$INCOMPATIBLE_PATTERN_SRC"
-if ! grep -q '^  lastMessage: string | number;$' "$INCOMPATIBLE_PATTERN_SRC"; then
-  error "Failed to build the incompatible FUSE source update fixture."
-fi
-
-tee "$FUSE_PATTERN_SRC" <"$INCOMPATIBLE_PATTERN_SRC" >/dev/null
-PATTERN_IDENTITY_AFTER_SOURCE_WRITE=$(
-  wait_for_pattern_identity_change "$PATTERN_IDENTITY_BEFORE_SOURCE_WRITE"
-)
-if [ "$PATTERN_IDENTITY_AFTER_SOURCE_WRITE" = "$PATTERN_IDENTITY_BEFORE_SOURCE_WRITE" ]; then
-  error "Dangerously authorized FUSE source write did not update the piece."
-fi
-wait_for_piece_value "lastMessage" '""'
-success "FUSE source writes can explicitly authorize an incompatible schema update"
-
-echo "FUSE exec integration passed."
+echo "FUSE exec integration section '$SECTION' passed."

--- a/packages/cli/integration/fuse-exec.sh
+++ b/packages/cli/integration/fuse-exec.sh
@@ -143,7 +143,10 @@ dump_daemon_state() {
 # mount, a daemon, and everything done with them — is one identity that can
 # only be scored, run, and skipped as a unit.
 phase() {
-  echo "→ $1"
+  # The prefix is not '→': `cf` starts its own hint lines with that, so a run
+  # of this suite holds three times as many of them as it has phases, and the
+  # log stops being greppable for where a failing run got to.
+  echo "▶ $1"
   cf_test_step_begin "$1"
 }
 

--- a/packages/cli/integration/test-records.sh
+++ b/packages/cli/integration/test-records.sh
@@ -105,28 +105,6 @@ cf_test_step_close() {
   CF_TEST_STEP_START_MS=""
 }
 
-# Records the phase that just finished as its own step, and starts the
-# next. This is the marker for a script whose phase markers trail their
-# work rather than leading it, where `cf_test_step_begin`'s lead it. What
-# that costs is failure attribution: a phase that fails never reaches its
-# marker, so the failure is carried by the script's own record rather than
-# by a step. Moving a script's markers ahead of their phases is what buys
-# that back, and is a change to the script rather than to this file.
-cf_test_step_done() {
-  if [ -z "${CF_TEST_RECORDS_DIR:-}" ]; then
-    return 0
-  fi
-  local end_ms
-  end_ms=$(cf_test_now_ms || echo 0)
-  local since="${CF_TEST_STEP_START_MS:-}"
-  if [ -z "$since" ]; then
-    since="$CF_TEST_RECORD_START_MS"
-  fi
-  cf_test_record_line "$CF_TEST_RECORD_NAME $1" "pass" $((end_ms - since))
-  CF_TEST_STEP_START_MS="$end_ms"
-  CF_TEST_STEP_NAME=""
-}
-
 # Records the whole script (or its dispatched section) as one test, from
 # start to exit.
 cf_test_record_script() {

--- a/packages/cli/test/fuse-sections.test.ts
+++ b/packages/cli/test/fuse-sections.test.ts
@@ -1,0 +1,248 @@
+/**
+ * The `case "$SECTION"` table at the end of integration/fuse-exec.sh chooses
+ * which phases a run executes, and each phase records as its own test. CI
+ * dispatches the table through `CF_FUSE_INTEGRATION_SECTION` on the FUSE step
+ * of the cli-integration-test job, and a run with no section dispatches `all`.
+ *
+ * The script brings up one FUSE mount and one daemon and then works through a
+ * piece on it, so a phase that reached for what a phase in another section
+ * left behind would pass under `all` and fail whenever a lane ran its section
+ * alone. These hold the table to the properties that make a section
+ * schedulable: every phase is reachable, from `all` and from what CI
+ * dispatches; the prelude every section depends on runs whichever section was
+ * asked for; and the two orderings the script's phases depend on survive.
+ *
+ * What they read is the text of the table, of the phase functions, and of the
+ * workflow. Whether a section really stands alone is settled by running it,
+ * which only CI can do.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+/** The FUSE integration script, whose tail holds the dispatch table. */
+const SCRIPT = await Deno.readTextFile(
+  new URL("../integration/fuse-exec.sh", import.meta.url),
+);
+
+/** The CI workflow, whose cli-integration-test job dispatches a section. */
+const WORKFLOW = await Deno.readTextFile(
+  new URL("../../../.github/workflows/deno.yml", import.meta.url),
+);
+
+/** The shell function that runs a phase, by the script's naming rule. */
+function phaseFunction(phase: string): string {
+  return `run_${phase.replaceAll("-", "_")}`;
+}
+
+/** The names inside a `NAME=( ... )` array literal, or undefined. */
+function shellArray(script: string, name: string): string[] | undefined {
+  const opened = script.indexOf(`\n${name}=(`);
+  if (opened < 0) return undefined;
+  const start = opened + name.length + 3;
+  const close = script.indexOf(")", start);
+  return script.slice(start, close).split(/\s+/).filter((word) =>
+    word.length > 0
+  );
+}
+
+/** One arm of the dispatch table and the phases it selects. */
+interface Arm {
+  /** The section name, as `CF_FUSE_INTEGRATION_SECTION` names it. */
+  section: string;
+
+  /** The phases the arm selects, in the order it lists them. */
+  phases: string[];
+}
+
+/**
+ * Reads the dispatch table. Each arm assigns `PHASES` a list of phase names
+ * and does nothing else, which is what lets an unknown section be rejected
+ * before the mount; an arm in any other shape is reported rather than read,
+ * so a phase selected some other way cannot slip past the checks below.
+ */
+function parseDispatchTable(script: string): {
+  arms: Arm[];
+  malformed: string[];
+} {
+  const opened = script.indexOf('case "$SECTION" in');
+  if (opened < 0) {
+    throw new Error('fuse-exec.sh has no `case "$SECTION" in` table');
+  }
+  const table = script.slice(opened, script.indexOf("\nesac", opened));
+  const arms: Arm[] = [];
+  const malformed: string[] = [];
+  // Each arm is `  <section>)` down to its `    ;;`. `*)` is the
+  // unknown-section error rather than a list of phases.
+  for (
+    const [, section, body] of table.matchAll(/^ {2}(\S+)\)\n(.*?)^ {4};;$/gms)
+  ) {
+    if (section === "*") continue;
+    const assigned = body.match(/^ {4}PHASES=\(([^)]*)\)\n$/s);
+    if (!assigned) {
+      malformed.push(`${section}: does not assign PHASES and nothing else`);
+      continue;
+    }
+    arms.push({
+      section,
+      phases: assigned[1].split(/\s+/).filter((word) => word.length > 0),
+    });
+  }
+  return { arms, malformed };
+}
+
+/** Every phase function the script defines, in the order it defines them. */
+function definedPhases(script: string): string[] {
+  return [...script.matchAll(/^(run_[a-z_]+)\(\) \{$/gm)].map((m) => m[1]);
+}
+
+/** The identities a phase function records. */
+function recordedBy(script: string, fn: string): string[] {
+  const lines = script.split("\n");
+  const opened = lines.indexOf(`${fn}() {`);
+  if (opened < 0) return [];
+  const body = lines.slice(opened + 1, lines.indexOf("}", opened));
+  return body.flatMap((line) => {
+    const marker = line.match(/^\s+phase "([^"]*)"$/);
+    return marker ? [marker[1]] : [];
+  });
+}
+
+/** The cli-integration-test job's block of the workflow. */
+function ciJobBlock(workflow: string): string {
+  const start = workflow.indexOf("\n  cli-integration-test:\n");
+  if (start < 0) throw new Error("deno.yml has no cli-integration-test job");
+  const rest = workflow.slice(start + 1);
+  const next = rest.search(/\n {2}[a-z][a-z0-9-]*:\n/);
+  return next < 0 ? rest : rest.slice(0, next + 1);
+}
+
+/** The sections that job dispatches, one per step that runs the script. */
+function ciSections(workflow: string): string[] {
+  return [
+    ...ciJobBlock(workflow).matchAll(
+      /^ +CF_FUSE_INTEGRATION_SECTION: (\S+)$/gm,
+    ),
+  ].map((m) => m[1]);
+}
+
+const { arms, malformed } = parseDispatchTable(SCRIPT);
+const byArm = new Map(arms.map((arm) => [arm.section, arm.phases]));
+const prelude = shellArray(SCRIPT, "PRELUDE") ?? [];
+const selectable = [...new Set(arms.flatMap((arm) => arm.phases))];
+const defined = definedPhases(SCRIPT);
+const order = new Map(defined.map((fn, index) => [fn, index]));
+
+describe("fuse-sections", () => {
+  it("gives every arm a list of phases and nothing else", () => {
+    expect(malformed).toEqual([]);
+  });
+
+  it("names a phase function for every phase it selects", () => {
+    // Deleting a function and leaving its name in an arm is valid shell that
+    // `bash -n` accepts too; the script reaches `command not found` only once
+    // CI has paid for a mount.
+    const named = [...prelude, ...selectable].map(phaseFunction);
+    expect(named.filter((fn) => !order.has(fn))).toEqual([]);
+  });
+
+  it("reaches every phase function the script defines", () => {
+    // The other direction: a phase nobody selects runs nowhere, which is how
+    // a test stays maintained and stops being reported on.
+    const reached = new Set([...prelude, ...selectable].map(phaseFunction));
+    expect(defined.filter((fn) => !reached.has(fn))).toEqual([]);
+  });
+
+  it("runs every selectable phase under `all`", () => {
+    const all = new Set(byArm.get("all") ?? []);
+    expect(selectable.filter((phase) => !all.has(phase))).toEqual([]);
+  });
+
+  it("runs every selectable phase under a section CI dispatches", () => {
+    const sections = ciSections(WORKFLOW);
+    expect(sections.length).toBeGreaterThan(0);
+    expect(sections.filter((section) => !byArm.has(section))).toEqual([]);
+    const covered = new Set(
+      sections.flatMap((section) => byArm.get(section) ?? []),
+    );
+    expect(selectable.filter((phase) => !covered.has(phase))).toEqual([]);
+  });
+
+  it("gives every selectable phase a section besides `all`", () => {
+    // `all` is the union, not a hiding place. A phase reachable only from it
+    // cannot be selected as part of anything smaller, which is the whole
+    // point of the table, and it would run nowhere the day CI dispatches
+    // sections rather than `all`.
+    const grouped = new Set(
+      arms.filter((arm) => arm.section !== "all").flatMap((arm) => arm.phases),
+    );
+    expect(selectable.filter((phase) => !grouped.has(phase))).toEqual([]);
+  });
+
+  it("keeps the prelude out of the arms", () => {
+    // A prelude phase runs whichever section was asked for. Selecting one as
+    // well would run it twice in a single invocation, and a phase recorded
+    // twice under one name is one identity carrying two outcomes.
+    const both = prelude.filter((phase) => selectable.includes(phase));
+    expect(both).toEqual([]);
+  });
+
+  it("lists each arm's phases once", () => {
+    const repeated = arms.flatMap((arm) =>
+      arm.phases.filter((phase, index) => arm.phases.indexOf(phase) !== index)
+        .map((phase) => `${arm.section}: ${phase}`)
+    );
+    expect(repeated).toEqual([]);
+  });
+
+  it("lists every arm's phases in the order the script defines them", () => {
+    // Two orderings are load-bearing rather than conventional. The handler
+    // phases assert `messageCount` as an absolute count up from zero, so they
+    // have to run in one order; and the source update ends by asserting the
+    // empty string the truncate phase left, so it has to follow it. The order
+    // the functions are written in is where both are recorded, which is why
+    // it is the reference here rather than `all` — an arm compared against
+    // `all` cannot catch `all` reordering itself.
+    const misordered = arms.filter((arm) =>
+      arm.phases.some((phase, index) =>
+        index > 0 &&
+        order.get(phaseFunction(phase))! <=
+          order.get(phaseFunction(arm.phases[index - 1]!))!
+      )
+    ).map((arm) => arm.section);
+    expect(misordered).toEqual([]);
+  });
+
+  it("runs the entity listing before anything that reads the piece", () => {
+    // The listing's assertion is that no entity payload has crossed the
+    // memory proxy, read from a trace that accumulates over the whole run.
+    // Any read that hydrates the piece first would put the payload in the
+    // trace, and the phase would fail without saying why.
+    expect(prelude.indexOf("entity-listing")).toBeGreaterThanOrEqual(0);
+    expect(prelude.indexOf("entity-listing")).toBeLessThan(
+      prelude.indexOf("piece-paths"),
+    );
+  });
+
+  it("records an identity from exactly one phase function", () => {
+    // A recorded name is the test's identity, so two functions writing one
+    // name would merge two tests into one that neither can be tracked
+    // through.
+    const owners = new Map<string, string[]>();
+    for (const fn of defined) {
+      for (const name of recordedBy(SCRIPT, fn)) {
+        owners.set(name, [...(owners.get(name) ?? []), fn]);
+      }
+    }
+    const shared = [...owners].filter(([, fns]) => fns.length > 1)
+      .map(([name, fns]) => `${name}: ${fns.join(", ")}`);
+    expect(shared).toEqual([]);
+  });
+
+  it("records at least one identity from every phase function", () => {
+    // A phase that records nothing is a phase selection cannot see, so
+    // nothing decides whether it is worth running.
+    expect(defined.filter((fn) => recordedBy(SCRIPT, fn).length === 0))
+      .toEqual([]);
+  });
+});

--- a/packages/cli/test/fuse-sections.test.ts
+++ b/packages/cli/test/fuse-sections.test.ts
@@ -10,7 +10,7 @@
  * alone. These hold the table to the properties that make a section
  * schedulable: every phase is reachable, from `all` and from what CI
  * dispatches; the prelude every section depends on runs whichever section was
- * asked for; and the two orderings the script's phases depend on survive.
+ * asked for; and the orderings the script's phases depend on survive.
  *
  * What they read is the text of the table, of the phase functions, and of the
  * workflow. Whether a section really stands alone is settled by running it,
@@ -35,15 +35,15 @@ function phaseFunction(phase: string): string {
   return `run_${phase.replaceAll("-", "_")}`;
 }
 
-/** The names inside a `NAME=( ... )` array literal, or undefined. */
-function shellArray(script: string, name: string): string[] | undefined {
-  const opened = script.indexOf(`\n${name}=(`);
-  if (opened < 0) return undefined;
-  const start = opened + name.length + 3;
-  const close = script.indexOf(")", start);
-  return script.slice(start, close).split(/\s+/).filter((word) =>
-    word.length > 0
-  );
+/**
+ * The names inside a `NAME=( ... )` array literal. Missing is an error rather
+ * than an empty list: the checks below read the prelude out of one, and an
+ * empty list would leave them passing over nothing.
+ */
+function shellArray(script: string, name: string): string[] {
+  const found = script.match(new RegExp(`^${name}=\\(([^)]*)\\)`, "m"));
+  if (!found) throw new Error(`fuse-exec.sh has no ${name} array`);
+  return found[1].split(/\s+/).filter((word) => word.length > 0);
 }
 
 /** One arm of the dispatch table and the phases it selects. */
@@ -128,7 +128,7 @@ function ciSections(workflow: string): string[] {
 
 const { arms, malformed } = parseDispatchTable(SCRIPT);
 const byArm = new Map(arms.map((arm) => [arm.section, arm.phases]));
-const prelude = shellArray(SCRIPT, "PRELUDE") ?? [];
+const prelude = shellArray(SCRIPT, "PRELUDE");
 const selectable = [...new Set(arms.flatMap((arm) => arm.phases))];
 const defined = definedPhases(SCRIPT);
 const order = new Map(defined.map((fn, index) => [fn, index]));

--- a/packages/cli/test/test-records-shell.test.ts
+++ b/packages/cli/test/test-records-shell.test.ts
@@ -116,12 +116,17 @@ describe("test-records-shell", () => {
     }
   });
 
-  it("records a trailing marker as the phase that just finished", async () => {
+  it("closes the open step from a script that owns its own exit trap", async () => {
+    // The shape fuse-exec.sh uses: it needs its own EXIT trap for the FUSE
+    // teardown, so it names itself and closes both records by hand instead of
+    // registering cf_test_record_script's trap.
+
     const records = await recorded(`
       CF_TEST_RECORD_NAME="fuse-exec.sh"
       CF_TEST_RECORD_START_MS=$(cf_test_now_ms)
-      cf_test_step_done "mounted the filesystem"
-      cf_test_step_done "read a callable"
+      cf_test_step_begin "mounted the filesystem"
+      cf_test_step_begin "read a callable"
+      cf_test_step_close 0
       cf_test_record_with_status 0
     `);
     expect(records.map((record) => record.test.n)).toEqual([
@@ -136,7 +141,8 @@ describe("test-records-shell", () => {
     const records = await recorded(`
       CF_TEST_RECORD_NAME="fuse-exec.sh"
       CF_TEST_RECORD_START_MS=$(cf_test_now_ms)
-      cf_test_step_done 'a "quoted" name with a \\ backslash'
+      cf_test_step_begin 'a "quoted" name with a \\ backslash'
+      cf_test_step_close 0
     `);
     expect(records.map((record) => record.test.n)).toEqual([
       String.raw`fuse-exec.sh a "quoted" name with a \ backslash`,
@@ -149,7 +155,6 @@ describe("test-records-shell", () => {
         `
         cf_test_record_script "acl.sh"
         cf_test_step_begin piece-values
-        cf_test_step_done "a phase"
       `,
         { recording: false },
       ),


### PR DESCRIPTION
`packages/cli/integration/fuse-exec.sh` mounts a FUSE filesystem, starts a daemon, builds a piece on it, and works through twenty-odd phases against it. A runner could ask for all of that or none of it, so a single decision governed several minutes of work. It is the one test surface in the topology with that shape, and
`docs/plans/pull-request-test-selection.md` names it as the one the pull-request test selection is not allowed to leave alone.

Two things were missing. This lands both.

## Failure attribution

The phase markers trailed the phases they named, so a phase that failed never reached its marker and the failure landed on the script's own whole-run record rather than on the step it belonged to. Each marker now leads its phase, through the same `cf_test_step_begin` the sibling `integration.sh` uses. The cleanup trap closes whichever phase was open with the body's own status, before the teardown adds its time to the clock, so a wedged teardown still lands on the script's record where it belongs.

Two parts of the script that were never recorded now are: bringing the mount up, and waiting for the mounted piece to hydrate. Both are ordinary phases, so a mount that never comes up is reported as the mount rather than as the script — which is the failure this suite is most likely to have. That takes the suite from 23 identities to 25. The other 23 keep the names they already record under, so no history splits and no alias is needed.

`cf_test_step_done`, the trailing-marker helper, has no callers left and goes with it. Its counterpart `cf_test_record_line` keeps the JSON escaping it has: a phase name here is a sentence somebody wrote, and one of them already contains an apostrophe.

## Section dispatch

The script takes a section, from `CF_FUSE_INTEGRATION_SECTION` or a positional argument, defaulting to `all`. Each phase becomes a function, and an arm of the table selects a list of them. The arm only builds that list, so an unknown section is rejected before anything is mounted: a typo costs a second rather than a mount.

A section is a group of phases over one mount rather than a phase on its own. The mount, the daemon and the piece cost more than every phase together and every phase needs all three, so four phases run whichever section was asked for and are not selectable: the mount, the entity listing, the piece-path hydration, and the entities-namespace entry.

That leaves four sections. `status` reads the mount root's `.status` document. `callables` checks what the mounted handler and tool files look like without running them. `exec` invokes them, through their shebangs and through `cf exec`. `writes` covers the write-through invocation, the truncate that has to disarm an already-open descriptor, and the source update.

Two dependencies decide where those boundaries fall, and both are about state a phase leaves behind. The handler phases assert `messageCount` as an absolute count up from the piece's initial zero, so they stay together and in order. The source update ends by asserting `lastMessage` is the empty string the truncate phase left, so it sits in the section holding that phase rather than in one of its own. A third ordering is why the entity listing always runs and runs early: its assertion is that no entity payload has crossed the memory proxy, read from a trace that accumulates over the whole run, so nothing may hydrate the piece before it.

`callable-entries` is a precondition rather than a boundary. It puts the callable files in place, so each section that runs one of them runs it first, and `all` runs it once.

## Holding the table to that

`packages/cli/test/fuse-sections.test.ts` reads the table, the phase functions and the workflow, the way `integration-sections.test.ts` reads its sibling's. It holds twelve properties: every arm selects phases and does nothing else; every selected phase names a function and every defined function is selected; every phase runs under `all`, under a section smaller than `all`, and under what the workflow dispatches; the prelude stays out of the arms and no arm lists a phase twice; every arm lists its phases in the order the script defines them, which is where the two state dependencies above are recorded; the entity listing precedes the piece hydration; and each recorded identity comes from exactly one phase, which records at least one.

Each of the twelve was checked by breaking the script or the workflow in the way it exists to catch, and confirming that it, and generally only it, failed.

The `run_` prefix now names a phase and nothing else, which the dispatch loop's `run_${PHASE//-/_}` already assumed; the one helper that shared it is renamed to `bounded`.

## What CI runs

Unchanged. The workflow step names `CF_FUSE_INTEGRATION_SECTION: all`, which is also the single line the test reads to learn what CI dispatches. Comparing the statements `all` executes against the previous script's, in order, shows only the differences this change intends: string assignments hoisted into the mount phase, the dead `ENTITY_BARE_ID` and an unreachable cleanup branch removed, the probe branch restructured around which phase owns the shared invocation, and a final message that names the section that passed.

The suite needs a real FUSE mount, so it was not run here; CI is the first place this script executes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6707?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

