### PR TITLE
docs(runner): attach reactivity-log comment blocks to what they describe

### DIFF
--- a/packages/runner/src/storage/reactivity-log.ts
+++ b/packages/runner/src/storage/reactivity-log.ts
@@ -105,18 +105,6 @@ export function isReadIgnoredForCommit(meta?: Metadata): boolean {
   return meta?.[ignoreReadForCommitMarker] === true;
 }
 
-// Transaction-level UI-input "blind leaf overwrite" mode. handleCellSet marks
-// the transaction around a scalar `$value` set (and unmarks before
-// prepareTxForCommit, so CFC boundary-commit read-then-writes keep their
-// preconditions); while marked, read() tags every read with `ignoreReadForCommit`
-// and skips `validated`, so the write carries no value-equality precondition on
-// its leaf (last-write-wins, which is correct for raw scalar UI input) — buildReads
-// downgrades the tagged reads to a single nonRecursive entity-root existence read,
-// which still catches a concurrent whole-doc delete/replace. Read-modify-write
-// and structured (array/object) writes are NOT marked and retain compare-and-set.
-// Both the wrapper and the inner storage transaction(s) are marked, since
-// read()/buildReads run on the inner one; the chain walk tolerates extra wrapper
-// layers.
 // Rejection listeners, registered per inner transaction (CT-1950). A
 // rejected commit's promise resolves only after finalizeRejection's
 // read-repair gate — the caller's retry needs the repaired base — but the
@@ -191,6 +179,20 @@ function* blindWriteTxChain(tx: object): Generator<object> {
   }
 }
 
+/**
+ * Transaction-level UI-input "blind leaf overwrite" mode. handleCellSet marks
+ * the transaction around a scalar `$value` set (and unmarks before
+ * prepareTxForCommit, so CFC boundary-commit read-then-writes keep their
+ * preconditions); while marked, read() tags every read with `ignoreReadForCommit`
+ * and skips `validated`, so the write carries no value-equality precondition on
+ * its leaf (last-write-wins, which is correct for raw scalar UI input) — buildReads
+ * downgrades the tagged reads to a single nonRecursive entity-root existence read,
+ * which still catches a concurrent whole-doc delete/replace. Read-modify-write
+ * and structured (array/object) writes are NOT marked and retain compare-and-set.
+ * Both the wrapper and the inner storage transaction(s) are marked, since
+ * read()/buildReads run on the inner one; the chain walk tolerates extra wrapper
+ * layers.
+ */
 export function markUiInputBlindWriteTx(tx: object): void {
   for (const layer of blindWriteTxChain(tx)) uiInputBlindWriteTxs.add(layer);
 }
@@ -217,25 +219,27 @@ export function isDurableReadTx(tx: object): boolean {
   return false;
 }
 
-// Lazy materialization: a marked transaction hands a reader views that resolve
-// each path as it is touched, rather than a value built in one pass before the
-// reader looks at any of it.
-//
-// The mark also decides how a view treats the transaction it was made against.
-// Unmarked, a query-result proxy is a standing handle: it resolves the
-// transaction on every access, so a holder keeps reading current state after
-// that transaction has finished — which long-lived consumers depend on, an LLM
-// tool call dispatched later and a SQLite result flushed post-commit among
-// them. Marked, a view keeps the transaction it was created with, so the value
-// it describes stays the value that was there when it was taken, and reading
-// after that transaction finishes throws rather than quietly reading from
-// committed state.
-//
-// Nothing outside the mark changes, so an unmarked transaction reads exactly as
-// it did before lazy materialization existed. Marked on the same wrapper chain
-// as the marks above, so a wrapper and the transaction it wraps read alike.
 const lazyMaterializationTxs = new WeakSet<object>();
 
