### PR TITLE
fix(patterns): a click waits for a control that can take it

### DIFF
--- a/docs/development/UI_TESTING.md
+++ b/docs/development/UI_TESTING.md
@@ -256,6 +256,14 @@ control after even that last measurement is caught as well: the helper stops an
 interaction that misses before the page sees it, and aims again.
 `docs/development/waiting-in-tests.md` describes how.
 
+It also holds until the control is enabled. A disabled control has a layout box
+and passes every rendered-ness check, and it still takes no click: the browser
+raises none on it, and a `cf-button` additionally gives it
+`pointer-events: none`, which sends the press to the host that wraps it.
+Where the state that enables a control is also the state that drops a surface
+above it, waiting covers the move as well as the enable, because the aim is
+taken once the page has settled into the layout it keeps.
+
 **Use `awaitViewSettled(page)`** from `@commonfabric/integration` as the
 lower-level wait after navigation or a state change. When the next step
 clicks a control, use `clickCfButton` instead. It resolves, settles, and marks

--- a/docs/development/waiting-in-tests.md
+++ b/docs/development/waiting-in-tests.md
@@ -102,14 +102,16 @@ Waits split into two groups with different primitives.
   `packages/patterns/integration/cfc-browser-helpers.ts` compose the two
   primitives above for common waits and interactions. Each of them settles and
   marks the exact rendered target before acting on it; what differs between them
-  is only how they recognize that target. `clickCfButton` takes the first match
-  and reaches through a host's shadow root for its inner `[data-cf-button]`, and
+  is only how they recognize that target. `clickCfButton` takes the first match,
+  reaches through a host's shadow root for its inner `[data-cf-button]`, and
+  answers only while neither the host nor that control is disabled;
   `clickCfButtonsConcurrently` does the same for a group. `clickNthCfButton`
   takes the `index`-th match of a selector that already resolves to the buttons
   themselves. `clickTrustedAction` takes the first enabled match of a
-  `data-ui-action` value. The note-button helpers take a button by its text or
-  its title. `submitViaEnter` focuses a field and presses Enter rather than
-  clicking, and settles around resolving that field the same way.
+  `data-ui-action` value. The note-button helpers take the first enabled
+  button matching a text or a title. `submitViaEnter` focuses a field and
+  presses Enter rather than clicking, and settles around resolving that field
+  the same way.
 
 To click a control that appears asynchronously, follow the `clickCfButton`
 shape rather than a find-and-click retry loop: a `waitForCondition` predicate
