### PR TITLE
fix(runner): #6535 ride-along — recover dropped piece instantiations once

### DIFF
--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -6653,12 +6653,14 @@ supply; OW29/OW32/OW34 closed):
     cancels only the node group that transaction installed, preserves
     the outer registration and its parent/root cancellation ownership,
     waits for retry readiness, and instantiates the still-current
-    pattern once into the next wave. A stop, runtime cycle, pointer
-    change, or newer node group wins through exact guards; a second drop
-    tears the exact registration down rather than spinning. A whole-wave
-    abort or abandon is not retried in place.
+    pattern once into the next wave. A stop/stopAll/dispose aborts that
+    readiness and any named-document pull through the outer registration's
+    cancellation signal; a runtime cycle, pointer change, or newer node
+    group wins through exact guards. A second drop tears the exact
+    registration down rather than spinning. A whole-wave abort or abandon
+    is not retried in place.
     Pinned in `executor-wave.test.ts` by a deterministic whole-document
-    conflict plus a stop-before-settlement companion. And OW46's
+    conflict plus a held-readiness teardown companion. And OW46's
     `structure-load-stuck` counter is BLIND here: it fires 6× per run
     in BOTH arms and in the reds names only the HOST's space, because
     it counts deferred structure loads of DEMANDED roots and this

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -6658,7 +6658,12 @@ supply; OW29/OW32/OW34 closed):
     cancellation signal; a runtime cycle, pointer change, or newer node
     group wins through exact guards. A second drop tears the exact
     registration down rather than spinning. A whole-wave abort or abandon
-    is not retried in place.
+    is not retried in place. An immediate self-minted instantiate commit
+    refusal/rejection also tears down the exact current registration in every
+    posture, including client/OFF: a graph whose setup writes never landed is
+    a zombie, not a viable self-healing registration. Explicit wave abandon
+    is classified separately and warned without incrementing the serving
+    runtime's structure-load-failure observer; other failures remain loud.
     Pinned in `executor-wave.test.ts` by a deterministic whole-document
     conflict plus a held-readiness teardown companion. And OW46's
     `structure-load-stuck` counter is BLIND here: it fires 6× per run

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -1266,8 +1266,14 @@ nod, 2026-08-07; recorded in the plan's stage list):**
   reads stale; the client's `piece-instantiate` then failed
   `piece-start-commit-failed` and the shells never idled) — the
   client-instantiate-vs-server-derive race at piece creation is
-  pre-existing and only softened, not closed (owner: the runner's
-  piece-start path).
+  still possible, but its one-shot loss arms are bounded in the runner:
+  a deferred client start that loses a stale-read race catches up from
+  served state, while a serving `piece-instantiate` contribution that
+  is dropped cancels only its exact speculative node group and
+  re-instantiates once in the next wave. The grace still reduces the
+  contention rate; correctness no longer depends on winning that first
+  bookkeeping wave. Whole-wave aborts and abandons keep their existing
+  lifecycle recovery instead of retrying in place.
 - OW19 — the demand-cycle terminal state: CLOSED by stage P2-F
   (2026-08-13; the RULED 2026-08-07 direction, built whole). A
   demanded root CONFIRMED synced with no pattern meta parks TERMINAL
@@ -2964,9 +2970,11 @@ Delta 2026-08-15 — Phase 6 independent-review fixes (same PR):
   Owed (Stage C, a NAMED FOLLOW-UP, NOT stage-B-owned): the served
   interval `#now/300` wish's value for a serving runtime at dispatch
   (or the pattern's `if (!now) return` guard reading a wall clock the
-  serving runtime supplies) — plus the pre-existing
-  client-instantiate-vs-server-derive race at piece creation (the
-  300 ms demand-wake grace mitigates, does not close it; residual x).**
+  serving runtime supplies). The separate
+  client-instantiate-vs-server-derive race at piece creation remains a
+  source of contention, but not an unrecovered one-shot loss: deferred
+  client starts catch up and dropped serving-instantiation contributions
+  retry once under exact lifecycle guards (residual x).**
 - OW34 — a CFC-serving POLICY item: served handler runs carry NO
   renderer-trusted event mark, so a per-user served handler's write to a
   UI-contract-gated (owner-protected) cell is refused by CFC at prepare
@@ -6639,11 +6647,18 @@ supply; OW29/OW32/OW34 closed):
     **Anti-red-herrings, recorded so the next seat does not
     re-derive them.** `piece-start-commit-failed` is NOT this file's
     discriminator: 13 occurrences across the campaign, 1-2 per run,
-    in GREEN runs as often as red. It remains a real unrecovered arm
-    — the catch-up recovery is wired to the deferred-start commit,
-    not to the piece-instantiate one — and this row already carries
-    it as an open residual, but it does not explain these reds, and
-    ruling it out cost the measuring seat real time. And OW46's
+    in GREEN runs as often as red. It did not explain these reds, and
+    ruling it out cost the measuring seat real time. The arm now observes
+    the self-minted transaction's wave settlement: a contribution drop
+    cancels only the node group that transaction installed, preserves
+    the outer registration and its parent/root cancellation ownership,
+    waits for retry readiness, and instantiates the still-current
+    pattern once into the next wave. A stop, runtime cycle, pointer
+    change, or newer node group wins through exact guards; a second drop
+    tears the exact registration down rather than spinning. A whole-wave
+    abort or abandon is not retried in place.
+    Pinned in `executor-wave.test.ts` by a deterministic whole-document
+    conflict plus a stop-before-settlement companion. And OW46's
     `structure-load-stuck` counter is BLIND here: it fires 6× per run
     in BOTH arms and in the reds names only the HOST's space, because
     it counts deferred structure loads of DEMANDED roots and this

