### PR TITLE
fix(patterns): a vote burst that recasts, and a rollback count of zero

### DIFF
--- a/docs/development/BENCHMARKS.md
+++ b/docs/development/BENCHMARKS.md
@@ -345,5 +345,6 @@ Which benchmarks that floor sits under is therefore a question of where
 a question the workflow's list answers.
 
 `packages/patterns/integration/lunch-poll-keyed-votes.test.ts` is the assertion
-half of the same property: it bounds rolled-back writes instead of timing them,
-so a regression that this benchmark shows as trend drift also fails a test.
+half of the same property: it counts rolled-back writes instead of timing them,
+and requires none, so a regression that this benchmark shows as trend drift
+also fails a test.

--- a/packages/patterns/integration/lunch-poll-keyed-votes.test.ts
+++ b/packages/patterns/integration/lunch-poll-keyed-votes.test.ts
@@ -23,12 +23,24 @@
  * session's vote by key alone. Under a whole-list write the tally still reads
  * right and that read finds nothing.
  *
- * The second test is the same property in the units a person feels, and it is a
- * bound rather than an equality: a keyed vote still shares its commit with the
- * work the poll's derived views do, and that work reads the whole list. This
- * file's own burst — three voters, four options, three rounds — measured 25
- * rolled-back writes keyed against 63 whole-list (2026-09-01, this harness), so
- * the bound of one per vote sits between them with room either side.
+ * The second test is the same property in the units a person feels: three
+ * voters recast every option at once, three rounds of it, and no write is
+ * rolled back at all. Two things make that an equality rather than a bound.
+ * Each voter's vote for an option is its own document, so a burst of recasts
+ * holds no document two sessions both write. And the color schedule advances
+ * every voter by one color a round, which leaves each option holding one of
+ * every color throughout, so the tallies the poll derives never change and
+ * never contend either. What the count answers is therefore the vote write
+ * alone, which is the question this file asks.
+ *
+ * The schedule is what makes it answer that. Casting the color already held
+ * clears the vote, and clearing one changes the shared list's membership,
+ * which is what the sessions' concurrent commits then get refused over. That
+ * cost is membership churn, and it is the same whether the vote itself is
+ * keyed or not. A burst that repeats a color pays it and measures something
+ * other than what it set out to. This burst costs 0 rolled-back writes with
+ * the keyed write and around 60 with a whole-list write (2026-09-02, this
+ * harness).
  *
  * The poll's identity is a shared `#profile` cell. The wish resolves in this
  * harness, and in a space holding no profile it resolves to the surface that
