### PR TITLE
refactor(data-model): a fabric primitive renders with its realm-crossing state

### DIFF
--- a/packages/data-model/src/fabric-bases/BaseFabricPrimitive.ts
+++ b/packages/data-model/src/fabric-bases/BaseFabricPrimitive.ts
@@ -65,7 +65,7 @@ export abstract class BaseFabricPrimitive extends FabricPrimitive {
    *
    * Delegates to the canonical debug renderer rather than formatting here, so
    * that this surface improves whenever that one does. Instance state is
-   * elided as `(...)`.
+   * rendered as the value's realm-crossing encoding.
    *
    * Duplicated on `BaseFabricInstance`, unavoidably. There is no shared base
    * class below `FabricSpecialObject`, and `FabricSpecialObject` itself is the

--- a/packages/data-model/src/value-debug.ts
+++ b/packages/data-model/src/value-debug.ts
@@ -19,7 +19,7 @@ import {
 // initialization". `codecOf.ts` itself is a leaf.
 import { codecOf } from "@/codec-common/codecOf.ts";
 import { isCodecTypeTag } from "@/codec-common/isCodecTypeTag.ts";
-import { JSON_CODEC } from "@/codec-interface/interface.ts";
+import { REALM_CODEC } from "@/codec-interface/interface.ts";
 import { NULL_LIVE_ENVIRONMENT } from "@/codec-interface/NullLiveEnvironment.ts";
 
 /**
@@ -60,6 +60,22 @@ function taggedFormOf(
   }
 
   return { tag: onlyKey.slice(1), payload: value[onlyKey] };
+}
+
+/**
+ * Replacer for the conversion of a realm-crossing encoding, which represents
+ * the one terminal that encoding uses and no `FabricValue` can hold: an
+ * `ArrayBuffer`, rendered as a `0x`-prefixed hexadecimal string of its bytes.
+ * Everything else is returned as it stands.
+ */
+function replaceRealmTerminal(value: unknown): unknown {
+  if (value instanceof ArrayBuffer) {
+    const hex = [...new Uint8Array(value)]
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("");
+    return `0x${hex}`;
+  }
+  return value;
 }
 
 /**
@@ -399,24 +415,36 @@ class DebugStringifier {
   }
 
   /**
-   * Renders a `FabricPrimitive`, in the elided form `/TypeName(...)`, where the
-   * type name is that of its codec type tag. When the codec cannot be found,
-   * the class name stands in for the type name.
+   * Renders a `FabricPrimitive` as `/TypeName(<state>)`, where the type name
+   * is that of its codec type tag and the state is its realm-crossing
+   * encoding, in the same form a class instance's properties take. When the
+   * codec cannot be found, the class name stands in for the type name and the
+   * state is elided.
    */
-  #renderFabricPrimitive(value: FabricPrimitive): string {
+  #renderFabricPrimitive(value: FabricPrimitive, indent: string): string {
     let tag;
+    let state: FabricValue;
 
     try {
-      // A `FabricPrimitive` binds no `[CODEC]`, so its JSON codec supplies the
-      // tag. TODO(danfuzz): Replace `JSON_CODEC` with `DEBUG_CODEC` once the
-      // latter exists.
-      tag = codecOf(value, JSON_CODEC).tagForValue(value);
+      // A `FabricPrimitive` binds no `[CODEC]`, so its realm codec supplies
+      // the tag and the state. That codec is the one whose terminals are the
+      // richest -- a `bigint` stays a `bigint`, bytes stay bytes -- which is
+      // what makes it the one to render. TODO(danfuzz): Replace `REALM_CODEC`
+      // with `DEBUG_CODEC` once the latter exists.
+      const codec = codecOf(value, REALM_CODEC);
+      tag = codec.tagForValue(value);
+      state = toStructuredDebugValue(
+        codec.encode(value, NULL_LIVE_ENVIRONMENT),
+        DEBUG_STRING_MAX_DEPTH,
+        replaceRealmTerminal,
+      );
     } catch {
-      // Never let the debug renderer throw; fall back to the class name.
-      tag = classNameOf(value);
+      // Never let the debug renderer throw; fall back to the class name, with
+      // the state elided.
+      return DebugStringifier.#renderElidedInstance(classNameOf(value));
     }
 
-    return DebugStringifier.#renderElidedInstance(tag);
+    return this.#renderInstance(tag.replace(/@.*$/, ""), state, indent);
   }
 
   /**
@@ -571,7 +599,7 @@ class DebugStringifier {
         } else if (Array.isArray(value)) {
           return this.#renderArray(value, indent);
         } else if (value instanceof FabricPrimitive) {
-          return this.#renderFabricPrimitive(value);
+          return this.#renderFabricPrimitive(value, indent);
         } else {
           // The conversion represents every other non-plain object as a plain
           // one, so what is left is a plain object.
@@ -598,10 +626,10 @@ class DebugStringifier {
   //
 
   /**
-   * Renders the elided form of a `FabricInstance` or `FabricPrimitive`, given
-   * its codec type tag (or, failing that, its class name). The slash suggests
-   * a known encodable type rather than an instance of some random class, and
-   * the version of the tag is left out.
+   * Renders the elided form of a `FabricInstance`, or of a `FabricPrimitive`
+   * whose state cannot be had, given its codec type tag (or, failing that,
+   * its class name). The slash suggests a known encodable type rather than an
+   * instance of some random class, and the version of the tag is left out.
    */
   static #renderElidedInstance(tag: string): string {
     return `/${tag.replace(/@.*$/, "")}(...)`;

--- a/packages/data-model/src/value-debug.ts
+++ b/packages/data-model/src/value-debug.ts
@@ -481,8 +481,8 @@ class DebugStringifier {
       );
 
       if (tagged !== undefined) {
-        // A marker in a plain object's shape, rendered as what it stands for
-        // rather than spread as properties.
+        // A marker form, rendered as what it stands for rather than spread as
+        // properties.
         return `${open}${this.#renderTaggedForm(tagged, indent)})`;
       } else {
         const parts = this.#renderProperties(

--- a/packages/data-model/src/value-debug.ts
+++ b/packages/data-model/src/value-debug.ts
@@ -37,6 +37,12 @@ const DEBUG_STRING_MAX_DEPTH = 10;
 type PrimitiveState = RealmCodecValue | FabricValue;
 
 /**
+ * One of the conversion's single-key tagged forms, taken apart: the tag,
+ * less its leading slash, and the payload under it.
+ */
+type TaggedForm = { readonly tag: string; readonly payload: FabricValue };
+
+/**
  * Returns the class name of the given object, or `<anonymous>` when it has
  * none. A class with no name reports it as the empty string, which counts.
  */
@@ -469,16 +475,22 @@ class DebugStringifier {
 
     if (payload === "/...") {
       return `${open}...)`;
-    } else if (
-      isPlainObject(payload) &&
-      (DebugStringifier.#taggedFormOf(payload as FabricPlainObject) ===
-        undefined)
-    ) {
-      const parts = this.#renderProperties(
+    } else if (isPlainObject(payload)) {
+      const tagged = DebugStringifier.#taggedFormOf(
         payload as FabricPlainObject,
-        indent,
       );
-      return this.#renderContainer(open, ")", parts, indent);
+
+      if (tagged !== undefined) {
+        // A marker in a plain object's shape, rendered as what it stands for
+        // rather than spread as properties.
+        return `${open}${this.#renderTaggedForm(tagged, indent)})`;
+      } else {
+        const parts = this.#renderProperties(
+          payload as FabricPlainObject,
+          indent,
+        );
+        return this.#renderContainer(open, ")", parts, indent);
+      }
     } else {
       // The payload sits where the parenthesis opens, so it takes the
       // indentation of the parenthesis itself.
@@ -494,61 +506,11 @@ class DebugStringifier {
     const tagged = DebugStringifier.#taggedFormOf(value);
 
     if (tagged !== undefined) {
-      const { tag, payload } = tagged;
-
-      if (isCodecTypeTag(tag)) {
-        // A `FabricInstance`, carried as its encoding under its codec type tag.
-        return DebugStringifier.#renderElidedInstance(tag);
-      }
-
-      switch (tag) {
-        case "circle": {
-          // A reference back to an enclosing object.
-          return "<circle>";
-        }
-
-        case "uniqueSymbol": {
-          // A unique (uninterned) symbol, whose payload is its description.
-          return (payload === undefined)
-            ? "Symbol()"
-            : `Symbol(${JSON.stringify(payload)})`;
-        }
-
-        case "function": {
-          // A function, whose payload names it, or is `/unconvertible` when
-          // even that failed; the latter falls through to render as it is.
-          const name = (typeof payload === "string")
-            ? payload.match(/^(?<name>.*)\(\.\.\.\)$/)?.groups?.name
-            : undefined;
-          if (name === "<anonymous>") {
-            return "(...) => {...}";
-          } else if (name !== undefined) {
-            return `function ${name}(...) {...}`;
-          }
-          return this.#renderInstance(tag, payload, indent);
-        }
-
-        case "unconvertible": {
-          // A value the conversion could not read, whose payload is the
-          // error's message.
-          return this.#renderInstance(tag, payload, indent);
-        }
-
-        case "...": {
-          // The depth-limit marker. What kind of value was elided is left
-          // out of the rendering.
-          return "...";
-        }
-
-        default: {
-          // A class instance, carried under its class name.
-          return this.#renderInstance(tag, payload, indent);
-        }
-      }
+      return this.#renderTaggedForm(tagged, indent);
+    } else {
+      const parts = this.#renderProperties(value, indent);
+      return this.#renderContainer("{", "}", parts, indent);
     }
-
-    const parts = this.#renderProperties(value, indent);
-    return this.#renderContainer("{", "}", parts, indent);
   }
 
   /**
@@ -630,6 +592,65 @@ class DebugStringifier {
     }
   }
 
+  /**
+   * Renders one of the conversion's single-key tagged forms, as what it
+   * stands for, with a container's closing bracket (when there is one and
+   * the rendering is multi-line) indented by `indent`.
+   */
+  #renderTaggedForm(tagged: TaggedForm, indent: string): string {
+    const { tag, payload } = tagged;
+
+    if (isCodecTypeTag(tag)) {
+      // A `FabricInstance`, carried as its encoding under its codec type tag.
+      return DebugStringifier.#renderElidedInstance(tag);
+    }
+
+    switch (tag) {
+      case "circle": {
+        // A reference back to an enclosing object.
+        return "<circle>";
+      }
+
+      case "uniqueSymbol": {
+        // A unique (uninterned) symbol, whose payload is its description.
+        return (payload === undefined)
+          ? "Symbol()"
+          : `Symbol(${JSON.stringify(payload)})`;
+      }
+
+      case "function": {
+        // A function, whose payload names it, or is `/unconvertible` when
+        // even that failed; the latter falls through to render as it is.
+        const name = (typeof payload === "string")
+          ? payload.match(/^(?<name>.*)\(\.\.\.\)$/)?.groups?.name
+          : undefined;
+        if (name === "<anonymous>") {
+          return "(...) => {...}";
+        } else if (name !== undefined) {
+          return `function ${name}(...) {...}`;
+        }
+        return this.#renderInstance(tag, payload, indent);
+      }
+
+      case "unconvertible": {
+        // A value the conversion could not read, whose payload is the
+        // error's message.
+        return this.#renderInstance(tag, payload, indent);
+      }
+
+      case "...": {
+        // The depth-limit marker. What kind of value was elided is left
+        // out of the rendering.
+        return "...";
+      }
+
+      default: {
+        // A class instance, carried under its class name.
+        return this.#renderInstance(tag, payload, indent);
+      }
+    }
+  }
+
   /** Returns the indentation for the contents of a container indented by `indent`. */
   #innerIndent(indent: string): string {
     return `${indent}${this.#indent ?? ""}`;
@@ -678,9 +699,7 @@ class DebugStringifier {
    * slash; the second-character check rules out the one and the unsafe-key
    * check the other.
    */
-  static #taggedFormOf(
-    value: FabricPlainObject,
-  ): { tag: string; payload: FabricValue } | undefined {
+  static #taggedFormOf(value: FabricPlainObject): TaggedForm | undefined {
     const keys = Object.keys(value);
     const onlyKey = (keys.length === 1) ? keys[0] : undefined;
 

--- a/packages/data-model/src/value-debug.ts
+++ b/packages/data-model/src/value-debug.ts
@@ -395,6 +395,7 @@ class DebugStringifier {
       return DebugStringifier.#renderElidedInstance(classNameOf(value));
     }
 
+    // Trim off the encoding version number.
     const open = `/${tag.replace(/@.*$/, "")}(`;
     const realm = (v: unknown, i: string) => this.#renderRealmState(v, i);
 

--- a/packages/data-model/src/value-debug.ts
+++ b/packages/data-model/src/value-debug.ts
@@ -63,19 +63,15 @@ function taggedFormOf(
 }
 
 /**
- * Replacer for the conversion of a realm-crossing encoding, which represents
- * the one terminal that encoding uses and no `FabricValue` can hold: an
- * `ArrayBuffer`, rendered as a `0x`-prefixed hexadecimal string of its bytes.
- * Everything else is returned as it stands.
+ * Renders an `ArrayBuffer` as `buf [...]`, with its bytes in hexadecimal, a
+ * space after every fourth byte.
  */
-function replaceRealmTerminal(value: unknown): unknown {
-  if (value instanceof ArrayBuffer) {
-    const hex = [...new Uint8Array(value)]
-      .map((b) => b.toString(16).padStart(2, "0"))
-      .join("");
-    return `0x${hex}`;
-  }
-  return value;
+function renderBuffer(buffer: ArrayBuffer): string {
+  const hex = [...new Uint8Array(buffer)]
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("")
+    .replace(/.{8}(?=.)/g, "$& ");
+  return `buf [${hex}]`;
 }
 
 /**
@@ -422,8 +418,8 @@ class DebugStringifier {
    * state is elided.
    */
   #renderFabricPrimitive(value: FabricPrimitive, indent: string): string {
-    let tag;
-    let state: FabricValue;
+    let tag: string;
+    let state: unknown;
 
     try {
       // A `FabricPrimitive` binds no `[CODEC]`, so its realm codec supplies
@@ -433,18 +429,58 @@ class DebugStringifier {
       // with `DEBUG_CODEC` once the latter exists.
       const codec = codecOf(value, REALM_CODEC);
       tag = codec.tagForValue(value);
-      state = toStructuredDebugValue(
-        codec.encode(value, NULL_LIVE_ENVIRONMENT),
-        DEBUG_STRING_MAX_DEPTH,
-        replaceRealmTerminal,
-      );
+      state = codec.encode(value, NULL_LIVE_ENVIRONMENT);
     } catch {
       // Never let the debug renderer throw; fall back to the class name, with
       // the state elided.
       return DebugStringifier.#renderElidedInstance(classNameOf(value));
     }
 
-    return this.#renderInstance(tag.replace(/@.*$/, ""), state, indent);
+    const open = `/${tag.replace(/@.*$/, "")}(`;
+    const realm = (v: unknown, i: string) => this.#renderRealmState(v, i);
+
+    if (isPlainObject(state)) {
+      const parts = this.#renderProperties(
+        state as Record<string, unknown>,
+        indent,
+        realm,
+        false,
+      );
+      return this.#renderContainer(open, ")", parts, indent);
+    }
+
+    return `${open}${this.#renderRealmState(state, indent)})`;
+  }
+
+  /**
+   * Renders a realm-crossing encoding, or a piece of one. The encoding's own
+   * terminal, an `ArrayBuffer`, is rendered as `buf [...]`; its containers are
+   * walked as they stand; and anything else takes the ordinary path through
+   * the conversion.
+   */
+  #renderRealmState(value: unknown, indent: string): string {
+    const realm = (v: unknown, i: string) => this.#renderRealmState(v, i);
+
+    if (value instanceof ArrayBuffer) {
+      return renderBuffer(value);
+    } else if (Array.isArray(value)) {
+      const inner = this.#innerIndent(indent);
+      const parts = value.map((element) => realm(element, inner));
+      return this.#renderContainer("[", "]", parts, indent);
+    } else if (isPlainObject(value)) {
+      const parts = this.#renderProperties(
+        value as Record<string, unknown>,
+        indent,
+        realm,
+        false,
+      );
+      return this.#renderContainer("{", "}", parts, indent);
+    }
+
+    return this.#renderSubvalue(
+      toStructuredDebugValue(value, DEBUG_STRING_MAX_DEPTH),
+      indent,
+    );
   }
 
   /**
@@ -546,18 +582,25 @@ class DebugStringifier {
 
   /**
    * Renders the properties of a plain object, one part per property, for a
-   * container whose closing bracket is indented by `indent`. A key is
-   * rendered as the original value's key: the conversion prefixes a slash to
-   * a key that starts with one and to an unsafe key, and that slash comes
-   * back off here.
+   * container whose closing bracket is indented by `indent`, each value
+   * rendered by `render` (by default, as a converted value). When `unescape`
+   * is `true` (the default), a key is rendered as the original value's key:
+   * the conversion prefixes a slash to a key that starts with one and to an
+   * unsafe key, and that slash comes back off here.
    */
