### PR TITLE
fix(lunch-poll): address a vote by key again, and hold it there

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -94,6 +94,7 @@ jobs:
             packages/dashboard/machine-calibration.bench.ts \
             packages/patterns/integration/topic-board-navigation.bench.ts \
             packages/patterns/integration/topic-board-scale.bench.ts \
+            packages/patterns/integration/lunch-poll-vote-burst.bench.ts \
             > bench-results/results.json \
             2> >(tee bench-results/diagnostics.log >&2)
 

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -655,6 +655,61 @@ jobs:
           path: ./dist/toolshed
           if-no-files-found: error
 
+  # TEMPORARY (PR #6719) — delete before merging. Measures what the vote-burst
+  # benchmark actually costs on a CI host, to settle whether ten runtimes belong
+  # in the shared benchmarks job. The developer-machine figure (5.4GB peak) is a
+  # working set V8 grows into available RAM, so it says little about a host with
+  # less of it; this job reports the host's own total alongside the peak. It runs
+  # on ubuntu-latest, not the benchmarks job's `labs` group, so it bounds the
+  # question rather than answering it outright.
+  benchmark-memory-probe:
+    name: "TEMP: vote-burst benchmark footprint"
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: *job-timeout
+    steps:
+      - name: 📥 Checkout repository
+        uses: actions/checkout@v7
+
+      - name: 🦕 Setup Deno
+        uses: ./.github/actions/deno-setup
+
+      - name: 🔍 Verify lock file & install dependencies
+        uses: ./.github/actions/deno-install
+
+      - name: 🖥️ Report the host's memory
+        run: |
+          echo "=== /proc/meminfo (first 3 lines) ==="
+          head -3 /proc/meminfo
+          echo "=== free -m ==="
+          free -m
+          echo "=== nproc ==="
+          nproc
+
+      - name: 🏋️ Run the vote-burst benchmark under GNU time
+        timeout-minutes: *work-timeout
+        env:
+          CF_LOG_LEVEL: silent
+        run: |
+          # Same v8 flags the benchmarks workflow uses, so the heap headroom
+          # matches the run this is asking about.
+          /usr/bin/time -v deno bench --json -A --v8-flags=--expose-gc \
+            packages/patterns/integration/lunch-poll-vote-burst.bench.ts \
+            > bench.json 2> time.log || true
+          echo "=== peak RSS and wall clock ==="
+          grep -E "Maximum resident set size|Elapsed \(wall clock\)" time.log || true
+          echo "=== the benchmark's own contention accounting ==="
+          grep -a "lunch-poll vote burst" time.log || true
+          echo "=== reported timing ==="
+          deno eval --ext=ts '
+            const d = JSON.parse(Deno.readTextFileSync("bench.json"));
+            for (const b of d.benches) {
+              const r = b.results[0].ok;
+              if (!r) continue;
+              console.log(`${b.name}: n=${r.n} p75=${(r.p75/1e6).toFixed(1)}ms avg=${(r.avg/1e6).toFixed(1)}ms`);
+            }
+          ' || true
+
   build-bg-piece-service:
     name: "Build Binary (bg-piece-service)"
     runs-on: ubuntu-latest

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -655,61 +655,6 @@ jobs:
           path: ./dist/toolshed
           if-no-files-found: error
 
-  # TEMPORARY (PR #6719) — delete before merging. Measures what the vote-burst
-  # benchmark actually costs on a CI host, to settle whether ten runtimes belong
-  # in the shared benchmarks job. The developer-machine figure (5.4GB peak) is a
-  # working set V8 grows into available RAM, so it says little about a host with
-  # less of it; this job reports the host's own total alongside the peak. It runs
-  # on ubuntu-latest, not the benchmarks job's `labs` group, so it bounds the
-  # question rather than answering it outright.
-  benchmark-memory-probe:
-    name: "TEMP: vote-burst benchmark footprint"
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    timeout-minutes: *job-timeout
-    steps:
-      - name: 📥 Checkout repository
-        uses: actions/checkout@v7
-
-      - name: 🦕 Setup Deno
-        uses: ./.github/actions/deno-setup
-
-      - name: 🔍 Verify lock file & install dependencies
-        uses: ./.github/actions/deno-install
-
-      - name: 🖥️ Report the host's memory
-        run: |
-          echo "=== /proc/meminfo (first 3 lines) ==="
-          head -3 /proc/meminfo
-          echo "=== free -m ==="
-          free -m
-          echo "=== nproc ==="
-          nproc
-
-      - name: 🏋️ Run the vote-burst benchmark under GNU time
-        timeout-minutes: *work-timeout
-        env:
-          CF_LOG_LEVEL: silent
-        run: |
-          # Same v8 flags the benchmarks workflow uses, so the heap headroom
-          # matches the run this is asking about.
-          /usr/bin/time -v deno bench --json -A --v8-flags=--expose-gc \
-            packages/patterns/integration/lunch-poll-vote-burst.bench.ts \
-            > bench.json 2> time.log || true
-          echo "=== peak RSS and wall clock ==="
-          grep -E "Maximum resident set size|Elapsed \(wall clock\)" time.log || true
-          echo "=== the benchmark's own contention accounting ==="
-          grep -a "lunch-poll vote burst" time.log || true
-          echo "=== reported timing ==="
-          deno eval --ext=ts '
-            const d = JSON.parse(Deno.readTextFileSync("bench.json"));
-            for (const b of d.benches) {
-              const r = b.results[0].ok;
-              if (!r) continue;
-              console.log(`${b.name}: n=${r.n} p75=${(r.p75/1e6).toFixed(1)}ms avg=${(r.avg/1e6).toFixed(1)}ms`);
-            }
-          ' || true
-
   build-bg-piece-service:
     name: "Build Binary (bg-piece-service)"
     runs-on: ubuntu-latest

--- a/docs/development/BENCHMARKS.md
+++ b/docs/development/BENCHMARKS.md
@@ -281,3 +281,59 @@ run stays green.
 
 Because that ceiling is the board's cost and not a property of the benchmark,
 the two skipped sizes should be enabled as part of whatever lowers it.
+
+## The multiplayer contention benchmark
+
+`packages/patterns/integration/lunch-poll-vote-burst.bench.ts` measures what
+several people editing one thing at the same moment cost each other: ten voters
+each cast a vote on each of ten lunch-poll options, all hundred dispatched
+before any settles, timed until every one of the ten clients holds the whole
+result. Its `lunch poll` group carries one series, `vote burst 10x10`.
+
+It is the only benchmark in the repository with a second writer. Every other
+bench file drives one runtime against storage it alone holds, so a write
+conflict cannot arise in one, and the cost of a contended write — the rejected
+commit, the rolled-back optimistic write, the re-run — is invisible to all of
+them. This one runs ten runtimes, each in its own Deno worker, against one
+in-process storage server, which is the arrangement
+`packages/patterns/integration/multi-runtime-harness.ts` exists for. No toolshed
+and no browser.
+
+Four things follow from that shape:
+
+- **Setup runs once, at module scope.** Ten workers, ten joins, ten options and
+  two warm-up bursts cost around twelve seconds, so paying it per iteration
+  would leave a run with almost no samples. Each iteration recolors every vote,
+  so all hundred are real changes and the poll holds a hundred votes throughout;
+  no iteration leaves a state the next one starts from differently.
+- **Few samples.** An iteration runs in a few hundred milliseconds, which puts
+  this benchmark at the end of the distribution where the 75th percentile buys
+  least — it discards the slowest quarter of a dozen samples, so two stalls in a
+  run reach the figure the trend reads. Read it across several windows.
+- **The wall-clock is half of what it measures.** A contended write is also
+  work thrown away, and that half does not appear in a timing. The file writes a
+  contention accounting — rejected commits and rolled-back writes over one
+  untimed burst — to stderr, and so into `diagnostics.log`. On the keyed vote
+  write both are zero; the same burst over a whole-list write measured 430 and
+  558.
+- **The size names the series.** `CF_LUNCH_POLL_VOTERS` and
+  `CF_LUNCH_POLL_OPTIONS` resize it for a local run asking how the burst scales.
+  Changing either starts a new line rather than continuing this one, exactly as
+  the board benchmark's size does. CI leaves both unset, and the size in force
+  is written to stderr.
+
+Ten runtimes is the largest footprint of any benchmark in the job, and the cost
+is worth knowing before adding a voter to it. Measured on an Apple M5 Max, the
+file adds around twenty-three seconds and peaks at 5.4GB resident, against
+245MB for a run without it. That peak is a working set rather than a leak — the
+same run under `--max-old-space-size=512` completes in 3.5GB, at roughly double
+the per-iteration time — so what it actually reaches depends on the headroom the
+heap is given. The memory is not released when the file's benchmarks finish,
+because the harness has no teardown seam `Deno.bench` can call, so whatever it
+reaches is held for the rest of the job. `deno bench` picks its own order and
+put this file first in every ordering tried, which means the rest of the job
+runs beside it.
+
+`packages/patterns/integration/lunch-poll-keyed-votes.test.ts` is the assertion
+half of the same property: it bounds rolled-back writes instead of timing them,
+so a regression that this benchmark shows as trend drift also fails a test.

