### PR TITLE
fix(runner): recover stale piece setup conflicts

### DIFF
--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -1269,8 +1269,9 @@ nod, 2026-08-07; recorded in the plan's stage list):**
   still possible, but its one-shot loss arms are bounded in the runner:
   a deferred client start that loses a stale-read race catches up from
   served state, while a serving `piece-instantiate` contribution that
-  is dropped cancels only its exact speculative node group and
-  re-instantiates once in the next wave. The grace still reduces the
+  is dropped, or whose immediate setup commit loses a stale-read race,
+  cancels only its exact speculative node group and re-instantiates once
+  from caught-up state. The grace still reduces the
   contention rate; correctness no longer depends on winning that first
   bookkeeping wave. Whole-wave aborts and abandons keep their existing
   lifecycle recovery instead of retrying in place.
@@ -2973,8 +2974,8 @@ Delta 2026-08-15 — Phase 6 independent-review fixes (same PR):
   serving runtime supplies). The separate
   client-instantiate-vs-server-derive race at piece creation remains a
   source of contention, but not an unrecovered one-shot loss: deferred
-  client starts catch up and dropped serving-instantiation contributions
-  retry once under exact lifecycle guards (residual x).**
+  client starts catch up, and stale-read or dropped serving-instantiation
+  commits recover once under exact lifecycle guards (residual x).**
 - OW34 — a CFC-serving POLICY item: served handler runs carry NO
   renderer-trusted event mark, so a per-user served handler's write to a
   UI-contract-gated (owner-protected) cell is refused by CFC at prepare
@@ -6658,14 +6659,17 @@ supply; OW29/OW32/OW34 closed):
     cancellation signal; a runtime cycle, pointer change, or newer node
     group wins through exact guards. A second drop tears the exact
     registration down rather than spinning. A whole-wave abort or abandon
-    is not retried in place. An immediate self-minted instantiate commit
-    refusal/rejection also tears down the exact current registration in every
-    posture, including client/OFF: a graph whose setup writes never landed is
-    a zombie, not a viable self-healing registration. Explicit wave abandon
-    is classified separately and warned without incrementing the serving
-    runtime's structure-load-failure observer; other failures remain loud.
-    Pinned in `executor-wave.test.ts` by a deterministic whole-document
-    conflict plus a held-readiness teardown companion. And OW46's
+    is not retried in place. An immediate self-minted instantiate commit that
+    loses a stale-read race follows the same one-shot recovery. Other immediate
+    refusals and rejections tear down the exact current registration. The OFF
+    posture keeps every immediate refusal terminal, leaving its cross-tab race
+    to the cross-tab mutex. A graph whose setup writes never landed is a
+    zombie, not a viable self-healing registration. Explicit wave abandon is
+    classified separately and warned
+    without incrementing the serving runtime's structure-load-failure
+    observer; other failures remain loud. Pinned in
+    `executor-wave.test.ts` by deterministic contribution-drop and stale-read
+    conflicts plus a held-readiness teardown companion. And OW46's
     `structure-load-stuck` counter is BLIND here: it fires 6× per run
     in BOTH arms and in the reds names only the HOST's space, because
     it counts deferred structure loads of DEMANDED roots and this

--- a/packages/patterns/integration/lunch-poll-keyed-votes.test.ts
+++ b/packages/patterns/integration/lunch-poll-keyed-votes.test.ts
@@ -143,6 +143,19 @@ describe("lunch poll: a vote is a keyed, mergeable write", () => {
     expect(await alice.read(["voteCount"])).toBe(0);
   });
 
