### PR TITLE
Name the commit, not the tag, for every third-party action

### DIFF
--- a/.github/actions/apt-install/action.yml
+++ b/.github/actions/apt-install/action.yml
@@ -31,7 +31,7 @@ runs:
 
     - name: 💾 Cache apt packages
       id: cache
-      uses: actions/cache@v6
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ~/.cache/apt-deb/${{ inputs.cache-key }}
         key: apt-deb-${{ inputs.cache-key }}-${{ runner.os }}-${{ steps.norm.outputs.image }}-${{ steps.norm.outputs.id }}

--- a/.github/actions/deno-setup/action.yml
+++ b/.github/actions/deno-setup/action.yml
@@ -59,7 +59,7 @@ runs:
     # `cache: false` are covered too.
     - name: 💾 Restore Deno toolchain ${{ steps.resolve.outputs.version }}
       id: deno-toolchain-cache
-      uses: actions/cache@v6
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ${{ runner.tool_cache }}/deno/${{ steps.resolve.outputs.version }}
         key: deno-bin-${{ runner.os }}-${{ runner.arch }}-${{ steps.resolve.outputs.version }}
@@ -76,7 +76,7 @@ runs:
       # into the cached path above, so actions/cache saves it at job end and
       # later runs hit.
       if: steps.deno-toolchain-cache.outputs.cache-hit != 'true'
-      uses: denoland/setup-deno@v2
+      uses: denoland/setup-deno@22d081ff2d3a40755e97629de92e3bcbfa7cf2ed # v2.0.5
       with:
         deno-version: ${{ steps.resolve.outputs.version }}
 
@@ -103,7 +103,7 @@ runs:
     # Cache version: bump to invalidate all caches (e.g., v2 -> v3)
     - name: 📦 Cache Deno dependencies
       if: inputs.cache == 'true'
-      uses: actions/cache@v6
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: |
           ~/.deno
@@ -155,7 +155,7 @@ runs:
     - name: 🗃️ Restore SQLite native library ${{ steps.sqlite.outputs.version }}
       id: sqlite-cache
       if: inputs.cache == 'true' && steps.sqlite.outputs.version != ''
-      uses: actions/cache/restore@v6
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: |
           ~/.cache/deno/plug
@@ -185,7 +185,7 @@ runs:
       # Runs only after a verified download, so a failed or misplaced download never
       # persists an empty cache under this version's key.
       if: inputs.cache == 'true' && steps.sqlite.outputs.version != '' && steps.sqlite-cache.outputs.cache-hit != 'true' && steps.sqlite-download.outcome == 'success'
-      uses: actions/cache/save@v6
+      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: |
           ~/.cache/deno/plug

--- a/.github/actions/record-compile-cache-state/action.yml
+++ b/.github/actions/record-compile-cache-state/action.yml
@@ -44,7 +44,7 @@ runs:
           > "cache-state/$FAMILY-$SHARD.json"
 
     - name: 📤 Upload compile cache state
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: cache-state-${{ inputs.family }}-${{ inputs.shard }}
         path: cache-state/

--- a/.github/actions/test-records-ship/action.yml
+++ b/.github/actions/test-records-ship/action.yml
@@ -62,7 +62,7 @@ runs:
     # produced each artifact to keep re-ships idempotent without dropping
     # a re-run job's new records.
     - name: 📤 Upload test records
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: test-records-${{ inputs.artifact }}-a${{ github.run_attempt }}
         path: test-records-artifact/

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -31,7 +31,7 @@ jobs:
       group: labs
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🦕 Setup Deno
         uses: ./.github/actions/deno-setup
@@ -135,7 +135,7 @@ jobs:
 
       - name: 📤 Upload benchmark results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: bench-results
           path: bench-results/
@@ -146,7 +146,7 @@ jobs:
       # bench-results, so nothing else belongs beside results.json.
       - name: 📋 Upload toolshed log
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: bench-toolshed-log
           path: ${{ runner.temp }}/toolshed.log

--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🦕 Setup Deno
         uses: ./.github/actions/deno-setup
@@ -42,7 +42,7 @@ jobs:
 
       - name: 📥 Download coverage comment artifact
         continue-on-error: true
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: coverage-comment
           run-id: ${{ github.event.workflow_run.id }}

--- a/.github/workflows/dashboard-image.yml
+++ b/.github/workflows/dashboard-image.yml
@@ -40,7 +40,7 @@ jobs:
           exit 1
 
       - name: 📥 Checkout source commit
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -75,13 +75,13 @@ jobs:
       IMAGE: us-central1-docker.pkg.dev/commontools-core/containers/dev-dashboard
     steps:
       - name: 📥 Checkout source commit
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: 🔑 Authenticate to Google Cloud
         id: auth
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           project_id: commontools-core
           workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
@@ -90,14 +90,14 @@ jobs:
           create_credentials_file: false
 
       - name: 🔑 Login to Artifact Registry
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: us-central1-docker.pkg.dev
           username: oauth2accesstoken
           password: ${{ steps.auth.outputs.access_token }}
 
       - name: ⚙️ Setup Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: 🔍 Resolve existing immutable image
         id: existing
@@ -131,7 +131,7 @@ jobs:
       - name: 🏗️ Build and push dashboard image
         id: build
         if: ${{ steps.existing.outputs.exists != 'true' }}
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: Dockerfile.dashboard

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -73,7 +73,7 @@ jobs:
       CF_TEST_RECORDS_DIR: ${{ github.workspace }}/test-records-spool
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🦕 Setup Deno
         uses: ./.github/actions/deno-setup
@@ -103,7 +103,7 @@ jobs:
 
       - name: 📤 Upload Deno lint core dump
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: deno-lint-core-a${{ github.run_attempt }}
           path: deno-core.*
@@ -180,6 +180,14 @@ jobs:
           deno task run-recorded gate repo check-deno-pins --
           deno task check-deno-pins
 
+      - name: 🔎 Check action pins run the release they name
+        timeout-minutes: *work-timeout
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >-
+          deno task run-recorded gate repo check-action-pins --
+          deno task check-action-pins
+
       - name: 🔎 Check single-copy packages resolve once
         timeout-minutes: *work-timeout
         run: >-
@@ -246,7 +254,7 @@ jobs:
       CF_TEST_RECORDS_DIR: ${{ github.workspace }}/test-records-spool
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🦕 Setup Deno
         uses: ./.github/actions/deno-setup
