### PR TITLE
feat(cli): the `#argument` suffix rides every spelling of the target

### DIFF
--- a/docs/common/workflows/reading-and-writing.md
+++ b/docs/common/workflows/reading-and-writing.md
@@ -70,16 +70,18 @@ reads.
 The suffix rides every spelling of the target — the reference form
 (`/of:fid1:…#argument`, `/thermostat#argument`), the bare id, and the slug
 (`--cell thermostat#argument`) — because all of them designate the same piece.
-A `--url` carries no fragment into the reference it decomposes to: a URL
-fragment is not part of the path a URL's piece is read out of. So where the URL
-names the piece, a `#argument` written on it is dropped without comment and the
-read goes to the result cell, and `--input` is the spelling that reaches the
-arguments cell. Where the URL names only the space, the piece arrives on
-`--cell`, which takes the suffix like any other target.
+A `--url` is not one of those spellings. It carries no fragment into the
+reference it decomposes to, whatever the URL names: a URL fragment is not part
+of the path a URL's piece is read out of, so a `#argument` written on a `--url`
+is dropped without comment and the read goes to the result cell. A URL that
+names the piece admits no target beside it, so `--input` is what reaches the
+arguments cell there. A URL that names only the space leaves the target to
+arrive as it always does — a positional address, or `--cell` — carrying the
+suffix like any other.
 
-That dropped fragment is the one place the suffix is ignored rather than
-refused. Everywhere else a `#argument` a command cannot honor is turned down by
-name.
+Hold on to the asymmetry. A suffix written on the target is honored where the
+command takes `--input` and refused by name where it does not; a suffix written
+on a `--url` gets neither.
 
 ### Nothing here runs the program
 

--- a/docs/common/workflows/reading-and-writing.md
+++ b/docs/common/workflows/reading-and-writing.md
@@ -264,9 +264,9 @@ reads back the cell the address just wrote to.
 cf get -s demo --piece 'thermostat#argument' target
 ```
 
-One refusal bounds it: a command that takes no `--input` takes no `#argument`
-either. The refusal names the flag rather than the suffix, because they are one
-selection with two spellings.
+What bounds it is the flag it is a spelling of: a command that takes no
+`--input` takes no `#argument` either. The refusal names the flag rather than
+the suffix, because they are one selection with two spellings.
 
 ```bash
 cf call -s demo "$ADDRESS#argument" setTarget '{"celsius":21}'

--- a/docs/common/workflows/reading-and-writing.md
+++ b/docs/common/workflows/reading-and-writing.md
@@ -70,10 +70,10 @@ reads.
 The suffix rides every spelling of the target — the reference form
 (`/of:fid1:…#argument`, `/thermostat#argument`), the bare id, and the slug
 (`--cell thermostat#argument`) — because all of them designate the same piece.
-The `--url` is the one that does not carry it: a URL fragment is not part of
-the path a URL's piece is read out of, so it is dropped without comment and the
-read goes to the result cell. With a `--url`, `--input` is the only spelling
-that reaches the arguments cell.
+A `--url` does not carry it: a URL fragment is not part of the path a URL's
+piece is read out of, so it is dropped without comment and the read goes to the
+result cell. With a `--url`, `--input` is the only spelling that reaches the
+arguments cell.
 
 ### Nothing here runs the program
 

--- a/docs/common/workflows/reading-and-writing.md
+++ b/docs/common/workflows/reading-and-writing.md
@@ -28,7 +28,7 @@ The **result** cell is what the pattern produced: its declared outputs, its
 derived fields, and handles for its verbs. It is where a command goes by
 default. The **arguments** cell is what a caller supplied: exactly the fields
 the pattern declared as input, and nothing else. A command reaches it two
-ways, `--input` as a flag and an `#argument` suffix on the address, and the
+ways, `--input` as a flag and an `#argument` suffix on the target, and the
 two are one selection rather than two.
 
 The CLI's own help calls that second cell the *input* cell where the flag is
@@ -67,13 +67,13 @@ read out of that one declaration. Any other command is refused by name, `cf
 call` among them, so a call cannot quietly be aimed at a cell no handler
 reads.
 
-The suffix rides the reference form — `/of:fid1:…#argument`,
-`/thermostat#argument` — and nothing else. On a bare id or an unrooted slug it
-is refused, because there is no reference there for it to attach to. On a
-`--url` it is not refused: a URL fragment is not part of the path a URL's piece
-is read out of, so it is dropped without comment and the read goes to the
-result cell. With a `--url` or a bare id, `--input` is the only spelling that
-reaches the arguments cell.
+The suffix rides every spelling of the target — the reference form
+(`/of:fid1:…#argument`, `/thermostat#argument`), the bare id, and the slug
+(`--cell thermostat#argument`) — because all of them designate the same piece.
+The `--url` is the one that does not carry it: a URL fragment is not part of
+the path a URL's piece is read out of, so it is dropped without comment and the
+read goes to the result cell. With a `--url`, `--input` is the only spelling
+that reaches the arguments cell.
 
 ### Nothing here runs the program
 
@@ -256,19 +256,17 @@ echo '30' | cf set -s demo "$ADDRESS#argument" target
 cf get -s demo --piece thermostat target --input
 ```
 
-Two refusals bound it. Written bare — unrooted — a slug or an id is not a
-reference, so the suffix has nothing to attach to and is refused rather than
-folded into the id, which is the failure it is guarding against: an id with a
-fragment buried in it fails later as an unknown piece. Rooted, the same slug is
-a reference and takes the suffix.
+A slug and a bare id designate the piece a reference designates, so the
+selection written after one means what it means after the other. Here the slug
+reads back the cell the address just wrote to.
 
 ```bash
 cf get -s demo --piece 'thermostat#argument' target
 ```
 
-And a command that takes no `--input` takes no `#argument` either. The refusal
-names the flag rather than the suffix, because they are one selection with two
-spellings.
+One refusal bounds it: a command that takes no `--input` takes no `#argument`
+either. The refusal names the flag rather than the suffix, because they are one
+selection with two spellings.
 
 ```bash
 cf call -s demo "$ADDRESS#argument" setTarget '{"celsius":21}'

--- a/docs/common/workflows/reading-and-writing.md
+++ b/docs/common/workflows/reading-and-writing.md
@@ -73,11 +73,11 @@ The suffix rides every spelling of the target — the reference form
 A `--url` is not one of those spellings. It carries no fragment into the
 reference it decomposes to, whatever the URL names: a URL fragment is not part
 of the path a URL's piece is read out of, so a `#argument` written on a `--url`
-is dropped without comment and the read goes to the result cell. A URL that
-names the piece admits no target beside it, so `--input` is what reaches the
-arguments cell there. A URL that names only the space leaves the target to
-arrive as it always does — a positional address, or `--cell` — carrying the
-suffix like any other.
+is dropped without comment and any read it would have redirected goes to the
+result cell. A URL that names the piece admits no `--cell` or positional
+address beside it, so `--input` is what reaches the arguments cell there. A URL
+that names only the space leaves the target to arrive as it always does — a
+positional address, or `--cell` — carrying the suffix like any other.
 
 Hold on to the asymmetry. A suffix written on the target is honored where the
 command takes `--input` and refused by name where it does not; a suffix written

--- a/docs/common/workflows/reading-and-writing.md
+++ b/docs/common/workflows/reading-and-writing.md
@@ -70,10 +70,16 @@ reads.
 The suffix rides every spelling of the target — the reference form
 (`/of:fid1:…#argument`, `/thermostat#argument`), the bare id, and the slug
 (`--cell thermostat#argument`) — because all of them designate the same piece.
