### PR TITLE
fix(runner): hold an event whose piece has no graph installed

### DIFF
--- a/docs/specs/server-side-execution/events.md
+++ b/docs/specs/server-side-execution/events.md
@@ -482,7 +482,8 @@ loop's duty).
   iteration stops the pass before it queues later arrivals behind the
   barrier's back — else a later arrival's consequence lands ahead of
   the withdrawn entry's re-drain, the b01 inversion. The piece-start
-  deferral (a served entry whose piece could not be started) carries
+  deferral (a served entry whose piece could not be started, or whose
+  piece stands registered between pattern graphs — T3) carries
   the same in-queue sweep; cross-space neighbours and LT1 in-process
   copies are excluded from the sweep,
   as everywhere. (α) preserved: the mark still commits exactly once, only
@@ -607,6 +608,22 @@ loop's duty).
   to unconsequenced and retried. Drop = the event is unrunnable;
   requeue = the event is fine and the commit was raced. §3d cites
   this predicate rather than restating it.
+
+  A piece reporting as STARTED does not settle the test on its own.
+  The instantiation commit that built its graph settles after the
+  start returns, and a refused one retires that graph: across the one
+  recovery the registration stands while the piece instantiates
+  again, and past that recovery the registration goes with it. Either
+  way the piece serves no handler on any of its streams while it
+  still reports as started. A send arriving in that window finds no
+  handler because the commit was raced, so it takes the piece-start
+  deferral of §4 — the durable entry stays pending and a later wave
+  re-drains it — never this drop. The deferral budget above is what
+  keeps that from wedging the stream: a piece that never regains a
+  graph runs the budget out and its events harden into this drop,
+  which is the honest outcome once the race window is long past. The
+  test reads whether the piece has a graph installed, not what its
+  start reported.
 
   **Where the notice lives, and when it retires (T7).** The
   dropped-event notice — `{ status: "dropped", reason }` naming the

--- a/packages/runner/src/ensure-piece-running.ts
+++ b/packages/runner/src/ensure-piece-running.ts
@@ -104,6 +104,14 @@ export type EnsurePieceVerdict = {
      * retries next cycle. */
     | "confirm-pull-failed";
 
+  /** Whether the started piece has a pattern graph installed AT THE
+   * MOMENT THIS IS CALLED. `started` reports what the start walk did,
+   * and the instantiation commit that walk fires settles after it
+   * returns: a refused commit retires the graph while the registration
+   * stands. A caller acting on `started` later asks this instead of
+   * assuming. Present whenever a start ran. */
+  graphIsInstalled?: () => boolean;
+
   /** The owning result doc's id (the chain terminus) where the chain
    * resolved — present for `started`, `no-pattern-meta`, and
    * `pattern-unloadable`. */
@@ -205,7 +213,13 @@ export async function ensurePieceRunningVerdict(
         `Piece started successfully`,
       ]);
 
