### PR TITLE
perf(runner): two more ancestor walks hold their ancestors on a stack

### DIFF
--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -3968,7 +3968,8 @@ function maybeConvertArrayPathToDataURILink(
  * value itself.
  */
 function containsCycle(value: unknown): boolean {
-  const ancestors = new Set<object>();
+  // The containers the walk is inside, which is what a cycle leads back to.
+  const ancestors = new IndexTrackingStack<object>();
   // Nodes already walked to completion without finding a cycle. Without this
   // memo the walk is exponential on shared acyclic references (a diamond per
   // level doubles the work), and candidate values are user-controlled.
@@ -3982,12 +3983,17 @@ function containsCycle(value: unknown): boolean {
     }
     if (completed.has(node)) return false;
     if (ancestors.has(node)) return true;
-    ancestors.add(node);
-    const values = Array.isArray(node) ? node : Object.values(node);
-    for (const child of values) {
-      if (walk(child)) return true;
+    ancestors.push(node);
+    // Every way out of the descent, the early return on a cycle included,
+    // takes the node back off the stack.
+    try {
+      const values = Array.isArray(node) ? node : Object.values(node);
+      for (const child of values) {
+        if (walk(child)) return true;
+      }
+    } finally {
+      ancestors.popExpect(node);
     }
-    ancestors.delete(node);
     completed.add(node);
     return false;
   };
@@ -3995,20 +4001,16 @@ function containsCycle(value: unknown): boolean {
 }
 
 /**
- * Validates that a value contains only static data (no cells or cell-like objects)
- * and has no circular references. Used by Cell.of() to ensure only serializable
- * static data is passed.
+ * Validates that `value` holds only static data: no cell or cell-like object
+ * anywhere in it, and no cycle. A value reached by two paths is shared rather
+ * than cyclic, and passes. This is what `Cell.of()` vets its initial value
+ * with.
  *
- * Note: Shared references (same object at multiple paths) are allowed.
- * Only true cycles (object referencing an ancestor) are rejected.
- *
- * @param value - The value to validate
- * @throws Error if value contains cells or has circular references
+ * @throws If `value` holds a cell or cell-like object, or a cycle.
  */
 function validateStaticData(value: unknown): void {
-  // Track ancestors in current path (for cycle detection)
-  // Shared references are fine - only cycles back to ancestors are errors
-  const ancestors = new Set<object>();
+  // The containers the walk is inside, which is what a cycle leads back to.
+  const ancestors = new IndexTrackingStack<object>();
 
   function traverse(val: unknown, path: string[]): void {
     // Primitives are always fine
@@ -4036,7 +4038,6 @@ function validateStaticData(value: unknown): void {
       );
     }
 
-    // Check for cycles - only ancestors in current path, not all seen objects
     if (ancestors.has(obj)) {
       throw new Error(
         `Cell.of() does not accept circular references. Cycle detected at path '${
@@ -4046,41 +4047,46 @@ function validateStaticData(value: unknown): void {
       );
     }
 
-    ancestors.add(obj);
+    ancestors.push(obj);
 
-    // A `FabricPrimitive` reaches here and survives, correctly: it has zero
-    // enumerable own properties, so `Object.keys()` is empty and the descent
-    // ends -- and a leaf holds no cell for this validation to find.
-    //
-    // A `FabricInstance` is refused instead. Its codec contents can hold a
-    // `Cell`, which is exactly what this validation exists to reject, and those
-    // contents are not reachable by property name -- so passing one through
-    // _smuggles_ a cell into static data past the check meant to stop it.
-    // That is not a completeness gap; it is the validation failing open.
-    //
-    // Nothing reaches this in production today, de facto rather than by
-    // construction: a `FabricError` is ungated and exposed to pattern authors,
-    // so what keeps this safe is that nothing yet puts one in `Cell.of()` data.
-    //
-    // TODO(danfuzz): descend by codec-mediated traversal into instance state,
-    // at which point this becomes a walk rather than a refusal.
-    if (obj instanceof FabricInstance) {
-      refuseFabricInstance(obj, `in \`Cell.of()\` static data`);
-    }
-
-    // Traverse arrays and objects
-    if (Array.isArray(obj)) {
-      for (let i = 0; i < obj.length; i++) {
-        traverse(obj[i], [...path, String(i)]);
+    // Every way out of the descent, a refusal thrown from inside it included,
+    // takes the object back off the stack.
+    try {
+      // A `FabricPrimitive` reaches here and survives, correctly: it has zero
+      // enumerable own properties, so `Object.keys()` is empty and the
+      // descent ends -- and a leaf holds no cell for this validation to find.
+      //
+      // A `FabricInstance` is refused instead. Its codec contents can hold a
+      // `Cell`, which is exactly what this validation exists to reject, and
+      // those contents are not reachable by property name -- so passing one
+      // through _smuggles_ a cell into static data past the check meant to
+      // stop it. That is not a completeness gap; it is the validation failing
+      // open.
+      //
+      // Nothing reaches this in production today, de facto rather than by
+      // construction: a `FabricError` is ungated and exposed to pattern
+      // authors, so what keeps this safe is that nothing yet puts one in
+      // `Cell.of()` data.
+      //
+      // TODO(danfuzz): descend by codec-mediated traversal into instance
+      // state, at which point this becomes a walk rather than a refusal.
+      if (obj instanceof FabricInstance) {
+        refuseFabricInstance(obj, `in \`Cell.of()\` static data`);
       }
-    } else {
-      for (const key of Object.keys(obj)) {
-        traverse((obj as Record<string, unknown>)[key], [...path, key]);
-      }
-    }
 
-    // Remove from ancestors when backtracking (shared refs at other paths are ok)
-    ancestors.delete(obj);
+      // Traverse arrays and objects
+      if (Array.isArray(obj)) {
+        for (let i = 0; i < obj.length; i++) {
+          traverse(obj[i], [...path, String(i)]);
+        }
+      } else {
+        for (const key of Object.keys(obj)) {
+          traverse((obj as Record<string, unknown>)[key], [...path, key]);
+        }
+      }
+    } finally {
+      ancestors.popExpect(obj);
+    }
   }
 
   traverse(value, []);

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -3970,10 +3970,12 @@ function maybeConvertArrayPathToDataURILink(
 function containsCycle(value: unknown): boolean {
   // The containers the walk is inside, which is what a cycle leads back to.
   const ancestors = new IndexTrackingStack<object>();
+
   // Nodes already walked to completion without finding a cycle. Without this
   // memo the walk is exponential on shared acyclic references (a diamond per
   // level doubles the work), and candidate values are user-controlled.
   const completed = new Set<object>();
+
   const walk = (node: unknown): boolean => {
     if (
       node === null || typeof node !== "object" || isCell(node) ||
@@ -3981,22 +3983,29 @@ function containsCycle(value: unknown): boolean {
     ) {
       return false;
     }
+
     if (completed.has(node)) return false;
     if (ancestors.has(node)) return true;
+
     ancestors.push(node);
+
     // Every way out of the descent, the early return on a cycle included,
     // takes the node back off the stack.
     try {
       const values = Array.isArray(node) ? node : Object.values(node);
+
       for (const child of values) {
         if (walk(child)) return true;
       }
     } finally {
       ancestors.popExpect(node);
     }
+
     completed.add(node);
+
     return false;
   };
+
   return walk(value);
 }
 

--- a/packages/runner/test/cell-value-checks.bench.ts
+++ b/packages/runner/test/cell-value-checks.bench.ts
@@ -1,0 +1,171 @@
+/**
+ * What a value costs to be checked before a cell takes it. `Cell.of()` checks
+ * that its initial value holds only static data and no cycle, and
+ * `addUnique()` checks each candidate for a cycle before comparing it against
+ * what the list holds. Each check is a walk over every container of the
+ * value.
+ *
+ * Three shapes:
+ *
+ *   - **records**: a list of records, each holding a tag list and an address,
+ *     which is the shape a document takes. Three containers per record under
+ *     one root.
+ *   - **flat**: one object holding a hundred scalars. A single container, so a
+ *     per-container cost has nothing to save here; it is the control.
+ *   - **chain**: a hundred objects nested one inside the next. The walk is a
+ *     hundred deep at the bottom, with every ancestor in play.
+ *
+ * `Cell.of()` creates no link and writes nothing, so the call is the check
+ * plus wrapping the value in a schema, and what the check costs is a real
+ * share of it. It is timed as a batch of `BATCH` calls on as many values,
+ * each figure being the cost of the batch: one call on the smallest shape
+ * runs well under the length at which Deno honors an explicit timer, and a
+ * body timed whole would report its scaffolding.
+ *
+ * `addUnique()` is timed against a list holding one element of the same
+ * shape, with a candidate that differs from it in content, so the call reads
+ * the list, checks the candidate, compares it against the element, and then
+ * writes it. The write is most of the call and grows with the value as the
+ * check does, so these figures say what the whole call costs by shape, and
+ * whether the check's share of it has moved is a question for the `Cell.of()`
+ * figures. Each iteration opens a transaction outside the timed window and
+ * aborts it afterward, so no iteration pays for one and none leaves anything
+ * behind for the next.
+ *
+ * Both are run under a frame, as a handler runs, and it is pushed and popped
+ * around each iteration so that none is left behind for whatever runs next in
+ * the same process.
+ */
+
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+import { popFrame, pushFrame } from "../src/builder/pattern.ts";
+import { Runtime } from "../src/runtime.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
+
+const signer = await Identity.fromPassphrase("bench cell value checks");
+const space = signer.did();
+
+/** Records in the `records` shape. */
+const RECORDS = 100;
+
+/** Scalars in the `flat` shape. */
+const FLAT_MEMBERS = 100;
+
+/** Objects in the `chain` shape, which is also how deep the walk goes. */
+const CHAIN_DEPTH = 100;
+
+/** How many `Cell.of()` calls one timed batch makes. */
+const BATCH = 16;
+
+/**
+ * A list of `RECORDS` records, each a small tree of its own. Two builds with
+ * the same `seed` are equal by content, and two with different seeds are not.
+ */
+function records(seed: number): unknown {
+  return Array.from({ length: RECORDS }, (_, index) => ({
+    id: index,
+    name: `Record ${seed}-${index}`,
+    tags: [`tag-${index % 7}`, `tag-${index % 11}`, `tag-${index % 13}`],
+    address: {
+      street: `${index} Main Street`,
+      city: "Springfield",
+      zip: String(10000 + index),
+    },
+  }));
+}
+
+/** One object holding `FLAT_MEMBERS` scalars; `seed` as for `records()`. */
+function flat(seed: number): unknown {
+  return Object.fromEntries(
+    Array.from(
+      { length: FLAT_MEMBERS },
+      (_, index) => [`m${index}`, index + seed],
+    ),
+  );
+}
+
+/** `CHAIN_DEPTH` objects, each holding the next; `seed` as for `records()`. */
+function chain(seed: number): unknown {
+  let node: unknown = { depth: CHAIN_DEPTH, seed };
+
+  for (let depth = CHAIN_DEPTH - 1; depth > 0; depth--) {
+    node = { depth, next: node };
+  }
+
+  return node;
+}
+
+/** The shapes. Every case builds its own value, so none sees another's. */
+const SHAPES = [
+  { name: "records", build: records },
+  { name: "flat", build: flat },
+  { name: "chain", build: chain },
+] as const;
+
+const storageManager = StorageManager.emulate({ as: signer });
+const runtime = new Runtime({
+  apiUrl: new URL(import.meta.url),
+  storageManager,
+});
+
+const { commonfabric: { Cell } } = createTrustedBuilder(runtime);
+
+//
+// Cell.of()
+//
+
+{
+  const tx = runtime.edit();
+
+  for (const shape of SHAPES) {
+    const values = Array.from({ length: BATCH }, () => shape.build(0));
+
+    Deno.bench(shape.name, { group: `Cell.of() x${BATCH}` }, (b) => {
+      const frame = pushFrame({ runtime, tx, space });
+
+      try {
+        b.start();
+        for (const value of values) Cell.of(value);
+        b.end();
+      } finally {
+        popFrame(frame);
+      }
+    });
+  }
+}
+
+//
+// addUnique()
+//
+
+for (const shape of SHAPES) {
+  const cause = `cell-value-checks-${shape.name}`;
+  const held = shape.build(0);
+
+  {
+    const tx = runtime.edit();
+
+    runtime.getCell<unknown[]>(space, cause, undefined, tx).set([held]);
+    await tx.commit();
+  }
+
+  Deno.bench(shape.name, { group: "addUnique()" }, (b) => {
+    const tx = runtime.edit();
+    // Pushed before the cell is made, which is when a cell takes its frame.
+    const frame = pushFrame({ runtime, tx, space });
+
+    try {
+      const cell = runtime.getCell<unknown[]>(space, cause, undefined, tx);
+      const candidate = shape.build(1);
+
+      b.start();
+      cell.addUnique(candidate);
+      b.end();
+    } finally {
+      popFrame(frame);
+      tx.abort("bench");
+    }
+  });
+}


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Fable 5.1)

`containsCycle()` and `validateStaticData()` in `cell.ts` recognized a cycle by
holding every container the walk was inside in a `Set`, which cost a hash
insert and a hash delete per container and read nothing back on a value with no
cycle in it, which is nearly all of them. They hold those containers on an
`IndexTrackingStack` instead, as the conversion in the same file already does.
In each walk the insert becomes a push, the delete a `popExpect()` naming what
has to come off, and the descent between them sits in a `try` whose `finally`
holds the pop, so that every way out of a container, the early return on a
cycle and a refusal thrown from inside the descent included, leaves the stack
as it found it. That is the shape the conversion already has.

The first commit adds `packages/runner/test/cell-value-checks.bench.ts`, which
times the two callers of these walks, `Cell.of()` and `addUnique()`, over three
shapes: a list of a hundred records (301 containers), one object holding a
hundred scalars (one container, the control), and a chain a hundred objects
deep. Nothing in the tree measured either call before it.

## What the callers cost

`cell-value-checks.bench.ts`, p75 per run, median of 8 interleaved runs a side,
base being the benchmark commit and branch being `56be7ec40`, which the head
differs from only by blank lines in `cell.ts`. Microseconds:

| group | shape | base | branch | | spread |
| --- | --- | --- | --- | --- | --- |
| `Cell.of()` x16 | records | 449.1 | 389.5 | **0.87x** | 3%/4% |
| `Cell.of()` x16 | flat | 34.7 | 34.5 | 0.99x | 6%/4% |
| `Cell.of()` x16 | chain | 198.5 | 225.7 | **1.14x** | 6%/4% |
| `addUnique()` | records | 3638.8 | 3625.5 | 1.00x | 11%/3% |
| `addUnique()` | flat | 187.8 | 184.6 | 0.98x | 8%/11% |
| `addUnique()` | chain | 1876.5 | 1883.1 | 1.00x | 6%/2% |

Three earlier sittings, taken as the benchmark and the change went through
review, put the records row at 0.82x, 0.82x and 0.86x and the chain row at
1.10x, 1.09x and 1.15x, so the two figures that move are stable across
sittings and the rest sit inside their spreads every time.

`Cell.of()` is the call where the walk shows: it creates no link and writes
nothing, so the check is a real fraction of it, and the record shape moves by
close to what the walk alone moves by below. The flat control has one
container and so nothing per container to save, and does not move.

`addUnique()` does not move on any shape, and is not expected to. A CPU
profile of the record shape puts 58% of the call in `diffAndUpdate()` and 30%
of it in the write batch under that, against about 10 us in the cycle walk, so
a fifth off the walk is under 1% of the call. The rows are here to say that
the caller is unaffected, not to show the change.

## What the walks themselves cost

A scratch harness, not in the tree, holding both forms of each function side by
side with the bodies copied from `main`. p75 per run, median of 3 runs.
Microseconds:

| shape | `containsCycle()` | | `validateStaticData()` | |
| --- | --- | --- | --- | --- |
| records 100 | 21.3 → 18.5 | **0.87x** | 26.9 → 22.0 | **0.82x** |
| records 1000 | 226.5 → 187.4 | **0.83x** | 280.5 → 227.3 | **0.81x** |
| flat 100 | 0.46 → 0.45 | 0.97x | 2.18 → 2.13 | 0.98x |
| chain 30 | 1.68 → 1.30 | 0.77x | 2.48 → 2.12 | 0.86x |
| chain 64 | 3.94 → 3.32 | 0.84x | 6.72 → 6.23 | 0.93x |
| chain 80 | 5.23 → 6.26 | **1.20x** | 9.35 → 10.08 | 1.08x |
| chain 100 | 6.07 → 7.68 | **1.26x** | 11.96 → 13.54 | 1.13x |
| chain 200 | 13.00 → 16.29 | 1.25x | 35.71 → 39.79 | 1.11x |

Spreads are 0–8% throughout.

## The chain rows, and where the step is

A single descent past 64 containers deep costs more on the stack than on the
set, and the step sits exactly at the stack's `ADD_INDEX_AT`. A chain of 64
still wins, because the lookup at the 64th push sees a height of 63; from 80 on
the descent builds an index, maintains it through the rest of the pushes and
pops, and drops it on the way back out, and a cycle guard that misses every
time never reads the index it paid for. That is a property of the class's
threshold rather than of this change, and any single-descent caller of the
class pays it on a value that deep. A value nested 65 deep is rare in practice,
the deepest shape in the walks' own tests being a diamond 30 deep, and the
record shape is what these walks see.

## What it does to a message crossing the IPC boundary

Nothing, and that is the point of measuring it: neither walk is on the IPC
path, so the crossing is this change's control, and the arc's running figure
gets one more point. `packages/runtime-client/bench/ipc-crossing.bench.ts` at
four commits in one sitting: the last build before the IPC envelope, the
envelope's own merge, `main` today, and this branch. The benchmark, its
far-side fixture and `BenchWorker` are byte-identical at all four, verified by
hash; the two older trees carry them as untracked copies and differ from their
commits in nothing else. p75 per run, median of 12 interleaved runs, each point
on the arm that point's code actually ran. Microseconds:

| subject | before the envelope | the envelope landed | | main today | | here | |
| --- | --- | --- | --- | --- | --- | --- | --- |
| small record | 13.5 | 14.4 | 1.06x | 13.3 | 0.98x | 13.4 | 0.99x |
| flat, 100 members | 45.5 | 49.3 | 1.08x | 40.6 | 0.89x | 41.0 | 0.90x |
| 100 records with links | 359.2 | 449.2 | 1.25x | 369.3 | 1.03x | 370.6 | 1.03x |
| 1000 records with links | 3431.3 | 4255.6 | 1.24x | 3468.6 | 1.01x | 3461.6 | 1.01x |

Ratios are against what the same message cost before the envelope existed.
The first two points reproduce the figures the previous change in this arc
reported to within 2% on the three larger subjects and 5% on the small record,
which `postMessage()` scheduling dominates; and `main today` here is that
change's own `here` column, reproduced to within 1% on every subject. Main
today against here, both arms:

| subject | envelope | status quo |
| --- | --- | --- |
| small record | 1.00x | 1.00x |
| flat, 100 members | 1.01x | 1.01x |
| 100 records with links | 1.00x | 1.00x |
| 1000 records with links | 1.00x | 1.01x |

Spreads run 5–20%, so every row is flat rather than merely quiet.

Per step, `bench/ipc-crossing-steps.bench.ts`, 8 interleaved runs a side over
its five subjects and eight steps: all 40 rows sit between 0.99x and 1.02x with
spreads of 1–10%, `convert` at 1.00x on every subject. The walk the arc's last
change moved is untouched here, and its row says so.

## What guards the change

Both walks have cycle tests and shared-reference tests already, and ablation
shows what each catches. Removing either walk's push fails its cycle tests, by
stack overflow. Removing the pop from `validateStaticData()` fails its
shared-reference test, a value reached twice being taken for a cycle. Removing
the pop from `containsCycle()` fails nothing: that walk memoizes every node it
completes and consults the memo before the ancestors, so a shared node is
answered by the memo and the missing pop is unobservable through this caller.
The pop is still what keeps the stack honest, and `popExpect()` would throw on
the first unbalanced pair.

Both walks' tests run green here, and the whole `runner` suite with them.