--- a/packages/runner/src/executor/wave.ts
+++ b/packages/runner/src/executor/wave.ts
@@ -1505,14 +1505,18 @@ export class WaveAccumulator
     if (this.#closed) return;
     this.#closed = true;
     for (const contribution of this.#contributions) {
-      this.#withdraw(contribution, `wave abandoned: ${reason}`);
+      this.#withdraw(
+        contribution,
+        `wave abandoned: ${reason}`,
+        "wave-abandoned",
+      );
     }
   }
 
   #withdraw(
     contribution: WaveContribution,
     message: string,
-    cause?: "contribution-dropped",
+    cause?: "contribution-dropped" | "wave-abandoned",
   ): void {
     for (const space of contribution.spaces) {
       space.resolveVerdict({

--- a/packages/runner/src/executor/wave.ts
+++ b/packages/runner/src/executor/wave.ts
@@ -1509,9 +1509,15 @@ export class WaveAccumulator
     }
   }
 
-  #withdraw(contribution: WaveContribution, message: string): void {
+  #withdraw(
+    contribution: WaveContribution,
+    message: string,
+    cause?: "contribution-dropped",
+  ): void {
     for (const space of contribution.spaces) {
-      space.resolveVerdict({ withdrawn: { message } });
+      space.resolveVerdict({
+        withdrawn: { message, ...(cause !== undefined ? { cause } : {}) },
+      });
     }
   }
 
@@ -2971,7 +2977,7 @@ export class WaveAccumulator
             "contribution; its own reads re-run it when fresh state " +
             "lands (serving-loop.md §3d)";
         this.#warnDropped(contribution, message);
-        this.#withdraw(contribution, message);
+        this.#withdraw(contribution, message, "contribution-dropped");
         continue;
       }
       if (droppedDocs[idx].size > 0) {
@@ -2999,6 +3005,7 @@ export class WaveAccumulator
           contribution,
           "superseded pure derivation writes dropped from the wave commit " +
             "(serving-loop.md §3d)",
+          "contribution-dropped",
         );
         continue;
       }

--- a/packages/runner/src/executor/wave.ts
+++ b/packages/runner/src/executor/wave.ts
@@ -3005,7 +3005,7 @@ export class WaveAccumulator
           contribution,
           "superseded pure derivation writes dropped from the wave commit " +
             "(serving-loop.md §3d)",
