### PR TITLE
Serve the patterns route beside a self-hosted storage server

### DIFF
--- a/docs/common/patterns/multi-user-patterns.md
+++ b/docs/common/patterns/multi-user-patterns.md
@@ -625,7 +625,11 @@ Three escalating options:
    (`packages/patterns/integration/multi-runtime-harness.ts`): opens an
    existing piece in several worker-isolated runtimes (distinct identities,
    or one identity in two sessions); supports trusted-surface CFC events
-   headlessly. See `cfc-group-chat-demo-multi-runtime.test.ts`.
+   headlessly. It serves the authored patterns tree beside its in-process
+   storage server, so a `#profile` wish opens the real create surface and a
+   pattern whose identity is a profile cell can be driven without a test seam
+   standing in for one. See `cfc-group-chat-demo-multi-runtime.test.ts` and
+   `profile-create-surface-multi-runtime.test.ts`.
 3. **Two simultaneous browsers**
    (`cfc-group-chat-demo-two-browsers.test.ts`,
    `lunch-poll-vote.test.ts`): guards the real DOM input binding /

--- a/docs/specs/pattern-imports/pattern-updates.md
+++ b/docs/specs/pattern-imports/pattern-updates.md
@@ -413,14 +413,14 @@ prior state rather than a schema.
 
 ## System-source patterns — the loop
 
