### PR TITLE
fix(runner): the runtime's own stores declare what flows into them

### DIFF
--- a/docs/specs/cfc-enforcement-matrix.md
+++ b/docs/specs/cfc-enforcement-matrix.md
@@ -346,34 +346,77 @@ The strict-only delta is:
   direction is over-taint, so reads stay protected; giving the envelope seam
   a path space of its own is what removes the collision.
 
-- **Piece-substrate declaration (§8.12.5 route 2) — implemented.** The
-  runtime writes a small set of documents while it sets a piece up: the
-  piece's argument document, and the internal documents and streams its
-  result projects to. It fills them with whatever the setup transaction
-  read. An author cannot know which atoms a given transaction will carry, so
-  a declaration written into a schema either misses them or over-declares
-  every instance of the pattern. The transaction declares the policy
-  instead, which is §8.12.5's route 2: the write that puts the join on a
-  path also declares, in that same transaction, a policy covering it. What
-  lands is the ceiling that resolved at the path plus exactly the clauses
-  that had nowhere to go, as an ordinary `declared` entry, so the fit test
-  passes and the store's promise becomes the audience of what it holds.
+- **Runtime-owned-store declaration (§8.12.5 route 2) — implemented.** The
+  runtime materializes a set of documents to hold a piece's machinery rather
+  than data an author named. There are four kinds: a piece's argument
+  document, its result document, and the internal documents and streams its
+  result projects to, all minted by the runner from the piece's result cause;
+  the state documents a builtin mints from its own node's cause, such as a
+  dialog's result, internal state and pinned-cell list, or a list operation's
+  result container; the per-event documents a builtin mints inside one
+  transaction, such as a dialog message; and the documents anchoring splits
+  out of a value written into any of those. The runtime fills all of them
+  with whatever the writing transaction read. An author cannot know which
+  atoms a given transaction will carry, so a declaration written into a schema
+  either misses them or over-declares every instance of the pattern. The
+  transaction declares the policy instead, which is §8.12.5's route 2: the
+  write that puts the join on a path also declares, in that same transaction,
+  a policy covering it. What lands is the ceiling that resolved at the path
+  plus exactly the clauses that had nowhere to go, as an ordinary `declared`
+  entry, so the fit test passes and the store's promise becomes the audience
+  of what it holds.
 
   Declaring is what makes the route sound where an exemption would not be.
-  The declared clauses persist as store policy, so readers of the substrate
+  The declared clauses persist as store policy, so readers of the store
   consume them, and go on consuming them after an overwrite clears the
   derived stamp. They are the clauses the ceiling did not already cover
   rather than the whole join: a clause the residency alternative satisfies
   lands in the stamp and not in the declaration, because the store already
-  answers for it. The cost is the ratchet §8.12.2 asks for: a substrate
-  document that once held data derived from a labeled read keeps that clause
-  after the read stops. The direction is over-taint.
+  answers for it. The cost is the ratchet §8.12.2 asks for: a document that
+  once held data derived from a labeled read keeps that clause after the read
+  stops. The direction is over-taint.
 
-  The route is the strict rung's, like the reject it replaces. Every rung
-  below keeps its `writer-fit(persist-and-flag)` diagnostic, which is the
-  rollout signal, and stores no declared policy it could never take back —
-  so `enforce-explicit` keeps the shipped posture bit-for-bit here too. At
-  strict, a declaration records a `writer-fit(piece-substrate-declared)`
+  The route runs on every write to such a store, not only while the piece is
+  being set up. What makes that safe is a property of the declaration rather
+  than of when it is made. A declared clause list is read two ways, and the
+  two agree: as a ceiling, §8.12.4's `canWrite` admits a label clause when
+  SOME declared clause subsumes it, and as a reader's taint, that same
+  section makes the declared label a floor every reader carries — §8.12.8
+  has reader taint consume the effective label, which always includes the
+  declared component. Subsumption means satisfying the declared clause
+  implies satisfying the label, so every reader of the store satisfies every
+  clause the store admits. One upgrade therefore admits more data AND
+  narrows the audience by the same step, and so does the next one: an
+  unbounded reactive stream of upgrades leaves a store readable by fewer
+  people than it started with, never by more. That is why the route needs no
+  bound on how many times it may fire, or on which clauses it may take from
+  a later transaction. It is §8.12.5's own argument for option 2 — existing
+  readers already expect data at the original label level — applied once per
+  write rather than once per piece.
+
+  The declaration is the runtime's to make. §8.12.8's component table names
+  "explicit store-label operations (upgrades per §8.12.5)" as a provenance
+  of the declared component beside schema `ifc` declarations, and §8.12.5
+  states the discipline as atomically tightening the label and then writing,
+  which is what declaring in the writing transaction does. The authority
+  §8.12.7 and safety invariant 1 require is for WIDENING — adding an
+  alternative to a clause already stored, which grows that clause's reader
+  set and is admissible only through a grant record or an intent-gated
+  declassification event. This route adds clauses and never alternatives, so
+  it never asks for that authority; the mint folds clause LISTS, and a
+  stored disjunction comes back with the alternatives it went in with.
+
+  The route is the strict rung's, like the reject it replaces, and §18.6.3's
+  "strict only rejects more" holds across it: a writer-fit misfit is not a
+  rejection at `enforce-explicit` — it persists and flags — so admitting one
+  at strict with a declaration admits nothing a lower rung refused. Every
+  rung below keeps its `writer-fit(persist-and-flag)` diagnostic, which is
+  the rollout signal, and stores no declared policy it could never take back.
+  That last is a statement about the RUNG rather than about a deployment: the
+  shipped shell posture is `enforce-explicit` with per-transaction escalation
+  to strict, so an escalated transaction writes a permanent declared entry
+  that every rung's readers then consume, and §8.12.1 does not let it back.
+  At strict, a declaration records a `writer-fit(runtime-owned-store-declared)`
   diagnostic naming the document, the path, and the clauses added: a
   permanent change to a store's policy leaves a trace even at the rung that
   admits it.
@@ -390,16 +433,94 @@ The strict-only delta is:
     markers in the same file corroborate against transaction state, which
     suits a claim about a write that has already happened, while this one
     is a claim about whose write it is, and a forger supplies the write.
-  - **Which document it names.** The runner records only addresses it
-    MINTS from the piece's result cell — the argument address it would
-    derive, and each derived internal cell's — and only where the address
-    names a whole document rather than a path inside one. It reads the
-    argument address back out of the result cell's stored meta on every
-    setup after the first, and where that stored link names some other
-    document (a nested piece's argument lives in its HOST's) no marker is
-    recorded, so that document keeps its own ceiling. Every document the
-    route does not reach keeps the ceiling it resolves to, and a misfit
-    there is refused as before, with the §8.12.5 remedy in the reason.
+  - **Which document it names.** The runner derives every address from the
+    piece's result cell — the result cell itself, the argument address that
+    cell's cause mints, and each derived internal cell's — and never reads
+    one back out of stored metadata, where an `argument` or manifest link can
+    name another document (a nested piece's argument lives in its HOST's).
+    A builtin names only the stores it mints from its own node's cause. In
+    every case the address must name a whole document rather than a path
+    inside one, and must lie in the owner's own space: a store elsewhere
+    belongs to whoever holds that space's replicas, so a policy declared on
+    it out of this piece's join would put those bytes behind a promise made
+    here. The result document is the one address a caller may have chosen
+    rather than the runtime minted; from the moment setup writes the piece's
+    meta into it, it is that piece's store and nothing else's, and the route
+    reaches every path written there. Every document the route does not
+    reach keeps the ceiling it resolves to, and a misfit there is refused as
+    before, with the §8.12.5 remedy in the reason.
+  - **How long the claim lasts.** A store the runtime mints and fills in one
+    transaction is named for that transaction. A store it KEEPS — written by
+    the reactive updates, event handlers and settled requests that come
+    after the mint, each on a transaction of its own — is enrolled instead,
+    and every later transaction of the same runtime finds it. An enrollment
+    lasts as long as the piece's nodes do and goes out with them, which is
+    what bounds it: a list operation mints one piece per element, so an
+    enrollment that lived for the process would grow with every element a
+    churning list ever held. A store minted per event takes the marker alone
+    for the same reason. Both carry the runtime's authorization, and both
+    are refused for an address naming part of a document or another space.
+  - **Which builtins may take it.** A builtin whose result store moves onto
+    the route gives up whatever its own ceiling was refusing, so the test is
+    what refuses that write instead. A builtin that stages its request as a
+    `sink-request` write-policy input has a ceiling to move the refusal to;
+    one that stages its effect directly — `sqliteQuery` and `navigateTo`
+    both call `enqueuePostCommitEffect` themselves — has none, so its stores
+    keep their own ceilings until the gate that should own them exists. Most
+    builtins are in neither group: a list coordinator, `ifElse`, `when`,
+    `unless`, `compileAndRun`, `cellFromUrl` and `inspectConfLabel` stage
+    nothing at all, so there is no egress to govern and no refusal to move,
+    and their stores take the route on the node-keyed test alone. That is
+    the reading to apply to a new builtin: ask what it stages before asking
+    what its stores may declare. `builtin-ownership-route.test.ts` pairs the
+    two sets mechanically, so a builtin that stages an effect and takes the
+    route fails rather than passing on a reviewer noticing.
+    Two further stores stay off the route for the reasons above rather than
+    for this one. A store the runtime keys on something other than a node —
+    `wish`'s interval clock, keyed on the interval, and its shared hashtag
+    state, keyed on the space and scope — is shared by every piece that asks
+    for it, so no one piece's flow join may declare its policy. And a
+    sidecar's result cell is the result cell of the piece the sidecar runs,
+    which that piece's own instantiation enrolls and its stop releases;
+    enrolling it again under the piece that launched it would hold it past
+    the release that owns it.
+  - **How ownership reaches an anchored document.** Anchoring splits one
+    value across two documents, deriving the child's id from the parent's
+    rather than from anything an author named, and nothing but that write
+    puts anything in the child. §8.2 treats either representation of a
+    pass-through as valid so long as the label is preserved, which is the
+    nearest thing the spec says to "the choice must not decide a verdict";
+    the reading here goes one step past that text. A child the runtime split
+    out of a store it owns is therefore that store's, and it takes the marker
+    alone: the transaction that
+    anchors it writes it, and a later write reaching the same position walks
+    through the same place again. A transaction addressing the child
+    directly rather than through its parent finds no claim and measures
+    against the child's own ceiling, which is the fail-closed direction. The
+    marker also carries the claim down a nested anchor, whose own parent is
+    the child marked a step earlier.
+
+    That direction has a shape an author meets rather than predicts, so it is
+    stated here concretely. On a piece whose result projects a list of
+    objects, `items.key(0).set({ note: labeled })` commits: the write goes
+    through the parent, re-anchors the element, and the route declares.
+    `items.key(0).key("note").set(labeled)` is refused with a writer-fit
+    misfit naming the child: the write addresses the child directly, so the
+    marker the parent's walk would have recorded is never reached, and the
+    child's own declaration is what measures it. The two spellings put the
+    same value in the same place and disagree.
+
+    Enrolling anchored children would settle it and is ruled out on
+    measurement, not on taste. A whole-list `set` re-anchors every element
+    with a fresh id, so six appends mint twenty-one children and five
+    rewrites of one position mint thirty more: an enrollment keyed on
+    children would grow with total historical writes times list length
+    rather than with live data, undoing one level down what the per-piece
+    release bounds. The fix that is both coherent and bounded is
+    link-carried provenance (§8.12.8) — deriving the child's ownership from
+    the parent link a write traverses — which is tracked separately.
+    `cfc-runtime-owned-store-wiring.test.ts` pins both spellings, so the
+    refused half flips visibly the day that lands.
   - **How far it reaches inside that document.** Every path the
     transaction writes there, not only the paths setup wrote: the marker
     names the store, and the declaration is a statement about the store.
@@ -439,23 +560,68 @@ The strict-only delta is:
     the carried-forward stored entry rather than standing in for it. Adding
     clauses is the restricting direction, so the monotonicity gate that runs
     earlier in the same walk cannot be contradicted by what this route
-    pushes. Growth is also what reaches a piece whose substrate was written
-    before any labeled read entered a transaction writing it: that substrate
-    declares nothing, and the write that first carries a join is the one
-    that declares it.
+    pushes. Growth is also what reaches a store written before any labeled
+    read entered a transaction writing it: that store declares nothing, and
+    the write that first carries a join is the one that declares it.
 
-  What the route does NOT reach is the piece's running graph. A lift or
-  handler writing in a later transaction records no setup marker, so its
-  target — commonly a `computed:` document — measures against its own
-  ceiling and a misfit there still refuses. Under strict that turns "the
-  piece will not start" into "the piece starts and drops those writes",
-  which is progress on the setup seam and not a working strict rung.
+  What the route does NOT reach is a document nobody named. A write to an
+  ordinary document measures against its own ceiling whichever transaction
+  makes it: a bystander written by a later transaction of the same piece is
+  refused exactly as one written by the setup transaction is. A `computed:`
+  document is outside the route for a different reason — the measurement
+  skips it altogether, per the computed-cell exemption above.
+
+  It DOES reach further than the setup-time route in two ways worth stating,
+  because neither follows from "the same rule, later". The piece's result
+  document is on the route and was not before, and it is the member the
+  "no schema declares this" argument does not carry — an author may write
+  `ifc` into a pattern's `resultSchema`. Where they did, the route declines
+  and the misfit stands; where they did not, it reaches every path written
+  there. And what the route tests is the STORE, not the caller: once a store
+  is enrolled, any writer reaching it takes the route and contributes the
+  clause its own join carries. The direction stays refusal — every clause
+  added narrows the store's audience and its readers carry it — so this is a
+  permanent over-taint another writer can impose rather than a disclosure it
+  can obtain. Constraining it to the runtime's own writes would need
+  something the transaction does not carry: pattern-authored code runs in the
+  runtime's realm, so "who is writing" is not a question the write side can
+  ask.
+
+  Two costs come with it, both outside the store. The declared list is a
+  conjunction every reader carries, so a store that accumulates clauses with
+  disjoint audiences ends up readable by nobody while still admitting
+  writes; that is §8.12.2's ratchet reaching its end, and §8.12.7 records the
+  same outcome for its own case as safe and an operational footgun worth
+  flagging in review — the direction is refusal rather than disclosure. Two
+  shapes reach it soonest, and both are worth knowing before raising the rung.
+  A piece's RESULT document is what other pieces read, and it now accumulates
+  every clause the piece ever read. And a conditional keeps ONE result store
+  per node — `ifElse`, `when`, `unless`, and `inspectConfLabel` over whatever
+  it is pointed at — so a branch that fires once leaves its clause on the
+  store the other branch writes through afterwards. Both are the ratchet
+  behaving as specified rather than a defect in the route, and both are
+  arguments for the per-value components carrying the audience rather than
+  the declared one. And a transaction that could not commit
+  now commits, so whatever else it staged proceeds — a post-commit effect, a
+  sink request. That is why the condition above asks what refuses a
+  builtin's request once its store no longer does, and it is the whole of
+  what the LLM sinks lose: `MAX_ENFORCEMENT_SINK_CEILINGS` declares no
+  ceiling for them, so a request the store's misfit used to refuse by
+  accident now goes. `max-enforcement-posture.test.ts` and
+  `builtin-abandoned-request.test.ts` pin that, and both flip when the
+  boundary-scoped admission mechanism that preset describes lands.
 
   Implementation in
   [prepare.ts](../../packages/runner/src/cfc/prepare.ts)
-  (`prepareBoundaryCommit` writer-fit) and
-  [runner.ts](../../packages/runner/src/runner.ts) (`recordPieceSubstrate`),
-  asserted condition by condition in
+  (`prepareBoundaryCommit` writer-fit),
+  [runner.ts](../../packages/runner/src/runner.ts)
+  (`recordRuntimeOwnedStore`),
+  [runtime-owned-store.ts](../../packages/runner/src/builtins/runtime-owned-store.ts)
+  (`ownedCell`, which a builtin mints its own state store through where the
+  mint and the scoping sit together, and the two helpers beside it for the
+  sites where they do not), and
+  [data-updating.ts](../../packages/runner/src/data-updating.ts)
+  (`anchorValueAsEntity`), asserted condition by condition in
   [cfc-writer-fit.test.ts](../../packages/runner/test/cfc-writer-fit.test.ts),
   and against the cross-space representation transform in
   [cfc-label-metadata-protection.test.ts](../../packages/runner/test/cfc-label-metadata-protection.test.ts).

--- a/docs/specs/cfc-spec-changes.md
+++ b/docs/specs/cfc-spec-changes.md
@@ -373,6 +373,83 @@ refuses a clause a policy evaluation would have discharged. A residual stands wh
 computed document, from a schema-carrying write: it stops being a write
 ceiling there, and stays a read floor.
 
+A third narrowing does not skip the measurement but answers it. The runtime
+materializes documents to hold a piece's MACHINERY rather than data an author
+named: a piece's argument, result and internal documents, minted by the runner
+from the piece's result cause; the state documents a builtin mints from its own
+node's cause; and the documents that anchoring splits out of a value written
+into any of those. The atoms these carry are a property of the transaction that
+filled them, so a declaration written into a schema either misses them or
+over-declares every instance of the pattern. §8.12.5's route 2 is what the
+runtime uses instead: the write that puts the join on a path also declares, in
+that same transaction, a policy covering it — the ceiling that resolved at the
+path plus exactly the clauses that had nowhere to go. The store's promise
+becomes the audience of what it holds, rather than the check being skipped.
+
+This is not a new route. §8.12.8's component table already names "explicit
+store-label operations (upgrades per §8.12.5 …)" as a provenance of the
+declared component, alongside schema `ifc` declarations — so a runtime-made
+upgrade is a sanctioned way for that component to change, and §8.12.5 option 2
+states the discipline: atomically tighten the store's label, then write. The
+runtime declares in the transaction that writes, which is that atomicity.
+
+What the widening adds is that the route runs on every write to such a store
+rather than only while a piece is being set up, and what licenses that is a
+property of the declaration rather than of when it is made. A declared clause
+list is a ceiling under §8.12.4 — `canWrite` asks that the store's declared
+confidentiality be at least as restrictive as the data's, which is `∃` a
+declared clause subsuming each label clause — and it is the reader's floor
+under the same section: a reader is tainted by at least the declared label, and
+§8.12.8 makes reader taint consume the effective label, which always includes
+the declared component. Subsumption makes the two agree: satisfying a declared
+clause implies satisfying the label it admits, so every reader of the store
+satisfies every clause the store admits. Each upgrade therefore admits more
+data AND narrows the audience by the same step. An unbounded reactive stream of
+upgrades leaves the store readable by fewer principals than it started with,
+never by more, which is why the route needs no bound on how often it may fire
+or on which clauses a later transaction may contribute. §8.12.5's own
+soundness argument is the same one: existing readers already expect data at the
+original label level.
+
+The route adds CLAUSES and never alternatives, which is the line §8.12.7 and
+safety invariant 1 draw. Adding a clause is the tightening §8.12.1 admits.
+Adding an alternative to a clause already stored grows that clause's reader set
+and is a widening, which those sections admit only through a grant record
+consulted at access time or an intent-gated declassification event — neither of
+which a write-side fit check is or could be. The mint folds clause LISTS, so a
+stored disjunction comes back with the alternatives it went in with.
+
+The cost is §8.12.2's ratchet: a store that once held data derived from a
+labeled read keeps that clause after the read stops, which is the over-taint
+direction. Its end state is a declared list whose clauses have disjoint
+audiences, which no principal satisfies — the store keeps admitting writes and
+stops being readable. §8.12.7 records that outcome for its own case as safe and
+an operational footgun worth flagging in review, and the direction here is the
+same: refusal, not disclosure.
+
+The claim that a store is the runtime's is made by the runtime, never measured
+from an input's own fields: the recording method is on the public transaction
+interface, so a marker without the runtime's authorization names nothing, and
+neither does one naming a store outside the owner's own space. It lasts for one
+transaction where the store is minted and filled in one go, and is enrolled for
+as long as the piece's nodes run where the store is written by the reactive
+updates, event handlers and settled requests that follow the mint. Ownership
+passes to an anchored child, whose id is derived from its parent's rather than
+named by an author. A document nobody named is untouched: a write to an
+ordinary document measures against its own ceiling whichever transaction makes
+it, so widening the route in time does not widen it in scope.
+
+Two costs sit outside the store, and both belong to the route rather than to
+the widening. The declared list is a conjunction every reader carries, so a
+store accumulating clauses with disjoint audiences ends up readable by nobody
+while still admitting writes — §8.12.2's ratchet reaching its end, refusal
+rather than disclosure. And a transaction that could not commit now commits, so
+whatever else it staged proceeds: a post-commit effect, a sink request. A
+builtin whose store moves onto the route therefore needs something else to
+refuse its request, which is a `sink-request` ceiling where the builtin stages
+one and nothing where it does not. Contract text in
+`docs/specs/cfc-enforcement-matrix.md` §4; tests `cfc-writer-fit.test.ts`.
+
 (d) **[normative] Residency fit — the ceiling a document carries by living
 where it lives.** The fit measurement joins the target's declared policy with
 one RESIDENCY clause, `Space(<the space the document resides in>)`. A flow

--- a/packages/cf-harness/test/run-pattern.test.ts
+++ b/packages/cf-harness/test/run-pattern.test.ts
@@ -1079,6 +1079,80 @@ describe("run-pattern", () => {
       expect(result.runState.status).not.toBe("failed");
     });
 
