### PR TITLE
fix(cli): teach the canonical quick check in the setsrc hint

### DIFF
--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -4706,7 +4706,8 @@ export async function applyPieceSourceCommandAction(
   (deps.hint ?? hint)(cliText(`NEXT STEPS:
   → Test in browser: ${config.apiUrl}/${config.space}/${config.piece}
   → Test a callable: cf call --cell ${config.piece} <callableName> ...
-  → Check state:     cf piece inspect --cell ${config.piece} ...`));
+  → Verify state:    cf get --cell ${config.piece} <path> ...
+  → Full inspect:    cf piece inspect --cell ${config.piece} ...`));
 }
 
 /**


### PR DESCRIPTION
Follow-up to #6234, which merged while this was in flight. Addresses cubic's last finding there (https://github.com/commontoolsinc/labs/pull/6234#discussion_r3908654009) — with its premise corrected.

The `setsrc` NEXT STEPS hint sent an operator straight to the full inspection. The file's own post-action idiom — the `cf call` and handler hints — puts the quick read first: `Verify state` with `cf get --cell`, then `Full inspect` with `cf piece inspect --cell`. After a source update the quick read is the one an operator wants first, so the hint now teaches the pair the way its siblings do.

The finding's stated premise was that `cf piece inspect` is a deprecated spelling gated by `PIECE_DATA_SPELLING_END_DATE`. It is not: the command is live, `docs/tutorial/06-workflow.md` teaches it, five sibling hints in the same file use it, and that constant no longer exists anywhere in the tree. What was real is the verify-then-inspect convention above.

Verified: `deno task check`, repo `fmt`/`lint`, and the full cli suite (210 tests) green on this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6730?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

