### PR TITLE
feat(utils): `has()`, for a caller that wants no position

### DIFF
--- a/packages/utils/src/index-tracking-stack.ts
+++ b/packages/utils/src/index-tracking-stack.ts
@@ -1,8 +1,8 @@
 /**
  * A stack of values offering `Array`-style {@link #indexOf} and {@link
- * #lastIndexOf}. A value's index is counted from the bottom, so the first
- * value pushed is at index `0`, and an index does not change while things are
- * pushed above it.
+ * #lastIndexOf}, and {@link #has} for a caller that wants no position. A
+ * value's index is counted from the bottom, so the first value pushed is at
+ * index `0`, and an index does not change while things are pushed above it.
  *
  * Values are compared as `Object.is` compares them: by identity for an object,
  * by value for a primitive, `NaN` matching itself, and `-0` distinct from `0`.
@@ -40,6 +40,11 @@ export class IndexTrackingStack<T = unknown> {
    */
   get depth(): number {
     return this.#stack.length;
+  }
+
+  /** Whether the stack holds the given value. */
+  has(value: T): boolean {
+    return this.indexOf(value) >= 0;
   }
 
   /**

--- a/packages/utils/test/index-tracking-stack.test.ts
+++ b/packages/utils/test/index-tracking-stack.test.ts
@@ -285,6 +285,65 @@ describe("IndexTrackingStack", () => {
     }
   });
 
+  describe("has()", () => {
+    for (const [where, height] of ARMS) {
+      describe(where, () => {
+        it("is true for a value the stack holds", () => {
+          const held = objects(2);
+          const stack = stackOf(height, held);
+
+          expect(stack.has(held[0]!)).toBe(true);
+          expect(stack.has(held[1]!)).toBe(true);
+        });
+
+        it("is false for a value the stack does not hold", () => {
+          const stack = stackOf(height, objects(2));
+
+          expect(stack.has({})).toBe(false);
+        });
+
+        it("is false once the value has been popped", () => {
+          const [kept, dropped] = objects(2) as [object, object];
+          const stack = stackOf(height, [kept, dropped]);
+
+          stack.pop();
+
+          expect(stack.has(kept)).toBe(true);
+          expect(stack.has(dropped)).toBe(false);
+        });
+
+        it("is true for a value held at more than one position", () => {
+          const twice = {};
+          const stack = stackOf(height, [twice, {}, twice]);
+
+          expect(stack.has(twice)).toBe(true);
+
+          stack.pop();
+          expect(stack.has(twice)).toBe(true);
+        });
+
+        it("is true for an `undefined` the stack holds", () => {
+          const stack = stackOf(height, [undefined]);
+
+          expect(stack.has(undefined)).toBe(true);
+        });
+
+        it("is true for a `NaN`, which strict comparison never finds", () => {
+          const stack = stackOf(height, [NaN]);
+
+          expect(stack.has(NaN)).toBe(true);
+        });
+
+        it("tells a held `-0` from a `0` the stack does not hold", () => {
+          const stack = stackOf(height, [-0]);
+
+          expect(stack.has(-0)).toBe(true);
+          expect(stack.has(0)).toBe(false);
+        });
+      });
+    }
+  });
+
   for (const lookup of LOOKUPS) {
     describe(`${lookup.name}()`, () => {
       /** The position of a repeated value this lookup reports, of two. */


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

`indexOf(value) >= 0` is how a caller asks whether the stack holds something,
and it says the question in terms of an answer it is going to throw away.
`has()` says it directly.

Both call sites in the tree — the two walks that recognize a cycle — spell it
the long way today, and can take this up once it lands.

## Tests

Seven cases, asked at both the height where a lookup is answered by searching
and the height where it is answered from an index, since which one answers is
not something a caller can see: a value the stack holds, one it does not, one
that has been popped, one held at more than one position, an `undefined`, a
`NaN`, and a held `-0` against a `0` the stack does not hold.

The last two are what stop the obvious shortcut. `Array.prototype.includes`
compares as `SameValueZero`, so it finds a `NaN` — and conflates `-0` with `0`,
where this class holds them apart. Ablating `has()` to use it fails five steps,
against a control arm that passes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6708?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

