### PR TITLE
feat(shuttle): the place value and the module that owns it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ Common Fabric product.
 2. System: schema-generator, iframe-sandbox, ts-transformers, js-compiler
 3. Capabilities: piece, html, llm, navigation
 4. Operation: background-piece-service, cf-harness, cli, connectors, fuse,
-   state-inspector
+   shuttle, state-inspector
 5. Deployed Product: toolshed, shell, lib-shell, runtime-client
 6. User Interface: ui
 7. End-User Programs: home-schemas, patterns

--- a/docs/plans/shuttle/README.md
+++ b/docs/plans/shuttle/README.md
@@ -173,8 +173,10 @@ invisible, the prompt renders the whole ambient record — place and scope
     suffix on an operand overrides the ambient scope for that operand. All
     three scope words are canonical, and a suffix on a reference is
     verified against the canonical parser; a scope-only `@scope` is
-    shuttle navigation syntax that only `cd` and `where` accept, alongside
-    `..` and `-`. A suffix names the base scope or the reading identity's own
+    shuttle navigation syntax, accepted by `cd` and `where` and printed by
+    `pwd`, and it sits alongside `/`, `..` and `-`, the other spellings
+    `cd` takes and the canonical grammar does not parse. A suffix names the
+    base scope or the reading identity's own
     overlays, never another identity's; standing in another identity's
     overlay is a canonical-grammar extension, out of v1.
 21. **The native tool set v0 is ruled and deferred** with decision 16's
@@ -261,9 +263,9 @@ The ambient context is one record:
   inside it) and scope.
 - **External working location**, **invocation session**.
 
-`cd` accepts relative path segments, `..`, rooted and complete canonical
-references, slugs, wish targets, and scope suffixes (space names join
-when multi-space sessions do). Every
+`cd` accepts relative path segments, `..`, `-`, `/`, rooted and complete
+canonical references, slugs, wish targets, and scope suffixes (space names
+join when multi-space sessions do). Every
 reference a command takes resolves against the cwd, and how much of the
 cwd it needs varies: a rooted `/of:…` fixes the piece and path but still
 draws its space from the place, so only a complete

--- a/docs/plans/shuttle/README.md
+++ b/docs/plans/shuttle/README.md
@@ -272,9 +272,10 @@ space that name resolved to, which is refused when that is not the
 connected space. A space name as an operand of its own joins when
 multi-space sessions do. Every
 reference a command takes resolves against the cwd, and how much of the
