### PR TITLE
fix(iframe-sandbox): order the guest port behind its parent posts

### DIFF
--- a/packages/iframe-sandbox/README.md
+++ b/packages/iframe-sandbox/README.md
@@ -248,6 +248,26 @@ directly to each guest; the outer frame does not relay capability traffic.
 parent so a guest can report failure before it has a working port. The host
 emits a `common-iframe-error` event.
 
+The alarm route and the port are separate channels, so a flush exchange puts
+what crossed before the port ahead of what crosses on it. The host announces the
+exchange ahead of each handoff; a guest that heard the announcement posts a
+nonce-carrying flush marker up the parent chain on taking its port, behind
+everything it posted there before, and holds its port traffic until the host
+echoes the nonce back over the port -- which the host does only once it has
+handled everything the relay carried ahead of the marker. An alarm raised before
+the guest's first write is therefore dispatched before that write lands. A guest
+whose host predates the exchange is never told about it, and sends unordered
+rather than waiting.
+
+A load report cannot be matched to a document: a guest can renavigate its own
+frame, and the inner frame's initial `about:blank` navigation can complete after
+a document was asked for, so reports do not stand one to one with the documents
+the host asks for. The host offers a fresh port per report and lets use decide
+which offer matters. A session's first request retires every session offered
+before it, and a guest already holding a port refuses the new offer rather than
+losing the session it has. Two offers are kept at most, which is what stops a
+guest renavigating its own frame from accumulating them.
+
 ## Security considerations
 
 - The bridge is capability-based, but every resource supplied to a frame is

--- a/packages/iframe-sandbox/src/bridge.ts
+++ b/packages/iframe-sandbox/src/bridge.ts
@@ -320,10 +320,26 @@ export class FabricBridgeHost {
   #nextCellHandle = 0;
   #operationTail: Promise<void> | undefined;
   #connected = true;
+  #firstRequestReported = false;
 
-  constructor(bridge: FabricBridge, port: MessagePort) {
+  readonly #onFirstRequest:
+    | ((session: FabricBridgeHost) => void)
+    | undefined;
+
+  /**
+   * Constructs an instance serving `bridge` over `port`. `onFirstRequest`,
+   * when supplied, is called once, ahead of handling the first valid request
+   * to arrive: a request proves the guest holds this session's port, which is
+   * what an embedder deciding between offered sessions needs to know.
+   */
+  constructor(
+    bridge: FabricBridge,
+    port: MessagePort,
+    onFirstRequest?: (session: FabricBridgeHost) => void,
+  ) {
     this.#bridge = bridge;
     this.#port = port;
+    this.#onFirstRequest = onFirstRequest;
     this.#port.onmessage = this.#onMessage;
     this.#port.start();
   }
@@ -342,6 +358,20 @@ export class FabricBridgeHost {
     this.#subscriptions.clear();
     this.#cells.clear();
     this.#port.close();
+  }
+
+  /**
+   * Sends the acknowledgement for a flush marker carrying `nonce`. A marker
+   * cannot say which session its guest holds, so an embedder answers every
+   * session it has open; only the guest that minted the nonce acts on it.
+   */
+  acknowledgeFlush(nonce: string): void {
+    this.#post({
+      protocol: BRIDGE_PROTOCOL,
+      version: BRIDGE_VERSION,
+      type: "flush",
+      nonce,
+    });
   }
 
   #post(message: BridgeHostMessage): void {
@@ -373,6 +403,10 @@ export class FabricBridgeHost {
       return;
     }
     if (!isBridgeRequest(decoded)) return;
+    if (!this.#firstRequestReported) {
+      this.#firstRequestReported = true;
+      this.#onFirstRequest?.(this);
+    }
     if (decoded.operation === "disconnect") {
       this.disconnect();
       return;

--- a/packages/iframe-sandbox/src/common-iframe-sandbox.ts
+++ b/packages/iframe-sandbox/src/common-iframe-sandbox.ts
@@ -2,6 +2,7 @@ import { css, html, LitElement, type PropertyValues } from "lit";
 import { property } from "lit/decorators.js";
 import { createRef, Ref, ref } from "lit/directives/ref.js";
 import { type FabricBridge, FabricBridgeHost } from "./bridge.ts";
+import { GuestSessions } from "./guest-sessions.ts";
 import * as IPC from "./ipc.ts";
 import OuterFrame from "./outer-frame.ts";
 
@@ -52,20 +53,8 @@ export class CommonIframeSandboxElement extends LitElement {
   #src = "";
   #bridge: FabricBridge | undefined;
 
-  /**
-   * The capability sessions on offer to the loaded guest, in offer order. One
-   * is offered per load report, and a load report cannot be matched to a
-   * document -- the inner frame's initial `about:blank` navigation can
-   * complete after a document was asked for, so one asked-for document can
-   * yield two reports. Which offer the guest holds is settled by use: a
-   * session's first request retires every session offered before it.
-   *
-   * Two entries is the most this holds. The guest takes the first port to
-   * reach a document of its that has none, so the session it holds is the
-   * earliest one still here, and everything offered after that one was
-   * refused.
-   */
-  #guestSessions: FabricBridgeHost[] = [];
+  /** The capability sessions on offer to the loaded guest. */
+  #guestSessions = new GuestSessions<FabricBridgeHost>();
 
   /**
    * The frame this element renders, held so the guest can be reached through
@@ -118,10 +107,10 @@ export class CommonIframeSandboxElement extends LitElement {
 
   /**
    * Offers the loaded guest one end of a fresh channel and takes the other.
-   * Each document is its own realm, so each gets a port of its own. A session
-   * already on offer stays as it is: whether this offer reaches a new document
-   * or one already holding a port -- which refuses it -- is settled by which
-   * session the guest's requests arrive on, not here.
+   * Each document is its own realm, so each gets a port of its own. Whether
+   * this offer reaches a new document or one already holding a port -- which
+   * refuses it -- is settled by which session the guest's requests arrive on;
+   * `GuestSessions` holds what that leaves undecided.
    */
   #openGuestPort() {
     // The guest is the inner frame, which is a frame of the outer one. A
@@ -133,56 +122,16 @@ export class CommonIframeSandboxElement extends LitElement {
       return;
     }
 
-    // A guest can renavigate its own frame, and each navigation reports a
-    // load, so what is kept here has to be bounded by something other than
-    // the guest's restraint. Two are kept: the first, which is the one a guest
-    // that has held a port since before any of this took, and the newest,
-    // which is the only other one still reachable. Dropping what was newest
-    // costs a guest that took that offer, has never spoken on it, and is still
-    // there after a further load report -- which is a document driving
-    // navigations while staying silent about the port it holds.
-    for (const superseded of this.#guestSessions.splice(1)) {
-      superseded.disconnect();
-    }
-
     const channel = new MessageChannel();
-    this.#guestSessions.push(
+    this.#guestSessions.offer(
       new FabricBridgeHost(
         this.bridge ?? { resources: {} },
         channel.port1,
-        (session) => this.#retireSessionsBefore(session),
+        (session) => this.#guestSessions.retireBefore(session),
       ),
     );
     guestWindow.postMessage(IPC.GUEST_PORT_ORDERED, "*");
     guestWindow.postMessage(IPC.GUEST_PORT_HANDOFF, "*", [channel.port2]);
-  }
-
-  /**
-   * Retires every session offered before `session`, which has shown the first
-   * request of its port. The guest holds one port, so a request on this
-   * session says every earlier offer went to a document that is gone or was
-   * refused; either way those sessions serve nobody, and closing them is what
-   * cancels a gone document's subscriptions. Later offers are left alone: a
-   * session is never unseated by an earlier one.
-   */
-  #retireSessionsBefore(session: FabricBridgeHost) {
-    const index = this.#guestSessions.indexOf(session);
-    if (index <= 0) return;
-    for (const retired of this.#guestSessions.splice(0, index)) {
-      retired.disconnect();
-    }
-  }
-
-  /**
-   * Closes every session on offer. What the guest sends afterwards reaches
-   * nothing, which is the point: the guest on the other end of a closed port
-   * is one this element is done with.
-   */
-  #closeGuestPort() {
-    for (const session of this.#guestSessions) {
-      session.disconnect();
-    }
-    this.#guestSessions = [];
   }
 
   /** Handles a message from the outer frame. */
