### PR TITLE
fix(fuse): retain every committed-write warning

### DIFF
--- a/packages/fuse/cell-bridge.test.ts
+++ b/packages/fuse/cell-bridge.test.ts
@@ -5602,7 +5602,7 @@ Deno.test("CellBridge.finalizeSourceWritePath preserves both warnings when the r
     throw new Error("the failed rebuild produced no persistent warning");
   }
   // This is the outer flush's final write into the synthetic log.
-  bridge.writeSourceErrorLog(writePath, finalized.errorLogWarning);
+  bridge.writeSourceErrorLog(writePath, finalized.logWarning);
 
   assertEquals(
     errors.lines.filter((line) =>

--- a/packages/fuse/cell-bridge.test.ts
+++ b/packages/fuse/cell-bridge.test.ts
@@ -24,7 +24,6 @@ import { FsTree } from "./tree.ts";
 import {
   CellBridge,
   type HandlerTarget,
-  sourceRefreshWarning,
   type SourceWritePath,
   type SpaceState,
   type WritePath,
@@ -42,6 +41,10 @@ import {
   listCfcXattrNames,
 } from "./annotations.ts";
 import { encodeFuseComponent } from "./path-codec.ts";
+import {
+  finalizeCommittedSourceWrite,
+  sourceRefreshWarning,
+} from "./source-write-finalize.ts";
 
 //
 // Shared helpers
@@ -5553,48 +5556,67 @@ Deno.test("CellBridge stops tracking a synthetic error.log the source takes over
   assertEquals(errors.lines.length, 1);
 });
 
-Deno.test("CellBridge.finalizeSourceWritePath reports the refresh warning when the rebuild fails", async () => {
+Deno.test("CellBridge.finalizeSourceWritePath preserves both warnings when the rebuild fails", async () => {
   // A committed write can fail twice: the piece refresh, carried by the
   // receipt, and then the projection rebuild here. The second failure must
   // not eat the first's message — "the source saved and the piece is not
   // running it" is the receipt's fact, not the rebuild's — so it is reported
   // even as the rebuild's own failure propagates to become the caller's
   // projection warning.
-  const bridge = new CellBridge(new FsTree(), "/tmp/cf-exec");
+  const tree = new FsTree();
+  const bridge = new CellBridge(tree, "/tmp/cf-exec");
   const state = buildTestSpace(bridge, "space", []);
-  const pieceIno = bridge.tree.addDir(state.piecesIno, "notes");
+  const pieceIno = tree.addDir(state.piecesIno, "notes");
+  const srcIno = tree.addDir(pieceIno, ".src");
+  const errorLogIno = tree.addFile(srcIno, "error.log", "", "string");
   state.pieceInos.set("notes", pieceIno);
+  state.srcInos.set("notes", srcIno);
+  state.srcErrorLogInos.set("notes", errorLogIno);
   (bridge as unknown as { buildSourceTree: () => Promise<void> })
     .buildSourceTree = () => Promise.reject(new Error("rebuild failed"));
+  const writePath = sourceWritePath("space", "notes", srcIno);
+  const receipt = {
+    status: "committed" as const,
+    ref: { identity: "A".repeat(43), symbol: "default" },
+    revisionId: "revision-2",
+    detachedOrigin: null,
+    refresh: {
+      status: "failed" as const,
+      warning: "dependency unavailable",
+    },
+  };
 
   const errors = captureConsoleErrors();
-  try {
-    await assertRejects(
-      () =>
-        bridge.finalizeSourceWritePath(
-          sourceWritePath("space", "notes", pieceIno),
-          {
-            status: "committed",
-            ref: { identity: "A".repeat(43), symbol: "default" },
-            revisionId: "revision-2",
-            detachedOrigin: null,
-            refresh: {
-              status: "failed",
-              warning: "dependency unavailable",
-            },
-          },
-        ),
-      Error,
-      "rebuild failed",
-    );
-  } finally {
-    errors.restore();
+  const finalized = await (async () => {
+    try {
+      return await finalizeCommittedSourceWrite(
+        receipt,
+        () => bridge.finalizeSourceWritePath(writePath, receipt),
+      );
+    } finally {
+      errors.restore();
+    }
+  })();
+
+  if (finalized.status !== "failed") {
+    throw new Error("the failed rebuild produced no persistent warning");
   }
+  // This is the outer flush's final write into the synthetic log.
+  bridge.writeSourceErrorLog(writePath, finalized.errorLogWarning);
 
   assertEquals(
     errors.lines.filter((line) =>
       line.includes("refreshing the running piece failed")
     ).length,
     1,
+  );
+  assertEquals(
+    getFileContent(tree, srcIno, "error.log"),
+    `Source revision revision-2 committed as cf:module/${
+      "A".repeat(43)
+    }#default, but refreshing the running piece failed: dependency unavailable\n` +
+      `Source revision revision-2 committed as cf:module/${
+        "A".repeat(43)
+      }#default, but refreshing the FUSE projection failed: rebuild failed`,
   );
 });

--- a/packages/fuse/cell-bridge.ts
+++ b/packages/fuse/cell-bridge.ts
@@ -48,7 +48,7 @@ import {
   encodeFuseComponent,
   encodeFusePathSegments,
 } from "./path-codec.ts";
-import { committedSourceWarning } from "./source-write-finalize.ts";
+import { sourceRefreshWarning } from "./source-write-finalize.ts";
 import {
   buildFsProjection,
   buildJsonTree,
@@ -358,28 +358,6 @@ interface PropRebuildJob {
   propName: "input" | "result";
   resolveLink: ResolveLink;
   spaceName: string;
-}
-
-/**
- * What `error.log` says after a source write whose transaction committed and
- * whose refresh of the running piece then failed, and `undefined` when the
- * refresh completed or the write made no source update.
- *
- * A write in that state saved the source and left the piece not running it,
- * which the file has to keep saying: `error.log` is cleared on a clean write,
- * so silence there is the mount reporting an unqualified success. Held apart
- * from the reporting so the text a reader finds in the file is assertable on
- * its own.
- */
-export function sourceRefreshWarning(
-  receipt: PatternUpdateReceipt | undefined,
-): string | undefined {
-  return receipt?.refresh.status === "failed"
-    ? committedSourceWarning(
-      receipt,
-      `refreshing the running piece failed: ${receipt.refresh.warning}`,
-    )
-    : undefined;
 }
 
 export class CellBridge {
@@ -2343,8 +2321,9 @@ export class CellBridge {
       // the piece is not running it" is exactly the message a projection
       // failure must not eat, and it is the receipt's, not the rebuild's.
       // On a failed rebuild the console line still fires and the file half
-      // lands wherever a synthetic log is standing; the rebuild's own failure
-      // propagates to the caller and is reported as its own warning there.
+      // lands wherever a synthetic log is standing. The caller then retains
+      // it when the rebuild's own warning becomes the complete persistent
+      // diagnostic.
       this.reportSourceRefreshWarning(
         writePath,
         sourceRefreshWarning(receipt),

--- a/packages/fuse/mod.test.ts
+++ b/packages/fuse/mod.test.ts
@@ -207,7 +207,7 @@ Deno.test("source writeback finalizes its receipt and persists every warning", a
   );
   assert(
     sourceWriteback.includes(
-      "finalized.errorLogWarning",
+      "finalized.logWarning",
     ),
     "source writeback must persist the complete post-commit diagnostic",
   );
@@ -232,7 +232,7 @@ Deno.test("source projection failures after commit become warnings, not rejected
       `Source revision revision-committed-before-finalize committed as ` +
       `cf:module/${"A".repeat(43)}#default, but refreshing the FUSE ` +
       `projection failed: projection rebuild failed`,
-    errorLogWarning:
+    logWarning:
       `Source revision revision-committed-before-finalize committed as ` +
       `cf:module/${"A".repeat(43)}#default, but refreshing the FUSE ` +
       `projection failed: projection rebuild failed`,

--- a/packages/fuse/mod.test.ts
+++ b/packages/fuse/mod.test.ts
@@ -187,14 +187,13 @@ Deno.test("source writeback retains attached data files", async () => {
   );
 });
 
-Deno.test("source writeback hands its receipt to the finalize that rebuilds .src", async () => {
-  // Where the report is composed and written is CellBridge's business, and
-  // deliberately so: finalizing rebuilds `.src` and mints a fresh empty
-  // `error.log`, so a report written out here would be discarded along with
-  // the inode it went to. What the flush path owes is the receipt, handed to
-  // the call that performs that rebuild. Read from the source because driving
-  // the flush needs a mounted filesystem, in the same way as the two cases
-  // above.
+Deno.test("source writeback finalizes its receipt and persists every warning", async () => {
+  // Finalizing rebuilds `.src` and mints a fresh empty `error.log`, so the
+  // receipt goes into the operation performing that rebuild. The outer flush
+  // then persists the finalizer's complete diagnostic, which retains both
+  // failures when the running-piece refresh and the projection fail. Read from
+  // the source because driving the flush needs a mounted filesystem, in the
+  // same way as the two cases above.
   const source = await Deno.readTextFile(new URL("./mod.ts", import.meta.url));
   const sourceWriteback = source.slice(
     source.indexOf('if (writeTarget?.kind === "source")'),
@@ -205,6 +204,12 @@ Deno.test("source writeback hands its receipt to the finalize that rebuilds .src
       "bridge.finalizeSourceWritePath(writeTarget.target, receipt)",
     ),
     "source writeback must hand the update receipt to the finalize",
+  );
+  assert(
+    sourceWriteback.includes(
+      "finalized.errorLogWarning",
+    ),
+    "source writeback must persist the complete post-commit diagnostic",
   );
 });
 
@@ -224,6 +229,10 @@ Deno.test("source projection failures after commit become warnings, not rejected
   assertEquals(failed, {
     status: "failed",
     warning:
+      `Source revision revision-committed-before-finalize committed as ` +
+      `cf:module/${"A".repeat(43)}#default, but refreshing the FUSE ` +
+      `projection failed: projection rebuild failed`,
+    errorLogWarning:
       `Source revision revision-committed-before-finalize committed as ` +
       `cf:module/${"A".repeat(43)}#default, but refreshing the FUSE ` +
       `projection failed: projection rebuild failed`,

--- a/packages/fuse/mod.ts
+++ b/packages/fuse/mod.ts
@@ -1864,10 +1864,7 @@ export async function main(argv: string[] = Deno.args) {
           // degraded mode when its projection refresh discovers an outage.
           if (isConnectionWriteFailure(error)) noteWriteFailure(error);
           console.error(`[source] ${finalized.warning}`);
-          bridge.writeSourceErrorLog(
-            writeTarget.target,
-            finalized.errorLogWarning,
-          );
+          bridge.writeSourceErrorLog(writeTarget.target, finalized.logWarning);
         }
         reconcileCfcWritebacks("source flush post-finalize");
         markExistingFinalized();

--- a/packages/fuse/mod.ts
+++ b/packages/fuse/mod.ts
@@ -1864,7 +1864,10 @@ export async function main(argv: string[] = Deno.args) {
           // degraded mode when its projection refresh discovers an outage.
           if (isConnectionWriteFailure(error)) noteWriteFailure(error);
           console.error(`[source] ${finalized.warning}`);
-          bridge.writeSourceErrorLog(writeTarget.target, finalized.warning);
+          bridge.writeSourceErrorLog(
+            writeTarget.target,
+            finalized.errorLogWarning,
+          );
         }
         reconcileCfcWritebacks("source flush post-finalize");
         markExistingFinalized();

--- a/packages/fuse/source-write-finalize.ts
+++ b/packages/fuse/source-write-finalize.ts
@@ -55,7 +55,7 @@ export async function finalizeCommittedSourceWrite(
     return {
       status: "failed" as const,
       warning,
-      errorLogWarning: refreshWarning === undefined
+      logWarning: refreshWarning === undefined
         ? warning
         : `${refreshWarning}\n${warning}`,
       error,

--- a/packages/fuse/source-write-finalize.ts
+++ b/packages/fuse/source-write-finalize.ts
@@ -15,9 +15,10 @@ export function committedSourceWarning(
 
 /**
  * What `error.log` says when the committed source did not reach the running
- * piece, and `undefined` when that refresh completed. A clean write clears the
- * log, so dropping this warning would report unqualified success while the
- * piece is still running its previous source.
+ * piece, and `undefined` when that refresh completed or the write made no
+ * source update. A clean write clears the log, so dropping this warning would
+ * report unqualified success while the piece is still running its previous
+ * source.
  */
 export function sourceRefreshWarning(
   receipt: PatternUpdateReceipt | undefined,

--- a/packages/fuse/source-write-finalize.ts
+++ b/packages/fuse/source-write-finalize.ts
@@ -14,11 +14,29 @@ export function committedSourceWarning(
 }
 
 /**
+ * What `error.log` says when the committed source did not reach the running
+ * piece, and `undefined` when that refresh completed. A clean write clears the
+ * log, so dropping this warning would report unqualified success while the
+ * piece is still running its previous source.
+ */
+export function sourceRefreshWarning(
+  receipt: PatternUpdateReceipt | undefined,
+): string | undefined {
+  return receipt?.refresh.status === "failed"
+    ? committedSourceWarning(
+      receipt,
+      `refreshing the running piece failed: ${receipt.refresh.warning}`,
+    )
+    : undefined;
+}
+
+/**
  * Run local FUSE projection work after a source transaction has committed.
  *
  * A failure here cannot undo the receipt and therefore must not reject the
- * filesystem write. Returning it as a warning keeps the durable outcome and
- * the local projection outcome separate at the same boundary as Piece does.
+ * filesystem write. A failed result keeps the projection warning separate for
+ * the console and composes every post-commit failure for the persistent
+ * `error.log` diagnostic.
  */
 export async function finalizeCommittedSourceWrite(
   receipt: PatternUpdateReceipt,
@@ -29,12 +47,17 @@ export async function finalizeCommittedSourceWrite(
     return { status: "completed" as const };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
+    const warning = committedSourceWarning(
+      receipt,
+      `refreshing the FUSE projection failed: ${message}`,
+    );
+    const refreshWarning = sourceRefreshWarning(receipt);
     return {
       status: "failed" as const,
-      warning: committedSourceWarning(
-        receipt,
-        `refreshing the FUSE projection failed: ${message}`,
-      ),
+      warning,
+      errorLogWarning: refreshWarning === undefined
+        ? warning
+        : `${refreshWarning}\n${warning}`,
       error,
     };
   }


### PR DESCRIPTION
Follow-up to #6234.

## Summary

- Preserve the running-piece refresh warning in `.src/error.log` when FUSE projection finalization also fails.
- Keep the projection-only warning separate for the console while returning a complete persistent diagnostic for the synthetic log.
- Keep committed-source warning construction in one module and update the double-failure regression to assert the final file contents.

## Behavior

A double failure previously emitted both warnings to the console, but the outer projection handler replaced the running-piece warning in `.src/error.log`. The finalization result now carries an `errorLogWarning` which contains both post-commit failures, separated by a newline. Projection-only failures retain their existing single-warning output.

## Verification

- `deno task test` in `packages/fuse`: 382 passed, 1 ignored
- `deno task check`: 46 package groups passed
- `deno lint`: 5,382 files passed
- `deno fmt --check`: 5,545 files passed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6733?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

