### PR TITLE
feat(shuttle): scaffold the package

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -37,6 +37,7 @@
     "./packages/runner",
     "./packages/runtime-client",
     "./packages/shell",
+    "./packages/shuttle",
     "./packages/spec-model",
     "./packages/state-inspector",
     "./packages/static",

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -162,7 +162,8 @@ a record: archive it to `docs/history/plans/` following the procedure in
   mutable current place — the context that fills in the omitted levels of the
   fabric's right-anchored references — plus full-screen live views, for
   inspecting and editing space and piece state. Decisions so far and open
-  questions; nothing is built yet.
+  questions; construction is under way, in the order its
+  [build sequence](shuttle/build-sequence.md) sets out.
 - [Shell completion coverage](cli-completion-coverage.md) sequences the work
   that makes `cf completion` answer correctly across the surface it claims and
   reach the verb surface it does not: the slots that offer a wrong candidate,

--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -90,11 +90,19 @@ recorded limit; the PR is whichever the review rules.
 
 ## Stage B — the shuttle package
 
-**B0 — scaffold** (after A1). `packages/shuttle` with its path in the root
-`deno.jsonc` workspace array and its own `tasks.test` entry — the two
-edits a new package needs, the second one load-bearing. Dependencies
-follow `docs/development/DEPENDENCIES.md`. No behavior; the package
-compiles and its empty test task runs.
+**B0 — scaffold** (after A1). Done. `packages/shuttle` is a workspace
+member: its path sits in the root `deno.jsonc` workspace array, and its
+own `deno.jsonc` carries the `tasks.test` entry — without which a
+`deno task test` run there resolves the root workspace task instead and
+re-runs the whole suite inside itself. The scaffold is configuration
+alone: no package name and no exports, because nothing imports shuttle
+and an export entry is a contract, and no dependency, because
+`deno task check-unused-deps` fails an alias no source file imports. It
+ships no source either. That is what the working rule below asks for —
+shuttle joins `deno task check`'s path list with B1's code — and it
+leaves `coverage-debt: packages/shuttle`, a metric group the gate
+derives from the path with no allowlist, at zero, so B1 lands its code
+and the tests covering it together.
 
 **B1 — walking skeleton** (after A1; A2 for nothing yet). The place value
 and its owner module — the whole pair, position *and* scope, because scope

--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -90,8 +90,9 @@ recorded limit; the PR is whichever the review rules.
 
 ## Stage B — the shuttle package
 
-**B0 — scaffold** (after A1). Done. `packages/shuttle` is a workspace
-member: its path sits in the root `deno.jsonc` workspace array, and its
+**B0 — scaffold** (after A1). Done (#6741). `packages/shuttle` is a
+workspace member: its path sits in the root `deno.jsonc` workspace array,
+and its
 own `deno.jsonc` carries the `tasks.test` entry — without which a
 `deno task test` run there resolves the root workspace task instead and
 re-runs the whole suite inside itself. The scaffold is configuration

--- a/packages/shuttle/deno.jsonc
+++ b/packages/shuttle/deno.jsonc
@@ -1,0 +1,6 @@
+{
+  // Dependency guide: ../../docs/development/DEPENDENCIES.md
+  "tasks": {
+    "test": "echo 'No tests defined.'"
+  }
+}


### PR DESCRIPTION
## Why

Stage B of the shuttle build needs a workspace member to put code in. This
creates one, and nothing else: `packages/shuttle` compiles and its test task
runs. The walking skeleton is B1.

The reason this is its own PR rather than the first commit of B1 is the
second of the two edits AGENTS.md requires. A new package needs its path in
the root `deno.jsonc` workspace array **and** a `tasks.test` entry of its
own — and without the second, `deno task test` in that directory falls
through to the root workspace task and re-runs the entire suite inside
itself, spawning processes until CI times out. That failure is silent until
it is expensive, so it is worth landing and verifying by itself.

First of the stage-B milestones behind the merged shuttle design (#6537),
after the stage-A seam work (#6626, #6646, #6676, #6682, #6704, #6705, and
#6717).

## What Changed

```jsonc
{
  // Dependency guide: ../../docs/development/DEPENDENCIES.md
  "tasks": {
    "test": "echo 'No tests defined.'"
  }
}
```

That is the entire package. Four decisions behind it, each checked rather
than assumed:

**Configuration only, no source.** The plan's own working rule holds shuttle
out of `tasks/typecheck.ts` until the PR that gives it real code, so a source
file landing here would be type-checked by nothing. And a new package
inherits the zero-increase coverage gate automatically — `metricGroupFor`
derives `packages/<name>` from the path with no allowlist — so an untested
source file would move `coverage-debt: packages/shuttle` off zero on the PR
that creates the package.

**`echo` rather than `deno test`.** `deno test` fails outright with no test
modules, and `--permit-no-files` would be a gate that stays green if B1's
test glob later matches nothing. AGENTS.md names the echo form for a package
without tests yet; `packages/patterns/auth` is the existing instance.

**No `name`, no `exports`.** Nothing imports shuttle — it is a leaf, and an
export entry is a contract with nothing behind it. Deno warns on every task
invocation for a `name` without `exports`, and the workspace members that
omit both are exactly the leaf applications: `dashboard`, `toolshed`,
`patterns/auth`.

**No dependencies.** `node:readline` is B1's need, and
`deno task check-unused-deps` fails a declared-but-unimported entry.

`docs/plans/README.md` said the shuttle plan had nothing built yet. This
change is what falsifies that, so it moves in the same change.

## Test plan

Gates, serially: `deno fmt --check`, `deno lint`, `deno task check`,
`deno task check-docs`, `check-unused-deps`, `check-single-copy-deps`,
`check-deno-pins`, `check-package-cycles` — all pass.

The load-bearing check, run in `packages/shuttle`:

```
$ deno task test
Task test echo 'No tests defined.'
No tests defined.
```

It resolves locally rather than recursing. The negative half was confirmed
with `deno task` in list-only form: with the entry present, `test` is the
package's own; with it removed, the same directory resolves
`test (workspace) → ./tasks/test.ts`, which is the recursion AGENTS.md warns
about.

The root task's selection layer was probed directly rather than by running
the browser-launching suite: the workspace resolves one unit for shuttle, no
internal sharding, default weight, not JUnit-capable — the same shape as
`patterns/auth`. `tasks/workspace-tests.test.ts` passes, including its case
that reads the real workspace manifests.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6741?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