@@ -226,7 +175,7 @@ export class CommonIframeSandboxElement extends LitElement {
           // cannot say which session its guest holds, so every session on
           // offer carries the answer; the nonce sees to it that only the
           // guest that posted this marker acts on one.
-          for (const session of this.#guestSessions) {
+          for (const session of this.#guestSessions.offered) {
             session.acknowledgeFlush(raised.nonce);
           }
         } else if (IPC.isGuestAlarm(raised)) {
@@ -278,7 +227,7 @@ export class CommonIframeSandboxElement extends LitElement {
    * holding it has gone.
    */
   #releaseGuest() {
-    this.#closeGuestPort();
+    this.#guestSessions.closeAll();
   }
 
   /**

--- a/packages/iframe-sandbox/src/common-iframe-sandbox.ts
+++ b/packages/iframe-sandbox/src/common-iframe-sandbox.ts
@@ -1,4 +1,4 @@
-import { css, html, LitElement } from "lit";
+import { css, html, LitElement, type PropertyValues } from "lit";
 import { property } from "lit/decorators.js";
 import { createRef, Ref, ref } from "lit/directives/ref.js";
 import { type FabricBridge, FabricBridgeHost } from "./bridge.ts";
@@ -23,9 +23,6 @@ export class CommonIframeSandboxElement extends LitElement {
     const previousValue = this.#src;
     this.#src = value;
     this.requestUpdate("src", previousValue);
-    if (this.readyWindow && value !== previousValue) {
-      this.#loadInnerDoc();
-    }
   }
 
   get bridge(): FabricBridge | undefined {
@@ -37,9 +34,6 @@ export class CommonIframeSandboxElement extends LitElement {
     const previousValue = this.#bridge;
     this.#bridge = value;
     this.requestUpdate("bridge", previousValue);
-    if (this.readyWindow && value !== previousValue && this.src) {
-      this.#loadInnerDoc();
-    }
   }
 
   @property({ attribute: "load-state", reflect: true })
@@ -58,8 +52,20 @@ export class CommonIframeSandboxElement extends LitElement {
   #src = "";
   #bridge: FabricBridge | undefined;
 
-  /** The capability session belonging to the currently loaded guest. */
-  #guestHost: FabricBridgeHost | undefined;
+  /**
+   * The capability sessions on offer to the loaded guest, in offer order. One
+   * is offered per load report, and a load report cannot be matched to a
+   * document -- the inner frame's initial `about:blank` navigation can
+   * complete after a document was asked for, so one asked-for document can
+   * yield two reports. Which offer the guest holds is settled by use: a
+   * session's first request retires every session offered before it.
+   *
+   * Two entries is the most this holds. The guest takes the first port to
+   * reach a document of its that has none, so the session it holds is the
+   * earliest one still here, and everything offered after that one was
+   * refused.
+   */
+  #guestSessions: FabricBridgeHost[] = [];
 
   /**
    * The frame this element renders, held so the guest can be reached through
@@ -111,13 +117,13 @@ export class CommonIframeSandboxElement extends LitElement {
   }
 
   /**
-   * Gives the newly loaded guest one end of a fresh channel and takes the
-   * other. Each document is its own realm, so each gets a port of its own, and
-   * no earlier one is left open behind it.
+   * Offers the loaded guest one end of a fresh channel and takes the other.
+   * Each document is its own realm, so each gets a port of its own. A session
+   * already on offer stays as it is: whether this offer reaches a new document
+   * or one already holding a port -- which refuses it -- is settled by which
+   * session the guest's requests arrive on, not here.
    */
   #openGuestPort() {
-    this.#closeGuestPort();
-
     // The guest is the inner frame, which is a frame of the outer one. A
     // cross-origin frame is unreachable for anything but this: indexed access
     // and `postMessage`, which is what a transfer rides.
@@ -127,22 +133,56 @@ export class CommonIframeSandboxElement extends LitElement {
       return;
     }
 
+    // A guest can renavigate its own frame, and each navigation reports a
+    // load, so what is kept here has to be bounded by something other than
+    // the guest's restraint. Two are kept: the first, which is the one a guest
+    // that has held a port since before any of this took, and the newest,
+    // which is the only other one still reachable. Dropping what was newest
+    // costs a guest that took that offer, has never spoken on it, and is still
+    // there after a further load report -- which is a document driving
+    // navigations while staying silent about the port it holds.
+    for (const superseded of this.#guestSessions.splice(1)) {
+      superseded.disconnect();
+    }
+
     const channel = new MessageChannel();
-    this.#guestHost = new FabricBridgeHost(
-      this.bridge ?? { resources: {} },
-      channel.port1,
+    this.#guestSessions.push(
+      new FabricBridgeHost(
+        this.bridge ?? { resources: {} },
+        channel.port1,
+        (session) => this.#retireSessionsBefore(session),
+      ),
     );
+    guestWindow.postMessage(IPC.GUEST_PORT_ORDERED, "*");
     guestWindow.postMessage(IPC.GUEST_PORT_HANDOFF, "*", [channel.port2]);
   }
 
   /**
-   * Closes the port to the current guest, if there is one. What the guest sends
-   * afterwards reaches nothing, which is the point: the guest on the other end
-   * of a closed port is one this element is done with.
+   * Retires every session offered before `session`, which has shown the first
+   * request of its port. The guest holds one port, so a request on this
+   * session says every earlier offer went to a document that is gone or was
+   * refused; either way those sessions serve nobody, and closing them is what
+   * cancels a gone document's subscriptions. Later offers are left alone: a
+   * session is never unseated by an earlier one.
+   */
+  #retireSessionsBefore(session: FabricBridgeHost) {
+    const index = this.#guestSessions.indexOf(session);
+    if (index <= 0) return;
+    for (const retired of this.#guestSessions.splice(0, index)) {
+      retired.disconnect();
+    }
+  }
+
+  /**
+   * Closes every session on offer. What the guest sends afterwards reaches
+   * nothing, which is the point: the guest on the other end of a closed port
+   * is one this element is done with.
    */
   #closeGuestPort() {
-    this.#guestHost?.disconnect();
-    this.#guestHost = undefined;
+    for (const session of this.#guestSessions) {
+      session.disconnect();
+    }
+    this.#guestSessions = [];
   }
 
   /** Handles a message from the outer frame. */