-**Toolshed side (memoized per file for the process lifetime; patterns are fixed
-for a toolshed's lifetime).** Add a `?identity` query param to the pattern route
-(`patterns.routes.ts`). For a requested file: walk its authored import closure
-via single-file reads (works in a compiled binary — no directory enumeration) →
-hash the **pristine** authored bytes → return the entry identity. **No
-type-check, no emit** — the light computation (`resolveEntryIdentity` in the
-runner). The worker independently checks the result by compiling the downloaded
-closure and comparing its compiler-produced entry identity.
+**Serving side (memoized per file for the process lifetime; patterns are fixed
+for a host's lifetime).** The pattern route answers a `?identity` query param.
+For a requested file: walk its authored import closure via single-file reads
+(works in a compiled binary — no directory enumeration) → hash the **pristine**
+authored bytes → return the entry identity. **No type-check, no emit** — the
+light computation (`resolveEntryIdentity` in the runner). The worker
+independently checks the result by compiling the downloaded closure and
+comparing its compiler-produced entry identity.
 
 Two implementation facts make the light identity equal what the worker stores as
 `patternIdentity`, verified by a parity test against the real `default-app.tsx`
@@ -433,9 +433,12 @@ and `home.tsx`:
 - **Name modules by their URL pathname.** A module's identity folds in its
   authored path (`computeModuleHashes`). The worker compiles system patterns
   over HTTP, where `HttpProgramResolver` names every module by its URL pathname
-  (`/api/patterns/…`). The toolshed therefore computes `?identity` over
+  (`/api/patterns/…`). The route therefore computes `?identity` over
   pathname-prefixed names — **not** patterns-root-relative names — or the two
-  identities never match and the check re-updates forever.
+  identities never match and the check re-updates forever. That computation is
+  the runner's `PatternsRoute`, which every host mounts rather than reproduces,
+  because a host whose answer differed by a byte would be one no runtime could
+  adopt.
 
 Both the `?identity` representation and every source-module representation use
 strong checksum `ETag`s with `Cache-Control: public, no-cache`. The identity

--- a/docs/specs/pattern-imports/pattern-updates.md
+++ b/docs/specs/pattern-imports/pattern-updates.md
@@ -96,7 +96,7 @@ during that implementation are archived at
 | `SourceReconciler` | `packages/runner/src/source-reconciler.ts` | Origin resolution, identity lookup, verified closure compile, and the guarded transition — one path for every piece |
 | Space root: `spaceCell.defaultPattern` link → root piece → `patternIdentity` | `packages/piece/src/ops/pieces-controller.ts` (`linkDefaultPattern`/`getDefaultPattern`) | What a system update rewrites |
 | `ensureDefaultPattern` (resolve → follow the origin → start) / `recreateDefaultPattern` (manual, **not** state-preserving) | `packages/piece/src/ops/pieces-controller.ts` | The root's open path and its repair ladder, and the state-losing escape hatch (recreate); both URL-based creation paths stamp `patternSource` |
-| System patterns = **raw TSX served by path**, bundled via `deno compile --include`; **no name→identity manifest** | `packages/toolshed/routes/patterns/patterns-server.ts`, `patterns.routes.ts` | Where the current system source + its identity come from |
+| System patterns = **raw TSX served by path**, bundled via `deno compile --include`; **no name→identity manifest** | `packages/runner/src/harness/patterns-route.deno.ts` defines the route; `packages/toolshed/routes/patterns/patterns-server.ts` and `patterns.routes.ts` name this deployment's directories and wire it into the server | Where the current system source + its identity come from |
 | Per-space host resolution: `mappedHostFor(space)` / `registerSpaceHost` (3-tier: seed `spaceHostMap` → learned site-table → default) | `Runtime.mappedHostFor` / `registerSpaceHost` in `packages/runner/src/runtime.ts`, `storage/v2-remote-session.ts` | Which toolshed a space's source is fetched from |
 | Identity computation: `transformInjectHelperModule` + `computeModuleIdentities` | `harness/pretransform.ts`, `sandbox/module-record-compiler.ts` | What toolshed runs to answer `?identity` |
 | Entry-doc `annotations` + `annotatePattern` | `pattern-manager.ts`, `cell-cache.ts` | **Rejected as the carrier** — see below |
@@ -535,11 +535,15 @@ binary populates from baked build metadata; the updater does not consult it.
 
 ## Build sketch (seams)
 
-- **Toolshed**: `?identity` handler + boot-time `{ name → identity }` cache in
-  the patterns route (`patterns.routes.ts` / `patterns.handlers.ts` /
-  `patterns-server.ts`); strong checksum `ETag` + mandatory revalidation for
-  identity and source responses; import `computeModuleIdentities` +
-  `transformInjectHelperModule` from the runner.
+- **Patterns route**: `?identity` handler + per-process `{ name → identity }`
+  cache, and strong checksum `ETag` + mandatory revalidation for identity and
+  source responses. All of it lives in the runner
+  (`harness/patterns-route.deno.ts`), beside `computeModuleIdentities` and
+  `transformInjectHelperModule`, because the identity it answers with is the
+  one a worker computes from the same source. A host supplies the directories
+  and mounts the route: toolshed at `patterns.routes.ts` /
+  `patterns.handlers.ts` / `patterns-server.ts`, and a self-hosted test
+  harness beside its own storage server.
 - **Runtime worker**: `SourceReconciler` owns per-space host resolution,
   conditionally revalidated `?identity` and source-closure fetches, locally
   compiled source-closure verification, and the guarded transition. The piece

--- a/packages/memory/test/v2/standalone-http.test.ts
+++ b/packages/memory/test/v2/standalone-http.test.ts
@@ -17,6 +17,22 @@ describe("standalone memory HTTP", () => {
     }
   });
 
+  it("reports itself up even behind a handler that answers everything", async () => {
+    // Whether the host is up is the host's own business. A caller mounting a
+    // broad handler would otherwise decide it, and a client whose health
+    // probe fails never opens a connection at all.
+
+    const server = StandaloneMemoryServer.start({
+      serve: () => new Response("mounted", { status: 200 }),
+    });
+    try {
+      const response = await fetch(new URL("/_health", server.url));
+      expect(await response.json()).toMatchObject({ status: "OK" });
+    } finally {
+      await server.close();
+    }
+  });
+
   it("asks a route it does not serve to upgrade instead", async () => {
     // A bare storage host has no patterns route, and a body answered `200`
     // is one a client compiles as the source it asked for.

--- a/packages/memory/test/v2/standalone-http.test.ts
+++ b/packages/memory/test/v2/standalone-http.test.ts
@@ -1,0 +1,80 @@
+/** Tests what the standalone memory host answers to ordinary HTTP requests. */
+
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import { StandaloneMemoryServer } from "../../v2/standalone.ts";
+
+describe("standalone memory HTTP", () => {
+  it("reports itself up on the health route", async () => {
+    const server = StandaloneMemoryServer.start();
+    try {
+      const response = await fetch(new URL("/_health", server.url));
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({ status: "OK" });
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("asks a route it does not serve to upgrade instead", async () => {
+    // A bare storage host has no patterns route, and a body answered `200`
+    // is one a client compiles as the source it asked for.
+
+    const server = StandaloneMemoryServer.start();
+    try {
+      const response = await fetch(
+        new URL("/api/patterns/system/profile-create.tsx", server.url),
+      );
+      expect(response.status).toBe(426);
+      expect(response.headers.get("Upgrade")).toBe("websocket");
+      expect(await response.text()).toContain("Upgrade: websocket");
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("answers with what the caller's handler returns", async () => {
+    const server = StandaloneMemoryServer.start({
+      serve: (request) =>
+        new Response(new URL(request.url).pathname, { status: 200 }),
+    });
+    try {
+      const response = await fetch(new URL("/anything", server.url));
+      expect(response.status).toBe(200);
+      expect(await response.text()).toBe("/anything");
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("cites a specification of the protocol it asks for", async () => {
+    // Read the path back out of the body and resolve it, rather than matching
+    // the words: a test that only checked the words would keep passing after
+    // the document it names moved.
+
+    const server = StandaloneMemoryServer.start();
+    try {
+      const response = await fetch(new URL("/anything", server.url));
+      const cited = /\bdocs\/\S+\.md\b/.exec(await response.text())?.[0];
+      expect(cited).toBeDefined();
+      const repositoryRoot = new URL("../../../../", import.meta.url);
+      expect((await Deno.stat(new URL(cited!, repositoryRoot))).isFile)
+        .toBe(true);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("asks a request the caller's handler declines to upgrade", async () => {
+    const server = StandaloneMemoryServer.start({ serve: () => undefined });
+    try {
+      const response = await fetch(new URL("/anything", server.url));
+      expect(response.status).toBe(426);
+      expect(response.headers.get("Upgrade")).toBe("websocket");
+      expect(await response.text()).toContain("Upgrade: websocket");
+    } finally {
+      await server.close();
+    }
+  });
+});

--- a/packages/memory/v2/standalone.ts
+++ b/packages/memory/v2/standalone.ts
@@ -8,6 +8,16 @@
  * without a toolshed process. Used by multi-runtime test harnesses
  * (`cf test` multi-user mode, packages/patterns integration tests).
  *
+ * A runtime addresses far more than storage at the host it is given: the
+ * health probe every client opens with, the patterns route, the
+ * language-model route, the blob routes. The health probe is answered here,
+ * because this server is what occupies the address and so is what can say it
+ * is up. The rest reach `serve`, and whatever the caller does not answer
+ * there is told the one thing that is true of this address: it speaks the
+ * memory websocket protocol, so upgrade. That is what a runtime asking a bare
+ * storage host for a route it does not have hears, and it carries a status
+ * that stops the answer being read as the thing that was asked for.
+ *
  * Deno-only (uses `Deno.serve`); keep this export path out of browser
  * bundles.
  */
@@ -35,6 +45,49 @@ const authorizeSessionOpen = (
   message: Parameters<typeof verifySessionOpenAuthorization>[0],
   context: Parameters<typeof verifySessionOpenAuthorization>[1],
 ): Promise<string> => verifySessionOpenAuthorization(message, context);
+
+/** Where a client asks whether the host serving its space is reachable. */
+const HEALTH_ROUTE = "/_health";
+
+/**
+ * The words the `426` below carries, for a reader rather than a parser.
+ *
+ * The citation names the repository before the path. A reader holding this
+ * response has just learned that a path on this host is answered with it, so
+ * a bare path invites the request that produced what they are reading.
+ */
+const UPGRADE_REQUIRED_BODY =
+  `This is a Common Fabric memory endpoint. It speaks the memory protocol
+over a websocket, so connect with an \`Upgrade: websocket\` request.
+Nothing here answers the request you just sent.
+
+The protocol is specified in the source repository, at
+docs/specs/memory-v2/04-protocol.md.
+`;
+
+/**
+ * What a plain HTTP request nothing else answered is told.
+ *
+ * `426` is the status for a server that will not answer over the protocol it
+ * was asked in but would answer over another, and its `Upgrade` header names
+ * that other one. It fits this address exactly: the websocket handshake is
+ * itself a `GET`, so the method was never the problem — the missing `Upgrade`
+ * header was.
+ *
+ * The body says as much in words, for whoever is holding the response rather
+ * than parsing it: a person who reached the address with `curl`, or one
+ * reading a log that printed what a fetch came back with.
+ */
+function upgradeRequired(): Response {
+  return new Response(UPGRADE_REQUIRED_BODY, {
+    status: 426,
+    headers: {
+      "content-type": "text/plain; charset=utf-8",
+      upgrade: "websocket",
+      connection: "Upgrade",
+    },
+  });
+}
 
 let nextConnectionTag = 0;
 
@@ -64,6 +117,12 @@ export class StandaloneMemoryServer {
         mode: MemoryServer.MemoryAclMode;
         serviceDids?: readonly string[];
       };
+
+      /** Answers the non-websocket requests this address receives. Anything
+       *  it declines, by answering `undefined`, is told to upgrade. */
+      serve?: (
+        request: Request,
+      ) => Response | undefined | Promise<Response | undefined>;
     } = {},
   ): StandaloneMemoryServer {
     const memory = new MemoryServer.Server({
@@ -80,7 +139,16 @@ export class StandaloneMemoryServer {
       onListen: () => {},
     }, (request) => {
       if (request.headers.get("upgrade")?.toLowerCase() !== "websocket") {
-        return new Response("memory websocket endpoint", { status: 200 });
+        if (new URL(request.url).pathname === HEALTH_ROUTE) {
+          return Response.json({
+            status: "OK",
+            timestamp: Date.now(),
+            gitSha: null,
+          });
+        }
+        return Promise.resolve(options.serve?.(request)).then((response) =>
+          response ?? upgradeRequired()
+        );
       }
       const { socket, response } = Deno.upgradeWebSocket(request);
       socket.binaryType = "arraybuffer";

--- a/packages/patterns/cfc-spec-gallery/main.test.tsx
+++ b/packages/patterns/cfc-spec-gallery/main.test.tsx
@@ -1,4 +1,5 @@
-import { assert, handler, pattern, Stream, TESTS } from "commonfabric";
+import { assert, handler, pattern, Stream, TESTS, UI } from "commonfabric";
+import { findNode, propsOf, readValue } from "../test/vnode-helpers.ts";
 import Gallery from "./main.tsx";
 
 const trigger = handler<void, { stream: Stream<void> }>((_, { stream }) => {
@@ -63,6 +64,16 @@ export default pattern(() => {
   });
 
   const assert_count = assert(() => instance.totalExamples === 16);
+  // Reaching into the rendered view is what builds it. Every card here is a
+  // call to one of this pattern's view helpers, and nothing else in this file
+  // asks for the view, so without this they run only where a browser renders
+  // the gallery — which is to say on some CI runs and not others.
+  const assert_renders_header = assert(() =>
+    findNode(instance[UI], (node) => {
+      const props = propsOf(node);
+      return props !== undefined && readValue(props["id"]) === "gallery-count";
+    }) !== undefined
+  );
   const assert_forward_prepared = assert(() => instance.completedCount === 0);
   const assert_forward_committed = assert(() =>
     instance.completedCount === 1 &&
@@ -93,6 +104,7 @@ export default pattern(() => {
   return {
     [TESTS]: [
       { assertion: assert_count },
+      { assertion: assert_renders_header },
       { action: action_change_forward_recipient },
       { action: action_prepare_forward },
       { assertion: assert_forward_prepared },

--- a/packages/patterns/cfc-spec-gallery/main.test.tsx
+++ b/packages/patterns/cfc-spec-gallery/main.test.tsx
@@ -1,5 +1,5 @@
 import { assert, handler, pattern, Stream, TESTS, UI } from "commonfabric";
-import { findNode, propsOf, readValue } from "../test/vnode-helpers.ts";
+import { findNodeById, hasText } from "../test/vnode-helpers.ts";
 import Gallery from "./main.tsx";
 
 const trigger = handler<void, { stream: Stream<void> }>((_, { stream }) => {
@@ -69,10 +69,7 @@ export default pattern(() => {
   // asks for the view, so without this they run only where a browser renders
   // the gallery — which is to say on some CI runs and not others.
   const assert_renders_header = assert(() =>
-    findNode(instance[UI], (node) => {
-      const props = propsOf(node);
-      return props !== undefined && readValue(props["id"]) === "gallery-count";
-    }) !== undefined
+    hasText(findNodeById(instance[UI], "gallery-count"), "16 total examples")
   );
   const assert_forward_prepared = assert(() => instance.completedCount === 0);
   const assert_forward_committed = assert(() =>

--- a/packages/patterns/integration/fixtures/lunch-poll-keyed-votes/main.tsx
+++ b/packages/patterns/integration/fixtures/lunch-poll-keyed-votes/main.tsx
@@ -29,9 +29,10 @@ import LunchPoll, {
  *
  * Two jobs, neither of which changes what the poll does.
  *
- * IDENTITY. The poll's identity is a shared `#profile` cell, and that wish does
- * not resolve in the multi-runtime harness's self-hosted server, so a session
- * there can never join and never vote. `claim` supplies what the wish would: a
+ * IDENTITY. The poll's identity is a shared `#profile` cell. In a space holding
+ * no profile that wish resolves to the surface offering to create one, so a
+ * session there has nothing to join or vote with until somebody uses it.
+ * `claim` supplies what a resolved wish would: a
  * shared-space profile per claimed name, handed to the poll through its
  * `overrideViewer` seam. One session claims "Alice", another claims "Bob", and
  * the poll sees two participants whose identities are two distinct documents —

--- a/packages/patterns/integration/fixtures/profile-create-surface.tsx
+++ b/packages/patterns/integration/fixtures/profile-create-surface.tsx
@@ -1,0 +1,23 @@
+/// <cts-enable />
+// FIXTURE (multi-runtime integration): wishes for `#profile` in a space that
+// holds none, which is what makes the runtime open the profile-create surface.
+//
+// The whole wish state is on the output, not just its `result`, so the test
+// can walk into the `[UI]` node the wish renders and reach the surface's own
+// piece behind it.
+import { NAME, pattern, UI, type VNode, wish } from "commonfabric";
+
+interface Output {
+  [NAME]: string;
+  [UI]: VNode;
+  profile: unknown;
+}
+
+export default pattern<void, Output>(() => {
+  const profile = wish<unknown>({ query: "#profile" });
+  return {
+    [NAME]: "profile-create-surface (multi-runtime fixture)",
+    [UI]: <div>{profile[UI]}</div>,
+    profile,
+  };
+});

--- a/packages/patterns/integration/lunch-poll-keyed-votes.test.ts
+++ b/packages/patterns/integration/lunch-poll-keyed-votes.test.ts
@@ -30,10 +30,12 @@
  * rolled-back writes keyed against 63 whole-list (2026-09-01, this harness), so
  * the bound of one per vote sits between them with room either side.
  *
- * The poll's identity is a shared `#profile` cell and that wish does not resolve
- * in this harness, so the sessions claim identities through the
- * `lunch-poll-keyed-votes` fixture. Everything under test is the poll's own
- * handlers, driven through the poll's own streams.
+ * The poll's identity is a shared `#profile` cell. The wish resolves in this
+ * harness, and in a space holding no profile it resolves to the surface that
+ * offers to create one — not to an identity a session can vote with. So the
+ * sessions claim identities through the `lunch-poll-keyed-votes` fixture, and
+ * everything under test is the poll's own handlers, driven through the poll's
+ * own streams.
  *
  * No toolshed or browser required (Deno workers + in-process storage server).
  */

--- a/packages/patterns/integration/multi-runtime-harness.ts
+++ b/packages/patterns/integration/multi-runtime-harness.ts
@@ -16,8 +16,11 @@
  * runtimes (verified-load registries, frame stacks and similar module-level
  * state cross-talk), and production never does — every browser tab or CLI
  * process is its own realm. The storage server is self-hosted in-process
- * (@commonfabric/memory/v2/standalone), so no toolshed is needed; pass
- * `apiUrl` to target a running toolshed instead.
+ * (@commonfabric/memory/v2/standalone), and serves the authored patterns tree
+ * beside it, so no toolshed is needed; pass `apiUrl` to target a running
+ * toolshed instead. Serving that tree is what lets a session resolve a
+ * `system:` origin, and so what lets a `#profile` wish open its real create
+ * surface rather than an account of why it could not.
  *
  * POSTURE (server-execution v2): the self-hosted standalone server has no
  * serving host — no ExecutorHost, no serving loop — and its engine reads
@@ -36,6 +39,8 @@
  * to before: flag unset or false keeps the in-process standalone server.
  */
 
+import { fromFileUrl } from "@std/path/from-file-url";
+
 import type { FabricValue } from "@commonfabric/data-model";
 import {
   fabricFromRealmValue,
@@ -46,6 +51,7 @@ import { Identity } from "@commonfabric/identity";
 import { StandaloneMemoryServer } from "@commonfabric/memory/v2/standalone";
 import { SERVER_EXECUTION_DEFAULT_ENABLED } from "@commonfabric/memory/v2/server-execution-default";
 import { experimentalOptionsFromEnv } from "@commonfabric/runner";
+import { PatternsRoute } from "@commonfabric/runner/patterns-route.deno";
 import {
   type RuntimeDiagnosticsSnapshot,
   type TrustedUiDescriptor,
@@ -114,6 +120,27 @@ const RPC_TIMEOUT_MS = 120_000;
  * ~2–3 s serving drain of a 40-event pipelined storm, small against the
  * suite timeouts a wedged consequence would otherwise eat. */
 const SERVED_SETTLE_QUIESCENCE_BUDGET_MS = 10_000;
+
+/**
+ * The authored patterns tree this repository deploys, served at the same
+ * address as the in-process storage server.
+ *
+ * A runtime resolves a `system:` provenance ref — the origin the wish
+ * builtin's sidecar surfaces record, and the one a space root carries —
+ * against the host serving its space. Self-hosting storage and leaving that
+ * route unanswered is a topology no deployment has, and under it a piece
+ * whose identity is a profile cell never gets its create surface. Answering it
+ * here is what lets a headless multi-runtime test drive the real resolution.
+ *
+ * One route for the process: it computes each pattern's closure identity once
+ * and holds it, and every harness in a run wants the same answers.
+ */
+let patternsRoute: PatternsRoute | undefined;
+function systemPatternsRoute(): PatternsRoute {
+  return patternsRoute ??= new PatternsRoute(
+    fromFileUrl(new URL("..", import.meta.url)),
+  );
+}
 
 class WorkerClient {
   #worker: Worker;
@@ -450,7 +477,9 @@ export class MultiRuntimeHarness {
         SERVER_EXECUTION_DEFAULT_ENABLED;
     const targetUrl = options.apiUrl ??
       (serverExecutionOn ? new URL(env.API_URL) : undefined);
-    const server = targetUrl ? undefined : StandaloneMemoryServer.start();
+    const server = targetUrl ? undefined : StandaloneMemoryServer.start({
+      serve: (request) => systemPatternsRoute().serve(request),
+    });
     const apiUrl = (targetUrl ?? server!.url).href;
 
     const sessions: MultiRuntimeSession[] = [];

--- a/packages/patterns/integration/profile-create-surface-multi-runtime.test.ts
+++ b/packages/patterns/integration/profile-create-surface-multi-runtime.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Multi-runtime regression test: a `#profile` wish in a space with no profile
+ * opens the real profile-create surface.
+ *
+ * The surface is a system pattern the runtime fetches from the host serving
+ * the space, under `system:system/profile-create.tsx`. A harness that hosts
+ * storage in-process and leaves that route unanswered has no way to open it,
+ * so a pattern whose identity is a profile cell could only ever be driven
+ * through the seams its own tests supply. Serving the patterns tree beside the
+ * storage server is what closes that gap, and this is the test that says so:
+ * it walks from the wish's `[UI]` node into the surface's own piece and reads
+ * the name that only the compiled system pattern produces.
+ *
+ * No toolshed or browser required (Deno workers + in-process storage server).
+ */
+
+import { expect } from "@std/expect";
+import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
+import { join } from "@std/path";
+import {
+  MultiRuntimeHarness,
+  type MultiRuntimeSession,
+} from "./multi-runtime-harness.ts";
+
+const PROGRAM_PATH = join(
+  import.meta.dirname!,
+  "fixtures",
+  "profile-create-surface.tsx",
+);
+const ROOT_PATH = join(import.meta.dirname!, "..");
+
+// The wish renders `<cf-render $cell={…}>`, whose `$cell` prop is the piece
+// the surface runs in. Reading through it reaches that piece's own output.
+const SURFACE_PIECE = ["profile", "$UI", "props", "$cell"];
+
+describe("profile-create surface across runtimes", () => {
+  let harness: MultiRuntimeHarness;
+  let alice: MultiRuntimeSession;
+  let bob: MultiRuntimeSession;
+
+  beforeAll(async () => {
+    harness = await MultiRuntimeHarness.create({
+      programPath: PROGRAM_PATH,
+      rootPath: ROOT_PATH,
+      sessions: ["alice", "bob"],
+    });
+    alice = harness.session("alice");
+    bob = harness.session("bob");
+  });
+
+  afterAll(async () => {
+    await harness?.dispose();
+  });
+
+  it("runs the compiled system pattern for the session that opened it", async () => {
+    await harness.settle();
+    expect(await alice.readRaw([...SURFACE_PIECE, "$NAME"])).toBe(
+      "Create Profile",
+    );
+  });
+
+  it("runs it for a session that only ever saw the stored piece", async () => {
+    await harness.settle();
+    expect(await bob.readRaw([...SURFACE_PIECE, "$NAME"])).toBe(
+      "Create Profile",
+    );
+  });
+});

--- a/packages/runner/deno.jsonc
+++ b/packages/runner/deno.jsonc
@@ -40,6 +40,7 @@
     "./storage/v2": "./src/storage/v2.ts",
     "./storage/cache.deno": "./src/storage/cache.deno.ts",
     "./local-program.deno": "./src/harness/local-program.deno.ts",
+    "./patterns-route.deno": "./src/harness/patterns-route.deno.ts",
     "./toolshed-http-auth": "./src/toolshed-http-auth.ts",
     "./cfc": "./src/cfc/mod.ts",
     "./cfc/label-view-core": "./src/cfc/label-view-core.ts",

--- a/packages/runner/src/harness/patterns-route.deno.ts
+++ b/packages/runner/src/harness/patterns-route.deno.ts
@@ -83,14 +83,25 @@ export class PatternsRoute {
     }));
   }
 
-  /** A pattern file's content as bytes. */
+  /**
+   * A pattern file's content as bytes.
+   *
+   * A path that names no file is not found, whichever of the three ways it
+   * fails to name one: nothing is there, it names a directory, or it
+   * continues below a file. The read reports each differently, and a caller
+   * asking for a pattern has the same answer for all three.
+   */
   async get(filename: string): Promise<Uint8Array> {
     const url = this.#resolve(filename);
 
     try {
       return await Deno.readFile(url);
     } catch (error) {
-      if (error instanceof Deno.errors.NotFound) {
+      if (
+        error instanceof Deno.errors.NotFound ||
+        error instanceof Deno.errors.IsADirectory ||
+        error instanceof Deno.errors.NotADirectory
+      ) {
         throw new Error(`Pattern file not found: ${filename}`);
       }
       throw error;

--- a/packages/runner/src/harness/patterns-route.deno.ts
+++ b/packages/runner/src/harness/patterns-route.deno.ts
@@ -1,0 +1,287 @@
+/**
+ * The patterns route: the server half of a `system:` pattern origin.
+ *
+ * A piece that records such an origin follows it by fetching a path under
+ * {@link PATTERNS_ROUTE_PREFIX} from the host serving its space — the source
+ * itself, or, with `?identity`, the content identity of that source's whole
+ * authored import closure. This is what answers.
+ *
+ * Both halves of that exchange belong to the runner. The route prefix is part
+ * of a pattern's content identity, because a compiled module is named by its
+ * URL pathname; and the identity a request asks for is the value a worker
+ * stores as `patternIdentity.identity` when it compiles the same source over
+ * HTTP. A host serving this route has to reproduce both exactly, and an answer
+ * that reproduces them imperfectly is one no runtime can adopt. So the route
+ * is defined once here, and each host — the toolshed, a test harness hosting
+ * storage in its own process — supplies its directories and composes the
+ * answer with whatever else it serves.
+ *
+ * Deno-only: it reads files. Single-file reads only, never a directory
+ * listing, so it behaves the same in a compiled binary's embedded file system
+ * as it does on a source tree.
+ */
+
+import { toFileUrl } from "@std/path/to-file-url";
+
+import {
+  compareETags,
+  createCacheHeaders,
+  generateETag,
+} from "@commonfabric/static/etag";
+import { decode } from "@commonfabric/utils/encoding";
+
+import { PATTERNS_ROUTE_PREFIX } from "../pattern-source-scheme.ts";
+import { resolveEntryIdentity } from "./entry-identity.ts";
+
+/**
+ * A directory of pattern source files reached under a route path prefix. The
+ * prefix is stripped before the rest of the path is resolved inside the
+ * directory, so a connector's patterns answer at a stable route of their own
+ * whatever their location on disk.
+ */
+export interface PatternSourceDirectory {
+  /** The route path prefix, ending in `/`, e.g. `github-activity/`. */
+  readonly routePrefix: string;
+
+  /** The directory on disk holding the files that prefix names. */
+  readonly directory: string;
+}
+
+/** What a single-file request asks for beyond the file itself. */
+export interface PatternFileRequest {
+  /** Answer with the entry closure's identity rather than the source. */
+  identity?: boolean;
+
+  /** The request's `If-None-Match`, which a matching ETag answers 304 to. */
+  ifNoneMatch?: string | null;
+}
+
+/** The route over one set of directories, and everything it answers. */
+export class PatternsRoute {
+  #baseUrl: URL;
+  #extraSources: Array<{ routePrefix: string; baseUrl: URL }>;
+
+  // Pattern files are fixed for the process's lifetime (baked into the binary
+  // or static on disk), so each file's content identity is computed once and
+  // cached forever. A rejected computation is evicted so a transient failure
+  // (e.g. an incomplete closure during a partial deploy) can be retried.
+  #identityCache = new Map<string, Promise<string>>();
+
+  /**
+   * `root` holds the patterns every route path reaches by default.
+   * `extraSources` name directories answering for a prefix of their own, and
+   * are consulted before `root`.
+   */
+  constructor(
+    root: string,
+    extraSources: readonly PatternSourceDirectory[] = [],
+  ) {
+    this.#baseUrl = directoryUrl(root);
+    this.#extraSources = extraSources.map((source) => ({
+      routePrefix: source.routePrefix,
+      baseUrl: directoryUrl(source.directory),
+    }));
+  }
+
+  /** A pattern file's content as bytes. */
+  async get(filename: string): Promise<Uint8Array> {
+    const url = this.#resolve(filename);
+
+    try {
+      return await Deno.readFile(url);
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        throw new Error(`Pattern file not found: ${filename}`);
+      }
+      throw error;
+    }
+  }
+
+  /** A pattern file's content as text. */
+  async getText(filename: string): Promise<string> {
+    const buffer = await this.get(filename);
+    return decode(buffer);
+  }
+
+  /**
+   * The content-addressed identity of a pattern entry — the value advertised
+   * to runtimes through `?identity`. Walks the entry's authored import closure
+   * via `getText` and hashes the pristine bytes; no compiler, runtime, or
+   * storage is involved. An updater independently compiles the downloaded
+   * closure and requires its entry ref to have this identity before replacing
+   * a root.
+   *
+   * `filename` is the same root-relative path `getText` accepts, e.g.
+   * `system/default-app.tsx`. Rejects if the closure is incomplete or reaches
+   * a `cf:` fabric import, which the light path does not model.
+   */
+  identity(filename: string): Promise<string> {
+    let cached = this.#identityCache.get(filename);
+    if (!cached) {
+      // Name modules by their URL pathname so the identity equals the one the
+      // worker computes when it compiles the same source over HTTP.
+      cached = resolveEntryIdentity(
+        `${PATTERNS_ROUTE_PREFIX}${filename}`,
+        (name) => this.getText(name.slice(PATTERNS_ROUTE_PREFIX.length)),
+      );
+      this.#identityCache.set(filename, cached);
+      cached.catch(() => this.#identityCache.delete(filename));
+    }
+    return cached;
+  }
+
+  /**
+   * This route's answer to `request`, or `undefined` when the request does not
+   * address the route — a path outside the prefix, or a method the route does
+   * not serve. A host composes that answer with whatever else it serves, and
+   * answers the leftovers itself.
+   */
+  async serve(request: Request): Promise<Response | undefined> {
+    if (request.method !== "GET" && request.method !== "HEAD") return undefined;
+    const url = new URL(request.url);
+    if (!url.pathname.startsWith(PATTERNS_ROUTE_PREFIX)) return undefined;
+    const encoded = url.pathname.slice(PATTERNS_ROUTE_PREFIX.length);
+    if (encoded.length === 0) return undefined;
+
+    // The route's own router decodes the path once, so `serveFile` receives
+    // the same shape from either entry point.
+    let filename: string;
+    try {
+      filename = decodeURIComponent(encoded);
+    } catch {
+      return invalidPatternPath();
+    }
+    return await this.serveFile(filename, {
+      identity: url.searchParams.has("identity"),
+      ifNoneMatch: request.headers.get("If-None-Match"),
+    });
+  }
+
+  /**
+   * The route's answer for one file, named by its path under the route prefix.
+   * A host whose own router has already picked the path apart calls this
+   * instead of {@link serve}.
+   *
+   * The path is checked before it is resolved. A `..` sequence would escape
+   * the directory, a leading `/` would make the name absolute in URL
+   * resolution, and a `:` would introduce a URL scheme
+   * (`file:///etc/passwd`). An internal `/` is allowed, because patterns are
+   * served from subdirectories. The check decodes first, so an encoded
+   * sequence is caught as the sequence it denotes.
+   */
+  async serveFile(
+    filename: string,
+    options: PatternFileRequest = {},
+  ): Promise<Response> {
+    const ifNoneMatch = options.ifNoneMatch ?? null;
+    try {
+      const decoded = decodeURIComponent(filename);
+      if (
+        decoded.includes("..") || decoded.startsWith("/") ||
+        decoded.includes(":")
+      ) {
+        return invalidPatternPath();
+      }
+
+      if (options.identity) {
+        const identity = await this.identity(filename);
+        return patternResponse(
+          identity,
+          "text/plain; charset=utf-8",
+          `"${identity}"`,
+          ifNoneMatch,
+        );
+      }
+
+      // Hash and serve the exact bytes so the ETag is a strong validator for
+      // the representation the client caches.
+      const content = await this.get(filename);
+      return patternResponse(
+        content as BodyInit,
+        "text/typescript-jsx; charset=utf-8",
+        await generateETag(content),
+        ifNoneMatch,
+      );
+    } catch (error) {
+      const { status, body } = classifyPatternError(error);
+      if (status === 500) console.error("Error serving pattern file:", error);
+      return Response.json(body, { status });
+    }
+  }
+
+  #resolve(filename: string): URL {
+    const source = this.#extraSources.find(({ routePrefix }) =>
+      filename.startsWith(routePrefix)
+    );
+    const baseUrl = source?.baseUrl ?? this.#baseUrl;
+    const relative = source === undefined
+      ? filename
+      : filename.slice(source.routePrefix.length);
+    const url = new URL(relative, baseUrl);
+
+    if (!url.href.startsWith(baseUrl.href)) {
+      throw new Error("Path traversal detected");
+    }
+    return url;
+  }
+}
+
+/** Headers shared by source and `?identity` responses. */
+export function patternResponseHeaders(
+  contentType: string,
+  etag: string,
+): Record<string, string> {
+  return {
+    "Content-Type": contentType,
+    ...createCacheHeaders(etag),
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type",
+    "Access-Control-Expose-Headers": "ETag",
+  };
+}
+
+/**
+ * Map a pattern-serving error to an HTTP status and body: a missing file →
+ * 404; a structurally invalid entry (incomplete import closure, or a `cf:`
+ * fabric import the light `?identity` path does not model) → 400 with the
+ * reason; anything else → 500.
+ */
+export function classifyPatternError(
+  error: unknown,
+): { status: 404 | 400 | 500; body: { error: string } } {
+  if (error instanceof Error && error.message.includes("not found")) {
+    return { status: 404, body: { error: "File not found" } };
+  }
+  if (
+    error instanceof Error &&
+    (error.message.includes("incomplete closure") ||
+      error.message.includes("fabric import"))
+  ) {
+    return { status: 400, body: { error: error.message } };
+  }
+  return { status: 500, body: { error: "Internal server error" } };
+}
+
+function patternResponse(
+  body: BodyInit,
+  contentType: string,
+  etag: string,
+  ifNoneMatch: string | null,
+): Response {
+  const headers = patternResponseHeaders(contentType, etag);
+  if (compareETags(etag, ifNoneMatch)) {
+    return new Response(null, { status: 304, headers });
+  }
+  return new Response(body, { status: 200, headers });
+}
+
+function invalidPatternPath(): Response {
+  return Response.json({ error: "Invalid file path" }, { status: 400 });
+}
+
+function directoryUrl(directory: string): URL {
+  const url = toFileUrl(directory);
+  if (!url.href.endsWith("/")) url.href += "/";
+  return url;
+}

--- a/packages/runner/test/PatternsRoute.test.ts
+++ b/packages/runner/test/PatternsRoute.test.ts
@@ -163,6 +163,26 @@ describe("PatternsRoute", () => {
     });
   });
 
+  it("answers a HEAD with the headers its GET would carry", async () => {
+    // A host probing for a file, or revalidating what it holds, asks with
+    // HEAD. It is the validator it comes for, so that has to be the same one
+    // the body would have arrived with; the host drops the body itself.
+
+    await withRoute({ "main.tsx": ENTRY }, async (route) => {
+      const head = await route.serve(
+        new Request("https://host.invalid/api/patterns/main.tsx", {
+          method: "HEAD",
+        }),
+      );
+      const body = await route.serve(get("/api/patterns/main.tsx"));
+      expect(head?.status).toBe(200);
+      expect(head?.headers.get("ETag")).toBe(body?.headers.get("ETag"));
+      expect(head?.headers.get("Content-Type")).toBe(
+        body?.headers.get("Content-Type"),
+      );
+    });
+  });
+
   it("refuses a name that resolves outside the directory it serves", async () => {
     // `serve` rejects such a path before this, so the guard here is what a
     // host calling the file accessors directly relies on.

--- a/packages/runner/test/PatternsRoute.test.ts
+++ b/packages/runner/test/PatternsRoute.test.ts
@@ -94,6 +94,46 @@ describe("PatternsRoute", () => {
     });
   });
 
+  it("answers 400 for a path that is not valid percent-encoding", async () => {
+    // A stray `%` survives URL parsing and reaches the route as written, so
+    // the route is what has to decide about it.
+
+    await withRoute({ "main.tsx": ENTRY }, async (route) => {
+      const response = await route.serve(get("/api/patterns/%ZZ.tsx"));
+      expect(response?.status).toBe(400);
+    });
+  });
+
+  it("answers 400 for an entry the light identity path cannot model", async () => {
+    // A fabric import folds another pattern's identity into this entry, which
+    // only a compile resolves. The entry is answerable, just not this way, and
+    // a runtime told `500` would read it as a host to try again later.
+
+    await withRoute(
+      { "main.tsx": 'import "cf:some/pattern";' },
+      async (route) => {
+        const response = await route.serve(
+          get("/api/patterns/main.tsx?identity"),
+        );
+        expect(response?.status).toBe(400);
+        expect((await response?.json()).error).toContain("fabric import");
+      },
+    );
+  });
+
+  it("answers 500 for a read failure it does not recognize", async () => {
+    // The route names the ways a path fails to name a file and answers 404 for
+    // each. Anything else the read reports is this host's own fault until
+    // somebody says otherwise, which is the answer that gets looked at.
+
+    await withRoute({ "main.tsx": ENTRY }, async (route) => {
+      const response = await route.serve(
+        get(`/api/patterns/${"a".repeat(300)}.tsx`),
+      );
+      expect(response?.status).toBe(500);
+    });
+  });
+
   it("answers 400 for a path that would leave the tree", async () => {
     await withRoute({ "main.tsx": ENTRY }, async (route) => {
       for (
@@ -120,6 +160,17 @@ describe("PatternsRoute", () => {
           }),
         ),
       ).toBeUndefined();
+    });
+  });
+
+  it("refuses a name that resolves outside the directory it serves", async () => {
+    // `serve` rejects such a path before this, so the guard here is what a
+    // host calling the file accessors directly relies on.
+
+    await withRoute({ "main.tsx": ENTRY }, async (route) => {
+      await expect(route.get("../outside.tsx")).rejects.toThrow(
+        "Path traversal detected",
+      );
     });
   });
 

--- a/packages/runner/test/PatternsRoute.test.ts
+++ b/packages/runner/test/PatternsRoute.test.ts
@@ -1,0 +1,129 @@
+/** Tests the patterns route over a directory of files it does not know. */
+
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+import { join } from "@std/path";
+import { PatternsRoute } from "../src/harness/patterns-route.deno.ts";
+
+const ENTRY = "export default 1;\n";
+const IMPORTER = 'import "./leaf.ts";\nexport default 2;\n';
+
+// Writes the named files into a fresh temp tree and returns its root. The
+// caller removes the tree.
+async function tree(files: Record<string, string>): Promise<string> {
+  const root = await Deno.makeTempDir({ prefix: "patterns-route-" });
+  for (const [path, contents] of Object.entries(files)) {
+    const full = join(root, path);
+    await Deno.mkdir(join(full, ".."), { recursive: true });
+    await Deno.writeTextFile(full, contents);
+  }
+  return root;
+}
+
+// Runs `body` against a route over a temp tree, then removes the tree.
+async function withRoute(
+  files: Record<string, string>,
+  body: (route: PatternsRoute, root: string) => Promise<void>,
+): Promise<void> {
+  const root = await tree(files);
+  try {
+    await body(new PatternsRoute(root), root);
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+}
+
+function get(path: string, headers: Record<string, string> = {}): Request {
+  return new Request(`https://host.invalid${path}`, { headers });
+}
+
+describe("PatternsRoute", () => {
+  it("serves a file's source under the patterns route", async () => {
+    await withRoute({ "system/main.tsx": ENTRY }, async (route) => {
+      const response = await route.serve(get("/api/patterns/system/main.tsx"));
+      expect(response?.status).toBe(200);
+      expect(response?.headers.get("Content-Type")).toContain(
+        "text/typescript-jsx",
+      );
+      expect(await response?.text()).toBe(ENTRY);
+    });
+  });
+
+  it("serves the entry closure's identity for `?identity`", async () => {
+    await withRoute(
+      { "main.tsx": IMPORTER, "leaf.ts": ENTRY },
+      async (route) => {
+        const response = await route.serve(
+          get("/api/patterns/main.tsx?identity"),
+        );
+        expect(response?.status).toBe(200);
+        expect(response?.headers.get("Content-Type")).toContain("text/plain");
+        const identity = (await response?.text())?.trim();
+        expect(identity).toBe(await route.identity("main.tsx"));
+      },
+    );
+  });
+
+  it("answers 304 when the request already holds the ETag", async () => {
+    await withRoute({ "main.tsx": ENTRY }, async (route) => {
+      const first = await route.serve(get("/api/patterns/main.tsx"));
+      const etag = first!.headers.get("ETag")!;
+      const second = await route.serve(
+        get("/api/patterns/main.tsx", { "If-None-Match": etag }),
+      );
+      expect(second?.status).toBe(304);
+      expect(await second?.text()).toBe("");
+    });
+  });
+
+  it("answers 404 for a file the tree does not hold", async () => {
+    await withRoute({ "main.tsx": ENTRY }, async (route) => {
+      const response = await route.serve(get("/api/patterns/absent.tsx"));
+      expect(response?.status).toBe(404);
+    });
+  });
+
+  it("answers 400 for a path that would leave the tree", async () => {
+    await withRoute({ "main.tsx": ENTRY }, async (route) => {
+      for (
+        const path of [
+          "/api/patterns/..%2Fmain.tsx",
+          "/api/patterns/%2Fetc%2Fpasswd",
+          "/api/patterns/file:passwd",
+        ]
+      ) {
+        const response = await route.serve(get(path));
+        expect(response?.status).toBe(400);
+      }
+    });
+  });
+
+  it("declines a request the route does not address", async () => {
+    await withRoute({ "main.tsx": ENTRY }, async (route) => {
+      expect(await route.serve(get("/main.tsx"))).toBeUndefined();
+      expect(await route.serve(get("/api/patterns/"))).toBeUndefined();
+      expect(
+        await route.serve(
+          new Request("https://host.invalid/api/patterns/main.tsx", {
+            method: "POST",
+          }),
+        ),
+      ).toBeUndefined();
+    });
+  });
+
+  it("serves a directory named for a prefix of its own", async () => {
+    const root = await tree({ "main.tsx": ENTRY });
+    const extra = await tree({ "main.tsx": IMPORTER, "leaf.ts": ENTRY });
+    try {
+      const route = new PatternsRoute(root, [
+        { routePrefix: "connector/", directory: extra },
+      ]);
+      expect(await route.getText("connector/main.tsx")).toBe(IMPORTER);
+      expect(await route.getText("main.tsx")).toBe(ENTRY);
+    } finally {
+      await Deno.remove(root, { recursive: true });
+      await Deno.remove(extra, { recursive: true });
+    }
+  });
+});

--- a/packages/runner/test/PatternsRoute.test.ts
+++ b/packages/runner/test/PatternsRoute.test.ts
@@ -76,10 +76,21 @@ describe("PatternsRoute", () => {
     });
   });
 
-  it("answers 404 for a file the tree does not hold", async () => {
-    await withRoute({ "main.tsx": ENTRY }, async (route) => {
-      const response = await route.serve(get("/api/patterns/absent.tsx"));
-      expect(response?.status).toBe(404);
+  it("answers 404 for a path that names no file", async () => {
+    // The three ways a path fails to name one. Each reports itself
+    // differently to the read, and the route serves files, never a listing.
+
+    await withRoute({ "system/main.tsx": ENTRY }, async (route) => {
+      for (
+        const path of [
+          "/api/patterns/absent.tsx",
+          "/api/patterns/system",
+          "/api/patterns/system/main.tsx/below.ts",
+        ]
+      ) {
+        const response = await route.serve(get(path));
+        expect(response?.status).toBe(404);
+      }
     });
   });
 

--- a/packages/toolshed/routes/patterns/patterns-identity-parity.test.ts
+++ b/packages/toolshed/routes/patterns/patterns-identity-parity.test.ts
@@ -8,7 +8,7 @@ import { HttpProgramResolver } from "@commonfabric/js-compiler/program";
 import { Engine, Runtime } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 
-import { PatternsServer } from "@/routes/patterns/patterns-server.ts";
+import { createPatternsRoute } from "@/routes/patterns/patterns-server.ts";
 
 /**
  * The load-bearing invariant of the `?identity` endpoint: the identity the
@@ -71,7 +71,7 @@ describe("?identity parity with a worker HTTP compile", () => {
 
   it("default-app.tsx: endpoint identity == worker compile", async () => {
     const worker = await workerCompiledIdentity("system/default-app.tsx");
-    const endpoint = await new PatternsServer().identity(
+    const endpoint = await createPatternsRoute().identity(
       "system/default-app.tsx",
     );
     expect(endpoint).toBe(worker);
@@ -79,7 +79,7 @@ describe("?identity parity with a worker HTTP compile", () => {
 
   it("home.tsx: endpoint identity == worker compile", async () => {
     const worker = await workerCompiledIdentity("system/home.tsx");
-    const endpoint = await new PatternsServer().identity("system/home.tsx");
+    const endpoint = await createPatternsRoute().identity("system/home.tsx");
     expect(endpoint).toBe(worker);
   });
 
@@ -89,7 +89,7 @@ describe("?identity parity with a worker HTTP compile", () => {
   // it belongs here beside the roots.
   it("profile-create.tsx: endpoint identity == worker compile", async () => {
     const worker = await workerCompiledIdentity("system/profile-create.tsx");
-    const endpoint = await new PatternsServer().identity(
+    const endpoint = await createPatternsRoute().identity(
       "system/profile-create.tsx",
     );
     expect(endpoint).toBe(worker);
@@ -97,7 +97,7 @@ describe("?identity parity with a worker HTTP compile", () => {
 
   it("profile-picker.tsx: endpoint identity == worker compile", async () => {
     const worker = await workerCompiledIdentity("system/profile-picker.tsx");
-    const endpoint = await new PatternsServer().identity(
+    const endpoint = await createPatternsRoute().identity(
       "system/profile-picker.tsx",
     );
     expect(endpoint).toBe(worker);
@@ -105,7 +105,7 @@ describe("?identity parity with a worker HTTP compile", () => {
 
   it("suggestion.tsx: endpoint identity == worker compile", async () => {
     const worker = await workerCompiledIdentity("system/suggestion.tsx");
-    const endpoint = await new PatternsServer().identity(
+    const endpoint = await createPatternsRoute().identity(
       "system/suggestion.tsx",
     );
     expect(endpoint).toBe(worker);

--- a/packages/toolshed/routes/patterns/patterns-server.ts
+++ b/packages/toolshed/routes/patterns/patterns-server.ts
@@ -1,121 +1,31 @@
 import { join } from "@std/path/join";
-import { toFileUrl } from "@std/path/to-file-url";
 
-import {
-  PATTERNS_ROUTE_PREFIX,
-  resolveEntryIdentity,
-} from "@commonfabric/runner";
-import { decode } from "@commonfabric/utils/encoding";
+import { PatternsRoute } from "@commonfabric/runner/patterns-route.deno";
 import { CONNECTOR_PATTERN_SOURCES } from "../../../connectors/pattern-sources.ts";
 
-// The prefix this route serves patterns under is the runner's constant, not
-// this route's own. A pattern's content identity folds in each module's
-// authored path, and the worker names modules by their URL pathname
-// (HttpProgramResolver), so the identity must be computed over
-// pathname-prefixed names to equal the worker's stored patternIdentity — and
-// the same prefix is what a `system:` provenance ref expands to.
-
 /**
- * Simple helper for serving pattern files from the patterns directory.
- * Works with both dev mode and compiled binaries.
+ * The patterns route this deployment serves: the authored patterns tree, plus
+ * each connector-owned tree at its stable route prefix.
+ *
+ * The route itself — its URL prefix, what `?identity` answers, and the caching
+ * headers around both — is the runner's, not this route file's. A pattern's
+ * content identity folds in each module's authored path, and the worker names
+ * modules by their URL pathname (HttpProgramResolver), so an answer that
+ * differed from the runner's own would be one no runtime could adopt.
  */
-export class PatternsServer {
-  #baseUrl: URL;
-  #connectorSources: Array<{ routePrefix: string; baseUrl: URL }>;
-  // Pattern files are fixed for the process's lifetime (baked into the binary
-  // or static on disk), so each file's content identity is computed once and
-  // cached forever. A rejected computation is evicted so a transient failure
-  // (e.g. an incomplete closure during a partial deploy) can be retried.
-  #identityCache = new Map<string, Promise<string>>();
-
-  constructor() {
-    const repositoryRoot = join(
-      import.meta.dirname || "",
-      "..",
-      "..",
-      "..",
-      "..",
-    );
-    this.#baseUrl = this.#directoryUrl(
-      join(repositoryRoot, "packages/patterns"),
-    );
-    this.#connectorSources = CONNECTOR_PATTERN_SOURCES.map((source) => ({
+export function createPatternsRoute(): PatternsRoute {
+  const repositoryRoot = join(
+    import.meta.dirname || "",
+    "..",
+    "..",
+    "..",
+    "..",
+  );
+  return new PatternsRoute(
+    join(repositoryRoot, "packages/patterns"),
+    CONNECTOR_PATTERN_SOURCES.map((source) => ({
       routePrefix: `${source.keyPrefix}/`,
-      baseUrl: this.#directoryUrl(join(repositoryRoot, source.directory)),
-    }));
-  }
-
-  #directoryUrl(directory: string): URL {
-    const url = toFileUrl(directory);
-    if (!url.href.endsWith("/")) url.href += "/";
-    return url;
-  }
-
-  #resolve(filename: string): URL {
-    const source = this.#connectorSources.find(({ routePrefix }) =>
-      filename.startsWith(routePrefix)
-    );
-    const baseUrl = source?.baseUrl ?? this.#baseUrl;
-    const relative = source === undefined
-      ? filename
-      : filename.slice(source.routePrefix.length);
-    const url = new URL(relative, baseUrl);
-
-    if (!url.href.startsWith(baseUrl.href)) {
-      throw new Error("Path traversal detected");
-    }
-    return url;
-  }
-
-  /**
-   * Get a pattern file's content as Uint8Array.
-   */
-  async get(filename: string): Promise<Uint8Array> {
-    const url = this.#resolve(filename);
-
-    try {
-      return await Deno.readFile(url);
-    } catch (error) {
-      if (error instanceof Deno.errors.NotFound) {
-        throw new Error(`Pattern file not found: ${filename}`);
-      }
-      throw error;
-    }
-  }
-
-  /**
-   * Get a pattern file's content as text.
-   */
-  async getText(filename: string): Promise<string> {
-    const buffer = await this.get(filename);
-    return decode(buffer);
-  }
-
-  /**
-   * Compute (and memoize) the content-addressed identity of a pattern entry —
-   * the value advertised to runtimes through `?identity`. Walks the entry's
-   * authored import closure via `getText` (single-file reads only, so it works
-   * in a compiled binary) and hashes the pristine bytes; no compiler, runtime,
-   * or storage is involved. An updater independently compiles the downloaded
-   * closure and requires its entry ref to have this identity before replacing
-   * a root.
-   *
-   * `filename` is the same root-relative path `getText` accepts, e.g.
-   * `system/default-app.tsx`. Rejects if the closure is incomplete or reaches a
-   * `cf:` fabric import (unsupported by the light path).
-   */
-  identity(filename: string): Promise<string> {
-    let cached = this.#identityCache.get(filename);
-    if (!cached) {
-      // Name modules by their URL pathname so the identity equals the one the
-      // worker computes when it compiles the same source over HTTP.
-      cached = resolveEntryIdentity(
-        `${PATTERNS_ROUTE_PREFIX}${filename}`,
-        (name) => this.getText(name.slice(PATTERNS_ROUTE_PREFIX.length)),
-      );
-      this.#identityCache.set(filename, cached);
-      cached.catch(() => this.#identityCache.delete(filename));
-    }
-    return cached;
-  }
+      directory: join(repositoryRoot, source.directory),
+    })),
+  );
 }

--- a/packages/toolshed/routes/patterns/patterns.handlers.ts
+++ b/packages/toolshed/routes/patterns/patterns.handlers.ts
@@ -1,119 +1,20 @@
 import type { Context } from "@hono/hono";
-import {
-  compareETags,
-  createCacheHeaders,
-  generateETag,
-} from "@commonfabric/static/etag";
-import { PatternsServer } from "./patterns-server.ts";
+import { createPatternsRoute } from "./patterns-server.ts";
 
-// Create a single server instance to be reused across requests
-const patternsServer = new PatternsServer();
-
-/** Headers shared by source and `?identity` responses from this process. */
-export function patternResponseHeaders(
-  contentType: string,
-  etag: string,
-): Record<string, string> {
-  return {
-    "Content-Type": contentType,
-    ...createCacheHeaders(etag),
-    "Access-Control-Allow-Origin": "*",
-    "Access-Control-Allow-Methods": "GET, OPTIONS",
-    "Access-Control-Allow-Headers": "Content-Type",
-    "Access-Control-Expose-Headers": "ETag",
-  };
-}
-
-function patternResponse(
-  c: Context,
-  body: BodyInit,
-  contentType: string,
-  etag: string,
-): Response {
-  const headers = patternResponseHeaders(contentType, etag);
-  if (compareETags(etag, c.req.header("If-None-Match"))) {
-    return new Response(null, { status: 304, headers });
-  }
-  return new Response(body, { status: 200, headers });
-}
+// Create a single route instance to be reused across requests: it memoizes
+// each pattern's closure identity, which is fixed for the process's lifetime.
+const patternsRoute = createPatternsRoute();
 
 /**
- * Handler for serving pattern files from the patterns directory.
- * Validates filenames and returns TSX/TS files with appropriate headers.
+ * Handler for serving pattern files from the patterns directory. The router
+ * has already split the path, so the file is asked for by name; everything
+ * else about the answer — validation, `?identity`, ETags, status mapping —
+ * belongs to the route.
  */
-export const getPattern = async (
-  c: Context,
-) => {
+export const getPattern = (c: Context): Promise<Response> => {
   const { filename } = c.req.param();
-
-  try {
-    // Security: validate filename doesn't contain path traversal
-    // Decode first to catch encoded traversal sequences (e.g. %2e%2e)
-    // Block .. sequences that could escape the patterns directory
-    // Block leading / which would create absolute paths in URL resolution
-    // Block : to prevent URL scheme injection (e.g., file:///etc/passwd)
-    // Allow internal / for subdirectory access (e.g., record/registry.ts)
-    const decoded = decodeURIComponent(filename);
-    if (
-      decoded.includes("..") || decoded.startsWith("/") ||
-      decoded.includes(":")
-    ) {
-      return c.json(
-        { error: "Invalid file path" },
-        400,
-      );
-    }
-
-    // `?identity`: return the complete authored pattern closure's identity (the
-    // value the runtime would store as patternIdentity.identity) as plain text,
-    // instead of the entry file's source.
-    if (new URL(c.req.url).searchParams.has("identity")) {
-      const identity = await patternsServer.identity(filename);
-      return patternResponse(
-        c,
-        identity,
-        "text/plain; charset=utf-8",
-        `"${identity}"`,
-      );
-    }
-
-    // Hash and serve the exact bytes so the ETag is a strong validator for the
-    // representation the client caches.
-    const content = await patternsServer.get(filename);
-    const etag = await generateETag(content);
-
-    // Return with proper headers for TSX files
-    return patternResponse(
-      c,
-      content as BodyInit,
-      "text/typescript-jsx; charset=utf-8",
-      etag,
-    );
-  } catch (error) {
-    const { status, body } = classifyPatternError(error);
-    if (status === 500) console.error("Error serving pattern file:", error);
-    return c.json(body, status);
-  }
+  return patternsRoute.serveFile(filename, {
+    identity: new URL(c.req.url).searchParams.has("identity"),
+    ifNoneMatch: c.req.header("If-None-Match"),
+  });
 };
-
-/**
- * Map a pattern-serving error to an HTTP status + body: a missing file → 404; a
- * structurally invalid entry (incomplete import closure, or a `cf:` fabric
- * import the light `?identity` path does not model) → 400 with the reason;
- * anything else → 500. Exported for testing.
- */
-export function classifyPatternError(
-  error: unknown,
-): { status: 404 | 400 | 500; body: { error: string } } {
-  if (error instanceof Error && error.message.includes("not found")) {
-    return { status: 404, body: { error: "File not found" } };
-  }
-  if (
-    error instanceof Error &&
-    (error.message.includes("incomplete closure") ||
-      error.message.includes("fabric import"))
-  ) {
-    return { status: 400, body: { error: error.message } };
-  }
-  return { status: 500, body: { error: "Internal server error" } };
-}

--- a/packages/toolshed/routes/patterns/patterns.test.ts
+++ b/packages/toolshed/routes/patterns/patterns.test.ts
@@ -4,11 +4,11 @@ import { generateETag } from "@commonfabric/static/etag";
 import env from "@/env.ts";
 import createApp from "@/lib/create-app.ts";
 import router from "@/routes/patterns/patterns.index.ts";
-import { PatternsServer } from "@/routes/patterns/patterns-server.ts";
 import {
   classifyPatternError,
   patternResponseHeaders,
-} from "@/routes/patterns/patterns.handlers.ts";
+} from "@commonfabric/runner/patterns-route.deno";
+import { createPatternsRoute } from "@/routes/patterns/patterns-server.ts";
 
 const IDENTITY_RE = /^[A-Za-z0-9_-]{43}$/;
 
@@ -193,7 +193,7 @@ describe("Patterns API", () => {
       // The same value the shared helper computes over default-app.tsx's actual
       // authored import closure — proves the endpoint wires through the runner
       // helper AND that the real system pattern's closure resolves cleanly.
-      const direct = await new PatternsServer().identity(
+      const direct = await createPatternsRoute().identity(
         "system/default-app.tsx",
       );
       expect(httpIdentity).toBe(direct);

--- a/packages/toolshed/routes/patterns/patterns.test.ts
+++ b/packages/toolshed/routes/patterns/patterns.test.ts
@@ -63,6 +63,19 @@ describe("Patterns API", () => {
       );
       expect(response.status).toBe(404);
     });
+
+    it("returns 404 for a path naming a directory or reaching below a file", async () => {
+      // Neither names a file this route can serve, and the route lists no
+      // directories, so both are absent rather than a fault of this server.
+
+      const directory = await app.request("/api/patterns/system");
+      expect(directory.status).toBe(404);
+
+      const belowAFile = await app.request(
+        "/api/patterns/record.tsx/below.ts",
+      );
+      expect(belowAFile.status).toBe(404);
+    });
   });
 
   describe("subdirectory imports", () => {


### PR DESCRIPTION
Every run of the multi-runtime pattern harness printed a compiler error to stderr, once per session, followed by "Can't load profile-create.tsx". The compiled text it complained about had "memory websocket endpoint" as its second line.

That string was the standalone memory server's answer to every request that is not a websocket upgrade, whatever the path. The harness hosts storage in its own process and hands every worker that server's address as the runtime's `apiUrl`, so a runtime resolving the `system:` origin of the profile-create surface fetched
`<host>/api/patterns/system/profile-create.tsx?identity`, was told 200, took "memory websocket endpoint" for the identity the origin advertises, fetched the same path again for the source, and compiled that sentence as TSX. This is the shape the `system:` scheme was introduced to stop — a catch-all 200 answering for a route that is not there — arriving from the test server rather than from a single-page-app fallback.

Two things followed from it. The error looked like a failure and was not, so every harness run carried noise a reader had to learn to ignore. And no headless multi-runtime test could drive a `#profile` wish through its real resolution, because the surface a user with no profile is shown could never be opened; patterns whose identity is a profile cell, lunch-poll among them, could only be driven through the seams their own tests supply.

So answer the route rather than answer for it.

The patterns route moves into the runner, at
`harness/patterns-route.deno.ts`. It was toolshed's, split between a `PatternsServer` class and a Hono handler, but both halves of what it answers are the runner's already: the route prefix is part of a pattern's content identity, because a compiled module is named by its URL pathname, and the identity `?identity` answers with is the value a worker stores when it compiles the same source over HTTP. A host that has to reproduce both exactly is a host that should not be reproducing them at all. The route now takes its directories from whoever constructs it and answers either a whole `Request` or a single named file; toolshed supplies the authored patterns tree and each connector's tree and keeps its Hono route, and the multi-runtime harness supplies the authored patterns tree beside its storage server.

The standalone memory server stops answering 200 to everything. It answers the health probe itself, because it is what occupies the address and so is what can say it is up; it offers the rest to an optional `serve` handler its caller passes; and anything nobody answers is a `426 Upgrade Required` carrying `Upgrade: websocket`.

`426` is the status for a server that will not answer over the protocol it was asked in but would answer over another, and its `Upgrade` header names that other one. `404` would say the thing asked for is not here, which is true but is not the useful half of the truth: the request was not for something absent, it was in the wrong protocol. `405` is the near miss worth naming — a websocket handshake is itself a `GET`, so the method was never what the server objected to. Either way a client sees the same thing, because each one tests `response.ok` rather than a particular status; the difference is what a person reading a log gets.

That person is who the body is for. It says in prose what the status and the header say in machine terms, and points at
`docs/specs/memory-v2/04-protocol.md` for the protocol it is asking to be spoken — the `hello` handshake, the message envelopes, the command set, and the compression envelope. The citation names the source repository before the path, because a reader holding this response has just learned that a path on this host is answered with it.

`cf test`'s multi-user runner gets the honest failure without further change: its module root is the directory of the pattern under test, which is not in general the deployment's patterns tree, so it is left declining the route, and the surface's own failure path writes the one line it was always meant to.

Tests: the route answers over a directory it does not know (source, `?identity`, 304, 404, an escaping path, a request outside the route); the standalone server's health, upgrade-required and hand-off behavior, including a check that reads the cited path back out of the body and resolves it, so the citation cannot rot unnoticed; and a multi-runtime integration test that wishes `#profile` in a fresh space and reads "Create Profile" out of the piece behind the wish's UI node, which only the compiled system pattern produces. That last one fails with `undefined` when the harness declines the route.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6742?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

