### PR TITLE
docs(topics): what Stage C leaves open, where a reader will find it

### DIFF
--- a/docs/plans/topics-verb-surface.md
+++ b/docs/plans/topics-verb-surface.md
@@ -159,6 +159,15 @@ usage:
   bound wrongly stamps a copy no reader sees, which is a silent failure, so it
   wants a browser test rather than an assumption.
 
+  Two other gaps are open against this item. An agent can add a comment and
+  cannot retract one, because these verbs name their target by reference and a
+  comment carries no fid an inline JSON event could name — [#6713], where the
+  candidate keys are set out. And the rule that a retracted link stops
+  resolving into `mentions` is carried by reading rather than by a test: it
+  needs a link whose URL names a real piece, and `cellFromUrl` answers with no
+  cell for any URL a pattern test can build, so a retracted link and a plain
+  web link are indistinguishable to the suite.
+
 - **`AgentActor` execution provenance** replacing per-event `agentName`, when
   the retention-and-provenance track clears its review. That review has not
   happened and nothing in that plan has started, so this item cannot begin
@@ -268,11 +277,13 @@ Two preconditions belong to the board rather than to the code:
 - **A new verb goes on `TopicOutput`, not on `TopicPiece`.** The board stores
   that projection, so it is a demand on every topic already held, and a
   required verb added to it refuses every piece deployed before the verb
-  existed. A verb has no default to be rescued by, so there is no compatible
-  way to demand a new one — optionality would work, but the placement is what
-  `setTitle` established and what keeps the board's contract still. The tell
-  that it worked is a baseline recorded for `topic.tsx` and none for
-  `main.tsx`.
+  existed. No pattern in the tree writes a verb with a default, so in practice
+  a newly demanded verb has nothing to rescue it — but that is a fact about
+  what patterns emit, not a rule the gate enforces: a stream node carrying a
+  `default` is ACCEPTED, which is [#6673]. Optionality would also work; the
+  placement is what `setTitle` established and what keeps the board's contract
+  still. The tell that it worked is a baseline recorded for `topic.tsx` and
+  none for `main.tsx`.
 - **`unmention` keeps removing rather than stamping**, and the pattern carries
   two removal semantics until [#6573] closes it. Not because an edge matters
   less than content, but because a mention is a bare reference with no record
@@ -287,3 +298,5 @@ Two preconditions belong to the board rather than to the code:
   fields from the board's published projection is accepted.
 
 [#6573]: https://github.com/commontoolsinc/labs/issues/6573
+[#6673]: https://github.com/commontoolsinc/labs/issues/6673
+[#6713]: https://github.com/commontoolsinc/labs/issues/6713


### PR DESCRIPTION
## Why

Asked what an agent picking up the Topics verb-surface plan would know about
its state, I checked instead of assuming — and found one claim that is wrong
and two open gaps that were findable only inside a pull request thread.

**The wrong claim is the reason this is not just tidying.** The plan said:

> A verb has no default to be rescued by, so there is no compatible way to
> demand a new one

Measured against `assertPatternSchemasBackwardCompatible` on main, a holder
newly demanding a required verb is REFUSED when the stream node carries no
default and **ACCEPTED** when it carries `default: {}`. Nothing special-cases
`asCell: ["stream"]` in the newly-required check. That is #6673.

The plan's conclusion survives — no pattern in the tree emits a defaulted verb
(0 of 449 recorded baselines), so in practice there is nothing to rescue one —
but that is a fact about what patterns emit, not a rule the gate enforces, and
the plan stated it as the rule. A reader deciding whether a board could demand
a verb would have taken it as settled. It is the shape this repository keeps
finding: a documented mechanism that nothing checks.

## What Changed

`docs/plans/topics-verb-surface.md` only.

- The verb-and-default claim is corrected to say what is actually true and
  cites #6673 for the part that is not.
- Item 1 gains its two open gaps, previously recorded only in review comments
  on #6701: agents cannot retract a comment they wrote (#6713), and the
  "retracted link stops resolving into `mentions`" rule is carried by reading
  rather than by a test, because no URL a pattern test can construct resolves
  to a piece.

## Test plan

Documentation only. `deno fmt --check`, `deno task check-docs`, and
`deno task check-skill-facts` pass.

The claim about the gate was verified by running the comparison directly
rather than by reading the checker, and the 0-of-449 figure by scanning every
recorded baseline for a stream node carrying a `default`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6739?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