-cwd it needs varies: a rooted `/of:…` fixes the piece and path but still
-draws its space from the place, so only a complete
-`/@did:key:…/of:…` names its cell from anywhere
+cwd it needs varies: a rooted `/of:…` fixes the piece and path but draws
+its space and its scope from the place, a complete `/@did:key:…/of:…`
+carries the space and still draws the scope, and only a fully qualified
+`/@did:key:…/of:…@scope` names its cell from anywhere
 ([`grammar.md`](grammar.md)). The place is result-rooted — `cd` refuses a
 reference carrying `#argument`, and arguments are reached per operand. The
 prompt renders position and scope compactly (an elided alias is checked

--- a/docs/plans/shuttle/README.md
+++ b/docs/plans/shuttle/README.md
@@ -264,8 +264,13 @@ The ambient context is one record:
 - **External working location**, **invocation session**.
 
 `cd` accepts relative path segments, `..`, `-`, `/`, rooted and complete
-canonical references, slugs, wish targets, and scope suffixes (space names
-join when multi-space sessions do). Every
+canonical references, slugs, wish targets, and scope suffixes. A space
+named by name inside a reference is accepted and settled in two steps,
+since deriving a DID from a name needs a session: the move comes back
+carrying the name, and landing it means handing it over again with the
+space that name resolved to, which is refused when that is not the
+connected space. A space name as an operand of its own joins when
+multi-space sessions do. Every
 reference a command takes resolves against the cwd, and how much of the
 cwd it needs varies: a rooted `/of:…` fixes the piece and path but still
 draws its space from the place, so only a complete

--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -129,7 +129,8 @@ Landed:
   relative segments, `..`, `-`, `/`, a scope-only `@scope`, and rooted and
   complete references; the `slugs/` and `pieces/` facets a space root
   reserves, and nothing else there; the rendering `pwd` prints of both
-  halves; and the refusals — a reference carrying `#argument`, a `#`
+  halves, the position line carrying the scope so that it denotes one cell
+  wherever it is read; and the refusals — a reference carrying `#argument`, a `#`
   buried in a bare piece id, a part no rendering would name back, and a
   move into a space other than the connected one, which is the gate a
   home-anchored entry point meets once resolution hands it a space. Two
@@ -172,12 +173,24 @@ Still to come:
   milestones add their dimensions to it as they add the dimensions
   themselves. It prints the record `pwd` prints, so it chooses the format
   for both — a test helper reads that format back by slicing a label
-  width, which is what a change to it has to move with. The format's own
-  hazards belong with it: a newline in a part is refused before it reaches
+  width, which is what a change to it has to move with. `pwd` is complete
+  and has no short form, the prompt being the short surface, so a format
+  that shortens has to stay pasteable — and decision 13's shortened-id
+  fallback is a prefix spelled exactly like a whole handle, which is the
+  part that does not. The format's own hazards belong with it: a newline in a part is refused before it reaches
   a place, because it would leave a shorter reference naming another cell,
   while a carriage return, a vertical tab, a form feed, a no-break space
   and the Unicode line and paragraph separators all read back whole and
   reach only a terminal.
+- **A dormant grammar concern.** `@` carries two meanings in one form: the
+  space slot of a reference and the scope suffix on a piece. `@user` alone
+  is the scope word, `/@user/<handle>` is a space *named* user, and
+  `/@user/<handle>@session` is both at once — and space names are
+  unvalidated, so the collision is live rather than hypothetical. Shuttle
+  cannot resolve it: decision 13 forbids inventing a spelling, and a second
+  scope spelling would be worse than the ambiguity. In v1 a space named by
+  name is refused unless it resolves to the connected space, which is what
+  keeps it dormant; multi-space sessions are where it wakes.
 - **Liveness, in two halves.** The held controller is memoized
   cf-harness-style, which covers the construction that never succeeds —
   the case that cache actually addresses. Recovery of an *established*

--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -116,42 +116,48 @@ leaves `coverage-debt: packages/shuttle`, a metric group the gate
 derives from the path with no allowlist, at zero, so B1 lands its code
 and the tests covering it together.
 
-**B1 — walking skeleton** (after A1; A2 for nothing yet). Open, and landing
-in slices. In, as `packages/shuttle/src/place.ts`: the pair itself, `cd` over
-relative segments, `..`, `-`, `/`, a scope-only `@scope`, and rooted and
-complete references; the `slugs/` and `pieces/` facets a space root reserves;
-what `pwd` prints of both halves; and the refusals — a reference carrying
-`#argument`, a `#` buried in a bare piece id, and a move into a space other
-than the connected one, which is the gate a home-anchored entry point meets
-once resolution hands it a space.
-Still to come: the prompt, the readline loop, the verbs over a held
-controller, wish and slug resolution, `where`, and both halves of liveness.
-The place value and its owner module — the whole pair, position *and*
-scope, because scope is half of what a place is (decision 20):
-`cd @user` and `cd @space` move it, the prompt renders it, and `pwd`
-prints both halves. The prompt, a readline loop, and `cd` / `ls` / `pwd`
-/ `get` over one held `PiecesController`, with `cd -` for the previous
-place and `#name` wish targets navigable within the connected space
-(`cd #favorites`, and the `wish` verb, over the `./lib/wish` export
-entry A1 adds; a home-anchored target from elsewhere is refused with the
-reason — decision 5). Slug and name resolution rides the machinery
-`--piece` already uses (`resolveStoredPieceAddress`, `listSpaceSlugs`),
-so no CLI-surface arc step gates B1. `where` lands here as the printing
-surface for the ambient record; later milestones add their dimensions to
-it as they add the dimensions themselves. Facets `slugs/` and `pieces/`
-only.
+**B1 — walking skeleton** (after A1; A2 for nothing yet). Landing in
+slices, and open until the last of them lands. Each slice moves what it
+built into the first list.
 
-Liveness, in two halves. The held controller is memoized cf-harness-style,
-which covers the construction that never succeeds — the case that cache
-actually addresses. Recovery of an *established* connection needs nothing
-from shuttle: the memory client reconnects and re-arms its watches by
-itself ([`runtime-integration.md`](runtime-integration.md)), so B1 proves
-that rather than rebuilding it — a test that drops the transport under a
-standing watch and shows the subscription still delivering afterwards. What
-B1 does build is the observation seam, reporting live, reconnecting, and
-permanently failed, because no such surface exists today and both the
-prompt and the view markers consume it. No retry loop in shuttle on either
-half.
+Landed:
+
+- **B1a — the place value and its owner module**
+  (`packages/shuttle/src/place.ts`). The whole pair, position *and* scope,
+  because scope is half of what a place is (decision 20): `cd` over
+  relative segments, `..`, `-`, `/`, a scope-only `@scope`, and rooted and
+  complete references; the `slugs/` and `pieces/` facets a space root
+  reserves, and nothing else there; the rendering `pwd` prints of both
+  halves; and the refusals — a reference carrying `#argument`, a `#`
+  buried in a bare piece id, and a move into a space other than the
+  connected one, which is the gate a home-anchored entry point meets once
+  resolution hands it a space.
+
+Still to come:
+
+- **The prompt, a readline loop, and the verbs** — `cd` / `ls` / `pwd` /
+  `get` over one held `PiecesController`, with `#name` wish targets
+  navigable within the connected space (`cd #favorites`, and the `wish`
+  verb, over the `./lib/wish` export entry A1 adds; a home-anchored target
+  from elsewhere is refused with the reason — decision 5).
+- **Slug and name resolution**, riding the machinery `--cell` already uses
+  (`resolveStoredPieceAddress`, `listSpaceSlugs`), so no CLI-surface arc
+  step gates B1.
+- **`where`**, the printing surface for the ambient record; later
+  milestones add their dimensions to it as they add the dimensions
+  themselves.
+- **Liveness, in two halves.** The held controller is memoized
+  cf-harness-style, which covers the construction that never succeeds —
+  the case that cache actually addresses. Recovery of an *established*
+  connection needs nothing from shuttle: the memory client reconnects and
+  re-arms its watches by itself
+  ([`runtime-integration.md`](runtime-integration.md)), so B1 proves that
+  rather than rebuilding it — a test that drops the transport under a
+  standing watch and shows the subscription still delivering afterwards.
+  What B1 does build is the observation seam, reporting live,
+  reconnecting, and permanently failed, because no such surface exists
+  today and both the prompt and the view markers consume it. No retry loop
+  in shuttle on either half.
 
 **B2 — writes, calls, handles** (after A2, A3, and A4 — a failed call or
 write must surface as a value, never reach `Deno.exit`). `set` with

--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -15,7 +15,8 @@ prerequisites land.
 **A1 — export entries.** Done (#6626). Importing `@commonfabric/cli`'s `.`
 entry runs CLI startup, so the package carries workspace-internal entries
 for the modules a sibling calls: `./lib/piece`, `./commands/piece`,
-`./lib/wish`, `./lib/piece-render`. The completion listing is not a plain
+`./lib/wish`, `./lib/piece-render`, and `./lib/llm-friendly-ref`, which a
+place reads every reference operand through. The completion listing is not a plain
 entry: it is `listCellKeys` in `packages/cli/lib/cell-listing.ts`,
 exported as `./lib/cell-listing` behind a `PieceResolutionDeps` seam with
 `keysOf` beside it. The providers are designed to fail silently and
@@ -144,12 +145,16 @@ Still to come:
   (`resolveStoredPieceAddress`, `listSpaceSlugs`), so no CLI-surface arc
   step gates B1.
 - **The vocabulary a relative segment speaks.** A relative operand splits
-  on `/` and its segments are literal, so a key holding the separator has
-  no relative spelling, and the reference grammar's `~1` escaping reaches
-  a reference and not a walk. `ls` settles it: how such a key prints and
-  how it is typed back want deciding together. Segment validation is the
-  same question — a slug's vocabulary holds a reference and not a relative
-  segment.
+  on `/` and its segments are literal, so three characters read differently
+  in a key depending on the door. A key holding the separator has no
+  relative spelling, and a segment lifted out of a rendering reads as a
+  different key without saying so — the one half that misleads. A leading
+  `@` reads as a scope word, and a `#` anywhere in the path makes the whole
+  rendering a reference `cd` refuses; both stop a reader rather than moving
+  one, and both leave the key reachable by its rooted spelling. `ls`
+  settles all three: how such a key prints and how it is typed back want
+  deciding together. Segment validation is the same question — a slug's
+  vocabulary holds a reference and not a relative segment.
 - **`where`**, the printing surface for the ambient record; later
   milestones add their dimensions to it as they add the dimensions
   themselves.

--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -118,11 +118,12 @@ and the tests covering it together.
 
 **B1 — walking skeleton** (after A1; A2 for nothing yet). Open, and landing
 in slices. In, as `packages/shuttle/src/place.ts`: the pair itself, `cd` over
-relative segments, `..`, `-`, a scope-only `@scope`, and rooted and complete
-references; the `slugs/` and `pieces/` facets a space root reserves; what
-`pwd` prints of both halves; and the refusals — a reference carrying
-`#argument`, and a move into a space other than the connected one, which is
-the gate a home-anchored entry point meets once resolution hands it a space.
+relative segments, `..`, `-`, `/`, a scope-only `@scope`, and rooted and
+complete references; the `slugs/` and `pieces/` facets a space root reserves;
+what `pwd` prints of both halves; and the refusals — a reference carrying
+`#argument`, a `#` buried in a bare piece id, and a move into a space other
+than the connected one, which is the gate a home-anchored entry point meets
+once resolution hands it a space.
 Still to come: the prompt, the readline loop, the verbs over a held
 controller, wish and slug resolution, `where`, and both halves of liveness.
 The place value and its owner module — the whole pair, position *and*

--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -175,9 +175,9 @@ Still to come:
   because a rendering of it would name a different cell. A piece is held to
   more than that: one holding a line break is refused for the same reason,
   and one that is empty, ends in whitespace, or holds an `@` is refused
-  because no slug or handle carries such a name — the parse would take it,
-  since its handle test is a length rule, and hand back a name nothing could
-  have produced.
+  because no slug or handle carries such a name.
+  [`grammar.md`](grammar.md) carries why that reason holds, and which of
+  those the canonical parse would take anyway.
 - **`where`** (B1c), the printing surface for the ambient record; later
   milestones add their dimensions to it as they add the dimensions themselves.
   It prints the record `pwd` prints, so it chooses the format for both — a

--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -130,18 +130,25 @@ Landed:
   complete references; the `slugs/` and `pieces/` facets a space root
   reserves, and nothing else there; the rendering `pwd` prints of both
   halves; and the refusals — a reference carrying `#argument`, a `#`
-  buried in a bare piece id, and a move into a space other than the
-  connected one, which is the gate a home-anchored entry point meets once
-  resolution hands it a space.
+  buried in a bare piece id, a part no rendering would name back, and a
+  move into a space other than the connected one, which is the gate a
+  home-anchored entry point meets once resolution hands it a space. Two
+  operands come back for the connection rather than moving: a `#name` wish
+  target, which B1b resolves, and a reference naming its space by name,
+  which is a two-step protocol — the caller resolves the name and hands the
+  move back with the space it resolved to, and the place is landed or
+  refused there.
 
 Still to come:
 
-- **The prompt, a readline loop, and the verbs** — `cd` / `ls` / `pwd` /
-  `get` over one held `PiecesController`, with `#name` wish targets
+- **The prompt, a readline loop, and the verbs** (B1b for the verbs and
+  the connection, B1c for the prompt) — `cd` / `ls` / `pwd` / `get` over
+  one held `PiecesController`, with `#name` wish targets
   navigable within the connected space (`cd #favorites`, and the `wish`
   verb, over the `./lib/wish` export entry A1 adds; a home-anchored target
   from elsewhere is refused with the reason — decision 5).
-- **Slug and name resolution**, riding the machinery `--cell` already uses
+- **Slug and name resolution** (B1b), riding the machinery `--cell` already
+  uses
   (`resolveStoredPieceAddress`, `listSpaceSlugs`), so no CLI-surface arc
   step gates B1.
 - **The vocabulary a relative segment speaks.** The two doors read a
@@ -153,21 +160,24 @@ Still to come:
   what each lifted segment does instead of naming its key, is pinned case
   by case in `packages/shuttle/test/place.test.ts`, each case under a
   mutation, so the record moves when the behavior does and not otherwise.
-  `ls` settles it: how such a key prints and how it is typed back want
-  deciding together. Segment validation is the same question, across three
+  `ls` settles it, in B1b: how such a key prints and how it is typed back
+  want deciding together. Segment validation is the same question, across three
   doors rather than two — a slug's vocabulary holds a reference, and
   neither a relative segment nor a resolved target is held to it. What is
-  settled is narrower: a segment no rendering would name back — empty,
-  ending in whitespace, or holding a line break — is refused at every door,
-  which leaves those keys with no spelling rather than one that prints as a
-  different cell.
-- **`where`**, the printing surface for the ambient record; later
+  settled is narrower: a part no rendering would name back — empty, ending
+  in whitespace, holding a line break, or, for a piece, holding an `@` —
+  is refused at every door, which leaves those names with no spelling
+  rather than one that prints as a different cell.
+- **`where`** (B1c), the printing surface for the ambient record; later
   milestones add their dimensions to it as they add the dimensions
   themselves. It prints the record `pwd` prints, so it chooses the format
   for both — a test helper reads that format back by slicing a label
-  width, which is what a change to it has to move with, and a key holding a
-  newline splits the two lines the format prints while leaving the
-  reference inside them intact.
+  width, which is what a change to it has to move with. The format's own
+  hazards belong with it: a newline in a part is refused before it reaches
+  a place, because it would leave a shorter reference naming another cell,
+  while a carriage return, a vertical tab, a form feed, a no-break space
+  and the Unicode line and paragraph separators all read back whole and
+  reach only a terminal.
 - **Liveness, in two halves.** The held controller is memoized
   cf-harness-style, which covers the construction that never succeeds —
   the case that cache actually addresses. Recovery of an *established*

--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -145,16 +145,14 @@ Still to come:
   (`resolveStoredPieceAddress`, `listSpaceSlugs`), so no CLI-surface arc
   step gates B1.
 - **The vocabulary a relative segment speaks.** The two doors read a
-  segment by different rules, so a handful of keys are spelled through one
-  and not the other. Which keys follows from where each reading is decided,
-  the rule [`grammar.md`](grammar.md) states: a relative operand reserves
-  `-`, `@scope`, `/` and a leading `#` at its head alone and `..` in every
-  segment, and takes every other segment literally, where a reference
-  unescapes `~1` and reserves `#` for `#argument` throughout. So a key
-  named `..`, and one holding the separator, are rooted-only, while a key
-  holding `#` is relative-only. What that costs a reader is the segment
-  lifted out of a rendering: `..`, `-`, and an escaped separator each move
-  somewhere else without saying so, where `@` refuses and `#` hands off.
+  segment by different rules — the reserved readings
+  [`grammar.md`](grammar.md) states, against a reference's own unescaping
+  and fragment rule — so some keys are spelled through one door and not the
+  other, and a segment lifted out of a rendering is an operand in its own
+  right rather than the key it was printed from. Which keys those are, and
+  what each lifted segment does instead of naming its key, is pinned case
+  by case in `packages/shuttle/test/place.test.ts`, each case under a
+  mutation, so the record moves when the behavior does and not otherwise.
   `ls` settles it: how such a key prints and how it is typed back want
   deciding together. Segment validation is the same question — a slug's
   vocabulary holds a reference and not a relative segment — and an empty

--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -157,9 +157,10 @@ Still to come:
   deciding together. Segment validation is the same question, across three
   doors rather than two — a slug's vocabulary holds a reference, and
   neither a relative segment nor a resolved target is held to it. What is
-  settled is narrower: a segment no rendering would name back, empty or
-  padded with whitespace, is refused at every door, which leaves those keys
-  with no spelling rather than one that prints as a different cell.
+  settled is narrower: a segment no rendering would name back — empty,
+  ending in whitespace, or holding a line break — is refused at every door,
+  which leaves those keys with no spelling rather than one that prints as a
+  different cell.
 - **`where`**, the printing surface for the ambient record; later
   milestones add their dimensions to it as they add the dimensions
   themselves. It prints the record `pwd` prints, so it chooses the format

--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -116,20 +116,29 @@ leaves `coverage-debt: packages/shuttle`, a metric group the gate
 derives from the path with no allowlist, at zero, so B1 lands its code
 and the tests covering it together.
 
-**B1 — walking skeleton** (after A1; A2 for nothing yet). The place value
-and its owner module — the whole pair, position *and* scope, because scope
-is half of what a place is (decision 20): `cd @user` and `cd @space` move
-it, the prompt renders it, and `pwd` prints both halves. The prompt, a
-readline loop, and `cd` / `ls` / `pwd` / `get` over one held
-`PiecesController`, with `cd -` for the previous place and `#name` wish
-targets navigable within the connected space (`cd #favorites`, and the
-`wish` verb, over the `./lib/wish` export entry A1 adds; a home-anchored
-target from elsewhere is refused with the reason — decision 5). Slug and
-name resolution rides the machinery `--piece` already uses
-(`resolveStoredPieceAddress`, `listSpaceSlugs`), so no CLI-surface arc
-step gates B1. `where` lands here as the printing
-surface for the ambient record; later milestones add their dimensions to it
-as they add the dimensions themselves. Facets `slugs/` and `pieces/` only.
+**B1 — walking skeleton** (after A1; A2 for nothing yet). Open, and landing
+in slices. In, as `packages/shuttle/src/place.ts`: the pair itself, `cd` over
+relative segments, `..`, `-`, a scope-only `@scope`, and rooted and complete
+references; the `slugs/` and `pieces/` facets a space root reserves; what
+`pwd` prints of both halves; and the refusals — a reference carrying
+`#argument`, and a move into a space other than the connected one, which is
+the gate a home-anchored entry point meets once resolution hands it a space.
+Still to come: the prompt, the readline loop, the verbs over a held
+controller, wish and slug resolution, `where`, and both halves of liveness.
+The place value and its owner module — the whole pair, position *and*
+scope, because scope is half of what a place is (decision 20):
+`cd @user` and `cd @space` move it, the prompt renders it, and `pwd`
+prints both halves. The prompt, a readline loop, and `cd` / `ls` / `pwd`
+/ `get` over one held `PiecesController`, with `cd -` for the previous
+place and `#name` wish targets navigable within the connected space
+(`cd #favorites`, and the `wish` verb, over the `./lib/wish` export
+entry A1 adds; a home-anchored target from elsewhere is refused with the
+reason — decision 5). Slug and name resolution rides the machinery
+`--piece` already uses (`resolveStoredPieceAddress`, `listSpaceSlugs`),
+so no CLI-surface arc step gates B1. `where` lands here as the printing
+surface for the ambient record; later milestones add their dimensions to
+it as they add the dimensions themselves. Facets `slugs/` and `pieces/`
+only.
 
 Liveness, in two halves. The held controller is memoized cf-harness-style,
 which covers the construction that never succeeds — the case that cache

--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -143,6 +143,13 @@ Still to come:
 - **Slug and name resolution**, riding the machinery `--cell` already uses
   (`resolveStoredPieceAddress`, `listSpaceSlugs`), so no CLI-surface arc
   step gates B1.
+- **The vocabulary a relative segment speaks.** A relative operand splits
+  on `/` and its segments are literal, so a key holding the separator has
+  no relative spelling, and the reference grammar's `~1` escaping reaches
+  a reference and not a walk. `ls` settles it: how such a key prints and
+  how it is typed back want deciding together. Segment validation is the
+  same question — a slug's vocabulary holds a reference and not a relative
+  segment.
 - **`where`**, the printing surface for the ambient record; later
   milestones add their dimensions to it as they add the dimensions
   themselves.

--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -125,20 +125,20 @@ built into the first list.
 Landed:
 
 - **B1a — the place value and its owner module**
-(`packages/shuttle/src/place.ts`). The whole pair, position *and* scope,
-because scope is half of what a place is (decision 20): `cd` over relative
-segments, `..`, `-`, `/`, a scope-only `@scope`, and rooted and complete
-references; the `slugs/` and `pieces/` facets a space root reserves, and
-nothing else there; the rendering `pwd` prints of both halves, the position
-line carrying the scope so that it denotes one cell wherever it is read; and
-the refusals — a reference carrying `#argument`, a `#` buried in a bare
-piece id, a part no rendering would name back, and a move into a space other
-than the connected one, which is the gate a home-anchored entry point meets
-once resolution hands it a space. Two operands come back for the connection
-rather than moving: a `#name` wish target, which B1b resolves, and a
-reference naming its space by name, which is a two-step protocol — the
-caller resolves the name and hands the move back with the space it resolved
-to, and the place is landed or refused there.
+  (`packages/shuttle/src/place.ts`). The whole pair, position *and* scope,
+  because scope is half of what a place is (decision 20): `cd` over relative
+  segments, `..`, `-`, `/`, a scope-only `@scope`, and rooted and complete
+  references; the `slugs/` and `pieces/` facets a space root reserves, and
+  nothing else there; the rendering `pwd` prints of both halves, the position
+  line carrying the scope so that it denotes one cell wherever it is read; and
+  the refusals — a reference carrying `#argument`, a `#` buried in a bare
+  piece id, a part no rendering would name back, and a move into a space other
+  than the connected one, which is the gate a home-anchored entry point meets
+  once resolution hands it a space. Two operands come back for the connection
+  rather than moving: a `#name` wish target, which B1b resolves, and a
+  reference naming its space by name, which is a two-step protocol — the
+  caller resolves the name and hands the move back with the space it resolved
+  to, and the place is landed or refused there.
 
 Still to come:
 
@@ -152,40 +152,45 @@ Still to come:
   uses
   (`resolveStoredPieceAddress`, `listSpaceSlugs`), so no CLI-surface arc
   step gates B1.
-- **The vocabulary a relative segment speaks.** The two doors read a
-  segment by different rules — the reserved readings
+- **The vocabulary a relative segment speaks.** The walk and a reference
+  read a segment by different rules — the reserved readings
   [`grammar.md`](grammar.md) states, against a reference's own unescaping
-  and fragment rule — so some keys are spelled through one door and not the
+  and fragment rule — so some keys are spelled through one and not the
   other, and a segment lifted out of a rendering is an operand in its own
   right rather than the key it was printed from. Which keys those are, and
   what each lifted segment does instead of naming its key, is pinned case
   by case in `packages/shuttle/test/place.test.ts`, each case under a
   mutation, so the record moves when the behavior does and not otherwise.
   `ls` settles it, in B1b: how such a key prints and how it is typed back
-  want deciding together. Segment validation is the same question, across three
-  doors rather than two — a slug's vocabulary holds a reference, and
-  neither a relative segment nor a resolved target is held to it. What is
-  settled is narrower, and in two parts. A path segment that is empty, ends
-  in whitespace, or holds a line break is refused at every door, because a
-  rendering of it would name a different cell. A piece is held to more than
-  that: one holding a line break is refused for the same reason, and one
-  that is empty, ends in whitespace, or holds an `@` is refused because no
-  slug or handle carries such a name — the parse would take it, since its
-  handle test is a length rule, and hand back a name nothing could have
-  produced.
+  want deciding together.
+
+  Whether a piece is held to the slug and handle vocabularies is the same
+  question, and its answer is a rule rather than a count: a piece is held
+  where it passes through the canonical parse, and nowhere else. A reference
+  is held that way, and a settled move inherits it, the arm being minted
+  from a parsed reference; every other way in admits a piece the fabric
+  would not name, an arm a caller assembles rather than receives included.
+  What is settled is narrower, and in two parts. A path segment that is
+  empty, ends in whitespace, or holds a line break is refused at every door,
+  because a rendering of it would name a different cell. A piece is held to
+  more than that: one holding a line break is refused for the same reason,
+  and one that is empty, ends in whitespace, or holds an `@` is refused
+  because no slug or handle carries such a name — the parse would take it,
+  since its handle test is a length rule, and hand back a name nothing could
+  have produced.
 - **`where`** (B1c), the printing surface for the ambient record; later
-milestones add their dimensions to it as they add the dimensions themselves.
-It prints the record `pwd` prints, so it chooses the format for both — a
-test helper reads that format back by slicing a label width, which is what a
-change to it has to move with. `pwd` is complete and has no short form, the
-prompt being the short surface, so a format that shortens has to stay
-pasteable — and decision 13's shortened-id fallback is a prefix spelled
-exactly like a whole handle, which is the part that does not. The format's
-own hazards belong with it: a newline in a part is refused before it reaches
-a place, because it would leave a shorter reference naming another cell,
-while a carriage return, a vertical tab, a form feed, a no-break space and
-the Unicode line and paragraph separators all read back whole and reach only
-a terminal.
+  milestones add their dimensions to it as they add the dimensions themselves.
+  It prints the record `pwd` prints, so it chooses the format for both — a
+  test helper reads that format back by slicing a label width, which is what a
+  change to it has to move with. `pwd` is complete and has no short form, the
+  prompt being the short surface, so a format that shortens has to stay
+  pasteable — and decision 13's shortened-id fallback is a prefix spelled
+  exactly like a whole handle, which is the part that does not. The format's
+  own hazards belong with it: a newline in a part is refused before it reaches
+  a place, because it would leave a shorter reference naming another cell,
+  while a carriage return, a vertical tab, a form feed, a no-break space and
+  the Unicode line and paragraph separators all read back whole and reach only
+  a terminal.
 - **Liveness, in two halves.** The held controller is memoized
   cf-harness-style, which covers the construction that never succeeds —
   the case that cache actually addresses. Recovery of an *established*

--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -16,7 +16,8 @@ prerequisites land.
 entry runs CLI startup, so the package carries workspace-internal entries
 for the modules a sibling calls: `./lib/piece`, `./commands/piece`,
 `./lib/wish`, `./lib/piece-render`, and `./lib/llm-friendly-ref`, which a
-place reads every reference operand through. The completion listing is not a plain
+place reads every reference operand through. The completion listing is not a
+plain
 entry: it is `listCellKeys` in `packages/cli/lib/cell-listing.ts`,
 exported as `./lib/cell-listing` behind a `PieceResolutionDeps` seam with
 `keysOf` beside it. The providers are designed to fail silently and
@@ -124,21 +125,20 @@ built into the first list.
 Landed:
 
 - **B1a — the place value and its owner module**
-  (`packages/shuttle/src/place.ts`). The whole pair, position *and* scope,
-  because scope is half of what a place is (decision 20): `cd` over
-  relative segments, `..`, `-`, `/`, a scope-only `@scope`, and rooted and
-  complete references; the `slugs/` and `pieces/` facets a space root
-  reserves, and nothing else there; the rendering `pwd` prints of both
-  halves, the position line carrying the scope so that it denotes one cell
-  wherever it is read; and the refusals — a reference carrying `#argument`, a `#`
-  buried in a bare piece id, a part no rendering would name back, and a
-  move into a space other than the connected one, which is the gate a
-  home-anchored entry point meets once resolution hands it a space. Two
-  operands come back for the connection rather than moving: a `#name` wish
-  target, which B1b resolves, and a reference naming its space by name,
-  which is a two-step protocol — the caller resolves the name and hands the
-  move back with the space it resolved to, and the place is landed or
-  refused there.
+(`packages/shuttle/src/place.ts`). The whole pair, position *and* scope,
+because scope is half of what a place is (decision 20): `cd` over relative
+segments, `..`, `-`, `/`, a scope-only `@scope`, and rooted and complete
+references; the `slugs/` and `pieces/` facets a space root reserves, and
+nothing else there; the rendering `pwd` prints of both halves, the position
+line carrying the scope so that it denotes one cell wherever it is read; and
+the refusals — a reference carrying `#argument`, a `#` buried in a bare
+piece id, a part no rendering would name back, and a move into a space other
+than the connected one, which is the gate a home-anchored entry point meets
+once resolution hands it a space. Two operands come back for the connection
+rather than moving: a `#name` wish target, which B1b resolves, and a
+reference naming its space by name, which is a two-step protocol — the
+caller resolves the name and hands the move back with the space it resolved
+to, and the place is landed or refused there.
 
 Still to come:
 
@@ -170,27 +170,29 @@ Still to come:
   is refused at every door, which leaves those names with no spelling
   rather than one that prints as a different cell.
 - **`where`** (B1c), the printing surface for the ambient record; later
-  milestones add their dimensions to it as they add the dimensions
-  themselves. It prints the record `pwd` prints, so it chooses the format
-  for both — a test helper reads that format back by slicing a label
-  width, which is what a change to it has to move with. `pwd` is complete
-  and has no short form, the prompt being the short surface, so a format
-  that shortens has to stay pasteable — and decision 13's shortened-id
-  fallback is a prefix spelled exactly like a whole handle, which is the
-  part that does not. The format's own hazards belong with it: a newline in a part is refused before it reaches
-  a place, because it would leave a shorter reference naming another cell,
-  while a carriage return, a vertical tab, a form feed, a no-break space
-  and the Unicode line and paragraph separators all read back whole and
-  reach only a terminal.
+milestones add their dimensions to it as they add the dimensions themselves.
+It prints the record `pwd` prints, so it chooses the format for both — a
+test helper reads that format back by slicing a label width, which is what a
+change to it has to move with. `pwd` is complete and has no short form, the
+prompt being the short surface, so a format that shortens has to stay
+pasteable — and decision 13's shortened-id fallback is a prefix spelled
+exactly like a whole handle, which is the part that does not. The format's
+own hazards belong with it: a newline in a part is refused before it reaches
+a place, because it would leave a shorter reference naming another cell,
+while a carriage return, a vertical tab, a form feed, a no-break space and
+the Unicode line and paragraph separators all read back whole and reach only
+a terminal.
 - **A dormant grammar concern.** `@` carries two meanings in one form: the
-  space slot of a reference and the scope suffix on a piece. `@user` alone
-  is the scope word, `/@user/<handle>` is a space *named* user, and
-  `/@user/<handle>@session` is both at once — and space names are
-  unvalidated, so the collision is live rather than hypothetical. Shuttle
-  cannot resolve it: decision 13 forbids inventing a spelling, and a second
-  scope spelling would be worse than the ambiguity. In v1 a space named by
-  name is refused unless it resolves to the connected space, which is what
-  keeps it dormant; multi-space sessions are where it wakes.
+space slot of a reference and the scope suffix on a piece. `@user` alone is
+the scope word, `/@user/<handle>` is a space *named* user, and
+`/@user/<handle>@session` is both at once — and space names are unvalidated,
+so the collision is live rather than hypothetical. Shuttle cannot resolve
+it: decision 13 forbids inventing a spelling, and a second scope spelling
+would be worse than the ambiguity. Issue
+[#6775](https://github.com/commontoolsinc/labs/issues/6775) carries it. In
+v1 a space named by name is refused unless it resolves to the connected
+space, which is what keeps it dormant; multi-space sessions are where it
+wakes.
 - **Liveness, in two halves.** The held controller is memoized
   cf-harness-style, which covers the construction that never succeeds —
   the case that cache actually addresses. Recovery of an *established*

--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -144,21 +144,22 @@ Still to come:
 - **Slug and name resolution**, riding the machinery `--cell` already uses
   (`resolveStoredPieceAddress`, `listSpaceSlugs`), so no CLI-surface arc
   step gates B1.
-- **The vocabulary a relative segment speaks.** A relative operand splits
-  on `/` and its segments are literal, so three characters are read
-  differently by the two doors, and each such key is reachable through the
-  door the other refuses. A key holding the separator, and one whose first
-  character is `@`, are reachable rooted and not relatively: `~1` escaping
-  reaches a reference and not a walk, and a leading `@` reads as a scope
-  word. A key holding `#` is the mirror, reachable relatively and not
-  rooted, since the reference grammar reserves `#` for `#argument`. One of
-  the three misleads and the rest refuse: a segment holding the separator,
-  lifted out of a rendering, reads as a different key without saying so.
-  `ls` settles all three: how such a key prints and how it is typed back
-  want deciding together. Segment validation is the same question — a
-  slug's vocabulary holds a reference and not a relative segment, and an
-  empty segment is refused at every door, which leaves the empty key with
-  no spelling rather than one that prints as its parent.
+- **The vocabulary a relative segment speaks.** The two doors read a
+  segment by different rules, so a handful of keys are spelled through one
+  and not the other. Which keys follows from where each reading is decided,
+  the rule [`grammar.md`](grammar.md) states: a relative operand reserves
+  `-`, `@scope`, `/` and a leading `#` at its head alone and `..` in every
+  segment, and takes every other segment literally, where a reference
+  unescapes `~1` and reserves `#` for `#argument` throughout. So a key
+  named `..`, and one holding the separator, are rooted-only, while a key
+  holding `#` is relative-only. What that costs a reader is the segment
+  lifted out of a rendering: `..`, `-`, and an escaped separator each move
+  somewhere else without saying so, where `@` refuses and `#` hands off.
+  `ls` settles it: how such a key prints and how it is typed back want
+  deciding together. Segment validation is the same question — a slug's
+  vocabulary holds a reference and not a relative segment — and an empty
+  segment is refused at every door, which leaves the empty key with no
+  spelling rather than one that prints as its parent.
 - **`where`**, the printing surface for the ambient record; later
   milestones add their dimensions to it as they add the dimensions
   themselves.

--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -156,14 +156,17 @@ Still to come:
   `ls` settles it: how such a key prints and how it is typed back want
   deciding together. Segment validation is the same question, across three
   doors rather than two — a slug's vocabulary holds a reference, and
-  neither a relative segment nor a resolved target is held to it — and an
-  empty segment is refused at every door, which leaves the empty key with
-  no spelling rather than one that prints as its parent.
+  neither a relative segment nor a resolved target is held to it. What is
+  settled is narrower: a segment no rendering would name back, empty or
+  padded with whitespace, is refused at every door, which leaves those keys
+  with no spelling rather than one that prints as a different cell.
 - **`where`**, the printing surface for the ambient record; later
   milestones add their dimensions to it as they add the dimensions
   themselves. It prints the record `pwd` prints, so it chooses the format
   for both — a test helper reads that format back by slicing a label
-  width, which is what a change to it has to move with.
+  width, which is what a change to it has to move with, and a key holding a
+  newline splits the two lines the format prints while leaving the
+  reference inside them intact.
 - **Liveness, in two halves.** The held controller is memoized
   cf-harness-style, which covers the construction that never succeeds —
   the case that cache actually addresses. Recovery of an *established*

--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -145,16 +145,20 @@ Still to come:
   (`resolveStoredPieceAddress`, `listSpaceSlugs`), so no CLI-surface arc
   step gates B1.
 - **The vocabulary a relative segment speaks.** A relative operand splits
-  on `/` and its segments are literal, so three characters read differently
-  in a key depending on the door. A key holding the separator has no
-  relative spelling, and a segment lifted out of a rendering reads as a
-  different key without saying so — the one half that misleads. A leading
-  `@` reads as a scope word, and a `#` anywhere in the path makes the whole
-  rendering a reference `cd` refuses; both stop a reader rather than moving
-  one, and both leave the key reachable by its rooted spelling. `ls`
-  settles all three: how such a key prints and how it is typed back want
-  deciding together. Segment validation is the same question — a slug's
-  vocabulary holds a reference and not a relative segment.
+  on `/` and its segments are literal, so three characters are read
+  differently by the two doors, and each such key is reachable through the
+  door the other refuses. A key holding the separator, and one whose first
+  character is `@`, are reachable rooted and not relatively: `~1` escaping
+  reaches a reference and not a walk, and a leading `@` reads as a scope
+  word. A key holding `#` is the mirror, reachable relatively and not
+  rooted, since the reference grammar reserves `#` for `#argument`. One of
+  the three misleads and the rest refuse: a segment holding the separator,
+  lifted out of a rendering, reads as a different key without saying so.
+  `ls` settles all three: how such a key prints and how it is typed back
+  want deciding together. Segment validation is the same question — a
+  slug's vocabulary holds a reference and not a relative segment, and an
+  empty segment is refused at every door, which leaves the empty key with
+  no spelling rather than one that prints as its parent.
 - **`where`**, the printing surface for the ambient record; later
   milestones add their dimensions to it as they add the dimensions
   themselves.

--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -165,10 +165,14 @@ Still to come:
   want deciding together. Segment validation is the same question, across three
   doors rather than two — a slug's vocabulary holds a reference, and
   neither a relative segment nor a resolved target is held to it. What is
-  settled is narrower: a part no rendering would name back — empty, ending
-  in whitespace, holding a line break, or, for a piece, holding an `@` —
-  is refused at every door, which leaves those names with no spelling
-  rather than one that prints as a different cell.
+  settled is narrower, and in two parts. A path segment that is empty, ends
+  in whitespace, or holds a line break is refused at every door, because a
+  rendering of it would name a different cell. A piece is held to more than
+  that: one holding a line break is refused for the same reason, and one
+  that is empty, ends in whitespace, or holds an `@` is refused because no
+  slug or handle carries such a name — the parse would take it, since its
+  handle test is a length rule, and hand back a name nothing could have
+  produced.
 - **`where`** (B1c), the printing surface for the ambient record; later
 milestones add their dimensions to it as they add the dimensions themselves.
 It prints the record `pwd` prints, so it chooses the format for both — a
@@ -182,17 +186,6 @@ a place, because it would leave a shorter reference naming another cell,
 while a carriage return, a vertical tab, a form feed, a no-break space and
 the Unicode line and paragraph separators all read back whole and reach only
 a terminal.
-- **A dormant grammar concern.** `@` carries two meanings in one form: the
-space slot of a reference and the scope suffix on a piece. `@user` alone is
-the scope word, `/@user/<handle>` is a space *named* user, and
-`/@user/<handle>@session` is both at once — and space names are unvalidated,
-so the collision is live rather than hypothetical. Shuttle cannot resolve
-it: decision 13 forbids inventing a spelling, and a second scope spelling
-would be worse than the ambiguity. Issue
-[#6775](https://github.com/commontoolsinc/labs/issues/6775) carries it. In
-v1 a space named by name is refused unless it resolves to the connected
-space, which is what keeps it dormant; multi-space sessions are where it
-wakes.
 - **Liveness, in two halves.** The held controller is memoized
   cf-harness-style, which covers the construction that never succeeds —
   the case that cache actually addresses. Recovery of an *established*

--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -154,13 +154,16 @@ Still to come:
   by case in `packages/shuttle/test/place.test.ts`, each case under a
   mutation, so the record moves when the behavior does and not otherwise.
   `ls` settles it: how such a key prints and how it is typed back want
-  deciding together. Segment validation is the same question — a slug's
-  vocabulary holds a reference and not a relative segment — and an empty
-  segment is refused at every door, which leaves the empty key with no
-  spelling rather than one that prints as its parent.
+  deciding together. Segment validation is the same question, across three
+  doors rather than two — a slug's vocabulary holds a reference, and
+  neither a relative segment nor a resolved target is held to it — and an
+  empty segment is refused at every door, which leaves the empty key with
+  no spelling rather than one that prints as its parent.
 - **`where`**, the printing surface for the ambient record; later
   milestones add their dimensions to it as they add the dimensions
-  themselves.
+  themselves. It prints the record `pwd` prints, so it chooses the format
+  for both — a test helper reads that format back by slicing a label
+  width, which is what a change to it has to move with.
 - **Liveness, in two halves.** The held controller is memoized
   cf-harness-style, which covers the construction that never succeeds —
   the case that cache actually addresses. Recovery of an *established*

--- a/docs/plans/shuttle/futures.md
+++ b/docs/plans/shuttle/futures.md
@@ -89,6 +89,13 @@ decisions point here where they defer.
   its v1 member, and `set x - < https://…` joins when a use rules it in.
 - **`search`.** A `search <query>` verb at any place, over what stands
   below it. Pipes over `ls` cover the interim.
+- **Which space a piece is in.** Naming the space that holds an arbitrary
+  piece, rather than the one the place stands in. It is a query over the
+  fabric and not a dimension of the ambient record, so it arrives with
+  multi-space sessions (candidate 3) and takes its answer from them. v1
+  refuses to follow a reference into another space — denoting is not
+  reaching ([`grammar.md`](grammar.md)) — so the only space v1 could ever
+  name is the connected one, which `where` already prints.
 
 ## Candidates, ranked
 

--- a/docs/plans/shuttle/grammar.md
+++ b/docs/plans/shuttle/grammar.md
@@ -43,7 +43,9 @@ as the canonical grammar's context rule already works:
   favorites resolve against the reading identity's home space regardless
   of the connected space (`packages/cli/lib/wish.ts`) — is refused with
   the reason in v1, which holds one connection to one space.
-- `..` — up one level; `cd -` — the previous place.
+- `/` — the space's own root, the leading `/` of a rooted reference
+  with nothing following it; `..` — up one level; `cd -` — the
+  previous place.
 - Anything else — relative: resolved as a child of the current position
   (a facet at a space root, a key or index inside a piece, a slug inside
   `slugs/`).
@@ -154,11 +156,13 @@ position levels, and an explicit suffix on an operand overrides it for
 that operand alone.
 
 A scope-only `@scope` is shuttle **navigation syntax**, not a reference. It
-sits with `..` and `-`: spellings that `cd` and `where` accept to move the
-cwd, and that the canonical grammar does not parse. `parseScopedIdSegment`
+sits with `/`, `..` and `-`: spellings that `cd` accepts to move the cwd,
+and that the canonical grammar does not parse. `parseScopedIdSegment`
 (`packages/runner/src/link-types.ts`) requires an id in front of the
-suffix and throws without one, so `@session` alone addresses nothing. The
-no-growth rule holds because the spelling never leaves those two verbs: an
+suffix and throws without one, so `@session` alone addresses nothing, and
+`parseReferenceParts` in the same module throws on a lone `/`, which names
+no piece handle, so the space root has no canonical spelling either. The
+no-growth rule holds because the spelling never leaves `cd` and `where`: an
 operand and a full reference always carry an id, no link endpoint can hold
 a scope-only suffix, and nothing serializes one. Setting the ambient scope
 is all `cd @session` does, and ordinary references pick it up from there.

--- a/docs/plans/shuttle/grammar.md
+++ b/docs/plans/shuttle/grammar.md
@@ -77,33 +77,36 @@ against the operand's head, and each takes the whole operand with it: `cd
 #favorites/topics` hands on the whole string as one target. So each is an
 ordinary data character in every later segment that is data — inside a
 piece. A later segment naming a piece is read by the canonical grammar
-instead, which carries both readings itself, so a scope suffix there moves
-the scope and a fragment there is refused. `..` is matched segment by
+instead, so a scope suffix there moves the scope. A fragment there is
+refused too, but by shuttle rather than by that grammar, which carries the
+`#argument` suffix on a piece designation and would take one. `..` is matched segment by
 segment as the walk splits them, so it is reserved in all of them and a key
 named `..` has no relative spelling — it reaches a place through a
 reference, the door that reads no `..` at all. `/` is the separator
 besides, so no segment of an operand holds one, and a key that does is
 spelled `~1`, which a reference unescapes and a walk does not.
 
-However a reading is matched, a part no rendering would name back is
-refused at every door. Two steps lose characters between a place and the
-rendering that names it. Reading a rendering back is a parse of a
-reference, which trims the string and drops a trailing empty segment.
-Writing one separates its lines with a newline. Both reach a path segment,
-so an empty segment, one ending in whitespace, and one holding a line break
-are refused, while one that merely starts with whitespace survives and is
-not.
+The property every door is held to is that a rendering may be refused but
+may never name a cell other than the one it was printed for. Two steps lose
+characters between a place and the rendering that names it. Reading a
+rendering back is a parse of a reference, which trims the string and drops a
+trailing empty segment. Writing one separates its lines with a newline. Both
+reach a path segment, so an empty segment, one ending in whitespace, and one
+holding a line break are refused, while one that merely starts with
+whitespace survives and is not. The first two are refused wherever they sit
+and not only last, because `..` makes any segment the last one.
 
 Only the newline reaches a piece. The scope suffix the rendering always
 writes sits between the piece and the end of the string, so the trim takes
 the suffix rather than the piece, and the parse's split at the last `@`
 takes the suffix's own — a piece comes back whole whatever it holds. The
-piece is nonetheless held to more: one that is empty, ends in whitespace,
-or holds an `@` is neither slug nor handle, so its rendering parses and is
-then refused as naming no piece. Refusing those at the door is what keeps
-a place to a name `pwd` can print as a reference somebody can follow, and
-no slug or handle carries an `@`, so it costs the fabric no name it can
-spell.
+piece is nonetheless held to more, for a different reason: one that is
+empty, ends in whitespace, or holds an `@` is refused because no slug or
+handle carries such a name. The parse would take it, its handle test being
+a length rule rather than an alphabet one, and hand back verbatim a name
+the `fid1` encoding could not have produced — a rendering that round-trips
+exactly and denotes nothing. That is neither a wrong address nor a dead
+one, which is why the reason cannot be either.
 
 A segment lifted out of a rendering is an operand in its own right, so
 these readings decide it rather than the key it was printed from.
@@ -394,6 +397,23 @@ and registered by
 spelling reaches any of them. Adding one item to a collection is therefore
 `get`, edit, `set`: the read-modify-write those operations were made
 first-class to avoid.
+
+**The `@` sigil carries two meanings.** It is the space slot of a reference
+and the scope suffix on a piece: `@user` alone is the scope word,
+`/@user/<handle>` is a space *named* user, and `/@user/<handle>@session` is
+both at once — and space names are unvalidated, so the collision is live
+rather than hypothetical. Shuttle cannot resolve it: decision 13 forbids
+inventing a spelling, and a second scope spelling would be worse than the
+ambiguity. Issue
+[#6775](https://github.com/commontoolsinc/labs/issues/6775) carries it. In
+v1 a space named by name is refused unless it resolves to the connected
+space, which is what keeps it dormant; multi-space sessions are where it
+wakes.
+
+**A shortened id is not an address.** The prompt falls back to one where no
+slug is confirmed, and it is spelled exactly as a whole handle is, so
+nothing in it says which it is. Whether the prompt stays pasteable, and how
+that fallback is marked if it does, is open — see the Prompt section above.
 
 The base-overlay spelling is settled above. The remaining open item for
 shuttle overall (shallow-sink expressibility) lives in

--- a/docs/plans/shuttle/grammar.md
+++ b/docs/plans/shuttle/grammar.md
@@ -61,7 +61,9 @@ How a reading is matched says where it holds, and there are three ways.
 `-` and a lone `/` are matched against the whole operand exactly, so
 neither governs a segment: a key named `-` is reachable relatively wherever
 it is not the whole operand. `@scope` and a lone leading `#` are matched
-against the operand's head, so each governs a first segment and is an
+against the operand's head, and each takes the whole operand with it: `cd
+@user/board` refuses rather than moving the scope and descending, and `cd
+#favorites/topics` hands on the whole string as one target. So each is an
 ordinary data character in every later segment that is data — inside a
 piece. A later segment naming a piece is read by the canonical grammar
 instead, which carries both readings itself, so a scope suffix there moves
@@ -73,16 +75,24 @@ besides, so no segment of an operand holds one, and a key that does is
 spelled `~1`, which a reference unescapes and a walk does not.
 
 However a reading is matched, a part no rendering would name back is
-refused at every door. Three steps lose characters between a place and the
+refused at every door. Two steps lose characters between a place and the
 rendering that names it. Reading a rendering back is a parse of a
 reference, which trims the string and drops a trailing empty segment.
-Writing one separates its lines with a newline. And the parse splits the
-piece segment at its last `@` and reads what follows as a scope, which
-reaches the piece and nothing else. So an empty part, one ending in
-whitespace, and one holding a line break are refused wherever they appear,
-a piece holding `@` is refused as well, and a part that merely starts with
-whitespace survives all three and is not. No slug or handle carries an `@`,
-so the piece rule costs the fabric no name it can spell.
+Writing one separates its lines with a newline. Both reach a path segment,
+so an empty segment, one ending in whitespace, and one holding a line break
+are refused, while one that merely starts with whitespace survives and is
+not.
+
+Only the newline reaches a piece. The scope suffix the rendering always
+writes sits between the piece and the end of the string, so the trim takes
+the suffix rather than the piece, and the parse's split at the last `@`
+takes the suffix's own — a piece comes back whole whatever it holds. The
+piece is nonetheless held to more: one that is empty, ends in whitespace,
+or holds an `@` is neither slug nor handle, so its rendering parses and is
+then refused as naming no piece. Refusing those at the door is what keeps
+a place to a name `pwd` can print as a reference somebody can follow, and
+no slug or handle carries an `@`, so it costs the fabric no name it can
+spell.
 
 A segment lifted out of a rendering is an operand in its own right, so
 these readings decide it rather than the key it was printed from.
@@ -104,12 +114,13 @@ match their name; `cd` refuses such a rendering rather than following it.
 
 A place is **result-rooted**, and holds exactly space, piece, path, and
 scope. `cd` refuses a target carrying `#argument`, in every spelling that
-takes one, rather than dropping the suffix silently: a place that could root at the arguments cell would
-leave every later relative read ambiguous about which side of the piece it
-addressed, and the prompt would have to carry the distinction for as long
-as you stood there. Arguments are reached per operand instead —
-`get topics/3#argument`, and `--input` on the `cf` verbs that take it — so
-the choice is one visible token at each use.
+takes one, rather than dropping the suffix silently: a place that could
+root at the arguments cell would leave every later relative read ambiguous
+about which side of the piece it addressed, and the prompt would have to
+carry the distinction for as long as you stood there. Arguments are
+reached per operand instead — `get topics/3#argument`, and `--input` on
+the `cf` verbs that take it — so the choice is one visible token at each
+use.
 
 ## The space root and facets
 

--- a/docs/plans/shuttle/grammar.md
+++ b/docs/plans/shuttle/grammar.md
@@ -89,21 +89,22 @@ these readings decide it rather than the key it was printed from.
 
 The `#` character has three readings, and they share nothing but the
 character. A lone `#name` token is a wish target, as above. `#argument` is
-a suffix on a reference and only that — it selects the piece's arguments
-cell, the same selection `--input` spells as a flag
-(`normalizeLLMFriendlyRef` in `packages/cli/lib/llm-friendly-ref.ts`, which
-strips it before the runner grammar sees the string, and refuses every
-other fragment). And inside a piece it is an ordinary character of a data
-key, under the rule above: the wish reading is decided on the whole
-operand, so it governs the head and nothing else.
+a suffix on a target, whichever way that target is written — a reference, a
+bare id, a slug — and it selects the piece's arguments cell, the same
+selection `--input` spells as a flag. `splitArgumentSuffix`
+(`packages/cli/lib/llm-friendly-ref.ts`) is that one reading: it takes the
+suffix off before anything parses what it followed, and refuses every other
+fragment. And inside a piece `#` is an ordinary character of a data key,
+under the rule above: the wish reading is decided on the whole operand, so
+it governs the head and nothing else.
 
 A container renders without the leading `/` that marks a reference, so a
 space root and a facet cannot be read back as a piece whose slug happens to
 match their name; `cd` refuses such a rendering rather than following it.
 
 A place is **result-rooted**, and holds exactly space, piece, path, and
-scope. `cd` refuses a reference carrying `#argument` rather than dropping
-the suffix silently: a place that could root at the arguments cell would
+scope. `cd` refuses a target carrying `#argument`, in every spelling that
+takes one, rather than dropping the suffix silently: a place that could root at the arguments cell would
 leave every later relative read ambiguous about which side of the piece it
 addressed, and the prompt would have to carry the distinction for as long
 as you stood there. Arguments are reached per operand instead —
@@ -251,6 +252,21 @@ fabric knows it by, a piece by its slug when the slug index confirms it, a
 shortened unique id otherwise, then the path. Shuttle uses the naming
 mechanisms the fabric supports and introduces none of its own; user-managed
 legible space names arrive when the fabric grows them.
+
+A shortened id is a prefix rather than an address, and it is spelled the
+way a whole handle is, so nothing in it says which it is. A prompt meant to
+be pasteable has to make that fallback visibly distinct, or leave it out.
+
+`pwd` is the complete address and has no short form. It writes the scope
+even when it is the base, so what it prints denotes one cell wherever it is
+read, where an omitted suffix would denote whatever the reader's own scope
+selects — shuttle writes absolutely and reads ambiently, the asymmetry a
+shell has between `pwd` and a relative path. Emitting the suffix only for a
+non-base scope would leave the common case contextual, since a suffix-less
+address read in a `@session` shuttle lands at session. The prompt is the
+short surface and is on screen continuously; what `pwd` is for is the thing
+you copy, so a form that cannot be pasted is the one output it should not
+produce.
 
 ## Writes
 

--- a/docs/plans/shuttle/grammar.md
+++ b/docs/plans/shuttle/grammar.md
@@ -64,8 +64,9 @@ cell, the same selection `--input` spells as a flag
 (`normalizeLLMFriendlyRef` in `packages/cli/lib/llm-friendly-ref.ts`, which
 strips it before the runner grammar sees the string, and refuses every
 other fragment). And inside a piece it is an ordinary character of a data
-key, because every segment there is data: neither reserved reading reaches
-a path segment.
+key — within a segment, and at the head of any segment after the first,
+because a lone leading `#` is read as a wish target before the operand is
+split at all.
 
 A place is **result-rooted**, and holds exactly space, piece, path, and
 scope. `cd` refuses a reference carrying `#argument` rather than dropping

--- a/docs/plans/shuttle/grammar.md
+++ b/docs/plans/shuttle/grammar.md
@@ -43,12 +43,12 @@ as the canonical grammar's context rule already works:
   cell read from anywhere. This is the form a printed address or a shared
   link should be, and it is what `pwd` prints, for that reason.
 
-The scope a complete reference omits is not a hole in it. Canonically an
-absent suffix *means* the base, which is why the serializer writes none for
-a base-scoped link. The two layers read the same absence differently —
-canonical says base, shuttle fills it from the place, the way a shell reads
-a relative path — and that difference is why `pwd` writes the suffix rather
-than trusting it to be inferred.
+  The scope a complete reference omits is not a hole in it. Canonically an
+  absent suffix *means* the base, which is why the serializer writes none
+  for a base-scoped link. The two layers read the same absence differently
+  — canonical says base, shuttle fills it from the place, the way a shell
+  reads a relative path — and that difference is why `pwd` writes the
+  suffix rather than trusting it to be inferred.
 - `#…` — a wish target (entry point), resolvable from anywhere within
   the connected space. A target anchored elsewhere — profile and
   favorites resolve against the reading identity's home space regardless
@@ -70,21 +70,21 @@ one; it is the piece and path it fixes, not the space.
 
 How a reading is matched says where it holds, and there are three ways.
 `-` and a lone `/` are matched against the whole operand exactly, so
-neither governs a segment: a key named `-` is reachable relatively wherever
-it is not the whole operand. `@scope` and a lone leading `#` are matched
-against the operand's head, and each takes the whole operand with it: `cd
-@user/board` refuses rather than moving the scope and descending, and `cd
-#favorites/topics` hands on the whole string as one target. So each is an
-ordinary data character in every later segment that is data — inside a
-piece. A later segment naming a piece is read by the canonical grammar
-instead, so a scope suffix there moves the scope. A fragment there is
-refused too, but by shuttle rather than by that grammar, which carries the
-`#argument` suffix on a piece designation and would take one. `..` is matched segment by
-segment as the walk splits them, so it is reserved in all of them and a key
-named `..` has no relative spelling — it reaches a place through a
-reference, the door that reads no `..` at all. `/` is the separator
-besides, so no segment of an operand holds one, and a key that does is
-spelled `~1`, which a reference unescapes and a walk does not.
+neither governs a segment: a key named `-` is reachable relatively
+wherever it is not the whole operand. `@scope` and a lone leading `#` are
+matched against the operand's head, and each takes the whole operand with
+it: `cd @user/board` refuses rather than moving the scope and descending,
+and `cd #favorites/topics` hands on the whole string as one target. So
+each is an ordinary data character in every later segment that is data —
+inside a piece. A later segment naming a piece is read by the canonical
+grammar instead, so a scope suffix there moves the scope. A fragment there
+is refused too, but by shuttle rather than by that grammar, which carries
+the `#argument` suffix on a piece designation and would take one. `..` is
+matched segment by segment as the walk splits them, so it is reserved in
+all of them and a key named `..` has no relative spelling — it reaches a
+place through a reference, the door that reads no `..` at all. `/` is the
+separator besides, so no segment of an operand holds one, and a key that
+does is spelled `~1`, which a reference unescapes and a walk does not.
 
 The property every door is held to is that a rendering may be refused but
 may never name a cell other than the one it was printed for. Two steps lose
@@ -415,6 +415,6 @@ slug is confirmed, and it is spelled exactly as a whole handle is, so
 nothing in it says which it is. Whether the prompt stays pasteable, and how
 that fallback is marked if it does, is open — see the Prompt section above.
 
-The base-overlay spelling is settled above. The remaining open item for
+The base-overlay spelling is settled above. One further open item for
 shuttle overall (shallow-sink expressibility) lives in
 [`views.md`](views.md).

--- a/docs/plans/shuttle/grammar.md
+++ b/docs/plans/shuttle/grammar.md
@@ -100,11 +100,13 @@ A `fuse/` facet mirroring the FUSE layout is designed and deferred past v1
 ([`futures.md`](futures.md)); shuttle leverages `packages/fuse`'s naming
 and hydration work regardless of when that facet lands.
 
-Facet names are reserved segments at the space root only; inside a piece,
-every segment is data — always. A piece's callables need no reserved name:
-they surface inline in listings, annotated as callable, exactly as the
-FUSE layout marks a handler an executable file inside the piece's tree
-(and the `verbs` verb lists them on demand).
+Facet names are reserved segments at the space root only; inside a piece
+no name is reserved at all, and a facet name is an ordinary data key
+there. The readings above are spellings rather than names, and are what
+they are wherever a piece's path admits them. A piece's callables need
+no reserved name: they surface inline in listings, annotated as
+callable, exactly as the FUSE layout marks a handler an executable file
+inside the piece's tree (and the `verbs` verb lists them on demand).
 
 The facet set stays deliberately small; growing it is a design decision,
 not a convenience.

--- a/docs/plans/shuttle/grammar.md
+++ b/docs/plans/shuttle/grammar.md
@@ -68,7 +68,7 @@ prefix, overriding it with the embedded space when one is present. A
 rooted reference is therefore exactly as space-dependent as a relative
 one; it is the piece and path it fixes, not the space.
 
-How a reading is matched says where it holds, and there are three ways.
+How a reading is matched says where it holds.
 `-` and a lone `/` are matched against the whole operand exactly, so
 neither governs a segment: a key named `-` is reachable relatively
 wherever it is not the whole operand. `@scope` and a lone leading `#` are
@@ -87,8 +87,8 @@ separator besides, so no segment of an operand holds one, and a key that
 does is spelled `~1`, which a reference unescapes and a walk does not.
 
 The property every door is held to is that a rendering may be refused but
-may never name a cell other than the one it was printed for. Two steps lose
-characters between a place and the rendering that names it. Reading a
+may never name a cell other than the one it was printed for. Characters go
+missing between a place and the rendering that names it. Reading a
 rendering back is a parse of a reference, which trims the string and drops a
 trailing empty segment. Writing one separates its lines with a newline. Both
 reach a path segment, so an empty segment, one ending in whitespace, and one

--- a/docs/plans/shuttle/grammar.md
+++ b/docs/plans/shuttle/grammar.md
@@ -57,12 +57,15 @@ prefix, overriding it with the embedded space when one is present. A
 rooted reference is therefore exactly as space-dependent as a relative
 one; it is the piece and path it fixes, not the space.
 
-Two spellings share the `#` character and nothing else. A lone `#name`
-token is a wish target, as above. `#argument` is a suffix on a reference
-and only that — it selects the piece's arguments cell, the same selection
-`--input` spells as a flag (`normalizeLLMFriendlyRef` in
-`packages/cli/lib/llm-friendly-ref.ts`, which strips it before the runner
-grammar sees the string, and refuses every other fragment).
+The `#` character has three readings, and they share nothing but the
+character. A lone `#name` token is a wish target, as above. `#argument` is
+a suffix on a reference and only that — it selects the piece's arguments
+cell, the same selection `--input` spells as a flag
+(`normalizeLLMFriendlyRef` in `packages/cli/lib/llm-friendly-ref.ts`, which
+strips it before the runner grammar sees the string, and refuses every
+other fragment). And inside a piece it is an ordinary character of a data
+key, because every segment there is data: neither reserved reading reaches
+a path segment.
 
 A place is **result-rooted**, and holds exactly space, piece, path, and
 scope. `cd` refuses a reference carrying `#argument` rather than dropping
@@ -162,9 +165,10 @@ and that the canonical grammar does not parse. `parseScopedIdSegment`
 suffix and throws without one, so `@session` alone addresses nothing, and
 `parseReferenceParts` in the same module throws on a lone `/`, which names
 no piece handle, so the space root has no canonical spelling either. The
-no-growth rule holds because the spelling never leaves `cd` and `where`: an
-operand and a full reference always carry an id, no link endpoint can hold
-a scope-only suffix, and nothing serializes one. Setting the ambient scope
+no-growth rule holds because the scope spelling never leaves the verbs that
+move and print the cwd — `cd`, `where`, and `pwd`: an operand and a full
+reference always carry an id, no link endpoint can hold a scope-only
+suffix, and nothing serializes one. Setting the ambient scope
 is all `cd @session` does, and ordinary references pick it up from there.
 
 The canonical grammar bounds what a suffix on a reference can say

--- a/docs/plans/shuttle/grammar.md
+++ b/docs/plans/shuttle/grammar.md
@@ -96,17 +96,33 @@ holding a line break are refused, while one that merely starts with
 whitespace survives and is not. The first two are refused wherever they sit
 and not only last, because `..` makes any segment the last one.
 
-Only the newline reaches a piece. The scope suffix the rendering always
-writes sits between the piece and the end of the string, so the trim takes
-the suffix rather than the piece, and the parse's split at the last `@`
-takes the suffix's own — a piece comes back whole whatever it holds. The
-piece is nonetheless held to more, for a different reason: one that is
+Only the newline reaches a piece that has one. The scope suffix the
+rendering always writes sits between the piece and the end of the string,
+so the trim takes the suffix rather than the piece, and the parse's split
+at the last `@` takes the suffix's own. An empty piece is the exception,
+and one fact generates it: its rendered id segment is the suffix and
+nothing else, so the split finds no id in front of it and the parse refuses
+the whole reference rather than handing anything back.
+
+The piece is nonetheless held to more, for a different reason: one that is
 empty, ends in whitespace, or holds an `@` is refused because no slug or
-handle carries such a name. The parse would take it, its handle test being
-a length rule rather than an alphabet one, and hand back verbatim a name
-the `fid1` encoding could not have produced — a rendering that round-trips
-exactly and denotes nothing. That is neither a wrong address nor a dead
-one, which is why the reason cannot be either.
+handle carries such a name. The reason covers all three. The mechanism
+behind it covers two: for a piece shaped like a handle — a colon, and
+twenty characters — the parse takes it, its handle test being a length rule
+rather than an alphabet one, and hands back verbatim a name the `fid1`
+encoding could not have produced, a rendering that round-trips exactly and
+denotes nothing. That is neither a wrong address nor a dead one, which is
+why the reason cannot be either. For an empty piece, and for anything
+shaped like a slug, the parse refuses it already; refusing at the door
+moves the refusal earlier and names the vocabulary where the parse names
+only the failure.
+
+One rule rather than three is a choice about wording, not about safety: the
+redundant cases cost nothing, and the rule buys no guarantee that every
+rendering is followable — a piece like `Not_A_Slug!!` passes it and the
+parse refuses that afterwards. Which pieces are held to the vocabulary at
+all is B1b's question, recorded with the other validation work in
+[`build-sequence.md`](build-sequence.md).
 
 A segment lifted out of a rendering is an operand in its own right, so
 these readings decide it rather than the key it was printed from.

--- a/docs/plans/shuttle/grammar.md
+++ b/docs/plans/shuttle/grammar.md
@@ -57,6 +57,14 @@ prefix, overriding it with the embedded space when one is present. A
 rooted reference is therefore exactly as space-dependent as a relative
 one; it is the piece and path it fixes, not the space.
 
+Where a reading is decided says where it holds. `-`, `@scope`, `/`, and a
+lone leading `#` are read on the whole operand before it is split, so each
+governs the operand's head and is an ordinary data character in every later
+segment. `..` and an empty segment are read segment by segment, so they are
+reserved wherever they appear — which is why a key named `..` has no
+relative spelling at all, while a key named `-` has one in any position but
+the first.
+
 The `#` character has three readings, and they share nothing but the
 character. A lone `#name` token is a wish target, as above. `#argument` is
 a suffix on a reference and only that — it selects the piece's arguments
@@ -64,9 +72,8 @@ cell, the same selection `--input` spells as a flag
 (`normalizeLLMFriendlyRef` in `packages/cli/lib/llm-friendly-ref.ts`, which
 strips it before the runner grammar sees the string, and refuses every
 other fragment). And inside a piece it is an ordinary character of a data
-key — within a segment, and at the head of any segment after the first,
-because a lone leading `#` is read as a wish target before the operand is
-split at all.
+key, under the rule above: the wish reading is decided on the whole
+operand, so it governs the head and nothing else.
 
 A place is **result-rooted**, and holds exactly space, piece, path, and
 scope. `cd` refuses a reference carrying `#argument` rather than dropping

--- a/docs/plans/shuttle/grammar.md
+++ b/docs/plans/shuttle/grammar.md
@@ -57,14 +57,23 @@ prefix, overriding it with the embedded space when one is present. A
 rooted reference is therefore exactly as space-dependent as a relative
 one; it is the piece and path it fixes, not the space.
 
-Where a reading is decided says where it holds. `-`, `@scope`, and a lone
-leading `#` are read on the whole operand before it is split, so each
-governs the operand's head and is an ordinary data character in every later
-segment. `..` and an empty segment are read segment by segment, so they are
-reserved wherever they appear — which is why a key named `..` has no
-relative spelling at all, while a key named `-` has one in any position but
-the first. `/` is neither: it is the separator, so a lone `/` is an operand
-of its own and no segment holds one.
+How a reading is matched says where it holds, and there are three ways.
+`-` and a lone `/` are matched against the whole operand exactly, so
+neither governs a segment: a key named `-` is reachable relatively wherever
+it is not the whole operand. `@scope` and a lone leading `#` are matched
+against the operand's head, so each governs a first segment and is an
+ordinary data character in every later one. `..` is matched segment by
+segment as the walk splits them, so it is reserved in all of them and a key
+named `..` has no relative spelling — it reaches a place through a
+reference, the door that reads no `..` at all. `/` is the separator
+besides, so no segment of an operand holds one, and a key that does is
+spelled `~1`, which a reference unescapes and a walk does not.
+
+However a reading is matched, a segment no rendering would name back —
+empty, or padded with whitespace — is refused at every door. A place prints
+as a reference, and a reference is read back trimmed and with a trailing
+empty segment dropped, so a place holding such a segment would print as a
+reference to a different cell.
 
 A segment lifted out of a rendering is an operand in its own right, so
 these readings decide it rather than the key it was printed from.

--- a/docs/plans/shuttle/grammar.md
+++ b/docs/plans/shuttle/grammar.md
@@ -28,16 +28,27 @@ as the canonical grammar's context rule already works:
 
 - `/of:…` — a **rooted** reference: it names the piece and path from the
   root, so no part of the position is read from the place — but it omits
-  the space, which the place still supplies. Rooted is not
+  the space and the scope, and the place supplies both. Rooted is not
   place-independent.
-- `/@did:key:…/of:…` — a **complete** reference: it carries its own space,
-  so it denotes the same cell read from anywhere. Only this form is
-  place-independent, and it is what a printed address or a shared link
-  should be. Denoting is not reaching, though: a connection serves one
-  space, so a complete reference naming a different space than the place's
-  is refused rather than followed — `validateEmbeddedSpaces`
-  (`packages/cli/lib/llm-friendly-ref.ts`) already holds `cf` to that, and
-  shuttle v1 holds one connection.
+- `/@did:key:…/of:…` — a **complete** reference: piece, path and space are
+  its own, and the scope is still the place's. It is place-independent in
+  one dimension and not in the other, so the same string read at `@user`
+  and at `@session` names two different cells. Denoting is not reaching,
+  either: a connection serves one space, so a reference naming a different
+  space than the place's is refused rather than followed —
+  `validateEmbeddedSpaces` (`packages/cli/lib/llm-friendly-ref.ts`) already
+  holds `cf` to that, and shuttle v1 holds one connection.
+- `/@did:key:…/of:…@scope` — a **fully qualified** reference: every level
+  is its own and nothing is read from the place, so it denotes the same
+  cell read from anywhere. This is the form a printed address or a shared
+  link should be, and it is what `pwd` prints, for that reason.
+
+The scope a complete reference omits is not a hole in it. Canonically an
+absent suffix *means* the base, which is why the serializer writes none for
+a base-scoped link. The two layers read the same absence differently —
+canonical says base, shuttle fills it from the place, the way a shell reads
+a relative path — and that difference is why `pwd` writes the suffix rather
+than trusting it to be inferred.
 - `#…` — a wish target (entry point), resolvable from anywhere within
   the connected space. A target anchored elsewhere — profile and
   favorites resolve against the reading identity's home space regardless

--- a/docs/plans/shuttle/grammar.md
+++ b/docs/plans/shuttle/grammar.md
@@ -62,18 +62,23 @@ How a reading is matched says where it holds, and there are three ways.
 neither governs a segment: a key named `-` is reachable relatively wherever
 it is not the whole operand. `@scope` and a lone leading `#` are matched
 against the operand's head, so each governs a first segment and is an
-ordinary data character in every later one. `..` is matched segment by
+ordinary data character in every later segment that is data — inside a
+piece. A later segment naming a piece is read by the canonical grammar
+instead, which carries both readings itself, so a scope suffix there moves
+the scope and a fragment there is refused. `..` is matched segment by
 segment as the walk splits them, so it is reserved in all of them and a key
 named `..` has no relative spelling — it reaches a place through a
 reference, the door that reads no `..` at all. `/` is the separator
 besides, so no segment of an operand holds one, and a key that does is
 spelled `~1`, which a reference unescapes and a walk does not.
 
-However a reading is matched, a segment no rendering would name back —
-empty, or padded with whitespace — is refused at every door. A place prints
-as a reference, and a reference is read back trimmed and with a trailing
-empty segment dropped, so a place holding such a segment would print as a
-reference to a different cell.
+However a reading is matched, a segment no rendering would name back is
+refused at every door. Two steps lose characters between a path and the
+rendering that names it: reading a rendering back is a parse of a
+reference, which trims the string and drops a trailing empty segment, and
+writing one separates its lines with a newline. So an empty segment, one
+ending in whitespace, and one holding a line break are refused, while a
+segment that merely starts with whitespace survives both and is not.
 
 A segment lifted out of a rendering is an operand in its own right, so
 these readings decide it rather than the key it was printed from.

--- a/docs/plans/shuttle/grammar.md
+++ b/docs/plans/shuttle/grammar.md
@@ -57,13 +57,17 @@ prefix, overriding it with the embedded space when one is present. A
 rooted reference is therefore exactly as space-dependent as a relative
 one; it is the piece and path it fixes, not the space.
 
-Where a reading is decided says where it holds. `-`, `@scope`, `/`, and a
-lone leading `#` are read on the whole operand before it is split, so each
+Where a reading is decided says where it holds. `-`, `@scope`, and a lone
+leading `#` are read on the whole operand before it is split, so each
 governs the operand's head and is an ordinary data character in every later
 segment. `..` and an empty segment are read segment by segment, so they are
 reserved wherever they appear — which is why a key named `..` has no
 relative spelling at all, while a key named `-` has one in any position but
-the first.
+the first. `/` is neither: it is the separator, so a lone `/` is an operand
+of its own and no segment holds one.
+
+A segment lifted out of a rendering is an operand in its own right, so
+these readings decide it rather than the key it was printed from.
 
 The `#` character has three readings, and they share nothing but the
 character. A lone `#name` token is a wish target, as above. `#argument` is

--- a/docs/plans/shuttle/grammar.md
+++ b/docs/plans/shuttle/grammar.md
@@ -384,6 +384,17 @@ the set would have to unteach.
 
 ## Open questions
 
-None here — the base-overlay spelling is settled above. The remaining
-open item for shuttle overall (shallow-sink expressibility) lives in
+**Appending to a collection.** Shuttle's write vocabulary is whole-value:
+`set` writes a value, `edit` writes back the one it opened, and `link`
+writes a reference. The fabric below has more than that — operation-based
+append, add-unique, increment and remove-by-value, covered in
+[`mergeable-collection-writes`](../../features/mergeable-collection-writes.md)
+and registered by
+[`patch-operations.md`](../../features/patch-operations.md) — and no shuttle
+spelling reaches any of them. Adding one item to a collection is therefore
+`get`, edit, `set`: the read-modify-write those operations were made
+first-class to avoid.
+
+The base-overlay spelling is settled above. The remaining open item for
+shuttle overall (shallow-sink expressibility) lives in
 [`views.md`](views.md).

--- a/docs/plans/shuttle/grammar.md
+++ b/docs/plans/shuttle/grammar.md
@@ -72,13 +72,17 @@ reference, the door that reads no `..` at all. `/` is the separator
 besides, so no segment of an operand holds one, and a key that does is
 spelled `~1`, which a reference unescapes and a walk does not.
 
-However a reading is matched, a segment no rendering would name back is
-refused at every door. Two steps lose characters between a path and the
-rendering that names it: reading a rendering back is a parse of a
-reference, which trims the string and drops a trailing empty segment, and
-writing one separates its lines with a newline. So an empty segment, one
-ending in whitespace, and one holding a line break are refused, while a
-segment that merely starts with whitespace survives both and is not.
+However a reading is matched, a part no rendering would name back is
+refused at every door. Three steps lose characters between a place and the
+rendering that names it. Reading a rendering back is a parse of a
+reference, which trims the string and drops a trailing empty segment.
+Writing one separates its lines with a newline. And the parse splits the
+piece segment at its last `@` and reads what follows as a scope, which
+reaches the piece and nothing else. So an empty part, one ending in
+whitespace, and one holding a line break are refused wherever they appear,
+a piece holding `@` is refused as well, and a part that merely starts with
+whitespace survives all three and is not. No slug or handle carries an `@`,
+so the piece rule costs the fabric no name it can spell.
 
 A segment lifted out of a rendering is an operand in its own right, so
 these readings decide it rather than the key it was printed from.
@@ -92,6 +96,10 @@ strips it before the runner grammar sees the string, and refuses every
 other fragment). And inside a piece it is an ordinary character of a data
 key, under the rule above: the wish reading is decided on the whole
 operand, so it governs the head and nothing else.
+
+A container renders without the leading `/` that marks a reference, so a
+space root and a facet cannot be read back as a piece whose slug happens to
+match their name; `cd` refuses such a rendering rather than following it.
 
 A place is **result-rooted**, and holds exactly space, piece, path, and
 scope. `cd` refuses a reference carrying `#argument` rather than dropping

--- a/packages/cli/deno.jsonc
+++ b/packages/cli/deno.jsonc
@@ -16,6 +16,7 @@
     ".": "./mod.ts",
     "./commands/piece": "./commands/piece.ts",
     "./lib/cell-listing": "./lib/cell-listing.ts",
+    "./lib/llm-friendly-ref": "./lib/llm-friendly-ref.ts",
     "./lib/piece": "./lib/piece.ts",
     "./lib/piece-render": "./lib/piece-render.ts",
     "./lib/wish": "./lib/wish.ts"

--- a/packages/shuttle/deno.jsonc
+++ b/packages/shuttle/deno.jsonc
@@ -1,6 +1,8 @@
 {
   // Dependency guide: ../../docs/development/DEPENDENCIES.md
   "tasks": {
-    "test": "echo 'No tests defined.'"
+    // --no-check: this package is type-checked by `deno task check`
+    // (tasks/check.sh).
+    "test": "deno test --no-check"
   }
 }

--- a/packages/shuttle/src/place.ts
+++ b/packages/shuttle/src/place.ts
@@ -339,15 +339,7 @@ function moveByReference(
   place: Place,
   reference: NormalizedLLMFriendlyRef,
 ): Step {
-  if (reference.input === true) {
-    return refuse(
-      "A place is result-rooted, so `cd` takes no `#argument` suffix. A " +
-        "place rooted at the arguments cell would leave every later " +
-        "relative read ambiguous about which side of the piece it " +
-        "addressed. Reach arguments per operand instead, as in " +
-        "`get topics/3#argument`.",
-    );
-  }
+  if (reference.input === true) return refuseArgumentSuffix();
   const moved: Place = {
     position: {
       kind: "piece",
@@ -445,10 +437,9 @@ function moveDown(from: Standing, segment: string): Step {
  * grammar carries it, and a suffix here moves the scope half of the place.
  *
  * A `#` is refused rather than taken as part of the id, for one of two
- * reasons. `#argument` is a real suffix in the wrong place: the alias grammar
- * has no fragments, and letting one through would bury the suffix inside the
- * id and fail as an unknown piece later, which is what the CLI's own
- * bare-alias intake says of the same spelling. Any other fragment is a
+ * reasons. `#argument` is refused for the reason it is refused on a
+ * reference — a place is result-rooted — which holds however the suffix is
+ * written, so both spellings give that one reason. Any other fragment is a
  * spelling nothing carries, `#` being reserved for `#argument` in the
  * reference form too, so the refusal says that rather than naming a form
  * which would refuse it again for a second reason.
@@ -462,16 +453,11 @@ function moveIntoPiece(
   const hash = segment.indexOf("#");
   if (hash !== -1) {
     const suffix = segment.slice(hash);
-    return suffix === "#argument"
-      ? refuse(
-        `The "#argument" suffix rides the reference form ` +
-          `(/of:fid1:...#argument), not the bare piece id.`,
-      )
-      : refuse(
-        `Unknown reference suffix "${suffix}". The one supported suffix ` +
-          `is "#argument", which the reference form carries and a bare ` +
-          `piece id does not.`,
-      );
+    return suffix === "#argument" ? refuseArgumentSuffix() : refuse(
+      `Unknown reference suffix "${suffix}". The one supported suffix ` +
+        `is "#argument", which the reference form carries and a bare ` +
+        `piece id does not.`,
+    );
   }
   let scoped;
   try {
@@ -522,6 +508,21 @@ function enterTarget(
 /** Whether `segment` names one of the facets a space root lists. */
 function isFacet(segment: string): segment is Facet {
   return (FACETS as readonly string[]).includes(segment);
+}
+
+/**
+ * Helper for the movers, which refuses the `#argument` suffix on a `cd`
+ * operand. A place is result-rooted, so no spelling of the suffix moves one
+ * and the reason never turns on which spelling carried it.
+ */
+function refuseArgumentSuffix(): Step {
+  return refuse(
+    "A place is result-rooted, so `cd` takes no `#argument` suffix. A " +
+      "place rooted at the arguments cell would leave every later " +
+      "relative read ambiguous about which side of the piece it " +
+      "addressed. Reach arguments per operand instead, as in " +
+      "`get topics/3#argument`.",
+  );
 }
 
 /** Helper for the movers, which builds a refusal carrying `reason`. */

--- a/packages/shuttle/src/place.ts
+++ b/packages/shuttle/src/place.ts
@@ -101,11 +101,15 @@ export interface Place {
 }
 
 /**
- * A move that worked out a place but not whether the space its reference named
- * by name is the connected one, which needs a session to derive a DID from a
- * name. Resolving that name — `validateEmbeddedSpaces` does it — and handing
- * this back to {@link CurrentPlace.settle} with the space it resolved to is
- * what lands it.
+ * A move whose reference named its space by name rather than by DID, which
+ * needs a session to derive the one from the other. Resolving that name —
+ * `validateEmbeddedSpaces` does it — and handing this back to
+ * {@link CurrentPlace.settle} with the space it resolved to is what lands it.
+ *
+ * It carries what the reference determined and no space, because whether the
+ * name denotes the connected space is the one thing not yet known: an arm
+ * with no space in it has none to be wrong about, and `settle` builds the
+ * place from the space it already holds.
  */
 export interface SpaceNamedMove {
   /** Names this arm of {@link Move}. */
@@ -114,8 +118,14 @@ export interface SpaceNamedMove {
   /** The space name the reference carried. */
   readonly name: string;
 
-  /** Where the reference lands, in the scope the reference asked for. */
-  readonly place: Place;
+  /** The piece as the reference spelled it: a handle or a slug. */
+  readonly piece: string;
+
+  /** Path inside the piece's result; empty for the piece itself. */
+  readonly path: readonly PathSegment[];
+
+  /** The scope the reference asked for, or the place's where it asked none. */
+  readonly scope: CellScope;
 }
 
 /** The arms of a {@link Move} that leave shuttle where it stood. */
@@ -227,10 +237,10 @@ export class CurrentPlace {
    * Lands a {@link SpaceNamedMove}, `confirmed` being the space its name
    * resolved to. A name that resolved to any space but the connected one is
    * refused here, so the comparison the reference deferred is made where the
-   * place would be adopted rather than left to the caller. The place is
-   * otherwise adopted as the move worked it out, scope included, which is
-   * what carries an `@scope` suffix through a reference that named its space
-   * by name.
+   * place would be adopted rather than left to the caller. The place is built
+   * from the connected space and the move's own piece, path and scope, which
+   * is what carries an `@scope` suffix through a reference that named its
+   * space by name.
    */
   settle(move: SpaceNamedMove, confirmed: MemorySpace): Move {
     const connected = this.#here.place.position.space;
@@ -240,7 +250,15 @@ export class CurrentPlace {
         connected,
       ));
     }
-    return this.#commit(land(move.place, []));
+    return this.#commit(land({
+      position: {
+        kind: "piece",
+        space: connected,
+        piece: move.piece,
+        path: move.path,
+      },
+      scope: move.scope,
+    }, []));
   }
 
   /** What `pwd` prints for this place. */
@@ -370,18 +388,25 @@ function moveByReference(
 ): Step {
   if (reference.input === true) return refuseArgumentSuffix();
   if (reference.path.includes("")) return refuseEmptySegment(operand);
-  const moved: Place = {
+  const scope = reference.scope ?? place.scope;
+  if (reference.embeddedSpace !== undefined) {
+    return {
+      kind: "space-by-name",
+      name: reference.embeddedSpace,
+      piece: reference.pieceId,
+      path: reference.path,
+      scope,
+    };
+  }
+  return land({
     position: {
       kind: "piece",
       space: place.position.space,
       piece: reference.pieceId,
       path: reference.path,
     },
-    scope: reference.scope ?? place.scope,
-  };
-  return reference.embeddedSpace === undefined
-    ? land(moved, [])
-    : { kind: "space-by-name", name: reference.embeddedSpace, place: moved };
+    scope,
+  }, []);
 }
 
 /**

--- a/packages/shuttle/src/place.ts
+++ b/packages/shuttle/src/place.ts
@@ -71,10 +71,12 @@ export interface PiecePosition {
   readonly piece: string;
 
   /**
-   * Path inside the piece's result; empty while standing at the piece. No
-   * segment of it is itself empty: the reference grammar drops a trailing
-   * empty segment, so a path ending in one would render as a reference to
-   * the piece above it and name a different cell.
+   * Path inside the piece's result; empty while standing at the piece. Every
+   * segment of it is one a rendering names back: neither empty nor padded
+   * with whitespace, because a place prints as a reference and a reference
+   * is read back trimmed and with a trailing empty segment dropped. A path
+   * holding either would render as a reference to a different cell — the
+   * piece above it, or the key of the trimmed spelling.
    */
   readonly path: readonly PathSegment[];
 }
@@ -179,7 +181,9 @@ export function placeAtSpaceRoot(space: MemorySpace): Place {
  * container's own rendering from resolving as a piece whose slug happens to
  * match. `cd` reads a piece rendering back whole, except where a path segment
  * holds a `#`, which the reference grammar reserves: `cd` refuses such a
- * rendering rather than reading it as some other cell. The scope renders here
+ * rendering rather than reading it as some other cell. A segment holding a
+ * newline splits the two lines this prints rather than the reference inside
+ * them, so what breaks there is the format. The scope renders here
  * rather than through the reference serializer, which emits no suffix for the
  * base scope.
  */
@@ -249,6 +253,10 @@ export class CurrentPlace {
         `\`${move.name}\` resolves to space \`${confirmed}\``,
         connected,
       ));
+    }
+    const fault = firstUnnameableSegment(move.path);
+    if (fault !== undefined) {
+      return this.#commit(refuseUnnameableSegment(move.piece, fault));
     }
     return this.#commit(land({
       position: {
@@ -387,7 +395,10 @@ function moveByReference(
   operand: string,
 ): Step {
   if (reference.input === true) return refuseArgumentSuffix();
-  if (reference.path.includes("")) return refuseEmptySegment(operand);
+  const badSegment = firstUnnameableSegment(reference.path);
+  if (badSegment !== undefined) {
+    return refuseUnnameableSegment(operand, badSegment);
+  }
   const scope = reference.scope ?? place.scope;
   if (reference.embeddedSpace !== undefined) {
     return {
@@ -425,7 +436,8 @@ function moveBySegments(from: Standing, operand: string): Step {
 
   let moved = from;
   for (const segment of segments) {
-    if (segment === "") return refuseEmptySegment(operand);
+    const fault = unnameableSegment(segment);
+    if (fault !== undefined) return refuseUnnameableSegment(operand, fault);
     const step = segment === ".." ? moveUp(moved) : moveDown(moved, segment);
     if (step.kind !== "moved") return step;
     moved = step.to;
@@ -555,8 +567,12 @@ function enterTarget(
       place.position.space,
     );
   }
-  if (target.path?.includes("")) {
-    return refuse(`\`${operand}\` resolves to a path with an empty segment.`);
+  const badSegment = firstUnnameableSegment(target.path ?? []);
+  if (badSegment !== undefined) {
+    return refuse(
+      `\`${operand}\` resolves to a path with ${badSegment}, so a rendering ` +
+        `of the place would name a different cell.`,
+    );
   }
   return land({
     ...place,
@@ -602,13 +618,42 @@ function refuseOtherSpace(clause: string, connected: MemorySpace): Step {
 }
 
 /**
- * Helper for the movers, which refuses `operand` for holding an empty path
- * segment. A position's path holds none, because the reference grammar drops
- * a trailing empty segment: a position holding one would render as a
- * reference naming the piece above it.
+ * Helper for the movers, which names what stops a rendering of a path
+ * holding `segment` from naming that path back, and returns nothing when
+ * nothing does.
+ *
+ * A place prints as a reference, and a reference is read back trimmed and
+ * with a trailing empty segment dropped. So an empty segment renders as the
+ * piece above, and a padded one renders as the key of its trimmed spelling.
+ * A number renders as its digits and always names itself back.
  */
-function refuseEmptySegment(operand: string): Step {
-  return refuse(`\`${operand}\` has an empty segment.`);
+function unnameableSegment(segment: PathSegment): string | undefined {
+  if (typeof segment === "number") return undefined;
+  if (segment === "") return "an empty segment";
+  if (segment !== segment.trim()) return "a segment padded with whitespace";
+  return undefined;
+}
+
+/** Helper for the movers, which is the first fault in `path`, if it has one. */
+function firstUnnameableSegment(
+  path: readonly PathSegment[],
+): string | undefined {
+  for (const segment of path) {
+    const fault = unnameableSegment(segment);
+    if (fault !== undefined) return fault;
+  }
+  return undefined;
+}
+
+/**
+ * Helper for the movers, which refuses `operand` for a segment no rendering
+ * names back, `fault` saying which segment and why.
+ */
+function refuseUnnameableSegment(operand: string, fault: string): Step {
+  return refuse(
+    `\`${operand}\` has ${fault}, so a rendering of the place would name a ` +
+      `different cell.`,
+  );
 }
 
 /** Helper for the movers, which builds a refusal carrying `reason`. */

--- a/packages/shuttle/src/place.ts
+++ b/packages/shuttle/src/place.ts
@@ -181,9 +181,10 @@ export function placeAtSpaceRoot(space: MemorySpace): Place {
  * container's own rendering from resolving as a piece whose slug happens to
  * match. `cd` reads a piece rendering back whole, except where a path segment
  * holds a `#`, which the reference grammar reserves: `cd` refuses such a
- * rendering rather than reading it as some other cell. A segment holding a
- * newline splits the two lines this prints rather than the reference inside
- * them, so what breaks there is the format. The scope renders here
+ * rendering rather than reading it as some other cell. A piece or segment
+ * holding a newline would split the position line, leaving a shorter
+ * reference that names another cell — which is why one is refused before it
+ * can reach a place rather than handled here. The scope renders here
  * rather than through the reference serializer, which emits no suffix for the
  * base scope.
  */
@@ -254,7 +255,8 @@ export class CurrentPlace {
         connected,
       ));
     }
-    const fault = firstUnnameableSegment(move.path);
+    const fault = unnameablePiece(move.piece) ??
+      firstUnnameableSegment(move.path);
     if (fault !== undefined) {
       return this.#commit(refuse(
         `The reference naming space \`${move.name}\` has ${fault}, so a ` +
@@ -375,13 +377,16 @@ function movePlace(
  * trail comes through untouched.
  */
 function moveScope(from: Standing, word: string): Step {
-  if (!CELL_SCOPE_VALUES.has(word)) {
-    return refuse(
-      `\`@${word}\` names no scope. The scopes are \`@space\`, \`@user\`, ` +
-        `and \`@session\`.`,
-    );
-  }
+  if (!CELL_SCOPE_VALUES.has(word)) return refuseUnknownScope(word);
   return land({ ...from.place, scope: word as CellScope }, from.trail);
+}
+
+/** Helper for the movers, which refuses `@word` for naming no scope. */
+function refuseUnknownScope(word: string): Step {
+  return refuse(
+    `\`@${word}\` names no scope. The scopes are \`@space\`, \`@user\`, ` +
+      `and \`@session\`.`,
+  );
 }
 
 /**
@@ -398,9 +403,11 @@ function moveByReference(
   operand: string,
 ): Step {
   if (reference.input === true) return refuseArgumentSuffix();
+  const badPiece = unnameablePiece(reference.pieceId);
+  if (badPiece !== undefined) return refuseUnnameable(operand, badPiece);
   const badSegment = firstUnnameableSegment(reference.path);
   if (badSegment !== undefined) {
-    return refuseUnnameableSegment(operand, badSegment);
+    return refuseUnnameable(operand, badSegment);
   }
   const scope = reference.scope ?? place.scope;
   if (reference.embeddedSpace !== undefined) {
@@ -440,7 +447,7 @@ function moveBySegments(from: Standing, operand: string): Step {
   let moved = from;
   for (const segment of segments) {
     const fault = unnameableSegment(segment);
-    if (fault !== undefined) return refuseUnnameableSegment(operand, fault);
+    if (fault !== undefined) return refuseUnnameable(operand, fault);
     const step = segment === ".." ? moveUp(moved) : moveDown(moved, segment);
     if (step.kind !== "moved") return step;
     moved = step.to;
@@ -541,9 +548,13 @@ function moveIntoPiece(
   let scoped;
   try {
     scoped = parseScopedIdSegment(segment);
-  } catch (error) {
-    return refuse(messageOf(error));
+  } catch {
+    // The one throw left: the suffix names no scope, `@` with no piece in
+    // front of it having been refused above.
+    return refuseUnknownScope(segment.slice(segment.lastIndexOf("@") + 1));
   }
+  const fault = unnameablePiece(scoped.id);
+  if (fault !== undefined) return refuseUnnameable(segment, fault);
   return land({
     position: {
       kind: "piece",
@@ -574,6 +585,13 @@ function enterTarget(
     return refuseOtherSpace(
       `\`${operand}\` resolves in space \`${target.space}\``,
       place.position.space,
+    );
+  }
+  const badPiece = unnameablePiece(target.piece);
+  if (badPiece !== undefined) {
+    return refuse(
+      `\`${operand}\` resolves to ${badPiece}, so a rendering of the place ` +
+        `would name a different cell.`,
     );
   }
   const badSegment = firstUnnameableSegment(target.path ?? []);
@@ -627,29 +645,55 @@ function refuseOtherSpace(clause: string, connected: MemorySpace): Step {
 }
 
 /**
- * Helper for the movers, which names what stops a rendering of a path
- * holding `segment` from naming that path back, and returns nothing when
- * nothing does.
+ * Helper for {@link unnameableSegment} and {@link unnameablePiece}, which
+ * names what the two steps every part of a rendering passes through would
+ * lose from `text`, `noun` naming the part.
  *
- * Two things lose characters between a path and the rendering that names it,
- * and each rules out what it can lose. Reading a rendering back is a parse of
- * a reference, which trims the string it is given and drops a trailing empty
- * segment; a segment ending in whitespace, and an empty one, are what that
- * reaches. Writing the rendering separates its lines with a newline, so a
- * segment holding one splits the position line and leaves a shorter reference
- * that names another cell. A number renders as its digits and survives both.
+ * Reading a rendering back is a parse of a reference, which trims the string
+ * it is given and drops a trailing empty segment; something ending in
+ * whitespace, and something empty, are what that reaches. Writing the
+ * rendering separates its lines with a newline, so one holding a newline
+ * splits the position line and leaves a shorter reference naming another
+ * cell.
  *
  * Leading whitespace survives both and is admitted: the parse trims the whole
- * string, which no leading segment character sits at the end of. What a
+ * string, which no leading character of a part sits at the end of. What a
  * terminal does with the other control characters is the format's concern
  * rather than this one's, since a reference carrying them reads back whole.
  */
-function unnameableSegment(segment: PathSegment): string | undefined {
-  if (typeof segment === "number") return undefined;
-  if (segment === "") return "an empty segment";
-  if (segment !== segment.trimEnd()) return "a segment ending in whitespace";
-  if (segment.includes("\n")) return "a segment holding a line break";
+function unnameableText(text: string, noun: string): string | undefined {
+  if (text === "") return `an empty ${noun}`;
+  if (text !== text.trimEnd()) return `a ${noun} ending in whitespace`;
+  if (text.includes("\n")) return `a ${noun} holding a line break`;
   return undefined;
+}
+
+/**
+ * Helper for the movers, which names what stops a rendering of a path holding
+ * `segment` from naming that path back, and returns nothing when nothing
+ * does. A number renders as its digits and survives every step.
+ */
+function unnameableSegment(segment: PathSegment): string | undefined {
+  return typeof segment === "number"
+    ? undefined
+    : unnameableText(segment, "segment");
+}
+
+/**
+ * Helper for the movers, which names what stops a rendering from naming
+ * `piece` back, and returns nothing when nothing does.
+ *
+ * A third step reads the piece segment and only that one, which is why this
+ * is not {@link unnameableSegment}: `parseScopedIdSegment` splits the piece
+ * at its last `@` and reads what follows as a scope, so a piece holding one
+ * is read back shortened — under a scope it never asked for where the suffix
+ * is a scope word, and as a refusal where it is not. A slug is lowercase
+ * letters, numbers and hyphens and a handle carries none either, so no piece
+ * the fabric can name is lost by refusing the character outright.
+ */
+function unnameablePiece(piece: string): string | undefined {
+  return unnameableText(piece, "piece") ??
+    (piece.includes("@") ? "a piece holding `@`" : undefined);
 }
 
 /** Helper for the movers, which is the first fault in `path`, if it has one. */
@@ -664,10 +708,10 @@ function firstUnnameableSegment(
 }
 
 /**
- * Helper for the movers, which refuses `operand` for a segment no rendering
- * names back, `fault` saying which segment and why.
+ * Helper for the movers, which refuses `operand` for a part no rendering
+ * names back, `fault` saying which part and why.
  */
-function refuseUnnameableSegment(operand: string, fault: string): Step {
+function refuseUnnameable(operand: string, fault: string): Step {
   return refuse(
     `\`${operand}\` has ${fault}, so a rendering of the place would name a ` +
       `different cell.`,

--- a/packages/shuttle/src/place.ts
+++ b/packages/shuttle/src/place.ts
@@ -103,8 +103,9 @@ export interface Place {
 /**
  * A move that worked out a place but not whether the space its reference named
  * by name is the connected one, which needs a session to derive a DID from a
- * name. Confirming that name — `validateEmbeddedSpaces` does it — and handing
- * this back to {@link CurrentPlace.settle} is what lands it.
+ * name. Resolving that name — `validateEmbeddedSpaces` does it — and handing
+ * this back to {@link CurrentPlace.settle} with the space it resolved to is
+ * what lands it.
  */
 export interface SpaceNamedMove {
   /** Names this arm of {@link Move}. */
@@ -223,12 +224,22 @@ export class CurrentPlace {
   }
 
   /**
-   * Lands a {@link SpaceNamedMove} whose space name the caller has confirmed
-   * names the connected space. The place is adopted as the move worked it out,
-   * scope included, which is what carries an `@scope` suffix through a
-   * reference that also named its space by name.
+   * Lands a {@link SpaceNamedMove}, `confirmed` being the space its name
+   * resolved to. A name that resolved to any space but the connected one is
+   * refused here, so the comparison the reference deferred is made where the
+   * place would be adopted rather than left to the caller. The place is
+   * otherwise adopted as the move worked it out, scope included, which is
+   * what carries an `@scope` suffix through a reference that named its space
+   * by name.
    */
-  settle(move: SpaceNamedMove): Move {
+  settle(move: SpaceNamedMove, confirmed: MemorySpace): Move {
+    const connected = this.#here.place.position.space;
+    if (confirmed !== connected) {
+      return this.#commit(refuseOtherSpace(
+        `\`${move.name}\` resolves to space \`${confirmed}\``,
+        connected,
+      ));
+    }
     return this.#commit(land(move.place, []));
   }
 
@@ -514,10 +525,9 @@ function enterTarget(
   operand: string,
 ): Step {
   if (target.space !== place.position.space) {
-    return refuse(
-      `\`${operand}\` resolves in space \`${target.space}\`, and this ` +
-        `shuttle is connected to \`${place.position.space}\`. One ` +
-        `connection serves one space.`,
+    return refuseOtherSpace(
+      `\`${operand}\` resolves in space \`${target.space}\``,
+      place.position.space,
     );
   }
   if (target.path?.includes("")) {
@@ -551,6 +561,18 @@ function refuseArgumentSuffix(): Step {
       "relative read ambiguous about which side of the piece it " +
       "addressed. Reach arguments per operand instead, as in " +
       "`get topics/3#argument`.",
+  );
+}
+
+/**
+ * Helper for the movers, which refuses something that named a space other
+ * than `connected`. `clause` says what named it and which space it named; the
+ * rest is the same fact whichever route reached it, so it is written once.
+ */
+function refuseOtherSpace(clause: string, connected: MemorySpace): Step {
+  return refuse(
+    `${clause}, and this shuttle is connected to \`${connected}\`. One ` +
+      `connection serves one space.`,
   );
 }
 

--- a/packages/shuttle/src/place.ts
+++ b/packages/shuttle/src/place.ts
@@ -69,7 +69,12 @@ export interface PiecePosition {
   /** The piece as the operand named it: a handle or a slug. */
   readonly piece: string;
 
-  /** Path inside the piece's result; empty while standing at the piece. */
+  /**
+   * Path inside the piece's result; empty while standing at the piece. No
+   * segment of it is itself empty: the reference grammar drops a trailing
+   * empty segment, so a path ending in one would render as a reference to
+   * the piece above it and name a different cell.
+   */
   readonly path: readonly PathSegment[];
 }
 
@@ -139,9 +144,10 @@ export interface ResolvedTarget {
 
   /**
    * Path inside that piece, absent or empty for the piece itself, with each
-   * segment as the resolution spelled it. {@link CurrentPlace.enter}
-   * normalizes them, so a caller hands over what it read rather than what a
-   * cell path holds.
+   * segment as the resolution spelled it. This is `NormalizedLink.path`'s
+   * own component type, so a resolution hands over what it is already
+   * holding; {@link CurrentPlace.enter} converts each segment to the
+   * number-or-string form a cell path takes.
    */
   readonly path?: readonly string[];
 }
@@ -313,7 +319,9 @@ function movePlace(
   } catch (error) {
     return refuse(messageOf(error));
   }
-  if (reference !== undefined) return moveByReference(place, reference);
+  if (reference !== undefined) {
+    return moveByReference(place, reference, trimmed);
+  }
 
   if (trimmed.startsWith("#")) return { kind: "wish", target: trimmed };
   return moveBySegments(from, trimmed);
@@ -346,8 +354,10 @@ function moveScope(from: Standing, word: string): Step {
 function moveByReference(
   place: Place,
   reference: NormalizedLLMFriendlyRef,
+  operand: string,
 ): Step {
   if (reference.input === true) return refuseArgumentSuffix();
+  if (reference.path.includes("")) return refuseEmptySegment(operand);
   const moved: Place = {
     position: {
       kind: "piece",
@@ -378,9 +388,7 @@ function moveBySegments(from: Standing, operand: string): Step {
 
   let moved = from;
   for (const segment of segments) {
-    if (segment === "") {
-      return refuse(`\`${operand}\` has an empty segment.`);
-    }
+    if (segment === "") return refuseEmptySegment(operand);
     const step = segment === ".." ? moveUp(moved) : moveDown(moved, segment);
     if (step.kind !== "moved") return step;
     moved = step.to;
@@ -511,6 +519,9 @@ function enterTarget(
         `connection serves one space.`,
     );
   }
+  if (target.path?.includes("")) {
+    return refuse(`\`${operand}\` resolves to a path with an empty segment.`);
+  }
   return land({
     ...place,
     position: {
@@ -540,6 +551,16 @@ function refuseArgumentSuffix(): Step {
       "addressed. Reach arguments per operand instead, as in " +
       "`get topics/3#argument`.",
   );
+}
+
+/**
+ * Helper for the movers, which refuses `operand` for holding an empty path
+ * segment. A position's path holds none, because the reference grammar drops
+ * a trailing empty segment: a position holding one would render as a
+ * reference naming the piece above it.
+ */
+function refuseEmptySegment(operand: string): Step {
+  return refuse(`\`${operand}\` has an empty segment.`);
 }
 
 /** Helper for the movers, which builds a refusal carrying `reason`. */

--- a/packages/shuttle/src/place.ts
+++ b/packages/shuttle/src/place.ts
@@ -741,8 +741,9 @@ const NO_SUCH_NAME = "no piece carries that name: a slug is lowercase " +
  * `segment` from naming that path back, and returns nothing when nothing
  * does.
  *
- * Two steps lose characters. Reading a rendering back is a parse of a
- * reference, which trims the string it is given and drops a trailing empty
+ * Characters go missing on the way out and on the way back. Reading a
+ * rendering back is a parse of a reference, which trims the string it is
+ * given and drops a trailing empty
  * segment. Writing the rendering separates its lines with a newline, so a
  * segment holding one splits the position line and leaves a shorter reference
  * naming another cell. Both are refused wherever a segment sits and not only
@@ -784,7 +785,8 @@ function unnameableSegment(segment: PathSegment): Fault | undefined {
  * segment is the suffix and nothing else, so the split finds no id in front of
  * it and the parse refuses the whole reference.
  *
- * The other three rules answer to {@link NO_SUCH_NAME} instead, which is a
+ * The rules that are not the newline answer to {@link NO_SUCH_NAME}
+ * instead, which is a
  * weaker claim than the segment rules make and the honest one. This door is
  * the only check for a handle-shaped piece; for an empty one and for anything
  * slug-shaped the parse refuses already, so refusing here moves the refusal

--- a/packages/shuttle/src/place.ts
+++ b/packages/shuttle/src/place.ts
@@ -175,8 +175,9 @@ export function placeAtSpaceRoot(space: MemorySpace): Place {
  * What `pwd` prints: both halves of the place, each on its own line.
  *
  * A leading `/` is what makes a string a reference, so it marks the one
- * position that is a cell. A piece therefore renders as a complete reference —
- * the form that denotes the same cell read from anywhere — while a root and a
+ * position that is a cell. A piece therefore renders as a fully qualified
+ * reference — the rung that supplies every level, and so the one that denotes
+ * the same cell read from anywhere — while a root and a
  * facet are containers and render without one, which is what keeps a
  * container's own rendering from resolving as a piece whose slug happens to
  * match. `cd` reads a piece rendering back whole, except where a path segment
@@ -345,7 +346,8 @@ type Step =
  *
  * The operand is read in the order the spellings can be told apart: `-`, a
  * scope-only `@scope`, and `/` are shuttle's own navigation syntax, any other
- * rooted string is a reference for the fabric's grammar to parse, a leading
+ * string starting with `/` is a reference for the fabric's grammar to parse,
+ * whichever rung of it, a leading
  * `#` is a wish target, and anything else is a relative walk from where
  * shuttle stands.
  */
@@ -419,8 +421,9 @@ function refuseUnknownScope(word: string): Step {
 /**
  * Where a parsed reference moves `place` to.
  *
- * A rooted reference fixes the piece and the path and takes its space from the
- * place; only a complete one carries a space of its own. The parse refuses a
+ * A rooted reference fixes the piece and the path and takes both its space
+ * and its scope from the place; a `@did:key:…` prefix supplies the space, and
+ * an `@scope` suffix the scope. The parse refuses a
  * space whose DID differs from the place's, and hands one written as a name
  * back for a session to settle, since deriving a DID from a name needs one.
  */

--- a/packages/shuttle/src/place.ts
+++ b/packages/shuttle/src/place.ts
@@ -137,8 +137,13 @@ export interface ResolvedTarget {
   /** The piece the target resolved to. */
   readonly piece: string;
 
-  /** Path inside that piece; absent or empty for the piece itself. */
-  readonly path?: readonly PathSegment[];
+  /**
+   * Path inside that piece, absent or empty for the piece itself, with each
+   * segment as the resolution spelled it. {@link CurrentPlace.enter}
+   * normalizes them, so a caller hands over what it read rather than what a
+   * cell path holds.
+   */
+  readonly path?: readonly string[];
 }
 
 /** The place a shuttle starts in: the space's root, read at the base scope. */
@@ -151,11 +156,14 @@ export function placeAtSpaceRoot(space: MemorySpace): Place {
  *
  * A leading `/` is what makes a string a reference, so it marks the one
  * position that is a cell. A piece therefore renders as a complete reference —
- * the form that denotes the same cell read from anywhere, and so the form
- * worth copying — while a root and a facet are containers and render without
- * one, which is what keeps a container's own rendering from resolving as a
- * piece whose slug happens to match. The scope renders here rather than
- * through the reference serializer, which emits no suffix for the base scope.
+ * the form that denotes the same cell read from anywhere — while a root and a
+ * facet are containers and render without one, which is what keeps a
+ * container's own rendering from resolving as a piece whose slug happens to
+ * match. `cd` reads a piece rendering back whole, except where a path segment
+ * holds a `#`, which the reference grammar reserves: `cd` refuses such a
+ * rendering rather than reading it as some other cell. The scope renders here
+ * rather than through the reference serializer, which emits no suffix for the
+ * base scope.
  */
 export function renderPlace(place: Place): string {
   return `position  ${renderPosition(place.position)}\n` +
@@ -486,6 +494,10 @@ function moveIntoPiece(
  * named it. A target that resolved in another space — which is what a
  * home-anchored entry point does whenever the reading identity's home space
  * is not the connected one — is refused: one connection serves one space.
+ *
+ * The path is normalized the way a reference's and a relative walk's are, so
+ * that a position names its cell the same however it was reached, which is
+ * what {@link Position} promises.
  */
 function enterTarget(
   place: Place,
@@ -505,7 +517,7 @@ function enterTarget(
       kind: "piece",
       space: target.space,
       piece: target.piece,
-      path: target.path ?? [],
+      path: target.path?.map(linkPathSegmentToCellPathSegment) ?? [],
     },
   }, []);
 }

--- a/packages/shuttle/src/place.ts
+++ b/packages/shuttle/src/place.ts
@@ -217,9 +217,20 @@ export class CurrentPlace {
   #here: Standing;
   #previous: Standing | undefined;
 
-  /** Constructs an instance standing at `place`, with no previous place. */
-  constructor(place: Place) {
-    this.#here = { place, trail: [] };
+  /**
+   * Constructs an instance standing at the root of `space`, with no previous
+   * place.
+   *
+   * A space is all a shuttle has when it starts, and taking one rather than a
+   * whole {@link Place} is what keeps {@link PiecePosition}'s invariant a
+   * property of the type. Every other door checks what it is handed; a
+   * constructor taking a place would be one that could not, and the invariant
+   * would hold only where somebody remembered it. Restoring a saved place is
+   * a named entry point with checking of its own, for whenever something
+   * needs one.
+   */
+  constructor(space: MemorySpace) {
+    this.#here = { place: placeAtSpaceRoot(space), trail: [] };
   }
 
   /** Where shuttle stands. */
@@ -271,8 +282,8 @@ export class CurrentPlace {
       firstUnnameableSegment(move.path);
     if (fault !== undefined) {
       return this.#commit(refuse(
-        `The reference naming space \`${move.name}\` has ${fault}, so a ` +
-          `rendering of the place would name a different cell.`,
+        `The reference naming space \`${move.name}\` has ${fault.what}, ` +
+          `so ${fault.so}.`,
       ));
     }
     return this.#commit(land({
@@ -465,10 +476,13 @@ function moveByReference(
  * segment is read against the level the one before it landed on, so `..` and a
  * descent compose in one operand.
  *
- * Segments split on `/` and are taken literally. The reference grammar's `~1`
- * escaping belongs to a reference, which a relative operand is not, so `~1`
- * here is two characters of a key and a key holding the separator has no
- * relative spelling at all.
+ * The operand is trimmed before it is split, so the outer edges of the first
+ * and last segments are lost here where a reference keeps them: `cd " a"`
+ * reaches the key `a`, and a key actually named `" a"` has no relative
+ * spelling, only a rooted one. Between those edges a segment is taken
+ * literally — the reference grammar's `~1` escaping belongs to a reference,
+ * which a relative operand is not, so `~1` here is two characters of a key
+ * and a key holding the separator has no relative spelling at all.
  */
 function moveBySegments(from: Standing, operand: string): Step {
   const segments = operand.split("/");
@@ -620,15 +634,14 @@ function enterTarget(
   const badPiece = unnameablePiece(target.piece);
   if (badPiece !== undefined) {
     return refuse(
-      `\`${operand}\` resolves to ${badPiece}, so a rendering of the place ` +
-        `would name a different cell.`,
+      `\`${operand}\` resolves to ${badPiece.what}, so ${badPiece.so}.`,
     );
   }
   const badSegment = firstUnnameableSegment(target.path ?? []);
   if (badSegment !== undefined) {
     return refuse(
-      `\`${operand}\` resolves to a path with ${badSegment}, so a rendering ` +
-        `of the place would name a different cell.`,
+      `\`${operand}\` resolves to a path with ${badSegment.what}, so ` +
+        `${badSegment.so}.`,
     );
   }
   return land({
@@ -675,69 +688,101 @@ function refuseOtherSpace(clause: string, connected: MemorySpace): Step {
 }
 
 /**
- * Helper for {@link unnameableSegment} and {@link unnameablePiece}, which
- * names what the two steps every part of a rendering passes through would
- * lose from `text`, `noun` naming the part.
- *
- * Reading a rendering back is a parse of a reference, which trims the string
- * it is given and drops a trailing empty segment; something ending in
- * whitespace, and something empty, are what that reaches. Writing the
- * rendering separates its lines with a newline, so one holding a newline
- * splits the position line and leaves a shorter reference naming another
- * cell.
- *
- * Leading whitespace survives both and is admitted: the parse trims the whole
- * string, which no leading character of a part sits at the end of. What a
- * terminal does with the other control characters is the format's concern
- * rather than this one's, since a reference carrying them reads back whole.
+ * What is wrong with one part of a place, and why that is refused. The two
+ * reasons are not interchangeable and a message is built from both, so a part
+ * carries the one that actually applies to it.
  */
-function unnameableText(text: string, noun: string): string | undefined {
-  if (text === "") return `an empty ${noun}`;
-  if (text !== text.trimEnd()) return `a ${noun} ending in whitespace`;
-  if (text.includes("\n")) return `a ${noun} holding a line break`;
-  return undefined;
+interface Fault {
+  /** The part and its flaw, as a noun phrase. */
+  readonly what: string;
+
+  /** Why it is refused, as a clause completing "so". */
+  readonly so: string;
 }
+
+/** The reason a part whose rendering would denote some other cell is refused. */
+const NAMES_ANOTHER = "a rendering of the place would name a different cell";
+
+/**
+ * The reason a piece the fabric could not have produced is refused.
+ *
+ * `isPieceHandle` is a length rule rather than an alphabet one, so the parse
+ * accepts a "handle" the `fid1` encoding cannot make and hands it back
+ * verbatim — such a rendering round-trips exactly and denotes nothing. That is
+ * neither a wrong address nor a dead one, so the reason it is refused cannot
+ * be either; it is that a place should stand only on a name something could
+ * have given it.
+ */
+const NO_SUCH_NAME = "no piece carries that name: a slug is lowercase " +
+  "letters, numbers and hyphens, and a handle is `of:fid1:` and base32";
 
 /**
  * Helper for the movers, which names what stops a rendering of a path holding
  * `segment` from naming that path back, and returns nothing when nothing
- * does. A number renders as its digits and survives every step.
+ * does.
+ *
+ * Two steps lose characters. Reading a rendering back is a parse of a
+ * reference, which trims the string it is given and drops a trailing empty
+ * segment. Writing the rendering separates its lines with a newline, so a
+ * segment holding one splits the position line and leaves a shorter reference
+ * naming another cell. Both are refused wherever a segment sits and not only
+ * last, because `..` makes any segment the last one. Leading whitespace
+ * survives both and is admitted: the parse trims the whole string, which no
+ * leading character of a segment sits at the end of. What a terminal does with the other control characters is
+ * the format's concern rather than this one's, since a reference carrying
+ * them reads back whole.
  */
-function unnameableSegment(segment: PathSegment): string | undefined {
-  if (typeof segment !== "number") return unnameableText(segment, "segment");
+function unnameableSegment(segment: PathSegment): Fault | undefined {
+  if (typeof segment !== "number") {
+    if (segment === "") return { what: "an empty segment", so: NAMES_ANOTHER };
+    if (segment !== segment.trimEnd()) {
+      return { what: "a segment ending in whitespace", so: NAMES_ANOTHER };
+    }
+    if (segment.includes("\n")) {
+      return { what: "a segment holding a line break", so: NAMES_ANOTHER };
+    }
+    return undefined;
+  }
   // A number renders as its digits, and only a canonical array index reads
   // back as the number it was: `1e21`, `-1` and `1.5` all print as something
   // the conversion leaves a string. The canonical rule decides, rather than a
   // second copy of it here.
   return linkPathSegmentToCellPathSegment(String(segment)) === segment
     ? undefined
-    : "a segment that is no canonical index";
+    : { what: "a segment that is no canonical index", so: NAMES_ANOTHER };
 }
 
 /**
- * Helper for the movers, which names what stops a rendering from naming
- * `piece` back, and returns nothing when nothing does.
+ * Helper for the movers, which names what stops a piece from being one a place
+ * may stand on, and returns nothing when nothing does.
  *
- * Only the newline reaches a piece. The scope suffix the rendering always
- * writes sits between the piece and the end of the string, so the trim
- * reaches the suffix rather than the piece, and the split at the last `@`
- * takes the suffix's own `@` rather than any the piece holds — a piece comes
- * back whole from both. What the rules here buy is narrower and still worth
- * having: they hold a place to a name `pwd` can print as a reference somebody
- * can follow. A piece that is empty, ends in whitespace, or holds an `@` is
- * neither slug nor handle, so its rendering parses and is then refused as
- * naming no piece — a dead address rather than a wrong one, and one this
- * module declines to stand at.
+ * Only the newline costs a piece its name. The scope suffix the rendering
+ * always writes sits between the piece and the end of the string, so the trim
+ * takes the suffix rather than the piece, and the split at the last `@` takes
+ * the suffix's own — a piece comes back whole from both, whatever it holds.
+ * The other three rules answer to {@link NO_SUCH_NAME} instead, which is a
+ * weaker claim than the segment rules make and the honest one: for a
+ * slug-shaped piece the canonical parse refuses these anyway, and for a
+ * handle-shaped one it does not, which is exactly why this door checks.
  */
-function unnameablePiece(piece: string): string | undefined {
-  return unnameableText(piece, "piece") ??
-    (piece.includes("@") ? "a piece holding `@`" : undefined);
+function unnameablePiece(piece: string): Fault | undefined {
+  if (piece.includes("\n")) {
+    return { what: "a piece holding a line break", so: NAMES_ANOTHER };
+  }
+  if (piece === "") return { what: "an empty piece", so: NO_SUCH_NAME };
+  if (piece !== piece.trimEnd()) {
+    return { what: "a piece ending in whitespace", so: NO_SUCH_NAME };
+  }
+  if (piece.includes("@")) {
+    return { what: "a piece holding `@`", so: NO_SUCH_NAME };
+  }
+  return undefined;
 }
 
 /** Helper for the movers, which is the first fault in `path`, if it has one. */
 function firstUnnameableSegment(
   path: readonly PathSegment[],
-): string | undefined {
+): Fault | undefined {
   for (const segment of path) {
     const fault = unnameableSegment(segment);
     if (fault !== undefined) return fault;
@@ -749,11 +794,8 @@ function firstUnnameableSegment(
  * Helper for the movers, which refuses `operand` for a part no rendering
  * names back, `fault` saying which part and why.
  */
-function refuseUnnameable(operand: string, fault: string): Step {
-  return refuse(
-    `\`${operand}\` has ${fault}, so a rendering of the place would name a ` +
-      `different cell.`,
-  );
+function refuseUnnameable(operand: string, fault: Fault): Step {
+  return refuse(`\`${operand}\` has ${fault.what}, so ${fault.so}.`);
 }
 
 /** Helper for the movers, which builds a refusal carrying `reason`. */

--- a/packages/shuttle/src/place.ts
+++ b/packages/shuttle/src/place.ts
@@ -194,8 +194,10 @@ export function placeAtSpaceRoot(space: MemorySpace): Place {
  * asymmetry a shell has between what `pwd` prints and what a relative path
  * means. The reference serializer omits a base scope for the opposite
  * convention, that an omitted suffix means the base, so this writes the
- * suffix itself; a piece holding an `@` is refused, which is what leaves the
- * one this writes unambiguous to the split that reads it back.
+ * suffix itself. The split that reads it back takes the last `@`, and this
+ * writes one after the piece, so the suffix it reads is always the one this
+ * wrote — whatever the piece holds, and independently of any rule about
+ * what a piece may hold.
  */
 export function renderPlace(place: Place): string {
   return `position  ${renderPosition(place)}\n` +
@@ -277,7 +279,16 @@ export class CurrentPlace {
         kind: "piece",
         space: connected,
         piece: move.piece,
-        path: move.path,
+        // Normalized the way every other door normalizes, so that a
+        // position names its cell the same however it was reached, which is
+        // what {@link Position} promises. A move `cd` minted carries a path
+        // the reference grammar already converted; one a caller built does
+        // not, and this is a public door.
+        path: move.path.map((segment) =>
+          typeof segment === "number"
+            ? segment
+            : linkPathSegmentToCellPathSegment(segment)
+        ),
       },
       scope: move.scope,
     }, []));
@@ -386,6 +397,13 @@ function movePlace(
  * trail comes through untouched.
  */
 function moveScope(from: Standing, word: string): Step {
+  if (word.includes("/")) {
+    return refuse(
+      `\`@${word}\` names no scope: a scope word holds no \`/\`. What ` +
+        `\`pwd\` prints for a space root or a facet is spelled this way and ` +
+        `names no cell — reach one by its facet or its piece.`,
+    );
+  }
   if (!CELL_SCOPE_VALUES.has(word)) return refuseUnknownScope(word);
   return land({ ...from.place, scope: word as CellScope }, from.trail);
 }
@@ -697,13 +715,16 @@ function unnameableSegment(segment: PathSegment): string | undefined {
  * Helper for the movers, which names what stops a rendering from naming
  * `piece` back, and returns nothing when nothing does.
  *
- * A third step reads the piece segment and only that one, which is why this
- * is not {@link unnameableSegment}: `parseScopedIdSegment` splits the piece
- * at its last `@` and reads what follows as a scope, so a piece holding one
- * is read back shortened — under a scope it never asked for where the suffix
- * is a scope word, and as a refusal where it is not. A slug is lowercase
- * letters, numbers and hyphens and a handle carries none either, so no piece
- * the fabric can name is lost by refusing the character outright.
+ * Only the newline reaches a piece. The scope suffix the rendering always
+ * writes sits between the piece and the end of the string, so the trim
+ * reaches the suffix rather than the piece, and the split at the last `@`
+ * takes the suffix's own `@` rather than any the piece holds — a piece comes
+ * back whole from both. What the rules here buy is narrower and still worth
+ * having: they hold a place to a name `pwd` can print as a reference somebody
+ * can follow. A piece that is empty, ends in whitespace, or holds an `@` is
+ * neither slug nor handle, so its rendering parses and is then refused as
+ * naming no piece — a dead address rather than a wrong one, and one this
+ * module declines to stand at.
  */
 function unnameablePiece(piece: string): string | undefined {
   return unnameableText(piece, "piece") ??

--- a/packages/shuttle/src/place.ts
+++ b/packages/shuttle/src/place.ts
@@ -720,14 +720,17 @@ interface Fault {
 const NAMES_ANOTHER = "a rendering of the place would name a different cell";
 
 /**
- * The reason a piece the fabric could not have produced is refused.
+ * The reason a piece the fabric could not have produced is refused. It holds
+ * of every rule that uses it; the mechanism behind it turns on the piece's
+ * shape rather than on which rule caught it.
  *
- * `isPieceHandle` is a length rule rather than an alphabet one, so the parse
- * accepts a "handle" the `fid1` encoding cannot make and hands it back
- * verbatim — such a rendering round-trips exactly and denotes nothing. That is
- * neither a wrong address nor a dead one, so the reason it is refused cannot
- * be either; it is that a place should stand only on a name something could
- * have given it.
+ * For a handle-shaped piece — a colon, and twenty characters — `isPieceHandle`
+ * is a length rule rather than an alphabet one, so the parse accepts a
+ * "handle" the `fid1` encoding cannot make and hands it back verbatim: a
+ * rendering that round-trips exactly and denotes nothing, neither a wrong
+ * address nor a dead one, so the reason it is refused cannot be either. An
+ * empty piece and a slug-shaped one the parse refuses on its own account, and
+ * this door reaches them first.
  */
 const NO_SUCH_NAME = "no piece carries that name: a slug is lowercase " +
   "letters, numbers, and single hyphens between words, and a handle is " +
@@ -776,11 +779,16 @@ function unnameableSegment(segment: PathSegment): Fault | undefined {
  * Only the newline costs a piece its name. The scope suffix the rendering
  * always writes sits between the piece and the end of the string, so the trim
  * takes the suffix rather than the piece, and the split at the last `@` takes
- * the suffix's own — a piece comes back whole from both, whatever it holds.
+ * the suffix's own — a piece with something in it comes back whole from both.
+ * An empty one is the exception, and one fact generates it: its rendered id
+ * segment is the suffix and nothing else, so the split finds no id in front of
+ * it and the parse refuses the whole reference.
+ *
  * The other three rules answer to {@link NO_SUCH_NAME} instead, which is a
- * weaker claim than the segment rules make and the honest one: for a
- * slug-shaped piece the canonical parse refuses these anyway, and for a
- * handle-shaped one it does not, which is exactly why this door checks.
+ * weaker claim than the segment rules make and the honest one. This door is
+ * the only check for a handle-shaped piece; for an empty one and for anything
+ * slug-shaped the parse refuses already, so refusing here moves the refusal
+ * earlier and names the vocabulary where the parse names only the failure.
  */
 function unnameablePiece(piece: string): Fault | undefined {
   if (piece.includes("\n")) {

--- a/packages/shuttle/src/place.ts
+++ b/packages/shuttle/src/place.ts
@@ -72,11 +72,11 @@ export interface PiecePosition {
 
   /**
    * Path inside the piece's result; empty while standing at the piece. Every
-   * segment of it is one a rendering names back: neither empty nor padded
-   * with whitespace, because a place prints as a reference and a reference
-   * is read back trimmed and with a trailing empty segment dropped. A path
-   * holding either would render as a reference to a different cell — the
-   * piece above it, or the key of the trimmed spelling.
+   * segment of it is one a rendering names back, which rules out three: an
+   * empty segment, one ending in whitespace, and one holding a line break.
+   * A path holding any of them renders as a reference to a different cell,
+   * because writing the rendering and reading it back each lose characters
+   * that {@link unnameableSegment} describes.
    */
   readonly path: readonly PathSegment[];
 }
@@ -256,7 +256,10 @@ export class CurrentPlace {
     }
     const fault = firstUnnameableSegment(move.path);
     if (fault !== undefined) {
-      return this.#commit(refuseUnnameableSegment(move.piece, fault));
+      return this.#commit(refuse(
+        `The reference naming space \`${move.name}\` has ${fault}, so a ` +
+          `rendering of the place would name a different cell.`,
+      ));
     }
     return this.#commit(land({
       position: {
@@ -529,6 +532,12 @@ function moveIntoPiece(
         `piece id does not.`,
     );
   }
+  if (segment.startsWith("@")) {
+    return refuse(
+      `\`${segment}\` names no piece. A scope suffix rides a piece id, and ` +
+        `a scope on its own is a whole operand rather than a segment.`,
+    );
+  }
   let scoped;
   try {
     scoped = parseScopedIdSegment(segment);
@@ -622,15 +631,24 @@ function refuseOtherSpace(clause: string, connected: MemorySpace): Step {
  * holding `segment` from naming that path back, and returns nothing when
  * nothing does.
  *
- * A place prints as a reference, and a reference is read back trimmed and
- * with a trailing empty segment dropped. So an empty segment renders as the
- * piece above, and a padded one renders as the key of its trimmed spelling.
- * A number renders as its digits and always names itself back.
+ * Two things lose characters between a path and the rendering that names it,
+ * and each rules out what it can lose. Reading a rendering back is a parse of
+ * a reference, which trims the string it is given and drops a trailing empty
+ * segment; a segment ending in whitespace, and an empty one, are what that
+ * reaches. Writing the rendering separates its lines with a newline, so a
+ * segment holding one splits the position line and leaves a shorter reference
+ * that names another cell. A number renders as its digits and survives both.
+ *
+ * Leading whitespace survives both and is admitted: the parse trims the whole
+ * string, which no leading segment character sits at the end of. What a
+ * terminal does with the other control characters is the format's concern
+ * rather than this one's, since a reference carrying them reads back whole.
  */
 function unnameableSegment(segment: PathSegment): string | undefined {
   if (typeof segment === "number") return undefined;
   if (segment === "") return "an empty segment";
-  if (segment !== segment.trim()) return "a segment padded with whitespace";
+  if (segment !== segment.trimEnd()) return "a segment ending in whitespace";
+  if (segment.includes("\n")) return "a segment holding a line break";
   return undefined;
 }
 

--- a/packages/shuttle/src/place.ts
+++ b/packages/shuttle/src/place.ts
@@ -1,0 +1,472 @@
+/**
+ * A place is where shuttle stands: the position it reads from and the scope it
+ * reads through. Both halves stick across navigation and both render, so they
+ * travel as one pair and `cd` is the single door to either.
+ *
+ * Everything here is a value and a decision about a value — no connection, and
+ * nothing read. The address grammar belongs to the fabric
+ * (`normalizeLLMFriendlyRef` over the runner's `parseReferenceParts`) and this
+ * module consumes it; what it adds is the navigation spellings that grammar
+ * has no room for — `..`, `-`, and a scope-only `@scope` — and the refusals a
+ * place is subject to.
+ */
+
+import type { CellScope } from "@commonfabric/api";
+import {
+  type NormalizedLLMFriendlyRef,
+  normalizeLLMFriendlyRef,
+} from "@commonfabric/cli/lib/llm-friendly-ref";
+import type { MemorySpace } from "@commonfabric/memory/interface";
+import {
+  CELL_SCOPE_VALUES,
+  encodeJsonPointer,
+  linkPathSegmentToCellPathSegment,
+  parseScopedIdSegment,
+} from "@commonfabric/runner/shared";
+
+/** One segment of a path inside a piece, in the form cell traversal takes. */
+export type PathSegment = string | number;
+
+/**
+ * The facets a space root lists. A populated space is too large for a flat
+ * root, so the root offers these and never pieces directly, and these names
+ * are reserved at the root alone — inside a piece every segment is data.
+ */
+export const FACETS = ["slugs", "pieces"] as const;
+
+/** One of the {@link FACETS}. */
+export type Facet = (typeof FACETS)[number];
+
+/** Standing at a space's root, whose children are its facets. */
+export interface SpaceRootPosition {
+  /** Names this arm of {@link Position}. */
+  readonly kind: "root";
+
+  /** The space, which one connection fixes for a shuttle's whole run. */
+  readonly space: MemorySpace;
+}
+
+/** Standing inside one facet of a space, whose children are pieces. */
+export interface FacetPosition {
+  /** Names this arm of {@link Position}. */
+  readonly kind: "facet";
+
+  /** The space, which one connection fixes for a shuttle's whole run. */
+  readonly space: MemorySpace;
+
+  /** Which facet is open. */
+  readonly facet: Facet;
+}
+
+/** Standing at a piece, or at a path inside its result. */
+export interface PiecePosition {
+  /** Names this arm of {@link Position}. */
+  readonly kind: "piece";
+
+  /** The space, which one connection fixes for a shuttle's whole run. */
+  readonly space: MemorySpace;
+
+  /** The piece as the operand named it: a handle or a slug. */
+  readonly piece: string;
+
+  /** Path inside the piece's result; empty while standing at the piece. */
+  readonly path: readonly PathSegment[];
+
+  /**
+   * The facet this piece was reached through, where it was reached through
+   * one. A piece is the same piece however it is reached, so this records the
+   * route and not the address: it is what `..` walks back out through, and it
+   * is absent for a piece a reference named outright.
+   */
+  readonly facet?: Facet;
+}
+
+/** Where in a space shuttle stands. */
+export type Position = SpaceRootPosition | FacetPosition | PiecePosition;
+
+/**
+ * The cwd pair: the position shuttle reads from, and the scope it reads
+ * through. A scope is a way of seeing every position rather than a location of
+ * its own, which is why it sits beside the position instead of inside it.
+ */
+export interface Place {
+  /** Where shuttle stands. */
+  readonly position: Position;
+
+  /** The overlay every read goes through while this place holds. */
+  readonly scope: CellScope;
+}
+
+/**
+ * What a move did. It either lands, is refused, or names something only the
+ * connection can settle: a wish target to resolve, or a space written as a
+ * name, where comparing two spellings needs a session to derive a DID.
+ */
+export type Move =
+  /** The move landed, and `place` is where shuttle now stands. */
+  | { readonly kind: "moved"; readonly place: Place }
+  /** The move is refused, for the reason given. */
+  | { readonly kind: "refused"; readonly reason: string }
+  /** The operand is a wish target, which the connected space resolves. */
+  | { readonly kind: "wish"; readonly target: string }
+  /**
+   * The reference names its space by name. `place` is where it lands once that
+   * name is confirmed to be the connected space, which `validateEmbeddedSpaces`
+   * settles against a session.
+   */
+  | {
+    readonly kind: "space-by-name";
+    readonly name: string;
+    readonly place: Place;
+  };
+
+/** What resolving a named entry point against the fabric produced. */
+export interface ResolvedTarget {
+  /** The space the target resolved in, which need not be the place's. */
+  readonly space: MemorySpace;
+
+  /** The piece the target resolved to. */
+  readonly piece: string;
+
+  /** Path inside that piece; absent or empty for the piece itself. */
+  readonly path?: readonly PathSegment[];
+}
+
+/** The place a shuttle starts in: the space's root, read at the base scope. */
+export function placeAtSpaceRoot(space: MemorySpace): Place {
+  return { position: { kind: "root", space }, scope: "space" };
+}
+
+/**
+ * What `pwd` prints: both halves of the place, each on its own line.
+ *
+ * The position renders as a complete reference wherever it is one, since that
+ * is the form which denotes the same cell read from anywhere and so the form
+ * worth copying. A root and a facet are containers rather than cells, and
+ * render with the trailing slash their names carry. The scope renders here
+ * rather than through the reference serializer, which emits no suffix for the
+ * base scope.
+ */
+export function renderPlace(place: Place): string {
+  return `position  ${renderPosition(place.position)}\n` +
+    `scope     ${renderScope(place.scope)}`;
+}
+
+/**
+ * The one owner of a shuttle's place: it holds where shuttle stands and where
+ * it stood before, moves between them, and refuses what the design refuses.
+ *
+ * Per instance rather than per process, so that several places — tabs, split
+ * views, an agent holding more than one — stay reachable.
+ */
+export class CurrentPlace {
+  #place: Place;
+  #previous: Place | undefined;
+
+  /** Constructs an instance standing at `place`, with no previous place. */
+  constructor(place: Place) {
+    this.#place = place;
+  }
+
+  /** Where shuttle stands. */
+  get place(): Place {
+    return this.#place;
+  }
+
+  /** Where it stood before its last landed move, once there has been one. */
+  get previous(): Place | undefined {
+    return this.#previous;
+  }
+
+  /**
+   * Moves as `operand` says, and returns what that did. The place changes only
+   * where the move lands, so a refusal and an unsettled operand both leave
+   * shuttle where it was.
+   */
+  cd(operand: string): Move {
+    return this.#commit(movePlace(this.#place, operand, this.#previous));
+  }
+
+  /**
+   * Moves into a target the fabric resolved, `operand` being the spelling that
+   * named it. A target that resolved in another space is refused: one
+   * connection serves one space.
+   */
+  enter(target: ResolvedTarget, operand: string): Move {
+    return this.#commit(enterTarget(this.#place, target, operand));
+  }
+
+  /** What `pwd` prints for this place. */
+  render(): string {
+    return renderPlace(this.#place);
+  }
+
+  /** Helper for the movers, which adopts a move that landed. */
+  #commit(move: Move): Move {
+    if (move.kind === "moved") {
+      this.#previous = this.#place;
+      this.#place = move.place;
+    }
+    return move;
+  }
+}
+
+/**
+ * Where `operand` moves `place` to, `previous` being the place `-` returns to.
+ *
+ * The operand is read in the order the spellings can be told apart: `-` and a
+ * scope-only `@scope` are shuttle's own navigation syntax, a rooted string is
+ * a reference for the fabric's grammar to parse, a leading `#` is a wish
+ * target, and anything else is a relative walk from where shuttle stands.
+ */
+function movePlace(place: Place, operand: string, previous?: Place): Move {
+  const trimmed = operand.trim();
+  if (trimmed === "") return refuse("`cd` takes a place to move to.");
+  if (trimmed === "-") {
+    return previous === undefined
+      ? refuse("There is no previous place to return to.")
+      : land(previous);
+  }
+  if (trimmed.startsWith("@")) return moveScope(place, trimmed.slice(1));
+
+  let reference;
+  try {
+    reference = normalizeLLMFriendlyRef(trimmed, {
+      space: place.position.space,
+    });
+  } catch (error) {
+    return refuse(messageOf(error));
+  }
+  if (reference !== undefined) return moveByReference(place, reference);
+
+  if (trimmed.startsWith("#")) return { kind: "wish", target: trimmed };
+  return moveBySegments(place, trimmed);
+}
+
+/**
+ * Where a `@scope` operand moves `place` to. `word` is the suffix without its
+ * `@`, and the scopes it may name are the canonical grammar's own, so no
+ * reference can carry a scope this refuses.
+ */
+function moveScope(place: Place, word: string): Move {
+  if (!CELL_SCOPE_VALUES.has(word)) {
+    return refuse(
+      `\`@${word}\` names no scope. The scopes are \`@space\`, \`@user\`, ` +
+        `and \`@session\`.`,
+    );
+  }
+  return land({ ...place, scope: word as CellScope });
+}
+
+/**
+ * Where a parsed reference moves `place` to.
+ *
+ * A rooted reference fixes the piece and the path and takes its space from the
+ * place; only a complete one carries a space of its own. The parse refuses a
+ * space whose DID differs from the place's, and hands one written as a name
+ * back for a session to settle, since deriving a DID from a name needs one.
+ */
+function moveByReference(
+  place: Place,
+  reference: NormalizedLLMFriendlyRef,
+): Move {
+  if (reference.input === true) {
+    return refuse(
+      "A place is result-rooted, so `cd` takes no `#argument` suffix. A " +
+        "place rooted at the arguments cell would leave every later " +
+        "relative read ambiguous about which side of the piece it " +
+        "addressed. Reach arguments per operand instead, as in " +
+        "`get topics/3#argument`.",
+    );
+  }
+  const moved: Place = {
+    position: {
+      kind: "piece",
+      space: place.position.space,
+      piece: reference.pieceId,
+      path: reference.path,
+    },
+    scope: reference.scope ?? place.scope,
+  };
+  return reference.embeddedSpace === undefined
+    ? land(moved)
+    : { kind: "space-by-name", name: reference.embeddedSpace, place: moved };
+}
+
+/**
+ * Where a relative operand moves `place` to, one segment at a time. Each
+ * segment is read against the level the one before it landed on, so `..` and a
+ * descent compose in one operand.
+ */
+function moveBySegments(place: Place, operand: string): Move {
+  const segments = operand.split("/");
+  if (segments[segments.length - 1] === "") segments.pop();
+
+  let moved = place;
+  for (const segment of segments) {
+    if (segment === "") {
+      return refuse(`\`${operand}\` has an empty segment.`);
+    }
+    const step = segment === ".." ? moveUp(moved) : moveDown(moved, segment);
+    if (step.kind !== "moved") return step;
+    moved = step.place;
+  }
+  return land(moved);
+}
+
+/** Where `..` moves `place` to: out of the level it stands in. */
+function moveUp(place: Place): Move {
+  const position = place.position;
+  switch (position.kind) {
+    case "root":
+      return land(place);
+    case "facet":
+      return land({
+        ...place,
+        position: { kind: "root", space: position.space },
+      });
+    case "piece":
+      if (position.path.length > 0) {
+        return land({
+          ...place,
+          position: { ...position, path: position.path.slice(0, -1) },
+        });
+      }
+      return land({
+        ...place,
+        position: position.facet === undefined
+          ? { kind: "root", space: position.space }
+          : { kind: "facet", space: position.space, facet: position.facet },
+      });
+  }
+}
+
+/**
+ * Where one relative segment moves `place` to: a facet at a space root, a
+ * piece inside a facet, and a data key or index inside a piece.
+ */
+function moveDown(place: Place, segment: string): Move {
+  const position = place.position;
+  switch (position.kind) {
+    case "root":
+      return isFacet(segment)
+        ? land({
+          ...place,
+          position: { kind: "facet", space: position.space, facet: segment },
+        })
+        : refuse(
+          `A space root lists facets, and \`${segment}\` names none. The ` +
+            `facets are \`slugs/\` and \`pieces/\`.`,
+        );
+    case "facet":
+      return moveIntoPiece(place, position, segment);
+    case "piece":
+      return land({
+        ...place,
+        position: {
+          ...position,
+          path: [...position.path, linkPathSegmentToCellPathSegment(segment)],
+        },
+      });
+  }
+}
+
+/**
+ * Where a segment naming a piece inside `facet` moves `place` to. The segment
+ * is the one a scope suffix may ride, since that is where the canonical
+ * grammar carries it, and a suffix here moves the scope half of the place.
+ */
+function moveIntoPiece(
+  place: Place,
+  facet: FacetPosition,
+  segment: string,
+): Move {
+  let scoped;
+  try {
+    scoped = parseScopedIdSegment(segment);
+  } catch (error) {
+    return refuse(messageOf(error));
+  }
+  return land({
+    position: {
+      kind: "piece",
+      space: facet.space,
+      piece: scoped.id,
+      path: [],
+      facet: facet.facet,
+    },
+    scope: scoped.scope ?? place.scope,
+  });
+}
+
+/**
+ * Where a resolved target moves `place` to, `operand` being the spelling that
+ * named it. A target that resolved in another space — which is what a
+ * home-anchored entry point does whenever the reading identity's home space
+ * is not the connected one — is refused: one connection serves one space.
+ */
+function enterTarget(
+  place: Place,
+  target: ResolvedTarget,
+  operand: string,
+): Move {
+  if (target.space !== place.position.space) {
+    return refuse(
+      `\`${operand}\` resolves in space \`${target.space}\`, and this ` +
+        `shuttle is connected to \`${place.position.space}\`. One ` +
+        `connection serves one space.`,
+    );
+  }
+  return land({
+    ...place,
+    position: {
+      kind: "piece",
+      space: target.space,
+      piece: target.piece,
+      path: target.path ?? [],
+    },
+  });
+}
+
+/** Whether `segment` names one of the facets a space root lists. */
+function isFacet(segment: string): segment is Facet {
+  return (FACETS as readonly string[]).includes(segment);
+}
+
+/** Helper for the movers, which builds a refusal carrying `reason`. */
+function refuse(reason: string): Move {
+  return { kind: "refused", reason };
+}
+
+/** Helper for the movers, which builds a move that landed on `place`. */
+function land(place: Place): Move {
+  return { kind: "moved", place };
+}
+
+/** Helper for the movers, which reads the message off a thrown value. */
+function messageOf(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/** Helper for {@link renderPlace}, which writes the position half. */
+function renderPosition(position: Position): string {
+  const space = `@${position.space}`;
+  switch (position.kind) {
+    case "root":
+      return encodeJsonPointer(["", space, ""]);
+    case "facet":
+      return encodeJsonPointer(["", space, position.facet, ""]);
+    case "piece":
+      return encodeJsonPointer([
+        "",
+        space,
+        position.piece,
+        ...position.path.map(String),
+      ]);
+  }
+}
+
+/** Helper for {@link renderPlace}, which writes the scope half. */
+function renderScope(scope: CellScope): string {
+  return `@${scope}`;
+}

--- a/packages/shuttle/src/place.ts
+++ b/packages/shuttle/src/place.ts
@@ -184,12 +184,21 @@ export function placeAtSpaceRoot(space: MemorySpace): Place {
  * rendering rather than reading it as some other cell. A piece or segment
  * holding a newline would split the position line, leaving a shorter
  * reference that names another cell — which is why one is refused before it
- * can reach a place rather than handled here. The scope renders here
- * rather than through the reference serializer, which emits no suffix for the
- * base scope.
+ * can reach a place rather than handled here.
+ *
+ * The scope is written on the piece even when it is the base, which is what
+ * makes "read from anywhere" true rather than nearly so. Scope is part of a
+ * cell's identity, and an omitted suffix is filled from wherever the reader
+ * stands, so a rendering without one denotes whatever cell the reader's own
+ * scope selects. Writing it absolutely and reading it ambiently is the
+ * asymmetry a shell has between what `pwd` prints and what a relative path
+ * means. The reference serializer omits a base scope for the opposite
+ * convention, that an omitted suffix means the base, so this writes the
+ * suffix itself; a piece holding an `@` is refused, which is what leaves the
+ * one this writes unambiguous to the split that reads it back.
  */
 export function renderPlace(place: Place): string {
-  return `position  ${renderPosition(place.position)}\n` +
+  return `position  ${renderPosition(place)}\n` +
     `scope     ${renderScope(place.scope)}`;
 }
 
@@ -534,9 +543,9 @@ function moveIntoPiece(
   if (hash !== -1) {
     const suffix = segment.slice(hash);
     return suffix === "#argument" ? refuseArgumentSuffix() : refuse(
-      `Unknown reference suffix "${suffix}". The one supported suffix ` +
-        `is "#argument", which the reference form carries and a bare ` +
-        `piece id does not.`,
+      `Unknown suffix "${suffix}". The one supported suffix is ` +
+        `"#argument", which selects the piece's arguments cell the way ` +
+        `"--input" does.`,
     );
   }
   if (segment.startsWith("@")) {
@@ -674,9 +683,14 @@ function unnameableText(text: string, noun: string): string | undefined {
  * does. A number renders as its digits and survives every step.
  */
 function unnameableSegment(segment: PathSegment): string | undefined {
-  return typeof segment === "number"
+  if (typeof segment !== "number") return unnameableText(segment, "segment");
+  // A number renders as its digits, and only a canonical array index reads
+  // back as the number it was: `1e21`, `-1` and `1.5` all print as something
+  // the conversion leaves a string. The canonical rule decides, rather than a
+  // second copy of it here.
+  return linkPathSegmentToCellPathSegment(String(segment)) === segment
     ? undefined
-    : unnameableText(segment, "segment");
+    : "a segment that is no canonical index";
 }
 
 /**
@@ -733,8 +747,14 @@ function messageOf(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-/** Helper for {@link renderPlace}, which writes the position half. */
-function renderPosition(position: Position): string {
+/**
+ * Helper for {@link renderPlace}, which writes the position half. A piece
+ * carries the scope, since only a piece is a cell for a scope to select
+ * within; a container renders its own name and leaves the scope to the line
+ * below.
+ */
+function renderPosition(place: Place): string {
+  const position = place.position;
   const space = `@${position.space}`;
   switch (position.kind) {
     case "root":
@@ -745,7 +765,7 @@ function renderPosition(position: Position): string {
       return encodeJsonPointer([
         "",
         space,
-        position.piece,
+        `${position.piece}@${place.scope}`,
         ...position.path.map(String),
       ]);
   }

--- a/packages/shuttle/src/place.ts
+++ b/packages/shuttle/src/place.ts
@@ -30,7 +30,8 @@ export type PathSegment = string | number;
 /**
  * The facets a space root lists. A populated space is too large for a flat
  * root, so the root offers these and never pieces directly, and these names
- * are reserved at the root alone — inside a piece every segment is data.
+ * are reserved at the root alone — inside a piece a facet name is an
+ * ordinary data key.
  */
 export const FACETS = ["slugs", "pieces"] as const;
 

--- a/packages/shuttle/src/place.ts
+++ b/packages/shuttle/src/place.ts
@@ -358,6 +358,11 @@ function moveByReference(
  * Where a relative operand moves `from` to, one segment at a time. Each
  * segment is read against the level the one before it landed on, so `..` and a
  * descent compose in one operand.
+ *
+ * Segments split on `/` and are taken literally. The reference grammar's `~1`
+ * escaping belongs to a reference, which a relative operand is not, so `~1`
+ * here is two characters of a key and a key holding the separator has no
+ * relative spelling at all.
  */
 function moveBySegments(from: Standing, operand: string): Step {
   const segments = operand.split("/");

--- a/packages/shuttle/src/place.ts
+++ b/packages/shuttle/src/place.ts
@@ -71,12 +71,14 @@ export interface PiecePosition {
   readonly piece: string;
 
   /**
-   * Path inside the piece's result; empty while standing at the piece. Every
-   * segment of it is one a rendering names back, which rules out three: an
-   * empty segment, one ending in whitespace, and one holding a line break.
-   * A path holding any of them renders as a reference to a different cell,
-   * because writing the rendering and reading it back each lose characters
-   * that {@link unnameableSegment} describes.
+   * Path inside the piece's result; empty while standing at the piece.
+   *
+   * Every door into this module refuses a segment a rendering would not name
+   * back — an empty one, one ending in whitespace, one holding a line break —
+   * because writing a rendering and reading it back each lose characters that
+   * {@link unnameableSegment} describes. That is an invariant the doors
+   * establish rather than one this structural type enforces, so a position
+   * reached any other way is outside it.
    */
   readonly path: readonly PathSegment[];
 }
@@ -180,12 +182,14 @@ export function placeAtSpaceRoot(space: MemorySpace): Place {
  * the same cell read from anywhere — while a root and a
  * facet are containers and render without one, which is what keeps a
  * container's own rendering from resolving as a piece whose slug happens to
- * match. `cd` reads a piece rendering back whole, except where a path segment
- * holds a `#`, which the reference grammar reserves: `cd` refuses such a
- * rendering rather than reading it as some other cell. A piece or segment
- * holding a newline would split the position line, leaving a shorter
- * reference that names another cell — which is why one is refused before it
- * can reach a place rather than handled here.
+ * match. What holds of a rendering is one property and not a list: `cd` may
+ * refuse it, but it never reads one as some other cell. Several things reach
+ * the first half — a `#` anywhere, which the reference grammar reserves, and
+ * a piece outside the slug and handle vocabularies — and enumerating them
+ * here would be a claim that goes stale as the vocabularies move. A piece or
+ * segment holding a newline would reach the second half, by splitting the
+ * position line into a shorter reference, which is why one is refused before
+ * it can reach a place rather than handled here.
  *
  * The scope is written on the piece even when it is the base, which is what
  * makes "read from anywhere" true rather than nearly so. Scope is part of a
@@ -200,7 +204,7 @@ export function placeAtSpaceRoot(space: MemorySpace): Place {
  * wrote — whatever the piece holds, and independently of any rule about
  * what a piece may hold.
  */
-export function renderPlace(place: Place): string {
+function renderPlace(place: Place): string {
   return `position  ${renderPosition(place)}\n` +
     `scope     ${renderScope(place.scope)}`;
 }
@@ -223,11 +227,12 @@ export class CurrentPlace {
    *
    * A space is all a shuttle has when it starts, and taking one rather than a
    * whole {@link Place} is what keeps {@link PiecePosition}'s invariant a
-   * property of the type. Every other door checks what it is handed; a
-   * constructor taking a place would be one that could not, and the invariant
-   * would hold only where somebody remembered it. Restoring a saved place is
-   * a named entry point with checking of its own, for whenever something
-   * needs one.
+   * property of every door rather than of whoever remembered it. It is not a
+   * property of the type: `Place` is a structural interface anyone can write
+   * a literal for. What holds is narrower and is what matters — no door into
+   * this module admits a position the invariant rules out. Restoring a saved
+   * place is a named entry point with checking of its own, for whenever
+   * something needs one.
    */
   constructor(space: MemorySpace) {
     this.#here = { place: placeAtSpaceRoot(space), trail: [] };
@@ -490,9 +495,13 @@ function moveBySegments(from: Standing, operand: string): Step {
 
   let moved = from;
   for (const segment of segments) {
-    const fault = unnameableSegment(segment);
-    if (fault !== undefined) return refuseUnnameable(operand, fault);
-    const step = segment === ".." ? moveUp(moved) : moveDown(moved, segment);
+    // No fault check here: which rule a segment answers to depends on what it
+    // is about to become, and only `moveDown` knows that. A segment naming a
+    // piece is held to the piece rules and told the piece's reason, which is
+    // not the reason a data key gets.
+    const step = segment === ".."
+      ? moveUp(moved)
+      : moveDown(moved, segment, operand);
     if (step.kind !== "moved") return step;
     moved = step.to;
   }
@@ -527,7 +536,7 @@ function enclosing(position: Position): Position {
  * inside a facet, and a data key or index inside a piece. A descent pushes the
  * level it left onto the trail, which is what `..` walks back out.
  */
-function moveDown(from: Standing, segment: string): Step {
+function moveDown(from: Standing, segment: string, operand: string): Step {
   const place = from.place;
   const position = place.position;
   const trail = [...from.trail, position];
@@ -543,8 +552,10 @@ function moveDown(from: Standing, segment: string): Step {
             `facets are \`slugs/\` and \`pieces/\`.`,
         );
     case "facet":
-      return moveIntoPiece(place, position, segment, trail);
-    case "piece":
+      return moveIntoPiece(place, position, segment, trail, operand);
+    case "piece": {
+      const fault = unnameableSegment(segment);
+      if (fault !== undefined) return refuseUnnameable(operand, fault);
       return land({
         ...place,
         position: {
@@ -552,6 +563,7 @@ function moveDown(from: Standing, segment: string): Step {
           path: [...position.path, linkPathSegmentToCellPathSegment(segment)],
         },
       }, trail);
+    }
   }
 }
 
@@ -573,6 +585,7 @@ function moveIntoPiece(
   facet: FacetPosition,
   segment: string,
   trail: Trail,
+  operand: string,
 ): Step {
   const hash = segment.indexOf("#");
   if (hash !== -1) {
@@ -598,7 +611,7 @@ function moveIntoPiece(
     return refuseUnknownScope(segment.slice(segment.lastIndexOf("@") + 1));
   }
   const fault = unnameablePiece(scoped.id);
-  if (fault !== undefined) return refuseUnnameable(segment, fault);
+  if (fault !== undefined) return refuseUnnameable(operand, fault);
   return land({
     position: {
       kind: "piece",
@@ -700,7 +713,10 @@ interface Fault {
   readonly so: string;
 }
 
-/** The reason a part whose rendering would denote some other cell is refused. */
+/**
+ * The reason a part whose rendering would denote some other cell is
+ * refused.
+ */
 const NAMES_ANOTHER = "a rendering of the place would name a different cell";
 
 /**
@@ -714,7 +730,8 @@ const NAMES_ANOTHER = "a rendering of the place would name a different cell";
  * have given it.
  */
 const NO_SUCH_NAME = "no piece carries that name: a slug is lowercase " +
-  "letters, numbers and hyphens, and a handle is `of:fid1:` and base32";
+  "letters, numbers, and single hyphens between words, and a handle is " +
+  "`of:fid1:` and unpadded base64url";
 
 /**
  * Helper for the movers, which names what stops a rendering of a path holding
@@ -728,9 +745,9 @@ const NO_SUCH_NAME = "no piece carries that name: a slug is lowercase " +
  * naming another cell. Both are refused wherever a segment sits and not only
  * last, because `..` makes any segment the last one. Leading whitespace
  * survives both and is admitted: the parse trims the whole string, which no
- * leading character of a segment sits at the end of. What a terminal does with the other control characters is
- * the format's concern rather than this one's, since a reference carrying
- * them reads back whole.
+ * leading character of a segment sits at the end of. What a terminal does with
+ * the other control characters is the format's concern rather than this one's,
+ * since a reference carrying them reads back whole.
  */
 function unnameableSegment(segment: PathSegment): Fault | undefined {
   if (typeof segment !== "number") {

--- a/packages/shuttle/src/place.ts
+++ b/packages/shuttle/src/place.ts
@@ -444,10 +444,14 @@ function moveDown(from: Standing, segment: string): Step {
  * is the one a scope suffix may ride, since that is where the canonical
  * grammar carries it, and a suffix here moves the scope half of the place.
  *
- * A `#` is refused rather than taken as part of the id, matching what the
- * CLI's own bare-alias intake does with the same spelling: the alias grammar
+ * A `#` is refused rather than taken as part of the id, for one of two
+ * reasons. `#argument` is a real suffix in the wrong place: the alias grammar
  * has no fragments, and letting one through would bury the suffix inside the
- * id and fail as an unknown piece later.
+ * id and fail as an unknown piece later, which is what the CLI's own
+ * bare-alias intake says of the same spelling. Any other fragment is a
+ * spelling nothing carries, `#` being reserved for `#argument` in the
+ * reference form too, so the refusal says that rather than naming a form
+ * which would refuse it again for a second reason.
  */
 function moveIntoPiece(
   place: Place,
@@ -455,11 +459,19 @@ function moveIntoPiece(
   segment: string,
   trail: Trail,
 ): Step {
-  if (segment.includes("#")) {
-    return refuse(
-      `The "#argument" suffix rides the reference form ` +
-        `(/of:fid1:...#argument), not the bare piece id.`,
-    );
+  const hash = segment.indexOf("#");
+  if (hash !== -1) {
+    const suffix = segment.slice(hash);
+    return suffix === "#argument"
+      ? refuse(
+        `The "#argument" suffix rides the reference form ` +
+          `(/of:fid1:...#argument), not the bare piece id.`,
+      )
+      : refuse(
+        `Unknown reference suffix "${suffix}". The one supported suffix ` +
+          `is "#argument", which the reference form carries and a bare ` +
+          `piece id does not.`,
+      );
   }
   let scoped;
   try {

--- a/packages/shuttle/src/place.ts
+++ b/packages/shuttle/src/place.ts
@@ -7,8 +7,8 @@
  * nothing read. The address grammar belongs to the fabric
  * (`normalizeLLMFriendlyRef` over the runner's `parseReferenceParts`) and this
  * module consumes it; what it adds is the navigation spellings that grammar
- * has no room for — `..`, `-`, and a scope-only `@scope` — and the refusals a
- * place is subject to.
+ * has no room for — `..`, `-`, `/`, and a scope-only `@scope` — and the
+ * refusals a place is subject to.
  */
 
 import type { CellScope } from "@commonfabric/api";
@@ -71,17 +71,14 @@ export interface PiecePosition {
 
   /** Path inside the piece's result; empty while standing at the piece. */
   readonly path: readonly PathSegment[];
-
-  /**
-   * The facet this piece was reached through, where it was reached through
-   * one. A piece is the same piece however it is reached, so this records the
-   * route and not the address: it is what `..` walks back out through, and it
-   * is absent for a piece a reference named outright.
-   */
-  readonly facet?: Facet;
 }
 
-/** Where in a space shuttle stands. */
+/**
+ * Where in a space shuttle stands. A position answers which cell this is and
+ * nothing else, so two arrivals at one cell are one position however
+ * differently they were reached; how shuttle got there is the trail
+ * {@link CurrentPlace} keeps.
+ */
 export type Position = SpaceRootPosition | FacetPosition | PiecePosition;
 
 /**
@@ -98,27 +95,39 @@ export interface Place {
 }
 
 /**
- * What a move did. It either lands, is refused, or names something only the
- * connection can settle: a wish target to resolve, or a space written as a
- * name, where comparing two spellings needs a session to derive a DID.
+ * A move that worked out a place but not whether the space its reference named
+ * by name is the connected one, which needs a session to derive a DID from a
+ * name. Confirming that name — `validateEmbeddedSpaces` does it — and handing
+ * this back to {@link CurrentPlace.settle} is what lands it.
  */
-export type Move =
-  /** The move landed, and `place` is where shuttle now stands. */
-  | { readonly kind: "moved"; readonly place: Place }
+export interface SpaceNamedMove {
+  /** Names this arm of {@link Move}. */
+  readonly kind: "space-by-name";
+
+  /** The space name the reference carried. */
+  readonly name: string;
+
+  /** Where the reference lands, in the scope the reference asked for. */
+  readonly place: Place;
+}
+
+/** The arms of a {@link Move} that leave shuttle where it stood. */
+type Unlanded =
   /** The move is refused, for the reason given. */
   | { readonly kind: "refused"; readonly reason: string }
   /** The operand is a wish target, which the connected space resolves. */
   | { readonly kind: "wish"; readonly target: string }
-  /**
-   * The reference names its space by name. `place` is where it lands once that
-   * name is confirmed to be the connected space, which `validateEmbeddedSpaces`
-   * settles against a session.
-   */
-  | {
-    readonly kind: "space-by-name";
-    readonly name: string;
-    readonly place: Place;
-  };
+  | SpaceNamedMove;
+
+/**
+ * What a move did. It either lands, is refused, or names something only the
+ * connection can settle: a wish target to resolve, or a space written as a
+ * name.
+ */
+export type Move =
+  /** The move landed, and `place` is where shuttle now stands. */
+  | { readonly kind: "moved"; readonly place: Place }
+  | Unlanded;
 
 /** What resolving a named entry point against the fabric produced. */
 export interface ResolvedTarget {
@@ -140,12 +149,13 @@ export function placeAtSpaceRoot(space: MemorySpace): Place {
 /**
  * What `pwd` prints: both halves of the place, each on its own line.
  *
- * The position renders as a complete reference wherever it is one, since that
- * is the form which denotes the same cell read from anywhere and so the form
- * worth copying. A root and a facet are containers rather than cells, and
- * render with the trailing slash their names carry. The scope renders here
- * rather than through the reference serializer, which emits no suffix for the
- * base scope.
+ * A leading `/` is what makes a string a reference, so it marks the one
+ * position that is a cell. A piece therefore renders as a complete reference —
+ * the form that denotes the same cell read from anywhere, and so the form
+ * worth copying — while a root and a facet are containers and render without
+ * one, which is what keeps a container's own rendering from resolving as a
+ * piece whose slug happens to match. The scope renders here rather than
+ * through the reference serializer, which emits no suffix for the base scope.
  */
 export function renderPlace(place: Place): string {
   return `position  ${renderPosition(place.position)}\n` +
@@ -153,29 +163,30 @@ export function renderPlace(place: Place): string {
 }
 
 /**
- * The one owner of a shuttle's place: it holds where shuttle stands and where
- * it stood before, moves between them, and refuses what the design refuses.
+ * The one owner of a shuttle's place: it holds where shuttle stands, where it
+ * stood before, and the levels it walked through to get there, moves between
+ * them, and refuses what the design refuses.
  *
  * Per instance rather than per process, so that several places — tabs, split
  * views, an agent holding more than one — stay reachable.
  */
 export class CurrentPlace {
-  #place: Place;
-  #previous: Place | undefined;
+  #here: Standing;
+  #previous: Standing | undefined;
 
   /** Constructs an instance standing at `place`, with no previous place. */
   constructor(place: Place) {
-    this.#place = place;
+    this.#here = { place, trail: [] };
   }
 
   /** Where shuttle stands. */
   get place(): Place {
-    return this.#place;
+    return this.#here.place;
   }
 
   /** Where it stood before its last landed move, once there has been one. */
   get previous(): Place | undefined {
-    return this.#previous;
+    return this.#previous?.place;
   }
 
   /**
@@ -184,7 +195,7 @@ export class CurrentPlace {
    * shuttle where it was.
    */
   cd(operand: string): Move {
-    return this.#commit(movePlace(this.#place, operand, this.#previous));
+    return this.#commit(movePlace(this.#here, operand, this.#previous));
   }
 
   /**
@@ -193,41 +204,98 @@ export class CurrentPlace {
    * connection serves one space.
    */
   enter(target: ResolvedTarget, operand: string): Move {
-    return this.#commit(enterTarget(this.#place, target, operand));
+    return this.#commit(enterTarget(this.#here.place, target, operand));
+  }
+
+  /**
+   * Lands a {@link SpaceNamedMove} whose space name the caller has confirmed
+   * names the connected space. The place is adopted as the move worked it out,
+   * scope included, which is what carries an `@scope` suffix through a
+   * reference that also named its space by name.
+   */
+  settle(move: SpaceNamedMove): Move {
+    return this.#commit(land(move.place, []));
   }
 
   /** What `pwd` prints for this place. */
   render(): string {
-    return renderPlace(this.#place);
+    return renderPlace(this.#here.place);
   }
 
-  /** Helper for the movers, which adopts a move that landed. */
-  #commit(move: Move): Move {
-    if (move.kind === "moved") {
-      this.#previous = this.#place;
-      this.#place = move.place;
-    }
-    return move;
+  /**
+   * Helper for the movers, which adopts a step that landed and reduces every
+   * step to the outcome a caller sees. The trail is navigation history rather
+   * than part of the place, so it stops here.
+   */
+  #commit(step: Step): Move {
+    if (step.kind !== "moved") return step;
+    this.#previous = this.#here;
+    this.#here = step.to;
+    return { kind: "moved", place: step.to.place };
   }
 }
 
 /**
- * Where `operand` moves `place` to, `previous` being the place `-` returns to.
+ * The levels walked through to reach where shuttle stands, outermost first,
+ * each the position one descent came from.
  *
- * The operand is read in the order the spellings can be told apart: `-` and a
- * scope-only `@scope` are shuttle's own navigation syntax, a rooted string is
- * a reference for the fabric's grammar to parse, a leading `#` is a wish
- * target, and anything else is a relative walk from where shuttle stands.
+ * `..` walks back out through it, which is what lets `cd slugs`, `cd board`,
+ * `cd ..` return to `slugs/` while the piece itself stays one position however
+ * it was reached. Three moves replace it wholesale rather than pushing: a
+ * reference and a resolved target carry no route, and `-` restores the route
+ * that came with the place it returns to.
  */
-function movePlace(place: Place, operand: string, previous?: Place): Move {
+type Trail = readonly Position[];
+
+/** Where shuttle stands, and the trail it walked to get there. */
+interface Standing {
+  /** The place itself. */
+  readonly place: Place;
+
+  /** How shuttle reached it. */
+  readonly trail: Trail;
+}
+
+/** A move as the movers pass it around, a landing carrying its trail. */
+type Step =
+  /** The move landed on `to`. */
+  | { readonly kind: "moved"; readonly to: Standing }
+  | Unlanded;
+
+/**
+ * Where `operand` moves `from` to, `previous` being the standing `-` returns
+ * to.
+ *
+ * The operand is read in the order the spellings can be told apart: `-`, a
+ * scope-only `@scope`, and `/` are shuttle's own navigation syntax, any other
+ * rooted string is a reference for the fabric's grammar to parse, a leading
+ * `#` is a wish target, and anything else is a relative walk from where
+ * shuttle stands.
+ */
+function movePlace(
+  from: Standing,
+  operand: string,
+  previous?: Standing,
+): Step {
+  const place = from.place;
   const trimmed = operand.trim();
   if (trimmed === "") return refuse("`cd` takes a place to move to.");
   if (trimmed === "-") {
     return previous === undefined
       ? refuse("There is no previous place to return to.")
-      : land(previous);
+      : land(previous.place, previous.trail);
   }
-  if (trimmed.startsWith("@")) return moveScope(place, trimmed.slice(1));
+  if (trimmed.startsWith("@")) return moveScope(from, trimmed.slice(1));
+
+  // A leading `/` roots a reference, and `/` alone roots one and names
+  // nothing further: the space's own root, which the grammar has no id
+  // segment to spell.
+  if (trimmed === "/") {
+    return land(
+      { ...place, position: { kind: "root", space: place.position.space } },
+      [],
+    );
+  }
 
   let reference;
   try {
@@ -240,22 +308,23 @@ function movePlace(place: Place, operand: string, previous?: Place): Move {
   if (reference !== undefined) return moveByReference(place, reference);
 
   if (trimmed.startsWith("#")) return { kind: "wish", target: trimmed };
-  return moveBySegments(place, trimmed);
+  return moveBySegments(from, trimmed);
 }
 
 /**
- * Where a `@scope` operand moves `place` to. `word` is the suffix without its
+ * Where a `@scope` operand moves `from` to. `word` is the suffix without its
  * `@`, and the scopes it may name are the canonical grammar's own, so no
- * reference can carry a scope this refuses.
+ * reference can carry a scope this refuses. The position does not move, so the
+ * trail comes through untouched.
  */
-function moveScope(place: Place, word: string): Move {
+function moveScope(from: Standing, word: string): Step {
   if (!CELL_SCOPE_VALUES.has(word)) {
     return refuse(
       `\`@${word}\` names no scope. The scopes are \`@space\`, \`@user\`, ` +
         `and \`@session\`.`,
     );
   }
-  return land({ ...place, scope: word as CellScope });
+  return land({ ...from.place, scope: word as CellScope }, from.trail);
 }
 
 /**
@@ -269,7 +338,7 @@ function moveScope(place: Place, word: string): Move {
 function moveByReference(
   place: Place,
   reference: NormalizedLLMFriendlyRef,
-): Move {
+): Step {
   if (reference.input === true) {
     return refuse(
       "A place is result-rooted, so `cd` takes no `#argument` suffix. A " +
@@ -289,77 +358,76 @@ function moveByReference(
     scope: reference.scope ?? place.scope,
   };
   return reference.embeddedSpace === undefined
-    ? land(moved)
+    ? land(moved, [])
     : { kind: "space-by-name", name: reference.embeddedSpace, place: moved };
 }
 
 /**
- * Where a relative operand moves `place` to, one segment at a time. Each
+ * Where a relative operand moves `from` to, one segment at a time. Each
  * segment is read against the level the one before it landed on, so `..` and a
  * descent compose in one operand.
  */
-function moveBySegments(place: Place, operand: string): Move {
+function moveBySegments(from: Standing, operand: string): Step {
   const segments = operand.split("/");
   if (segments[segments.length - 1] === "") segments.pop();
 
-  let moved = place;
+  let moved = from;
   for (const segment of segments) {
     if (segment === "") {
       return refuse(`\`${operand}\` has an empty segment.`);
     }
     const step = segment === ".." ? moveUp(moved) : moveDown(moved, segment);
     if (step.kind !== "moved") return step;
-    moved = step.place;
+    moved = step.to;
   }
-  return land(moved);
-}
-
-/** Where `..` moves `place` to: out of the level it stands in. */
-function moveUp(place: Place): Move {
-  const position = place.position;
-  switch (position.kind) {
-    case "root":
-      return land(place);
-    case "facet":
-      return land({
-        ...place,
-        position: { kind: "root", space: position.space },
-      });
-    case "piece":
-      if (position.path.length > 0) {
-        return land({
-          ...place,
-          position: { ...position, path: position.path.slice(0, -1) },
-        });
-      }
-      return land({
-        ...place,
-        position: position.facet === undefined
-          ? { kind: "root", space: position.space }
-          : { kind: "facet", space: position.space, facet: position.facet },
-      });
-  }
+  return land(moved.place, moved.trail);
 }
 
 /**
- * Where one relative segment moves `place` to: a facet at a space root, a
- * piece inside a facet, and a data key or index inside a piece.
+ * Where `..` moves `from` to: back out through the trail where there is one,
+ * and out of the level it stands in where the trail is empty, which is how a
+ * position a reference named outright backs out.
  */
-function moveDown(place: Place, segment: string): Move {
+function moveUp(from: Standing): Step {
+  const top = from.trail.at(-1);
+  return top === undefined
+    ? land({ ...from.place, position: enclosing(from.place.position) }, [])
+    : land({ ...from.place, position: top }, from.trail.slice(0, -1));
+}
+
+/**
+ * Helper for {@link moveUp}, which is the level `position` sits inside: the
+ * path one segment shorter where the position is one, and the space root
+ * otherwise, since a facet and a piece alike sit directly inside it.
+ */
+function enclosing(position: Position): Position {
+  return position.kind === "piece" && position.path.length > 0
+    ? { ...position, path: position.path.slice(0, -1) }
+    : { kind: "root", space: position.space };
+}
+
+/**
+ * Where one relative segment moves `from` to: a facet at a space root, a piece
+ * inside a facet, and a data key or index inside a piece. A descent pushes the
+ * level it left onto the trail, which is what `..` walks back out.
+ */
+function moveDown(from: Standing, segment: string): Step {
+  const place = from.place;
   const position = place.position;
+  const trail = [...from.trail, position];
   switch (position.kind) {
     case "root":
       return isFacet(segment)
         ? land({
           ...place,
           position: { kind: "facet", space: position.space, facet: segment },
-        })
+        }, trail)
         : refuse(
           `A space root lists facets, and \`${segment}\` names none. The ` +
             `facets are \`slugs/\` and \`pieces/\`.`,
         );
     case "facet":
-      return moveIntoPiece(place, position, segment);
+      return moveIntoPiece(place, position, segment, trail);
     case "piece":
       return land({
         ...place,
@@ -367,7 +435,7 @@ function moveDown(place: Place, segment: string): Move {
           ...position,
           path: [...position.path, linkPathSegmentToCellPathSegment(segment)],
         },
-      });
+      }, trail);
   }
 }
 
@@ -375,12 +443,24 @@ function moveDown(place: Place, segment: string): Move {
  * Where a segment naming a piece inside `facet` moves `place` to. The segment
  * is the one a scope suffix may ride, since that is where the canonical
  * grammar carries it, and a suffix here moves the scope half of the place.
+ *
+ * A `#` is refused rather than taken as part of the id, matching what the
+ * CLI's own bare-alias intake does with the same spelling: the alias grammar
+ * has no fragments, and letting one through would bury the suffix inside the
+ * id and fail as an unknown piece later.
  */
 function moveIntoPiece(
   place: Place,
   facet: FacetPosition,
   segment: string,
-): Move {
+  trail: Trail,
+): Step {
+  if (segment.includes("#")) {
+    return refuse(
+      `The "#argument" suffix rides the reference form ` +
+        `(/of:fid1:...#argument), not the bare piece id.`,
+    );
+  }
   let scoped;
   try {
     scoped = parseScopedIdSegment(segment);
@@ -393,10 +473,9 @@ function moveIntoPiece(
       space: facet.space,
       piece: scoped.id,
       path: [],
-      facet: facet.facet,
     },
     scope: scoped.scope ?? place.scope,
-  });
+  }, trail);
 }
 
 /**
@@ -409,7 +488,7 @@ function enterTarget(
   place: Place,
   target: ResolvedTarget,
   operand: string,
-): Move {
+): Step {
   if (target.space !== place.position.space) {
     return refuse(
       `\`${operand}\` resolves in space \`${target.space}\`, and this ` +
@@ -425,7 +504,7 @@ function enterTarget(
       piece: target.piece,
       path: target.path ?? [],
     },
-  });
+  }, []);
 }
 
 /** Whether `segment` names one of the facets a space root lists. */
@@ -434,13 +513,13 @@ function isFacet(segment: string): segment is Facet {
 }
 
 /** Helper for the movers, which builds a refusal carrying `reason`. */
-function refuse(reason: string): Move {
+function refuse(reason: string): Step {
   return { kind: "refused", reason };
 }
 
-/** Helper for the movers, which builds a move that landed on `place`. */
-function land(place: Place): Move {
-  return { kind: "moved", place };
+/** Helper for the movers, which builds a step landing on `place`. */
+function land(place: Place, trail: Trail): Step {
+  return { kind: "moved", to: { place, trail } };
 }
 
 /** Helper for the movers, which reads the message off a thrown value. */
@@ -453,9 +532,9 @@ function renderPosition(position: Position): string {
   const space = `@${position.space}`;
   switch (position.kind) {
     case "root":
-      return encodeJsonPointer(["", space, ""]);
+      return encodeJsonPointer([space, ""]);
     case "facet":
-      return encodeJsonPointer(["", space, position.facet, ""]);
+      return encodeJsonPointer([space, position.facet, ""]);
     case "piece":
       return encodeJsonPointer([
         "",

--- a/packages/shuttle/src/place.ts
+++ b/packages/shuttle/src/place.ts
@@ -80,7 +80,7 @@ export interface PiecePosition {
 }
 
 /**
- * Where in a space shuttle stands. A position answers which cell this is and
+ * Where in a space shuttle stands. A position is which cell this is and
  * nothing else, so two arrivals at one cell are one position however
  * differently they were reached; how shuttle got there is the trail
  * {@link CurrentPlace} keeps.

--- a/packages/shuttle/test/place.test.ts
+++ b/packages/shuttle/test/place.test.ts
@@ -499,11 +499,37 @@ describe("place", () => {
             });
           });
 
-          it("refuses `#` in a segment naming a piece", () => {
+          it("refuses `#argument` in a segment naming a piece", () => {
             expect(inSlugs().cd("board#argument")).toEqual({
               kind: "refused",
               reason: 'The "#argument" suffix rides the reference form ' +
                 "(/of:fid1:...#argument), not the bare piece id.",
+            });
+          });
+
+          it("refuses any other fragment for carrying no suffix at all", () => {
+            expect(inSlugs().cd("board#result")).toEqual({
+              kind: "refused",
+              reason: 'Unknown reference suffix "#result". The one ' +
+                'supported suffix is "#argument", which the reference form ' +
+                "carries and a bare piece id does not.",
+            });
+          });
+
+          it("names the whole fragment, not the part before a second `#`", () => {
+            expect(inSlugs().cd("board#argument#x")).toEqual({
+              kind: "refused",
+              reason: 'Unknown reference suffix "#argument#x". The one ' +
+                'supported suffix is "#argument", which the reference form ' +
+                "carries and a bare piece id does not.",
+            });
+          });
+
+          it("refuses a facet segment carrying a fragment for naming no facet", () => {
+            expect(atSpaceRoot().cd("slugs#argument")).toEqual({
+              kind: "refused",
+              reason: "A space root lists facets, and `slugs#argument` " +
+                "names none. The facets are `slugs/` and `pieces/`.",
             });
           });
 

--- a/packages/shuttle/test/place.test.ts
+++ b/packages/shuttle/test/place.test.ts
@@ -516,16 +516,24 @@ describe("place", () => {
             });
           });
 
-          it("hands back `#argument` too, since the head reading is one rule", () => {
+          it("hands back `#argument` as a target rather than refusing it", () => {
             // The wish reading is decided on the whole operand, so it does
             // not ask which word follows the `#`. `#argument` earns the
             // result-rooted refusal as a *suffix* on a reference; standing
             // alone it is a target name like any other, and the connection
-            // is what discovers there is none.
+            // is what discovers there is none. The case below drives the
+            // same point through a spelling a reference refuses outright.
 
             expect(atSpaceRoot().cd("#argument")).toEqual({
               kind: "wish",
               target: "#argument",
+            });
+          });
+
+          it("hands back a target holding a second `#`", () => {
+            expect(atSpaceRoot().cd("#a#b")).toEqual({
+              kind: "wish",
+              target: "#a#b",
             });
           });
         });
@@ -678,14 +686,12 @@ describe("place", () => {
           });
 
           describe("reserved readings", () => {
-            // Where a reading is decided says where it holds. `-`,
-            // `@scope`, `/` and a lone leading `#` are read on the whole
-            // operand before it is split, so each governs the head alone
-            // and is data everywhere after it; `..` is read segment by
-            // segment, so it is reserved wherever it appears. These four
-            // pin that rule rather than four instances of it, which is why
-            // each drives its character at the head of a later segment
-            // where the head-of-operand cases drive it first.
+            // Each of these drives its character at the head of a later
+            // segment, where the head-of-operand cases drive it first.
+            // That position is what tells the two kinds of reading apart —
+            // one decided on the whole operand, one decided segment by
+            // segment — so the four together pin which kind each reading
+            // is, rather than four instances of one kind.
 
             it("reads `-` as a data key in a later segment", () => {
               const place = atReferencedPiece();

--- a/packages/shuttle/test/place.test.ts
+++ b/packages/shuttle/test/place.test.ts
@@ -663,6 +663,61 @@ describe("place", () => {
             });
           });
 
+          describe("reserved readings", () => {
+            // Where a reading is decided says where it holds. `-`,
+            // `@scope`, `/` and a lone leading `#` are read on the whole
+            // operand before it is split, so each governs the head alone
+            // and is data everywhere after it; `..` is read segment by
+            // segment, so it is reserved wherever it appears. These four
+            // pin that rule rather than four instances of it, which is why
+            // each drives its character at the head of a later segment
+            // where the head-of-operand cases drive it first.
+
+            it("reads `-` as a data key in a later segment", () => {
+              const place = atReferencedPiece();
+              place.cd("a/-");
+              expect(place.place.position).toEqual({
+                kind: "piece",
+                space: SPACE,
+                piece: HANDLE,
+                path: ["a", "-"],
+              });
+            });
+
+            it("reads `@foo` as a data key in a later segment", () => {
+              const place = atReferencedPiece();
+              place.cd("a/@foo");
+              expect(place.place.position).toEqual({
+                kind: "piece",
+                space: SPACE,
+                piece: HANDLE,
+                path: ["a", "@foo"],
+              });
+            });
+
+            it("reads `#b` as a data key in a later segment", () => {
+              const place = atReferencedPiece();
+              place.cd("a/#b");
+              expect(place.place.position).toEqual({
+                kind: "piece",
+                space: SPACE,
+                piece: HANDLE,
+                path: ["a", "#b"],
+              });
+            });
+
+            it("reads `..` as a level to leave in a later segment", () => {
+              const place = atReferencedPiece();
+              place.cd("a/..");
+              expect(place.place.position).toEqual({
+                kind: "piece",
+                space: SPACE,
+                piece: HANDLE,
+                path: [],
+              });
+            });
+          });
+
           it("walks every level of a multi-segment operand", () => {
             const place = atSpaceRoot();
             place.cd("slugs/board/topics/3");

--- a/packages/shuttle/test/place.test.ts
+++ b/packages/shuttle/test/place.test.ts
@@ -454,18 +454,16 @@ describe("place", () => {
           });
 
           it("hands back a reference naming its space by name", () => {
+            // The arm carries no space. Whether the name denotes the
+            // connected one is what is not yet known, so there is nothing
+            // for a space field to hold that would not be a guess.
+
             expect(atSpaceRoot().cd(`/@estuary/${HANDLE}/title`)).toEqual({
               kind: "space-by-name",
               name: "estuary",
-              place: {
-                position: {
-                  kind: "piece",
-                  space: SPACE,
-                  piece: HANDLE,
-                  path: ["title"],
-                },
-                scope: "space",
-              },
+              piece: HANDLE,
+              path: ["title"],
+              scope: "space",
             });
           });
         });
@@ -953,13 +951,21 @@ describe("place", () => {
       });
 
       describe("settle()", () => {
-        it("lands the place the move worked out", () => {
+        it("builds the place from the connected space", () => {
           const place = atSpaceRoot();
           const move = place.cd(`/@estuary/${HANDLE}/title`);
           if (move.kind !== "space-by-name") throw new Error("not handed on");
           expect(place.settle(move, SPACE)).toEqual({
             kind: "moved",
-            place: move.place,
+            place: {
+              position: {
+                kind: "piece",
+                space: SPACE,
+                piece: HANDLE,
+                path: ["title"],
+              },
+              scope: "space",
+            },
           });
         });
 
@@ -972,11 +978,10 @@ describe("place", () => {
         });
 
         it("refuses a name that resolved to another space", () => {
-          // The arm's place carries the connected space, since that is the
-          // only space a reference without a DID can name. So settling a
-          // name that resolved elsewhere would land on the same piece id in
-          // the wrong space, and say nothing. The space the name resolved
-          // to is the caller's to supply and this module's to check.
+          // The place is built from the connected space, so settling a name
+          // that resolved elsewhere would land on the same piece id in the
+          // wrong space and say nothing. The space the name resolved to is
+          // the caller's to supply and this module's to check.
 
           const place = atSpaceRoot();
           const move = place.cd(`/@estuary/${HANDLE}`);

--- a/packages/shuttle/test/place.test.ts
+++ b/packages/shuttle/test/place.test.ts
@@ -17,8 +17,8 @@
  * words. Shuttle consumes the reference grammar rather than forking it, so a
  * rooted operand's diagnostics come from that layer and reach the reader
  * unaltered — the space-mismatch sentence and the unknown-suffix sentence
- * from `normalizeLLMFriendlyRef`, and the no-piece-handle sentence from
- * `parseReferenceParts`. Each is marked at its case as relayed. When one
+ * from `normalizeLLMFriendlyRef` and `splitArgumentSuffix`, and the
+ * no-piece-handle sentence from `parseReferenceParts`. Each is marked at its case as relayed. When one
  * moves upstream, the fix is to copy the new sentence here, never to match a
  * fragment of it: the whole sentence is what pins that the diagnostic arrives
  * intact, and a substring would let a rewording through that says something
@@ -178,9 +178,11 @@ describe("place", () => {
         //
         // Held fixed, and why: the space, which one connection settles and
         // no operand supplies, and the facet, which is one of two literals.
-        // Everything else varies — both parts a position spells, the scope
-        // now that the rendering carries it and the comparison is no longer
-        // vacuous, and all four doors that admit a position.
+        // Everything else varies, and varies crosswise: both parts a
+        // position spells, each driven through each of the four doors, at
+        // each of the three scopes. Reading back stands at a scope of its
+        // own, so the comparison sees whether the rendering carried the
+        // scope or the reader supplied it.
 
         const MARKS = [
           " ",
@@ -205,7 +207,12 @@ describe("place", () => {
          * part whose ordinary spelling is `head` followed by `tail`.
          */
         function candidates(head: string, tail: string): string[] {
-          const values = [""];
+          // The digit spellings sit here rather than among the marks: what
+          // they exercise is the conversion a path segment goes through,
+          // where a canonical index becomes a number and everything else
+          // stays a string, and a door that skips it disagrees with the
+          // three that do not.
+          const values = ["", "3", "0", "01", "1e21", "-1", "1.5"];
           for (const mark of MARKS) {
             values.push(
               mark + head + tail,
@@ -222,13 +229,19 @@ describe("place", () => {
           let refusedPart = 0;
           let refusedRendering = 0;
 
-          /** Helper for this case, which holds the property over `place`. */
-          function check(place: CurrentPlace, move: Move): void {
+          /**
+           * Helper for this case, which holds the property over `place`,
+           * reading its rendering back from `reader` — a scope the place is
+           * not at, so a rendering that omitted the scope would be filled
+           * with the wrong one rather than silently the right one.
+           */
+          function check(place: CurrentPlace, move: Move, reader: CellScope) {
             if (move.kind !== "moved") {
               refusedPart++;
               return;
             }
             const elsewhere = atSpaceRoot();
+            elsewhere.cd(`@${reader}`);
             if (elsewhere.cd(printedPosition(place)).kind !== "moved") {
               refusedRendering++;
               return;
@@ -238,9 +251,59 @@ describe("place", () => {
           }
 
           const scopes: CellScope[] = ["space", "user", "session"];
+
+          // The matrix. A door is driven for every component rather than
+          // for whichever one its loop happened to sit in — that asymmetry
+          // is how `settle` kept an unnormalized path while every other
+          // door normalized, in a block whose comment claimed all four.
+          const doors: {
+            door: string;
+            piece: (at: CurrentPlace, value: string) => Move;
+            segment: (at: CurrentPlace, value: string) => Move;
+          }[] = [
+            {
+              door: "enter",
+              piece: (at, v) =>
+                at.enter({ space: SPACE, piece: v, path: [] }, "#x"),
+              segment: (at, v) =>
+                at.enter({ space: SPACE, piece: HANDLE, path: [v] }, "#x"),
+            },
+            {
+              door: "settle",
+              piece: (at, v) =>
+                at.settle({
+                  kind: "space-by-name",
+                  name: "estuary",
+                  piece: v,
+                  path: [],
+                  scope: at.place.scope,
+                }, SPACE),
+              segment: (at, v) =>
+                at.settle({
+                  kind: "space-by-name",
+                  name: "estuary",
+                  piece: HANDLE,
+                  path: [v],
+                  scope: at.place.scope,
+                }, SPACE),
+            },
+            {
+              door: "walk",
+              piece: (at, v) => (at.cd("slugs"), at.cd(v)),
+              segment: (at, v) => (at.cd(`/${HANDLE}`), at.cd(v)),
+            },
+            {
+              door: "reference",
+              piece: (at, v) => at.cd(`/${v}`),
+              segment: (at, v) => at.cd(`/${HANDLE}/${v}`),
+            },
+          ];
+
           const pieces = candidates(HANDLE.slice(0, 10), HANDLE.slice(10));
           const segments = candidates("b", "");
-          for (const scope of scopes) {
+          for (const [index, scope] of scopes.entries()) {
+            const reader = scopes[(index + 1) % scopes.length];
+
             /** Helper for this case, which stands at `scope` to begin with. */
             const standing = (): CurrentPlace => {
               const place = atSpaceRoot();
@@ -248,46 +311,27 @@ describe("place", () => {
               return place;
             };
 
-            for (const piece of pieces) {
-              for (const path of [[], ["tail"]]) {
-                const entered = standing();
-                check(
-                  entered,
-                  entered.enter({ space: SPACE, piece, path }, "#x"),
-                );
-                const settled = standing();
-                check(
-                  settled,
-                  settled.settle({
-                    kind: "space-by-name",
-                    name: "estuary",
-                    piece,
-                    path,
-                    scope,
-                  }, SPACE),
-                );
+            for (const { piece, segment } of doors) {
+              for (const value of pieces) {
+                const at = standing();
+                check(at, piece(at, value), reader);
               }
-              const walked = standing();
-              walked.cd("slugs");
-              check(walked, walked.cd(piece));
-              const referenced = standing();
-              check(referenced, referenced.cd(`/${piece}`));
+              for (const value of segments) {
+                const at = standing();
+                check(at, segment(at, value), reader);
+              }
             }
-            for (const segment of segments) {
-              for (
-                const path of [[segment], [segment, "tail"], ["head", segment]]
-              ) {
-                const entered = standing();
+            // A segment reached past another one, which is the only shape
+            // the single-segment drives above cannot make.
+            for (const value of segments) {
+              for (const path of [[value, "tail"], ["head", value]]) {
+                const at = standing();
                 check(
-                  entered,
-                  entered.enter({ space: SPACE, piece: HANDLE, path }, "#x"),
+                  at,
+                  at.enter({ space: SPACE, piece: HANDLE, path }, "#x"),
+                  reader,
                 );
               }
-              const walked = standing();
-              walked.cd(`/${HANDLE}`);
-              check(walked, walked.cd(segment));
-              const referenced = standing();
-              check(referenced, referenced.cd(`/${HANDLE}/${segment}`));
             }
           }
 
@@ -296,6 +340,36 @@ describe("place", () => {
           expect(readBack).toBeGreaterThan(0);
           expect(refusedPart).toBeGreaterThan(0);
           expect(refusedRendering).toBeGreaterThan(0);
+        });
+      });
+
+      it("returns a base-scope rendering a reader elsewhere reads as base", () => {
+        // The case the ruling turns on. A rendering that omitted the base
+        // suffix would be filled from wherever it was read, so reading one
+        // from a `@user` shuttle is what tells "the scope was written and
+        // read" apart from "the scope was absent and supplied".
+
+        const place = atPiece();
+        expect(place.place.scope).toBe("space");
+        const elsewhere = atSpaceRoot();
+        elsewhere.cd("@user");
+        elsewhere.cd(printedPosition(place));
+        expect(elsewhere.place).toEqual(place.place);
+      });
+
+      it("returns a container rendering whose refusal names the right fault", () => {
+        // A container's rendering starts with the space's `@`, so pasting
+        // one back reaches the scope reading. The refusal has to be about
+        // what was pasted rather than about a scope word nobody wrote.
+
+        const place = inSlugs();
+        const move = atSpaceRoot().cd(printedPosition(place));
+        expect(move).toEqual({
+          kind: "refused",
+          reason: "`@did:key:z6MkConnectedSpace/slugs/` names no scope: a " +
+            "scope word holds no `/`. What `pwd` prints for a space root " +
+            "or a facet is spelled this way and names no cell — reach one " +
+            "by its facet or its piece.",
         });
       });
 
@@ -858,6 +932,17 @@ describe("place", () => {
             });
           });
 
+          it("gives a bare fragment the wording a reference's gets", () => {
+            // The two are copies: shuttle authors this one so the surfaces
+            // read as one, and the canonical layer authors the other. Only
+            // pinning them equal makes a reword that moves one and not the
+            // other fail here rather than diverge quietly.
+
+            expect(inSlugs().cd("board#result")).toEqual(
+              atSpaceRoot().cd(`/${HANDLE}#result`),
+            );
+          });
+
           it("names the whole fragment, not the part before a second `#`", () => {
             expect(inSlugs().cd("board#argument#x")).toEqual({
               kind: "refused",
@@ -1351,6 +1436,27 @@ describe("place", () => {
               "space.",
           });
           expect(place.place).toEqual(placeAtSpaceRoot(SPACE));
+        });
+
+        it("carries a number a move already converted through unchanged", () => {
+          // A move `cd` minted holds a path the reference grammar already
+          // converted, so the number arm of that conversion is the one such
+          // a move arrives on.
+
+          const place = atSpaceRoot();
+          place.settle({
+            kind: "space-by-name",
+            name: "estuary",
+            piece: HANDLE,
+            path: [3],
+            scope: "space",
+          }, SPACE);
+          expect(place.place.position).toEqual({
+            kind: "piece",
+            space: SPACE,
+            piece: HANDLE,
+            path: [3],
+          });
         });
 
         it("refuses a move whose path holds a number no digits name back", () => {

--- a/packages/shuttle/test/place.test.ts
+++ b/packages/shuttle/test/place.test.ts
@@ -42,6 +42,12 @@ function inSlugs(): CurrentPlace {
   return place;
 }
 
+/** Helper for the cases below, which reads the position `pwd` printed. */
+function printedPosition(place: CurrentPlace): string {
+  const [position] = place.render().split("\n");
+  return position.slice("position  ".length);
+}
+
 /** Helper for the cases below, which stands an instance at a piece. */
 function atPiece(): CurrentPlace {
   const place = inSlugs();
@@ -66,15 +72,15 @@ describe("place", () => {
   });
 
   describe("renderPlace()", () => {
-    it("returns the space root with a trailing slash, and the scope", () => {
+    it("returns a space root with no leading slash, and the scope", () => {
       expect(renderPlace(placeAtSpaceRoot(SPACE))).toBe(
-        "position  /@did:key:z6MkConnectedSpace/\nscope     @space",
+        "position  @did:key:z6MkConnectedSpace/\nscope     @space",
       );
     });
 
-    it("returns a facet with a trailing slash", () => {
+    it("returns a facet with no leading slash", () => {
       expect(renderPlace(inSlugs().place)).toBe(
-        "position  /@did:key:z6MkConnectedSpace/slugs/\nscope     @space",
+        "position  @did:key:z6MkConnectedSpace/slugs/\nscope     @space",
       );
     });
 
@@ -86,6 +92,35 @@ describe("place", () => {
         "position  /@did:key:z6MkConnectedSpace/board/topics/3\n" +
           "scope     @session",
       );
+    });
+
+    describe("round-tripping", () => {
+      // What a reader copies has to name the place it was printed for, or
+      // name nothing. A piece is a cell, so its rendering is a reference and
+      // `cd` takes it back; a container is not a cell, so its rendering is
+      // not a reference and `cd` refuses it rather than resolving it to a
+      // piece whose slug happens to match the container's name.
+
+      it("returns a piece rendering `cd` takes back to the same place", () => {
+        const place = atPiece();
+        place.cd("topics/3");
+        const elsewhere = atSpaceRoot();
+        elsewhere.cd(printedPosition(place));
+        expect(elsewhere.place).toEqual(place.place);
+      });
+
+      it("returns a space root rendering `cd` refuses", () => {
+        const place = atSpaceRoot();
+        expect(place.cd(printedPosition(place)).kind).toBe("refused");
+        expect(place.place).toEqual(placeAtSpaceRoot(SPACE));
+      });
+
+      it("returns a facet rendering `cd` refuses", () => {
+        const place = inSlugs();
+        const facet = place.place;
+        expect(place.cd(printedPosition(place)).kind).toBe("refused");
+        expect(place.place).toEqual(facet);
+      });
     });
   });
 
@@ -164,7 +199,6 @@ describe("place", () => {
                   space: SPACE,
                   piece: "board",
                   path: [],
-                  facet: "slugs",
                 },
                 scope: "space",
               },
@@ -181,6 +215,17 @@ describe("place", () => {
               space: SPACE,
               piece: "board",
               path: ["topics"],
+            });
+          });
+
+          it("restores the route, so `..` backs out the way it came", () => {
+            const place = atPiece();
+            place.cd("..");
+            place.cd("-");
+            place.cd("..");
+            expect(place.place.position).toEqual({
+              kind: "facet",
+              space: SPACE,
               facet: "slugs",
             });
           });
@@ -204,7 +249,6 @@ describe("place", () => {
                   space: SPACE,
                   piece: "board",
                   path: [],
-                  facet: "slugs",
                 },
                 scope: "session",
               },
@@ -216,6 +260,17 @@ describe("place", () => {
             place.cd("@user");
             place.cd("@space");
             expect(place.place.scope).toBe("space");
+          });
+
+          it("keeps the route, so `..` still backs out to the facet", () => {
+            const place = atPiece();
+            place.cd("@session");
+            place.cd("..");
+            expect(place.place.position).toEqual({
+              kind: "facet",
+              space: SPACE,
+              facet: "slugs",
+            });
           });
 
           it("refuses a suffix naming no scope", () => {
@@ -236,7 +291,6 @@ describe("place", () => {
                   space: SPACE,
                   piece: "board",
                   path: [],
-                  facet: "slugs",
                 },
                 scope: "session",
               },
@@ -329,7 +383,7 @@ describe("place", () => {
           });
 
           it("refuses a rooted string that names no piece", () => {
-            expect(atSpaceRoot().cd("/")).toEqual({
+            expect(atSpaceRoot().cd("//")).toEqual({
               kind: "refused",
               reason:
                 'Target must include a piece handle, e.g. "/of:fid1:abc123/path".',
@@ -350,6 +404,44 @@ describe("place", () => {
                 scope: "space",
               },
             });
+          });
+        });
+
+        describe("the space root", () => {
+          it("moves to the space root for `/` from a piece", () => {
+            expect(atPiece().cd("/")).toEqual({
+              kind: "moved",
+              place: {
+                position: { kind: "root", space: SPACE },
+                scope: "space",
+              },
+            });
+          });
+
+          it("moves to the space root for `/` from a path in a piece", () => {
+            const place = atPiece();
+            place.cd("topics/3");
+            place.cd("/");
+            expect(place.place.position).toEqual({
+              kind: "root",
+              space: SPACE,
+            });
+          });
+
+          it("moves to the space root for `/` from a facet", () => {
+            const place = inSlugs();
+            place.cd("/");
+            expect(place.place.position).toEqual({
+              kind: "root",
+              space: SPACE,
+            });
+          });
+
+          it("leaves the scope alone for `/`", () => {
+            const place = atPiece();
+            place.cd("@session");
+            place.cd("/");
+            expect(place.place.scope).toBe("session");
           });
         });
 
@@ -390,7 +482,6 @@ describe("place", () => {
                   space: SPACE,
                   piece: "board",
                   path: [],
-                  facet: "slugs",
                 },
                 scope: "space",
               },
@@ -405,7 +496,25 @@ describe("place", () => {
               space: SPACE,
               piece: "board",
               path: ["topics", 3],
-              facet: "slugs",
+            });
+          });
+
+          it("refuses `#` in a segment naming a piece", () => {
+            expect(inSlugs().cd("board#argument")).toEqual({
+              kind: "refused",
+              reason: 'The "#argument" suffix rides the reference form ' +
+                "(/of:fid1:...#argument), not the bare piece id.",
+            });
+          });
+
+          it("reads `#` inside a piece as part of a data key", () => {
+            const place = atPiece();
+            place.cd("topics#argument");
+            expect(place.place.position).toEqual({
+              kind: "piece",
+              space: SPACE,
+              piece: "board",
+              path: ["topics#argument"],
             });
           });
 
@@ -417,7 +526,6 @@ describe("place", () => {
               space: SPACE,
               piece: "board",
               path: ["mail@example"],
-              facet: "slugs",
             });
           });
 
@@ -429,7 +537,6 @@ describe("place", () => {
               space: SPACE,
               piece: "board",
               path: ["topics", 3],
-              facet: "slugs",
             });
           });
 
@@ -460,6 +567,23 @@ describe("place", () => {
             });
           });
 
+          it("walks out one level per `..`", () => {
+            const place = atPiece();
+            place.cd("..");
+            place.cd("..");
+            expect(place.place.position).toEqual({
+              kind: "root",
+              space: SPACE,
+            });
+          });
+
+          it("keeps the scope backing out of a piece a reference named", () => {
+            const place = atSpaceRoot();
+            place.cd(`/${HANDLE}@user`);
+            place.cd("..");
+            expect(place.place.scope).toBe("user");
+          });
+
           it("moves from a facet to the space root", () => {
             const place = inSlugs();
             place.cd("..");
@@ -478,7 +602,6 @@ describe("place", () => {
               space: SPACE,
               piece: "board",
               path: ["topics"],
-              facet: "slugs",
             });
           });
 
@@ -489,6 +612,18 @@ describe("place", () => {
               kind: "facet",
               space: SPACE,
               facet: "slugs",
+            });
+          });
+
+          it("drops a path segment inside a piece a reference named", () => {
+            const place = atSpaceRoot();
+            place.cd(`/${HANDLE}/topics/3`);
+            place.cd("..");
+            expect(place.place.position).toEqual({
+              kind: "piece",
+              space: SPACE,
+              piece: HANDLE,
+              path: ["topics"],
             });
           });
 
@@ -561,6 +696,38 @@ describe("place", () => {
           const place = atSpaceRoot();
           place.enter({ space: OTHER_SPACE, piece: HANDLE }, "#profile");
           expect(place.place).toEqual(placeAtSpaceRoot(SPACE));
+        });
+      });
+
+      describe("settle()", () => {
+        it("lands the place the move worked out", () => {
+          const place = atSpaceRoot();
+          const move = place.cd(`/@estuary/${HANDLE}/title`);
+          if (move.kind !== "space-by-name") throw new Error("not handed on");
+          expect(place.settle(move)).toEqual({
+            kind: "moved",
+            place: move.place,
+          });
+        });
+
+        it("keeps the scope a space-named reference asked for", () => {
+          const place = atSpaceRoot();
+          const move = place.cd(`/@estuary/${HANDLE}@user`);
+          if (move.kind !== "space-by-name") throw new Error("not handed on");
+          place.settle(move);
+          expect(place.place.scope).toBe("user");
+        });
+
+        it("carries no route, so `..` leaves the piece for the root", () => {
+          const place = inSlugs();
+          const move = place.cd(`/@estuary/${HANDLE}`);
+          if (move.kind !== "space-by-name") throw new Error("not handed on");
+          place.settle(move);
+          place.cd("..");
+          expect(place.place.position).toEqual({
+            kind: "root",
+            space: SPACE,
+          });
         });
       });
 

--- a/packages/shuttle/test/place.test.ts
+++ b/packages/shuttle/test/place.test.ts
@@ -558,7 +558,7 @@ describe("place", () => {
             });
           });
 
-          it("reads a segment inside a piece as data, `@` included", () => {
+          it("reads `@` inside a segment as part of a data key", () => {
             const place = atPiece();
             place.cd("mail@example");
             expect(place.place.position).toEqual({
@@ -569,10 +569,19 @@ describe("place", () => {
             });
           });
 
+          it("refuses a leading `@` inside a piece, reading it as a scope word", () => {
+            expect(atReferencedPiece().cd("@foo")).toEqual({
+              kind: "refused",
+              reason: "`@foo` names no scope. The scopes are `@space`, " +
+                "`@user`, and `@session`.",
+            });
+          });
+
           it("reads `~1` in a segment as two characters of a data key", () => {
             // A relative operand is not a reference, so the reference
             // grammar's `~1` escaping does not reach it: `~1` is literal
-            // here where a reference reads it as the separator. The case
+            // here where a reference reads it as a literal `/` inside the
+            // key. The case
             // below is the consequence — a key holding a `/` has no
             // relative spelling at all, since neither candidate reaches it
             // — and both are pinned so that teaching the walk to unescape
@@ -749,6 +758,26 @@ describe("place", () => {
             space: SPACE,
             piece: HANDLE,
             path: [],
+          });
+        });
+
+        it("normalizes the path the way a reference's is normalized", () => {
+          // A position names its cell and nothing about how it was reached,
+          // so the three doors have to agree on what a segment means. A
+          // canonical index is where they would part: the two `cd` branches
+          // convert one to a number and a resolution hands over what it
+          // read.
+
+          const entered = atSpaceRoot();
+          entered.enter({ space: SPACE, piece: HANDLE, path: ["3"] }, "#x");
+          const referenced = atSpaceRoot();
+          referenced.cd(`/${HANDLE}/3`);
+          expect(entered.place).toEqual(referenced.place);
+          expect(entered.place.position).toEqual({
+            kind: "piece",
+            space: SPACE,
+            piece: HANDLE,
+            path: [3],
           });
         });
 

--- a/packages/shuttle/test/place.test.ts
+++ b/packages/shuttle/test/place.test.ts
@@ -957,7 +957,7 @@ describe("place", () => {
           const place = atSpaceRoot();
           const move = place.cd(`/@estuary/${HANDLE}/title`);
           if (move.kind !== "space-by-name") throw new Error("not handed on");
-          expect(place.settle(move)).toEqual({
+          expect(place.settle(move, SPACE)).toEqual({
             kind: "moved",
             place: move.place,
           });
@@ -967,15 +967,35 @@ describe("place", () => {
           const place = atSpaceRoot();
           const move = place.cd(`/@estuary/${HANDLE}@user`);
           if (move.kind !== "space-by-name") throw new Error("not handed on");
-          place.settle(move);
+          place.settle(move, SPACE);
           expect(place.place.scope).toBe("user");
+        });
+
+        it("refuses a name that resolved to another space", () => {
+          // The arm's place carries the connected space, since that is the
+          // only space a reference without a DID can name. So settling a
+          // name that resolved elsewhere would land on the same piece id in
+          // the wrong space, and say nothing. The space the name resolved
+          // to is the caller's to supply and this module's to check.
+
+          const place = atSpaceRoot();
+          const move = place.cd(`/@estuary/${HANDLE}`);
+          if (move.kind !== "space-by-name") throw new Error("not handed on");
+          expect(place.settle(move, OTHER_SPACE)).toEqual({
+            kind: "refused",
+            reason: "`estuary` resolves to space `did:key:z6MkOtherSpace`, " +
+              "and this shuttle is connected to " +
+              "`did:key:z6MkConnectedSpace`. One connection serves one " +
+              "space.",
+          });
+          expect(place.place).toEqual(placeAtSpaceRoot(SPACE));
         });
 
         it("carries no route, so `..` leaves the piece for the root", () => {
           const place = inSlugs();
           const move = place.cd(`/@estuary/${HANDLE}`);
           if (move.kind !== "space-by-name") throw new Error("not handed on");
-          place.settle(move);
+          place.settle(move, SPACE);
           place.cd("..");
           expect(place.place.position).toEqual({
             kind: "root",

--- a/packages/shuttle/test/place.test.ts
+++ b/packages/shuttle/test/place.test.ts
@@ -172,14 +172,15 @@ describe("place", () => {
         // covered. So both parts a position spells vary, the empty value is
         // a candidate in its own right rather than something the shapes
         // happen not to reach, and every door that admits a position is
-        // driven — the two that take a caller's data, and the walk that
-        // takes a string.
+        // driven.
         //
         // Held fixed, and why: the space, which one connection settles and
-        // no operand supplies, and the facet, which is one of two literals.
+        // no operand supplies, and the facet, which is a fixed set of
+        // literals.
         // Everything else varies, and varies crosswise: both parts a
-        // position spells, each driven through each of the four doors, at
-        // each of the three scopes. Reading back stands at a scope of its
+        // position spells, each driven through every door in the table
+        // below, at each of the three scopes. Reading back stands at a
+        // scope of its
         // own, so the comparison sees whether the rendering carried the
         // scope or the reader supplied it.
 
@@ -1082,10 +1083,10 @@ describe("place", () => {
           describe("reserved readings", () => {
             // Each of these drives its character at the head of a later
             // segment, where the head-of-operand cases drive it first.
-            // That position is what tells the two kinds of reading apart —
-            // one decided on the whole operand, one decided segment by
-            // segment — so the four together pin which kind each reading
-            // is, rather than four instances of one kind.
+            // That position is what tells a reading decided on the whole
+            // operand from one decided segment by segment, so these pin
+            // which kind each reading is rather than several instances of
+            // one kind.
 
             it("reads `-` as a data key in a later segment", () => {
               const place = atReferencedPiece();
@@ -1349,10 +1350,9 @@ describe("place", () => {
 
         it("normalizes the path the way a reference's is normalized", () => {
           // A position names its cell and nothing about how it was reached,
-          // so the three doors have to agree on what a segment means. A
-          // canonical index is where they would part: the two `cd` branches
-          // convert one to a number and a resolution hands over what it
-          // read.
+          // so every door has to agree on what a segment means. A canonical
+          // index is where they would part: a door that skips the conversion
+          // lands a string where the others land a number.
 
           const entered = atSpaceRoot();
           entered.enter({ space: SPACE, piece: HANDLE, path: ["3"] }, "#x");

--- a/packages/shuttle/test/place.test.ts
+++ b/packages/shuttle/test/place.test.ts
@@ -111,7 +111,7 @@ describe("place", () => {
       );
     });
 
-    it("returns a piece and its path as a complete reference", () => {
+    it("returns a piece and its path as a fully qualified reference", () => {
       const place = atPiece();
       place.cd("topics/3");
       place.cd("@session");

--- a/packages/shuttle/test/place.test.ts
+++ b/packages/shuttle/test/place.test.ts
@@ -17,6 +17,7 @@
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
 
+import type { CellScope } from "@commonfabric/api";
 import type { MemorySpace } from "@commonfabric/memory/interface";
 
 import {
@@ -97,7 +98,7 @@ describe("place", () => {
       place.cd("topics/3");
       place.cd("@session");
       expect(renderPlace(place.place)).toBe(
-        "position  /@did:key:z6MkConnectedSpace/board/topics/3\n" +
+        "position  /@did:key:z6MkConnectedSpace/board@session/topics/3\n" +
           "scope     @session",
       );
     });
@@ -126,7 +127,7 @@ describe("place", () => {
         place.cd(`/${HANDLE}/a~1b`);
         const printed = printedPosition(place);
         expect(printed).toBe(
-          "/@did:key:z6MkConnectedSpace/of:fid1:abcdefghijklmnop/a~1b",
+          "/@did:key:z6MkConnectedSpace/of:fid1:abcdefghijklmnop@space/a~1b",
         );
         const elsewhere = atSpaceRoot();
         elsewhere.cd(printed);
@@ -142,7 +143,7 @@ describe("place", () => {
       });
 
       describe("over a constructed set of awkward parts", () => {
-        // Four findings in this class arrived one at a time, each from
+        // Five findings in this class arrived one at a time, each from
         // driving a value nobody had listed. This drives a construction and
         // asserts the property rather than the outcomes: a rendering may be
         // refused, but it may never name a cell other than the one it was
@@ -158,10 +159,10 @@ describe("place", () => {
         // takes a string.
         //
         // Held fixed, and why: the space, which one connection settles and
-        // no operand supplies; the facet, which is one of two literals; and
-        // the scope, which is one of three words and which `toEqual`
-        // therefore compares vacuously here, both sides being the base. A
-        // format that renders the scope differently would want that varied.
+        // no operand supplies, and the facet, which is one of two literals.
+        // Everything else varies — both parts a position spells, the scope
+        // now that the rendering carries it and the comparison is no longer
+        // vacuous, and all four doors that admit a position.
 
         const MARKS = [
           " ",
@@ -218,42 +219,58 @@ describe("place", () => {
             expect(elsewhere.place).toEqual(place.place);
           }
 
+          const scopes: CellScope[] = ["space", "user", "session"];
           const pieces = candidates(HANDLE.slice(0, 10), HANDLE.slice(10));
           const segments = candidates("b", "");
-          for (const piece of pieces) {
-            for (const path of [[], ["tail"]]) {
-              const entered = atSpaceRoot();
-              check(
-                entered,
-                entered.enter({ space: SPACE, piece, path }, "#x"),
-              );
-              const settled = atSpaceRoot();
-              check(
-                settled,
-                settled.settle({
-                  kind: "space-by-name",
-                  name: "estuary",
-                  piece,
-                  path,
-                  scope: "space",
-                }, SPACE),
-              );
+          for (const scope of scopes) {
+            /** Helper for this case, which stands at `scope` to begin with. */
+            const standing = (): CurrentPlace => {
+              const place = atSpaceRoot();
+              place.cd(`@${scope}`);
+              return place;
+            };
+
+            for (const piece of pieces) {
+              for (const path of [[], ["tail"]]) {
+                const entered = standing();
+                check(
+                  entered,
+                  entered.enter({ space: SPACE, piece, path }, "#x"),
+                );
+                const settled = standing();
+                check(
+                  settled,
+                  settled.settle({
+                    kind: "space-by-name",
+                    name: "estuary",
+                    piece,
+                    path,
+                    scope,
+                  }, SPACE),
+                );
+              }
+              const walked = standing();
+              walked.cd("slugs");
+              check(walked, walked.cd(piece));
+              const referenced = standing();
+              check(referenced, referenced.cd(`/${piece}`));
             }
-            const walked = inSlugs();
-            check(walked, walked.cd(piece));
-          }
-          for (const segment of segments) {
-            for (
-              const path of [[segment], [segment, "tail"], ["head", segment]]
-            ) {
-              const entered = atSpaceRoot();
-              check(
-                entered,
-                entered.enter({ space: SPACE, piece: HANDLE, path }, "#x"),
-              );
+            for (const segment of segments) {
+              for (
+                const path of [[segment], [segment, "tail"], ["head", segment]]
+              ) {
+                const entered = standing();
+                check(
+                  entered,
+                  entered.enter({ space: SPACE, piece: HANDLE, path }, "#x"),
+                );
+              }
+              const walked = standing();
+              walked.cd(`/${HANDLE}`);
+              check(walked, walked.cd(segment));
+              const referenced = standing();
+              check(referenced, referenced.cd(`/${HANDLE}/${segment}`));
             }
-            const walked = atReferencedPiece();
-            check(walked, walked.cd(segment));
           }
 
           // Every outcome has to occur, or the property above holds for want
@@ -531,6 +548,17 @@ describe("place", () => {
             });
           });
 
+          it("keeps the scope the place was reading through", () => {
+            // A reference without a suffix says nothing about scope, so the
+            // ambient one fills it, the way the place fills the levels the
+            // reference omits.
+
+            const place = atSpaceRoot();
+            place.cd("@session");
+            place.cd(`/${HANDLE}/title`);
+            expect(place.place.scope).toBe("session");
+          });
+
           it("refuses a complete reference naming another space", () => {
             expect(atSpaceRoot().cd(`/@${OTHER_SPACE}/${HANDLE}`)).toEqual({
               kind: "refused",
@@ -797,18 +825,18 @@ describe("place", () => {
           it("refuses any other fragment for carrying no suffix at all", () => {
             expect(inSlugs().cd("board#result")).toEqual({
               kind: "refused",
-              reason: 'Unknown reference suffix "#result". The one ' +
-                'supported suffix is "#argument", which the reference form ' +
-                "carries and a bare piece id does not.",
+              reason: 'Unknown suffix "#result". The one supported suffix ' +
+                'is "#argument", which selects the piece\'s arguments cell ' +
+                'the way "--input" does.',
             });
           });
 
           it("names the whole fragment, not the part before a second `#`", () => {
             expect(inSlugs().cd("board#argument#x")).toEqual({
               kind: "refused",
-              reason: 'Unknown reference suffix "#argument#x". The one ' +
-                'supported suffix is "#argument", which the reference form ' +
-                "carries and a bare piece id does not.",
+              reason: 'Unknown suffix "#argument#x". The one supported ' +
+                'suffix is "#argument", which selects the piece\'s ' +
+                'arguments cell the way "--input" does.',
             });
           });
 
@@ -1298,6 +1326,27 @@ describe("place", () => {
           expect(place.place).toEqual(placeAtSpaceRoot(SPACE));
         });
 
+        it("refuses a move whose path holds a number no digits name back", () => {
+          // A number renders as its digits, and only a canonical array
+          // index reads back as the number it was. This door is the one
+          // documented as taking a caller's own move, so it is where such
+          // a path arrives.
+
+          const place = atSpaceRoot();
+          expect(place.settle({
+            kind: "space-by-name",
+            name: "estuary",
+            piece: HANDLE,
+            path: [1.5],
+            scope: "space",
+          }, SPACE)).toEqual({
+            kind: "refused",
+            reason: "The reference naming space `estuary` has a segment " +
+              "that is no canonical index, so a rendering of the place " +
+              "would name a different cell.",
+          });
+        });
+
         it("refuses a move whose path holds a segment no rendering names", () => {
           // The arm is exported, so a caller can build one. `cd` cannot
           // mint a bad path any more, which leaves a hand-built move as the
@@ -1337,7 +1386,7 @@ describe("place", () => {
           const place = atPiece();
           place.cd("topics/3");
           expect(place.render()).toBe(
-            "position  /@did:key:z6MkConnectedSpace/board/topics/3\n" +
+            "position  /@did:key:z6MkConnectedSpace/board@space/topics/3\n" +
               "scope     @space",
           );
         });

--- a/packages/shuttle/test/place.test.ts
+++ b/packages/shuttle/test/place.test.ts
@@ -1,0 +1,563 @@
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import type { MemorySpace } from "@commonfabric/memory/interface";
+
+import {
+  CurrentPlace,
+  FACETS,
+  placeAtSpaceRoot,
+  renderPlace,
+} from "../src/place.ts";
+
+const SPACE = "did:key:z6MkConnectedSpace" as MemorySpace;
+const OTHER_SPACE = "did:key:z6MkOtherSpace" as MemorySpace;
+const HANDLE = "of:fid1:abcdefghijklmnop";
+
+/** Helper for the cases below, which stands an instance at the space root. */
+function atSpaceRoot(): CurrentPlace {
+  return new CurrentPlace(placeAtSpaceRoot(SPACE));
+}
+
+/** Helper for the cases below, which stands an instance inside `slugs/`. */
+function inSlugs(): CurrentPlace {
+  const place = atSpaceRoot();
+  place.cd("slugs");
+  return place;
+}
+
+/** Helper for the cases below, which stands an instance at a piece. */
+function atPiece(): CurrentPlace {
+  const place = inSlugs();
+  place.cd("board");
+  return place;
+}
+
+describe("place", () => {
+  describe("FACETS", () => {
+    it("holds `slugs` and `pieces`, and nothing else", () => {
+      expect(FACETS).toEqual(["slugs", "pieces"]);
+    });
+  });
+
+  describe("placeAtSpaceRoot()", () => {
+    it("returns the space's root read at the base scope", () => {
+      expect(placeAtSpaceRoot(SPACE)).toEqual({
+        position: { kind: "root", space: SPACE },
+        scope: "space",
+      });
+    });
+  });
+
+  describe("renderPlace()", () => {
+    it("returns the space root with a trailing slash, and the scope", () => {
+      expect(renderPlace(placeAtSpaceRoot(SPACE))).toBe(
+        "position  /@did:key:z6MkConnectedSpace/\nscope     @space",
+      );
+    });
+
+    it("returns a facet with a trailing slash", () => {
+      expect(renderPlace(inSlugs().place)).toBe(
+        "position  /@did:key:z6MkConnectedSpace/slugs/\nscope     @space",
+      );
+    });
+
+    it("returns a piece and its path as a complete reference", () => {
+      const place = atPiece();
+      place.cd("topics/3");
+      place.cd("@session");
+      expect(renderPlace(place.place)).toBe(
+        "position  /@did:key:z6MkConnectedSpace/board/topics/3\n" +
+          "scope     @session",
+      );
+    });
+  });
+
+  describe("CurrentPlace", () => {
+    describe("constructor()", () => {
+      it("returns an instance standing at the place it was given", () => {
+        expect(atSpaceRoot().place).toEqual(placeAtSpaceRoot(SPACE));
+      });
+
+      it("returns an instance with no previous place", () => {
+        expect(atSpaceRoot().previous).toBeUndefined();
+      });
+    });
+
+    describe("instance members", () => {
+      describe("place", () => {
+        it("returns the place a landed move moved to", () => {
+          const place = atSpaceRoot();
+          place.cd("pieces");
+          expect(place.place).toEqual({
+            position: { kind: "facet", space: SPACE, facet: "pieces" },
+            scope: "space",
+          });
+        });
+
+        it("returns the place shuttle stood at when a move is refused", () => {
+          const place = atSpaceRoot();
+          place.cd("board");
+          expect(place.place).toEqual(placeAtSpaceRoot(SPACE));
+        });
+
+        it("returns the place shuttle stood at for a wish target", () => {
+          const place = atSpaceRoot();
+          place.cd("#favorites");
+          expect(place.place).toEqual(placeAtSpaceRoot(SPACE));
+        });
+
+        it("returns the place shuttle stood at for a space named by name", () => {
+          const place = atSpaceRoot();
+          place.cd(`/@estuary/${HANDLE}`);
+          expect(place.place).toEqual(placeAtSpaceRoot(SPACE));
+        });
+      });
+
+      describe("previous", () => {
+        it("returns the place a landed move moved out of", () => {
+          const place = atSpaceRoot();
+          place.cd("slugs");
+          expect(place.previous).toEqual(placeAtSpaceRoot(SPACE));
+        });
+
+        it("returns nothing after a refused move", () => {
+          const place = atSpaceRoot();
+          place.cd("board");
+          expect(place.previous).toBeUndefined();
+        });
+      });
+
+      describe("cd()", () => {
+        it("refuses an empty operand", () => {
+          expect(atSpaceRoot().cd("  ")).toEqual({
+            kind: "refused",
+            reason: "`cd` takes a place to move to.",
+          });
+        });
+
+        describe("the previous place", () => {
+          it("returns to the previous place for `-`", () => {
+            const place = atPiece();
+            place.cd("topics");
+            expect(place.cd("-")).toEqual({
+              kind: "moved",
+              place: {
+                position: {
+                  kind: "piece",
+                  space: SPACE,
+                  piece: "board",
+                  path: [],
+                  facet: "slugs",
+                },
+                scope: "space",
+              },
+            });
+          });
+
+          it("swaps the two places, so a second `-` goes back again", () => {
+            const place = atPiece();
+            place.cd("topics");
+            place.cd("-");
+            place.cd("-");
+            expect(place.place.position).toEqual({
+              kind: "piece",
+              space: SPACE,
+              piece: "board",
+              path: ["topics"],
+              facet: "slugs",
+            });
+          });
+
+          it("refuses `-` while there is no previous place", () => {
+            expect(atSpaceRoot().cd("-")).toEqual({
+              kind: "refused",
+              reason: "There is no previous place to return to.",
+            });
+          });
+        });
+
+        describe("scope", () => {
+          it("moves the scope alone for `@session`", () => {
+            const place = atPiece();
+            expect(place.cd("@session")).toEqual({
+              kind: "moved",
+              place: {
+                position: {
+                  kind: "piece",
+                  space: SPACE,
+                  piece: "board",
+                  path: [],
+                  facet: "slugs",
+                },
+                scope: "session",
+              },
+            });
+          });
+
+          it("moves the scope back to the base for `@space`", () => {
+            const place = atSpaceRoot();
+            place.cd("@user");
+            place.cd("@space");
+            expect(place.place.scope).toBe("space");
+          });
+
+          it("refuses a suffix naming no scope", () => {
+            expect(atSpaceRoot().cd("@overlay")).toEqual({
+              kind: "refused",
+              reason: "`@overlay` names no scope. The scopes are `@space`, " +
+                "`@user`, and `@session`.",
+            });
+          });
+
+          it("moves position and scope together for `board@session`", () => {
+            const place = inSlugs();
+            expect(place.cd("board@session")).toEqual({
+              kind: "moved",
+              place: {
+                position: {
+                  kind: "piece",
+                  space: SPACE,
+                  piece: "board",
+                  path: [],
+                  facet: "slugs",
+                },
+                scope: "session",
+              },
+            });
+          });
+
+          it("refuses a suffix on a piece segment naming no scope", () => {
+            expect(inSlugs().cd("board@overlay")).toEqual({
+              kind: "refused",
+              reason: 'Invalid scope suffix "@overlay" in link handle. ' +
+                "Expected @space, @user, or @session.",
+            });
+          });
+        });
+
+        describe("references", () => {
+          it("takes the space from the place for a rooted reference", () => {
+            expect(atPiece().cd(`/${HANDLE}/topics/3`)).toEqual({
+              kind: "moved",
+              place: {
+                position: {
+                  kind: "piece",
+                  space: SPACE,
+                  piece: HANDLE,
+                  path: ["topics", 3],
+                },
+                scope: "space",
+              },
+            });
+          });
+
+          it("moves for a complete reference naming the connected space", () => {
+            expect(atSpaceRoot().cd(`/@${SPACE}/${HANDLE}`)).toEqual({
+              kind: "moved",
+              place: {
+                position: {
+                  kind: "piece",
+                  space: SPACE,
+                  piece: HANDLE,
+                  path: [],
+                },
+                scope: "space",
+              },
+            });
+          });
+
+          it("refuses a complete reference naming another space", () => {
+            expect(atSpaceRoot().cd(`/@${OTHER_SPACE}/${HANDLE}`)).toEqual({
+              kind: "refused",
+              reason: `Reference names space "${OTHER_SPACE}" but the ` +
+                `command targets space "${SPACE}".`,
+            });
+          });
+
+          it("takes the scope from an `@scope` suffix on the piece", () => {
+            expect(atSpaceRoot().cd(`/${HANDLE}@user/title`)).toEqual({
+              kind: "moved",
+              place: {
+                position: {
+                  kind: "piece",
+                  space: SPACE,
+                  piece: HANDLE,
+                  path: ["title"],
+                },
+                scope: "user",
+              },
+            });
+          });
+
+          it("refuses a reference carrying `#argument`", () => {
+            expect(atSpaceRoot().cd(`/${HANDLE}#argument`)).toEqual({
+              kind: "refused",
+              reason:
+                "A place is result-rooted, so `cd` takes no `#argument` " +
+                "suffix. A place rooted at the arguments cell would leave " +
+                "every later relative read ambiguous about which side of " +
+                "the piece it addressed. Reach arguments per operand " +
+                "instead, as in `get topics/3#argument`.",
+            });
+          });
+
+          it("refuses a reference carrying any other fragment", () => {
+            const move = atSpaceRoot().cd(`/${HANDLE}#result`);
+            expect(move).toEqual({
+              kind: "refused",
+              reason: 'Unknown reference suffix "#result". The one supported ' +
+                'suffix is "#argument", which selects the piece\'s arguments ' +
+                'cell the way "--input" does.',
+            });
+          });
+
+          it("refuses a rooted string that names no piece", () => {
+            expect(atSpaceRoot().cd("/")).toEqual({
+              kind: "refused",
+              reason:
+                'Target must include a piece handle, e.g. "/of:fid1:abc123/path".',
+            });
+          });
+
+          it("hands back a reference naming its space by name", () => {
+            expect(atSpaceRoot().cd(`/@estuary/${HANDLE}/title`)).toEqual({
+              kind: "space-by-name",
+              name: "estuary",
+              place: {
+                position: {
+                  kind: "piece",
+                  space: SPACE,
+                  piece: HANDLE,
+                  path: ["title"],
+                },
+                scope: "space",
+              },
+            });
+          });
+        });
+
+        describe("wish targets", () => {
+          it("hands back a `#name` target for the connection to resolve", () => {
+            expect(atSpaceRoot().cd("#favorites")).toEqual({
+              kind: "wish",
+              target: "#favorites",
+            });
+          });
+        });
+
+        describe("relative segments", () => {
+          it("moves into a facet named at the space root", () => {
+            expect(atSpaceRoot().cd("slugs")).toEqual({
+              kind: "moved",
+              place: {
+                position: { kind: "facet", space: SPACE, facet: "slugs" },
+                scope: "space",
+              },
+            });
+          });
+
+          it("refuses a segment at the space root naming no facet", () => {
+            expect(atSpaceRoot().cd("board")).toEqual({
+              kind: "refused",
+              reason: "A space root lists facets, and `board` names none. " +
+                "The facets are `slugs/` and `pieces/`.",
+            });
+          });
+
+          it("moves to a piece named inside a facet", () => {
+            expect(inSlugs().cd("board")).toEqual({
+              kind: "moved",
+              place: {
+                position: {
+                  kind: "piece",
+                  space: SPACE,
+                  piece: "board",
+                  path: [],
+                  facet: "slugs",
+                },
+                scope: "space",
+              },
+            });
+          });
+
+          it("reads a canonical index inside a piece as a number", () => {
+            const place = atPiece();
+            place.cd("topics/3");
+            expect(place.place.position).toEqual({
+              kind: "piece",
+              space: SPACE,
+              piece: "board",
+              path: ["topics", 3],
+              facet: "slugs",
+            });
+          });
+
+          it("reads a segment inside a piece as data, `@` included", () => {
+            const place = atPiece();
+            place.cd("mail@example");
+            expect(place.place.position).toEqual({
+              kind: "piece",
+              space: SPACE,
+              piece: "board",
+              path: ["mail@example"],
+              facet: "slugs",
+            });
+          });
+
+          it("walks every level of a multi-segment operand", () => {
+            const place = atSpaceRoot();
+            place.cd("slugs/board/topics/3");
+            expect(place.place.position).toEqual({
+              kind: "piece",
+              space: SPACE,
+              piece: "board",
+              path: ["topics", 3],
+              facet: "slugs",
+            });
+          });
+
+          it("ignores a trailing slash", () => {
+            const place = atSpaceRoot();
+            place.cd("slugs/");
+            expect(place.place.position).toEqual({
+              kind: "facet",
+              space: SPACE,
+              facet: "slugs",
+            });
+          });
+
+          it("refuses an operand with an empty segment", () => {
+            expect(atSpaceRoot().cd("slugs//board")).toEqual({
+              kind: "refused",
+              reason: "`slugs//board` has an empty segment.",
+            });
+          });
+        });
+
+        describe("`..`", () => {
+          it("stays at the space root", () => {
+            const place = atSpaceRoot();
+            expect(place.cd("..")).toEqual({
+              kind: "moved",
+              place: placeAtSpaceRoot(SPACE),
+            });
+          });
+
+          it("moves from a facet to the space root", () => {
+            const place = inSlugs();
+            place.cd("..");
+            expect(place.place.position).toEqual({
+              kind: "root",
+              space: SPACE,
+            });
+          });
+
+          it("drops the last path segment inside a piece", () => {
+            const place = atPiece();
+            place.cd("topics/3");
+            place.cd("..");
+            expect(place.place.position).toEqual({
+              kind: "piece",
+              space: SPACE,
+              piece: "board",
+              path: ["topics"],
+              facet: "slugs",
+            });
+          });
+
+          it("moves from a piece back out to the facet it came through", () => {
+            const place = atPiece();
+            place.cd("..");
+            expect(place.place.position).toEqual({
+              kind: "facet",
+              space: SPACE,
+              facet: "slugs",
+            });
+          });
+
+          it("moves from a piece a reference named to the space root", () => {
+            const place = atSpaceRoot();
+            place.cd(`/${HANDLE}`);
+            place.cd("..");
+            expect(place.place.position).toEqual({
+              kind: "root",
+              space: SPACE,
+            });
+          });
+
+          it("keeps the scope while the position moves", () => {
+            const place = atPiece();
+            place.cd("@session");
+            place.cd("..");
+            expect(place.place.scope).toBe("session");
+          });
+        });
+      });
+
+      describe("enter()", () => {
+        it("moves to a target that resolved in the connected space", () => {
+          const place = atSpaceRoot();
+          expect(
+            place.enter(
+              { space: SPACE, piece: HANDLE, path: ["title"] },
+              "#favorites",
+            ),
+          ).toEqual({
+            kind: "moved",
+            place: {
+              position: {
+                kind: "piece",
+                space: SPACE,
+                piece: HANDLE,
+                path: ["title"],
+              },
+              scope: "space",
+            },
+          });
+        });
+
+        it("stands at the piece itself for a target carrying no path", () => {
+          const place = atSpaceRoot();
+          place.enter({ space: SPACE, piece: HANDLE }, "#favorites");
+          expect(place.place.position).toEqual({
+            kind: "piece",
+            space: SPACE,
+            piece: HANDLE,
+            path: [],
+          });
+        });
+
+        it("refuses a target that resolved in another space", () => {
+          const place = atSpaceRoot();
+          expect(
+            place.enter({ space: OTHER_SPACE, piece: HANDLE }, "#profile"),
+          ).toEqual({
+            kind: "refused",
+            reason:
+              "`#profile` resolves in space `did:key:z6MkOtherSpace`, and " +
+              "this shuttle is connected to `did:key:z6MkConnectedSpace`. " +
+              "One connection serves one space.",
+          });
+        });
+
+        it("leaves shuttle where it stood when the target is refused", () => {
+          const place = atSpaceRoot();
+          place.enter({ space: OTHER_SPACE, piece: HANDLE }, "#profile");
+          expect(place.place).toEqual(placeAtSpaceRoot(SPACE));
+        });
+      });
+
+      describe("render()", () => {
+        it("returns both halves of the place it stands at", () => {
+          const place = atPiece();
+          place.cd("topics/3");
+          expect(place.render()).toBe(
+            "position  /@did:key:z6MkConnectedSpace/board/topics/3\n" +
+              "scope     @space",
+          );
+        });
+      });
+    });
+  });
+});

--- a/packages/shuttle/test/place.test.ts
+++ b/packages/shuttle/test/place.test.ts
@@ -499,12 +499,16 @@ describe("place", () => {
             });
           });
 
-          it("refuses `#argument` in a segment naming a piece", () => {
-            expect(inSlugs().cd("board#argument")).toEqual({
-              kind: "refused",
-              reason: 'The "#argument" suffix rides the reference form ' +
-                "(/of:fid1:...#argument), not the bare piece id.",
-            });
+          it("refuses `#argument` in a segment naming a piece for the same reason as a reference", () => {
+            // A place is result-rooted however the suffix was written, so
+            // the two spellings are pinned equal rather than each pinning
+            // its own text. That is what keeps a remedy naming the
+            // reference form — which `cd` refuses in turn — out of this
+            // one.
+
+            expect(inSlugs().cd("board#argument")).toEqual(
+              atSpaceRoot().cd(`/${HANDLE}#argument`),
+            );
           });
 
           it("refuses any other fragment for carrying no suffix at all", () => {

--- a/packages/shuttle/test/place.test.ts
+++ b/packages/shuttle/test/place.test.ts
@@ -119,6 +119,26 @@ describe("place", () => {
         expect(elsewhere.place).toEqual(place.place);
       });
 
+      it("escapes a `/` in a key, and takes that rendering back whole", () => {
+        const place = atSpaceRoot();
+        place.cd(`/${HANDLE}/a~1b`);
+        const printed = printedPosition(place);
+        expect(printed).toBe(
+          "/@did:key:z6MkConnectedSpace/of:fid1:abcdefghijklmnop/a~1b",
+        );
+        const elsewhere = atSpaceRoot();
+        elsewhere.cd(printed);
+        expect(elsewhere.place).toEqual(place.place);
+      });
+
+      it("returns a rendering `cd` refuses where a key holds a `#`", () => {
+        const place = atReferencedPiece();
+        place.cd("a#b");
+        const elsewhere = atSpaceRoot();
+        expect(elsewhere.cd(printedPosition(place)).kind).toBe("refused");
+        expect(elsewhere.place).toEqual(placeAtSpaceRoot(SPACE));
+      });
+
       it("returns a space root rendering `cd` refuses", () => {
         const place = atSpaceRoot();
         expect(place.cd(printedPosition(place)).kind).toBe("refused");
@@ -392,6 +412,38 @@ describe("place", () => {
             });
           });
 
+          it("refuses a reference holding an empty segment", () => {
+            // A rendering has to name the position it was printed for. The
+            // reference grammar drops a trailing empty segment, so a path
+            // ending in one would print as a reference to the piece above
+            // it — a different cell, with nothing said. The walk already
+            // refuses the spelling; this is the same refusal at the other
+            // door, and it costs the empty key its only spelling.
+
+            expect(atSpaceRoot().cd(`/${HANDLE}//`)).toEqual({
+              kind: "refused",
+              reason: `\`/${HANDLE}//\` has an empty segment.`,
+            });
+          });
+
+          it("refuses a reference holding an empty segment mid-path", () => {
+            expect(atSpaceRoot().cd(`/${HANDLE}/a//b`)).toEqual({
+              kind: "refused",
+              reason: `\`/${HANDLE}/a//b\` has an empty segment.`,
+            });
+          });
+
+          it("reads a trailing slash as the piece itself", () => {
+            const place = atSpaceRoot();
+            place.cd(`/${HANDLE}/`);
+            expect(place.place.position).toEqual({
+              kind: "piece",
+              space: SPACE,
+              piece: HANDLE,
+              path: [],
+            });
+          });
+
           it("refuses a rooted string that names no piece", () => {
             expect(atSpaceRoot().cd("//")).toEqual({
               kind: "refused",
@@ -570,7 +622,7 @@ describe("place", () => {
           });
 
           it("refuses a leading `@` inside a piece, reading it as a scope word", () => {
-            expect(atReferencedPiece().cd("@foo")).toEqual({
+            expect(atPiece().cd("@foo")).toEqual({
               kind: "refused",
               reason: "`@foo` names no scope. The scopes are `@space`, " +
                 "`@user`, and `@session`.",
@@ -778,6 +830,30 @@ describe("place", () => {
             space: SPACE,
             piece: HANDLE,
             path: [3],
+          });
+        });
+
+        it("carries no route, so `..` lands on the piece it entered", () => {
+          const entered = atSpaceRoot();
+          entered.enter({ space: SPACE, piece: HANDLE, path: ["3"] }, "#x");
+          entered.cd("..");
+          expect(entered.place.position).toEqual({
+            kind: "piece",
+            space: SPACE,
+            piece: HANDLE,
+            path: [],
+          });
+        });
+
+        it("refuses a target whose path holds an empty segment", () => {
+          expect(
+            atSpaceRoot().enter(
+              { space: SPACE, piece: HANDLE, path: ["a", ""] },
+              "#favorites",
+            ),
+          ).toEqual({
+            kind: "refused",
+            reason: "`#favorites` resolves to a path with an empty segment.",
           });
         });
 

--- a/packages/shuttle/test/place.test.ts
+++ b/packages/shuttle/test/place.test.ts
@@ -22,6 +22,7 @@ import type { MemorySpace } from "@commonfabric/memory/interface";
 import {
   CurrentPlace,
   FACETS,
+  type Move,
   placeAtSpaceRoot,
   renderPlace,
 } from "../src/place.ts";
@@ -140,16 +141,27 @@ describe("place", () => {
         expect(elsewhere.place).toEqual(placeAtSpaceRoot(SPACE));
       });
 
-      describe("over a constructed set of awkward segments", () => {
-        // Three findings in this class arrived one at a time, each from
-        // driving a segment nobody had listed, and each time the list was
-        // extended rather than the checking. This drives a construction
-        // instead, and asserts the property rather than the outcomes: a
-        // rendering may be refused, but it may never name a cell other
-        // than the one it was printed for. Adding a character to the set
-        // needs no expectation written for it, and a new lossy step in
-        // either the writing or the reading fails here whatever character
-        // exposes it.
+      describe("over a constructed set of awkward parts", () => {
+        // Four findings in this class arrived one at a time, each from
+        // driving a value nobody had listed. This drives a construction and
+        // asserts the property rather than the outcomes: a rendering may be
+        // refused, but it may never name a cell other than the one it was
+        // printed for.
+        //
+        // What it varies is as load-bearing as the property. A construction
+        // that holds a component fixed checks a slice and reads like a
+        // class, which is how a piece went unguarded while every path was
+        // covered. So both parts a position spells vary, the empty value is
+        // a candidate in its own right rather than something the shapes
+        // happen not to reach, and every door that admits a position is
+        // driven — the two that take a caller's data, and the walk that
+        // takes a string.
+        //
+        // Held fixed, and why: the space, which one connection settles and
+        // no operand supplies; the facet, which is one of two literals; and
+        // the scope, which is one of three words and which `toEqual`
+        // therefore compares vacuously here, both sides being the base. A
+        // format that renders the scope differently would want that varied.
 
         const MARKS = [
           " ",
@@ -169,35 +181,85 @@ describe("place", () => {
           ".",
         ];
 
+        /**
+         * Helper for the case below, which is every awkward spelling of a
+         * part whose ordinary spelling is `head` followed by `tail`.
+         */
+        function candidates(head: string, tail: string): string[] {
+          const values = [""];
+          for (const mark of MARKS) {
+            values.push(
+              mark + head + tail,
+              head + tail + mark,
+              head + mark + tail,
+              mark,
+            );
+          }
+          return values;
+        }
+
         it("never renders a place that reads back as a different one", () => {
           let readBack = 0;
-          let refusedSegment = 0;
+          let refusedPart = 0;
           let refusedRendering = 0;
-          for (const mark of MARKS) {
-            for (const segment of [`${mark}b`, `b${mark}`, `a${mark}b`, mark]) {
-              const place = atSpaceRoot();
-              const entered = place.enter(
-                { space: SPACE, piece: HANDLE, path: [segment] },
-                "#x",
-              );
-              if (entered.kind === "refused") {
-                refusedSegment++;
-                continue;
-              }
-              const elsewhere = atSpaceRoot();
-              if (elsewhere.cd(printedPosition(place)).kind !== "moved") {
-                refusedRendering++;
-                continue;
-              }
-              readBack++;
-              expect(elsewhere.place).toEqual(place.place);
+
+          /** Helper for this case, which holds the property over `place`. */
+          function check(place: CurrentPlace, move: Move): void {
+            if (move.kind !== "moved") {
+              refusedPart++;
+              return;
             }
+            const elsewhere = atSpaceRoot();
+            if (elsewhere.cd(printedPosition(place)).kind !== "moved") {
+              refusedRendering++;
+              return;
+            }
+            readBack++;
+            expect(elsewhere.place).toEqual(place.place);
           }
 
-          // All three outcomes have to occur, or the property above holds
-          // for want of anything to hold over.
+          const pieces = candidates(HANDLE.slice(0, 10), HANDLE.slice(10));
+          const segments = candidates("b", "");
+          for (const piece of pieces) {
+            for (const path of [[], ["tail"]]) {
+              const entered = atSpaceRoot();
+              check(
+                entered,
+                entered.enter({ space: SPACE, piece, path }, "#x"),
+              );
+              const settled = atSpaceRoot();
+              check(
+                settled,
+                settled.settle({
+                  kind: "space-by-name",
+                  name: "estuary",
+                  piece,
+                  path,
+                  scope: "space",
+                }, SPACE),
+              );
+            }
+            const walked = inSlugs();
+            check(walked, walked.cd(piece));
+          }
+          for (const segment of segments) {
+            for (
+              const path of [[segment], [segment, "tail"], ["head", segment]]
+            ) {
+              const entered = atSpaceRoot();
+              check(
+                entered,
+                entered.enter({ space: SPACE, piece: HANDLE, path }, "#x"),
+              );
+            }
+            const walked = atReferencedPiece();
+            check(walked, walked.cd(segment));
+          }
+
+          // Every outcome has to occur, or the property above holds for want
+          // of anything to hold over.
           expect(readBack).toBeGreaterThan(0);
-          expect(refusedSegment).toBeGreaterThan(0);
+          expect(refusedPart).toBeGreaterThan(0);
           expect(refusedRendering).toBeGreaterThan(0);
         });
       });
@@ -390,6 +452,31 @@ describe("place", () => {
             });
           });
 
+          it("refuses a piece left ending in whitespace by a scope suffix", () => {
+            // `cd board @space` is an ordinary typo. The suffix splits off
+            // cleanly and what remains is a piece the rendering would not
+            // name back, so the check runs on the piece the split produced
+            // rather than on the segment that carried it.
+
+            expect(inSlugs().cd("board @space")).toEqual({
+              kind: "refused",
+              reason: "`board @space` has a piece ending in whitespace, " +
+                "so a rendering of the place would name a different cell.",
+            });
+          });
+
+          it("refuses a piece holding `@`", () => {
+            // The split reads the last `@` as a scope, so a piece holding
+            // one is read back shortened. No slug or handle carries the
+            // character, so nothing nameable is lost.
+
+            expect(inSlugs().cd("board@session@session")).toEqual({
+              kind: "refused",
+              reason:
+                "`board@session@session` has a piece holding `@`, so a rendering of the place would name a different cell.",
+            });
+          });
+
           it("refuses a segment that is only a scope suffix", () => {
             expect(atSpaceRoot().cd("slugs/@user")).toEqual({
               kind: "refused",
@@ -400,10 +487,15 @@ describe("place", () => {
           });
 
           it("refuses a suffix on a piece segment naming no scope", () => {
+            // The same refusal a scope-only operand gets, since it is the
+            // same fault: shuttle owns the scope words, so the wording is
+            // its own rather than the parser's, which speaks of link
+            // handles a reader never typed.
+
             expect(inSlugs().cd("board@overlay")).toEqual({
               kind: "refused",
-              reason: 'Invalid scope suffix "@overlay" in link handle. ' +
-                "Expected @space, @user, or @session.",
+              reason: "`@overlay` names no scope. The scopes are `@space`, " +
+                "`@user`, and `@session`.",
             });
           });
         });
@@ -515,6 +607,19 @@ describe("place", () => {
               space: SPACE,
               piece: HANDLE,
               path: [],
+            });
+          });
+
+          it("refuses a reference whose piece holds a line break", () => {
+            // A handle is held to its length rather than its alphabet, so a
+            // reference can carry a piece the rendering would not name back
+            // even after the canonical parse has accepted it.
+
+            expect(atSpaceRoot().cd("/of:fid1:abc\ndefghijklmnop")).toEqual({
+              kind: "refused",
+              reason: "`/of:fid1:abc\ndefghijklmnop` has a piece holding a " +
+                "line break, so a rendering of the place would name a " +
+                "different cell.",
             });
           });
 
@@ -1067,6 +1172,19 @@ describe("place", () => {
             kind: "refused",
             reason: "`#favorites` resolves to a path with an empty " +
               "segment, so a rendering of the place would name a different cell.",
+          });
+        });
+
+        it("refuses a target whose piece holds a line break", () => {
+          expect(
+            atSpaceRoot().enter(
+              { space: SPACE, piece: "a\nb", path: [] },
+              "#favorites",
+            ),
+          ).toEqual({
+            kind: "refused",
+            reason: "`#favorites` resolves to a piece holding a line break, " +
+              "so a rendering of the place would name a different cell.",
           });
         });
 

--- a/packages/shuttle/test/place.test.ts
+++ b/packages/shuttle/test/place.test.ts
@@ -1,3 +1,19 @@
+/**
+ * Unit tests for the place value and the module that owns it. A place is a
+ * value and every move over it is a decision about one, so a case stands a
+ * `CurrentPlace` somewhere, hands `cd` a string, and reads back both what the
+ * move returned and where the instance ended up. No connection, no I/O and no
+ * clock stands behind any of it, which is what makes a case per move, per
+ * rendering and per refusal affordable.
+ *
+ * The returned outcome is the half to read first, because only two of the
+ * four arms a `Move` has are verdicts: the move landed, or it is refused. The
+ * other two report that the operand is one this module does not settle — a
+ * `#name` wish target, and a reference naming its space by name — since
+ * settling either needs a connection to resolve against. Their cases pin what
+ * gets handed on, and that the place did not move.
+ */
+
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
 

--- a/packages/shuttle/test/place.test.ts
+++ b/packages/shuttle/test/place.test.ts
@@ -16,14 +16,14 @@
  * A refusal's text is pinned whole, and three of them are somebody else's
  * words. Shuttle consumes the reference grammar rather than forking it, so a
  * rooted operand's diagnostics come from that layer and reach the reader
- * unaltered — the space-mismatch sentence and the unknown-suffix sentence
- * from `normalizeLLMFriendlyRef` and `splitArgumentSuffix`, and the
- * no-piece-handle sentence from `parseReferenceParts`. Each is marked at its case as relayed. When one
- * moves upstream, the fix is to copy the new sentence here, never to match a
- * fragment of it: the whole sentence is what pins that the diagnostic arrives
- * intact, and a substring would let a rewording through that says something
- * else. Other diagnostics from that layer reach a reader without a case
- * here — a bad space segment, a piece segment that is neither slug nor
+ * unaltered — the space-mismatch sentence and the unknown-suffix sentence from
+ * `normalizeLLMFriendlyRef` and `splitArgumentSuffix`, and the no-piece-handle
+ * sentence from `parseReferenceParts`. Each is marked at its case as relayed.
+ * When one moves upstream, the fix is to copy the new sentence here, never to
+ * match a fragment of it: the whole sentence is what pins that the diagnostic
+ * arrives intact, and a substring would let a rewording through that says
+ * something else. Other diagnostics from that layer reach a reader without a
+ * case here — a bad space segment, a piece segment that is neither slug nor
  * handle, a bad scope suffix on a reference — and pinning three of them is
  * enough to hold the relay itself, since all of them travel the same path.
  *
@@ -43,7 +43,6 @@ import {
   FACETS,
   type Move,
   placeAtSpaceRoot,
-  renderPlace,
 } from "../src/place.ts";
 
 const SPACE = "did:key:z6MkConnectedSpace" as MemorySpace;
@@ -98,15 +97,15 @@ describe("place", () => {
     });
   });
 
-  describe("renderPlace()", () => {
+  describe("render()", () => {
     it("returns a space root with no leading slash, and the scope", () => {
-      expect(renderPlace(placeAtSpaceRoot(SPACE))).toBe(
+      expect(atSpaceRoot().render()).toBe(
         "position  @did:key:z6MkConnectedSpace/\nscope     @space",
       );
     });
 
     it("returns a facet with no leading slash", () => {
-      expect(renderPlace(inSlugs().place)).toBe(
+      expect(inSlugs().render()).toBe(
         "position  @did:key:z6MkConnectedSpace/slugs/\nscope     @space",
       );
     });
@@ -115,7 +114,7 @@ describe("place", () => {
       const place = atPiece();
       place.cd("topics/3");
       place.cd("@session");
-      expect(renderPlace(place.place)).toBe(
+      expect(place.render()).toBe(
         "position  /@did:key:z6MkConnectedSpace/board@session/topics/3\n" +
           "scope     @session",
       );
@@ -574,8 +573,8 @@ describe("place", () => {
               kind: "refused",
               reason: "`board @space` has a piece ending in whitespace, " +
                 "so no piece carries that name: a slug is lowercase " +
-                "letters, numbers and hyphens, and a handle is " +
-                "`of:fid1:` and base32.",
+                "letters, numbers, and single hyphens between words, and a " +
+                "handle is `of:fid1:` and unpadded base64url.",
             });
           });
 
@@ -588,8 +587,8 @@ describe("place", () => {
               kind: "refused",
               reason: "`board@session@session` has a piece holding `@`, " +
                 "so no piece carries that name: a slug is lowercase " +
-                "letters, numbers and hyphens, and a handle is " +
-                "`of:fid1:` and base32.",
+                "letters, numbers, and single hyphens between words, and a " +
+                "handle is `of:fid1:` and unpadded base64url.",
             });
           });
 
@@ -1196,11 +1195,33 @@ describe("place", () => {
             });
           });
 
-          it("refuses an operand with an empty segment", () => {
+          it("gives a piece-name segment the piece's reason, not a segment's", () => {
+            // The same flaw in the same operand shape, one segment along
+            // from `a /b` above, which gets the segment reason. A piece
+            // ending in whitespace does not name another cell — the scope
+            // suffix stands between it and the trim — so it must not be
+            // told that it does.
+
+            expect(inSlugs().cd("board /x")).toEqual({
+              kind: "refused",
+              reason: "`board /x` has a piece ending in whitespace, so no " +
+                "piece carries that name: a slug is lowercase letters, " +
+                "numbers, and single hyphens between words, and a handle " +
+                "is `of:fid1:` and unpadded base64url.",
+            });
+          });
+
+          it("refuses an operand whose empty part would name a piece", () => {
+            // The empty part sits where a piece name goes, so it is held to
+            // the piece rule and told the piece's reason. A segment is
+            // faulted by what it is about to become, not by its position.
+
             expect(atSpaceRoot().cd("slugs//board")).toEqual({
               kind: "refused",
-              reason: "`slugs//board` has an empty segment, " +
-                "so a rendering of the place would name a different cell.",
+              reason: "`slugs//board` has an empty piece, so no piece " +
+                "carries that name: a slug is lowercase letters, numbers, " +
+                "and single hyphens between words, and a handle is " +
+                "`of:fid1:` and unpadded base64url.",
             });
           });
         });
@@ -1380,8 +1401,9 @@ describe("place", () => {
           ).toEqual({
             kind: "refused",
             reason: "`#favorites` resolves to an empty piece, so no piece " +
-              "carries that name: a slug is lowercase letters, numbers and " +
-              "hyphens, and a handle is `of:fid1:` and base32.",
+              "carries that name: a slug is lowercase letters, numbers, and " +
+              "single hyphens between words, and a handle is `of:fid1:` and " +
+              "unpadded base64url.",
           });
         });
 

--- a/packages/shuttle/test/place.test.ts
+++ b/packages/shuttle/test/place.test.ts
@@ -423,14 +423,16 @@ describe("place", () => {
 
             expect(atSpaceRoot().cd(`/${HANDLE}//`)).toEqual({
               kind: "refused",
-              reason: `\`/${HANDLE}//\` has an empty segment.`,
+              reason: `\`/${HANDLE}//\` has an empty segment, ` +
+                `so a rendering of the place would name a different cell.`,
             });
           });
 
           it("refuses a reference holding an empty segment mid-path", () => {
             expect(atSpaceRoot().cd(`/${HANDLE}/a//b`)).toEqual({
               kind: "refused",
-              reason: `\`/${HANDLE}/a//b\` has an empty segment.`,
+              reason: `\`/${HANDLE}/a//b\` has an empty segment, ` +
+                `so a rendering of the place would name a different cell.`,
             });
           });
 
@@ -442,6 +444,20 @@ describe("place", () => {
               space: SPACE,
               piece: HANDLE,
               path: [],
+            });
+          });
+
+          it("refuses a reference holding a padded segment", () => {
+            // A place prints as a reference and a reference is read back
+            // trimmed, so a padded segment would print as the key of its
+            // trimmed spelling. The empty segment above is the other half
+            // of one rule: a segment is admissible when a rendering names
+            // it back.
+
+            expect(atSpaceRoot().cd(`/${HANDLE}/a /b`)).toEqual({
+              kind: "refused",
+              reason: `\`/${HANDLE}/a /b\` has a segment padded with ` +
+                `whitespace, so a rendering of the place would name a different cell.`,
             });
           });
 
@@ -724,6 +740,36 @@ describe("place", () => {
               });
             });
 
+            it("reads `-` as a data key in the first segment", () => {
+              // `-` is matched against the whole operand exactly, where `@`
+              // and a leading `#` are matched against its head. So a key
+              // named `-` is spellable first and those two are not.
+
+              const place = atReferencedPiece();
+              place.cd("-/b");
+              expect(place.place.position).toEqual({
+                kind: "piece",
+                space: SPACE,
+                piece: HANDLE,
+                path: ["-", "b"],
+              });
+            });
+
+            it("reads `..` as a data key through a reference", () => {
+              // `..` is read segment by segment by the walk and by nothing
+              // else, so the reference door carries one as data. That is
+              // the only spelling a key named `..` has.
+
+              const place = atSpaceRoot();
+              place.cd(`/${HANDLE}/..`);
+              expect(place.place.position).toEqual({
+                kind: "piece",
+                space: SPACE,
+                piece: HANDLE,
+                path: [".."],
+              });
+            });
+
             it("reads `..` as a level to leave in a later segment", () => {
               const place = atReferencedPiece();
               place.cd("a/..");
@@ -757,10 +803,19 @@ describe("place", () => {
             });
           });
 
+          it("refuses an operand with a padded segment", () => {
+            expect(atSpaceRoot().cd("slugs/ board")).toEqual({
+              kind: "refused",
+              reason: "`slugs/ board` has a segment padded with whitespace, " +
+                "so a rendering of the place would name a different cell.",
+            });
+          });
+
           it("refuses an operand with an empty segment", () => {
             expect(atSpaceRoot().cd("slugs//board")).toEqual({
               kind: "refused",
-              reason: "`slugs//board` has an empty segment.",
+              reason: "`slugs//board` has an empty segment, " +
+                "so a rendering of the place would name a different cell.",
             });
           });
         });
@@ -926,8 +981,33 @@ describe("place", () => {
             ),
           ).toEqual({
             kind: "refused",
-            reason: "`#favorites` resolves to a path with an empty segment.",
+            reason: "`#favorites` resolves to a path with an empty " +
+              "segment, so a rendering of the place would name a different cell.",
           });
+        });
+
+        it("refuses a target whose path holds a padded segment", () => {
+          expect(
+            atSpaceRoot().enter(
+              { space: SPACE, piece: HANDLE, path: ["a "] },
+              "#favorites",
+            ),
+          ).toEqual({
+            kind: "refused",
+            reason: "`#favorites` resolves to a path with a segment padded " +
+              "with whitespace, so a rendering of the place would name a different cell.",
+          });
+        });
+
+        it("keeps the scope the place was reading through", () => {
+          // A resolved target names a cell and carries no scope of its own,
+          // so the scope the place already holds is what it is read
+          // through.
+
+          const place = atSpaceRoot();
+          place.cd("@session");
+          place.enter({ space: SPACE, piece: HANDLE }, "#favorites");
+          expect(place.place.scope).toBe("session");
         });
 
         it("refuses a target that resolved in another space", () => {
@@ -992,6 +1072,27 @@ describe("place", () => {
               "and this shuttle is connected to " +
               "`did:key:z6MkConnectedSpace`. One connection serves one " +
               "space.",
+          });
+          expect(place.place).toEqual(placeAtSpaceRoot(SPACE));
+        });
+
+        it("refuses a move whose path holds a segment no rendering names", () => {
+          // The arm is exported, so a caller can build one. `cd` cannot
+          // mint a bad path any more, which leaves a hand-built move as the
+          // way in — and this door builds a position from it exactly as
+          // `enter` builds one from a resolved target.
+
+          const place = atSpaceRoot();
+          expect(place.settle({
+            kind: "space-by-name",
+            name: "estuary",
+            piece: HANDLE,
+            path: ["a "],
+            scope: "space",
+          }, SPACE)).toEqual({
+            kind: "refused",
+            reason: `\`${HANDLE}\` has a segment padded with whitespace, ` +
+              `so a rendering of the place would name a different cell.`,
           });
           expect(place.place).toEqual(placeAtSpaceRoot(SPACE));
         });

--- a/packages/shuttle/test/place.test.ts
+++ b/packages/shuttle/test/place.test.ts
@@ -48,6 +48,13 @@ function printedPosition(place: CurrentPlace): string {
   return position.slice("position  ".length);
 }
 
+/** Helper for the cases below, which stands an instance at a named piece. */
+function atReferencedPiece(): CurrentPlace {
+  const place = atSpaceRoot();
+  place.cd(`/${HANDLE}`);
+  return place;
+}
+
 /** Helper for the cases below, which stands an instance at a piece. */
 function atPiece(): CurrentPlace {
   const place = inSlugs();
@@ -95,13 +102,16 @@ describe("place", () => {
     });
 
     describe("round-tripping", () => {
-      // What a reader copies has to name the place it was printed for, or
-      // name nothing. A piece is a cell, so its rendering is a reference and
-      // `cd` takes it back; a container is not a cell, so its rendering is
-      // not a reference and `cd` refuses it rather than resolving it to a
-      // piece whose slug happens to match the container's name.
+      // What a reader copies whole has to name the place it was printed
+      // for, or name nothing. A piece is a cell, so its rendering is a
+      // reference and `cd` takes it back; a container is not a cell, so its
+      // rendering is not a reference and `cd` refuses it rather than
+      // resolving it to a piece whose slug happens to match the container's
+      // name. A segment lifted out of a rendering is outside that: the
+      // rendering escapes a `/` in a key and a relative operand reads no
+      // escape, which the walk's own cases pin.
 
-      it("returns a piece rendering `cd` takes back to the same place", () => {
+      it("returns a piece rendering `cd` takes back to the same place, pasted whole", () => {
         const place = atPiece();
         place.cd("topics/3");
         const elsewhere = atSpaceRoot();
@@ -556,6 +566,39 @@ describe("place", () => {
               space: SPACE,
               piece: "board",
               path: ["mail@example"],
+            });
+          });
+
+          it("reads `~1` in a segment as two characters of a data key", () => {
+            // A relative operand is not a reference, so the reference
+            // grammar's `~1` escaping does not reach it: `~1` is literal
+            // here where a reference reads it as the separator. The case
+            // below is the consequence — a key holding a `/` has no
+            // relative spelling at all, since neither candidate reaches it
+            // — and both are pinned so that teaching the walk to unescape
+            // reds a case rather than arriving unremarked. Which vocabulary
+            // a relative segment speaks is settled where `ls` decides how
+            // such a key prints, the render and the read wanting to be
+            // decided together.
+
+            const place = atReferencedPiece();
+            place.cd("a~1b");
+            expect(place.place.position).toEqual({
+              kind: "piece",
+              space: SPACE,
+              piece: HANDLE,
+              path: ["a~1b"],
+            });
+          });
+
+          it("splits at every `/`, giving two keys rather than one holding it", () => {
+            const place = atReferencedPiece();
+            place.cd("a/b");
+            expect(place.place.position).toEqual({
+              kind: "piece",
+              space: SPACE,
+              piece: HANDLE,
+              path: ["a", "b"],
             });
           });
 

--- a/packages/shuttle/test/place.test.ts
+++ b/packages/shuttle/test/place.test.ts
@@ -651,6 +651,38 @@ describe("place", () => {
             expect(place.place.scope).toBe("session");
           });
 
+          it("names two cells for one suffix-less string read at two scopes", () => {
+            // The observable the always-emit ruling rests on, and the one
+            // the taxonomy turns on: a complete reference carries its space
+            // and not its scope, so the reader supplies the level it does
+            // not carry. Nothing else here reads a suffix-less reference —
+            // every rendering the property case reads back carries a
+            // suffix, because that is what `pwd` writes.
+
+            const reference = `/@${SPACE}/${HANDLE}/title`;
+            const reader = (scope: CellScope): CurrentPlace => {
+              const place = atSpaceRoot();
+              place.cd(`@${scope}`);
+              place.cd(reference);
+              return place;
+            };
+            expect(reader("user").place.scope).toBe("user");
+            expect(reader("session").place.scope).toBe("session");
+            expect(reader("user").place).not.toEqual(reader("session").place);
+          });
+
+          it("names one cell for a fully qualified string read at two scopes", () => {
+            const reference = `/@${SPACE}/${HANDLE}@user/title`;
+            const reader = (scope: CellScope): CurrentPlace => {
+              const place = atSpaceRoot();
+              place.cd(`@${scope}`);
+              place.cd(reference);
+              return place;
+            };
+            expect(reader("space").place).toEqual(reader("session").place);
+            expect(reader("space").place.scope).toBe("user");
+          });
+
           it("refuses a complete reference naming another space", () => {
             // Relayed: the canonical layer's sentence, not shuttle's
             // to choose. See the file header.

--- a/packages/shuttle/test/place.test.ts
+++ b/packages/shuttle/test/place.test.ts
@@ -140,6 +140,68 @@ describe("place", () => {
         expect(elsewhere.place).toEqual(placeAtSpaceRoot(SPACE));
       });
 
+      describe("over a constructed set of awkward segments", () => {
+        // Three findings in this class arrived one at a time, each from
+        // driving a segment nobody had listed, and each time the list was
+        // extended rather than the checking. This drives a construction
+        // instead, and asserts the property rather than the outcomes: a
+        // rendering may be refused, but it may never name a cell other
+        // than the one it was printed for. Adding a character to the set
+        // needs no expectation written for it, and a new lossy step in
+        // either the writing or the reading fails here whatever character
+        // exposes it.
+
+        const MARKS = [
+          " ",
+          "\t",
+          "\n",
+          "\r",
+          "\v",
+          "\f",
+          "\u00a0",
+          "\u2028",
+          "\u2029",
+          "/",
+          "~",
+          "#",
+          "@",
+          "-",
+          ".",
+        ];
+
+        it("never renders a place that reads back as a different one", () => {
+          let readBack = 0;
+          let refusedSegment = 0;
+          let refusedRendering = 0;
+          for (const mark of MARKS) {
+            for (const segment of [`${mark}b`, `b${mark}`, `a${mark}b`, mark]) {
+              const place = atSpaceRoot();
+              const entered = place.enter(
+                { space: SPACE, piece: HANDLE, path: [segment] },
+                "#x",
+              );
+              if (entered.kind === "refused") {
+                refusedSegment++;
+                continue;
+              }
+              const elsewhere = atSpaceRoot();
+              if (elsewhere.cd(printedPosition(place)).kind !== "moved") {
+                refusedRendering++;
+                continue;
+              }
+              readBack++;
+              expect(elsewhere.place).toEqual(place.place);
+            }
+          }
+
+          // All three outcomes have to occur, or the property above holds
+          // for want of anything to hold over.
+          expect(readBack).toBeGreaterThan(0);
+          expect(refusedSegment).toBeGreaterThan(0);
+          expect(refusedRendering).toBeGreaterThan(0);
+        });
+      });
+
       it("returns a space root rendering `cd` refuses", () => {
         const place = atSpaceRoot();
         expect(place.cd(printedPosition(place)).kind).toBe("refused");
@@ -328,6 +390,15 @@ describe("place", () => {
             });
           });
 
+          it("refuses a segment that is only a scope suffix", () => {
+            expect(atSpaceRoot().cd("slugs/@user")).toEqual({
+              kind: "refused",
+              reason: "`@user` names no piece. A scope suffix rides a piece " +
+                "id, and a scope on its own is a whole operand rather than " +
+                "a segment.",
+            });
+          });
+
           it("refuses a suffix on a piece segment naming no scope", () => {
             expect(inSlugs().cd("board@overlay")).toEqual({
               kind: "refused",
@@ -447,17 +518,26 @@ describe("place", () => {
             });
           });
 
-          it("refuses a reference holding a padded segment", () => {
-            // A place prints as a reference and a reference is read back
-            // trimmed, so a padded segment would print as the key of its
-            // trimmed spelling. The empty segment above is the other half
-            // of one rule: a segment is admissible when a rendering names
-            // it back.
-
+          it("refuses a reference holding a segment that ends in whitespace", () => {
             expect(atSpaceRoot().cd(`/${HANDLE}/a /b`)).toEqual({
               kind: "refused",
-              reason: `\`/${HANDLE}/a /b\` has a segment padded with ` +
+              reason: `\`/${HANDLE}/a /b\` has a segment ending in ` +
                 `whitespace, so a rendering of the place would name a different cell.`,
+            });
+          });
+
+          it("moves for a reference holding a segment that starts with one", () => {
+            // The parse trims the whole string, which no leading character
+            // of a segment sits at the end of, so leading whitespace
+            // survives the round trip and is admitted.
+
+            const place = atSpaceRoot();
+            place.cd(`/${HANDLE}/ a/b`);
+            expect(place.place.position).toEqual({
+              kind: "piece",
+              space: SPACE,
+              piece: HANDLE,
+              path: [" a", "b"],
             });
           });
 
@@ -803,11 +883,15 @@ describe("place", () => {
             });
           });
 
-          it("refuses an operand with a padded segment", () => {
-            expect(atSpaceRoot().cd("slugs/ board")).toEqual({
+          it("refuses an operand with a segment ending in whitespace", () => {
+            // The operand is trimmed before it is split, so only a segment
+            // with something after it can carry trailing whitespace this
+            // far.
+
+            expect(atReferencedPiece().cd("a /b")).toEqual({
               kind: "refused",
-              reason: "`slugs/ board` has a segment padded with whitespace, " +
-                "so a rendering of the place would name a different cell.",
+              reason: "`a /b` has a segment ending in whitespace, so a " +
+                "rendering of the place would name a different cell.",
             });
           });
 
@@ -986,7 +1070,27 @@ describe("place", () => {
           });
         });
 
-        it("refuses a target whose path holds a padded segment", () => {
+        it("refuses a target whose path holds a line break", () => {
+          // A rendering separates its two lines with a newline, so a
+          // segment holding one splits the position line and leaves a
+          // shorter reference — one that names another cell rather than
+          // failing to parse. A resolver reading JSON keys is the door
+          // such a segment arrives through.
+
+          expect(
+            atSpaceRoot().enter(
+              { space: SPACE, piece: HANDLE, path: ["a\nb"] },
+              "#favorites",
+            ),
+          ).toEqual({
+            kind: "refused",
+            reason: "`#favorites` resolves to a path with a segment holding " +
+              "a line break, so a rendering of the place would name a " +
+              "different cell.",
+          });
+        });
+
+        it("refuses a target whose path holds a segment ending in whitespace", () => {
           expect(
             atSpaceRoot().enter(
               { space: SPACE, piece: HANDLE, path: ["a "] },
@@ -994,8 +1098,8 @@ describe("place", () => {
             ),
           ).toEqual({
             kind: "refused",
-            reason: "`#favorites` resolves to a path with a segment padded " +
-              "with whitespace, so a rendering of the place would name a different cell.",
+            reason: "`#favorites` resolves to a path with a segment ending " +
+              "in whitespace, so a rendering of the place would name a different cell.",
           });
         });
 
@@ -1091,8 +1195,8 @@ describe("place", () => {
             scope: "space",
           }, SPACE)).toEqual({
             kind: "refused",
-            reason: `\`${HANDLE}\` has a segment padded with whitespace, ` +
-              `so a rendering of the place would name a different cell.`,
+            reason: `The reference naming space \`estuary\` has a segment ` +
+              `ending in whitespace, so a rendering of the place would name a different cell.`,
           });
           expect(place.place).toEqual(placeAtSpaceRoot(SPACE));
         });

--- a/packages/shuttle/test/place.test.ts
+++ b/packages/shuttle/test/place.test.ts
@@ -52,7 +52,7 @@ const HANDLE = "of:fid1:abcdefghijklmnop";
 
 /** Helper for the cases below, which stands an instance at the space root. */
 function atSpaceRoot(): CurrentPlace {
-  return new CurrentPlace(placeAtSpaceRoot(SPACE));
+  return new CurrentPlace(SPACE);
 }
 
 /** Helper for the cases below, which stands an instance inside `slugs/`. */
@@ -300,7 +300,7 @@ describe("place", () => {
           ];
 
           const pieces = candidates(HANDLE.slice(0, 10), HANDLE.slice(10));
-          const segments = candidates("b", "");
+          const segments = candidates("b", "c");
           for (const [index, scope] of scopes.entries()) {
             const reader = scopes[(index + 1) % scopes.length];
 
@@ -390,7 +390,10 @@ describe("place", () => {
 
   describe("CurrentPlace", () => {
     describe("constructor()", () => {
-      it("returns an instance standing at the place it was given", () => {
+      it("returns an instance standing at the root of the space it was given", () => {
+        // The constructor takes a space and not a place, so there is no
+        // door here for a position the other four would refuse.
+
         expect(atSpaceRoot().place).toEqual(placeAtSpaceRoot(SPACE));
       });
 
@@ -570,7 +573,9 @@ describe("place", () => {
             expect(inSlugs().cd("board @space")).toEqual({
               kind: "refused",
               reason: "`board @space` has a piece ending in whitespace, " +
-                "so a rendering of the place would name a different cell.",
+                "so no piece carries that name: a slug is lowercase " +
+                "letters, numbers and hyphens, and a handle is " +
+                "`of:fid1:` and base32.",
             });
           });
 
@@ -581,8 +586,10 @@ describe("place", () => {
 
             expect(inSlugs().cd("board@session@session")).toEqual({
               kind: "refused",
-              reason:
-                "`board@session@session` has a piece holding `@`, so a rendering of the place would name a different cell.",
+              reason: "`board@session@session` has a piece holding `@`, " +
+                "so no piece carries that name: a slug is lowercase " +
+                "letters, numbers and hyphens, and a handle is " +
+                "`of:fid1:` and base32.",
             });
           });
 
@@ -1022,6 +1029,23 @@ describe("place", () => {
             });
           });
 
+          it("trims the outer edges of an operand before splitting it", () => {
+            // A reference keeps what the walk drops here, and the walk is
+            // the only door that drops it — so a key named `" a"` is
+            // reachable by reference and not by walking to it. Landing on
+            // the trimmed key rather than refusing is what makes this
+            // worth pinning: nothing says the edge was lost.
+
+            const place = atReferencedPiece();
+            place.cd(" a ");
+            expect(place.place.position).toEqual({
+              kind: "piece",
+              space: SPACE,
+              piece: HANDLE,
+              path: ["a"],
+            });
+          });
+
           it("reads `~1` in a segment as two characters of a data key", () => {
             // A relative operand is not a reference, so the reference
             // grammar's `~1` escaping does not reach it: `~1` is literal
@@ -1344,6 +1368,20 @@ describe("place", () => {
             kind: "refused",
             reason: "`#favorites` resolves to a path with an empty " +
               "segment, so a rendering of the place would name a different cell.",
+          });
+        });
+
+        it("refuses a target whose piece is empty", () => {
+          expect(
+            atSpaceRoot().enter(
+              { space: SPACE, piece: "", path: [] },
+              "#favorites",
+            ),
+          ).toEqual({
+            kind: "refused",
+            reason: "`#favorites` resolves to an empty piece, so no piece " +
+              "carries that name: a slug is lowercase letters, numbers and " +
+              "hyphens, and a handle is `of:fid1:` and base32.",
           });
         });
 

--- a/packages/shuttle/test/place.test.ts
+++ b/packages/shuttle/test/place.test.ts
@@ -107,9 +107,10 @@ describe("place", () => {
       // reference and `cd` takes it back; a container is not a cell, so its
       // rendering is not a reference and `cd` refuses it rather than
       // resolving it to a piece whose slug happens to match the container's
-      // name. A segment lifted out of a rendering is outside that: the
-      // rendering escapes a `/` in a key and a relative operand reads no
-      // escape, which the walk's own cases pin.
+      // name. A segment lifted out of a rendering is outside that, for two
+      // reasons: it becomes an operand in its own right, so the head
+      // readings decide it, and the rendering escapes a `/` in a key where
+      // a relative operand reads no escape. The walk's own cases pin both.
 
       it("returns a piece rendering `cd` takes back to the same place, pasted whole", () => {
         const place = atPiece();
@@ -512,6 +513,19 @@ describe("place", () => {
             expect(atSpaceRoot().cd("#favorites")).toEqual({
               kind: "wish",
               target: "#favorites",
+            });
+          });
+
+          it("hands back `#argument` too, since the head reading is one rule", () => {
+            // The wish reading is decided on the whole operand, so it does
+            // not ask which word follows the `#`. `#argument` earns the
+            // result-rooted refusal as a *suffix* on a reference; standing
+            // alone it is a target name like any other, and the connection
+            // is what discovers there is none.
+
+            expect(atSpaceRoot().cd("#argument")).toEqual({
+              kind: "wish",
+              target: "#argument",
             });
           });
         });

--- a/packages/shuttle/test/place.test.ts
+++ b/packages/shuttle/test/place.test.ts
@@ -12,6 +12,24 @@
  * `#name` wish target, and a reference naming its space by name — since
  * settling either needs a connection to resolve against. Their cases pin what
  * gets handed on, and that the place did not move.
+ *
+ * A refusal's text is pinned whole, and three of them are somebody else's
+ * words. Shuttle consumes the reference grammar rather than forking it, so a
+ * rooted operand's diagnostics come from that layer and reach the reader
+ * unaltered — the space-mismatch sentence and the unknown-suffix sentence
+ * from `normalizeLLMFriendlyRef`, and the no-piece-handle sentence from
+ * `parseReferenceParts`. Each is marked at its case as relayed. When one
+ * moves upstream, the fix is to copy the new sentence here, never to match a
+ * fragment of it: the whole sentence is what pins that the diagnostic arrives
+ * intact, and a substring would let a rewording through that says something
+ * else. Other diagnostics from that layer reach a reader without a case
+ * here — a bad space segment, a piece segment that is neither slug nor
+ * handle, a bad scope suffix on a reference — and pinning three of them is
+ * enough to hold the relay itself, since all of them travel the same path.
+ *
+ * Every other refusal in this file is shuttle's own, and two of those
+ * deliberately mirror the canonical wording so the two surfaces read as one
+ * — those move by choice rather than by upstream drift.
  */
 
 import { expect } from "@std/expect";
@@ -560,6 +578,9 @@ describe("place", () => {
           });
 
           it("refuses a complete reference naming another space", () => {
+            // Relayed: the canonical layer's sentence, not shuttle's
+            // to choose. See the file header.
+
             expect(atSpaceRoot().cd(`/@${OTHER_SPACE}/${HANDLE}`)).toEqual({
               kind: "refused",
               reason: `Reference names space "${OTHER_SPACE}" but the ` +
@@ -595,12 +616,15 @@ describe("place", () => {
           });
 
           it("refuses a reference carrying any other fragment", () => {
+            // Relayed: the canonical layer's sentence, not shuttle's
+            // to choose. See the file header.
+
             const move = atSpaceRoot().cd(`/${HANDLE}#result`);
             expect(move).toEqual({
               kind: "refused",
-              reason: 'Unknown reference suffix "#result". The one supported ' +
-                'suffix is "#argument", which selects the piece\'s arguments ' +
-                'cell the way "--input" does.',
+              reason: 'Unknown suffix "#result". The one supported suffix ' +
+                'is "#argument", which selects the piece\'s arguments cell ' +
+                'the way "--input" does.',
             });
           });
 
@@ -675,6 +699,9 @@ describe("place", () => {
           });
 
           it("refuses a rooted string that names no piece", () => {
+            // Relayed: the canonical layer's sentence, not shuttle's
+            // to choose. See the file header.
+
             expect(atSpaceRoot().cd("//")).toEqual({
               kind: "refused",
               reason:

--- a/tasks/typecheck.ts
+++ b/tasks/typecheck.ts
@@ -73,6 +73,7 @@ const DIRS = [
   "packages/runtime-client",
   "packages/schema-generator/src",
   "packages/shell",
+  "packages/shuttle",
   "packages/spec-model",
   "packages/state-inspector",
   "packages/static/scripts",


### PR DESCRIPTION
## Why

B1 is the walking skeleton, and it is too much to land at once: `packages/shuttle`
inherits a zero-increase coverage gate from its first tracked source line, so the
milestone lands in slices. This is the first, and it builds the value the rest of
B1 stands on.

A place is the context that fills in the omitted levels of a reference. The
fabric's reference grammar is right-anchored, and shuttle's proposition is that
you navigate that context instead of copying printed addresses between commands.
Until the place exists as a value with its own semantics there is nothing for a
prompt to render, nothing for `ls` to list, and no answer to what a relative
operand means.

Landing it alone also puts those semantics under review on their own terms. The
refusals here are design decisions rather than error handling: what `cd` will not
do is what keeps every later relative read unambiguous.

Follows #6741 (the package scaffold) and #6750 (the workspace test-task guard).

## What Changed

**`packages/shuttle/src/place.ts`** — the place value and the module that owns it.

- `Place` is the pair (position, scope) of decision 20. `Position` is a three-arm
  union — space root, facet, piece — so the type answers which cell a place names
  and nothing else.
- `CurrentPlace` holds the current standing and the previous one. `cd`, `enter`
  and `settle` are the ways in; `render` is what `pwd` prints. A position is
  normalized at every one of those doors, so two arrivals at one cell compare
  equal however they were reached, and no door admits a value the invariant
  forbids — the constructor takes a space rather than a place for that reason.
- Navigation the canonical grammar does not parse — `/`, `..`, `-`, `@scope` — is
  shuttle's own syntax, handled before the string reaches
  `normalizeLLMFriendlyRef`. Anything rooted goes to the canonical parser
  unchanged: the alias layer is consumed, never forked.
- The route taken is kept as a trail beside the place rather than as a field on
  the position, so `..` retraces it — a piece entered through `slugs/` returns to
  `slugs/`.
- `pwd` prints a **fully qualified** address: the scope is always emitted, base
  included, so a rendering denotes one cell everywhere rather than depending on
  the reader's ambient scope. Shuttle writes absolute and reads ambient, the way
  a shell does with `pwd` and a relative path.
- The refusals carry their reasons, and the reasons are of two kinds: a value
  whose rendering would name a different cell, and a piece no slug or handle
  could carry.

**`packages/shuttle/test/place.test.ts`** — 114 cases. Renders are pinned as
literals *and* driven: a rendering read back lands at an equal place. A property
construction drives a matrix of {door, piece, segment} across candidates and
scopes, so a door cannot be added for one component and not another.

**Documentation.** `grammar.md` gains the reference taxonomy's four rungs, the
rule for where each reading is matched, and three open questions. `README.md` and
`build-sequence.md` follow it. `futures.md` records what is deferred.

## What this deliberately does not settle

The vocabulary a relative segment speaks — escaping, and slug/handle validation —
waits for `ls`, because how a key prints and how it is typed back want deciding
together. `pwd`'s two-line layout waits for `where`. Both are recorded in the
plan with the doors they touch.

## Test plan

- `deno fmt --check`, `deno lint`, `deno task check`, `deno task check-docs`,
  `deno task check-no-waitfor`, `deno task check-package-cycles`,
  `deno task check-skill-facts` — green.
- `deno task test` in `packages/shuttle` — 136 steps, 0 failed.
- Coverage: 358/358 lines, 33/33 functions, 174/175 branches. The untaken branch
  is a `String(error)` fallback for a thrown non-Error.
- 97 mutations over 114 cases, every case red under at least one — including
  mutations that re-admit each refused value class, collapse two refusal reasons
  into one, and revert each door's normalization.
