### PR TITLE
docs(cf-harness): reorient onboarding around attaching a console to your dev server

### DIFF
--- a/packages/cf-harness/ONBOARDING.md
+++ b/packages/cf-harness/ONBOARDING.md
@@ -1,31 +1,30 @@
-# cf-harness onboarding: one task to an openable piece
+# cf-harness onboarding: attach a console to your dev server
 
-Every command below is literal. Run it from the directory named above the block;
-replace only values in `<angle-brackets>`.
+Every command below is literal, and each block carries its own `cd`. Replace
+only values in `<angle-brackets>`.
 
 ## 1. What this is
 
 - `cf-harness` gives an agent a bounded prompt-and-tool loop.
-- Input cells enter that loop as handles, not copied values.
-- Patterns run beside those cells in one configured Fabric space.
-- Successful work is durable as a piece, and a slug makes it openable.
-- CFC policy and artifacts make the run inspectable after it ends.
+- The loop works in handles: names for data in a Fabric space, never copies of
+  it. A schema decides what crosses back as a value.
+- Work happens by writing patterns and running them in the space; a successful
+  run leaves a piece a person can open, and a slug makes it addressable.
+- CFC policy governs every tool call, and the run's artifacts make it
+  inspectable after it ends.
+- The console is a local web page over that loop: type a task, watch the run,
+  open what it built, and read what it left behind.
 