@@ -119,6 +121,12 @@ target to be rendered — laid out, and not `display:none` or `visibility:hidden
 — so a control still inside a collapsed menu is skipped until it becomes
 clickable rather than tagged while it has no layout box and then failing to
 click.
+
+Require it to be enabled as well, in that same predicate. A disabled control
+has a layout box, so rendered-ness alone answers it, and it still takes no
+click. A pattern disables a control while the state behind it is arriving — a
+row's "This is me" is disabled until the acting identity resolves — so the
+wait holds until that state lands.
 
 Resolve the target before settling the view inside that predicate. Let the
 check pass only when the same rendered element remains after the settle. A
@@ -162,10 +170,28 @@ into its computed visibility. So the click target's own check covers the whole
 chain, and checking the host as well buys nothing.
 
 Being rendered is a question about whether a click can be delivered, which is
-why it belongs in the predicate that tags the control. Whether the control is
-`disabled` is a separate question — a disabled control still takes the click and
-declines it. A test that needs a control enabled before clicking says so with
-`waitForDisabled(page, selector, false)`.
+why it belongs in the predicate that tags the control. Being enabled is the same
+question, so it belongs there too. The browser raises no click on a disabled
+control, and `cf-button` additionally gives one `pointer-events: none`, which
+sends the press to the host that wraps it. Either way the control is not
+activated, and the interceptor stops an interaction that did not carry the mark,
+so the aim tries again where the control still stands until it repeats a pixel
+and reports.
+
+Ask that of the host as well as of the control it wraps. Here being enabled
+parts company with being rendered: hiding an ancestor reaches the control
+through layout and inheritance, but `disabled` does not inherit, so a host
+carrying `disabled` or `aria-disabled="true"` over a control carrying neither
+has to be asked in its own right.
+
+Asking inside the predicate is what makes the element that was checked the
+element that gets marked. `waitForDisabled(page, selector, false)` ahead of a
+click does not give that: the element it inspects and the element the click
+marks are resolved by separate round trips, and a re-render between them —
+which is what landing the state that enables a control looks like — leaves the
+mark on a replacement the check never saw. Such a call still earns its place
+as an assertion that the page enabled the control, which is a claim about the
+pattern rather than a guard on the click.
 
 A control has to be rendered when the predicate tags it, but that alone does
 not make the click that follows safe. The page keeps running between the tag and
@@ -226,8 +252,11 @@ because that is the event a control acts on. The press and the release cross the
 protocol one at a time, so the page can carry the control away between them, and
 the browser then raises the click on the nearest ancestor the two have in common
 rather than on the control. A click that does not carry the mark is stopped like
-any other miss. So is a control that declines the interaction outright: a
-disabled one takes the press and raises no click at all.
+any other miss. So is a control that declines the interaction outright, and a
+disabled one arrives here two ways: it takes the press and raises no click at
+all, or, where a stylesheet has given it `pointer-events: none`, the press
+reaches the host that wraps it and the click is raised there, without the
+mark.
 
 What the interceptor stops is the press, the release and the click — the events
 a control acts on. The pointer moves to the point before it presses, and the

--- a/packages/integration/utils.ts
+++ b/packages/integration/utils.ts
@@ -98,6 +98,16 @@ export interface ProbeApi {
    */
   isRendered(element: Element): boolean;
 
+  /**
+   * Whether `element` declines a click: it carries `disabled`, or
+   * `aria-disabled="true"`. This is the "will this control act on a click"
+   * question a predicate asks alongside {@link ProbeApi.isRendered}, because a
+   * control can be laid out and take no click. A component that wraps its
+   * control in a host asks this of both: `disabled` does not inherit, so a host
+   * carrying it over a control that does not is a separate answer.
+   */
+  isDisabled(element: Element): boolean;
+
   /** Whether `element` is rendered and also on-screen. */
   isVisible(element: Element): boolean;
 
@@ -171,6 +181,10 @@ function installWaiter(
     return rect.width > 0 && rect.height > 0;
   };
 
+  const isDisabled = (element: Element): boolean =>
+    element.hasAttribute("disabled") ||
+    element.getAttribute("aria-disabled") === "true";
+
   // Typed as the ProbeApi the predicates are handed, so a method added to that
   // interface has to be implemented here too. The annotation is erased before
   // this function is serialized into the page, so it adds no runtime reference
@@ -192,6 +206,7 @@ function installWaiter(
       return out;
     },
     isRendered,
+    isDisabled,
     isVisible(element) {
       if (!isRendered(element)) return false;
       const rect = element.getBoundingClientRect();

--- a/packages/patterns/integration/cfc-browser-helpers.test.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.test.ts
@@ -24,7 +24,10 @@ import {
   submitViaEnter,
   waitForSettledText,
 } from "./cfc-browser-helpers.ts";
-import { clickButtonWithText } from "./note-button-helpers.ts";
+import {
+  clickButtonWithText,
+  readNoteButtonCandidates,
+} from "./note-button-helpers.ts";
 
 /** One element's live click marks, in attribute order. */
 type MarkProbe = { clicks: number; marksAtClick: string[]; marks: string[] };
@@ -1091,6 +1094,177 @@ describe("CFC browser helpers", () => {
     assertEquals(result.settleCalls, 2);
   });
 
+  it("passes over a disabled button carrying the text it was given", async () => {
+    // Text names a button, and a page can show the same words twice: a
+    // disabled control and, beside it, the one that is ready for the click.
+    // A disabled control is laid out and has a box, so rendered-ness alone
+    // answers it, and the browser raises no click on it. This fixture leaves
+    // the pointer events alone, so it covers that half; the case above, whose
+    // control carries `cf-button`'s `pointer-events: none`, covers the other.
+    await page.evaluate(() => {
+      const surface = document.createElement("div");
+      // Fixed and on screen, clear of the surfaces the cases above leave on
+      // the shared page, so the aim's scroll cannot move it and nothing else
+      // reaches the point this click is aimed at.
+      Object.assign(surface.style, {
+        position: "fixed",
+        left: "950px",
+        top: "120px",
+        width: "220px",
+      });
+      document.body.append(surface);
+
+      // Both carry the `cf-button` shape: a host whose shadow root holds the
+      // control that takes the click.
+      const make = (disabled: boolean): HTMLElement => {
+        const host = document.createElement("cf-button");
+        const root = host.attachShadow({ mode: "open" });
+        const button = document.createElement("button");
+        button.setAttribute("data-cf-button", "");
+        button.disabled = disabled;
+        button.textContent = "Publish the note";
+        Object.assign(button.style, {
+          display: "block",
+          width: "200px",
+          height: "40px",
+          padding: "0",
+          margin: "0",
+        });
+        host.toggleAttribute("disabled", disabled);
+        host.textContent = "Publish the note";
+        root.append(button);
+        surface.append(host);
+        return host;
+      };
+
+      const disabledHost = make(true);
+      const enabledHost = make(false);
+
+      let disabledHostClicks = 0;
+      let enabledClicks = 0;
+      disabledHost.addEventListener("click", () => void disabledHostClicks++);
+      enabledHost.addEventListener("click", () => void enabledClicks++);
+
+      (globalThis as typeof globalThis & {
+        commonfabric: { viewSettled: () => Promise<void> };
+      }).commonfabric = { viewSettled: () => Promise.resolve() };
+      (globalThis as typeof globalThis & {
+        __twinButtonClicks: () => { disabledHost: number; enabled: number };
+        __twinButtonTeardown: () => void;
+      }).__twinButtonClicks = () => ({
+        disabledHost: disabledHostClicks,
+        enabled: enabledClicks,
+      });
+      (globalThis as typeof globalThis & {
+        __twinButtonTeardown: () => void;
+      }).__twinButtonTeardown = () => surface.remove();
+    });
+
+    try {
+      await clickButtonWithText(page, "Publish the note");
+    } finally {
+      // The surface is fixed and would otherwise stand over these coordinates
+      // for every case below.
+      await page.evaluate(() =>
+        (globalThis as typeof globalThis & {
+          __twinButtonTeardown: () => void;
+        }).__twinButtonTeardown()
+      );
+    }
+
+    const clicks = await page.evaluate(() =>
+      (globalThis as typeof globalThis & {
+        __twinButtonClicks: () => { disabledHost: number; enabled: number };
+      }).__twinButtonClicks()
+    );
+    expect(clicks).toEqual({ disabledHost: 0, enabled: 1 });
+  });
+
+  it("reports why each candidate was passed over when none can be clicked", async () => {
+    // Waiting for a control to be enabled is waiting on the page, and a page
+    // that never enables it runs the wait out. What is on screen then is a
+    // button whose words are the ones that were asked for, sitting there
+    // disabled — which reads, to a report that says only that no button was
+    // found, as a button that was never on the page at all. The probe behind
+    // that report answers the finder's three decisions per candidate, so the
+    // one that failed only the last of them is distinguishable from the rest.
+    await page.evaluate(() => {
+      const surface = document.createElement("div");
+      Object.assign(surface.style, {
+        position: "fixed",
+        left: "950px",
+        top: "240px",
+        width: "220px",
+      });
+      document.body.append(surface);
+
+      const add = (
+        id: string,
+        text: string,
+        disabled: boolean,
+        rendered: boolean,
+      ) => {
+        const host = document.createElement("cf-button");
+        host.id = id;
+        const root = host.attachShadow({ mode: "open" });
+        const button = document.createElement("button");
+        button.setAttribute("data-cf-button", "");
+        button.disabled = disabled;
+        Object.assign(button.style, { display: "block", height: "20px" });
+        root.append(button);
+        host.textContent = text;
+        host.toggleAttribute("disabled", disabled);
+        if (!rendered) host.style.display = "none";
+        surface.append(host);
+      };
+
+      // One of each: named but disabled, named but not rendered, and one whose
+      // words are simply different.
+      add("probe-disabled", "Archive the ledger", true, true);
+      add("probe-hidden", "Archive the ledger", false, false);
+      add("probe-other", "Restore the ledger", false, true);
+    });
+
+    const report = await readNoteButtonCandidates(
+      page,
+      "cf-button",
+      "includes",
+      "Archive the ledger",
+    );
+    const byTag = report.candidates.filter((candidate) =>
+      candidate.text.includes("the ledger")
+    ).map(({ text, named, rendered, disabled }) => ({
+      text,
+      named,
+      rendered,
+      disabled,
+    }));
+    assertEquals(
+      byTag,
+      [
+        {
+          text: "Archive the ledger",
+          named: true,
+          rendered: true,
+          disabled: true,
+        },
+        {
+          text: "Archive the ledger",
+          named: true,
+          rendered: false,
+          disabled: false,
+        },
+        {
+          text: "Restore the ledger",
+          named: false,
+          rendered: true,
+          disabled: false,
+        },
+      ],
+      "the probe did not separate the three reasons a candidate was passed over",
+    );
+  });
+
   //
   // Filling, typing, and submitting
   //
@@ -1562,6 +1736,126 @@ describe("CFC browser helpers", () => {
       clicked,
       "the click never reached the target after its hidden surface returned",
     );
+  });
+
+  it("waits for a disabled control to be enabled before clicking it", async () => {
+    // A control the page has rendered disabled takes no click. The inner
+    // control carries `disabled`, and `cf-button`'s stylesheet gives it
+    // `pointer-events: none`, so the browser delivers the press to the host
+    // instead. The host does not carry the mark, so the click is stopped at the
+    // window and aimed again at the same pixel, which is where the aim gives
+    // up.
+    //
+    // A pattern renders a control disabled while the state that enables it is
+    // still arriving. A parking coordinator's "This is me" is disabled until
+    // the acting identity resolves, and the surface above it collapses as that
+    // same state lands. Marking a control in that state aims the click both at
+    // a point that takes it nowhere and at a position the page is about to
+    // leave.
+    //
+    // The settle is what carries the page through those steps, so the fixture
+    // advances one step per settle: the surface above the control shrinks, and
+    // on the last step the control is enabled. Each step mutates the DOM, which
+    // re-enters the wait, so the run is driven by the page's own progress
+    // rather than by a timer.
+    await page.evaluate(() => {
+      const surface = document.createElement("div");
+      // Fixed and on screen, clear of the surfaces the cases above leave on the
+      // shared page, so the aim's scroll cannot move it and nothing else
+      // reaches the point this click is aimed at.
+      Object.assign(surface.style, {
+        position: "fixed",
+        left: "950px",
+        top: "400px",
+        width: "220px",
+      });
+      document.body.append(surface);
+
+      // Stands in for the join surface a pattern drops once the identity it was
+      // collecting has resolved. It shrinks a step at a time, carrying the
+      // control up the page as it goes.
+      const filler = document.createElement("div");
+      Object.assign(filler.style, { width: "200px", height: "72px" });
+
+      // The `cf-button` shape: a host whose shadow root holds the control that
+      // takes the click, and a stylesheet that stops pointer events at the
+      // control while the host is disabled.
+      const host = document.createElement("div");
+      host.id = "gated-claim-button";
+      const root = host.attachShadow({ mode: "open" });
+      const style = document.createElement("style");
+      style.textContent =
+        ":host([disabled]) [data-cf-button] { pointer-events: none; }";
+      const button = document.createElement("button");
+      button.setAttribute("data-cf-button", "");
+      button.textContent = "This is me";
+      Object.assign(button.style, {
+        display: "block",
+        width: "200px",
+        height: "40px",
+        padding: "0",
+        margin: "0",
+      });
+      const setDisabled = (disabled: boolean) => {
+        button.disabled = disabled;
+        host.toggleAttribute("disabled", disabled);
+      };
+      setDisabled(true);
+      root.append(style, button);
+      surface.append(filler, host);
+
+      let clicks = 0;
+      button.addEventListener("click", () => void clicks++);
+
+      let stepsLeft = 3;
+      (globalThis as typeof globalThis & {
+        commonfabric: { viewSettled: () => Promise<void> };
+      }).commonfabric = {
+        viewSettled: () => {
+          if (stepsLeft > 0) {
+            stepsLeft--;
+            filler.style.height = `${stepsLeft * 24}px`;
+            if (stepsLeft === 0) setDisabled(false);
+          }
+          return Promise.resolve();
+        },
+      };
+      (globalThis as typeof globalThis & {
+        __gatedClaimState: () => { clicks: number; disabled: boolean };
+        __gatedClaimTeardown: () => void;
+      }).__gatedClaimState = () => ({ clicks, disabled: button.disabled });
+      (globalThis as typeof globalThis & {
+        __gatedClaimTeardown: () => void;
+      }).__gatedClaimTeardown = () => surface.remove();
+    });
+
+    const readState = () =>
+      page.evaluate(() =>
+        (globalThis as typeof globalThis & {
+          __gatedClaimState: () => { clicks: number; disabled: boolean };
+        }).__gatedClaimState()
+      );
+
+    // Without this the case says nothing: a fixture whose control starts
+    // enabled passes whether or not the helper waits for one.
+    assert(
+      (await readState()).disabled,
+      "the fixture should start with its control disabled",
+    );
+
+    try {
+      await clickCfButton(page, "#gated-claim-button");
+    } finally {
+      // The surface is fixed and would otherwise stand over these coordinates
+      // for every case below.
+      await page.evaluate(() =>
+        (globalThis as typeof globalThis & {
+          __gatedClaimTeardown: () => void;
+        }).__gatedClaimTeardown()
+      );
+    }
+
+    expect((await readState()).clicks).toBe(1);
   });
 
   it("clicks a control its surface keeps rebuilding under the aim", async () => {

--- a/packages/patterns/integration/cfc-browser-helpers.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.ts
@@ -406,21 +406,33 @@ export const settleAndMarkTargets = async (
   return true;
 };
 
-// The first element matching each selector, reached through a host's shadow
-// root when the host wraps the control that takes the click.
+// The first enabled element matching each selector, reached through a host's
+// shadow root when the host wraps the control that takes the click.
+//
+// A disabled control is passed over, and a selector all of whose matches are
+// disabled is not answered at all, so the wait holds until the page enables
+// one. Such a control takes no click: the browser raises none on it, and
+// `cf-button` additionally gives it `pointer-events: none`, which sends the
+// press to the host that wraps it. Either way the control is not activated, and
+// the aim keeps missing until it repeats a pixel and reports. Disabled-ness is
+// asked of both the host and the control it wraps, because `disabled` does not
+// inherit and a host can carry an `aria-disabled` its inner control does not.
 const findSelectorClickTargets = (
   probe: ProbeApi,
   selectors: readonly string[],
 ): readonly HTMLElement[] | undefined => {
+  const clickTarget = (element: Element): HTMLElement =>
+    (element.shadowRoot?.querySelector("[data-cf-button]") as
+      | HTMLElement
+      | null) ?? element as HTMLElement;
+
   const targets: HTMLElement[] = [];
   for (const selector of selectors) {
-    const host = probe.collect(selector)[0] as HTMLElement | undefined;
-    if (!host) return undefined;
-    targets.push(
-      (host.shadowRoot?.querySelector("[data-cf-button]") as
-        | HTMLElement
-        | null) ?? host,
+    const host = probe.collect(selector).find((match) =>
+      !probe.isDisabled(match) && !probe.isDisabled(clickTarget(match))
     );
+    if (!host) return undefined;
+    targets.push(clickTarget(host));
   }
   return targets;
 };
@@ -464,20 +476,19 @@ const findTrustedActionTarget = (
   probe: ProbeApi,
   action: string,
 ): readonly HTMLElement[] | undefined => {
-  const isDisabled = (element: HTMLElement): boolean =>
-    element.hasAttribute("disabled") ||
-    element.getAttribute("aria-disabled") === "true";
+  const clickTarget = (element: Element): HTMLElement =>
+    (element.shadowRoot?.querySelector("[data-cf-button]") as
+      | HTMLElement
+      | null) ?? element as HTMLElement;
 
   for (const element of probe.collect(`[data-ui-action="${action}"]`)) {
     const target = element as HTMLElement;
-    const clickTarget = (target.shadowRoot?.querySelector("[data-cf-button]") as
-      | HTMLElement
-      | null) ?? target;
+    const inner = clickTarget(target);
     if (
-      probe.isRendered(clickTarget) &&
-      !isDisabled(target) && !isDisabled(clickTarget)
+      probe.isRendered(inner) &&
+      !probe.isDisabled(target) && !probe.isDisabled(inner)
     ) {
-      return [clickTarget];
+      return [inner];
     }
   }
   return undefined;
@@ -883,10 +894,11 @@ async function settleWithClickTargets(
       tokens.map((token) => clearClickMark(page, token).catch(() => {})),
     );
     // Matches per selector, so the failure names which of a grouped dispatch's
-    // targets never rendered. Each match's `rect` and `visible` report whether
-    // the control was absent or present without a layout box. Every probe reads
-    // the same page, so the body text is reported once rather than once per
-    // selector.
+    // targets never came within reach of a click. Each match's `rect`,
+    // `visible` and `disabled` report which of the three it was: absent,
+    // present without a layout box, or present and declining the click. Every
+    // probe reads the same page, so the body text is reported once rather than
+    // once per selector.
     const probes = await Promise.all(
       selectors.map((selector) =>
         readTextProbe(page, selector).catch(() => undefined)
@@ -894,7 +906,9 @@ async function settleWithClickTargets(
     );
     // Indented for readable test-log output
     throw new Error(
-      `Timed out waiting for ${selectors.join(", ")} to render. Last probe: ${
+      `Timed out waiting for ${
+        selectors.join(", ")
+      } to be clickable. Last probe: ${
         toIndentedDebugString({
           matches: Object.fromEntries(
             selectors.map((selector, index) => [
@@ -1045,9 +1059,14 @@ type ClickAim =
  * What became of the trusted click the aim armed for.
  *
  * `hit` means the click reached the marked control. `missed` means it reached
- * something else. `pending` means no click event was raised at all, which is
- * what a control that declines the interaction leaves behind — a disabled one
- * takes the press and produces no click.
+ * something else. `pending` means no click event was raised at all.
+ *
+ * A control that declines the interaction leaves either one, depending on how
+ * it declines. A disabled control takes the press and produces no click, which
+ * is `pending`. One a stylesheet has additionally given `pointer-events: none`,
+ * as `cf-button` gives a disabled control, does not take the press either: it
+ * reaches the host that wraps the control, which raises a click the mark is
+ * absent from, and that is `missed`.
  *
  * Neither `missed` nor `pending` activated the control, so the click can be
  * aimed again.
@@ -2805,6 +2824,9 @@ type TextProbe = {
     text: string;
     rect: { width: number; height: number; top: number; left: number };
     visible: boolean;
+
+    /** Whether the match, or the control it wraps, declines a click. */
+    disabled: boolean;
   }>;
   bodyText: string;
 };
@@ -3275,6 +3297,20 @@ async function readTextProbe(
         style.display !== "none";
     }
 
+    // Resolved the way a click helper's finder resolves it, so a match a wait
+    // is holding for reports the state that wait is testing. A control that is
+    // rendered and visible and still not clicked is what this answers for.
+    // Spelled out rather than taken from `probe`, which a plain page evaluate
+    // is not handed.
+    function isDisabled(element: HTMLElement): boolean {
+      const declines = (candidate: Element): boolean =>
+        candidate.hasAttribute("disabled") ||
+        candidate.getAttribute("aria-disabled") === "true";
+      const inner = element.shadowRoot?.querySelector("[data-cf-button]") ??
+        element;
+      return declines(element) || declines(inner);
+    }
+
     function deepText(root: ParentNode): string {
       const parts: string[] = [];
       if (root instanceof HTMLElement) {
@@ -3333,6 +3369,7 @@ async function readTextProbe(
             left: rect.left,
           },
           visible: isVisible(target),
+          disabled: isDisabled(target),
         };
       }),
       bodyText: document.body === null

--- a/packages/patterns/integration/note-button-helpers.ts
+++ b/packages/patterns/integration/note-button-helpers.ts
@@ -3,6 +3,7 @@ import {
   type ProbeApi,
   waitForCondition,
 } from "@commonfabric/integration";
+import { toIndentedDebugString } from "@commonfabric/data-model";
 import {
   clickMarked,
   markTargetsArgs,
@@ -17,35 +18,128 @@ import {
 // or by data-ui-action value. Settling around the match, marking it, and
 // clicking it are that module's shared step, which every marked click runs.
 
-// Serialized into the page: the first rendered button or link whose text or
-// title matches, reached through its host's shadow root when the host wraps the
-// control that takes the click. "Rendered" means laid out and not
+// Serialized into the page: the first rendered, enabled button or link whose
+// text or title matches, reached through its host's shadow root when the host
+// wraps the control that takes the click. "Rendered" means laid out and not
 // display:none/visibility:hidden — the same elements the innerText scan the
 // poll used could see — and is viewport-independent, so a match below the fold
-// still qualifies: the click scrolls the element into view itself. Answers
-// `undefined` until a match exists, so the wait re-checks on the next DOM
-// mutation instead of the caller retrying a bare find-and-click loop.
-// Self-contained — it closes over nothing in this module — so it can be
-// serialized and run in the page.
+// still qualifies: the click scrolls the element into view itself. A disabled
+// match is passed over: it takes no click, since the browser raises none on it
+// and a `cf-button` additionally gives it `pointer-events: none`, which sends
+// the press to the host that wraps it. Disabled-ness is asked of both the match
+// and the control it wraps, because `disabled` does not inherit and a host can
+// carry an `aria-disabled` its inner control does not. Answers `undefined`
+// until such a match exists, so the wait re-checks on the next DOM mutation
+// instead of the caller retrying a bare find-and-click loop. Self-contained —
+// it closes over nothing in this module — so it can be serialized and run in
+// the page.
 const findNoteButton = (
   probe: ProbeApi,
   selector: string,
   match: "includes" | "exact" | "title",
   needle: string,
 ): readonly HTMLElement[] | undefined => {
+  const clickTarget = (element: Element): HTMLElement =>
+    (element.shadowRoot?.querySelector("[data-cf-button]") as
+      | HTMLElement
+      | null) ?? element as HTMLElement;
+
   const target = probe.collect(selector).find((element) => {
     if (!probe.isRendered(element)) return false;
+    if (probe.isDisabled(element) || probe.isDisabled(clickTarget(element))) {
+      return false;
+    }
     if (match === "title") return element.getAttribute("title") === needle;
     const text = (element.textContent ?? "").trim();
     return match === "exact" ? text === needle : text.includes(needle);
-  }) as HTMLElement | undefined;
+  });
   if (!target) return undefined;
-  return [
-    (target.shadowRoot?.querySelector("[data-cf-button]") as
-      | HTMLElement
-      | null) ?? target,
-  ];
+  return [clickTarget(target)];
 };
+
+// What the finder was deciding on when the wait for it ran out.
+export type NoteButtonProbe = {
+  selector: string;
+  match: string;
+  needle: string;
+  candidates: Array<{
+    tagName: string;
+    text: string;
+    title: string | null;
+
+    /** Whether the candidate's text or title is the one that was asked for. */
+    named: boolean;
+    rendered: boolean;
+
+    /** Whether the candidate, or the control it wraps, declines a click. */
+    disabled: boolean;
+  }>;
+};
+
+// Every element the selector reached, with the three things the finder decides
+// on. A wait that never resolves is one where no candidate satisfied all three,
+// and this names which one each candidate failed — a button whose words match
+// and which is sitting there disabled reads as such, rather than as a button
+// that was never on the page.
+export async function readNoteButtonCandidates(
+  page: Page,
+  selector: string,
+  match: "includes" | "exact" | "title",
+  needle: string,
+): Promise<NoteButtonProbe> {
+  return await page.evaluate(
+    (
+      targetSelector: string,
+      targetMatch: string,
+      targetNeedle: string,
+    ) => {
+      const collect = (root: Document | ShadowRoot, out: Element[]): void => {
+        for (const element of root.querySelectorAll("*")) {
+          try {
+            if (element.matches(targetSelector)) out.push(element);
+          } catch {
+            // Invalid selectors are reported through the empty probe.
+          }
+          if (element.shadowRoot) collect(element.shadowRoot, out);
+        }
+      };
+      const declines = (candidate: Element): boolean =>
+        candidate.hasAttribute("disabled") ||
+        candidate.getAttribute("aria-disabled") === "true";
+
+      const found: Element[] = [];
+      collect(document, found);
+      return {
+        selector: targetSelector,
+        match: targetMatch,
+        needle: targetNeedle,
+        candidates: found.map((element) => {
+          const style = globalThis.getComputedStyle(element);
+          const rect = element.getBoundingClientRect();
+          const text = (element.textContent ?? "").trim();
+          const title = element.getAttribute("title");
+          const inner = element.shadowRoot?.querySelector("[data-cf-button]") ??
+            element;
+          return {
+            tagName: element.tagName.toLowerCase(),
+            text: text.slice(0, 120),
+            title,
+            named: targetMatch === "title"
+              ? title === targetNeedle
+              : targetMatch === "exact"
+              ? text === targetNeedle
+              : text.includes(targetNeedle),
+            rendered: style.display !== "none" &&
+              style.visibility !== "hidden" &&
+              rect.width > 0 && rect.height > 0,
+            disabled: declines(element) || declines(inner),
+          };
+        }),
+      };
+    },
+    { args: [selector, match, needle] },
+  );
+}
 
 // Settle around a matching button, tag it, and dispatch a single trusted click
 // on it. Throws if no matching button becomes clickable.
@@ -62,10 +156,13 @@ async function settleAndClickNoteButton(
   try {
     await waitForCondition(page, settleAndMarkTargets, { args });
   } catch (cause) {
+    const probe = await readNoteButtonCandidates(page, selector, match, needle)
+      .catch(() => undefined);
+    // Indented for readable test-log output
     throw new Error(
       `Unable to find a ${
         match === "title" ? "button titled" : "button matching"
-      } "${needle}" to click`,
+      } "${needle}" to click. Last probe: ${toIndentedDebugString(probe)}`,
       { cause },
     );
   }