@@ -180,7 +220,16 @@ export class CommonIframeSandboxElement extends LitElement {
         // it along without reading it, so this is the first look anything has
         // had at it.
         const raised = outerMessage.data;
-        if (IPC.isGuestAlarm(raised)) {
+        if (IPC.isGuestFlush(raised)) {
+          // Everything the relay carried ahead of this marker has been
+          // handled, which is what the acknowledgement asserts. A marker
+          // cannot say which session its guest holds, so every session on
+          // offer carries the answer; the nonce sees to it that only the
+          // guest that posted this marker acts on one.
+          for (const session of this.#guestSessions) {
+            session.acknowledgeFlush(raised.nonce);
+          }
+        } else if (IPC.isGuestAlarm(raised)) {
           this.#dispatchGuestError(raised.data);
         } else {
           console.error(
@@ -269,6 +318,21 @@ export class CommonIframeSandboxElement extends LitElement {
     queueMicrotask(() => {
       if (!this.isConnected) this.#releaseGuest();
     });
+  }
+
+  /**
+   * Reloads on a change to `src` or `bridge`, once the frame is ready; until
+   * then `onOuterReady` does the first load. Reacting here rather than in the
+   * setters folds a batch of changes into one load: assigning both properties
+   * asks for one document, carrying both new values, rather than reloading
+   * the old document under the new bridge on the way.
+   */
+  protected override updated(changed: PropertyValues) {
+    super.updated(changed);
+    if (!this.readyWindow) return;
+    if (changed.has("src") || (changed.has("bridge") && this.src)) {
+      this.#loadInnerDoc();
+    }
   }
 
   /** @inheritDoc */

--- a/packages/iframe-sandbox/src/guest-sessions.ts
+++ b/packages/iframe-sandbox/src/guest-sessions.ts
@@ -1,0 +1,82 @@
+/**
+ * Decides which of the capability sessions offered to one guest frame is the
+ * one that matters. A session is offered per load report, and a load report
+ * cannot be matched to a document: a guest can renavigate its own frame, and
+ * the inner frame's initial `about:blank` navigation can complete after a
+ * document was asked for, so the reports do not stand one to one with the
+ * documents the host asks for. What settles it is use rather than counting.
+ */
+
+/** A capability session, as far as deciding between offers is concerned. */
+export type OfferedSession = {
+  /** Cancels the session's subscriptions and closes its port. */
+  disconnect(): void;
+};
+
+/**
+ * The sessions on offer to one guest frame, in offer order.
+ *
+ * Two entries is the most this holds. A guest takes the first port to reach a
+ * document of its that has none, so the session it holds is the earliest one
+ * still here, and everything offered after that one was refused.
+ */
+export class GuestSessions<T extends OfferedSession = OfferedSession> {
+  #offered: T[] = [];
+
+  /** The sessions on offer, oldest first. */
+  get offered(): readonly T[] {
+    return this.#offered;
+  }
+
+  /**
+   * Takes `session` as the newest offer, disconnecting any offer that is
+   * neither the first nor this one.
+   *
+   * A guest can renavigate its own frame, and each navigation reports a load,
+   * so what is held has to be bounded by something other than the guest's
+   * restraint. The first offer is kept because a guest that has held a port
+   * since before any of this holds that one; the newest is kept because it is
+   * the only other one still reachable. Dropping what was newest costs a guest
+   * that took that offer, has never spoken on it, and is still there after a
+   * further load report -- a document driving navigations while staying silent
+   * about the port it holds.
+   */
+  offer(session: T): void {
+    for (const superseded of this.#offered.splice(1)) {
+      superseded.disconnect();
+    }
+    this.#offered.push(session);
+  }
+
+  /**
+   * Retires every session offered before `session`, which has shown the first
+   * request of its port, and returns whether any were.
+   *
+   * The guest holds one port, so a request on this session says every earlier
+   * offer went to a document that is gone or was refused. Either way those
+   * sessions serve nobody, and disconnecting them is what cancels a gone
+   * document's subscriptions. Later offers are left alone, and so is a session
+   * this does not hold: a session is never unseated by an earlier one.
+   */
+  retireBefore(session: T): boolean {
+    const index = this.#offered.indexOf(session);
+    if (index <= 0) return false;
+    for (const retired of this.#offered.splice(0, index)) {
+      retired.disconnect();
+    }
+    return true;
+  }
+
+  /**
+   * Disconnects every session on offer and forgets them. What the guest sends
+   * afterwards reaches nothing, which is the point: the guest on the other end
+   * of a closed port is one the host is done with.
+   */
+  closeAll(): void {
+    const closing = this.#offered;
+    this.#offered = [];
+    for (const session of closing) {
+      session.disconnect();
+    }
+  }
+}

--- a/packages/iframe-sandbox/src/guest.ts
+++ b/packages/iframe-sandbox/src/guest.ts
@@ -24,8 +24,11 @@ import {
   type BridgeOperation,
   type BridgeRequest,
   type BridgeResolvedCell,
+  flushNonce,
   GUEST_PORT_HANDOFF,
+  GUEST_PORT_ORDERED,
   type GuestError,
+  type GuestFlush,
   isBridgeHostMessage,
 } from "./ipc.ts";
 
@@ -485,6 +488,8 @@ type Subscription = {
 /** Guest connection to the resources granted by the embedding host. */
 export class FabricClient {
   #port: MessagePort | undefined;
+  #ordered = false;
+  #awaitingFlushAck: string | undefined;
   #nextRequestId = 0;
   #nextSubscriptionId = 0;
   #pending = new Map<number, PendingRequest>();
@@ -649,21 +654,25 @@ export class FabricClient {
       operation,
       ...fields,
     };
+    // A call queues while there is no port, and while the port waits on the
+    // flush acknowledgement that puts it behind the guest's earlier
+    // parent-chain posts.
+    const queues = !this.#port || this.#awaitingFlushAck !== undefined;
     let encoded: EncodedBridgeRequest;
     try {
       encoded = realmFromFabricValue(request);
-      // `postMessage()` snapshots at send time. Queued calls have no port yet,
-      // so they snapshot the encoded form at invocation time instead of
-      // retaining caller-owned objects by reference until capability handoff.
-      if (!this.#port) encoded = structuredClone(encoded);
+      // `postMessage()` snapshots at send time. A queued call is not sent yet,
+      // so it snapshots the encoded form at invocation time instead of
+      // retaining caller-owned objects by reference until it is.
+      if (queues) encoded = structuredClone(encoded);
     } catch (cause) {
       return Promise.reject(cause);
     }
     const result = Promise.withResolvers<FabricValue | undefined>();
     result.promise.catch(() => {});
     this.#pending.set(id, result);
-    if (this.#port) this.#sendPending(id, encoded);
-    else this.#queued.push({ id, encoded });
+    if (queues) this.#queued.push({ id, encoded });
+    else this.#sendPending(id, encoded);
     return result.promise;
   }
 
@@ -738,6 +747,7 @@ export class FabricClient {
     this.#manifest = undefined;
     this.#cellOperationQueues.clear();
     this.#queued = [];
+    this.#awaitingFlushAck = undefined;
   }
 
   #send(request: BridgeRequest): void {
@@ -758,21 +768,47 @@ export class FabricClient {
   #onHandoff = (event: MessageEvent): void => {
     // The host owns the outer frame and posts directly to this inner guest, so
     // it is two parent hops away. The guest has an opaque origin and cannot
-    // origin-check that post, but it can still refuse a port offered by any
+    // origin-check that post, but it can still refuse a message sent by any
     // other window.
     const expectedHost = globalThis.parent?.parent;
-    if (
-      this.#port || event.data !== GUEST_PORT_HANDOFF || !event.ports[0] ||
-      (expectedHost && event.source !== expectedHost)
-    ) return;
+    if (expectedHost && event.source !== expectedHost) return;
+    if (event.data === GUEST_PORT_ORDERED) {
+      this.#ordered = true;
+      return;
+    }
+    if (this.#port || event.data !== GUEST_PORT_HANDOFF || !event.ports[0]) {
+      return;
+    }
     this.#port = event.ports[0];
     this.#port.onmessage = this.#onPortMessage;
     this.#port.start();
-    for (const request of this.#queued) {
+    const parent: Window | undefined = globalThis.parent;
+    if (this.#ordered && parent) {
+      // The marker rides the parent chain behind everything this guest posted
+      // there before its port, and port traffic holds until the host answers
+      // it -- which the host does only once the relay is handled up to the
+      // marker. That puts every pre-port post ahead of every port request.
+      this.#awaitingFlushAck = flushNonce();
+      parent.postMessage(
+        {
+          type: "flush",
+          nonce: this.#awaitingFlushAck,
+        } satisfies GuestFlush,
+        "*",
+      );
+    } else {
+      this.#flushQueued();
+    }
+  };
+
+  /** Sends every queued request, in the order the calls were made. */
+  #flushQueued(): void {
+    const queued = this.#queued;
+    this.#queued = [];
+    for (const request of queued) {
       this.#sendPending(request.id, request.encoded);
     }
-    this.#queued = [];
-  };
+  }
 
   #onPortMessage = (event: MessageEvent): void => {
     let decoded: FabricValue;
@@ -788,6 +824,18 @@ export class FabricClient {
   #accept(message: BridgeHostMessage): void {
     if (message.type === "event") {
       this.#subscriptions.get(message.subscription)?.update(message.value);
+      return;
+    }
+    if (message.type === "flush") {
+      // Only the acknowledgement echoing this guest's own nonce opens its
+      // port traffic; one answering another document's marker does not.
+      if (
+        this.#awaitingFlushAck !== undefined &&
+        message.nonce === this.#awaitingFlushAck
+      ) {
+        this.#awaitingFlushAck = undefined;
+        this.#flushQueued();
+      }
       return;
     }
     const pending = this.#pending.get(message.id);

--- a/packages/iframe-sandbox/src/ipc.ts
+++ b/packages/iframe-sandbox/src/ipc.ts
@@ -15,7 +15,9 @@ import type { FabricValue } from "@commonfabric/data-model";
 //         │                       ├────────srcdoc─────────►│
 //         │◄─────────LOAD─────────┤                        │
 //         │                       │                        │
+//         ├──────────────────ORDERED──────────────────────►│
 //         ├──────────────────PORT (transferred)───────────►│
+//         │◄──────FLUSH───────────┤◄───────(unread)────────┤
 //         │◄═════════════════════ port ═══════════════════►│
 //         │                       │                        │
 //         │◄──────ERROR───────────┤◄───────(unread)────────┤
@@ -28,6 +30,24 @@ import type { FabricValue } from "@commonfabric/data-model";
 // forwards without reading. A guest has a port for everything it means to say,
 // so a message arriving by that route is a guest reporting that it could not
 // use the port -- a way to raise an alarm, not a second way to talk.
+//
+// The relayed route and the port are separate channels, and nothing orders one
+// against the other. The `ORDERED`/`FLUSH` exchange is the rendezvous that
+// still puts what crossed before the port ahead of what crosses on it: the
+// host posts `ORDERED` ahead of the port to say it answers flush markers, and
+// a guest that heard it posts a `FLUSH` marker up the parent chain on taking
+// the port -- behind everything it posted there before -- and holds its port
+// traffic until the marker's acknowledgement comes back over the port. The
+// host acknowledges a marker only after handling everything the relay carried
+// ahead of it, so by the time any port request lands, every parent post the
+// guest made before taking its port has been handled.
+//
+// A guest that never heard `ORDERED` sends unordered rather than waiting,
+// which is what lets a guest and a host of different vintages pair up. What
+// answers a marker is the element's live set of sessions, so a guest whose
+// marker arrives after the element let go of its session holds its traffic
+// from then on. That guest is one the element has already stopped listening
+// to, on a port it has already closed.
 
 /**
  * Sent alongside the transferred port, so a guest recognizes the handoff by
@@ -35,6 +55,29 @@ import type { FabricValue } from "@commonfabric/data-model";
  * as a candidate.
  */
 export const GUEST_PORT_HANDOFF = "common-iframe-sandbox:port";
+
+/**
+ * Posted to the guest ahead of `GUEST_PORT_HANDOFF` to say the host answers
+ * flush markers. A guest that heard this before its handoff holds its port
+ * traffic behind the marker exchange; one that did not sends unordered, so
+ * neither side of a mixed pairing waits on an answer that cannot come.
+ */
+export const GUEST_PORT_ORDERED = "common-iframe-sandbox:ordered";
+
+/** Length in bytes of the random part of a flush marker's nonce. */
+const FLUSH_NONCE_BYTES = 8;
+
+/**
+ * Returns a nonce for a flush marker. It has to be unique among the markers
+ * one host element hears between teardowns, and `crypto.getRandomValues()` is
+ * available to a guest whether or not its document is a secure context.
+ */
+export function flushNonce(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(FLUSH_NONCE_BYTES));
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join(
+    "",
+  );
+}
 
 export enum IPCHostMessageType {
   // Host instructing the outer frame to load a new document.
@@ -111,6 +154,9 @@ export const BRIDGE_PROTOCOL = "common-fabric-bridge";
  * Exact encoding revision. An additive operation stays within this revision
  * only when a current guest negotiates it through describe() before sending
  * it, so an older host can reject the unsupported capability without hanging.
+ * The flush exchange is negotiated the same way through `GUEST_PORT_ORDERED`:
+ * a guest waits on an acknowledgement only from a host that announced it
+ * sends one.
  */
 export const BRIDGE_VERSION = 2;
 
@@ -219,7 +265,19 @@ export type BridgeEvent = {
   value?: FabricValue;
 };
 
-export type BridgeHostMessage = BridgeResponse | BridgeEvent;
+/**
+ * Acknowledges a flush marker, echoing its nonce. Sent over the port once the
+ * host has handled everything the parent-chain relay carried ahead of the
+ * marker; the guest holding that nonce releases its port traffic on it.
+ */
+export type BridgeFlushAck = {
+  protocol: typeof BRIDGE_PROTOCOL;
+  version: typeof BRIDGE_VERSION;
+  type: "flush";
+  nonce: string;
+};
+
+export type BridgeHostMessage = BridgeResponse | BridgeEvent | BridgeFlushAck;
 
 const hasBridgeHeader = (
   message: unknown,
@@ -281,6 +339,9 @@ export function isBridgeHostMessage(
   if (message.type === "event") {
     return typeof message.subscription === "string";
   }
+  if (message.type === "flush") {
+    return typeof message.nonce === "string";
+  }
   if (
     message.type !== "response" || !Number.isSafeInteger(message.id) ||
     typeof message.ok !== "boolean"
@@ -299,4 +360,19 @@ export function isGuestAlarm(message: unknown): message is GuestAlarm {
   return typeof message === "object" && message !== null &&
     (message as { type?: unknown }).type === "error" &&
     "data" in message && isGuestError(message.data as object);
+}
+
+/**
+ * Flush marker a guest posts up the parent chain on taking its port, behind
+ * everything it posted there before. The nonce is the guest's own token: the
+ * acknowledgement echoes it, and only the guest that minted it acts on the
+ * echo, so an acknowledgement broadcast wider than one session -- or answering
+ * an earlier document's marker -- releases nobody else's traffic.
+ */
+export type GuestFlush = { type: "flush"; nonce: string };
+
+export function isGuestFlush(message: unknown): message is GuestFlush {
+  return typeof message === "object" && message !== null &&
+    (message as { type?: unknown }).type === "flush" &&
+    typeof (message as { nonce?: unknown }).nonce === "string";
 }

--- a/packages/iframe-sandbox/test/bridge.test.ts
+++ b/packages/iframe-sandbox/test/bridge.test.ts
@@ -3,6 +3,7 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import type { FabricValue } from "@commonfabric/data-model";
+import { fabricFromRealmValue } from "@commonfabric/data-model/codecs";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 
 import {
@@ -13,7 +14,12 @@ import {
   FabricBridgeHost,
 } from "../src/bridge.ts";
 import { connectFabric } from "../src/guest.ts";
-import { type BridgeResolvedCell, GUEST_PORT_HANDOFF } from "../src/ipc.ts";
+import {
+  BRIDGE_PROTOCOL,
+  BRIDGE_VERSION,
+  type BridgeResolvedCell,
+  GUEST_PORT_HANDOFF,
+} from "../src/ipc.ts";
 
 function handOff(port: MessagePort): void {
   globalThis.dispatchEvent(
@@ -997,6 +1003,53 @@ describe("Fabric iframe bridge", () => {
       });
     } finally {
       client.disconnect();
+      host.disconnect();
+    }
+  });
+
+  it("reports the first valid request once", async () => {
+    const channel = new MessageChannel();
+    const reported: FabricBridgeHost[] = [];
+    const host = new FabricBridgeHost(
+      createFabricBridge({ count: cellResource(() => 1) }),
+      channel.port1,
+      (session) => reported.push(session),
+    );
+    const client = connectFabric();
+    handOff(channel.port2);
+
+    try {
+      await expect(client.cell<number>("count").pull()).resolves.toBe(1);
+      await expect(client.cell<number>("count").pull()).resolves.toBe(1);
+      expect(reported.length).toBe(1);
+      expect(reported[0]).toBe(host);
+    } finally {
+      client.disconnect();
+      host.disconnect();
+    }
+  });
+
+  it("acknowledges a flush to the guest port", async () => {
+    const channel = new MessageChannel();
+    const host = new FabricBridgeHost(
+      createFabricBridge({}),
+      channel.port1,
+    );
+
+    try {
+      const arriving = new Promise((resolve) => {
+        channel.port2.onmessage = (event) =>
+          resolve(fabricFromRealmValue(event.data));
+        channel.port2.start();
+      });
+      host.acknowledgeFlush("n1");
+      await expect(arriving).resolves.toEqual({
+        protocol: BRIDGE_PROTOCOL,
+        version: BRIDGE_VERSION,
+        type: "flush",
+        nonce: "n1",
+      });
+    } finally {
       host.disconnect();
     }
   });

--- a/packages/iframe-sandbox/test/guest-sessions.test.ts
+++ b/packages/iframe-sandbox/test/guest-sessions.test.ts
@@ -1,0 +1,164 @@
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import { GuestSessions, type OfferedSession } from "../src/guest-sessions.ts";
+
+/** A session that records whether it was disconnected, and how often. */
+class FakeSession implements OfferedSession {
+  disconnects = 0;
+
+  constructor(readonly name: string) {}
+
+  disconnect(): void {
+    this.disconnects++;
+  }
+}
+
+function names(sessions: readonly FakeSession[]): string[] {
+  return sessions.map((session) => session.name);
+}
+
+describe("GuestSessions", () => {
+  describe("offer()", () => {
+    it("keeps a single offer", () => {
+      const sessions = new GuestSessions<FakeSession>();
+      const first = new FakeSession("first");
+      sessions.offer(first);
+      expect(names(sessions.offered)).toEqual(["first"]);
+      expect(first.disconnects).toBe(0);
+    });
+
+    it("keeps both offers when a second arrives", () => {
+      // The guest may be holding either one at this point: the first if it was
+      // already there, the second if the first went to a document that is
+      // gone. Neither is disconnected until something says which.
+      const sessions = new GuestSessions<FakeSession>();
+      const first = new FakeSession("first");
+      const second = new FakeSession("second");
+      sessions.offer(first);
+      sessions.offer(second);
+      expect(names(sessions.offered)).toEqual(["first", "second"]);
+      expect(first.disconnects).toBe(0);
+      expect(second.disconnects).toBe(0);
+    });
+
+    it("disconnects the offer that was newest when a third arrives", () => {
+      const sessions = new GuestSessions<FakeSession>();
+      const first = new FakeSession("first");
+      const second = new FakeSession("second");
+      const third = new FakeSession("third");
+      sessions.offer(first);
+      sessions.offer(second);
+      sessions.offer(third);
+      expect(names(sessions.offered)).toEqual(["first", "third"]);
+      expect(second.disconnects).toBe(1);
+      expect(first.disconnects).toBe(0);
+      expect(third.disconnects).toBe(0);
+    });
+
+    it("holds two however many offers arrive", () => {
+      // A guest renavigating its own frame reports a load each time, and each
+      // report offers a session, so the bound is what keeps a guest from
+      // accumulating them.
+      const sessions = new GuestSessions<FakeSession>();
+      const offered: FakeSession[] = [];
+      for (let index = 0; index < 20; index++) {
+        const session = new FakeSession(`session-${index}`);
+        offered.push(session);
+        sessions.offer(session);
+      }
+      expect(names(sessions.offered)).toEqual(["session-0", "session-19"]);
+      expect(offered.filter((session) => session.disconnects === 0).length)
+        .toBe(2);
+    });
+  });
+
+  describe("retireBefore()", () => {
+    it("returns `false` and keeps every offer for the oldest session", () => {
+      // The oldest session speaking says nothing about the others: an offer
+      // made after it may still be waiting for the document that takes it.
+      const sessions = new GuestSessions<FakeSession>();
+      const first = new FakeSession("first");
+      const second = new FakeSession("second");
+      sessions.offer(first);
+      sessions.offer(second);
+      expect(sessions.retireBefore(first)).toBe(false);
+      expect(names(sessions.offered)).toEqual(["first", "second"]);
+      expect(first.disconnects).toBe(0);
+      expect(second.disconnects).toBe(0);
+    });
+
+    it("disconnects the offers made before the session that spoke", () => {
+      const sessions = new GuestSessions<FakeSession>();
+      const first = new FakeSession("first");
+      const second = new FakeSession("second");
+      sessions.offer(first);
+      sessions.offer(second);
+      expect(sessions.retireBefore(second)).toBe(true);
+      expect(names(sessions.offered)).toEqual(["second"]);
+      expect(first.disconnects).toBe(1);
+      expect(second.disconnects).toBe(0);
+    });
+
+    it("returns `false` for a session it does not hold", () => {
+      const sessions = new GuestSessions<FakeSession>();
+      const held = new FakeSession("held");
+      const stranger = new FakeSession("stranger");
+      sessions.offer(held);
+      expect(sessions.retireBefore(stranger)).toBe(false);
+      expect(names(sessions.offered)).toEqual(["held"]);
+      expect(held.disconnects).toBe(0);
+      expect(stranger.disconnects).toBe(0);
+    });
+
+    it("leaves nothing to retire when called twice", () => {
+      const sessions = new GuestSessions<FakeSession>();
+      const first = new FakeSession("first");
+      const second = new FakeSession("second");
+      sessions.offer(first);
+      sessions.offer(second);
+      sessions.retireBefore(second);
+      expect(sessions.retireBefore(second)).toBe(false);
+      expect(first.disconnects).toBe(1);
+    });
+  });
+
+  describe("closeAll()", () => {
+    it("disconnects every offer and forgets them", () => {
+      const sessions = new GuestSessions<FakeSession>();
+      const first = new FakeSession("first");
+      const second = new FakeSession("second");
+      sessions.offer(first);
+      sessions.offer(second);
+      sessions.closeAll();
+      expect(names(sessions.offered)).toEqual([]);
+      expect(first.disconnects).toBe(1);
+      expect(second.disconnects).toBe(1);
+    });
+
+    it("disconnects nothing a second time", () => {
+      const sessions = new GuestSessions<FakeSession>();
+      const only = new FakeSession("only");
+      sessions.offer(only);
+      sessions.closeAll();
+      sessions.closeAll();
+      expect(only.disconnects).toBe(1);
+    });
+
+    it("forgets the offers before disconnecting them", () => {
+      // A disconnect can reach back here -- closing a port is what makes a
+      // guest's session end, and the element closes sessions while tearing
+      // down -- so what it finds has to be the emptied list rather than the
+      // one being walked.
+      const sessions = new GuestSessions<OfferedSession>();
+      let seenDuringDisconnect: number | undefined;
+      sessions.offer({
+        disconnect: () => {
+          seenDuringDisconnect = sessions.offered.length;
+        },
+      });
+      sessions.closeAll();
+      expect(seenDuringDisconnect).toBe(0);
+    });
+  });
+});

--- a/packages/iframe-sandbox/test/guest.test.ts
+++ b/packages/iframe-sandbox/test/guest.test.ts
@@ -35,6 +35,29 @@ function handOffPort(): MessagePort {
   return channel.port1;
 }
 
+function event(subscription: string, value?: FabricValue): BridgeHostMessage {
+  return {
+    protocol: BRIDGE_PROTOCOL,
+    version: BRIDGE_VERSION,
+    type: "event",
+    subscription,
+    ...(value !== undefined && { value }),
+  };
+}
+
+// Resolves once the guest has handled everything already sent to it. One port
+// delivers in the order things were posted, so a round trip whose request the
+// guest sends after those messages is only answered once they are handled.
+async function settleAfterEvent(
+  fabric: FabricClient,
+  port: MessagePort,
+): Promise<void> {
+  const fence = fabric.request("pull", { resource: "fence", path: [] });
+  const request = await receive(port);
+  send(port, response(request.id));
+  await fence;
+}
+
 function receive(port: MessagePort): Promise<BridgeRequest> {
   return new Promise((resolve) => {
     port.addEventListener("message", (event) => {
@@ -198,6 +221,56 @@ describe("guest", () => {
         fabric.disconnect();
         await pulling?.catch(() => {});
         Reflect.set(globalThis, "parent", originalParent);
+      }
+    });
+
+    it("keeps the port it has when a second one is offered", async () => {
+      // The host offers a port per load report and cannot tell which document
+      // a report belongs to, so a guest that already has one is offered
+      // another. Keeping the first is what makes the extra offer harmless.
+      const fabric = connectFabric();
+      const held = handOffPort();
+      const replacement = new MessageChannel();
+      const toReplacement: unknown[] = [];
+      replacement.port1.addEventListener(
+        "message",
+        (event) => toReplacement.push((event as MessageEvent).data),
+      );
+      replacement.port1.start();
+      try {
+        globalThis.dispatchEvent(
+          new MessageEvent("message", {
+            data: GUEST_PORT_HANDOFF,
+            ports: [replacement.port2],
+          }),
+        );
+
+        const pulling = fabric.cell<number>("count").pull();
+        const request = await receive(held);
+        expect(request.operation).toBe("pull");
+        send(held, response(request.id, 5));
+        expect(await pulling).toBe(5);
+        expect(toReplacement).toEqual([]);
+      } finally {
+        fabric.disconnect();
+        replacement.port1.close();
+      }
+    });
+
+    it("ignores a message from the host that offers no port", async () => {
+      const fabric = connectFabric();
+      try {
+        globalThis.dispatchEvent(
+          new MessageEvent("message", { data: "something else" }),
+        );
+        const pulling = fabric.cell<number>("count").pull();
+        const host = handOffPort();
+        const request = await receive(host);
+        expect(request.operation).toBe("pull");
+        send(host, response(request.id, 5));
+        expect(await pulling).toBe(5);
+      } finally {
+        fabric.disconnect();
       }
     });
 
@@ -980,6 +1053,130 @@ describe("guest", () => {
         name: "FabricBridgeError",
         code: "disconnected",
       });
+    });
+
+    it("cancels a resource subscription with an `unsink` naming it", async () => {
+      const fabric = connectFabric();
+      try {
+        const host = handOffPort();
+        const seen: unknown[] = [];
+        const delivered = defer();
+        const stop = fabric.sqlite("appDatabase").sink(() => {
+          seen.push(null);
+          delivered.resolve();
+        });
+
+        const sink = await receive(host);
+        expect(sink).toMatchObject({
+          operation: "sink",
+          resource: "appDatabase",
+        });
+        send(host, response(sink.id));
+        send(host, event(sink.subscription as string));
+        await delivered.promise;
+        expect(seen.length).toBe(1);
+
+        // Cancelling names the same subscription, and an event that arrives
+        // afterwards reaches a listener nobody holds.
+        stop();
+        const unsink = await receive(host);
+        expect(unsink).toMatchObject({
+          operation: "unsink",
+          resource: "appDatabase",
+          subscription: sink.subscription,
+        });
+        send(host, event(sink.subscription as string));
+        await settleAfterEvent(fabric, host);
+        expect(seen.length).toBe(1);
+      } finally {
+        fabric.disconnect();
+      }
+    });
+
+    it("reports a sink the host refuses through the error callback", async () => {
+      const fabric = connectFabric();
+      try {
+        const host = handOffPort();
+        const failures: unknown[] = [];
+        const refused = defer();
+        fabric.sinkCell(
+          { resource: "count", path: [] },
+          () => {},
+          (error) => {
+            failures.push(error);
+            refused.resolve();
+          },
+        );
+
+        const sink = await receive(host);
+        send(host, {
+          protocol: BRIDGE_PROTOCOL,
+          version: BRIDGE_VERSION,
+          type: "response",
+          id: sink.id,
+          ok: false,
+          error: { code: "resource-not-found", message: "No such cell." },
+        });
+        await refused.promise;
+        expect(failures).toMatchObject([{ code: "resource-not-found" }]);
+
+        // The subscription is dropped with the failure, so a later event for
+        // it reaches nothing rather than a listener that never became live.
+        send(host, event(sink.subscription as string));
+        await settleAfterEvent(fabric, host);
+        expect(failures.length).toBe(1);
+      } finally {
+        fabric.disconnect();
+      }
+    });
+
+    it("keeps the other sinks when one listener's cleanup throws", async () => {
+      const fabric = connectFabric();
+      try {
+        const host = handOffPort();
+        const cell = fabric.cell<number>("count");
+        const quiet: Array<number | undefined> = [];
+        const updated = defer();
+        cell.sink(() => {
+          return () => {
+            throw new Error("cleanup failed");
+          };
+        });
+        cell.sink((value) => {
+          quiet.push(value);
+          if (value === 3) updated.resolve();
+        });
+
+        const sink = await receive(host);
+        send(host, response(sink.id));
+        send(host, event(sink.subscription as string, 3));
+        await updated.promise;
+
+        expect(quiet).toEqual([undefined, 3]);
+      } finally {
+        fabric.disconnect();
+      }
+    });
+
+    it("ignores a response whose request is not outstanding", async () => {
+      const fabric = connectFabric();
+      try {
+        const host = handOffPort();
+        const cell = fabric.cell<number>("count");
+        const pulling = cell.pull();
+        const request = await receive(host);
+        send(host, response(request.id, 1));
+        expect(await pulling).toBe(1);
+
+        // Answering the same request again reaches no pending caller. The
+        // value staying put is what says the second answer was dropped rather
+        // than applied to something else.
+        send(host, response(request.id, 2));
+        await settleAfterEvent(fabric, host);
+        expect(cell.get()).toBe(1);
+      } finally {
+        fabric.disconnect();
+      }
     });
   });
 

--- a/packages/iframe-sandbox/test/guest.test.ts
+++ b/packages/iframe-sandbox/test/guest.test.ts
@@ -3,6 +3,7 @@ import {
   fabricFromRealmValue,
   realmFromFabricValue,
 } from "@commonfabric/data-model/codecs";
+import { defer } from "@commonfabric/utils/defer";
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
 
@@ -18,6 +19,8 @@ import {
   type BridgeHostMessage,
   type BridgeRequest,
   GUEST_PORT_HANDOFF,
+  GUEST_PORT_ORDERED,
+  type GuestFlush,
 } from "../src/ipc.ts";
 
 function handOffPort(): MessagePort {
@@ -100,6 +103,121 @@ describe("guest", () => {
         });
       } finally {
         fabric.disconnect();
+      }
+    });
+
+    it("holds queued requests until the host answers the flush marker", async () => {
+      const posted: unknown[] = [];
+      const originalParent = Reflect.get(globalThis, "parent");
+      Reflect.set(globalThis, "parent", {
+        postMessage: (data: unknown) => posted.push(data),
+      });
+      const fabric = connectFabric();
+      try {
+        const pulling = fabric.cell<number>("count").pull();
+
+        // The collector is attached before the handoff, so a request sent at
+        // handoff is caught rather than missed.
+        const channel = new MessageChannel();
+        const arrived: unknown[] = [];
+        channel.port1.addEventListener(
+          "message",
+          (event) => arrived.push((event as MessageEvent).data),
+        );
+        channel.port1.start();
+        globalThis.dispatchEvent(
+          new MessageEvent("message", { data: GUEST_PORT_ORDERED }),
+        );
+        globalThis.dispatchEvent(
+          new MessageEvent("message", {
+            data: GUEST_PORT_HANDOFF,
+            ports: [channel.port2],
+          }),
+        );
+        expect(posted).toEqual([{ type: "flush", nonce: expect.any(String) }]);
+
+        // The sentinel goes the way the guest's requests go, and one port
+        // delivers in the order things were posted, so a request sent at
+        // handoff arrives ahead of it. The sentinel arriving alone is
+        // therefore the hold, rather than a request still in flight.
+        const sentinel = "sentinel";
+        const seen = defer();
+        channel.port1.addEventListener("message", (event) => {
+          if ((event as MessageEvent).data === sentinel) seen.resolve();
+        });
+        channel.port2.postMessage(sentinel);
+        await seen.promise;
+        expect(arrived).toEqual([sentinel]);
+
+        const marker = posted[0] as GuestFlush;
+        send(channel.port1, {
+          protocol: BRIDGE_PROTOCOL,
+          version: BRIDGE_VERSION,
+          type: "flush",
+          nonce: marker.nonce,
+        });
+        const request = await receive(channel.port1);
+        expect(request.operation).toBe("pull");
+        send(channel.port1, response(request.id, 7));
+        expect(await pulling).toBe(7);
+      } finally {
+        fabric.disconnect();
+        Reflect.set(globalThis, "parent", originalParent);
+      }
+    });
+
+    it("ignores a flush acknowledgement carrying another guest's nonce", async () => {
+      const posted: unknown[] = [];
+      const originalParent = Reflect.get(globalThis, "parent");
+      Reflect.set(globalThis, "parent", {
+        postMessage: (data: unknown) => posted.push(data),
+      });
+      const fabric = connectFabric();
+      let pulling: Promise<number> | undefined;
+      try {
+        pulling = fabric.cell<number>("count").pull();
+        globalThis.dispatchEvent(
+          new MessageEvent("message", { data: GUEST_PORT_ORDERED }),
+        );
+        const host = handOffPort();
+        expect(posted).toEqual([{ type: "flush", nonce: expect.any(String) }]);
+        send(host, {
+          protocol: BRIDGE_PROTOCOL,
+          version: BRIDGE_VERSION,
+          type: "flush",
+          nonce: "somebody-elses",
+        });
+        // disconnect() sends its request past the gate, so it fences the
+        // channel: the disconnect arriving first says the stray
+        // acknowledgement released nothing.
+        fabric.disconnect();
+        const request = await receive(host);
+        expect(request.operation).toBe("disconnect");
+        await expect(pulling).rejects.toMatchObject({ code: "disconnected" });
+      } finally {
+        fabric.disconnect();
+        await pulling?.catch(() => {});
+        Reflect.set(globalThis, "parent", originalParent);
+      }
+    });
+
+    it("sends queued requests at handoff when no parent can carry a marker", async () => {
+      const originalParent = Reflect.get(globalThis, "parent");
+      Reflect.set(globalThis, "parent", undefined);
+      const fabric = connectFabric();
+      try {
+        const pulling = fabric.cell<number>("count").pull();
+        globalThis.dispatchEvent(
+          new MessageEvent("message", { data: GUEST_PORT_ORDERED }),
+        );
+        const host = handOffPort();
+        const request = await receive(host);
+        expect(request.operation).toBe("pull");
+        send(host, response(request.id, 7));
+        expect(await pulling).toBe(7);
+      } finally {
+        fabric.disconnect();
+        Reflect.set(globalThis, "parent", originalParent);
       }
     });
 

--- a/packages/iframe-sandbox/test/iframe.browser.test.ts
+++ b/packages/iframe-sandbox/test/iframe.browser.test.ts
@@ -353,6 +353,83 @@ ${GUEST_EPILOG}`;
   }
 });
 
+Deno.test("an alarm raised before a write is dispatched before the write lands", async () => {
+  cleanupFixtures();
+
+  // The alarm route and the port are separate channels. An alarm crosses two
+  // window hops -- guest to outer frame, outer frame to host -- while port
+  // traffic reaches the host directly, and no task ordering holds one channel
+  // behind the other. The guarantee under test is the rendezvous that closes
+  // that race: a guest taking its port posts a flush marker up the parent
+  // chain, behind everything it posted there before, and holds its port
+  // traffic until the host answers -- so by the time any port operation
+  // lands, every earlier parent post has been handled. This test drives the
+  // schedule the rendezvous exists for: every relayed guest message is
+  // withheld, standing for a relay running behind the port, and released in
+  // arrival order once the third arrives. The third is the marker, which is
+  // the last thing the relay carries before port traffic can land.
+  const held: MessageEvent[] = [];
+  let releasing = false;
+  const release = () => {
+    releasing = true;
+    for (const event of held.splice(0)) {
+      globalThis.dispatchEvent(
+        new MessageEvent("message", {
+          data: event.data,
+          source: event.source,
+          origin: event.origin,
+        }),
+      );
+    }
+  };
+  const withhold = (event: MessageEvent) => {
+    if (releasing) return;
+    const data = event.data as { type?: unknown } | null;
+    if (!data || data.type !== "guest-error") return;
+    event.stopImmediatePropagation();
+    held.push(event);
+    if (held.length >= 3) release();
+  };
+  // Registered before the element is, so it hears each message first and can
+  // withhold it from the element.
+  globalThis.addEventListener("message", withhold);
+  try {
+    const context = new ContextShim({}, ["after"]);
+    const errors: string[] = [];
+    const onError = (event: Event) =>
+      errors.push((event as CustomEvent).detail.description);
+    document.addEventListener("common-iframe-error", onError);
+    try {
+      // The same three posts as the test above: a dropped protocol message, an
+      // alarm, a write. Here the write is only allowed to land after the
+      // withheld relay is released, and the alarm must already have been
+      // dispatched when it does.
+      const body = `${GUEST_PROLOG}
+parent.postMessage({ type: "write", data: ["relayed", 1] }, "*");
+parent.postMessage({ type: "error", data: {
+  description: "raised without a port",
+  source: "", lineno: 0, colno: 0, stacktrace: "",
+} }, "*");
+set("after", 1);
+${GUEST_EPILOG}`;
+      const iframe = await render(body, context);
+      await waitForContextValue(
+        context,
+        iframe,
+        "after",
+        (value) => value === 1,
+      );
+      assertEquals(context.get(iframe, "relayed"), undefined);
+      assertDeepEquals(errors, ["raised without a port"]);
+    } finally {
+      document.removeEventListener("common-iframe-error", onError);
+    }
+  } finally {
+    globalThis.removeEventListener("message", withhold);
+    cleanupFixtures();
+  }
+});
+
 Deno.test("a reattached element loads its document into the frame it gets", async () => {
   cleanupFixtures();
   try {
@@ -439,6 +516,60 @@ ${GUEST_EPILOG}`;
       refusal = String(error);
     }
     assert(refusal.includes("Already initialized"));
+  } finally {
+    cleanupFixtures();
+  }
+});
+
+Deno.test("a repeated load report does not unseat the guest holding its port", async () => {
+  cleanupFixtures();
+  try {
+    const context = new ContextShim({ watched: 1 }, ["ready", "echo"]);
+    const body = `${GUEST_PROLOG}
+onUpdate = (key, value) => {
+  if (key === "watched" && value === 2) set("echo", 2);
+};
+sink("watched");
+set("ready", true);
+${GUEST_EPILOG}`;
+    const iframe = await render(body, context);
+    await waitForContextValue(
+      context,
+      iframe,
+      "ready",
+      (value) => value === true,
+    );
+    assertEquals(context.callbacks.length, 1);
+
+    // The outer frame reports a load per completed navigation of its inner
+    // frame, and it cannot tell whose navigation a load event was: the
+    // initial `about:blank` one can complete after a document was asked for,
+    // in which case one asked-for document yields two reports. The element
+    // offers a fresh port on each report, and a session is retired only once
+    // a successor shows activity -- so a guest refusing the extra offer keeps
+    // the session it has, subscriptions included. The repeat is synthesized,
+    // as the real one turns on navigation timing inside the frame.
+    const inner = iframe as unknown as {
+      iframeRef: { value?: HTMLIFrameElement };
+    };
+    globalThis.dispatchEvent(
+      new MessageEvent("message", {
+        data: { type: "load" },
+        source: inner.iframeRef.value!.contentWindow!,
+        origin: "null",
+      }),
+    );
+    assertEquals(context.callbacks.length, 1);
+
+    // The subscription staying registered is half of it; the guest writing
+    // through the port it kept is the other half.
+    context.set(iframe, "watched", 2);
+    await waitForContextValue(
+      context,
+      iframe,
+      "echo",
+      (value) => value === 2,
+    );
   } finally {
     cleanupFixtures();
   }

--- a/packages/iframe-sandbox/test/ipc.test.ts
+++ b/packages/iframe-sandbox/test/ipc.test.ts
@@ -10,6 +10,7 @@ import {
   isBridgeRequest,
   isGuestAlarm,
   isGuestError,
+  isGuestFlush,
   isIPCGuestMessage,
 } from "../src/ipc.ts";
 
@@ -167,6 +168,16 @@ describe("ipc", () => {
         ok: false,
       })).toBe(false);
     });
+
+    it("accepts a flush acknowledgement only with its nonce", () => {
+      expect(isBridgeHostMessage({
+        ...HEADER,
+        type: "flush",
+        nonce: "n1",
+      })).toBe(true);
+      expect(isBridgeHostMessage({ ...HEADER, type: "flush" })).toBe(false);
+      expect(isBridgeHostMessage({ type: "flush", nonce: "n1" })).toBe(false);
+    });
   });
 
   describe("outer-frame messages", () => {
@@ -186,6 +197,13 @@ describe("ipc", () => {
       expect(isGuestError({ ...ERROR, lineno: "1" })).toBe(false);
       expect(isGuestAlarm({ type: "error", data: ERROR })).toBe(true);
       expect(isGuestAlarm({ type: "write", data: ERROR })).toBe(false);
+    });
+
+    it("recognizes only complete flush markers", () => {
+      expect(isGuestFlush({ type: "flush", nonce: "n1" })).toBe(true);
+      expect(isGuestFlush({ type: "flush" })).toBe(false);
+      expect(isGuestFlush({ type: "error", nonce: "n1" })).toBe(false);
+      expect(isGuestFlush("flush")).toBe(false);
     });
   });
 });


