### PR TITLE
fix(runner): a piece start reads durably, so its commit can export

### DIFF
--- a/docs/specs/server-side-execution/speculation.md
+++ b/docs/specs/server-side-execution/speculation.md
@@ -592,9 +592,40 @@ Both exclusions are about the NAMED BASIS of one commit, never a
 withdrawal: the echo itself stands until its ordinary retirement
 (§4). Value-consuming reads keep the refusal unchanged in every
 transaction shape, and a transaction outside the blind-write family —
-including its verifier reads — keeps naming every layer;
-`speculation-overlay.test.ts` pins the export, the scoping, the
-verify-durable consistency, and the content-addressed exemption.
+including its verifier reads — keeps naming every layer, unless it
+carries the durable-read mark below; `speculation-overlay.test.ts`
+pins the export, the scoping, the verify-durable consistency, the
+content-addressed exemption, and the durable-read mark on both a
+direct transaction and a piece start.
+
+### The durable-read mark, and the piece start that needs it
+
+An authored transaction whose writes must reach the wire can read the
+durable replica view instead of the ordinary one. `markDurableReadTx`
+(`storage/reactivity-log.ts`) is that mark: values and named basis
+both skip the process-local speculation layers, so what such a
+transaction consumed and what it names stay the same set — the
+verify-durable and name-durable pairing again, one shape wider. A
+document still short of its authoritative value re-derives reactively
+once that value lands, which is the recovery path §6's refusal
+message names. Two callers carry the mark. One is the direct SQLite
+capability's exec, an authored write with no reactive run around it.
+The other is the runner's piece start.
+
+A piece start mints its own transaction, instantiates the pattern's
+nodes into it, and commits it fire-and-forget as sanctioned
+bookkeeping (serving-loop.md §3d). It reads whatever the node
+bindings resolve through, which is as likely to be a document a
+standing echo rewrote as any other. Naming that echo's layer turns
+the start's commit into a terminal refusal, and the arm that catches
+one retires the piece's whole registration — taking with it the event
+handlers its graph installed, so the next send to one of those
+streams finds no handler and the scheduler drops the event. A list
+that grows by handler sends stops growing, one send at a time, with
+no error anywhere near the send. Reading durably is what keeps that
+commit exportable. The mark covers only the transaction the runner
+mints for itself; a start handed a caller's transaction keeps that
+caller's read semantics.
 
 One retirement wake completes the ruling's "fix infinitely stuck
 things" half (§4's evaluation detail): a sweep that runs while an

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -141,6 +141,7 @@ import {
 } from "./storage/interface.ts";
 import {
   machineryRead,
+  markDurableReadTx,
   schedulerDependencyRead,
 } from "./storage/reactivity-log.ts";
 import {
@@ -3422,6 +3423,13 @@ export class Runner {
           actionId: `piece-instantiate/${resultCell.sourceURI}`,
           kind: "bookkeeping",
         });
+        // The instantiation's writes are authored bookkeeping bound for
+        // the wire, so it reads the durable replica view: a commit basis
+        // naming a client speculation layer is refused terminally
+        // (speculation.md §6), and the arm that catches that refusal
+        // retires the piece registration along with the event handlers
+        // its graph installed.
+        markDurableReadTx(actualTx);
       }
       // A boot snapshot belongs to exactly one pattern instantiation. A later
       // patternIdentity hot-swap must register fresh under the same durable

--- a/packages/runner/test/speculation-overlay.test.ts
+++ b/packages/runner/test/speculation-overlay.test.ts
@@ -20,7 +20,10 @@
 // - a speculative run's post-commit effects follow the egress rule:
 //   external-sink kinds are DROPPED (the client never performs egress
 //   under the flag — README §3.5), while the reversible `navigateTo`
-//   kind still enacts (optimistic navigation, speculation.md §2).
+//   kind still enacts (optimistic navigation, speculation.md §2);
+// - the runner's own piece-start instantiation reads the DURABLE view,
+//   so its bookkeeping commit never names an overlay layer and the
+//   piece keeps the registration its event handlers hang off.
 
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
@@ -34,6 +37,7 @@ import { Runtime } from "../src/runtime.ts";
 import type {
   IExtendedStorageTransaction,
   MemorySpace,
+  SealedCommitVerdict,
 } from "../src/storage/interface.ts";
 import { ExecutorHost } from "../src/executor/host.ts";
 import { waitForSettled } from "../src/executor/watermark.ts";
@@ -58,7 +62,8 @@ import { getDirectTransactionReadActivities } from "../src/storage/transaction-i
 import { isTerminalRejection } from "../src/storage/rejection.ts";
 import type { PostCommitSideEffect } from "../src/cfc/types.ts";
 import { readStoredCfcMetadata } from "../src/cfc/metadata.ts";
