### PR TITLE
refactor(runner): take `$alias` bindings out of the link model

### DIFF
--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -111,7 +111,8 @@ mapped in [`../README.md`](../README.md).
 - [`skill-audit.md`](skill-audit.md) — the two mechanisms that keep the facts
   in a skill honest, including the `deno task check-skill-facts` tripwire
 - [`runtime-glossary.md`](runtime-glossary.md) — the storage and memory
-  vocabulary of the runtime. Pattern authors want the
+  vocabulary of the runtime, including the difference between a link and an
+  `$alias` pattern binding. Pattern authors want the
   [author-facing glossary](../common/concepts/glossary.md) instead
 
 ## Tools

--- a/docs/development/runtime-glossary.md
+++ b/docs/development/runtime-glossary.md
@@ -43,6 +43,32 @@ entity while retaining the history that state was reached through.
 New information accretes through commits, whose optimistic concurrency is
 described under [confirmed and pending](#confirmed-and-pending) below.
 
+## Link
+
+A reference from one place in stored data to another. There is one link form,
+the sigil link `{ "/": { "link@1": { … } } }`, and it always addresses a
+document that exists: it carries the document's identifier, and a read or a
+write through it lands there. A link whose payload sets `overwrite: "redirect"`
+is a **write redirect**, meaning a write through it lands at the target rather
+than replacing the link.
+
+[Identity and References](../specs/space-model/3-identity-and-references.md)
+specifies the format; `runner/src/link-types.ts` defines it.
+
+## `$alias` Binding
+
+A record of the form `{ "$alias": { … } }`, found inside a saved pattern node
+graph. Despite the resemblance to a write redirect, this is **not a link**, and
+none of the link predicates match it: an `$alias` record sitting in ordinary
+data is ordinary data.
+
+A binding carries no document identifier. It names a position that acquires a
+document only when the pattern graph is instantiated — by role
+(`cell: "argument"`, `cell: "result"`), by derivation (`partialCause`), or at a
+nesting level not yet reached (`defer`). Instantiation resolves it into an
+ordinary write-redirect link. `runner/src/alias-binding.ts` defines the form
+and says why it stays separate from the link model.
+
 ## Commit
 
 A batch of operations submitted together, carrying the operations themselves,

--- a/docs/specs/memory-v2/04-protocol.md
+++ b/docs/specs/memory-v2/04-protocol.md
@@ -594,8 +594,8 @@ against the earlier revision continue to expand references at alias schema
 positions, so those positions remain covered by the reservation rule below.
 
 The `schema-ref@2:` prefix is reserved in the `schema` field of `link@1` and
-legacy `$alias` payloads. Link recognition follows the canonical cell-rep
-form — in the legacy representation, the single-key `{ "/": { "link@1": … } }`
+`$alias` payloads. Link recognition follows the canonical cell-rep form — in
+the legacy representation, the single-key `{ "/": { "link@1": … } }`
 envelope — so an envelope carrying sibling keys is not a link and its contents
 are ordinary data. Memory servers MUST reject set or patch operations
 whose resulting stored document uses that prefix as an opaque schema string in

--- a/docs/specs/space-model/3-identity-and-references.md
+++ b/docs/specs/space-model/3-identity-and-references.md
@@ -53,18 +53,27 @@ Example:
 }
 ```
 
-#### Legacy Formats
+#### Not a Link: `$alias` Bindings
 
-**`$alias` format** — no longer a link. Generic link recognition and parsing
-(`isWriteRedirectLink`, `parseLink`, `isCellLink`) are sigil-only, so an
-`$alias` record found in data is a plain value. The form survives solely as
-Pattern *binding* vocabulary (produced by `withAliasBindings`, consumed
-via `isAliasBinding`/`parseAliasBinding`), where it marks intermediate
-bindings — e.g.
+An `$alias` record is Pattern *binding* vocabulary, and it is not a link.
+Generic link recognition and parsing (`isWriteRedirectLink`, `parseLink`,
+`isCellLink`) are sigil-only, so an `$alias` record found in data is a plain
+value. The form is defined in `runner/src/alias-binding.ts`, produced by
+pattern compilation, and recognized only inside Pattern objects — e.g.
 ```json
 { "$alias": { "cell": "argument", "path": ["items"] } }
 ```
-— not cross-document references.
+
+A link addresses a document that exists: it carries that document's
+identifier, and a read or a write through it lands there. A binding carries
+no identifier. It names a position that acquires a document only when the
+pattern graph is instantiated — by role (`cell: "argument"` or
+`cell: "result"`), by derivation (`partialCause`, naming a document to mint
+from the instance's result cell and that cause), or at a nesting level not yet
+reached (`defer`). Those are different kinds of thing, so this is not a legacy
+link format awaiting replacement by a sigil one. It is a separate vocabulary
+that the link model does not reach into, and both its writers and its readers
+are permanent. `runner/src/alias-binding.ts` gives the full reasoning.
 
 The plain-value reading applies to *data* only. Inside a Pattern object the
 interpretation is positional and shape-based with no escape encoding: pattern
@@ -75,6 +84,8 @@ state, or a pattern's outputs) is therefore not preserved as data: the
 serializer rewrites it as a nested-pattern binding (incrementing `defer`), and
 instantiation later resolves it as a write redirect into the pattern's own
 documents.
+
+#### Legacy Formats
 
 **`LegacyJSONCellLink`** (`{ cell: { "/": string }, path: [...] }`) — removed
 from write and recognition code paths. The type definition still exists in
@@ -205,9 +216,14 @@ simplify content addressing.
 `LegacyJSONCellLink` and bare string links (`{ "/": string }`) have been removed
 from write and recognition code paths. `LegacyJSONCellLink` retains
 backwards-compatible reading for previously persisted data, but is otherwise
-inactive. `$alias` has been removed from link recognition entirely — in data it
-is a plain value. It remains in use as Pattern-binding vocabulary only, and can
-be retired once pattern serialization emits sigil bindings.
+inactive.
+
+`$alias` is not on this list. It is Pattern-binding vocabulary rather than a
+link format, so there is nothing here to deprecate: link recognition already
+ignores it, and it is not a candidate for replacement by a sigil encoding
+because a binding names a position in a pattern instance while a link
+addresses a document. See
+[Not a Link: `$alias` Bindings](#not-a-link-alias-bindings).
 
 ---
 

--- a/packages/runner/src/alias-binding.ts
+++ b/packages/runner/src/alias-binding.ts
@@ -1,0 +1,100 @@
+/**
+ * The `$alias` binding form, which appears inside saved pattern node graphs.
+ *
+ * An `$alias` record is not a link, and it will not become one. A link
+ * addresses a document: it carries the identifier of a document that exists,
+ * and a read or a write through it lands there. An `$alias` record carries no
+ * such identifier. It names a position that acquires a document only when the
+ * pattern graph is instantiated, in one of three ways:
+ *
+ * - By role. `cell: "argument"` and `cell: "result"` name the argument and
+ *   result cells of whichever pattern instance the graph is being run as. A
+ *   pattern graph is a template, compiled once and instantiated against many
+ *   different pairs of documents, so at the time the record is written
+ *   neither document exists.
+ * - By derivation. `partialCause` names a document to mint from the
+ *   instance's result cell and that cause, at the instance's own scope. That
+ *   is a computation, not an address.
+ * - By nesting level. `defer` counts how many instantiations away the
+ *   record's pattern is. Each unwrapping decrements it, and the record names
+ *   anything at all only once it reaches zero. A link has no analogue: it
+ *   addresses a document now, or it is invalid.
+ *
+ * Expressing these as links would mean teaching the link payload a role
+ * selector, a partial cause and a nesting counter, and teaching every walk
+ * that consumes links — storage sync, the memory schema-table link extractor,
+ * contextual flow control, the filesystem JSON mapping — to recognize a link
+ * that does not yet address anything. That trades one binding form for three
+ * new fields in the type all of those walks depend on, and for a link model
+ * whose central invariant no longer holds. So the binding stays, and it stays
+ * outside the link model: nothing here is reachable through the link parsers,
+ * and an `$alias` record found in data is data.
+ *
+ * Pattern compilation emits these records. `builder/pattern.ts` mints them,
+ * `builder/to-encodable-form.ts` re-levels them for nested patterns, and the
+ * runner synthesizes one when it wraps a bare module as a pattern. Saved
+ * graphs hold them durably, so the reader here outlives any change to the
+ * writers.
+ *
+ * Two functions resolve a binding, both in `pattern-binding.ts` and both
+ * given the instance's argument link and result cell:
+ * `unwrapOneLevelAndBindToDoc` and `sendValueToBinding`. Anything walking a
+ * binding after unwrapping sees sigil links; an `$alias` record surviving
+ * that far belongs to a nested pattern and is inert at this level.
+ */
+
+import type { CellScope, JSONSchema, JSONValue } from "@commonfabric/api";
+import { isObjectNotArray } from "@commonfabric/utils/types";
+
+type AliasBindingBase = {
+  path: readonly string[];
+  schema?: JSONSchema;
+};
+
+// Named-cell aliases carry no scope: the referenced argument/result cell's
+// own link determines the scope when the binding is unwrapped.
+type AliasBindingNamedCell = AliasBindingBase & {
+  cell: "result" | "argument";
+  partialCause?: never;
+  scope?: never;
+  defer?: number;
+};
+
+/**
+ * These are partial bindings that may not be applicable to the current
+ * pattern. We track the defer count, and each time we unwrap bindings,
+ * we decrement that. Once it's 0, we know that it's associated with the
+ * current pattern, and we can generate real cells based ont the combination
+ * of the pattern's result (parent) and the partialCause.
+ *
+ * `scope` names where the derived internal cell is minted. It is a concrete
+ * `CellScope`: "inherit" is never generated (the builder's `cell.export()`
+ * filters non-cell scopes), and would mean the same as omitting it.
+ */
+type AliasBindingPartialCause = AliasBindingBase & {
+  cell?: never;
+  partialCause: JSONValue;
+  scope?: CellScope;
+  defer?: number;
+};
+
+export type AliasBinding = {
+  $alias:
+    | AliasBindingNamedCell
+    | AliasBindingPartialCause;
+};
+
+/**
+ * Check if value is an `$alias` pattern binding.
+ *
+ * The recognition is positional: a record reads as a binding because of where
+ * it sits, inside a pattern node graph, and a record of the same shape in
+ * ordinary data is ordinary data. Nothing in the link model consults this.
+ */
+export function isAliasBinding(value: any): value is AliasBinding {
+  return isObjectNotArray(value) && "$alias" in value &&
+    isObjectNotArray(value.$alias) &&
+    Array.isArray(value.$alias.path) &&
+    (value.$alias.partialCause !== undefined ||
+      value.$alias.cell === "result" || value.$alias.cell === "argument");
+}

--- a/packages/runner/src/builder/pattern.ts
+++ b/packages/runner/src/builder/pattern.ts
@@ -4,6 +4,7 @@ import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
 import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
 
+import { type AliasBinding } from "../alias-binding.ts";
 import { isCell, setCellUnlinkedSpace } from "../cell.ts";
 import type { ImplementationIdentity } from "../cfc/types.ts";
 import { createRef } from "../create-ref.ts";
@@ -28,7 +29,6 @@ import {
   UNUSED_RECORD_SUBSCHEMA_KEYS,
   UNUSED_SINGLE_SUBSCHEMA_KEYS,
 } from "../schema-walk.ts";
-import { type AliasBinding } from "../sigil-types.ts";
 import {
   IExtendedStorageTransaction,
   MemorySpace,

--- a/packages/runner/src/builder/to-encodable-form.ts
+++ b/packages/runner/src/builder/to-encodable-form.ts
@@ -9,7 +9,7 @@ import {
   shallowFabricFromNativeObjectElseUndefined,
 } from "@commonfabric/data-model";
 import { refuseFabricInstance } from "../fabric-special-object.ts";
-import { type AliasBinding } from "../sigil-types.ts";
+import { type AliasBinding, isAliasBinding } from "../alias-binding.ts";
 import {
   type FabricExecPlainObject,
   type FabricExecValue,
@@ -29,7 +29,6 @@ import {
   noteDerivedCopy,
 } from "./pattern-metadata.ts";
 import { getVerifiedProvenance } from "../harness/verified-provenance.ts";
-import { isAliasBinding } from "../link-utils.ts";
 import {
   getCellOrThrow,
   isCellResultForDereferencing,

--- a/packages/runner/src/link-types.ts
+++ b/packages/runner/src/link-types.ts
@@ -12,7 +12,6 @@ import {
 } from "./builder/types.ts";
 import { type MemorySpace } from "./cell.ts";
 import {
-  type AliasBinding,
   type CellLinkRefPayload,
   LINK_ADDRESS_KEYS,
   type SigilLink,
@@ -178,12 +177,13 @@ export function toMemorySpaceAddress(
 }
 
 /**
- * Primitive cell link types that can be serialized.
+ * The serializable link form. There is one, the sigil link, and every
+ * predicate and parser in this module speaks only about it.
  *
- * Legacy `$alias` records are NOT links: they only appear as bindings inside
- * Pattern objects (see {@link isAliasBinding}) and are plain data anywhere
- * else. Pattern machinery that consumes them checks `isAliasBinding`
- * explicitly and parses via {@link parseAliasBinding}.
+ * The one thing that resembles a link here and is not one is the `$alias`
+ * pattern binding, defined in `alias-binding.ts`. It carries no document
+ * identifier, so nothing in this module recognizes it and an `$alias` record
+ * found in data is data.
  */
 export type PrimitiveCellLink = SigilLink;
 
@@ -231,10 +231,6 @@ export function isNormalizedFullLink(value: any): value is NormalizedFullLink {
 /**
  * Check if value is a write-redirect link (sigil `link@1` with
  * `overwrite: "redirect"`).
- *
- * Legacy `$alias` records are deliberately NOT matched: they are only
- * meaningful as bindings inside Pattern objects, not as links in data.
- * Binding-side callers pair this with an explicit `isAliasBinding` check.
  */
 export function isWriteRedirectLink(
   value: any,
@@ -244,21 +240,6 @@ export function isWriteRedirectLink(
   }
 
   return false;
-}
-
-/**
- * Check if value is a `$alias` Pattern binding.
- *
- * `$alias` records are no longer links: they appear only as bindings inside
- * Pattern objects, in the intermediate form where we don't have enough detail
- * to point to an actual cell. In data they are plain values.
- */
-export function isAliasBinding(value: any): value is AliasBinding {
-  return isObjectNotArray(value) && "$alias" in value &&
-    isObjectNotArray(value.$alias) &&
-    Array.isArray(value.$alias.path) &&
-    (value.$alias.partialCause !== undefined ||
-      value.$alias.cell === "result" || value.$alias.cell === "argument");
 }
 
 /**
@@ -297,40 +278,6 @@ export function parseLinkPrimitive(
     };
   }
   throw new Error(`Link is not a primitive: ${value}`);
-}
-
-/**
- * Parse a legacy `$alias` Pattern binding to normalized format.
- *
- * This is binding-side machinery only: `$alias` records are kept in Pattern
- * objects but are plain data everywhere else, so the generic link parsers
- * ({@link parseLinkPrimitive}, `parseLink`) no longer accept them.
- */
-export function parseAliasBinding(
-  value: AliasBinding,
-  base: NormalizedFullLink,
-): NormalizedFullLink {
-  const alias = value.$alias;
-  // A partialCause alias denotes a derived internal cell — a different
-  // document minted from the result cell and the partialCause (see
-  // getDerivedInternalCellLink), in the alias's own `scope` — not a path
-  // within the base document, so it cannot be parsed against a base link.
-  // Callers must convert it via unwrapOneLevelAndBindToDoc instead.
-  if (alias.partialCause !== undefined) {
-    throw new Error(
-      `Cannot parse partialCause alias as link: ${JSON.stringify(value)}`,
-    );
-  }
-  // Named-cell ("argument"/"result") aliases carry no absolute id of their
-  // own here, so resolve to the base cell's document, in the base's scope.
-  return {
-    id: base.id,
-    path: alias.path,
-    space: base.space,
-    scope: base.scope,
-    ...(alias.schema !== undefined && { schema: alias.schema }),
-    overwrite: "redirect",
-  };
 }
 
 /**

--- a/packages/runner/src/link-utils.ts
+++ b/packages/runner/src/link-utils.ts
@@ -291,7 +291,7 @@ export function inlineExternalSchemaRefsInValue<T extends FabricValue>(
 }
 
 /**
- * Creates a sigil reference (link or alias) with shared logic
+ * Creates a sigil link, optionally a write redirect, with shared logic
  */
 export function createSigilLinkFromParsedLink(
   link: NormalizedLink,

--- a/packages/runner/src/pattern-binding.ts
+++ b/packages/runner/src/pattern-binding.ts
@@ -21,7 +21,6 @@ import {
   createSigilLinkFromParsedLink,
   getDerivedInternalCellLink,
   getMetaLink,
-  isAliasBinding,
   isCellLink,
   isSigilLink,
   isWriteRedirectLink,
@@ -31,6 +30,7 @@ import {
   sanitizeSchemaForLinks,
   sigilLinkAddressOnly,
 } from "./link-utils.ts";
+import { isAliasBinding } from "./alias-binding.ts";
 import type { IExtendedStorageTransaction } from "./storage/interface.ts";
 import { ignoreReadForScheduling } from "./scheduler.ts";
 import {
@@ -255,9 +255,12 @@ function sendValueToBindingInner<T>(
   if (argumentCellLink === undefined) {
     argumentCellLink = getMetaLink(cell as Cell<unknown>, "argument")!;
   }
-  // Handle both legacy $alias format and new sigil link format. `$alias` is
-  // only meaningful here because `binding` comes from a Pattern object;
-  // `isWriteRedirectLink` itself no longer matches it.
+  // A binding reaches a write target either as a sigil write redirect or as
+  // an `$alias` record. The second is only meaningful because `binding` comes
+  // from a pattern node graph; the link predicates do not match it, so this
+  // function resolves it here against the instance's argument and result
+  // cells. This and `unwrapOneLevelAndBindToDoc` below are the only two
+  // places that do.
   if (isWriteRedirectLink(binding) || isAliasBinding(binding)) {
     if (isAliasBinding(binding)) {
       const alias = binding.$alias;

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -29,6 +29,7 @@ import {
   isPlainObject,
 } from "@commonfabric/utils/types";
 
+import { isAliasBinding } from "./alias-binding.ts";
 import {
   patternFromFrame,
   popFrame,
@@ -80,13 +81,11 @@ import {
   getDerivedInternalCellLink,
   getMetaCell,
   getMetaLink,
-  isAliasBinding,
   isCellLink,
   isSigilLink,
   isWriteRedirectLink,
   KeepAsCell,
   type NormalizedFullLink,
-  parseAliasBinding,
   parseLink,
   toMemorySpaceAddress,
 } from "./link-utils.ts";
@@ -483,11 +482,13 @@ const recordOutputSchemaPolicyInputs = (
     return;
   }
 
-  if (isWriteRedirectLink(outputBinding) || isAliasBinding(outputBinding)) {
+  // Sigil redirects only. `outputBinding` has been through
+  // `unwrapOneLevelAndBindToDoc`, which turns this level's `$alias` bindings
+  // into sigil links; a record still carrying `$alias` here belongs to a
+  // nested pattern and names nothing at this level.
+  if (isWriteRedirectLink(outputBinding)) {
     const bindingBase = resultCell.getAsNormalizedFullLink();
-    const bindingLink = isAliasBinding(outputBinding)
-      ? parseAliasBinding(outputBinding, bindingBase)
-      : parseLink(outputBinding, bindingBase);
+    const bindingLink = parseLink(outputBinding, bindingBase);
     // Output-redirect resolution is result-plumbing machinery
     // (machineryRead, same family as sendValueToBinding's walk): its reads
     // must not consume `*`-path membership templates (bot review on this
@@ -603,11 +604,10 @@ const recordRawBuiltinBindingSchemaPolicyInputs = (
   resultCell: Cell<any>, // used as the base for output bindings
   outputBinding: unknown,
 ): void => {
-  if (isWriteRedirectLink(outputBinding) || isAliasBinding(outputBinding)) {
+  // Sigil redirects only, as in recordOutputSchemaPolicyInputs.
+  if (isWriteRedirectLink(outputBinding)) {
     const bindingBase = resultCell.getAsNormalizedFullLink();
-    const bindingLink = isAliasBinding(outputBinding)
-      ? parseAliasBinding(outputBinding, bindingBase)
-      : parseLink(outputBinding, bindingBase);
+    const bindingLink = parseLink(outputBinding, bindingBase);
     // Result-plumbing machinery, as in recordOutputSchemaPolicyInputs.
     const link = tx.runWithAmbientReadMeta(
       machineryRead,
@@ -659,13 +659,12 @@ const schemaForRawBuiltinRootOutputBinding = (
   resultCell: Cell<any>, // used as the base for output bindings
   outputBinding: unknown,
 ): JSONSchema | undefined => {
-  if (!isWriteRedirectLink(outputBinding) && !isAliasBinding(outputBinding)) {
+  // Sigil redirects only, as in recordOutputSchemaPolicyInputs.
+  if (!isWriteRedirectLink(outputBinding)) {
     return undefined;
   }
   const bindingBase = resultCell.getAsNormalizedFullLink();
-  const bindingLink = isAliasBinding(outputBinding)
-    ? parseAliasBinding(outputBinding, bindingBase)
-    : parseLink(outputBinding, bindingBase);
+  const bindingLink = parseLink(outputBinding, bindingBase);
   // Result-plumbing machinery, as in recordOutputSchemaPolicyInputs.
   const link = tx.runWithAmbientReadMeta(
     machineryRead,
@@ -771,25 +770,15 @@ export function firstResolvedOutputRedirect(
   baseCell: Cell<any>,
   causeOnlyIds?: ReadonlySet<string>,
 ): NormalizedFullLink | undefined {
-  if (isWriteRedirectLink(binding) || isAliasBinding(binding)) {
-    // A partialCause alias denotes a DERIVED INTERNAL cell — of the child
-    // level it was deferred to when it still carried `defer` — never the
-    // node's reserved result spot, and it cannot be parsed as a link
-    // (parseAliasBinding throws by design). Before 2026-07 this threw here,
-    // and the caller's catch skipped the WHOLE node's owned-cell pre-sync —
-    // silently re-exposing the cold-cache commit-revert race the pre-sync
-    // exists to prevent, for every sub-pattern whose outputs lead with such
-    // an alias (seen live on estuary home spaces as "resume-owned-cells
-    // skipping…"). Skip just this entry and keep scanning: the derived
-    // cells themselves are collected from each pattern's own
-    // derivedInternalCells manifest.
-    if (isAliasBinding(binding) && binding.$alias.partialCause !== undefined) {
-      return undefined;
-    }
+  // Sigil redirects only, as in recordOutputSchemaPolicyInputs. A surviving
+  // `$alias` record — most often a partialCause binding deferred to a child
+  // level — names a derived internal cell of THAT level, never this node's
+  // reserved result spot, so it contributes no redirect here. The walk below
+  // steps over it and keeps scanning; the derived cells themselves are
+  // collected from each pattern's own derivedInternalCells manifest.
+  if (isWriteRedirectLink(binding)) {
     const bindingBase = baseCell.getAsNormalizedFullLink();
-    const parsed = isAliasBinding(binding)
-      ? parseAliasBinding(binding, bindingBase)
-      : parseLink(binding, bindingBase);
+    const parsed = parseLink(binding, bindingBase);
     if (causeOnlyIds?.has(parsed.id)) return parsed;
     return resolveLink(runtime, tx, parsed, "writeRedirect");
   }
@@ -866,15 +855,15 @@ const recordSetupProjectionPolicyInputs = (
     return;
   }
 
-  // Sigil redirects only, deliberately NOT paired with `isAliasBinding`: the
-  // projection is about to be STORED (argument via diffAndUpdate, result via
-  // setRawUntyped), and in stored data only sigil links function as
-  // redirects — a residual `$alias` record (e.g. a still-deferred binding of
-  // an embedded pattern) is inert there. The prepare gate agrees: marker
-  // verification requires the stored value to be a sigil redirect
-  // (`setupProjectionSourceMatchesValue`), and recording a marker for an
-  // alias would wrongly widen `writeIsPatternSetupInitialization`'s
-  // trusted-initialization exemption to a path nothing redirects to.
+  // Sigil redirects only: the projection is about to be STORED (argument via
+  // diffAndUpdate, result via setRawUntyped), and in stored data only sigil
+  // links function as redirects — a residual `$alias` record (e.g. a
+  // still-deferred binding of an embedded pattern) is inert there. The
+  // prepare gate agrees: marker verification requires the stored value to be
+  // a sigil redirect (`setupProjectionSourceMatchesValue`), and recording a
+  // marker for an alias would wrongly widen
+  // `writeIsPatternSetupInitialization`'s trusted-initialization exemption to
+  // a path nothing redirects to.
   if (isWriteRedirectLink(projection)) {
     const target = resultCell.getAsNormalizedFullLink();
     const source = parseLink(projection, target);
@@ -6744,11 +6733,10 @@ export class Runner {
     };
 
     const visit = (schema: unknown, currentValue: unknown): void => {
-      // Sigil-only, deliberately NOT paired with `isAliasBinding`: the value
-      // is post-unwrap, where the only `$alias` records left belong to
-      // embedded Pattern values (their `defer` bookkeeping resolves them at
-      // that pattern's own instantiation) — parsing one here would read it at
-      // the wrong nesting level.
+      // Sigil-only: the value is post-unwrap, where the only `$alias`
+      // records left belong to embedded Pattern values (their `defer`
+      // bookkeeping resolves them at that pattern's own instantiation) —
+      // parsing one here would read it at the wrong nesting level.
       if (isWriteRedirectLink(currentValue)) {
         const link = parseLink(currentValue, resultCell);
         links.push({

--- a/packages/runner/src/shared.ts
+++ b/packages/runner/src/shared.ts
@@ -15,7 +15,6 @@ export {
   CELL_SCOPE_VALUES,
   createLLMFriendlyLink,
   encodeJsonPointer,
-  isAliasBinding,
   isPieceHandle,
   isSigilLink,
   linkPathSegmentToCellPathSegment,
@@ -26,6 +25,7 @@ export {
   parseScopedIdSegment,
   type ReferenceParts,
 } from "./link-types.ts";
+export { type AliasBinding, isAliasBinding } from "./alias-binding.ts";
 export {
   isLinkRef,
   type LinkRef,

--- a/packages/runner/src/sigil-types.ts
+++ b/packages/runner/src/sigil-types.ts
@@ -1,9 +1,4 @@
-import type {
-  CellScope,
-  JSONSchema,
-  JSONValue,
-  LinkScope,
-} from "@commonfabric/api";
+import type { JSONSchema, LinkScope } from "@commonfabric/api";
 import {
   LINK_V1_TAG,
   type LinkRef,
@@ -120,54 +115,10 @@ export type SigilLink<P extends CellLinkRefPayload = CellLinkRefPayload> =
   LinkRef<P>;
 
 /**
- * A {@link SigilLink} whose payload is a write redirect (an alias) — its
- * `overwrite` is fixed to `"redirect"`.
+ * A {@link SigilLink} whose payload is a write redirect — its `overwrite` is
+ * fixed to `"redirect"`, so a write through it lands at the target rather
+ * than replacing the link.
  */
 export type SigilWriteRedirectLink = LinkRef<
   CellLinkRefPayload & { overwrite: "redirect" }
 >;
-
-/**
- * `$alias` Pattern binding.
- *
- * These are used in intermediate bindings at runtime and are persisted in
- * saved patterns, like the map op. They are not links: in data, an `$alias`
- * record is a plain value.
- */
-type AliasBindingBase = {
-  path: readonly string[];
-  schema?: JSONSchema;
-};
-
-// Named-cell aliases carry no scope: the referenced argument/result cell's
-// own link determines the scope when the binding is unwrapped.
-type AliasBindingNamedCell = AliasBindingBase & {
-  cell: "result" | "argument";
-  partialCause?: never;
-  scope?: never;
-  defer?: number;
-};
-
-/**
- * These are partial bindings that may not be applicable to the current
- * pattern. We track the defer count, and each time we unwrap bindings,
- * we decrement that. Once it's 0, we know that it's associated with the
- * current pattern, and we can generate real cells based ont the combination
- * of the pattern's result (parent) and the partialCause.
- *
- * `scope` names where the derived internal cell is minted. It is a concrete
- * `CellScope`: "inherit" is never generated (the builder's `cell.export()`
- * filters non-cell scopes), and would mean the same as omitting it.
- */
-type AliasBindingPartialCause = AliasBindingBase & {
-  cell?: never;
-  partialCause: JSONValue;
-  scope?: CellScope;
-  defer?: number;
-};
-
-export type AliasBinding = {
-  $alias:
-    | AliasBindingNamedCell
-    | AliasBindingPartialCause;
-};

--- a/packages/runner/test/alias-binding.test.ts
+++ b/packages/runner/test/alias-binding.test.ts
@@ -1,0 +1,318 @@
+import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+import { isAliasBinding } from "../src/alias-binding.ts";
+import {
+  resetContentAddressedSchemasConfig,
+  setContentAddressedSchemasConfig,
+} from "../src/schema-doc-config.ts";
+import { type Pattern } from "../src/builder/types.ts";
+import {
+  getDerivedInternalCell,
+  isCellLink,
+  isWriteRedirectLink,
+  parseLink,
+} from "../src/link-utils.ts";
+import { Runtime } from "../src/runtime.ts";
+import { trustExecutable } from "./support/trusted-builder.ts";
+
+const signer = await Identity.fromPassphrase("test operator");
+const space = signer.did();
+
+describe("alias-binding", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+  });
+
+  afterEach(async () => {
+    await runtime?.storageManager.synced();
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  describe("isAliasBinding()", () => {
+    it("returns `true` for a named-cell binding naming the argument cell", () => {
+      expect(isAliasBinding({ $alias: { cell: "argument", path: ["a"] } }))
+        .toBe(true);
+    });
+
+    it("returns `true` for a named-cell binding naming the result cell", () => {
+      expect(isAliasBinding({ $alias: { cell: "result", path: [] } }))
+        .toBe(true);
+    });
+
+    it("returns `true` for a `partialCause` binding", () => {
+      expect(
+        isAliasBinding({
+          $alias: { partialCause: { $generated: 0 }, path: [], scope: "user" },
+        }),
+      ).toBe(true);
+    });
+
+    it("returns `true` for a deferred binding", () => {
+      expect(
+        isAliasBinding({ $alias: { cell: "argument", path: [], defer: 2 } }),
+      ).toBe(true);
+    });
+
+    it("returns `false` for a record naming neither a cell nor a cause", () => {
+      expect(isAliasBinding({ $alias: { path: ["a"] } })).toBe(false);
+    });
+
+    it("returns `false` for a record whose `cell` is an entity id", () => {
+      const cell = runtime.getCell(space, "alias binding with entity id");
+      expect(isAliasBinding({ $alias: { cell: cell.entityId, path: [] } }))
+        .toBe(false);
+    });
+
+    it("returns `false` for a record with no `path`", () => {
+      expect(isAliasBinding({ $alias: { cell: "argument" } })).toBe(false);
+    });
+
+    it("returns `false` for values that are not `$alias` records at all", () => {
+      expect(isAliasBinding({ notAlias: "value" })).toBe(false);
+      expect(isAliasBinding({ $alias: "not a record" })).toBe(false);
+      expect(isAliasBinding("string")).toBe(false);
+      expect(isAliasBinding(undefined)).toBe(false);
+    });
+  });
+
+  describe("the link model", () => {
+    // Every shape the binding admits, so a link predicate that started
+    // matching one of them is caught here rather than in whichever walk
+    // followed it into the wrong document.
+    const bindings = [
+      { $alias: { cell: "argument", path: ["input"] } },
+      { $alias: { cell: "result", path: [] } },
+      { $alias: { partialCause: "output", path: [], scope: "user" } },
+      { $alias: { cell: "argument", path: [], defer: 1 } },
+    ];
+
+    it("does not recognize any `$alias` binding as a link", () => {
+      for (const binding of bindings) {
+        expect(isCellLink(binding)).toBe(false);
+        expect(isWriteRedirectLink(binding)).toBe(false);
+      }
+    });
+
+    it("returns `undefined` when asked to parse an `$alias` binding as a link", () => {
+      const base = runtime.getCell(space, "alias binding parse base");
+      for (const binding of bindings) {
+        expect(parseLink(binding, base)).toBeUndefined();
+      }
+    });
+  });
+
+  describe("saved pattern graphs", () => {
+    // Saved graphs are durable data: stored pattern node graphs hold `$alias`
+    // records, so the runner reads every shape of them for as long as those
+    // graphs exist. These are hand-written graphs rather than compiler output
+    // for that reason — they stand in for what is already stored.
+    it("runs a stored graph whose bindings name the argument and result cells", async () => {
+      const pattern: Pattern = {
+        argumentSchema: {
+          type: "object",
+          properties: {
+            input: { type: "number" },
+            output: { type: "number" },
+          },
+        },
+        resultSchema: {},
+        result: { output: { $alias: { cell: "argument", path: ["output"] } } },
+        nodes: [
+          {
+            module: {
+              type: "javascript",
+              implementation: (value: number) => value * 2,
+            },
+            inputs: { $alias: { cell: "argument", path: ["input"] } },
+            outputs: { $alias: { cell: "argument", path: ["output"] } },
+          },
+        ],
+      };
+
+      const tx = runtime.edit();
+      const inputCell = runtime.getCell<{ input: number; output: number }>(
+        space,
+        "stored graph naming argument and result: input",
+        undefined,
+        tx,
+      );
+      inputCell.set({ input: 21, output: 0 });
+      await tx.commit();
+
+      const resultCell = runtime.getCell(
+        space,
+        "stored graph naming argument and result",
+      );
+      const result = runtime.run(
+        undefined,
+        trustExecutable(runtime, pattern) as never,
+        inputCell as never,
+        resultCell as never,
+      );
+
+      expect(await result.pull()).toEqual({ output: 42 });
+    });
+
+    it("runs a stored graph whose binding derives an internal cell from a partial cause", async () => {
+      const pattern: Pattern = {
+        argumentSchema: {
+          type: "object",
+          properties: { input: { type: "number" } },
+        },
+        resultSchema: {},
+        derivedInternalCells: [{ partialCause: "output" }],
+        result: { output: { $alias: { partialCause: "output", path: [] } } },
+        nodes: [
+          {
+            module: {
+              type: "javascript",
+              implementation: (value: number) => value + 1,
+            },
+            inputs: { $alias: { cell: "argument", path: ["input"] } },
+            outputs: { $alias: { partialCause: "output", path: [] } },
+          },
+        ],
+      };
+
+      const resultCell = runtime.getCell(
+        space,
+        "stored graph deriving an internal cell",
+      );
+      const result = runtime.run(
+        undefined,
+        trustExecutable(runtime, pattern) as never,
+        { input: 41 } as never,
+        resultCell as never,
+      );
+
+      expect(await result.pull()).toEqual({ output: 42 });
+      // The binding named a document to mint, so the value landed in the
+      // derived internal cell rather than anywhere addressable at save time.
+      expect(
+        getDerivedInternalCell(resultCell, { partialCause: "output" }).get(),
+      ).toBe(42);
+    });
+
+    it("runs a stored graph whose nested pattern carries deferred bindings", async () => {
+      const innerPattern: Pattern = {
+        argumentSchema: {
+          type: "object",
+          properties: { input: { type: "number" } },
+        },
+        resultSchema: {},
+        result: { $alias: { partialCause: "output", path: [], defer: 1 } },
+        nodes: [
+          {
+            module: { type: "passthrough" },
+            inputs: {
+              value: {
+                $alias: { cell: "argument", path: ["input"], defer: 1 },
+              },
+            },
+            outputs: {
+              value: { $alias: { partialCause: "output", path: [], defer: 1 } },
+            },
+          },
+        ],
+      };
+
+      const outerPattern: Pattern = {
+        argumentSchema: {
+          type: "object",
+          properties: { value: { type: "number" } },
+        },
+        resultSchema: {},
+        result: { result: { $alias: { partialCause: "output", path: [] } } },
+        nodes: [
+          {
+            module: { type: "pattern", implementation: innerPattern },
+            inputs: {
+              input: { $alias: { cell: "argument", path: ["value"] } },
+            },
+            outputs: { $alias: { partialCause: "output", path: [] } },
+          },
+        ],
+      };
+
+      const resultCell = runtime.getCell(
+        space,
+        "stored graph with deferred bindings",
+      );
+      const result = runtime.run(
+        undefined,
+        trustExecutable(runtime, outerPattern) as never,
+        { value: 7 } as never,
+        resultCell as never,
+      );
+
+      expect(await result.pull()).toEqual({ result: 7 });
+    });
+
+    it("carries an alias binding's own schema onto the link it is bound to", async () => {
+      // What is under test is that the BINDING's schema reaches the link it
+      // binds to, not how a link writer encodes a schema. Reference emission
+      // is flag-gated (`contentAddressedSchemas`), so pin it off here and the
+      // assertion holds whatever the build's default is.
+      const pattern: Pattern = {
+        argumentSchema: {
+          type: "object",
+          properties: { input: { type: "number" } },
+        },
+        resultSchema: {},
+        derivedInternalCells: [{ partialCause: "output" }],
+        result: {
+          output: {
+            $alias: {
+              partialCause: "output",
+              path: [],
+              schema: { type: "number" },
+            },
+          },
+        },
+        nodes: [
+          {
+            module: {
+              type: "javascript",
+              implementation: (value: number) => value * 3,
+            },
+            inputs: { $alias: { cell: "argument", path: ["input"] } },
+            outputs: { $alias: { partialCause: "output", path: [] } },
+          },
+        ],
+      };
+
+      setContentAddressedSchemasConfig(false);
+      try {
+        const resultCell = runtime.getCell(
+          space,
+          "stored graph with a schema-bearing binding",
+        );
+        const result = runtime.run(
+          undefined,
+          trustExecutable(runtime, pattern) as never,
+          { input: 5 } as never,
+          resultCell as never,
+        );
+
+        await result.pull();
+        const stored = (result.getRaw() as { output: unknown }).output;
+        expect(isWriteRedirectLink(stored)).toBe(true);
+        expect(parseLink(stored, result)!.schema).toEqual({ type: "number" });
+      } finally {
+        resetContentAddressedSchemasConfig();
+      }
+    });
+  });
+});

--- a/packages/runner/test/link-resolution.bench.ts
+++ b/packages/runner/test/link-resolution.bench.ts
@@ -3,7 +3,6 @@ import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 
 import { resolveLink } from "../src/link-resolution.ts";
 import { Runtime } from "../src/runtime.ts";
-import { parseAliasBinding } from "../src/link-utils.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();
@@ -25,14 +24,15 @@ Deno.bench("followWriteRedirects with simple alias", () => {
     tx,
   );
   testCell.set({ value: 42 });
-  // `$alias` is a Pattern binding, not a link, so parse it against the base
-  // full link via parseAliasBinding; `cell` satisfies the AliasBinding shape.
-  const binding = { $alias: { cell: "result" as const, path: ["value"] } };
 
   resolveLink(
     runtime,
     tx,
-    parseAliasBinding(binding, testCell.getAsNormalizedFullLink()),
+    {
+      ...testCell.getAsNormalizedFullLink(),
+      path: ["value"],
+      overwrite: "redirect",
+    },
     "writeRedirect",
   );
 
@@ -72,11 +72,14 @@ Deno.bench("followWriteRedirects with nested aliases (5 levels)", () => {
     });
   }
 
-  const binding = { $alias: { cell: "result" as const, path: ["next"] } };
   resolveLink(
     runtime,
     tx,
-    parseAliasBinding(binding, cells[0].getAsNormalizedFullLink()),
+    {
+      ...cells[0].getAsNormalizedFullLink(),
+      path: ["next"],
+      overwrite: "redirect",
+    },
     "writeRedirect",
   );
 

--- a/packages/runner/test/link-resolution.test.ts
+++ b/packages/runner/test/link-resolution.test.ts
@@ -11,7 +11,6 @@ import { resolveLink } from "../src/link-resolution.ts";
 import {
   areNormalizedLinksSame,
   isSigilLink,
-  parseAliasBinding,
   parseLink,
 } from "../src/link-utils.ts";
 import { Runtime } from "../src/runtime.ts";
@@ -98,7 +97,7 @@ describe("link-resolution", () => {
       rawTx.abort();
     });
 
-    it("should follow a simple alias", () => {
+    it("should follow a simple write redirect", () => {
       const testCell = runtime.getCell<{ value: number }>(
         space,
         "should follow a simple alias 1",
@@ -106,19 +105,20 @@ describe("link-resolution", () => {
         tx,
       );
       testCell.set({ value: 42 });
-      // `cell` only satisfies the AliasBinding constraint (name or
-      // partialCause); parseAliasBinding resolves against the base link.
-      const binding = { $alias: { cell: "result" as const, path: ["value"] } };
       const result = resolveLink(
         runtime,
         tx,
-        parseAliasBinding(binding, testCell.getAsNormalizedFullLink()),
+        {
+          ...testCell.getAsNormalizedFullLink(),
+          path: ["value"],
+          overwrite: "redirect",
+        },
         "writeRedirect",
       );
       expect(tx.readValueOrThrow(result)).toBe(42);
     });
 
-    it("should follow nested aliases", () => {
+    it("should follow nested write redirects", () => {
       const innerCell = runtime.getCell<{ inner: number }>(
         space,
         "should follow nested aliases 1",
@@ -135,11 +135,14 @@ describe("link-resolution", () => {
       outerCell.setRaw({
         outer: innerCell.key("inner").getAsWriteRedirectLink(),
       });
-      const binding = { $alias: { cell: "result" as const, path: ["outer"] } };
       const result = resolveLink(
         runtime,
         tx,
-        parseAliasBinding(binding, outerCell.getAsNormalizedFullLink()),
+        {
+          ...outerCell.getAsNormalizedFullLink(),
+          path: ["outer"],
+          overwrite: "redirect",
+        },
         "writeRedirect",
       );
       expect(
@@ -153,7 +156,7 @@ describe("link-resolution", () => {
       expect(tx.readValueOrThrow(result)).toBe(10);
     });
 
-    it("should allow aliases in aliased paths", () => {
+    it("should allow write redirects in redirected paths", () => {
       const testCell = runtime.getCell<any>(
         space,
         "should allow aliases in aliased paths 1",
@@ -168,13 +171,14 @@ describe("link-resolution", () => {
           b: { c: 1 },
         },
       });
-      const binding = {
-        $alias: { cell: "result" as const, path: ["a", "a", "c"] },
-      };
       const result = resolveLink(
         runtime,
         tx,
-        parseAliasBinding(binding, testCell.getAsNormalizedFullLink()),
+        {
+          ...testCell.getAsNormalizedFullLink(),
+          path: ["a", "a", "c"],
+          overwrite: "redirect",
+        },
         "writeRedirect",
       );
       expect(

--- a/packages/runner/test/link-utils.test.ts
+++ b/packages/runner/test/link-utils.test.ts
@@ -16,13 +16,11 @@ import {
   decodeJsonPointer,
   encodeJsonPointer,
   inlineExternalSchemaRefsInValue,
-  isAliasBinding,
   isCellLink,
   isSigilLink,
   isWriteRedirectLink,
   KeepAsCell,
   type NormalizedLink,
-  parseAliasBinding,
   parseLink,
   parseLinkOrThrow,
   parseLLMFriendlyLink,
@@ -37,7 +35,7 @@ import {
   resetContentAddressedSchemasConfig,
   setContentAddressedSchemasConfig,
 } from "../src/schema-doc-config.ts";
-import { type AliasBinding, LINK_V1_TAG } from "../src/sigil-types.ts";
+import { LINK_V1_TAG } from "../src/sigil-types.ts";
 import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
@@ -141,14 +139,6 @@ describe("link-utils", () => {
   });
 
   describe("isWriteRedirectLink", () => {
-    it("should not identify alias bindings as write redirect links", () => {
-      // `$alias` is only meaningful as a Pattern binding, not as a link in
-      // data; the binding predicate still matches it.
-      const legacyAlias = { $alias: { cell: "result", path: ["test"] } };
-      expect(isWriteRedirectLink(legacyAlias)).toBe(false);
-      expect(isAliasBinding(legacyAlias)).toBe(true);
-    });
-
     it("should identify sigil links with overwrite redirect as write redirect links", () => {
       const sigilLink = {
         "/": {
@@ -170,25 +160,6 @@ describe("link-utils", () => {
     it("should not identify non-links as write redirect links", () => {
       expect(isWriteRedirectLink("string")).toBe(false);
       expect(isWriteRedirectLink({ notLink: "value" })).toBe(false);
-    });
-  });
-
-  describe("isAliasBinding", () => {
-    it("should fail to match legacy aliases without name or cause", () => {
-      const legacyAlias = { $alias: { path: ["test"] } };
-      expect(isAliasBinding(legacyAlias)).toBe(false);
-    });
-
-    it("should fail to match legacy aliases with cell id", () => {
-      const cell = runtime.getCell(space, "test");
-      const legacyAlias = { $alias: { cell: cell.entityId, path: ["test"] } };
-      expect(isAliasBinding(legacyAlias)).toBe(false);
-    });
-
-    it("should not identify non-legacy aliases", () => {
-      expect(isAliasBinding({ notAlias: "value" })).toBe(false);
-      expect(isAliasBinding({ $alias: "not object" })).toBe(false);
-      expect(isAliasBinding({ $alias: { notPath: "value" } })).toBe(false);
     });
   });
 
@@ -385,102 +356,17 @@ describe("link-utils", () => {
       });
     });
 
-    it("should not parse alias bindings (those parse via parseAliasBinding)", () => {
+    it("returns `undefined` for an `$alias` record in data", () => {
       const cell = runtime.getCell(space, "test");
-      const legacyAlias = {
-        $alias: {
-          cell: cell.entityId,
-          path: ["nested", "value"],
-          schema: { type: "number" },
-        },
-      };
-      // As data, `$alias` is not a link.
-      expect(parseLink(legacyAlias, cell)).toBeUndefined();
-
-      // As a Pattern binding, it still parses via the binding-side parser
-      // (which ignores the doubly-legacy `cell` ref and resolves to base).
       expect(
-        parseAliasBinding(
-          legacyAlias as unknown as AliasBinding,
-          cell.getAsNormalizedFullLink(),
-        ),
-      ).toEqual({
-        id: expect.stringContaining("of:"),
-        path: ["nested", "value"],
-        space: space,
-        scope: "space",
-        schema: { type: "number" },
-        overwrite: "redirect",
-      });
-    });
-
-    it("should resolve named-cell alias bindings against the base", () => {
-      const baseCell = runtime.getCell(space, "base");
-      const legacyAlias = {
-        $alias: {
-          // Only satisfies the AliasBinding constraint (name or
-          // partialCause); parseAliasBinding resolves against the base link.
-          cell: "result" as const,
-          path: ["nested", "value"],
-        },
-      };
-      expect(parseLink(legacyAlias, baseCell)).toBeUndefined();
-
-      const result = parseAliasBinding(
-        legacyAlias,
-        baseCell.getAsNormalizedFullLink(),
-      );
-      expect(result).toEqual({
-        id: expect.stringContaining("of:"),
-        path: ["nested", "value"],
-        space: space,
-        scope: "space",
-        schema: undefined,
-        overwrite: "redirect",
-      });
-    });
-
-    it("should resolve explicit inherit scope on alias bindings to the base's scope", () => {
-      const baseCell = runtime.getCell(space, "base-inherit-scope");
-      const base = {
-        ...baseCell.getAsNormalizedFullLink(),
-        scope: "session" as const,
-      };
-
-      // The alias types no longer admit `scope: "inherit"` (the builder never
-      // generates it), but stored pattern JSON is untyped: parsing stays
-      // defensive and resolves it to the base link's scope, like an absent
-      // scope.
-      expect(
-        parseAliasBinding(
-          {
-            $alias: { path: ["nested", "value"], scope: "inherit" },
-          } as unknown as AliasBinding,
-          base,
-        ),
-      ).toEqual({
-        id: base.id,
-        path: ["nested", "value"],
-        space: space,
-        scope: "session",
-        overwrite: "redirect",
-      });
-
-      // A partialCause alias denotes a derived internal cell — a different
-      // document minted from the result cell and the partialCause, in the
-      // alias's own scope — so it cannot be parsed against a base link.
-      expect(() =>
-        parseAliasBinding(
-          {
-            $alias: {
-              partialCause: "internal-cell",
-              path: ["nested", "value"],
-              scope: "user",
-            },
+        parseLink({
+          $alias: {
+            cell: cell.entityId,
+            path: ["nested", "value"],
+            schema: { type: "number" },
           },
-          base,
-        )
-      ).toThrow("Cannot parse partialCause alias as link");
+        }, cell),
+      ).toBeUndefined();
     });
 
     it("should return undefined for non-link values", () => {

--- a/packages/runner/test/pattern-binding.test.ts
+++ b/packages/runner/test/pattern-binding.test.ts
@@ -14,6 +14,7 @@ import {
 } from "@commonfabric/memory/v2";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 
+import { isAliasBinding } from "../src/alias-binding.ts";
 import { popFrame, pushFrame } from "../src/builder/pattern.ts";
 import {
   linkCfcLabelView,
@@ -25,7 +26,6 @@ import {
   areNormalizedLinksSame,
   getDerivedInternalCellLink,
   getMetaCell,
-  isAliasBinding,
   parseLink,
 } from "../src/link-utils.ts";
 import { externalRefTo, resolvedSchema } from "./schema-ref-helpers.ts";

--- a/packages/runner/test/resume-output-redirect-partialcause.test.ts
+++ b/packages/runner/test/resume-output-redirect-partialcause.test.ts
@@ -12,13 +12,13 @@ import {
 
 // Seen live on estuary home spaces (2026-07-29): a sub-pattern node whose
 // stored outputs carry a DEFERRED partialCause alias unwraps to a bare
-// `{"$alias":{"partialCause":…}}` record, which parseAliasBinding refuses by
-// design — and the resume walk's catch then skipped the WHOLE node's
-// owned-cell pre-sync ("resume-owned-cells skipping a sub-pattern node whose
-// outputs did not bind or resolve"), silently re-exposing the cold-cache
-// commit-revert race the pre-sync exists to prevent. A partialCause alias is
-// a derived internal cell, never the node's reserved result spot: the scan
-// must skip the entry and keep looking, not abandon the node.
+// `{"$alias":{"partialCause":…}}` record, and the resume walk's catch then
+// skipped the WHOLE node's owned-cell pre-sync ("resume-owned-cells skipping
+// a sub-pattern node whose outputs did not bind or resolve"), silently
+// re-exposing the cold-cache commit-revert race the pre-sync exists to
+// prevent. A partialCause alias is a derived internal cell, never the node's
+// reserved result spot: the scan must step over the entry and keep looking,
+// not abandon the node.
 
 const signer = await Identity.fromPassphrase("resume-output-partialcause");
 const space = signer.did();

--- a/packages/runtime-client/src/cell-handle.ts
+++ b/packages/runtime-client/src/cell-handle.ts
@@ -861,9 +861,9 @@ export class CellHandle<T = unknown> {
 
   /**
    * Recursively hydrate any object, converting any sigil links into
-   * CellHandle instances. Legacy `$alias` records are plain data — they are
-   * only meaningful as bindings inside Pattern objects, which the client
-   * never interprets. A `FabricPrimitive` comes back as itself.
+   * CellHandle instances. `$alias` records are plain data — they are only
+   * meaningful as bindings inside Pattern objects, which the client never
+   * interprets. A `FabricPrimitive` comes back as itself.
    *
    * @throws If the value holds a `FabricInstance`, which is a container this
    *   walk cannot descend and so cannot hydrate a link inside.


### PR DESCRIPTION
The link model has one form left, the sigil link, but three alias-shaped things still greeted anyone reading it: a write-redirect link (glossed as "an alias" in two doc comments), the `$alias` pattern binding whose type lived in `sigil-types.ts`, and `parseAliasBinding`, which sat beside `parseLinkPrimitive` and parsed a binding into a link. Three separate comment blocks in `link-types.ts` existed only to say that the second of those is not a link.

The binding cannot become one. A link addresses a document: it carries that document's identifier, and a read or a write through it lands there. An `$alias` record carries no identifier. It names a position that acquires a document only when the pattern graph is instantiated — by role (`cell: "argument"`, `cell: "result"`), by derivation (`partialCause`, naming a document to mint from the instance's result cell and that cause), or at a nesting level not yet reached (`defer`). A pattern graph is a template, compiled once and instantiated against many different pairs of documents, so at the time a record is written the documents it will name do not exist. Folding that into the link payload would mean adding a role selector, a partial cause and a nesting counter to the type every link walk depends on — storage sync, the memory schema-table link extractor, contextual flow control, the filesystem JSON mapping — and teaching each of them to meet a link that addresses nothing yet. Pattern compilation still emits these records, and saved graphs hold them durably, so both the writer and the reader stay.

So the concept leaves the link model rather than the codebase. The form moves to `alias-binding.ts`, which carries the reasoning above, and `link-types.ts` and `sigil-types.ts` no longer mention it.

`parseAliasBinding` goes altogether. It was a second, weaker resolver: it refused `partialCause` bindings by throwing, ignored `defer`, and resolved a `cell: "argument"` binding against whatever base it was handed, which at all four of its call sites was the result cell rather than the argument cell. Those four sites consume bindings that have been through `unwrapOneLevelAndBindToDoc`, where this level's bindings have already become sigil links, so a surviving `$alias` record belongs to a nested pattern and names nothing here. Two neighboring sites in the same file already said exactly that and checked for sigil links only; all six now agree, and the ordinary record walk steps over a residual binding instead. Instrumenting every site across the runner suite found `firstResolvedOutputRedirect` reaching a binding fifteen times, every one of them a `partialCause` record that took the pre-existing early return, and the other three sites reaching none at all.

Resolution now happens in one place, `pattern-binding.ts`, whose two functions are given the instance's argument link and result cell.

Tests cover the predicate and the durable-format guarantee: saved graphs carrying each shape of binding — naming the argument cell, naming the result cell, deriving an internal cell from a partial cause, deferred inside a nested pattern, and carrying a schema — load and run. Breaking the predicate fails them, so they are evidence rather than decoration. The link-resolution tests that used `parseAliasBinding` only as a way to build a redirect into a path now build one directly.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6732?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

