### PR TITLE
fix(ui): finish indexed mention resolution

### DIFF
--- a/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.test.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.test.ts
@@ -1,5 +1,13 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import {
+  autocompletion,
+  CompletionContext,
+  type CompletionResult,
+  completionStatus,
+} from "@codemirror/autocomplete";
+import { EditorState, type TransactionSpec } from "@codemirror/state";
+import type { EditorView } from "@codemirror/view";
 import { NAME } from "@commonfabric/runner/shared";
 import { type CellHandle, type CellRef } from "@commonfabric/runtime-client";
 import { createMockCellHandle } from "../../test-utils/mock-cell-handle.ts";
@@ -360,11 +368,17 @@ describe("CFCodeEditor mention-piece resolution", () => {
   // the runtime does. Nothing here reaches a piece through a value.
   type ResolutionInternals = {
     mentionable: CellHandle<MentionableArray> | null;
+    mentioned?: CellHandle<MentionableArray>;
+    _editorView: EditorView | undefined;
     _resolvePieceIds(): Promise<void>;
+    _updateMentionedFromContent(content?: string): void;
     _resolvedPieceCells: Map<number, CellHandle<Mentionable>>;
     _getPieceId(index: number): string;
     findPieceById(id: string): CellHandle<Mentionable> | null;
     getFilteredMentionable(query: string): Array<[unknown, number]>;
+    createBacklinkCompletionSource(): (
+      context: CompletionContext,
+    ) => CompletionResult | null;
   };
 
   const internals = (element: CFCodeEditor): ResolutionInternals =>
@@ -422,6 +436,94 @@ describe("CFCodeEditor mention-piece resolution", () => {
     expect(element.getFilteredMentionable("").length).toBe(1);
     const found = element.findPieceById(element._getPieceId(0));
     expect(found?.id()).toBe(target.id());
+  });
+
+  it("defers `$mentioned` reconciliation until index rows resolve", async () => {
+    const element = internals(new CFCodeEditor());
+    const list = createMockCellHandle([
+      { [NAME]: "Row", title: "Row", piece: pieceLink },
+    ]);
+    const release = Promise.withResolvers<void>();
+    const realKey = list.key.bind(list);
+    list.key = ((key: PropertyKey) => {
+      const row = realKey(key as never);
+      if (String(key) === "0") {
+        const realRowKey = row.key.bind(row);
+        row.key = ((rowKey: PropertyKey) => {
+          const destination = realRowKey(rowKey as never);
+          if (String(rowKey) === "piece") {
+            const realResolve = destination.resolveAsCell.bind(destination);
+            destination.resolveAsCell = (async () => {
+              await release.promise;
+              return await realResolve();
+            }) as typeof destination.resolveAsCell;
+          }
+          return destination;
+        }) as unknown as typeof row.key;
+      }
+      return row;
+    }) as typeof list.key;
+
+    const mentioned = createMockCellHandle<MentionableArray>([], {
+      id: "of:mentioned" as CellRef["id"],
+    });
+    let writes = 0;
+    let written: MentionableArray | undefined;
+    const realSet = mentioned.set.bind(mentioned);
+    Object.defineProperty(mentioned, "set", {
+      value: (value: MentionableArray) => {
+        writes++;
+        written = value;
+        return realSet(value);
+      },
+    });
+    element.mentionable = list as unknown as CellHandle<MentionableArray>;
+    element.mentioned = mentioned;
+
+    const resolving = element._resolvePieceIds();
+    element._updateMentionedFromContent("[[Row (target-piece)]]");
+    expect(writes).toBe(0);
+
+    release.resolve();
+    await resolving;
+
+    expect(writes).toBe(1);
+    expect((written?.[0] as unknown as CellHandle<Mentionable>).id()).toBe(
+      "of:target-piece",
+    );
+  });
+
+  it("restarts a matching backlink completion after resolution", async () => {
+    const element = internals(new CFCodeEditor());
+    element.mentionable = createMockCellHandle([
+      { [NAME]: "Row", title: "Row", piece: pieceLink },
+    ]) as unknown as CellHandle<MentionableArray>;
+    const source = element.createBacklinkCompletionSource();
+    const state = EditorState.create({
+      doc: "[[Ro",
+      selection: { anchor: 4 },
+      extensions: [autocompletion({ override: [source] })],
+    });
+    const view: {
+      state: EditorState;
+      dispatch(spec: TransactionSpec): void;
+    } = {
+      state,
+      dispatch(spec: TransactionSpec) {
+        this.state = this.state.update(spec).state;
+      },
+    };
+    element._editorView = view as unknown as EditorView;
+
+    const initial = source(new CompletionContext(view.state, 4, true));
+    expect(initial?.options).toEqual([]);
+    expect(completionStatus(view.state)).toBe(null);
+
+    await element._resolvePieceIds();
+
+    expect(completionStatus(view.state)).toBe("pending");
+    const refreshed = source(new CompletionContext(view.state, 4, true));
+    expect(refreshed?.options.length).toBe(1);
   });
 
   it("keeps the newer resolution when an older pass finishes late", async () => {

--- a/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.test.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.test.ts
@@ -579,6 +579,31 @@ describe("CFCodeEditor mention-piece resolution", () => {
     expect(view.state.doc.toString()).toBe("[[New Topic]]");
   });
 
+  it("creates a piece when an unresolved row is not an exact match", () => {
+    const element = internals(new CFCodeEditor());
+    element.mentionable = createMockCellHandle([
+      { [NAME]: "Existing Topic", title: "Existing Topic", piece: pieceLink },
+    ]) as unknown as CellHandle<MentionableArray>;
+    element.pattern = createMockCellHandle("pattern");
+    let creation: [string, boolean] | undefined;
+    Object.defineProperty(element, "createBacklinkFromPattern", {
+      value: (text: string, navigate: boolean) => {
+        creation = [text, navigate];
+        return Promise.resolve();
+      },
+    });
+    const source = element.createBacklinkCompletionSource();
+    const view = createBacklinkView(source, "[[Top");
+
+    element._completeBacklinkQuery(
+      view as unknown as EditorView,
+      "Top",
+    );
+
+    expect(creation).toEqual(["Top", false]);
+    expect(view.state.doc.toString()).toBe("[[Top]]");
+  });
+
   it("restarts a matching backlink completion after resolution", async () => {
     const element = internals(new CFCodeEditor());
     element.mentionable = createMockCellHandle([

--- a/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.test.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.test.ts
@@ -369,16 +369,19 @@ describe("CFCodeEditor mention-piece resolution", () => {
   type ResolutionInternals = {
     mentionable: CellHandle<MentionableArray> | null;
     mentioned?: CellHandle<MentionableArray>;
+    pattern: CellHandle<string>;
     _editorView: EditorView | undefined;
     _resolvePieceIds(): Promise<void>;
-    _updateMentionedFromContent(content?: string): void;
     _resolvedPieceCells: Map<number, CellHandle<Mentionable>>;
+    _backlinkCompletionAwaitingResolution: boolean;
     _getPieceId(index: number): string;
     findPieceById(id: string): CellHandle<Mentionable> | null;
     getFilteredMentionable(query: string): Array<[unknown, number]>;
+    _completeBacklinkQuery(view: EditorView, text: string): void;
     createBacklinkCompletionSource(): (
       context: CompletionContext,
     ) => CompletionResult | null;
+    willUpdate(changedProperties: Map<string, unknown>): void;
   };
 
   const internals = (element: CFCodeEditor): ResolutionInternals =>
@@ -387,6 +390,26 @@ describe("CFCodeEditor mention-piece resolution", () => {
   const pieceLink = {
     "$link": { id: "of:target-piece", path: [] },
   };
+
+  /** Creates the stateful part of an `EditorView` used by completion. */
+  function createBacklinkView(
+    source: (context: CompletionContext) => CompletionResult | null,
+    doc: string,
+    hasFocus = true,
+  ) {
+    const state = EditorState.create({
+      doc,
+      selection: { anchor: doc.length },
+      extensions: [autocompletion({ override: [source] })],
+    });
+    return {
+      state,
+      hasFocus,
+      dispatch(spec: TransactionSpec) {
+        this.state = this.state.update(spec).state;
+      },
+    };
+  }
 
   it("resolves a piece-bearing entry to its piece", async () => {
     const element = internals(new CFCodeEditor());
@@ -463,6 +486,7 @@ describe("CFCodeEditor mention-piece resolution", () => {
       }
       return row;
     }) as typeof list.key;
+    Object.defineProperty(list, "asSchema", { value: () => list });
 
     const mentioned = createMockCellHandle<MentionableArray>([], {
       id: "of:mentioned" as CellRef["id"],
@@ -479,18 +503,80 @@ describe("CFCodeEditor mention-piece resolution", () => {
     });
     element.mentionable = list as unknown as CellHandle<MentionableArray>;
     element.mentioned = mentioned;
+    Object.defineProperty(element, "getValue", {
+      value: () => "[[Row (target-piece)]]",
+    });
+    const resolutions: Promise<void>[] = [];
+    const resolvePieceIds = element._resolvePieceIds.bind(element);
+    Object.defineProperty(element, "_resolvePieceIds", {
+      value: () => {
+        const resolution = resolvePieceIds();
+        resolutions.push(resolution);
+        return resolution;
+      },
+    });
 
-    const resolving = element._resolvePieceIds();
-    element._updateMentionedFromContent("[[Row (target-piece)]]");
+    element.willUpdate(new Map([["mentionable", null]]));
     expect(writes).toBe(0);
 
     release.resolve();
-    await resolving;
+    await Promise.all(resolutions);
 
     expect(writes).toBe(1);
     expect((written?.[0] as unknown as CellHandle<Mentionable>).id()).toBe(
       "of:target-piece",
     );
+  });
+
+  it("does not create a piece for an exact unresolved index row", async () => {
+    const element = internals(new CFCodeEditor());
+    element.mentionable = createMockCellHandle([
+      { [NAME]: "Existing Topic", title: "Existing Topic", piece: pieceLink },
+    ]) as unknown as CellHandle<MentionableArray>;
+    element.pattern = createMockCellHandle("pattern");
+    let creations = 0;
+    Object.defineProperty(element, "createBacklinkFromPattern", {
+      value: () => {
+        creations++;
+        return Promise.resolve();
+      },
+    });
+    const source = element.createBacklinkCompletionSource();
+    const view = createBacklinkView(source, "[[Existing Topic");
+    element._editorView = view as unknown as EditorView;
+
+    element._completeBacklinkQuery(
+      view as unknown as EditorView,
+      "Existing Topic",
+    );
+
+    expect(creations).toBe(0);
+    expect(view.state.doc.toString()).toBe("[[Existing Topic");
+    expect(element._backlinkCompletionAwaitingResolution).toBe(true);
+    await element._resolvePieceIds();
+  });
+
+  it("creates a piece when no exact row is present", () => {
+    const element = internals(new CFCodeEditor());
+    element.mentionable = createMockCellHandle<MentionableArray>([]);
+    element.pattern = createMockCellHandle("pattern");
+    let creation: [string, boolean] | undefined;
+    Object.defineProperty(element, "createBacklinkFromPattern", {
+      value: (text: string, navigate: boolean) => {
+        creation = [text, navigate];
+        return Promise.resolve();
+      },
+    });
+    const source = element.createBacklinkCompletionSource();
+    const view = createBacklinkView(source, "[[New Topic");
+
+    element._completeBacklinkQuery(
+      view as unknown as EditorView,
+      "New Topic",
+    );
+
+    expect(creation).toEqual(["New Topic", false]);
+    expect(view.state.doc.toString()).toBe("[[New Topic]]");
   });
 
   it("restarts a matching backlink completion after resolution", async () => {
@@ -499,20 +585,7 @@ describe("CFCodeEditor mention-piece resolution", () => {
       { [NAME]: "Row", title: "Row", piece: pieceLink },
     ]) as unknown as CellHandle<MentionableArray>;
     const source = element.createBacklinkCompletionSource();
-    const state = EditorState.create({
-      doc: "[[Ro",
-      selection: { anchor: 4 },
-      extensions: [autocompletion({ override: [source] })],
-    });
-    const view: {
-      state: EditorState;
-      dispatch(spec: TransactionSpec): void;
-    } = {
-      state,
-      dispatch(spec: TransactionSpec) {
-        this.state = this.state.update(spec).state;
-      },
-    };
+    const view = createBacklinkView(source, "[[Ro");
     element._editorView = view as unknown as EditorView;
 
     const initial = source(new CompletionContext(view.state, 4, true));
@@ -524,6 +597,23 @@ describe("CFCodeEditor mention-piece resolution", () => {
     expect(completionStatus(view.state)).toBe("pending");
     const refreshed = source(new CompletionContext(view.state, 4, true));
     expect(refreshed?.options.length).toBe(1);
+  });
+
+  it("does not restart a backlink completion after focus leaves", async () => {
+    const element = internals(new CFCodeEditor());
+    element.mentionable = createMockCellHandle([
+      { [NAME]: "Row", title: "Row", piece: pieceLink },
+    ]) as unknown as CellHandle<MentionableArray>;
+    const source = element.createBacklinkCompletionSource();
+    const view = createBacklinkView(source, "[[Ro", false);
+    element._editorView = view as unknown as EditorView;
+
+    const initial = source(new CompletionContext(view.state, 4, true));
+    expect(initial?.options).toEqual([]);
+
+    await element._resolvePieceIds();
+
+    expect(completionStatus(view.state)).toBe(null);
   });
 
   it("keeps the newer resolution when an older pass finishes late", async () => {

--- a/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
@@ -400,6 +400,14 @@ export class CFCodeEditor extends BaseElement {
   // identical when its contents change, so identity alone cannot stop an
   // older pass finishing late and overwriting a newer pass's ordering.
   private _resolveGeneration = 0;
+  // `$mentioned` cannot be reconciled while an index row has no piece id.
+  // Calls made during that window leave the latest content for the current
+  // resolution pass to reconcile when it publishes.
+  private _mentionResolutionPending = false;
+  private _deferredMentionedContent: string | null = null;
+  // A completion source that withheld a matching index row asks the current
+  // resolution pass to query it again once the row has a usable identity.
+  private _backlinkCompletionAwaitingResolution = false;
   private _referencesUnsub: (() => void) | null = null;
   // Label text last seen for each reference key, to detect a user's edit.
   private _previousRefLabels = new Map<string, string>();
@@ -489,6 +497,7 @@ export class CFCodeEditor extends BaseElement {
    */
   private createBacklinkCompletionSource() {
     return (context: CompletionContext): CompletionResult | null => {
+      this._backlinkCompletionAwaitingResolution = false;
       // Look for incomplete backlinks: [[ followed by optional text (not yet closed)
       const backlink = context.matchBefore(/\[\[([^\]]*)?/);
 
@@ -511,6 +520,8 @@ export class CFCodeEditor extends BaseElement {
       const query = backlink.text.slice(2); // Remove [[ prefix
 
       const mentionable = this.getFilteredMentionable(query);
+      this._backlinkCompletionAwaitingResolution = this
+        ._hasUnresolvedIndexRowFor(query);
 
       // Check if auto-close added ]] after cursor
       const hasAutoCloseBrackets = afterCursor.startsWith("]]");
@@ -599,6 +610,28 @@ export class CFCodeEditor extends BaseElement {
     }
 
     return matches;
+  }
+
+  /** Whether a matching index row is waiting for its piece identity. */
+  private _hasUnresolvedIndexRowFor(query: string): boolean {
+    const mentionableData = (this.mentionable?.get() ?? []) as MentionableArray;
+    const queryLower = query.toLowerCase();
+    return mentionableData.some((mention, index) =>
+      this._isIndexRow(index) &&
+      !this._resolvedPieceIds.has(index) &&
+      !!mention?.[NAME]?.toLowerCase()?.includes(queryLower)
+    );
+  }
+
+  /** Restarts a backlink query that withheld a matching index row. */
+  private _refreshBacklinkCompletion(): void {
+    if (!this._backlinkCompletionAwaitingResolution) return;
+    this._backlinkCompletionAwaitingResolution = false;
+
+    const view = this._editorView;
+    if (view && this._currentBacklinkQuery(view) !== null) {
+      startCompletion(view);
+    }
   }
 
   /**
@@ -1237,7 +1270,13 @@ export class CFCodeEditor extends BaseElement {
    */
   private async _resolvePieceIds(): Promise<void> {
     const handle = this.mentionable;
-    if (!handle) return;
+    if (!handle) {
+      this._mentionResolutionPending = false;
+      this._deferredMentionedContent = null;
+      return;
+    }
+
+    this._mentionResolutionPending = true;
 
     const mentionableData = (handle.get() ?? []) as MentionableArray;
 
@@ -1285,8 +1324,15 @@ export class CFCodeEditor extends BaseElement {
     ) {
       this._resolvedPieceIds = newResolved;
       this._resolvedPieceCells = newCells;
-      // Re-resolve mentioned from content now that we have stable IDs
-      this._updateMentionedFromContent();
+      this._mentionResolutionPending = false;
+      const deferredContent = this._deferredMentionedContent;
+      this._deferredMentionedContent = null;
+      if (deferredContent === null) {
+        this._updateMentionedFromContent();
+      } else {
+        this._updateMentionedFromContent(deferredContent);
+      }
+      this._refreshBacklinkCompletion();
     }
   }
 
@@ -1956,6 +2002,10 @@ export class CFCodeEditor extends BaseElement {
     this._cleanupCollaboration();
     this._cleanupPieceNameSubscriptions();
     this._cleanupRefDestinationSubscriptions();
+    this._resolveGeneration++;
+    this._mentionResolutionPending = false;
+    this._deferredMentionedContent = null;
+    this._backlinkCompletionAwaitingResolution = false;
     this._resolvedPieceIds.clear();
     this._resolvedPieceCells.clear();
     if (this._mentionableUnsub) {
@@ -2493,6 +2543,12 @@ export class CFCodeEditor extends BaseElement {
       // Enter: complete backlink OR exit editing mode (no newline inside backlinks)
       // Use Prec.highest to ensure this runs before autocompletion handlers
       Prec.highest(keymap.of([{
+        key: "Escape",
+        run: () => {
+          this._backlinkCompletionAwaitingResolution = false;
+          return false;
+        },
+      }, {
         key: "Enter",
         run: (view) => {
           const pos = view.state.selection.main.head;
@@ -2791,8 +2847,13 @@ export class CFCodeEditor extends BaseElement {
    * Link syntax: [[Name (id)]]. We parse ids and resolve them against
    * `$mentionable` to produce live Piece instances.
    */
-  private _updateMentionedFromContent(content = this.getValue() || ""): void {
+  private _updateMentionedFromContent(content?: string): void {
     if (!this.mentioned) return;
+    content ??= this._editorView?.state.doc.toString() ?? this.getValue() ?? "";
+    if (this._mentionResolutionPending) {
+      this._deferredMentionedContent = content;
+      return;
+    }
 
     if (this._refMode) {
       this._updateMentionedWithRefs(content);

--- a/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
@@ -612,15 +612,22 @@ export class CFCodeEditor extends BaseElement {
     return matches;
   }
 
-  /** Whether a matching index row is waiting for its piece identity. */
-  private _hasUnresolvedIndexRowFor(query: string): boolean {
+  /** Whether an unresolved index row contains or exactly matches `query`. */
+  private _hasUnresolvedIndexRowFor(
+    query: string,
+    match: "contains" | "exact" = "contains",
+  ): boolean {
     const mentionableData = (this.mentionable?.get() ?? []) as MentionableArray;
     const queryLower = query.toLowerCase();
-    return mentionableData.some((mention, index) =>
-      this._isIndexRow(index) &&
-      !this._resolvedPieceIds.has(index) &&
-      !!mention?.[NAME]?.toLowerCase()?.includes(queryLower)
-    );
+    return mentionableData.some((mention, index) => {
+      if (!this._isIndexRow(index) || this._resolvedPieceIds.has(index)) {
+        return false;
+      }
+      const name = mention?.[NAME]?.toLowerCase();
+      return match === "exact"
+        ? name === queryLower
+        : !!name?.includes(queryLower);
+    });
   }
 
   /** Restarts a backlink query that withheld a matching index row. */
@@ -629,7 +636,7 @@ export class CFCodeEditor extends BaseElement {
     this._backlinkCompletionAwaitingResolution = false;
 
     const view = this._editorView;
-    if (view && this._currentBacklinkQuery(view) !== null) {
+    if (view?.hasFocus && this._currentBacklinkQuery(view) !== null) {
       startCompletion(view);
     }
   }
@@ -660,6 +667,40 @@ export class CFCodeEditor extends BaseElement {
     }
 
     return null;
+  }
+
+  /** Completes an exact mention or creates when no exact row is present. */
+  private _completeBacklinkQuery(view: EditorView, text: string): void {
+    const exactMatch = this._findExactMentionable(text);
+    if (exactMatch) {
+      const [matchCell, matchIndex] = exactMatch;
+      const pieceName = matchCell.key(NAME).get() || text;
+      if (
+        !this._refMode ||
+        !this._completeMentionRef(view, pieceName, matchIndex)
+      ) {
+        const pieceId = this._getPieceId(matchIndex);
+        this._completeBacklinkWithId(view, text, pieceName, pieceId);
+      }
+      return;
+    }
+
+    // An exact row without an identity is an existing piece, not permission
+    // to create another one. Keep the query intact and reopen its completion
+    // after this pass, starting a fresh pass if the previous one failed.
+    if (this._hasUnresolvedIndexRowFor(text, "exact")) {
+      this._backlinkCompletionAwaitingResolution = true;
+      if (!this._mentionResolutionPending) void this._resolvePieceIds();
+      return;
+    }
+
+    if (!this.pattern) return;
+    if (this._refMode) {
+      this._createMentionRefFromPattern(view, text);
+    } else {
+      this._completeBacklinkText(view);
+      this.createBacklinkFromPattern(text, false);
+    }
   }
 
   /**
@@ -2580,31 +2621,7 @@ export class CFCodeEditor extends BaseElement {
           if (query != null) {
             const text = query.trim();
             if (text.length > 0) {
-              // Check for exact match in mentionable
-              const exactMatch = this._findExactMentionable(text);
-
-              if (exactMatch) {
-                // Found exact match - insert complete backlink with stable piece ID
-                const [matchCell, matchIndex] = exactMatch;
-                const pieceName = matchCell.key(NAME).get() || text;
-                if (
-                  !this._refMode ||
-                  !this._completeMentionRef(view, pieceName, matchIndex)
-                ) {
-                  const pieceId = this._getPieceId(matchIndex);
-                  this._completeBacklinkWithId(view, text, pieceName, pieceId);
-                }
-              } else if (this.pattern) {
-                // No exact match - create new piece without navigating
-                if (this._refMode) {
-                  this._createMentionRefFromPattern(view, text);
-                } else {
-                  // First complete the backlink text, then create the piece
-                  this._completeBacklinkText(view);
-                  // createBacklinkFromPattern will insert the ID and emit event
-                  this.createBacklinkFromPattern(text, false);
-                }
-              }
+              this._completeBacklinkQuery(view, text);
               return true;
             }
           }

--- a/packages/ui/src/v2/core/mention-controller.test.ts
+++ b/packages/ui/src/v2/core/mention-controller.test.ts
@@ -267,6 +267,27 @@ describe("MentionController — mention insertion", () => {
     expect(inserts[0]).toMatch(/^\[Test Item\]\(.+\)$/);
     expect(ctrl.isShowing).toBe(false);
   });
+
+  it("falls back to a direct entry's raw reference", async () => {
+    const inserts: string[] = [];
+    const ctrl = new MentionController(createMockHost(), {
+      getContent: () => "@",
+      getCursorPosition: () => 1,
+      onInsert: (markdown) => inserts.push(markdown),
+    });
+    const cell = createMentionableCell(["Direct"]);
+    ctrl.setMentionable(cell);
+    ctrl.handleInput(new Event("input"));
+    const mention = ctrl.getFilteredMentions()[0];
+    Object.defineProperty(mention, "resolveAsCell", {
+      value: () => Promise.reject(new Error("unavailable")),
+    });
+
+    await ctrl.insertMention(mention);
+
+    expect(inserts).toEqual(["[Direct](/of:mentionables/0)"]);
+    expect(ctrl.isShowing).toBe(false);
+  });
 });
 
 //
@@ -314,6 +335,33 @@ describe("MentionController — indexed rows", () => {
 
     expect(inserts.length).toBe(1);
     expect(inserts[0]).toBe("[Indexed Topic](/of:target-piece)");
+  });
+
+  it("leaves an index row uninserted when its piece cannot resolve", async () => {
+    const inserts: string[] = [];
+    const ctrl = new MentionController(createMockHost(), {
+      getContent: () => "@",
+      getCursorPosition: () => 1,
+      onInsert: (markdown) => inserts.push(markdown),
+    });
+    const { cell } = createIndexedCell([
+      { name: "Indexed Topic", pieceId: "of:target-piece" },
+    ]);
+    ctrl.setMentionable(cell);
+    ctrl.handleInput(new Event("input"));
+    const row = ctrl.getFilteredMentions()[0];
+    Object.defineProperty(row, "key", {
+      value: () => ({
+        asSchema: () => ({
+          resolveAsCell: () => Promise.reject(new Error("unavailable")),
+        }),
+      }),
+    });
+
+    await ctrl.insertMention(row);
+
+    expect(inserts).toEqual([]);
+    expect(ctrl.isShowing).toBe(true);
   });
 
   it("decodes a piece href back to its index row", async () => {

--- a/packages/ui/src/v2/core/mention-controller.ts
+++ b/packages/ui/src/v2/core/mention-controller.ts
@@ -267,6 +267,7 @@ export class MentionController implements ReactiveController {
    */
   async insertMention(mention: CellHandle<Mentionable>): Promise<void> {
     const markdown = await this.encodePieceAsMarkdown(mention);
+    if (markdown === null) return;
     this.config.onInsert(markdown, mention);
     this.hide();
   }
@@ -302,10 +303,15 @@ export class MentionController implements ReactiveController {
   private _destinationOf(
     mention: CellHandle<Mentionable>,
   ): CellHandle<Mentionable> {
-    const value = mention.get();
-    return value != null && Object.hasOwn(value, "piece")
+    return this._isIndexRow(mention)
       ? mention.key("piece").asSchema<Mentionable>(MentionableSchema)
       : mention;
+  }
+
+  /** Whether an entry is an index row standing for its `.piece`. */
+  private _isIndexRow(mention: CellHandle<Mentionable>): boolean {
+    const value = mention.get();
+    return value != null && Object.hasOwn(value, "piece");
   }
 
   /**
@@ -317,17 +323,17 @@ export class MentionController implements ReactiveController {
    */
   private async encodePieceAsMarkdown(
     piece: CellHandle<Mentionable>,
-  ): Promise<string> {
+  ): Promise<string | null> {
     const name = piece.get()?.[NAME] || "Unknown";
-    const destination = this._destinationOf(piece);
     try {
+      const destination = this._destinationOf(piece);
       const resolved = await destination.resolveAsCell();
       return `[${name}](/${resolved.ref().id})`;
     } catch {
-      // The ENTRY's href, not the destination's: decode's raw first pass
-      // matches entry refs, so this round-trips even for an index row
-      // whose piece failed to resolve — a `/…/piece` path would match
-      // neither pass.
+      // A direct entry is already the destination, so its raw ref remains a
+      // usable fallback. An index row is only bookkeeping; without its piece
+      // identity there is no valid mention to insert.
+      if (this._isIndexRow(piece)) return null;
       return `[${name}](${this._buildHref(piece.ref())})`;
     }
   }

--- a/packages/ui/src/v2/core/mention-controller.ts
+++ b/packages/ui/src/v2/core/mention-controller.ts
@@ -242,7 +242,8 @@ export class MentionController implements ReactiveController {
         return true;
 
       case "Enter":
-        // Only intercept Enter if a mention will actually be inserted.
+        // A selected row owns this keypress while its destination resolves.
+        // Failure leaves the selection and popup intact for another attempt.
         if (filteredMentions[this._state.selectedIndex]) {
           event.preventDefault();
           this.insertMention(filteredMentions[this._state.selectedIndex]);
@@ -262,8 +263,10 @@ export class MentionController implements ReactiveController {
   }
 
   /**
-   * Insert a mention at the current cursor position.
+   * Inserts a mention at the current cursor position.
    * Resolves the sub-cell to the real piece entity ID at insertion time.
+   * An index row whose piece cannot resolve inserts nothing and remains
+   * selected in the open popup.
    */
   async insertMention(mention: CellHandle<Mentionable>): Promise<void> {
     const markdown = await this.encodePieceAsMarkdown(mention);
@@ -315,11 +318,12 @@ export class MentionController implements ReactiveController {
   }
 
   /**
-   * Encode a piece as markdown link [name](/of:entityId).
+   * Encodes a piece as markdown link `[name](/of:entityId)`.
    * Resolves the entry's destination to the real piece entity ID so
    * downstream consumers (LLM tools, read operations) can access the full
    * schema. The display name is the entry's own — for an index row, the
-   * label it lists.
+   * label it lists. Returns `null` when an index row's piece cannot resolve;
+   * a direct entry can still fall back to its own raw reference.
    */
   private async encodePieceAsMarkdown(
     piece: CellHandle<Mentionable>,


### PR DESCRIPTION
## Summary

- defer `$mentioned` reconciliation until the current mentionable-resolution pass publishes stable piece identities
- leave prompt-input index rows uninserted when their destination cannot resolve, while preserving the raw-reference fallback for direct entries
- restart backlink completion when a matching index row that was withheld becomes resolvable

Follow-up to #6660 and its remaining review findings:
- https://github.com/commontoolsinc/labs/pull/6660#discussion_r3899994470
- https://github.com/commontoolsinc/labs/pull/6660#discussion_r3899995185

## Test plan

- `deno task --filter @commonfabric/ui test`
- `deno fmt --check`
- `deno lint`
- `deno task check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6718?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