### PR DESCRIPTION
`packages/patterns/integration/parking-coordinator-admin-view.test.ts` failed roughly one local run in four in the step that claims a row for a freshly created profile, and much more often than that on some machines: 2 of 8 runs passed while investigating. The report was always the same shape. The marked control "is aimed at ... again, where a trusted click already failed to reach it", and what the click reached was `cf-button < slot < div < cf-hstack`.

That path names the `cf-button` host rather than the control inside it that the mark was placed on. Instrumenting the landing interceptor to snapshot the marked element at the moment of the press showed why: the `<button>` in the host's shadow root carried `disabled`, and `cf-button`'s stylesheet gives a disabled control `pointer-events: none`, so the browser delivered the press to the host instead. The interceptor found no mark in the composed path, stopped the click at the window, and aimed again where the control still stood. The second dispatch repeated a pixel the first had lost at, which is where the aim reports and gives up.

The pattern renders that control disabled on purpose: a parking coordinator's "This is me" is disabled until the acting identity resolves. The relayout visible in the same failure follows from that too — the surface the pattern drops as the identity lands carries the control 72 pixels up the page, so the second aim, taken while the control was still disabled and still low, was measuring a position the page was about to leave. One call site had already met this and worked around it: `cfc-group-chat-demo.test.ts` carries a comment from an earlier investigation describing the same retarget on a send button.