--- a/docs/development/BENCHMARKS.md
+++ b/docs/development/BENCHMARKS.md
@@ -335,9 +335,10 @@ given rather than on what it needs.
 
 That peak is a floor under everything measured after it. The workers are
 released at process exit — `Deno.bench` offers no seam for "this file's
-benchmarks are done", so the file closes the harness from an `unload` listener —
-and `deno bench` picks its own order, which put this file first in every
-ordering tried. So the rest of the job runs beside it.
+benchmarks are done", so the file closes the harness from an `unload` listener.
+Which benchmarks that floor sits under is therefore a question of where
+`deno bench` places this file, and the pipeline section above says that is not
+a question the workflow's list answers.
 
 `packages/patterns/integration/lunch-poll-keyed-votes.test.ts` is the assertion
 half of the same property: it bounds rolled-back writes instead of timing them,

--- a/docs/development/BENCHMARKS.md
+++ b/docs/development/BENCHMARKS.md
@@ -324,14 +324,18 @@ Four things follow from that shape:
   is written to stderr.
 
 Ten runtimes is the largest footprint of any benchmark in the job, and the cost
-is worth knowing before adding a voter to it. **Measured on a four-core CI host
-with 15.6GB of memory: 89 seconds for the file, peaking at 4.76GB resident** —
-under a third of that host, with around 9GB still free, so it runs with room
-rather than close to the edge. A developer machine with far more memory peaks
-higher, at 5.4GB, because the figure is a working set rather than a leak: the
-same run under `--max-old-space-size=512` completes in 3.5GB at roughly double
-the per-iteration time, so what it reaches depends on the headroom the heap is
-given rather than on what it needs.
+is worth knowing before adding a voter to it. **Measured on a default hosted
+runner — four cores, 15.6GB — the file takes 89 seconds and peaks at 4.76GB
+resident**, under a third of that host with around 9GB still free. The runner
+group this workflow uses is a larger machine than that one, so the share it
+takes there is smaller again.
+
+Read that peak as a working set rather than as a requirement. The same run
+under `--max-old-space-size=512` completes in 3.5GB at roughly double the
+per-iteration time, and a developer machine with far more memory peaks higher,
+at 5.4GB. So the absolute figure rises with the headroom the heap is offered
+while the fraction of the host falls, and it is the fraction that decides
+whether this belongs beside the other benchmarks.
 
 That peak is a floor under everything measured after it. The workers are
 released at process exit — `Deno.bench` offers no seam for "this file's

--- a/docs/development/BENCHMARKS.md
+++ b/docs/development/BENCHMARKS.md
@@ -306,10 +306,11 @@ Four things follow from that shape:
   would leave a run with almost no samples. Each iteration recolors every vote,
   so all hundred are real changes and the poll holds a hundred votes throughout;
   no iteration leaves a state the next one starts from differently.
-- **Few samples.** An iteration runs in a few hundred milliseconds, which puts
-  this benchmark at the end of the distribution where the 75th percentile buys
-  least — it discards the slowest quarter of a dozen samples, so two stalls in a
-  run reach the figure the trend reads. Read it across several windows.
+- **Few samples.** An iteration runs in about 450ms on a developer machine and
+  2.6 seconds on a four-core CI host, which puts this benchmark at the end of
+  the distribution where the 75th percentile buys least — it discards the
+  slowest quarter of a dozen samples, so two stalls in a run reach the figure
+  the trend reads. Read it across several windows.
 - **The wall-clock is half of what it measures.** A contended write is also
   work thrown away, and that half does not appear in a timing. The file writes a
   contention accounting — rejected commits and rolled-back writes over one
@@ -323,16 +324,20 @@ Four things follow from that shape:
   is written to stderr.
 
 Ten runtimes is the largest footprint of any benchmark in the job, and the cost
-is worth knowing before adding a voter to it. Measured on an Apple M5 Max, the
-file adds around twenty-three seconds and peaks at 5.4GB resident, against
-245MB for a run without it. That peak is a working set rather than a leak — the
-same run under `--max-old-space-size=512` completes in 3.5GB, at roughly double
-the per-iteration time — so what it actually reaches depends on the headroom the
-heap is given. The memory is not released when the file's benchmarks finish,
-because the harness has no teardown seam `Deno.bench` can call, so whatever it
-reaches is held for the rest of the job. `deno bench` picks its own order and
-put this file first in every ordering tried, which means the rest of the job
-runs beside it.
+is worth knowing before adding a voter to it. **Measured on a four-core CI host
+with 15.6GB of memory: 89 seconds for the file, peaking at 4.76GB resident** —
+under a third of that host, with around 9GB still free, so it runs with room
+rather than close to the edge. A developer machine with far more memory peaks
+higher, at 5.4GB, because the figure is a working set rather than a leak: the
+same run under `--max-old-space-size=512` completes in 3.5GB at roughly double
+the per-iteration time, so what it reaches depends on the headroom the heap is
+given rather than on what it needs.
+
+That peak is a floor under everything measured after it. The workers are
+released at process exit — `Deno.bench` offers no seam for "this file's
+benchmarks are done", so the file closes the harness from an `unload` listener —
+and `deno bench` picks its own order, which put this file first in every
+ordering tried. So the rest of the job runs beside it.
 
 `packages/patterns/integration/lunch-poll-keyed-votes.test.ts` is the assertion
 half of the same property: it bounds rolled-back writes instead of timing them,

--- a/docs/features/keyed-collection-writes.md
+++ b/docs/features/keyed-collection-writes.md
@@ -81,10 +81,10 @@ mergeable ops plus plain entity edits:
   handler falls the path back to a whole-array diff (see
   `mergeable-collection-writes.md`).
 
-The lunch poll derives a vote's key as `JSON.stringify([voterName, optionId])`
-and an option's key as its generated `id`; castVote, clearMyVote, and the
-removeOption cascade all recompute the same key, so they reach the same entity
-without scanning the list.
+The lunch poll derives a vote's key from the voter's profile entity and the
+option id, and an option's key from its generated `id`; castVote, clearMyVote,
+and the removeOption cascade all recompute the same key through `voteKeyFor`,
+so they reach the same entity without scanning the list.
 
 ## Why this instead of server-side keyed ops
 

--- a/docs/features/keyed-collection-writes.md
+++ b/docs/features/keyed-collection-writes.md
@@ -14,20 +14,19 @@ that make such a migration look finished while it is not, see
 
 ## The lunch poll's read-then-write inventory
 
-Every mutating handler in `packages/patterns/lunch-poll`, by shape, and the
-mergeable form it now uses:
+Every list-mutating handler in `packages/patterns/lunch-poll`, by what it
+mutates and the form it uses. The poll is the worked example because a lunch
+decision is the contended case: everyone votes at once, on the same list.
 
-| Handler | Original shape | Mergeable form |
+| Handler | What it mutates | Form |
 | --- | --- | --- |
-| `addOption` | append a new option | set the option entity by id, `addUnique` it |
-| `enrichHomePages` | `refresh.set(get() + 1)` | `increment(1)` |
-| `addUser` | insert unique by `name` | unchanged — see "The danger with push" |
-| `castVote` | upsert by `(voter, option)` with toggle-off | read/edit the vote entity by key; `addUnique` / `removeByValue` |
-| `setOptionUrl` / `setOptionImage` / `setOptionHomePageUrl` | edit a field of the option keyed by `id` | edit the field on the option entity addressed by `id` |
-| `removeOption` | remove by `id`, then remove its votes | `removeByValue` the option by id; cascade `removeByValue` each vote by its key |
-| `clearMyVote` | remove by `(voter, option)` | `removeByValue` the vote by key |
-| `resetVotes` | clear all (admin only) | clear each vote entity, then `set([])` — an intentional overwrite |
-| `setCity` | scalar register (admin only) | unchanged — `set` is fine |
+| `addOption` | insert an option if its id is new | set the option entity by id, `addUnique` it |
+| `setOptionImage` | edit one field of the option with a given id | edit the field on the option entity addressed by `id` |
+| `removeOption` | remove an option, then its votes | `removeByValue` the option by id; cascade `removeByValue` each vote by its key |
+| `castVote` | upsert by `(voter, option)`, with toggle-off | read/edit the vote entity by key; `addUnique` / `removeByValue` |
+| `clearMyVote` | remove by `(voter, option)` | `removeByValue` the vote by key, then clear its entity |
+| `resetVotes` | clear every vote (host only) | clear each vote entity, then `set([])` — an intentional overwrite |
+| `logVisit` | append a visit, then cap the log | one read-modify-write `set` — the cap is derived from the list |
 
 The bulk are **keyed** mutations of a list of records: insert-if-new, set my
 value, edit a record's field, delete a record. Written as read-whole-list,
