### PR TITLE
fix(coverage): keep every realm's authored-pattern hits

### DIFF
--- a/docs/development/COVERAGE.md
+++ b/docs/development/COVERAGE.md
@@ -893,14 +893,58 @@ the same trap.
 Getting the hits back out crosses two boundaries: the worker's and the browser's.
 `PatternCoverageCollector.toData()` and `ingest()` give the spans and hit counts a
 plain-JSON form. The worker exposes them over the RuntimeClient IPC
-(`GetPatternCoverage`), and the harness pulls them with `page.evaluate` at
-teardown — one batched dump per page, not a per-hit round trip. Every realm runs
-the same instrumented bytes, so the fileName-plus-span-id keys line up: a realm
-that only warm-loaded already-instrumented bytes reports hits that merge cleanly
-against the realm that compiled them and holds the spans. The harness merges the
-realms' hits and writes one `*.pattern-coverage.lcov` tagged
+(`GetPatternCoverage`), and the harness pulls them with `page.evaluate` — one
+batched dump per runtime, not a per-hit round trip. Every realm runs the same
+instrumented bytes, so the fileName-plus-span-id keys line up: a realm that only
+warm-loaded already-instrumented bytes reports hits that merge cleanly against
+the realm that compiled them and holds the spans. The harness merges the realms'
+hits and writes a `*.pattern-coverage.lcov` tagged
 `TN:pattern-runtime-integration`, which the job uploads in its
 `coverage-profile-*` artifact.
+
+### One report per test file, not one per shard
+
+`deno test` runs each test file in its own isolate. A shard's files therefore
+hold separate instances of the harness module, each with its own collector and
+its own space, and each writes its own `*.pattern-coverage.lcov` under
+`CF_PATTERN_COVERAGE_DIR`. The gate copies and joins every `.lcov` in an
+artifact, so a shard's coverage arriving in several files reads the same as one,
+and a report is named apart from every other in the run for that reason.
+
+The isolation runs the other way as well. A test file that runs its patterns
+only through a pieces controller in the test process, with no page to dump from,
+never reaches the write and contributes nothing — `all.test.ts` is the case in
+the tree.
+
+### The dump has to happen before the runtime is dropped
+
+A worker's collector lives and dies with the runtime that built it. A shell
+builds a new runtime whenever the page navigates and whenever its identity is
+set — `shouldRecreateRuntime` compares the `Identity` object, and the integration
+harness mints a fresh one from what crosses the page boundary — so one suite runs
+through several runtimes, and every hit a dropped runtime holds is gone. A suite
+that drives one page through two logins has two runtimes and two dumps to take:
+one before the second navigation, and one before the harness disposes what that
+navigation left. The pull happens in three places — before a login, before the
+harness disposes a runtime, and on the page itself
+(`Page.addBeforeUnloadHook`), which is what covers a reload and a page close as
+well as a `goto`.
+
+Taking only the last runtime's dump is what makes a line's coverage turn on the
+environment, which the section above rules out. The lines at risk are the ones a
+flow reaches late — a derived expression that runs when the view renders it, a
+handler body that runs when the user gets that far. Whether the runtime holding
+those hits is the one still standing at teardown depends on how the run was
+timed and which shard the file landed in, and a line that drops out that way is
+charged to whichever pull request happened to reshuffle the shards.
+
+A dump that comes back empty-handed is reported, with one exception: a page that
+never booted a runtime holds nothing, and is normal. A page that cannot be
+reached at all, a runtime that does not answer the request, and a worker built
+with no collector each name what was lost on the job's log. Coming back with
+hits and no spans is not one of those — that is exactly what a realm that
+warm-loaded somebody else's instrumented bytes reports, and those hits key
+against the spans the compiling realm registered.
 
 Integration coverage counts toward the gated `coverage-debt: packages/patterns`
 metric exactly like unit coverage, which means a broad end-to-end flow that runs a

