### PR TITLE
fix(patterns): the lunch-poll scaling probe measures a poll again

### DIFF
--- a/packages/patterns/integration/fixtures/fabric-value-echo/main.tsx
+++ b/packages/patterns/integration/fixtures/fabric-value-echo/main.tsx
@@ -1,11 +1,14 @@
 import {
   Default,
   type FabricBytes,
+  handler,
   NAME,
   pattern,
   type PerSpace,
+  type Stream,
   UI,
   type VNode,
+  Writable,
 } from "commonfabric";
 
 /**
@@ -17,6 +20,16 @@ import {
  * boundary and nothing the pattern did to the value.
  */
 
+export interface SetWeirdEvent {
+  weird?: number;
+}
+
+const setWeird = handler<SetWeirdEvent, {
+  weird: Writable<Default<number, 0>>;
+}>(({ weird: next }, { weird }) => {
+  if (typeof next === "number") weird.set(next);
+});
+
 export interface FabricValueEchoInput {
   bytes?: PerSpace<FabricBytes | undefined>;
   weird?: PerSpace<Default<number, 0>>;
@@ -27,6 +40,9 @@ export interface FabricValueEchoOutput {
   [UI]: VNode;
   bytes?: PerSpace<FabricBytes | undefined>;
   weird: PerSpace<Default<number, 0>>;
+
+  /** A stream, which a result schema declares a cell. */
+  setWeird: Stream<SetWeirdEvent>;
 }
 
 export default pattern<FabricValueEchoInput, FabricValueEchoOutput>(
@@ -39,5 +55,6 @@ export default pattern<FabricValueEchoInput, FabricValueEchoOutput>(
     ),
     bytes,
     weird,
+    setWeird: setWeird({ weird }),
   }),
 );

--- a/packages/patterns/integration/lunch-poll-diagnose.test.ts
+++ b/packages/patterns/integration/lunch-poll-diagnose.test.ts
@@ -16,7 +16,7 @@
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
 import { linkRefFrom } from "@commonfabric/data-model/cell-rep";