## Answering the click helpers' finders

`clickCfButton` resolves its target through `findSelectorClickTargets`, which asked only whether the control was rendered. A disabled control is rendered: it is laid out, it is not `display:none`, and it has a box. `findTrustedActionTarget`, sitting beside it in the same file, has always asked whether the target is enabled as well, which is why the trusted action clicked immediately above the failing line never showed this.

Being enabled is the same question as being rendered — whether a click can be delivered — so it belongs in the same predicate, which is the one place that resolves the control either side of a settle and marks the element it checked. The three finders that reach a control through a host now share one answer, `ProbeApi.isDisabled`, next to `isRendered`. A finder is serialized into the page as its own source and closes over nothing, so a module-scope helper is not available to it; the probe it is handed is. Reaching through a host's shadow root for its inner `[data-cf-button]` stays with each finder, since that is knowledge about one component library and `packages/integration` sits below the package that owns it.

`findSelectorClickTargets` also skips to the first enabled match, the way `findTrustedActionTarget` and `findNoteButton` already did, so the three behave alike on a selector matching more than one element. The same gap existed in `findNoteButton`, which backs `clickButtonWithText` and its siblings; text is the weakest of the ways these helpers name a control, so a surface showing the same words on a disabled control and on the live one beside it handed every click to the disabled one.

