### PR TITLE
refactor(data-model): the `FabricValue` surface is the package's main export

### DIFF
--- a/docs/development/unit-test-coding-style.md
+++ b/docs/development/unit-test-coding-style.md
@@ -364,7 +364,7 @@ assert on _that_ result:
 
 ```ts
 import { expect } from "@std/expect";
-import { valueEqual } from "@commonfabric/data-model/fabric-value";
+import { valueEqual } from "@commonfabric/data-model";
 
 // Vacuous: asserts `Object.is(NaN, NaN)`, which holds regardless of
 // what `valueEqual()` does.

--- a/docs/plans/first-class-serializable-factories.md
+++ b/docs/plans/first-class-serializable-factories.md
@@ -174,8 +174,8 @@ Tests to port or extend:
 - [ ] Export only the minimum protocol surface needed by the runner and codec;
   do not expose `.curry` or state mutation to pattern authors.
 - [ ] Re-export the runner-facing protocol through
-  `packages/data-model/src/fabric-value.ts` without creating a dependency from
-  the data model back into the runner.
+  `packages/data-model/src/index.ts` without creating a dependency from the
+  data model back into the runner.
 
 Expected implementation files:
 

--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -77,15 +77,16 @@ wrapper classes (Section 1.4).
 > **Where a thing is declared is not where it is imported from**, and the
 > modules named here divide on that point. `interface.ts` and
 > `native-conversion.ts` are internal: they are not exported subpaths, and their
-> contents are reached through `@commonfabric/data-model/fabric-value`, which
-> re-exports them. `codec-interface/` is internal in the same way: it is reached
-> through `@commonfabric/data-model/codec-common`, which re-exports it.
-> `codec-common/`, `fabric-bases/` and `fabric-instances/` are exported subpaths
-> in their own right and are imported directly under those names; `fabric-value`
-> does *not* re-export the codec vocabulary, so `LiveEnvironment` and its
-> siblings come from `@commonfabric/data-model/codec-common`. Cite a module to
-> say where something is defined; consult the package's `exports` map to know
-> where to import it from.
+> contents are reached through `@commonfabric/data-model`, the package's main
+> entry point, which re-exports them. `codec-interface/` is internal in the same
+> way: it is reached through `@commonfabric/data-model/codec-common`, which
+> re-exports it. `codec-common/`, `fabric-bases/` and `fabric-instances/` are
+> exported subpaths in their own right and are imported directly under those
+> names; the main entry point does *not* re-export the codec vocabulary, so
+> `LiveEnvironment` and its siblings come from
+> `@commonfabric/data-model/codec-common`. Cite a module to say where something
+> is defined; consult the package's `exports` map to know where to import it
+> from.
 >
 > Type declarations visible to patterns are in
 > `packages/data-model/src/api.ts` (the `interface` + `declare const` pattern),
@@ -96,7 +97,7 @@ wrapper classes (Section 1.4).
 
 ```typescript
 // Shown at module scope.
-// file: packages/data-model/fabric-value.ts
+// file: packages/data-model/index.ts
 
 /**
  * The complete set of values that can flow through the runtime, be stored
@@ -229,7 +230,7 @@ native JS object types that the conversion layer can handle:
 
 ```typescript
 // Shown at module scope.
-// file: packages/data-model/fabric-value.ts
+// file: packages/data-model/index.ts
 
 /**
  * Union of raw native JS object types that the conversion layer can translate
@@ -2199,7 +2200,7 @@ codec system can round-trip it back to a real `Temperature` instance.
 
 import {
   type FabricValue,
-} from '@commonfabric/data-model/fabric-value';
+} from '@commonfabric/data-model';
 import {
   CODEC,
   BaseNonterminalCodec,
@@ -3202,7 +3203,7 @@ the left layer (JS wild west) and the middle layer (`FabricValue`) at the
 The module also provides a shallow conversion function
 (`shallowFabricFromNativeValue()`) and a type-check function
 (`isValidFabricConvertibleValue()`). The public surface is re-exported from
-`fabric-value.ts`, which also defines the comparison function `valueEqual()`.
+`index.ts`, which also defines the comparison function `valueEqual()`.
 
 ```typescript
 // Shown for illustration only.
@@ -3244,7 +3245,7 @@ The implementation is split across several files for separation of concerns:
 
 | File | Purpose |
 |------|---------|
-| `fabric-value.ts` | Public surface: re-exports the conversion functions (from `native-conversion.ts`), the type declarations (from `interface.ts`), and the clone helpers (from `value-clone.ts`); defines `valueEqual()` |
+| `index.ts` | Public surface: re-exports the conversion functions (from `native-conversion.ts`), the type declarations (from `interface.ts`), and the clone helpers (from `value-clone.ts`); defines `valueEqual()` |
 | `native-conversion.ts` | Conversion: `fabricFromNativeValue`, `shallowFabricFromNativeValue`, `nativeFromFabricValue`, `isValidFabricConvertibleValue` |
 | `fabric-bases/` | The abstract bases a concrete `FabricValue` extends, one per branch of the type hierarchy: `BaseFabricInstance.ts`, `BaseFabricPrimitive.ts` (plus an `index.ts` barrel). These are the implementer's half of the hierarchy; `interface.ts` is the client's, and reaching it does not reach these. |
 | `fabric-instances/` | Concrete `FabricInstance` subclasses, each in its own file: `FabricNativeWrapper.ts`, `FabricError.ts`, `FabricLink.ts`, `FabricMap.ts`, `FabricSet.ts` (plus an `index.ts` barrel). `UnknownValue` and `ProblematicValue` are `FabricInstance`s too, but live in `codec-common/`, existing only as products of a decode fault. |

--- a/packages/cf-harness/test/space-labels.test.ts
+++ b/packages/cf-harness/test/space-labels.test.ts
@@ -1,8 +1,8 @@
 import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Database } from "@db/sqlite";
+import type { FabricValue } from "@commonfabric/data-model";
 import { jsonFromFabricValue } from "@commonfabric/data-model/codecs";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 
 import type { LinkWalkBounds } from "@commonfabric/state-inspector";
 

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -2,14 +2,11 @@ import { ensureDir } from "@std/fs";
 import { dirname, join } from "@std/path";
 
 import type { CellScope, JSONSchema } from "@commonfabric/api";
+import { FabricPrimitive, FabricSpecialObject } from "@commonfabric/data-model";
 import {
   codecOf,
   NULL_LIVE_ENVIRONMENT,
 } from "@commonfabric/data-model/codec-common";
-import {
-  FabricPrimitive,
-  FabricSpecialObject,
-} from "@commonfabric/data-model/fabric-value";
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import { createSession, isDID, Session } from "@commonfabric/identity";
 import { collectDataFileNames } from "@commonfabric/js-compiler";

--- a/packages/cli/test/inspect-remote.test.ts
+++ b/packages/cli/test/inspect-remote.test.ts
@@ -11,8 +11,8 @@ import { Database } from "@db/sqlite";
 import { ValidationError } from "@cliffy/command";
 import { Identity } from "@commonfabric/identity";
 import { defaultCacheDir } from "@commonfabric/state-inspector";
+import type { FabricValue } from "@commonfabric/data-model";
 import { jsonFromFabricValue } from "@commonfabric/data-model/codecs";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { inspect } from "../commands/inspect.ts";
 
 const DUMP_BASE = "/api/storage/memory/dump";

--- a/packages/cli/test/piece-get-transform.test.ts
+++ b/packages/cli/test/piece-get-transform.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import type { FabricValue } from "@commonfabric/data-model";
 import { Identity } from "@commonfabric/identity";
 import { type Cell, type JSONSchema, Runtime } from "@commonfabric/runner";
 import {

--- a/packages/cli/test/piece-label.test.ts
+++ b/packages/cli/test/piece-label.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
-import { valueEqual } from "@commonfabric/data-model/fabric-value";
+import { valueEqual } from "@commonfabric/data-model";
 import {
   FabricBytes,
   FabricEpochNsec,

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -1,9 +1,9 @@
 import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 
+import { FabricSpecialObject } from "@commonfabric/data-model";
 import { FabricError } from "@commonfabric/data-model/fabric-instances";
 import { FabricHash } from "@commonfabric/data-model/fabric-primitives";
-import { FabricSpecialObject } from "@commonfabric/data-model/fabric-value";
 import { Identity } from "@commonfabric/identity";
 import { pieceId, SlugResolutionError } from "@commonfabric/piece";
 import {

--- a/packages/connectors/agents/connector/src/stable-fabric-value.ts
+++ b/packages/connectors/agents/connector/src/stable-fabric-value.ts
@@ -1,4 +1,10 @@
 import {
+  fabricFromNativeValue,
+  FabricInstance,
+  type FabricPlainObject,
+  type FabricValue,
+} from "@commonfabric/data-model";
+import {
   ProblematicValue,
   UnknownValue,
 } from "@commonfabric/data-model/codec-common";
@@ -7,12 +13,6 @@ import {
   FabricError,
   FabricLink,
 } from "@commonfabric/data-model/fabric-instances";
-import {
-  fabricFromNativeValue,
-  FabricInstance,
-  type FabricPlainObject,
-  type FabricValue,
-} from "@commonfabric/data-model/fabric-value";
 import { VALUE_TAGS } from "@commonfabric/data-model/VALUE_TAGS";
 import { tagFromNativeValue } from "@commonfabric/data-model/native-type-tags";
 import {

--- a/packages/connectors/agents/host/src/debug-view.ts
+++ b/packages/connectors/agents/host/src/debug-view.ts
@@ -5,10 +5,7 @@ import {
   cellHasOwnerProtection,
   stableCellId,
 } from "@commonfabric/agents-connector/fabric-graph";
-import type {
-  FabricPlainObject,
-  FabricValue,
-} from "@commonfabric/data-model/fabric-value";
+import type { FabricPlainObject, FabricValue } from "@commonfabric/data-model";
 import { internSchema } from "@commonfabric/data-model-schema";
 import { pieceId } from "@commonfabric/piece";
 import type { PiecesController } from "@commonfabric/piece/ops";

--- a/packages/connectors/github/connector/src/fabric-storage.ts
+++ b/packages/connectors/github/connector/src/fabric-storage.ts
@@ -1,7 +1,7 @@
 import {
   fabricFromNativeValue,
   type FabricValue,
-} from "@commonfabric/data-model/fabric-value";
+} from "@commonfabric/data-model";
 import type { Cell, MemorySpace, Runtime } from "@commonfabric/runner";
 
 export interface GithubFabricConnection {

--- a/packages/data-model-schema/src/basic-schemas.ts
+++ b/packages/data-model-schema/src/basic-schemas.ts
@@ -2,10 +2,7 @@
 
 import type { JSONSchemaObj, JSONSchemaTypes } from "@commonfabric/api";
 
-import {
-  FabricPrimitive,
-  type FabricValue,
-} from "@commonfabric/data-model/fabric-value";
+import { FabricPrimitive, type FabricValue } from "@commonfabric/data-model";
 import { internSchema } from "./schema-intern.ts";
 import { schemaTypeOfFabricPrimitive } from "./schemaTypeOfFabricPrimitive.ts";
 

--- a/packages/data-model-schema/src/schema-copy.ts
+++ b/packages/data-model-schema/src/schema-copy.ts
@@ -2,8 +2,8 @@
 
 import type { JSONSchema, MutableJSONSchemaObj } from "@commonfabric/api";
 
+import { cloneIfNecessary } from "@commonfabric/data-model";
 import { deepFreeze } from "@commonfabric/data-model/deep-freeze";
-import { cloneIfNecessary } from "@commonfabric/data-model/fabric-value";
 
 /**
  * Returns a deep-frozen copy of (or reference to) a JSONSchema, returning

--- a/packages/data-model-schema/src/schema-rewrite.ts
+++ b/packages/data-model-schema/src/schema-rewrite.ts
@@ -5,7 +5,7 @@ import type { JSONSchema, JSONSchemaObj } from "@commonfabric/api";
 import {
   type FabricValue,
   shallowMutableClone,
-} from "@commonfabric/data-model/fabric-value";
+} from "@commonfabric/data-model";
 import { internSchema, isInternedSchema } from "./schema-intern.ts";
 import { toDeepFrozenSchema } from "./schema-copy.ts";
 

--- a/packages/data-model-schema/src/schemaTypeOfFabricPrimitive.ts
+++ b/packages/data-model-schema/src/schemaTypeOfFabricPrimitive.ts
@@ -1,4 +1,5 @@
 import type { FabricPrimitiveSchemaType } from "@commonfabric/api";
+import type { FabricPrimitive } from "@commonfabric/data-model";
 import {
   FabricBytes,
   FabricEpochDay,
@@ -7,7 +8,6 @@ import {
   FabricKeyPair,
   FabricRegExp,
 } from "@commonfabric/data-model/fabric-primitives";
-import type { FabricPrimitive } from "@commonfabric/data-model/fabric-value";
 import { backtickQuote } from "@commonfabric/utils/markdown";
 
 /**

--- a/packages/data-model-schema/test/basic-schemas.test.ts
+++ b/packages/data-model-schema/test/basic-schemas.test.ts
@@ -3,7 +3,7 @@ import { expect } from "@std/expect";
 
 import type { JSONSchemaTypes } from "@commonfabric/api";
 
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import type { FabricValue } from "@commonfabric/data-model";
 
 import { isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
 import {

--- a/packages/data-model-schema/test/schema-type.test.ts
+++ b/packages/data-model-schema/test/schema-type.test.ts
@@ -18,6 +18,7 @@ import {
   isFabricPrimitiveSchemaType,
 } from "@commonfabric/api";
 
+import type { FabricPrimitive } from "@commonfabric/data-model";
 import { BaseFabricPrimitive } from "@commonfabric/data-model/fabric-bases";
 import {
   codecClasses,
@@ -28,7 +29,6 @@ import {
   FabricKeyPair,
   FabricRegExp,
 } from "@commonfabric/data-model/fabric-primitives";
-import type { FabricPrimitive } from "@commonfabric/data-model/fabric-value";
 
 import { schemaTypeOfFabricPrimitive } from "@/schemaTypeOfFabricPrimitive.ts";
 

--- a/packages/data-model/deno.jsonc
+++ b/packages/data-model/deno.jsonc
@@ -39,6 +39,7 @@
     ]
   },
   "exports": {
+    ".": "./src/index.ts",
     "./api": "./src/api.ts",
     "./VALUE_TAGS": "./src/VALUE_TAGS.ts",
     "./cell-rep": "./src/cell-rep.ts",
@@ -51,7 +52,6 @@
     "./fabric-bases": "./src/fabric-bases/index.ts",
     "./fabric-instances": "./src/fabric-instances/index.ts",
     "./fabric-primitives": "./src/fabric-primitives/index.ts",
-    "./fabric-value": "./src/fabric-value.ts",
     "./frozen-builtins": "./src/frozen-builtins.ts",
     "./native-type-tags": "./src/native-type-tags.ts",
     "./value-clone": "./src/value-clone.ts",

--- a/packages/data-model/src/codecs.ts
+++ b/packages/data-model/src/codecs.ts
@@ -17,7 +17,7 @@
 
 import { isInstance } from "@commonfabric/utils/types";
 
-import type { FabricValue } from "./fabric-value.ts";
+import type { FabricValue } from "./index.ts";
 import type { LiveEnvironment } from "./codec-interface/interface.ts";
 import { NULL_LIVE_ENVIRONMENT } from "./codec-interface/NullLiveEnvironment.ts";
 import type { CodecRegistry } from "./codec-common/CodecRegistry.ts";

--- a/packages/data-model/src/data-uri-codec.ts
+++ b/packages/data-model/src/data-uri-codec.ts
@@ -12,7 +12,7 @@ import {
 } from "@commonfabric/utils/base64url";
 import { NullLiveEnvironment } from "./codec-common/index.ts";
 import { fabricFromJsonValue, jsonFromFabricValue } from "./codecs.ts";
-import type { FabricValue } from "./fabric-value.ts";
+import type { FabricValue } from "./index.ts";
 
 /**
  * A URI in string form. Structurally identical to (and hence

--- a/packages/data-model/src/index.ts
+++ b/packages/data-model/src/index.ts
@@ -1,9 +1,12 @@
 /**
- * This module is the canonical public surface for the `FabricValue` types: the
- * type declarations, the `FabricInstance` base class, and the functions that
- * operate on them. Those are spread across several modules, not all of which
- * the package exports on their own, and a caller should not have to know which
- * is which.
+ * This module is the package's main entry point, and the canonical public
+ * surface for the `FabricValue` types: the type declarations, the
+ * `FabricInstance` base class, and the functions that operate on them. Those
+ * are spread across several modules, not all of which the package exports on
+ * their own, and a caller should not have to know which is which. The rest of
+ * the package -- the codec system, the concrete value classes, the hash and
+ * debug utilities -- is reached through the exported subpaths named in
+ * `deno.jsonc`, not through here.
  */
 
 // Re-export everything from `interface.ts`, which declares the types and the