-  #renderProperties(value: FabricPlainObject, indent: string): string[] {
+  #renderProperties(
+    value: Readonly<Record<string, unknown>>,
+    indent: string,
+    render: (value: unknown, indent: string) => string = (v, i) =>
+      this.#renderSubvalue(v as FabricValue, i),
+    unescape = true,
+  ): string[] {
     const inner = this.#innerIndent(indent);
     const separator = (this.#indent === undefined) ? ":" : ": ";
 
     return Object.keys(value).map((key) => {
-      const original = (key[0] === "/") ? key.slice(1) : key;
-      const rendered = this.#renderSubvalue(value[key], inner);
+      const original = (unescape && (key[0] === "/")) ? key.slice(1) : key;
+      const rendered = render(value[key], inner);
       return `${renderKey(original)}${separator}${rendered}`;
     });
   }

--- a/packages/data-model/src/value-debug.ts
+++ b/packages/data-model/src/value-debug.ts
@@ -39,73 +39,6 @@ function classNameOf(value: object): string {
 }
 
 /**
- * Returns the tag and payload of the given plain object when it is one of the
- * conversion's single-key tagged forms, and `undefined` when it is not. No key
- * of an original value can arrive in such a form, because the conversion
- * escapes a key with a leading slash and an unsafe key alike, by prefixing a
- * slash; the second-character check rules out the one and the unsafe-key
- * check the other.
- */
-function taggedFormOf(
-  value: FabricPlainObject,
-): { tag: string; payload: FabricValue } | undefined {
-  const keys = Object.keys(value);
-  const onlyKey = (keys.length === 1) ? keys[0] : undefined;
-
-  if (
-    (onlyKey === undefined) || (onlyKey[0] !== "/") || (onlyKey[1] === "/") ||
-    isUnsafeObjectKey(onlyKey.slice(1))
-  ) {
-    return undefined;
-  }
-
-  return { tag: onlyKey.slice(1), payload: value[onlyKey] };
-}
-
-/**
- * Renders an `ArrayBuffer` as `buf [...]`, with its bytes in hexadecimal, a
- * space after every fourth byte.
- */
-function renderBuffer(buffer: ArrayBuffer): string {
-  const hex = [...new Uint8Array(buffer)]
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("")
-    .replace(/.{8}(?=.)/g, "$& ");
-  return `buf [${hex}]`;
-}
-
-/**
- * Renders a key -- an object property name or a symbol's key -- bare when it
- * is a valid identifier, and as a quoted string otherwise. The identifier
- * check is the ASCII one.
- */
-function renderKey(key: string): string {
-  return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(key) ? key : JSON.stringify(key);
-}
-
-/**
- * Produces the `/unconvertible` result form which stands in for a value whose
- * conversion threw, carrying the message of the error thrown.
- */
-function makeUnconvertibleResult(error: any): FabricValue {
-  const message = (() => {
-    try {
-      if (error instanceof Error) {
-        const msg = error.message;
-        if (typeof msg === "string") {
-          return msg;
-        }
-      }
-      return String(error);
-    } catch {
-      return "/unconvertibleError";
-    }
-  })();
-
-  return { "/unconvertible": message };
-}
-
-/**
  * Helper class for converting values to their valid `FabricValue` debug
  * representations.
  */
@@ -149,7 +82,7 @@ class DebugConverter {
       // close to where they're thrown. This `catch` is a prophylactic "just
       // in case" to help nail down the intention of really really trying not to
       // `throw` out of this method.
-      return makeUnconvertibleResult(e);
+      return DebugConverter.#makeUnconvertibleResult(e);
     }
     // deno-coverage-ignore-stop
   }