+  it("makes a foreign cast visible after settling", async () => {
+    const [, bob] = everyone;
+    const option = options[1];
+
+    await bob.send("castVote", { optionId: option, voteType: "green" });
+    await harness.settle();
+    expect(await host.read(["voteCount"])).toBe(1);
+
+    await bob.send("clearMyVote", { optionId: option });
+    await harness.settle();
+    expect(await host.read(["voteCount"])).toBe(0);
+  });
+
   it("keeps a lunch-time burst from becoming a retry storm", async () => {
     // Everyone re-votes every option at once, repeatedly — the shape of a real
     // lunch decision, where a whole-list write makes each vote wait seconds.

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -1791,12 +1791,13 @@ export class Runner {
   // cancelled ownership already tombstones the work. Tracked solely so tests
   // can synchronize deterministically.
   #pendingDeferredStartCatchUps = new Set<Promise<unknown>>();
-  // Self-minted piece instantiations seal asynchronously into the serving
-  // wave. Their local graph is speculative until that wave settles, so a
-  // contribution drop tears down that exact node group and re-instantiates it
-  // once against the rolled-back view. This set is a deterministic test seam:
-  // disposal relies on the registration and lifecycle guards rather than
-  // waiting for a wave that a closing serving loop may abandon.
+  // Self-minted piece instantiations commit asynchronously. Their local graph
+  // is speculative until that commit and any serving wave settle, so a stale
+  // setup basis or contribution drop tears down that exact node group and
+  // re-instantiates it once against the caught-up view. This set is a
+  // deterministic test seam: disposal relies on the registration and
+  // lifecycle guards rather than waiting for work a closing serving loop may
+  // abandon.
   #pendingPieceInstantiationSettlements = new Set<Promise<unknown>>();
   // Both maps record that this runner prepared or stopped a result, so a later
   // start of the same result can reuse the cells it already assembled instead
@@ -3331,8 +3332,8 @@ export class Runner {
 
     // Create cancel group early, before wiring pattern/node sinks.
     const [cancelGroup, addCancel] = useCancelGroup();
-    // A withdrawn instantiation may be waiting for its conflict/session gate
-    // and a named-document pull before it retries. That work belongs to the
+    // A failed instantiation may be waiting for its conflict/session gate and
+    // a named-document pull before it recovers. That work belongs to the
     // OUTER registration, not the retired node group: stopping the piece must
     // release the fire-and-forget settlement even when readiness never does.
     const retryReadinessTeardown = new AbortController();
@@ -3380,7 +3381,7 @@ export class Runner {
     const instantiatePattern = (
       pattern: Pattern,
       useTx?: IExtendedStorageTransaction,
-      recoverDroppedContribution = true,
+      allowRecovery = true,
     ) => {
       if (!active || startLifecycleEpoch !== this.#lifecycleEpoch) return;
       // Create new cancel group for nodes
@@ -3455,9 +3456,49 @@ export class Runner {
             active && startLifecycleEpoch === this.#lifecycleEpoch &&
             this.cancels.get(key) === cancel && cancelNodes === nodeCancel &&
             currentPatternKey === patternKeyAtInstantiation;
+          const recoverInstantiationOnce = async (error: unknown) => {
+            if (!exactNodesAreCurrent()) return;
+            if (!allowRecovery) {
+              teardownRegistrationIfCurrent();
+              return;
+            }
+
+            nodeCancel();
+            if (cancelNodes === nodeCancel) cancelNodes = undefined;
+            await this.runtime.awaitCommitRetryReadiness(
+              error,
+              retryReadinessTeardown.signal,
+            );
+
+            if (
+              retryReadinessTeardown.signal.aborted || !active ||
+              startLifecycleEpoch !== this.#lifecycleEpoch ||
+              this.cancels.get(key) !== cancel ||
+              currentPatternKey !== patternKeyAtInstantiation ||
+              cancelNodes !== undefined
+            ) {
+              return;
+            }
+            try {
+              instantiatePattern(pattern, undefined, false);
+            } catch (retryError) {
+              this.#reportPieceStartCommitFailure(
+                instantiateActionId,
+                retryError,
+              );
+              teardownRegistrationIfCurrent();
+            }
+          };
           const commitWork = actualTx.commit().then(async ({ error }) => {
             if (error !== undefined) {
               this.#reportPieceStartCommitFailure(instantiateActionId, error);
+              if (
+                this.runtime.experimental.serverExecution === true &&
+                isStaleReadConflict(error)
+              ) {
+                await recoverInstantiationOnce(error);
+                return;
+              }
               if (exactNodesAreCurrent()) teardownRegistrationIfCurrent();
               return;
             }
@@ -3489,10 +3530,6 @@ export class Runner {
               teardownRegistrationIfCurrent();
               return;
             }
-            if (!recoverDroppedContribution) {
-              teardownRegistrationIfCurrent();
-              return;
-            }
 
             // The graph reads its own pending setup and internal-cell writes
             // while it is installed. Once the wave withdraws those writes,
@@ -3500,35 +3537,7 @@ export class Runner {
             // never became durable. Retire only the nodes this transaction
             // installed; the outer registration remains in place so its
             // original parent/root owner keeps the same cancellation handle.
-            nodeCancel();
-            if (cancelNodes === nodeCancel) cancelNodes = undefined;
-            await this.runtime.awaitCommitRetryReadiness(
-              settled.error,
-              retryReadinessTeardown.signal,
-            );
-
-            // A stop aborts the readiness/pull work above; a runtime cycle,
-            // pointer change, or newer instantiation during the wait owns the
-            // key now. Otherwise retry exactly once; a second drop tears the
-            // registration down instead of spinning on a permanent conflict.
-            if (
-              retryReadinessTeardown.signal.aborted || !active ||
-              startLifecycleEpoch !== this.#lifecycleEpoch ||
-              this.cancels.get(key) !== cancel ||
-              currentPatternKey !== patternKeyAtInstantiation ||
-              cancelNodes !== undefined
-            ) {
-              return;
-            }
-            try {
-              instantiatePattern(pattern, undefined, false);
-            } catch (retryError) {
-              this.#reportPieceStartCommitFailure(
-                instantiateActionId,
-                retryError,
-              );
-              teardownRegistrationIfCurrent();
-            }
+            await recoverInstantiationOnce(settled.error);
           }).catch((error) => {
             this.#reportPieceStartCommitFailure(instantiateActionId, error);
             if (exactNodesAreCurrent()) teardownRegistrationIfCurrent();

--- a/packages/runner/test/executor-wave.test.ts
+++ b/packages/runner/test/executor-wave.test.ts
@@ -153,6 +153,7 @@ describe("stage D seal-into-wave", () => {
   const stoppedWitnessPiece = async (
     id: string,
     options: { throwOnInstantiation?: number } = {},
+    targetRuntime = runtime,
   ) => {
     let instantiations = 0;
     let lastRunInstantiation = 0;
@@ -191,17 +192,17 @@ describe("stage D seal-into-wave", () => {
         outputs: {},
       }],
     };
-    const tx = runtime.edit();
-    const cell = runtime.getCell<Record<string, unknown>>(
+    const tx = targetRuntime.edit();
+    const cell = targetRuntime.getCell<Record<string, unknown>>(
       space,
       id,
       undefined,
       tx,
     );
-    const running = runtime.runner.run(tx, pattern, {}, cell);
+    const running = targetRuntime.runner.run(tx, pattern, {}, cell);
     expect((await tx.commit()).error).toBeUndefined();
     await running.pull();
-    runtime.runner.stop(cell);
+    targetRuntime.runner.stop(cell);
     return {
       cell,
       instantiations: () => instantiations,
@@ -3870,6 +3871,7 @@ describe("stage D seal-into-wave", () => {
 
     expect(await runtime.start(witness.cell)).toBe(true);
     await runtime.runner.idlePieceInstantiationSettlements();
+    await runtime.idle();
     expect(rejections).toBe(1);
     expect(failures).toContain(rejection);
 
@@ -3880,6 +3882,102 @@ describe("stage D seal-into-wave", () => {
     await runtime.idle();
     await runtime.runner.idlePieceInstantiationSettlements();
     expect(witness.instantiations()).toBe(3);
+  });
+
+  it("reinstantiates once after a stale-read piece-instantiation commit conflict", async () => {
+    const witness = await stoppedWitnessPiece(
+      "wave-piece-instantiate-stale-read",
+    );
+    const failures: unknown[] = [];
+    let seals = 0;
+    let readinessCalls = 0;
+    runtime.pieceStartCommitFailureObserver = ({ error }) => {
+      failures.push(error);
+    };
+    runtime.installSealDestination({
+      seal: (tx) => {
+        if (
+          waveRunContextOf(tx)?.actionId.startsWith("piece-instantiate/") &&
+          seals++ === 0
+        ) {
+          return Promise.resolve({
+            error: {
+              name: "ConflictError",
+              message:
+                "stale confirmed read: of:test at seq 1 conflicted with seq 2",
+              readyToRetry: () => {
+                readinessCalls += 1;
+                return Promise.resolve();
+              },
+            } as never,
+          });
+        }
+        return tx.tx.commit();
+      },
+    }, {
+      runStamper: (tx, info) =>
+        stampWaveRunContext(tx, {
+          actionId: info.actionId,
+          kind: info.kind,
+        }),
+    });
+
+    expect(await runtime.start(witness.cell)).toBe(true);
+    await runtime.runner.idlePieceInstantiationSettlements();
+
+    expect(seals).toBe(2);
+    expect(readinessCalls).toBe(1);
+    expect(failures).toHaveLength(1);
+    expect(witness.instantiations()).toBe(3);
+    expect(witness.lastRunInstantiation()).toBe(3);
+  });
+
+  it("keeps a stale-read piece-instantiation commit conflict terminal with server execution off", async () => {
+    const offManager = EmulatedStorageManager.connectTo(server, {
+      as: signer,
+    });
+    const offRuntime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: offManager,
+      experimental: { serverExecution: false },
+    });
+    const originalEdit = offRuntime.edit.bind(offRuntime);
+    try {
+      const witness = await stoppedWitnessPiece(
+        "off-piece-instantiate-stale-read",
+        {},
+        offRuntime,
+      );
+      let refused = false;
+      (offRuntime as unknown as { edit: typeof offRuntime.edit }).edit = ((
+        ...args: Parameters<typeof offRuntime.edit>
+      ) => {
+        const tx = originalEdit(...args);
+        if (refused) return tx;
+        refused = true;
+        (tx as unknown as { commit: typeof tx.commit }).commit = (() => {
+          const error = {
+            name: "ConflictError",
+            message:
+              "stale confirmed read: of:test at seq 1 conflicted with seq 2",
+            readyToRetry: () => Promise.resolve(),
+          };
+          tx.abort(error.message);
+          return Promise.resolve({ error });
+        }) as typeof tx.commit;
+        return tx;
+      }) as typeof offRuntime.edit;
+
+      expect(await offRuntime.start(witness.cell)).toBe(true);
+      await offRuntime.runner.idlePieceInstantiationSettlements();
+      expect(refused).toBe(true);
+      expect(witness.instantiations()).toBe(2);
+    } finally {
+      (offRuntime as unknown as { edit: typeof offRuntime.edit }).edit =
+        originalEdit;
+      await offRuntime.dispose();
+      await offManager.close();
+    }
   });
 
   it("aborts held retry readiness when the piece stops and does not revive it", async () => {


### PR DESCRIPTION
A self-minted piece instantiation can race serving-derived writes. Its setup commit is then refused for a stale read after the runner has installed new nodes. The existing failure path reports the conflict and tears down the registration. The affected session is left without a complete graph, so foreign writes remain invisible.

Retire only the nodes installed by the stale transaction. Wait for the conflict's catch-up signal, then instantiate once from the fresh view. Limit this recovery to server execution. Other immediate commit failures remain terminal.

Add deterministic runner tests for recovery with server execution on and terminal behavior with it off. Add a focused lunch-poll integration case that reproduces the lost foreign vote. Update the server-execution coverage record.

deflaked by Hixie's agent

Agent: Codex

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

