### PR TITLE
fix(runner): recover stale piece instantiation

### DIFF
--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -6656,14 +6656,18 @@ supply; OW29/OW32/OW34 closed):
     pattern once into the next wave. A stop/stopAll/dispose aborts that
     readiness and any named-document pull through the outer registration's
     cancellation signal; a runtime cycle, pointer change, or newer node
-    group wins through exact guards. A second drop tears the exact
-    registration down rather than spinning. A whole-wave abort or abandon
-    is not retried in place. An immediate self-minted instantiate commit
-    refusal/rejection also tears down the exact current registration in every
-    posture, including client/OFF: a graph whose setup writes never landed is
-    a zombie, not a viable self-healing registration. Explicit wave abandon
-    is classified separately and warned without incrementing the serving
-    runtime's structure-load-failure observer; other failures remain loud.
+    group wins through exact guards. Under server execution, an immediate
+    stale-read refusal follows the same catch-up and one-shot reinstantiation
+    path: it is the commit-time form of losing the materialization race, not a
+    terminal graph failure. A second recoverable failure tears the exact
+    registration down rather than spinning. A whole-wave abort or abandon is
+    not retried in place. Non-stale refusals and promise rejections remain
+    terminal in every posture, and client/OFF retains terminal behavior for
+    stale reads: a graph whose setup writes never landed is a zombie unless
+    the serving side's materialization supplies the repair path. Explicit wave
+    abandon is classified separately and warned without incrementing the
+    serving runtime's structure-load-failure observer; other failures remain
+    loud.
     Pinned in `executor-wave.test.ts` by a deterministic whole-document
     conflict plus a held-readiness teardown companion. And OW46's
     `structure-load-stuck` counter is BLIND here: it fires 6× per run

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -6666,10 +6666,18 @@ supply; OW29/OW32/OW34 closed):
     stale reads: a graph whose setup writes never landed is a zombie unless
     the serving side's materialization supplies the repair path. Explicit wave
     abandon is classified separately and warned without incrementing the
-    serving runtime's structure-load-failure observer; other failures remain
-    loud.
+    serving runtime's structure-load-failure observer. A recoverable failure
+    is warned on the same terms while its one retry is outstanding, and is
+    counted only if that retry also loses: the writes have not landed YET,
+    and reporting a loss the retry goes on to repair makes a routine race
+    read as a health regression on the very counter that exists to find real
+    ones. Every other failure remains loud.
     Pinned in `executor-wave.test.ts` by a deterministic whole-document
-    conflict plus a held-readiness teardown companion. And OW46's
+    conflict plus a held-readiness teardown companion, a flag-OFF
+    terminal-behavior companion, and a second-refusal companion for the
+    commit-time arm. The readiness assertions name a real conflicted
+    document, so the catch-up's named-document pull is exercised rather
+    than skipped. And OW46's
     `structure-load-stuck` counter is BLIND here: it fires 6× per run
     in BOTH arms and in the reds names only the HOST's space, because
     it counts deferred structure loads of DEMANDED roots and this

--- a/packages/patterns/integration/lunch-poll-keyed-votes.test.ts
+++ b/packages/patterns/integration/lunch-poll-keyed-votes.test.ts
@@ -143,6 +143,28 @@ describe("lunch poll: a vote is a keyed, mergeable write", () => {
     expect(await alice.read(["voteCount"])).toBe(0);
   });
 