@@ -174,7 +107,7 @@ class DebugConverter {
       try {
         byName[key] = this.#convertSubvalue(value[key], depth + 1);
       } catch (e) {
-        byName[key] = makeUnconvertibleResult(e);
+        byName[key] = DebugConverter.#makeUnconvertibleResult(e);
       }
     }
 
@@ -225,7 +158,7 @@ class DebugConverter {
       try {
         result[resultKey] = this.#convertSubvalue(value[key], depth + 1);
       } catch (e) {
-        result[resultKey] = makeUnconvertibleResult(e);
+        result[resultKey] = DebugConverter.#makeUnconvertibleResult(e);
       }
     }
 
@@ -272,7 +205,7 @@ class DebugConverter {
           const content = (name != "") ? `${name}(...)` : "<anonymous>(...)";
           return { "/function": content };
         } catch (e) {
-          return { "/function": makeUnconvertibleResult(e) };
+          return { "/function": DebugConverter.#makeUnconvertibleResult(e) };
         }
       }
 
@@ -331,8 +264,34 @@ class DebugConverter {
         this.#nestingStack.delete(value);
       }
     } catch (e) {
-      return makeUnconvertibleResult(e);
+      return DebugConverter.#makeUnconvertibleResult(e);
     }
+  }
+
+  //
+  // Static members
+  //
+
+  /**
+   * Produces the `/unconvertible` result form which stands in for a value whose
+   * conversion threw, carrying the message of the error thrown.
+   */
+  static #makeUnconvertibleResult(error: any): FabricValue {
+    const message = (() => {
+      try {
+        if (error instanceof Error) {
+          const msg = error.message;
+          if (typeof msg === "string") {
+            return msg;
+          }
+        }
+        return String(error);
+      } catch {
+        return "/unconvertibleError";
+      }
+    })();
+
+    return { "/unconvertible": message };
   }
 }
 