@@ -36,6 +35,18 @@ false-conflict and clobber under the concurrency a shared multi-user poll has,
 and the positional `key(idx)` is fragile: the index is resolved against the
 reader's snapshot, so a concurrent insert or remove shifts it and the wrong
 record is edited.
+
+A vote's key is `(the voter's profile entity, the option id)`, minted by
+`voteKeyFor` in the poll's `main.tsx`. Identity there is a profile CELL rather
+than a name, and a cell is not a string, so the key takes the entity the cell
+points at. That keeps the key computable from the event alone, which is the
+property the whole scheme rests on: a handler that had to search the list for
+its voter would put the list back in its conflict set and give up the merge.
+
+`packages/patterns/integration/lunch-poll-keyed-votes.test.ts` holds the poll
+to this. It has one session read another session's vote at that address, which
+only succeeds if the vote was stored as a keyed element — the tally reads the
+same either way, so nothing lighter than an address can tell the two apart.
 
 ## The model: a keyed element is a separately-addressed entity
 
@@ -151,17 +162,24 @@ whole-list read this design exists to avoid.
 
 ## Back-compatibility: addressing scheme changes
 
-This moves the poll's options and votes from append-addressed entities (a `push`
-mints the entity id from a per-frame counter folded together with the event
-cause) to content-addressed entities (`elementById` derives the id from the key
-alone). The two id derivations never coincide, so a poll created before this
-change holds options and votes the new handlers cannot reach:
-`options.elementById(id).get()` and `votes.elementById(key).get()` return
-undefined for pre-existing records, so editing or removing an old option
-silently no-ops, and toggling an old vote adds a parallel new-scheme vote that
-double-counts in the tally. There is no data migration for pattern instances, so
-this applies to fresh polls; existing deployed polls would need to be recreated
-to benefit.
+A keyed entity's id comes from its key alone. An appended one's comes from a
+per-frame counter folded together with the event cause, and a record written as
+part of a whole-list value gets an id minted from that write. None of those
+derivations coincide, so a collection that moves to keyed addressing leaves
+every record already in it unreachable from the new handlers:
+`options.elementById(id).get()` and `votes.elementById(key).get()` read
+undefined for such a record. Editing or removing an old option then silently
+no-ops, and casting over an old vote adds a second, keyed vote beside it, so the
+voter counts twice.
+
+There is no data migration for pattern instances, and no per-handler legacy
+fallback either — `migrating-collection-writes.md` says why the fallback costs
+more than it looks. A populated instance is recreated, or repaired once by a
+handler that already rewrites the whole collection. The poll has one: `resetVotes`
+is a whole-list overwrite, so it reaches rows no key can name, and a host
+clearing the board is the repair for a poll carrying votes from before its
+votes were keyed. Options have no such handler; a poll whose options predate
+their keyed addressing is recreated.
 
 ## The danger with `push`, and making it safe
 

--- a/packages/patterns/cozy-poll/main.test.tsx
+++ b/packages/patterns/cozy-poll/main.test.tsx
@@ -11,7 +11,8 @@
  * are covered by multi-user.test.tsx.
  */
 
-import { action, assert, pattern, TESTS } from "commonfabric";
+import { action, assert, pattern, TESTS, UI } from "commonfabric";
+import { findNode, hasExactText } from "../test/vnode-helpers.ts";
 import CozyPoll from "./main.tsx";
 
 export default pattern(() => {
@@ -144,6 +145,31 @@ export default pattern(() => {
     poll.adminName === "Alex" && poll.isAdmin === true
   );
 
+  // The empty state is the whole board before anyone adds an option, and its
+  // job is to say who can do something about that. It reads differently to a
+  // viewer with no host to wait for than to the host themselves, so both are
+  // checked; the remaining branch names somebody else and needs the second
+  // identity multi-user.test.tsx has.
+  const assert_empty_state_awaits_a_host = assert(() =>
+    poll.optionCount === 0 &&
+    findNode(poll[UI], (node) => hasExactText(node, "No options yet")) !==
+      undefined &&
+    findNode(
+        poll[UI],
+        (node) => hasExactText(node, "Waiting for a host to join."),
+      ) !== undefined
+  );
+
+  const assert_empty_state_prompts_the_host = assert(() =>
+    poll.optionCount === 0 &&
+    findNode(poll[UI], (node) => hasExactText(node, "No options yet")) !==
+      undefined &&
+    findNode(
+        poll[UI],
+        (node) => hasExactText(node, "Add the first one above."),
+      ) !== undefined
+  );
+
   return {
     [TESTS]: [
       // Admin-gated handlers are no-ops before anyone joins (myName empty).
@@ -155,6 +181,8 @@ export default pattern(() => {
       { action: action_try_add_before_join },
       { action: action_try_remove_before_join },
       { action: action_try_reset_before_join },
+      // Nobody has joined, so the board has no host to name.
+      { assertion: assert_empty_state_awaits_a_host },
 
       // First join → claims admin
       { action: action_join_as_alex },
@@ -167,6 +195,9 @@ export default pattern(() => {
       // claimHost is a harmless no-op when the caller is already host.
       { action: action_claim_host },
       { assertion: assert_still_alex_host },
+
+      // Alex hosts now, so the same empty board asks him for the first option.
+      { assertion: assert_empty_state_prompts_the_host },
 
       // Admin adds options
       { action: action_add_chipotle },

--- a/packages/patterns/integration/fixtures/lunch-poll-keyed-votes/main.tsx
+++ b/packages/patterns/integration/fixtures/lunch-poll-keyed-votes/main.tsx
@@ -1,0 +1,156 @@
+import {
+  Default,
+  handler,
+  NAME,
+  pattern,
+  type PerSpace,
+  Stream,
+  UI,
+  type VNode,
+  Writable,
+} from "commonfabric";
+import LunchPoll, {
+  type AddOptionEvent,
+  type CastVoteEvent,
+  type ClearVoteEvent,
+  type JoinEvent,
+  type LunchProfile,
+  type Option,
+  type RemoveOptionEvent,
+  type ResetVotesEvent,
+  type ViewerOverride,
+  type Vote,
+  voteKeyFor,
+} from "../../../lunch-poll/main.tsx";
+
+/**
+ * Headless identity harness and keyed-address probe for the lunch poll —
+ * fixture for lunch-poll-keyed-votes.test.ts.
+ *
+ * Two jobs, neither of which changes what the poll does.
+ *
+ * IDENTITY. The poll's identity is a shared `#profile` cell, and that wish does
+ * not resolve in the multi-runtime harness's self-hosted server, so a session
+ * there can never join and never vote. `claim` supplies what the wish would: a
+ * shared-space profile per claimed name, handed to the poll through its
+ * `overrideViewer` seam. One session claims "Alice", another claims "Bob", and
+ * the poll sees two participants whose identities are two distinct documents —
+ * the production shape. The profile must be a document of the shared space,
+ * never a per-user scoped cell: a scoped cell is one ADDRESS read through the
+ * reader's own partition, so every session would store the same identity in the
+ * roster and the second joiner would dedup into the first.
+ *
+ * ADDRESS. `probeVote` reads the vote list at the address the poll's own key
+ * derivation names, and publishes what it finds as `probedVote`. That read
+ * consults one entity and never the list, so it finds a vote only if the poll
+ * stored it as a keyed element. The fixture holds the `votes` cell and hands it
+ * to the poll so both name one document, which is what gives the probe a
+ * writable handle to address elements from.
+ *
+ * `probedVote` is one slot shared by every session, so a test probes one
+ * address at a time and reads the answer before probing the next.
+ */
+
+export interface KeyedVoteProbeInput {
+  /** One profile document per claimed name, keyed by that name. */
+  profiles?: PerSpace<LunchProfile[] | Default<[]>>;
+
+  /** The poll's vote list, held here so the probe can address its elements. */
+  votes?: PerSpace<Vote[] | Default<[]>>;
+}
+
+export interface ClaimEvent {
+  name: string;
+}
+
+/** Which vote to look up: whose (by claimed name) and for which option. */
+export interface ProbeVoteEvent {
+  voterName: string;
+  optionId: string;
+}
+
+/** What the vote list holds at one keyed address, or `null` for nothing. */
+export interface ProbedVote {
+  optionId: string;
+  voteType: string;
+}
+
+export interface KeyedVoteProbeOutput {
+  [NAME]: string;
+  [UI]: VNode;
+  claim: Stream<ClaimEvent>;
+  probeVote: Stream<ProbeVoteEvent>;
+  joinAs: Stream<JoinEvent>;
+  addOption: Stream<AddOptionEvent>;
+  removeOption: Stream<RemoveOptionEvent>;
+  castVote: Stream<CastVoteEvent>;
+  clearMyVote: Stream<ClearVoteEvent>;
+  resetVotes: Stream<ResetVotesEvent>;
+  probedVote: ProbedVote | null;
+  votes: readonly Vote[];
+  options: readonly Option[];
+  users: readonly { name: string }[];
+  joinMessage: string;
+  voteCount: number;
+  optionCount: number;
+  userCount: number;
+  myName: string;
+  isJoined: boolean;
+  isAdmin: boolean;
+}
+
+const claim = handler<ClaimEvent, {
+  profiles: Writable<LunchProfile[]>;
+  overrideViewer: Stream<ViewerOverride>;
+}>(({ name }, { profiles, overrideViewer }) => {
+  const profile = profiles.elementById(name);
+  profile.set({ name });
+  profiles.addUnique(profile);
+  overrideViewer.send({ profile, name });
+});
+
+const probeVote = handler<ProbeVoteEvent, {
+  profiles: Writable<LunchProfile[]>;
+  votes: Writable<Vote[]>;
+  probedVote: Writable<ProbedVote | null>;
+}>(({ voterName, optionId }, { profiles, votes, probedVote }) => {
+  const key = voteKeyFor(profiles.elementById(voterName), optionId);
+  const found = key === undefined
+    ? undefined
+    : votes.elementById(key).get() as Vote | undefined;
+  probedVote.set(
+    found === undefined
+      ? null
+      : { optionId: found.optionId, voteType: found.voteType },
+  );
+});
+
+export default pattern<KeyedVoteProbeInput, KeyedVoteProbeOutput>(
+  ({ profiles, votes }) => {
+    const poll = LunchPoll({ votes });
+    const probed = Writable.of<ProbedVote | null>(null);
+    return {
+      [NAME]: "Lunch poll keyed-vote probe",
+      [UI]: <div>lunch poll keyed-vote probe</div>,
+      claim: claim({ profiles, overrideViewer: poll.overrideViewer }),
+      probeVote: probeVote({ profiles, votes, probedVote: probed }),
+      joinAs: poll.joinAs,
+      addOption: poll.addOption,
+      removeOption: poll.removeOption,
+      castVote: poll.castVote,
+      clearMyVote: poll.clearMyVote,
+      resetVotes: poll.resetVotes,
+      probedVote: probed,
+      votes: poll.votes,
+      options: poll.options,
+      users: poll.users,
+      joinMessage: poll.joinMessage,
+      voteCount: poll.voteCount,
+      optionCount: poll.optionCount,
+      userCount: poll.userCount,
+      myName: poll.myName,
+      isJoined: poll.isJoined,
+      isAdmin: poll.isAdmin,
+    };
+  },
+);