--- a/packages/data-model/test/cloneForMutation.test.ts
+++ b/packages/data-model/test/cloneForMutation.test.ts
@@ -16,7 +16,7 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
-import { cloneForMutation, CloneForMutationError } from "@/fabric-value.ts";
+import { cloneForMutation, CloneForMutationError } from "@/index.ts";
 import { deepFreeze, isDeepFrozen } from "@/deep-freeze.ts";
 import { FabricEpochNsec } from "@/fabric-primitives/FabricEpochNsec.ts";
 import { FabricError } from "@/fabric-instances/FabricError.ts";

--- a/packages/data-model/test/cloneIfNecessary.test.ts
+++ b/packages/data-model/test/cloneIfNecessary.test.ts
@@ -25,8 +25,8 @@ import {
   cloneIfNecessary,
   type CloneOptions,
   isValidFabricValue,
-} from "@/fabric-value.ts";
-import type { FabricValue } from "@/fabric-value.ts";
+} from "@/index.ts";
+import type { FabricValue } from "@/index.ts";
 import { isDeepFrozen, isValidDeepFrozenFabricValue } from "@/deep-freeze.ts";
 import { FabricBytes } from "@/fabric-primitives/FabricBytes.ts";
 import { FabricEpochDay } from "@/fabric-primitives/FabricEpochDay.ts";

--- a/packages/data-model/test/codecs.test.ts
+++ b/packages/data-model/test/codecs.test.ts
@@ -24,10 +24,10 @@ import {
   realmFromFabricValue,
 } from "@/codecs.ts";
 import { FabricKeyPair } from "@/fabric-primitives/FabricKeyPair.ts";
-import { isValidFabricValue } from "@/fabric-value.ts";
+import { isValidFabricValue } from "@/index.ts";
 import { JsonCodecEngine } from "@/codec-json/JsonCodecEngine.ts";
 import { FabricError } from "@/fabric-instances/FabricError.ts";
-import type { FabricValue } from "@/fabric-value.ts";
+import type { FabricValue } from "@/index.ts";
 import { BaseLiveEnvironment } from "@/codec-interface/BaseLiveEnvironment.ts";
 
 /** Mock runtime for decode calls. */

--- a/packages/data-model/test/fabric-primitives/FabricEpochDay.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricEpochDay.test.ts
@@ -19,7 +19,7 @@ import { CODEC_TYPE_TAGS } from "@/codec-interface/codec-type-tags.ts";
 import { NULL_LIVE_ENVIRONMENT } from "@/codec-interface/NullLiveEnvironment.ts";
 import { JSON_CODEC } from "@/codec-interface/interface.ts";
 import { FabricEpochDay } from "@/fabric-primitives/FabricEpochDay.ts";
