### PR TITLE
fix(cf-harness): run_pattern's answer ceiling gates values, not the handle (CT-2175, CT-2188)

### DIFF
--- a/docs/specs/agent-harness/02-cfc-integration.md
+++ b/docs/specs/agent-harness/02-cfc-integration.md
@@ -118,7 +118,11 @@ artifacts it explains.
 MUST occur before invocation policy evaluation. Possession or successful
 resolution of a handle supplies neither prompt-slot authority nor a CFC release;
 the resulting invocation remains subject to the same label, authority, and
-side-effect checks as a directly supplied reference.
+side-effect checks as a directly supplied reference. The converse holds too:
+minting or returning a handle to the model is not a release. A handle names a
+referent without carrying it, so a tool MAY return one for a result whose
+labels a model-context ceiling refuses, and a release ceiling applies only to
+a value that crosses into model context.
 
 **AH-CFC-19.** Handle mappings are sensitive provenance evidence. Their access,
 retention, child-transfer, and model-disclosure boundaries MUST be at least as

--- a/docs/specs/cfc-enforcement-matrix.md
+++ b/docs/specs/cfc-enforcement-matrix.md
@@ -316,17 +316,21 @@ The strict-only delta is:
   What the skip does NOT do is release the value. A derivation's result
   leaves the fabric only through a sink, and a sink measures the join it is
   handed. Where the host is the one releasing — the `run_pattern` tool
-  answering a model with what a piece computed — there is no request to
-  record and no commit to gate, so that tool measures the release itself,
+  answering a model with the values a piece computed — there is no request
+  to record and no commit to gate, so that tool measures the release itself,
   against a public ceiling, through `describeSinkReleaseRefusal`
   ([run-pattern.ts](../../packages/cf-harness/src/tools/run-pattern.ts)).
-  The two routes fit their joins with one membership predicate, so a clause
-  outside a ceiling on one is outside it on the other. They differ in what
-  reaches the join: the host route measures what releasing the answer
-  resolved, and applies no exchange-rule rewriting to it, so a clause a
-  policy evaluation would have discharged is refused there. The ladder
-  governs it like any other gate — at `disabled` and `observe` it records
-  nothing that rejects.
+  What it measures is the values a `resultSchema` asks for. The result
+  reference it returns names the result without carrying it, so a call that
+  asks for no values is not measured, and a refusal withholds the values
+  while the reference goes out with them: a handle is not a release. The two
+  routes fit their joins with one membership predicate, so a clause outside
+  a ceiling on one is outside it on the other. They differ in what reaches
+  the join: the host route measures what releasing the values resolved, and
+  applies no exchange-rule rewriting to it, so a clause a policy evaluation
+  would have discharged is withheld there. The ladder governs it like any
+  other gate — at `disabled` and `observe` it records nothing that
+  withholds.
 
   The exemption is not a hole. A path counts as meta only while no payload
   write landed on it too, so a transaction writing both leaves the path

--- a/docs/specs/cfc-spec-changes.md
+++ b/docs/specs/cfc-spec-changes.md
@@ -357,11 +357,13 @@ later write of what it read misfits on the original clause. What the
 exemption gives up is a refusal that was doing an egress gate's work by
 accident: a value derived from labeled data now lands, and whether it may
 LEAVE is the sink's question. Where the host is the one releasing — a tool
-answering a model with what a piece computed — there is no sink request to
-record and no commit to gate, so the release is measured directly: read what
-is about to be released through a transaction, and fit that transaction's
-consumed join to the destination's ceiling, which for a model's context is
-the empty one. `describeSinkReleaseRefusal` (runner `cfc/prepare.ts`) is that
+answering a model with the values a piece computed — there is no sink request
+to record and no commit to gate, so the release is measured directly: read
+what is about to be released through a transaction, and fit that
+transaction's consumed join to the destination's ceiling, which for a model's
+context is the empty one. What is released is a value. A reference the tool
+hands back names the result without carrying it, so it is not measured, and a
+refusal withholds the values while the reference goes out. `describeSinkReleaseRefusal` (runner `cfc/prepare.ts`) is that
 measurement, and it shares `atomsOutsideCeiling` and the refusal-detail
 construction with the in-commit sink gate, so a clause outside a ceiling on
 one route is outside it on the other. Two differences are worth recording:

--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -1285,6 +1285,36 @@ carries no handle code. The persisted tool-output artifact keeps the raw
 reference, the raw result value, and the `pieceId` — a bare fabric identifier
 the handle boundary never swaps, so it stays out of the model-facing rendering.
 
+What the answer's values may carry is measured against the ceiling a model's
+context has, which admits nothing: a model's context is outside every space, so
+no confidentiality clause names an audience it belongs to. The reference is not
+measured, because it is not a disclosure. `resultRef` names the result without
+carrying it, and an agent holding one can wire it into a later run, hand it to a
+child, or publish it under a slug without ever reading it — the
+[CFC integration profile](../../docs/specs/agent-harness/02-cfc-integration.md)
+states this as AH-CFC-18. So a run that asks for no `resultSchema` gets
+`resultRef` whatever labels its result carries, and the ceiling is consulted
+only when a `resultSchema` asks for values. The measurement reads the result
+through a transaction — the result document and every computed cell it links to
+— and fits that transaction's consumed join to the ceiling. Under an enforcing
+mode a clause outside it withholds `value`, and the answer is still
+`{ status: "ok", resultRef }`: `valueError` states the refusal as an
+instruction, and `policyRefusal` carries it as data — the gates and sinks that
+refused, the offending atoms (a structured atom is counted rather than named,
+since it can carry the principal that introduced it), the keys of this call's
+own `inputs` whose values carried those atoms in, and whether dropping those
+keys is the whole remedy (`complete`), narrows the flow (`partial`), or reaches
+none of it (`none`). An input is attributed by the label-map entry the refused
+read consumed, so a link addressing a labeled field of a document is named for
+that entry whether the read landed on the field or on the document root. The
+refusal's reason names labels and documents, so it stays in the artifact's
+`rawCauseMessage` and out of the model-facing text. At `disabled` and `observe`
+nothing withholds: the values go out, and the same measurement is recorded on
+the artifact as `releaseObservation`, so an operator staging the ladder can size
+what raising it would withhold. The measurement applies no exchange-rule
+rewriting, so a clause a policy evaluation would have discharged is withheld
+here.
+
 A result that settles to nothing names its cause when one was observed: when the
 settled result fails the declared `resultSchema` or holds no fields of its own
 beyond the framework keys, the tool consults what the session's runtime reported