### PR DESCRIPTION
Two defects in the choreography that hands a sandboxed guest its capability port. Both are timing-dependent, and both were reached from one CI failure of `what a guest posts outside its port raises an alarm, not a write`, which failed with `[] does not deep equal ["raised without a port"]`.

The first is that the alarm route and the port are unordered. A guest with no working port raises an alarm by posting to its parent, which crosses two window hops -- guest to outer frame, outer frame to host -- while port traffic reaches the host directly. The outer frame handles a relayed guest message and its inner frame's load event from two different task sources, and the event loop orders neither against the other, so the host can hand over the port, take the guest's first write, and dispatch the earlier alarm after it.

A flush exchange closes that. The host posts an `ordered` announcement ahead of each port handoff. A guest that heard it mints a nonce, posts a flush marker up the parent chain on taking its port -- behind everything it posted there before, which is ordered because it is one sender and one receiver -- and holds its port traffic until the host echoes that nonce back over the port. The host echoes only once it has handled everything the relay carried ahead of the marker, so every pre-port parent post is handled before any port request. The exchange is negotiated rather than assumed: a guest that never heard the announcement sends unordered, so a guest and a host of different vintages cannot deadlock, and the nonce keeps one document's acknowledgement from releasing a different document's traffic.

The second is that a repeated load report unseated a live guest. The outer frame reports a load per completed navigation of its inner frame and cannot say which document a load event belongs to, so one asked-for document can yield two reports. The element used to tear down the live session on the second report and offer a fresh port, which the guest -- already holding one -- refuses, leaving it wedged on a closed port with its subscriptions cancelled. The element now keeps the sessions it has offered and lets use settle which one matters: a session's first request retires every session offered before it, so refusing a replacement handoff is safe.