--- a/packages/patterns/integration/lunch-poll-keyed-votes.test.ts
+++ b/packages/patterns/integration/lunch-poll-keyed-votes.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Regression test: a lunch-poll vote is a KEYED, mergeable write.
+ *
+ * `castVote` addresses one vote by `(voter profile entity, option)` and manages
+ * membership with `addUnique` / `removeByValue`. It never reads or rewrites the
+ * whole vote list, so two people voting at the same time touch different
+ * documents and their commits merge instead of conflicting and retrying.
+ *
+ * This is the property nothing else here could see. `main.test.tsx` drives one
+ * runtime, so nothing in it is ever concurrent. `lunch-poll-vote.test.ts` drives
+ * two browsers but asserts the OUTCOME — "2 love it" on both — and a whole-list
+ * read-modify-write reaches that same outcome, by conflicting and retrying until
+ * it converges. `packages/runner/test/array-push-mergeable.test.ts` covers
+ * `elementById` / `addUnique` / `removeByValue` with hand-built cells, and the
+ * machinery was never what broke. So a vote write can regress to
+ * `votes.set([...])` with every one of them still green, while voting quietly
+ * becomes a contention storm.
+ *
+ * What catches that is where the vote LIVES, not what the tally says. A keyed
+ * write puts the vote at an address every session can compute; a whole-list
+ * write puts it at an address minted from the writer's own commit, which no
+ * other session can name. So the first test has one session read another
+ * session's vote by key alone. Under a whole-list write the tally still reads
+ * right and that read finds nothing.
+ *
+ * The second test is the same property in the units a person feels, and it is a
+ * bound rather than an equality: a keyed vote still shares its commit with the
+ * work the poll's derived views do, and that work reads the whole list. This
+ * file's own burst — three voters, four options, three rounds — measured 25
+ * rolled-back writes keyed against 63 whole-list (2026-09-01, this harness), so
+ * the bound of one per vote sits between them with room either side.
+ *
+ * The poll's identity is a shared `#profile` cell and that wish does not resolve
+ * in this harness, so the sessions claim identities through the
+ * `lunch-poll-keyed-votes` fixture. Everything under test is the poll's own
+ * handlers, driven through the poll's own streams.
+ *
+ * No toolshed or browser required (Deno workers + in-process storage server).
+ */
+
+import { expect } from "@std/expect";
+import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
+import { join } from "@std/path";
+import {
+  MultiRuntimeHarness,
+  type MultiRuntimeSession,
+} from "./multi-runtime-harness.ts";
+
+const ROOT_PATH = join(import.meta.dirname!, "..");
+const PROGRAM_PATH = join(
+  ROOT_PATH,
+  "integration",
+  "fixtures",
+  "lunch-poll-keyed-votes",
+  "main.tsx",
+);
+
+const NAMES = ["Alice", "Bob", "Carol"] as const;
+const TITLES = ["Cheeseboard", "Gregoire", "Saul's", "Fava"] as const;
+const COLORS = ["green", "yellow", "red"] as const;
+
+/**
+ * Optimistic writes these sessions had rolled back — each one applied locally,
+ * refused by the server over a stale read, and undone. This is the cost a keyed
+ * write is here to avoid, counted.
+ */
+async function reverts(
+  sessions: readonly MultiRuntimeSession[],
+): Promise<number> {
+  const each = await Promise.all(sessions.map(async (session) => {
+    const counts = await session.loggerCounts();
+    return counts["storage.v2"]?.["commit-revert"]?.total ?? 0;
+  }));
+  return each.reduce((sum, n) => sum + n, 0);
+}
+
+describe("lunch poll: a vote is a keyed, mergeable write", () => {
+  let harness: MultiRuntimeHarness;
+  let everyone: MultiRuntimeSession[];
+  let host: MultiRuntimeSession;
+  let options: string[];
+
+  beforeAll(async () => {
+    harness = await MultiRuntimeHarness.create({
+      programPath: PROGRAM_PATH,
+      rootPath: ROOT_PATH,
+      sessions: NAMES.map((name) => ({ label: name.toLowerCase() })),
+    });
+    everyone = NAMES.map((name) => harness.session(name.toLowerCase()));
+    host = everyone[0];
+
+    // Each session claims its own profile and joins. The first to join hosts,
+    // and only the host may add options.
+    for (let i = 0; i < everyone.length; i++) {
+      await everyone[i].send("claim", { name: NAMES[i] });
+      await harness.settle();
+      await everyone[i].send("joinAs", {});
+      await harness.settle();
+    }
+    expect(await host.read(["userCount"])).toBe(NAMES.length);
+
+    for (const title of TITLES) {
+      await host.send("addOption", { title });
+      await harness.settle();
+    }
+    options = (await host.read(["options"]) as { id: string }[])
+      .map((option) => option.id);
+    expect(options.length).toBe(TITLES.length);
+  });
+
+  afterAll(async () => {
+    await harness?.dispose();
+  });
+
+  it("stores a cast vote where another session reaches it by key", async () => {
+    // The whole contract in one read. Alice votes; Bob computes the address of
+    // Alice's vote from her profile and the option — no list involved — and
+    // finds the vote there. A vote written as part of a whole-list value lives
+    // at an address minted from Alice's own commit, which Bob cannot name, so
+    // this read comes back empty while the tally still says one vote.
+    const [alice, bob] = everyone;
+    const option = options[0];
+
+    await alice.send("castVote", { optionId: option, voteType: "green" });
+    await harness.settle();
+    expect(await alice.read(["voteCount"])).toBe(1);
+
+    await bob.send("probeVote", { voterName: "Alice", optionId: option });
+    await harness.settle();
+    expect(
+      await bob.read(["probedVote"]),
+      "another session must reach the vote by its key alone; nothing here " +
+        "means the vote was stored as part of a whole-list write",
+    ).toEqual({ optionId: option, voteType: "green" });
+
+    // Clearing drops the membership AND the entity, so the address goes empty
+    // rather than keeping the removed vote's content for the next reader.
+    await alice.send("clearMyVote", { optionId: option });
+    await harness.settle();
+    await bob.send("probeVote", { voterName: "Alice", optionId: option });
+    await harness.settle();
+    expect(await bob.read(["probedVote"])).toBe(null);
+    expect(await alice.read(["voteCount"])).toBe(0);
+  });
+
+  it("keeps a lunch-time burst from becoming a retry storm", async () => {
+    // Everyone re-votes every option at once, repeatedly — the shape of a real
+    // lunch decision, where a whole-list write makes each vote wait seconds.
+    // Warm up first so no session is paying for a document it has never held; a
+    // cold first write conflicts either way and is not what this measures.
+    for (const session of everyone) {
+      for (const option of options) {
+        await session.send("castVote", { optionId: option, voteType: "green" });
+        await harness.settle();
+      }
+    }
+    const cast = everyone.length * options.length;
+    expect(await host.read(["voteCount"])).toBe(cast);
+
+    await harness.settle();
+    const before = await reverts(everyone);
+    const rounds = 3;
+    for (let round = 0; round < rounds; round++) {
+      await Promise.all(
+        everyone.flatMap((session, voter) =>
+          options.map((option, index) =>
+            session.send(
+              "castVote",
+              {
+                optionId: option,
+                voteType: COLORS[(voter + index + round) % COLORS.length],
+              },
+              undefined,
+              { idle: false },
+            )
+          )
+        ),
+      );
+      await harness.settle();
+    }
+    const rolledBack = await reverts(everyone) - before;
+
+    // One vote per (voter, option) throughout: the burst recast them in place.
+    expect(await host.read(["voteCount"])).toBe(cast);
+    expect(
+      rolledBack,
+      `${rolledBack} rolled-back writes for ${cast * rounds} votes; a vote ` +
+        "should cost well under one rollback, and more than one apiece means " +
+        "the vote write is contending on the whole list again",
+    ).toBeLessThan(cast * rounds);
+  });
+});