@@ -60,6 +72,15 @@ const PROGRAM_PATH = join(
 const NAMES = ["Alice", "Bob", "Carol"] as const;
 const TITLES = ["Cheeseboard", "Gregoire", "Saul's", "Fava"] as const;
 const COLORS = ["green", "yellow", "red"] as const;
+
+/**
+ * The color a voter casts for an option in a given round. Consecutive rounds
+ * differ for every voter and option, so no cast ever repeats the color that
+ * vote already holds and no cast is read as clearing it. Every option holds
+ * one of each color in every round, so the poll's tallies never change.
+ */
+const colorFor = (voter: number, option: number, round: number): string =>
+  COLORS[(voter + option + round) % COLORS.length];
 
 /**
  * Optimistic writes these sessions had rolled back — each one applied locally,
@@ -171,10 +192,15 @@ describe("lunch poll: a vote is a keyed, mergeable write", () => {
     // Everyone re-votes every option at once, repeatedly — the shape of a real
     // lunch decision, where a whole-list write makes each vote wait seconds.
     // Warm up first so no session is paying for a document it has never held; a
-    // cold first write conflicts either way and is not what this measures.
-    for (const session of everyone) {
-      for (const option of options) {
-        await session.send("castVote", { optionId: option, voteType: "green" });
+    // cold first write conflicts either way and is not what this measures. The
+    // warm-up is round zero of the same schedule, so the first measured round
+    // changes every color it touches.
+    for (let voter = 0; voter < everyone.length; voter++) {
+      for (let option = 0; option < options.length; option++) {
+        await everyone[voter].send("castVote", {
+          optionId: options[option],
+          voteType: colorFor(voter, option, 0),
+        });
         await harness.settle();
       }
     }
@@ -184,16 +210,13 @@ describe("lunch poll: a vote is a keyed, mergeable write", () => {
     await harness.settle();
     const before = await reverts(everyone);
     const rounds = 3;
-    for (let round = 0; round < rounds; round++) {
+    for (let round = 1; round <= rounds; round++) {
       await Promise.all(
         everyone.flatMap((session, voter) =>
           options.map((option, index) =>
             session.send(
               "castVote",
-              {
-                optionId: option,
-                voteType: COLORS[(voter + index + round) % COLORS.length],
-              },
+              { optionId: option, voteType: colorFor(voter, index, round) },
               undefined,
               { idle: false },
             )
@@ -208,9 +231,11 @@ describe("lunch poll: a vote is a keyed, mergeable write", () => {
     expect(await host.read(["voteCount"])).toBe(cast);
     expect(
       rolledBack,
-      `${rolledBack} rolled-back writes for ${cast * rounds} votes; a vote ` +
-        "should cost well under one rollback, and more than one apiece means " +
+      `${rolledBack} rolled-back writes for ${cast * rounds} concurrent ` +
+        "recasts; a recast writes one voter's own vote document and adds a " +
+        "membership already present, so it shares no document with another " +
+        "voter's recast and costs nothing to roll back. Anything here means " +
         "the vote write is contending on the whole list again",
-    ).toBeLessThan(cast * rounds);
+    ).toBe(0);
   });
 });

--- a/packages/patterns/integration/lunch-poll-vote-burst.bench.ts
+++ b/packages/patterns/integration/lunch-poll-vote-burst.bench.ts
@@ -25,8 +25,8 @@
  * 7 to 15 seconds and cost 430 rejected commits and 558 rolled-back writes —
  * and dropped two votes for the length of one burst on the way.
  * `packages/patterns/integration/lunch-poll-keyed-votes.test.ts` is the
- * assertion half of the same property, bounding rolled-back writes rather than
- * timing them.
+ * assertion half of the same property, requiring that a burst roll back no
+ * write at all rather than timing one.
  *
  * Sample count is the weak point, and it is inherent. An iteration takes about
  * 450ms on an Apple M5 Max and 2.6 seconds on a four-core CI host, so a run


### PR DESCRIPTION
The lunch-poll keyed-vote test's second case fires three voters at every option at once, three rounds of it, and counts the optimistic writes those sessions had rolled back. It required that count to stay under one per vote — 36 for the burst it runs — and CI saw 37. On a developer machine the same run measures 22 to 34 against that same 36, so the bound sat inside the ordinary spread of the quantity it was bounding, and the case failed whenever the spread went the wrong way.

That count was not measuring what the file asks about. Extending the burst to ten rounds puts every rolled-back write in the first two, and none at all from the third round on: the quantity is a fixed transient, compared against a bound that grows with the number of rounds. At three rounds the two are the same size.

The transient comes from the color schedule. `castVote` reads a cast in the color already held as clearing the vote, and the warm-up cast every vote green, so the first round's `(voter + option + round) % 3` came up green again for a third of the pairs and cleared them, and the second round put them back. Clearing a vote and re-adding it changes the shared list's membership, and a membership change is what the other sessions' in-flight commits get refused over. Read back, the refusals of one such burst name three different reads — the votes array, another voter's vote document, and the link resolved through it — and about half of the rolled-back writes are commits dropped because one they had stacked on locally was dropped, rather than refusals of their own. That accounting is the subject of its own investigation and does not change what this burst should be doing. None of the cost depends on whether the vote itself is keyed.

The burst now warms up at round zero of its own schedule and measures rounds one through three, so no cast ever repeats the color that vote holds and no cast is read as clearing it. Every option holds one of each color in every round, so the tallies the poll derives never change either, and what the count answers is the vote write alone. Measured that way the burst rolls back nothing, in every run, and the assertion becomes an equality rather than a bound: 0, against roughly 60 for the same burst with `castVote` regressed to a whole-list read-modify-write. The step also finishes in a fifth of the time, having stopped paying for the conflicts it was counting.

`docs/development/BENCHMARKS.md` and the burst benchmark's own header both describe this test as bounding rolled-back writes, and now say it requires none. The benchmark itself needed no change: its warm-up already runs two bursts of the same advancing schedule, so it never repeats a color.

deflaked by Hixie's agent

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6767?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