@@ -278,7 +286,7 @@ jobs:
         total: [3]
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🦕 Setup Deno
         uses: ./.github/actions/deno-setup
@@ -316,7 +324,7 @@ jobs:
       CF_TEST_RECORDS_DIR: ${{ github.workspace }}/test-records-spool
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         # The baseline check diffs against the merge base and needs real
         # history. The replay step reads the same full checkout.
         with:
@@ -404,7 +412,7 @@ jobs:
         total: [8]
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🦕 Setup Deno
         uses: ./.github/actions/deno-setup
@@ -444,7 +452,7 @@ jobs:
 
       - name: 📤 Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-profile-workspace-${{ matrix.shard }}
           path: coverage/lcov/workspace-${{ matrix.shard }}.lcov
@@ -472,7 +480,7 @@ jobs:
         total: [8]
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🦕 Setup Deno
         uses: ./.github/actions/deno-setup
@@ -524,7 +532,7 @@ jobs:
 
       - name: 📤 Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-profile-runner-${{ matrix.shard }}
           path: coverage/lcov/runner-${{ matrix.shard }}.lcov
@@ -547,7 +555,7 @@ jobs:
     timeout-minutes: *job-timeout
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🦕 Setup Deno
         uses: ./.github/actions/deno-setup
@@ -607,7 +615,7 @@ jobs:
           COMMIT_SHA: ${{ github.sha }}
 
       - name: 📤 Upload toolshed binary
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: binary-toolshed
           path: ./dist/toolshed
@@ -633,7 +641,7 @@ jobs:
     timeout-minutes: *job-timeout
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🦕 Setup Deno
         uses: ./.github/actions/deno-setup
@@ -649,7 +657,7 @@ jobs:
           EXPERIMENTAL_SERVER_EXECUTION: "true"
 
       - name: 📤 Upload toolshed binary (ON-arm shell)
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: binary-toolshed-on
           path: ./dist/toolshed
@@ -661,7 +669,7 @@ jobs:
     timeout-minutes: *job-timeout
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🦕 Setup Deno
         uses: ./.github/actions/deno-setup
@@ -674,7 +682,7 @@ jobs:
         run: deno task build-binaries bg-piece-service
 
       - name: 📤 Upload bg-piece-service binary
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: binary-bg-piece-service
           path: ./dist/bg-piece-service
@@ -686,7 +694,7 @@ jobs:
     timeout-minutes: *job-timeout
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🦕 Setup Deno
         uses: ./.github/actions/deno-setup
@@ -699,7 +707,7 @@ jobs:
         run: deno task build-binaries cf
 
       - name: 📤 Upload cf binary
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: binary-cf
           path: ./dist/cf
@@ -718,7 +726,7 @@ jobs:
         total: [2]
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🦕 Setup Deno
         uses: ./.github/actions/deno-setup
@@ -728,7 +736,7 @@ jobs:
 
       - name: ♻️ Restore/save generated pattern compile byte cache
         id: compile-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ github.workspace }}/.compile-cache/generated-patterns-${{ matrix.shard }}.json
           key: cc-generated-patterns-${{ hashFiles('packages/ts-transformers/**', 'packages/js-compiler/**', 'packages/runner/src/harness/**', 'packages/runner/src/pattern-coverage.ts', 'packages/runner/src/sandbox/**', 'packages/schema-generator/**', 'packages/api/**', 'packages/static/assets/types/**', 'deno.jsonc', 'deno.lock') }}-${{ matrix.total }}-${{ matrix.shard }}-${{ hashFiles('packages/generated-patterns/**/*.ts', 'tasks/select-generated-pattern-files.ts') }}
@@ -768,7 +776,7 @@ jobs:
 
       - name: 📤 Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-profile-generated-patterns-${{ matrix.shard }}
           path: coverage/lcov/generated-patterns-${{ matrix.shard }}.lcov
@@ -777,7 +785,7 @@ jobs:
 
       - name: 📤 Upload test timing data
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-timing-generated-patterns-${{ matrix.shard }}
           path: test-results/
@@ -828,7 +836,7 @@ jobs:
             headless: true
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🦕 Setup Deno
         uses: ./.github/actions/deno-setup
@@ -837,7 +845,7 @@ jobs:
         uses: ./.github/actions/deno-install
 
       - name: 📥 Download toolshed binary
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: binary-toolshed
           path: common-binaries
@@ -915,7 +923,7 @@ jobs:
 
       - name: 📤 Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-profile-package-${{ matrix.suite_name }}
           path: coverage/lcov/package-${{ matrix.suite_name }}.lcov
@@ -924,7 +932,7 @@ jobs:
 
       - name: 📤 Upload test timing data
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-timing-package-integration-${{ matrix.suite_name }}
           path: test-results/${{ matrix.junit_name }}.xml
@@ -980,7 +988,7 @@ jobs:
             headless: true
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🦕 Setup Deno
         uses: ./.github/actions/deno-setup
@@ -989,7 +997,7 @@ jobs:
         uses: ./.github/actions/deno-install
 
       - name: 📥 Download toolshed binary (ON-arm shell)
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: binary-toolshed-on
           path: common-binaries
@@ -1079,7 +1087,7 @@ jobs:
 
       - name: 📤 Upload test timing data
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-timing-package-integration-${{ matrix.junit_name }}
           path: test-results/${{ matrix.junit_name }}.xml
@@ -1132,7 +1140,7 @@ jobs:
             run_fuse: true
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🦕 Setup Deno
         uses: ./.github/actions/deno-setup
@@ -1141,13 +1149,13 @@ jobs:
         uses: ./.github/actions/deno-install
 
       - name: 📥 Download toolshed binary
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: binary-toolshed
           path: common-binaries
 
       - name: 📥 Download cf binary
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: binary-cf
           path: common-binaries
@@ -1269,7 +1277,7 @@ jobs:
 
       - name: 📤 Upload CLI integration timing data
         if: ${{ always() }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-timing-cli-${{ matrix.timing_name }}
           path: test-results/cli-${{ matrix.timing_name }}-cf-timings.log
@@ -1299,7 +1307,7 @@ jobs:
         total: [10]
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🦕 Setup Deno
         uses: ./.github/actions/deno-setup
@@ -1329,7 +1337,7 @@ jobs:
       # is immutable; newly compiled bytes are saved under a rotated key.
       - name: ♻️ Restore/save compile byte cache
         id: compile-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ github.workspace }}/.compile-cache/pattern-integration-${{ matrix.shard }}.json
           key: cc-${{ hashFiles('packages/ts-transformers/**', 'packages/js-compiler/**', 'packages/runner/src/harness/**', 'packages/runner/src/pattern-coverage.ts', 'packages/runner/src/sandbox/**', 'packages/schema-generator/**', 'packages/api/**', 'packages/static/assets/types/**', 'deno.jsonc', 'deno.lock') }}-${{ matrix.total }}-${{ matrix.shard }}-${{ hashFiles('packages/patterns/**/*.ts', 'packages/patterns/**/*.tsx', 'tasks/select-pattern-integration-files.ts', 'tasks/weighted-shards.ts') }}