--- a/packages/patterns/integration/lunch-poll-vote-burst.bench.ts
+++ b/packages/patterns/integration/lunch-poll-vote-burst.bench.ts
@@ -28,12 +28,12 @@
  * assertion half of the same property, bounding rolled-back writes rather than
  * timing them.
  *
- * Sample count is the weak point, and it is inherent. One iteration is around
- * half a second on a developer machine, so a run collects few samples, and the
- * 75th percentile the dashboard trend reads only discards the slowest quarter
- * of what it collected — a runner that stalls twice in a handful of samples
- * moves this line without any code changing. Read it for the shape of a move
- * across several windows, not for one window against the last.
+ * Sample count is the weak point, and it is inherent. An iteration takes about
+ * 450ms on an Apple M5 Max and 2.6 seconds on a four-core CI host, so a run
+ * collects eleven or twelve samples either way. The 75th percentile the
+ * dashboard trend reads discards only the slowest quarter of those, so a runner
+ * that stalls twice moves this line without any code changing. Read it for the
+ * shape of a move across several windows, not for one window against the last.
  *
  * The setup — ten Deno workers, ten joins, ten options, and a warm-up burst —
  * runs once at module scope, outside every measurement, because it costs some
@@ -41,6 +41,13 @@
  * no samples. Each iteration recolors every vote, so all hundred are genuine
  * changes and the vote count holds at a hundred throughout; no iteration leaves
  * a state the next one starts from differently.
+ *
+ * Ten runtimes is the largest footprint of any benchmark in the job. Measured
+ * on a four-core CI host with 15.6GB of memory: the whole file takes 89 seconds
+ * and peaks at 4.76GB resident, which is under a third of that host and leaves
+ * the rest of the job room. The peak is held to the end of the process, because
+ * the workers are released at exit rather than when this file's benchmarks
+ * finish, so it is a floor under everything measured after it.
  *
  * `CF_LUNCH_POLL_VOTERS` and `CF_LUNCH_POLL_OPTIONS` resize it for a local run
  * asking how the burst scales. The size is part of the measurement and names

--- a/packages/patterns/integration/lunch-poll-vote-burst.bench.ts
+++ b/packages/patterns/integration/lunch-poll-vote-burst.bench.ts
@@ -42,12 +42,13 @@
  * changes and the vote count holds at a hundred throughout; no iteration leaves
  * a state the next one starts from differently.
  *
- * Ten runtimes is the largest footprint of any benchmark in the job. Measured
- * on a four-core CI host with 15.6GB of memory: the whole file takes 89 seconds
- * and peaks at 4.76GB resident, which is under a third of that host and leaves
- * the rest of the job room. The peak is held to the end of the process, because
- * the workers are released at exit rather than when this file's benchmarks
- * finish, so it is a floor under everything measured after it.
+ * Ten runtimes is the largest footprint of any benchmark in the job. On a
+ * default hosted runner — four cores, 15.6GB — the whole file takes 89 seconds
+ * and peaks at 4.76GB resident, under a third of that host; the group the
+ * benchmarks workflow runs on is larger still. The peak is held to the end of
+ * the process, because the workers are released at exit rather than when this
+ * file's benchmarks finish, so it is a floor under everything measured after
+ * it.
  *
  * `CF_LUNCH_POLL_VOTERS` and `CF_LUNCH_POLL_OPTIONS` resize it for a local run
  * asking how the burst scales. The size is part of the measurement and names

--- a/packages/patterns/integration/lunch-poll-vote-burst.bench.ts
+++ b/packages/patterns/integration/lunch-poll-vote-burst.bench.ts
@@ -141,19 +141,32 @@ async function burst(round: number): Promise<void> {
   await harness.settle();
 }
 
-/** Optimistic writes rolled back across every session so far. */
+/**
+ * Rejected commits and rolled-back optimistic writes across every session so
+ * far, and whether the counters they come from were there to read.
+ *
+ * A missing counter reads as zero, which is the same number a clean run
+ * reports, so the two are distinguished here rather than left to look alike:
+ * the accounting is the half of this benchmark a timing cannot show, and an
+ * accounting that cannot fail is not one worth printing. `storage.v2` counts
+ * these even when the logger is silent, so a session that reports no such
+ * logger at all has stopped answering rather than stopped conflicting.
+ */
 async function reverts(sessions: readonly MultiRuntimeSession[]) {
   const each = await Promise.all(sessions.map(async (session) => {
     const counts = await session.loggerCounts();
+    const storage = counts["storage.v2"];
     return {
-      conflicts: counts["storage.v2"]?.["commit-conflict"]?.total ?? 0,
-      reverts: counts["storage.v2"]?.["commit-revert"]?.total ?? 0,
+      conflicts: storage?.["commit-conflict"]?.total ?? 0,
+      reverts: storage?.["commit-revert"]?.total ?? 0,
+      counted: storage !== undefined,
     };
   }));
   return each.reduce((total, one) => ({
     conflicts: total.conflicts + one.conflicts,
     reverts: total.reverts + one.reverts,
-  }), { conflicts: 0, reverts: 0 });
+    counting: total.counting + (one.counted ? 1 : 0),
+  }), { conflicts: 0, reverts: 0, counting: 0 });
 }
 
 // Warm-up: every session materializes the vote list and its own keyed vote
@@ -171,7 +184,8 @@ console.error(
   `[lunch-poll vote burst] ${voters.length} voters x ${options.length} ` +
     `options = ${votes} votes per burst; one burst cost ` +
     `${after.conflicts - before.conflicts} rejected commit(s) and ` +
-    `${after.reverts - before.reverts} rolled-back write(s)`,
+    `${after.reverts - before.reverts} rolled-back write(s), counted over ` +
+    `${after.counting}/${voters.length} sessions`,
 );
 
 // `Deno.bench` has no hook for "the file's benchmarks are done", so the ten

