### PR TITLE
feat(cf-harness): bounded transport retry that keeps the provider's reason (CT-2177)

### DIFF
--- a/docs/plans/cf-harness-codex-subscription-auth.md
+++ b/docs/plans/cf-harness-codex-subscription-auth.md
@@ -149,8 +149,11 @@ incompatible or too costly to maintain; it is not the selected path here.
 8. Browser callback login is the default. Device login is explicit and uses the
    provider-mandated polling interval. That bounded, cancelable protocol poll is
    the only new polling loop authorized by this plan.
-9. The first transport is SSE. WebSocket pooling, cached WebSocket deltas,
-   transport retries, sleeps, and automatic provider fallback are deferred.
+9. The first transport is SSE. WebSocket pooling, cached WebSocket deltas, and
+   automatic provider fallback are deferred. A transient transport or
+   provider failure is issued again under the bounded backoff the package
+   README describes under "Model attempts and transport retry"; that bounded
+   retry is the only sleep the model clients hold.
 10. Model ids come from the selected provider or explicit operator choice. Do
     not copy an upstream hard-coded allowlist and do not silently substitute a
     different model when a subscription lacks access.
@@ -621,7 +624,7 @@ Expected files:
 ## Deferred work
 
 - Codex Responses WebSocket transport and connection reuse.
-- Automatic transport retry or fallback.
+- Automatic provider fallback.
 - OS keychain-backed `cf-harness` credential storage.
 - Importing credentials from Codex CLI or other harnesses.
 - A native Codex app-server runtime mode.

--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -722,9 +722,10 @@ a protocol failure, not a transient one.
 Reissuing is safe because the harness dispatches nothing from an attempt that
 did not complete: a model exchange has no side effect until a tool call from its
 result is dispatched, and the client returns nothing until an attempt reaches a
-completed terminal response. The Codex client narrows this further: a stream
-that already delivered a tool call before it failed is not issued again, even
-for a transient reason, so nothing the model committed to is ever replayed.
+completed terminal response. Whatever a failed attempt streamed, tool calls
+included, is discarded with it. A `429` from the Codex provider is its usage
+limit, which the backoff does not clear; the retry there is bounded by the same
+schedule and costs seconds, not a turn.
 
 The bound is `transportRetries` attempts beyond the first — three unless a
 client is configured otherwise — with a backoff of `transportRetryDelayMs`

--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -169,7 +169,10 @@ What works today:
 - provider-neutral run-report model-attempt diagnostics, one record per attempt,
   naming the provider and the API operation that served it, and timing it twice
   — `durationMs` to the response headers, `responseCompleteDurationMs` to the