-import { shallowFabricFromNativeValue } from "@/fabric-value.ts";
+import { shallowFabricFromNativeValue } from "@/index.ts";
 import { FabricInstance, FabricPrimitive } from "@/interface.ts";
 
 describe("FabricEpochDay", () => {

--- a/packages/data-model/test/fabric-primitives/FabricEpochNsec.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricEpochNsec.test.ts
@@ -19,7 +19,7 @@ import { CODEC_TYPE_TAGS } from "@/codec-interface/codec-type-tags.ts";
 import { NULL_LIVE_ENVIRONMENT } from "@/codec-interface/NullLiveEnvironment.ts";
 import { JSON_CODEC } from "@/codec-interface/interface.ts";
 import { FabricEpochNsec } from "@/fabric-primitives/FabricEpochNsec.ts";
-import { shallowFabricFromNativeValue } from "@/fabric-value.ts";
+import { shallowFabricFromNativeValue } from "@/index.ts";
 import { FabricInstance, FabricPrimitive } from "@/interface.ts";
 
 describe("FabricEpochNsec", () => {

--- a/packages/data-model/test/fabric-primitives/FabricRegExp.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricRegExp.test.ts
@@ -27,7 +27,7 @@ import { FabricRegExp } from "@/fabric-primitives/FabricRegExp.ts";
 import {
   isValidFabricConvertibleValue,
   shallowFabricFromNativeValue,
-} from "@/fabric-value.ts";
+} from "@/index.ts";
 import { FabricInstance, FabricPrimitive } from "@/interface.ts";
 import { isValidFabricNativeObject } from "@/type-check.ts";
 import { tagFromNativeClass, tagFromNativeValue } from "@/native-type-tags.ts";

--- a/packages/data-model/test/shallowMutableClone.test.ts
+++ b/packages/data-model/test/shallowMutableClone.test.ts
@@ -15,7 +15,7 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
-import { shallowMutableClone } from "@/fabric-value.ts";
+import { shallowMutableClone } from "@/index.ts";
 import { deepFreeze, isDeepFrozen } from "@/deep-freeze.ts";
 import { FabricBytes } from "@/fabric-primitives/FabricBytes.ts";
 import { FabricHash } from "@/fabric-primitives/FabricHash.ts";

--- a/packages/data-model/test/value-clone.test.ts
+++ b/packages/data-model/test/value-clone.test.ts
@@ -26,7 +26,7 @@ import {
   CloneForMutationError,
   cloneWithoutValueAtPath,
   cloneWithValueAtPath,
-} from "@/fabric-value.ts";
+} from "@/index.ts";
 import { deepFreeze, isDeepFrozen } from "@/deep-freeze.ts";
 import { FabricError } from "@/fabric-instances/FabricError.ts";
 import { FabricHash } from "@/fabric-primitives/FabricHash.ts";

--- a/packages/data-model/test/valueEqual.test.ts
+++ b/packages/data-model/test/valueEqual.test.ts
@@ -21,7 +21,7 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
-import { type FabricValue, valueEqual } from "@/fabric-value.ts";
+import { type FabricValue, valueEqual } from "@/index.ts";
 import { deepFreeze } from "@/deep-freeze.ts";
 import { FabricBytes } from "@/fabric-primitives/FabricBytes.ts";
 import { FabricRegExp } from "@/fabric-primitives/FabricRegExp.ts";

--- a/packages/fuse/cfc-writeback.ts
+++ b/packages/fuse/cfc-writeback.ts
@@ -1,10 +1,7 @@
 import { encodeHex } from "@std/encoding/hex";
 
 import { sha256 } from "@commonfabric/content-hash";
-import {
-  cloneIfNecessary,
-  type FabricValue,
-} from "@commonfabric/data-model/fabric-value";
+import { cloneIfNecessary, type FabricValue } from "@commonfabric/data-model";
 import {
   type CfcEnforcementMode as RunnerCfcEnforcementMode,
   DEFAULT_CFC_ENFORCEMENT_MODE,

--- a/packages/html/bench/dom-event-crossing.bench.ts
+++ b/packages/html/bench/dom-event-crossing.bench.ts
@@ -34,8 +34,8 @@
 
 import { BenchWorker } from "@commonfabric/test-support/bench-worker";
 
+import type { FabricValue } from "@commonfabric/data-model";
 import { realmFromFabricValue } from "@commonfabric/data-model/codecs";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 
 import { serializeEvent } from "../src/main/events.ts";
 import type { EventRequest } from "./fixtures/dom-event-far-side.ts";

--- a/packages/html/src/debug.ts
+++ b/packages/html/src/debug.ts
@@ -7,7 +7,7 @@
  */
 
 import { type CellHandle, isCellHandle } from "@commonfabric/runtime-client";
-import { FabricSpecialObject } from "@commonfabric/data-model/fabric-value";
+import { FabricSpecialObject } from "@commonfabric/data-model";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import { debugVDOMSchema } from "@commonfabric/runner/schemas";
 import { type ActiveRender, getActiveRenders } from "./render.ts";

--- a/packages/html/src/main/events.ts
+++ b/packages/html/src/main/events.ts
@@ -8,7 +8,7 @@
 import {
   type FabricValue,
   isValidFabricValueLayer,
-} from "@commonfabric/data-model/fabric-value";
+} from "@commonfabric/data-model";
 import type { SigilLink } from "@commonfabric/runner/shared";
 import { isCellHandle } from "@commonfabric/runtime-client";
 import {

--- a/packages/html/src/vdom-ops.ts
+++ b/packages/html/src/vdom-ops.ts
@@ -5,7 +5,7 @@
  * on the main thread. They are batched and sent as a single message.
  */
 
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import type { FabricValue } from "@commonfabric/data-model";
 import type { CellRef } from "@commonfabric/runtime-client";
 
 /**

--- a/packages/html/src/worker/keying.ts
+++ b/packages/html/src/worker/keying.ts
@@ -5,7 +5,7 @@
  * enabling efficient diffing and reuse of DOM nodes.
  */
 
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import type { FabricValue } from "@commonfabric/data-model";
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import { isCell } from "@commonfabric/runner";
 

--- a/packages/html/test/worker-events.test.ts
+++ b/packages/html/test/worker-events.test.ts
@@ -3,9 +3,9 @@
  */
 
 import { assertEquals, assertThrows } from "@std/assert";
+import type { FabricValue } from "@commonfabric/data-model";
 import { realmFromFabricValue } from "@commonfabric/data-model/codecs";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import {
   $conn,
   CellHandle,

--- a/packages/iframe-sandbox/src/bridge.ts
+++ b/packages/iframe-sandbox/src/bridge.ts
@@ -3,7 +3,7 @@
  * Only resources named by the embedding host are reachable through the port.
  */
 
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import type { FabricValue } from "@commonfabric/data-model";
 import {
   fabricFromRealmValue,
   realmFromFabricValue,

--- a/packages/iframe-sandbox/src/guest.ts
+++ b/packages/iframe-sandbox/src/guest.ts
@@ -4,14 +4,14 @@
  */
 
 import {
-  fabricFromRealmValue,
-  realmFromFabricValue,
-} from "@commonfabric/data-model/codecs";
-import {
   cloneIfNecessary,
   type FabricValue,
   valueEqual,
-} from "@commonfabric/data-model/fabric-value";
+} from "@commonfabric/data-model";
+import {
+  fabricFromRealmValue,
+  realmFromFabricValue,
+} from "@commonfabric/data-model/codecs";
 
 import {
   BRIDGE_PROTOCOL,

--- a/packages/iframe-sandbox/src/ipc.ts
+++ b/packages/iframe-sandbox/src/ipc.ts
@@ -1,6 +1,6 @@
 // Types used by the `common-iframe-sandbox` IPC.
 
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import type { FabricValue } from "@commonfabric/data-model";
 
 // Diagram of the messages between the Host environment, the intermediary outer
 // frame, and the guest in the inner frame.

--- a/packages/iframe-sandbox/src/react.ts
+++ b/packages/iframe-sandbox/src/react.ts
@@ -3,7 +3,7 @@
  * The adapter takes hooks structurally, so React stays a guest dependency.
  */
 
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import type { FabricValue } from "@commonfabric/data-model";
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
 
 import {

--- a/packages/iframe-sandbox/test/bridge.test.ts
+++ b/packages/iframe-sandbox/test/bridge.test.ts
@@ -2,8 +2,8 @@
 
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import type { FabricValue } from "@commonfabric/data-model";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 
 import {
   type BridgeCancel,

--- a/packages/iframe-sandbox/test/guest.test.ts
+++ b/packages/iframe-sandbox/test/guest.test.ts
@@ -1,8 +1,8 @@
+import type { FabricValue } from "@commonfabric/data-model";
 import {
   fabricFromRealmValue,
   realmFromFabricValue,
 } from "@commonfabric/data-model/codecs";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
 

--- a/packages/iframe-sandbox/test/utils.ts
+++ b/packages/iframe-sandbox/test/utils.ts
@@ -1,4 +1,4 @@
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import type { FabricValue } from "@commonfabric/data-model";
 import { defer } from "@commonfabric/utils/defer";
 
 import type {

--- a/packages/lib-shell/src/runtime.ts
+++ b/packages/lib-shell/src/runtime.ts
@@ -1,7 +1,7 @@
 import { createSession, DID, Identity, Session } from "@commonfabric/identity";
 import { CFC_CONCEPT_KIND, cfcAtom } from "@commonfabric/api/cfc";
+import type { FabricPlainObject } from "@commonfabric/data-model";
 import { entityRefFromString } from "@commonfabric/data-model/cell-rep";
-import type { FabricPlainObject } from "@commonfabric/data-model/fabric-value";
 import { navigate } from "@commonfabric/navigation";
 import { slugIdForSpace } from "@commonfabric/runner/slugs";
 import { NameSchema } from "@commonfabric/runner/schemas";

--- a/packages/memory/test/v2-client-reconnect-auth.test.ts
+++ b/packages/memory/test/v2-client-reconnect-auth.test.ts
@@ -1,5 +1,5 @@
 import { assertEquals, assertRejects } from "@std/assert";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import type { FabricValue } from "@commonfabric/data-model";
 import {
   decodeMemoryBoundary,
   encodeMemoryBoundary,

--- a/packages/memory/test/v2-client.test.ts
+++ b/packages/memory/test/v2-client.test.ts
@@ -1,7 +1,7 @@
 import { assertEquals, assertExists, assertRejects } from "@std/assert";
 import { FakeTime } from "@std/testing/time";
 import { defer } from "@commonfabric/utils/defer";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import type { FabricValue } from "@commonfabric/data-model";
 import { Server, SessionRegistry } from "../v2/server.ts";
 import {
   decodeMemoryBoundary,

--- a/packages/memory/test/v2-engine.test.ts
+++ b/packages/memory/test/v2-engine.test.ts
@@ -6,12 +6,12 @@ import {
 } from "@std/assert";
 import { toFileUrl } from "@std/path";
 
+import type { FabricValue } from "@commonfabric/data-model";
 import {
   type EntityRef,
   entityRefFromString,
   LINK_V1_TAG,
 } from "@commonfabric/data-model/cell-rep";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { Database } from "@db/sqlite";
 
 import {

--- a/packages/memory/test/v2-patch.test.ts
+++ b/packages/memory/test/v2-patch.test.ts
@@ -17,12 +17,12 @@ import {
   assertThrows,
 } from "@std/assert";
 
+import { FabricInstance } from "@commonfabric/data-model";
 import { FabricError } from "@commonfabric/data-model/fabric-instances";
 import {
   FabricBytes,
   FabricEpochNsec,
 } from "@commonfabric/data-model/fabric-primitives";
-import { FabricInstance } from "@commonfabric/data-model/fabric-value";
 
 import { applyPatch, applyPatchToDocument } from "../v2/patch.ts";
 

--- a/packages/memory/test/v2-sync-schema-table.test.ts
+++ b/packages/memory/test/v2-sync-schema-table.test.ts
@@ -5,6 +5,10 @@ import {
   assertStrictEquals,
   assertThrows,
 } from "@std/assert";
+import type {
+  FabricValue,
+  MutableFabricPlainObjectLayer,
+} from "@commonfabric/data-model";
 import {
   isLinkRef,
   LINK_V1_TAG,
@@ -13,10 +17,6 @@ import {
   resetModernCellRepConfig,
   setModernCellRepConfig,
 } from "@commonfabric/data-model/cell-rep";
-import type {
-  FabricValue,
-  MutableFabricPlainObjectLayer,
-} from "@commonfabric/data-model/fabric-value";
 import { internSchema } from "@commonfabric/data-model-schema";
 import type { JSONSchema } from "@commonfabric/api";
 import {

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -1,6 +1,6 @@
 import { Database } from "@db/sqlite";
 import type { FabricValue } from "@commonfabric/api";
-import { valueEqual } from "@commonfabric/data-model/fabric-value";
+import { valueEqual } from "@commonfabric/data-model";
 import { internSchemaAsTaggedHashString } from "@commonfabric/data-model-schema";
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import type { JSONSchema } from "../../runner/src/builder/types.ts";

--- a/packages/memory/v2/patch.ts
+++ b/packages/memory/v2/patch.ts
@@ -1,12 +1,12 @@
 import type { FabricValue } from "@commonfabric/api";
-import { deepFreeze } from "@commonfabric/data-model/deep-freeze";
 import {
   cloneForMutation,
   CloneForMutationError,
   cloneIfNecessary,
   type MutableFabricContainerValueLayer,
   valueEqual,
-} from "@commonfabric/data-model/fabric-value";
+} from "@commonfabric/data-model";
+import { deepFreeze } from "@commonfabric/data-model/deep-freeze";
 import { isInstance, isObjectNotArray } from "@commonfabric/utils/types";
 import { type EntityDocument, isEntityDocument, type PatchOp } from "../v2.ts";
 import { encodePointer, parsePointer } from "./path.ts";

--- a/packages/memory/v2/schema-table-links.ts
+++ b/packages/memory/v2/schema-table-links.ts
@@ -1,10 +1,10 @@
 import type { FabricPlainObject, FabricValue } from "@commonfabric/api";
+import type { MutableFabricPlainObjectLayer } from "@commonfabric/data-model";
 import {
   isLinkRef,
   linkRefFrom,
   linkRefPayload,
 } from "@commonfabric/data-model/cell-rep";
-import type { MutableFabricPlainObjectLayer } from "@commonfabric/data-model/fabric-value";
 import { isPlainObject } from "@commonfabric/utils/types";
 
 export const REQUEST_SCHEMA_CAS_REF_PREFIX = "schema-cas@1:";

--- a/packages/memory/v2/sqlite/exec.ts
+++ b/packages/memory/v2/sqlite/exec.ts
@@ -4,8 +4,8 @@
 // the client (runner) before/after these calls.
 
 import { type BindValue, Database } from "@db/sqlite";
+import { fabricFromNativeValue } from "@commonfabric/data-model";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
-import { fabricFromNativeValue } from "@commonfabric/data-model/fabric-value";
 import { isPlainObject } from "@commonfabric/utils/types";
 import type { SqliteNativeRow } from "../../v2.ts";
 import { assertReadOnly, assertWriteSafe } from "./guard.ts";

--- a/packages/memory/v2/sqlite/row-label.ts
+++ b/packages/memory/v2/sqlite/row-label.ts
@@ -19,7 +19,7 @@
 // Pure module: no FFI, no engine imports — safe for client-side import.
 
 import type { FabricPlainObject, FabricValue } from "@commonfabric/api";
-import type { MutableFabricPlainObjectLayer } from "@commonfabric/data-model/fabric-value";
+import type { MutableFabricPlainObjectLayer } from "@commonfabric/data-model";
 import { isObjectNotArray } from "@commonfabric/utils/types";
 
 /** A reference to a declared column, handed to the rule as `f.<col>`. */

--- a/packages/patterns/integration/multi-runtime-harness.ts
+++ b/packages/patterns/integration/multi-runtime-harness.ts
@@ -36,11 +36,11 @@
  * to before: flag unset or false keeps the in-process standalone server.
  */
 
+import type { FabricValue } from "@commonfabric/data-model";
 import {
   fabricFromRealmValue,
   realmFromFabricValue,
 } from "@commonfabric/data-model/codecs";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { env } from "@commonfabric/integration";
 import { Identity } from "@commonfabric/identity";
 import { StandaloneMemoryServer } from "@commonfabric/memory/v2/standalone";

--- a/packages/patterns/integration/multi-runtime-ipc.ts
+++ b/packages/patterns/integration/multi-runtime-ipc.ts
@@ -8,8 +8,8 @@
  * nothing outside a worker may import a value from there.
  */
 
+import type { FabricValue } from "@commonfabric/data-model";
 import type { RealmEncodedValue } from "@commonfabric/data-model/codec-realm";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import type { SchedulerGraphSnapshot } from "@commonfabric/runner";
 
 /**

--- a/packages/patterns/integration/multi-runtime-worker.ts
+++ b/packages/patterns/integration/multi-runtime-worker.ts
@@ -11,15 +11,12 @@
  * what the protocol module is for.
  */
 
+import { type FabricValue, isValidFabricValue } from "@commonfabric/data-model";
 import {
   fabricFromRealmValue,
   realmFromFabricValue,
 } from "@commonfabric/data-model/codecs";
 import type { FabricKeyPair } from "@commonfabric/data-model/fabric-primitives";
-import {
-  type FabricValue,
-  isValidFabricValue,
-} from "@commonfabric/data-model/fabric-value";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import type { Cell } from "@commonfabric/runner";
 import {

--- a/packages/patterns/test/source-coverage/commonfabric-shim.test.ts
+++ b/packages/patterns/test/source-coverage/commonfabric-shim.test.ts
@@ -36,10 +36,7 @@
 
 // The generated child import map resolves the transitive
 // `data-model`/`content-hash`/`leb128` graph these pull in.
-import {
-  type FabricValue,
-  valueEqual,
-} from "@commonfabric/data-model/fabric-value";
+import { type FabricValue, valueEqual } from "@commonfabric/data-model";
 export { valueEqual };
 export {
   toCompactDebugString,

--- a/packages/piece/src/ops/bulk-repair.ts
+++ b/packages/piece/src/ops/bulk-repair.ts
@@ -32,10 +32,7 @@
  */
 
 import type { FabricValue } from "@commonfabric/api";
-import {
-  isValidFabricValue,
-  valueEqual,
-} from "@commonfabric/data-model/fabric-value";
+import { isValidFabricValue, valueEqual } from "@commonfabric/data-model";
 import { cloneIfNecessary } from "@commonfabric/data-model/value-clone";
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import { isLink } from "@commonfabric/runner";

--- a/packages/piece/src/ops/clone-data-guards.ts
+++ b/packages/piece/src/ops/clone-data-guards.ts
@@ -9,10 +9,7 @@ import {
   type IExtendedStorageTransaction,
 } from "@commonfabric/runner";
 import { cfcLabelViewForCellFailClosed } from "@commonfabric/runner/cfc";
-import {
-  FabricInstance,
-  FabricPrimitive,
-} from "@commonfabric/data-model/fabric-value";
+import { FabricInstance, FabricPrimitive } from "@commonfabric/data-model";
 import { commitPreconditionValueHash } from "@commonfabric/memory/v2";
 
 export function cloneCellKey(cell: Cell<unknown>): string {

--- a/packages/piece/src/ops/clone-data-snapshot.ts
+++ b/packages/piece/src/ops/clone-data-snapshot.ts
@@ -10,10 +10,7 @@ import {
   isCellResult,
   isStream,
 } from "@commonfabric/runner";
-import {
-  FabricInstance,
-  FabricPrimitive,
-} from "@commonfabric/data-model/fabric-value";
+import { FabricInstance, FabricPrimitive } from "@commonfabric/data-model";
 import {
   assertCloneDataUnlabeled,
   assertNoCloneFabricInstance,

--- a/packages/piece/src/schema-compatibility.ts
+++ b/packages/piece/src/schema-compatibility.ts
@@ -15,10 +15,7 @@ import {
 } from "@commonfabric/runner/cfc";
 import { isFabricPrimitiveSchemaType } from "@commonfabric/api";
 import { internSchema } from "@commonfabric/data-model-schema";
-import {
-  type FabricValue,
-  valueEqual,
-} from "@commonfabric/data-model/fabric-value";
+import { type FabricValue, valueEqual } from "@commonfabric/data-model";
 
 type SchemaObject = Exclude<JSONSchema, boolean>;
 type SchemaRole = "argument" | "result";

--- a/packages/piece/test/clone-data-guards.test.ts
+++ b/packages/piece/test/clone-data-guards.test.ts
@@ -11,10 +11,7 @@ import type {
   IExtendedStorageTransaction,
   MemorySpace,
 } from "@commonfabric/runner";
-import {
-  FabricInstance,
-  FabricPrimitive,
-} from "@commonfabric/data-model/fabric-value";
+import { FabricInstance, FabricPrimitive } from "@commonfabric/data-model";
 import { commitPreconditionValueHash } from "@commonfabric/memory/v2";
 import {
   assertNoCloneFabricInstance,

--- a/packages/piece/test/piece-origin.test.ts
+++ b/packages/piece/test/piece-origin.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 
-import { FabricInstance } from "@commonfabric/data-model/fabric-value";
+import { FabricInstance } from "@commonfabric/data-model";
 import { createSession, Identity } from "@commonfabric/identity";
 import {
   applyPieceSourceTransition,

--- a/packages/piece/test/pull-materialization.test.ts
+++ b/packages/piece/test/pull-materialization.test.ts
@@ -1,11 +1,11 @@
 import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 
+import type { FabricValue } from "@commonfabric/data-model";
 import {
   entityRefToString,
   linkRefPayload,
 } from "@commonfabric/data-model/cell-rep";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { createSession, Identity } from "@commonfabric/identity";
 import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 import {

--- a/packages/piece/test/state-continuity-harness.ts
+++ b/packages/piece/test/state-continuity-harness.ts
@@ -35,7 +35,7 @@ import { fromFileUrl } from "@std/path/from-file-url";
 // a `FabricSpecialObject` (bytes, an epoch). Neither survives a structural
 // comparison unaided — see `comparableState`.
 import type { JSONSchemaObj } from "@commonfabric/api";
-import { FabricSpecialObject } from "@commonfabric/data-model/fabric-value";
+import { FabricSpecialObject } from "@commonfabric/data-model";
 import { taggedHashStringOf } from "@commonfabric/data-model/value-hash";
 import { Identity } from "@commonfabric/identity";
 import type { Signer } from "@commonfabric/memory/interface";

--- a/packages/runner/src/acl-manager.ts
+++ b/packages/runner/src/acl-manager.ts
@@ -7,10 +7,7 @@ import {
   isACL,
 } from "@commonfabric/memory/acl";
 import type { Capability, URI } from "@commonfabric/memory/interface";
-import {
-  cloneIfNecessary,
-  type FabricValue,
-} from "@commonfabric/data-model/fabric-value";
+import { cloneIfNecessary, type FabricValue } from "@commonfabric/data-model";
 import type { Cell } from "./cell.ts";
 import type { Runtime } from "./runtime.ts";
 import type { IMemorySpaceAddress } from "./storage/interface.ts";

--- a/packages/runner/src/builder/factory.ts
+++ b/packages/runner/src/builder/factory.ts
@@ -2,6 +2,12 @@
  * Factory function to create builder functions with runtime dependency injection
  */
 
+import {
+  FabricInstance,
+  FabricPrimitive,
+  FabricSpecialObject,
+  valueEqual,
+} from "@commonfabric/data-model";
 import { entityRefToString } from "@commonfabric/data-model/cell-rep";
 import {
   FabricError,
@@ -15,12 +21,6 @@ import {
   FabricKeyPair,
   FabricRegExp,
 } from "@commonfabric/data-model/fabric-primitives";
-import {
-  FabricInstance,
-  FabricPrimitive,
-  FabricSpecialObject,
-  valueEqual,
-} from "@commonfabric/data-model/fabric-value";
 import {
   toCompactDebugString,
   toIndentedDebugString,

--- a/packages/runner/src/builder/node-utils.ts
+++ b/packages/runner/src/builder/node-utils.ts
@@ -1,4 +1,4 @@
-import { FabricInstance } from "@commonfabric/data-model/fabric-value";
+import { FabricInstance } from "@commonfabric/data-model";
 import { isObjectOrArray } from "@commonfabric/utils/types";
 
 import { isCell } from "../cell.ts";

--- a/packages/runner/src/builder/to-encodable-form.ts
+++ b/packages/runner/src/builder/to-encodable-form.ts
@@ -7,7 +7,7 @@ import {
   FabricInstance,
   FabricPrimitive,
   shallowFabricFromNativeObjectElseUndefined,
-} from "@commonfabric/data-model/fabric-value";
+} from "@commonfabric/data-model";
 import { refuseFabricInstance } from "../fabric-special-object.ts";
 import { type AliasBinding } from "../sigil-types.ts";
 import {

--- a/packages/runner/src/builder/traverse-utils.ts
+++ b/packages/runner/src/builder/traverse-utils.ts
@@ -1,8 +1,5 @@
 import { isObjectOrArray } from "@commonfabric/utils/types";
-import {
-  FabricInstance,
-  FabricPrimitive,
-} from "@commonfabric/data-model/fabric-value";
+import { FabricInstance, FabricPrimitive } from "@commonfabric/data-model";
 import { refuseFabricInstance } from "../fabric-special-object.ts";
 import { type FactoryInput, isPattern, isReactive } from "./types.ts";
 import { noteDerivedCopy } from "./pattern-metadata.ts";

--- a/packages/runner/src/builder/types.ts
+++ b/packages/runner/src/builder/types.ts
@@ -66,6 +66,12 @@ import type {
 import { toSchema } from "@commonfabric/api";
 import type { Schema } from "@commonfabric/api/schema";
 import type {
+  FabricInstance,
+  FabricPrimitive,
+  FabricSpecialObject,
+  valueEqual,
+} from "@commonfabric/data-model";
+import type {
   FabricError,
   FabricLink,
 } from "@commonfabric/data-model/fabric-instances";
@@ -77,12 +83,6 @@ import type {
   FabricKeyPair,
   FabricRegExp,
 } from "@commonfabric/data-model/fabric-primitives";
-import type {
-  FabricInstance,
-  FabricPrimitive,
-  FabricSpecialObject,
-  valueEqual,
-} from "@commonfabric/data-model/fabric-value";
 import type {
   toCompactDebugString,
   toIndentedDebugString,

--- a/packages/runner/src/builtins/fetch.ts
+++ b/packages/runner/src/builtins/fetch.ts
@@ -3,12 +3,9 @@ import type {
   JSONSchema,
   JSONSchemaObj,
 } from "@commonfabric/api";
+import { type FabricValue, valueEqual } from "@commonfabric/data-model";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import { internSchema } from "@commonfabric/data-model-schema";
-import {
-  type FabricValue,
-  valueEqual,
-} from "@commonfabric/data-model/fabric-value";
 import { isObjectOrArray } from "@commonfabric/utils/types";
 
 import { getPatternEnvironment } from "../builder/env.ts";

--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -2,15 +2,15 @@ import type { CfcAtom } from "@commonfabric/api/cfc";
 import { cfcAtom } from "@commonfabric/api/cfc";
 import type { Schema } from "@commonfabric/api/schema";
 import {
+  FabricInstance,
+  FabricPrimitive,
+  type FabricValue,
+} from "@commonfabric/data-model";
+import {
   entityRefToString,
   isEntityRef,
 } from "@commonfabric/data-model/cell-rep";
 import { hasDataUriScheme } from "@commonfabric/data-model/data-uri-codec";
-import {
-  FabricInstance,
-  FabricPrimitive,
-  type FabricValue,
-} from "@commonfabric/data-model/fabric-value";
 import {
   internSchema,
   isNontrivialSchema,

--- a/packages/runner/src/builtins/sqlite-builtins.ts
+++ b/packages/runner/src/builtins/sqlite-builtins.ts
@@ -42,12 +42,12 @@ import {
 import { waveRunContextOf, waveSettlementOf } from "../executor/wave.ts";
 import { parseCfLinkToSigil } from "./sqlite/cf-link.ts";
 import { type IFCLabel, mergeLabel } from "../cfc/label-view-core.ts";
-import { cloneIfNecessary } from "@commonfabric/data-model/value-clone";
 import {
   fabricFromNativeValue,
   type FabricValue,
   valueEqual,
-} from "@commonfabric/data-model/fabric-value";
+} from "@commonfabric/data-model";
+import { cloneIfNecessary } from "@commonfabric/data-model/value-clone";
 import { validateRowLabelSpec } from "@commonfabric/memory/sqlite/row-label";
 import {
   columnDeclaresIfc,

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -1,11 +1,5 @@
 import type { ReadonlyCell } from "@commonfabric/api";
 import {
-  type EntityRef,
-  entityRefFromString,
-  linkRefFrom,
-} from "@commonfabric/data-model/cell-rep";
-import { deepFreeze } from "@commonfabric/data-model/deep-freeze";
-import {
   assertValidFabricValueLayer,
   cloneIfNecessary,
   type FabricConvertibleValue,
@@ -19,7 +13,13 @@ import {
   shallowCleanPlainObject,
   shallowFabricFromNativeObjectElseUndefined,
   valueEqual,
-} from "@commonfabric/data-model/fabric-value";
+} from "@commonfabric/data-model";
+import {
+  type EntityRef,
+  entityRefFromString,
+  linkRefFrom,
+} from "@commonfabric/data-model/cell-rep";
+import { deepFreeze } from "@commonfabric/data-model/deep-freeze";
 import {
   deepFrozenCloneAndInternSchema,
   internSchema,

--- a/packages/runner/src/cfc/link-label-view.ts
+++ b/packages/runner/src/cfc/link-label-view.ts
@@ -11,15 +11,12 @@
  * is removed outright.
  */
 
+import { FabricInstance, FabricPrimitive } from "@commonfabric/data-model";
 import {
   isLinkRef,
   linkRefFrom,
   linkRefPayload,
 } from "@commonfabric/data-model/cell-rep";
-import {
-  FabricInstance,
-  FabricPrimitive,
-} from "@commonfabric/data-model/fabric-value";
 import { isObjectOrArray } from "@commonfabric/utils/types";
 import { refuseFabricInstance } from "../fabric-special-object.ts";
 import type { CellLinkRefPayload, SigilLink } from "../sigil-types.ts";

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -19,7 +19,7 @@ import {
   FabricPrimitive,
   isFabricObjectOrArray,
   valueEqual,
-} from "@commonfabric/data-model/fabric-value";
+} from "@commonfabric/data-model";
 import type { MemorySpace, URI } from "@commonfabric/memory/interface";
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 import { deepEqual } from "@commonfabric/utils/deep-equal";

--- a/packages/runner/src/cfc/request-snapshot.ts
+++ b/packages/runner/src/cfc/request-snapshot.ts
@@ -1,4 +1,4 @@
-import { cloneIfNecessary } from "@commonfabric/data-model/fabric-value";
+import { cloneIfNecessary } from "@commonfabric/data-model";
 import type { FabricValue } from "@commonfabric/api";
 
 /**

--- a/packages/runner/src/cfc/schema-sanitization.ts
+++ b/packages/runner/src/cfc/schema-sanitization.ts
@@ -17,7 +17,7 @@ import {
   type FabricValue,
   isFabricPlainObject,
   valueEqual,
-} from "@commonfabric/data-model/fabric-value";
+} from "@commonfabric/data-model";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
 import {
   isObjectNotArray,

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -5,8 +5,6 @@ import {
   type ScopeKeyIdentity,
 } from "@commonfabric/memory/v2";
 import type { CfcAtom } from "@commonfabric/api/cfc";
-import { linkRefFrom, linkRefPayload } from "@commonfabric/data-model/cell-rep";
-import { isFabricDataUri } from "@commonfabric/data-model/data-uri-codec";
 import {
   assertValidFabricValueLayer,
   cloneIfNecessary,
@@ -15,7 +13,9 @@ import {
   FabricSpecialObject,
   type FabricValue,
   shallowFabricFromNativeObjectElseUndefined,
-} from "@commonfabric/data-model/fabric-value";
+} from "@commonfabric/data-model";
+import { linkRefFrom, linkRefPayload } from "@commonfabric/data-model/cell-rep";
+import { isFabricDataUri } from "@commonfabric/data-model/data-uri-codec";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 import { getLogger } from "@commonfabric/utils/logger";

--- a/packages/runner/src/data-uri.ts
+++ b/packages/runner/src/data-uri.ts
@@ -24,15 +24,15 @@
  */
 
 import {
+  FabricInstance,
+  FabricPrimitive,
+  type FabricValue,
+} from "@commonfabric/data-model";
+import {
   dataUriFromValue,
   isFabricDataUri,
   valueFromDataUri,
 } from "@commonfabric/data-model/data-uri-codec";
-import {
-  FabricInstance,
-  FabricPrimitive,
-  type FabricValue,
-} from "@commonfabric/data-model/fabric-value";
 import { isObjectOrArray } from "@commonfabric/utils/types";
 
 import { type Cell, isCell } from "./cell.ts";

--- a/packages/runner/src/fabric-special-object.ts
+++ b/packages/runner/src/fabric-special-object.ts
@@ -1,4 +1,4 @@
-import type { FabricInstance } from "@commonfabric/data-model/fabric-value";
+import type { FabricInstance } from "@commonfabric/data-model";
 
 /**
  * Builds the refusal a `FabricInstance` gets from a walk that cannot yet

--- a/packages/runner/src/graph-query.ts
+++ b/packages/runner/src/graph-query.ts
@@ -13,7 +13,7 @@
  * the traversal's internals.
  */
 
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import type { FabricValue } from "@commonfabric/data-model";
 import { internPathSelector } from "@commonfabric/data-model-schema";
 import type { MemorySpace } from "@commonfabric/memory/interface";
 import type { ScopeKey, ScopeKeyIdentity } from "@commonfabric/memory/v2";

--- a/packages/runner/src/link-utils.ts
+++ b/packages/runner/src/link-utils.ts
@@ -1,5 +1,5 @@
+import type { FabricValue } from "@commonfabric/data-model";
 import { linkRefFrom, linkRefPayload } from "@commonfabric/data-model/cell-rep";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { deepFreeze, isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
 import {
   internSchema,

--- a/packages/runner/src/path-utils.ts
+++ b/packages/runner/src/path-utils.ts
@@ -1,4 +1,4 @@
-import { valueEqual } from "@commonfabric/data-model/fabric-value";
+import { valueEqual } from "@commonfabric/data-model";
 import { isObjectOrArray } from "@commonfabric/utils/types";
 
 /**

--- a/packages/runner/src/pattern-binding.ts
+++ b/packages/runner/src/pattern-binding.ts
@@ -4,7 +4,7 @@ import {
   FabricInstance,
   FabricPrimitive,
   valueEqual,
-} from "@commonfabric/data-model/fabric-value";
+} from "@commonfabric/data-model";
 import { deepFrozenCloneAndInternSchema } from "@commonfabric/data-model-schema";
 import {
   type FabricExecValue,

--- a/packages/runner/src/query-result-proxy.ts
+++ b/packages/runner/src/query-result-proxy.ts
@@ -1,4 +1,4 @@
-import { FabricPrimitive } from "@commonfabric/data-model/fabric-value";
+import { FabricPrimitive } from "@commonfabric/data-model";
 import { isObjectOrArray } from "@commonfabric/utils/types";
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 import { isStreamValue } from "./builder/types.ts";

--- a/packages/runner/src/reactive-dependencies.ts
+++ b/packages/runner/src/reactive-dependencies.ts
@@ -1,8 +1,5 @@
 import { isObjectOrArray, isPlainContainer } from "@commonfabric/utils/types";
-import {
-  type FabricValue,
-  valueEqual,
-} from "@commonfabric/data-model/fabric-value";
+import { type FabricValue, valueEqual } from "@commonfabric/data-model";
 import type { ScopeKeyIdentity } from "@commonfabric/memory/v2";
 import { isPrimitiveCellLink } from "./link-utils.ts";
 import { normalizeCellScope } from "./scope.ts";

--- a/packages/runner/src/runner-utils.ts
+++ b/packages/runner/src/runner-utils.ts
@@ -4,7 +4,7 @@ import {
   isValidFabricPlainObject,
   shallowMutableClone,
   valueEqual,
-} from "@commonfabric/data-model/fabric-value";
+} from "@commonfabric/data-model";
 import { linkRefFrom } from "@commonfabric/data-model/cell-rep";
 import { internSchema } from "@commonfabric/data-model-schema";
 import { deepEqual } from "@commonfabric/utils/deep-equal";

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -1,15 +1,15 @@
-import { isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
-import {
-  combineSchemaForLink,
-  resolveSchemaRefsCanonical,
-} from "./traverse.ts";
 import {
   fabricFromNativeValue,
   FabricInstance,
   type FabricValue,
   nativeFromFabricValue,
   valueEqual,
-} from "@commonfabric/data-model/fabric-value";
+} from "@commonfabric/data-model";
+import { isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
+import {
+  combineSchemaForLink,
+  resolveSchemaRefsCanonical,
+} from "./traverse.ts";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import { hashOf, hashStringOf } from "@commonfabric/data-model/value-hash";
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -1,10 +1,10 @@
+import { fabricFromNativeValue } from "@commonfabric/data-model";
 import {
   getModernCellRepConfig,
   resetModernCellRepConfig,
   setModernCellRepConfig,
 } from "@commonfabric/data-model/cell-rep";
 import { dataUriFromValue } from "@commonfabric/data-model/data-uri-codec";
-import { fabricFromNativeValue } from "@commonfabric/data-model/fabric-value";
 import { internSchema } from "@commonfabric/data-model-schema";
 import { createSession, Identity } from "@commonfabric/identity";
 import {

--- a/packages/runner/src/sandbox/result-normalization.ts
+++ b/packages/runner/src/sandbox/result-normalization.ts
@@ -1,13 +1,13 @@
+import {
+  fabricFromNativeValue,
+  type FabricValue,
+} from "@commonfabric/data-model";
 import { FabricError } from "@commonfabric/data-model/fabric-instances";
 import {
   FabricBytes,
   FabricEpochNsec,
   FabricRegExp,
 } from "@commonfabric/data-model/fabric-primitives";
-import {
-  fabricFromNativeValue,
-  type FabricValue,
-} from "@commonfabric/data-model/fabric-value";
 
 import { isReactive } from "../builder/types.ts";
 import { hasEncodableForm } from "../encodable-form.ts";

--- a/packages/runner/src/scheduler/diagnosis.ts
+++ b/packages/runner/src/scheduler/diagnosis.ts
@@ -2,7 +2,7 @@ import {
   type FabricValue,
   isFabricPlainObject,
   valueEqual,
-} from "@commonfabric/data-model/fabric-value";
+} from "@commonfabric/data-model";
 
 import type {
   IExtendedStorageTransaction,

--- a/packages/runner/src/scheduler/topology.ts
+++ b/packages/runner/src/scheduler/topology.ts
@@ -1,7 +1,4 @@
-import {
-  type FabricValue,
-  valueEqual,
-} from "@commonfabric/data-model/fabric-value";
+import { type FabricValue, valueEqual } from "@commonfabric/data-model";
 import {
   arraysOverlap,
   nonRecursiveReadMayOverlapWrite,

--- a/packages/runner/src/schema-view.ts
+++ b/packages/runner/src/schema-view.ts
@@ -41,8 +41,8 @@ import type {
   JSONSchemaTypes,
 } from "@commonfabric/api";
 import { schemaTypeOfFabricPrimitive } from "@commonfabric/data-model-schema";
-import { FabricPrimitive } from "@commonfabric/data-model/fabric-value";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import { FabricPrimitive } from "@commonfabric/data-model";
+import type { FabricValue } from "@commonfabric/data-model";
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 import { getLogger } from "@commonfabric/utils/logger";
 import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";

--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -3,14 +3,14 @@ import {
   type JSONSchemaObj,
   type JSONValue,
 } from "@commonfabric/api";
-import { isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
 import {
   cloneIfNecessary,
   FabricInstance,
   FabricPrimitive,
   type FabricValue,
   shallowMutableClone,
-} from "@commonfabric/data-model/fabric-value";
+} from "@commonfabric/data-model";
+import { isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
 import {
   internSchema,
   isNontrivialSchema,

--- a/packages/runner/src/storage/differential.ts
+++ b/packages/runner/src/storage/differential.ts
@@ -3,7 +3,7 @@ import {
   FabricSpecialObject,
   isFabricObjectOrArray,
   valueEqual,
-} from "@commonfabric/data-model/fabric-value";
+} from "@commonfabric/data-model";
 import {
   resolveScopeKey,
   type ScopeKeyIdentity,

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -1,16 +1,16 @@
 import type { JSONSchema as SchemaDocJSONSchema } from "@commonfabric/api";
+import {
+  type FabricPlainObject,
+  type FabricValue,
+  type MutableFabricPlainObjectLayer,
+  shallowMutableClone,
+} from "@commonfabric/data-model";
 import { deepFreeze } from "@commonfabric/data-model/deep-freeze";
 import { mapLinkSchemas } from "@commonfabric/memory/v2/schema-table-links";
 import { collectExternalSchemaRefHashes } from "../schema-decompose.ts";
 import { getContentAddressedSchemasConfig } from "../schema-doc-config.ts";
 import { lookupSchemaDocument } from "../schema-registry.ts";
 import type { URI } from "../sigil-types.ts";
-import {
-  type FabricPlainObject,
-  type FabricValue,
-  type MutableFabricPlainObjectLayer,
-  shallowMutableClone,
-} from "@commonfabric/data-model/fabric-value";
 import { aclDocId } from "@commonfabric/memory/acl";
 import {
   type CommitError,

--- a/packages/runner/src/storage/mergeable-ops.ts
+++ b/packages/runner/src/storage/mergeable-ops.ts
@@ -1,5 +1,5 @@
 import type { FabricValue } from "@commonfabric/api";
-import { valueEqual } from "@commonfabric/data-model/fabric-value";
+import { valueEqual } from "@commonfabric/data-model";
 import type { PatchOp } from "@commonfabric/memory/v2";
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 import { encodePointer, isPrefixPath } from "../../../memory/v2/path.ts";

--- a/packages/runner/src/storage/transaction/attestation.ts
+++ b/packages/runner/src/storage/transaction/attestation.ts
@@ -1,14 +1,14 @@
 import {
+  type FabricPlainObject,
+  type FabricValue,
+  valueEqual,
+} from "@commonfabric/data-model";
+import {
   extractDataUriPayloadText,
   isDataUriMediaType,
   isFabricDataUri,
   valueFromDataUriPayloadText,
 } from "@commonfabric/data-model/data-uri-codec";
-import {
-  type FabricPlainObject,
-  type FabricValue,
-  valueEqual,
-} from "@commonfabric/data-model/fabric-value";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import { LRUCache } from "@commonfabric/utils/cache";
 import { getLogger } from "@commonfabric/utils/logger";

--- a/packages/runner/src/storage/transaction/mutable-path-write.ts
+++ b/packages/runner/src/storage/transaction/mutable-path-write.ts
@@ -10,14 +10,14 @@
  */
 
 import {
-  cloneForMutation,
-  CloneForMutationError,
-} from "@commonfabric/data-model/value-clone";
-import {
   type FabricValue,
   isFabricPlainContainer,
   valueEqual,
-} from "@commonfabric/data-model/fabric-value";
+} from "@commonfabric/data-model";
+import {
+  cloneForMutation,
+  CloneForMutationError,
+} from "@commonfabric/data-model/value-clone";
 import { toDebugKindString } from "@commonfabric/data-model/value-debug";
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 import type {

--- a/packages/runner/src/storage/v2-transaction.ts
+++ b/packages/runner/src/storage/v2-transaction.ts
@@ -1,10 +1,7 @@
 import type { FabricValue } from "@commonfabric/api";
+import { cloneIfNecessary, valueEqual } from "@commonfabric/data-model";
 import { hasDataUriScheme } from "@commonfabric/data-model/data-uri-codec";
 import { deepFreeze, isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
-import {
-  cloneIfNecessary,
-  valueEqual,
-} from "@commonfabric/data-model/fabric-value";
 import {
   canResolveScopeKey,
   type CommitPrecondition,

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -1,9 +1,9 @@
 import type { FabricValue, SchemaPathSelector } from "@commonfabric/api";
+import { cloneIfNecessary } from "@commonfabric/data-model";
 import {
   hasDataUriScheme,
   valueFromDataUri,
 } from "@commonfabric/data-model/data-uri-codec";
-import { cloneIfNecessary } from "@commonfabric/data-model/fabric-value";
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import { aclDocId } from "@commonfabric/memory/acl";
 import type { Entity } from "@commonfabric/memory/interface";

--- a/packages/runner/src/telemetry.ts
+++ b/packages/runner/src/telemetry.ts
@@ -3,7 +3,7 @@
 // contexts to visualize or log events inside the runtime.
 
 import type { CfcRefusalDetail } from "./cfc/refusal-detail.ts";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import type { FabricValue } from "@commonfabric/data-model";
 
 import { IMemoryChange } from "./storage/interface.ts";
 

--- a/packages/runner/src/traverse-recorder.ts
+++ b/packages/runner/src/traverse-recorder.ts
@@ -1,6 +1,6 @@
 import type { SchemaPathSelector } from "@commonfabric/api";
+import type { FabricValue } from "@commonfabric/data-model";
 import { hasDataUriScheme } from "@commonfabric/data-model/data-uri-codec";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { cloneIfNecessary } from "@commonfabric/data-model/value-clone";
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
 

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -4,6 +4,12 @@ import {
   type JSONSchemaObj,
   type SchemaPathSelector,
 } from "@commonfabric/api";
+import {
+  FabricInstance,
+  FabricPrimitive,
+  FabricSpecialObject,
+  type FabricValue,
+} from "@commonfabric/data-model";
 import { linkRefFrom } from "@commonfabric/data-model/cell-rep";
 import { isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
 import {
@@ -18,12 +24,6 @@ import {
   schemaTypeOfFabricPrimitive,
   schemaWithProperties,
 } from "@commonfabric/data-model-schema";
-import {
-  FabricInstance,
-  FabricPrimitive,
-  FabricSpecialObject,
-  type FabricValue,
-} from "@commonfabric/data-model/fabric-value";
 import { toIndentedDebugString } from "@commonfabric/data-model/value-debug";
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import type { MemorySpace, Result, Unit } from "@commonfabric/memory/interface";

--- a/packages/runner/test/attestation-claim-fabric.test.ts
+++ b/packages/runner/test/attestation-claim-fabric.test.ts
@@ -8,8 +8,8 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
+import type { FabricValue } from "@commonfabric/data-model";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { claim } from "../src/storage/transaction/attestation.ts";
 import type {
   IAttestation,

--- a/packages/runner/test/builder-fabric-classes.test.ts
+++ b/packages/runner/test/builder-fabric-classes.test.ts
@@ -20,7 +20,7 @@ import {
   FabricInstance,
   FabricPrimitive,
   FabricSpecialObject,
-} from "@commonfabric/data-model/fabric-value";
+} from "@commonfabric/data-model";
 import {
   FabricError,
   FabricLink,

--- a/packages/runner/test/cell-arrays.test.ts
+++ b/packages/runner/test/cell-arrays.test.ts
@@ -8,8 +8,8 @@ import { DATA_URI_MEDIA_TYPE } from "@commonfabric/data-model/data-uri-codec";
 import "@commonfabric/utils/equal-ignoring-symbols";
 
 import { Writable } from "@commonfabric/api";
+import type { FabricValue } from "@commonfabric/data-model";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 

--- a/packages/runner/test/cell-meta-sink.test.ts
+++ b/packages/runner/test/cell-meta-sink.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import type { FabricValue } from "@commonfabric/data-model";
 import { Runtime } from "../src/runtime.ts";
 import type { Cell } from "../src/cell.ts";
 import type { Cancel } from "../src/cancel.ts";

--- a/packages/runner/test/cell-static-methods.test.ts
+++ b/packages/runner/test/cell-static-methods.test.ts
@@ -3,12 +3,12 @@ import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 
 import "@commonfabric/utils/equal-ignoring-symbols";
 
+import type { FabricValue } from "@commonfabric/data-model";
 import { FabricError } from "@commonfabric/data-model/fabric-instances";
 import {
   FabricBytes,
   FabricEpochNsec,
 } from "@commonfabric/data-model/fabric-primitives";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 

--- a/packages/runner/test/cfc-array-shrink-slot-labels.test.ts
+++ b/packages/runner/test/cfc-array-shrink-slot-labels.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import type { FabricValue } from "@commonfabric/data-model";
 import { Identity } from "@commonfabric/identity";
 import {
   SEED_ENVELOPE_SCHEMA_HASH,

--- a/packages/runner/test/cfc-computed-cell-derivation.test.ts
+++ b/packages/runner/test/cfc-computed-cell-derivation.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import type { FabricValue } from "@commonfabric/data-model";
 import { Identity } from "@commonfabric/identity";
 import {
   SEED_ENVELOPE_SCHEMA_HASH,

--- a/packages/runner/test/cfc-creation-membership-anchor.test.ts
+++ b/packages/runner/test/cfc-creation-membership-anchor.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import type { FabricValue } from "@commonfabric/data-model";
 import { Identity } from "@commonfabric/identity";
 import {
   SEED_ENVELOPE_SCHEMA_HASH,

--- a/packages/runner/test/cfc-cross-space-integrity.test.ts
+++ b/packages/runner/test/cfc-cross-space-integrity.test.ts
@@ -2,7 +2,7 @@ import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
 
 import { CFC_ATOM_TYPE, cfcAtom } from "@commonfabric/api/cfc";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import type { FabricValue } from "@commonfabric/data-model";
 import { Identity } from "@commonfabric/identity";
 import type { MemorySpace, URI } from "@commonfabric/memory/interface";
 

--- a/packages/runner/test/cfc-existence-channel.test.ts
+++ b/packages/runner/test/cfc-existence-channel.test.ts
@@ -2,7 +2,7 @@ import { expect } from "@std/expect";
 import { afterEach, describe, it } from "@std/testing/bdd";
 
 import type { FabricPlainObject } from "@commonfabric/api";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import type { FabricValue } from "@commonfabric/data-model";
 import { internSchema } from "@commonfabric/data-model-schema";
 import { Identity } from "@commonfabric/identity";
 

--- a/packages/runner/test/cfc-flow-pointwise.test.ts
+++ b/packages/runner/test/cfc-flow-pointwise.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import type { FabricValue } from "@commonfabric/data-model";
 import { Identity } from "@commonfabric/identity";
 import {
   SEED_ENVELOPE_SCHEMA_HASH,

--- a/packages/runner/test/cfc-observation-classes.test.ts
+++ b/packages/runner/test/cfc-observation-classes.test.ts
@@ -2,7 +2,7 @@ import { expect } from "@std/expect";
 import { afterEach, describe, it } from "@std/testing/bdd";
 
 import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import type { FabricValue } from "@commonfabric/data-model";
 import { internSchema } from "@commonfabric/data-model-schema";
 import { Identity } from "@commonfabric/identity";
 

--- a/packages/runner/test/cfc-persist-split.test.ts
+++ b/packages/runner/test/cfc-persist-split.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import type { FabricValue } from "@commonfabric/data-model";
 import { Identity } from "@commonfabric/identity";
 import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
 import {

--- a/packages/runner/test/cfc-prefix-provenance-stats.test.ts
+++ b/packages/runner/test/cfc-prefix-provenance-stats.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
 
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import type { FabricValue } from "@commonfabric/data-model";
 import { Identity } from "@commonfabric/identity";
 import type { URI } from "@commonfabric/memory/interface";
 

--- a/packages/runner/test/cfc-required-integrity-provenance.test.ts
+++ b/packages/runner/test/cfc-required-integrity-provenance.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
 
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import type { FabricValue } from "@commonfabric/data-model";
 import { Identity } from "@commonfabric/identity";
 import type { URI } from "@commonfabric/memory/interface";
 

--- a/packages/runner/test/cfc-resume-membership-taint.test.ts
+++ b/packages/runner/test/cfc-resume-membership-taint.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import type { FabricValue } from "@commonfabric/data-model";
 import { Identity } from "@commonfabric/identity";
 import {
   SEED_ENVELOPE_SCHEMA_HASH,

--- a/packages/runner/test/cfc-template-metadata-population.test.ts
+++ b/packages/runner/test/cfc-template-metadata-population.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, it } from "@std/testing/bdd";
 
 import type { CfcAtom } from "@commonfabric/api/cfc";
 import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import type { FabricValue } from "@commonfabric/data-model";
 import { internSchema } from "@commonfabric/data-model-schema";
 import { Identity } from "@commonfabric/identity";
 

--- a/packages/runner/test/cfc-template-population.test.ts
+++ b/packages/runner/test/cfc-template-population.test.ts
@@ -2,7 +2,7 @@ import { expect } from "@std/expect";
 import { afterEach, describe, it } from "@std/testing/bdd";
 
 import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import type { FabricValue } from "@commonfabric/data-model";
 import { internSchema } from "@commonfabric/data-model-schema";
 import { Identity } from "@commonfabric/identity";
 

--- a/packages/runner/test/cfc-write-floor.test.ts
+++ b/packages/runner/test/cfc-write-floor.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
 
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import type { FabricValue } from "@commonfabric/data-model";
 import { Identity } from "@commonfabric/identity";
 import type { URI } from "@commonfabric/memory/interface";
 

--- a/packages/runner/test/cfc-write-prefix-provenance.test.ts
+++ b/packages/runner/test/cfc-write-prefix-provenance.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
 
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import type { FabricValue } from "@commonfabric/data-model";
 import { Identity } from "@commonfabric/identity";
 import type { URI } from "@commonfabric/memory/interface";
 

--- a/packages/runner/test/compact-real.bench.ts
+++ b/packages/runner/test/compact-real.bench.ts
@@ -18,7 +18,7 @@
  *     --allow-write=/tmp,/var/folders test/compact-real.bench.ts
  */
 
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import type { FabricValue } from "@commonfabric/data-model";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 

--- a/packages/runner/test/convert-cells-to-links-frozenness.test.ts
+++ b/packages/runner/test/convert-cells-to-links-frozenness.test.ts
@@ -11,9 +11,9 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
+import type { FabricConvertibleValue } from "@commonfabric/data-model";
 import { isLinkRef, linkRefPayload } from "@commonfabric/data-model/cell-rep";
 import { deepFreeze } from "@commonfabric/data-model/deep-freeze";
-import type { FabricConvertibleValue } from "@commonfabric/data-model/fabric-value";
 import {
   FabricBytes,
   FabricEpochNsec,

--- a/packages/runner/test/convert-cells-to-links-sharing.test.ts
+++ b/packages/runner/test/convert-cells-to-links-sharing.test.ts
@@ -8,8 +8,8 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
+import { type FabricConvertibleValue } from "@commonfabric/data-model";
 import { FabricEpochNsec } from "@commonfabric/data-model/fabric-primitives";
-import { type FabricConvertibleValue } from "@commonfabric/data-model/fabric-value";
 
 import { convertCellsToLinks } from "../src/cell.ts";
 

--- a/packages/runner/test/convert-cells-to-links.bench.ts
+++ b/packages/runner/test/convert-cells-to-links.bench.ts
@@ -19,8 +19,8 @@
  *     deno task bench
  */
 
+import type { FabricValue } from "@commonfabric/data-model";
 import { deepFreeze } from "@commonfabric/data-model/deep-freeze";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 
 import { linkRefFrom } from "@commonfabric/data-model/cell-rep";
 

--- a/packages/runner/test/data-uri-inlining.test.ts
+++ b/packages/runner/test/data-uri-inlining.test.ts
@@ -5,10 +5,10 @@ import {
 import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 
+import type { FabricValue } from "@commonfabric/data-model";
 import { entityRefToString } from "@commonfabric/data-model/cell-rep";
 import { FabricError } from "@commonfabric/data-model/fabric-instances";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 

--- a/packages/runner/test/encodable-form.test.ts
+++ b/packages/runner/test/encodable-form.test.ts
@@ -17,7 +17,7 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
-import { fabricFromNativeValue } from "@commonfabric/data-model/fabric-value";
+import { fabricFromNativeValue } from "@commonfabric/data-model";
 import { dataUriFromValue } from "@commonfabric/data-model/data-uri-codec";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";

--- a/packages/runner/test/fabric-special-object.test.ts
+++ b/packages/runner/test/fabric-special-object.test.ts
@@ -9,13 +9,12 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
+import type { FabricInstance } from "@commonfabric/data-model";
 import { UnknownValue } from "@commonfabric/data-model/codec-common";
 import {
   FabricError,
   FabricMap,
 } from "@commonfabric/data-model/fabric-instances";
-
-import type { FabricInstance } from "@commonfabric/data-model/fabric-value";
 
 import { refuseFabricInstance } from "../src/fabric-special-object.ts";
 

--- a/packages/runner/test/frozen-reads-cache.bench.ts
+++ b/packages/runner/test/frozen-reads-cache.bench.ts
@@ -23,7 +23,7 @@
  *     --allow-write=/tmp,/var/folders test/frozen-reads-cache.bench.ts
  */
 
-import type { MutableFabricPlainObjectLayer } from "@commonfabric/data-model/fabric-value";
+import type { MutableFabricPlainObjectLayer } from "@commonfabric/data-model";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 

--- a/packages/runner/test/graph-query.test.ts
+++ b/packages/runner/test/graph-query.test.ts
@@ -2,7 +2,7 @@ import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
 
 import type { SchemaPathSelector } from "@commonfabric/api";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import type { FabricValue } from "@commonfabric/data-model";
 import type { MemorySpace, URI } from "@commonfabric/memory/interface";
 
 import {

--- a/packages/runner/test/llm-dialog-special-objects.test.ts
+++ b/packages/runner/test/llm-dialog-special-objects.test.ts
@@ -10,12 +10,12 @@
 import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 
+import { FabricInstance } from "@commonfabric/data-model";
 import { FabricError } from "@commonfabric/data-model/fabric-instances";
 import {
   FabricBytes,
   FabricEpochNsec,
 } from "@commonfabric/data-model/fabric-primitives";
-import { FabricInstance } from "@commonfabric/data-model/fabric-value";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 

--- a/packages/runner/test/memory-v2-native-commit.test.ts
+++ b/packages/runner/test/memory-v2-native-commit.test.ts
@@ -7,7 +7,7 @@ import {
 } from "@std/assert";
 import { fromFileUrl } from "@std/path/from-file-url";
 
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import type { FabricValue } from "@commonfabric/data-model";
 import { Identity } from "@commonfabric/identity";
 import { resolveLocalProgram } from "@commonfabric/runner/local-program.deno";
 import type { PatchOp } from "@commonfabric/memory/v2";

--- a/packages/runner/test/memory-v2-test-utils.ts
+++ b/packages/runner/test/memory-v2-test-utils.ts
@@ -1,5 +1,5 @@
 import { assertEquals } from "@std/assert";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import type { FabricValue } from "@commonfabric/data-model";
 import type { MemorySpace, Signer } from "@commonfabric/memory/interface";
 import {
   decodeMemoryBoundary,

--- a/packages/runner/test/node-utils.test.ts
+++ b/packages/runner/test/node-utils.test.ts
@@ -11,9 +11,9 @@ import { expect } from "@std/expect";
 
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import type { FabricValue } from "@commonfabric/data-model";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import { FabricError } from "@commonfabric/data-model/fabric-instances";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 
 import { Runtime } from "../src/runtime.ts";
 import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";

--- a/packages/runner/test/query-result-proxy-fabric-primitive.test.ts
+++ b/packages/runner/test/query-result-proxy-fabric-primitive.test.ts
@@ -10,7 +10,7 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
-import { FabricPrimitive } from "@commonfabric/data-model/fabric-value";
+import { FabricPrimitive } from "@commonfabric/data-model";
 import { Runtime } from "../src/runtime.ts";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import { internCellLinkSchema } from "../src/cell.ts";

--- a/packages/runner/test/query.test.ts
+++ b/packages/runner/test/query.test.ts
@@ -2,8 +2,8 @@ import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 
 import type { SchemaPathSelector } from "@commonfabric/api";
+import type { FabricValue } from "@commonfabric/data-model";
 import { entityRefToString } from "@commonfabric/data-model/cell-rep";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { Identity } from "@commonfabric/identity";
 import type {
   MIME,

--- a/packages/runner/test/reactive-dependencies.test.ts
+++ b/packages/runner/test/reactive-dependencies.test.ts
@@ -1,8 +1,8 @@
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
 
+import type { FabricValue } from "@commonfabric/data-model";
 import { FabricMap } from "@commonfabric/data-model/fabric-instances";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import type { MemorySpace } from "@commonfabric/memory/interface";
 
 import {

--- a/packages/runner/test/runner-argument-walks.test.ts
+++ b/packages/runner/test/runner-argument-walks.test.ts
@@ -20,9 +20,9 @@ import { expect } from "@std/expect";
 
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import type { FabricValue } from "@commonfabric/data-model";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import { FabricError } from "@commonfabric/data-model/fabric-instances";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 
 import { Runtime } from "../src/runtime.ts";
 import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";

--- a/packages/runner/test/scheduler-diagnosis.test.ts
+++ b/packages/runner/test/scheduler-diagnosis.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import type { FabricValue } from "@commonfabric/data-model";
 import {
   captureCommittedReads,
   captureTransactionWrites,

--- a/packages/runner/test/scheduler-pull-idempotency.test.ts
+++ b/packages/runner/test/scheduler-pull-idempotency.test.ts
@@ -1,6 +1,6 @@
 // Inline scheduler idempotency check tests.
 
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import type { FabricValue } from "@commonfabric/data-model";
 
 import {
   captureTransactionWrites,

--- a/packages/runner/test/schema-dispatch-fabric-instance.test.ts
+++ b/packages/runner/test/schema-dispatch-fabric-instance.test.ts
@@ -12,6 +12,7 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
 import { internSchema } from "@commonfabric/data-model-schema";
+import type { FabricValue } from "@commonfabric/data-model";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import {
   FabricError,
@@ -21,7 +22,6 @@ import {
   resetModernCellRepConfig,
   setModernCellRepConfig,
 } from "@commonfabric/data-model/cell-rep";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import type {
   Entity,
   Revision,

--- a/packages/runner/test/storage-synced-authorization.test.ts
+++ b/packages/runner/test/storage-synced-authorization.test.ts
@@ -1,6 +1,6 @@
 import { assert, assertEquals } from "@std/assert";
 
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import type { FabricValue } from "@commonfabric/data-model";
 import { Identity } from "@commonfabric/identity";
 import type { MemorySpace, Signer, URI } from "@commonfabric/memory/interface";
 import {

--- a/packages/runner/test/topology-maps-equal.test.ts
+++ b/packages/runner/test/topology-maps-equal.test.ts
@@ -8,8 +8,8 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
+import type { FabricValue } from "@commonfabric/data-model";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { mapsEqual } from "../src/scheduler/topology.ts";
 
 describe("mapsEqual", () => {

--- a/packages/runner/test/transaction-inspection.test.ts
+++ b/packages/runner/test/transaction-inspection.test.ts
@@ -1,7 +1,7 @@
 import { assertEquals, assertExists, assertThrows } from "@std/assert";
 import { describe, it } from "@std/testing/bdd";
 
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import type { FabricValue } from "@commonfabric/data-model";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 

--- a/packages/runner/test/traverse-anyof.bench.ts
+++ b/packages/runner/test/traverse-anyof.bench.ts
@@ -1,5 +1,5 @@
 import type { SchemaPathSelector } from "@commonfabric/api";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import type { FabricValue } from "@commonfabric/data-model";
 import type {
   Entity,
   Revision,

--- a/packages/runner/test/traverse-cycle.test.ts
+++ b/packages/runner/test/traverse-cycle.test.ts
@@ -2,7 +2,7 @@ import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
 
 import type { SchemaPathSelector } from "@commonfabric/api";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import type { FabricValue } from "@commonfabric/data-model";
 import type {
   Entity,
   Revision,

--- a/packages/runner/test/traverse-replay.test.ts
+++ b/packages/runner/test/traverse-replay.test.ts
@@ -10,9 +10,9 @@
  */
 
 import { assert } from "@std/assert";
+import type { FabricValue } from "@commonfabric/data-model";
 import { DATA_URI_MEDIA_TYPE } from "@commonfabric/data-model/data-uri-codec";
 import { linkRefFrom } from "@commonfabric/data-model/cell-rep";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import {
   diffOracles,
   listFixturePaths,

--- a/packages/runner/test/traverse-replay/replay.ts
+++ b/packages/runner/test/traverse-replay/replay.ts
@@ -14,9 +14,9 @@
  */
 
 import type { SchemaPathSelector } from "@commonfabric/api";
+import type { FabricValue } from "@commonfabric/data-model";
 import { hasDataUriScheme } from "@commonfabric/data-model/data-uri-codec";
 import { deepFreeze } from "@commonfabric/data-model/deep-freeze";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
 
 import { ExtendedStorageTransaction } from "../../src/storage/extended-storage-transaction.ts";

--- a/packages/runner/test/traverse-required-links.test.ts
+++ b/packages/runner/test/traverse-required-links.test.ts
@@ -11,7 +11,7 @@ import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
 
 import type { SchemaPathSelector } from "@commonfabric/api";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import type { FabricValue } from "@commonfabric/data-model";
 import type {
   Entity,
   Revision,

--- a/packages/runner/test/traverse-schema-doc-availability.test.ts
+++ b/packages/runner/test/traverse-schema-doc-availability.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import type { FabricValue } from "@commonfabric/data-model";
 import { internSchema } from "@commonfabric/data-model-schema";
 import type {
   Entity,

--- a/packages/runner/test/traverse-schema-docs.test.ts
+++ b/packages/runner/test/traverse-schema-docs.test.ts
@@ -8,7 +8,7 @@ import type {
   State,
   URI,
 } from "@commonfabric/memory/interface";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import type { FabricValue } from "@commonfabric/data-model";
 import {
   createDefaultTraversalContext,
   ManagedStorageTransaction,

--- a/packages/runner/test/traverse-schema-memo.test.ts
+++ b/packages/runner/test/traverse-schema-memo.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import type { SchemaPathSelector } from "@commonfabric/api";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import type { FabricValue } from "@commonfabric/data-model";
 import type {
   MemorySpace,
   Revision,

--- a/packages/runner/test/traverse.test.ts
+++ b/packages/runner/test/traverse.test.ts
@@ -3,9 +3,9 @@ import { type CellScope, resolveScopeKey } from "@commonfabric/memory/v2";
 import { describe, it } from "@std/testing/bdd";
 
 import type { SchemaPathSelector } from "@commonfabric/api";
+import type { FabricValue } from "@commonfabric/data-model";
 import { dataUriFromValue } from "@commonfabric/data-model/data-uri-codec";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import {
   internPathSelector,
   isInternedSchema,

--- a/packages/runtime-client/bench/ipc-crossing-steps.bench.ts
+++ b/packages/runtime-client/bench/ipc-crossing-steps.bench.ts
@@ -54,12 +54,12 @@
  */
 
 import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
+import type { FabricValue } from "@commonfabric/data-model";
 import {
   fabricFromRealmValue,
   realmFromFabricValue,
 } from "@commonfabric/data-model/codecs";
 import { linkRefFrom } from "@commonfabric/data-model/cell-rep";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { convertCellsToLinks, KeepAsCell } from "@commonfabric/runner";
 import {
   type CfcLabelView,

--- a/packages/runtime-client/bench/ipc-crossing.bench.ts
+++ b/packages/runtime-client/bench/ipc-crossing.bench.ts
@@ -40,9 +40,9 @@
 
 import { BenchWorker } from "@commonfabric/test-support/bench-worker";
 
+import type { FabricValue } from "@commonfabric/data-model";
 import { realmFromFabricValue } from "@commonfabric/data-model/codecs";
 import { linkRefFrom } from "@commonfabric/data-model/cell-rep";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { convertCellsToLinks, KeepAsCell } from "@commonfabric/runner";
 import { redactSigilCfcLabelViewsForDisplay } from "@commonfabric/runner/cfc";
 

--- a/packages/runtime-client/src/backends/runtime-processor.ts
+++ b/packages/runtime-client/src/backends/runtime-processor.ts
@@ -1,10 +1,10 @@
-import { newDefaultJsonCodecEngine } from "@commonfabric/data-model/codecs";
-import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import {
   cloneIfNecessary,
   fabricFromNativeValue,
   type FabricValue,
-} from "@commonfabric/data-model/fabric-value";
+} from "@commonfabric/data-model";
+import { newDefaultJsonCodecEngine } from "@commonfabric/data-model/codecs";
+import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import {
   toCompactDebugString,
   toStructuredDebugValue,

--- a/packages/runtime-client/src/backends/utils.ts
+++ b/packages/runtime-client/src/backends/utils.ts
@@ -3,7 +3,7 @@ import {
   FabricPrimitive,
   type FabricValue,
   isValidFabricValue,
-} from "@commonfabric/data-model/fabric-value";
+} from "@commonfabric/data-model";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import {
   Cell,

--- a/packages/runtime-client/src/cell-handle.ts
+++ b/packages/runtime-client/src/cell-handle.ts
@@ -8,7 +8,7 @@ import {
   FabricSpecialObject,
   type FabricValue,
   valueEqual,
-} from "@commonfabric/data-model/fabric-value";
+} from "@commonfabric/data-model";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import { DID } from "@commonfabric/identity";
 import { type CfcCellLinkRefPayload } from "@commonfabric/runner/cfc";

--- a/packages/runtime-client/src/protocol/types.ts
+++ b/packages/runtime-client/src/protocol/types.ts
@@ -1,13 +1,13 @@
 import type { MetaField } from "@commonfabric/runner";
 import type {
-  FabricBytes,
-  FabricKeyPair,
-} from "@commonfabric/data-model/fabric-primitives";
-import type {
   FabricArray,
   FabricPlainObject,
   FabricValue,
-} from "@commonfabric/data-model/fabric-value";
+} from "@commonfabric/data-model";
+import type {
+  FabricBytes,
+  FabricKeyPair,
+} from "@commonfabric/data-model/fabric-primitives";
 import type { DID } from "@commonfabric/identity";
 import { type Program } from "@commonfabric/js-compiler/interface";
 import type {

--- a/packages/runtime-client/src/runtime-client.ts
+++ b/packages/runtime-client/src/runtime-client.ts
@@ -5,11 +5,8 @@
  * for interacting with cells across the worker boundary.
  */
 
+import type { FabricPlainObject, FabricValue } from "@commonfabric/data-model";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
-import type {
-  FabricPlainObject,
-  FabricValue,
-} from "@commonfabric/data-model/fabric-value";
 import type { DID, Identity } from "@commonfabric/identity";
 import { Program } from "@commonfabric/js-compiler/interface";
 import type {

--- a/packages/runtime-client/test/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/test/backends/runtime-processor.test.ts
@@ -2,6 +2,7 @@ import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
 
 import { CFC_ATOM_TYPE, cfcAtom } from "@commonfabric/api/cfc";
+import { isValidFabricValue } from "@commonfabric/data-model";
 import { entityRefFrom } from "@commonfabric/data-model/cell-rep";
 import {
   fabricFromRealmValue,
@@ -12,7 +13,6 @@ import {
   FabricBytes,
   FabricEpochNsec,
 } from "@commonfabric/data-model/fabric-primitives";
-import { isValidFabricValue } from "@commonfabric/data-model/fabric-value";
 import { taggedHashStringOf } from "@commonfabric/data-model/value-hash";
 import { getLogger } from "@commonfabric/utils/logger";
 import { Identity } from "@commonfabric/identity";

--- a/packages/runtime-client/test/operation-collaboration.test.ts
+++ b/packages/runtime-client/test/operation-collaboration.test.ts
@@ -1,8 +1,8 @@
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
+import type { FabricValue } from "@commonfabric/data-model";
 import { fabricFromRealmValue } from "@commonfabric/data-model/codecs";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { Identity } from "@commonfabric/identity";
 import type { OperationFieldSnapshot } from "@commonfabric/memory/v2";
 import { Runtime } from "@commonfabric/runner";

--- a/packages/schema-generator/src/value-equality.ts
+++ b/packages/schema-generator/src/value-equality.ts
@@ -1,4 +1,4 @@
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import type { FabricValue } from "@commonfabric/data-model";
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
 
 /**

--- a/packages/schema-generator/test/fixtures-runner.test.ts
+++ b/packages/schema-generator/test/fixtures-runner.test.ts
@@ -8,16 +8,16 @@ import {
   createUnifiedDiff,
   defineFixtureSuite,
 } from "@commonfabric/test-support/fixture-runner";
+import {
+  FabricPrimitive,
+  type FabricValue,
+  valueEqual,
+} from "@commonfabric/data-model";
 import { JsonCodecEngine } from "@commonfabric/data-model/codec-json";
 import {
   fabricFromJsonValue,
   jsonFromFabricValue,
 } from "@commonfabric/data-model/codecs";
-import {
-  FabricPrimitive,
-  type FabricValue,
-  valueEqual,
-} from "@commonfabric/data-model/fabric-value";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import { SchemaGenerator } from "../src/schema-generator.ts";
 import {

--- a/packages/schema-generator/test/utils.ts
+++ b/packages/schema-generator/test/utils.ts
@@ -1,7 +1,7 @@
 import ts from "typescript";
 import { StaticCache } from "@commonfabric/static";
 import { isObjectOrArray } from "@commonfabric/utils/types";
-import { FabricPrimitive } from "@commonfabric/data-model/fabric-value";
+import { FabricPrimitive } from "@commonfabric/data-model";
 import type { JSONSchemaObj } from "@commonfabric/api";
 
 // Cache for TypeScript library definitions

--- a/packages/state-inspector/test/cli.test.ts
+++ b/packages/state-inspector/test/cli.test.ts
@@ -6,8 +6,8 @@
 import { assert, assertEquals, assertStringIncludes } from "@std/assert";
 import { expect } from "@std/expect";
 import { Database } from "@db/sqlite";
+import type { FabricValue } from "@commonfabric/data-model";
 import { jsonFromFabricValue } from "@commonfabric/data-model/codecs";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { applyCommit, close, open } from "@commonfabric/memory/v2/engine";
 import {
   CODEMIRROR_CHANGESET_CODEC,

--- a/packages/toolshed/routes/storage/memory/memory.test.ts
+++ b/packages/toolshed/routes/storage/memory/memory.test.ts
@@ -1,7 +1,7 @@
 import { assert, assertEquals } from "@std/assert";
 
+import type { FabricValue } from "@commonfabric/data-model";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { hashOf } from "@commonfabric/data-model/value-hash";
 import { createSession, Identity } from "@commonfabric/identity";
 import {

--- a/packages/ui/src/v2/components/cf-iframe/cell-bridge.ts
+++ b/packages/ui/src/v2/components/cf-iframe/cell-bridge.ts
@@ -9,7 +9,7 @@ import {
   createFabricBridge,
   type FabricBridge,
 } from "@commonfabric/iframe-sandbox";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import type { FabricValue } from "@commonfabric/data-model";
 import {
   CellHandle,
   type ClientCellValue,

--- a/scripts/ab-harness.ts
+++ b/scripts/ab-harness.ts
@@ -66,7 +66,7 @@ const ju: any = await (async () => {
 })();
 const md: any = await import(`${R}/builder/pattern-metadata.ts`);
 const { fabricFromNativeValue } = await import(
-  "@commonfabric/data-model/fabric-value"
+  "@commonfabric/data-model"
 );
 const { dataUriFromValue } = await import(
   "@commonfabric/data-model/data-uri-codec"

--- a/tasks/pattern-compat-lib.ts
+++ b/tasks/pattern-compat-lib.ts
@@ -21,13 +21,13 @@
 
 import { type JSONSchema, type Pattern } from "@commonfabric/runner";
 import { validateSchemaDefinition } from "@commonfabric/runner/cfc";
+import type { FabricValue } from "@commonfabric/data-model";
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import { JsonCodecEngine } from "@commonfabric/data-model/codec-json";
 import {
   fabricFromJsonValue,
   jsonFromFabricValue,
 } from "@commonfabric/data-model/codecs";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { assertPatternSchemasBackwardCompatible } from "../packages/piece/src/schema-compatibility.ts";
 
 /**


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

`@commonfabric/data-model/fabric-value` becomes `@commonfabric/data-model`, and
`packages/data-model/src/fabric-value.ts` becomes `src/index.ts`. The module was
already the canonical public surface for the types the package is named after;
naming it as a subpath made every caller spell out a choice there was only one
of. The rest of the package -- the codec system, the concrete value classes, the
hash and debug utilities -- keeps its own exported subpaths, and `index.ts` now
says so in its header, since a reader of an `index.ts` may reasonably expect the
whole package's surface.

165 import sites move, across 21 packages.

## The part that is not a `sed`

The bare specifier sorts to the **head** of a package's import run, where
`data-model/fabric-value` sat in the middle. A straight rewrite therefore left
76 files with a newly-unsorted run, against the sorting convention in
`docs/development/DEVELOPMENT.md`. Each such statement moves to just before the
first `@commonfabric/data-model/...` in the same blank-line-delimited block,
carrying any attached `//` comment, and never crossing a bare side-effect
import. Two files that constraint refused -- `runner/test/cell-arrays.test.ts`
(a side-effect import in the way) and `runner/test/fabric-special-object.test.ts`
(a blank line) -- were done by hand.

Sixteen runs still read as unsorted afterward. Every one of them was unsorted
before this change: the tree interleaves `@commonfabric/data-model-schema` among
the `data-model/*` subpaths inconsistently, `-` sorting ahead of `/`. Left
alone, as not this change's business.

## Documentation

- `docs/specs/space-model-formal-spec/1-fabric-values.md` -- the module-structure
  table row, the two `// file:` markers, and the "where a thing is declared is
  not where it is imported from" paragraph, which named `fabric-value` twice.
- `docs/plans/first-class-serializable-factories.md` -- a checklist item naming
  the file path.
- `docs/development/unit-test-coding-style.md` -- a code block importing
  `valueEqual()`.

## Gates

`deno fmt --check`, `deno lint`, `deno task check`, and all 15 auxiliary
`check-*` tasks pass. `data-model`: 48 passed. `runner`: 1341 passed.

Two things stated plainly rather than glossed:

- `deno fmt --check` reports `packages/ui/src/v2/components/cf-fab/cf-fab.ts`.
  That file is already unformatted on `main` and is untouched here.
- The local Deno is 2.9.6 against `mise.toml`'s pinned 2.9.4, so
  `deno task check` ran under `DENO_CHECK_VERSION_LENIENT=1`. The type-check
  verdict above is 2.9.6's; CI takes the pinned one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RU31Hr2ArCs8CpapGL8U87


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6724?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