+/**
+ * Lazy materialization: a marked transaction hands a reader views that resolve
+ * each path as it is touched, rather than a value built in one pass before the
+ * reader looks at any of it.
+ *
+ * The mark also decides how a view treats the transaction it was made against.
+ * Unmarked, a query-result proxy is a standing handle: it resolves the
+ * transaction on every access, so a holder keeps reading current state after
+ * that transaction has finished — which long-lived consumers depend on, an LLM
+ * tool call dispatched later and a SQLite result flushed post-commit among
+ * them. Marked, a view keeps the transaction it was created with, so the value
+ * it describes stays the value that was there when it was taken, and reading
+ * after that transaction finishes throws rather than quietly reading from
+ * committed state.
+ *
+ * Nothing outside the mark changes, so an unmarked transaction reads exactly as
+ * it did before lazy materialization existed. Marked on the same wrapper chain
+ * as the marks above, so a wrapper and the transaction it wraps read alike.
+ */
 export function markLazyMaterializationTx(tx: object): void {
   for (const layer of blindWriteTxChain(tx)) lazyMaterializationTxs.add(layer);
 }
@@ -244,6 +248,16 @@ export function unmarkLazyMaterializationTx(tx: object): void {
     lazyMaterializationTxs.delete(layer);
   }
 }
+export function isLazyMaterializationTx(tx: object): boolean {
+  // Walk the chain rather than testing the object: a wrapper built over a
+  // transaction that was marked earlier has never been marked itself, and must
+  // still report the mark of what it wraps.
+  for (const layer of blindWriteTxChain(tx)) {
+    if (lazyMaterializationTxs.has(layer)) return true;
+  }
+  return false;
+}
+
 // A refusal recorded on the transaction, so it survives being caught. A reader
 // can swallow a `SchemaMismatchError` — its own `try`/`catch`, or an `await`
 // that discards the rejection — and still hand back a plausible-looking result.
@@ -272,16 +286,6 @@ export function clearSchemaRefusalTx(tx: object, refusal: unknown): void {
   for (const layer of blindWriteTxChain(tx)) {
     if (schemaRefusals.get(layer) === refusal) schemaRefusals.delete(layer);
   }
-}
-
-export function isLazyMaterializationTx(tx: object): boolean {
-  // Walk the chain rather than testing the object: a wrapper built over a
-  // transaction that was marked earlier has never been marked itself, and must
-  // still report the mark of what it wraps.
-  for (const layer of blindWriteTxChain(tx)) {
-    if (lazyMaterializationTxs.has(layer)) return true;
-  }
-  return false;
 }
 
 // Renderer-input (user-keystroke `$value`) provenance for timing-mitigation


### PR DESCRIPTION
Two comment blocks in `packages/runner/src/storage/reactivity-log.ts` sit next to declarations they do not describe, and a reader following the file's own layout convention attributes them to the wrong mark.

The file records several per-transaction marks, each a WeakSet or WeakMap with a small group of mark/unmark/read functions around it, and each introduced by a comment block. Where those groups run together with no blank line between them, a block placed above one group's declaration reads as trailing commentary on the group before it.

The block beginning "Lazy materialization: a marked transaction hands a reader views that resolve each path as it is touched" sat immediately below `isDurableReadTx` and immediately above `lazyMaterializationTxs`. It describes the lazy-materialization mark, but it was read as describing the durable-read one. That misreading has happened twice: in review of PR #6744 a reviewer quoted the block's sentence about a view keeping the transaction it was created with, and about reading after that transaction finishes throwing, as a hazard of applying `markDurableReadTx` to the piece-instantiate transaction. There is no such hazard. The two marks have entirely disjoint consumers. `isDurableReadTx` is read only in `storage/v2-transaction.ts` and `storage/v2.ts`, where it selects the non-speculative document for a read and the durable layers for a commit basis;
`isLazyMaterializationTx` is read only in
`storage/extended-storage-transaction.ts`, which is what governs view lifetime.

The block describing the UI-input blind leaf overwrite mode was worse off. It was written directly above `uiInputBlindWriteTxs`, but a later change inserted the commit-rejection-listener declaration and its own comment between the two. The block was left about seventy lines from its subject, with no blank line separating it from the comment that follows, so the two blocks read as one comment about rejection listeners.

Both blocks become JSDoc on the mark function they describe, which is how `markDurableReadTx` immediately above already carries its documentation, and which an editor will show on hover at the call site where the question actually arises. The wording is unchanged; only the attachment moves. `isLazyMaterializationTx` moves up to join its own mark and unmark functions, where it had been separated from them by the schema-refusal group; that leaves the schema-refusal comment starting a group of its own rather than butting against
`unmarkLazyMaterializationTx`.

No executable code changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6770?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

