### PR TITLE
An acquired skill's pin reaches the child, and custody survives a failed delegation (CT-2170)

### DIFF
--- a/docs/plans/external-skill-acquisition.md
+++ b/docs/plans/external-skill-acquisition.md
@@ -140,7 +140,8 @@ below is what eventually does.
   renders no part of the value.
 - `loadHarnessSkillContextFromText` wraps the payload in a
   `<skill_context source="handle:<token>">` block and returns an activation
-  carrying the token and a sha256 digest of the exact text injected
+  carrying the token, a sha256 digest of the exact text injected, and — for a
+  handle an acquisition minted — the pin that acquisition recorded
   (`packages/cf-harness/src/skills/registry.ts`).
 - `scrubHandleSkillText` strips the payload from the child's final text
   **before** handle-token resolution, so the child cannot echo its skill back
@@ -148,6 +149,27 @@ below is what eventually does.
   embedded token and walk the echoed payload straight past the scrub.
 
 So the load path is done. What this plan adds is only what fills the cell.
+
+**The pin rides with the token, not with the text.** The handle-table entry an
+acquisition mints carries the discovery id, commit SHA, source URL,
+verification method, host-computed digest, and receive time. It is the only
+durable place that knows: the parent holds a token and the child holds text,
+and neither can name the commit. Carrying it on the entry is what lets a
+delegation write it into the child's activation record, so a reader of the run
+can say which bytes shaped the work. No model surface exposes the field — a
+model can neither write it nor read it.
+
+**Custody survives a failed delegation.** A child that dies takes nothing with
+it: the handle stays the parent's, and the harness will not attach it to the
+next child on its own, because choosing which child reads untrusted text is
+the decision `delegate_task` exists to record. What it refuses is the decision
+going unmade. While a run holds a token whose most recent delegation did not
+complete, a `delegate_task` that omits both `skillHandle` and
+`withoutSkillHandle` is refused, naming the outstanding token. The parent
+either carries the handle again or states that this child runs without it, and
+either way the run state says which. The outstanding set is read off the
+parent's own subagent run refs rather than held in memory, so it survives a
+resume.
 
 **The acquisition step.** The host-side `acquire_skill` effect resolves a
 discovery id, fetches a skill from a **pinned** address, verifies its complete

--- a/docs/plans/external-skill-acquisition.md
+++ b/docs/plans/external-skill-acquisition.md
@@ -167,9 +167,16 @@ going unmade. While a run holds a token whose most recent delegation did not
 complete, a `delegate_task` that omits both `skillHandle` and
 `withoutSkillHandle` is refused, naming the outstanding token. The parent
 either carries the handle again or states that this child runs without it, and
-either way the run state says which. The outstanding set is read off the
-parent's own subagent run refs rather than held in memory, so it survives a
-resume.
+either way the run state says which.
+
+The refusal asks a question once. A delegation that declares
+`withoutSkillHandle` discharges what was outstanding when it was made, so a
+run does not carry the flag for the rest of its life because one child died —
+though custody a later delegation goes on to incur is its own question, asked
+again. Both the outstanding set and the discharge are read off the parent's
+own subagent run refs rather than held in memory, so they survive a resume;
+a delegation left `running` by a crash is the case that most needs this, and
+counts as outstanding.
 
 **The acquisition step.** The host-side `acquire_skill` effect resolves a
 discovery id, fetches a skill from a **pinned** address, verifies its complete

--- a/packages/cf-harness/src/contracts/handle-table.ts
+++ b/packages/cf-harness/src/contracts/handle-table.ts
@@ -7,6 +7,8 @@
 
 import type { JSONSchema } from "@commonfabric/api";
 
+import type { HarnessSkillAcquisition } from "./skill.ts";
+
 /** Discriminator value of a {@link HarnessHandleTable}. */
 export const HARNESS_HANDLE_TABLE_TYPE = "cf-harness.handle-table";
 
@@ -104,6 +106,19 @@ export interface HarnessHandleEntry {
    * trusted.
    */
   schemaSource?: "harness";
+
+  /**
+   * Where the value behind a `skill-context` handle was fetched from, recorded
+   * by the host step that fetched it. The entry is the only durable place that
+   * knows: the parent holds a token, the child holds text, and neither can say
+   * which commit the bytes came from. Carrying it here is what lets the
+   * activation record a delegation writes name that commit.
+   *
+   * Absent on every handle whose value the harness did not fetch from an
+   * external source. A model can neither write nor read this field; it reaches
+   * a model-visible surface nowhere.
+   */
+  acquisition?: HarnessSkillAcquisition;
 }
 
 /**

--- a/packages/cf-harness/src/contracts/skill.ts
+++ b/packages/cf-harness/src/contracts/skill.ts
@@ -249,9 +249,12 @@ export interface HarnessSkillActivation {
 
   /**
    * The parent-held handle token a `skill-handle` activation's text was
-   * materialized through. Together with {@link digest} this is the
-   * activation's provenance: which reference supplied the skill, and the
-   * exact text it resolved to at activation time.
+   * materialized through. With {@link digest} it says which reference
+   * supplied the skill and the exact text it resolved to at activation time —
+   * the whole provenance for a handle the harness did not fetch. Where the
+   * handle came from an acquisition, {@link HarnessSkillActivation.acquisition}
+   * carries the rest of it, and a reader after the external source wants that
+   * field rather than this one.
    */
   handleToken?: string;
 

--- a/packages/cf-harness/src/contracts/skill.ts
+++ b/packages/cf-harness/src/contracts/skill.ts
@@ -191,6 +191,36 @@ export type HarnessSkillActivationSource =
   | "subagent-inherit"
   | "skill-handle";
 
