### PR TITLE
fix(patterns): a lunch-poll read site names its file and line

### DIFF
--- a/packages/patterns/integration/lunch-poll-diagnose.test.ts
+++ b/packages/patterns/integration/lunch-poll-diagnose.test.ts
@@ -16,7 +16,11 @@
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
 import { linkRefFrom } from "@commonfabric/data-model/cell-rep";
-import { runCase, voterIdentity } from "../tools/lunch-poll-diagnose.ts";
+import {
+  compactActionSite,
+  runCase,
+  voterIdentity,
+} from "../tools/lunch-poll-diagnose.ts";
 
 describe("lunch-poll-diagnose", () => {
   it("measures a poll two voters joined, filled, and voted in", async () => {
@@ -102,6 +106,45 @@ describe("lunch-poll-diagnose", () => {
       expect(() => voterIdentity({ profile: "not a link" })).toThrow(
         "cannot identify",
       );
+    });
+  });
+
+  describe("compactActionSite", () => {
+    // Every site the probe prints comes through here, from a handler id,
+    // which ends in its own authored source, or from the `src` the scheduler
+    // graph reports for a computation, whose id names content instead.
+
+    const IDENTITY = "Rn0PTb8geZO-q7Hg1DIBZI5JFBBLkW4oU3co2N9DLVA";
+
+    it("names the file, line and column of an authored site", () => {
+      expect(
+        compactActionSite(
+          `cf:module/${IDENTITY}/lunch-poll/main.tsx:1366:19`,
+        ),
+      ).toBe("lunch-poll/main.tsx:1366:19");
+    });
+
+    it("names the authored site a handler id ends in", () => {
+      expect(
+        compactActionSite(
+          `handler:cf:module/${IDENTITY}/lunch-poll/card.tsx:62:2`,
+        ),
+      ).toBe("lunch-poll/card.tsx:62:2");
+    });
+
+    it("names the symbol of an action with no authored site", () => {
+      expect(compactActionSite(`cf:module/${IDENTITY}:__cfLift_22:vt-pymUsk`))
+        .toBe("__cfLift_22:vt-pymUsk");
+    });
+
+    it("names a builtin by the builtin it is", () => {
+      expect(compactActionSite("raw:ifElse:ofNy8lcRiR_Z"))
+        .toBe("raw:ifElse:ofNy8lcRiR_Z");
+    });
+
+    it("names the result sink for a sink on the result", () => {
+      expect(compactActionSite(`sink:did:key:z6Mk/of:fid1:AAA/value`))
+        .toBe("sink:result");
     });
   });
 });

--- a/packages/patterns/tools/lunch-poll-diagnose.ts
+++ b/packages/patterns/tools/lunch-poll-diagnose.ts
@@ -479,7 +479,11 @@ const AUTHORED_SITE = /cf:module\/[^/]+\/(.+:\d+:\d+)$/;
 /** The same identity with no authored site: `cf:module/<identity>:<symbol>`. */
 const ADDRESSED_MODULE = /^cf:module\/[^:]+:(.+)$/;
 
