### PR TITLE
feat(ts-transformers): content-addressed hoist symbols, with positional aliases

### DIFF
--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -100,24 +100,26 @@ const PATTERN_COVERAGE_CACHE_VARIANT = "pattern-coverage";
 
 /**
  * The compiler's hoist namespace. `builder-call-hoisting` mints
- * `__cfPattern_<n>` (n counting from 1) for the anonymous sub-patterns it
- * derives, and registers them through `__cfReg` — never as exports.
- * Registration refuses an AUTHORED builder-artifact export under these names,
- * which is what lets everything downstream that must tell a derived hoist
- * from an authored artifact — the pattern-update gates among them — read
- * provenance from the spelling alone: a `__cfPattern_<n>` in the artifact
- * index can only be the transformer's.
+ * `__cfPattern_h<digest>` (content-addressed canonical names, optionally
+ * `_k`-ordinal-suffixed for identical twins) for the anonymous sub-patterns
+ * it derives, plus visit-order aliases `__cfPattern_<n>` (n counting from 1)
+ * that keep pointers stored under the historical numbering loadable, and
+ * registers both through `__cfReg` — never as exports. Registration refuses
+ * an AUTHORED builder-artifact export under either spelling, which is what
+ * lets everything downstream that must tell a derived hoist from an authored
+ * artifact — the pattern-update gates among them — read provenance from the
+ * spelling alone: a symbol in this namespace can only be the transformer's.
  *
  * What is PROHIBITED here is deliberately wider than what the compiler
  * MINTS, and wider than what a consumer recognizes as a hoist (the gate's
- * `isDerivedHoistSymbol` matches `_1` upward, since that is what actually
- * gets emitted). `_0` and `_01` are minted by nothing, so reserving them
- * costs authors nothing real — and leaving them authorable would leave the
- * confusable spellings, the ones a reader cannot tell from a hoist at a
- * glance, as the only ones anybody could take. A prohibition may safely
- * exceed the convention it protects; a recognizer may not.
+ * `isDerivedHoistSymbol` matches exactly what gets emitted). `_0` and `_01`
+ * are minted by nothing, and neither is a bare-`h` or malformed-digest name,
+ * so reserving them costs authors nothing real — and leaving them authorable
+ * would leave the confusable spellings, the ones a reader cannot tell from a
+ * hoist at a glance, as the only ones anybody could take. A prohibition may
+ * safely exceed the convention it protects; a recognizer may not.
  */
-const RESERVED_HOIST_EXPORT = /^__cfPattern_\d+$/;
+const RESERVED_HOIST_EXPORT = /^__cfPattern_(?:\d+|h[0-9a-z]+(?:_\d+)?)$/;
 
 /**
  * Throw if any module in an evaluated bundle exports a builder artifact in
@@ -140,7 +142,8 @@ function assertNoReservedHoistExports(
       ) {
         throw new Error(
           `module ${identity} exports the builder artifact ` +
-            `"${exportName}": the __cfPattern_<n> names are the compiler's ` +
+            `"${exportName}": the __cfPattern_<n> / __cfPattern_h<digest> ` +
+            `names are the compiler's ` +
             `own hoist namespace, and an authored artifact under one reads ` +
             `as a derived hoist wherever provenance matters — export it ` +
             `under another name`,

--- a/packages/runner/src/sandbox/compiled-bundle-verifier.ts
+++ b/packages/runner/src/sandbox/compiled-bundle-verifier.ts
@@ -1323,11 +1323,22 @@ function isCompiledExportStarStatementNormalized(normalized: string): boolean {
 
 /**
  * Recognize the transformer's hoist-registration statement:
- * `__cfReg({ __cfPattern_1, __cfLift_1, … })` — a call to `__cfReg` with a single
- * object literal of shorthand properties, each naming a top-level binding. The
- * shorthand form guarantees every registered value IS a module-level binding (no
- * arbitrary expression / closure value). Returns false for anything else, so a
- * non-conforming `__cfReg` use is rejected as unsupported.
+ * `__cfReg({ __cfPattern_h…, …, __cfPattern_1: __cfPattern_h…, … })` — a call
+ * to `__cfReg` with a single object literal whose entries take exactly two
+ * forms:
+ *
+ *   - a shorthand property naming a top-level binding (canonical hoist names
+ *     and authored non-exported builder consts); or
+ *   - a positional-alias property `__cf<Kind>_<n>: __cf<Kind>_h<digest>` whose
+ *     VALUE names a top-level binding — the visit-order alias the transformer
+ *     registers beside each content-addressed hoist so pointers stored under
+ *     the historical numbering stay loadable.
+ *
+ * Both forms guarantee every registered VALUE is a module-level binding (no
+ * arbitrary expression / closure value) — the property the shorthand-only rule
+ * existed for; the alias form adds only an inert key. Anything else — spreads,
+ * computed keys, string keys, non-alias-shaped `key:value` pairs — is rejected
+ * as unsupported.
  */
 function isHoistRegistrationCallNormalized(
   normalized: string,
@@ -1338,12 +1349,21 @@ function isHoistRegistrationCallNormalized(
   const inner = match[1].replace(/,$/, "").trim();
   if (inner.length === 0) return false;
   for (const raw of inner.split(",")) {
-    const name = raw.trim();
-    // Shorthand identifiers only (`{a,b}`); `key:value`, spreads, computed keys,
-    // and string keys all contain a disallowed character and are rejected.
-    if (!/^[A-Za-z_$][\w$]*$/.test(name)) return false;
-    // Each must be a top-level binding the verifier already saw declared.
-    if (!env.has(name)) return false;
+    const entry = raw.trim();
+    // Shorthand identifier (`{a,b}`): must be a declared top-level binding.
+    if (/^[A-Za-z_$][\w$]*$/.test(entry)) {
+      if (!env.has(entry)) return false;
+      continue;
+    }
+    // Positional-alias pair: numeric-alias key, content-addressed value, and
+    // the VALUE must be a declared top-level binding. Nothing else passes, so
+    // spreads / computed keys / string keys / arbitrary `key:value` stay
+    // rejected exactly as before.
+    const alias = entry.match(
+      /^(__cf[A-Za-z]+_\d+):(__cf[A-Za-z]+_h[0-9a-f]+(?:_\d+)?)$/,
+    );
+    if (!alias) return false;
+    if (!env.has(alias[2])) return false;
   }
   return true;
 }

--- a/packages/runner/test/cfreg-builder-identity.test.ts
+++ b/packages/runner/test/cfreg-builder-identity.test.ts
@@ -121,15 +121,29 @@ export default pattern<State>((state) => {
       expect(symbols.some((s) => s.startsWith("__cfPattern_"))).toBe(true);
       expect(symbols.some((s) => s.startsWith("__cfLift_"))).toBe(true);
 
+      const HOIST_ALIAS = /^__cf[A-Za-z]+_\d+$/;
       for (const symbol of symbols) {
-        // Reverse: { identity, symbol } resolves synchronously to a live value.
+        // Reverse: { identity, symbol } resolves synchronously to a live value
+        // under BOTH spellings — canonical content name and positional alias.
         const value = pm.artifactFromIdentitySync(identity, symbol);
         expect(value).toBeDefined();
-        // Forward: that live value reports the same { identity, symbol }.
-        expect(pm.getArtifactEntryRef(value as never)).toEqual({
-          identity,
-          symbol,
-        });
+        const forward = pm.getArtifactEntryRef(value as never);
+        expect(forward?.identity).toBe(identity);
+        if (HOIST_ALIAS.test(symbol)) {
+          // A positional alias resolves to the same live value, but the
+          // value's forward ref is its CANONICAL spelling — canonicals
+          // register first and the forward map is first-write-wins, which is
+          // what makes NEW serializations content-addressed while the numeric
+          // names keep the stored archive loadable.
+          expect(forward!.symbol).toMatch(
+            /^__cf[A-Za-z]+_h[0-9a-f]+(?:_\d+)?$/,
+          );
+          expect(pm.artifactFromIdentitySync(identity, forward!.symbol))
+            .toBe(value);
+        } else {
+          // Forward: a canonical or authored name round-trips identically.
+          expect(forward).toEqual({ identity, symbol });
+        }
       }
     } finally {
       await runtime.dispose();

--- a/packages/runner/test/cfreg-security.test.ts
+++ b/packages/runner/test/cfreg-security.test.ts
@@ -168,11 +168,35 @@ __cfReg({
     expect(() => verifyCompiledModuleBody(body, "/main.tsx")).toThrow();
   });
 
-  it("does NOT approve a key:value (non-shorthand) registration", () => {
-    // Only shorthand identifiers are a valid registration; `key: value` lets the
-    // value be an arbitrary expression, so the call shape is refused.
+  it("does NOT approve a key:value registration outside the alias form", () => {
+    // A `key: value` entry is valid ONLY as a positional alias
+    // (`__cf<Kind>_<n>: __cf<Kind>_h<digest>` over a declared binding); any
+    // other value expression is refused — the value could otherwise be an
+    // arbitrary expression.
     const body =
       `${IMPORT}\nconst __cfLift_1 = (0, cf.lift)((x) => x);\n__cfReg({ __cfLift_1: globalThis });`;
+    expect(() => verifyCompiledModuleBody(body, "/main.tsx")).toThrow();
+  });
+
+  it("approves a positional alias naming a declared canonical hoist", () => {
+    const body = `${IMPORT}
+const __cfLift_h0123456789ab = (0, cf.lift)((x) => x);
+__cfReg({ __cfLift_h0123456789ab, __cfLift_1: __cfLift_h0123456789ab });`;
+    expect(verifyCompiledModuleBody(body, "/main.tsx").hasHoistRegistration)
+      .toBe(true);
+  });
+
+  it("does NOT approve an alias whose canonical was never declared", () => {
+    const body = `${IMPORT}\n__cfReg({ __cfLift_1: __cfLift_h0123456789ab });`;
+    expect(() => verifyCompiledModuleBody(body, "/main.tsx")).toThrow();
+  });
+
+  it("does NOT approve an alias over a non-hoist-shaped value name", () => {
+    // The alias VALUE must be a content-addressed hoist name, so an authored
+    // binding cannot be smuggled behind the compiler's numeric namespace.
+    const body = `${IMPORT}
+const helper = (0, cf.lift)((x) => x);
+__cfReg({ helper, __cfLift_1: helper });`;
     expect(() => verifyCompiledModuleBody(body, "/main.tsx")).toThrow();
   });
 

--- a/packages/ts-transformers/src/ast/call-kind.ts
+++ b/packages/ts-transformers/src/ast/call-kind.ts
@@ -116,8 +116,11 @@ export const SYNTHETIC_HANDLER_HOIST_PREFIX = "__cfHandler";
  * argument of an enclosing `receiver.mapWithPattern(pattern(...), { params })`
  * call (per-instance captures flow through the params object, the second
  * argument). The bare pattern call is hoisted to
- * `const __cfPattern_N = __cfHelpers.pattern(...)` and the `*WithPattern` call's
- * first argument is rewritten to `__cfPattern_N`. The top-level
+ * `const __cfPattern_h<digest> = __cfHelpers.pattern(...)` (content-addressed
+ * canonical name; a visit-order `__cfPattern_N` alias is additionally
+ * registered for pointers stored under the historical numbering — see
+ * `builder-call-hoisting.ts`) and the `*WithPattern` call's first argument is
+ * rewritten to the canonical name. The top-level
  * `export default pattern(...)` is a direct call (not a `*WithPattern`
  * argument) and is NOT hoisted.
  */

--- a/packages/ts-transformers/src/transformers/builder-call-hoisting.ts
+++ b/packages/ts-transformers/src/transformers/builder-call-hoisting.ts
@@ -206,6 +206,49 @@ const HOISTABLE_BUILDERS: readonly HoistableBuilderSpec[] = [
   PATTERN_BUILDER,
 ];
 
+/**
+ * Marker that keeps the content-addressed hoist namespace (`__cfPattern_h…`)
+ * disjoint from the positional alias namespace (`__cfPattern_<n>`): a hash
+ * suffix always starts with this letter, a positional alias never does, so a
+ * recognizer can classify a symbol by shape alone and a hex digest that
+ * happens to be all-numeric can never be mistaken for an alias.
+ */
+const HOIST_HASH_MARKER = "h";
+
+/** Hex digits kept from the 64-bit digest: 48 bits, far past birthday range
+ * for the handful of hoists a single file mints. */
+const HOIST_HASH_LENGTH = 12;
+
+/**
+ * FNV-1a over the canonical print of a hoisted call, 64-bit.
+ *
+ * FROZEN. A hoist's content suffix is the durable half of the
+ * `{ identity, symbol }` reference deployed pieces store for their mapped
+ * sub-patterns (CT-1623), so this function and its input are part of the
+ * stored-data contract: changing either re-keys every hoist in the tree.
+ * The positional aliases keep OLD pointers loadable through such a change
+ * (a frozen source reproduces its visit order under any toolchain), but new
+ * correlation would churn fleet-wide — do not "improve" this hash.
+ */
+function fnv1a64(text: string): bigint {
+  const prime = 0x100000001b3n;
+  let hash = 0xcbf29ce484222325n;
+  for (let i = 0; i < text.length; i++) {
+    hash ^= BigInt(text.charCodeAt(i));
+    hash = (hash * prime) & 0xffffffffffffffffn;
+  }
+  return hash;
+}
+
+/** `h` + the first {@link HOIST_HASH_LENGTH} hex chars of the digest. */
+function hoistContentSuffix(printedInnerCall: string): string {
+  const digest = fnv1a64(printedInnerCall)
+    .toString(16)
+    .padStart(16, "0")
+    .slice(0, HOIST_HASH_LENGTH);
+  return `${HOIST_HASH_MARKER}${digest}`;
+}
+
 function hoistBuilderCalls(
   sourceFile: ts.SourceFile,
   context: TransformationContext,
@@ -250,24 +293,62 @@ function hoistBuilderCalls(
   // safe for lift/handler is NOT safe for pattern.)
   let pendingHoists: ts.Statement[] = [];
 
-  // Per-file counters keyed by builder prefix. Explicit counters + literal
-  // suffixes (NOT `factory.createUniqueName`, whose `.text` carries only the
-  // bare prefix and defers numeric suffixing to emit — so every hoisted
-  // identifier would share the same `.text`, breaking the identity-by-text
-  // lookups later stages rely on to match a `<prefix>_N` call site back to its
-  // hoisted const).
+  // Each hoist gets TWO names, and the split is load-bearing:
+  //
+  //   - a CANONICAL name, `<prefix>_h<digest>` — the digest of the inner
+  //     call's canonical (comment-stripped) print. Content-addressed, so
+  //     inserting, removing, or reordering OTHER hoists cannot re-key an
+  //     existing one; it re-keys only when its own callback or baked schemas
+  //     change, which is when its contract genuinely changed. The hoisted
+  //     const is bound under this name, call sites reference it, and it is
+  //     the symbol NEW `{ identity, symbol }` references serialize under.
+  //   - a POSITIONAL ALIAS, `<prefix>_<n>` in visit order — the historical
+  //     numbering. Registered alongside the canonical name (never bound, never
+  //     referenced by emitted code) so every `{ identity, symbol }` pointer a
+  //     deployed piece stored under the old numeric scheme keeps resolving:
+  //     by-identity cold loads recompile the OLD source with the CURRENT
+  //     toolchain, and a frozen source reproduces its visit order exactly.
+  //     Permanent, not transitional — the aliases are what make the stored
+  //     archive immortal under toolchain change.
+  //
+  // Both are explicit literal names (NOT `factory.createUniqueName`, whose
+  // `.text` carries only the bare prefix and defers numeric suffixing to emit —
+  // so every hoisted identifier would share the same `.text`, breaking the
+  // identity-by-text lookups later stages rely on to match a hoist call site
+  // back to its hoisted const).
   const counters = new Map<string, number>();
+  // Occurrences per canonical base name: identical twins (same builder, same
+  // printed content) share a digest, so the second onward takes an occurrence
+  // ordinal (`…_2`). Twins mint identical graphs, so even a cross-twin
+  // correlation is content-correct; the ordinal only keeps registration keys
+  // unique, deterministically.
+  const hashOccurrences = new Map<string, number>();
+  // Canonical print of a hoisted call for hashing: comments stripped (a
+  // comment edit must not re-key) and line endings pinned (the digest must not
+  // vary by platform). Runs after schema injection, so the print covers the
+  // callback AND its baked schemas — a type-level change re-keys, which is
+  // aligned: the sub-pattern's contract changed.
+  const hoistPrinter = ts.createPrinter({
+    removeComments: true,
+    newLine: ts.NewLineKind.LineFeed,
+  });
 
-  // Every hoisted builder-artifact name (`__cfPattern_N`, `__cfLift_N`,
-  // `__cfHandler_N`), in creation order. After the whole file is visited we emit
-  // a SINGLE trailing `__cfReg({ __cfPattern_1, __cfLift_1, … })` call so the
-  // runtime can assign each a content-addressed `{ identity, symbol }` reference
-  // (the property key is the symbol). A single trailing call — rather than
-  // exporting each hoist or registering it inline — keeps the verifier's job to
-  // "exactly one top-level `__cfReg` call" and lets a run-once trap reject any
-  // injected duplicate. See PatternManager.registerHoistedValues / the
-  // `__cfReg` factory parameter wired up by the module-record compiler.
+  // Every hoisted builder-artifact CANONICAL name plus every authored
+  // non-exported builder const, in creation order. After the whole file is
+  // visited we emit a SINGLE trailing
+  // `__cfReg({ __cfPattern_h…, …, __cfPattern_1: __cfPattern_h…, … })` call so
+  // the runtime can assign each a content-addressed `{ identity, symbol }`
+  // reference (the property key is the symbol). Canonical entries come FIRST:
+  // the runtime's forward value→ref map is first-write-wins, so ordering is
+  // what makes new serializations canonical-hash while the positional aliases
+  // (appended after) quietly serve pointers stored under the old numbering.
+  // A single trailing call — rather than exporting each hoist or registering
+  // it inline — keeps the verifier's job to "exactly one top-level `__cfReg`
+  // call" and lets a run-once trap reject any injected duplicate. See
+  // PatternManager.registerHoistedValues / the `__cfReg` factory parameter
+  // wired up by the module-record compiler.
   const registeredNames: string[] = [];
+  const hoistAliases: { alias: string; canonical: string }[] = [];
   const exportedSymbolsByLocalName = collectExportedLocalSymbols(sourceFile);
 
   const visit: ts.Visitor = (node: ts.Node): ts.Node => {
@@ -282,11 +363,25 @@ function hoistBuilderCalls(
         continue;
       }
 
+      // Positional alias: the historical visit-order numbering (see the
+      // counter block above for why it is registered but never bound).
       const next = (counters.get(builder.prefix) ?? 0) + 1;
       counters.set(builder.prefix, next);
-      const nameText = `${builder.prefix}_${next}`;
+      const aliasText = `${builder.prefix}_${next}`;
+      // Canonical name: content digest of the inner call's canonical print,
+      // plus an occurrence ordinal when an identical twin already minted it.
+      const printed = hoistPrinter
+        .printNode(ts.EmitHint.Expression, innerCall, sourceFile)
+        .replace(/\r\n/g, "\n");
+      const baseName = `${builder.prefix}_${hoistContentSuffix(printed)}`;
+      const occurrence = (hashOccurrences.get(baseName) ?? 0) + 1;
+      hashOccurrences.set(baseName, occurrence);
+      const nameText = occurrence === 1
+        ? baseName
+        : `${baseName}_${occurrence}`;
       const name = factory.createIdentifier(nameText);
       registeredNames.push(nameText);
+      hoistAliases.push({ alias: aliasText, canonical: nameText });
       recordBuilderSourceSite(
         nameText,
         resolveBuilderArtifact(innerCall, context.checker),
@@ -394,11 +489,25 @@ function hoistBuilderCalls(
           undefined,
           [
             factory.createObjectLiteralExpression(
-              registeredNames.map((n) =>
-                factory.createShorthandPropertyAssignment(
-                  factory.createIdentifier(n),
-                )
-              ),
+              [
+                // Canonical entries first — the runtime's forward value→ref
+                // map is first-write-wins, so this ordering is what stamps
+                // NEW serializations with the canonical hash symbol.
+                ...registeredNames.map((n) =>
+                  factory.createShorthandPropertyAssignment(
+                    factory.createIdentifier(n),
+                  )
+                ),
+                // Positional aliases after: same live values under the
+                // visit-order numeric names, serving every `{identity,symbol}`
+                // pointer stored under the historical numbering.
+                ...hoistAliases.map(({ alias, canonical }) =>
+                  factory.createPropertyAssignment(
+                    factory.createIdentifier(alias),
+                    factory.createIdentifier(canonical),
+                  )
+                ),
+              ],
               true,
             ),
           ],

--- a/packages/ts-transformers/test/builder-source-sites.test.ts
+++ b/packages/ts-transformers/test/builder-source-sites.test.ts
@@ -111,7 +111,7 @@ describe("builder-source-sites", () => {
       );
 
       const hoistedLift = Object.entries(sidecar?.sites ?? {}).find(
-        ([symbol]) => /^__cfLift_\d+$/.test(symbol),
+        ([symbol]) => /^__cfLift_h[0-9a-f]+(?:_\d+)?$/.test(symbol),
       );
       expect(hoistedLift?.[1]).toEqual({
         ...locationOf("() => value + 2"),

--- a/packages/ts-transformers/test/call-expression-iife-coverage.test.ts
+++ b/packages/ts-transformers/test/call-expression-iife-coverage.test.ts
@@ -48,7 +48,23 @@ export default pattern<Input, Output>(({ items, base }) => ({
 
 /** The lowered `mapWithPattern` callback body, isolated for assertions. */
 function mapCallbackBody(output: ts.SourceFile): ts.Node {
-  return extractedCallbackBody(output, "__cfPattern_1");
+  // Hoist names are content-addressed (`__cfPattern_h<digest>`), so locate
+  // the single hoisted pattern const by shape rather than by a positional
+  // spelling.
+  let hoisted: string | undefined;
+  for (const statement of output.statements) {
+    if (!ts.isVariableStatement(statement)) continue;
+    for (const decl of statement.declarationList.declarations) {
+      if (
+        ts.isIdentifier(decl.name) &&
+        decl.name.text.startsWith("__cfPattern_")
+      ) {
+        hoisted = decl.name.text;
+      }
+    }
+  }
+  if (!hoisted) throw new Error("no hoisted pattern const found");
+  return extractedCallbackBody(output, hoisted);
 }
 
 Deno.test(

--- a/packages/ts-transformers/test/closures/module-scope-helper-hoisting.test.ts
+++ b/packages/ts-transformers/test/closures/module-scope-helper-hoisting.test.ts
@@ -45,7 +45,7 @@ Deno.test("Closure Transformer hoists nested computed callbacks that close over 
   // lift is function-first: the callback leads, schemas trail. The hoisted call
   // carries explicit `<In, Out>` type args, so match `lift<…>(` then the callback.
   const hoistedMatch = normalized.match(
-    /const (__cfLift_\d+) = __cfHelpers\.lift<[\s\S]*?>\(\(\{ dateStr \}\) => formatDateShort\(dateStr\)/,
+    /const (__cfLift_h[0-9a-f]+(?:_\d+)?) = __cfHelpers\.lift<[\s\S]*?>\(\(\{ dateStr \}\) => formatDateShort\(dateStr\)/,
   );
 
   assert(hoistedMatch, `expected hoisted lift in output:\n${output}`);
@@ -133,7 +133,7 @@ Deno.test("CT-1655: whole synthesized mapWithPattern pattern() call is hoisted t
   // `__cf_pattern_input => { const entry = __cf_pattern_input.key("element"); ... }`.
   // The exact const name is generated; capture it for the call-site assertion.
   const hoistedMatch = normalized.match(
-    /const (__cfPattern_\d+) = __cfHelpers\.pattern\(\s*__cf_pattern_input\b/,
+    /const (__cfPattern_h[0-9a-f]+(?:_\d+)?) = __cfHelpers\.pattern\(\s*__cf_pattern_input\b/,
   );
   assert(
     hoistedMatch,

--- a/packages/ts-transformers/test/fixtures/ast-transform/authored-ifelse-reactive-roots.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/authored-ifelse-reactive-roots.expected.jsx
@@ -12,7 +12,7 @@ const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
 const identity = __cfHardenFn(<T,>(value: T) => value);
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h61cc9e54c9fe = __cfHelpers.lift<{
     name: string;
 }, string>(({ name }) => identity(name.trim()), {
     type: "object",
@@ -25,7 +25,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_hdc78b0cdd4c2 = __cfHelpers.lift<{
     count: number;
 }, number>(({ count }) => count + 1, {
     type: "object",
@@ -38,7 +38,7 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_3 = __cfHelpers.lift<{
+const __cfLift_h7d69e497d98e = __cfHelpers.lift<{
     cell: __cfHelpers.Writable<number>;
 }, number>(({ cell }) => cell.get(), {
     type: "object",
@@ -52,7 +52,7 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_4 = __cfHelpers.lift<{
+const __cfLift_h51c92805ae22 = __cfHelpers.lift<{
     name: string;
 }, string>(({ name }) => name.trim(), {
     type: "object",
@@ -65,7 +65,7 @@ const __cfLift_4 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_5 = __cfHelpers.lift<{
+const __cfLift_h51c92805ae22_2 = __cfHelpers.lift<{
     name: string;
 }, string>(({ name }) => name.trim(), {
     type: "object",
@@ -90,7 +90,7 @@ export default pattern((__cf_pattern_input) => {
     const show = __cf_pattern_input.key("show");
     const name = __cf_pattern_input.key("name");
     const cell = __cf_pattern_input.key("cell");
-    const upper = __cfLift_1({ name: name }).for("upper", true);
+    const upper = __cfLift_h61cc9e54c9fe({ name: name }).for("upper", true);
     return {
         value: ifElse({
             type: "boolean"
@@ -100,7 +100,7 @@ export default pattern((__cf_pattern_input) => {
             type: "number"
         } as const satisfies __cfHelpers.JSONSchema, {
             type: "number"
-        } as const satisfies __cfHelpers.JSONSchema, show, __cfLift_2({ count: count }), 0).for(["__patternResult", "value"], true),
+        } as const satisfies __cfHelpers.JSONSchema, show, __cfLift_hdc78b0cdd4c2({ count: count }), 0).for(["__patternResult", "value"], true),
         cellValue: ifElse({
             type: "boolean"
         } as const satisfies __cfHelpers.JSONSchema, {
@@ -109,7 +109,7 @@ export default pattern((__cf_pattern_input) => {
             type: "number"
         } as const satisfies __cfHelpers.JSONSchema, {
             type: "number"
-        } as const satisfies __cfHelpers.JSONSchema, show, __cfLift_3({ cell: cell }), 0).for(["__patternResult", "cellValue"], true),
+        } as const satisfies __cfHelpers.JSONSchema, show, __cfLift_h7d69e497d98e({ cell: cell }), 0).for(["__patternResult", "cellValue"], true),
         trimmed: ifElse({
             type: "boolean"
         } as const satisfies __cfHelpers.JSONSchema, {
@@ -118,9 +118,9 @@ export default pattern((__cf_pattern_input) => {
             type: "string"
         } as const satisfies __cfHelpers.JSONSchema, {
             type: "string"
-        } as const satisfies __cfHelpers.JSONSchema, show, __cfLift_4({ name: name }), "fallback").for(["__patternResult", "trimmed"], true),
+        } as const satisfies __cfHelpers.JSONSchema, show, __cfLift_h51c92805ae22({ name: name }), "fallback").for(["__patternResult", "trimmed"], true),
         upper,
-        upperDirect: __cfLift_5({ name: name }).for(["__patternResult", "upperDirect"], true)
+        upperDirect: __cfLift_h51c92805ae22_2({ name: name }).for(["__patternResult", "upperDirect"], true)
     };
 }, {
     type: "object",
@@ -165,9 +165,14 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2,
-    __cfLift_3,
-    __cfLift_4,
-    __cfLift_5
+    __cfLift_h61cc9e54c9fe,
+    __cfLift_hdc78b0cdd4c2,
+    __cfLift_h7d69e497d98e,
+    __cfLift_h51c92805ae22,
+    __cfLift_h51c92805ae22_2,
+    __cfLift_1: __cfLift_h61cc9e54c9fe,
+    __cfLift_2: __cfLift_hdc78b0cdd4c2,
+    __cfLift_3: __cfLift_h7d69e497d98e,
+    __cfLift_4: __cfLift_h51c92805ae22,
+    __cfLift_5: __cfLift_h51c92805ae22_2
 });

--- a/packages/ts-transformers/test/fixtures/ast-transform/builder-arg-hoisted-nullish-selection.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/builder-arg-hoisted-nullish-selection.expected.jsx
@@ -58,7 +58,7 @@ interface CardState {
     myName: Default<string, "">;
     profile?: Cell<Profile>;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hc5c32edf01b0 = __cfHelpers.lift<{
     profile?: __cfHelpers.Cell<Profile> | undefined;
     profileWish: {
         result: Profile | undefined;
@@ -116,7 +116,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+const __cfHandler_h98aa865b6fae = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
         boundJoin: {
@@ -158,7 +158,7 @@ export default pattern((__cf_pattern_input) => {
         },
         required: ["name"]
     } as const satisfies __cfHelpers.JSONSchema).for("profileWish", true);
-    const activeProfile = __cfLift_1({
+    const activeProfile = __cfLift_hc5c32edf01b0({
         profile: profile,
         profileWish: {
             result: profileWish.key("result")
@@ -170,7 +170,7 @@ export default pattern((__cf_pattern_input) => {
     }).for({ stream: "boundJoin" }, true);
     return {
         [UI]: (<div>
-        <cf-button onClick={__cfHandler_1({
+        <cf-button onClick={__cfHandler_h98aa865b6fae({
             boundJoin: boundJoin
         })}>
           Join
@@ -236,6 +236,8 @@ function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
     join,
-    __cfLift_1,
-    __cfHandler_1
+    __cfLift_hc5c32edf01b0,
+    __cfHandler_h98aa865b6fae,
+    __cfLift_1: __cfLift_hc5c32edf01b0,
+    __cfHandler_1: __cfHandler_h98aa865b6fae
 });

--- a/packages/ts-transformers/test/fixtures/ast-transform/builder-arg-ternary-label.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/builder-arg-ternary-label.expected.jsx
@@ -36,7 +36,7 @@ interface CardState {
     users: Default<string[], [
     ]>;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h1eef49fc3d16 = __cfHelpers.lift<{
     users: {
         length: number;
     };
@@ -57,7 +57,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+const __cfHandler_h98aa865b6fae = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
         boundJoin: {
@@ -97,13 +97,13 @@ export default pattern((__cf_pattern_input) => {
             type: "string"
         } as const satisfies __cfHelpers.JSONSchema, {
             "enum": ["join the others", "be first"]
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_1({ users: {
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_h1eef49fc3d16({ users: {
                 length: users.key("length")
             } }), "join the others", "be first").for(["boundJoin", "label"], true)
     }).for({ stream: "boundJoin" }, true);
     return {
         [UI]: (<div>
-        <cf-button onClick={__cfHandler_1({
+        <cf-button onClick={__cfHandler_h98aa865b6fae({
             boundJoin: boundJoin
         })}>
           Join
@@ -161,6 +161,8 @@ function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
     join,
-    __cfLift_1,
-    __cfHandler_1
+    __cfLift_h1eef49fc3d16,
+    __cfHandler_h98aa865b6fae,
+    __cfLift_1: __cfLift_h1eef49fc3d16,
+    __cfHandler_1: __cfHandler_h98aa865b6fae
 });

--- a/packages/ts-transformers/test/fixtures/ast-transform/builder-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/builder-conditional.expected.jsx
@@ -15,7 +15,7 @@ interface PatternState {
     count: Default<number, 0>;
     label: Default<string, "">;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hbb9e3a8118a5 = __cfHelpers.lift<{
     state: {
         count: number;
     };
@@ -62,7 +62,7 @@ export default pattern((state) => {
                     type: "object",
                     properties: {}
                 }]
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_1({ state: {
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_hbb9e3a8118a5({ state: {
                 count: state.key("count")
             } }), <p>Positive</p>, <p>Non-positive</p>)}
       </section>),
@@ -117,5 +117,6 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_hbb9e3a8118a5,
+    __cfLift_1: __cfLift_hbb9e3a8118a5
 });

--- a/packages/ts-transformers/test/fixtures/ast-transform/computed-alias-const-rewrite.expected.js
+++ b/packages/ts-transformers/test/fixtures/ast-transform/computed-alias-const-rewrite.expected.js
@@ -14,11 +14,12 @@ const __cfAmdHooks = undefined;
 // FIXTURE: computed-alias-const-rewrite
 // Verifies: stable const aliases to `computed()` still lower to `derive()`.
 const alias = computed;
-const __cfLift_1 = __cfHelpers.lift(() => 1, false, undefined, { completeSchedulerScopeSummary: true });
-export default __cfLift_1();
+const __cfLift_hd718d00bc54d = __cfHelpers.lift(() => 1, false, undefined, { completeSchedulerScopeSummary: true });
+export default __cfLift_hd718d00bc54d();
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_hd718d00bc54d,
+    __cfLift_1: __cfLift_hd718d00bc54d
 });

--- a/packages/ts-transformers/test/fixtures/ast-transform/computed-object-literal-input.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/computed-object-literal-input.expected.jsx
@@ -23,7 +23,7 @@ const acceptedCount = __cfHelpers.__cf_data(cell<number>(0, {
 const rejectedCount = __cfHelpers.__cf_data(cell<number>(0, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema).for("rejectedCount", true));
-const __cfLift_1 = lift((value: string) => value, {
+const __cfLift_h681d3e9d2cfd = lift((value: string) => value, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
@@ -34,35 +34,40 @@ const __cfLift_1 = lift((value: string) => value, {
 //   lift((value: string) => value)      → lift(inputSchema, outputSchema, fn)
 //   computed(() => `...`)               → captures lift outputs into lift(inputSchema, outputSchema, { ... }, fn)
 // Context: No export default; first export-relevant statement is the cells/lifts/computed at top level
-const normalizedStage = __cfHelpers.__cf_data(__cfLift_1(stage).for("normalizedStage", true));
-const __cfLift_2 = lift((count: number) => count, {
+const normalizedStage = __cfHelpers.__cf_data(__cfLift_h681d3e9d2cfd(stage).for("normalizedStage", true));
+const __cfLift_hc6a349af1b57 = lift((count: number) => count, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const attempts = __cfHelpers.__cf_data(__cfLift_2(attemptCount).for("attempts", true));
-const __cfLift_3 = lift((count: number) => count, {
+const attempts = __cfHelpers.__cf_data(__cfLift_hc6a349af1b57(attemptCount).for("attempts", true));
+const __cfLift_hc6a349af1b57_2 = lift((count: number) => count, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const accepted = __cfHelpers.__cf_data(__cfLift_3(acceptedCount).for("accepted", true));
-const __cfLift_4 = lift((count: number) => count, {
+const accepted = __cfHelpers.__cf_data(__cfLift_hc6a349af1b57_2(acceptedCount).for("accepted", true));
+const __cfLift_hc6a349af1b57_3 = lift((count: number) => count, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const rejected = __cfHelpers.__cf_data(__cfLift_4(rejectedCount).for("rejected", true));
-const __cfLift_5 = __cfHelpers.lift(() => `stage:${normalizedStage} attempts:${attempts}` +
+const rejected = __cfHelpers.__cf_data(__cfLift_hc6a349af1b57_3(rejectedCount).for("rejected", true));
+const __cfLift_hcb32783b4574 = __cfHelpers.lift(() => `stage:${normalizedStage} attempts:${attempts}` +
     ` accepted:${accepted} rejected:${rejected}`, false, undefined, { completeSchedulerScopeSummary: true });
-const _summary = __cfHelpers.__cf_data(__cfLift_5().for("_summary", true));
+const _summary = __cfHelpers.__cf_data(__cfLift_hcb32783b4574().for("_summary", true));
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2,
-    __cfLift_3,
-    __cfLift_4,
-    __cfLift_5
+    __cfLift_h681d3e9d2cfd,
+    __cfLift_hc6a349af1b57,
+    __cfLift_hc6a349af1b57_2,
+    __cfLift_hc6a349af1b57_3,
+    __cfLift_hcb32783b4574,
+    __cfLift_1: __cfLift_h681d3e9d2cfd,
+    __cfLift_2: __cfLift_hc6a349af1b57,
+    __cfLift_3: __cfLift_hc6a349af1b57_2,
+    __cfLift_4: __cfLift_hc6a349af1b57_3,
+    __cfLift_5: __cfLift_hcb32783b4574
 });

--- a/packages/ts-transformers/test/fixtures/ast-transform/counter-pattern-no-name.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/counter-pattern-no-name.expected.jsx
@@ -45,7 +45,7 @@ const decrement = handler(false as const satisfies __cfHelpers.JSONSchema, {
 }) => {
     state.value.set(state.value.get() - 1);
 });
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h7a4ce95fb921 = __cfHelpers.lift<{
     state: {
         value: number;
     };
@@ -87,7 +87,7 @@ export default pattern((state) => {
             type: "string"
         } as const satisfies __cfHelpers.JSONSchema, {
             type: ["number", "string"]
-        } as const satisfies __cfHelpers.JSONSchema, state.key("value"), __cfLift_1({ state: {
+        } as const satisfies __cfHelpers.JSONSchema, state.key("value"), __cfLift_h7a4ce95fb921({ state: {
                 value: state.key("value")
             } }), "unknown")}</li>
         </ul>
@@ -146,5 +146,6 @@ __cfHardenFn(h);
 __cfReg({
     increment,
     decrement,
-    __cfLift_1
+    __cfLift_h7a4ce95fb921,
+    __cfLift_1: __cfLift_h7a4ce95fb921
 });

--- a/packages/ts-transformers/test/fixtures/ast-transform/counter-pattern.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/counter-pattern.expected.jsx
@@ -45,7 +45,7 @@ const decrement = handler(false as const satisfies __cfHelpers.JSONSchema, {
 }) => {
     state.value.set(state.value.get() - 1);
 });
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h7a4ce95fb921 = __cfHelpers.lift<{
     state: {
         value: number;
     };
@@ -88,7 +88,7 @@ export default pattern((state) => {
             type: "string"
         } as const satisfies __cfHelpers.JSONSchema, {
             type: ["number", "string"]
-        } as const satisfies __cfHelpers.JSONSchema, state.key("value"), __cfLift_1({ state: {
+        } as const satisfies __cfHelpers.JSONSchema, state.key("value"), __cfLift_h7a4ce95fb921({ state: {
                 value: state.key("value")
             } }), "unknown")}</li>
         </ul>
@@ -147,5 +147,6 @@ __cfHardenFn(h);
 __cfReg({
     increment,
     decrement,
-    __cfLift_1
+    __cfLift_h7a4ce95fb921,
+    __cfLift_1: __cfLift_h7a4ce95fb921
 });

--- a/packages/ts-transformers/test/fixtures/ast-transform/event-handler-no-compute-wrap.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/event-handler-no-compute-wrap.expected.jsx
@@ -32,7 +32,7 @@ const handleClick = handler({
 } as const satisfies __cfHelpers.JSONSchema, (_, { count }) => {
     count.set(count.get() + 1);
 });
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h8d7014d0b3a5 = __cfHelpers.lift<{
     count: Default<number, 0>;
 }, number>(({ count }) => count + 1, {
     type: "object",
@@ -61,7 +61,7 @@ export default pattern((__cf_pattern_input) => {
     return {
         [UI]: (<div>
           {/* Regular JSX expression - should be wrapped in a lift-applied computation */}
-          <span>Count: {__cfLift_1({ count: count })}</span>
+          <span>Count: {__cfLift_h8d7014d0b3a5({ count: count })}</span>
 
           {/* Event handler with Reactive - should NOT be wrapped in a lift-applied computation */}
           <cf-button onClick={handleClick({ count })}>
@@ -122,5 +122,6 @@ function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
     handleClick,
-    __cfLift_1
+    __cfLift_h8d7014d0b3a5,
+    __cfLift_1: __cfLift_h8d7014d0b3a5
 });

--- a/packages/ts-transformers/test/fixtures/ast-transform/non-jsx-wildcard-traversal-call-roots.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/non-jsx-wildcard-traversal-call-roots.expected.jsx
@@ -23,7 +23,7 @@ interface State {
         }
     ];
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h5e22b2ec64a3 = __cfHelpers.lift<{
     state: {
         wishes: [{ id: string; status: string; }, { id: string; status: string; }];
     };
@@ -56,7 +56,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_h26eaecab77c8 = __cfHelpers.lift<{
     state: {
         wishes: [{ id: string; status: string; }, { id: string; status: string; }];
     };
@@ -92,7 +92,7 @@ const __cfLift_2 = __cfHelpers.lift<{
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_3 = __cfHelpers.lift<{
+const __cfLift_ha0b1686d00f1 = __cfHelpers.lift<{
     state: {
         wishes: [{ id: string; status: string; }, { id: string; status: string; }];
     };
@@ -128,7 +128,7 @@ const __cfLift_3 = __cfHelpers.lift<{
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_4 = __cfHelpers.lift<{
+const __cfLift_h02687c7c0570 = __cfHelpers.lift<{
     state: {
         wishes: [{ id: string; status: string; }, { id: string; status: string; }];
     };
@@ -170,16 +170,16 @@ const __cfLift_4 = __cfHelpers.lift<{
 // FIXTURE: non-jsx-wildcard-traversal-call-roots
 // Verifies: wildcard traversal calls lower as whole call roots outside JSX
 export default pattern((state) => ({
-    serialized: __cfLift_1({ state: {
+    serialized: __cfLift_h5e22b2ec64a3({ state: {
             wishes: state.key("wishes")
         } }).for(["__patternResult", "serialized"], true),
-    keys: __cfLift_2({ state: {
+    keys: __cfLift_h26eaecab77c8({ state: {
             wishes: state.key("wishes")
         } }).for(["__patternResult", "keys"], true),
-    values: __cfLift_3({ state: {
+    values: __cfLift_ha0b1686d00f1({ state: {
             wishes: state.key("wishes")
         } }).for(["__patternResult", "values"], true),
-    entries: __cfLift_4({ state: {
+    entries: __cfLift_h02687c7c0570({ state: {
             wishes: state.key("wishes")
         } }).for(["__patternResult", "entries"], true)
 }), {
@@ -236,8 +236,12 @@ export default pattern((state) => ({
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2,
-    __cfLift_3,
-    __cfLift_4
+    __cfLift_h5e22b2ec64a3,
+    __cfLift_h26eaecab77c8,
+    __cfLift_ha0b1686d00f1,
+    __cfLift_h02687c7c0570,
+    __cfLift_1: __cfLift_h5e22b2ec64a3,
+    __cfLift_2: __cfLift_h26eaecab77c8,
+    __cfLift_3: __cfLift_ha0b1686d00f1,
+    __cfLift_4: __cfLift_h02687c7c0570
 });

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-array-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-array-map.expected.jsx
@@ -28,7 +28,7 @@ const adder = handler(false as const satisfies __cfHelpers.JSONSchema, {
 }) => {
     state.values.push(Math.random().toString(36).substring(2, 15));
 });
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h9981af11a1a9 = __cfHelpers.lift<{
     values: unknown[];
 }, void>(({ values }) => {
     console.log("values#", values?.length);
@@ -46,7 +46,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     asCell: ["opaque"]
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hef2f7d69be51 = __cfHelpers.pattern(__cf_pattern_input => {
     const value = __cf_pattern_input.key("element");
     const index = __cf_pattern_input.key("index");
     return (<div>
@@ -93,13 +93,13 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 // Context: Destructured pattern parameter; combines array map transform with computed and handler schemas
 export default pattern((__cf_pattern_input) => {
     const values = __cf_pattern_input.key("values");
-    __cfLift_1({ values: values });
+    __cfLift_h9981af11a1a9({ values: values });
     return {
         [NAME]: str `Simple Value: ${values.key("length")}`,
         [UI]: (<div>
           <button type="button" onClick={adder({ values })}>Add Value</button>
           <div>
-            {values.mapWithPattern(__cfPattern_1, {})}
+            {values.mapWithPattern(__cfPattern_hef2f7d69be51, {})}
           </div>
         </div>),
         values,
@@ -159,6 +159,8 @@ function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
     adder,
-    __cfLift_1,
-    __cfPattern_1
+    __cfLift_h9981af11a1a9,
+    __cfPattern_hef2f7d69be51,
+    __cfLift_1: __cfLift_h9981af11a1a9,
+    __cfPattern_1: __cfPattern_hef2f7d69be51
 });

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-call-arg-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-call-arg-conditional.expected.jsx
@@ -12,7 +12,7 @@ const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
 const identity = __cfHardenFn(<T,>(value: T) => value);
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h4318ee2c2a91 = __cfHelpers.lift<{
     state: {
         done: boolean;
     };
@@ -39,7 +39,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 //   const label = identity(state.done ? "Done" : "Pending")
 //   → const label = lift(({ state }) => identity(state.done ? "Done" : "Pending"))({ state })
 export default pattern((state) => {
-    const label = __cfLift_1({ state: {
+    const label = __cfLift_h4318ee2c2a91({ state: {
             done: state.key("done")
         } }).for("label", true);
     return { label };
@@ -64,5 +64,6 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_h4318ee2c2a91,
+    __cfLift_1: __cfLift_h4318ee2c2a91
 });

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-call-root-containers.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-call-root-containers.expected.jsx
@@ -12,7 +12,7 @@ const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
 const identity = __cfHardenFn(<T,>(value: T) => value);
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h4318ee2c2a91 = __cfHelpers.lift<{
     state: {
         done: boolean;
     };
@@ -33,7 +33,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     "enum": ["Done", "Pending"]
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_h4318ee2c2a91_2 = __cfHelpers.lift<{
     state: {
         done: boolean;
     };
@@ -66,10 +66,10 @@ const __cfLift_2 = __cfHelpers.lift<{
 //   → return lift(({ state }) => identity(state.done ? "Done" : "Pending"))({ state })
 export const objectAndArray = pattern((state) => {
     const view = {
-        value: __cfLift_1({ state: {
+        value: __cfLift_h4318ee2c2a91({ state: {
                 done: state.key("done")
             } }).for(["view", "value"], true),
-        list: [__cfLift_2({ state: {
+        list: [__cfLift_h4318ee2c2a91_2({ state: {
                     done: state.key("done")
                 } }).for(["view", "list", 0], true)]
     };
@@ -97,7 +97,7 @@ export const objectAndArray = pattern((state) => {
     },
     required: ["value", "list"]
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_3 = __cfHelpers.lift<{
+const __cfLift_h4318ee2c2a91_3 = __cfHelpers.lift<{
     state: {
         done: boolean;
     };
@@ -118,7 +118,7 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     "enum": ["Done", "Pending"]
 } as const satisfies __cfHelpers.JSONSchema);
-export default pattern((state) => __cfLift_3({ state: {
+export default pattern((state) => __cfLift_h4318ee2c2a91_3({ state: {
         done: state.key("done")
     } }).for("__patternResult", true), {
     type: "object",
@@ -135,7 +135,10 @@ export default pattern((state) => __cfLift_3({ state: {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2,
-    __cfLift_3
+    __cfLift_h4318ee2c2a91,
+    __cfLift_h4318ee2c2a91_2,
+    __cfLift_h4318ee2c2a91_3,
+    __cfLift_1: __cfLift_h4318ee2c2a91,
+    __cfLift_2: __cfLift_h4318ee2c2a91_2,
+    __cfLift_3: __cfLift_h4318ee2c2a91_3
 });

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-local-helper-call-roots.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-local-helper-call-roots.expected.jsx
@@ -12,7 +12,7 @@ const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
 const double = __cfHardenFn((x: number) => x * 2);
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_ha35b82f2d059 = __cfHelpers.lift<{
     state: {
         count: number;
     };
@@ -40,7 +40,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 //   double(state.count + 1)   -> lift(({ state }) => double(state.count + 1))({ state })
 export default pattern((state) => ({
     staticDoubled: double(2),
-    doubled: __cfLift_1({ state: {
+    doubled: __cfLift_ha35b82f2d059({ state: {
             count: state.key("count")
         } }).for(["__patternResult", "doubled"], true)
 }), {
@@ -67,5 +67,6 @@ export default pattern((state) => ({
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_ha35b82f2d059,
+    __cfLift_1: __cfLift_ha35b82f2d059
 });

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-object-binary-add.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-object-binary-add.expected.jsx
@@ -11,7 +11,7 @@ import { pattern } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hef9d746c0d70 = __cfHelpers.lift<{
     state: {
         count: number;
     };
@@ -39,7 +39,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 //   return { next: state.count + 1 }
 //   → return { next: lift(({ state }) => state.count + 1)({ state }) }
 export default pattern((state) => ({
-    next: __cfLift_1({ state: {
+    next: __cfLift_hef9d746c0d70({ state: {
             count: state.key("count")
         } }).for(["__patternResult", "next"], true)
 }), {
@@ -63,5 +63,6 @@ export default pattern((state) => ({
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_hef9d746c0d70,
+    __cfLift_1: __cfLift_hef9d746c0d70
 });

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-object-prefix-not.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-object-prefix-not.expected.jsx
@@ -11,7 +11,7 @@ import { pattern } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h6daebbf29419 = __cfHelpers.lift<{
     state: {
         done: boolean;
     };
@@ -38,7 +38,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 //   return { hidden: !state.done }
 //   → return { hidden: lift(({ state }) => !state.done)({ state }) }
 export default pattern((state) => ({
-    hidden: __cfLift_1({ state: {
+    hidden: __cfLift_h6daebbf29419({ state: {
             done: state.key("done")
         } }).for(["__patternResult", "hidden"], true)
 }), {
@@ -62,5 +62,6 @@ export default pattern((state) => ({
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_h6daebbf29419,
+    __cfLift_1: __cfLift_h6daebbf29419
 });

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-top-level-root-lowering.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-top-level-root-lowering.expected.jsx
@@ -12,7 +12,7 @@ const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
 const identity = __cfHardenFn(<T,>(value: T) => value);
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h456b5e8dcaaa = __cfHelpers.lift<{
     state: {
         user: {
             name: string;
@@ -41,7 +41,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_h571176a622b0 = __cfHelpers.lift<{
     state: {
         maybeUser?: { name: string; } | undefined;
     };
@@ -67,7 +67,7 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["string", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_3 = __cfHelpers.lift<{
+const __cfLift_hc153d1b5c82c = __cfHelpers.lift<{
     state: {
         a: number;
         b: number;
@@ -92,7 +92,7 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_4 = __cfHelpers.lift<{
+const __cfLift_h1f431b9b430a = __cfHelpers.lift<{
     state: {
         float: string;
     };
@@ -113,7 +113,7 @@ const __cfLift_4 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_5 = __cfHelpers.lift<{
+const __cfLift_h10bbe946665d = __cfHelpers.lift<{
     state: {
         label?: string | null | undefined;
     };
@@ -143,25 +143,25 @@ const __cfLift_5 = __cfHelpers.lift<{
 //   state.label ?? "Pending"      -> lift-applied nullish root
 //   state.items?.[0]              -> lowered optional element access
 export default pattern((state) => {
-    const label = __cfLift_1({ state: {
+    const label = __cfLift_h456b5e8dcaaa({ state: {
             user: {
                 name: state.key("user", "name")
             }
         } }).for("label", true);
-    const maybeLabel = __cfLift_2({ state: {
+    const maybeLabel = __cfLift_h571176a622b0({ state: {
             maybeUser: state.key("maybeUser")
         } }).for("maybeLabel", true);
     return {
         label,
         maybeLabel,
-        maxValue: __cfLift_3({ state: {
+        maxValue: __cfLift_hc153d1b5c82c({ state: {
                 a: state.key("a"),
                 b: state.key("b")
             } }).for(["__patternResult", "maxValue"], true),
-        parsedValue: __cfLift_4({ state: {
+        parsedValue: __cfLift_h1f431b9b430a({ state: {
                 float: state.key("float")
             } }).for(["__patternResult", "parsedValue"], true),
-        fallbackLabel: __cfLift_5({ state: {
+        fallbackLabel: __cfLift_h10bbe946665d({ state: {
                 label: state.key("label")
             } }).for(["__patternResult", "fallbackLabel"], true),
         firstItem: state.key("items", "0")
@@ -239,9 +239,14 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2,
-    __cfLift_3,
-    __cfLift_4,
-    __cfLift_5
+    __cfLift_h456b5e8dcaaa,
+    __cfLift_h571176a622b0,
+    __cfLift_hc153d1b5c82c,
+    __cfLift_h1f431b9b430a,
+    __cfLift_h10bbe946665d,
+    __cfLift_1: __cfLift_h456b5e8dcaaa,
+    __cfLift_2: __cfLift_h571176a622b0,
+    __cfLift_3: __cfLift_hc153d1b5c82c,
+    __cfLift_4: __cfLift_h1f431b9b430a,
+    __cfLift_5: __cfLift_h10bbe946665d
 });

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-two-schemas.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-two-schemas.expected.jsx
@@ -19,7 +19,7 @@ interface Input {
 interface Result {
     doubled: number;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h7d1023a45462 = __cfHelpers.lift<{
     count: number;
 }, number>(({ count }) => count * 2, {
     type: "object",
@@ -40,7 +40,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 export default pattern((__cf_pattern_input) => {
     const count = __cf_pattern_input.key("count");
     return {
-        doubled: __cfLift_1({ count: count }).for(["__patternResult", "doubled"], true)
+        doubled: __cfLift_h7d1023a45462({ count: count }).for(["__patternResult", "doubled"], true)
     };
 }, {
     type: "object",
@@ -63,5 +63,6 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_h7d1023a45462,
+    __cfLift_1: __cfLift_h7d1023a45462
 });

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-with-name-and-type.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-with-name-and-type.expected.jsx
@@ -14,7 +14,7 @@ const __cfAmdHooks = undefined;
 interface MyInput {
     value: number;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h57f53477e330 = __cfHelpers.lift<{
     input: {
         value: number;
     };
@@ -42,7 +42,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 // Context: Type comes from inline parameter annotation, not generic type argument
 export default pattern((input: MyInput) => {
     return {
-        result: __cfLift_1({ input: {
+        result: __cfLift_h57f53477e330({ input: {
                 value: input.key("value")
             } }).for(["__patternResult", "result"], true)
     };
@@ -67,5 +67,6 @@ export default pattern((input: MyInput) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_h57f53477e330,
+    __cfLift_1: __cfLift_h57f53477e330
 });

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-with-type.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-with-type.expected.jsx
@@ -14,7 +14,7 @@ const __cfAmdHooks = undefined;
 interface MyInput {
     value: number;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h57f53477e330 = __cfHelpers.lift<{
     input: {
         value: number;
     };
@@ -42,7 +42,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 // Context: Identical structure to pattern-with-name-and-type; confirms consistent behavior
 export default pattern((input: MyInput) => {
     return {
-        result: __cfLift_1({ input: {
+        result: __cfLift_h57f53477e330({ input: {
                 value: input.key("value")
             } }).for(["__patternResult", "result"], true)
     };
@@ -67,5 +67,6 @@ export default pattern((input: MyInput) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_h57f53477e330,
+    __cfLift_1: __cfLift_h57f53477e330
 });

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-builders.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-builders.expected.jsx
@@ -40,7 +40,7 @@ const addTodo = handler({
 } as const satisfies __cfHelpers.JSONSchema, (event, state) => {
     state.items.push(event.add);
 });
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hfb57fac2bd3f = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const index = __cf_pattern_input.key("index");
     return <li key={index}>{item}</li>;
@@ -88,7 +88,7 @@ export default pattern((state) => {
           Add
         </button>
         <ul>
-          {state.key("items").mapWithPattern(__cfPattern_1, {})}
+          {state.key("items").mapWithPattern(__cfPattern_hfb57fac2bd3f, {})}
         </ul>
       </div>),
     };
@@ -139,5 +139,6 @@ function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
     addTodo,
-    __cfPattern_1
+    __cfPattern_hfb57fac2bd3f,
+    __cfPattern_1: __cfPattern_hfb57fac2bd3f
 });

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-computed-alias.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-computed-alias.expected.jsx
@@ -18,17 +18,18 @@ type AliasResult = {
     length: number;
 };
 declare const state: AliasInput;
-const __cfLift_1 = __cfHelpers.lift((): AliasResult => ({
+const __cfLift_heddc360e206e = __cfHelpers.lift((): AliasResult => ({
     length: state.text.length,
 }), false, undefined, { completeSchedulerScopeSummary: true });
 // FIXTURE: schema-generation-computed-alias
 // Verifies: a reactive builder imported under an alias still gets schema injection
 //   computedAlias((): AliasResult => ...) → captures `state` and lowers to lift(inputSchema, outputSchema, ...)
 // Context: Uses `import { computed as computedAlias }` to test aliased import tracking
-export const textLength = __cfHelpers.__cf_data(__cfLift_1().for("textLength", true));
+export const textLength = __cfHelpers.__cf_data(__cfLift_heddc360e206e().for("textLength", true));
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_heddc360e206e,
+    __cfLift_1: __cfLift_heddc360e206e
 });

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-computed-inside-jsx.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-computed-inside-jsx.expected.jsx
@@ -12,17 +12,18 @@ const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
 declare const value: number;
-const __cfLift_1 = __cfHelpers.lift(() => value * 2, false, undefined, { completeSchedulerScopeSummary: true });
+const __cfLift_h31aed4029e9a = __cfHelpers.lift(() => value * 2, false, undefined, { completeSchedulerScopeSummary: true });
 // FIXTURE: schema-generation-computed-inside-jsx
 // Verifies: a reactive builder inside a JSX expression still gets schemas injected
 //   computed(() => value * 2) → captures `value` and lowers to lift(inputSchema, outputSchema, ...)
 // Context: computed() appears as a JSX child expression, not a standalone statement
 export const result = (<div>
-    {__cfLift_1()}
+    {__cfLift_h31aed4029e9a()}
   </div>);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_h31aed4029e9a,
+    __cfLift_1: __cfLift_h31aed4029e9a
 });

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-computed-multiple-returns.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-computed-multiple-returns.expected.jsx
@@ -12,7 +12,7 @@ const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
 declare const flag: boolean;
-const __cfLift_1 = __cfHelpers.lift(() => {
+const __cfLift_hd4f94169a023 = __cfHelpers.lift(() => {
     if (flag) {
         return "hello";
     }
@@ -23,10 +23,11 @@ const __cfLift_1 = __cfHelpers.lift(() => {
 //   computed(() => { ... }) → output schema is an enum union of the returned literals
 // Context: Callback has two return statements (string and number); output schema is an enum union
 // Function with multiple return statements - should infer string | number
-export const multiReturn = __cfHelpers.__cf_data(__cfLift_1().for("multiReturn", true));
+export const multiReturn = __cfHelpers.__cf_data(__cfLift_hd4f94169a023().for("multiReturn", true));
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_hd4f94169a023,
+    __cfLift_1: __cfLift_hd4f94169a023
 });

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-computed-untyped.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-computed-untyped.expected.jsx
@@ -12,15 +12,16 @@ const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
 declare const total: number;
-const __cfLift_1 = __cfHelpers.lift(() => total * 2, false, undefined, { completeSchedulerScopeSummary: true });
+const __cfLift_h11e07c5a77da = __cfHelpers.lift(() => total * 2, false, undefined, { completeSchedulerScopeSummary: true });
 // FIXTURE: schema-generation-computed-untyped
 // Verifies: a reactive builder with no generic type args infers schemas from captured values
 //   computed(() => total * 2) → captures `total` ({ type: "number" }) and infers output from the body
 // Context: Input type comes from `declare const total: number`; output inferred from arrow body
-export const doubled = __cfHelpers.__cf_data(__cfLift_1().for("doubled", true));
+export const doubled = __cfHelpers.__cf_data(__cfLift_h11e07c5a77da().for("doubled", true));
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_h11e07c5a77da,
+    __cfLift_1: __cfLift_h11e07c5a77da
 });

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-computed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-computed.expected.jsx
@@ -18,17 +18,18 @@ type DeriveResult = {
     doubled: number;
 };
 declare const source: DeriveInput;
-const __cfLift_1 = __cfHelpers.lift((): DeriveResult => ({
+const __cfLift_h17a23688872a = __cfHelpers.lift((): DeriveResult => ({
     doubled: source.count * 2,
 }), false, undefined, { completeSchedulerScopeSummary: true });
 // FIXTURE: schema-generation-computed
 // Verifies: computed() closure-extracts a captured value into a lift() with input
 // (capture) and output schemas generated from type info
 //   computed(() => ({ doubled: source.count * 2 })) → lift(captureSchema, outputSchema, { source }, fn)
-export const doubledValue = __cfHelpers.__cf_data(__cfLift_1().for("doubledValue", true));
+export const doubledValue = __cfHelpers.__cf_data(__cfLift_h17a23688872a().for("doubledValue", true));
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_h17a23688872a,
+    __cfLift_1: __cfLift_h17a23688872a
 });

--- a/packages/ts-transformers/test/fixtures/ast-transform/str-template-call-interpolation.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/str-template-call-interpolation.expected.jsx
@@ -18,7 +18,7 @@ function format(n: number): string {
     return `#${n}`;
 }
 __cfHardenFn(format);
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h4cf6c56203e6 = __cfHelpers.lift<{
     cell: {
         value: number;
     };
@@ -39,7 +39,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_h6e766619f6ec = __cfHelpers.lift<{
     cell: {
         value: number;
     };
@@ -74,9 +74,9 @@ const __cfLift_2 = __cfHelpers.lift<{
 //   call-expressions were never classified as lowerable expression sites.
 export default pattern((cell) => {
     return {
-        [NAME]: str `bare ${cell.key("value")} call ${__cfLift_1({ cell: {
+        [NAME]: str `bare ${cell.key("value")} call ${__cfLift_h4cf6c56203e6({ cell: {
                 value: cell.key("value")
-            } })} math ${__cfLift_2({ cell: {
+            } })} math ${__cfLift_h6e766619f6ec({ cell: {
                 value: cell.key("value")
             } })}`,
         value: cell.key("value"),
@@ -105,6 +105,8 @@ export default pattern((cell) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2
+    __cfLift_h4cf6c56203e6,
+    __cfLift_h6e766619f6ec,
+    __cfLift_1: __cfLift_h4cf6c56203e6,
+    __cfLift_2: __cfLift_h6e766619f6ec
 });

--- a/packages/ts-transformers/test/fixtures/ast-transform/ternary_computed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/ternary_computed.expected.jsx
@@ -14,7 +14,7 @@ const __cfAmdHooks = undefined;
 interface PatternState {
     value: Default<number, 0>;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h7a4ce95fb921 = __cfHelpers.lift<{
     state: {
         value: number;
     };
@@ -35,7 +35,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_ha245ae91eff9 = __cfHelpers.lift<{
     state: {
         value: number;
     };
@@ -73,9 +73,9 @@ export default pattern((state) => {
             type: "string"
         } as const satisfies __cfHelpers.JSONSchema, {
             type: ["number", "string"]
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_1({ state: {
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_h7a4ce95fb921({ state: {
                 value: state.key("value")
-            } }), __cfLift_2({ state: {
+            } }), __cfLift_ha245ae91eff9({ state: {
                 value: state.key("value")
             } }), "undefined")}
       </div>),
@@ -126,6 +126,8 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2
+    __cfLift_h7a4ce95fb921,
+    __cfLift_ha245ae91eff9,
+    __cfLift_1: __cfLift_h7a4ce95fb921,
+    __cfLift_2: __cfLift_ha245ae91eff9
 });

--- a/packages/ts-transformers/test/fixtures/closures/action-basic.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-basic.expected.jsx
@@ -14,7 +14,7 @@ const __cfAmdHooks = undefined;
 interface State {
     count: Cell<number>;
 }
-const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+const __cfHandler_h5d43534d0802 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
         count: {
@@ -30,7 +30,7 @@ const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
 export default pattern((__cf_pattern_input) => {
     const count = __cf_pattern_input.key("count");
     return {
-        inc: __cfHandler_1({
+        inc: __cfHandler_h5d43534d0802({
             count: count
         }).for({ stream: ["__patternResult", "inc"] }, true)
     };
@@ -56,5 +56,6 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfHandler_1
+    __cfHandler_h5d43534d0802,
+    __cfHandler_1: __cfHandler_h5d43534d0802
 });

--- a/packages/ts-transformers/test/fixtures/closures/action-generic-event.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-generic-event.expected.jsx
@@ -17,7 +17,7 @@ interface MyEvent {
 interface State {
     value: Cell<string>;
 }
-const __cfHandler_1 = __cfHelpers.handler({
+const __cfHandler_he2ef4e205199 = __cfHelpers.handler({
     type: "object",
     properties: {
         data: {
@@ -43,7 +43,7 @@ export default pattern((__cf_pattern_input) => {
     const value = __cf_pattern_input.key("value");
     return {
         // Test action<MyEvent>((e) => ...) variant (type parameter instead of inline annotation)
-        update: __cfHandler_1({
+        update: __cfHandler_he2ef4e205199({
             value: value
         }).for({ stream: ["__patternResult", "update"] }, true)
     };
@@ -81,5 +81,6 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfHandler_1
+    __cfHandler_he2ef4e205199,
+    __cfHandler_1: __cfHandler_he2ef4e205199
 });

--- a/packages/ts-transformers/test/fixtures/closures/action-in-ternary-branch.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-in-ternary-branch.expected.jsx
@@ -25,7 +25,7 @@ interface Card {
 interface Input {
     card: Card;
 }
-const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+const __cfHandler_h51b930355b0f = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
         isEditing: {
@@ -37,7 +37,7 @@ const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
 } as const satisfies __cfHelpers.JSONSchema, (_, { isEditing }) => {
     isEditing.set(true);
 });
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h9c2da83d92d8 = __cfHelpers.lift<{
     card: {
         description: string;
     };
@@ -72,10 +72,10 @@ export default pattern((__cf_pattern_input) => {
     const isEditing = new Cell(false, {
         type: "boolean"
     } as const satisfies __cfHelpers.JSONSchema).for("isEditing", true);
-    const startEditing = __cfHandler_1({
+    const startEditing = __cfHandler_h51b930355b0f({
         isEditing: isEditing
     }).for({ stream: "startEditing" }, true);
-    const hasDescription = __cfLift_1({ card: {
+    const hasDescription = __cfLift_h9c2da83d92d8({ card: {
             description: card.key("description")
         } }).for("hasDescription", true);
     return {
@@ -195,6 +195,8 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfHandler_1,
-    __cfLift_1
+    __cfHandler_h51b930355b0f,
+    __cfLift_h9c2da83d92d8,
+    __cfHandler_1: __cfHandler_h51b930355b0f,
+    __cfLift_1: __cfLift_h9c2da83d92d8
 });

--- a/packages/ts-transformers/test/fixtures/closures/action-in-ternary-with-explicit-computed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-in-ternary-with-explicit-computed.expected.jsx
@@ -25,7 +25,7 @@ interface Card {
 interface Input {
     card: Card;
 }
-const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+const __cfHandler_h51b930355b0f = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
         isEditing: {
@@ -37,7 +37,7 @@ const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
 } as const satisfies __cfHelpers.JSONSchema, (_, { isEditing }) => {
     isEditing.set(true);
 });
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h8e88377ecb13 = __cfHelpers.lift<{
     card: {
         description: string;
     };
@@ -93,7 +93,7 @@ export default pattern((__cf_pattern_input) => {
     const isEditing = new Cell(false, {
         type: "boolean"
     } as const satisfies __cfHelpers.JSONSchema).for("isEditing", true);
-    const startEditing = __cfHandler_1({
+    const startEditing = __cfHandler_h51b930355b0f({
         isEditing: isEditing
     }).for({ stream: "startEditing" }, true);
     return {
@@ -120,7 +120,7 @@ export default pattern((__cf_pattern_input) => {
             <span>{card.key("title")}</span>
             {/* Explicit computed() wrapping JSX that references the action */}
             {/* The action must be captured in the lift-applied computation created for this computed */}
-            {__cfLift_1({
+            {__cfLift_h8e88377ecb13({
                 card: {
                     description: card.key("description")
                 },
@@ -201,6 +201,8 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfHandler_1,
-    __cfLift_1
+    __cfHandler_h51b930355b0f,
+    __cfLift_h8e88377ecb13,
+    __cfHandler_1: __cfHandler_h51b930355b0f,
+    __cfLift_1: __cfLift_h8e88377ecb13
 });

--- a/packages/ts-transformers/test/fixtures/closures/action-partial.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-partial.expected.jsx
@@ -17,7 +17,7 @@ interface BaseState {
 }
 // Partial<BaseState> should make both 'a' and 'b' optional in the schema
 type PartState = Partial<BaseState>;
-const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+const __cfHandler_h30e1080784a4 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
         a: {
@@ -30,7 +30,7 @@ const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, (_, { a }) => console.log(a));
-const __cfHandler_2 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+const __cfHandler_h0924cad1751f = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
         b: {
@@ -51,10 +51,10 @@ export default pattern((__cf_pattern_input) => {
     const a = __cf_pattern_input.key("a");
     const b = __cf_pattern_input.key("b");
     return {
-        readA: __cfHandler_1({
+        readA: __cfHandler_h30e1080784a4({
             a: a
         }).for({ stream: ["__patternResult", "readA"] }, true),
-        readB: __cfHandler_2({
+        readB: __cfHandler_h0924cad1751f({
             b: b
         }).for({ stream: ["__patternResult", "readB"] }, true)
     };
@@ -86,6 +86,8 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfHandler_1,
-    __cfHandler_2
+    __cfHandler_h30e1080784a4,
+    __cfHandler_h0924cad1751f,
+    __cfHandler_1: __cfHandler_h30e1080784a4,
+    __cfHandler_2: __cfHandler_h0924cad1751f
 });

--- a/packages/ts-transformers/test/fixtures/closures/action-required-partial.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-required-partial.expected.jsx
@@ -17,7 +17,7 @@ interface BaseState {
 }
 // Required<BaseState> should make 'a' required in the schema
 type ReqState = Required<BaseState>;
-const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+const __cfHandler_ha0ffa0cc7a66 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
         a: {
@@ -27,7 +27,7 @@ const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
     },
     required: ["a"]
 } as const satisfies __cfHelpers.JSONSchema, (_, { a }) => a.set("hello"));
-const __cfHandler_2 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+const __cfHandler_hfa3cd03bb942 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
         b: {
@@ -45,10 +45,10 @@ export default pattern((__cf_pattern_input) => {
     const a = __cf_pattern_input.key("a");
     const b = __cf_pattern_input.key("b");
     return {
-        setA: __cfHandler_1({
+        setA: __cfHandler_ha0ffa0cc7a66({
             a: a
         }).for({ stream: ["__patternResult", "setA"] }, true),
-        setB: __cfHandler_2({
+        setB: __cfHandler_hfa3cd03bb942({
             b: b
         }).for({ stream: ["__patternResult", "setB"] }, true)
     };
@@ -81,6 +81,8 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfHandler_1,
-    __cfHandler_2
+    __cfHandler_ha0ffa0cc7a66,
+    __cfHandler_hfa3cd03bb942,
+    __cfHandler_1: __cfHandler_ha0ffa0cc7a66,
+    __cfHandler_2: __cfHandler_hfa3cd03bb942
 });

--- a/packages/ts-transformers/test/fixtures/closures/action-result-not-opaque.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-result-not-opaque.expected.jsx
@@ -19,7 +19,7 @@ const __cfAmdHooks = undefined;
 interface State {
     label: string;
 }
-const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+const __cfHandler_hcc25504e4124 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
         count: {
@@ -31,7 +31,7 @@ const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
 } as const satisfies __cfHelpers.JSONSchema, (_, { count }) => {
     count.set(count.get() + 1);
 });
-const __cfHandler_2 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+const __cfHandler_h144e7c72f512 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
         count: {
@@ -52,10 +52,10 @@ export default pattern((__cf_pattern_input) => {
     const count = new Writable(0, {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema).for("count", true);
-    const increment = __cfHandler_1({
+    const increment = __cfHandler_hcc25504e4124({
         count: count
     }).for({ stream: "increment" }, true);
-    const decrement = __cfHandler_2({
+    const decrement = __cfHandler_h144e7c72f512({
         count: count
     }).for({ stream: "decrement" }, true);
     return {
@@ -112,6 +112,8 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfHandler_1,
-    __cfHandler_2
+    __cfHandler_hcc25504e4124,
+    __cfHandler_h144e7c72f512,
+    __cfHandler_1: __cfHandler_hcc25504e4124,
+    __cfHandler_2: __cfHandler_h144e7c72f512
 });

--- a/packages/ts-transformers/test/fixtures/closures/action-self-closure.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-self-closure.expected.jsx
@@ -21,7 +21,7 @@ interface TestOutput {
     title: string;
     count: number;
 }
-const __cfHandler_1 = __cfHelpers.handler({
+const __cfHandler_h0d1f87bd007c = __cfHelpers.handler({
     type: "object",
     properties: {},
     additionalProperties: false
@@ -42,7 +42,7 @@ const __cfHandler_1 = __cfHelpers.handler({
 } as const satisfies __cfHelpers.JSONSchema, (_, { self }) => {
     console.log("self.title:", self.title);
 });
-const __cfHandler_2 = __cfHelpers.handler({
+const __cfHandler_h855f350abb36 = __cfHelpers.handler({
     type: "object",
     properties: {},
     additionalProperties: false
@@ -94,13 +94,13 @@ export default pattern((__cf_pattern_input) => {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema).for("count", true);
     // Action closing over `self` — works because all inputs use Default<>
-    const showSelf = __cfHandler_1({
+    const showSelf = __cfHandler_h0d1f87bd007c({
         self: {
             title: self.key("title")
         }
     }).for({ stream: "showSelf" }, true);
     // Action closing over both `self` and `count`
-    const incrementWithSelf = __cfHandler_2({
+    const incrementWithSelf = __cfHandler_h855f350abb36({
         self: self,
         count: count
     }).for({ stream: "incrementWithSelf" }, true);
@@ -144,6 +144,8 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfHandler_1,
-    __cfHandler_2
+    __cfHandler_h0d1f87bd007c,
+    __cfHandler_h855f350abb36,
+    __cfHandler_1: __cfHandler_h0d1f87bd007c,
+    __cfHandler_2: __cfHandler_h855f350abb36
 });

--- a/packages/ts-transformers/test/fixtures/closures/action-with-event.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-with-event.expected.jsx
@@ -17,7 +17,7 @@ interface MyEvent {
 interface State {
     value: Cell<string>;
 }
-const __cfHandler_1 = __cfHelpers.handler({
+const __cfHandler_he2ef4e205199 = __cfHelpers.handler({
     type: "object",
     properties: {
         data: {
@@ -42,7 +42,7 @@ const __cfHandler_1 = __cfHelpers.handler({
 export default pattern((__cf_pattern_input) => {
     const value = __cf_pattern_input.key("value");
     return {
-        update: __cfHandler_1({
+        update: __cfHandler_he2ef4e205199({
             value: value
         }).for({ stream: ["__patternResult", "update"] }, true)
     };
@@ -80,5 +80,6 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfHandler_1
+    __cfHandler_he2ef4e205199,
+    __cfHandler_1: __cfHandler_he2ef4e205199
 });

--- a/packages/ts-transformers/test/fixtures/closures/array-method-scalar-nullish-lift.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/array-method-scalar-nullish-lift.expected.jsx
@@ -17,7 +17,7 @@ interface Row {
     primary?: string[];
     fallback: number[];
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h2797c28b9ee8 = __cfHelpers.lift<{
     r: {
         name?: string | undefined;
     };
@@ -37,9 +37,9 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h4fd82c3520eb = __cfHelpers.pattern(__cf_pattern_input => {
     const r = __cf_pattern_input.key("element");
-    return __cfLift_1({ r: {
+    return __cfLift_h2797c28b9ee8({ r: {
             name: r.key("name")
         } }).for("__patternResult", true);
 }, {
@@ -79,7 +79,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_hd145b9cf9544 = __cfHelpers.lift<{
     r: {
         active?: boolean | undefined;
     };
@@ -103,9 +103,9 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h25731035d0cc = __cfHelpers.pattern(__cf_pattern_input => {
     const r = __cf_pattern_input.key("element");
-    return __cfLift_2({ r: {
+    return __cfLift_hd145b9cf9544({ r: {
             active: r.key("active")
         } }).for("__patternResult", true);
 }, {
@@ -145,7 +145,7 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hf7edaa6532d0 = __cfHelpers.pattern(__cf_pattern_input => {
     const r = __cf_pattern_input.key("element");
     return <i>{r.key("name")}</i>;
 }, {
@@ -203,7 +203,7 @@ const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_4 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h6956235d0288 = __cfHelpers.pattern(__cf_pattern_input => {
     const r = __cf_pattern_input.key("element");
     return r.key("primary") ?? r.key("fallback");
 }, {
@@ -272,13 +272,13 @@ export default pattern((__cf_pattern_input) => {
     return {
         [UI]: (<div>
         {/* scalar string ??: lifted, so "default" is live */}
-        <div>{rows.mapWithPattern(__cfPattern_1, {})}</div>
+        <div>{rows.mapWithPattern(__cfPattern_h4fd82c3520eb, {})}</div>
         {/* scalar boolean ?? as a filter predicate: lifted */}
         <div>
-          {rows.filterWithPattern(__cfPattern_2, {}).mapWithPattern(__cfPattern_3, {})}
+          {rows.filterWithPattern(__cfPattern_h25731035d0cc, {}).mapWithPattern(__cfPattern_hf7edaa6532d0, {})}
         </div>
         {/* heterogeneous collection ?? (union of array types): stays structural */}
-        <div>{rows.mapWithPattern(__cfPattern_4, {})}</div>
+        <div>{rows.mapWithPattern(__cfPattern_h6956235d0288, {})}</div>
       </div>),
     };
 }, {
@@ -352,10 +352,16 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfPattern_1,
-    __cfLift_2,
-    __cfPattern_2,
-    __cfPattern_3,
-    __cfPattern_4
+    __cfLift_h2797c28b9ee8,
+    __cfPattern_h4fd82c3520eb,
+    __cfLift_hd145b9cf9544,
+    __cfPattern_h25731035d0cc,
+    __cfPattern_hf7edaa6532d0,
+    __cfPattern_h6956235d0288,
+    __cfLift_1: __cfLift_h2797c28b9ee8,
+    __cfPattern_1: __cfPattern_h4fd82c3520eb,
+    __cfLift_2: __cfLift_hd145b9cf9544,
+    __cfPattern_2: __cfPattern_h25731035d0cc,
+    __cfPattern_3: __cfPattern_hf7edaa6532d0,
+    __cfPattern_4: __cfPattern_h6956235d0288
 });

--- a/packages/ts-transformers/test/fixtures/closures/array-method-value-lift.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/array-method-value-lift.expected.jsx
@@ -15,7 +15,7 @@ interface Vote {
     optionId: string;
     voterName: string;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hce3149656a01 = __cfHelpers.lift<{
     v: {
         optionId: string;
     };
@@ -40,10 +40,10 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hcee6c5aa0bde = __cfHelpers.pattern(__cf_pattern_input => {
     const v = __cf_pattern_input.key("element");
     const oid = __cf_pattern_input.key("params", "oid");
-    return __cfLift_1({
+    return __cfLift_hce3149656a01({
         v: {
             optionId: v.key("optionId")
         },
@@ -83,7 +83,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_he9a21d43b468 = __cfHelpers.pattern(__cf_pattern_input => {
     const v = __cf_pattern_input.key("element");
     return <i>{v.key("voterName")}</i>;
 }, {
@@ -129,7 +129,7 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_hce3149656a01_2 = __cfHelpers.lift<{
     v: {
         optionId: string;
     };
@@ -154,10 +154,10 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hfd78bb41cc8e = __cfHelpers.pattern(__cf_pattern_input => {
     const v = __cf_pattern_input.key("element");
     const oid = __cf_pattern_input.key("params", "oid");
-    return __cfLift_2({
+    return __cfLift_hce3149656a01_2({
         v: {
             optionId: v.key("optionId")
         },
@@ -197,7 +197,7 @@ const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_3 = __cfHelpers.lift<{
+const __cfLift_hce3149656a01_3 = __cfHelpers.lift<{
     v: {
         optionId: string;
     };
@@ -222,10 +222,10 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_4 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hef1cb02287df = __cfHelpers.pattern(__cf_pattern_input => {
     const v = __cf_pattern_input.key("element");
     const oid = __cf_pattern_input.key("params", "oid");
-    return [__cfLift_3({
+    return [__cfLift_hce3149656a01_3({
             v: {
                 optionId: v.key("optionId")
             },
@@ -286,16 +286,16 @@ export default pattern((__cf_pattern_input) => {
         [UI]: (<div>
         {/* filter predicate: the comparison must be lifted to value level */}
         <div>
-          {votes.filterWithPattern(__cfPattern_1, {
+          {votes.filterWithPattern(__cfPattern_hcee6c5aa0bde, {
                 oid: oid
-            }).mapWithPattern(__cfPattern_2, {})}
+            }).mapWithPattern(__cfPattern_he9a21d43b468, {})}
         </div>
         {/* map to a bare non-JSX boolean: the comparison must be lifted */}
-        <div>{votes.mapWithPattern(__cfPattern_3, {
+        <div>{votes.mapWithPattern(__cfPattern_hfd78bb41cc8e, {
             oid: oid
         })}</div>
         {/* flatMap returning an array whose element is a comparison: must be lifted */}
-        <div>{votes.flatMapWithPattern(__cfPattern_4, {
+        <div>{votes.flatMapWithPattern(__cfPattern_hef1cb02287df, {
             oid: oid
         })}</div>
       </div>),
@@ -362,11 +362,18 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfPattern_1,
-    __cfPattern_2,
-    __cfLift_2,
-    __cfPattern_3,
-    __cfLift_3,
-    __cfPattern_4
+    __cfLift_hce3149656a01,
+    __cfPattern_hcee6c5aa0bde,
+    __cfPattern_he9a21d43b468,
+    __cfLift_hce3149656a01_2,
+    __cfPattern_hfd78bb41cc8e,
+    __cfLift_hce3149656a01_3,
+    __cfPattern_hef1cb02287df,
+    __cfLift_1: __cfLift_hce3149656a01,
+    __cfPattern_1: __cfPattern_hcee6c5aa0bde,
+    __cfPattern_2: __cfPattern_he9a21d43b468,
+    __cfLift_2: __cfLift_hce3149656a01_2,
+    __cfPattern_3: __cfPattern_hfd78bb41cc8e,
+    __cfLift_3: __cfLift_hce3149656a01_3,
+    __cfPattern_4: __cfPattern_hef1cb02287df
 });

--- a/packages/ts-transformers/test/fixtures/closures/cell-map-with-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/cell-map-with-captures.expected.jsx
@@ -15,7 +15,7 @@ interface State {
     values: number[];
     multiplier: number;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h15c6732687e5 = __cfHelpers.lift<{
     value: number;
     state: {
         multiplier: number;
@@ -40,10 +40,10 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h822e46241699 = __cfHelpers.pattern(__cf_pattern_input => {
     const value = __cf_pattern_input.key("element");
     const state = __cf_pattern_input.key("params", "state");
-    return (<span>{__cfLift_1({
+    return (<span>{__cfLift_h15c6732687e5({
         value: value,
         state: {
             multiplier: state.key("multiplier")
@@ -110,7 +110,7 @@ export default pattern((state) => {
     } as const satisfies __cfHelpers.JSONSchema).for("typedValues", true);
     return {
         [UI]: (<div>
-        {typedValues.mapWithPattern(__cfPattern_1, {
+        {typedValues.mapWithPattern(__cfPattern_h822e46241699, {
                 state: {
                     multiplier: state.key("multiplier")
                 }
@@ -165,6 +165,8 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfPattern_1
+    __cfLift_h15c6732687e5,
+    __cfPattern_h822e46241699,
+    __cfLift_1: __cfLift_h15c6732687e5,
+    __cfPattern_1: __cfPattern_h822e46241699
 });

--- a/packages/ts-transformers/test/fixtures/closures/cfreg-export-forms.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/cfreg-export-forms.expected.jsx
@@ -36,7 +36,7 @@ const reexportedLift = lift((x: number) => x - 1, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
 export { reexportedLift };
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h09d355f6a10b = __cfHelpers.pattern(__cf_pattern_input => {
     const x = __cf_pattern_input.key("element");
     return internalHelper(x).for("__patternResult", true);
 }, {
@@ -53,7 +53,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 export default pattern((__cf_pattern_input) => {
     const items = __cf_pattern_input.key("items");
     return ({
-        vs: items.mapWithPattern(__cfPattern_1, {}).for(["__patternResult", "vs"], true)
+        vs: items.mapWithPattern(__cfPattern_h09d355f6a10b, {}).for(["__patternResult", "vs"], true)
     });
 }, {
     type: "object",
@@ -83,5 +83,6 @@ function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
     internalHelper,
-    __cfPattern_1
+    __cfPattern_h09d355f6a10b,
+    __cfPattern_1: __cfPattern_h09d355f6a10b
 });

--- a/packages/ts-transformers/test/fixtures/closures/computed-all-literal-types.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-all-literal-types.expected.jsx
@@ -11,7 +11,7 @@ import { Writable, computed, pattern } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hffbfa1cebc06 = __cfHelpers.lift<{
     value: __cfHelpers.ReadonlyCell<number>;
     numLiteral: number;
     floatLiteral: number;
@@ -59,7 +59,7 @@ export default pattern(() => {
     const strLiteral = "hello";
     const boolLiteral = true;
     const floatLiteral = 3.14;
-    const result = __cfLift_1({
+    const result = __cfLift_hffbfa1cebc06({
         value: value,
         numLiteral: numLiteral,
         floatLiteral: floatLiteral,
@@ -74,5 +74,6 @@ export default pattern(() => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_hffbfa1cebc06,
+    __cfLift_1: __cfLift_hffbfa1cebc06
 });

--- a/packages/ts-transformers/test/fixtures/closures/computed-array-element-access.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-array-element-access.expected.jsx
@@ -11,7 +11,7 @@ import { Writable, computed, pattern } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h9b6aa85acc88 = __cfHelpers.lift<{
     value: __cfHelpers.ReadonlyCell<number>;
     factors: number[];
 }, number>(({ value, factors }) => value.get() * factors[1]!, {
@@ -41,7 +41,7 @@ export default pattern(() => {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema).for("value", true);
     const factors = [2, 3, 4];
-    const result = __cfLift_1({
+    const result = __cfLift_h9b6aa85acc88({
         value: value,
         factors: factors
     }).for("result", true);
@@ -53,5 +53,6 @@ export default pattern(() => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_h9b6aa85acc88,
+    __cfLift_1: __cfLift_h9b6aa85acc88
 });

--- a/packages/ts-transformers/test/fixtures/closures/computed-array-length.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-array-length.expected.jsx
@@ -25,7 +25,7 @@ interface Piece {
     id: string;
     name: string;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hbd624f7612fa = __cfHelpers.lift<{
     pieceRegistry: {
         length: number;
     };
@@ -46,7 +46,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_hf611cce52f3d = __cfHelpers.lift<{
     pieceRegistry: {
         length: number;
     };
@@ -67,7 +67,7 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hb25978ea4e46 = __cfHelpers.pattern(__cf_pattern_input => {
     const piece = __cf_pattern_input.key("element");
     return (<li>{piece.key("name")}</li>);
 }, {
@@ -149,15 +149,15 @@ export default pattern(() => {
         }
     } as const satisfies __cfHelpers.JSONSchema), pieceRegistry = __cf_destructure_1.key("result", "pieceRegistry").for("pieceRegistry", true);
     return {
-        [NAME]: __cfLift_1({ pieceRegistry: {
+        [NAME]: __cfLift_hbd624f7612fa({ pieceRegistry: {
                 length: pieceRegistry.key("length")
             } }),
         [UI]: (<div>
-        <span>Count: {__cfLift_2({ pieceRegistry: {
+        <span>Count: {__cfLift_hf611cce52f3d({ pieceRegistry: {
                 length: pieceRegistry.key("length")
             } })}</span>
         <ul>
-          {pieceRegistry.mapWithPattern(__cfPattern_1, {})}
+          {pieceRegistry.mapWithPattern(__cfPattern_hb25978ea4e46, {})}
         </ul>
       </div>),
     };
@@ -198,7 +198,10 @@ export default pattern(() => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2,
-    __cfPattern_1
+    __cfLift_hbd624f7612fa,
+    __cfLift_hf611cce52f3d,
+    __cfPattern_hb25978ea4e46,
+    __cfLift_1: __cfLift_hbd624f7612fa,
+    __cfLift_2: __cfLift_hf611cce52f3d,
+    __cfPattern_1: __cfPattern_hb25978ea4e46
 });

--- a/packages/ts-transformers/test/fixtures/closures/computed-basic-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-basic-capture.expected.jsx
@@ -11,7 +11,7 @@ import { Writable, computed, pattern } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hfe3b675f92e3 = __cfHelpers.lift<{
     value: __cfHelpers.ReadonlyCell<number>;
     multiplier: __cfHelpers.ReadonlyCell<number>;
 }, number>(({ value, multiplier }) => value.get() * multiplier.get(), {
@@ -41,7 +41,7 @@ export default pattern(() => {
     const multiplier = new Writable(2, {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema).for("multiplier", true);
-    const result = __cfLift_1({
+    const result = __cfLift_hfe3b675f92e3({
         value: value,
         multiplier: multiplier
     }).for("result", true);
@@ -53,5 +53,6 @@ export default pattern(() => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_hfe3b675f92e3,
+    __cfLift_1: __cfLift_hfe3b675f92e3
 });

--- a/packages/ts-transformers/test/fixtures/closures/computed-collision-property.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-collision-property.expected.jsx
@@ -11,7 +11,7 @@ import { Writable, computed, pattern } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h5e0071b7bb7b = __cfHelpers.lift<{
     multiplier: __cfHelpers.ReadonlyCell<number>;
 }, { multiplier: number; value: number; }>(({ multiplier }) => ({
     multiplier: multiplier.get(),
@@ -48,7 +48,7 @@ export default pattern(() => {
     } as const satisfies __cfHelpers.JSONSchema).for("multiplier", true);
     // The callback returns an object with a property named 'multiplier'.
     // Only the variable reference should resolve to the capture, NOT the property name.
-    const result = __cfLift_1({ multiplier: multiplier }).for("result", true);
+    const result = __cfLift_h5e0071b7bb7b({ multiplier: multiplier }).for("result", true);
     return result;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
@@ -66,5 +66,6 @@ export default pattern(() => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_h5e0071b7bb7b,
+    __cfLift_1: __cfLift_h5e0071b7bb7b
 });

--- a/packages/ts-transformers/test/fixtures/closures/computed-collision-shorthand.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-collision-shorthand.expected.jsx
@@ -11,7 +11,7 @@ import { Writable, computed, pattern } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h98de25b26c59 = __cfHelpers.lift<{
     multiplier: __cfHelpers.ReadonlyCell<number>;
 }, { value: number; data: { multiplier: __cfHelpers.Cell<number>; }; }>(({ multiplier }) => ({
     value: multiplier.get() * 3,
@@ -53,7 +53,7 @@ export default pattern(() => {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema).for("multiplier", true);
     // The callback uses shorthand property { multiplier } over the captured cell.
-    const result = __cfLift_1({ multiplier: multiplier }).for("result", true);
+    const result = __cfLift_h98de25b26c59({ multiplier: multiplier }).for("result", true);
     return result;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
@@ -78,5 +78,6 @@ export default pattern(() => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_h98de25b26c59,
+    __cfLift_1: __cfLift_h98de25b26c59
 });

--- a/packages/ts-transformers/test/fixtures/closures/computed-complex-expression.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-complex-expression.expected.jsx
@@ -11,7 +11,7 @@ import { Writable, computed, pattern } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hf338803faaec = __cfHelpers.lift<{
     a: __cfHelpers.ReadonlyCell<number>;
     b: __cfHelpers.ReadonlyCell<number>;
     c: __cfHelpers.ReadonlyCell<number>;
@@ -49,7 +49,7 @@ export default pattern(() => {
     const c = new Writable(5, {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema).for("c", true);
-    const result = __cfLift_1({
+    const result = __cfLift_hf338803faaec({
         a: a,
         b: b,
         c: c
@@ -62,5 +62,6 @@ export default pattern(() => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_hf338803faaec,
+    __cfLift_1: __cfLift_hf338803faaec
 });

--- a/packages/ts-transformers/test/fixtures/closures/computed-conditional-expression.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-conditional-expression.expected.jsx
@@ -11,7 +11,7 @@ import { Writable, computed, pattern } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h613504b1bcc8 = __cfHelpers.lift<{
     value: __cfHelpers.ReadonlyCell<number>;
     threshold: __cfHelpers.ReadonlyCell<number>;
     a: __cfHelpers.ReadonlyCell<number>;
@@ -57,7 +57,7 @@ export default pattern(() => {
     const b = new Writable(200, {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema).for("b", true);
-    const result = __cfLift_1({
+    const result = __cfLift_h613504b1bcc8({
         value: value,
         threshold: threshold,
         a: a,
@@ -71,5 +71,6 @@ export default pattern(() => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_h613504b1bcc8,
+    __cfLift_1: __cfLift_h613504b1bcc8
 });

--- a/packages/ts-transformers/test/fixtures/closures/computed-destructured-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-destructured-map.expected.jsx
@@ -22,7 +22,7 @@ interface Item {
     name: string;
     done: boolean;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_ha71d7bca9e61 = __cfHelpers.lift<{
     items: {
         done: boolean;
     }[];
@@ -75,7 +75,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_h67f7aabe675b = __cfHelpers.lift<{
     result: { tasks: Item[]; view: string; };
 }, __cfHelpers.JSXElement[]>(({ result }) => {
     const { tasks } = result;
@@ -149,10 +149,10 @@ const __cfLift_2 = __cfHelpers.lift<{
 //   This is a negative test for reactive .map() detection on derived values.
 export default pattern((__cf_pattern_input) => {
     const items = __cf_pattern_input.key("items");
-    const result = __cfLift_1({ items: items }).for("result", true);
+    const result = __cfLift_ha71d7bca9e61({ items: items }).for("result", true);
     return {
         [UI]: (<div>
-        {__cfLift_2({ result: result })}
+        {__cfLift_h67f7aabe675b({ result: result })}
       </div>),
     };
 }, {
@@ -214,6 +214,8 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2
+    __cfLift_ha71d7bca9e61,
+    __cfLift_h67f7aabe675b,
+    __cfLift_1: __cfLift_ha71d7bca9e61,
+    __cfLift_2: __cfLift_h67f7aabe675b
 });

--- a/packages/ts-transformers/test/fixtures/closures/computed-destructured-param.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-destructured-param.expected.jsx
@@ -15,7 +15,7 @@ interface Point {
     x: number;
     y: number;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h7011fbc61833 = __cfHelpers.lift<{
     point: __cfHelpers.ReadonlyCell<Point>;
     multiplier: __cfHelpers.ReadonlyCell<number>;
 }, number>(({ point, multiplier }) => {
@@ -72,7 +72,7 @@ export default pattern(() => {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema).for("multiplier", true);
     // Destructuring requires .get() first since the captured cell is not unwrapped
-    const result = __cfLift_1({
+    const result = __cfLift_h7011fbc61833({
         point: point,
         multiplier: multiplier
     }).for("result", true);
@@ -84,5 +84,6 @@ export default pattern(() => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_h7011fbc61833,
+    __cfLift_1: __cfLift_h7011fbc61833
 });

--- a/packages/ts-transformers/test/fixtures/closures/computed-filter-map-chain.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-filter-map-chain.expected.jsx
@@ -15,7 +15,7 @@ interface Preference {
     ingredient: string;
     preference: "liked" | "disliked";
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h83138ab16fd1 = __cfHelpers.lift<{
     state: {
         preferences: {
             ingredient: string;
@@ -64,7 +64,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 //   .filter() and .map() are standard Array methods — they must remain
 //   untransformed. This is a negative test for the reactive method detection.
 export default pattern((state) => {
-    const liked = __cfLift_1({ state: {
+    const liked = __cfLift_h83138ab16fd1({ state: {
             preferences: state.key("preferences")
         } }).for("liked", true);
     return { liked };
@@ -109,5 +109,6 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_h83138ab16fd1,
+    __cfLift_1: __cfLift_h83138ab16fd1
 });

--- a/packages/ts-transformers/test/fixtures/closures/computed-in-computed-property-access.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-in-computed-property-access.expected.jsx
@@ -11,9 +11,9 @@ import { computed, pattern } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift(() => ({ bar: 1 }), false, undefined, { completeSchedulerScopeSummary: true });
-const __cfLift_2 = __cfHelpers.lift(() => {
-    const foo = __cfLift_1().for("foo", true);
+const __cfLift_hb5b929fdfa70 = __cfHelpers.lift(() => ({ bar: 1 }), false, undefined, { completeSchedulerScopeSummary: true });
+const __cfLift_h5f15451fda8c = __cfHelpers.lift(() => {
+    const foo = __cfLift_hb5b929fdfa70().for("foo", true);
     return foo.key("bar");
 }, false, undefined, { completeSchedulerScopeSummary: true });
 // FIXTURE: computed-in-computed-property-access
@@ -24,7 +24,7 @@ const __cfLift_2 = __cfHelpers.lift(() => {
 //   inside a lift-applied callback need .key() rewriting even though they are not
 //   captured from an outer scope.
 export default pattern(() => {
-    const outer = __cfLift_2().for("outer", true);
+    const outer = __cfLift_h5f15451fda8c().for("outer", true);
     return outer;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
@@ -33,6 +33,8 @@ export default pattern(() => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2
+    __cfLift_hb5b929fdfa70,
+    __cfLift_h5f15451fda8c,
+    __cfLift_1: __cfLift_hb5b929fdfa70,
+    __cfLift_2: __cfLift_h5f15451fda8c
 });

--- a/packages/ts-transformers/test/fixtures/closures/computed-in-computed-scoped-no-false-rewrite.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-in-computed-scoped-no-false-rewrite.expected.jsx
@@ -12,11 +12,11 @@ const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
 const config = __cfHelpers.__cf_data({ bar: "module-level" });
-const __cfLift_1 = __cfHelpers.lift(() => ({ bar: 1 }), false, undefined, { completeSchedulerScopeSummary: true });
-const __cfLift_2 = __cfHelpers.lift(() => {
+const __cfLift_hb5b929fdfa70 = __cfHelpers.lift(() => ({ bar: 1 }), false, undefined, { completeSchedulerScopeSummary: true });
+const __cfLift_h986341a2479f = __cfHelpers.lift(() => {
     const condition = 1 > 0;
     if (condition) {
-        const config = __cfLift_1().for("config", true);
+        const config = __cfLift_hb5b929fdfa70().for("config", true);
         return config.key("bar");
     }
     return config.bar;
@@ -29,7 +29,7 @@ const __cfLift_2 = __cfHelpers.lift(() => {
 // Context: The pre-scan collects opaque roots by name; it must not leak
 //   across lexical scopes and incorrectly rewrite unrelated same-named accesses.
 export default pattern(() => {
-    const outer = __cfLift_2().for("outer", true);
+    const outer = __cfLift_h986341a2479f().for("outer", true);
     return outer;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: ["number", "string"]
@@ -38,6 +38,8 @@ export default pattern(() => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2
+    __cfLift_hb5b929fdfa70,
+    __cfLift_h986341a2479f,
+    __cfLift_1: __cfLift_hb5b929fdfa70,
+    __cfLift_2: __cfLift_h986341a2479f
 });

--- a/packages/ts-transformers/test/fixtures/closures/computed-inside-map-with-method-chain.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-inside-map-with-method-chain.expected.jsx
@@ -24,7 +24,7 @@ interface Item {
 interface State {
     items: Item[];
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h98f519c27816 = __cfHelpers.lift<{
     item: {
         subItems: SubItem[];
     };
@@ -68,13 +68,13 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hae21efa457c8 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return (<div>
             <h2>{item.key("title")}</h2>
             <p>
               Active items:{" "}
-              {__cfLift_1({ item: {
+              {__cfLift_h98f519c27816({ item: {
                 subItems: item.key("subItems")
             } })}
             </p>
@@ -156,7 +156,7 @@ export default pattern((state) => {
                 - inside the computed, item.subItems unwraps to a plain JS array
                 - .filter() returns a plain JS array
                 - Plain arrays don't have .mapWithPattern() */}
-        {state.key("items").mapWithPattern(__cfPattern_1, {})}
+        {state.key("items").mapWithPattern(__cfPattern_hae21efa457c8, {})}
       </div>),
     };
 }, {
@@ -239,6 +239,8 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfPattern_1
+    __cfLift_h98f519c27816,
+    __cfPattern_hae21efa457c8,
+    __cfLift_1: __cfLift_h98f519c27816,
+    __cfPattern_1: __cfPattern_hae21efa457c8
 });

--- a/packages/ts-transformers/test/fixtures/closures/computed-jsx-local-function.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-jsx-local-function.expected.jsx
@@ -11,7 +11,7 @@ import { computed, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h6ba434de0349 = __cfHelpers.lift<{
     count: number;
 }, __cfHelpers.JSXElement>(({ count }) => {
     const format = (value: number) => `Count: ${value}`;
@@ -53,7 +53,7 @@ export default pattern((__cf_pattern_input) => {
     const count = __cf_pattern_input.key("count");
     return {
         [UI]: (<div>
-        {__cfLift_1({ count: count })}
+        {__cfLift_h6ba434de0349({ count: count })}
       </div>),
     };
 }, {
@@ -98,5 +98,6 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_h6ba434de0349,
+    __cfLift_1: __cfLift_h6ba434de0349
 });

--- a/packages/ts-transformers/test/fixtures/closures/computed-local-var-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-local-var-map.expected.jsx
@@ -22,7 +22,7 @@ interface Item {
     name: string;
     price: number;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hd71ecf3d0bc1 = __cfHelpers.lift<{
     items: {
         price: number;
     }[];
@@ -63,7 +63,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_h2af3b9ccad92 = __cfHelpers.lift<{
     filtered: {
         name: string;
     }[];
@@ -122,10 +122,10 @@ const __cfLift_2 = __cfHelpers.lift<{
 //   This is a negative test for reactive .map() detection on local aliases.
 export default pattern((__cf_pattern_input) => {
     const items = __cf_pattern_input.key("items");
-    const filtered = __cfLift_1({ items: items }).for("filtered", true);
+    const filtered = __cfLift_hd71ecf3d0bc1({ items: items }).for("filtered", true);
     return {
         [UI]: (<div>
-        {__cfLift_2({ filtered: filtered })}
+        {__cfLift_h2af3b9ccad92({ filtered: filtered })}
       </div>),
     };
 }, {
@@ -187,6 +187,8 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2
+    __cfLift_hd71ecf3d0bc1,
+    __cfLift_h2af3b9ccad92,
+    __cfLift_1: __cfLift_hd71ecf3d0bc1,
+    __cfLift_2: __cfLift_h2af3b9ccad92
 });

--- a/packages/ts-transformers/test/fixtures/closures/computed-local-variable.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-local-variable.expected.jsx
@@ -11,7 +11,7 @@ import { Writable, computed, pattern } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h30a391b2a778 = __cfHelpers.lift<{
     a: __cfHelpers.ReadonlyCell<number>;
     b: __cfHelpers.ReadonlyCell<number>;
     c: __cfHelpers.ReadonlyCell<number>;
@@ -52,7 +52,7 @@ export default pattern(() => {
     const c = new Writable(30, {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema).for("c", true);
-    const result = __cfLift_1({
+    const result = __cfLift_h30a391b2a778({
         a: a,
         b: b,
         c: c
@@ -65,5 +65,6 @@ export default pattern(() => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_h30a391b2a778,
+    __cfLift_1: __cfLift_h30a391b2a778
 });

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-call-arg-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-call-arg-conditional.expected.jsx
@@ -18,7 +18,7 @@ interface Item {
 interface State {
     items: Item[];
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h4f0a5fd4ef76 = __cfHelpers.lift<{
     state: {
         items: Item[];
     };
@@ -67,7 +67,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_h0a84b210883c = __cfHelpers.lift<{
     row: {
         done: boolean;
     };
@@ -88,9 +88,9 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hcfc422cb3eff = __cfHelpers.pattern(__cf_pattern_input => {
     const row = __cf_pattern_input.key("element");
-    const label = __cfLift_2({ row: {
+    const label = __cfLift_h0a84b210883c({ row: {
             done: row.key("done")
         } }).for("label", true);
     return <span>{label}</span>;
@@ -141,12 +141,12 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 //   const label = identity(row.done ? "Done" : "Pending")
 //   → const label = lift(({ row }) => identity(row.done ? "Done" : "Pending"))(...)
 export default pattern((state) => {
-    const rows = __cfLift_1({ state: {
+    const rows = __cfLift_h4f0a5fd4ef76({ state: {
             items: state.key("items")
         } }).for("rows", true);
     return {
         [UI]: (<div>
-        {rows.mapWithPattern(__cfPattern_1, {})}
+        {rows.mapWithPattern(__cfPattern_hcfc422cb3eff, {})}
       </div>),
     };
 }, {
@@ -205,7 +205,10 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2,
-    __cfPattern_1
+    __cfLift_h4f0a5fd4ef76,
+    __cfLift_h0a84b210883c,
+    __cfPattern_hcfc422cb3eff,
+    __cfLift_1: __cfLift_h4f0a5fd4ef76,
+    __cfLift_2: __cfLift_h0a84b210883c,
+    __cfPattern_1: __cfPattern_hcfc422cb3eff
 });

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-call-arg-logical-and.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-call-arg-logical-and.expected.jsx
@@ -18,7 +18,7 @@ interface Item {
 interface State {
     items: Item[];
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h4f0a5fd4ef76 = __cfHelpers.lift<{
     state: {
         items: Item[];
     };
@@ -67,7 +67,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_hc047ab75db01 = __cfHelpers.lift<{
     row: {
         done: boolean;
     };
@@ -88,9 +88,9 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "unknown"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h92e5b1249432 = __cfHelpers.pattern(__cf_pattern_input => {
     const row = __cf_pattern_input.key("element");
-    const label = __cfLift_2({ row: {
+    const label = __cfLift_hc047ab75db01({ row: {
             done: row.key("done")
         } }).for("label", true);
     return <span>{label}</span>;
@@ -141,12 +141,12 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 //   const label = identity(row.done && "Done")
 //   → const label = lift(({ row }) => identity(row.done && "Done"))(...)
 export default pattern((state) => {
-    const rows = __cfLift_1({ state: {
+    const rows = __cfLift_h4f0a5fd4ef76({ state: {
             items: state.key("items")
         } }).for("rows", true);
     return {
         [UI]: (<div>
-        {rows.mapWithPattern(__cfPattern_1, {})}
+        {rows.mapWithPattern(__cfPattern_h92e5b1249432, {})}
       </div>),
     };
 }, {
@@ -205,7 +205,10 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2,
-    __cfPattern_1
+    __cfLift_h4f0a5fd4ef76,
+    __cfLift_hc047ab75db01,
+    __cfPattern_h92e5b1249432,
+    __cfLift_1: __cfLift_h4f0a5fd4ef76,
+    __cfLift_2: __cfLift_hc047ab75db01,
+    __cfPattern_1: __cfPattern_h92e5b1249432
 });

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-call-root-containers.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-call-root-containers.expected.jsx
@@ -18,7 +18,7 @@ interface Item {
 interface State {
     items: Item[];
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h4f0a5fd4ef76 = __cfHelpers.lift<{
     state: {
         items: Item[];
     };
@@ -67,7 +67,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_h0a84b210883c = __cfHelpers.lift<{
     row: {
         done: boolean;
     };
@@ -88,7 +88,7 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_3 = __cfHelpers.lift<{
+const __cfLift_h0a84b210883c_2 = __cfHelpers.lift<{
     row: {
         done: boolean;
     };
@@ -109,13 +109,13 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hf2ad469e50c6 = __cfHelpers.pattern(__cf_pattern_input => {
     const row = __cf_pattern_input.key("element");
     return ({
-        value: __cfLift_2({ row: {
+        value: __cfLift_h0a84b210883c({ row: {
                 done: row.key("done")
             } }).for(["__patternResult", "value"], true),
-        list: [__cfLift_3({ row: {
+        list: [__cfLift_h0a84b210883c_2({ row: {
                     done: row.key("done")
                 } }).for(["__patternResult", "list", 0], true)]
     });
@@ -153,7 +153,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     },
     required: ["value", "list"]
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_4 = __cfHelpers.lift<{
+const __cfLift_h0a84b210883c_3 = __cfHelpers.lift<{
     row: {
         done: boolean;
     };
@@ -174,9 +174,9 @@ const __cfLift_4 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hf3688bb5295a = __cfHelpers.pattern(__cf_pattern_input => {
     const row = __cf_pattern_input.key("element");
-    return __cfLift_4({ row: {
+    return __cfLift_h0a84b210883c_3({ row: {
             done: row.key("done")
         } }).for("__patternResult", true);
 }, {
@@ -212,11 +212,11 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
 //   row => identity(row.done ? "Done" : "Pending")
 //   → row => lift(({ row }) => identity(row.done ? "Done" : "Pending"))(...)
 export default pattern((state) => {
-    const rows = __cfLift_1({ state: {
+    const rows = __cfLift_h4f0a5fd4ef76({ state: {
             items: state.key("items")
         } }).for("rows", true);
-    const views = rows.mapWithPattern(__cfPattern_1, {}).for("views", true);
-    const labels = rows.mapWithPattern(__cfPattern_2, {}).for("labels", true);
+    const views = rows.mapWithPattern(__cfPattern_hf2ad469e50c6, {}).for("views", true);
+    const labels = rows.mapWithPattern(__cfPattern_hf3688bb5295a, {}).for("labels", true);
     return { views, labels };
 }, {
     type: "object",
@@ -274,10 +274,16 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2,
-    __cfLift_3,
-    __cfPattern_1,
-    __cfLift_4,
-    __cfPattern_2
+    __cfLift_h4f0a5fd4ef76,
+    __cfLift_h0a84b210883c,
+    __cfLift_h0a84b210883c_2,
+    __cfPattern_hf2ad469e50c6,
+    __cfLift_h0a84b210883c_3,
+    __cfPattern_hf3688bb5295a,
+    __cfLift_1: __cfLift_h4f0a5fd4ef76,
+    __cfLift_2: __cfLift_h0a84b210883c,
+    __cfLift_3: __cfLift_h0a84b210883c_2,
+    __cfPattern_1: __cfPattern_hf2ad469e50c6,
+    __cfLift_4: __cfLift_h0a84b210883c_3,
+    __cfPattern_2: __cfPattern_hf3688bb5295a
 });

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-direct-return-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-direct-return-conditional.expected.jsx
@@ -17,7 +17,7 @@ interface Item {
 interface State {
     items: Item[];
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h4f0a5fd4ef76 = __cfHelpers.lift<{
     state: {
         items: Item[];
     };
@@ -66,7 +66,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h9bfd0481d4b5 = __cfHelpers.pattern(__cf_pattern_input => {
     const row = __cf_pattern_input.key("element");
     return __cfHelpers.ifElse({
         type: "boolean"
@@ -106,12 +106,12 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 // Context: the conditional is the callback's root return expression, not nested
 //   inside returned JSX, which currently slips past the JSX-local rewrite pass.
 export default pattern((state) => {
-    const rows = __cfLift_1({ state: {
+    const rows = __cfLift_h4f0a5fd4ef76({ state: {
             items: state.key("items")
         } }).for("rows", true);
     return {
         [UI]: (<div>
-        {rows.mapWithPattern(__cfPattern_1, {})}
+        {rows.mapWithPattern(__cfPattern_h9bfd0481d4b5, {})}
       </div>),
     };
 }, {
@@ -170,6 +170,8 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfPattern_1
+    __cfLift_h4f0a5fd4ef76,
+    __cfPattern_h9bfd0481d4b5,
+    __cfLift_1: __cfLift_h4f0a5fd4ef76,
+    __cfPattern_1: __cfPattern_h9bfd0481d4b5
 });

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-in-derived-branch.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-in-derived-branch.expected.jsx
@@ -19,7 +19,7 @@ interface PatternInput {
     people?: Cell<Default<Person[], [
     ]>>;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h316fa572d593 = __cfHelpers.lift<{
     people: __cfHelpers.ReadonlyCell<Person[]>;
 }, { name: string; rank: number; isFirst: boolean; }[]>(({ people }) => [...people.get()]
     .sort((a, b) => a.rank - b.rank)
@@ -67,7 +67,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         required: ["name", "rank", "isFirst"]
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_h3a9c50d3f4cf = __cfHelpers.lift<{
     people: __cfHelpers.ReadonlyCell<unknown[]>;
 }, number>(({ people }) => people.get().length, {
     type: "object",
@@ -96,8 +96,8 @@ export default pattern((__cf_pattern_input) => {
     const showAdmin = new Writable(false, {
         type: "boolean"
     } as const satisfies __cfHelpers.JSONSchema).for("showAdmin", true);
-    const adminData = __cfLift_1({ people: people }).for("adminData", true);
-    const count = __cfLift_2({ people: people }).for("count", true);
+    const adminData = __cfLift_h316fa572d593({ people: people }).for("adminData", true);
+    const count = __cfLift_h3a9c50d3f4cf({ people: people }).for("count", true);
     return {
         [UI]: (<div>
         {__cfHelpers.ifElse({
@@ -191,6 +191,8 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2
+    __cfLift_h316fa572d593,
+    __cfLift_h3a9c50d3f4cf,
+    __cfLift_1: __cfLift_h316fa572d593,
+    __cfLift_2: __cfLift_h3a9c50d3f4cf
 });

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-in-ternary-branch.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-in-ternary-branch.expected.jsx
@@ -19,7 +19,7 @@ interface PatternInput {
     people?: Cell<Default<Person[], [
     ]>>;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h316fa572d593 = __cfHelpers.lift<{
     people: __cfHelpers.ReadonlyCell<Person[]>;
 }, { name: string; rank: number; isFirst: boolean; }[]>(({ people }) => [...people.get()]
     .sort((a, b) => a.rank - b.rank)
@@ -67,7 +67,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         required: ["name", "rank", "isFirst"]
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_h3a9c50d3f4cf = __cfHelpers.lift<{
     people: __cfHelpers.ReadonlyCell<unknown[]>;
 }, number>(({ people }) => people.get().length, {
     type: "object",
@@ -84,7 +84,7 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h9d910eebd9d0 = __cfHelpers.pattern(__cf_pattern_input => {
     const person = __cf_pattern_input.key("element");
     return (<span>{person.key("name")}</span>);
 }, {
@@ -130,7 +130,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_3 = __cfHelpers.lift<{
+const __cfLift_h18f03ff428f4 = __cfHelpers.lift<{
     count: number;
 }, string>(({ count }) => count + " people", {
     type: "object",
@@ -143,7 +143,7 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h278aca9fcc08 = __cfHelpers.pattern(__cf_pattern_input => {
     const entry = __cf_pattern_input.key("element");
     return (<li>
                     {__cfHelpers.ifElse({
@@ -211,11 +211,11 @@ export default pattern((__cf_pattern_input) => {
     const showAdmin = new Writable(false, {
         type: "boolean"
     } as const satisfies __cfHelpers.JSONSchema).for("showAdmin", true);
-    const adminData = __cfLift_1({ people: people }).for("adminData", true);
-    const count = __cfLift_2({ people: people }).for("count", true);
+    const adminData = __cfLift_h316fa572d593({ people: people }).for("adminData", true);
+    const count = __cfLift_h3a9c50d3f4cf({ people: people }).for("count", true);
     return {
         [UI]: (<div>
-        {people.mapWithPattern(__cfPattern_1, {})}
+        {people.mapWithPattern(__cfPattern_h9d910eebd9d0, {})}
         {__cfHelpers.ifElse({
             type: "boolean",
             asCell: ["cell"]
@@ -234,9 +234,9 @@ export default pattern((__cf_pattern_input) => {
                     properties: {}
                 }]
         } as const satisfies __cfHelpers.JSONSchema, showAdmin, <div>
-              <span>{__cfLift_3({ count: count })}</span>
+              <span>{__cfLift_h18f03ff428f4({ count: count })}</span>
               <ul>
-                {adminData.mapWithPattern(__cfPattern_2, {})}
+                {adminData.mapWithPattern(__cfPattern_h278aca9fcc08, {})}
               </ul>
             </div>, null)}
       </div>),
@@ -301,9 +301,14 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2,
-    __cfPattern_1,
-    __cfLift_3,
-    __cfPattern_2
+    __cfLift_h316fa572d593,
+    __cfLift_h3a9c50d3f4cf,
+    __cfPattern_h9d910eebd9d0,
+    __cfLift_h18f03ff428f4,
+    __cfPattern_h278aca9fcc08,
+    __cfLift_1: __cfLift_h316fa572d593,
+    __cfLift_2: __cfLift_h3a9c50d3f4cf,
+    __cfPattern_1: __cfPattern_h9d910eebd9d0,
+    __cfLift_3: __cfLift_h18f03ff428f4,
+    __cfPattern_2: __cfPattern_h278aca9fcc08
 });

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-input-no-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-input-no-captures.expected.jsx
@@ -24,7 +24,7 @@ interface Item {
     id: number;
     value: string;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h2f22449ca56e = __cfHelpers.lift<{
     items: __cfHelpers.ReadonlyCell<Item[]>;
 }, number>(({ items }) => items.get().map((item) => item.value).length, {
     type: "object",
@@ -62,7 +62,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 export default pattern((__cf_pattern_input) => {
     const items = __cf_pattern_input.key("items");
     // items is a captured cell; .get() yields a plain array, so .map() stays plain.
-    const count = __cfLift_1({ items: items }).for("count", true);
+    const count = __cfLift_h2f22449ca56e({ items: items }).for("count", true);
     return { count };
 }, {
     type: "object",
@@ -103,5 +103,6 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_h2f22449ca56e,
+    __cfLift_1: __cfLift_h2f22449ca56e
 });

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-local-array-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-local-array-conditional.expected.jsx
@@ -17,7 +17,7 @@ interface Item {
 interface State {
     items: Item[];
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h4f0a5fd4ef76 = __cfHelpers.lift<{
     state: {
         items: Item[];
     };
@@ -66,7 +66,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_hfae6d64a1363 = __cfHelpers.lift<{
     view: string[];
 }, string | undefined>(({ view }) => view[0], {
     type: "object",
@@ -82,7 +82,7 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["string", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hba25357e0165 = __cfHelpers.pattern(__cf_pattern_input => {
     const row = __cf_pattern_input.key("element");
     const view = [__cfHelpers.ifElse({
             type: "boolean"
@@ -93,7 +93,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         } as const satisfies __cfHelpers.JSONSchema, {
             "enum": ["Done", "Pending"]
         } as const satisfies __cfHelpers.JSONSchema, row.key("done"), "Done", "Pending").for(["view", 0], true)];
-    return <span>{__cfLift_2({ view: view })}</span>;
+    return <span>{__cfLift_hfae6d64a1363({ view: view })}</span>;
 }, {
     type: "object",
     properties: {
@@ -140,12 +140,12 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 //   const view = [row.done ? "Done" : "Pending"]
 //   → const view = [ifElse(row.done, "Done", "Pending")]
 export default pattern((state) => {
-    const rows = __cfLift_1({ state: {
+    const rows = __cfLift_h4f0a5fd4ef76({ state: {
             items: state.key("items")
         } }).for("rows", true);
     return {
         [UI]: (<div>
-        {rows.mapWithPattern(__cfPattern_1, {})}
+        {rows.mapWithPattern(__cfPattern_hba25357e0165, {})}
       </div>),
     };
 }, {
@@ -204,7 +204,10 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2,
-    __cfPattern_1
+    __cfLift_h4f0a5fd4ef76,
+    __cfLift_hfae6d64a1363,
+    __cfPattern_hba25357e0165,
+    __cfLift_1: __cfLift_h4f0a5fd4ef76,
+    __cfLift_2: __cfLift_hfae6d64a1363,
+    __cfPattern_1: __cfPattern_hba25357e0165
 });

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-local-call-root.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-local-call-root.expected.jsx
@@ -18,7 +18,7 @@ interface Item {
 interface State {
     items: Item[];
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h4f0a5fd4ef76 = __cfHelpers.lift<{
     state: {
         items: Item[];
     };
@@ -67,7 +67,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_h0a84b210883c = __cfHelpers.lift<{
     row: {
         done: boolean;
     };
@@ -88,9 +88,9 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hb3105b696468 = __cfHelpers.pattern(__cf_pattern_input => {
     const row = __cf_pattern_input.key("element");
-    const label = __cfLift_2({ row: {
+    const label = __cfLift_h0a84b210883c({ row: {
             done: row.key("done")
         } }).for("label", true);
     return label;
@@ -123,10 +123,10 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 //   const label = identity(row.done ? "Done" : "Pending")
 //   → const label = lift(({ row }) => identity(row.done ? "Done" : "Pending"))(...)
 export default pattern((state) => {
-    const rows = __cfLift_1({ state: {
+    const rows = __cfLift_h4f0a5fd4ef76({ state: {
             items: state.key("items")
         } }).for("rows", true);
-    const labels = rows.mapWithPattern(__cfPattern_1, {}).for("labels", true);
+    const labels = rows.mapWithPattern(__cfPattern_hb3105b696468, {}).for("labels", true);
     return { labels };
 }, {
     type: "object",
@@ -166,7 +166,10 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2,
-    __cfPattern_1
+    __cfLift_h4f0a5fd4ef76,
+    __cfLift_h0a84b210883c,
+    __cfPattern_hb3105b696468,
+    __cfLift_1: __cfLift_h4f0a5fd4ef76,
+    __cfLift_2: __cfLift_h0a84b210883c,
+    __cfPattern_1: __cfPattern_hb3105b696468
 });

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-local-object-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-local-object-conditional.expected.jsx
@@ -17,7 +17,7 @@ interface Item {
 interface State {
     items: Item[];
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h4f0a5fd4ef76 = __cfHelpers.lift<{
     state: {
         items: Item[];
     };
@@ -66,7 +66,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h1070c2639a19 = __cfHelpers.pattern(__cf_pattern_input => {
     const row = __cf_pattern_input.key("element");
     const view = { status: __cfHelpers.ifElse({
             type: "boolean"
@@ -124,12 +124,12 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 //   const view = { status: row.done ? "Done" : "Pending" }
 //   → const view = { status: ifElse(row.done, "Done", "Pending") }
 export default pattern((state) => {
-    const rows = __cfLift_1({ state: {
+    const rows = __cfLift_h4f0a5fd4ef76({ state: {
             items: state.key("items")
         } }).for("rows", true);
     return {
         [UI]: (<div>
-        {rows.mapWithPattern(__cfPattern_1, {})}
+        {rows.mapWithPattern(__cfPattern_h1070c2639a19, {})}
       </div>),
     };
 }, {
@@ -188,6 +188,8 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfPattern_1
+    __cfLift_h4f0a5fd4ef76,
+    __cfPattern_h1070c2639a19,
+    __cfLift_1: __cfLift_h4f0a5fd4ef76,
+    __cfPattern_1: __cfPattern_h1070c2639a19
 });

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-local-object-logical-or.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-local-object-logical-or.expected.jsx
@@ -17,7 +17,7 @@ interface Item {
 interface State {
     items: Item[];
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h4f0a5fd4ef76 = __cfHelpers.lift<{
     state: {
         items: Item[];
     };
@@ -66,7 +66,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h2f95c1bbd07f = __cfHelpers.pattern(__cf_pattern_input => {
     const row = __cf_pattern_input.key("element");
     const view = { status: __cfHelpers.unless({
             type: "boolean"
@@ -122,12 +122,12 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 //   const view = { status: row.done || "Pending" }
 //   → const view = { status: unless(row.done, "Pending") }
 export default pattern((state) => {
-    const rows = __cfLift_1({ state: {
+    const rows = __cfLift_h4f0a5fd4ef76({ state: {
             items: state.key("items")
         } }).for("rows", true);
     return {
         [UI]: (<div>
-        {rows.mapWithPattern(__cfPattern_1, {})}
+        {rows.mapWithPattern(__cfPattern_h2f95c1bbd07f, {})}
       </div>),
     };
 }, {
@@ -186,6 +186,8 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfPattern_1
+    __cfLift_h4f0a5fd4ef76,
+    __cfPattern_h2f95c1bbd07f,
+    __cfLift_1: __cfLift_h4f0a5fd4ef76,
+    __cfPattern_1: __cfPattern_h2f95c1bbd07f
 });

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-pre-resolved-return-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-pre-resolved-return-conditional.expected.jsx
@@ -17,7 +17,7 @@ interface Item {
 interface State {
     items: Item[];
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h9254f3c226f5 = __cfHelpers.lift<{
     state: {
         items: {
             done: boolean;
@@ -58,7 +58,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         required: ["done"]
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h96e461a101f5 = __cfHelpers.pattern(__cf_pattern_input => {
     const row = __cf_pattern_input.key("element");
     return __cfHelpers.ifElse({
         type: "boolean"
@@ -93,12 +93,12 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 //   rows.map((row) => row.done ? "Done" : "Pending")
 //   → rows.mapWithPattern(pattern(... return ifElse(row.done, "Done", "Pending")))
 export default pattern((state) => {
-    const rows = __cfLift_1({ state: {
+    const rows = __cfLift_h9254f3c226f5({ state: {
             items: state.key("items")
         } }).for("rows", true);
     return {
         [UI]: (<div>
-        {rows.mapWithPattern(__cfPattern_1, {})}
+        {rows.mapWithPattern(__cfPattern_h96e461a101f5, {})}
       </div>),
     };
 }, {
@@ -157,6 +157,8 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfPattern_1
+    __cfLift_h9254f3c226f5,
+    __cfPattern_h96e461a101f5,
+    __cfLift_1: __cfLift_h9254f3c226f5,
+    __cfPattern_1: __cfPattern_h96e461a101f5
 });

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-union-return.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-union-return.expected.jsx
@@ -23,7 +23,7 @@ interface Message {
 interface State {
     messages: Message[];
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h6cdcb512d0c4 = __cfHelpers.lift<{
     state: {
         messages: Message[];
     };
@@ -116,7 +116,7 @@ export default pattern((state) => {
     // The callback becomes synthetic during transformation, which previously
     // caused type inference to fail, resulting in a 'true' schema instead of
     // the correct union type schema.
-    const latestMessage = __cfLift_1({ state: {
+    const latestMessage = __cfLift_h6cdcb512d0c4({ state: {
             messages: state.key("messages")
         } }).for("latestMessage", true);
     return {
@@ -205,5 +205,6 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_h6cdcb512d0c4,
+    __cfLift_1: __cfLift_h6cdcb512d0c4
 });

--- a/packages/ts-transformers/test/fixtures/closures/computed-method-call-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-method-call-capture.expected.jsx
@@ -16,7 +16,7 @@ interface State {
         value: number;
     };
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hdea8c73a15e8 = __cfHelpers.lift<{
     value: __cfHelpers.ReadonlyCell<number>;
     state: {
         counter: {
@@ -59,7 +59,7 @@ export default pattern((state: State) => {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema).for("value", true);
     // Capture a deep property path on the pattern input
-    const result = __cfLift_1({
+    const result = __cfLift_hdea8c73a15e8({
         value: value,
         state: {
             counter: {
@@ -89,5 +89,6 @@ export default pattern((state: State) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_hdea8c73a15e8,
+    __cfLift_1: __cfLift_hdea8c73a15e8
 });

--- a/packages/ts-transformers/test/fixtures/closures/computed-multiple-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-multiple-captures.expected.jsx
@@ -11,7 +11,7 @@ import { Writable, computed, pattern } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h30a391b2a778 = __cfHelpers.lift<{
     a: __cfHelpers.ReadonlyCell<number>;
     b: __cfHelpers.ReadonlyCell<number>;
     c: __cfHelpers.ReadonlyCell<number>;
@@ -52,7 +52,7 @@ export default pattern(() => {
     const c = new Writable(30, {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema).for("c", true);
-    const result = __cfLift_1({
+    const result = __cfLift_h30a391b2a778({
         a: a,
         b: b,
         c: c
@@ -65,5 +65,6 @@ export default pattern(() => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_h30a391b2a778,
+    __cfLift_1: __cfLift_h30a391b2a778
 });

--- a/packages/ts-transformers/test/fixtures/closures/computed-nested-callback.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-nested-callback.expected.jsx
@@ -11,7 +11,7 @@ import { Writable, computed, pattern } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h8ca9cd70b32b = __cfHelpers.lift<{
     numbers: __cfHelpers.ReadonlyCell<number[]>;
     multiplier: __cfHelpers.ReadonlyCell<number>;
 }, number[]>(({ numbers, multiplier }) => numbers.get().map((n) => n * multiplier.get()), {
@@ -52,7 +52,7 @@ export default pattern(() => {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema).for("multiplier", true);
     // Nested callback - the inner array map runs on the unwrapped plain array
-    const result = __cfLift_1({
+    const result = __cfLift_h8ca9cd70b32b({
         numbers: numbers,
         multiplier: multiplier
     }).for("result", true);
@@ -67,5 +67,6 @@ export default pattern(() => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_h8ca9cd70b32b,
+    __cfLift_1: __cfLift_h8ca9cd70b32b
 });

--- a/packages/ts-transformers/test/fixtures/closures/computed-nested-property.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-nested-property.expected.jsx
@@ -11,7 +11,7 @@ import { Writable, computed, pattern } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h184f7de2d05a = __cfHelpers.lift<{
     counter: __cfHelpers.ReadonlyCell<{ count: number; }>;
 }, number>(({ counter }) => {
     const current = counter.get();
@@ -48,7 +48,7 @@ export default pattern(() => {
         },
         required: ["count"]
     } as const satisfies __cfHelpers.JSONSchema).for("counter", true);
-    const doubled = __cfLift_1({ counter: counter }).for("doubled", true);
+    const doubled = __cfLift_h184f7de2d05a({ counter: counter }).for("doubled", true);
     return doubled;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
@@ -57,5 +57,6 @@ export default pattern(() => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_h184f7de2d05a,
+    __cfLift_1: __cfLift_h184f7de2d05a
 });

--- a/packages/ts-transformers/test/fixtures/closures/computed-nested.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-nested.expected.jsx
@@ -11,7 +11,7 @@ import { Writable, computed, pattern } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h9ede6275b830 = __cfHelpers.lift<{
     a: __cfHelpers.ReadonlyCell<number>;
     b: __cfHelpers.ReadonlyCell<number>;
 }, number>(({ a, b }) => a.get() + b.get(), {
@@ -30,7 +30,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_h2c4416d8dec5 = __cfHelpers.lift<{
     sum: number;
 }, number>(({ sum }) => sum * 2, {
     type: "object",
@@ -56,11 +56,11 @@ export default pattern(() => {
     const b = new Writable(20, {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema).for("b", true);
-    const sum = __cfLift_1({
+    const sum = __cfLift_h9ede6275b830({
         a: a,
         b: b
     }).for("sum", true);
-    const doubled = __cfLift_2({ sum: sum }).for("doubled", true);
+    const doubled = __cfLift_h2c4416d8dec5({ sum: sum }).for("doubled", true);
     return doubled;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
@@ -69,6 +69,8 @@ export default pattern(() => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2
+    __cfLift_h9ede6275b830,
+    __cfLift_h2c4416d8dec5,
+    __cfLift_1: __cfLift_h9ede6275b830,
+    __cfLift_2: __cfLift_h2c4416d8dec5
 });

--- a/packages/ts-transformers/test/fixtures/closures/computed-no-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-no-captures.expected.jsx
@@ -11,12 +11,12 @@ import { computed, pattern } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift(() => 42, false, undefined, { completeSchedulerScopeSummary: true });
+const __cfLift_h480d04a41b50 = __cfHelpers.lift(() => 42, false, undefined, { completeSchedulerScopeSummary: true });
 // FIXTURE: computed-no-captures
 // Verifies: computed(() => expr) with no external captures is transformed to
 // lift(false, fn)() with no input object.
 export default pattern(() => {
-    const result = __cfLift_1().for("result", true);
+    const result = __cfLift_h480d04a41b50().for("result", true);
     return result;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
@@ -25,5 +25,6 @@ export default pattern(() => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_h480d04a41b50,
+    __cfLift_1: __cfLift_h480d04a41b50
 });

--- a/packages/ts-transformers/test/fixtures/closures/computed-nullable-optional-chain.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-nullable-optional-chain.expected.jsx
@@ -17,11 +17,11 @@ type Question = {
     category: string;
     priority: number;
 };
-const __cfLift_1 = __cfHelpers.lift((): Question | null => {
+const __cfLift_h9573153a224e = __cfHelpers.lift((): Question | null => {
     // In real code this would filter and return first match, or null
     return null;
 }, false, undefined, { completeSchedulerScopeSummary: true });
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_h5a6cb2bb4b3b = __cfHelpers.lift<{
     topQuestion: {
         question: string;
     } | null;
@@ -46,7 +46,7 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_3 = __cfHelpers.lift<{
+const __cfLift_he60ccd567888 = __cfHelpers.lift<{
     topQuestion: Question | null;
 }, string>(({ topQuestion }) => topQuestion === null ? "" : topQuestion.question, {
     type: "object",
@@ -80,7 +80,7 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_4 = __cfHelpers.lift<{
+const __cfLift_h815ffe88b108 = __cfHelpers.lift<{
     topQuestion: {
         category: string;
     } | null;
@@ -105,7 +105,7 @@ const __cfLift_4 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_5 = __cfHelpers.lift<{
+const __cfLift_h343c1dce0059 = __cfHelpers.lift<{
     topQuestion: Question | null;
 }, string>(({ topQuestion }) => topQuestion === null ? "" : topQuestion.category, {
     type: "object",
@@ -148,22 +148,22 @@ const __cfLift_5 = __cfHelpers.lift<{
 //   with asOpaque: true for the topQuestion capture.
 export default pattern((_) => {
     // This computed can return null - simulates finding a question from a list
-    const topQuestion = __cfLift_1().for("topQuestion", true);
+    const topQuestion = __cfLift_h9573153a224e().for("topQuestion", true);
     return {
         [NAME]: "Computed Nullable Optional Chain",
         [UI]: (<div>
         {/* BUG CASE: Optional chaining loses nullability in schema inference */}
         {/* The input schema should have topQuestion as anyOf [Question, null] */}
         {/* but instead infers topQuestion as object with required "question" */}
-        <p>Optional chaining: {__cfLift_2({ topQuestion: topQuestion })}</p>
+        <p>Optional chaining: {__cfLift_h5a6cb2bb4b3b({ topQuestion: topQuestion })}</p>
 
         {/* WORKAROUND: Explicit null check preserves nullability */}
         {/* This correctly generates anyOf [Question, null] in the schema */}
-        <p>Explicit check: {__cfLift_3({ topQuestion: topQuestion })}</p>
+        <p>Explicit check: {__cfLift_he60ccd567888({ topQuestion: topQuestion })}</p>
 
         {/* Same issue with category field */}
-        <span>Category (buggy): {__cfLift_4({ topQuestion: topQuestion })}</span>
-        <span>Category (works): {__cfLift_5({ topQuestion: topQuestion })}</span>
+        <span>Category (buggy): {__cfLift_h815ffe88b108({ topQuestion: topQuestion })}</span>
+        <span>Category (works): {__cfLift_h343c1dce0059({ topQuestion: topQuestion })}</span>
       </div>),
     };
 }, false as const satisfies __cfHelpers.JSONSchema, {
@@ -203,9 +203,14 @@ export default pattern((_) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2,
-    __cfLift_3,
-    __cfLift_4,
-    __cfLift_5
+    __cfLift_h9573153a224e,
+    __cfLift_h5a6cb2bb4b3b,
+    __cfLift_he60ccd567888,
+    __cfLift_h815ffe88b108,
+    __cfLift_h343c1dce0059,
+    __cfLift_1: __cfLift_h9573153a224e,
+    __cfLift_2: __cfLift_h5a6cb2bb4b3b,
+    __cfLift_3: __cfLift_he60ccd567888,
+    __cfLift_4: __cfLift_h815ffe88b108,
+    __cfLift_5: __cfLift_h343c1dce0059
 });

--- a/packages/ts-transformers/test/fixtures/closures/computed-optional-chaining.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-optional-chaining.expected.jsx
@@ -11,7 +11,7 @@ import { Writable, computed, pattern } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h0be697ef8abb = __cfHelpers.lift<{
     value: __cfHelpers.ReadonlyCell<number>;
     config: __cfHelpers.ReadonlyCell<{
         multiplier?: number;
@@ -63,7 +63,7 @@ export default pattern(() => {
     const value = new Writable(10, {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema).for("value", true);
-    const result = __cfLift_1({
+    const result = __cfLift_h0be697ef8abb({
         value: value,
         config: config
     }).for("result", true);
@@ -75,5 +75,6 @@ export default pattern(() => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_h0be697ef8abb,
+    __cfLift_1: __cfLift_h0be697ef8abb
 });

--- a/packages/ts-transformers/test/fixtures/closures/computed-pattern-param-mixed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-pattern-param-mixed.expected.jsx
@@ -11,7 +11,7 @@ import { Writable, computed, pattern } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hc92c45f76622 = __cfHelpers.lift<{
     value: __cfHelpers.ReadonlyCell<number>;
     config: {
         base: number;
@@ -67,7 +67,7 @@ export default pattern((config: {
     const threshold = new Writable(15, {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema).for("threshold", true); // cell local
-    const result = __cfLift_1({
+    const result = __cfLift_hc92c45f76622({
         value: value,
         config: {
             base: config.key("base"),
@@ -95,5 +95,6 @@ export default pattern((config: {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_hc92c45f76622,
+    __cfLift_1: __cfLift_hc92c45f76622
 });

--- a/packages/ts-transformers/test/fixtures/closures/computed-pattern-param.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-pattern-param.expected.jsx
@@ -11,7 +11,7 @@ import { Writable, computed, pattern } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h5796a7d89ccd = __cfHelpers.lift<{
     value: __cfHelpers.ReadonlyCell<number>;
     config: {
         multiplier: number;
@@ -49,7 +49,7 @@ export default pattern((config: {
     const value = new Writable(10, {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema).for("value", true);
-    const result = __cfLift_1({
+    const result = __cfLift_h5796a7d89ccd({
         value: value,
         config: {
             multiplier: config.key("multiplier")
@@ -71,5 +71,6 @@ export default pattern((config: {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_h5796a7d89ccd,
+    __cfLift_1: __cfLift_h5796a7d89ccd
 });

--- a/packages/ts-transformers/test/fixtures/closures/computed-pattern-typed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-pattern-typed.expected.jsx
@@ -11,7 +11,7 @@ import { Writable, computed, pattern } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h4a2148b1839d = __cfHelpers.lift<{
     value: __cfHelpers.ReadonlyCell<number>;
     multiplier: number;
 }, number>(({ value, multiplier }) => value.get() * multiplier, {
@@ -40,7 +40,7 @@ export default pattern((__cf_pattern_input) => {
     const value = new Writable(10, {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema).for("value", true);
-    const result = __cfLift_1({
+    const result = __cfLift_h4a2148b1839d({
         value: value,
         multiplier: multiplier
     }).for("result", true);
@@ -60,5 +60,6 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_h4a2148b1839d,
+    __cfLift_1: __cfLift_h4a2148b1839d
 });

--- a/packages/ts-transformers/test/fixtures/closures/computed-property-access-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-property-access-map.expected.jsx
@@ -22,7 +22,7 @@ interface Item {
     name: string;
     done: boolean;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_ha71d7bca9e61 = __cfHelpers.lift<{
     items: {
         done: boolean;
     }[];
@@ -75,7 +75,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_h61e4f72fe7bb = __cfHelpers.lift<{
     result: {
         tasks: {
             name: string;
@@ -142,10 +142,10 @@ const __cfLift_2 = __cfHelpers.lift<{
 //   Note the captures use result.key("tasks") to extract the needed sub-property.
 export default pattern((__cf_pattern_input) => {
     const items = __cf_pattern_input.key("items");
-    const result = __cfLift_1({ items: items }).for("result", true);
+    const result = __cfLift_ha71d7bca9e61({ items: items }).for("result", true);
     return {
         [UI]: (<div>
-        {__cfLift_2({ result: {
+        {__cfLift_h61e4f72fe7bb({ result: {
                     tasks: result.key("tasks")
                 } })}
       </div>),
@@ -209,6 +209,8 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2
+    __cfLift_ha71d7bca9e61,
+    __cfLift_h61e4f72fe7bb,
+    __cfLift_1: __cfLift_ha71d7bca9e61,
+    __cfLift_2: __cfLift_h61e4f72fe7bb
 });

--- a/packages/ts-transformers/test/fixtures/closures/computed-property-result.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-property-result.expected.jsx
@@ -11,7 +11,7 @@ import { Writable, computed, pattern } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h25d077160003 = __cfHelpers.lift<{
     value: __cfHelpers.ReadonlyCell<number>;
     config: { multiplier: number; divisor: number; };
     key: string;
@@ -52,7 +52,7 @@ export default pattern(() => {
     } as const satisfies __cfHelpers.JSONSchema).for("value", true);
     const config = { multiplier: 2, divisor: 5 };
     const key = "multiplier";
-    const result = __cfLift_1({
+    const result = __cfLift_h25d077160003({
         value: value,
         config: config,
         key: key
@@ -65,5 +65,6 @@ export default pattern(() => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_h25d077160003,
+    __cfLift_1: __cfLift_h25d077160003
 });

--- a/packages/ts-transformers/test/fixtures/closures/computed-reserved-names.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-reserved-names.expected.jsx
@@ -11,7 +11,7 @@ import { Writable, computed, pattern } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hd167cdcacdb8 = __cfHelpers.lift<{
     value: __cfHelpers.ReadonlyCell<number>;
     __cf_reserved: __cfHelpers.ReadonlyCell<number>;
 }, number>(({ value, __cf_reserved }) => value.get() * __cf_reserved.get(), {
@@ -41,7 +41,7 @@ export default pattern(() => {
     const __cf_reserved = new Writable(2, {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema);
-    const result = __cfLift_1({
+    const result = __cfLift_hd167cdcacdb8({
         value: value,
         __cf_reserved: __cf_reserved
     }).for("result", true);
@@ -53,5 +53,6 @@ export default pattern(() => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_hd167cdcacdb8,
+    __cfLift_1: __cfLift_hd167cdcacdb8
 });

--- a/packages/ts-transformers/test/fixtures/closures/computed-result-in-derive-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-result-in-derive-captures.expected.jsx
@@ -22,7 +22,7 @@ interface State {
         done: boolean;
     }>;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hb356a7f2b97f = __cfHelpers.lift<{
     state: {
         items: {
             done: boolean;
@@ -66,7 +66,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     },
     required: ["count", "total"]
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_h17e3cd177afb = __cfHelpers.lift<{
     stats: {
         count: number;
         total: number;
@@ -99,12 +99,12 @@ const __cfLift_2 = __cfHelpers.lift<{
 //   transform rewrites them to stats.key("count") and stats.key("total") in
 //   the captures object because stats is a Reactive.
 export default pattern((state) => {
-    const stats = __cfLift_1({ state: {
+    const stats = __cfLift_hb356a7f2b97f({ state: {
             items: state.key("items")
         } }).for("stats", true);
     return {
         [UI]: (<div>
-        {__cfLift_2({ stats: {
+        {__cfLift_h17e3cd177afb({ stats: {
                 count: stats.key("count"),
                 total: stats.key("total")
             } })}
@@ -164,6 +164,8 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2
+    __cfLift_hb356a7f2b97f,
+    __cfLift_h17e3cd177afb,
+    __cfLift_1: __cfLift_hb356a7f2b97f,
+    __cfLift_2: __cfLift_h17e3cd177afb
 });

--- a/packages/ts-transformers/test/fixtures/closures/computed-result-property-in-return.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-result-property-in-return.expected.jsx
@@ -20,7 +20,7 @@ const __cfAmdHooks = undefined;
 interface State {
     items: string[];
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hb27e9bd529db = __cfHelpers.lift<{
     state: {
         items: string[];
     };
@@ -44,7 +44,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_h8cc0d578f778 = __cfHelpers.lift<{
     summary: {
         length: number;
     };
@@ -72,12 +72,12 @@ const __cfLift_2 = __cfHelpers.lift<{
 //   When the second computed() accesses summary.length, the capture is rewritten
 //   to summary.key("length") because summary is a Reactive, not a plain value.
 export default pattern((state) => {
-    const summary = __cfLift_1({ state: {
+    const summary = __cfLift_hb27e9bd529db({ state: {
             items: state.key("items")
         } }).for("summary", true);
     return {
         summary,
-        charCount: __cfLift_2({ summary: {
+        charCount: __cfLift_h8cc0d578f778({ summary: {
                 length: summary.key("length")
             } }).for(["__patternResult", "charCount"], true)
     };
@@ -108,6 +108,8 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2
+    __cfLift_hb27e9bd529db,
+    __cfLift_h8cc0d578f778,
+    __cfLift_1: __cfLift_hb27e9bd529db,
+    __cfLift_2: __cfLift_h8cc0d578f778
 });

--- a/packages/ts-transformers/test/fixtures/closures/computed-template-literal-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-template-literal-capture.expected.jsx
@@ -11,7 +11,7 @@ import { computed, pattern } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h6053b8146eb3 = __cfHelpers.lift<{
     token: string;
 }, string>(({ token }) => `http://api.example.com?token=${token}`, {
     type: "object",
@@ -24,7 +24,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_hdba1116776e0 = __cfHelpers.lift<{
     token: string;
 }, { headers: { Authorization: string; }; }>(({ token }) => ({
     headers: { Authorization: `Bearer ${token}` },
@@ -59,8 +59,8 @@ export default pattern((__cf_pattern_input: {
     token: string;
 }) => {
     const token = __cf_pattern_input.key("token");
-    const url = __cfLift_1({ token: token }).for("url", true);
-    const options = __cfLift_2({ token: token }).for("options", true);
+    const url = __cfLift_h6053b8146eb3({ token: token }).for("url", true);
+    const options = __cfLift_hdba1116776e0({ token: token }).for("options", true);
     return { url, options };
 }, {
     type: "object",
@@ -98,6 +98,8 @@ export default pattern((__cf_pattern_input: {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2
+    __cfLift_h6053b8146eb3,
+    __cfLift_hdba1116776e0,
+    __cfLift_1: __cfLift_h6053b8146eb3,
+    __cfLift_2: __cfLift_hdba1116776e0
 });

--- a/packages/ts-transformers/test/fixtures/closures/computed-template-literal.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-template-literal.expected.jsx
@@ -11,7 +11,7 @@ import { Writable, computed, pattern } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_he58ebaec399e = __cfHelpers.lift<{
     prefix: __cfHelpers.ReadonlyCell<string>;
     value: __cfHelpers.ReadonlyCell<number>;
 }, string>(({ prefix, value }) => `${prefix.get()}${value.get()}`, {
@@ -40,7 +40,7 @@ export default pattern(() => {
     const prefix = new Writable("Value: ", {
         type: "string"
     } as const satisfies __cfHelpers.JSONSchema).for("prefix", true);
-    const result = __cfLift_1({
+    const result = __cfLift_he58ebaec399e({
         prefix: prefix,
         value: value
     }).for("result", true);
@@ -52,5 +52,6 @@ export default pattern(() => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_he58ebaec399e,
+    __cfLift_1: __cfLift_he58ebaec399e
 });

--- a/packages/ts-transformers/test/fixtures/closures/computed-type-assertion.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-type-assertion.expected.jsx
@@ -11,7 +11,7 @@ import { Writable, computed, pattern } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h0244550363a9 = __cfHelpers.lift<{
     value: __cfHelpers.ReadonlyCell<number>;
     multiplier: __cfHelpers.ReadonlyCell<number>;
 }, number>(({ value, multiplier }) => (value.get() * multiplier.get()) as number, {
@@ -41,7 +41,7 @@ export default pattern(() => {
     const multiplier = new Writable(2, {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema).for("multiplier", true);
-    const result = __cfLift_1({
+    const result = __cfLift_h0244550363a9({
         value: value,
         multiplier: multiplier
     }).for("result", true);
@@ -53,5 +53,6 @@ export default pattern(() => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_h0244550363a9,
+    __cfLift_1: __cfLift_h0244550363a9
 });

--- a/packages/ts-transformers/test/fixtures/closures/computed-union-undefined.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-union-undefined.expected.jsx
@@ -15,7 +15,7 @@ interface Config {
     required: number;
     unionUndefined: number | undefined;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_ha8f7d286d8ce = __cfHelpers.lift<{
     value: __cfHelpers.ReadonlyCell<number>;
     config: {
         required: number;
@@ -53,7 +53,7 @@ export default pattern((config: Config) => {
     const value = new Writable(10, {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema).for("value", true);
-    const result = __cfLift_1({
+    const result = __cfLift_ha8f7d286d8ce({
         value: value,
         config: {
             required: config.key("required"),
@@ -79,5 +79,6 @@ export default pattern((config: Config) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_ha8f7d286d8ce,
+    __cfLift_1: __cfLift_ha8f7d286d8ce
 });

--- a/packages/ts-transformers/test/fixtures/closures/computed-with-closed-over-cell-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-with-closed-over-cell-map.expected.jsx
@@ -11,7 +11,7 @@ import { Writable, computed, pattern } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h0d543629e9e2 = __cfHelpers.lift<{
     n: number;
     multiplier: __cfHelpers.Cell<number>;
 }, number>(({ n, multiplier }) => n * multiplier.get(), {
@@ -29,10 +29,10 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h8e7cbfd4f5fa = __cfHelpers.pattern(__cf_pattern_input => {
     const n = __cf_pattern_input.key("element");
     const multiplier = __cf_pattern_input.key("params", "multiplier");
-    return __cfLift_1({
+    return __cfLift_h0d543629e9e2({
         n: n,
         multiplier: multiplier
     }).for("__patternResult", true);
@@ -57,10 +57,10 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_h76dbf7cc5b9e = __cfHelpers.lift<{
     numbers: __cfHelpers.ReadonlyCell<number[]>;
     multiplier: __cfHelpers.ReadonlyCell<number>;
-}, number[]>(({ numbers, multiplier }) => numbers.mapWithPattern(__cfPattern_1, {
+}, number[]>(({ numbers, multiplier }) => numbers.mapWithPattern(__cfPattern_h8e7cbfd4f5fa, {
     multiplier: multiplier
 }), {
     type: "object",
@@ -104,7 +104,7 @@ export default pattern(() => {
     // The computed gets transformed to the lift-applied form lift(() => numbers.map(...))({})
     // Inside a lift-applied computation, .map on a closed-over Cell should STILL be transformed to mapWithPattern
     // because Cells need the pattern-based mapping even when unwrapped
-    const doubled = __cfLift_2({
+    const doubled = __cfLift_h76dbf7cc5b9e({
         numbers: numbers,
         multiplier: multiplier
     }).for("doubled", true);
@@ -119,7 +119,10 @@ export default pattern(() => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfPattern_1,
-    __cfLift_2
+    __cfLift_h0d543629e9e2,
+    __cfPattern_h8e7cbfd4f5fa,
+    __cfLift_h76dbf7cc5b9e,
+    __cfLift_1: __cfLift_h0d543629e9e2,
+    __cfPattern_1: __cfPattern_h8e7cbfd4f5fa,
+    __cfLift_2: __cfLift_h76dbf7cc5b9e
 });

--- a/packages/ts-transformers/test/fixtures/closures/computed-write-capability-materializer.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-write-capability-materializer.expected.jsx
@@ -14,7 +14,7 @@ const __cfAmdHooks = undefined;
 interface Item {
     title: string;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h69ac9161ab4d = __cfHelpers.lift<{
     items: __cfHelpers.ReadonlyCell<Item[]>;
     processed: __cfHelpers.WriteonlyCell<string[]>;
 }, void>(({ processed, items }) => {
@@ -85,7 +85,7 @@ export default pattern(() => {
             type: "string"
         }
     } as const satisfies __cfHelpers.JSONSchema).for("processed", true);
-    __cfLift_1({
+    __cfLift_h69ac9161ab4d({
         processed: processed,
         items: items
     });
@@ -125,5 +125,6 @@ export default pattern(() => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_h69ac9161ab4d,
+    __cfLift_1: __cfLift_h69ac9161ab4d
 });

--- a/packages/ts-transformers/test/fixtures/closures/fetch-json-result-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/fetch-json-result-map.expected.jsx
@@ -14,7 +14,7 @@ const __cfAmdHooks = undefined;
 interface Item {
     name: string;
 }
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hfe105d59f1b1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return <span>{item.key("name")}</span>;
 }, {
@@ -80,7 +80,7 @@ export default pattern(() => {
         result: []
     }), items = __cf_destructure_1.key("result").for("items", true);
     return {
-        [UI]: <div>{items.mapWithPattern(__cfPattern_1, {})}</div>,
+        [UI]: <div>{items.mapWithPattern(__cfPattern_hfe105d59f1b1, {})}</div>,
     };
 }, {
     type: "object",
@@ -120,5 +120,6 @@ export default pattern(() => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfPattern_1
+    __cfPattern_hfe105d59f1b1,
+    __cfPattern_1: __cfPattern_hfe105d59f1b1
 });

--- a/packages/ts-transformers/test/fixtures/closures/filter-basic.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/filter-basic.expected.jsx
@@ -19,7 +19,7 @@ interface Item {
 interface State {
     items: Item[];
 }
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h8fc1d53b74e8 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return item.key("active");
 }, {
@@ -50,7 +50,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h664e0cd4f21f = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return (<div>Item #{item.key("id")}: {item.key("name")}</div>);
 }, {
@@ -108,7 +108,7 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
 export default pattern((state) => {
     return {
         [UI]: (<div>
-        {state.key("items").filterWithPattern(__cfPattern_1, {}).mapWithPattern(__cfPattern_2, {})}
+        {state.key("items").filterWithPattern(__cfPattern_h8fc1d53b74e8, {}).mapWithPattern(__cfPattern_h664e0cd4f21f, {})}
       </div>),
     };
 }, {
@@ -173,6 +173,8 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfPattern_1,
-    __cfPattern_2
+    __cfPattern_h8fc1d53b74e8,
+    __cfPattern_h664e0cd4f21f,
+    __cfPattern_1: __cfPattern_h8fc1d53b74e8,
+    __cfPattern_2: __cfPattern_h664e0cd4f21f
 });

--- a/packages/ts-transformers/test/fixtures/closures/filter-flatmap-fallback-chain.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/filter-flatmap-fallback-chain.expected.jsx
@@ -15,7 +15,7 @@ interface Item {
     id: string;
     tags?: string[];
 }
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hfe30f5cc84bb = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return item.key("id");
 }, {
@@ -46,7 +46,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h935d88238b37 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return item.key("tags") ?? [];
 }, {
@@ -80,7 +80,7 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_he09e68784816 = __cfHelpers.pattern(__cf_pattern_input => {
     const tag = __cf_pattern_input.key("element");
     return <span>{tag}</span>;
 }, {
@@ -121,7 +121,7 @@ export default pattern((__cf_pattern_input) => {
     const items = __cf_pattern_input.key("items");
     return {
         [UI]: (<div>
-        {(items ?? []).filterWithPattern(__cfPattern_1, {}).flatMapWithPattern(__cfPattern_2, {}).mapWithPattern(__cfPattern_3, {})}
+        {(items ?? []).filterWithPattern(__cfPattern_hfe30f5cc84bb, {}).flatMapWithPattern(__cfPattern_h935d88238b37, {}).mapWithPattern(__cfPattern_he09e68784816, {})}
       </div>),
     };
 }, {
@@ -185,7 +185,10 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfPattern_1,
-    __cfPattern_2,
-    __cfPattern_3
+    __cfPattern_hfe30f5cc84bb,
+    __cfPattern_h935d88238b37,
+    __cfPattern_he09e68784816,
+    __cfPattern_1: __cfPattern_hfe30f5cc84bb,
+    __cfPattern_2: __cfPattern_h935d88238b37,
+    __cfPattern_3: __cfPattern_he09e68784816
 });

--- a/packages/ts-transformers/test/fixtures/closures/filter-flatmap-plain-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/filter-flatmap-plain-captures.expected.jsx
@@ -11,7 +11,7 @@ import { pattern } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h050dea176069 = __cfHelpers.lift<{
     item: {
         label: string;
     };
@@ -36,10 +36,10 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h4561f8309545 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const suffix = __cf_pattern_input.params.suffix;
-    return __cfLift_1({
+    return __cfLift_h050dea176069({
         item: {
             label: item.key("label")
         },
@@ -77,7 +77,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_hf9754c685f57 = __cfHelpers.lift<{
     item: {
         tags: string[];
     };
@@ -108,7 +108,7 @@ const __cfLift_2 = __cfHelpers.lift<{
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_he33e19088b5c = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const prefix = __cf_pattern_input.params.prefix;
     return __cfHelpers.ifElse({
@@ -126,7 +126,7 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
         items: {
             type: "string"
         }
-    } as const satisfies __cfHelpers.JSONSchema, item.key("tags", "length"), __cfLift_2({
+    } as const satisfies __cfHelpers.JSONSchema, item.key("tags", "length"), __cfLift_hf9754c685f57({
         item: {
             tags: item.key("tags")
         },
@@ -179,9 +179,9 @@ export default pattern((__cf_pattern_input) => {
     const suffix = "!";
     const prefix = "#";
     return {
-        labels: items.filterWithPattern(__cfPattern_1, {
+        labels: items.filterWithPattern(__cfPattern_h4561f8309545, {
             suffix: suffix
-        }).flatMapWithPattern(__cfPattern_2, {
+        }).flatMapWithPattern(__cfPattern_he33e19088b5c, {
             prefix: prefix
         }).for(["__patternResult", "labels"], true)
     };
@@ -224,8 +224,12 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfPattern_1,
-    __cfLift_2,
-    __cfPattern_2
+    __cfLift_h050dea176069,
+    __cfPattern_h4561f8309545,
+    __cfLift_hf9754c685f57,
+    __cfPattern_he33e19088b5c,
+    __cfLift_1: __cfLift_h050dea176069,
+    __cfPattern_1: __cfPattern_h4561f8309545,
+    __cfLift_2: __cfLift_hf9754c685f57,
+    __cfPattern_2: __cfPattern_he33e19088b5c
 });

--- a/packages/ts-transformers/test/fixtures/closures/filter-map-chain.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/filter-map-chain.expected.jsx
@@ -20,7 +20,7 @@ interface State {
     items: Item[];
     taxRate: number;
 }
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h8fc1d53b74e8 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return item.key("active");
 }, {
@@ -51,7 +51,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hb3e82ef6e306 = __cfHelpers.lift<{
     item: {
         price: number;
     };
@@ -84,11 +84,11 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h17b8a5d28ba0 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const state = __cf_pattern_input.key("params", "state");
     return (<div>
-              Total: {__cfLift_1({
+              Total: {__cfLift_hb3e82ef6e306({
         item: {
             price: item.key("price")
         },
@@ -168,7 +168,7 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
 export default pattern((state) => {
     return {
         [UI]: (<div>
-        {state.key("items").filterWithPattern(__cfPattern_1, {}).mapWithPattern(__cfPattern_2, {
+        {state.key("items").filterWithPattern(__cfPattern_h8fc1d53b74e8, {}).mapWithPattern(__cfPattern_h17b8a5d28ba0, {
                 state: {
                     taxRate: state.key("taxRate")
                 }
@@ -240,7 +240,10 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfPattern_1,
-    __cfLift_1,
-    __cfPattern_2
+    __cfPattern_h8fc1d53b74e8,
+    __cfLift_hb3e82ef6e306,
+    __cfPattern_h17b8a5d28ba0,
+    __cfPattern_1: __cfPattern_h8fc1d53b74e8,
+    __cfLift_1: __cfLift_hb3e82ef6e306,
+    __cfPattern_2: __cfPattern_h17b8a5d28ba0
 });

--- a/packages/ts-transformers/test/fixtures/closures/flatmap-basic.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/flatmap-basic.expected.jsx
@@ -18,7 +18,7 @@ interface Item {
 interface State {
     items: Item[];
 }
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h6c4c7c07d827 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return (<div>Item #{item.key("id")}</div>);
 }, {
@@ -74,7 +74,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 export default pattern((state) => {
     return {
         [UI]: (<div>
-        {state.key("items").flatMapWithPattern(__cfPattern_1, {})}
+        {state.key("items").flatMapWithPattern(__cfPattern_h6c4c7c07d827, {})}
       </div>),
     };
 }, {
@@ -139,5 +139,6 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfPattern_1
+    __cfPattern_h6c4c7c07d827,
+    __cfPattern_1: __cfPattern_h6c4c7c07d827
 });

--- a/packages/ts-transformers/test/fixtures/closures/handler-basic.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/handler-basic.expected.jsx
@@ -14,7 +14,7 @@ const __cfAmdHooks = undefined;
 interface State {
     counter: Cell<number>;
 }
-const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+const __cfHandler_hb2a3cc5d0b7a = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
         state: {
@@ -35,7 +35,7 @@ const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
 //   onClick={() => state.counter.set(...)} → onClick={handler(false, { state: { counter: asCell } }, (_, { state }) => ...)({ state: { counter } })}
 export default pattern((state) => {
     return {
-        [UI]: (<button type="button" onClick={__cfHandler_1({
+        [UI]: (<button type="button" onClick={__cfHandler_hb2a3cc5d0b7a({
             state: {
                 counter: state.key("counter")
             }
@@ -86,5 +86,6 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfHandler_1
+    __cfHandler_hb2a3cc5d0b7a,
+    __cfHandler_1: __cfHandler_hb2a3cc5d0b7a
 });

--- a/packages/ts-transformers/test/fixtures/closures/handler-computed-key.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/handler-computed-key.expected.jsx
@@ -20,7 +20,7 @@ function nextKey(): string {
     return `key-${counter}`;
 }
 __cfHardenFn(nextKey);
-const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+const __cfHandler_haae222600d44 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
         recordMap: {
@@ -41,7 +41,7 @@ const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
 export default pattern((state) => {
     const recordMap = state.key("records");
     return {
-        [UI]: (<button type="button" onClick={__cfHandler_1({
+        [UI]: (<button type="button" onClick={__cfHandler_haae222600d44({
             recordMap: recordMap
         })}>
         Step
@@ -94,5 +94,6 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfHandler_1
+    __cfHandler_haae222600d44,
+    __cfHandler_1: __cfHandler_haae222600d44
 });

--- a/packages/ts-transformers/test/fixtures/closures/handler-destructured-params.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/handler-destructured-params.expected.jsx
@@ -15,7 +15,7 @@ interface State {
     selectedValue: Cell<string>;
     lastItems: Cell<string>;
 }
-const __cfHandler_1 = __cfHelpers.handler({
+const __cfHandler_hc321cd91405f = __cfHelpers.handler({
     type: "object",
     properties: {
         detail: {
@@ -72,7 +72,7 @@ export default pattern((state) => {
         [UI]: (<cf-select $value={state.key("selectedValue")} items={[
                 { label: "Option A", value: "a" },
                 { label: "Option B", value: "b" },
-            ]} oncf-change={__cfHandler_1({
+            ]} oncf-change={__cfHandler_hc321cd91405f({
             state: {
                 selectedValue: state.key("selectedValue"),
                 lastItems: state.key("lastItems")
@@ -126,5 +126,6 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfHandler_1
+    __cfHandler_hc321cd91405f,
+    __cfHandler_1: __cfHandler_hc321cd91405f
 });

--- a/packages/ts-transformers/test/fixtures/closures/handler-event-param.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/handler-event-param.expected.jsx
@@ -15,7 +15,7 @@ interface State {
     selectedValue: Cell<string>;
     changeCount: Cell<number>;
 }
-const __cfHandler_1 = __cfHelpers.handler({
+const __cfHandler_h13b3f007f700 = __cfHelpers.handler({
     type: "object",
     properties: {
         detail: {
@@ -59,7 +59,7 @@ export default pattern((state) => {
         [UI]: (<cf-select $value={state.key("selectedValue")} items={[
                 { label: "Option A", value: "a" },
                 { label: "Option B", value: "b" },
-            ]} oncf-change={__cfHandler_1({
+            ]} oncf-change={__cfHandler_h13b3f007f700({
             state: {
                 selectedValue: state.key("selectedValue"),
                 changeCount: state.key("changeCount")
@@ -113,5 +113,6 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfHandler_1
+    __cfHandler_h13b3f007f700,
+    __cfHandler_1: __cfHandler_h13b3f007f700
 });

--- a/packages/ts-transformers/test/fixtures/closures/handler-nested-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/handler-nested-map.expected.jsx
@@ -17,7 +17,7 @@ interface State {
     }>;
     multiplier: number;
 }
-const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+const __cfHandler_h078ba45a8e11 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
         state: {
@@ -53,7 +53,7 @@ const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
 // Context: .map() on a plain array inside a handler remains a normal JS .map(), not a reactive transform
 export default pattern((state) => {
     return {
-        [UI]: (<button type="button" onClick={__cfHandler_1({
+        [UI]: (<button type="button" onClick={__cfHandler_h078ba45a8e11({
             state: {
                 items: state.key("items"),
                 multiplier: state.key("multiplier")
@@ -116,5 +116,6 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfHandler_1
+    __cfHandler_h078ba45a8e11,
+    __cfHandler_1: __cfHandler_h078ba45a8e11
 });

--- a/packages/ts-transformers/test/fixtures/closures/handler-no-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/handler-no-captures.expected.jsx
@@ -14,7 +14,7 @@ const __cfAmdHooks = undefined;
 interface State {
     counter: Cell<number>;
 }
-const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+const __cfHandler_he9fc23f93dc0 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {}
 } as const satisfies __cfHelpers.JSONSchema, (__cf_handler_event, __cf_handler_params) => console.log("hi"));
@@ -24,7 +24,7 @@ const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
 // Context: No closed-over state; capture object is empty
 export default pattern((_state) => {
     return {
-        [UI]: (<button type="button" onClick={__cfHandler_1({})}>
+        [UI]: (<button type="button" onClick={__cfHandler_he9fc23f93dc0({})}>
         Log
       </button>),
     };
@@ -71,5 +71,6 @@ export default pattern((_state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfHandler_1
+    __cfHandler_he9fc23f93dc0,
+    __cfHandler_1: __cfHandler_he9fc23f93dc0
 });

--- a/packages/ts-transformers/test/fixtures/closures/handler-reserved-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/handler-reserved-capture.expected.jsx
@@ -14,7 +14,7 @@ const __cfAmdHooks = undefined;
 interface State {
     label: string;
 }
-const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+const __cfHandler_h194ddf07454f = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
         __cf_handler_event: {
@@ -30,7 +30,7 @@ const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
 export default pattern((state) => {
     const __cf_handler_event = state.key("label");
     return {
-        [UI]: (<button type="button" onClick={__cfHandler_1({
+        [UI]: (<button type="button" onClick={__cfHandler_h194ddf07454f({
             __cf_handler_event: __cf_handler_event
         })}>
         Echo
@@ -78,5 +78,6 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfHandler_1
+    __cfHandler_h194ddf07454f,
+    __cfHandler_1: __cfHandler_h194ddf07454f
 });

--- a/packages/ts-transformers/test/fixtures/closures/handler-unused-event.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/handler-unused-event.expected.jsx
@@ -14,7 +14,7 @@ const __cfAmdHooks = undefined;
 interface State {
     counter: Cell<number>;
 }
-const __cfHandler_1 = __cfHelpers.handler({
+const __cfHandler_h277e99ce2f8f = __cfHelpers.handler({
     type: "unknown"
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
@@ -38,7 +38,7 @@ const __cfHandler_1 = __cfHelpers.handler({
 // Context: Event param is named _ (unused); transformer emits a generic event schema placeholder
 export default pattern((state) => {
     return {
-        [UI]: (<button type="button" onClick={__cfHandler_1({
+        [UI]: (<button type="button" onClick={__cfHandler_h277e99ce2f8f({
             state: {
                 counter: state.key("counter")
             }
@@ -89,5 +89,6 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfHandler_1
+    __cfHandler_h277e99ce2f8f,
+    __cfHandler_1: __cfHandler_h277e99ce2f8f
 });

--- a/packages/ts-transformers/test/fixtures/closures/helper-owned-handler-nested-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/helper-owned-handler-nested-captures.expected.jsx
@@ -49,7 +49,7 @@ interface Input {
 interface Output {
     trigger: Stream<void>;
 }
-const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+const __cfHandler_heb6a7002a08c = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
         fileId: {
@@ -92,7 +92,7 @@ export default pattern((__cf_pattern_input) => {
     const content = __cf_pattern_input.key("content");
     const savedContent = __cf_pattern_input.key("savedContent");
     const onSaveFile = __cf_pattern_input.key("onSaveFile");
-    const trigger = __cfHandler_1({
+    const trigger = __cfHandler_heb6a7002a08c({
         fileId: fileId,
         content: content,
         savedContent: savedContent,
@@ -145,5 +145,6 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfHandler_1
+    __cfHandler_heb6a7002a08c,
+    __cfHandler_1: __cfHandler_heb6a7002a08c
 });

--- a/packages/ts-transformers/test/fixtures/closures/hoisted-handler-preserves-capture-schemas.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/hoisted-handler-preserves-capture-schemas.expected.jsx
@@ -60,7 +60,7 @@ const Item = pattern((__cf_pattern_input) => {
     },
     required: ["id", "label", "$NAME"]
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+const __cfHandler_h7f101cf62941 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
         items: {
@@ -99,7 +99,7 @@ const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
         return navigateTo(existing);
     }
 });
-const __cfHandler_2 = __cfHelpers.handler({
+const __cfHandler_h69a1e74752ae = __cfHelpers.handler({
     type: "object",
     properties: {
         label: {
@@ -166,13 +166,13 @@ export default pattern((__cf_pattern_input) => {
     // `goToAllNotesAction` — reads `items.get()`, filters, conditionally
     // navigates. Triggers `items` to be classified `readonly` in this
     // action's captures schema.
-    const read = __cfHandler_1({
+    const read = __cfHandler_h7f101cf62941({
         items: items
     }).for({ stream: "read" }, true);
     // `write` action: matches the shape of notebook.tsx's
     // `createNoteStreamAction` — pushes a new item, returns it. Should
     // get a schema with `items` classified `writeonly` (plus `self`).
-    const write = __cfHandler_2({
+    const write = __cfHandler_h69a1e74752ae({
         self: self,
         items: items
     }).for({ stream: "write" }, true);
@@ -230,6 +230,8 @@ function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
     Item,
-    __cfHandler_1,
-    __cfHandler_2
+    __cfHandler_h7f101cf62941,
+    __cfHandler_h69a1e74752ae,
+    __cfHandler_1: __cfHandler_h7f101cf62941,
+    __cfHandler_2: __cfHandler_h69a1e74752ae
 });

--- a/packages/ts-transformers/test/fixtures/closures/ifelse-factory-boundaries.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/ifelse-factory-boundaries.expected.jsx
@@ -57,7 +57,7 @@ interface Message {
     id: string;
     type: "chat" | "system";
 }
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h6be15d4c8476 = __cfHelpers.pattern(__cf_pattern_input => {
     const entry = __cf_pattern_input.key("element");
     return ifElse({
         type: "boolean"
@@ -117,7 +117,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h1379edb67d59 = __cfHelpers.lift<{
     msg: {
         type: string;
     };
@@ -138,7 +138,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hf2fadcd49d39 = __cfHelpers.pattern(__cf_pattern_input => {
     const msg = __cf_pattern_input.key("element");
     const selectedId = __cf_pattern_input.key("params", "selectedId");
     return ifElse({
@@ -153,7 +153,7 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
                 type: "object",
                 properties: {}
             }]
-    } as const satisfies __cfHelpers.JSONSchema, {} as const satisfies __cfHelpers.JSONSchema, __cfLift_1({ msg: {
+    } as const satisfies __cfHelpers.JSONSchema, {} as const satisfies __cfHelpers.JSONSchema, __cfLift_h1379edb67d59({ msg: {
             type: msg.key("type")
         } }), <span>{msg.key("id")}</span>, <button type="button" onClick={selectMessage({ selectedId, msgId: msg.key("id") })}>
                 open
@@ -220,8 +220,8 @@ export default pattern((__cf_pattern_input) => {
     } as const satisfies __cfHelpers.JSONSchema).for("selectedId", true);
     return {
         [UI]: (<div>
-          {entries.mapWithPattern(__cfPattern_1, {})}
-          {messages.mapWithPattern(__cfPattern_2, {
+          {entries.mapWithPattern(__cfPattern_h6be15d4c8476, {})}
+          {messages.mapWithPattern(__cfPattern_hf2fadcd49d39, {
                 selectedId: selectedId
             })}
         </div>),
@@ -307,7 +307,10 @@ __cfHardenFn(h);
 __cfReg({
     moduleHasSettings,
     selectMessage,
-    __cfPattern_1,
-    __cfLift_1,
-    __cfPattern_2
+    __cfPattern_h6be15d4c8476,
+    __cfLift_h1379edb67d59,
+    __cfPattern_hf2fadcd49d39,
+    __cfPattern_1: __cfPattern_h6be15d4c8476,
+    __cfLift_1: __cfLift_h1379edb67d59,
+    __cfPattern_2: __cfPattern_hf2fadcd49d39
 });

--- a/packages/ts-transformers/test/fixtures/closures/inline-action-in-ternary-branch.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/inline-action-in-ternary-branch.expected.jsx
@@ -27,7 +27,7 @@ interface State {
     card: Card;
     isEditing: Cell<boolean>;
 }
-const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+const __cfHandler_h4dd54a6449de = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
         state: {
@@ -43,11 +43,11 @@ const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
     },
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, (__cf_handler_event, { state }) => state.isEditing.set(true));
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h6f2eaa266e70 = __cfHelpers.lift<{
     state: {
         isEditing: __cfHelpers.ReadonlyCell<boolean>;
     };
-}, __cfHelpers.JSXElement>(({ state }) => (<cf-button onClick={__cfHandler_1({
+}, __cfHelpers.JSXElement>(({ state }) => (<cf-button onClick={__cfHandler_h4dd54a6449de({
     state: {
         isEditing: state.isEditing
     }
@@ -116,7 +116,7 @@ export default pattern((state) => {
             <span>{state.key("card", "title")}</span>
             {/* Explicit computed() wrapping a button with inline handler */}
             {/* The Cell ref in the handler must be captured in the lift-applied computation */}
-            {__cfLift_1({ state: {
+            {__cfLift_h6f2eaa266e70({ state: {
                     isEditing: state.key("isEditing")
                 } })}
           </div>)}
@@ -198,6 +198,8 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfHandler_1,
-    __cfLift_1
+    __cfHandler_h4dd54a6449de,
+    __cfLift_h6f2eaa266e70,
+    __cfHandler_1: __cfHandler_h4dd54a6449de,
+    __cfLift_1: __cfLift_h6f2eaa266e70
 });

--- a/packages/ts-transformers/test/fixtures/closures/lift-result-type-cf-ref-normalized.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/lift-result-type-cf-ref-normalized.expected.jsx
@@ -11,7 +11,7 @@ import { computed, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hf3bba001ed9d = __cfHelpers.lift<{
     count: number;
 }, __cfHelpers.JSXElement>(({ count }) => <span>{count}</span>, {
     type: "object",
@@ -56,7 +56,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 export default pattern((__cf_pattern_input) => {
     const count = __cf_pattern_input.key("count");
     return {
-        [UI]: <div>{__cfLift_1({ count: count })}</div>,
+        [UI]: <div>{__cfLift_hf3bba001ed9d({ count: count })}</div>,
     };
 }, {
     type: "object",
@@ -100,5 +100,6 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_hf3bba001ed9d,
+    __cfLift_1: __cfLift_hf3bba001ed9d
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-and-handler.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-and-handler.expected.jsx
@@ -18,7 +18,7 @@ interface State {
     discount: number;
     selectedIndex: Cell<number>;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h0433d932131d = __cfHelpers.lift<{
     item: {
         price: number;
     };
@@ -51,7 +51,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+const __cfHandler_h729d60abca1f = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
         index: {
@@ -70,12 +70,12 @@ const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
     },
     required: ["index", "state"]
 } as const satisfies __cfHelpers.JSONSchema, (__cf_handler_event, { state, index }) => state.selectedIndex.set(index));
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h33cd374e1aa8 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const index = __cf_pattern_input.key("index");
     const state = __cf_pattern_input.key("params", "state");
     return (<div>
-            <span>{__cfLift_1({
+            <span>{__cfLift_h0433d932131d({
         item: {
             price: item.key("price")
         },
@@ -83,7 +83,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
             discount: state.key("discount")
         }
     })}</span>
-            <button type="button" onClick={__cfHandler_1({
+            <button type="button" onClick={__cfHandler_h729d60abca1f({
         state: {
             selectedIndex: state.key("selectedIndex")
         },
@@ -149,7 +149,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_hd8e957cc3711 = __cfHelpers.lift<{
     state: {
         items: { price: number; }[];
         selectedIndex: __cfHelpers.Cell<number>;
@@ -184,7 +184,7 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_3 = __cfHelpers.lift<{
+const __cfLift_hbbe16dd84b57 = __cfHelpers.lift<{
     state: {
         items: { price: number; }[];
         selectedIndex: __cfHelpers.Cell<number>;
@@ -231,18 +231,18 @@ const __cfLift_3 = __cfHelpers.lift<{
 export default pattern((state) => {
     return {
         [UI]: (<div>
-        {state.key("items").mapWithPattern(__cfPattern_1, {
+        {state.key("items").mapWithPattern(__cfPattern_h33cd374e1aa8, {
                 state: {
                     discount: state.key("discount"),
                     selectedIndex: state.key("selectedIndex")
                 }
             })}
         <div>
-          Selected: {__cfLift_2({ state: {
+          Selected: {__cfLift_hd8e957cc3711({ state: {
                 items: state.key("items"),
                 selectedIndex: state.key("selectedIndex")
             } })} x {state.key("discount")} ={" "}
-          {__cfLift_3({ state: {
+          {__cfLift_hbbe16dd84b57({ state: {
                 items: state.key("items"),
                 selectedIndex: state.key("selectedIndex"),
                 discount: state.key("discount")
@@ -308,9 +308,14 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfHandler_1,
-    __cfPattern_1,
-    __cfLift_2,
-    __cfLift_3
+    __cfLift_h0433d932131d,
+    __cfHandler_h729d60abca1f,
+    __cfPattern_h33cd374e1aa8,
+    __cfLift_hd8e957cc3711,
+    __cfLift_hbbe16dd84b57,
+    __cfLift_1: __cfLift_h0433d932131d,
+    __cfHandler_1: __cfHandler_h729d60abca1f,
+    __cfPattern_1: __cfPattern_h33cd374e1aa8,
+    __cfLift_2: __cfLift_hd8e957cc3711,
+    __cfLift_3: __cfLift_hbbe16dd84b57
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-array-destructure-lowering.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-array-destructure-lowering.expected.jsx
@@ -18,7 +18,7 @@ type Row = [
 interface State {
     rows: Row[];
 }
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hfb8884dfa497 = __cfHelpers.pattern(__cf_pattern_input => {
     const left = __cf_pattern_input.key("element", "0");
     const right = __cf_pattern_input.key("element", "1");
     return (<span>
@@ -68,7 +68,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 export default pattern((state) => {
     return {
         [UI]: (<div>
-        {state.key("rows").mapWithPattern(__cfPattern_1, {})}
+        {state.key("rows").mapWithPattern(__cfPattern_hfb8884dfa497, {})}
       </div>),
     };
 }, {
@@ -124,5 +124,6 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfPattern_1
+    __cfPattern_hfb8884dfa497,
+    __cfPattern_1: __cfPattern_hfb8884dfa497
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-array-destructure-shorthand.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-array-destructure-shorthand.expected.jsx
@@ -18,7 +18,7 @@ type ItemTuple = [
 interface State {
     items: ItemTuple[];
 }
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hb6e87fc67996 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element", "0");
     return (<div data-item={item}>{item}</div>);
 }, {
@@ -58,7 +58,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hcb04fddf85c5 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element", "0");
     const count = __cf_pattern_input.key("element", "1");
     const index = __cf_pattern_input.key("index");
@@ -116,10 +116,10 @@ export default pattern((__cf_pattern_input) => {
         [UI]: (<div>
         {/* Array destructured parameter - without fix, 'item' would be
                 incorrectly captured in params due to shorthand usage in JSX */}
-        {items.mapWithPattern(__cfPattern_1, {})}
+        {items.mapWithPattern(__cfPattern_hb6e87fc67996, {})}
 
         {/* Multiple array destructured params */}
-        {items.mapWithPattern(__cfPattern_2, {})}
+        {items.mapWithPattern(__cfPattern_hcb04fddf85c5, {})}
       </div>),
     };
 }, {
@@ -175,6 +175,8 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfPattern_1,
-    __cfPattern_2
+    __cfPattern_hb6e87fc67996,
+    __cfPattern_hcb04fddf85c5,
+    __cfPattern_1: __cfPattern_hb6e87fc67996,
+    __cfPattern_2: __cfPattern_hcb04fddf85c5
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-array-destructured.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-array-destructured.expected.jsx
@@ -19,7 +19,7 @@ interface State {
     pizzas: PizzaEntry[];
     scale: number;
 }
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h50853fac3465 = __cfHelpers.pattern(__cf_pattern_input => {
     const date = __cf_pattern_input.key("element", "0");
     const pizza = __cf_pattern_input.key("element", "1");
     return (<div>
@@ -62,7 +62,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hc843d1f36cab = __cfHelpers.pattern(__cf_pattern_input => {
     const date = __cf_pattern_input.key("element", "0");
     const pizza = __cf_pattern_input.key("element", "1");
     const state = __cf_pattern_input.key("params", "state");
@@ -130,10 +130,10 @@ export default pattern((state) => {
     return {
         [UI]: (<div>
         {/* Map with array destructured parameter */}
-        {state.key("pizzas").mapWithPattern(__cfPattern_1, {})}
+        {state.key("pizzas").mapWithPattern(__cfPattern_h50853fac3465, {})}
 
         {/* Map with array destructured parameter and capture */}
-        {state.key("pizzas").mapWithPattern(__cfPattern_2, {
+        {state.key("pizzas").mapWithPattern(__cfPattern_hc843d1f36cab, {
                 state: {
                     scale: state.key("scale")
                 }
@@ -196,6 +196,8 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfPattern_1,
-    __cfPattern_2
+    __cfPattern_h50853fac3465,
+    __cfPattern_hc843d1f36cab,
+    __cfPattern_1: __cfPattern_h50853fac3465,
+    __cfPattern_2: __cfPattern_hc843d1f36cab
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-body-destructure-cases.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-body-destructure-cases.expected.jsx
@@ -22,7 +22,7 @@ interface State {
     spots: Spot[];
     people: Person[];
 }
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_haef5fc049b98 = __cfHelpers.pattern(__cf_pattern_input => {
     const spot = __cf_pattern_input.key("element");
     const sn = spot.key("spotNumber");
     return <li>{sn}</li>;
@@ -66,7 +66,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h08a94ce500b2 = __cfHelpers.lift<{
     spotPreferences: string[];
 }, boolean>(({ spotPreferences }) => spotPreferences.length > 0, {
     type: "object",
@@ -82,7 +82,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_h7c1de21101a8 = __cfHelpers.lift<{
     spotPreferences: string[];
 }, string>(({ spotPreferences }) => spotPreferences.map((n) => "#" + n).join(", "), {
     type: "object",
@@ -98,7 +98,7 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hce187d7e99a4 = __cfHelpers.pattern(__cf_pattern_input => {
     const person = __cf_pattern_input.key("element");
     const name = person.key("name"), spotPreferences = person.key("spotPreferences");
     return (<li>
@@ -119,7 +119,7 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
                 type: "object",
                 properties: {}
             }]
-    } as const satisfies __cfHelpers.JSONSchema, __cfLift_1({ spotPreferences: spotPreferences }), <span>{__cfLift_2({ spotPreferences: spotPreferences })}</span>, null)}
+    } as const satisfies __cfHelpers.JSONSchema, __cfLift_h08a94ce500b2({ spotPreferences: spotPreferences }), <span>{__cfLift_h7c1de21101a8({ spotPreferences: spotPreferences })}</span>, null)}
               </li>);
 }, {
     type: "object",
@@ -178,11 +178,11 @@ export default pattern((state) => {
     return {
         [UI]: (<section>
         <ul>
-          {state.key("spots").mapWithPattern(__cfPattern_1, {})}
+          {state.key("spots").mapWithPattern(__cfPattern_haef5fc049b98, {})}
         </ul>
 
         <ul>
-          {state.key("people").mapWithPattern(__cfPattern_2, {})}
+          {state.key("people").mapWithPattern(__cfPattern_hce187d7e99a4, {})}
         </ul>
       </section>),
     };
@@ -263,8 +263,12 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfPattern_1,
-    __cfLift_1,
-    __cfLift_2,
-    __cfPattern_2
+    __cfPattern_haef5fc049b98,
+    __cfLift_h08a94ce500b2,
+    __cfLift_h7c1de21101a8,
+    __cfPattern_hce187d7e99a4,
+    __cfPattern_1: __cfPattern_haef5fc049b98,
+    __cfLift_1: __cfLift_h08a94ce500b2,
+    __cfLift_2: __cfLift_h7c1de21101a8,
+    __cfPattern_2: __cfPattern_hce187d7e99a4
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-callback-schema-params.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-callback-schema-params.expected.jsx
@@ -19,7 +19,7 @@ interface State {
     items: Item[];
     discount: number;
 }
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h8c0ea3a732e7 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return <span>{item.key("id")}</span>;
 }, {
@@ -65,7 +65,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h0433d932131d = __cfHelpers.lift<{
     item: {
         price: number;
     };
@@ -98,10 +98,10 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hd039b5092703 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const state = __cf_pattern_input.key("params", "state");
-    return (<span>{__cfLift_1({
+    return (<span>{__cfLift_h0433d932131d({
         item: {
             price: item.key("price")
         },
@@ -178,10 +178,10 @@ export default pattern((state) => {
     return {
         [UI]: (<div>
         <section data-kind="unused">
-          {state.key("items").mapWithPattern(__cfPattern_1, {})}
+          {state.key("items").mapWithPattern(__cfPattern_h8c0ea3a732e7, {})}
         </section>
         <section data-kind="used">
-          {state.key("items").mapWithPattern(__cfPattern_2, {
+          {state.key("items").mapWithPattern(__cfPattern_hd039b5092703, {
                 state: {
                     discount: state.key("discount")
                 }
@@ -251,7 +251,10 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfPattern_1,
-    __cfLift_1,
-    __cfPattern_2
+    __cfPattern_h8c0ea3a732e7,
+    __cfLift_h0433d932131d,
+    __cfPattern_hd039b5092703,
+    __cfPattern_1: __cfPattern_h8c0ea3a732e7,
+    __cfLift_1: __cfLift_h0433d932131d,
+    __cfPattern_2: __cfPattern_hd039b5092703
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-capture-cell-fn.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-capture-cell-fn.expected.jsx
@@ -16,7 +16,7 @@ interface State {
         name: string;
     }>;
 }
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h0a5a0f7b7aed = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const count = __cf_pattern_input.key("params", "count");
     return (<span>{item.key("name")} #{count}</span>);
@@ -75,7 +75,7 @@ export default pattern((state) => {
     } as const satisfies __cfHelpers.JSONSchema).for("count", true);
     return {
         [UI]: (<div>
-        {state.key("items").mapWithPattern(__cfPattern_1, {
+        {state.key("items").mapWithPattern(__cfPattern_h0a5a0f7b7aed, {
                 count: count
             })}
       </div>),
@@ -131,5 +131,6 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfPattern_1
+    __cfPattern_h0a5a0f7b7aed,
+    __cfPattern_1: __cfPattern_h0a5a0f7b7aed
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-capture-cell-of.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-capture-cell-of.expected.jsx
@@ -16,7 +16,7 @@ interface State {
         name: string;
     }>;
 }
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h519c6aeeafda = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const counter = __cf_pattern_input.key("params", "counter");
     return (<span>{item.key("name")} #{counter}</span>);
@@ -75,7 +75,7 @@ export default pattern((state) => {
     } as const satisfies __cfHelpers.JSONSchema).for("counter", true);
     return {
         [UI]: (<div>
-        {state.key("items").mapWithPattern(__cfPattern_1, {
+        {state.key("items").mapWithPattern(__cfPattern_h519c6aeeafda, {
                 counter: counter
             })}
       </div>),
@@ -131,5 +131,6 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfPattern_1
+    __cfPattern_h519c6aeeafda,
+    __cfPattern_1: __cfPattern_h519c6aeeafda
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-capture-cell-param-no-name.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-capture-cell-param-no-name.expected.jsx
@@ -50,7 +50,7 @@ const removeItem = handler({
 } as const satisfies __cfHelpers.JSONSchema, (_, _2) => {
     // Not relevant for repro
 });
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hba6d2feac2a7 = __cfHelpers.pattern(__cf_pattern_input => {
     const _ = __cf_pattern_input.key("element");
     const index = __cf_pattern_input.key("index");
     const items = __cf_pattern_input.key("params", "items");
@@ -125,7 +125,7 @@ export default pattern((__cf_pattern_input: InputSchema) => {
     const items = __cf_pattern_input.key("items");
     return {
         [UI]: (<ul>
-          {items.mapWithPattern(__cfPattern_1, {
+          {items.mapWithPattern(__cfPattern_hba6d2feac2a7, {
                 items: items
             })}
         </ul>),
@@ -189,5 +189,6 @@ function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
     removeItem,
-    __cfPattern_1
+    __cfPattern_hba6d2feac2a7,
+    __cfPattern_1: __cfPattern_hba6d2feac2a7
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-capture-cell-param.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-capture-cell-param.expected.jsx
@@ -50,7 +50,7 @@ const removeItem = handler({
 } as const satisfies __cfHelpers.JSONSchema, (_, _2) => {
     // Not relevant for repro
 });
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h0d242f72c8b4 = __cfHelpers.pattern(__cf_pattern_input => {
     const _ = __cf_pattern_input.key("element");
     const index = __cf_pattern_input.key("index");
     const items = __cf_pattern_input.key("params", "items");
@@ -124,7 +124,7 @@ export default pattern((__cf_pattern_input) => {
     const items = __cf_pattern_input.key("items");
     return {
         [UI]: (<ul>
-          {items.mapWithPattern(__cfPattern_1, {
+          {items.mapWithPattern(__cfPattern_h0d242f72c8b4, {
                 items: items
             })}
         </ul>),
@@ -188,5 +188,6 @@ function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
     removeItem,
-    __cfPattern_1
+    __cfPattern_h0d242f72c8b4,
+    __cfPattern_1: __cfPattern_h0d242f72c8b4
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-capture-derived-from-param.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-capture-derived-from-param.expected.jsx
@@ -17,7 +17,7 @@ interface State {
         multiplier: number;
     };
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h25cf91f00267 = __cfHelpers.lift<{
     item: number;
     settings: {
         multiplier: number;
@@ -42,10 +42,10 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h52a3fab159a0 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const settings = __cf_pattern_input.key("params", "settings");
-    return (<span>{__cfLift_1({
+    return (<span>{__cfLift_h25cf91f00267({
         item: item,
         settings: {
             multiplier: settings.key("multiplier")
@@ -103,7 +103,7 @@ export default pattern((state) => {
     const settings = state.key("settings");
     return {
         [UI]: (<div>
-        {state.key("items").mapWithPattern(__cfPattern_1, {
+        {state.key("items").mapWithPattern(__cfPattern_h52a3fab159a0, {
                 settings: {
                     multiplier: settings.key("multiplier")
                 }
@@ -164,6 +164,8 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfPattern_1
+    __cfLift_h25cf91f00267,
+    __cfPattern_h52a3fab159a0,
+    __cfLift_1: __cfLift_h25cf91f00267,
+    __cfPattern_1: __cfPattern_h52a3fab159a0
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-capture-mixed-reactivity.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-capture-mixed-reactivity.expected.jsx
@@ -17,7 +17,7 @@ interface State {
     }>;
     threshold: number;
 }
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hb9399f42a1a3 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const label = __cf_pattern_input.params.label;
     const derived = __cf_pattern_input.key("params", "derived");
@@ -90,7 +90,7 @@ export default pattern((state) => {
     const derived = state.key("threshold");
     return {
         [UI]: (<div>
-        {state.key("items").mapWithPattern(__cfPattern_1, {
+        {state.key("items").mapWithPattern(__cfPattern_hb9399f42a1a3, {
                 label: label,
                 derived: derived,
                 limit: limit
@@ -151,5 +151,6 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfPattern_1
+    __cfPattern_hb9399f42a1a3,
+    __cfPattern_1: __cfPattern_hb9399f42a1a3
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-capture-object-literal.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-capture-object-literal.expected.jsx
@@ -16,7 +16,7 @@ interface State {
         name: string;
     }>;
 }
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_ha8f1995eb83d = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const style = __cf_pattern_input.params.style;
     return (<span style={style}>{item.key("name")}</span>);
@@ -81,7 +81,7 @@ export default pattern((state) => {
     const style = { color: "red", fontSize: 14 };
     return {
         [UI]: (<div>
-        {state.key("items").mapWithPattern(__cfPattern_1, {
+        {state.key("items").mapWithPattern(__cfPattern_ha8f1995eb83d, {
                 style: style
             })}
       </div>),
@@ -137,5 +137,6 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfPattern_1
+    __cfPattern_ha8f1995eb83d,
+    __cfPattern_1: __cfPattern_ha8f1995eb83d
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-capture-writable-of.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-capture-writable-of.expected.jsx
@@ -16,7 +16,7 @@ interface State {
         name: string;
     }>;
 }
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hf5ad69cfa60d = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const selected = __cf_pattern_input.key("params", "selected");
     return (<span>{item.key("name")} {selected}</span>);
@@ -83,7 +83,7 @@ export default pattern((state) => {
     } as const satisfies __cfHelpers.JSONSchema).for("selected", true);
     return {
         [UI]: (<div>
-        {state.key("items").mapWithPattern(__cfPattern_1, {
+        {state.key("items").mapWithPattern(__cfPattern_hf5ad69cfa60d, {
                 selected: selected
             })}
       </div>),
@@ -139,5 +139,6 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfPattern_1
+    __cfPattern_hf5ad69cfa60d,
+    __cfPattern_1: __cfPattern_hf5ad69cfa60d
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-cell-receiver-in-lift.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-cell-receiver-in-lift.expected.jsx
@@ -21,7 +21,7 @@ const items = __cfHelpers.__cf_data(new Cell<string[]>([], {
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema).for("items", true));
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h29c94d383dae = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return item;
 }, {
@@ -35,7 +35,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-export const fn = lift(() => items.mapWithPattern(__cfPattern_1, {}), false as const satisfies __cfHelpers.JSONSchema, {
+export const fn = lift(() => items.mapWithPattern(__cfPattern_h29c94d383dae, {}), false as const satisfies __cfHelpers.JSONSchema, {
     type: "array",
     items: {
         type: "string"
@@ -45,5 +45,6 @@ export const fn = lift(() => items.mapWithPattern(__cfPattern_1, {}), false as c
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfPattern_1
+    __cfPattern_h29c94d383dae,
+    __cfPattern_1: __cfPattern_h29c94d383dae
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-computed-alias-side-effect.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-computed-alias-side-effect.expected.jsx
@@ -19,7 +19,7 @@ __cfHardenFn(nextKey);
 interface State {
     items: Array<Record<string, number>>;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h8cb8146c03b7 = __cfHelpers.lift<{
     element: any;
     __cf_amount_key: any;
 }, number | undefined>(({ element, __cf_amount_key }) => element[__cf_amount_key], {
@@ -32,10 +32,10 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["number", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_he5b726ec597e = __cfHelpers.pattern(__cf_pattern_input => {
     const element = __cf_pattern_input.key("element");
     const __cf_amount_key = nextKey();
-    const amount = __cfLift_1({
+    const amount = __cfLift_h8cb8146c03b7({
         element: element,
         __cf_amount_key: __cf_amount_key
     }).for("amount", true);
@@ -81,7 +81,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 export default pattern((state) => {
     return {
         [UI]: (<div>
-        {state.key("items").mapWithPattern(__cfPattern_1, {})}
+        {state.key("items").mapWithPattern(__cfPattern_he5b726ec597e, {})}
       </div>),
     };
 }, {
@@ -133,6 +133,8 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfPattern_1
+    __cfLift_h8cb8146c03b7,
+    __cfPattern_he5b726ec597e,
+    __cfLift_1: __cfLift_h8cb8146c03b7,
+    __cfPattern_1: __cfPattern_he5b726ec597e
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-computed-alias-with-plain-binding.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-computed-alias-with-plain-binding.expected.jsx
@@ -22,7 +22,7 @@ interface Item {
 interface State {
     items: Item[];
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h148727a9fbdc = __cfHelpers.lift<{
     element: any;
     __cf_val_key: any;
 }, number>(({ element, __cf_val_key }) => element[__cf_val_key], {
@@ -35,7 +35,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_h00cbd59dbc77 = __cfHelpers.lift<{
     foo: number;
     val: number;
 }, number>(({ foo, val }) => foo + val, {
@@ -52,15 +52,15 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hf94efab96759 = __cfHelpers.pattern(__cf_pattern_input => {
     const element = __cf_pattern_input.key("element");
     const __cf_val_key = dynamicKey();
     const foo = element.key("foo");
-    const val = __cfLift_1({
+    const val = __cfLift_h148727a9fbdc({
         element: element,
         __cf_val_key: __cf_val_key
     }).for("val", true);
-    return (<span>{__cfLift_2({
+    return (<span>{__cfLift_h00cbd59dbc77({
         foo: foo,
         val: val
     })}</span>);
@@ -115,7 +115,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 export default pattern((state) => {
     return {
         [UI]: (<div>
-        {state.key("items").mapWithPattern(__cfPattern_1, {})}
+        {state.key("items").mapWithPattern(__cfPattern_hf94efab96759, {})}
       </div>),
     };
 }, {
@@ -177,7 +177,10 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2,
-    __cfPattern_1
+    __cfLift_h148727a9fbdc,
+    __cfLift_h00cbd59dbc77,
+    __cfPattern_hf94efab96759,
+    __cfLift_1: __cfLift_h148727a9fbdc,
+    __cfLift_2: __cfLift_h00cbd59dbc77,
+    __cfPattern_1: __cfPattern_hf94efab96759
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-computed-fallback-alias.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-computed-fallback-alias.expected.jsx
@@ -21,7 +21,7 @@ interface Message {
 interface Input {
     messages: Message[];
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h4603604df9ca = __cfHelpers.lift<{
     msg: {
         reactions?: Reaction[] | undefined;
     };
@@ -69,7 +69,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_ha2237755eb6a = __cfHelpers.pattern(__cf_pattern_input => {
     const reaction = __cf_pattern_input.key("element");
     const msg = __cf_pattern_input.key("params", "msg");
     return (<button type="button" data-msg-id={msg.key("id")}>
@@ -130,13 +130,13 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hf1b99ce1e8ac = __cfHelpers.pattern(__cf_pattern_input => {
     const msg = __cf_pattern_input.key("element");
-    const messageReactions = __cfLift_1({ msg: {
+    const messageReactions = __cfLift_h4603604df9ca({ msg: {
             reactions: msg.key("reactions")
         } }).for("messageReactions", true);
     return (<div>
-              {messageReactions.mapWithPattern(__cfPattern_1, {
+              {messageReactions.mapWithPattern(__cfPattern_ha2237755eb6a, {
             msg: {
                 id: msg.key("id")
             }
@@ -206,7 +206,7 @@ export default pattern((__cf_pattern_input) => {
     const messages = __cf_pattern_input.key("messages");
     return {
         [UI]: (<div>
-        {messages.mapWithPattern(__cfPattern_2, {})}
+        {messages.mapWithPattern(__cfPattern_hf1b99ce1e8ac, {})}
       </div>),
     };
 }, {
@@ -280,7 +280,10 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfPattern_1,
-    __cfPattern_2
+    __cfLift_h4603604df9ca,
+    __cfPattern_ha2237755eb6a,
+    __cfPattern_hf1b99ce1e8ac,
+    __cfLift_1: __cfLift_h4603604df9ca,
+    __cfPattern_1: __cfPattern_ha2237755eb6a,
+    __cfPattern_2: __cfPattern_hf1b99ce1e8ac
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-conditional-expression.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-conditional-expression.expected.jsx
@@ -20,7 +20,7 @@ interface State {
     discount: number;
     threshold: number;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h190d601dc2cf = __cfHelpers.lift<{
     item: {
         price: number;
     };
@@ -53,7 +53,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_h83368a347e7e = __cfHelpers.lift<{
     item: {
         price: number;
     };
@@ -86,7 +86,7 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hc63611996d3d = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const state = __cf_pattern_input.key("params", "state");
     return (<div>
@@ -98,14 +98,14 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema, __cfLift_1({
+    } as const satisfies __cfHelpers.JSONSchema, __cfLift_h190d601dc2cf({
         item: {
             price: item.key("price")
         },
         state: {
             threshold: state.key("threshold")
         }
-    }), __cfLift_2({
+    }), __cfLift_h83368a347e7e({
         item: {
             price: item.key("price")
         },
@@ -184,7 +184,7 @@ export default pattern((state) => {
     return {
         [UI]: (<div>
         {/* Ternary with captures in map callback */}
-        {state.key("items").mapWithPattern(__cfPattern_1, {
+        {state.key("items").mapWithPattern(__cfPattern_hc63611996d3d, {
                 state: {
                     threshold: state.key("threshold"),
                     discount: state.key("discount")
@@ -257,7 +257,10 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2,
-    __cfPattern_1
+    __cfLift_h190d601dc2cf,
+    __cfLift_h83368a347e7e,
+    __cfPattern_hc63611996d3d,
+    __cfLift_1: __cfLift_h190d601dc2cf,
+    __cfLift_2: __cfLift_h83368a347e7e,
+    __cfPattern_1: __cfPattern_hc63611996d3d
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-conditional-inline-handler-send.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-conditional-inline-handler-send.expected.jsx
@@ -67,7 +67,7 @@ const castVote = handler({
         event,
     ]);
 });
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hb6b80ab5da8b = __cfHelpers.lift<{
     castVote: __cfHelpers.HandlerFactory<VoteEvent, { votes: __cfHelpers.Cell<VoteEvent[]>; }, void>;
     state: {
         votes: VoteEvent[];
@@ -124,7 +124,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+const __cfHandler_h404d9c845282 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
         item: {
@@ -160,7 +160,7 @@ const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
     id: item.id,
     step: "single",
 }));
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h29244172d48f = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const state = __cf_pattern_input.key("params", "state");
     const boundCastVote = __cf_pattern_input.key("params", "boundCastVote");
@@ -179,7 +179,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
                 type: "object",
                 properties: {}
             }]
-    } as const satisfies __cfHelpers.JSONSchema, state.key("canVote"), <button type="button" onClick={__cfHandler_1({
+    } as const satisfies __cfHelpers.JSONSchema, state.key("canVote"), <button type="button" onClick={__cfHandler_h404d9c845282({
         boundCastVote: boundCastVote,
         item: {
             id: item.key("id")
@@ -270,7 +270,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 // Context: The conditional branch makes expression rewriting recurse into the
 // handler subtree; the authored handler arrow must be treated as safe context.
 export default pattern((state) => {
-    const boundCastVote = __cfLift_1({
+    const boundCastVote = __cfLift_hb6b80ab5da8b({
         castVote: castVote,
         state: {
             votes: state.key("votes")
@@ -278,7 +278,7 @@ export default pattern((state) => {
     }).for({ stream: "boundCastVote" }, true);
     return {
         [UI]: (<div>
-        {state.key("items").mapWithPattern(__cfPattern_1, {
+        {state.key("items").mapWithPattern(__cfPattern_h29244172d48f, {
                 state: {
                     canVote: state.key("canVote")
                 },
@@ -367,7 +367,10 @@ function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
     castVote,
-    __cfLift_1,
-    __cfHandler_1,
-    __cfPattern_1
+    __cfLift_hb6b80ab5da8b,
+    __cfHandler_h404d9c845282,
+    __cfPattern_h29244172d48f,
+    __cfLift_1: __cfLift_hb6b80ab5da8b,
+    __cfHandler_1: __cfHandler_h404d9c845282,
+    __cfPattern_1: __cfPattern_h29244172d48f
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-destructure-alias-action-collision.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-destructure-alias-action-collision.expected.jsx
@@ -17,7 +17,7 @@ interface Spot {
 interface State {
     spots: Spot[];
 }
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_haef5fc049b98 = __cfHelpers.pattern(__cf_pattern_input => {
     const spot = __cf_pattern_input.key("element");
     const sn = spot.key("spotNumber");
     return <li>{sn}</li>;
@@ -69,7 +69,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 export default pattern((state) => {
     return {
         [UI]: (<ul>
-        {state.key("spots").mapWithPattern(__cfPattern_1, {})}
+        {state.key("spots").mapWithPattern(__cfPattern_haef5fc049b98, {})}
       </ul>),
     };
 }, {
@@ -128,5 +128,6 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfPattern_1
+    __cfPattern_haef5fc049b98,
+    __cfPattern_1: __cfPattern_haef5fc049b98
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-destructured-alias.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-destructured-alias.expected.jsx
@@ -17,7 +17,7 @@ interface State {
     }>;
     discount: number;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h53f0365313a2 = __cfHelpers.lift<{
     cost: number;
     state: {
         discount: number;
@@ -42,10 +42,10 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hbf7e0ca7e298 = __cfHelpers.pattern(__cf_pattern_input => {
     const cost = __cf_pattern_input.key("element", "price");
     const state = __cf_pattern_input.key("params", "state");
-    return (<span>{__cfLift_1({
+    return (<span>{__cfLift_h53f0365313a2({
         cost: cost,
         state: {
             discount: state.key("discount")
@@ -109,7 +109,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 export default pattern((state) => {
     return {
         [UI]: (<div>
-        {state.key("items").mapWithPattern(__cfPattern_1, {
+        {state.key("items").mapWithPattern(__cfPattern_hbf7e0ca7e298, {
                 state: {
                     discount: state.key("discount")
                 }
@@ -170,6 +170,8 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfPattern_1
+    __cfLift_h53f0365313a2,
+    __cfPattern_hbf7e0ca7e298,
+    __cfLift_1: __cfLift_h53f0365313a2,
+    __cfPattern_1: __cfPattern_hbf7e0ca7e298
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-destructured-computed-alias.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-destructured-computed-alias.expected.jsx
@@ -19,7 +19,7 @@ interface Item {
 interface State {
     items: Item[];
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h148727a9fbdc = __cfHelpers.lift<{
     element: any;
     __cf_val_key: any;
 }, number>(({ element, __cf_val_key }) => element[__cf_val_key], {
@@ -32,10 +32,10 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h82c0b36ba4dc = __cfHelpers.pattern(__cf_pattern_input => {
     const element = __cf_pattern_input.key("element");
     const __cf_val_key = dynamicKey;
-    const val = __cfLift_1({
+    const val = __cfLift_h148727a9fbdc({
         element: element,
         __cf_val_key: __cf_val_key
     }).for("val", true);
@@ -91,7 +91,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 export default pattern((state) => {
     return {
         [UI]: (<div>
-        {state.key("items").mapWithPattern(__cfPattern_1, {})}
+        {state.key("items").mapWithPattern(__cfPattern_h82c0b36ba4dc, {})}
       </div>),
     };
 }, {
@@ -153,6 +153,8 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfPattern_1
+    __cfLift_h148727a9fbdc,
+    __cfPattern_h82c0b36ba4dc,
+    __cfLift_1: __cfLift_h148727a9fbdc,
+    __cfPattern_1: __cfPattern_h82c0b36ba4dc
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-destructured-numeric-alias.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-destructured-numeric-alias.expected.jsx
@@ -16,7 +16,7 @@ interface State {
         0: number;
     }>;
 }
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_heebd878ced06 = __cfHelpers.pattern(__cf_pattern_input => {
     const first = __cf_pattern_input.key("element", "0");
     return (<span>{first}</span>);
 }, {
@@ -61,7 +61,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 export default pattern((state) => {
     return {
         [UI]: (<div>
-        {state.key("entries").mapWithPattern(__cfPattern_1, {})}
+        {state.key("entries").mapWithPattern(__cfPattern_heebd878ced06, {})}
       </div>),
     };
 }, {
@@ -115,5 +115,6 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfPattern_1
+    __cfPattern_heebd878ced06,
+    __cfPattern_1: __cfPattern_heebd878ced06
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-destructured-opaque-local-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-destructured-opaque-local-capture.expected.jsx
@@ -21,7 +21,7 @@ interface State {
         }[];
     }[];
 }
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h13cb7f8764ac = __cfHelpers.pattern(__cf_pattern_input => {
     const tag = __cf_pattern_input.key("element");
     const tasks = __cf_pattern_input.key("params", "tasks");
     return (<span>
@@ -77,11 +77,11 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hf49a97a2ad1d = __cfHelpers.pattern(__cf_pattern_input => {
     const section = __cf_pattern_input.key("element");
     const tasks = section.key("tasks");
     return (<div>
-            {section.key("tags").mapWithPattern(__cfPattern_1, {
+            {section.key("tags").mapWithPattern(__cfPattern_h13cb7f8764ac, {
             tasks: {
                 length: tasks.key("length")
             }
@@ -149,7 +149,7 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
 //   nested tag callback reads tasks.length through key("length"), not plain params values
 export default pattern((state) => ({
     [UI]: (<div>
-      {state.key("sections").mapWithPattern(__cfPattern_2, {})}
+      {state.key("sections").mapWithPattern(__cfPattern_hf49a97a2ad1d, {})}
     </div>),
 }), {
     type: "object",
@@ -223,6 +223,8 @@ export default pattern((state) => ({
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfPattern_1,
-    __cfPattern_2
+    __cfPattern_h13cb7f8764ac,
+    __cfPattern_hf49a97a2ad1d,
+    __cfPattern_1: __cfPattern_h13cb7f8764ac,
+    __cfPattern_2: __cfPattern_hf49a97a2ad1d
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-destructured-param.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-destructured-param.expected.jsx
@@ -19,7 +19,7 @@ interface State {
     points: Point[];
     scale: number;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hae54a1e61729 = __cfHelpers.lift<{
     x: number;
     state: {
         scale: number;
@@ -44,7 +44,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_h4cc8bf30c1a4 = __cfHelpers.lift<{
     y: number;
     state: {
         scale: number;
@@ -69,17 +69,17 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h7633819272db = __cfHelpers.pattern(__cf_pattern_input => {
     const x = __cf_pattern_input.key("element", "x");
     const y = __cf_pattern_input.key("element", "y");
     const state = __cf_pattern_input.key("params", "state");
     return (<div>
-            Point: ({__cfLift_1({
+            Point: ({__cfLift_hae54a1e61729({
         x: x,
         state: {
             scale: state.key("scale")
         }
-    })}, {__cfLift_2({
+    })}, {__cfLift_h4cc8bf30c1a4({
         y: y,
         state: {
             scale: state.key("scale")
@@ -148,7 +148,7 @@ export default pattern((state) => {
     return {
         [UI]: (<div>
         {/* Map with destructured parameter and capture */}
-        {state.key("points").mapWithPattern(__cfPattern_1, {
+        {state.key("points").mapWithPattern(__cfPattern_h7633819272db, {
                 state: {
                     scale: state.key("scale")
                 }
@@ -217,7 +217,10 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2,
-    __cfPattern_1
+    __cfLift_hae54a1e61729,
+    __cfLift_h4cc8bf30c1a4,
+    __cfPattern_h7633819272db,
+    __cfLift_1: __cfLift_hae54a1e61729,
+    __cfLift_2: __cfLift_h4cc8bf30c1a4,
+    __cfPattern_1: __cfPattern_h7633819272db
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-destructured-string-alias.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-destructured-string-alias.expected.jsx
@@ -16,7 +16,7 @@ interface State {
         couponCode: string;
     }>;
 }
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h8541149637f5 = __cfHelpers.pattern(__cf_pattern_input => {
     const code = __cf_pattern_input.key("element", "couponCode");
     return (<span>{code}</span>);
 }, {
@@ -61,7 +61,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 export default pattern((state) => {
     return {
         [UI]: (<div>
-        {state.key("items").mapWithPattern(__cfPattern_1, {})}
+        {state.key("items").mapWithPattern(__cfPattern_h8541149637f5, {})}
       </div>),
     };
 }, {
@@ -115,5 +115,6 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfPattern_1
+    __cfPattern_h8541149637f5,
+    __cfPattern_1: __cfPattern_h8541149637f5
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-element-access-opaque.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-element-access-opaque.expected.jsx
@@ -15,7 +15,7 @@ interface State {
     sortedTags: string[];
     tagCounts: Record<string, number>;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h4dee98929829 = __cfHelpers.lift<{
     state: {
         tagCounts: Record<string, number>;
     };
@@ -44,11 +44,11 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["number", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hd6dbc804668e = __cfHelpers.pattern(__cf_pattern_input => {
     const tag = __cf_pattern_input.key("element");
     const state = __cf_pattern_input.key("params", "state");
     return (<span>
-            {tag}: {__cfLift_1({
+            {tag}: {__cfLift_h4dee98929829({
         state: {
             tagCounts: state.key("tagCounts")
         },
@@ -111,7 +111,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 export default pattern((state) => {
     return {
         [UI]: (<div>
-        {state.key("sortedTags").mapWithPattern(__cfPattern_1, {
+        {state.key("sortedTags").mapWithPattern(__cfPattern_hd6dbc804668e, {
                 state: {
                     tagCounts: state.key("tagCounts")
                 }
@@ -170,6 +170,8 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfPattern_1
+    __cfLift_h4dee98929829,
+    __cfPattern_hd6dbc804668e,
+    __cfLift_1: __cfLift_h4dee98929829,
+    __cfPattern_1: __cfPattern_hd6dbc804668e
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-element-computed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-element-computed.expected.jsx
@@ -19,7 +19,7 @@ interface State {
     items: Item[];
     prefix: string;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hde6b17cd8251 = __cfHelpers.lift<{
     item: {
         name: string;
     };
@@ -40,11 +40,11 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h491a3cfd1b4c = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const index = __cf_pattern_input.key("index");
     return (<div>
-            Item #{index}: {__cfLift_1({ item: {
+            Item #{index}: {__cfLift_hde6b17cd8251({ item: {
             name: item.key("name")
         } })}
           </div>);
@@ -95,7 +95,7 @@ export default pattern((state) => {
     return {
         [UI]: (<div>
         {/* Performs computation on element property - should wrap in computed() */}
-        {state.key("items").mapWithPattern(__cfPattern_1, {})}
+        {state.key("items").mapWithPattern(__cfPattern_h491a3cfd1b4c, {})}
       </div>),
     };
 }, {
@@ -160,6 +160,8 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfPattern_1
+    __cfLift_hde6b17cd8251,
+    __cfPattern_h491a3cfd1b4c,
+    __cfLift_1: __cfLift_hde6b17cd8251,
+    __cfPattern_1: __cfPattern_h491a3cfd1b4c
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-generic-type-parameter.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-generic-type-parameter.expected.jsx
@@ -36,7 +36,7 @@ function processWithType<T>(emails: Reactive<Email[]>, _prompt: string) {
     });
 }
 __cfHardenFn(processWithType);
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h12b668620a29 = __cfHelpers.lift<{
     state: {
         emails: Email[];
         prompt: string;
@@ -91,7 +91,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     }
 } as const satisfies __cfHelpers.JSONSchema);
 export default pattern((state) => {
-    const results = __cfLift_1({ state: {
+    const results = __cfLift_h12b668620a29({ state: {
             emails: state.key("emails"),
             prompt: state.key("prompt")
         } }).for("results", true);
@@ -149,5 +149,6 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_h12b668620a29,
+    __cfLift_1: __cfLift_h12b668620a29
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-handler-reference-no-name.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-handler-reference-no-name.expected.jsx
@@ -41,7 +41,7 @@ interface State {
     items: Item[];
     count: Cell<number>;
 }
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h017ccb87b2a6 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const state = __cf_pattern_input.key("params", "state");
     return (<cf-button onClick={handleClick({ count: state.key("count") })}>
@@ -114,7 +114,7 @@ export default pattern((state: State) => {
     return {
         [UI]: (<div>
         {/* Map callback references handler - should NOT capture it */}
-        {state.key("items").mapWithPattern(__cfPattern_1, {
+        {state.key("items").mapWithPattern(__cfPattern_h017ccb87b2a6, {
                 state: {
                     count: state.key("count")
                 }
@@ -185,5 +185,6 @@ function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
     handleClick,
-    __cfPattern_1
+    __cfPattern_h017ccb87b2a6,
+    __cfPattern_1: __cfPattern_h017ccb87b2a6
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-handler-reference-with-type-arg-no-name.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-handler-reference-with-type-arg-no-name.expected.jsx
@@ -41,7 +41,7 @@ interface State {
     items: Item[];
     count: Cell<number>;
 }
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h017ccb87b2a6 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const state = __cf_pattern_input.key("params", "state");
     return (<cf-button onClick={handleClick({ count: state.key("count") })}>
@@ -114,7 +114,7 @@ export default pattern((state) => {
     return {
         [UI]: (<div>
         {/* Map callback references handler - should NOT capture it */}
-        {state.key("items").mapWithPattern(__cfPattern_1, {
+        {state.key("items").mapWithPattern(__cfPattern_h017ccb87b2a6, {
                 state: {
                     count: state.key("count")
                 }
@@ -185,5 +185,6 @@ function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
     handleClick,
-    __cfPattern_1
+    __cfPattern_h017ccb87b2a6,
+    __cfPattern_1: __cfPattern_h017ccb87b2a6
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-handler-reference.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-handler-reference.expected.jsx
@@ -41,7 +41,7 @@ interface State {
     items: Item[];
     count: Cell<number>;
 }
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h017ccb87b2a6 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const state = __cf_pattern_input.key("params", "state");
     return (<cf-button onClick={handleClick({ count: state.key("count") })}>
@@ -114,7 +114,7 @@ export default pattern((state) => {
     return {
         [UI]: (<div>
         {/* Map callback references handler - should NOT capture it */}
-        {state.key("items").mapWithPattern(__cfPattern_1, {
+        {state.key("items").mapWithPattern(__cfPattern_h017ccb87b2a6, {
                 state: {
                     count: state.key("count")
                 }
@@ -185,5 +185,6 @@ function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
     handleClick,
-    __cfPattern_1
+    __cfPattern_h017ccb87b2a6,
+    __cfPattern_1: __cfPattern_h017ccb87b2a6
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-import-reference.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-import-reference.expected.jsx
@@ -25,7 +25,7 @@ interface Item {
 interface State {
     items: Item[];
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h93cc44154d43 = __cfHelpers.lift<{
     item: {
         price: number;
     };
@@ -46,10 +46,10 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hdada347782d7 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return (<div>
-            Item: {__cfLift_1({ item: {
+            Item: {__cfLift_h93cc44154d43({ item: {
             price: item.key("price")
         } })}
           </div>);
@@ -105,7 +105,7 @@ export default pattern((state) => {
     return {
         [UI]: (<div>
         {/* Should NOT capture module-level constant or function */}
-        {state.key("items").mapWithPattern(__cfPattern_1, {})}
+        {state.key("items").mapWithPattern(__cfPattern_hdada347782d7, {})}
       </div>),
     };
 }, {
@@ -167,6 +167,8 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfPattern_1
+    __cfLift_h93cc44154d43,
+    __cfPattern_hdada347782d7,
+    __cfLift_1: __cfLift_h93cc44154d43,
+    __cfPattern_1: __cfPattern_hdada347782d7
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-index-param-used.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-index-param-used.expected.jsx
@@ -19,7 +19,7 @@ interface State {
     items: Item[];
     offset: number;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hb484e503a22f = __cfHelpers.lift<{
     index: number;
     state: {
         offset: number;
@@ -44,12 +44,12 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h8a25b63df1cb = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const index = __cf_pattern_input.key("index");
     const state = __cf_pattern_input.key("params", "state");
     return (<div>
-            Item #{__cfLift_1({
+            Item #{__cfLift_hb484e503a22f({
         index: index,
         state: {
             offset: state.key("offset")
@@ -118,7 +118,7 @@ export default pattern((state) => {
     return {
         [UI]: (<div>
         {/* Uses both index parameter and captures state.offset */}
-        {state.key("items").mapWithPattern(__cfPattern_1, {
+        {state.key("items").mapWithPattern(__cfPattern_h8a25b63df1cb, {
                 state: {
                     offset: state.key("offset")
                 }
@@ -187,6 +187,8 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfPattern_1
+    __cfLift_hb484e503a22f,
+    __cfPattern_h8a25b63df1cb,
+    __cfLift_1: __cfLift_hb484e503a22f,
+    __cfPattern_1: __cfPattern_h8a25b63df1cb
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-index-shorthand.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-index-shorthand.expected.jsx
@@ -18,7 +18,7 @@ interface Item {
 interface State {
     items: Item[];
 }
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hc2743d0ed6b3 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const i = __cf_pattern_input.key("index");
     return (<div key={i}>
@@ -62,7 +62,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h055bedc1745d = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const idx = __cf_pattern_input.key("index");
     return (<div key={idx}>
@@ -115,10 +115,10 @@ export default pattern((state) => {
     return {
         [UI]: (<div>
         {/* Map with common shorthand index parameter names */}
-        {state.key("items").mapWithPattern(__cfPattern_1, {})}
+        {state.key("items").mapWithPattern(__cfPattern_hc2743d0ed6b3, {})}
 
         {/* Map with idx as index parameter */}
-        {state.key("items").mapWithPattern(__cfPattern_2, {})}
+        {state.key("items").mapWithPattern(__cfPattern_h055bedc1745d, {})}
       </div>),
     };
 }, {
@@ -180,6 +180,8 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfPattern_1,
-    __cfPattern_2
+    __cfPattern_hc2743d0ed6b3,
+    __cfPattern_h055bedc1745d,
+    __cfPattern_1: __cfPattern_hc2743d0ed6b3,
+    __cfPattern_2: __cfPattern_h055bedc1745d
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-inline-fallback-receivers.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-inline-fallback-receivers.expected.jsx
@@ -22,7 +22,7 @@ interface Message {
 interface Input {
     messages: Message[];
 }
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hff129e72c0e8 = __cfHelpers.pattern(__cf_pattern_input => {
     const reaction = __cf_pattern_input.key("element");
     const msg = __cf_pattern_input.key("params", "msg");
     return (<button type="button" data-msg-id={msg.key("id")}>
@@ -89,7 +89,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h332182e77eca = __cfHelpers.pattern(__cf_pattern_input => {
     const reaction = __cf_pattern_input.key("element");
     const msg = __cf_pattern_input.key("params", "msg");
     return (<span>
@@ -148,15 +148,15 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h829001654f7f = __cfHelpers.pattern(__cf_pattern_input => {
     const msg = __cf_pattern_input.key("element");
     return (<section>
-            {(msg.key("reactions") ?? []).mapWithPattern(__cfPattern_1, {
+            {(msg.key("reactions") ?? []).mapWithPattern(__cfPattern_hff129e72c0e8, {
             msg: {
                 id: msg.key("id")
             }
         })}
-            {(msg.key("reactions") || []).mapWithPattern(__cfPattern_2, {
+            {(msg.key("reactions") || []).mapWithPattern(__cfPattern_h332182e77eca, {
             msg: {
                 id: msg.key("id")
             }
@@ -232,7 +232,7 @@ export default pattern((__cf_pattern_input) => {
     const messages = __cf_pattern_input.key("messages");
     return {
         [UI]: (<div>
-        {messages.mapWithPattern(__cfPattern_3, {})}
+        {messages.mapWithPattern(__cfPattern_h829001654f7f, {})}
       </div>),
     };
 }, {
@@ -312,7 +312,10 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfPattern_1,
-    __cfPattern_2,
-    __cfPattern_3
+    __cfPattern_hff129e72c0e8,
+    __cfPattern_h332182e77eca,
+    __cfPattern_h829001654f7f,
+    __cfPattern_1: __cfPattern_hff129e72c0e8,
+    __cfPattern_2: __cfPattern_h332182e77eca,
+    __cfPattern_3: __cfPattern_h829001654f7f
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-inside-ifelse-with-handler.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-inside-ifelse-with-handler.expected.jsx
@@ -42,7 +42,7 @@ const removeItem = handler({
         items.set(currentItems.toSpliced(index, 1));
     }
 });
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hc7fc4f5f7121 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const items = __cf_pattern_input.key("params", "items");
     return (<div>
@@ -129,7 +129,7 @@ export default pattern((__cf_pattern_input) => {
                         properties: {}
                     }]
             } as const satisfies __cfHelpers.JSONSchema, {} as const satisfies __cfHelpers.JSONSchema, hasItems, <div>
-              {items.mapWithPattern(__cfPattern_1, {
+              {items.mapWithPattern(__cfPattern_hc7fc4f5f7121, {
                     items: items
                 })}
             </div>, <div>No items</div>)}
@@ -198,5 +198,6 @@ function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
     removeItem,
-    __cfPattern_1
+    __cfPattern_hc7fc4f5f7121,
+    __cfPattern_1: __cfPattern_hc7fc4f5f7121
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-jsx-map-filter-chain.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-jsx-map-filter-chain.expected.jsx
@@ -15,7 +15,7 @@ interface Item {
     name: string;
     active: boolean;
 }
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h2034208c1680 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return ({
         name: item.key("name"),
@@ -55,7 +55,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     },
     required: ["name", "active"]
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h5603ae6f4eee = __cfHelpers.pattern(__cf_pattern_input => {
     const entry = __cf_pattern_input.key("element");
     return entry.key("active");
 }, {
@@ -78,7 +78,7 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h27bd6432e8db = __cfHelpers.pattern(__cf_pattern_input => {
     const entry = __cf_pattern_input.key("element");
     return <span>{entry.key("name")}</span>;
 }, {
@@ -129,7 +129,7 @@ export default pattern((__cf_pattern_input) => {
     const list = __cf_pattern_input.key("list");
     return {
         [UI]: (<div>
-        {list.mapWithPattern(__cfPattern_1, {}).filterWithPattern(__cfPattern_2, {}).mapWithPattern(__cfPattern_3, {})}
+        {list.mapWithPattern(__cfPattern_h2034208c1680, {}).filterWithPattern(__cfPattern_h5603ae6f4eee, {}).mapWithPattern(__cfPattern_h27bd6432e8db, {})}
       </div>),
     };
 }, {
@@ -191,7 +191,10 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfPattern_1,
-    __cfPattern_2,
-    __cfPattern_3
+    __cfPattern_h2034208c1680,
+    __cfPattern_h5603ae6f4eee,
+    __cfPattern_h27bd6432e8db,
+    __cfPattern_1: __cfPattern_h2034208c1680,
+    __cfPattern_2: __cfPattern_h5603ae6f4eee,
+    __cfPattern_3: __cfPattern_h27bd6432e8db
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-local-helper-call-root.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-local-helper-call-root.expected.jsx
@@ -12,7 +12,7 @@ const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
 const identity = __cfHardenFn(<T,>(value: T) => value);
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hbaa31b91b83b = __cfHelpers.lift<{
     item: string;
 }, string>(({ item }) => identity(item.toUpperCase()), {
     type: "object",
@@ -25,9 +25,9 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_ha490a8b5065b = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
-    return __cfLift_1({ item: item }).for("__patternResult", true);
+    return __cfLift_hbaa31b91b83b({ item: item }).for("__patternResult", true);
 }, {
     type: "object",
     properties: {
@@ -47,7 +47,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 //   -> mapWithPattern(..., ({ item }) => lift(({ item }) => identity(item.toUpperCase()))(...))
 export default pattern((__cf_pattern_input) => {
     const items = __cf_pattern_input.key("items");
-    return items.mapWithPattern(__cfPattern_1, {}).for("__patternResult", true);
+    return items.mapWithPattern(__cfPattern_ha490a8b5065b, {}).for("__patternResult", true);
 }, {
     type: "object",
     properties: {
@@ -69,6 +69,8 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfPattern_1
+    __cfLift_hbaa31b91b83b,
+    __cfPattern_ha490a8b5065b,
+    __cfLift_1: __cfLift_hbaa31b91b83b,
+    __cfPattern_1: __cfPattern_ha490a8b5065b
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-multiple-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-multiple-captures.expected.jsx
@@ -21,7 +21,7 @@ interface State {
     taxRate: number;
 }
 const shippingCost = 5.99;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hc845c33291aa = __cfHelpers.lift<{
     item: {
         price: number;
         quantity: number;
@@ -66,12 +66,12 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h0db025943008 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const state = __cf_pattern_input.key("params", "state");
     const multiplier = __cf_pattern_input.params.multiplier;
     return (<span>
-            Total: {__cfLift_1({
+            Total: {__cfLift_hc845c33291aa({
         item: {
             price: item.key("price"),
             quantity: item.key("quantity")
@@ -161,7 +161,7 @@ export default pattern((state) => {
     const multiplier = 2;
     return {
         [UI]: (<div>
-        {state.key("items").mapWithPattern(__cfPattern_1, {
+        {state.key("items").mapWithPattern(__cfPattern_h0db025943008, {
                 state: {
                     discount: state.key("discount"),
                     taxRate: state.key("taxRate")
@@ -235,6 +235,8 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfPattern_1
+    __cfLift_hc845c33291aa,
+    __cfPattern_h0db025943008,
+    __cfLift_1: __cfLift_hc845c33291aa,
+    __cfPattern_1: __cfPattern_h0db025943008
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-multiple-similar-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-multiple-similar-captures.expected.jsx
@@ -22,7 +22,7 @@ interface State {
         discount: number;
     };
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h7054fb4e11e1 = __cfHelpers.lift<{
     item: {
         price: number;
     };
@@ -75,11 +75,11 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h11b0654cd179 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const state = __cf_pattern_input.key("params", "state");
     return (<span>
-            {__cfLift_1({
+            {__cfLift_h7054fb4e11e1({
         item: {
             price: item.key("price")
         },
@@ -166,7 +166,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 export default pattern((state) => {
     return {
         [UI]: (<div>
-        {state.key("items").mapWithPattern(__cfPattern_1, {
+        {state.key("items").mapWithPattern(__cfPattern_h11b0654cd179, {
                 state: {
                     checkout: {
                         discount: state.key("checkout", "discount")
@@ -247,6 +247,8 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfPattern_1
+    __cfLift_h7054fb4e11e1,
+    __cfPattern_h11b0654cd179,
+    __cfLift_1: __cfLift_h7054fb4e11e1,
+    __cfPattern_1: __cfPattern_h11b0654cd179
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-nested-callback.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-nested-callback.expected.jsx
@@ -24,7 +24,7 @@ interface State {
     items: Item[];
     prefix: string;
 }
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h3b72c8cb776e = __cfHelpers.pattern(__cf_pattern_input => {
     const tag = __cf_pattern_input.key("element");
     const item = __cf_pattern_input.key("params", "item");
     return (<li>{item.key("name")} - {tag.key("name")}</li>);
@@ -86,13 +86,13 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hba936b52ceef = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const state = __cf_pattern_input.key("params", "state");
     return (<div>
             {state.key("prefix")}: {item.key("name")}
             <ul>
-              {item.key("tags").mapWithPattern(__cfPattern_1, {
+              {item.key("tags").mapWithPattern(__cfPattern_h3b72c8cb776e, {
             item: {
                 name: item.key("name")
             }
@@ -184,7 +184,7 @@ export default pattern((state) => {
     return {
         [UI]: (<div>
         {/* Outer map captures state.prefix, inner map closes over item from outer callback */}
-        {state.key("items").mapWithPattern(__cfPattern_2, {
+        {state.key("items").mapWithPattern(__cfPattern_hba936b52ceef, {
                 state: {
                     prefix: state.key("prefix")
                 }
@@ -271,6 +271,8 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfPattern_1,
-    __cfPattern_2
+    __cfPattern_h3b72c8cb776e,
+    __cfPattern_hba936b52ceef,
+    __cfPattern_1: __cfPattern_h3b72c8cb776e,
+    __cfPattern_2: __cfPattern_hba936b52ceef
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-nested-property.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-nested-property.expected.jsx
@@ -23,7 +23,7 @@ interface State {
     items: Item[];
     currentUser: User;
 }
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h456793747a37 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const state = __cf_pattern_input.key("params", "state");
     return (<div>
@@ -103,7 +103,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 export default pattern((state) => {
     return {
         [UI]: (<div>
-        {state.key("items").mapWithPattern(__cfPattern_1, {
+        {state.key("items").mapWithPattern(__cfPattern_h456793747a37, {
                 state: {
                     currentUser: {
                         firstName: state.key("currentUser", "firstName"),
@@ -187,5 +187,6 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfPattern_1
+    __cfPattern_h456793747a37,
+    __cfPattern_1: __cfPattern_h456793747a37
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-no-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-no-captures.expected.jsx
@@ -18,7 +18,7 @@ interface Item {
 interface State {
     items: Item[];
 }
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h8fb708da64cf = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return (<div>Item #{item.key("id")}: ${item.key("price")}</div>);
 }, {
@@ -72,7 +72,7 @@ export default pattern((state) => {
     return {
         [UI]: (<div>
         {/* No captures - just uses the callback parameter */}
-        {state.key("items").mapWithPattern(__cfPattern_1, {})}
+        {state.key("items").mapWithPattern(__cfPattern_h8fb708da64cf, {})}
       </div>),
     };
 }, {
@@ -134,5 +134,6 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfPattern_1
+    __cfPattern_h8fb708da64cf,
+    __cfPattern_1: __cfPattern_h8fb708da64cf
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-outer-element.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-outer-element.expected.jsx
@@ -15,7 +15,7 @@ interface State {
     items: number[];
     highlight: string;
 }
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h4ad5e93039d3 = __cfHelpers.pattern(__cf_pattern_input => {
     const _ = __cf_pattern_input.key("element");
     const index = __cf_pattern_input.key("index");
     const element = __cf_pattern_input.key("params", "element");
@@ -69,7 +69,7 @@ export default pattern((state) => {
     const element = state.key("highlight");
     return {
         [UI]: (<div>
-        {state.key("items").mapWithPattern(__cfPattern_1, {
+        {state.key("items").mapWithPattern(__cfPattern_h4ad5e93039d3, {
                 element: element
             })}
       </div>),
@@ -122,5 +122,6 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfPattern_1
+    __cfPattern_h4ad5e93039d3,
+    __cfPattern_1: __cfPattern_h4ad5e93039d3
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-paren-wrapped-callback.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-paren-wrapped-callback.expected.jsx
@@ -14,7 +14,7 @@ const __cfAmdHooks = undefined;
 interface Row {
     label: string;
 }
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_he1be81448b35 = __cfHelpers.pattern(__cf_pattern_input => {
     const r = __cf_pattern_input.key("element");
     return r.key("label");
 }, {
@@ -47,7 +47,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 //   reactive .map that throws at runtime
 export default pattern((__cf_pattern_input) => {
     const rows = __cf_pattern_input.key("rows");
-    const out = rows.mapWithPattern(__cfPattern_1, {}).for("out", true);
+    const out = rows.mapWithPattern(__cfPattern_he1be81448b35, {}).for("out", true);
     return { out };
 }, {
     type: "object",
@@ -87,5 +87,6 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfPattern_1
+    __cfPattern_he1be81448b35,
+    __cfPattern_1: __cfPattern_he1be81448b35
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-parking-style-join.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-parking-style-join.expected.jsx
@@ -32,7 +32,7 @@ interface State {
     removePersonConfirmTarget: string | null;
     spots: Spot[];
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hef6f0b5f7981 = __cfHelpers.lift<{
     state: {
         editingPersonName: string | null;
     };
@@ -61,7 +61,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_h703af272706b = __cfHelpers.lift<{
     state: {
         removePersonConfirmTarget: string | null;
     };
@@ -90,7 +90,7 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_3 = __cfHelpers.lift<{
+const __cfLift_h15cbbaba2d64 = __cfHelpers.lift<{
     state: {
         spots: {
             spotNumber: string;
@@ -147,7 +147,7 @@ const __cfLift_3 = __cfHelpers.lift<{
         required: ["label", "value"]
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_4 = __cfHelpers.lift<{
+const __cfLift_h10a03c43aa30 = __cfHelpers.lift<{
     activeSpotOpts: {
         length: number;
     };
@@ -168,7 +168,7 @@ const __cfLift_4 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_5 = __cfHelpers.lift<{
+const __cfLift_h08a94ce500b2 = __cfHelpers.lift<{
     spotPreferences: string[];
 }, boolean>(({ spotPreferences }) => spotPreferences.length > 0, {
     type: "object",
@@ -184,7 +184,7 @@ const __cfLift_5 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_6 = __cfHelpers.lift<{
+const __cfLift_h7c1de21101a8 = __cfHelpers.lift<{
     spotPreferences: string[];
 }, string>(({ spotPreferences }) => spotPreferences.map((n) => "#" + n).join(", "), {
     type: "object",
@@ -200,23 +200,23 @@ const __cfLift_6 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h643a896225ff = __cfHelpers.pattern(__cf_pattern_input => {
     const person = __cf_pattern_input.key("element");
     const state = __cf_pattern_input.key("params", "state");
     const personName = person.key("name"), email = person.key("email"), commuteMode = person.key("commuteMode"), priorityRank = person.key("priorityRank"), defaultSpot = person.key("defaultSpot"), spotPreferences = person.key("spotPreferences"), isFirst = person.key("isFirst"), isLast = person.key("isLast");
-    const isEditing = __cfLift_1({
+    const isEditing = __cfLift_hef6f0b5f7981({
         state: {
             editingPersonName: state.key("editingPersonName")
         },
         personName: personName
     }).for("isEditing", true);
-    const isRemoveConfirm = __cfLift_2({
+    const isRemoveConfirm = __cfLift_h703af272706b({
         state: {
             removePersonConfirmTarget: state.key("removePersonConfirmTarget")
         },
         personName: personName
     }).for("isRemoveConfirm", true);
-    const activeSpotOpts = __cfLift_3({ state: {
+    const activeSpotOpts = __cfLift_h15cbbaba2d64({ state: {
             spots: state.key("spots")
         } }).for("activeSpotOpts", true);
     return (<section>
@@ -325,7 +325,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
                 type: "object",
                 properties: {}
             }]
-    } as const satisfies __cfHelpers.JSONSchema, __cfLift_4({ activeSpotOpts: {
+    } as const satisfies __cfHelpers.JSONSchema, __cfLift_h10a03c43aa30({ activeSpotOpts: {
             length: activeSpotOpts.key("length")
         } }), <span>spots</span>, null)}
               {__cfHelpers.ifElse({
@@ -344,8 +344,8 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
                 type: "object",
                 properties: {}
             }]
-    } as const satisfies __cfHelpers.JSONSchema, __cfLift_5({ spotPreferences: spotPreferences }), <span>
-                    Prefers: {__cfLift_6({ spotPreferences: spotPreferences })}
+    } as const satisfies __cfHelpers.JSONSchema, __cfLift_h08a94ce500b2({ spotPreferences: spotPreferences }), <span>
+                    Prefers: {__cfLift_h7c1de21101a8({ spotPreferences: spotPreferences })}
                   </span>, null)}
             </section>);
 }, {
@@ -468,7 +468,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 export default pattern((state) => {
     return {
         [UI]: (<div>
-        {state.key("people").mapWithPattern(__cfPattern_1, {
+        {state.key("people").mapWithPattern(__cfPattern_h643a896225ff, {
                 state: {
                     editingPersonName: state.key("editingPersonName"),
                     removePersonConfirmTarget: state.key("removePersonConfirmTarget"),
@@ -592,11 +592,18 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2,
-    __cfLift_3,
-    __cfLift_4,
-    __cfLift_5,
-    __cfLift_6,
-    __cfPattern_1
+    __cfLift_hef6f0b5f7981,
+    __cfLift_h703af272706b,
+    __cfLift_h15cbbaba2d64,
+    __cfLift_h10a03c43aa30,
+    __cfLift_h08a94ce500b2,
+    __cfLift_h7c1de21101a8,
+    __cfPattern_h643a896225ff,
+    __cfLift_1: __cfLift_hef6f0b5f7981,
+    __cfLift_2: __cfLift_h703af272706b,
+    __cfLift_3: __cfLift_h15cbbaba2d64,
+    __cfLift_4: __cfLift_h10a03c43aa30,
+    __cfLift_5: __cfLift_h08a94ce500b2,
+    __cfLift_6: __cfLift_h7c1de21101a8,
+    __cfPattern_1: __cfPattern_h643a896225ff
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-pattern-factory-result-key-access.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-pattern-factory-result-key-access.expected.jsx
@@ -65,7 +65,7 @@ const EntryRow = pattern((input) => ({
     },
     required: ["rendered", "$UI", "$NAME"]
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h78b7b76105ac = __cfHelpers.pattern(__cf_pattern_input => {
     const entry = __cf_pattern_input.key("element");
     const row = EntryRow({
         piece: entry.key("piece"),
@@ -130,7 +130,7 @@ export default pattern((__cf_pattern_input) => {
     const filtered = __cf_pattern_input.key("filtered");
     return ({
         [UI]: (<div>
-      {filtered.mapWithPattern(__cfPattern_1, {})}
+      {filtered.mapWithPattern(__cfPattern_h78b7b76105ac, {})}
     </div>),
     });
 }, {
@@ -199,5 +199,6 @@ function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
     EntryRow,
-    __cfPattern_1
+    __cfPattern_h78b7b76105ac,
+    __cfPattern_1: __cfPattern_h78b7b76105ac
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-plain-array-callback-local-comparison.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-plain-array-callback-local-comparison.expected.jsx
@@ -16,7 +16,7 @@ interface Input {
     weekDates: string[];
     todayDate: string;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hea7ee1be0297 = __cfHelpers.lift<{
     weekDates: string[];
     todayDate: string;
     colIdx: number;
@@ -56,7 +56,7 @@ export default pattern((__cf_pattern_input) => {
     return {
         [UI]: (<div>
         {COLUMN_INDICES.map((colIdx) => {
-                const isToday = __cfLift_1({
+                const isToday = __cfLift_hea7ee1be0297({
                     weekDates: weekDates,
                     todayDate: todayDate,
                     colIdx: colIdx
@@ -121,5 +121,6 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_hea7ee1be0297,
+    __cfLift_1: __cfLift_hea7ee1be0297
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-plain-array-no-transform.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-plain-array-no-transform.expected.jsx
@@ -14,7 +14,7 @@ const __cfAmdHooks = undefined;
 interface State {
     multiplier: number;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h8ee54f7adb93 = __cfHelpers.lift<{
     state: {
         multiplier: number;
     };
@@ -51,7 +51,7 @@ export default pattern((state) => {
     return {
         [UI]: (<div>
         {/* Plain array should NOT be transformed, even with captures */}
-        {plainArray.map((n) => (<span>{__cfLift_1({
+        {plainArray.map((n) => (<span>{__cfLift_h8ee54f7adb93({
                 state: {
                     multiplier: state.multiplier
                 },
@@ -101,5 +101,6 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_h8ee54f7adb93,
+    __cfLift_1: __cfLift_h8ee54f7adb93
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-plain-array-some-alias-in-computed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-plain-array-some-alias-in-computed.expected.jsx
@@ -24,7 +24,7 @@ interface Input {
     logs: Writable<HabitLog[]>;
     todayDate: string;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hac16c55fa17a = __cfHelpers.lift<{
     logs: __cfHelpers.ReadonlyCell<HabitLog[]>;
     habit: {
         name: string;
@@ -79,11 +79,11 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hd0e404c05c63 = __cfHelpers.pattern(__cf_pattern_input => {
     const habit = __cf_pattern_input.key("element");
     const logs = __cf_pattern_input.key("params", "logs");
     const todayDate = __cf_pattern_input.key("params", "todayDate");
-    const doneToday = __cfLift_1({
+    const doneToday = __cfLift_hac16c55fa17a({
         logs: logs,
         habit: {
             name: habit.key("name")
@@ -180,7 +180,7 @@ export default pattern((__cf_pattern_input) => {
     const logs = __cf_pattern_input.key("logs");
     const todayDate = __cf_pattern_input.key("todayDate");
     return {
-        [UI]: <div>{habits.mapWithPattern(__cfPattern_1, {
+        [UI]: <div>{habits.mapWithPattern(__cfPattern_hd0e404c05c63, {
                 logs: logs,
                 todayDate: todayDate
             })}</div>,
@@ -266,6 +266,8 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfPattern_1
+    __cfLift_hac16c55fa17a,
+    __cfPattern_hd0e404c05c63,
+    __cfLift_1: __cfLift_hac16c55fa17a,
+    __cfPattern_1: __cfPattern_hd0e404c05c63
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-plain-array-some-in-computed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-plain-array-some-in-computed.expected.jsx
@@ -24,7 +24,7 @@ interface Input {
     logs: Writable<HabitLog[]>;
     todayDate: string;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h093ae1e435d0 = __cfHelpers.lift<{
     logs: __cfHelpers.ReadonlyCell<HabitLog[]>;
     habit: {
         name: string;
@@ -76,11 +76,11 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h7539fce3615a = __cfHelpers.pattern(__cf_pattern_input => {
     const habit = __cf_pattern_input.key("element");
     const logs = __cf_pattern_input.key("params", "logs");
     const todayDate = __cf_pattern_input.key("params", "todayDate");
-    const doneToday = __cfLift_1({
+    const doneToday = __cfLift_h093ae1e435d0({
         logs: logs,
         habit: {
             name: habit.key("name")
@@ -177,7 +177,7 @@ export default pattern((__cf_pattern_input) => {
     const logs = __cf_pattern_input.key("logs");
     const todayDate = __cf_pattern_input.key("todayDate");
     return {
-        [UI]: <div>{habits.mapWithPattern(__cfPattern_1, {
+        [UI]: <div>{habits.mapWithPattern(__cfPattern_h7539fce3615a, {
                 logs: logs,
                 todayDate: todayDate
             })}</div>,
@@ -263,6 +263,8 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfPattern_1
+    __cfLift_h093ae1e435d0,
+    __cfPattern_h7539fce3615a,
+    __cfLift_1: __cfLift_h093ae1e435d0,
+    __cfPattern_1: __cfPattern_h7539fce3615a
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-receiver-key-lowering.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-receiver-key-lowering.expected.jsx
@@ -19,7 +19,7 @@ interface Item {
 interface Input {
     items: Item[];
 }
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h660817dcb292 = __cfHelpers.pattern(__cf_pattern_input => {
     const subItem = __cf_pattern_input.key("element");
     return subItem.key("value");
 }, {
@@ -39,9 +39,9 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h809ee353f610 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
-    return item.key("subItems").mapWithPattern(__cfPattern_1, {}).for("__patternResult", true);
+    return item.key("subItems").mapWithPattern(__cfPattern_h660817dcb292, {}).for("__patternResult", true);
 }, {
     type: "object",
     properties: {
@@ -83,7 +83,7 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
 // Context: No captures; receiver expression item.subItems is lowered to item.key("subItems")
 const _p = pattern((__cf_pattern_input) => {
     const items = __cf_pattern_input.key("items");
-    return items.mapWithPattern(__cfPattern_2, {});
+    return items.mapWithPattern(__cfPattern_h809ee353f610, {});
 }, {
     type: "object",
     properties: {
@@ -129,6 +129,8 @@ function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
     _p,
-    __cfPattern_1,
-    __cfPattern_2
+    __cfPattern_h660817dcb292,
+    __cfPattern_h809ee353f610,
+    __cfPattern_1: __cfPattern_h660817dcb292,
+    __cfPattern_2: __cfPattern_h809ee353f610
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-receiver-method-roots.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-receiver-method-roots.expected.jsx
@@ -12,7 +12,7 @@ const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
 const identity = __cfHardenFn(<T,>(value: T) => value);
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h8ee1135a2ccf = __cfHelpers.lift<{
     item: string;
 }, string>(({ item }) => item.toUpperCase(), {
     type: "object",
@@ -25,9 +25,9 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hbc17ca4d1b2f = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
-    return <span>{__cfLift_1({ item: item })}</span>;
+    return <span>{__cfLift_h8ee1135a2ccf({ item: item })}</span>;
 }, {
     type: "object",
     properties: {
@@ -57,7 +57,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_hbaa31b91b83b = __cfHelpers.lift<{
     item: string;
 }, string>(({ item }) => identity(item.toUpperCase()), {
     type: "object",
@@ -70,9 +70,9 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hb5c2e134399f = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
-    return <span>{__cfLift_2({ item: item })}</span>;
+    return <span>{__cfLift_hbaa31b91b83b({ item: item })}</span>;
 }, {
     type: "object",
     properties: {
@@ -110,8 +110,8 @@ export default pattern((__cf_pattern_input) => {
     const items = __cf_pattern_input.key("items");
     return ({
         [UI]: (<div>
-      {items.mapWithPattern(__cfPattern_1, {})}
-      {items.mapWithPattern(__cfPattern_2, {})}
+      {items.mapWithPattern(__cfPattern_hbc17ca4d1b2f, {})}
+      {items.mapWithPattern(__cfPattern_hb5c2e134399f, {})}
     </div>),
     });
 }, {
@@ -159,8 +159,12 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfPattern_1,
-    __cfLift_2,
-    __cfPattern_2
+    __cfLift_h8ee1135a2ccf,
+    __cfPattern_hbc17ca4d1b2f,
+    __cfLift_hbaa31b91b83b,
+    __cfPattern_hb5c2e134399f,
+    __cfLift_1: __cfLift_h8ee1135a2ccf,
+    __cfPattern_1: __cfPattern_hbc17ca4d1b2f,
+    __cfLift_2: __cfLift_hbaa31b91b83b,
+    __cfPattern_2: __cfPattern_hb5c2e134399f
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-regains-reactive-aliases.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-regains-reactive-aliases.expected.jsx
@@ -22,7 +22,7 @@ const passthrough = lift((items: string[]) => items, {
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h25c7969c79e7 = __cfHelpers.lift<{
     state: {
         items: string[];
     };
@@ -49,7 +49,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_h46fcdf4bd295 = __cfHelpers.lift<{
     inner: string[];
 }, string[]>(({ inner }) => inner, {
     type: "object",
@@ -68,7 +68,7 @@ const __cfLift_2 = __cfHelpers.lift<{
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_3 = __cfHelpers.lift<{
+const __cfLift_haacab7ab55c2 = __cfHelpers.lift<{
     item: string;
 }, string>(({ item }) => item + "!", {
     type: "object",
@@ -81,9 +81,9 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hbedea5792321 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
-    return __cfLift_3({ item: item }).for("__patternResult", true);
+    return __cfLift_haacab7ab55c2({ item: item }).for("__patternResult", true);
 }, {
     type: "object",
     properties: {
@@ -95,11 +95,11 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_4 = __cfHelpers.lift<{
+const __cfLift_h3a10d74f22a6 = __cfHelpers.lift<{
     inner: string[];
 }, string[]>(({ inner }) => {
-    const foo = __cfLift_2({ inner: inner }).for("foo", true);
-    return foo.mapWithPattern(__cfPattern_1, {});
+    const foo = __cfLift_h46fcdf4bd295({ inner: inner }).for("foo", true);
+    return foo.mapWithPattern(__cfPattern_hbedea5792321, {});
 }, {
     type: "object",
     properties: {
@@ -117,7 +117,7 @@ const __cfLift_4 = __cfHelpers.lift<{
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_5 = __cfHelpers.lift<{
+const __cfLift_haacab7ab55c2_2 = __cfHelpers.lift<{
     item: string;
 }, string>(({ item }) => item + "!", {
     type: "object",
@@ -130,9 +130,9 @@ const __cfLift_5 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h3a7d86a214aa = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
-    return __cfLift_5({ item: item }).for("__patternResult", true);
+    return __cfLift_haacab7ab55c2_2({ item: item }).for("__patternResult", true);
 }, {
     type: "object",
     properties: {
@@ -144,11 +144,11 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_6 = __cfHelpers.lift<{
+const __cfLift_hb60fff46237a = __cfHelpers.lift<{
     inner: string[];
 }, string[]>(({ inner }) => {
     const foo = passthrough(inner).for("foo", true);
-    return foo.mapWithPattern(__cfPattern_2, {});
+    return foo.mapWithPattern(__cfPattern_h3a7d86a214aa, {});
 }, {
     type: "object",
     properties: {
@@ -166,7 +166,7 @@ const __cfLift_6 = __cfHelpers.lift<{
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_7 = __cfHelpers.lift<{
+const __cfLift_haacab7ab55c2_3 = __cfHelpers.lift<{
     item: string;
 }, string>(({ item }) => item + "!", {
     type: "object",
@@ -179,9 +179,9 @@ const __cfLift_7 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hc0add00504ab = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
-    return __cfLift_7({ item: item }).for("__patternResult", true);
+    return __cfLift_haacab7ab55c2_3({ item: item }).for("__patternResult", true);
 }, {
     type: "object",
     properties: {
@@ -193,7 +193,7 @@ const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_8 = __cfHelpers.lift(() => {
+const __cfLift_h7059495abfc1 = __cfHelpers.lift(() => {
     const foo = wish<Default<string[], [
     ]>>({ query: "#items" }, {
         type: "array",
@@ -202,9 +202,9 @@ const __cfLift_8 = __cfHelpers.lift(() => {
         },
         "default": []
     } as const satisfies __cfHelpers.JSONSchema).result!;
-    return foo.mapWithPattern(__cfPattern_3, {});
+    return foo.mapWithPattern(__cfPattern_hc0add00504ab, {});
 }, false, undefined, { completeSchedulerScopeSummary: true });
-const __cfLift_9 = __cfHelpers.lift<{
+const __cfLift_h46fcdf4bd295_2 = __cfHelpers.lift<{
     inner: string[];
 }, string[]>(({ inner }) => inner, {
     type: "object",
@@ -223,7 +223,7 @@ const __cfLift_9 = __cfHelpers.lift<{
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_10 = __cfHelpers.lift<{
+const __cfLift_hd0cb62492362 = __cfHelpers.lift<{
     item: {
         length: number;
     };
@@ -244,9 +244,9 @@ const __cfLift_10 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_4 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h349f704fe887 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
-    return __cfLift_10({ item: {
+    return __cfLift_hd0cb62492362({ item: {
             length: item.key("length")
         } }).for("__patternResult", true);
 }, {
@@ -260,7 +260,7 @@ const __cfPattern_4 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_11 = __cfHelpers.lift<{
+const __cfLift_haacab7ab55c2_4 = __cfHelpers.lift<{
     item: string;
 }, string>(({ item }) => item + "!", {
     type: "object",
@@ -273,9 +273,9 @@ const __cfLift_11 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_5 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_ha964652d3e0d = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
-    return __cfLift_11({ item: item }).for("__patternResult", true);
+    return __cfLift_haacab7ab55c2_4({ item: item }).for("__patternResult", true);
 }, {
     type: "object",
     properties: {
@@ -287,12 +287,12 @@ const __cfPattern_5 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_12 = __cfHelpers.lift<{
+const __cfLift_h663d123103e9 = __cfHelpers.lift<{
     inner: string[];
 }, string[]>(({ inner }) => {
-    const foo = __cfLift_9({ inner: inner }).for("foo", true);
-    const filtered = foo.filterWithPattern(__cfPattern_4, {}).for("filtered", true);
-    return filtered.mapWithPattern(__cfPattern_5, {});
+    const foo = __cfLift_h46fcdf4bd295_2({ inner: inner }).for("foo", true);
+    const filtered = foo.filterWithPattern(__cfPattern_h349f704fe887, {}).for("filtered", true);
+    return filtered.mapWithPattern(__cfPattern_ha964652d3e0d, {});
 }, {
     type: "object",
     properties: {
@@ -310,7 +310,7 @@ const __cfLift_12 = __cfHelpers.lift<{
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_13 = __cfHelpers.lift<{
+const __cfLift_h46fcdf4bd295_3 = __cfHelpers.lift<{
     inner: string[];
 }, string[]>(({ inner }) => inner, {
     type: "object",
@@ -329,7 +329,7 @@ const __cfLift_13 = __cfHelpers.lift<{
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_14 = __cfHelpers.lift<{
+const __cfLift_hd0cb62492362_2 = __cfHelpers.lift<{
     item: {
         length: number;
     };
@@ -350,9 +350,9 @@ const __cfLift_14 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_6 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h75d29e59268b = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
-    return __cfLift_14({ item: {
+    return __cfLift_hd0cb62492362_2({ item: {
             length: item.key("length")
         } }).for("__patternResult", true);
 }, {
@@ -366,7 +366,7 @@ const __cfPattern_6 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_15 = __cfHelpers.lift<{
+const __cfLift_h8ee1135a2ccf = __cfHelpers.lift<{
     item: string;
 }, string>(({ item }) => item.toUpperCase(), {
     type: "object",
@@ -379,9 +379,9 @@ const __cfLift_15 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_7 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hf23ac404a1de = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
-    return __cfLift_15({ item: item }).for("__patternResult", true);
+    return __cfLift_h8ee1135a2ccf({ item: item }).for("__patternResult", true);
 }, {
     type: "object",
     properties: {
@@ -393,12 +393,12 @@ const __cfPattern_7 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_16 = __cfHelpers.lift<{
+const __cfLift_h5e1e356213e2 = __cfHelpers.lift<{
     inner: string[];
 }, string[]>(({ inner }) => {
-    const foo = __cfLift_13({ inner: inner }).for("foo", true);
-    const filtered = foo.filterWithPattern(__cfPattern_6, {}).for("filtered", true);
-    return filtered.mapWithPattern(__cfPattern_7, {});
+    const foo = __cfLift_h46fcdf4bd295_3({ inner: inner }).for("foo", true);
+    const filtered = foo.filterWithPattern(__cfPattern_h75d29e59268b, {}).for("filtered", true);
+    return filtered.mapWithPattern(__cfPattern_hf23ac404a1de, {});
 }, {
     type: "object",
     properties: {
@@ -429,14 +429,14 @@ const __cfLift_16 = __cfHelpers.lift<{
 // Context: contrasts with the existing plain-array compute fixtures where the
 // callback receiver really is compute-owned plain JS data.
 export default pattern((state) => {
-    const inner = __cfLift_1({ state: {
+    const inner = __cfLift_h25c7969c79e7({ state: {
             items: state.key("items")
         } }).for("inner", true);
-    const fromComputed = __cfLift_4({ inner: inner }).for("fromComputed", true);
-    const fromLift = __cfLift_6({ inner: inner }).for("fromLift", true);
-    const fromWish = __cfLift_8().for("fromWish", true);
-    const fromFiltered = __cfLift_12({ inner: inner }).for("fromFiltered", true);
-    const fromFilteredReceiverMethod = __cfLift_16({ inner: inner }).for("fromFilteredReceiverMethod", true);
+    const fromComputed = __cfLift_h3a10d74f22a6({ inner: inner }).for("fromComputed", true);
+    const fromLift = __cfLift_hb60fff46237a({ inner: inner }).for("fromLift", true);
+    const fromWish = __cfLift_h7059495abfc1().for("fromWish", true);
+    const fromFiltered = __cfLift_h663d123103e9({ inner: inner }).for("fromFiltered", true);
+    const fromFilteredReceiverMethod = __cfLift_h5e1e356213e2({ inner: inner }).for("fromFilteredReceiverMethod", true);
     return {
         fromComputed,
         fromLift,
@@ -496,27 +496,50 @@ function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
     passthrough,
-    __cfLift_1,
-    __cfLift_2,
-    __cfLift_3,
-    __cfPattern_1,
-    __cfLift_4,
-    __cfLift_5,
-    __cfPattern_2,
-    __cfLift_6,
-    __cfLift_7,
-    __cfPattern_3,
-    __cfLift_8,
-    __cfLift_9,
-    __cfLift_10,
-    __cfPattern_4,
-    __cfLift_11,
-    __cfPattern_5,
-    __cfLift_12,
-    __cfLift_13,
-    __cfLift_14,
-    __cfPattern_6,
-    __cfLift_15,
-    __cfPattern_7,
-    __cfLift_16
+    __cfLift_h25c7969c79e7,
+    __cfLift_h46fcdf4bd295,
+    __cfLift_haacab7ab55c2,
+    __cfPattern_hbedea5792321,
+    __cfLift_h3a10d74f22a6,
+    __cfLift_haacab7ab55c2_2,
+    __cfPattern_h3a7d86a214aa,
+    __cfLift_hb60fff46237a,
+    __cfLift_haacab7ab55c2_3,
+    __cfPattern_hc0add00504ab,
+    __cfLift_h7059495abfc1,
+    __cfLift_h46fcdf4bd295_2,
+    __cfLift_hd0cb62492362,
+    __cfPattern_h349f704fe887,
+    __cfLift_haacab7ab55c2_4,
+    __cfPattern_ha964652d3e0d,
+    __cfLift_h663d123103e9,
+    __cfLift_h46fcdf4bd295_3,
+    __cfLift_hd0cb62492362_2,
+    __cfPattern_h75d29e59268b,
+    __cfLift_h8ee1135a2ccf,
+    __cfPattern_hf23ac404a1de,
+    __cfLift_h5e1e356213e2,
+    __cfLift_1: __cfLift_h25c7969c79e7,
+    __cfLift_2: __cfLift_h46fcdf4bd295,
+    __cfLift_3: __cfLift_haacab7ab55c2,
+    __cfPattern_1: __cfPattern_hbedea5792321,
+    __cfLift_4: __cfLift_h3a10d74f22a6,
+    __cfLift_5: __cfLift_haacab7ab55c2_2,
+    __cfPattern_2: __cfPattern_h3a7d86a214aa,
+    __cfLift_6: __cfLift_hb60fff46237a,
+    __cfLift_7: __cfLift_haacab7ab55c2_3,
+    __cfPattern_3: __cfPattern_hc0add00504ab,
+    __cfLift_8: __cfLift_h7059495abfc1,
+    __cfLift_9: __cfLift_h46fcdf4bd295_2,
+    __cfLift_10: __cfLift_hd0cb62492362,
+    __cfPattern_4: __cfPattern_h349f704fe887,
+    __cfLift_11: __cfLift_haacab7ab55c2_4,
+    __cfPattern_5: __cfPattern_ha964652d3e0d,
+    __cfLift_12: __cfLift_h663d123103e9,
+    __cfLift_13: __cfLift_h46fcdf4bd295_3,
+    __cfLift_14: __cfLift_hd0cb62492362_2,
+    __cfPattern_6: __cfPattern_h75d29e59268b,
+    __cfLift_15: __cfLift_h8ee1135a2ccf,
+    __cfPattern_7: __cfPattern_hf23ac404a1de,
+    __cfLift_16: __cfLift_h5e1e356213e2
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-result-cell-preserved.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-result-cell-preserved.expected.jsx
@@ -85,7 +85,7 @@ const Sub = pattern((__cf_pattern_input) => {
 export interface Input {
     items: Item[];
 }
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hfb54462a066e = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return Sub({ item });
 }, {
@@ -133,7 +133,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema);
 export default pattern((__cf_pattern_input) => {
     const items = __cf_pattern_input.key("items");
-    const subs = items.mapWithPattern(__cfPattern_1, {}).for("subs", true);
+    const subs = items.mapWithPattern(__cfPattern_hfb54462a066e, {}).for("subs", true);
     return { subs };
 }, {
     type: "object",
@@ -198,5 +198,6 @@ function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
     Sub,
-    __cfPattern_1
+    __cfPattern_hfb54462a066e,
+    __cfPattern_1: __cfPattern_hfb54462a066e
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-root-fallback-wrappers.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-root-fallback-wrappers.expected.jsx
@@ -14,7 +14,7 @@ const __cfAmdHooks = undefined;
 interface Item {
     id: string;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hff88f9de98cc = __cfHelpers.lift<{
     items?: Item[] | undefined;
 }, Item[]>(({ items }) => items ?? [], {
     type: "object",
@@ -54,7 +54,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hb32bf9452bc4 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return <span data-inline-id={item.key("id")}>{item.key("id")}</span>;
 }, {
@@ -97,7 +97,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_heac5394eeb2e = __cfHelpers.lift<{
     items?: Item[] | undefined;
 }, Item[]>(({ items }) => (items as Item[] | undefined) ?? [], {
     type: "object",
@@ -137,7 +137,7 @@ const __cfLift_2 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h2d6ab837b25b = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return (<span data-cast-id={item.key("id")}>{item.key("id")}</span>);
 }, {
@@ -180,7 +180,7 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_3 = __cfHelpers.lift<{
+const __cfLift_h8652c8fdce24 = __cfHelpers.lift<{
     items?: Item[] | undefined;
 }, Item[]>(({ items }) => (items satisfies Item[] | undefined) ?? [], {
     type: "object",
@@ -220,7 +220,7 @@ const __cfLift_3 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hef14e1c72f15 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return (<span data-satisfies-id={item.key("id")}>{item.key("id")}</span>);
 }, {
@@ -273,9 +273,9 @@ export default pattern((__cf_pattern_input) => {
     const items = __cf_pattern_input.key("items");
     return {
         [UI]: (<div>
-        {(__cfLift_1({ items: items })).mapWithPattern(__cfPattern_1, {})}
-        {(__cfLift_2({ items: items })).mapWithPattern(__cfPattern_2, {})}
-        {(__cfLift_3({ items: items })).mapWithPattern(__cfPattern_3, {})}
+        {(__cfLift_hff88f9de98cc({ items: items })).mapWithPattern(__cfPattern_hb32bf9452bc4, {})}
+        {(__cfLift_heac5394eeb2e({ items: items })).mapWithPattern(__cfPattern_h2d6ab837b25b, {})}
+        {(__cfLift_h8652c8fdce24({ items: items })).mapWithPattern(__cfPattern_hef14e1c72f15, {})}
       </div>),
     };
 }, {
@@ -333,10 +333,16 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfPattern_1,
-    __cfLift_2,
-    __cfPattern_2,
-    __cfLift_3,
-    __cfPattern_3
+    __cfLift_hff88f9de98cc,
+    __cfPattern_hb32bf9452bc4,
+    __cfLift_heac5394eeb2e,
+    __cfPattern_h2d6ab837b25b,
+    __cfLift_h8652c8fdce24,
+    __cfPattern_hef14e1c72f15,
+    __cfLift_1: __cfLift_hff88f9de98cc,
+    __cfPattern_1: __cfPattern_hb32bf9452bc4,
+    __cfLift_2: __cfLift_heac5394eeb2e,
+    __cfPattern_2: __cfPattern_h2d6ab837b25b,
+    __cfLift_3: __cfLift_h8652c8fdce24,
+    __cfPattern_3: __cfPattern_hef14e1c72f15
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-single-capture-no-name.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-single-capture-no-name.expected.jsx
@@ -17,7 +17,7 @@ interface State {
     }>;
     discount: number;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h0433d932131d = __cfHelpers.lift<{
     item: {
         price: number;
     };
@@ -50,10 +50,10 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h27008255a1a1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const state = __cf_pattern_input.key("params", "state");
-    return (<span>{__cfLift_1({
+    return (<span>{__cfLift_h0433d932131d({
         item: {
             price: item.key("price")
         },
@@ -118,7 +118,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 export default pattern((state: State) => {
     return {
         [UI]: (<div>
-        {state.key("items").mapWithPattern(__cfPattern_1, {
+        {state.key("items").mapWithPattern(__cfPattern_h27008255a1a1, {
                 state: {
                     discount: state.key("discount")
                 }
@@ -179,6 +179,8 @@ export default pattern((state: State) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfPattern_1
+    __cfLift_h0433d932131d,
+    __cfPattern_h27008255a1a1,
+    __cfLift_1: __cfLift_h0433d932131d,
+    __cfPattern_1: __cfPattern_h27008255a1a1
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-single-capture-with-type-arg-no-name.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-single-capture-with-type-arg-no-name.expected.jsx
@@ -17,7 +17,7 @@ interface State {
     }>;
     discount: number;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h0433d932131d = __cfHelpers.lift<{
     item: {
         price: number;
     };
@@ -50,10 +50,10 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h27008255a1a1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const state = __cf_pattern_input.key("params", "state");
-    return (<span>{__cfLift_1({
+    return (<span>{__cfLift_h0433d932131d({
         item: {
             price: item.key("price")
         },
@@ -118,7 +118,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 export default pattern((state) => {
     return {
         [UI]: (<div>
-        {state.key("items").mapWithPattern(__cfPattern_1, {
+        {state.key("items").mapWithPattern(__cfPattern_h27008255a1a1, {
                 state: {
                     discount: state.key("discount")
                 }
@@ -179,6 +179,8 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfPattern_1
+    __cfLift_h0433d932131d,
+    __cfPattern_h27008255a1a1,
+    __cfLift_1: __cfLift_h0433d932131d,
+    __cfPattern_1: __cfPattern_h27008255a1a1
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-single-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-single-capture.expected.jsx
@@ -17,7 +17,7 @@ interface State {
     }>;
     discount: number;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h0433d932131d = __cfHelpers.lift<{
     item: {
         price: number;
     };
@@ -50,10 +50,10 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h27008255a1a1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const state = __cf_pattern_input.key("params", "state");
-    return (<span>{__cfLift_1({
+    return (<span>{__cfLift_h0433d932131d({
         item: {
             price: item.key("price")
         },
@@ -118,7 +118,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 export default pattern((state) => {
     return {
         [UI]: (<div>
-        {state.key("items").mapWithPattern(__cfPattern_1, {
+        {state.key("items").mapWithPattern(__cfPattern_h27008255a1a1, {
                 state: {
                     discount: state.key("discount")
                 }
@@ -179,6 +179,8 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfPattern_1
+    __cfLift_h0433d932131d,
+    __cfPattern_h27008255a1a1,
+    __cfLift_1: __cfLift_h0433d932131d,
+    __cfPattern_1: __cfPattern_h27008255a1a1
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-symbol-key-access.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-symbol-key-access.expected.jsx
@@ -18,7 +18,7 @@ interface Entry {
 interface Input {
     items: Entry[];
 }
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hb82b3fcbd408 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return ({ n: item.key(__cfHelpers.NAME), u: item.key(__cfHelpers.UI) });
 }, {
@@ -62,7 +62,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 // Context: Symbol-keyed property access (NAME, UI) is lowered to .key() with helper references
 const _p = pattern((__cf_pattern_input) => {
     const items = __cf_pattern_input.key("items");
-    return items.mapWithPattern(__cfPattern_1, {});
+    return items.mapWithPattern(__cfPattern_hb82b3fcbd408, {});
 }, {
     type: "object",
     properties: {
@@ -108,5 +108,6 @@ function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
     _p,
-    __cfPattern_1
+    __cfPattern_hb82b3fcbd408,
+    __cfPattern_1: __cfPattern_hb82b3fcbd408
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-template-literal.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-template-literal.expected.jsx
@@ -20,7 +20,7 @@ interface State {
     prefix: string;
     suffix: string;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h508f75dbbc9b = __cfHelpers.lift<{
     state: {
         prefix: string;
         suffix: string;
@@ -57,10 +57,10 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h20ff6bcddac9 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const state = __cf_pattern_input.key("params", "state");
-    return (<div>{__cfLift_1({
+    return (<div>{__cfLift_h508f75dbbc9b({
         state: {
             prefix: state.key("prefix"),
             suffix: state.key("suffix")
@@ -139,7 +139,7 @@ export default pattern((state) => {
     return {
         [UI]: (<div>
         {/* Template literal with captures */}
-        {state.key("items").mapWithPattern(__cfPattern_1, {
+        {state.key("items").mapWithPattern(__cfPattern_h20ff6bcddac9, {
                 state: {
                     prefix: state.key("prefix"),
                     suffix: state.key("suffix")
@@ -212,6 +212,8 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfPattern_1
+    __cfLift_h508f75dbbc9b,
+    __cfPattern_h20ff6bcddac9,
+    __cfLift_1: __cfLift_h508f75dbbc9b,
+    __cfPattern_1: __cfPattern_h20ff6bcddac9
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-ternary-inside-nested-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-ternary-inside-nested-map.expected.jsx
@@ -34,7 +34,7 @@ interface PatternInput {
     ]>>;
     showInactive?: Default<boolean, false>;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h3e4089b7ce19 = __cfHelpers.lift<{
     items: __cfHelpers.ReadonlyCell<unknown[]>;
 }, boolean>(({ items }) => items.get().length > 0, {
     type: "object",
@@ -51,7 +51,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_hfdc4f733cafa = __cfHelpers.lift<{
     item: {
         tags: {
             length: number;
@@ -80,7 +80,7 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h2a999321e38e = __cfHelpers.pattern(__cf_pattern_input => {
     const tag = __cf_pattern_input.key("element");
     const showInactive = __cf_pattern_input.key("params", "showInactive");
     return (<li>
@@ -156,7 +156,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h766236d8cc20 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const showInactive = __cf_pattern_input.key("params", "showInactive");
     return (<div>
@@ -169,13 +169,13 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
         type: "string"
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "string"
-    } as const satisfies __cfHelpers.JSONSchema, __cfLift_2({ item: {
+    } as const satisfies __cfHelpers.JSONSchema, __cfLift_hfdc4f733cafa({ item: {
             tags: {
                 length: item.key("tags", "length")
             }
         } }), item.key("label"), "No tags")}</strong>
               <ul>
-                {item.key("tags").mapWithPattern(__cfPattern_1, {
+                {item.key("tags").mapWithPattern(__cfPattern_h2a999321e38e, {
             showInactive: showInactive
         })}
               </ul>
@@ -258,7 +258,7 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
 export default pattern((__cf_pattern_input) => {
     const items = __cf_pattern_input.key("items");
     const showInactive = __cf_pattern_input.key("showInactive");
-    const hasItems = __cfLift_1({ items: items }).for("hasItems", true);
+    const hasItems = __cfLift_h3e4089b7ce19({ items: items }).for("hasItems", true);
     return {
         [UI]: (<div>
         {__cfHelpers.ifElse({
@@ -279,7 +279,7 @@ export default pattern((__cf_pattern_input) => {
                     type: "object",
                     properties: {}
                 }]
-        } as const satisfies __cfHelpers.JSONSchema, hasItems, items.mapWithPattern(__cfPattern_2, {
+        } as const satisfies __cfHelpers.JSONSchema, hasItems, items.mapWithPattern(__cfPattern_h766236d8cc20, {
             showInactive: showInactive
         }), <p>No items</p>)}
       </div>),
@@ -363,8 +363,12 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2,
-    __cfPattern_1,
-    __cfPattern_2
+    __cfLift_h3e4089b7ce19,
+    __cfLift_hfdc4f733cafa,
+    __cfPattern_h2a999321e38e,
+    __cfPattern_h766236d8cc20,
+    __cfLift_1: __cfLift_h3e4089b7ce19,
+    __cfLift_2: __cfLift_hfdc4f733cafa,
+    __cfPattern_1: __cfPattern_h2a999321e38e,
+    __cfPattern_2: __cfPattern_h766236d8cc20
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-wish-default-handler-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-wish-default-handler-capture.expected.jsx
@@ -52,7 +52,7 @@ const removeItem = handler({
 } as const satisfies __cfHelpers.JSONSchema, (_, { items, item }) => {
     items.remove(item);
 });
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hdaf4da8c46b9 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const items = __cf_pattern_input.key("params", "items");
     return (<li>
@@ -148,7 +148,7 @@ export default pattern((_) => {
     return {
         [NAME]: "Test",
         [UI]: (<ul>
-        {items.mapWithPattern(__cfPattern_1, {
+        {items.mapWithPattern(__cfPattern_hdaf4da8c46b9, {
                 items: items
             })}
       </ul>),
@@ -195,5 +195,6 @@ function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
     removeItem,
-    __cfPattern_1
+    __cfPattern_hdaf4da8c46b9,
+    __cfPattern_1: __cfPattern_hdaf4da8c46b9
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-with-array-param-no-name.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-with-array-param-no-name.expected.jsx
@@ -11,7 +11,7 @@ import { cell, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h5049118e4ead = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const index = __cf_pattern_input.key("index");
     const array = __cf_pattern_input.key("array");
@@ -70,7 +70,7 @@ export default pattern((_state: any) => {
     } as const satisfies __cfHelpers.JSONSchema).for("items", true);
     return {
         [UI]: (<div>
-        {items.mapWithPattern(__cfPattern_1, {})}
+        {items.mapWithPattern(__cfPattern_h5049118e4ead, {})}
       </div>),
     };
 }, false as const satisfies __cfHelpers.JSONSchema, {
@@ -107,5 +107,6 @@ export default pattern((_state: any) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfPattern_1
+    __cfPattern_h5049118e4ead,
+    __cfPattern_1: __cfPattern_h5049118e4ead
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-with-array-param.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-with-array-param.expected.jsx
@@ -11,7 +11,7 @@ import { cell, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h5049118e4ead = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const index = __cf_pattern_input.key("index");
     const array = __cf_pattern_input.key("array");
@@ -70,7 +70,7 @@ export default pattern((_state) => {
     } as const satisfies __cfHelpers.JSONSchema).for("items", true);
     return {
         [UI]: (<div>
-        {items.mapWithPattern(__cfPattern_1, {})}
+        {items.mapWithPattern(__cfPattern_h5049118e4ead, {})}
       </div>),
     };
 }, false as const satisfies __cfHelpers.JSONSchema, {
@@ -107,5 +107,6 @@ export default pattern((_state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfPattern_1
+    __cfPattern_h5049118e4ead,
+    __cfPattern_1: __cfPattern_h5049118e4ead
 });

--- a/packages/ts-transformers/test/fixtures/closures/nested-computed-in-ifelse.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/nested-computed-in-ifelse.expected.jsx
@@ -22,7 +22,7 @@ import { computed, ifElse, pattern, UI, Writable } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h2cec5ba7cbc2 = __cfHelpers.lift<{
     secondToggle: __cfHelpers.ReadonlyCell<boolean>;
 }, { background: string; }>(({ secondToggle }) => {
     const val = secondToggle.get();
@@ -45,7 +45,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     },
     required: ["background"]
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_h2cec5ba7cbc2_2 = __cfHelpers.lift<{
     secondToggle: __cfHelpers.ReadonlyCell<boolean>;
 }, { background: string; }>(({ secondToggle }) => {
     // This .get() should NOT be wrapped in an extra lift-applied computation
@@ -86,7 +86,7 @@ export default pattern(() => {
     return {
         [UI]: (<div>
         {/* Case A: Top-level computed - always worked */}
-        <div style={__cfLift_1({ secondToggle: secondToggle })}>Case A</div>
+        <div style={__cfLift_h2cec5ba7cbc2({ secondToggle: secondToggle })}>Case A</div>
 
         {/* Case B: Computed inside ifElse - this was the bug */}
         {ifElse({
@@ -102,7 +102,7 @@ export default pattern(() => {
                         type: "object",
                         properties: {}
                     }]
-            } as const satisfies __cfHelpers.JSONSchema, {} as const satisfies __cfHelpers.JSONSchema, showOuter, <div style={__cfLift_2({ secondToggle: secondToggle })}>Case B</div>, <div>Hidden</div>)}
+            } as const satisfies __cfHelpers.JSONSchema, {} as const satisfies __cfHelpers.JSONSchema, showOuter, <div style={__cfLift_h2cec5ba7cbc2_2({ secondToggle: secondToggle })}>Case B</div>, <div>Hidden</div>)}
       </div>),
     };
 }, {
@@ -143,6 +143,8 @@ export default pattern(() => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2
+    __cfLift_h2cec5ba7cbc2,
+    __cfLift_h2cec5ba7cbc2_2,
+    __cfLift_1: __cfLift_h2cec5ba7cbc2,
+    __cfLift_2: __cfLift_h2cec5ba7cbc2_2
 });

--- a/packages/ts-transformers/test/fixtures/closures/nested-map-derived-collection.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/nested-map-derived-collection.expected.jsx
@@ -42,7 +42,7 @@ const tallyOptions = __cfHardenFn((options: Option[], votes: Vote[]): OptionTall
     voters: votes.map((v) => ({ name: v.voterName })),
 })));
 const enrichTallies = __cfHardenFn((tallies: OptionTally[]): OptionTally[] => tallies.map((t): OptionTally => ({ option: t.option, voters: t.voters })));
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h90ef09089cf2 = __cfHelpers.lift<{
     options: Option[];
     votes: Vote[];
 }, OptionTally[]>(({ options, votes }) => tallyOptions(options, votes), {
@@ -123,7 +123,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_h93f64cb4fad6 = __cfHelpers.lift<{
     ranked: OptionTally[];
 }, OptionTally[]>(({ ranked }) => enrichTallies(ranked), {
     type: "object",
@@ -206,7 +206,7 @@ const __cfLift_2 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h3fd665e8a85e = __cfHelpers.pattern(__cf_pattern_input => {
     const voter = __cf_pattern_input.key("element");
     return <span>{voter.key("name")}</span>;
 }, {
@@ -244,9 +244,9 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_he33b6c12f867 = __cfHelpers.pattern(__cf_pattern_input => {
     const tally = __cf_pattern_input.key("element");
-    return (<div>{tally.key("voters").mapWithPattern(__cfPattern_1, {})}</div>);
+    return (<div>{tally.key("voters").mapWithPattern(__cfPattern_h3fd665e8a85e, {})}</div>);
 }, {
     type: "object",
     properties: {
@@ -308,7 +308,7 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h3fd665e8a85e_2 = __cfHelpers.pattern(__cf_pattern_input => {
     const voter = __cf_pattern_input.key("element");
     return <span>{voter.key("name")}</span>;
 }, {
@@ -346,9 +346,9 @@ const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_4 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hbce8dac4f201 = __cfHelpers.pattern(__cf_pattern_input => {
     const tally = __cf_pattern_input.key("element");
-    return (<div>{tally.key("voters").mapWithPattern(__cfPattern_3, {})}</div>);
+    return (<div>{tally.key("voters").mapWithPattern(__cfPattern_h3fd665e8a85e_2, {})}</div>);
 }, {
     type: "object",
     properties: {
@@ -413,18 +413,18 @@ const __cfPattern_4 = __cfHelpers.pattern(__cf_pattern_input => {
 export default pattern((__cf_pattern_input) => {
     const votes = __cf_pattern_input.key("votes");
     const options = __cf_pattern_input.key("options");
-    const ranked = __cfLift_1({
+    const ranked = __cfLift_h90ef09089cf2({
         options: options,
         votes: votes
     }).for("ranked", true);
-    const enriched = __cfLift_2({ ranked: ranked }).for("enriched", true);
+    const enriched = __cfLift_h93f64cb4fad6({ ranked: ranked }).for("enriched", true);
     return {
         [UI]: (<div>
           <div>
-            {ranked.mapWithPattern(__cfPattern_2, {})}
+            {ranked.mapWithPattern(__cfPattern_he33b6c12f867, {})}
           </div>
           <div>
-            {enriched.mapWithPattern(__cfPattern_4, {})}
+            {enriched.mapWithPattern(__cfPattern_hbce8dac4f201, {})}
           </div>
         </div>),
     };
@@ -502,10 +502,16 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2,
-    __cfPattern_1,
-    __cfPattern_2,
-    __cfPattern_3,
-    __cfPattern_4
+    __cfLift_h90ef09089cf2,
+    __cfLift_h93f64cb4fad6,
+    __cfPattern_h3fd665e8a85e,
+    __cfPattern_he33b6c12f867,
+    __cfPattern_h3fd665e8a85e_2,
+    __cfPattern_hbce8dac4f201,
+    __cfLift_1: __cfLift_h90ef09089cf2,
+    __cfLift_2: __cfLift_h93f64cb4fad6,
+    __cfPattern_1: __cfPattern_h3fd665e8a85e,
+    __cfPattern_2: __cfPattern_he33b6c12f867,
+    __cfPattern_3: __cfPattern_h3fd665e8a85e_2,
+    __cfPattern_4: __cfPattern_hbce8dac4f201
 });

--- a/packages/ts-transformers/test/fixtures/closures/nested-map-fallback-receiver.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/nested-map-fallback-receiver.expected.jsx
@@ -21,7 +21,7 @@ interface State {
     }>, [
     ]>;
 }
-const __cfHandler_1 = __cfHelpers.handler({
+const __cfHandler_hb20549a97e67 = __cfHelpers.handler({
     type: "object",
     properties: {
         name: {
@@ -42,7 +42,7 @@ const __cfHandler_1 = __cfHelpers.handler({
     },
     required: ["assignName"]
 } as const satisfies __cfHelpers.JSONSchema, (p, { assignName }) => assignName.set(p.name));
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hec8401e03c4b = __cfHelpers.lift<{
     people: __cfHelpers.PerSpace<__cfHelpers.Cell<Person[]>>;
 }, readonly Person[]>(({ people }) => people.get(), {
     type: "object",
@@ -87,7 +87,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfHandler_2 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+const __cfHandler_h2a93a514867f = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
         p: {
@@ -112,10 +112,10 @@ const __cfHandler_2 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
     },
     required: ["p", "setAssign"]
 } as const satisfies __cfHelpers.JSONSchema, (__cf_handler_event, { setAssign, p }) => setAssign.send({ name: p.name }));
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h82f00529d775 = __cfHelpers.pattern(__cf_pattern_input => {
     const p = __cf_pattern_input.key("element");
     const setAssign = __cf_pattern_input.key("params", "setAssign");
-    return (<button type="button" onClick={__cfHandler_2({
+    return (<button type="button" onClick={__cfHandler_h2a93a514867f({
         setAssign: setAssign,
         p: {
             name: p.key("name")
@@ -179,13 +179,13 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h425affd75001 = __cfHelpers.pattern(__cf_pattern_input => {
     const row = __cf_pattern_input.key("element");
     const people = __cf_pattern_input.key("params", "people");
     const setAssign = __cf_pattern_input.key("params", "setAssign");
     return (<div>
             <span>{row.key("label")}</span>
-            {(__cfLift_1({ people: people }) ?? []).mapWithPattern(__cfPattern_1, {
+            {(__cfLift_hec8401e03c4b({ people: people }) ?? []).mapWithPattern(__cfPattern_h82f00529d775, {
             setAssign: setAssign
         })}
           </div>);
@@ -302,12 +302,12 @@ export default pattern((__cf_pattern_input) => {
         type: "string",
         scope: "space"
     } as const satisfies __cfHelpers.JSONSchema).for("assignName", true);
-    const setAssign = __cfHandler_1({
+    const setAssign = __cfHandler_hb20549a97e67({
         assignName: assignName
     }).for({ stream: "setAssign" }, true);
     return {
         [UI]: (<div>
-        {rows.mapWithPattern(__cfPattern_2, {
+        {rows.mapWithPattern(__cfPattern_h425affd75001, {
                 people: people,
                 setAssign: setAssign
             })}
@@ -368,9 +368,14 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfHandler_1,
-    __cfLift_1,
-    __cfHandler_2,
-    __cfPattern_1,
-    __cfPattern_2
+    __cfHandler_hb20549a97e67,
+    __cfLift_hec8401e03c4b,
+    __cfHandler_h2a93a514867f,
+    __cfPattern_h82f00529d775,
+    __cfPattern_h425affd75001,
+    __cfHandler_1: __cfHandler_hb20549a97e67,
+    __cfLift_1: __cfLift_hec8401e03c4b,
+    __cfHandler_2: __cfHandler_h2a93a514867f,
+    __cfPattern_1: __cfPattern_h82f00529d775,
+    __cfPattern_2: __cfPattern_h425affd75001
 });

--- a/packages/ts-transformers/test/fixtures/closures/pattern-computed-reactive-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/pattern-computed-reactive-map.expected.jsx
@@ -11,7 +11,7 @@ import { computed, pattern } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h0386b6a2a2c4 = __cfHelpers.lift<{
     items: number[] & {} & { [SELF]: Reactive<any>; };
 }, number[]>(({ items }) => items.map((n) => n * 2), {
     type: "object",
@@ -39,7 +39,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 export default pattern((items) => {
     // items is Reactive<number[]> as a pattern parameter
     // Inside the computed callback (which becomes a lift-applied computation), items.map should NOT be transformed
-    const doubled = __cfLift_1({ items: items }).for("doubled", true);
+    const doubled = __cfLift_h0386b6a2a2c4({ items: items }).for("doubled", true);
     return doubled;
 }, {
     type: "array",
@@ -56,5 +56,6 @@ export default pattern((items) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_h0386b6a2a2c4,
+    __cfLift_1: __cfLift_h0386b6a2a2c4
 });

--- a/packages/ts-transformers/test/fixtures/closures/pattern-nested-jsx-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/pattern-nested-jsx-map.expected.jsx
@@ -34,7 +34,7 @@ interface PatternInput {
     items?: Cell<Default<Item[], [
     ]>>;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h3e4089b7ce19 = __cfHelpers.lift<{
     items: __cfHelpers.ReadonlyCell<unknown[]>;
 }, boolean>(({ items }) => items.get().length > 0, {
     type: "object",
@@ -51,7 +51,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_hed11891c86ff = __cfHelpers.lift<{
     i: number;
     item: {
         selectedIndex: number;
@@ -76,7 +76,7 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hc18144a802d5 = __cfHelpers.pattern(__cf_pattern_input => {
     const tag = __cf_pattern_input.key("element");
     const i = __cf_pattern_input.key("index");
     const item = __cf_pattern_input.key("params", "item");
@@ -89,7 +89,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         type: "string"
     } as const satisfies __cfHelpers.JSONSchema, {
         "enum": ["", "* "]
-    } as const satisfies __cfHelpers.JSONSchema, __cfLift_2({
+    } as const satisfies __cfHelpers.JSONSchema, __cfLift_hed11891c86ff({
         i: i,
         item: {
             selectedIndex: item.key("selectedIndex")
@@ -155,12 +155,12 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h5f4600c84b6a = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return (<div>
               <strong>{item.key("label")}</strong>
               <ul>
-                {item.key("tags").mapWithPattern(__cfPattern_1, {
+                {item.key("tags").mapWithPattern(__cfPattern_hc18144a802d5, {
             item: {
                 selectedIndex: item.key("selectedIndex")
             }
@@ -236,7 +236,7 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
 //   both the outer and inner levels.
 export default pattern((__cf_pattern_input) => {
     const items = __cf_pattern_input.key("items");
-    const hasItems = __cfLift_1({ items: items }).for("hasItems", true);
+    const hasItems = __cfLift_h3e4089b7ce19({ items: items }).for("hasItems", true);
     return {
         [UI]: (<div>
         {__cfHelpers.ifElse({
@@ -257,7 +257,7 @@ export default pattern((__cf_pattern_input) => {
                     type: "object",
                     properties: {}
                 }]
-        } as const satisfies __cfHelpers.JSONSchema, hasItems, items.mapWithPattern(__cfPattern_2, {}), <p>No items</p>)}
+        } as const satisfies __cfHelpers.JSONSchema, hasItems, items.mapWithPattern(__cfPattern_h5f4600c84b6a, {}), <p>No items</p>)}
       </div>),
     };
 }, {
@@ -335,8 +335,12 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2,
-    __cfPattern_1,
-    __cfPattern_2
+    __cfLift_h3e4089b7ce19,
+    __cfLift_hed11891c86ff,
+    __cfPattern_hc18144a802d5,
+    __cfPattern_h5f4600c84b6a,
+    __cfLift_1: __cfLift_h3e4089b7ce19,
+    __cfLift_2: __cfLift_hed11891c86ff,
+    __cfPattern_1: __cfPattern_hc18144a802d5,
+    __cfPattern_2: __cfPattern_h5f4600c84b6a
 });

--- a/packages/ts-transformers/test/fixtures/closures/pattern-opaque-destructure-temporary-root-names.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/pattern-opaque-destructure-temporary-root-names.expected.jsx
@@ -11,7 +11,7 @@ import { computed, generateObject, pattern } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h35f6b154a7fa = __cfHelpers.lift<{
     messages: string[];
 }, string>(({ messages }) => messages[0] ?? "", {
     type: "object",
@@ -27,7 +27,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_h2805ae6f8be9 = __cfHelpers.lift<{
     result?: any;
 }, any>(({ result }) => result?.title ?? "Untitled", {
     type: "object",
@@ -43,7 +43,7 @@ const __cfLift_2 = __cfHelpers.lift<{
 //   fires while pending, keeping the `?? "Untitled"` fallback live.
 export default pattern((__cf_pattern_input) => {
     const messages = __cf_pattern_input.key("messages");
-    const preview = __cfLift_1({ messages: messages }).for("preview", true);
+    const preview = __cfLift_h35f6b154a7fa({ messages: messages }).for("preview", true);
     const __cf_destructure_1 = generateObject({
         prompt: preview,
         schema: {
@@ -54,7 +54,7 @@ export default pattern((__cf_pattern_input) => {
             required: ["title"],
         },
     }), result = __cf_destructure_1.key("result").for("result", true);
-    return <div>{__cfLift_2({ result: result })}</div>;
+    return <div>{__cfLift_h2805ae6f8be9({ result: result })}</div>;
 }, {
     type: "object",
     properties: {
@@ -91,6 +91,8 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2
+    __cfLift_h35f6b154a7fa,
+    __cfLift_h2805ae6f8be9,
+    __cfLift_1: __cfLift_h35f6b154a7fa,
+    __cfLift_2: __cfLift_h2805ae6f8be9
 });

--- a/packages/ts-transformers/test/fixtures/closures/pattern-optional-destructured-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/pattern-optional-destructured-capture.expected.jsx
@@ -11,7 +11,7 @@ import { computed, pattern } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h597481f99252 = __cfHelpers.lift<{
     req: string;
     opt?: string;
     ud: string;
@@ -76,7 +76,7 @@ export default pattern((__cf_pattern_input) => {
     const ud = __cf_pattern_input.key("ud");
     const renamed = __cf_pattern_input.key("ren");
     const qOpt = __cf_pattern_input.key("q-opt");
-    const body = __cfLift_1({
+    const body = __cfLift_h597481f99252({
         req: req,
         opt: opt,
         ud: ud,
@@ -129,5 +129,6 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_h597481f99252,
+    __cfLift_1: __cfLift_h597481f99252
 });

--- a/packages/ts-transformers/test/fixtures/closures/pattern-preserve-opaque-input.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/pattern-preserve-opaque-input.expected.jsx
@@ -15,7 +15,7 @@ interface State {
     foo: string;
     bar: string;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h43377fdb439e = __cfHelpers.lift<{
     input: __cfHelpers.Writable<State>;
 }, string>(({ input }) => input.key("foo").get(), {
     type: "object",
@@ -51,7 +51,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 //   reactive context, so it gets wrapped in a lift-applied computation.
 export default pattern((input: Writable<State>) => {
     return {
-        [UI]: <div>{__cfLift_1({ input: input })}</div>,
+        [UI]: <div>{__cfLift_h43377fdb439e({ input: input })}</div>,
     };
 }, {
     $ref: "#/$defs/State",
@@ -104,5 +104,6 @@ export default pattern((input: Writable<State>) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_h43377fdb439e,
+    __cfLift_1: __cfLift_h43377fdb439e
 });

--- a/packages/ts-transformers/test/fixtures/closures/patternTool-basic-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/patternTool-basic-capture.expected.jsx
@@ -19,7 +19,7 @@ type Output = {
         content: string;
     }>;
 };
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_he09a421517d6 = __cfHelpers.lift<{
     query: string;
     content: string;
 }, string[]>(({ content, query }) => {
@@ -41,13 +41,13 @@ const __cfLift_1 = __cfHelpers.lift<{
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfPattern_1 = pattern((__cf_pattern_input: {
+const __cfPattern_h01d651c494bf = pattern((__cf_pattern_input: {
     query: string;
     content: string;
 }) => {
     const query = __cf_pattern_input.key("query");
     const content = __cf_pattern_input.key("content");
-    return __cfLift_1({
+    return __cfLift_he09a421517d6({
         content: content,
         query: query
     }).for("__patternResult", true);
@@ -75,7 +75,7 @@ const __cfPattern_1 = pattern((__cf_pattern_input: {
 // Context: `content` appears in the pattern callback's destructured input and is
 //   pre-filled through extraParams.
 export default pattern(() => {
-    const grepTool = patternTool(__cfPattern_1, { content: content.for(["grepTool", 1, "content"], true) });
+    const grepTool = patternTool(__cfPattern_h01d651c494bf, { content: content.for(["grepTool", 1, "content"], true) });
     return { grepTool };
 }, {
     type: "object",
@@ -128,6 +128,8 @@ export default pattern(() => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfPattern_1
+    __cfLift_he09a421517d6,
+    __cfPattern_h01d651c494bf,
+    __cfLift_1: __cfLift_he09a421517d6,
+    __cfPattern_1: __cfPattern_h01d651c494bf
 });

--- a/packages/ts-transformers/test/fixtures/closures/patternTool-local-var.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/patternTool-local-var.expected.jsx
@@ -19,7 +19,7 @@ type Output = {
         content: string;
     }>;
 };
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_ha211a6369c80 = __cfHelpers.lift<{
     language: string;
 }, string>(({ language }) => `Translate to ${language}.`, {
     type: "object",
@@ -32,7 +32,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_h5c730a888d1d = __cfHelpers.lift<{
     content: string;
 }, string>(({ content }) => content, {
     type: "object",
@@ -45,7 +45,7 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_3 = __cfHelpers.lift<{
+const __cfLift_he03f43d93cdf = __cfHelpers.lift<{
     genResult: {
         pending: boolean;
         result?: string | undefined;
@@ -74,17 +74,17 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["string", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfPattern_1 = pattern((__cf_pattern_input: {
+const __cfPattern_h502969b505f1 = pattern((__cf_pattern_input: {
     language: string;
     content: string;
 }) => {
     const language = __cf_pattern_input.key("language");
     const content = __cf_pattern_input.key("content");
     const genResult = generateText({
-        system: __cfLift_1({ language: language }).for(["genResult", "system"], true),
-        prompt: __cfLift_2({ content: content }).for(["genResult", "prompt"], true)
+        system: __cfLift_ha211a6369c80({ language: language }).for(["genResult", "system"], true),
+        prompt: __cfLift_h5c730a888d1d({ content: content }).for(["genResult", "prompt"], true)
     }).for("genResult", true);
-    return __cfLift_3({ genResult: {
+    return __cfLift_he03f43d93cdf({ genResult: {
             pending: genResult.key("pending"),
             result: genResult.key("result")
         } }).for("__patternResult", true);
@@ -109,7 +109,7 @@ const __cfPattern_1 = pattern((__cf_pattern_input: {
 //   extraParams).
 //   patternTool(pattern(({ language, content }) => …genResult…), { content })
 export default pattern(() => {
-    const tool = patternTool(__cfPattern_1, { content: content.for(["tool", 1, "content"], true) });
+    const tool = patternTool(__cfPattern_h502969b505f1, { content: content.for(["tool", 1, "content"], true) });
     return { tool };
 }, {
     type: "object",
@@ -162,8 +162,12 @@ export default pattern(() => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2,
-    __cfLift_3,
-    __cfPattern_1
+    __cfLift_ha211a6369c80,
+    __cfLift_h5c730a888d1d,
+    __cfLift_he03f43d93cdf,
+    __cfPattern_h502969b505f1,
+    __cfLift_1: __cfLift_ha211a6369c80,
+    __cfLift_2: __cfLift_h5c730a888d1d,
+    __cfLift_3: __cfLift_he03f43d93cdf,
+    __cfPattern_1: __cfPattern_h502969b505f1
 });

--- a/packages/ts-transformers/test/fixtures/closures/patternTool-multiple-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/patternTool-multiple-captures.expected.jsx
@@ -20,7 +20,7 @@ const prefix = __cfHelpers.__cf_data(new Writable("Result: ", {
 type Output = {
     tool: PatternToolResult<Record<string, never>>;
 };
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hd3fe53f71737 = __cfHelpers.lift<{
     value: number;
 }, string>(({ value }) => {
     return prefix.get() + String(value * multiplier.get());
@@ -35,11 +35,11 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfPattern_1 = pattern((__cf_pattern_input: {
+const __cfPattern_h5ae6df945493 = pattern((__cf_pattern_input: {
     value: number;
 }) => {
     const value = __cf_pattern_input.key("value");
-    return __cfLift_1({ value: value }).for("__patternResult", true);
+    return __cfLift_hd3fe53f71737({ value: value }).for("__patternResult", true);
 }, {
     type: "object",
     properties: {
@@ -61,7 +61,7 @@ const __cfPattern_1 = pattern((__cf_pattern_input: {
 // Context: Both `prefix` and `multiplier` are module-scoped new Writable() values;
 //   `value` is the pattern's only per-call input.
 export default pattern(() => {
-    const tool = patternTool(__cfPattern_1);
+    const tool = patternTool(__cfPattern_h5ae6df945493);
     return { tool };
 }, {
     type: "object",
@@ -110,6 +110,8 @@ export default pattern(() => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfPattern_1
+    __cfLift_hd3fe53f71737,
+    __cfPattern_h5ae6df945493,
+    __cfLift_1: __cfLift_hd3fe53f71737,
+    __cfPattern_1: __cfPattern_h5ae6df945493
 });

--- a/packages/ts-transformers/test/fixtures/closures/patternTool-no-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/patternTool-no-captures.expected.jsx
@@ -14,7 +14,7 @@ const __cfAmdHooks = undefined;
 type Output = {
     tool: PatternToolResult<Record<string, never>>;
 };
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_he09a421517d6 = __cfHelpers.lift<{
     query: string;
     content: string;
 }, string[]>(({ content, query }) => {
@@ -36,13 +36,13 @@ const __cfLift_1 = __cfHelpers.lift<{
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfPattern_1 = pattern((__cf_pattern_input: {
+const __cfPattern_h01d651c494bf = pattern((__cf_pattern_input: {
     query: string;
     content: string;
 }) => {
     const query = __cf_pattern_input.key("query");
     const content = __cf_pattern_input.key("content");
-    return __cfLift_1({
+    return __cfLift_he09a421517d6({
         content: content,
         query: query
     }).for("__patternResult", true);
@@ -69,7 +69,7 @@ const __cfPattern_1 = pattern((__cf_pattern_input: {
 // Context: The pattern callback only references its own parameters (query,
 //   content) and no module-scoped reactive variables, so no extraParams.
 export default pattern(() => {
-    const tool = patternTool(__cfPattern_1);
+    const tool = patternTool(__cfPattern_h01d651c494bf);
     return { tool };
 }, {
     type: "object",
@@ -118,6 +118,8 @@ export default pattern(() => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfPattern_1
+    __cfLift_he09a421517d6,
+    __cfPattern_h01d651c494bf,
+    __cfLift_1: __cfLift_he09a421517d6,
+    __cfPattern_1: __cfPattern_h01d651c494bf
 });

--- a/packages/ts-transformers/test/fixtures/closures/patternTool-with-existing-params.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/patternTool-with-existing-params.expected.jsx
@@ -22,7 +22,7 @@ type Output = {
         offset: number;
     }>;
 };
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h11ccdccd43c8 = __cfHelpers.lift<{
     value: number;
     offset: number;
 }, number>(({ value, offset }) => {
@@ -41,13 +41,13 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfPattern_1 = pattern((__cf_pattern_input: {
+const __cfPattern_h4e99b307fa7d = pattern((__cf_pattern_input: {
     value: number;
     offset: number;
 }) => {
     const value = __cf_pattern_input.key("value");
     const offset = __cf_pattern_input.key("offset");
-    return __cfLift_1({
+    return __cfLift_h11ccdccd43c8({
         value: value,
         offset: offset
     }).for("__patternResult", true);
@@ -74,7 +74,7 @@ const __cfPattern_1 = pattern((__cf_pattern_input: {
 //   began requiring an explicit pattern.
 //   patternTool(pattern(({ value, offset }) => …multiplier.get()…), { offset })
 export default pattern(() => {
-    const tool = patternTool(__cfPattern_1, { offset: offset.for(["tool", 1, "offset"], true) });
+    const tool = patternTool(__cfPattern_h4e99b307fa7d, { offset: offset.for(["tool", 1, "offset"], true) });
     return { tool };
 }, {
     type: "object",
@@ -127,6 +127,8 @@ export default pattern(() => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfPattern_1
+    __cfLift_h11ccdccd43c8,
+    __cfPattern_h4e99b307fa7d,
+    __cfLift_1: __cfLift_h11ccdccd43c8,
+    __cfPattern_1: __cfPattern_h4e99b307fa7d
 });

--- a/packages/ts-transformers/test/fixtures/closures/readonly-capture-named-alias-nested-cell.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/readonly-capture-named-alias-nested-cell.expected.jsx
@@ -26,7 +26,7 @@ type EntriesValue = Entry[] | Default<[
 // Reads the cell only (passed by reference, never written) — makes the capture
 // read-only and triggers the Cell -> ReadonlyCell narrowing.
 const firstName = __cfHardenFn((entries: Cell<EntriesValue>): string => (entries.get() ?? [])[0]?.profile.get().name ?? "");
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h66ce37b0964f = __cfHelpers.lift<{
     entries: __cfHelpers.ReadonlyCell<EntriesValue>;
 }, string>(({ entries }) => firstName(entries), {
     type: "object",
@@ -109,7 +109,7 @@ export default pattern(() => {
             }
         }
     } as const satisfies __cfHelpers.JSONSchema).for("entries", true);
-    return __cfLift_1({ entries: entries }).for("__patternResult", true);
+    return __cfLift_h66ce37b0964f({ entries: entries }).for("__patternResult", true);
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
@@ -117,5 +117,6 @@ export default pattern(() => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_h66ce37b0964f,
+    __cfLift_1: __cfLift_h66ce37b0964f
 });

--- a/packages/ts-transformers/test/fixtures/closures/unless-with-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/unless-with-map.expected.jsx
@@ -26,7 +26,7 @@ interface PatternInput {
     items: Cell<Default<Item[], [
     ]>>;
 }
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hc3ba77b76767 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return <li>{item.key("label")}</li>;
 }, {
@@ -89,7 +89,7 @@ export default pattern((__cf_pattern_input) => {
             items: {}
         } as const satisfies __cfHelpers.JSONSchema, {
             asCell: ["cell"]
-        } as const satisfies __cfHelpers.JSONSchema, customContent, items.mapWithPattern(__cfPattern_1, {}))}
+        } as const satisfies __cfHelpers.JSONSchema, customContent, items.mapWithPattern(__cfPattern_hc3ba77b76767, {}))}
       </div>),
     };
 }, {
@@ -153,5 +153,6 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfPattern_1
+    __cfPattern_hc3ba77b76767,
+    __cfPattern_1: __cfPattern_hc3ba77b76767
 });

--- a/packages/ts-transformers/test/fixtures/closures/when-with-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/when-with-map.expected.jsx
@@ -26,7 +26,7 @@ interface PatternInput {
     items: Cell<Default<Item[], [
     ]>>;
 }
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hc3ba77b76767 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return <li>{item.key("label")}</li>;
 }, {
@@ -94,7 +94,7 @@ export default pattern((__cf_pattern_input) => {
                     type: "array",
                     items: {}
                 }]
-        } as const satisfies __cfHelpers.JSONSchema, showItems, items.mapWithPattern(__cfPattern_1, {}))}
+        } as const satisfies __cfHelpers.JSONSchema, showItems, items.mapWithPattern(__cfPattern_hc3ba77b76767, {}))}
       </div>),
     };
 }, {
@@ -158,5 +158,6 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfPattern_1
+    __cfPattern_hc3ba77b76767,
+    __cfPattern_1: __cfPattern_hc3ba77b76767
 });

--- a/packages/ts-transformers/test/fixtures/closures/writable-of-terminal-methods.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/writable-of-terminal-methods.expected.jsx
@@ -20,7 +20,7 @@ const __cfAmdHooks = undefined;
 interface State {
     title: string;
 }
-const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+const __cfHandler_h3748f2ada0c9 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
         counter: {
@@ -53,7 +53,7 @@ export default pattern((__cf_pattern_input) => {
     const label = new Writable("Count", {
         type: "string"
     } as const satisfies __cfHelpers.JSONSchema).for("label", true);
-    const reset = __cfHandler_1({
+    const reset = __cfHandler_h3748f2ada0c9({
         counter: counter,
         label: label
     }).for({ stream: "reset" }, true);
@@ -115,5 +115,6 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfHandler_1
+    __cfHandler_h3748f2ada0c9,
+    __cfHandler_1: __cfHandler_h3748f2ada0c9
 });

--- a/packages/ts-transformers/test/fixtures/handler-schema/contract-authored-event.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/contract-authored-event.expected.jsx
@@ -36,7 +36,7 @@ interface ProbeOutput {
     entries: string[];
     add: Stream<ProbeEvent, ProbeResult>;
 }
-const __cfHandler_1 = __cfHelpers.handler({
+const __cfHandler_h8bce45e0dabd = __cfHelpers.handler({
     type: "object",
     properties: {
         title: {
@@ -96,7 +96,7 @@ const __cfHandler_1 = __cfHelpers.handler({
     } as const satisfies __cfHelpers.JSONSchema });
 export default pattern((__cf_pattern_input) => {
     const entries = __cf_pattern_input.key("entries");
-    const add = __cfHandler_1({
+    const add = __cfHandler_h8bce45e0dabd({
         entries: entries
     }).for({ stream: "add" }, true);
     return { [NAME]: "probe", entries: entries.for(["__patternResult", "entries"], true), add: add.for({ stream: ["__patternResult", "add"] }, true) };
@@ -172,5 +172,6 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfHandler_1
+    __cfHandler_h8bce45e0dabd,
+    __cfHandler_1: __cfHandler_h8bce45e0dabd
 });

--- a/packages/ts-transformers/test/fixtures/handler-schema/contract-authored-shapes.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/contract-authored-shapes.expected.jsx
@@ -46,7 +46,7 @@ interface Out {
         ok: boolean;
     }>;
 }
-const __cfHandler_1 = __cfHelpers.handler({
+const __cfHandler_hfaa598c7156f = __cfHelpers.handler({
     anyOf: [{
             type: "object",
             properties: {
@@ -99,7 +99,7 @@ const __cfHandler_1 = __cfHelpers.handler({
         },
         required: ["ok"]
     } as const satisfies __cfHelpers.JSONSchema });
-const __cfHandler_2 = __cfHelpers.handler({
+const __cfHandler_h945fffca7161 = __cfHelpers.handler({
     type: "array",
     items: {
         type: "string"
@@ -118,7 +118,7 @@ const __cfHandler_2 = __cfHelpers.handler({
         },
         required: ["n"]
     } as const satisfies __cfHelpers.JSONSchema });
-const __cfHandler_3 = __cfHelpers.handler({
+const __cfHandler_hc7858bec2146 = __cfHelpers.handler({
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
@@ -134,7 +134,7 @@ const __cfHandler_3 = __cfHelpers.handler({
         },
         required: ["n"]
     } as const satisfies __cfHelpers.JSONSchema });
-const __cfHandler_4 = __cfHelpers.handler({
+const __cfHandler_h8b5b8b11d10a = __cfHelpers.handler({
     type: "object",
     properties: {
         base: {
@@ -181,12 +181,12 @@ const __cfHandler_4 = __cfHelpers.handler({
     } as const satisfies __cfHelpers.JSONSchema });
 export default pattern((__cf_pattern_input) => {
     const log = __cf_pattern_input.key("log");
-    const addUnion = __cfHandler_1({
+    const addUnion = __cfHandler_hfaa598c7156f({
         log: log
     }).for({ stream: "addUnion" }, true);
-    const addArr = __cfHandler_2({}).for({ stream: "addArr" }, true);
-    const addStr = __cfHandler_3({}).for({ stream: "addStr" }, true);
-    const addSection = __cfHandler_4({
+    const addArr = __cfHandler_h945fffca7161({}).for({ stream: "addArr" }, true);
+    const addStr = __cfHandler_hc7858bec2146({}).for({ stream: "addStr" }, true);
+    const addSection = __cfHandler_h8b5b8b11d10a({
         log: log
     }).for({ stream: "addSection" }, true);
     return { [NAME]: "p", log: log!.for(["__patternResult", "log"], true), addUnion: addUnion.for({ stream: ["__patternResult", "addUnion"] }, true), addArr: addArr.for({ stream: ["__patternResult", "addArr"] }, true), addStr: addStr.for({ stream: ["__patternResult", "addStr"] }, true), addSection: addSection.for({ stream: ["__patternResult", "addSection"] }, true) };
@@ -287,8 +287,12 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfHandler_1,
-    __cfHandler_2,
-    __cfHandler_3,
-    __cfHandler_4
+    __cfHandler_hfaa598c7156f,
+    __cfHandler_h945fffca7161,
+    __cfHandler_hc7858bec2146,
+    __cfHandler_h8b5b8b11d10a,
+    __cfHandler_1: __cfHandler_hfaa598c7156f,
+    __cfHandler_2: __cfHandler_h945fffca7161,
+    __cfHandler_3: __cfHandler_hc7858bec2146,
+    __cfHandler_4: __cfHandler_h8b5b8b11d10a
 });

--- a/packages/ts-transformers/test/fixtures/handler-schema/contract-nested-unread-reference.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/contract-nested-unread-reference.expected.jsx
@@ -33,7 +33,7 @@ interface Out {
         ok: boolean;
     }>;
 }
-const __cfHandler_1 = __cfHelpers.handler({
+const __cfHandler_h2b697611607a = __cfHelpers.handler({
     type: "object",
     properties: {
         title: {
@@ -94,7 +94,7 @@ const __cfHandler_1 = __cfHelpers.handler({
     } as const satisfies __cfHelpers.JSONSchema });
 export default pattern((__cf_pattern_input) => {
     const log = __cf_pattern_input.key("log");
-    const add = __cfHandler_1({
+    const add = __cfHandler_h2b697611607a({
         log: log
     }).for({ stream: "add" }, true);
     return { [NAME]: "p", log: log!.for(["__patternResult", "log"], true), add: add.for({ stream: ["__patternResult", "add"] }, true) };
@@ -168,5 +168,6 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfHandler_1
+    __cfHandler_h2b697611607a,
+    __cfHandler_1: __cfHandler_h2b697611607a
 });

--- a/packages/ts-transformers/test/fixtures/handler-schema/stream-declared-result.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/stream-declared-result.expected.jsx
@@ -59,7 +59,7 @@ const renameTopic = handler({
         },
         required: ["topic"]
     } as const satisfies __cfHelpers.JSONSchema });
-const __cfHandler_1 = __cfHelpers.handler({
+const __cfHandler_h8f543109e761 = __cfHelpers.handler({
     type: "object",
     properties: {
         title: {
@@ -94,7 +94,7 @@ const __cfHandler_1 = __cfHelpers.handler({
         },
         required: ["topic"]
     } as const satisfies __cfHelpers.JSONSchema });
-const __cfHandler_2 = __cfHelpers.handler({
+const __cfHandler_h8adce53a36df = __cfHelpers.handler({
     type: "object",
     properties: {
         title: {
@@ -121,11 +121,11 @@ export default pattern(() => {
     // A verb that declares what it produces (verb contract rule 3). The result
     // rides `Stream`'s second type parameter and is opt-in by naming both type
     // arguments — it is never inferred from the body.
-    const addTopic = __cfHandler_1({
+    const addTopic = __cfHandler_h8f543109e761({
         count: count
     }).for({ stream: "addTopic" }, true);
     // The value-less shape, unchanged, for contrast.
-    const touch = __cfHandler_2({
+    const touch = __cfHandler_h8adce53a36df({
         count: count
     }).for({ stream: "touch" }, true);
     // Returned against the `Verbs` annotation on `pattern<>` above, so the
@@ -198,6 +198,8 @@ function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
     renameTopic,
-    __cfHandler_1,
-    __cfHandler_2
+    __cfHandler_h8f543109e761,
+    __cfHandler_h8adce53a36df,
+    __cfHandler_1: __cfHandler_h8f543109e761,
+    __cfHandler_2: __cfHandler_h8adce53a36df
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/authored-ifelse-jsx-branches.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/authored-ifelse-jsx-branches.expected.jsx
@@ -14,7 +14,7 @@ const __cfAmdHooks = undefined;
 interface Item {
     name: string;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h279203547b20 = __cfHelpers.lift<{
     limit: number;
 }, boolean>(({ limit }) => limit > 0, {
     type: "object",
@@ -27,7 +27,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hfe105d59f1b1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return <span>{item.key("name")}</span>;
 }, {
@@ -70,7 +70,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_h2903f1fcd2e2 = __cfHelpers.lift<{
     count: __cfHelpers.ReadonlyCell<number>;
 }, number>(({ count }) => count.get(), {
     type: "object",
@@ -130,7 +130,7 @@ export default pattern((__cf_pattern_input) => {
                         }]
                 }
             }
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_1({ limit: limit }), items.mapWithPattern(__cfPattern_1, {}), <span>Hidden</span>)}
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_h279203547b20({ limit: limit }), items.mapWithPattern(__cfPattern_hfe105d59f1b1, {}), <span>Hidden</span>)}
       <p>{ifElse({
             type: "boolean"
         } as const satisfies __cfHelpers.JSONSchema, {
@@ -139,7 +139,7 @@ export default pattern((__cf_pattern_input) => {
             type: "number"
         } as const satisfies __cfHelpers.JSONSchema, {
             type: "number"
-        } as const satisfies __cfHelpers.JSONSchema, show, __cfLift_2({ count: count }), 0)}</p>
+        } as const satisfies __cfHelpers.JSONSchema, show, __cfLift_h2903f1fcd2e2({ count: count }), 0)}</p>
     </div>),
     });
 }, {
@@ -208,7 +208,10 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfPattern_1,
-    __cfLift_2
+    __cfLift_h279203547b20,
+    __cfPattern_hfe105d59f1b1,
+    __cfLift_h2903f1fcd2e2,
+    __cfLift_1: __cfLift_h279203547b20,
+    __cfPattern_1: __cfPattern_hfe105d59f1b1,
+    __cfLift_2: __cfLift_h2903f1fcd2e2
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/binding-attr-nullish-wish-fallback.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/binding-attr-nullish-wish-fallback.expected.jsx
@@ -18,7 +18,7 @@ interface Profile {
 interface BadgeState {
     profileInput?: Profile;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h5e12a53b8b00 = __cfHelpers.lift<{
     profileInput?: Profile | undefined;
     profileWish: {
         result: Profile | undefined;
@@ -99,7 +99,7 @@ export default pattern((__cf_pattern_input) => {
     } as const satisfies __cfHelpers.JSONSchema).for("profileWish", true);
     return {
         [UI]: (<div>
-        <cf-profile-badge $profile={__cfLift_1({
+        <cf-profile-badge $profile={__cfLift_h5e12a53b8b00({
             profileInput: profileInput,
             profileWish: {
                 result: profileWish.key("result")
@@ -162,5 +162,6 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_h5e12a53b8b00,
+    __cfLift_1: __cfLift_h5e12a53b8b00
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/cell-get-in-ifelse-predicate.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/cell-get-in-ifelse-predicate.expected.jsx
@@ -11,7 +11,7 @@ import { Cell, ifElse, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hd9841d3f637b = __cfHelpers.lift<{
     showHistory: boolean;
     messageCount: number;
     dismissedIndex: __cfHelpers.ReadonlyCell<number>;
@@ -58,7 +58,7 @@ export default pattern((__cf_pattern_input) => {
                     type: "object",
                     properties: {}
                 }]
-        } as const satisfies __cfHelpers.JSONSchema, {} as const satisfies __cfHelpers.JSONSchema, __cfLift_1({
+        } as const satisfies __cfHelpers.JSONSchema, {} as const satisfies __cfHelpers.JSONSchema, __cfLift_hd9841d3f637b({
             showHistory: showHistory,
             messageCount: messageCount,
             dismissedIndex: dismissedIndex
@@ -114,5 +114,6 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_hd9841d3f637b,
+    __cfLift_1: __cfLift_hd9841d3f637b
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/complex-expressions.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/complex-expressions.expected.jsx
@@ -16,7 +16,7 @@ interface Problem {
     discount: number;
     tax: number;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h2bb23d5a01ed = __cfHelpers.lift<{
     price: number;
     discount: number;
 }, number>(({ price, discount }) => price - discount, {
@@ -33,7 +33,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_h1e98e70f8a68 = __cfHelpers.lift<{
     price: number;
     discount: number;
     tax: number;
@@ -65,11 +65,11 @@ export default pattern((__cf_pattern_input) => {
     return {
         [UI]: (<div>
           <p>Price: {price}</p>
-          <p>Discount: {__cfLift_1({
+          <p>Discount: {__cfLift_h2bb23d5a01ed({
             price: price,
             discount: discount
         })}</p>
-          <p>With tax: {__cfLift_2({
+          <p>With tax: {__cfLift_h1e98e70f8a68({
             price: price,
             discount: discount,
             tax: tax
@@ -124,6 +124,8 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2
+    __cfLift_h2bb23d5a01ed,
+    __cfLift_h1e98e70f8a68,
+    __cfLift_1: __cfLift_h2bb23d5a01ed,
+    __cfLift_2: __cfLift_h1e98e70f8a68
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/computed-boundary-nested-ternaries.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/computed-boundary-nested-ternaries.expected.jsx
@@ -11,7 +11,7 @@ import { computed, ifElse, pattern } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h4a92c84a9f6d = __cfHelpers.lift<{
     bar: boolean;
 }, "B" | "C">(({ bar }) => bar ? "B" : "C", {
     type: "object",
@@ -39,7 +39,7 @@ export const OuterTernary = pattern((__cf_pattern_input) => {
         type: "string"
     } as const satisfies __cfHelpers.JSONSchema, {
         "enum": ["B", "C", "D"]
-    } as const satisfies __cfHelpers.JSONSchema, show, __cfLift_1({ bar: bar }), "D")}</div>);
+    } as const satisfies __cfHelpers.JSONSchema, show, __cfLift_h4a92c84a9f6d({ bar: bar }), "D")}</div>);
 }, {
     type: "object",
     properties: {
@@ -72,7 +72,7 @@ export const OuterTernary = pattern((__cf_pattern_input) => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_h1659fa1d5ff8 = __cfHelpers.lift<{
     foo: boolean;
     bar: boolean;
 }, "A" | "B" | "C">(({ foo, bar }) => foo ? "A" : bar ? "B" : "C", {
@@ -101,7 +101,7 @@ export const AuthoredIfElse = pattern((__cf_pattern_input) => {
         type: "string"
     } as const satisfies __cfHelpers.JSONSchema, {
         "enum": ["A", "B", "C", "D"]
-    } as const satisfies __cfHelpers.JSONSchema, show, __cfLift_2({
+    } as const satisfies __cfHelpers.JSONSchema, show, __cfLift_h1659fa1d5ff8({
         foo: foo,
         bar: bar
     }), "D");
@@ -126,6 +126,8 @@ export const AuthoredIfElse = pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2
+    __cfLift_h4a92c84a9f6d,
+    __cfLift_h1659fa1d5ff8,
+    __cfLift_1: __cfLift_h4a92c84a9f6d,
+    __cfLift_2: __cfLift_h1659fa1d5ff8
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/conditional-empty-check.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/conditional-empty-check.expected.jsx
@@ -11,7 +11,7 @@ import { cell, NAME, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h821e518f00ae = __cfHelpers.lift<{
     items: __cfHelpers.Cell<string[]>;
 }, boolean>(({ items }) => !items.get().length, {
     type: "object",
@@ -56,7 +56,7 @@ export default pattern(() => {
                     type: "object",
                     properties: {}
                 }]
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_1({ items: items }), <span>No items</span>)}
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_h821e518f00ae({ items: items }), <span>No items</span>)}
       </div>),
     };
 }, false as const satisfies __cfHelpers.JSONSchema, {
@@ -96,5 +96,6 @@ export default pattern(() => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_h821e518f00ae,
+    __cfLift_1: __cfLift_h821e518f00ae
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/derived-property-access-with-derived-key.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/derived-property-access-with-derived-key.expected.jsx
@@ -19,7 +19,7 @@ interface Assignment {
     aisle: string;
     item: Item;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hdfdd4a0a93ef = __cfHelpers.lift<{
     items: Item[];
 }, { aisle: string; item: Item; }[]>(({ items }) => items.map((item, idx) => ({
     aisle: `Aisle ${(idx % 3) + 1}`,
@@ -80,7 +80,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_h62deca37e9c0 = __cfHelpers.lift<{
     itemsWithAisles: { aisle: string; item: Item; }[];
 }, Record<string, Assignment[]>>(({ itemsWithAisles }) => {
     const groups: Record<string, Assignment[]> = {};
@@ -163,7 +163,7 @@ const __cfLift_2 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_3 = __cfHelpers.lift<{
+const __cfLift_hfe4fb97e8dd9 = __cfHelpers.lift<{
     groupedByAisle: Record<string, Assignment[]>;
 }, string[]>(({ groupedByAisle }) => Object.keys(groupedByAisle).sort(), {
     type: "object",
@@ -213,7 +213,7 @@ const __cfLift_3 = __cfHelpers.lift<{
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_4 = __cfHelpers.lift<{
+const __cfLift_h4cc04b1fdb7a = __cfHelpers.lift<{
     groupedByAisle: Record<string, Assignment[]>;
     aisleName: string;
 }, Assignment[] | undefined>(({ groupedByAisle, aisleName }) => groupedByAisle[aisleName], {
@@ -298,7 +298,7 @@ const __cfLift_4 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h343da164a877 = __cfHelpers.pattern(__cf_pattern_input => {
     const assignment = __cf_pattern_input.key("element");
     return (<div>
                   <span>{assignment.key("item", "name")}</span>
@@ -360,15 +360,15 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h44e336242e82 = __cfHelpers.pattern(__cf_pattern_input => {
     const aisleName = __cf_pattern_input.key("element");
     const groupedByAisle = __cf_pattern_input.key("params", "groupedByAisle");
     return (<div>
               <h3>{aisleName}</h3>
-              {__cfLift_4({
+              {__cfLift_h4cc04b1fdb7a({
             groupedByAisle: groupedByAisle,
             aisleName: aisleName
-        })!.mapWithPattern(__cfPattern_1, {})}
+        })!.mapWithPattern(__cfPattern_h343da164a877, {})}
             </div>);
 }, {
     type: "object",
@@ -453,18 +453,18 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
 export default pattern((__cf_pattern_input) => {
     const items = __cf_pattern_input.key("items");
     // Create assignments with aisle data (whole-array map kept inside computed)
-    const itemsWithAisles = __cfLift_1({ items: items }).for("itemsWithAisles", true);
+    const itemsWithAisles = __cfLift_hdfdd4a0a93ef({ items: items }).for("itemsWithAisles", true);
     // Group by aisle - returns Record<string, Assignment[]>
-    const groupedByAisle = __cfLift_2({ itemsWithAisles: itemsWithAisles }).for("groupedByAisle", true);
+    const groupedByAisle = __cfLift_h62deca37e9c0({ itemsWithAisles: itemsWithAisles }).for("groupedByAisle", true);
     // Derive sorted aisle names from grouped object
-    const aisleNames = __cfLift_3({ groupedByAisle: groupedByAisle }).for("aisleNames", true);
+    const aisleNames = __cfLift_hfe4fb97e8dd9({ groupedByAisle: groupedByAisle }).for("aisleNames", true);
     // The pattern from CT-1036:
     // - Map over derived keys (aisleNames)
     // - Access derived object with derived key (groupedByAisle[aisleName])
     // - Map over the result
     return {
         [UI]: (<div>
-          {aisleNames.mapWithPattern(__cfPattern_2, {
+          {aisleNames.mapWithPattern(__cfPattern_h44e336242e82, {
                 groupedByAisle: groupedByAisle
             })}
         </div>),
@@ -529,10 +529,16 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2,
-    __cfLift_3,
-    __cfLift_4,
-    __cfPattern_1,
-    __cfPattern_2
+    __cfLift_hdfdd4a0a93ef,
+    __cfLift_h62deca37e9c0,
+    __cfLift_hfe4fb97e8dd9,
+    __cfLift_h4cc04b1fdb7a,
+    __cfPattern_h343da164a877,
+    __cfPattern_h44e336242e82,
+    __cfLift_1: __cfLift_hdfdd4a0a93ef,
+    __cfLift_2: __cfLift_h62deca37e9c0,
+    __cfLift_3: __cfLift_hfe4fb97e8dd9,
+    __cfLift_4: __cfLift_h4cc04b1fdb7a,
+    __cfPattern_1: __cfPattern_h343da164a877,
+    __cfPattern_2: __cfPattern_h44e336242e82
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/element-access-both-opaque.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/element-access-both-opaque.expected.jsx
@@ -11,7 +11,7 @@ import { cell, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h688cce498d95 = __cfHelpers.lift<{
     items: __cfHelpers.Cell<string[]>;
     index: __cfHelpers.Cell<number>;
 }, string | undefined>(({ items, index }) => items.get()[index.get()], {
@@ -50,7 +50,7 @@ export default pattern((_state) => {
         [UI]: (<div>
         <h3>Element Access with Both Reactives</h3>
         {/* Both items and index are Reactives */}
-        <p>Selected item: {__cfLift_1({
+        <p>Selected item: {__cfLift_h688cce498d95({
             items: items,
             index: index
         })}</p>
@@ -90,5 +90,6 @@ export default pattern((_state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_h688cce498d95,
+    __cfLift_1: __cfLift_h688cce498d95
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/element-access-complex.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/element-access-complex.expected.jsx
@@ -31,7 +31,7 @@ interface State {
     selectedUser: number;
     selectedScore: number;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h860446cd1638 = __cfHelpers.lift<{
     state: {
         matrix: number[][];
         row: number;
@@ -66,7 +66,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["number", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_h9c7d581e4e10 = __cfHelpers.lift<{
     state: {
         nested: {
             arrays: string[][];
@@ -109,7 +109,7 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["string", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_3 = __cfHelpers.lift<{
+const __cfLift_he8e8823883f4 = __cfHelpers.lift<{
     state: {
         items: string[];
     };
@@ -133,7 +133,7 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["string", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_4 = __cfHelpers.lift<{
+const __cfLift_h52574bf035a0 = __cfHelpers.lift<{
     state: {
         arr: number[];
     };
@@ -157,7 +157,7 @@ const __cfLift_4 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_5 = __cfHelpers.lift<{
+const __cfLift_h769ee8901e64 = __cfHelpers.lift<{
     state: {
         arr: number[];
         a: number;
@@ -189,7 +189,7 @@ const __cfLift_5 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["number", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_6 = __cfHelpers.lift<{
+const __cfLift_hb65ad4a78287 = __cfHelpers.lift<{
     state: {
         items: string[];
         row: number;
@@ -217,7 +217,7 @@ const __cfLift_6 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["string", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_7 = __cfHelpers.lift<{
+const __cfLift_ha0897c0f9871 = __cfHelpers.lift<{
     state: {
         arr: number[];
         a: number;
@@ -245,7 +245,7 @@ const __cfLift_7 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["number", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_8 = __cfHelpers.lift<{
+const __cfLift_h68d29bbf3148 = __cfHelpers.lift<{
     state: {
         users: { name: string; scores: number[]; }[];
         selectedUser: number;
@@ -289,7 +289,7 @@ const __cfLift_8 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["number", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_9 = __cfHelpers.lift<{
+const __cfLift_haff7a419013e = __cfHelpers.lift<{
     state: {
         items: string[];
         indices: number[];
@@ -320,7 +320,7 @@ const __cfLift_9 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["string", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_10 = __cfHelpers.lift<{
+const __cfLift_h48090f780881 = __cfHelpers.lift<{
     state: {
         arr: number[];
     };
@@ -344,7 +344,7 @@ const __cfLift_10 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["number", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_11 = __cfHelpers.lift<{
+const __cfLift_h9a449c893c58 = __cfHelpers.lift<{
     state: {
         nested: {
             arrays: string[][];
@@ -383,7 +383,7 @@ const __cfLift_11 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_12 = __cfHelpers.lift<{
+const __cfLift_h26eb61961c4f = __cfHelpers.lift<{
     state: {
         users: { name: string; scores: number[]; }[];
         selectedUser: number;
@@ -423,7 +423,7 @@ const __cfLift_12 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_13 = __cfHelpers.lift<{
+const __cfLift_h4df3f753c34a = __cfHelpers.lift<{
     state: {
         arr: number[];
         a: number;
@@ -451,7 +451,7 @@ const __cfLift_13 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_14 = __cfHelpers.lift<{
+const __cfLift_h4835bfaf53dc = __cfHelpers.lift<{
     state: {
         items: string[];
         b: number;
@@ -479,7 +479,7 @@ const __cfLift_14 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_15 = __cfHelpers.lift<{
+const __cfLift_h80544c1076c9 = __cfHelpers.lift<{
     state: {
         matrix: number[][];
         row: number;
@@ -514,7 +514,7 @@ const __cfLift_15 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_16 = __cfHelpers.lift<{
+const __cfLift_heea236e134c8 = __cfHelpers.lift<{
     state: {
         arr: number[];
         a: number;
@@ -546,7 +546,7 @@ const __cfLift_16 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_17 = __cfHelpers.lift<{
+const __cfLift_h23c3da2b9c6a = __cfHelpers.lift<{
     state: {
         items: string[];
         indices: number[];
@@ -577,7 +577,7 @@ const __cfLift_17 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_18 = __cfHelpers.lift<{
+const __cfLift_hc317dc01eb04 = __cfHelpers.lift<{
     state: {
         arr: number[];
     };
@@ -612,14 +612,14 @@ export default pattern((state) => {
         [UI]: (<div>
         <h3>Nested Element Access</h3>
         {/* Double indexing into matrix */}
-        <p>Matrix value: {__cfLift_1({ state: {
+        <p>Matrix value: {__cfLift_h860446cd1638({ state: {
                 matrix: state.key("matrix"),
                 row: state.key("row"),
                 col: state.key("col")
             } })}</p>
 
         {/* Triple nested access */}
-        <p>Deep nested: {__cfLift_2({ state: {
+        <p>Deep nested: {__cfLift_h9c7d581e4e10({ state: {
                 nested: {
                     arrays: state.key("nested", "arrays"),
                     index: state.key("nested", "index")
@@ -631,32 +631,32 @@ export default pattern((state) => {
         {/* Same array accessed multiple times with different indices */}
         <p>
           First and last: {state.key("items", "0")} and{" "}
-          {__cfLift_3({ state: {
+          {__cfLift_he8e8823883f4({ state: {
                 items: state.key("items")
             } })}
         </p>
 
         {/* Array used in computation and access */}
-        <p>Sum of ends: {__cfLift_4({ state: {
+        <p>Sum of ends: {__cfLift_h52574bf035a0({ state: {
                 arr: state.key("arr")
             } })}</p>
 
         <h3>Computed Indices</h3>
         {/* Index from multiple state values */}
-        <p>Computed index: {__cfLift_5({ state: {
+        <p>Computed index: {__cfLift_h769ee8901e64({ state: {
                 arr: state.key("arr"),
                 a: state.key("a"),
                 b: state.key("b")
             } })}</p>
 
         {/* Index from computation involving array */}
-        <p>Modulo index: {__cfLift_6({ state: {
+        <p>Modulo index: {__cfLift_hb65ad4a78287({ state: {
                 items: state.key("items"),
                 row: state.key("row")
             } })}</p>
 
         {/* Complex index expression */}
-        <p>Complex: {__cfLift_7({ state: {
+        <p>Complex: {__cfLift_ha0897c0f9871({ state: {
                 arr: state.key("arr"),
                 a: state.key("a")
             } })}</p>
@@ -665,7 +665,7 @@ export default pattern((state) => {
         {/* Element access returning array, then accessing that */}
         <p>
           User score:{" "}
-          {__cfLift_8({ state: {
+          {__cfLift_h68d29bbf3148({ state: {
                 users: state.key("users"),
                 selectedUser: state.key("selectedUser"),
                 selectedScore: state.key("selectedScore")
@@ -673,19 +673,19 @@ export default pattern((state) => {
         </p>
 
         {/* Using one array element as index for another */}
-        <p>Indirect: {__cfLift_9({ state: {
+        <p>Indirect: {__cfLift_haff7a419013e({ state: {
                 items: state.key("items"),
                 indices: state.key("indices")
             } })}</p>
 
         {/* Array element used as index for same array */}
-        <p>Self reference: {__cfLift_10({ state: {
+        <p>Self reference: {__cfLift_h48090f780881({ state: {
                 arr: state.key("arr")
             } })}</p>
 
         <h3>Mixed Property and Element Access</h3>
         {/* Property access followed by element access with computed index */}
-        <p>Mixed: {__cfLift_11({ state: {
+        <p>Mixed: {__cfLift_h9a449c893c58({ state: {
                 nested: {
                     arrays: state.key("nested", "arrays"),
                     index: state.key("nested", "index")
@@ -693,7 +693,7 @@ export default pattern((state) => {
             } })}</p>
 
         {/* Element access followed by property access */}
-        <p>User name length: {__cfLift_12({ state: {
+        <p>User name length: {__cfLift_h26eb61961c4f({ state: {
                 users: state.key("users"),
                 selectedUser: state.key("selectedUser")
             } })}</p>
@@ -710,10 +710,10 @@ export default pattern((state) => {
             type: "string"
         } as const satisfies __cfHelpers.JSONSchema, {
             type: "string"
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_13({ state: {
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_h4df3f753c34a({ state: {
                 arr: state.key("arr"),
                 a: state.key("a")
-            } }), __cfLift_14({ state: {
+            } }), __cfLift_h4835bfaf53dc({ state: {
                 items: state.key("items"),
                 b: state.key("b")
             } }), state.key("items", "0")!)}
@@ -729,7 +729,7 @@ export default pattern((state) => {
             type: "string"
         } as const satisfies __cfHelpers.JSONSchema, {
             "enum": ["positive", "non-positive"]
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_15({ state: {
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_h80544c1076c9({ state: {
                 matrix: state.key("matrix"),
                 row: state.key("row"),
                 col: state.key("col")
@@ -738,20 +738,20 @@ export default pattern((state) => {
 
         <h3>Element Access with Operators</h3>
         {/* Element access with arithmetic */}
-        <p>Product: {__cfLift_16({ state: {
+        <p>Product: {__cfLift_heea236e134c8({ state: {
                 arr: state.key("arr"),
                 a: state.key("a"),
                 b: state.key("b")
             } })}</p>
 
         {/* Element access with string concatenation */}
-        <p>Concat: {__cfLift_17({ state: {
+        <p>Concat: {__cfLift_h23c3da2b9c6a({ state: {
                 items: state.key("items"),
                 indices: state.key("indices")
             } })}</p>
 
         {/* Multiple element accesses in single expression */}
-        <p>Sum: {__cfLift_18({ state: {
+        <p>Sum: {__cfLift_hc317dc01eb04({ state: {
                 arr: state.key("arr")
             } })}</p>
       </div>),
@@ -876,22 +876,40 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2,
-    __cfLift_3,
-    __cfLift_4,
-    __cfLift_5,
-    __cfLift_6,
-    __cfLift_7,
-    __cfLift_8,
-    __cfLift_9,
-    __cfLift_10,
-    __cfLift_11,
-    __cfLift_12,
-    __cfLift_13,
-    __cfLift_14,
-    __cfLift_15,
-    __cfLift_16,
-    __cfLift_17,
-    __cfLift_18
+    __cfLift_h860446cd1638,
+    __cfLift_h9c7d581e4e10,
+    __cfLift_he8e8823883f4,
+    __cfLift_h52574bf035a0,
+    __cfLift_h769ee8901e64,
+    __cfLift_hb65ad4a78287,
+    __cfLift_ha0897c0f9871,
+    __cfLift_h68d29bbf3148,
+    __cfLift_haff7a419013e,
+    __cfLift_h48090f780881,
+    __cfLift_h9a449c893c58,
+    __cfLift_h26eb61961c4f,
+    __cfLift_h4df3f753c34a,
+    __cfLift_h4835bfaf53dc,
+    __cfLift_h80544c1076c9,
+    __cfLift_heea236e134c8,
+    __cfLift_h23c3da2b9c6a,
+    __cfLift_hc317dc01eb04,
+    __cfLift_1: __cfLift_h860446cd1638,
+    __cfLift_2: __cfLift_h9c7d581e4e10,
+    __cfLift_3: __cfLift_he8e8823883f4,
+    __cfLift_4: __cfLift_h52574bf035a0,
+    __cfLift_5: __cfLift_h769ee8901e64,
+    __cfLift_6: __cfLift_hb65ad4a78287,
+    __cfLift_7: __cfLift_ha0897c0f9871,
+    __cfLift_8: __cfLift_h68d29bbf3148,
+    __cfLift_9: __cfLift_haff7a419013e,
+    __cfLift_10: __cfLift_h48090f780881,
+    __cfLift_11: __cfLift_h9a449c893c58,
+    __cfLift_12: __cfLift_h26eb61961c4f,
+    __cfLift_13: __cfLift_h4df3f753c34a,
+    __cfLift_14: __cfLift_h4835bfaf53dc,
+    __cfLift_15: __cfLift_h80544c1076c9,
+    __cfLift_16: __cfLift_heea236e134c8,
+    __cfLift_17: __cfLift_h23c3da2b9c6a,
+    __cfLift_18: __cfLift_hc317dc01eb04
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/element-access-simple.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/element-access-simple.expected.jsx
@@ -18,7 +18,7 @@ interface State {
     row: number;
     col: number;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h18bda725b619 = __cfHelpers.lift<{
     state: {
         items: string[];
         index: number;
@@ -46,7 +46,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["string", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_he8e8823883f4 = __cfHelpers.lift<{
     state: {
         items: string[];
     };
@@ -70,7 +70,7 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["string", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_3 = __cfHelpers.lift<{
+const __cfLift_h860446cd1638 = __cfHelpers.lift<{
     state: {
         matrix: number[][];
         row: number;
@@ -115,18 +115,18 @@ export default pattern((state) => {
         [UI]: (<div>
         <h3>Dynamic Element Access</h3>
         {/* Basic dynamic index */}
-        <p>Item: {__cfLift_1({ state: {
+        <p>Item: {__cfLift_h18bda725b619({ state: {
                 items: state.key("items"),
                 index: state.key("index")
             } })}</p>
 
         {/* Computed index */}
-        <p>Last: {__cfLift_2({ state: {
+        <p>Last: {__cfLift_he8e8823883f4({ state: {
                 items: state.key("items")
             } })}</p>
 
         {/* Double indexing */}
-        <p>Matrix: {__cfLift_3({ state: {
+        <p>Matrix: {__cfLift_h860446cd1638({ state: {
                 matrix: state.key("matrix"),
                 row: state.key("row"),
                 col: state.key("col")
@@ -196,7 +196,10 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2,
-    __cfLift_3
+    __cfLift_h18bda725b619,
+    __cfLift_he8e8823883f4,
+    __cfLift_h860446cd1638,
+    __cfLift_1: __cfLift_h18bda725b619,
+    __cfLift_2: __cfLift_he8e8823883f4,
+    __cfLift_3: __cfLift_h860446cd1638
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/filter-callback-local-consts.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/filter-callback-local-consts.expected.jsx
@@ -24,7 +24,7 @@ interface Input {
 interface Output {
     [UI]: VNode;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h9d9f829bb403 = __cfHelpers.lift<{
     file: {
         type: string;
     };
@@ -45,9 +45,9 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h5d209dccb645 = __cfHelpers.pattern(__cf_pattern_input => {
     const file = __cf_pattern_input.key("element");
-    const isFolder = __cfLift_1({ file: {
+    const isFolder = __cfLift_h9d9f829bb403({ file: {
             type: file.key("type")
         } }).for("isFolder", true);
     return isFolder;
@@ -76,7 +76,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_heeb0796677a1 = __cfHelpers.pattern(__cf_pattern_input => {
     const file = __cf_pattern_input.key("element");
     return <span>{file.key("name")}</span>;
 }, {
@@ -126,7 +126,7 @@ export default pattern((__cf_pattern_input) => {
     const files = __cf_pattern_input.key("files");
     return {
         [UI]: (<div>
-        {files.filterWithPattern(__cfPattern_1, {}).mapWithPattern(__cfPattern_2, {})}
+        {files.filterWithPattern(__cfPattern_h5d209dccb645, {}).mapWithPattern(__cfPattern_heeb0796677a1, {})}
       </div>),
     };
 }, {
@@ -167,7 +167,10 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfPattern_1,
-    __cfPattern_2
+    __cfLift_h9d9f829bb403,
+    __cfPattern_h5d209dccb645,
+    __cfPattern_heeb0796677a1,
+    __cfLift_1: __cfLift_h9d9f829bb403,
+    __cfPattern_1: __cfPattern_h5d209dccb645,
+    __cfPattern_2: __cfPattern_heeb0796677a1
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/flatmap-callback-expression-statement.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/flatmap-callback-expression-statement.expected.jsx
@@ -24,7 +24,7 @@ interface Input {
 interface Output {
     [UI]: VNode;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h7edd79c9f7d5 = __cfHelpers.lift<{
     file: {
         name: string;
         type: string;
@@ -49,9 +49,9 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     asCell: ["opaque"]
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h19687273ff43 = __cfHelpers.pattern(__cf_pattern_input => {
     const file = __cf_pattern_input.key("element");
-    __cfLift_1({ file: {
+    __cfLift_h7edd79c9f7d5({ file: {
             name: file.key("name"),
             type: file.key("type")
         } });
@@ -109,7 +109,7 @@ export default pattern((__cf_pattern_input) => {
     const files = __cf_pattern_input.key("files");
     return {
         [UI]: (<div>
-        {files.flatMapWithPattern(__cfPattern_1, {})}
+        {files.flatMapWithPattern(__cfPattern_h19687273ff43, {})}
       </div>),
     };
 }, {
@@ -150,6 +150,8 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfPattern_1
+    __cfLift_h7edd79c9f7d5,
+    __cfPattern_h19687273ff43,
+    __cfLift_1: __cfLift_h7edd79c9f7d5,
+    __cfPattern_1: __cfPattern_h19687273ff43
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-captures.expected.jsx
@@ -35,7 +35,7 @@ function visibleEntries(entries: Writable<Default<Entry[], [
     return list.filter((entry) => prefix.length === 0 || entry.name.startsWith(prefix));
 }
 __cfHardenFn(visibleEntries);
-const __cfHandler_1 = __cfHelpers.handler({
+const __cfHandler_hfc59d3603eb4 = __cfHelpers.handler({
     type: "object",
     properties: {
         name: {
@@ -58,7 +58,7 @@ const __cfHandler_1 = __cfHelpers.handler({
 } as const satisfies __cfHelpers.JSONSchema, ({ name }, { path }) => {
     path.push(name);
 });
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hfd50a862864e = __cfHelpers.lift<{
     path: __cfHelpers.Cell<string[]>;
 }, readonly string[]>(({ path }) => path.get(), {
     type: "object",
@@ -78,7 +78,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_hfd50a862864e_2 = __cfHelpers.lift<{
     path: __cfHelpers.Cell<string[]>;
 }, readonly string[]>(({ path }) => path.get(), {
     type: "object",
@@ -98,7 +98,7 @@ const __cfLift_2 = __cfHelpers.lift<{
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_3 = __cfHelpers.lift<{
+const __cfLift_hea53e36dd1c6 = __cfHelpers.lift<{
     entries: Writable<Default<Entry[], [
     ]>>;
     p: readonly string[];
@@ -149,7 +149,7 @@ const __cfLift_3 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfHandler_2 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+const __cfHandler_h3b6a02d71010 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
         entry: {
@@ -174,10 +174,10 @@ const __cfHandler_2 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
     },
     required: ["entry", "pushPath"]
 } as const satisfies __cfHelpers.JSONSchema, (_, { pushPath, entry }) => pushPath.send({ name: entry.name }));
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h5badd6dda8c6 = __cfHelpers.pattern(__cf_pattern_input => {
     const entry = __cf_pattern_input.key("element");
     const pushPath = __cf_pattern_input.key("params", "pushPath");
-    return (<button type="button" onClick={__cfHandler_2({
+    return (<button type="button" onClick={__cfHandler_h3b6a02d71010({
         pushPath: pushPath,
         entry: {
             name: entry.key("name")
@@ -249,7 +249,7 @@ export default pattern((__cf_pattern_input) => {
             type: "string"
         }
     } as const satisfies __cfHelpers.JSONSchema).for("path", true);
-    const pushPath = __cfHandler_1({
+    const pushPath = __cfHandler_hfc59d3603eb4({
         path: path
     }).for({ stream: "pushPath" }, true);
     return {
@@ -268,7 +268,7 @@ export default pattern((__cf_pattern_input) => {
                     items: {
                         type: "string"
                     }
-                } as const satisfies __cfHelpers.JSONSchema, __cfLift_1({ path: path }).for(["p", 3], true), []).for("p", true);
+                } as const satisfies __cfHelpers.JSONSchema, __cfLift_hfd50a862864e({ path: path }).for(["p", 3], true), []).for("p", true);
                 if (p.length === 0)
                     return null;
                 return <div>{p[p.length - 1]}</div>;
@@ -287,12 +287,12 @@ export default pattern((__cf_pattern_input) => {
                     items: {
                         type: "string"
                     }
-                } as const satisfies __cfHelpers.JSONSchema, __cfLift_2({ path: path }).for(["p", 3], true), []).for("p", true);
-                const visible = __cfLift_3({
+                } as const satisfies __cfHelpers.JSONSchema, __cfLift_hfd50a862864e_2({ path: path }).for(["p", 3], true), []).for("p", true);
+                const visible = __cfLift_hea53e36dd1c6({
                     entries: entries,
                     p: p
                 }).for("visible", true);
-                return visible.mapWithPattern(__cfPattern_1, {
+                return visible.mapWithPattern(__cfPattern_h5badd6dda8c6, {
                     pushPath: pushPath
                 });
             })()}
@@ -335,10 +335,16 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfHandler_1,
-    __cfLift_1,
-    __cfLift_2,
-    __cfLift_3,
-    __cfHandler_2,
-    __cfPattern_1
+    __cfHandler_hfc59d3603eb4,
+    __cfLift_hfd50a862864e,
+    __cfLift_hfd50a862864e_2,
+    __cfLift_hea53e36dd1c6,
+    __cfHandler_h3b6a02d71010,
+    __cfPattern_h5badd6dda8c6,
+    __cfHandler_1: __cfHandler_hfc59d3603eb4,
+    __cfLift_1: __cfLift_hfd50a862864e,
+    __cfLift_2: __cfLift_hfd50a862864e_2,
+    __cfLift_3: __cfLift_hea53e36dd1c6,
+    __cfHandler_2: __cfHandler_h3b6a02d71010,
+    __cfPattern_1: __cfPattern_h5badd6dda8c6
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-default-input-local-chain-map-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-default-input-local-chain-map-capture.expected.jsx
@@ -43,7 +43,7 @@ interface Input {
 interface Output {
     [UI]: VNode;
 }
-const __cfHandler_1 = __cfHelpers.handler({
+const __cfHandler_hfc59d3603eb4 = __cfHelpers.handler({
     type: "object",
     properties: {
         name: {
@@ -66,7 +66,7 @@ const __cfHandler_1 = __cfHelpers.handler({
 } as const satisfies __cfHelpers.JSONSchema, ({ name }, { path }) => {
     path.push(name);
 });
-const __cfHandler_2 = __cfHelpers.handler({
+const __cfHandler_hb1fea7adc27a = __cfHelpers.handler({
     type: "object",
     properties: {
         item: {
@@ -106,7 +106,7 @@ const __cfHandler_2 = __cfHelpers.handler({
 } as const satisfies __cfHelpers.JSONSchema, ({ item }, __cf_action_params) => {
     void item;
 });
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hfd50a862864e = __cfHelpers.lift<{
     path: __cfHelpers.Cell<string[]>;
 }, readonly string[]>(({ path }) => path.get(), {
     type: "object",
@@ -126,7 +126,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_h98ff9fc03d40 = __cfHelpers.lift<{
     unsorted: Entry[];
 }, Entry[]>(({ unsorted }) => [...unsorted].sort((a: Entry, b: Entry) => {
     if (a.type === b.type)
@@ -201,7 +201,7 @@ const __cfLift_2 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfHandler_3 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+const __cfHandler_hb75a3a162723 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
         item: {
@@ -228,7 +228,7 @@ const __cfHandler_3 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
 } as const satisfies __cfHelpers.JSONSchema, (_, { handleNavigateInto, item }) => handleNavigateInto.send({
     name: item.name,
 }));
-const __cfHandler_4 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+const __cfHandler_h1e2796f330fe = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
         item: {
@@ -276,7 +276,7 @@ const __cfHandler_4 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, (_, { handleOpenFile, item }) => handleOpenFile.send({ item }));
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h40871c06266f = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const handleNavigateInto = __cf_pattern_input.key("params", "handleNavigateInto");
     const handleOpenFile = __cf_pattern_input.key("params", "handleOpenFile");
@@ -290,13 +290,13 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     } as const satisfies __cfHelpers.JSONSchema, !isFolder &&
         !!item.key("contentType"), item.key("contentType") !== "binary").for("isOpenable", true);
     return (<button type="button" onClick={isFolder
-            ? __cfHandler_3({
+            ? __cfHandler_hb75a3a162723({
                 handleNavigateInto: handleNavigateInto,
                 item: {
                     name: item.key("name")
                 }
             }) : isOpenable
-            ? __cfHandler_4({
+            ? __cfHandler_h1e2796f330fe({
                 handleOpenFile: handleOpenFile,
                 item: item
             }) : undefined}>
@@ -394,10 +394,10 @@ export default pattern((__cf_pattern_input) => {
             type: "string"
         }
     } as const satisfies __cfHelpers.JSONSchema).for("path", true);
-    const handleNavigateInto = __cfHandler_1({
+    const handleNavigateInto = __cfHandler_hfc59d3603eb4({
         path: path
     }).for({ stream: "handleNavigateInto" }, true);
-    const handleOpenFile = __cfHandler_2({}).for({ stream: "handleOpenFile" }, true);
+    const handleOpenFile = __cfHandler_hb1fea7adc27a({}).for({ stream: "handleOpenFile" }, true);
     return {
         [UI]: (<div>
         {(() => {
@@ -480,10 +480,10 @@ export default pattern((__cf_pattern_input) => {
                     items: {
                         type: "string"
                     }
-                } as const satisfies __cfHelpers.JSONSchema, __cfLift_1({ path: path }), [])).for("p", true) as string[];
+                } as const satisfies __cfHelpers.JSONSchema, __cfLift_hfd50a862864e({ path: path }), [])).for("p", true) as string[];
                 const unsorted = findChildren(tree, p) as Entry[];
-                const items = __cfLift_2({ unsorted: unsorted }).for("items", true);
-                return items.mapWithPattern(__cfPattern_1, {
+                const items = __cfLift_h98ff9fc03d40({ unsorted: unsorted }).for("items", true);
+                return items.mapWithPattern(__cfPattern_h40871c06266f, {
                     handleNavigateInto: handleNavigateInto,
                     handleOpenFile: handleOpenFile
                 });
@@ -541,11 +541,18 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfHandler_1,
-    __cfHandler_2,
-    __cfLift_1,
-    __cfLift_2,
-    __cfHandler_3,
-    __cfHandler_4,
-    __cfPattern_1
+    __cfHandler_hfc59d3603eb4,
+    __cfHandler_hb1fea7adc27a,
+    __cfLift_hfd50a862864e,
+    __cfLift_h98ff9fc03d40,
+    __cfHandler_hb75a3a162723,
+    __cfHandler_h1e2796f330fe,
+    __cfPattern_h40871c06266f,
+    __cfHandler_1: __cfHandler_hfc59d3603eb4,
+    __cfHandler_2: __cfHandler_hb1fea7adc27a,
+    __cfLift_1: __cfLift_hfd50a862864e,
+    __cfLift_2: __cfLift_h98ff9fc03d40,
+    __cfHandler_3: __cfHandler_hb75a3a162723,
+    __cfHandler_4: __cfHandler_h1e2796f330fe,
+    __cfPattern_1: __cfPattern_h40871c06266f
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-filter-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-filter-capture.expected.jsx
@@ -30,7 +30,7 @@ function visibleEntries(entries: Writable<Default<Entry[], [
     return list.filter((entry) => prefix.length === 0 || entry.name.startsWith(prefix));
 }
 __cfHardenFn(visibleEntries);
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hfd50a862864e = __cfHelpers.lift<{
     path: __cfHelpers.Cell<string[]>;
 }, readonly string[]>(({ path }) => path.get(), {
     type: "object",
@@ -50,7 +50,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_hea53e36dd1c6 = __cfHelpers.lift<{
     entries: Writable<Default<Entry[], [
     ]>>;
     p: readonly string[];
@@ -101,7 +101,7 @@ const __cfLift_2 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_3 = __cfHelpers.lift<{
+const __cfLift_h760c82446a9c = __cfHelpers.lift<{
     entry: {
         name: string;
     };
@@ -127,10 +127,10 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hd1bda252591e = __cfHelpers.pattern(__cf_pattern_input => {
     const entry = __cf_pattern_input.key("element");
     const labelPrefix = __cf_pattern_input.key("params", "labelPrefix");
-    return __cfLift_3({
+    return __cfLift_h760c82446a9c({
         entry: {
             name: entry.key("name")
         },
@@ -168,7 +168,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hc8ed09c750dc = __cfHelpers.pattern(__cf_pattern_input => {
     const entry = __cf_pattern_input.key("element");
     return <button type="button">{entry.key("name")}</button>;
 }, {
@@ -238,15 +238,15 @@ export default pattern((__cf_pattern_input) => {
                     items: {
                         type: "string"
                     }
-                } as const satisfies __cfHelpers.JSONSchema, __cfLift_1({ path: path }).for(["p", 3], true), []).for("p", true);
-                const visible = __cfLift_2({
+                } as const satisfies __cfHelpers.JSONSchema, __cfLift_hfd50a862864e({ path: path }).for(["p", 3], true), []).for("p", true);
+                const visible = __cfLift_hea53e36dd1c6({
                     entries: entries,
                     p: p
                 }).for("visible", true);
-                const filtered = visible.filterWithPattern(__cfPattern_1, {
+                const filtered = visible.filterWithPattern(__cfPattern_hd1bda252591e, {
                     labelPrefix: labelPrefix
                 }).for("filtered", true);
-                return filtered.mapWithPattern(__cfPattern_2, {});
+                return filtered.mapWithPattern(__cfPattern_hc8ed09c750dc, {});
             })()}
       </div>)
     };
@@ -287,9 +287,14 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2,
-    __cfLift_3,
-    __cfPattern_1,
-    __cfPattern_2
+    __cfLift_hfd50a862864e,
+    __cfLift_hea53e36dd1c6,
+    __cfLift_h760c82446a9c,
+    __cfPattern_hd1bda252591e,
+    __cfPattern_hc8ed09c750dc,
+    __cfLift_1: __cfLift_hfd50a862864e,
+    __cfLift_2: __cfLift_hea53e36dd1c6,
+    __cfLift_3: __cfLift_h760c82446a9c,
+    __cfPattern_1: __cfPattern_hd1bda252591e,
+    __cfPattern_2: __cfPattern_hc8ed09c750dc
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-flatmap-fallback-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-flatmap-fallback-capture.expected.jsx
@@ -27,7 +27,7 @@ interface Output {
     [UI]: VNode;
 }
 const visibleEntries = __cfHardenFn((entries: Entry[], prefix: string) => entries.filter((entry) => entry.name.startsWith(prefix)));
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hd194ffcb3be3 = __cfHelpers.lift<{
     entries: Entry[];
     prefix: string;
 }, Entry[]>(({ entries, prefix }) => visibleEntries(entries, prefix), {
@@ -72,7 +72,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_hbfa9244d5eee = __cfHelpers.lift<{
     entry: {
         name: string;
     };
@@ -97,7 +97,7 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h6bcb4e4b757d = __cfHelpers.pattern(__cf_pattern_input => {
     const entry = __cf_pattern_input.key("element");
     const labelPrefix = __cf_pattern_input.key("params", "labelPrefix");
     return __cfHelpers.ifElse({
@@ -115,7 +115,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         items: {
             type: "string"
         }
-    } as const satisfies __cfHelpers.JSONSchema, __cfLift_2({
+    } as const satisfies __cfHelpers.JSONSchema, __cfLift_hbfa9244d5eee({
         entry: {
             name: entry.key("name")
         },
@@ -155,7 +155,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hc8a1beca432f = __cfHelpers.pattern(__cf_pattern_input => {
     const label = __cf_pattern_input.key("element");
     return <button type="button">{label}</button>;
 }, {
@@ -229,14 +229,14 @@ export default pattern((__cf_pattern_input) => {
                             required: ["name"]
                         }
                     }
-                } as const satisfies __cfHelpers.JSONSchema, __cfLift_1({
+                } as const satisfies __cfHelpers.JSONSchema, __cfLift_hd194ffcb3be3({
                     entries: entries,
                     prefix: prefix
                 }).for(["visible", 3], true), []).for("visible", true);
-                const labels = visible.flatMapWithPattern(__cfPattern_1, {
+                const labels = visible.flatMapWithPattern(__cfPattern_h6bcb4e4b757d, {
                     labelPrefix: labelPrefix
                 }).for("labels", true);
-                return labels.mapWithPattern(__cfPattern_2, {});
+                return labels.mapWithPattern(__cfPattern_hc8a1beca432f, {});
             })()}
     </div>)
     });
@@ -281,8 +281,12 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2,
-    __cfPattern_1,
-    __cfPattern_2
+    __cfLift_hd194ffcb3be3,
+    __cfLift_hbfa9244d5eee,
+    __cfPattern_h6bcb4e4b757d,
+    __cfPattern_hc8a1beca432f,
+    __cfLift_1: __cfLift_hd194ffcb3be3,
+    __cfLift_2: __cfLift_hbfa9244d5eee,
+    __cfPattern_1: __cfPattern_h6bcb4e4b757d,
+    __cfPattern_2: __cfPattern_hc8a1beca432f
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-map-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-map-capture.expected.jsx
@@ -34,7 +34,7 @@ function visibleEntries(entries: Writable<Default<Entry[], [
     return list.filter((entry) => prefix.length === 0 || entry.name.startsWith(prefix));
 }
 __cfHardenFn(visibleEntries);
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hfd50a862864e = __cfHelpers.lift<{
     path: __cfHelpers.Cell<string[]>;
 }, readonly string[]>(({ path }) => path.get(), {
     type: "object",
@@ -54,7 +54,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_hea53e36dd1c6 = __cfHelpers.lift<{
     entries: Writable<Default<Entry[], [
     ]>>;
     p: readonly string[];
@@ -105,7 +105,7 @@ const __cfLift_2 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h0c68680bd45d = __cfHelpers.pattern(__cf_pattern_input => {
     const entry = __cf_pattern_input.key("element");
     const labelPrefix = __cf_pattern_input.key("params", "labelPrefix");
     return (<button type="button">
@@ -188,12 +188,12 @@ export default pattern((__cf_pattern_input) => {
                     items: {
                         type: "string"
                     }
-                } as const satisfies __cfHelpers.JSONSchema, __cfLift_1({ path: path }).for(["p", 3], true), []).for("p", true);
-                const visible = __cfLift_2({
+                } as const satisfies __cfHelpers.JSONSchema, __cfLift_hfd50a862864e({ path: path }).for(["p", 3], true), []).for("p", true);
+                const visible = __cfLift_hea53e36dd1c6({
                     entries: entries,
                     p: p
                 }).for("visible", true);
-                return visible.mapWithPattern(__cfPattern_1, {
+                return visible.mapWithPattern(__cfPattern_h0c68680bd45d, {
                     labelPrefix: labelPrefix
                 });
             })()}
@@ -236,7 +236,10 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2,
-    __cfPattern_1
+    __cfLift_hfd50a862864e,
+    __cfLift_hea53e36dd1c6,
+    __cfPattern_h0c68680bd45d,
+    __cfLift_1: __cfLift_hfd50a862864e,
+    __cfLift_2: __cfLift_hea53e36dd1c6,
+    __cfPattern_1: __cfPattern_h0c68680bd45d
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-map-fallback-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-map-fallback-capture.expected.jsx
@@ -27,7 +27,7 @@ interface Output {
     [UI]: VNode;
 }
 const visibleEntries = __cfHardenFn((entries: Entry[], prefix: string) => entries.filter((entry) => entry.name.startsWith(prefix)));
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hd194ffcb3be3 = __cfHelpers.lift<{
     entries: Entry[];
     prefix: string;
 }, Entry[]>(({ entries, prefix }) => visibleEntries(entries, prefix), {
@@ -72,7 +72,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h81b52218b9d7 = __cfHelpers.pattern(__cf_pattern_input => {
     const entry = __cf_pattern_input.key("element");
     const labelPrefix = __cf_pattern_input.key("params", "labelPrefix");
     return (<button type="button">
@@ -169,11 +169,11 @@ export default pattern((__cf_pattern_input) => {
                             required: ["name"]
                         }
                     }
-                } as const satisfies __cfHelpers.JSONSchema, __cfLift_1({
+                } as const satisfies __cfHelpers.JSONSchema, __cfLift_hd194ffcb3be3({
                     entries: entries,
                     prefix: prefix
                 }).for(["visible", 3], true), []).for("visible", true);
-                return visible.mapWithPattern(__cfPattern_1, {
+                return visible.mapWithPattern(__cfPattern_h81b52218b9d7, {
                     labelPrefix: labelPrefix
                 });
             })()}
@@ -220,6 +220,8 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfPattern_1
+    __cfLift_hd194ffcb3be3,
+    __cfPattern_h81b52218b9d7,
+    __cfLift_1: __cfLift_hd194ffcb3be3,
+    __cfPattern_1: __cfPattern_h81b52218b9d7
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-local-initializer-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-local-initializer-captures.expected.jsx
@@ -43,7 +43,7 @@ interface Input {
 interface Output {
     [UI]: VNode;
 }
-const __cfHandler_1 = __cfHelpers.handler({
+const __cfHandler_hfc59d3603eb4 = __cfHelpers.handler({
     type: "object",
     properties: {
         name: {
@@ -66,7 +66,7 @@ const __cfHandler_1 = __cfHelpers.handler({
 } as const satisfies __cfHelpers.JSONSchema, ({ name }, { path }) => {
     path.push(name);
 });
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hfd50a862864e = __cfHelpers.lift<{
     path: __cfHelpers.Cell<string[]>;
 }, readonly string[]>(({ path }) => path.get(), {
     type: "object",
@@ -86,7 +86,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_he3cf86ab1f0d = __cfHelpers.lift<{
     tree: __cfHelpers.Cell<Entry[]>;
     p: readonly string[];
 }, readonly Entry[]>(({ tree, p }) => findChildren(tree, p), {
@@ -159,7 +159,7 @@ const __cfLift_2 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_3 = __cfHelpers.lift<{
+const __cfLift_h5e6bc47ef34d = __cfHelpers.lift<{
     unsorted: readonly Entry[];
 }, Entry[]>(({ unsorted }) => [...unsorted].sort((a: Entry, b: Entry) => a.name.localeCompare(b.name)), {
     type: "object",
@@ -224,7 +224,7 @@ const __cfLift_3 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfHandler_2 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+const __cfHandler_h5e44d572cb85 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
         item: {
@@ -249,10 +249,10 @@ const __cfHandler_2 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
     },
     required: ["item", "pushPath"]
 } as const satisfies __cfHelpers.JSONSchema, (_, { pushPath, item }) => pushPath.send({ name: item.name }));
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h181d19baff88 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const pushPath = __cf_pattern_input.key("params", "pushPath");
-    return (<button type="button" onClick={__cfHandler_2({
+    return (<button type="button" onClick={__cfHandler_h5e44d572cb85({
         pushPath: pushPath,
         item: {
             name: item.key("name")
@@ -339,7 +339,7 @@ export default pattern((__cf_pattern_input) => {
             type: "string"
         }
     } as const satisfies __cfHelpers.JSONSchema).for("path", true);
-    const pushPath = __cfHandler_1({
+    const pushPath = __cfHandler_hfc59d3603eb4({
         path: path
     }).for({ stream: "pushPath" }, true);
     return {
@@ -359,13 +359,13 @@ export default pattern((__cf_pattern_input) => {
                     items: {
                         type: "string"
                     }
-                } as const satisfies __cfHelpers.JSONSchema, __cfLift_1({ path: path }).for(["p", 3], true), []).for("p", true);
-                const unsorted = __cfLift_2({
+                } as const satisfies __cfHelpers.JSONSchema, __cfLift_hfd50a862864e({ path: path }).for(["p", 3], true), []).for("p", true);
+                const unsorted = __cfLift_he3cf86ab1f0d({
                     tree: tree,
                     p: p
                 }).for("unsorted", true);
-                const items = __cfLift_3({ unsorted: unsorted }).for("items", true);
-                return items.mapWithPattern(__cfPattern_1, {
+                const items = __cfLift_h5e6bc47ef34d({ unsorted: unsorted }).for("items", true);
+                return items.mapWithPattern(__cfPattern_h181d19baff88, {
                     pushPath: pushPath
                 });
             })()}
@@ -420,10 +420,16 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfHandler_1,
-    __cfLift_1,
-    __cfLift_2,
-    __cfLift_3,
-    __cfHandler_2,
-    __cfPattern_1
+    __cfHandler_hfc59d3603eb4,
+    __cfLift_hfd50a862864e,
+    __cfLift_he3cf86ab1f0d,
+    __cfLift_h5e6bc47ef34d,
+    __cfHandler_h5e44d572cb85,
+    __cfPattern_h181d19baff88,
+    __cfHandler_1: __cfHandler_hfc59d3603eb4,
+    __cfLift_1: __cfLift_hfd50a862864e,
+    __cfLift_2: __cfLift_he3cf86ab1f0d,
+    __cfLift_3: __cfLift_h5e6bc47ef34d,
+    __cfHandler_2: __cfHandler_h5e44d572cb85,
+    __cfPattern_1: __cfPattern_h181d19baff88
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/ifelse-undefined-value.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/ifelse-undefined-value.expected.jsx
@@ -11,7 +11,7 @@ import { computed, fetchText, ifElse, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hd8360bf3dee1 = __cfHelpers.lift<{
     pending: boolean;
     result: string;
 }, boolean>(({ pending, result }) => pending || !result, {
@@ -28,7 +28,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_h682d6b85c3f2 = __cfHelpers.lift<{
     result: string;
 }, boolean>(({ result }) => !!result, {
     type: "object",
@@ -78,7 +78,7 @@ export default pattern(() => {
                 },
                 required: ["result"]
             }]
-    } as const satisfies __cfHelpers.JSONSchema, __cfLift_1({
+    } as const satisfies __cfHelpers.JSONSchema, __cfLift_hd8360bf3dee1({
         pending: pending,
         result: result
     }).for(["output1", 4], true), undefined, { result }).for("output1", true);
@@ -107,7 +107,7 @@ export default pattern(() => {
                 },
                 required: ["data"]
             }]
-    } as const satisfies __cfHelpers.JSONSchema, __cfLift_2({ result: result }).for(["output2", 4], true), { data: result }, undefined).for("output2", true);
+    } as const satisfies __cfHelpers.JSONSchema, __cfLift_h682d6b85c3f2({ result: result }).for(["output2", 4], true), { data: result }, undefined).for("output2", true);
     return {
         [UI]: (<div>
         <span>{output1}</span>
@@ -152,6 +152,8 @@ export default pattern(() => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2
+    __cfLift_hd8360bf3dee1,
+    __cfLift_h682d6b85c3f2,
+    __cfLift_1: __cfLift_hd8360bf3dee1,
+    __cfLift_2: __cfLift_h682d6b85c3f2
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-arithmetic-operations.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-arithmetic-operations.expected.jsx
@@ -17,7 +17,7 @@ interface State {
     discount: number;
     quantity: number;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hef9d746c0d70 = __cfHelpers.lift<{
     state: {
         count: number;
     };
@@ -38,7 +38,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_h613c2baa7390 = __cfHelpers.lift<{
     state: {
         count: number;
     };
@@ -59,7 +59,7 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_3 = __cfHelpers.lift<{
+const __cfLift_hbfc813e57691 = __cfHelpers.lift<{
     state: {
         count: number;
     };
@@ -80,7 +80,7 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_4 = __cfHelpers.lift<{
+const __cfLift_h5a5ddaaafc5b = __cfHelpers.lift<{
     state: {
         price: number;
     };
@@ -101,7 +101,7 @@ const __cfLift_4 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_5 = __cfHelpers.lift<{
+const __cfLift_haa9004f29aac = __cfHelpers.lift<{
     state: {
         count: number;
     };
@@ -122,7 +122,7 @@ const __cfLift_5 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_6 = __cfHelpers.lift<{
+const __cfLift_h34f9ca32751b = __cfHelpers.lift<{
     state: {
         price: number;
         discount: number;
@@ -147,7 +147,7 @@ const __cfLift_6 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_7 = __cfHelpers.lift<{
+const __cfLift_h45f1dd57b8e4 = __cfHelpers.lift<{
     state: {
         price: number;
         quantity: number;
@@ -172,7 +172,7 @@ const __cfLift_7 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_8 = __cfHelpers.lift<{
+const __cfLift_hedf9460692b5 = __cfHelpers.lift<{
     state: {
         price: number;
         quantity: number;
@@ -197,7 +197,7 @@ const __cfLift_8 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_9 = __cfHelpers.lift<{
+const __cfLift_h58852644c59a = __cfHelpers.lift<{
     state: {
         count: number;
         quantity: number;
@@ -231,7 +231,7 @@ const __cfLift_9 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_10 = __cfHelpers.lift<{
+const __cfLift_h8d8f9939b8e5 = __cfHelpers.lift<{
     state: {
         count: number;
     };
@@ -252,7 +252,7 @@ const __cfLift_10 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_11 = __cfHelpers.lift<{
+const __cfLift_h35977e3f9ec2 = __cfHelpers.lift<{
     state: {
         price: number;
     };
@@ -273,7 +273,7 @@ const __cfLift_11 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_12 = __cfHelpers.lift<{
+const __cfLift_he1d832981ff3 = __cfHelpers.lift<{
     state: {
         price: number;
     };
@@ -303,37 +303,37 @@ export default pattern((state) => {
     return {
         [UI]: (<div>
         <h3>Basic Arithmetic</h3>
-        <p>Count + 1: {__cfLift_1({ state: {
+        <p>Count + 1: {__cfLift_hef9d746c0d70({ state: {
                 count: state.key("count")
             } })}</p>
-        <p>Count - 1: {__cfLift_2({ state: {
+        <p>Count - 1: {__cfLift_h613c2baa7390({ state: {
                 count: state.key("count")
             } })}</p>
-        <p>Count * 2: {__cfLift_3({ state: {
+        <p>Count * 2: {__cfLift_hbfc813e57691({ state: {
                 count: state.key("count")
             } })}</p>
-        <p>Price / 2: {__cfLift_4({ state: {
+        <p>Price / 2: {__cfLift_h5a5ddaaafc5b({ state: {
                 price: state.key("price")
             } })}</p>
-        <p>Count % 3: {__cfLift_5({ state: {
+        <p>Count % 3: {__cfLift_haa9004f29aac({ state: {
                 count: state.key("count")
             } })}</p>
 
         <h3>Complex Expressions</h3>
-        <p>Discounted Price: {__cfLift_6({ state: {
+        <p>Discounted Price: {__cfLift_h34f9ca32751b({ state: {
                 price: state.key("price"),
                 discount: state.key("discount")
             } })}</p>
-        <p>Total: {__cfLift_7({ state: {
+        <p>Total: {__cfLift_h45f1dd57b8e4({ state: {
                 price: state.key("price"),
                 quantity: state.key("quantity")
             } })}</p>
-        <p>With Tax (8%): {__cfLift_8({ state: {
+        <p>With Tax (8%): {__cfLift_hedf9460692b5({ state: {
                 price: state.key("price"),
                 quantity: state.key("quantity")
             } })}</p>
         <p>
-          Complex: {__cfLift_9({ state: {
+          Complex: {__cfLift_h58852644c59a({ state: {
                 count: state.key("count"),
                 quantity: state.key("quantity"),
                 price: state.key("price"),
@@ -342,12 +342,12 @@ export default pattern((state) => {
         </p>
 
         <h3>Multiple Same Ref</h3>
-        <p>Count³: {__cfLift_10({ state: {
+        <p>Count³: {__cfLift_h8d8f9939b8e5({ state: {
                 count: state.key("count")
             } })}</p>
-        <p>Price Range: ${__cfLift_11({ state: {
+        <p>Price Range: ${__cfLift_h35977e3f9ec2({ state: {
                 price: state.key("price")
-            } })} - ${__cfLift_12({ state: {
+            } })} - ${__cfLift_he1d832981ff3({ state: {
                 price: state.key("price")
             } })}</p>
       </div>),
@@ -403,16 +403,28 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2,
-    __cfLift_3,
-    __cfLift_4,
-    __cfLift_5,
-    __cfLift_6,
-    __cfLift_7,
-    __cfLift_8,
-    __cfLift_9,
-    __cfLift_10,
-    __cfLift_11,
-    __cfLift_12
+    __cfLift_hef9d746c0d70,
+    __cfLift_h613c2baa7390,
+    __cfLift_hbfc813e57691,
+    __cfLift_h5a5ddaaafc5b,
+    __cfLift_haa9004f29aac,
+    __cfLift_h34f9ca32751b,
+    __cfLift_h45f1dd57b8e4,
+    __cfLift_hedf9460692b5,
+    __cfLift_h58852644c59a,
+    __cfLift_h8d8f9939b8e5,
+    __cfLift_h35977e3f9ec2,
+    __cfLift_he1d832981ff3,
+    __cfLift_1: __cfLift_hef9d746c0d70,
+    __cfLift_2: __cfLift_h613c2baa7390,
+    __cfLift_3: __cfLift_hbfc813e57691,
+    __cfLift_4: __cfLift_h5a5ddaaafc5b,
+    __cfLift_5: __cfLift_haa9004f29aac,
+    __cfLift_6: __cfLift_h34f9ca32751b,
+    __cfLift_7: __cfLift_h45f1dd57b8e4,
+    __cfLift_8: __cfLift_hedf9460692b5,
+    __cfLift_9: __cfLift_h58852644c59a,
+    __cfLift_10: __cfLift_h8d8f9939b8e5,
+    __cfLift_11: __cfLift_h35977e3f9ec2,
+    __cfLift_12: __cfLift_he1d832981ff3
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-array-method-sink-calls.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-array-method-sink-calls.expected.jsx
@@ -16,7 +16,7 @@ interface State {
     threshold: number;
     factor: number;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hf710939c6dec = __cfHelpers.lift<{
     state: {
         items: number[];
         threshold: number;
@@ -44,7 +44,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_h86830e31d06f = __cfHelpers.lift<{
     state: {
         items: number[];
         threshold: number;
@@ -76,7 +76,7 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_3 = __cfHelpers.lift<{
+const __cfLift_h71f22e3fcaa9 = __cfHelpers.lift<{
     state: {
         items: number[];
         threshold: number;
@@ -104,7 +104,7 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_4 = __cfHelpers.lift<{
+const __cfLift_hdfcc753b3edd = __cfHelpers.lift<{
     state: {
         items: number[];
         threshold: number;
@@ -145,14 +145,14 @@ export default pattern((state) => {
         [UI]: (<div>
         <p>
           Filter joined:{" "}
-          {__cfLift_1({ state: {
+          {__cfLift_hf710939c6dec({ state: {
                 items: state.key("items"),
                 threshold: state.key("threshold")
             } })}
         </p>
         <p>
           Filter map joined:{" "}
-          {__cfLift_2({ state: {
+          {__cfLift_h86830e31d06f({ state: {
                 items: state.key("items"),
                 threshold: state.key("threshold"),
                 factor: state.key("factor")
@@ -160,14 +160,14 @@ export default pattern((state) => {
         </p>
         <p>
           Filter joined upper:{" "}
-          {__cfLift_3({ state: {
+          {__cfLift_h71f22e3fcaa9({ state: {
                 items: state.key("items"),
                 threshold: state.key("threshold")
             } })}
         </p>
         <p>
           Filter joined upper trimmed:{" "}
-          {__cfLift_4({ state: {
+          {__cfLift_hdfcc753b3edd({ state: {
                 items: state.key("items"),
                 threshold: state.key("threshold")
             } })}
@@ -225,8 +225,12 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2,
-    __cfLift_3,
-    __cfLift_4
+    __cfLift_hf710939c6dec,
+    __cfLift_h86830e31d06f,
+    __cfLift_h71f22e3fcaa9,
+    __cfLift_hdfcc753b3edd,
+    __cfLift_1: __cfLift_hf710939c6dec,
+    __cfLift_2: __cfLift_h86830e31d06f,
+    __cfLift_3: __cfLift_h71f22e3fcaa9,
+    __cfLift_4: __cfLift_hdfcc753b3edd
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-complex-mixed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-complex-mixed.expected.jsx
@@ -23,7 +23,7 @@ interface State {
     discount: number;
     taxRate: number;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h2a59c1898c48 = __cfHelpers.lift<{
     state: {
         items: {
             name: string;
@@ -59,7 +59,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_hd75a5a4a2b41 = __cfHelpers.lift<{
     item: {
         price: number;
     };
@@ -92,7 +92,7 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_3 = __cfHelpers.lift<{
+const __cfLift_hdd8535926630 = __cfHelpers.lift<{
     item: {
         price: number;
     };
@@ -130,14 +130,14 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h54d847ceb4b0 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const state = __cf_pattern_input.key("params", "state");
     return (<li key={item.key("id")}>
               <span>{item.key("name")}</span>
               <span>- Original: ${item.key("price")}</span>
               <span>
-                - Discounted: ${__cfLift_2({
+                - Discounted: ${__cfLift_hd75a5a4a2b41({
         item: {
             price: item.key("price")
         },
@@ -148,7 +148,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
               </span>
               <span>
                 - With tax:
-                ${__cfLift_3({
+                ${__cfLift_hdd8535926630({
         item: {
             price: item.key("price")
         },
@@ -226,7 +226,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_4 = __cfHelpers.lift<{
+const __cfLift_h4a3f5c27f005 = __cfHelpers.lift<{
     state: {
         items: Item[];
     };
@@ -256,7 +256,7 @@ const __cfLift_4 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_5 = __cfHelpers.lift<{
+const __cfLift_hfcbdbf9c0faf = __cfHelpers.lift<{
     state: {
         discount: number;
     };
@@ -277,7 +277,7 @@ const __cfLift_5 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_6 = __cfHelpers.lift<{
+const __cfLift_h8096a0efba94 = __cfHelpers.lift<{
     state: {
         taxRate: number;
     };
@@ -298,7 +298,7 @@ const __cfLift_6 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_7 = __cfHelpers.lift<{
+const __cfLift_hbae4b7d842de = __cfHelpers.lift<{
     state: {
         items: Item[];
     };
@@ -328,7 +328,7 @@ const __cfLift_7 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_8 = __cfHelpers.lift<{
+const __cfLift_h4d6d1265abb7 = __cfHelpers.lift<{
     state: {
         items: Item[];
     };
@@ -358,7 +358,7 @@ const __cfLift_8 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_9 = __cfHelpers.lift<{
+const __cfLift_h6ad1d5ba034c = __cfHelpers.lift<{
     state: {
         items: Item[];
     };
@@ -388,7 +388,7 @@ const __cfLift_9 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_10 = __cfHelpers.lift<{
+const __cfLift_h34931f5c6931 = __cfHelpers.lift<{
     state: {
         filter: {
             length: number;
@@ -431,7 +431,7 @@ export default pattern((state) => {
         <p>Total items: {state.key("items", "length")}</p>
         <p>
           Filtered count:{" "}
-          {__cfLift_1({ state: {
+          {__cfLift_h2a59c1898c48({ state: {
                 items: state.key("items"),
                 filter: state.key("filter")
             } })}
@@ -439,7 +439,7 @@ export default pattern((state) => {
 
         <h3>Array with Complex Expressions</h3>
         <ul>
-          {state.key("items").mapWithPattern(__cfPattern_1, {
+          {state.key("items").mapWithPattern(__cfPattern_h54d847ceb4b0, {
                 state: {
                     discount: state.key("discount"),
                     taxRate: state.key("taxRate")
@@ -449,15 +449,15 @@ export default pattern((state) => {
 
         <h3>Array Methods</h3>
         <p>Item count: {state.key("items", "length")}</p>
-        <p>Active items: {__cfLift_4({ state: {
+        <p>Active items: {__cfLift_h4a3f5c27f005({ state: {
                 items: state.key("items")
             } })}</p>
 
         <h3>Simple Operations</h3>
-        <p>Discount percent: {__cfLift_5({ state: {
+        <p>Discount percent: {__cfLift_hfcbdbf9c0faf({ state: {
                 discount: state.key("discount")
             } })}%</p>
-        <p>Tax percent: {__cfLift_6({ state: {
+        <p>Tax percent: {__cfLift_h8096a0efba94({ state: {
                 taxRate: state.key("taxRate")
             } })}%</p>
 
@@ -470,7 +470,7 @@ export default pattern((state) => {
             type: "string"
         } as const satisfies __cfHelpers.JSONSchema, {
             "enum": ["Yes", "No"]
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_7({ state: {
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_hbae4b7d842de({ state: {
                 items: state.key("items")
             } }), "Yes", "No")}</p>
         <p>Any active: {__cfHelpers.ifElse({
@@ -481,7 +481,7 @@ export default pattern((state) => {
             type: "string"
         } as const satisfies __cfHelpers.JSONSchema, {
             "enum": ["Yes", "No"]
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_8({ state: {
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_h4d6d1265abb7({ state: {
                 items: state.key("items")
             } }), "Yes", "No")}</p>
         <p>
@@ -494,13 +494,13 @@ export default pattern((state) => {
             type: "string"
         } as const satisfies __cfHelpers.JSONSchema, {
             "enum": ["Yes", "No"]
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_9({ state: {
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_h6ad1d5ba034c({ state: {
                 items: state.key("items")
             } }), "Yes", "No")}
         </p>
 
         <h3>Object Operations</h3>
-        <div data-item-count={state.key("items", "length")} data-has-filter={__cfLift_10({ state: {
+        <div data-item-count={state.key("items", "length")} data-has-filter={__cfLift_h34931f5c6931({ state: {
                 filter: {
                     length: state.key("filter", "length")
                 }
@@ -583,15 +583,26 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2,
-    __cfLift_3,
-    __cfPattern_1,
-    __cfLift_4,
-    __cfLift_5,
-    __cfLift_6,
-    __cfLift_7,
-    __cfLift_8,
-    __cfLift_9,
-    __cfLift_10
+    __cfLift_h2a59c1898c48,
+    __cfLift_hd75a5a4a2b41,
+    __cfLift_hdd8535926630,
+    __cfPattern_h54d847ceb4b0,
+    __cfLift_h4a3f5c27f005,
+    __cfLift_hfcbdbf9c0faf,
+    __cfLift_h8096a0efba94,
+    __cfLift_hbae4b7d842de,
+    __cfLift_h4d6d1265abb7,
+    __cfLift_h6ad1d5ba034c,
+    __cfLift_h34931f5c6931,
+    __cfLift_1: __cfLift_h2a59c1898c48,
+    __cfLift_2: __cfLift_hd75a5a4a2b41,
+    __cfLift_3: __cfLift_hdd8535926630,
+    __cfPattern_1: __cfPattern_h54d847ceb4b0,
+    __cfLift_4: __cfLift_h4a3f5c27f005,
+    __cfLift_5: __cfLift_hfcbdbf9c0faf,
+    __cfLift_6: __cfLift_h8096a0efba94,
+    __cfLift_7: __cfLift_hbae4b7d842de,
+    __cfLift_8: __cfLift_h4d6d1265abb7,
+    __cfLift_9: __cfLift_h6ad1d5ba034c,
+    __cfLift_10: __cfLift_h34931f5c6931
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-conditional-rendering-no-name.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-conditional-rendering-no-name.expected.jsx
@@ -19,7 +19,7 @@ interface State {
     hasPermission: boolean;
     isPremium: boolean;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h89148dfed5bb = __cfHelpers.lift<{
     state: {
         count: number;
     };
@@ -40,7 +40,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_h80b473952880 = __cfHelpers.lift<{
     state: {
         score: number;
     };
@@ -61,7 +61,7 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_3 = __cfHelpers.lift<{
+const __cfLift_h87a39eab30b0 = __cfHelpers.lift<{
     state: {
         score: number;
     };
@@ -82,7 +82,7 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_4 = __cfHelpers.lift<{
+const __cfLift_hf81d88ebaf5e = __cfHelpers.lift<{
     state: {
         count: number;
     };
@@ -103,7 +103,7 @@ const __cfLift_4 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_5 = __cfHelpers.lift<{
+const __cfLift_hfd1cf776e918 = __cfHelpers.lift<{
     state: {
         count: number;
     };
@@ -124,7 +124,7 @@ const __cfLift_5 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_6 = __cfHelpers.lift<{
+const __cfLift_h8b2cca337f2b = __cfHelpers.lift<{
     state: {
         userType: string;
     };
@@ -145,7 +145,7 @@ const __cfLift_6 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_7 = __cfHelpers.lift<{
+const __cfLift_h1b1c89380d86 = __cfHelpers.lift<{
     state: {
         userType: string;
     };
@@ -166,7 +166,7 @@ const __cfLift_7 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_8 = __cfHelpers.lift<{
+const __cfLift_hbb9e3a8118a5 = __cfHelpers.lift<{
     state: {
         count: number;
     };
@@ -187,7 +187,7 @@ const __cfLift_8 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_9 = __cfHelpers.lift<{
+const __cfLift_hf41cec7a3d28 = __cfHelpers.lift<{
     state: {
         count: number;
     };
@@ -208,7 +208,7 @@ const __cfLift_9 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_10 = __cfHelpers.lift<{
+const __cfLift_h1ceb9e35cb2e = __cfHelpers.lift<{
     state: {
         score: number;
     };
@@ -229,7 +229,7 @@ const __cfLift_10 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_11 = __cfHelpers.lift<{
+const __cfLift_h9abe7ff5580a = __cfHelpers.lift<{
     state: {
         count: number;
     };
@@ -287,7 +287,7 @@ export default pattern((state) => {
             type: "string"
         } as const satisfies __cfHelpers.JSONSchema, {
             "enum": ["High", "Low"]
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_1({ state: {
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_h89148dfed5bb({ state: {
                 count: state.key("count")
             } }), "High", "Low")}</span>
         <span>{__cfHelpers.ifElse({
@@ -298,7 +298,7 @@ export default pattern((state) => {
             "enum": ["B", "C"]
         } as const satisfies __cfHelpers.JSONSchema, {
             "enum": ["B", "C", "A"]
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_2({ state: {
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_h80b473952880({ state: {
                 score: state.key("score")
             } }), "A", __cfHelpers.ifElse({
             type: "boolean"
@@ -308,7 +308,7 @@ export default pattern((state) => {
             type: "string"
         } as const satisfies __cfHelpers.JSONSchema, {
             "enum": ["B", "C"]
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_3({ state: {
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_h87a39eab30b0({ state: {
                 score: state.key("score")
             } }), "B", "C"))}</span>
         <span>
@@ -320,7 +320,7 @@ export default pattern((state) => {
             "enum": ["Single", "Multiple"]
         } as const satisfies __cfHelpers.JSONSchema, {
             "enum": ["Single", "Multiple", "Empty"]
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_4({ state: {
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_hf81d88ebaf5e({ state: {
                 count: state.key("count")
             } }), "Empty", __cfHelpers.ifElse({
             type: "boolean"
@@ -330,7 +330,7 @@ export default pattern((state) => {
             type: "string"
         } as const satisfies __cfHelpers.JSONSchema, {
             "enum": ["Single", "Multiple"]
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_5({ state: {
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_hfd1cf776e918({ state: {
                 count: state.key("count")
             } }), "Single", "Multiple"))}
         </span>
@@ -364,7 +364,7 @@ export default pattern((state) => {
             "enum": ["User", "Guest"]
         } as const satisfies __cfHelpers.JSONSchema, {
             "enum": ["User", "Guest", "Admin"]
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_6({ state: {
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_h8b2cca337f2b({ state: {
                 userType: state.key("userType")
             } }), "Admin", __cfHelpers.ifElse({
             type: "boolean"
@@ -374,7 +374,7 @@ export default pattern((state) => {
             type: "string"
         } as const satisfies __cfHelpers.JSONSchema, {
             "enum": ["User", "Guest"]
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_7({ state: {
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_h1b1c89380d86({ state: {
                 userType: state.key("userType")
             } }), "User", "Guest"))}
         </span>
@@ -412,9 +412,9 @@ export default pattern((state) => {
             type: "boolean"
         } as const satisfies __cfHelpers.JSONSchema, {
             type: "boolean"
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_8({ state: {
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_hbb9e3a8118a5({ state: {
                 count: state.key("count")
-            } }), __cfLift_9({ state: {
+            } }), __cfLift_hf41cec7a3d28({ state: {
                 count: state.key("count")
             } })), "In Range", "Out of Range")}
         </span>
@@ -433,7 +433,7 @@ export default pattern((state) => {
             type: "boolean"
         } as const satisfies __cfHelpers.JSONSchema, {
             type: "boolean"
-        } as const satisfies __cfHelpers.JSONSchema, state.key("isPremium"), __cfLift_10({ state: {
+        } as const satisfies __cfHelpers.JSONSchema, state.key("isPremium"), __cfLift_h1ceb9e35cb2e({ state: {
                 score: state.key("score")
             } })), "Premium Features", "Basic Features")}
         </span>
@@ -465,7 +465,7 @@ export default pattern((state) => {
                     type: "object",
                     properties: {}
                 }]
-        } as const satisfies __cfHelpers.JSONSchema, {} as const satisfies __cfHelpers.JSONSchema, __cfLift_11({ state: {
+        } as const satisfies __cfHelpers.JSONSchema, {} as const satisfies __cfHelpers.JSONSchema, __cfLift_h9abe7ff5580a({ state: {
                 count: state.key("count")
             } }), <ul>
             <li>Many items: {state.key("count")}</li>
@@ -529,15 +529,26 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2,
-    __cfLift_3,
-    __cfLift_4,
-    __cfLift_5,
-    __cfLift_6,
-    __cfLift_7,
-    __cfLift_8,
-    __cfLift_9,
-    __cfLift_10,
-    __cfLift_11
+    __cfLift_h89148dfed5bb,
+    __cfLift_h80b473952880,
+    __cfLift_h87a39eab30b0,
+    __cfLift_hf81d88ebaf5e,
+    __cfLift_hfd1cf776e918,
+    __cfLift_h8b2cca337f2b,
+    __cfLift_h1b1c89380d86,
+    __cfLift_hbb9e3a8118a5,
+    __cfLift_hf41cec7a3d28,
+    __cfLift_h1ceb9e35cb2e,
+    __cfLift_h9abe7ff5580a,
+    __cfLift_1: __cfLift_h89148dfed5bb,
+    __cfLift_2: __cfLift_h80b473952880,
+    __cfLift_3: __cfLift_h87a39eab30b0,
+    __cfLift_4: __cfLift_hf81d88ebaf5e,
+    __cfLift_5: __cfLift_hfd1cf776e918,
+    __cfLift_6: __cfLift_h8b2cca337f2b,
+    __cfLift_7: __cfLift_h1b1c89380d86,
+    __cfLift_8: __cfLift_hbb9e3a8118a5,
+    __cfLift_9: __cfLift_hf41cec7a3d28,
+    __cfLift_10: __cfLift_h1ceb9e35cb2e,
+    __cfLift_11: __cfLift_h9abe7ff5580a
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-conditional-rendering.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-conditional-rendering.expected.jsx
@@ -19,7 +19,7 @@ interface State {
     hasPermission: boolean;
     isPremium: boolean;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h89148dfed5bb = __cfHelpers.lift<{
     state: {
         count: number;
     };
@@ -40,7 +40,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_h80b473952880 = __cfHelpers.lift<{
     state: {
         score: number;
     };
@@ -61,7 +61,7 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_3 = __cfHelpers.lift<{
+const __cfLift_h87a39eab30b0 = __cfHelpers.lift<{
     state: {
         score: number;
     };
@@ -82,7 +82,7 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_4 = __cfHelpers.lift<{
+const __cfLift_hf81d88ebaf5e = __cfHelpers.lift<{
     state: {
         count: number;
     };
@@ -103,7 +103,7 @@ const __cfLift_4 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_5 = __cfHelpers.lift<{
+const __cfLift_hfd1cf776e918 = __cfHelpers.lift<{
     state: {
         count: number;
     };
@@ -124,7 +124,7 @@ const __cfLift_5 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_6 = __cfHelpers.lift<{
+const __cfLift_h8b2cca337f2b = __cfHelpers.lift<{
     state: {
         userType: string;
     };
@@ -145,7 +145,7 @@ const __cfLift_6 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_7 = __cfHelpers.lift<{
+const __cfLift_h1b1c89380d86 = __cfHelpers.lift<{
     state: {
         userType: string;
     };
@@ -166,7 +166,7 @@ const __cfLift_7 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_8 = __cfHelpers.lift<{
+const __cfLift_hbb9e3a8118a5 = __cfHelpers.lift<{
     state: {
         count: number;
     };
@@ -187,7 +187,7 @@ const __cfLift_8 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_9 = __cfHelpers.lift<{
+const __cfLift_hf41cec7a3d28 = __cfHelpers.lift<{
     state: {
         count: number;
     };
@@ -208,7 +208,7 @@ const __cfLift_9 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_10 = __cfHelpers.lift<{
+const __cfLift_h1ceb9e35cb2e = __cfHelpers.lift<{
     state: {
         score: number;
     };
@@ -229,7 +229,7 @@ const __cfLift_10 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_11 = __cfHelpers.lift<{
+const __cfLift_h9abe7ff5580a = __cfHelpers.lift<{
     state: {
         count: number;
     };
@@ -287,7 +287,7 @@ export default pattern((state) => {
             type: "string"
         } as const satisfies __cfHelpers.JSONSchema, {
             "enum": ["High", "Low"]
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_1({ state: {
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_h89148dfed5bb({ state: {
                 count: state.key("count")
             } }), "High", "Low")}</span>
         <span>{__cfHelpers.ifElse({
@@ -298,7 +298,7 @@ export default pattern((state) => {
             "enum": ["B", "C"]
         } as const satisfies __cfHelpers.JSONSchema, {
             "enum": ["B", "C", "A"]
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_2({ state: {
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_h80b473952880({ state: {
                 score: state.key("score")
             } }), "A", __cfHelpers.ifElse({
             type: "boolean"
@@ -308,7 +308,7 @@ export default pattern((state) => {
             type: "string"
         } as const satisfies __cfHelpers.JSONSchema, {
             "enum": ["B", "C"]
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_3({ state: {
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_h87a39eab30b0({ state: {
                 score: state.key("score")
             } }), "B", "C"))}</span>
         <span>
@@ -320,7 +320,7 @@ export default pattern((state) => {
             "enum": ["Single", "Multiple"]
         } as const satisfies __cfHelpers.JSONSchema, {
             "enum": ["Single", "Multiple", "Empty"]
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_4({ state: {
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_hf81d88ebaf5e({ state: {
                 count: state.key("count")
             } }), "Empty", __cfHelpers.ifElse({
             type: "boolean"
@@ -330,7 +330,7 @@ export default pattern((state) => {
             type: "string"
         } as const satisfies __cfHelpers.JSONSchema, {
             "enum": ["Single", "Multiple"]
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_5({ state: {
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_hfd1cf776e918({ state: {
                 count: state.key("count")
             } }), "Single", "Multiple"))}
         </span>
@@ -364,7 +364,7 @@ export default pattern((state) => {
             "enum": ["User", "Guest"]
         } as const satisfies __cfHelpers.JSONSchema, {
             "enum": ["User", "Guest", "Admin"]
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_6({ state: {
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_h8b2cca337f2b({ state: {
                 userType: state.key("userType")
             } }), "Admin", __cfHelpers.ifElse({
             type: "boolean"
@@ -374,7 +374,7 @@ export default pattern((state) => {
             type: "string"
         } as const satisfies __cfHelpers.JSONSchema, {
             "enum": ["User", "Guest"]
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_7({ state: {
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_h1b1c89380d86({ state: {
                 userType: state.key("userType")
             } }), "User", "Guest"))}
         </span>
@@ -412,9 +412,9 @@ export default pattern((state) => {
             type: "boolean"
         } as const satisfies __cfHelpers.JSONSchema, {
             type: "boolean"
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_8({ state: {
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_hbb9e3a8118a5({ state: {
                 count: state.key("count")
-            } }), __cfLift_9({ state: {
+            } }), __cfLift_hf41cec7a3d28({ state: {
                 count: state.key("count")
             } })), "In Range", "Out of Range")}
         </span>
@@ -433,7 +433,7 @@ export default pattern((state) => {
             type: "boolean"
         } as const satisfies __cfHelpers.JSONSchema, {
             type: "boolean"
-        } as const satisfies __cfHelpers.JSONSchema, state.key("isPremium"), __cfLift_10({ state: {
+        } as const satisfies __cfHelpers.JSONSchema, state.key("isPremium"), __cfLift_h1ceb9e35cb2e({ state: {
                 score: state.key("score")
             } })), "Premium Features", "Basic Features")}
         </span>
@@ -465,7 +465,7 @@ export default pattern((state) => {
                     type: "object",
                     properties: {}
                 }]
-        } as const satisfies __cfHelpers.JSONSchema, {} as const satisfies __cfHelpers.JSONSchema, __cfLift_11({ state: {
+        } as const satisfies __cfHelpers.JSONSchema, {} as const satisfies __cfHelpers.JSONSchema, __cfLift_h9abe7ff5580a({ state: {
                 count: state.key("count")
             } }), <ul>
             <li>Many items: {state.key("count")}</li>
@@ -529,15 +529,26 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2,
-    __cfLift_3,
-    __cfLift_4,
-    __cfLift_5,
-    __cfLift_6,
-    __cfLift_7,
-    __cfLift_8,
-    __cfLift_9,
-    __cfLift_10,
-    __cfLift_11
+    __cfLift_h89148dfed5bb,
+    __cfLift_h80b473952880,
+    __cfLift_h87a39eab30b0,
+    __cfLift_hf81d88ebaf5e,
+    __cfLift_hfd1cf776e918,
+    __cfLift_h8b2cca337f2b,
+    __cfLift_h1b1c89380d86,
+    __cfLift_hbb9e3a8118a5,
+    __cfLift_hf41cec7a3d28,
+    __cfLift_h1ceb9e35cb2e,
+    __cfLift_h9abe7ff5580a,
+    __cfLift_1: __cfLift_h89148dfed5bb,
+    __cfLift_2: __cfLift_h80b473952880,
+    __cfLift_3: __cfLift_h87a39eab30b0,
+    __cfLift_4: __cfLift_hf81d88ebaf5e,
+    __cfLift_5: __cfLift_hfd1cf776e918,
+    __cfLift_6: __cfLift_h8b2cca337f2b,
+    __cfLift_7: __cfLift_h1b1c89380d86,
+    __cfLift_8: __cfLift_hbb9e3a8118a5,
+    __cfLift_9: __cfLift_hf41cec7a3d28,
+    __cfLift_10: __cfLift_h1ceb9e35cb2e,
+    __cfLift_11: __cfLift_h9abe7ff5580a
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-direct-branch-roots.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-direct-branch-roots.expected.jsx
@@ -11,7 +11,7 @@ import { pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_ha520b347478a = __cfHelpers.lift<{
     state: {
         task: {
             done: boolean;
@@ -40,7 +40,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_h10bbe946665d = __cfHelpers.lift<{
     state: {
         label?: string | null | undefined;
     };
@@ -83,7 +83,7 @@ export default pattern((state) => ({
         type: "boolean"
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "boolean"
-    } as const satisfies __cfHelpers.JSONSchema, state.key("showCompleted"), __cfLift_1({ state: {
+    } as const satisfies __cfHelpers.JSONSchema, state.key("showCompleted"), __cfLift_ha520b347478a({ state: {
             task: {
                 done: state.key("task", "done")
             }
@@ -120,7 +120,7 @@ export default pattern((state) => ({
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "string"
     } as const satisfies __cfHelpers.JSONSchema, state.key("fallbackLabel"), "C"))}</p>
-      <p>{__cfLift_2({ state: {
+      <p>{__cfLift_h10bbe946665d({ state: {
             label: state.key("label")
         } })}</p>
     </div>),
@@ -191,6 +191,8 @@ export default pattern((state) => ({
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2
+    __cfLift_ha520b347478a,
+    __cfLift_h10bbe946665d,
+    __cfLift_1: __cfLift_ha520b347478a,
+    __cfLift_2: __cfLift_h10bbe946665d
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-filter-length-roots.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-filter-length-roots.expected.jsx
@@ -11,7 +11,7 @@ import { pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h2d7ef0946ff7 = __cfHelpers.lift<{
     state: {
         items: number[];
         threshold: number;
@@ -39,7 +39,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_h221c3b85ff3f = __cfHelpers.lift<{
     state: {
         items: number[];
         threshold: number;
@@ -67,7 +67,7 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_3 = __cfHelpers.lift<{
+const __cfLift_h221c3b85ff3f_2 = __cfHelpers.lift<{
     state: {
         items: number[];
         threshold: number;
@@ -104,11 +104,11 @@ const __cfLift_3 = __cfHelpers.lift<{
 // Context: all three shapes should lower without leaking callback locals.
 export default pattern((state) => ({
     [UI]: (<div>
-      <p>{__cfLift_1({ state: {
+      <p>{__cfLift_h2d7ef0946ff7({ state: {
             items: state.key("items"),
             threshold: state.key("threshold")
         } })}</p>
-      <p>{__cfLift_2({ state: {
+      <p>{__cfLift_h221c3b85ff3f({ state: {
             items: state.key("items"),
             threshold: state.key("threshold")
         } })}</p>
@@ -121,7 +121,7 @@ export default pattern((state) => ({
         type: "string"
     } as const satisfies __cfHelpers.JSONSchema, {
         "enum": ["Yes", "No"]
-    } as const satisfies __cfHelpers.JSONSchema, __cfLift_3({ state: {
+    } as const satisfies __cfHelpers.JSONSchema, __cfLift_h221c3b85ff3f_2({ state: {
             items: state.key("items"),
             threshold: state.key("threshold")
         } }), "Yes", "No")}
@@ -175,7 +175,10 @@ export default pattern((state) => ({
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2,
-    __cfLift_3
+    __cfLift_h2d7ef0946ff7,
+    __cfLift_h221c3b85ff3f,
+    __cfLift_h221c3b85ff3f_2,
+    __cfLift_1: __cfLift_h2d7ef0946ff7,
+    __cfLift_2: __cfLift_h221c3b85ff3f,
+    __cfLift_3: __cfLift_h221c3b85ff3f_2
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-function-calls.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-function-calls.expected.jsx
@@ -20,7 +20,7 @@ interface State {
     name: string;
     float: string;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hc153d1b5c82c = __cfHelpers.lift<{
     state: {
         a: number;
         b: number;
@@ -45,7 +45,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_hffd39797350c = __cfHelpers.lift<{
     state: {
         a: number;
     };
@@ -66,7 +66,7 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_3 = __cfHelpers.lift<{
+const __cfLift_h57086f1770fe = __cfHelpers.lift<{
     state: {
         a: number;
         b: number;
@@ -91,7 +91,7 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_4 = __cfHelpers.lift<{
+const __cfLift_he75194969f73 = __cfHelpers.lift<{
     state: {
         price: number;
     };
@@ -112,7 +112,7 @@ const __cfLift_4 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_5 = __cfHelpers.lift<{
+const __cfLift_h6c3d6e4ebc7e = __cfHelpers.lift<{
     state: {
         price: number;
     };
@@ -133,7 +133,7 @@ const __cfLift_5 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_6 = __cfHelpers.lift<{
+const __cfLift_h01327696368c = __cfHelpers.lift<{
     state: {
         price: number;
     };
@@ -154,7 +154,7 @@ const __cfLift_6 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_7 = __cfHelpers.lift<{
+const __cfLift_ha1812ca90e20 = __cfHelpers.lift<{
     state: {
         a: number;
     };
@@ -175,7 +175,7 @@ const __cfLift_7 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_8 = __cfHelpers.lift<{
+const __cfLift_hd70a6d2393b8 = __cfHelpers.lift<{
     state: {
         name: string;
     };
@@ -196,7 +196,7 @@ const __cfLift_8 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_9 = __cfHelpers.lift<{
+const __cfLift_h06a586055757 = __cfHelpers.lift<{
     state: {
         name: string;
     };
@@ -217,7 +217,7 @@ const __cfLift_9 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_10 = __cfHelpers.lift<{
+const __cfLift_hbce3f5caa499 = __cfHelpers.lift<{
     state: {
         text: string;
     };
@@ -238,7 +238,7 @@ const __cfLift_10 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_11 = __cfHelpers.lift<{
+const __cfLift_h20a0fe9c716a = __cfHelpers.lift<{
     state: {
         text: string;
     };
@@ -259,7 +259,7 @@ const __cfLift_11 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_12 = __cfHelpers.lift<{
+const __cfLift_hd27e59eaabe9 = __cfHelpers.lift<{
     state: {
         text: string;
     };
@@ -280,7 +280,7 @@ const __cfLift_12 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_13 = __cfHelpers.lift<{
+const __cfLift_hbe3db5019722 = __cfHelpers.lift<{
     state: {
         name: string;
     };
@@ -301,7 +301,7 @@ const __cfLift_13 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_14 = __cfHelpers.lift<{
+const __cfLift_hb8f89b907c39 = __cfHelpers.lift<{
     state: {
         price: number;
     };
@@ -322,7 +322,7 @@ const __cfLift_14 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_15 = __cfHelpers.lift<{
+const __cfLift_hb821b83dfb5b = __cfHelpers.lift<{
     state: {
         price: number;
     };
@@ -343,7 +343,7 @@ const __cfLift_15 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_16 = __cfHelpers.lift<{
+const __cfLift_h1f431b9b430a = __cfHelpers.lift<{
     state: {
         float: string;
     };
@@ -364,7 +364,7 @@ const __cfLift_16 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_17 = __cfHelpers.lift<{
+const __cfLift_hb332029fac5d = __cfHelpers.lift<{
     state: {
         float: string;
     };
@@ -385,7 +385,7 @@ const __cfLift_17 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_18 = __cfHelpers.lift<{
+const __cfLift_hf4dc1251e63c = __cfHelpers.lift<{
     state: {
         values: number[];
     };
@@ -409,7 +409,7 @@ const __cfLift_18 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_19 = __cfHelpers.lift<{
+const __cfLift_h81c31b3c6346 = __cfHelpers.lift<{
     state: {
         values: number[];
     };
@@ -433,7 +433,7 @@ const __cfLift_19 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_20 = __cfHelpers.lift<{
+const __cfLift_hf6f49a1f9e90 = __cfHelpers.lift<{
     state: {
         values: number[];
     };
@@ -457,7 +457,7 @@ const __cfLift_20 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_21 = __cfHelpers.lift<{
+const __cfLift_h4bea4b458ea1 = __cfHelpers.lift<{
     state: {
         a: number;
     };
@@ -478,7 +478,7 @@ const __cfLift_21 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_22 = __cfHelpers.lift<{
+const __cfLift_h2d17bf278df3 = __cfHelpers.lift<{
     state: {
         a: number;
     };
@@ -499,7 +499,7 @@ const __cfLift_22 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_23 = __cfHelpers.lift<{
+const __cfLift_h5dac3358f7b4 = __cfHelpers.lift<{
     state: {
         name: string;
     };
@@ -520,7 +520,7 @@ const __cfLift_23 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_24 = __cfHelpers.lift<{
+const __cfLift_h6c2a5c2bed73 = __cfHelpers.lift<{
     state: {
         a: number;
         b: number;
@@ -554,41 +554,41 @@ export default pattern((state) => {
     return {
         [UI]: (<div>
         <h3>Math Functions</h3>
-        <p>Max: {__cfLift_1({ state: {
+        <p>Max: {__cfLift_hc153d1b5c82c({ state: {
                 a: state.key("a"),
                 b: state.key("b")
             } })}</p>
-        <p>Min: {__cfLift_2({ state: {
+        <p>Min: {__cfLift_hffd39797350c({ state: {
                 a: state.key("a")
             } })}</p>
-        <p>Abs: {__cfLift_3({ state: {
+        <p>Abs: {__cfLift_h57086f1770fe({ state: {
                 a: state.key("a"),
                 b: state.key("b")
             } })}</p>
-        <p>Round: {__cfLift_4({ state: {
+        <p>Round: {__cfLift_he75194969f73({ state: {
                 price: state.key("price")
             } })}</p>
-        <p>Floor: {__cfLift_5({ state: {
+        <p>Floor: {__cfLift_h6c3d6e4ebc7e({ state: {
                 price: state.key("price")
             } })}</p>
-        <p>Ceiling: {__cfLift_6({ state: {
+        <p>Ceiling: {__cfLift_h01327696368c({ state: {
                 price: state.key("price")
             } })}</p>
-        <p>Square root: {__cfLift_7({ state: {
+        <p>Square root: {__cfLift_ha1812ca90e20({ state: {
                 a: state.key("a")
             } })}</p>
 
         <h3>String Methods as Function Calls</h3>
-        <p>Uppercase: {__cfLift_8({ state: {
+        <p>Uppercase: {__cfLift_hd70a6d2393b8({ state: {
                 name: state.key("name")
             } })}</p>
-        <p>Lowercase: {__cfLift_9({ state: {
+        <p>Lowercase: {__cfLift_h06a586055757({ state: {
                 name: state.key("name")
             } })}</p>
-        <p>Substring: {__cfLift_10({ state: {
+        <p>Substring: {__cfLift_hbce3f5caa499({ state: {
                 text: state.key("text")
             } })}</p>
-        <p>Replace: {__cfLift_11({ state: {
+        <p>Replace: {__cfLift_h20a0fe9c716a({ state: {
                 text: state.key("text")
             } })}</p>
         <p>Includes: {__cfHelpers.ifElse({
@@ -599,7 +599,7 @@ export default pattern((state) => {
             type: "string"
         } as const satisfies __cfHelpers.JSONSchema, {
             "enum": ["Yes", "No"]
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_12({ state: {
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_hd27e59eaabe9({ state: {
                 text: state.key("text")
             } }), "Yes", "No")}</p>
         <p>Starts with: {__cfHelpers.ifElse({
@@ -610,48 +610,48 @@ export default pattern((state) => {
             type: "string"
         } as const satisfies __cfHelpers.JSONSchema, {
             "enum": ["Yes", "No"]
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_13({ state: {
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_hbe3db5019722({ state: {
                 name: state.key("name")
             } }), "Yes", "No")}</p>
 
         <h3>Number Methods</h3>
-        <p>To Fixed: {__cfLift_14({ state: {
+        <p>To Fixed: {__cfLift_hb8f89b907c39({ state: {
                 price: state.key("price")
             } })}</p>
-        <p>To Precision: {__cfLift_15({ state: {
+        <p>To Precision: {__cfLift_hb821b83dfb5b({ state: {
                 price: state.key("price")
             } })}</p>
 
         <h3>Parse Functions</h3>
-        <p>Parse Int: {__cfLift_16({ state: {
+        <p>Parse Int: {__cfLift_h1f431b9b430a({ state: {
                 float: state.key("float")
             } })}</p>
-        <p>Parse Float: {__cfLift_17({ state: {
+        <p>Parse Float: {__cfLift_hb332029fac5d({ state: {
                 float: state.key("float")
             } })}</p>
 
         <h3>Array Method Calls</h3>
-        <p>Sum: {__cfLift_18({ state: {
+        <p>Sum: {__cfLift_hf4dc1251e63c({ state: {
                 values: state.key("values")
             } })}</p>
-        <p>Max value: {__cfLift_19({ state: {
+        <p>Max value: {__cfLift_h81c31b3c6346({ state: {
                 values: state.key("values")
             } })}</p>
-        <p>Joined: {__cfLift_20({ state: {
+        <p>Joined: {__cfLift_hf6f49a1f9e90({ state: {
                 values: state.key("values")
             } })}</p>
 
         <h3>Complex Function Calls</h3>
-        <p>Multiple args: {__cfLift_21({ state: {
+        <p>Multiple args: {__cfLift_h4bea4b458ea1({ state: {
                 a: state.key("a")
             } })}</p>
-        <p>Nested calls: {__cfLift_22({ state: {
+        <p>Nested calls: {__cfLift_h2d17bf278df3({ state: {
                 a: state.key("a")
             } })}</p>
-        <p>Chained calls: {__cfLift_23({ state: {
+        <p>Chained calls: {__cfLift_h5dac3358f7b4({ state: {
                 name: state.key("name")
             } })}</p>
-        <p>With expressions: {__cfLift_24({ state: {
+        <p>With expressions: {__cfLift_h6c2a5c2bed73({ state: {
                 a: state.key("a"),
                 b: state.key("b")
             } })}</p>
@@ -720,28 +720,52 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2,
-    __cfLift_3,
-    __cfLift_4,
-    __cfLift_5,
-    __cfLift_6,
-    __cfLift_7,
-    __cfLift_8,
-    __cfLift_9,
-    __cfLift_10,
-    __cfLift_11,
-    __cfLift_12,
-    __cfLift_13,
-    __cfLift_14,
-    __cfLift_15,
-    __cfLift_16,
-    __cfLift_17,
-    __cfLift_18,
-    __cfLift_19,
-    __cfLift_20,
-    __cfLift_21,
-    __cfLift_22,
-    __cfLift_23,
-    __cfLift_24
+    __cfLift_hc153d1b5c82c,
+    __cfLift_hffd39797350c,
+    __cfLift_h57086f1770fe,
+    __cfLift_he75194969f73,
+    __cfLift_h6c3d6e4ebc7e,
+    __cfLift_h01327696368c,
+    __cfLift_ha1812ca90e20,
+    __cfLift_hd70a6d2393b8,
+    __cfLift_h06a586055757,
+    __cfLift_hbce3f5caa499,
+    __cfLift_h20a0fe9c716a,
+    __cfLift_hd27e59eaabe9,
+    __cfLift_hbe3db5019722,
+    __cfLift_hb8f89b907c39,
+    __cfLift_hb821b83dfb5b,
+    __cfLift_h1f431b9b430a,
+    __cfLift_hb332029fac5d,
+    __cfLift_hf4dc1251e63c,
+    __cfLift_h81c31b3c6346,
+    __cfLift_hf6f49a1f9e90,
+    __cfLift_h4bea4b458ea1,
+    __cfLift_h2d17bf278df3,
+    __cfLift_h5dac3358f7b4,
+    __cfLift_h6c2a5c2bed73,
+    __cfLift_1: __cfLift_hc153d1b5c82c,
+    __cfLift_2: __cfLift_hffd39797350c,
+    __cfLift_3: __cfLift_h57086f1770fe,
+    __cfLift_4: __cfLift_he75194969f73,
+    __cfLift_5: __cfLift_h6c3d6e4ebc7e,
+    __cfLift_6: __cfLift_h01327696368c,
+    __cfLift_7: __cfLift_ha1812ca90e20,
+    __cfLift_8: __cfLift_hd70a6d2393b8,
+    __cfLift_9: __cfLift_h06a586055757,
+    __cfLift_10: __cfLift_hbce3f5caa499,
+    __cfLift_11: __cfLift_h20a0fe9c716a,
+    __cfLift_12: __cfLift_hd27e59eaabe9,
+    __cfLift_13: __cfLift_hbe3db5019722,
+    __cfLift_14: __cfLift_hb8f89b907c39,
+    __cfLift_15: __cfLift_hb821b83dfb5b,
+    __cfLift_16: __cfLift_h1f431b9b430a,
+    __cfLift_17: __cfLift_hb332029fac5d,
+    __cfLift_18: __cfLift_hf4dc1251e63c,
+    __cfLift_19: __cfLift_h81c31b3c6346,
+    __cfLift_20: __cfLift_hf6f49a1f9e90,
+    __cfLift_21: __cfLift_h4bea4b458ea1,
+    __cfLift_22: __cfLift_h2d17bf278df3,
+    __cfLift_23: __cfLift_h5dac3358f7b4,
+    __cfLift_24: __cfLift_h6c2a5c2bed73
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-property-access.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-property-access.expected.jsx
@@ -42,7 +42,7 @@ interface State {
     index: number;
     numbers: number[];
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hac88b0f3cc94 = __cfHelpers.lift<{
     state: {
         user: {
             age: number;
@@ -71,7 +71,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_hb13699ae58ef = __cfHelpers.lift<{
     state: {
         user: {
             name: string;
@@ -100,7 +100,7 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_3 = __cfHelpers.lift<{
+const __cfLift_hf8eb9f36e610 = __cfHelpers.lift<{
     state: {
         user: {
             profile: {
@@ -137,7 +137,7 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_4 = __cfHelpers.lift<{
+const __cfLift_h18bda725b619 = __cfHelpers.lift<{
     state: {
         items: string[];
         index: number;
@@ -165,7 +165,7 @@ const __cfLift_4 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["string", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_5 = __cfHelpers.lift<{
+const __cfLift_he8e8823883f4 = __cfHelpers.lift<{
     state: {
         items: string[];
     };
@@ -189,7 +189,7 @@ const __cfLift_5 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["string", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_6 = __cfHelpers.lift<{
+const __cfLift_h1f8a7cf17de9 = __cfHelpers.lift<{
     state: {
         numbers: number[];
         index: number;
@@ -217,7 +217,7 @@ const __cfLift_6 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["number", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_7 = __cfHelpers.lift<{
+const __cfLift_hf77db0ecd45b = __cfHelpers.lift<{
     state: {
         config: {
             theme: {
@@ -254,7 +254,7 @@ const __cfLift_7 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_8 = __cfHelpers.lift<{
+const __cfLift_hb093995257fe = __cfHelpers.lift<{
     state: {
         user: {
             name: string;
@@ -295,7 +295,7 @@ const __cfLift_8 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_9 = __cfHelpers.lift<{
+const __cfLift_h7d60d3cae9dd = __cfHelpers.lift<{
     state: {
         config: {
             theme: {
@@ -372,13 +372,13 @@ export default pattern((state) => {
         </p>
 
         <h3>Property Access with Operations</h3>
-        <p>Age + 1: {__cfLift_1({ state: {
+        <p>Age + 1: {__cfLift_hac88b0f3cc94({ state: {
                 user: {
                     age: state.key("user", "age")
                 }
             } })}</p>
         <p>Name length: {state.key("user", "name", "length")}</p>
-        <p>Uppercase name: {__cfLift_2({ state: {
+        <p>Uppercase name: {__cfLift_hb13699ae58ef({ state: {
                 user: {
                     name: state.key("user", "name")
                 }
@@ -393,7 +393,7 @@ export default pattern((state) => {
             type: "string"
         } as const satisfies __cfHelpers.JSONSchema, {
             "enum": ["Yes", "No"]
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_3({ state: {
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_hf8eb9f36e610({ state: {
                 user: {
                     profile: {
                         location: state.key("user", "profile", "location")
@@ -403,15 +403,15 @@ export default pattern((state) => {
         </p>
 
         <h3>Array Element Access</h3>
-        <p>Item at index: {__cfLift_4({ state: {
+        <p>Item at index: {__cfLift_h18bda725b619({ state: {
                 items: state.key("items"),
                 index: state.key("index")
             } })}</p>
         <p>First item: {state.key("items", "0")}</p>
-        <p>Last item: {__cfLift_5({ state: {
+        <p>Last item: {__cfLift_he8e8823883f4({ state: {
                 items: state.key("items")
             } })}</p>
-        <p>Number at index: {__cfLift_6({ state: {
+        <p>Number at index: {__cfLift_h1f8a7cf17de9({ state: {
                 numbers: state.key("numbers"),
                 index: state.key("index")
             } })}</p>
@@ -419,7 +419,7 @@ export default pattern((state) => {
         <h3>Config Access with Styles</h3>
         <p style={{
             color: state.key("config", "theme", "primaryColor"),
-            fontSize: __cfLift_7({ state: {
+            fontSize: __cfLift_hf77db0ecd45b({ state: {
                     config: {
                         theme: {
                             fontSize: state.key("config", "theme", "fontSize")
@@ -445,7 +445,7 @@ export default pattern((state) => {
         </div>
 
         <h3>Complex Property Chains</h3>
-        <p>{__cfLift_8({ state: {
+        <p>{__cfLift_hb093995257fe({ state: {
                 user: {
                     name: state.key("user", "name"),
                     profile: {
@@ -453,7 +453,7 @@ export default pattern((state) => {
                     }
                 }
             } })}</p>
-        <p>Font size + 2: {__cfLift_9({ state: {
+        <p>Font size + 2: {__cfLift_h7d60d3cae9dd({ state: {
                 config: {
                     theme: {
                         fontSize: state.key("config", "theme", "fontSize")
@@ -614,13 +614,22 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2,
-    __cfLift_3,
-    __cfLift_4,
-    __cfLift_5,
-    __cfLift_6,
-    __cfLift_7,
-    __cfLift_8,
-    __cfLift_9
+    __cfLift_hac88b0f3cc94,
+    __cfLift_hb13699ae58ef,
+    __cfLift_hf8eb9f36e610,
+    __cfLift_h18bda725b619,
+    __cfLift_he8e8823883f4,
+    __cfLift_h1f8a7cf17de9,
+    __cfLift_hf77db0ecd45b,
+    __cfLift_hb093995257fe,
+    __cfLift_h7d60d3cae9dd,
+    __cfLift_1: __cfLift_hac88b0f3cc94,
+    __cfLift_2: __cfLift_hb13699ae58ef,
+    __cfLift_3: __cfLift_hf8eb9f36e610,
+    __cfLift_4: __cfLift_h18bda725b619,
+    __cfLift_5: __cfLift_he8e8823883f4,
+    __cfLift_6: __cfLift_h1f8a7cf17de9,
+    __cfLift_7: __cfLift_hf77db0ecd45b,
+    __cfLift_8: __cfLift_hb093995257fe,
+    __cfLift_9: __cfLift_h7d60d3cae9dd
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-string-operations.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-string-operations.expected.jsx
@@ -18,7 +18,7 @@ interface State {
     message: string;
     count: number;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hb5d66f421e31 = __cfHelpers.lift<{
     state: {
         title: string;
         firstName: string;
@@ -47,7 +47,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_h15e8e7a39b75 = __cfHelpers.lift<{
     state: {
         firstName: string;
         lastName: string;
@@ -72,7 +72,7 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_3 = __cfHelpers.lift<{
+const __cfLift_hab5f61386c04 = __cfHelpers.lift<{
     state: {
         firstName: string;
     };
@@ -93,7 +93,7 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_4 = __cfHelpers.lift<{
+const __cfLift_h386a71e909e3 = __cfHelpers.lift<{
     state: {
         firstName: string;
     };
@@ -114,7 +114,7 @@ const __cfLift_4 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_5 = __cfHelpers.lift<{
+const __cfLift_h25caee64b0f1 = __cfHelpers.lift<{
     state: {
         firstName: string;
         lastName: string;
@@ -139,7 +139,7 @@ const __cfLift_5 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_6 = __cfHelpers.lift<{
+const __cfLift_hb9a61a2da304 = __cfHelpers.lift<{
     state: {
         title: string;
         firstName: string;
@@ -168,7 +168,7 @@ const __cfLift_6 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_7 = __cfHelpers.lift<{
+const __cfLift_ha60c52f437d2 = __cfHelpers.lift<{
     state: {
         firstName: string;
     };
@@ -189,7 +189,7 @@ const __cfLift_7 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_8 = __cfHelpers.lift<{
+const __cfLift_hfebbbd81c011 = __cfHelpers.lift<{
     state: {
         title: string;
     };
@@ -210,7 +210,7 @@ const __cfLift_8 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_9 = __cfHelpers.lift<{
+const __cfLift_h2167e67dc3af = __cfHelpers.lift<{
     state: {
         message: string;
     };
@@ -231,7 +231,7 @@ const __cfLift_9 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_10 = __cfHelpers.lift<{
+const __cfLift_hb6c794b52f0b = __cfHelpers.lift<{
     state: {
         firstName: string;
         count: number;
@@ -256,7 +256,7 @@ const __cfLift_10 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_11 = __cfHelpers.lift<{
+const __cfLift_h1b1fd4031ba9 = __cfHelpers.lift<{
     state: {
         firstName: string;
         count: number;
@@ -281,7 +281,7 @@ const __cfLift_11 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_12 = __cfHelpers.lift<{
+const __cfLift_hc4c271035fc3 = __cfHelpers.lift<{
     state: {
         count: number;
     };
@@ -311,55 +311,55 @@ export default pattern((state) => {
     return {
         [UI]: (<div>
         <h3>String Concatenation</h3>
-        <h1>{__cfLift_1({ state: {
+        <h1>{__cfLift_hb5d66f421e31({ state: {
                 title: state.key("title"),
                 firstName: state.key("firstName"),
                 lastName: state.key("lastName")
             } })}</h1>
-        <p>{__cfLift_2({ state: {
+        <p>{__cfLift_h15e8e7a39b75({ state: {
                 firstName: state.key("firstName"),
                 lastName: state.key("lastName")
             } })}</p>
-        <p>{__cfLift_3({ state: {
+        <p>{__cfLift_hab5f61386c04({ state: {
                 firstName: state.key("firstName")
             } })}</p>
 
         <h3>Template Literals</h3>
-        <p>{__cfLift_4({ state: {
+        <p>{__cfLift_h386a71e909e3({ state: {
                 firstName: state.key("firstName")
             } })}</p>
-        <p>{__cfLift_5({ state: {
+        <p>{__cfLift_h25caee64b0f1({ state: {
                 firstName: state.key("firstName"),
                 lastName: state.key("lastName")
             } })}</p>
-        <p>{__cfLift_6({ state: {
+        <p>{__cfLift_hb9a61a2da304({ state: {
                 title: state.key("title"),
                 firstName: state.key("firstName"),
                 lastName: state.key("lastName")
             } })}</p>
 
         <h3>String Methods</h3>
-        <p>Uppercase: {__cfLift_7({ state: {
+        <p>Uppercase: {__cfLift_ha60c52f437d2({ state: {
                 firstName: state.key("firstName")
             } })}</p>
-        <p>Lowercase: {__cfLift_8({ state: {
+        <p>Lowercase: {__cfLift_hfebbbd81c011({ state: {
                 title: state.key("title")
             } })}</p>
         <p>Length: {state.key("message", "length")}</p>
-        <p>Substring: {__cfLift_9({ state: {
+        <p>Substring: {__cfLift_h2167e67dc3af({ state: {
                 message: state.key("message")
             } })}</p>
 
         <h3>Mixed String and Number</h3>
-        <p>{__cfLift_10({ state: {
+        <p>{__cfLift_hb6c794b52f0b({ state: {
                 firstName: state.key("firstName"),
                 count: state.key("count")
             } })}</p>
-        <p>{__cfLift_11({ state: {
+        <p>{__cfLift_h1b1fd4031ba9({ state: {
                 firstName: state.key("firstName"),
                 count: state.key("count")
             } })}</p>
-        <p>Count as string: {__cfLift_12({ state: {
+        <p>Count as string: {__cfLift_hc4c271035fc3({ state: {
                 count: state.key("count")
             } })}</p>
       </div>),
@@ -418,16 +418,28 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2,
-    __cfLift_3,
-    __cfLift_4,
-    __cfLift_5,
-    __cfLift_6,
-    __cfLift_7,
-    __cfLift_8,
-    __cfLift_9,
-    __cfLift_10,
-    __cfLift_11,
-    __cfLift_12
+    __cfLift_hb5d66f421e31,
+    __cfLift_h15e8e7a39b75,
+    __cfLift_hab5f61386c04,
+    __cfLift_h386a71e909e3,
+    __cfLift_h25caee64b0f1,
+    __cfLift_hb9a61a2da304,
+    __cfLift_ha60c52f437d2,
+    __cfLift_hfebbbd81c011,
+    __cfLift_h2167e67dc3af,
+    __cfLift_hb6c794b52f0b,
+    __cfLift_h1b1fd4031ba9,
+    __cfLift_hc4c271035fc3,
+    __cfLift_1: __cfLift_hb5d66f421e31,
+    __cfLift_2: __cfLift_h15e8e7a39b75,
+    __cfLift_3: __cfLift_hab5f61386c04,
+    __cfLift_4: __cfLift_h386a71e909e3,
+    __cfLift_5: __cfLift_h25caee64b0f1,
+    __cfLift_6: __cfLift_hb9a61a2da304,
+    __cfLift_7: __cfLift_ha60c52f437d2,
+    __cfLift_8: __cfLift_hfebbbd81c011,
+    __cfLift_9: __cfLift_h2167e67dc3af,
+    __cfLift_10: __cfLift_hb6c794b52f0b,
+    __cfLift_11: __cfLift_h1b1fd4031ba9,
+    __cfLift_12: __cfLift_hc4c271035fc3
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-wildcard-traversal-call-roots.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-wildcard-traversal-call-roots.expected.jsx
@@ -23,7 +23,7 @@ interface State {
         }
     ];
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h5e22b2ec64a3 = __cfHelpers.lift<{
     state: {
         wishes: [{ id: string; status: string; }, { id: string; status: string; }];
     };
@@ -56,7 +56,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_h26eaecab77c8 = __cfHelpers.lift<{
     state: {
         wishes: [{ id: string; status: string; }, { id: string; status: string; }];
     };
@@ -92,7 +92,7 @@ const __cfLift_2 = __cfHelpers.lift<{
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_3 = __cfHelpers.lift<{
+const __cfLift_ha0b1686d00f1 = __cfHelpers.lift<{
     state: {
         wishes: [{ id: string; status: string; }, { id: string; status: string; }];
     };
@@ -128,7 +128,7 @@ const __cfLift_3 = __cfHelpers.lift<{
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_4 = __cfHelpers.lift<{
+const __cfLift_h02687c7c0570 = __cfHelpers.lift<{
     state: {
         wishes: [{ id: string; status: string; }, { id: string; status: string; }];
     };
@@ -171,16 +171,16 @@ const __cfLift_4 = __cfHelpers.lift<{
 // Verifies: wildcard traversal calls lower as whole JSX call roots
 export default pattern((state) => ({
     [UI]: (<div>
-      <p>{__cfLift_1({ state: {
+      <p>{__cfLift_h5e22b2ec64a3({ state: {
             wishes: state.key("wishes")
         } })}</p>
-      <p>{__cfLift_2({ state: {
+      <p>{__cfLift_h26eaecab77c8({ state: {
             wishes: state.key("wishes")
         } })}</p>
-      <p>{__cfLift_3({ state: {
+      <p>{__cfLift_ha0b1686d00f1({ state: {
             wishes: state.key("wishes")
         } })}</p>
-      <p>{__cfLift_4({ state: {
+      <p>{__cfLift_h02687c7c0570({ state: {
             wishes: state.key("wishes")
         } })}</p>
     </div>),
@@ -238,8 +238,12 @@ export default pattern((state) => ({
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2,
-    __cfLift_3,
-    __cfLift_4
+    __cfLift_h5e22b2ec64a3,
+    __cfLift_h26eaecab77c8,
+    __cfLift_ha0b1686d00f1,
+    __cfLift_h02687c7c0570,
+    __cfLift_1: __cfLift_h5e22b2ec64a3,
+    __cfLift_2: __cfLift_h26eaecab77c8,
+    __cfLift_3: __cfLift_ha0b1686d00f1,
+    __cfLift_4: __cfLift_h02687c7c0570
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/logical-and-non-jsx.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/logical-and-non-jsx.expected.jsx
@@ -11,7 +11,7 @@ import { cell, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h3c7cdbd4b59e = __cfHelpers.lift<{
     user: __cfHelpers.Cell<{ name: string; age: number; }>;
 }, boolean>(({ user }) => user.get().name.length > 0, {
     type: "object",
@@ -31,7 +31,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_h5da851da8897 = __cfHelpers.lift<{
     user: __cfHelpers.Cell<{ name: string; age: number; }>;
 }, string>(({ user }) => `Hello, ${user.get().name}!`, {
     type: "object",
@@ -51,7 +51,7 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_3 = __cfHelpers.lift<{
+const __cfLift_h813665f2b200 = __cfHelpers.lift<{
     user: __cfHelpers.Cell<{ name: string; age: number; }>;
 }, boolean>(({ user }) => user.get().age > 18, {
     type: "object",
@@ -71,7 +71,7 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_4 = __cfHelpers.lift<{
+const __cfLift_h705bdbd2337e = __cfHelpers.lift<{
     user: __cfHelpers.Cell<{ name: string; age: number; }>;
 }, number>(({ user }) => user.get().age, {
     type: "object",
@@ -121,7 +121,7 @@ export default pattern((_state) => {
             type: "string"
         } as const satisfies __cfHelpers.JSONSchema, {
             type: ["boolean", "string"]
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_1({ user: user }), __cfLift_2({ user: user }))}</p>
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_h3c7cdbd4b59e({ user: user }), __cfLift_h5da851da8897({ user: user }))}</p>
 
         {/* Non-JSX right side: number expression */}
         <p>Age: {__cfHelpers.when({
@@ -130,7 +130,7 @@ export default pattern((_state) => {
             type: "number"
         } as const satisfies __cfHelpers.JSONSchema, {
             type: ["boolean", "number"]
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_3({ user: user }), __cfLift_4({ user: user }))}</p>
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_h813665f2b200({ user: user }), __cfLift_h705bdbd2337e({ user: user }))}</p>
       </div>),
     };
 }, false as const satisfies __cfHelpers.JSONSchema, {
@@ -167,8 +167,12 @@ export default pattern((_state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2,
-    __cfLift_3,
-    __cfLift_4
+    __cfLift_h3c7cdbd4b59e,
+    __cfLift_h5da851da8897,
+    __cfLift_h813665f2b200,
+    __cfLift_h705bdbd2337e,
+    __cfLift_1: __cfLift_h3c7cdbd4b59e,
+    __cfLift_2: __cfLift_h5da851da8897,
+    __cfLift_3: __cfLift_h813665f2b200,
+    __cfLift_4: __cfLift_h705bdbd2337e
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/logical-complex-expressions.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/logical-complex-expressions.expected.jsx
@@ -11,7 +11,7 @@ import { cell, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h284e66f4c6e0 = __cfHelpers.lift<{
     items: __cfHelpers.Cell<string[]>;
     isEnabled: __cfHelpers.Cell<boolean>;
 }, Readonly<boolean>>(({ items, isEnabled }) => items.get().length > 0 && isEnabled.get(), {
@@ -33,7 +33,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_hcafc955c989d = __cfHelpers.lift<{
     count: __cfHelpers.Cell<number>;
     items: __cfHelpers.Cell<string[]>;
 }, boolean>(({ count, items }) => (count.get() > 10 || items.get().length > 5), {
@@ -89,7 +89,7 @@ export default pattern((_state) => {
                     type: "object",
                     properties: {}
                 }]
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_1({
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_h284e66f4c6e0({
             items: items,
             isEnabled: isEnabled
         }), <div>Enabled with items</div>)}
@@ -109,7 +109,7 @@ export default pattern((_state) => {
                     type: "object",
                     properties: {}
                 }]
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_2({
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_hcafc955c989d({
             count: count,
             items: items
         }), <div>Threshold met</div>)}
@@ -149,6 +149,8 @@ export default pattern((_state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2
+    __cfLift_h284e66f4c6e0,
+    __cfLift_hcafc955c989d,
+    __cfLift_1: __cfLift_h284e66f4c6e0,
+    __cfLift_2: __cfLift_hcafc955c989d
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/logical-mixed-and-or.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/logical-mixed-and-or.expected.jsx
@@ -11,7 +11,7 @@ import { cell, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hefc277b5b8c3 = __cfHelpers.lift<{
     user: __cfHelpers.Cell<{ name: string; age: number; }>;
 }, string | false>(({ user }) => (user.get().name.length > 0 && user.get().name), {
     type: "object",
@@ -36,7 +36,7 @@ const __cfLift_1 = __cfHelpers.lift<{
             "enum": [false]
         }]
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_h4b4a158e7f60 = __cfHelpers.lift<{
     defaultMessage: __cfHelpers.Cell<string>;
 }, string>(({ defaultMessage }) => defaultMessage.get(), {
     type: "object",
@@ -50,7 +50,7 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_3 = __cfHelpers.lift<{
+const __cfLift_h813665f2b200 = __cfHelpers.lift<{
     user: __cfHelpers.Cell<{ name: string; age: number; }>;
 }, boolean>(({ user }) => user.get().age > 18, {
     type: "object",
@@ -70,7 +70,7 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_4 = __cfHelpers.lift<{
+const __cfLift_h4263b494dc38 = __cfHelpers.lift<{
     user: __cfHelpers.Cell<{ name: string; age: number; }>;
 }, string>(({ user }) => user.get().name, {
     type: "object",
@@ -90,7 +90,7 @@ const __cfLift_4 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_5 = __cfHelpers.lift<{
+const __cfLift_h334d0ef251d1 = __cfHelpers.lift<{
     user: __cfHelpers.Cell<{ name: string; age: number; }>;
 }, string | false>(({ user }) => (user.get().name.length > 0 && `Hello ${user.get().name}`) ||
     (user.get().age > 0 && `Age: ${user.get().age}`), {
@@ -154,7 +154,7 @@ export default pattern((_state) => {
             type: "string"
         } as const satisfies __cfHelpers.JSONSchema, {
             type: "string"
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_1({ user: user }), __cfLift_2({ defaultMessage: defaultMessage }))}</span>
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_hefc277b5b8c3({ user: user }), __cfLift_h4b4a158e7f60({ defaultMessage: defaultMessage }))}</span>
 
         {/* condition && (value || fallback) pattern */}
         <span>{__cfHelpers.when({
@@ -163,13 +163,13 @@ export default pattern((_state) => {
             type: "string"
         } as const satisfies __cfHelpers.JSONSchema, {
             type: ["boolean", "string"]
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_3({ user: user }), __cfHelpers.unless({
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_h813665f2b200({ user: user }), __cfHelpers.unless({
             type: "string"
         } as const satisfies __cfHelpers.JSONSchema, {
             type: "string"
         } as const satisfies __cfHelpers.JSONSchema, {
             type: "string"
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_4({ user: user }), "Anonymous Adult"))}</span>
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_h4263b494dc38({ user: user }), "Anonymous Adult"))}</span>
 
         {/* Complex: (a && b) || (c && d) */}
         <span>
@@ -179,7 +179,7 @@ export default pattern((_state) => {
             type: "string"
         } as const satisfies __cfHelpers.JSONSchema, {
             type: "string"
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_5({ user: user }), "Unknown user")}
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_h334d0ef251d1({ user: user }), "Unknown user")}
         </span>
       </div>),
     };
@@ -217,9 +217,14 @@ export default pattern((_state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2,
-    __cfLift_3,
-    __cfLift_4,
-    __cfLift_5
+    __cfLift_hefc277b5b8c3,
+    __cfLift_h4b4a158e7f60,
+    __cfLift_h813665f2b200,
+    __cfLift_h4263b494dc38,
+    __cfLift_h334d0ef251d1,
+    __cfLift_1: __cfLift_hefc277b5b8c3,
+    __cfLift_2: __cfLift_h4b4a158e7f60,
+    __cfLift_3: __cfLift_h813665f2b200,
+    __cfLift_4: __cfLift_h4263b494dc38,
+    __cfLift_5: __cfLift_h334d0ef251d1
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/logical-nullish-coalescing.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/logical-nullish-coalescing.expected.jsx
@@ -11,7 +11,7 @@ import { cell, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hb7301f4eead6 = __cfHelpers.lift<{
     config: __cfHelpers.Cell<{ timeout: number | null; retries: number | undefined; }>;
 }, number>(({ config }) => (config.get().timeout ?? 30), {
     type: "object",
@@ -35,7 +35,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_hf99436a4be1e = __cfHelpers.lift<{
     config: __cfHelpers.Cell<{ timeout: number | null; retries: number | undefined; }>;
 }, boolean>(({ config }) => (config.get().retries ?? 3) > 0, {
     type: "object",
@@ -54,7 +54,7 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_3 = __cfHelpers.lift<{
+const __cfLift_h612c9c5c807d = __cfHelpers.lift<{
     items: __cfHelpers.Cell<string[]>;
 }, string | false>(({ items }) => items.get().length > 0 && (items.get()[0] ?? "empty"), {
     type: "object",
@@ -121,7 +121,7 @@ export default pattern((_state) => {
             type: "string"
         } as const satisfies __cfHelpers.JSONSchema, {
             type: ["number", "string"]
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_1({ config: config }), "disabled")}</span>
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_hb7301f4eead6({ config: config }), "disabled")}</span>
 
         {/* ?? followed by && */}
         <span>{__cfHelpers.when({
@@ -130,7 +130,7 @@ export default pattern((_state) => {
             type: "string"
         } as const satisfies __cfHelpers.JSONSchema, {
             "enum": [false, "Will retry"]
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_2({ config: config }), "Will retry")}</span>
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_hf99436a4be1e({ config: config }), "Will retry")}</span>
 
         {/* Mixed: ?? with && and || */}
         <span>
@@ -140,7 +140,7 @@ export default pattern((_state) => {
             type: "string"
         } as const satisfies __cfHelpers.JSONSchema, {
             type: "string"
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_3({ items: items }), "no items")}
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_h612c9c5c807d({ items: items }), "no items")}
         </span>
       </div>),
     };
@@ -178,7 +178,10 @@ export default pattern((_state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2,
-    __cfLift_3
+    __cfLift_hb7301f4eead6,
+    __cfLift_hf99436a4be1e,
+    __cfLift_h612c9c5c807d,
+    __cfLift_1: __cfLift_hb7301f4eead6,
+    __cfLift_2: __cfLift_hf99436a4be1e,
+    __cfLift_3: __cfLift_h612c9c5c807d
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/logical-or-unless.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/logical-or-unless.expected.jsx
@@ -11,7 +11,7 @@ import { cell, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h6cc24f939f41 = __cfHelpers.lift<{
     items: __cfHelpers.Cell<string[]>;
 }, number>(({ items }) => items.get().length, {
     type: "object",
@@ -55,7 +55,7 @@ export default pattern((_state) => {
                     type: "object",
                     properties: {}
                 }]
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_1({ items: items }), <span>List is empty</span>)}
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_h6cc24f939f41({ items: items }), <span>List is empty</span>)}
       </div>),
     };
 }, false as const satisfies __cfHelpers.JSONSchema, {
@@ -92,5 +92,6 @@ export default pattern((_state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_h6cc24f939f41,
+    __cfLift_1: __cfLift_h6cc24f939f41
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/logical-triple-and-chain.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/logical-triple-and-chain.expected.jsx
@@ -11,7 +11,7 @@ import { cell, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hf4e7d1ab5fb4 = __cfHelpers.lift<{
     user: __cfHelpers.Cell<{ active: boolean; verified: boolean; name: string; }>;
 }, boolean>(({ user }) => user.get().active && user.get().verified, {
     type: "object",
@@ -34,7 +34,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_h7c79f9ddc33e = __cfHelpers.lift<{
     user: __cfHelpers.Cell<{ active: boolean; verified: boolean; name: string; }>;
 }, string>(({ user }) => user.get().name, {
     type: "object",
@@ -96,7 +96,7 @@ export default pattern((_state) => {
                     type: "object",
                     properties: {}
                 }]
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_1({ user: user }), <span>Welcome, {__cfLift_2({ user: user })}!</span>)}
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_hf4e7d1ab5fb4({ user: user }), <span>Welcome, {__cfLift_h7c79f9ddc33e({ user: user })}!</span>)}
       </div>),
     };
 }, false as const satisfies __cfHelpers.JSONSchema, {
@@ -133,6 +133,8 @@ export default pattern((_state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2
+    __cfLift_hf4e7d1ab5fb4,
+    __cfLift_h7c79f9ddc33e,
+    __cfLift_1: __cfLift_hf4e7d1ab5fb4,
+    __cfLift_2: __cfLift_h7c79f9ddc33e
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/logical-triple-or-chain.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/logical-triple-or-chain.expected.jsx
@@ -11,7 +11,7 @@ import { cell, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hd337c2a65e32 = __cfHelpers.lift<{
     primary: __cfHelpers.Cell<string>;
     secondary: __cfHelpers.Cell<string>;
 }, number>(({ primary, secondary }) => primary.get().length || secondary.get().length, {
@@ -30,7 +30,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_h18cb601b88ef = __cfHelpers.lift<{
     items: __cfHelpers.Cell<string[]>;
 }, number | undefined>(({ items }) => items.get()[0]?.length || items.get()[1]?.length, {
     type: "object",
@@ -74,7 +74,7 @@ export default pattern((_state) => {
             type: "string"
         } as const satisfies __cfHelpers.JSONSchema, {
             type: ["number", "string"]
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_1({
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_hd337c2a65e32({
             primary: primary,
             secondary: secondary
         }), "no content")}</span>
@@ -86,7 +86,7 @@ export default pattern((_state) => {
             type: "number"
         } as const satisfies __cfHelpers.JSONSchema, {
             type: "number"
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_2({ items: items }), 0)}</span>
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_h18cb601b88ef({ items: items }), 0)}</span>
       </div>),
     };
 }, false as const satisfies __cfHelpers.JSONSchema, {
@@ -123,6 +123,8 @@ export default pattern((_state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2
+    __cfLift_hd337c2a65e32,
+    __cfLift_h18cb601b88ef,
+    __cfLift_1: __cfLift_hd337c2a65e32,
+    __cfLift_2: __cfLift_h18cb601b88ef
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-array-length-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-array-length-conditional.expected.jsx
@@ -11,7 +11,7 @@ import { cell, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h66c4b91b886a = __cfHelpers.lift<{
     list: __cfHelpers.Cell<string[]>;
 }, boolean>(({ list }) => list.get().length > 0, {
     type: "object",
@@ -28,7 +28,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hd2753091aa55 = __cfHelpers.pattern(__cf_pattern_input => {
     const name = __cf_pattern_input.key("element");
     return (<span>{name}</span>);
 }, {
@@ -86,8 +86,8 @@ export default pattern((_state) => {
                     type: "object",
                     properties: {}
                 }]
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_1({ list: list }), <div>
-            {list.mapWithPattern(__cfPattern_1, {})}
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_h66c4b91b886a({ list: list }), <div>
+            {list.mapWithPattern(__cfPattern_hd2753091aa55, {})}
           </div>)}
       </div>),
     };
@@ -125,6 +125,8 @@ export default pattern((_state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfPattern_1
+    __cfLift_h66c4b91b886a,
+    __cfPattern_hd2753091aa55,
+    __cfLift_1: __cfLift_h66c4b91b886a,
+    __cfPattern_1: __cfPattern_hd2753091aa55
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-aliased-const-computation.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-aliased-const-computation.expected.jsx
@@ -28,7 +28,7 @@ interface Input {
 interface Output {
     [UI]: VNode;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hefcd2f624156 = __cfHelpers.lift<{
     kind: string;
 }, boolean>(({ kind }) => kind === "folder", {
     type: "object",
@@ -41,10 +41,10 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h305a224a01fa = __cfHelpers.pattern(__cf_pattern_input => {
     const file = __cf_pattern_input.key("element");
     const kind = file.key("type");
-    const isFolder = __cfLift_1({ kind: kind }).for("isFolder", true);
+    const isFolder = __cfLift_hefcd2f624156({ kind: kind }).for("isFolder", true);
     return <span>{__cfHelpers.ifElse({
         type: "boolean"
     } as const satisfies __cfHelpers.JSONSchema, {
@@ -101,7 +101,7 @@ export default pattern((__cf_pattern_input) => {
     const files = __cf_pattern_input.key("files");
     return {
         [UI]: (<div>
-        {files.mapWithPattern(__cfPattern_1, {})}
+        {files.mapWithPattern(__cfPattern_h305a224a01fa, {})}
       </div>),
     };
 }, {
@@ -144,6 +144,8 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfPattern_1
+    __cfLift_hefcd2f624156,
+    __cfPattern_h305a224a01fa,
+    __cfLift_1: __cfLift_hefcd2f624156,
+    __cfPattern_1: __cfPattern_h305a224a01fa
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-array-destructured-alias-computation.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-array-destructured-alias-computation.expected.jsx
@@ -31,7 +31,7 @@ interface Input {
 interface Output {
     [UI]: VNode;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hefcd2f624156 = __cfHelpers.lift<{
     kind: string;
 }, boolean>(({ kind }) => kind === "folder", {
     type: "object",
@@ -44,10 +44,10 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h6fd00dccaaaa = __cfHelpers.pattern(__cf_pattern_input => {
     const file = __cf_pattern_input.key("element");
     const __cf_destructure_1 = file.key("tags"), kind = __cf_destructure_1.key("0");
-    const isFolder = __cfLift_1({ kind: kind }).for("isFolder", true);
+    const isFolder = __cfLift_hefcd2f624156({ kind: kind }).for("isFolder", true);
     return <span>{__cfHelpers.ifElse({
         type: "boolean"
     } as const satisfies __cfHelpers.JSONSchema, {
@@ -107,7 +107,7 @@ export default pattern((__cf_pattern_input) => {
     const files = __cf_pattern_input.key("files");
     return {
         [UI]: (<div>
-        {files.mapWithPattern(__cfPattern_1, {})}
+        {files.mapWithPattern(__cfPattern_h6fd00dccaaaa, {})}
       </div>),
     };
 }, {
@@ -153,6 +153,8 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfPattern_1
+    __cfLift_hefcd2f624156,
+    __cfPattern_h6fd00dccaaaa,
+    __cfLift_1: __cfLift_hefcd2f624156,
+    __cfPattern_1: __cfPattern_h6fd00dccaaaa
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-direct-alias.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-direct-alias.expected.jsx
@@ -29,7 +29,7 @@ interface Input {
 interface Output {
     [UI]: VNode;
 }
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h16ad5e108a52 = __cfHelpers.pattern(__cf_pattern_input => {
     const file = __cf_pattern_input.key("element");
     const kind = file.key("type");
     return <span>{kind}</span>;
@@ -80,7 +80,7 @@ export default pattern((__cf_pattern_input) => {
     const files = __cf_pattern_input.key("files");
     return {
         [UI]: (<div>
-        {files.mapWithPattern(__cfPattern_1, {})}
+        {files.mapWithPattern(__cfPattern_h16ad5e108a52, {})}
       </div>),
     };
 }, {
@@ -123,5 +123,6 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfPattern_1
+    __cfPattern_h16ad5e108a52,
+    __cfPattern_1: __cfPattern_h16ad5e108a52
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-element-property-helper-comparison.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-element-property-helper-comparison.expected.jsx
@@ -35,7 +35,7 @@ interface Output {
     [UI]: VNode;
 }
 const senderName = __cfHardenFn((name?: string) => name?.trim() || "Anonymous");
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h902b97e3e367 = __cfHelpers.lift<{
     selectedRoom: __cfHelpers.ReadonlyCell<Default<{
         messages: Message[];
     }, {
@@ -97,7 +97,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_h3d5fbc953a9b = __cfHelpers.lift<{
     message: {
         author: string;
     };
@@ -124,7 +124,7 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_3 = __cfHelpers.lift<{
+const __cfLift_hdab7585059f5 = __cfHelpers.lift<{
     message: {
         author: string;
     };
@@ -145,16 +145,16 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h3e608b30d351 = __cfHelpers.pattern(__cf_pattern_input => {
     const message = __cf_pattern_input.key("element");
     const name = __cf_pattern_input.key("params", "name");
-    const isMine = __cfLift_2({
+    const isMine = __cfLift_h3d5fbc953a9b({
         message: {
             author: message.key("author")
         },
         name: name
     }).for("isMine", true);
-    const isKnownAuthor = __cfLift_3({ message: {
+    const isKnownAuthor = __cfLift_hdab7585059f5({ message: {
             author: message.key("author")
         } }).for("isKnownAuthor", true);
     return (<div data-author-kind={__cfHelpers.ifElse({
@@ -236,7 +236,7 @@ export default pattern((__cf_pattern_input) => {
     const selectedRoom = __cf_pattern_input.key("selectedRoom");
     return {
         [UI]: (<div>
-        {__cfLift_1({ selectedRoom: selectedRoom }).mapWithPattern(__cfPattern_1, {
+        {__cfLift_h902b97e3e367({ selectedRoom: selectedRoom }).mapWithPattern(__cfPattern_h3e608b30d351, {
             name: name
         })}
       </div>),
@@ -294,8 +294,12 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2,
-    __cfLift_3,
-    __cfPattern_1
+    __cfLift_h902b97e3e367,
+    __cfLift_h3d5fbc953a9b,
+    __cfLift_hdab7585059f5,
+    __cfPattern_h3e608b30d351,
+    __cfLift_1: __cfLift_h902b97e3e367,
+    __cfLift_2: __cfLift_h3d5fbc953a9b,
+    __cfLift_3: __cfLift_hdab7585059f5,
+    __cfPattern_1: __cfPattern_h3e608b30d351
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-expression-statement.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-expression-statement.expected.jsx
@@ -29,7 +29,7 @@ interface Input {
 interface Output {
     [UI]: VNode;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h7edd79c9f7d5 = __cfHelpers.lift<{
     file: {
         name: string;
         type: string;
@@ -54,9 +54,9 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     asCell: ["opaque"]
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h94959f643484 = __cfHelpers.pattern(__cf_pattern_input => {
     const file = __cf_pattern_input.key("element");
-    __cfLift_1({ file: {
+    __cfLift_h7edd79c9f7d5({ file: {
             name: file.key("name"),
             type: file.key("type")
         } });
@@ -108,7 +108,7 @@ export default pattern((__cf_pattern_input) => {
     const files = __cf_pattern_input.key("files");
     return {
         [UI]: (<div>
-        {files.mapWithPattern(__cfPattern_1, {})}
+        {files.mapWithPattern(__cfPattern_h94959f643484, {})}
       </div>),
     };
 }, {
@@ -151,6 +151,8 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfPattern_1
+    __cfLift_h7edd79c9f7d5,
+    __cfPattern_h94959f643484,
+    __cfLift_1: __cfLift_h7edd79c9f7d5,
+    __cfPattern_1: __cfPattern_h94959f643484
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-helper-call-over-alias.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-helper-call-over-alias.expected.jsx
@@ -29,7 +29,7 @@ interface Output {
     [UI]: VNode;
 }
 const describeKind = __cfHardenFn((kind: "file" | "folder"): string => kind === "folder" ? "dir" : "doc");
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_ha40a77bcb51e = __cfHelpers.lift<{
     kind: string;
 }, string>(({ kind }) => describeKind(kind), {
     type: "object",
@@ -42,10 +42,10 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hafa35a142340 = __cfHelpers.pattern(__cf_pattern_input => {
     const file = __cf_pattern_input.key("element");
     const kind = file.key("type");
-    const label = __cfLift_1({ kind: kind }).for("label", true);
+    const label = __cfLift_ha40a77bcb51e({ kind: kind }).for("label", true);
     return <span>{label}</span>;
 }, {
     type: "object",
@@ -94,7 +94,7 @@ export default pattern((__cf_pattern_input) => {
     const files = __cf_pattern_input.key("files");
     return {
         [UI]: (<div>
-        {files.mapWithPattern(__cfPattern_1, {})}
+        {files.mapWithPattern(__cfPattern_hafa35a142340, {})}
       </div>),
     };
 }, {
@@ -137,6 +137,8 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfPattern_1
+    __cfLift_ha40a77bcb51e,
+    __cfPattern_hafa35a142340,
+    __cfLift_1: __cfLift_ha40a77bcb51e,
+    __cfPattern_1: __cfPattern_hafa35a142340
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-local-consts.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-local-consts.expected.jsx
@@ -29,7 +29,7 @@ interface Input {
 interface Output {
     [UI]: VNode;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h9d9f829bb403 = __cfHelpers.lift<{
     file: {
         type: string;
     };
@@ -50,7 +50,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_hbaf04710eb97 = __cfHelpers.lift<{
     file: {
         contentType: string;
     };
@@ -71,9 +71,9 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hfd0e1ffaf712 = __cfHelpers.pattern(__cf_pattern_input => {
     const file = __cf_pattern_input.key("element");
-    const isFolder = __cfLift_1({ file: {
+    const isFolder = __cfLift_h9d9f829bb403({ file: {
             type: file.key("type")
         } }).for("isFolder", true);
     const isOpenable = __cfHelpers.unless({
@@ -82,7 +82,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         type: "boolean"
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "boolean"
-    } as const satisfies __cfHelpers.JSONSchema, isFolder, __cfLift_2({ file: {
+    } as const satisfies __cfHelpers.JSONSchema, isFolder, __cfLift_hbaf04710eb97({ file: {
             contentType: file.key("contentType")
         } }).for(["isOpenable", 4], true)).for("isOpenable", true);
     return <span>{__cfHelpers.ifElse({
@@ -144,7 +144,7 @@ export default pattern((__cf_pattern_input) => {
     const files = __cf_pattern_input.key("files");
     return {
         [UI]: (<div>
-        {files.mapWithPattern(__cfPattern_1, {})}
+        {files.mapWithPattern(__cfPattern_hfd0e1ffaf712, {})}
       </div>),
     };
 }, {
@@ -190,7 +190,10 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2,
-    __cfPattern_1
+    __cfLift_h9d9f829bb403,
+    __cfLift_hbaf04710eb97,
+    __cfPattern_hfd0e1ffaf712,
+    __cfLift_1: __cfLift_h9d9f829bb403,
+    __cfLift_2: __cfLift_hbaf04710eb97,
+    __cfPattern_1: __cfPattern_hfd0e1ffaf712
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-object-aggregate-alias-computation.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-object-aggregate-alias-computation.expected.jsx
@@ -28,7 +28,7 @@ interface Input {
 interface Output {
     [UI]: VNode;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h4c78e6e15064 = __cfHelpers.lift<{
     meta: {
         kind: string;
     };
@@ -49,10 +49,10 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h2c300a803ab3 = __cfHelpers.pattern(__cf_pattern_input => {
     const file = __cf_pattern_input.key("element");
     const meta = { kind: file.key("type") };
-    const isFolder = __cfLift_1({ meta: {
+    const isFolder = __cfLift_h4c78e6e15064({ meta: {
             kind: meta.kind
         } }).for("isFolder", true);
     return <span>{__cfHelpers.ifElse({
@@ -111,7 +111,7 @@ export default pattern((__cf_pattern_input) => {
     const files = __cf_pattern_input.key("files");
     return {
         [UI]: (<div>
-        {files.mapWithPattern(__cfPattern_1, {})}
+        {files.mapWithPattern(__cfPattern_h2c300a803ab3, {})}
       </div>),
     };
 }, {
@@ -154,6 +154,8 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfPattern_1
+    __cfLift_h4c78e6e15064,
+    __cfPattern_h2c300a803ab3,
+    __cfLift_1: __cfLift_h4c78e6e15064,
+    __cfPattern_1: __cfPattern_h2c300a803ab3
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-object-aggregate-plain-sibling-computation.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-object-aggregate-plain-sibling-computation.expected.jsx
@@ -28,7 +28,7 @@ interface Input {
 interface Output {
     [UI]: VNode;
 }
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hb4bf6788dc37 = __cfHelpers.pattern(__cf_pattern_input => {
     const file = __cf_pattern_input.key("element");
     const meta = { kind: file.key("type"), label: "plain" };
     const shout = meta.label + "!";
@@ -80,7 +80,7 @@ export default pattern((__cf_pattern_input) => {
     const files = __cf_pattern_input.key("files");
     return {
         [UI]: (<div>
-        {files.mapWithPattern(__cfPattern_1, {})}
+        {files.mapWithPattern(__cfPattern_hb4bf6788dc37, {})}
       </div>),
     };
 }, {
@@ -123,5 +123,6 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfPattern_1
+    __cfPattern_hb4bf6788dc37,
+    __cfPattern_1: __cfPattern_hb4bf6788dc37
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-object-destructured-alias-computation.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-object-destructured-alias-computation.expected.jsx
@@ -28,7 +28,7 @@ interface Input {
 interface Output {
     [UI]: VNode;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hefcd2f624156 = __cfHelpers.lift<{
     kind: string;
 }, boolean>(({ kind }) => kind === "folder", {
     type: "object",
@@ -41,10 +41,10 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h305a224a01fa = __cfHelpers.pattern(__cf_pattern_input => {
     const file = __cf_pattern_input.key("element");
     const kind = file.key("type");
-    const isFolder = __cfLift_1({ kind: kind }).for("isFolder", true);
+    const isFolder = __cfLift_hefcd2f624156({ kind: kind }).for("isFolder", true);
     return <span>{__cfHelpers.ifElse({
         type: "boolean"
     } as const satisfies __cfHelpers.JSONSchema, {
@@ -101,7 +101,7 @@ export default pattern((__cf_pattern_input) => {
     const files = __cf_pattern_input.key("files");
     return {
         [UI]: (<div>
-        {files.mapWithPattern(__cfPattern_1, {})}
+        {files.mapWithPattern(__cfPattern_h305a224a01fa, {})}
       </div>),
     };
 }, {
@@ -144,6 +144,8 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfPattern_1
+    __cfLift_hefcd2f624156,
+    __cfPattern_h305a224a01fa,
+    __cfLift_1: __cfLift_hefcd2f624156,
+    __cfPattern_1: __cfPattern_h305a224a01fa
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-tuple-aggregate-alias-computation.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-tuple-aggregate-alias-computation.expected.jsx
@@ -28,7 +28,7 @@ interface Input {
 interface Output {
     [UI]: VNode;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h8e5d5956c2b9 = __cfHelpers.lift<{
     info: readonly ["file" | "folder", string];
 }, boolean>(({ info }) => info[0] === "folder", {
     type: "object",
@@ -44,10 +44,10 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hbc994e1522ed = __cfHelpers.pattern(__cf_pattern_input => {
     const file = __cf_pattern_input.key("element");
     const info = [file.key("type"), file.key("name")] as const;
-    const isFolder = __cfLift_1({ info: info }).for("isFolder", true);
+    const isFolder = __cfLift_h8e5d5956c2b9({ info: info }).for("isFolder", true);
     return <span>{__cfHelpers.ifElse({
         type: "boolean"
     } as const satisfies __cfHelpers.JSONSchema, {
@@ -104,7 +104,7 @@ export default pattern((__cf_pattern_input) => {
     const files = __cf_pattern_input.key("files");
     return {
         [UI]: (<div>
-        {files.mapWithPattern(__cfPattern_1, {})}
+        {files.mapWithPattern(__cfPattern_hbc994e1522ed, {})}
       </div>),
     };
 }, {
@@ -147,6 +147,8 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfPattern_1
+    __cfLift_h8e5d5956c2b9,
+    __cfPattern_hbc994e1522ed,
+    __cfLift_1: __cfLift_h8e5d5956c2b9,
+    __cfPattern_1: __cfPattern_hbc994e1522ed
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-nested-conditional-no-name.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-nested-conditional-no-name.expected.jsx
@@ -11,7 +11,7 @@ import { cell, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h72e9809a4df5 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return (<div>
                 {__cfHelpers.when({
@@ -101,7 +101,7 @@ export default pattern((_state: any) => {
                     properties: {}
                 }]
         } as const satisfies __cfHelpers.JSONSchema, showList, <div>
-            {items.mapWithPattern(__cfPattern_1, {})}
+            {items.mapWithPattern(__cfPattern_h72e9809a4df5, {})}
           </div>)}
       </div>),
     };
@@ -139,5 +139,6 @@ export default pattern((_state: any) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfPattern_1
+    __cfPattern_h72e9809a4df5,
+    __cfPattern_1: __cfPattern_h72e9809a4df5
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-nested-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-nested-conditional.expected.jsx
@@ -11,7 +11,7 @@ import { cell, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h72e9809a4df5 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return (<div>
                 {__cfHelpers.when({
@@ -101,7 +101,7 @@ export default pattern((_state) => {
                     properties: {}
                 }]
         } as const satisfies __cfHelpers.JSONSchema, showList, <div>
-            {items.mapWithPattern(__cfPattern_1, {})}
+            {items.mapWithPattern(__cfPattern_h72e9809a4df5, {})}
           </div>)}
       </div>),
     };
@@ -139,5 +139,6 @@ export default pattern((_state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfPattern_1
+    __cfPattern_h72e9809a4df5,
+    __cfPattern_1: __cfPattern_h72e9809a4df5
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-row-ternary-computed-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-row-ternary-computed-capture.expected.jsx
@@ -20,7 +20,7 @@ interface LinksState {
     ]>;
     myName: Default<string, "">;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h578766f76305 = __cfHelpers.lift<{
     myName: Default<string, "">;
 }, string>(({ myName }) => myName.trim(), {
     type: "object",
@@ -34,7 +34,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_h44217494a20f = __cfHelpers.lift<{
     entry: {
         name: string;
     };
@@ -59,7 +59,7 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h693560d5b14a = __cfHelpers.pattern(__cf_pattern_input => {
     const entry = __cf_pattern_input.key("element");
     const me = __cf_pattern_input.key("params", "me");
     return (__cfHelpers.ifElse({
@@ -78,7 +78,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
                 type: "object",
                 properties: {}
             }]
-    } as const satisfies __cfHelpers.JSONSchema, __cfLift_2({
+    } as const satisfies __cfHelpers.JSONSchema, __cfLift_h44217494a20f({
         entry: {
             name: entry.key("name")
         },
@@ -150,10 +150,10 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 export default pattern((__cf_pattern_input) => {
     const links = __cf_pattern_input.key("links");
     const myName = __cf_pattern_input.key("myName");
-    const me = __cfLift_1({ myName: myName }).for("me", true);
+    const me = __cfLift_h578766f76305({ myName: myName }).for("me", true);
     return {
         [UI]: (<div>
-        {links.mapWithPattern(__cfPattern_1, {
+        {links.mapWithPattern(__cfPattern_h693560d5b14a, {
                 me: me
             })}
       </div>),
@@ -222,7 +222,10 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2,
-    __cfPattern_1
+    __cfLift_h578766f76305,
+    __cfLift_h44217494a20f,
+    __cfPattern_h693560d5b14a,
+    __cfLift_1: __cfLift_h578766f76305,
+    __cfLift_2: __cfLift_h44217494a20f,
+    __cfPattern_1: __cfPattern_h693560d5b14a
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-single-capture-no-name.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-single-capture-no-name.expected.jsx
@@ -11,7 +11,7 @@ import { cell, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hc6f7d7e5f267 = __cfHelpers.lift<{
     people: __cfHelpers.Cell<{ id: string; name: string; }[]>;
 }, boolean>(({ people }) => people.get().length > 0, {
     type: "object",
@@ -28,7 +28,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hfc461082958c = __cfHelpers.pattern(__cf_pattern_input => {
     const person = __cf_pattern_input.key("element");
     const index = __cf_pattern_input.key("index");
     return (<li key={index}>{person.key("name")}</li>);
@@ -109,8 +109,8 @@ export default pattern((_state: any) => {
                     type: "object",
                     properties: {}
                 }]
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_1({ people: people }), <ul>
-            {people.mapWithPattern(__cfPattern_1, {})}
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_hc6f7d7e5f267({ people: people }), <ul>
+            {people.mapWithPattern(__cfPattern_hfc461082958c, {})}
           </ul>)}
       </div>),
     };
@@ -148,6 +148,8 @@ export default pattern((_state: any) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfPattern_1
+    __cfLift_hc6f7d7e5f267,
+    __cfPattern_hfc461082958c,
+    __cfLift_1: __cfLift_hc6f7d7e5f267,
+    __cfPattern_1: __cfPattern_hfc461082958c
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-single-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-single-capture.expected.jsx
@@ -11,7 +11,7 @@ import { cell, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hc6f7d7e5f267 = __cfHelpers.lift<{
     people: __cfHelpers.Cell<{ id: string; name: string; }[]>;
 }, boolean>(({ people }) => people.get().length > 0, {
     type: "object",
@@ -28,7 +28,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hfc461082958c = __cfHelpers.pattern(__cf_pattern_input => {
     const person = __cf_pattern_input.key("element");
     const index = __cf_pattern_input.key("index");
     return (<li key={index}>{person.key("name")}</li>);
@@ -109,8 +109,8 @@ export default pattern((_state) => {
                     type: "object",
                     properties: {}
                 }]
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_1({ people: people }), <ul>
-            {people.mapWithPattern(__cfPattern_1, {})}
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_hc6f7d7e5f267({ people: people }), <ul>
+            {people.mapWithPattern(__cfPattern_hfc461082958c, {})}
           </ul>)}
       </div>),
     };
@@ -148,6 +148,8 @@ export default pattern((_state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfPattern_1
+    __cfLift_hc6f7d7e5f267,
+    __cfPattern_hfc461082958c,
+    __cfLift_1: __cfLift_hc6f7d7e5f267,
+    __cfPattern_1: __cfPattern_hfc461082958c
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/method-chains.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/method-chains.expected.jsx
@@ -33,7 +33,7 @@ interface State {
     words: string[];
     separator: string;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h9081a474aad4 = __cfHelpers.lift<{
     state: {
         text: string;
     };
@@ -54,7 +54,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_h7896aef8ca05 = __cfHelpers.lift<{
     state: {
         text: string;
         searchTerm: string;
@@ -79,7 +79,7 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_3 = __cfHelpers.lift<{
+const __cfLift_hb6912d2577b2 = __cfHelpers.lift<{
     state: {
         text: string;
     };
@@ -100,7 +100,7 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_4 = __cfHelpers.lift<{
+const __cfLift_h2d7ef0946ff7 = __cfHelpers.lift<{
     state: {
         items: number[];
         threshold: number;
@@ -128,7 +128,7 @@ const __cfLift_4 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_5 = __cfHelpers.lift<{
+const __cfLift_h0cd385b3067d = __cfHelpers.lift<{
     x: number;
     state: {
         threshold: number;
@@ -153,10 +153,10 @@ const __cfLift_5 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h9107ac6a272b = __cfHelpers.pattern(__cf_pattern_input => {
     const x = __cf_pattern_input.key("element");
     const state = __cf_pattern_input.key("params", "state");
-    return __cfLift_5({
+    return __cfLift_h0cd385b3067d({
         x: x,
         state: {
             threshold: state.key("threshold")
@@ -188,7 +188,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_6 = __cfHelpers.lift<{
+const __cfLift_hbe5543f09e91 = __cfHelpers.lift<{
     x: number;
     state: {
         factor: number;
@@ -213,10 +213,10 @@ const __cfLift_6 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h04d76eaa28e8 = __cfHelpers.pattern(__cf_pattern_input => {
     const x = __cf_pattern_input.key("element");
     const state = __cf_pattern_input.key("params", "state");
-    return (<li>Value: {__cfLift_6({
+    return (<li>Value: {__cfLift_hbe5543f09e91({
         x: x,
         state: {
             factor: state.key("factor")
@@ -266,7 +266,7 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_7 = __cfHelpers.lift<{
+const __cfLift_h1d2655fb4465 = __cfHelpers.lift<{
     state: {
         items: number[];
         start: number;
@@ -298,7 +298,7 @@ const __cfLift_7 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_8 = __cfHelpers.lift<{
+const __cfLift_h14aff5984dc5 = __cfHelpers.lift<{
     state: {
         items: number[];
         start: number;
@@ -330,7 +330,7 @@ const __cfLift_8 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_9 = __cfHelpers.lift<{
+const __cfLift_h871b40cef8a2 = __cfHelpers.lift<{
     state: {
         names: string[];
         prefix: string;
@@ -358,7 +358,7 @@ const __cfLift_9 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_10 = __cfHelpers.lift<{
+const __cfLift_hf34b0d1503fb = __cfHelpers.lift<{
     state: {
         names: string[];
         searchTerm: string;
@@ -386,7 +386,7 @@ const __cfLift_10 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["string", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_11 = __cfHelpers.lift<{
+const __cfLift_h4986244d6780 = __cfHelpers.lift<{
     name: string;
 }, string>(({ name }) => name.trim().toLowerCase().replace(" ", "-"), {
     type: "object",
@@ -399,9 +399,9 @@ const __cfLift_11 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h549de416cfc5 = __cfHelpers.pattern(__cf_pattern_input => {
     const name = __cf_pattern_input.key("element");
-    return (<li>{__cfLift_11({ name: name })}</li>);
+    return (<li>{__cfLift_h4986244d6780({ name: name })}</li>);
 }, {
     type: "object",
     properties: {
@@ -431,7 +431,7 @@ const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_12 = __cfHelpers.lift<{
+const __cfLift_hc866279bad4e = __cfHelpers.lift<{
     state: {
         prices: number[];
         discount: number;
@@ -459,7 +459,7 @@ const __cfLift_12 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_13 = __cfHelpers.lift<{
+const __cfLift_h9ba75e82a891 = __cfHelpers.lift<{
     state: {
         items: number[];
         factor: number;
@@ -488,7 +488,7 @@ const __cfLift_13 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_14 = __cfHelpers.lift<{
+const __cfLift_hbcd3098f4f0f = __cfHelpers.lift<{
     state: {
         prices: number[];
         discount: number;
@@ -516,7 +516,7 @@ const __cfLift_14 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_15 = __cfHelpers.lift<{
+const __cfLift_h67e5639d1c3a = __cfHelpers.lift<{
     state: {
         text: string;
         prefix: string;
@@ -541,7 +541,7 @@ const __cfLift_15 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_16 = __cfHelpers.lift<{
+const __cfLift_hab2ab062f23d = __cfHelpers.lift<{
     state: {
         text: string;
         prefix: string;
@@ -567,7 +567,7 @@ const __cfLift_16 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_17 = __cfHelpers.lift<{
+const __cfLift_h2e85ccda6ac5 = __cfHelpers.lift<{
     state: {
         users: { name: string; age: number; active: boolean; }[];
         minAge: number;
@@ -604,7 +604,7 @@ const __cfLift_17 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_18 = __cfHelpers.lift<{
+const __cfLift_hf623a67f2f2a = __cfHelpers.lift<{
     u: {
         name: string;
     };
@@ -625,7 +625,7 @@ const __cfLift_18 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_19 = __cfHelpers.lift<{
+const __cfLift_hfa7da76579e9 = __cfHelpers.lift<{
     u: {
         name: string;
     };
@@ -646,7 +646,7 @@ const __cfLift_19 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_4 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h5c631ca7072d = __cfHelpers.pattern(__cf_pattern_input => {
     const u = __cf_pattern_input.key("element");
     return (<li>{__cfHelpers.ifElse({
         type: "boolean"
@@ -656,9 +656,9 @@ const __cfPattern_4 = __cfHelpers.pattern(__cf_pattern_input => {
         type: "string"
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "string"
-    } as const satisfies __cfHelpers.JSONSchema, u.key("active"), __cfLift_18({ u: {
+    } as const satisfies __cfHelpers.JSONSchema, u.key("active"), __cfLift_hf623a67f2f2a({ u: {
             name: u.key("name")
-        } }), __cfLift_19({ u: {
+        } }), __cfLift_hfa7da76579e9({ u: {
             name: u.key("name")
         } }))}</li>);
 }, {
@@ -702,7 +702,7 @@ const __cfPattern_4 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_20 = __cfHelpers.lift<{
+const __cfLift_h8c8befaf28ff = __cfHelpers.lift<{
     state: {
         users: { name: string; age: number; active: boolean; }[];
         minAge: number;
@@ -736,7 +736,7 @@ const __cfLift_20 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_21 = __cfHelpers.lift<{
+const __cfLift_h52dd955df9f1 = __cfHelpers.lift<{
     state: {
         users: { name: string; age: number; active: boolean; }[];
     };
@@ -766,7 +766,7 @@ const __cfLift_21 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_22 = __cfHelpers.lift<{
+const __cfLift_hd48812c2edec = __cfHelpers.lift<{
     state: {
         text: string;
         prefix: string;
@@ -791,7 +791,7 @@ const __cfLift_22 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_23 = __cfHelpers.lift<{
+const __cfLift_h8cec59f2be0f = __cfHelpers.lift<{
     state: {
         text: string;
         threshold: number;
@@ -816,7 +816,7 @@ const __cfLift_23 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_24 = __cfHelpers.lift<{
+const __cfLift_he375e7e47c26 = __cfHelpers.lift<{
     state: {
         words: string[];
         separator: string;
@@ -855,14 +855,14 @@ export default pattern((state) => {
         [UI]: (<div>
         <h3>Chained String Methods</h3>
         {/* Simple chain */}
-        <p>Trimmed lower: {__cfLift_1({ state: {
+        <p>Trimmed lower: {__cfLift_h9081a474aad4({ state: {
                 text: state.key("text")
             } })}</p>
 
         {/* Chain with reactive argument */}
         <p>
           Contains search:{" "}
-          {__cfLift_2({ state: {
+          {__cfLift_h7896aef8ca05({ state: {
                 text: state.key("text"),
                 searchTerm: state.key("searchTerm")
             } })}
@@ -871,7 +871,7 @@ export default pattern((state) => {
         {/* Longer chain */}
         <p>
           Processed:{" "}
-          {__cfLift_3({ state: {
+          {__cfLift_hb6912d2577b2({ state: {
                 text: state.key("text")
             } })}
         </p>
@@ -880,7 +880,7 @@ export default pattern((state) => {
         {/* Filter then length */}
         <p>
           Count above threshold:{" "}
-          {__cfLift_4({ state: {
+          {__cfLift_h2d7ef0946ff7({ state: {
                 items: state.key("items"),
                 threshold: state.key("threshold")
             } })}
@@ -888,11 +888,11 @@ export default pattern((state) => {
 
         {/* Filter then map */}
         <ul>
-          {state.key("items").filterWithPattern(__cfPattern_1, {
+          {state.key("items").filterWithPattern(__cfPattern_h9107ac6a272b, {
                 state: {
                     threshold: state.key("threshold")
                 }
-            }).mapWithPattern(__cfPattern_2, {
+            }).mapWithPattern(__cfPattern_h04d76eaa28e8, {
                 state: {
                     factor: state.key("factor")
                 }
@@ -902,7 +902,7 @@ export default pattern((state) => {
         {/* Multiple filters */}
         <p>
           Double filter count:{" "}
-          {__cfLift_7({ state: {
+          {__cfLift_h1d2655fb4465({ state: {
                 items: state.key("items"),
                 start: state.key("start"),
                 end: state.key("end")
@@ -912,7 +912,7 @@ export default pattern((state) => {
         <h3>Methods with Reactive Arguments</h3>
         {/* Slice with reactive indices */}
         <p>
-          Sliced items: {__cfLift_8({ state: {
+          Sliced items: {__cfLift_h14aff5984dc5({ state: {
                 items: state.key("items"),
                 start: state.key("start"),
                 end: state.key("end")
@@ -922,7 +922,7 @@ export default pattern((state) => {
         {/* String methods with reactive args */}
         <p>
           Starts with:{" "}
-          {__cfLift_9({ state: {
+          {__cfLift_h871b40cef8a2({ state: {
                 names: state.key("names"),
                 prefix: state.key("prefix")
             } })}
@@ -930,7 +930,7 @@ export default pattern((state) => {
 
         {/* Array find with reactive predicate */}
         <p>
-          First match: {__cfLift_10({ state: {
+          First match: {__cfLift_hf34b0d1503fb({ state: {
                 names: state.key("names"),
                 searchTerm: state.key("searchTerm")
             } })}
@@ -939,12 +939,12 @@ export default pattern((state) => {
         <h3>Complex Method Combinations</h3>
         {/* Map with chained operations inside */}
         <ul>
-          {state.key("names").mapWithPattern(__cfPattern_3, {})}
+          {state.key("names").mapWithPattern(__cfPattern_h549de416cfc5, {})}
         </ul>
 
         {/* Reduce with reactive accumulator */}
         <p>
-          Total with discount: {__cfLift_12({ state: {
+          Total with discount: {__cfLift_hc866279bad4e({ state: {
                 prices: state.key("prices"),
                 discount: state.key("discount")
             } })}
@@ -953,7 +953,7 @@ export default pattern((state) => {
         {/* Method result used in computation */}
         <p>
           Average * factor:{" "}
-          {__cfLift_13({ state: {
+          {__cfLift_h9ba75e82a891({ state: {
                 items: state.key("items"),
                 factor: state.key("factor")
             } })}
@@ -962,7 +962,7 @@ export default pattern((state) => {
         <h3>Methods on Computed Values</h3>
         {/* Method on binary expression result */}
         <p>
-          Formatted price: {__cfLift_14({ state: {
+          Formatted price: {__cfLift_hbcd3098f4f0f({ state: {
                 prices: state.key("prices"),
                 discount: state.key("discount")
             } })}
@@ -971,7 +971,7 @@ export default pattern((state) => {
         {/* Method on conditional result */}
         <p>
           Conditional trim:{" "}
-          {__cfLift_15({ state: {
+          {__cfLift_h67e5639d1c3a({ state: {
                 text: state.key("text"),
                 prefix: state.key("prefix")
             } })}
@@ -980,7 +980,7 @@ export default pattern((state) => {
         {/* Method chain on computed value */}
         <p>
           Complex:{" "}
-          {__cfLift_16({ state: {
+          {__cfLift_hab2ab062f23d({ state: {
                 text: state.key("text"),
                 prefix: state.key("prefix")
             } })}
@@ -990,7 +990,7 @@ export default pattern((state) => {
         {/* Filter with multiple conditions */}
         <p>
           Active adults:{" "}
-          {__cfLift_17({ state: {
+          {__cfLift_h2e85ccda6ac5({ state: {
                 users: state.key("users"),
                 minAge: state.key("minAge")
             } })}
@@ -998,7 +998,7 @@ export default pattern((state) => {
 
         {/* Map with conditional logic */}
         <ul>
-          {state.key("users").mapWithPattern(__cfPattern_4, {})}
+          {state.key("users").mapWithPattern(__cfPattern_h5c631ca7072d, {})}
         </ul>
 
         {/* Some/every with reactive predicates */}
@@ -1012,7 +1012,7 @@ export default pattern((state) => {
             type: "string"
         } as const satisfies __cfHelpers.JSONSchema, {
             "enum": ["Yes", "No"]
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_20({ state: {
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_h8c8befaf28ff({ state: {
                 users: state.key("users"),
                 minAge: state.key("minAge")
             } }), "Yes", "No")}
@@ -1025,14 +1025,14 @@ export default pattern((state) => {
             type: "string"
         } as const satisfies __cfHelpers.JSONSchema, {
             "enum": ["Yes", "No"]
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_21({ state: {
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_h52dd955df9f1({ state: {
                 users: state.key("users")
             } }), "Yes", "No")}</p>
 
         <h3>Method Calls in Expressions</h3>
         {/* Method result in arithmetic */}
         <p>
-          Length sum: {__cfLift_22({ state: {
+          Length sum: {__cfLift_hd48812c2edec({ state: {
                 text: state.key("text"),
                 prefix: state.key("prefix")
             } })}
@@ -1048,14 +1048,14 @@ export default pattern((state) => {
             type: "string"
         } as const satisfies __cfHelpers.JSONSchema, {
             "enum": ["Yes", "No"]
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_23({ state: {
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_h8cec59f2be0f({ state: {
                 text: state.key("text"),
                 threshold: state.key("threshold")
             } }), "Yes", "No")}
         </p>
 
         {/* Multiple method results combined */}
-        <p>Joined: {__cfLift_24({ state: {
+        <p>Joined: {__cfLift_he375e7e47c26({ state: {
                 words: state.key("words"),
                 separator: state.key("separator")
             } })}</p>
@@ -1175,32 +1175,60 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2,
-    __cfLift_3,
-    __cfLift_4,
-    __cfLift_5,
-    __cfPattern_1,
-    __cfLift_6,
-    __cfPattern_2,
-    __cfLift_7,
-    __cfLift_8,
-    __cfLift_9,
-    __cfLift_10,
-    __cfLift_11,
-    __cfPattern_3,
-    __cfLift_12,
-    __cfLift_13,
-    __cfLift_14,
-    __cfLift_15,
-    __cfLift_16,
-    __cfLift_17,
-    __cfLift_18,
-    __cfLift_19,
-    __cfPattern_4,
-    __cfLift_20,
-    __cfLift_21,
-    __cfLift_22,
-    __cfLift_23,
-    __cfLift_24
+    __cfLift_h9081a474aad4,
+    __cfLift_h7896aef8ca05,
+    __cfLift_hb6912d2577b2,
+    __cfLift_h2d7ef0946ff7,
+    __cfLift_h0cd385b3067d,
+    __cfPattern_h9107ac6a272b,
+    __cfLift_hbe5543f09e91,
+    __cfPattern_h04d76eaa28e8,
+    __cfLift_h1d2655fb4465,
+    __cfLift_h14aff5984dc5,
+    __cfLift_h871b40cef8a2,
+    __cfLift_hf34b0d1503fb,
+    __cfLift_h4986244d6780,
+    __cfPattern_h549de416cfc5,
+    __cfLift_hc866279bad4e,
+    __cfLift_h9ba75e82a891,
+    __cfLift_hbcd3098f4f0f,
+    __cfLift_h67e5639d1c3a,
+    __cfLift_hab2ab062f23d,
+    __cfLift_h2e85ccda6ac5,
+    __cfLift_hf623a67f2f2a,
+    __cfLift_hfa7da76579e9,
+    __cfPattern_h5c631ca7072d,
+    __cfLift_h8c8befaf28ff,
+    __cfLift_h52dd955df9f1,
+    __cfLift_hd48812c2edec,
+    __cfLift_h8cec59f2be0f,
+    __cfLift_he375e7e47c26,
+    __cfLift_1: __cfLift_h9081a474aad4,
+    __cfLift_2: __cfLift_h7896aef8ca05,
+    __cfLift_3: __cfLift_hb6912d2577b2,
+    __cfLift_4: __cfLift_h2d7ef0946ff7,
+    __cfLift_5: __cfLift_h0cd385b3067d,
+    __cfPattern_1: __cfPattern_h9107ac6a272b,
+    __cfLift_6: __cfLift_hbe5543f09e91,
+    __cfPattern_2: __cfPattern_h04d76eaa28e8,
+    __cfLift_7: __cfLift_h1d2655fb4465,
+    __cfLift_8: __cfLift_h14aff5984dc5,
+    __cfLift_9: __cfLift_h871b40cef8a2,
+    __cfLift_10: __cfLift_hf34b0d1503fb,
+    __cfLift_11: __cfLift_h4986244d6780,
+    __cfPattern_3: __cfPattern_h549de416cfc5,
+    __cfLift_12: __cfLift_hc866279bad4e,
+    __cfLift_13: __cfLift_h9ba75e82a891,
+    __cfLift_14: __cfLift_hbcd3098f4f0f,
+    __cfLift_15: __cfLift_h67e5639d1c3a,
+    __cfLift_16: __cfLift_hab2ab062f23d,
+    __cfLift_17: __cfLift_h2e85ccda6ac5,
+    __cfLift_18: __cfLift_hf623a67f2f2a,
+    __cfLift_19: __cfLift_hfa7da76579e9,
+    __cfPattern_4: __cfPattern_h5c631ca7072d,
+    __cfLift_20: __cfLift_h8c8befaf28ff,
+    __cfLift_21: __cfLift_h52dd955df9f1,
+    __cfLift_22: __cfLift_hd48812c2edec,
+    __cfLift_23: __cfLift_h8cec59f2be0f,
+    __cfLift_24: __cfLift_he375e7e47c26
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/optional-chain-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/optional-chain-captures.expected.jsx
@@ -22,7 +22,7 @@ interface State {
     };
     items: Item[];
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_heb4680985495 = __cfHelpers.lift<{
     item: {
         maybe?: { value: number; } | undefined;
     };
@@ -48,9 +48,9 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_haeccc601a30f = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
-    return (<span>{__cfLift_1({ item: {
+    return (<span>{__cfLift_heb4680985495({ item: {
             maybe: item.key("maybe")
         } })}</span>);
 }, {
@@ -107,7 +107,7 @@ export default pattern((state) => {
     return {
         [UI]: (<div>
         <span>{state.key("maybe", "value")}</span>
-        {state.key("items").mapWithPattern(__cfPattern_1, {})}
+        {state.key("items").mapWithPattern(__cfPattern_haeccc601a30f, {})}
       </div>),
     };
 }, {
@@ -180,6 +180,8 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfPattern_1
+    __cfLift_heb4680985495,
+    __cfPattern_haeccc601a30f,
+    __cfLift_1: __cfLift_heb4680985495,
+    __cfPattern_1: __cfPattern_haeccc601a30f
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/optional-element-access.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/optional-element-access.expected.jsx
@@ -11,7 +11,7 @@ import { cell, NAME, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h55fc09e91e15 = __cfHelpers.lift<{
     list: __cfHelpers.Cell<string[] | undefined>;
 }, boolean>(({ list }) => !list.get()?.[0], {
     type: "object",
@@ -64,7 +64,7 @@ export default pattern(() => {
                     type: "object",
                     properties: {}
                 }]
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_1({ list: list }), <span>No first entry</span>)}
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_h55fc09e91e15({ list: list }), <span>No first entry</span>)}
       </div>),
     };
 }, false as const satisfies __cfHelpers.JSONSchema, {
@@ -104,5 +104,6 @@ export default pattern(() => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_h55fc09e91e15,
+    __cfLift_1: __cfLift_h55fc09e91e15
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/optional-method-calls.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/optional-method-calls.expected.jsx
@@ -20,7 +20,7 @@ interface State {
     suffix: string;
     items: Array<string | undefined>;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h75a57fdb1745 = __cfHelpers.lift<{
     state: {
         maybeText?: string | undefined;
     };
@@ -40,7 +40,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["string", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_hdd5f23bb73e2 = __cfHelpers.lift<{
     state: {
         maybeText?: string | undefined;
     };
@@ -60,7 +60,7 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_3 = __cfHelpers.lift<{
+const __cfLift_h9b1a146aab98 = __cfHelpers.lift<{
     state: {
         maybeText?: string | undefined;
         suffix: string;
@@ -85,7 +85,7 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["string", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_4 = __cfHelpers.lift<{
+const __cfLift_h64f5ae547b8d = __cfHelpers.lift<{
     item: string | undefined;
 }, string | undefined>(({ item }) => item?.trim?.(), {
     type: "object",
@@ -97,9 +97,9 @@ const __cfLift_4 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["string", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h626f90a53442 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
-    return <span>{__cfLift_4({ item: item })}</span>;
+    return <span>{__cfLift_h64f5ae547b8d({ item: item })}</span>;
 }, {
     type: "object",
     properties: {
@@ -137,18 +137,18 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 // Context: Optionality modifies an otherwise supported call;
 //          the underlying call's provenance and lowering route stay unchanged.
 export default pattern((state) => ({
-    normalized: __cfLift_1({ state: {
+    normalized: __cfLift_h75a57fdb1745({ state: {
             maybeText: state.key("maybeText")
         } }).for(["__patternResult", "normalized"], true),
-    selected: __cfLift_2({ state: {
+    selected: __cfLift_hdd5f23bb73e2({ state: {
             maybeText: state.key("maybeText")
         } }).for(["__patternResult", "selected"], true),
     [UI]: (<div>
-      <p>{__cfLift_3({ state: {
+      <p>{__cfLift_h9b1a146aab98({ state: {
             maybeText: state.key("maybeText"),
             suffix: state.key("suffix")
         } })}</p>
-      {state.key("items").mapWithPattern(__cfPattern_1, {})}
+      {state.key("items").mapWithPattern(__cfPattern_h626f90a53442, {})}
     </div>)
 }), {
     type: "object",
@@ -207,9 +207,14 @@ export default pattern((state) => ({
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2,
-    __cfLift_3,
-    __cfLift_4,
-    __cfPattern_1
+    __cfLift_h75a57fdb1745,
+    __cfLift_hdd5f23bb73e2,
+    __cfLift_h9b1a146aab98,
+    __cfLift_h64f5ae547b8d,
+    __cfPattern_h626f90a53442,
+    __cfLift_1: __cfLift_h75a57fdb1745,
+    __cfLift_2: __cfLift_hdd5f23bb73e2,
+    __cfLift_3: __cfLift_h9b1a146aab98,
+    __cfLift_4: __cfLift_h64f5ae547b8d,
+    __cfPattern_1: __cfPattern_h626f90a53442
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/parameterized-inline-call-root.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/parameterized-inline-call-root.expected.jsx
@@ -11,7 +11,7 @@ import { pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hb101a264907f = __cfHelpers.lift<{
     prefix: string;
     count: number;
 }, string>(({ prefix, count }) => ((value: number) => prefix + value)(count), {
@@ -38,7 +38,7 @@ export default pattern((__cf_pattern_input) => {
     const prefix = __cf_pattern_input.key("prefix");
     const count = __cf_pattern_input.key("count");
     return ({
-        [UI]: <div>{__cfLift_1({
+        [UI]: <div>{__cfLift_hb101a264907f({
             prefix: prefix,
             count: count
         })}</div>,
@@ -88,5 +88,6 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_hb101a264907f,
+    __cfLift_1: __cfLift_hb101a264907f
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/parent-suppression-edge.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/parent-suppression-edge.expected.jsx
@@ -86,7 +86,7 @@ interface State {
         }>;
     };
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h71e9d701c801 = __cfHelpers.lift<{
     state: {
         user: {
             name: string;
@@ -132,7 +132,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_he21c0225beb1 = __cfHelpers.lift<{
     state: {
         user: {
             age: number;
@@ -161,7 +161,7 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_3 = __cfHelpers.lift<{
+const __cfLift_h9e8d04319c76 = __cfHelpers.lift<{
     state: {
         user: {
             age: number;
@@ -190,7 +190,7 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_4 = __cfHelpers.lift<{
+const __cfLift_h60141b04cf72 = __cfHelpers.lift<{
     state: {
         user: {
             name: string;
@@ -232,7 +232,7 @@ const __cfLift_4 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_5 = __cfHelpers.lift<{
+const __cfLift_h92e2b22acbf8 = __cfHelpers.lift<{
     state: {
         user: {
             name: string;
@@ -261,7 +261,7 @@ const __cfLift_5 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_6 = __cfHelpers.lift<{
+const __cfLift_hdcaaec4b17d4 = __cfHelpers.lift<{
     state: {
         config: {
             theme: {
@@ -316,7 +316,7 @@ const __cfLift_6 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_7 = __cfHelpers.lift<{
+const __cfLift_hb13699ae58ef = __cfHelpers.lift<{
     state: {
         user: {
             name: string;
@@ -345,7 +345,7 @@ const __cfLift_7 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_8 = __cfHelpers.lift<{
+const __cfLift_h60316a6a3ad1 = __cfHelpers.lift<{
     state: {
         user: {
             email: string;
@@ -392,7 +392,7 @@ export default pattern((state) => {
         {/* String concatenation with multiple property accesses */}
         <p>
           Full profile:{" "}
-          {__cfLift_1({ state: {
+          {__cfLift_h71e9d701c801({ state: {
                 user: {
                     name: state.key("user", "name"),
                     profile: {
@@ -405,12 +405,12 @@ export default pattern((state) => {
 
         {/* Arithmetic with multiple properties from same base */}
         <p>
-          Age calculation: {__cfLift_2({ state: {
+          Age calculation: {__cfLift_he21c0225beb1({ state: {
                 user: {
                     age: state.key("user", "age")
                 }
             } })} months, or{" "}
-          {__cfLift_3({ state: {
+          {__cfLift_h9e8d04319c76({ state: {
                 user: {
                     age: state.key("user", "age")
                 }
@@ -495,14 +495,14 @@ export default pattern((state) => {
             type: "string"
         } as const satisfies __cfHelpers.JSONSchema, {
             type: "string"
-        } as const satisfies __cfHelpers.JSONSchema, state.key("user", "settings", "notifications"), __cfLift_4({ state: {
+        } as const satisfies __cfHelpers.JSONSchema, state.key("user", "settings", "notifications"), __cfLift_h60141b04cf72({ state: {
                 user: {
                     name: state.key("user", "name"),
                     settings: {
                         theme: state.key("user", "settings", "theme")
                     }
                 }
-            } }), __cfLift_5({ state: {
+            } }), __cfLift_h92e2b22acbf8({ state: {
                 user: {
                     name: state.key("user", "name")
                 }
@@ -511,7 +511,7 @@ export default pattern((state) => {
 
         {/* Computed expression with shared base */}
         <p>
-          Spacing calc: {__cfLift_6({ state: {
+          Spacing calc: {__cfLift_hdcaaec4b17d4({ state: {
                 config: {
                     theme: {
                         spacing: {
@@ -547,12 +547,12 @@ export default pattern((state) => {
         <h3>Method Calls on Shared Bases</h3>
         {/* Multiple method calls on properties from same base */}
         <p>
-          Formatted: {__cfLift_7({ state: {
+          Formatted: {__cfLift_hb13699ae58ef({ state: {
                 user: {
                     name: state.key("user", "name")
                 }
             } })} -{" "}
-          {__cfLift_8({ state: {
+          {__cfLift_h60316a6a3ad1({ state: {
                 user: {
                     email: state.key("user", "email")
                 }
@@ -963,12 +963,20 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2,
-    __cfLift_3,
-    __cfLift_4,
-    __cfLift_5,
-    __cfLift_6,
-    __cfLift_7,
-    __cfLift_8
+    __cfLift_h71e9d701c801,
+    __cfLift_he21c0225beb1,
+    __cfLift_h9e8d04319c76,
+    __cfLift_h60141b04cf72,
+    __cfLift_h92e2b22acbf8,
+    __cfLift_hdcaaec4b17d4,
+    __cfLift_hb13699ae58ef,
+    __cfLift_h60316a6a3ad1,
+    __cfLift_1: __cfLift_h71e9d701c801,
+    __cfLift_2: __cfLift_he21c0225beb1,
+    __cfLift_3: __cfLift_h9e8d04319c76,
+    __cfLift_4: __cfLift_h60141b04cf72,
+    __cfLift_5: __cfLift_h92e2b22acbf8,
+    __cfLift_6: __cfLift_hdcaaec4b17d4,
+    __cfLift_7: __cfLift_hb13699ae58ef,
+    __cfLift_8: __cfLift_h60316a6a3ad1
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/pattern-statements-vs-jsx.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/pattern-statements-vs-jsx.expected.jsx
@@ -42,7 +42,7 @@ const decrement = handler(false as const satisfies __cfHelpers.JSONSchema, {
 }) => {
     state.value.set(state.value.get() - 1);
 });
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h7a4ce95fb921 = __cfHelpers.lift<{
     state: {
         value: number;
     };
@@ -63,7 +63,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_hf91f105c3f4a = __cfHelpers.lift<{
     state: {
         value: number;
     };
@@ -84,7 +84,7 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_3 = __cfHelpers.lift<{
+const __cfLift_he3dc8b96511a = __cfHelpers.lift<{
     state: {
         value: number;
     };
@@ -105,7 +105,7 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_4 = __cfHelpers.lift<{
+const __cfLift_h318c05695b48 = __cfHelpers.lift<{
     state: {
         value: number;
     };
@@ -142,15 +142,15 @@ export default pattern((state) => {
           {/* These SHOULD be transformed (JSX expression context) */}
           Current: {state.key("value")}
           <br />
-          Next number: {__cfLift_1({ state: {
+          Next number: {__cfLift_h7a4ce95fb921({ state: {
                 value: state.key("value")
             } })}
           <br />
-          Previous: {__cfLift_2({ state: {
+          Previous: {__cfLift_hf91f105c3f4a({ state: {
                 value: state.key("value")
             } })}
           <br />
-          Doubled: {__cfLift_3({ state: {
+          Doubled: {__cfLift_he3dc8b96511a({ state: {
                 value: state.key("value")
             } })}
           <br />
@@ -162,7 +162,7 @@ export default pattern((state) => {
             type: "string"
         } as const satisfies __cfHelpers.JSONSchema, {
             "enum": ["High", "Low"]
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_4({ state: {
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_h318c05695b48({ state: {
                 value: state.key("value")
             } }), "High", "Low")}
         </p>
@@ -221,8 +221,12 @@ __cfHardenFn(h);
 __cfReg({
     increment,
     decrement,
-    __cfLift_1,
-    __cfLift_2,
-    __cfLift_3,
-    __cfLift_4
+    __cfLift_h7a4ce95fb921,
+    __cfLift_hf91f105c3f4a,
+    __cfLift_he3dc8b96511a,
+    __cfLift_h318c05695b48,
+    __cfLift_1: __cfLift_h7a4ce95fb921,
+    __cfLift_2: __cfLift_hf91f105c3f4a,
+    __cfLift_3: __cfLift_he3dc8b96511a,
+    __cfLift_4: __cfLift_h318c05695b48
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/pattern-vs-computed-logical-and.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/pattern-vs-computed-logical-and.expected.jsx
@@ -63,7 +63,7 @@ export const PatternLogicalAnd = pattern((__cf_pattern_input) => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_ha0c6789b93cc = __cfHelpers.lift<{
     foo: boolean;
     bar: string;
 }, string | false>(({ foo, bar }) => foo && bar, {
@@ -88,7 +88,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 export const ComputedLogicalAnd = pattern((__cf_pattern_input) => {
     const foo = __cf_pattern_input.key("foo");
     const bar = __cf_pattern_input.key("bar");
-    return (<div>{__cfLift_1({
+    return (<div>{__cfLift_ha0c6789b93cc({
         foo: foo,
         bar: bar
     })}</div>);
@@ -128,5 +128,6 @@ export const ComputedLogicalAnd = pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_ha0c6789b93cc,
+    __cfLift_1: __cfLift_ha0c6789b93cc
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/pattern-with-cells.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/pattern-with-cells.expected.jsx
@@ -11,7 +11,7 @@ import { pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h6e766619f6ec = __cfHelpers.lift<{
     cell: {
         value: number;
     };
@@ -32,7 +32,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_he3d28b1cf8a0 = __cfHelpers.lift<{
     cell: {
         value: number;
     };
@@ -62,10 +62,10 @@ export default pattern((cell) => {
     return {
         [UI]: (<div>
         <p>Current value: {cell.key("value")}</p>
-        <p>Next value: {__cfLift_1({ cell: {
+        <p>Next value: {__cfLift_h6e766619f6ec({ cell: {
                 value: cell.key("value")
             } })}</p>
-        <p>Double: {__cfLift_2({ cell: {
+        <p>Double: {__cfLift_he3d28b1cf8a0({ cell: {
                 value: cell.key("value")
             } })}</p>
       </div>),
@@ -116,6 +116,8 @@ export default pattern((cell) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2
+    __cfLift_h6e766619f6ec,
+    __cfLift_he3d28b1cf8a0,
+    __cfLift_1: __cfLift_h6e766619f6ec,
+    __cfLift_2: __cfLift_he3d28b1cf8a0
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/reactive-cell-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/reactive-cell-map.expected.jsx
@@ -144,7 +144,7 @@ const goToPiece = handler({
     console.log("goToPiece clicked");
     return navigateTo(piece);
 });
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h47a985a89abd = __cfHelpers.lift<{
     cellRef: unknown[];
 }, boolean>(({ cellRef }) => !cellRef?.length, {
     type: "object",
@@ -160,7 +160,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_h91b64b70a4ed = __cfHelpers.lift<{
     piece: any;
 }, any>(({ piece }) => piece[__cfHelpers.NAME], {
     type: "object",
@@ -169,7 +169,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     },
     required: ["piece"]
 } as const satisfies __cfHelpers.JSONSchema, true as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h1a719250c3fa = __cfHelpers.pattern(__cf_pattern_input => {
     const piece = __cf_pattern_input.key("element");
     const index = __cf_pattern_input.key("index");
     return (<li>
@@ -178,7 +178,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
                 </cf-button>
                 <span>Piece {index + 1}: {__cfHelpers.unless(true as const satisfies __cfHelpers.JSONSchema, {
         type: "string"
-    } as const satisfies __cfHelpers.JSONSchema, true as const satisfies __cfHelpers.JSONSchema, __cfLift_2({ piece: piece }), "Unnamed")}</span>
+    } as const satisfies __cfHelpers.JSONSchema, true as const satisfies __cfHelpers.JSONSchema, __cfLift_h91b64b70a4ed({ piece: piece }), "Unnamed")}</span>
               </li>);
 }, {
     type: "object",
@@ -244,8 +244,8 @@ export default pattern(() => {
                     type: "object",
                     properties: {}
                 }]
-        } as const satisfies __cfHelpers.JSONSchema, {} as const satisfies __cfHelpers.JSONSchema, __cfLift_1({ cellRef: cellRef }), <div>No pieces created yet</div>, <ul>
-            {cellRef.mapWithPattern(__cfPattern_1, {})}
+        } as const satisfies __cfHelpers.JSONSchema, {} as const satisfies __cfHelpers.JSONSchema, __cfLift_h47a985a89abd({ cellRef: cellRef }), <div>No pieces created yet</div>, <ul>
+            {cellRef.mapWithPattern(__cfPattern_h1a719250c3fa, {})}
           </ul>)}
 
         <cf-button onClick={createSimplePattern({ cellRef })}>
@@ -301,7 +301,10 @@ __cfReg({
     addPieceAndNavigate,
     createSimplePattern,
     goToPiece,
-    __cfLift_1,
-    __cfLift_2,
-    __cfPattern_1
+    __cfLift_h47a985a89abd,
+    __cfLift_h91b64b70a4ed,
+    __cfPattern_h1a719250c3fa,
+    __cfLift_1: __cfLift_h47a985a89abd,
+    __cfLift_2: __cfLift_h91b64b70a4ed,
+    __cfPattern_1: __cfPattern_h1a719250c3fa
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/reactive-operations.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/reactive-operations.expected.jsx
@@ -11,7 +11,7 @@ import { cell, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h8ffe8e869121 = __cfHelpers.lift<{
     count: __cfHelpers.Cell<number>;
 }, number>(({ count }) => count.get() + 1, {
     type: "object",
@@ -25,7 +25,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_h0d44f256eeb0 = __cfHelpers.lift<{
     count: __cfHelpers.Cell<number>;
 }, number>(({ count }) => count.get() * 2, {
     type: "object",
@@ -39,7 +39,7 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_3 = __cfHelpers.lift<{
+const __cfLift_hbee1d910e928 = __cfHelpers.lift<{
     price: __cfHelpers.Cell<number>;
 }, number>(({ price }) => price.get() * 1.1, {
     type: "object",
@@ -68,9 +68,9 @@ export default pattern((_state) => {
     return {
         [UI]: (<div>
         <p>Count: {count}</p>
-        <p>Next: {__cfLift_1({ count: count })}</p>
-        <p>Double: {__cfLift_2({ count: count })}</p>
-        <p>Total: {__cfLift_3({ price: price })}</p>
+        <p>Next: {__cfLift_h8ffe8e869121({ count: count })}</p>
+        <p>Double: {__cfLift_h0d44f256eeb0({ count: count })}</p>
+        <p>Total: {__cfLift_hbee1d910e928({ price: price })}</p>
       </div>),
     };
 }, false as const satisfies __cfHelpers.JSONSchema, {
@@ -107,7 +107,10 @@ export default pattern((_state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2,
-    __cfLift_3
+    __cfLift_h8ffe8e869121,
+    __cfLift_h0d44f256eeb0,
+    __cfLift_hbee1d910e928,
+    __cfLift_1: __cfLift_h8ffe8e869121,
+    __cfLift_2: __cfLift_h0d44f256eeb0,
+    __cfLift_3: __cfLift_hbee1d910e928
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/safe-context-and-jsx.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/safe-context-and-jsx.expected.jsx
@@ -12,7 +12,7 @@ import { handler, computed } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h497773797bb6 = __cfHelpers.lift<{
     show: boolean;
 }, boolean>(({ show }) => show, {
     type: "object",
@@ -118,9 +118,9 @@ const MyHandler = handler({
     },
     required: ["show"]
 } as const satisfies __cfHelpers.JSONSchema, (_event, { show }) => {
-    return <div>{__cfLift_1({ show: show }) && <span>Content</span>}</div>;
+    return <div>{__cfLift_h497773797bb6({ show: show }) && <span>Content</span>}</div>;
 });
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_ha03ba3ee95e4 = __cfHelpers.lift<{
     value: string | null;
 }, string | null>(({ value }) => value, {
     type: "object",
@@ -233,14 +233,16 @@ const MyHandler2 = handler({
     },
     required: ["value"]
 } as const satisfies __cfHelpers.JSONSchema, (_event, { value }) => {
-    return <div>{__cfLift_2({ value: value }) || <span>Fallback</span>}</div>;
+    return <div>{__cfLift_ha03ba3ee95e4({ value: value }) || <span>Fallback</span>}</div>;
 });
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
     MyHandler,
-    __cfLift_1,
+    __cfLift_h497773797bb6,
     MyHandler2,
-    __cfLift_2
+    __cfLift_ha03ba3ee95e4,
+    __cfLift_1: __cfLift_h497773797bb6,
+    __cfLift_2: __cfLift_ha03ba3ee95e4
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/ternary-binary-condition-body-alias.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/ternary-binary-condition-body-alias.expected.jsx
@@ -15,7 +15,7 @@ interface PollState {
     users: Default<string[], [
     ]>;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h42f13f2d01f6 = __cfHelpers.lift<{
     userCount: number;
 }, boolean>(({ userCount }) => userCount > 0, {
     type: "object",
@@ -57,7 +57,7 @@ export default pattern((__cf_pattern_input) => {
                     type: "object",
                     properties: {}
                 }]
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_1({ userCount: userCount }), <div>has users</div>, null)}
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_h42f13f2d01f6({ userCount: userCount }), <div>has users</div>, null)}
       </div>),
     };
 }, {
@@ -106,5 +106,6 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_h42f13f2d01f6,
+    __cfLift_1: __cfLift_h42f13f2d01f6
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/ternary-branch-ownership.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/ternary-branch-ownership.expected.jsx
@@ -27,7 +27,7 @@ type State = {
     recentEvents: TagEvent[];
     items: Item[];
 };
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hdbf1e9e0ab50 = __cfHelpers.lift<{
     state: {
         items: Item[];
     };
@@ -82,7 +82,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_h0fd003a899da = __cfHelpers.lift<{
     state: {
         items: {
             length: number;
@@ -111,7 +111,7 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_3 = __cfHelpers.lift<{
+const __cfLift_h24bcb361f84f = __cfHelpers.lift<{
     state: any;
 }, boolean>(({ state }) => state.recentEvents.length === 0, {
     type: "object",
@@ -122,7 +122,7 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h0ba44e3e915a = __cfHelpers.pattern(__cf_pattern_input => {
     const event = __cf_pattern_input.key("element");
     const idx = __cf_pattern_input.key("index");
     return (<cf-hstack key={idx} gap="2">
@@ -183,10 +183,10 @@ export default pattern((state) => {
     const showList = new Writable(true, {
         type: "boolean"
     } as const satisfies __cfHelpers.JSONSchema).for("showList", true);
-    const sorted = __cfLift_1({ state: {
+    const sorted = __cfLift_hdbf1e9e0ab50({ state: {
             items: state.key("items")
         } }).for("sorted", true);
-    const count = __cfLift_2({ state: {
+    const count = __cfLift_h0fd003a899da({ state: {
             items: {
                 length: state.key("items", "length")
             }
@@ -219,8 +219,8 @@ export default pattern((state) => {
                     type: "object",
                     properties: {}
                 }]
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_3({ state: state }), <span>No events yet</span>, <div>
-              {state.key("recentEvents").mapWithPattern(__cfPattern_1, {})}
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_h24bcb361f84f({ state: state }), <span>No events yet</span>, <div>
+              {state.key("recentEvents").mapWithPattern(__cfPattern_h0ba44e3e915a, {})}
             </div>)}
         {__cfHelpers.ifElse({
             type: "boolean",
@@ -338,8 +338,12 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2,
-    __cfLift_3,
-    __cfPattern_1
+    __cfLift_hdbf1e9e0ab50,
+    __cfLift_h0fd003a899da,
+    __cfLift_h24bcb361f84f,
+    __cfPattern_h0ba44e3e915a,
+    __cfLift_1: __cfLift_hdbf1e9e0ab50,
+    __cfLift_2: __cfLift_h0fd003a899da,
+    __cfLift_3: __cfLift_h24bcb361f84f,
+    __cfPattern_1: __cfPattern_h0ba44e3e915a
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/ternary-hoisted-compute-plain-map-branch.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/ternary-hoisted-compute-plain-map-branch.expected.jsx
@@ -15,7 +15,7 @@ interface Item {
     name: string;
     value: number;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hdbf1e9e0ab50 = __cfHelpers.lift<{
     state: {
         items: Item[];
     };
@@ -70,7 +70,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_h0fd003a899da = __cfHelpers.lift<{
     state: {
         items: {
             length: number;
@@ -110,10 +110,10 @@ export default pattern((state) => {
     const showList = new Writable(true, {
         type: "boolean"
     } as const satisfies __cfHelpers.JSONSchema).for("showList", true);
-    const sorted = __cfLift_1({ state: {
+    const sorted = __cfLift_hdbf1e9e0ab50({ state: {
             items: state.key("items")
         } }).for("sorted", true);
-    const count = __cfLift_2({ state: {
+    const count = __cfLift_h0fd003a899da({ state: {
             items: {
                 length: state.key("items", "length")
             }
@@ -206,6 +206,8 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2
+    __cfLift_hdbf1e9e0ab50,
+    __cfLift_h0fd003a899da,
+    __cfLift_1: __cfLift_hdbf1e9e0ab50,
+    __cfLift_2: __cfLift_h0fd003a899da
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/ternary-pure-jsx-map-branch.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/ternary-pure-jsx-map-branch.expected.jsx
@@ -14,7 +14,7 @@ const __cfAmdHooks = undefined;
 interface TagEvent {
     label: string;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hd28349b3dbd1 = __cfHelpers.lift<{
     recentEvents: TagEvent[];
 }, boolean>(({ recentEvents }) => recentEvents.length === 0, {
     type: "object",
@@ -30,7 +30,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h558563f72c28 = __cfHelpers.pattern(__cf_pattern_input => {
     const event = __cf_pattern_input.key("element");
     const idx = __cf_pattern_input.key("index");
     return (<cf-hstack key={idx} gap="2">
@@ -107,8 +107,8 @@ export default pattern((__cf_pattern_input) => {
                     type: "object",
                     properties: {}
                 }]
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_1({ recentEvents: recentEvents }), <span>No events yet</span>, <div>
-            {recentEvents.mapWithPattern(__cfPattern_1, {})}
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_hd28349b3dbd1({ recentEvents: recentEvents }), <span>No events yet</span>, <div>
+            {recentEvents.mapWithPattern(__cfPattern_h558563f72c28, {})}
           </div>)}
     </div>),
     });
@@ -168,6 +168,8 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfPattern_1
+    __cfLift_hd28349b3dbd1,
+    __cfPattern_h558563f72c28,
+    __cfLift_1: __cfLift_hd28349b3dbd1,
+    __cfPattern_1: __cfPattern_h558563f72c28
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/wrapped-element-binding-reads.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/wrapped-element-binding-reads.expected.jsx
@@ -34,7 +34,7 @@ interface Input {
 interface Output {
     [UI]: VNode;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h6ffc7530c62b = __cfHelpers.lift<{
     entry: {
         name: string;
     };
@@ -59,7 +59,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_hca58bff417ac = __cfHelpers.lift<{
     entry: {
         name: string;
     };
@@ -84,7 +84,7 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_3 = __cfHelpers.lift<{
+const __cfLift_h6b42d324c18f = __cfHelpers.lift<{
     entry: {
         name: string;
     };
@@ -109,25 +109,25 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_haaea8be7f307 = __cfHelpers.pattern(__cf_pattern_input => {
     const entry = __cf_pattern_input.key("element");
     const prefix = __cf_pattern_input.key("params", "prefix");
     // Parenthesized: (entry).name
-    const a = __cfLift_1({
+    const a = __cfLift_h6ffc7530c62b({
         entry: {
             name: entry.key("name")
         },
         prefix: prefix
     }).for("a", true);
     // Non-null asserted: entry!.name
-    const b = __cfLift_2({
+    const b = __cfLift_hca58bff417ac({
         entry: {
             name: entry.key("name")
         },
         prefix: prefix
     }).for("b", true);
     // 'as' asserted: (entry as Entry).name
-    const c = __cfLift_3({
+    const c = __cfLift_h6b42d324c18f({
         entry: {
             name: entry.key("name")
         },
@@ -188,7 +188,7 @@ export default pattern((__cf_pattern_input) => {
     const prefix = __cf_pattern_input.key("prefix");
     return ({
         [UI]: (<div>
-      {entries.mapWithPattern(__cfPattern_1, {
+      {entries.mapWithPattern(__cfPattern_haaea8be7f307, {
                 prefix: prefix
             })}
     </div>),
@@ -231,8 +231,12 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2,
-    __cfLift_3,
-    __cfPattern_1
+    __cfLift_h6ffc7530c62b,
+    __cfLift_hca58bff417ac,
+    __cfLift_h6b42d324c18f,
+    __cfPattern_haaea8be7f307,
+    __cfLift_1: __cfLift_h6ffc7530c62b,
+    __cfLift_2: __cfLift_hca58bff417ac,
+    __cfLift_3: __cfLift_h6b42d324c18f,
+    __cfPattern_1: __cfPattern_haaea8be7f307
 });

--- a/packages/ts-transformers/test/fixtures/kitchensink/branch-lowered-capture-preservation.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/kitchensink/branch-lowered-capture-preservation.expected.jsx
@@ -97,7 +97,7 @@ interface Item {
     pinned?: boolean;
     allowMultiple: boolean;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h4d9e116b1c61 = __cfHelpers.lift<{
     items: Item[];
 }, { entry: Item; index: number; isExpanded: boolean; isPinned: boolean; allowMultiple: boolean; }[]>(({ items }) => items.map((entry, index) => ({
     entry,
@@ -180,7 +180,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_hf32bfc90e343 = __cfHelpers.lift<{
     entry: {
         collapsed?: boolean | undefined;
     };
@@ -204,7 +204,7 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_3 = __cfHelpers.lift<{
+const __cfLift_h7e3316bb80f6 = __cfHelpers.lift<{
     entry: {
         note?: string | undefined;
     };
@@ -232,7 +232,7 @@ const __cfLift_3 = __cfHelpers.lift<{
     },
     required: ["fontWeight"]
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_4 = __cfHelpers.lift<{
+const __cfLift_h33dbdd99e517 = __cfHelpers.lift<{
     entry: {
         note?: string | undefined;
     };
@@ -252,7 +252,7 @@ const __cfLift_4 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_5 = __cfHelpers.lift<{
+const __cfLift_hf7a605e4a7d3 = __cfHelpers.lift<{
     isExpanded: boolean;
 }, boolean>(({ isExpanded }) => !isExpanded, {
     type: "object",
@@ -265,7 +265,7 @@ const __cfLift_5 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_6 = __cfHelpers.lift<{
+const __cfLift_hf7a605e4a7d3_2 = __cfHelpers.lift<{
     isExpanded: boolean;
 }, boolean>(({ isExpanded }) => !isExpanded, {
     type: "object",
@@ -278,7 +278,7 @@ const __cfLift_6 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h1e351f7978d7 = __cfHelpers.pattern(__cf_pattern_input => {
     const entry = __cf_pattern_input.key("element", "entry");
     const index = __cf_pattern_input.key("element", "index");
     const isExpanded = __cf_pattern_input.key("element", "isExpanded");
@@ -303,7 +303,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         anyOf: [{
                 type: "null"
             }, {}]
-    } as const satisfies __cfHelpers.JSONSchema, __cfLift_2({ entry: {
+    } as const satisfies __cfHelpers.JSONSchema, __cfLift_hf32bfc90e343({ entry: {
             collapsed: entry.key("collapsed")
         } }), <div>
               {ifElse({
@@ -324,7 +324,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
                 editingNoteIndex,
                 editingNoteText,
                 index,
-            })} style={__cfLift_3({ entry: entry })} title={__cfLift_4({ entry: entry })}>
+            })} style={__cfLift_h7e3316bb80f6({ entry: entry })} title={__cfLift_h33dbdd99e517({ entry: entry })}>
                   note
                 </button>, null)}
               {__cfHelpers.when({
@@ -337,7 +337,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         anyOf: [{
                 type: ["boolean", "null"]
             }, {}]
-    } as const satisfies __cfHelpers.JSONSchema, __cfLift_5({ isExpanded: isExpanded }), ifElse({
+    } as const satisfies __cfHelpers.JSONSchema, __cfLift_hf7a605e4a7d3({ isExpanded: isExpanded }), ifElse({
         type: "boolean"
     } as const satisfies __cfHelpers.JSONSchema, {
         anyOf: [{}, {
@@ -378,7 +378,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
                 type: "object",
                 properties: {}
             }]
-    } as const satisfies __cfHelpers.JSONSchema, __cfLift_6({ isExpanded: isExpanded }), <button type="button" onClick={trashSubPiece({
+    } as const satisfies __cfHelpers.JSONSchema, __cfLift_hf7a605e4a7d3_2({ isExpanded: isExpanded }), <button type="button" onClick={trashSubPiece({
             subPieces,
             trashedSubPieces,
             expandedIndex,
@@ -525,10 +525,10 @@ export default pattern((__cf_pattern_input) => {
     const settingsModuleIndex = new Writable<number | undefined>(undefined, {
         type: ["number", "undefined"]
     } as const satisfies __cfHelpers.JSONSchema).for("settingsModuleIndex", true);
-    const allEntries = __cfLift_1({ items: items }).for("allEntries", true);
+    const allEntries = __cfLift_h4d9e116b1c61({ items: items }).for("allEntries", true);
     return {
         [UI]: (<div>
-        {allEntries.mapWithPattern(__cfPattern_1, {
+        {allEntries.mapWithPattern(__cfPattern_h1e351f7978d7, {
                 subPieces: subPieces,
                 editingNoteIndex: editingNoteIndex,
                 editingNoteText: editingNoteText,
@@ -619,11 +619,18 @@ __cfReg({
     openSettings,
     toggleExpanded,
     trashSubPiece,
-    __cfLift_1,
-    __cfLift_2,
-    __cfLift_3,
-    __cfLift_4,
-    __cfLift_5,
-    __cfLift_6,
-    __cfPattern_1
+    __cfLift_h4d9e116b1c61,
+    __cfLift_hf32bfc90e343,
+    __cfLift_h7e3316bb80f6,
+    __cfLift_h33dbdd99e517,
+    __cfLift_hf7a605e4a7d3,
+    __cfLift_hf7a605e4a7d3_2,
+    __cfPattern_h1e351f7978d7,
+    __cfLift_1: __cfLift_h4d9e116b1c61,
+    __cfLift_2: __cfLift_hf32bfc90e343,
+    __cfLift_3: __cfLift_h7e3316bb80f6,
+    __cfLift_4: __cfLift_h33dbdd99e517,
+    __cfLift_5: __cfLift_hf7a605e4a7d3,
+    __cfLift_6: __cfLift_hf7a605e4a7d3_2,
+    __cfPattern_1: __cfPattern_h1e351f7978d7
 });

--- a/packages/ts-transformers/test/fixtures/kitchensink/helper-owned-compute-branches.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/kitchensink/helper-owned-compute-branches.expected.jsx
@@ -33,7 +33,7 @@ interface Project {
     members: string[];
     badges: Badge[];
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hcc2204ac106f = __cfHelpers.lift<{
     state: {
         showArchived: boolean;
         projects: {
@@ -115,7 +115,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_h6fc8d8628c41 = __cfHelpers.lift<{
     memberIndex: number;
 }, boolean>(({ memberIndex }) => memberIndex === 0, {
     type: "object",
@@ -128,7 +128,7 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_3 = __cfHelpers.lift<{
+const __cfLift_hdf4bcefb52cf = __cfHelpers.lift<{
     project: {
         name: string;
     };
@@ -153,7 +153,7 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h17b323b2c208 = __cfHelpers.pattern(__cf_pattern_input => {
     const member = __cf_pattern_input.key("element");
     const memberIndex = __cf_pattern_input.key("index");
     const project = __cf_pattern_input.params.project;
@@ -166,7 +166,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         type: "string"
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "string"
-    } as const satisfies __cfHelpers.JSONSchema, __cfLift_2({ memberIndex: memberIndex }), __cfLift_3({
+    } as const satisfies __cfHelpers.JSONSchema, __cfLift_h6fc8d8628c41({ memberIndex: memberIndex }), __cfLift_hdf4bcefb52cf({
         project: {
             name: project.name
         },
@@ -220,7 +220,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_4 = __cfHelpers.lift<{
+const __cfLift_hceda935cd7a2 = __cfHelpers.lift<{
     visibleProjects: {
         name: string;
         badges: {
@@ -262,7 +262,7 @@ visibleProjects.map((project, projectIndex) => {
                     : ""}
             </span>))}
           {/* [TRANSFORM] .map() → mapWithPattern: fallbackMembers is a Writable (reactive Cell), lowered even inside computed */}
-          {fallbackMembers.mapWithPattern(__cfPattern_1, {
+          {fallbackMembers.mapWithPattern(__cfPattern_h17b323b2c208, {
             project: {
                 name: project.name
             }
@@ -362,12 +362,12 @@ export default pattern((state) => {
         }
     } as const satisfies __cfHelpers.JSONSchema).for("fallbackMembers", true);
     // [TRANSFORM] computed() -> lift(): captures state.showArchived, state.projects
-    const visibleProjects = __cfLift_1({ state: {
+    const visibleProjects = __cfLift_hcc2204ac106f({ state: {
             showArchived: state.key("showArchived"),
             projects: state.key("projects")
         } }).for("visibleProjects", true);
     // [TRANSFORM] computed() -> lift(): captures visibleProjects (asOpaque), state.prefix, fallbackMembers (asCell — Writable)
-    const rows = __cfLift_4({
+    const rows = __cfLift_hceda935cd7a2({
         visibleProjects: visibleProjects,
         state: {
             prefix: state.key("prefix")
@@ -469,9 +469,14 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2,
-    __cfLift_3,
-    __cfPattern_1,
-    __cfLift_4
+    __cfLift_hcc2204ac106f,
+    __cfLift_h6fc8d8628c41,
+    __cfLift_hdf4bcefb52cf,
+    __cfPattern_h17b323b2c208,
+    __cfLift_hceda935cd7a2,
+    __cfLift_1: __cfLift_hcc2204ac106f,
+    __cfLift_2: __cfLift_h6fc8d8628c41,
+    __cfLift_3: __cfLift_hdf4bcefb52cf,
+    __cfPattern_1: __cfPattern_h17b323b2c208,
+    __cfLift_4: __cfLift_hceda935cd7a2
 });

--- a/packages/ts-transformers/test/fixtures/kitchensink/nested-computed-output-maps.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/kitchensink/nested-computed-output-maps.expected.jsx
@@ -78,7 +78,7 @@ const passthroughLabels = lift((labels: string[]) => labels, {
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h501ebd2fc822 = __cfHelpers.lift<{
     state: {
         threads: Thread[];
         showFlagged: boolean;
@@ -220,7 +220,7 @@ state.threads.map((thread, outerIndex) => ({
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_hcca64af3f49f = __cfHelpers.lift<{
     visibleComments: Comment[];
 }, Comment[]>(({ visibleComments }) => visibleComments, {
     type: "object",
@@ -285,7 +285,7 @@ const __cfLift_2 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_3 = __cfHelpers.lift<{
+const __cfLift_h237caf5ae9ed = __cfHelpers.lift<{
     reboundIndex: number;
     outerIndex: number;
 }, boolean>(({ reboundIndex, outerIndex }) => reboundIndex === outerIndex, {
@@ -302,7 +302,7 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_4 = __cfHelpers.lift<{
+const __cfLift_h2c81ffb44100 = __cfHelpers.lift<{
     state: {
         lane: string;
     };
@@ -335,7 +335,7 @@ const __cfLift_4 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h9876d1a32b2f = __cfHelpers.pattern(__cf_pattern_input => {
     const comment = __cf_pattern_input.key("element");
     const reboundIndex = __cf_pattern_input.key("index");
     const outerIndex = __cf_pattern_input.params.outerIndex;
@@ -349,10 +349,10 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         type: "string"
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "string"
-    } as const satisfies __cfHelpers.JSONSchema, __cfLift_3({
+    } as const satisfies __cfHelpers.JSONSchema, __cfLift_h237caf5ae9ed({
         reboundIndex: reboundIndex,
         outerIndex: outerIndex
-    }), __cfLift_4({
+    }), __cfLift_h2c81ffb44100({
         state: {
             lane: state.key("lane")
         },
@@ -420,7 +420,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_5 = __cfHelpers.lift<{
+const __cfLift_h7a3748fcc627 = __cfHelpers.lift<{
     edgeIndex: number;
     outerIndex: number;
 }, boolean>(({ edgeIndex, outerIndex }) => edgeIndex === outerIndex, {
@@ -437,7 +437,7 @@ const __cfLift_5 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_6 = __cfHelpers.lift<{
+const __cfLift_hce182c9f2358 = __cfHelpers.lift<{
     state: {
         lane: string;
     };
@@ -462,7 +462,7 @@ const __cfLift_6 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_he535898b6b88 = __cfHelpers.pattern(__cf_pattern_input => {
     const edge = __cf_pattern_input.key("element");
     const edgeIndex = __cf_pattern_input.key("index");
     const outerIndex = __cf_pattern_input.params.outerIndex;
@@ -476,10 +476,10 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
         type: "string"
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "string"
-    } as const satisfies __cfHelpers.JSONSchema, __cfLift_5({
+    } as const satisfies __cfHelpers.JSONSchema, __cfLift_h7a3748fcc627({
         edgeIndex: edgeIndex,
         outerIndex: outerIndex
-    }), __cfLift_6({
+    }), __cfLift_hce182c9f2358({
         state: {
             lane: state.key("lane")
         },
@@ -536,7 +536,7 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_7 = __cfHelpers.lift<{
+const __cfLift_h99f835fa1c74 = __cfHelpers.lift<{
     visibleThreads: {
         thread: {
             title: string;
@@ -562,7 +562,7 @@ visibleThreads.map(({ thread, outerIndex, visibleComments }) => {
     const plainSeparators = ["top", "bottom"].map((edge) => `${thread.title}-${edge}`);
     const liftedSeparators = passthroughLabels(plainSeparators).for("liftedSeparators", true);
     // [TRANSFORM] computed() → lift() (nested): captures visibleComments from outer computed scope
-    const reboundComments = __cfLift_2({ visibleComments: visibleComments }).for("reboundComments", true);
+    const reboundComments = __cfLift_hcca64af3f49f({ visibleComments: visibleComments }).for("reboundComments", true);
     return (<article>
           <h2>{thread.title}</h2>
           {/* [TRANSFORM] .map() stays plain: visibleComments is destructured from captured computed input */}
@@ -600,7 +600,7 @@ visibleThreads.map(({ thread, outerIndex, visibleComments }) => {
             </div>))}
           {/* [TRANSFORM] .map() → mapWithPattern: reboundComments is output of nested computed() — reactive even inside outer computed */}
           {/* [TRANSFORM] closure captures: outerIndex (via params opaque), state.lane (via params reactive .key()) */}
-          {reboundComments.mapWithPattern(__cfPattern_1, {
+          {reboundComments.mapWithPattern(__cfPattern_h9876d1a32b2f, {
             outerIndex: outerIndex,
             state: {
                 lane: state.lane
@@ -608,7 +608,7 @@ visibleThreads.map(({ thread, outerIndex, visibleComments }) => {
         })}
           {/* [TRANSFORM] .map() → mapWithPattern: liftedSeparators is output of lift() — reactive even inside outer computed */}
           {/* [TRANSFORM] closure captures: outerIndex (via params opaque), state.lane (via params reactive .key()) */}
-          {liftedSeparators.mapWithPattern(__cfPattern_2, {
+          {liftedSeparators.mapWithPattern(__cfPattern_he535898b6b88, {
             outerIndex: outerIndex,
             state: {
                 lane: state.lane
@@ -717,7 +717,7 @@ visibleThreads.map(({ thread, outerIndex, visibleComments }) => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_8 = __cfHelpers.lift<{
+const __cfLift_hc40d6438fae7 = __cfHelpers.lift<{
     labelIndex: number;
 }, boolean>(({ labelIndex }) => labelIndex === 0, {
     type: "object",
@@ -730,7 +730,7 @@ const __cfLift_8 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_9 = __cfHelpers.lift<{
+const __cfLift_h4866d7f7ca10 = __cfHelpers.lift<{
     state: {
         lane: string;
     };
@@ -755,7 +755,7 @@ const __cfLift_9 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hc09ff3953e73 = __cfHelpers.pattern(__cf_pattern_input => {
     const label = __cf_pattern_input.key("element");
     const labelIndex = __cf_pattern_input.key("index");
     const state = __cf_pattern_input.key("params", "state");
@@ -768,7 +768,7 @@ const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
         type: "string"
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "string"
-    } as const satisfies __cfHelpers.JSONSchema, __cfLift_8({ labelIndex: labelIndex }), __cfLift_9({
+    } as const satisfies __cfHelpers.JSONSchema, __cfLift_hc40d6438fae7({ labelIndex: labelIndex }), __cfLift_h4866d7f7ca10({
         state: {
             lane: state.key("lane")
         },
@@ -822,7 +822,7 @@ const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_4 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hcb517b892e1a = __cfHelpers.pattern(__cf_pattern_input => {
     const row = __cf_pattern_input.key("element");
     const rowIndex = __cf_pattern_input.key("index");
     return (<section data-row={rowIndex}>{row}</section>);
@@ -887,12 +887,12 @@ export default pattern((state) => {
     } as const satisfies __cfHelpers.JSONSchema).for("selectedCommentId", true);
     const laneLabels = passthroughLabels(["lane", "detail", "summary"]).for("laneLabels", true);
     // [TRANSFORM] computed() → lift(): captures state.threads, state.showFlagged
-    const visibleThreads = __cfLift_1({ state: {
+    const visibleThreads = __cfLift_h501ebd2fc822({ state: {
             threads: state.key("threads"),
             showFlagged: state.key("showFlagged")
         } }).for("visibleThreads", true);
     // [TRANSFORM] computed() → lift(): captures visibleThreads (asOpaque), selectedCommentId (asCell — Writable), state.lane
-    const threadRows = __cfLift_7({
+    const threadRows = __cfLift_h99f835fa1c74({
         visibleThreads: visibleThreads,
         selectedCommentId: selectedCommentId,
         state: {
@@ -903,13 +903,13 @@ export default pattern((state) => {
         [UI]: (<div>
         {/* [TRANSFORM] .map() → mapWithPattern: laneLabels is output of lift() in pattern context — reactive */}
         {/* [TRANSFORM] ternary lowered: labelIndex===0 ? `${state.lane}:${label}` : label → ifElse(lift(cond), lift(true-branch), label) */}
-        {laneLabels.mapWithPattern(__cfPattern_3, {
+        {laneLabels.mapWithPattern(__cfPattern_hc09ff3953e73, {
                 state: {
                     lane: state.key("lane")
                 }
             })}
         {/* [TRANSFORM] .map() → mapWithPattern: threadRows is output of computed() — reactive, back in pattern-owned UI */}
-        {threadRows.mapWithPattern(__cfPattern_4, {})}
+        {threadRows.mapWithPattern(__cfPattern_hcb517b892e1a, {})}
       </div>),
     };
 }, {
@@ -1009,17 +1009,30 @@ __cfHardenFn(h);
 __cfReg({
     jumpToComment,
     passthroughLabels,
-    __cfLift_1,
-    __cfLift_2,
-    __cfLift_3,
-    __cfLift_4,
-    __cfPattern_1,
-    __cfLift_5,
-    __cfLift_6,
-    __cfPattern_2,
-    __cfLift_7,
-    __cfLift_8,
-    __cfLift_9,
-    __cfPattern_3,
-    __cfPattern_4
+    __cfLift_h501ebd2fc822,
+    __cfLift_hcca64af3f49f,
+    __cfLift_h237caf5ae9ed,
+    __cfLift_h2c81ffb44100,
+    __cfPattern_h9876d1a32b2f,
+    __cfLift_h7a3748fcc627,
+    __cfLift_hce182c9f2358,
+    __cfPattern_he535898b6b88,
+    __cfLift_h99f835fa1c74,
+    __cfLift_hc40d6438fae7,
+    __cfLift_h4866d7f7ca10,
+    __cfPattern_hc09ff3953e73,
+    __cfPattern_hcb517b892e1a,
+    __cfLift_1: __cfLift_h501ebd2fc822,
+    __cfLift_2: __cfLift_hcca64af3f49f,
+    __cfLift_3: __cfLift_h237caf5ae9ed,
+    __cfLift_4: __cfLift_h2c81ffb44100,
+    __cfPattern_1: __cfPattern_h9876d1a32b2f,
+    __cfLift_5: __cfLift_h7a3748fcc627,
+    __cfLift_6: __cfLift_hce182c9f2358,
+    __cfPattern_2: __cfPattern_he535898b6b88,
+    __cfLift_7: __cfLift_h99f835fa1c74,
+    __cfLift_8: __cfLift_hc40d6438fae7,
+    __cfLift_9: __cfLift_h4866d7f7ca10,
+    __cfPattern_3: __cfPattern_hc09ff3953e73,
+    __cfPattern_4: __cfPattern_hcb517b892e1a
 });

--- a/packages/ts-transformers/test/fixtures/kitchensink/nested-writable-pattern-branches.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/kitchensink/nested-writable-pattern-branches.expected.jsx
@@ -63,7 +63,7 @@ const selectTask = handler({
     },
     required: ["selectedTaskId", "hoveredSectionId", "sectionId", "taskId", "sectionIndex", "taskIndex"]
 } as const satisfies __cfHelpers.JSONSchema, (_event, state) => state);
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h684f660abd51 = __cfHelpers.lift<{
     state: {
         sections: __cfHelpers.ReadonlyCell<unknown[]>;
     };
@@ -88,7 +88,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_h78fd377906a6 = __cfHelpers.lift<{
     task: {
         note?: string | undefined;
     };
@@ -108,7 +108,7 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_3 = __cfHelpers.lift<{
+const __cfLift_h45179e144554 = __cfHelpers.lift<{
     tagIndex: number;
     taskIndex: number;
 }, boolean>(({ tagIndex, taskIndex }) => tagIndex === taskIndex, {
@@ -125,7 +125,7 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_heaa3a32a7fcf = __cfHelpers.pattern(__cf_pattern_input => {
     const tag = __cf_pattern_input.key("element");
     const tagIndex = __cf_pattern_input.key("index");
     const taskIndex = __cf_pattern_input.key("params", "taskIndex");
@@ -141,7 +141,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
             type: "string"
         } as const satisfies __cfHelpers.JSONSchema, {
             type: "string"
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_3({
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_h45179e144554({
             tagIndex: tagIndex,
             taskIndex: taskIndex
         }), `${section.key("title")}:${tag}`, __cfHelpers.ifElse({
@@ -228,7 +228,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_he515ddba3102 = __cfHelpers.pattern(__cf_pattern_input => {
     const task = __cf_pattern_input.key("element");
     const taskIndex = __cf_pattern_input.key("index");
     const selectedTaskId = __cf_pattern_input.key("params", "selectedTaskId");
@@ -276,14 +276,14 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
             type: "boolean"
         } as const satisfies __cfHelpers.JSONSchema, {
             type: "boolean"
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_2({ task: {
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_h78fd377906a6({ task: {
                 note: task.key("note")
             } }), task.key("note") !== ""), <strong>{task.key("label")}</strong>, <em>{task.key("label")}</em>))}
                         </button>
                         {/* [TRANSFORM] .map() → mapWithPattern: task.tags is reactive pattern-owned data (nested inside sections map) */}
                         {/* [TRANSFORM] closure captures: taskIndex, section, state, task (all via params) */}
                         {/* [TRANSFORM] ternary lowered: tagIndex===taskIndex ? `${section.title}:${tag}` : (showCompleted||!task.done ? tag : "") */}
-                        {task.key("tags").mapWithPattern(__cfPattern_1, {
+                        {task.key("tags").mapWithPattern(__cfPattern_heaa3a32a7fcf, {
             taskIndex: taskIndex,
             section: {
                 title: section.key("title")
@@ -392,7 +392,7 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_4 = __cfHelpers.lift<{
+const __cfLift_hdc8e33263517 = __cfHelpers.lift<{
     section: {
         tasks: {
             length: number;
@@ -449,7 +449,7 @@ section.tasks.length > 0
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h4dcc24e464fa = __cfHelpers.pattern(__cf_pattern_input => {
     const section = __cf_pattern_input.key("element");
     const sectionIndex = __cf_pattern_input.key("index");
     const state = __cf_pattern_input.key("params", "state");
@@ -486,7 +486,7 @@ const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
         } as const satisfies __cfHelpers.JSONSchema, {} as const satisfies __cfHelpers.JSONSchema, section.key("expanded"), <div>
                     {/* [TRANSFORM] .map() → mapWithPattern: section.tasks is reactive pattern-owned data */}
                     {/* [TRANSFORM] closure captures: selectedTaskId, hoveredSectionId, section, sectionIndex, state (all via params) */}
-                    {section.key("tasks").mapWithPattern(__cfPattern_2, {
+                    {section.key("tasks").mapWithPattern(__cfPattern_he515ddba3102, {
                 selectedTaskId: selectedTaskId,
                 hoveredSectionId: hoveredSectionId,
                 section: {
@@ -498,7 +498,7 @@ const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
                     showCompleted: state.key("showCompleted")
                 }
             })}
-                  </div>, __cfLift_4({ section: {
+                  </div>, __cfLift_hdc8e33263517({ section: {
                 tasks: {
                     length: section.key("tasks", "length")
                 },
@@ -624,7 +624,7 @@ export default pattern((state) => {
         type: ["string", "undefined"]
     } as const satisfies __cfHelpers.JSONSchema).for("hoveredSectionId", true);
     // [TRANSFORM] computed() -> lift(): captures state.sections (asCell — Writable<Section[]>)
-    const hasSections = __cfLift_1({ state: {
+    const hasSections = __cfLift_h684f660abd51({ state: {
             sections: state.key("sections")
         } }).for("hasSections", true);
     return {
@@ -645,7 +645,7 @@ export default pattern((state) => {
         } as const satisfies __cfHelpers.JSONSchema, {} as const satisfies __cfHelpers.JSONSchema, hasSections, <div>
             {/* [TRANSFORM] .map() → mapWithPattern: state.sections is Writable<Section[]> — reactive, pattern context */}
             {/* [TRANSFORM] closure captures: state (reactive), selectedTaskId (Writable), hoveredSectionId (Writable) */}
-            {state.key("sections").mapWithPattern(__cfPattern_3, {
+            {state.key("sections").mapWithPattern(__cfPattern_h4dcc24e464fa, {
                 state: {
                     globalAccent: state.key("globalAccent"),
                     showCompleted: state.key("showCompleted")
@@ -770,11 +770,18 @@ function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
     selectTask,
-    __cfLift_1,
-    __cfLift_2,
-    __cfLift_3,
-    __cfPattern_1,
-    __cfPattern_2,
-    __cfLift_4,
-    __cfPattern_3
+    __cfLift_h684f660abd51,
+    __cfLift_h78fd377906a6,
+    __cfLift_h45179e144554,
+    __cfPattern_heaa3a32a7fcf,
+    __cfPattern_he515ddba3102,
+    __cfLift_hdc8e33263517,
+    __cfPattern_h4dcc24e464fa,
+    __cfLift_1: __cfLift_h684f660abd51,
+    __cfLift_2: __cfLift_h78fd377906a6,
+    __cfLift_3: __cfLift_h45179e144554,
+    __cfPattern_1: __cfPattern_heaa3a32a7fcf,
+    __cfPattern_2: __cfPattern_he515ddba3102,
+    __cfLift_4: __cfLift_hdc8e33263517,
+    __cfPattern_3: __cfPattern_h4dcc24e464fa
 });

--- a/packages/ts-transformers/test/fixtures/schema-injection/builder-input-path-shrink.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/builder-input-path-shrink.expected.jsx
@@ -32,8 +32,8 @@ const deriveInput: Writable<{
     foo: string;
     bar: string;
 }> = __cfHelpers.__cf_data({} as never);
-const __cfLift_1 = __cfHelpers.lift(() => deriveInput.key("foo").get(), false, undefined, { completeSchedulerScopeSummary: true });
-const computedObserved = __cfHelpers.__cf_data(__cfLift_1().for("computedObserved", true));
+const __cfLift_hbc33c525c128 = __cfHelpers.lift(() => deriveInput.key("foo").get(), false, undefined, { completeSchedulerScopeSummary: true });
+const computedObserved = __cfHelpers.__cf_data(__cfLift_hbc33c525c128().for("computedObserved", true));
 const handlerObserved = handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
@@ -130,7 +130,7 @@ const liftExplicit = lift((input) => input.key("foo").get(), {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+const __cfHandler_h92f4cf8b6b9f = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
         input: {
@@ -150,7 +150,7 @@ const actionPattern = pattern((input: Writable<{
     foo: string;
     bar: string;
 }>) => {
-    const a = __cfHandler_1({
+    const a = __cfHandler_h92f4cf8b6b9f({
         input: input
     }).for({ stream: "a" }, true);
     return a;
@@ -184,12 +184,14 @@ function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
     liftOptional,
-    __cfLift_1,
+    __cfLift_hbc33c525c128,
     handlerObserved,
     handlerExplicit,
     liftInterprocedural,
     liftWriteOnly,
     liftExplicit,
     actionPattern,
-    __cfHandler_1
+    __cfHandler_h92f4cf8b6b9f,
+    __cfLift_1: __cfLift_hbc33c525c128,
+    __cfHandler_1: __cfHandler_h92f4cf8b6b9f
 });

--- a/packages/ts-transformers/test/fixtures/schema-injection/capability-wrapper-narrowing.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/capability-wrapper-narrowing.expected.jsx
@@ -137,7 +137,7 @@ const comparable = lift((input: Writable<State>) => input.equals(input), {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hfe30f5cc84bb = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return item.key("id");
 }, {
@@ -165,7 +165,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const opaqueMap = lift((input: Writable<Item[]>) => input.mapWithPattern(__cfPattern_1, {}), {
+const opaqueMap = lift((input: Writable<Item[]>) => input.mapWithPattern(__cfPattern_hfe30f5cc84bb, {}), {
     type: "array",
     items: {
         $ref: "#/$defs/Item"
@@ -196,5 +196,6 @@ export { comparable, opaqueMap, pushOnly, readOnly, readWrite, setOnly, updateOn
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfPattern_1
+    __cfPattern_hfe30f5cc84bb,
+    __cfPattern_1: __cfPattern_hfe30f5cc84bb
 });

--- a/packages/ts-transformers/test/fixtures/schema-injection/context-lift-result-property-projection-shorthand.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/context-lift-result-property-projection-shorthand.expected.jsx
@@ -47,7 +47,7 @@ const liftSummary = lift(({ primary, secondary }) => {
     },
     required: ["primary", "secondary", "difference"]
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h96ef859499ed = __cfHelpers.lift<{
     summary: {
         difference: any;
     };
@@ -71,7 +71,7 @@ export default pattern((__cf_pattern_input) => {
     const primary = __cf_pattern_input.key("primary");
     const secondary = __cf_pattern_input.key("secondary");
     const summary = liftSummary({ primary: primary.for(["summary", "primary"], true), secondary: secondary.for(["summary", "secondary"], true) }).for("summary", true);
-    const difference = __cfLift_1({ summary: {
+    const difference = __cfLift_h96ef859499ed({ summary: {
             difference: summary.key("difference")
         } }).for("difference", true);
     return { difference };
@@ -100,5 +100,6 @@ function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
     liftSummary,
-    __cfLift_1
+    __cfLift_h96ef859499ed,
+    __cfLift_1: __cfLift_h96ef859499ed
 });

--- a/packages/ts-transformers/test/fixtures/schema-injection/context-lift-result-property-projection.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/context-lift-result-property-projection.expected.jsx
@@ -47,7 +47,7 @@ const liftSummary = lift(({ primary, secondary }) => {
     },
     required: ["primary", "secondary", "difference"]
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h96ef859499ed = __cfHelpers.lift<{
     summary: {
         difference: any;
     };
@@ -74,7 +74,7 @@ export default pattern((__cf_pattern_input) => {
     const primary = __cf_pattern_input.key("primary");
     const secondary = __cf_pattern_input.key("secondary");
     const summary = liftSummary({ primary: primary.for(["summary", "primary"], true), secondary: secondary.for(["summary", "secondary"], true) }).for("summary", true);
-    const difference = __cfLift_1({ summary: {
+    const difference = __cfLift_h96ef859499ed({ summary: {
             difference: summary.key("difference")
         } }).for("difference", true);
     return {
@@ -107,5 +107,6 @@ function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
     liftSummary,
-    __cfLift_1
+    __cfLift_h96ef859499ed,
+    __cfLift_1: __cfLift_h96ef859499ed
 });

--- a/packages/ts-transformers/test/fixtures/schema-injection/default-survives-capture-shrink.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/default-survives-capture-shrink.expected.jsx
@@ -39,7 +39,7 @@ interface Input {
     items: Item[];
     boxes: Tagged<number>[];
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h92f89a953010 = __cfHelpers.lift<{
     items: {
         done: boolean | (false & { readonly [DEFAULT_MARKER]: false; });
     }[];
@@ -64,7 +64,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_h9f7ff89c3038 = __cfHelpers.lift<{
     items: {
         label: string | (string & { readonly [DEFAULT_MARKER]: ""; });
     }[];
@@ -89,7 +89,7 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_3 = __cfHelpers.lift<{
+const __cfLift_h3f01798c9e11 = __cfHelpers.lift<{
     items: {
         rank: number | (number & { readonly [DEFAULT_MARKER]: 7; });
     }[];
@@ -114,7 +114,7 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_4 = __cfHelpers.lift<{
+const __cfLift_hd693c8f0c88c = __cfHelpers.lift<{
     boxes: {
         note: string | (string & { readonly [DEFAULT_MARKER]: "n/a"; });
     }[];
@@ -142,10 +142,10 @@ const __cfLift_4 = __cfHelpers.lift<{
 export default pattern((__cf_pattern_input) => {
     const items = __cf_pattern_input.key("items");
     const boxes = __cf_pattern_input.key("boxes");
-    const firstDone = __cfLift_1({ items: items }).for("firstDone", true);
-    const firstLabelEmpty = __cfLift_2({ items: items }).for("firstLabelEmpty", true);
-    const firstRank = __cfLift_3({ items: items }).for("firstRank", true);
-    const firstBoxNote = __cfLift_4({ boxes: boxes }).for("firstBoxNote", true);
+    const firstDone = __cfLift_h92f89a953010({ items: items }).for("firstDone", true);
+    const firstLabelEmpty = __cfLift_h9f7ff89c3038({ items: items }).for("firstLabelEmpty", true);
+    const firstRank = __cfLift_h3f01798c9e11({ items: items }).for("firstRank", true);
+    const firstBoxNote = __cfLift_hd693c8f0c88c({ boxes: boxes }).for("firstBoxNote", true);
     return { firstDone, firstLabelEmpty, firstRank, firstBoxNote };
 }, {
     type: "object",
@@ -216,8 +216,12 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2,
-    __cfLift_3,
-    __cfLift_4
+    __cfLift_h92f89a953010,
+    __cfLift_h9f7ff89c3038,
+    __cfLift_h3f01798c9e11,
+    __cfLift_hd693c8f0c88c,
+    __cfLift_1: __cfLift_h92f89a953010,
+    __cfLift_2: __cfLift_h9f7ff89c3038,
+    __cfLift_3: __cfLift_h3f01798c9e11,
+    __cfLift_4: __cfLift_hd693c8f0c88c
 });

--- a/packages/ts-transformers/test/fixtures/schema-injection/default-survives-path-lowering.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/default-survives-path-lowering.expected.jsx
@@ -31,7 +31,7 @@ interface Settings {
 interface Input {
     settings: Settings;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hd71ee5e7e564 = __cfHelpers.lift<{
     settings: {
         note: string | (string & { readonly [DEFAULT_MARKER]: "n/a"; });
     };
@@ -53,7 +53,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_hb214eb60162b = __cfHelpers.lift<{
     settings: {
         count: number | (number & { readonly [DEFAULT_MARKER]: 3; });
     };
@@ -75,7 +75,7 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_3 = __cfHelpers.lift<{
+const __cfLift_h469941f83a9a = __cfHelpers.lift<{
     settings: {
         enabled: boolean | (false & { readonly [DEFAULT_MARKER]: true; }) | (true & { readonly [DEFAULT_MARKER]: true; });
     };
@@ -99,13 +99,13 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
 export default pattern((__cf_pattern_input) => {
     const settings = __cf_pattern_input.key("settings");
-    const noteIsUnset = __cfLift_1({ settings: {
+    const noteIsUnset = __cfLift_hd71ee5e7e564({ settings: {
             note: settings.key("note")
         } }).for("noteIsUnset", true);
-    const countTimesTwo = __cfLift_2({ settings: {
+    const countTimesTwo = __cfLift_hb214eb60162b({ settings: {
             count: settings.key("count")
         } }).for("countTimesTwo", true);
-    const isEnabled = __cfLift_3({ settings: {
+    const isEnabled = __cfLift_h469941f83a9a({ settings: {
             enabled: settings.key("enabled")
         } }).for("isEnabled", true);
     return { noteIsUnset, countTimesTwo, isEnabled };
@@ -156,7 +156,10 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2,
-    __cfLift_3
+    __cfLift_hd71ee5e7e564,
+    __cfLift_hb214eb60162b,
+    __cfLift_h469941f83a9a,
+    __cfLift_1: __cfLift_hd71ee5e7e564,
+    __cfLift_2: __cfLift_hb214eb60162b,
+    __cfLift_3: __cfLift_h469941f83a9a
 });

--- a/packages/ts-transformers/test/fixtures/schema-injection/index-signature-extras-optional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/index-signature-extras-optional.expected.jsx
@@ -27,7 +27,7 @@ interface TaggedItem {
 interface Input {
     items: TaggedItem[];
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h665cafd00974 = __cfHelpers.lift<{
     items: {
         priority?: any;
     }[];
@@ -48,7 +48,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_hc7b56ac5455a = __cfHelpers.lift<{
     items: {
         label: string;
     }[];
@@ -75,9 +75,9 @@ const __cfLift_2 = __cfHelpers.lift<{
 export default pattern((__cf_pattern_input) => {
     const items = __cf_pattern_input.key("items");
     // Extras key: only exists on some elements; must shrink to `priority?`.
-    const extraIsNine = __cfLift_1({ items: items }).for("extraIsNine", true);
+    const extraIsNine = __cfLift_h665cafd00974({ items: items }).for("extraIsNine", true);
     // Declared key for contrast: stays required as before.
-    const labelIsGamma = __cfLift_2({ items: items }).for("labelIsGamma", true);
+    const labelIsGamma = __cfLift_hc7b56ac5455a({ items: items }).for("labelIsGamma", true);
     return { extraIsNine, labelIsGamma };
 }, {
     type: "object",
@@ -121,6 +121,8 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2
+    __cfLift_h665cafd00974,
+    __cfLift_hc7b56ac5455a,
+    __cfLift_1: __cfLift_h665cafd00974,
+    __cfLift_2: __cfLift_hc7b56ac5455a
 });

--- a/packages/ts-transformers/test/fixtures/schema-transform/boolean-result-schema-normalization.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/boolean-result-schema-normalization.expected.jsx
@@ -11,7 +11,7 @@ import { pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h1ceb9e35cb2e = __cfHelpers.lift<{
     state: {
         score: number;
     };
@@ -54,7 +54,7 @@ export default pattern((state: {
             type: "boolean"
         } as const satisfies __cfHelpers.JSONSchema, {
             type: "boolean"
-        } as const satisfies __cfHelpers.JSONSchema, state.key("isPremium"), __cfLift_1({ state: {
+        } as const satisfies __cfHelpers.JSONSchema, state.key("isPremium"), __cfLift_h1ceb9e35cb2e({ state: {
                 score: state.key("score")
             } })), "Premium", "Regular")}</div>,
     };
@@ -103,5 +103,6 @@ export default pattern((state: {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_h1ceb9e35cb2e,
+    __cfLift_1: __cfLift_h1ceb9e35cb2e
 });

--- a/packages/ts-transformers/test/fixtures/schema-transform/cell-get-binding-autowrap.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/cell-get-binding-autowrap.expected.jsx
@@ -11,7 +11,7 @@ import { pattern, Writable } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h0939521a2ccd = __cfHelpers.lift<{
     layout: __cfHelpers.Writable<string>;
 }, number>(({ layout }) => layout.get().trim().length, {
     type: "object",
@@ -36,7 +36,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 //   `cell-get-terminal-binding-autowrap`.
 export default pattern((__cf_pattern_input) => {
     const layout = __cf_pattern_input.key("layout");
-    const len = __cfLift_1({ layout: layout }).for("len", true);
+    const len = __cfLift_h0939521a2ccd({ layout: layout }).for("len", true);
     return { len };
 }, {
     type: "object",
@@ -60,5 +60,6 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_h0939521a2ccd,
+    __cfLift_1: __cfLift_h0939521a2ccd
 });

--- a/packages/ts-transformers/test/fixtures/schema-transform/cell-get-derived-collection-map-paren-builder.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/cell-get-derived-collection-map-paren-builder.expected.jsx
@@ -15,7 +15,7 @@ interface Row {
     label: string;
     keep: boolean;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h6e93f541fe6d = __cfHelpers.lift<{
     rows: __cfHelpers.Writable<Row[]>;
 }, readonly Row[]>(({ rows }) => rows.get(), {
     type: "object",
@@ -63,7 +63,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h370484f37ccb = __cfHelpers.pattern(__cf_pattern_input => {
     const r = __cf_pattern_input.key("element");
     return r.key("keep");
 }, {
@@ -91,7 +91,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hfd5c00670ad6 = __cfHelpers.pattern(__cf_pattern_input => {
     const v = __cf_pattern_input.key("element");
     return <li>{v.key("label")}</li>;
 }, {
@@ -147,10 +147,10 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
 //   transparent parens (§5.7 paren-invariance).
 export default pattern((__cf_pattern_input) => {
     const rows = __cf_pattern_input.key("rows");
-    const view = __cfLift_1({ rows: rows }).filterWithPattern(__cfPattern_1, {}).for("view", true);
+    const view = __cfLift_h6e93f541fe6d({ rows: rows }).filterWithPattern(__cfPattern_h370484f37ccb, {}).for("view", true);
     return {
         [UI]: (<ul>
-        {view.mapWithPattern(__cfPattern_2, {})}
+        {view.mapWithPattern(__cfPattern_hfd5c00670ad6, {})}
       </ul>),
         view,
     };
@@ -232,7 +232,10 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfPattern_1,
-    __cfPattern_2
+    __cfLift_h6e93f541fe6d,
+    __cfPattern_h370484f37ccb,
+    __cfPattern_hfd5c00670ad6,
+    __cfLift_1: __cfLift_h6e93f541fe6d,
+    __cfPattern_1: __cfPattern_h370484f37ccb,
+    __cfPattern_2: __cfPattern_hfd5c00670ad6
 });

--- a/packages/ts-transformers/test/fixtures/schema-transform/cell-get-derived-collection-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/cell-get-derived-collection-map.expected.jsx
@@ -15,7 +15,7 @@ interface Row {
     label: string;
     keep: boolean;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h6e93f541fe6d = __cfHelpers.lift<{
     rows: __cfHelpers.Writable<Row[]>;
 }, readonly Row[]>(({ rows }) => rows.get(), {
     type: "object",
@@ -63,7 +63,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h370484f37ccb = __cfHelpers.pattern(__cf_pattern_input => {
     const r = __cf_pattern_input.key("element");
     return r.key("keep");
 }, {
@@ -91,7 +91,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_ha854a0c40711 = __cfHelpers.lift<{
     view: Row[];
 }, boolean>(({ view }) => view.length > 0, {
     type: "object",
@@ -107,7 +107,7 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h578460d853bc = __cfHelpers.pattern(__cf_pattern_input => {
     const v = __cf_pattern_input.key("element");
     return v.key("label");
 }, {
@@ -135,7 +135,7 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hfd5c00670ad6 = __cfHelpers.pattern(__cf_pattern_input => {
     const v = __cf_pattern_input.key("element");
     return <li>{v.key("label")}</li>;
 }, {
@@ -181,7 +181,7 @@ const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_4 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_he8f19eda4470 = __cfHelpers.pattern(__cf_pattern_input => {
     const v = __cf_pattern_input.key("element");
     return <em>{v.key("label")}</em>;
 }, {
@@ -242,13 +242,13 @@ const __cfPattern_4 = __cfHelpers.pattern(__cf_pattern_input => {
 //   boolean-consumer lift over the same local.
 export default pattern((__cf_pattern_input) => {
     const rows = __cf_pattern_input.key("rows");
-    const view = __cfLift_1({ rows: rows }).filterWithPattern(__cfPattern_1, {}).for("view", true);
-    const hasAny = __cfLift_2({ view: view }).for("hasAny", true);
-    const labels = view.mapWithPattern(__cfPattern_2, {}).for("labels", true);
+    const view = __cfLift_h6e93f541fe6d({ rows: rows }).filterWithPattern(__cfPattern_h370484f37ccb, {}).for("view", true);
+    const hasAny = __cfLift_ha854a0c40711({ view: view }).for("hasAny", true);
+    const labels = view.mapWithPattern(__cfPattern_h578460d853bc, {}).for("labels", true);
     return {
         [UI]: (<section>
         <ul>
-          {view.mapWithPattern(__cfPattern_3, {})}
+          {view.mapWithPattern(__cfPattern_hfd5c00670ad6, {})}
         </ul>
         {__cfHelpers.ifElse({
             type: "boolean"
@@ -267,7 +267,7 @@ export default pattern((__cf_pattern_input) => {
                     properties: {}
                 }]
         } as const satisfies __cfHelpers.JSONSchema, hasAny, <div>
-              {view.mapWithPattern(__cfPattern_4, {})}
+              {view.mapWithPattern(__cfPattern_he8f19eda4470, {})}
             </div>, null)}
       </section>),
         labels,
@@ -338,10 +338,16 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfPattern_1,
-    __cfLift_2,
-    __cfPattern_2,
-    __cfPattern_3,
-    __cfPattern_4
+    __cfLift_h6e93f541fe6d,
+    __cfPattern_h370484f37ccb,
+    __cfLift_ha854a0c40711,
+    __cfPattern_h578460d853bc,
+    __cfPattern_hfd5c00670ad6,
+    __cfPattern_he8f19eda4470,
+    __cfLift_1: __cfLift_h6e93f541fe6d,
+    __cfPattern_1: __cfPattern_h370484f37ccb,
+    __cfLift_2: __cfLift_ha854a0c40711,
+    __cfPattern_2: __cfPattern_h578460d853bc,
+    __cfPattern_3: __cfPattern_hfd5c00670ad6,
+    __cfPattern_4: __cfPattern_he8f19eda4470
 });

--- a/packages/ts-transformers/test/fixtures/schema-transform/cell-get-terminal-binding-autowrap.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/cell-get-terminal-binding-autowrap.expected.jsx
@@ -15,7 +15,7 @@ interface Row {
     sentAt: number;
     body: string;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h6e3cc74f1dd3 = __cfHelpers.lift<{
     rows: __cfHelpers.Writable<Row[]>;
 }, number>(({ rows }) => rows.get().length, {
     type: "object",
@@ -32,7 +32,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_2 = __cfHelpers.lift<{
+const __cfLift_h6e93f541fe6d = __cfHelpers.lift<{
     rows: __cfHelpers.Writable<Row[]>;
 }, readonly Row[]>(({ rows }) => rows.get(), {
     type: "object",
@@ -80,7 +80,7 @@ const __cfLift_2 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_3 = __cfHelpers.lift<{
+const __cfLift_hb4c16d0a1435 = __cfHelpers.lift<{
     rows: __cfHelpers.Writable<Row[]>;
 }, Row | undefined>(({ rows }) => rows.get()[0], {
     type: "object",
@@ -129,7 +129,7 @@ const __cfLift_3 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_4 = __cfHelpers.lift<{
+const __cfLift_h982e956d5205 = __cfHelpers.lift<{
     rows: __cfHelpers.Writable<Row[]>;
 }, string>(({ rows }) => rows.get().join(","), {
     type: "object",
@@ -160,7 +160,7 @@ const __cfLift_4 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_5 = __cfHelpers.lift<{
+const __cfLift_h6e93f541fe6d_2 = __cfHelpers.lift<{
     rows: __cfHelpers.Writable<Row[]>;
 }, readonly Row[]>(({ rows }) => rows.get(), {
     type: "object",
@@ -208,7 +208,7 @@ const __cfLift_5 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_6 = __cfHelpers.lift<{
+const __cfLift_h994a3cd6b58c = __cfHelpers.lift<{
     row: {
         sentAt: number;
     };
@@ -229,9 +229,9 @@ const __cfLift_6 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hcf51934bbcbe = __cfHelpers.pattern(__cf_pattern_input => {
     const row = __cf_pattern_input.key("element");
-    return __cfLift_6({ row: {
+    return __cfLift_h994a3cd6b58c({ row: {
             sentAt: row.key("sentAt")
         } }).for("__patternResult", true);
 }, {
@@ -259,7 +259,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_7 = __cfHelpers.lift<{
+const __cfLift_hd457b85824ad = __cfHelpers.lift<{
     label?: __cfHelpers.Writable<string> | undefined;
 }, string | undefined>(({ label }) => label?.get(), {
     type: "object",
@@ -292,12 +292,12 @@ const __cfLift_7 = __cfHelpers.lift<{
 export default pattern((__cf_pattern_input) => {
     const rows = __cf_pattern_input.key("rows");
     const label = __cf_pattern_input.key("label");
-    const count = __cfLift_1({ rows: rows }).for("count", true);
-    const all = __cfLift_2({ rows: rows }).for("all", true);
-    const first = __cfLift_3({ rows: rows }).for("first", true);
-    const joined = __cfLift_4({ rows: rows }).for("joined", true);
-    const recent = __cfLift_5({ rows: rows }).filterWithPattern(__cfPattern_1, {}).for("recent", true);
-    const optional = __cfLift_7({ label: label }).for("optional", true);
+    const count = __cfLift_h6e3cc74f1dd3({ rows: rows }).for("count", true);
+    const all = __cfLift_h6e93f541fe6d({ rows: rows }).for("all", true);
+    const first = __cfLift_hb4c16d0a1435({ rows: rows }).for("first", true);
+    const joined = __cfLift_h982e956d5205({ rows: rows }).for("joined", true);
+    const recent = __cfLift_h6e93f541fe6d_2({ rows: rows }).filterWithPattern(__cfPattern_hcf51934bbcbe, {}).for("recent", true);
+    const optional = __cfLift_hd457b85824ad({ label: label }).for("optional", true);
     return { count, all, first, joined, recent, optional };
 }, {
     type: "object",
@@ -381,12 +381,20 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1,
-    __cfLift_2,
-    __cfLift_3,
-    __cfLift_4,
-    __cfLift_5,
-    __cfLift_6,
-    __cfPattern_1,
-    __cfLift_7
+    __cfLift_h6e3cc74f1dd3,
+    __cfLift_h6e93f541fe6d,
+    __cfLift_hb4c16d0a1435,
+    __cfLift_h982e956d5205,
+    __cfLift_h6e93f541fe6d_2,
+    __cfLift_h994a3cd6b58c,
+    __cfPattern_hcf51934bbcbe,
+    __cfLift_hd457b85824ad,
+    __cfLift_1: __cfLift_h6e3cc74f1dd3,
+    __cfLift_2: __cfLift_h6e93f541fe6d,
+    __cfLift_3: __cfLift_hb4c16d0a1435,
+    __cfLift_4: __cfLift_h982e956d5205,
+    __cfLift_5: __cfLift_h6e93f541fe6d_2,
+    __cfLift_6: __cfLift_h994a3cd6b58c,
+    __cfPattern_1: __cfPattern_hcf51934bbcbe,
+    __cfLift_7: __cfLift_hd457b85824ad
 });

--- a/packages/ts-transformers/test/fixtures/schema-transform/pattern-any-result-override.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/pattern-any-result-override.expected.jsx
@@ -13,7 +13,7 @@ const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
 // Simulates `any` leaking through a generic function (like generateObject)
 declare function fetchAny(): any;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hba4cf0446c2a = __cfHelpers.lift<{
     result: any;
     prompt: string;
 }, any>(({ result, prompt }) => result?.title || prompt || "Untitled", {
@@ -35,7 +35,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 export const TypedFromAny = pattern((__cf_pattern_input) => {
     const prompt = __cf_pattern_input.key("prompt");
     const result = fetchAny();
-    return __cfLift_1({
+    return __cfLift_hba4cf0446c2a({
         result: result,
         prompt: prompt
     });
@@ -80,5 +80,6 @@ export const TypedUIOutput = pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_hba4cf0446c2a,
+    __cfLift_1: __cfLift_hba4cf0446c2a
 });

--- a/packages/ts-transformers/test/fixtures/schema-transform/pattern-explicit-types.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/pattern-explicit-types.expected.jsx
@@ -17,7 +17,7 @@ interface Input {
 interface Output extends Input {
     bar: number;
 }
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h32a2c448187a = __cfHelpers.lift<{
     input: { foo: string; } & {} & { [SELF]: Output; };
 }, { bar: number; foo: string; [SELF]: Output; }>(({ input }) => ({ ...input, bar: 123 }), {
     type: "object",
@@ -50,7 +50,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 //   pattern<Input, Output>() → input schema from Input, output schema from Output (includes inherited fields)
 //   Output extends Input → output schema includes both own (bar) and inherited (foo) properties
 export default pattern((input) => {
-    return __cfLift_1({ input: input }).for("__patternResult", true);
+    return __cfLift_h32a2c448187a({ input: input }).for("__patternResult", true);
 }, {
     type: "object",
     properties: {
@@ -75,5 +75,6 @@ export default pattern((input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_h32a2c448187a,
+    __cfLift_1: __cfLift_h32a2c448187a
 });

--- a/packages/ts-transformers/test/fixtures/schema-transform/pattern-with-types.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/pattern-with-types.expected.jsx
@@ -134,7 +134,7 @@ const addItem = handler // <
 }) => {
     items.push({ text: event.detail.message });
 });
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hf4a79a3cefa7 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const index = __cf_pattern_input.key("index");
     return (<li key={index}>{item.key("text")}</li>);
@@ -200,7 +200,7 @@ export default pattern((__cf_pattern_input) => {
         <p>Basic pattern</p>
         <p>Items count: {items_count}</p>
         <ul>
-          {items.mapWithPattern(__cfPattern_1, {})}
+          {items.mapWithPattern(__cfPattern_hf4a79a3cefa7, {})}
         </ul>
         <cf-message-input name="Send" placeholder="Type a message..." appearance="rounded" oncf-send={addItem({ items })}/>
       </div>),
@@ -273,5 +273,6 @@ function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
     addItem,
-    __cfPattern_1
+    __cfPattern_hf4a79a3cefa7,
+    __cfPattern_1: __cfPattern_hf4a79a3cefa7
 });

--- a/packages/ts-transformers/test/fixtures/schema-transform/reactive-array-element-access-schema.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/reactive-array-element-access-schema.expected.jsx
@@ -11,7 +11,7 @@ import { cell, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_h688cce498d95 = __cfHelpers.lift<{
     items: __cfHelpers.Cell<string[]>;
     index: __cfHelpers.Cell<number>;
 }, string | undefined>(({ items, index }) => items.get()[index.get()], {
@@ -47,7 +47,7 @@ export default pattern((_state) => {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema).for("index", true);
     return {
-        [UI]: <div>{__cfLift_1({
+        [UI]: <div>{__cfLift_h688cce498d95({
             items: items,
             index: index
         })}</div>,
@@ -86,5 +86,6 @@ export default pattern((_state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_h688cce498d95,
+    __cfLift_1: __cfLift_h688cce498d95
 });

--- a/packages/ts-transformers/test/fixtures/schema-transform/reactive-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/reactive-map.expected.jsx
@@ -15,7 +15,7 @@ interface TodoItem {
     title: string;
     done: boolean;
 }
-const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_hd349f6e34126 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return item.key("title");
 }, {
@@ -43,7 +43,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_h7731df73031f = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const index = __cf_pattern_input.key("index");
     return ({
@@ -99,9 +99,9 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
 export default pattern((__cf_pattern_input) => {
     const items = __cf_pattern_input.key("items");
     // Map on opaque ref arrays should be transformed to mapWithPattern
-    const mapped = items.mapWithPattern(__cfPattern_1, {}).for("mapped", true);
+    const mapped = items.mapWithPattern(__cfPattern_hd349f6e34126, {}).for("mapped", true);
     // This should also be transformed
-    const filtered = items.mapWithPattern(__cfPattern_2, {}).for("filtered", true);
+    const filtered = items.mapWithPattern(__cfPattern_h7731df73031f, {}).for("filtered", true);
     return { mapped, filtered };
 }, {
     type: "object",
@@ -162,6 +162,8 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfPattern_1,
-    __cfPattern_2
+    __cfPattern_hd349f6e34126,
+    __cfPattern_h7731df73031f,
+    __cfPattern_1: __cfPattern_hd349f6e34126,
+    __cfPattern_2: __cfPattern_h7731df73031f
 });

--- a/packages/ts-transformers/test/fixtures/schema-transform/with-reactive.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/with-reactive.expected.jsx
@@ -27,7 +27,7 @@ const model = __cfHelpers.__cf_data({
         value: 0
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_hfa486dfebf88 = __cfHelpers.lift<{
     cell: {
         value: __cfHelpers.Cell<number>;
     };
@@ -55,7 +55,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 //   toSchema<State>({default: ...}) → schema with "default" key preserved
 //   bare `cell.value.get() * 2` → auto-wraps, capturing cell.key("value") into lift(inputSchema, outputSchema, fn)
 export default pattern((cell) => {
-    const doubled = __cfLift_1({ cell: {
+    const doubled = __cfLift_hfa486dfebf88({ cell: {
             value: cell.key("value")
         } }).for("doubled", true);
     return {
@@ -88,5 +88,6 @@ export default pattern((cell) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    __cfLift_1
+    __cfLift_hfa486dfebf88,
+    __cfLift_1: __cfLift_hfa486dfebf88
 });

--- a/packages/ts-transformers/test/hoist-symbol-stability.test.ts
+++ b/packages/ts-transformers/test/hoist-symbol-stability.test.ts
@@ -1,0 +1,117 @@
+import { assert, assertEquals } from "@std/assert";
+import { transformSource } from "./utils.ts";
+
+/**
+ * Content-addressed hoist symbols (the fix for source-order numbering
+ * stranding deployed pieces): a hoist's canonical name is a digest of its own
+ * canonical print, so inserting, removing, or reordering OTHER hoists must
+ * not re-key an existing one. These tests pin the three load-bearing
+ * properties: insertion stability, twin determinism, and positional-alias
+ * emission.
+ */
+
+const PATTERN_HASH_NAME = /__cfPattern_h[0-9a-f]{12}(?:_[2-9]\d*)?/g;
+
+function patternNames(output: string): Set<string> {
+  return new Set(output.match(PATTERN_HASH_NAME) ?? []);
+}
+
+const TWO_MAPS = `
+import { pattern } from "commonfabric";
+
+interface Item {
+  title: string;
+  done: boolean;
+}
+
+export default pattern<{ items: Item[] }>(({ items }) => {
+  const titles = items.map((item) => item.title);
+  const flags = items.map((item) => item.done);
+  return { titles, flags };
+});
+`;
+
+// The same file with a NEW map inserted AHEAD of both existing ones — the
+// exact edit that renumbered `_2` to `_4` under the positional scheme.
+const THREE_MAPS = TWO_MAPS.replace(
+  "const titles",
+  "const lengths = items.map((item) => item.title.length);\n  const titles",
+);
+
+// Two byte-identical callbacks: same digest, so the second takes an
+// occurrence ordinal.
+const TWIN_MAPS = `
+import { pattern } from "commonfabric";
+
+interface Item {
+  title: string;
+}
+
+export default pattern<{ items: Item[] }>(({ items }) => {
+  const a = items.map((item) => item.title);
+  const b = items.map((item) => item.title);
+  return { a, b };
+});
+`;
+
+Deno.test("inserting a map ahead leaves existing canonical names untouched", async () => {
+  const two = await transformSource(TWO_MAPS);
+  const three = await transformSource(THREE_MAPS);
+  const twoNames = patternNames(two);
+  const threeNames = patternNames(three);
+  assertEquals(twoNames.size, 2, `expected 2 hoists in base: ${[...twoNames]}`);
+  assertEquals(
+    threeNames.size,
+    3,
+    `expected 3 hoists after insertion: ${[...threeNames]}`,
+  );
+  for (const name of twoNames) {
+    assert(
+      threeNames.has(name),
+      `existing hoist ${name} was re-keyed by an unrelated insertion; ` +
+        `after: ${[...threeNames]}`,
+    );
+  }
+});
+
+Deno.test("identical twins take deterministic occurrence ordinals", async () => {
+  const output = await transformSource(TWIN_MAPS);
+  const names = [...patternNames(output)];
+  assertEquals(names.length, 2, `expected exactly two names: ${names}`);
+  const [base, second] = names[0].length <= names[1].length
+    ? [names[0], names[1]]
+    : [names[1], names[0]];
+  assertEquals(
+    second,
+    `${base}_2`,
+    "twin must be the base name plus an occurrence ordinal",
+  );
+});
+
+Deno.test("positional aliases are registered beside canonical names", async () => {
+  const output = await transformSource(THREE_MAPS);
+  // Canonical shorthand first, then the visit-order alias naming the same
+  // binding — first-write-wins in the runtime's forward map is what makes new
+  // serializations canonical, so the ORDER is part of the contract.
+  const aliasMatches = [
+    ...output.matchAll(/__cfPattern_(\d+): (__cfPattern_h[0-9a-f]{12}\w*)/g),
+  ];
+  assertEquals(
+    aliasMatches.map((m) => m[1]),
+    ["1", "2", "3"],
+    "every hoist gets a visit-order alias",
+  );
+  for (const m of aliasMatches) {
+    assert(
+      output.indexOf(`${m[2]},`) < output.indexOf(`${m[1]}: ${m[2]}`) ||
+        output.indexOf(`${m[2]}\n`) < output.indexOf(`${m[1]}: ${m[2]}`),
+      `canonical ${m[2]} must be registered before its alias`,
+    );
+  }
+});
+
+Deno.test("hash names are deterministic across compilations", async () => {
+  const first = await transformSource(TWO_MAPS);
+  const second = await transformSource(TWO_MAPS);
+  assertEquals(patternNames(first), patternNames(second));
+});

--- a/packages/ts-transformers/test/lineage-regression.test.ts
+++ b/packages/ts-transformers/test/lineage-regression.test.ts
@@ -166,7 +166,7 @@ interface BuilderSite {
   readonly callback: ts.ArrowFunction | ts.FunctionExpression | undefined;
 }
 
-const HOISTED_NAME = /^__cf(Lift|Pattern|Handler)_\d+$/;
+const HOISTED_NAME = /^__cf(Lift|Pattern|Handler)_(?:\d+|h[0-9a-f]+(?:_\d+)?)$/;
 
 /**
  * Every hoisted builder-artifact const (`const __cf{Lift,Pattern,Handler}_N =

--- a/packages/ts-transformers/test/pipeline-regressions.test.ts
+++ b/packages/ts-transformers/test/pipeline-regressions.test.ts
@@ -1248,7 +1248,7 @@ export default pattern<{ values: string[] }>(({ values }) => {
     const liftApply = forCall.expression.expression;
     assert(
       ts.isCallExpression(liftApply) && ts.isIdentifier(liftApply.expression) &&
-        /^__cfLift_\d+$/.test(liftApply.expression.text),
+        /^__cfLift_h[0-9a-f]+(?:_\d+)?$/.test(liftApply.expression.text),
       "expected the .for receiver to be a hoisted __cfLift_N application",
     );
     const liftArg = liftApply.arguments[0];

--- a/tasks/pattern-vintage-lib.test.ts
+++ b/tasks/pattern-vintage-lib.test.ts
@@ -1801,6 +1801,9 @@ describe("derived-hoist classification", () => {
   it("recognizes a transformer-emitted pattern hoist", () => {
     expect(isDerivedHoistSymbol("__cfPattern_4")).toBe(true);
     expect(isDerivedHoistSymbol("__cfPattern_12")).toBe(true);
+    // Content-addressed canonical names, bare and twin-ordinal-suffixed.
+    expect(isDerivedHoistSymbol("__cfPattern_h0123456789ab")).toBe(true);
+    expect(isDerivedHoistSymbol("__cfPattern_h0123456789ab_2")).toBe(true);
   });
 
   it("returns false for authored exports and other synthetics", () => {
@@ -1809,6 +1812,12 @@ describe("derived-hoist classification", () => {
     expect(isDerivedHoistSymbol("__cfLift_2")).toBe(false);
     expect(isDerivedHoistSymbol("__cfPattern_")).toBe(false);
     expect(isDerivedHoistSymbol("x__cfPattern_4")).toBe(false);
+    // Malformed content names: short digest, uppercase, ordinal 1 (never
+    // minted — the first twin keeps the bare name), lift-prefixed.
+    expect(isDerivedHoistSymbol("__cfPattern_h0123")).toBe(false);
+    expect(isDerivedHoistSymbol("__cfPattern_hABCDEF789012")).toBe(false);
+    expect(isDerivedHoistSymbol("__cfPattern_h0123456789ab_1")).toBe(false);
+    expect(isDerivedHoistSymbol("__cfLift_h0123456789ab")).toBe(false);
   });
 
   it("returns false for numbers the per-file counter never mints", () => {

--- a/tasks/pattern-vintage-lib.ts
+++ b/tasks/pattern-vintage-lib.ts
@@ -1243,21 +1243,28 @@ export function isClean(
 /**
  * Whether a recorded instantiation is a transformer-emitted pattern hoist —
  * an anonymous sub-pattern the compiler derives from the source (a mapped
- * row's body), as opposed to a pattern an author exports. The `__cfPattern_N`
- * name is the transformer's own emission convention, and N is a builder node
- * id with no stability across edits — which is exactly why nothing durable
- * may be addressed by it. The per-file counter starts at 1, so
- * `__cfPattern_0` is not a name the transformer mints.
+ * row's body), as opposed to a pattern an author exports. Two spellings are
+ * the transformer's own emission convention:
+ *
+ *   - `__cfPattern_h<digest>` (optionally `_k` twin-ordinal-suffixed) — the
+ *     content-addressed CANONICAL name: stable under insertion and reorder of
+ *     other hoists, re-keyed only when the hoisted call's own content changes.
+ *   - `__cfPattern_N` — the visit-order POSITIONAL alias, kept registered so
+ *     pointers stored under the historical numbering stay loadable. N is
+ *     positional with no stability across edits — which is exactly why new
+ *     durable references serialize under the canonical name instead. The
+ *     per-file counter starts at 1, so `__cfPattern_0` is not a name the
+ *     transformer mints.
  *
  * Spelling IS provenance, because registration enforces it: the runner
  * refuses an authored builder-artifact export in this namespace
  * (`RESERVED_HOIST_EXPORT`, `pattern-manager.ts`), and every path that runs
  * a pattern — the runtime's, and this gate's own capture and replay
- * compiles — goes through that seam. A symbol with this shape in a manifest
+ * compiles — goes through that seam. A symbol with either shape in a manifest
  * or the artifact index is the transformer's.
  */
 export function isDerivedHoistSymbol(symbol: string): boolean {
-  return /^__cfPattern_[1-9]\d*$/.test(symbol);
+  return /^__cfPattern_(?:[1-9]\d*|h[0-9a-f]{12}(?:_[2-9]\d*)?)$/.test(symbol);
 }
 
 /**


### PR DESCRIPTION
## What was wrong

A hoisted builder's symbol was its visit-order ordinal (`__cfPattern_2`), and that ordinal is the durable half of the `{identity, symbol}` reference deployed pieces store for their mapped sub-patterns (CT-1623 `$patternRef`). `identity` re-hashes on every version, so cross-version correlation rides the symbol — and inserting a `.map()` ahead of an existing one re-keyed every later hoist and stranded every piece instantiated from them. #5779 documented the class as "rule 2" (`_2` → `_4`), worked around it by ordering the UI so new maps come last, and the follow-up landed on the board as "Inline-pattern numbering strands deployed pieces". Layout as a deployment constraint was the smell: the first person who doesn't know the rule violates it, and the failure surfaces at vintage time, far from the edit.

## What changed

**Canonical names are content-addressed.** A hoist's name is now `__cfPattern_h<digest>` — a digest of the hoisted call's canonical print (comments stripped, line endings pinned). Hoisting runs after schema injection, so the print covers the callback *and* its baked schemas: formatting and comment edits never re-key; a schema change does, which is when the sub-pattern's contract genuinely changed. Identical twins take deterministic occurrence ordinals (`…_2`). Insertion, removal, and reordering of other hoists cannot re-key a hoist, **by construction** — the failure class this replaces ceases to exist rather than being policed.

**Positional aliases are permanent, not transitional.** Every hoist also registers its visit-order numeric name in the same `__cfReg` call, mapped to the canonical binding. This is what makes the stored archive immortal: by-identity cold loads recompile OLD source with the CURRENT toolchain, and a frozen source reproduces its visit order exactly — so every `{identity, symbol}` pointer ever stored keeps resolving under any future toolchain (including through future changes to the hash itself). Canonical entries precede aliases because the runtime's forward value→ref map is first-write-wins: new serializations are canonical-hash; the numeric spellings quietly serve the archive. The updater is never touched.

**Recognizers follow their own doctrine** ("a prohibition may safely exceed the convention it protects; a recognizer may not"): `RESERVED_HOIST_EXPORT` over-covers both spellings; `isDerivedHoistSymbol` matches exactly what is minted; the compiled-bundle verifier accepts precisely the alias pair shape — numeric-alias key, content-addressed value naming a declared top-level binding — and nothing else new, preserving the security property the shorthand-only rule existed for (every registered value IS a module-level binding).

The digest is FNV-1a 64 (first 12 hex chars), documented as **frozen**: it is part of the stored-data contract. The `h` marker keeps the content namespace disjoint from the numeric alias namespace even for an all-digit digest.

## Verification

- New `hoist-symbol-stability.test.ts`: insertion ahead leaves existing canonical names untouched; twins get deterministic ordinals; aliases register beside (and after) canonicals; names are deterministic across compilations
- `packages/ts-transformers`: full suite green (1168), including 294 goldens regenerated under `UPDATE_GOLDENS=1` — audited: every changed line is a name change or an alias line, zero collateral
- `cfreg-security`: alias-form positives and negatives (undeclared canonical, non-hoist value smuggled behind a numeric key — both refused)
- `pattern-vintage` green: the pinned fixtures store real numeric-symbol sentinels, so their clean replay IS the cross-flip acceptance — historical pointers resolving through the aliases
- `pattern-compat` green (contract surfaces don't carry hoist symbols; confirmed no baseline churn)
- Full runner + patterns suites green; `deno fmt` / `lint` / `check` clean

## Coordination

The permanent-alias registration shape touches `__cfReg`/PatternManager semantics — runtime owners' eyes wanted on that call specifically. The board topic carries the full mechanism dossier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6731?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