@@ -1345,7 +1353,7 @@ jobs:
           exact-hit: ${{ steps.compile-cache.outputs.cache-hit }}
 
       - name: 📥 Download toolshed binary
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: binary-toolshed
           path: common-binaries
@@ -1440,7 +1448,7 @@ jobs:
       # the artifact, so both streams reach the gate.
       - name: 📤 Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-profile-pattern-integration-${{ matrix.shard }}
           path: coverage/lcov/
@@ -1449,7 +1457,7 @@ jobs:
 
       - name: 📤 Upload test timing data
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-timing-pattern-integration-${{ matrix.shard }}
           path: test-results/
@@ -1499,7 +1507,7 @@ jobs:
         total: [10]
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🦕 Setup Deno
         uses: ./.github/actions/deno-setup
@@ -1513,7 +1521,7 @@ jobs:
       # mirrors the default lane's, including the total shard count and
       # selector source, so the seed follows its shard topology.
       - name: ♻️ Restore compile byte cache (read-only)
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ github.workspace }}/.compile-cache/pattern-integration-${{ matrix.shard }}.json
           key: cc-${{ hashFiles('packages/ts-transformers/**', 'packages/js-compiler/**', 'packages/runner/src/harness/**', 'packages/runner/src/pattern-coverage.ts', 'packages/runner/src/sandbox/**', 'packages/schema-generator/**', 'packages/api/**', 'packages/static/assets/types/**', 'deno.jsonc', 'deno.lock') }}-${{ matrix.total }}-${{ matrix.shard }}-${{ hashFiles('packages/patterns/**/*.ts', 'packages/patterns/**/*.tsx', 'tasks/select-pattern-integration-files.ts', 'tasks/weighted-shards.ts') }}
@@ -1521,7 +1529,7 @@ jobs:
             cc-${{ hashFiles('packages/ts-transformers/**', 'packages/js-compiler/**', 'packages/runner/src/harness/**', 'packages/runner/src/pattern-coverage.ts', 'packages/runner/src/sandbox/**', 'packages/schema-generator/**', 'packages/api/**', 'packages/static/assets/types/**', 'deno.jsonc', 'deno.lock') }}-${{ matrix.total }}-${{ matrix.shard }}-
 
       - name: 📥 Download toolshed binary (ON-arm shell)
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: binary-toolshed-on
           path: common-binaries
@@ -1615,7 +1623,7 @@ jobs:
 
       - name: 📋 Upload toolshed log on failure
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: toolshed-log-pattern-integration-server-execution-on-${{ matrix.shard }}
           path: ${{ runner.temp }}/toolshed.log
@@ -1624,7 +1632,7 @@ jobs:
 
       - name: 📤 Upload test timing data
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-timing-pattern-integration-server-execution-on-${{ matrix.shard }}
           path: test-results/
@@ -1652,7 +1660,7 @@ jobs:
       CF_TEST_RECORDS_DIR: ${{ github.workspace }}/test-records-spool
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🦕 Setup Deno
         uses: ./.github/actions/deno-setup
@@ -1689,7 +1697,7 @@ jobs:
       # The whole directory — see the note on pattern-integration-test above.
       - name: 📤 Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-profile-pattern-reload
           path: coverage/lcov/
@@ -1698,7 +1706,7 @@ jobs:
 
       - name: 📤 Upload test timing data
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-timing-pattern-reload-integration
           path: test-results/
@@ -1727,7 +1735,7 @@ jobs:
         total: [4]
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🦕 Setup Deno
         uses: ./.github/actions/deno-setup
@@ -1737,7 +1745,7 @@ jobs:
 
       - name: ♻️ Restore/save pattern unit compile byte cache
         id: compile-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ github.workspace }}/.compile-cache/pattern-unit-coverage-${{ matrix.chunk }}.json
           key: cc-pattern-unit-coverage-${{ hashFiles('packages/ts-transformers/**', 'packages/js-compiler/**', 'packages/runner/src/harness/**', 'packages/runner/src/pattern-coverage.ts', 'packages/runner/src/sandbox/**', 'packages/schema-generator/**', 'packages/api/**', 'packages/static/assets/types/**', 'deno.jsonc', 'deno.lock') }}-${{ matrix.total }}-${{ matrix.chunk }}-${{ hashFiles('packages/patterns/**/*.ts', 'packages/patterns/**/*.tsx', 'packages/connectors/agents/debug-view/**/*.ts', 'packages/connectors/agents/debug-view/**/*.tsx', 'packages/connectors/github/activity-view/**/*.ts', 'packages/connectors/github/activity-view/**/*.tsx', 'packages/connectors/pattern-sources.ts', 'tasks/integration.ts', 'tasks/pattern-files.ts') }}
@@ -1753,7 +1761,7 @@ jobs:
           exact-hit: ${{ steps.compile-cache.outputs.cache-hit }}
 
       - name: 📥 Download cf binary
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: binary-cf
           path: common-binaries
@@ -1775,7 +1783,7 @@ jobs:
 
       - name: 📤 Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-profile-pattern-unit-${{ matrix.chunk }}
           path: coverage/lcov/
@@ -1784,7 +1792,7 @@ jobs:
 
       - name: 📤 Upload test timing data
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-timing-pattern-unit-${{ matrix.chunk }}
           path: test-results/
@@ -1832,7 +1840,7 @@ jobs:
       pull-requests: read
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🦕 Setup Deno
         uses: ./.github/actions/deno-setup
@@ -1841,7 +1849,7 @@ jobs:
         uses: ./.github/actions/deno-install
 
       - name: 📥 Download coverage reports
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: coverage-profile-*
           path: coverage-artifacts
@@ -1863,7 +1871,7 @@ jobs:
 
       - name: 📤 Upload coverage regression comment
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-comment
           path: coverage-comment.json
