### PR TITLE
feat(memory): report the evaluation caches on /api/health/stats; evict at the entry cap

### DIFF
--- a/docs/development/debugging/profiling.md
+++ b/docs/development/debugging/profiling.md
@@ -371,6 +371,25 @@ process:
   while a corpus is being walked means its working set does not fit the
   budget, and every walk is paying decode and deep-freeze for it again — on
   the Topics board that was most of a second of server time per walk.
+- `evaluationCaches` — the memory server's query evaluation caches
+  (`QueryEvaluationCache` in `packages/memory/v2/query.ts`): one entry per
+  space the server has evaluated in, under the caches' retained `weight`
+  against the cross-space `budget`. Each space carries the cache's current
+  `seq`, its live `entries` split by share class (`entriesPure`,
+  `entriesAbsentResidue`, `entriesTainted`) and the lifetime counters for
+  what became of the evaluations it saw: `hits` (split as `hitsPure`,
+  `hitsAbsentResidue`, `hitsIdentity`), `misses`, `residueRefusals`,
+  `rotations` (a commit or engine change cleared it), `capEvictions` (a new
+  shape displaced the oldest at the entry cap) and `budgetEvictions` (the
+  weight budget removed it). Read it as a difference across one repeated
+  load at a constant `seq`. Hits rising on the repeat means watch
+  establishment is being served. Misses rising together with
+  `entriesTainted` means the entries are keyed to the (principal, session)
+  that recorded them — a page load is a new session, so a reload never
+  matches. A `rotations` step between the captures means a commit landed and
+  the comparison is void. An eviction counter rising means the load's
+  distinct shapes outnumber the cap or outweigh the budget, and which counter
+  moved says which.
 - `servingLoop` — the serving loop's counters
   ([`serving-loop.md` §7](../../specs/server-side-execution/serving-loop.md)),
   present only when this process serves. `settle.series` is a ready-made

--- a/docs/development/debugging/profiling.md
+++ b/docs/development/debugging/profiling.md
@@ -381,15 +381,22 @@ process:
   `hitsAbsentResidue`, `hitsIdentity`), `misses`, `residueRefusals`,
   `rotations` (a commit or engine change cleared it), `capEvictions` (a new
   shape displaced the oldest at the entry cap) and `budgetEvictions` (the
-  weight budget removed it). Read it as a difference across one repeated
-  load at a constant `seq`. Hits rising on the repeat means watch
-  establishment is being served. Misses rising together with
-  `entriesTainted` means the entries are keyed to the (principal, session)
-  that recorded them — a page load is a new session, so a reload never
-  matches. A `rotations` step between the captures means a commit landed and
-  the comparison is void. An eviction counter rising means the load's
-  distinct shapes outnumber the cap or outweigh the budget, and which counter
-  moved says which.
+  weight budget removed it). Know what the cache covers before reading it:
+  fresh evaluations only — a session's first watch group per branch, a
+  whole-set establishment on resume, and `graph.query`. A later `watch.add`
+  in the same session extends that session's graph and never touches the
+  cache, so a page load that grows its watch set batch by batch records one
+  entry and re-walks the rest; `rootsVisited == watches` on those batches is
+  the design, not a miss. Read the counters as a difference across one
+  repeated establishment at a constant `seq`. Hits rising on the repeat
+  means it is being served. Misses rising together with `entriesTainted`
+  means the entries are keyed to the (principal, session) that recorded
+  them, which a new session never matches. A `rotations` step between the
+  captures means a commit landed and the comparison is void. An eviction
+  counter rising says which bound moved. Per-space records live as long as
+  the space's cache object: the space bound keeps the eight most recently
+  evaluated, and a budget pass sweeps empty leftovers, so compare two
+  captures only while `spacesDropped` holds still between them.
 - `servingLoop` — the serving loop's counters
   ([`serving-loop.md` §7](../../specs/server-side-execution/serving-loop.md)),
   present only when this process serves. `settle.series` is a ready-made

--- a/docs/development/debugging/profiling.md
+++ b/docs/development/debugging/profiling.md
@@ -373,15 +373,18 @@ process:
   the Topics board that was most of a second of server time per walk.
 - `evaluationCaches` — the memory server's query evaluation caches
   (`QueryEvaluationCache` in `packages/memory/v2/query.ts`): one entry per
-  space the server has evaluated in, under the caches' retained `weight`
-  against the cross-space `budget`. Each space carries the cache's current
+  space whose cache the server currently retains (the eight most recently
+  evaluated; `spacesDropped` counts the ones let go), under the caches'
+  retained `weight` against the cross-space `budget`. Each space carries the
+  cache's current
   `seq`, its live `entries` split by share class (`entriesPure`,
   `entriesAbsentResidue`, `entriesTainted`) and the lifetime counters for
   what became of the evaluations it saw: `hits` (split as `hitsPure`,
   `hitsAbsentResidue`, `hitsIdentity`), `misses`, `residueRefusals`,
-  `rotations` (a commit or engine change cleared it), `capEvictions` (a new
-  shape displaced the oldest at the entry cap) and `budgetEvictions` (the
-  weight budget removed it). Know what the cache covers before reading it:
+  `rotations` (a commit or engine change cleared it), `capRefusals` (a full
+  cache turned a new shape away until the next rotation) and
+  `budgetEvictions` (the weight budget removed an entry). Know what the cache
+  covers before reading it:
   fresh evaluations only — a session's first watch group per branch, a
   whole-set establishment on resume, and `graph.query`. A later `watch.add`
   in the same session extends that session's graph and never touches the
@@ -392,8 +395,9 @@ process:
   means it is being served. Misses rising together with `entriesTainted`
   means the entries are keyed to the (principal, session) that recorded
   them, which a new session never matches. A `rotations` step between the
-  captures means a commit landed and the comparison is void. An eviction
-  counter rising says which bound moved. Per-space records live as long as
+  captures means a commit landed and the comparison is void. `capRefusals`
+  rising means the seq's distinct shapes outnumber the cap; `budgetEvictions`
+  rising means they outweigh the budget. Per-space records live as long as
   the space's cache object: the space bound keeps the eight most recently
   evaluated, and a budget pass sweeps empty leftovers, so compare two
   captures only while `spacesDropped` holds still between them.
@@ -403,9 +407,11 @@ process:
   per-authored-input latency series: admission to watermark coverage, with the
   wave and cycle counts behind each entry.
 
-Everything here accumulates for the process's whole life, across every space it
-has served, so a phase is a difference between two captures rather than any
-single one — and **only `count` and `totalTime` subtract**. `min`, `max`, `p50`,
+`timingStats` and `logCounts` accumulate for the process's whole life, across
+every space the process has served, so a phase is a difference between two
+captures rather than any single one — and **only `count` and `totalTime`
+subtract**. (`evaluationCaches` is the exception: its per-space records live
+with their cache objects, as above.) `min`, `max`, `p50`,
 `p95` and the CDF describe the whole lifetime; differencing them yields a number
 that looks like a phase percentile and is not one. What a diff of the two
 additive fields does give you honestly is the phase's call count and its mean.

