### PR TITLE
fix(runner): drop CFC flow stamps the declared label already covers

### DIFF
--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -645,10 +645,14 @@ the per-epic implementation notes).
   are `off`, `observe`, and `persist`. `observe` computes the conservative label
   join and emits diagnostics but writes nothing; `persist` writes the derived
   label components onto value write targets, except where the target's declared
-  store policy already carries every clause the join would state there — a
-  derived entry repeating it changes no label a reader resolves, so the persist
-  seam drops it. Propagation runs only when the enforcement mode is at least
-  `observe`; it derives and stores labels but never rejects on its own.
+  store policy already carries every clause the join would state there and the
+  component adds no integrity of its own — such an entry changes no label a
+  reader resolves, so the persist seam drops it. A transaction the runtime
+  attributes to an implementation carries derivation provenance in its
+  integrity, which no store policy states, so its value entries are kept and a
+  labeled collection an attributed writer maintains still grows per element.
+  Propagation runs only when the enforcement mode is at least `observe`; it
+  derives and stores labels but never rejects on its own.
 - **Current default and planned end state.** `off` by default. The target is to
   move toward `persist` as the downstream egress gates (render ceiling, sink
   ceilings, and the LLM path) come online.

--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -644,9 +644,11 @@ the per-epic implementation notes).
 - **Purpose.** Controls flow-label propagation at the commit boundary. Values
   are `off`, `observe`, and `persist`. `observe` computes the conservative label
   join and emits diagnostics but writes nothing; `persist` writes the derived
-  label components onto every value write target. Propagation runs only when the
-  enforcement mode is at least `observe`; it derives and stores labels but never
-  rejects on its own.
+  label components onto value write targets, except where the target's declared
+  store policy already carries every clause the join would state there — a
+  derived entry repeating it changes no label a reader resolves, so the persist
+  seam drops it. Propagation runs only when the enforcement mode is at least
+  `observe`; it derives and stores labels but never rejects on its own.
 - **Current default and planned end state.** `off` by default. The target is to
   move toward `persist` as the downstream egress gates (render ceiling, sink
   ceilings, and the LLM path) come online.

--- a/docs/specs/cfc-spec-changes.md
+++ b/docs/specs/cfc-spec-changes.md
@@ -1028,3 +1028,53 @@ committed field is unenforceable — the plaintext arm of this rule rejects a
 malformed owner and the committed arm cannot, which is a general property of
 every check that validates a commitment-classified field rather than
 something particular to this one.
+
+## From the redundant-entry collapse (2026-09-01)
+
+**SC-40 [editorial] The redundant-entry collapse spans components —
+§4.6.4.** `open`. §4.6.4's idempotent-label-persistence paragraph closes
+with a redundancy rule: "A derived-component entry whose label equals the
+effective label of its parent entry for the same component is redundant and
+SHOULD be dropped at persist time." The qualifier bounds the rule to an
+ancestor of the entry's own component. The runner drops a per-value entry
+whose clauses the DECLARED component already carries at that path, which the
+sentence does not describe.
+
+Three parts of the specification make the broader rule sound, and the entry
+proposes writing them into the sentence rather than leaving an
+implementation to assemble them. §8.12.8 makes the effective label at a path
+the join of the components present there, and that join is a clause union.
+§8.11.4 stores content and flow clauses in one array and does not track them
+apart at runtime, so a clause is the same clause whichever component supplies
+it. §10's compact observer model states that boundary noninterference is
+"not about forcing hidden clauses to be literally identical", and that a
+label map reached outside the first-layer introspection API is an
+"enforcement and proof/model artifact, not a public raw-label surface".
+§4.6.4's own operational guidance already permits avoiding a redundant stored
+template "as long as effective observation labels computed at boundaries are
+identical", which is the test the broader rule meets.
+
+The supplying component's update discipline is the part that has to be said
+out loud. A declared entry may supply the cover because §8.12.1 forbids it to
+shrink, so a clause it carries today it carries tomorrow. A link-carried
+entry may not: §8.12.8 has it replaced when the reference at the path is
+rewritten, which would take the covered clauses with it and leave nothing
+stating them.
+
+One boundary-visible difference follows from the drop rather than from the
+rule. §4.6.4.2 has metadata population fail closed for a declared entry —
+"This interim does not extend to declared or authored entries" — so a path
+left carrying its declaration alone reports its atoms' source-bearing fields
+as unobservable, where the derived entry that was dropped supplied them the
+interim label. That is §4.6.4.2's own treatment of a declared-only path,
+reached by removing an entry rather than by changing what any entry means.
+
+Proposed edit: restate the redundancy sentence over the effective label
+rather than over one component. A per-value entry whose clauses the
+components present at its path already carry is redundant and SHOULD be
+dropped at persist time, provided every supplying component's discipline
+forbids it to lower them — which admits the declared component and excludes
+the link-carried one. Name the observation-class axis in the same breath: the
+cover has to hold under each read class that consumes the entry, since a
+class-scoped declared entry can shadow a covering one for some classes and
+not others.