--- a/packages/cf-harness/src/tools/run-pattern.ts
+++ b/packages/cf-harness/src/tools/run-pattern.ts
@@ -601,6 +601,12 @@ const pathHasPrefix = (
   prefix.length <= path.length &&
   prefix.every((segment, index) => segment === path[index]);
 
+/** Whether one path is a prefix of the other, either way round. */
+const pathsComparable = (
+  a: readonly string[],
+  b: readonly string[],
+): boolean => pathHasPrefix(a, b) || pathHasPrefix(b, a);
+
 const inputAddressKey = (address: RunPatternInputAddress): string =>
   JSON.stringify([address.key, address.hash, address.path]);
 
@@ -616,10 +622,13 @@ const inputAddressKey = (address: RunPatternInputAddress): string =>
  * dereference traces the attribution read recorded are the route from the
  * one to the other, and following them is what places such a read.
  *
- * A link at or below the input's address leads to its target as it stands.
- * A link above it — the document root is itself a link, say — leads to the
- * target extended by the rest of the input's path, since that is where the
- * value continues on the far side.
+ * A trace's target is the address the resolution continued to, not the bare
+ * far end of the link: a link above the input's address — the document root
+ * is itself a link, say — lands its trace at the input's own position on the
+ * far side. So a link at, below, or above the address leads to the target as
+ * it stands, and only a link beside the address, on a sibling path, leads the
+ * input nowhere. Every trace is a value dereference: the transaction that
+ * records them only reads.
  */
 const inputAddressesReached = (
   addresses: readonly RunPatternInputAddress[],
@@ -632,7 +641,6 @@ const inputAddressesReached = (
   for (let index = 0; index < reached.length; index += 1) {
     const from = reached[index];
     for (const trace of traces) {
-      if (trace.kind !== "value") continue;
       const targetHash = comparableEntityHash(trace.target.id);
       if (
         targetHash === undefined ||
@@ -640,18 +648,8 @@ const inputAddressesReached = (
       ) {
         continue;
       }
-      let path: readonly string[];
-      if (pathHasPrefix(trace.source.path, from.path)) {
-        path = trace.target.path;
-      } else if (pathHasPrefix(from.path, trace.source.path)) {
-        path = [
-          ...trace.target.path,
-          ...from.path.slice(trace.source.path.length),
-        ];
-      } else {
-        continue;
-      }
-      const next = { key: from.key, hash: targetHash, path };
+      if (!pathsComparable(trace.source.path, from.path)) continue;
+      const next = { key: from.key, hash: targetHash, path: trace.target.path };
       const key = inputAddressKey(next);
       if (!seen.has(key)) {
         seen.add(key);

--- a/packages/cf-harness/src/tools/run-pattern.ts
+++ b/packages/cf-harness/src/tools/run-pattern.ts
@@ -10,6 +10,7 @@ import {
 import {
   type CfcAddress,
   type CfcConfClause,
+  type CfcDereferenceTrace,
   type CfcRefusalAttribution,
   type CfcRefusalDetail,
   type CfcRefusalGate,
@@ -104,11 +105,22 @@ export interface RunPatternToolSuccessOutput {
   /**
    * What the release measurement refused, on a run the enforcement ladder did
    * not reject it on. Artifact-only, like the other fields the prompt loop
-   * strips: the answer went out, so the model has nothing to act on, while an
+   * strips: the values went out, so the model has nothing to act on, while an
    * operator staging the ladder has the population that raising it would
-   * start refusing.
+   * start withholding. Absent, like `policyRefusal`, on a run that asked for
+   * no values, since nothing was measured.
    */
   releaseObservation?: RunPatternPolicyRefusal;
+
+  /**
+   * What the answer's own sink refused to release and which of this call's
+   * inputs carried it, when the enforcement ladder withheld `value` over it.
+   * The result stands in the space under its own labels and `resultRef`
+   * names it: a reference discloses nothing, so what the refusal withholds
+   * is the values alone. `valueError` states the same refusal as an
+   * instruction.
+   */
+  policyRefusal?: RunPatternPolicyRefusal;
 
   /**
    * The compiled pattern's result schema — the shape of whatever
@@ -135,8 +147,11 @@ export interface RunPatternToolSuccessOutput {
 
   linkedStringCount?: number;
 
-  /** Why `value` is absent despite a `resultSchema`: the raw result did not
-   * match the schema. */
+  /**
+   * Why `value` is absent despite a `resultSchema`: the raw result did not
+   * match the schema, or the space's policy refused to release it, in which
+   * case `policyRefusal` carries the refusal as data.
+   */
   valueError?: string;
 
   /**
@@ -154,11 +169,14 @@ export interface RunPatternToolSuccessOutput {
   patternPublication?: RunPatternPublicationReport;
 
   /**
-   * What the render gate's probe THREW, when one did — never what it
-   * rendered. Retained for the persisted artifact and stripped from the
-   * model-facing rendering, on the same terms as every other thrown message
+   * Text retained for the persisted artifact and stripped from the
+   * model-facing rendering. The reason a release refusal stated, when
+   * `policyRefusal` is present, since it names the labels and documents the
+   * flow touched. And what the render gate's probe THREW, when one did —
+   * never what it rendered — on the same terms as every other thrown message
    * this tool withholds: a computation over data the model cannot read can
-   * carry that data in what it throws.
+   * carry that data in what it throws. A run with both carries the reason
+   * first and the thrown text after a blank line.
    *
    * **The artifact root is not a confidentiality boundary.** `bash` does not
    * reserve it the way `read_file`, `write_file`, `edit_file` and
@@ -278,10 +296,11 @@ export interface RunPatternToolErrorOutput {
   rawCauseMessage?: string;
 
   /**
-   * What a boundary refused and which of this call's own inputs carried it,
-   * when a policy refusal is what stopped the run. A refused commit landed no
-   * result; a refused release landed one, which stays in the space under its
-   * own labels while the answer is withheld.
+   * What the commit boundary refused and which of this call's own inputs
+   * carried it, when a policy refusal is what stopped the run: the write was
+   * rejected, so no result landed. A refusal at the answer's own sink is not
+   * this — the result landed and its reference is returned — so it rides on
+   * the success output instead.
    */
   policyRefusal?: RunPatternPolicyRefusal;
 }
@@ -297,6 +316,34 @@ export const isRunPatternToolSuccessOutput = (
   "status" in output && output.status === "ok" &&
   "resultRef" in output && typeof output.resultRef === "string" &&
   "resultRefSchema" in output;
+
+/** `RunPatternPolicyRefusal`, as the output schema states it. */
+const RUN_PATTERN_POLICY_REFUSAL_SCHEMA = {
+  type: "object",
+  properties: {
+    gates: {
+      type: "array",
+      items: { type: "string", enum: ["sink-ceiling", "writer-fit"] },
+    },
+    sinks: { type: "array", items: { type: "string" } },
+    offendingAtoms: { type: "array", items: { type: "string" } },
+    withheldAtomCount: { type: "integer", minimum: 0 },
+    inputKeys: { type: "array", items: { type: "string" } },
+    unattributedInputCount: { type: "integer", minimum: 0 },
+    attribution: {
+      type: "string",
+      enum: ["complete", "partial", "none"],
+    },
+  },
+  required: [
+    "gates",
+    "sinks",
+    "offendingAtoms",
+    "inputKeys",
+    "attribution",
+  ],
+  additionalProperties: false,
+} satisfies JSONSchema;
 
 export const runPatternToolDescriptor: HarnessToolDescriptor = {
   toolId: "run_pattern",
@@ -340,7 +387,7 @@ export const runPatternToolDescriptor: HarnessToolDescriptor = {
           { type: "object", additionalProperties: true },
         ],
         description:
-          'JSON Schema for the result value. Without it you get resultRef only and no value at all, so pass it whenever you need to read what the pattern computed. A value is returned only for the fields the schema models: an inert one (a number, a boolean, an enum or const string) comes back as itself; anything else is withheld as text and comes back as a reference token addressing that position, which describe_handle can inspect and a later run_pattern can wire by reference. Example: {"type":"object","properties":{"total":{"type":"number"}},"required":["total"]}. The framework\'s own result keys ($NAME, $UI and the other rendering variants) need not be declared.',
+          'JSON Schema for the result value. Without it you get resultRef only and no value at all, so pass it whenever you need to read what the pattern computed. A value is returned only for the fields the schema models: an inert one (a number, a boolean, an enum or const string) comes back as itself; anything else is withheld as text and comes back as a reference token addressing that position, which describe_handle can inspect and a later run_pattern can wire by reference. Example: {"type":"object","properties":{"total":{"type":"number"}},"required":["total"]}. The framework\'s own result keys ($NAME, $UI and the other rendering variants) need not be declared. When the space\'s policy does not admit releasing the values to you, value is withheld, valueError says why and which input carried the refused label, and resultRef still names the result: pass it on by reference.',
       },
     },
     // Exactly one of `sourceText` and `patternId` is required, which is a
@@ -360,6 +407,7 @@ export const runPatternToolDescriptor: HarnessToolDescriptor = {
         value: {},
         linkedStringCount: { type: "integer", minimum: 0 },
         valueError: { type: "string" },
+        policyRefusal: RUN_PATTERN_POLICY_REFUSAL_SCHEMA,
         rawValue: {},
         patternPublication: {
           type: "object",
@@ -412,32 +460,7 @@ export const runPatternToolDescriptor: HarnessToolDescriptor = {
         message: { type: "string" },
         pieceId: { type: "string" },
         rawCauseMessage: { type: "string" },
-        policyRefusal: {
-          type: "object",
-          properties: {
-            gates: {
-              type: "array",
-              items: { type: "string", enum: ["sink-ceiling", "writer-fit"] },
-            },
-            sinks: { type: "array", items: { type: "string" } },
-            offendingAtoms: { type: "array", items: { type: "string" } },
-            withheldAtomCount: { type: "integer", minimum: 0 },
-            inputKeys: { type: "array", items: { type: "string" } },
-            unattributedInputCount: { type: "integer", minimum: 0 },
-            attribution: {
-              type: "string",
-              enum: ["complete", "partial", "none"],
-            },
-          },
-          required: [
-            "gates",
-            "sinks",
-            "offendingAtoms",
-            "inputKeys",
-            "attribution",
-          ],
-          additionalProperties: false,
-        },
+        policyRefusal: RUN_PATTERN_POLICY_REFUSAL_SCHEMA,
       },
       required: ["outputId", "status", "message"],
       additionalProperties: false,
@@ -532,6 +555,13 @@ const RUN_PATTERN_ANSWER_SINK = "run_pattern";
  * so no confidentiality clause names an audience it belongs to, and an empty
  * ceiling — "public only", per `sink-inventory.ts` — is the one that says so.
  *
+ * What crosses the sink is a VALUE. The result reference the tool returns is
+ * an opaque handle: it names the result without carrying it, and holding it
+ * discloses nothing (AH-CFC-18), so the ceiling is consulted only for a call
+ * that asks for values through `resultSchema`, and what a refusal withholds
+ * is those values and never the reference. The model composes work out of
+ * names it cannot read; that is what lets it route data it never sees.
+ *
  * Empty rather than absent, and the difference is the point. A sink absent
  * from the inventory goes ungated because a deployment has not decided about
  * it; this sink is not one a deployment declares, since the audience on the
@@ -563,21 +593,84 @@ interface RunPatternInputAddress {
   readonly path: readonly string[];
 }
 
-const pathStartsWith = (
+/** Whether `path` starts with `prefix`. */
+const pathHasPrefix = (
   path: readonly string[],
   prefix: readonly string[],
 ): boolean =>
   prefix.length <= path.length &&
   prefix.every((segment, index) => segment === path[index]);
 
+const inputAddressKey = (address: RunPatternInputAddress): string =>
+  JSON.stringify([address.key, address.hash, address.path]);
+
+/**
+ * The addresses an input's value reaches, given the dereferences a read of
+ * it performed: the address the caller's link named, and every address a
+ * link on the way to the value led on to, transitively.
+ *
+ * A caller's link commonly names a document that holds the value by
+ * reference rather than one that holds it — an operator-attached cell whose
+ * field links to the cell that carries the label — so the document a
+ * refused read names is one the caller's address never mentions. The
+ * dereference traces the attribution read recorded are the route from the
+ * one to the other, and following them is what places such a read.
+ *
+ * A link at or below the input's address leads to its target as it stands.
+ * A link above it — the document root is itself a link, say — leads to the
+ * target extended by the rest of the input's path, since that is where the
+ * value continues on the far side.
+ */
+const inputAddressesReached = (
+  addresses: readonly RunPatternInputAddress[],
+  traces: readonly CfcDereferenceTrace[],
+): readonly RunPatternInputAddress[] => {
+  const reached = [...addresses];
+  const seen = new Set(reached.map(inputAddressKey));
+  // A worklist: an address pushed here is visited in its turn, and the set
+  // above is what bounds the walk — a cycle of links adds nothing twice.
+  for (let index = 0; index < reached.length; index += 1) {
+    const from = reached[index];
+    for (const trace of traces) {
+      if (trace.kind !== "value") continue;
+      const targetHash = comparableEntityHash(trace.target.id);
+      if (
+        targetHash === undefined ||
+        comparableEntityHash(trace.source.id) !== from.hash
+      ) {
+        continue;
+      }
+      let path: readonly string[];
+      if (pathHasPrefix(trace.source.path, from.path)) {
+        path = trace.target.path;
+      } else if (pathHasPrefix(from.path, trace.source.path)) {
+        path = [
+          ...trace.target.path,
+          ...from.path.slice(trace.source.path.length),
+        ];
+      } else {
+        continue;
+      }
+      const next = { key: from.key, hash: targetHash, path };
+      const key = inputAddressKey(next);
+      if (!seen.has(key)) {
+        seen.add(key);
+        reached.push(next);
+      }
+    }
+  }
+  return reached;
+};
+
 /**
  * The keys of `inputs` a refused read belongs to, empty when none does.
  *
- * A read reaches an input two ways. It reads the document the caller's link
- * addressed, which the retained addresses match. Or it reads the piece's
- * argument document, where every input — link or plain JSON — sits under its
- * own key, so the first path segment is the key. Both are matched, because
- * one refusal commonly reports the same input through both.
+ * A read reaches an input two ways. It reads a document the caller's link
+ * addressed or led on to, which the addresses the input reached match. Or it
+ * reads the piece's argument document, where every input — link or plain
+ * JSON — sits under its own key, so the first path segment is the key. Both
+ * are matched, because one refusal commonly reports the same input through
+ * both.
  *
  * Every match is returned. One document handed in under two keys is reached
  * by dropping either alias alone, and a remedy naming one of them would
@@ -596,7 +689,7 @@ const refusalReadInputKeys = (
   const keys: string[] = [];
   for (const address of addresses) {
     if (
-      address.hash === readHash && pathStartsWith(read.path, address.path) &&
+      address.hash === readHash && pathHasPrefix(read.path, address.path) &&
       !keys.includes(address.key)
     ) {
       keys.push(address.key);
@@ -647,10 +740,18 @@ const namableRefusalAtom = (rendered: string): boolean => {
 export const runPatternPolicyRefusal = (
   refusals: readonly CfcRefusalDetail[],
   inputKeysFor: (read: CfcAddress) => readonly string[],
-): RunPatternPolicyRefusal | undefined => {
-  if (refusals.length === 0) {
-    return undefined;
-  }
+): RunPatternPolicyRefusal | undefined =>
+  nonEmpty(refusals) ? foldPolicyRefusals(refusals, inputKeysFor) : undefined;
+
+/** Whether `items` has a first element, narrowing to the tuple that says so. */
+const nonEmpty = <T>(items: readonly T[]): items is readonly [T, ...T[]] =>
+  items.length > 0;
+
+/** {@link runPatternPolicyRefusal} over at least one detail. */
+const foldPolicyRefusals = (
+  refusals: readonly [CfcRefusalDetail, ...CfcRefusalDetail[]],
+  inputKeysFor: (read: CfcAddress) => readonly string[],
+): RunPatternPolicyRefusal => {
   const gates: CfcRefusalGate[] = [];
   const sinks: string[] = [];
   const offendingAtoms: string[] = [];
@@ -708,7 +809,8 @@ const quoteAll = (values: readonly string[]): string =>
 /**
  * Which boundary a refusal came from, which decides what the caller is told
  * became of the result: a refused commit landed no result, while a refused
- * release has one, in the space under its own labels.
+ * release has one, in the space under its own labels, whose reference the
+ * caller holds with the values withheld.
  */
 export type RunPatternRefusalBoundary = "commit" | "release";
 
@@ -729,21 +831,23 @@ export const policyRefusalMessage = (
   const atoms = refusal.offendingAtoms.length > 0
     ? ` (${refusal.offendingAtoms.join(", ")})`
     : "";
-  const refused = boundaryRefused === "commit"
-    ? "commit its result"
-    : "release its result";
-  const became = boundaryRefused === "commit"
-    ? "the result never landed"
-    : "the result stays in the space and is withheld here";
-  const opening =
-    `the pattern ran but the space's policy refused to ${refused}: ` +
-    `${boundary} does not admit the confidentiality${atoms} this run ` +
-    `carries, so ${became}`;
+  const opening = boundaryRefused === "commit"
+    ? `the pattern ran but the space's policy refused to commit its result: ` +
+      `${boundary} does not admit the confidentiality${atoms} this run ` +
+      `carries, so the result never landed`
+    : `the pattern ran and its result is in the space, but the space's ` +
+      `policy refused to release its values: ${boundary} does not admit ` +
+      `the confidentiality${atoms} the result carries, so value is ` +
+      `withheld here while resultRef still names the result, which can be ` +
+      `passed on by reference`;
   const plural = refusal.inputKeys.length > 1;
   const keys = `input${plural ? "s" : ""} ${quoteAll(refusal.inputKeys)}`;
+  const cleared = boundaryRefused === "commit"
+    ? "proceeds"
+    : "releases its values";
   const remedy = refusal.attribution === "complete"
     ? `Every label refused here came in through ${keys}, so the same run ` +
-      `without ${plural ? "them" : "it"} proceeds`
+      `without ${plural ? "them" : "it"} ${cleared}`
     : refusal.attribution === "partial"
     ? `Some of what was refused came in through ${keys}; dropping ` +
       `${plural ? "them" : "it"} narrows the flow without necessarily ` +
@@ -1371,23 +1475,22 @@ export const runPatternTool: HarnessToolDefinition<
       space,
     );
     /**
-     * The report a policy refusal produces, whichever boundary stated it.
+     * The report a policy refusal produces, whichever boundary stated it:
+     * each offending read resolved to a key of this call's `inputs`.
      *
-     * The refusal reason stays out of the model-facing message the same way
-     * thrown text does: it names the documents and label atoms involved —
-     * fabric identifiers and policy detail the model does not read — so the
-     * artifact keeps it and the model gets the fact of the refusal.
+     * The caller's own addresses are extended by the dereferences the
+     * attribution read below recorded, so a read of a document the caller's
+     * link reaches through a link it holds is placed as readily as a read of
+     * the document it names. The piece's argument document is where every
+     * input reaches the pattern under its own key, so a refused read of it
+     * names an input by its first path segment. Its address is resolved here
+     * rather than kept from creation because only a refusal asks for it, and
+     * an argument cell that will not resolve leaves the caller's own
+     * addresses as the route from a clause back to an input key.
      */
-    const policyRefusalOutput = async (
-      details: readonly CfcRefusalDetail[],
-      boundaryRefused: RunPatternRefusalBoundary,
-      rawCauseMessage: string,
-    ) => {
-      recordOutcome("run_failed");
-      // The piece's argument document is where every input reaches the
-      // pattern under its own key, so a refused read of it names an input
-      // by its first path segment. Its address is resolved here rather than
-      // kept from creation because only a refusal asks for it.
+    const describeRefusal = async (
+      details: readonly [CfcRefusalDetail, ...CfcRefusalDetail[]],
+    ): Promise<RunPatternPolicyRefusal> => {
       let argumentHash: string | undefined;
       try {
         argumentHash = comparableEntityHash(
@@ -1396,22 +1499,41 @@ export const runPatternTool: HarnessToolDefinition<
       } catch {
         argumentHash = undefined;
       }
-      const policyRefusal = runPatternPolicyRefusal(
+      const reached = inputAddressesReached(inputAddresses, attributionTraces);
+      return foldPolicyRefusals(
         details,
         (read) =>
           refusalReadInputKeys(
             read,
-            inputAddresses,
+            reached,
             argumentHash,
             suppliedInputKeys,
           ),
       );
+    };
+
+    /**
+     * What a refused commit reports: a failed run, since nothing landed.
+     *
+     * The refusal reason stays out of the model-facing message the same way
+     * thrown text does: it names the documents and label atoms involved —
+     * fabric identifiers and policy detail the model does not read — so the
+     * artifact keeps it and the model gets the fact of the refusal.
+     */
+    const commitRefusalOutput = async (
+      details: readonly CfcRefusalDetail[],
+      rawCauseMessage: string,
+    ) => {
+      recordOutcome("run_failed");
+      const policyRefusal = nonEmpty(details)
+        ? await describeRefusal(details)
+        : undefined;
       return {
         ...errorOutput(
           "error",
           policyRefusal === undefined
             ? RUN_PATTERN_OPAQUE_REFUSAL_MESSAGE
-            : policyRefusalMessage(policyRefusal, boundaryRefused),
+            : policyRefusalMessage(policyRefusal, "commit"),
         ),
         pieceId: piece.id,
         rawCauseMessage,
@@ -1419,40 +1541,49 @@ export const runPatternTool: HarnessToolDefinition<
       };
     };
 
-    // The answer is an egress: what this tool returns is read by a model,
-    // outside every space the fabric labels. A pattern's own egresses are
-    // sink requests the commit boundary gates, and this one records none, so
-    // it is measured here. The measurement is a transaction that reads what
-    // the answer stands for, and its consumed join is what the answer
-    // carries — the result document, and every computed cell the result links
-    // to. Nothing is committed.
+    // The result is read HERE, through a transaction, and the value below is
+    // that read rather than a second one: a result the reactive graph
+    // advances between two reads would otherwise let a later clean state
+    // answer for an earlier labeled one. The read is host-side and discloses
+    // nothing by itself. What the answer discloses is the VALUES a
+    // `resultSchema` asks for, and those are an egress: they are read by a
+    // model, outside every space the fabric labels. A pattern's own egresses
+    // are sink requests the commit boundary gates, and this one records
+    // none, so it is measured here, and only when values were asked for —
+    // the transaction's consumed join, the result document and every
+    // computed cell the result links to, against the ceiling a model's
+    // context carries. The result reference goes out either way: it names
+    // the result without carrying it, and a name is not a release
+    // (AH-CFC-18). Nothing is committed.
     //
-    // A second transaction reads the piece's argument document, and only that
-    // transaction does. Every input reaches the pattern through that document
-    // under its own key, so a clause it carries names an input the caller can
-    // drop; a clause reaching the answer by another route is reported as
-    // unattributed.
+    // A second transaction reads the piece's argument document and the
+    // caller's own live inputs, and only that transaction does. Every input
+    // reaches the pattern through that document under its own key, so a
+    // clause it carries names an input the caller can drop; a clause
+    // reaching the answer by another route is reported as unattributed. The
+    // dereferences that transaction records on the way are kept with it:
+    // they are what place a read of a document the caller's link reaches
+    // through a link rather than names. Whether a refusal comes from this
+    // measurement or from the commit boundary, the attribution read is the
+    // same, so it runs whether or not values were asked for.
     //
-    // The ladder decides whether a recorded reason REJECTS, not whether it is
-    // taken: the measurement runs at every rung, so an observe-stage rollout
-    // can size what turning the rung up would refuse, which is what the sink
-    // gate beside it does with the same reason.
+    // The ladder decides whether a recorded reason WITHHOLDS the values, not
+    // whether they are measured: the measurement runs at every rung, so an
+    // observe-stage rollout can size what turning the rung up would withhold,
+    // which is what the sink gate beside it does with the same reason.
     const releaseGateRejects =
       pieces.runtime.cfcEnforcementMode !== "disabled" &&
       pieces.runtime.cfcEnforcementMode !== "observe";
     let releaseRefusal: CfcRefusalDetail | undefined;
+    let attributionTraces: readonly CfcDereferenceTrace[] = [];
     let rawValue: unknown;
     const measureRelease = async () => {
       const releaseTx = pieces.runtime.edit();
       const inputsTx = pieces.runtime.edit();
       try {
-        // The answer the tool returns is read HERE, through the transaction
-        // that measures it, and the value below is that read rather than a
-        // second one. A result the reactive graph advances between two reads
-        // would otherwise let a later clean state answer for an earlier
-        // labeled one. The `required` relaxation is the piece controller's,
-        // so a scoped link the session cannot materialize degrades its member
-        // rather than voiding the whole read.
+        // The `required` relaxation is the piece controller's, so a scoped
+        // link the session cannot materialize degrades its member rather
+        // than voiding the whole read.
         const measuredResult = cellWithScopedLinkRequiredsRelaxed(
           resultCell.withTx(releaseTx),
         );
@@ -1472,12 +1603,16 @@ export const runPatternTool: HarnessToolDefinition<
           await measuredInput.pull();
           asSerializableValue(measuredInput.get());
         }
-        return describeSinkReleaseRefusal(
-          releaseTx,
-          inputsTx,
-          RUN_PATTERN_ANSWER_SINK,
-          RUN_PATTERN_ANSWER_CEILING,
-        );
+        // Copied before the abort below, which clears them.
+        attributionTraces = [...inputsTx.getCfcState().dereferenceTraces];
+        return parsedResultSchema === undefined
+          ? undefined
+          : describeSinkReleaseRefusal(
+            releaseTx,
+            inputsTx,
+            RUN_PATTERN_ANSWER_SINK,
+            RUN_PATTERN_ANSWER_CEILING,
+          );
       } finally {
         releaseTx.abort("run_pattern release measurement");
         inputsTx.abort("run_pattern release attribution");
@@ -1553,9 +1688,8 @@ export const runPatternTool: HarnessToolDefinition<
         record.name === "CfcCommitRefusalError"
       );
       if (refusal !== undefined) {
-        return await policyRefusalOutput(
+        return await commitRefusalOutput(
           refusal.refusals ?? [],
-          "commit",
           refusal.message,
         );
       }
@@ -1615,35 +1749,28 @@ export const runPatternTool: HarnessToolDefinition<
         };
       }
     }
-    // A measurement the ladder does not reject on is still an answer about
-    // this run, and the only place it can be read from is the artifact.
-    const releaseObservation =
-      releaseRefusal === undefined || releaseGateRejects
-        ? undefined
-        : runPatternPolicyRefusal(
-          [releaseRefusal],
-          (read) =>
-            refusalReadInputKeys(
-              read,
-              inputAddresses,
-              undefined,
-              suppliedInputKeys,
-            ),
-        );
-    if (releaseRefusal !== undefined && releaseGateRejects) {
-      return await policyRefusalOutput(
-        [releaseRefusal],
-        "release",
-        releaseRefusal.reason,
-      );
-    }
     // A result the caller's own `resultSchema` refused is reported as neither
     // outcome: the pattern ran and landed a result, and the schema it did not
     // match was written by whoever called the tool, so it is evidence about
-    // the caller's contract rather than about the pattern.
+    // the caller's contract rather than about the pattern. A release the
+    // ceiling refused is evidence about policy, and the run succeeded under
+    // it.
     if (valueError === undefined) {
       recordOutcome("run_succeeded");
     }
+    // What the measurement found goes one of two ways. Where the ladder
+    // rejects, the values are withheld and the refusal reaches the model as
+    // data and as an instruction, with its reason kept for the artifact.
+    // Where it does not, the values go out and the measurement is still an
+    // answer about this run, which only the artifact can carry.
+    const withheldRefusal = releaseGateRejects ? releaseRefusal : undefined;
+    const withheld = withheldRefusal === undefined
+      ? undefined
+      : await describeRefusal([withheldRefusal]);
+    const releaseObservation =
+      releaseGateRejects || releaseRefusal === undefined
+        ? undefined
+        : await describeRefusal([releaseRefusal]);
 
     /**
      * The render gate: what the pattern's own `$UI` does before the pattern
@@ -1883,19 +2010,31 @@ export const runPatternTool: HarnessToolDefinition<
         }
       }
     }
+    const retainedCauses = [withheldRefusal?.reason, probeThrown].filter(
+      (text): text is string => text !== undefined,
+    );
     return {
       outputId,
       status: "ok",
       resultRef,
       resultRefSchema: pattern.resultSchema,
       pieceId: piece.id,
-      ...(value !== undefined ? { value } : {}),
-      ...(linkedStringCount !== undefined ? { linkedStringCount } : {}),
-      ...(valueError !== undefined ? { valueError } : {}),
+      ...(withheld !== undefined
+        ? {
+          valueError: policyRefusalMessage(withheld, "release"),
+          policyRefusal: withheld,
+        }
+        : {
+          ...(value !== undefined ? { value } : {}),
+          ...(linkedStringCount !== undefined ? { linkedStringCount } : {}),
+          ...(valueError !== undefined ? { valueError } : {}),
+        }),
       ...(rawValue !== undefined ? { rawValue } : {}),
       ...(releaseObservation !== undefined ? { releaseObservation } : {}),
       ...(publication !== undefined ? { patternPublication: publication } : {}),
-      ...(probeThrown !== undefined ? { rawCauseMessage: probeThrown } : {}),
+      ...(retainedCauses.length > 0
+        ? { rawCauseMessage: retainedCauses.join("\n\n") }
+        : {}),
     };
   },
 };

--- a/packages/cf-harness/test/run-pattern.test.ts
+++ b/packages/cf-harness/test/run-pattern.test.ts
@@ -320,6 +320,110 @@ async function seedLabelledSecret(
 }
 
 /**
+ * A pattern over an operator-shaped account: a balance and a list of
+ * transactions, the spending summed from the negative amounts. The input is
+ * typed as plain data, which is how a model wires a cell it was handed.
+ */
+const SPENDING_PATTERN_SOURCE = [
+  "import { computed, pattern } from 'commonfabric';",
+  "interface Transaction { amount: number; }",
+  "interface Account { balance: number; transactions: Transaction[]; }",
+  "interface Input { account: Account; }",
+  "interface Output { totalSpending: number; }",
+  "export default pattern<Input, Output>(({ account }) => ({",
+  "  totalSpending: computed(() => account.transactions.reduce(",
+  "    (sum, t) => sum + (t.amount < 0 ? -t.amount : 0),",
+  "    0,",
+  "  )),",
+  "}));",
+  "",
+].join("\n");
+
+const TOTAL_SPENDING_RESULT_SCHEMA = {
+  type: "object",
+  properties: { totalSpending: { type: "number" } },
+  required: ["totalSpending"],
+} as const;
+
+/**
+ * Seeds an account the way an operator attaches one: a document whose
+ * `account` field is a LINK to a second document, and the second document is
+ * the one that carries the confidentiality, on its root. Returns the
+ * LLM-friendly link to the first document's `account` field, which is what
+ * the agent is handed — so the labeled document is one the agent's address
+ * never names, reached only by dereferencing the link it holds.
+ */
+async function seedLabelledAccount(
+  runtime: Runtime,
+  space: ReturnType<PiecesController["getSpace"]>,
+  cause: string,
+): Promise<string> {
+  const seed = runtime.edit();
+  const accountCell = runtime.getCell(
+    space,
+    `${cause}-account`,
+    {
+      type: "object",
+      properties: {
+        balance: { type: "number" },
+        transactions: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: { amount: { type: "number" } },
+          },
+        },
+      },
+    },
+    seed,
+  );
+  const accountId = accountCell.getAsNormalizedFullLink().id;
+  writeSeedEnvelopeDoc(seed, space);
+  seed.writeOrThrow({ space, scope: "space", id: accountId, path: [] }, {
+    value: {
+      balance: 2000,
+      transactions: [{ amount: -120 }, { amount: 2000 }, { amount: -25 }],
+    },
+    cfc: {
+      version: 1,
+      schemaHash: SEED_ENVELOPE_SCHEMA_HASH,
+      labelMap: {
+        version: 1,
+        entries: [{ path: [], label: { confidentiality: ["finance"] } }],
+      },
+    },
+  });
+  const holderCell = runtime.getCell(
+    space,
+    `${cause}-holder`,
+    { type: "object", properties: { account: { type: "object" } } },
+    seed,
+  );
+  seed.writeOrThrow(
+    {
+      space,
+      scope: "space",
+      id: holderCell.getAsNormalizedFullLink().id,
+      path: [],
+    },
+    {
+      value: {
+        account: {
+          "/": {
+            "link@1": { id: accountId, path: [], scope: "space", space },
+          },
+        },
+      },
+    },
+  );
+  expect((await seed.commit()).ok).toBeDefined();
+  return createLLMFriendlyLink(
+    holderCell.key("account").getAsNormalizedFullLink(),
+    space,
+  );
+}
+
+/**
  * The session's pieces with the argument-document route to an input key taken
  * away: once the piece is running, resolving its argument cell fails. That is
  * the state a refusal report degrades under when the argument cell of a piece
@@ -1029,15 +1133,21 @@ describe("run-pattern", () => {
             "",
           ].join("\n"),
           inputs: { source: sourceRef },
+          resultSchema: {
+            type: "object",
+            properties: { copied: { type: "string" } },
+            required: ["copied"],
+          },
         });
-        const output = result.output as RunPatternToolErrorOutput;
-        expect(output.status).toBe("error");
-        expect(output.message).toContain("policy refused to release");
-        expect(output.message).toContain("withheld here");
+        const output = result.output as RunPatternToolSuccessOutput;
+        expect(output.status).toBe("ok");
+        expect(output.value).toBeUndefined();
+        expect(output.valueError).toContain("policy refused to release");
+        expect(output.valueError).toContain("withheld here");
         // The refusal reason is a data channel: it stays in the artifact
         // field the prompt loop strips from model context, never in the
-        // message.
-        expect(output.message).not.toContain("exceeds ceiling");
+        // model-facing text.
+        expect(output.valueError).not.toContain("exceeds ceiling");
         expect(output.rawCauseMessage).toContain(
           'confidentiality exceeds ceiling for run_pattern: "secret"',
         );
@@ -1064,12 +1174,13 @@ describe("run-pattern", () => {
             resultSchema: TOTAL_RESULT_SCHEMA,
           },
         );
-        const output = result.output as RunPatternToolErrorOutput;
-        expect(output.status).toBe("error");
-        expect(output.message).toContain("policy refused to release");
-        expect(output.message).toContain('input "source"');
-        expect(output.message).toContain("without it proceeds");
-        expect(output.message).not.toContain('"amount"');
+        const output = result.output as RunPatternToolSuccessOutput;
+        expect(output.status).toBe("ok");
+        expect(output.value).toBeUndefined();
+        expect(output.valueError).toContain("policy refused to release");
+        expect(output.valueError).toContain('input "source"');
+        expect(output.valueError).toContain("without it releases its values");
+        expect(output.valueError).not.toContain('"amount"');
         expect(output.policyRefusal).toEqual({
           gates: ["sink-ceiling"],
           sinks: ["run_pattern"],
@@ -1102,8 +1213,9 @@ describe("run-pattern", () => {
           sourceText: OPTIONAL_SECRET_PATTERN_SOURCE,
           inputs,
           resultSchema: TOTAL_RESULT_SCHEMA,
-        })).output as RunPatternToolErrorOutput;
-        expect(refused.status).toBe("error");
+        })).output as RunPatternToolSuccessOutput;
+        expect(refused.status).toBe("ok");
+        expect(refused.value).toBeUndefined();
         expect(refused.policyRefusal?.attribution).toBe("complete");
         const named = refused.policyRefusal?.inputKeys ?? [];
         expect(named).toEqual(["source"]);
@@ -1142,7 +1254,7 @@ describe("run-pattern", () => {
             resultSchema: TOTAL_RESULT_SCHEMA,
           },
         );
-        const output = result.output as RunPatternToolErrorOutput;
+        const output = result.output as RunPatternToolSuccessOutput;
         const encoded = JSON.stringify(output.policyRefusal);
         expect(scrubBareFabricIdentifiers(encoded)).toBe(encoded);
         expect(encoded).not.toContain(space);
@@ -1177,11 +1289,22 @@ describe("run-pattern", () => {
               "",
             ].join("\n"),
             inputs: { source: sourceRef },
+            resultSchema: {
+              type: "object",
+              properties: {
+                copy: {
+                  type: "object",
+                  properties: { secret: { type: "string" } },
+                },
+              },
+              required: ["copy"],
+            },
           },
         );
-        const output = result.output as RunPatternToolErrorOutput;
-        expect(output.status).toBe("error");
-        expect(output.message).toContain("policy refused to release");
+        const output = result.output as RunPatternToolSuccessOutput;
+        expect(output.status).toBe("ok");
+        expect(output.value).toBeUndefined();
+        expect(output.valueError).toContain("policy refused to release");
         expect(output.policyRefusal?.offendingAtoms).toEqual(['"secret"']);
       } finally {
         await dispose();
@@ -1229,8 +1352,8 @@ describe("run-pattern", () => {
             resultSchema: TOTAL_RESULT_SCHEMA,
           },
         );
-        const output = result.output as RunPatternToolErrorOutput;
-        expect(output.status).toBe("error");
+        const output = result.output as RunPatternToolSuccessOutput;
+        expect(output.status).toBe("ok");
         expect(output.policyRefusal?.inputKeys).toEqual(
           expect.arrayContaining(["source", "alsoSource"]),
         );
@@ -1265,11 +1388,22 @@ describe("run-pattern", () => {
               "",
             ].join("\n"),
             inputs: { source: sourceRef },
+            resultSchema: {
+              type: "object",
+              properties: {
+                wrapper: {
+                  type: "object",
+                  properties: { note: { type: "string" } },
+                },
+              },
+              required: ["wrapper"],
+            },
           },
         );
-        const output = result.output as RunPatternToolErrorOutput;
-        expect(output.status).toBe("error");
-        expect(output.message).toContain("policy refused to release");
+        const output = result.output as RunPatternToolSuccessOutput;
+        expect(output.status).toBe("ok");
+        expect(output.value).toBeUndefined();
+        expect(output.valueError).toContain("policy refused to release");
         expect(output.policyRefusal?.offendingAtoms).toEqual(['"secret"']);
       } finally {
         await dispose();
@@ -1362,11 +1496,11 @@ describe("run-pattern", () => {
           inputs: { amount: 2, source: sourceRef },
           resultSchema: TOTAL_RESULT_SCHEMA,
         });
-        const output = result.output as RunPatternToolErrorOutput;
-        expect(output.status).toBe("error");
+        const output = result.output as RunPatternToolSuccessOutput;
+        expect(output.status).toBe("ok");
         expect(output.policyRefusal?.inputKeys).toEqual(["source"]);
         expect(output.policyRefusal?.attribution).toBe("complete");
-        expect(output.message).toContain("without it proceeds");
+        expect(output.valueError).toContain("without it releases its values");
       } finally {
         await dispose();
       }
@@ -1391,9 +1525,128 @@ describe("run-pattern", () => {
             resultSchema: TOTAL_RESULT_SCHEMA,
           },
         );
-        const output = result.output as RunPatternToolErrorOutput;
-        expect(output.status).toBe("error");
+        const output = result.output as RunPatternToolSuccessOutput;
+        expect(output.status).toBe("ok");
         expect(output.policyRefusal?.unattributedInputCount).toBe(1);
+      } finally {
+        await dispose();
+      }
+    });
+
+    it("returns the result reference without consulting the ceiling when no `resultSchema` asks for values", async () => {
+      // A reference names the result without carrying it, so handing one
+      // back discloses nothing: the ceiling gates values, and a call that
+      // asks for none is not measured against it. This is the shape an
+      // agent that routes data it never reads relies on — the pattern
+      // derives from a labeled input, and the reference to what it derived
+      // comes back all the same.
+      const { runtime, pieces, space, dispose } = await createStrictFabric();
+      try {
+        const accountRef = await seedLabelledAccount(
+          runtime,
+          space,
+          "release-reference-only",
+        );
+        const result = await createStrictEngine(pieces).invokeBuiltinTool(
+          "run_pattern",
+          {
+            sourceText: SPENDING_PATTERN_SOURCE,
+            inputs: { account: accountRef },
+          },
+        );
+        const output = result.output as RunPatternToolSuccessOutput;
+        expect(output.status).toBe("ok");
+        expect(output.resultRef).toMatch(/^\/of:/);
+        expect(output.value).toBeUndefined();
+        expect(output.valueError).toBeUndefined();
+        expect(output.policyRefusal).toBeUndefined();
+        expect(output.releaseObservation).toBeUndefined();
+        // The result did derive from the labeled input: the reference names
+        // exactly what the ceiling withholds as a value.
+        expect((output.rawValue as { totalSpending: number }).totalSpending)
+          .toBe(145);
+      } finally {
+        await dispose();
+      }
+    });
+
+    it("withholds the values the ceiling refuses and still returns the result reference", async () => {
+      // Asking for values is what consults the ceiling, and a refusal
+      // withholds exactly what was measured: the values. The reference comes
+      // back with them withheld, so the agent can still pass the result on
+      // by reference, and the refusal reaches it as data and as an
+      // instruction while the reason stays in the artifact.
+      const { runtime, pieces, space, dispose } = await createStrictFabric();
+      try {
+        const accountRef = await seedLabelledAccount(
+          runtime,
+          space,
+          "release-values-withheld",
+        );
+        const result = await createStrictEngine(pieces).invokeBuiltinTool(
+          "run_pattern",
+          {
+            sourceText: SPENDING_PATTERN_SOURCE,
+            inputs: { account: accountRef },
+            resultSchema: TOTAL_SPENDING_RESULT_SCHEMA,
+          },
+        );
+        const output = result.output as RunPatternToolSuccessOutput;
+        expect(output.status).toBe("ok");
+        expect(output.resultRef).toMatch(/^\/of:/);
+        expect(output.value).toBeUndefined();
+        expect(output.linkedStringCount).toBeUndefined();
+        expect(output.valueError).toContain(
+          "policy refused to release its values",
+        );
+        expect(output.valueError).toContain("resultRef still names the result");
+        expect(output.valueError).not.toContain("exceeds ceiling");
+        expect(output.rawCauseMessage).toContain(
+          'confidentiality exceeds ceiling for run_pattern: "finance"',
+        );
+        expect(output.policyRefusal?.gates).toEqual(["sink-ceiling"]);
+        expect(output.policyRefusal?.offendingAtoms).toEqual(['"finance"']);
+        expect((output.rawValue as { totalSpending: number }).totalSpending)
+          .toBe(145);
+      } finally {
+        await dispose();
+      }
+    });
+
+    it("names the input whose link reaches the labeled document through a link it holds", async () => {
+      // The caller's address names the holder document; the label lives on
+      // the document the holder's `account` field links to, which the
+      // caller's address never names. The refused read is of that second
+      // document, and what ties it back to `account` is the dereference the
+      // attribution read performed to get there. The refusal names `account`
+      // as the whole remedy rather than counting the document as one no
+      // input accounts for.
+      const { runtime, pieces, space, dispose } = await createStrictFabric();
+      try {
+        const accountRef = await seedLabelledAccount(
+          runtime,
+          space,
+          "release-field-addressed-input",
+        );
+        const result = await createStrictEngine(pieces).invokeBuiltinTool(
+          "run_pattern",
+          {
+            sourceText: SPENDING_PATTERN_SOURCE,
+            inputs: { account: accountRef },
+            resultSchema: TOTAL_SPENDING_RESULT_SCHEMA,
+          },
+        );
+        const output = result.output as RunPatternToolSuccessOutput;
+        expect(output.status).toBe("ok");
+        expect(output.policyRefusal).toEqual({
+          gates: ["sink-ceiling"],
+          sinks: ["run_pattern"],
+          offendingAtoms: ['"finance"'],
+          inputKeys: ["account"],
+          attribution: "complete",
+        });
+        expect(output.valueError).toContain('input "account"');
+        expect(output.valueError).toContain("without it releases its values");
       } finally {
         await dispose();
       }
@@ -1495,8 +1748,8 @@ describe("run-pattern", () => {
       // is itself a link into the labelled source path. The result reads
       // back as the values, but no document at rest holds a copy at all: a
       // reader reaching the text does so through the source's own label map.
-      // The answer still leaves the fabric for a model, so it is refused on
-      // the labels those links reach.
+      // The call asks for no values, so what leaves the fabric for the model
+      // is the reference alone, and nothing is measured or withheld.
       const { runtime, pieces, space, dispose } = await createStrictFabric();
       try {
         const expenseIds: string[] = [];
@@ -1579,13 +1832,14 @@ describe("run-pattern", () => {
             ),
           },
         });
-        const output = result.output as RunPatternToolErrorOutput;
-        expect(output.status).toBe("error");
-        expect(output.message).toContain("policy refused to release");
+        const output = result.output as RunPatternToolSuccessOutput;
+        expect(output.status).toBe("ok");
+        expect(output.value).toBeUndefined();
+        expect(output.policyRefusal).toBeUndefined();
         await runtime.idle();
         await pieces.synced();
 
-        const piece = await pieces.get(output.pieceId!);
+        const piece = await pieces.get(output.pieceId);
         expect(await piece.result.get(["notes"])).toEqual([
           "alpha-secret",
           "beta-secret",
@@ -2539,10 +2793,12 @@ describe("run-pattern", () => {
       );
     });
 
-    it("says the result is withheld when the release boundary refused", () => {
+    it("says the values are withheld and the reference stands when the release boundary refused", () => {
       // The answer's own sink refuses what the run already landed, so what
       // the caller is told became of the result differs from a refused
-      // commit: it exists, in the space, under its own labels.
+      // commit: it exists, in the space, under its own labels, and the
+      // caller holds its reference with the values withheld — so the remedy
+      // releases values rather than making the run proceed.
       const message = policyRefusalMessage({
         gates: ["sink-ceiling"],
         sinks: ["run_pattern"],
@@ -2550,10 +2806,9 @@ describe("run-pattern", () => {
         inputKeys: ["source"],
         attribution: "complete",
       }, "release");
-      expect(message).toContain("policy refused to release its result");
-      expect(message).toContain(
-        "the result stays in the space and is withheld here",
-      );
+      expect(message).toContain("policy refused to release its values");
+      expect(message).toContain("resultRef still names the result");
+      expect(message).toContain("without it releases its values");
       expect(message).not.toContain("never landed");
     });
 

--- a/packages/cf-harness/test/run-pattern.test.ts
+++ b/packages/cf-harness/test/run-pattern.test.ts
@@ -346,59 +346,69 @@ const TOTAL_SPENDING_RESULT_SCHEMA = {
 } as const;
 
 /**
- * Seeds an account the way an operator attaches one: a document whose
- * `account` field is a LINK to a second document, and the second document is
- * the one that carries the confidentiality, on its root. Returns the
- * LLM-friendly link to the first document's `account` field, which is what
- * the agent is handed — so the labeled document is one the agent's address
- * never names, reached only by dereferencing the link it holds.
+ * How the holder document an agent is handed reaches the labeled account:
+ * through a link in its `account` field, the way an operator attaches one;
+ * through a link at its own root, above the field the agent addresses; or
+ * through its `account` field beside a `notes` field linking to an
+ * unlabeled document, so a dereference the holder records leads somewhere
+ * the account never goes.
  */
-async function seedLabelledAccount(
+type AccountHolderShape = "field-link" | "root-link" | "two-fields";
+
+/**
+ * Seeds an account the way an operator attaches one: a holder document that
+ * reaches the account document by a link, with the confidentiality on the
+ * account document and not on the holder. Returns the LLM-friendly link to
+ * the holder's `account` position, which is what the agent is handed — so
+ * the labeled document is one the agent's address never names, reached only
+ * by dereferencing what the holder holds — and, for the two-field shape, the
+ * link to its `notes` position as well.
+ */
+async function seedAccountHolder(
   runtime: Runtime,
   space: ReturnType<PiecesController["getSpace"]>,
   cause: string,
-): Promise<string> {
+  shape: AccountHolderShape,
+): Promise<{ account: string; notes: string }> {
   const seed = runtime.edit();
+  const account = {
+    balance: 2000,
+    transactions: [{ amount: -120 }, { amount: 2000 }, { amount: -25 }],
+  };
   const accountCell = runtime.getCell(
     space,
     `${cause}-account`,
-    {
-      type: "object",
-      properties: {
-        balance: { type: "number" },
-        transactions: {
-          type: "array",
-          items: {
-            type: "object",
-            properties: { amount: { type: "number" } },
-          },
-        },
-      },
-    },
+    undefined,
     seed,
   );
   const accountId = accountCell.getAsNormalizedFullLink().id;
   writeSeedEnvelopeDoc(seed, space);
+  // A root-linked holder continues into the account document at `account`,
+  // so that document carries the field and the label sits on it; the others
+  // link straight at the account, labeled at its root.
   seed.writeOrThrow({ space, scope: "space", id: accountId, path: [] }, {
-    value: {
-      balance: 2000,
-      transactions: [{ amount: -120 }, { amount: 2000 }, { amount: -25 }],
-    },
+    value: shape === "root-link" ? { account } : account,
     cfc: {
       version: 1,
       schemaHash: SEED_ENVELOPE_SCHEMA_HASH,
       labelMap: {
         version: 1,
-        entries: [{ path: [], label: { confidentiality: ["finance"] } }],
+        entries: [{
+          path: shape === "root-link" ? ["account"] : [],
+          label: { confidentiality: ["finance"] },
+        }],
       },
     },
   });
-  const holderCell = runtime.getCell(
-    space,
-    `${cause}-holder`,
-    { type: "object", properties: { account: { type: "object" } } },
-    seed,
-  );
+  const notesCell = runtime.getCell(space, `${cause}-notes`, undefined, seed);
+  const notesId = notesCell.getAsNormalizedFullLink().id;
+  seed.writeOrThrow({ space, scope: "space", id: notesId, path: [] }, {
+    value: { text: "unlabeled" },
+  });
+  const linkTo = (id: string) => ({
+    "/": { "link@1": { id, path: [], scope: "space", space } },
+  });
+  const holderCell = runtime.getCell(space, `${cause}-holder`, undefined, seed);
   seed.writeOrThrow(
     {
       space,
@@ -407,20 +417,33 @@ async function seedLabelledAccount(
       path: [],
     },
     {
-      value: {
-        account: {
-          "/": {
-            "link@1": { id: accountId, path: [], scope: "space", space },
-          },
-        },
-      },
+      value: shape === "root-link"
+        ? linkTo(accountId)
+        : shape === "two-fields"
+        ? { account: linkTo(accountId), notes: linkTo(notesId) }
+        : { account: linkTo(accountId) },
     },
   );
   expect((await seed.commit()).ok).toBeDefined();
-  return createLLMFriendlyLink(
-    holderCell.key("account").getAsNormalizedFullLink(),
-    space,
-  );
+  return {
+    account: createLLMFriendlyLink(
+      holderCell.key("account").getAsNormalizedFullLink(),
+      space,
+    ),
+    notes: createLLMFriendlyLink(
+      holderCell.key("notes").getAsNormalizedFullLink(),
+      space,
+    ),
+  };
+}
+
+/** {@link seedAccountHolder} in the operator's shape, the account link alone. */
+async function seedLabelledAccount(
+  runtime: Runtime,
+  space: ReturnType<PiecesController["getSpace"]>,
+  cause: string,
+): Promise<string> {
+  return (await seedAccountHolder(runtime, space, cause, "field-link")).account;
 }
 
 /**
@@ -1647,6 +1670,85 @@ describe("run-pattern", () => {
         });
         expect(output.valueError).toContain('input "account"');
         expect(output.valueError).toContain("without it releases its values");
+      } finally {
+        await dispose();
+      }
+    });
+
+    it("names the input when the link it follows sits above the input's address", async () => {
+      // The holder's root is itself a link, and the caller's address names
+      // the `account` field beneath it: the dereference the attribution read
+      // records starts above the address, so the address continues on the
+      // far side of the link, into the account document's own `account`
+      // field, where the label sits.
+      const { runtime, pieces, space, dispose } = await createStrictFabric();
+      try {
+        const refs = await seedAccountHolder(
+          runtime,
+          space,
+          "release-root-linked-holder",
+          "root-link",
+        );
+        const result = await createStrictEngine(pieces).invokeBuiltinTool(
+          "run_pattern",
+          {
+            sourceText: SPENDING_PATTERN_SOURCE,
+            inputs: { account: refs.account },
+            resultSchema: TOTAL_SPENDING_RESULT_SCHEMA,
+          },
+        );
+        const output = result.output as RunPatternToolSuccessOutput;
+        expect(output.status).toBe("ok");
+        expect(output.policyRefusal?.inputKeys).toEqual(["account"]);
+        expect(output.policyRefusal?.attribution).toBe("complete");
+      } finally {
+        await dispose();
+      }
+    });
+
+    it("does not name an input for a dereference the holder made somewhere else", async () => {
+      // The holder links to the labeled account under `account` and to an
+      // unlabeled document under `notes`, and both are inputs. The `notes`
+      // dereference is recorded against the same holder document, but it
+      // starts beside the `account` address rather than at, below, or above
+      // it, so it leads the `account` input nowhere — and `notes` is not
+      // named, since nothing it reaches carries the label.
+      const { runtime, pieces, space, dispose } = await createStrictFabric();
+      try {
+        const refs = await seedAccountHolder(
+          runtime,
+          space,
+          "release-two-field-holder",
+          "two-fields",
+        );
+        const result = await createStrictEngine(pieces).invokeBuiltinTool(
+          "run_pattern",
+          {
+            sourceText: [
+              "import { computed, pattern } from 'commonfabric';",
+              "interface Transaction { amount: number; }",
+              "interface Account { balance: number; transactions: Transaction[]; }",
+              "interface Notes { text: string; }",
+              "interface Input { account: Account; notes: Notes; }",
+              "interface Output { totalSpending: number; noteLength: number; }",
+              "export default pattern<Input, Output>(({ account, notes }) => ({",
+              "  totalSpending: computed(() => account.transactions.reduce(",
+              "    (sum, t) => sum + (t.amount < 0 ? -t.amount : 0),",
+              "    0,",
+              "  )),",
+              "  noteLength: computed(() => notes.text.length),",
+              "}));",
+              "",
+            ].join("\n"),
+            inputs: { account: refs.account, notes: refs.notes },
+            resultSchema: TOTAL_SPENDING_RESULT_SCHEMA,
+          },
+        );
+        const output = result.output as RunPatternToolSuccessOutput;
+        expect(output.status).toBe("ok");
+        expect(output.policyRefusal?.inputKeys).toEqual(["account"]);
+        expect(output.policyRefusal?.attribution).toBe("complete");
+        expect(output.valueError).not.toContain('"notes"');
       } finally {
         await dispose();
       }


### PR DESCRIPTION
Part of CT-2175 (question 1, ruled 2026-09-02: a reference-only answer is not a release). Fixes CT-2188.

## What changes

**The `run_pattern` answer ceiling gates values only.** The sink measured everything the tool returned and refused the whole answer, `resultRef` included, whenever the result carried a clause outside the public-only model-context ceiling. Under `max-enforcement` every pattern computed over a labeled input ran and was then refused, reference and all (12 refusals in the CT-2066 demo rerun). Now:

- A call with no `resultSchema` receives `resultRef` (and the piece id in the artifact) without the ceiling being consulted. Nothing is disclosed, so nothing is measured.
- A call whose values the ceiling refuses still receives `resultRef`, with `value` withheld: `valueError` states the refusal as an instruction, `policyRefusal` carries it as data on the success output, and the reason stays in the artifact's `rawCauseMessage`. The run is recorded as `run_succeeded`; the refusal is evidence about policy, not the pattern.
- No new tool-API surface: `policyRefusal` moves onto the success output for the release case (the error output keeps it for commit refusals), and `valueError` already meant "why `value` is absent despite a `resultSchema`". The output schema shares one `policyRefusal` schema between the two branches instead of two copies.

**Attribution (CT-2188).** The demo's refusal said "No input of this call accounts for what was refused" with `inputKeys: []`, `unattributedInputCount: 1`, while `account` was the only input. Root cause, verified against the demo's label reader output (`cell-labels-read-by-hand.json`: the entry on the input cell has `source: of:fid1:ZIFG…`, a different document): the caller's link names a document whose `account` field is itself a link, and the label lives on the document that link leads to. `refusalReadInputKeys` compared documents by hash against the caller's address alone, so the refused read of the linked document matched nothing. The attribution transaction already records the dereferences it performs (`getCfcState().dereferenceTraces`), so those traces now extend the caller's addresses to every document a link on the way to the value led to, transitively, and the refusal names `account` as the whole remedy. The attribution read now runs whether or not values were asked for, since a commit refusal is attributed the same way.

## Tests

Three new tests in `packages/cf-harness/test/run-pattern.test.ts` use the demo's shape: a holder document whose `account` field links to a document labeled `confidentiality: ["finance"]` at its root, and a pattern summing that account's spending. Each was run against the pre-change code (or the pre-change attribution rule) and fails there:

- `returns the result reference without consulting the ceiling when no resultSchema asks for values` — guards: a handle is not a release; nothing measured, no `policyRefusal`, no `releaseObservation`, `resultRef` present, and the raw result in the artifact proves the result did derive from the labeled input.
- `withholds the values the ceiling refuses and still returns the result reference` — guards: asking for values consults the ceiling; the refusal withholds `value` and `linkedStringCount` only; `resultRef` stands; the reason is in `rawCauseMessage` and not in model-facing text.
- `names the input whose link reaches the labeled document through a link it holds` — guards CT-2188: `inputKeys: ["account"]`, `attribution: "complete"`, and the message names the input. Without trace following this reproduces the demo record exactly (`attribution: "none"`, `inputKeys: []`, `unattributedInputCount: 1`).

Existing release-refusal tests move from the error output to the success output, and the ones that asked for no values now pass a `resultSchema`, since that is what consults the ceiling. The pattern-body map test that expected a refusal on a schema-less call now expects the reference alone.

## Docs

- `packages/cf-harness/README.md`: new paragraph after the success-output paragraph describing the value-only contract, the refusal fields, attribution, and the observe-posture observation.
- `docs/specs/cfc-enforcement-matrix.md` and `docs/specs/cfc-spec-changes.md`: the host-route paragraphs now say the measurement covers the values a `resultSchema` asks for and that a refusal withholds values while the reference goes out.
- `docs/specs/agent-harness/02-cfc-integration.md`, AH-CFC-18 (normative). Appended to the clause, verbatim: "The converse holds too: minting or returning a handle to the model is not a release. A handle names a referent without carrying it, so a tool MAY return one for a result whose labels a model-context ceiling refuses, and a release ceiling applies only to a value that crosses into model context." The existing text said possession of a handle grants no release; it did not say returning one is not a release, which is the reading the gate had taken.
- The `resultSchema` tool description the model reads now says what a refusal withholds and that `resultRef` still names the result.

## Not in this change

- The measurement is still over the whole result document (every computed cell the result links to), not only the positions the `resultSchema` models. A schema that models only unlabeled fields of a result that also carries labeled ones is refused its values. Same coarseness as before; narrowing it means re-reading the released positions through the measuring transaction.
- Release refusals are still visible only in tool outputs, not in `policy-trace.json` (CT-2175 audit-visibility item, open). Questions 2 to 5 on CT-2175 remain open.

Linear-issue: References CT-2175
Linear-issue-url: https://linear.app/common-tools/issue/CT-2175/nothing-has-ever-been-refused-by-a-label-and-declassification-by
Linear-issue: Fixes CT-2188
Linear-issue-url: https://linear.app/common-tools/issue/CT-2188/run-pattern-sink-refusal-says-no-input-accounts-for-the-label-while

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6759?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

