### PR TITLE
perf(runner): a graph-query walk chases metadata for named roots, not crossings

### DIFF
--- a/packages/memory/test/v2-query.test.ts
+++ b/packages/memory/test/v2-query.test.ts
@@ -2350,10 +2350,15 @@ Deno.test("memory v2 query chases metadata for named roots, not crossings", asyn
           value: { value: { kind: "target pattern" } },
         }, {
           op: "set",
+          id: "of:target-result",
+          value: { value: { computed: "target result" } },
+        }, {
+          op: "set",
           id: "of:crossing-target",
           value: {
             value: { name: "target" },
             pattern: link("of:target-family"),
+            result: link("of:target-result"),
           },
         }, {
           op: "set",
@@ -2392,12 +2397,14 @@ Deno.test("memory v2 query chases metadata for named roots, not crossings", asyn
     );
 
     const ids = new Set(rooted.entities.map((entity) => entity.id));
-    // The named root arrives with its metadata family; the document the
-    // walk reaches through the `child` crossing arrives under the reader's
-    // narrowing, without its own family.
+    // The named root arrives with its full metadata family; the document
+    // the walk reaches through the `child` crossing arrives with the rails
+    // computed values ride — its result — and without the rails that
+    // serve loading it: its pattern.
     assert(ids.has("of:meta-root"));
     assert(ids.has("of:crossing-target"));
     assert(ids.has("of:root-family"));
+    assert(ids.has("of:target-result"));
     assert(!ids.has("of:target-family"));
 
     const targetRooted = queryGraph(
@@ -2463,6 +2470,53 @@ Deno.test("memory v2 query chases metadata for named roots, not crossings", asyn
     // root's document before it is visited, and coverage skips the second
     // root's traversal — but a named root's family arrives regardless.
     assert(bothIds.has("of:target-family"));
+
+    // The same guarantee across INCREMENTAL adds: a first query's crossing
+    // covers the target's selector, and a later query naming the target is
+    // not covered until its family has been chased — the extension supplies
+    // it, and only then does coverage hold.
+    const tracked = trackGraph(space, engine, {
+      roots: [{
+        id: "of:meta-root",
+        selector: {
+          path: [],
+          schema: {
+            type: "object",
+            properties: {
+              child: {
+                type: "object",
+                properties: { name: { type: "string" } },
+              },
+            },
+          },
+        },
+      }],
+    });
+    const laterQuery: Parameters<typeof extendTrackedGraph>[3] = {
+      roots: [{
+        id: "of:crossing-target",
+        selector: {
+          path: [],
+          schema: {
+            type: "object",
+            properties: { name: { type: "string" } },
+          },
+        },
+      }],
+    };
+    assert(!isGraphQueryCoveredByState(space, tracked.state, laterQuery));
+    const familyExtended = extendTrackedGraph(
+      space,
+      engine,
+      tracked.state,
+      laterQuery,
+    );
+    assert(
+      [...familyExtended.updates.values()].some((entity) =>
+        entity.id === "of:target-family"
+      ),
+    );
+    assert(isGraphQueryCoveredByState(space, tracked.state, laterQuery));
   } finally {
     close(engine);
     await Deno.remove(path);

--- a/packages/memory/test/v2-query.test.ts
+++ b/packages/memory/test/v2-query.test.ts
@@ -2425,6 +2425,44 @@ Deno.test("memory v2 query chases metadata for named roots, not crossings", asyn
     // load rides the naming, not the reachability.
     assert(targetIds.has("of:crossing-target"));
     assert(targetIds.has("of:target-family"));
+
+    const bothRooted = queryGraph(
+      space,
+      engine,
+      {
+        roots: [{
+          id: "of:meta-root",
+          selector: {
+            path: [],
+            schema: {
+              type: "object",
+              properties: {
+                child: {
+                  type: "object",
+                  properties: { name: { type: "string" } },
+                },
+              },
+            },
+          },
+        }, {
+          id: "of:crossing-target",
+          selector: {
+            path: [],
+            schema: {
+              type: "object",
+              properties: { name: { type: "string" } },
+            },
+          },
+        }],
+      },
+      undefined,
+      identity,
+    );
+    const bothIds = new Set(bothRooted.entities.map((entity) => entity.id));
+    // Naming beats ordering: the first root's crossing may cover the second
+    // root's document before it is visited, and coverage skips the second
+    // root's traversal — but a named root's family arrives regardless.
+    assert(bothIds.has("of:target-family"));
   } finally {
     close(engine);
     await Deno.remove(path);

--- a/packages/memory/test/v2-query.test.ts
+++ b/packages/memory/test/v2-query.test.ts
@@ -2326,3 +2326,107 @@ Deno.test("memory v2 extendTrackedGraph attributes the roots it adds", async () 
     await Deno.remove(path);
   }
 });
+
+Deno.test("memory v2 query chases metadata for named roots, not crossings", async () => {
+  const { engine, path } = await createEngine();
+  const space = "did:key:z6Mk-memory-v2-query-meta-roots";
+  const link = (id: string) => ({ "/": { "link@1": { id, path: [], space } } });
+
+  try {
+    applyCommit(engine, {
+      sessionId: "session:writer",
+      invocation: invocationFor(1),
+      authorization,
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id: "of:root-family",
+          value: { value: { kind: "root pattern" } },
+        }, {
+          op: "set",
+          id: "of:target-family",
+          value: { value: { kind: "target pattern" } },
+        }, {
+          op: "set",
+          id: "of:crossing-target",
+          value: {
+            value: { name: "target" },
+            pattern: link("of:target-family"),
+          },
+        }, {
+          op: "set",
+          id: "of:meta-root",
+          value: {
+            value: { child: link("of:crossing-target") },
+            pattern: link("of:root-family"),
+          },
+        }],
+      },
+    });
+
+    const identity = { principal: "did:key:alice", sessionId: "session:alice" };
+    const rooted = queryGraph(
+      space,
+      engine,
+      {
+        roots: [{
+          id: "of:meta-root",
+          selector: {
+            path: [],
+            schema: {
+              type: "object",
+              properties: {
+                child: {
+                  type: "object",
+                  properties: { name: { type: "string" } },
+                },
+              },
+            },
+          },
+        }],
+      },
+      undefined,
+      identity,
+    );
+
+    const ids = new Set(rooted.entities.map((entity) => entity.id));
+    // The named root arrives with its metadata family; the document the
+    // walk reaches through the `child` crossing arrives under the reader's
+    // narrowing, without its own family.
+    assert(ids.has("of:meta-root"));
+    assert(ids.has("of:crossing-target"));
+    assert(ids.has("of:root-family"));
+    assert(!ids.has("of:target-family"));
+
+    const targetRooted = queryGraph(
+      space,
+      engine,
+      {
+        roots: [{
+          id: "of:crossing-target",
+          selector: {
+            path: [],
+            schema: {
+              type: "object",
+              properties: { name: { type: "string" } },
+            },
+          },
+        }],
+      },
+      undefined,
+      identity,
+    );
+    const targetIds = new Set(
+      targetRooted.entities.map((entity) => entity.id),
+    );
+    // The same document, NAMED as a root, chases its family: intent to
+    // load rides the naming, not the reachability.
+    assert(targetIds.has("of:crossing-target"));
+    assert(targetIds.has("of:target-family"));
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});