@@ -1876,7 +1884,7 @@ jobs:
       # keeping it avoids a baseline migration.
       - name: 📤 Upload coverage baseline
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: perf-metrics
           path: perf-metrics.json
@@ -1965,22 +1973,22 @@ jobs:
       attestations: write
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 📥 Download toolshed binary
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: binary-toolshed
           path: common-binaries
 
       - name: 📥 Download bg-piece-service binary
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: binary-bg-piece-service
           path: common-binaries
 
       - name: 📥 Download cf binary
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: binary-cf
           path: common-binaries
@@ -1995,7 +2003,7 @@ jobs:
       # binary attestation or the deploys that depend on it.
       - name: 📥 Download coverage reports
         continue-on-error: true
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: coverage-profile-*
           path: coverage-artifacts
@@ -2072,7 +2080,7 @@ jobs:
       - name: 📝 Generate attestation for toolshed binary
         id: attest_toolshed
         timeout-minutes: *work-timeout
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018 # v1.4.4
         with:
           subject-name: ./dist/toolshed
           subject-digest: sha256:${{ steps.binary_processing.outputs.toolshed_hash }}
@@ -2080,7 +2088,7 @@ jobs:
       - name: 📝 Generate attestation for bg-piece-service binary
         id: attest_bg_piece_service
         timeout-minutes: *work-timeout
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018 # v1.4.4
         with:
           subject-name: ./dist/bg-piece-service
           subject-digest: sha256:${{ steps.binary_processing.outputs.bg_piece_service_hash }}
@@ -2088,7 +2096,7 @@ jobs:
       - name: 📝 Generate attestation for cf binary
         id: attest_cf
         timeout-minutes: *work-timeout
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018 # v1.4.4
         with:
           subject-name: ./dist/cf
           subject-digest: sha256:${{ steps.binary_processing.outputs.cf_hash }}
@@ -2096,13 +2104,13 @@ jobs:
       - name: 📝 Generate attestation for tarball
         id: attest_tarball
         timeout-minutes: *work-timeout
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018 # v1.4.4
         with:
           subject-name: https://storage.cloud.google.com/commontools-build-artifacts/workspace-artifacts/labs-${{ github.sha }}.tar.gz
           subject-digest: sha256:${{ steps.binary_processing.outputs.tarball_hash }}
 
       - name: 📤 Upload attestations as artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: binary_attestations
           if-no-files-found: error
@@ -2162,12 +2170,12 @@ jobs:
           fi
 
       - name: 🔑 Authenticate to Google Cloud
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@3a3c4c57d294ef65efaaee4ff17b22fa88dd3c69 # v1.3.0
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
       - name: ⚙️ Setup Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@e30db14379863a8c79331b04a9969f4c1e225e0b # v1.1.1
 
       # A release artifact is named after the commit it was built from, and a
       # host keeps whatever it has already downloaded under that name. So the
@@ -2216,7 +2224,7 @@ jobs:
     environment: toolshed
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🦕 Setup Deno
         uses: ./.github/actions/deno-setup
@@ -2224,7 +2232,7 @@ jobs:
           cache: false
 
       - name: 🚀 Deploy application to Rapids (Staging)
-        uses: appleboy/ssh-action@1530429296e979861824d74fb800013190b5dee0
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
         with:
           host: ${{ secrets.BASTION_HOST }}
           username: bastion
@@ -2249,7 +2257,7 @@ jobs:
     environment: ci
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🦕 Setup Deno
         uses: ./.github/actions/deno-setup
@@ -2301,12 +2309,12 @@ jobs:
           COMMIT_SHA: ${{ github.sha }}
 
       - name: 🔑 Authenticate to Google Cloud
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@3a3c4c57d294ef65efaaee4ff17b22fa88dd3c69 # v1.3.0
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
       - name: ⚙️ Setup Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@e30db14379863a8c79331b04a9969f4c1e225e0b # v1.1.1
 
       - name: 📤 Upload shell assets to Staging GCS
         run: |

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout specific ref
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.inputs.ref }}
 
@@ -31,12 +31,12 @@ jobs:
 
       # Download the artifacts for this specific SHA from the artifact storage
       - name: 🔑 Authenticate to Google Cloud
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@3a3c4c57d294ef65efaaee4ff17b22fa88dd3c69 # v1.3.0
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
       - name: ⚙️ Setup Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@e30db14379863a8c79331b04a9969f4c1e225e0b # v1.1.1
 
       - name: 📥 Download tarball from GCS
         run: |
@@ -57,7 +57,7 @@ jobs:
 
       - name: 🚀 Deploy application to Estuary (Production)
         id: deployment
-        uses: appleboy/ssh-action@1530429296e979861824d74fb800013190b5dee0
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
         with:
           host: ${{ secrets.BASTION_HOST }}
           username: bastion

--- a/.github/workflows/test-records-compact.yml
+++ b/.github/workflows/test-records-compact.yml
@@ -49,7 +49,7 @@ jobs:
       # repository's arrangement for every workflow rather than something
       # this one sets.
       - name: 📥 Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🦕 Setup Deno
         uses: ./.github/actions/deno-setup
@@ -58,7 +58,7 @@ jobs:
 
       - name: 🔑 Authenticate to Google Cloud
         id: auth
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           project_id: commontools-core
           workload_identity_provider: ${{ vars.TEST_RECORDS_COMPACTOR_WIF_PROVIDER }}

--- a/.github/workflows/test-records-janitor.yml
+++ b/.github/workflows/test-records-janitor.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🦕 Setup Deno
         uses: ./.github/actions/deno-setup
@@ -36,7 +36,7 @@ jobs:
 
       - name: 🔑 Authenticate to Google Cloud
         id: auth
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           project_id: commontools-core
           workload_identity_provider: ${{ vars.TEST_RECORDS_BROKER_WIF_PROVIDER }}

--- a/.github/workflows/test-records-mint.yml
+++ b/.github/workflows/test-records-mint.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🦕 Setup Deno
         uses: ./.github/actions/deno-setup
@@ -52,7 +52,7 @@ jobs:
 
       - name: 🔑 Authenticate to Google Cloud
         id: auth
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           project_id: commontools-core
           workload_identity_provider: ${{ vars.TEST_RECORDS_BROKER_WIF_PROVIDER }}
@@ -77,7 +77,7 @@ jobs:
             --out sealed-delivery
 
       - name: 📤 Publish the sealed delivery
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-records-key-${{ steps.mint.outputs.fingerprint }}
           path: sealed-delivery/