+/**
+ * Where a handle-delivered skill's text was fetched from, as the trusted host
+ * recorded it at acquisition. Every field is host-computed or host-observed:
+ * none is read out of the fetched bytes, which is what lets a reader treat
+ * this as provenance rather than as a claim the skill makes about itself.
+ *
+ * It grants nothing. Its job is to make acting under an externally acquired
+ * skill's influence a legible event, so a reader of the activation record can
+ * name the commit whose bytes shaped the run.
+ */
+export interface HarnessSkillAcquisition {
+  /** Discovery id the pin was resolved from, in `owner/repo/slug` form. */
+  registryId: string;
+
+  /** Full commit SHA of the immutable tree the bytes were read from. */
+  commitSha: string;
+
+  /** The exact pinned URL fetched. */
+  sourceUrl: string;
+
+  /** How the address was pinned. */
+  verification: "git-commit-sha";
+
+  /** Digest the host computed over the fetched bytes. */
+  valueDigest: string;
+
+  /** Host wall-clock time the bytes were received (ISO 8601). */
+  receivedAt: string;
+}
+
 export interface HarnessSkillActivation {
   name: string;
   source: HarnessSkillActivationSource;
@@ -224,6 +254,14 @@ export interface HarnessSkillActivation {
    * exact text it resolved to at activation time.
    */
   handleToken?: string;
+
+  /**
+   * Where the skill text came from, for a `skill-handle` activation whose
+   * handle was minted by an external acquisition. Absent when the handle
+   * names a cell this harness did not fetch — an operator-seeded skill cell,
+   * say — where there is no external source to name.
+   */
+  acquisition?: HarnessSkillAcquisition;
 }
 
 export interface HarnessSkillActivations {

--- a/packages/cf-harness/src/contracts/subagent.ts
+++ b/packages/cf-harness/src/contracts/subagent.ts
@@ -573,6 +573,16 @@ interface HarnessSubagentRunRefBase {
    * memory is what makes it survive a resume.
    */
   skillHandle?: string;
+
+  /**
+   * Set when this delegation stated it deliberately carries no acquired
+   * skill. It discharges the run's outstanding custody: the parent has
+   * answered the question the refusal asks, once, and later delegations are
+   * not asked again. Recording it here rather than in memory is what makes
+   * the answer survive a resume, and what lets a reader see that a
+   * skill-free child was chosen rather than a field dropped.
+   */
+  withoutSkillHandle?: boolean;
 }
 
 export interface HarnessRunningSubagentRunRef
@@ -640,7 +650,9 @@ export interface DelegateTaskToolInput {
    *
    * It grants nothing and attaches nothing. Its whole effect is to make the
    * choice explicit in the transcript and the run state, so a reader can tell
-   * a considered decision from a dropped field.
+   * a considered decision from a dropped field. Stating it once discharges
+   * the custody it answers: a run does not carry the flag for the rest of its
+   * life because one child died.
    */
   withoutSkillHandle?: boolean;
 }

--- a/packages/cf-harness/src/contracts/subagent.ts
+++ b/packages/cf-harness/src/contracts/subagent.ts
@@ -559,6 +559,20 @@ interface HarnessSubagentRunRefBase {
   parentToolCallId: string;
   childRunId: string;
   manifest: HarnessSubagentRunManifest;
+
+  /**
+   * The skill-context handle token this delegation carried, when it carried
+   * one. Absent means the child ran with no acquired skill, which is a fact
+   * about the run and not a gap in the record.
+   *
+   * The run's outstanding skill custody is read off this field and {@link
+   * HarnessTerminalSubagentRunRef.status}: a token whose most recent
+   * delegation did not complete has custody outstanding, and the next
+   * delegation must either carry that token again or say it is deliberately
+   * running without it. Deriving custody from the run state rather than from
+   * memory is what makes it survive a resume.
+   */
+  skillHandle?: string;
 }
 
 export interface HarnessRunningSubagentRunRef
@@ -616,6 +630,19 @@ export interface DelegateTaskToolInput {
    * unforgeable table membership instead of by name.
    */
   skillHandle?: string;
+
+  /**
+   * States that this delegation deliberately carries no acquired skill. It is
+   * required — and meaningful — only while the run has outstanding skill
+   * custody: a delegation that carried a handle did not complete, and the
+   * next one omitting {@link DelegateTaskToolInput.skillHandle} would
+   * otherwise silently produce work nothing records as skill-free.
+   *
+   * It grants nothing and attaches nothing. Its whole effect is to make the
+   * choice explicit in the transcript and the run state, so a reader can tell
+   * a considered decision from a dropped field.
+   */
+  withoutSkillHandle?: boolean;
 }
 
 export interface DelegateTaskToolOutput {

--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -41,6 +41,7 @@ import type { PromptSlotBinding } from "./contracts/prompt-slot.ts";
 import { harnessCredentialOwnersEqual } from "./contracts/run-manifest.ts";
 import type { HarnessRunReport } from "./contracts/run-report.ts";
 import type {
+  HarnessSkillAcquisition,
   HarnessSkillActivations,
   HarnessSkillRegistry,
   HarnessSkillResourceRead,
@@ -1051,12 +1052,20 @@ export class CfHarnessEngine {
     await this.persistRunState();
   }
 
-  /** Mints and records a handle consumable only as delegated skill context. */
-  async mintSkillContextHandle(ref: string): Promise<string> {
+  /**
+   * Mints and records a handle consumable only as delegated skill context,
+   * carrying `acquisition` as the entry's record of where the value came
+   * from. Only a host step that performed the fetch can supply that record,
+   * and it is what a later delegation's activation names.
+   */
+  async mintSkillContextHandle(
+    ref: string,
+    acquisition: HarnessSkillAcquisition,
+  ): Promise<string> {
     const minted = await mintAddressHandle(
       this.handleTable ?? createHarnessHandleTable(this.#runState.runId),
       ref,
-      { capability: "skill-context" },
+      { capability: "skill-context", acquisition },
     );
     await this.recordHandleTable(minted.table);
     return minted.token;
@@ -1888,7 +1897,10 @@ export class CfHarnessEngine {
           getSkillsShAcquisitionClient: this.#skillsShAcquisitionClientFactory,
         }
         : {}),
-      mintSkillContextHandle: (ref: string) => this.mintSkillContextHandle(ref),
+      mintSkillContextHandle: (
+        ref: string,
+        acquisition: HarnessSkillAcquisition,
+      ) => this.mintSkillContextHandle(ref, acquisition),
       ...(this.#taskText !== undefined ? { taskText: this.#taskText } : {}),
       sandbox: this.sandbox,
       hostProcessRunner: this.hostProcessRunner,

--- a/packages/cf-harness/src/handle-table.ts
+++ b/packages/cf-harness/src/handle-table.ts
@@ -30,6 +30,16 @@ import {
   type HarnessHandleTable,
   MIN_HANDLE_TOKEN_SUFFIX_LENGTH,
 } from "./contracts/handle-table.ts";
+import type { HarnessSkillAcquisition } from "./contracts/skill.ts";
+
+/** Acquisition fields every recorded provenance must carry as a non-empty string. */
+const ACQUISITION_STRING_FIELDS = [
+  "registryId",
+  "commitSha",
+  "sourceUrl",
+  "valueDigest",
+  "receivedAt",
+] as const satisfies readonly (keyof HarnessSkillAcquisition)[];
 
 /**
  * Digest function used to derive token suffixes. A seam for tests that need
@@ -161,6 +171,15 @@ export interface MintAddressHandleOptions {
    * provenance `describe_handle` discloses.
    */
   schema?: JSONSchema;
+
+  /**
+   * Where the caller fetched the value at the address from, when the caller is
+   * the host step that fetched it. Recorded verbatim onto the entry, and
+   * filled the same way a schema is: an entry that already carries one keeps
+   * it, because the token holders already delegating through it were told
+   * about the first.
+   */
+  acquisition?: HarnessSkillAcquisition;
 }
 
 /**
@@ -192,11 +211,13 @@ export const mintAddressHandle = async (
   const key = addressKey(link);
   const schema = options.schema;
   const capability = options.capability;
+  const acquisition = options.acquisition;
   const existing = table.entries.find((entry) => entry.addressKey === key);
   if (existing !== undefined) {
     const nextCapability = existing.capability ?? capability;
     if (
       (existing.schema !== undefined || schema === undefined) &&
+      (existing.acquisition !== undefined || acquisition === undefined) &&
       existing.capability === nextCapability
     ) {
       return { table, token: existing.token };
@@ -210,6 +231,9 @@ export const mintAddressHandle = async (
               ...entry,
               ...(entry.schema === undefined && schema !== undefined
                 ? { schema, schemaSource: "harness" as const }
+                : {}),
+              ...(entry.acquisition === undefined && acquisition !== undefined
+                ? { acquisition }
                 : {}),
               ...(nextCapability !== undefined
                 ? { capability: nextCapability }
@@ -242,6 +266,7 @@ export const mintAddressHandle = async (
     ...(schema !== undefined
       ? { schema, schemaSource: "harness" as const }
       : {}),
+    ...(acquisition !== undefined ? { acquisition } : {}),
   };
   return {
     table: { ...table, entries: [...table.entries, entry] },
@@ -561,6 +586,32 @@ export const assertValidHarnessHandleTable = (
           String(entry.capability)
         }\``,
       );
+    }
+    if (entry.acquisition !== undefined) {
+      // Acquisition provenance is trusted-side only, so a table that arrives
+      // claiming it on a handle no acquisition could have minted is refused
+      // rather than read: a `skill-context` capability is what says the value
+      // is skill text a host step fetched.
+      if (entry.capability !== "skill-context") {
+        throw new Error(
+          `invalid handle table: entry \`${entry.token}\` carries acquisition provenance without the \`skill-context\` capability`,
+        );
+      }
+      for (const field of ACQUISITION_STRING_FIELDS) {
+        const value = entry.acquisition[field];
+        if (typeof value !== "string" || value.length === 0) {
+          throw new Error(
+            `invalid handle table: entry \`${entry.token}\` has an empty acquisition \`${field}\``,
+          );
+        }
+      }
+      if (entry.acquisition.verification !== "git-commit-sha") {
+        throw new Error(
+          `invalid handle table: entry \`${entry.token}\` has an unknown acquisition verification \`${
+            String(entry.acquisition.verification)
+          }\``,
+        );
+      }
     }
     if (tokens.has(entry.token)) {
       throw new Error(

--- a/packages/cf-harness/src/handle-table.ts
+++ b/packages/cf-harness/src/handle-table.ts
@@ -588,6 +588,17 @@ export const assertValidHarnessHandleTable = (
       );
     }
     if (entry.acquisition !== undefined) {
+      // Shape before fields: a persisted table is untrusted input, and reading
+      // a field off a null or an array would fail as a TypeError naming
+      // neither the table nor the entry.
+      if (
+        typeof entry.acquisition !== "object" || entry.acquisition === null ||
+        Array.isArray(entry.acquisition)
+      ) {
+        throw new Error(
+          `invalid handle table: entry \`${entry.token}\` has an acquisition that is not an object`,
+        );
+      }
       // Acquisition provenance is trusted-side only, so a table that arrives
       // claiming it on a handle no acquisition could have minted is refused
       // rather than read: a `skill-context` capability is what says the value

--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -1168,6 +1168,12 @@ export const scrubHandleSkillTextDeep = (
  * token whose latest delegation completed is not outstanding, so an ordinary
  * run that delegated once and succeeded is never gated.
  *
+ * `running` counts as not completed, which costs nothing while a run is
+ * healthy — tool calls are dispatched one at a time, so a delegation's
+ * terminal ref always supersedes its running ref before the next delegation is
+ * judged — and is the whole answer after a crash, where the running ref is the
+ * only trace the lost delegation left.
+ *
  * Reads the parent's own run state, so the answer survives a resume: nothing
  * about custody lives only in this process.
  */
@@ -1177,10 +1183,6 @@ export const outstandingSkillCustody = (
   const latestCompleted = new Map<string, boolean>();
   for (const run of subagentRuns) {
     if (run.skillHandle === undefined) continue;
-    // A `running` ref is superseded by the terminal ref recorded for the same
-    // delegation, and a delegation still in flight has not failed, so only a
-    // terminal status decides.
-    if (run.status === "running") continue;
     latestCompleted.set(run.skillHandle, run.status === "completed");
   }
   return [...latestCompleted]

--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -51,6 +51,7 @@ import {
   type HarnessToolPolicyDecision,
 } from "./contracts/run-report.ts";
 import type {
+  HarnessSkillAcquisition,
   HarnessSkillActivation,
   HarnessSkillRegistry,
 } from "./contracts/skill.ts";
@@ -71,6 +72,7 @@ import {
   type HarnessSubagentProfileConfig,
   type HarnessSubagentResult,
   type HarnessSubagentRunManifest,
+  type HarnessSubagentRunRef,
   type HarnessSubagentRunStateSummary,
   type HarnessSubagentStructuredReturn,
   isHarnessSubagentProfile,
@@ -829,6 +831,28 @@ const parseDelegateTaskInput = (
       },
     };
   }
+  if (
+    input.withoutSkillHandle !== undefined &&
+    typeof input.withoutSkillHandle !== "boolean"
+  ) {
+    return {
+      invalid: {
+        field: "withoutSkillHandle",
+        expected: "`true` to state the delegation carries no skill, or omit it",
+      },
+    };
+  }
+  // Both together is a call that says two things at once, and the harness
+  // would have to pick one. Refusing states which fields disagree instead.
+  if (input.skillHandle !== undefined && input.withoutSkillHandle === true) {
+    return {
+      invalid: {
+        field: "withoutSkillHandle",
+        expected:
+          "omitted when `skillHandle` is supplied; a delegation carries a skill or states it does not",
+      },
+    };
+  }
   let parsedReturnSchema: ReturnType<typeof parseSubagentReturnSchema>;
   try {
     parsedReturnSchema = parseSubagentReturnSchema(input.returnSchema);
@@ -876,6 +900,9 @@ const parseDelegateTaskInput = (
       ...(patternRefs !== undefined ? { patternRefs } : {}),
       ...(typeof input.skillHandle === "string"
         ? { skillHandle: input.skillHandle.trim() }
+        : {}),
+      ...(input.withoutSkillHandle === true
+        ? { withoutSkillHandle: true }
         : {}),
     },
   };
@@ -1128,6 +1155,37 @@ export const scrubHandleSkillTextDeep = (
     );
   }
   return value;
+};
+
+/**
+ * The skill-context tokens this run acquired, delegated, and has not yet seen
+ * a completed delegation for — in first-delegated order.
+ *
+ * A token is outstanding when the most recent delegation carrying it did not
+ * complete. That is the state a model-driven retry appears in: the child died,
+ * the parent will issue the task again, and a re-issue that drops the token
+ * produces work no record connects to the skill the run acquired for it. A
+ * token whose latest delegation completed is not outstanding, so an ordinary
+ * run that delegated once and succeeded is never gated.
+ *
+ * Reads the parent's own run state, so the answer survives a resume: nothing
+ * about custody lives only in this process.
+ */
+export const outstandingSkillCustody = (
+  subagentRuns: readonly HarnessSubagentRunRef[],
+): readonly string[] => {
+  const latestCompleted = new Map<string, boolean>();
+  for (const run of subagentRuns) {
+    if (run.skillHandle === undefined) continue;
+    // A `running` ref is superseded by the terminal ref recorded for the same
+    // delegation, and a delegation still in flight has not failed, so only a
+    // terminal status decides.
+    if (run.status === "running") continue;
+    latestCompleted.set(run.skillHandle, run.status === "completed");
+  }
+  return [...latestCompleted]
+    .filter(([, completed]) => !completed)
+    .map(([token]) => token);
 };
 
 const resolveChildHandleTokens = (
@@ -3622,6 +3680,41 @@ export class CfHarnessPromptLoop {
         };
       }
       policyDecisionReasonCodes.push("subagent_profile_allowed");
+      if (
+        delegateInput.skillHandle === undefined &&
+        delegateInput.withoutSkillHandle !== true
+      ) {
+        // Custody, not carry-forward: the harness will not attach an acquired
+        // skill to a child the parent did not choose to give it, because
+        // choosing which child reads untrusted text is the decision
+        // `delegate_task` exists to record. What it refuses to accept is the
+        // decision going unmade — a delegation that neither carries the
+        // outstanding handle nor says it is running without one.
+        const outstanding = outstandingSkillCustody(
+          this.engine.getRunState().subagentRuns ?? [],
+        );
+        if (outstanding.length > 0) {
+          return await this.#rejectInvalidToolCall({
+            toolCall,
+            invalid: {
+              reason: "invalid-argument",
+              toolId: "delegate_task",
+              field: "skillHandle",
+              expected:
+                `either \`skillHandle\` set to a handle whose delegation did not complete (${
+                  outstanding.join(", ")
+                }), or \`withoutSkillHandle\` set to \`true\` to state this child runs with no acquired skill`,
+            },
+            sequence,
+            startedAt: activityStartedAt,
+            effectClass: tool.descriptor.effectClass,
+            ...(promptSlotBinding !== undefined ? { promptSlotBinding } : {}),
+            toolInputSummary,
+            policyEventIndexes,
+            recordActivity,
+          });
+        }
+      }
       if (delegateInput.skillHandle !== undefined) {
         // Trusted-side materialization, refused BEFORE dispatch: a handle
         // this run does not hold is a model-written-call mistake (the same
@@ -3685,6 +3778,9 @@ export class CfHarnessPromptLoop {
         resolvedDelegateSkill = {
           text: resolution.value.trimEnd(),
           token: entry!.token,
+          ...(entry!.acquisition !== undefined
+            ? { acquisition: entry!.acquisition }
+            : {}),
         };
       }
     }
@@ -4082,8 +4178,15 @@ export class CfHarnessPromptLoop {
     toolCall: HarnessToolCall;
     input: DelegateTaskToolInput;
 
-    /** The materialized skillHandle text + token, resolved before dispatch. */
-    resolvedSkill?: { text: string; token: string };
+    /**
+     * The materialized skillHandle text, its token, and the acquisition the
+     * token's entry records, all resolved before dispatch.
+     */
+    resolvedSkill?: {
+      text: string;
+      token: string;
+      acquisition?: HarnessSkillAcquisition;
+    };
 
     model: string;
     promptSlotBinding?: PromptSlotBinding;
@@ -4274,6 +4377,9 @@ export class CfHarnessPromptLoop {
       childRunId,
       status: "running",
       manifest,
+      ...(options.resolvedSkill !== undefined
+        ? { skillHandle: options.resolvedSkill.token }
+        : {}),
     });
     const childLoop = new CfHarnessPromptLoop({
       engine: childEngine,
@@ -4352,6 +4458,9 @@ export class CfHarnessPromptLoop {
         const handleSkill = await loadHarnessSkillContextFromText({
           text: options.resolvedSkill.text,
           handleToken: options.resolvedSkill.token,
+          ...(options.resolvedSkill.acquisition !== undefined
+            ? { acquisition: options.resolvedSkill.acquisition }
+            : {}),
           runId: childRunId,
           activatedAt: childCreatedState.updatedAt,
         });
@@ -4501,6 +4610,9 @@ export class CfHarnessPromptLoop {
       status: subagent.status,
       summary: subagent.summary,
       manifest,
+      ...(options.resolvedSkill !== undefined
+        ? { skillHandle: options.resolvedSkill.token }
+        : {}),
       runState: subagent.runState,
       ...(structuredReturn !== undefined ? { structuredReturn } : {}),
     });

--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -1174,6 +1174,11 @@ export const scrubHandleSkillTextDeep = (
  * judged — and is the whole answer after a crash, where the running ref is the
  * only trace the lost delegation left.
  *
+ * A delegation that declared `withoutSkillHandle` discharges everything
+ * outstanding when it is reached. The refusal exists to make the parent answer
+ * once; a run that answered is not asked again, and does not carry the flag
+ * for the rest of its life because one child died.
+ *
  * Reads the parent's own run state, so the answer survives a resume: nothing
  * about custody lives only in this process.
  */
@@ -1182,6 +1187,10 @@ export const outstandingSkillCustody = (
 ): readonly string[] => {
   const latestCompleted = new Map<string, boolean>();
   for (const run of subagentRuns) {
+    if (run.withoutSkillHandle === true) {
+      latestCompleted.clear();
+      continue;
+    }
     if (run.skillHandle === undefined) continue;
     latestCompleted.set(run.skillHandle, run.status === "completed");
   }
@@ -4382,6 +4391,9 @@ export class CfHarnessPromptLoop {
       ...(options.resolvedSkill !== undefined
         ? { skillHandle: options.resolvedSkill.token }
         : {}),
+      ...(delegateInput.withoutSkillHandle === true
+        ? { withoutSkillHandle: true }
+        : {}),
     });
     const childLoop = new CfHarnessPromptLoop({
       engine: childEngine,
@@ -4614,6 +4626,9 @@ export class CfHarnessPromptLoop {
       manifest,
       ...(options.resolvedSkill !== undefined
         ? { skillHandle: options.resolvedSkill.token }
+        : {}),
+      ...(delegateInput.withoutSkillHandle === true
+        ? { withoutSkillHandle: true }
         : {}),
       runState: subagent.runState,
       ...(structuredReturn !== undefined ? { structuredReturn } : {}),

--- a/packages/cf-harness/src/skills/registry.ts
+++ b/packages/cf-harness/src/skills/registry.ts
@@ -13,6 +13,7 @@ import {
 import {
   HARNESS_SKILL_ACTIVATIONS_TYPE,
   HARNESS_SKILL_REGISTRY_TYPE,
+  type HarnessSkillAcquisition,
   type HarnessSkillActivation,
   type HarnessSkillActivations,
   type HarnessSkillActivationSource,
@@ -68,6 +69,12 @@ export interface LoadHarnessSkillContextFromTextOptions {
 
   /** The parent-held token the text was materialized through. */
   handleToken: string;
+
+  /**
+   * Where the handle's value was fetched from, when the token's entry carries
+   * that record. Omitted for a handle the harness did not acquire.
+   */
+  acquisition?: HarnessSkillAcquisition;
 
   runId: string;
   activatedAt?: string;
@@ -848,6 +855,9 @@ export const loadHarnessSkillContextFromText = async (
       activatedAt,
       cfcPromptRole: "context",
       handleToken: options.handleToken,
+      ...(options.acquisition !== undefined
+        ? { acquisition: options.acquisition }
+        : {}),
     },
   };
 };

--- a/packages/cf-harness/src/tools/acquire-skill.ts
+++ b/packages/cf-harness/src/tools/acquire-skill.ts
@@ -242,8 +242,20 @@ export const acquireSkillTool: HarnessToolDefinition<
         );
       }
       await runtime.idle();
+      // The same host-observed facts the mark on the write carries, kept on
+      // the handle entry as well: the mark travels with the cell and the
+      // entry travels with the token, and it is the token a later delegation
+      // resolves when it writes the child's activation record.
       const skillHandle = await context.mintSkillContextHandle(
         createLLMFriendlyLink(link, space),
+        {
+          registryId: resolvedPin.id,
+          commitSha: resolvedPin.commitSha,
+          sourceUrl: acquired.sourceUrl,
+          verification: "git-commit-sha",
+          valueDigest: acquired.valueDigest,
+          receivedAt,
+        },
       );
       return {
         outputId,

--- a/packages/cf-harness/src/tools/delegate-task.ts
+++ b/packages/cf-harness/src/tools/delegate-task.ts
@@ -87,7 +87,12 @@ export const delegateTaskTool: HarnessToolDefinition<
         skillHandle: {
           type: "string",
           description:
-            "Optional handle (cfh:a:… token) naming a cell whose string value is skill text for the child. The text is materialized on the trusted host side and injected into the child's context; this run never sees it.",
+            "Optional handle (cfh:a:… token) naming a cell whose string value is skill text for the child. The text is materialized on the trusted host side and injected into the child's context; this run never sees it. A delegation that failed does not carry its handle forward: re-issuing it means passing the same token again.",
+        },
+        withoutSkillHandle: {
+          type: "boolean",
+          description:
+            "States that this delegation deliberately runs with no acquired skill. Required only after a delegation carrying a skillHandle failed, where omitting both fields is refused: the harness cannot tell a considered choice from a dropped one, and the child's work would carry no record either way. It attaches nothing and permits nothing.",
         },
       },
     },

--- a/packages/cf-harness/src/tools/types.ts
+++ b/packages/cf-harness/src/tools/types.ts
@@ -9,6 +9,7 @@ import type {
 } from "../contracts/cfc-invocation-context.ts";
 import type {
   HarnessAllowedSkillScript,
+  HarnessSkillAcquisition,
   HarnessSkillActivations,
   HarnessSkillRegistry,
   HarnessSkillResourceRead,
@@ -81,8 +82,17 @@ export interface HarnessToolContext {
    */
   getSkillsShAcquisitionClient?: () => Promise<SkillsShAcquisitionClient>;
 
-  /** Mints the sole capability that may enter delegate_task.skillHandle. */
-  mintSkillContextHandle?(ref: string): Promise<string>;
+  /**
+   * Mints the sole capability that may enter delegate_task.skillHandle,
+   * recording where the caller fetched the value from. The provenance is
+   * mandatory because the mint is reachable only from the acquisition step,
+   * which always knows it, and an entry without it could name no commit when
+   * the handle is later delegated.
+   */
+  mintSkillContextHandle?(
+    ref: string,
+    acquisition: HarnessSkillAcquisition,
+  ): Promise<string>;
 
   /**
    * Whether a pattern the model authored and ran successfully is published

--- a/packages/cf-harness/test/handle-table.test.ts
+++ b/packages/cf-harness/test/handle-table.test.ts
@@ -8,6 +8,7 @@ import {
   type HarnessHandleTable,
   MIN_HANDLE_TOKEN_SUFFIX_LENGTH,
 } from "../src/contracts/handle-table.ts";
+import type { HarnessSkillAcquisition } from "../src/contracts/skill.ts";
 import {
   assertValidHarnessHandleTable,
   createHarnessHandleTable,
@@ -28,6 +29,15 @@ const SUMMARY_SCHEMA = {
   type: "object",
   properties: { summary: { type: "string" } },
 } as const;
+const ACQUISITION = {
+  registryId: "owner/repository/slug",
+  commitSha: "f484c8265e70ec910a57342389cca5c5de7d8167",
+  sourceUrl:
+    "https://raw.githubusercontent.com/owner/repository/f484c8265e70ec910a57342389cca5c5de7d8167/skills/slug/SKILL.md",
+  verification: "git-commit-sha",
+  valueDigest: "sha256:B0YTDTjHlcVP6qHSqd5d4P5aGgCp9TS8VTB92T-rosg",
+  receivedAt: "2026-04-15T19:00:00.000Z",
+} as const satisfies HarnessSkillAcquisition;
 
 /**
  * A hasher that yields the same digest for every first-attempt preimage
@@ -725,6 +735,56 @@ describe("handle-table", () => {
 
       expect(() => assertValidHarnessHandleTable(broken)).toThrow(
         "unknown capability",
+      );
+    });
+
+    it("throws for acquisition provenance on an entry without the skill-context capability", async () => {
+      const { table } = await mintAddressHandle(
+        createHarnessHandleTable("run-1"),
+        LINK_A,
+        { acquisition: ACQUISITION },
+      );
+
+      expect(() => assertValidHarnessHandleTable(table)).toThrow(
+        "without the `skill-context` capability",
+      );
+    });
+
+    it("throws for an acquisition field that is not a non-empty string", async () => {
+      const { table } = await mintAddressHandle(
+        createHarnessHandleTable("run-1"),
+        LINK_A,
+        { capability: "skill-context", acquisition: ACQUISITION },
+      );
+      const broken = {
+        ...table,
+        entries: table.entries.map((entry) => ({
+          ...entry,
+          acquisition: { ...ACQUISITION, commitSha: "" },
+        })),
+      } as unknown as HarnessHandleTable;
+
+      expect(() => assertValidHarnessHandleTable(broken)).toThrow(
+        "empty acquisition `commitSha`",
+      );
+    });
+
+    it("throws for an acquisition verification outside the vocabulary", async () => {
+      const { table } = await mintAddressHandle(
+        createHarnessHandleTable("run-1"),
+        LINK_A,
+        { capability: "skill-context", acquisition: ACQUISITION },
+      );
+      const broken = {
+        ...table,
+        entries: table.entries.map((entry) => ({
+          ...entry,
+          acquisition: { ...ACQUISITION, verification: "vibes" },
+        })),
+      } as unknown as HarnessHandleTable;
+
+      expect(() => assertValidHarnessHandleTable(broken)).toThrow(
+        "unknown acquisition verification",
       );
     });
 

--- a/packages/cf-harness/test/handle-table.test.ts
+++ b/packages/cf-harness/test/handle-table.test.ts
@@ -750,6 +750,24 @@ describe("handle-table", () => {
       );
     });
 
+    it("throws for an acquisition that is not an object", async () => {
+      const { table } = await mintAddressHandle(
+        createHarnessHandleTable("run-1"),
+        LINK_A,
+        { capability: "skill-context", acquisition: ACQUISITION },
+      );
+      for (const acquisition of [null, ["not", "an", "object"], "text"]) {
+        const broken = {
+          ...table,
+          entries: table.entries.map((entry) => ({ ...entry, acquisition })),
+        } as unknown as HarnessHandleTable;
+
+        expect(() => assertValidHarnessHandleTable(broken)).toThrow(
+          "an acquisition that is not an object",
+        );
+      }
+    });
+
     it("throws for an acquisition field that is not a non-empty string", async () => {
       const { table } = await mintAddressHandle(
         createHarnessHandleTable("run-1"),

--- a/packages/cf-harness/test/prompt-loop-external-skill-acquisition.test.ts
+++ b/packages/cf-harness/test/prompt-loop-external-skill-acquisition.test.ts
@@ -4,6 +4,7 @@
  * the existing echo scrub prevents the child from returning it.
  */
 
+import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
 import { createSession, Identity } from "@commonfabric/identity";
 import { PiecesController } from "@commonfabric/piece/ops";
 import { Runtime } from "@commonfabric/runner";
@@ -12,6 +13,7 @@ import { expect } from "@std/expect";
 import { normalize } from "@std/path/posix";
 import { describe, it } from "@std/testing/bdd";
 
+import { DEFAULT_SUBAGENT_PROFILE } from "../src/contracts/subagent.ts";
 import { CfHarnessEngine } from "../src/engine.ts";
 import { CfHarnessPromptLoop } from "../src/prompt-loop.ts";
 import { SkillsShAcquisitionClient } from "../src/skills-sh/acquisition.ts";
@@ -202,99 +204,69 @@ describe("prompt-loop external skill acquisition", () => {
       });
       const requestBodies: unknown[] = [];
       let handleToken = "";
+      let acquireOffered: readonly string[] = [];
+      let childText = "";
+      // Each misuse refusal the parent read, in the order it read them. They
+      // are checked after the run: an `expect()` that throws inside the
+      // scripted fetch is swallowed by the model client's error path and
+      // fails nothing.
+      const refusals: string[] = [];
       const modelFetch: typeof fetch = (_input, init) => {
         const body = JSON.parse(String(init?.body));
         requestBodies.push(body);
         const index = requestBodies.length - 1;
         const view = chatViewOfRequest(body);
+        const lastToolContent = () =>
+          view.messages.findLast((message) => message.role === "tool")
+            ?.content ?? "";
         let turn: unknown;
         if (index === 0) {
-          expect(view.tools).toContain("acquire_skill");
+          acquireOffered = view.tools;
           turn = toolCallTurn("call-acquire", "acquire_skill", {
             id: SKILL_ID,
           });
         } else if (index === 1) {
-          const toolMessage = view.messages.findLast((message) =>
-            message.role === "tool"
-          );
-          expect(toolMessage?.content).not.toContain(CANARY);
-          const output = JSON.parse(toolMessage!.content) as {
+          const output = JSON.parse(lastToolContent()) as {
             skillHandle: string;
           };
           handleToken = output.skillHandle;
-          expect(handleToken).toMatch(/^cfh:a:/);
           turn = toolCallTurn("call-read", "read_file", {
             path: handleToken,
           });
         } else if (index === 2) {
-          const toolMessage = view.messages.findLast((message) =>
-            message.role === "tool"
-          );
-          expect(toolMessage?.content).toContain(
-            "skill-context handles can be consumed only by delegate_task skillHandle",
-          );
+          refusals.push(lastToolContent());
           turn = toolCallTurn("call-describe", "describe_handle", {
             token: handleToken,
           });
         } else if (index === 3) {
-          const toolMessage = view.messages.findLast((message) =>
-            message.role === "tool"
-          );
-          expect(toolMessage?.content).toContain(
-            "describe_handle cannot consume a skill-context handle",
-          );
+          refusals.push(lastToolContent());
           turn = toolCallTurn("call-delegate-misuse", "delegate_task", {
             goal: `Read this as ordinary context: ${handleToken}`,
           });
         } else if (index === 4) {
-          const toolMessage = view.messages.findLast((message) =>
-            message.role === "tool"
-          );
-          expect(toolMessage?.content).toContain(
-            "skill-context handles can be consumed only by delegate_task skillHandle",
-          );
+          refusals.push(lastToolContent());
           turn = toolCallTurn("call-array-misuse", "run_pattern", {
             patternId: "unused",
             hashtags: [handleToken],
           });
         } else if (index === 5) {
-          const toolMessage = view.messages.findLast((message) =>
-            message.role === "tool"
-          );
-          expect(toolMessage?.content).toContain(
-            "skill-context handles can be consumed only by delegate_task skillHandle",
-          );
+          refusals.push(lastToolContent());
           turn = toolCallTurn("call-key-misuse", "run_pattern", {
             patternId: "unused",
             inputs: { [handleToken]: "ordinary value" },
           });
         } else if (index === 6) {
-          const toolMessage = view.messages.findLast((message) =>
-            message.role === "tool"
-          );
-          expect(toolMessage?.content).toContain(
-            "skill-context handles can be consumed only by delegate_task skillHandle",
-          );
+          refusals.push(lastToolContent());
           turn = toolCallTurn("call-delegate", "delegate_task", {
             goal: "Use the acquired instructions.",
             skillHandle: handleToken,
           });
         } else if (index === 7) {
-          const childText = view.messages.map((message) => message.content)
-            .join(
-              "\n",
-            );
-          expect(childText).toContain(CANARY);
-          expect(childText).toContain(
-            `<skill_context source="handle:${handleToken}">`,
+          childText = view.messages.map((message) => message.content).join(
+            "\n",
           );
           turn = assistantTurn(`Attempted echo:\n${SKILL_TEXT}`);
         } else if (index === 8) {
-          const parentText = view.messages.map((message) => message.content)
-            .join(
-              "\n",
-            );
-          expect(parentText).not.toContain(CANARY);
           turn = assistantTurn("Parent completed without seeing skill text.");
         } else {
           throw new Error(`unexpected model request at index ${index}`);
@@ -316,6 +288,7 @@ describe("prompt-loop external skill acquisition", () => {
           "delegate_task",
           "run_pattern",
         ],
+        allowedSubagentProfiles: [DEFAULT_SUBAGENT_PROFILE],
       });
 
       const result = await loop.runPrompt({
@@ -327,6 +300,26 @@ describe("prompt-loop external skill acquisition", () => {
       );
       expect(result.finalAssistantText).not.toContain(CANARY);
       expect(requestBodies).toHaveLength(9);
+      expect(acquireOffered).toContain("acquire_skill");
+      expect(handleToken).toMatch(/^cfh:a:/);
+      // Every route by which the parent could have read the value behind the
+      // token instead of delegating it, refused.
+      const handleOnlyRefusal =
+        "skill-context handles can be consumed only by delegate_task skillHandle";
+      expect(refusals).toHaveLength(5);
+      expect(refusals[0]).toContain(handleOnlyRefusal);
+      expect(refusals[1]).toContain(
+        "describe_handle cannot consume a skill-context handle",
+      );
+      for (const refusal of refusals.slice(2)) {
+        expect(refusal).toContain(handleOnlyRefusal);
+      }
+      // The one child that ran received the text, under the token's own
+      // source attribute.
+      expect(childText).toContain(CANARY);
+      expect(childText).toContain(
+        `<skill_context source="handle:${handleToken}">`,
+      );
       for (const index of [0, 1, 2, 3, 4, 5, 6, 8]) {
         const parentText = chatViewOfRequest(requestBodies[index]).messages
           .map((message) => message.content).join("\n");
@@ -335,6 +328,217 @@ describe("prompt-loop external skill acquisition", () => {
     } finally {
       await runtime.dispose();
       await storageManager.close();
+    }
+  });
+
+  it("refuses a retry that drops the handle, and records the pin on the child that receives it", async () => {
+    // The whole arc a dropped handle hides in: acquire, delegate, lose the
+    // child, delegate again. The second delegation is where custody is either
+    // held or silently lost, and the third is where the record has to say
+    // which commit shaped the work that shipped.
+
+    const identity = await Identity.fromPassphrase(
+      `external-skill-custody-${crypto.randomUUID()}`,
+    );
+    const storageManager = StorageManager.emulate({ as: identity });
+    const runtime = new Runtime({
+      apiUrl: new URL("http://toolshed.test"),
+      storageManager,
+      cfcEnforcementMode: "disabled",
+      cfcFlowLabels: "off",
+    });
+    const pieces = new PiecesController(
+      await createSession({
+        identity,
+        spaceName: `external-skill-custody-${crypto.randomUUID()}`,
+      }),
+      runtime,
+    );
+    await pieces.synced();
+    const artifactRoot = await Deno.makeTempDir({
+      prefix: "external-skill-custody-",
+    });
+    try {
+      const runId = "external-skill-custody-run";
+      const engine = new CfHarnessEngine({
+        sandboxRuntime: new FakeSandboxRuntime(),
+        runId,
+        artifactRoot,
+        model: "gpt-5.4",
+        cfcEnforcementMode: "disabled",
+        fabricSessionFactory: () => Promise.resolve({ pieces }),
+        skillsShAcquisitionClientFactory: () =>
+          Promise.resolve(
+            new SkillsShAcquisitionClient({ fetch: githubFetch }),
+          ),
+      });
+      const requestBodies: unknown[] = [];
+      let handleToken = "";
+      let firstDelegationOutput = "";
+      let retryRefusal = "";
+      let retriedChildText = "";
+      // Every check on what a request carried is made after the run, on text
+      // captured here: an `expect()` that throws inside the scripted fetch is
+      // swallowed by the model client's error path and fails nothing.
+      const modelFetch: typeof fetch = (_input, init) => {
+        const body = JSON.parse(String(init?.body));
+        requestBodies.push(body);
+        const index = requestBodies.length - 1;
+        const view = chatViewOfRequest(body);
+        const lastToolContent = () =>
+          view.messages.findLast((message) => message.role === "tool")
+            ?.content ?? "";
+        let turn: unknown;
+        if (index === 0) {
+          turn = toolCallTurn("call-acquire", "acquire_skill", {
+            id: SKILL_ID,
+          });
+        } else if (index === 1) {
+          handleToken =
+            (JSON.parse(lastToolContent()) as { skillHandle: string })
+              .skillHandle;
+          turn = toolCallTurn("call-first", "delegate_task", {
+            goal: "Use the acquired instructions.",
+            skillHandle: handleToken,
+          });
+        } else if (index === 2) {
+          // The child's own request. Answering it with a provider error is
+          // what leaves the first delegation failed and its custody
+          // outstanding.
+          return Promise.resolve(
+            new Response("upstream stream error", { status: 500 }),
+          );
+        } else if (index === 3) {
+          firstDelegationOutput = lastToolContent();
+          turn = toolCallTurn("call-retry-bare", "delegate_task", {
+            goal: "Use the acquired instructions.",
+          });
+        } else if (index === 4) {
+          retryRefusal = lastToolContent();
+          turn = toolCallTurn("call-retry-held", "delegate_task", {
+            goal: "Use the acquired instructions.",
+            skillHandle: handleToken,
+          });
+        } else if (index === 5) {
+          retriedChildText = view.messages.map((message) => message.content)
+            .join("\n");
+          turn = assistantTurn("Worked through the acquired instructions.");
+        } else if (index === 6) {
+          turn = assistantTurn("Parent shipped the retried result.");
+        } else {
+          throw new Error(`unexpected model request at index ${index}`);
+        }
+        return Promise.resolve(
+          new Response(JSON.stringify(responsesBodyFromChatFixture(turn)), {
+            status: 200,
+          }),
+        );
+      };
+      const loop = new CfHarnessPromptLoop({
+        apiKey: "test-key",
+        engine,
+        fetchFn: modelFetch,
+        allowedToolIds: ["acquire_skill", "delegate_task"],
+        allowedSubagentProfiles: [DEFAULT_SUBAGENT_PROFILE],
+      });
+
+      const result = await loop.runPrompt({
+        prompt: "Acquire the skill and see the work through.",
+      });
+
+      expect(result.finalAssistantText).toBe(
+        "Parent shipped the retried result.",
+      );
+      expect(requestBodies).toHaveLength(7);
+      // The first delegation ran a child and lost it.
+      expect(firstDelegationOutput).toContain('"status":"failed"');
+      // The retry that carried the handle again reached a child holding the
+      // skill text, which is what makes the refusal in between meaningful.
+      expect(retriedChildText).toContain(CANARY);
+      expect(retriedChildText).toContain(
+        `<skill_context source="handle:${handleToken}">`,
+      );
+      // The bare retry never reached a child: it came back as an invalid tool
+      // call naming the handle whose delegation did not complete.
+      expect(retryRefusal).toContain("cf-harness.invalid-tool-call");
+      expect(retryRefusal).toContain(handleToken);
+      expect(retryRefusal).toContain("withoutSkillHandle");
+      const childRuns = result.runState.subagentRuns ?? [];
+      const terminalChildRuns = childRuns.filter((run) =>
+        run.status !== "running"
+      );
+      expect(terminalChildRuns.map((run) => run.status)).toEqual([
+        "failed",
+        "completed",
+      ]);
+      // Both delegations that ran carried the handle, and the record says so.
+      expect(terminalChildRuns.map((run) => run.skillHandle)).toEqual([
+        handleToken,
+        handleToken,
+      ]);
+      // The child that produced the shipped answer holds an activation naming
+      // the commit its instructions came from.
+      const activations = JSON.parse(
+        await Deno.readTextFile(
+          `${artifactRoot}/${
+            terminalChildRuns[1]!.childRunId
+          }/skill-activations.json`,
+        ),
+      ) as {
+        activations: {
+          source: string;
+          acquisition?: Record<string, string>;
+        }[];
+      };
+      const handleActivation = activations.activations.find((activation) =>
+        activation.source === "skill-handle"
+      );
+      expect(handleActivation?.acquisition).toEqual({
+        registryId: SKILL_ID,
+        commitSha: COMMIT_SHA,
+        sourceUrl: SKILL_URL,
+        verification: "git-commit-sha",
+        valueDigest: handleActivation!.acquisition!.valueDigest,
+        receivedAt: handleActivation!.acquisition!.receivedAt,
+      });
+      expect(handleActivation?.acquisition?.valueDigest).toMatch(/^sha256:/);
+      // The pin is provenance, never the payload: nothing about it carries the
+      // skill's own bytes back to a reader of the record.
+      expect(JSON.stringify(activations)).not.toContain(CANARY);
+      // The same acquisition also anchors an `ExternalIngest` mark on the cell
+      // it wrote, so the provenance is on the value as well as in the record.
+      const replica = storageManager.open(pieces.getSpace())
+        .replica as unknown as {
+          getDocument(id: string): {
+            cfc?: {
+              labelMap?: {
+                entries: {
+                  origin?: string;
+                  label: { integrity?: { type: string }[] };
+                }[];
+              };
+            };
+          } | undefined;
+        };
+      const skillCellId = runtime.getCell(
+        pieces.getSpace(),
+        `external-skill:${runId}:${runId}:acquire_skill:1`,
+        {} as const,
+      ).getAsNormalizedFullLink().id;
+      const ingestAtoms =
+        (replica.getDocument(skillCellId)?.cfc?.labelMap?.entries ?? [])
+          .filter((entry) => entry.origin === "external-ingest")
+          .flatMap((entry) => entry.label.integrity ?? []);
+      expect(ingestAtoms).toHaveLength(1);
+      expect(ingestAtoms[0]).toMatchObject({
+        type: CFC_ATOM_TYPE.ExternalIngest,
+        kind: "fetch",
+        pinnedSource: { url: SKILL_URL, commitSha: COMMIT_SHA },
+      });
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+      await Deno.remove(artifactRoot, { recursive: true });
     }
   });
 });

--- a/packages/cf-harness/test/prompt-loop-skill-handle.test.ts
+++ b/packages/cf-harness/test/prompt-loop-skill-handle.test.ts
@@ -705,6 +705,7 @@ describe("prompt-loop delegate_task skillHandle", () => {
     const runRef = (
       skillHandle: string | undefined,
       status: "running" | "completed" | "failed",
+      withoutSkillHandle = false,
     ) =>
       ({
         type: "cf-harness.subagent-run-ref",
@@ -713,6 +714,7 @@ describe("prompt-loop delegate_task skillHandle", () => {
         manifest: {},
         status,
         ...(skillHandle !== undefined ? { skillHandle } : {}),
+        ...(withoutSkillHandle ? { withoutSkillHandle: true } : {}),
       }) as unknown as HarnessSubagentRunRef;
 
     it("holds a token whose latest delegation failed", () => {
@@ -740,6 +742,25 @@ describe("prompt-loop delegate_task skillHandle", () => {
       // settled would drop custody exactly where it is least safe to.
       expect(outstandingSkillCustody([runRef("cfh:a:aaaaa", "running")]))
         .toEqual(["cfh:a:aaaaa"]);
+    });
+
+    it("discharges custody once a delegation declared it carries no skill", () => {
+      // The refusal exists to make the parent answer once. Having answered,
+      // the run is not asked again on every later delegation.
+      expect(outstandingSkillCustody([
+        runRef("cfh:a:aaaaa", "failed"),
+        runRef(undefined, "completed", true),
+      ])).toEqual([]);
+    });
+
+    it("holds a token a delegation after the declaration failed on", () => {
+      // The declaration answers what was outstanding when it was made, not
+      // custody a later delegation goes on to incur.
+      expect(outstandingSkillCustody([
+        runRef("cfh:a:aaaaa", "failed"),
+        runRef(undefined, "completed", true),
+        runRef("cfh:a:bbbbb", "failed"),
+      ])).toEqual(["cfh:a:bbbbb"]);
     });
 
     it("ignores delegations that carried no handle", () => {

--- a/packages/cf-harness/test/prompt-loop-skill-handle.test.ts
+++ b/packages/cf-harness/test/prompt-loop-skill-handle.test.ts
@@ -17,7 +17,11 @@ import { createLLMFriendlyLink } from "@commonfabric/runner/shared";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { normalize } from "@std/path/posix";
 import { CfHarnessEngine } from "../src/engine.ts";
-import { CfHarnessPromptLoop } from "../src/prompt-loop.ts";
+import {
+  CfHarnessPromptLoop,
+  outstandingSkillCustody,
+} from "../src/prompt-loop.ts";
+import type { HarnessSubagentRunRef } from "../src/contracts/subagent.ts";
 import {
   createHarnessHandleTable,
   mintAddressHandle,
@@ -694,6 +698,55 @@ describe("prompt-loop delegate_task skillHandle", () => {
       expect(childText).toContain(
         `<skill_context source="handle:${minted.token}">`,
       );
+    });
+  });
+
+  describe("outstandingSkillCustody()", () => {
+    const runRef = (
+      skillHandle: string | undefined,
+      status: "running" | "completed" | "failed",
+    ) =>
+      ({
+        type: "cf-harness.subagent-run-ref",
+        parentToolCallId: `call-${status}`,
+        childRunId: `child-${status}`,
+        manifest: {},
+        status,
+        ...(skillHandle !== undefined ? { skillHandle } : {}),
+      }) as unknown as HarnessSubagentRunRef;
+
+    it("holds a token whose latest delegation failed", () => {
+      expect(outstandingSkillCustody([runRef("cfh:a:aaaaa", "failed")]))
+        .toEqual(["cfh:a:aaaaa"]);
+    });
+
+    it("releases a token once a later delegation carrying it completed", () => {
+      expect(outstandingSkillCustody([
+        runRef("cfh:a:aaaaa", "failed"),
+        runRef("cfh:a:aaaaa", "completed"),
+      ])).toEqual([]);
+    });
+
+    it("holds a token again when a delegation after a completed one failed", () => {
+      expect(outstandingSkillCustody([
+        runRef("cfh:a:aaaaa", "completed"),
+        runRef("cfh:a:aaaaa", "failed"),
+      ])).toEqual(["cfh:a:aaaaa"]);
+    });
+
+    it("holds a token left in flight, which is all a crash leaves behind", () => {
+      // No terminal ref was ever recorded: the process died mid-delegation and
+      // the run resumed. The running ref is the only trace, and reading it as
+      // settled would drop custody exactly where it is least safe to.
+      expect(outstandingSkillCustody([runRef("cfh:a:aaaaa", "running")]))
+        .toEqual(["cfh:a:aaaaa"]);
+    });
+
+    it("ignores delegations that carried no handle", () => {
+      expect(outstandingSkillCustody([
+        runRef(undefined, "failed"),
+        runRef(undefined, "running"),
+      ])).toEqual([]);
     });
   });
 });


### PR DESCRIPTION
CT-2170. Two properties an externally acquired skill did not hold, both about
what the record can say afterwards — which is the whole point of acquiring
under provenance. Verified against last night's cell C2 artifacts, and fixed
with a live probe as the acceptance bar.

## The pin reaches the child

A skills.sh acquisition established a full pin — discovery id, commit SHA,
source URL, verification method, host-computed digest — and then discarded it
into the parent's tool output. Every child context and every activation record
was silent about which bytes shaped the work.

An acquisition now records that pin on the handle-table entry it mints, and a
delegation writes it into the child's activation record. The entry is the only
durable place that could know: the parent holds a token, the child holds text,
and neither can name the commit. The field reaches no model surface — a model
can neither write it nor read it — and `assertValidHarnessHandleTable` refuses
acquisition provenance on an entry without the `skill-context` capability, so
a table cannot arrive claiming it on a handle no acquisition minted.

The `ExternalIngest` mark on the acquiring write already existed (#6668); a
grep for `ExternalIngest` misses it because the call is
`stampExternalFetchIngest`. A test now pins it on the real acquisition write
shape rather than leaving it to be rediscovered.

## Custody survives a failed delegation

In C2 the parent delegated twice with `skillHandle` `cfh:a:6nehk`, lost both
children to provider stream errors, and delegated a third time with no handle.
The shipped artifact came from a child that never received the acquired skill,
and nothing refused, warned, or recorded the difference.

**Refusal, not carry-forward** — and the reasoning is the design of record's,
not a preference. `docs/plans/external-skill-acquisition.md` states that
loading a handle into a child is "a separate later `delegate_task` decision",
and `acquire_skill`'s own descriptor says acquisition "loads nothing".
Attaching a handle to the next child on the harness's own initiative would
expand untrusted influence to a child the parent never chose, which is exactly
the decision `delegate_task` exists to record. So the harness will not do it.

What it refuses is the decision going unmade. `delegate_task` gains
`withoutSkillHandle`, a statement that this child deliberately runs with no
acquired skill; supplying it alongside `skillHandle` is refused as a call that
says two things at once. While the run holds a token whose most recent
delegation did not complete, a delegation omitting both fields comes back as
an invalid tool call naming the outstanding token. A prompt-only measure was
not acceptable here — the night's evidence is that guidance does not reliably
transfer.

The outstanding set is derived from the parent's own subagent run refs (which
now record `skillHandle`) rather than held in process memory, so custody
survives a resume.

## The acquisition suite's positive half was vacuous

Worth calling out because it is why this went unguarded. In
`prompt-loop-external-skill-acquisition.test.ts`, "keeps acquired text out of
every parent request and return" never spawned a child: passing
`allowedToolIds` empties the subagent-profile allowlist, so the delegation was
denied with `profile "default" is not allowed in this run`. Its
`expect(childText).toContain(CANARY)` was evaluating a *parent* request and
returning false — and the test passed anyway, because an `expect()` thrown
inside the scripted `fetch` is swallowed by the model client's error path.

Both that test and the new one now allow the profile and assert on text
captured during the run rather than inside the fetch.

## Live demonstration

One CLI probe end to end against toolshed :8063 (sha `180d006f`), skills.sh as
the registry, identity passed by path. 430s, `status: completed`,
model gpt-5.6-sol, run `916d0a0f-8ebc-440c-803d-83444b19e629`.

Artifacts under
`packages/cf-harness/.cf-harness-ct2170/` (untracked; run output, not part of
this change):

- `result.json` — the run shipped a SWOT worksheet.
- `runs/916d0a0f-…/tool-outputs/…_acquire_skill_4-acquire_skill.json` — the
  parent's pin, as before.
- `runs/916d0a0f-….subagent.1/skill-activations.json` — **the fix**: the
  `skill-handle` activation now carries `registryId`
  `linuszz/business-strategy-planning-skills/swot-analysis`, `commitSha`
  `7737792630e2ba1dd98451619fd924486f6ed9fd`, the source URL,
  `verification: git-commit-sha`, and `valueDigest sha256:Fp0nju…`. That is
  the same commit C2 recorded only in the parent.

The custody gate did not fire in this run, correctly: the single delegation
completed, so no custody was outstanding. The refusal is covered by test.

## Named non-goal: the release carries no label

Stated plainly because the demonstration was asked to settle it. The mark
mints — proven by test on the real write shape — but it is not observable
server-side. Reading the probe space read-only with `cf inspect`, the
acquisition cell holding the SWOT text has no `cfc` path at all, and after the
full run the space holds 228 entities with **zero** `labelMap` anywhere, while
another active toolshed space has 73. The run used
`--fabric-cfc-flow-labels persist --fabric-cfc-posture max-enforcement`.

So the shipped worksheet carries no CFC label of any kind, and neither does
the skill cell. Nothing in that space is labeled, which points at the harness
fabric session's label persistence rather than at the mint or at acquisition.
Not chased here; tracked on CT-2169.

CT-2068's declassification direction remains untouched, per the design's
explicit non-goal.

## Gates

- `deno test` in `packages/cf-harness`: `ok | 920 passed (1633 steps) | 0 failed (1m6s)`
- `deno fmt --check` repo-wide: `Checked 5579 files`
- `deno lint packages/cf-harness packages/runner`: `Checked 1329 files`
- `deno task check-docs`: `All 599 checked code block(s) passed.`
- `deno task check-skill-facts`: `Agent-facing facts OK (49 documents).`
- `deno task check-no-waitfor`: `No new polling waitFor in integration tests (6 allowlisted exception(s)).`

Mutation-verified: inverting the custody filter, and dropping the acquisition
passthrough, each kill the new test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6734?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