-function compactActionSite(actionId: string): string {
+/**
+ * The readable site of an action, from its id or from the authored source the
+ * graph reports for it.
+ */
+export function compactActionSite(actionId: string): string {
   const authored = AUTHORED_SITE.exec(actionId);
   if (authored) return authored[1];
   if (actionId.startsWith("raw:")) {

--- a/packages/patterns/tools/lunch-poll-diagnose.ts
+++ b/packages/patterns/tools/lunch-poll-diagnose.ts
@@ -34,6 +34,7 @@ interface TraceAddressSummary {
 
 interface ActionRunTraceSummary {
   actionId: string;
+  site: string;
   actionType: string;
   durationMs: number;
   declaredWrites: readonly TraceAddressSummary[];
@@ -51,7 +52,7 @@ interface DiagnosticsSummary {
     demanded: number;
     liveEffects: number;
     pullDemandRoots: number;
-    topReadNodes: readonly { id: string; type: string; readCount: number }[];
+    topReadNodes: readonly { site: string; type: string; readCount: number }[];
   };
   settle: {
     totalHistoryEntries: number;
@@ -330,18 +331,24 @@ function traceAddressSummary(value: unknown): TraceAddressSummary {
   };
 }
 
-function traceEntrySummary(value: unknown): ActionRunTraceSummary {
+function traceEntrySummary(
+  value: unknown,
+  siteOf: (actionId: string) => string,
+): ActionRunTraceSummary {
   if (!isObjectNotArray(value)) {
     return {
       actionId: "",
+      site: "",
       actionType: "",
       durationMs: 0,
       declaredWrites: [],
       actualWrites: [],
     };
   }
+  const actionId = asString(value.actionId);
   return {
-    actionId: asString(value.actionId),
+    actionId,
+    site: siteOf(actionId),
     actionType: asString(value.actionType),
     durationMs: asNumber(value.durationMs),
     declaredWrites: Array.isArray(value.declaredWrites)
@@ -388,9 +395,20 @@ function diagnosticsSummary(
   let demanded = 0;
   let liveEffects = 0;
   let pullDemandRoots = 0;
+
+  // Where each action was authored, for the ids that carry it. A handler's id
+  // holds its own authored site; a lift's is content-addressed, so its site
+  // reaches this probe only through the graph.
+  const authoredSites = new Map<string, string>();
+  for (const node of diagnostics.graph.nodes) {
+    if (node.src !== undefined) authoredSites.set(node.id, node.src);
+  }
+  const siteOf = (actionId: string): string =>
+    compactActionSite(authoredSites.get(actionId) ?? actionId);
+
   const topReadNodes = diagnostics.graph.nodes
     .map((node) => ({
-      id: node.id,
+      site: siteOf(node.id),
       type: node.type,
       readCount: (node.reads?.length ?? 0) + (node.shallowReads?.length ?? 0),
     }))
@@ -410,7 +428,7 @@ function diagnosticsSummary(
   const previousTraceLength = traceCursors.get(label) ?? 0;
   traceCursors.set(label, diagnostics.actionRunTrace.length);
   const newTrace = diagnostics.actionRunTrace.slice(previousTraceLength)
-    .map(traceEntrySummary);
+    .map((entry) => traceEntrySummary(entry, siteOf));
   const newWritesByPath: Record<string, number> = {};
   for (const entry of newTrace) {
     for (const write of entry.actualWrites) {
@@ -451,19 +469,26 @@ function diagnosticsSummary(
 const maxOf = (values: readonly number[]): number =>
   values.length === 0 ? 0 : Math.max(...values);
 
+/**
+ * An authored source location, as the module identity carries it:
+ * `cf:module/<identity>/<path>:<line>:<col>`. A handler's action id ends in
+ * one; so does the `src` the graph reports for a computation.
+ */
+const AUTHORED_SITE = /cf:module\/[^/]+\/(.+:\d+:\d+)$/;
+
+/** The same identity with no authored site: `cf:module/<identity>:<symbol>`. */
+const ADDRESSED_MODULE = /^cf:module\/[^:]+:(.+)$/;
+
 function compactActionSite(actionId: string): string {
-  const marker = `lunch-poll/${matrixProgram}:`;
-  const markerIndex = actionId.indexOf(marker);
-  if (markerIndex >= 0) {
-    const rest = actionId.slice(markerIndex + marker.length);
-    const [line = "?", column = "?"] = rest.split(":");
-    return `${matrixProgram}:${line}:${column}`;
-  }
+  const authored = AUTHORED_SITE.exec(actionId);
+  if (authored) return authored[1];
   if (actionId.startsWith("raw:")) {
     return actionId.split(":").slice(0, 3).join(":");
   }
   if (actionId.startsWith("pull:")) return "pull:result";
   if (actionId.startsWith("sink:")) return "sink:result";
+  const addressed = ADDRESSED_MODULE.exec(actionId);
+  if (addressed) return addressed[1];
   return actionId.slice(0, 80);
 }
 
@@ -475,10 +500,9 @@ function compactTopReadSites(
     { site: string; readCount: number; type: string }
   >();
   for (const node of diagnostics.graph.topReadNodes) {
-    const site = compactActionSite(node.id);
-    const previous = bySite.get(site);
-    bySite.set(site, {
-      site,
+    const previous = bySite.get(node.site);
+    bySite.set(node.site, {
+      site: node.site,
       readCount: (previous?.readCount ?? 0) + node.readCount,
       type: previous?.type ?? node.type,
     });
@@ -531,7 +555,7 @@ function compactSessionSample(
       newTraceEntries: diagnostics.actions.newTraceEntries,
       slowestNew: slowest
         ? {
-          site: compactActionSite(slowest.actionId),
+          site: slowest.site,
           durationMs: slowest.durationMs,
           actualWrites: slowest.actualWrites.length,
         }

--- a/packages/runner/src/scheduler/graph-snapshot.ts
+++ b/packages/runner/src/scheduler/graph-snapshot.ts
@@ -1,5 +1,6 @@
 import type { ScopeKeyIdentity } from "@commonfabric/memory/v2";
 import { resolveScopeKey } from "@commonfabric/memory/v2";
+import { getAuthoredDebugSource } from "../harness/authored-debug-source.ts";
 import { arraysOverlap } from "../reactive-dependencies.ts";
 import { normalizeCellScope } from "../scope.ts";
 import type { IMemorySpaceAddress } from "../storage/interface.ts";
@@ -72,6 +73,11 @@ export function buildSchedulerGraphSnapshot(
       formatAddress(write, identity)
     );
 
+    // The authored implementation, for the two debug-only labels below.
+    const implementation = (action as Action & {
+      module?: { implementation?: unknown };
+    }).module?.implementation;
+
     // Get timing controls
     const debounceMs = state.getDebounce(action);
     const throttleMs = state.getThrottle(action);
@@ -98,9 +104,8 @@ export function buildSchedulerGraphSnapshot(
         : undefined,
       parentId,
       childCount: childCount && childCount > 0 ? childCount : undefined,
-      preview: (action as Action & {
-        module?: { implementation?: { preview?: string } };
-      }).module?.implementation?.preview,
+      preview: (implementation as { preview?: string } | undefined)?.preview,
+      src: getAuthoredDebugSource(implementation)?.src,
       reads,
       shallowReads,
       writes,

--- a/packages/runner/src/telemetry.ts
+++ b/packages/runner/src/telemetry.ts
@@ -36,6 +36,13 @@ export type SchedulerGraphNode = {
   parentId?: string; // ID of parent action if this was created during parent's execution
   childCount?: number; // Number of child actions created during this action's execution
   preview?: string; // First ~200 chars of function body for hover tooltips
+  // Where the action's implementation was authored, as
+  // `cf:module/<identity>/<path>:<line>:<col>`. The transformer records the
+  // line and column of each hoisted builder call, so this names the `lift`,
+  // `computed` or `handler` site itself rather than the module. Present for an
+  // implementation the engine verified; absent for the builtins and for host
+  // and dynamic builders, which have no authored site.
+  src?: string;
   // Diagnostic info: what cells this action reads and writes
   reads?: string[]; // space/entity paths this action reads
   shallowReads?: string[]; // non-recursive reads used for structural invalidation

--- a/packages/runner/test/scheduler/graph-snapshot.test.ts
+++ b/packages/runner/test/scheduler/graph-snapshot.test.ts
@@ -1,0 +1,90 @@
+import { beforeAll, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+import type { RuntimeProgram } from "../../src/harness/types.ts";
+import { Runtime } from "../../src/runtime.ts";
+import type { SchedulerGraphNode } from "../../src/telemetry.ts";
+
+const signer = await Identity.fromPassphrase("graph snapshot source sites");
+const space = signer.did();
+
+// One lift, declared on line 2 of the module and applied once by the pattern.
+// The transformer records the position of the `lift(...)` call, so the site the
+// snapshot reports is that declaration rather than the application below it.
+const ONE_LIFT_PROGRAM: RuntimeProgram = {
+  main: "/main.tsx",
+  files: [{
+    name: "/main.tsx",
+    contents: [
+      "import { pattern, lift } from 'commonfabric';",
+      "const doubled = lift((n: number) => n * 2);",
+      "export default pattern<{ value: number }>(({ value }) => ({",
+      "  doubled: doubled(value),",
+      "}));",
+    ].join("\n"),
+  }],
+};
+
+/** Runs `program` and answers with the scheduler graph it built. */
+async function runAndSnapshot(
+  program: RuntimeProgram,
+  argument: Record<string, number>,
+): Promise<SchedulerGraphNode[]> {
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+  try {
+    const compiled = await runtime.patternManager.compilePattern(program);
+    const tx = runtime.edit();
+    const resultCell = runtime.getCell<unknown>(
+      space,
+      "snapshot",
+      undefined,
+      tx,
+    );
+    const handle = runtime.run(tx, compiled, argument, resultCell);
+    await tx.commit();
+    await handle.pull();
+    await runtime.idle();
+    return runtime.scheduler.getGraphSnapshot().nodes;
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+}
+
+describe("graph-snapshot", () => {
+  describe("buildSchedulerGraphSnapshot()", () => {
+    let nodes: SchedulerGraphNode[];
+    let lift: SchedulerGraphNode;
+
+    beforeAll(async () => {
+      nodes = await runAndSnapshot(ONE_LIFT_PROGRAM, { value: 5 });
+      const lifts = nodes.filter((node) => node.id.startsWith("cf:module/"));
+      expect(lifts.length).toBe(1);
+      lift = lifts[0];
+    });
+
+    it("reports the authored site of a lift as `src`", () => {
+      expect(lift.src).toMatch(/^cf:module\/[^/]+\/main\.tsx:2:\d+$/);
+    });
+
+    it("reports a `src` under the module identity the action id carries", () => {
+      const identity = lift.id.slice("cf:module/".length).split(":")[0];
+
+      expect(lift.src?.startsWith(`cf:module/${identity}/`)).toBe(true);
+    });
+
+    it("reports no `src` for an input node", () => {
+      const inputs = nodes.filter((node) => node.type === "input");
+
+      expect(inputs.length).toBeGreaterThan(0);
+      for (const input of inputs) expect(input.src).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
The lunch-poll scaling probe's `topReadSites` ranks the graph's heaviest readers, and those are nearly all computations. It labeled each one by looking in the action id for `lunch-poll/<program>:` and reading the line and column after it -- the shape a HANDLER id has, a handler being named after its authored source. A computation id is content-addressed (`cf:module/<identity>:__cfLift_22:<instance>`) and holds no such marker, so every entry fell through to the first eighty characters of the id. The section read as a list of truncated module hashes, in a report whose whole job is to say which code is doing the reading.

Nothing else the graph snapshot carried per node said where a computation came from either: a body preview, a content-addressed pattern identity, a parent id, but no path and no line. The information does exist one hop away. When the engine registers a verified builder artifact it records the authored site for that implementation -- `cf:module/<identity>/<path>:<line>:<col>`, built from the line and column the transformer emitted for the hoisted builder call and the module's own source path. That record is what makes a handler's action id readable. Computations do not take their id from it, theirs being content-addressed, so the site never reached anyone looking at the graph.

So the snapshot forwards it: each node carries `src` beside the `preview` it already had, read from the same implementation through `getAuthoredDebugSource`. A node whose implementation has no authored site -- a builtin such as `ifElse`, a host or dynamic builder -- has no `src`, as do the input nodes, which have no implementation at all. The probe indexes the graph by action id and resolves a site through that index first, falling back to the id itself. `topReadSites` and the slowest-action site both go through it, the second being a trace entry with only an id to go on.

Two narrower gaps close with it. The marker named one file -- the program passed to `--program` -- so a lift or handler in any other file of the same pattern missed it as well;
`lunch-poll/participant-identity-card.tsx:228:29` now labels itself like any other site. And an action with no authored site at all keeps its symbol (`__cfLift_22:<instance>`) instead of the hash in front of it.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6727?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