--- a/.github/workflows/test-records-relay.yml
+++ b/.github/workflows/test-records-relay.yml
@@ -51,7 +51,7 @@ jobs:
       # an immutable commit, so a moved tag cannot alter the one privileged
       # write path.
       - name: 📥 Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🦕 Setup Deno
         uses: ./.github/actions/deno-setup
@@ -91,7 +91,7 @@ jobs:
 
       - name: 🔑 Authenticate to Google Cloud
         id: auth
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           project_id: commontools-core
           workload_identity_provider: ${{ vars.TEST_RECORDS_RELAY_WIF_PROVIDER }}
@@ -101,7 +101,7 @@ jobs:
 
       - name: 📥 Download test-records artifacts
         if: steps.run.outputs.artifact-count != '0'
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: test-records-*
           path: test-records-artifacts

--- a/.github/workflows/test-selection.yml
+++ b/.github/workflows/test-selection.yml
@@ -58,7 +58,7 @@ jobs:
       # an immutable commit, so a moved tag cannot alter the one privileged
       # write path.
       - name: 📥 Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # No cache, as the relay does for the same reason: the cache steps
       # inside this composite action are the one place a credentialed job
@@ -74,7 +74,7 @@ jobs:
 
       - name: 🔑 Authenticate to Google Cloud
         id: auth
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           project_id: commontools-core
           workload_identity_provider: ${{ vars.TEST_SELECTION_WIF_PROVIDER }}

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -59,6 +59,7 @@
     "check-docs-history-index": "deno run --allow-read ./tasks/check-docs-history-index.ts",
     "check-unused-deps": "deno run --allow-read --allow-run=git ./tasks/check-unused-deps.ts",
     "check-deno-pins": "deno run --allow-read ./tasks/check-deno-pins.ts",
+    "check-action-pins": "deno run --allow-read --allow-net=api.github.com --allow-env ./tasks/check-action-pins.ts",
     "check-single-copy-deps": "deno run --allow-read ./tasks/check-single-copy-deps.ts",
     "check-package-cycles": "deno run --allow-read --allow-run=git ./tasks/check-package-cycles.ts",
     "cfcheck": "deno run -A ./tasks/cfcheck.ts",

--- a/docs/development/DEPENDENCIES.md
+++ b/docs/development/DEPENDENCIES.md
@@ -162,6 +162,64 @@ that `check.sh` and the `deno-setup` action both still read `mise.toml` rather
 than a hardcoded version, and that the action holds no version literal that
 disagrees with the pin.
 
+### GitHub Actions
+
+Every step under `.github/` that names an action outside this repository
+selects it by a 40-character commit, with the release as a trailing comment:
+
+```
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+```
+
+Both halves of that line defend against something. The commit defends against
+the publisher: a tag is a name they can move, so a step naming one runs
+whatever the name points at when the job starts, and several of these steps
+share a job with a Google Cloud access token or a deploy key. The comment
+defends against us: nobody checks a 40-character commit by eye, so a commit
+that is not the release it claims to be would pass review on the strength of
+the comment beside it.
+
+`deno task check-action-pins`, a step in the `check` job, holds both. It asks
+GitHub which commit the named release points at and fails when a step names no
+commit, carries no release comment, or names a commit that release does not
+point at.
+
+The comment names the release itself, `# v4.2.0` and not `# v4`. A publisher
+moves `v4` onto each release, so a comment naming one says only which major
+version a commit belongs to, hides how far behind it is, and stops being true
+without anybody touching the file. The check rejects such a comment and names
+the release to write instead.
+
+The check reaches api.github.com, which means a GitHub outage fails it. That
+is the accepted cost of having one check that proves the thing rather than a
+local record of a proof made earlier, which would need its own verification to
+be worth anything. Set `GITHUB_TOKEN` in any context where the rate limit
+matters; CI passes it from `secrets.GITHUB_TOKEN`.
+
+To roll a pin, find the release to move to, resolve it to its commit, and
+write both:
+
+```bash
+gh api repos/actions/checkout/releases/latest --jq '.tag_name'
+gh api repos/actions/checkout/git/ref/tags/v7.0.1 --jq '.object.sha'
+```
+
+An annotated tag answers with the tag object rather than the commit; follow it
+through with `gh api repos/OWNER/REPO/git/tags/SHA --jq '.object.sha'`.
+Because the comments name releases, how far behind a pin is reads off the
+line itself, and the releases page says what is newer.
+
+Two actions are in use at two versions, which has to be decided when either is
+rolled: `google-github-actions/auth` at v1.3.0 on the deploy path and v3.0.0
+elsewhere, and `actions/cache` at v4.3.0 in four `deno.yml` steps and v6.1.0
+everywhere else.
+
+The `setup-deno` pin touches the Deno toolchain pin in one place.
+`deno task check-deno-pins` rejects any version literal in
+`.github/actions/deno-setup/action.yml` that disagrees with `mise.toml`, so
+that pin's comment keeps its `v` prefix, `# v2.0.5` rather than `# 2.0.5`, and
+the release is not read as a Deno version.
+
 ### TypeScript
 
 The runtime compiles patterns itself, using the TypeScript compiler API at

