### PR TITLE
fix(tasks): the workspace runner refuses to start when a member has no test task

### DIFF
--- a/.claude/rules/workspace-packages.md
+++ b/.claude/rules/workspace-packages.md
@@ -16,16 +16,19 @@ This is not a tidiness rule. The root test runner (`tasks/test.ts`) walks every
 workspace member and runs `deno task test` in each. A member with no `test`
 task falls through to the root workspace's task, which is the whole suite —
 so the suite would re-enter itself once per such package, spawning processes
-exponentially. The runner reads every member's manifest before it spawns
-anything and refuses to start when one has no `test` entry, naming it, so the
-symptom is that message rather than a hung job.
+exponentially. The runner reads every member's manifest before it runs any of
+their test tasks, and refuses to start when one has no `test` entry, naming it,
+so the symptom is that message rather than a hung job.
 
-A `test` task defined by its `"dependencies"` alone satisfies the rule, since
-the name still resolves in the package's own directory. The check therefore
-asks whether the manifest declares the task at all, which is a different
-question from the one `memberTestTask()` in `tasks/workspace-tests.ts` answers
-— what command line the task runs, which a dependencies-only task does not
-have.
+What the entry has to do is resolve in the package's own directory, and two
+things follow. A `test` task defined by its `"dependencies"` alone satisfies
+the rule, so the check asks whether the manifest declares the task at all —
+a different question from the one `memberTestTask()` in
+`tasks/workspace-tests.ts` answers, which is what command line the task runs,
+and a dependencies-only task has none. And the manifest that has to carry the
+entry is the one Deno resolves: a `deno.json` beside a `deno.jsonc` is taken
+whole and the other file ignored, so a `test` task written in the ignored one
+counts for nothing.
 
 `packages/utils/deno.jsonc` is a correct minimal example.
 

--- a/.claude/rules/workspace-packages.md
+++ b/.claude/rules/workspace-packages.md
@@ -15,9 +15,17 @@ when it does not have them yet.
 This is not a tidiness rule. The root test runner (`tasks/test.ts`) walks every
 workspace member and runs `deno task test` in each. A member with no `test`
 task falls through to the root workspace's task, which is the whole suite —
-so the suite re-enters itself once per such package, spawning processes
-exponentially until CI times out. The symptom is a hung job, not an error
-message naming the package.
+so the suite would re-enter itself once per such package, spawning processes
+exponentially. The runner reads every member's manifest before it spawns
+anything and refuses to start when one has no `test` entry, naming it, so the
+symptom is that message rather than a hung job.
+
+A `test` task defined by its `"dependencies"` alone satisfies the rule, since
+the name still resolves in the package's own directory. The check therefore
+asks whether the manifest declares the task at all, which is a different
+question from the one `memberTestTask()` in `tasks/workspace-tests.ts` answers
+— what command line the task runs, which a dependencies-only task does not
+have.
 
 `packages/utils/deno.jsonc` is a correct minimal example.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,8 +221,11 @@ is missed:
 2. A `"tasks"` object in its own `deno.jsonc` carrying a `"test"` entry — either
    `"deno test"`, or `"echo 'No tests defined.'"` when it has no tests yet.
    Without one, `deno task test` falls through to the root workspace's task and
-   re-runs the whole suite inside itself, spawning processes exponentially until
-   CI times out. `packages/utils/deno.jsonc` is a correct example.
+   re-runs the whole suite inside itself, spawning processes exponentially. The
+   workspace runner reads every member's manifest before it spawns anything and
+   refuses to start when one has no `"test"` entry, so what a missing entry
+   costs is a message naming the member rather than a CI timeout.
+   `packages/utils/deno.jsonc` is a correct example.
 
 When the package needs a dependency, follow `docs/development/DEPENDENCIES.md`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,9 +222,9 @@ is missed:
    `"deno test"`, or `"echo 'No tests defined.'"` when it has no tests yet.
    Without one, `deno task test` falls through to the root workspace's task and
    re-runs the whole suite inside itself, spawning processes exponentially. The