-A `--url` does not carry it: a URL fragment is not part of the path a URL's
-piece is read out of, so it is dropped without comment and the read goes to the
-result cell. With a `--url`, `--input` is the only spelling that reaches the
-arguments cell.
+A `--url` carries no fragment into the reference it decomposes to: a URL
+fragment is not part of the path a URL's piece is read out of. So where the URL
+names the piece, a `#argument` written on it is dropped without comment and the
+read goes to the result cell, and `--input` is the spelling that reaches the
+arguments cell. Where the URL names only the space, the piece arrives on
+`--cell`, which takes the suffix like any other target.
+
+That dropped fragment is the one place the suffix is ignored rather than
+refused. Everywhere else a `#argument` a command cannot honor is turned down by
+name.
 
 ### Nothing here runs the program
 

--- a/docs/plans/cli-completion-coverage.md
+++ b/docs/plans/cli-completion-coverage.md
@@ -230,22 +230,23 @@ it with: the embedded space, the `@scope` suffix, a trailing path, and the
 `#argument` suffix that selects the arguments cell the way `--input` does. What
 that does not recognize falls through to the alias grammar,
 `id[@scope][#argument]` (`splitArgumentSuffix` then `parseScopedIdSegment`).
-Taking the word verbatim as a piece id — which this
-did — meant every documented spelling but the bare id resolved to a listing
-call that could not succeed, and so to a slot that silently offered nothing.
+Every spelling that intake accepts has to reach one of those two readings. A
+word taken verbatim as a piece id resolves to a listing call that cannot
+succeed, and completion answers a failure with silence, so the slot offers
+nothing and says nothing about why.
 
 An embedded space DID supplies the space where the line names none, the way
 `parsePieceOptions` does with the same reference. Where the line names one it
 wins, and a mismatch between the two is the command's to report.
 
-The positional address was a second, independent break: it occupied positional
-index 0, so the cursor resolved to the variadic `tail` rather than to
-`callable`. `resolveCompletionLine` now reads it out as `line.address` instead
-of counting it, which shifts the index the way `readCallTarget` and
-`readTargetPositionals` shift it. Which commands accept one is carried in
-`POSITIONAL_ADDRESS_COMMANDS`, for the reason `PRE_PARSE_GLOBALS` is carried:
-nothing on the command tree distinguishes those arguments from an ordinary
-string.
+A positional address is the second thing this item settles, independent of the
+grammar above. `resolveCompletionLine` reads it out as `line.address` rather
+than counting it, which shifts the index the way `readCallTarget` and
+`readTargetPositionals` shift it; counted, it would hold positional index 0 and
+put the cursor on the variadic `tail` where `callable` belongs. Which commands
+accept one is carried in `POSITIONAL_ADDRESS_COMMANDS`, for the reason
+`PRE_PARSE_GLOBALS` is carried: nothing on the command tree distinguishes those
+arguments from an ordinary string.
 
 ## Pattern vocabulary
 

--- a/docs/plans/cli-completion-coverage.md
+++ b/docs/plans/cli-completion-coverage.md
@@ -228,8 +228,9 @@ name should offer.
 `normalizeLLMFriendlyRef`, which is the function the command's own intake parses
 it with: the embedded space, the `@scope` suffix, a trailing path, and the
 `#argument` suffix that selects the arguments cell the way `--input` does. What
-that does not recognize falls through to the alias grammar
-(`parseScopedIdSegment`). Taking the word verbatim as a piece id — which this
+that does not recognize falls through to the alias grammar,
+`id[@scope][#argument]` (`splitArgumentSuffix` then `parseScopedIdSegment`).
+Taking the word verbatim as a piece id — which this
 did — meant every documented spelling but the bare id resolved to a listing
 call that could not succeed, and so to a slot that silently offered nothing.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -155,10 +155,10 @@ since all three designate the same piece. Only commands that take `--input`
 accept it; `#` is reserved for the suffix, so a path key containing `#` needs
 the positional path spelling. A `--url` carries no fragment into the reference
 it decomposes to, whatever the URL names, so a `#argument` written on one is
-dropped rather than refused. A URL that names the piece admits no target beside
-it, and `--input` is what reaches the arguments cell there; a URL that names
-only the space leaves the target to arrive as it always does — a positional
-address, or `--cell` — carrying the suffix like any other.
+dropped rather than refused. A URL that names the piece admits no `--cell` or
+positional address beside it, and `--input` is what reaches the arguments cell
+there; a URL that names only the space leaves the target to arrive as it always
+does — a positional address, or `--cell` — carrying the suffix like any other.
 
 `cf piece apply` replaces a piece's whole input rather than one path within it.
 It validates the document against the pattern's `argumentSchema` and re-executes

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -149,10 +149,13 @@ piece-management concern, and the spelling says so. They were once mounted under
 `cf piece` as well; those spellings are removed
 (docs/plans/cli-surface-shape.md, step 6b).
 
-A reference may also end in `#argument`, which selects the piece's arguments
-cell the way `--input` does. Only commands that take `--input` accept it; `#` is
-reserved for the suffix, so a path key containing `#` needs the positional path
-spelling.
+A target may also end in `#argument`, which selects the piece's arguments cell
+the way `--input` does — on a reference, on a bare id, and on a slug alike,
+since all three designate the same piece. Only commands that take `--input`
+accept it; `#` is reserved for the suffix, so a path key containing `#` needs
+the positional path spelling. A `--url` carries no fragment into the reference
+it decomposes to, so `--input` is the spelling that reaches the arguments cell
+there.
 
 `cf piece apply` replaces a piece's whole input rather than one path within it.
 It validates the document against the pattern's `argumentSchema` and re-executes
@@ -296,10 +299,10 @@ standard error and continues searching that piece and the rest of the space.
 ## Piece CFC labels
 
 `cf piece get-label` returns the effective CFC label view for a result path.
-Pass `--input` to select the input cell — a `--cell` reference ending in
-`#argument` selects it too. The paths in the returned view are relative to the
-selected path, and the view includes declared, derived, and link-carried labels.
-An unlabeled value returns JSON `null`.
+Pass `--input` to select the input cell — a `--cell` value ending in `#argument`
+selects it too. The paths in the returned view are relative to the selected
+path, and the view includes declared, derived, and link-carried labels. An
+unlabeled value returns JSON `null`.
 
 ```bash
 cf piece get-label --cell ID messages/0/body
@@ -1276,9 +1279,9 @@ line, in either of its spellings — `--remote=<url>` or bare.
 
 An option's value completes the same whether it is written after a space or
 after `=`, and every spelling of a target reaches the same slots behind it: the
-bare id, the reference (space-qualified or not, with an `@scope` suffix, an
-embedded path, or the `#argument` suffix), and a reference written positionally
-in place of the flag.
+bare id, the slug, the reference (space-qualified or not, with an embedded
+path), and a reference written positionally in place of the flag — each of them
+carrying the `@scope` and `#argument` suffixes.
 
 Past a `stopEarly()` boundary — after `cf call`'s callable name, after
 `cf exec`'s mounted file — nothing is offered. The CLI's own flags are refused

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -154,10 +154,11 @@ the way `--input` does — on a reference, on a bare id, and on a slug alike,
 since all three designate the same piece. Only commands that take `--input`
 accept it; `#` is reserved for the suffix, so a path key containing `#` needs
 the positional path spelling. A `--url` carries no fragment into the reference
