### PR TITLE
feat(cli): one deployment per process, refused when a second arrives

### DIFF
--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -93,11 +93,10 @@ prose: `claimProcessDeployment` (`lib/process-deployment.ts`) refuses a
 connection to a second *deployment*, a weaker bound than the limit and
 the one where those settings actually fight, since a verb reaching an
 un-injected library function opens another connection to the same
-deployment as a matter of course. The three declarations in
-`packages/cli` carry the limit;
-[`runtime-integration.md`](runtime-integration.md) item 6 carries the
-inventory, both bounds, and the globals in the other two packages, which
-are recorded there and nowhere else.
+deployment as a matter of course. The three declarations that carry the
+limit are all in `packages/cli`; the inventory, both bounds, and the
+globals in the other two packages, recorded there and nowhere else, are
+in item 6 of [`runtime-integration.md`](runtime-integration.md).
 
 ## Stage B — the shuttle package
 

--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -80,21 +80,24 @@ Each threaded seam carries the test the override makes possible: an
 injected exit that throws, and the report read back as a value.
 
 **A5 — module-global state.** Done, as the recorded limit rather than as
-scoping: **one deployment per process**. `quietMode` (`commands/piece.ts`)
-is the process's hint posture and `receipted` (`lib/write-receipt.ts`)
-memoizes the write receipt for the life of the process, while a
-connection's own settings — the LLM endpoint, the base URL a pattern's
-relative `fetch` resolves against, and the ambient experimental flags a
-`Runtime` applies — land in globals under `packages/llm` and
-`packages/runner` that no connection owns. Each declaration carries the
-limit, and `claimProcessDeployment` (`lib/process-deployment.ts`) enforces
-the half a check can see: `loadPieces` claims the deployment it opens
-against, so a connection to a second one fails naming both, where two
-connections to one deployment write the same settings and are what a `cf`
-verb already does. Scoping them is part of multi-space sessions
-([`futures.md`](futures.md) candidate 3), and
+scoping: **shuttle v1 holds one connection per process**, revisited when
+multiple places arrive ([`futures.md`](futures.md) candidate 3). What the
+limit covers is `quietMode` (`commands/piece.ts`), the process's hint
+posture; `receipted` (`lib/write-receipt.ts`), which memoizes the write
+receipt for the life of the process; and a connection's own settings —
+the LLM endpoint, the base URL a pattern's relative `fetch` resolves
+against, and the ambient experimental flags a `Runtime` applies — which
+land in globals under `packages/llm` and `packages/runner` that no
+connection owns. Part of that is mechanically enforced and the rest is
+prose: `claimProcessDeployment` (`lib/process-deployment.ts`) refuses a
+connection to a second *deployment*, a weaker bound than the limit and
+the one where those settings actually fight, since a verb reaching an
+un-injected library function opens another connection to the same
+deployment as a matter of course. The three declarations in
+`packages/cli` carry the limit;
 [`runtime-integration.md`](runtime-integration.md) item 6 carries the
-list and the bound.
+inventory, both bounds, and the globals in the other two packages, which
+are recorded there and nowhere else.
 
 ## Stage B — the shuttle package
 

--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -79,14 +79,22 @@ drawing its own screen. The bulk seams — survey, repair, retarget,
 Each threaded seam carries the test the override makes possible: an
 injected exit that throws, and the report read back as a value.
 
-**A5 — module-global state.** `quietMode` is a file-level `let`;
-`setLLMUrl` is written by both `loadPieces` and
-`PiecesController.initialize`; `receipted` (`lib/write-receipt.ts`)
-memoizes the write receipt per process, so a shell names a space once and
-says nothing for the writes after. Either scope them per connection, or
-land a recorded limit: one connection per process for shuttle v1,
-revisited when multiple places arrive. The cheap honest move is the
-recorded limit; the PR is whichever the review rules.
+**A5 — module-global state.** Done, as the recorded limit rather than as
+scoping: **one deployment per process**. `quietMode` (`commands/piece.ts`)
+is the process's hint posture and `receipted` (`lib/write-receipt.ts`)
+memoizes the write receipt for the life of the process, while a
+connection's own settings — the LLM endpoint, the base URL a pattern's
+relative `fetch` resolves against, and the ambient experimental flags a
+`Runtime` applies — land in globals under `packages/llm` and
+`packages/runner` that no connection owns. Each declaration carries the
+limit, and `claimProcessDeployment` (`lib/process-deployment.ts`) enforces
+the half a check can see: `loadPieces` claims the deployment it opens
+against, so a connection to a second one fails naming both, where two
+connections to one deployment write the same settings and are what a `cf`
+verb already does. Scoping them is part of multi-space sessions
+([`futures.md`](futures.md) candidate 3), and
+[`runtime-integration.md`](runtime-integration.md) item 6 carries the
+list and the bound.
 
 ## Stage B — the shuttle package
 

--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -93,7 +93,7 @@ prose: `claimProcessDeployment` (`lib/process-deployment.ts`) refuses a
 connection to a second *deployment*, a weaker bound than the limit and
 the one where those settings actually fight, since a verb reaching an
 un-injected library function opens another connection to the same
-deployment as a matter of course. The three declarations that carry the
+deployment as a matter of course. The three declarations that name the
 limit are all in `packages/cli`; the inventory, both bounds, and the
 globals in the other two packages, recorded there and nowhere else, are
 in item 6 of [`runtime-integration.md`](runtime-integration.md).

--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -79,8 +79,9 @@ drawing its own screen. The bulk seams — survey, repair, retarget,
 Each threaded seam carries the test the override makes possible: an
 injected exit that throws, and the report read back as a value.
 