-**Goal:** weaver pill → harness session → openable, reactive, CFC-governed
-piece.
-
-The two ideas underneath the flow are
-[handles and patterns](README.md#the-model-handles-and-patterns): a schema
-decides what may cross as a value, and computation goes to the referenced data.
-The web service implements clauses 1–4 of the
-[weaver service contract](https://linear.app/common-tools/issue/CT-2155);
-local-auth simplification is still open under clause 5.
+[Handles and patterns](README.md#the-model-handles-and-patterns) is the model
+underneath all of it. This document is the path from a toolshed you already run
+to a session you can browse. The labeled-cell flow is one worked example in
+section 7, not a prerequisite for anything before it.
 
 ### The three demos
 
 - [CT-2190](https://linear.app/common-tools/issue/CT-2190/demo-the-weaver-pill-cf-harness-session-openable-cfc-governed-piece)
-  demonstrates the Weaver pill → harness → openable, CFC-governed piece; this
-  document is its runbook.
+  demonstrates the Weaver pill → harness → openable, CFC-governed piece; section
+  7 is its runbook.
 - [CT-2189](https://linear.app/common-tools/issue/CT-2189/demo-bills-dashboard-from-gmail-plaid-connectors-cfc-governed-alexs)
   demonstrates the connector-fed bills dashboard over Gmail and Plaid; its
   loom-side gaps are stated on the issue.
@@ -35,33 +34,46 @@ local-auth simplification is still open under clause 5.
 
 ## 2. Prerequisites
 
-1. Install the Deno version pinned by `mise.toml`, using any version manager.
-   Check the active binary:
+Four things are needed to explore. The pattern-index allowlist is a fifth that a
+first run does without.
+
+1. **The pinned Deno.** `mise.toml` pins the version; install it with any
+   version manager and check the active binary:
 
    ```sh
    cd <labs>
    deno --version
    ```
 
-   Success is a version matching the pin. For `mise` users whose shell has not
-   activated its shims, run `mise install` and then
-   `export PATH="$(mise where deno)/bin:$PATH"`.
+   Success is a version matching the pin. For `mise` users: a fresh checkout or
+   worktree is untrusted, so `mise where deno` fails until you run `mise trust`
+   in it. Either trust it, or skip the shims and put the install on `PATH`
+   directly:
 
-2. Start Docker and register the `runsc-cfc` runtime. On macOS, follow the
-   gVisor
+   ```sh
+   export PATH="$HOME/.local/share/mise/installs/deno/<pinned-version>/bin:$PATH"
+   ```
+
+   Every `deno run` and `deno task` in this checkout prints a repeated
+   `Warning Ignored build scripts for packages: npm:fuse-native@2.2.6` box on
+   stderr. It is noise; the command's output is on stdout.
+
+2. **Docker with the `runsc-cfc` runtime.** Every tool the model runs executes
+   in a container under that runtime. On macOS, follow the gVisor
    [Docker Desktop CFC setup guide](https://github.com/commontoolsinc/gvisor/blob/cfc_v2/g3doc/user_guide/quick_start/docker_desktop_cfc.md);
-   it owns the installation and registration procedure. Confirm only the
-   resulting contract here:
+   it owns installation and registration. Confirm the result:
 
    ```sh
    docker info --format '{{json .Runtimes}}'
    ```
 
    Success is a `runsc-cfc` entry whose `runtimeArgs` name both
-   `--cfc-result-dir` and `--cfc-invocation-context-dir`.
+   `--cfc-result-dir` and `--cfc-invocation-context-dir`. Keep those two paths;
+   section 3 needs them. On Docker Desktop they read `/host_mnt/Users/...`; the
+   host-side path is the same with `/host_mnt` removed.
 
-3. Obtain a PKCS#8 identity keyfile. This one identity signs both the Fabric
-   session and pattern-index requests. To mint one:
+3. **An identity keyfile.** One PKCS#8 key signs the Fabric session, the
+   pattern-index requests, and the browser login in section 5. To mint one:
 
    ```sh
    cd <labs>
@@ -70,10 +82,10 @@ local-auth simplification is still open under clause 5.
    deno run -A packages/cli/mod.ts id did "$HOME/.cf-demo.key"
    ```
 
-   Success is a printed `did:key:z6Mk…`. Set `CF_IDENTITY` to an existing
-   keyfile instead when one already owns the target space.
+   Success is a printed `did:key:z6Mk…`. Use an existing keyfile instead when
+   one already owns the space you intend to work in.
 
-4. Connect the `openai-codex` provider:
+4. **A connected model provider.** For `openai-codex`:
 
    ```sh
    cd <labs>/packages/cf-harness
@@ -82,91 +94,101 @@ local-auth simplification is still open under clause 5.
    deno task run -- config set openai-codex
    ```
 
-   Success is `auth status` reporting the credential as connected. These files
-   live under `CF_HARNESS_HOME`, which defaults to `$HOME/.cf-harness`.
+   Success is `auth status` reporting the credential as connected. Skip
+   `auth login` when it already is. These files live under `CF_HARNESS_HOME`,
+   which defaults to `$HOME/.cf-harness`.
 
-5. Put the identity's DID on the pattern-index allowlist. Follow
-   [pattern-index ONBOARDING §2](https://github.com/commontoolsinc/pattern-index/blob/main/ONBOARDING.md#2-access),
-   including its signed search check. Success is HTTP `200` with a `results`
-   array; `403` means the signer is not allowlisted.
+5. **The pattern-index allowlist, optionally.** The index is a shared cloud
+   service that lets a run find an existing pattern instead of writing one, and
+   publishes what a run built. Access is by DID, and getting on the allowlist is
+   a manual step an admin performs in the Firebase console, not something you
+   can do from here:
+   [pattern-index ONBOARDING §2](https://github.com/commontoolsinc/pattern-index/blob/main/ONBOARDING.md#2-access)
+   names the collection and the document to add. The repository is private, so
+   the link needs GitHub access.
 
-For commands below, either use an installed `cf` or define this source-checkout
-equivalent once:
+   What you get without it: leave `CF_HARNESS_PATTERN_INDEX_URL` unset in
+   section 3, and the session offers no `search_patterns` or `record_feedback`,
+   publishes nothing, and the console's Index view says the server has no index.
+   Every other part of a run works. Set the URL before your DID is allowlisted,
+   and the run still completes: `search_patterns` returns `status: "error"` with
+   a `403` message in the transcript, and the server log reports
+   `run_pattern could not publish the pattern it ran to the pattern index: … (403)`.
+
+For the `cf` commands below, either use an installed `cf` or define this
+source-checkout equivalent once:
 
 ```sh
 export LABS_ROOT=<labs>
 cf() { (cd "$LABS_ROOT" && deno task cf "$@"); }
 ```
 
-## 3. Start the environment
+## 3. Attach a console to your dev server
 
-If a toolshed and shell are already running through Loom,
-`scripts/start-local-dev.sh`, or another development setup, skip to the console
-step. Point `CF_HARNESS_FABRIC_API_URL` at that toolshed and use that shell's
-origin in the piece URL. The parity check and `MEMORY_DIR` guidance still apply.
-
-The three-terminal recipe below is one known-good arrangement. It uses toolshed
-on `:8063` and shell on `:5173`; these ports are examples, not requirements. The
-general server lifecycle and log locations remain in
+The console attaches to a toolshed and shell that are already running: Loom,
+`scripts/start-local-dev.sh`, or your own arrangement. It needs three facts
+about that toolshed. Starting one from scratch is in
 [Local Development Servers](../../docs/development/LOCAL_DEV_SERVERS.md); the
-commands here spell out each process so the serving store is explicit.
+same three facts apply to it.
 
-### Terminal 1: toolshed
-
-Omit `MEMORY_DIR` for a new store at toolshed's default `./cache/memory/`, or
-set it to a `file://` URL when toolshed serves an existing directory store. The
-full configuration contract is in
-[Configuration — Memory store](../../docs/development/CONFIGURATION.md#memory-store).
-Toolshed logs the selected directory as `Memory: Using directory mode: …`.
+**The API URL.** The toolshed's origin, `http://127.0.0.1:8000` under
+`start-local-dev.sh`. Confirm it and note its commit:
 
 ```sh
-cd <labs>/packages/toolshed
-export MEMORY_DIR=file://<absolute-toolshed-cache-directory>/
-export SHELL_URL=http://127.0.0.1:5173
-export API_URL=http://127.0.0.1:8063
-export MEMORY_URL=http://127.0.0.1:8063
-deno run --unstable-otel -A --env-file=.env index.ts --port=8063
+curl -sS <toolshed-api-url>/api/meta | jq '{gitSha, cfc}'
 ```
 
-Success is `Server is starting on port http://0.0.0.0:8063`, followed by an HTTP
-response from:
+**Its store directory.** The console reads the space's labels back from the
+toolshed's own SQLite files when a run ends, so it needs the directory the
+toolshed serves from. Find it one of three ways:
+
+- The toolshed's startup log has one line
+  `Memory: Using directory mode: file:///…/`. The console's `MEMORY_DIR` is that
+  URL without `file://`. Under `start-local-dev.sh` that log is
+  `packages/toolshed/local-dev-toolshed.log`.
+- A toolshed started without `MEMORY_DIR` uses `cache/memory/` under the
+  directory it was started in, which for the scripts and the manual recipe is
+  `<labs>/packages/toolshed/cache/memory/`.
+- For a Loom-launched toolshed, `loom toolshed-store-dir <instance>` prints the
+  `file://` URL.
+
+When none of those is at hand, the running toolshed's process environment holds
+`MEMORY_DIR` when one was set. A wrong directory is not fatal to the run; it
+shows up as `cell-labels.json` saying `space-not-found`, which section 11
+covers.
+
+**Its commit, against yours.** The parity check compares the toolshed's `gitSha`
+with the checkout the console runs from:
 
 ```sh
-curl -sS http://127.0.0.1:8063/api/meta | jq '{gitSha, cfc}'
+test "$(curl -sS <toolshed-api-url>/api/meta | jq -r .gitSha)" = \
+  "$(git -C <labs> rev-parse HEAD)"
 ```
 
-### Terminal 2: shell
+No output and exit status `0` is a match. A mismatch is expected when the
+toolshed was started from another checkout, which a shared machine or a
+colleague's server makes the normal case; it is not something to fix by
+restarting a server that is not yours. What it risks is the console's runtime
+client and the server disagreeing on a protocol the checkout moved, which
+surfaces as a failed turn rather than a wrong result. A toolshed older than your
+checkout by a few commits usually runs fine. Restart from your checkout when a
+turn fails for a reason that reads like a protocol mismatch, or when you need
+the toolshed's CFC posture to match what this checkout documents.
 
-Use `dev-local`; `dev` points at the cloud backend.
+### Start the console
 
-```sh
-cd <labs>/packages/shell
-TOOLSHED_PORT=8063 deno task dev-local
-```
-
-Success is the felt development server listening on `http://127.0.0.1:5173`.
-
-### Terminal 3: console
-
-These are all of the environment values needed for the full harness path:
-
-| Variable                                      | Value                                                                                      |
-| --------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| `CF_HARNESS_CONSOLE_PORT`                     | Any free local port.                                                                       |
-| `CF_HARNESS_CONSOLE_DIR`                      | Any absolute directory unique to this console; it holds sessions, runs, and the workspace. |
-| `CF_HARNESS_FABRIC_API_URL`                   | The API URL of the toolshed the input cells and resulting pieces use.                      |
-| `CF_HARNESS_FABRIC_IDENTITY`                  | The absolute path to the identity keyfile from prerequisite 3.                             |
-| `CF_HARNESS_FABRIC_SPACE`                     | The name of a target space accessible to that identity.                                    |
-| `CF_HARNESS_PATTERN_INDEX_URL`                | The shared cloud pattern-index URL shown below.                                            |
-| `CF_HARNESS_SKILLS_REGISTRY_URL`              | The shared skills.sh URL shown below.                                                      |
-| `CF_HARNESS_RUNSC_CFC_RESULT_DIR`             | The host side of the result directory named by the `runsc-cfc` registration.               |
-| `CF_HARNESS_RUNSC_CFC_INVOCATION_CONTEXT_DIR` | The host side of the invocation-context directory named by the `runsc-cfc` registration.   |
-| `MEMORY_DIR`                                  | The plain absolute cache directory of the toolshed named by `CF_HARNESS_FABRIC_API_URL`.   |
-
-Read the two sidecar host directories back with the prerequisite's
-`docker info --format '{{json .Runtimes}}'` command. For a Loom-launched
-toolshed, `loom toolshed-store-dir <instance>` prints its `file://` cache URL;
-use the corresponding plain directory path for the console's `MEMORY_DIR`.
+| Variable                                      | Value                                                                                          |
+| --------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `CF_HARNESS_CONSOLE_PORT`                     | Any free local port; the default is `8100`.                                                    |
+| `CF_HARNESS_CONSOLE_DIR`                      | Any absolute directory unique to this console. It holds sessions, runs, and the workspace.     |
+| `CF_HARNESS_FABRIC_API_URL`                   | The toolshed API URL from above.                                                               |
+| `CF_HARNESS_FABRIC_IDENTITY`                  | The absolute path to the keyfile from prerequisite 3.                                          |
+| `CF_HARNESS_FABRIC_SPACE`                     | A space name. A new name is fine; a `did:key` is refused.                                      |
+| `CF_HARNESS_RUNSC_CFC_RESULT_DIR`             | The host side of `--cfc-result-dir` from prerequisite 2.                                       |
+| `CF_HARNESS_RUNSC_CFC_INVOCATION_CONTEXT_DIR` | The host side of `--cfc-invocation-context-dir` from prerequisite 2.                           |
+| `MEMORY_DIR`                                  | The toolshed's store directory from above, as a plain path.                                    |
+| `CF_HARNESS_PATTERN_INDEX_URL`                | Optional: `https://us-central1-pattern-index.cloudfunctions.net`, once prerequisite 5 is done. |
+| `CF_HARNESS_SKILLS_REGISTRY_URL`              | Optional: `https://skills.sh`, which adds a metadata-only `search_skills` tool.                |
 
 ```sh
 cd <labs>/packages/cf-harness
@@ -175,8 +197,6 @@ export CF_HARNESS_CONSOLE_DIR=<absolute-unique-console-directory>
 export CF_HARNESS_FABRIC_API_URL=<toolshed-api-url>
 export CF_HARNESS_FABRIC_IDENTITY=<absolute-path-to-identity-keyfile>
 export CF_HARNESS_FABRIC_SPACE=<space-name>
-export CF_HARNESS_PATTERN_INDEX_URL=https://us-central1-pattern-index.cloudfunctions.net
-export CF_HARNESS_SKILLS_REGISTRY_URL=https://skills.sh
 export CF_HARNESS_FABRIC_CFC_POSTURE=max-enforcement
 export CF_HARNESS_FABRIC_CFC_FLOW_LABELS=persist
 export CF_HARNESS_FABRIC_CFC_ENFORCEMENT_MODE=enforce-explicit
@@ -186,15 +206,18 @@ export MEMORY_DIR=<absolute-toolshed-cache-directory>
 deno task console
 ```
 
-Success is a startup summary naming the configured space, toolshed, and index
-URLs and `max-enforcement, flow labels persist, enforce-explicit`, followed by
-an HTTP `200` here:
+The three CFC exports are the console's defaults, written out so the posture a
+run ran under is never a guess. Success is a startup summary naming the space,
+the toolshed, `(not configured)` or a URL for the index and skills,
+`cfc:
+max-enforcement, flow labels persist, enforce-explicit`, and the two
+sidecar directories; then HTTP `200` here:
 
 ```sh
 curl -sS http://127.0.0.1:<free-console-port>/api/health | jq
 ```
 
-The expected health body is:
+The expected body is:
 
 ```json
 {
@@ -204,18 +227,236 @@ The expected health body is:
 }
 ```
 
-Before spending a provider turn, make the parity check:
+`unverified` is honest: health makes no Fabric round trip. Never point two
+console processes at one `CF_HARNESS_CONSOLE_DIR`; until CT-2156 closes, they
+interleave each other's records.
 
-```sh
-test "$(curl -sS "$CF_HARNESS_FABRIC_API_URL/api/meta" | jq -r .gitSha)" = \
-  "$(git rev-parse HEAD)"
+## 4. Use it
+
+### The words
+
+- A **space** is where cells and pieces live, named here by
+  `CF_HARNESS_FABRIC_SPACE`.
+- A **pattern** is the program the model writes; a **piece** is that pattern
+  running in the space, with its own data and UI.
+- A **slug** is the name `assign_slug` gives a piece, which makes it a URL.
+- A **handle** is a token like `cfh:a:d4nfc` the model holds in place of data.
+  It resolves to an address in the space such as `/of:fid1:…/path`, and the
+  run's handle table joins the two.
+- An **input cell** is a cell you attach to a task, which the model receives as
+  a handle and a name you chose, never as its contents.
+- A **session** is one conversation with the console; a **turn** is one message
+  into it; a **run** is the artifact directory one turn produces. The turn ID
+  and the root run ID are the same string, and a `delegate_task` child writes
+  its own run beside its parent as `<runId>.subagent.<n>`.
+- The **posture** is the CFC configuration the run's patterns deploy into; the
+  three dials are printed at startup and recorded on every run.
+- A **sidecar** is the process beside the sandbox that records what each tool
+  call was allowed to observe; its two directories are the ones from
+  prerequisite 2.
+
+### Type a task
+
+Open `http://127.0.0.1:<free-console-port>/` in a browser. The page has one text
+box, Start, and two header buttons: **Runs** and **Index**. Type a task that
+needs no input cells; that is the simplest first run, and the box's own
+placeholder describes it. For example:
+
+```text
+Build me a small piece that shows a reading list of three books (title and
+author) with a checkbox next to each one I can tick when I finish it. Name
+the piece reading-list.
 ```
 
-No output and exit status `0` is success. The toolshed `/api/meta.gitSha` must
-equal the checkout from which the console is running; restart the servers when
-it does not.
+Press Start. The address becomes `?sessionId=<id>`, the status reads `working`,
+and the feed shows each tool call as it begins and completes, assistant text
+between calls, a nested block for each `delegate_task` child, and the final text
+in a box when the turn ends. [What you'll see](console/README.md#what-youll-see)
+describes each entry.
 
-## 4. Seed a labeled input cell by hand
+Two things the first turn does that are not faults:
+
+- The server log prints
+  `fabric grants unavailable for this turn: Error: space
+  has no default pattern to anchor the piece registry`
+  on a space with no default pattern, which a new name always is. The turn
+  continues without the grants that let a task explore what the space already
+  holds.
+- The Runs column fills in at the first completed tool call. Press its
+  **Refresh** button to see the root run before that.
+
+When the run names a piece, an **Open your piece** link appears above the feed
+and the status reads `done`. Section 5 is what the browser needs before that
+link renders. The box then sends follow-up turns into the same session; **New
+session** returns to the empty page, which lists every session this console
+knows.
+
+### Read the run
+
+The **Runs** view is three columns: every run the console has made, with
+children nested under the run that delegated to them; the run being read; and a
+map of how it went. The map heads with the CFC regime and the blunt counts:
+calls failed, calls CFC refused, patterns that read no cell. Click a node to
+move to that step. The run's own panes are **Timeline** (each step with its
+handles in scope, arguments, CFC decision, and full input and output),
+**Patterns** (every `run_pattern` attempt with the source it submitted and any
+compiler diagnostic), **Tool outputs**, and **Artifacts**.
+[Reading a run](console/README.md#reading-a-run) is the full description.
+
+The same run is on disk:
+
+```text
+<CF_HARNESS_CONSOLE_DIR>/
+├── sessions.sqlite            # sessions, turns, and events
+└── runs/
+    ├── <runId>/               # the turn's root run
+    │   ├── run-state.json     # status, lineage, postures, input cells, failures
+    │   ├── transcript.json    # what the model saw: handles and denials, never payloads
+    │   ├── run-report.json    # model attempts, usage, timeline
+    │   ├── policy-snapshot.json
+    │   ├── policy-trace.json  # every CFC decision
+    │   ├── capabilities.json
+    │   ├── skill-registry.json
+    │   ├── cell-labels.json   # labels read from the space as the run ended
+    │   └── tool-outputs/      # every full tool result, including pattern sources
+    └── <runId>.subagent.1/    # a delegate_task child, same layout
+```
+
+`transcript.json` is the fastest way to see what the model was working with:
+every tool result is a record keyed by `outputId`, and the pattern source the
+model wrote is in `tool-outputs/`, not in the transcript. `run-state.json` reads
+`status: "running"` until one terminal write turns it `completed` or `failed`,
+and that same write records `cell-labels.json`.
+
+The **Index** view, at `?view=index`, reads the pattern index through the server
+with your identity; with no index configured it says so.
+[The Index view](console/README.md#the-index-view) describes its three panes.
+
+## 5. Open the piece
+
+The console's link uses the toolshed origin, which proxies the shell. The shell
+needs an identity before any piece renders: on first load it shows
+`Preparing secure storage...`, then **Register** and **Login**. Choose Login,
+then **Import CLI Key**, and pick the keyfile from prerequisite 3. This is once
+per browser profile. The piece then renders at either address:
+
+```text
+<toolshed-api-url>/<space-name>/<slug>
+<shell-origin>/<space-name>/<slug>
+```
+
+From the command line, the same piece resolves by slug:
+
+```sh
+export CF_API_URL=<toolshed-api-url>
+export CF_IDENTITY=<absolute-path-to-identity-keyfile>
+export CF_SPACE=<space-name>
+cf get /<slug>
+export PIECE_ID=$(cf get "/<slug>" --select '@' | \
+  jq -r '."$link" | sub("^/of:"; "")')
+cf piece render --cell "$PIECE_ID"
+```
+
+`cf get /<slug>` returns the piece's live result. The `--select '@'` form
+returns `{"$link":"/of:fid1:…"}`; stripping `/of:` gives the ID that
+`cf piece render` accepts, and success there is rendered HTML. Render by ID
+because render-by-slug currently crashes (CT-2185).
+
+## 6. Drive it from the web API
+
+For the weaver, a script, or an agent that does not hold a browser. The
+[console routes](console/README.md#http-routes) require the per-process token
+cookie that `GET /` sets, because the server treats loopback as an address
+rather than an authorization; fetch `/` once and reuse the cookie jar.
+
+### Submit
+
+```sh
+export CONSOLE_URL=http://127.0.0.1:<free-console-port>
+export COOKIE_JAR=$(mktemp /tmp/cf-harness-cookie.XXXXXX)
+curl -sS -c "$COOKIE_JAR" "$CONSOLE_URL/" >/dev/null
+
+TASK_RESPONSE=$(curl -sS -b "$COOKIE_JAR" \
+  -H 'Content-Type: application/json' \
+  -d '{"text": "Build me a reading list of three books with a checkbox next to each. Name the piece reading-list."}' \
+  "$CONSOLE_URL/api/task")
+printf '%s\n' "$TASK_RESPONSE" | jq
+export SESSION_ID=$(printf '%s' "$TASK_RESPONSE" | jq -r .sessionId)
+export TURN_ID=$(printf '%s' "$TASK_RESPONSE" | jq -r .turnId)
+```
+
+Success is HTTP `200` with non-empty `sessionId` and `turnId`. Add `sessionId`
+to the body to continue a session, and `inputCells` to attach cells; section 7
+shows the shape.
+
+### Wait by polling
+
+A script asks once and repeats only while it receives `409`:
+
+```sh
+curl -i -sS -b "$COOKIE_JAR" "$CONSOLE_URL/api/turns/$TURN_ID/result"
+```
+
+The whole rule is `409` keep asking, `200` read the result, `410` stop with the
+terminal failure. A `404` is either an unknown turn or a completed turn whose
+artifacts are unavailable; inspect its `code`. Once it is `200`, keep the body:
+
+```sh
+TURN_RESULT=$(curl -sS -b "$COOKIE_JAR" "$CONSOLE_URL/api/turns/$TURN_ID/result")
+printf '%s\n' "$TURN_RESULT" | jq
+```
+
+The successful result is:
+
+```json
+{
+  "pieces": [
+    {
+      "slug": "reading-list",
+      "url": "<toolshed-api-url>/<space-name>/reading-list"
+    }
+  ],
+  "spaceName": "<space-name>",
+  "finalText": "Created reading-list."
+}
+```
+
+`pieces` is always present and may be empty. A caller opens `pieces[0].url`; it
+does not parse `finalText` to find a link.
+
+### Wait on the event stream
+
+The stream is what the page reads. It does not close when the turn ends: after
+the terminal event it keeps sending `event: ping` every fifteen seconds for as
+long as the connection is held, so a caller must disconnect on the terminal
+event rather than wait for end of stream.
+
+```sh
+curl -N -b "$COOKIE_JAR" "$CONSOLE_URL/api/events?sessionId=$SESSION_ID"
+```
+
+Every chat event is one frame:
+
+```text
+event: chat
+id: <sequence>
+data: {"type":"…","sessionId":"…","turnId":"…","sequence":<n>,"emittedAt":"…","event":{"kind":"…",…}}
+
+event: ping
+data: <beat>
+```
+
+The terminal kinds are `turn_completed`, whose `event.result` is the same object
+the poll returns, and `turn_failed` and `turn_canceled`. Reconnecting with
+`&afterSequence=<sequence>` resumes after the last frame read.
+
+## 7. Worked example: a labeled input cell through to the audit
+
+This is the CT-2190 flow: a cell carrying a confidentiality label enters a task
+as an input cell, the piece the run builds derives from it, and the store and
+the audit show the label followed. Everything here builds on sections 3 to 6.
+
+### Seed the cell
 
 Save this pattern as `finance-data.tsx` in the labs root. It passes the
 `account` input through to the `account` result and renders its balance:
@@ -244,8 +485,7 @@ export default pattern<FinanceData, FinanceData>(({ account }) => ({
 }));
 ```
 
-From the labs root, deploy the file, keep the printed piece ID, and attach the
-confidentiality label through the checked piece-data write path:
+Deploy it, keep the printed piece ID, and attach the label:
 
 ```sh
 cd <labs>
@@ -263,10 +503,9 @@ echo '{"confidentiality":["finance"]}' | \
 cf piece get-label --cell "$INPUT_PIECE_ID" account
 ```
 
-`cf piece new` succeeds by printing a `fid1:…` piece ID and the
-`transaction-data` slug. `cf set` writes the sample account into the piece's
-input, and `cf piece step` makes the pass-through result current. The final
-readback succeeds with this shape:
+`cf piece new` prints a `fid1:…` piece ID and the `transaction-data` slug;
+`cf set` writes the sample account into the piece's input; `cf piece step` makes
+the pass-through result current. The readback succeeds with:
 
 ```json
 {
@@ -275,31 +514,19 @@ readback succeeds with this shape:
 }
 ```
 
-The demo input reference is the entity form of that result path:
+The input reference is the entity form of that result path. The `/of:` prefix is
+required; the `/fid1:…` form printed in some piece hints is not an input-cell
+reference.
 
 ```sh
 export INPUT_CELL_REF="/of:${INPUT_PIECE_ID}/account"
 ```
 
-The `/of:` prefix is required. The `/fid1:…` form printed in some piece hints is
-not an input-cell entity URI.
+### Submit with the cell attached
 
-## 5. Drive a run over the web API
-
-The [console authentication contract](console/README.md#http-routes) requires
-the per-process token cookie that `GET /` sets on every route except
-`/api/health`, so a same-machine caller performs that GET once and reuses its
-cookie jar; loopback alone is not authorization. A shared bearer token is the
-open simplification in
-[CT-2155 clause 5](https://linear.app/common-tools/issue/CT-2155).
-
-### Get the cookie and submit
+With the cookie jar from section 6:
 
 ```sh
-export CONSOLE_URL=<console-url>
-export COOKIE_JAR=$(mktemp /tmp/cf-harness-cookie.XXXXXX)
-curl -sS -c "$COOKIE_JAR" "$CONSOLE_URL/" >/dev/null
-
 TASK_RESPONSE=$(curl -sS -b "$COOKIE_JAR" \
   -H 'Content-Type: application/json' \
   -d "$(jq -n --arg ref "$INPUT_CELL_REF" '{
@@ -307,163 +534,66 @@ TASK_RESPONSE=$(curl -sS -b "$COOKIE_JAR" \
     inputCells: [{name: "transactions", ref: $ref}]
   }')" \
   "$CONSOLE_URL/api/task")
-printf '%s\n' "$TASK_RESPONSE" | jq
 export SESSION_ID=$(printf '%s' "$TASK_RESPONSE" | jq -r .sessionId)
 export TURN_ID=$(printf '%s' "$TASK_RESPONSE" | jq -r .turnId)
 ```
 
-Success is HTTP `200` with non-empty `sessionId` and `turnId`. To continue an
-existing harness conversation, add `sessionId` to the submitted object. Each
-`inputCells` entry is `{name, ref}`; `ref` must be an entity link such as
-`/of:fid1:…/path` (or `computed:`), and an invalid spelling is HTTP `400` before
-a turn starts.
+Each `inputCells` entry is `{name, ref}`. `ref` must be an entity link such as
+`/of:fid1:…/path` (or `computed:`); an invalid form is HTTP `400` before a turn
+starts. Wait as in section 6, then resolve the piece as in section 5 to set
+`PIECE_ID`.
 
-### Wait for completion
+### Read the labels back
 
-Prefer the event-driven SSE stream:
-
-```sh
-curl -N -b "$COOKIE_JAR" \
-  "$CONSOLE_URL/api/events?sessionId=$SESSION_ID"
-```
-
-Success is a terminal `turn_completed` event whose `result` has the structured
-shape below. `turn_failed` and `turn_canceled` are terminal failures.
-
-A caller that cannot hold SSE can ask once and repeat only while it receives
-`409`:
-
-```sh
-curl -i -sS -b "$COOKIE_JAR" \
-  "$CONSOLE_URL/api/turns/$TURN_ID/result"
-```
-
-The whole polling rule is `409` keep asking, `200` read the result, `410` stop
-with the terminal failure. A `404` is either an unknown turn or a completed turn
-whose artifacts are unavailable; inspect its `code`.
-
-Once the status is `200`, retain the body for the remaining commands:
-
-```sh
-TURN_RESULT=$(curl -sS -b "$COOKIE_JAR" \
-  "$CONSOLE_URL/api/turns/$TURN_ID/result")
-printf '%s\n' "$TURN_RESULT" | jq
-```
-
-The successful structured result is:
-
-```json
-{
-  "pieces": [
-    {
-      "slug": "budget-dashboard",
-      "url": "<toolshed-api-url>/<space-name>/budget-dashboard"
-    }
-  ],
-  "spaceName": "<space-name>",
-  "finalText": "Your budget dashboard is ready."
-}
-```
-
-`pieces` is always present and may be empty. A caller opens `pieces[0].url`; it
-does not parse `finalText` to find a link.
-
-### Resolve, render, and open the piece
-
-```sh
-export SLUG=$(printf '%s' "$TURN_RESULT" | jq -r '.pieces[0].slug')
-cf get "/$SLUG"
-export PIECE_ID=$(cf get "/$SLUG" --select '@' | \
-  jq -r '."$link" | sub("^/of:"; "")')
-cf piece render --cell "$PIECE_ID"
-```
-
-The first `cf get /<slug>` succeeds by returning the piece's live result. The
-`--select '@'` form returns `{"$link":"/of:fid1:…"}`; stripping `/of:` gives the
-ID that `cf piece render` accepts. Success there is rendered HTML. Render by ID
-because render-by-slug currently crashes (CT-2185).
-
-The direct shell address is:
-
-```text
-<shell-origin>/<space-name>/<slug-or-fid1-id>
-```
-
-The URL returned by the console uses the toolshed origin, which proxies the same
-shell and is also openable.
-
-## 6. Read the evidence and run the CFC audit
-
-A console run lives at:
-
-```text
-<CF_HARNESS_CONSOLE_DIR>/runs/<runId>/
-├── run-state.json
-├── transcript.json
-├── run-report.json
-├── policy-snapshot.json
-├── policy-trace.json
-├── tool-outputs/
-└── cell-labels.json       # read from the space as the run ended
-```
-
-The console's Runs view renders the same tree. A caller may rely on
-`run-state.json` for `runId`; lifecycle `status`; `createdAt`, `updatedAt`, and
-terminal `endedAt`/`terminalReason`; the selected model and provider; the
-harness and `fabricSessionCfc` postures; `inputCells`; artifact paths;
-`toolOutputs`; child lineage; and `failureRecords`/`primaryFailure`. A run stays
-`running` until one terminal write changes it to `completed` or `failed`.
-
-The terminal write that records the `run-state.json` outcome also writes
-`cell-labels.json`, from a read of the space as the run ended. The parent and
-every `delegate_task` child perform and record their own read. When `--space-db`
-selects the store, each child inherits it from the parent. A snapshot that
-cannot be taken or written produces a failure record on that run with
-`source: "cell_labels"`.
-
-Use the other records for their narrower evidence:
-
-- `transcript.json` is the durable provider-safe conversation and tool-call
-  sequence.
-- `tool-outputs/` holds every full tool result, including the `assign_slug`
-  result from which the console constructs `pieces[{slug,url}]`.
-- `policy-trace.json` holds CFC policy decisions; `policy-snapshot.json` holds
-  the run-level harness posture.
-- `cell-labels.json`, when present and `status` is `read`, is the terminal
-  snapshot read from the space. `unavailable` and `no-document` are not evidence
-  that a cell is unlabeled.
-
-Read the store live as an independent check:
+Live from the store:
 
 ```sh
 cf piece get-label --cell "$INPUT_PIECE_ID" account
 cf piece get-label --cell "$PIECE_ID" <derived-result-path>
 ```
 
-Then audit the root run and its `delegate_task` children:
+The derived path carries the `finance` atom, with the space's own account of
+what it was computed from. The run's `cell-labels.json` holds the same read as
+the run ended; when its `status` is `read`, its entries are the terminal
+snapshot, and `unavailable` or `no-document` is not evidence that a cell is
+unlabeled. In the Runs view the cell chip's **space** row draws from the same
+file, and a **derived** cell is colored apart from a merely labeled one.
+
+### Audit
 
 ```sh
 cd <labs>/packages/cf-harness
 deno task cfc-audit "$CF_HARNESS_CONSOLE_DIR/runs/$TURN_ID"
 ```
 
-Or audit the whole artifact root:
+The [CFC audit reference](README.md#the-cfc-audit) defines AUD-1 through AUD-9.
+Read verdicts literally: `pass` is established; `not-applicable` means complete
+evidence showed the subject did not arise; `warn` means weaker assurance; `fail`
+is a contradicted requirement; and `inconclusive` means required evidence was
+absent. `inconclusive` is never `pass`.
 
-```sh
-deno task cfc-audit "$CF_HARNESS_CONSOLE_DIR/runs" --fail-on inconclusive
-```
+What a console run audits to today, so you can tell your run from the checker:
 
-The [CFC audit reference](README.md#the-cfc-audit) defines AUD-1 through AUD-9
-and their cited clauses. Read verdicts literally: `pass` is established;
-`not-applicable` means complete evidence showed the subject did not arise;
-`warn` means weaker assurance; `fail` is a contradicted requirement; and
-`inconclusive` means required evidence was absent or unreadable. `inconclusive`
-is never `pass`. AUD-9's detail says whether the terminal cell-label read was
-attempted. A path containing no run exits `2` because nothing was audited.
+- **AUD-9 `fail` on the root run** (CT-2191): the checker requires an invocation
+  context for every side effect, and `delegate_task` and `assign_slug` run
+  host-side and record none. Every console run that delegates or names a piece
+  reports this.
+- **AUD-3 `fail` on a child that ran patterns** (CT-2187): the checker counts
+  each `run-pattern-source.json` sidecar in `tool-outputs/` as a tool effect
+  with no policy decision. Every run whose `run_pattern` submitted source
+  reports this, naming each attempt.
+- **AUD-2 `warn` on the root run**: a root that delegated all its substrate work
+  exercised no enforcement itself, and the check says so rather than passing.
+  This is the documented reading, not a defect.
 
-## 7. Run the CLI path instead
+So `FAIL 2 WARN 1` over a root and one child is the expected verdict line until
+those two issues close. A finding outside that set is about your run. Read AUD-4
+and AUD-5 first: a denial that reached the model with a payload, or a handle
+used before it was disclosed, is a real problem.
 
-The batch CLI and console resolve the same session configuration. The CLI
+## 8. Run the CLI path instead
+
+The batch CLI and the console resolve the same session configuration. The CLI
 refuses an enforcing run unless both runsc-cfc transports are named:
 
 ```sh
@@ -484,15 +614,15 @@ deno task run -- \
   --prompt "Make me a budget dashboard from my transaction data — totals by category that update when the data changes."
 ```
 
-Success is exit status `0` and a completed operator summary naming the run
-artifact directory. A result handle or slug appears in the final response and
-retained tool output when the run produced one. `--space-db` is the exact space
-database used only by the terminal label reader; it does not change the Fabric
-session's target, and every `delegate_task` child inherits it.
+Drop `--input-cell` for a task with no cells. Success is exit status `0` and a
+completed operator summary naming the run artifact directory, which has the
+layout in section 4. `--space-db` is the exact space database used only by the
+terminal label reader; it does not change the Fabric session's target, and every
+`delegate_task` child inherits it.
 [Running patterns against a Fabric space](README.md#running-patterns-against-a-fabric-space)
 defines the three required session flags and the input-cell behavior.
 
-## 8. Experiments and measurement
+## 9. Experiments and measurement
 
 [Measuring the pattern index loop](docs/pattern-index-measurement.md) is the
 protocol for comparable experiments: the fixed task suite, the rule that a
@@ -508,13 +638,13 @@ exits zero only when every task completed. The pattern-index repository's
 [own onboarding](https://github.com/commontoolsinc/pattern-index/blob/main/ONBOARDING.md)
 owns allowlisting, signed direct calls, corpus behavior, and its repo map.
 
-## 9. What works today and what does not
+## 10. What works today and what does not
 
 [Current state](docs/CURRENT_STATE.md) is the maintained capability inventory.
 For this path, the batch and interactive loops, input-cell handles, host-side
 `run_pattern`, slug assignment, structured web completion, durable artifacts,
-pattern-index search/publication, CFC posture records, provider-attempt records,
-and the offline audit are usable now.
+pattern-index search and publication, CFC posture records, provider-attempt
+records, and the offline audit are usable now.
 
 The boundaries that affect this onboarding are:
 
@@ -524,22 +654,43 @@ The boundaries that affect this onboarding are:
   `valueError` that explains why and names the input carrying the label, and
   `policyRefusal` as structured data. Declassification by policy — releasing a
   value under one policy and refusing it under another — remains open.
-- CT-2155 clause 5: protected web routes still use the `GET /` cookie exchange;
-  there is no shared bearer-token shortcut.
+- CT-2187 and CT-2191: the audit's known findings in section 7.
+- CT-2155 clause 5: protected web routes use the `GET /` cookie exchange; there
+  is no shared bearer-token shortcut.
 - CT-2185: `cf piece render --cell /<slug>` crashes; resolve with `cf get` and
   render by `fid1:` ID.
+- CT-2156: two consoles on one `CF_HARNESS_CONSOLE_DIR` interleave records.
 
-## 10. Troubleshooting
+## 11. Troubleshooting
+
+**The event stream never ends.** It is not meant to. `turn_completed`,
+`turn_failed`, and `turn_canceled` are the terminal events; after one of them
+the server keeps the connection open with `ping` frames. Disconnect on the
+terminal event, or poll `/api/turns/<turnId>/result` instead.
+
+**Parity mismatch on a shared toolshed.** The toolshed was started from another
+checkout. It is expected, and the run usually completes. Restart from your own
+checkout only when a turn fails in a way that reads as a protocol disagreement.
+
+**`403` from the index.** Your DID is not on the pattern-index allowlist.
+`search_patterns` returns an error to the model and publication fails in the
+server log; the run still completes. Unset `CF_HARNESS_PATTERN_INDEX_URL` to
+remove the tool until an admin allowlists you.
+
+**The shell shows Register / Login instead of the piece.** The browser holds no
+identity. Login → Import CLI Key with the keyfile from prerequisite 3.
+
+**`space has no default pattern to anchor the piece registry`.** A fresh space
+name. The turn continues without well-known grants.
 
 **Healthy console, dead Fabric.** `/api/health` returning HTTP `200` with
-`fabricSession: "unverified"` is honest by design: it does not make a Fabric
-round trip. Probe toolshed `/api/meta`, run the parity check, and perform a real
-`cf get` before spending a model turn.
+`fabricSession: "unverified"` says nothing about Fabric. Probe toolshed
+`/api/meta` and perform a real `cf get` before spending a model turn.
 
 **Wrong store.** `cell-labels.json` with `unavailableReason:
 "space-not-found"`,
 or every cell carrying `unreadReason: "no-document"`, usually means the label
-reader opened no store or another worktree's store. Give the console the serving
+reader opened no store or another checkout's store. Give the console the serving
 toolshed's plain `MEMORY_DIR`; give a CLI run the exact `--space-db`.
 [Reading the labels back](docs/pattern-index-measurement.md#reading-the-labels-back)
 defines both forms.
@@ -553,22 +704,20 @@ defines the bounded retry contract.
 
 **Sandbox refusal under `enforce-explicit`.** Check the startup banner,
 `policy-trace.json`, full `tool-outputs/`, and Docker's registered runtime args.
-The harness-side directories must match the host side of runsc-cfc's
+The harness-side directories must be the host side of runsc-cfc's
 `--cfc-result-dir` and `--cfc-invocation-context-dir`; on Docker Desktop the
 runtime sees their `/host_mnt/...` projections. A refusal is evidence to read,
 not a reason to silently drop to `observe`.
 
 **Concurrent consoles.** Never point two console processes at one
-`CF_HARNESS_CONSOLE_DIR`. Until CT-2156 closes, shared session and artifact
-directories can interleave records. Give each process an absolute, unique
-directory.
+`CF_HARNESS_CONSOLE_DIR`. Give each process an absolute, unique directory.
 
-## 11. Repo map
+## 12. Repo map
 
 - [`README.md`](README.md) — complete harness model, CLI surface, runtime tools,
   provider behavior, and CFC audit reference.
 - [`console/README.md`](console/README.md) — console configuration, web API,
-  SSE, structured result, label snapshot, and operator views.
+  SSE, structured result, label snapshot, and the Runs and Index views.
 - [`docs/CURRENT_STATE.md`](docs/CURRENT_STATE.md) — maintained capability and
   limitation inventory.
 - [`docs/pattern-index-measurement.md`](docs/pattern-index-measurement.md) —

--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -1,9 +1,11 @@
 # @commonfabric/cf-harness
 
 **Start here:** [ONBOARDING.md](ONBOARDING.md) is the single path from local
-prerequisites through a web-API run with input cells to an openable piece, its
-artifacts, and the CFC audit; it also points to the experiment and measurement
-records without duplicating them here.
+prerequisites to a console attached to a toolshed you already run, a first task
+typed into its page, and the session, transcript, and run artifacts it leaves;
+it carries the labeled-input-cell flow through to the CFC audit as one worked
+example, and points to the experiment and measurement records without
+duplicating them here.
 
 `cf-harness` is an in-house agent harness package for Common Fabric. It is being
 built as a general Common Fabric agent runtime, with Loom as the first target


### PR DESCRIPTION
Revision of `packages/cf-harness/ONBOARDING.md` from the CT-2066 cold-read test (2026-09-02) and Ben's reorientation: the doc is now a guide to cf-harness as a tool — attach a console to whatever toolshed and shell you already run, open the console page, type a task with no input cells, and browse the sessions, transcripts, and run artifacts it leaves. The labeled-cell finance flow is one worked example (section 7), not the spine. Documentation only; the README's one-line pointer to the doc is updated to match.

## Against the tester's proposed changes

1. **Stream never ends** — section 6 states the stream stays open after the terminal event with `ping` frames every fifteen seconds (the server's interval), gives the poll rule first and the SSE frame shape second, and Troubleshooting repeats it.
2. **Explore without the demo** — section 4 "Type a task" is the first run, with a no-input-cell task and the Refresh note for the Runs column; the labeled-cell flow moved to section 7.
3. **`MEMORY_DIR` for a non-Loom toolshed** — section 3 gives the toolshed log line, the default `packages/toolshed/cache/memory/` location (and the `start-local-dev.sh` log file), the Loom command, and the process environment as a last resort. The `/host_mnt` translation now sits in prerequisite 2 where the paths are first read.
4. **Shell needs an identity** — section 5 opens with Login → Import CLI Key; Troubleshooting has it too.
5. **`mise trust`** — prerequisite 1 says a fresh checkout or worktree is untrusted and gives the install-path alternative.
6. **Allowlist is a manual admin step** — prerequisite 5 says an admin adds a Firestore document, that the linked repo is private, what is absent without the URL, and what a 403 looks like in the transcript and server log when the URL is set before allowlisting.
7. **Parity mismatch on a shared toolshed** — section 3 says it is expected, what it risks, and when a restart is warranted.
8. **Fresh space warning** — section 4 and Troubleshooting name `space has no default pattern to anchor the piece registry` as benign.
9. **Expected audit verdict** — section 7 states today's expected `FAIL 2 WARN 1` for a root plus one child, attributes AUD-9 to CT-2191, AUD-3 to CT-2187, and AUD-2 to the documented "went untested" reading, and says which checks a reader should treat as real.
10. **Glossary and cruft** — "Run it from the directory named above the block" is gone (each block carries its `cd`); section 4 opens with one-line definitions of space, pattern, piece, slug, handle, input cell, session/turn/run, posture, and sidecar; prerequisite 1 names the `fuse-native` warning as stderr noise.

Not done, deliberately: the tester's observation that a child's `run_pattern` output said `patternPublication: {status: "recorded"}` while the server logged a 403 publish failure is a possible code defect, not a doc fix; it is not claimed either way here and wants its own issue. The three CFC dials' individual meanings are linked (console README, CFC section) rather than re-explained.

Follow-up outside this repo: pattern-index `ONBOARDING.md` describes this document as "the numbered path for starting toolshed, shell, and console; submitting input cells through the web API", which no longer matches its shape.

Gates run: `deno fmt --check`, `deno lint`, `check-docs`, `check-command-docs`, `check-skill-facts`, `check-docs-history-index` — all pass. Every heading anchor the document links to was checked against the target files. No servers were started; the console from the cold-read test was no longer running, so the UI strings were verified against `console/src/app.ts` and the shell's `LoginView.ts` instead.

Relates to CT-2066

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6760?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