--- a/packages/memory/test/v2-query-evaluation-cache.test.ts
+++ b/packages/memory/test/v2-query-evaluation-cache.test.ts
@@ -728,7 +728,7 @@ describe("v2 query evaluation cache", () => {
       hits: 0,
       misses: 0,
       rotations: 0,
-      capEvictions: 0,
+      capRefusals: 0,
       budgetEvictions: 0,
       hitsPure: 0,
       hitsAbsentResidue: 0,
@@ -1212,7 +1212,7 @@ describe("v2 query evaluation cache", () => {
     }
   });
 
-  it("evicts the oldest shape when one past the cap is recorded at a sequence", async () => {
+  it("keeps a full cache's working set and counts the shapes it turns away", async () => {
     const space = "did:key:z6Mk-eval-cache-cap";
     const engine = await openEngine({
       url: new URL("memory:///eval-cache-cap"),
@@ -1255,26 +1255,28 @@ describe("v2 query evaluation cache", () => {
       );
     for (let shape = 1; shape <= count; shape++) evaluate(shape);
 
-    // One shape past the cap at a single sequence: the newest recorded by
-    // displacing the oldest, so the cache stays full and current instead
-    // of freezing at whatever filled it first.
+    // One shape past the cap at a single sequence: the cache is full, the
+    // extra shape was turned away and counted, and the first cap shapes
+    // are still the working set.
     let diagnostics = queryEvaluationCacheDiagnostics(cache);
     expect(diagnostics.misses).toBe(count);
     expect(diagnostics.entries).toBe(EVALUATION_CACHE_MAX_ENTRIES);
     expect(diagnostics.weight).toBe(EVALUATION_CACHE_MAX_ENTRIES);
-    expect(diagnostics.capEvictions).toBe(1);
+    expect(diagnostics.capRefusals).toBe(1);
 
-    // The newest shape serves; the displaced one re-walks, and recording
-    // it again displaces the next-oldest in turn — no more than that: the
-    // shape after it is still served.
-    expect(evaluate(count).stats.rootsVisited).toBe(0);
-    expect(evaluate(1).stats.rootsVisited).toBe(1);
-    expect(evaluate(3).stats.rootsVisited).toBe(0);
-    expect(evaluate(2).stats.rootsVisited).toBe(1);
+    // A second cycle over the same shapes serves every retained one — the
+    // property displacing the oldest entry would destroy (each miss would
+    // evict the shape the cycle asks for next) — and turns the extra shape
+    // away again.
+    let served = 0;
+    for (let shape = 1; shape <= count; shape++) {
+      if (evaluate(shape).stats.rootsVisited === 0) served++;
+    }
+    expect(served).toBe(EVALUATION_CACHE_MAX_ENTRIES);
     diagnostics = queryEvaluationCacheDiagnostics(cache);
-    expect(diagnostics.hitsPure).toBe(2);
-    expect(diagnostics.misses).toBe(count + 2);
-    expect(diagnostics.capEvictions).toBe(3);
+    expect(diagnostics.hitsPure).toBe(EVALUATION_CACHE_MAX_ENTRIES);
+    expect(diagnostics.misses).toBe(count + 1);
+    expect(diagnostics.capRefusals).toBe(2);
     expect(diagnostics.entries).toBe(EVALUATION_CACHE_MAX_ENTRIES);
     expect(diagnostics.weight).toBe(EVALUATION_CACHE_MAX_ENTRIES);
   });
@@ -1330,16 +1332,29 @@ describe("v2 query evaluation cache", () => {
       }
     }
   });
-  it("withdraws its health provider on close, never a successor's", async () => {
+  it("reports the newest live server's caches, whichever order servers close", async () => {
+    // Earlier tests in this file leave servers open, and a live server is
+    // reported for as long as it lives — so measure relative to whatever is
+    // registered when this test starts, and expect to hand back to it.
+    const before = getEvaluationCachesDiagnostics()?.budget;
     const first = createServer("memory://eval-cache-provider-first", 7);
     const second = createServer("memory://eval-cache-provider-second", 9);
-    // Last registration wins: the second server is the one reported.
+    // The newest server is the one reported.
     expect(getEvaluationCachesDiagnostics()?.budget).toBe(9);
-    // Closing an earlier server leaves the live one's provider in place.
-    await first.close();
-    expect(getEvaluationCachesDiagnostics()?.budget).toBe(9);
-    // Closing the registered one withdraws it: nothing stale is reported.
+    // Closing the newest hands the report back to the older live server
+    // rather than hiding it.
     await second.close();
-    expect(getEvaluationCachesDiagnostics()).toBeUndefined();
+    expect(getEvaluationCachesDiagnostics()?.budget).toBe(7);
+    await first.close();
+    expect(getEvaluationCachesDiagnostics()?.budget).toBe(before);
+
+    // And the other order: closing an older server leaves the live newest
+    // in place; closing that withdraws it.
+    const third = createServer("memory://eval-cache-provider-third", 11);
+    const fourth = createServer("memory://eval-cache-provider-fourth", 13);
+    await third.close();
+    expect(getEvaluationCachesDiagnostics()?.budget).toBe(13);
+    await fourth.close();
+    expect(getEvaluationCachesDiagnostics()?.budget).toBe(before);
   });
 });

--- a/packages/memory/test/v2-query-evaluation-cache.test.ts
+++ b/packages/memory/test/v2-query-evaluation-cache.test.ts
@@ -4,11 +4,12 @@ import { applyCommit, open as openEngine } from "../v2/engine.ts";
 import {
   classifyStateScope,
   createQueryEvaluationCache,
+  EVALUATION_CACHE_MAX_ENTRIES,
   queryEvaluationCacheDiagnostics,
   type TrackedGraphState,
   trackGraph,
 } from "../v2/query.ts";
-import { Server } from "../v2/server.ts";
+import { getEvaluationCachesDiagnostics, Server } from "../v2/server.ts";
 import {
   encodeMemoryBoundary,
   getMemoryProtocolFlags,
@@ -727,6 +728,8 @@ describe("v2 query evaluation cache", () => {
       hits: 0,
       misses: 0,
       rotations: 0,
+      capEvictions: 0,
+      budgetEvictions: 0,
       hitsPure: 0,
       hitsAbsentResidue: 0,
       hitsIdentity: 0,
@@ -933,9 +936,14 @@ describe("v2 query evaluation cache", () => {
         );
       }
       // Each corpus weighs 2; a budget of 3 holds one of them, so the
-      // second space's insert evicted the first space's entry.
+      // second space's insert evicted the first space's entry — and the
+      // evicted space's counter, not the inserting space's, records it.
       expect(server.evaluationCacheDiagnostics(spaces[0]).weight).toBe(0);
+      expect(server.evaluationCacheDiagnostics(spaces[0]).budgetEvictions)
+        .toBe(1);
       expect(server.evaluationCacheDiagnostics(spaces[1]).weight).toBe(2);
+      expect(server.evaluationCacheDiagnostics(spaces[1]).budgetEvictions)
+        .toBe(0);
     } finally {
       for (const connection of connections) {
         connection.close();
@@ -962,6 +970,7 @@ describe("v2 query evaluation cache", () => {
       expect(diagnostics.misses).toBe(1);
       expect(diagnostics.entries).toBe(0);
       expect(diagnostics.weight).toBe(0);
+      expect(diagnostics.budgetEvictions).toBe(1);
     } finally {
       connection.close();
     }
@@ -1166,6 +1175,124 @@ describe("v2 query evaluation cache", () => {
       );
       expect(server.evaluationCacheDiagnostics(spaces[0]).seq).toBe(-1);
       expect(server.evaluationCacheDiagnostics(spaces[1]).entries).toBe(1);
+    } finally {
+      for (const connection of connections) {
+        connection.close();
+      }
+    }
+  });
+
+  it("evicts the oldest shape when one past the cap is recorded at a sequence", async () => {
+    const space = "did:key:z6Mk-eval-cache-cap";
+    const engine = await openEngine({
+      url: new URL("memory:///eval-cache-cap"),
+    });
+    const count = EVALUATION_CACHE_MAX_ENTRIES + 1;
+    applyCommit(engine, {
+      sessionId: "session:test",
+      invocation: {
+        iss: "did:key:test",
+        aud: "did:key:service",
+        cmd: "/memory/transact",
+        sub: space,
+      },
+      authorization: { proof: "ok" },
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: Array.from({ length: count }, (_, index) => ({
+          op: "set" as const,
+          id: `of:doc:${index + 1}`,
+          value: { value: { n: index + 1 } },
+        })),
+      },
+    });
+    const cache = createQueryEvaluationCache();
+    // One root per shape: every evaluation is a distinct, scope-pure
+    // entry weighing one entity.
+    const evaluate = (shape: number) =>
+      trackGraph(
+        space,
+        engine,
+        {
+          roots: [{
+            id: `of:doc:${shape}`,
+            selector: { path: [], schema: true },
+          }],
+        },
+        undefined,
+        { evaluationCache: cache },
+      );
+    for (let shape = 1; shape <= count; shape++) evaluate(shape);
+
+    // One shape past the cap at a single sequence: the newest recorded by
+    // displacing the oldest, so the cache stays full and current instead
+    // of freezing at whatever filled it first.
+    let diagnostics = queryEvaluationCacheDiagnostics(cache);
+    expect(diagnostics.misses).toBe(count);
+    expect(diagnostics.entries).toBe(EVALUATION_CACHE_MAX_ENTRIES);
+    expect(diagnostics.weight).toBe(EVALUATION_CACHE_MAX_ENTRIES);
+    expect(diagnostics.capEvictions).toBe(1);
+
+    // The newest shape serves; the displaced one re-walks, and recording
+    // it again displaces the next-oldest in turn — no more than that: the
+    // shape after it is still served.
+    expect(evaluate(count).stats.rootsVisited).toBe(0);
+    expect(evaluate(1).stats.rootsVisited).toBe(1);
+    expect(evaluate(3).stats.rootsVisited).toBe(0);
+    expect(evaluate(2).stats.rootsVisited).toBe(1);
+    diagnostics = queryEvaluationCacheDiagnostics(cache);
+    expect(diagnostics.hitsPure).toBe(2);
+    expect(diagnostics.misses).toBe(count + 2);
+    expect(diagnostics.capEvictions).toBe(3);
+    expect(diagnostics.entries).toBe(EVALUATION_CACHE_MAX_ENTRIES);
+    expect(diagnostics.weight).toBe(EVALUATION_CACHE_MAX_ENTRIES);
+  });
+
+  it("reports every cached space through the health provider", async () => {
+    const server = createServer("memory://eval-cache-provider", 64);
+    const spaces = [
+      "did:key:z6Mk-eval-provider-1",
+      "did:key:z6Mk-eval-provider-2",
+    ];
+    const connections: ReturnType<Server["connect"]>[] = [];
+    try {
+      for (const space of spaces) {
+        const messages: ServerMessage[] = [];
+        const connection = server.connect((message) => messages.push(message));
+        connections.push(connection);
+        const sessionId = await openSession(
+          connection,
+          messages,
+          space,
+          space.slice(-10),
+        );
+        await seedDocs(server, messages, space, sessionId, ["of:doc:1"]);
+        await watchAdd(
+          connection,
+          messages,
+          space,
+          sessionId,
+          space.slice(-10),
+          [{ id: "of:doc:1" }],
+        );
+      }
+      // The module-level provider (the health route's handle) reads the
+      // last-constructed server: every space it has evaluated in, each
+      // exactly as the per-space peek reports it, under the caches' total
+      // weight and the budget in force; a never-evaluated space is absent.
+      const report = getEvaluationCachesDiagnostics();
+      expect(report).toEqual(server.evaluationCachesDiagnostics());
+      expect(report?.budget).toBe(64);
+      expect(report?.weight).toBe(2);
+      expect(Object.keys(report!.spaces).toSorted()).toEqual(spaces);
+      for (const space of spaces) {
+        expect(report!.spaces[space]).toEqual(
+          server.evaluationCacheDiagnostics(space),
+        );
+        expect(report!.spaces[space].entries).toBe(1);
+        expect(report!.spaces[space].misses).toBe(1);
+      }
     } finally {
       for (const connection of connections) {
         connection.close();

--- a/packages/memory/test/v2-query-evaluation-cache.test.ts
+++ b/packages/memory/test/v2-query-evaluation-cache.test.ts
@@ -944,6 +944,31 @@ describe("v2 query evaluation cache", () => {
       expect(server.evaluationCacheDiagnostics(spaces[1]).weight).toBe(2);
       expect(server.evaluationCacheDiagnostics(spaces[1]).budgetEvictions)
         .toBe(0);
+      // The drained space kept its (empty) cache and its record.
+      expect(server.evaluationCachesDiagnostics().spacesDropped).toBe(0);
+      expect(spaces[0] in server.evaluationCachesDiagnostics().spaces).toBe(
+        true,
+      );
+
+      // A third space over budget: this pass sweeps the empty leftover —
+      // dropping the first space's record, counted — before evicting.
+      const third = "did:key:z6Mk-eval-budget-3";
+      const messages: ServerMessage[] = [];
+      const connection = server.connect((message) => messages.push(message));
+      connections.push(connection);
+      const sessionId = await openSession(connection, messages, third, "b3");
+      await seedDocs(server, messages, third, sessionId, [
+        "of:doc:1",
+        "of:doc:2",
+      ]);
+      await watchAdd(connection, messages, third, sessionId, "b3", [
+        { id: "of:doc:1" },
+        { id: "of:doc:2" },
+      ]);
+      const report = server.evaluationCachesDiagnostics();
+      expect(report.spacesDropped).toBe(1);
+      expect(spaces[0] in report.spaces).toBe(false);
+      expect(report.weight).toBe(2);
     } finally {
       for (const connection of connections) {
         connection.close();
@@ -1159,8 +1184,13 @@ describe("v2 query evaluation cache", () => {
         );
       }
       // Nine spaces evaluated against a bound of eight: the first has been
-      // evicted (a peek reads empty), the rest retain their entries.
+      // evicted (a peek reads empty), the rest retain their entries — and
+      // the drop is counted, since it took the space's record with it.
       expect(server.evaluationCacheDiagnostics(spaces[0]).entries).toBe(0);
+      expect(server.evaluationCachesDiagnostics().spacesDropped).toBe(1);
+      expect(spaces[0] in server.evaluationCachesDiagnostics().spaces).toBe(
+        false,
+      );
       expect(server.evaluationCacheDiagnostics(spaces[1]).entries).toBe(1);
       expect(server.evaluationCacheDiagnostics(spaces[8]).entries).toBe(1);
 
@@ -1285,6 +1315,7 @@ describe("v2 query evaluation cache", () => {
       expect(report).toEqual(server.evaluationCachesDiagnostics());
       expect(report?.budget).toBe(64);
       expect(report?.weight).toBe(2);
+      expect(report?.spacesDropped).toBe(0);
       expect(Object.keys(report!.spaces).toSorted()).toEqual(spaces);
       for (const space of spaces) {
         expect(report!.spaces[space]).toEqual(
@@ -1298,5 +1329,17 @@ describe("v2 query evaluation cache", () => {
         connection.close();
       }
     }
+  });
+  it("withdraws its health provider on close, never a successor's", async () => {
+    const first = createServer("memory://eval-cache-provider-first", 7);
+    const second = createServer("memory://eval-cache-provider-second", 9);
+    // Last registration wins: the second server is the one reported.
+    expect(getEvaluationCachesDiagnostics()?.budget).toBe(9);
+    // Closing an earlier server leaves the live one's provider in place.
+    await first.close();
+    expect(getEvaluationCachesDiagnostics()?.budget).toBe(9);
+    // Closing the registered one withdraws it: nothing stale is reported.
+    await second.close();
+    expect(getEvaluationCachesDiagnostics()).toBeUndefined();
   });
 });

--- a/packages/memory/v2/query.ts
+++ b/packages/memory/v2/query.ts
@@ -508,11 +508,12 @@ const evaluationIdentityKey = (options: TrackGraphOptions): string =>
  * by the server's cross-space retained-entity budget, which evicts by
  * weight (see Server's evaluation-cache budget).
  *
- * The bound holds by eviction: at the cap a new shape displaces the oldest
- * entry (Map insertion order — the order the weight budget evicts in too)
- * rather than going unrecorded, so a full cache keeps recording instead of
- * freezing at whatever filled it first. Insertion-order eviction serves a
- * repeated cycle of shapes only while the whole cycle fits under the cap.
+ * The bound holds by ADMISSION: a full cache records no new shape until a
+ * commit rotates it. That keeps a stable working set stable — a repeated
+ * cycle of up to this many shapes keeps serving — where displacing the
+ * oldest entry instead would turn a cycle one shape longer than the cap
+ * into a miss on every step. What a full cache turns away is counted
+ * (`capRefusals`), so a frozen cache is visible rather than silent.
  */
 export const EVALUATION_CACHE_MAX_ENTRIES = 16;
 
@@ -527,8 +528,9 @@ export type QueryEvaluationCacheDiagnostics = {
   misses: number;
   rotations: number;
 
-  /** Entries displaced at the entry cap by a newer shape. */
-  capEvictions: number;
+  /** New shapes a full cache turned away (recorded again only after the
+   * next rotation). */
+  capRefusals: number;
 
   /** Entries removed by the server's cross-space weight budget. */
   budgetEvictions: number;
@@ -650,8 +652,8 @@ export type QueryEvaluationCache = {
    * engine object for the same space. */
   rotations: number;
 
-  /** Entries displaced at EVALUATION_CACHE_MAX_ENTRIES by a newer shape. */
-  capEvictions: number;
+  /** New shapes turned away at EVALUATION_CACHE_MAX_ENTRIES. */
+  capRefusals: number;
 
   /** Entries the server's weight budget removed (its enforcement pass
    * counts here; the cache itself never evicts by weight). */
@@ -669,7 +671,7 @@ export const createQueryEvaluationCache = (): QueryEvaluationCache => ({
   residueRefusals: 0,
   misses: 0,
   rotations: 0,
-  capEvictions: 0,
+  capRefusals: 0,
   budgetEvictions: 0,
 });
 
@@ -687,7 +689,7 @@ export const queryEvaluationCacheDiagnostics = (
     hits: cache.hitsPure + cache.hitsAbsentResidue + cache.hitsIdentity,
     misses: cache.misses,
     rotations: cache.rotations,
-    capEvictions: cache.capEvictions,
+    capRefusals: cache.capRefusals,
     budgetEvictions: cache.budgetEvictions,
     hitsPure: cache.hitsPure,
     hitsAbsentResidue: cache.hitsAbsentResidue,
@@ -1624,25 +1626,18 @@ export const trackGraph = (
     const weight = state.entities.size;
     const key = share.kind === "tainted" ? cacheKeys.identity : cacheKeys.pure;
     const previous = cache.entries.get(key);
-    if (
-      previous === undefined &&
-      cache.entries.size >= EVALUATION_CACHE_MAX_ENTRIES
-    ) {
-      // A new shape at the cap displaces the oldest entry; re-recording a
-      // present key (a refused absent-residue share re-evaluated) replaces
-      // in place and grows nothing.
-      const oldestKey = cache.entries.keys().next().value!;
-      const oldest = cache.entries.get(oldestKey)!;
-      cache.entries.delete(oldestKey);
-      cache.weight -= oldest.weight;
-      cache.capEvictions++;
+    if (cache.entries.size < EVALUATION_CACHE_MAX_ENTRIES) {
+      cache.entries.set(key, {
+        state: cloneTrackedGraphState(engine, state),
+        share,
+        weight,
+      });
+      cache.weight += weight - (previous?.weight ?? 0);
+    } else if (previous === undefined) {
+      // Full: the new shape waits for the next rotation (see the cap's doc).
+      // A present key is already served and is simply not re-recorded.
+      cache.capRefusals++;
     }
-    cache.entries.set(key, {
-      state: cloneTrackedGraphState(engine, state),
-      share,
-      weight,
-    });
-    cache.weight += weight - (previous?.weight ?? 0);
   }
   return {
     serverSeq: Engine.serverSeq(engine),

--- a/packages/memory/v2/query.ts
+++ b/packages/memory/v2/query.ts
@@ -512,9 +512,13 @@ const evaluationIdentityKey = (options: TrackGraphOptions): string =>
  * entry (Map insertion order — the order the weight budget evicts in too)
  * rather than going unrecorded, so a full cache keeps recording instead of
  * freezing at whatever filled it first. Insertion-order eviction serves a
- * repeated cycle of shapes only while the whole cycle fits under the cap.
+ * repeated cycle of shapes only while the whole cycle fits under the cap,
+ * so the cap is sized to clear one client's page load (a topics-board
+ * reload arrives as ~23 frames, most of them watch batches) with room for
+ * other clients' shapes and for per-session tainted entries, which never
+ * serve anyone else.
  */
-export const EVALUATION_CACHE_MAX_ENTRIES = 16;
+export const EVALUATION_CACHE_MAX_ENTRIES = 64;
 
 export type QueryEvaluationCacheDiagnostics = {
   seq: number;

--- a/packages/memory/v2/query.ts
+++ b/packages/memory/v2/query.ts
@@ -580,6 +580,16 @@ export type QueryEvaluationCacheDiagnostics = {
  * watch corpus between two commits (a reconnect stampede after a process
  * death is this, at its worst).
  *
+ * Fresh evaluations alone consult it: a session's first watch group per
+ * branch, a whole-set establishment (session resume), and `graph.query`.
+ * A later `watch.add` in the same session EXTENDS that session's tracked
+ * graph (`extendTrackedGraph`), and an extension's walk depends on what the
+ * session already covers, so it is neither served nor recorded. A page
+ * load that grows its watch set batch by batch therefore records one
+ * entry — its first batch — and re-walks the rest on every load; what the
+ * cache covers is many sessions establishing one corpus, not one session's
+ * incremental establishment.
+ *
  * Scope purity decides who may share an entry. An evaluation whose whole
  * reach — tracked, missed, and loaded — resolved under the `space` scope is
  * identical for every identity and is shared across them; one that touched

--- a/packages/memory/v2/query.ts
+++ b/packages/memory/v2/query.ts
@@ -512,13 +512,9 @@ const evaluationIdentityKey = (options: TrackGraphOptions): string =>
  * entry (Map insertion order — the order the weight budget evicts in too)
  * rather than going unrecorded, so a full cache keeps recording instead of
  * freezing at whatever filled it first. Insertion-order eviction serves a
- * repeated cycle of shapes only while the whole cycle fits under the cap,
- * so the cap is sized to clear one client's page load (a topics-board
- * reload arrives as ~23 frames, most of them watch batches) with room for
- * other clients' shapes and for per-session tainted entries, which never
- * serve anyone else.
+ * repeated cycle of shapes only while the whole cycle fits under the cap.
  */
-export const EVALUATION_CACHE_MAX_ENTRIES = 64;
+export const EVALUATION_CACHE_MAX_ENTRIES = 16;
 
 export type QueryEvaluationCacheDiagnostics = {
   seq: number;

--- a/packages/memory/v2/query.ts
+++ b/packages/memory/v2/query.ts
@@ -507,8 +507,14 @@ const evaluationIdentityKey = (options: TrackGraphOptions): string =>
  * adversarial query-shape churn, not the memory bound. Memory is bounded
  * by the server's cross-space retained-entity budget, which evicts by
  * weight (see Server's evaluation-cache budget).
+ *
+ * The bound holds by eviction: at the cap a new shape displaces the oldest
+ * entry (Map insertion order — the order the weight budget evicts in too)
+ * rather than going unrecorded, so a full cache keeps recording instead of
+ * freezing at whatever filled it first. Insertion-order eviction serves a
+ * repeated cycle of shapes only while the whole cycle fits under the cap.
  */
-const EVALUATION_CACHE_MAX_ENTRIES = 16;
+export const EVALUATION_CACHE_MAX_ENTRIES = 16;
 
 export type QueryEvaluationCacheDiagnostics = {
   seq: number;
@@ -520,6 +526,12 @@ export type QueryEvaluationCacheDiagnostics = {
 
   misses: number;
   rotations: number;
+
+  /** Entries displaced at the entry cap by a newer shape. */
+  capEvictions: number;
+
+  /** Entries removed by the server's cross-space weight budget. */
+  budgetEvictions: number;
 
   /** Serves of a scope-pure entry (identical for every identity). */
   hitsPure: number;
@@ -627,6 +639,13 @@ export type QueryEvaluationCache = {
   /** Times the cache was rotated out — a newer engine seq, or a different
    * engine object for the same space. */
   rotations: number;
+
+  /** Entries displaced at EVALUATION_CACHE_MAX_ENTRIES by a newer shape. */
+  capEvictions: number;
+
+  /** Entries the server's weight budget removed (its enforcement pass
+   * counts here; the cache itself never evicts by weight). */
+  budgetEvictions: number;
 };
 
 export const createQueryEvaluationCache = (): QueryEvaluationCache => ({
@@ -640,6 +659,8 @@ export const createQueryEvaluationCache = (): QueryEvaluationCache => ({
   residueRefusals: 0,
   misses: 0,
   rotations: 0,
+  capEvictions: 0,
+  budgetEvictions: 0,
 });
 
 export const queryEvaluationCacheDiagnostics = (
@@ -656,6 +677,8 @@ export const queryEvaluationCacheDiagnostics = (
     hits: cache.hitsPure + cache.hitsAbsentResidue + cache.hitsIdentity,
     misses: cache.misses,
     rotations: cache.rotations,
+    capEvictions: cache.capEvictions,
+    budgetEvictions: cache.budgetEvictions,
     hitsPure: cache.hitsPure,
     hitsAbsentResidue: cache.hitsAbsentResidue,
     hitsIdentity: cache.hitsIdentity,
@@ -1584,16 +1607,26 @@ export const trackGraph = (
     ...lazyState,
     rootFamilies,
   };
-  if (
-    cache !== undefined && cacheKeys !== undefined &&
-    cache.entries.size < EVALUATION_CACHE_MAX_ENTRIES
-  ) {
+  if (cache !== undefined && cacheKeys !== undefined) {
     // The cache keeps its own clone: the state returned below belongs to
     // the caller's session, whose refreshes and extensions mutate it.
     const share = classifyStateScope(state);
     const weight = state.entities.size;
     const key = share.kind === "tainted" ? cacheKeys.identity : cacheKeys.pure;
     const previous = cache.entries.get(key);
+    if (
+      previous === undefined &&
+      cache.entries.size >= EVALUATION_CACHE_MAX_ENTRIES
+    ) {
+      // A new shape at the cap displaces the oldest entry; re-recording a
+      // present key (a refused absent-residue share re-evaluated) replaces
+      // in place and grows nothing.
+      const oldestKey = cache.entries.keys().next().value!;
+      const oldest = cache.entries.get(oldestKey)!;
+      cache.entries.delete(oldestKey);
+      cache.weight -= oldest.weight;
+      cache.capEvictions++;
+    }
     cache.entries.set(key, {
       state: cloneTrackedGraphState(engine, state),
       share,

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -437,6 +437,13 @@ export const getDocumentCachesDiagnostics = ():
 export type EvaluationCachesDiagnostics = {
   budget: number;
   weight: number;
+
+  /** Spaces whose cache OBJECT was dropped — by the space bound or the
+   * empty-cache sweep — taking the space's counters with it. Per-space
+   * records live as long as their object: while this count holds still
+   * between two captures, every record present in both is continuous. */
+  spacesDropped: number;
+
   spaces: Record<string, QueryEvaluationCacheDiagnostics>;
 };
 
@@ -1407,6 +1414,14 @@ export class Server {
    * most QUERY_EVALUATION_CACHE_MAX_SPACES spaces in LRU order. */
   #queryEvaluationCaches = new Map<string, QueryEvaluationCache>();
 
+  /** Cache objects dropped so far (see EvaluationCachesDiagnostics). */
+  #evaluationCacheSpacesDropped = 0;
+
+  /** This server's health-route provider, kept so close() can withdraw
+   * exactly it and never a successor's. */
+  #evaluationCachesDiagnosticsProvider = () =>
+    this.evaluationCachesDiagnostics();
+
   #engines = new Map<string, Promise<Engine.Engine>>();
   // The resolved-engine index for the SYNC cross-engine lease lookup
   // (server-execution v2 Phase 5; see openEngine / #liveCoHostedLeaseSpaceFor).
@@ -1626,8 +1641,8 @@ export class Server {
     documentCachesDiagnosticsProviders.push(
       this.#documentCachesDiagnosticsProvider,
     );
-    evaluationCachesDiagnosticsProvider = () =>
-      this.evaluationCachesDiagnostics();
+    evaluationCachesDiagnosticsProvider =
+      this.#evaluationCachesDiagnosticsProvider;
   }
 
   /** This server's health-route providers, kept so close() can withdraw
@@ -2151,6 +2166,16 @@ export class Server {
       documentCachesDiagnosticsProviders,
       this.#documentCachesDiagnosticsProvider,
     );
+    // Withdraw the health-route provider if it is still this server's, so
+    // a closed server is neither reported nor kept alive by the route.
+    // Synchronous, ahead of the first await: an un-awaited close still
+    // withdraws it at once.
+    if (
+      evaluationCachesDiagnosticsProvider ===
+        this.#evaluationCachesDiagnosticsProvider
+    ) {
+      evaluationCachesDiagnosticsProvider = undefined;
+    }
     this.#cancelScheduledRefresh();
     await this.#refreshing;
     await this.#drainSpacePublicationLocks();
@@ -4686,6 +4711,7 @@ export class Server {
       const oldest = this.#queryEvaluationCaches.keys().next().value;
       if (oldest !== undefined) {
         this.#queryEvaluationCaches.delete(oldest);
+        this.#evaluationCacheSpacesDropped++;
       }
     }
     return cache;
@@ -4706,11 +4732,14 @@ export class Server {
     // Entry-less leftovers (drained by an earlier pass, or rotation-
     // cleared and idle since) drop before eviction: an empty cache holds
     // no weight, only a stale LRU slot. The rebuild preserves order.
+    const before = this.#queryEvaluationCaches.size;
     this.#queryEvaluationCaches = new Map(
       [...this.#queryEvaluationCaches].filter(
         ([, cache]) => cache.entries.size > 0,
       ),
     );
+    this.#evaluationCacheSpacesDropped += before -
+      this.#queryEvaluationCaches.size;
     // Least-recently-evaluated spaces first (map insertion order IS the
     // LRU order), oldest entry first within each. A space drained by THIS
     // pass keeps its cache — its counters and LRU position belong to a
@@ -4745,7 +4774,7 @@ export class Server {
    * per-space form: nothing is created or recency-bumped. A space lists
    * for as long as its cache object lives (its counters outlive rotation,
    * which clears entries only), and disappears once the space bound or a
-   * budget pass drops the cache itself. */
+   * budget pass drops the cache itself — `spacesDropped` counts those. */
   evaluationCachesDiagnostics(): EvaluationCachesDiagnostics {
     const spaces: Record<string, QueryEvaluationCacheDiagnostics> = {};
     let weight = 0;
@@ -4757,6 +4786,7 @@ export class Server {
       budget: this.options.queryEvaluationCacheBudget ??
         QUERY_EVALUATION_CACHE_BUDGET,
       weight,
+      spacesDropped: this.#evaluationCacheSpacesDropped,
       spaces,
     };
   }

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -432,6 +432,24 @@ export const getDocumentCachesDiagnostics = ():
   | DocumentCachesDiagnostics
   | undefined => documentCachesDiagnosticsProviders.at(-1)?.();
 
+/** Every cached space's evaluation-cache counters, with the caches' total
+ * retained weight against the cross-space budget. */
+export type EvaluationCachesDiagnostics = {
+  budget: number;
+  weight: number;
+  spaces: Record<string, QueryEvaluationCacheDiagnostics>;
+};
+
+let evaluationCachesDiagnosticsProvider:
+  | (() => EvaluationCachesDiagnostics)
+  | undefined;
+
+/** The co-hosted memory server's evaluation-cache counters for the health
+ * route; undefined when no server has been constructed in this process. */
+export const getEvaluationCachesDiagnostics = ():
+  | EvaluationCachesDiagnostics
+  | undefined => evaluationCachesDiagnosticsProvider?.();
+
 const randomHex = (bytes: number): string => {
   const data = crypto.getRandomValues(new Uint8Array(bytes));
   return [...data].map((byte) => byte.toString(16).padStart(2, "0")).join("");
@@ -1608,6 +1626,8 @@ export class Server {
     documentCachesDiagnosticsProviders.push(
       this.#documentCachesDiagnosticsProvider,
     );
+    evaluationCachesDiagnosticsProvider = () =>
+      this.evaluationCachesDiagnostics();
   }
 
   /** This server's health-route providers, kept so close() can withdraw
@@ -4701,6 +4721,7 @@ export class Server {
         const entry = cache.entries.get(oldestEntry)!;
         cache.entries.delete(oldestEntry);
         cache.weight -= entry.weight;
+        cache.budgetEvictions++;
         total -= entry.weight;
       }
       if (total <= budget) return;
@@ -4717,6 +4738,27 @@ export class Server {
     return queryEvaluationCacheDiagnostics(
       cache ?? createQueryEvaluationCache(),
     );
+  }
+
+  /** Every cached space's counters and the caches' total retained weight
+   * against the budget — the health route's view. A peek like the
+   * per-space form: nothing is created or recency-bumped. A space lists
+   * for as long as its cache object lives (its counters outlive rotation,
+   * which clears entries only), and disappears once the space bound or a
+   * budget pass drops the cache itself. */
+  evaluationCachesDiagnostics(): EvaluationCachesDiagnostics {
+    const spaces: Record<string, QueryEvaluationCacheDiagnostics> = {};
+    let weight = 0;
+    for (const [space, cache] of this.#queryEvaluationCaches) {
+      spaces[space] = queryEvaluationCacheDiagnostics(cache);
+      weight += cache.weight;
+    }
+    return {
+      budget: this.options.queryEvaluationCacheBudget ??
+        QUERY_EVALUATION_CACHE_BUDGET,
+      weight,
+      spaces,
+    };
   }
 
   async evaluateGraphQuery(

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -447,15 +447,18 @@ export type EvaluationCachesDiagnostics = {
   spaces: Record<string, QueryEvaluationCacheDiagnostics>;
 };
 
-let evaluationCachesDiagnosticsProvider:
-  | (() => EvaluationCachesDiagnostics)
-  | undefined;
+/** Live servers' providers in construction order; a server removes its own
+ * on close(), so the newest LIVE server is always the one reported. */
+const evaluationCachesDiagnosticsProviders: (
+  () => EvaluationCachesDiagnostics
+)[] = [];
 
 /** The co-hosted memory server's evaluation-cache counters for the health
- * route; undefined when no server has been constructed in this process. */
+ * route — the most recently constructed server still open; undefined when
+ * none is. */
 export const getEvaluationCachesDiagnostics = ():
   | EvaluationCachesDiagnostics
-  | undefined => evaluationCachesDiagnosticsProvider?.();
+  | undefined => evaluationCachesDiagnosticsProviders.at(-1)?.();
 
 const randomHex = (bytes: number): string => {
   const data = crypto.getRandomValues(new Uint8Array(bytes));
@@ -1418,7 +1421,7 @@ export class Server {
   #evaluationCacheSpacesDropped = 0;
 
   /** This server's health-route provider, kept so close() can withdraw
-   * exactly it and never a successor's. */
+   * exactly it and no other server's. */
   #evaluationCachesDiagnosticsProvider = () =>
     this.evaluationCachesDiagnostics();
 
@@ -1634,15 +1637,15 @@ export class Server {
       options.documentCacheTotalBudgetBytes ??
         DOCUMENT_CACHE_TOTAL_BUDGET_BYTES,
     );
-    // Module-level providers for the health route (push-priority counters,
-    // Phase 6; document caches): the newest live server is reported, and
-    // close() withdraws exactly this server's.
+    // Module-level providers for the health route: the newest live server is
+    // reported, and close() withdraws exactly this server's.
     pushPriorityStatsProviders.push(this.#pushPriorityStatsProvider);
     documentCachesDiagnosticsProviders.push(
       this.#documentCachesDiagnosticsProvider,
     );
-    evaluationCachesDiagnosticsProvider =
-      this.#evaluationCachesDiagnosticsProvider;
+    evaluationCachesDiagnosticsProviders.push(
+      this.#evaluationCachesDiagnosticsProvider,
+    );
   }
 
   /** This server's health-route providers, kept so close() can withdraw
@@ -2166,16 +2169,10 @@ export class Server {
       documentCachesDiagnosticsProviders,
       this.#documentCachesDiagnosticsProvider,
     );
-    // Withdraw the health-route provider if it is still this server's, so
-    // a closed server is neither reported nor kept alive by the route.
-    // Synchronous, ahead of the first await: an un-awaited close still
-    // withdraws it at once.
-    if (
-      evaluationCachesDiagnosticsProvider ===
-        this.#evaluationCachesDiagnosticsProvider
-    ) {
-      evaluationCachesDiagnosticsProvider = undefined;
-    }
+    withdrawProvider(
+      evaluationCachesDiagnosticsProviders,
+      this.#evaluationCachesDiagnosticsProvider,
+    );
     this.#cancelScheduledRefresh();
     await this.#refreshing;
     await this.#drainSpacePublicationLocks();

--- a/packages/toolshed/routes/health/health.handlers.ts
+++ b/packages/toolshed/routes/health/health.handlers.ts
@@ -4,6 +4,7 @@ import type { AppRouteHandler } from "@/lib/types.ts";
 import type { DashRoute, IndexRoute, StatsRoute } from "./health.routes.ts";
 import {
   getDocumentCachesDiagnostics,
+  getEvaluationCachesDiagnostics,
   getPushPriorityStats,
   getSlowQueries,
 } from "@commonfabric/memory/v2/server";
@@ -57,6 +58,11 @@ export const stats: AppRouteHandler<StatsRoute> = (c) => {
   // whether a corpus's working set stays resident between the walks that
   // read it. Present whenever a memory server is co-hosted.
   const documentCaches = getDocumentCachesDiagnostics();
+  // The memory server's query evaluation caches, per space: whether the
+  // corpus's watch establishment is being served or re-walked, and why
+  // (hit class, taint, rotation, eviction). Present whenever a memory
+  // server is co-hosted — every serving toolshed, both arms.
+  const evaluationCaches = getEvaluationCachesDiagnostics();
   return c.json({
     timestamp: Date.now(),
     serverStart: serverStartTimestamp,
@@ -64,6 +70,7 @@ export const stats: AppRouteHandler<StatsRoute> = (c) => {
     timingStats: getTimingStatsBreakdown(),
     slowQueries: [...getSlowQueries()],
     ...(documentCaches === undefined ? {} : { documentCaches }),
+    ...(evaluationCaches === undefined ? {} : { evaluationCaches }),
     ...(servingLoop === undefined ? {} : {
       servingLoop: { ...servingLoop, ...(push === undefined ? {} : { push }) },
     }),

--- a/packages/toolshed/routes/health/health.routes.ts
+++ b/packages/toolshed/routes/health/health.routes.ts
@@ -50,6 +50,16 @@ export const stats = createRoute({
             }),
           ),
         }).optional(),
+        // The memory server's query evaluation caches
+        // (packages/memory/v2/query.ts `QueryEvaluationCacheDiagnostics`),
+        // keyed by space, with the caches' retained weight against the
+        // cross-space budget — present whenever a memory server is
+        // co-hosted in this process.
+        evaluationCaches: z.object({
+          budget: z.number(),
+          weight: z.number(),
+          spaces: z.record(z.string(), z.any()),
+        }).optional(),
         // The serving loop's counters (server-execution v2,
         // serving-loop.md §7) — present only while an ExecutorHost runs
         // in this process (the ON arm).

--- a/packages/toolshed/routes/health/health.routes.ts
+++ b/packages/toolshed/routes/health/health.routes.ts
@@ -58,6 +58,10 @@ export const stats = createRoute({
         evaluationCaches: z.object({
           budget: z.number(),
           weight: z.number(),
+          // Cache objects dropped so far; a reader compares two captures
+          // only while this holds still (profiling.md, "Read
+          // /api/health/stats").
+          spacesDropped: z.number(),
           spaces: z.record(z.string(), z.any()),
         }).optional(),
         // The serving loop's counters (server-execution v2,

--- a/packages/toolshed/routes/health/health.test.ts
+++ b/packages/toolshed/routes/health/health.test.ts
@@ -2,9 +2,9 @@ import { assertEquals } from "@std/assert";
 import { Server } from "@commonfabric/memory/v2/server";
 
 import env from "@/env.ts";
-import { stats as statsRoute } from "@/routes/health/health.routes.ts";
 import createApp from "@/lib/create-app.ts";
 import router from "@/routes/health/health.index.ts";
+import { stats as statsRoute } from "@/routes/health/health.routes.ts";
 
 if (env.ENV !== "test") {
   throw new Error("ENV must be 'test'");
@@ -123,7 +123,29 @@ Deno.test("health routes", async (t) => {
         );
         assertEquals(typeof json.evaluationCaches.budget, "number");
         assertEquals(json.evaluationCaches.weight, 0);
+        assertEquals(json.evaluationCaches.spacesDropped, 0);
         assertEquals(json.evaluationCaches.spaces, {});
+
+        // The declared response schema admits the live response and requires
+        // the continuity signal a reader depends on (`spacesDropped`).
+        const declared = (statsRoute.responses as Record<
+          number,
+          {
+            content: {
+              "application/json": {
+                schema: { safeParse(value: unknown): { success: boolean } };
+              };
+            };
+          }
+        >)[200].content["application/json"].schema;
+        assertEquals(declared.safeParse(json).success, true);
+        const { spacesDropped: _dropped, ...withoutDropped } =
+          json.evaluationCaches;
+        assertEquals(
+          declared.safeParse({ ...json, evaluationCaches: withoutDropped })
+            .success,
+          false,
+        );
       } finally {
         await server.close();
       }

--- a/packages/toolshed/routes/health/health.test.ts
+++ b/packages/toolshed/routes/health/health.test.ts
@@ -98,4 +98,35 @@ Deno.test("health routes", async (t) => {
       }
     },
   );
+
+  await t.step(
+    "GET /api/health/stats reports the memory server's evaluation caches",
+    async () => {
+      // The provider is module-level and registered by the Server
+      // constructor (last registration wins), so a server constructed here
+      // stands in for the co-hosted one; it has evaluated nothing.
+      const server = new Server({
+        store: new URL("memory://health-stats-test"),
+        authorizeSessionOpen: () => "did:key:z6Mk-health-stats-principal",
+        sessionOpenAuth: { audience: "did:key:z6Mk-health-stats-audience" },
+      });
+      try {
+        const response = await app.request("/api/health/stats");
+        assertEquals(response.status, 200);
+
+        const json = await response.json();
+        assertEquals(typeof json.serverStart, "number");
+        assertEquals(Array.isArray(json.slowQueries), true);
+        assertEquals(
+          json.evaluationCaches,
+          server.evaluationCachesDiagnostics(),
+        );
+        assertEquals(typeof json.evaluationCaches.budget, "number");
+        assertEquals(json.evaluationCaches.weight, 0);
+        assertEquals(json.evaluationCaches.spaces, {});
+      } finally {
+        await server.close();
+      }
+    },
+  );
 });


### PR DESCRIPTION
## Why

After #6726 the topics board on rapids still pays its full ~7 s server traversal on every load at a **constant** seq: `rootsVisited == watches` on every slow batch across two reloads and two isolation reads, with no commit in between. The query evaluation cache is built to share exactly this kind of work, and its counters (#6457) would say why it serves nothing, but no route exposed them, so the cause was undecidable from outside the process.

## What

Diagnostics, no behavior change to the cache's admission, no experimental flag (cheap, always on).

- `/api/health/stats` gains `evaluationCaches`: `{ budget, weight, spacesDropped, spaces: { <space DID>: QueryEvaluationCacheDiagnostics } }`, declared in the route schema. A registry of live servers' providers in construction order (the newest live server is reported; `close()` removes a server's own entry), mirroring the push-priority counters' module-level posture. The read is a peek: nothing created or recency-bumped. Present whenever a memory server is co-hosted, optional in the schema so a process without one is honest rather than reporting zeros.
- Counters for every way an entry or record can vanish: `capRefusals` (a full cache turned a new shape away; admission is unchanged from before this PR, so a frozen cache is now visible rather than silent), `budgetEvictions` (the weight budget's pass, counted on the evicted space's cache), and `spacesDropped` (a space's cache object dropped by the space bound or the empty-cache sweep, taking its counters with it). Per-space records live as long as their object, so compare two captures only while `spacesDropped` holds still.
- Identity semantics untouched: `classifyStateScope` alone still decides who an entry may serve; key-vocabulary.md §5's inventory stands as written.

History on this branch, for the reviewer: an evict-oldest-at-cap policy and a cap raise (16 → 64) were committed and both reverted. The cap raise rested on a wrong premise (a load records one shape, not one per batch, see below); the eviction turned a stable cycle one shape longer than the cap into a miss on every step (sol's measurement: 0 hits, 17 misses on the repeat where the admission guard serves 16). Admission is back to the pre-PR guard, with the refusals counted.

## What the counters showed, first reading

Against a local copy of the production board (the Aug 31 estuary snapshot), two identical `cf` reads of the board's argument doc, thirty seconds apart, no commit between:

| | read 1 | read 2 |
|---|---|---|
| cache-eligible evaluations | 1 miss, entry recorded, **pure** | 1 **hit** (`hitsPure`) |
| `session.watch.add` batches | 135 / 5,602 / 1,161 roots, all `rootsVisited == watches` | same three, same shape, all re-walked |
| wall | 7.9 s | 8.3 s |

Not taint, not the cap, not the budget: **eligibility**. In `session.watch.add`, only a session's first watch group per branch calls `trackGraph` with the cache; every later `watch.add` in that session goes through `extendTrackedGraph`, which never consults it, by design (an extension's walk depends on what the session already covers). A page load grows its watch set batch by batch, so it records one entry and re-walks the rest on every load, on every server. The cache's coverage is many sessions establishing one corpus (resume, reconnect stampedes), not one session's incremental establishment. `packages/memory/v2/query.ts`'s cache doc and the profiling doc now say so, so `rootsVisited == watches` on those batches reads as the design rather than as a miss. A real page load on the same rig confirmed it: one eligible evaluation, five large extension batches.

## Tests

`packages/memory/test/v2-query-evaluation-cache.test.ts`
- **keeps a full cache's working set and counts the shapes it turns away**: `MAX_ENTRIES + 1` distinct shapes at one seq, then the same sequence again; `MAX_ENTRIES` are served on the repeat (`rootsVisited` 0), the extra shape is refused and counted both times. Mutation-checked: with evict-oldest in place the repeat serves nothing.
- **reports every cached space through the health provider**: the provider's report equals `server.evaluationCachesDiagnostics()`, each space equals the per-space peek; budget, summed weight, `spacesDropped` 0; a never-evaluated space absent.
- **reports the newest live server's caches, whichever order servers close**: newest-closes-first hands back to the older live server; oldest-closes-first leaves the newest in place; both measured relative to the registry's prior state.
- `budgetEvictions` asserted on the existing budget tests; the space-bound test asserts `spacesDropped` and the record's absence; the budget test gains a third space whose insert sweeps the drained first space, counted.

`packages/toolshed/routes/health/health.test.ts`: `GET /api/health/stats` carries `evaluationCaches` equal to the constructed server's report, the live response parses through the declared route schema, and the same response without `spacesDropped` fails it.

Gates (deno 2.9.4, the mise pin): fmt, lint, `deno task check` (workspace), `packages/memory` 595 passed / 0 failed, `packages/toolshed` 146 passed / 0 failed, `check-test-aliases` clean.

## Docs

`docs/development/debugging/profiling.md`, "Read `/api/health/stats`": the field, what the cache does and does not cover, how to read the counters as a difference across one repeated establishment at a constant `seq`, and the lifetime caveat (`spacesDropped`); the process-lifetime paragraph is scoped to `timingStats` and `logCounts`.

Not touched: `/api/health/dash`, `SlowQuery`, the cache's admission policy.

## After deploy

```
curl -s http://127.0.0.1:PORT/api/health/stats | jq '.evaluationCaches'
```
On the shard serving a space, before and after one board reload: expect one miss (the first batch) and no serving of the later batches; a session resume or reconnect stampede is where `hits` should climb, and `capRefusals` rising says the seq's distinct shapes outnumber the cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
