### PR TITLE
docs(testing): put a local run on the server-execution ON arm

### DIFF
--- a/docs/development/TESTING.md
+++ b/docs/development/TESTING.md
@@ -70,6 +70,61 @@ a focused browser regression with a plain Deno unit test for any extracted
 policy or state machine, because code executed inside Chrome does not enter
 Deno's V8 coverage profile.
 
+### Running a test under the server-execution ON arm
+
+`serverExecution` is off by default, and CI runs the ON arm as its own lanes on
+a toolshed binary built with `EXPERIMENTAL_SERVER_EXECUTION=true`.
+[EXPERIMENTAL_OPTIONS.md](EXPERIMENTAL_OPTIONS.md#serverexecution) covers the
+flag itself.
+
+Running one of those tests locally means putting the flag on every process the
+test spans, not only the one `deno test` starts. A pattern integration test
+drives a runtime in the test process and commits through a toolshed, and the
+per-class commit admission rows are enforced by the memory server under the
+flag, so a test process on the ON arm talking to a toolshed on the OFF arm is
+on neither arm. Start the servers with it too:
+
+```bash
+EXPERIMENTAL_SERVER_EXECUTION=true ./scripts/start-local-dev.sh
+cd packages/patterns
+EXPERIMENTAL_SERVER_EXECUTION=true API_URL=http://localhost:8000/ \
+  deno test --no-check -A ./integration/<name>.test.ts
+```
+
+Then ask the server what posture it is in, rather than trusting the command
+that set it:
+
+```bash
+curl -fsS http://localhost:8000/api/health/stats | jq -e '.servingLoop != null'
+```
+
+`servingLoop` is null on the OFF arm and an object on the ON arm, and this is
+the check CI's own posture-probe step makes against the server; the paragraph
+below covers the shell half, which that step asserts separately.
+
+The toolshed log records the same thing, but it accumulates NUL bytes, so
+`grep` can decide it is binary and print nothing rather than the line that is
+there; pass `grep -a` if you read it.
+
+`restart-local-dev.sh` is the reason to check rather than assume. It runs
+`start-local-dev.sh` as a fresh process without the environment it was itself
+given, so restarting to pick up an edit returns the toolshed to the default
+while the posture the reader set appears to still be in place. Stop and start,
+or re-supply the variable to the restart.
+
+A posture mismatch does not announce itself. It fails the test, which reads as
+the behavior under test being broken, so a run against a default-posture
+toolshed can report a test as failing at every commit while CI has that test
+green. That is enough to send a bisect to the wrong answer, which is the cost
+worth avoiding here.
+
+None of this reaches a test that opens a browser. The shell's half of the
+posture is a build-time define that the local dev servers do not carry:
+`/api/meta` reports `shellServerExecutionDefine` as null whatever the toolshed
+was started with, where CI's ON lane requires `"true"`. So this recipe covers a
+browser-free test, whose whole posture is the test process and the toolshed. A
+browser test on a faithful ON arm needs the built binary.
+
 ### Tests that start Deno
 
 For deliberate import-map and lockfile changes, follow the


### PR DESCRIPTION
`serverExecution` is off by default and CI runs the ON arm as its own lanes, on a toolshed binary built with the flag. Running one of those tests locally is a different exercise, and nothing said what it takes.

Putting `EXPERIMENTAL_SERVER_EXECUTION=true` on the `deno test` process alone is not the ON arm. A pattern integration test drives a runtime in the test process and commits through a toolshed, and the per-class commit admission rows are enforced by the memory server under the flag, so a test process on the ON arm talking to a default toolshed is on neither arm.

The failure mode is what makes this worth writing down. The mismatch does not announce itself as a configuration problem: it fails the test, which reads as the behavior under test being broken. A run against a default-posture toolshed reported one ON-arm pattern test as failing at every commit tried, including commits CI had green, and restarting the toolshed with the flag turned that same commit from failing every run to passing every run. A measurement like that is not merely useless. It agrees with whatever the person running it already suspected, and it is enough to send a bisect to the wrong answer.

A rule is not enough on its own, because more than one thing puts the posture back after it has been set correctly. `restart-local-dev.sh` runs `start-local-dev.sh` as a fresh process without the environment it was itself given, so restarting to pick up an edit returns the toolshed to the default while the posture appears to still be in place. Verified directly: `/api/health/stats` reported `servingLoop` non-null, a plain `restart-local-dev.sh` followed, and it reported null with the toolshed log reading `serverExecution=false`.

So the section leads with the positive check rather than the rule. `servingLoop` is null on the OFF arm and an object on the ON arm, and it settles the question whatever put the posture wrong — a restart, a stale server, or the flag never having reached the toolshed at all. That is scoped to the server half deliberately: CI's posture-probe step asserts two things, and calling one of them "the" assertion would read as though a green `servingLoop` settles the whole posture, which is the belief this section exists to take away.

Two smaller notes come with it. The toolshed log answers the same question and is the obvious place to look, but it accumulates NUL bytes, so `grep` can decide the file is binary and print nothing rather than the line that is there; whether it does depends on where the NUL sits relative to the match, which makes it a trap rather than a consistent failure. And the shell's side of the posture is a build-time define that the local dev servers do not carry at all: `/api/meta` reports `shellServerExecutionDefine` as null whatever the toolshed was started with, where CI's ON lane requires `"true"`. The local recipe is therefore for a browser-free test by construction rather than by convenience, and a browser test on a faithful ON arm needs the built binary.

The restart behavior, both arms of the health probe, the null shell define under a flagged start, and the NUL bytes in the log were each checked against a running pair of servers rather than read off the scripts. `deno task check-docs`, `check-skill-facts`, `deno fmt --check` and `deno lint` pass.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6766?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