-import type { JSONSchema } from "../src/builder/types.ts";
+import type { JSONSchema, Module, Pattern } from "../src/builder/types.ts";
+import type { Cell } from "../src/cell.ts";
 import { waitUntil } from "./support/wait-until.ts";
 
 const spaceSigner = await Identity.fromPassphrase("speculation overlay space");
@@ -2168,6 +2173,151 @@ describe("Phase 2 speculation overlay", () => {
     );
     verdict.resolve({ withdrawn: { message: "test complete" } });
     await sealed.settled;
+  });
+
+  it("a piece-start instantiation reads through the durable view while a speculative echo stands: its bookkeeping commit lands and the piece stays registered (speculation.md §6)", async () => {
+    // The runner's own piece-instantiation transaction is an authored
+    // write bound for the wire, so its read basis must never name a
+    // speculative layer. The refusal is terminal by ruling, and the arm
+    // that catches it retires the whole piece registration — which takes
+    // the event handlers the graph installed with it, so the next send
+    // to one of those streams finds no handler and drops. That is the
+    // shape the record-module-chrome integration test hit on the ON
+    // lane: a dropped `addModule` send three milliseconds after a
+    // `SpeculativeBasisError` on `piece-instantiate/...`.
+    //
+    // The piece is a hand-built witness whose one raw node reads a shared
+    // document through the instantiation's own transaction and writes a
+    // changing value, so every instantiation carries a real bookkeeping
+    // commit instead of being optimized away to a no-op — the device
+    // executor-wave.test.ts uses for this same machinery.
+    clientManager = EmulatedStorageManager.connectTo(server, {
+      as: aliceSigner,
+    });
+    clientRuntime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: clientManager,
+      experimental: { serverExecution: true },
+    });
+    const engine = await server.engineForSpace(space);
+
+    const shared = clientRuntime.getCell<{ n: number }>(
+      space,
+      "piece-start-shared-input",
+      undefined,
+    );
+    await shared.sync();
+    {
+      const seed = clientRuntime.edit();
+      shared.withTx(seed).set({ n: 1 });
+      expect((await seed.commit()).error).toBeUndefined();
+    }
+    await clientRuntime.storageManager.synced();
+
+    let instantiations = 0;
+    const readPerInstantiation: unknown[] = [];
+    const pattern: Pattern = {
+      argumentSchema: { type: "object", properties: {} },
+      resultSchema: {
+        type: "object",
+        properties: { witness: { type: "number" } },
+      },
+      result: {},
+      nodes: [{
+        module: {
+          type: "raw",
+          implementation: (...args: unknown[]) => {
+            const parentCell = args[4] as Cell<Record<string, unknown>>;
+            instantiations += 1;
+            readPerInstantiation.push(
+              shared.withTx(parentCell.tx).key("n").get(),
+            );
+            parentCell.key("witness").set(instantiations);
+            return { action: () => {} };
+          },
+        } as Module,
+        inputs: {},
+        outputs: {},
+      }],
+    };
+
+    const witness = clientRuntime.getCell<Record<string, unknown>>(
+      space,
+      "piece-start-witness",
+      undefined,
+    );
+    {
+      const tx = clientRuntime.edit();
+      const running = clientRuntime.runner.run(
+        tx,
+        pattern,
+        {},
+        witness.withTx(tx),
+      );
+      expect((await tx.commit()).error).toBeUndefined();
+      await running.pull();
+    }
+    await clientRuntime.storageManager.synced();
+    expect(instantiations).toBe(1);
+    const registrationsWhileRunning = clientRuntime.runner.cancels.size;
+    clientRuntime.runner.stop(witness);
+    expect(clientRuntime.runner.cancels.size).toBe(
+      registrationsWhileRunning - 1,
+    );
+
+    // The window: an echo stands on the shared document, so an
+    // instantiation that reads it through the ordinary view names a
+    // process-local layer in its commit basis.
+    const replica = clientManager.open(space).replica;
+    const sharedLink = shared.getAsNormalizedFullLink();
+    const durableDoc = replica.getDocument(sharedLink.id, sharedLink.scope);
+    const verdict = Promise.withResolvers<SealedCommitVerdict>();
+    const sealed = replica.sealNative!(
+      {
+        operations: [{
+          op: "set",
+          id: sharedLink.id,
+          type: "application/json",
+          value: {
+            ...(durableDoc as Record<string, unknown>),
+            value: { n: 99 },
+          },
+        }],
+      },
+      undefined,
+      verdict.promise,
+      { speculative: true },
+    );
+    expect(shared.get()).toEqual({ n: 99 });
+
+    const failures: Array<{ actionId: string; name?: string }> = [];
+    clientRuntime.pieceStartCommitFailureObserver = ({ actionId, error }) => {
+      failures.push({ actionId, name: (error as { name?: string })?.name });
+    };
+    try {
+      expect(await clientRuntime.start(witness)).toBe(true);
+      await clientRuntime.idle();
+      await clientRuntime.runner.idlePieceInstantiationSettlements();
+
+      // Its setup write landed: nothing refused it.
+      expect(failures).toEqual([]);
+      // The instantiation ran against the durable value, not the echo's,
+      // which is the value side of the basis it names.
+      expect(instantiations).toBe(2);
+      expect(readPerInstantiation[1]).toBe(1);
+      // And the store holds what it wrote.
+      await clientRuntime.storageManager.synced();
+      expect(
+        (Engine.read(engine, { id: witness.getAsNormalizedFullLink().id })
+          ?.value as { witness?: number } | undefined)?.witness,
+      ).toBe(2);
+      // So the piece is still registered, and the handlers its graph
+      // installed are still reachable by an event.
+      expect(clientRuntime.runner.cancels.size).toBe(registrationsWhileRunning);
+    } finally {
+      verdict.resolve({ withdrawn: { message: "test complete" } });
+      await sealed.settled.catch(() => {});
+    }
   });
 
   it("under a standing overlay layer whose writes include /cfc, a blind-write tx's verifier-shaped read sees the DURABLE doc while an ordinary read sees the overlay — verify-durable and name-durable travel together (RULED 2026-08-21)", async () => {

--- a/packages/runner/test/speculation-overlay.test.ts
+++ b/packages/runner/test/speculation-overlay.test.ts
@@ -2320,6 +2320,140 @@ describe("Phase 2 speculation overlay", () => {
     }
   });
 
+  it("a piece-start instantiation still consumes a DURABLE in-flight layer: the mark excludes speculation, not everything pending (speculation.md §6)", async () => {
+    // The reverse pin of the case above, and the one that catches the
+    // wrong implementation of it. The durable-read mark must skip the
+    // process-local speculation layers and nothing else: a durable
+    // sealed layer is a real write on its way to the store, its localSeq
+    // is nameable in a commit basis, and an instantiation that stopped
+    // consuming it would build the graph from a value the store is
+    // already past. Written as "skip every pending layer" the case above
+    // still passes and this one reads 1.
+    //
+    // The two seals differ in exactly one token — the `speculative`
+    // option — so the values the two tests expect are what separates the
+    // two layer classes.
+    clientManager = EmulatedStorageManager.connectTo(server, {
+      as: aliceSigner,
+    });
+    clientRuntime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: clientManager,
+      experimental: { serverExecution: true },
+    });
+
+    const shared = clientRuntime.getCell<{ n: number }>(
+      space,
+      "piece-start-durable-input",
+      undefined,
+    );
+    await shared.sync();
+    {
+      const seed = clientRuntime.edit();
+      shared.withTx(seed).set({ n: 1 });
+      expect((await seed.commit()).error).toBeUndefined();
+    }
+    await clientRuntime.storageManager.synced();
+
+    let instantiations = 0;
+    const readPerInstantiation: unknown[] = [];
+    const pattern: Pattern = {
+      argumentSchema: { type: "object", properties: {} },
+      resultSchema: {
+        type: "object",
+        properties: { witness: { type: "number" } },
+      },
+      result: {},
+      nodes: [{
+        module: {
+          type: "raw",
+          implementation: (...args: unknown[]) => {
+            const parentCell = args[4] as Cell<Record<string, unknown>>;
+            instantiations += 1;
+            readPerInstantiation.push(
+              shared.withTx(parentCell.tx).key("n").get(),
+            );
+            parentCell.key("witness").set(instantiations);
+            return { action: () => {} };
+          },
+        } as Module,
+        inputs: {},
+        outputs: {},
+      }],
+    };
+
+    const witness = clientRuntime.getCell<Record<string, unknown>>(
+      space,
+      "piece-start-durable-witness",
+      undefined,
+    );
+    {
+      const tx = clientRuntime.edit();
+      const running = clientRuntime.runner.run(
+        tx,
+        pattern,
+        {},
+        witness.withTx(tx),
+      );
+      expect((await tx.commit()).error).toBeUndefined();
+      await running.pull();
+    }
+    await clientRuntime.storageManager.synced();
+    expect(instantiations).toBe(1);
+    expect(readPerInstantiation[0]).toBe(1);
+    clientRuntime.runner.stop(witness);
+
+    // A DURABLE sealed layer: the same shape as the speculative one
+    // above without the `speculative` option, so it is a write bound for
+    // the store whose verdict has not landed yet.
+    const replica = clientManager.open(space).replica;
+    const sharedLink = shared.getAsNormalizedFullLink();
+    const durableDoc = replica.getDocument(sharedLink.id, sharedLink.scope);
+    const verdict = Promise.withResolvers<SealedCommitVerdict>();
+    const sealed = replica.sealNative!(
+      {
+        operations: [{
+          op: "set",
+          id: sharedLink.id,
+          type: "application/json",
+          value: {
+            ...(durableDoc as Record<string, unknown>),
+            value: { n: 42 },
+          },
+        }],
+      },
+      undefined,
+      verdict.promise,
+    );
+    expect(shared.get()).toEqual({ n: 42 });
+
+    const refusals: unknown[] = [];
+    clientRuntime.pieceStartCommitFailureObserver = ({ error }) => {
+      refusals.push(error);
+    };
+    try {
+      expect(await clientRuntime.start(witness)).toBe(true);
+      await clientRuntime.idle();
+
+      // The layer is durable, so the instantiation consumed it.
+      expect(instantiations).toBe(2);
+      expect(readPerInstantiation[1]).toBe(42);
+      // And naming it is legitimate: whatever this commit's fate, it is
+      // never the terminal refusal a speculative basis earns. Its fate
+      // rides the seal's undischarged verdict, which is why the outcome
+      // itself is not asserted here.
+      await clientRuntime.runner.idlePieceInstantiationSettlements();
+      expect(
+        refusals.filter((error) =>
+          isTerminalRejection(error as { name?: string })
+        ),
+      ).toEqual([]);
+    } finally {
+      verdict.resolve({ withdrawn: { message: "test complete" } });
+      await sealed.settled.catch(() => {});
+    }
+  });
+
   it("under a standing overlay layer whose writes include /cfc, a blind-write tx's verifier-shaped read sees the DURABLE doc while an ordinary read sees the overlay — verify-durable and name-durable travel together (RULED 2026-08-21)", async () => {
     // The consistency pin for the ruled arm (b): the value the
     // verifier consumes must match the basis named for it. The echo


### PR DESCRIPTION
The transaction a piece start mints for itself instantiates the pattern's nodes and then commits, fire-and-forget, as sanctioned bookkeeping. It reads whatever the node bindings resolve through. Under server-side execution one of those documents can be carrying a client speculation layer: the still-standing echo of a handler this process ran locally, waiting for the server's own commit to cover it.

Reading through that layer put it in the commit's read basis, and a basis naming a process-local layer cannot be exported — the layer exists only in this process, so the server could never resolve it as a pending-read dependency. The replica refuses such a commit outright with a terminal SpeculativeBasisError, and the arm that catches a refused instantiation retires the piece's whole registration. The registration is what the graph's event handlers hang off, so the piece loses them, and the next send to one of those streams finds no handler and is dropped. Nothing fails near the send: a list that grows by handler sends simply stops growing, one send at a time.

Mark the self-minted transaction durable-read. Its values and its named basis then both skip the speculation layers, so the instantiation is built from the state the server will see and its commit exports. A document still short of its authoritative value re-derives reactively once that value lands, which is the recovery the refusal message already names. A start handed a caller's transaction is untouched and keeps that caller's read semantics.

markDurableReadTx already existed for authored writes in this position; the direct SQLite exec capability is its other caller.

speculation.md section 6 gains that mark and both its carriers, since it previously said a transaction outside the blind-write family always names every layer.

The test reproduces the refusal with no timing in it. A hand-built witness piece reads a shared document through the instantiation's own transaction and writes a changing value, so every instantiation carries a real bookkeeping commit rather than being optimized away to a no-op; a restart with nothing new to write never reaches the export path at all, which is why the integration surface reproduces this only under load. The piece is started, stopped, and started again while a speculative layer stands on that document. It asserts that nothing refused the commit, that the instantiation saw the durable value rather than the echo's, that the store holds what it wrote, and that the piece kept its registration. Without the durable-read mark it fails with the same SpeculativeBasisError seen in CI.

This is the terminal half of a pair on one commit path. A plain stale-read conflict there also retired the piece; that arm now recovers once through awaitCommitRetryReadiness, and this change does not touch it. Neither half changes what the scheduler does with a send that arrives while a piece has no handler, so the window remains reachable when an instantiate failure gets past the one recovery.

deflaked by Hixie's agent (Claude Opus 5, session FC)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6769?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