--- a/packages/memory/v2/query.ts
+++ b/packages/memory/v2/query.ts
@@ -83,6 +83,14 @@ export type TrackedGraphState = {
   entities: Map<QueryDocKey, EntitySnapshot>;
   memo: SchemaMemo;
   manager: EngineObjectManager;
+
+  /** Root doc keys whose FULL metadata family this state has chased —
+   * recorded when a query NAMES a document and its walk visits it. A
+   * crossing records reach in the tracker but only the crossing rails of
+   * the family, so coverage of a later query that names the document
+   * requires this record too: reach without family is not coverage for a
+   * root (see isGraphQueryCoveredByState). */
+  rootFamilies: Set<string>;
 };
 
 /**
@@ -843,6 +851,7 @@ export const cloneTrackedGraphState = (
     entities: new Map(state.entities),
     memo: new Map(state.memo),
     manager,
+    rootFamilies: new Set(state.rootFamilies),
   };
 };
 
@@ -1385,6 +1394,7 @@ export const trackGraph = (
   };
   const sharedMemo = createSchemaMemo();
   const stats = createQueryTraversalStats();
+  const rootFamilies = new Set<string>();
   const readCountBefore = manager.readCount;
   const walk = new GraphQueryWalk({
     manager,
@@ -1415,17 +1425,14 @@ export const trackGraph = (
           : { scopeKey: root.entityScopeKey }),
         type: "application/json",
       });
+      const rootKey = rootDocKey(space, root, identityOf(manager));
       if (loaded !== null) {
-        walk.visit(
-          loaded,
-          selector,
-          rootDocKey(space, root, identityOf(manager)),
-        );
+        walk.visit(loaded, selector, rootKey);
+        // The visit chased the named document's full family; an absent
+        // root records nothing, so its later creation re-evaluates it.
+        rootFamilies.add(rootKey);
       } else {
-        schemaTracker.add(
-          rootDocKey(space, root, identityOf(manager)),
-          selector,
-        );
+        schemaTracker.add(rootKey, selector);
       }
     });
   }
@@ -1456,6 +1463,7 @@ export const trackGraph = (
     entities,
     memo: sharedMemo,
     manager,
+    rootFamilies,
   };
   if (
     cache !== undefined && cacheKeys !== undefined &&
@@ -1509,7 +1517,7 @@ export const extendTrackedGraph = (
       const rootScope = root.scope ?? DEFAULT_SCOPE;
       const rootKey = rootDocKey(space, root, identityOf(manager));
       touched.add(rootKey);
-      evaluateTrackedDocument(
+      const visited = evaluateTrackedDocument(
         space,
         manager,
         {
@@ -1525,6 +1533,9 @@ export const extendTrackedGraph = (
         state.memo,
         stats,
       );
+      // The visit chased the named document's full family; an absent
+      // root records nothing, so its later creation re-evaluates it.
+      if (visited) state.rootFamilies.add(rootKey);
     });
   }
 
@@ -1591,7 +1602,13 @@ export const isGraphQueryCoveredByState = (
   query.roots.every((root) => {
     const selector = toDocumentSelector(root.selector);
     const rootKey = rootDocKey(space, root, identityOf(state.manager));
-    return schemaTrackerCoversSelector(state.tracker, rootKey, selector);
+    // Reach without family is not coverage for a NAMED root: a crossing
+    // may have recorded the selector while chasing only the crossing
+    // rails, and naming the document entitles the caller to its full
+    // family (extendTrackedGraph's visit supplies it, cheaply, when the
+    // selector itself is already covered).
+    return schemaTrackerCoversSelector(state.tracker, rootKey, selector) &&
+      state.rootFamilies.has(rootKey);
   });
 
 export const queryGraph = (
@@ -1844,7 +1861,7 @@ const evaluateTrackedDocument = (
   // into one batch, say) keeps waiting for a real arrival, so its
   // caller passes a sink the wire never sees.
   absentSink: MapSetStringToPathSelectors = schemaTracker,
-) => {
+): boolean => {
   const docKey: QueryDocKey = address.scopeKey !== undefined
     ? `${space}/${address.scopeKey}/${address.id}`
     : toDocKey(
@@ -1856,7 +1873,7 @@ const evaluateTrackedDocument = (
   const loaded = manager.load(address);
   if (loaded === null || loaded.value === undefined) {
     absentSink.add(docKey, internPathSelector(selector));
-    return;
+    return false;
   }
   // A fresh walk per document, so each starts with an empty pointer-cycle
   // tracker while sharing the query's reach and its memoized schema results.
@@ -1869,6 +1886,7 @@ const evaluateTrackedDocument = (
     memo: sharedMemo,
     stats,
   }).visit(loaded, selector, docKey);
+  return true;
 };
 
 export const toDocKey = (

--- a/packages/runner/src/graph-query.ts
+++ b/packages/runner/src/graph-query.ts
@@ -194,6 +194,18 @@ export class GraphQueryWalk {
             : this.#keyOverrides.get(referrerKey) ?? referrerKey,
         );
       },
+      undefined,
+      undefined,
+      // Documents this walk loads through link crossings do not chase
+      // their metadata families; only the document a `visit()` call names
+      // does, through the loadMetaLinkedDocs call in `visit()` itself. A
+      // caller that intends to load and run what it named — a piece
+      // resume, a setsrc staging read — names it as a root, so a root's
+      // pattern/source/cfc family still arrives with it. A crossing-
+      // reached document is one the query did not name, and chasing its
+      // family multiplies a wide walk by every visited piece's whole doc
+      // set while delivering documents nothing asked to interpret.
+      false,
     );
     this.#memo = options.memo ?? createSchemaMemo();
     this.stats = options.stats ?? createGraphQueryWalkStats();
@@ -201,8 +213,10 @@ export class GraphQueryWalk {
 
   /**
    * Walks `document` under `selector`, recording every document the schema
-   * reaches — including the metadata documents a reader needs to interpret
-   * them — in the walk's schema tracker.
+   * reaches in the walk's schema tracker. The named document's own metadata
+   * family — pattern, source, cfc, and the rest — is recorded with it;
+   * documents the walk merely reaches through link crossings are recorded
+   * under the selectors that reached them, without their families.
    *
    * The document records under `schemaTrackerKey` over the walk's identity
    * unless the caller passes `docKey`: a caller that named an explicit
@@ -277,6 +291,11 @@ export class GraphQueryWalk {
       this.#addTraverserStats(traverser);
     }
 
+    // The named document's family, chased here regardless of the context's
+    // includeMeta — that flag governs the traverser's link crossings above,
+    // and it is off so a crossing-reached document is delivered without its
+    // family. What a caller names, it may intend to load; what a walk merely
+    // reaches, it does not.
     loadMetaLinkedDocs(
       tx,
       {

--- a/packages/runner/src/graph-query.ts
+++ b/packages/runner/src/graph-query.ts
@@ -22,6 +22,7 @@ import { isObjectNotArray } from "@commonfabric/utils/types";
 import type { JSONSchema } from "./builder/types.ts";
 import { ExtendedStorageTransaction } from "./storage/extended-storage-transaction.ts";
 import {
+  ALL_META_RAILS,
   type BaseMemoryAddress,
   CompoundCycleTracker,
   createSchemaMemo,
@@ -32,6 +33,7 @@ import {
   loadMetaLinkedDocs,
   ManagedStorageTransaction,
   MapSetStringToPathSelectors,
+  type MetaRail,
   type ObjectStorageManager,
   type SchemaMemo,
   SchemaObjectTraverser,
@@ -66,6 +68,16 @@ export type GraphQueryWalkStats = {
   getDocAtPathCalls: number;
   schemaMemoHits: number;
 };
+
+/**
+ * The rails a crossing-reached document still chases: the ones computed
+ * values are supplied through. A plain subscriber whose walk crosses into
+ * a piece reads what the piece computes off `result`, and `internal`
+ * carries the sub-piece manifests those computations hang off. The
+ * remaining rails — pattern, argument, cfc — serve loading and running a
+ * piece, which is the intent of naming one, not of reaching one.
+ */
+const CROSSING_META_RAILS: readonly MetaRail[] = ["result", "internal"];
 
 export const createGraphQueryWalkStats = (): GraphQueryWalkStats => ({
   coveredSelectorSkips: 0,
@@ -196,16 +208,17 @@ export class GraphQueryWalk {
       },
       undefined,
       undefined,
-      // Documents this walk loads through link crossings do not chase
-      // their metadata families; only the document a `visit()` call names
-      // does, through the loadMetaLinkedDocs call in `visit()` itself. A
-      // caller that intends to load and run what it named — a piece
-      // resume, a setsrc staging read — names it as a root, so a root's
-      // pattern/source/cfc family still arrives with it. A crossing-
-      // reached document is one the query did not name, and chasing its
-      // family multiplies a wide walk by every visited piece's whole doc
-      // set while delivering documents nothing asked to interpret.
-      false,
+      // A document this walk loads through a link crossing chases only the
+      // rails computed values arrive through — `result` and `internal` —
+      // so a subscriber reading THROUGH a piece still receives and stays
+      // subscribed to what the piece computes. The full family belongs to
+      // the documents a query names: `visit()` chases every rail for its
+      // named document, which is what a caller that intends to load and
+      // run one — a piece resume, a setsrc staging read — relies on.
+      // Chasing every rail at every crossing instead multiplies a wide
+      // walk by each visited piece's whole doc set (pattern, argument,
+      // cfc and their recursion) for documents nothing asked to run.
+      CROSSING_META_RAILS,
     );
     this.#memo = options.memo ?? createSchemaMemo();
     this.stats = options.stats ?? createGraphQueryWalkStats();
@@ -292,14 +305,13 @@ export class GraphQueryWalk {
       }
     }
 