-   workspace runner reads every member's manifest before it spawns anything and
-   refuses to start when one has no `"test"` entry, so what a missing entry
-   costs is a message naming the member rather than a CI timeout.
+   workspace runner reads every member's manifest before it runs any of their
+   test tasks, and refuses to start when one has no `"test"` entry, so what a
+   missing entry costs is a message naming the member rather than a CI timeout.
    `packages/utils/deno.jsonc` is a correct example.
 
 When the package needs a dependency, follow `docs/development/DEPENDENCIES.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -220,12 +220,12 @@ is missed:
 1. Its path added to the `"workspace"` array in the root `deno.jsonc`.
 2. A `"tasks"` object in its own `deno.jsonc` carrying a `"test"` entry — either
    `"deno test"`, or `"echo 'No tests defined.'"` when it has no tests yet.
-   Without one, `deno task test` falls through to the root workspace's task and
-   re-runs the whole suite inside itself, spawning processes exponentially. The
-   workspace runner reads every member's manifest before it runs any of their
-   test tasks, and refuses to start when one has no `"test"` entry, so what a
-   missing entry costs is a message naming the member rather than a CI timeout.
-   `packages/utils/deno.jsonc` is a correct example.
+   Without one, `deno task test` falls through to the root workspace's task,
+   which would re-run the whole suite inside itself, spawning processes
+   exponentially. The workspace runner reads every member's manifest before it
+   runs any of their test tasks, and refuses to start when one has no `"test"`
+   entry, so what a missing entry costs is a message naming the member rather
+   than a CI timeout. `packages/utils/deno.jsonc` is a correct example.
 
 When the package needs a dependency, follow `docs/development/DEPENDENCIES.md`.
 

--- a/docs/development/DEVELOPMENT.md
+++ b/docs/development/DEVELOPMENT.md
@@ -642,9 +642,9 @@ suite will break.
    a package lacks a test task, Deno resolves the task name against the root
    workspace instead, which re-runs the entire test suite recursively and spawns
    processes exponentially. The runner reads every member's manifest before it
-   spawns anything and refuses to start when one has no `"test"` entry, naming
-   the member; that check is what keeps a missing entry to a message rather than
-   a CI timeout.
+   runs any of their test tasks, and refuses to start when one has no `"test"`
+   entry, naming the member; that check is what keeps a missing entry to a
+   message rather than a CI timeout.
 
    Use `"deno test"` for packages with tests, or `"echo 'No tests defined.'"` as
    a stub for packages that don't have tests yet. A `"test"` task defined by its

--- a/docs/development/DEVELOPMENT.md
+++ b/docs/development/DEVELOPMENT.md
@@ -640,11 +640,16 @@ suite will break.
    object with a `"test"` entry. The root test runner (`tasks/test.ts`) iterates
    all workspace members and runs `deno task test` in each package directory. If
    a package lacks a test task, Deno resolves the task name against the root
-   workspace instead, which re-runs the entire test suite recursively. This
-   causes exponential process spawning and will time out CI.
+   workspace instead, which re-runs the entire test suite recursively and spawns
+   processes exponentially. The runner reads every member's manifest before it
+   spawns anything and refuses to start when one has no `"test"` entry, naming
+   the member; that check is what keeps a missing entry to a message rather than
+   a CI timeout.
 
    Use `"deno test"` for packages with tests, or `"echo 'No tests defined.'"` as
-   a stub for packages that don't have tests yet.
+   a stub for packages that don't have tests yet. A `"test"` task defined by its
+   `"dependencies"` alone counts too: what the check asks is whether the name
+   resolves in the package's own directory.
 
 3. **Minimal `deno.jsonc` example:**
 

--- a/docs/development/DEVELOPMENT.md
+++ b/docs/development/DEVELOPMENT.md
@@ -640,11 +640,11 @@ suite will break.
    object with a `"test"` entry. The root test runner (`tasks/test.ts`) iterates
    all workspace members and runs `deno task test` in each package directory. If
    a package lacks a test task, Deno resolves the task name against the root
-   workspace instead, which re-runs the entire test suite recursively and spawns
-   processes exponentially. The runner reads every member's manifest before it
-   runs any of their test tasks, and refuses to start when one has no `"test"`
-   entry, naming the member; that check is what keeps a missing entry to a
-   message rather than a CI timeout.
+   workspace instead, which would re-run the entire test suite recursively,
+   spawning processes exponentially. The runner reads every member's manifest
+   before it runs any of their test tasks, and refuses to start when one has no
+   `"test"` entry, naming the member; that check is what keeps a missing entry
+   to a message rather than a CI timeout.
 
    Use `"deno test"` for packages with tests, or `"echo 'No tests defined.'"` as
    a stub for packages that don't have tests yet. A `"test"` task defined by its

--- a/packages/patterns/deno.jsonc
+++ b/packages/patterns/deno.jsonc
@@ -41,8 +41,9 @@
   //
   // Every workspace member must define a `test` task. The root runner
   // (tasks/test.ts) calls `deno task test` in each member, and a member with no
-  // such task falls through to the root task and recurses over the whole
-  // workspace. So this lane stays a real task, never an empty stub.
+  // such task would fall through to the root task and recurse over the whole
+  // workspace; the runner refuses to start rather than let that happen, and
+  // names the member. So this lane stays a real task, never an empty stub.
   //
   // For how to write each kind of test and how CI measures them, see
   // docs/development/TESTING.md (the testing hub),

--- a/skills/cf-review/SKILL.md
+++ b/skills/cf-review/SKILL.md
@@ -199,8 +199,10 @@ transformer bug with a repro — not to hand-build a workaround.
 Stray cruft is trivial to fix but shouldn't merge: leftover debug logging /
 `*.log` / scratch notes, commented-out code, `.only` on tests, "temp" / "HACK"
 stopgaps, abandoned TODOs. A new workspace package must register in the root
-`deno.jsonc` and carry its own `tasks.test` (a missing one makes the root runner
-recurse and time out CI). Run `deno fmt` and `deno lint` on touched files.
+`deno.jsonc` and carry its own `tasks.test`, in the manifest Deno resolves — a
+`deno.json` shadows a `deno.jsonc` beside it. Without one the root runner
+refuses to start and names the member. Run `deno fmt` and `deno lint` on touched
+files.
 
 **A doc comment detached from its declaration** belongs here too, and a diff is
 the one place it is easy to see. A definition added directly under an existing

--- a/tasks/workspace-tests.test.ts
+++ b/tasks/workspace-tests.test.ts
@@ -654,9 +654,56 @@ Deno.test("assertMemberTestTasksDefined accepts a test task defined by dependenc
   }
 });
 
+Deno.test("assertMemberTestTasksDefined reads the manifest Deno resolves", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "ws-manifest-precedence-" });
+  try {
+    await makeWorkspace(dir, ["a"]);
+    // `makeWorkspace` gave the member a `deno.jsonc` with a `test` task.
+    // Deno takes the `deno.json` where a member carries both and ignores the
+    // other file whole, so the task in it is not one `deno task test` can
+    // find, and the member falls through to the root workspace all the same.
+    await Deno.writeTextFile(
+      `${dir}/packages/a/deno.json`,
+      JSON.stringify({ tasks: { bench: "deno bench" } }),
+    );
+
+    const members = await readWorkspaceMembers(`${dir}/deno.jsonc`);
+    await assertRejects(
+      () => assertMemberTestTasksDefined(members, dir),
+      Error,
+      "Missing from: `./packages/a`",
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("runTests refuses a workspace whose member defines no test task", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "ws-guarded-run-" });
+  try {
+    await makeWorkspace(dir, ["a", "b"]);
+    await Deno.writeTextFile(
+      `${dir}/packages/b/deno.jsonc`,
+      JSON.stringify({ tasks: { bench: "deno bench" } }),
+    );
+
+    await assertRejects(
+      () => runTests([], undefined, dir),
+      Error,
+      "Missing from: `./packages/b`",
+    );
+    // Each package's test task writes a marker when it runs, so an empty
+    // list is what says the refusal came ahead of the spawn loop rather than
+    // part way through it.
+    assertEquals(await ranPackages(dir, ["a", "b"]), []);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
 Deno.test("every workspace member defines a test task of its own", async () => {
-  // The same assertion the runner makes before it spawns anything, made
-  // here so that a member missing one is named by a failing test as well.
+  // The same assertion the runner makes ahead of its spawn loop, made here
+  // so that a member missing one is named by a failing test as well.
   const rootUrl = new URL("../", import.meta.url);
   const members = await readWorkspaceMembers(new URL("deno.jsonc", rootUrl));
   await assertMemberTestTasksDefined(members, rootUrl);

--- a/tasks/workspace-tests.test.ts
+++ b/tasks/workspace-tests.test.ts
@@ -1,7 +1,8 @@
-import { assertEquals, assertThrows } from "@std/assert";
+import { assertEquals, assertRejects, assertThrows } from "@std/assert";
 import {
   acceptsJUnitPath,
   acceptsPreload,
+  assertMemberTestTasksDefined,
   assertTaskTestsIncluded,
   initializeDb,
   junitCapableMembers,
@@ -589,4 +590,74 @@ Deno.test("the workspace's capable members are read from their manifests", async
   ) {
     assertEquals(capable.has(member), false, `${member} should not`);
   }
+});
+
+//
+// Every member's own `test` task
+//
+// The runner refuses to start a run when a member defines none: `deno task
+// test` in that member's directory resolves against the root workspace
+// instead, and the suite re-enters itself once per such member.
+//
+
+Deno.test("assertMemberTestTasksDefined names every member defining no test task", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "ws-missing-test-task-" });
+  try {
+    await makeWorkspace(dir, ["a", "b", "c"]);
+    // Two shapes reach the same place: a manifest whose tasks are all
+    // something else, and a member with no manifest at all.
+    await Deno.writeTextFile(
+      `${dir}/packages/b/deno.jsonc`,
+      JSON.stringify({ tasks: { bench: "deno bench" } }),
+    );
+    await Deno.remove(`${dir}/packages/c/deno.jsonc`);
+
+    const members = await readWorkspaceMembers(`${dir}/deno.jsonc`);
+    const error = await assertRejects(
+      () => assertMemberTestTasksDefined(members, dir),
+      Error,
+      "Missing from: `./packages/b`, `./packages/c`",
+    );
+    // Whoever meets this has just added a package and does not know the
+    // rule, so the message carries the entry to add and where to copy it
+    // from.
+    assertEquals(error.message.includes("echo 'No tests defined.'"), true);
+    assertEquals(error.message.includes("packages/utils/deno.jsonc"), true);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("assertMemberTestTasksDefined accepts a test task defined by dependencies alone", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "ws-dependency-test-task-" });
+  try {
+    await makeWorkspace(dir, ["a"]);
+    await Deno.writeTextFile(
+      `${dir}/packages/a/deno.jsonc`,
+      JSON.stringify({
+        tasks: {
+          check: "deno check .",
+          "just-test": "deno test",
+          test: { dependencies: ["check", "just-test"] },
+        },
+      }),
+    );
+
+    // Such a task resolves in the member's own directory, so the suite
+    // cannot re-enter itself through it. Whether it carries a command line
+    // is a different question, and the one `memberTestTask()` asks.
+    const members = await readWorkspaceMembers(`${dir}/deno.jsonc`);
+    await assertMemberTestTasksDefined(members, dir);
+    assertEquals(await memberTestTask("./packages/a", dir), undefined);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("every workspace member defines a test task of its own", async () => {
+  // The same assertion the runner makes before it spawns anything, made
+  // here so that a member missing one is named by a failing test as well.
+  const rootUrl = new URL("../", import.meta.url);
+  const members = await readWorkspaceMembers(new URL("deno.jsonc", rootUrl));
+  await assertMemberTestTasksDefined(members, rootUrl);
 });

--- a/tasks/workspace-tests.test.ts
+++ b/tasks/workspace-tests.test.ts
@@ -1,4 +1,9 @@
-import { assertEquals, assertRejects, assertThrows } from "@std/assert";
+import {
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+  assertThrows,
+} from "@std/assert";
 import {
   acceptsJUnitPath,
   acceptsPreload,
@@ -604,8 +609,10 @@ Deno.test("assertMemberTestTasksDefined names every member defining no test task
   const dir = await Deno.makeTempDir({ prefix: "ws-missing-test-task-" });
   try {
     await makeWorkspace(dir, ["a", "b", "c"]);
-    // Two shapes reach the same place: a manifest whose tasks are all
-    // something else, and a member with no manifest at all.
+    // Two shapes, one report: a manifest whose tasks are all something
+    // else, which is what falls through to the root workspace, and a member
+    // with no manifest, which never gets that far — Deno refuses to load a
+    // workspace at all when one of its members has no config file.
     await Deno.writeTextFile(
       `${dir}/packages/b/deno.jsonc`,
       JSON.stringify({ tasks: { bench: "deno bench" } }),
@@ -616,13 +623,16 @@ Deno.test("assertMemberTestTasksDefined names every member defining no test task
     const error = await assertRejects(
       () => assertMemberTestTasksDefined(members, dir),
       Error,
-      "Missing from: `./packages/b`, `./packages/c`",
+      "Missing from: `./packages/b/deno.jsonc`, `./packages/c/deno.jsonc`",
     );
     // Whoever meets this has just added a package and does not know the
     // rule, so the message carries the entry to add and where to copy it
     // from.
-    assertEquals(error.message.includes("echo 'No tests defined.'"), true);
-    assertEquals(error.message.includes("packages/utils/deno.jsonc"), true);
+    assertStringIncludes(error.message, "echo 'No tests defined.'");
+    assertStringIncludes(error.message, "packages/utils/deno.jsonc");
+    // Creating the other manifest is the way out that costs the member its
+    // `imports`, so the message has to warn against it where it is met.
+    assertStringIncludes(error.message, "ignores the other whole");
   } finally {
     await Deno.remove(dir, { recursive: true });
   }
@@ -668,10 +678,12 @@ Deno.test("assertMemberTestTasksDefined reads the manifest Deno resolves", async
     );
 
     const members = await readWorkspaceMembers(`${dir}/deno.jsonc`);
+    // The manifest named is the one Deno reads, not the one the author put
+    // the task in — which is the whole of what the member got wrong.
     await assertRejects(
       () => assertMemberTestTasksDefined(members, dir),
       Error,
-      "Missing from: `./packages/a`",
+      "Missing from: `./packages/a/deno.json`",
     );
   } finally {
     await Deno.remove(dir, { recursive: true });
@@ -690,7 +702,7 @@ Deno.test("runTests refuses a workspace whose member defines no test task", asyn
     await assertRejects(
       () => runTests([], undefined, dir),
       Error,
-      "Missing from: `./packages/b`",
+      "Missing from: `./packages/b/deno.jsonc`",
     );
     // Each package's test task writes a marker when it runs, so an empty
     // list is what says the refusal came ahead of the spawn loop rather than

--- a/tasks/workspace-tests.ts
+++ b/tasks/workspace-tests.ts
@@ -252,18 +252,18 @@ function directoryUrl(root: string | URL): URL {
 type TaskDefinition = string | { command?: string };
 
 /**
- * The `test` task each of a member's manifests defines, in the order Deno
- * resolves the manifests. `deno.json` comes first because Deno resolves it
- * first, so a member carrying both is read the way its own tooling reads it.
- * A manifest that is absent, or that defines no `test` task, contributes
- * nothing, so an empty result denotes a member with no `test` task at all.
+ * The `test` task the manifest Deno resolves for a member defines, or
+ * `undefined` where that manifest defines none. A member carrying both a
+ * `deno.json` and a `deno.jsonc` is read the way its own tooling reads it:
+ * Deno takes the `deno.json` and ignores the other file entirely rather than
+ * merging the two, so a `test` task written in the manifest Deno ignores is
+ * not a task anything can run.
  */
-async function memberTestTaskDefinitions(
+async function memberTestTaskDefinition(
   member: string,
   root: string | URL,
-): Promise<TaskDefinition[]> {
+): Promise<TaskDefinition | undefined> {
   const rootUrl = directoryUrl(root);
-  const definitions: TaskDefinition[] = [];
   for (const manifest of ["deno.json", "deno.jsonc"]) {
     let text: string;
     try {
@@ -271,38 +271,35 @@ async function memberTestTaskDefinitions(
     } catch {
       continue;
     }
-    const tasks = (parseJsonc(text) as {
+    return (parseJsonc(text) as {
       tasks?: Record<string, TaskDefinition>;
-    })?.tasks;
-    if (tasks?.test !== undefined) definitions.push(tasks.test);
+    })?.tasks?.test;
   }
-  return definitions;
+  return undefined;
 }
 
 /**
- * The command line a member's `test` task runs, when a manifest of that
- * member defines the task with a command. A task defined by its
- * `dependencies` alone carries no command and reads as `undefined` here, the
- * same as a member defining no `test` task at all;
+ * The command line a member's `test` task runs, when the manifest Deno
+ * resolves for that member defines the task with a command. A task defined
+ * by its `dependencies` alone carries no command and reads as `undefined`
+ * here, the same as a member defining no `test` task at all;
  * `assertMemberTestTasksDefined()` is what tells those two apart.
  */
 export async function memberTestTask(
   member: string,
   root: string | URL = Deno.cwd(),
 ): Promise<string | undefined> {
-  for (const task of await memberTestTaskDefinitions(member, root)) {
-    const command = typeof task === "string" ? task : task.command;
-    if (command !== undefined) return command;
-  }
-  return undefined;
+  const task = await memberTestTaskDefinition(member, root);
+  return typeof task === "string" ? task : task?.command;
 }
 
 /**
  * Throws unless every member defines a `test` task of its own, in whatever
- * form — a command, or dependencies alone. Starting a run with one missing is
- * what this refuses: `deno task test` in that member's directory resolves
- * against the root workspace instead, which is this suite, so the run
- * re-enters itself once per such member.
+ * form — a command, or dependencies alone — in the manifest Deno resolves
+ * for it. Starting a run with one missing is what this refuses: `deno task
+ * test` in that member's directory resolves against the root workspace
+ * instead, which is this suite, so the run re-enters itself once per such
+ * member.
  */
 export async function assertMemberTestTasksDefined(
   members: readonly string[],
@@ -310,9 +307,8 @@ export async function assertMemberTestTasksDefined(
 ): Promise<void> {
   const missing: string[] = [];
   for (const member of members) {
-    if ((await memberTestTaskDefinitions(member, root)).length === 0) {
-      missing.push(member);
-    }
+    const task = await memberTestTaskDefinition(member, root);
+    if (task === undefined) missing.push(member);
   }
   if (missing.length === 0) return;
   const named = missing.map((member) => `\`${member}\``).join(", ");
@@ -479,9 +475,10 @@ export async function runTests(
   const members = await readWorkspaceMembers(
     path.join(workspaceCwd, "deno.jsonc"),
   );
-  // Before anything is spawned, and over every member rather than this
-  // shard's: a member with no `test` task of its own is what turns one run
-  // into an unbounded number of them.
+  // No member's test task is spawned until every member has been checked,
+  // and every member is checked rather than this shard's: one with no `test`
+  // task of its own is what turns a single run into an unbounded number of
+  // them.
   await assertMemberTestTasksDefined(members, workspaceCwd);
   const units = selectShardMembers(members, disabledPackages, shard);
   if (units.length === 0) {

--- a/tasks/workspace-tests.ts
+++ b/tasks/workspace-tests.ts
@@ -251,31 +251,46 @@ function directoryUrl(root: string | URL): URL {
  */
 type TaskDefinition = string | { command?: string };
 
+/** The manifest Deno resolves for a member, and its `test` task. */
+interface MemberManifest {
+  /** Path to the manifest, relative to the workspace root. */
+  readonly path: string;
+
+  /** The `test` task it defines, where it defines one. */
+  readonly testTask: TaskDefinition | undefined;
+}
+
 /**
- * The `test` task the manifest Deno resolves for a member defines, or
- * `undefined` where that manifest defines none. A member carrying both a
- * `deno.json` and a `deno.jsonc` is read the way its own tooling reads it:
- * Deno takes the `deno.json` and ignores the other file entirely rather than
- * merging the two, so a `test` task written in the manifest Deno ignores is
- * not a task anything can run.
+ * The manifest Deno resolves for a member, and the `test` task that one
+ * manifest defines. A member carrying both a `deno.json` and a `deno.jsonc`
+ * is read the way its own tooling reads it: Deno takes the `deno.json` and
+ * ignores the other file entirely rather than merging the two, so a `test`
+ * task written in the manifest Deno ignores is not a task anything can run.
+ *
+ * A member with no manifest at all takes the `deno.jsonc` path, so that a
+ * report naming it names the file to write. Such a member never reaches the
+ * fall-through a `test` task exists to prevent, because Deno refuses to load
+ * a workspace at all when one of its members has no config file.
  */
-async function memberTestTaskDefinition(
+async function memberManifest(
   member: string,
   root: string | URL,
-): Promise<TaskDefinition | undefined> {
+): Promise<MemberManifest> {
   const rootUrl = directoryUrl(root);
   for (const manifest of ["deno.json", "deno.jsonc"]) {
+    const manifestPath = `${member}/${manifest}`;
     let text: string;
     try {
-      text = await Deno.readTextFile(new URL(`${member}/${manifest}`, rootUrl));
+      text = await Deno.readTextFile(new URL(manifestPath, rootUrl));
     } catch {
       continue;
     }
-    return (parseJsonc(text) as {
+    const tasks = (parseJsonc(text) as {
       tasks?: Record<string, TaskDefinition>;
-    })?.tasks?.test;
+    })?.tasks;
+    return { path: manifestPath, testTask: tasks?.test };
   }
-  return undefined;
+  return { path: `${member}/deno.jsonc`, testTask: undefined };
 }
 
 /**
@@ -289,8 +304,8 @@ export async function memberTestTask(
   member: string,
   root: string | URL = Deno.cwd(),
 ): Promise<string | undefined> {
-  const task = await memberTestTaskDefinition(member, root);
-  return typeof task === "string" ? task : task?.command;
+  const { testTask } = await memberManifest(member, root);
+  return typeof testTask === "string" ? testTask : testTask?.command;
 }
 
 /**
@@ -307,21 +322,24 @@ export async function assertMemberTestTasksDefined(
 ): Promise<void> {
   const missing: string[] = [];
   for (const member of members) {
-    const task = await memberTestTaskDefinition(member, root);
-    if (task === undefined) missing.push(member);
+    const { path, testTask } = await memberManifest(member, root);
+    if (testTask === undefined) missing.push(path);
   }
   if (missing.length === 0) return;
-  const named = missing.map((member) => `\`${member}\``).join(", ");
+  const named = missing.map((manifest) => `\`${manifest}\``).join(", ");
   throw new Error(
     [
       `Every workspace member needs a \`test\` task of its own.`,
       `Missing from: ${named}.`,
-      `Add a \`tasks\` object to the member's \`deno.json\` or \`deno.jsonc\``,
-      `carrying a \`test\` entry — \`deno test\` where the package has tests,`,
-      `or \`echo 'No tests defined.'\` where it has none yet, as`,
-      `\`packages/utils/deno.jsonc\` shows. Without that entry,`,
-      `\`deno task test\` in the package directory resolves against the root`,
-      `workspace instead, and the whole suite runs inside itself.`,
+      `Add a \`test\` entry to that manifest's \`tasks\` — \`deno test\` where`,
+      `the package has tests, or \`echo 'No tests defined.'\` where it has`,
+      `none yet, as \`packages/utils/deno.jsonc\` shows. Put it in the file`,
+      `named above rather than in a second manifest beside it: where a member`,
+      `carries both a \`deno.json\` and a \`deno.jsonc\`, Deno takes the`,
+      `\`deno.json\` and ignores the other whole, \`imports\` and all.`,
+      `Without the entry, \`deno task test\` in the package directory resolves`,
+      `against the root workspace instead, and the whole suite runs inside`,
+      `itself.`,
     ].join(" "),
   );
 }

--- a/tasks/workspace-tests.ts
+++ b/tasks/workspace-tests.ts
@@ -245,15 +245,25 @@ function directoryUrl(root: string | URL): URL {
 }
 
 /**
- * The `test` task a member's manifest defines, when it defines one.
- * `deno.json` is read first because Deno resolves it first, so a member
- * carrying both is read the way its own tooling reads it.
+ * A task as a manifest writes it: the command line itself, or an object that
+ * may carry one. An object with no `command` is defined by its `dependencies`
+ * instead, and Deno runs those.
  */
-export async function memberTestTask(
+type TaskDefinition = string | { command?: string };
+
+/**
+ * The `test` task each of a member's manifests defines, in the order Deno
+ * resolves the manifests. `deno.json` comes first because Deno resolves it
+ * first, so a member carrying both is read the way its own tooling reads it.
+ * A manifest that is absent, or that defines no `test` task, contributes
+ * nothing, so an empty result denotes a member with no `test` task at all.
+ */
+async function memberTestTaskDefinitions(
   member: string,
-  root: string | URL = Deno.cwd(),
-): Promise<string | undefined> {
+  root: string | URL,
+): Promise<TaskDefinition[]> {
   const rootUrl = directoryUrl(root);
+  const definitions: TaskDefinition[] = [];
   for (const manifest of ["deno.json", "deno.jsonc"]) {
     let text: string;
     try {
@@ -262,13 +272,62 @@ export async function memberTestTask(
       continue;
     }
     const tasks = (parseJsonc(text) as {
-      tasks?: Record<string, string | { command?: string }>;
+      tasks?: Record<string, TaskDefinition>;
     })?.tasks;
-    const task = tasks?.test;
-    const command = typeof task === "string" ? task : task?.command;
+    if (tasks?.test !== undefined) definitions.push(tasks.test);
+  }
+  return definitions;
+}
+
+/**
+ * The command line a member's `test` task runs, when a manifest of that
+ * member defines the task with a command. A task defined by its
+ * `dependencies` alone carries no command and reads as `undefined` here, the
+ * same as a member defining no `test` task at all;
+ * `assertMemberTestTasksDefined()` is what tells those two apart.
+ */
+export async function memberTestTask(
+  member: string,
+  root: string | URL = Deno.cwd(),
+): Promise<string | undefined> {
+  for (const task of await memberTestTaskDefinitions(member, root)) {
+    const command = typeof task === "string" ? task : task.command;
     if (command !== undefined) return command;
   }
   return undefined;
+}
+
+/**
+ * Throws unless every member defines a `test` task of its own, in whatever
+ * form — a command, or dependencies alone. Starting a run with one missing is
+ * what this refuses: `deno task test` in that member's directory resolves
+ * against the root workspace instead, which is this suite, so the run
+ * re-enters itself once per such member.
+ */
+export async function assertMemberTestTasksDefined(
+  members: readonly string[],
+  root: string | URL = Deno.cwd(),
+): Promise<void> {
+  const missing: string[] = [];
+  for (const member of members) {
+    if ((await memberTestTaskDefinitions(member, root)).length === 0) {
+      missing.push(member);
+    }
+  }
+  if (missing.length === 0) return;
+  const named = missing.map((member) => `\`${member}\``).join(", ");
+  throw new Error(
+    [
+      `Every workspace member needs a \`test\` task of its own.`,
+      `Missing from: ${named}.`,
+      `Add a \`tasks\` object to the member's \`deno.json\` or \`deno.jsonc\``,
+      `carrying a \`test\` entry — \`deno test\` where the package has tests,`,
+      `or \`echo 'No tests defined.'\` where it has none yet, as`,
+      `\`packages/utils/deno.jsonc\` shows. Without that entry,`,
+      `\`deno task test\` in the package directory resolves against the root`,
+      `workspace instead, and the whole suite runs inside itself.`,
+    ].join(" "),
+  );
 }
 
 /**
@@ -417,11 +476,14 @@ export async function runTests(
   workspaceCwd: string = Deno.cwd(),
 ): Promise<boolean> {
   const suiteStartedAt = Date.now();
-  const units = selectShardMembers(
-    await readWorkspaceMembers(path.join(workspaceCwd, "deno.jsonc")),
-    disabledPackages,
-    shard,
+  const members = await readWorkspaceMembers(
+    path.join(workspaceCwd, "deno.jsonc"),
   );
+  // Before anything is spawned, and over every member rather than this
+  // shard's: a member with no `test` task of its own is what turns one run
+  // into an unbounded number of them.
+  await assertMemberTestTasksDefined(members, workspaceCwd);
+  const units = selectShardMembers(members, disabledPackages, shard);
   if (units.length === 0) {
     console.error("No workspace packages selected to test.");
     return false;


### PR DESCRIPTION
## Why

AGENTS.md says a new workspace package needs two edits, "and the second one
bites hard when it is missed": its path in the root `deno.jsonc` workspace
array, and a `tasks` object in its own `deno.jsonc` carrying a `test` entry.
Without the second, `deno task test` in that directory falls through to the
root workspace task and re-runs the whole suite inside itself, spawning
processes until CI times out.

Nothing enforced that. `testPackage` spawns `deno task test` in a member's
directory without checking a local task exists; `assertTaskTestsIncluded`
sounds like the guard and is not — it only asserts the `tasks` package is a
member; and every case in `workspace-tests.test.ts` builds a synthetic
workspace under a temp directory, so none of them sees the real member list.
The first thing that notices is a hung job.

This came out of review on #6741, which scaffolds a package and therefore
lands exactly the entry this protects.

## What Changed

`assertMemberTestTasksDefined` runs at the top of `runTests`, before the
first spawn, and names every member missing the entry:

```
Every workspace member needs a `test` task of its own. Missing from:
`./packages/leb128`. Add a `tasks` object to the member's `deno.json` or
`deno.jsonc` carrying a `test` entry — `deno test` where the package has
tests, or `echo 'No tests defined.'` where it has none yet, as
`packages/utils/deno.jsonc` shows. Without that entry, `deno task test` in
the package directory resolves against the root workspace instead, and the
whole suite runs inside itself.
```

**A runtime assertion rather than a test alone**, because a test reports the
fire without putting it out: the tasks shard goes red while the other shards
are still forking. The assertion runs before anything spawns, and it fires on
the path the author is actually standing on — running `deno task test` inside
the new package is the mistake, and that falls through to the root runner,
which now stops one level in. The CI-failure property is kept anyway: one of
the three new tests asserts the real manifest, so a missing entry is a named
failing test too.

**The obvious predicate was wrong, and checking it is most of this change.**
`memberTestTask()` returns the member's `test` *command* — and against the
real 47-member workspace it returns `undefined` for **eight** members that
all define `tasks.test` perfectly well, as a dependencies-only task object:

```jsonc
"test": { "description": "Type check & run tests",
          "dependencies": ["check", "just-test"] }
```

Such a task has no `command` for `memberTestTask` to read. That conflation is
harmless where it is used today — a task with no readable command line
demonstrably cannot be shown to forward `--junit-path` — but a guard built on
it would have failed eight correct packages on day one. The predicate is
therefore *presence of `tasks.test` in any form*: string, `{command}`, or
`{dependencies}`, all three of which make `deno task test` resolve locally,
which is the whole of what stops the recursion.

`memberTestTask` moves onto a shared manifest reader rather than growing a
second copy of the `deno.json`-before-`deno.jsonc` resolution rule. Its
semantics are unchanged and its doc comment now states the bound it actually
has.

## Test plan

`deno fmt --check`, `deno lint`, `deno task check`, `deno task check-docs`,
`deno task check-skill-facts`, and `deno task test` in `tasks` (687 passed,
0 failed).

Three new cases: the guard names every member defining no test task (two
shapes — a manifest with other tasks, and no manifest at all); it accepts a
test task defined by dependencies alone, and asserts `memberTestTask()`
returns `undefined` for that same member, so nobody can "simplify" the guard
back onto the wrong predicate; and every real workspace member defines a test
task of its own.

Proven to fail: with `packages/leb128`'s `tasks.test` temporarily removed, the
real-manifest test fails with the message above, and `runTests` against the
real root throws before selecting anything — it never reaches the point where
it would have spawned. The file was restored byte-identically (sha256 checked)
and `git diff HEAD~1..HEAD -- packages/` is empty.

## Documentation

`.claude/rules/workspace-packages.md` said "The symptom is a hung job, not an
error message naming the package." That is now false, so correcting it was
not optional. AGENTS.md and `docs/development/DEVELOPMENT.md` carried the same
now-false "until CI times out" tail and get the same correction, plus a note
that a `dependencies`-only test task counts — without which someone meeting a
false alarm would "fix" eight manifests that are already correct.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6750?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

