### PR TITLE
feat(cli): scroll cf view with the mouse wheel

### DIFF
--- a/packages/cli/commands/view.ts
+++ b/packages/cli/commands/view.ts
@@ -41,7 +41,8 @@ COMMON USAGE:
   cf check ./p.tsx --show-transformed --no-run | cf view --plain | bat
 
 KEYS (press ? in the viewer for the full list):
-  ↑/↓ k/j scroll · ←/→ h/l pan · Space/b page · g/G top/bottom · / search
+  mouse wheel, ↑/↓ or k/j scroll · ←/→ h/l pan · Space/b page
+  g/G top/bottom · / search
   structure tree: w/s sibling · a/d parent/child · Tab/⇧Tab depth-first
   Enter info card · in it: ↑/↓ pick a reference · Enter opens it · z reveals it
   v source/rendered · t look up a definition · # line numbers · \\ wrap mode · q quit

--- a/packages/cli/lib/view/ansi.ts
+++ b/packages/cli/lib/view/ansi.ts
@@ -94,6 +94,8 @@ export function visibleWidth(text: string): number {
 export const term = {
   enterAltScreen: `${CSI}?1049h`,
   leaveAltScreen: `${CSI}?1049l`,
+  enableMouse: `${CSI}?1000h${CSI}?1006h`,
+  disableMouse: `${CSI}?1006l${CSI}?1000l`,
   hideCursor: `${CSI}?25l`,
   showCursor: `${CSI}?25h`,
   clearScreen: `${CSI}2J`,

--- a/packages/cli/lib/view/keys.ts
+++ b/packages/cli/lib/view/keys.ts
@@ -13,10 +13,11 @@
 export interface Key {
   /**
    * Normalized name: an arrow/nav name ("up", "down", "left", "right",
-   * "pageup", "pagedown", "home", "end"), a function key ("f1".."f12"), an
-   * editing name ("enter", "escape", "backspace", "delete", "tab", "space"), a
-   * control combo ("ctrl-c", "ctrl-d", …), or the literal character for a
-   * printable key ("a", "/", "?").
+   * "pageup", "pagedown", "home", "end"), a mouse-wheel name ("wheel-up",
+   * "wheel-down"), a function key ("f1".."f12"), an editing name ("enter",
+   * "escape", "backspace", "delete", "tab", "space"), a control combo
+   * ("ctrl-c", "ctrl-d", …), or the literal character for a printable key
+   * ("a", "/", "?").
    */
   readonly name: string;
 
@@ -57,6 +58,14 @@ export function decodeKeys(buf: Uint8Array): DecodeResult {
         continue;
       }
       if (n === 0x5b) { // CSI: ESC [ <params> <final>
+        // X10 mouse reports put the three encoded mouse bytes after the `M`
+        // final instead of inside the CSI parameters.
+        if (i + 2 < buf.length && buf[i + 2] === 0x4d) {
+          if (i + 5 >= buf.length) break;
+          keys.push(mouseToKey(buf[i + 3] - 32));
+          i += 6;
+          continue;
+        }
         let j = i + 2;
         let params = "";
         while (j < buf.length && buf[j] >= 0x30 && buf[j] <= 0x3f) {
@@ -200,6 +209,10 @@ function csiToKey(final: number, params: string): Key {
       return { name: "f3" };
     case 0x53:
       return { name: "f4" };
+    case 0x4d:
+      return params.startsWith("<")
+        ? mouseToKey(parseInt(params.slice(1).split(";", 1)[0], 10))
+        : { name: "unknown" };
     case 0x7e:
       return tildeKey(params);
     default:
@@ -250,6 +263,14 @@ function tildeKey(params: string): Key {
     default:
       return { name: "unknown" };
   }
+}
+
+/** Maps a terminal mouse button code to the wheel event it represents. */
+function mouseToKey(button: number): Key {
+  const baseButton = button & ~(4 | 8 | 16 | 32);
+  if (baseButton === 64) return { name: "wheel-up" };
+  if (baseButton === 65) return { name: "wheel-down" };
+  return { name: "unknown" };
 }
 
 function ss3ToKey(final: number): Key {

--- a/packages/cli/lib/view/pager.ts
+++ b/packages/cli/lib/view/pager.ts
@@ -245,7 +245,7 @@ export async function runPager(
       tty.setRaw(false);
     } catch { /* ignore */ }
     deps.write(
-      `${CSI}?7h${term.showCursor}` +
+      `${term.disableMouse}${CSI}?7h${term.showCursor}` +
         (padBg ? term.resetDefaultBg : "") + term.leaveAltScreen,
     );
     try {
@@ -289,7 +289,7 @@ export async function runPager(
 
   tty.setRaw(true);
   deps.write(
-    `${term.enterAltScreen}${term.hideCursor}` +
+    `${term.enterAltScreen}${term.enableMouse}${term.hideCursor}` +
       (padBg ? term.setDefaultBg(padBg) : ""),
   );
 

--- a/packages/cli/lib/view/pager.ts
+++ b/packages/cli/lib/view/pager.ts
@@ -244,10 +244,12 @@ export async function runPager(
     try {
       tty.setRaw(false);
     } catch { /* ignore */ }
-    deps.write(
-      `${term.disableMouse}${CSI}?7h${term.showCursor}` +
-        (padBg ? term.resetDefaultBg : "") + term.leaveAltScreen,
-    );
+    try {
+      deps.write(
+        `${term.disableMouse}${CSI}?7h${term.showCursor}` +
+          (padBg ? term.resetDefaultBg : "") + term.leaveAltScreen,
+      );
+    } catch { /* ignore */ }
     try {
       tty.close();
     } catch { /* ignore */ }
@@ -287,15 +289,14 @@ export async function runPager(
   deps.addSignalListener("SIGINT", onInterrupt);
   deps.addSignalListener("SIGTERM", onTerminate);
 
-  tty.setRaw(true);
-  deps.write(
-    `${term.enterAltScreen}${term.enableMouse}${term.hideCursor}` +
-      (padBg ? term.setDefaultBg(padBg) : ""),
-  );
-
   const buf = new Uint8Array(4096);
   let leftover: Uint8Array = new Uint8Array(0);
   try {
+    tty.setRaw(true);
+    deps.write(
+      `${term.enterAltScreen}${term.enableMouse}${term.hideCursor}` +
+        (padBg ? term.setDefaultBg(padBg) : ""),
+    );
     draw();
     // Warm the TypeScript program after the first frame is on screen, while the
     // user is reading it and before any keypress arrives, so the first info card

--- a/packages/cli/lib/view/session.ts
+++ b/packages/cli/lib/view/session.ts
@@ -1157,6 +1157,7 @@ export class Session {
     this.pendingPush = null;
     this.expireMessage();
     if (key.name === "wheel-up" || key.name === "wheel-down") {
+      this.#chord = null;
       this.#handleWheel(key.name === "wheel-up" ? -1 : 1);
       return;
     }

--- a/packages/cli/lib/view/session.ts
+++ b/packages/cli/lib/view/session.ts
@@ -151,6 +151,7 @@ interface PeekOverlay {
 }
 
 const HORIZONTAL_STEP = 8;
+const MOUSE_WHEEL_STEP = 3;
 
 // Messages shown when a diff's edit policy refuses an edit.
 const NOT_EDITABLE_MSG =
@@ -1155,6 +1156,10 @@ export class Session {
     this.pendingReveal = null;
     this.pendingPush = null;
     this.expireMessage();
+    if (key.name === "wheel-up" || key.name === "wheel-down") {
+      this.#handleWheel(key.name === "wheel-up" ? -1 : 1);
+      return;
+    }
     if (
       this.#mode === "savePrompt" || this.#mode === "amendPrompt" ||
       this.#mode === "revertPrompt"
@@ -1191,6 +1196,37 @@ export class Session {
 
   #contentRows(): number {
     return Math.max(1, this.height - 1);
+  }
+
+  /** Scrolls the active document or list without moving the edit cursor. */
+  #handleWheel(direction: -1 | 1): void {
+    this.#message = "";
+    const delta = direction * MOUSE_WHEEL_STEP;
+    if (
+      this.#mode === "savePrompt" || this.#mode === "amendPrompt" ||
+      this.#mode === "revertPrompt"
+    ) return;
+    if (this.#mode === "filePicker") {
+      const last = Math.max(0, this.#pickerEntries.length - 1);
+      this.#pickerSel = clamp(this.#pickerSel + delta, 0, last);
+      this.#ensurePickerVisible();
+      return;
+    }
+    if (this.#mode === "jumpList") {
+      const last = Math.max(0, this.#jumpEntries.length - 1);
+      this.#jumpSel = clamp(this.#jumpSel + delta, 0, last);
+      this.#scrollJumpToSelection(this.#jumpSel);
+      return;
+    }
+    if (this.#overlay) {
+      this.#overlayScroll = clamp(
+        this.#overlayScroll + delta,
+        0,
+        this.#overlayMaxScroll(this.#overlay),
+      );
+      return;
+    }
+    this.top = clamp(this.top + delta, 0, this.#lastTop());
   }
 
   #clampScroll(): void {
@@ -1733,14 +1769,7 @@ export class Session {
   private handleOverlayKey(key: Key): void {
     const overlay = this.#overlay;
     if (!overlay) return;
-    // Stop scrolling once the last line reaches the bottom of the box, so the
-    // final line does not drift up past the frame — the same clamp the main
-    // view uses.
-    const innerH = overlayBox(this.width, this.height).innerH;
-    const maxScroll = Math.max(
-      0,
-      this.#activeOverlayLines(overlay).length - innerH,
-    );
+    const maxScroll = this.#overlayMaxScroll(overlay);
     const hasTargets = overlay.mode === "info" && overlay.targets.length > 0;
     switch (key.name) {
       case "escape":
@@ -1832,6 +1861,12 @@ export class Session {
         this.#overlayScroll = clamp(this.#overlayScroll - 10, 0, maxScroll);
         break;
     }
+  }
+
+  /** Furthest scroll position which keeps the overlay's last line in its box. */
+  #overlayMaxScroll(overlay: PeekOverlay): number {
+    const innerH = overlayBox(this.width, this.height).innerH;
+    return Math.max(0, this.#activeOverlayLines(overlay).length - innerH);
   }
 
   #handleNormalKey(key: Key): void {
@@ -4956,6 +4991,7 @@ export function helpOverlay(): {
 } {
   const rows: Array<[string, string]> = [
     ["Scrolling", ""],
+    ["  mouse wheel", "scroll up / down"],
     ["  K / J", "line up / down"],
     ["  H / L", "scroll left / right"],
     ["  ↑ ↓ ← →", "scroll / pan the view"],

--- a/packages/cli/test/view-jumplist.test.ts
+++ b/packages/cli/test/view-jumplist.test.ts
@@ -228,6 +228,16 @@ Deno.test("jumplist: pagedown and pageup jump the selection to the ends", () => 
   assertEquals(s.view().overlay?.selectedLine, 0, "clamped to the first entry");
 });
 
+Deno.test("jumplist: the mouse wheel moves three entries", () => {
+  const s = diffSession(LOG);
+  press(s, "i");
+  assertEquals(s.view().overlay?.selectedLine, 0);
+  press(s, "wheel-down");
+  assertEquals(s.view().overlay?.selectedLine, 3);
+  press(s, "wheel-up");
+  assertEquals(s.view().overlay?.selectedLine, 0);
+});
+
 Deno.test("jumplist: space pages the selection down", () => {
   const s = diffSession(LOG);
   press(s, "i");

--- a/packages/cli/test/view-keys.test.ts
+++ b/packages/cli/test/view-keys.test.ts
@@ -43,6 +43,7 @@ Deno.test("decode: SGR mouse wheel reports", () => {
   assertEquals(names(bytes("\x1b[<65;12;7M")), ["wheel-down"]);
   assertEquals(names(bytes("\x1b[<68;12;7M")), ["wheel-up"]);
   assertEquals(names(bytes("\x1b[<69;12;7M")), ["wheel-down"]);
+  assertEquals(names(bytes("\x1b[<0;12;7M")), ["unknown"]);
   assertEquals(names(bytes("\x1b[<65;12;7m")), ["unknown"]);
 });
 

--- a/packages/cli/test/view-keys.test.ts
+++ b/packages/cli/test/view-keys.test.ts
@@ -38,6 +38,26 @@ Deno.test("decode: arrow keys (CSI)", () => {
   assertEquals(names(raw(0x1b, 0x5b, 0x46)), ["end"]);
 });
 
+Deno.test("decode: SGR mouse wheel reports", () => {
+  assertEquals(names(bytes("\x1b[<64;12;7M")), ["wheel-up"]);
+  assertEquals(names(bytes("\x1b[<65;12;7M")), ["wheel-down"]);
+  assertEquals(names(bytes("\x1b[<68;12;7M")), ["wheel-up"]);
+  assertEquals(names(bytes("\x1b[<69;12;7M")), ["wheel-down"]);
+  assertEquals(names(bytes("\x1b[<65;12;7m")), ["unknown"]);
+});
+
+Deno.test("decode: X10 mouse wheel reports", () => {
+  assertEquals(names(raw(0x1b, 0x5b, 0x4d, 96, 33, 33)), ["wheel-up"]);
+  assertEquals(names(raw(0x1b, 0x5b, 0x4d, 97, 33, 33)), ["wheel-down"]);
+});
+
+Deno.test("decode: an incomplete X10 mouse report remains buffered", () => {
+  const input = raw(0x1b, 0x5b, 0x4d, 96, 33);
+  const result = decodeKeys(input);
+  assertEquals(result.keys, []);
+  assertEquals(result.rest, input);
+});
+
 Deno.test("decode: page up/down and home/end (tilde sequences)", () => {
   assertEquals(names(raw(0x1b, 0x5b, 0x35, 0x7e)), ["pageup"]);
   assertEquals(names(raw(0x1b, 0x5b, 0x36, 0x7e)), ["pagedown"]);

--- a/packages/cli/test/view-pager-cov.test.ts
+++ b/packages/cli/test/view-pager-cov.test.ts
@@ -142,6 +142,31 @@ Deno.test("pager: draws the document and quits on q", async () => {
   // The alt screen is entered on start and left on cleanup.
   assert(writes.some((w) => w.includes("\x1b[?1049h")), "entered alt screen");
   assert(writes.some((w) => w.includes("\x1b[?1049l")), "left alt screen");
+  assert(writes.some((w) => w.includes(term.enableMouse)), "enabled the mouse");
+  assert(
+    writes.some((w) => w.includes(term.disableMouse)),
+    "disabled the mouse",
+  );
+});
+
+Deno.test("pager: an SGR mouse-wheel report scrolls the document", async () => {
+  const doc = parseDocument(
+    Array.from({ length: 20 }, (_, i) => `line ${i}`).join("\n"),
+  );
+  const { deps, writes } = makeFake({
+    consoleSize: { columns: 30, rows: 6 },
+    steps: [
+      { bytes: enc("\x1b[<65;1;1M") },
+      { bytes: enc("q") },
+    ],
+  });
+  await runPager(doc, OPTS, undefined, undefined, deps);
+  const frames = writes.filter((write) => write.includes("\x1b[?7l"));
+  const wheelFrame = frames.at(-1)!;
+  assert(
+    wheelFrame.includes("line 3") && !wheelFrame.includes("line 0"),
+    "the wheel redraw starts three lines down",
+  );
 });
 
 Deno.test("pager: unknown named files schedule no semantic work", async () => {

--- a/packages/cli/test/view-pager-cov.test.ts
+++ b/packages/cli/test/view-pager-cov.test.ts
@@ -187,13 +187,13 @@ Deno.test("pager: an SGR mouse-wheel report scrolls the document", async () => {
   await runPager(doc, OPTS, undefined, undefined, deps);
   const frames = writes.filter((write) => write.includes("\x1b[?7l"));
   const wheelFrame = frames.at(-1)!;
-  assert(
-    wheelFrame.includes("line 3") &&
-      !wheelFrame.includes("line 0") &&
-      !wheelFrame.includes("line 1") &&
-      !wheelFrame.includes("line 2"),
-    "the wheel redraw starts three lines down",
-  );
+  assert(wheelFrame.includes("line 3"), "the wheel frame contains line 3");
+  for (const skippedLine of ["line 0", "line 1", "line 2"]) {
+    assert(
+      !wheelFrame.includes(skippedLine),
+      `the wheel frame starts after ${skippedLine}`,
+    );
+  }
 });
 
 Deno.test("pager: unknown named files schedule no semantic work", async () => {

--- a/packages/cli/test/view-pager-cov.test.ts
+++ b/packages/cli/test/view-pager-cov.test.ts
@@ -48,6 +48,7 @@ interface FakeOpts {
   closeThrows?: boolean;
   consoleSizeThrows?: boolean;
   consoleSize?: { columns: number; rows: number };
+  writeThrowsFrom?: number;
   addSignalThrowsFor?: Deno.Signal;
   removeSignalThrows?: boolean;
   env?: Record<string, string>;
@@ -59,7 +60,9 @@ function makeFake(opts: FakeOpts = {}) {
   const removed: string[] = [];
   const timers = new Map<number, () => void>();
   const exited: number[] = [];
+  const ttyState = { rawModes: [] as boolean[], closes: 0 };
   let nextTimer = 1;
+  let writeCount = 0;
   const steps = (opts.steps ?? []).slice();
 
   const tty: PagerTty = {
@@ -82,11 +85,13 @@ function makeFake(opts: FakeOpts = {}) {
       }
     },
     setRaw(mode) {
+      ttyState.rawModes.push(mode);
       // Throw only on the cleanup setRaw(false); the startup setRaw(true) is
       // not guarded, so a startup throw would escape.
       if (opts.setRawThrows && !mode) throw new Error("setRaw failed");
     },
     close() {
+      ttyState.closes++;
       if (opts.closeThrows) throw new Error("close failed");
     },
   };
@@ -96,7 +101,15 @@ function makeFake(opts: FakeOpts = {}) {
       if (opts.openThrows) throw new Error("no controlling terminal");
       return tty;
     },
-    write: (t) => writes.push(t),
+    write: (t) => {
+      writes.push(t);
+      writeCount++;
+      if (
+        opts.writeThrowsFrom !== undefined && writeCount >= opts.writeThrowsFrom
+      ) {
+        throw new Error("write failed");
+      }
+    },
     consoleSize: () => {
       if (opts.consoleSizeThrows) throw new Error("no console");
       return opts.consoleSize ?? { columns: 80, rows: 24 };
@@ -123,7 +136,7 @@ function makeFake(opts: FakeOpts = {}) {
     // here would only stall the run.
     delay: () => Promise.resolve(),
   };
-  return { deps, writes, signals, removed, timers, exited };
+  return { deps, writes, signals, removed, timers, exited, ttyState };
 }
 
 Deno.test("pager: a missing /dev/tty raises a ViewError", async () => {
@@ -149,6 +162,17 @@ Deno.test("pager: draws the document and quits on q", async () => {
   );
 });
 
+Deno.test("pager: restores the terminal when the initial write fails", async () => {
+  const { deps, ttyState } = makeFake({ writeThrowsFrom: 1 });
+  await assertRejects(
+    () => runPager(DOC, OPTS, undefined, undefined, deps),
+    Error,
+    "write failed",
+  );
+  assertEquals(ttyState.rawModes, [true, false]);
+  assertEquals(ttyState.closes, 1);
+});
+
 Deno.test("pager: an SGR mouse-wheel report scrolls the document", async () => {
   const doc = parseDocument(
     Array.from({ length: 20 }, (_, i) => `line ${i}`).join("\n"),
@@ -164,7 +188,10 @@ Deno.test("pager: an SGR mouse-wheel report scrolls the document", async () => {
   const frames = writes.filter((write) => write.includes("\x1b[?7l"));
   const wheelFrame = frames.at(-1)!;
   assert(
-    wheelFrame.includes("line 3") && !wheelFrame.includes("line 0"),
+    wheelFrame.includes("line 3") &&
+      !wheelFrame.includes("line 0") &&
+      !wheelFrame.includes("line 1") &&
+      !wheelFrame.includes("line 2"),
     "the wheel redraw starts three lines down",
   );
 });

--- a/packages/cli/test/view-session-cov.test.ts
+++ b/packages/cli/test/view-session-cov.test.ts
@@ -1158,6 +1158,19 @@ Deno.test("session: the quit save-prompt answers s / d / c", () => {
     press(s, "escape"); // back to the pager (the buffer is still dirty)
     press(s, "q"); // dirty -> save prompt
     assert(promptText(s.view()).includes("Save changes"), promptText(s.view()));
+    const beforeWheel = s.view();
+    press(s, "wheel-down");
+    assertEquals(
+      promptText(s.view()),
+      promptText(beforeWheel),
+      "wheel input leaves the prompt open",
+    );
+    assertEquals(s.view().top, beforeWheel.top, "wheel input does not scroll");
+    assertEquals(
+      s.view().dialog?.focus,
+      beforeWheel.dialog?.focus,
+      "wheel input does not move the focused button",
+    );
     press(s, "s");
     assert(saved.text?.includes("A"), saved.text ?? "");
     assert(s.quit, "s saved and quit");
@@ -2565,6 +2578,16 @@ Deno.test("filepickercov: paging through a long listing scrolls the picker", () 
   press(s, "up", "ctrl-p"); // arrow and Emacs up
   press(s, "pageup");
   assertEquals(s.view().overlay!.selectedLine, 0, "back at the top");
+});
+
+Deno.test("filepickercov: the mouse wheel moves three entries", () => {
+  const s = pickerSession();
+  press(s, "ctrl-x", "ctrl-f");
+  assertEquals(s.view().overlay?.selectedLine, 0);
+  press(s, "wheel-down");
+  assertEquals(s.view().overlay?.selectedLine, 3);
+  press(s, "wheel-up");
+  assertEquals(s.view().overlay?.selectedLine, 0);
 });
 
 Deno.test("filepickercov: backspace on an empty filter steps up a directory", () => {

--- a/packages/cli/test/view-session.test.ts
+++ b/packages/cli/test/view-session.test.ts
@@ -68,6 +68,38 @@ Deno.test("session: vertical scrolling and clamping", () => {
   assertEquals(s.view().top, 0);
 });
 
+Deno.test("session: the mouse wheel scrolls without moving the edit cursor", () => {
+  const text = Array.from({ length: 20 }, (_, i) => `line ${i}`).join("\n");
+  const source: EditableSource = {
+    label: null,
+    editable: true,
+    parse: (next) => parseDocument(next),
+    save: () => "",
+  };
+  const session = new Session(
+    parseDocument(text),
+    { color: false, showLineNumbers: false },
+    { width: 30, height: 6 },
+    undefined,
+    source,
+  );
+  press(session, "e");
+  const cursor = session.view().cursor;
+  press(session, "wheel-down");
+  assertEquals(session.view().top, 3);
+  assertEquals(session.view().cursor, cursor);
+  press(session, "wheel-up", "wheel-up");
+  assertEquals(session.view().top, 0);
+});
+
+Deno.test("session: the mouse wheel scrolls an overlay", () => {
+  const session = makeSession();
+  press(session, "?");
+  assertEquals(session.view().overlay?.scroll, 0);
+  press(session, "wheel-down");
+  assertEquals(session.view().overlay?.scroll, 3);
+});
+
 Deno.test("session: an ordinary file ends at the bottom of the viewport", () => {
   const text = Array.from({ length: 12 }, (_, i) => `line ${i}`).join("\n");
   const s = new Session(

--- a/packages/cli/test/view-session.test.ts
+++ b/packages/cli/test/view-session.test.ts
@@ -90,6 +90,8 @@ Deno.test("session: the mouse wheel scrolls without moving the edit cursor", () 
   assertEquals(session.view().cursor, cursor);
   press(session, "wheel-up", "wheel-up");
   assertEquals(session.view().top, 0);
+  press(session, "ctrl-x", "wheel-down", "z");
+  assertEquals(session.view().message, "", "the wheel cancelled the C-x chord");
 });
 
 Deno.test("session: the mouse wheel scrolls an overlay", () => {


### PR DESCRIPTION
Enable basic and SGR terminal mouse reporting while the interactive pager owns the alternate screen. Decode wheel reports from modern SGR and legacy X10 formats, and scroll the active document or overlay by three rows without moving the edit cursor.

Disable mouse reporting on every pager cleanup path so terminal input returns to normal after quitting or receiving a signal.

Tests cover both encodings, partial X10 input, modifier bits, session clamping, overlay and edit-mode behavior, terminal setup and teardown, and an injected SGR report that proves the rendered viewport moved.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6737?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