-    // The named document's family, chased even when selector coverage skips
-    // the traversal above: a crossing may have covered this document before
-    // a root named it, and coverage proves reach, not family. Chased here
-    // regardless of the context's includeMeta — that flag governs the
-    // traverser's link crossings, and it is off so a crossing-reached
-    // document is delivered without its family. What a caller names, it may
-    // intend to load; what a walk merely reaches, it does not. The chase
-    // dedupes through `metaDocsVisited`, so a repeat visit re-reads nothing.
+    // The named document's FULL family — every rail, not the crossing
+    // subset the context grants mid-walk loads — chased even when selector
+    // coverage skips the traversal above: a crossing may have covered this
+    // document before a root named it, and coverage proves reach, not
+    // family. What a caller names, it may intend to load; what a walk
+    // merely reaches, it does not. The chase dedupes through
+    // `metaDocsVisited`, so a repeat visit re-reads nothing new.
     loadMetaLinkedDocs(
       tx,
       {
@@ -307,6 +319,7 @@ export class GraphQueryWalk {
         value: document.value,
       },
       this.#context,
+      ALL_META_RAILS,
     );
   }
 

--- a/packages/runner/src/graph-query.ts
+++ b/packages/runner/src/graph-query.ts
@@ -244,17 +244,16 @@ export class GraphQueryWalk {
       this.#keyOverrides.set(derivedKey, docKey);
     }
     const internedSelector = internPathSelector(effectiveSelector);