@@ -447,9 +406,9 @@ class DebugStringifier {
         false,
       );
       return this.#renderContainer(open, ")", parts, indent);
+    } else {
+      return `${open}${this.#renderRealmState(state, indent)})`;
     }
-
-    return `${open}${this.#renderRealmState(state, indent)})`;
   }
 
   /**
@@ -462,7 +421,7 @@ class DebugStringifier {
     const realm = (v: unknown, i: string) => this.#renderRealmState(v, i);
 
     if (value instanceof ArrayBuffer) {
-      return renderBuffer(value);
+      return DebugStringifier.#renderBuffer(value);
     } else if (Array.isArray(value)) {
       const inner = this.#innerIndent(indent);
       const parts = value.map((element) => realm(element, inner));
@@ -501,7 +460,8 @@ class DebugStringifier {
       return `${open}...)`;
     } else if (
       isPlainObject(payload) &&
-      (taggedFormOf(payload as FabricPlainObject) === undefined)
+      (DebugStringifier.#taggedFormOf(payload as FabricPlainObject) ===
+        undefined)
     ) {
       const parts = this.#renderProperties(
         payload as FabricPlainObject,
@@ -520,7 +480,7 @@ class DebugStringifier {
    * multi-line) is indented by `indent`.
    */
   #renderPlainObject(value: FabricPlainObject, indent: string): string {
-    const tagged = taggedFormOf(value);
+    const tagged = DebugStringifier.#taggedFormOf(value);
 
     if (tagged !== undefined) {
       const { tag, payload } = tagged;
@@ -601,7 +561,7 @@ class DebugStringifier {
     return Object.keys(value).map((key) => {
       const original = (unescape && (key[0] === "/")) ? key.slice(1) : key;
       const rendered = render(value[key], inner);
-      return `${renderKey(original)}${separator}${rendered}`;
+      return `${DebugStringifier.#renderKey(original)}${separator}${rendered}`;
     });
   }
 
@@ -633,7 +593,7 @@ class DebugStringifier {
       case "symbol": {
         // The conversion represents a unique symbol as a tagged object, so
         // only an interned symbol arrives here.
-        return `@${renderKey(Symbol.keyFor(value) ?? "")}`;
+        return `@${DebugStringifier.#renderKey(Symbol.keyFor(value) ?? "")}`;
       }
 
       case "object": {
@@ -669,6 +629,18 @@ class DebugStringifier {
   //
 
   /**
+   * Renders an `ArrayBuffer` as `buf [...]`, with its bytes in hexadecimal, a
+   * space after every fourth byte.
+   */
+  static #renderBuffer(buffer: ArrayBuffer): string {
+    const hex = [...new Uint8Array(buffer)]
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("")
+      .replace(/.{8}(?=.)/g, "$& ");
+    return `buf [${hex}]`;
+  }
+
+  /**
    * Renders the elided form of a `FabricInstance`, or of a `FabricPrimitive`
    * whose state cannot be had, given its codec type tag (or, failing that,
    * its class name). The slash suggests a known encodable type rather than an
@@ -676,6 +648,39 @@ class DebugStringifier {
    */
   static #renderElidedInstance(tag: string): string {
     return `/${tag.replace(/@.*$/, "")}(...)`;
+  }
+
+  /**
+   * Renders a key -- an object property name or a symbol's key -- bare when it
+   * is a valid identifier, and as a quoted string otherwise. The identifier
+   * check is the ASCII one.
+   */
+  static #renderKey(key: string): string {
+    return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(key) ? key : JSON.stringify(key);
+  }
+
+  /**
+   * Returns the tag and payload of the given plain object when it is one of the
+   * conversion's single-key tagged forms, and `undefined` when it is not. No key
+   * of an original value can arrive in such a form, because the conversion
+   * escapes a key with a leading slash and an unsafe key alike, by prefixing a
+   * slash; the second-character check rules out the one and the unsafe-key
+   * check the other.
+   */
+  static #taggedFormOf(
+    value: FabricPlainObject,
+  ): { tag: string; payload: FabricValue } | undefined {
+    const keys = Object.keys(value);
+    const onlyKey = (keys.length === 1) ? keys[0] : undefined;
+
+    if (
+      (onlyKey === undefined) || (onlyKey[0] !== "/") || (onlyKey[1] === "/") ||
+      isUnsafeObjectKey(onlyKey.slice(1))
+    ) {
+      return undefined;
+    }
+
+    return { tag: onlyKey.slice(1), payload: value[onlyKey] };
   }
 }
 