The predicate reads attributes, which covers a native control — whose `disabled` property reflects to the attribute — and a custom element carrying `disabled` or `aria-disabled="true"`. It is deliberately not the rule `disabledIs` uses for `waitForDisabled`, which answers a different question: whether the control a test is asserting about is disabled, native inputs and all.

## Saying so when a wait runs out

Making enabled-ness part of what a wait holds for means the report for a stuck wait has to name it, or a control that is present, visible and never clicked is one the diagnostic has nothing to say about.

The selector path said "Timed out waiting for <selector> to render", which describes only one of the two ways it can now get stuck. It says the target never became clickable, and each match in the shared text probe carries `disabled` beside `rect` and `visible`, so the three cases — absent, present without a layout box, and present and declining the click — are separable. Every failure that prints matches gains that.

The text-matching path threw `Unable to find a button matching "X" to click` with the timeout as its only cause and no probe at all, which describes a button sitting on the page disabled as one that was never there. It now lists every element the selector reached against the finder's three decisions: whether the words are the ones asked for, whether it is rendered, and whether it declines a click.

That probe is exported and has a case of its own, because the wait it reports on cannot be provoked from a test — the stuck-condition net is five minutes and a test has sixty seconds — so exercising it directly is the only way to know it is right.

## Documentation

`waiting-in-tests.md` carried two answers to this question. Its section on writing a click predicate now requires the target enabled; its section on what such a predicate checks said the opposite, that `disabled` is a separate question, that such a control "still takes the click and declines it", and that a test needing one enabled says so with `waitForDisabled(page, selector, false)` beforehand.

