### PR TITLE
perf(runner): the conversion copies an annotated container once, not twice

### DIFF
--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -4247,14 +4247,34 @@ function convertOneToLinks(
     // anything else non-index is genuinely unrepresentable and must still be
     // rejected.
     if (isCellResultForDereferencing(value) && isPlainContainer(value)) {
-      // What these produce is a valid `FabricValueLayer` already, so it wants
-      // no further conversion. Objects need this as much as arrays do -- the
-      // annotation goes on either (see `schema.ts`).
-      container = (Array.isArray(value)
-        ? shallowCleanArray(value, false)
-        : shallowCleanPlainObject(value as object, false)) as
-          | unknown[]
-          | Record<string, unknown>;
+      const isArray = Array.isArray(value);
+
+      if (
+        Object.hasOwn(value, toCell) &&
+        Object.getPrototypeOf(value) ===
+          (isArray ? Array.prototype : Object.prototype)
+      ) {
+        // An annotated container: a plain array or object carrying the
+        // symbol as its own property, and content otherwise. The rebuild
+        // below reads only index and enumerable string keys, so the symbol
+        // does not reach the result and a cleaned copy would be a second
+        // copy of the same content. The prototype check is what lets the
+        // rebuild use the container's own `map()`: a subclass would answer
+        // with a subclass instance.
+        container = value as unknown[] | Record<string, unknown>;
+      } else {
+        // A query-result proxy answers the symbol from a trap rather than an
+        // own property, and its `map()` is the proxy's, not `Array`'s, so it
+        // is read out into a plain copy first. What these produce is a valid
+        // `FabricValueLayer` already, so it wants no further conversion.
+        // Objects need this as much as arrays do -- the annotation goes on
+        // either (see `schema.ts`).
+        container = (isArray
+          ? shallowCleanArray(value, false)
+          : shallowCleanPlainObject(value as object, false)) as
+            | unknown[]
+            | Record<string, unknown>;
+      }
     } else {
       // A native object carrying a fabric form is minted into it here: a
       // `Date` or `Uint8Array` becomes a `FabricPrimitive`, an `Error` a

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -4241,11 +4241,11 @@ function convertOneToLinks(
   // the walk, and the next position holding it would be taken for a cycle.
   try {
     // A schema-bearing read hangs a non-enumerable `toCell` symbol on the
-    // arrays it returns. That symbol is machinery, not content, and an array
-    // carrying it is not a `FabricValue`, so drop it before the vetting below
-    // would reject it. Only annotated arrays are cleaned: an array carrying
-    // anything else non-index is genuinely unrepresentable and must still be
-    // rejected.
+    // containers it returns. That symbol is machinery, not content, and a
+    // container carrying it is not a `FabricValue`, so it is kept away from
+    // the vetting below, which would refuse it. Whatever else a container
+    // carries that is neither an index nor an enumerable string key is
+    // dropped along with the symbol.
     if (isCellResultForDereferencing(value) && isPlainContainer(value)) {
       const isArray = Array.isArray(value);
 
@@ -4255,18 +4255,17 @@ function convertOneToLinks(
           (isArray ? Array.prototype : Object.prototype)
       ) {
         // An annotated container: a plain array or object carrying the
-        // symbol as its own property, and content otherwise. The rebuild
-        // below reads only index and enumerable string keys, so the symbol
-        // does not reach the result and a cleaned copy would be a second
-        // copy of the same content. The prototype check is what lets the
-        // rebuild use the container's own `map()`: a subclass would answer
-        // with a subclass instance.
+        // symbol as its own property. The rebuild below reads only index and
+        // enumerable string keys, so it sheds the symbol on its own, and the
+        // container goes to it as it stands. The prototype check is what
+        // lets the rebuild use the container's own `map()`, which on a
+        // subclass would return a subclass instance.
         container = value as unknown[] | Record<string, unknown>;
       } else {
-        // A query-result proxy answers the symbol from a trap rather than an
-        // own property, and its `map()` is the proxy's, not `Array`'s, so it
-        // is read out into a plain copy first. What these produce is a valid
-        // `FabricValueLayer` already, so it wants no further conversion.
+        // A query-result proxy serves the symbol from a trap rather than as
+        // an own property, and a subclass fails the prototype check. Either
+        // is read out into a plain copy first, which is a valid
+        // `FabricValueLayer` already and so wants no further conversion.
         // Objects need this as much as arrays do -- the annotation goes on
         // either (see `schema.ts`).
         container = (isArray

--- a/packages/runner/test/convert-cells-to-links-annotations.test.ts
+++ b/packages/runner/test/convert-cells-to-links-annotations.test.ts
@@ -74,8 +74,8 @@ describe("convertCellsToLinks() with runtime-annotated arrays", () => {
 
   it("returns a plain array from an annotated `Array` subclass", () => {
     // An annotated container is rebuilt through its own `map()`, which on a
-    // subclass would answer with a subclass instance. The prototype guard is
-    // what keeps such a value on the cleaning path instead.
+    // subclass would return a subclass instance. The prototype guard is what
+    // keeps such a value on the cleaning path instead.
     class Tagged extends Array<number> {}
     const tagged = Tagged.from([1, 2]);
     Object.defineProperty(tagged, toCell, {
@@ -93,8 +93,8 @@ describe("convertCellsToLinks() with runtime-annotated arrays", () => {
   });
 
   it("converts a schemaless read, which is a proxy, under `doNotConvertCellResults`", () => {
-    // A schemaless read answers the annotation from a trap rather than an own
-    // property, and its `map()` is the proxy's. Its content still comes
+    // A schemaless read serves the annotation from a trap rather than as an
+    // own property, and its `map()` is the proxy's. Its content still comes
     // through as plain containers.
     const cell = runtime.getCell<unknown>(
       space,

--- a/packages/runner/test/convert-cells-to-links-annotations.test.ts
+++ b/packages/runner/test/convert-cells-to-links-annotations.test.ts
@@ -10,6 +10,7 @@ import { expect } from "@std/expect";
 
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { toCell } from "../src/back-to-cell.ts";
 import { type CellLinkInput, convertCellsToLinks } from "../src/cell.ts";
 import { Runtime } from "../src/runtime.ts";
 import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
@@ -69,6 +70,47 @@ describe("convertCellsToLinks() with runtime-annotated arrays", () => {
         includeSchema: true,
       }),
     ).toEqual([4, 5]);
+  });
+
+  it("returns a plain array from an annotated `Array` subclass", () => {
+    // An annotated container is rebuilt through its own `map()`, which on a
+    // subclass would answer with a subclass instance. The prototype guard is
+    // what keeps such a value on the cleaning path instead.
+    class Tagged extends Array<number> {}
+    const tagged = Tagged.from([1, 2]);
+    Object.defineProperty(tagged, toCell, {
+      value: () => runtime.getCell(space, "annotated-subclass", undefined, tx),
+      enumerable: false,
+    });
+
+    const converted = convertCellsToLinks(tagged as CellLinkInput, {
+      doNotConvertCellResults: true,
+      includeSchema: true,
+    });
+
+    expect(converted).toEqual([1, 2]);
+    expect(Object.getPrototypeOf(converted)).toBe(Array.prototype);
+  });
+
+  it("converts a schemaless read, which is a proxy, under `doNotConvertCellResults`", () => {
+    // A schemaless read answers the annotation from a trap rather than an own
+    // property, and its `map()` is the proxy's. Its content still comes
+    // through as plain containers.
+    const cell = runtime.getCell<unknown>(
+      space,
+      "annotated-proxy",
+      undefined,
+      tx,
+    );
+    cell.set({ list: [1, 2, 3], nested: { a: 1 } });
+
+    const converted = convertCellsToLinks(cell.get() as CellLinkInput, {
+      doNotConvertCellResults: true,
+      includeSchema: true,
+    });
+
+    expect(converted).toEqual({ list: [1, 2, 3], nested: { a: 1 } });
+    expect(Object.getOwnPropertySymbols(converted)).toEqual([]);
   });
 
   it("still rejects an array carrying a genuine named property", () => {

--- a/packages/runtime-client/bench/fixtures/schema-read.ts
+++ b/packages/runtime-client/bench/fixtures/schema-read.ts
@@ -1,0 +1,80 @@
+/**
+ * A list of records as a schema-bearing read hands it back, which is what the
+ * worker converts on its way to the client: every container carries the
+ * back-to-cell annotation and is deeply frozen, and each record's `source` is
+ * a `Cell` where the synthetic lists beside this fixture hold a link already.
+ * The conversion takes a different branch on each, so a benchmark over the
+ * synthetic list alone measures the branch a real message never takes.
+ */
+
+import { Identity } from "@commonfabric/identity";
+import { type JSONSchema, Runtime } from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+/** The list's schema, whose `source` reads back as a `Cell`. */
+const LIST_SCHEMA = {
+  type: "array",
+  items: {
+    type: "object",
+    properties: {
+      title: { type: "string" },
+      count: { type: "number" },
+      done: { type: "boolean" },
+      tags: { type: "array", items: { type: "string" } },
+      source: { asCell: ["cell"] },
+    },
+  },
+} as const satisfies JSONSchema;
+
+const signer = await Identity.fromPassphrase("bench schema read");
+const space = signer.did();
+
+/**
+ * The runtime the reads come from. It lives as long as the benchmarks do: a
+ * value it hands back reaches into it through the annotation, and a `Cell`
+ * in that value is one of its cells.
+ */
+const runtime = new Runtime({
+  apiUrl: new URL(import.meta.url),
+  storageManager: StorageManager.emulate({ as: signer }),
+});
+
+/**
+ * Reads a list of `items` records through the schema above, each record
+ * holding a few scalars, a nested array, and a `source` referring to a
+ * document of its own. What comes back is the read's own result, annotated
+ * and frozen as a read leaves it.
+ */
+export async function readRecordList(items: number): Promise<unknown> {
+  const cause = `schema-read-${items}`;
+
+  {
+    const tx = runtime.edit();
+    const subjects = Array.from({ length: items }, (_, index) => {
+      const subject = runtime.getCell<{ name: string }>(
+        space,
+        `${cause}-subject-${index}`,
+        undefined,
+        tx,
+      );
+
+      subject.set({ name: `Subject ${index}` });
+
+      return subject;
+    });
+
+    runtime.getCell<unknown>(space, cause, undefined, tx).setRaw(
+      subjects.map((subject, index) => ({
+        title: `item number ${index}`,
+        count: index,
+        done: (index % 3) === 0,
+        tags: [`tag-${index % 7}`, `tag-${index % 11}`],
+        source: subject.getAsLink(),
+      })),
+    );
+
+    await tx.commit();
+  }
+
+  return runtime.getCell(space, cause, LIST_SCHEMA, runtime.edit()).get();
+}

--- a/packages/runtime-client/bench/fixtures/schema-read.ts
+++ b/packages/runtime-client/bench/fixtures/schema-read.ts
@@ -4,7 +4,7 @@
  * back-to-cell annotation and is deeply frozen, and each record's `source` is
  * a `Cell` where the synthetic lists beside this fixture hold a link already.
  * The conversion takes a different branch on each, so a benchmark over the
- * synthetic list alone measures the branch a real message never takes.
+ * synthetic list alone measures the branch no read result takes.
  */
 
 import { Identity } from "@commonfabric/identity";
@@ -76,5 +76,12 @@ export async function readRecordList(items: number): Promise<unknown> {
     await tx.commit();
   }
 
-  return runtime.getCell(space, cause, LIST_SCHEMA, runtime.edit()).get();
+  const tx = runtime.edit();
+  const value = runtime.getCell(space, cause, LIST_SCHEMA, tx).get();
+
+  // The read is what the transaction was for, so it is settled here rather
+  // than left open behind the value, which converts the same either way.
+  await tx.commit();
+
+  return value;
 }

--- a/packages/runtime-client/bench/ipc-crossing-steps.bench.ts
+++ b/packages/runtime-client/bench/ipc-crossing-steps.bench.ts
@@ -70,6 +70,8 @@ import {
 import { CellHandle } from "@/cell-handle.ts";
 import { $conn, type RuntimeClient } from "@/runtime-client.ts";
 
+import { readRecordList } from "./fixtures/schema-read.ts";
+
 /** The options the IPC response and notification paths convert under. */
 const CONVERT_OPTIONS = {
   includeSchema: true,
@@ -171,6 +173,19 @@ const SUBJECTS: readonly Subject[] = [
   { name: "100 records, labeled", value: makeList(100, true), labeled: true },
   { name: "1000 records", value: makeList(1000, false), labeled: false },
   { name: "1000 records, labeled", value: makeList(1000, true), labeled: true },
+  // The read subjects are the same records as a schema-bearing read hands
+  // them back, which is what the worker actually converts: every container
+  // annotated and frozen, and each `source` a `Cell` rather than a link.
+  {
+    name: "100 records, read",
+    value: await readRecordList(100) as FabricValue,
+    labeled: false,
+  },
+  {
+    name: "1000 records, read",
+    value: await readRecordList(1000) as FabricValue,
+    labeled: false,
+  },
 ];
 
 for (const { name, value, labeled } of SUBJECTS) {

--- a/packages/runtime-client/bench/ipc-crossing.bench.ts
+++ b/packages/runtime-client/bench/ipc-crossing.bench.ts
@@ -47,6 +47,7 @@ import { convertCellsToLinks, KeepAsCell } from "@commonfabric/runner";
 import { redactSigilCfcLabelViewsForDisplay } from "@commonfabric/runner/cfc";
 
 import type { CrossingRequest } from "./fixtures/ipc-far-side.ts";
+import { readRecordList } from "./fixtures/schema-read.ts";
 
 /** The options the IPC response and notification paths convert under. */
 const CONVERT_OPTIONS = {
@@ -105,6 +106,11 @@ const SUBJECTS: readonly (readonly [string, FabricValue])[] = [
   ["flat 100 members", makeFlat(100)],
   ["100 records with links", makeList(100)],
   ["1000 records with links", makeList(1000)],
+  // The read subjects are the same records as a schema-bearing read hands
+  // them back, which is what the worker actually converts: every container
+  // annotated and frozen, and each `source` a `Cell` rather than a link.
+  ["100 records, read", await readRecordList(100) as FabricValue],
+  ["1000 records, read", await readRecordList(1000) as FabricValue],
 ];
 
 for (const [name, value] of SUBJECTS) {

--- a/packages/runtime-client/deno.jsonc
+++ b/packages/runtime-client/deno.jsonc
@@ -11,8 +11,11 @@
     "integration": "LOG_LEVEL=warn deno test -A $INTEGRATION_TEST_FLAGS \"./integration/*.test.ts\"",
     // --allow-read so that a benchmark may start a `Worker`, which reads the
     // worker's module from disk. The crossing benchmark measures a real
-    // `postMessage()`, that being the boundary the connection is.
-    "bench": "deno bench --allow-read --no-check bench/"
+    // `postMessage()`, that being the boundary the connection is. The rest
+    // are what an emulated runtime needs, whose storage is SQLite reached
+    // over FFI: a benchmark reads its subject through one, so that the value
+    // it times is what a read hands back.
+    "bench": "deno bench --allow-read --allow-write --allow-net --allow-ffi --allow-env --no-check bench/"
   },
   "exports": {
     ".": "./src/mod.ts",

--- a/packages/runtime-client/deno.jsonc
+++ b/packages/runtime-client/deno.jsonc
@@ -11,11 +11,11 @@
     "integration": "LOG_LEVEL=warn deno test -A $INTEGRATION_TEST_FLAGS \"./integration/*.test.ts\"",
     // --allow-read so that a benchmark may start a `Worker`, which reads the
     // worker's module from disk. The crossing benchmark measures a real
-    // `postMessage()`, that being the boundary the connection is. The rest
-    // are what an emulated runtime needs, whose storage is SQLite reached
-    // over FFI: a benchmark reads its subject through one, so that the value
-    // it times is what a read hands back.
-    "bench": "deno bench --allow-read --allow-write --allow-net --allow-ffi --allow-env --no-check bench/"
+    // `postMessage()`, that being the boundary the connection is. --allow-ffi
+    // and --allow-env are what an emulated runtime needs, whose storage is
+    // SQLite reached over FFI: a benchmark reads its subject through one, so
+    // that the value it times is what a read hands back.
+    "bench": "deno bench --allow-read --allow-ffi --allow-env --no-check bench/"
   },
   "exports": {
     ".": "./src/mod.ts",


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Fable 5.1)

`convertOneToLinks()` takes its cell-result branch for every container of a
schema-bearing read, and that branch copied each one twice: `shallowCleanArray()`
or `shallowCleanPlainObject()` built a plain copy to shed the non-enumerable
back-to-cell symbol, and then the rebuild below, `map()` on an array and
`Object.entries()` into `fromEntries()` on an object, built a second copy and
discarded the first. The rebuild reads only index and enumerable string keys, so
it sheds the symbol on its own. An annotated plain container now goes to it
directly.

Two kinds of value stay on the cleaning path, and each has a test:

- **A query-result proxy.** It satisfies `isCellResultForDereferencing()` too,
  but answers the symbol from a trap rather than an own property, and its
  `map()` is the proxy's: it pins the instant, reads the whole array through
  the transaction, wraps each element in a view proxy, and only then applies
  `Array.prototype.map`. Cleaning it first is the path a proxy takes today, and
  this change leaves that path exactly as it was. The discriminator is the
  symbol as an **own** property, which a proxy reports `false` for and an
  annotated container `true`.
- **A container whose prototype is not `Array.prototype` or
  `Object.prototype`.** Its `map()` would answer with a subclass instance.

The tests are behavior tests, not change tests: both pass on `main` as well,
and the change preserves what they pin. Ablation shows what each guard is for.
Removing the prototype guard fails the subclass test. Removing the own-symbol
guard fails nothing, because a proxy sent down the fast path still converts to
the same value through its own `map()`; that guard preserves the mechanism a
proxy reads by, and how its reads reach the transaction log, rather than the
result.

A differential probe of the two paths over eleven shapes, real reads and
hand-annotated values alike, holes, `undefined`-valued keys, accessor indices,
non-enumerable string keys, a null prototype and a subclass among them, finds
one input on which they differ: a plain array carrying the symbol as an own
property and a non-enumerable data property at an index, which the clean turns
into a hole and the rebuild reads. Storage normalization gives a read
enumerable data indices only, so nothing reaching this branch has one. On
every other shape the results are equal in value, prototype, frozenness, own
symbols and key order.

## What a real read looks like, and why nothing measured it

Every subject the two crossing benchmarks time is a synthetic list: plain
containers holding links, which take the conversion's native branch. What the
worker converts is a schema-bearing read, and a probe through an emulated
runtime says what that is: on a 100-record list, 201 containers, every one
annotated and deep-frozen, none a proxy, and 100 `Cell`s where the synthetic
list holds links. So every benchmark in the tree measured the branch a real
message never takes.

The first commit adds `bench/fixtures/schema-read.ts`, which reads a record
list through an emulated runtime under a schema whose `source` reads back as a
`Cell`, and two subjects built from it, `100 records, read` and `1000 records,
read`, join both crossing benchmarks. The bench task gains `--allow-ffi` and
`--allow-env`, which an emulated runtime needs, its storage being SQLite over
FFI; CI already runs the benches with `-A`.

## What the conversion costs on a read

`bench/ipc-crossing-steps.bench.ts`, p75 per run, median of 8 interleaved runs
a side, base being the benchmark commit and branch the change, measured before
`main` was merged in (the merge remaps `data-model` imports and touches no
code on this path). Microseconds:

| subject | step | main | here | | spread |
| --- | --- | --- | --- | --- | --- |
| 100 records, read | convert | 128.3 | 105.4 | **0.82x** | 3%/5% |
| 1000 records, read | convert | 1379.2 | 1153.8 | **0.84x** | 8%/6% |
| 100 records, read | redact | 15.2 | 15.3 | 1.00x | 2%/2% |
| 100 records, read | encode | 34.2 | 34.0 | 0.99x | 3%/3% |
| 100 records, read | transport, raw | 110.2 | 110.9 | 1.01x | 6%/4% |
| 100 records, read | decode | 26.4 | 26.2 | 0.99x | 17%/2% |
| 100 records, read | hydrate, decoded | 15.6 | 15.5 | 0.99x | 9%/2% |

One step moves on the read subjects and the other seven do not, on both sizes.
A read of 1000 records puts the conversion at 1379 us of a message whose next
largest step is the transport at 1096, so the step this reaches is the largest
one, and a sixth off it is what a real message saves.

On the five synthetic subjects every step sits between 0.98x and 1.02x. The
four `convert` rows there read 1.01x to 1.02x, inside spreads of 2–6% but the
same sign each time; the branch those subjects take is untouched by this
change, so if that is real it is code layout, and it is small against the 0.82x
on the branch a real message takes.

## What it does to a message crossing the IPC boundary

`bench/ipc-crossing.bench.ts`, p75 per run, median of 12 interleaved runs a
side, the same sitting. Both arms:

| subject | arm | main | here | | spread |
| --- | --- | --- | --- | --- | --- |
| 100 records, read | envelope | 372.4 | 348.9 | **0.94x** | 6%/3% |
| 1000 records, read | envelope | 3612.8 | 3362.4 | **0.93x** | 11%/5% |
| 100 records, read | status quo | 302.6 | 278.0 | 0.92x | 5%/3% |
| 1000 records, read | status quo | 2921.1 | 2659.0 | 0.91x | 11%/8% |

Both arms move by about the same amount, which is what says the change landed
where it claims: the conversion runs on every message, and an envelope is
optional. The read subjects and the synthetic `records with links` subjects of
the same size cross at about the same cost on `main`, 372 against 378 and 3613
against 3554, so the synthetic list was a fair stand-in for the whole message
even while it was the wrong stand-in for the conversion step.

### Where that sits in the arc

The same benchmark at four commits, measured in one sitting: the last build
before the IPC envelope, the envelope's own merge, `main` today, and this
branch. The far-side fixture and `BenchWorker` are byte-identical at all four,
verified by hash; the two older trees carry `main`'s copy of the benchmark,
which has the four subjects below and not the read subjects, and differ from
their commits in nothing else. Each point is on the arm that point's code
actually ran. Microseconds:

| subject | before the envelope | the envelope landed | | main today | | here | |
| --- | --- | --- | --- | --- | --- | --- | --- |
| small record | 13.5 | 14.6 | 1.09x | 13.7 | 1.02x | 13.7 | 1.02x |
| flat, 100 members | 45.8 | 49.8 | 1.09x | 41.2 | 0.90x | 41.3 | 0.90x |
| 100 records with links | 363.2 | 455.5 | 1.25x | 378.3 | 1.04x | 379.1 | 1.04x |
| 1000 records with links | 3469.8 | 4376.0 | 1.26x | 3554.1 | 1.02x | 3608.2 | 1.04x |

The synthetic subjects do not move here, and are not expected to: they take
the branch this change leaves alone. The `1000 records with links` row's 1.04x
against 1.02x sits inside spreads of 15% and 8%, and its status-quo arm reads
1.00x. The read subjects are the rows that carry this change, and they are
the ones a real message resembles.

## The controls

The status-quo arm across all four trees is flat between the first two
points on every subject (363.2 against 363.0, 3469.8 against 3480.8), which
is what makes the arc table readable, and flat between `main` and here on
every synthetic subject. The redaction, encode, transport, decode and hydrate
steps sit at 0.98x to 1.01x on every subject, read subjects included: nothing
downstream of the conversion sees a different value, which is what
behavior-preserving has to mean here.

Both packages' suites run green on the branch, `deno task check` with them.
