### PR TITLE
fix(cf-harness): the label reader follows links to the end, and names the store it read (CT-2169)

### DIFF
--- a/packages/cf-harness/console/README.md
+++ b/packages/cf-harness/console/README.md
@@ -353,7 +353,11 @@ cells the space holds no label for. The database is opened read-only, and it is
 found by the space the fabric session names; `--space-db` points at the file
 instead, for a host whose store is not where the search looks — and a file named
 for anything but its space proves no DID, so every spaced reference and link
-goes unread against one.
+goes unread against one. A cell the opened file holds no document for is
+recorded as unread too, not as unlabeled: the run held a reference to it, so a
+store with nothing at it is a store the run did not write into. A file holding
+none of a run's cells is said out loud as the wrong store, with the fix beside
+it.
 
 ## Reading a run
 

--- a/packages/cf-harness/console/server.ts
+++ b/packages/cf-harness/console/server.ts
@@ -350,7 +350,7 @@ const parseTaskInputCells = (
  * batch CLI resolves argv into, so a capability configurable there is
  * configurable here by the same name. This surface adds only what an HTTP
  * server has and a command does not — a port, a durable session store, a
- * seeded system prompt, a space database to read labels out of.
+ * seeded system prompt.
  */
 interface ConsoleConfig extends HarnessSessionConfig {
   port: number;
@@ -368,13 +368,6 @@ interface ConsoleConfig extends HarnessSessionConfig {
   cfcInvocationContextDir: string;
 
   sessionDbPath?: string;
-
-  /**
-   * The space database the per-cell label snapshot reads, for a host whose
-   * store is not where the discovery walk looks. Absent, the space the
-   * fabric session names is resolved against the caches on this host.
-   */
-  spaceDbPath?: string;
 
   /**
    * System prompt seeded into every console session, read from the file named

--- a/packages/cf-harness/docs/pattern-index-measurement.md
+++ b/packages/cf-harness/docs/pattern-index-measurement.md
@@ -467,6 +467,74 @@ contradiction would refuse every correctly configured night. The report prints
 the server's block as the server's, beside the console's as the console's, and
 leaves the comparison to a reader who knows which runtime they are asking about.
 
+The comment above `ServerMeta` in `scripts/run-measurement-batch.ts` is the
+canonical statement of that rule, and is the thing to read before treating the
+server's block as evidence about anything a run wrote.
+
+## Which dial decides whether a label is written
+
+**The writing session's, and only the writing session's.** A `labelMap` is a
+field of the document a transaction commits, written by the runtime that commits
+it — the fabric session's runtime here, whose dials `--fabric-cfc-flow-labels`
+and `--fabric-cfc-posture` set. The memory server stores what it is given and
+mints no label of its own, so no server configuration turns label persistence on
+or off for these runs, and there is no toolshed environment variable that would.
+A toolshed reporting `flowLabels: "off"` while a session writes labeled
+documents into it is the system working.
+
+Two consequences worth stating, because assuming either way round is expensive:
+
+- The server's posture is **not** evidence about what a run wrote. To find out
+  what a run wrote, read the space.
+- A run's own `cell-labels.json` is not evidence either, unless it says
+  `status: "read"`. An `unavailable` snapshot is a reader that never reached the
+  store, which is the section below.
+
+## Reading the labels back
+
+The labels live in the serving toolshed's own store, and a run reads them from
+that file rather than over the wire. Finding it is the operator's job whenever
+the harness and the toolshed do not share a working tree.
+
+The search walks up from the working directory looking for
+`packages/toolshed/cache/memory` and `cache/memory` at each level, so it finds
+the store of a toolshed serving from the same checkout and no other. A
+measurement run from a second worktree — the ordinary arrangement, since the
+toolshed holds a branch still while the work moves on — shares no ancestor with
+the serving tree, and the search comes up empty. That reads as
+`unavailableReason: "space-not-found"`, under which every cell of the run is
+recorded as unasked-about.
+
+The worse case is a second worktree that has served the same space itself at
+some point, and so holds a file of the same name. The search finds that one,
+opens it, and finds none of the cells the run wrote. Each such cell is recorded
+with `unreadReason: "no-document"` rather than with an empty entry list, and a
+snapshot in which every cell reads that way is warned about as the wrong store.
+Neither reading is "the run wrote no labels".
+
+Point it at the store instead. Either of these names the same place:
+
+```sh
+# The environment the search consults first, for any run.
+MEMORY_DIR=/path/to/serving-tree/packages/toolshed/cache/memory
+
+# The flag, which names one database file directly.
+--space-db /path/to/serving-tree/packages/toolshed/cache/memory/engine-v3/engine-v3/<did>.sqlite
+```
+
+`--space-db` (`CF_HARNESS_SPACE_DB`) takes a file and needs the three fabric
+session flags beside it. `MEMORY_DIR` takes the cache directory and lets the
+space the session names resolve within it, which is what a batch spanning
+several spaces wants.
+
+A snapshot that then says `status: "read"` is a positive finding: the cells it
+lists carry the labels it shows, and a cell with an empty `entries` and no
+`unreadReason` is a cell the space holds no label for. The read follows the
+links out of each cell as far as the pattern's shape runs — a piece names its
+results, and each result may name cells of its own — so a label derived on a
+computed value sits in the snapshot under the path of links that reaches it,
+naming the cell it was read from as `source`.
+
 ## The failure this measurement exists to not commit
 
 Three separate things went wrong in the same shape while this was being built,

--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -195,6 +195,7 @@ const CLI_STRING_FLAGS = [
   "fabric-cfc-enforcement-mode",
   "fabric-cfc-flow-labels",
   "fabric-cfc-posture",
+  "space-db",
   "pattern-index-url",
   "host-mount",
   "browser-access-lease-id",
@@ -533,6 +534,10 @@ Options:
                                 into the named CFC posture bundle (every staged
                                 enforcement dial on); the two dials above still
                                 apply over the bundle
+  --space-db <path>             The space database the run's per-cell label
+                                snapshot reads. Give it when this run's working
+                                directory shares no ancestor with the server's,
+                                which is what the discovery walk looks under
   --pattern-index-url <url>     Base URL of the pattern index for search_patterns,
                                 record_feedback, and run_pattern's patternId argument;
                                 signs with the fabric session identity, so it needs the
@@ -564,6 +569,7 @@ Environment:
   CF_HARNESS_FABRIC_CFC_ENFORCEMENT_MODE Default value for --fabric-cfc-enforcement-mode
   CF_HARNESS_FABRIC_CFC_FLOW_LABELS Default value for --fabric-cfc-flow-labels
   CF_HARNESS_FABRIC_CFC_POSTURE Default value for --fabric-cfc-posture
+  CF_HARNESS_SPACE_DB           Default value for --space-db
   CF_HARNESS_PATTERN_INDEX_URL  Default value for --pattern-index-url
   CF_HARNESS_PATTERN_INDEX_PUBLISH 0 applies --no-pattern-index-publish
   CF_HARNESS_PATTERN_INDEX_PUBLISH_DISCOVERABLE 1 offers successful authored
@@ -1370,6 +1376,7 @@ export const parseCfHarnessCliArgs = async (
       CF_HARNESS_FABRIC_API_URL: Deno.env.get("CF_HARNESS_FABRIC_API_URL"),
       CF_HARNESS_FABRIC_IDENTITY: Deno.env.get("CF_HARNESS_FABRIC_IDENTITY"),
       CF_HARNESS_FABRIC_SPACE: Deno.env.get("CF_HARNESS_FABRIC_SPACE"),
+      CF_HARNESS_SPACE_DB: Deno.env.get("CF_HARNESS_SPACE_DB"),
       CF_HARNESS_FABRIC_CFC_ENFORCEMENT_MODE: Deno.env.get(
         "CF_HARNESS_FABRIC_CFC_ENFORCEMENT_MODE",
       ),
@@ -1685,6 +1692,23 @@ export const parseCfHarnessCliArgs = async (
       "--fabric-cfc-enforcement-mode, --fabric-cfc-flow-labels, and --fabric-cfc-posture configure the fabric session's runtime and need --fabric-api-url, --fabric-identity, and --fabric-space",
     );
   }
+  const rawSpaceDb = typeof args["space-db"] === "string"
+    ? args["space-db"].trim()
+    : nonEmptyEnvValue(env.CF_HARNESS_SPACE_DB);
+  if (rawSpaceDb === "") {
+    throw new Error("--space-db requires a non-empty value");
+  }
+  if (rawSpaceDb !== undefined && fabricSession === undefined) {
+    // The snapshot it points at is taken over the cells of a fabric session,
+    // so without one there is nothing for the database to be read for, and a
+    // path accepted here would silently do nothing all run.
+    throw new Error(
+      "--space-db names the database the fabric session's labels are read from and needs --fabric-api-url, --fabric-identity, and --fabric-space",
+    );
+  }
+  const spaceDbPath = rawSpaceDb === undefined
+    ? undefined
+    : resolve(cwd, rawSpaceDb);
   const rawPatternIndexUrl = typeof args["pattern-index-url"] === "string"
     ? args["pattern-index-url"].trim()
     : nonEmptyEnvValue(env.CF_HARNESS_PATTERN_INDEX_URL);
@@ -1841,6 +1865,7 @@ export const parseCfHarnessCliArgs = async (
     ...(sandboxDockerRuntime !== undefined ? { sandboxDockerRuntime } : {}),
     ...(fabricMount !== undefined ? { fabricMount } : {}),
     ...(fabricSession !== undefined ? { fabricSession } : {}),
+    ...(spaceDbPath !== undefined ? { spaceDbPath } : {}),
     ...(patternIndex !== undefined ? { patternIndex } : {}),
     ...(skillsSh !== undefined ? { skillsSh } : {}),
     hostMounts,

--- a/packages/cf-harness/src/contracts/cell-labels.ts
+++ b/packages/cf-harness/src/contracts/cell-labels.ts
@@ -112,11 +112,24 @@ export interface HarnessCellLabelEntry {
  * `below-read-depth` is a path sitting deeper inside a document than the
  * reader descends into one. Nothing was read at it or beneath it, and the
  * path names exactly where that begins.
+ *
+ * `beyond-link-hops` is the same fact along the other axis: a link sitting
+ * further out of the cell than the reader follows links. The document it
+ * addresses was not read, and neither was anything it links to in turn.
+ *
+ * `no-document` is an id the opened store holds no document for — never
+ * written, deleted, or undecodable. The run held a reference to it, so the
+ * cell exists somewhere; a store with nothing at it is a store that did not
+ * receive the run's writes, which is what a snapshot taken against the wrong
+ * file looks like, and the reading "this cell carries no label" would be
+ * exactly wrong.
  */
 export type HarnessCellLabelUnreadReason =
   | "cross-space"
   | "space-unproven"
-  | "below-read-depth";
+  | "below-read-depth"
+  | "beyond-link-hops"
+  | "no-document";
 
 /**
  * Why a cell's labels are some of what the space holds rather than all of it.
@@ -133,18 +146,27 @@ export type HarnessCellLabelUnreadReason =
  * evidence of the value the budget exists against — a restored graph with a
  * cycle in it, or a row no reader could enumerate the paths of — so it is
  * something to investigate rather than something to expect.
+ *
+ * `document-budget-exhausted` is the same statement about the graph rather
+ * than about one value: the reader spent its allowance of documents before
+ * the cells reachable from this one ran out. The links it had yet to follow
+ * were enumerated, but the paths beneath each of them were not, so naming
+ * them would claim more than was read.
  */
-export type HarnessCellLabelTruncationReason = "node-budget-exhausted";
+export type HarnessCellLabelTruncationReason =
+  | "node-budget-exhausted"
+  | "document-budget-exhausted";
 
 /**
  * One path inside a cell whose labels were not looked for, and why.
  *
- * A link one hop out of a cell is followed only where the store it addresses
- * is the opened one, and a path deeper than the reader descends is not
- * reached at all; either way the path holds no entry. Recording it is what
- * keeps it readable as a cell nobody asked about: an entry list carries no
- * gaps of its own, so a path missing from one is otherwise a path the space
- * holds no label for.
+ * A link is followed only where the store it addresses is the opened one,
+ * holds a document at it, and the reader still has hops to spend, and a path
+ * deeper than the reader descends is not reached at all; either way the path
+ * holds no entry.
+ * Recording it is what keeps it readable as a cell nobody asked about: an
+ * entry list carries no gaps of its own, so a path missing from one is
+ * otherwise a path the space holds no label for.
  */
 export interface HarnessCellLabelUnreadPath {
   /** The path inside the document, as an entry at it would be written. */

--- a/packages/cf-harness/src/session-assembly.ts
+++ b/packages/cf-harness/src/session-assembly.ts
@@ -92,6 +92,16 @@ export interface HarnessSessionConfig {
   skillScriptExecutionTarget: HarnessSkillScriptExecutionTarget;
 
   fabricSession?: HarnessFabricSessionConfig;
+
+  /**
+   * The space database the run's per-cell label snapshot reads. The labels a
+   * session writes land in the serving toolshed's own store, and the snapshot
+   * reads that file rather than asking over the wire; absent, the file is
+   * found by searching this host's caches for the space the fabric session
+   * names, which finds only a toolshed serving from the same checkout.
+   */
+  spaceDbPath?: string;
+
   patternIndex?: HarnessPatternIndexConfig;
   skillsSh?: HarnessSkillsShConfig;
 
@@ -222,6 +232,9 @@ export const harnessSessionEngineOptions = (
       : {}),
     ...(config.fabricSession !== undefined
       ? { fabricSession: config.fabricSession }
+      : {}),
+    ...(config.spaceDbPath !== undefined
+      ? { spaceDbPath: config.spaceDbPath }
       : {}),
     ...(config.patternIndex !== undefined
       ? { patternIndex: config.patternIndex }

--- a/packages/cf-harness/src/space-labels.ts
+++ b/packages/cf-harness/src/space-labels.ts
@@ -254,11 +254,41 @@ const unreadReasonOf = (
   return space === did ? undefined : "cross-space";
 };
 
-/** One cell a document links to, and the path inside the document it sat at. */
+/** One cell reached from another, and the path it was reached by. */
 interface LinkedCell {
   path: readonly string[];
   id: string;
+
+  /**
+   * The path inside the reached document the link addresses. A link names a
+   * value within a document as readily as the document itself, and what sits
+   * at `path` is that value: a label at or above `into` covers it, a label
+   * beneath `into` sits correspondingly beneath `path`, and a label elsewhere
+   * in the document is not about it.
+   */
+  into: readonly string[];
 }
+
+/**
+ * Where a path inside a linked document sits, seen through the link that
+ * reached the document — or `undefined` when the link does not reach it. A
+ * path at or above `into` covers the whole of what the link addresses, so it
+ * lands at the link itself; a path beneath `into` lands beneath the link by
+ * the same remainder; a path that diverges from `into` is in a part of the
+ * document the link does not address.
+ */
+const throughLink = (
+  link: Pick<LinkedCell, "path" | "into">,
+  inside: readonly string[],
+): readonly string[] | undefined => {
+  const shared = Math.min(link.into.length, inside.length);
+  for (let index = 0; index < shared; index += 1) {
+    if (link.into[index] !== inside[index]) {
+      return undefined;
+    }
+  }
+  return [...link.path, ...inside.slice(link.into.length)];
+};
 
 // How far into one document's value this reader walks for links. Both bounds
 // sit far above the shape of any document a pattern writes, because this
@@ -273,17 +303,39 @@ const LINK_WALK: LinkWalkBounds = {
   maxNodes: 100_000,
 };
 
+/** How far out of one cell the reader follows links, and at what cost. */
+export interface LinkGraphBounds {
+  /**
+   * Links followed in a row. A cell at this distance is read; one further out
+   * is an unread path at the link that addresses it.
+   */
+  maxHops: number;
+
+  /** Documents read per cell, across every hop, however many links reach them. */
+  maxDocuments: number;
+}
+
+// How far out of a cell this reader follows links. The cell a run holds a
+// reference to is the piece, and a pattern's results are their own cells
+// hanging off it, each of which may name further cells of its own — so the
+// derived label a reader is looking for sits however many links out the
+// pattern's shape puts it, and a reader that stops at a fixed distance
+// reports the cells beyond it as carrying no label. Both bounds sit far above
+// the shape of a piece graph, for the same reason the value bounds above do.
+const LINK_GRAPH: LinkGraphBounds = {
+  maxHops: 16,
+  maxDocuments: 4096,
+};
+
 /**
  * The cells one document links to, each at the path inside the document it
  * sits at, the paths whose links were not followed, and whether the walk ran
- * out before the end of the value. A pattern's results are their own cells
- * rather than paths inside the piece that names them, so following these one
- * hop is what puts a derived label where a reader looks for it.
+ * out before the end of the value.
  *
  * The walk descends through the objects and arrays of the value — an array
- * index is a path segment like any other — and stops at each link it meets:
- * the read is one hop wide, so a linked document's own links are not the
- * business of this document's labels.
+ * index is a path segment like any other — and stops at each link it meets.
+ * What a linked document links to in turn is a question about that document,
+ * asked by walking it too; this answers only for the one it was given.
  *
  * A link this store cannot answer for is returned as an unread path rather
  * than dropped, and so is a path the walk sat too shallow to reach. Dropped,
@@ -314,7 +366,7 @@ const linkedCellsOf = (
     }
     const reason = unreadReasonOf(link.space, space);
     if (reason === undefined) {
-      linked.push({ path: at, id: link.id });
+      linked.push({ path: at, id: link.id, into: link.path ?? [] });
     } else {
       unreadPaths.push({ path: at, reason });
     }
@@ -331,6 +383,127 @@ const linkedCellsOf = (
   };
 };
 
+/** What one document contributed to the walk over the graph around it. */
+interface GraphStep {
+  entries: HarnessCellLabelEntry[];
+  linked: LinkedCell[];
+  unreadPaths: HarnessCellLabelUnreadPath[];
+  truncation?: HarnessCellLabelTruncationReason;
+}
+
+/**
+ * Every label the space holds on the cells reachable from one document, each
+ * under the path it was reached by.
+ *
+ * The graph is walked breadth first, so the cells nearest the one a run holds
+ * a reference to are the ones a narrow budget spends itself on. A document's
+ * labels are recorded at every path that reaches it, because a label at a
+ * path is a fact about that path: one document linked from two places is
+ * labeled at both, and reporting it at one of them would leave the other
+ * reading as unlabeled.
+ *
+ * Two bounds make that finite. A cell further out than `maxHops` links is not
+ * read, and the link addressing it is recorded as an unread path. A walk that
+ * runs out of documents stops where it stands and marks the whole cell
+ * truncated — it enumerated the links it had left but read none of them, so
+ * it cannot vouch for the paths beneath any of them.
+ *
+ * A cycle needs neither bound to terminate: a link back to a document already
+ * on the chain that reached it contributes that document's labels at the path
+ * it sits at, and is not descended into, so the walk unfolds each loop once
+ * rather than to the hop bound.
+ */
+const walkLinkedLabels = (
+  read: (id: string) => Record<string, unknown> | undefined,
+  root: { id: string; document: Record<string, unknown> | undefined },
+  space: string | undefined,
+  bounds: LinkWalkBounds,
+  graph: LinkGraphBounds,
+): GraphStep => {
+  const own = linkedCellsOf(root.document, space, bounds);
+  const entries: HarnessCellLabelEntry[] = [];
+  const unreadPaths = [...own.unreadPaths];
+  let truncation = own.truncation;
+  // Each queued cell carries the chain of ids that reached it, which is what
+  // a cycle is recognized against. Sharing one set across the queue would
+  // instead read a diamond — two paths to one cell — as a loop. The cell the
+  // walk started from is on every chain: its labels are already recorded, so
+  // a link back to it closes a loop exactly as any other repeat does.
+  let frontier = own.linked.map((cell) => ({
+    ...cell,
+    chain: new Set([root.id]),
+  }));
+  const linked = [...own.linked];
+  let documents = 0;
+  for (let hop = 0; frontier.length > 0; hop += 1) {
+    const next: typeof frontier = [];
+    for (const { path, id, into, chain } of frontier) {
+      if (hop >= graph.maxHops) {
+        unreadPaths.push({ path, reason: "beyond-link-hops" });
+        continue;
+      }
+      if (documents >= graph.maxDocuments) {
+        truncation ??= "document-budget-exhausted";
+        continue;
+      }
+      const document = read(id);
+      documents += 1;
+      if (document === undefined) {
+        unreadPaths.push({ path, reason: "no-document" });
+        continue;
+      }
+      const through = { path, into };
+      for (const entry of labelsOf(document).entries) {
+        const at = throughLink(through, entry.path);
+        if (at !== undefined) {
+          entries.push({ ...entry, path: at, source: id });
+        }
+      }
+      // A document reached through itself has just had its labels recorded at
+      // this path; descending again would walk the same loop one more time
+      // for no fact this record does not already hold.
+      if (chain.has(id)) {
+        continue;
+      }
+      const step = linkedCellsOf(document, space, bounds);
+      truncation ??= step.truncation;
+      for (const unread of step.unreadPaths) {
+        const at = throughLink(through, unread.path);
+        if (at !== undefined) {
+          unreadPaths.push({ path: at, reason: unread.reason });
+        }
+      }
+      const reached = new Set(chain).add(id);
+      for (const cell of step.linked) {
+        const at = throughLink(through, cell.path);
+        if (at === undefined) {
+          continue;
+        }
+        // A link above `into` addresses a document this link reaches part
+        // of, so the remainder of `into` carries on inside it; a link beneath
+        // addresses whatever it addresses, whole.
+        const below = {
+          path: at,
+          id: cell.id,
+          into: [
+            ...cell.into,
+            ...into.slice(Math.min(cell.path.length, into.length)),
+          ],
+        };
+        linked.push(below);
+        next.push({ ...below, chain: reached });
+      }
+    }
+    frontier = next;
+  }
+  return {
+    entries,
+    linked,
+    unreadPaths,
+    ...(truncation !== undefined ? { truncation } : {}),
+  };
+};
+
 /** A space DB opened for reading labels, and the space it was resolved from. */
 export interface SpaceLabelReader {
   readonly dbPath: string;
@@ -343,21 +516,21 @@ export interface SpaceLabelReader {
   readonly did?: string;
 
   /**
-   * The labels stored for one cell, and for the cells it links to one hop
-   * out. A linked cell's entries arrive under the path the link sat at,
-   * however deep inside the value that was, and say which cell they were read
-   * from, so the two are never confused.
+   * The labels stored for one cell, and for every cell reachable from it. A
+   * reached cell's entries arrive under the path that reached it — the links
+   * followed to get there, each at whatever depth in its own document it sat
+   * at — and say which cell they were read from, so the two are never
+   * confused.
    *
-   * An entity that holds no document — never written, deleted, or
-   * undecodable — reads as no labels, the same as one whose document carries
-   * no `cfc` path: neither is a label this reader can report, and one corrupt
-   * entity does not end the walk.
-   *
-   * An address in another space is not looked up at all: the answer comes
-   * back `unread`, which is a different fact from a document with no labels.
-   * A link into another space is the same fact one level down, and comes
+   * An entity the store holds no document for — never written, deleted, or
+   * undecodable — comes back `unread`, which is a different fact from a
+   * document that carries no `cfc` path: the second is a cell the space holds
+   * no label for, the first is a cell this store cannot speak for at all. An
+   * address in another space is not looked up, and comes back `unread` the
+   * same way. A link to either is the same fact one level down, and comes
    * back as an `unreadPaths` entry at the path that held it — as does a path
-   * lying deeper in the value than the walk descends.
+   * lying deeper in the value than the walk descends, and a link lying
+   * further out than it follows links.
    */
   read(address: CellAddress): StoredCellLabels & { linked: LinkedCell[] };
 
@@ -378,6 +551,14 @@ export interface SpaceLabelReaderOptions {
    * knowledge and never truthfulness.
    */
   linkWalk?: LinkWalkBounds;
+
+  /**
+   * How far out of each cell the walk follows links, and how many documents
+   * it may read doing it. {@link LINK_GRAPH} is what a run records under; the
+   * same trade as `linkWalk`, along the other axis, and reported the same
+   * way.
+   */
+  linkGraph?: LinkGraphBounds;
 }
 
 /**
@@ -397,6 +578,7 @@ export const openSpaceLabelReader = async (
   const opened: SpaceDb = openSpace(dbPath);
   const did = spaceDidOfDbPath(dbPath);
   const bounds = options.linkWalk ?? LINK_WALK;
+  const graph = options.linkGraph ?? LINK_GRAPH;
   return {
     dbPath,
     ...(did !== undefined ? { did } : {}),
@@ -413,44 +595,36 @@ export const openSpaceLabelReader = async (
         .map((scope) => reconstructOutcome(opened, { id: address.id, scope }))
         .find((candidate) => candidate.status === "present");
       if (outcome === undefined || outcome.status !== "present") {
-        return { entries: [], linked: [] };
+        return { entries: [], linked: [], unread: "no-document" };
       }
       const own = labelsOf(outcome.document);
-      const { linked, unreadPaths, truncation } = linkedCellsOf(
-        outcome.document,
+      const { entries, linked, unreadPaths, truncation } = walkLinkedLabels(
+        (id) => {
+          const target = reconstructOutcome(opened, { id, scope: "space" });
+          return target.status === "present" ? target.document : undefined;
+        },
+        { id: address.id, document: outcome.document },
         did,
         bounds,
+        graph,
       );
       if (truncation !== undefined) {
-        // Said out loud as well as recorded. The budget is what makes a
-        // restored graph with a cycle in it finite, so a document that
-        // reaches it is the shape the budget exists against rather than a
-        // large honest value, and the labels of every cell beneath it are
-        // now unknown.
+        // Said out loud as well as recorded. Both budgets are what make a
+        // restored graph with a cycle in it finite, so a cell that reaches
+        // one is the shape they exist against rather than an honestly large
+        // one, and the labels of every cell beyond that point are now
+        // unknown.
         console.warn(
           `cf-harness read only part of "${address.id}" in ${dbPath}: the ` +
-            `value walk stopped after ${bounds.maxNodes} nodes, so the ` +
-            `labels of the cells it links to below that point are unknown ` +
-            `rather than absent. A value this large is usually a cycle.`,
+            `walk stopped after ${bounds.maxNodes} value nodes or ` +
+            `${graph.maxDocuments} documents, so the labels of the cells ` +
+            `beyond that point are unknown rather than absent. A graph this ` +
+            `large is usually a cycle.`,
         );
-      }
-      const entries = [...own.entries];
-      for (const { path, id } of linked) {
-        const target = reconstructOutcome(opened, { id, scope: "space" });
-        if (target.status !== "present") {
-          continue;
-        }
-        for (const entry of labelsOf(target.document).entries) {
-          entries.push({
-            ...entry,
-            path: [...path, ...entry.path],
-            source: id,
-          });
-        }
       }
       return {
         ...own,
-        entries,
+        entries: [...own.entries, ...entries],
         linked,
         ...(unreadPaths.length > 0 ? { unreadPaths } : {}),
         ...(truncation !== undefined ? { truncation } : {}),
@@ -471,6 +645,9 @@ export interface SpaceLabelSnapshotRequest {
   /** How far into each cell's value the read walks; see {@link LINK_WALK}. */
   linkWalk?: LinkWalkBounds;
 
+  /** How far out of each cell the read follows links; see {@link LINK_GRAPH}. */
+  linkGraph?: LinkGraphBounds;
+
   /** The references the run held, in the order it minted them. */
   refs: readonly string[];
 
@@ -486,12 +663,16 @@ export interface SpaceLabelSnapshotRequest {
  * read as a cell the space holds no label for. A reference into another
  * space does address a cell, so it is recorded and marked unread instead of
  * dropped: the run held it, and a reader that saw it vanish would take the
- * snapshot to cover every cell the run touched. A link the walk could not
- * follow is the same, held as an unread path at the path it sat at, as is a
- * path it sat too shallow to reach. A walk that ran out of nodes names no
- * path — it stopped before enumerating what it had left — so it marks the
- * whole cell truncated instead. Every other failure lands on the snapshot as
- * a whole, so a reader can tell "no labels" from "not read".
+ * snapshot to cover every cell the run touched. So is a reference the store
+ * holds no document for, and a store holding none of the cells a run wrote
+ * is a store the run did not write into — said out loud, because the file
+ * the search found is the likeliest thing to be wrong and the snapshot alone
+ * cannot say so. A link the walk could not follow is the same, held as an
+ * unread path at the path it sat at, as is a path it sat too shallow to
+ * reach. A walk that ran out of nodes names no path — it stopped before
+ * enumerating what it had left — so it marks the whole cell truncated
+ * instead. Every other failure lands on the snapshot as a whole, so a reader
+ * can tell "no labels" from "not read".
  */
 export const readSpaceCellLabels = async (
   request: SpaceLabelSnapshotRequest,
@@ -506,6 +687,9 @@ export const readSpaceCellLabels = async (
     reader = await openSpaceLabelReader(request.space, {
       ...(request.dbPath !== undefined ? { dbPath: request.dbPath } : {}),
       ...(request.linkWalk !== undefined ? { linkWalk: request.linkWalk } : {}),
+      ...(request.linkGraph !== undefined
+        ? { linkGraph: request.linkGraph }
+        : {}),
     });
   } catch (error) {
     return {
@@ -554,6 +738,19 @@ export const readSpaceCellLabels = async (
           : {}),
         entries: read.entries,
       });
+    }
+    if (
+      cells.length > 0 &&
+      cells.every((cell) => cell.unreadReason === "no-document")
+    ) {
+      console.warn(
+        `cf-harness found none of the ${cells.length} cell(s) the run held ` +
+          `in ${reader.dbPath}. The labels a session writes land in the ` +
+          `serving toolshed's store; a file holding none of the run's cells ` +
+          `is a different store, and every cell is recorded as unread ` +
+          `rather than unlabeled. Point the reader at the serving ` +
+          `toolshed's cache with MEMORY_DIR, or at the file with --space-db.`,
+      );
     }
     return { ...base, status: "read", space, cells };
   } catch (error) {

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -691,6 +691,75 @@ Deno.test("parseCfHarnessCliArgs rejects fabric CFC dials without a fabric sessi
   );
 });
 
+const withFabricSession = (...extra: string[]) => [
+  "--prompt",
+  "hi",
+  "--fabric-api-url",
+  "https://toolshed.example/",
+  "--fabric-identity",
+  "keys/agent.pkcs8",
+  "--fabric-space",
+  "my-space",
+  ...extra,
+];
+
+Deno.test("parseCfHarnessCliArgs resolves the space database against the working directory", async () => {
+  const parsed = await parseCfHarnessCliArgs(
+    withFabricSession("--space-db", "cache/memory/space.sqlite"),
+    { cwd: "/tmp/project", env: {} },
+  );
+  if ("help" in parsed) {
+    throw new Error("expected config result");
+  }
+  assertEquals(parsed.spaceDbPath, "/tmp/project/cache/memory/space.sqlite");
+});
+
+Deno.test("parseCfHarnessCliArgs takes the space database from the environment", async () => {
+  const parsed = await parseCfHarnessCliArgs(withFabricSession(), {
+    cwd: "/tmp/project",
+    env: { CF_HARNESS_SPACE_DB: "/srv/toolshed/space.sqlite" },
+  });
+  if ("help" in parsed) {
+    throw new Error("expected config result");
+  }
+  assertEquals(parsed.spaceDbPath, "/srv/toolshed/space.sqlite");
+});
+
+Deno.test("parseCfHarnessCliArgs leaves the space database unset when nothing names one", async () => {
+  const parsed = await parseCfHarnessCliArgs(withFabricSession(), {
+    cwd: "/tmp/project",
+    env: {},
+  });
+  if ("help" in parsed) {
+    throw new Error("expected config result");
+  }
+  assertEquals(parsed.spaceDbPath, undefined);
+});
+
+Deno.test("parseCfHarnessCliArgs rejects a space database without a fabric session", async () => {
+  await assertRejects(
+    () =>
+      parseCfHarnessCliArgs(
+        ["--prompt", "hi", "--space-db", "space.sqlite"],
+        { cwd: "/tmp/project", env: {} },
+      ),
+    Error,
+    "needs --fabric-api-url, --fabric-identity, and --fabric-space",
+  );
+});
+
+Deno.test("parseCfHarnessCliArgs rejects an empty space database value", async () => {
+  await assertRejects(
+    () =>
+      parseCfHarnessCliArgs(withFabricSession("--space-db", "  "), {
+        cwd: "/tmp/project",
+        env: {},
+      }),
+    Error,
+    "--space-db requires a non-empty value",
+  );
+});
+
 Deno.test("parseCfHarnessCliArgs resolves run manifest paths", async () => {
   const parsed = await parseCfHarnessCliArgs(
     ["--prompt", "hi", "--run-manifest", "loom-run.json"],

--- a/packages/cf-harness/test/session-assembly.test.ts
+++ b/packages/cf-harness/test/session-assembly.test.ts
@@ -64,6 +64,8 @@ const parityArguments = (
     "/console/.cf-harness-console/cfc/results",
     "--cfc-invocation-context-dir",
     "/console/.cf-harness-console/cfc/invocation-context",
+    "--space-db",
+    "/serving/cache/memory/space.sqlite",
     "--allow-subagent-profile",
     "default",
     "--allow-subagent-profile",
@@ -97,6 +99,8 @@ const parityArguments = (
     `name=reference,source=${hostMountSource},target=/reference`,
     "--session-db",
     "none",
+    "--space-db",
+    "/serving/cache/memory/space.sqlite",
   ],
 });
 
@@ -182,6 +186,27 @@ describe("session-assembly", () => {
         expect(allowedToolIds).toContain("search_patterns");
         expect(allowedToolIds).toContain("search_skills");
         expect(allowedToolIds).toContain("acquire_skill");
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("read labels from the same space database", async () => {
+      const { workspace, hostMountSource, skillsRoot, cleanup } =
+        await parityDirectories();
+      try {
+        const args = parityArguments(workspace, hostMountSource, skillsRoot);
+        const cli = await cliSession(args.cli);
+        const server = await resolveConsoleConfig(args.console, {}, "/console");
+
+        // Named rather than left to the comparison above: a parity that held
+        // because neither surface carried the path would say nothing.
+        expect(harnessSessionEngineOptions(cli).spaceDbPath).toBe(
+          "/serving/cache/memory/space.sqlite",
+        );
+        expect(harnessSessionEngineOptions(server).spaceDbPath).toBe(
+          "/serving/cache/memory/space.sqlite",
+        );
       } finally {
         await cleanup();
       }

--- a/packages/cf-harness/test/space-labels.test.ts
+++ b/packages/cf-harness/test/space-labels.test.ts
@@ -8,6 +8,7 @@ import type { LinkWalkBounds } from "@commonfabric/state-inspector";
 
 import {
   cellAddressOfRef,
+  type LinkGraphBounds,
   openSpaceLabelReader,
   readSpaceCellLabels,
   type SpaceLabelReader,
@@ -86,10 +87,51 @@ const NESTER = entity("nester");
  */
 const DEEPER = entity("deeper");
 
+/**
+ * A chain of three documents, each linking to the next at `next`. The cell a
+ * run holds a reference to is the piece, and a pattern's results hang off it
+ * with results of their own below them, so the label a reader is after sits
+ * at the end of a chain like this one rather than one link from the piece.
+ */
+const CHAIN_TOP = entity("chainTop");
+const CHAIN_MID = entity("chainMid");
+const CHAIN_END = entity("chainEnd");
+
+/**
+ * Two documents that link to each other at `peer`. Following links until
+ * there are none left never terminates on these, so what stops the walk is
+ * recognizing the loop rather than running out of a budget.
+ */
+const LOOP_ONE = entity("loopOne");
+const LOOP_TWO = entity("loopTwo");
+
+/**
+ * A document reaching {@link CHAIN_END} twice and at two distances: directly
+ * at `right`, and at `left` through the cell above it in the chain. The label
+ * sits at both paths, so a reader that recorded it at one of them would leave
+ * the other reading as a path the space labels nothing at.
+ */
+const DIAMOND = entity("diamond");
+
+/**
+ * A document linking at `gone` to {@link NEVER_WRITTEN}, which the store holds
+ * nothing for. The link addresses a cell; the store cannot speak for it.
+ */
+const DANGLING = entity("dangling");
+
+/**
+ * A document labelled at two of its paths, `account` and `other`, and one
+ * that links into it at `account` alone. A pattern's result names the input
+ * value it was computed from by the path inside the input cell that holds
+ * it, so the label a reader is after covers exactly what the link addresses.
+ */
+const ACCOUNTS = entity("accounts");
+const SLOTTED = entity("slotted");
+
 /** One stored link, in the at-rest sigil form the store holds. */
-const link = (id: string, space?: string) => ({
+const link = (id: string, space?: string, path: string[] = []) => ({
   "/": {
-    "link@1": { id, path: [], ...(space === undefined ? {} : { space }) },
+    "link@1": { id, path, ...(space === undefined ? {} : { space }) },
   },
 });
 
@@ -213,6 +255,97 @@ const documents: Record<string, unknown> = {
       deep: { down: link(COLLIDING) },
     },
   },
+  [CHAIN_TOP]: { value: { next: link(CHAIN_MID) } },
+  [CHAIN_MID]: {
+    value: { next: link(CHAIN_END) },
+    cfc: {
+      version: 1,
+      labelMap: {
+        version: 1,
+        entries: [
+          stored(
+            [],
+            { confidentiality: ["mid-secret"], integrity: [] },
+            "link",
+          ),
+        ],
+      },
+    },
+  },
+  [CHAIN_END]: {
+    value: { leaf: "the end of the chain" },
+    cfc: {
+      version: 1,
+      labelMap: {
+        version: 1,
+        entries: [
+          stored([], {
+            confidentiality: ["end-secret"],
+            integrity: [],
+          }, "derived"),
+        ],
+      },
+    },
+  },
+  [LOOP_ONE]: {
+    value: { peer: link(LOOP_TWO) },
+    cfc: {
+      version: 1,
+      labelMap: {
+        version: 1,
+        entries: [
+          stored(
+            [],
+            { confidentiality: ["one-secret"], integrity: [] },
+            "link",
+          ),
+        ],
+      },
+    },
+  },
+  [LOOP_TWO]: {
+    value: { peer: link(LOOP_ONE) },
+    cfc: {
+      version: 1,
+      labelMap: {
+        version: 1,
+        entries: [
+          stored(
+            [],
+            { confidentiality: ["two-secret"], integrity: [] },
+            "link",
+          ),
+        ],
+      },
+    },
+  },
+  [DIAMOND]: { value: { left: link(CHAIN_MID), right: link(CHAIN_END) } },
+  [DANGLING]: { value: { gone: link(NEVER_WRITTEN) } },
+  [ACCOUNTS]: {
+    value: { account: { balance: 1 }, other: "not addressed" },
+    cfc: {
+      version: 1,
+      labelMap: {
+        version: 1,
+        entries: [
+          stored(["account"], {
+            confidentiality: ["account-secret"],
+            integrity: [],
+          }, "declared"),
+          stored(["other"], {
+            confidentiality: ["other-secret"],
+            integrity: [],
+          }, "declared"),
+        ],
+      },
+    },
+  },
+  [SLOTTED]: {
+    value: {
+      slot: link(ACCOUNTS, undefined, ["account"]),
+      leaf: link(CHAIN_END, undefined, ["leaf"]),
+    },
+  },
   [COMMITTED]: {
     value: { attachment: "…" },
     cfc: {
@@ -253,7 +386,20 @@ const SHALLOW: LinkWalkBounds = {
 const SPENT: LinkWalkBounds = { maxDepth: 64, maxNodes: 2 };
 
 /** The documents written as plain JSON rather than through the codec. */
-const PLAIN = new Set([UNLABELLED, LINKER, NESTER, DEEPER]);
+const PLAIN = new Set([
+  UNLABELLED,
+  LINKER,
+  NESTER,
+  DEEPER,
+  CHAIN_TOP,
+  CHAIN_MID,
+  LOOP_ONE,
+  LOOP_TWO,
+  DIAMOND,
+  DANGLING,
+  ACCOUNTS,
+  SLOTTED,
+]);
 
 /**
  * A stored `revision.data` payload. Most documents go in through the codec,
@@ -323,6 +469,21 @@ describe("space-labels", () => {
     const bounded = await openSpaceLabelReader("demo-space", {
       dbPath: didDbPath,
       linkWalk,
+    });
+    try {
+      body(bounded);
+    } finally {
+      bounded.close();
+    }
+  };
+
+  const withGraphBoundedReader = async (
+    linkGraph: LinkGraphBounds,
+    body: (bounded: SpaceLabelReader) => void,
+  ): Promise<void> => {
+    const bounded = await openSpaceLabelReader("demo-space", {
+      dbPath: didDbPath,
+      linkGraph,
     });
     try {
       body(bounded);
@@ -433,9 +594,20 @@ describe("space-labels", () => {
       expect(read.schemaHash).toBe(undefined);
     });
 
-    it("returns an empty entry list for an entity the space never wrote", () => {
-      expect(reader.read({ id: NEVER_WRITTEN, scope: "space" }).entries)
-        .toEqual([]);
+    it("returns an entity the store holds no document for as unread", () => {
+      expect(reader.read({ id: NEVER_WRITTEN, scope: "space" })).toEqual({
+        entries: [],
+        linked: [],
+        unread: "no-document",
+      });
+    });
+
+    it("returns the path of a link to an entity the store holds no document for as unread", () => {
+      const read = didReader.read({ id: DANGLING, scope: "space" });
+      expect(read.unreadPaths).toEqual([
+        { path: ["gone"], reason: "no-document" },
+      ]);
+      expect(read.unread).toBe(undefined);
     });
 
     it("returns a disjunctive confidentiality clause as one atom carrying its alternatives", () => {
@@ -509,8 +681,8 @@ describe("space-labels", () => {
     it("returns the labels of the linked cells naming no space and naming the opened one", () => {
       const read = didReader.read({ id: LINKER, scope: "space" });
       expect(read.linked).toEqual([
-        { path: ["mine"], id: COLLIDING },
-        { path: ["ours"], id: COLLIDING },
+        { path: ["mine"], id: COLLIDING, into: [] },
+        { path: ["ours"], id: COLLIDING, into: [] },
       ]);
       expect(read.entries).toEqual([
         {
@@ -549,7 +721,11 @@ describe("space-labels", () => {
 
     it("returns only the link naming no space when the opened file proves no DID", () => {
       const read = reader.read({ id: LINKER, scope: "space" });
-      expect(read.linked).toEqual([{ path: ["mine"], id: COLLIDING }]);
+      expect(read.linked).toEqual([{
+        path: ["mine"],
+        id: COLLIDING,
+        into: [],
+      }]);
       expect(read.entries.map((entry) => entry.path)).toEqual([["mine"]]);
     });
 
@@ -584,8 +760,8 @@ describe("space-labels", () => {
     it("returns an array index as a path segment of a link held in an array", () => {
       const read = didReader.read({ id: NESTER, scope: "space" });
       expect(read.linked).toEqual([
-        { path: ["nested", "mine"], id: COLLIDING },
-        { path: ["list", "0", "ours"], id: COLLIDING },
+        { path: ["nested", "mine"], id: COLLIDING, into: [] },
+        { path: ["list", "0", "ours"], id: COLLIDING, into: [] },
       ]);
     });
 
@@ -614,6 +790,118 @@ describe("space-labels", () => {
       ]);
     });
 
+    it("returns the label of a cell two links out under the path that reached it", () => {
+      const read = didReader.read({ id: CHAIN_TOP, scope: "space" });
+      expect(read.entries).toEqual([
+        {
+          path: ["next"],
+          confidentiality: [{ type: "mid-secret", name: "mid-secret" }],
+          integrity: [],
+          origin: "link",
+          source: CHAIN_MID,
+        },
+        {
+          path: ["next", "next"],
+          confidentiality: [{ type: "end-secret", name: "end-secret" }],
+          integrity: [],
+          origin: "derived",
+          source: CHAIN_END,
+        },
+      ]);
+    });
+
+    it("returns the label at the path a link addresses at the link itself", () => {
+      const read = didReader.read({ id: SLOTTED, scope: "space" });
+      expect(read.entries).toEqual([
+        {
+          path: ["slot"],
+          confidentiality: [{ type: "account-secret", name: "account-secret" }],
+          integrity: [],
+          origin: "declared",
+          source: ACCOUNTS,
+        },
+        {
+          path: ["leaf"],
+          confidentiality: [{ type: "end-secret", name: "end-secret" }],
+          integrity: [],
+          origin: "derived",
+          source: CHAIN_END,
+        },
+      ]);
+    });
+
+    it("returns the label of a cell reached two ways under each path that reached it", () => {
+      const read = didReader.read({ id: DIAMOND, scope: "space" });
+      expect(read.entries.map((entry) => [entry.source, entry.path])).toEqual([
+        [CHAIN_MID, ["left"]],
+        [CHAIN_END, ["right"]],
+        [CHAIN_END, ["left", "next"]],
+      ]);
+    });
+
+    it("unfolds a loop once, holding the label of each cell on it", () => {
+      const read = didReader.read({ id: LOOP_ONE, scope: "space" });
+      expect(read.entries).toEqual([
+        {
+          path: [],
+          confidentiality: [{ type: "one-secret", name: "one-secret" }],
+          integrity: [],
+          origin: "link",
+        },
+        {
+          path: ["peer"],
+          confidentiality: [{ type: "two-secret", name: "two-secret" }],
+          integrity: [],
+          origin: "link",
+          source: LOOP_TWO,
+        },
+        {
+          path: ["peer", "peer"],
+          confidentiality: [{ type: "one-secret", name: "one-secret" }],
+          integrity: [],
+          origin: "link",
+          source: LOOP_ONE,
+        },
+      ]);
+      expect(read.truncation).toBe(undefined);
+    });
+
+    it("returns the path of a link further out than the read follows links as unread", async () => {
+      await withGraphBoundedReader({ maxHops: 1, maxDocuments: 64 }, (b) => {
+        const read = b.read({ id: CHAIN_TOP, scope: "space" });
+        expect(read.unreadPaths).toEqual([
+          { path: ["next", "next"], reason: "beyond-link-hops" },
+        ]);
+        expect(read.truncation).toBe(undefined);
+      });
+    });
+
+    it("returns the label of the cell a hop-bounded read did reach", async () => {
+      await withGraphBoundedReader({ maxHops: 1, maxDocuments: 64 }, (b) => {
+        const read = b.read({ id: CHAIN_TOP, scope: "space" });
+        expect(read.entries.map((entry) => entry.source)).toEqual([CHAIN_MID]);
+      });
+    });
+
+    it("returns the whole cell truncated when the read runs out of documents", async () => {
+      await collectWarnings(async () => {
+        await withGraphBoundedReader({ maxHops: 8, maxDocuments: 1 }, (b) => {
+          const read = b.read({ id: CHAIN_TOP, scope: "space" });
+          expect(read.truncation).toBe("document-budget-exhausted");
+          expect(read.entries.map((entry) => entry.source)).toEqual([
+            CHAIN_MID,
+          ]);
+        });
+      });
+    });
+
+    it("returns no truncation for a cell whose graph fits the document budget", async () => {
+      await withGraphBoundedReader({ maxHops: 8, maxDocuments: 64 }, (b) => {
+        expect(b.read({ id: CHAIN_TOP, scope: "space" }).truncation)
+          .toBe(undefined);
+      });
+    });
+
     it("returns the path a shallower walk stopped short of as unread", async () => {
       await withBoundedReader(SHALLOW, (bounded) => {
         const read = bounded.read({ id: DEEPER, scope: "space" });
@@ -627,7 +915,11 @@ describe("space-labels", () => {
     it("returns the labels of the link a shallower walk did reach", async () => {
       await withBoundedReader(SHALLOW, (bounded) => {
         const read = bounded.read({ id: DEEPER, scope: "space" });
-        expect(read.linked).toEqual([{ path: ["shallow"], id: COLLIDING }]);
+        expect(read.linked).toEqual([{
+          path: ["shallow"],
+          id: COLLIDING,
+          into: [],
+        }]);
         expect(read.entries.map((entry) => entry.path)).toEqual([["shallow"]]);
       });
     });
@@ -705,6 +997,32 @@ describe("space-labels", () => {
     it("drops a reference that names no document", async () => {
       const snapshot = await read(["my notebook", `/${DECLARED}`]);
       expect(snapshot.cells.map((cell) => cell.entityId)).toEqual([DECLARED]);
+    });
+
+    it("records a reference the store holds no document for as unread", async () => {
+      const [snapshot, warnings] = await collectWarningsOf(() =>
+        read([`/${NEVER_WRITTEN}`, `/${DECLARED}`])
+      );
+      expect(snapshot.status).toBe("read");
+      expect(snapshot.cells.map((cell) => cell.unreadReason)).toEqual([
+        "no-document",
+        undefined,
+      ]);
+      expect(warnings).toEqual([]);
+    });
+
+    it("warns that the store is a different one when it holds none of the cells the run held", async () => {
+      const [snapshot, warnings] = await collectWarningsOf(() =>
+        read([`/${NEVER_WRITTEN}`, `/${entity("neverEither")}`])
+      );
+      expect(snapshot.status).toBe("read");
+      expect(snapshot.cells.map((cell) => cell.unreadReason)).toEqual([
+        "no-document",
+        "no-document",
+      ]);
+      expect(warnings.length).toBe(1);
+      expect(warnings[0]).toContain(dbPath);
+      expect(warnings[0]).toContain("--space-db");
     });
 
     const readAgainstDid = (refs: readonly string[]) =>

--- a/packages/cf-harness/test/space-labels.test.ts
+++ b/packages/cf-harness/test/space-labels.test.ts
@@ -120,13 +120,18 @@ const DIAMOND = entity("diamond");
 const DANGLING = entity("dangling");
 
 /**
- * A document labelled at two of its paths, `account` and `other`, and one
- * that links into it at `account` alone. A pattern's result names the input
- * value it was computed from by the path inside the input cell that holds
- * it, so the label a reader is after covers exactly what the link addresses.
+ * A document labelled at two of its paths, `account` and `other`, holding a
+ * link at `other`, and one that links into it at `account` alone. A
+ * pattern's result names the input value it was computed from by the path
+ * inside the input cell that holds it, so the label a reader is after covers
+ * exactly what the link addresses — and what sits elsewhere in the document,
+ * label and link alike, is not reached through it.
  */
 const ACCOUNTS = entity("accounts");
 const SLOTTED = entity("slotted");
+
+/** A document linking at `via` to {@link LINKER}, whose own links go unread. */
+const VIA = entity("via");
 
 /** One stored link, in the at-rest sigil form the store holds. */
 const link = (id: string, space?: string, path: string[] = []) => ({
@@ -322,7 +327,7 @@ const documents: Record<string, unknown> = {
   [DIAMOND]: { value: { left: link(CHAIN_MID), right: link(CHAIN_END) } },
   [DANGLING]: { value: { gone: link(NEVER_WRITTEN) } },
   [ACCOUNTS]: {
-    value: { account: { balance: 1 }, other: "not addressed" },
+    value: { account: { balance: 1 }, other: link(CHAIN_END) },
     cfc: {
       version: 1,
       labelMap: {
@@ -346,6 +351,7 @@ const documents: Record<string, unknown> = {
       leaf: link(CHAIN_END, undefined, ["leaf"]),
     },
   },
+  [VIA]: { value: { via: link(LINKER) } },
   [COMMITTED]: {
     value: { attachment: "…" },
     cfc: {
@@ -399,6 +405,7 @@ const PLAIN = new Set([
   DANGLING,
   ACCOUNTS,
   SLOTTED,
+  VIA,
 ]);
 
 /**
@@ -827,6 +834,29 @@ describe("space-labels", () => {
           origin: "derived",
           source: CHAIN_END,
         },
+      ]);
+    });
+
+    it("returns no cell reached through a link elsewhere in the document a link addresses part of", () => {
+      const read = didReader.read({ id: SLOTTED, scope: "space" });
+      expect(read.linked).toEqual([
+        { path: ["slot"], id: ACCOUNTS, into: ["account"] },
+        { path: ["leaf"], id: CHAIN_END, into: ["leaf"] },
+      ]);
+      expect(read.entries.map((entry) => entry.path)).toEqual([
+        ["slot"],
+        ["leaf"],
+      ]);
+    });
+
+    it("returns the unread path of a linked cell under the path that reached it", () => {
+      const read = didReader.read({ id: VIA, scope: "space" });
+      expect(read.unreadPaths).toEqual([
+        { path: ["via", "theirs"], reason: "cross-space" },
+      ]);
+      expect(read.entries.map((entry) => entry.path)).toEqual([
+        ["via", "mine"],
+        ["via", "ours"],
       ]);
     });
 


### PR DESCRIPTION
## What

The per-cell label snapshot a cf-harness run records was reading zero labels out of spaces that hold them. The store was fine; the reader was not, in two ways named on CT-2169:

- **A — store discovery.** The reader found the space database by walking up from the working directory, so a run from a worktree other than the serving toolshed's opened a different file, or none. The batch CLI now takes `--space-db` / `CF_HARNESS_SPACE_DB` the way the console already does, carried on the one `HarnessSessionConfig` both surfaces assemble from (the console's private copy of the field is gone). A cell the opened store holds no document for is recorded as `unreadReason: "no-document"` rather than as an empty entry list, and a snapshot in which every cell reads that way is warned about as the wrong store, naming `MEMORY_DIR` and `--space-db` as the fix.
- **B — link depth.** The reader followed a cell's links exactly one hop, so a label derived on a result of a result read as absent. The walk now follows links as far as the pattern's shape runs: breadth first, under a hop bound (`beyond-link-hops` unread paths) and a document budget (`document-budget-exhausted` truncation), unfolding each cycle once. It also rewrites each label through the path the link addresses, so a label on the value a link names lands at the link itself instead of at a path that does not exist in the linking value.

`docs/pattern-index-measurement.md` now states which dial decides whether a label is written (the writing session's, never the server's) and how a reader in another worktree points at the serving toolshed's store.

## Re-check of night-5 cell D against the correct store

Reading cell D's three refs with this reader against the `n5-inputcell` store (`~/.bb/worktrees/env_m69fg39nps/labs/packages/toolshed/cache/memory`): `status: "read"`, the result cell carries `confidentiality: [finance]` declared at `balance` (through its link to the input cell's `account` path) and derived at its `$UI` paths, with `TransformedBy` integrity on the computed value. The run's own snapshot had recorded `unavailable` / `space-not-found`, which is defect A exactly.

## Tests

- `space-labels.test.ts`: two-hop chain, diamond (labeled at both paths), loop unfolded once, hop bound, document budget, link into a sub-path, dangling link, absent document, all-absent warning.
- `session-assembly.test.ts`: both surfaces carry the same `spaceDbPath` into engine options.
- `cli.test.ts`: `--space-db` resolution, environment default, rejection without a fabric session.

Four failures in the full `cf-harness` suite (`routes skills.sh discovery through its injected fetch` and three `CfHarnessPromptLoop` tests) reproduce on a clean `origin/main` checkout and are unrelated.

`deno fmt --check`, `deno lint`, `deno task check`, `deno task check-docs` clean.

Linear-issue: Fixes CT-2169
Linear-issue-url: https://linear.app/common-tools/issue/CT-2169/input-cell-confidentiality-label-does-not-derive-to-results-is

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6751?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

