### PR TITLE
docs(topics): three things the board does that its skill did not say

### DIFF
--- a/skills/topics/SKILL.md
+++ b/skills/topics/SKILL.md
@@ -57,6 +57,20 @@ cf piece verbs --cell "$TOPICS_BOARD" --json
 cf call --cell "$TOPICS_BOARD" addTopic --help --json
 ```
 
+The deployment can be well behind the checkout the CLI runs from, and that gap
+explains board behavior that would otherwise read as a defect. Ask it which
+commit it serves before recording one:
+
+```bash
+curl -fsS "$CF_API_URL/api/meta" | jq -r .gitSha
+```
+
+Resolve that in the repository — `git log --oneline -1 <sha>`, and
+`git rev-list --count <sha>..upstream/main` for the distance — before concluding
+anything from a verb that behaves unlike the source in front of you. A gap of
+dozens of commits is ordinary, so which source is running is the first question,
+not the last.
+
 Repeat `describe`, `verbs`, and `call <verb> --help --json` after selecting a
 Topic. `piece verbs` lists contract verbs by default; `--all` additionally shows
 UI wrappers and deprecated verbs. The board's published Topic rows deliberately
@@ -111,6 +125,15 @@ compose directly into later commands. The space prefix appears only when the
 reference's space differs from the command's target space, so never reconstruct
 or edit the emitted address.
 
+That rule is about writing an address. Reading one has a counterpart: a Topic
+answers to more than one address, so two that differ as strings can name the
+same Topic. The `$link` a `mention` edge carries is not the string the board
+index hands out for the Topic it points at. Resolve each address and compare
+what comes back rather than comparing the addresses, and compare on something a
+separate document would not share — `createdAt`, or the comment thread — since a
+title alone can be duplicated. An address you do not recognise on an edge is not
+evidence the edge is wrong.
+
 Read one Topic's durable input before changing it:
 
 ```bash
@@ -151,12 +174,20 @@ When the result is present, carry `TOPIC` into the next command. Use JSON
 encoding or schema-derived flags for multiline Markdown; do not interpolate
 unescaped content into JSON.
 
-Current Estuary calls have a known observation asymmetry: `addTopic` has both
-reported an error after committing and reported success without committing.
-Treat every call envelope as an observation, not proof of durable state. Read
-back after every mutation. For `addTopic`, use a distinctive title and compare
-the narrow board index before and after the call; if the result is uncertain,
-recover its `$link` there rather than blindly creating another Topic.
+Current Estuary calls have a known observation asymmetry. `addTopic` has
+reported an error after committing and has reported success without committing.
+A call can also answer nothing at all: `addTopic` and `addLink` have each hung
+past a ten-minute client timeout and committed, and an `addTopic` has hung the
+same way and not committed. A timeout therefore settles nothing in either
+direction, and none of this is particular to `addTopic` — take it as the
+behavior of every authored-content verb.
+
+So treat every call envelope, and every absence of one, as an observation rather
+than proof of durable state, and read back after every mutation. For `addTopic`,
+use a distinctive title and compare the narrow board index before and after the
+call; if the result is uncertain, recover its `$link` there rather than blindly
+creating another Topic. Retrying on the strength of a timeout is how one Topic
+becomes two.
 
 ```bash
 cf get "$TOPICS_BOARD" index --step --select @,title


### PR DESCRIPTION
Each of these cost a session real work today, and each is a sentence.

A TIMED-OUT CALL SETTLES NOTHING EITHER WAY. The skill warned that a call envelope is not proof of durable state, and scoped that to `addTopic` and to an envelope arriving: an error after committing, or a success without committing. Both halves of that scope are too narrow. A call can answer nothing at all — an `addTopic` and an `addLink` each hung past a ten-minute client timeout and had committed, and an `addTopic` from another session hung the same way and had not. So a timeout is uninformative in both directions, which is a stronger claim than the one the skill was making, since an arriving envelope at least says the call reached a conclusion. It is also not particular to `addTopic`, so the warning now covers every authored-content verb. The read-back procedure the skill already prescribes caught all three; what needed changing was the set of outcomes a reader thinks it applies to. Retrying on the strength of a timeout is how one Topic becomes two, and that is now said outright.

ASK THE BOARD WHICH COMMIT IT IS SERVING. "The running piece is authoritative" opens the orientation section, which then shows three ways to read the deployed contract without saying how to find out which source that contract was built from. The deployment can sit a long way behind the checkout the CLI runs from, and a reader comparing a verb's behavior against the source in front of them is then comparing against the wrong source. `/api/meta` answers it directly, which is worth writing down because the alternative people find is reading the commit out of a warning on a failed call. The bar is what it changes: an oddity is a question about which source is running before it is a defect. Written as method rather than measurement, since the distance changes daily.

AN ADDRESS YOU DO NOT RECOGNISE IS NOT A BROKEN EDGE. The skill says never to reconstruct or edit an emitted address; that is the rule for writing one, and there was no counterpart for reading one. A Topic answers to more than one address, so two that differ as strings can name the same Topic, and the `$link` a `mention` edge carries is not the string the board index hands out for the Topic it points at. Without that, string-comparing the two reads as a broken edge — which two sessions concluded independently, from opposite directions, on the same working pair of edges. The section gives the sufficient check rather than only the fact, because the obvious check is not enough: resolving both addresses and finding the same title does not settle it, since a separate document can carry the same title. What settles it is a field a copy would not share. Verified on this pair — the mention's address and the index's address for the Topic it names both report `createdAt` 1788316989000, where the Topic holding the edge reports 1788315445000.

No defect is implied by any of it. `mention` records the edge it claims, and the projection that made it look otherwise is one unhelpful reading against a deployment well behind the checkout, which is the case the deployed-commit check exists for.

`skills/` is the canonical source and both mirrors are symlinks to it, so these edits reach the Codex and Claude copies. Note that `skills/` is formatted by `deno fmt`, unlike `docs/`, so prose there is reflowed rather than hand-wrapped. `deno task check-skill-facts`, `check-docs`, `deno fmt --check` and `deno lint` pass.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6765?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