-          "contribution-dropped",
+          allDropped ? "contribution-dropped" : undefined,
         );
         continue;
       }

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -3247,6 +3247,12 @@ export class Runner {
 
     // Create cancel group early, before wiring pattern/node sinks.
     const [cancelGroup, addCancel] = useCancelGroup();
+    // A withdrawn instantiation may be waiting for its conflict/session gate
+    // and a named-document pull before it retries. That work belongs to the
+    // OUTER registration, not the retired node group: stopping the piece must
+    // release the fire-and-forget settlement even when readiness never does.
+    const retryReadinessTeardown = new AbortController();
+    addCancel(() => retryReadinessTeardown.abort());
     const startLifecycleEpoch = this.#lifecycleEpoch;
     let active = true;
     const cancel = () => {
@@ -3401,14 +3407,18 @@ export class Runner {
             // original parent/root owner keeps the same cancellation handle.
             nodeCancel();
             if (cancelNodes === nodeCancel) cancelNodes = undefined;
-            await this.runtime.awaitCommitRetryReadiness(settled.error);
+            await this.runtime.awaitCommitRetryReadiness(
+              settled.error,
+              retryReadinessTeardown.signal,
+            );
 
-            // A stop, runtime cycle, pointer change, or newer instantiation
-            // during the readiness wait owns the key now. Otherwise retry
-            // exactly once; a second drop tears the registration down
-            // instead of spinning on a permanently conflicting write.
+            // A stop aborts the readiness/pull work above; a runtime cycle,
+            // pointer change, or newer instantiation during the wait owns the
+            // key now. Otherwise retry exactly once; a second drop tears the
+            // registration down instead of spinning on a permanent conflict.
             if (
-              !active || startLifecycleEpoch !== this.#lifecycleEpoch ||
+              retryReadinessTeardown.signal.aborted || !active ||
+              startLifecycleEpoch !== this.#lifecycleEpoch ||
               this.cancels.get(key) !== cancel ||
               currentPatternKey !== patternKeyAtInstantiation ||
               cancelNodes !== undefined

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -3382,15 +3382,26 @@ export class Runner {
             const settled = await settlement;
             if (settled.error === undefined) return;
 
-            this.#reportPieceStartCommitFailure(
-              instantiateActionId,
-              settled.error,
-            );
+            const waveWithdrawalCause = (settled.error as {
+              waveWithdrawalCause?: unknown;
+            }).waveWithdrawalCause;
+            if (waveWithdrawalCause === "wave-abandoned") {
+              // Explicit abandon is clean enclosing-lifecycle teardown, not a
+              // structure-load failure. Keep it visible without incrementing
+              // the serving runtime's failure observer/health counter.
+              logger.warn("piece-start-commit-abandoned", () => [
+                `piece-start commit ${instantiateActionId} was withdrawn by ` +
+                "wave abandon; the enclosing lifecycle owns any restart",
+                settled.error,
+              ]);
+            } else {
+              this.#reportPieceStartCommitFailure(
+                instantiateActionId,
+                settled.error,
+              );
+            }
             if (!exactNodesAreCurrent()) return;
-            if (
-              (settled.error as { waveWithdrawalCause?: unknown })
-                .waveWithdrawalCause !== "contribution-dropped"
-            ) {
+            if (waveWithdrawalCause !== "contribution-dropped") {
               teardownRegistrationIfCurrent();
               return;
             }

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -1709,6 +1709,13 @@ export class Runner {
   // cancelled ownership already tombstones the work. Tracked solely so tests
   // can synchronize deterministically.
   #pendingDeferredStartCatchUps = new Set<Promise<unknown>>();
+  // Self-minted piece instantiations seal asynchronously into the serving
+  // wave. Their local graph is speculative until that wave settles, so a
+  // contribution drop tears down that exact node group and re-instantiates it
+  // once against the rolled-back view. This set is a deterministic test seam:
+  // disposal relies on the registration and lifecycle guards rather than
+  // waiting for a wave that a closing serving loop may abandon.
+  #pendingPieceInstantiationSettlements = new Set<Promise<unknown>>();
   // Both maps record that this runner prepared or stopped a result, so a later
   // start of the same result can reuse the cells it already assembled instead
   // of re-syncing dependencies and rehydrating a snapshot. They are shortcuts:
@@ -3283,6 +3290,7 @@ export class Runner {
     const instantiatePattern = (
       pattern: Pattern,
       useTx?: IExtendedStorageTransaction,
+      recoverDroppedContribution = true,
     ) => {
       if (!active || startLifecycleEpoch !== this.#lifecycleEpoch) return;
       // Create new cancel group for nodes
@@ -3346,13 +3354,84 @@ export class Runner {
           // and, on a serving runtime, counted.
           const instantiateActionId =
             `piece-instantiate/${resultCell.sourceURI}`;
-          actualTx.commit().then(({ error }) => {
+          const patternKeyAtInstantiation = currentPatternKey;
+          const teardownRegistrationIfCurrent = () => {
+            if (this.cancels.get(key) !== cancel) return;
+            this.cancels.delete(key);
+            this.#allCancels.delete(cancel);
+            cancel();
+          };
+          const exactNodesAreCurrent = () =>
+            active && startLifecycleEpoch === this.#lifecycleEpoch &&
+            this.cancels.get(key) === cancel && cancelNodes === nodeCancel &&
+            currentPatternKey === patternKeyAtInstantiation;
+          const commitWork = actualTx.commit().then(async ({ error }) => {
             if (error !== undefined) {
               this.#reportPieceStartCommitFailure(instantiateActionId, error);
+              if (exactNodesAreCurrent()) teardownRegistrationIfCurrent();
+              return;
+            }
+            const settlement = waveSettlementOf(actualTx);
+            if (settlement === undefined) return;
+            const settled = await settlement;
+            if (settled.error === undefined) return;
+
+            this.#reportPieceStartCommitFailure(
+              instantiateActionId,
+              settled.error,
+            );
+            if (!exactNodesAreCurrent()) return;
+            if (
+              (settled.error as { waveWithdrawalCause?: unknown })
+                .waveWithdrawalCause !== "contribution-dropped"
+            ) {
+              teardownRegistrationIfCurrent();
+              return;
+            }
+            if (!recoverDroppedContribution) {
+              teardownRegistrationIfCurrent();
+              return;
+            }
+
+            // The graph reads its own pending setup and internal-cell writes
+            // while it is installed. Once the wave withdraws those writes,
+            // keeping that graph would leave a registration whose substrate
+            // never became durable. Retire only the nodes this transaction
+            // installed; the outer registration remains in place so its
+            // original parent/root owner keeps the same cancellation handle.
+            nodeCancel();
+            if (cancelNodes === nodeCancel) cancelNodes = undefined;
+            await this.runtime.awaitCommitRetryReadiness(settled.error);
+
+            // A stop, runtime cycle, pointer change, or newer instantiation
+            // during the readiness wait owns the key now. Otherwise retry
+            // exactly once; a second drop tears the registration down
+            // instead of spinning on a permanently conflicting write.
+            if (
+              !active || startLifecycleEpoch !== this.#lifecycleEpoch ||
+              this.cancels.get(key) !== cancel ||
+              currentPatternKey !== patternKeyAtInstantiation ||
+              cancelNodes !== undefined
+            ) {
+              return;
+            }
+            try {
+              instantiatePattern(pattern, undefined, false);
+            } catch (retryError) {
+              this.#reportPieceStartCommitFailure(
+                instantiateActionId,
+                retryError,
+              );
+              teardownRegistrationIfCurrent();
             }
           }).catch((error) => {
             this.#reportPieceStartCommitFailure(instantiateActionId, error);
+            if (exactNodesAreCurrent()) teardownRegistrationIfCurrent();
           });
+          this.#pendingPieceInstantiationSettlements.add(commitWork);
+          commitWork.finally(() =>
+            this.#pendingPieceInstantiationSettlements.delete(commitWork)
+          );
         }
       }
     };
@@ -5999,6 +6078,20 @@ export class Runner {
   async idleDeferredStartCatchUps(): Promise<void> {
     while (this.#pendingDeferredStartCatchUps.size > 0) {
       await Promise.allSettled([...this.#pendingDeferredStartCatchUps]);
+    }
+  }
+
+  /**
+   * TESTS ONLY: settle self-minted piece-instantiation commits and any
+   * withdrawal recovery they schedule. Never called from dispose(): a serving
+   * wave can remain open until its host closes or abandons it, while lifecycle
+   * guards already prevent a settled continuation from reviving stopped work.
+   */
+  async idlePieceInstantiationSettlements(): Promise<void> {
+    while (this.#pendingPieceInstantiationSettlements.size > 0) {
+      await Promise.allSettled([
+        ...this.#pendingPieceInstantiationSettlements,
+      ]);
     }
   }
 

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -2817,7 +2817,16 @@ export interface ISpaceReplica extends ISpace {
  */
 export type SealedCommitVerdict =
   | { committed: { seq: number } }
-  | { withdrawn: { message: string; superseded?: true } };
+  | {
+    withdrawn: {
+      message: string;
+      superseded?: true;
+      /** A single contribution was dropped while the rest of its wave
+       * remained viable. Consumers may distinguish this from whole-wave
+       * abort/abandon without parsing a diagnostic message. */
+      cause?: "contribution-dropped";
+    };
+  };
 
 /** A replica's handle for one sealed native commit. */
 export interface SealedNativeCommit {

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -2821,10 +2821,10 @@ export type SealedCommitVerdict =
     withdrawn: {
       message: string;
       superseded?: true;
-      /** A single contribution was dropped while the rest of its wave
-       * remained viable. Consumers may distinguish this from whole-wave
-       * abort/abandon without parsing a diagnostic message. */
-      cause?: "contribution-dropped";
+      /** Structured withdrawal classification for consumers that must not
+       * parse diagnostic prose. A contribution drop is retryable in place;
+       * an explicit wave abandon is expected enclosing-lifecycle teardown. */
+      cause?: "contribution-dropped" | "wave-abandoned";
     };
   };
 

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -4614,11 +4614,23 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
             identity,
           );
         }
+        const withdrawalCause = "cause" in v.withdrawn
+          ? v.withdrawn.cause
+          : undefined;
+        // Settlement consumers need the wave's structured distinction: a
+        // dropped contribution may retry in place, while an abort/abandon
+        // belongs to the enclosing lifecycle. Do not make them parse prose.
+        const rejection = {
+          ...this.#makeLocalRejection(commit, v.withdrawn.message),
+          ...(withdrawalCause !== undefined
+            ? { waveWithdrawalCause: withdrawalCause }
+            : {}),
+        };
         return await this.#finalizeRejection(
           localSeq,
           operations,
           source,
-          this.#makeLocalRejection(commit, v.withdrawn.message),
+          rejection,
           identity,
         );
       }

--- a/packages/runner/test/executor-wave.test.ts
+++ b/packages/runner/test/executor-wave.test.ts
@@ -3930,6 +3930,10 @@ describe("stage D seal-into-wave", () => {
     const firstWave = newWave({ lease });
     const recoveryWave = newWave({ lease });
     const route = routePieceInstantiationWaves(firstWave, recoveryWave);
+    const failures: unknown[] = [];
+    runtime.pieceStartCommitFailureObserver = ({ error }) => {
+      failures.push(error);
+    };
 
     expect(await runtime.start(witness.cell)).toBe(true);
     await route.firstSeal;
@@ -3942,6 +3946,9 @@ describe("stage D seal-into-wave", () => {
 
     expect(route.recoverySeals()).toBe(0);
     expect(witness.instantiations()).toBe(2);
+    // Explicit wave abandonment is clean enclosing-lifecycle teardown: it
+    // remains visible as a warning, but does not tick the failure observer.
+    expect(failures).toEqual([]);
 
     // The non-retryable withdrawal removed the dead registration, so an
     // ordinary later start can rebuild it through its owning lifecycle.
@@ -4052,7 +4059,12 @@ describe("stage F fix round: foreign-batch settle sequences and shallow reads", 
     runtime.clearSealDestination();
     wave2.abandon("test-induced abort");
     await wave2.settled();
-    expect((await settlement2!).error).toBeDefined();
+    const settled2 = await settlement2!;
+    expect(settled2.error).toBeDefined();
+    expect(
+      (settled2.error as { waveWithdrawalCause?: unknown })
+        .waveWithdrawalCause,
+    ).toBe("wave-abandoned");
 
     // A tx that never sealed into a wave has no settlement (the OFF
     // arm's discriminator).

--- a/packages/runner/test/executor-wave.test.ts
+++ b/packages/runner/test/executor-wave.test.ts
@@ -150,7 +150,10 @@ describe("stage D seal-into-wave", () => {
       sessionId: executionLeaseHolder(`service:${space}`),
     });
 
-  const stoppedWitnessPiece = async (id: string) => {
+  const stoppedWitnessPiece = async (
+    id: string,
+    options: { throwOnInstantiation?: number } = {},
+  ) => {
     let instantiations = 0;
     let lastRunInstantiation = 0;
     const pattern: Pattern = {
@@ -168,6 +171,9 @@ describe("stage D seal-into-wave", () => {
               key: (name: string) => { set: (value: number) => void };
             };
             instantiations += 1;
+            if (instantiations === options.throwOnInstantiation) {
+              throw new Error(`witness instantiation ${instantiations} failed`);
+            }
             // `parentCell` is bound to startCore's actual transaction. A
             // changing value makes every instantiation contribute a real
             // bookkeeping write instead of being optimized to a no-op.
@@ -527,6 +533,8 @@ describe("stage D seal-into-wave", () => {
     stampWaveRunContext(tx1, { actionId: "derive-x", kind: "derivation" });
     x.withTx(tx1).set({ value: 10 });
     expect((await tx1.commit()).error).toBeUndefined();
+    const tx1Settlement = waveSettlementOf(tx1);
+    expect(tx1Settlement).toBeDefined();
 
     const tx2 = runtime.edit();
     stampWaveRunContext(tx2, { actionId: "derive-z", kind: "derivation" });
@@ -554,6 +562,7 @@ describe("stage D seal-into-wave", () => {
     runtime.clearSealDestination();
     const outcome = await wave.commitWave(newSink());
     await wave.settled();
+    const tx1Settled = await tx1Settlement!;
 
     // The superseded pure write dropped (counted), and the derivation
     // that READ the withdrawn write dropped with it — nothing derived
@@ -563,6 +572,10 @@ describe("stage D seal-into-wave", () => {
     expect(outcome.dependencyDroppedWrites).toBe(1);
     expect(outcome.dispositions[0]).toEqual({ kind: "dropped" });
     expect(outcome.dispositions[1]).toEqual({ kind: "dropped" });
+    expect(
+      (tx1Settled.error as { waveWithdrawalCause?: unknown } | undefined)
+        ?.waveWithdrawalCause,
+    ).toBe("contribution-dropped");
     // No wave commit happened at all (nothing survived), and the
     // authored value stands — dropping is what makes that sound.
     expect(outcome.seq).toBeUndefined();
@@ -2219,6 +2232,8 @@ describe("stage D seal-into-wave", () => {
     x.withTx(tx).set({ value: 1 });
     keep.withTx(tx).set({ value: 2 });
     expect((await tx.commit()).error).toBeUndefined();
+    const settlement = waveSettlementOf(tx);
+    expect(settlement).toBeDefined();
     runtime.clearSealDestination();
 
     // The rival lands BETWEEN the accumulator's head query and the store
@@ -2254,6 +2269,7 @@ describe("stage D seal-into-wave", () => {
 
     const outcome = await wave.commitWave(racingSink);
     await wave.settled();
+    const settled = await settlement!;
 
     // Attempt 1 was rejected with the doc NAMED; the loop folded it in,
     // dropped the superseded write, and attempt 2 committed the rest.
@@ -2264,6 +2280,11 @@ describe("stage D seal-into-wave", () => {
       kind: "partially-dropped",
       droppedOps: 1,
     });
+    expect(settled.error).toBeDefined();
+    expect(
+      (settled.error as { waveWithdrawalCause?: unknown })
+        .waveWithdrawalCause,
+    ).toBeUndefined();
     const stored = Engine.readState(engine, { id: xLink.id });
     expect(stored?.document).toEqual({ value: { value: 99 } });
     const keepLink = keep.getAsNormalizedFullLink();
@@ -3776,7 +3797,92 @@ describe("stage D seal-into-wave", () => {
     lease.release();
   });
 
-  it("does not revive a piece stopped before its withdrawn instantiation settles", async () => {
+  it("surfaces a synchronous reinstantiation failure and tears down the registration", async () => {
+    const witness = await stoppedWitnessPiece(
+      "wave-piece-instantiate-retry-throws",
+      { throwOnInstantiation: 3 },
+    );
+    const lease = liveLease();
+    const firstWave = newWave({ lease });
+    const recoveryWave = newWave({ lease });
+    const route = routePieceInstantiationWaves(firstWave, recoveryWave);
+    const failures: unknown[] = [];
+    runtime.pieceStartCommitFailureObserver = ({ error }) => {
+      failures.push(error);
+    };
+
+    expect(await runtime.start(witness.cell)).toBe(true);
+    await route.firstSeal;
+    await runtime.idle();
+    await route.idleSeals();
+    route.useRecoveryWave();
+    await firstWave.commitWave(wholeDocumentConflictSink(newSink()));
+    await firstWave.settled();
+    await runtime.runner.idlePieceInstantiationSettlements();
+
+    expect(witness.instantiations()).toBe(3);
+    expect(
+      failures.some((error) =>
+        error instanceof Error && error.message ===
+          "witness instantiation 3 failed"
+      ),
+    ).toBe(true);
+    expect(route.recoverySeals()).toBe(0);
+
+    // The failed retry retired the exact outer registration, so an ordinary
+    // later start can instantiate it afresh instead of finding a dead entry.
+    runtime.clearSealDestination();
+    recoveryWave.abandon("test cleanup");
+    expect(await runtime.start(witness.cell)).toBe(true);
+    await runtime.idle();
+    await runtime.runner.idlePieceInstantiationSettlements();
+    expect(witness.instantiations()).toBe(4);
+    lease.release();
+  });
+
+  it("surfaces a rejected piece-instantiation commit and tears down the registration", async () => {
+    const witness = await stoppedWitnessPiece(
+      "wave-piece-instantiate-commit-rejects",
+    );
+    const rejection = new Error("piece instantiate destination rejected");
+    const failures: unknown[] = [];
+    let rejections = 0;
+    runtime.pieceStartCommitFailureObserver = ({ error }) => {
+      failures.push(error);
+    };
+    runtime.installSealDestination({
+      seal: (tx) => {
+        if (
+          waveRunContextOf(tx)?.actionId.startsWith("piece-instantiate/")
+        ) {
+          rejections += 1;
+          return Promise.reject(rejection);
+        }
+        return tx.tx.commit();
+      },
+    }, {
+      runStamper: (tx, info) =>
+        stampWaveRunContext(tx, {
+          actionId: info.actionId,
+          kind: info.kind,
+        }),
+    });
+
+    expect(await runtime.start(witness.cell)).toBe(true);
+    await runtime.runner.idlePieceInstantiationSettlements();
+    expect(rejections).toBe(1);
+    expect(failures).toContain(rejection);
+
+    // Promise rejection takes the same exact-registration teardown path as a
+    // refused Result, so the next owner can start the piece normally.
+    runtime.clearSealDestination();
+    expect(await runtime.start(witness.cell)).toBe(true);
+    await runtime.idle();
+    await runtime.runner.idlePieceInstantiationSettlements();
+    expect(witness.instantiations()).toBe(3);
+  });
+
+  it("aborts held retry readiness when the piece stops and does not revive it", async () => {
     const { cell } = await stoppedWitnessPiece(
       "wave-piece-instantiate-stop",
     );
@@ -3784,20 +3890,35 @@ describe("stage D seal-into-wave", () => {
     const firstWave = newWave({ lease });
     const recoveryWave = newWave({ lease });
     const route = routePieceInstantiationWaves(firstWave, recoveryWave);
+    const readinessEntered = Promise.withResolvers<void>();
+    const heldReadiness = Promise.withResolvers<void>();
+    runtime.pieceStartCommitFailureObserver = ({ actionId, error }) => {
+      if (!actionId.startsWith("piece-instantiate/")) return;
+      (error as { readyToRetry?: () => Promise<void> }).readyToRetry = () => {
+        readinessEntered.resolve();
+        return heldReadiness.promise;
+      };
+    };
 
     expect(await runtime.start(cell)).toBe(true);
     await route.firstSeal;
     await runtime.idle();
     await route.idleSeals();
-    runtime.runner.stop(cell);
     route.useRecoveryWave();
-    firstWave.abandon("the stopped-start settlement gate");
+    await firstWave.commitWave(wholeDocumentConflictSink(newSink()));
     await firstWave.settled();
+    await readinessEntered.promise;
+
+    // The settlement is parked inside readyToRetry(), not merely waiting for
+    // its post-readiness exact-registration guard. Stopping must abort that
+    // wait so fire-and-forget settlement can quiesce without releasing it.
+    runtime.runner.stop(cell);
     await runtime.runner.idlePieceInstantiationSettlements();
 
     expect(route.recoverySeals()).toBe(0);
     runtime.clearSealDestination();
     recoveryWave.abandon("test cleanup");
+    heldReadiness.resolve();
     lease.release();
   });
 

--- a/packages/runner/test/executor-wave.test.ts
+++ b/packages/runner/test/executor-wave.test.ts
@@ -63,6 +63,7 @@ import {
 } from "../src/storage/v2.ts";
 import type { Signer } from "@commonfabric/memory/interface";
 import { Runtime } from "../src/runtime.ts";
+import type { Module, Pattern } from "../src/builder/types.ts";
 import type {
   ITransactionSealSink,
   MemorySpace,
@@ -148,6 +149,124 @@ describe("stage D seal-into-wave", () => {
       // exactly the stage-F SpaceServer posture.
       sessionId: executionLeaseHolder(`service:${space}`),
     });
+
+  const stoppedWitnessPiece = async (id: string) => {
+    let instantiations = 0;
+    let lastRunInstantiation = 0;
+    const pattern: Pattern = {
+      argumentSchema: { type: "object", properties: {} },
+      resultSchema: {
+        type: "object",
+        properties: { witness: { type: "number" } },
+      },
+      result: {},
+      nodes: [{
+        module: {
+          type: "raw",
+          implementation: (...args: unknown[]) => {
+            const parentCell = args[4] as {
+              key: (name: string) => { set: (value: number) => void };
+            };
+            instantiations += 1;
+            // `parentCell` is bound to startCore's actual transaction. A
+            // changing value makes every instantiation contribute a real
+            // bookkeeping write instead of being optimized to a no-op.
+            parentCell.key("witness").set(instantiations);
+            const thisInstantiation = instantiations;
+            const action = () => {
+              lastRunInstantiation = thisInstantiation;
+            };
+            return {
+              action,
+            };
+          },
+        } as Module,
+        inputs: {},
+        outputs: {},
+      }],
+    };
+    const tx = runtime.edit();
+    const cell = runtime.getCell<Record<string, unknown>>(
+      space,
+      id,
+      undefined,
+      tx,
+    );
+    const running = runtime.runner.run(tx, pattern, {}, cell);
+    expect((await tx.commit()).error).toBeUndefined();
+    await running.pull();
+    runtime.runner.stop(cell);
+    return {
+      cell,
+      instantiations: () => instantiations,
+      lastRunInstantiation: () => lastRunInstantiation,
+    };
+  };
+
+  const routePieceInstantiationWaves = (
+    firstWave: WaveAccumulator,
+    recoveryWave: WaveAccumulator,
+  ) => {
+    let destinationWave = firstWave;
+    const firstSeal = Promise.withResolvers<void>();
+    const recoverySeal = Promise.withResolvers<void>();
+    let recoverySeals = 0;
+    let sealChain = Promise.resolve();
+    runtime.installSealDestination({
+      seal: (tx) => {
+        const target = destinationWave;
+        const sealed = sealChain.then(async () => {
+          const result = await target.seal(tx);
+          if (
+            result.error === undefined &&
+            waveSettlementOf(tx) !== undefined &&
+            waveRunContextOf(tx)?.actionId.startsWith("piece-instantiate/")
+          ) {
+            if (target === firstWave) firstSeal.resolve();
+            else {
+              recoverySeals += 1;
+              recoverySeal.resolve();
+            }
+          }
+          return result;
+        });
+        sealChain = sealed.then(() => undefined, () => undefined);
+        return sealed;
+      },
+    }, {
+      runStamper: (tx, info) =>
+        stampWaveRunContext(tx, {
+          actionId: info.actionId,
+          kind: info.kind,
+        }),
+    });
+    return {
+      firstSeal: firstSeal.promise,
+      recoverySeal: recoverySeal.promise,
+      recoverySeals: () => recoverySeals,
+      idleSeals: () => sealChain,
+      useRecoveryWave: () => {
+        destinationWave = recoveryWave;
+      },
+    };
+  };
+
+  const wholeDocumentConflictSink = (
+    inner: WaveCommitSink,
+  ): WaveCommitSink => {
+    const conflictHead = Engine.serverSeq(engine) + 1;
+    return {
+      currentHeads: (_targetSpace, docs) =>
+        Promise.resolve(
+          new Map(docs.map((doc) => [
+            `${doc.id} ${doc.scopeKey}`,
+            conflictHead,
+          ])),
+        ),
+      concurrentWritePaths: () => Promise.resolve([[]]),
+      commitWave: (batch) => inner.commitWave(batch),
+    };
+  };
 
   /** Seed a foreign engine's GENESIS ACL as its first commit (OW31 B4:
    * the sink refuses a foreign data batch into a seq-0/no-ACL engine —
@@ -3562,6 +3681,156 @@ describe("stage D seal-into-wave", () => {
     // Both survive: the concurrent field AND the rebased advance.
     const stored = Engine.readState(engine, { id: link.id });
     expect(stored?.document).toEqual({ value: { seq: 9, other: 7 } });
+  });
+
+  it("reinstantiates a piece once after its bookkeeping contribution is withdrawn, preserving the live registration and action", async () => {
+    const witness = await stoppedWitnessPiece(
+      "wave-piece-instantiate-recovery",
+    );
+    const { cell } = witness;
+    const lease = liveLease();
+    const firstWave = newWave({ lease });
+    const recoveryWave = newWave({ lease });
+    const route = routePieceInstantiationWaves(firstWave, recoveryWave);
+    const failures: Array<{ actionId: string; error: unknown }> = [];
+    runtime.pieceStartCommitFailureObserver = (failure) => {
+      failures.push(failure);
+    };
+
+    expect(await runtime.start(cell)).toBe(true);
+    await route.firstSeal;
+    await runtime.idle();
+    await route.idleSeals();
+    route.useRecoveryWave();
+
+    // Every document the first wave wrote appears to have advanced, and a
+    // whole-document rival write overlaps it. Bookkeeping cannot commute with
+    // that shape, so the accumulator deterministically drops the complete
+    // piece-instantiate contribution instead of relying on event-loop timing.
+    const inner = newSink();
+    const conflictSink = wholeDocumentConflictSink(inner);
+    const firstOutcome = await firstWave.commitWave(conflictSink);
+    await firstWave.settled();
+    expect(
+      firstOutcome.dispositions.some((disposition) =>
+        disposition.kind === "dropped"
+      ),
+    ).toBe(true);
+
+    // Settlement, not seal acceptance, triggers one fresh instantiation into
+    // the next wave. Let its newly registered actions quiesce before closing
+    // that wave, matching the serving loop's seal barrier.
+    await route.recoverySeal;
+    await runtime.idle();
+    runtime.clearSealDestination();
+    const recoveryOutcome = await recoveryWave.commitWave(inner);
+    await recoveryWave.settled();
+    await runtime.runner.idlePieceInstantiationSettlements();
+    expect(recoveryOutcome.aborted).toBeUndefined();
+    expect(route.recoverySeals()).toBe(1);
+    expect(
+      failures.some((failure) =>
+        failure.actionId.startsWith("piece-instantiate/")
+      ),
+    ).toBe(true);
+
+    // The retry kept the original outer registration alive, and the action
+    // belonging to its third raw-module instantiation ran.
+    expect(witness.instantiations()).toBe(3);
+    expect(witness.lastRunInstantiation()).toBe(3);
+    lease.release();
+  });
+
+  it("tears down after a second dropped piece-instantiation contribution instead of retrying again", async () => {
+    const witness = await stoppedWitnessPiece(
+      "wave-piece-instantiate-second-drop",
+    );
+    const lease = liveLease();
+    const firstWave = newWave({ lease });
+    const recoveryWave = newWave({ lease });
+    const route = routePieceInstantiationWaves(firstWave, recoveryWave);
+    const conflictSink = wholeDocumentConflictSink(newSink());
+
+    expect(await runtime.start(witness.cell)).toBe(true);
+    await route.firstSeal;
+    await runtime.idle();
+    await route.idleSeals();
+    route.useRecoveryWave();
+    await firstWave.commitWave(conflictSink);
+    await firstWave.settled();
+    await route.recoverySeal;
+    await runtime.idle();
+    await recoveryWave.commitWave(conflictSink);
+    await recoveryWave.settled();
+    await runtime.runner.idlePieceInstantiationSettlements();
+
+    // Initial materialization + losing start + its one retry. A loop would
+    // instantiate a fourth graph after the recovery wave withdrew it.
+    expect(witness.instantiations()).toBe(3);
+
+    runtime.clearSealDestination();
+    expect(await runtime.start(witness.cell)).toBe(true);
+    await runtime.idle();
+    await runtime.runner.idlePieceInstantiationSettlements();
+    expect(witness.instantiations()).toBe(4);
+    lease.release();
+  });
+
+  it("does not revive a piece stopped before its withdrawn instantiation settles", async () => {
+    const { cell } = await stoppedWitnessPiece(
+      "wave-piece-instantiate-stop",
+    );
+    const lease = liveLease();
+    const firstWave = newWave({ lease });
+    const recoveryWave = newWave({ lease });
+    const route = routePieceInstantiationWaves(firstWave, recoveryWave);
+
+    expect(await runtime.start(cell)).toBe(true);
+    await route.firstSeal;
+    await runtime.idle();
+    await route.idleSeals();
+    runtime.runner.stop(cell);
+    route.useRecoveryWave();
+    firstWave.abandon("the stopped-start settlement gate");
+    await firstWave.settled();
+    await runtime.runner.idlePieceInstantiationSettlements();
+
+    expect(route.recoverySeals()).toBe(0);
+    runtime.clearSealDestination();
+    recoveryWave.abandon("test cleanup");
+    lease.release();
+  });
+
+  it("does not retry an abandoned piece-instantiation wave in place", async () => {
+    const witness = await stoppedWitnessPiece(
+      "wave-piece-instantiate-abandon",
+    );
+    const lease = liveLease();
+    const firstWave = newWave({ lease });
+    const recoveryWave = newWave({ lease });
+    const route = routePieceInstantiationWaves(firstWave, recoveryWave);
+
+    expect(await runtime.start(witness.cell)).toBe(true);
+    await route.firstSeal;
+    await runtime.idle();
+    await route.idleSeals();
+    route.useRecoveryWave();
+    firstWave.abandon("whole-wave lifecycle recovery owns this case");
+    await firstWave.settled();
+    await runtime.runner.idlePieceInstantiationSettlements();
+
+    expect(route.recoverySeals()).toBe(0);
+    expect(witness.instantiations()).toBe(2);
+
+    // The non-retryable withdrawal removed the dead registration, so an
+    // ordinary later start can rebuild it through its owning lifecycle.
+    runtime.clearSealDestination();
+    expect(await runtime.start(witness.cell)).toBe(true);
+    await runtime.idle();
+    await runtime.runner.idlePieceInstantiationSettlements();
+    expect(witness.instantiations()).toBe(3);
+    recoveryWave.abandon("test cleanup");
+    lease.release();
   });
 });
 


### PR DESCRIPTION
## Companion to #6535

This PR rides along with #6535 and should merge before or alongside it. #6535 flips `EXPERIMENTAL_SERVER_EXECUTION` to default ON; this closes a one-shot loss in that serving path before the flip becomes the default.

It is intentionally based on `main`, rather than stacked on the #6535 branch, so it remains independently mergeable while still being an explicit prerequisite/companion to the flip.

## What changed

- Observe the durable wave settlement of self-minted `piece-instantiate` transactions.
- Carry a structured `contribution-dropped` cause through settlement only when the complete contribution was dropped; partial drops do not opt into piece recovery.
- On that exact cause, cancel only the speculative node group, preserve the outer parent/root ownership handle, wait for retry readiness, and instantiate once into the fresh wave.
- Bind retry readiness and its named-document pull to the outer registration's teardown signal, so stop/stopAll/dispose quiesces pending recovery work.
- Let runtime reset, pattern changes, or newer nodes win through exact ownership guards.
- Tear the registration down after a second drop or a failed retry instead of looping.
- Intentionally tear down the exact current registration after an immediate self-minted instantiate commit refusal/rejection in every posture, including client/OFF; a graph whose setup writes did not land is a zombie rather than a viable self-healing registration.
- Classify explicit wave abandonment as `wave-abandoned`: warn and tear down without retrying or incrementing the serving runtime's structure-load-failure observer. Other whole-wave failures remain loud and lifecycle-owned.

## Why

A new piece can race client-authored materialization against its first serving-side bookkeeping wave. If that `piece-instantiate` contribution loses a whole-document conflict, the wave withdraws its substrate after seal acceptance. The graph previously stayed registered even though its setup never became durable, leaving dependent computations and UI permanently absent.

## Verification

- `deno test -A packages/runner/test/executor-wave.test.ts` — 53 steps passed
- `deno test -A packages/runner/test/executor-run-supply.test.ts packages/runner/test/nested-piece-setup-repair.test.ts packages/runner/test/child-pattern-start-ownership.test.ts` — 19 steps passed, one pre-existing ignored step
- `deno check packages/runner/test/executor-wave.test.ts`
- `deno fmt --check` on all changed TypeScript files
- `git diff --check`

The regression coverage deterministically pins successful recovery, the one-retry bound, cancellation during held readiness, whole-vs-partial withdrawal causes, synchronous retry failure, rejected commit cleanup, and the structured clean-abandon boundary (including no failure-observer tick).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6720?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