--- a/packages/runner/src/cfc/observation-classes.ts
+++ b/packages/runner/src/cfc/observation-classes.ts
@@ -63,6 +63,17 @@ const CONSUMED_CLASSES: Record<
 };
 
 /**
+ * Every classified read shape, in the order {@link CONSUMED_CLASSES} declares
+ * them. That record is typed over the whole union, so a shape added to
+ * {@link ReadObservationShape} without an entry there does not compile, and
+ * this list cannot fall behind it — which a hand-written array can, silently,
+ * for a caller that quantifies over the shapes to prove something about all
+ * of them.
+ */
+export const readObservationShapes = (): ReadObservationShape[] =>
+  Object.keys(CONSUMED_CLASSES) as ReadObservationShape[];
+
+/**
  * The consumption class of a persisted entry; `undefined` means covering
  * (consumed by every content read class). Implements the C0 §3 carve-out: a
  * legacy `origin:"link"` entry with absent `observes` is implicitly

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -252,6 +252,162 @@ const labelForEntriesAtPath = (
   return joined;
 };
 
+// The §4.6.4 redundant-entry collapse, applied to the per-value components
+// this pass mints. `labelForEntriesAtPath` resolves each component on its own
+// and joins the results, and that join is a clause union with structural
+// dedup, so a `derived` or `structure` entry contributes nothing at a path
+// where the DECLARED component already carries every one of its clauses.
+// Which component supplied a clause does not survive that join: §8.11.4
+// keeps content and flow clauses in one array rather than tracking them
+// apart, and §10's observer model has a label map outside the introspection
+// API as an enforcement artifact rather than an observable surface, so two
+// entry sets that resolve the same boundary labels say the same thing.
+//
+// The growth this closes shows up on a collection whose schema declares an
+// element label. An append reads the collection through that declaration, so
+// the transaction's join is the declared label, and stamping the join onto
+// the appended index records there what the declared `*` entry already says.
+// Two entries per element (the value/shape class split), plus the
+// label-metadata templates derived from them, accumulate for the life of the
+// collection and carry nothing a reader did not already have.
+//
+// Four conditions keep the collapse exact rather than merely fail-safe:
+// every effective label a boundary computes stays the label it computes with
+// the entry in place, rather than a wider one.
+//
+//  - The entry's path is concrete. At a concrete path the resolution
+//    computed here is the resolution a read performs. A `*` segment would
+//    make the entry stand for many concrete paths, at some of which a more
+//    specific declared entry could resolve instead.
+//  - No declared entry sits strictly below that path. Every read at-or-below
+//    the entry's path then resolves the declared component to what it
+//    resolves to at the entry's own path, which is the one place this checks.
+//  - The entry carries confidentiality only. Integrity is never unioned
+//    across components (§8.12.8), so a declared integrity claim cannot stand
+//    in for a per-value one.
+//  - The declared component covers the entry's clauses under every read
+//    selection that consumes the entry, and covers whatever the entry's own
+//    component resolves to once the entry is gone. `"all"` is one of those
+//    selections in its own right: it applies no class filter, so the
+//    declared entry it resolves to can be a classed one the classified
+//    selections filter out, carrying clauses their covers need not. The
+//    second half of the condition is what holds an entry in place while it
+//    shadows a less specific entry of its own component, whose label a read
+//    would otherwise start resolving instead.
+//
+// Past those conditions the collapse rests on the declared component not
+// shrinking, which §8.12.1 requires of it: a clause the declaration stops
+// carrying is one no dropped entry is left to state. The schema walk holds
+// to that by merging the stored envelope's own schema into the one a write
+// arrives with, so a write through a schema declaring less at a path does
+// not lower the entry there.
+//
+// One boundary-visible difference rides along. The §4.6.4.2 population rule
+// fails closed for a declared entry, so a path this leaves carrying its
+// declaration alone reports its atoms' source-bearing fields as
+// unobservable, where the derived entry it dropped supplied them the interim
+// label (`label-introspection.ts`).
+//
+// The `shape` (existence) entries collapse like any other, and the
+// freeze-at-creation mint reads their absence the way it reads the absence
+// left by a path created under an empty join: a later write to that path
+// whose join the declared component does not cover mints the existence entry
+// then, carrying that write's join.
+const READ_CLASS_SELECTIONS: readonly ReadClassSelection[] = [
+  "value",
+  "shape",
+  "followRef",
+  "all",
+];
+
+const clausesCoveredBy = (
+  clauses: readonly CfcConfClause[],
+  cover: readonly CfcConfClause[],
+): boolean => {
+  const normalizedCover = cover.map((clause) => normalizeClause(clause));
+  return clauses.every((clause) => {
+    const normalized = normalizeClause(clause);
+    return normalizedCover.some((candidate) =>
+      deepEqual(candidate, normalized)
+    );
+  });
+};
+
+const isRedundantWithDeclared = (
+  entry: LabelMapEntry,
+  declared: readonly LabelMapEntry[],
+  sameComponent: readonly LabelMapEntry[],
+): boolean => {
+  const clauses = entry.label.confidentiality ?? [];
+  if (clauses.length === 0 || (entry.label.integrity?.length ?? 0) > 0) {
+    return false;
+  }
+  const path = canonicalizeLogicalPath(entry.path);
+  if (path.includes("*")) {
+    return false;
+  }
+  if (
+    declared.some((candidate) => {
+      const candidatePath = canonicalizeLogicalPath(candidate.path);
+      return candidatePath.length > path.length &&
+        isPrefix(path, candidatePath);
+    })
+  ) {
+    return false;
+  }
+  return READ_CLASS_SELECTIONS.every((selection) => {
+    if (!readConsumesEntry(selection, entry)) {
+      return true;
+    }
+    const consumes = (candidate: LabelMapEntry) =>
+      readConsumesEntry(selection, candidate);
+    const cover =
+      labelForEntriesAtPath(declared.filter(consumes), path)?.confidentiality ??
+        [];
+    const residual = labelForEntriesAtPath(
+      sameComponent.filter((candidate) =>
+        candidate !== entry && consumes(candidate)
+      ),
+      path,
+    )?.confidentiality ?? [];
+    return clausesCoveredBy(clauses, cover) &&
+      clausesCoveredBy(residual, cover);
+  });
+};
+
+/**
+ * Drop the per-value entries the declared component already covers. Runs on
+ * the final payload entry set, before the label-metadata templates are
+ * derived from it, so a dropped entry takes its templates with it.
+ */
+const collapseRedundantEntries = (
+  entries: readonly LabelMapEntry[],
+): LabelMapEntry[] => {
+  const declared = entries.filter((entry) => entry.origin === "declared");
+  if (declared.length === 0) {
+    return [...entries];
+  }
+  const perValue = new Map<string, LabelMapEntry[]>();
+  for (const entry of entries) {
+    if (entry.origin === "derived" || entry.origin === "structure") {
+      const component = perValue.get(entry.origin);
+      if (component === undefined) {
+        perValue.set(entry.origin, [entry]);
+      } else {
+        component.push(entry);
+      }
+    }
+  }
+  return entries.filter((entry) =>
+    (entry.origin !== "derived" && entry.origin !== "structure") ||
+    !isRedundantWithDeclared(
+      entry,
+      declared,
+      perValue.get(entry.origin) ?? [],
+    )
+  );
+};
+
 // Effective label of a consumed read. A recursive read materializes the
 // whole subtree under `path`, so its label is the most-specific
 // ancestor-or-equal entry (§4.6.3 replace-down resolution) joined with
@@ -7264,6 +7420,16 @@ export const prepareBoundaryCommit = (
       }
     }
 