The second passage was also wrong about the mechanism, which is what let the two drift apart, and the rewrite keeps the contrast the section is built around. Checking rendered-ness on the click target alone covers the whole ancestor chain, because hiding an ancestor reaches the control through layout and inheritance. `disabled` does not inherit, so the host is a separate answer, which is why the check runs on both.

It also says what `waitForDisabled(page, selector, false)` ahead of a click is and is not. The element it inspects and the element the click marks are resolved by separate round trips, so a re-render between them — which is what landing the state that enables a control looks like — leaves the mark on a replacement the check never saw. As an assertion that the page enabled the control it earns its place; as a guard on the click it never closed the gap. `UI_TESTING.md` gained the same correction.

A disabled control reaches the interceptor two ways and leaves a different verdict each time, so the passage describing those verdicts, and the `ClickLanding` doc comment beside them, name both: it takes the press and raises no click, or, under `pointer-events: none`, the press reaches the host and the click is raised there without the mark.

## Tests

Two cases in the helpers' own suite cover the two routes. The first builds the `cf-button` shape by hand — a host whose shadow root holds the control, and a stylesheet that stops pointer events at it while the host is disabled — below a surface that collapses one step per view settle and enables the control on the last step. The steps are driven by the settle rather than by a timer, and each mutates the DOM, so the wait re-enters on the page's own progress. The second pairs a disabled control and an enabled one carrying the same text and asserts the click reached the enabled one; it leaves the pointer events alone, so it covers the other route. Both fixtures take their surfaces down when their case ends, since the page is shared across the whole file.

Verified against the failure it explains. Before the change, `parking-coordinator-admin-view.test.ts` passed 2 of 8 local runs, always failing the same way; after it, 36 of 36 across four separate batches, including 8 after the final rebase. Both new cases were confirmed to fail with the enabled-ness gate removed and everything else in place, so neither passes for another reason. The helpers' own suite passes in full, as do the thirteen pattern integration suites that click through these helpers, `packages/integration`'s own tests, `deno task check`, repo-wide `deno fmt --check` and `deno lint`, and the standalone `check-no-waitfor`, `check-docs` and `check-skill-facts` gates.

One thing this leaves alone: a wait that can never be satisfied still runs to `waitForCondition`'s five-minute net, which outlasts the sixty seconds a test has in CI, so its diagnostic may not print. That is a property of the wait machinery rather than of this change — the trusted action helper has always had it — and shortening it means tightening a timeout, which deserves its own decision.

deflaked by Hixie's agent

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6745?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