--- a/packages/integration/browser.ts
+++ b/packages/integration/browser.ts
@@ -7,6 +7,7 @@ import {
 } from "@astral/astral";
 import { astralBinaryPath, closeAstralBrowser } from "./astral-adapter.ts";
 import { Page } from "./page.ts";
+import { collectPatternCoverage } from "./pattern-coverage.ts";
 
 const DEFAULT_ASTRAL_TIMEOUT = 60_000;
 
@@ -47,8 +48,14 @@ export class Browser {
     options?: WaitForOptions & SandboxOptions & UserAgentOptions,
   ): Promise<Page> {
     this.#checkIsOk();
-    const page = await this.#browser!.newPage(url, options);
-    return new Page(page, { timeout: this.#timeout });
+    const page = new Page(
+      await this.#browser!.newPage(url, options),
+      { timeout: this.#timeout },
+    );
+    // The worker's pattern-coverage hits live in the page's realm and go with
+    // the document. A page that booted no runtime hands over nothing here.
+    page.addBeforeUnloadHook(() => collectPatternCoverage(page));
+    return page;
   }
 
   // The browser-level CDP websocket endpoint. Chrome supports multiple

--- a/packages/integration/page.ts
+++ b/packages/integration/page.ts
@@ -73,6 +73,7 @@ export class Page extends EventTarget {
   #page: AstralPage | null;
   #timeout: number;
   #afterNavigation: Array<() => Promise<void> | void> = [];
+  #beforeUnload: Array<() => Promise<void> | void> = [];
   #interactionObserver?: InteractionObserver;
   #defaultTypeDelay = 0;
   #decoratedElements = new WeakSet<AstralElementHandle>();
@@ -277,6 +278,29 @@ export class Page extends EventTarget {
     this.#defaultTypeDelay = delay;
   }
 
+  // Registers `hook` to run before this page's current document goes away:
+  // a navigation, a reload, or the page closing. Hooks run in the order they
+  // were added, and the returned function removes this one. Anything held in
+  // the document's realm — the runtime worker and what it has accumulated —
+  // is still reachable from a hook and gone once it returns.
+  addBeforeUnloadHook(hook: () => Promise<void> | void): () => void {
+    this.#beforeUnload.push(hook);
+    return () => {
+      const index = this.#beforeUnload.indexOf(hook);
+      if (index >= 0) this.#beforeUnload.splice(index, 1);
+    };
+  }
+
+  async #runBeforeUnloadHooks(): Promise<void> {
+    // Over a snapshot, so a hook registered by a hook waits for the next
+    // unload. Each is re-checked against the live list, so a hook whose remover
+    // ran while an earlier hook was awaiting does not run afterwards.
+    for (const hook of [...this.#beforeUnload]) {
+      if (!this.#beforeUnload.includes(hook)) continue;
+      await hook();
+    }
+  }
+
   // Registers `hook` to run after every navigation this page performs, once
   // the navigation itself has settled. Hooks run in the order they were added,
   // and the returned function removes this one. A page carries several at a
@@ -368,6 +392,7 @@ export class Page extends EventTarget {
     });
     await previousNavigation;
     try {
+      await this.#runBeforeUnloadHooks();
       await operation();
     } finally {
       releaseNavigation();
@@ -688,6 +713,7 @@ export class Page extends EventTarget {
   // Passthru of `@astral/astral`'s `Page#close`
   async close() {
     this.#checkIsOk();
+    await this.#runBeforeUnloadHooks();
     const page = this.#page;
     this.#page = null;
     await page!.close();

--- a/packages/integration/pattern-coverage.test.ts
+++ b/packages/integration/pattern-coverage.test.ts
@@ -202,3 +202,64 @@ Deno.test("a worker built without a collector reports the loss", async () => {
   assertEquals(warnings.length, 1);
   assert(warnings[0].includes("without a collector"), warnings[0]);
 });
+
+Deno.test("a second runtime's dump adds to the first rather than replacing it", async () => {
+  // One page runs several runtimes, because the shell builds a new one for
+  // every navigation and every identity set on it, and each is pulled from
+  // before it goes. What the second hands over joins what the first did.
+  const fileName = "/api/patterns/system/profile-create.tsx";
+  const compiled = { ...span(fileName), id: 2 };
+  const warnings = await collectingWarnings(async (dir) => {
+    await collectPatternCoverage(
+      respondingPage(() => ({
+        data: { spans: [compiled], hits: [{ fileName, id: 2, count: 1 }] },
+      })),
+    );
+    assertEquals(
+      (await lcovCounts(dir, "system/profile-create.tsx")).get(1),
+      1,
+      "the first runtime's hit",
+    );
+
+    await collectPatternCoverage(
+      respondingPage(() => ({
+        data: { spans: [compiled], hits: [{ fileName, id: 2, count: 1 }] },
+      })),
+    );
+    assertEquals(
+      (await lcovCounts(dir, "system/profile-create.tsx")).get(1),
+      2,
+      "both runtimes' hits, added rather than the second standing alone",
+    );
+  });
+  assertEquals(warnings, []);
+});
+
+Deno.test("a later dump leaves an earlier dump's record standing", async () => {
+  // Each dump rewrites the whole merged report, which is what lets the file on
+  // disk stand complete at every moment without a process-exit hook. A dump
+  // that names one pattern carries every earlier pattern out with it.
+  const first = "/api/patterns/system/piece-grid.tsx";
+  const second = "/api/patterns/system/backlinks-index.tsx";
+  const dumpOf = (fileName: string, id: number) => ({
+    data: {
+      spans: [{ ...span(fileName), id }],
+      hits: [{ fileName, id, count: 1 }],
+    },
+  });
+  const warnings = await collectingWarnings(async (dir) => {
+    await collectPatternCoverage(respondingPage(() => dumpOf(first, 3)));
+    await collectPatternCoverage(respondingPage(() => dumpOf(second, 4)));
+    assertEquals(
+      (await lcovCounts(dir, "system/piece-grid.tsx")).get(1),
+      1,
+      "the first dump's record survived the second dump's rewrite",
+    );
+    assertEquals(
+      (await lcovCounts(dir, "system/backlinks-index.tsx")).get(1),
+      1,
+      "the second dump's own record",
+    );
+  });
+  assertEquals(warnings, []);
+});

--- a/packages/integration/pattern-coverage.test.ts
+++ b/packages/integration/pattern-coverage.test.ts
@@ -1,7 +1,12 @@
 import { assert, assertEquals } from "@std/assert";
 import { resolve } from "@std/path";
 import type { PatternCoverageSpan } from "@commonfabric/runner";
-import { PATTERNS_ROOT, withRepositoryFileNames } from "./pattern-coverage.ts";
+import {
+  collectPatternCoverage,
+  PATTERNS_ROOT,
+  withRepositoryFileNames,
+} from "./pattern-coverage.ts";
+import type { Page } from "./page.ts";
 
 const span = (fileName: string): PatternCoverageSpan => ({
   fileName,
@@ -69,4 +74,131 @@ Deno.test("a name that is not under the patterns route is left alone", () => {
     hits: [{ fileName: mounted, id: 1, count: 1 }],
   });
   assertEquals(mapped.spans[0].fileName, mounted);
+});
+
+//
+// Collecting one page's dump
+//
+// The dump is the only chance to take what a worker holds: the runtime it
+// belongs to is dropped immediately afterwards, and every hit it accumulated
+// goes with it. A page that never booted a runtime is the one empty-handed
+// answer that costs nothing. Every other one is coverage the report will not
+// carry, which the gate reads as lines that ran nowhere, so the cases below
+// pin that each of those says so.
+//
+
+// A `Page` that answers `evaluate` with `respond()`, ignoring the function it
+// is handed. The real evaluate runs that function in the page's realm; here the
+// answer stands for what the realm would have returned.
+function respondingPage(respond: () => unknown): Page {
+  return {
+    evaluate: () => Promise.resolve(respond()),
+  } as unknown as Page;
+}
+
+// Runs `body` with pattern coverage written to a temporary directory, and with
+// every `console.warn` collected rather than printed. Returns what was warned.
+async function collectingWarnings(
+  body: (dir: string) => Promise<void>,
+): Promise<string[]> {
+  const dir = await Deno.makeTempDir();
+  const previousDir = Deno.env.get("CF_PATTERN_COVERAGE_DIR");
+  const warn = console.warn;
+  const warnings: string[] = [];
+  console.warn = (...args: unknown[]) => warnings.push(args.join(" "));
+  Deno.env.set("CF_PATTERN_COVERAGE_DIR", dir);
+  try {
+    await body(dir);
+  } finally {
+    console.warn = warn;
+    if (previousDir === undefined) Deno.env.delete("CF_PATTERN_COVERAGE_DIR");
+    else Deno.env.set("CF_PATTERN_COVERAGE_DIR", previousDir);
+    await Deno.remove(dir, { recursive: true });
+  }
+  return warnings;
+}
+
+// The `DA:` counts the merged LCOV in `dir` carries for `path`.
+async function lcovCounts(
+  dir: string,
+  path: string,
+): Promise<Map<number, number>> {
+  const [entry] = [...Deno.readDirSync(dir)];
+  const text = await Deno.readTextFile(resolve(dir, entry.name));
+  const counts = new Map<number, number>();
+  let inRecord = false;
+  for (const line of text.split("\n")) {
+    if (line.startsWith("SF:")) inRecord = line.slice(3).endsWith(path);
+    else if (inRecord && line.startsWith("DA:")) {
+      const [number, count] = line.slice(3).split(",");
+      counts.set(Number(number), Number(count));
+    }
+  }
+  return counts;
+}
+
+Deno.test("a dump carrying only hits credits the lines they name", async () => {
+  // The realm that compiled a pattern holds its spans; a realm that warm-loaded
+  // the same instrumented bytes reports hits against them and holds none. The
+  // second dump is the whole contribution of every page that ran a pattern
+  // somebody else compiled.
+  const fileName = "/api/patterns/system/profile-home.tsx";
+  const compiled = span(fileName);
+  const warnings = await collectingWarnings(async (dir) => {
+    await collectPatternCoverage(
+      respondingPage(() => ({ data: { spans: [compiled], hits: [] } })),
+    );
+    assertEquals(
+      (await lcovCounts(dir, "system/profile-home.tsx")).get(1),
+      0,
+      "the compiling realm ran no line of it",
+    );
+
+    await collectPatternCoverage(
+      respondingPage(() => ({
+        data: { spans: [], hits: [{ fileName, id: compiled.id, count: 1 }] },
+      })),
+    );
+    assertEquals(
+      (await lcovCounts(dir, "system/profile-home.tsx")).get(1),
+      1,
+      "the warm-loading realm's hit lands on the compiling realm's span",
+    );
+  });
+  assertEquals(warnings, []);
+});
+
+Deno.test("a page that never booted a runtime is collected in silence", async () => {
+  const warnings = await collectingWarnings(async () => {
+    await collectPatternCoverage(respondingPage(() => ({ noRuntime: true })));
+  });
+  assertEquals(warnings, []);
+});
+
+Deno.test("a page that cannot be reached reports what it took with it", async () => {
+  const warnings = await collectingWarnings(async () => {
+    await collectPatternCoverage(respondingPage(() => {
+      throw new Error("Page is already closed.");
+    }));
+  });
+  assertEquals(warnings.length, 1);
+  assert(warnings[0].includes("Page is already closed."), warnings[0]);
+});
+
+Deno.test("a runtime that does not answer the request reports the loss", async () => {
+  const warnings = await collectingWarnings(async () => {
+    await collectPatternCoverage(
+      respondingPage(() => ({ noCoverageRequest: true })),
+    );
+  });
+  assertEquals(warnings.length, 1);
+  assert(warnings[0].includes("getPatternCoverage"), warnings[0]);
+});
+
+Deno.test("a worker built without a collector reports the loss", async () => {
+  const warnings = await collectingWarnings(async () => {
+    await collectPatternCoverage(respondingPage(() => ({ data: null })));
+  });
+  assertEquals(warnings.length, 1);
+  assert(warnings[0].includes("without a collector"), warnings[0]);
 });

--- a/packages/integration/pattern-coverage.ts
+++ b/packages/integration/pattern-coverage.ts
@@ -4,9 +4,12 @@
  * The pattern's statements execute in the shell's runtime Web Worker, which has
  * no filesystem, so the hits have to come back across two boundaries before this
  * process can write LCOV: the worker's (a `GetPatternCoverage` request) and the
- * browser's (a `page.evaluate`). Both are crossed once per page at teardown —
- * the worker accumulates hits locally and hands over the whole report, rather
- * than reporting each hit as it happens.
+ * browser's (a `page.evaluate`). The worker accumulates hits locally and hands
+ * over the whole report, rather than reporting each hit as it happens, so both
+ * boundaries are crossed once per runtime, immediately before the shell drops
+ * that runtime and the collector inside it. A shell drops one whenever the page
+ * navigates and whenever an identity is set on it, so one suite has as many
+ * dumps to take as it has runtimes.
  *
  * See docs/development/COVERAGE.md.
  */
@@ -18,6 +21,7 @@ import {
   type PatternCoverageData,
   writePatternCoverageLcov,
 } from "@commonfabric/runner";
+import { describeThrown } from "./describe-thrown.ts";
 import type { Page } from "./page.ts";
 // Declares the `commonfabric` page global the dump below reads.
 import "../shell/src/globals.ts";
@@ -47,6 +51,10 @@ const PATTERNS_ROUTE_PREFIX = "/api/patterns/";
  * same instrumented bytes, which carry the file name and span id of whichever
  * realm compiled them — so a page that only warm-loaded bytes still reports hits
  * that land on another page's spans.
+ *
+ * One collector per test file, not per run: `deno test` gives each test file its
+ * own isolate, so each holds its own instance of this module. What merges here
+ * is what one test file's realms ran.
  */
 const collector = new PatternCoverageCollector();
 
@@ -74,9 +82,17 @@ export function patternCoverageCollector():
   return patternCoverageDir() === undefined ? undefined : collector;
 }
 
-/** One file per test process; `deno test` runs a shard's files in one process. */
+/**
+ * The file this collector writes, named apart from every other collector's in
+ * the same run: a shard runs several test files and each holds a collector of
+ * its own. The gate joins every `.lcov` an artifact carries, so a shard's report
+ * arriving in several files reads the same as one.
+ */
+const OUTPUT_FILE_NAME =
+  `pattern-integration-${Deno.pid}-${crypto.randomUUID()}.pattern-coverage.lcov`;
+
 function outputPath(dir: string): string {
-  return join(dir, `pattern-integration-${Deno.pid}.pattern-coverage.lcov`);
+  return join(dir, OUTPUT_FILE_NAME);
 }
 
 export function withRepositoryFileNames(
@@ -107,12 +123,22 @@ export async function enablePatternCoverage(page: Page): Promise<void> {
   });
 }
 
+/** What one page had to hand over when it was asked for its worker's hits. */
+type PatternCoverageDump =
+  | { noRuntime: true }
+  | { noCoverageRequest: true }
+  | { data: PatternCoverageData | null };
+
 /**
  * Pull one page's accumulated hits and rewrite the merged LCOV. Must run before
- * the page's runtime is disposed, which takes the worker's collector with it.
+ * the page's runtime is dropped, which takes the worker's collector with it.
  *
- * Best-effort: a page that never booted a runtime, or whose worker is already
- * gone, contributes nothing rather than failing the test it is tearing down.
+ * A page that cannot answer never fails the test it is collecting from. One
+ * empty-handed answer costs nothing: a page that never booted a runtime holds
+ * nothing, and says nothing. Every other one is a page whose worker ran authored
+ * statements this report will not carry, which the gate charges to whoever
+ * changes the tree next, so each of those names what was lost and why.
+ *
  * Rewriting the whole merged report on every dump keeps the file complete
  * without needing a process-exit hook.
  */
@@ -120,21 +146,37 @@ export async function collectPatternCoverage(page: Page): Promise<void> {
   const dir = patternCoverageDir();
   if (dir === undefined) return;
 
-  // `noRuntime` and a null report are different failures: the first is a page
-  // that never booted a runtime (nothing to collect, and normal), the second is
-  // a worker built without a collector — i.e. the flag above never reached it,
-  // which would otherwise look exactly like a pattern that ran no lines.
-  let result: { noRuntime: true } | { data: PatternCoverageData | null };
+  // Four answers, one of them normal. `noRuntime` is a page that never booted
+  // one, so there was nothing to collect. A runtime with no `getPatternCoverage`
+  // is a shell built against a runtime client from before the request existed. A
+  // null report is a worker built without a collector — the flag `localStorage`
+  // carries never reached its `InitializationData`. Anything thrown is a page
+  // that could not be reached at all, the worker having gone first.
+  let result: PatternCoverageDump;
   try {
     result = await page.evaluate(async () => {
       const rt = globalThis.commonfabric?.rt;
-      if (!rt?.getPatternCoverage) return { noRuntime: true as const };
+      if (!rt) return { noRuntime: true as const };
+      if (!rt.getPatternCoverage) return { noCoverageRequest: true as const };
       return { data: await rt.getPatternCoverage() };
-    }) as { noRuntime: true } | { data: PatternCoverageData | null };
-  } catch {
+    }) as PatternCoverageDump;
+  } catch (error) {
+    console.warn(
+      "[pattern-coverage] this page could not be asked for its worker's " +
+        "pattern coverage, so every hit the worker held is lost: " +
+        describeThrown(error),
+    );
     return;
   }
   if ("noRuntime" in result) return;
+  if ("noCoverageRequest" in result) {
+    console.warn(
+      "[pattern-coverage] this page's runtime client does not answer " +
+        "getPatternCoverage, so its worker's pattern coverage is lost. The " +
+        "shell it loaded was built against a runtime client without it.",
+    );
+    return;
+  }
 
   const data = result.data;
   if (data === null) {
@@ -145,7 +187,11 @@ export async function collectPatternCoverage(page: Page): Promise<void> {
     );
     return;
   }
-  if (data.spans.length === 0) return;
+  // Hits with no spans beside them are a realm that only warm-loaded
+  // already-instrumented bytes; they key against the spans the realm that
+  // compiled those bytes registered, so they are ingested like any others. A
+  // dump with neither ran no instrumented statement, so it has nothing to add.
+  if (data.spans.length === 0 && data.hits.length === 0) return;
 
   collector.ingest(data);
   await writeMergedPatternCoverage(dir);

--- a/packages/integration/shell-utils.ts
+++ b/packages/integration/shell-utils.ts
@@ -90,6 +90,13 @@ export async function login(page: Page, identity: Identity): Promise<void> {
 
   const serializedId = jsonFromFabricValue(keyPair);
 
+  // Setting an identity builds a new runtime and drops the one the page is
+  // holding: `resolveIdentity` mints a fresh `Identity` from what crosses the
+  // boundary, so `shouldRecreateRuntime` fires on the object even for the DID
+  // already logged in. Take the outgoing worker's pattern-coverage hits while
+  // it is still there to ask.
+  await collectPatternCoverage(page);
+
   // Everything from here on runs against the page, and every way it can fail
   // says nothing about the page it failed against. The runtime handshake below
   // reports which of its two stages ran out, and no more than that.
@@ -459,9 +466,6 @@ export class ShellIntegration {
   #afterAll = async () => {
     if (this.#page) {
       await getPresentationSession()?.close(this.#page);
-      // Before disposing: the worker owns the collector, and disposing the
-      // runtime takes it with it.
-      await collectPatternCoverage(this.#page);
     }
     await this.#disposePageRuntime();
     await this.#page?.close();
@@ -475,6 +479,9 @@ export class ShellIntegration {
   async #disposePageRuntime(): Promise<void> {
     const page = this.#page;
     if (!page) return;
+    // Before disposing: the worker owns the collector, and disposing the
+    // runtime takes it with it.
+    await collectPatternCoverage(page);
     try {
       await page.evaluate(async () => {
         await globalThis.commonfabric?.rt?.dispose();


### PR DESCRIPTION
The authored-pattern coverage the browser-driven integration suites collect was losing most of what it measured, and losing it silently, in three separate ways. Which lines survived depended on how the test files happened to be distributed across shards, so adding one file under packages/patterns/integration/ reshuffled the shards and moved the `coverage-debt: packages/patterns` count in files the change never touched.

The largest loss was the report's file name. `deno test` runs each test file in its own isolate, so each holds its own instance of packages/integration/pattern-coverage.ts and its own collector, but every one of them wrote
`pattern-integration-<pid>.pattern-coverage.lcov` — one name for the whole process. Each test file's report therefore overwrote the one before it, and a shard uploaded only what its last collecting file had gathered. Locally, shard 2 of 10 reported 2836 covered lines where its files together cover 5405: the whole of
parking-coordinator-admin-view.test.ts was overwritten by shared-profile.test.ts. Each collector now writes a file named apart from the others, and the gate already joins every `.lcov` an artifact carries.

The second loss was ordering. The harness pulled a page's hits once, at teardown. The shell builds a new runtime whenever the page navigates and whenever an identity is set on it — `shouldRecreateRuntime` compares the `Identity` object, and the harness mints a fresh one from what crosses the page boundary — and dropping a runtime takes the worker's collector with it. So every runtime but the last contributed nothing, and which lines that cost depended on which flow the last runtime happened to have run. `Page` now takes before-unload hooks, run on a navigation, a reload, and a close, and `Browser.newPage` registers the pull on every page it makes; the harness pulls again before a login and before it disposes a runtime. Each of those points is immediately followed by the runtime going away, so every runtime is pulled exactly once. shared-profile.test.ts and parking-coordinator-admin-view.test.ts each run two runtimes and were each reporting one.

The third loss was a dump carrying hits and no spans of its own, which was dropped outright. That is what a realm reports when it only warm-loaded already-instrumented bytes: the spans belong to whichever realm compiled them, the hits key against those spans, and merging the two is what the collector's `ingest` is for.

Three of the four ways a dump can come back empty-handed returned in silence, which is how all of this went unreported. Only a page that never booted a runtime has nothing to lose, and that one stays quiet. A page that cannot be reached at all, a runtime that does not answer the request, and a worker built with no collector now each say on the log what was lost and why.

Verified locally against shard 2 of 10: each file's contribution is the same whether the file runs alone or beside the rest of its shard — the shard's covered-line set equals the union of the files' own, exactly — and repeated runs of one file produce identical coverage. That is the property a shard reshuffle needs. Every file belongs to exactly one shard, so a union that does not depend on a file's company does not depend on the assignment either.

One gap this does not close: a test file that runs patterns only through a pieces controller in the test process, with no page to dump from, never reaches the write and contributes nothing at all. all.test.ts is that case, and docs/development/COVERAGE.md now records it.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6746?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