--- a/packages/data-model/src/value-debug.ts
+++ b/packages/data-model/src/value-debug.ts
@@ -21,12 +21,20 @@ import { codecOf } from "@/codec-common/codecOf.ts";
 import { isCodecTypeTag } from "@/codec-common/isCodecTypeTag.ts";
 import { REALM_CODEC } from "@/codec-interface/interface.ts";
 import { NULL_LIVE_ENVIRONMENT } from "@/codec-interface/NullLiveEnvironment.ts";
+import type { RealmCodecValue } from "@/codec-realm/interface.ts";
 
 /**
  * Nesting depth a debug string renders to. TODO(danfuzz): Make this
  * adjustable by the caller, once there is a caller that wants to.
  */
 const DEBUG_STRING_MAX_DEPTH = 10;
+
+/**
+ * What a `FabricPrimitive`'s codec hands back to be rendered: the
+ * realm-crossing encoding of a terminal codec, or the expansion of a
+ * nonterminal one into other `FabricValue`s.
+ */
+type PrimitiveState = RealmCodecValue | FabricValue;
 
 /**
  * Returns the class name of the given object, or `<anonymous>` when it has
@@ -378,7 +386,7 @@ class DebugStringifier {
    */
   #renderFabricPrimitive(value: FabricPrimitive, indent: string): string {
     let tag: string;