+    it("reports a commit the boundary refused as a refusal, not as a thrown computation", async () => {
+      // The two exits share a guard — a piece whose result never landed — and
+      // are told apart only by the error's name, so a refusal reported as a
+      // thrown computation would carry the wrong message and lose its
+      // structured refusals. A pattern this PR's ownership route cannot get
+      // refused any more (every store such a run writes is one the runtime
+      // owns), so the record is raised by name here rather than by provoking
+      // the boundary: what is under test is which exit the tool takes and
+      // what it puts in the model-facing message, both of which read the name
+      // and nothing else about how the record arrived.
+      const engine = createEngine();
+      const result = await engine.invokeBuiltinTool("run_pattern", {
+        sourceText: [
+          "import { computed, pattern } from 'commonfabric';",
+          "interface Output { boom: number; }",
+          "export default pattern<Record<string, never>, Output>(() => ({",
+          "  boom: computed(() => {",
+          "    const refusal = new Error('refused: /of:doc at //x');",
+          "    refusal.name = 'CfcCommitRefusalError';",
+          "    throw refusal;",
+          "  }),",
+          "}));",
+          "",
+        ].join("\n"),
+      });
+      const output = result.output as RunPatternToolErrorOutput;
+      expect(output.status).toBe("error");
+      expect(output.message).toContain("policy refused to commit");
+      expect(output.message).not.toContain("failed while settling");
+      // A refusal the boundary described only in prose carries no structured
+      // refusals, so the message is the opaque one and the detail stays in
+      // the artifact field the prompt loop strips from model context.
+      expect(output.message).not.toContain("of:doc");
+      expect(output.rawCauseMessage).toContain("of:doc");
+      expect(output.pieceId).toBeDefined();
+    });
+
+    it("names the clause and the gate when the refused commit carried structured refusals", async () => {
+      // The other arm of the same exit: a refusal the boundary described
+      // structurally gets the described message rather than the opaque one,
+      // and the atoms reach the model while the documents do not.
+      const engine = createEngine();
+      const result = await engine.invokeBuiltinTool("run_pattern", {
+        sourceText: [
+          "import { computed, pattern } from 'commonfabric';",
+          "interface Output { boom: number; }",
+          "export default pattern<Record<string, never>, Output>(() => ({",
+          "  boom: computed(() => {",
+          "    const refusal = new Error('refused: /of:ledger at //total') as",
+          "      Error & { refusals?: unknown[] };",
+          "    refusal.name = 'CfcCommitRefusalError';",
+          "    refusal.refusals = [{",
+          "      gate: 'writer-fit',",
+          "      offendingAtoms: ['\"expense-note\"'],",
+          "      inputs: [],",
+          "      attribution: 'none',",
+          "      reason: 'writer-fit confidentiality misfit',",
+          "    }];",
+          "    throw refusal;",
+          "  }),",
+          "}));",
+          "",
+        ].join("\n"),
+      });
+      const output = result.output as RunPatternToolErrorOutput;
+      expect(output.status).toBe("error");
+      expect(output.message).toContain("policy refused to commit");
+      expect(output.message).toContain("expense-note");
+      expect(output.policyRefusal).toBeDefined();
+      // Document identifiers stay out of the model-facing message either way.
+      expect(output.message).not.toContain("of:ledger");
+      expect(output.rawCauseMessage).toContain("of:ledger");
+    });
+
     it("returns an error naming the policy refusal when the answer carries a label the model may not read", async () => {
       // A strict flow-label runtime over a labelled source: the pattern
       // derives from the secret, and its result carries the secret's label.
@@ -1757,12 +1831,18 @@ describe("run-pattern", () => {
     it("commits no unlabelled copy when a pattern-body map reads labelled values inline", async () => {
       // A pattern-body `.map()` runs as the built-in map, whose coordinator
       // reads the list raw. With the labelled values inline in that list, the
-      // read carries their confidentiality, so under enforce-strict the
-      // coordinator's own container write into an ordinary document is
-      // refused and nothing lands: the labelled text exists at rest only in
-      // the seeded source document, and the tool reports the commit refusal —
-      // the coordinator carries the piece's observation identity, which is
-      // what attributes a `raw:map` action's refusal to its piece.
+      // read carries their confidentiality into the stores the map writes —
+      // its result container and one result document per element. Those are
+      // stores the runtime owns, so each declares that confidentiality
+      // (§8.12.5 route 2) rather than refusing the write, and the run
+      // commits. Nothing copies the text even so: each element result is a
+      // link into the labelled source path, so the labelled text exists at
+      // rest only in the seeded source document.
+      //
+      // What the labels stop is the ANSWER. The model's context is outside
+      // every space, so the answer ceiling withholds the value the tool would
+      // return, and the handle it returns instead names a result that stays
+      // in the space.
       const { runtime, pieces, space, dispose } = await createStrictFabric();
       try {
         const seed = runtime.edit();
@@ -1824,21 +1904,25 @@ describe("run-pattern", () => {
             ),
           },
         });
-        const output = result.output as RunPatternToolErrorOutput;
-        expect(output.status).toBe("error");
-        expect(output.message).toContain("policy refused to commit");
-        expect(output.rawCauseMessage).toContain(
-          "writer-fit confidentiality misfit",
-        );
-        const pieceId = output.pieceId;
-        expect(pieceId).toBeDefined();
+        const output = result.output as RunPatternToolSuccessOutput;
+        // The run commits and returns its handle; the answer ceiling gates the
+        // VALUE, which stays in the space. The sibling below reaches the same
+        // outcome from the linked shape, so inline values and linked ones now
+        // differ only in which document holds the text.
+        expect(output.status).toBe("ok");
+        expect(output.value).toBeUndefined();
+        expect(output.policyRefusal).toBeUndefined();
         await runtime.idle();
         await pieces.synced();
 
-        const piece = await pieces.get(pieceId!);
-        expect(await piece.result.get([])).toBeUndefined();
-        expect(docsHolding(runtime, space, `of:${pieceId}`, "alpha-secret"))
-          .toEqual([sourceId]);
+        const piece = await pieces.get(output.pieceId);
+        expect(await piece.result.get(["notes"])).toEqual([
+          "alpha-secret",
+          "beta-secret",
+        ]);
+        expect(
+          docsHolding(runtime, space, `of:${output.pieceId}`, "alpha-secret"),
+        ).toEqual([sourceId]);
       } finally {
         await dispose();
       }

--- a/packages/runner/src/builtins/cell-from-url.ts
+++ b/packages/runner/src/builtins/cell-from-url.ts
@@ -4,6 +4,10 @@ import { type Runtime } from "../runtime.ts";
 import { type Action } from "../scheduler.ts";
 import type { URI } from "../sigil-types.ts";
 import { slugIdForSpace } from "../slugs.ts";
+import {
+  enrollRuntimeOwnedStore,
+  recordRuntimeOwnedStore,
+} from "./runtime-owned-store.ts";
 import type {
   IExtendedStorageTransaction,
   MemorySpace,
@@ -51,6 +55,14 @@ export function cellFromUrl(
       undefined,
       tx,
     );
+    // Both stores are keyed on this node's cause and outlive the transaction
+    // that mints them, so each is named and enrolled the way every other
+    // builtin's state store is. The mint stays as it was: these two carry no
+    // instance scope, and `ownedCell` would address them at one.
+    for (const store of [pending, cell]) {
+      recordRuntimeOwnedStore(tx, parentCell, store);
+      enrollRuntimeOwnedStore(tx, parentCell, store);
+    }
     sendResult(tx, { pending, cell });
 
     const inputs = inputsCell.withTx(tx);

--- a/packages/runner/src/builtins/compile-and-run.ts
+++ b/packages/runner/src/builtins/compile-and-run.ts
@@ -10,7 +10,8 @@ import type { Runtime } from "../runtime.ts";
 import { type Action } from "../scheduler.ts";
 import { narrowestScope } from "../scope.ts";
 import type { IExtendedStorageTransaction } from "../storage/interface.ts";
-import { resolvedCellScope, scopedCell } from "./scope-policy.ts";
+import { ownedCell } from "./runtime-owned-store.ts";
+import { resolvedCellScope } from "./scope-policy.ts";
 
 /**
  * Compile a pattern/module and run it.
@@ -102,32 +103,35 @@ export function compileAndRun(
       if (cellsInitialized && cellScope !== outputScope) {
         previousCallHash = undefined;
       }
-      const basePending = runtime.getCell<boolean>(
-        parentCell.space,
+      pending = ownedCell<boolean>(
+        runtime,
+        tx,
+        parentCell,
         { compile: { pending: cause } },
         undefined,
-        tx,
+        outputScope,
       );
-      pending = scopedCell(runtime, tx, basePending, outputScope);
       pending.send(false);
 
-      const baseResult = runtime.getCell<string | undefined>(
-        parentCell.space,
+      result = ownedCell<string | undefined>(
+        runtime,
+        tx,
+        parentCell,
         { compile: { result: cause } },
         undefined,
-        tx,
+        outputScope,
       );
-      result = scopedCell(runtime, tx, baseResult, outputScope);
 
-      const baseError = runtime.getCell<string | undefined>(
-        parentCell.space,
+      error = ownedCell<string | undefined>(
+        runtime,
+        tx,
+        parentCell,
         { compile: { error: cause } },
         undefined,
-        tx,
+        outputScope,
       );
-      error = scopedCell(runtime, tx, baseError, outputScope);
 
-      const baseErrors = runtime.getCell<
+      errors = ownedCell<
         | Array<
           {
             line: number;
@@ -139,12 +143,13 @@ export function compileAndRun(
         >
         | undefined
       >(
-        parentCell.space,
+        runtime,
+        tx,
+        parentCell,
         { compile: { errors: cause } },
         undefined,
-        tx,
+        outputScope,
       );
-      errors = scopedCell(runtime, tx, baseErrors, outputScope);
 
       sendResult(tx, { pending, result, error, errors });
       cellsInitialized = true;

--- a/packages/runner/src/builtins/fetch-program.ts
+++ b/packages/runner/src/builtins/fetch-program.ts
@@ -16,6 +16,11 @@ import type { Runtime } from "../runtime.ts";
 import { type Action } from "../scheduler.ts";
 import type { IExtendedStorageTransaction } from "../storage/interface.ts";
 import { computeInputHashFromValue } from "./fetch-utils.ts";
+import {
+  enrollRuntimeOwnedStore,
+  ownedCell,
+  recordRuntimeOwnedStore,
+} from "./runtime-owned-store.ts";
 import { scopedCell } from "./scope-policy.ts";
 
 /**
@@ -229,33 +234,36 @@ export function fetchProgram(
     const outputScope = tx.getNarrowestReadScope();
 
     if (!cellsInitialized || cellScope !== outputScope) {
-      const basePending = runtime.getCell<boolean>(
-        parentCell.space,
+      pending = ownedCell<boolean>(
+        runtime,
+        tx,
+        parentCell,
         { fetchProgram: { pending: cause } },
         undefined,
-        tx,
+        outputScope,
       );
-      pending = scopedCell(runtime, tx, basePending, outputScope);
 
-      const baseResult = runtime.getCell<ProgramResult | undefined>(
-        parentCell.space,
+      result = ownedCell<ProgramResult | undefined>(
+        runtime,
+        tx,
+        parentCell,
         {
           fetchProgram: { result: cause },
         },
         undefined,
-        tx,
+        outputScope,
       );
-      result = scopedCell(runtime, tx, baseResult, outputScope);
 
-      const baseError = runtime.getCell<any | undefined>(
-        parentCell.space,
+      error = ownedCell<any | undefined>(
+        runtime,
+        tx,
+        parentCell,
         {
           fetchProgram: { error: cause },
         },
         undefined,
-        tx,
+        outputScope,
       );
-      error = scopedCell(runtime, tx, baseError, outputScope);
 
       const baseCache = runtime.getCell(
         parentCell.space,
@@ -269,6 +277,8 @@ export function fetchProgram(
         baseCache,
         outputScope,
       ) as Cell<Record<string, FetchCacheEntry>>;
+      recordRuntimeOwnedStore(tx, parentCell, cache);
+      enrollRuntimeOwnedStore(tx, parentCell, cache);
 
       // Link the new result cells to the parent result cell
       setResultCell(pending, parentCell);

--- a/packages/runner/src/builtins/fetch.ts
+++ b/packages/runner/src/builtins/fetch.ts
@@ -31,11 +31,11 @@ import {
   tryClaimMutex,
   tryWriteResult,
 } from "./fetch-utils.ts";
+import { ownedCell } from "./runtime-owned-store.ts";
 import {
   effectTargetKey,
   markEffectCompletion,
 } from "../executor/effect-completion.ts";
-import { scopedCell } from "./scope-policy.ts";
 
 type FetchRequestOptions = {
   body?: any;
@@ -381,41 +381,45 @@ function fetchBuiltin(kind: FetchKind) {
       const outputScope = tx.getNarrowestReadScope();
 
       if (!cellsInitialized || cellScope !== outputScope) {
-        const basePending = runtime.getCell<boolean>(
-          parentCell.space,
+        pending = ownedCell<boolean>(
+          runtime,
+          tx,
+          parentCell,
           { [kind.name]: { pending: cause } },
           undefined,
-          tx,
+          outputScope,
         );
-        pending = scopedCell(runtime, tx, basePending, outputScope);
 
-        const baseResult = runtime.getCell<any | undefined>(
-          parentCell.space,
+        result = ownedCell<any | undefined>(
+          runtime,
+          tx,
+          parentCell,
           {
             [kind.name]: { result: cause },
           },
           undefined,
-          tx,
+          outputScope,
         );
-        result = scopedCell(runtime, tx, baseResult, outputScope);
 
-        const baseError = runtime.getCell<any | undefined>(
-          parentCell.space,
+        error = ownedCell<any | undefined>(
+          runtime,
+          tx,
+          parentCell,
           {
             [kind.name]: { error: cause },
           },
           undefined,
-          tx,
+          outputScope,
         );
-        error = scopedCell(runtime, tx, baseError, outputScope);
 
-        const baseInternal = runtime.getCell(
-          parentCell.space,
+        internal = ownedCell(
+          runtime,
+          tx,
+          parentCell,
           { [kind.name]: { internal: cause } },
           internalSchema,
-          tx,
+          outputScope,
         );
-        internal = scopedCell(runtime, tx, baseInternal, outputScope);
 
         // Link the new result cells to the parent result cell
         setResultCell(pending, parentCell);

--- a/packages/runner/src/builtins/if-else.ts
+++ b/packages/runner/src/builtins/if-else.ts
@@ -7,7 +7,8 @@ import { type RawBuiltinResult } from "../module.ts";
 import { type Runtime } from "../runtime.ts";
 import { type Action } from "../scheduler.ts";
 import type { IExtendedStorageTransaction } from "../storage/interface.ts";
-import { resolvedCellScope, scopedCell } from "./scope-policy.ts";
+import { ownedCell } from "./runtime-owned-store.ts";
+import { resolvedCellScope } from "./scope-policy.ts";
 
 /**
  * Argument schema for ifElse. The action value-reads ONLY `condition`; the
@@ -55,13 +56,14 @@ export function ifElse(
   const action: Action = (tx: IExtendedStorageTransaction) => {
     const { cell: conditionCell, value: condition } = readCondition(tx);
     const resultScope = resolvedCellScope(runtime, tx, conditionCell);
-    const baseResult = runtime.getCell<any>(
-      parentCell.space,
+    const result = ownedCell<any>(
+      runtime,
+      tx,
+      parentCell,
       { ifElse: cause },
       undefined,
-      tx,
+      resultScope,
     );
-    const result = scopedCell(runtime, tx, baseResult, resultScope);
     sendResult(tx, result);
     const resultWithLog = result.withTx(tx);
     const inputsWithLog = inputsCell.withTx(tx);

--- a/packages/runner/src/builtins/inspect-conf-label.ts
+++ b/packages/runner/src/builtins/inspect-conf-label.ts
@@ -8,7 +8,8 @@ import {
   type InspectConfLabelResult,
   inspectStoredConfLabel,
 } from "../cfc/label-introspection.ts";
-import { resolvedCellScope, scopedCell } from "./scope-policy.ts";
+import { ownedCell } from "./runtime-owned-store.ts";
+import { resolvedCellScope } from "./scope-policy.ts";
 
 // Inv-12 Stage 2 (spec §4.6.4.1; docs/specs/cfc-label-metadata-confidentiality
 // .md §3): `inspectConfLabel` — the ONLY pattern-facing surface for
@@ -72,13 +73,14 @@ export function inspectConfLabel(
       tx,
       inputsWithTx.key("target"),
     );
-    const baseResult = runtime.getCell<InspectConfLabelResult>(
-      parentCell.space,
+    const result = ownedCell<InspectConfLabelResult>(
+      runtime,
+      tx,
+      parentCell,
       { inspectConfLabel: cause },
       undefined,
-      tx,
+      resultScope,
     );
-    const result = scopedCell(runtime, tx, baseResult, resultScope);
     sendResult(tx, result);
 
     const inputs = inputsWithTx.asSchema(INPUT_SCHEMA).get() as {

--- a/packages/runner/src/builtins/list-coordinator-plan.ts
+++ b/packages/runner/src/builtins/list-coordinator-plan.ts
@@ -9,11 +9,8 @@ import { listElementLink } from "./list-element-link.ts";
 import { inferListOpArgumentUsage } from "./list-op-argument-usage.ts";
 import { listResultSchema } from "./list-result-schema.ts";
 import { resolveOpPattern } from "./op-pattern-ref.ts";
-import {
-  narrowestCellScope,
-  outputSpotFromBinding,
-  scopedCell,
-} from "./scope-policy.ts";
+import { ownedCell } from "./runtime-owned-store.ts";
+import { narrowestCellScope, outputSpotFromBinding } from "./scope-policy.ts";
 
 /** The three list coordinators, by the builtin ref name each registers. */
 export type ListOp = "map" | "filter" | "flatMap";
@@ -123,13 +120,14 @@ export function listCoordinatorPlan(
   const resultSchema = op === "map"
     ? listResultSchema(opPattern.resultSchema)
     : listResultSchema();
-  const baseResult = runtime.getCell<any[]>(
-    parentCell.space,
+  const container = ownedCell<any[]>(
+    runtime,
+    tx,
+    parentCell,
     { [op]: parentCell.entityId, outputSpot },
     resultSchema,
-    tx,
+    scope,
   );
-  const container = scopedCell(runtime, tx, baseResult, scope);
   const elementKeys = Array.isArray(list)
     ? listElementKeys(list)
     : new Map<number, string>();

--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -113,7 +113,7 @@ import {
   LLMToolSchema,
 } from "./llm-schemas.ts";
 import { resolveStoredPatternAsync } from "./op-pattern-ref.ts";
-import { scopedCell } from "./scope-policy.ts";
+import { ownedCell, recordRuntimeOwnedStore } from "./runtime-owned-store.ts";
 
 // Message schema that mints the `LlmDerived` provenance stamp (Epic D1).
 // Recorded as the schema write-policy input for each model-produced message's
@@ -3372,25 +3372,27 @@ export function llmDialog(
       // previously existing results. Note that we might not yet have it loaded
       // and that this function will be called again once the data is loaded
       // (but this if branch will be skipped then).
-      const baseResult = runtime.getCell(
-        parentCell.space,
+      result = ownedCell(
+        runtime,
+        tx,
+        parentCell,
         { llmDialog: { result: cause } },
         resultSchema,
-        tx,
+        outputScope,
       );
-      result = scopedCell(runtime, tx, baseResult, outputScope);
       result.sync(); // Kick off sync, no need to await
 
       // Create another cell to store the internal state. This isn't returned to
       // the caller. But again, the predictable cause means all instances tied
       // to the same input cells will coordinate via the same cell.
-      const baseInternal = runtime.getCell(
-        parentCell.space,
+      internal = ownedCell(
+        runtime,
+        tx,
+        parentCell,
         { llmDialog: { internal: cause } },
         internalSchema,
-        tx,
+        outputScope,
       );
-      internal = scopedCell(runtime, tx, baseInternal, outputScope);
       internal.sync(); // Kick off sync, no need to await
 
       // Create pinnedCells cell to store the internal pinned cells state
@@ -3405,13 +3407,14 @@ export function llmDialog(
           required: ["path", "name"],
         },
       } as const;
-      const basePinnedCells = runtime.getCell(
-        parentCell.space,
+      pinnedCells = ownedCell(
+        runtime,
+        tx,
+        parentCell,
         { llmDialog: { pinnedCells: cause } },
         pinnedCellsSchema,
-        tx,
+        outputScope,
       );
-      pinnedCells = scopedCell(runtime, tx, basePinnedCells, outputScope);
       pinnedCells.sync(); // Kick off sync, no need to await
 
       const pending = result.key("pending");
@@ -3510,6 +3513,21 @@ export function llmDialog(
             tx,
             messagesBase.scope,
           );
+          // Each message is its own document, minted from this node's cause
+          // and named by nobody's schema. It is filled by the transaction that
+          // mints it, so the marker alone reaches it — enrolling a per-message
+          // store would grow the runtime's set for as long as the piece runs
+          // (`runtime-owned-store.ts`).
+          //
+          // The document is minted in the resolved messages array's space,
+          // which need not be this node's. Where it is not, the marker names
+          // nothing: a store in another space belongs to whoever holds that
+          // space's replicas, so this node's flow join has no business
+          // becoming its declared policy. A labeled write to such a transcript
+          // is refused, as it was before this route existed; admitting it
+          // needs a cross-space release decision, which is not a write-side
+          // fit check's to make.
+          recordRuntimeOwnedStore(tx, result, messageCell);
           messageCell.withTx(tx).set(
             // Cast because we can't yet express ArrayBuffer in JSON Schema
             { ...event } as Schema<typeof LLMMessageSchema>,
@@ -3835,6 +3853,9 @@ async function startRequest(
           tx,
           base.scope,
         );
+        // Per-message store: named for this transaction, not enrolled. See
+        // the sibling in `addMessage` and `runtime-owned-store.ts`.
+        recordRuntimeOwnedStore(tx, result, messageCell);
         messageCell.withTx(tx).set(message);
         return messageCell;
       }),
@@ -4090,6 +4111,8 @@ Some operations (especially \`invoke()\` with patterns) create "Pages" - running
               tx,
               errorBase.scope,
             );
+            // Per-message store: named for this transaction, not enrolled.
+            recordRuntimeOwnedStore(tx, result, errorCell);
             errorCell.withTx(tx).set(
               errorMessage as Schema<typeof LLMMessageSchema>,
             );

--- a/packages/runner/src/builtins/llm.ts
+++ b/packages/runner/src/builtins/llm.ts
@@ -59,7 +59,7 @@ import {
   LLMResultSchema,
   LLMToolSchema,
 } from "./llm-schemas.ts";
-import { scopedCell } from "./scope-policy.ts";
+import { ownedCell } from "./runtime-owned-store.ts";
 
 const logger = getLogger("llm", {
   enabled: true,
@@ -749,13 +749,14 @@ export function llm(
       if (cellsInitialized && cellScope !== outputScope) {
         previousCallHash = undefined;
       }
-      const baseResultCell = runtime.getCell(
-        parentCell.space,
+      resultCell = ownedCell(
+        runtime,
+        tx,
+        parentCell,
         { llm: { result: cause } },
         LLMResultSchema,
-        tx,
+        outputScope,
       );
-      resultCell = scopedCell(runtime, tx, baseResultCell, outputScope);
       resultCell.sync();
       sendResult(tx, resultCell);
       cellsInitialized = true;
@@ -1135,13 +1136,14 @@ export function generateText(
       if (cellsInitialized && cellScope !== outputScope) {
         previousCallHash = undefined;
       }
-      const baseResultCell = runtime.getCell(
-        parentCell.space,
+      resultCell = ownedCell(
+        runtime,
+        tx,
+        parentCell,
         { generateText: { result: cause } },
         GenerateTextResultSchema,
-        tx,
+        outputScope,
       );
-      resultCell = scopedCell(runtime, tx, baseResultCell, outputScope);
       resultCell.sync();
       sendResult(tx, resultCell);
       cellsInitialized = true;
@@ -1496,13 +1498,14 @@ export function generateObject<T extends Record<string, unknown>>(
       if (cellsInitialized && cellScope !== outputScope) {
         previousCallHash = undefined;
       }
-      const baseResultCell = runtime.getCell(
-        parentCell.space,
+      resultCell = ownedCell(
+        runtime,
+        tx,
+        parentCell,
         { generateObject: { result: cause } },
         GenerateObjectResultSchema,
-        tx,
+        outputScope,
       );
-      resultCell = scopedCell(runtime, tx, baseResultCell, outputScope);
       resultCell.sync();
       sendResult(tx, resultCell);
       cellsInitialized = true;

--- a/packages/runner/src/builtins/runtime-owned-store.ts
+++ b/packages/runner/src/builtins/runtime-owned-store.ts
@@ -1,0 +1,137 @@
+// The seam a builtin holding state goes through: mint the document, name it to
+// the write-side fit check, and enroll it for as long as the piece runs.
+//
+// A store the runtime owns holds whatever the transactions running a builtin
+// read, so no confidentiality an author writes into a schema covers it. Naming
+// it here is what lets CFC's fit check (spec §8.12.4) declare that policy from
+// the flow instead of refusing the write; `docs/specs/cfc-enforcement-matrix.md`
+// §4 states which stores qualify.
+
+import type { JSONSchema } from "../builder/types.ts";
+import type { Cell } from "../cell.ts";
+import {
+  CFC_STRUCTURAL_PROVENANCE_RUNTIME_OWNED_STORE,
+  runtimeWritePolicyAuthorization,
+} from "../cfc/types.ts";
+import type { NormalizedFullLink } from "../link-types.ts";
+import { runtimeOwnedStoreOwnerKey } from "../cfc/runtime-owned-stores.ts";
+import type { Runtime } from "../runtime.ts";
+import type { IExtendedStorageTransaction } from "../storage/interface.ts";
+import { scopedCell } from "./scope-policy.ts";
+
+/**
+ * Name `store` as a store the runtime owns for `owner`'s piece: a document a
+ * builtin mints from its own node's cause to hold state, rather than data an
+ * author named.
+ *
+ * A builtin's state store holds whatever the transactions running that builtin
+ * read, and an author cannot know which atoms a given transaction will carry,
+ * so no confidentiality declaration written into a schema covers it. CFC's
+ * write-side fit check (spec §8.12.4) reads this marker and declares that
+ * policy itself; `docs/specs/cfc-enforcement-matrix.md` §4 states the route.
+ * The runner records the same marker for a piece's own argument, result and
+ * internal documents.
+ *
+ * Only a store keyed on this NODE belongs here. A document the runtime mints
+ * from a constant or from the space's own principal — a space cell, a shared
+ * clock, a per-space pinned-cell list — is shared by every piece in the space,
+ * so one piece's flow join has no business becoming its declared policy.
+ *
+ * The marker names the store for THIS transaction, which is what a store the
+ * runtime mints and fills in one go needs — a dialog message, say. A store the
+ * node keeps across transactions wants {@link ownedCell}, which enrolls it as
+ * well.
+ *
+ * The marker carries the runtime's authorization, which is what the fit check
+ * asks for: the method that records it is reachable from anything holding a
+ * cell, so an unmarked marker naming the same document counts for nothing.
+ */
+export function recordRuntimeOwnedStore(
+  tx: IExtendedStorageTransaction,
+  owner: Cell<any>,
+  store: Cell<any>,
+): void {
+  const ownerLink = owner.getAsNormalizedFullLink();
+  const storeLink = store.getAsNormalizedFullLink();
+  tx.recordCfcWritePolicyInput({
+    kind: "structural-provenance",
+    target: {
+      space: storeLink.space,
+      id: storeLink.id,
+      scope: storeLink.scope,
+      path: [...storeLink.path],
+    },
+    claim: CFC_STRUCTURAL_PROVENANCE_RUNTIME_OWNED_STORE,
+    sources: [{
+      space: ownerLink.space,
+      id: ownerLink.id,
+      scope: ownerLink.scope,
+      path: [...ownerLink.path],
+    }],
+  }, runtimeWritePolicyAuthorization);
+}
+
+/**
+ * The store this node keeps under `cause`, at `scope` — minted in `owner`'s
+ * space, named to the write-side fit check per {@link
+ * recordRuntimeOwnedStore}, ENROLLED for the rest of this runtime's life, and
+ * addressed at the instance scope the caller asked for.
+ *
+ * This is the shape every builtin holding its own state uses, so the mint, the
+ * marker and the scoping stay together: a builtin that mints a store without
+ * naming it has a store whose every labeled write is refused, and the refusal
+ * arrives at whichever later transaction first carries a label rather than at
+ * the mint.
+ *
+ * The enrollment is what reaches those later transactions — a node's state is
+ * written by event handlers and by settled requests, each on a transaction of
+ * its own. It lasts until `owner`'s piece is cancelled, which is why only a
+ * store the node KEEPS belongs here: one minted per event would grow the
+ * enrollment for as long as the piece runs, and needs the marker alone.
+ */
+export function ownedCell<T = any>(
+  runtime: Runtime,
+  tx: IExtendedStorageTransaction,
+  owner: Cell<any>,
+  cause: unknown,
+  schema: JSONSchema | undefined,
+  scope: NormalizedFullLink["scope"],
+): Cell<T> {
+  const base = runtime.getCell<T>(owner.space, cause, schema, tx);
+  const store = scopedCell(runtime, tx, base, scope);
+  recordRuntimeOwnedStore(tx, owner, store);
+  enrollRuntimeOwnedStore(tx, owner, store);
+  return store;
+}
+
+/**
+ * Enroll `store` as a store the runtime owns for `owner`'s piece, so a
+ * transaction that neither minted it nor re-marked it still finds it, until
+ * that piece's nodes are cancelled. Pairs with {@link
+ * recordRuntimeOwnedStore}, which names it for one transaction; both are
+ * wanted where a store outlives its mint.
+ */
+export function enrollRuntimeOwnedStore(
+  tx: IExtendedStorageTransaction,
+  owner: Cell<any>,
+  store: Cell<any>,
+): void {
+  const ownerLink = owner.getAsNormalizedFullLink();
+  const storeLink = store.getAsNormalizedFullLink();
+  const ownerKey = runtimeOwnedStoreOwnerKey(
+    storeLink,
+    ownerLink,
+    owner.runtime.scopeKeyIdentity,
+  );
+  if (ownerKey === undefined) return;
+  tx.enrollRuntimeOwnedStore(
+    {
+      space: storeLink.space,
+      id: storeLink.id,
+      scope: storeLink.scope,
+      path: [...storeLink.path],
+    },
+    ownerKey,
+    runtimeWritePolicyAuthorization,
+  );
+}

--- a/packages/runner/src/builtins/stream-data.ts
+++ b/packages/runner/src/builtins/stream-data.ts
@@ -7,11 +7,11 @@ import { createFrozenRequestSnapshot } from "../cfc/request-snapshot.ts";
 import { enqueueSinkRequestPostCommitEffect } from "../cfc/sink-request.ts";
 import { effectTargetKey } from "../executor/effect-completion.ts";
 import { settleAbandonedRequest } from "./abandoned-request.ts";
+import { ownedCell } from "./runtime-owned-store.ts";
 import { setPatternCell, setResultCell } from "../result-utils.ts";
 import type { Runtime } from "../runtime.ts";
 import { type Action } from "../scheduler.ts";
 import type { IExtendedStorageTransaction } from "../storage/interface.ts";
-import { scopedCell } from "./scope-policy.ts";
 
 /**
  * Stream data from a URL, used for querying Synopsys.
@@ -68,34 +68,37 @@ export function streamData(
       if (cellsInitialized && cellScope !== outputScope) {
         previousCall = "";
       }
-      const basePending = runtime.getCell<boolean>(
-        parentCell.space,
+      pending = ownedCell<boolean>(
+        runtime,
+        tx,
+        parentCell,
         { streamData: { pending: cause } },
         undefined,
-        tx,
+        outputScope,
       );
-      pending = scopedCell(runtime, tx, basePending, outputScope);
       pending.send(false);
 
-      const baseResult = runtime.getCell<any | undefined>(
-        parentCell.space,
+      result = ownedCell<any | undefined>(
+        runtime,
+        tx,
+        parentCell,
         {
           streamData: { result: cause },
         },
         undefined,
-        tx,
+        outputScope,
       );
-      result = scopedCell(runtime, tx, baseResult, outputScope);
 
-      const baseError = runtime.getCell<any | undefined>(
-        parentCell.space,
+      error = ownedCell<any | undefined>(
+        runtime,
+        tx,
+        parentCell,
         {
           streamData: { error: cause },
         },
         undefined,
-        tx,
+        outputScope,
       );
-      error = scopedCell(runtime, tx, baseError, outputScope);
 
       // Link the new result cells to the parent result cell
       setResultCell(pending, parentCell);

--- a/packages/runner/src/builtins/unless.ts
+++ b/packages/runner/src/builtins/unless.ts
@@ -3,7 +3,8 @@ import { type Action } from "../scheduler.ts";
 import { type Runtime } from "../runtime.ts";
 import type { IExtendedStorageTransaction } from "../storage/interface.ts";
 import { resolveLink } from "../link-resolution.ts";
-import { resolvedCellScope, scopedCell } from "./scope-policy.ts";
+import { ownedCell } from "./runtime-owned-store.ts";
+import { resolvedCellScope } from "./scope-policy.ts";
 import { parseLink } from "../link-utils.ts";
 
 /**
@@ -21,13 +22,14 @@ export function unless(
   return (tx: IExtendedStorageTransaction) => {
     const conditionCell = inputsCell.key("condition");
     const resultScope = resolvedCellScope(runtime, tx, conditionCell);
-    const baseResult = runtime.getCell<any>(
-      parentCell.space,
+    const result = ownedCell<any>(
+      runtime,
+      tx,
+      parentCell,
       { unless: cause },
       undefined,
-      tx,
+      resultScope,
     );
-    const result = scopedCell(runtime, tx, baseResult, resultScope);
     sendResult(tx, result);
     const resultWithLog = result.withTx(tx);
     const inputsWithLog = inputsCell.withTx(tx);

--- a/packages/runner/src/builtins/when.ts
+++ b/packages/runner/src/builtins/when.ts
@@ -3,7 +3,8 @@ import { type Action } from "../scheduler.ts";
 import { type Runtime } from "../runtime.ts";
 import type { IExtendedStorageTransaction } from "../storage/interface.ts";
 import { resolveLink } from "../link-resolution.ts";
-import { resolvedCellScope, scopedCell } from "./scope-policy.ts";
+import { ownedCell } from "./runtime-owned-store.ts";
+import { resolvedCellScope } from "./scope-policy.ts";
 import { parseLink } from "../link-utils.ts";
 
 /**
@@ -21,13 +22,14 @@ export function when(
   return (tx: IExtendedStorageTransaction) => {
     const conditionCell = inputsCell.key("condition");
     const resultScope = resolvedCellScope(runtime, tx, conditionCell);
-    const baseResult = runtime.getCell<any>(
-      parentCell.space,
+    const result = ownedCell<any>(
+      runtime,
+      tx,
+      parentCell,
       { when: cause },
       undefined,
-      tx,
+      resultScope,
     );
-    const result = scopedCell(runtime, tx, baseResult, resultScope);
     sendResult(tx, result);
     const resultWithLog = result.withTx(tx);
     const inputsWithLog = inputsCell.withTx(tx);

--- a/packages/runner/src/builtins/wish.ts
+++ b/packages/runner/src/builtins/wish.ts
@@ -46,6 +46,10 @@ import {
   isStorageTransactionInconsistent,
 } from "../storage/rejection.ts";
 import { onSchemaRegistryClear } from "../schema-registry.ts";
+import {
+  enrollRuntimeOwnedStore,
+  recordRuntimeOwnedStore,
+} from "./runtime-owned-store.ts";
 import { scopedCell } from "./scope-policy.ts";
 import { rawMetaWriteAuthorization } from "../meta-seam.ts";
 
@@ -1258,6 +1262,8 @@ function resolveSpaceTarget(
         undefined,
         ctx.tx,
       );
+      recordRuntimeOwnedStore(ctx.tx, ctx.parentCell, cell);
+      enrollRuntimeOwnedStore(ctx.tx, ctx.parentCell, cell);
       const existing = cell.withTx(ctx.tx).sample();
       if (existing == null) {
         cell.withTx(ctx.tx).set(
@@ -2107,6 +2113,8 @@ export function wish(
       tx,
     );
     const scoped = scopedCell(runtime, tx, baseCell, outputScope);
+    recordRuntimeOwnedStore(tx, parentCell, scoped);
+    enrollRuntimeOwnedStore(tx, parentCell, scoped);
     if (scoped !== baseCell) {
       // Copy the meta result link from the base cell into our new scoped cell
       const resultLink = getMetaLink(baseCell.withTx(tx), "result");
@@ -2611,6 +2619,8 @@ export function wish(
         undefined,
         tx,
       );
+      recordRuntimeOwnedStore(tx, parentCell, slot.readyCell);
+      enrollRuntimeOwnedStore(tx, parentCell, slot.readyCell);
     }
     slot.readyCell.get();
 

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -127,7 +127,6 @@ import { cfcSchemaEntries } from "./schema-label-view.ts";
 import { mergeCfcSchemaEnvelopes } from "./schema-merge.ts";
 import { createTrustResolver } from "./trust.ts";
 import {
-  CFC_STRUCTURAL_PROVENANCE_PIECE_SUBSTRATE,
   CFC_STRUCTURAL_PROVENANCE_SEED_MATERIALIZATION,
   CFC_STRUCTURAL_PROVENANCE_SETUP_PROJECTION,
   type CfcAddress,
@@ -137,6 +136,7 @@ import {
   type ImplementationIdentity,
   type LabelMapEntry,
   type LabelObservationClass,
+  runtimeWritePolicyAuthorization,
   type WritePolicyInput,
 } from "./types.ts";
 import {
@@ -1057,44 +1057,6 @@ const writeIsPatternSetupInitialization = (
       );
     })
   );
-};
-
-/**
- * The documents this transaction is setting a piece up in, as target keys —
- * each piece's argument document, and the internal documents its result
- * projects to.
- *
- * The route below ACTS on these markers rather than measuring them, so who
- * recorded one decides whether it counts. `recordCfcWritePolicyInput` is on
- * the public transaction interface and pattern-authored code reaches the
- * transaction its cells are bound to, so an input's own fields say only what
- * its recorder wrote: a marker without the runtime's mark names nothing here.
- * The two sibling markers in this file corroborate against transaction state
- * instead, which suits a claim about a write that has already happened; this
- * one is a claim about whose write it is.
- *
- * A marker whose address carries a path names part of a document rather than
- * the document, and is ignored too: the route declares a policy for the whole
- * store, so it may only take a marker that claims the whole store. The setup
- * path records the empty path for every document it mints from a piece's
- * result cell, so this excludes only an argument link that was stored
- * pointing into some other document.
- */
-const pieceSetupSubstrateDocuments = (
-  tx: IExtendedStorageTransaction,
-): Set<string> => {
-  const documents = new Set<string>();
-  for (const input of tx.getCfcState().writePolicyInputs) {
-    if (
-      input.kind === "structural-provenance" &&
-      input.claim === CFC_STRUCTURAL_PROVENANCE_PIECE_SUBSTRATE &&
-      canonicalizeLogicalPath(input.target.path).length === 0 &&
-      tx.isRuntimeWritePolicyInput(input)
-    ) {
-      documents.add(targetKey(input.target));
-    }
-  }
-  return documents;
 };
 
 const storedMetadataFor = (
@@ -6041,16 +6003,12 @@ export const prepareBoundaryCommit = (
     );
   }
   const targetKeys = new Set([...candidates.keys(), ...linkWrites.keys()]);
-  // Computed once: the §8.12.5 route-2 seam is a property of the transaction,
-  // and the persist loop below asks about it per target.
-  // The §8.12.5 route-2 seam is a property of the transaction, so it is read
-  // once. Only the strict rung's declaration consults it, and only where the
-  // flow join is stamped, so no other posture pays for the scan — and every
-  // rung below keeps the persist-and-flag diagnostic that is its rollout
-  // signal, storing no declared policy it could never take back.
-  const pieceSubstrateDocuments = flowPersist && writerFitRejects
-    ? pieceSetupSubstrateDocuments(tx)
-    : new Set<string>();
+  // Only the strict rung's §8.12.5 route-2 declaration asks whether a target
+  // is a store the runtime owns, and only where the flow join is stamped, so
+  // no other posture pays for the question — and every rung below keeps the
+  // persist-and-flag diagnostic that is its rollout signal, storing no
+  // declared policy it could never take back.
+  const askRuntimeOwnership = flowPersist && writerFitRejects;
   // A vouched ingest writes its provenance mark even when the payload write
   // carries no schema candidate and flow labels are off, so the ingest target
   // must enter the persist loop on its own. The anchor is the cell the helper
@@ -6984,11 +6942,26 @@ export const prepareBoundaryCommit = (
         )
         : [];
       // Whether a misfit below is answered by declaring a covering policy
-      // (§8.12.5 route 2) instead of refusing: this document is one the
-      // runner named as a piece's substrate, at a rung that would reject.
+      // (§8.12.5 route 2) instead of refusing: this document is a store the
+      // runtime owns, at a rung that would reject.
       // `cfc-enforcement-matrix.md` §4 states the route; the rest of the
       // conditions on it are at the mint below.
-      const pieceSetupSubstrate = pieceSubstrateDocuments.has(key);
+      //
+      // The route ACTS on the runtime's claim rather than measuring it, which
+      // is why the transaction answers only for markers that arrived carrying
+      // the runtime's authorization. `recordCfcWritePolicyInput` is on the
+      // public transaction interface and pattern-authored code reaches the
+      // transaction its cells are bound to, so an input's own fields say only
+      // what its recorder wrote. The two sibling markers in this file
+      // corroborate against transaction state instead, which suits a claim
+      // about a write that has already happened; this one is a claim about
+      // whose write it is.
+      const runtimeOwnedStore = askRuntimeOwnership &&
+        tx.isRuntimeOwnedStore(
+          target.space,
+          id,
+          runtimeWritePolicyAuthorization,
+        );
       // SC-4, freeze-at-creation form: a path's shape (existence) entry is
       // minted ONCE — at creation, or at the one-time migration of legacy
       // pre-class entries (whose accumulated confidentiality is absorbed
@@ -7136,7 +7109,7 @@ export const prepareBoundaryCommit = (
             ],
           );
           if (
-            offending.length > 0 && pieceSetupSubstrate &&
+            offending.length > 0 && runtimeOwnedStore &&
             // A schema that declares at this exact path owns the store's
             // policy there; widening it from the join would make the walk's
             // own re-mint non-monotone on the next write and brick the path
@@ -7172,19 +7145,41 @@ export const prepareBoundaryCommit = (
             // go, so the store's promise becomes the audience of what it
             // holds. What lands is what the ceiling did not already cover,
             // so a clause residency satisfies stays in the stamp alone.
-            // A piece's substrate is filled by the runtime out of
-            // what the setup transaction read — the argument document, and
-            // the internal documents and streams its result projects to —
-            // and no value schema can carry that declaration, because the
-            // atoms are a property of the transaction rather than of the
-            // pattern.
+            // A store the runtime owns is filled by the runtime out of what
+            // the writing transaction read — a piece's argument document,
+            // the internal documents and streams its result projects to,
+            // and the state documents a builtin mints from its own node's
+            // cause — and no value schema can carry that declaration,
+            // because the atoms are a property of the transaction rather
+            // than of the pattern.
             //
-            // The declaration only ever grows, which is what §8.12.1 asks
-            // of a declared component. `declaredCeiling` resolves over the
-            // entries this walk is about to persist, carried-forward stored
-            // declared entries among them, so the union below contains
-            // every clause the path already declared, and adding clauses is
-            // the restricting direction.
+            // The declaration only ever grows by CLAUSE, which is what
+            // §8.12.1 asks of a declared component. `declaredCeiling`
+            // resolves over the entries this walk is about to persist,
+            // carried-forward stored declared entries among them, so the
+            // union below contains every clause the path already declared,
+            // and adding clauses is the restricting direction.
+            //
+            // Growing a stored clause's ALTERNATIVES would be the other
+            // thing: it enlarges that clause's reader set, which §8.12.7
+            // and safety invariant 1 admit only through a grant record or
+            // an intent-gated declassification event. `foldedUnique` folds
+            // clause LISTS — `normalizeClause` works inside one clause and
+            // never merges two — so a stored disjunction comes back with
+            // the alternatives it went in with.
+            //
+            // Growth is also what makes the route safe to run on every
+            // write rather than only while the runtime is setting a piece
+            // up. A clause list is read two ways, and the two agree: as a
+            // ceiling §8.12.4's `canWrite` admits a label clause when SOME
+            // declared clause subsumes it, and as a reader's floor that
+            // same section taints a reader with at least the declared
+            // label. Subsumption means satisfying the declared clause
+            // implies satisfying the label, so a reader of this store
+            // satisfies every clause the store admits. Adding a clause
+            // therefore admits more data AND narrows the audience by the
+            // same step, however many times it happens — §8.12.5's own
+            // argument for option 2, applied per write.
             //
             // Marked like a flow stamp rather than like an authored
             // declaration: the content is the join, so it carries whatever
@@ -7200,7 +7195,7 @@ export const prepareBoundaryCommit = (
               origin: "declared",
             }));
             tx.noteCfcDiagnostic(
-              `writer-fit(piece-substrate-declared): ${id} at /${
+              `writer-fit(runtime-owned-store-declared): ${id} at /${
                 path.join("/")
               } (§8.12.5 route 2): ${offending.map(renderCfcAtom).join(", ")}`,
             );

--- a/packages/runner/src/cfc/runtime-owned-stores.ts
+++ b/packages/runner/src/cfc/runtime-owned-stores.ts
@@ -1,0 +1,106 @@
+import {
+  resolveScopeKey,
+  type ScopeKeyIdentity,
+} from "@commonfabric/memory/v2";
+import type { NormalizedFullLink } from "../link-types.ts";
+
+/**
+ * The stores a runtime owns: the documents it materializes to hold a piece's
+ * machinery rather than data an author named.
+ *
+ * Which store the runtime owns is a fact about the store rather than about the
+ * transaction that first wrote it, so the answer outlives that transaction —
+ * the reactive updates, event handlers and settled requests that fill such a
+ * store each run on a transaction of their own, and none of them re-names it.
+ * `Runtime.edit` hands this object to every transaction it creates, which is
+ * what carries the answer across.
+ *
+ * Every enrollment names the piece the store was minted for, and a piece takes
+ * its own out when it stops. That is what bounds this: a list operation mints
+ * one piece per element, so an enrollment that lived for the process would
+ * grow with every element a churning list ever held.
+ */
+export class RuntimeOwnedStores {
+  /**
+   * The pieces holding each store. A store leaves when the last of them does:
+   * one store legitimately has several owners — the scope instances of one
+   * causal piece are separate registrations that stop separately, and a
+   * re-instantiation re-enrolls what the one before it did — so dropping a
+   * store on the first release would refuse the survivors' writes.
+   */
+  readonly #owners = new Map<string, Set<string>>();
+  /** The stores each piece enrolled, for the release. */
+  readonly #byOwner = new Map<string, Set<string>>();
+
+  has(store: string): boolean {
+    return this.#owners.has(store);
+  }
+
+  add(store: string, owner: string): void {
+    let owners = this.#owners.get(store);
+    if (owners === undefined) {
+      owners = new Set<string>();
+      this.#owners.set(store, owners);
+    }
+    owners.add(owner);
+    let owned = this.#byOwner.get(owner);
+    if (owned === undefined) {
+      owned = new Set<string>();
+      this.#byOwner.set(owner, owned);
+    }
+    owned.add(store);
+  }
+
+  /** Forget what `owner` enrolled, leaving what other pieces still hold. */
+  releaseOwner(owner: string): void {
+    const owned = this.#byOwner.get(owner);
+    if (owned === undefined) return;
+    for (const store of owned) {
+      // Present by construction: `add` fills both maps together, and a store
+      // leaves `#owners` only once no `#byOwner` set still names it.
+      const owners = this.#owners.get(store)!;
+      owners.delete(owner);
+      if (owners.size === 0) this.#owners.delete(store);
+    }
+    this.#byOwner.delete(owner);
+  }
+}
+
+/**
+ * The key a store the runtime owns is enrolled under: the space and the
+ * document id, joined on a separator neither can contain.
+ *
+ * Scope is deliberately not part of it. `docs/specs/scoped-cell-instances.md`
+ * makes scope an addressing dimension layered over a causal id rather than a
+ * component of it, so the space-, user- and session-scoped instances of one id
+ * are instances of the same cell — the runtime materializes each of them for
+ * the same piece, and a narrower instance's audience is a subset of the
+ * broader one's. Keying on scope would enroll whichever instance the runtime
+ * happened to mint first and refuse the others.
+ */
+export const runtimeOwnedStoreKey = (space: string, id: string): string =>
+  `${space}\u0000${id}`;
+
+/**
+ * The key a piece owns its enrollments under, or `undefined` where it may own
+ * none.
+ *
+ * Scope IS part of this one, resolved the way the runner keys its own piece
+ * registrations: two scope instances of one causal piece are two registrations
+ * that start and stop separately, so they are two owners. A scope-free owner
+ * key would let one instance's teardown take the other's enrollments with it.
+ *
+ * A piece owns nothing outside its own space. A store elsewhere belongs to
+ * whoever holds that space's replicas, so a policy declared on it out of this
+ * piece's flow join would put those bytes behind a promise made here.
+ */
+export const runtimeOwnedStoreOwnerKey = (
+  store: { space: string },
+  owner: NormalizedFullLink,
+  identity: ScopeKeyIdentity,
+): string | undefined =>
+  owner.space === store.space
+    ? `${owner.space}\u0000${
+      resolveScopeKey(owner.scope, identity)
+    }\u0000${owner.id}`
+    : undefined;

--- a/packages/runner/src/cfc/types.ts
+++ b/packages/runner/src/cfc/types.ts
@@ -36,15 +36,24 @@ export const CFC_STRUCTURAL_PROVENANCE_SETUP_PROJECTION =
 export const CFC_STRUCTURAL_PROVENANCE_SEED_MATERIALIZATION =
   "runtime.setup.seed-materialization";
 
-// A document a piece is being set up in: its argument document, or an
-// internal document or stream its result projects to. `target` is the
-// document, minted from the piece's result cell; `sources` is that result
-// document. The prepare gate reads it for the §8.12.5 route-2 declaration
-// described in `docs/specs/cfc-enforcement-matrix.md` §4, and takes it only
-// where `target` names a whole document AND the input was recorded under
-// {@link runtimeWritePolicyAuthorization}.
-export const CFC_STRUCTURAL_PROVENANCE_PIECE_SUBSTRATE =
-  "runtime.setup.piece-substrate";
+// A store the runtime owns: a document it materializes to hold a piece's
+// machinery rather than data an author named. Four kinds carry it — a piece's
+// argument, result and internal documents, minted by the runner from the
+// piece's result cause; the state documents a builtin mints from its own
+// node's cause; the per-event documents a builtin mints inside one
+// transaction; and the documents anchoring splits out of a value written into
+// any of those. `target` is that document; `sources` is the document the
+// runtime derived it from. The prepare gate reads it for the §8.12.5 route-2
+// declaration described in `docs/specs/cfc-enforcement-matrix.md` §4, and
+// takes it only where `target` names a whole document AND the input was
+// recorded under {@link runtimeWritePolicyAuthorization}.
+//
+// The marker names the store for one transaction. A store written outside the
+// transaction that minted it is enrolled beside it
+// (`IExtendedStorageTransaction.enrollRuntimeOwnedStore`), which lasts for the
+// runtime's life.
+export const CFC_STRUCTURAL_PROVENANCE_RUNTIME_OWNED_STORE =
+  "runtime.owned-store";
 
 /**
  * Marks a write-policy input as one the runtime itself recorded.
@@ -76,7 +85,7 @@ export interface RuntimeWritePolicyAuthorization {
  *
  * In-package callers only: `cfc/mod.ts` re-exports the type and not this
  * value, so it stays out of the package's public entry points, and holding it
- * is what naming a piece's substrate takes.
+ * is what naming a store the runtime owns takes.
  */
 export const runtimeWritePolicyAuthorization: RuntimeWritePolicyAuthorization =
   Object.freeze(

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -45,8 +45,10 @@ import {
   UnknownCfcMetadataVersionError,
 } from "./cfc/metadata.ts";
 import {
+  CFC_STRUCTURAL_PROVENANCE_RUNTIME_OWNED_STORE,
   CFC_STRUCTURAL_PROVENANCE_SEED_MATERIALIZATION,
   type CfcAddress,
+  runtimeWritePolicyAuthorization,
 } from "./cfc/types.ts";
 import { createRef } from "./create-ref.ts";
 import { findAndInlineDataUriLinks } from "./data-uri.ts";
@@ -537,6 +539,44 @@ function anchorValueAsEntity(
     newEntryLink.schema,
     options?.schemaRole,
   );
+
+  // Anchoring splits one value across two documents, so the child is the
+  // runtime's store whenever the parent is: its id is derived here rather than
+  // named by an author, and nothing but this write puts anything in it.
+  // §8.2 treats either representation of a pass-through as valid so long as
+  // the label is preserved; this reads that one step further, as the choice
+  // not deciding a verdict. The
+  // claim rides the marker alone, not an enrollment — the anchored document is
+  // written by the transaction that anchors it, and a later write that reaches
+  // the same position walks through here again. A transaction that addresses
+  // the child directly rather than through its parent finds no claim and is
+  // measured against the child's own ceiling, which is the fail-closed
+  // direction. The marker also carries the claim down a nested anchor, whose
+  // own parent is the child this call just marked.
+  if (
+    tx.isRuntimeOwnedStore(
+      link.space,
+      link.id,
+      runtimeWritePolicyAuthorization,
+    )
+  ) {
+    tx.recordCfcWritePolicyInput({
+      kind: "structural-provenance",
+      target: {
+        space: newEntryLink.space,
+        id: newEntryLink.id,
+        scope: newEntryLink.scope,
+        path: [],
+      },
+      claim: CFC_STRUCTURAL_PROVENANCE_RUNTIME_OWNED_STORE,
+      sources: [{
+        space: link.space,
+        id: link.id,
+        scope: link.scope,
+        path: [...path],
+      }],
+    }, runtimeWritePolicyAuthorization);
+  }
 
   return [
     // If it wasn't already, set the current value to be a doc link to this doc

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -100,6 +100,7 @@ import {
   toMemorySpaceAddress,
 } from "./link-utils.ts";
 import { isRawBuiltinResult, type RawBuiltinReturnType } from "./module.ts";
+import { runtimeOwnedStoreOwnerKey } from "./cfc/runtime-owned-stores.ts";
 import {
   resolveScopeKey,
   type ScopeKey,
@@ -172,7 +173,7 @@ import {
   validateSchemaValue,
 } from "./cfc/schema-sanitization.ts";
 import {
-  CFC_STRUCTURAL_PROVENANCE_PIECE_SUBSTRATE,
+  CFC_STRUCTURAL_PROVENANCE_RUNTIME_OWNED_STORE,
   CFC_STRUCTURAL_PROVENANCE_SETUP_PROJECTION,
   type ImplementationIdentity,
   runtimeWritePolicyAuthorization,
@@ -951,11 +952,14 @@ const recordSetupProjectionPolicyInputs = (
 };
 
 /**
- * Name `substrate` as a document this transaction is setting `resultCell`'s
- * piece up in.
+ * Name `substrate` as a store the runtime owns for `resultCell`'s piece — its
+ * result document, its argument document, or an internal document or stream
+ * its result projects to. The result document is the one address on the route
+ * an author chose rather than the runtime derived, so a schema declaring at a
+ * written path there keeps its own policy and the route stands aside.
  *
- * A piece's substrate holds whatever the setup transaction read, and an
- * author cannot know which atoms a given transaction will carry, so no
+ * Such a store holds whatever the transaction filling it read, and an author
+ * cannot know which atoms a given transaction will carry, so no
  * confidentiality declaration written into a schema covers it. CFC's
  * write-side fit check (spec §8.12.4) reads this marker and declares that
  * policy itself; `docs/specs/cfc-enforcement-matrix.md` §4 states the route.
@@ -968,9 +972,11 @@ const recordSetupProjectionPolicyInputs = (
  *
  * The marker carries the runtime's authorization, which is what the fit check
  * asks for: the method that records it is reachable from anything holding a
- * cell, so an unmarked marker naming the same document counts for nothing.
+ * cell, so an unmarked marker naming the same document counts for nothing. It
+ * names the store for THIS transaction; the enrollment that carries the claim
+ * into later ones is {@link enrollPieceOwnedStores}.
  */
-const recordPieceSubstrate = (
+const recordRuntimeOwnedStore = (
   tx: IExtendedStorageTransaction,
   resultCell: Cell<any>,
   substrate: NormalizedFullLink,
@@ -984,7 +990,7 @@ const recordPieceSubstrate = (
       scope: substrate.scope,
       path: [...substrate.path],
     },
-    claim: CFC_STRUCTURAL_PROVENANCE_PIECE_SUBSTRATE,
+    claim: CFC_STRUCTURAL_PROVENANCE_RUNTIME_OWNED_STORE,
     sources: [{
       space: result.space,
       id: result.id,
@@ -994,14 +1000,91 @@ const recordPieceSubstrate = (
   }, runtimeWritePolicyAuthorization);
 };
 
-/** Whether two links name the same document, each at that document's root. */
-const sameRootDocument = (
-  left: NormalizedFullLink,
-  right: NormalizedFullLink,
-): boolean =>
-  left.space === right.space && left.id === right.id &&
-  left.scope === right.scope && left.path.length === 0 &&
-  right.path.length === 0;
+/**
+ * The stores the runtime owns for `resultCell`'s piece: its result document,
+ * its argument document, and each internal document its result projects to.
+ *
+ * Every address but the first is MINTED from `resultCell`'s cause, never read
+ * back out of stored metadata: a stored `argument` or manifest link can name
+ * another document — a nested piece's argument lives in its host's — and that
+ * document is its owner's store rather than this piece's. What the piece does
+ * not actually write is harmless to name, because nobody else mints these
+ * addresses.
+ *
+ * The RESULT document is the exception, and the weakest member of the set. It
+ * is often minted from a node's cause — a nested piece's is `{resultFor}`, and
+ * that is the case the widening exists for — but a top-level piece's is an
+ * address its caller chose, and unlike the others it HAS a value schema: the
+ * pattern's `resultSchema`, which an author may write `ifc` into. So the
+ * "no schema can declare this" argument does not carry it. What carries it is
+ * narrower: from the moment setup writes this piece's meta into it, the
+ * document is that piece's store, and the runtime fills it with what the
+ * transaction read. Where the author DID declare, `remintedDeclaredPaths`
+ * hands the path back to them and the route declines. Where they did not, the
+ * route reaches every path written there — by any writer, not only by the
+ * runtime, since what it tests is the store rather than the caller.
+ */
+const pieceOwnedStores = (
+  tx: IExtendedStorageTransaction,
+  resultCell: Cell<any>,
+  pattern: Pattern,
+): NormalizedFullLink[] => [
+  resultCell.getAsNormalizedFullLink(),
+  getMetaCell(resultCell, "argument", tx).getAsNormalizedFullLink(),
+  ...(pattern.derivedInternalCells ?? []).map((descriptor) =>
+    getDerivedInternalCellLink(resultCell, descriptor)
+  ),
+];
+
+/**
+ * Name this piece's stores for the transaction setting it up. Setup fills them
+ * in the transaction that names them, so the marker is all it needs.
+ */
+const markPieceOwnedStores = (
+  tx: IExtendedStorageTransaction,
+  resultCell: Cell<any>,
+  pattern: Pattern,
+): void => {
+  for (const store of pieceOwnedStores(tx, resultCell, pattern)) {
+    recordRuntimeOwnedStore(tx, resultCell, store);
+  }
+};
+
+/**
+ * Name this piece's stores and ENROLL them, which is what the graph about to
+ * run needs: its reactive updates, event handlers and settled requests each
+ * write on a transaction of their own, and none of them names anything.
+ *
+ * Called at node instantiation rather than at setup, so that a piece started
+ * from its stored identity — a cold replica loading one — enrolls too, and so
+ * that a setup attempt that never commits enrolls nothing. It runs again on
+ * every re-instantiation, which is idempotent; the enrollment goes out once,
+ * with the piece, at the release `startCore` registers.
+ */
+const enrollPieceOwnedStores = (
+  tx: IExtendedStorageTransaction,
+  resultCell: Cell<any>,
+  pattern: Pattern,
+): void => {
+  const owner = resultCell.getAsNormalizedFullLink();
+  const identity = resultCell.runtime.scopeKeyIdentity;
+  for (const store of pieceOwnedStores(tx, resultCell, pattern)) {
+    recordRuntimeOwnedStore(tx, resultCell, store);
+    // Same space by construction: every store here is minted in the result
+    // cell's space, which is the owner's.
+    const ownerKey = runtimeOwnedStoreOwnerKey(store, owner, identity)!;
+    tx.enrollRuntimeOwnedStore(
+      {
+        space: store.space,
+        id: store.id,
+        scope: store.scope,
+        path: [...store.path],
+      },
+      ownerKey,
+      runtimeWritePolicyAuthorization,
+    );
+  }
+};
 
 type SetupResult<R> = {
   resultCell: Cell<R>;
@@ -2202,21 +2285,10 @@ export class Runner {
 
   #updateArgument<T>(
     tx: IExtendedStorageTransaction,
-    resultCell: Cell<any>,
     argumentLink: NormalizedFullLink,
     argument: T,
     argumentSchema: JSONSchema | undefined,
   ): void {
-    // The argument link can come from the result cell's stored `argument`
-    // meta, which need not name the document this result cell's cause mints
-    // — a nested piece's argument lives in its HOST's document. Mark the
-    // substrate only where the two agree, so the marker never claims a store
-    // this piece does not own.
-    const mintedArgument = getMetaCell(resultCell, "argument", tx)
-      .getAsNormalizedFullLink();
-    if (sameRootDocument(argumentLink, mintedArgument)) {
-      recordPieceSubstrate(tx, resultCell, mintedArgument);
-    }
     const argumentCell = this.runtime.getCellFromLink(
       argumentLink,
       undefined,
@@ -2257,7 +2329,6 @@ export class Runner {
    * reject the transaction unless the resulting value satisfies its schema. */
   #updateAndValidateArgument<T>(
     tx: IExtendedStorageTransaction,
-    resultCell: Cell<any>,
     argumentLink: NormalizedFullLink,
     argument: T,
     argumentSchema: JSONSchema,
@@ -2265,7 +2336,6 @@ export class Runner {
   ): void {
     this.#updateArgument(
       tx,
-      resultCell,
       argumentLink,
       argument,
       argumentSchema,
@@ -2470,7 +2540,6 @@ export class Runner {
       // pattern-changing updates always take the validated path below.
       this.#updateArgument(
         tx,
-        resultCell,
         argumentLink,
         nextArgument,
         pattern.argumentSchema,
@@ -2591,13 +2660,6 @@ export class Runner {
         link: derivedSigilLink,
       });
       setResultCell(derivedCell, resultCell.asSchema(pattern.resultSchema));
-      // Minted from the result cell's cause, so this address is the piece's
-      // own by construction.
-      recordPieceSubstrate(
-        tx,
-        resultCell,
-        getDerivedInternalCellLink(resultCell, descriptor),
-      );
       if (manifestMatch === -1) {
         // Seed the build-time default for the freshly created cell. The
         // manifest entry and this default are written together in one
@@ -2636,6 +2698,15 @@ export class Runner {
     argument: T,
     resultCell: Cell<R>,
   ): void {
+    // Every write below fills a store this piece owns — the argument
+    // document, each internal document the result projects to, and the result
+    // document the projection lands in — so the transaction making them has to
+    // name them. This is the one place all of that happens, and it is reached
+    // on a transaction of its own from a pattern swap and from a start repair
+    // as well as from `setupInternal`, neither of which the instantiation's
+    // enrollment covers: a swap commits its setup before instantiating, and a
+    // descriptor the incoming pattern adds is a document nothing has named.
+    markPieceOwnedStores(tx, resultCell, pattern);
     const { sameStoredSetup, restageStoredArgument } = setupState;
     const defaults = extractDefaultValues(pattern.argumentSchema);
     let argumentLink = getMetaLink(resultCell, "argument");
@@ -2746,7 +2817,6 @@ export class Runner {
         // case — so the merge yields a value.)
         this.#updateAndValidateArgument(
           tx,
-          resultCell,
           argumentLink,
           nextArgument,
           pattern.argumentSchema,
@@ -2762,7 +2832,6 @@ export class Runner {
       // validate their exact supplied value before entering Runner.
       this.#updateArgument(
         tx,
-        resultCell,
         argumentLink,
         nextArgument,
         pattern.argumentSchema,
@@ -2960,6 +3029,11 @@ export class Runner {
     }
 
     const { pattern, entryRef, resolvedPatternOrModule } = resolvedPattern;
+    // The reuse arms below write the argument without reaching
+    // `#applySetupState`, which names these stores for every other setup
+    // write. Naming them twice on one transaction costs a second marker
+    // record and decides nothing differently.
+    markPieceOwnedStores(tx, resultCell, pattern);
     // "Same pattern between runs" — drives name preservation and
     // reuse-running-setup. Compare the new pattern pointer against the stored
     // one. A keyless pattern carries a stable session-synthetic ref (minted per
@@ -3377,6 +3451,25 @@ export class Runner {
       active = false;
       this.#locallyCommittedHandlerResultStarts.delete(key);
       cancelGroup();
+      // AFTER the group, not inside it. The stores this piece owns are
+      // enrolled per instantiation and released once, with the piece — but a
+      // builtin's teardown writes into those same stores on a transaction of
+      // its own (a dialog takes its pending flag down, a fetch clears its
+      // request id), and a release that ran first would leave those writes
+      // measured against a ceiling the route can no longer answer. Releasing
+      // as a member of the group would do exactly that: `useCancelGroup` runs
+      // its members in insertion order, and this one is registered before the
+      // node group is.
+      //
+      // Hanging it on the per-instantiation node group instead would be wrong
+      // for a different reason: a swap, a repair and a withdrawn-contribution
+      // recovery each tear that group down and re-instantiate, so the
+      // enrollment would survive only while every such site happened to cancel
+      // before instantiating.
+      this.runtime.releaseRuntimeOwnedStores(
+        resultCell.getAsNormalizedFullLink(),
+        runtimeWritePolicyAuthorization,
+      );
     }) as PieceRegistration;
     // `cancelNodes` holds the live graph's cancellation, and stands empty
     // between the retirement a refused instantiation commit performs and the
@@ -3427,6 +3520,7 @@ export class Runner {
 
       // Instantiate nodes
       const actualTx = useTx ?? this.runtime.edit();
+      enrollPieceOwnedStores(actualTx, resultCell, pattern);
       const shouldCommit = !useTx;
       if (shouldCommit) {
         // Self-minted instantiation tx (the hot-swap watcher's

--- a/packages/runner/src/runtime-presets.ts
+++ b/packages/runner/src/runtime-presets.ts
@@ -577,6 +577,17 @@ export type CfcPosture = "max-enforcement";
  * publishes that as a deviation rather than leaving it to be inferred from a
  * sink's absence from a ceiling list. Building the mechanism that retires the
  * gap is planned in `docs/plans/cfc-llm-sink-admission.md`.
+ *
+ * Until the §8.12.5 route-2 widening, one path was gated anyway, by accident:
+ * a pattern calling `llm(...)` staged its request in the transaction that also
+ * wrote the builtin's own result store, that store declared nothing, and the
+ * writer-fit misfit refused the commit. It fired on every such call, so under
+ * this posture an llm call over caveated content did not work at all — the
+ * opposite of what the rationale above says the sink is for. The store now
+ * declares what flows into it, so the ungoverned statement holds of the
+ * builtin path too. `max-enforcement-posture.test.ts` pins the hand-staged
+ * request and `builtin-abandoned-request.test.ts` the builtin one; both flip
+ * to asserting the refusal when the admission mechanism lands.
  */
 export const MAX_ENFORCEMENT_SINK_GOVERNANCE: SinkGovernanceRegistry = Object
   .freeze({

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -157,6 +157,14 @@ import {
   type WriteStackTraceEntry,
   type WriteStackTraceMatcher,
 } from "./storage/write-stack-trace.ts";
+import {
+  runtimeOwnedStoreOwnerKey,
+  RuntimeOwnedStores,
+} from "./cfc/runtime-owned-stores.ts";
+import {
+  type RuntimeWritePolicyAuthorization,
+  runtimeWritePolicyAuthorized,
+} from "./cfc/types.ts";
 import type { NonIdempotentReport } from "./telemetry.ts";
 import {
   createUnsafeHostTrustToken,
@@ -950,6 +958,11 @@ export class Runtime {
   // into it instead of committing to the store. Never installed on a
   // client or in the OFF arm — installSealDestination throws off the flag.
   #transactionSealDestination: TransactionSealDestination | undefined;
+  // The stores this runtime owns: the documents it materializes to hold a
+  // piece's machinery. Every transaction `edit()` creates gets the same
+  // object, which is what lets a write outside the transaction that minted a
+  // store still find it. See `cfc/runtime-owned-stores.ts`.
+  readonly #runtimeOwnedStores = new RuntimeOwnedStores();
   // The serving loop's run stamper (installed WITH the destination): the
   // scheduler hands it each run's durable action id + kind, and it
   // attaches the wave run context before the tx seals.
@@ -2127,7 +2140,29 @@ export class Runtime {
     wrapped.configureSealDestination(
       this.#transactionSealDestination ?? this.#speculationDestination(),
     );
+    wrapped.configureRuntimeOwnedStores(this.#runtimeOwnedStores);
     return wrapped;
+  }
+
+  /**
+   * Forget the stores enrolled for the piece at `owner` — its own documents
+   * and the state documents its builtins minted. Called when a piece stops,
+   * which is what keeps the enrollment bounded by the pieces running rather
+   * than by every piece the process has ever run. A store another piece — a
+   * second scope instance of this one, say — still holds stays.
+   *
+   * Takes the runtime's write-policy authorization, like the enrollment it
+   * undoes: pattern-authored code reaches this object through a cell, and a
+   * release it made would refuse another piece's writes.
+   */
+  releaseRuntimeOwnedStores(
+    owner: NormalizedFullLink,
+    authorization?: RuntimeWritePolicyAuthorization,
+  ): void {
+    if (!runtimeWritePolicyAuthorized(authorization)) return;
+    // The owner stands as its own store here, so the key's space test holds.
+    const key = runtimeOwnedStoreOwnerKey(owner, owner, this.scopeKeyIdentity)!;
+    this.#runtimeOwnedStores.releaseOwner(key);
   }
 
   /**

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -103,7 +103,14 @@ import {
   type TrustSnapshot,
   type WritePolicyInput,
 } from "../cfc/mod.ts";
-import { runtimeWritePolicyAuthorized } from "../cfc/types.ts";
+import {
+  runtimeOwnedStoreKey,
+  type RuntimeOwnedStores,
+} from "../cfc/runtime-owned-stores.ts";
+import {
+  CFC_STRUCTURAL_PROVENANCE_RUNTIME_OWNED_STORE,
+  runtimeWritePolicyAuthorized,
+} from "../cfc/types.ts";
 import { CFC_POLICY_MANIFEST_ID_PREFIX } from "../cfc/policy.ts";
 import { isTerminalRefusal, plainReason } from "../cfc/verdict-reason.ts";
 import {
@@ -441,6 +448,15 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
   // record. `#`-private, so nothing outside this class can add to it; the one
   // writer is `recordCfcWritePolicyInput` handed the runtime's mark.
   #runtimeWritePolicyInputs = new WeakSet<WritePolicyInput>();
+  // The stores the runtime owns that a marker named on THIS transaction, by
+  // {@link runtimeOwnedStoreKey}. A store the runtime mints and fills in one
+  // go needs no more than this.
+  #markedOwnedStores = new Set<string>();
+  // The stores the runtime owns that outlive the transaction that minted them,
+  // shared with every other transaction of the same runtime (`Runtime.edit`
+  // hands the same object to each). Absent on a transaction the runtime did
+  // not configure, which leaves only this transaction's own markers.
+  #runtimeOwnedStores: RuntimeOwnedStores | undefined;
   // Per-transaction cache of `Cell.get()` results, keyed by stable cell view.
   // Replaced wholesale on any write (see `#invalidateReadResultCache`), so a hit
   // is only ever served when nothing has been written since the cached read.
@@ -1448,6 +1464,23 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     // for exactly the records that arrived with the mark.
     if (runtimeWritePolicyAuthorized(authorization)) {
       this.#runtimeWritePolicyInputs.add(frozen);
+      // An authorized marker naming a WHOLE document in the OWNER's own space
+      // says the runtime owns that store, for the rest of this transaction.
+      // Both tests are the ones enrollment applies: a marker carrying a path
+      // names part of a document, and ownership is a claim about the whole
+      // store; and a store outside the owner's space belongs to whoever holds
+      // that space's replicas, so declaring a policy on it from this piece's
+      // join would put another space's bytes behind this one's promise.
+      if (
+        frozen.kind === "structural-provenance" &&
+        frozen.claim === CFC_STRUCTURAL_PROVENANCE_RUNTIME_OWNED_STORE &&
+        canonicalizeLogicalPath(frozen.target.path).length === 0 &&
+        frozen.sources?.[0]?.space === frozen.target.space
+      ) {
+        this.#markedOwnedStores.add(
+          runtimeOwnedStoreKey(frozen.target.space, frozen.target.id),
+        );
+      }
     }
     if (this.#cfcState.prepare.status === "prepared") {
       this.invalidateCfc("write-policy-input-added");
@@ -1456,6 +1489,59 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
 
   isRuntimeWritePolicyInput(input: WritePolicyInput): boolean {
     return this.#runtimeWritePolicyInputs.has(input);
+  }
+
+  /**
+   * One-shot handover of the runtime's owned-store enrollment, called by
+   * `Runtime.edit` for every transaction it creates. The same set reaches
+   * every transaction, which is what carries an enrollment past the
+   * transaction that made it.
+   */
+  configureRuntimeOwnedStores(stores: RuntimeOwnedStores): void {
+    if (this.#runtimeOwnedStores !== undefined) {
+      throw new Error(
+        "Runtime-owned stores are already configured for this transaction",
+      );
+    }
+    this.#runtimeOwnedStores = stores;
+  }
+
+  enrollRuntimeOwnedStore(
+    target: CfcAddress,
+    owner: string,
+    authorization?: RuntimeWritePolicyAuthorization,
+  ): void {
+    // The same mark the write-policy marker carries. An enrollment outlives
+    // every transaction, so it is at least as much the runtime's to make.
+    if (!runtimeWritePolicyAuthorized(authorization)) return;
+    // The same path test the marker applies: ownership is a claim about a
+    // whole store. `runtimeOwnedStoreOwnerKey` applies the other one, refusing
+    // to name an owner for a store outside its own space.
+    if (canonicalizeLogicalPath(target.path).length > 0) return;
+    // Deliberately not transactional. Which store the runtime owns does not
+    // depend on whether a write landed, and an abandoned attempt that enrolled
+    // one named an address derived from its own piece's cause, which nothing
+    // else mints. The piece's release is what takes it out again.
+    this.#runtimeOwnedStores?.add(
+      runtimeOwnedStoreKey(target.space, target.id),
+      owner,
+    );
+  }
+
+  isRuntimeOwnedStore(
+    space: string,
+    id: string,
+    authorization?: RuntimeWritePolicyAuthorization,
+  ): boolean {
+    // Answers about the whole runtime's enrollment, not this transaction's, so
+    // it takes the runtime's mark like the recorders do. Every store id here
+    // is derivable from a piece's cause, so an ungated answer would tell
+    // pattern-authored code — which reaches `cell.tx` — whether a given piece
+    // is running in this runtime.
+    if (!runtimeWritePolicyAuthorized(authorization)) return false;
+    const key = runtimeOwnedStoreKey(space, id);
+    return this.#markedOwnedStores.has(key) ||
+      (this.#runtimeOwnedStores?.has(key) ?? false);
   }
 
   recordCfcConsultedGrant(consulted: ConsultedGrant): void {
@@ -3163,6 +3249,22 @@ export class TransactionWrapper implements IExtendedStorageTransaction {
 
   isRuntimeWritePolicyInput(input: WritePolicyInput): boolean {
     return this.#wrapped.isRuntimeWritePolicyInput(input);
+  }
+
+  enrollRuntimeOwnedStore(
+    target: CfcAddress,
+    owner: string,
+    authorization?: RuntimeWritePolicyAuthorization,
+  ): void {
+    this.#wrapped.enrollRuntimeOwnedStore(target, owner, authorization);
+  }
+
+  isRuntimeOwnedStore(
+    space: string,
+    id: string,
+    authorization?: RuntimeWritePolicyAuthorization,
+  ): boolean {
+    return this.#wrapped.isRuntimeOwnedStore(space, id, authorization);
   }
 
   recordCfcConsultedGrant(consulted: ConsultedGrant): void {

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -1929,6 +1929,52 @@ export interface IExtendedStorageTransaction extends IStorageTransaction {
   isRuntimeWritePolicyInput(input: WritePolicyInput): boolean;
 
   /**
+   * Enroll `target` as a store this runtime owns for `owner`'s piece — a
+   * document it materializes to hold that piece's machinery rather than data
+   * an author named — for as long as that piece's nodes run, rather than for
+   * this transaction alone.
+   *
+   * Enrollment is what a store written outside the transaction that minted it
+   * needs: the runtime instantiates a piece's nodes, and mints a builtin's
+   * state stores, before the reactive updates, event handlers and settled
+   * requests that fill them run. A store minted and filled in one transaction
+   * wants only the write-policy marker.
+   *
+   * `owner` is a `runtimeOwnedStoreOwnerKey` value — per scope instance, since
+   * two scope instances of one causal piece start and stop separately, and
+   * absent for a store outside the owner's own space. A store several pieces
+   * enroll leaves when the last of them releases it.
+   *
+   * Ignored without `runtimeWritePolicyAuthorization`, and ignored for an
+   * address carrying a path: ownership is a claim about a whole store.
+   */
+  enrollRuntimeOwnedStore(
+    target: CfcAddress,
+    owner: string,
+    authorization?: RuntimeWritePolicyAuthorization,
+  ): void;
+
+  /**
+   * Whether the runtime owns the store at `id` in `space` — named by an
+   * authorized whole-document
+   * `CFC_STRUCTURAL_PROVENANCE_RUNTIME_OWNED_STORE` marker on this
+   * transaction, or enrolled by a previous {@link enrollRuntimeOwnedStore}.
+   *
+   * Scope is not an argument — every scoped instance of one causal id is an
+   * instance of the same cell.
+   *
+   * Takes the runtime's mark, like the recorders do: it answers about the
+   * whole runtime rather than this transaction, and every id it knows is
+   * derivable from a piece's cause, so an ungated answer would tell
+   * pattern-authored code whether a given piece is running here.
+   */
+  isRuntimeOwnedStore(
+    space: string,
+    id: string,
+    authorization?: RuntimeWritePolicyAuthorization,
+  ): boolean;
+
+  /**
    * Records a grant document consulted by policyState-guarded boundary
    * evaluation (§8.12.7 route 2a) — address plus resolution-time content
    * digest — for the prepared-digest binding (`PreparedDigestInput.

--- a/packages/runner/test/builtin-abandoned-request-supersession.test.ts
+++ b/packages/runner/test/builtin-abandoned-request-supersession.test.ts
@@ -27,7 +27,10 @@ import { waitForCellValue } from "@commonfabric/integration/wait-for-cell-value"
 import { createBuilder } from "../src/builder/factory.ts";
 import { getPatternEnvironment, setPatternEnvironment } from "../src/env.ts";
 import { Runtime } from "../src/runtime.ts";
-import { MAX_ENFORCEMENT_CFC_OPTIONS } from "../src/runtime-presets.ts";
+import {
+  MAX_ENFORCEMENT_CFC_OPTIONS,
+  MAX_ENFORCEMENT_SINK_CEILINGS,
+} from "../src/runtime-presets.ts";
 import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
 
@@ -75,6 +78,21 @@ describe("whose cells an abandoned request's ending writes", () => {
       storageManager,
       ...MAX_ENFORCEMENT_CFC_OPTIONS,
       cfcEnforcementMode: "enforce-strict",
+      // The bundle declares a ceiling for the fetch and streamData sinks and
+      // none for the LLM ones, so an LLM request is ungated on
+      // confidentiality there. These cases are about the ENDING a refused
+      // request leaves behind, so they declare the ceiling the refusal comes
+      // from. Before the runtime's own stores declared what flowed into them,
+      // the refusal arrived by accident instead: the builtin's result store
+      // could not hold the caveat, so the transaction staging the request was
+      // refused for a reason about the store rather than about the request.
+      cfcSinkMaxConfidentiality: {
+        ...MAX_ENFORCEMENT_SINK_CEILINGS,
+        llm: [],
+        llmDialog: [],
+        generateText: [],
+        generateObject: [],
+      },
     });
     tx = runtime.edit();
     ({ commonfabric } = createTrustedBuilder(runtime));

--- a/packages/runner/test/builtin-abandoned-request.test.ts
+++ b/packages/runner/test/builtin-abandoned-request.test.ts
@@ -2,6 +2,12 @@
  * What a builtin leaves behind when the transaction staging its request is
  * abandoned.
  *
+ * Every case here abandons that transaction the same way: the request carries
+ * a caveat the sink's declared ceiling does not admit, so the sink-request
+ * check refuses the commit. The stores each builtin writes on the way there
+ * are the runtime's own, and declare what flows into them rather than
+ * refusing it.
+ *
  * Each of these stages its request in the transaction that schedules the work
  * and does the work once that transaction commits, so an abandoned one means
  * the request is never sent. The settled shape differs per builtin, but the
@@ -36,7 +42,10 @@ import { createBuilder } from "../src/builder/factory.ts";
 import type { Cell } from "../src/builder/types.ts";
 import { LLMMessageSchema } from "../src/builtins/llm-schemas.ts";
 import { Runtime } from "../src/runtime.ts";
-import { MAX_ENFORCEMENT_CFC_OPTIONS } from "../src/runtime-presets.ts";
+import {
+  MAX_ENFORCEMENT_CFC_OPTIONS,
+  MAX_ENFORCEMENT_SINK_CEILINGS,
+} from "../src/runtime-presets.ts";
 import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
 import { waitForCellValue } from "@commonfabric/integration/wait-for-cell-value";
@@ -44,10 +53,10 @@ import { waitForCellValue } from "@commonfabric/integration/wait-for-cell-value"
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();
 
-// A caveat the result store does not declare. The builtin reads the input
-// carrying it, so its writes derive that confidentiality, and the undeclared
-// store resolves to the empty ceiling — the writer-fit misfit, which rejects
-// at `enforce-strict`.
+// A caveat no sink here is cleared for. The builtin reads the input carrying
+// it, so the request it stages carries it too, and the ceiling declared for
+// that sink above admits none — the sink-request refusal, which rejects the
+// staging transaction at `enforce-strict`.
 const PROMPT_INFLUENCE = {
   type: "https://commonfabric.org/cfc/atom/Caveat",
   kind: "https://commonfabric.org/cfc/concepts/prompt-influence",
@@ -70,6 +79,21 @@ describe("a builtin whose staged request is abandoned", () => {
       // per-session raise on top of it, and the bundle's persisted flow labels
       // are what make that raise conform.
       cfcEnforcementMode: "enforce-strict",
+      // The bundle declares a ceiling for the fetch and streamData sinks and
+      // none for the LLM ones, so an LLM request is ungated on
+      // confidentiality there. These cases are about the ENDING a refused
+      // request leaves behind, so they declare the ceiling the refusal comes
+      // from. Before the runtime's own stores declared what flowed into them,
+      // the refusal arrived by accident instead: the builtin's result store
+      // could not hold the caveat, so the transaction staging the request was
+      // refused for a reason about the store rather than about the request.
+      cfcSinkMaxConfidentiality: {
+        ...MAX_ENFORCEMENT_SINK_CEILINGS,
+        llm: [],
+        llmDialog: [],
+        generateText: [],
+        generateObject: [],
+      },
     });
     tx = runtime.edit();
     ({ commonfabric } = createTrustedBuilder(runtime));
@@ -382,6 +406,13 @@ describe("a builtin whose staged request is abandoned", () => {
     // the run materializes it as a cell reference without reading its fields,
     // and the handler reads a field to build the request the turn would send.
     // So the caveat goes on the field.
+    //
+    // What refuses is the SINK: the log the dialog is given already carries
+    // the caveat, so the request the turn would send carries it too, and the
+    // llmDialog ceiling above admits none. The stores the turn writes on its
+    // way there — the dialog's own result and internal documents, and the
+    // document each appended message becomes — are the runtime's, and declare
+    // what flows into them rather than refusing it.
 
     const { pattern, llmDialog, Cell: BuilderCell } = commonfabric;
     const resultSchema = {
@@ -397,9 +428,8 @@ describe("a builtin whose staged request is abandoned", () => {
       required: ["addMessage"],
     } as const satisfies JSONSchema;
 
-    const testPattern = pattern(
-      () => {
-        const messages = BuilderCell.of<BuiltInLLMMessage[]>([]);
+    const testPattern = pattern<{ messages: BuiltInLLMMessage[] }>(
+      ({ messages }) => {
         const briefing = BuilderCell.of({ note: "a hostile briefing" }, {
           type: "object",
           properties: {
@@ -420,13 +450,29 @@ describe("a builtin whose staged request is abandoned", () => {
       resultSchema,
     );
 
+    const messagesCell = runtime.getCell<BuiltInLLMMessage[]>(
+      space,
+      "llmDialog-abandoned-messages",
+      {
+        type: "array",
+        items: { type: "object", additionalProperties: true },
+        ifc: { confidentiality: [PROMPT_INFLUENCE] },
+      },
+      tx,
+    );
+    messagesCell.set([{ role: "assistant", content: "an earlier turn" }]);
     const resultCell = runtime.getCell(
       space,
       "llmDialog-abandoned",
       resultSchema,
       tx,
     );
-    const result = runtime.run(tx, testPattern, {}, resultCell);
+    const result = runtime.run(
+      tx,
+      testPattern,
+      { messages: messagesCell },
+      resultCell,
+    );
     runtime.prepareTxForCommit(tx);
     // The run that sets the dialog up has to land: a refusal here would be the
     // caveat reaching the wrong transaction, and the wait below would then be
@@ -448,10 +494,106 @@ describe("a builtin whose staged request is abandoned", () => {
 
     expect(settled.pending).toBe(false);
     // The turn is not in the conversation: the message the handler appended
-    // rode the abandoned transaction, so the ending has no turn to answer and
-    // writes no assistant message.
-    expect(result.withTx().key("messages").get()).toEqual([]);
+    // rode the abandoned transaction, so the log still holds what it held
+    // before the send, and the ending has no turn to answer.
+    expect(result.withTx().key("messages").get()).toEqual([
+      { role: "assistant", content: "an earlier turn" },
+    ]);
   });
+  describe("and an llm sink the shipped bundle declares no ceiling for", () => {
+    // What the bundle refuses here, and what it does not. The ceilings above
+    // are this file's own: `MAX_ENFORCEMENT_SINK_CEILINGS` names the fetch and
+    // streamData sinks and no llm one, and a sink with no ceiling gets no gate
+    // (`sink-inventory.ts`; `max-enforcement-posture.test.ts` pins the same
+    // verdict for a hand-staged request).
+    //
+    // Until the §8.12.5 route-2 widening one path was gated anyway, by
+    // accident: the transaction staging the request also wrote the builtin's
+    // own result store, that store declared nothing, and the writer-fit misfit
+    // refused the commit — on every such call, so an llm call over caveated
+    // content did not work at all under this posture. The store declares what
+    // flows into it now, so the request goes. This case is where that shows,
+    // and it flips to asserting the refusal when the boundary-scoped admission
+    // mechanism `MAX_ENFORCEMENT_SINK_CEILINGS` describes lands.
+
+    let bundleStorage: ReturnType<typeof StorageManager.emulate>;
+    let bundleRuntime: Runtime;
+    let bundleTx: IExtendedStorageTransaction;
+    let bundleBuilder: ReturnType<typeof createBuilder>["commonfabric"];
+
+    beforeEach(() => {
+      enableMockMode();
+      clearMockResponses();
+      bundleStorage = StorageManager.emulate({ as: signer });
+      bundleRuntime = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager: bundleStorage,
+        ...MAX_ENFORCEMENT_CFC_OPTIONS,
+        cfcEnforcementMode: "enforce-strict",
+      });
+      bundleTx = bundleRuntime.edit();
+      ({ commonfabric: bundleBuilder } = createTrustedBuilder(bundleRuntime));
+    });
+
+    afterEach(async () => {
+      resetMockMode();
+      await bundleTx.commit();
+      await bundleRuntime.idle();
+      await bundleRuntime.dispose();
+      await bundleStorage.close();
+    });
+
+    it("sends llm's request even though the messages carry a caveat", async () => {
+      const { pattern, llm, Cell: BuilderCell } = bundleBuilder;
+      let requestsSent = 0;
+      addMockResponse(() => {
+        requestsSent += 1;
+        return true;
+      }, {
+        role: "assistant",
+        content: "an answer",
+        id: "ungated-llm-sink",
+      });
+      const testPattern = pattern<Record<string, never>>(() => {
+        const messages = BuilderCell.of([{
+          role: "user",
+          content: "a briefing the result store does not declare",
+        }], {
+          type: "array",
+          items: { type: "object", additionalProperties: true },
+          ifc: { confidentiality: [PROMPT_INFLUENCE] },
+        });
+        // deno-lint-ignore no-explicit-any
+        return llm({ messages } as any);
+      });
+      const resultCell = bundleRuntime.getCell(
+        space,
+        "llm-ungated-sink",
+        testPattern.resultSchema,
+        bundleTx,
+      );
+      const result = bundleRuntime.run(
+        bundleTx,
+        testPattern,
+        {},
+        resultCell,
+      );
+      bundleRuntime.prepareTxForCommit(bundleTx);
+      await bundleTx.commit();
+
+      const settled = await waitForCellValue<{ pending?: boolean }>(
+        bundleRuntime,
+        result,
+        (value) => value?.pending === false,
+      );
+      await bundleRuntime.settled();
+
+      expect(settled.pending).toBe(false);
+      expect(result.withTx().key("error").get()).toBeUndefined();
+      expect(requestsSent).toBe(1);
+    });
+  });
+
   describe("and the same builtins when the transaction commits", () => {
     // An unlabelled input leaves the result store's ceiling nothing to
     // refuse, so the staging transaction commits and the work starts. The

--- a/packages/runner/test/builtin-ownership-route.test.ts
+++ b/packages/runner/test/builtin-ownership-route.test.ts
@@ -1,0 +1,55 @@
+// Which builtins may put their stores on the ownership route, checked against
+// the source rather than against a reviewer's memory.
+//
+// A store on the route gives up whatever refusal its own ceiling was
+// providing, so the test is what refuses that write instead. A builtin that
+// stages its effect itself has nothing to move the refusal to, which is why
+// `docs/specs/cfc-enforcement-matrix.md` §4 keeps those stores off the route.
+// The rule is prose everywhere else; here it is the two sets being disjoint.
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+const BUILTINS = new URL("../src/builtins/", import.meta.url);
+
+/** The helpers that put a store on the route, however a builtin reaches it. */
+const ROUTE = /\bownedCell[<(]|\brecordRuntimeOwnedStore\(/;
+/** Staging an effect directly, with no sink request to carry a ceiling. */
+const STAGES_EFFECT = /\benqueuePostCommitEffect\(/;
+
+const sources = async () => {
+  const found = new Map<string, string>();
+  for await (const entry of Deno.readDir(BUILTINS)) {
+    if (!entry.isFile || !entry.name.endsWith(".ts")) continue;
+    // The seam itself names both sides; it is the definition, not a caller.
+    if (entry.name === "runtime-owned-store.ts") continue;
+    found.set(
+      entry.name,
+      await Deno.readTextFile(new URL(entry.name, BUILTINS)),
+    );
+  }
+  return found;
+};
+
+describe("the builtin ownership route", () => {
+  it("puts no store of an effect-staging builtin on the route", async () => {
+    const offenders = [...await sources()]
+      .filter(([, text]) => STAGES_EFFECT.test(text) && ROUTE.test(text))
+      .map(([name]) => name);
+
+    // A builtin reaching both is a decision someone has to make rather than
+    // a line to delete: either the effect gets a sink request whose ceiling
+    // can carry the refusal, or the store stays off the route and keeps its
+    // own, or the matrix records why this one is neither.
+    expect(offenders).toEqual([]);
+  });
+
+  it("finds the route in use and effects staged, so the pairing means something", async () => {
+    // Without this, deleting both helpers would leave the case above green.
+    const found = await sources();
+    const onRoute = [...found].filter(([, t]) => ROUTE.test(t));
+    const staging = [...found].filter(([, t]) => STAGES_EFFECT.test(t));
+    expect(onRoute.length).toBeGreaterThan(0);
+    expect(staging.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/runner/test/cfc-label-metadata-protection.test.ts
+++ b/packages/runner/test/cfc-label-metadata-protection.test.ts
@@ -18,7 +18,7 @@ import {
 } from "../src/cfc/label-representation.ts";
 import type { CfcLabelMetadataProtectionMode } from "../src/cfc/mod.ts";
 import {
-  CFC_STRUCTURAL_PROVENANCE_PIECE_SUBSTRATE,
+  CFC_STRUCTURAL_PROVENANCE_RUNTIME_OWNED_STORE,
   runtimeWritePolicyAuthorization,
 } from "../src/cfc/types.ts";
 import { parseLink } from "../src/link-utils.ts";
@@ -463,8 +463,8 @@ describe("CFC cross-space label-metadata persist transform (inv-12 Stage 1)", ()
       }
     });
 
-    it("commits the piece-substrate declaration built from that same join", async () => {
-      // The §8.12.5 route-2 declaration a piece's setup mints carries the
+    it("commits the runtime-owned-store declaration built from that same join", async () => {
+      // The §8.12.5 route-2 declaration a store the runtime owns mints carries the
       // flow join as its content, so it is the one `declared` entry the
       // transform applies to. Leaving it verbatim beside the committed
       // derived stamp of the same atoms would publish in one entry what the
@@ -501,7 +501,7 @@ describe("CFC cross-space label-metadata persist transform (inv-12 Stage 1)", ()
             id: substrateLink.id,
             path: [],
           },
-          claim: CFC_STRUCTURAL_PROVENANCE_PIECE_SUBSTRATE,
+          claim: CFC_STRUCTURAL_PROVENANCE_RUNTIME_OWNED_STORE,
           sources: [{
             space: resultLink.space,
             scope: resultLink.scope,

--- a/packages/runner/test/cfc-runtime-owned-store-wiring.test.ts
+++ b/packages/runner/test/cfc-runtime-owned-store-wiring.test.ts
@@ -1,0 +1,431 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { Identity } from "@commonfabric/identity";
+import type { FactoryInput, JSONSchema } from "../src/builder/types.ts";
+import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
+import { enrollRuntimeOwnedStore } from "../src/builtins/runtime-owned-store.ts";
+import { parseLink } from "../src/link-utils.ts";
+import { runtimeWritePolicyAuthorization } from "../src/cfc/types.ts";
+import {
+  SEED_ENVELOPE_SCHEMA_HASH,
+  writeSeedEnvelopeDoc,
+} from "./cfc-seed-envelope.ts";
+
+const signer = await Identity.fromPassphrase("runtime owned store wiring");
+const space = signer.did();
+const elsewhere =
+  (await Identity.fromPassphrase("runtime owned store elsewhere")).did();
+
+/**
+ * That the runner enrolls a running piece's own stores, that a builtin
+ * enrolls the state stores it mints, and that both go when the piece stops.
+ *
+ * `cfc-writer-fit.test.ts` states the RULE against a hand-recorded marker.
+ * These run a real piece, so they cover the wiring the rule rests on: which
+ * transaction names the stores, and when the enrollment ends. A hand-recorded
+ * marker cannot tell whether `startCore` registered anything at all.
+ */
+describe("runtime-owned-store enrollment wiring", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      cfcEnforcementMode: "enforce-strict",
+      cfcFlowLabels: "persist",
+    });
+  });
+
+  afterEach(async () => {
+    await runtime.dispose();
+    await storageManager.close();
+  });
+
+  /**
+   * A source whose `secret` field carries `clause`. Each write wants its own:
+   * a route-2 upgrade declares what it carried, so a second write reusing the
+   * first's clause would fit the store's own declaration whatever the
+   * enrollment says.
+   */
+  const seedSecret = async (name: string, clause = name) => {
+    const seed = runtime.edit();
+    const cell = runtime.getCell(space, name, {
+      type: "object",
+      properties: { secret: { type: "string" } },
+    } as JSONSchema);
+    const id = cell.getAsNormalizedFullLink().id;
+    writeSeedEnvelopeDoc(seed, space);
+    seed.writeOrThrow({ space, scope: "space", id, path: [] }, {
+      value: { secret: "s3cr3t" },
+      cfc: {
+        version: 1,
+        schemaHash: SEED_ENVELOPE_SCHEMA_HASH,
+        labelMap: {
+          version: 1,
+          entries: [{
+            path: ["secret"],
+            label: { confidentiality: [clause] },
+          }],
+        },
+      },
+      // deno-lint-ignore no-explicit-any
+    } as any);
+    expect((await seed.commit()).ok).toBeDefined();
+  };
+
+  /** Start a piece holding a list of its own, and hand back that list. */
+  const startPiece = async (name: string) => {
+    const { commonfabric } = createTrustedBuilder(runtime);
+    const { pattern, Cell: BuilderCell } = commonfabric;
+    const testPattern = pattern<Record<string, never>>(() => ({
+      notes: BuilderCell.of<string[]>([]),
+    }));
+    const tx = runtime.edit();
+    const resultCell = runtime.getCell(
+      space,
+      name,
+      testPattern.resultSchema,
+      tx,
+    );
+    const result = runtime.run(tx, testPattern, {}, resultCell);
+    runtime.prepareTxForCommit(tx);
+    expect((await tx.commit()).error).toBeUndefined();
+    await runtime.idle();
+    return { result, resultCell };
+  };
+
+  /**
+   * Append what the seeded source carries to the piece's own list, on a fresh
+   * transaction that names no store — the shape a reactive update has.
+   */
+  const appendSecret = async (
+    result: Awaited<ReturnType<typeof startPiece>>["result"],
+    sourceName: string,
+    suffix: string,
+  ) => {
+    const tx = runtime.edit();
+    tx.setCfcEnforcementMode("enforce-strict");
+    const source = runtime.getCell(space, sourceName, undefined, tx);
+    const raw = source.getRaw() as { secret?: string };
+    // deno-lint-ignore no-explicit-any
+    (result.withTx(tx) as any).key("notes").set([`${raw.secret}/${suffix}`]);
+    tx.prepareCfc();
+    return await tx.commit();
+  };
+
+  it("enrolls a running piece's stores, so a later write declares", async () => {
+    // The write runs on a transaction of its own, which names nothing: the
+    // enrollment the instantiation made is the whole of what reaches it.
+    await seedSecret("wiring-append-source");
+    const { result } = await startPiece("wiring-append");
+
+    expect((await appendSecret(result, "wiring-append-source", "first")).error)
+      .toBeUndefined();
+  });
+
+  it("declares on the piece's own result document", async () => {
+    // The result document is on the route and the others are not enough to
+    // put it there: a nested piece's result is `{resultFor}`, minted from a
+    // node's cause, and the reactive update that first carried a label into
+    // one is half of what this change exists for. It is also the member whose
+    // paths an author CAN declare, so where a schema does, the route declines
+    // and the misfit stands.
+    await seedSecret("wiring-result-source");
+    const { commonfabric } = createTrustedBuilder(runtime);
+    const { pattern, Cell: BuilderCell } = commonfabric;
+    const testPattern = pattern<Record<string, never>>(() => ({
+      note: BuilderCell.of(""),
+    }));
+    const tx = runtime.edit();
+    const resultCell = runtime.getCell(
+      space,
+      "wiring-result",
+      testPattern.resultSchema,
+      tx,
+    );
+    const result = runtime.run(tx, testPattern, {}, resultCell);
+    runtime.prepareTxForCommit(tx);
+    expect((await tx.commit()).error).toBeUndefined();
+    await runtime.idle();
+
+    // A later transaction naming no store, writing a labeled value into the
+    // result DOCUMENT — addressed without the pattern's schema, at a path
+    // that projects to no internal cell, so the write lands there and not in
+    // something the manifest already covers.
+    void result;
+    const write = runtime.edit();
+    write.setCfcEnforcementMode("enforce-strict");
+    const source = runtime.getCell(
+      space,
+      "wiring-result-source",
+      undefined,
+      write,
+    );
+    const raw = source.getRaw() as { secret?: string };
+    const document = runtime.getCell<{ scratch?: string }>(
+      space,
+      "wiring-result",
+      undefined,
+      write,
+    );
+    document.key("scratch").set(`${raw.secret}!`);
+    write.prepareCfc();
+    expect((await write.commit()).error).toBeUndefined();
+  });
+
+  it("enrolls no store a builtin minted outside the owner's space", () => {
+    // A store elsewhere belongs to whoever holds that space's replicas, so a
+    // policy declared on it out of this piece's flow join would put another
+    // space's bytes behind a promise made here. The helper every builtin
+    // holding state goes through is where that is settled, because the
+    // enrollment key names an owner and a store outside the space has none.
+    const tx = runtime.edit();
+    const owner = runtime.getCell(space, "cross-space-owner", undefined, tx);
+    const here = runtime.getCell(space, "cross-space-here", undefined, tx);
+    const there = runtime.getCell(
+      elsewhere,
+      "cross-space-there",
+      undefined,
+      tx,
+    );
+
+    enrollRuntimeOwnedStore(tx, owner, here);
+    enrollRuntimeOwnedStore(tx, owner, there);
+
+    expect(
+      tx.isRuntimeOwnedStore(
+        space,
+        here.getAsNormalizedFullLink().id,
+        runtimeWritePolicyAuthorization,
+      ),
+    ).toBe(true);
+    expect(
+      tx.isRuntimeOwnedStore(
+        elsewhere,
+        there.getAsNormalizedFullLink().id,
+        runtimeWritePolicyAuthorization,
+      ),
+    ).toBe(false);
+    tx.abort("done");
+  });
+
+  it("lets them go when the piece stops", async () => {
+    // Nothing may keep an enrollment alive past its piece: a list operation
+    // mints one piece per element, so an enrollment that outlived its piece
+    // would grow with every element a churning list ever held.
+    await seedSecret("wiring-release-source");
+    const { result, resultCell } = await startPiece("wiring-release");
+    expect((await appendSecret(result, "wiring-release-source", "first")).error)
+      .toBeUndefined();
+
+    runtime.runner.stop(resultCell);
+
+    // A clause the store's own declaration does not already cover, so the
+    // route is what the write needs and the release is what took it away.
+    await seedSecret("wiring-release-other");
+    const refused = await appendSecret(
+      result,
+      "wiring-release-other",
+      "second",
+    );
+    expect(refused.error?.message).toContain(
+      "writer-fit confidentiality misfit",
+    );
+  });
+
+  it("releases an element piece's stores when its element leaves the list", async () => {
+    // A list operation mints one piece per element and stops it when the
+    // element goes, so the enrollment must follow the piece rather than the
+    // list: an element that left keeps its result document, and that
+    // document is nobody's store any more.
+    const { commonfabric } = createTrustedBuilder(runtime);
+    const { pattern, lift } = commonfabric;
+    const doubled = pattern<{ values: number[] }>(({ values }) => ({
+      values,
+      // deno-lint-ignore no-explicit-any
+      output: (values as any).mapWithPattern(
+        pattern(({ element }: FactoryInput<any>) =>
+          lift((value: number) => value * 2)(element)
+        ),
+        {},
+      ),
+    }));
+    const values = Array.from({ length: 6 }, (_, index) => index);
+    let tx = runtime.edit();
+    const resultCell = runtime.getCell(space, "wiring-elements", undefined, tx);
+    const result = runtime.run(tx, doubled, { values }, resultCell);
+    runtime.prepareTxForCommit(tx);
+    expect((await tx.commit()).error).toBeUndefined();
+    await runtime.settled();
+    await result.pull();
+
+    // The container holds one link per element, to that element piece's
+    // result document.
+    const elementIds = () => {
+      const read = runtime.edit();
+      // The output spot links to a computed document, which links to the
+      // container; the container holds one link per element. Follow links
+      // until the array itself.
+      let cell = result.withTx(read).key("output");
+      let raw = cell.getRaw();
+      while (!Array.isArray(raw)) {
+        cell = runtime.getCellFromLink(parseLink(raw, cell)!, undefined, read);
+        raw = cell.getRaw();
+      }
+      const ids = (raw as { "/": { "link@1": { id: string } } }[]).map(
+        (entry) => entry["/"]["link@1"].id,
+      );
+      read.abort("read");
+      return ids;
+    };
+    const owned = (id: string) => {
+      const ask = runtime.edit();
+      const answer = ask.isRuntimeOwnedStore(
+        space,
+        id,
+        runtimeWritePolicyAuthorization,
+      );
+      ask.abort("ask");
+      return answer;
+    };
+    const before = elementIds();
+    expect(before.length).toBe(6);
+    for (const id of before) expect(owned(id)).toBe(true);
+
+    tx = runtime.edit();
+    result.withTx(tx).key("values").set(values.slice(0, 2));
+    runtime.prepareTxForCommit(tx);
+    expect((await tx.commit()).error).toBeUndefined();
+    await runtime.settled();
+    await result.pull();
+
+    const after = elementIds();
+    expect(after).toEqual(before.slice(0, 2));
+    for (const id of before.slice(0, 2)) expect(owned(id)).toBe(true);
+    for (const id of before.slice(2)) expect(owned(id)).toBe(false);
+  });
+
+  describe("an element anchored inside a store the runtime owns", () => {
+    // The anchored child takes the marker alone, recorded by the write that
+    // anchors it. What that reaches and what it does not is the line an
+    // author meets: a write that re-anchors the element commits, and a write
+    // addressed into the existing child through its link is measured against
+    // the child's own ceiling and refused. Both halves are pinned so the
+    // refused one flips visibly when link-carried provenance (§8.12.8)
+    // reaches it.
+
+    const startListPiece = async (name: string) => {
+      const { commonfabric } = createTrustedBuilder(runtime);
+      const { pattern, Cell: BuilderCell } = commonfabric;
+      const listPattern = pattern<Record<string, never>>(() => ({
+        items: BuilderCell.of<{ note: string }[]>([], {
+          type: "array",
+          items: { type: "object", properties: { note: { type: "string" } } },
+        }),
+      }));
+      const tx = runtime.edit();
+      const resultCell = runtime.getCell(
+        space,
+        name,
+        listPattern.resultSchema,
+        tx,
+      );
+      const result = runtime.run(tx, listPattern, {}, resultCell);
+      runtime.prepareTxForCommit(tx);
+      expect((await tx.commit()).error).toBeUndefined();
+      await runtime.idle();
+      return result;
+    };
+
+    /** Write what `sourceName` carries into the piece's list, per `shape`. */
+    const writeLabeled = async (
+      result: Awaited<ReturnType<typeof startListPiece>>,
+      sourceName: string,
+      // deno-lint-ignore no-explicit-any
+      shape: (items: any, secret: string) => void,
+    ) => {
+      const tx = runtime.edit();
+      tx.setCfcEnforcementMode("enforce-strict");
+      const source = runtime.getCell(space, sourceName, undefined, tx);
+      const raw = source.getRaw() as { secret?: string };
+      // deno-lint-ignore no-explicit-any
+      shape((result.withTx(tx) as any).key("items"), raw.secret!);
+      tx.prepareCfc();
+      return await tx.commit();
+    };
+
+    it("declares on the child the anchoring write mints", async () => {
+      await seedSecret("anchor-append-source", "anchor-append");
+      const result = await startListPiece("wiring-anchor-append");
+      const appended = await writeLabeled(
+        result,
+        "anchor-append-source",
+        (items, secret) => items.set([{ note: `${secret}/append` }]),
+      );
+      expect(appended.error).toBeUndefined();
+    });
+
+    it("commits a write that re-anchors the element", async () => {
+      await seedSecret("anchor-rewrite-first", "anchor-rewrite-1");
+      await seedSecret("anchor-rewrite-second", "anchor-rewrite-2");
+      await seedSecret("anchor-rewrite-third", "anchor-rewrite-3");
+      const result = await startListPiece("wiring-anchor-rewrite");
+      expect(
+        (await writeLabeled(
+          result,
+          "anchor-rewrite-first",
+          (items, secret) => items.set([{ note: `${secret}/append` }]),
+        )).error,
+      ).toBeUndefined();
+      // The whole list again, and the element alone: each puts an object at
+      // the position, so each walks through the anchoring and marks the
+      // child it mints.
+      expect(
+        (await writeLabeled(
+          result,
+          "anchor-rewrite-second",
+          (items, secret) => items.set([{ note: `${secret}/rewrite` }]),
+        )).error,
+      ).toBeUndefined();
+      expect(
+        (await writeLabeled(
+          result,
+          "anchor-rewrite-third",
+          (items, secret) => items.key(0).set({ note: `${secret}/element` }),
+        )).error,
+      ).toBeUndefined();
+    });
+
+    it("refuses a write addressed into the existing child", async () => {
+      // The ordinary handler shape — one field of one existing item — and the
+      // one this route does not reach: the write follows the link into the
+      // child and finds no claim there.
+      await seedSecret("anchor-field-first", "anchor-field-1");
+      await seedSecret("anchor-field-second", "anchor-field-2");
+      const result = await startListPiece("wiring-anchor-field");
+      expect(
+        (await writeLabeled(
+          result,
+          "anchor-field-first",
+          (items, secret) => items.set([{ note: `${secret}/append` }]),
+        )).error,
+      ).toBeUndefined();
+      const refused = await writeLabeled(
+        result,
+        "anchor-field-second",
+        (items, secret) => items.key(0).key("note").set(`${secret}/field`),
+      );
+      expect(refused.error?.message).toContain(
+        "writer-fit confidentiality misfit",
+      );
+      expect(refused.error?.message).toContain("at /note");
+      expect(refused.error?.message).toContain('"anchor-field-2"');
+    });
+  });
+});

--- a/packages/runner/test/cfc-writer-fit.test.ts
+++ b/packages/runner/test/cfc-writer-fit.test.ts
@@ -9,10 +9,12 @@ import {
 } from "./cfc-seed-envelope.ts";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import { Runtime } from "../src/runtime.ts";
+import { runtimeOwnedStoreOwnerKey } from "../src/cfc/runtime-owned-stores.ts";
+import type { NormalizedFullLink } from "../src/link-types.ts";
 import { getDerivedInternalCellLink, parseLink } from "../src/link-utils.ts";
 import { CFC_LABEL_READ_FAILED_ATOM } from "../src/cfc/observation.ts";
 import {
-  CFC_STRUCTURAL_PROVENANCE_PIECE_SUBSTRATE,
+  CFC_STRUCTURAL_PROVENANCE_RUNTIME_OWNED_STORE,
   CFC_STRUCTURAL_PROVENANCE_SEED_MATERIALIZATION,
   runtimeWritePolicyAuthorization,
 } from "../src/cfc/types.ts";
@@ -86,6 +88,10 @@ const ownSpacePrincipal = {
 // A second person, who is neither this space's DID nor its acting signer.
 const OTHER_PRINCIPAL = "did:key:zOtherPerson";
 
+// A third, for a clause that must land beside an existing one rather than
+// inside it.
+const THIRD_PRINCIPAL = "did:key:zThirdPerson";
+
 // The three spellings of one principal (§15.2): the identity atom, the
 // personal-space atom naming its owner, and the legacy bare DID string.
 const userPrincipal = (subject: string) => ({
@@ -96,6 +102,17 @@ const personalSpacePrincipal = (owner: string) => ({
   type: "https://commonfabric.org/cfc/atom/PersonalSpace",
   owner,
 });
+
+// A space that is not the one every document in this file lives in.
+const OTHER_SPACE = "did:key:z6MkfZ3gV6ZKqmyWLTPYnPYRUYQBqTHTNCJgqbCkNBzYqZ4H";
+
+// A list schema whose ELEMENT objects get anchored into documents of their
+// own. Neither the list nor the items declare a store policy, so an anchored
+// child starts from the empty ceiling.
+const anchoringList = (): JSONSchema => ({
+  type: "array",
+  items: { type: "object", properties: { note: { type: "string" } } },
+} as JSONSchema);
 
 // A target schema whose store policy is exactly `confidentiality`.
 const declaring = (
@@ -178,11 +195,14 @@ const writerFitDiagnostics = (
   tx: { getCfcState(): { diagnostics: string[] } },
 ) => tx.getCfcState().diagnostics.filter((d) => d.includes("writer-fit"));
 
-// The marker the runner records for each document it sets a piece up in,
-// naming the piece's result document as the source. `authorized` stands for
-// who recorded it: the runtime passes its authorization, and code that merely
-// holds a transaction cannot.
-const recordPieceSubstrate = (
+// The marker the runner records for each store it owns, naming the piece's
+// result document as the source. `authorized` stands for who recorded it: the
+// runtime passes its authorization, and code that merely holds a transaction
+// cannot. `enrol` stands for the enrollment the runner records beside the
+// marker, which is what carries the claim into later transactions; a store the
+// runtime mints and fills in one transaction gets the marker alone.
+const recordRuntimeOwnedStore = (
+  runtime: Runtime,
   tx: ReturnType<Runtime["edit"]>,
   resultCell: {
     getAsNormalizedFullLink(): { space: string; scope: string; id: string };
@@ -196,18 +216,20 @@ const recordPieceSubstrate = (
     };
   },
   authorized = true,
+  enrol = true,
 ): void => {
   const result = resultCell.getAsNormalizedFullLink();
   const substrate = substrateCell.getAsNormalizedFullLink();
+  const target = {
+    space: substrate.space as `did:${string}:${string}`,
+    scope: substrate.scope as "space",
+    id: substrate.id,
+    path: [...substrate.path],
+  };
   tx.recordCfcWritePolicyInput({
     kind: "structural-provenance",
-    target: {
-      space: substrate.space as `did:${string}:${string}`,
-      scope: substrate.scope as "space",
-      id: substrate.id,
-      path: [...substrate.path],
-    },
-    claim: CFC_STRUCTURAL_PROVENANCE_PIECE_SUBSTRATE,
+    target,
+    claim: CFC_STRUCTURAL_PROVENANCE_RUNTIME_OWNED_STORE,
     sources: [{
       space: result.space as `did:${string}:${string}`,
       scope: result.scope as "space",
@@ -215,6 +237,43 @@ const recordPieceSubstrate = (
       path: [],
     }],
   }, authorized ? runtimeWritePolicyAuthorization : undefined);
+  if (enrol) {
+    const ownerKey = runtimeOwnedStoreOwnerKey(
+      substrate,
+      result as NormalizedFullLink,
+      runtime.scopeKeyIdentity,
+    );
+    if (ownerKey !== undefined) {
+      tx.enrollRuntimeOwnedStore(
+        target,
+        ownerKey,
+        authorized ? runtimeWritePolicyAuthorization : undefined,
+      );
+    }
+  }
+};
+
+// Read the seeded source and write what it carries into `targetName`, with no
+// marker of its own — the transaction a reactive update makes.
+const writeSecretInto = async (
+  runtime: Runtime,
+  sourceName: string,
+  targetName: string,
+  suffix = "first",
+) => {
+  const tx = runtime.edit();
+  tx.setCfcEnforcementMode("enforce-strict");
+  const source = runtime.getCell(signer.did(), sourceName, undefined, tx);
+  const raw = source.getRaw() as { secret?: string };
+  const target = runtime.getCell<{ copied?: string }>(
+    signer.did(),
+    targetName,
+    undefined,
+    tx,
+  );
+  target.set({ copied: `${raw.secret}/${suffix}` });
+  tx.prepareCfc();
+  return await tx.commit();
 };
 
 describe("CFC writer-fit (canWrite, §8.12.4 / SC-18b)", () => {
@@ -1435,15 +1494,16 @@ describe("CFC writer-fit (canWrite, §8.12.4 / SC-18b)", () => {
     nodes: [],
   } satisfies Pattern;
 
-  describe("the piece-substrate declaration (§8.12.5 route 2)", () => {
-    // A piece's substrate is filled by the runtime out of whatever the setup
-    // transaction read: the argument document, and the internal documents
-    // and streams the result projects to. No value schema can declare a
-    // covering policy for them, because the atoms are a property of the
-    // transaction rather than of the pattern, so the transaction declares
-    // that policy itself. `docs/specs/cfc-enforcement-matrix.md` §4 states
-    // the route and the four conditions on it; one test per condition
-    // follows.
+  describe("the runtime-owned-store declaration (§8.12.5 route 2)", () => {
+    // A store the runtime owns is filled by the runtime out of whatever the
+    // writing transaction read: a piece's argument, result and internal
+    // documents, the state documents a builtin mints from its own node's
+    // cause, and the documents anchoring splits out of a value written into
+    // any of those. No value schema can declare a covering policy for them,
+    // because the atoms are a property of the transaction rather than of the
+    // pattern, so the transaction declares that policy itself.
+    // `docs/specs/cfc-enforcement-matrix.md` §4 states the route and the
+    // conditions on it; one test per condition follows.
 
     it("declares the join on a document the substrate marker names", async () => {
       const storageManager = StorageManager.emulate({ as: signer });
@@ -1472,7 +1532,7 @@ describe("CFC writer-fit (canWrite, §8.12.4 / SC-18b)", () => {
           undefined,
           tx,
         );
-        recordPieceSubstrate(tx, result, substrate);
+        recordRuntimeOwnedStore(runtime, tx, result, substrate);
         substrate.set({ copied: `${raw.secret}!` });
         const substrateId = substrate.getAsNormalizedFullLink().id;
         tx.prepareCfc();
@@ -1490,7 +1550,7 @@ describe("CFC writer-fit (canWrite, §8.12.4 / SC-18b)", () => {
         expect(flags.length).toBe(1);
         expect(
           flags.some((flag) =>
-            flag.includes("writer-fit(piece-substrate-declared)") &&
+            flag.includes("writer-fit(runtime-owned-store-declared)") &&
             flag.includes(`${substrateId} at /`) && flag.includes('"secret"')
           ),
         ).toBe(true);
@@ -1531,7 +1591,7 @@ describe("CFC writer-fit (canWrite, §8.12.4 / SC-18b)", () => {
           undefined,
           tx,
         );
-        recordPieceSubstrate(tx, result, substrate);
+        recordRuntimeOwnedStore(runtime, tx, result, substrate);
         const bystander = runtime.getCell(
           signer.did(),
           "writer-fit-seam-bystander",
@@ -1598,7 +1658,7 @@ describe("CFC writer-fit (canWrite, §8.12.4 / SC-18b)", () => {
             undefined,
             tx,
           );
-          recordPieceSubstrate(tx, result, substrate);
+          recordRuntimeOwnedStore(runtime, tx, result, substrate);
           substrate.set({ copied });
           tx.prepareCfc();
           expect((await tx.commit()).ok).toBeDefined();
@@ -1626,6 +1686,861 @@ describe("CFC writer-fit (canWrite, §8.12.4 / SC-18b)", () => {
         // the narrower join: the declared component never shrinks.
         expect(await declaredClauses(["writer-fit-seam-grow-first"]))
           .toEqual(grown);
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("declares on a later transaction that names no store of its own", async () => {
+      // Instance 1: a piece whose result projects a list. Setup is one
+      // transaction; the reactive update that appends to the list is another,
+      // and it records no marker of its own. The enrollment made at setup is
+      // what carries the claim there, so the array-length bookkeeping write
+      // declares rather than refusing.
+
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = newRuntime(storageManager);
+      try {
+        await seedSecretSource(runtime, "writer-fit-owned-later-source");
+
+        const setup = runtime.edit();
+        setup.setCfcEnforcementMode("enforce-strict");
+        const result = runtime.getCell(
+          signer.did(),
+          "writer-fit-owned-later-result",
+          undefined,
+          setup,
+        );
+        const list = runtime.getCell<string[]>(
+          signer.did(),
+          "writer-fit-owned-later-list",
+          { type: "array", items: { type: "string" } } as JSONSchema,
+          setup,
+        );
+        recordRuntimeOwnedStore(runtime, setup, result, list);
+        list.set(["first"]);
+        const listId = list.getAsNormalizedFullLink().id;
+        setup.prepareCfc();
+        expect((await setup.commit()).ok).toBeDefined();
+        expect(replicaEntries(storageManager, listId)).toEqual([]);
+
+        const update = runtime.edit();
+        update.setCfcEnforcementMode("enforce-strict");
+        const source = runtime.getCell(
+          signer.did(),
+          "writer-fit-owned-later-source",
+          undefined,
+          update,
+        );
+        const raw = source.getRaw() as { secret?: string };
+        const listInUpdate = runtime.getCell<string[]>(
+          signer.did(),
+          "writer-fit-owned-later-list",
+          { type: "array", items: { type: "string" } } as JSONSchema,
+          update,
+        );
+        listInUpdate.set(["first", `${raw.secret}!`]);
+        update.prepareCfc();
+        expect((await update.commit()).ok).toBeDefined();
+
+        const declared = replicaEntries(storageManager, listId)
+          .filter((entry) => entry.origin === "declared");
+        expect(declared.length).toBeGreaterThan(0);
+        expect(
+          declared.some((entry) =>
+            (entry.label.confidentiality ?? []).includes("secret")
+          ),
+        ).toBe(true);
+        expect(
+          writerFitDiagnostics(update).some((flag) =>
+            flag.includes("writer-fit(runtime-owned-store-declared)")
+          ),
+        ).toBe(true);
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("declares a builtin's own result store on a later transaction", async () => {
+      // Instance 2: a dialog writes its own result while the conversation
+      // carries a material-risk caveat. The store is minted from the node's
+      // cause on the builtin's first run and written by every turn afterwards,
+      // each on a transaction of its own.
+
+      const caveat = {
+        type: "https://commonfabric.org/cfc/atom/Caveat",
+        kind:
+          "https://commonfabric.org/cfc/concepts/prompt-injection-risk-unscreened",
+        source: {
+          type: "https://commonfabric.org/cfc/atom/Resource",
+          class: "HostileVendorBriefing",
+          subject: "did:example:writer-fit-owned-builtin",
+        },
+      } as const;
+
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = newRuntime(storageManager);
+      try {
+        await seedSecretSource(
+          runtime,
+          "writer-fit-owned-builtin-source",
+          [caveat],
+        );
+
+        const mint = runtime.edit();
+        mint.setCfcEnforcementMode("enforce-strict");
+        const node = runtime.getCell(
+          signer.did(),
+          "writer-fit-owned-builtin-node",
+          undefined,
+          mint,
+        );
+        const store = runtime.getCell<{ copied?: string }>(
+          signer.did(),
+          "writer-fit-owned-builtin-store",
+          undefined,
+          mint,
+        );
+        recordRuntimeOwnedStore(runtime, mint, node, store);
+        store.set({});
+        const storeId = store.getAsNormalizedFullLink().id;
+        mint.prepareCfc();
+        expect((await mint.commit()).ok).toBeDefined();
+
+        const turn = runtime.edit();
+        turn.setCfcEnforcementMode("enforce-strict");
+        const source = runtime.getCell(
+          signer.did(),
+          "writer-fit-owned-builtin-source",
+          undefined,
+          turn,
+        );
+        const raw = source.getRaw() as { secret?: string };
+        const storeInTurn = runtime.getCell<{ copied?: string }>(
+          signer.did(),
+          "writer-fit-owned-builtin-store",
+          undefined,
+          turn,
+        );
+        storeInTurn.set({ copied: `${raw.secret}!` });
+        turn.prepareCfc();
+        expect((await turn.commit()).ok).toBeDefined();
+
+        expect(
+          replicaEntries(storageManager, storeId).some((entry) =>
+            entry.origin === "declared" &&
+            JSON.stringify(entry.label.confidentiality ?? []).includes(
+              "prompt-injection-risk-unscreened",
+            )
+          ),
+        ).toBe(true);
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("taints every reader with what a grown declaration admits", async () => {
+      // This is what makes the route safe to run on every write rather than
+      // only while a piece is being set up. A declared clause list is read two
+      // ways, and the two agree: as a ceiling a label clause is admitted when
+      // SOME declared clause subsumes it, and as a reader's taint the whole
+      // list is a conjunction every reader carries. So each upgrade admits
+      // more data AND narrows the audience by the same step, however many
+      // times it happens — a store an unbounded reactive stream has walked is
+      // readable by fewer people than when it started, never by more.
+
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = newRuntime(storageManager);
+      try {
+        for (const clause of ["alpha", "beta", "gamma"]) {
+          await seedSecretSource(
+            runtime,
+            `writer-fit-owned-walk-${clause}`,
+            [clause],
+          );
+        }
+
+        const born = runtime.edit();
+        const result = runtime.getCell(
+          signer.did(),
+          "writer-fit-owned-walk-result",
+          undefined,
+          born,
+        );
+        const store = runtime.getCell<{ copied?: string }>(
+          signer.did(),
+          "writer-fit-owned-walk-store",
+          undefined,
+          born,
+        );
+        recordRuntimeOwnedStore(runtime, born, result, store);
+        store.set({ copied: "public" });
+        const storeId = store.getAsNormalizedFullLink().id;
+        expect((await born.commit()).ok).toBeDefined();
+
+        // One upgrade per clause, each on its own transaction, none of which
+        // names a store: the enrollment above is all they have.
+        for (const clause of ["alpha", "beta", "gamma"]) {
+          const tx = runtime.edit();
+          tx.setCfcEnforcementMode("enforce-strict");
+          const source = runtime.getCell(
+            signer.did(),
+            `writer-fit-owned-walk-${clause}`,
+            undefined,
+            tx,
+          );
+          const raw = source.getRaw() as { secret?: string };
+          const storeInTx = runtime.getCell<{ copied?: string }>(
+            signer.did(),
+            "writer-fit-owned-walk-store",
+            undefined,
+            tx,
+          );
+          // A distinct value per round: an identical write diffs to nothing
+          // and would leave the declaration where the round before put it.
+          storeInTx.set({ copied: `${raw.secret}/${clause}` });
+          tx.prepareCfc();
+          expect((await tx.commit()).ok).toBeDefined();
+        }
+
+        const declared = replicaEntries(storageManager, storeId)
+          .filter((entry) => entry.origin === "declared");
+        expect(declared.length).toBe(1);
+        expect(declared[0].label.confidentiality).toEqual([
+          "alpha",
+          "beta",
+          "gamma",
+        ]);
+
+        // The negative the growth implies: a reader of the walked store
+        // carries all three, so copying what it read into an undeclared store
+        // is refused on every one of them.
+        const readBack = runtime.edit();
+        readBack.setCfcEnforcementMode("enforce-strict");
+        const storeInRead = runtime.getCell<{ copied?: string }>(
+          signer.did(),
+          "writer-fit-owned-walk-store",
+          undefined,
+          readBack,
+        );
+        const seen = storeInRead.getRaw() as { copied?: string };
+        const sink = runtime.getCell<{ copied?: string }>(
+          signer.did(),
+          "writer-fit-owned-walk-sink",
+          undefined,
+          readBack,
+        );
+        sink.set({ copied: `${seen.copied}?` });
+        readBack.prepareCfc();
+        const refused = await readBack.commit();
+        expect(refused.error?.message).toContain(
+          "writer-fit confidentiality misfit",
+        );
+        for (const clause of ["alpha", "beta", "gamma"]) {
+          expect(refused.error?.message).toContain(`"${clause}"`);
+        }
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("rejects a later write to a document beside a store it owns", async () => {
+      // Widening the route in TIME must not widen it in SCOPE. An enrollment
+      // names one store; a bystander written by a later transaction of the
+      // same piece keeps its own ceiling.
+
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = newRuntime(storageManager);
+      try {
+        await seedSecretSource(runtime, "writer-fit-owned-bystander-source");
+
+        const setup = runtime.edit();
+        const result = runtime.getCell(
+          signer.did(),
+          "writer-fit-owned-bystander-result",
+          undefined,
+          setup,
+        );
+        const store = runtime.getCell(
+          signer.did(),
+          "writer-fit-owned-bystander-store",
+          undefined,
+          setup,
+        );
+        recordRuntimeOwnedStore(runtime, setup, result, store);
+        store.set({ copied: "public" });
+        expect((await setup.commit()).ok).toBeDefined();
+
+        const later = runtime.edit();
+        later.setCfcEnforcementMode("enforce-strict");
+        const source = runtime.getCell(
+          signer.did(),
+          "writer-fit-owned-bystander-source",
+          undefined,
+          later,
+        );
+        const raw = source.getRaw() as { secret?: string };
+        const bystander = runtime.getCell(
+          signer.did(),
+          "writer-fit-owned-bystander",
+          undefined,
+          later,
+        );
+        bystander.set({ copied: `${raw.secret}!` });
+        const bystanderId = bystander.getAsNormalizedFullLink().id;
+        later.prepareCfc();
+        const committed = await later.commit();
+        expect(committed.error?.message).toContain(
+          "writer-fit confidentiality misfit",
+        );
+        expect(committed.error?.message).toContain(`for ${bystanderId} at /`);
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("enrolls nothing from a marker the runtime did not record", async () => {
+      // The across-transaction twin of the unauthorized-marker case: an
+      // unmarked marker names nothing in its own transaction, and leaves
+      // nothing behind for a later one either.
+
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = newRuntime(storageManager);
+      try {
+        await seedSecretSource(runtime, "writer-fit-owned-forged-source");
+
+        const forge = runtime.edit();
+        const result = runtime.getCell(
+          signer.did(),
+          "writer-fit-owned-forged-result",
+          undefined,
+          forge,
+        );
+        const store = runtime.getCell(
+          signer.did(),
+          "writer-fit-owned-forged-store",
+          undefined,
+          forge,
+        );
+        recordRuntimeOwnedStore(runtime, forge, result, store, false);
+        store.set({ copied: "public" });
+        const storeId = store.getAsNormalizedFullLink().id;
+        expect((await forge.commit()).ok).toBeDefined();
+
+        const later = runtime.edit();
+        later.setCfcEnforcementMode("enforce-strict");
+        const source = runtime.getCell(
+          signer.did(),
+          "writer-fit-owned-forged-source",
+          undefined,
+          later,
+        );
+        const raw = source.getRaw() as { secret?: string };
+        const storeLater = runtime.getCell(
+          signer.did(),
+          "writer-fit-owned-forged-store",
+          undefined,
+          later,
+        );
+        storeLater.set({ copied: `${raw.secret}!` });
+        later.prepareCfc();
+        const committed = await later.commit();
+        expect(committed.error?.message).toContain(
+          "writer-fit confidentiality misfit",
+        );
+        expect(committed.error?.message).toContain(`for ${storeId} at /`);
+        expect(
+          replicaEntries(storageManager, storeId).some((entry) =>
+            entry.origin === "declared"
+          ),
+        ).toBe(false);
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("adds a clause rather than an alternative to one already there", async () => {
+      // The line §8.12.7 draws, and safety invariant 1 with it. Adding a
+      // CLAUSE is tightening, which §8.12.1 admits and §8.12.5 sanctions as
+      // the upgrade. Adding an ALTERNATIVE to a clause already stored grows
+      // that clause's reader set, which is a widening `canUpdateStoreLabel`
+      // rejects and which §8.12.7 admits only through a grant record or an
+      // intent-gated declassification event — neither of which a write-side
+      // fit check is.
+      //
+      // So the route folds clause LISTS and never clause alternatives: a
+      // stored `anyOf` comes back exactly as it went in, beside the new
+      // clause rather than holding it.
+
+      const audience = {
+        anyOf: [
+          userPrincipal(signer.did()),
+          userPrincipal(OTHER_PRINCIPAL),
+        ],
+      };
+
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = newRuntime(storageManager);
+      try {
+        await seedSecretSource(runtime, "writer-fit-owned-clause-first", [
+          audience,
+        ]);
+        await seedSecretSource(runtime, "writer-fit-owned-clause-second", [
+          userPrincipal(THIRD_PRINCIPAL),
+        ]);
+
+        const enrol = runtime.edit();
+        const result = runtime.getCell(
+          signer.did(),
+          "writer-fit-owned-clause-result",
+          undefined,
+          enrol,
+        );
+        const store = runtime.getCell(
+          signer.did(),
+          "writer-fit-owned-clause-store",
+          undefined,
+          enrol,
+        );
+        recordRuntimeOwnedStore(runtime, enrol, result, store);
+        store.set({ copied: "public" });
+        const storeId = store.getAsNormalizedFullLink().id;
+        expect((await enrol.commit()).ok).toBeDefined();
+
+        expect(
+          (await writeSecretInto(
+            runtime,
+            "writer-fit-owned-clause-first",
+            "writer-fit-owned-clause-store",
+          )).error,
+        ).toBeUndefined();
+        expect(
+          (await writeSecretInto(
+            runtime,
+            "writer-fit-owned-clause-second",
+            "writer-fit-owned-clause-store",
+            "second",
+          )).error,
+        ).toBeUndefined();
+
+        const declared = replicaEntries(storageManager, storeId)
+          .filter((entry) => entry.origin === "declared");
+        expect(declared.length).toBe(1);
+        const clauses = declared[0].label.confidentiality ?? [];
+        // Two clauses. The `anyOf` carries the alternatives it arrived with
+        // and no more — canonical order, not membership, is what normalizing
+        // it changes — and the second clause stands beside it.
+        expect(clauses.length).toBe(2);
+        const orClause = clauses.find((clause) =>
+          typeof clause === "object" && clause !== null && "anyOf" in clause
+        ) as { anyOf: unknown[] } | undefined;
+        expect(orClause).toBeDefined();
+        expect(orClause!.anyOf.length).toBe(2);
+        expect(orClause!.anyOf).toContainEqual(userPrincipal(signer.did()));
+        expect(orClause!.anyOf).toContainEqual(userPrincipal(OTHER_PRINCIPAL));
+        expect(clauses).toContainEqual(userPrincipal(THIRD_PRINCIPAL));
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("names nothing where the owner is in another space", async () => {
+      // A store in another space belongs to whoever holds that space's
+      // replicas. Declaring a policy on it out of this piece's join would put
+      // those bytes behind a promise made here, so a marker naming one counts
+      // for nothing however it is authorized.
+
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = newRuntime(storageManager);
+      try {
+        await seedSecretSource(runtime, "writer-fit-owned-foreign-source");
+
+        const tx = runtime.edit();
+        tx.setCfcEnforcementMode("enforce-strict");
+        const source = runtime.getCell(
+          signer.did(),
+          "writer-fit-owned-foreign-source",
+          undefined,
+          tx,
+        );
+        const raw = source.getRaw() as { secret?: string };
+        const result = runtime.getCell(
+          signer.did(),
+          "writer-fit-owned-foreign-result",
+          undefined,
+          tx,
+        );
+        const store = runtime.getCell(
+          signer.did(),
+          "writer-fit-owned-foreign-store",
+          undefined,
+          tx,
+        );
+        const storeLink = store.getAsNormalizedFullLink();
+        const resultLink = result.getAsNormalizedFullLink();
+        // The marker as the runtime records it, except that the source names
+        // another space — which is what the guard reads.
+        tx.recordCfcWritePolicyInput({
+          kind: "structural-provenance",
+          target: {
+            space: storeLink.space as `did:${string}:${string}`,
+            scope: storeLink.scope as "space",
+            id: storeLink.id,
+            path: [],
+          },
+          claim: CFC_STRUCTURAL_PROVENANCE_RUNTIME_OWNED_STORE,
+          sources: [{
+            space: OTHER_SPACE,
+            scope: "space",
+            id: resultLink.id,
+            path: [],
+          }],
+        }, runtimeWritePolicyAuthorization);
+        store.set({ copied: `${raw.secret}!` });
+        tx.prepareCfc();
+        const committed = await tx.commit();
+        expect(committed.error?.message).toContain(
+          "writer-fit confidentiality misfit",
+        );
+        expect(committed.error?.message).toContain(`for ${storeLink.id} at /`);
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("forgets what a piece enrolled when the piece is released", async () => {
+      // The enrollment lasts as long as the piece's nodes do, which is what
+      // bounds it: a list operation mints one piece per element, so an
+      // enrollment that lived for the process would grow with every element a
+      // churning list ever held.
+
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = newRuntime(storageManager);
+      try {
+        await seedSecretSource(runtime, "writer-fit-owned-release-source");
+        // A clause per write. Each route-2 upgrade declares what it carried,
+        // so a later write reusing an earlier clause would fit the store's own
+        // declaration whatever the enrollment says.
+        await seedSecretSource(runtime, "writer-fit-owned-release-second", [
+          "second-clause",
+        ]);
+        await seedSecretSource(runtime, "writer-fit-owned-release-third", [
+          "third-clause",
+        ]);
+
+        const enrol = runtime.edit();
+        const result = runtime.getCell(
+          signer.did(),
+          "writer-fit-owned-release-result",
+          undefined,
+          enrol,
+        );
+        const store = runtime.getCell(
+          signer.did(),
+          "writer-fit-owned-release-store",
+          undefined,
+          enrol,
+        );
+        recordRuntimeOwnedStore(runtime, enrol, result, store);
+        store.set({ copied: "public" });
+        const storeId = store.getAsNormalizedFullLink().id;
+        expect((await enrol.commit()).ok).toBeDefined();
+
+        // A write in a later transaction takes the route while the piece
+        // holds the enrollment.
+        const declared = await writeSecretInto(
+          runtime,
+          "writer-fit-owned-release-source",
+          "writer-fit-owned-release-store",
+        );
+        expect(declared.error).toBeUndefined();
+
+        // An unauthorized release changes nothing: pattern-authored code
+        // reaches the runtime through a cell, and a release it made would
+        // refuse another piece's writes.
+        runtime.releaseRuntimeOwnedStores(
+          result.getAsNormalizedFullLink(),
+          undefined,
+        );
+        expect(
+          (await writeSecretInto(
+            runtime,
+            "writer-fit-owned-release-second",
+            "writer-fit-owned-release-store",
+            "second",
+          )).error,
+        ).toBeUndefined();
+
+        runtime.releaseRuntimeOwnedStores(
+          result.getAsNormalizedFullLink(),
+          runtimeWritePolicyAuthorization,
+        );
+        const refused = await writeSecretInto(
+          runtime,
+          "writer-fit-owned-release-third",
+          "writer-fit-owned-release-store",
+          "third",
+        );
+        expect(refused.error?.message).toContain(
+          "writer-fit confidentiality misfit",
+        );
+        expect(refused.error?.message).toContain(`for ${storeId} at /`);
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("keeps a store a second owner still holds", async () => {
+      // Two scope instances of one causal piece are two registrations that
+      // start and stop separately, so they are two owners of the same store —
+      // the store key is scope-free, because the scoped instances of one
+      // causal id are instances of one cell. Releasing either owner must
+      // leave the other's writes admitted; dropping the store on the first
+      // release would refuse the survivor.
+
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = newRuntime(storageManager);
+      try {
+        await seedSecretSource(runtime, "writer-fit-owned-two-owners-source");
+        await seedSecretSource(runtime, "writer-fit-owned-two-owners-other", [
+          "other",
+        ]);
+
+        const store = runtime.getCell(
+          signer.did(),
+          "writer-fit-owned-two-owners-store",
+          undefined,
+        );
+        const storeLink = store.getAsNormalizedFullLink();
+        const first = runtime.getCell(
+          signer.did(),
+          "writer-fit-owned-two-owners-piece",
+          undefined,
+        );
+        const firstLink = first.getAsNormalizedFullLink();
+        // The same causal piece at a narrower scope: same id, different
+        // instance, so `runtimeOwnedStoreOwnerKey` gives a different owner.
+        const secondLink = { ...firstLink, scope: "user" } as typeof firstLink;
+
+        const tx = runtime.edit();
+        for (const owner of [firstLink, secondLink]) {
+          const ownerKey = runtimeOwnedStoreOwnerKey(
+            storeLink,
+            owner,
+            runtime.scopeKeyIdentity,
+          );
+          expect(ownerKey).toBeDefined();
+          tx.enrollRuntimeOwnedStore(
+            {
+              space: storeLink.space,
+              scope: storeLink.scope,
+              id: storeLink.id,
+              path: [],
+            },
+            ownerKey!,
+            runtimeWritePolicyAuthorization,
+          );
+        }
+        store.withTx(tx).set({ copied: "public" });
+        expect((await tx.commit()).ok).toBeDefined();
+
+        // The first owner goes; the second still holds the store.
+        runtime.releaseRuntimeOwnedStores(
+          firstLink,
+          runtimeWritePolicyAuthorization,
+        );
+        expect(
+          (await writeSecretInto(
+            runtime,
+            "writer-fit-owned-two-owners-source",
+            "writer-fit-owned-two-owners-store",
+          )).error,
+        ).toBeUndefined();
+
+        // The second goes too, and now nobody does.
+        runtime.releaseRuntimeOwnedStores(
+          secondLink,
+          runtimeWritePolicyAuthorization,
+        );
+        const refused = await writeSecretInto(
+          runtime,
+          "writer-fit-owned-two-owners-other",
+          "writer-fit-owned-two-owners-store",
+          "second",
+        );
+        expect(refused.error?.message).toContain(
+          "writer-fit confidentiality misfit",
+        );
+        expect(refused.error?.message).toContain(`for ${storeLink.id} at /`);
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("keeps the enrollment across a second instantiation", async () => {
+      // The enrollment is released once, with the PIECE, not with each node
+      // group. Every site that re-instantiates a piece — a pattern swap, a
+      // start repair, a withdrawn-contribution recovery — tears the previous
+      // node group down first and instantiates afterwards, so a release hung
+      // on that group would leave a running piece un-enrolled wherever those
+      // two steps were ever ordered the other way. Enrolling twice is what a
+      // re-instantiation does, and it is idempotent.
+
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = newRuntime(storageManager);
+      try {
+        await seedSecretSource(runtime, "writer-fit-owned-reinstate-source");
+
+        const result = runtime.getCell(
+          signer.did(),
+          "writer-fit-owned-reinstate-result",
+          undefined,
+        );
+        const store = runtime.getCell(
+          signer.did(),
+          "writer-fit-owned-reinstate-store",
+          undefined,
+        );
+        const storeId = store.getAsNormalizedFullLink().id;
+
+        // Two instantiations, as a swap or a recovery makes them.
+        for (const _ of [0, 1]) {
+          const tx = runtime.edit();
+          recordRuntimeOwnedStore(runtime, tx, result, store);
+          expect((await tx.commit()).ok).toBeDefined();
+        }
+
+        const declared = await writeSecretInto(
+          runtime,
+          "writer-fit-owned-reinstate-source",
+          "writer-fit-owned-reinstate-store",
+        );
+        expect(declared.error).toBeUndefined();
+
+        // And one release still takes it out: the second enrollment did not
+        // leave a second entry the release would miss.
+        runtime.releaseRuntimeOwnedStores(
+          result.getAsNormalizedFullLink(),
+          runtimeWritePolicyAuthorization,
+        );
+        await seedSecretSource(runtime, "writer-fit-owned-reinstate-other", [
+          "other",
+        ]);
+        const refused = await writeSecretInto(
+          runtime,
+          "writer-fit-owned-reinstate-other",
+          "writer-fit-owned-reinstate-store",
+          "second",
+        );
+        expect(refused.error?.message).toContain(
+          "writer-fit confidentiality misfit",
+        );
+        expect(refused.error?.message).toContain(`for ${storeId} at /`);
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("declares on a document anchored inside a store it owns", async () => {
+      // Anchoring splits one value across two documents. The child's id is
+      // derived from the parent's rather than named by an author, and nothing
+      // but this write puts anything in it, so it is the runtime's store
+      // whenever the parent is.
+
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = newRuntime(storageManager);
+      try {
+        await seedSecretSource(runtime, "writer-fit-owned-anchor-source");
+
+        const tx = runtime.edit();
+        tx.setCfcEnforcementMode("enforce-strict");
+        const source = runtime.getCell(
+          signer.did(),
+          "writer-fit-owned-anchor-source",
+          undefined,
+          tx,
+        );
+        const raw = source.getRaw() as { secret?: string };
+        const result = runtime.getCell(
+          signer.did(),
+          "writer-fit-owned-anchor-result",
+          undefined,
+          tx,
+        );
+        const store = runtime.getCell<{ note: string }[]>(
+          signer.did(),
+          "writer-fit-owned-anchor-store",
+          anchoringList(),
+          tx,
+        );
+        recordRuntimeOwnedStore(runtime, tx, result, store);
+        store.set([{ note: `${raw.secret}!` }]);
+        const storeId = store.getAsNormalizedFullLink().id;
+        tx.prepareCfc();
+        expect((await tx.commit()).ok).toBeDefined();
+
+        // The parent's own write is all links, so it takes shape-only stamps
+        // and is never measured; the content — and the declaration — lands on
+        // the document the write anchored.
+        const declaredOn = writerFitDiagnostics(tx)
+          .filter((flag) =>
+            flag.includes("writer-fit(runtime-owned-store-declared)")
+          );
+        expect(declaredOn.length).toBe(1);
+        expect(declaredOn[0]).not.toContain(storeId);
+        expect(declaredOn[0]).toContain('"secret"');
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("rejects a document anchored inside an ordinary one", async () => {
+      // The negative twin: the same anchored write under a parent the runtime
+      // does not own. The parent's own write is all links, so it is never
+      // measured; the anchored child is, and it is refused, because the
+      // child's ownership comes from the parent's and there is none.
+
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = newRuntime(storageManager);
+      try {
+        await seedSecretSource(runtime, "writer-fit-plain-anchor-source");
+
+        const tx = runtime.edit();
+        tx.setCfcEnforcementMode("enforce-strict");
+        const source = runtime.getCell(
+          signer.did(),
+          "writer-fit-plain-anchor-source",
+          undefined,
+          tx,
+        );
+        const raw = source.getRaw() as { secret?: string };
+        const store = runtime.getCell<{ note: string }[]>(
+          signer.did(),
+          "writer-fit-plain-anchor-store",
+          anchoringList(),
+          tx,
+        );
+        store.set([{ note: `${raw.secret}!` }]);
+        const storeId = store.getAsNormalizedFullLink().id;
+        tx.prepareCfc();
+        const committed = await tx.commit();
+        expect(committed.error?.message).toContain(
+          "writer-fit confidentiality misfit",
+        );
+        expect(committed.error?.message).toContain('"secret"');
+        expect(committed.error?.message).not.toContain(`for ${storeId} at /`);
       } finally {
         await runtime.dispose();
         await storageManager.close();
@@ -1684,7 +2599,7 @@ describe("CFC writer-fit (canWrite, §8.12.4 / SC-18b)", () => {
           },
           tx,
         );
-        recordPieceSubstrate(tx, result, substrate);
+        recordRuntimeOwnedStore(runtime, tx, result, substrate);
         substrate.key("copied").set(`${raw.secret}!`);
         tx.prepareCfc();
         const committed = await tx.commit();
@@ -1731,7 +2646,7 @@ describe("CFC writer-fit (canWrite, §8.12.4 / SC-18b)", () => {
           undefined,
           tx,
         );
-        recordPieceSubstrate(tx, result, substrate.key("copied"));
+        recordRuntimeOwnedStore(runtime, tx, result, substrate.key("copied"));
         substrate.set({ copied: `${raw.secret}!` });
         tx.prepareCfc();
         const committed = await tx.commit();
@@ -1779,7 +2694,7 @@ describe("CFC writer-fit (canWrite, §8.12.4 / SC-18b)", () => {
           undefined,
           tx,
         );
-        recordPieceSubstrate(tx, result, substrate);
+        recordRuntimeOwnedStore(runtime, tx, result, substrate);
         substrate.set({ copied: `${raw.secret}!` });
         const substrateId = substrate.getAsNormalizedFullLink().id;
         tx.prepareCfc();
@@ -1829,7 +2744,7 @@ describe("CFC writer-fit (canWrite, §8.12.4 / SC-18b)", () => {
           undefined,
           tx,
         );
-        recordPieceSubstrate(tx, result, substrate);
+        recordRuntimeOwnedStore(runtime, tx, result, substrate);
         substrate.set({ copied: `${raw.secret}!` });
         const substrateId = substrate.getAsNormalizedFullLink().id;
         tx.prepareCfc();
@@ -1882,7 +2797,7 @@ describe("CFC writer-fit (canWrite, §8.12.4 / SC-18b)", () => {
           undefined,
           tx,
         );
-        recordPieceSubstrate(tx, result, substrate);
+        recordRuntimeOwnedStore(runtime, tx, result, substrate);
         substrate.set({ copied: `${raw.secret}!` });
         const substrateId = substrate.getAsNormalizedFullLink().id;
         tx.prepareCfc();
@@ -1932,7 +2847,7 @@ describe("CFC writer-fit (canWrite, §8.12.4 / SC-18b)", () => {
           undefined,
           tx,
         );
-        recordPieceSubstrate(tx, result, bystander, false);
+        recordRuntimeOwnedStore(runtime, tx, result, bystander, false);
         bystander.set({ note: `${raw.secret}!` });
         const bystanderId = bystander.getAsNormalizedFullLink().id;
         tx.prepareCfc();
@@ -2036,7 +2951,7 @@ describe("CFC writer-fit (canWrite, §8.12.4 / SC-18b)", () => {
           undefined,
           tx,
         );
-        recordPieceSubstrate(tx, result, substrate);
+        recordRuntimeOwnedStore(runtime, tx, result, substrate);
         substrate.set({ copied: `${raw.secret}!` });
         const substrateId = substrate.getAsNormalizedFullLink().id;
         tx.prepareCfc();
@@ -2089,7 +3004,7 @@ describe("CFC writer-fit (canWrite, §8.12.4 / SC-18b)", () => {
             undefined,
             tx,
           );
-          recordPieceSubstrate(tx, result, substrate);
+          recordRuntimeOwnedStore(runtime, tx, result, substrate);
           if (field === "") {
             substrate.set({ first: `${raw.secret}!` });
           } else {
@@ -2160,7 +3075,7 @@ describe("CFC writer-fit (canWrite, §8.12.4 / SC-18b)", () => {
           undefined,
           tx,
         );
-        recordPieceSubstrate(tx, result, substrate);
+        recordRuntimeOwnedStore(runtime, tx, result, substrate);
         substrate.set({ copied: `${raw.secret}!` });
         const substrateId = substrate.getAsNormalizedFullLink().id;
         tx.prepareCfc();

--- a/packages/runner/test/extended-storage-transaction.test.ts
+++ b/packages/runner/test/extended-storage-transaction.test.ts
@@ -11,8 +11,15 @@ import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { Runtime } from "../src/runtime.ts";
-import { createNonReactiveTransaction } from "../src/storage/extended-storage-transaction.ts";
-import { runtimeWritePolicyAuthorization } from "../src/cfc/types.ts";
+import {
+  createNonReactiveTransaction,
+  type ExtendedStorageTransaction,
+} from "../src/storage/extended-storage-transaction.ts";
+import { RuntimeOwnedStores } from "../src/cfc/runtime-owned-stores.ts";
+import {
+  CFC_STRUCTURAL_PROVENANCE_RUNTIME_OWNED_STORE,
+  runtimeWritePolicyAuthorization,
+} from "../src/cfc/types.ts";
 import { type JSONSchema } from "../src/builder/types.ts";
 
 const signer = await Identity.fromPassphrase("extended-storage-transaction");
@@ -242,7 +249,7 @@ describe("extended-storage-transaction", () => {
       ({
         kind: "structural-provenance",
         target: { space, id, scope: "space", path: [] },
-        claim: "runtime.setup.piece-substrate",
+        claim: CFC_STRUCTURAL_PROVENANCE_RUNTIME_OWNED_STORE,
         sources: [],
       }) as const;
 
@@ -307,6 +314,145 @@ describe("extended-storage-transaction", () => {
           runtimeWritePolicyAuthorization,
         );
         expect(tx.isRuntimeWritePolicyInput(input("of:owned"))).toBe(false);
+      } finally {
+        await tx.commit();
+      }
+    });
+  });
+  describe("the enrollment of a store the runtime owns", () => {
+    // The enrollment answers for the whole runtime rather than for one
+    // transaction, which is what carries it to the reactive updates and
+    // settled requests that fill such a store. Every id in it is derivable
+    // from a piece's cause, so the answer takes the runtime's mark: without
+    // it, pattern-authored code reaching `cell.tx` could ask whether a given
+    // piece is running here.
+
+    const address = (id: string) =>
+      ({ space, id, scope: "space", path: [] }) as const;
+
+    it("answers for a store a previous transaction enrolled", async () => {
+      const first = runtime.edit();
+      first.enrollRuntimeOwnedStore(
+        address("of:enrolled"),
+        "owner-key",
+        runtimeWritePolicyAuthorization,
+      );
+      await first.commit();
+
+      const later = runtime.edit();
+      try {
+        expect(
+          later.isRuntimeOwnedStore(
+            space,
+            "of:enrolled",
+            runtimeWritePolicyAuthorization,
+          ),
+        ).toBe(true);
+      } finally {
+        await later.commit();
+      }
+    });
+
+    it("answers `false` to a caller without the runtime's mark", async () => {
+      const tx = runtime.edit();
+      try {
+        tx.enrollRuntimeOwnedStore(
+          address("of:unmarked-reader"),
+          "owner-key",
+          runtimeWritePolicyAuthorization,
+        );
+        expect(tx.isRuntimeOwnedStore(space, "of:unmarked-reader")).toBe(false);
+        expect(
+          tx.isRuntimeOwnedStore(
+            space,
+            "of:unmarked-reader",
+            runtimeWritePolicyAuthorization,
+          ),
+        ).toBe(true);
+      } finally {
+        await tx.commit();
+      }
+    });
+
+    it("is answered through a wrapper as through what it wraps", async () => {
+      const tx = runtime.edit();
+      const wrapper = createNonReactiveTransaction(tx);
+      try {
+        tx.enrollRuntimeOwnedStore(
+          address("of:through-a-wrapper"),
+          "owner-key",
+          runtimeWritePolicyAuthorization,
+        );
+        expect(
+          wrapper.isRuntimeOwnedStore(
+            space,
+            "of:through-a-wrapper",
+            runtimeWritePolicyAuthorization,
+          ),
+        ).toBe(true);
+        expect(
+          wrapper.isRuntimeOwnedStore(space, "of:through-a-wrapper"),
+        ).toBe(false);
+      } finally {
+        await tx.commit();
+      }
+    });
+
+    it("enrolls through a wrapper into what it wraps", async () => {
+      const tx = runtime.edit();
+      const wrapper = createNonReactiveTransaction(tx);
+      try {
+        wrapper.enrollRuntimeOwnedStore(
+          address("of:enrolled-through-a-wrapper"),
+          "owner-key",
+          runtimeWritePolicyAuthorization,
+        );
+        expect(
+          tx.isRuntimeOwnedStore(
+            space,
+            "of:enrolled-through-a-wrapper",
+            runtimeWritePolicyAuthorization,
+          ),
+        ).toBe(true);
+      } finally {
+        await tx.commit();
+      }
+    });
+
+    it("answers for a store enrolled at a different scope instance", async () => {
+      // The store key omits scope deliberately: the scope instances of one
+      // causal cell are instances of the same store, materialized for the
+      // same piece, so an enrollment made while the store was addressed at
+      // one scope has to answer the write that arrives at another. Keying on
+      // scope would enroll whichever instance the runtime minted first and
+      // refuse the rest.
+      const tx = runtime.edit();
+      try {
+        tx.enrollRuntimeOwnedStore(
+          { space, id: "of:scoped-instance", scope: "session", path: [] },
+          "owner-key",
+          runtimeWritePolicyAuthorization,
+        );
+        expect(
+          tx.isRuntimeOwnedStore(
+            space,
+            "of:scoped-instance",
+            runtimeWritePolicyAuthorization,
+          ),
+        ).toBe(true);
+      } finally {
+        await tx.commit();
+      }
+    });
+
+    it("takes one handover of the runtime's set, not two", async () => {
+      // `Runtime.edit` hands its set to every transaction it makes, so a
+      // second handover would swap the set a transaction already answers
+      // from.
+      const tx = runtime.edit() as ExtendedStorageTransaction;
+      try {
+        expect(() => tx.configureRuntimeOwnedStores(new RuntimeOwnedStores()))
+          .toThrow("already configured");
       } finally {
         await tx.commit();
       }

--- a/packages/runner/test/generate-object-cfc-refusal.test.ts
+++ b/packages/runner/test/generate-object-cfc-refusal.test.ts
@@ -25,7 +25,10 @@ import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { createBuilder } from "../src/builder/factory.ts";
 import type { Cell, JSONSchema } from "../src/builder/types.ts";
 import { Runtime } from "../src/runtime.ts";
-import { MAX_ENFORCEMENT_CFC_OPTIONS } from "../src/runtime-presets.ts";
+import {
+  MAX_ENFORCEMENT_CFC_OPTIONS,
+  MAX_ENFORCEMENT_SINK_CEILINGS,
+} from "../src/runtime-presets.ts";
 import { MAX_RETRIES_FOR_REACTIVE } from "../src/scheduler/constants.ts";
 import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
 import { waitForLlmSettled } from "./support/llm-result.ts";
@@ -36,10 +39,10 @@ const space = signer.did();
 
 enableMockMode();
 
-// A caveat the pattern's own result store does not declare. The builtin reads
-// the messages carrying it, so its writes derive that confidentiality, and the
-// undeclared store resolves to the empty ceiling — the writer-fit misfit of
-// §8.12.4, which rejects at `enforce-strict`.
+// A caveat the generateObject sink is not cleared for. The builtin reads the
+// messages carrying it, so the request it stages carries it too, and the
+// ceiling declared for that sink below admits none — the sink-request refusal
+// of §8.12.4, which rejects at `enforce-strict`.
 const PROMPT_INFLUENCE = {
   type: "https://commonfabric.org/cfc/atom/Caveat",
   kind: "https://commonfabric.org/cfc/concepts/prompt-influence",
@@ -78,6 +81,21 @@ describe("generateObject under a refused commit", () => {
       // per-session raise on top of it, and the bundle's persisted flow labels
       // are what make that raise conform.
       cfcEnforcementMode: "enforce-strict",
+      // The bundle declares a ceiling for the fetch and streamData sinks and
+      // none for the LLM ones, so an LLM request is ungated on
+      // confidentiality there. These cases are about the ENDING a refused
+      // request leaves behind, so they declare the ceiling the refusal comes
+      // from. Before the runtime's own stores declared what flowed into them,
+      // the refusal arrived by accident instead: the builtin's result store
+      // could not hold the caveat, so the transaction staging the request was
+      // refused for a reason about the store rather than about the request.
+      cfcSinkMaxConfidentiality: {
+        ...MAX_ENFORCEMENT_SINK_CEILINGS,
+        llm: [],
+        llmDialog: [],
+        generateText: [],
+        generateObject: [],
+      },
     });
     tx = runtime.edit();
     ({ commonfabric } = createTrustedBuilder(runtime));
@@ -161,12 +179,10 @@ describe("generateObject under a refused commit", () => {
     expect(settled.error).toBe(
       "generateObject request was refused before it started",
     );
-    // The pattern is the writer whose write was refused, and the reason names
-    // the document the rule matched on, the confidentiality that did not fit,
-    // and the `source` of each caveat — the principal that introduced it, which
-    // the pattern-facing surface withholds (inv-12 / audit 28b). The refusal
-    // reaches the operator through the log instead.
-    expect(settled.error).not.toContain("writer-fit");
+    // The rule's own reason names the sink, the confidentiality that exceeded
+    // its ceiling, and the `source` of each caveat — the principal that
+    // introduced it, which the pattern-facing surface withholds (inv-12 /
+    // audit 28b). The refusal reaches the operator through the log instead.
     expect(settled.error).not.toContain(PROMPT_INFLUENCE.source);
     expect(settled.error).not.toContain(PROMPT_INFLUENCE.kind);
     // A refused request produces no answer and no record of a conversation:

--- a/packages/runner/test/max-enforcement-posture.test.ts
+++ b/packages/runner/test/max-enforcement-posture.test.ts
@@ -236,6 +236,12 @@ describe("max-enforcement CFC posture as one system (CT-2075)", () => {
       // boundary-scoped admission mechanism described on
       // MAX_ENFORCEMENT_SINK_CEILINGS; when that lands, this test flips to
       // asserting the refusal.
+      //
+      // This case stages the request by hand and writes to no store, so it
+      // pins the SINK's verdict alone. `builtin-abandoned-request.test.ts`
+      // pins the same verdict for a pattern calling the builtin, which is the
+      // path a product takes and the one that was gated by accident until the
+      // §8.12.5 route-2 widening.
       await withPostureRuntime(async (runtime) => {
         const cell = await seedSource(
           runtime,

--- a/packages/runner/test/runtime-owned-stores.test.ts
+++ b/packages/runner/test/runtime-owned-stores.test.ts
@@ -1,0 +1,126 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import {
+  runtimeOwnedStoreKey,
+  runtimeOwnedStoreOwnerKey,
+  RuntimeOwnedStores,
+} from "../src/cfc/runtime-owned-stores.ts";
+import type { NormalizedFullLink } from "../src/link-types.ts";
+
+const SPACE = "did:key:zOwnedStores" as const;
+const OTHER_SPACE = "did:key:zElsewhere" as const;
+
+const identity = { principal: SPACE, sessionId: "session-1" } as Parameters<
+  typeof runtimeOwnedStoreOwnerKey
+>[2];
+
+const link = (
+  id: string,
+  scope?: string,
+  space: string = SPACE,
+): NormalizedFullLink =>
+  ({
+    space,
+    id,
+    path: [],
+    ...(scope !== undefined && { scope }),
+  }) as NormalizedFullLink;
+
+describe("the stores a runtime owns", () => {
+  describe("RuntimeOwnedStores", () => {
+    it("answers for a store an owner enrolled, and not for one nobody did", () => {
+      const stores = new RuntimeOwnedStores();
+      stores.add("store-a", "piece-1");
+      expect(stores.has("store-a")).toBe(true);
+      expect(stores.has("store-b")).toBe(false);
+    });
+
+    it("keeps a store the releasing owner was not the last to hold", () => {
+      // Two scope instances of one causal piece are two owners of one store.
+      const stores = new RuntimeOwnedStores();
+      stores.add("store-a", "piece@space");
+      stores.add("store-a", "piece@session");
+
+      stores.releaseOwner("piece@space");
+      expect(stores.has("store-a")).toBe(true);
+
+      stores.releaseOwner("piece@session");
+      expect(stores.has("store-a")).toBe(false);
+    });
+
+    it("drops only what the released owner held", () => {
+      const stores = new RuntimeOwnedStores();
+      stores.add("store-a", "piece-1");
+      stores.add("store-b", "piece-2");
+
+      stores.releaseOwner("piece-1");
+      expect(stores.has("store-a")).toBe(false);
+      expect(stores.has("store-b")).toBe(true);
+    });
+
+    it("takes a repeated enrollment as the one it already holds", () => {
+      // A re-instantiation enrolls what the instantiation before it did, and
+      // one release still empties the store's owner set.
+      const stores = new RuntimeOwnedStores();
+      stores.add("store-a", "piece-1");
+      stores.add("store-a", "piece-1");
+
+      stores.releaseOwner("piece-1");
+      expect(stores.has("store-a")).toBe(false);
+    });
+
+    it("ignores a release naming an owner it never held", () => {
+      const stores = new RuntimeOwnedStores();
+      stores.add("store-a", "piece-1");
+
+      stores.releaseOwner("piece-2");
+      expect(stores.has("store-a")).toBe(true);
+    });
+  });
+
+  describe("runtimeOwnedStoreKey()", () => {
+    it("names one store across its scoped instances", () => {
+      // Scope addresses an instance of one causal cell rather than naming a
+      // different store (`docs/specs/scoped-cell-instances.md`).
+      expect(runtimeOwnedStoreKey(SPACE, "of:one")).toBe(
+        runtimeOwnedStoreKey(SPACE, "of:one"),
+      );
+      expect(runtimeOwnedStoreKey(SPACE, "of:one")).not.toBe(
+        runtimeOwnedStoreKey(SPACE, "of:two"),
+      );
+      expect(runtimeOwnedStoreKey(SPACE, "of:one")).not.toBe(
+        runtimeOwnedStoreKey(OTHER_SPACE, "of:one"),
+      );
+    });
+  });
+
+  describe("runtimeOwnedStoreOwnerKey()", () => {
+    it("separates the scope instances of one causal piece", () => {
+      const store = link("of:store");
+      const spaceScoped = runtimeOwnedStoreOwnerKey(
+        store,
+        link("of:piece", "space"),
+        identity,
+      );
+      const sessionScoped = runtimeOwnedStoreOwnerKey(
+        store,
+        link("of:piece", "session"),
+        identity,
+      );
+      expect(spaceScoped).toBeDefined();
+      expect(sessionScoped).toBeDefined();
+      expect(spaceScoped).not.toBe(sessionScoped);
+    });
+
+    it("names no owner for a store outside the owner's space", () => {
+      expect(
+        runtimeOwnedStoreOwnerKey(
+          link("of:store", "space", OTHER_SPACE),
+          link("of:piece", "space"),
+          identity,
+        ),
+      ).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
Under `cfcEnforcementMode: "enforce-strict"` with `cfcFlowLabels: "persist"`, a document the runtime materializes to hold a piece's machinery — one no value schema can declare a store policy on — had no route to accept labeled data except while the piece was being set up. Two reproducible refusals, both blocking the dial defaults in #6619:

  writer-fit confidentiality misfit for of:fid1:... at /length
  (canWrite, §8.12.4):
  {"type":".../cfc/atom/User","subject":"did:key:..."} writerId:
  "cf:module/...:__cfLift_72:..."

on a reactive update appending to a list, and

  writer-fit confidentiality misfit for of:fid1:... at / (canWrite,
  §8.12.4): {"type":".../cfc/atom/Caveat",
  "kind":".../prompt-injection-risk-unscreened", ...} writerId:
  "raw:llmDialog:..."

on `llmDialog` writing its own result while the conversation carried a material-risk caveat.

d97be2205 already answers this shape. Where the writing transaction carries a clause the target declares no ceiling for, §8.12.5's route 2 has that same transaction declare a policy covering it — the ceiling that resolved at the path plus exactly the clauses that had nowhere to go — so the fit test passes because the store's policy covers the data. The route ran only on a document the runner had named as a piece's substrate in the transaction doing the naming, which is the setup transaction.

The question to settle first was whether that guard is load-bearing. It is not, and this is what says so rather than a preference. A declared clause list is read two ways, and the two agree: as a write ceiling a label clause is admitted when SOME declared clause subsumes it (§8.12.4), and as a reader's taint the whole list is a conjunction every reader of the path carries. Subsumption means satisfying the declared clause implies satisfying the label it admits, so every reader of the store satisfies every clause the store admits. One upgrade therefore admits more data AND narrows the audience by the same step, and so does the next. Tested rather than argued: four upgrades in four separate transactions accumulate into one `declared` entry carrying all four clauses, and a fifth transaction that reads the store back and writes what it read into an undeclared one is refused naming all four. An unbounded reactive stream of upgrades therefore walks a store's audience INWARD, never outward, and the route needs no bound on how often it fires or on which clauses a later transaction may contribute. Both halves of that experiment are now cases in the file.

So the guard is widened rather than replaced, and the concept it guards is renamed for what it now covers: not a piece's substrate but a store the runtime OWNS. Tracing the two instances found that neither is a piece's substrate, which is why one rule was the right shape. Logging the cause of every document `Runtime.getCell` mints, and matching those causes against the refused ids, named them: the first is a `map` node's result container, keyed `{map, outputSpot}`, and a nested piece's result document, keyed `{resultFor}`; the second is the dialog's own result store, keyed `{llmDialog: {result}}`. All three are minted by the runtime from a node's cause and named by nobody's schema. So is a piece's substrate. The rule covering them is that one sentence.

A claim of ownership has two lifetimes, because a store has two shapes. A store the runtime mints and fills in one transaction — a dialog message, say — is named by the marker alone, as before. A store it KEEPS, written afterwards by reactive updates, event handlers and settled requests each on a transaction of its own, is also ENROLLED: `Runtime.edit` hands every transaction the same `RuntimeOwnedStores`, and `enrollRuntimeOwnedStore` adds to it under the same authorization the marker carries. Which store the runtime owns is a fact about the store rather than about the write, so a later transaction that names nothing finds the answer already recorded.

An enrollment names the piece it was made for and goes out with that piece's nodes. Both halves of that bound it. A store minted per event takes the marker alone, or the enrollment would grow for as long as the piece runs; and the enrollment is released on cancel, or it would grow for as long as the PROCESS runs, since a list operation mints one piece per element and a churning list is unbounded in elements. Enrollment also happens at node instantiation rather than at setup, which is what reaches a piece started from its stored identity — a cold replica loading one never runs setup — and what keeps a setup attempt that never commits from enrolling anything.

Ownership also passes to an anchored document. Anchoring splits one value across two documents, deriving the child's id from the parent's rather than from anything an author named, and nothing but that write puts anything in the child. `anchorValueAsEntity` records the marker for the child whenever the parent is owned, which is what admits the CFC clause atoms `llmDialog` stores as `messageObservations` — each becomes a document of its own holding one `Caveat`, and each was refused by the label it is itself made of. The marker alone suffices there and carries down a nested anchor, whose own parent is the child marked a step earlier.

Every builtin that holds state mints it through one seam now. `ownedCell` mints the document, records the marker and enrolls it, replacing the `getCell` + `scopedCell` pair each builtin wrote out; the twenty-eight sites that had that pair are shorter for it. Only a store keyed on the NODE goes through it. A document the runtime mints from a constant or from the space's own principal — a space cell, a shared clock, a per-space pinned-cell list — is shared by every piece in the space, so one piece's flow join has no business becoming its declared policy, and those keep their own ceilings.

The runner names a piece's own three stores through one seam too: the result document, the argument document and each internal document the result projects to, every address derived from the result cell rather than read back out of stored metadata. That is what lets `sameRootDocument` go — the guard existed to keep a STORED argument link from claiming a host's document, and nothing reads a stored link here. The result document is the one address a caller may have chosen rather than the runtime minted; from the moment setup writes the piece's meta into it, it is that piece's store and nothing else's, and the route reaches every path written there.

One more condition, on the address rather than the recorder: a marker naming a store outside the OWNER's space names nothing. A store elsewhere belongs to whoever holds that space's replicas, so a policy declared on it out of this piece's join would put those bytes behind a promise made here. `llmDialog` mints its per-message documents in the resolved messages array's space, which need not be the node's, so this is reachable rather than theoretical.

Nothing else moves. Every other condition on the route stands: no declaration where a schema declares at the written path, no ungrantable read-failed marker, no container clause naming another space, and no marker without the runtime's authorization. Widening the route in time does not widen it in scope — a bystander document written by a later transaction of the same piece is refused exactly as one written by the setup transaction is — and the route still sits at the strict rung, so every rung below keeps its `writer-fit(persist-and-flag)` diagnostic and stores no declared policy it could never take back. The diagnostic the strict rung records is renamed with the concept, to `writer-fit(runtime-owned-store-declared)`.

Each store this moves onto route 2 gives up whatever refusal its own ceiling was providing, which is a cost outside the store: a transaction that could not commit now commits, so whatever else it staged proceeds. That is the test for which builtins may take the route. One that stages its request as a `sink-request` policy input has a ceiling to move the refusal to; `sqliteQuery` and `navigateTo` stage their effects directly and have none, so their stores keep their own ceilings until the gate that should own them exists.

The LLM sinks are the case where the cost is paid. `MAX_ENFORCEMENT_SINK_CEILINGS` declares ceilings for the fetch and streamData sinks and none for the llm ones, deliberately: its own note says a public-only ceiling would refuse the flows those sinks exist for, and that governing llm release needs a boundary-scoped admission mechanism the posture does not yet carry. What that note did not say is that one path was gated anyway, by accident — a pattern calling `llm` staged its request in the transaction that also wrote the builtin's result store, and the store's misfit refused the commit. It fired on every such call, so under that posture an llm call over caveated content did not work at all, which is the opposite of what the note says the sink is for. It goes now, and the posture's "ungoverned" statement becomes true of the builtin path too.

That path was not pinned. `max-enforcement-posture.test.ts` hand-stages its request and writes to no store, so the writer-fit never applied to it; the four cases in `builtin-abandoned-request.test.ts` that did cover it were using the store's refusal as a lever for testing something else. So the pin is added where the delta is: a pattern calling `llm` over caveated messages, under the bundle exactly as shipped, reaching the mock client. It fails against a reverted route with `llm request was refused before it started`, caused by the misfit. It flips to asserting the refusal when the mechanism the preset names lands. The four cases that were leaning on the store now declare a ceiling for the sink they test and abandon through that instead.

Measured with the strict posture forced on: the agent host's debug-view pattern tests go from one passing of six to six of six, with no writer-fit misfit left in the run; `packages/patterns/untested-apps. test.tsx` goes from seven assertions passing with two commit refusals to seven passing with none.

Nine cases join the writer-fit file beside the existing ones, each verified against a reverted fix. Two positives for the instances above: a list set up in one transaction and appended to in another, and a builtin's result store minted in one turn and written in the next, both committing with the declaration grown to cover the clause. One for the anchored child, and its negative twin under a parent the runtime does not own. One for the release, which takes a piece's enrollments out and leaves the next clause refused, and which an unauthorized caller cannot make. And four negatives, because a change that only ever admits is not a rule: the reader-taint half of the growth experiment above, a bystander written by a later transaction, a marker the runtime did not record, and a store outside the owner's space — each refused with its own id in the reason. Reverting the enrollment fails the two positives and the growth case; reverting the anchored-child marker fails only its own; and making the ownership predicate answer `true` for everything fails every negative along with sixteen that were already there.

Contract text in `docs/specs/cfc-enforcement-matrix.md` §4, which described a route that only ran at setup, and the SC-18 notes in `docs/specs/cfc-spec-changes.md`, which now carry the two-readings argument beside the meta-seam and computed-cell narrowings it sits with. Both also carry what the route costs outside the store — the transaction that now commits, and the conjunction a long-lived declaration can walk to an audience nobody satisfies, which is §8.12.2's ratchet reaching its end and refuses rather than discloses.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6740?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

ACCEPT_COVERAGE_DEBT: packages/cf-harness +23 lines
ACCEPT_COVERAGE_DEBT: packages/runner +8 lines