+  it("shows one session's vote to another after it settles", async () => {
+    // The narrowest statement of what a torn-down poll graph costs. Bob
+    // votes; Alice's session must see the tally move. A session whose piece
+    // lost its instantiation and was never re-instantiated keeps serving its
+    // last durable value instead, so this read stays at zero while Bob's
+    // write is sitting in the store. The burst test below catches the same
+    // loss, but only as a side effect of counting rollbacks.
+    const [, bob] = everyone;
+    const option = options[1];
+
+    await bob.send("castVote", { optionId: option, voteType: "green" });
+    await harness.settle();
+    expect(
+      await host.read(["voteCount"]),
+      "the host's graph must observe a vote another session cast",
+    ).toBe(1);
+
+    await bob.send("clearMyVote", { optionId: option });
+    await harness.settle();
+    expect(await host.read(["voteCount"])).toBe(0);
+  });
+
   it("keeps a lunch-time burst from becoming a retry storm", async () => {
     // Everyone re-votes every option at once, repeatedly — the shape of a real
     // lunch decision, where a whole-list write makes each vote wait seconds.

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -1791,12 +1791,13 @@ export class Runner {
   // cancelled ownership already tombstones the work. Tracked solely so tests
   // can synchronize deterministically.
   #pendingDeferredStartCatchUps = new Set<Promise<unknown>>();
-  // Self-minted piece instantiations seal asynchronously into the serving
-  // wave. Their local graph is speculative until that wave settles, so a
-  // contribution drop tears down that exact node group and re-instantiates it
-  // once against the rolled-back view. This set is a deterministic test seam:
-  // disposal relies on the registration and lifecycle guards rather than
-  // waiting for a wave that a closing serving loop may abandon.
+  // Self-minted piece instantiations commit asynchronously. Their local graph
+  // is speculative until the commit and any serving-wave settlement succeed,
+  // so a stale-read refusal or contribution drop tears down that exact node
+  // group and re-instantiates it once against the repaired view. This set is a
+  // deterministic test seam: disposal relies on the registration and
+  // lifecycle guards rather than waiting for a readiness gate or a wave that
+  // a closing serving loop may abandon.
   #pendingPieceInstantiationSettlements = new Set<Promise<unknown>>();
   // Both maps record that this runner prepared or stopped a result, so a later
   // start of the same result can reuse the cells it already assembled instead
@@ -3331,7 +3332,7 @@ export class Runner {
 
     // Create cancel group early, before wiring pattern/node sinks.
     const [cancelGroup, addCancel] = useCancelGroup();
-    // A withdrawn instantiation may be waiting for its conflict/session gate
+    // A recoverable instantiation may be waiting for its conflict/session gate
     // and a named-document pull before it retries. That work belongs to the
     // OUTER registration, not the retired node group: stopping the piece must
     // release the fire-and-forget settlement even when readiness never does.
@@ -3380,7 +3381,7 @@ export class Runner {
     const instantiatePattern = (
       pattern: Pattern,
       useTx?: IExtendedStorageTransaction,
-      recoverDroppedContribution = true,
+      recoverOnce = true,
     ) => {
       if (!active || startLifecycleEpoch !== this.#lifecycleEpoch) return;
       // Create new cancel group for nodes
@@ -3455,10 +3456,60 @@ export class Runner {
             active && startLifecycleEpoch === this.#lifecycleEpoch &&
             this.cancels.get(key) === cancel && cancelNodes === nodeCancel &&
             currentPatternKey === patternKeyAtInstantiation;
+          const recoverInstantiationOnce = async (error: unknown) => {
+            if (!exactNodesAreCurrent()) return;
+            if (!recoverOnce) {
+              teardownRegistrationIfCurrent();
+              return;
+            }
+
+            // The graph reads its own pending setup and internal-cell writes
+            // while it is installed. A stale-read refusal or a later wave
+            // withdrawal means those writes never became durable. Retire only
+            // the nodes this transaction installed; the outer registration
+            // remains in place so its parent/root owner keeps the same
+            // cancellation handle.
+            nodeCancel();
+            if (cancelNodes === nodeCancel) cancelNodes = undefined;
+            await this.runtime.awaitCommitRetryReadiness(
+              error,
+              retryReadinessTeardown.signal,
+            );
+
+            // A stop aborts the readiness/pull work above; a runtime cycle,
+            // pointer change, or newer instantiation during the wait owns the
+            // key now. Otherwise retry exactly once; a second recoverable
+            // failure tears the registration down instead of spinning.
+            if (
+              retryReadinessTeardown.signal.aborted || !active ||
+              startLifecycleEpoch !== this.#lifecycleEpoch ||
+              this.cancels.get(key) !== cancel ||
+              currentPatternKey !== patternKeyAtInstantiation ||
+              cancelNodes !== undefined
+            ) {
+              return;
+            }
+            try {
+              instantiatePattern(pattern, undefined, false);
+            } catch (retryError) {
+              this.#reportPieceStartCommitFailure(
+                instantiateActionId,
+                retryError,
+              );
+              teardownRegistrationIfCurrent();
+            }
+          };
           const commitWork = actualTx.commit().then(async ({ error }) => {
             if (error !== undefined) {
               this.#reportPieceStartCommitFailure(instantiateActionId, error);
-              if (exactNodesAreCurrent()) teardownRegistrationIfCurrent();
+              if (
+                this.runtime.experimental.serverExecution === true &&
+                isStaleReadConflict(error)
+              ) {
+                await recoverInstantiationOnce(error);
+              } else if (exactNodesAreCurrent()) {
+                teardownRegistrationIfCurrent();
+              }
               return;
             }
             const settlement = waveSettlementOf(actualTx);
@@ -3489,46 +3540,7 @@ export class Runner {
               teardownRegistrationIfCurrent();
               return;
             }
-            if (!recoverDroppedContribution) {
-              teardownRegistrationIfCurrent();
-              return;
-            }
-
-            // The graph reads its own pending setup and internal-cell writes
-            // while it is installed. Once the wave withdraws those writes,
-            // keeping that graph would leave a registration whose substrate
-            // never became durable. Retire only the nodes this transaction
-            // installed; the outer registration remains in place so its
-            // original parent/root owner keeps the same cancellation handle.
-            nodeCancel();
-            if (cancelNodes === nodeCancel) cancelNodes = undefined;
-            await this.runtime.awaitCommitRetryReadiness(
-              settled.error,
-              retryReadinessTeardown.signal,
-            );
-
-            // A stop aborts the readiness/pull work above; a runtime cycle,
-            // pointer change, or newer instantiation during the wait owns the
-            // key now. Otherwise retry exactly once; a second drop tears the
-            // registration down instead of spinning on a permanent conflict.
-            if (
-              retryReadinessTeardown.signal.aborted || !active ||
-              startLifecycleEpoch !== this.#lifecycleEpoch ||
-              this.cancels.get(key) !== cancel ||
-              currentPatternKey !== patternKeyAtInstantiation ||
-              cancelNodes !== undefined
-            ) {
-              return;
-            }
-            try {
-              instantiatePattern(pattern, undefined, false);
-            } catch (retryError) {
-              this.#reportPieceStartCommitFailure(
-                instantiateActionId,
-                retryError,
-              );
-              teardownRegistrationIfCurrent();
-            }
+            await recoverInstantiationOnce(settled.error);
           }).catch((error) => {
             this.#reportPieceStartCommitFailure(instantiateActionId, error);
             if (exactNodesAreCurrent()) teardownRegistrationIfCurrent();
@@ -6352,9 +6364,10 @@ export class Runner {
 
   /**
    * TESTS ONLY: settle self-minted piece-instantiation commits and any
-   * withdrawal recovery they schedule. Never called from dispose(): a serving
-   * wave can remain open until its host closes or abandons it, while lifecycle
-   * guards already prevent a settled continuation from reviving stopped work.
+   * one-shot recovery they schedule. Never called from dispose(): a readiness
+   * gate or serving wave can remain open until its host closes or abandons it,
+   * while lifecycle guards already prevent a settled continuation from
+   * reviving stopped work.
    */
   async idlePieceInstantiationSettlements(): Promise<void> {
     while (this.#pendingPieceInstantiationSettlements.size > 0) {

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -3456,12 +3456,39 @@ export class Runner {
             active && startLifecycleEpoch === this.#lifecycleEpoch &&
             this.cancels.get(key) === cancel && cancelNodes === nodeCancel &&
             currentPatternKey === patternKeyAtInstantiation;
-          const recoverInstantiationOnce = async (error: unknown) => {
-            if (!exactNodesAreCurrent()) return;
-            if (!recoverOnce) {
+          const recoverInstantiationOnce = async (
+            error: unknown,
+            recoverable = true,
+          ) => {
+            if (!exactNodesAreCurrent()) {
+              // A stop, a runtime cycle, or a newer instantiation retired
+              // these nodes while the commit was in flight. Whoever holds
+              // the key now has their own graph; nothing was lost.
+              logger.warn("piece-start-commit-superseded", () => [
+                `piece-start commit ${instantiateActionId} was refused after ` +
+                "its nodes were retired; the current owner is unaffected",
+                error,
+              ]);
+              return;
+            }
+            if (!recoverOnce || !recoverable) {
+              // Either the one retry lost the same way, or this failure was
+              // never the recoverable class. The graph's setup does not
+              // become durable and the load has genuinely failed.
+              this.#reportPieceStartCommitFailure(instantiateActionId, error);
               teardownRegistrationIfCurrent();
               return;
             }
+
+            // Recoverable, and about to be recovered: the setup writes have
+            // not landed YET. Counting this as a structure-load failure
+            // would report a loss that the retry below goes on to repair,
+            // and a routine race would read as a health regression.
+            logger.warn("piece-start-commit-recovering", () => [
+              `piece-start commit ${instantiateActionId} lost its basis to ` +
+              "the serving side; re-instantiating once from the caught-up view",
+              error,
+            ]);
 
             // The graph reads its own pending setup and internal-cell writes
             // while it is installed. A stale-read refusal or a later wave
@@ -3501,15 +3528,15 @@ export class Runner {
           };
           const commitWork = actualTx.commit().then(async ({ error }) => {
             if (error !== undefined) {
-              this.#reportPieceStartCommitFailure(instantiateActionId, error);
               if (
                 this.runtime.experimental.serverExecution === true &&
                 isStaleReadConflict(error)
               ) {
                 await recoverInstantiationOnce(error);
-              } else if (exactNodesAreCurrent()) {
-                teardownRegistrationIfCurrent();
+                return;
               }
+              this.#reportPieceStartCommitFailure(instantiateActionId, error);
+              if (exactNodesAreCurrent()) teardownRegistrationIfCurrent();
               return;
             }
             const settlement = waveSettlementOf(actualTx);
@@ -3529,18 +3556,19 @@ export class Runner {
                 "wave abandon; the enclosing lifecycle owns any restart",
                 settled.error,
               ]);
-            } else {
-              this.#reportPieceStartCommitFailure(
-                instantiateActionId,
-                settled.error,
-              );
-            }
-            if (!exactNodesAreCurrent()) return;
-            if (waveWithdrawalCause !== "contribution-dropped") {
-              teardownRegistrationIfCurrent();
+              if (exactNodesAreCurrent()) teardownRegistrationIfCurrent();
               return;
             }
-            await recoverInstantiationOnce(settled.error);
+            // A WHOLE contribution drop is recoverable in the same sense the
+            // stale-read refusal is, and the helper reports only if its one
+            // retry also loses. A partial drop is not: part of the
+            // contribution stands, so there is no rolled-back view to
+            // re-instantiate against, and it takes the same terminal arm a
+            // second failure takes.
+            await recoverInstantiationOnce(
+              settled.error,
+              waveWithdrawalCause === "contribution-dropped",
+            );
           }).catch((error) => {
             this.#reportPieceStartCommitFailure(instantiateActionId, error);
             if (exactNodesAreCurrent()) teardownRegistrationIfCurrent();

--- a/packages/runner/test/executor-wave.test.ts
+++ b/packages/runner/test/executor-wave.test.ts
@@ -152,8 +152,9 @@ describe("stage D seal-into-wave", () => {
 
   const stoppedWitnessPiece = async (
     id: string,
-    options: { throwOnInstantiation?: number } = {},
+    options: { throwOnInstantiation?: number; on?: Runtime } = {},
   ) => {
+    const host = options.on ?? runtime;
     let instantiations = 0;
     let lastRunInstantiation = 0;
     const pattern: Pattern = {
@@ -191,17 +192,17 @@ describe("stage D seal-into-wave", () => {
         outputs: {},
       }],
     };
-    const tx = runtime.edit();
-    const cell = runtime.getCell<Record<string, unknown>>(
+    const tx = host.edit();
+    const cell = host.getCell<Record<string, unknown>>(
       space,
       id,
       undefined,
       tx,
     );
-    const running = runtime.runner.run(tx, pattern, {}, cell);
+    const running = host.runner.run(tx, pattern, {}, cell);
     expect((await tx.commit()).error).toBeUndefined();
     await running.pull();
-    runtime.runner.stop(cell);
+    host.runner.stop(cell);
     return {
       cell,
       instantiations: () => instantiations,
@@ -3714,10 +3715,26 @@ describe("stage D seal-into-wave", () => {
     runtime.pieceStartCommitFailureObserver = ({ error }) => {
       failures.push(error);
     };
+    // The refusal names a REAL document, in the shape `toRejectedError`
+    // hands the runner: the engine's message plus the conflict descriptor
+    // parsed out of it. Readiness has two halves — the wire's `readyToRetry`
+    // gate and the named document's pull — and a refusal carrying no
+    // `conflict` silently exercises only the first.
+    const conflicted = witness.cell.getAsNormalizedFullLink().id;
+    const pulled: string[] = [];
+    const provider = runtime.storageManager.open(space);
+    const providerSync = provider.sync.bind(provider);
+    (provider as { sync: typeof provider.sync }).sync = ((
+      ...args: Parameters<typeof provider.sync>
+    ) => {
+      pulled.push(String(args[0]));
+      return providerSync(...args);
+    }) as typeof provider.sync;
     const staleRead = {
       name: "ConflictError" as const,
-      message: "stale confirmed read: of:piece-start at seq 0 " +
+      message: `stale confirmed read: ${conflicted} at seq 0 ` +
         "conflicted with seq 1",
+      conflict: { space, the: "application/json", of: conflicted },
       readyToRetry: () => {
         readinessCalls += 1;
         return Promise.resolve();
@@ -3750,9 +3767,165 @@ describe("stage D seal-into-wave", () => {
 
     expect(pieceInstantiationSeals).toBe(2);
     expect(readinessCalls).toBe(1);
+    expect(
+      pulled,
+      "readiness must also pull the conflicted document, so the retry's " +
+        "write carries its true version instead of re-asserting seq 0",
+    ).toContain(conflicted);
     expect(failures).toContain(staleRead);
     expect(witness.instantiations()).toBe(3);
     expect(witness.lastRunInstantiation()).toBe(3);
+  });
+
+  it("keeps a stale-read instantiation refusal terminal off the flag", async () => {
+    const offManager = EmulatedStorageManager.connectTo(server, {
+      as: signer,
+    });
+    const offRuntime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: offManager,
+      experimental: { serverExecution: false },
+    });
+    try {
+      const witness = await stoppedWitnessPiece(
+        "off-piece-instantiate-stale-read",
+        { on: offRuntime },
+      );
+
+      // The instantiate transaction names ITSELF through `stampServerRun`,
+      // which an OFF runtime still calls even though it records nothing.
+      // That is the handle this test needs: an OFF runtime rejects the seal
+      // destination the flag-ON tests refuse through, and a start mints
+      // several transactions, so refusing merely the first would not say
+      // which one was refused.
+      const instantiateTxs = new WeakSet<object>();
+      const originalStamp = offRuntime.stampServerRun.bind(offRuntime);
+      (offRuntime as { stampServerRun: typeof offRuntime.stampServerRun })
+        .stampServerRun = ((
+          tx: Parameters<typeof offRuntime.stampServerRun>[0],
+          info: Parameters<typeof offRuntime.stampServerRun>[1],
+        ) => {
+          if (info.actionId.startsWith("piece-instantiate/")) {
+            instantiateTxs.add(tx);
+          }
+          return originalStamp(tx, info);
+        }) as typeof offRuntime.stampServerRun;
+
+      const conflicted = witness.cell.getAsNormalizedFullLink().id;
+      const staleRead = {
+        name: "ConflictError" as const,
+        message: `stale confirmed read: ${conflicted} at seq 0 ` +
+          "conflicted with seq 1",
+        conflict: { space, the: "application/json", of: conflicted },
+        readyToRetry: () => Promise.resolve(),
+      };
+      let refusals = 0;
+      const originalEdit = offRuntime.edit.bind(offRuntime);
+      (offRuntime as { edit: typeof offRuntime.edit }).edit = ((
+        ...args: Parameters<typeof offRuntime.edit>
+      ) => {
+        const tx = originalEdit(...args);
+        const commit = tx.commit.bind(tx);
+        (tx as { commit: typeof tx.commit }).commit = (() => {
+          if (!instantiateTxs.has(tx)) return commit();
+          refusals += 1;
+          tx.abort(staleRead.message);
+          return Promise.resolve({ error: staleRead as never });
+        }) as typeof tx.commit;
+        return tx;
+      }) as typeof offRuntime.edit;
+
+      let readinessCalls = 0;
+      const originalReadiness = offRuntime.awaitCommitRetryReadiness.bind(
+        offRuntime,
+      );
+      offRuntime.awaitCommitRetryReadiness = ((
+        ...args: Parameters<typeof offRuntime.awaitCommitRetryReadiness>
+      ) => {
+        readinessCalls += 1;
+        return originalReadiness(...args);
+      }) as typeof offRuntime.awaitCommitRetryReadiness;
+
+      const started = await offRuntime.start(witness.cell);
+      await offRuntime.idle();
+      await offRuntime.runner.idlePieceInstantiationSettlements();
+
+      // The refusal reached the instantiate commit itself, and off the flag
+      // it stays terminal: no catch-up is awaited and no second attempt is
+      // made. The repaired view a retry would read is the serving side's to
+      // supply, and an OFF runtime has none, so the start reports the piece
+      // as not running rather than recovering it. The same refusal under
+      // the flag leaves `start` true and instantiates a third time.
+      expect(refusals).toBe(1);
+      expect(started).toBe(false);
+      expect(readinessCalls).toBe(0);
+      expect(witness.instantiations()).toBe(2);
+    } finally {
+      await offRuntime.dispose();
+      await offManager.close();
+    }
+  });
+
+  it("tears down after a second stale-read refusal instead of spinning", async () => {
+    const witness = await stoppedWitnessPiece(
+      "wave-piece-instantiate-stale-read-twice",
+    );
+    let pieceInstantiationSeals = 0;
+    let readinessCalls = 0;
+    const failures: unknown[] = [];
+    runtime.pieceStartCommitFailureObserver = ({ error }) => {
+      failures.push(error);
+    };
+    const conflicted = witness.cell.getAsNormalizedFullLink().id;
+    const staleRead = {
+      name: "ConflictError" as const,
+      message: `stale confirmed read: ${conflicted} at seq 0 ` +
+        "conflicted with seq 1",
+      conflict: { space, the: "application/json", of: conflicted },
+      readyToRetry: () => {
+        readinessCalls += 1;
+        return Promise.resolve();
+      },
+    };
+    runtime.installSealDestination({
+      seal: (tx) => {
+        if (
+          !waveRunContextOf(tx)?.actionId.startsWith("piece-instantiate/")
+        ) {
+          return tx.tx.commit();
+        }
+        pieceInstantiationSeals += 1;
+        if (pieceInstantiationSeals <= 2) {
+          return Promise.resolve({ error: staleRead as never });
+        }
+        return tx.tx.commit();
+      },
+    }, {
+      runStamper: (tx, info) =>
+        stampWaveRunContext(tx, {
+          actionId: info.actionId,
+          kind: info.kind,
+        }),
+    });
+
+    expect(await runtime.start(witness.cell)).toBe(true);
+    await runtime.idle();
+    await runtime.runner.idlePieceInstantiationSettlements();
+
+    // Exactly one retry. A basis the serving side does not repair is a
+    // permanent refusal, so the second one retires the registration rather
+    // than spinning on it.
+    expect(pieceInstantiationSeals).toBe(2);
+    expect(readinessCalls).toBe(1);
+    expect(failures).toContain(staleRead);
+    expect(witness.instantiations()).toBe(3);
+
+    // Retired, not wedged: a later owner starts the piece afresh.
+    runtime.clearSealDestination();
+    expect(await runtime.start(witness.cell)).toBe(true);
+    await runtime.idle();
+    await runtime.runner.idlePieceInstantiationSettlements();
+    expect(witness.instantiations()).toBe(4);
   });
 
   it("declines a stale-read refusal the stopped piece no longer owns", async () => {

--- a/packages/runner/test/executor-wave.test.ts
+++ b/packages/runner/test/executor-wave.test.ts
@@ -3755,6 +3755,61 @@ describe("stage D seal-into-wave", () => {
     expect(witness.lastRunInstantiation()).toBe(3);
   });
 
+  it("declines a stale-read refusal the stopped piece no longer owns", async () => {
+    const witness = await stoppedWitnessPiece(
+      "wave-piece-instantiate-stale-read-stopped",
+    );
+    let pieceInstantiationSeals = 0;
+    let readinessCalls = 0;
+    const refusalRequested = Promise.withResolvers<void>();
+    const heldRefusal = Promise.withResolvers<{ error: unknown }>();
+    const staleRead = {
+      name: "ConflictError" as const,
+      message: "stale confirmed read: of:piece-start at seq 0 " +
+        "conflicted with seq 1",
+      readyToRetry: () => {
+        readinessCalls += 1;
+        return Promise.resolve();
+      },
+    };
+    runtime.installSealDestination({
+      seal: (tx) => {
+        if (
+          !waveRunContextOf(tx)?.actionId.startsWith("piece-instantiate/")
+        ) {
+          return tx.tx.commit();
+        }
+        pieceInstantiationSeals += 1;
+        if (pieceInstantiationSeals === 1) {
+          refusalRequested.resolve();
+          return heldRefusal.promise as never;
+        }
+        return tx.tx.commit();
+      },
+    }, {
+      runStamper: (tx, info) =>
+        stampWaveRunContext(tx, {
+          actionId: info.actionId,
+          kind: info.kind,
+        }),
+    });
+
+    expect(await runtime.start(witness.cell)).toBe(true);
+    await refusalRequested.promise;
+
+    // The stop lands while the instantiate commit is still in flight, so the
+    // refusal arrives against a registration this attempt no longer owns.
+    // Recovery declines: the stop keeps the key, and no readiness gate is
+    // entered on behalf of retired nodes.
+    runtime.runner.stop(witness.cell);
+    heldRefusal.resolve({ error: staleRead as never });
+    await runtime.runner.idlePieceInstantiationSettlements();
+
+    expect(pieceInstantiationSeals).toBe(1);
+    expect(readinessCalls).toBe(0);
+    expect(witness.instantiations()).toBe(2);
+  });
+
   it("tears down after an immediate non-stale instantiation refusal", async () => {
     const witness = await stoppedWitnessPiece(
       "wave-piece-instantiate-terminal-refusal",

--- a/packages/runner/test/executor-wave.test.ts
+++ b/packages/runner/test/executor-wave.test.ts
@@ -3704,6 +3704,104 @@ describe("stage D seal-into-wave", () => {
     expect(stored?.document).toEqual({ value: { seq: 9, other: 7 } });
   });
 
+  it("reinstantiates a piece once after an immediate stale-read refusal", async () => {
+    const witness = await stoppedWitnessPiece(
+      "wave-piece-instantiate-stale-read",
+    );
+    let pieceInstantiationSeals = 0;
+    let readinessCalls = 0;
+    const failures: unknown[] = [];
+    runtime.pieceStartCommitFailureObserver = ({ error }) => {
+      failures.push(error);
+    };
+    const staleRead = {
+      name: "ConflictError" as const,
+      message: "stale confirmed read: of:piece-start at seq 0 " +
+        "conflicted with seq 1",
+      readyToRetry: () => {
+        readinessCalls += 1;
+        return Promise.resolve();
+      },
+    };
+    runtime.installSealDestination({
+      seal: (tx) => {
+        if (
+          !waveRunContextOf(tx)?.actionId.startsWith("piece-instantiate/")
+        ) {
+          return tx.tx.commit();
+        }
+        pieceInstantiationSeals += 1;
+        if (pieceInstantiationSeals === 1) {
+          return Promise.resolve({ error: staleRead as never });
+        }
+        return tx.tx.commit();
+      },
+    }, {
+      runStamper: (tx, info) =>
+        stampWaveRunContext(tx, {
+          actionId: info.actionId,
+          kind: info.kind,
+        }),
+    });
+
+    expect(await runtime.start(witness.cell)).toBe(true);
+    await runtime.idle();
+    await runtime.runner.idlePieceInstantiationSettlements();
+
+    expect(pieceInstantiationSeals).toBe(2);
+    expect(readinessCalls).toBe(1);
+    expect(failures).toContain(staleRead);
+    expect(witness.instantiations()).toBe(3);
+    expect(witness.lastRunInstantiation()).toBe(3);
+  });
+
+  it("tears down after an immediate non-stale instantiation refusal", async () => {
+    const witness = await stoppedWitnessPiece(
+      "wave-piece-instantiate-terminal-refusal",
+    );
+    const refusal = {
+      name: "TransactionError" as const,
+      message: "piece instantiate destination refused",
+    };
+    const failures: unknown[] = [];
+    let refusals = 0;
+    runtime.pieceStartCommitFailureObserver = ({ error }) => {
+      failures.push(error);
+    };
+    runtime.installSealDestination({
+      seal: (tx) => {
+        if (
+          waveRunContextOf(tx)?.actionId.startsWith("piece-instantiate/") &&
+          refusals === 0
+        ) {
+          refusals += 1;
+          return Promise.resolve({ error: refusal as never });
+        }
+        return tx.tx.commit();
+      },
+    }, {
+      runStamper: (tx, info) =>
+        stampWaveRunContext(tx, {
+          actionId: info.actionId,
+          kind: info.kind,
+        }),
+    });
+
+    expect(await runtime.start(witness.cell)).toBe(true);
+    await runtime.runner.idlePieceInstantiationSettlements();
+    expect(refusals).toBe(1);
+    expect(failures).toContain(refusal);
+    expect(witness.instantiations()).toBe(2);
+
+    // A terminal refusal retires the exact outer registration, so a later
+    // owner can start the piece afresh instead of finding a dead entry.
+    runtime.clearSealDestination();
+    expect(await runtime.start(witness.cell)).toBe(true);
+    await runtime.idle();
+    await runtime.runner.idlePieceInstantiationSettlements();
+    expect(witness.instantiations()).toBe(3);
+  });
+
   it("reinstantiates a piece once after its bookkeeping contribution is withdrawn, preserving the live registration and action", async () => {
     const witness = await stoppedWitnessPiece(
       "wave-piece-instantiate-recovery",

--- a/packages/runner/test/executor-wave.test.ts
+++ b/packages/runner/test/executor-wave.test.ts
@@ -3772,7 +3772,10 @@ describe("stage D seal-into-wave", () => {
       "readiness must also pull the conflicted document, so the retry's " +
         "write carries its true version instead of re-asserting seq 0",
     ).toContain(conflicted);
-    expect(failures).toContain(staleRead);
+    expect(
+      failures,
+      "a refusal the retry repaired is not a structure-load failure",
+    ).toEqual([]);
     expect(witness.instantiations()).toBe(3);
     expect(witness.lastRunInstantiation()).toBe(3);
   });
@@ -4076,10 +4079,11 @@ describe("stage D seal-into-wave", () => {
     expect(recoveryOutcome.aborted).toBeUndefined();
     expect(route.recoverySeals()).toBe(1);
     expect(
-      failures.some((failure) =>
+      failures.filter((failure) =>
         failure.actionId.startsWith("piece-instantiate/")
       ),
-    ).toBe(true);
+      "a withdrawal the retry repaired is not a structure-load failure",
+    ).toEqual([]);
 
     // The retry kept the original outer registration alive, and the action
     // belonging to its third raw-module instantiation ran.
@@ -4218,13 +4222,21 @@ describe("stage D seal-into-wave", () => {
     const route = routePieceInstantiationWaves(firstWave, recoveryWave);
     const readinessEntered = Promise.withResolvers<void>();
     const heldReadiness = Promise.withResolvers<void>();
-    runtime.pieceStartCommitFailureObserver = ({ actionId, error }) => {
-      if (!actionId.startsWith("piece-instantiate/")) return;
+    // Park the recovery inside the readiness gate. The withdrawal error the
+    // wave mints carries no `readyToRetry`, so one is threaded onto it here
+    // and the real gate still races it against the teardown signal — which
+    // is the behavior under test.
+    const originalReadiness = runtime.awaitCommitRetryReadiness.bind(runtime);
+    runtime.awaitCommitRetryReadiness = ((
+      error: unknown,
+      signal?: AbortSignal,
+    ) => {
       (error as { readyToRetry?: () => Promise<void> }).readyToRetry = () => {
         readinessEntered.resolve();
         return heldReadiness.promise;
       };
-    };
+      return originalReadiness(error, signal);
+    }) as typeof runtime.awaitCommitRetryReadiness;
 
     expect(await runtime.start(cell)).toBe(true);
     await route.firstSeal;


### PR DESCRIPTION
## Summary

- recover an immediate stale-read refusal of a self-minted piece-instantiation commit once under server execution
- share the existing exact-registration, cancellation, readiness, and one-shot guards with contribution-drop recovery
- keep non-stale refusals, promise rejections, client/OFF behavior, and second recoverable failures terminal
- add deterministic regression and boundary coverage and update the server-execution verification record

This fixes the failure exposed by the red main run after #6720 without reverting its contribution-drop recovery mechanism.

## Testing

- runner executor-wave test file: 55 steps passed
- EXPERIMENTAL_SERVER_EXECUTION=true deno task integration patterns lunch-poll-keyed-votes
- deno fmt --check
- deno lint
- deno task check

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6744?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

