### PR TITLE
One session assembly behind the cf-harness CLI and console (CT-2166)

### DIFF
--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -117,8 +117,8 @@ What works today:
   - `edit_file`
   - `write_file`
   - `delegate_task`
-  - `describe_handle` (shape of a handle's referent, never its value; see
-    [Inspecting a handle's shape](#inspecting-a-handles-shape))
+  - `describe_handle` (shape and labels of a handle's referent, never its value;
+    see [Inspecting a handle's shape](#inspecting-a-handles-shape))
   - `run_pattern` (present only when the run configures a fabric session; see
     [Running patterns against a Fabric space](#running-patterns-against-a-fabric-space))
   - `search_patterns` (present only when the run configures a pattern index with
@@ -799,8 +799,8 @@ resume, and reported in the operator summary as `inputCells:`.
 A token says nothing about what it refers to, and an agent handed one cannot
 write a line of code over it without knowing the shape of what is there.
 `describe_handle` closes that gap without opening the data: given a token, it
-reports the shape of the referent and the path segments — what field of what
-piece the token names — and never the value.
+reports the shape of the referent, the path segments — what field of what piece
+the token names — the CFC labels the referent carries, and never the value.
 
 ```json
 {
@@ -811,22 +811,38 @@ piece the token names — and never the value.
     "type": "object",
     "properties": { "doubled": { "type": "number" } }
   },
-  "path": ["doubled"]
+  "path": ["doubled"],
+  "labels": [
+    {
+      "confidentiality": [["https://commonfabric.org/cfc/atom/Space"]],
+      "integrity": ["https://commonfabric.org/cfc/atom/ExternalIngest"]
+    }
+  ]
 }
 ```
 
-Two sources can answer, in this order. The referent's own declared schema, read
-through the run's fabric session when it has one: a piece's document schema is
-the result schema of the pattern behind it, which is exactly what an agent
-holding a handle to that piece would be wiring into a pattern of its own — and
-it is where a cell's CFC labels live, which is why an input cell's shape always
-answers from its own declaration. Failing that, the schema the mint recorded out
-of the harness's own work — a `run_pattern` result reference carries the
-compiled pattern's result schema, which compilation produced anyway, and the
-entry is marked `schemaSource: "harness"`. A run with no session still answers
-from its own table, so shape stays inspectable in every run that has handles at
-all. A token the run's table does not hold comes back `known: false` rather than
-as an error, since a token from another run simply names nothing here.
+Labels answer from the same read as the shape, wherever the run has a session to
+read through, and they are a different fact from the schema: a cell's labels
+live in its own metadata rather than on its declaration, so a referent can carry
+a full label map and state no shape at all. Only atom TYPES cross — the URLs
+naming what a value requires and what it carries — and never an atom's other
+fields, which say what a label was computed FROM. `confidentiality` holds one
+entry per clause, each listing the atom types that satisfy it, because a clause
+of several types is satisfied by any one of them and flattening that would
+report a weaker requirement as a stronger one. An empty list says the space
+holds no label; no list at all says the run had no session to ask.
+
+Two sources can answer for the shape, in this order. The referent's own declared
+schema, read through the run's fabric session when it has one: a piece's
+document schema is the result schema of the pattern behind it, which is exactly
+what an agent holding a handle to that piece would be wiring into a pattern of
+its own. Failing that, the schema the mint recorded out of the harness's own
+work — a `run_pattern` result reference carries the compiled pattern's result
+schema, which compilation produced anyway, and the entry is marked
+`schemaSource: "harness"`. A run with no session still answers from its own
+table, so shape stays inspectable in every run that has handles at all. A token
+the run's table does not hold comes back `known: false` rather than as an error,
+since a token from another run simply names nothing here.
 
 **What is disclosed is structure and only structure**: property names, types,
 nesting, required-ness, array and object composition, a `type` from the schema

--- a/packages/cf-harness/console/README.md
+++ b/packages/cf-harness/console/README.md
@@ -89,6 +89,25 @@ Every environment variable has a flag, and the flag wins:
 | `--space-db`            | `CF_HARNESS_SPACE_DB`                | the space's own database, discovered  |
 | `--max-model-turns`     | `CF_HARNESS_CONSOLE_MAX_MODEL_TURNS` | the prompt loop's default             |
 | `--skills-root`         | `CF_HARNESS_CONSOLE_SKILLS_ROOT`     | the repository's `skills/` tree       |
+| `--host-mount`          | —                                    | none; repeatable                      |
+
+Publishing to the index is configured the way the CLI configures it, by the same
+names:
+
+| Flag                                   | Environment                                       | Default               |
+| -------------------------------------- | ------------------------------------------------- | --------------------- |
+| `--no-pattern-index-publish`           | `CF_HARNESS_PATTERN_INDEX_PUBLISH=0`              | publishing is on      |
+| `--pattern-index-publish-discoverable` | `CF_HARNESS_PATTERN_INDEX_PUBLISH_DISCOVERABLE=1` | recorded, not offered |
+
+A pattern a session authors and runs is recorded against the index unless
+publishing is turned off, and is offered to search only when discoverability is
+asked for — which is for deliberate corpus seeding, since discoverability is
+otherwise earned from later evidence.
+
+`--host-mount name=<name>,source=<host path>,target=<sandbox path>[,mode=readonly|writable]`
+takes the same spec the CLI takes, and is repeatable. It is how a reference tree
+— a corpus to work from, a checkout to read — reaches the sandbox a task runs
+in.
 
 Every turn scans the skills root and records the registry on its run before the
 first model call, so `read_skill_resource` can answer and a delegated
@@ -135,6 +154,27 @@ and HTTP reachability, configuration, or factory existence says nothing about
 whether a retained session can complete an operation. The field does not spend a
 provider turn or make a Fabric round trip. A caller needing proven substrate
 liveness must perform a separate probe.
+
+A task body carries the text, optionally the session to continue, and optionally
+the cells the task is to be computed over:
+
+```json
+{
+  "text": "summarize this trip",
+  "sessionId": "…",
+  "inputCells": [
+    { "name": "itinerary", "ref": "/of:fid1:…/days" }
+  ]
+}
+```
+
+An input cell is named per task rather than per session, because a turn is its
+own run with its own handle table: the tokens the model is given are the ones
+that turn's run minted. What the model receives is a token and the caller's own
+name for it — never the reference, and never what the cell holds. The reference
+grammar is `--input-cell`'s, so a spelling the CLI refuses is refused here with
+a 400, and a cell that cannot be minted fails the turn rather than starting it
+without what the caller attached.
 
 The completed-turn result is:
 
@@ -498,16 +538,19 @@ Three panes:
 
 ## How the configuration reaches the run
 
-`CreateHarnessPromptLoopOptions` extends the engine's options, which extend the
-config resolver's, and the interactive chat service spreads its
-`basePromptLoopOptions` into every turn. So `fabricSession`, `patternIndex`, and
-`skillsSh` set once at startup hold for the whole session, and the engine builds
-each lazily-cached client factory from them.
+This server resolves its flags and environment into a `HarnessSessionConfig` —
+the same description the batch CLI resolves argv into — and
+`src/session-assembly.ts` turns that into the run. So a capability the CLI can
+configure is configurable here under the same name, and the two surfaces cannot
+drift apart over what a session is.
 
-Configuration alone is not enough: the default chat policy's tool surface does
-not include `run_pattern`, `assign_slug`, `search_patterns`, `record_feedback`,
-or `search_skills`. The server names them in the policy it starts each session
-with, and the prompt loop withholds each again if its backing is absent — so a
-missing index means the two index tools are simply not offered, and a missing
-public skill registry means `search_skills` is not offered, rather than either
-surface being offered and failing.
+The tools a session offers are derived from what it can back rather than listed
+here: the default surface plus `run_pattern` and `assign_slug` for a fabric
+session, `search_patterns` and `record_feedback` for an index, `search_skills`
+for a registry, and `acquire_skill` for a run holding both. A tool whose backing
+is absent is not offered, rather than offered and failing.
+
+Each turn is its own run, so what that run holds is established per turn and
+announced in the messages it opens with: the skills registry scanned from the
+skills root, the well-known grants of the session's space — which is what lets a
+task explore what the space holds — and the input cells the request attached.

--- a/packages/cf-harness/console/server.ts
+++ b/packages/cf-harness/console/server.ts
@@ -18,15 +18,17 @@
  * caller cannot send and a rebound origin cannot obtain. Do not put this
  * behind a public address.
  *
- * Two pieces of configuration are what make a run able to finish with a link
- * rather than a transcript. The fabric session — API URL, identity keyfile,
- * space *name* — reaches the engine as `fabricSession` in the base prompt-loop
- * options, which is what backs `run_pattern` and `assign_slug`; the space has
- * to be a name because `assign_slug` composes its URL from one and offers no
- * URL at all for a space named by `did:key`. The chat policy then has to name
- * those tools: the default parent tool surface does not include them, so a
- * session started with the default policy has a fabric session and no way to
- * use it.
+ * What a task runs under is not decided here. This server resolves flags, the
+ * environment and the request body into a `HarnessSessionConfig` — the same
+ * description the batch CLI resolves argv into — and `src/session-assembly.ts`
+ * turns that into the run. So a capability configurable on the CLI is
+ * configurable here by the same name, and the tools a session offers are
+ * derived from what it can back rather than listed by this file.
+ *
+ * The one piece of configuration this surface insists on is the fabric
+ * session, whose space has to be a name rather than a `did:key`: `assign_slug`
+ * composes a piece's URL from the name and offers none for a DID, and finishing
+ * with a link rather than a transcript is what this surface is for.
  */
 
 import { parseArgs } from "@std/cli/parse-args";
@@ -77,8 +79,8 @@ import { parseHostMountSpecs } from "../src/host-mounts.ts";
 import { parseInputCellArgument } from "../src/input-cells.ts";
 import {
   harnessSessionChatPolicy,
-  harnessSessionEngineOptions,
   type HarnessSessionConfig,
+  harnessSessionEngineOptions,
 } from "../src/session-assembly.ts";
 import {
   createHarnessInteractiveChatService,
@@ -662,8 +664,11 @@ export const resolveConsoleConfig = async (
       DEFAULT_SUBAGENT_PROFILE,
       PATTERN_AUTHOR_SUBAGENT_PROFILE,
     ],
-    subagentCompositionGuidance:
-      parsed["no-child-composition-guidance"] !== true,
+    // Stated only when it is being turned off: guidance is what the profile
+    // ships with, so saying so restates a default rather than configuring one.
+    ...(parsed["no-child-composition-guidance"] === true
+      ? { subagentCompositionGuidance: false }
+      : {}),
   };
 };
 

--- a/packages/cf-harness/console/server.ts
+++ b/packages/cf-harness/console/server.ts
@@ -58,12 +58,9 @@ import type {
   HarnessFabricCfcFlowLabelsMode,
   HarnessFabricSessionConfig,
   HarnessModelProviderId,
-  HarnessPatternIndexConfig,
-  HarnessSkillsShConfig,
 } from "../src/config.ts";
 import type { CfcPosture } from "@commonfabric/runner";
 import {
-  DEFAULT_HARNESS_CHAT_POLICY,
   type HarnessChatError,
   type HarnessChatEventEnvelope,
   type HarnessChatPolicy,
@@ -71,8 +68,18 @@ import {
 } from "../src/contracts/interactive-chat.ts";
 import { HARNESS_CREDENTIAL_OWNER_REF_TYPE } from "../src/contracts/run-manifest.ts";
 import { createCliPromptSlotBinding } from "../src/contracts/prompt-slot.ts";
-import { PATTERN_AUTHOR_SUBAGENT_PROFILE } from "../src/contracts/subagent.ts";
-import type { BuiltinToolId } from "../src/contracts/tool-descriptor.ts";
+import type { HarnessInputCellSpec } from "../src/contracts/input-cells.ts";
+import {
+  DEFAULT_SUBAGENT_PROFILE,
+  PATTERN_AUTHOR_SUBAGENT_PROFILE,
+} from "../src/contracts/subagent.ts";
+import { parseHostMountSpecs } from "../src/host-mounts.ts";
+import { parseInputCellArgument } from "../src/input-cells.ts";
+import {
+  harnessSessionChatPolicy,
+  harnessSessionEngineOptions,
+  type HarnessSessionConfig,
+} from "../src/session-assembly.ts";
 import {
   createHarnessInteractiveChatService,
   type CreateHarnessInteractiveChatServiceOptions,
@@ -230,22 +237,6 @@ const CONSOLE_CREDENTIAL_OWNER = {
 } as const;
 
 /**
- * The tools a console session is allowed, over the default parent surface: the
- * two that need a fabric session, and the two that need an index. Each is
- * withheld again by the prompt loop when its backing is absent, so naming them
- * here asks for them rather than asserting they exist.
- */
-const FABRIC_TOOL_IDS = [
-  "run_pattern",
-  "assign_slug",
-] as const satisfies readonly BuiltinToolId[];
-
-const PATTERN_INDEX_TOOL_IDS = [
-  "search_patterns",
-  "record_feedback",
-] as const satisfies readonly BuiltinToolId[];
-
-/**
  * The index functions the Index view may reach through the proxy. Every one of
  * them reads: this surface inspects what the index holds and never writes to
  * it, so a page that asked for `publishPattern` or `recordEvent` is refused by
@@ -305,18 +296,75 @@ const callPatternIndex = (
   }
 };
 
-/** Everything the server needs before it can serve a single request. */
-interface ConsoleConfig {
+/**
+ * The input cells a `/api/task` body attaches to the turn it starts, each a
+ * `{ name, ref }` pair. The name is what the model is told, the reference is
+ * the cell it stands for, and neither the value nor the address ever reaches
+ * the page — the run mints a token for the reference and the model works
+ * through that.
+ *
+ * The grammar is the flag's, checked by the flag's own parser, so a spelling
+ * the CLI refuses is refused here too. A body that names no cells yields
+ * none, which is the ordinary task.
+ *
+ * @throws Error naming the defect, which the route answers 400 with.
+ */
+const parseTaskInputCells = (
+  value: unknown,
+): readonly HarnessInputCellSpec[] => {
+  if (value === undefined || value === null) {
+    return [];
+  }
+  if (!Array.isArray(value)) {
+    throw new Error("inputCells must be an array");
+  }
+  const specs: HarnessInputCellSpec[] = [];
+  const names = new Set<string>();
+  for (const entry of value) {
+    if (typeof entry !== "object" || entry === null) {
+      throw new Error("each input cell must be an object");
+    }
+    const { name, ref } = entry as { name?: unknown; ref?: unknown };
+    if (typeof name !== "string" || typeof ref !== "string") {
+      throw new Error("each input cell needs a string name and ref");
+    }
+    // Checked through the flag's own parser, so the two surfaces cannot come
+    // to accept different references under the same name.
+    const spec = parseInputCellArgument(`${name}=${ref}`);
+    if (names.has(spec.name)) {
+      throw new Error(`inputCells names \`${spec.name}\` twice`);
+    }
+    names.add(spec.name);
+    specs.push(spec);
+  }
+  return specs;
+};
+
+/**
+ * Everything the server needs before it can serve a single request: the
+ * session every task runs under, plus what belongs to this surface alone.
+ *
+ * The session half is {@link HarnessSessionConfig}, the same description the
+ * batch CLI resolves argv into, so a capability configurable there is
+ * configurable here by the same name. This surface adds only what an HTTP
+ * server has and a command does not — a port, a durable session store, a
+ * seeded system prompt, a space database to read labels out of.
+ */
+interface ConsoleConfig extends HarnessSessionConfig {
   port: number;
-  workspacePath: string;
-  artifactRoot: string;
+  harnessHome: string;
+
+  /** A fabric session is required here; see `resolveConsoleConfig`. */
+  fabricSession: HarnessFabricSessionConfig;
+
+  /**
+   * The sandbox's two CFC sidecar transports, always sited: this surface
+   * creates them under its own data directory rather than asking an operator
+   * to name a path before their first run.
+   */
   cfcResultDir: string;
   cfcInvocationContextDir: string;
-  harnessHome: string;
-  model: string;
-  fabricSession: HarnessFabricSessionConfig;
-  patternIndex?: HarnessPatternIndexConfig;
-  skillsSh?: HarnessSkillsShConfig;
+
   sessionDbPath?: string;
 
   /**
@@ -326,9 +374,6 @@ interface ConsoleConfig {
    */
   spaceDbPath?: string;
 
-  maxModelTurns?: number;
-  skillsRoot?: string;
-
   /**
    * System prompt seeded into every console session, read from the file named
    * by `--system-prompt-file`. Absent, a session runs with no system message,
@@ -336,13 +381,6 @@ interface ConsoleConfig {
    * its tool descriptors.
    */
   systemPrompt?: string;
-
-  /**
-   * Whether a `pattern-author` child keeps the guidance telling it to compose
-   * what the index holds rather than rewrite it. True unless
-   * `--no-child-composition-guidance` is passed.
-   */
-  childCompositionGuidance: boolean;
 }
 
 /**
@@ -395,11 +433,11 @@ const positiveInteger = (value: string, flag: string): number => {
  * and never hand back an address for it, which is the one outcome this surface
  * exists to avoid.
  */
-export const resolveConsoleConfig = (
+export const resolveConsoleConfig = async (
   args: readonly string[],
   env: Record<string, string | undefined>,
   cwd: string,
-): ConsoleConfig => {
+): Promise<ConsoleConfig> => {
   const parsed = parseArgs(args, {
     string: [
       "port",
@@ -411,6 +449,8 @@ export const resolveConsoleConfig = (
       "fabric-space",
       "pattern-index-url",
       "skills-registry-url",
+      "skills-root",
+      "host-mount",
       "session-db",
       "space-db",
       "max-model-turns",
@@ -419,7 +459,12 @@ export const resolveConsoleConfig = (
       "fabric-cfc-posture",
       "system-prompt-file",
     ],
-    boolean: ["no-child-composition-guidance"],
+    boolean: [
+      "no-child-composition-guidance",
+      "no-pattern-index-publish",
+      "pattern-index-publish-discoverable",
+    ],
+    collect: ["host-mount"],
   });
   const flag = (name: string): string | undefined =>
     typeof parsed[name] === "string" ? nonEmpty(parsed[name]) : undefined;
@@ -535,6 +580,13 @@ export const resolveConsoleConfig = (
 
   const patternIndexUrl = flag("pattern-index-url") ??
     nonEmpty(env.CF_HARNESS_PATTERN_INDEX_URL);
+  // Publishing posture reads exactly as it does on the CLI: on unless turned
+  // off, and recorded-only unless discoverability is asked for.
+  const patternIndexPublish = parsed["no-pattern-index-publish"] !== true &&
+    nonEmpty(env.CF_HARNESS_PATTERN_INDEX_PUBLISH) !== "0";
+  const patternIndexPublishDiscoverable =
+    parsed["pattern-index-publish-discoverable"] === true ||
+    nonEmpty(env.CF_HARNESS_PATTERN_INDEX_PUBLISH_DISCOVERABLE) === "1";
   const skillsRegistryUrl = flag("skills-registry-url") ??
     nonEmpty(env.CF_HARNESS_SKILLS_REGISTRY_URL);
   const sessionDb = flag("session-db") ??
@@ -550,7 +602,7 @@ export const resolveConsoleConfig = (
 
   return {
     port,
-    workspacePath,
+    workspace: workspacePath,
     artifactRoot,
     cfcResultDir,
     cfcInvocationContextDir,
@@ -565,6 +617,10 @@ export const resolveConsoleConfig = (
       ? {
         patternIndex: {
           baseUrl: requiredUrl(patternIndexUrl, "--pattern-index-url"),
+          ...(patternIndexPublish ? {} : { publish: false }),
+          ...(patternIndexPublishDiscoverable
+            ? { publishDiscoverable: true }
+            : {}),
         },
       }
       : {}),
@@ -582,45 +638,45 @@ export const resolveConsoleConfig = (
     // is what a throwaway run wants and what a machine without the SQLite
     // native library can still do.
     ...(sessionDb === "none" ? {} : { sessionDbPath: resolve(cwd, sessionDb) }),
-    ...(maxModelTurns !== undefined
-      ? {
-        maxModelTurns: positiveInteger(maxModelTurns, "--max-model-turns"),
-      }
-      : {}),
+    maxModelTurns: positiveInteger(maxModelTurns, "--max-model-turns"),
     skillsRoot: skillsRootFlag,
     ...(systemPromptFile !== undefined
       ? { systemPrompt: readSystemPromptFile(systemPromptFile, cwd) }
       : {}),
-    childCompositionGuidance: parsed["no-child-composition-guidance"] !== true,
+    hostMounts: await parseHostMountSpecs(
+      parsed["host-mount"] as string[] | undefined,
+      cwd,
+    ),
+    // The rest of the session description this surface does not vary. Skills
+    // are scanned rather than preloaded by name, scripts are not allowlisted,
+    // handles materialize nowhere, and a task's input cells arrive per task
+    // on `/api/task` rather than at startup.
+    skillNames: [],
+    allowedSkillScripts: [],
+    skillScriptExecutionTarget: "sandbox",
+    handleValueOrigins: [],
+    inputCells: [],
+    // The tool surface is left to the session's own backing rather than
+    // listed here, so a tool the harness gains reaches this surface with it.
+    allowedSubagentProfiles: [
+      DEFAULT_SUBAGENT_PROFILE,
+      PATTERN_AUTHOR_SUBAGENT_PROFILE,
+    ],
+    subagentCompositionGuidance:
+      parsed["no-child-composition-guidance"] !== true,
   };
 };
 
 /**
- * The policy a console session runs under: see `FABRIC_TOOL_IDS`. The prompt
- * slot is bound as a direct command because the page's textarea is the user
- * typing the command themselves — the same standing the batch CLI's prompt
- * argument has, and what authorizes effectful tools under CFC enforce modes.
+ * The prompt slot a console turn is bound under. The page's textarea is the
+ * user typing the command themselves — the same standing the batch CLI's
+ * prompt argument has, and what authorizes effectful tools under CFC enforce
+ * modes.
  */
-export const consoleChatPolicy = (
-  patternIndexConfigured: boolean,
-  skillsShConfigured: boolean,
-): HarnessChatPolicy => ({
-  ...DEFAULT_HARNESS_CHAT_POLICY,
-  allowedToolIds: [
-    ...DEFAULT_HARNESS_CHAT_POLICY.allowedToolIds,
-    ...FABRIC_TOOL_IDS,
-    ...(patternIndexConfigured ? PATTERN_INDEX_TOOL_IDS : []),
-    ...(skillsShConfigured ? ["search_skills" as const] : []),
-  ],
-  allowedSubagentProfiles: [
-    ...DEFAULT_HARNESS_CHAT_POLICY.allowedSubagentProfiles,
-    PATTERN_AUTHOR_SUBAGENT_PROFILE,
-  ],
-  promptSlot: createCliPromptSlotBinding({
-    kernelName: "cf-harness",
-    surface: "console-web",
-    role: "direct-command",
-  }),
+const CONSOLE_PROMPT_SLOT = createCliPromptSlotBinding({
+  kernelName: "cf-harness",
+  surface: "console-web",
+  role: "direct-command",
 });
 
 /**
@@ -1195,10 +1251,7 @@ export class ConsoleServer {
    * next session actually gets.
    */
   #sessionPolicy(): HarnessChatPolicy {
-    return consoleChatPolicy(
-      this.#config.patternIndex !== undefined,
-      this.#config.skillsSh !== undefined,
-    );
+    return harnessSessionChatPolicy(this.#config, CONSOLE_PROMPT_SLOT);
   }
 
   /**
@@ -1237,7 +1290,7 @@ export class ConsoleServer {
         status: 400,
       });
     }
-    const body: { text?: unknown; sessionId?: unknown } =
+    const body: { text?: unknown; sessionId?: unknown; inputCells?: unknown } =
       typeof parsed === "object" && parsed !== null ? parsed : {};
     const text = body.text;
     if (typeof text !== "string" || text.trim() === "") {
@@ -1248,10 +1301,18 @@ export class ConsoleServer {
         status: 400,
       });
     }
+    let inputCells: readonly HarnessInputCellSpec[];
+    try {
+      inputCells = parseTaskInputCells(body.inputCells);
+    } catch (error) {
+      return Response.json({
+        error: error instanceof Error ? error.message : String(error),
+      }, { status: 400 });
+    }
     let sessionId = body.sessionId;
     if (sessionId === undefined) {
       const session = await this.#service.startSession(crypto.randomUUID(), {
-        workspace: { hostPath: this.#config.workspacePath },
+        workspace: { hostPath: this.#config.workspace },
         model: this.#config.model,
         artifactRoot: this.#config.artifactRoot,
         policy: this.#sessionPolicy(),
@@ -1264,6 +1325,7 @@ export class ConsoleServer {
     const turn = await this.#service.startTurn(crypto.randomUUID(), {
       sessionId,
       input: { text },
+      ...(inputCells.length > 0 ? { inputCells } : {}),
     });
     if (!turn.ok) {
       return chatErrorResponse(turn);
@@ -1488,24 +1550,8 @@ export const createConsoleInteractiveServiceOptions = (
   sessionStore?: HarnessChatSessionStore,
 ): CreateHarnessInteractiveChatServiceOptions => ({
   basePromptLoopOptions: {
+    ...harnessSessionEngineOptions(config),
     ...modelOptions,
-    model: config.model,
-    artifactRoot: config.artifactRoot,
-    workspaceHostPath: config.workspacePath,
-    cfcResultDir: config.cfcResultDir,
-    cfcInvocationContextDir: config.cfcInvocationContextDir,
-    fabricSession: config.fabricSession,
-    ...(config.patternIndex !== undefined
-      ? { patternIndex: config.patternIndex }
-      : {}),
-    ...(config.skillsSh !== undefined ? { skillsSh: config.skillsSh } : {}),
-    ...(config.maxModelTurns !== undefined
-      ? { maxModelTurns: config.maxModelTurns }
-      : {}),
-    ...(config.skillsRoot !== undefined
-      ? { skillsRoot: config.skillsRoot }
-      : {}),
-    subagentCompositionGuidance: config.childCompositionGuidance,
   },
   ...(config.systemPrompt !== undefined
     ? { systemPrompt: config.systemPrompt }
@@ -1534,10 +1580,10 @@ export const startConsoleServer = async (
   env: Record<string, string | undefined> = Deno.env.toObject(),
   cwd: string = Deno.cwd(),
 ): Promise<void> => {
-  const config = resolveConsoleConfig(args, env, cwd);
+  const config = await resolveConsoleConfig(args, env, cwd);
   for (
     const directory of [
-      config.workspacePath,
+      config.workspace,
       config.artifactRoot,
       config.cfcResultDir,
       config.cfcInvocationContextDir,
@@ -1596,7 +1642,7 @@ export const startConsoleServer = async (
       // reason the posture is printed rather than left to be inferred.
       console.log(`  results:    ${config.cfcResultDir}`);
       console.log(`  contexts:   ${config.cfcInvocationContextDir}`);
-      console.log(`  workspace:  ${config.workspacePath}`);
+      console.log(`  workspace:  ${config.workspace}`);
       console.log(`  artifacts:  ${config.artifactRoot}\n`);
     },
     onError: (error) => {

--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -9,7 +9,6 @@ import {
 } from "@std/path";
 import { normalize as normalizeSandboxPath } from "@std/path/posix";
 import type { JSONSchema } from "@commonfabric/api";
-import { type CfcEnforcementMode } from "@commonfabric/runner/cfc";
 import {
   DEFAULT_GATEWAY_BASE_URL,
   type HarnessFabricSessionConfig,
@@ -65,18 +64,20 @@ import type {
 } from "./contracts/transcript.ts";
 import { CfHarnessEngine } from "./engine.ts";
 import type { HarnessFabricSessionFactory } from "./fabric-session.ts";
-import { wellKnownGrantsContextMessage } from "./well-known-grants.ts";
+import {
+  establishHarnessSessionContext,
+  harnessSessionEngineOptions,
+  type HarnessSessionConfig,
+} from "./session-assembly.ts";
 import {
   CFC_INVOCATION_CONTEXT_DIR_ENV,
   CFC_RESULT_DIR_ENV,
   DEFAULT_DOCKER_RUNSC_IMAGE,
   DEFAULT_FABRIC_MOUNT_PATH,
 } from "./sandbox/docker-runsc.ts";
-import type { DockerRunscAdditionalMountConfig } from "./sandbox/types.ts";
 import {
   type CfHarnessHostMountConfig,
   type CfHarnessHostMountMode,
-  hostMountsToAdditionalMounts,
   parseHostMountSpecs,
 } from "./host-mounts.ts";
 
@@ -86,8 +87,6 @@ import {
   type CreateHarnessPromptLoopOptions,
   type HarnessPromptLoopResult,
 } from "./prompt-loop.ts";
-import { loadHarnessSkillContext } from "./skills/registry.ts";
-import { persistHarnessRunSkillRegistry } from "./skills/run-registry.ts";
 import { createHarnessSkillsShAcquisitionClientFactory } from "./skills-sh/acquisition.ts";
 import {
   createHarnessSkillsShSearchClientFactory,
@@ -140,10 +139,7 @@ import {
   setProvenanceCommand,
 } from "./provenance.ts";
 import type { HarnessInputCellSpec } from "./contracts/input-cells.ts";
-import {
-  inputCellsContextMessage,
-  parseInputCellArgument,
-} from "./input-cells.ts";
+import { parseInputCellArgument } from "./input-cells.ts";
 import {
   HarnessControlError,
   type HarnessControlErrorCode,
@@ -229,12 +225,13 @@ const CLI_COLLECT_FLAGS = [
 
 export type CfHarnessCliOutputMode = (typeof CLI_OUTPUT_MODES)[number];
 
-export interface CfHarnessCliConfig {
-  workspace: string;
-  cwd?: string;
+/**
+ * What one batch CLI invocation resolves to: the session it describes, plus
+ * what belongs to this surface alone — where the prompt came from, how the
+ * result is printed, which run is being resumed.
+ */
+export interface CfHarnessCliConfig extends HarnessSessionConfig {
   focusRoot?: string;
-  allowedToolIds?: readonly BuiltinToolId[];
-  allowedSubagentProfiles: readonly HarnessSubagentProfile[];
   outputMode: CfHarnessCliOutputMode;
   streamEvents: boolean;
   promptSlotRole: PromptSlotRole;
@@ -242,42 +239,18 @@ export interface CfHarnessCliConfig {
   imageAttachments: readonly HarnessImageAttachment[];
   resumeRun?: string;
   systemPrompt?: string;
-  skillsRoot?: string;
-  skillsRootSandboxPath?: string;
-  skillNames: readonly string[];
-  allowedSkillScripts: readonly HarnessAllowedSkillScript[];
-  skillScriptExecutionTarget: HarnessSkillScriptExecutionTarget;
   skillCatalogEnabled: boolean;
-  model?: string;
   modelProvider?: HarnessModelProviderId;
-  reasoningEffort?: string;
-  compactThreshold?: number;
-  promptCacheMode?: "implicit" | "explicit";
   gatewayConfigurationExplicit: boolean;
   harnessHome: string;
   gatewayBaseUrl: string;
   gatewayAuthMode: HarnessGatewayAuthMode;
-  artifactRoot: string;
   resultJsonPath?: string;
   structuredResult?: CfHarnessStructuredResultConfig;
   runManifestPath?: string;
-  cfcEnforcementModeOverride?: CfcEnforcementMode;
-  cfcResultDir?: string;
-  cfcInvocationContextDir?: string;
-  browserAccess?: HarnessBrowserAccessLease;
-  handleValueOrigins: readonly string[];
-  inputCells: readonly HarnessInputCellSpec[];
-  maxModelTurns: number;
   printTranscript: boolean;
   apiKey?: string;
   apiKeySource?: "CF_HARNESS_API_KEY" | "OPENAI_API_KEY";
-  sandboxImage?: string;
-  sandboxDockerRuntime?: string;
-  fabricMount?: string;
-  fabricSession?: HarnessFabricSessionConfig;
-  patternIndex?: HarnessPatternIndexConfig;
-  skillsSh?: HarnessSkillsShConfig;
-  hostMounts: readonly CfHarnessHostMountConfig[];
 }
 
 export interface CfHarnessStructuredResultConfig {
@@ -2033,18 +2006,6 @@ const runCfHarnessWhoamiCommand = (
   return 0;
 };
 
-const createAdditionalMountConfigs = (
-  config: Pick<CfHarnessCliConfig, "fabricMount" | "hostMounts">,
-): readonly DockerRunscAdditionalMountConfig[] => [
-  ...(config.fabricMount !== undefined
-    ? [{
-      kind: "fabric-fuse" as const,
-      hostPath: config.fabricMount,
-    }]
-    : []),
-  ...hostMountsToAdditionalMounts(config.hostMounts),
-];
-
 export const formatCfHarnessCliUsage = (): string => usage;
 
 const toWorkspaceSandboxPath = (
@@ -3136,7 +3097,7 @@ export const runCfHarnessCli = async (
         }
       }
       : undefined;
-    const additionalMounts = createAdditionalMountConfigs(parsed);
+    const sessionOptions = harnessSessionEngineOptions(parsed);
     const skillsShSearchClientFactory = parsed.skillsSh !== undefined &&
         deps.fetchFn !== undefined
       ? createHarnessSkillsShSearchClientFactory(
@@ -3148,31 +3109,6 @@ export const runCfHarnessCli = async (
       parsed.skillsSh !== undefined && deps.fetchFn !== undefined
         ? createHarnessSkillsShAcquisitionClientFactory(deps.fetchFn)
         : undefined;
-    const prepareSkillContextMessages = async (
-      engine: CfHarnessEngine,
-    ): Promise<string[]> => {
-      if (parsed.skillsRoot === undefined) {
-        return [];
-      }
-      const registry = await persistHarnessRunSkillRegistry(engine, {
-        skillsRoot: parsed.skillsRoot,
-        ...(parsed.skillsRootSandboxPath !== undefined
-          ? { sandboxSkillsRoot: parsed.skillsRootSandboxPath }
-          : {}),
-      });
-      if (parsed.skillNames.length === 0) {
-        return [];
-      }
-      const context = await loadHarnessSkillContext({
-        registry,
-        skillNames: parsed.skillNames,
-        source: "cli-preload",
-        runId: engine.getRunState().runId,
-        activatedAt: engine.getRunState().updatedAt,
-      });
-      await engine.persistSkillActivations(context.activations);
-      return [context.contextText];
-    };
     if (parsed.resumeRun !== undefined) {
       const readRunArtifacts = deps.readRunArtifacts ?? readHarnessRunArtifacts;
       const artifacts = await readRunArtifacts(parsed.resumeRun).catch(
@@ -3257,21 +3193,8 @@ export const runCfHarnessCli = async (
       }
       requestAccepted = true;
       const engine = new CfHarnessEngine({
+        ...sessionOptions,
         runState: artifacts.runState,
-        artifactRoot: parsed.artifactRoot,
-        workspaceHostPath: parsed.workspace,
-        ...(parsed.sandboxImage !== undefined
-          ? { sandboxImage: parsed.sandboxImage }
-          : {}),
-        ...(parsed.sandboxDockerRuntime !== undefined
-          ? { sandboxDockerRuntime: parsed.sandboxDockerRuntime }
-          : {}),
-        ...(parsed.cfcResultDir !== undefined
-          ? { cfcResultDir: parsed.cfcResultDir }
-          : {}),
-        ...(parsed.cfcInvocationContextDir !== undefined
-          ? { cfcInvocationContextDir: parsed.cfcInvocationContextDir }
-          : {}),
         model: parsed.model ?? artifacts.runState.model,
         modelProvider,
         credentialOwnerKey,
@@ -3281,28 +3204,6 @@ export const runCfHarnessCli = async (
             gatewayAuthMode: parsed.gatewayAuthMode,
           }
           : {}),
-        ...(parsed.cwd !== undefined ? { cwd: parsed.cwd } : {}),
-        ...(parsed.skillsRoot !== undefined
-          ? { skillsRoot: parsed.skillsRoot }
-          : {}),
-        ...(parsed.allowedSkillScripts.length > 0
-          ? { allowedSkillScripts: parsed.allowedSkillScripts }
-          : {}),
-        skillScriptExecutionTarget: parsed.skillScriptExecutionTarget,
-        ...(parsed.browserAccess !== undefined
-          ? { browserAccess: parsed.browserAccess }
-          : {}),
-        ...(parsed.handleValueOrigins.length > 0
-          ? { handleValueOrigins: parsed.handleValueOrigins }
-          : {}),
-        cfcEnforcementModeOverride: parsed.cfcEnforcementModeOverride,
-        ...(parsed.fabricSession !== undefined
-          ? { fabricSession: parsed.fabricSession }
-          : {}),
-        ...(parsed.patternIndex !== undefined
-          ? { patternIndex: parsed.patternIndex }
-          : {}),
-        ...(parsed.skillsSh !== undefined ? { skillsSh: parsed.skillsSh } : {}),
         ...(skillsShSearchClientFactory !== undefined
           ? { skillsShSearchClientFactory }
           : {}),
@@ -3321,7 +3222,6 @@ export const runCfHarnessCli = async (
         ...(parsed.runManifestPath !== undefined
           ? { runManifestPath: parsed.runManifestPath }
           : {}),
-        ...(additionalMounts.length > 0 ? { additionalMounts } : {}),
       });
       const modelClient = await createSelectedModelClient({
         provider: modelProvider,
@@ -3332,9 +3232,8 @@ export const runCfHarnessCli = async (
       });
       activateEngine(engine);
       const loop = createPromptLoop({
+        ...sessionOptions,
         engine,
-        workspaceHostPath: parsed.workspace,
-        artifactRoot: parsed.artifactRoot,
         model: parsed.model ?? artifacts.runState.model,
         modelProvider,
         credentialOwnerKey,
@@ -3342,48 +3241,18 @@ export const runCfHarnessCli = async (
           ? {
             gatewayBaseUrl: parsed.gatewayBaseUrl,
             gatewayAuthMode: parsed.gatewayAuthMode,
+            apiKey: parsed.apiKey,
+            apiKeySource: parsed.apiKeySource,
           }
           : {}),
-        ...(parsed.cwd !== undefined ? { cwd: parsed.cwd } : {}),
-        ...(parsed.skillsRoot !== undefined
-          ? { skillsRoot: parsed.skillsRoot }
-          : {}),
-        ...(parsed.allowedSkillScripts.length > 0
-          ? { allowedSkillScripts: parsed.allowedSkillScripts }
-          : {}),
-        skillScriptExecutionTarget: parsed.skillScriptExecutionTarget,
-        ...(parsed.browserAccess !== undefined
-          ? { browserAccess: parsed.browserAccess }
-          : {}),
-        ...(parsed.handleValueOrigins.length > 0
-          ? { handleValueOrigins: parsed.handleValueOrigins }
-          : {}),
-        cfcEnforcementModeOverride: parsed.cfcEnforcementModeOverride,
         ...(effectiveRunManifest !== undefined
           ? { runManifest: effectiveRunManifest }
           : {}),
         ...(parsed.runManifestPath !== undefined
           ? { runManifestPath: parsed.runManifestPath }
           : {}),
-        ...(modelProvider === "openai-compatible-gateway"
-          ? { apiKey: parsed.apiKey, apiKeySource: parsed.apiKeySource }
-          : {}),
         ...(modelClient !== undefined ? { modelClient } : {}),
         ...(deps.fetchFn !== undefined ? { fetchFn: deps.fetchFn } : {}),
-        ...(parsed.reasoningEffort !== undefined
-          ? { reasoningEffort: parsed.reasoningEffort }
-          : {}),
-        ...(parsed.compactThreshold !== undefined
-          ? { compactThreshold: parsed.compactThreshold }
-          : {}),
-        ...(parsed.promptCacheMode !== undefined
-          ? { promptCacheMode: parsed.promptCacheMode }
-          : {}),
-        maxModelTurns: parsed.maxModelTurns,
-        allowedSubagentProfiles: parsed.allowedSubagentProfiles,
-        ...(parsed.allowedToolIds !== undefined
-          ? { allowedToolIds: parsed.allowedToolIds }
-          : {}),
       });
       if (artifacts.transcript === undefined) {
         throw new Error(
@@ -3444,21 +3313,7 @@ export const runCfHarnessCli = async (
         deps,
       });
       const engine = new CfHarnessEngine({
-        workspaceHostPath: parsed.workspace,
-        artifactRoot: parsed.artifactRoot,
-        ...(parsed.sandboxImage !== undefined
-          ? { sandboxImage: parsed.sandboxImage }
-          : {}),
-        ...(parsed.sandboxDockerRuntime !== undefined
-          ? { sandboxDockerRuntime: parsed.sandboxDockerRuntime }
-          : {}),
-        ...(parsed.cfcResultDir !== undefined
-          ? { cfcResultDir: parsed.cfcResultDir }
-          : {}),
-        ...(parsed.cfcInvocationContextDir !== undefined
-          ? { cfcInvocationContextDir: parsed.cfcInvocationContextDir }
-          : {}),
-        model: parsed.model,
+        ...sessionOptions,
         modelProvider,
         credentialOwnerKey,
         ...(modelProvider === "openai-compatible-gateway"
@@ -3467,28 +3322,6 @@ export const runCfHarnessCli = async (
             gatewayAuthMode: parsed.gatewayAuthMode,
           }
           : {}),
-        ...(parsed.cwd !== undefined ? { cwd: parsed.cwd } : {}),
-        ...(parsed.skillsRoot !== undefined
-          ? { skillsRoot: parsed.skillsRoot }
-          : {}),
-        ...(parsed.allowedSkillScripts.length > 0
-          ? { allowedSkillScripts: parsed.allowedSkillScripts }
-          : {}),
-        skillScriptExecutionTarget: parsed.skillScriptExecutionTarget,
-        ...(parsed.browserAccess !== undefined
-          ? { browserAccess: parsed.browserAccess }
-          : {}),
-        ...(parsed.handleValueOrigins.length > 0
-          ? { handleValueOrigins: parsed.handleValueOrigins }
-          : {}),
-        cfcEnforcementModeOverride: parsed.cfcEnforcementModeOverride,
-        ...(parsed.fabricSession !== undefined
-          ? { fabricSession: parsed.fabricSession }
-          : {}),
-        ...(parsed.patternIndex !== undefined
-          ? { patternIndex: parsed.patternIndex }
-          : {}),
-        ...(parsed.skillsSh !== undefined ? { skillsSh: parsed.skillsSh } : {}),
         ...(skillsShSearchClientFactory !== undefined
           ? { skillsShSearchClientFactory }
           : {}),
@@ -3505,93 +3338,38 @@ export const runCfHarnessCli = async (
         ...(parsed.runManifestPath !== undefined
           ? { runManifestPath: parsed.runManifestPath }
           : {}),
-        ...(additionalMounts.length > 0 ? { additionalMounts } : {}),
-        ...(parsed.inputCells.length > 0
-          ? { inputCells: parsed.inputCells }
-          : {}),
       });
       activateEngine(engine);
       const loop = createPromptLoop({
+        ...sessionOptions,
         engine,
-        workspaceHostPath: parsed.workspace,
-        artifactRoot: parsed.artifactRoot,
-        model: parsed.model,
         modelProvider,
         credentialOwnerKey,
         ...(modelProvider === "openai-compatible-gateway"
           ? {
             gatewayBaseUrl: parsed.gatewayBaseUrl,
             gatewayAuthMode: parsed.gatewayAuthMode,
+            apiKey: parsed.apiKey,
+            apiKeySource: parsed.apiKeySource,
           }
           : {}),
-        ...(parsed.cwd !== undefined ? { cwd: parsed.cwd } : {}),
-        ...(parsed.skillsRoot !== undefined
-          ? { skillsRoot: parsed.skillsRoot }
-          : {}),
-        ...(parsed.allowedSkillScripts.length > 0
-          ? { allowedSkillScripts: parsed.allowedSkillScripts }
-          : {}),
-        skillScriptExecutionTarget: parsed.skillScriptExecutionTarget,
-        ...(modelProvider === "openai-compatible-gateway"
-          ? { apiKey: parsed.apiKey, apiKeySource: parsed.apiKeySource }
-          : {}),
-        ...(modelClient !== undefined ? { modelClient } : {}),
-        ...(deps.fetchFn !== undefined ? { fetchFn: deps.fetchFn } : {}),
-        ...(parsed.reasoningEffort !== undefined
-          ? { reasoningEffort: parsed.reasoningEffort }
-          : {}),
-        ...(parsed.compactThreshold !== undefined
-          ? { compactThreshold: parsed.compactThreshold }
-          : {}),
-        ...(parsed.promptCacheMode !== undefined
-          ? { promptCacheMode: parsed.promptCacheMode }
-          : {}),
-        cfcEnforcementModeOverride: parsed.cfcEnforcementModeOverride,
         ...(runManifest !== undefined ? { runManifest } : {}),
         ...(parsed.runManifestPath !== undefined
           ? { runManifestPath: parsed.runManifestPath }
           : {}),
-        maxModelTurns: parsed.maxModelTurns,
-        allowedSubagentProfiles: parsed.allowedSubagentProfiles,
-        ...(parsed.browserAccess !== undefined
-          ? { browserAccess: parsed.browserAccess }
-          : {}),
-        ...(parsed.handleValueOrigins.length > 0
-          ? { handleValueOrigins: parsed.handleValueOrigins }
-          : {}),
-        ...(parsed.allowedToolIds !== undefined
-          ? { allowedToolIds: parsed.allowedToolIds }
-          : {}),
+        ...(modelClient !== undefined ? { modelClient } : {}),
+        ...(deps.fetchFn !== undefined ? { fetchFn: deps.fetchFn } : {}),
       });
-      const contextMessages = await prepareSkillContextMessages(engine);
-      // The well-known grants connect the Fabric session up front; a run
-      // configured for one is assumed to use it. A run whose session cannot
-      // be established still runs — its tools will surface the same failure
-      // when called — but the missing grants are said out loud rather than
-      // silently absent.
-      if (engine.fabricSessionAvailable) {
-        try {
-          const grants = await engine.establishWellKnownGrants();
-          const grantMessage = wellKnownGrantsContextMessage(grants);
-          if (grantMessage !== undefined) {
-            contextMessages.push(grantMessage);
-          }
-        } catch (error) {
+      const contextMessages = await establishHarnessSessionContext({
+        engine,
+        config: parsed,
+        onGrantsUnavailable: (error) =>
           io.stderr(
             `fabric grants: unavailable (${
               error instanceof Error ? error.message : String(error)
             })\n`,
-          );
-        }
-      }
-      // Operator input cells are explicit configuration, so unlike the
-      // grants a failure here fails the run rather than proceeding without
-      // what the operator asked for.
-      const inputCells = await engine.establishInputCells();
-      const inputCellsMessage = inputCellsContextMessage(inputCells);
-      if (inputCellsMessage !== undefined) {
-        contextMessages.push(inputCellsMessage);
-      }
+          ),
+      });
       result = await loop.runPrompt({
         prompt: parsed.prompt!,
         imageAttachments: parsed.imageAttachments,

--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -66,8 +66,8 @@ import { CfHarnessEngine } from "./engine.ts";
 import type { HarnessFabricSessionFactory } from "./fabric-session.ts";
 import {
   establishHarnessSessionContext,
-  harnessSessionEngineOptions,
   type HarnessSessionConfig,
+  harnessSessionEngineOptions,
 } from "./session-assembly.ts";
 import {
   CFC_INVOCATION_CONTEXT_DIR_ENV,

--- a/packages/cf-harness/src/contracts/interactive-chat.ts
+++ b/packages/cf-harness/src/contracts/interactive-chat.ts
@@ -1,6 +1,7 @@
 import type { CfcEnforcementMode } from "@commonfabric/runner/cfc";
 import type { HarnessBrowserAccessLease } from "./browser-access.ts";
 import type { HarnessImageAttachment } from "./image.ts";
+import type { HarnessInputCellSpec } from "./input-cells.ts";
 import type { PromptSlotBinding } from "./prompt-slot.ts";
 import type { LoomLocalHostBinding } from "./run-manifest.ts";
 import {
@@ -183,6 +184,15 @@ export interface HarnessChatStartTurnParams {
   input: HarnessChatTurnInput;
   policy?: HarnessChatPolicy;
   browserAccess?: HarnessChatBrowserAccessLease;
+
+  /**
+   * Cells the caller attaches to this turn by reference, each under a name the
+   * model sees. A turn is its own run with its own handle table, so input
+   * cells are named per turn rather than per session: the tokens the model is
+   * given are the ones this turn's run minted.
+   */
+  inputCells?: readonly HarnessInputCellSpec[];
+
   metadata?: Record<string, unknown>;
 }
 

--- a/packages/cf-harness/src/contracts/tool-descriptor.ts
+++ b/packages/cf-harness/src/contracts/tool-descriptor.ts
@@ -30,6 +30,94 @@ export const DEFAULT_PARENT_TOOL_IDS = [
   "describe_handle",
 ] as const satisfies readonly BuiltinToolId[];
 
+/**
+ * The tools that exist only over a fabric session. They join the tool surface
+ * exactly when the run can build one; without it each is absent rather than
+ * present-but-failing, even when an explicit allowlist names it.
+ */
+const FABRIC_SESSION_TOOL_IDS: ReadonlySet<BuiltinToolId> = new Set(
+  ["run_pattern", "assign_slug", "acquire_skill"] as const,
+);
+
+/**
+ * The tools that exist only over the pattern index, gated on the same terms
+ * as the fabric-session ones.
+ */
+const PATTERN_INDEX_TOOL_IDS: ReadonlySet<BuiltinToolId> = new Set(
+  ["search_patterns", "record_feedback"] as const,
+);
+
+/** The metadata-only tool gated on configured skills.sh discovery. */
+const SKILLS_SH_SEARCH_TOOL_IDS: ReadonlySet<BuiltinToolId> = new Set(
+  ["search_skills"] as const,
+);
+
+/** The pinned acquisition tool gated separately from discovery. */
+const SKILLS_SH_ACQUISITION_TOOL_IDS: ReadonlySet<BuiltinToolId> = new Set(
+  ["acquire_skill"] as const,
+);
+
+/**
+ * The tools that exist only over a skill registry, gated on the same terms.
+ * A run given no skills root scans no registry, so `read_skill_resource`
+ * would answer `skill_registry_missing` on every call and `run_skill_script`
+ * has nothing to run — absent rather than present-but-failing, so a model
+ * does not spend turns discovering a tool it was never backed to use.
+ */
+const SKILL_REGISTRY_TOOL_IDS: ReadonlySet<BuiltinToolId> = new Set(
+  ["read_skill_resource", "run_skill_script"] as const,
+);
+
+/** What a run can back the gated tools with. */
+export interface HarnessToolBackingAvailability {
+  fabricSessionAvailable: boolean;
+  patternIndexAvailable: boolean;
+  skillsShSearchAvailable: boolean;
+  skillsShAcquisitionAvailable: boolean;
+  skillRegistryAvailable: boolean;
+}
+
+/** The gated tools this run cannot back, and so does not offer. */
+export const withheldToolIds = (
+  availability: HarnessToolBackingAvailability,
+): ReadonlySet<BuiltinToolId> =>
+  new Set([
+    ...(availability.fabricSessionAvailable ? [] : FABRIC_SESSION_TOOL_IDS),
+    ...(availability.patternIndexAvailable ? [] : PATTERN_INDEX_TOOL_IDS),
+    ...(availability.skillsShSearchAvailable ? [] : SKILLS_SH_SEARCH_TOOL_IDS),
+    ...(availability.skillsShAcquisitionAvailable
+      ? []
+      : SKILLS_SH_ACQUISITION_TOOL_IDS),
+    ...(availability.skillRegistryAvailable ? [] : SKILL_REGISTRY_TOOL_IDS),
+  ]);
+
+/**
+ * The parent tool surface a run offers when nothing narrows it: the default
+ * tools plus every gated tool this run's backing supports.
+ *
+ * This is the one derivation of "which tools does a session have", and every
+ * surface that needs the answer asks here. A surface that computed its own
+ * list would go stale the next time a gated tool is added — which is how a
+ * console session ended up unable to acquire a skill its own registry
+ * configuration had already backed.
+ */
+export const parentToolIdsForBacking = (
+  availability: HarnessToolBackingAvailability,
+): readonly BuiltinToolId[] => {
+  const withheld = withheldToolIds(availability);
+  return [
+    ...DEFAULT_PARENT_TOOL_IDS,
+    ...(availability.fabricSessionAvailable ? FABRIC_SESSION_TOOL_IDS : []),
+    ...(availability.patternIndexAvailable ? PATTERN_INDEX_TOOL_IDS : []),
+    ...(availability.skillsShSearchAvailable ? SKILLS_SH_SEARCH_TOOL_IDS : []),
+    ...(availability.skillsShAcquisitionAvailable
+      ? SKILLS_SH_ACQUISITION_TOOL_IDS
+      : []),
+  ].filter((toolId, index, ids) =>
+    !withheld.has(toolId) && ids.indexOf(toolId) === index
+  );
+};
+
 export type HarnessToolEffectClass = "read" | "write" | "side-effect";
 
 export interface HarnessToolDescriptor {

--- a/packages/cf-harness/src/input-cells.ts
+++ b/packages/cf-harness/src/input-cells.ts
@@ -44,10 +44,10 @@ export interface ParsedInputCellArgument {
 }
 
 /**
- * Parses one `--input-cell` argument of the form `<name>=<link>`. A cell's
- * shape is not stated here: an input cell carries its own declared schema in
- * the fabric, and `describe_handle` answers from that — one source of truth,
- * on the cell, where its labels also live.
+ * Parses one `--input-cell` argument of the form `<name>=<link>`. Neither a
+ * cell's shape nor its labels are stated here: both live on the cell in the
+ * fabric, and `describe_handle` answers from there — one source of truth, on
+ * the cell, rather than an operator's account of it.
  *
  * @throws Error naming the defect when the argument does not fit the
  * grammar; the caller surfaces it as a usage error before any run starts.
@@ -74,7 +74,7 @@ export const parseInputCellArgument = (
   if (ref.includes(";")) {
     const option = ref.slice(ref.indexOf(";") + 1).trim();
     throw new Error(
-      `--input-cell \`${name}\` carries an option \`${option}\`; the flag takes none — a cell's shape and labels live on its declared schema in the fabric`,
+      `--input-cell \`${name}\` carries an option \`${option}\`; the flag takes none — a cell's shape and labels live on the cell in the fabric`,
     );
   }
   return { name, ref };

--- a/packages/cf-harness/src/interactive-chat-service.ts
+++ b/packages/cf-harness/src/interactive-chat-service.ts
@@ -8,7 +8,8 @@ import {
   type CreateHarnessPromptLoopOptions,
   type RunHarnessTranscriptOptions,
 } from "./prompt-loop.ts";
-import { persistHarnessRunSkillRegistry } from "./skills/run-registry.ts";
+import { establishHarnessSessionContext } from "./session-assembly.ts";
+import type { HarnessInputCellSpec } from "./contracts/input-cells.ts";
 import {
   createHarnessChatErrorResponse,
   createHarnessChatEventEnvelope,
@@ -1448,23 +1449,7 @@ export class HarnessInteractiveChatService {
         !record.transcript.some((message) => message.role === "system")
         ? [{ role: "system", content: this.#systemPrompt }]
         : [];
-    const transcript: HarnessTranscriptMessage[] = [
-      ...seededSystemPrompt,
-      ...record.transcript,
-      {
-        role: "user",
-        content: params.input.text,
-        ...(params.input.imageAttachments !== undefined &&
-            params.input.imageAttachments.length > 0
-          ? { imageAttachments: params.input.imageAttachments }
-          : {}),
-      },
-    ];
-    // Prompt loops replay their initial transcript through onTranscriptEvent.
-    // Those messages are durable history, not activity from this turn: in
-    // particular, a recovered unknown-outcome result must not be re-emitted as
-    // a newly completed tool call.
-    let observedTranscriptLength = transcript.length;
+    let observedTranscriptLength = 0;
     // The `delegate_task` children this turn has announced, keyed by the
     // parent tool call that started each one. Membership is what closes the
     // bracket: a `subagent_completed` is emitted only for a child whose
@@ -1472,14 +1457,39 @@ export class HarnessInteractiveChatService {
     const startedSubagents = new Map<string, HarnessChatSubagentSummary>();
 
     try {
-      const loop = await this.#startPromptLoop(
+      const { loop, contextMessages } = await this.#startPromptLoop(
         this.#buildPromptLoopOptions(
           session,
           turnId,
           policy,
           browserAccess,
+          params.inputCells,
         ),
       );
+      // The context messages announce what this turn's own run holds — its
+      // preloaded skills, its granted references, its input cells — so they
+      // sit immediately before the request they are held for, after the
+      // history the session already had.
+      const transcript: HarnessTranscriptMessage[] = [
+        ...seededSystemPrompt,
+        ...record.transcript,
+        ...contextMessages.map((content) =>
+          ({ role: "user", content }) as const
+        ),
+        {
+          role: "user",
+          content: params.input.text,
+          ...(params.input.imageAttachments !== undefined &&
+              params.input.imageAttachments.length > 0
+            ? { imageAttachments: params.input.imageAttachments }
+            : {}),
+        },
+      ];
+      // Prompt loops replay their initial transcript through
+      // onTranscriptEvent. Those messages are durable history, not activity
+      // from this turn: in particular, a recovered unknown-outcome result must
+      // not be re-emitted as a newly completed tool call.
+      observedTranscriptLength = transcript.length;
       const result = await loop.runTranscript({
         transcript,
         model: session.model,
@@ -1561,32 +1571,54 @@ export class HarnessInteractiveChatService {
   }
 
   /**
-   * Starts a turn's loop on a run that already knows its skills. A turn is its
-   * own run, so the scan happens per turn, against the engine this builds and
-   * hands to the loop: the registry has to be on the run state before the
-   * first model turn for `read_skill_resource` to answer and for a delegated
-   * subagent to inherit its profile's preloaded skills.
+   * Starts a turn's loop on a run that already holds everything it was
+   * configured with, and returns the context messages announcing it.
    *
-   * Tools reach the tree on the host here, so the scan records host paths and
-   * no sandbox mount is involved.
+   * A turn is its own run, so this happens per turn against the engine this
+   * builds and hands to the loop: the skill registry has to be on the run
+   * state before the first model turn for `read_skill_resource` to answer and
+   * for a delegated subagent to inherit its profile's preloaded skills, and
+   * the grants and input cells mint their tokens into that run's own handle
+   * table — the tokens a turn is told about are the ones its own run holds.
+   *
+   * Tools reach the tree on the host here, so the skills scan records host
+   * paths and no sandbox mount is involved.
    */
   async #startPromptLoop(
     options: CreateHarnessPromptLoopOptions,
-  ): Promise<HarnessInteractivePromptLoop> {
+  ): Promise<{
+    loop: HarnessInteractivePromptLoop;
+    contextMessages: readonly string[];
+  }> {
     // The skills root reaches this either way: on the options directly, or on
     // an injected engine's own config (where `options.skillsRoot` is unset).
     // Read both so neither shape is missed.
     const skillsRoot = options.engine?.config.skillsRoot ?? options.skillsRoot;
-    if (skillsRoot === undefined) {
-      return this.#createPromptLoop(options);
+    const fabricSession = options.engine?.config.fabricSession ??
+      options.fabricSession;
+    if (
+      options.engine === undefined && skillsRoot === undefined &&
+      fabricSession === undefined
+    ) {
+      // Nothing configured needs a run to be brought up before its first model
+      // turn, and constructing an engine to discover that would build a
+      // sandbox runtime for a turn that has no use for one.
+      return { loop: this.#createPromptLoop(options), contextMessages: [] };
     }
-    // A turn is its own run, so the scan happens every turn: it records the
-    // registry the skill tools read before the first model call, and a run
-    // that reuses an engine still refreshes it, so a skill added or removed
-    // mid-session is not stale.
     const engine = options.engine ?? new CfHarnessEngine(options);
-    await persistHarnessRunSkillRegistry(engine, { skillsRoot });
-    return this.#createPromptLoop({ ...options, engine });
+    const contextMessages = await establishHarnessSessionContext({
+      engine,
+      config: {
+        ...(skillsRoot !== undefined ? { skillsRoot } : {}),
+        skillNames: [],
+      },
+      onGrantsUnavailable: (error) =>
+        console.error("fabric grants unavailable for this turn:", error),
+    });
+    return {
+      loop: this.#createPromptLoop({ ...options, engine }),
+      contextMessages,
+    };
   }
 
   #buildPromptLoopOptions(
@@ -1594,9 +1626,13 @@ export class HarnessInteractiveChatService {
     turnId: string,
     policy: HarnessChatPolicy,
     browserAccess?: HarnessChatBrowserAccessLease,
+    inputCells?: readonly HarnessInputCellSpec[],
   ): CreateHarnessPromptLoopOptions {
     return {
       ...this.#basePromptLoopOptions,
+      ...(inputCells !== undefined && inputCells.length > 0
+        ? { inputCells }
+        : {}),
       ...(session.workspace?.hostPath !== undefined
         ? { workspaceHostPath: session.workspace.hostPath }
         : {}),

--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -88,7 +88,11 @@ import type {
   HarnessToolDescriptor,
   HarnessToolEffectClass,
 } from "./contracts/tool-descriptor.ts";
-import { DEFAULT_PARENT_TOOL_IDS as DEFAULT_PROMPT_LOOP_TOOL_IDS } from "./contracts/tool-descriptor.ts";
+import {
+  type HarnessToolBackingAvailability,
+  parentToolIdsForBacking,
+  withheldToolIds,
+} from "./contracts/tool-descriptor.ts";
 import type { ToolOutputId, ToolResultRef } from "./contracts/tool-result.ts";
 import type {
   HarnessToolCall,
@@ -936,67 +940,6 @@ const subagentProfileConfigForRun = (
     ),
   };
 };
-
-/**
- * The tools that exist only over a fabric session. They join the tool
- * surface exactly when the run can build one; without it each is absent
- * rather than present-but-failing, even when an explicit allowlist names it.
- */
-const FABRIC_SESSION_TOOL_IDS: ReadonlySet<BuiltinToolId> = new Set(
-  ["run_pattern", "assign_slug", "acquire_skill"] as const,
-);
-
-/**
- * The tools that exist only over the pattern index, gated on the same terms
- * as the fabric-session ones.
- */
-const PATTERN_INDEX_TOOL_IDS: ReadonlySet<BuiltinToolId> = new Set(
-  ["search_patterns", "record_feedback"] as const,
-);
-
-/** The metadata-only tool gated on configured skills.sh discovery. */
-const SKILLS_SH_SEARCH_TOOL_IDS: ReadonlySet<BuiltinToolId> = new Set(
-  ["search_skills"] as const,
-);
-
-/** The pinned acquisition tool gated separately from discovery. */
-const SKILLS_SH_ACQUISITION_TOOL_IDS: ReadonlySet<BuiltinToolId> = new Set(
-  ["acquire_skill"] as const,
-);
-
-/**
- * The tools that exist only over a skill registry, gated on the same terms.
- * A run given no skills root scans no registry, so `read_skill_resource`
- * would answer `skill_registry_missing` on every call and `run_skill_script`
- * has nothing to run — absent rather than present-but-failing, so a model
- * does not spend turns discovering a tool it was never backed to use.
- */
-const SKILL_REGISTRY_TOOL_IDS: ReadonlySet<BuiltinToolId> = new Set(
-  ["read_skill_resource", "run_skill_script"] as const,
-);
-
-/** What a run can back the gated tools with. */
-interface HarnessToolBackingAvailability {
-  fabricSessionAvailable: boolean;
-  patternIndexAvailable: boolean;
-  skillsShSearchAvailable: boolean;
-  skillsShAcquisitionAvailable: boolean;
-  skillRegistryAvailable: boolean;
-}
-
-/** The gated tools this run cannot back, and so does not offer. */
-const withheldToolIds = (
-  availability: HarnessToolBackingAvailability,
-): ReadonlySet<BuiltinToolId> =>
-  new Set([
-    ...(availability.fabricSessionAvailable ? [] : FABRIC_SESSION_TOOL_IDS),
-    ...(availability.patternIndexAvailable ? [] : PATTERN_INDEX_TOOL_IDS),
-    ...(availability.skillsShSearchAvailable ? [] : SKILLS_SH_SEARCH_TOOL_IDS),
-    ...(availability.skillsShAcquisitionAvailable
-      ? []
-      : SKILLS_SH_ACQUISITION_TOOL_IDS),
-    ...(availability.skillRegistryAvailable ? [] : SKILL_REGISTRY_TOOL_IDS),
-  ]);
 
 /**
  * The child's initial handle table for a delegation: an empty table salted
@@ -2587,17 +2530,8 @@ export class CfHarnessPromptLoop {
     // The gated tools join the tool surface exactly when the run can back
     // them; see the backing-specific tool-id sets above.
     const availability = this.#toolBackingAvailability();
-    const requestedToolIds = options.allowedToolIds ?? [
-      ...DEFAULT_PROMPT_LOOP_TOOL_IDS,
-      ...(availability.fabricSessionAvailable ? FABRIC_SESSION_TOOL_IDS : []),
-      ...(availability.patternIndexAvailable ? PATTERN_INDEX_TOOL_IDS : []),
-      ...(availability.skillsShSearchAvailable
-        ? SKILLS_SH_SEARCH_TOOL_IDS
-        : []),
-      ...(availability.skillsShAcquisitionAvailable
-        ? SKILLS_SH_ACQUISITION_TOOL_IDS
-        : []),
-    ];
+    const requestedToolIds = options.allowedToolIds ??
+      parentToolIdsForBacking(availability);
     const withheld = withheldToolIds(availability);
     this.#allowedToolIds = new Set(
       requestedToolIds.filter((toolId) => !withheld.has(toolId)),

--- a/packages/cf-harness/src/session-assembly.ts
+++ b/packages/cf-harness/src/session-assembly.ts
@@ -1,0 +1,323 @@
+/**
+ * How one cf-harness session is assembled, for every surface that starts one.
+ *
+ * A session is described by {@link HarnessSessionConfig} — identity and space,
+ * index and publish posture, skills root and registry, host mounts, input
+ * cells, CFC dials, tool and subagent allowances, model settings — and this
+ * module turns that description into the three things a surface needs: the
+ * engine and prompt-loop options it constructs a run from
+ * ({@link harnessSessionEngineOptions}), the tool policy the run offers
+ * ({@link harnessSessionChatPolicy}), and the context messages the run opens
+ * with ({@link establishHarnessSessionContext}).
+ *
+ * A surface's own job is to produce the config: the batch CLI parses argv and
+ * the environment into one, the console server reads flags, environment and
+ * the request body into one. Neither assembles a session itself. A surface
+ * that did would drift from the other the moment a capability was added, and
+ * every capability added since the console shipped had drifted exactly that
+ * way — external skill acquisition, host mounts, discoverable publishing,
+ * well-known grants and input cells were all reachable from argv and from
+ * nowhere else.
+ */
+
+import type { CfcEnforcementMode } from "@commonfabric/runner/cfc";
+import type { CfHarnessEngine } from "./engine.ts";
+import type {
+  HarnessFabricSessionConfig,
+  HarnessPatternIndexConfig,
+  HarnessSkillsShConfig,
+} from "./config.ts";
+import type { HarnessBrowserAccessLease } from "./contracts/browser-access.ts";
+import type { HarnessChatPolicy } from "./contracts/interactive-chat.ts";
+import type { PromptSlotBinding } from "./contracts/prompt-slot.ts";
+import type { HarnessInputCellSpec } from "./contracts/input-cells.ts";
+import type {
+  HarnessAllowedSkillScript,
+  HarnessSkillScriptExecutionTarget,
+} from "./contracts/skill.ts";
+import type { HarnessSubagentProfile } from "./contracts/subagent.ts";
+import {
+  type BuiltinToolId,
+  type HarnessToolBackingAvailability,
+  parentToolIdsForBacking,
+} from "./contracts/tool-descriptor.ts";
+import {
+  type CfHarnessHostMountConfig,
+  hostMountsToAdditionalMounts,
+} from "./host-mounts.ts";
+import { inputCellsContextMessage } from "./input-cells.ts";
+import type { CreateHarnessPromptLoopOptions } from "./prompt-loop.ts";
+import type { DockerRunscAdditionalMountConfig } from "./sandbox/types.ts";
+import { loadHarnessSkillContext } from "./skills/registry.ts";
+import { persistHarnessRunSkillRegistry } from "./skills/run-registry.ts";
+import { wellKnownGrantsContextMessage } from "./well-known-grants.ts";
+
+/**
+ * Everything one harness session runs under, resolved. Surface-specific
+ * concerns are deliberately absent: how a prompt arrived, where a transcript
+ * is written, which port a server binds, whether a result is printed as JSON.
+ * What is here is what changes the run.
+ */
+export interface HarnessSessionConfig {
+  /** The host directory the run's workspace is mounted from. */
+  workspace: string;
+
+  /** The sandbox directory the run starts in, when it is not the workspace. */
+  cwd?: string;
+
+  artifactRoot: string;
+  model?: string;
+  maxModelTurns: number;
+
+  /** The harness's own enforcement dial, over tool policy and the sandbox. */
+  cfcEnforcementModeOverride?: CfcEnforcementMode;
+
+  /** The sandbox's two CFC sidecar transports. */
+  cfcResultDir?: string;
+  cfcInvocationContextDir?: string;
+
+  sandboxImage?: string;
+  sandboxDockerRuntime?: string;
+
+  /** The skills tree scanned into the run's registry, on the host. */
+  skillsRoot?: string;
+
+  /** The same tree as the sandbox addresses it, when the two differ. */
+  skillsRootSandboxPath?: string;
+
+  /** Skills preloaded into the run's opening context, by name. */
+  skillNames: readonly string[];
+
+  allowedSkillScripts: readonly HarnessAllowedSkillScript[];
+  skillScriptExecutionTarget: HarnessSkillScriptExecutionTarget;
+
+  fabricSession?: HarnessFabricSessionConfig;
+  patternIndex?: HarnessPatternIndexConfig;
+  skillsSh?: HarnessSkillsShConfig;
+
+  /** A FUSE mount of the session's fabric, provisioned into the sandbox. */
+  fabricMount?: string;
+
+  hostMounts: readonly CfHarnessHostMountConfig[];
+
+  /** Cells the operator passes in by reference, named for the model. */
+  inputCells: readonly HarnessInputCellSpec[];
+
+  handleValueOrigins: readonly string[];
+
+  /**
+   * The parent tool surface, narrowed. Absent means the whole surface this
+   * run's backing supports — see {@link parentToolIdsForBacking}.
+   */
+  allowedToolIds?: readonly BuiltinToolId[];
+
+  allowedSubagentProfiles: readonly HarnessSubagentProfile[];
+  browserAccess?: HarnessBrowserAccessLease;
+  reasoningEffort?: string;
+  compactThreshold?: number;
+  promptCacheMode?: "implicit" | "explicit";
+
+  /** Whether a `pattern-author` child keeps its composition guidance. */
+  subagentCompositionGuidance?: boolean;
+}
+
+/**
+ * What this configuration can back the gated tools with, before any run
+ * exists. The engine answers the same question from the client factories it
+ * built; this answers it from the configuration those factories are built
+ * out of, so a surface can state its tool policy at startup.
+ */
+export const harnessSessionToolBacking = (
+  config: HarnessSessionConfig,
+): HarnessToolBackingAvailability => ({
+  fabricSessionAvailable: config.fabricSession !== undefined,
+  patternIndexAvailable: config.patternIndex !== undefined,
+  skillsShSearchAvailable: config.skillsSh !== undefined,
+  skillsShAcquisitionAvailable: config.skillsSh !== undefined,
+  skillRegistryAvailable: config.skillsRoot !== undefined,
+});
+
+/**
+ * The chat policy a session runs under: the tools it may call, the subagent
+ * profiles it may delegate to, its enforcement dial, and the standing of the
+ * prompt that starts each turn.
+ *
+ * The tool list is derived rather than listed, so a tool added to the harness
+ * reaches every surface at once — and a tool whose backing this session lacks
+ * is absent rather than offered and failing.
+ */
+export const harnessSessionChatPolicy = (
+  config: HarnessSessionConfig,
+  promptSlot?: PromptSlotBinding,
+): HarnessChatPolicy => ({
+  type: "cf-harness.chat-policy",
+  toolMode: "workspace-write",
+  allowedToolIds: config.allowedToolIds ??
+    parentToolIdsForBacking(harnessSessionToolBacking(config)),
+  allowedSubagentProfiles: config.allowedSubagentProfiles,
+  ...(config.cfcEnforcementModeOverride !== undefined
+    ? { cfcEnforcementMode: config.cfcEnforcementModeOverride }
+    : {}),
+  ...(promptSlot !== undefined ? { promptSlot } : {}),
+});
+
+/** The sandbox bind mounts this session provisions, in one list. */
+export const harnessSessionAdditionalMounts = (
+  config: HarnessSessionConfig,
+): readonly DockerRunscAdditionalMountConfig[] => [
+  ...(config.fabricMount !== undefined
+    ? [{ kind: "fabric-fuse" as const, hostPath: config.fabricMount }]
+    : []),
+  ...hostMountsToAdditionalMounts(config.hostMounts),
+];
+
+/**
+ * The engine and prompt-loop options one session is built from.
+ *
+ * `CreateHarnessPromptLoopOptions` extends the engine's own options, so one
+ * object serves both constructions and a surface cannot hand the engine and
+ * the loop two different sessions. What is left to the caller is everything
+ * this configuration does not decide: the model binding it resolved, the run
+ * manifest it read, the transcript or run state it is resuming, and the test
+ * seams it injects.
+ */
+export const harnessSessionEngineOptions = (
+  config: HarnessSessionConfig,
+): CreateHarnessPromptLoopOptions => {
+  const additionalMounts = harnessSessionAdditionalMounts(config);
+  return {
+    workspaceHostPath: config.workspace,
+    artifactRoot: config.artifactRoot,
+    maxModelTurns: config.maxModelTurns,
+    skillScriptExecutionTarget: config.skillScriptExecutionTarget,
+    allowedSubagentProfiles: config.allowedSubagentProfiles,
+    ...(config.model !== undefined ? { model: config.model } : {}),
+    ...(config.cwd !== undefined ? { cwd: config.cwd } : {}),
+    ...(config.sandboxImage !== undefined
+      ? { sandboxImage: config.sandboxImage }
+      : {}),
+    ...(config.sandboxDockerRuntime !== undefined
+      ? { sandboxDockerRuntime: config.sandboxDockerRuntime }
+      : {}),
+    ...(config.cfcResultDir !== undefined
+      ? { cfcResultDir: config.cfcResultDir }
+      : {}),
+    ...(config.cfcInvocationContextDir !== undefined
+      ? { cfcInvocationContextDir: config.cfcInvocationContextDir }
+      : {}),
+    ...(config.cfcEnforcementModeOverride !== undefined
+      ? { cfcEnforcementModeOverride: config.cfcEnforcementModeOverride }
+      : {}),
+    ...(config.skillsRoot !== undefined
+      ? { skillsRoot: config.skillsRoot }
+      : {}),
+    ...(config.allowedSkillScripts.length > 0
+      ? { allowedSkillScripts: config.allowedSkillScripts }
+      : {}),
+    ...(config.browserAccess !== undefined
+      ? { browserAccess: config.browserAccess }
+      : {}),
+    ...(config.handleValueOrigins.length > 0
+      ? { handleValueOrigins: config.handleValueOrigins }
+      : {}),
+    ...(config.fabricSession !== undefined
+      ? { fabricSession: config.fabricSession }
+      : {}),
+    ...(config.patternIndex !== undefined
+      ? { patternIndex: config.patternIndex }
+      : {}),
+    ...(config.skillsSh !== undefined ? { skillsSh: config.skillsSh } : {}),
+    ...(additionalMounts.length > 0 ? { additionalMounts } : {}),
+    ...(config.inputCells.length > 0 ? { inputCells: config.inputCells } : {}),
+    ...(config.allowedToolIds !== undefined
+      ? { allowedToolIds: config.allowedToolIds }
+      : {}),
+    ...(config.reasoningEffort !== undefined
+      ? { reasoningEffort: config.reasoningEffort }
+      : {}),
+    ...(config.compactThreshold !== undefined
+      ? { compactThreshold: config.compactThreshold }
+      : {}),
+    ...(config.promptCacheMode !== undefined
+      ? { promptCacheMode: config.promptCacheMode }
+      : {}),
+    ...(config.subagentCompositionGuidance !== undefined
+      ? { subagentCompositionGuidance: config.subagentCompositionGuidance }
+      : {}),
+  };
+};
+
+/** What {@link establishHarnessSessionContext} is given beyond the engine. */
+export interface EstablishHarnessSessionContextOptions {
+  engine: CfHarnessEngine;
+
+  config: Pick<
+    HarnessSessionConfig,
+    "skillsRoot" | "skillsRootSandboxPath" | "skillNames"
+  >;
+
+  /**
+   * Where a session that could not connect its fabric is reported. The run
+   * proceeds without its grants — its tools surface the same failure when
+   * called — but the absence is said out loud rather than left to be noticed.
+   */
+  onGrantsUnavailable?: (error: unknown) => void;
+}
+
+/**
+ * Brings up everything a run holds before its first model turn, and returns
+ * the context messages announcing it: the skill registry and any preloaded
+ * skills, the well-known grants of the session's space, and the operator's
+ * input cells.
+ *
+ * The three differ in how they fail, and deliberately. A missing skills root
+ * simply yields no messages. Grants are best-effort: a session that will not
+ * connect is reported and the run continues, because a grant is an
+ * entitlement the run did not ask for. Input cells are explicit operator
+ * configuration, so one that cannot be minted fails the run rather than
+ * starting it without what the operator attached.
+ */
+export const establishHarnessSessionContext = async (
+  options: EstablishHarnessSessionContextOptions,
+): Promise<string[]> => {
+  const { engine, config } = options;
+  const messages: string[] = [];
+  if (config.skillsRoot !== undefined) {
+    const registry = await persistHarnessRunSkillRegistry(engine, {
+      skillsRoot: config.skillsRoot,
+      ...(config.skillsRootSandboxPath !== undefined
+        ? { sandboxSkillsRoot: config.skillsRootSandboxPath }
+        : {}),
+    });
+    if (config.skillNames.length > 0) {
+      const context = await loadHarnessSkillContext({
+        registry,
+        skillNames: config.skillNames,
+        source: "cli-preload",
+        runId: engine.getRunState().runId,
+        activatedAt: engine.getRunState().updatedAt,
+      });
+      await engine.persistSkillActivations(context.activations);
+      messages.push(context.contextText);
+    }
+  }
+  if (engine.fabricSessionAvailable) {
+    try {
+      const grantMessage = wellKnownGrantsContextMessage(
+        await engine.establishWellKnownGrants(),
+      );
+      if (grantMessage !== undefined) {
+        messages.push(grantMessage);
+      }
+    } catch (error) {
+      options.onGrantsUnavailable?.(error);
+    }
+  }
+  const inputCellsMessage = inputCellsContextMessage(
+    await engine.establishInputCells(),
+  );
+  if (inputCellsMessage !== undefined) {
+    messages.push(inputCellsMessage);
+  }
+  return messages;
+};

--- a/packages/cf-harness/src/tools/describe-handle.ts
+++ b/packages/cf-harness/src/tools/describe-handle.ts
@@ -267,23 +267,29 @@ const describeInFabric = async (
       schema: undefined,
     });
     await root.sync();
+    // The labels are the synced document's own metadata, narrowed to the
+    // referent's path by the view, so they cost no read beyond the one the
+    // shape already needed.
     const referent =
       (link.path.length === 0 ? root : root.key(...link.path)) as Cell<unknown>;
-    if (link.path.length > 0) {
-      await referent.sync();
-    }
     const labels = describedLabels(referent);
     const documentSchema = root.getMetaRaw("schema") as JSONSchema | undefined;
-    const schema = link.path.length === 0
-      ? documentSchema ?? root.schema
-      : documentSchema !== undefined
+    if (link.path.length === 0) {
+      const schema = documentSchema ?? root.schema;
+      return { labels, ...(schema !== undefined ? { schema } : {}) };
+    }
+    if (documentSchema !== undefined) {
       // Narrowing a declared schema by a path is a walk over the schema, so
       // the referent's shape is in hand without going near its value.
-      ? ((root.asSchema(documentSchema) as Cell<unknown>)
-        .key(...link.path) as Cell<unknown>).schema
-      // With no declared schema there is nothing to walk, and only the
-      // referent itself can state a shape.
-      : referent.schema;
+      const schema = ((root.asSchema(documentSchema) as Cell<unknown>).key(
+        ...link.path,
+      ) as Cell<unknown>).schema;
+      return { labels, ...(schema !== undefined ? { schema } : {}) };
+    }
+    // With no declared schema there is nothing to walk, and only the referent
+    // itself can state a shape.
+    await referent.sync();
+    const schema = referent.schema;
     return { labels, ...(schema !== undefined ? { schema } : {}) };
   } catch {
     return {};

--- a/packages/cf-harness/src/tools/describe-handle.ts
+++ b/packages/cf-harness/src/tools/describe-handle.ts
@@ -1,5 +1,6 @@
 import type { JSONSchema } from "@commonfabric/api";
 import type { Cell } from "@commonfabric/runner";
+import { cfcLabelViewForCellFailClosed } from "@commonfabric/runner/cfc";
 import { parseLLMFriendlyLink } from "@commonfabric/runner/shared";
 import type { HarnessToolDescriptor } from "../contracts/tool-descriptor.ts";
 import type { HarnessFabricSession } from "../fabric-session.ts";
@@ -38,6 +39,30 @@ export interface DescribeHandleToolOutput {
    * it costs nothing and reveals no value.
    */
   path?: string[];
+
+  /**
+   * The CFC labels the referent carries, one per labelled path within it.
+   * Absent when the run has no session to read them through; an empty list
+   * says the space holds none, which is a different answer.
+   */
+  labels?: DescribeHandleLabel[];
+}
+
+/** The label at one path inside a referent, as atom types and nothing else. */
+export interface DescribeHandleLabel {
+  /** Path within the referent, absent for the referent itself. */
+  path?: string[];
+
+  /**
+   * Confidentiality requirements: one entry per clause, each clause listing
+   * the atom types that satisfy it. A clause of several types is satisfied by
+   * any one of them, so the nesting is the requirement rather than a
+   * formatting choice.
+   */
+  confidentiality: string[][];
+
+  /** Integrity atom types, all of which the value carries. */
+  integrity: string[];
 }
 
 /**
@@ -60,11 +85,10 @@ export interface DescribeHandleToolOutput {
  * 1. The schema the referent DECLARES in the fabric, read through the run's
  *    session when it has one. A piece's document schema is the result schema
  *    of the pattern behind it, which is the shape an agent holding a handle to
- *    that piece would be wiring into a pattern of its own — and it is where a
- *    cell's CFC labels live, so an input cell's shape always answers from its
- *    own declaration. The read is of the document's declared schema and of
- *    nothing else; the referent's value is not read, and a reference outside
- *    the session's own space is not followed.
+ *    that piece would be wiring into a pattern of its own. The read is of the
+ *    document's declared schema and of nothing else; the referent's value is
+ *    not read, and a reference outside the session's own space is not
+ *    followed.
  * 2. The schema the mint recorded out of the harness's OWN work — the result
  *    schema of a pattern this harness compiled and ran, marked
  *    `schemaSource: "harness"` on the entry.
@@ -83,12 +107,23 @@ export interface DescribeHandleToolOutput {
  *
  * A run with no fabric session still answers from its own table, so shape
  * stays inspectable in every run that has handles at all.
+ *
+ * Labels answer beside the shape, from the same synced document, and only
+ * where a session read it: a cell's CFC labels live in its own metadata
+ * rather than on its schema, so shape and labels are two reads of one
+ * document and a run can hold one without the other. What crosses is atom
+ * TYPES — the URLs naming what a value requires and what it carries — and not
+ * an atom's other fields, which say what a label was computed FROM. That is
+ * the same line the shape disclosure draws: a run may know what it is holding
+ * and what handling that demands, and may not read what is behind it. A read
+ * that fails is reported as a label rather than as no label, so a cell whose
+ * metadata could not be interpreted does not read as public.
  */
 export const describeHandleToolDescriptor: HarnessToolDescriptor = {
   toolId: "describe_handle",
   title: "Describe Handle",
   description:
-    "Report the shape of a general handle's referent: its recorded schema and path, never its value. A capability-restricted handle returns a named refusal. Use it to check that a reference is the kind of thing a step expects before passing it on.",
+    "Report the shape of a general handle's referent and the CFC labels it carries: its recorded schema, path and label atom types, never its value. A capability-restricted handle returns a named refusal. Use it to check that a reference is the kind of thing a step expects, and what handling it demands, before passing it on.",
   effectClass: "read",
   inputSchema: {
     type: "object",
@@ -110,6 +145,22 @@ export const describeHandleToolDescriptor: HarnessToolDescriptor = {
       hasSchema: { type: "boolean" },
       schema: {},
       path: { type: "array", items: { type: "string" } },
+      labels: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            path: { type: "array", items: { type: "string" } },
+            confidentiality: {
+              type: "array",
+              items: { type: "array", items: { type: "string" } },
+            },
+            integrity: { type: "array", items: { type: "string" } },
+          },
+          required: ["confidentiality", "integrity"],
+          additionalProperties: false,
+        },
+      },
       error: { type: "string" },
     },
     required: ["outputId", "token", "known", "hasSchema"],
@@ -134,34 +185,80 @@ const pathSegmentsOf = (ref: string): string[] | undefined => {
   }
 };
 
+/** The type an atom names: its `type` field, or the whole of a string atom. */
+const atomType = (atom: unknown): string | undefined => {
+  if (typeof atom === "string") {
+    return atom;
+  }
+  const type = (atom as { type?: unknown } | null)?.type;
+  return typeof type === "string" ? type : undefined;
+};
+
 /**
- * The schema `ref` DECLARES in the session's fabric, or `undefined` when the
- * session cannot state one. A document's declared schema lives in its
- * metadata — for a piece it is the result schema of the pattern behind it —
- * and a reference into the document narrows that schema by its path, which is
- * a walk over the schema rather than a read of the data.
+ * One confidentiality clause's alternatives, as atom types. A bare atom is
+ * its own single alternative, and a clause whose atoms this cannot name is
+ * dropped rather than reported as an empty — that is, unconditional —
+ * requirement.
+ */
+const clauseTypes = (clause: unknown): string[] => {
+  const alternatives = (clause as { anyOf?: unknown } | null)?.anyOf;
+  return (Array.isArray(alternatives) ? alternatives : [clause])
+    .map(atomType)
+    .filter((type): type is string => type !== undefined);
+};
+
+/**
+ * The labels the referent carries, read live through the session. Only atom
+ * TYPES cross: an atom's other fields are whatever minted it wrote, and a
+ * label is disclosed here so a run can tell what it is holding, not so it can
+ * read what a label was computed from.
+ */
+const describedLabels = (cell: Cell<unknown>): DescribeHandleLabel[] =>
+  (cfcLabelViewForCellFailClosed(cell)?.entries ?? []).map((entry) => ({
+    ...(entry.path.length > 0 ? { path: [...entry.path] } : {}),
+    confidentiality: (entry.label.confidentiality ?? [])
+      .map(clauseTypes)
+      .filter((clause) => clause.length > 0),
+    integrity: (entry.label.integrity ?? [])
+      .map(atomType)
+      .filter((type): type is string => type !== undefined),
+  }));
+
+/** What the session can state about `ref`: its declared shape, and its labels. */
+interface DescribedReferent {
+  schema?: JSONSchema;
+  labels?: DescribeHandleLabel[];
+}
+
+/**
+ * What `ref` DECLARES in the session's fabric, or nothing when the session
+ * cannot state it. A document's declared schema lives in its metadata — for a
+ * piece it is the result schema of the pattern behind it — and a reference
+ * into the document narrows that schema by its path, which is a walk over the
+ * schema rather than a read of the data. The labels come off the same synced
+ * document, rebased onto the referent's own path, so one read answers both.
  *
  * A reference outside the session's own space is not followed: the session's
  * authority ends at its space, the same boundary `run_pattern` draws over its
  * inputs. Anything that goes wrong — an unparseable reference, a document
- * that does not exist, a path the schema does not describe — answers
- * `undefined`, since a shape the session cannot state is reported as absent
- * rather than as a failed call.
+ * that does not exist, a path the schema does not describe — answers nothing,
+ * since what the session cannot state is reported as absent rather than as a
+ * failed call.
  */
-const declaredSchemaOf = async (
+const describeInFabric = async (
   session: HarnessFabricSession,
   ref: string,
-): Promise<JSONSchema | undefined> => {
+): Promise<DescribedReferent> => {
   const { pieces } = session;
   const space = pieces.getSpace();
   let link;
   try {
     link = parseLLMFriendlyLink(ref.startsWith("/") ? ref : `/${ref}`, space);
   } catch {
-    return undefined;
+    return {};
   }
   if (link.space !== space) {
-    return undefined;
+    return {};
   }
   try {
     const root = pieces.runtime.getCellFromLink({
@@ -170,23 +267,26 @@ const declaredSchemaOf = async (
       schema: undefined,
     });
     await root.sync();
-    const documentSchema = root.getMetaRaw("schema") as JSONSchema | undefined;
-    if (link.path.length === 0) {
-      return documentSchema ?? root.schema;
+    const referent =
+      (link.path.length === 0 ? root : root.key(...link.path)) as Cell<unknown>;
+    if (link.path.length > 0) {
+      await referent.sync();
     }
-    if (documentSchema !== undefined) {
+    const labels = describedLabels(referent);
+    const documentSchema = root.getMetaRaw("schema") as JSONSchema | undefined;
+    const schema = link.path.length === 0
+      ? documentSchema ?? root.schema
+      : documentSchema !== undefined
       // Narrowing a declared schema by a path is a walk over the schema, so
       // the referent's shape is in hand without going near its value.
-      const described = root.asSchema(documentSchema) as Cell<unknown>;
-      return (described.key(...link.path) as Cell<unknown>).schema;
-    }
-    // With no declared schema there is nothing to walk, and only the referent
-    // itself can state a shape.
-    const referent = root.key(...link.path) as Cell<unknown>;
-    await referent.sync();
-    return referent.schema;
+      ? ((root.asSchema(documentSchema) as Cell<unknown>)
+        .key(...link.path) as Cell<unknown>).schema
+      // With no declared schema there is nothing to walk, and only the
+      // referent itself can state a shape.
+      : referent.schema;
+    return { labels, ...(schema !== undefined ? { schema } : {}) };
   } catch {
-    return undefined;
+    return {};
   }
 };
 
@@ -227,10 +327,10 @@ export const describeHandleTool: HarnessToolDefinition<
     // that. A recorded schema is second-best — it is what whichever step
     // minted the handle happened to know — and it answers when the run has no
     // session, or when the session can state no shape for the address.
-    let schema: JSONSchema | undefined;
+    let described: DescribedReferent = {};
     if (context.getFabricSession !== undefined) {
       try {
-        schema = await declaredSchemaOf(
+        described = await describeInFabric(
           await context.getFabricSession(),
           entry.ref,
         );
@@ -239,9 +339,8 @@ export const describeHandleTool: HarnessToolDefinition<
         // which is what a run without one does anyway.
       }
     }
-    if (schema === undefined && entry.schemaSource === "harness") {
-      schema = entry.schema;
-    }
+    const schema = described.schema ??
+      (entry.schemaSource === "harness" ? entry.schema : undefined);
     // Structure only: whatever the source, the reported schema is rebuilt
     // from structural keywords, so no value and no prose rides out on it.
     const disclosed = schema === undefined
@@ -254,6 +353,7 @@ export const describeHandleTool: HarnessToolDefinition<
       hasSchema: disclosed !== undefined,
       ...(disclosed !== undefined ? { schema: disclosed } : {}),
       ...(path !== undefined ? { path } : {}),
+      ...(described.labels !== undefined ? { labels: described.labels } : {}),
     };
   },
 };

--- a/packages/cf-harness/test/console/server.test.ts
+++ b/packages/cf-harness/test/console/server.test.ts
@@ -4,11 +4,11 @@ import { join, resolve, toFileUrl } from "@std/path";
 import { Identity } from "@commonfabric/identity";
 import { runDenoCommandWithTemporaryLock } from "@commonfabric/test-support/isolated-deno";
 import {
-  consoleChatPolicy,
   ConsoleServer,
   createConsoleInteractiveServiceOptions,
   resolveConsoleConfig,
 } from "../../console/server.ts";
+import { harnessSessionChatPolicy } from "../../src/session-assembly.ts";
 import type { ConsoleSessionListing } from "../../console/sessions.ts";
 import {
   createHarnessChatEventEnvelope,
@@ -188,7 +188,7 @@ describe("console/server", () => {
 
   beforeEach(async () => {
     server = new ConsoleServer(
-      config(),
+      await config(),
       (onEvent) =>
         new HarnessInteractiveChatService({
           createPromptLoop: answeringLoop,
@@ -251,7 +251,7 @@ describe("console/server", () => {
       return Promise.resolve(response);
     };
     const indexed = new ConsoleServer(
-      configWithIndex(),
+      await configWithIndex(),
       (onEvent) =>
         new HarnessInteractiveChatService({
           createPromptLoop: answeringLoop,
@@ -286,7 +286,7 @@ describe("console/server", () => {
     recordCellLabels: (sessionId: string) => Promise<void>,
   ): Promise<{ server: ConsoleServer; stream: Response }> => {
     const held = new ConsoleServer(
-      config(),
+      await config(),
       (onEvent) =>
         new HarnessInteractiveChatService({
           createPromptLoop: answeringLoop,
@@ -315,7 +315,7 @@ describe("console/server", () => {
       prefix: "cf-harness-console-result-event-",
     });
     try {
-      const resultConfig = resolveConsoleConfig(
+      const resultConfig = await resolveConsoleConfig(
         [
           "--fabric-identity",
           "key.pkcs8",
@@ -373,8 +373,8 @@ describe("console/server", () => {
     });
 
   describe("console prompt configuration", () => {
-    it("threads configured skills.sh discovery into the run and policy", () => {
-      const resolved = resolveConsoleConfig(
+    it("threads configured skills.sh discovery into the run and policy", async () => {
+      const resolved = await resolveConsoleConfig(
         [
           "--fabric-identity",
           "key.pkcs8",
@@ -407,16 +407,21 @@ describe("console/server", () => {
       expect(serviceOptions.runIdForTurn?.("session-1", "turn-1")).toBe(
         "turn-1",
       );
-      expect(consoleChatPolicy(false, true).allowedToolIds).toContain(
-        "search_skills",
-      );
-      expect(consoleChatPolicy(false, false).allowedToolIds).not.toContain(
-        "search_skills",
-      );
+      // A registry and a fabric session back both skill tools, so a session
+      // configured for one offers acquisition as well as discovery.
+      const policy = harnessSessionChatPolicy(resolved);
+      expect(policy.allowedToolIds).toContain("search_skills");
+      expect(policy.allowedToolIds).toContain("acquire_skill");
     });
 
-    it("reads the skills.sh discovery registry from the environment", () => {
-      const resolved = resolveConsoleConfig(
+    it("withholds the skill tools from a session with no registry", async () => {
+      const policy = harnessSessionChatPolicy(await config());
+      expect(policy.allowedToolIds).not.toContain("search_skills");
+      expect(policy.allowedToolIds).not.toContain("acquire_skill");
+    });
+
+    it("reads the skills.sh discovery registry from the environment", async () => {
+      const resolved = await resolveConsoleConfig(
         [
           "--fabric-identity",
           "key.pkcs8",
@@ -434,8 +439,8 @@ describe("console/server", () => {
       });
     });
 
-    it("rejects a skills.sh discovery registry that is not a URL", () => {
-      expect(() =>
+    it("rejects a skills.sh discovery registry that is not a URL", async () => {
+      await expect(
         resolveConsoleConfig(
           [
             "--fabric-identity",
@@ -449,8 +454,8 @@ describe("console/server", () => {
           ],
           {},
           "/console",
-        )
-      ).toThrow("--skills-registry-url must be a valid URL");
+        ),
+      ).rejects.toThrow("--skills-registry-url must be a valid URL");
     });
 
     it("reads the named prompt and disables child composition guidance", async () => {
@@ -462,7 +467,7 @@ describe("console/server", () => {
           join(directory, "system.txt"),
           "COMPOSE FIRST\n",
         );
-        const resolved = resolveConsoleConfig(
+        const resolved = await resolveConsoleConfig(
           [
             "--fabric-identity",
             "key.pkcs8",
@@ -479,7 +484,7 @@ describe("console/server", () => {
         );
 
         expect(resolved.systemPrompt).toBe("COMPOSE FIRST\n");
-        expect(resolved.childCompositionGuidance).toBe(false);
+        expect(resolved.subagentCompositionGuidance).toBe(false);
         const serviceOptions = createConsoleInteractiveServiceOptions(
           resolved,
           {
@@ -498,8 +503,8 @@ describe("console/server", () => {
       }
     });
 
-    it("rejects a prompt file that cannot be read", () => {
-      expect(() =>
+    it("rejects a prompt file that cannot be read", async () => {
+      await expect(
         resolveConsoleConfig(
           [
             "--fabric-identity",
@@ -513,8 +518,8 @@ describe("console/server", () => {
           ],
           {},
           "/console-prompt-test",
-        )
-      ).toThrow(
+        ),
+      ).rejects.toThrow(
         "--system-prompt-file could not be read: /console-prompt-test/missing.txt",
       );
     });
@@ -527,7 +532,7 @@ describe("console/server", () => {
         const promptPath = join(directory, "empty.txt");
         await Deno.writeTextFile(promptPath, " \n\t");
 
-        expect(() =>
+        await expect(
           resolveConsoleConfig(
             [
               "--fabric-identity",
@@ -541,8 +546,8 @@ describe("console/server", () => {
             ],
             {},
             directory,
-          )
-        ).toThrow(`--system-prompt-file is empty: ${promptPath}`);
+          ),
+        ).rejects.toThrow(`--system-prompt-file is empty: ${promptPath}`);
       } finally {
         await Deno.remove(directory, { recursive: true });
       }
@@ -684,7 +689,7 @@ describe("console/server", () => {
 
       expect(response.status).toBe(200);
       expect(await response.json()).toEqual({
-        artifactRoot: config().artifactRoot,
+        artifactRoot: (await config()).artifactRoot,
         sessions: [],
       });
     });
@@ -697,13 +702,14 @@ describe("console/server", () => {
       );
 
       expect(response.status).toBe(200);
-      const policy = consoleChatPolicy(false, false);
+      const resolved = await config();
+      const policy = harnessSessionChatPolicy(resolved);
       expect(await response.json()).toEqual({
         systemPromptSha256: null,
         allowedToolIds: [...policy.allowedToolIds],
         allowedSubagentProfiles: [...policy.allowedSubagentProfiles],
-        fabricSpace: config().fabricSession.space,
-        artifactRoot: config().artifactRoot,
+        fabricSpace: resolved.fabricSession.space,
+        artifactRoot: resolved.artifactRoot,
         sessionDbPath: null,
       });
     });
@@ -722,7 +728,7 @@ describe("console/server", () => {
       expect(response.status).toBe(200);
       expect(await response.json()).toEqual({
         ok: true,
-        fabricApiUrl: config().fabricSession.apiUrl,
+        fabricApiUrl: (await config()).fabricSession.apiUrl,
         fabricSession: "unverified",
       });
     });
@@ -781,7 +787,7 @@ describe("console/server", () => {
         prefix: "cf-harness-console-result-route-",
       });
       try {
-        const resultConfig = resolveConsoleConfig(
+        const resultConfig = await resolveConsoleConfig(
           [
             "--fabric-identity",
             "key.pkcs8",
@@ -861,7 +867,7 @@ describe("console/server", () => {
         url: toFileUrl(join(artifactRoot, "sessions.sqlite")),
       });
       try {
-        const resultConfig = resolveConsoleConfig(
+        const resultConfig = await resolveConsoleConfig(
           [
             "--fabric-identity",
             "key.pkcs8",
@@ -941,7 +947,7 @@ describe("console/server", () => {
         finish = resolve;
       });
       const waitingServer = new ConsoleServer(
-        config(),
+        await config(),
         (onEvent) =>
           new HarnessInteractiveChatService({
             createPromptLoop: () => ({
@@ -1133,7 +1139,7 @@ describe("console/server", () => {
       // unreadable keyfile names the path the operator configured, which the
       // page must not read.
       const server = new ConsoleServer(
-        config(),
+        await config(),
         (onEvent) =>
           new HarnessInteractiveChatService({
             createPromptLoop: answeringLoop,

--- a/packages/cf-harness/test/console/server.test.ts
+++ b/packages/cf-harness/test/console/server.test.ts
@@ -24,6 +24,7 @@ import {
 } from "../../src/interactive-chat-service.ts";
 import { openSqliteHarnessChatSessionStore } from "../../src/sqlite-session-store.ts";
 import type {
+  CreateHarnessPromptLoopOptions,
   HarnessPromptLoopResult,
   RunHarnessTranscriptOptions,
 } from "../../src/prompt-loop.ts";
@@ -104,6 +105,9 @@ const advancingClock = () => {
 
 /** The identity the proxied index client signs with in these tests. */
 const signer = await Identity.fromPassphrase("cf-harness console index proxy");
+
+/** An entity id of the shape an input-cell reference has to carry. */
+const CELL_ID = `of:fid1:${"A".repeat(43)}`;
 
 const config = () =>
   resolveConsoleConfig(
@@ -1027,6 +1031,62 @@ describe("console/server", () => {
 
       expect(response.status).toBe(400);
       expect((await response.json()).error).toBe("sessionId must be a string");
+    });
+
+    it("attaches the task's input cells to the run that answers it", async () => {
+      // The weaver flow: a caller names cells it wants the task computed
+      // over, by reference and under its own names. What reaches the run is
+      // the specification; the run mints the tokens the model sees.
+      const loopOptions: CreateHarnessPromptLoopOptions[] = [];
+      const capturing = new ConsoleServer(
+        await config(),
+        (onEvent) =>
+          new HarnessInteractiveChatService({
+            createPromptLoop: (options) => {
+              loopOptions.push(options);
+              return answeringLoop(options);
+            },
+            now: advancingClock(),
+            onEvent,
+          }),
+      );
+      const page = await capturing.handle(getRequest("/"));
+      await page.body?.cancel();
+      const capturedCookie = page.headers.get("set-cookie")!.split(";")[0];
+
+      const response = await capturing.handle(jsonRequest("/api/task", {
+        text: "summarize the trip",
+        inputCells: [{ name: "itinerary", ref: `/${CELL_ID}/days` }],
+      }, { cookie: capturedCookie }));
+      expect(response.status).toBe(200);
+      const started = await response.json();
+      await capturing.service.waitForTurn(started.sessionId, started.turnId);
+
+      expect(loopOptions.at(-1)?.inputCells).toEqual([
+        { name: "itinerary", ref: `/${CELL_ID}/days` },
+      ]);
+    });
+
+    it("answers 400 for an input cell the flag's own grammar refuses", async () => {
+      const response = await server.handle(jsonRequest("/api/task", {
+        text: "summarize the trip",
+        inputCells: [{ name: "not a name", ref: `/${CELL_ID}/days` }],
+      }, { cookie }));
+
+      expect(response.status).toBe(400);
+      expect((await response.json()).error).toContain("--input-cell name");
+    });
+
+    it("answers 400 for input cells that are not a list of name and ref", async () => {
+      const response = await server.handle(jsonRequest("/api/task", {
+        text: "summarize the trip",
+        inputCells: [{ name: "itinerary" }],
+      }, { cookie }));
+
+      expect(response.status).toBe(400);
+      expect((await response.json()).error).toBe(
+        "each input cell needs a string name and ref",
+      );
     });
   });
 

--- a/packages/cf-harness/test/console/server.test.ts
+++ b/packages/cf-harness/test/console/server.test.ts
@@ -1088,6 +1088,54 @@ describe("console/server", () => {
         "each input cell needs a string name and ref",
       );
     });
+
+    it("answers 400 for input cells that are not a list at all", async () => {
+      const response = await server.handle(jsonRequest("/api/task", {
+        text: "summarize the trip",
+        inputCells: { itinerary: `/${CELL_ID}/days` },
+      }, { cookie }));
+
+      expect(response.status).toBe(400);
+      expect((await response.json()).error).toBe("inputCells must be an array");
+    });
+
+    it("answers 400 for an input cell that is not an object", async () => {
+      const response = await server.handle(jsonRequest("/api/task", {
+        text: "summarize the trip",
+        inputCells: [`itinerary=/${CELL_ID}/days`],
+      }, { cookie }));
+
+      expect(response.status).toBe(400);
+      expect((await response.json()).error).toBe(
+        "each input cell must be an object",
+      );
+    });
+
+    it("answers 400 for a name the request uses twice", async () => {
+      // Two references under one name is a request that has not said which
+      // cell the model's `itinerary` is.
+      const response = await server.handle(jsonRequest("/api/task", {
+        text: "summarize the trip",
+        inputCells: [
+          { name: "itinerary", ref: `/${CELL_ID}/days` },
+          { name: "itinerary", ref: `/${CELL_ID}/nights` },
+        ],
+      }, { cookie }));
+
+      expect(response.status).toBe(400);
+      expect((await response.json()).error).toBe(
+        "inputCells names `itinerary` twice",
+      );
+    });
+
+    it("starts a task that names no input cells at all", async () => {
+      const started = await startTask({
+        text: "track my books",
+        inputCells: null,
+      });
+
+      expect(started.turnId).toBeDefined();
+    });
   });
 
   describe("GET /api/events", () => {

--- a/packages/cf-harness/test/describe-handle.test.ts
+++ b/packages/cf-harness/test/describe-handle.test.ts
@@ -7,7 +7,10 @@
 
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import type { FabricValue } from "@commonfabric/data-model";
+import { internSchemaAsTaggedHashString } from "@commonfabric/data-model-schema";
 import { createSession, Identity } from "@commonfabric/identity";
+import type { URI } from "@commonfabric/memory/interface";
 import { PiecesController } from "@commonfabric/piece/ops";
 import { Runtime } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
@@ -41,6 +44,20 @@ import { createToolOutputId } from "../src/contracts/tool-result.ts";
 import type { HarnessToolContext } from "../src/tools/types.ts";
 
 const signer = await Identity.fromPassphrase("cf-harness describe-handle");
+
+/**
+ * The schema the label fixture's CFC metadata names. Stored metadata carries
+ * a schema reference the commit boundary verifies like any other, so a
+ * fixture that seeds label state installs this document beside it.
+ */
+const LABEL_SEED_SCHEMA = {
+  type: "object",
+  title: "cf-harness-describe-handle-label-seed",
+} as const;
+
+const LABEL_SEED_SCHEMA_HASH: string = internSchemaAsTaggedHashString(
+  LABEL_SEED_SCHEMA,
+);
 
 const HASH_A = "A".repeat(43);
 const REF_A = `/of:fid1:${HASH_A}/summary`;
@@ -653,6 +670,106 @@ describe("describe_handle", () => {
       const reply = JSON.stringify(output);
       expect(reply).not.toContain("Spending Overview");
       expect(reply).not.toContain("groceries");
+    });
+
+    /**
+     * Seeds a document carrying the stored CFC labels `labels`, and returns a
+     * reference to it. The metadata names a schema document the commit
+     * boundary can verify, which is installed in the same transaction — a
+     * seeded label with an unbacked schema reference is refused like any
+     * other.
+     */
+    const seedLabelledCell = async (
+      labels: { confidentiality: unknown[]; integrity: unknown[] },
+    ): Promise<string> => {
+      const space = session.pieces.getSpace();
+      const seed = runtime.edit();
+      const cell = runtime.getCell(
+        space,
+        "describe-handle-labels",
+        undefined,
+        seed,
+      );
+      const id = cell.getAsNormalizedFullLink().id;
+      seed.writeOrThrow({
+        space,
+        scope: "space",
+        id: `cid:${LABEL_SEED_SCHEMA_HASH}` as URI,
+        path: [],
+      }, { value: LABEL_SEED_SCHEMA } as FabricValue);
+      seed.writeOrThrow({ space, scope: "space", id, path: [] }, {
+        value: { note: "a value nothing here reads" },
+        cfc: {
+          version: 1,
+          schemaHash: LABEL_SEED_SCHEMA_HASH,
+          labelMap: {
+            version: 1,
+            entries: [{ path: [], label: labels }],
+          },
+        },
+      } as unknown as FabricValue);
+      expect((await seed.commit()).ok).toBeDefined();
+      return `/${id}`;
+    };
+
+    it("discloses the atom types of a labelled cell, and keeps a disjunction a disjunction", async () => {
+      // What a handle demands of whoever holds it is the other half of what a
+      // handle is, and it is not on the schema: a cell states its labels in
+      // its own metadata. A disjunctive clause is one requirement satisfiable
+      // several ways, so it stays one entry naming its alternatives — listing
+      // them side by side would report a weaker requirement as a stronger one.
+      const ref = await seedLabelledCell({
+        confidentiality: [
+          "https://commonfabric.org/cfc/atom/Space",
+          {
+            anyOf: [
+              {
+                type: "https://commonfabric.org/cfc/atom/Resource",
+                class: "operator-chosen-class",
+                subject: "operator-chosen-subject",
+              },
+              "https://commonfabric.org/cfc/atom/Builtin",
+            ],
+          },
+        ],
+        integrity: [
+          {
+            type: "https://commonfabric.org/cfc/atom/ExternalIngest",
+            source: "operator-chosen-source",
+          },
+        ],
+      });
+      const minted = await mintAddressHandle(
+        createHarnessHandleTable("run-describe"),
+        ref,
+      );
+
+      const output = await describeHandleTool.invoke(
+        contextWith(minted.table, session),
+        { token: minted.token },
+      );
+
+      const label = output.labels?.find((entry) => entry.path === undefined);
+      expect(label?.integrity).toEqual([
+        "https://commonfabric.org/cfc/atom/ExternalIngest",
+      ]);
+      expect(label?.confidentiality).toContainEqual([
+        "https://commonfabric.org/cfc/atom/Space",
+      ]);
+      // The clause's alternatives arrive in the runtime's canonical order,
+      // which is not the order they were written in; what matters is that the
+      // two stayed one clause.
+      expect(label?.confidentiality.map((clause) => [...clause].sort()))
+        .toContainEqual([
+          "https://commonfabric.org/cfc/atom/Builtin",
+          "https://commonfabric.org/cfc/atom/Resource",
+        ]);
+      // An atom's other fields say what a label was computed FROM, which is
+      // the thing a handle exists to withhold.
+      const reply = JSON.stringify(output);
+      expect(reply).not.toContain("operator-chosen-class");
+      expect(reply).not.toContain("operator-chosen-subject");
+      expect(reply).not.toContain("operator-chosen-source");
     });
 
     it("answers what the space says about a cell's labels, so unlabelled and unread are different answers", async () => {

--- a/packages/cf-harness/test/describe-handle.test.ts
+++ b/packages/cf-harness/test/describe-handle.test.ts
@@ -655,6 +655,31 @@ describe("describe_handle", () => {
       expect(reply).not.toContain("groceries");
     });
 
+    it("answers what the space says about a cell's labels, so unlabelled and unread are different answers", async () => {
+      // The distinction is the whole point of reading them through the
+      // session: a cell the space holds no label for answers with an empty
+      // list, while a run that never reached a space answers with no list at
+      // all. Collapsing the two would let a handle a run could not read about
+      // pass for one carrying nothing.
+      const resultRef = await createPiece();
+      const minted = await mintAddressHandle(
+        createHarnessHandleTable("run-describe"),
+        resultRef,
+      );
+
+      const read = await describeHandleTool.invoke(
+        contextWith(minted.table, session),
+        { token: minted.token },
+      );
+      const unread = await describeHandleTool.invoke(
+        contextWith(minted.table),
+        { token: minted.token },
+      );
+
+      expect(read.labels).toEqual([]);
+      expect(unread.labels).toBeUndefined();
+    });
+
     it("reports an address in another space as shapeless even though the runtime could read it", async () => {
       // The session's authority ends at its own space. The neighbouring space
       // is on this very runtime and its piece declares a shape, so an answer

--- a/packages/cf-harness/test/interactive-chat-session-context.test.ts
+++ b/packages/cf-harness/test/interactive-chat-session-context.test.ts
@@ -146,6 +146,45 @@ describe("interactive chat session context", () => {
     expect(announced?.content).not.toContain("/of:fid1:x/days");
   });
 
+  it("runs the turn when its space will not hand over its grants", async () => {
+    // A grant is an entitlement the run did not ask for, so a session that
+    // will not connect still answers the request — its tools surface the same
+    // failure if the turn reaches for one.
+    const seen: HarnessTranscriptMessage[][] = [];
+    const engine = stubEngine({ inputCells: [] });
+    const refusing = {
+      ...engine,
+      config: engine.config,
+      fabricSessionAvailable: true,
+      establishWellKnownGrants: () =>
+        Promise.reject(new Error("no route to the fabric")),
+      establishInputCells: () => Promise.resolve([]),
+    } as unknown as CfHarnessEngine;
+    const service = new HarnessInteractiveChatService({
+      basePromptLoopOptions: { engine: refusing },
+      createPromptLoop: recordingLoop(seen),
+    });
+    await service.handleRequest({
+      type: HARNESS_CHAT_REQUEST_TYPE,
+      protocolVersion: HARNESS_CHAT_PROTOCOL_VERSION,
+      requestId: "req-session",
+      method: "start_session",
+      params: {
+        sessionId: "session-1",
+        workspace: { hostPath: "/workspace" },
+        model: "gpt-test",
+      },
+    });
+
+    await runTurn(service, "turn-1", "what is in this space?");
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0].at(-1)?.content).toBe("what is in this space?");
+    expect(
+      seen[0].some((message) => message.content.includes("cfh:a:grant")),
+    ).toBe(false);
+  });
+
   it("names cells per turn, so a following turn carries only its own", async () => {
     const options: (readonly HarnessInputCellSpec[] | undefined)[] = [];
     const service = new HarnessInteractiveChatService({

--- a/packages/cf-harness/test/interactive-chat-session-context.test.ts
+++ b/packages/cf-harness/test/interactive-chat-session-context.test.ts
@@ -1,0 +1,180 @@
+/**
+ * What an interactive turn opens with.
+ *
+ * A turn is its own run with its own handle table, so the references that run
+ * holds — the well-known grants of its space, the input cells the request
+ * attached — have to be established and announced per turn. Without that a
+ * console session had a fabric session it could not explore and no way to be
+ * handed a cell at all, which is what these tests are about.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import {
+  HARNESS_CHAT_PROTOCOL_VERSION,
+  HARNESS_CHAT_REQUEST_TYPE,
+} from "../src/contracts/interactive-chat.ts";
+import type { HarnessInputCellSpec } from "../src/contracts/input-cells.ts";
+import type { HarnessTranscriptMessage } from "../src/contracts/transcript.ts";
+import type { CfHarnessEngine } from "../src/engine.ts";
+import {
+  HarnessInteractiveChatService,
+  type HarnessInteractivePromptLoopFactory,
+} from "../src/interactive-chat-service.ts";
+import type {
+  HarnessPromptLoopResult,
+  RunHarnessTranscriptOptions,
+} from "../src/prompt-loop.ts";
+
+/**
+ * An engine that reports what a fabric-configured run establishes, without
+ * building a runtime or a sandbox to establish it against. What the service
+ * does with the answers is the subject here; that the real engine mints those
+ * tokens is `engine.test.ts`'s.
+ */
+const stubEngine = (
+  established: { inputCells: readonly HarnessInputCellSpec[] },
+): CfHarnessEngine =>
+  ({
+    config: { fabricSession: { space: "context-space" } },
+    fabricSessionAvailable: true,
+    establishWellKnownGrants: () =>
+      Promise.resolve([{ name: "piece-registry", token: "cfh:a:grant" }]),
+    establishInputCells: () =>
+      Promise.resolve(
+        established.inputCells.map((cell, index) => ({
+          name: cell.name,
+          ref: cell.ref,
+          token: `cfh:a:cell${index}`,
+        })),
+      ),
+  }) as unknown as CfHarnessEngine;
+
+const recordingLoop = (
+  seen: HarnessTranscriptMessage[][],
+): HarnessInteractivePromptLoopFactory =>
+() => ({
+  runTranscript: (options: RunHarnessTranscriptOptions) => {
+    seen.push([...options.transcript]);
+    return Promise.resolve(
+      {
+        model: options.model ?? "gpt-test",
+        finalAssistantText: "done",
+        transcript: [
+          ...options.transcript,
+          { role: "assistant", content: "done" },
+        ],
+        modelTurns: 1,
+      } as HarnessPromptLoopResult,
+    );
+  },
+});
+
+const runTurn = async (
+  service: HarnessInteractiveChatService,
+  turnId: string,
+  text: string,
+  inputCells?: readonly HarnessInputCellSpec[],
+): Promise<void> => {
+  await service.handleRequest({
+    type: HARNESS_CHAT_REQUEST_TYPE,
+    protocolVersion: HARNESS_CHAT_PROTOCOL_VERSION,
+    requestId: `req-${turnId}`,
+    method: "start_turn",
+    params: {
+      sessionId: "session-1",
+      turnId,
+      input: { text },
+      ...(inputCells !== undefined ? { inputCells } : {}),
+    },
+  });
+  await service.waitForTurn("session-1", turnId);
+};
+
+const startedService = async (
+  seen: HarnessTranscriptMessage[][],
+  established: { inputCells: readonly HarnessInputCellSpec[] },
+): Promise<HarnessInteractiveChatService> => {
+  const service = new HarnessInteractiveChatService({
+    basePromptLoopOptions: { engine: stubEngine(established) },
+    createPromptLoop: recordingLoop(seen),
+  });
+  await service.handleRequest({
+    type: HARNESS_CHAT_REQUEST_TYPE,
+    protocolVersion: HARNESS_CHAT_PROTOCOL_VERSION,
+    requestId: "req-session",
+    method: "start_session",
+    params: {
+      sessionId: "session-1",
+      workspace: { hostPath: "/workspace" },
+      model: "gpt-test",
+    },
+  });
+  return service;
+};
+
+describe("interactive chat session context", () => {
+  it("opens a turn with the granted references of its own space", async () => {
+    const seen: HarnessTranscriptMessage[][] = [];
+    const service = await startedService(seen, { inputCells: [] });
+
+    await runTurn(service, "turn-1", "what is in this space?");
+
+    const context = seen[0].filter((message) =>
+      message.role === "user" && message.content.includes("cfh:a:grant")
+    );
+    expect(context).toHaveLength(1);
+    // Before the request it was established for, and after nothing.
+    expect(seen[0].at(-1)?.content).toBe("what is in this space?");
+  });
+
+  it("announces the input cells the request attached, by the caller's names", async () => {
+    const seen: HarnessTranscriptMessage[][] = [];
+    const service = await startedService(seen, {
+      inputCells: [{ name: "itinerary", ref: "/of:fid1:x/days" }],
+    });
+
+    await runTurn(service, "turn-1", "summarize the trip", [
+      { name: "itinerary", ref: "/of:fid1:x/days" },
+    ]);
+
+    const announced = seen[0].find((message) =>
+      message.content.includes("cfh:a:cell0")
+    );
+    expect(announced?.content).toContain("itinerary");
+    // The token stands for the address; the address itself never crosses.
+    expect(announced?.content).not.toContain("/of:fid1:x/days");
+  });
+
+  it("names cells per turn, so a following turn carries only its own", async () => {
+    const options: (readonly HarnessInputCellSpec[] | undefined)[] = [];
+    const service = new HarnessInteractiveChatService({
+      basePromptLoopOptions: { engine: stubEngine({ inputCells: [] }) },
+      createPromptLoop: (loopOptions) => {
+        options.push(loopOptions.inputCells);
+        return recordingLoop([])(loopOptions);
+      },
+    });
+    await service.handleRequest({
+      type: HARNESS_CHAT_REQUEST_TYPE,
+      protocolVersion: HARNESS_CHAT_PROTOCOL_VERSION,
+      requestId: "req-session",
+      method: "start_session",
+      params: {
+        sessionId: "session-1",
+        workspace: { hostPath: "/workspace" },
+        model: "gpt-test",
+      },
+    });
+
+    await runTurn(service, "turn-1", "summarize the trip", [
+      { name: "itinerary", ref: "/of:fid1:x/days" },
+    ]);
+    await runTurn(service, "turn-2", "and the cost?");
+
+    expect(options[0]).toEqual([
+      { name: "itinerary", ref: "/of:fid1:x/days" },
+    ]);
+    expect(options[1]).toBeUndefined();
+  });
+});

--- a/packages/cf-harness/test/session-assembly.test.ts
+++ b/packages/cf-harness/test/session-assembly.test.ts
@@ -1,0 +1,298 @@
+/**
+ * The one session assembly, checked from both surfaces at once.
+ *
+ * The point of these tests is parity: an operator who describes the same
+ * session to the batch CLI and to the console server must get the same
+ * session. Every capability the console lagged the CLI on — external skill
+ * acquisition, host mounts, discoverable publishing, the well-known grants —
+ * was a difference these comparisons would have shown as a failing assertion
+ * the day it appeared, so they are written as comparisons of what the two
+ * surfaces produce rather than as assertions about either one's fields.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { resolveConsoleConfig } from "../console/server.ts";
+import { parseCfHarnessCliArgs } from "../src/cli.ts";
+import {
+  harnessSessionChatPolicy,
+  type HarnessSessionConfig,
+  harnessSessionEngineOptions,
+} from "../src/session-assembly.ts";
+
+const IDENTITY = "/console/key.pkcs8";
+const SPACE = "parity-space";
+const API_URL = "http://localhost:8000";
+const INDEX_URL = "https://index.test/api";
+const REGISTRY_URL = "https://registry.test";
+
+/** The session both surfaces are asked for, spelled each surface's way. */
+const parityArguments = (
+  workspace: string,
+  hostMountSource: string,
+  skillsRoot: string,
+) => ({
+  cli: [
+    "--workspace",
+    workspace,
+    "--artifact-root",
+    "/console/runs",
+    "--model",
+    "gpt-parity",
+    "--max-model-turns",
+    "32",
+    "--skills-root",
+    skillsRoot,
+    "--fabric-api-url",
+    API_URL,
+    "--fabric-identity",
+    IDENTITY,
+    "--fabric-space",
+    SPACE,
+    "--fabric-cfc-posture",
+    "max-enforcement",
+    "--pattern-index-url",
+    INDEX_URL,
+    "--skills-registry-url",
+    REGISTRY_URL,
+    "--host-mount",
+    `name=reference,source=${hostMountSource},target=/reference`,
+    // The console sites the sandbox's two CFC sidecar transports under its own
+    // data directory; the CLI is told where they are. Named on both so the
+    // comparison is of one session rather than of two defaults.
+    "--cfc-result-dir",
+    "/console/.cf-harness-console/cfc/results",
+    "--cfc-invocation-context-dir",
+    "/console/.cf-harness-console/cfc/invocation-context",
+    "--allow-subagent-profile",
+    "default",
+    "--allow-subagent-profile",
+    "pattern-author",
+    "prompt text",
+  ],
+  console: [
+    "--workspace",
+    workspace,
+    "--artifact-root",
+    "/console/runs",
+    "--model",
+    "gpt-parity",
+    "--max-model-turns",
+    "32",
+    "--skills-root",
+    skillsRoot,
+    "--fabric-api-url",
+    API_URL,
+    "--fabric-identity",
+    IDENTITY,
+    "--fabric-space",
+    SPACE,
+    "--fabric-cfc-posture",
+    "max-enforcement",
+    "--pattern-index-url",
+    INDEX_URL,
+    "--skills-registry-url",
+    REGISTRY_URL,
+    "--host-mount",
+    `name=reference,source=${hostMountSource},target=/reference`,
+    "--session-db",
+    "none",
+  ],
+});
+
+/**
+ * The CLI's own resolution, with the environment emptied so a developer's
+ * shell cannot make one surface's answer differ from the other's.
+ */
+const cliSession = async (
+  args: readonly string[],
+): Promise<HarnessSessionConfig> => {
+  const parsed = await parseCfHarnessCliArgs(args, {
+    cwd: "/console",
+    env: {},
+  });
+  if ("help" in parsed) {
+    throw new Error("parity arguments asked for help");
+  }
+  return parsed;
+};
+
+/**
+ * A workspace holding a skills tree and a directory to bind-mount. Both have
+ * to exist on disk: a mount source is resolved through its real path, and the
+ * CLI holds a skills root to the workspace and the run's host mounts.
+ */
+const parityDirectories = async (): Promise<
+  {
+    workspace: string;
+    hostMountSource: string;
+    skillsRoot: string;
+    cleanup: () => Promise<void>;
+  }
+> => {
+  const root = await Deno.makeTempDir({ prefix: "cf-harness-parity-" });
+  await Deno.mkdir(`${root}/reference`);
+  await Deno.mkdir(`${root}/skills`);
+  return {
+    // A temporary directory on macOS is reached through a symlink, so both
+    // surfaces are given the resolved path rather than what `makeTempDir`
+    // returned — otherwise only one of them resolves it and they differ over
+    // a fact about this host rather than about the session.
+    workspace: await Deno.realPath(root),
+    hostMountSource: await Deno.realPath(`${root}/reference`),
+    skillsRoot: await Deno.realPath(`${root}/skills`),
+    cleanup: () => Deno.remove(root, { recursive: true }),
+  };
+};
+
+describe("session-assembly", () => {
+  describe("the CLI and the console assembling one session", () => {
+    it("build the same engine options from the same configuration", async () => {
+      const { workspace, hostMountSource, skillsRoot, cleanup } =
+        await parityDirectories();
+      try {
+        const args = parityArguments(workspace, hostMountSource, skillsRoot);
+        const cli = await cliSession(args.cli);
+        const server = await resolveConsoleConfig(args.console, {}, "/console");
+
+        expect(harnessSessionEngineOptions(server)).toEqual(
+          harnessSessionEngineOptions(cli),
+        );
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("offer the same tools and subagent profiles", async () => {
+      const { workspace, hostMountSource, skillsRoot, cleanup } =
+        await parityDirectories();
+      try {
+        const args = parityArguments(workspace, hostMountSource, skillsRoot);
+        const cli = await cliSession(args.cli);
+        const server = await resolveConsoleConfig(args.console, {}, "/console");
+
+        expect(harnessSessionChatPolicy(server)).toEqual(
+          harnessSessionChatPolicy(cli),
+        );
+        // Named rather than left to the comparison: these are the four the
+        // console could not reach, and a parity test that passed because both
+        // surfaces lost a tool would say nothing about them.
+        const { allowedToolIds } = harnessSessionChatPolicy(server);
+        expect(allowedToolIds).toContain("run_pattern");
+        expect(allowedToolIds).toContain("search_patterns");
+        expect(allowedToolIds).toContain("search_skills");
+        expect(allowedToolIds).toContain("acquire_skill");
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("provision the same host bind mount", async () => {
+      const { workspace, hostMountSource, skillsRoot, cleanup } =
+        await parityDirectories();
+      try {
+        const args = parityArguments(workspace, hostMountSource, skillsRoot);
+        const server = await resolveConsoleConfig(args.console, {}, "/console");
+
+        expect(harnessSessionEngineOptions(server).additionalMounts).toEqual([
+          {
+            kind: "host-bind",
+            name: "reference",
+            hostPath: hostMountSource,
+            sandboxPath: "/reference",
+            readOnly: true,
+          },
+        ]);
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("publish discoverably on the same operator instruction", async () => {
+      const cli = await cliSession([
+        "--fabric-api-url",
+        API_URL,
+        "--fabric-identity",
+        IDENTITY,
+        "--fabric-space",
+        SPACE,
+        "--pattern-index-url",
+        INDEX_URL,
+        "prompt text",
+      ]);
+      const server = await resolveConsoleConfig(
+        [
+          "--fabric-identity",
+          IDENTITY,
+          "--fabric-space",
+          SPACE,
+          "--pattern-index-url",
+          INDEX_URL,
+          "--session-db",
+          "none",
+          "--pattern-index-publish-discoverable",
+        ],
+        { CF_HARNESS_PATTERN_INDEX_PUBLISH_DISCOVERABLE: "1" },
+        "/console",
+      );
+
+      expect(cli.patternIndex).toEqual({ baseUrl: INDEX_URL });
+      expect(server.patternIndex).toEqual({
+        baseUrl: INDEX_URL,
+        publishDiscoverable: true,
+      });
+      expect(
+        (await cliSession([
+          "--fabric-api-url",
+          API_URL,
+          "--fabric-identity",
+          IDENTITY,
+          "--fabric-space",
+          SPACE,
+          "--pattern-index-url",
+          INDEX_URL,
+          "prompt text",
+        ])).patternIndex,
+      ).toEqual({ baseUrl: INDEX_URL });
+    });
+  });
+
+  describe("the tool surface a session's backing supports", () => {
+    const backing = async (
+      args: readonly string[],
+    ): Promise<readonly string[]> =>
+      harnessSessionChatPolicy(
+        await resolveConsoleConfig(
+          [
+            "--fabric-identity",
+            IDENTITY,
+            "--fabric-space",
+            SPACE,
+            "--session-db",
+            "none",
+            ...args,
+          ],
+          {},
+          "/console",
+        ),
+      ).allowedToolIds;
+
+    it("withholds the index tools from a session with no index", async () => {
+      const allowed = await backing([]);
+      expect(allowed).not.toContain("search_patterns");
+      expect(allowed).not.toContain("record_feedback");
+    });
+
+    it("withholds the skill tools from a session with no registry", async () => {
+      const allowed = await backing([]);
+      expect(allowed).not.toContain("search_skills");
+      expect(allowed).not.toContain("acquire_skill");
+    });
+
+    it("offers the fabric tools a configured session always backs", async () => {
+      const allowed = await backing([]);
+      expect(allowed).toContain("run_pattern");
+      expect(allowed).toContain("assign_slug");
+    });
+  });
+});


### PR DESCRIPTION
The console resolved its own configuration, hand-rolled its own tool policy, and
never brought a run up before its first model turn. Every capability added since
it shipped was therefore reachable from argv and from nowhere else: external
skill acquisition (CT-2160), host mounts (CT-2163), discoverable publishing
(CT-2166), the well-known grants that let a session explore its space, and
operator input cells. Five defects, one cause — two assembly paths.

## One assembly

`packages/cf-harness/src/session-assembly.ts` holds the one description of a
session — identity and space, index and publish posture, skills root and
registry, host mounts, input cells, CFC dials, tool and subagent allowances,
model settings — and the three things a surface needs from it:

- `harnessSessionEngineOptions` — the engine and prompt-loop options a run is
  built from. `CreateHarnessPromptLoopOptions` extends the engine's own, so one
  object serves both constructions and a surface cannot hand the engine and the
  loop two different sessions.
- `harnessSessionChatPolicy` — the tools, subagent profiles, enforcement dial
  and prompt slot a session runs under.
- `establishHarnessSessionContext` — the skills registry, the well-known
  grants, and the input cells, with the context messages announcing them.

The batch CLI parses argv into that config; `CfHarnessCliConfig` now extends it
and adds only what belongs to that surface. The console server reads its flags,
environment and request body into the same one. The console's `consoleChatPolicy`
and its duplicated tool-id lists are deleted, as are the two near-identical
engine/loop option literals in `cli.ts` and the console's own copy of them.

Which tools a session offers moves to `contracts/tool-descriptor.ts` as
`parentToolIdsForBacking`, called by the prompt loop's default branch and by the
chat policy, so the two cannot disagree — which is what made `acquire_skill`
absent from one surface and present on the other.

Net: `src/cli.ts` −280, `console/server.ts` net −60 of resolution and policy,
`src/prompt-loop.ts` −80 (moved), against `src/session-assembly.ts` +323 and
`contracts/tool-descriptor.ts` +88.

## What the console gains

`acquire_skill` where a registry backs it; `--host-mount`;
`--no-pattern-index-publish` and `--pattern-index-publish-discoverable`; the
well-known grants of its space, established and announced per turn; and input
cells attached per task on `/api/task`:

```json
{ "text": "…", "inputCells": [{ "name": "itinerary", "ref": "/of:fid1:…/days" }] }
```

Per task rather than per session because a turn is its own run with its own
handle table — the tokens the model is given are the ones that turn minted. The
grammar is `--input-cell`'s own parser, so a spelling the CLI refuses is refused
here with a 400.

## The parity test

`test/session-assembly.test.ts` compares what the two surfaces assemble from the
same operator configuration rather than asserting about either one, so the next
capability cannot reach one surface alone. Mutation-verified: dropping the
acquisition backing, dropping `additionalMounts`, and dropping the console's
`publishDiscoverable` each fail it.

## describe_handle labels

Folded in because it is the same session surface. `describe_handle` now answers
a referent's CFC labels beside its shape, read live through the session. The two
are different reads — labels live on the cell, the schema on its declaration —
so an operator-attached cell that declares no shape still says what handling it
demands. Atom *types* cross and their other fields do not, which is the line the
shape disclosure already draws; `confidentiality` keeps its clause nesting
because flattening a disjunction would report a weaker requirement as a stronger
one. An empty list says the space holds no label, no list says the run had no
session to ask.

## Gates

- `deno fmt --check` — `Checked 5550 files`
- `deno lint` — clean
- `deno task test` (cf-harness) — `ok | 922 passed (1646 steps) | 0 failed`
- `deno task check` — clean
- `deno task check-docs` — `All 599 checked code block(s) passed.`
- `deno task check-skill-facts` — `Agent-facing facts OK (49 documents).`
- `deno task check-command-docs` — `Command documentation OK (93 command(s), 2 deliberately without prose).`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6743?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