-it decomposes to, so where the URL names the piece `--input` is the spelling
-that reaches the arguments cell, and a `#argument` written on such a URL is
-dropped rather than refused; where the URL names only the space, the piece
-arrives on `--cell` and takes the suffix.
+it decomposes to, whatever the URL names, so a `#argument` written on one is
+dropped rather than refused. A URL that names the piece admits no target beside
+it, and `--input` is what reaches the arguments cell there; a URL that names
+only the space leaves the target to arrive as it always does — a positional
+address, or `--cell` — carrying the suffix like any other.
 
 `cf piece apply` replaces a piece's whole input rather than one path within it.
 It validates the document against the pattern's `argumentSchema` and re-executes

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -154,8 +154,10 @@ the way `--input` does — on a reference, on a bare id, and on a slug alike,
 since all three designate the same piece. Only commands that take `--input`
 accept it; `#` is reserved for the suffix, so a path key containing `#` needs
 the positional path spelling. A `--url` carries no fragment into the reference
-it decomposes to, so `--input` is the spelling that reaches the arguments cell
-there.
+it decomposes to, so where the URL names the piece `--input` is the spelling
+that reaches the arguments cell, and a `#argument` written on such a URL is
+dropped rather than refused; where the URL names only the space, the piece
+arrives on `--cell` and takes the suffix.
 
 `cf piece apply` replaces a piece's whole input rather than one path within it.
 It validates the document against the pattern's `argumentSchema` and re-executes

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -4771,8 +4771,8 @@ export function parsePieceOptions(
   }
   if (config.pieceInput && !parseOptions?.acceptsArgument) {
     throw new ValidationError(
-      `The piece reference selects the arguments cell ("#argument") but ` +
-        `this command does not take "--input".`,
+      `The target selects the arguments cell ("#argument") but this ` +
+        `command does not take "--input".`,
       { exitCode: 1 },
     );
   }

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -5066,9 +5066,10 @@ export function parseLink(
   // same word and has no positional path to fall back on, so a `#` elsewhere
   // in one is part of the key it sits in and stays readable. A reference
   // endpoint is already past `normalizeLLMFriendlyRef`, which reserves `#`
-  // outright, so the two spellings differ here on purpose. The test named
-  // "parseLink() keeps a `#` inside a bare endpoint's path key" is what holds
-  // this apart from the shared reader.
+  // outright, so the two spellings differ here on purpose. What holds this
+  // apart from the shared reader is one case in
+  // `packages/cli/test/piece.test.ts`, "parseLink() keeps a `#` inside a bare
+  // endpoint's path key".
   if (ref.endsWith("#argument")) {
     throw new ValidationError(
       `The "#argument" suffix does not apply to a link endpoint.`,

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -5059,9 +5059,16 @@ export function parseLink(
   }
 
   // The bare spelling reaches the same refusal, so the suffix is turned down
-  // wherever it is written rather than buried in an id nothing resolves. Only
-  // this suffix: an endpoint's path has no positional spelling to fall back
-  // on, so a `#` anywhere else in one stays part of the key it sits in.
+  // wherever it is written rather than buried in an id nothing resolves.
+  //
+  // This suffix and no other fragment, which is why the test is `endsWith`
+  // rather than the shared reader: a bare endpoint carries its path in the
+  // same word and has no positional path to fall back on, so a `#` elsewhere
+  // in one is part of the key it sits in and stays readable. A reference
+  // endpoint is already past `normalizeLLMFriendlyRef`, which reserves `#`
+  // outright, so the two spellings differ here on purpose. The test named
+  // "parseLink() keeps a `#` inside a bare endpoint's path key" is what holds
+  // this apart from the shared reader.
   if (ref.endsWith("#argument")) {
     throw new ValidationError(
       `The "#argument" suffix does not apply to a link endpoint.`,

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -66,6 +66,7 @@ import { reservesStdoutForCommandOutput } from "../lib/json-output.ts";
 import {
   isReference,
   normalizeLLMFriendlyRef,
+  splitArgumentSuffix,
 } from "../lib/llm-friendly-ref.ts";
 import { renderPiece } from "../lib/piece-render.ts";
 import type {
@@ -1559,8 +1560,9 @@ PATH FORMAT: Use forward slashes and numeric indices for arrays.
 ADDRESS: The target is best written in the first positional, as a reference
 (it begins with "/"): cf ${spelling} /tracker/items 0/name. A reference names
 the piece by handle or by slug, and may carry the space by name or by DID
-(/@my-space/tracker). A trailing #argument selects the arguments cell the way
---input does. --cell takes the same word when a flag suits better.`,
+(/@my-space/tracker). --cell takes the same word when a flag suits better, and
+is where the bare id and slug spellings go. A trailing #argument selects the
+arguments cell the way --input does, on any of them.`,
     )
     .usage(`${pieceUsage} [addressOrPath] [path]`)
     .example(
@@ -1633,7 +1635,7 @@ the piece by handle or by slug, and may carry the space by name or by DID
     .option(
       "--input",
       "Read from the piece's input cell instead of result cell (the " +
-        '"#argument" reference suffix spells the same selection)',
+        '"#argument" suffix on the target spells the same selection)',
     )
     .option(
       "--step",
@@ -1683,9 +1685,10 @@ JSON VALUES: Strings need quotes: echo '"hello"' | cf ${spelling} ...
 ADDRESS: The target is best written in the first positional, as a reference
 (it begins with "/"): a path embedded in it counts, so cf ${spelling}
 /tracker/title needs no path argument. A reference names the piece by handle
-or by slug, and may carry the space (/@my-space/tracker). A trailing #argument
-selects the arguments cell the way --input does. --cell takes the same word
-when a flag suits better.`,
+or by slug, and may carry the space (/@my-space/tracker). --cell takes the
+same word when a flag suits better, and is where the bare id and slug
+spellings go. A trailing #argument selects the arguments cell the way --input
+does, on any of them.`,
       ),
     )
     .usage(`${pieceUsage} [addressOrPath] [path]`)
@@ -1711,7 +1714,7 @@ when a flag suits better.`,
     .option(
       "--input",
       "Write to the piece's input cell instead of result cell (the " +
-        '"#argument" reference suffix spells the same selection)',
+        '"#argument" suffix on the target spells the same selection)',
     )
     .arguments("[addressOrPath:string] [path:string]")
     .action(withNoSectionMarker(spelling, setCellValueFromCommand));
@@ -2689,7 +2692,7 @@ declared, derived, and link-carried labels. Omit path to inspect the root.`,
   .option(
     "--input",
     "Read from the piece's input cell instead of result cell (the " +
-      '"#argument" reference suffix spells the same selection)',
+      '"#argument" suffix on the target spells the same selection)',
   )
   .option(
     "--json",
@@ -2729,7 +2732,7 @@ updated effective label view.`),
   .option(
     "--input",
     "Write to the piece's input cell instead of result cell (the " +
-      '"#argument" reference suffix spells the same selection)',
+      '"#argument" suffix on the target spells the same selection)',
   )
   .option(
     "--json",
@@ -3649,6 +3652,13 @@ export function readBulkSelection(
           throw new ValidationError(
             `A scoped piece cannot be selected for a bulk operation; drop ` +
               `the @scope suffix on ${JSON.stringify(entry)}.`,
+            { exitCode: 1 },
+          );
+        }
+        if (splitArgumentSuffix(entry).input) {
+          throw new ValidationError(
+            `A bulk operation reads whole pieces; drop the #argument suffix ` +
+              `on ${JSON.stringify(entry)}.`,
             { exitCode: 1 },
           );
         }
@@ -4962,16 +4972,12 @@ export function parseSpaceOptions(
         if (!targetSpace) output.space = llmRef.embeddedSpace;
       }
     } else {
-      // The alias grammar has no fragments, and letting one through would
-      // bury the suffix inside the id and fail as an unknown piece later.
-      if (cell.includes("#")) {
-        throw new ValidationError(
-          `The "#argument" suffix rides the reference form ` +
-            `(/of:fid1:...#argument), not the bare piece id.`,
-          { exitCode: 1 },
-        );
-      }
-      const parsedPiece = parseScopedId(cell);
+      // A bare id and a slug designate the piece a reference designates, so
+      // the suffix means the same on them. It comes off first: left on, it
+      // sits inside the id and surfaces as an unknown piece.
+      const bare = splitArgumentSuffix(cell);
+      if (bare.input) output.pieceInput = true;
+      const parsedPiece = parseScopedId(bare.target);
       output.piece = parsedPiece.id;
       if (parsedPiece.scope) output.pieceScope = parsedPiece.scope;
     }
@@ -5050,6 +5056,17 @@ export function parseLink(
       ...(llmRef.embeddedSpace && { embeddedSpace: llmRef.embeddedSpace }),
       ...(llmRef.path.length > 0 && { path: llmRef.path }),
     };
+  }
+
+  // The bare spelling reaches the same refusal, so the suffix is turned down
+  // wherever it is written rather than buried in an id nothing resolves. Only
+  // this suffix: an endpoint's path has no positional spelling to fall back
+  // on, so a `#` anywhere else in one stays part of the key it sits in.
+  if (ref.endsWith("#argument")) {
+    throw new ValidationError(
+      `The "#argument" suffix does not apply to a link endpoint.`,
+      { exitCode: 1 },
+    );
   }
 
   const parts = ref.split("/");

--- a/packages/cli/integration/completion-over-the-cli.sh
+++ b/packages/cli/integration/completion-over-the-cli.sh
@@ -302,6 +302,14 @@ check "$ARGUMENT_KEYS" \
 check "1" "$(printf '%s' "$ARGUMENT_KEYS" | grep -c 'settings')" \
   "which is a key the arguments cell actually holds"
 
+# The suffix rides the bare slug the same way, because the slug names the
+# piece the reference names.
+check "1" "$(succeeds $CF get --quiet --piece "board#argument" $ARGS)" \
+  "the suffix on a bare slug is a --piece value the command accepts too"
+check "$ARGUMENT_KEYS" \
+  "$(candidates_at "cf get $LINE_ARGS --piece board#argument ")" \
+  "and completes the same arguments-cell keys behind it"
+
 # A path embedded in the reference is where the walk starts, the way
 # `mergePiecePath` puts it in front of the positional path.
 check "density,theme" \

--- a/packages/cli/integration/read-write-demo.sh
+++ b/packages/cli/integration/read-write-demo.sh
@@ -2,7 +2,7 @@
 # Reading and writing a piece's cells as something to watch — the half of the
 # CLI a caller reaches for before any verb: a shaped read, the two cells one
 # piece has and the flag that chooses between them, the `#argument` suffix
-# that spells the same choice on an address, the write that runs nothing, the
+# that spells the same choice on the target, the write that runs nothing, the
 # step that recomputes, and the wish that answers with an address it had to
 # write a cell to find.
 #
@@ -278,12 +278,10 @@ say "does, on both the read and the write."
 run cf get -s "$SPACE" "$ADDRESS#argument" target
 run_stdin '30' cf set -s "$SPACE" "$ADDRESS#argument" target
 run cf get -s "$SPACE" --piece thermostat target --input
-say "The suffix rides the canonical reference form and nothing else. On a"
-say "slug or a bare id there is no reference for it to attach to, and it is"
-say "refused rather than folded into the id:"
-refused "the suffix rides the canonical reference, not a slug or bare id" \
-  "rides the canonical reference form" \
-  cf get -s "$SPACE" --piece 'thermostat#argument' target
+say "The suffix rides every spelling of the target, because every spelling"
+say "names the same piece. On the slug it selects the cell the address just"
+say "wrote to:"
+run cf get -s "$SPACE" --piece 'thermostat#argument' target
 say "And a command that takes no --input takes no #argument either, so a"
 say "call cannot quietly be aimed at the arguments cell:"
 refused "a command without --input has no arguments cell to select" \
@@ -319,7 +317,7 @@ say "is not effect-free."
 
 printf '\n%s━━ The shape of it %s\n' "$B" "$N"
 say "A piece has two cells and one flag that chooses between them, spelled"
-say "again as a suffix on an address. A read shapes its own answer and"
+say "again as a suffix on the target. A read shapes its own answer and"
 say "changes nothing. A write commits a value and runs nothing — not a set,"
 say "and not a verb call either — so a derived field keeps answering to the"
 say "state it was last computed from until cf piece step observes the piece."

--- a/packages/cli/integration/read-write-demo.sh
+++ b/packages/cli/integration/read-write-demo.sh
@@ -278,9 +278,9 @@ say "does, on both the read and the write."
 run cf get -s "$SPACE" "$ADDRESS#argument" target
 run_stdin '30' cf set -s "$SPACE" "$ADDRESS#argument" target
 run cf get -s "$SPACE" --piece thermostat target --input
-say "The suffix rides every spelling of the target, because every spelling"
-say "names the same piece. On the slug it selects the cell the address just"
-say "wrote to:"
+say "A slug and a bare id designate the piece a reference designates, so the"
+say "selection written after one means what it means after the other. Here the"
+say "slug reads back the cell the address just wrote to:"
 run cf get -s "$SPACE" --piece 'thermostat#argument' target
 say "And a command that takes no --input takes no #argument either, so a"
 say "call cannot quietly be aimed at the arguments cell:"
@@ -317,10 +317,11 @@ say "is not effect-free."
 
 printf '\n%s━━ The shape of it %s\n' "$B" "$N"
 say "A piece has two cells and one flag that chooses between them, spelled"
-say "again as a suffix on the target. A read shapes its own answer and"
-say "changes nothing. A write commits a value and runs nothing — not a set,"
-say "and not a verb call either — so a derived field keeps answering to the"
-say "state it was last computed from until cf piece step observes the piece."
+say "again as a suffix on a reference, a bare id or a slug. A read shapes"
+say "its own answer and changes nothing. A write commits a value and runs"
+say "nothing — not a set, and not a verb call either — so a derived field"
+say "keeps answering to the state it was last computed from until cf piece"
+say "step observes the piece."
 say "And the one read here that is not free is the one that never named an"
 say "address: a wish resolves by writing."
 say ""

--- a/packages/cli/lib/completion/providers.ts
+++ b/packages/cli/lib/completion/providers.ts
@@ -20,7 +20,10 @@ import type { Candidate } from "./static.ts";
 import type { CompletionLine } from "./line.ts";
 import { longName } from "./line.ts";
 import { absPath } from "../utils.ts";
-import { normalizeLLMFriendlyRef } from "../llm-friendly-ref.ts";
+import {
+  normalizeLLMFriendlyRef,
+  splitArgumentSuffix,
+} from "../llm-friendly-ref.ts";
 import { parseScopedIdSegment } from "@commonfabric/runner/shared";
 import type { PieceConfig, SpaceConfig } from "../piece.ts";
 import ports from "@commonfabric/ports" with { type: "json" };
@@ -127,16 +130,16 @@ function writtenPieceRef(line: CompletionLine): string | undefined {
  *
  * `normalizeLLMFriendlyRef` reads the reference: the embedded space, the
  * `@scope` suffix, an embedded path, and the `#argument` suffix that selects
- * the arguments cell the way `--input` does. What it does not
- * recognize falls through to the alias grammar, which is `id[@scope]`. Taking
- * the word verbatim as a piece id — which this did — meant every documented
- * spelling but the bare id resolved to a listing call that could not succeed,
- * and so to a slot that silently offered nothing.
+ * the arguments cell the way `--input` does. What it does not recognize falls
+ * through to the alias grammar, `id[@scope][#argument]`. Every spelling the
+ * command's intake accepts has to reach one of the two readings: a word taken
+ * verbatim as a piece id resolves to a listing call that cannot succeed, and
+ * so to a slot that silently offers nothing.
  *
  * A malformed reference is `null` rather than a throw: the caller is a
  * provider, and a half-typed word is the normal state of one.
  */
-function resolvePieceContext(line: CompletionLine): PieceConfig | null {
+export function resolvePieceContext(line: CompletionLine): PieceConfig | null {
   const written = writtenPieceRef(line);
   if (!written) return null;
 
@@ -150,9 +153,11 @@ function resolvePieceContext(line: CompletionLine): PieceConfig | null {
   }
 
   if (!ref) {
+    let bare;
     let alias;
     try {
-      alias = parseScopedIdSegment(written);
+      bare = splitArgumentSuffix(written);
+      alias = parseScopedIdSegment(bare.target);
     } catch {
       return null;
     }
@@ -162,6 +167,7 @@ function resolvePieceContext(line: CompletionLine): PieceConfig | null {
       ...space,
       piece: alias.id,
       ...(alias.scope && { pieceScope: alias.scope }),
+      ...(bare.input && { pieceInput: true }),
     };
   }
 

--- a/packages/cli/lib/completion/providers.ts
+++ b/packages/cli/lib/completion/providers.ts
@@ -345,8 +345,8 @@ async function cellPathCandidates(
   const { parentPath, prefix } = splitPathPrefix(line.word);
   const { listCellKeys } = await import("../cell-listing.ts");
   const keys = await listCellKeys(config, parentPath, {
-    // `#argument` on the reference and `--input` as a flag are two spellings
-    // of one selection, so both reach the arguments cell here.
+    // `#argument` on the target and `--input` as a flag are two spellings of
+    // one selection, so both reach the arguments cell here.
     input: line.flags.has("input") || config.pieceInput === true,
   });
   if (keys.length === 0) return NOTHING;

--- a/packages/cli/lib/llm-friendly-ref.ts
+++ b/packages/cli/lib/llm-friendly-ref.ts
@@ -13,13 +13,16 @@
  * say what they are, so neither can be mistaken for a name and the wider
  * vocabulary costs the narrower one nothing.
  *
- * At these seams the reference may additionally end in the `#argument`
- * suffix, which selects the piece's arguments cell the way `--input` does.
+ * At these seams a target may additionally end in the `#argument` suffix,
+ * which selects the piece's arguments cell the way `--input` does.
  *
- * The CLI's bare grammar (`pieceId[@scope]`, `pieceId[@scope]/path` at link
- * endpoints, and slugs) is a convenience alias for interactive use. New
- * reference-syntax capabilities land in the canonical form first, and the
- * alias must not grow a capability the canonical form lacks.
+ * The CLI's bare grammar (`pieceId[@scope][#argument]`,
+ * `pieceId[@scope]/path` at link endpoints, and slugs) is a convenience alias
+ * for interactive use. New reference-syntax capabilities land in the
+ * canonical form first, and the alias must not grow a capability the
+ * canonical form lacks. The suffix is one the canonical form has, and a bare
+ * id designates the piece a reference designates, so it means the same on
+ * both.
  */
 
 import { ValidationError } from "@cliffy/command";
@@ -159,6 +162,37 @@ function validatePieceSegment(pieceId: string): void {
 }
 
 /**
+ * Split the trailing `#argument` suffix off a target, and say whether it was
+ * there.
+ *
+ * Both spellings of a target take the suffix, so both reach it here. `#` is
+ * reserved for it: a target carrying any other fragment is refused, which is
+ * why a path key containing `#` needs the positional path spelling rather
+ * than the embedded one.
+ *
+ * The split runs before anything else parses the target. Left on, the suffix
+ * lands inside the piece id, and the refusal that follows names an unknown
+ * piece — a message that says nothing about the `#` that caused it.
+ */
+export function splitArgumentSuffix(
+  target: string,
+): { target: string; input: boolean } {
+  const hash = target.indexOf("#");
+  if (hash === -1) return { target, input: false };
+
+  const suffix = target.slice(hash);
+  if (suffix !== "#argument") {
+    throw new ValidationError(
+      `Unknown suffix "${suffix}". The one supported suffix is ` +
+        `"#argument", which selects the piece's arguments cell the way ` +
+        `"--input" does.`,
+      { exitCode: 1 },
+    );
+  }
+  return { target: target.slice(0, hash), input: true };
+}
+
+/**
  * Normalize a piece reference — `/of:fid1:abc.../path`, or `/tracker/path`,
  * optionally with a `/@space/` prefix or an `@scope` suffix on the piece —
  * into the piece, scope, and path the CLI's own intake uses.
@@ -172,36 +206,20 @@ function validatePieceSegment(pieceId: string): void {
  * through `validateEmbeddedSpaces` once the session has resolved its own.
  *
  * The one addition to the runner's grammar is the trailing `#argument`
- * suffix, which comes back as `input`. `#` is reserved for it: a reference
- * carrying any other fragment is refused, so a path key containing `#` needs
- * the positional path spelling rather than the embedded one.
+ * suffix, read by {@link splitArgumentSuffix} and returned as `input`.
  */
 export function normalizeLLMFriendlyRef(
   ref: string,
   options: { space?: string } = {},
 ): NormalizedLLMFriendlyRef | undefined {
-  let trimmed = ref.trim();
+  const trimmed = ref.trim();
   if (!isReference(trimmed)) return undefined;
 
-  let input = false;
-  const hash = trimmed.indexOf("#");
-  if (hash !== -1) {
-    const suffix = trimmed.slice(hash);
-    if (suffix !== "#argument") {
-      throw new ValidationError(
-        `Unknown reference suffix "${suffix}". The one supported suffix ` +
-          `is "#argument", which selects the piece's arguments cell the ` +
-          `way "--input" does.`,
-        { exitCode: 1 },
-      );
-    }
-    input = true;
-    trimmed = trimmed.slice(0, hash);
-  }
+  const { target, input } = splitArgumentSuffix(trimmed);
 
   let parsed;
   try {
-    parsed = parseReferenceParts(trimmed);
+    parsed = parseReferenceParts(target);
   } catch (error) {
     throw new ValidationError(
       error instanceof Error ? error.message : String(error),

--- a/packages/cli/lib/llm-friendly-ref.ts
+++ b/packages/cli/lib/llm-friendly-ref.ts
@@ -172,7 +172,10 @@ function validatePieceSegment(pieceId: string): void {
  *
  * The split runs before anything else parses the target. Left on, the suffix
  * lands inside the piece id, and the refusal that follows names an unknown
- * piece — a message that says nothing about the `#` that caused it.
+ * piece — a message that says nothing about the `#` that caused it. A suffix
+ * with nothing in front of it is refused here for the same reason: what is
+ * left names no piece, and the refusal downstream would report a target the
+ * caller did write as one they did not.
  */
 export function splitArgumentSuffix(
   target: string,
@@ -186,6 +189,13 @@ export function splitArgumentSuffix(
       `Unknown suffix "${suffix}". The one supported suffix is ` +
         `"#argument", which selects the piece's arguments cell the way ` +
         `"--input" does.`,
+      { exitCode: 1 },
+    );
+  }
+  if (hash === 0) {
+    throw new ValidationError(
+      `"#argument" selects a piece's arguments cell, so it follows the ` +
+        `piece it selects.`,
       { exitCode: 1 },
     );
   }

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -174,10 +174,9 @@ export interface PieceConfig extends SpaceConfig {
   piecePath?: (string | number)[];
 
   /**
-   * True when the reference carried the `#argument` suffix: the caller
-   * selected the piece's arguments cell. A command that takes `--input`
-   * honors it as that flag; every other command rejects a reference that
-   * carries it.
+   * True when the target carried the `#argument` suffix: the caller selected
+   * the piece's arguments cell. A command that takes `--input` honors it as
+   * that flag; every other command rejects a target that carries it.
    */
   pieceInput?: boolean;
 }

--- a/packages/cli/test/completion-providers.test.ts
+++ b/packages/cli/test/completion-providers.test.ts
@@ -15,6 +15,7 @@ import {
   linkEndpointPrefix,
   liveCandidates,
   projectionKeys,
+  resolvePieceContext,
   resolveSpaceContext,
   shapeEntityCandidates,
   shapePieceCandidates,
@@ -171,6 +172,42 @@ Deno.test("space context: the line's own --space wins over an embedded one", asy
         "did:key:zEmbedded",
       )?.space,
       "team",
+    );
+  });
+});
+
+Deno.test("piece context: #argument reads the same on both spellings of a target", async () => {
+  // Completion reads the target through the grammar the command's own intake
+  // reads it with, so a suffix the command honors is a suffix the keys
+  // offered behind it come from the arguments cell for.
+  await withEnv({ identity: "/env.key", apiUrl: "http://env:9999" }, () => {
+    const rooted = resolvePieceContext(
+      lineFor("cf get -s demo --piece /thermostat#argument "),
+    );
+    const bare = resolvePieceContext(
+      lineFor("cf get -s demo --piece thermostat#argument "),
+    );
+    assert(rooted);
+    assert(bare);
+    assertEquals(bare.piece, "thermostat");
+    assertEquals(bare.pieceInput, rooted.pieceInput);
+    assertEquals(bare.pieceInput, true);
+    // A scope written in front of the suffix survives it.
+    assertEquals(
+      resolvePieceContext(
+        lineFor("cf get -s demo --piece thermostat@session#argument "),
+      )?.pieceScope,
+      "session",
+    );
+    // Nothing but the suffix selects that cell.
+    assertFalse(
+      resolvePieceContext(lineFor("cf get -s demo --piece thermostat "))
+        ?.pieceInput,
+    );
+    // A fragment the grammar refuses is a half-typed word, not a throw.
+    assertEquals(
+      resolvePieceContext(lineFor("cf get -s demo --piece thermostat#res ")),
+      null,
     );
   });
 });

--- a/packages/cli/test/completion-providers.test.ts
+++ b/packages/cli/test/completion-providers.test.ts
@@ -199,11 +199,13 @@ Deno.test("piece context: #argument reads the same on both spellings of a target
       )?.pieceScope,
       "session",
     );
-    // Nothing but the suffix selects that cell.
-    assertFalse(
-      resolvePieceContext(lineFor("cf get -s demo --piece thermostat "))
-        ?.pieceInput,
+    // Nothing but the suffix selects that cell, and a plain slug still
+    // resolves — a context of `null` there is a slot offering nothing.
+    const plain = resolvePieceContext(
+      lineFor("cf get -s demo --piece thermostat "),
     );
+    assert(plain);
+    assertFalse(plain.pieceInput);
     // A fragment the grammar refuses is a half-typed word, not a throw.
     assertEquals(
       resolvePieceContext(lineFor("cf get -s demo --piece thermostat#res ")),

--- a/packages/cli/test/completion-providers.test.ts
+++ b/packages/cli/test/completion-providers.test.ts
@@ -189,8 +189,11 @@ Deno.test("piece context: #argument reads the same on both spellings of a target
     );
     assert(rooted);
     assert(bare);
+    // The whole context, not just the suffix: "read the same" is the claim,
+    // and a spelling that agreed on `pieceInput` while disagreeing on the
+    // space or the piece would satisfy a narrower one.
+    assertEquals(bare, rooted);
     assertEquals(bare.piece, "thermostat");
-    assertEquals(bare.pieceInput, rooted.pieceInput);
     assertEquals(bare.pieceInput, true);
     // A scope written in front of the suffix survives it.
     assertEquals(

--- a/packages/cli/test/llm-friendly-ref.test.ts
+++ b/packages/cli/test/llm-friendly-ref.test.ts
@@ -3,6 +3,7 @@ import { expect } from "@std/expect";
 import {
   isReference,
   normalizeLLMFriendlyRef,
+  splitArgumentSuffix,
   validateEmbeddedSpaces,
 } from "../lib/llm-friendly-ref.ts";
 import { createSession, Identity } from "@commonfabric/identity";
@@ -229,12 +230,37 @@ describe("llm-friendly-ref", () => {
 
   it("rejects any fragment other than #argument", () => {
     expect(() => normalizeLLMFriendlyRef(`/${HANDLE}#result`)).toThrow(
-      /Unknown reference suffix "#result"/,
+      /Unknown suffix "#result"/,
     );
     // "#" is reserved for the suffix, so a path key containing it is not an
     // embedded-path spelling.
     expect(() => normalizeLLMFriendlyRef(`/${HANDLE}/we#ird`)).toThrow(
-      /Unknown reference suffix/,
+      /Unknown suffix/,
+    );
+  });
+
+  it("splits the suffix off a bare target the way it does off a reference", () => {
+    // One reading for both spellings: the piece a bare id names is the piece
+    // a reference names, so the selection written after it means the same.
+    expect(splitArgumentSuffix("thermostat#argument")).toEqual({
+      target: "thermostat",
+      input: true,
+    });
+    expect(splitArgumentSuffix(`${HANDLE}@user#argument`)).toEqual({
+      target: `${HANDLE}@user`,
+      input: true,
+    });
+    expect(splitArgumentSuffix("thermostat")).toEqual({
+      target: "thermostat",
+      input: false,
+    });
+    expect(() => splitArgumentSuffix("thermostat#result")).toThrow(
+      /Unknown suffix "#result"/,
+    );
+    // The suffix closes the target, so a scope written behind it is part of
+    // the fragment rather than a scope.
+    expect(() => splitArgumentSuffix("thermostat#argument@user")).toThrow(
+      /Unknown suffix "#argument@user"/,
     );
   });
 });

--- a/packages/cli/test/llm-friendly-ref.test.ts
+++ b/packages/cli/test/llm-friendly-ref.test.ts
@@ -262,5 +262,10 @@ describe("llm-friendly-ref", () => {
     expect(() => splitArgumentSuffix("thermostat#argument@user")).toThrow(
       /Unknown suffix "#argument@user"/,
     );
+    // Nothing in front of it leaves no piece to select the cell of, and the
+    // refusal downstream would report the target as one nobody wrote.
+    expect(() => splitArgumentSuffix("#argument")).toThrow(
+      /follows the piece it selects/,
+    );
   });
 });

--- a/packages/cli/test/piece-survey.test.ts
+++ b/packages/cli/test/piece-survey.test.ts
@@ -493,6 +493,10 @@ describe("piece-survey", () => {
           [`/of:fid1:${HANDLE}/topics/0`, "drop the path"],
           [`/of:fid1:${HANDLE}@user`, "@scope suffix"],
           [`/of:fid1:${HANDLE}#argument`, "#argument suffix"],
+          // The bare spelling reaches the same refusal: an entry is one
+          // whole piece however the caller wrote it.
+          [`of:fid1:${HANDLE}#argument`, "#argument suffix"],
+          [`of:fid1:${HANDLE}#result`, 'Unknown suffix "#result"'],
         ]
       ) {
         await expect(

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -439,11 +439,15 @@ describe("cli piece parsing", () => {
     )
       .toThrow(/does not take "--input"/);
     // The command's own declaration is what decides, so the bare spelling of
-    // the same selection meets the same refusal.
+    // the same selection reaches the same refusal — and the refusal names the
+    // target rather than a reference, which is not what a slug is.
     expect(() => parsePieceOptions({ ...base, cell: `${PIECE}#argument` }))
       .toThrow(/does not take "--input"/);
     expect(() => parsePieceOptions({ ...base, cell: "thermostat#argument" }))
-      .toThrow(/does not take "--input"/);
+      .toThrow(
+        'The target selects the arguments cell ("#argument") but this ' +
+          'command does not take "--input".',
+      );
   });
 
   it('parseSpaceOptions() reads "#argument" off a bare id and off a slug', () => {
@@ -764,6 +768,7 @@ describe("cli piece parsing", () => {
       deps,
     );
 
+    expect(reads).toHaveLength(3);
     for (const read of reads) {
       expect(read[0]).toMatchObject({ piece: "thermostat" });
       expect(read.slice(1)).toEqual([
@@ -771,6 +776,27 @@ describe("cli piece parsing", () => {
         { input: true, step: undefined },
       ]);
     }
+  });
+
+  it('setCellValueFromCommand() writes through "#argument" on a bare target', async () => {
+    const base = { apiUrl: API_URL, space: SPACE, identity: ID, quiet: true };
+    const writes: unknown[][] = [];
+    await setCellValueFromCommand(
+      { ...base, cell: "thermostat#argument" },
+      "target",
+      undefined,
+      {
+        drainStdin: (() => Promise.resolve(30)) as never,
+        setCellValue: ((...args: unknown[]) => {
+          writes.push(args);
+          return Promise.resolve();
+        }) as never,
+        render: (() => {}) as never,
+      },
+    );
+    expect(writes).toHaveLength(1);
+    expect(writes[0]?.[0]).toMatchObject({ piece: "thermostat" });
+    expect(writes[0]?.slice(1)).toEqual([["target"], 30, { input: true }]);
   });
 
   it("getCellValueFromCommand() leaves an unresolved path on the caller's sinks rather than exiting", async () => {

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -658,6 +658,22 @@ describe("cli piece parsing", () => {
       .toThrow(/does not apply to a link endpoint/);
   });
 
+  it("parseLink() keeps a `#` inside a bare endpoint's path key", () => {
+    // Why the refusal above tests `endsWith` rather than reading the fragment
+    // the way the shared reader does. A bare endpoint carries its piece and
+    // path in one word and has no positional path beside it, so reading every
+    // fragment here would leave a key holding `#` with no spelling at all.
+
+    expect(parseLink("tracker/we#ird")).toEqual({
+      pieceId: "tracker",
+      path: ["we#ird"],
+    });
+    // The reference form reserves `#` outright, which is the difference the
+    // two readers exist for.
+    expect(() => parseLink("/tracker/we#ird"))
+      .toThrow(/Unknown suffix "#ird"/);
+  });
+
   it("parseSpaceOptions() refuses a piece reference beside a URL that names a piece", () => {
     // Silently preferring either target is how a caller reads a piece they
     // did not name; before this rule the URL's piece won without a word.

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -438,10 +438,46 @@ describe("cli piece parsing", () => {
       parsePieceOptions({ ...base, cell: `/${LLM_HANDLE}#argument` })
     )
       .toThrow(/does not take "--input"/);
-    // The alias grammar has no fragments; refusing loudly beats burying the
-    // suffix inside an id that later fails as unknown.
-    expect(() => parseSpaceOptions({ ...base, cell: `${PIECE}#argument` }))
-      .toThrow(/rides the reference form/);
+    // The command's own declaration is what decides, so the bare spelling of
+    // the same selection meets the same refusal.
+    expect(() => parsePieceOptions({ ...base, cell: `${PIECE}#argument` }))
+      .toThrow(/does not take "--input"/);
+    expect(() => parsePieceOptions({ ...base, cell: "thermostat#argument" }))
+      .toThrow(/does not take "--input"/);
+  });
+
+  it('parseSpaceOptions() reads "#argument" off a bare id and off a slug', () => {
+    const base = { apiUrl: API_URL, space: SPACE, identity: ID };
+    expect(parseSpaceOptions({ ...base, cell: `${PIECE}#argument` }))
+      .toMatchObject({ piece: PIECE, pieceInput: true });
+    expect(parseSpaceOptions({ ...base, cell: "thermostat#argument" }))
+      .toMatchObject({ piece: "thermostat", pieceInput: true });
+    // The suffix comes off before the scope is read, so the two compose in
+    // the order the reference form writes them.
+    expect(parseSpaceOptions({ ...base, cell: "thermostat@session#argument" }))
+      .toMatchObject({
+        piece: "thermostat",
+        pieceScope: "session",
+        pieceInput: true,
+      });
+    // A target with no suffix names no cell but the result cell.
+    expect(
+      parsePieceOptions({ ...base, cell: "thermostat" }, {
+        acceptsArgument: true,
+      }).pieceInput,
+    ).toBeUndefined();
+  });
+
+  it("parseSpaceOptions() reports an unknown fragment on a bare target as one", () => {
+    // Left on the id the fragment is a piece nothing resolves, and the
+    // refusal that follows names the piece rather than the "#" that caused
+    // it. One sentence covers both spellings, since one reader splits both.
+
+    const base = { apiUrl: API_URL, space: SPACE, identity: ID };
+    expect(() => parseSpaceOptions({ ...base, cell: "thermostat#result" }))
+      .toThrow(/Unknown suffix "#result"/);
+    expect(() => parseSpaceOptions({ ...base, cell: `/${LLM_HANDLE}#result` }))
+      .toThrow(/Unknown suffix "#result"/);
   });
 
   it("readTargetPositionals() reads a leading canonical reference as the address", () => {
@@ -610,6 +646,12 @@ describe("cli piece parsing", () => {
   it('parseLink() rejects the "#argument" suffix on a link endpoint', () => {
     expect(() => parseLink(`/${LLM_HANDLE}#argument`))
       .toThrow(/does not apply to a link endpoint/);
+    // A link endpoint names a position to store, and the arguments cell is
+    // not one — whichever spelling of the target asks for it.
+    expect(() => parseLink(`${LLM_HANDLE}#argument`))
+      .toThrow(/does not apply to a link endpoint/);
+    expect(() => parseLink("thermostat/draft#argument"))
+      .toThrow(/does not apply to a link endpoint/);
   });
 
   it("parseSpaceOptions() refuses a piece reference beside a URL that names a piece", () => {
@@ -689,6 +731,46 @@ describe("cli piece parsing", () => {
     );
     expect(reads[1]?.slice(1)).toEqual([[], { input: true, step: undefined }]);
     expect(rendered).toEqual([{ ok: true }, { ok: true }]);
+  });
+
+  it('getCellValueFromCommand() reads "#argument" on a bare target as --input does', async () => {
+    const base = { apiUrl: API_URL, space: SPACE, identity: ID, quiet: true };
+    const reads: unknown[][] = [];
+    const deps = {
+      getCellValue: ((...args: unknown[]) => {
+        reads.push(args);
+        return Promise.resolve({ ok: true });
+      }) as never,
+      render: (() => {}) as never,
+    };
+
+    await getCellValueFromCommand(
+      { ...base, cell: "thermostat", input: true },
+      "target",
+      undefined,
+      deps,
+    );
+    await getCellValueFromCommand(
+      { ...base, cell: "thermostat#argument" },
+      "target",
+      undefined,
+      deps,
+    );
+    // Written together the two spellings union: one selection said twice.
+    await getCellValueFromCommand(
+      { ...base, cell: "thermostat#argument", input: true },
+      "target",
+      undefined,
+      deps,
+    );
+
+    for (const read of reads) {
+      expect(read[0]).toMatchObject({ piece: "thermostat" });
+      expect(read.slice(1)).toEqual([
+        ["target"],
+        { input: true, step: undefined },
+      ]);
+    }
   });
 
   it("getCellValueFromCommand() leaves an unresolved path on the caller's sinks rather than exiting", async () => {

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -157,10 +157,10 @@ answer composes into the next command.
   and a slug all take it, since all three designate the same piece. A command
   that takes no `--input` refuses the suffix rather than ignoring it, `cf call`
   among them. A `--url` carries no fragment into the reference it decomposes to,
-  so where the URL names the piece `--input` is the spelling that reaches the
-  arguments cell; where it names only the space, the piece arrives on `--cell`
-  and takes the suffix. A `#argument` written on a piece-naming `--url` is the
-  one place the suffix is dropped rather than refused.
+  whatever the URL names, so a `#argument` written on one is dropped rather than
+  refused. A URL naming the piece admits no target beside it, so `--input` is
+  what reaches the arguments cell there; a URL naming only the space leaves the
+  target to the positional address or `--cell`, which carry the suffix.
 
 ## Where the read options go
 

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -158,9 +158,10 @@ answer composes into the next command.
   that takes no `--input` refuses the suffix rather than ignoring it, `cf call`
   among them. A `--url` carries no fragment into the reference it decomposes to,
   whatever the URL names, so a `#argument` written on one is dropped rather than
-  refused. A URL naming the piece admits no target beside it, so `--input` is
-  what reaches the arguments cell there; a URL naming only the space leaves the
-  target to the positional address or `--cell`, which carry the suffix.
+  refused. A URL naming the piece admits no `--cell` or positional address
+  beside it, so `--input` is what reaches the arguments cell there; a URL naming
+  only the space leaves the target to arrive as it always does — a positional
+  address, or `--cell` — carrying the suffix like any other.
 
 ## Where the read options go
 

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -156,8 +156,11 @@ answer composes into the next command.
   `cf get`, `cf set`, and `cf piece get-label|set-label`. A reference, a bare id
   and a slug all take it, since all three designate the same piece. A command
   that takes no `--input` refuses the suffix rather than ignoring it, `cf call`
-  among them. A `--url` carries no fragment, so there `--input` is the spelling
-  that reaches the arguments cell.
+  among them. A `--url` carries no fragment into the reference it decomposes to,
+  so where the URL names the piece `--input` is the spelling that reaches the
+  arguments cell; where it names only the space, the piece arrives on `--cell`
+  and takes the suffix. A `#argument` written on a piece-naming `--url` is the
+  one place the suffix is dropped rather than refused.
 
 ## Where the read options go
 

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -151,12 +151,13 @@ answer composes into the next command.
   Naming the target twice — the flag beside a positional reference — is refused.
 - `--url <browser url>` is a convenience for pasting. It is not a spelling of
   its own: the host becomes `--api-url` and the rest becomes a reference.
-- A reference ending `#argument` selects the piece's arguments cell — the same
+- A target ending `#argument` selects the piece's arguments cell — the same
   selection `--input` makes, and it is accepted exactly where `--input` is:
-  `cf get`, `cf set`, and `cf piece get-label|set-label`. A command that takes
-  no `--input` refuses the suffix rather than ignoring it, `cf call` among them.
-  The suffix needs a reference, so with `--url` or a bare id, `--input` is the
-  spelling that reaches it.
+  `cf get`, `cf set`, and `cf piece get-label|set-label`. A reference, a bare id
+  and a slug all take it, since all three designate the same piece. A command
+  that takes no `--input` refuses the suffix rather than ignoring it, `cf call`
+  among them. A `--url` carries no fragment, so there `--input` is the spelling
+  that reaches the arguments cell.
 
 ## Where the read options go
 


### PR DESCRIPTION
## Why

`#argument` selects a piece's arguments cell — the same selection `--input` spells
as a flag. `cf` accepted it on the canonical reference form and refused it on a
bare id or slug, on the stated ground that "on a slug or a bare id there is no
reference for it to attach to".

That ground does not hold. A bare id designates the same piece a reference does —
that is what makes it an alias. `cf get --cell thermostat target --input` already
reads the arguments cell of a bare id, so the operation accepts the concept and
only the spelling was refused. No ambiguity was being prevented: `SLUG_PATTERN`
admits no `#`, and neither does a minted handle. The alias grammar already carries
a suffix, since `parseScopedIdSegment` splits `@scope` off a bare id. And the
no-growth rule forbids the alias only a capability the canonical form lacks, which
this is not.

What was real in the old reason is the mechanical half: the suffix has to come off
before the id is parsed, or it is buried in the id and fails later as an unknown
piece, far from its cause. That is preserved.

## What Changed

**One reader for the suffix.** `splitArgumentSuffix` in `lib/llm-friendly-ref.ts`
splits `#argument`, refuses any other fragment, and refuses a suffix with no piece
in front of it. Both the canonical and the alias paths go through it, so one
sentence is true of both spellings and the unknown-fragment error no longer says
"reference" to someone who wrote a slug.

**The bare branch splits before it parses**, and sets `pieceInput`. Completion does
the same, so candidates behind `--cell thermostat#argument` come from the
arguments cell.

**The refusals that mean something else are untouched, and now reach both
spellings.** A command taking no `--input` still refuses the suffix — that gate is
now the only rule refusing it for that reason. A bulk operation still refuses it,
because a bulk operation reads whole pieces. A link endpoint still refuses it,
deliberately through `endsWith` rather than the shared reader: an endpoint carries
piece and path in one word with no positional path beside it, so a `#` elsewhere
has to stay part of its key. A test pins that difference, and it is the only thing
in the tree holding the two readers apart.

**Documentation.** `README.md`, `docs/common/workflows/reading-and-writing.md`,
`skills/cf/SKILL.md` and the completion plan describe the suffix as riding the
target rather than the reference form. `integration/read-write-demo.sh`
demonstrates the acceptance where it demonstrated the refusal.

A `--url` carries no fragment into the reference it decomposes to, whatever the
URL names, so a `#argument` written on one is dropped rather than refused. That
asymmetry is now stated in all three carriers.

## Test plan

- `deno fmt --check`, `deno lint`, `deno task check`, `deno task check-docs`,
  `check-verb-session-sync`, `check-completion-slots`, `check-command-docs`,
  `check-skill-facts`, `check-no-waitfor`, `check-conflict-markers`,
  `check-package-cycles`, `check-docs-history-index` — green.
- `deno task test` in `packages/cli` — 211 passed, 0 failed.
- Coverage: `packages/cli` uncovered lines 2827 → 2805, **−22**.
- Thirteen mutations, each reddening the case that names the behavior it breaks —
  including one that unifies the two link-endpoint readers, which reds exactly the
  case defending why they differ.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6761?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