+    // The §4.6.4 redundant-entry collapse, ahead of the template derivation
+    // so a dropped entry takes its label-metadata templates with it. It runs
+    // on the final payload set, so it reaches carried-forward entries as well
+    // as this attempt's mints: a document that accumulated redundant
+    // per-value entries under an earlier build sheds them on its next
+    // persist.
+    const collapsedLabelEntries = collapseRedundantEntries(
+      persistedLabelEntries,
+    );
+
     // Stage B (template-population §5/§6; spec §4.6.4.2): derive the
     // label-metadata population templates from the FINAL payload entries —
     // after every clear/carry/mint AND after the Stage-1 representation
@@ -7277,21 +7443,21 @@ export const prepareBoundaryCommit = (
     // the per-path §4.6.4.1 metadata addressing requires. No new dial: the
     // templates describe whatever payload entries the existing dials
     // persisted.
-    persistedLabelEntries.push(
-      ...deriveLabelMetadataTemplateEntries(persistedLabelEntries),
+    collapsedLabelEntries.push(
+      ...deriveLabelMetadataTemplateEntries(collapsedLabelEntries),
     );
 
     const manifestFailures = installCarriedPolicyManifests(
       tx,
       space,
-      persistedLabelEntries,
+      collapsedLabelEntries,
     );
     if (manifestFailures.length > 0) {
       reasons.push(...manifestFailures);
       continue;
     }
 
-    const coalescedLabelEntries = coalesceLabelEntries(persistedLabelEntries);
+    const coalescedLabelEntries = coalesceLabelEntries(collapsedLabelEntries);
 
     if (
       coalescedLabelEntries.length === 0 && !flowCleared && !remintCleared &&

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -111,6 +111,7 @@ import {
   type ReadClassSelection,
   readConsumesEntry,
   type ReadObservationShape,
+  readObservationShapes,
 } from "./observation-classes.ts";
 import {
   atomsOutsideCeiling,
@@ -271,6 +272,14 @@ const labelForEntriesAtPath = (
 // label-metadata templates derived from them, accumulate for the life of the
 // collection and carry nothing a reader did not already have.
 //
+// How much of that an append sheds depends on whether the runtime attributes
+// it. An action transaction carries an implementation identity, which mints
+// §8.9.3's `TransformedBy` into the join's integrity, and the value stamp
+// carries it; no declaration states derivation provenance, so the third
+// condition below keeps that stamp and the templates derived from it. What
+// collapses on an attributed append is the confidentiality-only shape stamps,
+// leaving four entries per element where an unattributed one leaves none.
+//
 // Four conditions keep the collapse exact rather than merely fail-safe:
 // every effective label a boundary computes stays the label it computes with
 // the entry in place, rather than a wider one.
@@ -287,13 +296,23 @@ const labelForEntriesAtPath = (
 //    in for a per-value one.
 //  - The declared component covers the entry's clauses under every read
 //    selection that consumes the entry, and covers whatever the entry's own
-//    component resolves to once the entry is gone. `"all"` is one of those
-//    selections in its own right: it applies no class filter, so the
-//    declared entry it resolves to can be a classed one the classified
-//    selections filter out, carrying clauses their covers need not. The
-//    second half of the condition is what holds an entry in place while it
-//    shadows a less specific entry of its own component, whose label a read
-//    would otherwise start resolving instead.
+//    component resolves to once the entry is gone; and that residual
+//    resolution carries no integrity the resolution with the entry in place
+//    does not. `"all"` is one of those selections in its own right: it
+//    applies no class filter, so the declared entry it resolves to can be a
+//    classed one the classified selections filter out, carrying clauses
+//    their covers need not.
+//
+//    The residual half of that condition is what holds an entry in place
+//    while it shadows a less specific entry of its own component.
+//    Replace-down picks one entry per component, so dropping this one hands
+//    reads at its path the whole of the ancestor's label: its
+//    confidentiality, which the cover has to carry, and its integrity, which
+//    no other component states. Integrity arriving that way is an
+//    over-claim, and §8.9.3's hereditary meet is what it would fool — the
+//    weakest-link rule turns on a read of this path resolving no
+//    certification, and the ancestor's would survive the meet in its
+//    place.
 //
 // Past those conditions the collapse rests on the declared component not
 // shrinking, which §8.12.1 requires of it: a clause the declaration stops
@@ -314,64 +333,129 @@ const labelForEntriesAtPath = (
 // whose join the declared component does not cover mints the existence entry
 // then, carrying that write's join.
 const READ_CLASS_SELECTIONS: readonly ReadClassSelection[] = [
-  "value",
-  "shape",
-  "followRef",
+  ...readObservationShapes(),
   "all",
 ];
+
+const atomsContained = (
+  atoms: readonly unknown[],
+  within: readonly unknown[],
+): boolean =>
+  atoms.every((atom) => within.some((candidate) => deepEqual(candidate, atom)));
 
 const clausesCoveredBy = (
   clauses: readonly CfcConfClause[],
   cover: readonly CfcConfClause[],
-): boolean => {
-  const normalizedCover = cover.map((clause) => normalizeClause(clause));
-  return clauses.every((clause) => {
-    const normalized = normalizeClause(clause);
-    return normalizedCover.some((candidate) =>
-      deepEqual(candidate, normalized)
-    );
-  });
+): boolean =>
+  atomsContained(
+    clauses.map((clause) => normalizeClause(clause)),
+    cover.map((clause) => normalizeClause(clause)),
+  );
+
+/**
+ * Entries arranged so the ones bearing on a concrete path are found without
+ * walking the set. `labelForEntriesAtPath` considers exactly the entries
+ * `isPrefix(entry.path, path)` admits, and for a concrete path that is the
+ * entry's own path, one of its prefixes, or a `*` pattern matching one of
+ * them — so a keyed lookup per prefix plus a walk of the `*` entries finds
+ * every one of them. The `*` entries are a schema's `items` templates and the
+ * runtime's `*`-child class templates, whose count follows the schema and the
+ * container inventory rather than a collection's length.
+ *
+ * `descendants` answers the other direction, for the condition that refuses
+ * an entry with a declared entry strictly below it: it holds a key for each
+ * strict prefix of each concrete path, so the question is one lookup.
+ */
+type PathIndex = {
+  byPath: Map<string, LabelMapEntry[]>;
+  patterns: LabelMapEntry[];
+  descendants: Set<string>;
 };
+
+const pathIndexOf = (entries: readonly LabelMapEntry[]): PathIndex => {
+  const byPath = new Map<string, LabelMapEntry[]>();
+  const patterns: LabelMapEntry[] = [];
+  const descendants = new Set<string>();
+  for (const entry of entries) {
+    const path = canonicalizeLogicalPath(entry.path);
+    if (path.includes("*")) {
+      patterns.push(entry);
+      continue;
+    }
+    const key = pathKey(path);
+    const at = byPath.get(key);
+    if (at === undefined) {
+      byPath.set(key, [entry]);
+    } else {
+      at.push(entry);
+    }
+    for (let depth = 0; depth < path.length; depth++) {
+      descendants.add(pathKey(path.slice(0, depth)));
+    }
+  }
+  return { byPath, patterns, descendants };
+};
+
+/** The indexed entries that bear on a read at `path`. */
+const indexedEntriesAt = (
+  index: PathIndex,
+  path: readonly string[],
+): LabelMapEntry[] => {
+  const out = index.patterns.filter((entry) =>
+    isPrefix(canonicalizeLogicalPath(entry.path), path)
+  );
+  for (let depth = 0; depth <= path.length; depth++) {
+    const at = index.byPath.get(pathKey(path.slice(0, depth)));
+    if (at !== undefined) {
+      out.push(...at);
+    }
+  }
+  return out;
+};
+
+/** Whether an indexed entry sits strictly below `path`. */
+const indexedEntryBelow = (
+  index: PathIndex,
+  path: readonly string[],
+): boolean =>
+  index.descendants.has(pathKey(path)) ||
+  index.patterns.some((entry) => {
+    const entryPath = canonicalizeLogicalPath(entry.path);
+    return entryPath.length > path.length && isPrefix(path, entryPath);
+  });
 
 const isRedundantWithDeclared = (
   entry: LabelMapEntry,
-  declared: readonly LabelMapEntry[],
-  sameComponent: readonly LabelMapEntry[],
+  declared: PathIndex,
+  sameComponent: PathIndex,
 ): boolean => {
   const clauses = entry.label.confidentiality ?? [];
   if (clauses.length === 0 || (entry.label.integrity?.length ?? 0) > 0) {
     return false;
   }
   const path = canonicalizeLogicalPath(entry.path);
-  if (path.includes("*")) {
+  if (path.includes("*") || indexedEntryBelow(declared, path)) {
     return false;
   }
-  if (
-    declared.some((candidate) => {
-      const candidatePath = canonicalizeLogicalPath(candidate.path);
-      return candidatePath.length > path.length &&
-        isPrefix(path, candidatePath);
-    })
-  ) {
-    return false;
-  }
+  const declaredAt = indexedEntriesAt(declared, path);
+  const sameComponentAt = indexedEntriesAt(sameComponent, path);
   return READ_CLASS_SELECTIONS.every((selection) => {
     if (!readConsumesEntry(selection, entry)) {
       return true;
     }
     const consumes = (candidate: LabelMapEntry) =>
       readConsumesEntry(selection, candidate);
-    const cover =
-      labelForEntriesAtPath(declared.filter(consumes), path)?.confidentiality ??
-        [];
+    const consumed = sameComponentAt.filter(consumes);
+    const cover = labelForEntriesAtPath(declaredAt.filter(consumes), path)
+      ?.confidentiality ?? [];
+    const shadowed = labelForEntriesAtPath(consumed, path);
     const residual = labelForEntriesAtPath(
-      sameComponent.filter((candidate) =>
-        candidate !== entry && consumes(candidate)
-      ),
+      consumed.filter((candidate) => candidate !== entry),
       path,
-    )?.confidentiality ?? [];
+    );
     return clausesCoveredBy(clauses, cover) &&
-      clausesCoveredBy(residual, cover);
+      clausesCoveredBy(residual?.confidentiality ?? [], cover) &&
+      atomsContained(residual?.integrity ?? [], shadowed?.integrity ?? []);
   });
 };
 
@@ -387,25 +471,22 @@ const collapseRedundantEntries = (
   if (declared.length === 0) {
     return [...entries];
   }
-  const perValue = new Map<string, LabelMapEntry[]>();
-  for (const entry of entries) {
-    if (entry.origin === "derived" || entry.origin === "structure") {
-      const component = perValue.get(entry.origin);
-      if (component === undefined) {
-        perValue.set(entry.origin, [entry]);
-      } else {
-        component.push(entry);
-      }
-    }
-  }
-  return entries.filter((entry) =>
-    (entry.origin !== "derived" && entry.origin !== "structure") ||
-    !isRedundantWithDeclared(
-      entry,
-      declared,
-      perValue.get(entry.origin) ?? [],
-    )
+  const declaredIndex = pathIndexOf(declared);
+  const derivedIndex = pathIndexOf(
+    entries.filter((entry) => entry.origin === "derived"),
   );
+  const structureIndex = pathIndexOf(
+    entries.filter((entry) => entry.origin === "structure"),
+  );
+  return entries.filter((entry) => {
+    const sameComponent = entry.origin === "derived"
+      ? derivedIndex
+      : entry.origin === "structure"
+      ? structureIndex
+      : undefined;
+    return sameComponent === undefined ||
+      !isRedundantWithDeclared(entry, declaredIndex, sameComponent);
+  });
 };
 
 // Effective label of a consumed read. A recursive read materializes the

--- a/packages/runner/test/cfc-policy-manifest-consultation.test.ts
+++ b/packages/runner/test/cfc-policy-manifest-consultation.test.ts
@@ -546,12 +546,19 @@ describe("module-policy manifest consultation", () => {
       );
       expect(stored?.value).toEqual(artifact);
       expect(stored?.cfc).toBeUndefined();
-      // The derived write itself was measured: the tainted join persisted a
-      // derived component onto the declared-covered target.
+      // The value target went through the persist loop while the manifest
+      // document did not: its envelope carries the declared store policy,
+      // and no derived component beside it — the tainted join is the
+      // declared policy, which the §4.6.4 redundant-entry collapse leaves
+      // stated once.
       const derivedEntries =
         storedDocument(storageManager, derivedId)?.cfc?.labelMap?.entries ?? [];
+      expect(derivedEntries.some((entry) =>
+        entry.origin === "declared" &&
+        (entry.label.confidentiality ?? []).includes("secret")
+      )).toBe(true);
       expect(derivedEntries.some((entry) => entry.origin === "derived")).toBe(
-        true,
+        false,
       );
       expect(
         tx.getCfcState().diagnostics.filter((diagnostic) =>

--- a/packages/runner/test/cfc-redundant-entry-collapse.test.ts
+++ b/packages/runner/test/cfc-redundant-entry-collapse.test.ts
@@ -408,6 +408,87 @@ describe("CFC redundant entry collapse", () => {
     }
   });
 
+  it("keeps a wildcard-path stamp a declaration at the same pattern covers", async () => {
+    // A `*` path stands for many concrete paths, and the declared component
+    // can resolve differently at some of them, so the resolution computed at
+    // the pattern itself does not settle the question the collapse asks.
+
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = newRuntime(storageManager);
+    try {
+      const mapSchema = {
+        type: "object",
+        additionalProperties: {
+          type: "string",
+          ifc: { confidentiality: [cfcAtom.resource("Shared")] },
+        },
+      } as unknown as JSONSchema;
+      const mapId = runtime
+        .getCell<Record<string, string>>(
+          signer.did(),
+          "collapse-template-map",
+          mapSchema,
+        )
+        .getAsNormalizedFullLink().id;
+
+      // A `*`-child class template of the kind a declared coordinator
+      // container is stamped with, carrying exactly what the declaration
+      // beside it carries.
+      const seed = runtime.edit();
+      writeSeedEnvelopeDoc(seed, signer.did());
+      seed.writeOrThrow({
+        space: signer.did(),
+        scope: "space",
+        id: mapId,
+        path: [],
+      }, {
+        value: { kept: "1" },
+        cfc: {
+          version: 1,
+          schemaHash: SEED_ENVELOPE_SCHEMA_HASH,
+          labelMap: {
+            version: 1,
+            entries: [
+              {
+                path: ["*"],
+                label: { confidentiality: [cfcAtom.resource("Shared")] },
+                origin: "declared",
+              },
+              {
+                path: ["*"],
+                label: { confidentiality: [cfcAtom.resource("Shared")] },
+                origin: "structure",
+                observes: "shape",
+              },
+            ],
+          },
+        },
+        // deno-lint-ignore no-explicit-any
+      } as any);
+      expect((await seed.commit()).ok).toBeDefined();
+
+      const tx = runtime.edit();
+      runtime.getCell<Record<string, string>>(
+        signer.did(),
+        "collapse-template-map",
+        mapSchema,
+        tx,
+      ).key("added").set("2");
+      tx.prepareCfc();
+      expect((await tx.commit()).ok).toBeDefined();
+
+      const entries = replicaEntries(storageManager, mapId);
+      expect(
+        entries.some((entry) =>
+          entry.origin === "structure" && entry.path.join("/") === "*"
+        ),
+      ).toBe(true);
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
   it("keeps the root stamps a wildcard child declaration does not reach", async () => {
     // A declared entry at `["*"]` covers the children and not the container
     // node they hang off, so the stamps recording what the container's own

--- a/packages/runner/test/cfc-redundant-entry-collapse.test.ts
+++ b/packages/runner/test/cfc-redundant-entry-collapse.test.ts
@@ -1,0 +1,334 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import type { FabricValue } from "@commonfabric/api";
+import { Identity } from "@commonfabric/identity";
+import { cfcAtom } from "@commonfabric/api/cfc";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { JSONSchema } from "../src/builder/types.ts";
+import {
+  SEED_ENVELOPE_SCHEMA_HASH,
+  writeSeedEnvelopeDoc,
+} from "./cfc-seed-envelope.ts";
+
+const signer = await Identity.fromPassphrase("runner-cfc-redundant-collapse");
+
+type StoredEntry = {
+  path: string[];
+  label: { confidentiality?: unknown[]; integrity?: unknown[] };
+  origin?: string;
+};
+
+const replicaEntries = (
+  storageManager: ReturnType<typeof StorageManager.emulate>,
+  id: string,
+): StoredEntry[] => {
+  const replica = storageManager.open(signer.did()).replica as unknown as {
+    getDocument(id: string): {
+      cfc?: { labelMap?: { entries: StoredEntry[] } };
+    } | undefined;
+  };
+  return replica.getDocument(id)?.cfc?.labelMap?.entries ?? [];
+};
+
+const newRuntime = (
+  storageManager: ReturnType<typeof StorageManager.emulate>,
+) =>
+  new Runtime({
+    apiUrl: new URL("https://example.com"),
+    storageManager,
+    cfcEnforcementMode: "enforce-explicit",
+    cfcFlowLabels: "persist",
+  });
+
+// A list whose elements the schema declares `Resource(Secret)` on. The
+// declared entry lands at the wildcard child path `["*"]`, which covers every
+// index and `length`.
+const labeledListSchema = {
+  type: "array",
+  items: {
+    type: "string",
+    ifc: { confidentiality: [cfcAtom.resource("Secret")] },
+  },
+} as unknown as JSONSchema;
+
+// Seed a document carrying `confidentiality` on its `secret` field, so a
+// transaction reading it takes those clauses into the per-transaction join.
+const seedSource = async (
+  runtime: Runtime,
+  name: string,
+  confidentiality: readonly FabricValue[],
+) => {
+  const seed = runtime.edit();
+  const source = runtime.getCell(signer.did(), name, {
+    type: "object",
+    properties: { secret: { type: "string" } },
+  } as JSONSchema);
+  const sourceId = source.getAsNormalizedFullLink().id;
+  writeSeedEnvelopeDoc(seed, signer.did());
+  seed.writeOrThrow({
+    space: signer.did(),
+    scope: "space",
+    id: sourceId,
+    path: [],
+  }, {
+    value: { secret: "s3cr3t" },
+    cfc: {
+      version: 1,
+      schemaHash: SEED_ENVELOPE_SCHEMA_HASH,
+      labelMap: {
+        version: 1,
+        entries: [{
+          path: ["secret"],
+          label: { confidentiality: [...confidentiality] },
+        }],
+      },
+    },
+  });
+  expect((await seed.commit()).ok).toBeDefined();
+};
+
+describe("CFC redundant entry collapse", () => {
+  // A `derived` or `structure` entry whose clauses the declared component
+  // already carries at the same path adds nothing to the label a boundary
+  // resolves: `labelForEntriesAtPath` resolves each component separately and
+  // joins the results, and the join deduplicates clauses structurally. Such
+  // an entry is dropped at persist time (spec §4.6.4).
+
+  it("holds a labeled list's label map at its declared entry across appends", async () => {
+    // Appending reads the list through its own element declaration, so the
+    // transaction's join is that declaration. Stamping the join onto the new
+    // index would record there what the `["*"]` entry already says, and the
+    // metadata templates derived from those stamps would follow — five
+    // entries per element, for the life of the list.
+
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = newRuntime(storageManager);
+    try {
+      const seeded = runtime.edit();
+      runtime.getCell<string[]>(
+        signer.did(),
+        "collapse-labeled-list",
+        labeledListSchema,
+        seeded,
+      ).set(["seed"]);
+      seeded.prepareCfc();
+      expect((await seeded.commit()).ok).toBeDefined();
+
+      const listId = runtime
+        .getCell<string[]>(
+          signer.did(),
+          "collapse-labeled-list",
+          labeledListSchema,
+        )
+        .getAsNormalizedFullLink().id;
+      const seededEntries = replicaEntries(storageManager, listId);
+      expect(seededEntries).toEqual([{
+        path: ["*"],
+        label: { confidentiality: [cfcAtom.resource("Secret")] },
+        origin: "declared",
+      }]);
+
+      for (const element of ["A", "B", "C"]) {
+        const tx = runtime.edit();
+        runtime.getCell<string[]>(
+          signer.did(),
+          "collapse-labeled-list",
+          labeledListSchema,
+          tx,
+        ).push(element);
+        tx.prepareCfc();
+        // Nothing to say about the envelope means no envelope write: the
+        // SC-11 canonical comparison finds the recomputed metadata identical
+        // and the append leaves the `["cfc"]` document alone.
+        expect(
+          [...(tx.getWriteDetails?.(signer.did()) ?? [])].filter((write) =>
+            write.address.id === listId && write.address.path[0] === "cfc"
+          ),
+        ).toEqual([]);
+        expect((await tx.commit()).ok).toBeDefined();
+      }
+
+      expect(replicaEntries(storageManager, listId)).toEqual(seededEntries);
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("keeps a stamp carrying a clause the declared component does not", async () => {
+    // The join of an append that also read an unrelated labeled source
+    // carries a clause the element declaration does not, so the stamp is
+    // the only place that clause is recorded at the appended index.
+
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = newRuntime(storageManager);
+    try {
+      await seedSource(runtime, "collapse-foreign-source", [
+        cfcAtom.resource("Other"),
+      ]);
+
+      const seeded = runtime.edit();
+      runtime.getCell<string[]>(
+        signer.did(),
+        "collapse-mixed-list",
+        labeledListSchema,
+        seeded,
+      ).set(["seed"]);
+      seeded.prepareCfc();
+      expect((await seeded.commit()).ok).toBeDefined();
+
+      const tx = runtime.edit();
+      const source = runtime.getCell(
+        signer.did(),
+        "collapse-foreign-source",
+        undefined,
+        tx,
+      );
+      const raw = source.getRaw() as { secret?: string };
+      runtime.getCell<string[]>(
+        signer.did(),
+        "collapse-mixed-list",
+        labeledListSchema,
+        tx,
+      ).push(`${raw.secret}!`);
+      tx.prepareCfc();
+      expect((await tx.commit()).ok).toBeDefined();
+
+      const listId = runtime
+        .getCell<string[]>(
+          signer.did(),
+          "collapse-mixed-list",
+          labeledListSchema,
+        )
+        .getAsNormalizedFullLink().id;
+      const stamped = replicaEntries(storageManager, listId).filter((entry) =>
+        entry.origin === "derived" && entry.path.join("/") === "1"
+      );
+      expect(stamped.length).toBeGreaterThan(0);
+      for (const entry of stamped) {
+        expect(entry.label.confidentiality).toContainEqual(
+          cfcAtom.resource("Other"),
+        );
+      }
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("keeps the root stamps a wildcard child declaration does not reach", async () => {
+    // A declared entry at `["*"]` covers the children and not the container
+    // node they hang off, so the stamps recording what the container's own
+    // write derived from stay where they are.
+
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = newRuntime(storageManager);
+    try {
+      await seedSource(runtime, "collapse-container-source", [
+        cfcAtom.resource("Outer"),
+      ]);
+
+      const tx = runtime.edit();
+      const source = runtime.getCell(
+        signer.did(),
+        "collapse-container-source",
+        undefined,
+        tx,
+      );
+      const raw = source.getRaw() as { secret?: string };
+      const map = runtime.getCell<Record<string, string>>(
+        signer.did(),
+        "collapse-container-map",
+        {
+          type: "object",
+          additionalProperties: {
+            type: "string",
+            ifc: { confidentiality: [cfcAtom.resource("Secret")] },
+          },
+        } as unknown as JSONSchema,
+        tx,
+      );
+      map.set({ first: `${raw.secret}!` });
+      const mapId = map.getAsNormalizedFullLink().id;
+      tx.prepareCfc();
+      expect((await tx.commit()).ok).toBeDefined();
+
+      const entries = replicaEntries(storageManager, mapId);
+      expect(
+        entries.some((entry) =>
+          entry.origin === "declared" && entry.path.join("/") === "*"
+        ),
+      ).toBe(true);
+      const rootStamps = entries.filter((entry) =>
+        entry.origin === "derived" && entry.path.length === 0
+      );
+      expect(rootStamps.length).toBeGreaterThan(0);
+      for (const entry of rootStamps) {
+        expect(entry.label.confidentiality).toContainEqual(
+          cfcAtom.resource("Outer"),
+        );
+      }
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("keeps a stamp a more specific declared entry sits below", async () => {
+    // The declared component resolves by longest matching prefix, so the
+    // `["inner"]` declaration replaces the root declaration for reads at that
+    // path. A root stamp the root declaration covers is therefore not covered
+    // one segment down, and dropping it would lower the label there.
+
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = newRuntime(storageManager);
+    try {
+      await seedSource(runtime, "collapse-nested-source", [
+        cfcAtom.resource("Outer"),
+      ]);
+
+      const tx = runtime.edit();
+      const source = runtime.getCell(
+        signer.did(),
+        "collapse-nested-source",
+        undefined,
+        tx,
+      );
+      const raw = source.getRaw() as { secret?: string };
+      const target = runtime.getCell<{ inner?: string }>(
+        signer.did(),
+        "collapse-nested-target",
+        {
+          type: "object",
+          properties: {
+            inner: {
+              type: "string",
+              ifc: { confidentiality: [cfcAtom.resource("Inner")] },
+            },
+          },
+          ifc: { confidentiality: [cfcAtom.resource("Outer")] },
+        } as unknown as JSONSchema,
+        tx,
+      );
+      target.set({ inner: `${raw.secret}!` });
+      const targetId = target.getAsNormalizedFullLink().id;
+      tx.prepareCfc();
+      expect((await tx.commit()).ok).toBeDefined();
+
+      const entries = replicaEntries(storageManager, targetId);
+      const rootStamps = entries.filter((entry) =>
+        entry.origin === "derived" && entry.path.length === 0
+      );
+      expect(rootStamps.length).toBeGreaterThan(0);
+      for (const entry of rootStamps) {
+        expect(entry.label.confidentiality).toEqual([
+          cfcAtom.resource("Outer"),
+        ]);
+      }
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+});

--- a/packages/runner/test/cfc-redundant-entry-collapse.test.ts
+++ b/packages/runner/test/cfc-redundant-entry-collapse.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import type { FabricValue } from "@commonfabric/api";
 import { Identity } from "@commonfabric/identity";
-import { cfcAtom } from "@commonfabric/api/cfc";
+import { CFC_ATOM_TYPE, cfcAtom } from "@commonfabric/api/cfc";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import { Runtime } from "../src/runtime.ts";
 import type { JSONSchema } from "../src/builder/types.ts";
@@ -58,6 +58,7 @@ const seedSource = async (
   runtime: Runtime,
   name: string,
   confidentiality: readonly FabricValue[],
+  integrity: readonly FabricValue[] = [],
 ) => {
   const seed = runtime.edit();
   const source = runtime.getCell(signer.did(), name, {
@@ -80,7 +81,10 @@ const seedSource = async (
         version: 1,
         entries: [{
           path: ["secret"],
-          label: { confidentiality: [...confidentiality] },
+          label: {
+            confidentiality: [...confidentiality],
+            ...(integrity.length > 0 ? { integrity: [...integrity] } : {}),
+          },
         }],
       },
     },
@@ -211,6 +215,193 @@ describe("CFC redundant entry collapse", () => {
           cfcAtom.resource("Other"),
         );
       }
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("keeps a stamp carrying integrity where the declaration covers its clauses", async () => {
+    // Integrity is never unioned across components, so a declared entry
+    // stating the same confidentiality does not stand in for one. The
+    // confidentiality-only existence stamp beside it is covered and goes.
+
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = newRuntime(storageManager);
+    try {
+      const certified = {
+        type: CFC_ATOM_TYPE.PolicyCertified,
+        policy: "collapse-policy",
+      };
+      await seedSource(
+        runtime,
+        "collapse-certified-source",
+        [cfcAtom.resource("Shared")],
+        [certified],
+      );
+
+      // The target carries the same certification, so the write's read of
+      // its prior value does not empty the weakest-link integrity meet.
+      const targetSchema = {
+        type: "object",
+        properties: { copied: { type: "string" } },
+        ifc: { confidentiality: [cfcAtom.resource("Shared")] },
+      } as unknown as JSONSchema;
+      const targetId = runtime
+        .getCell(signer.did(), "collapse-certified-target", targetSchema)
+        .getAsNormalizedFullLink().id;
+      const seedTarget = runtime.edit();
+      writeSeedEnvelopeDoc(seedTarget, signer.did());
+      seedTarget.writeOrThrow({
+        space: signer.did(),
+        scope: "space",
+        id: targetId,
+        path: [],
+      }, {
+        value: {},
+        cfc: {
+          version: 1,
+          schemaHash: SEED_ENVELOPE_SCHEMA_HASH,
+          labelMap: {
+            version: 1,
+            entries: [{
+              path: [],
+              label: {
+                confidentiality: [cfcAtom.resource("Shared")],
+                integrity: [certified],
+              },
+              origin: "declared",
+            }],
+          },
+        },
+      });
+      expect((await seedTarget.commit()).ok).toBeDefined();
+
+      const tx = runtime.edit();
+      const source = runtime.getCell(
+        signer.did(),
+        "collapse-certified-source",
+        undefined,
+        tx,
+      );
+      const raw = source.getRaw() as { secret?: string };
+      runtime.getCell<{ copied?: string }>(
+        signer.did(),
+        "collapse-certified-target",
+        targetSchema,
+        tx,
+      ).set({ copied: `${raw.secret}!` });
+      tx.prepareCfc();
+      expect((await tx.commit()).ok).toBeDefined();
+
+      const entries = replicaEntries(storageManager, targetId);
+      const stamps = entries.filter((entry) => entry.origin === "derived");
+      expect(stamps.length).toBeGreaterThan(0);
+      for (const entry of stamps) {
+        expect(entry.label.integrity).toContainEqual(certified);
+      }
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("keeps a stamp whose own component carries integrity above it", async () => {
+    // Replace-down picks one entry per component, so a child stamp hides its
+    // ancestor's whole label. Dropping the child would hand reads at its path
+    // the ancestor's integrity — certification for content derived from none
+    // — which is the over-claim §8.9.3's weakest-link meet exists to refuse.
+
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = newRuntime(storageManager);
+    try {
+      const certified = {
+        type: CFC_ATOM_TYPE.PolicyCertified,
+        policy: "collapse-shadowed",
+      };
+      const mapSchema = {
+        type: "object",
+        additionalProperties: {
+          type: "string",
+          ifc: { confidentiality: [cfcAtom.resource("Shared")] },
+        },
+      } as unknown as JSONSchema;
+      const mapId = runtime
+        .getCell<Record<string, string>>(
+          signer.did(),
+          "collapse-shadowed-map",
+          mapSchema,
+        )
+        .getAsNormalizedFullLink().id;
+
+      // The state an earlier certified write over the container leaves, with
+      // a later uncertified write to one child under it.
+      const seed = runtime.edit();
+      writeSeedEnvelopeDoc(seed, signer.did());
+      seed.writeOrThrow({
+        space: signer.did(),
+        scope: "space",
+        id: mapId,
+        path: [],
+      }, {
+        value: { kept: "1" },
+        cfc: {
+          version: 1,
+          schemaHash: SEED_ENVELOPE_SCHEMA_HASH,
+          labelMap: {
+            version: 1,
+            entries: [
+              {
+                path: ["*"],
+                label: { confidentiality: [cfcAtom.resource("Shared")] },
+                origin: "declared",
+              },
+              {
+                path: [],
+                label: {
+                  confidentiality: [cfcAtom.resource("Shared")],
+                  integrity: [certified],
+                },
+                origin: "derived",
+                observes: "value",
+              },
+              {
+                path: ["kept"],
+                label: { confidentiality: [cfcAtom.resource("Shared")] },
+                origin: "derived",
+                observes: "value",
+              },
+            ],
+          },
+        },
+        // deno-lint-ignore no-explicit-any
+      } as any);
+      expect((await seed.commit()).ok).toBeDefined();
+
+      // Any further persist rebuilds the entry set and runs the collapse over
+      // it, carried-forward entries included.
+      const tx = runtime.edit();
+      runtime.getCell<Record<string, string>>(
+        signer.did(),
+        "collapse-shadowed-map",
+        mapSchema,
+        tx,
+      ).key("added").set("2");
+      tx.prepareCfc();
+      expect((await tx.commit()).ok).toBeDefined();
+
+      const entries = replicaEntries(storageManager, mapId);
+      expect(
+        entries.some((entry) =>
+          entry.origin === "derived" && entry.path.join("/") === "kept"
+        ),
+      ).toBe(true);
+      expect(
+        entries.some((entry) =>
+          entry.origin === "derived" && entry.path.length === 0 &&
+          (entry.label.integrity ?? []).length > 0
+        ),
+      ).toBe(true);
     } finally {
       await runtime.dispose();
       await storageManager.close();

--- a/packages/runner/test/cfc-writer-fit.test.ts
+++ b/packages/runner/test/cfc-writer-fit.test.ts
@@ -358,7 +358,11 @@ describe("CFC writer-fit (canWrite, §8.12.4 / SC-18b)", () => {
         e.origin === "declared" &&
         (e.label.confidentiality ?? []).includes("secret")
       )).toBe(true);
-      expect(entries.some((e) => e.origin === "derived")).toBe(true);
+      // Nothing is stamped beside it: the join the write carried is the
+      // declared policy itself, and a derived entry repeating it adds
+      // nothing to the label a read resolves at any path (§4.6.4
+      // redundant-entry collapse).
+      expect(entries.some((e) => e.origin === "derived")).toBe(false);
       expect(
         tx.getCfcState().diagnostics.filter((d) => d.includes("writer-fit")),
       ).toEqual([]);


### PR DESCRIPTION
With flow labels persisting, appending an element to a collection whose schema declares an element label grew that document's stored `["cfc"]` label map by five entries, and every one of them said what a covering entry already said.

The append reads the collection, and that read resolves the collection's own declared element label, so the transaction's join is the declared label. The persist seam then stamps that join at each written path -- the new index and `length` -- as a `derived` entry per observation class, and the label-metadata population pass mints a template per protected atom field beside each of them. Resolving a label at a path joins the declared component's answer with the derived component's, and the join is a clause union with structural deduplication, so the stamps changed no label anyone could resolve. A list of N elements accumulated on the order of 5N such entries, and every append rewrote the envelope.

The persist seam now drops a `derived` or `structure` entry whose clauses the declared component already carries at its path, ahead of deriving the label-metadata templates from the entry set, so a dropped entry takes its templates with it. Four conditions keep the collapse exact rather than merely safe, meaning every label a boundary computes stays the label it computes with the entry in place rather than a wider one:

- the entry's path is concrete, so the resolution computed at it is the resolution a read performs;
- no declared entry sits strictly below that path, so every read below it resolves the declared component to the same thing;
- the entry carries confidentiality only, since integrity is never unioned across components (section 8.12.8);
- the declared component covers both the entry's clauses and whatever the entry's own component resolves to once the entry is gone, under every read selection that consumes the entry -- the unclassified `all` selection included, which can resolve a classed declared entry that the classified selections filter out.

Three parts of the specification carry the rule. Section 8.12.8 makes the effective label at a path the join of the components present there, and that join is a clause union. Section 8.11.4 stores content and flow clauses in one array and does not track them apart at runtime, so a clause is the same clause whichever component supplies it. Section 10's compact observer model states that boundary noninterference is "not about forcing hidden clauses to be literally identical", and that a label map reached outside the first-layer introspection API is an enforcement artifact rather than a public raw-label surface. Together: an entry set that resolves the same boundary labels is the same state, and the stored clause structure is not itself an observable.

Past the four conditions the collapse rests on the declared component not shrinking, which section 8.12.1 requires of it. That premise is not the declared-monotonicity dial, which ships off: the schema walk merges the stored envelope's own schema into the one a write arrives with, so a write through a schema declaring less at a path does not lower the entry there. Checked against three shapes of weakening -- a lower `ifc`, no `ifc`, and no schema at all -- each of which leaves the stored declaration standing. The link-carried component could not supply a cover on the same terms, since section 8.12.8 has it replaced when the reference at the path is rewritten, and the collapse admits declared covers alone.

Section 4.6.4's own redundancy sentence is narrower than this rule: it is bounded to "the effective label of its parent entry for the same component". SC-40 records the gap and proposes restating it over the effective label, with the supplying component's discipline and the observation-class axis named beside it.

The collapse runs over the final entry set rather than at the mint sites, so a document that accumulated these entries under an earlier build sheds them on its next persist. Where it empties an append's whole contribution the recomputed envelope is identical to the stored one, and the idempotence check then skips the `["cfc"]` write outright: an append to a labeled list touches only the list.

One boundary-visible difference rides along. Section 4.6.4.2 has metadata population fail closed for a declared entry -- "This interim does not extend to declared or authored entries" -- so a path left carrying its declaration alone reports its atoms' source-bearing fields as unobservable, where the dropped derived entry supplied them the interim label. That is section 4.6.4.2's own treatment of a declared-only path, reached by removing an entry rather than by changing what any entry means.

Two existing tests asserted that a write whose declared policy covers its join persists a derived component beside the declared one. Those two facts are now mutually exclusive by construction, so the tests state the collapse instead.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6721?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