-**A5 — module-global state.** Done, as the recorded limit rather than as
-scoping: **shuttle v1 holds one connection per process**, revisited when
+**A5 — module-global state.** Done (#6717), as the recorded limit rather
+than as scoping: **shuttle v1 holds one connection per process**, revisited
+when
 multiple places arrive ([`futures.md`](futures.md) candidate 3). What the
 limit covers is `quietMode` (`commands/piece.ts`), the process's hint
 posture; `receipted` (`lib/write-receipt.ts`), which memoizes the write

--- a/docs/plans/shuttle/runtime-integration.md
+++ b/docs/plans/shuttle/runtime-integration.md
@@ -287,21 +287,21 @@ Each of these is small and lands on its own; together they are what decision
    scoping: **shuttle v1 holds one connection per process**, revisited
    when multiple places arrive ([`futures.md`](futures.md) candidate 3).
    Three kinds of state are the process's rather than a connection's, and
-   the first kind is what a
-   connection writes for itself — the endpoint `setLLMUrl` holds, written
-   by `loadPieces` and by `PiecesController.initialize` in another
-   package; the base URL `getPatternEnvironment()` hands a pattern's
-   relative `fetch`, which the `remoteClient` preset pins from `apiUrl`;
-   and the ambient experimental flags a `Runtime` applies as it is built
-   (`modernCellRep`, `contentAddressedSchemas`,
-   `readerSchemaPrecedence`), which for a CLI connection come from the
-   deployment itself. The second is the posture a caller sets: `quietMode`,
-   which each `FromCommand` entry writes and which therefore stands as the
-   last caller left it. The third is a memo of work already done:
-   `receipted` (`lib/write-receipt.ts`), so a shell holding a connection
-   names a space once and stays silent for every write after, and the
-   version-skew note `deferSkewNoteUntilFailureExit` holds for a failure
-   exit, which is one note about one server and prints at process end.
+   the first kind is what a connection writes for itself — the endpoint
+   `setLLMUrl` holds, written by `loadPieces` and by
+   `PiecesController.initialize` in another package; the base URL
+   `getPatternEnvironment()` hands a pattern's relative `fetch`, which the
+   `remoteClient` preset pins from `apiUrl`; and the ambient experimental
+   flags a `Runtime` applies as it is built (`modernCellRep`,
+   `contentAddressedSchemas`, `readerSchemaPrecedence`), which for a CLI
+   connection come from the deployment itself. The second is the posture a
+   caller sets: `quietMode`, which each `FromCommand` entry writes and
+   which therefore stands as the last caller left it. The third is a memo
+   of work already done: `receipted` (`lib/write-receipt.ts`), so a shell
+   holding a connection names a space once and stays silent for every
+   write after, and the version-skew note `deferSkewNoteUntilFailureExit`
+   holds for a failure exit, which is one note about one server and prints
+   at process end.
 
    What a check can reach is narrower than the limit, and the two are not
    the same claim. `claimProcessDeployment` (`lib/process-deployment.ts`)
@@ -321,9 +321,9 @@ Each of these is small and lands on its own; together they are what decision
    writes begin. The globals in `packages/llm` and `packages/runner`
    belong to other packages and say nothing about it, so this inventory is
    the only record of them — and the part of it that goes stale first if
-   nobody reads it back against those files.
-   `packages/cli/README.md` records the limit for a caller of the library
-   seams, and a shuttle process holds the one connection the limit allows.
+   nobody reads it back against those files. `packages/cli/README.md`
+   records the limit for a caller of the library seams, and a shuttle
+   process holds the one connection the limit allows.
 7. **Disposal.** `withRuntimeCleanupOnFailure` disposes only on throw; the
    success path relies on process exit. In a long-lived shell every
    un-injected call leaks a runtime, a storage manager, and a WebSocket —

--- a/docs/plans/shuttle/runtime-integration.md
+++ b/docs/plans/shuttle/runtime-integration.md
@@ -254,7 +254,7 @@ Each of these is small and lands on its own; together they are what decision
    and `call` all reach. It wants a sink of its own rather than the hint
    stream, because `--quiet` deliberately does not silence it, and a memo
    per connection rather than per process — its `receipted` set, which
-   item 6 names beside the other two globals.
+   item 6 names among the state one process's callers share.
 
    The second is **lib-internal warnings no seam reaches**, all in
    `lib/piece.ts`, and the sweep is of every `console.*` there rather
@@ -283,13 +283,40 @@ Each of these is small and lands on its own; together they are what decision
    them, but writes nothing unless `CF_CLI_TRACE_TIMINGS=1` asks it to.
 
    Sweep each as views need it captured.
-6. **Module-global state.** `quietMode` is a file-level `let` set on every
-   `FromCommand` entry; `setLLMUrl` is a global written by both `loadPieces`
-   and `PiecesController.initialize`, so two connections on different API
-   URLs would fight; and `receipted` (`lib/write-receipt.ts`) memoizes the
-   write receipt per process, so a long-lived shell names a space once and
-   stays silent for every write after. Scope them, or accept
-   one-connection-per-process for v1 and record the limit.
+6. **Module-global state.** Done, as the recorded limit rather than as
+   scoping: **one deployment per process**. Three kinds of state are the
+   process's rather than a connection's, and the first kind is what a
+   connection writes for itself — the endpoint `setLLMUrl` holds, written
+   by `loadPieces` and by `PiecesController.initialize` in another
+   package; the base URL `getPatternEnvironment()` hands a pattern's
+   relative `fetch`, which the `remoteClient` preset pins from `apiUrl`;
+   and the ambient experimental flags a `Runtime` applies as it is built
+   (`modernCellRep`, `contentAddressedSchemas`,
+   `readerSchemaPrecedence`), which for a CLI connection come from the
+   deployment itself. The second is the posture a caller sets: `quietMode`,
+   which each `FromCommand` entry writes and which therefore stands as the
+   last caller left it. The third is a memo of work already done:
+   `receipted` (`lib/write-receipt.ts`), so a shell holding a connection
+   names a space once and stays silent for every write after, and the
+   version-skew note `deferSkewNoteUntilFailureExit` holds for a failure
+   exit, which is one note about one server and prints at process end.
+
+   `claimProcessDeployment` (`lib/process-deployment.ts`) holds the limit
+   where a check can reach it: `loadPieces` claims the deployment it opens
+   against, and a connection to a different one throws naming both rather
+   than rewriting the first's settings. Two bounds on that. A second
+   connection to the *same* deployment is unremarked — it writes the same
+   settings, and it is what a verb reaching an un-injected library
+   function already does — so the posture and the two memos are held by
+   the limit rather than by the check. And a connection opened through
+   `PiecesController.initialize` directly, as `packages/fuse` and
+   `packages/cf-harness` open one, passes no claim. The declarations carry
+   the limit too, which is where a maintainer reading one finds it, and
+   `packages/cli/README.md` records it for a caller of the library seams.
+
+   A shuttle process therefore serves one deployment, and scoping these
+   per connection is part of multi-space sessions
+   ([`futures.md`](futures.md) candidate 3).
 7. **Disposal.** `withRuntimeCleanupOnFailure` disposes only on throw; the
    success path relies on process exit. In a long-lived shell every
    un-injected call leaks a runtime, a storage manager, and a WebSocket —

--- a/docs/plans/shuttle/runtime-integration.md
+++ b/docs/plans/shuttle/runtime-integration.md
@@ -284,8 +284,10 @@ Each of these is small and lands on its own; together they are what decision
 
    Sweep each as views need it captured.
 6. **Module-global state.** Done, as the recorded limit rather than as
-   scoping: **one deployment per process**. Three kinds of state are the
-   process's rather than a connection's, and the first kind is what a
+   scoping: **shuttle v1 holds one connection per process**, revisited
+   when multiple places arrive ([`futures.md`](futures.md) candidate 3).
+   Three kinds of state are the process's rather than a connection's, and
+   the first kind is what a
    connection writes for itself — the endpoint `setLLMUrl` holds, written
    by `loadPieces` and by `PiecesController.initialize` in another
    package; the base URL `getPatternEnvironment()` hands a pattern's
@@ -301,22 +303,27 @@ Each of these is small and lands on its own; together they are what decision
    version-skew note `deferSkewNoteUntilFailureExit` holds for a failure
    exit, which is one note about one server and prints at process end.
 
-   `claimProcessDeployment` (`lib/process-deployment.ts`) holds the limit
-   where a check can reach it: `loadPieces` claims the deployment it opens
-   against, and a connection to a different one throws naming both rather
-   than rewriting the first's settings. Two bounds on that. A second
-   connection to the *same* deployment is unremarked — it writes the same
-   settings, and it is what a verb reaching an un-injected library
-   function already does — so the posture and the two memos are held by
-   the limit rather than by the check. And a connection opened through
+   What a check can reach is narrower than the limit, and the two are not
+   the same claim. `claimProcessDeployment` (`lib/process-deployment.ts`)
+   refuses a connection to a second *deployment*: `loadPieces` claims the
+   one it opens against, and a connection to a different one throws
+   naming both rather than rewriting the first's settings. That is the
+   bound where those settings actually fight, and it is weaker than the
+   limit in two directions. A second connection to the *same* deployment
+   passes — it writes the same settings, and it is what a verb reaching an
+   un-injected library function already does — so the posture and the two
+   memos rest on the limit alone. And a connection opened through
    `PiecesController.initialize` directly, as `packages/fuse` and
-   `packages/cf-harness` open one, passes no claim. The declarations carry
-   the limit too, which is where a maintainer reading one finds it, and
-   `packages/cli/README.md` records it for a caller of the library seams.
+   `packages/cf-harness` open one, passes no claim at all.
 
-   A shuttle process therefore serves one deployment, and scoping these
-   per connection is part of multi-space sessions
-   ([`futures.md`](futures.md) candidate 3).
+   Three declarations carry the limit, all of them in `packages/cli`:
+   `quietMode`, `receipted`, and `loadPieces`, where a connection's own
+   writes begin. The globals in `packages/llm` and `packages/runner`
+   belong to other packages and say nothing about it, so this inventory is
+   the only record of them — and the part of it that goes stale first if
+   nobody reads it back against those files.
+   `packages/cli/README.md` records the limit for a caller of the library
+   seams, and a shuttle process holds the one connection the limit allows.
 7. **Disposal.** `withRuntimeCleanupOnFailure` disposes only on throw; the
    success path relies on process exit. In a long-lived shell every
    un-injected call leaks a runtime, a storage manager, and a WebSocket —

--- a/docs/plans/shuttle/runtime-integration.md
+++ b/docs/plans/shuttle/runtime-integration.md
@@ -316,14 +316,16 @@ Each of these is small and lands on its own; together they are what decision
    `PiecesController.initialize` directly, as `packages/fuse` and
    `packages/cf-harness` open one, passes no claim at all.
 
-   Three declarations carry the limit, all of them in `packages/cli`:
-   `quietMode`, `receipted`, and `loadPieces`, where a connection's own
-   writes begin. The globals in `packages/llm` and `packages/runner`
-   belong to other packages and say nothing about it, so this inventory is
-   the only record of them — and the part of it that goes stale first if
-   nobody reads it back against those files. `packages/cli/README.md`
-   records the limit for a caller of the library seams, and a shuttle
-   process holds the one connection the limit allows.
+   Three declarations name it, all of them in `packages/cli`: `quietMode`
+   and `receipted` say what holds of them under it, and `loadPieces` says
+   what it refuses and where the reasoning is kept. The globals in
+   `packages/llm` and `packages/runner` belong to other packages and say
+   nothing about it, so this inventory is the only record of them — and
+   the part of it that goes stale first if nobody reads it back against
+   those files. What `packages/cli/README.md` records is the deployment
+   rule, on `cf`'s own terms: one connection per process is false of `cf`,
+   where a single verb opens several, so the connection limit is recorded
+   here, and a shuttle process is what holds to it.
 7. **Disposal.** `withRuntimeCleanupOnFailure` disposes only on throw; the
    success path relies on process exit. In a long-lived shell every
    un-injected call leaks a runtime, a storage manager, and a WebSocket —

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -357,7 +357,10 @@ scoped to the connection that wrote it. So a connection to a second deployment
 is refused, naming both, rather than rewriting what the first one set while the
 first connection carries on against the new settings. `claimProcessDeployment`
 in `lib/process-deployment.ts` is where that is decided, and `loadPieces` claims
-on the way to opening a connection.
+on the way to opening a connection. Two deployments therefore need two
+processes, and restarting is how one process changes deployment — a claim stands
+whether or not the connection it was made for opened, so a well-formed host that
+answers nothing holds it too.
 
 One invocation of `cf` reaches one deployment, so the limit costs a command
 nothing. What it constrains is a caller holding a connection across many

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -357,10 +357,12 @@ scoped to the connection that wrote it. So a connection to a second deployment
 is refused, naming both, rather than rewriting what the first one set while the
 first connection carries on against the new settings. `claimProcessDeployment`
 in `lib/process-deployment.ts` is where that is decided, and `loadPieces` claims
-on the way to opening a connection. Two deployments therefore need two
-processes, and restarting is how one process changes deployment — a claim stands
-whether or not the connection it was made for opened, so a well-formed host that
-answers nothing holds it too.
+on the way to opening a connection. What counts as the same deployment is the
+spelling `cf` normalizes an API URL to, so a trailing slash or a query string
+does not make a second one. Two deployments therefore need two processes, and
+restarting is how one process changes deployment — a claim stands whether or not
+the connection it was made for opened, so a well-formed host that answers
+nothing holds it too.
 
 One invocation of `cf` reaches one deployment, so the limit costs a command
 nothing. What it constrains is a caller holding a connection across many

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -347,6 +347,26 @@ replayable only within the session it was chosen in, and a session minted on the
 spot would make the replay name a different invocation. A call naming neither
 gets both, minted for that one call.
 
+## One deployment per process
+
+A `cf` process talks to one deployment. Opening a connection writes settings
+that belong to the deployment into state that belongs to the process — the
+endpoint an LLM call reaches, the base URL a pattern's relative `fetch` resolves
+against, the ambient experimental flags a runtime applies — and none of it is
+scoped to the connection that wrote it. So a connection to a second deployment
+is refused, naming both, rather than rewriting what the first one set while the
+first connection carries on against the new settings. `claimProcessDeployment`
+in `lib/process-deployment.ts` is where that is decided, and `loadPieces` claims
+on the way to opening a connection.
+
+One invocation of `cf` reaches one deployment, so the limit costs a command
+nothing. What it constrains is a caller holding a connection across many
+commands, and two more pieces of state constrain that caller the same way with
+no check behind them, because a second connection to one deployment is
+indistinguishable from the several a single verb already opens: the hint posture
+`--quiet` sets, which stands as the last caller left it, and the write receipt's
+memo, which names a space once for the life of the process.
+
 ## Output Conventions
 
 - stdout carries command output only; hints and diagnostics go to stderr.

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -126,9 +126,14 @@ import {
 import { absPath } from "../lib/utils.ts";
 import { noteWroteTo } from "../lib/write-receipt.ts";
 
-// Hint system: print helpful next-step suggestions after operations
+// Hint system: print helpful next-step suggestions after operations. The
+// posture is the process's rather than one call's, so it stands as the last
+// caller left it until the next caller sets it. That is sound while one
+// command is in flight at a time, which is what
+// `docs/plans/shuttle/runtime-integration.md` holds a long-lived caller to.
 let quietMode = false;
 
+/** Sets whether hints print, for every caller in this process. */
 export function setQuietMode(quiet: boolean) {
   quietMode = quiet;
 }

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -26,6 +26,7 @@ import {
 } from "@commonfabric/runner/shared";
 import { decode } from "@commonfabric/utils/encoding";
 
+import { normalizeApiUrl } from "../lib/api-url.ts";
 import {
   type PhaseRetarget,
   readSourcePin,
@@ -153,17 +154,6 @@ function hint(message: string, showQuietTip = true) {
  */
 function note(message: string) {
   console.error(message);
-}
-
-export function normalizeApiUrl(apiUrl: string): string {
-  const parsed = new URL(apiUrl);
-  const normalized = new URL(parsed);
-  const basePath = parsed.pathname.split("/").filter(Boolean).join("/");
-  normalized.pathname = basePath ? `/${basePath}` : "/";
-  normalized.search = "";
-  normalized.hash = "";
-  const href = normalized.toString();
-  return basePath ? href : href.slice(0, -1);
 }
 
 function summarizeForDisplay(value: unknown): unknown {

--- a/packages/cli/commands/wish.ts
+++ b/packages/cli/commands/wish.ts
@@ -1,12 +1,13 @@
 import { Command, ValidationError } from "@cliffy/command";
 import { type DID, isDID } from "@commonfabric/identity";
 import { parseCellPath } from "@commonfabric/runner";
+import { normalizeApiUrl } from "../lib/api-url.ts";
 import { cliText } from "../lib/cli-name.ts";
 import { refuseSectionMarker } from "../lib/section-marker.ts";
 import { render } from "../lib/render.ts";
 import { getDidFromFile } from "../lib/identity.ts";
 import { absPath } from "../lib/utils.ts";
-import { normalizeApiUrl, setQuietMode } from "./piece.ts";
+import { setQuietMode } from "./piece.ts";
 import { projectWishValue, readWish } from "../lib/wish.ts";
 import {
   type CellSelection,

--- a/packages/cli/lib/api-url.ts
+++ b/packages/cli/lib/api-url.ts
@@ -1,0 +1,20 @@
+/**
+ * The canonical spelling of the API URL written `apiUrl`: no query, no
+ * fragment, empty path segments collapsed, and no trailing slash. Two
+ * spellings of one deployment normalize to one string, which is what lets
+ * them compare equal — as the identity of the deployment a process is
+ * connected to, and as the base a printed app route is built on.
+ *
+ * Throws on an `apiUrl` that does not parse, so a caller that may hold one
+ * establishes that first.
+ */
+export function normalizeApiUrl(apiUrl: string): string {
+  const parsed = new URL(apiUrl);
+  const normalized = new URL(parsed);
+  const basePath = parsed.pathname.split("/").filter(Boolean).join("/");
+  normalized.pathname = basePath ? `/${basePath}` : "/";
+  normalized.search = "";
+  normalized.hash = "";
+  const href = normalized.toString();
+  return basePath ? href : href.slice(0, -1);
+}

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -118,6 +118,7 @@ import { pinProgramFabricImports, renderPinRewrite } from "./fabric-deps.ts";
 import { loadIdentity } from "./identity.ts";
 import { stderrConsoleHandler } from "./json-output.ts";
 import { validateEmbeddedSpaces } from "./llm-friendly-ref.ts";
+import { claimProcessDeployment } from "./process-deployment.ts";
 import { deriveDiskHandleId } from "./sqlite-source.ts";
 import { throwOnSpaceAuthorizationError } from "./utils.ts";
 import { startVersionCheck } from "./version-check.ts";
@@ -501,9 +502,20 @@ async function makeSession(config: SpaceConfig): Promise<Session> {
   }
 }
 
+/**
+ * Opens a connection to the deployment at `config.apiUrl` and returns the
+ * controller over it: a space session, a runtime carrying that deployment's
+ * experimental options, and a server proven live before it returns.
+ *
+ * Throws when this process is already connected to a different deployment.
+ * The settings a connection writes — the LLM endpoint below among them — are
+ * the process's rather than the connection's, so a process serves one
+ * deployment; `process-deployment.ts` carries what that costs.
+ */
 export async function loadPieces(
   config: SpaceConfig,
 ): Promise<PiecesController> {
+  claimProcessDeployment(config.apiUrl);
   setLLMUrl(config.apiUrl);
   // The deployment's own flag posture, with this process's explicit
   // EXPERIMENTAL_* still winning per flag: a cf binary is installed

--- a/packages/cli/lib/process-deployment.ts
+++ b/packages/cli/lib/process-deployment.ts
@@ -19,6 +19,8 @@
  * belongs when one connection stops being enough.
  */
 
+import { normalizeApiUrl } from "./api-url.ts";
+
 /**
  * The deployment claimed, normalized for comparison, or `null` while this
  * process has claimed none.
@@ -26,15 +28,18 @@
 let claimed: string | null = null;
 
 /**
- * Helper for {@link claimProcessDeployment}, which normalizes `apiUrl` for
- * comparison, or returns `null` for one no connection can be opened over.
+ * Helper for {@link claimProcessDeployment}, which returns the deployment
+ * `apiUrl` names, or `null` for one no connection can be opened over.
  *
  * Every consumer of an API URL resolves a path against it, so that is the
- * test: `localhost:8000` parses as a URL and still fails it, its `8000`
- * being an opaque path that no path can be resolved against.
+ * test for the second case: `localhost:8000` parses as a URL and still fails
+ * it, its `8000` being an opaque path that no path can be resolved against.
+ * What passes is keyed through `normalizeApiUrl`, the spelling the whole CLI
+ * reads an API URL by, so two spellings of one deployment claim one
+ * deployment.
  */
 function deploymentKey(apiUrl: string): string | null {
-  return URL.canParse("/", apiUrl) ? new URL(apiUrl).href : null;
+  return URL.canParse("/", apiUrl) ? normalizeApiUrl(apiUrl) : null;
 }
 
 /**

--- a/packages/cli/lib/process-deployment.ts
+++ b/packages/cli/lib/process-deployment.ts
@@ -27,15 +27,14 @@ let claimed: string | null = null;
 
 /**
  * Helper for {@link claimProcessDeployment}, which normalizes `apiUrl` for
- * comparison, returning it as written when it does not parse — an unusable
- * API URL is the connection's error to raise rather than this one's.
+ * comparison, or returns `null` for one no connection can be opened over.
+ *
+ * Every consumer of an API URL resolves a path against it, so that is the
+ * test: `localhost:8000` parses as a URL and still fails it, its `8000`
+ * being an opaque path that no path can be resolved against.
  */
-function deploymentKey(apiUrl: string): string {
-  try {
-    return new URL(apiUrl).href;
-  } catch {
-    return apiUrl;
-  }
+function deploymentKey(apiUrl: string): string | null {
+  return URL.canParse("/", apiUrl) ? new URL(apiUrl).href : null;
 }
 
 /**
@@ -43,8 +42,11 @@ function deploymentKey(apiUrl: string): string {
  * different one is already claimed. Claiming the deployment already held is
  * what every connection after the first does, and passes.
  *
- * A claim stands whether or not the connection it was made for opens: a
- * connection that fails on the way up has written those settings already.
+ * A claim stands whether or not the connection it was made for opens, since
+ * a connection that fails on the way up has written those settings already.
+ * One case cannot have written them: an API URL no connection can be opened
+ * over fails before the first of them is set, so it claims nothing and the
+ * corrected URL after it still connects.
  *
  * What it catches is a second deployment, not a second connection: two
  * connections to one deployment write the same settings and go unremarked,
@@ -52,6 +54,7 @@ function deploymentKey(apiUrl: string): string {
  */
 export function claimProcessDeployment(apiUrl: string): void {
   const key = deploymentKey(apiUrl);
+  if (key === null) return;
   if (claimed === null) {
     claimed = key;
     return;

--- a/packages/cli/lib/process-deployment.ts
+++ b/packages/cli/lib/process-deployment.ts
@@ -43,10 +43,12 @@ function deploymentKey(apiUrl: string): string | null {
  * what every connection after the first does, and passes.
  *
  * A claim stands whether or not the connection it was made for opens, since
- * a connection that fails on the way up has written those settings already.
- * One case cannot have written them: an API URL no connection can be opened
- * over fails before the first of them is set, so it claims nothing and the
- * corrected URL after it still connects.
+ * a connection that fails on the way up has written those settings already:
+ * a well-formed host that answers nothing holds the claim until the process
+ * restarts, which is what the refusal names. One case cannot have written
+ * them: an API URL no connection can be opened over fails before the first
+ * of them is set, so it claims nothing and the corrected URL after it still
+ * connects.
  *
  * What it catches is a second deployment, not a second connection: two
  * connections to one deployment write the same settings and go unremarked,
@@ -64,7 +66,8 @@ export function claimProcessDeployment(apiUrl: string): void {
     `This process is connected to \`${claimed}\`, so a connection to ` +
       `\`${key}\` is refused: the settings a connection writes are the ` +
       `process's rather than the connection's, which is one deployment ` +
-      `per process.`,
+      `per process. Reach \`${key}\` from a separate process — ` +
+      `restarting is the deployment switch.`,
   );
 }
 

--- a/packages/cli/lib/process-deployment.ts
+++ b/packages/cli/lib/process-deployment.ts
@@ -10,11 +10,13 @@
  * rewrites all of it while the first connection carries on — against the
  * second deployment's settings, and reporting nothing.
  *
- * One deployment per process is the limit taken in place of scoping those
- * globals per connection, and this is where it is enforced.
- * `docs/plans/shuttle/runtime-integration.md` records what the limit costs a
- * long-lived process that holds a connection, and where the scoping work
- * belongs when a caller needs more than one.
+ * So a process holds one deployment, and a connection to a second is refused
+ * here. What a caller holding a connection across many commands has to hold
+ * to is tighter than that, because a second connection to the *same*
+ * deployment shares this state too and is indistinguishable from the several
+ * an ordinary verb opens. `docs/plans/shuttle/runtime-integration.md` records
+ * the whole of that, what it costs such a caller, and where the scoping work
+ * belongs when one connection stops being enough.
  */
 
 /**

--- a/packages/cli/lib/process-deployment.ts
+++ b/packages/cli/lib/process-deployment.ts
@@ -1,0 +1,69 @@
+/**
+ * The deployment a process is connected to, held so that a connection to a
+ * second one fails by name instead of silently taking the first one's place.
+ *
+ * Opening a connection writes settings that belong to the deployment into
+ * state that belongs to the process: the endpoint an LLM call reaches, the
+ * base URL a pattern's relative `fetch` resolves against, and the ambient
+ * experimental flags a runtime applies. None of it is scoped to the
+ * connection that wrote it, so a connection to a different deployment
+ * rewrites all of it while the first connection carries on — against the
+ * second deployment's settings, and reporting nothing.
+ *
+ * One deployment per process is the limit taken in place of scoping those
+ * globals per connection, and this is where it is enforced.
+ * `docs/plans/shuttle/runtime-integration.md` records what the limit costs a
+ * long-lived process that holds a connection, and where the scoping work
+ * belongs when a caller needs more than one.
+ */
+
+/**
+ * The deployment claimed, normalized for comparison, or `null` while this
+ * process has claimed none.
+ */
+let claimed: string | null = null;
+
+/**
+ * Helper for {@link claimProcessDeployment}, which normalizes `apiUrl` for
+ * comparison, returning it as written when it does not parse — an unusable
+ * API URL is the connection's error to raise rather than this one's.
+ */
+function deploymentKey(apiUrl: string): string {
+  try {
+    return new URL(apiUrl).href;
+  } catch {
+    return apiUrl;
+  }
+}
+
+/**
+ * Claims the deployment at `apiUrl` as this process's, and throws when a
+ * different one is already claimed. Claiming the deployment already held is
+ * what every connection after the first does, and passes.
+ *
+ * A claim stands whether or not the connection it was made for opens: a
+ * connection that fails on the way up has written those settings already.
+ *
+ * What it catches is a second deployment, not a second connection: two
+ * connections to one deployment write the same settings and go unremarked,
+ * as does everything else one process's connections share.
+ */
+export function claimProcessDeployment(apiUrl: string): void {
+  const key = deploymentKey(apiUrl);
+  if (claimed === null) {
+    claimed = key;
+    return;
+  }
+  if (claimed === key) return;
+  throw new Error(
+    `This process is connected to \`${claimed}\`, so a connection to ` +
+      `\`${key}\` is refused: the settings a connection writes are the ` +
+      `process's rather than the connection's, which is one deployment ` +
+      `per process.`,
+  );
+}
+
+/** Forgets the claimed deployment. For tests that drive several claims. */
+export function resetProcessDeployment(): void {
+  claimed = null;
+}

--- a/packages/cli/lib/write-receipt.ts
+++ b/packages/cli/lib/write-receipt.ts
@@ -34,6 +34,11 @@ import type {
 /**
  * Spaces already receipted in this process, so a command whose work runs
  * through several write functions reports the space once rather than per call.
+ *
+ * The memo is the process's rather than one connection's, so a caller that
+ * holds a connection across many writes names a space once for the life of
+ * the process; `docs/plans/shuttle/runtime-integration.md` carries what that
+ * costs such a caller.
  */
 const receipted = new Set<string>();
 

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -29,7 +29,6 @@ import {
   getCellValueFromCommand,
   localPatternEntry,
   mergePiecePath,
-  normalizeApiUrl,
   parseLink,
   parsePieceOptions,
   parseSpaceOptions,
@@ -40,6 +39,7 @@ import {
   setCellValueFromCommand,
   setPieceSourceFromCommand,
 } from "../commands/piece.ts";
+import { normalizeApiUrl } from "../lib/api-url.ts";
 import {
   CellSelectionError,
   parseCellSelectionOptions,

--- a/packages/cli/test/process-deployment.test.ts
+++ b/packages/cli/test/process-deployment.test.ts
@@ -1,0 +1,52 @@
+import { expect } from "@std/expect";
+import { beforeEach, describe, it } from "@std/testing/bdd";
+
+import { loadPieces } from "../lib/piece.ts";
+import {
+  claimProcessDeployment,
+  resetProcessDeployment,
+} from "../lib/process-deployment.ts";
+
+describe("process-deployment", () => {
+  beforeEach(() => {
+    resetProcessDeployment();
+  });
+
+  describe("claimProcessDeployment()", () => {
+    it("accepts a second claim on the deployment already claimed", () => {
+      claimProcessDeployment("https://toolshed.test");
+      expect(() => claimProcessDeployment("https://toolshed.test/"))
+        .not.toThrow();
+    });
+
+    it("throws naming both deployments given a different one", () => {
+      claimProcessDeployment("https://first.test");
+      expect(() => claimProcessDeployment("https://second.test")).toThrow(
+        /`https:\/\/first\.test\/`.*`https:\/\/second\.test\/`/,
+      );
+    });
+
+    it("compares an api url that does not parse as written", () => {
+      claimProcessDeployment("toolshed-without-a-scheme");
+      expect(() => claimProcessDeployment("toolshed-without-a-scheme"))
+        .not.toThrow();
+      expect(() => claimProcessDeployment("another-without-a-scheme"))
+        .toThrow();
+    });
+  });
+
+  describe("loadPieces()", () => {
+    // The claim is the connection's first act, ahead of the identity it reads
+    // and the deployment it fetches flags from, so the rejection below is the
+    // limit's own message rather than a failure of either.
+
+    it("rejects a connection to a second deployment", async () => {
+      claimProcessDeployment("https://first.test");
+      await expect(loadPieces({
+        apiUrl: "https://second.test",
+        identity: "/nonexistent/second-deployment.key",
+        space: "second-deployment",
+      })).rejects.toThrow("one deployment per process");
+    });
+  });
+});

--- a/packages/cli/test/process-deployment.test.ts
+++ b/packages/cli/test/process-deployment.test.ts
@@ -37,8 +37,18 @@ describe("process-deployment", () => {
     it("throws naming both deployments given a different one", () => {
       claimProcessDeployment("https://first.test");
       expect(() => claimProcessDeployment("https://second.test")).toThrow(
-        /`https:\/\/first\.test\/`.*`https:\/\/second\.test\/`/,
+        /`https:\/\/first\.test`.*`https:\/\/second\.test`/,
       );
+    });
+
+    it("accepts every spelling the CLI reads as one deployment", () => {
+      claimProcessDeployment("https://toolshed.test/base/");
+      expect(() => claimProcessDeployment("https://toolshed.test/base"))
+        .not.toThrow();
+      expect(() => claimProcessDeployment("https://toolshed.test/base?x=1"))
+        .not.toThrow();
+      expect(() => claimProcessDeployment("https://toolshed.test/base#top"))
+        .not.toThrow();
     });
 
     it("says how to reach the refused deployment", () => {

--- a/packages/cli/test/process-deployment.test.ts
+++ b/packages/cli/test/process-deployment.test.ts
@@ -41,6 +41,13 @@ describe("process-deployment", () => {
       );
     });
 
+    it("says how to reach the refused deployment", () => {
+      claimProcessDeployment("https://first.test");
+      expect(() => claimProcessDeployment("https://second.test")).toThrow(
+        "restarting is the deployment switch",
+      );
+    });
+
     it("declines an api url no connection can use, leaving the claim unmade", () => {
       claimProcessDeployment("not-a-url");
       claimProcessDeployment("localhost:8000");

--- a/packages/cli/test/process-deployment.test.ts
+++ b/packages/cli/test/process-deployment.test.ts
@@ -1,3 +1,15 @@
+/**
+ * Unit tests for the process's claim on the deployment it connects to: what
+ * `claimProcessDeployment` accepts, what it refuses, and how it compares two
+ * spellings of one API URL. The claim is a module-level string and nothing
+ * else, so each case resets it and calls the function directly.
+ *
+ * The last case drives the real `loadPieces`, which claims ahead of the
+ * identity it reads and the flags it fetches from the deployment. A refused
+ * connection therefore rejects with the limit's own message, and no runtime,
+ * socket, or server stands behind that case either.
+ */
+
 import { expect } from "@std/expect";
 import { beforeEach, describe, it } from "@std/testing/bdd";
 

--- a/packages/cli/test/process-deployment.test.ts
+++ b/packages/cli/test/process-deployment.test.ts
@@ -1,13 +1,16 @@
 /**
  * Unit tests for the process's claim on the deployment it connects to: what
- * `claimProcessDeployment` accepts, what it refuses, and how it compares two
- * spellings of one API URL. The claim is a module-level string and nothing
- * else, so each case resets it and calls the function directly.
+ * `claimProcessDeployment` accepts, what it refuses, what it declines to
+ * record at all, and how it compares two spellings of one API URL. The claim
+ * is a module-level string and nothing else, so each case resets it and calls
+ * the function directly.
  *
- * The last case drives the real `loadPieces`, which claims ahead of the
- * identity it reads and the flags it fetches from the deployment. A refused
- * connection therefore rejects with the limit's own message, and no runtime,
- * socket, or server stands behind that case either.
+ * The `loadPieces` cases drive the real thing, which claims ahead of the
+ * identity it reads and the flags it fetches from the deployment: a refused
+ * connection rejects with the limit's own message, and an API URL no
+ * connection can be opened over rejects on the URL itself, leaving the claim
+ * free for the corrected one. No runtime, socket, or server stands behind
+ * either.
  */
 
 import { expect } from "@std/expect";
@@ -38,12 +41,11 @@ describe("process-deployment", () => {
       );
     });
 
-    it("compares an api url that does not parse as written", () => {
-      claimProcessDeployment("toolshed-without-a-scheme");
-      expect(() => claimProcessDeployment("toolshed-without-a-scheme"))
-        .not.toThrow();
-      expect(() => claimProcessDeployment("another-without-a-scheme"))
-        .toThrow();
+    it("declines an api url no connection can use, leaving the claim unmade", () => {
+      claimProcessDeployment("not-a-url");
+      claimProcessDeployment("localhost:8000");
+      expect(() => claimProcessDeployment("https://first.test")).not.toThrow();
+      expect(() => claimProcessDeployment("https://second.test")).toThrow();
     });
   });
 
@@ -59,6 +61,16 @@ describe("process-deployment", () => {
         identity: "/nonexistent/second-deployment.key",
         space: "second-deployment",
       })).rejects.toThrow("one deployment per process");
+    });
+
+    it("leaves the claim unmade for an api url it cannot connect over", async () => {
+      await expect(loadPieces({
+        apiUrl: "localhost:8000",
+        identity: "/nonexistent/unusable-api-url.key",
+        space: "unusable-api-url",
+      })).rejects.toThrow();
+      expect(() => claimProcessDeployment("https://real.test")).not.toThrow();
+      expect(() => claimProcessDeployment("https://other.test")).toThrow();
     });
   });
 });


### PR DESCRIPTION
## Why

Three pieces of state in `packages/cli` belong to the process rather than to
the connection that set them, and a second connection to a different
deployment would fight over them silently. `setLLMUrl` is written by
`loadPieces` and again by `PiecesController.initialize` in another package;
`quietMode` is a file-level `let` written by every `FromCommand` entry;
`receipted` memoizes which spaces this process has already named in a write
receipt.

Sweeping for the shape rather than the three names found **six**. The three
the design did not name are the ones that matter most:

- `globalEnv` (`packages/runner/src/builder/env.ts`), written on every
  `Runtime` construction, which decides where a pattern's relative `fetch`
  goes. Its own comment says it: *"setting it unconditionally from every
  Runtime would let the last-constructed runtime clobber the apiUrl other
  runtimes' patterns see. … This is still a singleton."*
- three experimental-flag control points, also written per `Runtime`, taking
  their values from the **deployment** — so two deployments with different
  flag postures overwrite each other.
- `pendingSkewNote`, where a second server's version-skew note replaces the
  first's.

Shuttle v1 holds one connection per process, which is what makes this safe.
This records that limit — and makes the part of it a process can actually
check fail loudly instead of silently.

Last of the stage-A seam PRs behind the merged shuttle design (#6537), after
#6626, #6646, #6676, #6682, #6704 and #6705.

## What Changed

`claimProcessDeployment(apiUrl)` records the deployment this process opened
against and throws, naming both, when a different one arrives. It runs as
`loadPieces`' first statement — ahead of `setLLMUrl` and the `Runtime`
construction — because a connection that fails on the way up has already
written those globals, so success is the wrong trigger.

**The check is weaker than the limit, deliberately, and the plan says so.**
`cf` opens many connections per process — every un-injected library function
calls `loadPieces` again — so a count-based check would break ordinary
commands. What a process can detect is a second *deployment*, which is the
bound where those settings actually fight. A second connection to the same
deployment passes, and `quietMode` and `receipted` rest on the recorded limit
alone.

**A connection that provably writes nothing consumes nothing.** `setLLMUrl`
resolves `/api/ai/llm` *against* the API URL, so it throws for any URL that
cannot serve as a base — and such a connection pollutes no global. The claim
therefore declines a URL `URL.canParse("/", apiUrl)` rejects, rather than
burning the process's one claim on it. The sharp case is `localhost:8000`:
it **parses** as a URL, its `8000` an opaque path, so a naive "does it parse"
check would have left the hole open for exactly the typo people make.

## Test plan

Gates, serially: `deno fmt --check`, `deno lint`, `deno task check`,
`deno task check-docs`, and `deno task test` in `packages/cli` — exit 0,
1760 parallel + 210 serial, 0 failed.

Five cases in `test/process-deployment.test.ts`, four pure and one driving
real `loadPieces` — which claims ahead of the identity read and the flag
fetch, so the rejection needs no network and no key. A five-mutant matrix
kills every case, each to a distinct one:

| Mutation | Killed by |
|---|---|
| `deploymentKey` returns `null` unconditionally | two cases — so they assert a **usable** URL still claims |
| naive `URL.canParse(apiUrl)` | "declines an api url no connection can use" |
| drop the same-deployment early return | "accepts a second claim" |
| warn instead of throw | two cases |
| message drops the already-claimed url | "throws naming both" |

## Two limits recorded rather than papered over

A claim **survives a failed connection**. A well-formed but wrong host burns
the process's claim, because `setLLMUrl` succeeded and the global was written.
Only the unusable-URL case is exempt, and the message names restart as the
recovery.

The `packages/llm` and `packages/runner` globals carry no comment about this;
the plan is their only record, and it says so. Three declarations name the
limit, all in `packages/cli`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6717?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

