### PR TITLE
fix(runner): a piece setup keeps the argument slots it is not given

### DIFF
--- a/packages/runner/src/runner-utils.ts
+++ b/packages/runner/src/runner-utils.ts
@@ -408,6 +408,29 @@ export function mergeObjects<T>(
 }
 
 /**
+ * Fold the slots a stored argument holds into the argument a caller supplied,
+ * so a write of the result leaves untouched every top-level slot the caller
+ * did not name. A supplied slot wins over the stored one at every key it
+ * carries, including a key it carries as `undefined`.
+ *
+ * Both operands must be plain records for there to be slots to fold; anything
+ * else (a scalar, an array, a link) is a whole value, and the supplied one
+ * stands as it is.
+ */
+export function foldStoredArgumentSlots<T>(
+  supplied: T,
+  stored: unknown,
+): T {
+  if (
+    !isFabricPlainObject(supplied as FabricValue) || isCellLink(supplied) ||
+    !isFabricPlainObject(stored as FabricValue) || isCellLink(stored)
+  ) {
+    return supplied;
+  }
+  return { ...stored as object, ...supplied as object } as T;
+}
+
+/**
  * Merge schema defaults into an existing argument while avoiding optional
  * object defaults that would create an invalid partial value on their own.
  */

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -188,6 +188,7 @@ import { setResultCell } from "./result-utils.ts";
 import {
   describePatternOrModule,
   extractDefaultValues,
+  foldStoredArgumentSlots,
   mergeSchemaDefaults,
   sanitizeDebugLabel,
   schemaAcceptsOpaqueCellValue,
@@ -2193,6 +2194,7 @@ export class Runner {
     argumentLink: NormalizedFullLink,
     argument: T,
     argumentSchema: JSONSchema | undefined,
+    projection: unknown = argument,
   ): void {
     // The argument link can come from the result cell's stored `argument`
     // meta, which need not name the document this result cell's cause mints
@@ -2224,12 +2226,21 @@ export class Runner {
     // a serialized pattern graph it previously stopped at -- a function halts
     // its descent, a record does not -- and record structural-provenance
     // claims from positions it has never seen.
+    //
+    // What it walks is what this setup PROJECTS, which is `projection`: the
+    // argument itself wherever the two are one value, and the caller's own
+    // argument where the value being written folded the stored document's
+    // slots in. Each redirect it finds records a setup-projection marker, and
+    // a marker exempts writes at-or-below its target from `writeAuthorizedBy`
+    // for the rest of the transaction (`writeIsPatternSetupInitialization` in
+    // cfc/prepare.ts), so the redirects it walks are the ones this setup
+    // establishes rather than the ones the document already held.
     recordSetupProjectionPolicyInputs(
       tx,
       this.runtime,
       argumentCell,
       argumentSchema,
-      argument,
+      projection,
     );
     diffAndUpdate(
       this.runtime,
@@ -2444,8 +2455,13 @@ export class Runner {
     if (setupState.sameStoredSetup) {
       const argumentLink = getMetaLink(resultCell, "argument")!;
       const defaults = extractDefaultValues(pattern.argumentSchema);
-      const nextArgument = mergeSchemaDefaults(
+      const supplied = mergeSchemaDefaults(
         argument,
+        defaults,
+        pattern.argumentSchema,
+      );
+      const nextArgument = mergeSchemaDefaults(
+        this.#argumentOverStoredSlots(tx, argumentLink, argument),
         defaults,
         pattern.argumentSchema,
       );
@@ -2461,6 +2477,7 @@ export class Runner {
         argumentLink,
         nextArgument,
         pattern.argumentSchema,
+        supplied,
       );
       return { resultCell, patternRef, needsStart: false };
     }
@@ -2612,6 +2629,23 @@ export class Runner {
   }
 
   /**
+   * The argument to write for a piece whose argument document already exists,
+   * built from `argument` over the slots that document holds. The stored read
+   * goes through `tx`, so the write it shapes sits in the same conflict set.
+   */
+  #argumentOverStoredSlots<T>(
+    tx: IExtendedStorageTransaction,
+    argumentLink: NormalizedFullLink,
+    argument: T,
+  ): T {
+    if (argument === undefined) return argument;
+    const stored = this.runtime
+      .getCellFromLink(argumentLink, undefined, tx)
+      .getRaw({ meta: ignoreReadForScheduling });
+    return foldStoredArgumentSlots(argument, stored);
+  }
+
+  /**
    * When this function is first called, the resultCell may not have its
    * internal, argument, and pattern cells set up, so do that here.
    */
@@ -2642,6 +2676,9 @@ export class Runner {
     );
 
     let nextArgument: T | undefined = argument;
+    // What the setup projects, where that is not the value being written. Set
+    // only where the two differ; the write below falls back to `nextArgument`.
+    let suppliedProjection: T | undefined;
     let argumentUpdated = false;
     // The argument meta field of the result cell should be a link to the
     // argument cell. If it doesn't exist, we need to apply the defaults
@@ -2676,7 +2713,16 @@ export class Runner {
       if (argumentLink === undefined) {
         throw new Error("Invalid argument link in updateArgument");
       }
-    } else if (restageStoredArgument) {
+    } else if (!restageStoredArgument) {
+      // Same stored setup over an argument document that already exists. The
+      // write below replaces the whole document, so it carries the slots this
+      // caller does not name: a nested piece is replayed with the argument its
+      // parent's expression carries — `Poll({ votes })` names one slot — and
+      // the piece's own state lives in the rest. What the setup PROJECTS stays
+      // the argument this caller supplied.
+      suppliedProjection = argument;
+      nextArgument = this.#argumentOverStoredSlots(tx, argumentLink, argument);
+    } else {
       const previousArgumentCell = this.runtime.getCellFromLink(
         argumentLink,
         undefined,
@@ -2753,6 +2799,7 @@ export class Runner {
         argumentLink,
         nextArgument,
         pattern.argumentSchema,
+        suppliedProjection ?? nextArgument,
       );
     }
 

--- a/packages/runner/test/piece-argument-replay.test.ts
+++ b/packages/runner/test/piece-argument-replay.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Setting up a piece whose argument document already exists writes that whole
+ * document, so what the write carries decides what survives. A caller names
+ * some of the argument's slots and leaves the rest to the piece: a nested
+ * piece is instantiated with the argument its parent's expression carries —
+ * `Child({ supplied })` names one slot — and the piece's own durable state
+ * lives in the slots that expression never mentions.
+ *
+ * These tests pin both routes a same-pattern setup takes over an existing
+ * argument document: `Runner.#applySetupState`, which a piece reaches when it
+ * holds no registration (the nested piece its parent restarts), and
+ * `Runner.#maybeReuseRunningSetup`, which a registered piece reaches when it is
+ * run again with an argument.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+
+import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+
+const signer = await Identity.fromPassphrase("piece argument replay");
+const space = signer.did();
+
+// `kept` is the piece's own state: seeded from its schema default at the first
+// setup and grown by `add` after that. `supplied` is what a caller passes in.
+const CHILD_SOURCE = [
+  "import { Default, handler, pattern, Stream, Writable } from 'commonfabric';",
+  "",
+  "export interface Arguments {",
+  "  supplied?: string | Default<'seed'>;",
+  "  kept?: string[] | Default<[]>;",
+  "}",
+  "",
+  "export interface Surface {",
+  "  add: Stream<{ text: string }>;",
+  "  kept: readonly string[];",
+  "}",
+  "",
+  "const add = handler<{ text: string }, { kept: Writable<string[]> }>(",
+  "  ({ text }, { kept }) => {",
+  "    kept.push(text);",
+  "  },",
+  ");",
+  "",
+  "export default pattern<Arguments, Surface>(({ kept }) => ({",
+  "  add: add({ kept }),",
+  "  kept,",
+  "}));",
+  "",
+].join("\n");
+
+// The parent's expression names `supplied` alone, so the nested piece's `kept`
+// is state no caller passes down. Its `add` stream and `kept` reading are
+// re-exported so a test drives and reads the nested piece through the root.
+const PARENT_SOURCE = [
+  "import { pattern } from 'commonfabric';",
+  "import Child, { type Arguments, type Surface } from './child.tsx';",
+  "",
+  "export default pattern<Arguments, Surface>(({ supplied }) => {",
+  "  const child = Child({ supplied });",
+  "  return { add: child.add, kept: child.kept };",
+  "});",
+  "",
+].join("\n");
+
+const files = [
+  { name: "/child.tsx", contents: CHILD_SOURCE },
+  { name: "/main.tsx", contents: PARENT_SOURCE },
+];
+
+const parentProgram: RuntimeProgram = { main: "/main.tsx", files };
+const childProgram: RuntimeProgram = { main: "/child.tsx", files };
+
+/** Run `probe` against a fresh runtime over an emulated store. */
+const withRuntime = async (
+  probe: (runtime: Runtime) => Promise<void>,
+): Promise<void> => {
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+  try {
+    await probe(runtime);
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+};
+
+/**
+ * Run `program` at `cause` with `supplied` alone, then grow the piece's `kept`
+ * to `["one", "two"]` through its `add` stream.
+ */
+const startedPiece = async (
+  runtime: Runtime,
+  program: RuntimeProgram,
+  cause: string,
+) => {
+  const tx = runtime.edit();
+  const pattern = await runtime.patternManager.compilePattern(program, {
+    space,
+    tx,
+  });
+  const cell = runtime.getCell<Record<string, unknown>>(
+    space,
+    cause,
+    undefined,
+    tx,
+  );
+  const running = runtime.run(tx, pattern, { supplied: "first" }, cell);
+  await tx.commit();
+  await running.pull();
+  await runtime.idle();
+
+  for (const text of ["one", "two"]) {
+    (cell.key("add") as unknown as { send: (event: unknown) => void })
+      .send({ text });
+    await runtime.idle();
+  }
+  await cell.pull();
+  expect(cell.key("kept").get()).toEqual(["one", "two"]);
+  return { cell, pattern };
+};
+
+describe("piece argument replay", () => {
+  it("keeps a nested piece's state when its parent is restarted", async () => {
+    await withRuntime(async (runtime) => {
+      const { cell } = await startedPiece(
+        runtime,
+        parentProgram,
+        "parent-restart",
+      );
+
+      runtime.runner.stop(cell);
+      expect(await runtime.start(cell)).toBe(true);
+      await runtime.idle();
+      await cell.pull();
+
+      expect(
+        cell.key("kept").get(),
+        "the restart re-instantiated the nested piece with the argument its " +
+          "parent's expression names, and dropped the slots that expression " +
+          "leaves to the piece",
+      ).toEqual(["one", "two"]);
+    });
+  });
+
+  it("keeps the slots an argument does not name when a running piece is run again", async () => {
+    await withRuntime(async (runtime) => {
+      const { cell, pattern } = await startedPiece(
+        runtime,
+        childProgram,
+        "running-rerun",
+      );
+
+      const tx = runtime.edit();
+      runtime.run(tx, pattern, { supplied: "second" }, cell);
+      await tx.commit();
+      await runtime.idle();
+      await cell.pull();
+
+      expect(
+        cell.key("kept").get(),
+        "the re-run wrote the whole argument document from a value naming " +
+          "`supplied` alone, so `kept` fell back to its schema default",
+      ).toEqual(["one", "two"]);
+    });
+  });
+});


### PR DESCRIPTION
A piece's setup writes its whole argument document, and it builds the value it writes from the argument the caller supplied. Where the caller supplies only part of that argument, the rest of the document was rebuilt from the pattern's schema: a slot with a declared default came back as that default, and a slot without one went absent. Everything the caller does not pass down is the piece's own state, so setting a piece up a second time reset it.

The case that bites is a nested piece. It is instantiated with the argument expression its parent's pattern carries, and that expression names the inputs the parent passes down and nothing else. `Poll({ votes })` names one slot; the poll's options, roster, host, viewer and history all live in the slots it does not name. Re-instantiating the parent emptied the poll.

Both routes into that write now fold the stored document's slots in under the supplied argument, so a slot the caller does not name keeps what the document holds and the schema defaults reach only the slots nothing fills. `Runner.#applySetupState` is the route a piece takes when it holds no registration, which is where a nested piece lands when its parent restarts; `Runner.#maybeReuseRunningSetup` is the route a registered piece takes when it is run again with an argument, which is where the parent's own re-instantiation sends a nested piece that is still registered, and where `PiecesController.runWithPattern` sends a piece whose inputs are being updated. The stored read goes through the setup transaction, so the write it shapes sits in that transaction's conflict set.

The two new tests pin one route each: a parent stopped and started again, and a registered piece run again with an argument naming one of its two slots. Each is red without the change, reporting the piece's `kept` list as empty where it held two entries.

This came out of the lunch-poll keyed-votes integration failure, where three sessions under server execution kept re-instantiating the poll's parent and one of those instantiations committed the clobbering write, leaving the poll with no options, no roster and no votes. The instantiation churn behind that is separately fixed: a refused piece-start commit now retries from a repaired view instead of tearing the piece down, so that test is green without this change as well. What stays is the write itself, which resets a nested piece's state on any re-instantiation, in any posture.

deflaked by Hixie's agent (Claude Opus 5)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6771?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