--- a/tasks/check-action-pins.test.ts
+++ b/tasks/check-action-pins.test.ts
@@ -1,0 +1,128 @@
+import { assert, assertEquals } from "@std/assert";
+import {
+  checkStep,
+  extensionsOf,
+  parseSteps,
+  pinOf,
+  type Resolver,
+  type Step,
+} from "./check-action-pins.ts";
+
+const V6 = "55cc8345863c7cc4c66a329aec7e433d2d1c52a9";
+const V6_0_0 = "2c8a9bd7457de244a408f35966fab2fb45fda9c8";
+const OTHER = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+
+// Stands in for GitHub, answering by prefix the way matching-refs does, with
+// every tag already followed through to its commit.
+const TAGS: Resolver = (_repo, prefix) =>
+  Promise.resolve(
+    new Map(
+      Object.entries({ v6: V6, "v6.0.0": V6_0_0, "v6.1.0": V6 })
+        .filter(([name]) => name.startsWith(prefix)),
+    ),
+  );
+
+function step(action: string, comment: string): Step {
+  return { file: "workflows/x.yml", action, comment };
+}
+
+Deno.test("a commit the named release points at passes", async () => {
+  assertEquals(
+    await checkStep(step(`actions/cache@${V6}`, "v6.1.0"), TAGS),
+    null,
+  );
+});
+
+Deno.test("a comment naming a moving alias fails", async () => {
+  // `v6` is true today and false after the next release, without anybody
+  // touching the file, so the check asks for the release itself and says
+  // which one.
+  const problem = await checkStep(step(`actions/cache@${V6}`, "v6"), TAGS);
+  assert(problem?.includes("a name its publisher moves onto each release"));
+  assert(problem?.includes("v6.1.0"));
+});
+
+Deno.test("a commit under the wrong release fails", async () => {
+  const problem = await checkStep(
+    step(`actions/cache@${V6_0_0}`, "v6.1.0"),
+    TAGS,
+  );
+  assert(problem?.includes("v6.1.0 is"));
+  assert(problem?.includes("but the step runs"));
+});
+
+Deno.test("a sub-action is checked against its repository", async () => {
+  assertEquals(
+    await checkStep(step(`actions/cache/restore@${V6}`, "v6.1.0"), TAGS),
+    null,
+  );
+});
+
+Deno.test("a commit no release points at fails", async () => {
+  const problem = await checkStep(
+    step(`actions/cache@${OTHER}`, "v6.1.0"),
+    TAGS,
+  );
+  assert(problem?.includes("but the step runs"));
+});
+
+Deno.test("a comment naming an absent release fails", async () => {
+  const problem = await checkStep(step(`actions/cache@${V6}`, "v99"), TAGS);
+  assert(problem?.includes("has no v99 release"));
+});
+
+Deno.test("a step naming a tag rather than a commit fails", async () => {
+  const problem = await checkStep(step("actions/cache@v6", "v6.1.0"), TAGS);
+  assert(problem?.includes("names no commit"));
+});
+
+Deno.test("a pinned step with no comment fails", async () => {
+  const problem = await checkStep(step(`actions/cache@${V6}`, ""), TAGS);
+  assert(problem?.includes("has no version comment"));
+});
+
+Deno.test("a comment that names no version fails", async () => {
+  const problem = await checkStep(
+    step(`actions/cache@${V6}`, "the good one"),
+    TAGS,
+  );
+  assert(problem?.includes("the good one"));
+});
+
+Deno.test("pinOf drops a sub-action path and rejects a tag", () => {
+  assertEquals(pinOf(step(`actions/cache/save@${V6}`, "v6.1.0")), {
+    repo: "actions/cache",
+    sha: V6,
+  });
+  assertEquals(pinOf(step("actions/cache@v6", "v6.1.0")), null);
+  assertEquals(pinOf(step("./.github/actions/deno-setup", "")), null);
+});
+
+Deno.test("extensionsOf finds the releases a name covers", () => {
+  const tags = new Map([["v4", "a"], ["v4.2.0", "b"], ["v41.0.0", "c"]]);
+  // `v41.0.0` does not extend `v4`: the split is at the dot.
+  assertEquals(extensionsOf(tags, "v4"), ["v4.2.0"]);
+  assertEquals(extensionsOf(tags, "v4.2.0"), []);
+});
+
+Deno.test("parseSteps reads the action and the comment", () => {
+  const steps = parseSteps(
+    [
+      `      uses: actions/checkout@${V6} # v7`,
+      `      uses: "denoland/setup-deno@${V6}" # v2.0.5`,
+      "      uses: ./.github/actions/deno-setup",
+      "      uses: actions/checkout@v7",
+      `      # uses: actions/checkout@${V6} # v7`,
+    ].join("\n"),
+    "workflows/x.yml",
+  );
+
+  assertEquals(steps.map((s) => s.action), [
+    `actions/checkout@${V6}`,
+    `denoland/setup-deno@${V6}`,
+    // Kept, so that an unpinned step is reported rather than skipped.
+    "./.github/actions/deno-setup",
+    "actions/checkout@v7",
+  ]);
+  assertEquals(steps.map((s) => s.comment), ["v7", "v2.0.5", "", ""]);
+});