Offers are capped at two, which are the only ones a guest can still be holding: the first, and the newest. Without a cap they accumulate. A guest can renavigate its own frame, each navigation reports a load, and a session is otherwise retired only by a successor that speaks -- so a guest that reloads and stays quiet keeps a live session, port, and subscription map per reload, which also multiplies the acknowledgement a flush marker fans out. Measured in a browser: one guest-driven reload yields two load reports and two sessions, and an unguarded reload loop grows without bound. The cap costs a document that took the offer that was newest, has never spoken on it, and is still there after a further load report.

The bridge protocol version is unchanged. The acknowledgement is an additive message negotiated through the announcement, and an unrecognized message was already dropped by both ends' validators.

Two tests pin this, and each was checked to fail only for its own mechanism. Removing the flush exchange fails `an alarm raised before a write is dispatched before the write lands` with the symptom CI saw; removing the session tolerance fails `a repeated load report does not unseat the guest holding its port`. Both drive their schedule on purpose rather than waiting for it: the first withholds relayed messages so the relay runs behind the port, and the second synthesizes the duplicate report, because a race that CI hits in under half its runs is not one a test can wait for. The unit test for the hold posts a sentinel down the queue the guest's requests travel on, where delivery order is guaranteed, and requires the sentinel to arrive alone; sending the acknowledgement and then reading the request would pass whether or not the guest held.

A third defect reached from the same failure, two `srcdoc` assignments in quick succession dropping a navigation, is fixed separately by the outer frame giving each document a frame of its own. What remains of it here is that the element folds a batch of property changes into one document request through the Lit update lifecycle, so assigning `bridge` and `src` together asks for one document carrying both rather than loading the previous `src` on the way.

deflaked by Hixie's agent (Claude Opus 5)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6776?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