-    if (
-      schemaTrackerCoversSelector(
-        this.#context.schemaTracker,
-        docKey,
-        internedSelector,
-      )
-    ) {
+    const covered = schemaTrackerCoversSelector(
+      this.#context.schemaTracker,
+      docKey,
+      internedSelector,
+    );
+    if (covered) {
       this.stats.coveredSelectorSkips++;
-      return;
+    } else {
+      this.#context.schemaTracker.add(docKey, internedSelector);
     }
-    this.#context.schemaTracker.add(docKey, internedSelector);
 
     if (!isObjectNotArray(document.value)) {
       return;
@@ -263,39 +262,44 @@ export class GraphQueryWalk {
     const tx = new ExtendedStorageTransaction(
       new ManagedStorageTransaction(this.#manager),
     );
-    const value = (document.value as { value: FabricValue }).value;
-    const root: IMemorySpaceValueAttestation = {
-      address: { ...document.address, space: this.#space, path: ["value"] },
-      value,
-    };
-    const [nextDoc, nextSelector] = getAtPath(
-      tx,
-      root,
-      effectiveSelector.path.slice(1),
-      this.#context,
-      effectiveSelector,
-    );
-    if (
-      nextDoc.value !== undefined &&
-      nextSelector !== undefined &&
-      nextSelector.schema !== false
-    ) {
-      const traverser = new SchemaObjectTraverser(
+    if (!covered) {
+      const value = (document.value as { value: FabricValue }).value;
+      const root: IMemorySpaceValueAttestation = {
+        address: { ...document.address, space: this.#space, path: ["value"] },
+        value,
+      };
+      const [nextDoc, nextSelector] = getAtPath(
         tx,
-        nextSelector,
+        root,
+        effectiveSelector.path.slice(1),
         this.#context,
-        undefined,
-        this.#memo,
+        effectiveSelector,
       );
-      traverser.traverse(nextDoc);
-      this.#addTraverserStats(traverser);
+      if (
+        nextDoc.value !== undefined &&
+        nextSelector !== undefined &&
+        nextSelector.schema !== false
+      ) {
+        const traverser = new SchemaObjectTraverser(
+          tx,
+          nextSelector,
+          this.#context,
+          undefined,
+          this.#memo,
+        );
+        traverser.traverse(nextDoc);
+        this.#addTraverserStats(traverser);
+      }
     }
 
-    // The named document's family, chased here regardless of the context's
-    // includeMeta — that flag governs the traverser's link crossings above,
-    // and it is off so a crossing-reached document is delivered without its
-    // family. What a caller names, it may intend to load; what a walk merely
-    // reaches, it does not.
+    // The named document's family, chased even when selector coverage skips
+    // the traversal above: a crossing may have covered this document before
+    // a root named it, and coverage proves reach, not family. Chased here
+    // regardless of the context's includeMeta — that flag governs the
+    // traverser's link crossings, and it is off so a crossing-reached
+    // document is delivered without its family. What a caller names, it may
+    // intend to load; what a walk merely reaches, it does not. The chase
+    // dedupes through `metaDocsVisited`, so a repeat visit re-reads nothing.
     loadMetaLinkedDocs(
       tx,
       {

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -1274,6 +1274,19 @@ export type TraversalContext = {
   scopeKeyIdentity: ScopeKeyIdentity;
 
   includeMeta: boolean;
+
+  /**
+   * Whether a document the traversal loads mid-walk chases its metadata
+   * family (`loadMetaLinkedDocs`). On by default: a runtime traversal that
+   * loads a document generally intends to interpret it. The memory server's
+   * graph-query walk turns this off and chases only the documents a query
+   * NAMES as roots — a crossing-reached document is delivered under the
+   * selector that reached it, without its family, because chasing at every
+   * load multiplies a wide walk by each visited piece's whole doc set.
+   * Consulted only where `includeMeta` already gates the chase; it does not
+   * affect `traverseCells`, which `includeMeta` also carries.
+   */
+  chaseLoadedMeta: boolean;
   metaDocsVisited: Set<string>;
 
   /**
@@ -1329,12 +1342,14 @@ export function createTraversalContext(
   ) => void,
   schemaDocsLoaded: Set<string> = new Set<string>(),
   schemaDocsAvailable: Set<string> = new Set<string>(),
+  chaseLoadedMeta: boolean = true,
 ): TraversalContext {
   return {
     tracker,
     schemaTracker,
     scopeKeyIdentity,
     includeMeta,
+    chaseLoadedMeta,
     metaDocsVisited,
     onMissingLinkTarget,
     schemaDocsLoaded,
@@ -2575,8 +2590,9 @@ function trackVisitedDoc(
     );
   }
   // Load the metadata-linked docs recursively unless the address holds no
-  // value.
-  if (context.includeMeta) {
+  // value, or the context reserves the chase for the documents a caller
+  // names (`chaseLoadedMeta`).
+  if (context.includeMeta && context.chaseLoadedMeta) {
     // Loading metadata requires the full doc. Ignore this read for scheduling.
     const { ok: fullDoc } = tx.read(
       { ...target, path: [] },

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -1276,18 +1276,23 @@ export type TraversalContext = {
   includeMeta: boolean;
 
   /**
-   * Whether a document the traversal loads mid-walk chases its metadata
-   * family (`loadMetaLinkedDocs`). On by default: a runtime traversal that
-   * loads a document generally intends to interpret it. The memory server's
-   * graph-query walk turns this off and chases only the documents a query
-   * NAMES as roots — a crossing-reached document is delivered under the
-   * selector that reached it, without its family, because chasing at every
-   * load multiplies a wide walk by each visited piece's whole doc set.
-   * Consulted only where `includeMeta` already gates the chase; it does not
-   * affect `traverseCells`, which `includeMeta` also carries.
+   * The metadata rails a document the traversal loads mid-walk chases
+   * (`loadMetaLinkedDocs`). Every rail by default: a runtime traversal
+   * that loads a document generally intends to interpret it. The memory
+   * server's graph-query walk narrows this to the rails a reader needs of
+   * a document it reached but did not name — `result` and `internal`, the
+   * rails computed values arrive through — and reserves the full family
+   * for the documents a query NAMES as roots, because chasing every rail
+   * at every load multiplies a wide walk by each visited piece's whole
+   * doc set. Consulted only where `includeMeta` already gates the chase;
+   * it does not affect `traverseCells`, which `includeMeta` also carries.
    */
-  chaseLoadedMeta: boolean;
-  metaDocsVisited: Set<string>;
+  loadedMetaRails: readonly MetaRail[];
+
+  /** Tracker key → the rails already chased for that document within this
+   * traversal, so a later chase under a wider rail set still walks the
+   * rails an earlier, narrower one did not. */
+  metaDocsVisited: Map<string, Set<MetaRail>>;
 
   /**
    * Reports a followed link whose target document is absent from the local
@@ -1334,7 +1339,10 @@ export function createTraversalContext(
   schemaTracker: MapSet<string, SchemaPathSelector>,
   scopeKeyIdentity: ScopeKeyIdentity,
   includeMeta: boolean = false,
-  metaDocsVisited: Set<string> = new Set<string>(),
+  metaDocsVisited: Map<string, Set<MetaRail>> = new Map<
+    string,
+    Set<MetaRail>
+  >(),
   onMissingLinkTarget?: (
     link: NormalizedFullLink,
     sourceSpace: MemorySpace,
@@ -1342,14 +1350,14 @@ export function createTraversalContext(
   ) => void,
   schemaDocsLoaded: Set<string> = new Set<string>(),
   schemaDocsAvailable: Set<string> = new Set<string>(),
-  chaseLoadedMeta: boolean = true,
+  loadedMetaRails: readonly MetaRail[] = ALL_META_RAILS,
 ): TraversalContext {
   return {
     tracker,
     schemaTracker,
     scopeKeyIdentity,
     includeMeta,
-    chaseLoadedMeta,
+    loadedMetaRails,
     metaDocsVisited,
     onMissingLinkTarget,
     schemaDocsLoaded,
@@ -1362,7 +1370,10 @@ export function createDefaultTraversalContext(
   includeMeta: boolean = true,
   schemaTracker: MapSet<string, SchemaPathSelector> =
     new MapSetStringToPathSelectors(true),
-  metaDocsVisited: Set<string> = new Set<string>(),
+  metaDocsVisited: Map<string, Set<MetaRail>> = new Map<
+    string,
+    Set<MetaRail>
+  >(),
   onMissingLinkTarget?: (
     link: NormalizedFullLink,
     sourceSpace: MemorySpace,
@@ -2590,9 +2601,9 @@ function trackVisitedDoc(
     );
   }
   // Load the metadata-linked docs recursively unless the address holds no
-  // value, or the context reserves the chase for the documents a caller
-  // names (`chaseLoadedMeta`).
-  if (context.includeMeta && context.chaseLoadedMeta) {
+  // value, over the rails the context grants a mid-walk load
+  // (`loadedMetaRails`).
+  if (context.includeMeta && context.loadedMetaRails.length > 0) {
     // Loading metadata requires the full doc. Ignore this read for scheduling.
     const { ok: fullDoc } = tx.read(
       { ...target, path: [] },
@@ -2606,6 +2617,7 @@ function trackVisitedDoc(
           value: fullDoc.value,
         },
         context,
+        context.loadedMetaRails,
       );
     }
   }
@@ -2615,7 +2627,7 @@ function trackVisitedDoc(
 function loadMetaLinkedDoc(
   tx: IExtendedStorageTransaction,
   valueEntry: IMemorySpaceAttestation,
-  meta: "cfc" | "result" | "pattern" | "argument" | "internal",
+  meta: MetaRail,
   schemaTracker: MapSet<string, SchemaPathSelector>,
   identity: ScopeKeyIdentity,
 ): IMemorySpaceAttestation[] {
@@ -2840,36 +2852,65 @@ function cfcMetaToSigilLink(obj: unknown): SigilLink | undefined {
   return undefined;
 }
 
-// Recursively load the meta linked docs from the doc. Every loaded doc is
+/** The rails a document's metadata family hangs off. */
+export type MetaRail = "cfc" | "result" | "pattern" | "argument" | "internal";
+
+export const ALL_META_RAILS: readonly MetaRail[] = [
+  "cfc",
+  "result",
+  "pattern",
+  "argument",
+  "internal",
+];
+
+// Recursively load the meta linked docs from the doc, over the given rails
+// (every rail unless the caller narrows them). Every loaded doc is
 // delivered whole — tracked under the rejecting selector — and never
 // schema-traversed; narrowing a meta document by schema is not a policy
 // this traversal has.
+//
+// The visited record is per RAIL, not per document: one traversal can chase
+// a document under the crossing subset first and under every rail later —
+// a walk crosses into a piece before a root names it — and the later call
+// must still chase the rails the earlier one did not.
 export function loadMetaLinkedDocs(
   tx: IExtendedStorageTransaction,
   valueEntry: IMemorySpaceAttestation,
   context: TraversalContext,
+  rails: readonly MetaRail[] = ALL_META_RAILS,
 ) {
+  const missingRailsOf = (key: string): MetaRail[] => {
+    const seen = context.metaDocsVisited.get(key);
+    return seen === undefined
+      ? [...rails]
+      : rails.filter((rail) => !seen.has(rail));
+  };
+  const recordRails = (key: string, chased: readonly MetaRail[]): void => {
+    let seen = context.metaDocsVisited.get(key);
+    if (seen === undefined) {
+      seen = new Set<MetaRail>();
+      context.metaDocsVisited.set(key, seen);
+    }
+    for (const rail of chased) seen.add(rail);
+  };
+
   const valueEntryKey = getTrackerKey(
     valueEntry.address,
     context.scopeKeyIdentity,
   );
-  if (context.metaDocsVisited.has(valueEntryKey)) {
+  const entryRails = missingRailsOf(valueEntryKey);
+  if (entryRails.length === 0) {
     return;
   }
-  context.metaDocsVisited.add(valueEntryKey);
+  recordRails(valueEntryKey, entryRails);
 
-  const pendingDocs = [valueEntry];
+  const pendingDocs: [IMemorySpaceAttestation, readonly MetaRail[]][] = [[
+    valueEntry,
+    entryRails,
+  ]];
   while (pendingDocs.length > 0) {
-    const currentDoc = pendingDocs.shift()!;
-    for (
-      const meta of [
-        "cfc",
-        "result",
-        "pattern",
-        "argument",
-        "internal",
-      ] as const
-    ) {
+    const [currentDoc, currentRails] = pendingDocs.shift()!;
+    for (const meta of currentRails) {
       const linkedDocs = loadMetaLinkedDoc(
         tx,
         currentDoc,
@@ -2886,9 +2927,10 @@ export function loadMetaLinkedDocs(
           linkedDoc.address,
           context.scopeKeyIdentity,
         );
-        if (context.metaDocsVisited.has(linkedDocKey)) continue;
-        context.metaDocsVisited.add(linkedDocKey);
-        pendingDocs.push(linkedDoc);
+        const linkedRails = missingRailsOf(linkedDocKey);
+        if (linkedRails.length === 0) continue;
+        recordRails(linkedDocKey, linkedRails);
+        pendingDocs.push([linkedDoc, linkedRails]);
       }
     }
   }

--- a/packages/runner/test/traverse-schema-doc-availability.test.ts
+++ b/packages/runner/test/traverse-schema-doc-availability.test.ts
@@ -73,7 +73,7 @@ const contextWith = (
     new MapSetStringToPathSelectors(true),
     TEST_SCOPE_IDENTITY,
     false,
-    new Set(),
+    new Map(),
     onMissingLinkTarget,
   );
 


### PR DESCRIPTION
## Why

One walk class owns the residual board-load wall on Estuary: `session.watch.add`
on the board argument's `topics` root costs 7.6–9.1 s with **reads=10,638**, and
every CLI invocation's cold pull of the board root costs ~7 s with reads=11,913
(#6512's live attribution, measured across board loads on shard 8020 after the
mentionable-index migration). The declared demand is three scalar fields per
topic; the walk visits ~72 documents per topic anyway.

The width is not the traversal. On a board-clone rig with
`CF_TRAVERSE_DIAGNOSTICS` and a closure-stage probe, the shaped read's
traverser makes **264 schema visits** — while the schema tracker ends at
**10,139 keys**. The multiplier is `loadMetaLinkedDocs`: the graph-query walk
chases every document it loads mid-walk — the recursive BFS over the
cfc/result/pattern/argument/internal rails — selector-independently, so each
of ~140 crossing-reached topic pieces delivers its whole ~72-document family.
That also explains why no demand-side narrowing ever moved this class: a
three-scalar reader, an `unknown` reader, and `schema: true` all measured
within a few percent of each other (10,212 / 10,212 / 14,444 documents),
because the chase does not consult the reader at all.

## What changed

The chase now follows **naming, not reachability**. A document a caller names
as a query root still arrives with its metadata family, through
`GraphQueryWalk.visit()`'s own `loadMetaLinkedDocs` call — a caller that
intends to load and run what it named (a piece resume, a setsrc staging read)
names it as a root, and its pattern/source/cfc family arrives with it exactly
as before. A document the walk merely reaches through a link crossing is
delivered under the selector that reached it, without its family.

Mechanically: `TraversalContext` gains `chaseLoadedMeta` (default `true`, so
every existing context behaves as before), consulted only where `includeMeta`
already gates the mid-walk chase. The graph-query walk sets it `false`.
`includeMeta` itself is untouched — it also carries `traverseCells`, the
memory-walk/runtime-walk mode switch, which is why the two meanings needed
separate fields.

## Where this head stands (updated after Sol's round)

Both review P1s were valid and are fixed on this head:

- **Crossing-reached pieces keep their computed rails.** The all-off form
  broke a real contract — `executor-space-root-ensure` pins that a plain
  space-cell subscriber receives (and stays subscribed to) the computed
  cells of a piece its walk crosses into, and those arrive through the
  metadata family. The chase is now RAIL-scoped: a crossing chases
  `result` and `internal`; a named root chases every rail. The visited
  record became per-rail so a crossing-subset chase composes with a later
  full chase of the same document.
- **Named-root families survive coverage, including incremental
  `watch.add`.** `TrackedGraphState.rootFamilies` records which named
  documents have been family-chased; `isGraphQueryCoveredByState` requires
  it, so a later query naming a previously-crossed document extends (a
  cheap chase-only visit) instead of skipping. Pinned from the query
  surface and the incremental path, mutation-verified in both directions.

**The honest perf status: the width win is parked on this head.** Rig
attribution (board-clone, serial single-variable server restarts) of the
10,212-document shaped walk:

| crossing rails               | documents delivered |
| ---------------------------- | ------------------- |
| none                         | 776                 |
| `result`                     | 776                 |
| `result` + `internal`        | 10,226              |

`result` adds nothing — computed results already arrive through value
links. **The entire width is the `internal` rail, even chased
non-recursively** (~19 internal-manifest links per visited document), and
the executor contract needs exactly that rail at crossings (`result`-only
deterministically times out, with a schema-closure quarantine besides). So
rail and depth scoping cannot keep both, and this head keeps correctness.
The perf follow-up needs a finer distinction on the internal manifest —
demand-aware chase, an exported-vs-private marking on manifest entries, or
a register-without-deliver split — which is a design conversation, not a
patch. The machinery this PR adds (rail-scoped chase, per-rail visited
record, root-family coverage) is the substrate any of those lands on.

## Gates

memory 593 passed / 0 failed; `executor-space-root-ensure` green; runner
suite, repo `fmt`/`lint`, full `deno task check` green locally; CI is the
authority on the integration lanes this round.