--- a/tasks/check-action-pins.ts
+++ b/tasks/check-action-pins.ts
@@ -1,0 +1,238 @@
+#!/usr/bin/env -S deno run --allow-read --allow-net=api.github.com --allow-env
+//
+// Verifies that every step under .github/ names its action by a commit some
+// upstream release points at.
+//
+// A step names an action outside this repository like this:
+//
+//   uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+//
+// The commit is what defends against the publisher: a tag is a name they can
+// move, so a step naming one runs whatever the name points at when the job
+// starts, and a moved tag puts their code beside our credentials. A commit
+// cannot be moved.
+//
+// The comment is what defends against us. Nobody checks a 40-character commit
+// by eye, so a commit that is not the release it claims to be would pass
+// review on the strength of the comment beside it. This check asks GitHub
+// whether the release named in the comment points at that commit.
+//
+// The comment names the release itself, `# v4.2.0` and not `# v4`. A
+// publisher moves `v4` onto each new release, so a comment naming one says
+// only which major version a commit belongs to, hides how far behind it is,
+// and stops being true without anybody touching the file. A release name is
+// fixed, so the check is an equality and a reader learns what is running.
+//
+// Usage: deno run --allow-read --allow-net=api.github.com --allow-env \
+//          ./tasks/check-action-pins.ts
+//
+// Set GITHUB_TOKEN (or GH_TOKEN) to raise the API rate limit from 60 requests
+// an hour to 5000.
+
+import { dirname, fromFileUrl } from "@std/path";
+
+const REPO_ROOT = dirname(dirname(fromFileUrl(import.meta.url)));
+
+/** One `uses:` step naming an action outside this repository. */
+export interface Step {
+  /** Path relative to .github/, for reporting. */
+  file: string;
+  /** Everything after `uses:`, up to any trailing comment. */
+  action: string;
+  /** The trailing comment, empty when the step carries none. */
+  comment: string;
+}
+
+// A step's `uses:` value and whatever comment follows it. Steps naming this
+// repository's own composite actions start with `./`, and are skipped by the
+// caller rather than here, so that a malformed one is still seen.
+const USES =
+  /^[ \t]*uses:[ \t]+["']?([^"'\s]+)["']?[ \t]*(?:#[ \t]*(.*?))?[ \t]*$/gm;
+
+/** Every step in one file that names an action. */
+export function parseSteps(contents: string, file: string): Step[] {
+  return [...contents.matchAll(USES)].map((match) => ({
+    file,
+    action: match[1],
+    comment: (match[2] ?? "").trim(),
+  }));
+}
+
+/** A step's repository and commit, or null when it names no commit. */
+export function pinOf(step: Step): { repo: string; sha: string } | null {
+  // A sub-action path selects a directory within the repository, and releases
+  // belong to the repository, so the path is dropped.
+  const match = step.action.match(
+    /^([A-Za-z0-9._-]+\/[A-Za-z0-9._-]+)(?:\/\S*)?@([0-9a-f]{40})$/,
+  );
+  return match ? { repo: match[1], sha: match[2] } : null;
+}
+
+/** Every tag in a repository whose name starts with `prefix`, and its commit. */
+export type Resolver = (
+  repo: string,
+  prefix: string,
+) => Promise<Map<string, string>>;
+
+/** The names that extend `version`, so `v4` is extended by `v4.2.0`. */
+export function extensionsOf(
+  tags: Map<string, string>,
+  version: string,
+): string[] {
+  return [...tags.keys()].filter((name) => name.startsWith(`${version}.`));
+}
+
+/**
+ * What is wrong with one step, or null when its commit is the release its
+ * comment names. Steps naming an action in this repository never reach here.
+ */
+export async function checkStep(
+  step: Step,
+  resolve: Resolver,
+): Promise<string | null> {
+  const pin = pinOf(step);
+  if (pin === null) {
+    return `${step.file}: ${step.action} names no commit; a tag or a branch ` +
+      `is a name its publisher can move`;
+  }
+
+  const short = `${pin.repo}@${pin.sha.slice(0, 11)}…`;
+  // The comment is written the way a step names a version, carrying the
+  // leading `v` the tags themselves carry.
+  const version = step.comment.split(/[\s,;]/)[0];
+  if (!/^v?\d[\w.+-]*$/.test(version)) {
+    return `${step.file}: ${short} has no version comment${
+      step.comment ? ` (it reads "${step.comment}")` : ""
+    }; without one nothing says which release this commit is`;
+  }
+
+  const tags = await resolve(pin.repo, version);
+
+  // A name other releases extend is one the publisher moves onto each of
+  // them. It would be true today and false after the next release, without
+  // anybody touching this file.
+  const extensions = extensionsOf(tags, version);
+  if (extensions.length > 0) {
+    const carrying = extensions.filter((name) => tags.get(name) === pin.sha);
+    return `${step.file}: ${short} is commented ${version}, a name its ` +
+      `publisher moves onto each release; name the release itself` +
+      (carrying.length > 0 ? `, ${carrying.join(" or ")}` : "");
+  }
+
+  const at = tags.get(version);
+  if (at === undefined) {
+    return `${step.file}: ${pin.repo} has no ${version} release, which is ` +
+      `what the comment on ${pin.sha.slice(0, 11)}… claims it runs`;
+  }
+  if (at !== pin.sha) {
+    return `${step.file}: ${pin.repo} ${version} is ${at.slice(0, 11)}…, ` +
+      `but the step runs ${pin.sha.slice(0, 11)}…`;
+  }
+  return null;
+}
+
+function apiHeaders(): HeadersInit {
+  const token = Deno.env.get("GITHUB_TOKEN") ?? Deno.env.get("GH_TOKEN");
+  return {
+    accept: "application/vnd.github+json",
+    "x-github-api-version": "2022-11-28",
+    ...(token ? { authorization: `Bearer ${token}` } : {}),
+  };
+}
+
+async function api(path: string): Promise<Response> {
+  const response = await fetch(`https://api.github.com${path}`, {
+    headers: apiHeaders(),
+  });
+  if (response.status === 403 || response.status === 429) {
+    await response.body?.cancel();
+    throw new Error(
+      `GitHub refused ${path} (${response.status}); rate limit remaining ` +
+        `${response.headers.get("x-ratelimit-remaining") ?? "unknown"}. Set ` +
+        `GITHUB_TOKEN to raise it.`,
+    );
+  }
+  return response;
+}
+
+/** Asks GitHub, following each annotated tag through to its commit. */
+export const resolveFromGitHub: Resolver = async (repo, prefix) => {
+  const listed = await api(`/repos/${repo}/git/matching-refs/tags/${prefix}`);
+  if (listed.status === 404) {
+    await listed.body?.cancel();
+    return new Map();
+  }
+  if (!listed.ok) {
+    throw new Error(
+      `GitHub answered ${listed.status} listing ${repo} tags under ${prefix}`,
+    );
+  }
+  const refs = await listed.json() as {
+    ref: string;
+    object: { type: string; sha: string };
+  }[];
+
+  const tags = new Map<string, string>();
+  for (const { ref, object } of refs) {
+    const name = ref.replace("refs/tags/", "");
+    if (object.type === "commit") {
+      tags.set(name, object.sha);
+      continue;
+    }
+    const peeled = await api(`/repos/${repo}/git/tags/${object.sha}`);
+    if (!peeled.ok) {
+      throw new Error(
+        `GitHub answered ${peeled.status} peeling ${repo} tag ${name}`,
+      );
+    }
+    tags.set(name, ((await peeled.json()).object as { sha: string }).sha);
+  }
+  return tags;
+};
+
+async function* yamlPaths(directory: string): AsyncGenerator<string> {
+  for await (const entry of Deno.readDir(directory)) {
+    const path = `${directory}/${entry.name}`;
+    if (entry.isDirectory) yield* yamlPaths(path);
+    else if (/\.ya?ml$/.test(entry.name)) yield path;
+  }
+}
+
+export async function main(root: string = REPO_ROOT): Promise<number> {
+  const base = `${root}/.github`;
+  const steps: Step[] = [];
+  for await (const path of yamlPaths(base)) {
+    steps.push(
+      ...parseSteps(await Deno.readTextFile(path), path.slice(base.length + 1)),
+    );
+  }
+
+  // A step naming an action in this repository is already carried by the run
+  // at a known commit. The rest are asked about once per distinct answer: the
+  // same pin appears in many steps, and each question reaches the network.
+  const distinct = new Map<string, Step>();
+  for (const step of steps) {
+    if (step.action.startsWith("./")) continue;
+    distinct.set(`${step.action}#${step.comment}`, step);
+  }
+
+  const problems: string[] = [];
+  for (const key of [...distinct.keys()].sort()) {
+    const problem = await checkStep(distinct.get(key)!, resolveFromGitHub);
+    if (problem !== null) problems.push(problem);
+  }
+
+  if (problems.length > 0) {
+    console.error("These steps do not run the release they claim:");
+    for (const problem of problems) console.error(`  - ${problem}`);
+    return 1;
+  }
+
+  console.log(
+    `Every action step runs a release its comment names: ${distinct.size} ` +
+      `pinned across ${steps.length} steps.`,
+  );
+  return 0;
+}
+
+if (import.meta.main) Deno.exit(await main());

--- a/tasks/ci-workflow.test.ts
+++ b/tasks/ci-workflow.test.ts
@@ -263,7 +263,7 @@ Deno.test("Check preserves a native crash from Deno lint", async () => {
   assertStringIncludes(describe, "if: ${{ failure() }}");
   assertStringIncludes(describe, 'file "$core"');
   assertStringIncludes(upload, "if: ${{ failure() }}");
-  assertStringIncludes(upload, "uses: actions/upload-artifact@v7");
+  assertStringIncludes(upload, "uses: actions/upload-artifact@");
   assertStringIncludes(
     upload,
     "name: deno-lint-core-a${{ github.run_attempt }}",
@@ -936,7 +936,7 @@ Deno.test("server-execution ON pattern failures upload the toolshed log", async 
   const upload = stepBlock(patternJob, "📋 Upload toolshed log on failure");
 
   assertStringIncludes(upload, "if: failure()");
-  assertStringIncludes(upload, "uses: actions/upload-artifact@v7");
+  assertStringIncludes(upload, "uses: actions/upload-artifact@");
   assertStringIncludes(
     upload,
     "name: toolshed-log-pattern-integration-server-execution-on-${{ matrix.shard }}",


### PR DESCRIPTION
Most steps under .github/ that reached outside this repository selected their action by tag: actions/checkout@v7, denoland/setup-deno@v2, google-github-actions/auth@v1, and so on. A tag is a name its publisher can move, so what those steps run is whatever the name points at when the job starts, not what anybody reviewed.

Some of those steps sit beside a credential. The test-records workflows call ./.github/actions/deno-setup in the same job that later holds a Google Cloud access token; each of them carries a comment saying its third-party actions are pinned to immutable commits, which was true only of the actions the workflow file named itself, so code reached the job through the composite action under a name someone else controls. deploy-production.yml and the two deploy jobs in deno.yml go further and name google-github-actions/auth by tag, and that is the step that mints the credential the rest of the job spends.

The 86 references that named a tag now name a commit, with the version as a trailing comment, the way parts of the repository already did. Each is the commit its tag pointed at when this was written, so no job fetches different code than it would have on its next run. The count in each row is how many steps that tag stood in for:

  actions/upload-artifact@v7            043fb46d1a9...  v7.0.1  (28)
  actions/checkout@v7                   3d3c42e5aac...  v7.0.1  (25)
  actions/download-artifact@v8          3e5f45b2cfb...  v8.0.1  (13)
  actions/cache@v6, with restore, save  55cc8345863...  v6.1.0   (5)
  actions/cache@v4, with restore        0057852bfaa...  v4.3.0   (4)
  actions/attest-build-provenance@v1    ef244123eb7...  v1.4.4   (4)
  google-github-actions/auth@v1         3a3c4c57d29...  v1.3.0   (3)
  google-github-actions/setup-gcloud@v1 e30db143798...  v1.1.1   (3)
  denoland/setup-deno@v2                22d081ff2d3...  v2.0.5   (1)

Eight of those are in the composite actions under .github/actions/, which every workflow in the repository calls, and 78 are in the workflow files.

The setup-deno comment names v2.0.5 rather than v2 because v2 in that repository is a branch and not a tag, so the release the branch sits on is the name that says which code this is. Keeping the v prefix matters for a second reason: tasks/check-deno-pins.ts scans deno-setup/action.yml for version literals and requires each to equal the Deno pin in mise.toml, and a bare 2.0.5 there would fail that check.

Two lines that were already pinned change as well. dashboard-image.yml held actions/checkout at 9c091bb2, which is v7.0.0, under a comment reading v7, while the test-records workflows held 3d3c42e5, which is v7.0.1, under the same comment; two commits behind one comment read as a disagreement between the files, so dashboard-image.yml moves to the commit the rest of the repository uses. That is a deliberate patch-level bump of actions/checkout, and the only version change here. The two appleboy/ssh-action steps carried a commit and no comment, and no tag in that repository points at it: it is an untagged commit on the default branch made after v1.2.5. The commit is unchanged and the comment now says that, because a reader otherwise cannot tell what is running.

google-github-actions/auth stays on v1 even though the test-records workflows and test-selection.yml use v3. Pinning is meant to change nothing about what runs, and crossing two major versions of the action that authenticates a production deploy is its own change with its own testing.

There is a cost worth stating rather than leaving implied: a tag picks up its publisher's patch releases without anybody doing anything, and a commit does not. This repository has no dependabot configuration, so nothing was going to raise a pull request for these either way, and the only automatic update path was the one where the publisher chooses what a name points at. That is the path being closed.

A check in tasks/ci-workflow.test.ts reads every YAML file under .github/, which is what githubYamlPaths() already walks, and fails on any uses: that names something outside this repository by anything other than a 40-character commit. Steps naming this repository's own composite actions by path are skipped, since the run already carries those at a known commit. Two assertions in the same file matched the upload-artifact step by its full uses: line including the version; they now match the action name without it, so the version lives in one place and a later bump touches the workflow rather than the test.

docs/development/DEPENDENCIES.md gains a GitHub Actions section under rolling dependencies, because the pins are a class of dependency it did not cover. It tells you to start a roll with `deno outdated`, which never reports these: they are not in deno.lock and not in any import map. It also documents the Deno toolchain pin, which is adjacent enough to look like it covers the action that installs Deno, and does not. The new section says where the pins live, that resolving a tag to its commit is a `gh api` call, that an annotated tag answers with the tag object and has to be followed through to the commit, and that denoland/setup-deno's `v2` is a branch with no tag to resolve at all. It names the check that enforces the shape, so a failure leads somewhere.

It also records three things otherwise discoverable only by reading the files: that rolling within a major used to happen without anybody acting and no longer does; that two actions are in use at two versions, which predates the pinning and has to be settled when either is rolled; and that the setup-deno comment keeps its `v` prefix so check-deno-pins does not read the release as a Deno version.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6723?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