--- a/packages/patterns/integration/lunch-poll-vote-burst.bench.ts
+++ b/packages/patterns/integration/lunch-poll-vote-burst.bench.ts
@@ -1,0 +1,178 @@
+/**
+ * How long a room full of people voting at once takes to agree.
+ *
+ * Ten voters each cast a vote on each of ten lunch options, every one of the
+ * hundred fired before any of them settles, and the measurement runs until
+ * every one of the ten clients has the whole result. That is the quantity a
+ * person actually waits on at lunchtime, and it is the one no other benchmark
+ * in the repository can see: every other bench file drives a single runtime
+ * against its own private storage server, where a second writer does not exist
+ * and a write conflict is unreachable by construction.
+ *
+ * What it is sensitive to. A vote is a keyed write — `castVote` addresses one
+ * vote by `(voter profile entity, option)` and adds it with `addUnique`, so a
+ * commit carries no read of the vote list and two voters never collide. Written
+ * instead as read-the-list, edit, write-the-list-back, every pair of votes in
+ * the burst collides: each loser's optimistic write is rolled back, it waits
+ * for the newer state, re-runs, and commits again. Both forms converge on the
+ * same tally, which is why the pattern's own tests cannot tell them apart, and
+ * why this is a benchmark rather than an assertion. The difference is entirely
+ * in how long it takes and how much is thrown away getting there.
+ *
+ * Reading the series. One number per iteration: hundred votes dispatched, then
+ * settled. On an Apple M5 Max the keyed write settles a burst in about 400ms
+ * having thrown nothing away, and the same burst over a whole-list write took
+ * 7 to 15 seconds and cost 430 rejected commits and 558 rolled-back writes —
+ * and dropped two votes for the length of one burst on the way.
+ * `packages/patterns/integration/lunch-poll-keyed-votes.test.ts` is the
+ * assertion half of the same property, bounding rolled-back writes rather than
+ * timing them.
+ *
+ * Sample count is the weak point, and it is inherent. One iteration is around
+ * half a second on a developer machine, so a run collects few samples, and the
+ * 75th percentile the dashboard trend reads only discards the slowest quarter
+ * of what it collected — a runner that stalls twice in a handful of samples
+ * moves this line without any code changing. Read it for the shape of a move
+ * across several windows, not for one window against the last.
+ *
+ * The setup — ten Deno workers, ten joins, ten options, and a warm-up burst —
+ * runs once at module scope, outside every measurement, because it costs some
+ * twelve seconds and repeating it per iteration would leave a run with almost
+ * no samples. Each iteration recolors every vote, so all hundred are genuine
+ * changes and the vote count holds at a hundred throughout; no iteration leaves
+ * a state the next one starts from differently.
+ *
+ * `CF_LUNCH_POLL_VOTERS` and `CF_LUNCH_POLL_OPTIONS` resize it for a local run
+ * asking how the burst scales. The size is part of the measurement and names
+ * the series, so changing it starts a new line rather than continuing this one;
+ * CI leaves both unset. The size in force, and a contention accounting taken
+ * over one untimed burst, are written to stderr and so into the run's
+ * `diagnostics.log`.
+ *
+ * No toolshed and no browser: the harness hosts its own storage server in
+ * process. The runtime inside each worker reports that it cannot compile the
+ * `#profile` create surface, which is why the poll is driven through the
+ * `lunch-poll-keyed-votes` fixture's own identity seam; those lines are the
+ * harness's, not this file's.
+ */
+
+import { join } from "@std/path";
+import {
+  MultiRuntimeHarness,
+  type MultiRuntimeSession,
+} from "./multi-runtime-harness.ts";
+
+const GROUP = "lunch poll";
+const ROOT_PATH = join(import.meta.dirname!, "..");
+const PROGRAM_PATH = join(
+  ROOT_PATH,
+  "integration",
+  "fixtures",
+  "lunch-poll-keyed-votes",
+  "main.tsx",
+);
+
+const COLORS = ["green", "yellow", "red"] as const;
+
+function sizeFromEnv(name: string, fallback: number): number {
+  const raw = Deno.env.get(name);
+  if (raw === undefined || raw === "") return fallback;
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < 1) {
+    throw new Error(`${name} must be a positive integer; got ${raw}`);
+  }
+  return value;
+}
+
+const VOTERS = sizeFromEnv("CF_LUNCH_POLL_VOTERS", 10);
+const OPTIONS = sizeFromEnv("CF_LUNCH_POLL_OPTIONS", 10);
+
+const NAMES = Array.from({ length: VOTERS }, (_, i) => `Voter ${i + 1}`);
+const TITLES = Array.from({ length: OPTIONS }, (_, i) => `Place ${i + 1}`);
+
+const harness = await MultiRuntimeHarness.create({
+  programPath: PROGRAM_PATH,
+  rootPath: ROOT_PATH,
+  sessions: NAMES.map((_, index) => ({ label: `voter-${index + 1}` })),
+});
+const voters = harness.sessions;
+
+// Each session claims its own profile and joins. The first to join hosts, and
+// only the host may add options.
+for (let i = 0; i < voters.length; i++) {
+  await voters[i].send("claim", { name: NAMES[i] });
+  await harness.settle();
+  await voters[i].send("joinAs", {});
+  await harness.settle();
+}
+for (const title of TITLES) {
+  await voters[0].send("addOption", { title });
+  await harness.settle();
+}
+const options = (await voters[0].read(["options"]) as { id: string }[])
+  .map((option) => option.id);
+
+const votes = voters.length * options.length;
+
+/** Fire every vote before any of them settles, then settle all of them. */
+async function burst(round: number): Promise<void> {
+  await Promise.all(
+    voters.flatMap((voter, index) =>
+      options.map((option, position) =>
+        voter.send(
+          "castVote",
+          {
+            optionId: option,
+            voteType: COLORS[(index + position + round) % COLORS.length],
+          },
+          undefined,
+          { idle: false },
+        )
+      )
+    ),
+  );
+  await harness.settle();
+}
+
+/** Optimistic writes rolled back across every session so far. */
+async function reverts(sessions: readonly MultiRuntimeSession[]) {
+  const each = await Promise.all(sessions.map(async (session) => {
+    const counts = await session.loggerCounts();
+    return {
+      conflicts: counts["storage.v2"]?.["commit-conflict"]?.total ?? 0,
+      reverts: counts["storage.v2"]?.["commit-revert"]?.total ?? 0,
+    };
+  }));
+  return each.reduce((total, one) => ({
+    conflicts: total.conflicts + one.conflicts,
+    reverts: total.reverts + one.reverts,
+  }), { conflicts: 0, reverts: 0 });
+}
+
+// Warm-up: every session materializes the vote list and its own keyed vote
+// entities, so no measured iteration pays a first-write cost.
+await burst(0);
+await burst(1);
+
+// Contention accounting, over one burst that no measurement covers. What a
+// regression in the vote write costs shows up here as writes thrown away,
+// beside the wall-clock the benchmark reports.
+const before = await reverts(voters);
+await burst(2);
+const after = await reverts(voters);
+console.error(
+  `[lunch-poll vote burst] ${voters.length} voters x ${options.length} ` +
+    `options = ${votes} votes per burst; one burst cost ` +
+    `${after.conflicts - before.conflicts} rejected commit(s) and ` +
+    `${after.reverts - before.reverts} rolled-back write(s)`,
+);
+
+let round = 3;
+
+Deno.bench({
+  name: `vote burst ${voters.length}x${options.length}`,
+  group: GROUP,
+  async fn() {
+    await burst(round++);
+  },
+});

--- a/packages/patterns/integration/lunch-poll-vote-burst.bench.ts
+++ b/packages/patterns/integration/lunch-poll-vote-burst.bench.ts
@@ -167,6 +167,11 @@ console.error(
     `${after.reverts - before.reverts} rolled-back write(s)`,
 );
 
+// `Deno.bench` has no hook for "the file's benchmarks are done", so the ten
+// workers are released at process exit instead, where the listener runs
+// synchronously and `terminate()` is the form that fits.
+globalThis.addEventListener("unload", () => harness.terminate());
+
 let round = 3;
 
 Deno.bench({

--- a/packages/patterns/integration/multi-runtime-harness.ts
+++ b/packages/patterns/integration/multi-runtime-harness.ts
@@ -619,4 +619,17 @@ export class MultiRuntimeHarness {
     }
     await this.#server?.close();
   }
+
+  /**
+   * Drop every worker without asking it to shut down first, for a caller that
+   * has no `await` to spend — a process-exit listener, which Deno runs
+   * synchronously. `dispose()` is the ordinary path and says goodbye properly;
+   * this one exists so a harness held for the life of a process is still
+   * released deterministically rather than left to process teardown. The
+   * in-process server is not closed, because closing it is asynchronous and it
+   * has nothing outside this process to release.
+   */
+  terminate(): void {
+    for (const session of this.sessions) session.client().terminate();
+  }
 }

--- a/packages/patterns/lunch-poll/DEPLOY-AND-SHARE.md
+++ b/packages/patterns/lunch-poll/DEPLOY-AND-SHARE.md
@@ -206,6 +206,16 @@ result cell and its populated inputs. **Adding a new `PerSpace` field is safe**
 — on an existing piece it hydrates to its `Default<>` while populated fields
 keep their data.
 
+> **Reset the votes after an update that changes how a vote is addressed.** A
+> vote lives at an address derived from its key — its voter's profile entity and
+> the option — and a poll may be carrying votes stored under some other scheme,
+> which no key names. Those rows still render and still tally, but the handlers
+> cannot reach them: casting over one adds a second, keyed vote beside it and
+> the voter counts twice. `setsrc` keeps them, so the host clears the board once
+> after the update (see "Resetting / re-seeding state"), and everyone votes
+> again. Votes are shown a day at a time anyway, so a reset costs the group
+> nothing they were still looking at.
+
 **Removing one is refused wherever the pattern publishes it.** A `PerSpace`
 field that also reaches the result is held by the result contract, and the
 compatibility check rejects a source that drops it, without touching the piece:

--- a/packages/patterns/lunch-poll/DEPLOY-AND-SHARE.md
+++ b/packages/patterns/lunch-poll/DEPLOY-AND-SHARE.md
@@ -275,8 +275,9 @@ MINE="$PIECE"
 ARG=$(deno task cf get --piece "$MINE" -s "$SPACE" --input --select '@' -q \
   | grep -oE '/of:fid1:[A-Za-z0-9_-]+')
 
