### PR TITLE
style: give each file header the blank line that bounds it

### DIFF
--- a/packages/cf-harness/console/src/index.ts
+++ b/packages/cf-harness/console/src/index.ts
@@ -1,2 +1,3 @@
 /** The console page's entry point: registering the app registers the rest. */
+
 import "./app.ts";

--- a/packages/cf-harness/src/pattern-index/publish-render-gate.ts
+++ b/packages/cf-harness/src/pattern-index/publish-render-gate.ts
@@ -79,6 +79,7 @@
  * per publishing run, over source the model wrote. That is named here rather
  * than argued away.
  */
+
 import type { JSONSchema } from "@commonfabric/api";
 
 import type { Cell } from "@commonfabric/runner";

--- a/packages/cf-harness/src/tools/browser.ts
+++ b/packages/cf-harness/src/tools/browser.ts
@@ -5,6 +5,7 @@
  * argument list, and the invocation that attaches the Browser Access lease
  * and keeps its endpoint out of everything the model reads.
  */
+
 import type { JSONSchema } from "@commonfabric/api";
 
 import {

--- a/packages/cf-harness/src/tools/handle-values.ts
+++ b/packages/cf-harness/src/tools/handle-values.ts
@@ -18,6 +18,7 @@
  * only the first resolves. Without that check a handle field is a general read
  * of every cell in the run's space.
  */
+
 import { parseLLMFriendlyLink } from "@commonfabric/runner/shared";
 
 import {

--- a/packages/cf-harness/test/assign-slug.test.ts
+++ b/packages/cf-harness/test/assign-slug.test.ts
@@ -5,6 +5,7 @@
  * token that is not a piece, a position inside one, another space's
  * reference.
  */
+
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 
 import { expect } from "@std/expect";

--- a/packages/cf-harness/test/browser-access.test.ts
+++ b/packages/cf-harness/test/browser-access.test.ts
@@ -2,6 +2,7 @@
  * Unit tests for the Browser Access lease contract: CDP origin normalization
  * and lease freshness validation.
  */
+
 import { describe, it } from "@std/testing/bdd";
 
 import { expect } from "@std/expect";

--- a/packages/cf-harness/test/browser.test.ts
+++ b/packages/cf-harness/test/browser.test.ts
@@ -4,6 +4,7 @@
  * and the invocation path where a bound handle becomes a value trusted-side
  * and stays out of everything the model reads afterwards.
  */
+
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 
 import { expect } from "@std/expect";

--- a/packages/cf-harness/test/fabric-observations.test.ts
+++ b/packages/cf-harness/test/fabric-observations.test.ts
@@ -4,6 +4,7 @@
  * that arrive without a pattern frame, the exclusion of busy-window markers
  * that defer nothing, and sequence-scoped windows.
  */
+
 import { describe, it } from "@std/testing/bdd";
 
 import { expect } from "@std/expect";

--- a/packages/cf-harness/test/handle-values.test.ts
+++ b/packages/cf-harness/test/handle-values.test.ts
@@ -4,6 +4,7 @@
  * holds a handle to resolves at all, the refusals for a reference that names
  * nothing readable, and the rule that no message ever renders the referent.
  */
+
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 
 import { expect } from "@std/expect";

--- a/packages/cf-harness/test/input-cells.test.ts
+++ b/packages/cf-harness/test/input-cells.test.ts
@@ -4,6 +4,7 @@
  * announcement text — which must carry tokens and the operator's names only,
  * never the address behind a token.
  */
+
 import { describe, it } from "@std/testing/bdd";
 
 import { expect } from "@std/expect";

--- a/packages/cf-harness/test/prompt-loop-skill-handle.test.ts
+++ b/packages/cf-harness/test/prompt-loop-skill-handle.test.ts
@@ -6,6 +6,7 @@
  * the child never holds the handle, and selection is by table membership
  * rather than by registry name.
  */
+
 import { describe, it } from "@std/testing/bdd";
 
 import { expect } from "@std/expect";

--- a/packages/cf-harness/test/skill-text-scrub.test.ts
+++ b/packages/cf-harness/test/skill-text-scrub.test.ts
@@ -8,6 +8,7 @@
  * "scrub every string in this structure" rather than one with a silent gap
  * that a future validator change could expose.
  */
+
 import { describe, it } from "@std/testing/bdd";
 
 import { expect } from "@std/expect";

--- a/packages/cf-harness/test/structured-result.test.ts
+++ b/packages/cf-harness/test/structured-result.test.ts
@@ -4,6 +4,7 @@
  * everything else — including a caller-provided opaque link the sanitizer
  * preserved, which `sealedPaths` never lists — passes through untouched.
  */
+
 import { describe, it } from "@std/testing/bdd";
 
 import { expect } from "@std/expect";

--- a/packages/cf-harness/test/well-known-grants.test.ts
+++ b/packages/cf-harness/test/well-known-grants.test.ts
@@ -4,6 +4,7 @@
  * announcement text — which must carry tokens and harness-authored prose
  * only, never the address behind a token.
  */
+
 import { describe, it } from "@std/testing/bdd";
 
 import { expect } from "@std/expect";

--- a/packages/cli/test/fixtures/action-event/event-payload.test.tsx
+++ b/packages/cli/test/fixtures/action-event/event-payload.test.tsx
@@ -4,6 +4,7 @@
  * what the step authored. An object payload is the case that matters: a
  * primitive one has always arrived.
  */
+
 import {
   assert,
   type Default,

--- a/packages/cli/test/fixtures/action-event/trusted-gesture.test.tsx
+++ b/packages/cli/test/fixtures/action-event/trusted-gesture.test.tsx
@@ -3,6 +3,7 @@
  * carries `type: "click"`; a payload adds to that gesture rather than
  * replacing it, so the handler sees both.
  */
+
 import { assert, handler, pattern, TESTS, type Writable } from "commonfabric";
 
 const record = handler<

--- a/packages/cli/test/fixtures/data-files/multi-user.test.tsx
+++ b/packages/cli/test/fixtures/data-files/multi-user.test.tsx
@@ -6,6 +6,7 @@
  * them. This reads a data file from inside both participants, which is the
  * only place the crossing can be observed.
  */
+
 import { assert, dataFile, multiUserTest, pattern, TESTS } from "commonfabric";
 
 interface Cities {

--- a/packages/cli/test/fixtures/multi-user-steps/event-payload.test.tsx
+++ b/packages/cli/test/fixtures/multi-user-steps/event-payload.test.tsx
@@ -6,6 +6,7 @@
  * the orchestrator delivers anything other than what the step authored. An
  * object payload is the case that matters: a primitive one has always arrived.
  */
+
 import {
   assert,
   handler,

--- a/packages/cli/test/fixtures/multi-user-steps/invalid-step.test.tsx
+++ b/packages/cli/test/fixtures/multi-user-steps/invalid-step.test.tsx
@@ -5,6 +5,7 @@
  * orchestrator has to name the step's own keys, so an author can see which
  * key they wrote.
  */
+
 import { multiUserTest, pattern, TESTS } from "commonfabric";
 
 export const setup = pattern<Record<string, never>, { ok: boolean }>(() => ({

--- a/packages/cli/test/fixtures/step-kinds/marker-step.test.tsx
+++ b/packages/cli/test/fixtures/step-kinds/marker-step.test.tsx
@@ -3,6 +3,7 @@
  * `{ await }` synchronize participants; a single-user run has none, so they
  * are inert and the run reports only the assertion.
  */
+
 import { action, assert, pattern, TESTS, Writable } from "commonfabric";
 
 export default pattern(() => {

--- a/packages/generated-patterns/integration/patterns/counter-when-unless-operators.pattern.ts
+++ b/packages/generated-patterns/integration/patterns/counter-when-unless-operators.pattern.ts
@@ -9,6 +9,7 @@
  * Simple opaque refs (like `showPanel && value`) don't use when/unless,
  * only complex expressions that need derivation.
  */
+
 import { type Cell, Default, handler, lift, pattern, str } from "commonfabric";
 
 interface WhenUnlessArgs {

--- a/packages/runner/test/cfc-refusal-detail.test.ts
+++ b/packages/runner/test/cfc-refusal-detail.test.ts
@@ -16,6 +16,7 @@
  *   refusal leaves when the commit boundary decides it is retryable rather
  *   than terminal and so never puts it on the error channel at all.
  */
+
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 
 import { expect } from "@std/expect";

--- a/packages/runner/test/cfc-terminal-refusal-rerun.test.ts
+++ b/packages/runner/test/cfc-terminal-refusal-rerun.test.ts
@@ -31,6 +31,7 @@
  * never meets a refusal does not re-run on a metadata change either — so it
  * is documented here rather than pinned as a test.
  */
+
 import { describe, it } from "@std/testing/bdd";
 
 import { expect } from "@std/expect";

--- a/packages/runner/test/cfc-verdict-reason.test.ts
+++ b/packages/runner/test/cfc-verdict-reason.test.ts
@@ -7,6 +7,7 @@
  * failed, a prepared state a caller disturbed. Collapsing the two strands the
  * write, which is the failure OW50 exists to surface rather than reproduce.
  */
+
 import { describe, it } from "@std/testing/bdd";
 
 import { expect } from "@std/expect";

--- a/packages/runner/test/generate-object-cfc-refusal.test.ts
+++ b/packages/runner/test/generate-object-cfc-refusal.test.ts
@@ -8,6 +8,7 @@
  * builtin does with one: it settles, once, with the refusal as its error, and
  * the request it could not send is staged once rather than once per retry.
  */
+
 import { expect } from "@std/expect";
 
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";

--- a/packages/runner/test/max-enforcement-posture.test.ts
+++ b/packages/runner/test/max-enforcement-posture.test.ts
@@ -15,6 +15,7 @@
  *   terminal and reaches the scheduler's error channel with its reasons,
  *   rather than reading as a healthy, quietly empty piece.
  */
+
 import { describe, it } from "@std/testing/bdd";
 
 import { expect } from "@std/expect";

--- a/packages/runner/test/memory-v2-reconnect-holdings.test.ts
+++ b/packages/runner/test/memory-v2-reconnect-holdings.test.ts
@@ -7,6 +7,7 @@
  * extrapolated one (04-protocol.md §4.1.2; `SpaceReplica.holdings`;
  * 09-invariants.md INV-14).
  */
+
 import { assert } from "@std/assert";
 
 import { expect } from "@std/expect";

--- a/packages/runner/test/release-vs-stop-link-resolution.test.ts
+++ b/packages/runner/test/release-vs-stop-link-resolution.test.ts
@@ -11,6 +11,7 @@
  * held start. Only the generic scheduler test runtime is needed, so the pin
  * lives here on its own.
  */
+
 import { expect } from "@std/expect";
 
 import {

--- a/packages/runner/test/schema-ref-helpers.ts
+++ b/packages/runner/test/schema-ref-helpers.ts
@@ -7,6 +7,7 @@
  * handed. The link or binding carrying the reference is never rewritten;
  * consumers resolve at their point of use.
  */
+
 import type { JSONSchemaObj } from "@commonfabric/api";
 
 import { internSchemaAsTaggedHashString } from "@commonfabric/data-model-schema";

--- a/packages/runner/test/transaction-abandon-callbacks.test.ts
+++ b/packages/runner/test/transaction-abandon-callbacks.test.ts
@@ -7,6 +7,7 @@
  * transaction's part is narrow: dispatch once, never after a commit succeeded,
  * and never through a wrapper standing for work whose outcome nobody acts on.
  */
+
 import { expect } from "@std/expect";
 
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";

--- a/packages/runner/test/traverse-recorder.test.ts
+++ b/packages/runner/test/traverse-recorder.test.ts
@@ -6,6 +6,7 @@
  * once, repeated selectors and links shared rather than copied, and a bound on
  * how much one run may accumulate.
  */
+
 import { describe, it } from "@std/testing/bdd";
 
 import { expect } from "@std/expect";

--- a/packages/runner/test/unknown-reference-materialization.test.ts
+++ b/packages/runner/test/unknown-reference-materialization.test.ts
@@ -12,6 +12,7 @@
  * traversal and the lazy view a lift's argument goes through — have to answer
  * them identically, or the same field means two things.
  */
+
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 
 import { expect } from "@std/expect";

--- a/packages/ui/src/v2/components/cf-markdown/cf-markdown.browser.test.ts
+++ b/packages/ui/src/v2/components/cf-markdown/cf-markdown.browser.test.ts
@@ -6,6 +6,7 @@
  * arguments, so the BDD functions the rest of the repository uses are not
  * available here.
  */
+
 import { assert, assertEquals, assertStringIncludes } from "@std/assert";
 
 import { CFMarkdown } from "./index.ts";

--- a/scripts/topics-rehearsal-lib.ts
+++ b/scripts/topics-rehearsal-lib.ts
@@ -18,6 +18,7 @@
  * shebang a lie. That half lives in `topics-snapshot-lib.ts`, which only the
  * export imports, and the test file holds a check that it stayed there.
  */
+
 export const repoRoot = new URL("..", import.meta.url).pathname;
 
 /** Run `cf` from the repository root and return stdout; throw on failure. */

--- a/scripts/topics-snapshot-lib.ts
+++ b/scripts/topics-snapshot-lib.ts
@@ -16,6 +16,7 @@
  * which stays free of this dependency — `topics-rehearsal-lib.test.ts` holds
  * a check that it did.
  */
+
 import { decodedLinkOf } from "@commonfabric/state-inspector";
 
 /**

--- a/skills/perf-investigation/scripts/attribute-measures.ts
+++ b/skills/perf-investigation/scripts/attribute-measures.ts
@@ -34,6 +34,7 @@
  * too much — and is fixed differently from a caller with many parent spans
  * doing a little each, which is a frequency problem.
  */
+
 import {
   ancestors,
   buildForest,

--- a/skills/perf-investigation/scripts/wall-time.ts
+++ b/skills/perf-investigation/scripts/wall-time.ts
@@ -26,6 +26,7 @@
  * you have: unwrapped compute and a blocking round trip look identical from
  * here. What it can do is say where to look, and how much is at stake.
  */
+
 import { buildForest, loadMeasures, type Span } from "./measure-forest.ts";
 
 /**


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

The last class the ex-post-facto review measured, after #6693, #6694, #6696,
#6698, #6700, #6702 and #6706.

A file header sits at the top "with nothing between it and them but a blank
line", and §"File headers" says why that blank is load-bearing: it "keeps the
header from being read as the doc comment of the first declaration under it".
**37 files did not have it.**

- **36 are certain**: the header sits flush on the first `import`. A doc comment
  cannot document an import, so there is nothing else such a comment could be.
- **The 37th** is `scripts/topics-rehearsal-lib.ts`, whose header names its
  sibling files and explains the module's two halves before running straight
  into `export const repoRoot`.

## What is deliberately not fixed

The census found **55 more** files whose leading doc comment sits flush on a
*declaration* rather than an import. Those are overwhelmingly correct as they
stand: §"File headers" exempts a file that defines a single thing, and in such a
file the leading comment **is** that declaration's doc comment — which takes no
blank line, because a doc comment binds to what follows it. Each was read rather
than counted; the ones that are plainly file-scoped prose are in this change.

Two shapes in that group are traps worth naming for whoever sweeps next:

- **`packages/schema-generator/test/fixtures/schema/descriptions-*.input.ts` —
  the leading comment is PROGRAM INPUT.** The generator turns it into a schema
  `description`, and `descriptions-basic.expected.json` pins two of them. A blank
  line would detach the comment from its interface and break the golden.
  §"File headers" also exempts a test fixture whose content is the point.
- Files whose single declaration is documented in the header's place — the
  sanctioned exemption, not a missing blank.

## One file to watch

`packages/generated-patterns/integration/patterns/counter-when-unless-operators.pattern.ts`
is in the diff. `isPatternSource` is scoped to `packages/patterns`, so this file
feeds no baseline or vintage machinery, and its test drives the pattern by
behavior rather than by source bytes — but it **is** a pattern, and the pattern
integration lane is the one to watch here. Flagging rather than silently
excluding it.

## The instrument

A detector for this rule with a control fixture holding **both** populations:
three planted violations that must be found, and five GOOD files that must not
be — covering a shebang prelude, a lint pragma, a `//` block, an absent header,
and a conforming one. Expected counts stated before running: 2 IMPORT + 1 DECL,
measured exactly. After the sweep the tree reports **IMPORT 0** and the control
still reports **3**, so the zero is a measurement rather than a blind tool.

Building the control from both directions is this arc's own lesson, learned
twice today from opposite sides: a control made only of sites that must be found
cannot see a false positive, and one made only of sites that must not be cannot
see a false negative.

## The diff

```
added non-blank:  0
added blank:     37
deleted:          0
```

## Verification

Suites green: runner 1339, cf-harness 919, cli 210, ui 52, topics 2.
`check-skill-facts` 49 documents. `deno fmt --check` and `deno lint` clean over
all 37 files.

Gates run **off-pin**: this machine has `deno` 2.9.6 where `mise.toml` pins
2.9.4 and `mise` is not installed. CI's pinned run is the authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013j3CN3biC4UbWbid8wrSjk


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6712?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