-  end of the body or stream, which is the model's own working time
+  end of the body or stream, which is the model's own working time — with the
+  provider's stated reason for a failed attempt and, when the client issued the
+  exchange again, why; see
+  [Model attempts and transport retry](#model-attempts-and-transport-retry)
 - provider-reported per-turn token usage in run reports, with aggregate input,
   cached-input, cache-write, output, reasoning, and total tokens surfaced in
   operator and batch results
@@ -688,6 +691,50 @@ export CF_HARNESS_CFC_ENFORCEMENT_MODE=observe
 
 Tool outputs are then exposed raw with policy warnings recorded in the run
 report instead of being denied for missing trusted mediation metadata.
+
+### Model attempts and transport retry
+
+Every request a model client issues is one `cf-harness.model-attempt` record in
+the run report's `modelAttempts`, whether it got a response or not. A record
+names the provider and operation, numbers the attempt against
+`maxTransportAttempts`, times it, summarizes the request, and says how it ended:
+`outcome` is `transport_error` when no response arrived and `http_response`
+otherwise, with the status and selected headers.
+
+A failed attempt carries the provider's own reason wherever the provider stated
+one. `providerError` holds the provider's `type`, `code`, and `message` as the
+provider sent them — from the body of a non-2xx response, from an in-stream
+`error` event, or from a failed terminal response — and the same three fields
+are in the message of the error the turn fails with, so a turn failure record, a
+console `turn_failed` event, and the CLI's control failure all say what the
+provider said. A provider that returns a bare `503` states no reason, and the
+record carries none rather than a guess.
+
+A transient failure is issued again before anything reaches the harness. Three
+kinds qualify, and only these: a transport error, where no response arrived; a
+`429` or `5xx` status; and a provider-stated error whose type or code names
+capacity, rate limiting, or a server-side fault — `server_is_overloaded` and
+`service_unavailable_error` among them. Anything else ends the exchange on its
+first attempt: a `4xx` refuses the request itself, a provider error naming the
+request cannot be cleared by waiting, and a body that is not SSE-framed JSON is
+a protocol failure, not a transient one.
+
+Reissuing is safe because the harness dispatches nothing from an attempt that
+did not complete: a model exchange has no side effect until a tool call from its
+result is dispatched, and the client returns nothing until an attempt reaches a
+completed terminal response. The Codex client narrows this further: a stream
+that already delivered a tool call before it failed is not issued again, even
+for a transient reason, so nothing the model committed to is ever replayed.
+
+The bound is `transportRetries` attempts beyond the first — three unless a
+client is configured otherwise — with a backoff of `transportRetryDelayMs`
+before the second attempt, doubling before each attempt after it. An attempt
+that is followed by another says so: its record carries `retry`, naming the
+`kind` of transient failure (`transport_error`, `http_status`, or
+`provider_error`) and the `delayMs` waited before the next attempt. The last
+attempt of an exchange never carries one, however it ended. The backoff is
+waited out through an injected `transportRetryDelay`, which is how a test drives
+a retry sequence without a timer.
 
 ### Session-local address handles
 

--- a/packages/cf-harness/docs/OPENAI_CODEX_PROTOCOL.md
+++ b/packages/cf-harness/docs/OPENAI_CODEX_PROTOCOL.md
@@ -79,8 +79,9 @@ expose token material, account identifiers, expiry, or raw responses.
   rate limiting, or a server fault — is issued again under the bounded backoff
   described in the package README under "Model attempts and transport retry".
   The provider's stated `type`, `code`, and `message` are recorded on the
-  attempt and carried in the failure the turn ends with. A stream that delivered
-  a tool call before failing is not issued again.
+  attempt and carried in the failure the turn ends with. Whatever a failed
+  attempt streamed is discarded with it; nothing reaches the harness until an
+  attempt completes.
 
 Provider-scoped model discovery uses only
 `https://chatgpt.com/backend-api/codex/models?client_version=0.0.0`. It sends

--- a/packages/cf-harness/docs/OPENAI_CODEX_PROTOCOL.md
+++ b/packages/cf-harness/docs/OPENAI_CODEX_PROTOCOL.md
@@ -72,8 +72,15 @@ expose token material, account identifiers, expiry, or raw responses.
   explicit breakpoints are available only through the compatible API gateway.
 - Tool continuation retains both the public call id and provider function-item
   id, so the corresponding `function_call_output` remains paired after resume.
-- The first transport is SSE. WebSockets, transparent retries, endpoint probing,
-  and client-id fallback are not implemented.
+- The first transport is SSE. WebSockets, endpoint probing, and client-id
+  fallback are not implemented.
+- A transient failure — a transport error, a `429` or `5xx` status, an in-stream
+  `error` event or `response.failed` terminal whose type or code names overload,
+  rate limiting, or a server fault — is issued again under the bounded backoff
+  described in the package README under "Model attempts and transport retry".
+  The provider's stated `type`, `code`, and `message` are recorded on the
+  attempt and carried in the failure the turn ends with. A stream that delivered
+  a tool call before failing is not issued again.
 
 Provider-scoped model discovery uses only
 `https://chatgpt.com/backend-api/codex/models?client_version=0.0.0`. It sends

--- a/packages/cf-harness/src/gateway/openai-client.ts
+++ b/packages/cf-harness/src/gateway/openai-client.ts
@@ -4,19 +4,28 @@ import {
   type HarnessFetch,
 } from "../contracts/http-fetch.ts";
 import {
+  type HarnessProviderError,
+  isTransientHttpStatus,
+  providerErrorFromJsonText,
+} from "../model/provider-error.ts";
+import {
+  type HarnessModelAttemptRetry,
+  type HarnessTransportRetryOptions,
+  TransportRetrySchedule,
+} from "../model/transport-retry.ts";
+import {
   currentProvenance,
   type HarnessProvenance,
   provenanceHeaders,
   provenanceUserAgent,
 } from "../provenance.ts";
 
-export interface OpenAICompatibleGatewayClientOptions {
+export interface OpenAICompatibleGatewayClientOptions
+  extends HarnessTransportRetryOptions {
   baseUrl: string;
   authMode?: "bearer" | "none";
   apiKey?: string;
   apiKeySource?: string;
-  chatCompletionTransportRetries?: number;
-  chatCompletionRetryDelayMs?: number;
   fetchFn?: HarnessFetch;
 
   /**
@@ -197,6 +206,15 @@ export interface OpenAIChatCompletionAttemptDiagnostic {
   responseBodyExcerpt?: string;
   responseBodyTruncated?: boolean;
   errorDetail?: string;
+
+  /** The provider's stated reason, when a non-2xx body carried one. */
+  providerError?: HarnessProviderError;
+
+  /**
+   * Present when this attempt failed transiently and the client issued
+   * another: what was transient, and the backoff before the next attempt.
+   */
+  retry?: HarnessModelAttemptRetry;
 }
 
 export interface OpenAIChatCompletionAttemptOptions {
@@ -222,8 +240,6 @@ export interface OpenAIChatCompletionResponse {
   sources?: readonly unknown[];
 }
 
-const DEFAULT_CHAT_COMPLETION_TRANSPORT_RETRIES = 1;
-const DEFAULT_CHAT_COMPLETION_RETRY_DELAY_MS = 1_000;
 const MAX_ERROR_BODY_EXCERPT_CHARS = 2_048;
 const SELECTED_RESPONSE_HEADERS = [
   "x-request-id",
@@ -241,14 +257,6 @@ const REQUEST_ID_HEADER_NAMES = [
   "cf-ray",
 ] as const;
 
-const nonNegativeIntegerOrDefault = (
-  input: number | undefined,
-  fallback: number,
-): number =>
-  input !== undefined && Number.isInteger(input) && input >= 0
-    ? input
-    : fallback;
-
 const chatCompletionAbortReason = (signal: AbortSignal): unknown =>
   signal.reason ?? new DOMException(
     "chat completion request aborted",
@@ -259,27 +267,6 @@ const throwIfChatCompletionAborted = (signal?: AbortSignal): void => {
   if (signal?.aborted) {
     throw chatCompletionAbortReason(signal);
   }
-};
-
-const sleep = (ms: number, signal?: AbortSignal): Promise<void> => {
-  throwIfChatCompletionAborted(signal);
-  if (ms <= 0) {
-    return Promise.resolve();
-  }
-  if (signal === undefined) {
-    return new Promise((resolve) => setTimeout(resolve, ms));
-  }
-  return new Promise((resolve, reject) => {
-    const timeout = setTimeout(() => {
-      signal.removeEventListener("abort", onAbort);
-      resolve();
-    }, ms);
-    const onAbort = () => {
-      clearTimeout(timeout);
-      reject(chatCompletionAbortReason(signal));
-    };
-    signal.addEventListener("abort", onAbort, { once: true });
-  });
 };
 
 const errorMessage = (error: unknown): string =>
@@ -385,6 +372,12 @@ interface ChatCompletionFetchResult {
 
   /** Monotonic reading taken as the returned attempt was dispatched. */
   dispatchedAtMs: number;
+
+  /**
+   * The body of a non-2xx response, read to classify and record the failure.
+   * Absent for a 2xx response, whose body is left for the caller.
+   */
+  errorBody?: string;
 }
 
 export class OpenAICompatibleGatewayClient {
@@ -393,8 +386,7 @@ export class OpenAICompatibleGatewayClient {
   readonly apiKey?: string;
   readonly apiKeySource?: string;
   readonly #fetchFn: HarnessFetch;
-  readonly #chatCompletionTransportRetries: number;
-  readonly #chatCompletionRetryDelayMs: number;
+  readonly #retrySchedule: TransportRetrySchedule;
   readonly #provenance?: HarnessProvenance;
   readonly #monotonicNowMs: () => number;
 
@@ -405,14 +397,7 @@ export class OpenAICompatibleGatewayClient {
     this.apiKeySource = options.apiKeySource;
     this.#fetchFn = options.fetchFn ?? defaultHarnessFetch;
     this.#provenance = options.provenance;
-    this.#chatCompletionTransportRetries = nonNegativeIntegerOrDefault(
-      options.chatCompletionTransportRetries,
-      DEFAULT_CHAT_COMPLETION_TRANSPORT_RETRIES,
-    );
-    this.#chatCompletionRetryDelayMs = nonNegativeIntegerOrDefault(
-      options.chatCompletionRetryDelayMs,
-      DEFAULT_CHAT_COMPLETION_RETRY_DELAY_MS,
-    );
+    this.#retrySchedule = new TransportRetrySchedule(options);
     this.#monotonicNowMs = options.monotonicNowMs ?? (() => performance.now());
   }
 
@@ -464,14 +449,24 @@ export class OpenAICompatibleGatewayClient {
     });
   }
 
+  /**
+   * Issues a chat completion and returns the response for the caller to read.
+   * A non-2xx response has already been read to record it, and comes back
+   * with its body restored; a 2xx body is untouched.
+   */
   async createChatCompletion(
     payload: OpenAIChatCompletionRequest,
     options: OpenAIChatCompletionAttemptOptions = {},
   ): Promise<Response> {
-    const { response, diagnostic } = await this.#fetchChatCompletion(
-      payload,
-      options,
-    );
+    const { response, diagnostic, errorBody } = await this
+      .#fetchChatCompletion(payload, options);
+    if (errorBody !== undefined) {
+      return new Response(errorBody, {
+        status: response.status,
+        statusText: response.statusText,
+        headers: response.headers,
+      });
+    }
     await emitChatCompletionAttempt(options, diagnostic);
     return response;
   }
@@ -504,6 +499,12 @@ export class OpenAICompatibleGatewayClient {
     );
   }
 
+  /**
+   * Issues one operation until an attempt gets a 2xx response, a non-2xx
+   * response the schedule does not retry, or the schedule runs out. Every
+   * attempt is recorded; a non-2xx response is recorded here with its body,
+   * and a 2xx response by whichever caller reads the body.
+   */
   async #fetchOperation(
     endpoint: URL,
     operation: OpenAIGatewayOperation,
@@ -517,90 +518,102 @@ export class OpenAICompatibleGatewayClient {
       body: serializedPayload,
       ...(options.signal !== undefined ? { signal: options.signal } : {}),
     };
-    const maxTransportAttempts = this.#chatCompletionTransportRetries + 1;
-    let lastError: unknown;
-    for (let attempt = 1; attempt <= maxTransportAttempts; attempt += 1) {
+    const maxTransportAttempts = this.#retrySchedule.maxAttempts;
+    for (let attempt = 1;; attempt += 1) {
       throwIfChatCompletionAborted(options.signal);
       const startedAt = new Date();
       const startedAtMs = this.#monotonicNowMs();
+      const attemptBase = {
+        type: "cf-harness.gateway.chat-completion-attempt" as const,
+        operation,
+        endpoint: endpoint.toString(),
+        attempt,
+        maxTransportAttempts,
+        startedAt: startedAt.toISOString(),
+        request,
+      };
+      let response: Response;
       try {
-        const response = await this.#fetchFn(endpoint, init);
-        const endedAt = new Date();
-        const responseHeaders = selectResponseHeaders(response.headers);
-        const requestId = selectRequestId(response.headers);
-        return {
-          response,
-          dispatchedAtMs: startedAtMs,
-          diagnostic: {
-            type: "cf-harness.gateway.chat-completion-attempt",
-            operation: operation,
-            endpoint: endpoint.toString(),
-            attempt,
-            maxTransportAttempts,
-            startedAt: startedAt.toISOString(),
-            endedAt: endedAt.toISOString(),
-            durationMs: this.#elapsedMsSince(startedAtMs),
-            request,
-            outcome: "http_response",
-            httpStatus: response.status,
-            httpStatusText: response.statusText,
-            ...(requestId !== undefined ? { requestId } : {}),
-            ...(responseHeaders !== undefined ? { responseHeaders } : {}),
-          },
-        };
+        response = await this.#fetchFn(endpoint, init);
       } catch (error) {
-        lastError = error;
         const endedAt = new Date();
         // A transport failure ends the exchange where it is thrown, so the
         // two durations are one measurement.
         const durationMs = this.#elapsedMsSince(startedAtMs);
+        // An aborted attempt is followed by nothing, so its record claims no
+        // retry.
+        const retry = options.signal?.aborted
+          ? undefined
+          : this.#retrySchedule.retryAfter(attempt, "transport_error");
         await emitChatCompletionAttempt(options, {
-          type: "cf-harness.gateway.chat-completion-attempt",
-          operation: operation,
-          endpoint: endpoint.toString(),
-          attempt,
-          maxTransportAttempts,
-          startedAt: startedAt.toISOString(),
+          ...attemptBase,
           endedAt: endedAt.toISOString(),
           durationMs,
           responseCompleteDurationMs: durationMs,
-          request,
           outcome: "transport_error",
           errorDetail: errorMessage(error),
+          ...(retry !== undefined ? { retry } : {}),
         });
         if (options.signal?.aborted) {
           throw chatCompletionAbortReason(options.signal);
         }
-        if (attempt >= maxTransportAttempts) {
+        if (retry === undefined) {
           throw transportErrorAfterRetries(operation, endpoint, attempt, error);
         }
-        await sleep(this.#chatCompletionRetryDelayMs * attempt, options.signal);
+        await this.#retrySchedule.waitBefore(attempt + 1, options.signal);
+        continue;
       }
+      const endedAt = new Date();
+      const responseHeaders = selectResponseHeaders(response.headers);
+      const requestId = selectRequestId(response.headers);
+      const diagnostic: OpenAIChatCompletionAttemptDiagnostic = {
+        ...attemptBase,
+        endedAt: endedAt.toISOString(),
+        durationMs: this.#elapsedMsSince(startedAtMs),
+        outcome: "http_response",
+        httpStatus: response.status,
+        httpStatusText: response.statusText,
+        ...(requestId !== undefined ? { requestId } : {}),
+        ...(responseHeaders !== undefined ? { responseHeaders } : {}),
+      };
+      if (response.ok) {
+        return { response, diagnostic, dispatchedAtMs: startedAtMs };
+      }
+      const errorBody = await response.text();
+      const providerError = providerErrorFromJsonText(errorBody);
+      const retry = this.#retrySchedule.retryAfter(
+        attempt,
+        isTransientHttpStatus(response.status) ? "http_status" : undefined,
+      );
+      const recorded: OpenAIChatCompletionAttemptDiagnostic = {
+        ...diagnostic,
+        responseCompleteDurationMs: this.#elapsedMsSince(startedAtMs),
+        ...responseBodyDiagnosticFields(errorBody),
+        ...(providerError !== undefined ? { providerError } : {}),
+        ...(retry !== undefined ? { retry } : {}),
+      };
+      await emitChatCompletionAttempt(options, recorded);
+      throwIfChatCompletionAborted(options.signal);
+      if (retry === undefined) {
+        return {
+          response,
+          diagnostic: recorded,
+          dispatchedAtMs: startedAtMs,
+          errorBody,
+        };
+      }
+      await this.#retrySchedule.waitBefore(attempt + 1, options.signal);
     }
-    throw transportErrorAfterRetries(
-      operation,
-      endpoint,
-      maxTransportAttempts,
-      lastError,
-    );
   }
 
   async createChatCompletionJson(
     payload: OpenAIChatCompletionRequest,
     options: OpenAIChatCompletionAttemptOptions = {},
   ): Promise<OpenAIChatCompletionResponse> {
-    const { response, diagnostic, dispatchedAtMs } = await this
-      .#fetchChatCompletion(
-        payload,
-        options,
-      );
-    if (!response.ok) {
-      const body = await response.text();
-      await emitChatCompletionAttempt(options, {
-        ...diagnostic,
-        responseCompleteDurationMs: this.#elapsedMsSince(dispatchedAtMs),
-        ...responseBodyDiagnosticFields(body),
-      });
+    const { response, diagnostic, dispatchedAtMs, errorBody } = await this
+      .#fetchChatCompletion(payload, options);
+    if (errorBody !== undefined) {
+      const body = errorBody;
       if (response.status === 401) {
         const sourceText = this.authMode === "none"
           ? "unauthenticated caller mode was used; gateway or upstream credentials rejected the request"
@@ -627,17 +640,10 @@ export class OpenAICompatibleGatewayClient {
     payload: OpenAIResponsesRequest,
     options: OpenAIChatCompletionAttemptOptions = {},
   ): Promise<OpenAIResponsesResponse> {
-    const { response, diagnostic, dispatchedAtMs } = await this.#fetchResponses(
-      payload,
-      options,
-    );
-    if (!response.ok) {
-      const body = await response.text();
-      await emitChatCompletionAttempt(options, {
-        ...diagnostic,
-        responseCompleteDurationMs: this.#elapsedMsSince(dispatchedAtMs),
-        ...responseBodyDiagnosticFields(body),
-      });
+    const { response, diagnostic, dispatchedAtMs, errorBody } = await this
+      .#fetchResponses(payload, options);
+    if (errorBody !== undefined) {
+      const body = errorBody;
       if (response.status === 401) {
         const sourceText = this.authMode === "none"
           ? "unauthenticated caller mode was used; gateway or upstream credentials rejected the request"

--- a/packages/cf-harness/src/model/client.ts
+++ b/packages/cf-harness/src/model/client.ts
@@ -5,6 +5,8 @@ import type {
   HarnessTranscriptMessage,
 } from "../contracts/transcript.ts";
 import type { HarnessCredentialOwnerRef } from "../contracts/run-manifest.ts";
+import type { HarnessProviderError } from "./provider-error.ts";
+import type { HarnessModelAttemptRetry } from "./transport-retry.ts";
 
 export interface HarnessModelRequestSummary {
   model: string;
@@ -52,6 +54,19 @@ export interface HarnessModelAttemptDiagnostic {
   responseBodyExcerpt?: string;
   responseBodyTruncated?: boolean;
   errorDetail?: string;
+
+  /**
+   * The provider's stated reason for the failure, when the response, stream,
+   * or error body carried one.
+   */
+  providerError?: HarnessProviderError;
+
+  /**
+   * Present when this attempt failed transiently and the client issued
+   * another: what was transient, and the backoff before the next attempt.
+   * Absent on the attempt that ended the exchange, however it ended.
+   */
+  retry?: HarnessModelAttemptRetry;
 }
 
 export interface HarnessModelTurnRequest {

--- a/packages/cf-harness/src/model/openai-codex-responses.ts
+++ b/packages/cf-harness/src/model/openai-codex-responses.ts
@@ -249,9 +249,6 @@ const readResponsesStream = async (
   return { streamedItems };
 };
 
-const isFunctionCallItem = (item: unknown): boolean =>
-  isObjectNotArray(item) && item.type === "function_call";
-
 /**
  * The exchange one turn issues, fixed before the first attempt so every
  * attempt sends the same request.
@@ -703,15 +700,10 @@ export class OpenAICodexResponsesClient implements HarnessModelClient {
       ...httpAttempt,
       responseCompleteDurationMs: this.#elapsedMsSince(startedAtMs),
     };
-    // A stream that already delivered a tool call is not issued again, even
-    // for a transient failure: the retry that is safe is the one that
-    // replays nothing the model committed to.
-    const streamedToolCall = reading.streamedItems.some(isFunctionCallItem);
     const transientKind = (
       providerError: HarnessProviderError | undefined,
     ): HarnessTransientFailureKind | undefined =>
-      providerError !== undefined && !streamedToolCall &&
-        isTransientProviderError(providerError)
+      providerError !== undefined && isTransientProviderError(providerError)
         ? "provider_error"
         : undefined;
     if (reading.providerError !== undefined) {

--- a/packages/cf-harness/src/model/openai-codex-responses.ts
+++ b/packages/cf-harness/src/model/openai-codex-responses.ts
@@ -5,11 +5,26 @@ import {
 } from "../contracts/run-manifest.ts";
 import { defaultHarnessFetch } from "../contracts/http-fetch.ts";
 import {
+  describeProviderError,
+  type HarnessProviderError,
+  isTransientHttpStatus,
+  isTransientProviderError,
+  mapProviderError,
+  providerErrorFromJsonText,
+  providerErrorFromPayload,
+} from "./provider-error.ts";
+import {
+  describeTerminalFailure,
   normalizeTerminalResponse,
   providerRunAffinityKey,
   toResponsesInput,
   toResponsesTools,
 } from "./responses-protocol.ts";
+import {
+  type HarnessTransientFailureKind,
+  type HarnessTransportRetryOptions,
+  TransportRetrySchedule,
+} from "./transport-retry.ts";
 import type { OpenAICodexOAuthCredential } from "../auth/types.ts";
 import { isObjectNotArray } from "@commonfabric/utils/types";
 
@@ -35,7 +50,8 @@ export interface OpenAICodexCredentialResolverLike {
   resolve(signal?: AbortSignal): Promise<OpenAICodexOAuthCredential>;
 }
 
-export interface OpenAICodexResponsesClientOptions {
+export interface OpenAICodexResponsesClientOptions
+  extends HarnessTransportRetryOptions {
   credentialResolver: OpenAICodexCredentialResolverLike;
   credentialOwner?: HarnessCredentialOwnerRef;
   fetchFn?: HarnessFetch;
@@ -81,6 +97,19 @@ const redactCredentialValues = (
 const abortReason = (signal: AbortSignal): unknown =>
   signal.reason ?? new DOMException("operation aborted", "AbortError");
 
+/**
+ * A stream that stopped before the provider finished with it: a read that
+ * failed, or a body that ended mid-event or before the terminal event. The
+ * connection went away, not the protocol, which is what makes the attempt
+ * one to issue again.
+ */
+class StreamInterrupted extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "StreamInterrupted";
+  }
+}
+
 async function* parseSse(
   response: Response,
   signal?: AbortSignal,
@@ -107,7 +136,7 @@ async function* parseSse(
         read = await reader.read();
       } catch {
         if (signal?.aborted) throw abortReason(signal);
-        throw providerUnavailable("Codex Responses stream read failed");
+        throw new StreamInterrupted("Codex Responses stream read failed");
       }
       const { value, done } = read;
       if (signal?.aborted) throw abortReason(signal);
@@ -142,7 +171,7 @@ async function* parseSse(
       if (done) break;
     }
     if (buffered.trim().length > 0) {
-      throw providerUnavailable(
+      throw new StreamInterrupted(
         "Codex Responses stream ended with an incomplete SSE event",
       );
     }
@@ -155,6 +184,93 @@ async function* parseSse(
     reader.releaseLock();
   }
 }
+
+/** What one read of a Responses stream produced, up to where it stopped. */
+interface StreamReading {
+  /** Every completed output item the stream delivered, in order. */
+  streamedItems: unknown[];
+
+  /**
+   * The terminal event's `response`, when the stream reached one. Absent when
+   * the provider stated an error instead, or the stream ended first.
+   */
+  terminal?: Record<string, unknown>;
+
+  /** The provider's stated error, when the stream ended on an `error` event. */
+  providerError?: HarnessProviderError;
+}
+
+/**
+ * Reads a Responses stream to its terminal event, its `error` event, or its
+ * end. Throws the abort reason on abort, `StreamInterrupted` when the
+ * connection goes before the provider is done, and a provider-unavailable
+ * control error for a body that is not SSE-framed JSON events.
+ */
+const readResponsesStream = async (
+  response: Response,
+  signal: AbortSignal | undefined,
+): Promise<StreamReading> => {
+  // The ChatGPT Codex backend streams each completed output item via a
+  // `response.output_item.done` event, but with `store: false` it returns an
+  // EMPTY `output` array on the terminal `response.completed` event (it does
+  // not assemble a stored response to echo back). Accumulate the streamed
+  // items so the model's message and tool calls are not silently dropped.
+  const streamedItems: unknown[] = [];
+  for await (const event of parseSse(response, signal)) {
+    const type = event.type;
+    if (type === "response.output_item.done" && event.item !== undefined) {
+      streamedItems.push(event.item);
+    }
+    if (type === "error") {
+      return {
+        streamedItems,
+        providerError: providerErrorFromPayload(event) ??
+          { message: "the provider stated no reason" },
+      };
+    }
+    if (
+      type === "response.completed" || type === "response.done" ||
+      type === "response.incomplete" || type === "response.failed"
+    ) {
+      if (
+        typeof event.response !== "object" || event.response === null ||
+        Array.isArray(event.response)
+      ) {
+        throw providerUnavailable(
+          "Codex Responses terminal event did not include a response object",
+        );
+      }
+      return {
+        streamedItems,
+        terminal: event.response as Record<string, unknown>,
+      };
+    }
+  }
+  return { streamedItems };
+};
+
+const isFunctionCallItem = (item: unknown): boolean =>
+  isObjectNotArray(item) && item.type === "function_call";
+
+/**
+ * The exchange one turn issues, fixed before the first attempt so every
+ * attempt sends the same request.
+ */
+interface CodexExchange {
+  request: HarnessModelTurnRequest;
+  credential: OpenAICodexOAuthCredential;
+  body: string;
+  affinityKey: string;
+}
+
+/**
+ * How one attempt ended: with a terminal response to normalize, or with the
+ * error to throw and, when the schedule issues another attempt, the kind of
+ * transient failure that justified it.
+ */
+type CodexAttemptOutcome =
+  | { terminal: Record<string, unknown> }
+  | { error: HarnessControlError; retry?: HarnessTransientFailureKind };
 
 const selectedHeaders = (
   headers: Headers,
@@ -184,6 +300,52 @@ const emitAttempt = async (
   }
 };
 
+/**
+ * The control error for a non-2xx response. A usage-limit response stays
+ * concise because its body is the account's, not the operator's; the
+ * provider's stated reason for any other failure rides along, since a `503`
+ * alone says nothing about whether waiting will help.
+ */
+const httpFailure = (
+  status: number,
+  providerError: HarnessProviderError | undefined,
+): HarnessControlError => {
+  if (status === 429) {
+    return providerUnavailable("OpenAI Codex usage limit reached");
+  }
+  if (status === 401 || status === 403) {
+    return providerAuthRequired(
+      "OpenAI Codex authentication is no longer accepted",
+    );
+  }
+  return providerUnavailable(
+    `OpenAI Codex Responses request failed (${status})` +
+      (providerError === undefined
+        ? ""
+        : `: ${describeProviderError(providerError)}`),
+  );
+};
+
+/**
+ * With `store: false` the ChatGPT Codex backend returns no assembled output
+ * on the terminal event — an empty array, or (also observed on this backend)
+ * `null` — even though it streamed the items. Fall back to what was
+ * accumulated so downstream parsing sees the model's message and tool calls.
+ * A POPULATED terminal output always wins (no double-counting); any other
+ * malformed shape is left for `normalizeTerminalResponse()` to reject.
+ */
+const withStreamedOutput = (
+  terminal: Record<string, unknown>,
+  streamedItems: readonly unknown[],
+): Record<string, unknown> => {
+  const terminalOutputEmpty = terminal.output === null ||
+    terminal.output === undefined ||
+    (Array.isArray(terminal.output) && terminal.output.length === 0);
+  return terminalOutputEmpty && streamedItems.length > 0
+    ? { ...terminal, output: [...streamedItems] }
+    : terminal;
+};
+
 export class OpenAICodexResponsesClient implements HarnessModelClient {
   readonly providerId = "openai-codex";
   readonly credentialOwner?: HarnessCredentialOwnerRef;
@@ -192,6 +354,7 @@ export class OpenAICodexResponsesClient implements HarnessModelClient {
   readonly #endpoint: string;
   readonly #now: () => Date;
   readonly #monotonicNowMs: () => number;
+  readonly #retrySchedule: TransportRetrySchedule;
 
   constructor(options: OpenAICodexResponsesClientOptions) {
     this.#resolver = options.credentialResolver;
@@ -226,6 +389,7 @@ export class OpenAICodexResponsesClient implements HarnessModelClient {
     }
     this.#now = options.now ?? (() => new Date());
     this.#monotonicNowMs = options.monotonicNowMs ?? (() => performance.now());
+    this.#retrySchedule = new TransportRetrySchedule(options);
   }
 
   /** Whole milliseconds elapsed since a monotonic reading. */
@@ -364,7 +528,6 @@ export class OpenAICodexResponsesClient implements HarnessModelClient {
     const affinityKey = providerRunAffinityKey(
       request.cacheAffinityKey ?? request.runId,
     );
-    const requestId = crypto.randomUUID();
     const body = JSON.stringify({
       model: request.model,
       store: false,
@@ -381,8 +544,70 @@ export class OpenAICodexResponsesClient implements HarnessModelClient {
       tool_choice: "auto",
       parallel_tool_calls: true,
     });
+    const exchange: CodexExchange = { request, credential, body, affinityKey };
+    // Nothing leaves this loop until an attempt reaches a completed terminal
+    // response, so a tool call streamed by an attempt that failed is never
+    // the one the harness dispatches.
+    for (let attempt = 1;; attempt += 1) {
+      const outcome = await this.#attempt(exchange, attempt);
+      if ("terminal" in outcome) {
+        return this.#turnResult(outcome.terminal, request.model);
+      }
+      if (outcome.retry === undefined) throw outcome.error;
+      await this.#retrySchedule.waitBefore(attempt + 1, request.signal);
+    }
+  }
+
+  /**
+   * Issues the exchange once and records the attempt, however it ends. A
+   * transient failure comes back with the kind that makes it one when the
+   * schedule has an attempt left; abort and protocol failures are thrown.
+   */
+  async #attempt(
+    exchange: CodexExchange,
+    attempt: number,
+  ): Promise<CodexAttemptOutcome> {
+    const { request, credential, body, affinityKey } = exchange;
+    const redact = (text: string): string =>
+      redactCredentialValues(text, credential);
     const startedAt = this.#now();
     const startedAtMs = this.#monotonicNowMs();
+    const attemptBase = {
+      type: "cf-harness.model-attempt" as const,
+      providerId: this.providerId,
+      operation: "responses.stream",
+      endpoint: this.#endpoint,
+      attempt,
+      maxTransportAttempts: this.#retrySchedule.maxAttempts,
+      startedAt: startedAt.toISOString(),
+      request: {
+        model: request.model,
+        messageCount: request.transcript.length,
+        toolCount: request.tools.length,
+        nativeModelToolCount: 0,
+        serializedBytes: textBytes(body),
+      },
+    };
+    // Records the attempt as failed and settles whether another follows. An
+    // aborted attempt is followed by nothing, so its record claims no retry;
+    // the abort itself is thrown after the record so an abort landing during
+    // it is not reported as a provider failure.
+    const failed = async (
+      kind: HarnessTransientFailureKind | undefined,
+      record: Omit<HarnessModelAttemptDiagnostic, keyof typeof attemptBase>,
+      error: HarnessControlError,
+    ): Promise<CodexAttemptOutcome> => {
+      const retry = request.signal?.aborted
+        ? undefined
+        : this.#retrySchedule.retryAfter(attempt, kind);
+      await emitAttempt(request.onAttempt, {
+        ...attemptBase,
+        ...record,
+        ...(retry !== undefined ? { retry } : {}),
+      });
+      if (request.signal?.aborted) throw abortReason(request.signal);
+      return retry === undefined ? { error } : { error, retry: retry.kind };
+    };
     let response: Response;
     try {
       response = await this.#fetchFn(this.#endpoint, {
@@ -397,7 +622,7 @@ export class OpenAICodexResponsesClient implements HarnessModelClient {
           accept: "text/event-stream",
           "content-type": "application/json",
           "session-id": affinityKey,
-          "x-client-request-id": requestId,
+          "x-client-request-id": crypto.randomUUID(),
         },
         body,
         signal: request.signal,
@@ -407,57 +632,23 @@ export class OpenAICodexResponsesClient implements HarnessModelClient {
         throw abortReason(request.signal);
       }
     } catch (error) {
-      const endedAt = this.#now();
-      const errorDetail = redactCredentialValues(
-        error instanceof Error ? error.message : String(error),
-        credential,
-      );
       // A transport failure ends the exchange where it is thrown, so the two
       // durations are one measurement.
       const durationMs = this.#elapsedMsSince(startedAtMs);
-      await emitAttempt(request.onAttempt, {
-        type: "cf-harness.model-attempt",
-        providerId: this.providerId,
-        operation: "responses.stream",
-        endpoint: this.#endpoint,
-        attempt: 1,
-        maxTransportAttempts: 1,
-        startedAt: startedAt.toISOString(),
-        endedAt: endedAt.toISOString(),
+      return await failed("transport_error", {
+        endedAt: this.#now().toISOString(),
         durationMs,
         responseCompleteDurationMs: durationMs,
-        request: {
-          model: request.model,
-          messageCount: request.transcript.length,
-          toolCount: request.tools.length,
-          nativeModelToolCount: 0,
-          serializedBytes: textBytes(body),
-        },
         outcome: "transport_error",
-        errorDetail,
-      });
-      if (request.signal?.aborted) throw abortReason(request.signal);
-      throw providerUnavailable("OpenAI Codex transport request failed");
+        errorDetail: redact(
+          error instanceof Error ? error.message : String(error),
+        ),
+      }, providerUnavailable("OpenAI Codex transport request failed"));
     }
-    const endedAt = this.#now();
-    const baseAttempt: HarnessModelAttemptDiagnostic = {
-      type: "cf-harness.model-attempt",
-      providerId: this.providerId,
-      operation: "responses.stream",
-      endpoint: this.#endpoint,
-      attempt: 1,
-      maxTransportAttempts: 1,
-      startedAt: startedAt.toISOString(),
-      endedAt: endedAt.toISOString(),
+    const httpAttempt = {
+      endedAt: this.#now().toISOString(),
       durationMs: this.#elapsedMsSince(startedAtMs),
-      request: {
-        model: request.model,
-        messageCount: request.transcript.length,
-        toolCount: request.tools.length,
-        nativeModelToolCount: 0,
-        serializedBytes: textBytes(body),
-      },
-      outcome: "http_response",
+      outcome: "http_response" as const,
       httpStatus: response.status,
       httpStatusText: response.statusText,
       ...(selectedHeaders(response.headers) !== undefined
@@ -466,92 +657,118 @@ export class OpenAICodexResponsesClient implements HarnessModelClient {
     };
     if (!response.ok) {
       let responseBodyBytes: number | undefined;
+      let providerError: HarnessProviderError | undefined;
       try {
-        responseBodyBytes = textBytes(await response.text());
+        const text = await response.text();
+        responseBodyBytes = textBytes(text);
+        const stated = providerErrorFromJsonText(text);
+        providerError = stated === undefined
+          ? undefined
+          : mapProviderError(stated, redact);
       } catch {
         if (request.signal?.aborted) throw abortReason(request.signal);
       }
-      await emitAttempt(request.onAttempt, {
-        ...baseAttempt,
-        responseCompleteDurationMs: this.#elapsedMsSince(startedAtMs),
-        ...(responseBodyBytes !== undefined ? { responseBodyBytes } : {}),
-      });
-      if (request.signal?.aborted) throw abortReason(request.signal);
-      if (response.status === 429) {
-        throw providerUnavailable("OpenAI Codex usage limit reached");
-      }
-      if (response.status === 401 || response.status === 403) {
-        throw providerAuthRequired(
-          "OpenAI Codex authentication is no longer accepted",
-        );
-      }
-      throw providerUnavailable(
-        `OpenAI Codex Responses request failed (${response.status})`,
+      return await failed(
+        isTransientHttpStatus(response.status) ? "http_status" : undefined,
+        {
+          ...httpAttempt,
+          responseCompleteDurationMs: this.#elapsedMsSince(startedAtMs),
+          ...(responseBodyBytes !== undefined ? { responseBodyBytes } : {}),
+          ...(providerError !== undefined ? { providerError } : {}),
+        },
+        httpFailure(response.status, providerError),
       );
     }
-    let terminal: Record<string, unknown> | undefined;
-    // The ChatGPT Codex backend streams each completed output item via a
-    // `response.output_item.done` event, but with `store: false` it returns an
-    // EMPTY `output` array on the terminal `response.completed` event (it does
-    // not assemble a stored response to echo back). Accumulate the streamed
-    // items so the model's message and tool calls are not silently dropped.
-    const streamedItems: unknown[] = [];
+    let reading: StreamReading;
     try {
-      for await (const event of parseSse(response, request.signal)) {
-        const type = event.type;
-        if (type === "response.output_item.done" && event.item !== undefined) {
-          streamedItems.push(event.item);
-        }
-        if (type === "error") {
-          throw providerUnavailable(
-            "OpenAI Codex Responses stream returned an error event",
-          );
-        }
-        if (
-          type === "response.completed" || type === "response.done" ||
-          type === "response.incomplete" || type === "response.failed"
-        ) {
-          if (
-            typeof event.response !== "object" || event.response === null ||
-            Array.isArray(event.response)
-          ) {
-            throw providerUnavailable(
-              "Codex Responses terminal event did not include a response object",
-            );
-          }
-          terminal = event.response as Record<string, unknown>;
-          break;
-        }
-      }
-    } finally {
-      // The generation happens across this stream, not before it, so the one
-      // record this attempt gets is emitted here — however the stream ended.
-      await emitAttempt(request.onAttempt, {
-        ...baseAttempt,
+      reading = await readResponsesStream(response, request.signal);
+    } catch (error) {
+      const completed = {
+        ...httpAttempt,
         responseCompleteDurationMs: this.#elapsedMsSince(startedAtMs),
-      });
+      };
+      if (error instanceof StreamInterrupted) {
+        return await failed(
+          "transport_error",
+          completed,
+          providerUnavailable(error.message),
+        );
+      }
+      // The generation happens across the stream, so the attempt is recorded
+      // however the stream ended.
+      await emitAttempt(request.onAttempt, { ...attemptBase, ...completed });
+      throw error;
     }
+    const completed = {
+      ...httpAttempt,
+      responseCompleteDurationMs: this.#elapsedMsSince(startedAtMs),
+    };
+    // A stream that already delivered a tool call is not issued again, even
+    // for a transient failure: the retry that is safe is the one that
+    // replays nothing the model committed to.
+    const streamedToolCall = reading.streamedItems.some(isFunctionCallItem);
+    const transientKind = (
+      providerError: HarnessProviderError | undefined,
+    ): HarnessTransientFailureKind | undefined =>
+      providerError !== undefined && !streamedToolCall &&
+        isTransientProviderError(providerError)
+        ? "provider_error"
+        : undefined;
+    if (reading.providerError !== undefined) {
+      const providerError = mapProviderError(reading.providerError, redact);
+      return await failed(
+        transientKind(providerError),
+        { ...completed, providerError },
+        providerUnavailable(
+          "OpenAI Codex Responses stream returned an error event: " +
+            describeProviderError(providerError),
+        ),
+      );
+    }
+    if (reading.terminal === undefined) {
+      return await failed(
+        "transport_error",
+        completed,
+        providerUnavailable(
+          "Codex Responses stream ended without a terminal response event",
+        ),
+      );
+    }
+    const terminal = withStreamedOutput(
+      reading.terminal,
+      reading.streamedItems,
+    );
+    const terminalFailure = describeTerminalFailure(
+      terminal,
+      OPENAI_CODEX_RESPONSES_LABEL,
+    );
+    if (terminalFailure !== undefined) {
+      const stated = providerErrorFromPayload(terminal);
+      const providerError = stated === undefined
+        ? undefined
+        : mapProviderError(stated, redact);
+      return await failed(
+        terminal.status === "failed" ? transientKind(providerError) : undefined,
+        {
+          ...completed,
+          ...(providerError !== undefined ? { providerError } : {}),
+        },
+        providerUnavailable(redact(terminalFailure)),
+      );
+    }
+    await emitAttempt(request.onAttempt, { ...attemptBase, ...completed });
     // Emitting the attempt is the last await the stream's own abort handling
     // does not cover, so an abort landing during it would otherwise surface as
     // a completed turn.
     if (request.signal?.aborted) throw abortReason(request.signal);
-    if (!terminal) {
-      throw providerUnavailable(
-        "Codex Responses stream ended without a terminal response event",
-      );
-    }
-    // With `store: false` the ChatGPT Codex backend returns no assembled output
-    // on the terminal event — an empty array, or (also observed on this
-    // backend) `null` — even though it streamed the items. Fall back to what we
-    // accumulated so downstream parsing sees the model's message and tool
-    // calls. A POPULATED terminal output always wins (no double-counting); any
-    // other malformed shape is left for normalizeTerminalResponse to reject.
-    const terminalOutputEmpty = terminal.output === null ||
-      terminal.output === undefined ||
-      (Array.isArray(terminal.output) && terminal.output.length === 0);
-    if (terminalOutputEmpty && streamedItems.length > 0) {
-      terminal = { ...terminal, output: streamedItems };
-    }
+    return { terminal };
+  }
+
+  /** Normalizes a completed terminal response into the turn's result. */
+  #turnResult(
+    terminal: Record<string, unknown>,
+    model: string,
+  ): HarnessModelTurnResult {
     const rawUsage = isObjectNotArray(terminal.usage)
       ? terminal.usage
       : undefined;
@@ -564,13 +781,14 @@ export class OpenAICodexResponsesClient implements HarnessModelClient {
     try {
       assistant = normalizeTerminalResponse(
         terminal,
-        request.model,
+        model,
         OPENAI_CODEX_PROVIDER_ID,
         OPENAI_CODEX_RESPONSES_LABEL,
       );
-    } catch {
+    } catch (error) {
       throw providerUnavailable(
-        "OpenAI Codex returned an invalid terminal response",
+        "OpenAI Codex returned an invalid terminal response: " +
+          (error instanceof Error ? error.message : String(error)),
       );
     }
     return {

--- a/packages/cf-harness/src/model/provider-error.ts
+++ b/packages/cf-harness/src/model/provider-error.ts
@@ -1,0 +1,143 @@
+/**
+ * The reason a provider gives for a failed exchange, in the provider's own
+ * vocabulary, and whether that reason is transient. Every model client
+ * reports a provider's stated failure in this one shape — whether it arrived
+ * as an in-stream `error` event, a failed terminal response, or the body of a
+ * non-2xx response — so an operator reading an attempt record or a failure
+ * message sees the provider's type, code, and message wherever the failure
+ * surfaced, and the retry decision keys off the same fields everywhere.
+ */
+
+/** A provider's stated reason for a failed exchange. */
+export interface HarnessProviderError {
+  /** Provider error class, such as `service_unavailable_error`. */
+  type?: string;
+
+  /** Provider error code, such as `server_is_overloaded`. */
+  code?: string;
+
+  /** The provider's own message. */
+  message: string;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const nonEmptyString = (value: unknown): string | undefined =>
+  typeof value === "string" && value.length > 0 ? value : undefined;
+
+/**
+ * Reads a provider error out of a payload that carries one. The fields are
+ * read from the payload's `error` object when it has one, which is how the
+ * OpenAI Responses `error` event, its failed terminal `response`, and its
+ * non-2xx bodies are all shaped; otherwise from the payload itself, where a
+ * `type` of `error` is the event's type rather than the error's and is left
+ * out. Returns `undefined` for a payload that states no message, since an
+ * error without one tells an operator nothing the status or event type did
+ * not already.
+ */
+export const providerErrorFromPayload = (
+  payload: unknown,
+): HarnessProviderError | undefined => {
+  if (!isRecord(payload)) return undefined;
+  const nested = isRecord(payload.error);
+  const source = nested ? payload.error as Record<string, unknown> : payload;
+  const message = nonEmptyString(source.message);
+  if (message === undefined) return undefined;
+  const rawType = nonEmptyString(source.type);
+  const type = !nested && rawType === "error" ? undefined : rawType;
+  const code = nonEmptyString(source.code);
+  return {
+    ...(type !== undefined ? { type } : {}),
+    ...(code !== undefined ? { code } : {}),
+    message,
+  };
+};
+
+/**
+ * Like `providerErrorFromPayload()`, except the payload arrives as text that
+ * may or may not be JSON. Text that is not a JSON object carries no provider
+ * error, whatever it says.
+ */
+export const providerErrorFromJsonText = (
+  text: string,
+): HarnessProviderError | undefined => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+  return providerErrorFromPayload(parsed);
+};
+
+/**
+ * Renders a provider error for a failure message: the type and code, when
+ * present, ahead of the message, so `service_unavailable_error /
+ * server_is_overloaded: Our servers are currently overloaded` reads as the
+ * provider said it.
+ */
+export const describeProviderError = (error: HarnessProviderError): string => {
+  const classification = [error.type, error.code].filter((part) =>
+    part !== undefined
+  ).join(" / ");
+  return classification.length > 0
+    ? `${classification}: ${error.message}`
+    : error.message;
+};
+
+/**
+ * Applies `redact` to every field of a provider error. A provider's message
+ * is its own prose, and a client that redacts credential values from
+ * everything it records applies the same redaction here.
+ */
+export const mapProviderError = (
+  error: HarnessProviderError,
+  redact: (text: string) => string,
+): HarnessProviderError => ({
+  ...(error.type !== undefined ? { type: redact(error.type) } : {}),
+  ...(error.code !== undefined ? { code: redact(error.code) } : {}),
+  message: redact(error.message),
+});
+
+/**
+ * Error types a provider states for a failure that waiting alone can clear:
+ * capacity, rate limiting, and its own internal faults.
+ */
+const TRANSIENT_PROVIDER_ERROR_TYPES: ReadonlySet<string> = new Set([
+  "overloaded_error",
+  "rate_limit_error",
+  "server_error",
+  "service_unavailable_error",
+  "timeout_error",
+]);
+
+/** Error codes a provider states for the same transient failures. */
+const TRANSIENT_PROVIDER_ERROR_CODES: ReadonlySet<string> = new Set([
+  "overloaded",
+  "rate_limit_exceeded",
+  "server_error",
+  "server_is_overloaded",
+  "service_unavailable",
+  "timeout",
+]);
+
+/**
+ * Whether a provider-stated error is one waiting alone can clear. The
+ * decision rests on the provider's type or code alone: a message is prose,
+ * and an error stating neither field is not transient, whatever it says.
+ */
+export const isTransientProviderError = (
+  error: HarnessProviderError,
+): boolean =>
+  (error.type !== undefined &&
+    TRANSIENT_PROVIDER_ERROR_TYPES.has(error.type)) ||
+  (error.code !== undefined && TRANSIENT_PROVIDER_ERROR_CODES.has(error.code));
+
+/**
+ * Whether an HTTP status is one waiting alone can clear: rate limiting, and
+ * every server-side status. A 4xx other than 429 states that the request
+ * itself is refused, and issuing it again cannot change that.
+ */
+export const isTransientHttpStatus = (status: number): boolean =>
+  status === 429 || status >= 500;

--- a/packages/cf-harness/src/model/responses-protocol.ts
+++ b/packages/cf-harness/src/model/responses-protocol.ts
@@ -10,6 +10,10 @@ import type {
   HarnessTranscriptMessage,
 } from "../contracts/transcript.ts";
 import { materializeImageAttachmentContentPart } from "../image-attachments.ts";
+import {
+  describeProviderError,
+  providerErrorFromPayload,
+} from "./provider-error.ts";
 
 /**
  * Shared OpenAI Responses API wire mapping.
@@ -334,18 +338,38 @@ export const addFirstUserPromptCacheBreakpoint = (
   );
 };
 
+/**
+ * The message for a terminal response whose status says the provider did not
+ * finish — `failed`, `incomplete`, or `cancelled` — carrying the provider's
+ * stated reason when the response has one, or `undefined` for any other
+ * status.
+ */
+export const describeTerminalFailure = (
+  response: Record<string, unknown>,
+  label: string,
+): string | undefined => {
+  const status = response.status;
+  if (
+    status !== "incomplete" && status !== "failed" && status !== "cancelled"
+  ) {
+    return undefined;
+  }
+  const providerError = providerErrorFromPayload(response);
+  return `${label} ended with status ${status}` +
+    (providerError === undefined
+      ? ""
+      : `: ${describeProviderError(providerError)}`);
+};
+
 export const normalizeTerminalResponse = (
   response: Record<string, unknown>,
   sourceModel: string,
   providerId: string,
   label: string,
 ): HarnessAssistantTranscriptMessage => {
+  const failure = describeTerminalFailure(response, label);
+  if (failure !== undefined) throw new Error(failure);
   const status = response.status;
-  if (
-    status === "incomplete" || status === "failed" || status === "cancelled"
-  ) {
-    throw new Error(`${label} ended with status ${String(status)}`);
-  }
   if (status !== "completed") {
     throw new Error(`${label} terminal event has an unknown status`);
   }

--- a/packages/cf-harness/src/model/transport-retry.ts
+++ b/packages/cf-harness/src/model/transport-retry.ts
@@ -1,0 +1,165 @@
+/**
+ * The bound on how many times a model client issues one exchange, and the
+ * backoff between issues.
+ *
+ * A model exchange has no side effect until the harness dispatches a tool
+ * call from its result, and a client returns nothing until an attempt
+ * completes, so issuing a failed attempt again is safe. What makes it worth
+ * doing is that the failure was transient — a transport error, a 429 or 5xx
+ * status, or a provider-stated overload — and what keeps it from becoming an
+ * unbounded loop is this schedule. Every attempt, retried or not, is recorded
+ * where the client records attempts, and an attempt that is followed by
+ * another says so and says why.
+ */
+
+/**
+ * Which kind of transient failure an attempt ended in: the request never got
+ * a response, the response carried a 429 or 5xx status, or the provider
+ * answered and then stated a transient error of its own.
+ */
+export type HarnessTransientFailureKind =
+  | "transport_error"
+  | "http_status"
+  | "provider_error";
+
+/**
+ * What an attempt record carries when the attempt failed transiently and the
+ * client issues another: the kind of failure, and the backoff before the next
+ * attempt starts.
+ */
+export interface HarnessModelAttemptRetry {
+  /** Which transient failure the attempt ended in. */
+  kind: HarnessTransientFailureKind;
+
+  /** Milliseconds waited before the next attempt. */
+  delayMs: number;
+}
+
+/**
+ * Waits out a backoff, rejecting with the signal's reason if it aborts first.
+ * Production waits on a timer; a test injects one that records the delay it
+ * was asked for and resolves at once, which is what keeps a retry test off the
+ * wall clock.
+ */
+export type HarnessTransportRetryDelay = (
+  ms: number,
+  signal?: AbortSignal,
+) => Promise<void>;
+
+/** The retry controls a model client accepts. */
+export interface HarnessTransportRetryOptions {
+  /**
+   * Attempts beyond the first. `0` issues each exchange once. Defaults to
+   * `DEFAULT_TRANSPORT_RETRIES`.
+   */
+  transportRetries?: number;
+
+  /**
+   * Backoff before the second attempt, doubling before each attempt after
+   * it. Defaults to `DEFAULT_TRANSPORT_RETRY_DELAY_MS`.
+   */
+  transportRetryDelayMs?: number;
+
+  /** How a backoff is waited out. Defaults to `abortableDelay`. */
+  transportRetryDelay?: HarnessTransportRetryDelay;
+}
+
+/** Attempts beyond the first, unless a client is configured otherwise. */
+export const DEFAULT_TRANSPORT_RETRIES = 3;
+
+/** Backoff before the second attempt, unless configured otherwise. */
+export const DEFAULT_TRANSPORT_RETRY_DELAY_MS = 1_000;
+
+const nonNegativeIntegerOrDefault = (
+  input: number | undefined,
+  fallback: number,
+): number =>
+  input !== undefined && Number.isInteger(input) && input >= 0
+    ? input
+    : fallback;
+
+const abortReason = (signal: AbortSignal): unknown =>
+  signal.reason ?? new DOMException("transport retry aborted", "AbortError");
+
+/**
+ * Waits `ms` milliseconds on a timer, rejecting with the signal's reason as
+ * soon as it aborts. A wait of zero or less resolves without arming a timer.
+ */
+export const abortableDelay: HarnessTransportRetryDelay = (ms, signal) => {
+  if (signal?.aborted) return Promise.reject(abortReason(signal));
+  if (ms <= 0) return Promise.resolve();
+  if (signal === undefined) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timeout);
+      reject(abortReason(signal));
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+};
+
+/**
+ * The attempts one exchange may take and the backoff between them. Attempts
+ * are numbered from 1; the schedule says whether attempt `n` failing with a
+ * given kind of failure is followed by attempt `n + 1`, and how long to wait
+ * before it.
+ */
+export class TransportRetrySchedule {
+  readonly #maxAttempts: number;
+  readonly #baseDelayMs: number;
+  readonly #delay: HarnessTransportRetryDelay;
+
+  /** Constructs an instance from a client's retry options. */
+  constructor(options: HarnessTransportRetryOptions = {}) {
+    this.#maxAttempts = 1 + nonNegativeIntegerOrDefault(
+      options.transportRetries,
+      DEFAULT_TRANSPORT_RETRIES,
+    );
+    this.#baseDelayMs = nonNegativeIntegerOrDefault(
+      options.transportRetryDelayMs,
+      DEFAULT_TRANSPORT_RETRY_DELAY_MS,
+    );
+    this.#delay = options.transportRetryDelay ?? abortableDelay;
+  }
+
+  /** How many attempts one exchange may take, the first included. */
+  get maxAttempts(): number {
+    return this.#maxAttempts;
+  }
+
+  /**
+   * Milliseconds of backoff before `attempt` starts: none before the first,
+   * the base delay before the second, and double the previous backoff before
+   * each attempt after that.
+   */
+  delayMsBefore(attempt: number): number {
+    return attempt <= 1 ? 0 : this.#baseDelayMs * 2 ** (attempt - 2);
+  }
+
+  /**
+   * The retry that follows `attempt` failing with `kind`, for its attempt
+   * record, or `undefined` when nothing follows it: the failure was not
+   * transient, or the attempt was the last the schedule allows.
+   */
+  retryAfter(
+    attempt: number,
+    kind: HarnessTransientFailureKind | undefined,
+  ): HarnessModelAttemptRetry | undefined {
+    if (kind === undefined || attempt >= this.#maxAttempts) return undefined;
+    return { kind, delayMs: this.delayMsBefore(attempt + 1) };
+  }
+
+  /**
+   * Waits out the backoff before `attempt`, rejecting with the signal's
+   * reason if it aborts first.
+   */
+  async waitBefore(attempt: number, signal?: AbortSignal): Promise<void> {
+    await this.#delay(this.delayMsBefore(attempt), signal);
+  }
+}

--- a/packages/cf-harness/test/model-attempt-duration.test.ts
+++ b/packages/cf-harness/test/model-attempt-duration.test.ts
@@ -81,7 +81,7 @@ describe("model-attempt-duration", () => {
       const client = new OpenAICompatibleGatewayClient({
         baseUrl: "https://llm.stage.commontools.dev/",
         apiKey: "test-key",
-        chatCompletionTransportRetries: 0,
+        transportRetries: 0,
         monotonicNowMs: scriptedClock([1_000, 1_040]),
         fetchFn: () => Promise.reject(new Error("connection reset")),
       });
@@ -153,6 +153,7 @@ describe("model-attempt-duration", () => {
     it("ends `responseCompleteDurationMs` at the terminal stream event", async () => {
       const attempts: HarnessModelAttemptDiagnostic[] = [];
       const client = new OpenAICodexResponsesClient({
+        transportRetries: 0,
         credentialResolver: { resolve: () => Promise.resolve(credential) },
         monotonicNowMs: scriptedClock([1_000, 1_012, 1_900]),
         fetchFn: () =>
@@ -191,6 +192,7 @@ describe("model-attempt-duration", () => {
     it("records one attempt for a stream that ends without a terminal event", async () => {
       const attempts: HarnessModelAttemptDiagnostic[] = [];
       const client = new OpenAICodexResponsesClient({
+        transportRetries: 0,
         credentialResolver: { resolve: () => Promise.resolve(credential) },
         monotonicNowMs: scriptedClock([1_000, 1_012, 1_500]),
         fetchFn: () =>
@@ -215,6 +217,7 @@ describe("model-attempt-duration", () => {
     it("ends both durations at the failure for a transport error", async () => {
       const attempts: HarnessModelAttemptDiagnostic[] = [];
       const client = new OpenAICodexResponsesClient({
+        transportRetries: 0,
         credentialResolver: { resolve: () => Promise.resolve(credential) },
         monotonicNowMs: scriptedClock([1_000, 1_055]),
         fetchFn: () => Promise.reject(new Error("connection reset")),
@@ -240,6 +243,7 @@ describe("model-attempt-duration", () => {
     it("throws the abort reason for an abort landing while the attempt is emitted", async () => {
       const controller = new AbortController();
       const client = new OpenAICodexResponsesClient({
+        transportRetries: 0,
         credentialResolver: { resolve: () => Promise.resolve(credential) },
         monotonicNowMs: scriptedClock([1_000, 1_012, 1_900]),
         fetchFn: () =>

--- a/packages/cf-harness/test/openai-client.test.ts
+++ b/packages/cf-harness/test/openai-client.test.ts
@@ -172,13 +172,13 @@ Deno.test("OpenAICompatibleGatewayClient parses successful chat completion JSON 
   assertEquals(response.choices[0]?.message.content, "ok");
 });
 
-Deno.test("OpenAICompatibleGatewayClient retries chat completion transport failures once by default", async () => {
+Deno.test("OpenAICompatibleGatewayClient retries a chat completion transport failure by default", async () => {
   let calls = 0;
   const attempts: OpenAIChatCompletionAttemptDiagnostic[] = [];
   const client = new OpenAICompatibleGatewayClient({
     baseUrl: "https://llm.stage.commontools.dev/",
     apiKey: "test-key",
-    chatCompletionRetryDelayMs: 0,
+    transportRetryDelayMs: 0,
     fetchFn: () => {
       calls += 1;
       if (calls === 1) {
@@ -225,7 +225,7 @@ Deno.test("OpenAICompatibleGatewayClient does not retry aborted chat completion 
   const client = new OpenAICompatibleGatewayClient({
     baseUrl: "https://llm.stage.commontools.dev/",
     apiKey: "test-key",
-    chatCompletionRetryDelayMs: 0,
+    transportRetryDelayMs: 0,
     fetchFn: (_input, init) => {
       calls += 1;
       assertEquals(init?.signal, controller.signal);
@@ -263,7 +263,7 @@ Deno.test("OpenAICompatibleGatewayClient surfaces exhausted chat completion tran
   const client = new OpenAICompatibleGatewayClient({
     baseUrl: "https://llm.stage.commontools.dev/",
     apiKey: "test-key",
-    chatCompletionRetryDelayMs: 0,
+    transportRetryDelayMs: 0,
     fetchFn: () => {
       calls += 1;
       return Promise.reject(new Error("connection error: timed out"));
@@ -277,9 +277,9 @@ Deno.test("OpenAICompatibleGatewayClient surfaces exhausted chat completion tran
         messages: [],
       }),
     Error,
-    "chat.completions transport request failed after 2 attempts",
+    "chat.completions transport request failed after 4 attempts",
   );
-  assertEquals(calls, 2);
+  assertEquals(calls, 4);
 });
 
 Deno.test("OpenAICompatibleGatewayClient surfaces chat completion errors with response text", async () => {
@@ -324,7 +324,7 @@ Deno.test("OpenAICompatibleGatewayClient surfaces chat completion errors with re
   assertEquals(attempt.operation, "chat.completions");
   assertEquals(attempt.outcome, "http_response");
   assertEquals(attempt.attempt, 1);
-  assertEquals(attempt.maxTransportAttempts, 2);
+  assertEquals(attempt.maxTransportAttempts, 4);
   assertEquals(attempt.request.model, "gpt-5.4");
   assertEquals(attempt.request.messageCount, 1);
   assertEquals(attempt.request.toolCount, 1);

--- a/packages/cf-harness/test/openai-codex-responses.test.ts
+++ b/packages/cf-harness/test/openai-codex-responses.test.ts
@@ -51,6 +51,7 @@ Deno.test("Codex Responses client rejects conflicting credential owner bindings"
   assertThrows(
     () =>
       new OpenAICodexResponsesClient({
+        transportRetries: 0,
         credentialResolver: {
           ownerKey: owner.ownerKey,
           credentialOwner: owner,
@@ -64,6 +65,7 @@ Deno.test("Codex Responses client rejects conflicting credential owner bindings"
   assertThrows(
     () =>
       new OpenAICodexResponsesClient({
+        transportRetries: 0,
         credentialResolver: {
           ownerKey: "loom:user-b",
           credentialOwner: owner,
@@ -78,6 +80,7 @@ Deno.test("Codex Responses client rejects conflicting credential owner bindings"
 Deno.test("Codex Responses client sends the pinned owner-authenticated request", async () => {
   let request: { input: URL | RequestInfo; init?: RequestInit } | undefined;
   const client = new OpenAICodexResponsesClient({
+    transportRetries: 0,
     credentialResolver: { resolve: () => Promise.resolve(credential) },
     fetchFn: (input, init) => {
       request = { input, init };
@@ -130,6 +133,7 @@ Deno.test("Codex Responses supports stable affinity and reasoning controls", asy
   let body: Record<string, unknown> | undefined;
   let headers: Headers | undefined;
   const client = new OpenAICodexResponsesClient({
+    transportRetries: 0,
     credentialResolver: { resolve: () => Promise.resolve(credential) },
     fetchFn: (_input, init) => {
       body = JSON.parse(String(init?.body));
@@ -166,6 +170,7 @@ Deno.test("Codex Responses supports stable affinity and reasoning controls", asy
 Deno.test("Codex Responses rejects API prompt cache mode controls", async () => {
   let resolvedCredential = false;
   const client = new OpenAICodexResponsesClient({
+    transportRetries: 0,
     credentialResolver: {
       resolve: () => {
         resolvedCredential = true;
@@ -195,6 +200,7 @@ Deno.test("Codex Responses client bounds stable run affinity identifiers", async
   const requests: Array<{ headers: Headers; body: Record<string, unknown> }> =
     [];
   const client = new OpenAICodexResponsesClient({
+    transportRetries: 0,
     credentialResolver: { resolve: () => Promise.resolve(credential) },
     fetchFn: (_input, init) => {
       requests.push({
@@ -256,6 +262,7 @@ Deno.test("Codex Responses client recovers streamed output items when store:fals
   // streamed items or it silently drops the model's message and tool calls
   // (observed live: agents did nothing, 0 tool calls, empty final text).
   const client = new OpenAICodexResponsesClient({
+    transportRetries: 0,
     credentialResolver: { resolve: () => Promise.resolve(credential) },
     fetchFn: () =>
       Promise.resolve(sse(
@@ -302,6 +309,7 @@ Deno.test("Codex Responses client recovers streamed output items when the termin
   // The same backend has also been observed returning `output: null` (not just
   // an empty array) with valid streamed items. Treat null like empty.
   const client = new OpenAICodexResponsesClient({
+    transportRetries: 0,
     credentialResolver: { resolve: () => Promise.resolve(credential) },
     fetchFn: () =>
       Promise.resolve(sse(
@@ -336,6 +344,7 @@ Deno.test("Codex Responses client recovers streamed output items when the termin
 Deno.test("Codex Responses client normalizes tool calls and preserves encrypted continuation", async () => {
   const requestBodies: Array<Record<string, unknown>> = [];
   const client = new OpenAICodexResponsesClient({
+    transportRetries: 0,
     credentialResolver: { resolve: () => Promise.resolve(credential) },
     fetchFn: (_input, init) => {
       requestBodies.push(JSON.parse(String(init?.body)));
@@ -425,6 +434,7 @@ Deno.test("Codex Responses client normalizes tool calls and preserves encrypted 
 Deno.test("Codex Responses client rejects cross-model continuation before resolving credentials", async () => {
   let credentialResolutions = 0;
   const client = new OpenAICodexResponsesClient({
+    transportRetries: 0,
     credentialResolver: {
       resolve: () => {
         credentialResolutions += 1;
@@ -466,6 +476,7 @@ Deno.test("Codex Responses client rejects cross-model continuation before resolv
 
 Deno.test("Codex Responses client surfaces refusal-only output", async () => {
   const client = new OpenAICodexResponsesClient({
+    transportRetries: 0,
     credentialResolver: { resolve: () => Promise.resolve(credential) },
     fetchFn: () =>
       Promise.resolve(sse({
@@ -496,6 +507,7 @@ Deno.test("Codex Responses client surfaces refusal-only output", async () => {
 
 Deno.test("Codex Responses client rejects streams without a terminal event", async () => {
   const client = new OpenAICodexResponsesClient({
+    transportRetries: 0,
     credentialResolver: { resolve: () => Promise.resolve(credential) },
     fetchFn: () =>
       Promise.resolve(
@@ -519,6 +531,7 @@ Deno.test("Codex Responses client rejects streams without a terminal event", asy
 
 Deno.test("Codex Responses client rejects malformed SSE JSON", async () => {
   const client = new OpenAICodexResponsesClient({
+    transportRetries: 0,
     credentialResolver: { resolve: () => Promise.resolve(credential) },
     fetchFn: () =>
       Promise.resolve(
@@ -544,6 +557,7 @@ Deno.test("Codex Responses client keeps multiple tool calls and failure outputs 
   const requestBodies: Array<Record<string, unknown>> = [];
   let requestCount = 0;
   const client = new OpenAICodexResponsesClient({
+    transportRetries: 0,
     credentialResolver: { resolve: () => Promise.resolve(credential) },
     fetchFn: (_input, init) => {
       requestBodies.push(JSON.parse(String(init?.body)));
@@ -632,6 +646,7 @@ Deno.test("Codex Responses client maps bounded image attachments", async () => {
     });
     let requestBody: Record<string, unknown> | undefined;
     const client = new OpenAICodexResponsesClient({
+      transportRetries: 0,
       credentialResolver: { resolve: () => Promise.resolve(credential) },
       fetchFn: (_input, init) => {
         requestBody = JSON.parse(String(init?.body));
@@ -667,6 +682,7 @@ Deno.test("Codex Responses client maps bounded image attachments", async () => {
 
 Deno.test("Codex Responses client rejects incomplete tool calls", async () => {
   const client = new OpenAICodexResponsesClient({
+    transportRetries: 0,
     credentialResolver: { resolve: () => Promise.resolve(credential) },
     fetchFn: () =>
       Promise.resolve(sse({
@@ -718,6 +734,7 @@ Deno.test("Codex Responses client parses CRLF SSE split across byte boundaries",
     },
   });
   const client = new OpenAICodexResponsesClient({
+    transportRetries: 0,
     credentialResolver: { resolve: () => Promise.resolve(credential) },
     fetchFn: () => Promise.resolve(new Response(body, { status: 200 })),
   });
@@ -741,6 +758,7 @@ Deno.test("Codex Responses client parses CRLF SSE split across byte boundaries",
 
 Deno.test("Codex Responses client rejects conflicting duplicate tool-call ids", async () => {
   const client = new OpenAICodexResponsesClient({
+    transportRetries: 0,
     credentialResolver: { resolve: () => Promise.resolve(credential) },
     fetchFn: () =>
       Promise.resolve(sse({
@@ -781,6 +799,7 @@ Deno.test("Codex model discovery is live, owner-authenticated, and ordered", asy
   let requestedHeaders = new Headers();
   let requestedRedirect: RequestRedirect | undefined;
   const client = new OpenAICodexResponsesClient({
+    transportRetries: 0,
     credentialResolver: { resolve: () => Promise.resolve(credential) },
     fetchFn: (input, init) => {
       requestedUrl = String(input);
@@ -846,6 +865,7 @@ Deno.test("Codex model discovery classifies provider failures", async () => {
     ] as const
   ) {
     const client = new OpenAICodexResponsesClient({
+      transportRetries: 0,
       credentialResolver: { resolve: () => Promise.resolve(credential) },
       fetchFn,
     });
@@ -859,6 +879,7 @@ Deno.test("Codex model discovery classifies provider failures", async () => {
 Deno.test("Codex Responses quota errors are concise and do not retain response bodies", async () => {
   const attempts: unknown[] = [];
   const client = new OpenAICodexResponsesClient({
+    transportRetries: 0,
     credentialResolver: { resolve: () => Promise.resolve(credential) },
     fetchFn: () =>
       Promise.resolve(
@@ -905,6 +926,7 @@ Deno.test("Codex Responses classifies provider HTTP failures", async () => {
     ] as const
   ) {
     const client = new OpenAICodexResponsesClient({
+      transportRetries: 0,
       credentialResolver: { resolve: () => Promise.resolve(credential) },
       fetchFn: () => Promise.resolve(new Response("unavailable", { status })),
     });
@@ -926,6 +948,7 @@ Deno.test("Codex Responses classifies provider HTTP failures", async () => {
 Deno.test("Codex transport errors redact credential and account values", async () => {
   const attempts: unknown[] = [];
   const client = new OpenAICodexResponsesClient({
+    transportRetries: 0,
     credentialResolver: { resolve: () => Promise.resolve(credential) },
     fetchFn: () =>
       Promise.reject(
@@ -964,6 +987,7 @@ Deno.test("Codex Responses bounds failures while reading provider error bodies",
     },
   });
   const client = new OpenAICodexResponsesClient({
+    transportRetries: 0,
     credentialResolver: { resolve: () => Promise.resolve(credential) },
     fetchFn: () => Promise.resolve(new Response(body, { status: 503 })),
   });
@@ -986,6 +1010,7 @@ Deno.test("Codex Responses preserves abort during provider error diagnostics", a
   const controller = new AbortController();
   const reason = new Error("abort during provider diagnostics");
   const client = new OpenAICodexResponsesClient({
+    transportRetries: 0,
     credentialResolver: { resolve: () => Promise.resolve(credential) },
     fetchFn: () =>
       Promise.resolve(new Response("unavailable", { status: 503 })),
@@ -1020,6 +1045,7 @@ Deno.test("Codex Responses abort cancels an active stream without retry", async 
     },
   });
   const client = new OpenAICodexResponsesClient({
+    transportRetries: 0,
     credentialResolver: {
       resolve: (signal) => {
         assertEquals(signal, controller.signal);
@@ -1061,6 +1087,7 @@ Deno.test("Codex Responses preserves non-DOM abort reasons when stream cancellat
   });
   const controller = new AbortController();
   const client = new OpenAICodexResponsesClient({
+    transportRetries: 0,
     credentialResolver: { resolve: () => Promise.resolve(credential) },
     fetchFn: () => {
       markRequested();
@@ -1095,6 +1122,7 @@ Deno.test("Codex Responses preserves abort after credential resolution", async (
   });
   let requests = 0;
   const client = new OpenAICodexResponsesClient({
+    transportRetries: 0,
     credentialResolver: {
       resolve: async () => {
         markResolving();
@@ -1146,6 +1174,7 @@ Deno.test("Codex Responses returns on the first terminal event and cancels a kee
     },
   });
   const client = new OpenAICodexResponsesClient({
+    transportRetries: 0,
     credentialResolver: { resolve: () => Promise.resolve(credential) },
     fetchFn: () => Promise.resolve(new Response(body, { status: 200 })),
   });
@@ -1164,6 +1193,7 @@ Deno.test("Codex Responses returns on the first terminal event and cancels a kee
 
 Deno.test("Codex Responses recognizes response.failed as terminal", async () => {
   const client = new OpenAICodexResponsesClient({
+    transportRetries: 0,
     credentialResolver: { resolve: () => Promise.resolve(credential) },
     fetchFn: () =>
       Promise.resolve(sse({
@@ -1182,7 +1212,7 @@ Deno.test("Codex Responses recognizes response.failed as terminal", async () => 
         runId: "run-response-failed",
       }),
     HarnessControlError,
-    "invalid terminal response",
+    "Codex Responses ended with status failed",
   );
 });
 
@@ -1197,6 +1227,7 @@ Deno.test("Codex Responses cancels the stream after malformed SSE", async () => 
     },
   });
   const client = new OpenAICodexResponsesClient({
+    transportRetries: 0,
     credentialResolver: { resolve: () => Promise.resolve(credential) },
     fetchFn: () => Promise.resolve(new Response(body, { status: 200 })),
   });

--- a/packages/cf-harness/test/openai-compatible-gateway-chat.test.ts
+++ b/packages/cf-harness/test/openai-compatible-gateway-chat.test.ts
@@ -28,7 +28,7 @@ const clientWith = (
     new OpenAICompatibleGatewayClient({
       baseUrl: GATEWAY,
       authMode: "none",
-      chatCompletionTransportRetries: 0,
+      transportRetries: 0,
       fetchFn: (input, init) => {
         const url = String(input);
         if (init?.body !== undefined) {
@@ -293,7 +293,7 @@ Deno.test("transport failures name the operation that failed", async () => {
     new OpenAICompatibleGatewayClient({
       baseUrl: GATEWAY,
       authMode: "none",
-      chatCompletionTransportRetries: 0,
+      transportRetries: 0,
       fetchFn: () => Promise.reject(new Error("connection error: timed out")),
     }),
   );

--- a/packages/cf-harness/test/prompt-loop-external-skill-acquisition.test.ts
+++ b/packages/cf-harness/test/prompt-loop-external-skill-acquisition.test.ts
@@ -15,6 +15,7 @@ import { describe, it } from "@std/testing/bdd";
 
 import { DEFAULT_SUBAGENT_PROFILE } from "../src/contracts/subagent.ts";
 import { CfHarnessEngine } from "../src/engine.ts";
+import { OpenAICompatibleGatewayClient } from "../src/gateway/openai-client.ts";
 import { CfHarnessPromptLoop } from "../src/prompt-loop.ts";
 import { SkillsShAcquisitionClient } from "../src/skills-sh/acquisition.ts";
 import { SkillsShSearchClient } from "../src/skills-sh/search-client.ts";
@@ -434,10 +435,18 @@ describe("prompt-loop external skill acquisition", () => {
           }),
         );
       };
+      // The scripted fetch answers by request index, so the child's one
+      // provider failure has to end its exchange there rather than be issued
+      // again: a gateway client with no transport retries makes that so.
       const loop = new CfHarnessPromptLoop({
-        apiKey: "test-key",
         engine,
-        fetchFn: modelFetch,
+        gatewayClient: new OpenAICompatibleGatewayClient({
+          baseUrl: engine.config.gatewayBaseUrl,
+          authMode: engine.config.gatewayAuthMode,
+          apiKey: "test-key",
+          transportRetries: 0,
+          fetchFn: modelFetch,
+        }),
         allowedToolIds: ["acquire_skill", "delegate_task"],
         allowedSubagentProfiles: [DEFAULT_SUBAGENT_PROFILE],
       });

--- a/packages/cf-harness/test/provider-error.test.ts
+++ b/packages/cf-harness/test/provider-error.test.ts
@@ -1,0 +1,152 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import {
+  describeProviderError,
+  isTransientHttpStatus,
+  isTransientProviderError,
+  mapProviderError,
+  providerErrorFromJsonText,
+  providerErrorFromPayload,
+} from "../src/model/provider-error.ts";
+
+describe("provider-error", () => {
+  describe("providerErrorFromPayload()", () => {
+    it("reads type, code, and message from a nested `error` object", () => {
+      expect(providerErrorFromPayload({
+        type: "error",
+        error: {
+          type: "service_unavailable_error",
+          code: "server_is_overloaded",
+          message:
+            "Our servers are currently overloaded. Please try again later.",
+        },
+      })).toEqual({
+        type: "service_unavailable_error",
+        code: "server_is_overloaded",
+        message:
+          "Our servers are currently overloaded. Please try again later.",
+      });
+    });
+
+    it("reads a top-level code and message, leaving out a `type` that names the event", () => {
+      expect(providerErrorFromPayload({
+        type: "error",
+        code: "rate_limit_exceeded",
+        message: "slow down",
+        sequence_number: 3,
+      })).toEqual({ code: "rate_limit_exceeded", message: "slow down" });
+    });
+
+    it("keeps a top-level `type` that is not the event's", () => {
+      expect(providerErrorFromPayload({
+        type: "server_error",
+        message: "boom",
+      })).toEqual({ type: "server_error", message: "boom" });
+    });
+
+    it("returns `undefined` for a payload that states no message", () => {
+      expect(providerErrorFromPayload({ error: { code: "x" } }))
+        .toBeUndefined();
+      expect(providerErrorFromPayload({ error: "down" })).toBeUndefined();
+      expect(providerErrorFromPayload("down")).toBeUndefined();
+      expect(providerErrorFromPayload(null)).toBeUndefined();
+    });
+
+    it("leaves out an empty type or code", () => {
+      expect(providerErrorFromPayload({
+        error: { type: "", code: "", message: "m" },
+      })).toEqual({ message: "m" });
+    });
+  });
+
+  describe("providerErrorFromJsonText()", () => {
+    it("parses a JSON body that carries an error object", () => {
+      expect(providerErrorFromJsonText(
+        '{"error":{"type":"server_error","message":"down"}}',
+      )).toEqual({ type: "server_error", message: "down" });
+    });
+
+    it("returns `undefined` for text that is not JSON", () => {
+      expect(providerErrorFromJsonText("<html>502</html>")).toBeUndefined();
+      expect(providerErrorFromJsonText("")).toBeUndefined();
+    });
+  });
+
+  describe("describeProviderError()", () => {
+    it("renders type and code ahead of the message", () => {
+      expect(describeProviderError({
+        type: "service_unavailable_error",
+        code: "server_is_overloaded",
+        message: "overloaded",
+      })).toBe("service_unavailable_error / server_is_overloaded: overloaded");
+    });
+
+    it("renders whichever of type or code is present", () => {
+      expect(describeProviderError({ code: "c", message: "m" })).toBe("c: m");
+      expect(describeProviderError({ type: "t", message: "m" })).toBe("t: m");
+    });
+
+    it("renders the message alone when neither type nor code is present", () => {
+      expect(describeProviderError({ message: "m" })).toBe("m");
+    });
+  });
+
+  describe("mapProviderError()", () => {
+    it("applies the mapping to every field that is present", () => {
+      expect(mapProviderError(
+        { type: "t-secret", code: "c-secret", message: "m-secret" },
+        (text) => text.replace("secret", "[redacted]"),
+      )).toEqual({
+        type: "t-[redacted]",
+        code: "c-[redacted]",
+        message: "m-[redacted]",
+      });
+      expect(mapProviderError({ message: "m" }, (text) => text.toUpperCase()))
+        .toEqual({ message: "M" });
+    });
+  });
+
+  describe("isTransientProviderError()", () => {
+    it("returns `true` for a transient type or code", () => {
+      expect(isTransientProviderError({
+        type: "service_unavailable_error",
+        message: "m",
+      })).toBe(true);
+      expect(isTransientProviderError({
+        code: "server_is_overloaded",
+        message: "m",
+      })).toBe(true);
+      expect(isTransientProviderError({
+        type: "invalid_request_error",
+        code: "rate_limit_exceeded",
+        message: "m",
+      })).toBe(true);
+    });
+
+    it("returns `false` for an error that states neither a transient type nor a transient code", () => {
+      expect(isTransientProviderError({
+        type: "invalid_request_error",
+        code: "context_length_exceeded",
+        message: "overloaded",
+      })).toBe(false);
+      expect(isTransientProviderError({ message: "server_is_overloaded" }))
+        .toBe(false);
+    });
+  });
+
+  describe("isTransientHttpStatus()", () => {
+    it("returns `true` for 429 and every 5xx status", () => {
+      expect(isTransientHttpStatus(429)).toBe(true);
+      expect(isTransientHttpStatus(500)).toBe(true);
+      expect(isTransientHttpStatus(503)).toBe(true);
+      expect(isTransientHttpStatus(599)).toBe(true);
+    });
+
+    it("returns `false` for every other status", () => {
+      expect(isTransientHttpStatus(400)).toBe(false);
+      expect(isTransientHttpStatus(401)).toBe(false);
+      expect(isTransientHttpStatus(404)).toBe(false);
+      expect(isTransientHttpStatus(200)).toBe(false);
+    });
+  });
+});

--- a/packages/cf-harness/test/transport-retry.test.ts
+++ b/packages/cf-harness/test/transport-retry.test.ts
@@ -309,33 +309,6 @@ describe("transport-retry", () => {
       expect(attempts[0].providerError?.code).toBe("context_length_exceeded");
     });
 
-    it("does not issue the exchange again once the failed stream delivered a tool call", async () => {
-      const { delays, delay } = recordingDelay();
-      const { attempts, complete, calls } = codexClient(
-        () =>
-          sse({
-            type: "response.output_item.done",
-            item: {
-              type: "function_call",
-              id: "fc_1",
-              call_id: "call_1",
-              name: "read_file",
-              arguments: "{}",
-            },
-          }, OVERLOADED_EVENT),
-        { delay },
-      );
-
-      const error = await rejectionOf(complete());
-
-      expect((error as HarnessControlError).code).toBe("provider-unavailable");
-      expect((error as Error).message).toContain(OVERLOADED_DESCRIPTION);
-      expect(calls()).toBe(1);
-      expect(delays).toEqual([]);
-      expect(attempts[0].providerError).toEqual(OVERLOADED_EVENT.error);
-      expect(attempts[0].retry).toBeUndefined();
-    });
-
     it("records an error event that states no reason without inventing one", async () => {
       const { attempts, complete } = codexClient(
         () => sse({ type: "error" }),

--- a/packages/cf-harness/test/transport-retry.test.ts
+++ b/packages/cf-harness/test/transport-retry.test.ts
@@ -1,0 +1,719 @@
+/**
+ * The bounded transport retry both model clients share: which failures are
+ * issued again, how the backoff runs, what every attempt record says, and
+ * what a caller is thrown when the schedule runs out. Backoff is driven by an
+ * injected delay that records what it was asked for and resolves at once, so
+ * nothing here waits on a timer.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { FakeTime } from "@std/testing/time";
+import { expect } from "@std/expect";
+import type { OpenAICodexOAuthCredential } from "../src/auth/types.ts";
+import { HarnessControlError } from "../src/control-errors.ts";
+import {
+  type OpenAIChatCompletionAttemptDiagnostic,
+  OpenAICompatibleGatewayClient,
+} from "../src/gateway/openai-client.ts";
+import type { HarnessModelAttemptDiagnostic } from "../src/model/client.ts";
+import { OpenAICodexResponsesClient } from "../src/model/openai-codex-responses.ts";
+import {
+  abortableDelay,
+  DEFAULT_TRANSPORT_RETRIES,
+  DEFAULT_TRANSPORT_RETRY_DELAY_MS,
+  type HarnessTransportRetryDelay,
+  TransportRetrySchedule,
+} from "../src/model/transport-retry.ts";
+
+const credential: OpenAICodexOAuthCredential = {
+  type: "oauth",
+  providerId: "openai-codex",
+  accessToken: "access-secret",
+  refreshToken: "refresh-secret",
+  expiresAt: Date.now() + 60_000,
+  accountId: "acct-123",
+};
+
+const OVERLOADED_EVENT = {
+  type: "error",
+  error: {
+    type: "service_unavailable_error",
+    code: "server_is_overloaded",
+    message: "Our servers are currently overloaded. Please try again later.",
+  },
+};
+
+const OVERLOADED_DESCRIPTION =
+  "service_unavailable_error / server_is_overloaded: Our servers are currently overloaded. Please try again later.";
+
+const sse = (...events: unknown[]): Response =>
+  new Response(
+    events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join(""),
+    { status: 200, headers: { "content-type": "text/event-stream" } },
+  );
+
+const completedStream = (): Response =>
+  sse({
+    type: "response.completed",
+    response: {
+      id: "resp_1",
+      status: "completed",
+      output: [{
+        type: "message",
+        id: "msg_1",
+        role: "assistant",
+        content: [{ type: "output_text", text: "hello" }],
+      }],
+    },
+  });
+
+/** A delay that records each backoff it is asked for and resolves at once. */
+const recordingDelay = (): {
+  delays: number[];
+  delay: HarnessTransportRetryDelay;
+} => {
+  const delays: number[] = [];
+  return {
+    delays,
+    delay: (ms) => {
+      delays.push(ms);
+      return Promise.resolve();
+    },
+  };
+};
+
+const rejectionOf = async (promise: Promise<unknown>): Promise<unknown> => {
+  try {
+    await promise;
+  } catch (error) {
+    return error;
+  }
+  throw new Error("expected the promise to reject");
+};
+
+describe("transport-retry", () => {
+  describe("TransportRetrySchedule", () => {
+    describe("constructor()", () => {
+      it("allows one attempt more than the configured retries", () => {
+        expect(new TransportRetrySchedule({ transportRetries: 0 }).maxAttempts)
+          .toBe(1);
+        expect(new TransportRetrySchedule({ transportRetries: 2 }).maxAttempts)
+          .toBe(3);
+      });
+
+      it("falls back to the defaults for an absent or invalid option", () => {
+        expect(new TransportRetrySchedule().maxAttempts)
+          .toBe(DEFAULT_TRANSPORT_RETRIES + 1);
+        expect(new TransportRetrySchedule({ transportRetries: -1 }).maxAttempts)
+          .toBe(DEFAULT_TRANSPORT_RETRIES + 1);
+        expect(new TransportRetrySchedule().delayMsBefore(2))
+          .toBe(DEFAULT_TRANSPORT_RETRY_DELAY_MS);
+        expect(
+          new TransportRetrySchedule({ transportRetryDelayMs: 1.5 })
+            .delayMsBefore(2),
+        ).toBe(DEFAULT_TRANSPORT_RETRY_DELAY_MS);
+      });
+    });
+
+    describe("instance members", () => {
+      describe("delayMsBefore()", () => {
+        it("returns no backoff before the first attempt and doubles it before each attempt after the second", () => {
+          const schedule = new TransportRetrySchedule({
+            transportRetryDelayMs: 100,
+          });
+          expect([1, 2, 3, 4].map((attempt) => schedule.delayMsBefore(attempt)))
+            .toEqual([0, 100, 200, 400]);
+        });
+      });
+
+      describe("retryAfter()", () => {
+        it("returns the kind and the backoff before the next attempt", () => {
+          const schedule = new TransportRetrySchedule({
+            transportRetries: 2,
+            transportRetryDelayMs: 100,
+          });
+          expect(schedule.retryAfter(1, "http_status"))
+            .toEqual({ kind: "http_status", delayMs: 100 });
+          expect(schedule.retryAfter(2, "transport_error"))
+            .toEqual({ kind: "transport_error", delayMs: 200 });
+        });
+
+        it("returns `undefined` for a failure that is not transient", () => {
+          expect(new TransportRetrySchedule().retryAfter(1, undefined))
+            .toBeUndefined();
+        });
+
+        it("returns `undefined` on the last attempt the schedule allows", () => {
+          const schedule = new TransportRetrySchedule({ transportRetries: 2 });
+          expect(schedule.retryAfter(3, "provider_error")).toBeUndefined();
+          expect(schedule.retryAfter(4, "provider_error")).toBeUndefined();
+        });
+      });
+
+      describe("waitBefore()", () => {
+        it("waits out the backoff through the injected delay", async () => {
+          const { delays, delay } = recordingDelay();
+          const schedule = new TransportRetrySchedule({
+            transportRetryDelayMs: 100,
+            transportRetryDelay: delay,
+          });
+          await schedule.waitBefore(3);
+          expect(delays).toEqual([200]);
+        });
+      });
+    });
+  });
+
+  describe("abortableDelay()", () => {
+    it("resolves once the timer fires", async () => {
+      using time = new FakeTime();
+      let resolved = false;
+      const waiting = abortableDelay(50).then(() => {
+        resolved = true;
+      });
+      await time.tickAsync(49);
+      expect(resolved).toBe(false);
+      await time.tickAsync(1);
+      await waiting;
+      expect(resolved).toBe(true);
+    });
+
+    it("resolves at once for a zero delay", async () => {
+      await abortableDelay(0);
+    });
+
+    it("rejects with the abort reason when the signal aborts mid-wait", async () => {
+      using time = new FakeTime();
+      const controller = new AbortController();
+      const reason = new Error("canceled during backoff");
+      const waiting = abortableDelay(50, controller.signal);
+      await time.tickAsync(10);
+      controller.abort(reason);
+      expect(await rejectionOf(waiting)).toBe(reason);
+    });
+
+    it("rejects with the abort reason when the signal is already aborted", async () => {
+      const controller = new AbortController();
+      const reason = new Error("already canceled");
+      controller.abort(reason);
+      expect(await rejectionOf(abortableDelay(50, controller.signal)))
+        .toBe(reason);
+    });
+  });
+
+  describe("OpenAICodexResponsesClient", () => {
+    const codexClient = (
+      respond: (call: number) => Response | Promise<Response>,
+      options: {
+        transportRetries?: number;
+        delay?: HarnessTransportRetryDelay;
+      } = {},
+    ) => {
+      const attempts: HarnessModelAttemptDiagnostic[] = [];
+      let calls = 0;
+      const client = new OpenAICodexResponsesClient({
+        credentialResolver: { resolve: () => Promise.resolve(credential) },
+        transportRetries: options.transportRetries ?? 2,
+        transportRetryDelayMs: 100,
+        ...(options.delay !== undefined
+          ? { transportRetryDelay: options.delay }
+          : {}),
+        fetchFn: () => {
+          calls += 1;
+          return Promise.resolve(respond(calls));
+        },
+      });
+      const complete = (signal?: AbortSignal) =>
+        client.complete({
+          model: "gpt-5.4",
+          transcript: [{ role: "user", content: "hi" }],
+          tools: [],
+          nativeModelToolIds: [],
+          runId: "run-retry",
+          ...(signal !== undefined ? { signal } : {}),
+          onAttempt: (attempt) => {
+            attempts.push(attempt);
+          },
+        });
+      return { attempts, complete, calls: () => calls };
+    };
+
+    it("issues the exchange again after a transient in-stream error event, recording the provider's reason on the failed attempt", async () => {
+      const { delays, delay } = recordingDelay();
+      const { attempts, complete, calls } = codexClient(
+        (call) => call === 1 ? sse(OVERLOADED_EVENT) : completedStream(),
+        { delay },
+      );
+
+      const result = await complete();
+
+      expect(result.assistant.content).toBe("hello");
+      expect(calls()).toBe(2);
+      expect(delays).toEqual([100]);
+      expect(attempts.map((attempt) => attempt.attempt)).toEqual([1, 2]);
+      expect(attempts.map((attempt) => attempt.maxTransportAttempts))
+        .toEqual([3, 3]);
+      expect(attempts[0].outcome).toBe("http_response");
+      expect(attempts[0].providerError).toEqual(OVERLOADED_EVENT.error);
+      expect(attempts[0].retry)
+        .toEqual({ kind: "provider_error", delayMs: 100 });
+      expect(attempts[1].providerError).toBeUndefined();
+      expect(attempts[1].retry).toBeUndefined();
+    });
+
+    it("throws the provider's reason once the schedule runs out, with every attempt recorded", async () => {
+      const { delays, delay } = recordingDelay();
+      const { attempts, complete, calls } = codexClient(
+        () => sse(OVERLOADED_EVENT),
+        { delay },
+      );
+
+      const error = await rejectionOf(complete());
+
+      expect(error).toBeInstanceOf(HarnessControlError);
+      expect((error as HarnessControlError).code).toBe("provider-unavailable");
+      expect((error as Error).message).toBe(
+        `OpenAI Codex Responses stream returned an error event: ${OVERLOADED_DESCRIPTION}`,
+      );
+      expect(calls()).toBe(3);
+      expect(delays).toEqual([100, 200]);
+      expect(attempts.map((attempt) => attempt.retry?.delayMs))
+        .toEqual([100, 200, undefined]);
+      expect(attempts[2].providerError).toEqual(OVERLOADED_EVENT.error);
+    });
+
+    it("does not issue the exchange again for an error event the provider does not state as transient", async () => {
+      const { delays, delay } = recordingDelay();
+      const { attempts, complete, calls } = codexClient(
+        () =>
+          sse({
+            type: "error",
+            error: {
+              type: "invalid_request_error",
+              code: "context_length_exceeded",
+              message: "the input is too long",
+            },
+          }),
+        { delay },
+      );
+
+      const error = await rejectionOf(complete());
+
+      expect((error as Error).message).toBe(
+        "OpenAI Codex Responses stream returned an error event: invalid_request_error / context_length_exceeded: the input is too long",
+      );
+      expect(calls()).toBe(1);
+      expect(delays).toEqual([]);
+      expect(attempts.length).toBe(1);
+      expect(attempts[0].retry).toBeUndefined();
+      expect(attempts[0].providerError?.code).toBe("context_length_exceeded");
+    });
+
+    it("does not issue the exchange again once the failed stream delivered a tool call", async () => {
+      const { delays, delay } = recordingDelay();
+      const { attempts, complete, calls } = codexClient(
+        () =>
+          sse({
+            type: "response.output_item.done",
+            item: {
+              type: "function_call",
+              id: "fc_1",
+              call_id: "call_1",
+              name: "read_file",
+              arguments: "{}",
+            },
+          }, OVERLOADED_EVENT),
+        { delay },
+      );
+
+      const error = await rejectionOf(complete());
+
+      expect((error as HarnessControlError).code).toBe("provider-unavailable");
+      expect((error as Error).message).toContain(OVERLOADED_DESCRIPTION);
+      expect(calls()).toBe(1);
+      expect(delays).toEqual([]);
+      expect(attempts[0].providerError).toEqual(OVERLOADED_EVENT.error);
+      expect(attempts[0].retry).toBeUndefined();
+    });
+
+    it("records an error event that states no reason without inventing one", async () => {
+      const { attempts, complete } = codexClient(
+        () => sse({ type: "error" }),
+        { transportRetries: 0 },
+      );
+
+      const error = await rejectionOf(complete());
+
+      expect((error as Error).message).toBe(
+        "OpenAI Codex Responses stream returned an error event: the provider stated no reason",
+      );
+      expect(attempts[0].providerError)
+        .toEqual({ message: "the provider stated no reason" });
+    });
+
+    it("issues the exchange again after a `response.failed` terminal that states a transient reason", async () => {
+      const { delays, delay } = recordingDelay();
+      const { attempts, complete, calls } = codexClient(
+        (call) =>
+          call === 1
+            ? sse({
+              type: "response.failed",
+              response: {
+                status: "failed",
+                output: [],
+                error: { code: "server_error", message: "internal fault" },
+              },
+            })
+            : completedStream(),
+        { delay },
+      );
+
+      const result = await complete();
+
+      expect(result.assistant.content).toBe("hello");
+      expect(calls()).toBe(2);
+      expect(delays).toEqual([100]);
+      expect(attempts[0].providerError)
+        .toEqual({ code: "server_error", message: "internal fault" });
+      expect(attempts[0].retry?.kind).toBe("provider_error");
+    });
+
+    it("names a `response.failed` terminal's reason when the schedule runs out", async () => {
+      const { complete } = codexClient(
+        () =>
+          sse({
+            type: "response.failed",
+            response: {
+              status: "failed",
+              output: [],
+              error: { code: "server_error", message: "internal fault" },
+            },
+          }),
+        { transportRetries: 0 },
+      );
+
+      const error = await rejectionOf(complete());
+
+      expect((error as Error).message).toBe(
+        "Codex Responses ended with status failed: server_error: internal fault",
+      );
+    });
+
+    it("issues the exchange again after a 5xx response, recording the body's reason", async () => {
+      const { delays, delay } = recordingDelay();
+      const { attempts, complete, calls } = codexClient(
+        (call) =>
+          call === 1
+            ? new Response(
+              JSON.stringify({
+                error: { type: "server_error", message: "try again" },
+              }),
+              { status: 503 },
+            )
+            : completedStream(),
+        { delay },
+      );
+
+      const result = await complete();
+
+      expect(result.assistant.content).toBe("hello");
+      expect(calls()).toBe(2);
+      expect(delays).toEqual([100]);
+      expect(attempts[0].httpStatus).toBe(503);
+      expect(attempts[0].providerError)
+        .toEqual({ type: "server_error", message: "try again" });
+      expect(attempts[0].retry).toEqual({ kind: "http_status", delayMs: 100 });
+    });
+
+    it("names the body's reason when a 5xx response ends the schedule", async () => {
+      const { complete } = codexClient(
+        () =>
+          new Response(
+            JSON.stringify({
+              error: { type: "server_error", message: "try again" },
+            }),
+            { status: 503 },
+          ),
+        { transportRetries: 0 },
+      );
+
+      const error = await rejectionOf(complete());
+
+      expect((error as Error).message).toBe(
+        "OpenAI Codex Responses request failed (503): server_error: try again",
+      );
+    });
+
+    it("redacts credential values from the provider's reason", async () => {
+      const { attempts, complete } = codexClient(
+        () =>
+          sse({
+            type: "error",
+            error: {
+              type: "server_error",
+              message: "access-secret for acct-123 failed",
+            },
+          }),
+        { transportRetries: 0 },
+      );
+
+      const error = await rejectionOf(complete());
+
+      const serialized = `${(error as Error).message}${
+        JSON.stringify(attempts)
+      }`;
+      expect(serialized.includes("access-secret")).toBe(false);
+      expect(serialized.includes("acct-123")).toBe(false);
+      expect(attempts[0].providerError?.message)
+        .toBe("[redacted] for [redacted] failed");
+    });
+
+    it("does not issue the exchange again after a 4xx other than 429", async () => {
+      const { delays, delay } = recordingDelay();
+      const { attempts, complete, calls } = codexClient(
+        () => new Response("unauthorized", { status: 401 }),
+        { delay },
+      );
+
+      const error = await rejectionOf(complete());
+
+      expect((error as HarnessControlError).code).toBe(
+        "provider-auth-required",
+      );
+      expect(calls()).toBe(1);
+      expect(delays).toEqual([]);
+      expect(attempts[0].retry).toBeUndefined();
+    });
+
+    it("issues the exchange again after a transport error", async () => {
+      const { delays, delay } = recordingDelay();
+      const { attempts, complete, calls } = codexClient(
+        (call) =>
+          call === 1
+            ? Promise.reject(new Error("connection reset"))
+            : completedStream(),
+        { delay },
+      );
+
+      const result = await complete();
+
+      expect(result.assistant.content).toBe("hello");
+      expect(calls()).toBe(2);
+      expect(delays).toEqual([100]);
+      expect(attempts[0].outcome).toBe("transport_error");
+      expect(attempts[0].retry)
+        .toEqual({ kind: "transport_error", delayMs: 100 });
+    });
+
+    it("issues the exchange again after a stream that ends before its terminal event", async () => {
+      const { delays, delay } = recordingDelay();
+      const { attempts, complete, calls } = codexClient(
+        (call) =>
+          call === 1
+            ? sse({ type: "response.output_text.delta", delta: "partial" })
+            : completedStream(),
+        { delay },
+      );
+
+      const result = await complete();
+
+      expect(result.assistant.content).toBe("hello");
+      expect(calls()).toBe(2);
+      expect(delays).toEqual([100]);
+      expect(attempts[0].retry?.kind).toBe("transport_error");
+    });
+
+    it("does not issue the exchange again for a stream that is not SSE-framed JSON", async () => {
+      const { delays, delay } = recordingDelay();
+      const { complete, calls } = codexClient(
+        () => new Response("data: {not-json}\n\n", { status: 200 }),
+        { delay },
+      );
+
+      const error = await rejectionOf(complete());
+
+      expect((error as Error).message).toContain("malformed JSON");
+      expect(calls()).toBe(1);
+      expect(delays).toEqual([]);
+    });
+
+    it("rejects with the abort reason when the signal aborts during the backoff", async () => {
+      const controller = new AbortController();
+      const reason = new Error("canceled during backoff");
+      const { complete, calls } = codexClient(
+        () => sse(OVERLOADED_EVENT),
+        {
+          delay: (_ms, signal) => {
+            controller.abort(reason);
+            return Promise.reject(signal?.reason);
+          },
+        },
+      );
+
+      expect(await rejectionOf(complete(controller.signal))).toBe(reason);
+      expect(calls()).toBe(1);
+    });
+  });
+
+  describe("OpenAICompatibleGatewayClient", () => {
+    const gatewayClient = (
+      respond: (call: number) => Response | Promise<Response>,
+      options: { transportRetries?: number } = {},
+    ) => {
+      const attempts: OpenAIChatCompletionAttemptDiagnostic[] = [];
+      const { delays, delay } = recordingDelay();
+      let calls = 0;
+      const client = new OpenAICompatibleGatewayClient({
+        baseUrl: "https://llm.stage.commontools.dev/",
+        apiKey: "test-key",
+        transportRetries: options.transportRetries ?? 2,
+        transportRetryDelayMs: 100,
+        transportRetryDelay: delay,
+        fetchFn: () => {
+          calls += 1;
+          return Promise.resolve(respond(calls));
+        },
+      });
+      const attemptOptions = {
+        onChatCompletionAttempt: (
+          attempt: OpenAIChatCompletionAttemptDiagnostic,
+        ) => {
+          attempts.push(attempt);
+        },
+      };
+      return { client, attempts, delays, attemptOptions, calls: () => calls };
+    };
+
+    const completedResponse = (): Response =>
+      new Response(
+        JSON.stringify({
+          status: "completed",
+          output: [{
+            type: "message",
+            content: [{ type: "output_text", text: "ok" }],
+          }],
+        }),
+        { status: 200 },
+      );
+
+    it("issues a Responses request again after a 5xx, recording the body's reason", async () => {
+      const { client, attempts, delays, attemptOptions, calls } = gatewayClient(
+        (call) =>
+          call === 1
+            ? new Response(
+              JSON.stringify({
+                error: { type: "server_error", message: "upstream down" },
+              }),
+              { status: 502 },
+            )
+            : completedResponse(),
+      );
+
+      const response = await client.createResponseJson(
+        { model: "gpt-5.6", input: [] },
+        attemptOptions,
+      );
+
+      expect(response.status).toBe("completed");
+      expect(calls()).toBe(2);
+      expect(delays).toEqual([100]);
+      expect(attempts.map((attempt) => attempt.httpStatus)).toEqual([502, 200]);
+      expect(attempts[0].providerError)
+        .toEqual({ type: "server_error", message: "upstream down" });
+      expect(attempts[0].retry).toEqual({ kind: "http_status", delayMs: 100 });
+      expect(attempts[0].responseBodyExcerpt).toContain("upstream down");
+      expect(attempts[1].retry).toBeUndefined();
+    });
+
+    it("throws the final response's body once a 5xx ends the schedule", async () => {
+      const { client, attempts, delays, attemptOptions, calls } = gatewayClient(
+        () => new Response("gateway overloaded", { status: 503 }),
+      );
+
+      const error = await rejectionOf(client.createChatCompletionJson(
+        { model: "gpt-5.4", messages: [] },
+        attemptOptions,
+      ));
+
+      expect((error as Error).message)
+        .toBe("chat completion request failed (503): gateway overloaded");
+      expect(calls()).toBe(3);
+      expect(delays).toEqual([100, 200]);
+      expect(attempts.map((attempt) => attempt.retry?.delayMs))
+        .toEqual([100, 200, undefined]);
+      expect(attempts[2].providerError).toBeUndefined();
+    });
+
+    it("does not issue a request again after a 4xx other than 429", async () => {
+      const { client, attempts, delays, attemptOptions, calls } = gatewayClient(
+        () => new Response("bad request", { status: 400 }),
+      );
+
+      const error = await rejectionOf(client.createChatCompletionJson(
+        { model: "gpt-5.4", messages: [] },
+        attemptOptions,
+      ));
+
+      expect((error as Error).message)
+        .toBe("chat completion request failed (400): bad request");
+      expect(calls()).toBe(1);
+      expect(delays).toEqual([]);
+      expect(attempts.length).toBe(1);
+      expect(attempts[0].retry).toBeUndefined();
+    });
+
+    it("issues a request again after a 429", async () => {
+      const { client, attempts, calls } = gatewayClient(
+        (call) =>
+          call === 1
+            ? new Response("slow down", { status: 429 })
+            : completedResponse(),
+      );
+
+      await client.createResponseJson({ model: "gpt-5.6", input: [] }, {
+        onChatCompletionAttempt: (attempt) => {
+          attempts.push(attempt);
+        },
+      });
+
+      expect(calls()).toBe(2);
+      expect(attempts[0].retry?.kind).toBe("http_status");
+    });
+
+    it("waits out the backoff through the injected delay after a transport error", async () => {
+      const { client, attempts, delays, attemptOptions, calls } = gatewayClient(
+        (call) =>
+          call === 1
+            ? Promise.reject(new Error("connection reset"))
+            : completedResponse(),
+      );
+
+      await client.createResponseJson(
+        { model: "gpt-5.6", input: [] },
+        attemptOptions,
+      );
+
+      expect(calls()).toBe(2);
+      expect(delays).toEqual([100]);
+      expect(attempts[0].outcome).toBe("transport_error");
+      expect(attempts[0].retry)
+        .toEqual({ kind: "transport_error", delayMs: 100 });
+    });
+
+    it("returns a non-2xx response with its body readable to a caller that reads the response itself", async () => {
+      const { client, attempts, attemptOptions } = gatewayClient(
+        () => new Response("bad request", { status: 400 }),
+      );
+
+      const response = await client.createChatCompletion(
+        { model: "gpt-5.4", messages: [] },
+        attemptOptions,
+      );
+
+      expect(response.status).toBe(400);
+      expect(await response.text()).toBe("bad request");
+      expect(attempts.length).toBe(1);
+      expect(attempts[0].responseBodyExcerpt).toBe("bad request");
+    });
+  });
+});


### PR DESCRIPTION
## What

Two parts of CT-2177, as ruled: preserve the provider's stated error reason, and retry transient transport failures inside the model client, bounded and with backoff. Child resume and harness re-delegation are out of scope.

**Provider error preserved.** `src/model/provider-error.ts` is the one representation of a provider-stated failure (`type`, `code`, `message`). Both clients record it as `providerError` on the model attempt record and carry the same three fields in the message of the error the turn fails with, so the turn failure record, the console `turn_failed` event, and the CLI control failure all say what the provider said. Yesterday's payload now reads `service_unavailable_error / server_is_overloaded: Our servers are currently overloaded. Please try again later.` It is read from an in-stream `error` event, a failed terminal `response`, and a non-2xx body alike. Credential values are redacted from it on the Codex path as everything else is.

**Bounded transport retry.** `src/model/transport-retry.ts` holds the schedule both clients share: `transportRetries` attempts beyond the first (default 3), backoff of `transportRetryDelayMs` (default 1s) before the second attempt, doubling after. Three kinds of failure retry, and only these: a transport error (no response, or a stream cut before its terminal event), a 429 or 5xx, and a provider-stated error whose type or code names overload, rate limiting, or a server fault. Every attempt is recorded; an attempt followed by another carries `retry: { kind, delayMs }`. The backoff is waited out through an injected `transportRetryDelay`, so tests drive a retry sequence with a recording delay and no timer.

The single invariant that makes reissuing safe: the retry loop sits inside `complete()`, nothing is returned until an attempt reaches a completed terminal response, and whatever a failed attempt streamed (tool calls included) is discarded with it. So no tool call is ever dispatched from an attempt that did not complete.

A Codex `429` is the subscription usage limit, which backoff does not clear; it stays in the transient set because the same status is a transient rate limit on the gateway, and the Codex retry is bounded by the same schedule.

The gateway client's `chatCompletionTransportRetries` / `chatCompletionRetryDelayMs` options are renamed to the shared `transportRetries` / `transportRetryDelayMs` (no production caller set them). The gateway now also retries 429/5xx, which it did not before.

## Docs

`packages/cf-harness/README.md` gains "Model attempts and transport retry"; `docs/OPENAI_CODEX_PROTOCOL.md` and `docs/plans/cf-harness-codex-subscription-auth.md` no longer say retries are unimplemented or deferred.

## Tests and what each guards

- `test/provider-error.test.ts`: the provider error is read from nested and top-level shapes without mistaking the event `type` for the error type; an error with no message is not invented; transient classification keys off type/code only; 429 and 5xx are the transient statuses.
- `test/transport-retry.test.ts`: the schedule's bound and doubling backoff; `abortableDelay` resolves on its timer (under `FakeTime`) and rejects with the abort reason. For the Codex client: a transient error event is reissued with the reason and `retry` recorded on the failed attempt; exhaustion throws the provider's reason with every attempt recorded; a non-transient error event, a 4xx, and a malformed stream are not reissued; a transient `response.failed`, a 5xx, a transport error, and a truncated stream are; an abort during the backoff rejects with its reason and issues nothing more; credential values are redacted from the reason. For the gateway client: 5xx and 429 are reissued with the body's reason recorded, 400 is not, exhaustion throws the final body, and the raw `createChatCompletion` still hands back a readable non-2xx body.
- Existing Codex and gateway tests that exercise a failure path now pin `transportRetries: 0`, so they state a single attempt rather than inherit one. The custody test in `prompt-loop-external-skill-acquisition.test.ts` scripts fetch by request index, so it now builds its gateway client with no retries.

## Checks

`deno fmt --check`, `deno lint`, `deno task check`, and the `packages/cf-harness` suite run outside the agent sandbox.

Linear-issue: Fixes CT-2177
Linear-issue-url: https://linear.app/common-tools/issue/CT-2177/provider-stream-errors-fail-hard-at-every-layer-no-transport-retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)