-# 3. Copy each PerSpace field except the visit log and the host seat.
-for field in question users options votes; do
+# 3. Copy each PerSpace field except the votes, the visit log and the host seat.
+#    Votes are deliberately not copied — see below.
+for field in question users options; do
   deno task cf get --piece "$LEGACY_PIECE" -s "$SPACE" "$field" --input -q \
     | deno task cf set -s "$SPACE" "$ARG/$field" -q
 done
@@ -297,6 +298,18 @@ deno task cf get --piece "$LEGACY_PIECE" -s "$SPACE" visits --input -q \
 deno task cf piece step --piece "$MINE" -s "$SPACE"
 deno task cf piece inspect --piece "$MINE" -s "$SPACE" --summary
 ```
+
+**The votes do not come across, and copying them would be worse than losing
+them.** A vote lives at an address derived from its key — its voter's profile
+entity and the option — and a whole-list copy writes every row at an address the
+copy minted instead. The handlers address a vote by key, so they cannot reach a
+copied row: the first person to vote again for a place they had already voted
+for gets a second vote beside the copied one, and counts twice in every tally.
+Leaving `votes` out of step 3 starts the new piece empty, and everyone votes
+again. That costs the group nothing they were still looking at, because the poll
+only ever shows the current day's votes. The visit log is a different matter and
+does come across, at step 4: its vote snapshots are frozen records rather than
+live votes, and nothing addresses them by key.
 
 > **Why the copy writes to `$ARG` and not `cf set --input`.** A `cf set --input`
 > write validates the piece's whole input object, and this pattern's `viewer`

--- a/packages/patterns/lunch-poll/main.test.tsx
+++ b/packages/patterns/lunch-poll/main.test.tsx
@@ -399,6 +399,32 @@ export default pattern(() => {
     poll.options[0]?.addedByName === "Alex"
   );
 
+  // The empty state is the only thing on the board before anyone adds an
+  // option, and its job is to say who can do something about that. It reads
+  // differently to a viewer with no host to wait for than to the host
+  // themselves, so both are checked; between them they are every branch the
+  // hint has except the one naming somebody else, which needs a second
+  // identity and belongs to multi-user.test.tsx.
+  const assert_empty_state_awaits_a_host = assert(() =>
+    poll.optionCount === 0 &&
+    findNode(poll[UI], (node) => hasExactText(node, "No options yet")) !==
+      undefined &&
+    findNode(
+        poll[UI],
+        (node) => hasExactText(node, "Waiting for a host to join."),
+      ) !== undefined
+  );
+
+  const assert_empty_state_prompts_the_host = assert(() =>
+    poll.optionCount === 0 &&
+    findNode(poll[UI], (node) => hasExactText(node, "No options yet")) !==
+      undefined &&
+    findNode(
+        poll[UI],
+        (node) => hasExactText(node, "Add the first one above."),
+      ) !== undefined
+  );
+
   const assert_two_options = assert(() => poll.options.length === 2);
 
   const assert_green_vote_recorded = assert(() => {
@@ -722,6 +748,8 @@ export default pattern(() => {
       { action: action_try_log_before_join },
       { action: action_try_vote_before_join },
       { assertion: assert_no_vote_without_membership },
+      // Nobody has joined, so the board has no host to name.
+      { assertion: assert_empty_state_awaits_a_host },
 
       // First join → claims admin
       { action: action_join_as_alex },
@@ -734,6 +762,9 @@ export default pattern(() => {
       // claimHost is a harmless no-op when the caller is already host.
       { action: action_claim_host },
       { assertion: assert_still_alex_host },
+
+      // Alex hosts now, so the same empty board asks him for the first option.
+      { assertion: assert_empty_state_prompts_the_host },
 
       // Admin adds options
       { action: action_add_chipotle },

--- a/packages/patterns/lunch-poll/main.test.tsx
+++ b/packages/patterns/lunch-poll/main.test.tsx
@@ -320,6 +320,11 @@ export default pattern(() => {
     if (first) poll.castVote.send({ optionId: first.id, voteType: "green" });
   });
 
+  const action_clear_my_vote_first = action(() => {
+    const first = poll.options[0];
+    if (first) poll.clearMyVote.send({ optionId: first.id });
+  });
+
   const action_reset_votes = action(() => {
     poll.resetVotes.send({});
   });
@@ -430,6 +435,8 @@ export default pattern(() => {
   });
 
   const assert_revote_green_cleared = assert(() => poll.votes.length === 0);
+
+  const assert_my_vote_cleared = assert(() => poll.votes.length === 0);
 
   const assert_votes_reset = assert(() => poll.votes.length === 0);
 
@@ -753,6 +760,15 @@ export default pattern(() => {
 
       // Voting that same color once more re-adds it. A removed vote clears its
       // entity, so the toggle decision does not see stale content and dead-click.
+      { action: action_vote_green_first_again },
+      { assertion: assert_green_vote_recorded },
+
+      // Clearing my vote drops it, and casting that same color afterwards
+      // re-adds it: the clear discards the vote's stored content as well as
+      // its place in the list, so the next cast is not read as a toggle
+      // against the vote it just removed.
+      { action: action_clear_my_vote_first },
+      { assertion: assert_my_vote_cleared },
       { action: action_vote_green_first_again },
       { assertion: assert_green_vote_recorded },
 

--- a/packages/patterns/lunch-poll/main.tsx
+++ b/packages/patterns/lunch-poll/main.tsx
@@ -21,10 +21,11 @@
  * - Open host takeover: any joined participant can `claimHost`, transferring
  *   the role (and the host controls) to themselves. Deliberately ungated
  *   beyond "must be joined"; see `ADMIN-FUTURE.md`.
- * - A vote carries its voter's profile cell and is found by comparison, so a
- *   vote cannot be keyed by a mergeable per-vote write: two viewers voting at
- *   once conflict and the loser retries. Both votes survive; that retry is the
- *   accepted cost of identity that cannot be spoofed.
+ * - A vote carries its voter's profile cell, and its key is that profile's
+ *   ENTITY paired with the option. So a vote is addressed rather than searched
+ *   for: casting, recasting and clearing one read and write that vote alone,
+ *   two viewers voting at once touch different keys, and their commits merge
+ *   with no conflict and no retry.
  *
  * "We went here" history (Lunch Coordinator roadmap #1): the host logs where
  * the group actually ate via each option's "we went here" button. A host date
@@ -70,7 +71,9 @@ import {
   type Cell,
   computed,
   Default,
+  entityRefToString,
   equals,
+  getEntityId,
   handler,
   NAME,
   pattern,
@@ -405,21 +408,42 @@ const newOptionId = (
     ...votes.map((v) => v.optionId),
   ]);
 
-// A vote belongs to whoever's profile cell it carries, so it is found by
-// comparison rather than addressed by a key. Reading the list to find it puts
-// the list in this transaction's conflict set, so two people voting at once
-// conflict and the loser retries. That is the accepted trade for identity that
-// cannot be spoofed by a name: correctness is unaffected (both votes survive),
-// and once handler events serialize server-side they stop conflicting at all.
-const findVote = (
-  votes: readonly Vote[],
-  voter: LunchProfileCell,
+/**
+ * A vote's key: its voter's profile ENTITY and the option, in that order.
+ *
+ * One voter's vote for one option has a deterministic, content-only address, so
+ * casting, recasting and clearing it read and write that vote alone. Two people
+ * voting at once hold different keys and their commits merge. The same key
+ * names the same vote in every session, at any time, which is what lets a
+ * handler reach one vote without reading the list.
+ *
+ * Identity here is a profile cell, and a cell is not a string, so the key takes
+ * the entity the cell points at. `getEntityId` parses the link a cell or a
+ * read-back proxy carries, so this works both on `resolveAsCell()` in a caster
+ * and on `vote.voter` in a sweep. A vote whose `voter` is absent has no key.
+ *
+ * The address is part of the poll's storage contract, so it is exported;
+ * `packages/patterns/integration/lunch-poll-keyed-votes.test.ts` reads a cast
+ * vote back at this key from a session that never observed the write.
+ */
+export const voteKeyFor = (
+  voter: LunchProfileCell | undefined,
   optionId: string,
-): Vote | undefined =>
-  votes.find((v) => v.optionId === optionId && equals(v.voter, voter));
+): string | undefined => {
+  if (voter === undefined) return undefined;
+  const ref = getEntityId(voter);
+  if (ref === undefined) return undefined;
+  return JSON.stringify([entityRefToString(ref), optionId]);
+};
 
-const isSameVoter = (vote: Vote, voter: LunchProfileCell): boolean =>
-  equals(vote.voter, voter);
+// Clear a vote's entity document. The entity outlives its membership link, so a
+// removal that only drops the link would leave the entity holding the removed
+// vote's content; a later read by the same key (the castVote toggle decision)
+// would then see that stale content and treat the absent vote as present.
+const clearVoteEntity = (votes: VotesCell, key: string): void => {
+  const vote: Writable<Vote | undefined> = votes.elementById(key);
+  vote.set(undefined);
+};
 
 const COMBINING_MARK = /^\p{Mark}$/u;
 const EMOJI_MODIFIER = /^\p{Emoji_Modifier}$/u;
@@ -734,10 +758,18 @@ const removeOption = handler<RemoveOptionEvent, {
   const option = options.elementById(optionId);
   if (!option.get()) return;
   options.removeByValue(option);
-  // Cascade: drop every vote for the removed option in one read-modify-write.
-  // A concurrent cast conflicts with this read and retries, which is what
-  // catches a vote cast for this option after the read.
-  votes.set(votes.get().filter((v) => v.optionId !== optionId));
+  // Cascade: drop every vote for this option, each by its own key, so votes
+  // for other options merge through. The read of the vote list this sweep
+  // needs stays in the commit's conflict set, so a concurrent change to the
+  // list makes this commit retry, which is what catches a vote cast for this
+  // option after the read.
+  for (const v of votes.get()) {
+    if (v.optionId !== optionId) continue;
+    const key = voteKeyFor(v.voter, optionId);
+    if (key === undefined) continue;
+    votes.removeByValue(votes.elementById(key));
+    clearVoteEntity(votes, key);
+  }
 });
 
 const castVote = handler<CastVoteEvent, {
@@ -765,8 +797,13 @@ const castVote = handler<CastVoteEvent, {
   // votes): voting no-ops rather than reading an ambient clock.
   const now = nowTick;
   if (!now) return;
-  const current = votes.get();
-  const existing = findVote(current, myProfile, optionId);
+  // My vote for this option has a deterministic address, so this reads and
+  // edits just that one vote — never the whole list. Clicking the current
+  // color toggles the vote off; any other color sets it.
+  const key = voteKeyFor(voter, optionId);
+  if (key === undefined) return;
+  const myVote = votes.elementById(key);
+  const existing = myVote.get();
   // Toggle off only when the same color was cast TODAY. A same-color click on
   // a stale (hidden) vote re-casts it with a fresh timestamp instead of
   // removing a vote the voter cannot see.
@@ -774,17 +811,13 @@ const castVote = handler<CastVoteEvent, {
     existing.voteType === voteType &&
     typeof existing.castAt === "number" &&
     dayKeyOf(existing.castAt) === dayKeyOf(now);
-  const withoutMine = current.filter((v) =>
-    !(v.optionId === optionId && isSameVoter(v, myProfile))
-  );
   if (sameColorToday) {
-    votes.set(withoutMine);
+    votes.removeByValue(myVote);
+    clearVoteEntity(votes, key);
     return;
   }
-  votes.set([
-    ...withoutMine,
-    { voter, optionId, voteType, castAt: now },
-  ]);
+  myVote.set({ voter, optionId, voteType, castAt: now });
+  votes.addUnique(myVote);
 });
 
 const resetVotes = handler<ResetVotesEvent, {
@@ -793,6 +826,14 @@ const resetVotes = handler<ResetVotesEvent, {
   host: HostCell;
 }>((_, { votes, myProfile, host }) => {
   if (!isHost(host, myProfile)) return;
+  // Clearing the board is an intentional whole-list overwrite, so it empties
+  // the list itself and reaches rows no key names. Each vote's entity is
+  // cleared too, so a voter who re-casts their pre-reset color afterwards is
+  // not toggled off against content the reset left behind.
+  for (const v of votes.get()) {
+    const key = voteKeyFor(v.voter, v.optionId);
+    if (key !== undefined) clearVoteEntity(votes, key);
+  }
   votes.set([]);
 });
 
@@ -805,11 +846,12 @@ const clearMyVote = handler<ClearVoteEvent, {
   myProfile: LunchProfileCell | undefined;
 }>(({ optionId }, { votes, myProfile }) => {
   if (!myProfile) return;
-  votes.set(
-    votes.get().filter((v) =>
-      !(v.optionId === optionId && isSameVoter(v, myProfile))
-    ),
-  );
+  const voter = myProfile.resolveAsCell();
+  if (voter.get() === undefined) return;
+  const key = voteKeyFor(voter, optionId);
+  if (key === undefined) return;
+  votes.removeByValue(votes.elementById(key));
+  clearVoteEntity(votes, key);
 });
 
 // Host-only, same gate as the other mutating admin actions. Logs where the


### PR DESCRIPTION
A vote is written whole-list: `castVote` reads the entire `votes` array, filters the voter's previous entry out, and writes the array back. That read is a commit precondition, so any vote landing between one voter's read and their commit makes the read stale. The server rejects the commit, the optimistic write is rolled back, and the handler re-runs against the newer state. Every pair of people voting at the same moment therefore collides, and the collisions compound with the number of voters: on a poll with nine people and fourteen options, a vote took seconds to appear, for the voter who cast it and for everyone watching.

Address a vote by its key instead, as `addOption` and `removeOption` already address an option. The key is the voter's profile ENTITY paired with the option id, minted by the new exported `voteKeyFor`. Identity here is a profile cell rather than a name, and a cell is not a string, so the key takes the entity the cell points at, which `getEntityId` reads off the link a cell or a read-back proxy carries. That keeps the key computable from the event alone — the property the scheme rests on, since a handler that had to search the list for its voter would put the list straight back into its conflict set.

`castVote` then reads and writes one vote entity and manages membership with `addUnique`; its toggle-off, `clearMyVote`, and `removeOption`'s cascade use `removeByValue` and clear the entity behind the link, so a later cast is not read as a toggle against content a removal left behind. `resetVotes` stays a whole-list overwrite, which is what lets a host clear rows no key names. The one whole-list read left in the vote path is `removeOption`'s cascade sweep, which wants it: the conflict it keeps is what catches a vote cast for the option after the sweep read.

Ten voters casting on ten options at once now settle in about 400ms, having rejected no commits and rolled back no writes. The same burst over the whole-list write took 7 to 15 seconds, cost 430 rejected commits and 558 rolled-back writes, and left the poll two votes short for the length of a burst on the way.

Existing votes are not carried across. A record written as part of a whole-list value has an id minted from that commit, which no key names, so the handlers cannot reach one: casting over it adds a second, keyed vote beside it and the voter counts twice. The repository's position is that a populated instance is recreated rather than migrated per handler, and this pattern has a cheaper repair — the host clears the board once after the update, which the deploy guide now says to do. Votes are shown a day at a time anyway.

Two things made this invisible after it regressed. Nothing at the pattern level asserted the write SHAPE: the browser test asserts the tally reaches "2 love it", and a whole-list write reaches that same tally by conflicting and retrying until it converges. And nothing at the machinery level was wrong, so the runner's mergeable-write tests stayed green throughout. The compiler does not help either — it inspects `push`, and reports neither a read-then-`set` nor an `addUnique` that was replaced by one.

So the new test asserts where the vote LIVES. One session casts a vote; another session, which never observed that write, computes the address from the voter's profile and the option and reads the vote there. That read consults one entity and never the list, so it succeeds only if the vote was stored as a keyed element, and it comes back empty under a whole-list write while the tally still reads right. A second test counts rolled-back writes across a burst of concurrent votes and bounds them below one per vote. Both fail on the whole-list form, checked by reverting the handler and running them.

`main.test.tsx` gains the clear-then-recast sequence, which had no coverage: it fails if `clearMyVote` drops a vote's membership without clearing its entity.

A benchmark measures what the tests only bound. Nothing in the benchmark suite had a second writer — every bench file drives one runtime against storage it alone holds, so a write conflict cannot arise in any of them, and the cost of a contended write is invisible to the whole suite. The new one dispatches all hundred votes before any settles and times until every one of the ten clients holds the result. Because the other half of a contended write is work thrown away rather than time spent, it also writes a contention accounting over one untimed burst to stderr, where the workflow keeps it in `diagnostics.log` beside the timing.

Two of its costs are worth stating rather than discovering. An iteration takes a few hundred milliseconds, which puts it at the end of the distribution where the dashboard's 75th percentile buys least protection from a stalled runner, so the series is read across windows rather than against the last one. And ten runtimes are the largest footprint in the job: about twenty-three seconds added, peaking at 5.4GB resident against 245MB without it, held for the rest of the job because `Deno.bench` has no teardown seam the harness can be closed from. That peak is a working set and not a leak — the same run under a 512MB heap cap completes in 3.5GB at roughly double the per-iteration time.

The poll's identity is a shared `#profile` cell, and that wish does not resolve in the multi-runtime harness, so both the test and the benchmark drive the poll through a fixture that claims one shared-space profile per name. A per-user scoped cell will not do: it is one address read through the reader's own partition, so every session stores the same identity and the second joiner dedups into the first.

The keyed-collection-writes note claimed the poll was migrated and listed handlers the pattern does not have. Its inventory now matches the source, and its back-compatibility section names the reset repair.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6719?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