-    let state: unknown;
+    let state: PrimitiveState;
 
     try {
       // A `FabricPrimitive` binds no `[CODEC]`, so its realm codec supplies
@@ -386,7 +394,7 @@ class DebugStringifier {
       // richest -- a `bigint` stays a `bigint`, bytes stay bytes -- which is
       // what makes it the one to render. TODO(danfuzz): Replace `REALM_CODEC`
       // with `DEBUG_CODEC` once the latter exists.
-      const codec = codecOf(value, REALM_CODEC);
+      const codec = codecOf<RealmCodecValue>(value, REALM_CODEC);
       tag = codec.tagForValue(value);
       state = codec.encode(value, NULL_LIVE_ENVIRONMENT);
     } catch {
@@ -397,11 +405,12 @@ class DebugStringifier {
 
     // Trim off the encoding version number.
     const open = `/${tag.replace(/@.*$/, "")}(`;
-    const realm = (v: unknown, i: string) => this.#renderRealmState(v, i);
+    const realm = (v: PrimitiveState, i: string) =>
+      this.#renderRealmState(v, i);
 
     if (isPlainObject(state)) {
       const parts = this.#renderProperties(
-        state as Record<string, unknown>,
+        state as { readonly [key: string]: PrimitiveState },
         indent,
         realm,
         false,
@@ -418,8 +427,9 @@ class DebugStringifier {
    * walked as they stand; and anything else takes the ordinary path through
    * the conversion.
    */
-  #renderRealmState(value: unknown, indent: string): string {
-    const realm = (v: unknown, i: string) => this.#renderRealmState(v, i);
+  #renderRealmState(value: PrimitiveState, indent: string): string {
+    const realm = (v: PrimitiveState, i: string) =>
+      this.#renderRealmState(v, i);
 
     if (value instanceof ArrayBuffer) {
       return DebugStringifier.#renderBuffer(value);
@@ -429,18 +439,18 @@ class DebugStringifier {
       return this.#renderContainer("[", "]", parts, indent);
     } else if (isPlainObject(value)) {
       const parts = this.#renderProperties(
-        value as Record<string, unknown>,
+        value as { readonly [key: string]: PrimitiveState },
         indent,
         realm,
         false,
       );
       return this.#renderContainer("{", "}", parts, indent);
+    } else {
+      return this.#renderSubvalue(
+        toStructuredDebugValue(value, DEBUG_STRING_MAX_DEPTH),
+        indent,
+      );
     }
-
-    return this.#renderSubvalue(
-      toStructuredDebugValue(value, DEBUG_STRING_MAX_DEPTH),
-      indent,
-    );
   }
 
   /**
@@ -549,19 +559,19 @@ class DebugStringifier {
    * the conversion prefixes a slash to a key that starts with one and to an
    * unsafe key, and that slash comes back off here.
    */
-  #renderProperties(
-    value: Readonly<Record<string, unknown>>,
+  #renderProperties<T>(
+    value: { readonly [key: string]: T },
     indent: string,
-    render: (value: unknown, indent: string) => string = (v, i) =>
-      this.#renderSubvalue(v as FabricValue, i),
+    render: (value: T, indent: string) => string = (v, i) =>
+      this.#renderSubvalue(v as unknown as FabricValue, i),
     unescape = true,
   ): string[] {
     const inner = this.#innerIndent(indent);
     const separator = (this.#indent === undefined) ? ":" : ": ";
 
-    return Object.keys(value).map((key) => {
+    return Object.entries(value).map(([key, subvalue]) => {
       const original = (unescape && (key[0] === "/")) ? key.slice(1) : key;
-      const rendered = render(value[key], inner);
+      const rendered = render(subvalue, inner);
       return `${DebugStringifier.#renderKey(original)}${separator}${rendered}`;
     });
   }

--- a/packages/data-model/test/value-debug-cases.test.ts
+++ b/packages/data-model/test/value-debug-cases.test.ts
@@ -8,8 +8,9 @@
  *
  * The expression is evaluated with every `FabricInstance` and
  * `FabricPrimitive` class in scope under its own name, along with the three
- * abstract base classes and the codec-binding symbols, so that a case can
- * define a class of its own; nothing else beyond the language is in scope.
+ * abstract base classes and the realm codec's binding symbol, so that a case
+ * can define a class of its own; nothing else beyond the language is in
+ * scope.
  *
  * To rewrite each file's recorded renderings from the actual ones, run this
  * from the package directory:
@@ -23,7 +24,7 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
-import { JSON_CODEC, REALM_CODEC } from "@/codec-interface/interface.ts";
+import { REALM_CODEC } from "@/codec-interface/interface.ts";
 import * as fabricInstances from "@/fabric-instances/index.ts";
 import * as fabricPrimitives from "@/fabric-primitives/index.ts";
 import {
@@ -61,7 +62,6 @@ const SCOPE: Record<string, unknown> = Object.fromEntries([
     FabricInstance,
     FabricPrimitive,
     FabricSpecialObject,
-    JSON_CODEC,
     REALM_CODEC,
   }),
 ]);

--- a/packages/data-model/test/value-debug-cases.test.ts
+++ b/packages/data-model/test/value-debug-cases.test.ts
@@ -7,8 +7,9 @@
  * the renderer, to be read as such when it changes.
  *
  * The expression is evaluated with every `FabricInstance` and
- * `FabricPrimitive` class in scope under its own name, and nothing else beyond
- * the language.
+ * `FabricPrimitive` class in scope under its own name, along with the three
+ * abstract base classes and the codec-binding symbols, so that a case can
+ * define a class of its own; nothing else beyond the language is in scope.
  *
  * To rewrite each file's recorded renderings from the actual ones, run this
  * from the package directory:
@@ -22,8 +23,14 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
+import { JSON_CODEC, REALM_CODEC } from "@/codec-interface/interface.ts";
 import * as fabricInstances from "@/fabric-instances/index.ts";
 import * as fabricPrimitives from "@/fabric-primitives/index.ts";
+import {
+  FabricInstance,
+  FabricPrimitive,
+  FabricSpecialObject,
+} from "@/interface.ts";
 import { toCompactDebugString, toIndentedDebugString } from "@/value-debug.ts";
 
 /** Directory holding the case files. */
@@ -43,14 +50,21 @@ const UPDATE_GOLDENS = (() => {
 })();
 
 /** Names and values in scope when a case's expression is evaluated. */
-const SCOPE: Record<string, unknown> = Object.fromEntries(
-  [...Object.entries(fabricInstances), ...Object.entries(fabricPrimitives)]
+const SCOPE: Record<string, unknown> = Object.fromEntries([
+  ...[...Object.entries(fabricInstances), ...Object.entries(fabricPrimitives)]
     .filter(([, value]) =>
       typeof value === "function" && /^Fabric/.test(
         (value as { name: string }).name,
       )
     ),
-);
+  ...Object.entries({
+    FabricInstance,
+    FabricPrimitive,
+    FabricSpecialObject,
+    JSON_CODEC,
+    REALM_CODEC,
+  }),
+]);
 
 /** Evaluates a case's expression, producing the value it describes. */
 function evaluateExpression(expression: string): unknown {

--- a/packages/data-model/test/value-debug-cases/fabric-epoch-nsec.txt
+++ b/packages/data-model/test/value-debug-cases/fabric-epoch-nsec.txt
@@ -1,5 +1,5 @@
 new FabricEpochNsec(123456789n)
 
-/EpochNsec(...)
+/EpochNsec(123456789n)
 
-/EpochNsec(...)
+/EpochNsec(123456789n)

--- a/packages/data-model/test/value-debug-cases/fabric-epoch-nsec.txt
+++ b/packages/data-model/test/value-debug-cases/fabric-epoch-nsec.txt
@@ -1,5 +1,0 @@
-new FabricEpochNsec(123456789n)
-
-/EpochNsec(123456789n)
-
-/EpochNsec(123456789n)

--- a/packages/data-model/test/value-debug-cases/fabric-nested.txt
+++ b/packages/data-model/test/value-debug-cases/fabric-nested.txt
@@ -5,14 +5,14 @@
 }
 
 {
-  when: /EpochNsec(...),
+  when: /EpochNsec(1n),
   list: [
-    /EpochNsec(...),
-    /Bytes(...)
+    /EpochNsec(2n),
+    /Bytes("0x01")
   ],
   deeper: {
     link: /Link(...)
   }
 }
 
-{when:/EpochNsec(...),list:[/EpochNsec(...),/Bytes(...)],deeper:{link:/Link(...)}}
+{when:/EpochNsec(1n),list:[/EpochNsec(2n),/Bytes("0x01")],deeper:{link:/Link(...)}}

--- a/packages/data-model/test/value-debug-cases/fabric-nested.txt
+++ b/packages/data-model/test/value-debug-cases/fabric-nested.txt
@@ -8,11 +8,11 @@
   when: /EpochNsec(1n),
   list: [
     /EpochNsec(2n),
-    /Bytes("0x01")
+    /Bytes(buf [01])
   ],
   deeper: {
     link: /Link(...)
   }
 }
 
-{when:/EpochNsec(1n),list:[/EpochNsec(2n),/Bytes("0x01")],deeper:{link:/Link(...)}}
+{when:/EpochNsec(1n),list:[/EpochNsec(2n),/Bytes(buf [01])],deeper:{link:/Link(...)}}

--- a/packages/data-model/test/value-debug-cases/fabric-regexp.txt
+++ b/packages/data-model/test/value-debug-cases/fabric-regexp.txt
@@ -1,9 +1,0 @@
-new FabricRegExp(/ab+c/gi)
-
-/RegExp(
-  source: "ab+c",
-  flags: "gi",
-  flavor: "es2025"
-)
-
-/RegExp(source:"ab+c",flags:"gi",flavor:"es2025")

--- a/packages/data-model/test/value-debug-cases/fabric-regexp.txt
+++ b/packages/data-model/test/value-debug-cases/fabric-regexp.txt
@@ -1,5 +1,9 @@
 new FabricRegExp(/ab+c/gi)
 
-/RegExp(...)
+/RegExp(
+  source: "ab+c",
+  flags: "gi",
+  flavor: "es2025"
+)
 
-/RegExp(...)
+/RegExp(source:"ab+c",flags:"gi",flavor:"es2025")

--- a/packages/data-model/test/value-debug-cases/omnibus-fabric-primitive.txt
+++ b/packages/data-model/test/value-debug-cases/omnibus-fabric-primitive.txt
@@ -12,8 +12,8 @@
   "epoch nsec": /EpochNsec(123456789n),
   "epoch nsec, negative": /EpochNsec(-1n),
   "epoch day": /EpochDay(19000),
-  bytes: /Bytes("0x000102feff"),
-  "bytes, empty": /Bytes("0x"),
+  bytes: /Bytes(buf [000102fe ff]),
+  "bytes, empty": /Bytes(buf []),
   regexp: /RegExp(
     source: "ab+c",
     flags: "gi",
@@ -21,7 +21,7 @@
   ),
   hash: /Hash(
     tag: "fid1",
-    hash: "0xd1c04643837606808cda3212bb7b6d73fd1186ee698604439d6caf95759e06ae"
+    hash: buf [d1c04643 83760680 8cda3212 bb7b6d73 fd1186ee 69860443 9d6caf95 759e06ae]
   )
 }
 

--- a/packages/data-model/test/value-debug-cases/omnibus-fabric-primitive.txt
+++ b/packages/data-model/test/value-debug-cases/omnibus-fabric-primitive.txt
@@ -1,0 +1,28 @@
+{
+  "epoch nsec": new FabricEpochNsec(123456789n),
+  "epoch nsec, negative": new FabricEpochNsec(-1n),
+  "epoch day": new FabricEpochDay(19000),
+  bytes: new FabricBytes(new Uint8Array([0, 1, 2, 254, 255])),
+  "bytes, empty": new FabricBytes(new Uint8Array(0)),
+  regexp: new FabricRegExp(/ab+c/gi),
+  hash: FabricHash.fromString("fid1:0cBGQ4N2BoCM2jISu3ttc_0Rhu5phgRDnWyvlXWeBq4"),
+}
+
+{
+  "epoch nsec": /EpochNsec(123456789n),
+  "epoch nsec, negative": /EpochNsec(-1n),
+  "epoch day": /EpochDay(19000),
+  bytes: /Bytes("0x000102feff"),
+  "bytes, empty": /Bytes("0x"),
+  regexp: /RegExp(
+    source: "ab+c",
+    flags: "gi",
+    flavor: "es2025"
+  ),
+  hash: /Hash(
+    tag: "fid1",
+    hash: "0xd1c04643837606808cda3212bb7b6d73fd1186ee698604439d6caf95759e06ae"
+  )
+}
+
+{"epoch nsec":/EpochNsec(123456789n),"epoch nsec, negative":/EpochNsec(-1n),"epoch day":/EpochDay...

--- a/packages/data-model/test/value-debug-cases/realm-state-nested.txt
+++ b/packages/data-model/test/value-debug-cases/realm-state-nested.txt
@@ -1,0 +1,35 @@
+(() => {
+  // No shipped primitive's realm encoding nests, so this one stands in: its
+  // state holds an array with a buffer inside it, and an object with another
+  // object inside that.
+  class Nested extends FabricPrimitive {
+    static get [REALM_CODEC]() {
+      return {
+        tagForValue: () => "Nested@1",
+        encode: () => ({
+          list: [1, new Uint8Array([1, 2]).buffer, [true]],
+          inner: { b: new ArrayBuffer(0), deeper: { n: 3n } },
+        }),
+      };
+    }
+  }
+  return new Nested();
+})()
+
+/Nested(
+  list: [
+    1,
+    buf [0102],
+    [
+      true
+    ]
+  ],
+  inner: {
+    b: buf [],
+    deeper: {
+      n: 3n
+    }
+  }
+)
+
+/Nested(list:[1,buf [0102],[true]],inner:{b:buf [],deeper:{n:3n}})

--- a/packages/data-model/test/value-debug.test.ts
+++ b/packages/data-model/test/value-debug.test.ts
@@ -29,11 +29,6 @@ import { FabricEpochNsec } from "@/fabric-primitives/FabricEpochNsec.ts";
 import { FabricError } from "@/fabric-instances/FabricError.ts";
 import { FabricMap } from "@/fabric-instances/FabricMap.ts";
 import { FabricRegExp } from "@/fabric-primitives/FabricRegExp.ts";
-import {
-  REALM_CODEC,
-  type TerminalCodec,
-} from "@/codec-interface/interface.ts";
-import type { RealmCodecValue } from "@/codec-realm/interface.ts";
 import { FabricPrimitive, FabricSpecialObject } from "@/interface.ts";
 
 describe("value-debug", () => {
@@ -83,32 +78,6 @@ describe("value-debug", () => {
 
       expect(toCompactDebugString(new RoguePrimitive()))
         .toBe("/RoguePrimitive(...)");
-    });
-
-    it("renders a `FabricPrimitive` whose realm state nests arrays and objects", () => {
-      // No shipped primitive's realm encoding nests, so a synthetic one
-      // stands in: its state holds an array with a buffer inside it, and an
-      // object with another object inside that.
-
-      class NestedPrimitive extends FabricPrimitive {
-        static get [REALM_CODEC](): TerminalCodec<RealmCodecValue> {
-          return {
-            tagForValue: () => "Nested@1",
-            encode: () => ({
-              list: [1, new Uint8Array([1, 2]).buffer, [true]],
-              inner: { b: new ArrayBuffer(0), deeper: { n: 3n } },
-            }),
-          } as unknown as TerminalCodec<RealmCodecValue>;
-        }
-      }
-
-      expect(toCompactDebugString(new NestedPrimitive())).toBe(
-        "/Nested(list:[1,buf [0102],[true]],inner:{b:buf [],deeper:{n:3n}})",
-      );
-      expect(toIndentedDebugString(new NestedPrimitive())).toBe(
-        "/Nested(\n  list: [\n    1,\n    buf [0102],\n    [\n      true\n    ]\n  ],\n" +
-          "  inner: {\n    b: buf [],\n    deeper: {\n      n: 3n\n    }\n  }\n)",
-      );
     });
 
     describe("with `maxLength`", () => {

--- a/packages/data-model/test/value-debug.test.ts
+++ b/packages/data-model/test/value-debug.test.ts
@@ -193,7 +193,7 @@ describe("value-debug", () => {
 
     it("renders a FabricPrimitive as its debug string, not `{}`", () => {
       const bytes = new FabricBytes(new Uint8Array([1, 2, 3]));
-      expect(Deno.inspect(bytes)).toBe('/Bytes("0x010203")');
+      expect(Deno.inspect(bytes)).toBe("/Bytes(buf [010203])");
     });
 
     it("renders a FabricInstance as its debug string, not `{}`", () => {
@@ -203,9 +203,9 @@ describe("value-debug", () => {
 
     it("renders when nested in containers", () => {
       const bytes = new FabricBytes(new Uint8Array([9]));
-      expect(Deno.inspect({ blob: bytes })).toBe('{ blob: /Bytes("0x09") }');
+      expect(Deno.inspect({ blob: bytes })).toBe("{ blob: /Bytes(buf [09]) }");
       expect(Deno.inspect([bytes, bytes]))
-        .toBe('[ /Bytes("0x09"), /Bytes("0x09") ]');
+        .toBe("[ /Bytes(buf [09]), /Bytes(buf [09]) ]");
     });
   });
 });

--- a/packages/data-model/test/value-debug.test.ts
+++ b/packages/data-model/test/value-debug.test.ts
@@ -29,6 +29,11 @@ import { FabricEpochNsec } from "@/fabric-primitives/FabricEpochNsec.ts";
 import { FabricError } from "@/fabric-instances/FabricError.ts";
 import { FabricMap } from "@/fabric-instances/FabricMap.ts";
 import { FabricRegExp } from "@/fabric-primitives/FabricRegExp.ts";
+import {
+  REALM_CODEC,
+  type TerminalCodec,
+} from "@/codec-interface/interface.ts";
+import type { RealmCodecValue } from "@/codec-realm/interface.ts";
 import { FabricPrimitive, FabricSpecialObject } from "@/interface.ts";
 
 describe("value-debug", () => {
@@ -78,6 +83,32 @@ describe("value-debug", () => {
 
       expect(toCompactDebugString(new RoguePrimitive()))
         .toBe("/RoguePrimitive(...)");
+    });
+
+    it("renders a `FabricPrimitive` whose realm state nests arrays and objects", () => {
+      // No shipped primitive's realm encoding nests, so a synthetic one
+      // stands in: its state holds an array with a buffer inside it, and an
+      // object with another object inside that.
+
+      class NestedPrimitive extends FabricPrimitive {
+        static get [REALM_CODEC](): TerminalCodec<RealmCodecValue> {
+          return {
+            tagForValue: () => "Nested@1",
+            encode: () => ({
+              list: [1, new Uint8Array([1, 2]).buffer, [true]],
+              inner: { b: new ArrayBuffer(0), deeper: { n: 3n } },
+            }),
+          } as unknown as TerminalCodec<RealmCodecValue>;
+        }
+      }
+
+      expect(toCompactDebugString(new NestedPrimitive())).toBe(
+        "/Nested(list:[1,buf [0102],[true]],inner:{b:buf [],deeper:{n:3n}})",
+      );
+      expect(toIndentedDebugString(new NestedPrimitive())).toBe(
+        "/Nested(\n  list: [\n    1,\n    buf [0102],\n    [\n      true\n    ]\n  ],\n" +
+          "  inner: {\n    b: buf [],\n    deeper: {\n      n: 3n\n    }\n  }\n)",
+      );
     });
 
     describe("with `maxLength`", () => {

--- a/packages/data-model/test/value-debug.test.ts
+++ b/packages/data-model/test/value-debug.test.ts
@@ -193,7 +193,7 @@ describe("value-debug", () => {
 
     it("renders a FabricPrimitive as its debug string, not `{}`", () => {
       const bytes = new FabricBytes(new Uint8Array([1, 2, 3]));
-      expect(Deno.inspect(bytes)).toBe("/Bytes(...)");
+      expect(Deno.inspect(bytes)).toBe('/Bytes("0x010203")');
     });
 
     it("renders a FabricInstance as its debug string, not `{}`", () => {
@@ -203,8 +203,9 @@ describe("value-debug", () => {
 
     it("renders when nested in containers", () => {
       const bytes = new FabricBytes(new Uint8Array([9]));
-      expect(Deno.inspect({ blob: bytes })).toBe("{ blob: /Bytes(...) }");
-      expect(Deno.inspect([bytes, bytes])).toBe("[ /Bytes(...), /Bytes(...) ]");
+      expect(Deno.inspect({ blob: bytes })).toBe('{ blob: /Bytes("0x09") }');
+      expect(Deno.inspect([bytes, bytes]))
+        .toBe('[ /Bytes("0x09"), /Bytes("0x09") ]');
     });
   });
 });

--- a/packages/html/test/debug.test.ts
+++ b/packages/html/test/debug.test.ts
@@ -20,7 +20,7 @@ describe("debug", () => {
   describe("formatTree", () => {
     it("names a `FabricBytes` standing where a node would", () => {
       expect(formatTree(new FabricBytes(new Uint8Array([1, 2, 3]))))
-        .toBe('/Bytes("0x010203")');
+        .toBe("/Bytes(buf [010203])");
     });
 
     it("names a `FabricError`, the `FabricInstance` arm", () => {
@@ -32,7 +32,7 @@ describe("debug", () => {
 
     it("indents a named special object like any other node", () => {
       expect(formatTree(new FabricBytes(new Uint8Array([1])), 2))
-        .toBe('    /Bytes("0x01")');
+        .toBe("    /Bytes(buf [01])");
     });
 
     it("names a special object held as a render prop", () => {

--- a/packages/html/test/debug.test.ts
+++ b/packages/html/test/debug.test.ts
@@ -20,7 +20,7 @@ describe("debug", () => {
   describe("formatTree", () => {
     it("names a `FabricBytes` standing where a node would", () => {
       expect(formatTree(new FabricBytes(new Uint8Array([1, 2, 3]))))
-        .toBe("/Bytes(...)");
+        .toBe('/Bytes("0x010203")');
     });
 
     it("names a `FabricError`, the `FabricInstance` arm", () => {
@@ -32,7 +32,7 @@ describe("debug", () => {
 
     it("indents a named special object like any other node", () => {
       expect(formatTree(new FabricBytes(new Uint8Array([1])), 2))
-        .toBe("    /Bytes(...)");
+        .toBe('    /Bytes("0x01")');
     });
 
     it("names a special object held as a render prop", () => {
@@ -41,7 +41,7 @@ describe("debug", () => {
         props: { when: new FabricEpochNsec(1_000n) },
       };
 
-      expect(formatTree(node)).toContain("when=/EpochNsec(...)");
+      expect(formatTree(node)).toContain("when=/EpochNsec(1000n)");
     });
   });
 });


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Fable 5.1)

## What

A `FabricPrimitive` in a debug string renders as `/TypeName(<state>)`, its state being its realm codec's encoding, laid out the way a class instance's properties are. The elided `/TypeName(...)` stays only for a primitive whose codec cannot be found, and for every `FabricInstance`, which is unchanged.

The realm codec is the one to render because its terminals are the richest: an epoch stays a `bigint` or a number rather than base64url text, and bytes stay bytes. Its one terminal that no `FabricValue` holds, an `ArrayBuffer`, gets a form of its own, `buf [...]`, with the bytes in hexadecimal and a space after every fourth. The state is rendered by a small walker rather than through the conversion, so that buffer reaches the renderer as itself.

From the new `omnibus-fabric-primitive` case file:

```
"epoch nsec": /EpochNsec(123456789n),
"epoch day": /EpochDay(19000),
bytes: /Bytes(buf [000102fe ff]),
"bytes, empty": /Bytes(buf []),
regexp: /RegExp(source:"ab+c",flags:"gi",flavor:"es2025"),
hash: /Hash(tag:"fid1",hash:buf [d1c04643 83760680 ...])
```

## Also touched

- `packages/data-model/test/value-debug-cases/`: the new omnibus file, and the three existing fabric-primitive cases regenerated.
- `packages/data-model/test/value-debug.test.ts` and `packages/html/test/debug.test.ts`: inspector and `formatTree()` pins on the new form.
- `BaseFabricPrimitive`'s inspector doc comment, which no longer claims the state is elided.

## Verification

`deno lint`, `deno fmt --check`, and the data-model and html suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4EVv9Vip3dPJpNsjRzut4


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6779?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

