### PR TITLE
perf(data-model): a codec act tracks its walk on a stack, not in a set

### DIFF
--- a/packages/data-model/src/codec-common/BaseCodecAct.ts
+++ b/packages/data-model/src/codec-common/BaseCodecAct.ts
@@ -89,7 +89,7 @@ export abstract class BaseCodecAct<Encoded> {
   protected tryEnter(value: object): boolean {
     const inProgress = this.#inProgress ??= new IndexTrackingStack<object>();
 
-    if (inProgress.indexOf(value) >= 0) {
+    if (inProgress.has(value)) {
       return false;
     }
 

--- a/packages/data-model/src/codec-common/BaseCodecAct.ts
+++ b/packages/data-model/src/codec-common/BaseCodecAct.ts
@@ -1,3 +1,5 @@
+import { IndexTrackingStack } from "@commonfabric/utils/index-tracking-stack";
+
 import type { LiveEnvironment } from "@/codec-interface/interface.ts";
 import type { CodecEngineConfig } from "./CodecEngineConfig.ts";
 import type { CodecRegistry } from "./CodecRegistry.ts";
@@ -30,7 +32,7 @@ export abstract class BaseCodecAct<Encoded> {
    * The values whose walk is in progress, or `undefined` before the first one
    * is entered.
    */
-  #seen: Set<object> | undefined;
+  #inProgress: IndexTrackingStack<object> | undefined;
 
   /** Constructs an instance. */
   constructor(config: CodecEngineConfig<Encoded>, env: LiveEnvironment) {
@@ -47,9 +49,15 @@ export abstract class BaseCodecAct<Encoded> {
     return this.#env;
   }
 
-  /** Leaves a value, its walk being finished. */
+  /**
+   * Leaves the given value, its walk being finished. It has to be the value
+   * most recently entered, entering and leaving nesting strictly, which is
+   * what the subclass contract asks of an implementation.
+   *
+   * @throws If the value is not the one most recently entered.
+   */
   leave(value: object): void {
-    this.#seen?.delete(value);
+    this.#inProgress?.popExpect(value);
   }
 
   /** The configuration of the engine that minted this act. */
@@ -70,7 +78,7 @@ export abstract class BaseCodecAct<Encoded> {
    * means is up to the caller, so each subclass wraps this with its own
    * reading: encoding refuses a cycle outright, where decoding reports one.
    *
-   * The set behind this is created here rather than in the constructor, so
+   * The chain behind this is created here rather than in the constructor, so
    * that walking a lone self-representing value -- much the commonest case,
    * and the one where a fixed cost shows up most -- allocates nothing beyond
    * the act itself.
@@ -79,13 +87,13 @@ export abstract class BaseCodecAct<Encoded> {
    *   progress.
    */
   protected tryEnter(value: object): boolean {
-    const seen = this.#seen ??= new Set();
+    const inProgress = this.#inProgress ??= new IndexTrackingStack<object>();
 
-    if (seen.has(value)) {
+    if (inProgress.indexOf(value) >= 0) {
       return false;
     }
 
-    seen.add(value);
+    inProgress.push(value);
     return true;
   }
 }

--- a/packages/data-model/src/codec-common/BaseCodecAct.ts
+++ b/packages/data-model/src/codec-common/BaseCodecAct.ts
@@ -32,7 +32,7 @@ export abstract class BaseCodecAct<Encoded> {
    * The values whose walk is in progress, or `undefined` before the first one
    * is entered.
    */
-  #inProgress: IndexTrackingStack<object> | undefined;
+  #seen: IndexTrackingStack<object> | undefined;
 
   /** Constructs an instance. */
   constructor(config: CodecEngineConfig<Encoded>, env: LiveEnvironment) {
@@ -57,7 +57,7 @@ export abstract class BaseCodecAct<Encoded> {
    * @throws If the value is not the one most recently entered.
    */
   leave(value: object): void {
-    this.#inProgress?.popExpect(value);
+    this.#seen?.popExpect(value);
   }
 
   /** The configuration of the engine that minted this act. */
@@ -87,13 +87,13 @@ export abstract class BaseCodecAct<Encoded> {
    *   progress.
    */
   protected tryEnter(value: object): boolean {
-    const inProgress = this.#inProgress ??= new IndexTrackingStack<object>();
+    const seen = this.#seen ??= new IndexTrackingStack<object>();
 
-    if (inProgress.has(value)) {
+    if (seen.has(value)) {
       return false;
     }
 
-    inProgress.push(value);
+    seen.push(value);
     return true;
   }
 }

--- a/packages/data-model/src/codec-common/BaseCodecAct.ts
+++ b/packages/data-model/src/codec-common/BaseCodecAct.ts
@@ -78,7 +78,7 @@ export abstract class BaseCodecAct<Encoded> {
    * means is up to the caller, so each subclass wraps this with its own
    * reading: encoding refuses a cycle outright, where decoding reports one.
    *
-   * The chain behind this is created here rather than in the constructor, so
+   * The stack behind this is created here rather than in the constructor, so
    * that walking a lone self-representing value -- much the commonest case,
    * and the one where a fixed cost shows up most -- allocates nothing beyond
    * the act itself.

--- a/packages/data-model/src/codec-common/BaseDecodeAct.ts
+++ b/packages/data-model/src/codec-common/BaseDecodeAct.ts
@@ -56,7 +56,7 @@ export abstract class BaseDecodeAct<Encoded, SerializedForm = Encoded>
    *
    * Whether cycles are guarded at all is the format's decision, made by
    * whether this method enters a node: a format whose input it parses for
-   * itself cannot be handed a cycle, so it enters none and this act's chain
+   * itself cannot be handed a cycle, so it enters none and this act's stack
    * of values in progress is never allocated.
    *
    * An implementation that does guard owes the act one thing: every object it
@@ -79,7 +79,7 @@ export abstract class BaseDecodeAct<Encoded, SerializedForm = Encoded>
    *
    * Whether a format guards cycles at all is decided by whether its walk
    * calls this: a format whose input it parses for itself is handed a tree by
-   * construction, so it never does, and its chain of values in progress is
+   * construction, so it never does, and its stack of values in progress is
    * never allocated. One handed a tree it did not build enters every node it
    * descends through.
    *

--- a/packages/data-model/src/codec-common/BaseDecodeAct.ts
+++ b/packages/data-model/src/codec-common/BaseDecodeAct.ts
@@ -56,8 +56,8 @@ export abstract class BaseDecodeAct<Encoded, SerializedForm = Encoded>
    *
    * Whether cycles are guarded at all is the format's decision, made by
    * whether this method enters a node: a format whose input it parses for
-   * itself cannot be handed a cycle, so it enters none and this act's set is
-   * never allocated.
+   * itself cannot be handed a cycle, so it enters none and this act's chain
+   * of values in progress is never allocated.
    *
    * An implementation that does guard owes the act one thing: every object it
    * is about to descend through goes through {@link #enterOrReport} first, and
@@ -79,8 +79,9 @@ export abstract class BaseDecodeAct<Encoded, SerializedForm = Encoded>
    *
    * Whether a format guards cycles at all is decided by whether its walk
    * calls this: a format whose input it parses for itself is handed a tree by
-   * construction, so it never does, and its set is never allocated. One
-   * handed a tree it did not build enters every node it descends through.
+   * construction, so it never does, and its chain of values in progress is
+   * never allocated. One handed a tree it did not build enters every node it
+   * descends through.
    *
    * @returns `true` if the node was entered, `false` if it was already in
    *   progress -- which is a cycle, and the caller's to report.


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

`BaseCodecAct` recognized a cycle by holding every value whose walk was in
progress in a `Set`, which cost a hash insert and a hash delete per container.
A value with no cycle in it — which is nearly all of them — paid that at every
container and read nothing back.

It holds them on an `IndexTrackingStack` instead, which at the depths a value
graph actually reaches costs less, and which answers from an index rather than
a scan once a graph is deep enough that scanning would not.

`leave()` keeps its parameter and hands it to `popExpect()`. A set that failed
to delete merely left a stale entry; a stack answers by position, so a walk
that left a value it had not entered would go on answering with every position
after it wrong by one. The check is the stack's, so nothing here needs a
coverage directive.

## What it costs, across every shape the codecs are benchmarked on

`bench/codec-realm.bench.ts`, unchanged, 114 benchmarks, p75 per run, median of
5 interleaved runs a side. Microseconds:

| shape | main | branch | |
| --- | --- | --- | --- |
| decode json-pass-through-001000 | 287.0 | 208.5 | **0.73x** |
| encode json-pass-through-001000 | 373.2 | 287.5 | **0.77x** |
| decode pass-through-001000 | 251.7 | 198.5 | 0.79x |
| encode pass-through-001000 | 343.3 | 286.9 | 0.84x |

**49 of the 114 run at 0.95x or better, and none at 1.05x or worse.** The few
reading 1.02–1.04x carry spreads that cover them, one of them 41%. Median
across all 114 is 0.974x.

What wins is a graph of nested containers with nothing tagged in it, which is
where the old code paid per container and read nothing back. What does not move
is a single wide container — one `enter` and one `leave` however many elements
it holds — and that is the right shape for it not to move.

## The control is a whole codec that should not move, and does not

`bench/codec-json.bench.ts`, 4 runs a side, split by operation against the same
split for the realm codec:

| | benches | median | best |
| --- | --- | --- | --- |
| `codec-json` **decode** | 57 | **0.999x** | 0.96x |
| `codec-json` encode | 57 | 0.984x | 0.85x |
| `codec-realm` decode | 48 | 0.977x | 0.72x |
| `codec-realm` encode | 57 | 0.983x | 0.77x |

A JSON decode parses its own input, so it cannot be handed a cycle, enters no
value, and never allocates the chain at all — which `BaseDecodeAct` says of
itself. It is therefore the one path in either codec that this change cannot
reach, and it is the one row that does not move. Everything that tracks moved;
the thing that does not track, did not.

`codec-json`'s three rows past 1.05x are noise, with branch-side spreads of 30%
to 70% against 4 runs; the realm figures are the ones to weigh.

## What it does to a message crossing the IPC boundary

The crossing is the number this arc has been tracked on, so it is here too even
though it is one caller among many.
`packages/runtime-client/bench/ipc-crossing.bench.ts`, unchanged, p75 per run,
median of 12 interleaved runs a side. Each point shows the arm that point's
code actually ran:

| subject | arm | main | branch | |
| --- | --- | --- | --- | --- |
| 100 records with links | envelope | 409.1 | 379.9 | **0.93x** |
| 1000 records with links | envelope | 3919.7 | 3610.9 | **0.92x** |
| 100 records with links | status quo | 317.7 | 316.9 | 1.00x |
| 1000 records with links | status quo | 3015.6 | 2993.3 | 0.99x |
| flat, 100 members | envelope | 40.9 | 40.9 | 1.00x |
| small record | envelope | 13.2 | 13.1 | 0.99x |

**The status-quo arm is the control, and it is flat.** A message with no
envelope around it never reaches a codec act, so a change confined to one
cannot move it — and does not. `flat, 100 members` is one container holding a
hundred scalars, which has no per-container bookkeeping to save, and it does
not move either.

Per step, 1000 records, median of 6 runs, from
`bench/ipc-crossing-steps.bench.ts`:

| step | main | branch | | labeled |
| --- | --- | --- | --- | --- |
| encode | 450.4 | 363.3 | **0.81x** | 0.75x |
| decode | 361.7 | 272.0 | **0.75x** | 0.69x |
| convert | 1463.8 | 1471.4 | 1.01x | 1.01x |
| redact | 147.2 | 147.1 | 1.00x | 1.00x |
| transport | 1162.6 | 1165.8 | 1.00x | 1.00x |
| hydrate | 148.2 | 147.6 | 1.00x | 1.00x |

Two steps move and four do not, which is exactly the two that go through a
codec act.

## Reach

This is not only the IPC path. Every encode and every decode goes through this
act, whatever the format, so the shapes above are the population rather than
one caller's payload.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6709?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