-      return { started: true, rootId, observedDocIds };
+      return {
+        started: true,
+        graphIsInstalled: () =>
+          runtime.runner.pieceGraphIsInstalled(resultCell),
+        rootId,
+        observedDocIds,
+      };
     } catch (error) {
       // Make sure to commit/rollback the transaction on error
       try {

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -1783,11 +1783,24 @@ function dedupeNormalizedLinks(
   return deduped;
 }
 
+/**
+ * A started piece's registration: the cancel that retires it, carrying
+ * whether the pattern graph it was installed with is still there. The
+ * registration outlives that graph — a refused instantiation commit retires
+ * the graph and the recovery installs another under the same registration —
+ * so a caller asking what the piece can serve right now reads the probe
+ * rather than the registration's presence.
+ */
+type PieceRegistration = Cancel & { graphIsInstalled: () => boolean };
+
 export class Runner {
   // A member below declared `private` rather than `#` is one the runner suites
   // reach and drive directly; a `#` name would put it out of their reach.
 
-  readonly cancels = new Map<`${MemorySpace}/${ScopeKey}/${URI}`, Cancel>();
+  readonly cancels = new Map<
+    `${MemorySpace}/${ScopeKey}/${URI}`,
+    PieceRegistration
+  >();
   #allCancels = new Set<Cancel>();
   // In-flight unloadable-pointer roll-forward commits (CT-1923). Deliberately
   // outside the scheduler, like PatternUpdater's checks — dispose() settles
@@ -3359,12 +3372,16 @@ export class Runner {
     addCancel(() => retryReadinessTeardown.abort());
     const startLifecycleEpoch = this.#lifecycleEpoch;
     let active = true;
-    const cancel = () => {
+    const cancel = (() => {
       if (!active) return;
       active = false;
       this.#locallyCommittedHandlerResultStarts.delete(key);
       cancelGroup();
-    };
+    }) as PieceRegistration;
+    // `cancelNodes` holds the live graph's cancellation, and stands empty
+    // between the retirement a refused instantiation commit performs and the
+    // instantiation that replaces it.
+    cancel.graphIsInstalled = () => cancelNodes !== undefined;
     this.cancels.set(key, cancel);
     this.#allCancels.add(cancel);
 
@@ -6545,6 +6562,24 @@ export class Runner {
         visited,
       );
     }
+  }
+
+  /**
+   * Whether the piece owning `resultCell` has a pattern graph installed
+   * right now.
+   *
+   * A piece is registered from the moment its start walk runs, and the
+   * instantiation commit that graph was built in settles afterwards. A
+   * refused commit retires the graph while the registration stands, so a
+   * caller deciding what the piece can serve — the scheduler, holding an
+   * event for a stream it finds no handler on — asks this rather than
+   * reading the start's outcome.
+   *
+   * @param resultCell - The result doc or cell of the piece to ask about.
+   */
+  pieceGraphIsInstalled<T>(resultCell: Cell<T>): boolean {
+    return this.cancels.get(this.getDocKey(resultCell))?.graphIsInstalled() ===
+      true;
   }
 
   /**

--- a/packages/runner/src/scheduler/events.ts
+++ b/packages/runner/src/scheduler/events.ts
@@ -1,7 +1,10 @@
 import { getLogger } from "@commonfabric/utils/logger";
 import { recordTrustedEventPolicyInputs } from "../cfc/ui-contract.ts";
 import type { Cancel } from "../cancel.ts";
-import { ensurePieceRunning } from "../ensure-piece-running.ts";
+import {
+  ensurePieceRunningVerdict,
+  type EnsurePieceVerdict,
+} from "../ensure-piece-running.ts";
 import { waveRunContextOf } from "../executor/wave.ts";
 import {
   areNormalizedLinksSame,
@@ -174,7 +177,7 @@ export interface SchedulerEventQueueState {
   readonly loadPieceForEvent?: (
     runtime: Runtime,
     eventLink: NormalizedFullLink,
-  ) => Promise<boolean>;
+  ) => Promise<EnsurePieceVerdict>;
   readonly queueExecution: () => void;
   readonly recordLineageEvent: (
     originTx: IExtendedStorageTransaction,
@@ -593,10 +596,11 @@ export function queueSchedulerEvent(state: SchedulerEventQueueState, args: {
 
     const startTask = (async () => {
       try {
-        const started = await (state.loadPieceForEvent ?? ensurePieceRunning)(
-          state.runtime,
-          args.eventLink,
-        );
+        const verdict = await (state.loadPieceForEvent ??
+          ensurePieceRunningVerdict)(
+            state.runtime,
+            args.eventLink,
+          );
         // The origin may have failed while the piece was loading.
         if (
           queuedEvent.finalOutcomeNotified ||
@@ -611,25 +615,43 @@ export function queueSchedulerEvent(state: SchedulerEventQueueState, args: {
           queuedEvent.handler = loadedHandler;
           queuedEvent.action = (tx) => loadedHandler(tx, args.event);
           delete queuedEvent.handlerLoadPending;
-        } else if (started) {
-          // The piece ran and registered NOTHING for this stream —
-          // events.md §5's drop predicate ("no runnable handler").
+        } else if (
+          verdict.started && verdict.graphIsInstalled?.() !== false
+        ) {
+          // The piece is running with its pattern graph installed and
+          // registered NOTHING for this stream — events.md §5's drop
+          // predicate ("no runnable handler"). A verdict carrying no
+          // graph probe reads as installed: only a start walk mints
+          // one, and its absence says nothing about the piece.
           dropQueuedEvent(
             state,
             queuedEvent,
             `Event dropped: no handler registered for ${args.eventLink.id} after starting its piece`,
           );
         } else {
-          // The piece could not be STARTED — for a served (drained)
-          // event this is a cold-view deferral (the creation-race
-          // shape), never the drop predicate: the durable entry stays
-          // pending and a later wave re-drains it. Client-side the
-          // distinction is moot (no durable entry to re-drain) and the
-          // drop keeps its existing shape.
+          // Either the piece could not be STARTED, or it has no
+          // pattern graph installed: a refused instantiation commit
+          // retires the graph the start walk installed, and the runner
+          // then either re-instantiates once from a caught-up view or
+          // retires the registration with it. The walk ran before any
+          // of that, so `started` reports a piece that has nothing
+          // registered for any of its streams. Neither shape is the
+          // drop predicate — the handler is missing because the commit
+          // was raced, not because there is none, and events.md §5
+          // calls for a requeue there. For a served (drained) event
+          // that is a deferral: the durable entry stays pending and a
+          // later wave re-drains it, under the serving loop's bounded
+          // deferral budget — a condition that outlasts the budget
+          // hardens into §5's drop notice rather than wedging the
+          // stream. Client-side the distinction is moot (no durable
+          // entry to re-drain) and the drop keeps its existing shape.
+          const pieceState = verdict.started
+            ? "has no pattern graph installed"
+            : "could not be started";
           dropQueuedEvent(
             state,
             queuedEvent,
-            `Event dropped: no handler registered for ${args.eventLink.id} and its piece could not be started`,
+            `Event dropped: no handler registered for ${args.eventLink.id} and its piece ${pieceState}`,
             queuedEvent.served !== undefined ? "deferred" : "dropped",
           );
           if (queuedEvent.served !== undefined) {
@@ -640,7 +662,7 @@ export function queueSchedulerEvent(state: SchedulerEventQueueState, args: {
             deferLaterSameSpaceServedEvents(
               state,
               queuedEvent,
-              "whose piece could not be started",
+              `whose piece ${pieceState}`,
             );
           }
         }

--- a/packages/runner/test/scheduler-event-drop-predicate.test.ts
+++ b/packages/runner/test/scheduler-event-drop-predicate.test.ts
@@ -1,0 +1,303 @@
+import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+import type { Pattern } from "../src/builder/types.ts";
+import { ensurePieceRunning } from "../src/ensure-piece-running.ts";
+import {
+  getDerivedInternalCell,
+  getMetaCell,
+  type NormalizedFullLink,
+} from "../src/link-utils.ts";
+import { rawMetaWriteAuthorization } from "../src/meta-seam.ts";
+import { setResultCell } from "../src/result-utils.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { ServedEventFailureOutcome } from "../src/scheduler/types.ts";
+import { trustPattern } from "./support/trusted-builder.ts";
+
+const signer = await Identity.fromPassphrase("test operator");
+const space = signer.did();
+
+type CommitRefusal = { name: string; message: string };
+
+// Refuse the next commit reaching the emulated memory server and let every
+// later one through, the way a serving side that advanced a document the
+// commit's basis names refuses one commit and accepts its successor.
+function rejectNextTransact(
+  runtime: Runtime,
+  error: CommitRefusal,
+): () => void {
+  type Response = {
+    type: "response";
+    requestId: string;
+    error: CommitRefusal;
+  };
+  const server = (runtime.storageManager as unknown as {
+    server(): {
+      transact(
+        message: { requestId: string },
+        publish?: (response: Response) => void,
+      ): Promise<Response>;
+    };
+  }).server();
+  const original = server.transact.bind(server);
+  let armed = true;
+  server.transact = (message, publish) => {
+    if (!armed) return original(message, publish);
+    armed = false;
+    const response: Response = {
+      type: "response",
+      requestId: message.requestId,
+      error,
+    };
+    publish?.(response);
+    return Promise.resolve(response);
+  };
+  return () => {
+    server.transact = original;
+  };
+}
+
+describe("scheduler event drop predicate", () => {
+  // Every case here puts one piece into the state a refused instantiation
+  // commit leaves it in: the registration stands, its pattern graph is
+  // retired, and the one re-instantiation the runner schedules is waiting on
+  // a caught-up view. Nothing is registered for the piece's stream in that
+  // state, and `ensurePieceRunning` reports the piece as started.
+
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let handlerEvents: unknown[];
+  let restoreTransact: (() => void) | undefined;
+  let releaseRetry: (() => void) | undefined;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      experimental: { serverExecution: true },
+    });
+    handlerEvents = [];
+  });
+
+  afterEach(async () => {
+    releaseRetry?.();
+    await runtime.runner.idlePieceInstantiationSettlements();
+    restoreTransact?.();
+    await runtime.dispose();
+    await storageManager.close();
+  });
+
+  // Start a piece whose instantiation commit is refused, and return the link
+  // of the stream its handler is bound to. The pattern instantiates a child
+  // piece: instantiation must carry durable writes of its own, or its commit
+  // settles locally and no refusal can reach it.
+  async function startPieceWithRetiredGraph(): Promise<NormalizedFullLink> {
+    const childPattern: Pattern = {
+      argumentSchema: {
+        type: "object",
+        properties: { input: { type: "number" }, output: { type: "number" } },
+      },
+      resultSchema: {},
+      result: { $alias: { partialCause: "output", path: [], defer: 1 } },
+      nodes: [
+        {
+          module: { type: "passthrough" },
+          inputs: {
+            value: { $alias: { cell: "argument", path: ["input"], defer: 1 } },
+          },
+          outputs: {
+            value: { $alias: { partialCause: "output", path: [], defer: 1 } },
+          },
+        },
+      ],
+    };
+    const pattern: Pattern = {
+      argumentSchema: {
+        type: "object",
+        properties: { value: { type: "number" } },
+      },
+      resultSchema: {
+        type: "object",
+        properties: { events: { type: "object" }, seen: { type: "number" } },
+      },
+      derivedInternalCells: [
+        { partialCause: "events", schema: { default: { $stream: true } } },
+        { partialCause: "seen", schema: { default: 0 } },
+        { partialCause: "child" },
+      ],
+      result: {
+        events: { $alias: { partialCause: "events", path: [] } },
+        seen: { $alias: { partialCause: "seen", path: [] } },
+      },
+      nodes: [
+        {
+          module: {
+            type: "javascript",
+            wrapper: "handler",
+            implementation: (event: unknown, ctx: { seen: number }) => {
+              handlerEvents.push(event);
+              ctx.seen = (ctx.seen ?? 0) + 1;
+            },
+          },
+          inputs: {
+            $event: { $alias: { partialCause: "events", path: [] } },
+            $ctx: { seen: { $alias: { partialCause: "seen", path: [] } } },
+          },
+          outputs: { seen: { $alias: { partialCause: "seen", path: [] } } },
+        },
+        {
+          module: { type: "pattern", implementation: childPattern },
+          inputs: { input: { $alias: { cell: "argument", path: ["value"] } } },
+          outputs: { $alias: { partialCause: "child", path: [] } },
+        },
+      ],
+    };
+    const patternIdentity = {
+      identity: "test-drop-predicate",
+      symbol: "default",
+    };
+    runtime.patternManager.associatePatternIdentity(
+      trustPattern(runtime, pattern),
+      patternIdentity,
+    );
+
+    const tx = runtime.edit();
+    const resultCell = runtime.getCell(
+      space,
+      "drop-predicate-result",
+      undefined,
+      tx,
+    );
+    const argumentCell = getMetaCell(resultCell, "argument", tx);
+    const eventsCell = getDerivedInternalCell(resultCell, {
+      partialCause: "events",
+    }, tx);
+    const seenCell = getDerivedInternalCell(resultCell, {
+      partialCause: "seen",
+    }, tx);
+    resultCell.setRaw({
+      events: eventsCell.getAsWriteRedirectLink(),
+      seen: seenCell.getAsWriteRedirectLink(),
+    });
+    resultCell.setMetaRaw(
+      "patternIdentity",
+      patternIdentity,
+      rawMetaWriteAuthorization,
+    );
+    resultCell.setMetaRaw(
+      "argument",
+      argumentCell.getAsWriteRedirectLink(),
+      rawMetaWriteAuthorization,
+    );
+    setResultCell(eventsCell, resultCell);
+    setResultCell(seenCell, resultCell);
+    argumentCell.set({ value: 1 });
+    eventsCell.setRaw({ $stream: true });
+    await tx.commit();
+
+    restoreTransact = rejectNextTransact(runtime, {
+      name: "ConflictError",
+      message: "stale confirmed read: of:drop-predicate-result at seq 0 " +
+        "conflicted with seq 1",
+    });
+    // Hold the re-instantiation at its readiness gate, so the piece stays in
+    // the state under test for as long as the case needs it.
+    const parked = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    releaseRetry = release.resolve;
+    runtime.awaitCommitRetryReadiness = () => {
+      parked.resolve();
+      return release.promise;
+    };
+
+    await runtime.runner.start(resultCell);
+    await parked.promise;
+    return eventsCell.getAsNormalizedFullLink();
+  }
+
+  it("reports a piece whose graph is retired as started", async () => {
+    const eventsLink = await startPieceWithRetiredGraph();
+
+    expect(await ensurePieceRunning(runtime, eventsLink)).toBe(true);
+  });
+
+  it("defers a served event sent while its piece's graph is retired", async () => {
+    const eventsLink = await startPieceWithRetiredGraph();
+    const outcomes: ServedEventFailureOutcome[] = [];
+
+    runtime.scheduler.queueEvent(
+      eventsLink,
+      { type: "add-module" },
+      true,
+      undefined,
+      false,
+      {
+        eventId: "evt:add-module",
+        served: {
+          streamEntry: { sidecarId: "of:stream-events", index: 0, seq: 1 },
+          onFailure: (outcome) => outcomes.push(outcome),
+        },
+      },
+    );
+    await runtime.idle();
+
+    expect(handlerEvents).toEqual([]);
+    expect(outcomes).toEqual([{
+      kind: "deferred",
+      message: expect.any(String),
+    }]);
+  });
+
+  it("holds a later-arrived served event behind the deferred one", async () => {
+    const eventsLink = await startPieceWithRetiredGraph();
+    const followerLink: NormalizedFullLink = {
+      ...eventsLink,
+      id: "of:follower-stream",
+    };
+    const followerOutcomes: ServedEventFailureOutcome[] = [];
+    const followerEvents: unknown[] = [];
+    runtime.scheduler.addEventHandler((_tx, value) => {
+      followerEvents.push(value);
+    }, followerLink);
+
+    runtime.scheduler.queueEvent(
+      eventsLink,
+      { type: "add-module" },
+      true,
+      undefined,
+      false,
+      {
+        eventId: "evt:add-module",
+        served: {
+          streamEntry: { sidecarId: "of:stream-events", index: 0, seq: 1 },
+        },
+      },
+    );
+    runtime.scheduler.queueEvent(
+      followerLink,
+      { type: "follower" },
+      true,
+      undefined,
+      false,
+      {
+        eventId: "evt:follower",
+        served: {
+          streamEntry: { sidecarId: "of:stream-follower", index: 0, seq: 2 },
+          onFailure: (outcome) => followerOutcomes.push(outcome),
+        },
+      },
+    );
+    await runtime.idle();
+
+    expect(followerEvents).toEqual([]);
+    expect(followerOutcomes).toEqual([{
+      kind: "deferred",
+      cause: "arrival-barrier",
+      blockedBy: "evt:add-module",
+    }]);
+  });
+});

--- a/packages/runner/test/scheduler-event-identity.test.ts
+++ b/packages/runner/test/scheduler-event-identity.test.ts
@@ -1,5 +1,6 @@
 import type { MemorySpace } from "@commonfabric/memory/interface";
 
+import type { EnsurePieceVerdict } from "../src/ensure-piece-running.ts";
 import type { NormalizedFullLink } from "../src/link-utils.ts";
 import type { Runtime } from "../src/runtime.ts";
 import {
@@ -30,6 +31,12 @@ const eventLink: NormalizedFullLink = {
 
 function eventKey(id: string): string {
   return id.split(":")[1];
+}
+
+// A piece-start outcome for the `loadPieceForEvent` seam, carrying only what
+// these cases turn on: a started piece has its pattern graph installed.
+function pieceLoadVerdict(started: boolean): EnsurePieceVerdict {
+  return { started, graphIsInstalled: () => started, observedDocIds: [] };
 }
 
 describe("scheduler event identity", () => {
@@ -185,8 +192,8 @@ describe("scheduler event identity", () => {
     };
     const env = createSchedulerTestRuntime(import.meta.url);
     const handled: string[] = [];
-    let finishPieceLoad!: (started: boolean) => void;
-    const pieceLoad = new Promise<boolean>((resolve) => {
+    let finishPieceLoad!: (verdict: EnsurePieceVerdict) => void;
+    const pieceLoad = new Promise<EnsurePieceVerdict>((resolve) => {
       finishPieceLoad = resolve;
     });
     try {
@@ -194,7 +201,7 @@ describe("scheduler event identity", () => {
       // dispatch, commits, and continuation all run through the real Scheduler.
       const schedulerInternals = env.runtime.scheduler as unknown as {
         eventQueueState: {
-          loadPieceForEvent?: () => Promise<boolean>;
+          loadPieceForEvent?: () => Promise<EnsurePieceVerdict>;
         };
       };
       schedulerInternals.eventQueueState.loadPieceForEvent = () => pieceLoad;
@@ -213,12 +220,12 @@ describe("scheduler event identity", () => {
       env.runtime.scheduler.addEventHandler((_tx, value) => {
         handled.push(String(value));
       }, loadingLink);
-      finishPieceLoad(true);
+      finishPieceLoad(pieceLoadVerdict(true));
       await env.runtime.idle();
 
       expect(handled).toEqual(["first", "second"]);
     } finally {
-      finishPieceLoad(true);
+      finishPieceLoad(pieceLoadVerdict(true));
       await disposeSchedulerTestRuntime(env);
     }
   });
@@ -262,7 +269,7 @@ describe("scheduler event identity", () => {
   it("does not resurrect an event dropped while its handler is loading", async () => {
     const eventQueue: QueuedEvent[] = [];
     const backgroundTasks = new Set<Promise<unknown>>();
-    const pieceLoad = Promise.withResolvers<boolean>();
+    const pieceLoad = Promise.withResolvers<EnsurePieceVerdict>();
     let callbackCount = 0;
     const droppedTx = {
       abort: () => {},
@@ -291,7 +298,7 @@ describe("scheduler event identity", () => {
 
     dropQueuedEvent(state, queued, "lineage failed while loading");
     dropQueuedEvent(state, queued, "duplicate terminal notification");
-    pieceLoad.resolve(true);
+    pieceLoad.resolve(pieceLoadVerdict(true));
     await Promise.all([...backgroundTasks]);
 
     expect(eventQueue).toEqual([]);
@@ -306,7 +313,7 @@ describe("scheduler event identity", () => {
     for (
       const loadFailure of [
         () => Promise.reject(new Error("start failed")),
-        () => Promise.resolve(false),
+        () => Promise.resolve(pieceLoadVerdict(false)),
       ]
     ) {
       const eventQueue: QueuedEvent[] = [];


### PR DESCRIPTION
The scheduler, holding an event for a stream it finds no handler on, starts the owning piece and looks again. When the second look still found nothing, the first of its three arms settled the event as events.md section 5's drop: no consequence commits, and the sender is told the event will never run.

That arm read `ensurePieceRunning`'s `started`, which reports what the start walk did. The walk fires the piece's instantiation commit and returns without waiting for it. A refused commit is then recovered once under server execution: the runner retires the pattern graph that commit installed, waits for a caught-up view, and instantiates again, keeping the registration in place across the wait so the piece's owner keeps its cancellation handle. A refusal past that one recovery retires the registration outright instead. Either way the piece serves no handler on any of its streams while `start()` still reports it as running, so the arm could not tell a piece whose handler a raced commit retired from a piece that genuinely registers none for that stream.

events.md section 5 draws that line explicitly: an event drops when there is no runnable handler, "never the run raced". A handler retired by a raced commit is runnable and its event is fine, so the spec calls for a requeue where the code dropped.

The arm now asks whether the piece has a pattern graph installed rather than what its start reported. `Runner` publishes that as a read-only query, `pieceGraphIsInstalled`, answered from the live node cancellation each registration already carries; the piece-instantiate site is untouched. `ensurePieceRunningVerdict` hands its caller a probe for that query rather than a value, because the answer changes between the start returning and the scheduler reading it. A piece with no graph installed now takes the arm that was already there for a piece that could not be started: a served event defers, its durable entry stays pending for a later wave to re-drain, and every later-arrived served entry in the same space waits behind it under the barrier that holds arrival order; a client event keeps its existing drop.

The three new cases put one piece into that state deterministically. A hand-built pattern instantiates a child piece, so its instantiation carries durable writes and its commit can be refused at all; the emulated memory server refuses that one commit as a stale confirmed read; and the readiness gate the recovery waits on is held open for as long as the case needs. The first case pins the reason the arm cannot read `started` alone. The other two state the disposition: the served event defers rather than drops, and a later-arrived served event in the same space waits behind it.

This is what fails `record module chrome` in the server-execution pattern integration job. The `addModule` send that adds the photo module arrives while the piece it targets is between graphs, and being dropped rather than held it never runs, so the module list never grows and the test throws "the photo module was not added".

deflaked by Hixie's agent (Claude Opus 5)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6774?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