-import { runCase, voterKey } from "../tools/lunch-poll-diagnose.ts";
+import { runCase, voterIdentity } from "../tools/lunch-poll-diagnose.ts";
 
 describe("lunch-poll-diagnose", () => {
   it("measures a poll two voters joined, filled, and voted in", async () => {
@@ -50,33 +50,56 @@ describe("lunch-poll-diagnose", () => {
     }
   });
 
-  describe("voterKey", () => {
+  describe("voterIdentity", () => {
     // A vote names its voter by profile cell, and a read of the poll output
     // hands that back either resolved or as the link that reaches it. Both
     // name the same person, and the convergence fingerprint is only a
     // comparison of vote sets while every voter has a key of their own.
 
+    const ID = "of:fid1:lj_-VYUlQNO3nl9TB-U3wTrLA7NTtge02az-NgnaA1g";
+    const SPACE = "did:key:z6Mkh7LjNUSoSVtFSQQRAVZz5XigakGLvLemwAeC4nCjQb4m";
+
     it("names a voter by the name on their resolved profile", () => {
-      expect(voterKey({ name: "User 1" })).toBe("User 1");
+      expect(voterIdentity({ name: "User 1" })).toEqual(["name", "User 1"]);
     });
 
     it("names a voter by the link that reaches their profile", () => {
-      const id = "of:fid1:lj_-VYUlQNO3nl9TB-U3wTrLA7NTtge02az-NgnaA1g";
-      const space = "did:key:z6Mkh7LjNUSoSVtFSQQRAVZz5XigakGLvLemwAeC4nCjQb4m";
-      const key = voterKey(
-        linkRefFrom({ path: [], id, space, scope: "space" }),
+      const identity = voterIdentity(
+        linkRefFrom({ path: [], id: ID, space: SPACE, scope: "space" }),
       );
-      expect(key).toBe(`${space}/${id}/`);
+      expect(identity).toEqual(["link", SPACE, ID, "space", []]);
+    });
+
+    it("tells two links apart by the scope they are stored under", () => {
+      const inSpace = linkRefFrom({
+        path: [],
+        id: ID,
+        space: SPACE,
+        scope: "space",
+      });
+      const perUser = linkRefFrom({
+        path: [],
+        id: ID,
+        space: SPACE,
+        scope: "user",
+      });
+      expect(voterIdentity(inSpace)).not.toEqual(voterIdentity(perUser));
+    });
+
+    it("tells two links apart when a path segment holds a separator", () => {
+      const nested = linkRefFrom({ path: ["a", "b"], id: ID, space: SPACE });
+      const dotted = linkRefFrom({ path: ["a.b"], id: ID, space: SPACE });
+      expect(voterIdentity(nested)).not.toEqual(voterIdentity(dotted));
     });
 
     it("names no voter for a vote that has none", () => {
-      expect(voterKey(undefined)).toBe("");
+      expect(voterIdentity(undefined)).toEqual([]);
     });
 
     it("refuses a voter it cannot name", () => {
       // An empty key for a voter who has one would read as a vote nobody
       // cast, in every session at once, and compare equal everywhere.
-      expect(() => voterKey({ profile: "not a link" })).toThrow(
+      expect(() => voterIdentity({ profile: "not a link" })).toThrow(
         "cannot identify",
       );
     });

--- a/packages/patterns/integration/lunch-poll-diagnose.test.ts
+++ b/packages/patterns/integration/lunch-poll-diagnose.test.ts
@@ -1,0 +1,51 @@
+/**
+ * The lunch-poll scaling probe still drives the poll it measures.
+ *
+ * `tools/lunch-poll-diagnose.ts` is the scaling diagnostic for the lunch
+ * poll, and nothing else runs it. Every step it drives is gated in the
+ * pattern — joining needs a resolved profile, adding an option needs the
+ * host, casting a vote needs a roster entry and a resolved clock — and a gate
+ * that refuses writes nothing and reports nothing. A probe driving a contract
+ * the pattern has moved on from therefore still finishes and still prints its
+ * JSON, reporting a matrix of zeros that reads like a measurement of an idle
+ * poll. This runs the smallest case the probe has and asks what it measured.
+ *
+ * No toolshed or browser required (Deno workers + in-process storage server).
+ */
+
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+import { runCase } from "../tools/lunch-poll-diagnose.ts";
+
+describe("lunch-poll-diagnose", () => {
+  it("measures a poll two voters joined, filled, and voted in", async () => {
+    const result = await runCase({
+      optionCount: 1,
+      userCount: 2,
+      voteRounds: 1,
+    });
+
+    // Both sessions see the same poll, and it is the poll the case asked
+    // for: two voters on the roster, the host's one option, and a vote from
+    // each of them.
+    expect(result.convergence.converged).toBe(true);
+    expect(result.convergence.userCounts).toEqual([2, 2]);
+    expect(result.convergence.optionCounts).toEqual([1, 1]);
+    expect(result.convergence.voteCounts).toEqual([2, 2]);
+
+    // The samples the probe exists to collect, taken at each phase.
+    expect(result.phases.map((phase) => phase.phase)).toEqual([
+      "baseline-open",
+      "all-users-join",
+      "host-adds-options",
+      "concurrent-vote-round-1",
+    ]);
+    for (const phase of result.phases) {
+      expect(phase.aggregate.maxNodes).toBeGreaterThan(0);
+      expect(phase.sessions.map((session) => session.label)).toEqual([
+        "user-1",
+        "user-2",
+      ]);
+    }
+  });
+});

--- a/packages/patterns/integration/lunch-poll-diagnose.test.ts
+++ b/packages/patterns/integration/lunch-poll-diagnose.test.ts
@@ -15,7 +15,8 @@
 
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
-import { runCase } from "../tools/lunch-poll-diagnose.ts";
+import { linkRefFrom } from "@commonfabric/data-model/cell-rep";
+import { runCase, voterKey } from "../tools/lunch-poll-diagnose.ts";
 
 describe("lunch-poll-diagnose", () => {
   it("measures a poll two voters joined, filled, and voted in", async () => {
@@ -47,5 +48,37 @@ describe("lunch-poll-diagnose", () => {
         "user-2",
       ]);
     }
+  });
+
+  describe("voterKey", () => {
+    // A vote names its voter by profile cell, and a read of the poll output
+    // hands that back either resolved or as the link that reaches it. Both
+    // name the same person, and the convergence fingerprint is only a
+    // comparison of vote sets while every voter has a key of their own.
+
+    it("names a voter by the name on their resolved profile", () => {
+      expect(voterKey({ name: "User 1" })).toBe("User 1");
+    });
+
+    it("names a voter by the link that reaches their profile", () => {
+      const id = "of:fid1:lj_-VYUlQNO3nl9TB-U3wTrLA7NTtge02az-NgnaA1g";
+      const space = "did:key:z6Mkh7LjNUSoSVtFSQQRAVZz5XigakGLvLemwAeC4nCjQb4m";
+      const key = voterKey(
+        linkRefFrom({ path: [], id, space, scope: "space" }),
+      );
+      expect(key).toBe(`${space}/${id}/`);
+    });
+
+    it("names no voter for a vote that has none", () => {
+      expect(voterKey(undefined)).toBe("");
+    });
+
+    it("refuses a voter it cannot name", () => {
+      // An empty key for a voter who has one would read as a vote nobody
+      // cast, in every session at once, and compare equal everywhere.
+      expect(() => voterKey({ profile: "not a link" })).toThrow(
+        "cannot identify",
+      );
+    });
   });
 });

--- a/packages/patterns/integration/multi-runtime-fidelity.test.ts
+++ b/packages/patterns/integration/multi-runtime-fidelity.test.ts
@@ -17,6 +17,7 @@ import { join } from "@std/path";
 import { Identity } from "@commonfabric/identity";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
+import { isObjectNotArray } from "@commonfabric/utils/types";
 import {
   MultiRuntimeHarness,
   type MultiRuntimeSession,
@@ -33,6 +34,11 @@ const BYTES: (string | number)[] = ["bytes"];
 const WEIRD: (string | number)[] = ["weird"];
 
 const CONTENT = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
+
+/** Whether `value` is a link sigil, the form a cell crosses the boundary in. */
+const isSigilLink = (value: unknown): boolean =>
+  isObjectNotArray(value) && isObjectNotArray(value["/"]) &&
+  isObjectNotArray(value["/"]["link@1"]);
 
 describe("multi-runtime harness value fidelity", () => {
   let harness: MultiRuntimeHarness;
@@ -81,6 +87,31 @@ describe("multi-runtime harness value fidelity", () => {
     assert(
       Object.keys(counts).length > 1,
       "a breakdown naming no logger at all",
+    );
+  });
+
+  it("reads a whole result, with a link where the schema says cell", async () => {
+    // A schema-aware read hands back a live `Cell` at every `asCell`
+    // location, and a cell belongs to the runtime's own realm. `setWeird` is
+    // a stream, which is one such location; a pattern's `[UI]` tree is full of
+    // them. Reading the whole result at all is half the assertion.
+    const whole = await alice.read() as Record<string, unknown>;
+    assertEquals(
+      typeof whole.weird,
+      "number",
+      `weird came back as ${toCompactDebugString(whole.weird)}`,
+    );
+    assert(
+      isSigilLink(whole.setWeird),
+      `setWeird came back as ${toCompactDebugString(whole.setWeird)}, ` +
+        "not the link that reaches it",
+    );
+    // The containers around it stay containers: the same read annotates each
+    // one with the cell it came from, and an annotation is not a cell the
+    // schema asked for.
+    assert(
+      isObjectNotArray(whole.$UI) && whole.$UI.name === "div",
+      `the view came back as ${toCompactDebugString(whole.$UI)}`,
     );
   });
 

--- a/packages/patterns/integration/multi-runtime-fidelity.test.ts
+++ b/packages/patterns/integration/multi-runtime-fidelity.test.ts
@@ -95,10 +95,13 @@ describe("multi-runtime harness value fidelity", () => {
     // location, and a cell belongs to the runtime's own realm. `setWeird` is
     // a stream, which is one such location; a pattern's `[UI]` tree is full of
     // them. Reading the whole result at all is half the assertion.
+    await alice.send("setWeird", { weird: 41 });
+    await harness.settle();
+
     const whole = await alice.read() as Record<string, unknown>;
     assertEquals(
-      typeof whole.weird,
-      "number",
+      whole.weird,
+      41,
       `weird came back as ${toCompactDebugString(whole.weird)}`,
     );
     assert(

--- a/packages/patterns/integration/multi-runtime-fidelity.test.ts
+++ b/packages/patterns/integration/multi-runtime-fidelity.test.ts
@@ -17,6 +17,7 @@ import { join } from "@std/path";
 import { Identity } from "@commonfabric/identity";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
+import { isLinkRef } from "@commonfabric/data-model/cell-rep";
 import { isObjectNotArray } from "@commonfabric/utils/types";
 import {
   MultiRuntimeHarness,
@@ -34,11 +35,6 @@ const BYTES: (string | number)[] = ["bytes"];
 const WEIRD: (string | number)[] = ["weird"];
 
 const CONTENT = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
-
-/** Whether `value` is a link sigil, the form a cell crosses the boundary in. */
-const isSigilLink = (value: unknown): boolean =>
-  isObjectNotArray(value) && isObjectNotArray(value["/"]) &&
-  isObjectNotArray(value["/"]["link@1"]);
 
 describe("multi-runtime harness value fidelity", () => {
   let harness: MultiRuntimeHarness;
@@ -105,7 +101,7 @@ describe("multi-runtime harness value fidelity", () => {
       `weird came back as ${toCompactDebugString(whole.weird)}`,
     );
     assert(
-      isSigilLink(whole.setWeird),
+      isLinkRef(whole.setWeird),
       `setWeird came back as ${toCompactDebugString(whole.setWeird)}, ` +
         "not the link that reaches it",
     );

--- a/packages/patterns/integration/multi-runtime-harness.ts
+++ b/packages/patterns/integration/multi-runtime-harness.ts
@@ -272,7 +272,13 @@ export class MultiRuntimeSession {
     }) as { ok: boolean; error?: { name?: string; message?: string } };
   }
 
-  /** Read a value from the piece result, pulling fresh state first. */
+  /**
+   * Read a value from the piece result, pulling fresh state first. Where the
+   * result schema says `asCell` — over a pattern's `[UI]` tree, among other
+   * places — the value carries the link that reaches the cell rather than the
+   * cell, which belongs to the runtime's own realm. Read a path below such a
+   * cell, or use `readRaw`, to reach its contents.
+   */
   async read(path: (string | number)[] = []): Promise<FabricValue> {
     return await this.#client.call("read", { path });
   }
@@ -282,6 +288,23 @@ export class MultiRuntimeSession {
    *  carry, e.g. a query result's `requestHash`. */
   async readRaw(path: (string | number)[] = []): Promise<FabricValue> {
     return await this.#client.call("readRaw", { path });
+  }
+
+  /**
+   * Mint a cell in this runtime's space holding `value`, and answer with the
+   * link that reaches it. `cause` names the cell: the same cause is the same
+   * cell, a different cause a different one.
+   *
+   * The link is ordinary data, so it can be passed straight back in a `send`
+   * event to reach a handler input declared `asCell`. That is how a headless
+   * caller hands a pattern a cell it did not create — a viewer identity, say,
+   * where a browser would supply a resolved `#profile`.
+   */
+  async createCell(
+    cause: FabricValue,
+    value: FabricValue,
+  ): Promise<FabricValue> {
+    return await this.#client.call("createCell", { cause, value });
   }
 
   /** Inspect the normalized link (id, space, scope) at `path` in the result. */

--- a/packages/patterns/integration/multi-runtime-worker.ts
+++ b/packages/patterns/integration/multi-runtime-worker.ts
@@ -23,6 +23,7 @@ import {
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import type { Cell } from "@commonfabric/runner";
 import {
+  convertCellsToLinks,
   markUiInputBlindWriteTx,
   setBlindStructuralTarget,
   unmarkUiInputBlindWriteTx,
@@ -355,6 +356,22 @@ const handlers: Record<
     };
   },
 
+  /**
+   * Read the value of the cell reached from the piece result by `path`,
+   * through the result schema.
+   *
+   * A schema-aware read hands back a live `Cell` wherever the schema says
+   * `asCell`, and a pattern's result schema says that all over its `[UI]`
+   * tree: every view node's props and children are cells. A live cell belongs
+   * to this realm and cannot cross to the harness, so each one becomes the
+   * link that reaches it — the sigil form `readRaw` leaves nested links in.
+   * Read a path below such a cell, or `readRaw`, to get its contents.
+   *
+   * `doNotConvertCellResults` limits the conversion to the cells the schema
+   * asked for. The same read annotates each container it returns with the cell
+   * it came from, and that annotation is machinery rather than content: the
+   * container's own entries are what the reader asked for.
+   */
   async read({ path }) {
     const target = result();
     await target.pull();
@@ -362,7 +379,7 @@ const handlers: Record<
     for (const segment of (path ?? []) as (string | number)[]) {
       cell = cell.key(segment as never);
     }
-    return cell.get();
+    return convertCellsToLinks(cell.get(), { doNotConvertCellResults: true });
   },
 
   /**
@@ -379,6 +396,31 @@ const handlers: Record<
       cell = cell.key(segment as never);
     }
     return cell.resolveAsCell().getRaw();
+  },
+
+  /**
+   * Mint a cell in this runtime's space holding `value`, and answer with the
+   * link that reaches it.
+   *
+   * `cause` names the cell, so two sessions asking for the same cause in the
+   * same space get the same cell and two causes get two cells. The answer is
+   * ordinary fabric data, so a later `send` can carry it into a handler input
+   * declared `asCell` — which is how a headless caller hands a pattern a cell
+   * it did not create, the way a browser viewer's resolved `#profile` reaches
+   * one.
+   */
+  async createCell({ cause, value }) {
+    const runtime = controller().runtime;
+    const space = currentPiece().getCell().getAsNormalizedFullLink().space;
+    const cell = runtime.getCell<FabricValue>(space, cause);
+    const { error } = await runtime.editWithRetry((tx) => {
+      cell.withTx(tx).set(value as never);
+    });
+    if (error) {
+      throw new Error(`createCell failed: ${error.message}`);
+    }
+    await idle();
+    return cell.getAsLink();
   },
 
   /**

--- a/packages/patterns/lunch-poll/README.md
+++ b/packages/patterns/lunch-poll/README.md
@@ -9,6 +9,14 @@ files so repo-wide pattern checks do not compile it as a pattern:
 By default, diagnostics run against `main.tsx` so runtime changes are measured
 against the product lunch-poll graph instead of a comparison fixture.
 
+Each case opens one poll across as many runtimes as it has voters, gives every
+voter an identity, joins them, has the host add the options, and then runs the
+requested number of rounds of concurrent voting. Every phase is sampled for
+scheduler graph size, settle cost, and action-run trace, and each case ends with
+the commit-churn counters and a cross-session convergence check. The sampled
+phases go to standard output as one JSON document; the per-phase summary lines
+go to standard error.
+
 Run a single lunch-poll scenario with `N` options, `M` voters, and `X` vote
 cycles by setting one option count, one user count, and one round count. `M`
 must be at least `1` because one user is the host that creates options and
@@ -18,8 +26,7 @@ drives refreshes:
 deno run -A packages/patterns/tools/lunch-poll-diagnose.ts \
   --options=10 \
   --users=5 \
-  --rounds=3 \
-  --skip-refresh
+  --rounds=3
 ```
 
 Run an explicit matrix with `options x users` cases when comparing runtime
@@ -28,8 +35,14 @@ changes across multiple sizes:
 ```bash
 deno run -A packages/patterns/tools/lunch-poll-diagnose.ts \
   --cases=1x2,3x5,10x5 \
-  --rounds=3 \
-  --skip-refresh
+  --rounds=3
+```
+
+`--quick` is the smoke-sized default matrix — options `1,3` against `2` users
+for one round — for checking that the probe itself still runs:
+
+```bash
+deno run -A packages/patterns/tools/lunch-poll-diagnose.ts --quick
 ```
 
 Use `--program=<file>` to point the same scenario runner at another local lunch
@@ -40,6 +53,14 @@ experiment:
 deno run -A packages/patterns/tools/lunch-poll-diagnose.ts \
   --program=main.tsx \
   --cases=1x2,3x5,10x5 \
-  --rounds=3 \
-  --skip-refresh
+  --rounds=3
 ```
+
+Every step the probe drives is gated in the pattern: joining needs a resolved
+profile, adding an option needs the host, and casting a vote needs a roster
+entry and a resolved clock. A case whose setup a gate refuses fails with the
+phase it stopped at and the poll state each session was left in, rather than
+reporting the zeros that refusal produces.
+`../integration/lunch-poll-diagnose.test.ts` runs the smallest case there is and
+checks what it measured, so a change to one of those gates fails there rather
+than the next time somebody reaches for the probe.

--- a/packages/patterns/tools/lunch-poll-diagnose.ts
+++ b/packages/patterns/tools/lunch-poll-diagnose.ts
@@ -10,8 +10,8 @@ interface PollOutputSummary {
   users: readonly { name?: string }[];
   options: readonly { id?: string; title?: string }[];
   votes: readonly {
-    /** What names the voter — see `voterKey` — or "" for a vote with none. */
-    voter: string;
+    /** What names the voter — see `voterIdentity`. */
+    voter: readonly unknown[];
     optionId?: string;
     voteType?: string;
   }[];
@@ -200,12 +200,15 @@ async function collectConvergence(
 ): Promise<ConvergenceResult> {
   const states = await Promise.all(sessions.map(async (session) => {
     const poll = pollSummary(await session.read());
+    // Each vote renders as JSON of its own, so no option id carrying the
+    // delimiter can run two votes together, and sorting orders values that
+    // are equal exactly when the votes are.
     const fingerprint = poll.votes
       .map((vote) =>
-        `${vote.voter}|${vote.optionId ?? "?"}|${vote.voteType ?? "?"}`
+        JSON.stringify([vote.voter, vote.optionId ?? "", vote.voteType ?? ""])
       )
       .sort()
-      .join(",");
+      .join("\n");
     return {
       votes: poll.voteCount,
       options: poll.optionCount,
@@ -266,16 +269,20 @@ const asStringArray = (value: unknown): readonly string[] =>
  * Anything else refuses. A voter this cannot name flattens every vote's key to
  * the same empty string, in every session at once, which leaves the votes
  * comparing equal and the run reporting a convergence it never checked.
+ *
+ * What comes back is a tagged tuple, which the fingerprint compares whole, so
+ * two voters are equal exactly when they are the same voter. A link's entire
+ * address goes in — a cell's scope names the partition it is stored under, so
+ * one id under two scopes is two cells — and its path stays the array it is,
+ * which no delimiter can run together.
  */
-export function voterKey(value: unknown): string {
-  if (value === undefined || value === null) return "";
+export function voterIdentity(value: unknown): readonly unknown[] {
+  if (value === undefined || value === null) return [];
   const link = parseLink(value);
-  if (link) {
-    return `${link.space ?? "?"}/${link.id}/${link.path.join(".")}`;
-  }
+  if (link) return ["link", link.space, link.id, link.scope, link.path];
   if (isObjectNotArray(value)) {
     const name = asString(value.name);
-    if (name !== "") return name;
+    if (name !== "") return ["name", name];
   }
   throw new Error(
     `a vote names a voter this tool cannot identify: ${JSON.stringify(value)}`,
@@ -292,7 +299,7 @@ function pollSummary(value: unknown): PollOutputSummary {
     users: asRecordArray(value.users),
     options: asRecordArray(value.options),
     votes: asRecordArray(value.votes).map((vote) => ({
-      voter: voterKey(vote.voter),
+      voter: voterIdentity(vote.voter),
       optionId: asString(vote.optionId),
       voteType: asString(vote.voteType),
     })),

--- a/packages/patterns/tools/lunch-poll-diagnose.ts
+++ b/packages/patterns/tools/lunch-poll-diagnose.ts
@@ -9,17 +9,18 @@ interface PollOutputSummary {
   users: readonly { name?: string }[];
   options: readonly { id?: string; title?: string }[];
   votes: readonly {
-    voterName?: string;
+    /** The name on the voter's profile, or "" for a vote with no voter. */
+    voterName: string;
     optionId?: string;
     voteType?: string;
   }[];
-  history: readonly unknown[];
-  adminName: string;
+  hostName: string;
   myName: string;
+  todayDate: string;
+  joinMessage: string;
   userCount: number;
   optionCount: number;
   voteCount: number;
-  historyCount: number;
   isJoined: boolean;
   isAdmin: boolean;
 }
@@ -78,7 +79,7 @@ interface MatrixConfig {
   voteRounds: number;
 }
 
-interface CaseConfig {
+export interface CaseConfig {
   optionCount: number;
   userCount: number;
   voteRounds: number;
@@ -88,7 +89,13 @@ interface CompactSessionSample {
   label: string;
   poll: {
     myName: string;
+    hostName: string;
+    isJoined: boolean;
     isAdmin: boolean;
+    /** Why this session's last join was refused, or "". */
+    joinMessage: string;
+    /** The day votes are filtered to, or "" until the `#now/300` wish lands. */
+    todayDate: string;
     users: number;
     options: number;
     votes: number;
@@ -145,7 +152,7 @@ interface ChurnTotals {
   commitRejected: number;
 }
 
-interface CaseResult {
+export interface CaseResult {
   case: {
     users: number;
     options: number;
@@ -176,7 +183,7 @@ async function collectChurn(
   return totals;
 }
 
-interface ConvergenceResult {
+export interface ConvergenceResult {
   converged: boolean;
   voteCounts: number[];
   optionCounts: number[];
@@ -194,9 +201,7 @@ async function collectConvergence(
     const poll = pollSummary(await session.read());
     const fingerprint = poll.votes
       .map((vote) =>
-        `${vote.voterName ?? "?"}|${vote.optionId ?? "?"}|${
-          vote.voteType ?? "?"
-        }`
+        `${vote.voterName}|${vote.optionId ?? "?"}|${vote.voteType ?? "?"}`
       )
       .sort()
       .join(",");
@@ -246,6 +251,13 @@ const asStringArray = (value: unknown): readonly string[] =>
     ? value.filter((entry): entry is string => typeof entry === "string")
     : [];
 
+// A vote names its voter by profile cell, which a read of the poll output
+// resolves to the profile's contents. The name on it is what tells one voter
+// from another in the convergence fingerprint below, and this tool gives every
+// session a distinct one.
+const voterName = (value: unknown): string =>
+  isObjectNotArray(value) ? asString(value.name) : "";
+
 function pollSummary(value: unknown): PollOutputSummary {
   if (!isObjectNotArray(value)) {
     throw new Error(
@@ -255,14 +267,18 @@ function pollSummary(value: unknown): PollOutputSummary {
   return {
     users: asRecordArray(value.users),
     options: asRecordArray(value.options),
-    votes: asRecordArray(value.votes),
-    history: Array.isArray(value.history) ? value.history : [],
-    adminName: asString(value.adminName),
+    votes: asRecordArray(value.votes).map((vote) => ({
+      voterName: voterName(vote.voter),
+      optionId: asString(vote.optionId),
+      voteType: asString(vote.voteType),
+    })),
+    hostName: asString(value.hostName),
     myName: asString(value.myName),
+    todayDate: asString(value.todayDate),
+    joinMessage: asString(value.joinMessage),
     userCount: asNumber(value.userCount),
     optionCount: asNumber(value.optionCount),
     voteCount: asNumber(value.voteCount),
-    historyCount: asNumber(value.historyCount),
     isJoined: asBoolean(value.isJoined),
     isAdmin: asBoolean(value.isAdmin),
   };
@@ -452,7 +468,11 @@ function compactSessionSample(
     label,
     poll: {
       myName: poll.myName,
+      hostName: poll.hostName,
+      isJoined: poll.isJoined,
       isAdmin: poll.isAdmin,
+      joinMessage: poll.joinMessage,
+      todayDate: poll.todayDate,
       users: poll.userCount,
       options: poll.optionCount,
       votes: poll.voteCount,
@@ -562,6 +582,56 @@ async function samplePhase(
   return sample;
 }
 
+/**
+ * Claim each session's viewer identity through the poll's `overrideViewer`
+ * seam.
+ *
+ * Identity in this poll is a profile cell. A browser viewer gets one from the
+ * `#profile` wish, which has nothing to resolve it in a headless runtime, so
+ * each session mints its own profile cell and claims that. The handler runs in
+ * the sending session's runtime, so every claim lands in that session's own
+ * per-user slot and the sessions stay distinct people on one shared poll.
+ */
+async function claimIdentities(
+  sessions: readonly MultiRuntimeSession[],
+): Promise<void> {
+  await Promise.all(sessions.map(async (session, index) => {
+    const name = `User ${index + 1}`;
+    const profile = await session.createCell(
+      `lunch-poll-diagnose profile ${session.label}`,
+      { name },
+    );
+    await session.send("overrideViewer", { profile, name });
+  }));
+}
+
+/**
+ * Check that a phase's setup took, naming the sessions it did not reach.
+ *
+ * Every step these phases drive is gated in the pattern — joining needs a
+ * resolved profile, adding an option needs the host, casting a vote needs a
+ * roster entry and a resolved clock — and a gate that refuses writes nothing
+ * and reports nothing, leaving the samples that follow reading as an idle
+ * poll. The check asks whether a gate was passed at all, not whether every
+ * write survived: a vote lost to commit contention is what the churn and
+ * convergence sections report.
+ */
+function checkPhase(
+  phase: PhaseSample,
+  requirement: string,
+  reached: (poll: CompactSessionSample["poll"]) => boolean,
+): void {
+  const failures = phase.sessions.filter((session) => !reached(session.poll));
+  if (failures.length === 0) return;
+  throw new Error(
+    `after phase "${phase.phase}", ${failures.length} of ` +
+      `${phase.sessions.length} sessions did not ${requirement}: ` +
+      failures
+        .map((session) => `${session.label} ${JSON.stringify(session.poll)}`)
+        .join("; "),
+  );
+}
+
 async function optionIds(session: MultiRuntimeSession): Promise<string[]> {
   const poll = pollSummary(await session.read());
   return poll.options.map((option) => option.id).filter((id): id is string =>
@@ -584,7 +654,12 @@ async function createHarness(config: CaseConfig): Promise<MultiRuntimeHarness> {
   return harness;
 }
 
-async function runCase(config: CaseConfig): Promise<CaseResult> {
+/**
+ * Run one case end to end: open the poll across a runtime per voter, give each
+ * voter an identity, join them, add the options, and vote. Exported so a test
+ * can drive the probe's own setup rather than a copy of it.
+ */
+export async function runCase(config: CaseConfig): Promise<CaseResult> {
   traceCursors.clear();
   const harness = await createHarness(config);
   const phases: PhaseSample[] = [];
@@ -596,46 +671,63 @@ async function runCase(config: CaseConfig): Promise<CaseResult> {
   const host = sessions[0];
 
   try {
+    // Standing in for the `#profile` wish, which is what a browser viewer
+    // loads with, so the baseline below is a poll whose viewers have an
+    // identity and have not joined yet.
+    await claimIdentities(sessions);
     phases.push(await samplePhase("baseline-open", harness, async () => {}));
 
-    phases.push(
-      await samplePhase("all-users-join", harness, async () => {
-        await host.send("joinAs", { name: "User 1" });
-        await Promise.all(
-          sessions.slice(1).map((session, index) =>
-            session.send("joinAs", { name: `User ${index + 2}` })
-          ),
-        );
-      }),
-    );
+    // The host joins alone and first: the first joiner takes the host role,
+    // and the phases below need a settled answer to who that is.
+    const joinPhase = await samplePhase("all-users-join", harness, async () => {
+      await host.send("joinAs", {});
+      await Promise.all(
+        sessions.slice(1).map((session) => session.send("joinAs", {})),
+      );
+    });
+    phases.push(joinPhase);
+    checkPhase(joinPhase, "join the poll", (poll) => poll.isJoined);
 
-    phases.push(
-      await samplePhase("host-adds-options", harness, async () => {
+    const optionsPhase = await samplePhase(
+      "host-adds-options",
+      harness,
+      async () => {
         for (let index = 0; index < config.optionCount; index++) {
           await host.send("addOption", { title: `Restaurant ${index + 1}` });
         }
-      }),
+      },
+    );
+    phases.push(optionsPhase);
+    checkPhase(
+      optionsPhase,
+      "see the host's options",
+      (poll) => poll.options > 0,
     );
 
     for (let round = 0; round < config.voteRounds; round++) {
-      phases.push(
-        await samplePhase(
-          `concurrent-vote-round-${round + 1}`,
-          harness,
-          async () => {
-            const ids = await optionIds(host);
-            if (ids.length === 0) return;
-            await Promise.all(
-              sessions.map((session, index) =>
-                session.send("castVote", {
-                  optionId: ids[(round + index) % ids.length],
-                  voteType: VOTE_COLORS[(round + index) % VOTE_COLORS.length],
-                })
-              ),
-            );
-          },
-        ),
+      const votePhase = await samplePhase(
+        `concurrent-vote-round-${round + 1}`,
+        harness,
+        async () => {
+          const ids = await optionIds(host);
+          if (ids.length === 0) return;
+          await Promise.all(
+            sessions.map((session, index) =>
+              session.send("castVote", {
+                optionId: ids[(round + index) % ids.length],
+                voteType: VOTE_COLORS[(round + index) % VOTE_COLORS.length],
+              })
+            ),
+          );
+        },
       );
+      phases.push(votePhase);
+      // Only the first round is checked: a vote recast in the same color on
+      // the same option and the same day toggles off, so a later round can
+      // empty the poll again.
+      if (round === 0) {
+        checkPhase(votePhase, "see any vote", (poll) => poll.votes > 0);
+      }
     }
 
     const churn = await collectChurn(sessions);

--- a/packages/patterns/tools/lunch-poll-diagnose.ts
+++ b/packages/patterns/tools/lunch-poll-diagnose.ts
@@ -1,3 +1,4 @@
+import { parseLink } from "@commonfabric/runner";
 import { isObjectNotArray } from "@commonfabric/utils/types";
 import {
   MultiRuntimeHarness,
@@ -9,8 +10,8 @@ interface PollOutputSummary {
   users: readonly { name?: string }[];
   options: readonly { id?: string; title?: string }[];
   votes: readonly {
-    /** The name on the voter's profile, or "" for a vote with no voter. */
-    voterName: string;
+    /** What names the voter — see `voterKey` — or "" for a vote with none. */
+    voter: string;
     optionId?: string;
     voteType?: string;
   }[];
@@ -201,7 +202,7 @@ async function collectConvergence(
     const poll = pollSummary(await session.read());
     const fingerprint = poll.votes
       .map((vote) =>
-        `${vote.voterName}|${vote.optionId ?? "?"}|${vote.voteType ?? "?"}`
+        `${vote.voter}|${vote.optionId ?? "?"}|${vote.voteType ?? "?"}`
       )
       .sort()
       .join(",");
@@ -251,12 +252,35 @@ const asStringArray = (value: unknown): readonly string[] =>
     ? value.filter((entry): entry is string => typeof entry === "string")
     : [];
 
-// A vote names its voter by profile cell, which a read of the poll output
-// resolves to the profile's contents. The name on it is what tells one voter
-// from another in the convergence fingerprint below, and this tool gives every
-// session a distinct one.
-const voterName = (value: unknown): string =>
-  isObjectNotArray(value) ? asString(value.name) : "";
+/**
+ * What names a vote's voter, for the convergence fingerprint below.
+ *
+ * A vote's voter is a profile cell, and a read of the poll output can hand it
+ * back either way round: resolved to the profile's contents, whose name tells
+ * one voter from another and which this tool gives every session a distinct
+ * one of, or — where the result schema declares the location a cell — as the
+ * link that reaches it, which names the same profile just as well. A vote with
+ * no voter at all is a vote stored by the poll's name-keyed predecessor, which
+ * tallies anonymously.
+ *
+ * Anything else refuses. A voter this cannot name flattens every vote's key to
+ * the same empty string, in every session at once, which leaves the votes
+ * comparing equal and the run reporting a convergence it never checked.
+ */
+export function voterKey(value: unknown): string {
+  if (value === undefined || value === null) return "";
+  const link = parseLink(value);
+  if (link) {
+    return `${link.space ?? "?"}/${link.id}/${link.path.join(".")}`;
+  }
+  if (isObjectNotArray(value)) {
+    const name = asString(value.name);
+    if (name !== "") return name;
+  }
+  throw new Error(
+    `a vote names a voter this tool cannot identify: ${JSON.stringify(value)}`,
+  );
+}
 
 function pollSummary(value: unknown): PollOutputSummary {
   if (!isObjectNotArray(value)) {
@@ -268,7 +292,7 @@ function pollSummary(value: unknown): PollOutputSummary {
     users: asRecordArray(value.users),
     options: asRecordArray(value.options),
     votes: asRecordArray(value.votes).map((vote) => ({
-      voterName: voterName(vote.voter),
+      voter: voterKey(vote.voter),
       optionId: asString(vote.optionId),
       voteType: asString(vote.voteType),
     })),


### PR DESCRIPTION
The lunch-poll scaling probe failed on every case, and behind that failure it had stopped driving the poll at all.

The failure first. A worker realm answers each multi-runtime harness command with one codec-realm encoding, which carries the whole `FabricValue` domain and nothing outside it. The `read` command answered with `cell.get()` straight off a schema-aware read, and such a read hands back a live `Cell` wherever the schema says `asCell`. A cell belongs to the runtime's own realm, so the encode refused it and the caller got

    Cannot encode instance `{"/":{"link@1":{"path":["props",
    "data-poll-toda...`: no applicable codec.

in place of the value it asked for. The vdom schemas mark a view node's props and children `asCell`, so a read of a whole pattern result hits this on any pattern with a view, as does a path read that lands on a location the result schema declares a cell.

Convert the answer with `convertCellsToLinks`, so a cell crosses as the link that reaches it. That is the sigil form `readRaw` already leaves nested links in, and a caller that wants the contents reads a path below the cell. The conversion runs with `doNotConvertCellResults`, because a schema-aware read also annotates each container it returns with the cell it came from, and the walk treats an annotated container as a cell: with the annotation honored, a read of the whole result comes back as one link to the result.

With the read answering, the probe ran to completion and reported a matrix of zeros. It was driving a poll the pattern no longer is. It joined each session by sending a display name to `joinAs`, and the poll's identity is the viewer's profile cell: `JoinEvent` is a closed empty schema, so every join was refused with "additional property name". Nobody joined, the host gate then refused every option, and the vote gate refused every vote. The run still finished and still printed its JSON, and those zeros read exactly like a measurement of an idle poll.

Claim each session's identity through the pattern's `overrideViewer` seam, the headless stand-in for the `#profile`, `#profileName` and `#profileAvatar` wishes: mint a profile cell in each session's own runtime, send it with a display name, then join with the empty event the pattern takes. The handler runs in the sending session's runtime, so each claim lands in that session's own per-user slot and the sessions stay distinct people on one shared poll.

Minting that cell needs a harness command of its own. `set` and `push` write into the result and `link` only inspects, so add `createCell`, which mints a cell in a session's runtime holding a value and answers with the link that reaches it. The link travels back in a later `send` event and reaches a handler input declared `asCell`, which is how a headless caller hands a pattern the kind of cell a resolved wish supplies in a browser.

Read the fields the pattern exposes: `hostName` rather than an `adminName` that is not there, and a vote's voter through the profile the vote names rather than through a `voterName` a vote no longer carries. The convergence fingerprint reads the name off that resolved profile, and every session in a run has a distinct one.

Check each phase's gate. Joining needs a resolved profile, adding an option needs the host, and casting a vote needs a roster entry and a resolved clock, and a gate that refuses writes nothing and reports nothing. A refused phase now fails with the phase it stopped at and the poll state each session was left in. The checks ask whether a gate was passed, not whether every write survived: a vote lost to commit contention is what the churn and convergence sections report, and only the first vote round is checked, since recasting the same color on the same option on the same day toggles the vote off.

A case of 14 options and 5 voters over three rounds now converges on 14 options, 5 users and 15 votes across every session, through some 1400 commit conflicts, with the scheduler graph growing from 149 nodes at open to 1488 by the last round.

Both failures were invisible because nothing ran the probe and nothing read a whole pattern result across the harness boundary. Cover the read in `multi-runtime-fidelity.test.ts`, which now reads the whole result of its echo fixture and checks that a plain value stays a value, that a stream comes back as the link that reaches it, and that the containers around it stay containers. The fixture gains that stream through a handler setting the number the other cases write, so it echoes through a second path rather than carrying a field nothing drives. Without the conversion above, the case fails with the encode refusal quoted at the top.

Cover the probe by exporting `runCase`, so a test drives the probe's own setup rather than a copy of it, and by adding
`integration/lunch-poll-diagnose.test.ts`. It runs the smallest case there is — one option, two voters, one round, about five seconds — and asks what it measured: both sessions converged on two voters, one option and a vote from each, with a sample per phase. Take the identity claim out and it fails with the phase it stopped at and the pattern's own reason, "Join needs a resolved profile — create or pick one first." Its counts were stable across five consecutive runs, which is what makes the exact roster and vote totals an assertion rather than a flake: the pattern's read-modify-write handlers retry on conflict, so a count short of the total is a loss worth failing on.

The lunch-poll README picks up the same treatment: it documented a `--skip-refresh` flag the tool does not accept, said nothing about `--quick`, and said nothing about what a run reports or what covers it.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6722?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

