### PR TITLE
docs(cf-harness): the CFC circuit, an interactive system map of the harness and its trust boundaries

### DIFF
--- a/packages/cf-harness/docs/README.md
+++ b/packages/cf-harness/docs/README.md
@@ -22,6 +22,10 @@ migration notes live under `docs/history/` at the repository root.
   against the pattern index is measured so two runs can be compared: the task
   wording rule the finding rests on, what a batch records, and what its counts
   do and do not establish.
+- [system-map/](system-map/README.md) — an interactive map of the harness and
+  the runtime around it, drawn by trust boundary: where every gate sits and its
+  status, where the threats lie and which are closed by planned work, guarded by
+  CFC, or held by people and process; with the procedure for keeping it true.
 
 ## Normative boundary
 

--- a/packages/cf-harness/docs/system-map/README.md
+++ b/packages/cf-harness/docs/system-map/README.md
@@ -1,0 +1,110 @@
+# The CFC circuit: an interactive system map
+
+[`cfc-system-map.html`](cfc-system-map.html) is a self-contained, pannable map
+of the harness and the runtime around it, drawn to answer three questions for a
+colleague seeing the system for the first time: what we are building, where we
+have to trust ourselves, and where the threats lie and how the CFC circuit gets
+closed. Open the file in any browser; it has no remote dependencies.
+
+## What it draws
+
+Four horizontal bands, ordered by trust: **Outside** (the model provider, the
+web, third-party skills and APIs: never trusted), **Agent execution** (the
+harness, its children and its sandbox: mediated), the **Trusted computing base**
+(cf-service, the runner as CFC kernel, spaces, policy, connectors, the pattern
+index: where we trust ourselves), and **Evidence** (run artifacts and the audit
+checker: how we check ourselves). A person and an operator sit in the margin as
+principals. Data flows left to right.
+
+On top of the bands sit two layers whose colors carry status and nothing else
+does:
+
+- **Gates** are diamonds on the edges where a value may cross a boundary. Their
+  fill is their status: solid green shipped, solid amber partial, hollow red a
+  gap, dashed gray intended.
+- **Threats** are red-ringed hexagons, numbered, in three kinds: amber for a
+  vector a named piece of planned work closes, green for one CFC holds today,
+  gray with a person glyph for one CFC cannot close and people and process hold.
+
+Line kinds distinguish opaque handles (dashed light blue, the "route what you
+never hold" idea), model-visible bytes, labeled values inside the base,
+untrusted content in or requests out, control, and evidence.
+
+Clicking any node, edge, gate or threat opens its story in the side panel: role,
+trust class, what landed (with pull-request links), the threats that live there,
+and what it takes to close the circuit. Five guided walks (the circuit, the
+three demos, and the trusted base ring by ring) dim everything but the current
+step and zoom to it. Edge labels and gate captions hide at overview and appear
+as you zoom, so the structure reads before the detail.
+
+## What it claims, and where each claim comes from
+
+The map is a snapshot; its "Snapshot as of" date is in the welcome panel. Every
+sentence on it was checked against three sources, in this order of authority:
+
+1. Code: `packages/cf-harness/src` (the tools, the prompt loop, the handle
+   table, the sandbox mediation), `packages/cf-harness/console`,
+   `packages/cf-harness/audit`, and `packages/runner/src/cfc`.
+2. Live documents: the package [README](../../README.md),
+   [CURRENT_STATE.md](../CURRENT_STATE.md), the "Known deviations" list in
+   [IMPLEMENTATION_PROFILE.md](../IMPLEMENTATION_PROFILE.md), the CFC section of
+   [EXPERIMENTAL_OPTIONS.md](../../../../docs/development/EXPERIMENTAL_OPTIONS.md),
+   and the specifications under
+   [`docs/specs/`](../../../../docs/specs/README.md), the enforcement matrix and
+   the agent-harness contracts among them.
+3. Issues: the boundary inventory posted on CT-2175 is what the gate statuses
+   were derived from; the three demo issues (CT-2190, CT-2189, CT-2091) are what
+   the walks follow. Claims about loom's connectors come from CT-2189 and are
+   not verified against loom's code, which this repository does not hold; the
+   map says so where it makes them.
+
+## Updating it
+
+The map is hand-authored, not generated: every position is a coordinate in the
+file, chosen so that no edge crosses a node and no label lands on another. That
+is what makes it legible, and it is also why an update is an edit rather than a
+rebuild. All of the content lives in data tables at the top of the script, and
+none of the drawing code needs to change to alter what the map says.
+
+- `nodes`, `edges`, `groups`, `bands`: what is drawn and where. An edge is an
+  explicit polyline; a gate is placed at a fraction along its edge.
+- `gateDefs`: each gate's title, status (`shipped`, `partial`, `gap`,
+  `intended`), one-line status caption, and the boundary it sits on.
+- `threats` and `threatClass`: each threat's position and class (`guarded`,
+  `upcoming`, `residual`).
+- `D`, `GD`, `TD`, `ED`: the side-panel copy for nodes, gates, threats and
+  edges. A `close` list is what it takes to close the circuit at that element; a
+  `links` list names the pull requests that landed; a threat's `plan` names the
+  work that closes it.
+- `stories`: the walks, each a list of steps naming the elements to focus and
+  the caption to show.
+
+When the system changes in a way the map describes, edit the table that holds
+the claim, bump the snapshot date in the welcome text, and re-verify in a
+browser. The two reviews that shaped the current version are the procedure for a
+larger revision, and both are worth running as subagents with the file and the
+sources above in hand:
+
+- An **accuracy review**: for every gate status, threat class and sentence of
+  copy, find the code or document that makes it true today, and report anything
+  wrong, stale, overstated or unverifiable with a citation. The boundary
+  inventory on CT-2175 is the natural checklist for gates; the deviations list
+  is the checklist for what the harness does not yet do. Check in particular
+  anything that merged after those two were written.
+- A **visual review**: render the map at a typical presentation size and list
+  every collision, every edge that passes through a node, every parallel run too
+  close to separate, and every label unreadable at fit zoom; then judge whether
+  status color still lives only on gates and threats.
+
+Regenerating the review screenshots takes a local static server, since browsers
+block `file:` navigation from automation:
+
+```sh
+cd packages/cf-harness/docs/system-map && python3 -m http.server 8765 --bind 127.0.0.1
+```
+
+## Relation to the other documents here
+
+The map is a reading aid, not a source of truth. Where it and
+[IMPLEMENTATION_PROFILE.md](../IMPLEMENTATION_PROFILE.md) or the code disagree,
+the map is what is out of date, and the fix is the update procedure above.

--- a/packages/cf-harness/docs/system-map/README.md
+++ b/packages/cf-harness/docs/system-map/README.md
@@ -39,8 +39,9 @@ as you zoom, so the structure reads before the detail.
 
 ## What it claims, and where each claim comes from
 
-The map is a snapshot; its "Snapshot as of" date is in the welcome panel. Every
-sentence on it was checked against three sources, in this order of authority:
+The map is a snapshot: the date and the labs commit it describes are stamped in
+the top-left corner of the canvas and named in the welcome panel. Every sentence
+on it was checked against three sources, in this order of authority:
 
 1. Code: `packages/cf-harness/src` (the tools, the prompt loop, the handle
    table, the sandbox mediation), `packages/cf-harness/console`,
@@ -80,10 +81,11 @@ none of the drawing code needs to change to alter what the map says.
   the caption to show.
 
 When the system changes in a way the map describes, edit the table that holds
-the claim, bump the snapshot date in the welcome text, and re-verify in a
-browser. The two reviews that shaped the current version are the procedure for a
-larger revision, and both are worth running as subagents with the file and the
-sources above in hand:
+the claim, set `SNAPSHOT` (the date and the labs commit the map now describes;
+it is stamped in the canvas's top-left corner and named in the welcome text),
+and re-verify in a browser. The two reviews that shaped the current version are
+the procedure for a larger revision, and both are worth running as subagents
+with the file and the sources above in hand:
 
 - An **accuracy review**: for every gate status, threat class and sentence of
   copy, find the code or document that makes it true today, and report anything

--- a/packages/cf-harness/docs/system-map/cfc-system-map.html
+++ b/packages/cf-harness/docs/system-map/cfc-system-map.html
@@ -1,0 +1,3174 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Common Fabric · the CFC circuit — system map</title>
+    <style>
+      :root, [data-theme="dark"] {
+        --bg: #0f1115;
+        --grid: #1b1f28;
+        --panel: #171a21;
+        --panel-2: #1e222b;
+        --line: #2b303b;
+        --fg: #e6e8ee;
+        --muted: #9aa3b2;
+        --accent: #7dd3fc;
+        --node: #1b1f28;
+        --node-stroke: #454c5a;
+        --node-hover: #242a36;
+        --node-focus: #27303f;
+        --gate-fill: #12151b;
+        --ink: #0b0d11;
+        --story-bg: rgba(23, 26, 33, 0.97);
+        --outside: #fb7185;
+        --tcb: #34d399;
+        --tcb-tint: rgba(52, 211, 153, 0.06);
+        --k-handle: #7dd3fc;
+        --k-value: #e879f9;
+        --k-labeled: #f1f5f9;
+        --k-ingress: #fb7185;
+        --k-control: #6b7280;
+        --k-evidence: #a78bfa;
+        --s-shipped: #22c55e;
+        --s-partial: #f59e0b;
+        --s-gap: #ef4444;
+        --s-intended: #94a3b8;
+        --dim: 0.22;
+      }
+      [data-theme="light"] {
+        --bg: #f6f7f9;
+        --grid: #e3e6eb;
+        --panel: #ffffff;
+        --panel-2: #eef1f5;
+        --line: #d5dae2;
+        --fg: #14181f;
+        --muted: #5b6472;
+        --accent: #0369a1;
+        --node: #ffffff;
+        --node-stroke: #8b94a3;
+        --node-hover: #eef4ff;
+        --node-focus: #e0efff;
+        --gate-fill: #ffffff;
+        --ink: #ffffff;
+        --story-bg: rgba(255, 255, 255, 0.97);
+        --outside: #e11d48;
+        --tcb: #059669;
+        --tcb-tint: rgba(5, 150, 105, 0.07);
+        --k-handle: #0284c7;
+        --k-value: #c026d3;
+        --k-labeled: #111827;
+        --k-ingress: #e11d48;
+        --k-control: #6b7280;
+        --k-evidence: #7c3aed;
+        --s-shipped: #16a34a;
+        --s-partial: #d97706;
+        --s-gap: #dc2626;
+        --s-intended: #64748b;
+        --dim: 0.18;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html, body {
+        margin: 0;
+        height: 100%;
+        background: var(--bg);
+        color: var(--fg);
+        font:
+          14px/1.45 -apple-system,
+          BlinkMacSystemFont,
+          "Inter",
+          "Segoe UI",
+          Helvetica,
+          Arial,
+          sans-serif;
+        overflow: hidden;
+      }
+      #app {
+        display: grid;
+        grid-template-columns: 1fr 400px;
+        grid-template-rows: auto 1fr auto;
+        height: 100%;
+      }
+      header {
+        grid-column: 1 / 3;
+        display: grid;
+        gap: 6px 14px;
+        padding: 8px 16px;
+        border-bottom: 1px solid var(--line);
+        background: var(--panel);
+      }
+      header .row {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        flex-wrap: wrap;
+      }
+      header h1 {
+        font-size: 15px;
+        margin: 0 10px 0 0;
+        font-weight: 600;
+        letter-spacing: 0.01em;
+        white-space: nowrap;
+      }
+      header h1 span {
+        color: var(--muted);
+        font-weight: 400;
+      }
+      .group {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+      }
+      .group + .group {
+        margin-left: 6px;
+        padding-left: 12px;
+        border-left: 1px solid var(--line);
+      }
+      .glabel {
+        color: var(--muted);
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        margin-right: 4px;
+      }
+      button {
+        background: var(--panel-2);
+        color: var(--fg);
+        border: 1px solid var(--line);
+        border-radius: 7px;
+        padding: 5px 10px;
+        font: inherit;
+        font-size: 13px;
+        cursor: pointer;
+      }
+      button:hover {
+        border-color: var(--accent);
+      }
+      button.on {
+        background: var(--accent);
+        border-color: var(--accent);
+        color: var(--ink);
+      }
+      button.chip {
+        display: inline-flex;
+        align-items: center;
+        gap: 7px;
+      }
+      button.chip .sw {
+        width: 22px;
+        height: 0;
+        border-top: 3px solid currentColor;
+        border-radius: 2px;
+      }
+      button.chip .sw.dash {
+        border-top-style: dashed;
+      }
+      button.chip .sw.dot {
+        border-top-style: dotted;
+      }
+      button.chip.off {
+        opacity: 0.35;
+      }
+      #stage {
+        grid-column: 1;
+        grid-row: 2;
+        position: relative;
+        overflow: hidden;
+        background:
+          radial-gradient(circle at 1px 1px, var(--grid) 1px, transparent 1px) 0
+          0 / 28px 28px,
+          var(--bg);
+        cursor: grab;
+      }
+      #stage.dragging {
+        cursor: grabbing;
+      }
+      svg {
+        width: 100%;
+        height: 100%;
+        display: block;
+      }
+      aside {
+        grid-column: 2;
+        grid-row: 2 / 4;
+        border-left: 1px solid var(--line);
+        background: var(--panel);
+        overflow: auto;
+        padding: 18px;
+        font-size: 15px;
+      }
+      aside h2 {
+        font-size: 18px;
+        margin: 8px 0 4px;
+      }
+      aside .kind {
+        display: inline-block;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        padding: 2px 8px;
+        border-radius: 999px;
+        border: 1px solid var(--line);
+        color: var(--muted);
+        margin-right: 6px;
+      }
+      aside .kind.b-outside {
+        border-color: var(--outside);
+        color: var(--outside);
+      }
+      aside .kind.b-tcb {
+        border-color: var(--tcb);
+        color: var(--tcb);
+      }
+      aside .status {
+        display: inline-block;
+        font-size: 11px;
+        padding: 2px 8px;
+        border-radius: 999px;
+        color: var(--ink);
+        font-weight: 600;
+        vertical-align: middle;
+      }
+      aside .status.shipped {
+        background: var(--s-shipped);
+      }
+      aside .status.partial {
+        background: var(--s-partial);
+      }
+      aside .status.gap {
+        background: var(--s-gap);
+        color: #fff;
+      }
+      aside .status.intended {
+        background: var(--s-intended);
+      }
+      aside p {
+        margin: 8px 0;
+      }
+      aside h3 {
+        font-size: 12px;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--muted);
+        margin: 18px 0 6px;
+      }
+      aside ul {
+        margin: 0;
+        padding-left: 18px;
+      }
+      aside li {
+        margin: 5px 0;
+      }
+      aside code {
+        font: 13px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace;
+        background: var(--panel-2);
+        padding: 1px 5px;
+        border-radius: 4px;
+      }
+      aside a {
+        color: var(--accent);
+        text-decoration: none;
+      }
+      aside a:hover {
+        text-decoration: underline;
+      }
+      aside .hint {
+        color: var(--muted);
+        font-size: 13px;
+      }
+      aside .bk {
+        display: inline-block;
+        margin-bottom: 8px;
+        font-size: 13px;
+      }
+      #story {
+        grid-column: 1;
+        border-top: 1px solid var(--line);
+        background: var(--story-bg);
+        padding: 12px 16px;
+        display: none;
+        gap: 14px;
+        align-items: flex-start;
+      }
+      #story.on {
+        display: flex;
+      }
+      #story .n {
+        color: var(--accent);
+        font-size: 12px;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        white-space: nowrap;
+        padding-top: 4px;
+        min-width: 200px;
+      }
+      #story .n small {
+        display: block;
+        color: var(--muted);
+        text-transform: none;
+        letter-spacing: 0;
+        margin-top: 4px;
+      }
+      #story .t {
+        flex: 1;
+        font-size: 15px;
+      }
+      #story .t b {
+        display: block;
+        margin-bottom: 3px;
+        font-size: 17px;
+      }
+      #story .dots {
+        display: flex;
+        gap: 5px;
+        margin-top: 8px;
+      }
+      #story .dots i {
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background: var(--line);
+        display: block;
+      }
+      #story .dots i.on {
+        background: var(--accent);
+      }
+      #story .nav {
+        display: flex;
+        gap: 6px;
+      }
+      #stage .hud {
+        position: absolute;
+        top: 10px;
+        left: 12px;
+        color: var(--muted);
+        font-size: 12px;
+        pointer-events: none;
+      }
+
+      /* SVG */
+      .band-rect {
+        fill: none;
+        stroke-width: 1.5;
+        rx: 18;
+        stroke: var(--line);
+      }
+      .band-rect.outside {
+        stroke: var(--outside);
+        stroke-opacity: 0.55;
+      }
+      .band-rect.tcb {
+        fill: var(--tcb-tint);
+        stroke: var(--tcb);
+        stroke-width: 2.5;
+      }
+      .band-title {
+        font-size: 26px;
+        font-weight: 700;
+        letter-spacing: 0.05em;
+        fill: var(--muted);
+      }
+      .band-title.outside {
+        fill: var(--outside);
+      }
+      .band-title.tcb {
+        fill: var(--tcb);
+      }
+      .band-sub {
+        font-size: 18px;
+        fill: var(--muted);
+        font-weight: 400;
+      }
+      .group-rect {
+        fill: none;
+        stroke: var(--line);
+        stroke-dasharray: 6 5;
+        rx: 14;
+      }
+      .group-title {
+        font-size: 14px;
+        fill: var(--muted);
+        font-weight: 600;
+        letter-spacing: 0.06em;
+      }
+      .node {
+        cursor: pointer;
+      }
+      .node rect {
+        fill: var(--node);
+        stroke: var(--node-stroke);
+        stroke-width: 1.5;
+        rx: 12;
+      }
+      .node.attach rect {
+        stroke-dasharray: 5 4;
+        fill: none;
+      }
+      .node .ic {
+        fill: none;
+        stroke: var(--muted);
+        stroke-width: 1.8;
+        stroke-linecap: round;
+        stroke-linejoin: round;
+      }
+      .node text {
+        fill: var(--fg);
+        font-size: 18px;
+        font-weight: 600;
+        pointer-events: none;
+      }
+      .node text.sub {
+        fill: var(--muted);
+        font-size: 13px;
+        font-weight: 400;
+      }
+      .node:hover rect, .node.sel rect {
+        fill: var(--node-hover);
+        stroke-width: 2.5;
+      }
+      .node.focus rect {
+        fill: var(--node-focus);
+        stroke: var(--accent);
+        stroke-width: 3;
+      }
+      .node.focus .ic {
+        stroke: var(--accent);
+      }
+      .edge path {
+        fill: none;
+        stroke-width: 3;
+        stroke-linejoin: round;
+        stroke-linecap: round;
+      }
+      .edge.k-handle path {
+        stroke: var(--k-handle);
+        stroke-dasharray: 10 7;
+      }
+      .edge.k-value path {
+        stroke: var(--k-value);
+      }
+      .edge.k-labeled path {
+        stroke: var(--k-labeled);
+        stroke-width: 3.5;
+      }
+      .edge.k-ingress path {
+        stroke: var(--k-ingress);
+      }
+      .edge.k-control path {
+        stroke: var(--k-control);
+        stroke-width: 1.8;
+      }
+      .edge.k-evidence path {
+        stroke: var(--k-evidence);
+        stroke-dasharray: 2 7;
+      }
+      .edge text {
+        font-size: 13px;
+        fill: var(--muted);
+        paint-order: stroke;
+        stroke: var(--bg);
+        stroke-width: 5px;
+        stroke-linejoin: round;
+        pointer-events: none;
+      }
+      .edge.focus path {
+        stroke-width: 5;
+      }
+      .edge.focus text {
+        fill: var(--fg);
+      }
+      .edge path.hit {
+        stroke: transparent !important;
+        stroke-width: 20;
+        cursor: pointer;
+        marker-start: none !important;
+        marker-end: none !important;
+        stroke-dasharray: none !important;
+      }
+      .gate {
+        cursor: pointer;
+      }
+      .gate polygon {
+        stroke-width: 3;
+      }
+      .gate.shipped polygon {
+        fill: var(--s-shipped);
+        stroke: var(--s-shipped);
+      }
+      .gate.partial polygon {
+        fill: var(--s-partial);
+        stroke: var(--s-partial);
+      }
+      .gate.gap polygon {
+        fill: var(--gate-fill);
+        stroke: var(--s-gap);
+        stroke-width: 4;
+      }
+      .gate.intended polygon {
+        fill: var(--gate-fill);
+        stroke: var(--s-intended);
+        stroke-dasharray: 5 4;
+      }
+      .gate .sh {
+        fill: none;
+        stroke-width: 2.2;
+        stroke: var(--ink);
+      }
+      .gate.gap .sh {
+        stroke: var(--s-gap);
+      }
+      .gate.intended .sh {
+        stroke: var(--s-intended);
+      }
+      .gate text.lbl {
+        font-size: 13px;
+        fill: var(--fg);
+        font-weight: 600;
+        paint-order: stroke;
+        stroke: var(--bg);
+        stroke-width: 5px;
+        pointer-events: none;
+      }
+      .gate text.st {
+        font-size: 12px;
+        font-weight: 500;
+        paint-order: stroke;
+        stroke: var(--bg);
+        stroke-width: 5px;
+        pointer-events: none;
+      }
+      .gate.focus polygon {
+        stroke: var(--accent);
+        stroke-width: 5;
+      }
+      .threat {
+        cursor: pointer;
+      }
+      .threat .mk {
+        stroke: var(--bg);
+        stroke-width: 2.5;
+      }
+      .threat.c-guarded .mk {
+        fill: var(--s-shipped);
+      }
+      .threat.c-upcoming .mk {
+        fill: var(--s-partial);
+      }
+      .threat.c-residual .mk {
+        fill: var(--s-intended);
+      }
+      .threat .ring {
+        fill: none;
+        stroke: var(--s-gap);
+        stroke-width: 2.5;
+      }
+      .threat .pg {
+        fill: none;
+        stroke: var(--ink);
+        stroke-width: 1.6;
+      }
+      .threat text {
+        fill: var(--ink);
+        font-size: 14px;
+        font-weight: 800;
+        pointer-events: none;
+      }
+      .threat.focus .mk {
+        stroke: var(--accent);
+        stroke-width: 4;
+      }
+      .threat.hidden {
+        display: none;
+      }
+      .dim {
+        opacity: var(--dim);
+        filter: saturate(0.25);
+      }
+      /* level of detail by zoom */
+      svg.z0 .edge text,
+      svg.z0 .gate text.st,
+      svg.z0 .node text.sub,
+      svg.z0 .group-title,
+      svg.z0 .band-sub {
+        display: none;
+      }
+      svg.z1 .gate text.st {
+        display: none;
+      }
+      .arrow {
+        fill: currentColor;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app">
+      <header>
+        <div class="row">
+          <h1>
+            Common Fabric · the CFC circuit <span>· what we are building,
+              where we trust ourselves, where the threats lie</span>
+          </h1>
+          <div class="group">
+            <span class="glabel">Walk</span>
+            <button data-story="circuit">The circuit</button>
+            <button data-story="pill">Demo 1 · Weaver pill</button>
+            <button data-story="bills">Demo 2 · Bills dashboard</button>
+            <button data-story="hostile">Demo 3 · Hostile skill</button>
+            <button data-story="trust">Where we trust ourselves</button>
+          </div>
+          <div class="group">
+            <span class="glabel">Show</span>
+            <button id="btnThreats" class="on">Threats</button>
+            <button id="btnStatus" class="on">Gate status</button>
+            <button id="btnTheme">Light</button>
+            <button id="btnFit">Fit</button>
+          </div>
+        </div>
+        <div class="row">
+          <div class="group" id="tlegend">
+            <span class="glabel">Threats</span>
+          </div>
+          <div class="group" id="glegend">
+            <span class="glabel">Gates</span>
+          </div>
+          <div class="group" id="legend"><span class="glabel">Lines</span></div>
+        </div>
+      </header>
+      <div id="stage">
+        <svg id="svg" xmlns="http://www.w3.org/2000/svg" class="z0">
+          <defs></defs>
+          <g id="world"></g>
+        </svg>
+        <div class="hud">
+          drag to pan · scroll to zoom · click anything for its story
+        </div>
+      </div>
+      <div id="story">
+        <div class="n" id="storyN"></div>
+        <div class="t" id="storyT"></div>
+        <div class="nav">
+          <button id="sPrev">←</button>
+          <button id="sNext">→</button>
+          <button id="sClose">Exit</button>
+        </div>
+      </div>
+      <aside id="detail"></aside>
+    </div>
+    <script>
+      // ------------------------------------------------------------------ layout data
+      const W = 2760, H = 1840;
+      const bands = [
+        {
+          id: "outside",
+          x: 250,
+          y: 40,
+          w: 2470,
+          h: 260,
+          title: "OUTSIDE",
+          sub: "never trusted · content is data, never a command",
+        },
+        {
+          id: "agent",
+          x: 250,
+          y: 340,
+          w: 2470,
+          h: 680,
+          title: "AGENT EXECUTION",
+          sub:
+            "mediated · the model proposes, trusted code decides · the model holds names, not values",
+        },
+        {
+          id: "tcb",
+          x: 250,
+          y: 1060,
+          w: 2470,
+          h: 420,
+          title: "TRUSTED COMPUTING BASE",
+          sub:
+            "where we have to trust ourselves · labels live here, policy meaning is decided here",
+        },
+        {
+          id: "evidence",
+          x: 250,
+          y: 1520,
+          w: 2470,
+          h: 260,
+          title: "EVIDENCE",
+          sub:
+            "verified · enforcement happens live, audit checks that it left proof",
+        },
+      ];
+      const groups = [
+        {
+          x: 1200,
+          y: 500,
+          w: 310,
+          h: 400,
+          title: "CHILDREN · fresh context, seeded handles only",
+        },
+        {
+          x: 1580,
+          y: 500,
+          w: 570,
+          h: 400,
+          title: "SANDBOX · every observation is mediated",
+        },
+      ];
+      const nodes = [
+        {
+          id: "person",
+          band: "principal",
+          ic: "person",
+          x: 60,
+          y: 560,
+          w: 150,
+          h: 92,
+          t: "Person",
+          s: "colleague · Alex · a user",
+        },
+        {
+          id: "operator",
+          band: "principal",
+          ic: "person",
+          x: 60,
+          y: 1600,
+          w: 150,
+          h: 92,
+          t: "Operator",
+          s: "Common Fabric employee",
+        },
+
+        {
+          id: "provider",
+          band: "outside",
+          ic: "sparkle",
+          x: 1000,
+          y: 130,
+          w: 230,
+          h: 92,
+          t: "LLM provider",
+          s: "OpenAI-compatible gateway · Codex",
+        },
+        {
+          id: "www",
+          band: "outside",
+          ic: "globe",
+          x: 1560,
+          y: 130,
+          w: 200,
+          h: 92,
+          t: "WWW",
+          s: "web_search · web_fetch",
+        },
+        {
+          id: "skillssh",
+          band: "outside",
+          ic: "globe",
+          x: 1820,
+          y: 130,
+          w: 220,
+          h: 92,
+          t: "Skills.sh",
+          s: "third-party skill authors",
+        },
+        {
+          id: "thirdparty",
+          band: "outside",
+          ic: "globe",
+          x: 2300,
+          y: 130,
+          w: 240,
+          h: 92,
+          t: "Plaid · Gmail",
+          s: "third-party data APIs",
+        },
+
+        {
+          id: "weaver",
+          band: "agent",
+          ic: "window",
+          x: 290,
+          y: 560,
+          w: 210,
+          h: 92,
+          t: "Weaver pill",
+          s: "/cf-harness … · opens the piece",
+        },
+        {
+          id: "console",
+          band: "agent",
+          ic: "server",
+          x: 550,
+          y: 560,
+          w: 210,
+          h: 92,
+          t: "Harness console",
+          s: "POST /api/task · SSE · result",
+        },
+        {
+          id: "adapters",
+          band: "agent",
+          ic: "server",
+          x: 550,
+          y: 780,
+          w: 210,
+          h: 80,
+          t: "Loom · Pattern Factory",
+          s: "product adapters",
+        },
+        {
+          id: "gateway",
+          band: "agent",
+          ic: "server",
+          x: 1000,
+          y: 380,
+          w: 230,
+          h: 80,
+          t: "LLM gateway (ours)",
+          s: "tokens out · proposals in",
+        },
+        {
+          id: "parent",
+          band: "agent",
+          ic: "cpu",
+          x: 800,
+          y: 560,
+          w: 230,
+          h: 110,
+          t: "Parent harness",
+          s: "prompt loop · tool mediation",
+        },
+        {
+          id: "handles",
+          band: "agent",
+          ic: "key",
+          attach: true,
+          x: 800,
+          y: 760,
+          w: 230,
+          h: 64,
+          t: "Handle table",
+          s: "cfh:a: tokens ↔ cell addresses",
+        },
+        {
+          id: "child_pa",
+          band: "agent",
+          ic: "cpu",
+          x: 1220,
+          y: 540,
+          w: 280,
+          h: 80,
+          t: "pattern-author child",
+          s: "writes and runs the pattern",
+        },
+        {
+          id: "child_browser",
+          band: "agent",
+          ic: "cpu",
+          x: 1220,
+          y: 660,
+          w: 220,
+          h: 80,
+          t: "browser child",
+          s: "typed browser tool",
+        },
+        {
+          id: "child_web",
+          band: "agent",
+          ic: "cpu",
+          x: 1220,
+          y: 780,
+          w: 220,
+          h: 80,
+          t: "web child",
+          s: "web_fetch · web_search",
+        },
+        {
+          id: "docker",
+          band: "agent",
+          ic: "box",
+          x: 1600,
+          y: 540,
+          w: 250,
+          h: 92,
+          t: "Docker · runsc-cfc",
+          s: "bash · read_file · write_file",
+        },
+        {
+          id: "mount",
+          band: "agent",
+          ic: "folder",
+          x: 1600,
+          y: 700,
+          w: 200,
+          h: 80,
+          t: "Workspace mount",
+          s: "read-only or writable",
+        },
+        {
+          id: "localskills",
+          band: "agent",
+          ic: "folder",
+          x: 1880,
+          y: 540,
+          w: 250,
+          h: 80,
+          t: "Local skills registry",
+          s: "preloaded, digest-pinned",
+        },
+        {
+          id: "docs",
+          band: "agent",
+          ic: "file",
+          x: 1880,
+          y: 700,
+          w: 250,
+          h: 80,
+          t: "docs/common",
+          s: "trusted text; context, not command",
+        },
+
+        {
+          id: "apps",
+          band: "tcb",
+          ic: "window",
+          x: 290,
+          y: 1140,
+          w: 210,
+          h: 92,
+          t: "Estuary · Rapids",
+          s: "fabric apps",
+        },
+        {
+          id: "toolshed",
+          band: "tcb",
+          ic: "server",
+          x: 550,
+          y: 1140,
+          w: 180,
+          h: 92,
+          t: "cf-service",
+          s: "memory API · identity · UCAN",
+        },
+        {
+          id: "runner",
+          band: "tcb",
+          ic: "shield",
+          x: 800,
+          y: 1120,
+          w: 300,
+          h: 140,
+          t: "Runner · CFC kernel",
+          s: "derives labels · decides every gate it owns",
+        },
+        {
+          id: "spaces",
+          band: "tcb",
+          ic: "database",
+          x: 1220,
+          y: 1140,
+          w: 230,
+          h: 100,
+          t: "Spaces",
+          s: "values + per-path labels",
+        },
+        {
+          id: "policy",
+          band: "tcb",
+          ic: "sliders",
+          x: 800,
+          y: 1330,
+          w: 240,
+          h: 92,
+          t: "Policy posture",
+          s: "dials · records · grants · digest",
+        },
+        {
+          id: "index",
+          band: "tcb",
+          ic: "search",
+          x: 1360,
+          y: 1330,
+          w: 250,
+          h: 92,
+          t: "Pattern index",
+          s: "programs + metadata, not data",
+        },
+        {
+          id: "gardening",
+          band: "tcb",
+          ic: "leaf",
+          x: 1660,
+          y: 1330,
+          w: 250,
+          h: 80,
+          t: "Automated gardening",
+          s: "bounded writer",
+        },
+        {
+          id: "sqlite",
+          band: "tcb",
+          ic: "table",
+          x: 1860,
+          y: 1140,
+          w: 250,
+          h: 100,
+          t: "Connector SQLite tables",
+          s: "row labels from a table contract",
+        },
+        {
+          id: "connectors",
+          band: "tcb",
+          ic: "link",
+          x: 2200,
+          y: 1140,
+          w: 250,
+          h: 100,
+          t: "Connectors (loom)",
+          s: "ingress mediator",
+        },
+
+        {
+          id: "artifacts",
+          band: "evidence",
+          ic: "archive",
+          x: 800,
+          y: 1600,
+          w: 300,
+          h: 100,
+          t: "Run artifacts",
+          s: "transcript · run-state · labels · tool outputs",
+        },
+        {
+          id: "audit",
+          band: "evidence",
+          ic: "checklist",
+          x: 1180,
+          y: 1600,
+          w: 250,
+          h: 100,
+          t: "CFC audit checker",
+          s: "9 checks, spec-anchored",
+        },
+      ];
+      const extraLines = {
+        runner: [
+          "sink ceiling · writer fit · write floor",
+          "policy evaluation · render ceiling",
+        ],
+        parent: ["mode × effect class × prompt slot"],
+        artifacts: ["policy snapshot · cell-label snapshot"],
+        spaces: ["links keep labels; copies lose them"],
+        sqlite: ["re-derived on every read"],
+        connectors: ["sqlite_sources → injected handle cell"],
+        audit: ["verifies; never enforces"],
+      };
+      const icons = {
+        person:
+          '<circle cx="12" cy="8" r="4"/><path d="M4 21c0-4 4-6 8-6s8 2 8 6"/>',
+        globe:
+          '<circle cx="12" cy="12" r="9"/><path d="M3 12h18M12 3c3 3 3 15 0 18M12 3c-3 3-3 15 0 18"/>',
+        database:
+          '<ellipse cx="12" cy="5" rx="8" ry="3"/><path d="M4 5v14c0 1.7 3.6 3 8 3s8-1.3 8-3V5M4 12c0 1.7 3.6 3 8 3s8-1.3 8-3"/>',
+        box:
+          '<path d="M12 2l9 5v10l-9 5-9-5V7zM12 12l9-5M12 12L3 7M12 12v10"/>',
+        cpu:
+          '<rect x="5" y="5" width="14" height="14" rx="2"/><rect x="9" y="9" width="6" height="6"/><path d="M9 2v3M15 2v3M9 19v3M15 19v3M2 9h3M2 15h3M19 9h3M19 15h3"/>',
+        shield:
+          '<path d="M12 2l8 3v6c0 5-3.5 9-8 11-4.5-2-8-6-8-11V5z"/><path d="M9 12l2 2 4-4"/>',
+        folder: '<path d="M3 6h6l2 2h10v11H3z"/>',
+        file: '<path d="M6 2h8l5 5v15H6zM14 2v5h5M9 13h6M9 17h6"/>',
+        server:
+          '<rect x="3" y="4" width="18" height="6" rx="1"/><rect x="3" y="14" width="18" height="6" rx="1"/><path d="M7 7h.01M7 17h.01"/>',
+        key: '<circle cx="8" cy="14" r="4"/><path d="M11 11l9-9M16 6l3 3"/>',
+        window:
+          '<rect x="3" y="4" width="18" height="16" rx="2"/><path d="M3 9h18M7 6.5h.01"/>',
+        sparkle:
+          '<path d="M12 3l2 5 5 2-5 2-2 5-2-5-5-2 5-2z"/><path d="M19 15l1 2 2 1-2 1-1 2-1-2-2-1 2-1z"/>',
+        link:
+          '<path d="M10 14a4 4 0 005.7 0l3-3a4 4 0 00-5.7-5.7l-1 1M14 10a4 4 0 00-5.7 0l-3 3a4 4 0 005.7 5.7l1-1"/>',
+        table:
+          '<rect x="3" y="4" width="18" height="16"/><path d="M3 10h18M3 15h18M9 4v16"/>',
+        search: '<circle cx="11" cy="11" r="7"/><path d="M20 20l-4-4"/>',
+        sliders:
+          '<path d="M4 7h9M17 7h3M4 12h3M11 12h9M4 17h11M19 17h1"/><circle cx="15" cy="7" r="2"/><circle cx="9" cy="12" r="2"/><circle cx="17" cy="17" r="2"/>',
+        leaf: '<path d="M5 19c0-8 5-13 14-14-1 9-6 14-14 14zM5 19l8-8"/>',
+        archive: '<path d="M3 4h18v4H3zM5 8v12h14V8M10 12h4"/>',
+        checklist:
+          '<path d="M10 6h10M10 12h10M10 18h10M4 6l1.5 1.5L8 5M4 12l1.5 1.5L8 11M4 18l1.5 1.5L8 17"/>',
+      };
+      // edges: pts are explicit polylines; k = line kind; gate = gate id at fraction gt; gabove = caption above the diamond; lp = label anchor [x, y, anchor]
+      const edges = [
+        {
+          id: "e_person_weaver",
+          from: "person",
+          to: "weaver",
+          k: "control",
+          pts: [[210, 606], [290, 606]],
+          label: "“make me a budget dashboard”",
+          lp: [250, 548],
+        },
+        {
+          id: "e_weaver_console",
+          from: "weaver",
+          to: "console",
+          k: "control",
+          pts: [[500, 606], [550, 606]],
+          label: "POST /api/task {text, inputCells}",
+          lp: [525, 548],
+        },
+        {
+          id: "e_console_parent",
+          from: "console",
+          to: "parent",
+          k: "control",
+          pts: [[760, 606], [800, 606]],
+          label: "one session config",
+          lp: [780, 548],
+        },
+        {
+          id: "e_adapters_parent",
+          from: "adapters",
+          to: "parent",
+          k: "control",
+          pts: [[655, 780], [655, 700], [830, 700], [830, 670]],
+        },
+        {
+          id: "e_handles_parent",
+          from: "handles",
+          to: "parent",
+          k: "handle",
+          pts: [[915, 760], [915, 670]],
+          label: "tokens in · tokens out",
+          lp: [930, 720, "start"],
+        },
+        {
+          id: "e_parent_gateway",
+          from: "parent",
+          to: "gateway",
+          k: "value",
+          bi: true,
+          pts: [[915, 560], [915, 410], [1000, 410]],
+          label: "context bytes ↑  proposals ↓",
+          lp: [905, 500, "end"],
+          gate: "g_context",
+          gt: 0.45,
+          gabove: true,
+        },
+        {
+          id: "e_gateway_provider",
+          from: "gateway",
+          to: "provider",
+          k: "value",
+          bi: true,
+          pts: [[1115, 380], [1115, 222]],
+          label: "tokens",
+          lp: [1128, 300, "start"],
+        },
+        {
+          id: "e_parent_child",
+          from: "parent",
+          to: "child_pa",
+          k: "handle",
+          pts: [[1030, 580], [1220, 580]],
+          label: "delegate_task",
+          lp: [1185, 545],
+          gate: "g_deleg",
+          gt: 0.3,
+          gabove: true,
+        },
+        {
+          id: "e_child_parent",
+          from: "child_pa",
+          to: "parent",
+          k: "handle",
+          pts: [[1220, 616], [1030, 616]],
+          label: "return",
+          lp: [1075, 660],
+          gate: "g_return",
+          gt: 0.3,
+        },
+        {
+          id: "e_parent_docker",
+          from: "parent",
+          to: "docker",
+          k: "control",
+          pts: [[980, 560], [980, 470], [1560, 470], [1560, 586], [1600, 586]],
+          label: "tool call",
+          lp: [1300, 460],
+          gate: "g_tool",
+          gt: 0.62,
+          gabove: true,
+        },
+        {
+          id: "e_docker_parent",
+          from: "docker",
+          to: "handles",
+          k: "ingress",
+          pts: [[1830, 632], [1830, 940], [1110, 940], [1110, 792], [
+            1030,
+            792,
+          ]],
+          label: "observation + sidecar policy",
+          lp: [1470, 958],
+          gate: "g_obs",
+          gt: 0.9,
+        },
+        {
+          id: "e_docker_mount",
+          from: "docker",
+          to: "mount",
+          k: "control",
+          pts: [[1680, 632], [1680, 700]],
+        },
+        {
+          id: "e_skills_docker",
+          from: "localskills",
+          to: "docker",
+          k: "control",
+          pts: [[1880, 580], [1850, 580]],
+        },
+        {
+          id: "e_docs_mount",
+          from: "docs",
+          to: "mount",
+          k: "control",
+          pts: [[1880, 740], [1800, 740]],
+        },
+        {
+          id: "e_web_www",
+          from: "child_web",
+          to: "www",
+          k: "ingress",
+          bi: true,
+          pts: [[1440, 820], [1540, 820], [1540, 330], [1660, 330], [
+            1660,
+            222,
+          ]],
+          label: "request out · response in",
+          lp: [1552, 808, "start"],
+          gate: "g_egress",
+          gt: 0.62,
+        },
+        {
+          id: "e_skillssh",
+          from: "child_pa",
+          to: "skillssh",
+          k: "ingress",
+          bi: true,
+          pts: [[1420, 540], [1420, 430], [1930, 430], [1930, 222]],
+          label: "acquire_skill",
+          lp: [1700, 422],
+          gate: "g_ingest",
+          gt: 0.82,
+        },
+        {
+          id: "e_run_pattern",
+          from: "child_pa",
+          to: "runner",
+          k: "handle",
+          bi: true,
+          pts: [[1460, 620], [1460, 960], [980, 960], [980, 1120]],
+          label:
+            "run_pattern(handles) ↓ · resultRef ↑ · values only if the ceiling admits",
+          lp: [1150, 950],
+          gate: "g_release",
+          gt: 0.5,
+        },
+        {
+          id: "e_runner_spaces",
+          from: "runner",
+          to: "spaces",
+          k: "labeled",
+          bi: true,
+          pts: [[1100, 1190], [1220, 1190]],
+          gate: "g_write",
+          gt: 0.5,
+          gabove: true,
+        },
+        {
+          id: "e_policy_runner",
+          from: "policy",
+          to: "runner",
+          k: "control",
+          pts: [[920, 1330], [920, 1260]],
+          label: "posture + snapshot",
+          lp: [935, 1300, "start"],
+        },
+        {
+          id: "e_toolshed_runner",
+          from: "toolshed",
+          to: "runner",
+          k: "labeled",
+          bi: true,
+          pts: [[730, 1186], [800, 1186]],
+          label: "memory API",
+          lp: [765, 1172],
+        },
+        {
+          id: "e_apps_toolshed",
+          from: "apps",
+          to: "toolshed",
+          k: "control",
+          pts: [[500, 1186], [550, 1186]],
+        },
+        {
+          id: "e_person_apps",
+          from: "person",
+          to: "apps",
+          k: "control",
+          pts: [[135, 652], [135, 1186], [290, 1186]],
+          label: "identity · UCAN",
+          lp: [150, 900, "start"],
+        },
+        {
+          id: "e_render",
+          from: "toolshed",
+          to: "weaver",
+          k: "labeled",
+          pts: [[640, 1140], [640, 1040], [395, 1040], [395, 652]],
+          label: "rendered piece",
+          lp: [520, 1031],
+          gate: "g_render",
+          gt: 0.8,
+        },
+        {
+          id: "e_thirdparty_conn",
+          from: "thirdparty",
+          to: "connectors",
+          k: "ingress",
+          pts: [[2420, 222], [2420, 1090], [2325, 1090], [2325, 1140]],
+          label: "rows",
+          lp: [2432, 600, "start"],
+          gate: "g_conn",
+          gt: 0.78,
+        },
+        {
+          id: "e_conn_sqlite",
+          from: "connectors",
+          to: "sqlite",
+          k: "labeled",
+          pts: [[2200, 1190], [2110, 1190]],
+          label: "handle cell",
+          lp: [2155, 1178],
+        },
+        {
+          id: "e_sqlite_spaces",
+          from: "sqlite",
+          to: "spaces",
+          k: "labeled",
+          pts: [[1860, 1190], [1450, 1190]],
+          label: "read-only handle + freshness cell",
+          lp: [1655, 1178],
+        },
+        {
+          id: "e_handles_spaces",
+          from: "handles",
+          to: "spaces",
+          k: "handle",
+          pts: [[1020, 824], [1020, 1085], [1335, 1085], [1335, 1140]],
+          label: "a token names a cell address",
+          lp: [1175, 1078],
+        },
+        {
+          id: "e_index",
+          from: "child_pa",
+          to: "index",
+          k: "control",
+          pts: [[1485, 620], [1485, 1330]],
+          label: "search · publish · feedback",
+          lp: [1498, 1050, "start"],
+          gate: "g_index",
+          gt: 0.88,
+        },
+        {
+          id: "e_gardening",
+          from: "gardening",
+          to: "index",
+          k: "control",
+          pts: [[1660, 1370], [1610, 1370]],
+        },
+        {
+          id: "e_runner_artifacts",
+          from: "runner",
+          to: "artifacts",
+          k: "evidence",
+          pts: [[1085, 1260], [1085, 1600]],
+          label: "labels · decisions · refusals",
+          lp: [1100, 1560, "start"],
+        },
+        {
+          id: "e_parent_artifacts",
+          from: "parent",
+          to: "artifacts",
+          k: "evidence",
+          pts: [[800, 640], [775, 640], [775, 1650], [800, 1650]],
+          label: "transcript · run-state · policy snapshot",
+          lp: [765, 1330, "end"],
+        },
+        {
+          id: "e_artifacts_audit",
+          from: "artifacts",
+          to: "audit",
+          k: "evidence",
+          pts: [[1100, 1650], [1180, 1650]],
+        },
+        {
+          id: "e_audit_operator",
+          from: "audit",
+          to: "operator",
+          k: "evidence",
+          pts: [[1305, 1700], [1305, 1740], [235, 1740], [235, 1646], [
+            210,
+            1646,
+          ]],
+          label: "findings",
+          lp: [760, 1732],
+          gate: "g_operator",
+          gt: 0.85,
+        },
+        {
+          id: "e_operator_policy",
+          from: "operator",
+          to: "policy",
+          k: "control",
+          pts: [[135, 1600], [135, 1376], [800, 1376]],
+          label: "operator-authored records",
+          lp: [400, 1368],
+        },
+      ];
+      const gateDefs = {
+        g_context: {
+          t: "Model context",
+          status: "gap",
+          short: "no gate here",
+          boundary: "agent → outside",
+        },
+        g_deleg: {
+          t: "Delegation brief",
+          status: "gap",
+          short: "brief is prose",
+          boundary: "parent → child",
+        },
+        g_return: {
+          t: "Child return",
+          status: "shipped",
+          short: "validated",
+          boundary: "child → parent",
+        },
+        g_tool: {
+          t: "Tool mediation",
+          status: "partial",
+          short: "label-blind",
+          boundary: "model proposal → sandbox",
+        },
+        g_obs: {
+          t: "Observation",
+          status: "partial",
+          short: "sidecar taint",
+          boundary: "sandbox → model context",
+        },
+        g_egress: {
+          t: "Web egress",
+          status: "partial",
+          short: "provisional",
+          boundary: "agent → outside",
+        },
+        g_ingest: {
+          t: "External ingest",
+          status: "partial",
+          short: "stamped, unread",
+          boundary: "outside → agent",
+        },
+        g_release: {
+          t: "Value release",
+          status: "partial",
+          short: "ceiling, no policy",
+          boundary: "TCB → model context",
+        },
+        g_write: {
+          t: "Write gate",
+          status: "shipped",
+          short: "enforce-explicit",
+          boundary: "runner → space",
+        },
+        g_render: {
+          t: "Render ceiling",
+          status: "partial",
+          short: "off by default",
+          boundary: "TCB → person",
+        },
+        g_conn: {
+          t: "Connector ingress",
+          status: "gap",
+          short: "unlabeled",
+          boundary: "outside → TCB",
+        },
+        g_index: {
+          t: "Publication",
+          status: "shipped",
+          short: "program, not data",
+          boundary: "child → index",
+        },
+        g_operator: {
+          t: "Operator access",
+          status: "intended",
+          short: "unaudited",
+          boundary: "evidence → person",
+        },
+      };
+      const statusNames = {
+        shipped: "shipped",
+        partial: "partial",
+        gap: "gap",
+        intended: "intended",
+      };
+      // c: "guarded" = held by CFC today · "upcoming" = closed by named planned work · "residual" = never closed by CFC; held by people and process
+      const threats = [
+        {
+          id: "t1",
+          n: 1,
+          c: "guarded",
+          x: 1968,
+          y: 300,
+          t: "Prompt injection through fetched text",
+        },
+        {
+          id: "t2",
+          n: 2,
+          c: "upcoming",
+          x: 1502,
+          y: 350,
+          t: "Exfiltration through web egress",
+        },
+        {
+          id: "t3",
+          n: 3,
+          c: "guarded",
+          x: 1262,
+          y: 405,
+          t: "The provider sees the whole context",
+        },
+        {
+          id: "t4",
+          n: 4,
+          c: "upcoming",
+          x: 1140,
+          y: 668,
+          t: "Values smuggled in a delegation brief",
+        },
+        {
+          id: "t5",
+          n: 5,
+          c: "upcoming",
+          x: 1712,
+          y: 666,
+          t: "Files carry no fabric labels",
+        },
+        {
+          id: "t6",
+          n: 6,
+          c: "residual",
+          x: 1125,
+          y: 1690,
+          t: "Transcripts leak provenance",
+        },
+        {
+          id: "t7",
+          n: 7,
+          c: "upcoming",
+          x: 2155,
+          y: 1212,
+          t: "Unlabeled ingress: nothing to hold",
+        },
+        {
+          id: "t8",
+          n: 8,
+          c: "upcoming",
+          x: 1120,
+          y: 1470,
+          t: "A refusal the decision channel cannot see",
+        },
+        {
+          id: "t9",
+          n: 9,
+          c: "guarded",
+          x: 1012,
+          y: 515,
+          t: "Model output minting authority",
+        },
+        {
+          id: "t10",
+          n: 10,
+          c: "guarded",
+          x: 1655,
+          y: 1215,
+          t: "Copy strips labels; only links keep them",
+        },
+        {
+          id: "t11",
+          n: 11,
+          c: "residual",
+          x: 262,
+          y: 1700,
+          t: "Insider with privileged access",
+        },
+        {
+          id: "t12",
+          n: 12,
+          c: "upcoming",
+          x: 1830,
+          y: 785,
+          t: "The sandbox can read the run's own artifacts",
+        },
+        {
+          id: "t13",
+          n: 13,
+          c: "upcoming",
+          x: 1132,
+          y: 1122,
+          t: "A pattern's llm calls have no ceiling",
+        },
+      ];
+      const threatClass = {
+        upcoming: {
+          name: "closed by planned work",
+          color: "var(--s-partial)",
+          blurb:
+            "A named gap with an owner and an issue. Until it lands, this vector is open.",
+        },
+        guarded: {
+          name: "guarded by CFC",
+          color: "var(--s-shipped)",
+          blurb:
+            "Held today by labels, handles and gates. The design does not rely on the attacker behaving.",
+        },
+        residual: {
+          name: "remains; held by people and process",
+          color: "var(--s-intended)",
+          blurb:
+            "CFC cannot close this. It is held by authentication, scoping and audit of the people who hold access.",
+        },
+      };
+      // ------------------------------------------------------------------ detail copy
+      const PR = (n) =>
+        `<a href="https://github.com/commontoolsinc/labs/pull/${n}" target="_blank">#${n}</a>`;
+      const D = {
+        person: {
+          kind: "Principal",
+          band: "principal",
+          body:
+            `<p>The colleague who types the pill, or Alex running the bills demo. Authority in this system starts here: an authenticated identity with UCAN grants on a space. Nothing the model says can add to it.</p><p>The person also decides what is labeled. In the Weaver-pill demo the input cell carries <code>confidentiality:[finance]</code> because a person put it there; the rest of the circuit follows from that one act.</p>`,
+          close: [
+            "The pill itself is Dan's side: contract clauses 1–4 landed, 5 open (CT-2190).",
+          ],
+        },
+        operator: {
+          kind: "Principal",
+          band: "principal",
+          body:
+            `<p>A Common Fabric employee with privileged access: to run artifacts, transcripts, the gateway, the index, the policy records. Operators are principals too, so their access should be authenticated, scoped and audited rather than ambient.</p><p>The operator is also the only author of declassification policy. Patterns may classify data and reference a policy by hash; they can never write their own exchange rules.</p>`,
+          threats: ["t11", "t6"],
+          close: [
+            "Nothing is written down about gating or logging operator access to run artifacts. Harness deviation 4 notes only that raw operator reports may expose artifact paths and canonical references. The gate on this map is an intention, not a plan.",
+          ],
+        },
+        provider: {
+          kind: "Outside",
+          band: "outside",
+          body:
+            `<p>The model host. It sees every byte the harness puts in context and returns text that is, by construction, untrusted: a completion is a <em>proposal</em> for a tool call, never a command.</p><p>Because nothing can be gated at the provider, everything must be gated before it gets into context. That is the whole reason the model works in handles.</p>`,
+          threats: ["t3", "t9"],
+          links: [[
+            "provider outages surface as the provider's own words, with bounded retry",
+            6752,
+          ]],
+        },
+        www: {
+          kind: "Outside",
+          band: "outside",
+          body:
+            `<p>Reached through the harness's web tools: the <code>web_fetch</code> and <code>web_search</code> child profiles, or a parent with an explicit <code>web_fetch</code> allowlist. Two-way risk: the request body can carry information out; the response is untrusted content coming in.</p><p>The sandbox is a second route. Its Docker network mode defaults to <code>bridge</code>, and <code>curl</code> is the only network-shaped command bash inspects (it allows localhost and <code>host.docker.internal</code> only), so a sandboxed shell in any profile can reach the network by other means.</p>`,
+          threats: ["t1", "t2"],
+          close: [
+            "<code>web_fetch</code> applies bounds and redirect checks but stamps no label and no ExternalIngest mark on what it returns.",
+            "Network authority is a curl guard plus a Docker network mode, not an explicit destination profile across sandbox and web tools (harness deviation 3). Per-child <code>--network none</code> is described as cheap plumbing, not done.",
+          ],
+        },
+        skillssh: {
+          kind: "Outside",
+          band: "outside",
+          body:
+            `<p>Where a third-party skill comes from. A skill is text the model will read as instructions, so a hostile author's skill is the cleanest prompt-injection vector we have. Demo 3 (CT-2091) runs exactly that: a fetched skill that tries to make the agent post data it holds.</p><p>The defense is not to detect the injection. It is that the agent never holds the data: it holds handles, and every sink the injection could aim at is a gate.</p>`,
+          threats: ["t1"],
+          links: [[
+            "skills acquired from skills.sh are pinned by digest and labeled",
+            6734,
+          ]],
+          close: [
+            "The ExternalIngest integrity stamp is written at acquisition but never consulted at a release site.",
+          ],
+        },
+        thirdparty: {
+          kind: "Outside",
+          band: "outside",
+          body:
+            `<p>Plaid transactions and Gmail messages for the bills dashboard. They enter through loom's connectors, never straight into a pattern. Today Plaid rows stop in a loom-owned <code>source-records.db</code> and Gmail rows in msgvault's database; neither is a cell in any space yet.</p>`,
+          threats: ["t7"],
+          close: [
+            "Declare Plaid and Gmail as <code>sqlite_sources</code> and register their handle and freshness cells into the target space. This is THE blocking gap for demo 2 and it is loom-side (CT-2189 gap 1).",
+          ],
+        },
+        weaver: {
+          kind: "Caller",
+          band: "agent",
+          body:
+            `<p>The command pill: <code>/cf-harness make me a budget dashboard from my transaction data</code>. The contract Weaver implements: post the text and the input cells to the console, follow progress over SSE, poll for the result, open the returned piece by slug as a panel. Harness-side clauses 1–4 have landed; the Weaver wiring and clause 5 are Dan's and not yet demonstrated. The acceptance run used a weaver-shaped caller (curl) and opened the piece with <code>cf get</code> and <code>cf piece render</code>.</p><p>Weaver is also where the person finally <em>sees</em> values. That display is a release: the runner's render ceiling can decide what the panel shows, once it is on.</p>`,
+          links: [[
+            "failed turns are terminal (410), running turns say poll again (409), one writer for run state",
+            6753,
+          ]],
+        },
+        console: {
+          kind: "Harness service",
+          band: "agent",
+          body:
+            `<p>The service the weaver pings. Bad input refs are a 400 before any turn spends. CLI and console assemble the <em>same</em> session from one config, so the class of “console lags the CLI” bugs is gone. The console's fabric session defaults to the <code>max-enforcement</code> posture: policy evaluation on, public-only ceilings on the fetch sinks, enforcement mode pinned at <code>enforce-explicit</code> (not strict, so writer-fit misfits flag rather than reject).</p>`,
+          links: [["one config for CLI and console", 6743], [
+            "turn lifecycle",
+            6753,
+          ], [
+            "labels land in every run's artifacts in the same write as its outcome",
+            6757,
+          ]],
+        },
+        adapters: {
+          kind: "Harness adapters",
+          band: "agent",
+          body:
+            `<p>Loom is the harness's first product adapter and Pattern Factory its first multi-phase orchestration adapter. Both still select the <code>observe</code> CFC mode for workflows whose sandbox output does not yet carry mediation metadata end to end (deviation 2).</p>`,
+        },
+        gateway: {
+          kind: "Our service",
+          band: "agent",
+          threats: ["t3", "t11", "t13"],
+          body:
+            `<p>Our proxy in front of the provider. It is ours, so it is trusted for transport and, on OpenAI-compatible traffic, for attribution headers (the Codex transport carries none). It is not a gate: it forwards whatever context the harness built.</p><p>The runner defines an <code>llm</code> sink class with no ceiling, and the harness's own model call is not a runner sink. So there is no label check on this edge; the protection is that labeled values were already withheld upstream and replaced with tokens. That protection does not cover a pattern's own llm calls, which reach the provider from inside the trusted base with no ceiling at all.</p>`,
+          close: [
+            "Nothing measures the assembled context itself. CT-2175 question 2 asks whether a runner <code>model-context</code> sink class should exist so this becomes a real gate.",
+          ],
+        },
+        parent: {
+          kind: "Harness",
+          band: "agent",
+          body:
+            `<p>The prompt loop. It builds the context, offers only the configured tools, and mediates every tool call: mode × effect class × prompt-slot authority. It swaps cell addresses to <code>cfh:a:</code> tokens in everything model-bound and resolves tokens in model-authored arguments before policy evaluation and dispatch.</p><p>It does not evaluate policy; it transports evidence, applies the selected exposure posture, and records what it decided. It does decide three boundaries with fixed local rules: tool mediation, observation rendering, and the <code>run_pattern</code> answer ceiling (a harness constant fitted with a runner helper). CT-2175 recommends moving that last one into the runner.</p>`,
+          threats: ["t9", "t4"],
+          close: [
+            "Tool-level decisions have no label input at all; labels only reach a decision at the sinks the runner owns.",
+          ],
+        },
+        handles: {
+          kind: "Handle table",
+          band: "agent",
+          body:
+            `<p>The mechanism that lets the agent route data it never sees. A token names a cell address without carrying the value. The model composes work out of tokens: pass one to <code>run_pattern</code>, hand one to a child, name a piece with <code>assign_slug</code>, ask <code>describe_handle</code> what shape it has.</p><p>Ruled today: possession of a handle is not a release. A handle is never withheld; only values are gated.</p>`,
+          links: [["a handle is never withheld, values are gated", 6759]],
+          close: [
+            "Value handles (as opposed to address handles), lifetimes, release and garbage collection are not yet contracts (deviation 4).",
+          ],
+        },
+        child_pa: {
+          kind: "Child harness",
+          band: "agent",
+          body:
+            `<p>Spawned by <code>delegate_task</code> with a fresh context, seeded with exactly the parent tokens its brief names. It writes a pattern, runs it in the trusted fabric session, and returns a handle to the piece. Its return is schema-validated and sanitized: sealed strings become tokens, stray token-shaped text is scrubbed.</p><p>In today's demo run, five of these each called <code>run_pattern</code> over the finance cell, built a real dashboard, and had its values refused twelve times: the first label-driven refusals ever.</p>`,
+          threats: ["t4"],
+        },
+        child_browser: {
+          kind: "Child harness",
+          band: "agent",
+          body:
+            `<p>A host-adjacent profile whose typed <code>browser</code> tool the harness binds to a leased CDP endpoint. Verb allowlist; a <code>valueHandle</code> or <code>urlHandle</code> lets an action spend a value the model never held. That spend is a release path: it is guarded by a per-run origin allowlist, not per handle and with no label input, and a page that receives the value can hand it to whatever reads the page next.</p>`,
+          threats: ["t2"],
+          close: [
+            "“Labels' job … not yet wired”: the browser tool has no label input, and its origin allowlist is per run rather than per handle.",
+          ],
+        },
+        child_web: {
+          kind: "Child harness",
+          band: "agent",
+          body:
+            `<p>The profiles that carry the web tools. A parent can also allowlist <code>web_fetch</code> explicitly. What comes back is untrusted content. These are not the only way to the network: the sandbox's bridge networking is (see WWW).</p>`,
+          threats: ["t1", "t2"],
+        },
+        docker: {
+          kind: "Sandbox",
+          band: "agent",
+          body:
+            `<p>Most tool execution runs in Docker under <code>runsc-cfc</code>, the gVisor runtime with CFC taint tracking. Output crosses back to the model through a sidecar that marks each observation <code>observed</code>, <code>opaque</code> or <code>denied</code>; the harness renders that verdict and never overrides it. Network mode defaults to bridge.</p>`,
+          threats: ["t5", "t12"],
+          close: [
+            "The sandbox's taint (xattr) is a different label store from the runner's. Bridging the two is the retirement condition for the product <code>observe</code> bridges.",
+          ],
+        },
+        mount: {
+          kind: "Sandbox",
+          band: "agent",
+          body:
+            `<p>Workspace, fabric and explicit host mounts with path containment. Ordinary files do not carry fabric labels because a labeled value was written into them; the write floor and the direct-command authority ladder are what stand between the model and a writable path. The run's own artifact directory is inside the workspace and not reserved (CT-2117).</p>`,
+          threats: ["t5", "t12"],
+        },
+        localskills: {
+          kind: "Trusted text",
+          band: "agent",
+          body:
+            `<p>Skills preloaded from the local registry, digest-pinned, with indexed resource reads and an exact allowlist of Deno or Bash scripts. Skill text is context, not operator instruction. The ruling that operator-provided text is trusted for confidentiality and labeled for integrity (CT-2173) covers operator docs; skills follow by extension, and none of it is implemented yet: workspace reads still release into context with an empty label (CT-2165).</p>`,
+        },
+        docs: {
+          kind: "Trusted text",
+          band: "agent",
+          body:
+            `<p>Repository documentation the pattern-author child reads to write patterns. Ruled (CT-2173): trusted for confidentiality, labeled for integrity; context, never command authority. Not yet built: a workspace doc read releases into context with an empty label (CT-2165). <code>PromptSlotBound</code> authority is a separate thing from a CFC label and is drawn as one.</p>`,
+        },
+        apps: {
+          kind: "Fabric app",
+          band: "tcb",
+          body:
+            `<p>Estuary, Rapids and the shell: user-facing apps that read and write spaces through cf-service with the person's identity. Where they are reachable from is a network fact, not a trust fact. What makes their reads safe is the runner's gates, not the network.</p>`,
+        },
+        toolshed: {
+          kind: "TCB",
+          band: "tcb",
+          body:
+            `<p>The Common Fabric service: memory API, identity, UCAN authorization, the shell. CFC does not replace space authorization; it runs on top of it.</p><p>Note: toolshed's own runtime reports <code>policyEvaluation: off</code>. The policy snapshot that governs harness writes lives on the harness's client runtime, so no toolshed change is needed for the demo.</p>`,
+        },
+        runner: {
+          kind: "TCB · CFC kernel",
+          band: "tcb",
+          threats: ["t13", "t8"],
+          body:
+            `<p>The one place policy meaning lives. On every transaction it derives labels onto computed values (the store put <code>finance</code> on every field of today's dashboard with a verified <code>TransformedBy</code> atom) and runs the gates:</p><ul><li><b>Sink ceiling</b>: a release's consumed labels must fit the sink's ceiling.</li><li><b>Writer fit</b> and <b>write floor</b>: what a writer may put where, and the integrity a written value must carry. Writer-fit misfits reject only under <code>enforce-strict</code>; under the console's <code>enforce-explicit</code> they persist and flag.</li><li><b>Policy evaluation</b>: exchange rules that can discharge a clause before the fit; only ever loosens, fails closed on fuel or lookup.</li><li><b>Render ceiling</b>: the same fit for the display sink.</li></ul><p>Its posture is a set of orthogonal dials, not an on/off switch.</p>`,
+          links: [["the label reader was broken, the store was fine", 6751]],
+        },
+        spaces: {
+          kind: "TCB · store",
+          band: "tcb",
+          body:
+            `<p>Cells stored per space (a DID), with labels stored per path alongside values. Between spaces only a link preserves labels and integrity; copying materialized bytes makes a fresh value with no attestation.</p>`,
+          threats: ["t10"],
+        },
+        policy: {
+          kind: "TCB · configuration",
+          band: "tcb",
+          body:
+            `<p>Two things, both operator-owned. The <b>dials</b> are runtime options: the enforcement matrix names five (enforcement mode, flow-label persistence, write floor, trigger-read gating, policy evaluation) and the runtime has nine; the console's <code>max-enforcement</code> bundle sets seven of them, with the enforcement mode pinned at <code>enforce-explicit</code>. The <b>policy snapshot</b> is the digest-bound set of exchange-rule records and grants. Records are <code>ambient</code> (apply to every label) or <code>referenced</code> (fire only where the label names them by hash).</p>`,
+          close: [
+            "There is no door for a policy record to reach a harness runtime: config exposes a posture name only (CT-2175 question 4).",
+            "Guard shape for the demo's finance-release record is undecided (question 3).",
+          ],
+        },
+        index: {
+          kind: "TCB · program plane",
+          band: "tcb",
+          body:
+            `<p>A metadata plane, not a data plane. Search results enter model context as an observation; the selected pattern's source is fetched and compiled host-side; publication sends the program, and the render gate runs over a synthetic instance so no user data rides along.</p>`,
+        },
+        gardening: {
+          kind: "TCB · writer",
+          band: "tcb",
+          body:
+            `<p>Automated maintenance of the index. Intended shape: a bounded writer with its own provenance and audit trail, so it can never become a way to publish data.</p>`,
+        },
+        sqlite: {
+          kind: "TCB · connector data",
+          band: "tcb",
+          body:
+            `<p class="hint">Loom-side claims here come from CT-2189 and the connector map on CT-2066; loom's code is not in this repository.</p><p>Fabric-connected SQLite tables patterns can query. Row-level CFC is implemented in the runtime: rules come from the table contract and are re-derived on every read, including for rows written before the rule (the mailbox demo pattern does this today).</p>`,
+          threats: ["t7"],
+          close: [
+            "Injection seeds <code>tables: {}</code> and treats injected files as unlabeled, so connector rows carry no labels yet. Decide how a connector's schema and row-label rules reach the handle (CT-2189 gap 2, shared loom + labs).",
+            "<code>describe_handle</code> can tell the model nothing about an injected table until the handle cell declares a schema (gap 4, ours, small).",
+          ],
+        },
+        connectors: {
+          kind: "TCB · ingress mediator",
+          band: "tcb",
+          body:
+            `<p class="hint">Loom-side; described from CT-2189, not verified against loom's code.</p><p>Loom's connectors pull third-party data and stamp trusted provenance on the way in. <code>loom-daemon</code> can inject a read-only SQLite handle cell plus a freshness cell into a piece for any connector declared with <code>sqlite_sources</code>; two loom patterns already read connector databases this way.</p>`,
+          close: [
+            "Plaid and Gmail are not declared as <code>sqlite_sources</code> (CT-2189 gap 1, Alex's side).",
+            "Egress through a connector needs its own gate evaluating destination, labels and authority; not drawn because none exists yet.",
+          ],
+        },
+        artifacts: {
+          kind: "Evidence",
+          band: "evidence",
+          body:
+            `<p>Every run writes its transcript, run-state, policy snapshot, tool outputs, child references, skill provenance, and, since today, the per-cell labels its space holds for the cells it touched, in the same write as the run's outcome. The one artifact a run does not write from its own knowledge.</p>`,
+          threats: ["t6", "t8", "t12"],
+          links: [[
+            "cell labels recorded in the write that ends the run",
+            6757,
+          ]],
+          close: [
+            "The twelve refusals are structured in tool outputs but absent from the policy trace; the check that counts them is in open PR #6755.",
+            "The artifact root is readable from the sandbox (CT-2117).",
+          ],
+        },
+        audit: {
+          kind: "Evidence · verifier",
+          band: "evidence",
+          body:
+            `<p>Runs over any recorded run and grades nine checks (AUD-1 to AUD-9) pass, fail, warn or inconclusive against quoted spec clauses; inconclusive is never pass. First run over the demo: 63 checks over 7 runs, 33 pass, 13 fail (7 real, 6 a checker false positive). The demo acceptance bar is now “the checker passes”. A second batch of checks, including the one that counts release refusals, is in an open PR (#6755).</p><p>It verifies; it never enforces. Missing evidence is a finding, not proof that a gate ran.</p>`,
+          links: [["spec-anchored CFC checker", 6749], [
+            "what the audit found",
+            6754,
+          ]],
+        },
+      };
+      const GD = {
+        g_context: {
+          body:
+            `<p>The boundary between what the harness assembled and what the provider sees. By design there is no label check here: the runner's <code>llm</code> sink class has no ceiling and the harness's model call is not a runner sink. Every value that could have been labeled was withheld or tokenized before it got this far.</p>`,
+          why:
+            "Where the whole design is tested: if a labeled value made it into context, the provider has it and no later gate helps.",
+          close: [
+            "Give the model context a runner sink class of its own (CT-2175 recommendation B) so the answer boundary becomes one runner gate instead of a harness copy.",
+            "Then the harness deletes its own <code>RUN_PATTERN_ANSWER_CEILING</code> measurement.",
+          ],
+          threats: ["t3"],
+        },
+        g_deleg: {
+          body:
+            `<p>Handles cross this boundary correctly: a child's table is seeded with exactly the parent tokens the brief names, and tokens stay identical across the hierarchy. But the brief itself, <code>goal</code> and <code>context</code>, is free text, and a parent can put anything it happens to know in it.</p>`,
+          why:
+            "The place the handle model is not yet fully realized; named as live work in the harness README.",
+          close: ["Make the brief bound references rather than prose."],
+          threats: ["t4"],
+        },
+        g_return: {
+          body:
+            `<p>A child's return is a new observation, not a continuation of the parent's token stream. It is validated against the delegation's return schema, sanitized, sealed strings become parent-resolvable tokens, and any token-shaped text still standing is scrubbed to inert text. Raw child evidence stays in artifacts, off the parent's return channel.</p>`,
+          why: "Structure only: no label information crosses with the return.",
+        },
+        g_tool: {
+          body:
+            `<p>Every tool proposal the model makes is decided as mode × effect class × prompt-slot authority. A malformed call comes back as a typed, recoverable refusal naming the field, never the value. Denials, activities and failure records are all written.</p>`,
+          why:
+            "This gate has no label input at all. It decides <em>whether</em> a tool may run, never what the tool may release; that belongs to the sinks.",
+          threats: ["t9"],
+        },
+        g_obs: {
+          body:
+            `<p>Sandbox output crosses back through a sidecar that marks it <code>observed</code>, <code>opaque</code> or <code>denied</code> from runsc's xattr taint. The harness renders the verdict and never decides.</p>`,
+          why:
+            "The sandbox's taint store and the runner's label store are two different systems that do not yet speak.",
+          close: [
+            "Real sidecar evidence for every exposed observation, so Loom and Pattern Factory can leave <code>observe</code> mode (deviation 2).",
+            "The mediation depends on how the operator registered <code>runsc-cfc</code>: without <code>--cfc-invocation-context-dir</code> the harness writes invocation contexts nothing reads and input labels drop silently, while the guard only checks that the directories are named (CT-2105).",
+            "Reserve the artifact root from the sandbox (CT-2117).",
+          ],
+          threats: ["t5", "t12"],
+        },
+        g_egress: {
+          body:
+            `<p>Outbound from the harness: <code>web_fetch</code> applies bounds and redirect checks; the browser tool has a verb allowlist and a per-run origin allowlist for the values a <code>valueHandle</code> spends; the bash <code>curl</code> guard admits localhost targets only, and nothing else in the sandbox is inspected while its network mode is bridge. Inbound: the response is untrusted.</p><p>Inside a pattern, web egress is gated for real: the max-enforcement bundle puts public-only ceilings on the six fetch sinks.</p>`,
+          why:
+            "The exfiltration sink an injected skill aims at. Harness-side it is protected mostly by the agent not holding values, not by a label check on the request.",
+          close: [
+            "Represent network authority as an explicit destination profile across sandbox and web tools (deviation 3).",
+            "Label what the web tools bring back, and give the browser's value release a label input.",
+          ],
+          threats: ["t2", "t1"],
+        },
+        g_ingest: {
+          body:
+            `<p><code>acquire_skill</code> pins the skill by digest, stamps <code>ExternalIngest</code> integrity, and hands back a capability-typed handle. Fetched skill text remains context.</p>`,
+          why:
+            "The stamp is written but never read at a release site, so integrity provenance does not yet change any decision.",
+          close: [
+            "Read the integrity stamp at the write floor and at egress, so text from outside can never become direct-command authority.",
+          ],
+          threats: ["t1"],
+        },
+        g_release: {
+          body:
+            `<p>The gate that fired for the first time today. <code>run_pattern</code> reads the result under the runner and fits the consumed labels against a public-only answer ceiling. Ruled: a reference-only answer is not a release, so the handle always comes back; only the values a <code>resultSchema</code> asks for are gated, and a refusal names the input that carried the label.</p>`,
+          why:
+            "This is the guarantee the product sells: computation goes to the data and the model gets a name, not the number.",
+          links: [["ceiling gates values, not the handle", 6759]],
+          close: [
+            "The fit skips the runner's policy evaluation, so no exchange rule can discharge <code>finance</code> here yet. Policy A vs policy B (released under one, refused under the other) is the smallest honest experiment (CT-2175).",
+            "Record the refusal as a policy event so audit can count it (CT-2188 attribution fixed in the same change).",
+          ],
+          threats: ["t8"],
+        },
+        g_write: {
+          body:
+            `<p>Every transaction commits through the runner's boundary pass. The enforcement mode is <code>enforce-explicit</code> by default and in the console's bundle, so a recorded reason rejects the commit, including a labeled write with no resolvable policy input. The write floor and trigger-read gating are further reason sources on their own dials. Writer fit is not: its misfit rejects only under <code>enforce-strict</code>, and persists-and-flags under explicit, which is what runs today.</p>`,
+          why:
+            "The place labels are derived and persisted; everything downstream reads what this wrote.",
+          close: [
+            "<code>cfcFlowLabels: persist</code> on the writing runtime is what the bills dashboard needs to keep connector labels on its materialized result.",
+          ],
+        },
+        g_render: {
+          body:
+            `<p>The display sink. When the shell renders a piece, the runner can fit the value's labels against a render ceiling with <code>sinkClass: display</code>; it is the precedent for every non-network release site. It is implemented but off by default: a browser profile has to populate the ceiling (<code>commonfabric.cfcRenderCeiling()</code> in localStorage, dogfood only, expected to over-block until exchange resolution lands). In today's demo the panel showed finance values because no ceiling was populated, not because a fit admitted them.</p>`,
+          why:
+            "The person is a sink too. This is the last gate before human eyes, and today it is open.",
+          close: [
+            "Turn the ceiling on by default once exchange resolution can discharge what a person is entitled to see.",
+          ],
+        },
+        g_conn: {
+          body:
+            `<p>Where third-party rows should receive their labels: a table contract that declares the schema and row-label rules, re-derived on every read.</p>`,
+          why:
+            "If rows enter unlabeled, the dashboard is unlabeled and CFC has nothing to hold. The circuit is open at its source.",
+          close: [
+            "Declare the connectors as <code>sqlite_sources</code> (gap 1) and give injected handles a labeled table contract (gap 2).",
+          ],
+          threats: ["t7"],
+        },
+        g_index: {
+          body:
+            `<p>Publishing to the index sends the program, never the data. Search metadata enters context as an observation; pattern source is compiled host-side. Delegation can pass up to eight pattern references, resolved only from search results this parent actually saw.</p>`,
+          why:
+            "Keeps the index a program plane. Gardening should stay a bounded writer with provenance.",
+        },
+        g_operator: {
+          body:
+            `<p>Operators read artifacts and audit findings. Transcripts, handle maps and policy evidence can reveal sensitive provenance and need protection comparable to the data itself.</p>`,
+          why: "The one gate with no code behind it yet.",
+          close: ["Authenticated, scoped, logged access to raw run artifacts."],
+          threats: ["t11", "t6"],
+        },
+      };
+      const TD = {
+        t1: {
+          body:
+            `<p>A fetched skill or a web page tells the model to do something. That is the normal case, not the anomaly: the model reads untrusted text as instructions and cannot tell them apart.</p><p><b>What holds:</b> the agent holds handles, not values, and the sinks an instruction could aim at are gated. Authority comes from the caller-bound prompt slot and the tool gate checks that slot on every effectful call, so fetched text cannot become a command. Labels play no part in that today: the ExternalIngest stamp is written but never read, and <code>web_fetch</code> text is not labeled at all.</p>`,
+          where: ["skillssh", "www", "g_ingest", "g_egress"],
+        },
+        t2: {
+          plan:
+            "Network authority as an explicit destination profile across sandbox and web tools (harness deviation 3), and a label input on web_fetch and browser so the egress ceiling sees what a pattern's fetch sinks already see.",
+          body:
+            `<p>The model, injected or merely mistaken, puts something it holds into a URL, a request body, or a curl. <b>What holds:</b> the model does not hold labeled values; pattern-side fetch sinks have public-only ceilings. <b>What does not yet:</b> the harness-side web tools have no label input; network authority is provisional.</p>`,
+          where: ["child_web", "www", "g_egress"],
+        },
+        t3: {
+          body:
+            `<p>The provider sees every byte of context and keeps its own logs. There is no gate at the provider, so a labeled value that reaches context is gone. <b>What holds:</b> values are withheld or tokenized before context. <b>Open:</b> nothing measures the assembled context as a sink.</p>`,
+          where: ["provider", "gateway", "g_context"],
+        },
+        t4: {
+          plan:
+            "Bound references in the brief instead of prose; named as live work in the harness README.",
+          body:
+            `<p><code>delegate_task</code> takes <code>goal</code> and <code>context</code> as prose. Handles cross by seeding, but a parent can also write anything it knows into the brief, and the child's fresh context starts from that. Named in the harness README as the place the handle model is not yet realized.</p>`,
+          where: ["parent", "child_pa", "g_deleg"],
+        },
+        t5: {
+          plan:
+            "Real sidecar evidence for every exposed observation so the product adapters leave observe mode (deviation 2), and one label vocabulary across runsc taint and runner labels.",
+          body:
+            `<p>A value written into the workspace mount is a file. Files carry runsc taint, not fabric labels, and the two stores do not talk. <b>What holds:</b> the write floor and the direct-command authority ladder on <code>write_file</code>; the sidecar's opaque/denied verdicts on reads.</p>`,
+          where: ["docker", "mount", "g_obs"],
+        },
+        t6: {
+          body:
+            `<p>Transcripts, handle maps and policy traces are sensitive provenance in their own right. Raw operator reports may expose artifact paths and canonical references. Operator access is not yet authenticated per artifact or logged.</p>`,
+          where: ["artifacts", "operator", "g_operator"],
+        },
+        t7: {
+          plan:
+            "CT-2189 gaps 1 and 2: declare the connectors as sqlite_sources and give injected handles a labeled table contract.",
+          body:
+            `<p>Connector rows arrive with no labels because injected handles seed <code>tables: {}</code>. An unlabeled input produces an unlabeled dashboard and CFC has nothing to hold; the whole circuit is only as strong as its source label.</p>`,
+          where: ["thirdparty", "connectors", "sqlite", "g_conn"],
+        },
+        t8: {
+          plan:
+            "Record the release refusal as a policy event with a runner-minted refusal detail; merge the audit check that counts policyRefusal on tool outputs (open PR #6755); attribution fixed in #6759.",
+          body:
+            `<p>The twelve refusals are structured: each tool output carries a <code>policyRefusal</code> with gates, atoms and the input that carried the label. What cannot show them is the policy <em>decision</em> channel, because the loop records its allow decision before the tool runs; the trace's reason-code union has no label-shaped member, and the merged audit's denial check reads decisions only, so it counts zero. The channel exists, it is structured, and it is empty. A gate we cannot prove fired is, for a colleague, a gate that did not.</p>`,
+          where: ["runner", "artifacts", "audit", "g_release"],
+        },
+        t9: {
+          body:
+            `<p>Provider output must never mint command authority. Authority comes from the prompt slot the caller bound (<code>PromptSlotBound</code>), and the tool gate checks that slot on every effectful call. Model text that looks like an operator instruction is still model text.</p>`,
+          where: ["parent", "gateway", "g_tool"],
+        },
+        t10: {
+          body:
+            `<p>Between spaces, only a link preserves labels and integrity. Copying materialized bytes creates a fresh value with no attestation. Any tool that “helpfully” materializes a value across spaces opens the circuit.</p>`,
+          where: ["spaces", "toolshed"],
+        },
+        t12: {
+          plan:
+            "Reserve the artifact root from bash and from any child sharing the workspace (CT-2117, open).",
+          body:
+            `<p><code>bash</code> does not reserve <code>.cf-harness-artifacts/</code>. A <code>cat</code> of the run's own tool-output JSON reads back the whole unsanitized result, the raw cause message and bare piece ids, and a delegated child sharing the workspace reaches it too. Reproduced with a planted marker by two reviewers. This is a direct route from “withheld” to model context, and it undermines every “retained in the artifact, withheld here” claim on this map until it is closed.</p>`,
+          where: ["docker", "mount", "artifacts", "g_obs"],
+        },
+        t13: {
+          plan:
+            "A ceiling on the runner's llm sink class, so a pattern's model calls fit like its fetch calls do (CT-2091 build list, item 5).",
+          body:
+            `<p>A model-authored pattern can call <code>llm</code>, <code>generateText</code> or <code>llmDialog</code> over the finance cell. Under <code>max-enforcement</code> those sinks have no ceiling, so labeled values leave for the provider with no gate. The fetch sinks are capped; the llm sinks are not, and a failing-when-fixed test pins the gap. This is a second egress from the trusted base into the provider, beside the model-context edge.</p>`,
+          where: ["runner", "gateway", "provider", "g_context"],
+        },
+        t11: {
+          body:
+            `<p>Employees with access to the gateway, spaces, the index or artifacts. Operators are principals: authenticated, scoped, audited. The map draws no red line from an employee to a component because access is meant to be a gate, not a leak.</p>`,
+          where: ["operator", "gateway", "toolshed", "index", "g_operator"],
+        },
+      };
+      const ED = {
+        e_parent_gateway:
+          `<p>What the harness sends the provider and what the provider sends back. Outbound bytes are model-visible by definition; inbound completions are untrusted proposals. There is no label gate on this edge; see the gate.</p>`,
+        e_run_pattern:
+          `<p><code>run_pattern</code> is the central tool: the child writes a pattern and runs it in the trusted fabric session against the handles it holds. Its fabric identity stays outside Docker and its authority is one configured space. Computation goes to the data.</p><p>The result of a run comes back as <code>resultRef</code>, a handle, on success and on a release refusal alike. A commit refusal (write floor, missing policy input, writer fit under strict) or a run failure returns an error with no handle. Fields the <code>resultSchema</code> models as inert (numbers, booleans, enums) come back as themselves if the ceiling admits them; everything else as a reference token.</p>`,
+        e_handles_spaces:
+          `<p>A <code>cfh:a:</code> token is a deterministic per-run name for a cell address. Bare fabric IDs are not converted. The mapping lives in <code>run-state.json</code> and survives batch resume; an interactive (console) restore does not persist it yet.</p>`,
+        e_render:
+          `<p>The piece is opened by slug through the shell (Weaver once wired; <code>cf piece render</code> in the acceptance run). What it may display is the render ceiling's decision in the runner, not the caller's, once that ceiling is populated.</p>`,
+        e_thirdparty_conn:
+          `<p>Plaid transactions and Gmail messages pulled by loom's connectors. Ingress, not a pattern fetch.</p>`,
+        e_conn_sqlite:
+          `<p>Today: rows stop in <code>source-records.db</code> and <code>msgvault.db</code>. Intended: <code>loom-daemon</code> injects a read-only <code>SqliteDb</code> handle cell and a freshness cell into the target space.</p>`,
+        e_sqlite_spaces:
+          `<p>Once the handle cell exists it is an ordinary same-space cell, so <code>--input-cell</code> and <code>/api/task inputCells</code> carry it into a harness session with no new transport.</p>`,
+        e_parent_child:
+          `<p>Delegation seeds the child's handle table with the parent entries the brief names, and nothing else. The brief itself is prose.</p>`,
+        e_child_parent:
+          `<p>Return is validated, sanitized and re-minted through the parent's boundary. Raw child evidence is retained outside the parent's return channel.</p>`,
+        e_skillssh:
+          `<p><code>acquire_skill</code>: fetch a skill from skills.sh, pin it by digest, stamp ExternalIngest, return a capability-typed handle.</p>`,
+        e_web_www:
+          `<p>Only the web child profiles or an explicit parent allowlist reach here. Request out, untrusted content in.</p>`,
+        e_runner_artifacts:
+          `<p>Labels, decisions, commit refusals and, since today, the cell-label snapshot for touched cells, written in the same write as the run's outcome.</p>`,
+        e_audit_operator:
+          `<p>Findings for a person to act on. Operator access to raw artifacts is the intended gate that has no code yet.</p>`,
+        e_operator_policy:
+          `<p>Policy records and grants are operator-authored. Patterns can reference a policy by hash; they cannot write one.</p>`,
+      };
+
+      // ------------------------------------------------------------------ stories
+      const stories = {
+        circuit: {
+          title: "The CFC circuit",
+          steps: [
+            {
+              f: ["person", "e_person_weaver", "thirdparty", "g_conn"],
+              sel: "person",
+              h: "1 · Label at the source",
+              t: "A person labels the input cell (finance). A connector's table contract labels rows as they arrive. Everything downstream is only as strong as this.",
+            },
+            {
+              f: ["spaces", "runner", "g_write"],
+              sel: "spaces",
+              h: "2 · Store per path",
+              t: "Labels sit beside values, per path, in the space. Links keep them; copies lose them.",
+            },
+            {
+              f: ["handles", "e_handles_spaces", "e_handles_parent", "parent"],
+              sel: "handles",
+              h: "3 · Name, don't carry",
+              t: "The harness mints a token for the cell. The model gets the name. It can route the name anywhere; it never holds the value.",
+            },
+            {
+              f: [
+                "child_pa",
+                "e_run_pattern",
+                "runner",
+                "e_runner_spaces",
+                "spaces",
+                "g_write",
+              ],
+              sel: "runner",
+              h: "4 · Computation goes to the data",
+              t: "The child writes a pattern and runs it in the trusted session. The runner derives finance onto every computed field with a TransformedBy atom.",
+            },
+            {
+              f: ["g_release", "e_run_pattern", "policy", "e_policy_runner"],
+              sel: "g_release",
+              h: "5 · Release is a decision",
+              t: "The handle always comes back. Values are fitted against the sink's ceiling; a policy may discharge a clause first; otherwise a typed refusal naming the input.",
+            },
+            {
+              f: [
+                "g_render",
+                "e_render",
+                "weaver",
+                "g_egress",
+                "g_context",
+                "g_obs",
+              ],
+              sel: "g_render",
+              h: "6 · Every sink should be a gate",
+              t: "The design: display, web egress, model context and files are each a sink with a ceiling. Today two fit live: a pattern's fetch sinks under max-enforcement, and the run_pattern answer. The display ceiling is off by default; model context has none; files carry no labels. The gate colors say which is which.",
+            },
+            {
+              f: [
+                "e_runner_artifacts",
+                "e_parent_artifacts",
+                "artifacts",
+                "e_artifacts_audit",
+                "audit",
+              ],
+              sel: "audit",
+              h: "7 · Prove it",
+              t: "Labels and decisions are written in the same write as the outcome. The checker grades the record against quoted spec clauses; inconclusive is never pass.",
+            },
+            {
+              f: [
+                "g_context",
+                "g_deleg",
+                "g_egress",
+                "g_ingest",
+                "g_conn",
+                "g_operator",
+                "g_render",
+                "t8",
+                "t12",
+                "t13",
+                "policy",
+              ],
+              sel: "g_release",
+              h: "8 · Where the circuit is still open",
+              t: "Policy discharge at the release gate and a door for records (CT-2175). The prose delegation brief. Web and browser tools without label input, and bridge networking in the sandbox. A pattern's llm calls uncapped. The sandbox reading the run's own artifacts (CT-2117). Connector rows unlabeled (CT-2189). Refusals absent from the decision channel. The display ceiling off. Operator access unaudited.",
+            },
+          ],
+        },
+        pill: {
+          title: "Demo 1 · Weaver pill (CT-2190)",
+          steps: [
+            {
+              f: ["person", "e_person_weaver", "weaver"],
+              sel: "weaver",
+              h: "Type the pill",
+              t: "/cf-harness make me a budget dashboard from my transaction data. The person's transaction cell already carries confidentiality:[finance].",
+            },
+            {
+              f: [
+                "weaver",
+                "e_weaver_console",
+                "console",
+                "e_console_parent",
+                "parent",
+              ],
+              sel: "console",
+              h: "One honest contract",
+              t: "POST /api/task {text, inputCells} → SSE progress → GET result. Bad refs are a 400 before any turn spends; failed turns are terminal; one writer for run state.",
+            },
+            {
+              f: [
+                "parent",
+                "handles",
+                "e_handles_parent",
+                "e_handles_spaces",
+                "spaces",
+              ],
+              sel: "handles",
+              h: "Mint the handle",
+              t: "The input cell becomes cfh:a:… in the model's world. The model sees the cell's schema and label through describe_handle, never the rows.",
+            },
+            {
+              f: ["parent", "e_parent_child", "g_deleg", "child_pa"],
+              sel: "child_pa",
+              h: "Delegate to a pattern author",
+              t: "A fresh child context seeded with that one token. Today five children ran; the brief around the token is still prose (open).",
+            },
+            {
+              f: [
+                "child_pa",
+                "e_run_pattern",
+                "runner",
+                "e_runner_spaces",
+                "spaces",
+                "g_write",
+              ],
+              sel: "runner",
+              h: "Build and run over the data",
+              t: "The child writes the dashboard pattern and runs it. The store derives finance onto totalSpending and every other field, TransformedBy verified, readable back over the wire.",
+            },
+            {
+              f: ["g_release", "e_run_pattern", "child_pa", "t8"],
+              sel: "g_release",
+              h: "The gate fires",
+              t: "Twelve times across five children the runtime refused to release the finance values. Nothing had ever been refused by a label before today. With #6759 the handle comes back regardless.",
+            },
+            {
+              f: [
+                "child_pa",
+                "e_child_parent",
+                "g_return",
+                "parent",
+                "console",
+                "e_weaver_console",
+                "weaver",
+              ],
+              sel: "weaver",
+              h: "Return a name, open a piece",
+              t: "The rerun answered the handle question: one POST, one child, 6m40s. The gate still refused the values to the model; the model shipped the bound dashboard anyway, by handle. It got slugged, opened, and reflowed when the transaction cell changed. Acceptance itself is not yet a pass: the audit still has two fails, both checker-side (CT-2187, CT-2191).",
+            },
+            {
+              f: ["g_render", "e_render", "weaver", "person"],
+              sel: "g_render",
+              h: "The person sees values",
+              t: "Display is a release. The render ceiling decides what the panel shows to the person who owns the data. Acceptance: the checker passes over the run.",
+            },
+          ],
+        },
+        bills: {
+          title: "Demo 2 · Bills dashboard from Gmail + Plaid (CT-2189)",
+          steps: [
+            {
+              f: ["thirdparty", "e_thirdparty_conn", "connectors", "g_conn"],
+              sel: "connectors",
+              h: "Ingress through connectors",
+              t: "Plaid and Gmail rows arrive through loom's connectors. Today they stop in loom-owned databases; neither is a cell in any space.",
+            },
+            {
+              f: ["connectors", "e_conn_sqlite", "sqlite", "t7"],
+              sel: "sqlite",
+              h: "Gap 1 and 2 (loom side)",
+              t: "Declare both as sqlite_sources so loom-daemon injects a handle cell and freshness cell; give the injected handle a labeled table contract so rows carry CFC labels. This is the blocking gap and it is Alex's to pick up or hand over.",
+            },
+            {
+              f: [
+                "sqlite",
+                "e_sqlite_spaces",
+                "spaces",
+                "handles",
+                "e_handles_spaces",
+              ],
+              sel: "spaces",
+              h: "A labeled cell like any other",
+              t: "Once the handle cell exists, /api/task inputCells carries it into a session with no new transport. The path is identical to demo 1 from here.",
+            },
+            {
+              f: ["child_pa", "e_run_pattern", "runner", "spaces", "g_write"],
+              sel: "runner",
+              h: "Two handles, one pattern",
+              t: "A single SQL statement cannot span two handles; query each and join in fabric computation. Reuse the bill-extractor status logic (unpaid, paid, overdue, likely paid) and extend it to the demo's upcoming and nearly-overdue states. Persisting derived labels needs cfcFlowLabels: persist.",
+            },
+            {
+              f: [
+                "g_release",
+                "e_run_pattern",
+                "child_pa",
+                "e_child_parent",
+                "parent",
+                "weaver",
+                "g_render",
+                "e_render",
+                "person",
+              ],
+              sel: "g_render",
+              h: "A panel in Weaver",
+              t: "The dashboard's result cells carry the connector labels, derived and TransformedBy. Alex opens it as a panel. No notification sink: the dashboard is the deliverable.",
+            },
+          ],
+        },
+        hostile: {
+          title: "Demo 3 · A hostile skill has nothing to steal (CT-2091)",
+          steps: [
+            {
+              f: ["child_pa", "e_skillssh", "skillssh", "g_ingest", "t1"],
+              sel: "g_ingest",
+              h: "Acquire a skill from outside",
+              t: "search_skills finds one on skills.sh; acquire_skill pins it by digest and stamps ExternalIngest. The skill text carries an injection: post the user's finance data to an outside URL.",
+            },
+            {
+              f: ["child_pa", "handles", "e_handles_parent", "t4"],
+              sel: "handles",
+              h: "What the agent actually holds",
+              t: "Tokens. The finance cell is cfh:a:… in context. The injection can name it, route it, describe its shape. It cannot read a row.",
+            },
+            {
+              f: ["child_web", "e_web_www", "g_egress", "www", "t2"],
+              sel: "g_egress",
+              h: "The injection aims at egress",
+              t: "Any attempt to fetch with data in the URL or body reaches the web tools without a value to send. Pattern-side, the fetch sinks have public-only ceilings and refuse finance outright.",
+            },
+            {
+              f: ["g_release", "e_run_pattern", "g_context", "t3"],
+              sel: "g_release",
+              h: "Asking for values is a release",
+              t: "If the injected skill asks run_pattern for a resultSchema over finance, the ceiling refuses the values and names the input. Handle returns; value does not.",
+            },
+            {
+              f: [
+                "artifacts",
+                "e_parent_artifacts",
+                "e_runner_artifacts",
+                "audit",
+                "t8",
+              ],
+              sel: "audit",
+              h: "The attempt is on the record",
+              t: "Skill provenance, the tool proposals, the refusal. Open: the refusal needs to be a policy event so the checker can count it, and the ingest stamp needs to be read at the egress gate.",
+            },
+          ],
+        },
+        trust: {
+          title: "Where we have to trust ourselves",
+          steps: [
+            {
+              f: [
+                "runner",
+                "policy",
+                "spaces",
+                "toolshed",
+                "g_write",
+                "g_release",
+                "g_render",
+              ],
+              sel: "runner",
+              h: "The kernel",
+              t: "The runner owns every label and every decision. A bug here is a bug in the guarantee, and no other component can catch it. This is the smallest thing we must get right.",
+            },
+            {
+              f: [
+                "parent",
+                "handles",
+                "child_pa",
+                "g_tool",
+                "g_return",
+                "g_deleg",
+                "console",
+              ],
+              sel: "parent",
+              h: "The harness",
+              t: "Trusted to transport faithfully: tokenize everything model-bound, resolve before dispatch, seed children with exactly what the brief names, never decide policy itself. It records every decision so the runner's meaning can be checked against what it did.",
+            },
+            {
+              f: [
+                "docker",
+                "g_obs",
+                "gateway",
+                "connectors",
+                "g_conn",
+                "index",
+                "g_index",
+              ],
+              sel: "docker",
+              h: "The mediators",
+              t: "The sandbox sidecar, our gateway, the connector ingress, the index: each is trusted to stamp or withhold at a boundary. They are ours, so they are inside the base; they are also where two label stores meet and can disagree.",
+            },
+            {
+              f: [
+                "provider",
+                "www",
+                "skillssh",
+                "thirdparty",
+                "g_context",
+                "g_egress",
+                "g_ingest",
+              ],
+              sel: "provider",
+              h: "What we never trust",
+              t: "The model, the web, third-party skills and APIs. The design never asks them to behave. It asks that nothing valuable reaches them, and that nothing they say becomes authority.",
+            },
+            {
+              f: ["artifacts", "audit", "operator", "g_operator", "t6", "t11"],
+              sel: "audit",
+              h: "How we check ourselves",
+              t: "Evidence written by the enforcing components, verified by a checker that never enforces, read by operators whose access is itself a gate. Trust in the base is earned by the record, not asserted.",
+            },
+          ],
+        },
+      };
+
+      // ------------------------------------------------------------------ render
+      const kindNames = {
+        handle: ["handle · no disclosure", "dash"],
+        value: ["model-visible", ""],
+        labeled: ["labeled value", ""],
+        ingress: ["untrusted in / out", ""],
+        control: ["control", ""],
+        evidence: ["evidence", "dot"],
+      };
+      const svg = document.getElementById("svg"),
+        world = document.getElementById("world");
+      const NS = "http://www.w3.org/2000/svg";
+      const el = (n, a = {}, parent) => {
+        const e = document.createElementNS(NS, n);
+        for (const k in a) e.setAttribute(k, a[k]);
+        if (parent) parent.appendChild(e);
+        return e;
+      };
+      const N = Object.fromEntries(nodes.map((n) => [n.id, n]));
+      function pathD(pts, r = 14) {
+        if (pts.length < 3) return "M" + pts.map((p) => p.join(",")).join(" L");
+        let d = `M${pts[0][0]},${pts[0][1]}`;
+        for (let i = 1; i < pts.length - 1; i++) {
+          const p0 = pts[i - 1], p1 = pts[i], p2 = pts[i + 1];
+          const d1 = Math.hypot(p1[0] - p0[0], p1[1] - p0[1]),
+            d2 = Math.hypot(p2[0] - p1[0], p2[1] - p1[1]);
+          const rr = Math.min(r, d1 / 2, d2 / 2);
+          const a = [
+            p1[0] + (p0[0] - p1[0]) / d1 * rr,
+            p1[1] + (p0[1] - p1[1]) / d1 * rr,
+          ];
+          const b = [
+            p1[0] + (p2[0] - p1[0]) / d2 * rr,
+            p1[1] + (p2[1] - p1[1]) / d2 * rr,
+          ];
+          d += ` L${a[0]},${a[1]} Q${p1[0]},${p1[1]} ${b[0]},${b[1]}`;
+        }
+        const l = pts[pts.length - 1];
+        d += ` L${l[0]},${l[1]}`;
+        return d;
+      }
+      function along(pts, t) {
+        const segs = [];
+        let total = 0;
+        for (let i = 1; i < pts.length; i++) {
+          const L = Math.hypot(
+            pts[i][0] - pts[i - 1][0],
+            pts[i][1] - pts[i - 1][1],
+          );
+          segs.push(L);
+          total += L;
+        }
+        let want = t * total;
+        for (let i = 0; i < segs.length; i++) {
+          if (want <= segs[i]) {
+            const f = want / segs[i];
+            return [
+              pts[i][0] + (pts[i + 1][0] - pts[i][0]) * f,
+              pts[i][1] + (pts[i + 1][1] - pts[i][1]) * f,
+            ];
+          }
+          want -= segs[i];
+        }
+        return pts[pts.length - 1];
+      }
+
+      const defs = svg.querySelector("defs");
+      for (const k of Object.keys(kindNames)) {
+        const m = el("marker", {
+          id: "arr-" + k,
+          viewBox: "0 0 10 10",
+          refX: 8,
+          refY: 5,
+          markerWidth: 5,
+          markerHeight: 5,
+          orient: "auto-start-reverse",
+        }, defs);
+        el(
+          "path",
+          { d: "M0,0 L10,5 L0,10 z", style: `fill: var(--k-${k})` },
+          m,
+        );
+      }
+
+      const gBands = el("g", {}, world),
+        gGroups = el("g", {}, world),
+        gEdges = el("g", {}, world),
+        gNodes = el("g", {}, world),
+        gGates = el("g", {}, world),
+        gThreats = el("g", {}, world);
+      for (const b of bands) {
+        const g = el("g", {}, gBands);
+        el("rect", {
+          class: "band-rect " + b.id,
+          x: b.x,
+          y: b.y,
+          width: b.w,
+          height: b.h,
+        }, g);
+        const tt = el("text", {
+          class: "band-title " + b.id,
+          x: b.x + 20,
+          y: b.y + 38,
+        }, g);
+        tt.textContent = b.title;
+        const st = el(
+          "text",
+          { class: "band-sub", x: b.x + 20, y: b.y + 38 },
+          g,
+        );
+        st.textContent = "· " + b.sub;
+        requestAnimationFrame(() => {
+          st.setAttribute("x", b.x + 20 + tt.getBBox().width + 14);
+        });
+      }
+      const pt = el("text", { class: "group-title", x: 60, y: 540 }, gBands);
+      pt.textContent = "PRINCIPALS";
+      for (const g of groups) {
+        const gg = el("g", {}, gGroups);
+        el("rect", {
+          class: "group-rect",
+          x: g.x,
+          y: g.y,
+          width: g.w,
+          height: g.h,
+        }, gg);
+        const t = el(
+          "text",
+          { class: "group-title", x: g.x + 14, y: g.y + 24 },
+          gg,
+        );
+        t.textContent = g.title;
+      }
+
+      const edgePts = {};
+      for (const e of edges) {
+        const pts = e.pts;
+        edgePts[e.id] = pts;
+        const g = el("g", { class: "edge k-" + e.k, "data-id": e.id }, gEdges);
+        const d = pathD(pts);
+        el("path", { class: "hit", d }, g);
+        const p = el("path", { d }, g);
+        if (!e.bi) p.setAttribute("marker-end", `url(#arr-${e.k})`);
+        if (e.label) {
+          let x, y, anchor = "middle";
+          if (e.lp) {
+            [x, y] = e.lp;
+            anchor = e.lp[2] || "middle";
+          } else {
+            [x, y] = along(pts, 0.5);
+            y -= 9;
+          }
+          const t = el("text", { x, y, "text-anchor": anchor }, g);
+          t.textContent = e.label;
+        }
+      }
+      for (const n of nodes) {
+        const g = el("g", {
+          class: "node" + (n.attach ? " attach" : ""),
+          "data-id": n.id,
+          transform: `translate(${n.x},${n.y})`,
+        }, gNodes);
+        el("rect", { width: n.w, height: n.h }, g);
+        const ig = el("g", {
+          class: "ic",
+          transform: "translate(12,12) scale(1.1)",
+        }, g);
+        ig.innerHTML = icons[n.ic] || "";
+        const t = el("text", { x: 44, y: 32 }, g);
+        t.textContent = n.t;
+        const s = el("text", { class: "sub", x: 44, y: 54 }, g);
+        s.textContent = n.s;
+        (extraLines[n.id] || []).forEach((line, i) => {
+          const x = el("text", { class: "sub", x: 14, y: 78 + i * 20 }, g);
+          x.textContent = line;
+        });
+      }
+      for (const e of edges) {
+        if (e.gate) {
+          const gd = gateDefs[e.gate];
+          const [x, y] = along(edgePts[e.id], e.gt);
+          const g = el("g", {
+            class: "gate " + gd.status,
+            "data-id": e.gate,
+            transform: `translate(${x},${y})`,
+          }, gGates);
+          el("polygon", { points: "0,-24 24,0 0,24 -24,0" }, g);
+          el("path", {
+            class: "sh",
+            d: "M0,-11 l8,3 v5 c0,5 -3.5,9 -8,11 c-4.5,-2 -8,-6 -8,-11 v-5 z",
+            transform: "translate(0,1)",
+          }, g);
+          const l = el("text", {
+            class: "lbl",
+            "text-anchor": "middle",
+            y: e.gabove ? -36 : 44,
+          }, g);
+          l.textContent = gd.t;
+          const l2 = el("text", {
+            class: "st",
+            "text-anchor": "middle",
+            y: e.gabove ? -52 : 60,
+            "data-status": 1,
+            style: `fill: var(--s-${gd.status})`,
+          }, g);
+          l2.textContent = gd.short;
+        }
+      }
+      for (const t of threats) {
+        const g = el("g", {
+          class: "threat c-" + t.c,
+          "data-id": t.id,
+          transform: `translate(${t.x},${t.y})`,
+        }, gThreats);
+        el("polygon", {
+          class: "ring",
+          points: "0,-23 20,-11.5 20,11.5 0,23 -20,11.5 -20,-11.5",
+        }, g);
+        el("polygon", {
+          class: "mk",
+          points: "0,-18 15.6,-9 15.6,9 0,18 -15.6,9 -15.6,-9",
+        }, g);
+        const tx = el("text", { "text-anchor": "middle", y: 5 }, g);
+        tx.textContent = t.n;
+        if (t.c === "residual") {
+          const pg = el("g", {
+            class: "pg",
+            transform: "translate(11,-24) scale(.55)",
+          }, g);
+          pg.innerHTML = icons.person;
+        }
+      }
+
+      // ------------------------------------------------------------------ pan / zoom
+      const stage = document.getElementById("stage");
+      let vb = { x: 0, y: 0, w: W, h: H };
+      function applyVB() {
+        svg.setAttribute("viewBox", `${vb.x} ${vb.y} ${vb.w} ${vb.h}`);
+        const s = stage.getBoundingClientRect().width / vb.w;
+        svg.classList.toggle("z0", s < 0.7);
+        svg.classList.toggle("z1", s >= 0.7 && s < 1.05);
+        svg.classList.toggle("z2", s >= 1.05);
+      }
+      function fit(pad = 40) {
+        const r = stage.getBoundingClientRect();
+        const s = Math.min(r.width / (W + pad * 2), r.height / (H + pad * 2));
+        vb = {
+          w: r.width / s,
+          h: r.height / s,
+          x: -pad - (r.width / s - W - pad * 2) / 2,
+          y: -pad - (r.height / s - H - pad * 2) / 2,
+        };
+        applyVB();
+      }
+      function fitTo(ids, pad = 120) {
+        const boxes = [];
+        for (const id of ids) {
+          const n = N[id];
+          if (n) boxes.push([n.x, n.y, n.x + n.w, n.y + n.h]);
+          const g = gGates.querySelector(`[data-id="${id}"]`);
+          if (g) {
+            const m = g.transform.baseVal.getItem(0).matrix;
+            boxes.push([m.e - 70, m.f - 70, m.e + 70, m.f + 70]);
+          }
+          if (edgePts[id]) {
+            for (const p of edgePts[id]) boxes.push([p[0], p[1], p[0], p[1]]);
+          }
+          const th = threats.find((t) => t.id === id);
+          if (th) boxes.push([th.x - 24, th.y - 24, th.x + 24, th.y + 24]);
+        }
+        if (!boxes.length) return;
+        const x0 = Math.min(...boxes.map((b) => b[0])) - pad,
+          y0 = Math.min(...boxes.map((b) => b[1])) - pad,
+          x1 = Math.max(...boxes.map((b) => b[2])) + pad,
+          y1 = Math.max(...boxes.map((b) => b[3])) + pad;
+        const r = stage.getBoundingClientRect();
+        const s = Math.min(r.width / (x1 - x0), r.height / (y1 - y0), 0.9);
+        const target = { w: r.width / s, h: r.height / s };
+        target.x = (x0 + x1) / 2 - target.w / 2;
+        target.y = (y0 + y1) / 2 - target.h / 2;
+        animateTo(target);
+      }
+      let anim = null;
+      function animateTo(t) {
+        const from = { ...vb }, t0 = performance.now();
+        cancelAnimationFrame(anim);
+        const step = (now) => {
+          const k = Math.min(1, (now - t0) / 420), e = 1 - Math.pow(1 - k, 3);
+          vb = {
+            x: from.x + (t.x - from.x) * e,
+            y: from.y + (t.y - from.y) * e,
+            w: from.w + (t.w - from.w) * e,
+            h: from.h + (t.h - from.h) * e,
+          };
+          applyVB();
+          if (k < 1) anim = requestAnimationFrame(step);
+        };
+        anim = requestAnimationFrame(step);
+      }
+      let drag = null;
+      stage.addEventListener("pointerdown", (ev) => {
+        drag = {
+          x: ev.clientX,
+          y: ev.clientY,
+          vx: vb.x,
+          vy: vb.y,
+          moved: false,
+          target: ev.target,
+        };
+        stage.classList.add("dragging");
+        stage.setPointerCapture(ev.pointerId);
+      });
+      stage.addEventListener("pointermove", (ev) => {
+        if (!drag) return;
+        const r = stage.getBoundingClientRect();
+        const s = vb.w / r.width;
+        const dx = ev.clientX - drag.x, dy = ev.clientY - drag.y;
+        if (Math.abs(dx) + Math.abs(dy) > 3) drag.moved = true;
+        vb.x = drag.vx - dx * s;
+        vb.y = drag.vy - dy * s;
+        applyVB();
+      });
+      stage.addEventListener("pointerup", (ev) => {
+        const moved = drag && drag.moved;
+        const tgt = drag && drag.target;
+        drag = null;
+        stage.classList.remove("dragging");
+        if (!moved && tgt) {
+          const t = tgt.closest("[data-id]");
+          if (t) select(t.dataset.id);
+        }
+      });
+      stage.addEventListener("wheel", (ev) => {
+        ev.preventDefault();
+        const r = stage.getBoundingClientRect();
+        const mx = vb.x + (ev.clientX - r.left) / r.width * vb.w,
+          my = vb.y + (ev.clientY - r.top) / r.height * vb.h;
+        const f = Math.exp(ev.deltaY * 0.0015);
+        const nw = Math.max(400, Math.min(W * 2, vb.w * f));
+        const k = nw / vb.w;
+        vb = {
+          w: nw,
+          h: vb.h * k,
+          x: mx - (mx - vb.x) * k,
+          y: my - (my - vb.y) * k,
+        };
+        applyVB();
+      }, { passive: false });
+      window.addEventListener("resize", () => fit());
+      fit();
+      document.getElementById("btnFit").onclick = () => {
+        exitStory();
+        fit();
+      };
+      document.getElementById("btnTheme").onclick = function () {
+        const html = document.documentElement;
+        const light = html.dataset.theme !== "light";
+        html.dataset.theme = light ? "light" : "dark";
+        this.textContent = light ? "Dark" : "Light";
+      };
+
+      // ------------------------------------------------------------------ legends + toggles
+      const legend = document.getElementById("legend");
+      const kindOn = new Set(Object.keys(kindNames));
+      for (const k of Object.keys(kindNames)) {
+        const b = document.createElement("button");
+        b.className = "chip";
+        b.innerHTML = `<span class="sw ${kindNames[k][1]}"></span>${
+          kindNames[k][0]
+        }`;
+        b.style.color = `var(--k-${k})`;
+        b.onclick = () => {
+          if (kindOn.has(k)) kindOn.delete(k);
+          else kindOn.add(k);
+          b.classList.toggle("off", !kindOn.has(k));
+          refresh();
+        };
+        legend.appendChild(b);
+      }
+      let showThreats = true, showStatus = true;
+      const classOn = new Set(Object.keys(threatClass));
+      const tlegend = document.getElementById("tlegend");
+      for (const c of Object.keys(threatClass)) {
+        const b = document.createElement("button");
+        b.className = "chip";
+        b.innerHTML = `<span style="color:${
+          threatClass[c].color
+        };font-size:16px;line-height:0">⬢</span>${threatClass[c].name}`;
+        b.onclick = () => {
+          if (classOn.has(c)) classOn.delete(c);
+          else classOn.add(c);
+          b.classList.toggle("off", !classOn.has(c));
+          refresh();
+        };
+        tlegend.appendChild(b);
+      }
+      const glegend = document.getElementById("glegend");
+      for (const s of Object.keys(statusNames)) {
+        const b = document.createElement("span");
+        b.className = "chip";
+        b.style.cssText =
+          "display:inline-flex;align-items:center;gap:6px;font-size:13px;color:var(--muted)";
+        b.innerHTML =
+          `<span style="color:var(--s-${s});font-size:16px;line-height:0">${
+            s === "gap" || s === "intended" ? "◇" : "◆"
+          }</span>${statusNames[s]}`;
+        glegend.appendChild(b);
+      }
+      document.getElementById("btnThreats").onclick = function () {
+        showThreats = !showThreats;
+        this.classList.toggle("on", showThreats);
+        refresh();
+      };
+      document.getElementById("btnStatus").onclick = function () {
+        showStatus = !showStatus;
+        this.classList.toggle("on", showStatus);
+        refresh();
+      };
+
+      // ------------------------------------------------------------------ selection / detail
+      const detail = document.getElementById("detail");
+      let selected = null;
+      let story = null, stepI = 0;
+      const history = [];
+      function statusPill(s) {
+        return `<span class="status ${s}">${statusNames[s]}</span>`;
+      }
+      function linksHtml(links) {
+        return links && links.length
+          ? `<h3>Landed</h3><ul>${
+            links.map(([t, n]) => `<li>${PR(n)} ${t}</li>`).join("")
+          }</ul>`
+          : "";
+      }
+      function closeHtml(c) {
+        return c && c.length
+          ? `<h3>To close the circuit</h3><ul>${
+            c.map((x) => `<li>${x}</li>`).join("")
+          }</ul>`
+          : "";
+      }
+      function threatsHtml(ts) {
+        return ts && ts.length
+          ? `<h3>Threats here</h3><ul>${
+            ts.map((id) => {
+              const t = threats.find((x) => x.id === id);
+              const c = threatClass[t.c];
+              return `<li><a href="#" data-go="${id}">${t.n} · ${t.t}</a> <span class="status" style="background:${c.color};font-size:10px">${c.name}</span></li>`;
+            }).join("")
+          }</ul>`
+          : "";
+      }
+      function whereHtml(ids) {
+        return ids && ids.length
+          ? `<h3>Where</h3><p>${
+            ids.map((id) => {
+              const n = N[id];
+              const g = gateDefs[id];
+              return `<a href="#" data-go="${id}">${
+                n ? n.t : g ? g.t + " gate" : id
+              }</a>`;
+            }).join(" · ")
+          }</p>`
+          : "";
+      }
+      function renderDetail(id) {
+        let html = "";
+        const back = history.length > 1
+          ? `<a href="#" class="bk" data-back="1">← back</a><br>`
+          : "";
+        if (N[id]) {
+          const n = N[id], d = D[id] || {};
+          html = `${back}<span class="kind b-${n.band}">${
+            d.kind || n.band
+          }</span><h2>${n.t}</h2><p class="hint">${n.s}</p>${d.body || ""}${
+            linksHtml(d.links)
+          }${threatsHtml(d.threats)}${closeHtml(d.close)}`;
+        } else if (gateDefs[id]) {
+          const g = gateDefs[id], d = GD[id] || {};
+          html = `${back}<span class="kind">Gate · ${g.boundary}</span>${
+            statusPill(g.status)
+          }<h2>${g.t}</h2>${d.body || ""}${
+            d.why ? `<h3>Why it matters</h3><p>${d.why}</p>` : ""
+          }${linksHtml(d.links)}${threatsHtml(d.threats)}${closeHtml(d.close)}`;
+        } else if (id.startsWith("t")) {
+          const t = threats.find((x) => x.id === id),
+            d = TD[id] || {},
+            c = threatClass[t.c];
+          html =
+            `${back}<span class="kind">Threat ${t.n}</span><span class="status" style="background:${c.color}">${c.name}</span><h2>${t.t}</h2><p class="hint">${c.blurb}</p>${
+              d.body || ""
+            }${d.plan ? `<h3>What closes it</h3><p>${d.plan}</p>` : ""}${
+              whereHtml(d.where)
+            }`;
+        } else {
+          const e = edges.find((x) => x.id === id);
+          if (e) {
+            const gd = e.gate && gateDefs[e.gate];
+            html =
+              `${back}<span class="kind" style="color:var(--k-${e.k});border-color:var(--k-${e.k})">${
+                kindNames[e.k][0]
+              }</span><h2>${N[e.from].t} → ${N[e.to].t}</h2>${
+                e.label ? `<p class="hint">${e.label}</p>` : ""
+              }${ED[id] || ""}${
+                gd
+                  ? `<h3>Gate on this edge</h3><p><a href="#" data-go="${e.gate}">${gd.t}</a> ${
+                    statusPill(gd.status)
+                  }</p>`
+                  : ""
+              }`;
+          }
+        }
+        detail.innerHTML = html || welcome();
+        detail.scrollTop = 0;
+        detail.querySelectorAll("[data-go]").forEach((a) =>
+          a.onclick = (ev) => {
+            ev.preventDefault();
+            select(a.dataset.go, true);
+          }
+        );
+        const bk = detail.querySelector("[data-back]");
+        if (bk) {
+          bk.onclick = (ev) => {
+            ev.preventDefault();
+            history.pop();
+            const prev = history.pop();
+            select(prev, true);
+          };
+        }
+      }
+      function welcome() {
+        return `<span class="kind">Start here</span><h2>How to read this map</h2><p>Four bands, top to bottom: what we never trust, what we mediate, what we must trust, and how we check ourselves. Data flows left to right; a colleague's request enters at the left and a rendered piece comes back to them there. Only the trusted computing base is tinted: it is the thing this map is about.</p><p><b>Diamonds are gates</b>: the only places a value may cross a boundary. Solid green shipped; solid amber partial; hollow red a gap; dashed gray intended.</p><p><b>Red-ringed hexagons are threats</b>, in three kinds. <span style="color:var(--s-partial)">⬢ closed by planned work</span>: a named gap with an owner. <span style="color:var(--s-shipped)">⬢ guarded by CFC</span>: held today. <span style="color:var(--s-intended)">⬢ remains</span>: CFC cannot close it; people and process hold it. Click one to see where it lives and what holds against it.</p><p><b>Dashed light-blue lines are handles</b>: names for data the model routes without ever holding. That line type is the whole idea. Bright white lines are labeled values inside the base; they never leave it except through a gate.</p><h3>Walks</h3><ul><li><b>The circuit</b>: label at the source → store per path → name don't carry → compute at the data → gated release → every sink a gate → prove it → what is still open.</li><li><b>Demo 1</b>: the Weaver pill, as it ran today.</li><li><b>Demo 2</b>: bills from Gmail and Plaid, with the loom-side gaps named.</li><li><b>Demo 3</b>: a hostile skill with nothing to steal.</li><li><b>Where we trust ourselves</b>: the base, ring by ring.</li></ul><p class="hint">Zoom in for edge labels and gate status captions; they hide at overview so the structure reads first.</p><p class="hint">Snapshot as of 2026-09-02, fact-checked against the code, the live docs and the issues. Gate statuses follow the boundary inventory on CT-2175, the deviations list in the harness implementation profile, and what merged after both were written. Loom-side claims are from CT-2189 and not verified against loom's code.</p>`;
+      }
+      function select(id, zoom) {
+        selected = id;
+        if (history[history.length - 1] !== id) history.push(id);
+        renderDetail(id);
+        refresh();
+        if (zoom) fitTo([id], 260);
+      }
+
+      // ------------------------------------------------------------------ stories
+      const storyBox = document.getElementById("story");
+      function startStory(id) {
+        story = stories[id];
+        stepI = 0;
+        document.querySelectorAll("[data-story]").forEach((b) =>
+          b.classList.toggle("on", b.dataset.story === id)
+        );
+        storyBox.classList.add("on");
+        showStep();
+      }
+      function exitStory() {
+        story = null;
+        storyBox.classList.remove("on");
+        document.querySelectorAll("[data-story]").forEach((b) =>
+          b.classList.remove("on")
+        );
+        refresh();
+      }
+      function showStep() {
+        const s = story.steps[stepI];
+        document.getElementById("storyN").innerHTML =
+          `${story.title}<small>step ${
+            stepI + 1
+          } of ${story.steps.length} · ← → move · Esc exits</small><div class="dots">${
+            story.steps.map((_, i) =>
+              `<i class="${i === stepI ? "on" : ""}"></i>`
+            ).join("")
+          }</div>`;
+        document.getElementById("storyT").innerHTML = `<b>${s.h}</b>${s.t}`;
+        selected = s.sel;
+        history.length = 0;
+        history.push(s.sel);
+        renderDetail(s.sel);
+        refresh();
+        fitTo(s.f, 160);
+        document.getElementById("sNext").textContent =
+          stepI === story.steps.length - 1 ? "Done" : "→";
+        document.getElementById("sPrev").disabled = stepI === 0;
+      }
+      document.querySelectorAll("[data-story]").forEach((b) =>
+        b.onclick = () => startStory(b.dataset.story)
+      );
+      document.getElementById("sPrev").onclick = () => {
+        if (stepI > 0) {
+          stepI--;
+          showStep();
+        }
+      };
+      document.getElementById("sNext").onclick = () => {
+        if (stepI < story.steps.length - 1) {
+          stepI++;
+          showStep();
+        } else {
+          exitStory();
+          fit();
+        }
+      };
+      document.getElementById("sClose").onclick = () => {
+        exitStory();
+        fit();
+      };
+      window.addEventListener("keydown", (ev) => {
+        if (!story) return;
+        if (ev.key === "ArrowRight") document.getElementById("sNext").click();
+        if (ev.key === "ArrowLeft") document.getElementById("sPrev").click();
+        if (ev.key === "Escape") document.getElementById("sClose").click();
+      });
+
+      // ------------------------------------------------------------------ refresh classes
+      function refresh() {
+        const focus = story ? new Set(story.steps[stepI].f) : null;
+        const related = new Set();
+        if (selected) {
+          related.add(selected);
+          const e = edges.find((x) => x.id === selected);
+          if (e) {
+            related.add(e.from);
+            related.add(e.to);
+            if (e.gate) related.add(e.gate);
+          }
+          for (const e of edges) {
+            if (e.gate === selected) {
+              related.add(e.id);
+              related.add(e.from);
+              related.add(e.to);
+            }
+            if (N[selected] && (e.from === selected || e.to === selected)) {
+              related.add(e.id);
+              if (e.gate) related.add(e.gate);
+            }
+          }
+          const td = TD[selected];
+          if (td && td.where) td.where.forEach((w) => related.add(w));
+        }
+        world.querySelectorAll("[data-id]").forEach((g) => {
+          const id = g.dataset.id;
+          const isEdge = g.classList.contains("edge");
+          const isThreat = g.classList.contains("threat");
+          const isGate = g.classList.contains("gate");
+          g.classList.toggle("sel", id === selected);
+          let dim = false, foc = false;
+          if (focus) {
+            foc = focus.has(id) || (isEdge && (() => {
+              const e = edges.find((x) => x.id === id);
+              return e && e.gate && focus.has(e.gate);
+            })());
+            dim = !foc;
+          } else if (selected) {
+            foc = related.has(id) && id !== selected;
+            dim = !related.has(id);
+          }
+          if (isEdge) {
+            const e = edges.find((x) => x.id === id);
+            if (!kindOn.has(e.k)) dim = true;
+          }
+          if (isThreat) {
+            g.classList.toggle(
+              "hidden",
+              !showThreats || !classOn.has(threats.find((t) => t.id === id).c),
+            );
+          }
+          if (isGate) {
+            g.querySelector("[data-status]").style.visibility = showStatus
+              ? ""
+              : "hidden";
+            for (const s of Object.keys(statusNames)) {
+              g.classList.toggle(s, showStatus && gateDefs[id].status === s);
+            }
+            g.classList.toggle(
+              "intended",
+              showStatus ? gateDefs[id].status === "intended" : true,
+            );
+          }
+          g.classList.toggle("dim", dim);
+          g.classList.toggle("focus", foc || id === selected);
+        });
+      }
+      renderDetail("");
+      refresh();
+    </script>
+  </body>
+</html>

--- a/packages/cf-harness/docs/system-map/cfc-system-map.html
+++ b/packages/cf-harness/docs/system-map/cfc-system-map.html
@@ -5,607 +5,610 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Common Fabric · the CFC circuit — system map</title>
     <style>
-      :root, [data-theme="dark"] {
-        --bg: #0f1115;
-        --grid: #1b1f28;
-        --panel: #171a21;
-        --panel-2: #1e222b;
-        --line: #2b303b;
-        --fg: #e6e8ee;
-        --muted: #9aa3b2;
-        --accent: #7dd3fc;
-        --node: #1b1f28;
-        --node-stroke: #454c5a;
-        --node-hover: #242a36;
-        --node-focus: #27303f;
-        --gate-fill: #12151b;
-        --ink: #0b0d11;
-        --story-bg: rgba(23, 26, 33, 0.97);
-        --outside: #fb7185;
-        --tcb: #34d399;
-        --tcb-tint: rgba(52, 211, 153, 0.06);
-        --k-handle: #7dd3fc;
-        --k-value: #e879f9;
-        --k-labeled: #f1f5f9;
-        --k-ingress: #fb7185;
-        --k-control: #6b7280;
-        --k-evidence: #a78bfa;
-        --s-shipped: #22c55e;
-        --s-partial: #f59e0b;
-        --s-gap: #ef4444;
-        --s-intended: #94a3b8;
-        --dim: 0.22;
-      }
-      [data-theme="light"] {
-        --bg: #f6f7f9;
-        --grid: #e3e6eb;
-        --panel: #ffffff;
-        --panel-2: #eef1f5;
-        --line: #d5dae2;
-        --fg: #14181f;
-        --muted: #5b6472;
-        --accent: #0369a1;
-        --node: #ffffff;
-        --node-stroke: #8b94a3;
-        --node-hover: #eef4ff;
-        --node-focus: #e0efff;
-        --gate-fill: #ffffff;
-        --ink: #ffffff;
-        --story-bg: rgba(255, 255, 255, 0.97);
-        --outside: #e11d48;
-        --tcb: #059669;
-        --tcb-tint: rgba(5, 150, 105, 0.07);
-        --k-handle: #0284c7;
-        --k-value: #c026d3;
-        --k-labeled: #111827;
-        --k-ingress: #e11d48;
-        --k-control: #6b7280;
-        --k-evidence: #7c3aed;
-        --s-shipped: #16a34a;
-        --s-partial: #d97706;
-        --s-gap: #dc2626;
-        --s-intended: #64748b;
-        --dim: 0.18;
-      }
-      * {
-        box-sizing: border-box;
-      }
-      html, body {
-        margin: 0;
-        height: 100%;
-        background: var(--bg);
-        color: var(--fg);
-        font:
-          14px/1.45 -apple-system,
-          BlinkMacSystemFont,
-          "Inter",
-          "Segoe UI",
-          Helvetica,
-          Arial,
-          sans-serif;
-        overflow: hidden;
-      }
-      #app {
-        display: grid;
-        grid-template-columns: 1fr 400px;
-        grid-template-rows: auto 1fr auto;
-        height: 100%;
-      }
-      header {
-        grid-column: 1 / 3;
-        display: grid;
-        gap: 6px 14px;
-        padding: 8px 16px;
-        border-bottom: 1px solid var(--line);
-        background: var(--panel);
-      }
-      header .row {
-        display: flex;
-        align-items: center;
-        gap: 8px;
-        flex-wrap: wrap;
-      }
-      header h1 {
-        font-size: 15px;
-        margin: 0 10px 0 0;
-        font-weight: 600;
-        letter-spacing: 0.01em;
-        white-space: nowrap;
-      }
-      header h1 span {
-        color: var(--muted);
-        font-weight: 400;
-      }
-      .group {
-        display: flex;
-        align-items: center;
-        gap: 6px;
-      }
-      .group + .group {
-        margin-left: 6px;
-        padding-left: 12px;
-        border-left: 1px solid var(--line);
-      }
-      .glabel {
-        color: var(--muted);
-        font-size: 11px;
-        text-transform: uppercase;
-        letter-spacing: 0.08em;
-        margin-right: 4px;
-      }
-      button {
-        background: var(--panel-2);
-        color: var(--fg);
-        border: 1px solid var(--line);
-        border-radius: 7px;
-        padding: 5px 10px;
-        font: inherit;
-        font-size: 13px;
-        cursor: pointer;
-      }
-      button:hover {
-        border-color: var(--accent);
-      }
-      button.on {
-        background: var(--accent);
-        border-color: var(--accent);
-        color: var(--ink);
-      }
-      button.chip {
-        display: inline-flex;
-        align-items: center;
-        gap: 7px;
-      }
-      button.chip .sw {
-        width: 22px;
-        height: 0;
-        border-top: 3px solid currentColor;
-        border-radius: 2px;
-      }
-      button.chip .sw.dash {
-        border-top-style: dashed;
-      }
-      button.chip .sw.dot {
-        border-top-style: dotted;
-      }
-      button.chip.off {
-        opacity: 0.35;
-      }
-      #stage {
-        grid-column: 1;
-        grid-row: 2;
-        position: relative;
-        overflow: hidden;
-        background:
-          radial-gradient(circle at 1px 1px, var(--grid) 1px, transparent 1px) 0
-          0 / 28px 28px,
-          var(--bg);
-        cursor: grab;
-      }
-      #stage.dragging {
-        cursor: grabbing;
-      }
-      svg {
-        width: 100%;
-        height: 100%;
-        display: block;
-      }
-      aside {
-        grid-column: 2;
-        grid-row: 2 / 4;
-        border-left: 1px solid var(--line);
-        background: var(--panel);
-        overflow: auto;
-        padding: 18px;
-        font-size: 15px;
-      }
-      aside h2 {
-        font-size: 18px;
-        margin: 8px 0 4px;
-      }
-      aside .kind {
-        display: inline-block;
-        font-size: 11px;
-        text-transform: uppercase;
-        letter-spacing: 0.08em;
-        padding: 2px 8px;
-        border-radius: 999px;
-        border: 1px solid var(--line);
-        color: var(--muted);
-        margin-right: 6px;
-      }
-      aside .kind.b-outside {
-        border-color: var(--outside);
-        color: var(--outside);
-      }
-      aside .kind.b-tcb {
-        border-color: var(--tcb);
-        color: var(--tcb);
-      }
-      aside .status {
-        display: inline-block;
-        font-size: 11px;
-        padding: 2px 8px;
-        border-radius: 999px;
-        color: var(--ink);
-        font-weight: 600;
-        vertical-align: middle;
-      }
-      aside .status.shipped {
-        background: var(--s-shipped);
-      }
-      aside .status.partial {
-        background: var(--s-partial);
-      }
-      aside .status.gap {
-        background: var(--s-gap);
-        color: #fff;
-      }
-      aside .status.intended {
-        background: var(--s-intended);
-      }
-      aside p {
-        margin: 8px 0;
-      }
-      aside h3 {
-        font-size: 12px;
-        text-transform: uppercase;
-        letter-spacing: 0.08em;
-        color: var(--muted);
-        margin: 18px 0 6px;
-      }
-      aside ul {
-        margin: 0;
-        padding-left: 18px;
-      }
-      aside li {
-        margin: 5px 0;
-      }
-      aside code {
-        font: 13px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace;
-        background: var(--panel-2);
-        padding: 1px 5px;
-        border-radius: 4px;
-      }
-      aside a {
-        color: var(--accent);
-        text-decoration: none;
-      }
-      aside a:hover {
-        text-decoration: underline;
-      }
-      aside .hint {
-        color: var(--muted);
-        font-size: 13px;
-      }
-      aside .bk {
-        display: inline-block;
-        margin-bottom: 8px;
-        font-size: 13px;
-      }
-      #story {
-        grid-column: 1;
-        border-top: 1px solid var(--line);
-        background: var(--story-bg);
-        padding: 12px 16px;
-        display: none;
-        gap: 14px;
-        align-items: flex-start;
-      }
-      #story.on {
-        display: flex;
-      }
-      #story .n {
-        color: var(--accent);
-        font-size: 12px;
-        text-transform: uppercase;
-        letter-spacing: 0.08em;
-        white-space: nowrap;
-        padding-top: 4px;
-        min-width: 200px;
-      }
-      #story .n small {
-        display: block;
-        color: var(--muted);
-        text-transform: none;
-        letter-spacing: 0;
-        margin-top: 4px;
-      }
-      #story .t {
-        flex: 1;
-        font-size: 15px;
-      }
-      #story .t b {
-        display: block;
-        margin-bottom: 3px;
-        font-size: 17px;
-      }
-      #story .dots {
-        display: flex;
-        gap: 5px;
-        margin-top: 8px;
-      }
-      #story .dots i {
-        width: 8px;
-        height: 8px;
-        border-radius: 50%;
-        background: var(--line);
-        display: block;
-      }
-      #story .dots i.on {
-        background: var(--accent);
-      }
-      #story .nav {
-        display: flex;
-        gap: 6px;
-      }
-      #stage .hud {
-        position: absolute;
-        top: 10px;
-        left: 12px;
-        color: var(--muted);
-        font-size: 12px;
-        pointer-events: none;
-      }
+    :root,
+    [data-theme="dark"] {
+      --bg: #0f1115;
+      --grid: #1b1f28;
+      --panel: #171a21;
+      --panel-2: #1e222b;
+      --line: #2b303b;
+      --fg: #e6e8ee;
+      --muted: #9aa3b2;
+      --accent: #7dd3fc;
+      --node: #1b1f28;
+      --node-stroke: #454c5a;
+      --node-hover: #242a36;
+      --node-focus: #27303f;
+      --gate-fill: #12151b;
+      --ink: #0b0d11;
+      --story-bg: rgba(23, 26, 33, 0.97);
+      --outside: #fb7185;
+      --tcb: #34d399;
+      --tcb-tint: rgba(52, 211, 153, 0.06);
+      --k-handle: #7dd3fc;
+      --k-value: #e879f9;
+      --k-labeled: #f1f5f9;
+      --k-ingress: #fb7185;
+      --k-control: #6b7280;
+      --k-evidence: #a78bfa;
+      --s-shipped: #22c55e;
+      --s-partial: #f59e0b;
+      --s-gap: #ef4444;
+      --s-intended: #94a3b8;
+      --dim: 0.22;
+    }
+    [data-theme="light"] {
+      --bg: #f6f7f9;
+      --grid: #e3e6eb;
+      --panel: #ffffff;
+      --panel-2: #eef1f5;
+      --line: #d5dae2;
+      --fg: #14181f;
+      --muted: #5b6472;
+      --accent: #0369a1;
+      --node: #ffffff;
+      --node-stroke: #8b94a3;
+      --node-hover: #eef4ff;
+      --node-focus: #e0efff;
+      --gate-fill: #ffffff;
+      --ink: #ffffff;
+      --story-bg: rgba(255, 255, 255, 0.97);
+      --outside: #e11d48;
+      --tcb: #059669;
+      --tcb-tint: rgba(5, 150, 105, 0.07);
+      --k-handle: #0284c7;
+      --k-value: #c026d3;
+      --k-labeled: #111827;
+      --k-ingress: #e11d48;
+      --k-control: #6b7280;
+      --k-evidence: #7c3aed;
+      --s-shipped: #16a34a;
+      --s-partial: #d97706;
+      --s-gap: #dc2626;
+      --s-intended: #64748b;
+      --dim: 0.18;
+    }
+    * {
+      box-sizing: border-box;
+    }
+    html,
+    body {
+      margin: 0;
+      height: 100%;
+      background: var(--bg);
+      color: var(--fg);
+      font:
+        14px/1.45 -apple-system,
+        BlinkMacSystemFont,
+        "Inter",
+        "Segoe UI",
+        Helvetica,
+        Arial,
+        sans-serif;
+      overflow: hidden;
+    }
+    #app {
+      display: grid;
+      grid-template-columns: 1fr 400px;
+      grid-template-rows: auto 1fr auto;
+      height: 100%;
+    }
+    header {
+      grid-column: 1 / 3;
+      display: grid;
+      gap: 6px 14px;
+      padding: 8px 16px;
+      border-bottom: 1px solid var(--line);
+      background: var(--panel);
+    }
+    header .row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex-wrap: wrap;
+    }
+    header h1 {
+      font-size: 15px;
+      margin: 0 10px 0 0;
+      font-weight: 600;
+      letter-spacing: 0.01em;
+      white-space: nowrap;
+    }
+    header h1 span {
+      color: var(--muted);
+      font-weight: 400;
+    }
+    .group {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+    }
+    .group + .group {
+      margin-left: 6px;
+      padding-left: 12px;
+      border-left: 1px solid var(--line);
+    }
+    .glabel {
+      color: var(--muted);
+      font-size: 11px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      margin-right: 4px;
+    }
+    button {
+      background: var(--panel-2);
+      color: var(--fg);
+      border: 1px solid var(--line);
+      border-radius: 7px;
+      padding: 5px 10px;
+      font: inherit;
+      font-size: 13px;
+      cursor: pointer;
+    }
+    button:hover {
+      border-color: var(--accent);
+    }
+    button.on {
+      background: var(--accent);
+      border-color: var(--accent);
+      color: var(--ink);
+    }
+    button.chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 7px;
+    }
+    button.chip .sw {
+      width: 22px;
+      height: 0;
+      border-top: 3px solid currentColor;
+      border-radius: 2px;
+    }
+    button.chip .sw.dash {
+      border-top-style: dashed;
+    }
+    button.chip .sw.dot {
+      border-top-style: dotted;
+    }
+    button.chip.off {
+      opacity: 0.35;
+    }
+    #stage {
+      grid-column: 1;
+      grid-row: 2;
+      position: relative;
+      overflow: hidden;
+      background:
+        radial-gradient(circle at 1px 1px, var(--grid) 1px, transparent 1px) 0
+        0 / 28px 28px,
+        var(--bg);
+      cursor: grab;
+    }
+    #stage.dragging {
+      cursor: grabbing;
+    }
+    svg {
+      width: 100%;
+      height: 100%;
+      display: block;
+    }
+    aside {
+      grid-column: 2;
+      grid-row: 2 / 4;
+      border-left: 1px solid var(--line);
+      background: var(--panel);
+      overflow: auto;
+      padding: 18px;
+      font-size: 15px;
+    }
+    aside h2 {
+      font-size: 18px;
+      margin: 8px 0 4px;
+    }
+    aside .kind {
+      display: inline-block;
+      font-size: 11px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      padding: 2px 8px;
+      border-radius: 999px;
+      border: 1px solid var(--line);
+      color: var(--muted);
+      margin-right: 6px;
+    }
+    aside .kind.b-outside {
+      border-color: var(--outside);
+      color: var(--outside);
+    }
+    aside .kind.b-tcb {
+      border-color: var(--tcb);
+      color: var(--tcb);
+    }
+    aside .status {
+      display: inline-block;
+      font-size: 11px;
+      padding: 2px 8px;
+      border-radius: 999px;
+      color: var(--ink);
+      font-weight: 600;
+      vertical-align: middle;
+    }
+    aside .status.shipped {
+      background: var(--s-shipped);
+    }
+    aside .status.partial {
+      background: var(--s-partial);
+    }
+    aside .status.gap {
+      background: var(--s-gap);
+      color: #fff;
+    }
+    aside .status.intended {
+      background: var(--s-intended);
+    }
+    aside p {
+      margin: 8px 0;
+    }
+    aside h3 {
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--muted);
+      margin: 18px 0 6px;
+    }
+    aside ul {
+      margin: 0;
+      padding-left: 18px;
+    }
+    aside li {
+      margin: 5px 0;
+    }
+    aside code {
+      font: 13px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace;
+      background: var(--panel-2);
+      padding: 1px 5px;
+      border-radius: 4px;
+    }
+    aside a {
+      color: var(--accent);
+      text-decoration: none;
+    }
+    aside a:hover {
+      text-decoration: underline;
+    }
+    aside .hint {
+      color: var(--muted);
+      font-size: 13px;
+    }
+    aside .bk {
+      display: inline-block;
+      margin-bottom: 8px;
+      font-size: 13px;
+    }
+    #story {
+      grid-column: 1;
+      border-top: 1px solid var(--line);
+      background: var(--story-bg);
+      padding: 12px 16px;
+      display: none;
+      gap: 14px;
+      align-items: flex-start;
+    }
+    #story.on {
+      display: flex;
+    }
+    #story .n {
+      color: var(--accent);
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      white-space: nowrap;
+      padding-top: 4px;
+      min-width: 200px;
+    }
+    #story .n small {
+      display: block;
+      color: var(--muted);
+      text-transform: none;
+      letter-spacing: 0;
+      margin-top: 4px;
+    }
+    #story .t {
+      flex: 1;
+      font-size: 15px;
+    }
+    #story .t b {
+      display: block;
+      margin-bottom: 3px;
+      font-size: 17px;
+    }
+    #story .dots {
+      display: flex;
+      gap: 5px;
+      margin-top: 8px;
+    }
+    #story .dots i {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background: var(--line);
+      display: block;
+    }
+    #story .dots i.on {
+      background: var(--accent);
+    }
+    #story .nav {
+      display: flex;
+      gap: 6px;
+    }
+    #stage .hud {
+      position: absolute;
+      top: 10px;
+      left: 12px;
+      color: var(--muted);
+      font-size: 12px;
+      pointer-events: none;
+    }
 
-      /* SVG */
-      .band-rect {
-        fill: none;
-        stroke-width: 1.5;
-        rx: 18;
-        stroke: var(--line);
-      }
-      .band-rect.outside {
-        stroke: var(--outside);
-        stroke-opacity: 0.55;
-      }
-      .band-rect.tcb {
-        fill: var(--tcb-tint);
-        stroke: var(--tcb);
-        stroke-width: 2.5;
-      }
-      .band-title {
-        font-size: 26px;
-        font-weight: 700;
-        letter-spacing: 0.05em;
-        fill: var(--muted);
-      }
-      .band-title.outside {
-        fill: var(--outside);
-      }
-      .band-title.tcb {
-        fill: var(--tcb);
-      }
-      .band-sub {
-        font-size: 18px;
-        fill: var(--muted);
-        font-weight: 400;
-      }
-      .group-rect {
-        fill: none;
-        stroke: var(--line);
-        stroke-dasharray: 6 5;
-        rx: 14;
-      }
-      .stamp {
-        font-size: 22px;
-        fill: var(--muted);
-        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-        letter-spacing: 0.04em;
-      }
-      .group-title {
-        font-size: 14px;
-        fill: var(--muted);
-        font-weight: 600;
-        letter-spacing: 0.06em;
-      }
-      .node {
-        cursor: pointer;
-      }
-      .node rect {
-        fill: var(--node);
-        stroke: var(--node-stroke);
-        stroke-width: 1.5;
-        rx: 12;
-      }
-      .node.attach rect {
-        stroke-dasharray: 5 4;
-        fill: none;
-      }
-      .node .ic {
-        fill: none;
-        stroke: var(--muted);
-        stroke-width: 1.8;
-        stroke-linecap: round;
-        stroke-linejoin: round;
-      }
-      .node text {
-        fill: var(--fg);
-        font-size: 18px;
-        font-weight: 600;
-        pointer-events: none;
-      }
-      .node text.sub {
-        fill: var(--muted);
-        font-size: 13px;
-        font-weight: 400;
-      }
-      .node:hover rect, .node.sel rect {
-        fill: var(--node-hover);
-        stroke-width: 2.5;
-      }
-      .node.focus rect {
-        fill: var(--node-focus);
-        stroke: var(--accent);
-        stroke-width: 3;
-      }
-      .node.focus .ic {
-        stroke: var(--accent);
-      }
-      .edge path {
-        fill: none;
-        stroke-width: 3;
-        stroke-linejoin: round;
-        stroke-linecap: round;
-      }
-      .edge.k-handle path {
-        stroke: var(--k-handle);
-        stroke-dasharray: 10 7;
-      }
-      .edge.k-value path {
-        stroke: var(--k-value);
-      }
-      .edge.k-labeled path {
-        stroke: var(--k-labeled);
-        stroke-width: 3.5;
-      }
-      .edge.k-ingress path {
-        stroke: var(--k-ingress);
-      }
-      .edge.k-control path {
-        stroke: var(--k-control);
-        stroke-width: 1.8;
-      }
-      .edge.k-evidence path {
-        stroke: var(--k-evidence);
-        stroke-dasharray: 2 7;
-      }
-      .edge text {
-        font-size: 13px;
-        fill: var(--muted);
-        paint-order: stroke;
-        stroke: var(--bg);
-        stroke-width: 5px;
-        stroke-linejoin: round;
-        pointer-events: none;
-      }
-      .edge.focus path {
-        stroke-width: 5;
-      }
-      .edge.focus text {
-        fill: var(--fg);
-      }
-      .edge path.hit {
-        stroke: transparent !important;
-        stroke-width: 20;
-        cursor: pointer;
-        marker-start: none !important;
-        marker-end: none !important;
-        stroke-dasharray: none !important;
-      }
-      .gate {
-        cursor: pointer;
-      }
-      .gate polygon {
-        stroke-width: 3;
-      }
-      .gate.shipped polygon {
-        fill: var(--s-shipped);
-        stroke: var(--s-shipped);
-      }
-      .gate.partial polygon {
-        fill: var(--s-partial);
-        stroke: var(--s-partial);
-      }
-      .gate.gap polygon {
-        fill: var(--gate-fill);
-        stroke: var(--s-gap);
-        stroke-width: 4;
-      }
-      .gate.intended polygon {
-        fill: var(--gate-fill);
-        stroke: var(--s-intended);
-        stroke-dasharray: 5 4;
-      }
-      .gate .sh {
-        fill: none;
-        stroke-width: 2.2;
-        stroke: var(--ink);
-      }
-      .gate.gap .sh {
-        stroke: var(--s-gap);
-      }
-      .gate.intended .sh {
-        stroke: var(--s-intended);
-      }
-      .gate text.lbl {
-        font-size: 13px;
-        fill: var(--fg);
-        font-weight: 600;
-        paint-order: stroke;
-        stroke: var(--bg);
-        stroke-width: 5px;
-        pointer-events: none;
-      }
-      .gate text.st {
-        font-size: 12px;
-        font-weight: 500;
-        paint-order: stroke;
-        stroke: var(--bg);
-        stroke-width: 5px;
-        pointer-events: none;
-      }
-      .gate.focus polygon {
-        stroke: var(--accent);
-        stroke-width: 5;
-      }
-      .threat {
-        cursor: pointer;
-      }
-      .threat .mk {
-        stroke: var(--bg);
-        stroke-width: 2.5;
-      }
-      .threat.c-guarded .mk {
-        fill: var(--s-shipped);
-      }
-      .threat.c-upcoming .mk {
-        fill: var(--s-partial);
-      }
-      .threat.c-residual .mk {
-        fill: var(--s-intended);
-      }
-      .threat .ring {
-        fill: none;
-        stroke: var(--s-gap);
-        stroke-width: 2.5;
-      }
-      .threat .pg {
-        fill: none;
-        stroke: var(--ink);
-        stroke-width: 1.6;
-      }
-      .threat text {
-        fill: var(--ink);
-        font-size: 14px;
-        font-weight: 800;
-        pointer-events: none;
-      }
-      .threat.focus .mk {
-        stroke: var(--accent);
-        stroke-width: 4;
-      }
-      .threat.hidden {
-        display: none;
-      }
-      .dim {
-        opacity: var(--dim);
-        filter: saturate(0.25);
-      }
-      /* level of detail by zoom */
-      svg.z0 .edge text,
-      svg.z0 .gate text.st,
-      svg.z0 .node text.sub,
-      svg.z0 .group-title,
-      svg.z0 .band-sub {
-        display: none;
-      }
-      svg.z1 .gate text.st {
-        display: none;
-      }
-      .arrow {
-        fill: currentColor;
-      }
+    /* SVG */
+    .band-rect {
+      fill: none;
+      stroke-width: 1.5;
+      rx: 18;
+      stroke: var(--line);
+    }
+    .band-rect.outside {
+      stroke: var(--outside);
+      stroke-opacity: 0.55;
+    }
+    .band-rect.tcb {
+      fill: var(--tcb-tint);
+      stroke: var(--tcb);
+      stroke-width: 2.5;
+    }
+    .band-title {
+      font-size: 26px;
+      font-weight: 700;
+      letter-spacing: 0.05em;
+      fill: var(--muted);
+    }
+    .band-title.outside {
+      fill: var(--outside);
+    }
+    .band-title.tcb {
+      fill: var(--tcb);
+    }
+    .band-sub {
+      font-size: 18px;
+      fill: var(--muted);
+      font-weight: 400;
+    }
+    .group-rect {
+      fill: none;
+      stroke: var(--line);
+      stroke-dasharray: 6 5;
+      rx: 14;
+    }
+    .stamp {
+      font-size: 22px;
+      fill: var(--muted);
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      letter-spacing: 0.04em;
+    }
+    .group-title {
+      font-size: 14px;
+      fill: var(--muted);
+      font-weight: 600;
+      letter-spacing: 0.06em;
+    }
+    .node {
+      cursor: pointer;
+    }
+    .node rect {
+      fill: var(--node);
+      stroke: var(--node-stroke);
+      stroke-width: 1.5;
+      rx: 12;
+    }
+    .node.attach rect {
+      stroke-dasharray: 5 4;
+      fill: none;
+    }
+    .node .ic {
+      fill: none;
+      stroke: var(--muted);
+      stroke-width: 1.8;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+    }
+    .node text {
+      fill: var(--fg);
+      font-size: 18px;
+      font-weight: 600;
+      pointer-events: none;
+    }
+    .node text.sub {
+      fill: var(--muted);
+      font-size: 13px;
+      font-weight: 400;
+    }
+    .node:hover rect,
+    .node.sel rect {
+      fill: var(--node-hover);
+      stroke-width: 2.5;
+    }
+    .node.focus rect {
+      fill: var(--node-focus);
+      stroke: var(--accent);
+      stroke-width: 3;
+    }
+    .node.focus .ic {
+      stroke: var(--accent);
+    }
+    .edge path {
+      fill: none;
+      stroke-width: 3;
+      stroke-linejoin: round;
+      stroke-linecap: round;
+    }
+    .edge.k-handle path {
+      stroke: var(--k-handle);
+      stroke-dasharray: 10 7;
+    }
+    .edge.k-value path {
+      stroke: var(--k-value);
+    }
+    .edge.k-labeled path {
+      stroke: var(--k-labeled);
+      stroke-width: 3.5;
+    }
+    .edge.k-ingress path {
+      stroke: var(--k-ingress);
+    }
+    .edge.k-control path {
+      stroke: var(--k-control);
+      stroke-width: 1.8;
+    }
+    .edge.k-evidence path {
+      stroke: var(--k-evidence);
+      stroke-dasharray: 2 7;
+    }
+    .edge text {
+      font-size: 13px;
+      fill: var(--muted);
+      paint-order: stroke;
+      stroke: var(--bg);
+      stroke-width: 5px;
+      stroke-linejoin: round;
+      pointer-events: none;
+    }
+    .edge.focus path {
+      stroke-width: 5;
+    }
+    .edge.focus text {
+      fill: var(--fg);
+    }
+    .edge path.hit {
+      stroke: transparent !important;
+      stroke-width: 20;
+      cursor: pointer;
+      marker-start: none !important;
+      marker-end: none !important;
+      stroke-dasharray: none !important;
+    }
+    .gate {
+      cursor: pointer;
+    }
+    .gate polygon {
+      stroke-width: 3;
+    }
+    .gate.shipped polygon {
+      fill: var(--s-shipped);
+      stroke: var(--s-shipped);
+    }
+    .gate.partial polygon {
+      fill: var(--s-partial);
+      stroke: var(--s-partial);
+    }
+    .gate.gap polygon {
+      fill: var(--gate-fill);
+      stroke: var(--s-gap);
+      stroke-width: 4;
+    }
+    .gate.intended polygon {
+      fill: var(--gate-fill);
+      stroke: var(--s-intended);
+      stroke-dasharray: 5 4;
+    }
+    .gate .sh {
+      fill: none;
+      stroke-width: 2.2;
+      stroke: var(--ink);
+    }
+    .gate.gap .sh {
+      stroke: var(--s-gap);
+    }
+    .gate.intended .sh {
+      stroke: var(--s-intended);
+    }
+    .gate text.lbl {
+      font-size: 13px;
+      fill: var(--fg);
+      font-weight: 600;
+      paint-order: stroke;
+      stroke: var(--bg);
+      stroke-width: 5px;
+      pointer-events: none;
+    }
+    .gate text.st {
+      font-size: 12px;
+      font-weight: 500;
+      paint-order: stroke;
+      stroke: var(--bg);
+      stroke-width: 5px;
+      pointer-events: none;
+    }
+    .gate.focus polygon {
+      stroke: var(--accent);
+      stroke-width: 5;
+    }
+    .threat {
+      cursor: pointer;
+    }
+    .threat .mk {
+      stroke: var(--bg);
+      stroke-width: 2.5;
+    }
+    .threat.c-guarded .mk {
+      fill: var(--s-shipped);
+    }
+    .threat.c-upcoming .mk {
+      fill: var(--s-partial);
+    }
+    .threat.c-residual .mk {
+      fill: var(--s-intended);
+    }
+    .threat .ring {
+      fill: none;
+      stroke: var(--s-gap);
+      stroke-width: 2.5;
+    }
+    .threat .pg {
+      fill: none;
+      stroke: var(--ink);
+      stroke-width: 1.6;
+    }
+    .threat text {
+      fill: var(--ink);
+      font-size: 14px;
+      font-weight: 800;
+      pointer-events: none;
+    }
+    .threat.focus .mk {
+      stroke: var(--accent);
+      stroke-width: 4;
+    }
+    .threat.hidden {
+      display: none;
+    }
+    .dim {
+      opacity: var(--dim);
+      filter: saturate(0.25);
+    }
+    /* level of detail by zoom */
+    svg.z0 .edge text,
+    svg.z0 .gate text.st,
+    svg.z0 .node text.sub,
+    svg.z0 .group-title,
+    svg.z0 .band-sub {
+      display: none;
+    }
+    svg.z1 .gate text.st {
+      display: none;
+    }
+    .arrow {
+      fill: currentColor;
+    }
     </style>
   </head>
   <body>
@@ -663,2525 +666,2518 @@
       <aside id="detail"></aside>
     </div>
     <script>
-      // ------------------------------------------------------------------ layout data
-      // The state of this repository the map describes. Bump both when the
-      // map is re-verified; the stamp is drawn in the canvas's top-left corner.
-      const SNAPSHOT = { date: "2026-09-02", sha: "80ddb05554" };
-      const W = 2760, H = 1840;
-      const bands = [
-        {
-          id: "outside",
-          x: 250,
-          y: 40,
-          w: 2470,
-          h: 260,
-          title: "OUTSIDE",
-          sub: "never trusted · content is data, never a command",
-        },
-        {
-          id: "agent",
-          x: 250,
-          y: 340,
-          w: 2470,
-          h: 680,
-          title: "AGENT EXECUTION",
-          sub:
-            "mediated · the model proposes, trusted code decides · the model holds names, not values",
-        },
-        {
-          id: "tcb",
-          x: 250,
-          y: 1060,
-          w: 2470,
-          h: 420,
-          title: "TRUSTED COMPUTING BASE",
-          sub:
-            "where we have to trust ourselves · labels live here, policy meaning is decided here",
-        },
-        {
-          id: "evidence",
-          x: 250,
-          y: 1520,
-          w: 2470,
-          h: 260,
-          title: "EVIDENCE",
-          sub:
-            "verified · enforcement happens live, audit checks that it left proof",
-        },
-      ];
-      const groups = [
-        {
-          x: 1200,
-          y: 500,
-          w: 310,
-          h: 400,
-          title: "CHILDREN · fresh context, seeded handles only",
-        },
-        {
-          x: 1580,
-          y: 500,
-          w: 570,
-          h: 400,
-          title: "SANDBOX · every observation is mediated",
-        },
-      ];
-      const nodes = [
-        {
-          id: "person",
-          band: "principal",
-          ic: "person",
-          x: 60,
-          y: 560,
-          w: 150,
-          h: 92,
-          t: "Person",
-          s: "colleague · Alex · a user",
-        },
-        {
-          id: "operator",
-          band: "principal",
-          ic: "person",
-          x: 60,
-          y: 1600,
-          w: 150,
-          h: 92,
-          t: "Operator",
-          s: "Common Fabric employee",
-        },
+    // ------------------------------------------------------------------ layout data
+    // The state of this repository the map describes. Bump both when the
+    // map is re-verified; the stamp is drawn in the canvas's top-left corner.
+    const SNAPSHOT = { date: "2026-09-02", sha: "80ddb05554" };
+    const W = 2760, H = 1840;
+    const bands = [
+      {
+        id: "outside",
+        x: 250,
+        y: 40,
+        w: 2470,
+        h: 260,
+        title: "OUTSIDE",
+        sub: "never trusted · content is data, never a command",
+      },
+      {
+        id: "agent",
+        x: 250,
+        y: 340,
+        w: 2470,
+        h: 680,
+        title: "AGENT EXECUTION",
+        sub:
+          "mediated · the model proposes, trusted code decides · the model holds names, not values",
+      },
+      {
+        id: "tcb",
+        x: 250,
+        y: 1060,
+        w: 2470,
+        h: 420,
+        title: "TRUSTED COMPUTING BASE",
+        sub:
+          "where we have to trust ourselves · labels live here, policy meaning is decided here",
+      },
+      {
+        id: "evidence",
+        x: 250,
+        y: 1520,
+        w: 2470,
+        h: 260,
+        title: "EVIDENCE",
+        sub: "verified · enforcement happens live, audit checks that it left proof",
+      },
+    ];
+    const groups = [
+      {
+        x: 1200,
+        y: 500,
+        w: 310,
+        h: 400,
+        title: "CHILDREN · fresh context, seeded handles only",
+      },
+      {
+        x: 1580,
+        y: 500,
+        w: 570,
+        h: 400,
+        title: "SANDBOX · every observation is mediated",
+      },
+    ];
+    const nodes = [
+      {
+        id: "person",
+        band: "principal",
+        ic: "person",
+        x: 60,
+        y: 560,
+        w: 150,
+        h: 92,
+        t: "Person",
+        s: "colleague · Alex · a user",
+      },
+      {
+        id: "operator",
+        band: "principal",
+        ic: "person",
+        x: 60,
+        y: 1600,
+        w: 150,
+        h: 92,
+        t: "Operator",
+        s: "Common Fabric employee",
+      },
 
-        {
-          id: "provider",
-          band: "outside",
-          ic: "sparkle",
-          x: 1000,
-          y: 130,
-          w: 230,
-          h: 92,
-          t: "LLM provider",
-          s: "OpenAI-compatible gateway · Codex",
-        },
-        {
-          id: "www",
-          band: "outside",
-          ic: "globe",
-          x: 1560,
-          y: 130,
-          w: 200,
-          h: 92,
-          t: "WWW",
-          s: "web_search · web_fetch",
-        },
-        {
-          id: "skillssh",
-          band: "outside",
-          ic: "globe",
-          x: 1820,
-          y: 130,
-          w: 220,
-          h: 92,
-          t: "Skills.sh",
-          s: "third-party skill authors",
-        },
-        {
-          id: "thirdparty",
-          band: "outside",
-          ic: "globe",
-          x: 2300,
-          y: 130,
-          w: 240,
-          h: 92,
-          t: "Plaid · Gmail",
-          s: "third-party data APIs",
-        },
+      {
+        id: "provider",
+        band: "outside",
+        ic: "sparkle",
+        x: 1000,
+        y: 130,
+        w: 230,
+        h: 92,
+        t: "LLM provider",
+        s: "OpenAI-compatible gateway · Codex",
+      },
+      {
+        id: "www",
+        band: "outside",
+        ic: "globe",
+        x: 1560,
+        y: 130,
+        w: 200,
+        h: 92,
+        t: "WWW",
+        s: "web_search · web_fetch",
+      },
+      {
+        id: "skillssh",
+        band: "outside",
+        ic: "globe",
+        x: 1820,
+        y: 130,
+        w: 220,
+        h: 92,
+        t: "Skills.sh",
+        s: "third-party skill authors",
+      },
+      {
+        id: "thirdparty",
+        band: "outside",
+        ic: "globe",
+        x: 2300,
+        y: 130,
+        w: 240,
+        h: 92,
+        t: "Plaid · Gmail",
+        s: "third-party data APIs",
+      },
 
-        {
-          id: "weaver",
-          band: "agent",
-          ic: "window",
-          x: 290,
-          y: 560,
-          w: 210,
-          h: 92,
-          t: "Weaver pill",
-          s: "/cf-harness … · opens the piece",
-        },
-        {
-          id: "console",
-          band: "agent",
-          ic: "server",
-          x: 550,
-          y: 560,
-          w: 210,
-          h: 92,
-          t: "Harness console",
-          s: "POST /api/task · SSE · result",
-        },
-        {
-          id: "adapters",
-          band: "agent",
-          ic: "server",
-          x: 550,
-          y: 780,
-          w: 210,
-          h: 80,
-          t: "Loom · Pattern Factory",
-          s: "product adapters",
-        },
-        {
-          id: "gateway",
-          band: "agent",
-          ic: "server",
-          x: 1000,
-          y: 380,
-          w: 230,
-          h: 80,
-          t: "LLM gateway (ours)",
-          s: "tokens out · proposals in",
-        },
-        {
-          id: "parent",
-          band: "agent",
-          ic: "cpu",
-          x: 800,
-          y: 560,
-          w: 230,
-          h: 110,
-          t: "Parent harness",
-          s: "prompt loop · tool mediation",
-        },
-        {
-          id: "handles",
-          band: "agent",
-          ic: "key",
-          attach: true,
-          x: 800,
-          y: 760,
-          w: 230,
-          h: 64,
-          t: "Handle table",
-          s: "cfh:a: tokens ↔ cell addresses",
-        },
-        {
-          id: "child_pa",
-          band: "agent",
-          ic: "cpu",
-          x: 1220,
-          y: 540,
-          w: 280,
-          h: 80,
-          t: "pattern-author child",
-          s: "writes and runs the pattern",
-        },
-        {
-          id: "child_browser",
-          band: "agent",
-          ic: "cpu",
-          x: 1220,
-          y: 660,
-          w: 220,
-          h: 80,
-          t: "browser child",
-          s: "typed browser tool",
-        },
-        {
-          id: "child_web",
-          band: "agent",
-          ic: "cpu",
-          x: 1220,
-          y: 780,
-          w: 220,
-          h: 80,
-          t: "web child",
-          s: "web_fetch · web_search",
-        },
-        {
-          id: "docker",
-          band: "agent",
-          ic: "box",
-          x: 1600,
-          y: 540,
-          w: 250,
-          h: 92,
-          t: "Docker · runsc-cfc",
-          s: "bash · read_file · write_file",
-        },
-        {
-          id: "mount",
-          band: "agent",
-          ic: "folder",
-          x: 1600,
-          y: 700,
-          w: 200,
-          h: 80,
-          t: "Workspace mount",
-          s: "read-only or writable",
-        },
-        {
-          id: "localskills",
-          band: "agent",
-          ic: "folder",
-          x: 1880,
-          y: 540,
-          w: 250,
-          h: 80,
-          t: "Local skills registry",
-          s: "preloaded, digest-pinned",
-        },
-        {
-          id: "docs",
-          band: "agent",
-          ic: "file",
-          x: 1880,
-          y: 700,
-          w: 250,
-          h: 80,
-          t: "docs/common",
-          s: "trusted text; context, not command",
-        },
+      {
+        id: "weaver",
+        band: "agent",
+        ic: "window",
+        x: 290,
+        y: 560,
+        w: 210,
+        h: 92,
+        t: "Weaver pill",
+        s: "/cf-harness … · opens the piece",
+      },
+      {
+        id: "console",
+        band: "agent",
+        ic: "server",
+        x: 550,
+        y: 560,
+        w: 210,
+        h: 92,
+        t: "Harness console",
+        s: "POST /api/task · SSE · result",
+      },
+      {
+        id: "adapters",
+        band: "agent",
+        ic: "server",
+        x: 550,
+        y: 780,
+        w: 210,
+        h: 80,
+        t: "Loom · Pattern Factory",
+        s: "product adapters",
+      },
+      {
+        id: "gateway",
+        band: "agent",
+        ic: "server",
+        x: 1000,
+        y: 380,
+        w: 230,
+        h: 80,
+        t: "LLM gateway (ours)",
+        s: "tokens out · proposals in",
+      },
+      {
+        id: "parent",
+        band: "agent",
+        ic: "cpu",
+        x: 800,
+        y: 560,
+        w: 230,
+        h: 110,
+        t: "Parent harness",
+        s: "prompt loop · tool mediation",
+      },
+      {
+        id: "handles",
+        band: "agent",
+        ic: "key",
+        attach: true,
+        x: 800,
+        y: 760,
+        w: 230,
+        h: 64,
+        t: "Handle table",
+        s: "cfh:a: tokens ↔ cell addresses",
+      },
+      {
+        id: "child_pa",
+        band: "agent",
+        ic: "cpu",
+        x: 1220,
+        y: 540,
+        w: 280,
+        h: 80,
+        t: "pattern-author child",
+        s: "writes and runs the pattern",
+      },
+      {
+        id: "child_browser",
+        band: "agent",
+        ic: "cpu",
+        x: 1220,
+        y: 660,
+        w: 220,
+        h: 80,
+        t: "browser child",
+        s: "typed browser tool",
+      },
+      {
+        id: "child_web",
+        band: "agent",
+        ic: "cpu",
+        x: 1220,
+        y: 780,
+        w: 220,
+        h: 80,
+        t: "web child",
+        s: "web_fetch · web_search",
+      },
+      {
+        id: "docker",
+        band: "agent",
+        ic: "box",
+        x: 1600,
+        y: 540,
+        w: 250,
+        h: 92,
+        t: "Docker · runsc-cfc",
+        s: "bash · read_file · write_file",
+      },
+      {
+        id: "mount",
+        band: "agent",
+        ic: "folder",
+        x: 1600,
+        y: 700,
+        w: 200,
+        h: 80,
+        t: "Workspace mount",
+        s: "read-only or writable",
+      },
+      {
+        id: "localskills",
+        band: "agent",
+        ic: "folder",
+        x: 1880,
+        y: 540,
+        w: 250,
+        h: 80,
+        t: "Local skills registry",
+        s: "preloaded, digest-pinned",
+      },
+      {
+        id: "docs",
+        band: "agent",
+        ic: "file",
+        x: 1880,
+        y: 700,
+        w: 250,
+        h: 80,
+        t: "docs/common",
+        s: "trusted text; context, not command",
+      },
 
-        {
-          id: "apps",
-          band: "tcb",
-          ic: "window",
-          x: 290,
-          y: 1140,
-          w: 210,
-          h: 92,
-          t: "Estuary · Rapids",
-          s: "fabric apps",
-        },
-        {
-          id: "toolshed",
-          band: "tcb",
-          ic: "server",
-          x: 550,
-          y: 1140,
-          w: 180,
-          h: 92,
-          t: "cf-service",
-          s: "memory API · identity · UCAN",
-        },
-        {
-          id: "runner",
-          band: "tcb",
-          ic: "shield",
-          x: 800,
-          y: 1120,
-          w: 300,
-          h: 140,
-          t: "Runner · CFC kernel",
-          s: "derives labels · decides every gate it owns",
-        },
-        {
-          id: "spaces",
-          band: "tcb",
-          ic: "database",
-          x: 1220,
-          y: 1140,
-          w: 230,
-          h: 100,
-          t: "Spaces",
-          s: "values + per-path labels",
-        },
-        {
-          id: "policy",
-          band: "tcb",
-          ic: "sliders",
-          x: 800,
-          y: 1330,
-          w: 240,
-          h: 92,
-          t: "Policy posture",
-          s: "dials · records · grants · digest",
-        },
-        {
-          id: "index",
-          band: "tcb",
-          ic: "search",
-          x: 1360,
-          y: 1330,
-          w: 250,
-          h: 92,
-          t: "Pattern index",
-          s: "programs + metadata, not data",
-        },
-        {
-          id: "gardening",
-          band: "tcb",
-          ic: "leaf",
-          x: 1660,
-          y: 1330,
-          w: 250,
-          h: 80,
-          t: "Automated gardening",
-          s: "bounded writer",
-        },
-        {
-          id: "sqlite",
-          band: "tcb",
-          ic: "table",
-          x: 1860,
-          y: 1140,
-          w: 250,
-          h: 100,
-          t: "Connector SQLite tables",
-          s: "row labels from a table contract",
-        },
-        {
-          id: "connectors",
-          band: "tcb",
-          ic: "link",
-          x: 2200,
-          y: 1140,
-          w: 250,
-          h: 100,
-          t: "Connectors (loom)",
-          s: "ingress mediator",
-        },
+      {
+        id: "apps",
+        band: "tcb",
+        ic: "window",
+        x: 290,
+        y: 1140,
+        w: 210,
+        h: 92,
+        t: "Estuary · Rapids",
+        s: "fabric apps",
+      },
+      {
+        id: "toolshed",
+        band: "tcb",
+        ic: "server",
+        x: 550,
+        y: 1140,
+        w: 180,
+        h: 92,
+        t: "cf-service",
+        s: "memory API · identity · UCAN",
+      },
+      {
+        id: "runner",
+        band: "tcb",
+        ic: "shield",
+        x: 800,
+        y: 1120,
+        w: 300,
+        h: 140,
+        t: "Runner · CFC kernel",
+        s: "derives labels · decides every gate it owns",
+      },
+      {
+        id: "spaces",
+        band: "tcb",
+        ic: "database",
+        x: 1220,
+        y: 1140,
+        w: 230,
+        h: 100,
+        t: "Spaces",
+        s: "values + per-path labels",
+      },
+      {
+        id: "policy",
+        band: "tcb",
+        ic: "sliders",
+        x: 800,
+        y: 1330,
+        w: 240,
+        h: 92,
+        t: "Policy posture",
+        s: "dials · records · grants · digest",
+      },
+      {
+        id: "index",
+        band: "tcb",
+        ic: "search",
+        x: 1360,
+        y: 1330,
+        w: 250,
+        h: 92,
+        t: "Pattern index",
+        s: "programs + metadata, not data",
+      },
+      {
+        id: "gardening",
+        band: "tcb",
+        ic: "leaf",
+        x: 1660,
+        y: 1330,
+        w: 250,
+        h: 80,
+        t: "Automated gardening",
+        s: "bounded writer",
+      },
+      {
+        id: "sqlite",
+        band: "tcb",
+        ic: "table",
+        x: 1860,
+        y: 1140,
+        w: 250,
+        h: 100,
+        t: "Connector SQLite tables",
+        s: "row labels from a table contract",
+      },
+      {
+        id: "connectors",
+        band: "tcb",
+        ic: "link",
+        x: 2200,
+        y: 1140,
+        w: 250,
+        h: 100,
+        t: "Connectors (loom)",
+        s: "ingress mediator",
+      },
 
-        {
-          id: "artifacts",
-          band: "evidence",
-          ic: "archive",
-          x: 800,
-          y: 1600,
-          w: 300,
-          h: 100,
-          t: "Run artifacts",
-          s: "transcript · run-state · labels · tool outputs",
-        },
-        {
-          id: "audit",
-          band: "evidence",
-          ic: "checklist",
-          x: 1180,
-          y: 1600,
-          w: 250,
-          h: 100,
-          t: "CFC audit checker",
-          s: "9 checks, spec-anchored",
-        },
-      ];
-      const extraLines = {
-        runner: [
-          "sink ceiling · writer fit · write floor",
-          "policy evaluation · render ceiling",
+      {
+        id: "artifacts",
+        band: "evidence",
+        ic: "archive",
+        x: 800,
+        y: 1600,
+        w: 300,
+        h: 100,
+        t: "Run artifacts",
+        s: "transcript · run-state · labels · tool outputs",
+      },
+      {
+        id: "audit",
+        band: "evidence",
+        ic: "checklist",
+        x: 1180,
+        y: 1600,
+        w: 250,
+        h: 100,
+        t: "CFC audit checker",
+        s: "9 checks, spec-anchored",
+      },
+    ];
+    const extraLines = {
+      runner: [
+        "sink ceiling · writer fit · write floor",
+        "policy evaluation · render ceiling",
+      ],
+      parent: ["mode × effect class × prompt slot"],
+      artifacts: ["policy snapshot · cell-label snapshot"],
+      spaces: ["links keep labels; copies lose them"],
+      sqlite: ["re-derived on every read"],
+      connectors: ["sqlite_sources → injected handle cell"],
+      audit: ["verifies; never enforces"],
+    };
+    const icons = {
+      person: '<circle cx="12" cy="8" r="4"/><path d="M4 21c0-4 4-6 8-6s8 2 8 6"/>',
+      globe:
+        '<circle cx="12" cy="12" r="9"/><path d="M3 12h18M12 3c3 3 3 15 0 18M12 3c-3 3-3 15 0 18"/>',
+      database:
+        '<ellipse cx="12" cy="5" rx="8" ry="3"/><path d="M4 5v14c0 1.7 3.6 3 8 3s8-1.3 8-3V5M4 12c0 1.7 3.6 3 8 3s8-1.3 8-3"/>',
+      box: '<path d="M12 2l9 5v10l-9 5-9-5V7zM12 12l9-5M12 12L3 7M12 12v10"/>',
+      cpu:
+        '<rect x="5" y="5" width="14" height="14" rx="2"/><rect x="9" y="9" width="6" height="6"/><path d="M9 2v3M15 2v3M9 19v3M15 19v3M2 9h3M2 15h3M19 9h3M19 15h3"/>',
+      shield:
+        '<path d="M12 2l8 3v6c0 5-3.5 9-8 11-4.5-2-8-6-8-11V5z"/><path d="M9 12l2 2 4-4"/>',
+      folder: '<path d="M3 6h6l2 2h10v11H3z"/>',
+      file: '<path d="M6 2h8l5 5v15H6zM14 2v5h5M9 13h6M9 17h6"/>',
+      server:
+        '<rect x="3" y="4" width="18" height="6" rx="1"/><rect x="3" y="14" width="18" height="6" rx="1"/><path d="M7 7h.01M7 17h.01"/>',
+      key: '<circle cx="8" cy="14" r="4"/><path d="M11 11l9-9M16 6l3 3"/>',
+      window:
+        '<rect x="3" y="4" width="18" height="16" rx="2"/><path d="M3 9h18M7 6.5h.01"/>',
+      sparkle:
+        '<path d="M12 3l2 5 5 2-5 2-2 5-2-5-5-2 5-2z"/><path d="M19 15l1 2 2 1-2 1-1 2-1-2-2-1 2-1z"/>',
+      link:
+        '<path d="M10 14a4 4 0 005.7 0l3-3a4 4 0 00-5.7-5.7l-1 1M14 10a4 4 0 00-5.7 0l-3 3a4 4 0 005.7 5.7l1-1"/>',
+      table:
+        '<rect x="3" y="4" width="18" height="16"/><path d="M3 10h18M3 15h18M9 4v16"/>',
+      search: '<circle cx="11" cy="11" r="7"/><path d="M20 20l-4-4"/>',
+      sliders:
+        '<path d="M4 7h9M17 7h3M4 12h3M11 12h9M4 17h11M19 17h1"/><circle cx="15" cy="7" r="2"/><circle cx="9" cy="12" r="2"/><circle cx="17" cy="17" r="2"/>',
+      leaf: '<path d="M5 19c0-8 5-13 14-14-1 9-6 14-14 14zM5 19l8-8"/>',
+      archive: '<path d="M3 4h18v4H3zM5 8v12h14V8M10 12h4"/>',
+      checklist:
+        '<path d="M10 6h10M10 12h10M10 18h10M4 6l1.5 1.5L8 5M4 12l1.5 1.5L8 11M4 18l1.5 1.5L8 17"/>',
+    };
+    // edges: pts are explicit polylines; k = line kind; gate = gate id at fraction gt; gabove = caption above the diamond; lp = label anchor [x, y, anchor]
+    const edges = [
+      {
+        id: "e_person_weaver",
+        from: "person",
+        to: "weaver",
+        k: "control",
+        pts: [[210, 606], [290, 606]],
+        label: "“make me a budget dashboard”",
+        lp: [250, 548],
+      },
+      {
+        id: "e_weaver_console",
+        from: "weaver",
+        to: "console",
+        k: "control",
+        pts: [[500, 606], [550, 606]],
+        label: "POST /api/task {text, inputCells}",
+        lp: [525, 548],
+      },
+      {
+        id: "e_console_parent",
+        from: "console",
+        to: "parent",
+        k: "control",
+        pts: [[760, 606], [800, 606]],
+        label: "one session config",
+        lp: [780, 548],
+      },
+      {
+        id: "e_adapters_parent",
+        from: "adapters",
+        to: "parent",
+        k: "control",
+        pts: [[655, 780], [655, 700], [830, 700], [830, 670]],
+      },
+      {
+        id: "e_handles_parent",
+        from: "handles",
+        to: "parent",
+        k: "handle",
+        pts: [[915, 760], [915, 670]],
+        label: "tokens in · tokens out",
+        lp: [930, 720, "start"],
+      },
+      {
+        id: "e_parent_gateway",
+        from: "parent",
+        to: "gateway",
+        k: "value",
+        bi: true,
+        pts: [[915, 560], [915, 410], [1000, 410]],
+        label: "context bytes ↑  proposals ↓",
+        lp: [905, 500, "end"],
+        gate: "g_context",
+        gt: 0.45,
+        gabove: true,
+      },
+      {
+        id: "e_gateway_provider",
+        from: "gateway",
+        to: "provider",
+        k: "value",
+        bi: true,
+        pts: [[1115, 380], [1115, 222]],
+        label: "tokens",
+        lp: [1128, 300, "start"],
+      },
+      {
+        id: "e_parent_child",
+        from: "parent",
+        to: "child_pa",
+        k: "handle",
+        pts: [[1030, 580], [1220, 580]],
+        label: "delegate_task",
+        lp: [1185, 545],
+        gate: "g_deleg",
+        gt: 0.3,
+        gabove: true,
+      },
+      {
+        id: "e_child_parent",
+        from: "child_pa",
+        to: "parent",
+        k: "handle",
+        pts: [[1220, 616], [1030, 616]],
+        label: "return",
+        lp: [1075, 660],
+        gate: "g_return",
+        gt: 0.3,
+      },
+      {
+        id: "e_parent_docker",
+        from: "parent",
+        to: "docker",
+        k: "control",
+        pts: [[980, 560], [980, 470], [1560, 470], [1560, 586], [1600, 586]],
+        label: "tool call",
+        lp: [1300, 460],
+        gate: "g_tool",
+        gt: 0.62,
+        gabove: true,
+      },
+      {
+        id: "e_docker_parent",
+        from: "docker",
+        to: "handles",
+        k: "ingress",
+        pts: [[1830, 632], [1830, 940], [1110, 940], [1110, 792], [
+          1030,
+          792,
+        ]],
+        label: "observation + sidecar policy",
+        lp: [1470, 958],
+        gate: "g_obs",
+        gt: 0.9,
+      },
+      {
+        id: "e_docker_mount",
+        from: "docker",
+        to: "mount",
+        k: "control",
+        pts: [[1680, 632], [1680, 700]],
+      },
+      {
+        id: "e_skills_docker",
+        from: "localskills",
+        to: "docker",
+        k: "control",
+        pts: [[1880, 580], [1850, 580]],
+      },
+      {
+        id: "e_docs_mount",
+        from: "docs",
+        to: "mount",
+        k: "control",
+        pts: [[1880, 740], [1800, 740]],
+      },
+      {
+        id: "e_web_www",
+        from: "child_web",
+        to: "www",
+        k: "ingress",
+        bi: true,
+        pts: [[1440, 820], [1540, 820], [1540, 330], [1660, 330], [
+          1660,
+          222,
+        ]],
+        label: "request out · response in",
+        lp: [1552, 808, "start"],
+        gate: "g_egress",
+        gt: 0.62,
+      },
+      {
+        id: "e_skillssh",
+        from: "child_pa",
+        to: "skillssh",
+        k: "ingress",
+        bi: true,
+        pts: [[1420, 540], [1420, 430], [1930, 430], [1930, 222]],
+        label: "acquire_skill",
+        lp: [1700, 422],
+        gate: "g_ingest",
+        gt: 0.82,
+      },
+      {
+        id: "e_run_pattern",
+        from: "child_pa",
+        to: "runner",
+        k: "handle",
+        bi: true,
+        pts: [[1460, 620], [1460, 960], [980, 960], [980, 1120]],
+        label:
+          "run_pattern(handles) ↓ · resultRef ↑ · values only if the ceiling admits",
+        lp: [1150, 950],
+        gate: "g_release",
+        gt: 0.5,
+      },
+      {
+        id: "e_runner_spaces",
+        from: "runner",
+        to: "spaces",
+        k: "labeled",
+        bi: true,
+        pts: [[1100, 1190], [1220, 1190]],
+        gate: "g_write",
+        gt: 0.5,
+        gabove: true,
+      },
+      {
+        id: "e_policy_runner",
+        from: "policy",
+        to: "runner",
+        k: "control",
+        pts: [[920, 1330], [920, 1260]],
+        label: "posture + snapshot",
+        lp: [935, 1300, "start"],
+      },
+      {
+        id: "e_toolshed_runner",
+        from: "toolshed",
+        to: "runner",
+        k: "labeled",
+        bi: true,
+        pts: [[730, 1186], [800, 1186]],
+        label: "memory API",
+        lp: [765, 1172],
+      },
+      {
+        id: "e_apps_toolshed",
+        from: "apps",
+        to: "toolshed",
+        k: "control",
+        pts: [[500, 1186], [550, 1186]],
+      },
+      {
+        id: "e_person_apps",
+        from: "person",
+        to: "apps",
+        k: "control",
+        pts: [[135, 652], [135, 1186], [290, 1186]],
+        label: "identity · UCAN",
+        lp: [150, 900, "start"],
+      },
+      {
+        id: "e_render",
+        from: "toolshed",
+        to: "weaver",
+        k: "labeled",
+        pts: [[640, 1140], [640, 1040], [395, 1040], [395, 652]],
+        label: "rendered piece",
+        lp: [520, 1031],
+        gate: "g_render",
+        gt: 0.8,
+      },
+      {
+        id: "e_thirdparty_conn",
+        from: "thirdparty",
+        to: "connectors",
+        k: "ingress",
+        pts: [[2420, 222], [2420, 1090], [2325, 1090], [2325, 1140]],
+        label: "rows",
+        lp: [2432, 600, "start"],
+        gate: "g_conn",
+        gt: 0.78,
+      },
+      {
+        id: "e_conn_sqlite",
+        from: "connectors",
+        to: "sqlite",
+        k: "labeled",
+        pts: [[2200, 1190], [2110, 1190]],
+        label: "handle cell",
+        lp: [2155, 1178],
+      },
+      {
+        id: "e_sqlite_spaces",
+        from: "sqlite",
+        to: "spaces",
+        k: "labeled",
+        pts: [[1860, 1190], [1450, 1190]],
+        label: "read-only handle + freshness cell",
+        lp: [1655, 1178],
+      },
+      {
+        id: "e_handles_spaces",
+        from: "handles",
+        to: "spaces",
+        k: "handle",
+        pts: [[1020, 824], [1020, 1085], [1335, 1085], [1335, 1140]],
+        label: "a token names a cell address",
+        lp: [1175, 1078],
+      },
+      {
+        id: "e_index",
+        from: "child_pa",
+        to: "index",
+        k: "control",
+        pts: [[1485, 620], [1485, 1330]],
+        label: "search · publish · feedback",
+        lp: [1498, 1050, "start"],
+        gate: "g_index",
+        gt: 0.88,
+      },
+      {
+        id: "e_gardening",
+        from: "gardening",
+        to: "index",
+        k: "control",
+        pts: [[1660, 1370], [1610, 1370]],
+      },
+      {
+        id: "e_runner_artifacts",
+        from: "runner",
+        to: "artifacts",
+        k: "evidence",
+        pts: [[1085, 1260], [1085, 1600]],
+        label: "labels · decisions · refusals",
+        lp: [1100, 1560, "start"],
+      },
+      {
+        id: "e_parent_artifacts",
+        from: "parent",
+        to: "artifacts",
+        k: "evidence",
+        pts: [[800, 640], [775, 640], [775, 1650], [800, 1650]],
+        label: "transcript · run-state · policy snapshot",
+        lp: [765, 1330, "end"],
+      },
+      {
+        id: "e_artifacts_audit",
+        from: "artifacts",
+        to: "audit",
+        k: "evidence",
+        pts: [[1100, 1650], [1180, 1650]],
+      },
+      {
+        id: "e_audit_operator",
+        from: "audit",
+        to: "operator",
+        k: "evidence",
+        pts: [[1305, 1700], [1305, 1740], [235, 1740], [235, 1646], [
+          210,
+          1646,
+        ]],
+        label: "findings",
+        lp: [760, 1732],
+        gate: "g_operator",
+        gt: 0.85,
+      },
+      {
+        id: "e_operator_policy",
+        from: "operator",
+        to: "policy",
+        k: "control",
+        pts: [[135, 1600], [135, 1376], [800, 1376]],
+        label: "operator-authored records",
+        lp: [400, 1368],
+      },
+    ];
+    const gateDefs = {
+      g_context: {
+        t: "Model context",
+        status: "gap",
+        short: "no gate here",
+        boundary: "agent → outside",
+      },
+      g_deleg: {
+        t: "Delegation brief",
+        status: "gap",
+        short: "brief is prose",
+        boundary: "parent → child",
+      },
+      g_return: {
+        t: "Child return",
+        status: "shipped",
+        short: "validated",
+        boundary: "child → parent",
+      },
+      g_tool: {
+        t: "Tool mediation",
+        status: "partial",
+        short: "label-blind",
+        boundary: "model proposal → sandbox",
+      },
+      g_obs: {
+        t: "Observation",
+        status: "partial",
+        short: "sidecar taint",
+        boundary: "sandbox → model context",
+      },
+      g_egress: {
+        t: "Web egress",
+        status: "partial",
+        short: "provisional",
+        boundary: "agent → outside",
+      },
+      g_ingest: {
+        t: "External ingest",
+        status: "partial",
+        short: "stamped, unread",
+        boundary: "outside → agent",
+      },
+      g_release: {
+        t: "Value release",
+        status: "partial",
+        short: "ceiling, no policy",
+        boundary: "TCB → model context",
+      },
+      g_write: {
+        t: "Write gate",
+        status: "shipped",
+        short: "enforce-explicit",
+        boundary: "runner → space",
+      },
+      g_render: {
+        t: "Render ceiling",
+        status: "partial",
+        short: "off by default",
+        boundary: "TCB → person",
+      },
+      g_conn: {
+        t: "Connector ingress",
+        status: "gap",
+        short: "unlabeled",
+        boundary: "outside → TCB",
+      },
+      g_index: {
+        t: "Publication",
+        status: "shipped",
+        short: "program, not data",
+        boundary: "child → index",
+      },
+      g_operator: {
+        t: "Operator access",
+        status: "intended",
+        short: "unaudited",
+        boundary: "evidence → person",
+      },
+    };
+    const statusNames = {
+      shipped: "shipped",
+      partial: "partial",
+      gap: "gap",
+      intended: "intended",
+    };
+    // c: "guarded" = held by CFC today · "upcoming" = closed by named planned work · "residual" = never closed by CFC; held by people and process
+    const threats = [
+      {
+        id: "t1",
+        n: 1,
+        c: "guarded",
+        x: 1968,
+        y: 300,
+        t: "Prompt injection through fetched text",
+      },
+      {
+        id: "t2",
+        n: 2,
+        c: "upcoming",
+        x: 1502,
+        y: 350,
+        t: "Exfiltration through web egress",
+      },
+      {
+        id: "t3",
+        n: 3,
+        c: "guarded",
+        x: 1262,
+        y: 405,
+        t: "The provider sees the whole context",
+      },
+      {
+        id: "t4",
+        n: 4,
+        c: "upcoming",
+        x: 1140,
+        y: 668,
+        t: "Values smuggled in a delegation brief",
+      },
+      {
+        id: "t5",
+        n: 5,
+        c: "upcoming",
+        x: 1712,
+        y: 666,
+        t: "Files carry no fabric labels",
+      },
+      {
+        id: "t6",
+        n: 6,
+        c: "residual",
+        x: 1125,
+        y: 1690,
+        t: "Transcripts leak provenance",
+      },
+      {
+        id: "t7",
+        n: 7,
+        c: "upcoming",
+        x: 2155,
+        y: 1212,
+        t: "Unlabeled ingress: nothing to hold",
+      },
+      {
+        id: "t8",
+        n: 8,
+        c: "upcoming",
+        x: 1120,
+        y: 1470,
+        t: "A refusal the decision channel cannot see",
+      },
+      {
+        id: "t9",
+        n: 9,
+        c: "guarded",
+        x: 1012,
+        y: 515,
+        t: "Model output minting authority",
+      },
+      {
+        id: "t10",
+        n: 10,
+        c: "guarded",
+        x: 1655,
+        y: 1215,
+        t: "Copy strips labels; only links keep them",
+      },
+      {
+        id: "t11",
+        n: 11,
+        c: "residual",
+        x: 262,
+        y: 1700,
+        t: "Insider with privileged access",
+      },
+      {
+        id: "t12",
+        n: 12,
+        c: "upcoming",
+        x: 1830,
+        y: 785,
+        t: "The sandbox can read the run's own artifacts",
+      },
+      {
+        id: "t13",
+        n: 13,
+        c: "upcoming",
+        x: 1132,
+        y: 1122,
+        t: "A pattern's llm calls have no ceiling",
+      },
+    ];
+    const threatClass = {
+      upcoming: {
+        name: "closed by planned work",
+        color: "var(--s-partial)",
+        blurb:
+          "A named gap with an owner and an issue. Until it lands, this vector is open.",
+      },
+      guarded: {
+        name: "guarded by CFC",
+        color: "var(--s-shipped)",
+        blurb:
+          "Held today by labels, handles and gates. The design does not rely on the attacker behaving.",
+      },
+      residual: {
+        name: "remains; held by people and process",
+        color: "var(--s-intended)",
+        blurb:
+          "CFC cannot close this. It is held by authentication, scoping and audit of the people who hold access.",
+      },
+    };
+    // ------------------------------------------------------------------ detail copy
+    const PR = (n) =>
+      `<a href="https://github.com/commontoolsinc/labs/pull/${n}" target="_blank">#${n}</a>`;
+    const D = {
+      person: {
+        kind: "Principal",
+        band: "principal",
+        body:
+          `<p>The colleague who types the pill, or Alex running the bills demo. Authority in this system starts here: an authenticated identity with UCAN grants on a space. Nothing the model says can add to it.</p><p>The person also decides what is labeled. In the Weaver-pill demo the input cell carries <code>confidentiality:[finance]</code> because a person put it there; the rest of the circuit follows from that one act.</p>`,
+        close: [
+          "The pill itself is Dan's side: contract clauses 1–4 landed, 5 open (CT-2190).",
         ],
-        parent: ["mode × effect class × prompt slot"],
-        artifacts: ["policy snapshot · cell-label snapshot"],
-        spaces: ["links keep labels; copies lose them"],
-        sqlite: ["re-derived on every read"],
-        connectors: ["sqlite_sources → injected handle cell"],
-        audit: ["verifies; never enforces"],
-      };
-      const icons = {
-        person:
-          '<circle cx="12" cy="8" r="4"/><path d="M4 21c0-4 4-6 8-6s8 2 8 6"/>',
-        globe:
-          '<circle cx="12" cy="12" r="9"/><path d="M3 12h18M12 3c3 3 3 15 0 18M12 3c-3 3-3 15 0 18"/>',
-        database:
-          '<ellipse cx="12" cy="5" rx="8" ry="3"/><path d="M4 5v14c0 1.7 3.6 3 8 3s8-1.3 8-3V5M4 12c0 1.7 3.6 3 8 3s8-1.3 8-3"/>',
-        box:
-          '<path d="M12 2l9 5v10l-9 5-9-5V7zM12 12l9-5M12 12L3 7M12 12v10"/>',
-        cpu:
-          '<rect x="5" y="5" width="14" height="14" rx="2"/><rect x="9" y="9" width="6" height="6"/><path d="M9 2v3M15 2v3M9 19v3M15 19v3M2 9h3M2 15h3M19 9h3M19 15h3"/>',
-        shield:
-          '<path d="M12 2l8 3v6c0 5-3.5 9-8 11-4.5-2-8-6-8-11V5z"/><path d="M9 12l2 2 4-4"/>',
-        folder: '<path d="M3 6h6l2 2h10v11H3z"/>',
-        file: '<path d="M6 2h8l5 5v15H6zM14 2v5h5M9 13h6M9 17h6"/>',
-        server:
-          '<rect x="3" y="4" width="18" height="6" rx="1"/><rect x="3" y="14" width="18" height="6" rx="1"/><path d="M7 7h.01M7 17h.01"/>',
-        key: '<circle cx="8" cy="14" r="4"/><path d="M11 11l9-9M16 6l3 3"/>',
-        window:
-          '<rect x="3" y="4" width="18" height="16" rx="2"/><path d="M3 9h18M7 6.5h.01"/>',
-        sparkle:
-          '<path d="M12 3l2 5 5 2-5 2-2 5-2-5-5-2 5-2z"/><path d="M19 15l1 2 2 1-2 1-1 2-1-2-2-1 2-1z"/>',
-        link:
-          '<path d="M10 14a4 4 0 005.7 0l3-3a4 4 0 00-5.7-5.7l-1 1M14 10a4 4 0 00-5.7 0l-3 3a4 4 0 005.7 5.7l1-1"/>',
-        table:
-          '<rect x="3" y="4" width="18" height="16"/><path d="M3 10h18M3 15h18M9 4v16"/>',
-        search: '<circle cx="11" cy="11" r="7"/><path d="M20 20l-4-4"/>',
-        sliders:
-          '<path d="M4 7h9M17 7h3M4 12h3M11 12h9M4 17h11M19 17h1"/><circle cx="15" cy="7" r="2"/><circle cx="9" cy="12" r="2"/><circle cx="17" cy="17" r="2"/>',
-        leaf: '<path d="M5 19c0-8 5-13 14-14-1 9-6 14-14 14zM5 19l8-8"/>',
-        archive: '<path d="M3 4h18v4H3zM5 8v12h14V8M10 12h4"/>',
-        checklist:
-          '<path d="M10 6h10M10 12h10M10 18h10M4 6l1.5 1.5L8 5M4 12l1.5 1.5L8 11M4 18l1.5 1.5L8 17"/>',
-      };
-      // edges: pts are explicit polylines; k = line kind; gate = gate id at fraction gt; gabove = caption above the diamond; lp = label anchor [x, y, anchor]
-      const edges = [
-        {
-          id: "e_person_weaver",
-          from: "person",
-          to: "weaver",
-          k: "control",
-          pts: [[210, 606], [290, 606]],
-          label: "“make me a budget dashboard”",
-          lp: [250, 548],
-        },
-        {
-          id: "e_weaver_console",
-          from: "weaver",
-          to: "console",
-          k: "control",
-          pts: [[500, 606], [550, 606]],
-          label: "POST /api/task {text, inputCells}",
-          lp: [525, 548],
-        },
-        {
-          id: "e_console_parent",
-          from: "console",
-          to: "parent",
-          k: "control",
-          pts: [[760, 606], [800, 606]],
-          label: "one session config",
-          lp: [780, 548],
-        },
-        {
-          id: "e_adapters_parent",
-          from: "adapters",
-          to: "parent",
-          k: "control",
-          pts: [[655, 780], [655, 700], [830, 700], [830, 670]],
-        },
-        {
-          id: "e_handles_parent",
-          from: "handles",
-          to: "parent",
-          k: "handle",
-          pts: [[915, 760], [915, 670]],
-          label: "tokens in · tokens out",
-          lp: [930, 720, "start"],
-        },
-        {
-          id: "e_parent_gateway",
-          from: "parent",
-          to: "gateway",
-          k: "value",
-          bi: true,
-          pts: [[915, 560], [915, 410], [1000, 410]],
-          label: "context bytes ↑  proposals ↓",
-          lp: [905, 500, "end"],
-          gate: "g_context",
-          gt: 0.45,
-          gabove: true,
-        },
-        {
-          id: "e_gateway_provider",
-          from: "gateway",
-          to: "provider",
-          k: "value",
-          bi: true,
-          pts: [[1115, 380], [1115, 222]],
-          label: "tokens",
-          lp: [1128, 300, "start"],
-        },
-        {
-          id: "e_parent_child",
-          from: "parent",
-          to: "child_pa",
-          k: "handle",
-          pts: [[1030, 580], [1220, 580]],
-          label: "delegate_task",
-          lp: [1185, 545],
-          gate: "g_deleg",
-          gt: 0.3,
-          gabove: true,
-        },
-        {
-          id: "e_child_parent",
-          from: "child_pa",
-          to: "parent",
-          k: "handle",
-          pts: [[1220, 616], [1030, 616]],
-          label: "return",
-          lp: [1075, 660],
-          gate: "g_return",
-          gt: 0.3,
-        },
-        {
-          id: "e_parent_docker",
-          from: "parent",
-          to: "docker",
-          k: "control",
-          pts: [[980, 560], [980, 470], [1560, 470], [1560, 586], [1600, 586]],
-          label: "tool call",
-          lp: [1300, 460],
-          gate: "g_tool",
-          gt: 0.62,
-          gabove: true,
-        },
-        {
-          id: "e_docker_parent",
-          from: "docker",
-          to: "handles",
-          k: "ingress",
-          pts: [[1830, 632], [1830, 940], [1110, 940], [1110, 792], [
-            1030,
-            792,
-          ]],
-          label: "observation + sidecar policy",
-          lp: [1470, 958],
-          gate: "g_obs",
-          gt: 0.9,
-        },
-        {
-          id: "e_docker_mount",
-          from: "docker",
-          to: "mount",
-          k: "control",
-          pts: [[1680, 632], [1680, 700]],
-        },
-        {
-          id: "e_skills_docker",
-          from: "localskills",
-          to: "docker",
-          k: "control",
-          pts: [[1880, 580], [1850, 580]],
-        },
-        {
-          id: "e_docs_mount",
-          from: "docs",
-          to: "mount",
-          k: "control",
-          pts: [[1880, 740], [1800, 740]],
-        },
-        {
-          id: "e_web_www",
-          from: "child_web",
-          to: "www",
-          k: "ingress",
-          bi: true,
-          pts: [[1440, 820], [1540, 820], [1540, 330], [1660, 330], [
-            1660,
-            222,
-          ]],
-          label: "request out · response in",
-          lp: [1552, 808, "start"],
-          gate: "g_egress",
-          gt: 0.62,
-        },
-        {
-          id: "e_skillssh",
-          from: "child_pa",
-          to: "skillssh",
-          k: "ingress",
-          bi: true,
-          pts: [[1420, 540], [1420, 430], [1930, 430], [1930, 222]],
-          label: "acquire_skill",
-          lp: [1700, 422],
-          gate: "g_ingest",
-          gt: 0.82,
-        },
-        {
-          id: "e_run_pattern",
-          from: "child_pa",
-          to: "runner",
-          k: "handle",
-          bi: true,
-          pts: [[1460, 620], [1460, 960], [980, 960], [980, 1120]],
-          label:
-            "run_pattern(handles) ↓ · resultRef ↑ · values only if the ceiling admits",
-          lp: [1150, 950],
-          gate: "g_release",
-          gt: 0.5,
-        },
-        {
-          id: "e_runner_spaces",
-          from: "runner",
-          to: "spaces",
-          k: "labeled",
-          bi: true,
-          pts: [[1100, 1190], [1220, 1190]],
-          gate: "g_write",
-          gt: 0.5,
-          gabove: true,
-        },
-        {
-          id: "e_policy_runner",
-          from: "policy",
-          to: "runner",
-          k: "control",
-          pts: [[920, 1330], [920, 1260]],
-          label: "posture + snapshot",
-          lp: [935, 1300, "start"],
-        },
-        {
-          id: "e_toolshed_runner",
-          from: "toolshed",
-          to: "runner",
-          k: "labeled",
-          bi: true,
-          pts: [[730, 1186], [800, 1186]],
-          label: "memory API",
-          lp: [765, 1172],
-        },
-        {
-          id: "e_apps_toolshed",
-          from: "apps",
-          to: "toolshed",
-          k: "control",
-          pts: [[500, 1186], [550, 1186]],
-        },
-        {
-          id: "e_person_apps",
-          from: "person",
-          to: "apps",
-          k: "control",
-          pts: [[135, 652], [135, 1186], [290, 1186]],
-          label: "identity · UCAN",
-          lp: [150, 900, "start"],
-        },
-        {
-          id: "e_render",
-          from: "toolshed",
-          to: "weaver",
-          k: "labeled",
-          pts: [[640, 1140], [640, 1040], [395, 1040], [395, 652]],
-          label: "rendered piece",
-          lp: [520, 1031],
-          gate: "g_render",
-          gt: 0.8,
-        },
-        {
-          id: "e_thirdparty_conn",
-          from: "thirdparty",
-          to: "connectors",
-          k: "ingress",
-          pts: [[2420, 222], [2420, 1090], [2325, 1090], [2325, 1140]],
-          label: "rows",
-          lp: [2432, 600, "start"],
-          gate: "g_conn",
-          gt: 0.78,
-        },
-        {
-          id: "e_conn_sqlite",
-          from: "connectors",
-          to: "sqlite",
-          k: "labeled",
-          pts: [[2200, 1190], [2110, 1190]],
-          label: "handle cell",
-          lp: [2155, 1178],
-        },
-        {
-          id: "e_sqlite_spaces",
-          from: "sqlite",
-          to: "spaces",
-          k: "labeled",
-          pts: [[1860, 1190], [1450, 1190]],
-          label: "read-only handle + freshness cell",
-          lp: [1655, 1178],
-        },
-        {
-          id: "e_handles_spaces",
-          from: "handles",
-          to: "spaces",
-          k: "handle",
-          pts: [[1020, 824], [1020, 1085], [1335, 1085], [1335, 1140]],
-          label: "a token names a cell address",
-          lp: [1175, 1078],
-        },
-        {
-          id: "e_index",
-          from: "child_pa",
-          to: "index",
-          k: "control",
-          pts: [[1485, 620], [1485, 1330]],
-          label: "search · publish · feedback",
-          lp: [1498, 1050, "start"],
-          gate: "g_index",
-          gt: 0.88,
-        },
-        {
-          id: "e_gardening",
-          from: "gardening",
-          to: "index",
-          k: "control",
-          pts: [[1660, 1370], [1610, 1370]],
-        },
-        {
-          id: "e_runner_artifacts",
-          from: "runner",
-          to: "artifacts",
-          k: "evidence",
-          pts: [[1085, 1260], [1085, 1600]],
-          label: "labels · decisions · refusals",
-          lp: [1100, 1560, "start"],
-        },
-        {
-          id: "e_parent_artifacts",
-          from: "parent",
-          to: "artifacts",
-          k: "evidence",
-          pts: [[800, 640], [775, 640], [775, 1650], [800, 1650]],
-          label: "transcript · run-state · policy snapshot",
-          lp: [765, 1330, "end"],
-        },
-        {
-          id: "e_artifacts_audit",
-          from: "artifacts",
-          to: "audit",
-          k: "evidence",
-          pts: [[1100, 1650], [1180, 1650]],
-        },
-        {
-          id: "e_audit_operator",
-          from: "audit",
-          to: "operator",
-          k: "evidence",
-          pts: [[1305, 1700], [1305, 1740], [235, 1740], [235, 1646], [
-            210,
-            1646,
-          ]],
-          label: "findings",
-          lp: [760, 1732],
-          gate: "g_operator",
-          gt: 0.85,
-        },
-        {
-          id: "e_operator_policy",
-          from: "operator",
-          to: "policy",
-          k: "control",
-          pts: [[135, 1600], [135, 1376], [800, 1376]],
-          label: "operator-authored records",
-          lp: [400, 1368],
-        },
-      ];
-      const gateDefs = {
-        g_context: {
-          t: "Model context",
-          status: "gap",
-          short: "no gate here",
-          boundary: "agent → outside",
-        },
-        g_deleg: {
-          t: "Delegation brief",
-          status: "gap",
-          short: "brief is prose",
-          boundary: "parent → child",
-        },
-        g_return: {
-          t: "Child return",
-          status: "shipped",
-          short: "validated",
-          boundary: "child → parent",
-        },
-        g_tool: {
-          t: "Tool mediation",
-          status: "partial",
-          short: "label-blind",
-          boundary: "model proposal → sandbox",
-        },
-        g_obs: {
-          t: "Observation",
-          status: "partial",
-          short: "sidecar taint",
-          boundary: "sandbox → model context",
-        },
-        g_egress: {
-          t: "Web egress",
-          status: "partial",
-          short: "provisional",
-          boundary: "agent → outside",
-        },
-        g_ingest: {
-          t: "External ingest",
-          status: "partial",
-          short: "stamped, unread",
-          boundary: "outside → agent",
-        },
-        g_release: {
-          t: "Value release",
-          status: "partial",
-          short: "ceiling, no policy",
-          boundary: "TCB → model context",
-        },
-        g_write: {
-          t: "Write gate",
-          status: "shipped",
-          short: "enforce-explicit",
-          boundary: "runner → space",
-        },
-        g_render: {
-          t: "Render ceiling",
-          status: "partial",
-          short: "off by default",
-          boundary: "TCB → person",
-        },
-        g_conn: {
-          t: "Connector ingress",
-          status: "gap",
-          short: "unlabeled",
-          boundary: "outside → TCB",
-        },
-        g_index: {
-          t: "Publication",
-          status: "shipped",
-          short: "program, not data",
-          boundary: "child → index",
-        },
-        g_operator: {
-          t: "Operator access",
-          status: "intended",
-          short: "unaudited",
-          boundary: "evidence → person",
-        },
-      };
-      const statusNames = {
-        shipped: "shipped",
-        partial: "partial",
-        gap: "gap",
-        intended: "intended",
-      };
-      // c: "guarded" = held by CFC today · "upcoming" = closed by named planned work · "residual" = never closed by CFC; held by people and process
-      const threats = [
-        {
-          id: "t1",
-          n: 1,
-          c: "guarded",
-          x: 1968,
-          y: 300,
-          t: "Prompt injection through fetched text",
-        },
-        {
-          id: "t2",
-          n: 2,
-          c: "upcoming",
-          x: 1502,
-          y: 350,
-          t: "Exfiltration through web egress",
-        },
-        {
-          id: "t3",
-          n: 3,
-          c: "guarded",
-          x: 1262,
-          y: 405,
-          t: "The provider sees the whole context",
-        },
-        {
-          id: "t4",
-          n: 4,
-          c: "upcoming",
-          x: 1140,
-          y: 668,
-          t: "Values smuggled in a delegation brief",
-        },
-        {
-          id: "t5",
-          n: 5,
-          c: "upcoming",
-          x: 1712,
-          y: 666,
-          t: "Files carry no fabric labels",
-        },
-        {
-          id: "t6",
-          n: 6,
-          c: "residual",
-          x: 1125,
-          y: 1690,
-          t: "Transcripts leak provenance",
-        },
-        {
-          id: "t7",
-          n: 7,
-          c: "upcoming",
-          x: 2155,
-          y: 1212,
-          t: "Unlabeled ingress: nothing to hold",
-        },
-        {
-          id: "t8",
-          n: 8,
-          c: "upcoming",
-          x: 1120,
-          y: 1470,
-          t: "A refusal the decision channel cannot see",
-        },
-        {
-          id: "t9",
-          n: 9,
-          c: "guarded",
-          x: 1012,
-          y: 515,
-          t: "Model output minting authority",
-        },
-        {
-          id: "t10",
-          n: 10,
-          c: "guarded",
-          x: 1655,
-          y: 1215,
-          t: "Copy strips labels; only links keep them",
-        },
-        {
-          id: "t11",
-          n: 11,
-          c: "residual",
-          x: 262,
-          y: 1700,
-          t: "Insider with privileged access",
-        },
-        {
-          id: "t12",
-          n: 12,
-          c: "upcoming",
-          x: 1830,
-          y: 785,
-          t: "The sandbox can read the run's own artifacts",
-        },
-        {
-          id: "t13",
-          n: 13,
-          c: "upcoming",
-          x: 1132,
-          y: 1122,
-          t: "A pattern's llm calls have no ceiling",
-        },
-      ];
-      const threatClass = {
-        upcoming: {
-          name: "closed by planned work",
-          color: "var(--s-partial)",
-          blurb:
-            "A named gap with an owner and an issue. Until it lands, this vector is open.",
-        },
-        guarded: {
-          name: "guarded by CFC",
-          color: "var(--s-shipped)",
-          blurb:
-            "Held today by labels, handles and gates. The design does not rely on the attacker behaving.",
-        },
-        residual: {
-          name: "remains; held by people and process",
-          color: "var(--s-intended)",
-          blurb:
-            "CFC cannot close this. It is held by authentication, scoping and audit of the people who hold access.",
-        },
-      };
-      // ------------------------------------------------------------------ detail copy
-      const PR = (n) =>
-        `<a href="https://github.com/commontoolsinc/labs/pull/${n}" target="_blank">#${n}</a>`;
-      const D = {
-        person: {
-          kind: "Principal",
-          band: "principal",
-          body:
-            `<p>The colleague who types the pill, or Alex running the bills demo. Authority in this system starts here: an authenticated identity with UCAN grants on a space. Nothing the model says can add to it.</p><p>The person also decides what is labeled. In the Weaver-pill demo the input cell carries <code>confidentiality:[finance]</code> because a person put it there; the rest of the circuit follows from that one act.</p>`,
-          close: [
-            "The pill itself is Dan's side: contract clauses 1–4 landed, 5 open (CT-2190).",
-          ],
-        },
-        operator: {
-          kind: "Principal",
-          band: "principal",
-          body:
-            `<p>A Common Fabric employee with privileged access: to run artifacts, transcripts, the gateway, the index, the policy records. Operators are principals too, so their access should be authenticated, scoped and audited rather than ambient.</p><p>The operator is also the only author of declassification policy. Patterns may classify data and reference a policy by hash; they can never write their own exchange rules.</p>`,
-          threats: ["t11", "t6"],
-          close: [
-            "Nothing is written down about gating or logging operator access to run artifacts. Harness deviation 4 notes only that raw operator reports may expose artifact paths and canonical references. The gate on this map is an intention, not a plan.",
-          ],
-        },
-        provider: {
-          kind: "Outside",
-          band: "outside",
-          body:
-            `<p>The model host. It sees every byte the harness puts in context and returns text that is, by construction, untrusted: a completion is a <em>proposal</em> for a tool call, never a command.</p><p>Because nothing can be gated at the provider, everything must be gated before it gets into context. That is the whole reason the model works in handles.</p>`,
-          threats: ["t3", "t9"],
-          links: [[
-            "provider outages surface as the provider's own words, with bounded retry",
-            6752,
-          ]],
-        },
-        www: {
-          kind: "Outside",
-          band: "outside",
-          body:
-            `<p>Reached through the harness's web tools: the <code>web_fetch</code> and <code>web_search</code> child profiles, or a parent with an explicit <code>web_fetch</code> allowlist. Two-way risk: the request body can carry information out; the response is untrusted content coming in.</p><p>The sandbox is a second route. Its Docker network mode defaults to <code>bridge</code>, and <code>curl</code> is the only network-shaped command bash inspects (it allows localhost and <code>host.docker.internal</code> only), so a sandboxed shell in any profile can reach the network by other means.</p>`,
-          threats: ["t1", "t2"],
-          close: [
-            "<code>web_fetch</code> applies bounds and redirect checks but stamps no label and no ExternalIngest mark on what it returns.",
-            "Network authority is a curl guard plus a Docker network mode, not an explicit destination profile across sandbox and web tools (harness deviation 3). Per-child <code>--network none</code> is described as cheap plumbing, not done.",
-          ],
-        },
-        skillssh: {
-          kind: "Outside",
-          band: "outside",
-          body:
-            `<p>Where a third-party skill comes from. A skill is text the model will read as instructions, so a hostile author's skill is the cleanest prompt-injection vector we have. Demo 3 (CT-2091) runs exactly that: a fetched skill that tries to make the agent post data it holds.</p><p>The defense is not to detect the injection. It is that the agent never holds the data: it holds handles, and every sink the injection could aim at is a gate.</p>`,
-          threats: ["t1"],
-          links: [[
-            "skills acquired from skills.sh are pinned by digest and labeled",
-            6734,
-          ]],
-          close: [
-            "The ExternalIngest integrity stamp is written at acquisition but never consulted at a release site.",
-          ],
-        },
-        thirdparty: {
-          kind: "Outside",
-          band: "outside",
-          body:
-            `<p>Plaid transactions and Gmail messages for the bills dashboard. They enter through loom's connectors, never straight into a pattern. Today Plaid rows stop in a loom-owned <code>source-records.db</code> and Gmail rows in msgvault's database; neither is a cell in any space yet.</p>`,
-          threats: ["t7"],
-          close: [
-            "Declare Plaid and Gmail as <code>sqlite_sources</code> and register their handle and freshness cells into the target space. This is THE blocking gap for demo 2 and it is loom-side (CT-2189 gap 1).",
-          ],
-        },
-        weaver: {
-          kind: "Caller",
-          band: "agent",
-          body:
-            `<p>The command pill: <code>/cf-harness make me a budget dashboard from my transaction data</code>. The contract Weaver implements: post the text and the input cells to the console, follow progress over SSE, poll for the result, open the returned piece by slug as a panel. Harness-side clauses 1–4 have landed; the Weaver wiring and clause 5 are Dan's and not yet demonstrated. The acceptance run used a weaver-shaped caller (curl) and opened the piece with <code>cf get</code> and <code>cf piece render</code>.</p><p>Weaver is also where the person finally <em>sees</em> values. That display is a release: the runner's render ceiling can decide what the panel shows, once it is on.</p>`,
-          links: [[
-            "failed turns are terminal (410), running turns say poll again (409), one writer for run state",
-            6753,
-          ]],
-        },
-        console: {
-          kind: "Harness service",
-          band: "agent",
-          body:
-            `<p>The service the weaver pings. Bad input refs are a 400 before any turn spends. CLI and console assemble the <em>same</em> session from one config, so the class of “console lags the CLI” bugs is gone. The console's fabric session defaults to the <code>max-enforcement</code> posture: policy evaluation on, public-only ceilings on the fetch sinks, enforcement mode pinned at <code>enforce-explicit</code> (not strict, so writer-fit misfits flag rather than reject).</p>`,
-          links: [["one config for CLI and console", 6743], [
-            "turn lifecycle",
-            6753,
-          ], [
-            "labels land in every run's artifacts in the same write as its outcome",
-            6757,
-          ]],
-        },
-        adapters: {
-          kind: "Harness adapters",
-          band: "agent",
-          body:
-            `<p>Loom is the harness's first product adapter and Pattern Factory its first multi-phase orchestration adapter. Both still select the <code>observe</code> CFC mode for workflows whose sandbox output does not yet carry mediation metadata end to end (deviation 2).</p>`,
-        },
-        gateway: {
-          kind: "Our service",
-          band: "agent",
-          threats: ["t3", "t11", "t13"],
-          body:
-            `<p>Our proxy in front of the provider. It is ours, so it is trusted for transport and, on OpenAI-compatible traffic, for attribution headers (the Codex transport carries none). It is not a gate: it forwards whatever context the harness built.</p><p>The runner defines an <code>llm</code> sink class with no ceiling, and the harness's own model call is not a runner sink. So there is no label check on this edge; the protection is that labeled values were already withheld upstream and replaced with tokens. That protection does not cover a pattern's own llm calls, which reach the provider from inside the trusted base with no ceiling at all.</p>`,
-          close: [
-            "Nothing measures the assembled context itself. CT-2175 question 2 asks whether a runner <code>model-context</code> sink class should exist so this becomes a real gate.",
-          ],
-        },
-        parent: {
-          kind: "Harness",
-          band: "agent",
-          body:
-            `<p>The prompt loop. It builds the context, offers only the configured tools, and mediates every tool call: mode × effect class × prompt-slot authority. It swaps cell addresses to <code>cfh:a:</code> tokens in everything model-bound and resolves tokens in model-authored arguments before policy evaluation and dispatch.</p><p>It does not evaluate policy; it transports evidence, applies the selected exposure posture, and records what it decided. It does decide three boundaries with fixed local rules: tool mediation, observation rendering, and the <code>run_pattern</code> answer ceiling (a harness constant fitted with a runner helper). CT-2175 recommends moving that last one into the runner.</p>`,
-          threats: ["t9", "t4"],
-          close: [
-            "Tool-level decisions have no label input at all; labels only reach a decision at the sinks the runner owns.",
-          ],
-        },
-        handles: {
-          kind: "Handle table",
-          band: "agent",
-          body:
-            `<p>The mechanism that lets the agent route data it never sees. A token names a cell address without carrying the value. The model composes work out of tokens: pass one to <code>run_pattern</code>, hand one to a child, name a piece with <code>assign_slug</code>, ask <code>describe_handle</code> what shape it has.</p><p>Ruled today: possession of a handle is not a release. A handle is never withheld; only values are gated.</p>`,
-          links: [["a handle is never withheld, values are gated", 6759]],
-          close: [
-            "Value handles (as opposed to address handles), lifetimes, release and garbage collection are not yet contracts (deviation 4).",
-          ],
-        },
-        child_pa: {
-          kind: "Child harness",
-          band: "agent",
-          body:
-            `<p>Spawned by <code>delegate_task</code> with a fresh context, seeded with exactly the parent tokens its brief names. It writes a pattern, runs it in the trusted fabric session, and returns a handle to the piece. Its return is schema-validated and sanitized: sealed strings become tokens, stray token-shaped text is scrubbed.</p><p>In today's demo run, five of these each called <code>run_pattern</code> over the finance cell, built a real dashboard, and had its values refused twelve times: the first label-driven refusals ever.</p>`,
-          threats: ["t4"],
-        },
-        child_browser: {
-          kind: "Child harness",
-          band: "agent",
-          body:
-            `<p>A host-adjacent profile whose typed <code>browser</code> tool the harness binds to a leased CDP endpoint. Verb allowlist; a <code>valueHandle</code> or <code>urlHandle</code> lets an action spend a value the model never held. That spend is a release path: it is guarded by a per-run origin allowlist, not per handle and with no label input, and a page that receives the value can hand it to whatever reads the page next.</p>`,
-          threats: ["t2"],
-          close: [
-            "“Labels' job … not yet wired”: the browser tool has no label input, and its origin allowlist is per run rather than per handle.",
-          ],
-        },
-        child_web: {
-          kind: "Child harness",
-          band: "agent",
-          body:
-            `<p>The profiles that carry the web tools. A parent can also allowlist <code>web_fetch</code> explicitly. What comes back is untrusted content. These are not the only way to the network: the sandbox's bridge networking is (see WWW).</p>`,
-          threats: ["t1", "t2"],
-        },
-        docker: {
-          kind: "Sandbox",
-          band: "agent",
-          body:
-            `<p>Most tool execution runs in Docker under <code>runsc-cfc</code>, the gVisor runtime with CFC taint tracking. Output crosses back to the model through a sidecar that marks each observation <code>observed</code>, <code>opaque</code> or <code>denied</code>; the harness renders that verdict and never overrides it. Network mode defaults to bridge.</p>`,
-          threats: ["t5", "t12"],
-          close: [
-            "The sandbox's taint (xattr) is a different label store from the runner's. Bridging the two is the retirement condition for the product <code>observe</code> bridges.",
-          ],
-        },
-        mount: {
-          kind: "Sandbox",
-          band: "agent",
-          body:
-            `<p>Workspace, fabric and explicit host mounts with path containment. Ordinary files do not carry fabric labels because a labeled value was written into them; the write floor and the direct-command authority ladder are what stand between the model and a writable path. The run's own artifact directory is inside the workspace and not reserved (CT-2117).</p>`,
-          threats: ["t5", "t12"],
-        },
-        localskills: {
-          kind: "Trusted text",
-          band: "agent",
-          body:
-            `<p>Skills preloaded from the local registry, digest-pinned, with indexed resource reads and an exact allowlist of Deno or Bash scripts. Skill text is context, not operator instruction. The ruling that operator-provided text is trusted for confidentiality and labeled for integrity (CT-2173) covers operator docs; skills follow by extension, and none of it is implemented yet: workspace reads still release into context with an empty label (CT-2165).</p>`,
-        },
-        docs: {
-          kind: "Trusted text",
-          band: "agent",
-          body:
-            `<p>Repository documentation the pattern-author child reads to write patterns. Ruled (CT-2173): trusted for confidentiality, labeled for integrity; context, never command authority. Not yet built: a workspace doc read releases into context with an empty label (CT-2165). <code>PromptSlotBound</code> authority is a separate thing from a CFC label and is drawn as one.</p>`,
-        },
-        apps: {
-          kind: "Fabric app",
-          band: "tcb",
-          body:
-            `<p>Estuary, Rapids and the shell: user-facing apps that read and write spaces through cf-service with the person's identity. Where they are reachable from is a network fact, not a trust fact. What makes their reads safe is the runner's gates, not the network.</p>`,
-        },
-        toolshed: {
-          kind: "TCB",
-          band: "tcb",
-          body:
-            `<p>The Common Fabric service: memory API, identity, UCAN authorization, the shell. CFC does not replace space authorization; it runs on top of it.</p><p>Note: toolshed's own runtime reports <code>policyEvaluation: off</code>. The policy snapshot that governs harness writes lives on the harness's client runtime, so no toolshed change is needed for the demo.</p>`,
-        },
-        runner: {
-          kind: "TCB · CFC kernel",
-          band: "tcb",
-          threats: ["t13", "t8"],
-          body:
-            `<p>The one place policy meaning lives. On every transaction it derives labels onto computed values (the store put <code>finance</code> on every field of today's dashboard with a verified <code>TransformedBy</code> atom) and runs the gates:</p><ul><li><b>Sink ceiling</b>: a release's consumed labels must fit the sink's ceiling.</li><li><b>Writer fit</b> and <b>write floor</b>: what a writer may put where, and the integrity a written value must carry. Writer-fit misfits reject only under <code>enforce-strict</code>; under the console's <code>enforce-explicit</code> they persist and flag.</li><li><b>Policy evaluation</b>: exchange rules that can discharge a clause before the fit; only ever loosens, fails closed on fuel or lookup.</li><li><b>Render ceiling</b>: the same fit for the display sink.</li></ul><p>Its posture is a set of orthogonal dials, not an on/off switch.</p>`,
-          links: [["the label reader was broken, the store was fine", 6751]],
-        },
-        spaces: {
-          kind: "TCB · store",
-          band: "tcb",
-          body:
-            `<p>Cells stored per space (a DID), with labels stored per path alongside values. Between spaces only a link preserves labels and integrity; copying materialized bytes makes a fresh value with no attestation.</p>`,
-          threats: ["t10"],
-        },
-        policy: {
-          kind: "TCB · configuration",
-          band: "tcb",
-          body:
-            `<p>Two things, both operator-owned. The <b>dials</b> are runtime options: the enforcement matrix names five (enforcement mode, flow-label persistence, write floor, trigger-read gating, policy evaluation) and the runtime has nine; the console's <code>max-enforcement</code> bundle sets seven of them, with the enforcement mode pinned at <code>enforce-explicit</code>. The <b>policy snapshot</b> is the digest-bound set of exchange-rule records and grants. Records are <code>ambient</code> (apply to every label) or <code>referenced</code> (fire only where the label names them by hash).</p>`,
-          close: [
-            "There is no door for a policy record to reach a harness runtime: config exposes a posture name only (CT-2175 question 4).",
-            "Guard shape for the demo's finance-release record is undecided (question 3).",
-          ],
-        },
-        index: {
-          kind: "TCB · program plane",
-          band: "tcb",
-          body:
-            `<p>A metadata plane, not a data plane. Search results enter model context as an observation; the selected pattern's source is fetched and compiled host-side; publication sends the program, and the render gate runs over a synthetic instance so no user data rides along.</p>`,
-        },
-        gardening: {
-          kind: "TCB · writer",
-          band: "tcb",
-          body:
-            `<p>Automated maintenance of the index. Intended shape: a bounded writer with its own provenance and audit trail, so it can never become a way to publish data.</p>`,
-        },
-        sqlite: {
-          kind: "TCB · connector data",
-          band: "tcb",
-          body:
-            `<p class="hint">Loom-side claims here come from CT-2189 and the connector map on CT-2066; loom's code is not in this repository.</p><p>Fabric-connected SQLite tables patterns can query. Row-level CFC is implemented in the runtime: rules come from the table contract and are re-derived on every read, including for rows written before the rule (the mailbox demo pattern does this today).</p>`,
-          threats: ["t7"],
-          close: [
-            "Injection seeds <code>tables: {}</code> and treats injected files as unlabeled, so connector rows carry no labels yet. Decide how a connector's schema and row-label rules reach the handle (CT-2189 gap 2, shared loom + labs).",
-            "<code>describe_handle</code> can tell the model nothing about an injected table until the handle cell declares a schema (gap 4, ours, small).",
-          ],
-        },
-        connectors: {
-          kind: "TCB · ingress mediator",
-          band: "tcb",
-          body:
-            `<p class="hint">Loom-side; described from CT-2189, not verified against loom's code.</p><p>Loom's connectors pull third-party data and stamp trusted provenance on the way in. <code>loom-daemon</code> can inject a read-only SQLite handle cell plus a freshness cell into a piece for any connector declared with <code>sqlite_sources</code>; two loom patterns already read connector databases this way.</p>`,
-          close: [
-            "Plaid and Gmail are not declared as <code>sqlite_sources</code> (CT-2189 gap 1, Alex's side).",
-            "Egress through a connector needs its own gate evaluating destination, labels and authority; not drawn because none exists yet.",
-          ],
-        },
-        artifacts: {
-          kind: "Evidence",
-          band: "evidence",
-          body:
-            `<p>Every run writes its transcript, run-state, policy snapshot, tool outputs, child references, skill provenance, and, since today, the per-cell labels its space holds for the cells it touched, in the same write as the run's outcome. The one artifact a run does not write from its own knowledge.</p>`,
-          threats: ["t6", "t8", "t12"],
-          links: [[
-            "cell labels recorded in the write that ends the run",
-            6757,
-          ]],
-          close: [
-            "The twelve refusals are structured in tool outputs but absent from the policy trace; the check that counts them is in open PR #6755.",
-            "The artifact root is readable from the sandbox (CT-2117).",
-          ],
-        },
-        audit: {
-          kind: "Evidence · verifier",
-          band: "evidence",
-          body:
-            `<p>Runs over any recorded run and grades nine checks (AUD-1 to AUD-9) pass, fail, warn or inconclusive against quoted spec clauses; inconclusive is never pass. First run over the demo: 63 checks over 7 runs, 33 pass, 13 fail (7 real, 6 a checker false positive). The demo acceptance bar is now “the checker passes”. A second batch of checks, including the one that counts release refusals, is in an open PR (#6755).</p><p>It verifies; it never enforces. Missing evidence is a finding, not proof that a gate ran.</p>`,
-          links: [["spec-anchored CFC checker", 6749], [
-            "what the audit found",
-            6754,
-          ]],
-        },
-      };
-      const GD = {
-        g_context: {
-          body:
-            `<p>The boundary between what the harness assembled and what the provider sees. By design there is no label check here: the runner's <code>llm</code> sink class has no ceiling and the harness's model call is not a runner sink. Every value that could have been labeled was withheld or tokenized before it got this far.</p>`,
-          why:
-            "Where the whole design is tested: if a labeled value made it into context, the provider has it and no later gate helps.",
-          close: [
-            "Give the model context a runner sink class of its own (CT-2175 recommendation B) so the answer boundary becomes one runner gate instead of a harness copy.",
-            "Then the harness deletes its own <code>RUN_PATTERN_ANSWER_CEILING</code> measurement.",
-          ],
-          threats: ["t3"],
-        },
-        g_deleg: {
-          body:
-            `<p>Handles cross this boundary correctly: a child's table is seeded with exactly the parent tokens the brief names, and tokens stay identical across the hierarchy. But the brief itself, <code>goal</code> and <code>context</code>, is free text, and a parent can put anything it happens to know in it.</p>`,
-          why:
-            "The place the handle model is not yet fully realized; named as live work in the harness README.",
-          close: ["Make the brief bound references rather than prose."],
-          threats: ["t4"],
-        },
-        g_return: {
-          body:
-            `<p>A child's return is a new observation, not a continuation of the parent's token stream. It is validated against the delegation's return schema, sanitized, sealed strings become parent-resolvable tokens, and any token-shaped text still standing is scrubbed to inert text. Raw child evidence stays in artifacts, off the parent's return channel.</p>`,
-          why: "Structure only: no label information crosses with the return.",
-        },
-        g_tool: {
-          body:
-            `<p>Every tool proposal the model makes is decided as mode × effect class × prompt-slot authority. A malformed call comes back as a typed, recoverable refusal naming the field, never the value. Denials, activities and failure records are all written.</p>`,
-          why:
-            "This gate has no label input at all. It decides <em>whether</em> a tool may run, never what the tool may release; that belongs to the sinks.",
-          threats: ["t9"],
-        },
-        g_obs: {
-          body:
-            `<p>Sandbox output crosses back through a sidecar that marks it <code>observed</code>, <code>opaque</code> or <code>denied</code> from runsc's xattr taint. The harness renders the verdict and never decides.</p>`,
-          why:
-            "The sandbox's taint store and the runner's label store are two different systems that do not yet speak.",
-          close: [
-            "Real sidecar evidence for every exposed observation, so Loom and Pattern Factory can leave <code>observe</code> mode (deviation 2).",
-            "The mediation depends on how the operator registered <code>runsc-cfc</code>: without <code>--cfc-invocation-context-dir</code> the harness writes invocation contexts nothing reads and input labels drop silently, while the guard only checks that the directories are named (CT-2105).",
-            "Reserve the artifact root from the sandbox (CT-2117).",
-          ],
-          threats: ["t5", "t12"],
-        },
-        g_egress: {
-          body:
-            `<p>Outbound from the harness: <code>web_fetch</code> applies bounds and redirect checks; the browser tool has a verb allowlist and a per-run origin allowlist for the values a <code>valueHandle</code> spends; the bash <code>curl</code> guard admits localhost targets only, and nothing else in the sandbox is inspected while its network mode is bridge. Inbound: the response is untrusted.</p><p>Inside a pattern, web egress is gated for real: the max-enforcement bundle puts public-only ceilings on the six fetch sinks.</p>`,
-          why:
-            "The exfiltration sink an injected skill aims at. Harness-side it is protected mostly by the agent not holding values, not by a label check on the request.",
-          close: [
-            "Represent network authority as an explicit destination profile across sandbox and web tools (deviation 3).",
-            "Label what the web tools bring back, and give the browser's value release a label input.",
-          ],
-          threats: ["t2", "t1"],
-        },
-        g_ingest: {
-          body:
-            `<p><code>acquire_skill</code> pins the skill by digest, stamps <code>ExternalIngest</code> integrity, and hands back a capability-typed handle. Fetched skill text remains context.</p>`,
-          why:
-            "The stamp is written but never read at a release site, so integrity provenance does not yet change any decision.",
-          close: [
-            "Read the integrity stamp at the write floor and at egress, so text from outside can never become direct-command authority.",
-          ],
-          threats: ["t1"],
-        },
-        g_release: {
-          body:
-            `<p>The gate that fired for the first time today. <code>run_pattern</code> reads the result under the runner and fits the consumed labels against a public-only answer ceiling. Ruled: a reference-only answer is not a release, so the handle always comes back; only the values a <code>resultSchema</code> asks for are gated, and a refusal names the input that carried the label.</p>`,
-          why:
-            "This is the guarantee the product sells: computation goes to the data and the model gets a name, not the number.",
-          links: [["ceiling gates values, not the handle", 6759]],
-          close: [
-            "The fit skips the runner's policy evaluation, so no exchange rule can discharge <code>finance</code> here yet. Policy A vs policy B (released under one, refused under the other) is the smallest honest experiment (CT-2175).",
-            "Record the refusal as a policy event so audit can count it (CT-2188 attribution fixed in the same change).",
-          ],
-          threats: ["t8"],
-        },
-        g_write: {
-          body:
-            `<p>Every transaction commits through the runner's boundary pass. The enforcement mode is <code>enforce-explicit</code> by default and in the console's bundle, so a recorded reason rejects the commit, including a labeled write with no resolvable policy input. The write floor and trigger-read gating are further reason sources on their own dials. Writer fit is not: its misfit rejects only under <code>enforce-strict</code>, and persists-and-flags under explicit, which is what runs today.</p>`,
-          why:
-            "The place labels are derived and persisted; everything downstream reads what this wrote.",
-          close: [
-            "<code>cfcFlowLabels: persist</code> on the writing runtime is what the bills dashboard needs to keep connector labels on its materialized result.",
-          ],
-        },
-        g_render: {
-          body:
-            `<p>The display sink. When the shell renders a piece, the runner can fit the value's labels against a render ceiling with <code>sinkClass: display</code>; it is the precedent for every non-network release site. It is implemented but off by default: a browser profile has to populate the ceiling (<code>commonfabric.cfcRenderCeiling()</code> in localStorage, dogfood only, expected to over-block until exchange resolution lands). In today's demo the panel showed finance values because no ceiling was populated, not because a fit admitted them.</p>`,
-          why:
-            "The person is a sink too. This is the last gate before human eyes, and today it is open.",
-          close: [
-            "Turn the ceiling on by default once exchange resolution can discharge what a person is entitled to see.",
-          ],
-        },
-        g_conn: {
-          body:
-            `<p>Where third-party rows should receive their labels: a table contract that declares the schema and row-label rules, re-derived on every read.</p>`,
-          why:
-            "If rows enter unlabeled, the dashboard is unlabeled and CFC has nothing to hold. The circuit is open at its source.",
-          close: [
-            "Declare the connectors as <code>sqlite_sources</code> (gap 1) and give injected handles a labeled table contract (gap 2).",
-          ],
-          threats: ["t7"],
-        },
-        g_index: {
-          body:
-            `<p>Publishing to the index sends the program, never the data. Search metadata enters context as an observation; pattern source is compiled host-side. Delegation can pass up to eight pattern references, resolved only from search results this parent actually saw.</p>`,
-          why:
-            "Keeps the index a program plane. Gardening should stay a bounded writer with provenance.",
-        },
-        g_operator: {
-          body:
-            `<p>Operators read artifacts and audit findings. Transcripts, handle maps and policy evidence can reveal sensitive provenance and need protection comparable to the data itself.</p>`,
-          why: "The one gate with no code behind it yet.",
-          close: ["Authenticated, scoped, logged access to raw run artifacts."],
-          threats: ["t11", "t6"],
-        },
-      };
-      const TD = {
-        t1: {
-          body:
-            `<p>A fetched skill or a web page tells the model to do something. That is the normal case, not the anomaly: the model reads untrusted text as instructions and cannot tell them apart.</p><p><b>What holds:</b> the agent holds handles, not values, and the sinks an instruction could aim at are gated. Authority comes from the caller-bound prompt slot and the tool gate checks that slot on every effectful call, so fetched text cannot become a command. Labels play no part in that today: the ExternalIngest stamp is written but never read, and <code>web_fetch</code> text is not labeled at all.</p>`,
-          where: ["skillssh", "www", "g_ingest", "g_egress"],
-        },
-        t2: {
-          plan:
-            "Network authority as an explicit destination profile across sandbox and web tools (harness deviation 3), and a label input on web_fetch and browser so the egress ceiling sees what a pattern's fetch sinks already see.",
-          body:
-            `<p>The model, injected or merely mistaken, puts something it holds into a URL, a request body, or a curl. <b>What holds:</b> the model does not hold labeled values; pattern-side fetch sinks have public-only ceilings. <b>What does not yet:</b> the harness-side web tools have no label input; network authority is provisional.</p>`,
-          where: ["child_web", "www", "g_egress"],
-        },
-        t3: {
-          body:
-            `<p>The provider sees every byte of context and keeps its own logs. There is no gate at the provider, so a labeled value that reaches context is gone. <b>What holds:</b> values are withheld or tokenized before context. <b>Open:</b> nothing measures the assembled context as a sink.</p>`,
-          where: ["provider", "gateway", "g_context"],
-        },
-        t4: {
-          plan:
-            "Bound references in the brief instead of prose; named as live work in the harness README.",
-          body:
-            `<p><code>delegate_task</code> takes <code>goal</code> and <code>context</code> as prose. Handles cross by seeding, but a parent can also write anything it knows into the brief, and the child's fresh context starts from that. Named in the harness README as the place the handle model is not yet realized.</p>`,
-          where: ["parent", "child_pa", "g_deleg"],
-        },
-        t5: {
-          plan:
-            "Real sidecar evidence for every exposed observation so the product adapters leave observe mode (deviation 2), and one label vocabulary across runsc taint and runner labels.",
-          body:
-            `<p>A value written into the workspace mount is a file. Files carry runsc taint, not fabric labels, and the two stores do not talk. <b>What holds:</b> the write floor and the direct-command authority ladder on <code>write_file</code>; the sidecar's opaque/denied verdicts on reads.</p>`,
-          where: ["docker", "mount", "g_obs"],
-        },
-        t6: {
-          body:
-            `<p>Transcripts, handle maps and policy traces are sensitive provenance in their own right. Raw operator reports may expose artifact paths and canonical references. Operator access is not yet authenticated per artifact or logged.</p>`,
-          where: ["artifacts", "operator", "g_operator"],
-        },
-        t7: {
-          plan:
-            "CT-2189 gaps 1 and 2: declare the connectors as sqlite_sources and give injected handles a labeled table contract.",
-          body:
-            `<p>Connector rows arrive with no labels because injected handles seed <code>tables: {}</code>. An unlabeled input produces an unlabeled dashboard and CFC has nothing to hold; the whole circuit is only as strong as its source label.</p>`,
-          where: ["thirdparty", "connectors", "sqlite", "g_conn"],
-        },
-        t8: {
-          plan:
-            "Record the release refusal as a policy event with a runner-minted refusal detail; merge the audit check that counts policyRefusal on tool outputs (open PR #6755); attribution fixed in #6759.",
-          body:
-            `<p>The twelve refusals are structured: each tool output carries a <code>policyRefusal</code> with gates, atoms and the input that carried the label. What cannot show them is the policy <em>decision</em> channel, because the loop records its allow decision before the tool runs; the trace's reason-code union has no label-shaped member, and the merged audit's denial check reads decisions only, so it counts zero. The channel exists, it is structured, and it is empty. A gate we cannot prove fired is, for a colleague, a gate that did not.</p>`,
-          where: ["runner", "artifacts", "audit", "g_release"],
-        },
-        t9: {
-          body:
-            `<p>Provider output must never mint command authority. Authority comes from the prompt slot the caller bound (<code>PromptSlotBound</code>), and the tool gate checks that slot on every effectful call. Model text that looks like an operator instruction is still model text.</p>`,
-          where: ["parent", "gateway", "g_tool"],
-        },
-        t10: {
-          body:
-            `<p>Between spaces, only a link preserves labels and integrity. Copying materialized bytes creates a fresh value with no attestation. Any tool that “helpfully” materializes a value across spaces opens the circuit.</p>`,
-          where: ["spaces", "toolshed"],
-        },
-        t12: {
-          plan:
-            "Reserve the artifact root from bash and from any child sharing the workspace (CT-2117, open).",
-          body:
-            `<p><code>bash</code> does not reserve <code>.cf-harness-artifacts/</code>. A <code>cat</code> of the run's own tool-output JSON reads back the whole unsanitized result, the raw cause message and bare piece ids, and a delegated child sharing the workspace reaches it too. Reproduced with a planted marker by two reviewers. This is a direct route from “withheld” to model context, and it undermines every “retained in the artifact, withheld here” claim on this map until it is closed.</p>`,
-          where: ["docker", "mount", "artifacts", "g_obs"],
-        },
-        t13: {
-          plan:
-            "A ceiling on the runner's llm sink class, so a pattern's model calls fit like its fetch calls do (CT-2091 build list, item 5).",
-          body:
-            `<p>A model-authored pattern can call <code>llm</code>, <code>generateText</code> or <code>llmDialog</code> over the finance cell. Under <code>max-enforcement</code> those sinks have no ceiling, so labeled values leave for the provider with no gate. The fetch sinks are capped; the llm sinks are not, and a failing-when-fixed test pins the gap. This is a second egress from the trusted base into the provider, beside the model-context edge.</p>`,
-          where: ["runner", "gateway", "provider", "g_context"],
-        },
-        t11: {
-          body:
-            `<p>Employees with access to the gateway, spaces, the index or artifacts. Operators are principals: authenticated, scoped, audited. The map draws no red line from an employee to a component because access is meant to be a gate, not a leak.</p>`,
-          where: ["operator", "gateway", "toolshed", "index", "g_operator"],
-        },
-      };
-      const ED = {
-        e_parent_gateway:
-          `<p>What the harness sends the provider and what the provider sends back. Outbound bytes are model-visible by definition; inbound completions are untrusted proposals. There is no label gate on this edge; see the gate.</p>`,
-        e_run_pattern:
-          `<p><code>run_pattern</code> is the central tool: the child writes a pattern and runs it in the trusted fabric session against the handles it holds. Its fabric identity stays outside Docker and its authority is one configured space. Computation goes to the data.</p><p>The result of a run comes back as <code>resultRef</code>, a handle, on success and on a release refusal alike. A commit refusal (write floor, missing policy input, writer fit under strict) or a run failure returns an error with no handle. Fields the <code>resultSchema</code> models as inert (numbers, booleans, enums) come back as themselves if the ceiling admits them; everything else as a reference token.</p>`,
-        e_handles_spaces:
-          `<p>A <code>cfh:a:</code> token is a deterministic per-run name for a cell address. Bare fabric IDs are not converted. The mapping lives in <code>run-state.json</code> and survives batch resume; an interactive (console) restore does not persist it yet.</p>`,
-        e_render:
-          `<p>The piece is opened by slug through the shell (Weaver once wired; <code>cf piece render</code> in the acceptance run). What it may display is the render ceiling's decision in the runner, not the caller's, once that ceiling is populated.</p>`,
-        e_thirdparty_conn:
-          `<p>Plaid transactions and Gmail messages pulled by loom's connectors. Ingress, not a pattern fetch.</p>`,
-        e_conn_sqlite:
-          `<p>Today: rows stop in <code>source-records.db</code> and <code>msgvault.db</code>. Intended: <code>loom-daemon</code> injects a read-only <code>SqliteDb</code> handle cell and a freshness cell into the target space.</p>`,
-        e_sqlite_spaces:
-          `<p>Once the handle cell exists it is an ordinary same-space cell, so <code>--input-cell</code> and <code>/api/task inputCells</code> carry it into a harness session with no new transport.</p>`,
-        e_parent_child:
-          `<p>Delegation seeds the child's handle table with the parent entries the brief names, and nothing else. The brief itself is prose.</p>`,
-        e_child_parent:
-          `<p>Return is validated, sanitized and re-minted through the parent's boundary. Raw child evidence is retained outside the parent's return channel.</p>`,
-        e_skillssh:
-          `<p><code>acquire_skill</code>: fetch a skill from skills.sh, pin it by digest, stamp ExternalIngest, return a capability-typed handle.</p>`,
-        e_web_www:
-          `<p>Only the web child profiles or an explicit parent allowlist reach here. Request out, untrusted content in.</p>`,
-        e_runner_artifacts:
-          `<p>Labels, decisions, commit refusals and, since today, the cell-label snapshot for touched cells, written in the same write as the run's outcome.</p>`,
-        e_audit_operator:
-          `<p>Findings for a person to act on. Operator access to raw artifacts is the intended gate that has no code yet.</p>`,
-        e_operator_policy:
-          `<p>Policy records and grants are operator-authored. Patterns can reference a policy by hash; they cannot write one.</p>`,
-      };
+      },
+      operator: {
+        kind: "Principal",
+        band: "principal",
+        body:
+          `<p>A Common Fabric employee with privileged access: to run artifacts, transcripts, the gateway, the index, the policy records. Operators are principals too, so their access should be authenticated, scoped and audited rather than ambient.</p><p>The operator is also the only author of declassification policy. Patterns may classify data and reference a policy by hash; they can never write their own exchange rules.</p>`,
+        threats: ["t11", "t6"],
+        close: [
+          "Nothing is written down about gating or logging operator access to run artifacts. Harness deviation 4 notes only that raw operator reports may expose artifact paths and canonical references. The gate on this map is an intention, not a plan.",
+        ],
+      },
+      provider: {
+        kind: "Outside",
+        band: "outside",
+        body:
+          `<p>The model host. It sees every byte the harness puts in context and returns text that is, by construction, untrusted: a completion is a <em>proposal</em> for a tool call, never a command.</p><p>Because nothing can be gated at the provider, everything must be gated before it gets into context. That is the whole reason the model works in handles.</p>`,
+        threats: ["t3", "t9"],
+        links: [[
+          "provider outages surface as the provider's own words, with bounded retry",
+          6752,
+        ]],
+      },
+      www: {
+        kind: "Outside",
+        band: "outside",
+        body:
+          `<p>Reached through the harness's web tools: the <code>web_fetch</code> and <code>web_search</code> child profiles, or a parent with an explicit <code>web_fetch</code> allowlist. Two-way risk: the request body can carry information out; the response is untrusted content coming in.</p><p>The sandbox is a second route. Its Docker network mode defaults to <code>bridge</code>, and <code>curl</code> is the only network-shaped command bash inspects (it allows localhost and <code>host.docker.internal</code> only), so a sandboxed shell in any profile can reach the network by other means.</p>`,
+        threats: ["t1", "t2"],
+        close: [
+          "<code>web_fetch</code> applies bounds and redirect checks but stamps no label and no ExternalIngest mark on what it returns.",
+          "Network authority is a curl guard plus a Docker network mode, not an explicit destination profile across sandbox and web tools (harness deviation 3). Per-child <code>--network none</code> is described as cheap plumbing, not done.",
+        ],
+      },
+      skillssh: {
+        kind: "Outside",
+        band: "outside",
+        body:
+          `<p>Where a third-party skill comes from. A skill is text the model will read as instructions, so a hostile author's skill is the cleanest prompt-injection vector we have. Demo 3 (CT-2091) runs exactly that: a fetched skill that tries to make the agent post data it holds.</p><p>The defense is not to detect the injection. It is that the agent never holds the data: it holds handles, and every sink the injection could aim at is a gate.</p>`,
+        threats: ["t1"],
+        links: [[
+          "skills acquired from skills.sh are pinned by digest and labeled",
+          6734,
+        ]],
+        close: [
+          "The ExternalIngest integrity stamp is written at acquisition but never consulted at a release site.",
+        ],
+      },
+      thirdparty: {
+        kind: "Outside",
+        band: "outside",
+        body:
+          `<p>Plaid transactions and Gmail messages for the bills dashboard. They enter through loom's connectors, never straight into a pattern. Today Plaid rows stop in a loom-owned <code>source-records.db</code> and Gmail rows in msgvault's database; neither is a cell in any space yet.</p>`,
+        threats: ["t7"],
+        close: [
+          "Declare Plaid and Gmail as <code>sqlite_sources</code> and register their handle and freshness cells into the target space. This is THE blocking gap for demo 2 and it is loom-side (CT-2189 gap 1).",
+        ],
+      },
+      weaver: {
+        kind: "Caller",
+        band: "agent",
+        body:
+          `<p>The command pill: <code>/cf-harness make me a budget dashboard from my transaction data</code>. The contract Weaver implements: post the text and the input cells to the console, follow progress over SSE, poll for the result, open the returned piece by slug as a panel. Harness-side clauses 1–4 have landed; the Weaver wiring and clause 5 are Dan's and not yet demonstrated. The acceptance run used a weaver-shaped caller (curl) and opened the piece with <code>cf get</code> and <code>cf piece render</code>.</p><p>Weaver is also where the person finally <em>sees</em> values. That display is a release: the runner's render ceiling can decide what the panel shows, once it is on.</p>`,
+        links: [[
+          "failed turns are terminal (410), running turns say poll again (409), one writer for run state",
+          6753,
+        ]],
+      },
+      console: {
+        kind: "Harness service",
+        band: "agent",
+        body:
+          `<p>The service the weaver pings. Bad input refs are a 400 before any turn spends. CLI and console assemble the <em>same</em> session from one config, so the class of “console lags the CLI” bugs is gone. The console's fabric session defaults to the <code>max-enforcement</code> posture: policy evaluation on, public-only ceilings on the fetch sinks, enforcement mode pinned at <code>enforce-explicit</code> (not strict, so writer-fit misfits flag rather than reject).</p>`,
+        links: [["one config for CLI and console", 6743], [
+          "turn lifecycle",
+          6753,
+        ], [
+          "labels land in every run's artifacts in the same write as its outcome",
+          6757,
+        ]],
+      },
+      adapters: {
+        kind: "Harness adapters",
+        band: "agent",
+        body:
+          `<p>Loom is the harness's first product adapter and Pattern Factory its first multi-phase orchestration adapter. Both still select the <code>observe</code> CFC mode for workflows whose sandbox output does not yet carry mediation metadata end to end (deviation 2).</p>`,
+      },
+      gateway: {
+        kind: "Our service",
+        band: "agent",
+        threats: ["t3", "t11", "t13"],
+        body:
+          `<p>Our proxy in front of the provider. It is ours, so it is trusted for transport and, on OpenAI-compatible traffic, for attribution headers (the Codex transport carries none). It is not a gate: it forwards whatever context the harness built.</p><p>The runner defines an <code>llm</code> sink class with no ceiling, and the harness's own model call is not a runner sink. So there is no label check on this edge; the protection is that labeled values were already withheld upstream and replaced with tokens. That protection does not cover a pattern's own llm calls, which reach the provider from inside the trusted base with no ceiling at all.</p>`,
+        close: [
+          "Nothing measures the assembled context itself. CT-2175 question 2 asks whether a runner <code>model-context</code> sink class should exist so this becomes a real gate.",
+        ],
+      },
+      parent: {
+        kind: "Harness",
+        band: "agent",
+        body:
+          `<p>The prompt loop. It builds the context, offers only the configured tools, and mediates every tool call: mode × effect class × prompt-slot authority. It swaps cell addresses to <code>cfh:a:</code> tokens in everything model-bound and resolves tokens in model-authored arguments before policy evaluation and dispatch.</p><p>It does not evaluate policy; it transports evidence, applies the selected exposure posture, and records what it decided. It does decide three boundaries with fixed local rules: tool mediation, observation rendering, and the <code>run_pattern</code> answer ceiling (a harness constant fitted with a runner helper). CT-2175 recommends moving that last one into the runner.</p>`,
+        threats: ["t9", "t4"],
+        close: [
+          "Tool-level decisions have no label input at all; labels only reach a decision at the sinks the runner owns.",
+        ],
+      },
+      handles: {
+        kind: "Handle table",
+        band: "agent",
+        body:
+          `<p>The mechanism that lets the agent route data it never sees. A token names a cell address without carrying the value. The model composes work out of tokens: pass one to <code>run_pattern</code>, hand one to a child, name a piece with <code>assign_slug</code>, ask <code>describe_handle</code> what shape it has.</p><p>Ruled today: possession of a handle is not a release. A handle is never withheld; only values are gated.</p>`,
+        links: [["a handle is never withheld, values are gated", 6759]],
+        close: [
+          "Value handles (as opposed to address handles), lifetimes, release and garbage collection are not yet contracts (deviation 4).",
+        ],
+      },
+      child_pa: {
+        kind: "Child harness",
+        band: "agent",
+        body:
+          `<p>Spawned by <code>delegate_task</code> with a fresh context, seeded with exactly the parent tokens its brief names. It writes a pattern, runs it in the trusted fabric session, and returns a handle to the piece. Its return is schema-validated and sanitized: sealed strings become tokens, stray token-shaped text is scrubbed.</p><p>In today's demo run, five of these each called <code>run_pattern</code> over the finance cell, built a real dashboard, and had its values refused twelve times: the first label-driven refusals ever.</p>`,
+        threats: ["t4"],
+      },
+      child_browser: {
+        kind: "Child harness",
+        band: "agent",
+        body:
+          `<p>A host-adjacent profile whose typed <code>browser</code> tool the harness binds to a leased CDP endpoint. Verb allowlist; a <code>valueHandle</code> or <code>urlHandle</code> lets an action spend a value the model never held. That spend is a release path: it is guarded by a per-run origin allowlist, not per handle and with no label input, and a page that receives the value can hand it to whatever reads the page next.</p>`,
+        threats: ["t2"],
+        close: [
+          "“Labels' job … not yet wired”: the browser tool has no label input, and its origin allowlist is per run rather than per handle.",
+        ],
+      },
+      child_web: {
+        kind: "Child harness",
+        band: "agent",
+        body:
+          `<p>The profiles that carry the web tools. A parent can also allowlist <code>web_fetch</code> explicitly. What comes back is untrusted content. These are not the only way to the network: the sandbox's bridge networking is (see WWW).</p>`,
+        threats: ["t1", "t2"],
+      },
+      docker: {
+        kind: "Sandbox",
+        band: "agent",
+        body:
+          `<p>Most tool execution runs in Docker under <code>runsc-cfc</code>, the gVisor runtime with CFC taint tracking. Output crosses back to the model through a sidecar that marks each observation <code>observed</code>, <code>opaque</code> or <code>denied</code>; the harness renders that verdict and never overrides it. Network mode defaults to bridge.</p>`,
+        threats: ["t5", "t12"],
+        close: [
+          "The sandbox's taint (xattr) is a different label store from the runner's. Bridging the two is the retirement condition for the product <code>observe</code> bridges.",
+        ],
+      },
+      mount: {
+        kind: "Sandbox",
+        band: "agent",
+        body:
+          `<p>Workspace, fabric and explicit host mounts with path containment. Ordinary files do not carry fabric labels because a labeled value was written into them; the write floor and the direct-command authority ladder are what stand between the model and a writable path. The run's own artifact directory is inside the workspace and not reserved (CT-2117).</p>`,
+        threats: ["t5", "t12"],
+      },
+      localskills: {
+        kind: "Trusted text",
+        band: "agent",
+        body:
+          `<p>Skills preloaded from the local registry, digest-pinned, with indexed resource reads and an exact allowlist of Deno or Bash scripts. Skill text is context, not operator instruction. The ruling that operator-provided text is trusted for confidentiality and labeled for integrity (CT-2173) covers operator docs; skills follow by extension, and none of it is implemented yet: workspace reads still release into context with an empty label (CT-2165).</p>`,
+      },
+      docs: {
+        kind: "Trusted text",
+        band: "agent",
+        body:
+          `<p>Repository documentation the pattern-author child reads to write patterns. Ruled (CT-2173): trusted for confidentiality, labeled for integrity; context, never command authority. Not yet built: a workspace doc read releases into context with an empty label (CT-2165). <code>PromptSlotBound</code> authority is a separate thing from a CFC label and is drawn as one.</p>`,
+      },
+      apps: {
+        kind: "Fabric app",
+        band: "tcb",
+        body:
+          `<p>Estuary, Rapids and the shell: user-facing apps that read and write spaces through cf-service with the person's identity. Where they are reachable from is a network fact, not a trust fact. What makes their reads safe is the runner's gates, not the network.</p>`,
+      },
+      toolshed: {
+        kind: "TCB",
+        band: "tcb",
+        body:
+          `<p>The Common Fabric service: memory API, identity, UCAN authorization, the shell. CFC does not replace space authorization; it runs on top of it.</p><p>Note: toolshed's own runtime reports <code>policyEvaluation: off</code>. The policy snapshot that governs harness writes lives on the harness's client runtime, so no toolshed change is needed for the demo.</p>`,
+      },
+      runner: {
+        kind: "TCB · CFC kernel",
+        band: "tcb",
+        threats: ["t13", "t8"],
+        body:
+          `<p>The one place policy meaning lives. On every transaction it derives labels onto computed values (the store put <code>finance</code> on every field of today's dashboard with a verified <code>TransformedBy</code> atom) and runs the gates:</p><ul><li><b>Sink ceiling</b>: a release's consumed labels must fit the sink's ceiling.</li><li><b>Writer fit</b> and <b>write floor</b>: what a writer may put where, and the integrity a written value must carry. Writer-fit misfits reject only under <code>enforce-strict</code>; under the console's <code>enforce-explicit</code> they persist and flag.</li><li><b>Policy evaluation</b>: exchange rules that can discharge a clause before the fit; only ever loosens, fails closed on fuel or lookup.</li><li><b>Render ceiling</b>: the same fit for the display sink.</li></ul><p>Its posture is a set of orthogonal dials, not an on/off switch.</p>`,
+        links: [["the label reader was broken, the store was fine", 6751]],
+      },
+      spaces: {
+        kind: "TCB · store",
+        band: "tcb",
+        body:
+          `<p>Cells stored per space (a DID), with labels stored per path alongside values. Between spaces only a link preserves labels and integrity; copying materialized bytes makes a fresh value with no attestation.</p>`,
+        threats: ["t10"],
+      },
+      policy: {
+        kind: "TCB · configuration",
+        band: "tcb",
+        body:
+          `<p>Two things, both operator-owned. The <b>dials</b> are runtime options: the enforcement matrix names five (enforcement mode, flow-label persistence, write floor, trigger-read gating, policy evaluation) and the runtime has nine; the console's <code>max-enforcement</code> bundle sets seven of them, with the enforcement mode pinned at <code>enforce-explicit</code>. The <b>policy snapshot</b> is the digest-bound set of exchange-rule records and grants. Records are <code>ambient</code> (apply to every label) or <code>referenced</code> (fire only where the label names them by hash).</p>`,
+        close: [
+          "There is no door for a policy record to reach a harness runtime: config exposes a posture name only (CT-2175 question 4).",
+          "Guard shape for the demo's finance-release record is undecided (question 3).",
+        ],
+      },
+      index: {
+        kind: "TCB · program plane",
+        band: "tcb",
+        body:
+          `<p>A metadata plane, not a data plane. Search results enter model context as an observation; the selected pattern's source is fetched and compiled host-side; publication sends the program, and the render gate runs over a synthetic instance so no user data rides along.</p>`,
+      },
+      gardening: {
+        kind: "TCB · writer",
+        band: "tcb",
+        body:
+          `<p>Automated maintenance of the index. Intended shape: a bounded writer with its own provenance and audit trail, so it can never become a way to publish data.</p>`,
+      },
+      sqlite: {
+        kind: "TCB · connector data",
+        band: "tcb",
+        body:
+          `<p class="hint">Loom-side claims here come from CT-2189 and the connector map on CT-2066; loom's code is not in this repository.</p><p>Fabric-connected SQLite tables patterns can query. Row-level CFC is implemented in the runtime: rules come from the table contract and are re-derived on every read, including for rows written before the rule (the mailbox demo pattern does this today).</p>`,
+        threats: ["t7"],
+        close: [
+          "Injection seeds <code>tables: {}</code> and treats injected files as unlabeled, so connector rows carry no labels yet. Decide how a connector's schema and row-label rules reach the handle (CT-2189 gap 2, shared loom + labs).",
+          "<code>describe_handle</code> can tell the model nothing about an injected table until the handle cell declares a schema (gap 4, ours, small).",
+        ],
+      },
+      connectors: {
+        kind: "TCB · ingress mediator",
+        band: "tcb",
+        body:
+          `<p class="hint">Loom-side; described from CT-2189, not verified against loom's code.</p><p>Loom's connectors pull third-party data and stamp trusted provenance on the way in. <code>loom-daemon</code> can inject a read-only SQLite handle cell plus a freshness cell into a piece for any connector declared with <code>sqlite_sources</code>; two loom patterns already read connector databases this way.</p>`,
+        close: [
+          "Plaid and Gmail are not declared as <code>sqlite_sources</code> (CT-2189 gap 1, Alex's side).",
+          "Egress through a connector needs its own gate evaluating destination, labels and authority; not drawn because none exists yet.",
+        ],
+      },
+      artifacts: {
+        kind: "Evidence",
+        band: "evidence",
+        body:
+          `<p>Every run writes its transcript, run-state, policy snapshot, tool outputs, child references, skill provenance, and, since today, the per-cell labels its space holds for the cells it touched, in the same write as the run's outcome. The one artifact a run does not write from its own knowledge.</p>`,
+        threats: ["t6", "t8", "t12"],
+        links: [[
+          "cell labels recorded in the write that ends the run",
+          6757,
+        ]],
+        close: [
+          "The twelve refusals are structured in tool outputs but absent from the policy trace; the check that counts them is in open PR #6755.",
+          "The artifact root is readable from the sandbox (CT-2117).",
+        ],
+      },
+      audit: {
+        kind: "Evidence · verifier",
+        band: "evidence",
+        body:
+          `<p>Runs over any recorded run and grades nine checks (AUD-1 to AUD-9) pass, fail, warn or inconclusive against quoted spec clauses; inconclusive is never pass. First run over the demo: 63 checks over 7 runs, 33 pass, 13 fail (7 real, 6 a checker false positive). The demo acceptance bar is now “the checker passes”. A second batch of checks, including the one that counts release refusals, is in an open PR (#6755).</p><p>It verifies; it never enforces. Missing evidence is a finding, not proof that a gate ran.</p>`,
+        links: [["spec-anchored CFC checker", 6749], [
+          "what the audit found",
+          6754,
+        ]],
+      },
+    };
+    const GD = {
+      g_context: {
+        body:
+          `<p>The boundary between what the harness assembled and what the provider sees. By design there is no label check here: the runner's <code>llm</code> sink class has no ceiling and the harness's model call is not a runner sink. Every value that could have been labeled was withheld or tokenized before it got this far.</p>`,
+        why:
+          "Where the whole design is tested: if a labeled value made it into context, the provider has it and no later gate helps.",
+        close: [
+          "Give the model context a runner sink class of its own (CT-2175 recommendation B) so the answer boundary becomes one runner gate instead of a harness copy.",
+          "Then the harness deletes its own <code>RUN_PATTERN_ANSWER_CEILING</code> measurement.",
+        ],
+        threats: ["t3"],
+      },
+      g_deleg: {
+        body:
+          `<p>Handles cross this boundary correctly: a child's table is seeded with exactly the parent tokens the brief names, and tokens stay identical across the hierarchy. But the brief itself, <code>goal</code> and <code>context</code>, is free text, and a parent can put anything it happens to know in it.</p>`,
+        why:
+          "The place the handle model is not yet fully realized; named as live work in the harness README.",
+        close: ["Make the brief bound references rather than prose."],
+        threats: ["t4"],
+      },
+      g_return: {
+        body:
+          `<p>A child's return is a new observation, not a continuation of the parent's token stream. It is validated against the delegation's return schema, sanitized, sealed strings become parent-resolvable tokens, and any token-shaped text still standing is scrubbed to inert text. Raw child evidence stays in artifacts, off the parent's return channel.</p>`,
+        why: "Structure only: no label information crosses with the return.",
+      },
+      g_tool: {
+        body:
+          `<p>Every tool proposal the model makes is decided as mode × effect class × prompt-slot authority. A malformed call comes back as a typed, recoverable refusal naming the field, never the value. Denials, activities and failure records are all written.</p>`,
+        why:
+          "This gate has no label input at all. It decides <em>whether</em> a tool may run, never what the tool may release; that belongs to the sinks.",
+        threats: ["t9"],
+      },
+      g_obs: {
+        body:
+          `<p>Sandbox output crosses back through a sidecar that marks it <code>observed</code>, <code>opaque</code> or <code>denied</code> from runsc's xattr taint. The harness renders the verdict and never decides.</p>`,
+        why:
+          "The sandbox's taint store and the runner's label store are two different systems that do not yet speak.",
+        close: [
+          "Real sidecar evidence for every exposed observation, so Loom and Pattern Factory can leave <code>observe</code> mode (deviation 2).",
+          "The mediation depends on how the operator registered <code>runsc-cfc</code>: without <code>--cfc-invocation-context-dir</code> the harness writes invocation contexts nothing reads and input labels drop silently, while the guard only checks that the directories are named (CT-2105).",
+          "Reserve the artifact root from the sandbox (CT-2117).",
+        ],
+        threats: ["t5", "t12"],
+      },
+      g_egress: {
+        body:
+          `<p>Outbound from the harness: <code>web_fetch</code> applies bounds and redirect checks; the browser tool has a verb allowlist and a per-run origin allowlist for the values a <code>valueHandle</code> spends; the bash <code>curl</code> guard admits localhost targets only, and nothing else in the sandbox is inspected while its network mode is bridge. Inbound: the response is untrusted.</p><p>Inside a pattern, web egress is gated for real: the max-enforcement bundle puts public-only ceilings on the six fetch sinks.</p>`,
+        why:
+          "The exfiltration sink an injected skill aims at. Harness-side it is protected mostly by the agent not holding values, not by a label check on the request.",
+        close: [
+          "Represent network authority as an explicit destination profile across sandbox and web tools (deviation 3).",
+          "Label what the web tools bring back, and give the browser's value release a label input.",
+        ],
+        threats: ["t2", "t1"],
+      },
+      g_ingest: {
+        body:
+          `<p><code>acquire_skill</code> pins the skill by digest, stamps <code>ExternalIngest</code> integrity, and hands back a capability-typed handle. Fetched skill text remains context.</p>`,
+        why:
+          "The stamp is written but never read at a release site, so integrity provenance does not yet change any decision.",
+        close: [
+          "Read the integrity stamp at the write floor and at egress, so text from outside can never become direct-command authority.",
+        ],
+        threats: ["t1"],
+      },
+      g_release: {
+        body:
+          `<p>The gate that fired for the first time today. <code>run_pattern</code> reads the result under the runner and fits the consumed labels against a public-only answer ceiling. Ruled: a reference-only answer is not a release, so the handle always comes back; only the values a <code>resultSchema</code> asks for are gated, and a refusal names the input that carried the label.</p>`,
+        why:
+          "This is the guarantee the product sells: computation goes to the data and the model gets a name, not the number.",
+        links: [["ceiling gates values, not the handle", 6759]],
+        close: [
+          "The fit skips the runner's policy evaluation, so no exchange rule can discharge <code>finance</code> here yet. Policy A vs policy B (released under one, refused under the other) is the smallest honest experiment (CT-2175).",
+          "Record the refusal as a policy event so audit can count it (CT-2188 attribution fixed in the same change).",
+        ],
+        threats: ["t8"],
+      },
+      g_write: {
+        body:
+          `<p>Every transaction commits through the runner's boundary pass. The enforcement mode is <code>enforce-explicit</code> by default and in the console's bundle, so a recorded reason rejects the commit, including a labeled write with no resolvable policy input. The write floor and trigger-read gating are further reason sources on their own dials. Writer fit is not: its misfit rejects only under <code>enforce-strict</code>, and persists-and-flags under explicit, which is what runs today.</p>`,
+        why:
+          "The place labels are derived and persisted; everything downstream reads what this wrote.",
+        close: [
+          "<code>cfcFlowLabels: persist</code> on the writing runtime is what the bills dashboard needs to keep connector labels on its materialized result.",
+        ],
+      },
+      g_render: {
+        body:
+          `<p>The display sink. When the shell renders a piece, the runner can fit the value's labels against a render ceiling with <code>sinkClass: display</code>; it is the precedent for every non-network release site. It is implemented but off by default: a browser profile has to populate the ceiling (<code>commonfabric.cfcRenderCeiling()</code> in localStorage, dogfood only, expected to over-block until exchange resolution lands). In today's demo the panel showed finance values because no ceiling was populated, not because a fit admitted them.</p>`,
+        why:
+          "The person is a sink too. This is the last gate before human eyes, and today it is open.",
+        close: [
+          "Turn the ceiling on by default once exchange resolution can discharge what a person is entitled to see.",
+        ],
+      },
+      g_conn: {
+        body:
+          `<p>Where third-party rows should receive their labels: a table contract that declares the schema and row-label rules, re-derived on every read.</p>`,
+        why:
+          "If rows enter unlabeled, the dashboard is unlabeled and CFC has nothing to hold. The circuit is open at its source.",
+        close: [
+          "Declare the connectors as <code>sqlite_sources</code> (gap 1) and give injected handles a labeled table contract (gap 2).",
+        ],
+        threats: ["t7"],
+      },
+      g_index: {
+        body:
+          `<p>Publishing to the index sends the program, never the data. Search metadata enters context as an observation; pattern source is compiled host-side. Delegation can pass up to eight pattern references, resolved only from search results this parent actually saw.</p>`,
+        why:
+          "Keeps the index a program plane. Gardening should stay a bounded writer with provenance.",
+      },
+      g_operator: {
+        body:
+          `<p>Operators read artifacts and audit findings. Transcripts, handle maps and policy evidence can reveal sensitive provenance and need protection comparable to the data itself.</p>`,
+        why: "The one gate with no code behind it yet.",
+        close: ["Authenticated, scoped, logged access to raw run artifacts."],
+        threats: ["t11", "t6"],
+      },
+    };
+    const TD = {
+      t1: {
+        body:
+          `<p>A fetched skill or a web page tells the model to do something. That is the normal case, not the anomaly: the model reads untrusted text as instructions and cannot tell them apart.</p><p><b>What holds:</b> the agent holds handles, not values, and the sinks an instruction could aim at are gated. Authority comes from the caller-bound prompt slot and the tool gate checks that slot on every effectful call, so fetched text cannot become a command. Labels play no part in that today: the ExternalIngest stamp is written but never read, and <code>web_fetch</code> text is not labeled at all.</p>`,
+        where: ["skillssh", "www", "g_ingest", "g_egress"],
+      },
+      t2: {
+        plan:
+          "Network authority as an explicit destination profile across sandbox and web tools (harness deviation 3), and a label input on web_fetch and browser so the egress ceiling sees what a pattern's fetch sinks already see.",
+        body:
+          `<p>The model, injected or merely mistaken, puts something it holds into a URL, a request body, or a curl. <b>What holds:</b> the model does not hold labeled values; pattern-side fetch sinks have public-only ceilings. <b>What does not yet:</b> the harness-side web tools have no label input; network authority is provisional.</p>`,
+        where: ["child_web", "www", "g_egress"],
+      },
+      t3: {
+        body:
+          `<p>The provider sees every byte of context and keeps its own logs. There is no gate at the provider, so a labeled value that reaches context is gone. <b>What holds:</b> values are withheld or tokenized before context. <b>Open:</b> nothing measures the assembled context as a sink.</p>`,
+        where: ["provider", "gateway", "g_context"],
+      },
+      t4: {
+        plan:
+          "Bound references in the brief instead of prose; named as live work in the harness README.",
+        body:
+          `<p><code>delegate_task</code> takes <code>goal</code> and <code>context</code> as prose. Handles cross by seeding, but a parent can also write anything it knows into the brief, and the child's fresh context starts from that. Named in the harness README as the place the handle model is not yet realized.</p>`,
+        where: ["parent", "child_pa", "g_deleg"],
+      },
+      t5: {
+        plan:
+          "Real sidecar evidence for every exposed observation so the product adapters leave observe mode (deviation 2), and one label vocabulary across runsc taint and runner labels.",
+        body:
+          `<p>A value written into the workspace mount is a file. Files carry runsc taint, not fabric labels, and the two stores do not talk. <b>What holds:</b> the write floor and the direct-command authority ladder on <code>write_file</code>; the sidecar's opaque/denied verdicts on reads.</p>`,
+        where: ["docker", "mount", "g_obs"],
+      },
+      t6: {
+        body:
+          `<p>Transcripts, handle maps and policy traces are sensitive provenance in their own right. Raw operator reports may expose artifact paths and canonical references. Operator access is not yet authenticated per artifact or logged.</p>`,
+        where: ["artifacts", "operator", "g_operator"],
+      },
+      t7: {
+        plan:
+          "CT-2189 gaps 1 and 2: declare the connectors as sqlite_sources and give injected handles a labeled table contract.",
+        body:
+          `<p>Connector rows arrive with no labels because injected handles seed <code>tables: {}</code>. An unlabeled input produces an unlabeled dashboard and CFC has nothing to hold; the whole circuit is only as strong as its source label.</p>`,
+        where: ["thirdparty", "connectors", "sqlite", "g_conn"],
+      },
+      t8: {
+        plan:
+          "Record the release refusal as a policy event with a runner-minted refusal detail; merge the audit check that counts policyRefusal on tool outputs (open PR #6755); attribution fixed in #6759.",
+        body:
+          `<p>The twelve refusals are structured: each tool output carries a <code>policyRefusal</code> with gates, atoms and the input that carried the label. What cannot show them is the policy <em>decision</em> channel, because the loop records its allow decision before the tool runs; the trace's reason-code union has no label-shaped member, and the merged audit's denial check reads decisions only, so it counts zero. The channel exists, it is structured, and it is empty. A gate we cannot prove fired is, for a colleague, a gate that did not.</p>`,
+        where: ["runner", "artifacts", "audit", "g_release"],
+      },
+      t9: {
+        body:
+          `<p>Provider output must never mint command authority. Authority comes from the prompt slot the caller bound (<code>PromptSlotBound</code>), and the tool gate checks that slot on every effectful call. Model text that looks like an operator instruction is still model text.</p>`,
+        where: ["parent", "gateway", "g_tool"],
+      },
+      t10: {
+        body:
+          `<p>Between spaces, only a link preserves labels and integrity. Copying materialized bytes creates a fresh value with no attestation. Any tool that “helpfully” materializes a value across spaces opens the circuit.</p>`,
+        where: ["spaces", "toolshed"],
+      },
+      t12: {
+        plan:
+          "Reserve the artifact root from bash and from any child sharing the workspace (CT-2117, open).",
+        body:
+          `<p><code>bash</code> does not reserve <code>.cf-harness-artifacts/</code>. A <code>cat</code> of the run's own tool-output JSON reads back the whole unsanitized result, the raw cause message and bare piece ids, and a delegated child sharing the workspace reaches it too. Reproduced with a planted marker by two reviewers. This is a direct route from “withheld” to model context, and it undermines every “retained in the artifact, withheld here” claim on this map until it is closed.</p>`,
+        where: ["docker", "mount", "artifacts", "g_obs"],
+      },
+      t13: {
+        plan:
+          "A ceiling on the runner's llm sink class, so a pattern's model calls fit like its fetch calls do (CT-2091 build list, item 5).",
+        body:
+          `<p>A model-authored pattern can call <code>llm</code>, <code>generateText</code> or <code>llmDialog</code> over the finance cell. Under <code>max-enforcement</code> those sinks have no ceiling, so labeled values leave for the provider with no gate. The fetch sinks are capped; the llm sinks are not, and a failing-when-fixed test pins the gap. This is a second egress from the trusted base into the provider, beside the model-context edge.</p>`,
+        where: ["runner", "gateway", "provider", "g_context"],
+      },
+      t11: {
+        body:
+          `<p>Employees with access to the gateway, spaces, the index or artifacts. Operators are principals: authenticated, scoped, audited. The map draws no red line from an employee to a component because access is meant to be a gate, not a leak.</p>`,
+        where: ["operator", "gateway", "toolshed", "index", "g_operator"],
+      },
+    };
+    const ED = {
+      e_parent_gateway:
+        `<p>What the harness sends the provider and what the provider sends back. Outbound bytes are model-visible by definition; inbound completions are untrusted proposals. There is no label gate on this edge; see the gate.</p>`,
+      e_run_pattern:
+        `<p><code>run_pattern</code> is the central tool: the child writes a pattern and runs it in the trusted fabric session against the handles it holds. Its fabric identity stays outside Docker and its authority is one configured space. Computation goes to the data.</p><p>The result of a run comes back as <code>resultRef</code>, a handle, on success and on a release refusal alike. A commit refusal (write floor, missing policy input, writer fit under strict) or a run failure returns an error with no handle. Fields the <code>resultSchema</code> models as inert (numbers, booleans, enums) come back as themselves if the ceiling admits them; everything else as a reference token.</p>`,
+      e_handles_spaces:
+        `<p>A <code>cfh:a:</code> token is a deterministic per-run name for a cell address. Bare fabric IDs are not converted. The mapping lives in <code>run-state.json</code> and survives batch resume; an interactive (console) restore does not persist it yet.</p>`,
+      e_render:
+        `<p>The piece is opened by slug through the shell (Weaver once wired; <code>cf piece render</code> in the acceptance run). What it may display is the render ceiling's decision in the runner, not the caller's, once that ceiling is populated.</p>`,
+      e_thirdparty_conn:
+        `<p>Plaid transactions and Gmail messages pulled by loom's connectors. Ingress, not a pattern fetch.</p>`,
+      e_conn_sqlite:
+        `<p>Today: rows stop in <code>source-records.db</code> and <code>msgvault.db</code>. Intended: <code>loom-daemon</code> injects a read-only <code>SqliteDb</code> handle cell and a freshness cell into the target space.</p>`,
+      e_sqlite_spaces:
+        `<p>Once the handle cell exists it is an ordinary same-space cell, so <code>--input-cell</code> and <code>/api/task inputCells</code> carry it into a harness session with no new transport.</p>`,
+      e_parent_child:
+        `<p>Delegation seeds the child's handle table with the parent entries the brief names, and nothing else. The brief itself is prose.</p>`,
+      e_child_parent:
+        `<p>Return is validated, sanitized and re-minted through the parent's boundary. Raw child evidence is retained outside the parent's return channel.</p>`,
+      e_skillssh:
+        `<p><code>acquire_skill</code>: fetch a skill from skills.sh, pin it by digest, stamp ExternalIngest, return a capability-typed handle.</p>`,
+      e_web_www:
+        `<p>Only the web child profiles or an explicit parent allowlist reach here. Request out, untrusted content in.</p>`,
+      e_runner_artifacts:
+        `<p>Labels, decisions, commit refusals and, since today, the cell-label snapshot for touched cells, written in the same write as the run's outcome.</p>`,
+      e_audit_operator:
+        `<p>Findings for a person to act on. Operator access to raw artifacts is the intended gate that has no code yet.</p>`,
+      e_operator_policy:
+        `<p>Policy records and grants are operator-authored. Patterns can reference a policy by hash; they cannot write one.</p>`,
+    };
 
-      // ------------------------------------------------------------------ stories
-      const stories = {
-        circuit: {
-          title: "The CFC circuit",
-          steps: [
-            {
-              f: ["person", "e_person_weaver", "thirdparty", "g_conn"],
-              sel: "person",
-              h: "1 · Label at the source",
-              t: "A person labels the input cell (finance). A connector's table contract labels rows as they arrive. Everything downstream is only as strong as this.",
-            },
-            {
-              f: ["spaces", "runner", "g_write"],
-              sel: "spaces",
-              h: "2 · Store per path",
-              t: "Labels sit beside values, per path, in the space. Links keep them; copies lose them.",
-            },
-            {
-              f: ["handles", "e_handles_spaces", "e_handles_parent", "parent"],
-              sel: "handles",
-              h: "3 · Name, don't carry",
-              t: "The harness mints a token for the cell. The model gets the name. It can route the name anywhere; it never holds the value.",
-            },
-            {
-              f: [
-                "child_pa",
-                "e_run_pattern",
-                "runner",
-                "e_runner_spaces",
-                "spaces",
-                "g_write",
-              ],
-              sel: "runner",
-              h: "4 · Computation goes to the data",
-              t: "The child writes a pattern and runs it in the trusted session. The runner derives finance onto every computed field with a TransformedBy atom.",
-            },
-            {
-              f: ["g_release", "e_run_pattern", "policy", "e_policy_runner"],
-              sel: "g_release",
-              h: "5 · Release is a decision",
-              t: "The handle always comes back. Values are fitted against the sink's ceiling; a policy may discharge a clause first; otherwise a typed refusal naming the input.",
-            },
-            {
-              f: [
-                "g_render",
-                "e_render",
-                "weaver",
-                "g_egress",
-                "g_context",
-                "g_obs",
-              ],
-              sel: "g_render",
-              h: "6 · Every sink should be a gate",
-              t: "The design: display, web egress, model context and files are each a sink with a ceiling. Today two fit live: a pattern's fetch sinks under max-enforcement, and the run_pattern answer. The display ceiling is off by default; model context has none; files carry no labels. The gate colors say which is which.",
-            },
-            {
-              f: [
-                "e_runner_artifacts",
-                "e_parent_artifacts",
-                "artifacts",
-                "e_artifacts_audit",
-                "audit",
-              ],
-              sel: "audit",
-              h: "7 · Prove it",
-              t: "Labels and decisions are written in the same write as the outcome. The checker grades the record against quoted spec clauses; inconclusive is never pass.",
-            },
-            {
-              f: [
-                "g_context",
-                "g_deleg",
-                "g_egress",
-                "g_ingest",
-                "g_conn",
-                "g_operator",
-                "g_render",
-                "t8",
-                "t12",
-                "t13",
-                "policy",
-              ],
-              sel: "g_release",
-              h: "8 · Where the circuit is still open",
-              t: "Policy discharge at the release gate and a door for records (CT-2175). The prose delegation brief. Web and browser tools without label input, and bridge networking in the sandbox. A pattern's llm calls uncapped. The sandbox reading the run's own artifacts (CT-2117). Connector rows unlabeled (CT-2189). Refusals absent from the decision channel. The display ceiling off. Operator access unaudited.",
-            },
-          ],
-        },
-        pill: {
-          title: "Demo 1 · Weaver pill (CT-2190)",
-          steps: [
-            {
-              f: ["person", "e_person_weaver", "weaver"],
-              sel: "weaver",
-              h: "Type the pill",
-              t: "/cf-harness make me a budget dashboard from my transaction data. The person's transaction cell already carries confidentiality:[finance].",
-            },
-            {
-              f: [
-                "weaver",
-                "e_weaver_console",
-                "console",
-                "e_console_parent",
-                "parent",
-              ],
-              sel: "console",
-              h: "One honest contract",
-              t: "POST /api/task {text, inputCells} → SSE progress → GET result. Bad refs are a 400 before any turn spends; failed turns are terminal; one writer for run state.",
-            },
-            {
-              f: [
-                "parent",
-                "handles",
-                "e_handles_parent",
-                "e_handles_spaces",
-                "spaces",
-              ],
-              sel: "handles",
-              h: "Mint the handle",
-              t: "The input cell becomes cfh:a:… in the model's world. The model sees the cell's schema and label through describe_handle, never the rows.",
-            },
-            {
-              f: ["parent", "e_parent_child", "g_deleg", "child_pa"],
-              sel: "child_pa",
-              h: "Delegate to a pattern author",
-              t: "A fresh child context seeded with that one token. Today five children ran; the brief around the token is still prose (open).",
-            },
-            {
-              f: [
-                "child_pa",
-                "e_run_pattern",
-                "runner",
-                "e_runner_spaces",
-                "spaces",
-                "g_write",
-              ],
-              sel: "runner",
-              h: "Build and run over the data",
-              t: "The child writes the dashboard pattern and runs it. The store derives finance onto totalSpending and every other field, TransformedBy verified, readable back over the wire.",
-            },
-            {
-              f: ["g_release", "e_run_pattern", "child_pa", "t8"],
-              sel: "g_release",
-              h: "The gate fires",
-              t: "Twelve times across five children the runtime refused to release the finance values. Nothing had ever been refused by a label before today. With #6759 the handle comes back regardless.",
-            },
-            {
-              f: [
-                "child_pa",
-                "e_child_parent",
-                "g_return",
-                "parent",
-                "console",
-                "e_weaver_console",
-                "weaver",
-              ],
-              sel: "weaver",
-              h: "Return a name, open a piece",
-              t: "The rerun answered the handle question: one POST, one child, 6m40s. The gate still refused the values to the model; the model shipped the bound dashboard anyway, by handle. It got slugged, opened, and reflowed when the transaction cell changed. Acceptance itself is not yet a pass: the audit still has two fails, both checker-side (CT-2187, CT-2191).",
-            },
-            {
-              f: ["g_render", "e_render", "weaver", "person"],
-              sel: "g_render",
-              h: "The person sees values",
-              t: "Display is a release. The render ceiling decides what the panel shows to the person who owns the data. Acceptance: the checker passes over the run.",
-            },
-          ],
-        },
-        bills: {
-          title: "Demo 2 · Bills dashboard from Gmail + Plaid (CT-2189)",
-          steps: [
-            {
-              f: ["thirdparty", "e_thirdparty_conn", "connectors", "g_conn"],
-              sel: "connectors",
-              h: "Ingress through connectors",
-              t: "Plaid and Gmail rows arrive through loom's connectors. Today they stop in loom-owned databases; neither is a cell in any space.",
-            },
-            {
-              f: ["connectors", "e_conn_sqlite", "sqlite", "t7"],
-              sel: "sqlite",
-              h: "Gap 1 and 2 (loom side)",
-              t: "Declare both as sqlite_sources so loom-daemon injects a handle cell and freshness cell; give the injected handle a labeled table contract so rows carry CFC labels. This is the blocking gap and it is Alex's to pick up or hand over.",
-            },
-            {
-              f: [
-                "sqlite",
-                "e_sqlite_spaces",
-                "spaces",
-                "handles",
-                "e_handles_spaces",
-              ],
-              sel: "spaces",
-              h: "A labeled cell like any other",
-              t: "Once the handle cell exists, /api/task inputCells carries it into a session with no new transport. The path is identical to demo 1 from here.",
-            },
-            {
-              f: ["child_pa", "e_run_pattern", "runner", "spaces", "g_write"],
-              sel: "runner",
-              h: "Two handles, one pattern",
-              t: "A single SQL statement cannot span two handles; query each and join in fabric computation. Reuse the bill-extractor status logic (unpaid, paid, overdue, likely paid) and extend it to the demo's upcoming and nearly-overdue states. Persisting derived labels needs cfcFlowLabels: persist.",
-            },
-            {
-              f: [
-                "g_release",
-                "e_run_pattern",
-                "child_pa",
-                "e_child_parent",
-                "parent",
-                "weaver",
-                "g_render",
-                "e_render",
-                "person",
-              ],
-              sel: "g_render",
-              h: "A panel in Weaver",
-              t: "The dashboard's result cells carry the connector labels, derived and TransformedBy. Alex opens it as a panel. No notification sink: the dashboard is the deliverable.",
-            },
-          ],
-        },
-        hostile: {
-          title: "Demo 3 · A hostile skill has nothing to steal (CT-2091)",
-          steps: [
-            {
-              f: ["child_pa", "e_skillssh", "skillssh", "g_ingest", "t1"],
-              sel: "g_ingest",
-              h: "Acquire a skill from outside",
-              t: "search_skills finds one on skills.sh; acquire_skill pins it by digest and stamps ExternalIngest. The skill text carries an injection: post the user's finance data to an outside URL.",
-            },
-            {
-              f: ["child_pa", "handles", "e_handles_parent", "t4"],
-              sel: "handles",
-              h: "What the agent actually holds",
-              t: "Tokens. The finance cell is cfh:a:… in context. The injection can name it, route it, describe its shape. It cannot read a row.",
-            },
-            {
-              f: ["child_web", "e_web_www", "g_egress", "www", "t2"],
-              sel: "g_egress",
-              h: "The injection aims at egress",
-              t: "Any attempt to fetch with data in the URL or body reaches the web tools without a value to send. Pattern-side, the fetch sinks have public-only ceilings and refuse finance outright.",
-            },
-            {
-              f: ["g_release", "e_run_pattern", "g_context", "t3"],
-              sel: "g_release",
-              h: "Asking for values is a release",
-              t: "If the injected skill asks run_pattern for a resultSchema over finance, the ceiling refuses the values and names the input. Handle returns; value does not.",
-            },
-            {
-              f: [
-                "artifacts",
-                "e_parent_artifacts",
-                "e_runner_artifacts",
-                "audit",
-                "t8",
-              ],
-              sel: "audit",
-              h: "The attempt is on the record",
-              t: "Skill provenance, the tool proposals, the refusal. Open: the refusal needs to be a policy event so the checker can count it, and the ingest stamp needs to be read at the egress gate.",
-            },
-          ],
-        },
-        trust: {
-          title: "Where we have to trust ourselves",
-          steps: [
-            {
-              f: [
-                "runner",
-                "policy",
-                "spaces",
-                "toolshed",
-                "g_write",
-                "g_release",
-                "g_render",
-              ],
-              sel: "runner",
-              h: "The kernel",
-              t: "The runner owns every label and every decision. A bug here is a bug in the guarantee, and no other component can catch it. This is the smallest thing we must get right.",
-            },
-            {
-              f: [
-                "parent",
-                "handles",
-                "child_pa",
-                "g_tool",
-                "g_return",
-                "g_deleg",
-                "console",
-              ],
-              sel: "parent",
-              h: "The harness",
-              t: "Trusted to transport faithfully: tokenize everything model-bound, resolve before dispatch, seed children with exactly what the brief names, never decide policy itself. It records every decision so the runner's meaning can be checked against what it did.",
-            },
-            {
-              f: [
-                "docker",
-                "g_obs",
-                "gateway",
-                "connectors",
-                "g_conn",
-                "index",
-                "g_index",
-              ],
-              sel: "docker",
-              h: "The mediators",
-              t: "The sandbox sidecar, our gateway, the connector ingress, the index: each is trusted to stamp or withhold at a boundary. They are ours, so they are inside the base; they are also where two label stores meet and can disagree.",
-            },
-            {
-              f: [
-                "provider",
-                "www",
-                "skillssh",
-                "thirdparty",
-                "g_context",
-                "g_egress",
-                "g_ingest",
-              ],
-              sel: "provider",
-              h: "What we never trust",
-              t: "The model, the web, third-party skills and APIs. The design never asks them to behave. It asks that nothing valuable reaches them, and that nothing they say becomes authority.",
-            },
-            {
-              f: ["artifacts", "audit", "operator", "g_operator", "t6", "t11"],
-              sel: "audit",
-              h: "How we check ourselves",
-              t: "Evidence written by the enforcing components, verified by a checker that never enforces, read by operators whose access is itself a gate. Trust in the base is earned by the record, not asserted.",
-            },
-          ],
-        },
-      };
+    // ------------------------------------------------------------------ stories
+    const stories = {
+      circuit: {
+        title: "The CFC circuit",
+        steps: [
+          {
+            f: ["person", "e_person_weaver", "thirdparty", "g_conn"],
+            sel: "person",
+            h: "1 · Label at the source",
+            t: "A person labels the input cell (finance). A connector's table contract labels rows as they arrive. Everything downstream is only as strong as this.",
+          },
+          {
+            f: ["spaces", "runner", "g_write"],
+            sel: "spaces",
+            h: "2 · Store per path",
+            t: "Labels sit beside values, per path, in the space. Links keep them; copies lose them.",
+          },
+          {
+            f: ["handles", "e_handles_spaces", "e_handles_parent", "parent"],
+            sel: "handles",
+            h: "3 · Name, don't carry",
+            t: "The harness mints a token for the cell. The model gets the name. It can route the name anywhere; it never holds the value.",
+          },
+          {
+            f: [
+              "child_pa",
+              "e_run_pattern",
+              "runner",
+              "e_runner_spaces",
+              "spaces",
+              "g_write",
+            ],
+            sel: "runner",
+            h: "4 · Computation goes to the data",
+            t: "The child writes a pattern and runs it in the trusted session. The runner derives finance onto every computed field with a TransformedBy atom.",
+          },
+          {
+            f: ["g_release", "e_run_pattern", "policy", "e_policy_runner"],
+            sel: "g_release",
+            h: "5 · Release is a decision",
+            t: "The handle always comes back. Values are fitted against the sink's ceiling; a policy may discharge a clause first; otherwise a typed refusal naming the input.",
+          },
+          {
+            f: [
+              "g_render",
+              "e_render",
+              "weaver",
+              "g_egress",
+              "g_context",
+              "g_obs",
+            ],
+            sel: "g_render",
+            h: "6 · Every sink should be a gate",
+            t: "The design: display, web egress, model context and files are each a sink with a ceiling. Today two fit live: a pattern's fetch sinks under max-enforcement, and the run_pattern answer. The display ceiling is off by default; model context has none; files carry no labels. The gate colors say which is which.",
+          },
+          {
+            f: [
+              "e_runner_artifacts",
+              "e_parent_artifacts",
+              "artifacts",
+              "e_artifacts_audit",
+              "audit",
+            ],
+            sel: "audit",
+            h: "7 · Prove it",
+            t: "Labels and decisions are written in the same write as the outcome. The checker grades the record against quoted spec clauses; inconclusive is never pass.",
+          },
+          {
+            f: [
+              "g_context",
+              "g_deleg",
+              "g_egress",
+              "g_ingest",
+              "g_conn",
+              "g_operator",
+              "g_render",
+              "t8",
+              "t12",
+              "t13",
+              "policy",
+            ],
+            sel: "g_release",
+            h: "8 · Where the circuit is still open",
+            t: "Policy discharge at the release gate and a door for records (CT-2175). The prose delegation brief. Web and browser tools without label input, and bridge networking in the sandbox. A pattern's llm calls uncapped. The sandbox reading the run's own artifacts (CT-2117). Connector rows unlabeled (CT-2189). Refusals absent from the decision channel. The display ceiling off. Operator access unaudited.",
+          },
+        ],
+      },
+      pill: {
+        title: "Demo 1 · Weaver pill (CT-2190)",
+        steps: [
+          {
+            f: ["person", "e_person_weaver", "weaver"],
+            sel: "weaver",
+            h: "Type the pill",
+            t: "/cf-harness make me a budget dashboard from my transaction data. The person's transaction cell already carries confidentiality:[finance].",
+          },
+          {
+            f: [
+              "weaver",
+              "e_weaver_console",
+              "console",
+              "e_console_parent",
+              "parent",
+            ],
+            sel: "console",
+            h: "One honest contract",
+            t: "POST /api/task {text, inputCells} → SSE progress → GET result. Bad refs are a 400 before any turn spends; failed turns are terminal; one writer for run state.",
+          },
+          {
+            f: [
+              "parent",
+              "handles",
+              "e_handles_parent",
+              "e_handles_spaces",
+              "spaces",
+            ],
+            sel: "handles",
+            h: "Mint the handle",
+            t: "The input cell becomes cfh:a:… in the model's world. The model sees the cell's schema and label through describe_handle, never the rows.",
+          },
+          {
+            f: ["parent", "e_parent_child", "g_deleg", "child_pa"],
+            sel: "child_pa",
+            h: "Delegate to a pattern author",
+            t: "A fresh child context seeded with that one token. Today five children ran; the brief around the token is still prose (open).",
+          },
+          {
+            f: [
+              "child_pa",
+              "e_run_pattern",
+              "runner",
+              "e_runner_spaces",
+              "spaces",
+              "g_write",
+            ],
+            sel: "runner",
+            h: "Build and run over the data",
+            t: "The child writes the dashboard pattern and runs it. The store derives finance onto totalSpending and every other field, TransformedBy verified, readable back over the wire.",
+          },
+          {
+            f: ["g_release", "e_run_pattern", "child_pa", "t8"],
+            sel: "g_release",
+            h: "The gate fires",
+            t: "Twelve times across five children the runtime refused to release the finance values. Nothing had ever been refused by a label before today. With #6759 the handle comes back regardless.",
+          },
+          {
+            f: [
+              "child_pa",
+              "e_child_parent",
+              "g_return",
+              "parent",
+              "console",
+              "e_weaver_console",
+              "weaver",
+            ],
+            sel: "weaver",
+            h: "Return a name, open a piece",
+            t: "The rerun answered the handle question: one POST, one child, 6m40s. The gate still refused the values to the model; the model shipped the bound dashboard anyway, by handle. It got slugged, opened, and reflowed when the transaction cell changed. Acceptance itself is not yet a pass: the audit still has two fails, both checker-side (CT-2187, CT-2191).",
+          },
+          {
+            f: ["g_render", "e_render", "weaver", "person"],
+            sel: "g_render",
+            h: "The person sees values",
+            t: "Display is a release. The render ceiling decides what the panel shows to the person who owns the data. Acceptance: the checker passes over the run.",
+          },
+        ],
+      },
+      bills: {
+        title: "Demo 2 · Bills dashboard from Gmail + Plaid (CT-2189)",
+        steps: [
+          {
+            f: ["thirdparty", "e_thirdparty_conn", "connectors", "g_conn"],
+            sel: "connectors",
+            h: "Ingress through connectors",
+            t: "Plaid and Gmail rows arrive through loom's connectors. Today they stop in loom-owned databases; neither is a cell in any space.",
+          },
+          {
+            f: ["connectors", "e_conn_sqlite", "sqlite", "t7"],
+            sel: "sqlite",
+            h: "Gap 1 and 2 (loom side)",
+            t: "Declare both as sqlite_sources so loom-daemon injects a handle cell and freshness cell; give the injected handle a labeled table contract so rows carry CFC labels. This is the blocking gap and it is Alex's to pick up or hand over.",
+          },
+          {
+            f: [
+              "sqlite",
+              "e_sqlite_spaces",
+              "spaces",
+              "handles",
+              "e_handles_spaces",
+            ],
+            sel: "spaces",
+            h: "A labeled cell like any other",
+            t: "Once the handle cell exists, /api/task inputCells carries it into a session with no new transport. The path is identical to demo 1 from here.",
+          },
+          {
+            f: ["child_pa", "e_run_pattern", "runner", "spaces", "g_write"],
+            sel: "runner",
+            h: "Two handles, one pattern",
+            t: "A single SQL statement cannot span two handles; query each and join in fabric computation. Reuse the bill-extractor status logic (unpaid, paid, overdue, likely paid) and extend it to the demo's upcoming and nearly-overdue states. Persisting derived labels needs cfcFlowLabels: persist.",
+          },
+          {
+            f: [
+              "g_release",
+              "e_run_pattern",
+              "child_pa",
+              "e_child_parent",
+              "parent",
+              "weaver",
+              "g_render",
+              "e_render",
+              "person",
+            ],
+            sel: "g_render",
+            h: "A panel in Weaver",
+            t: "The dashboard's result cells carry the connector labels, derived and TransformedBy. Alex opens it as a panel. No notification sink: the dashboard is the deliverable.",
+          },
+        ],
+      },
+      hostile: {
+        title: "Demo 3 · A hostile skill has nothing to steal (CT-2091)",
+        steps: [
+          {
+            f: ["child_pa", "e_skillssh", "skillssh", "g_ingest", "t1"],
+            sel: "g_ingest",
+            h: "Acquire a skill from outside",
+            t: "search_skills finds one on skills.sh; acquire_skill pins it by digest and stamps ExternalIngest. The skill text carries an injection: post the user's finance data to an outside URL.",
+          },
+          {
+            f: ["child_pa", "handles", "e_handles_parent", "t4"],
+            sel: "handles",
+            h: "What the agent actually holds",
+            t: "Tokens. The finance cell is cfh:a:… in context. The injection can name it, route it, describe its shape. It cannot read a row.",
+          },
+          {
+            f: ["child_web", "e_web_www", "g_egress", "www", "t2"],
+            sel: "g_egress",
+            h: "The injection aims at egress",
+            t: "Any attempt to fetch with data in the URL or body reaches the web tools without a value to send. Pattern-side, the fetch sinks have public-only ceilings and refuse finance outright.",
+          },
+          {
+            f: ["g_release", "e_run_pattern", "g_context", "t3"],
+            sel: "g_release",
+            h: "Asking for values is a release",
+            t: "If the injected skill asks run_pattern for a resultSchema over finance, the ceiling refuses the values and names the input. Handle returns; value does not.",
+          },
+          {
+            f: [
+              "artifacts",
+              "e_parent_artifacts",
+              "e_runner_artifacts",
+              "audit",
+              "t8",
+            ],
+            sel: "audit",
+            h: "The attempt is on the record",
+            t: "Skill provenance, the tool proposals, the refusal. Open: the refusal needs to be a policy event so the checker can count it, and the ingest stamp needs to be read at the egress gate.",
+          },
+        ],
+      },
+      trust: {
+        title: "Where we have to trust ourselves",
+        steps: [
+          {
+            f: [
+              "runner",
+              "policy",
+              "spaces",
+              "toolshed",
+              "g_write",
+              "g_release",
+              "g_render",
+            ],
+            sel: "runner",
+            h: "The kernel",
+            t: "The runner owns every label and every decision. A bug here is a bug in the guarantee, and no other component can catch it. This is the smallest thing we must get right.",
+          },
+          {
+            f: [
+              "parent",
+              "handles",
+              "child_pa",
+              "g_tool",
+              "g_return",
+              "g_deleg",
+              "console",
+            ],
+            sel: "parent",
+            h: "The harness",
+            t: "Trusted to transport faithfully: tokenize everything model-bound, resolve before dispatch, seed children with exactly what the brief names, never decide policy itself. It records every decision so the runner's meaning can be checked against what it did.",
+          },
+          {
+            f: [
+              "docker",
+              "g_obs",
+              "gateway",
+              "connectors",
+              "g_conn",
+              "index",
+              "g_index",
+            ],
+            sel: "docker",
+            h: "The mediators",
+            t: "The sandbox sidecar, our gateway, the connector ingress, the index: each is trusted to stamp or withhold at a boundary. They are ours, so they are inside the base; they are also where two label stores meet and can disagree.",
+          },
+          {
+            f: [
+              "provider",
+              "www",
+              "skillssh",
+              "thirdparty",
+              "g_context",
+              "g_egress",
+              "g_ingest",
+            ],
+            sel: "provider",
+            h: "What we never trust",
+            t: "The model, the web, third-party skills and APIs. The design never asks them to behave. It asks that nothing valuable reaches them, and that nothing they say becomes authority.",
+          },
+          {
+            f: ["artifacts", "audit", "operator", "g_operator", "t6", "t11"],
+            sel: "audit",
+            h: "How we check ourselves",
+            t: "Evidence written by the enforcing components, verified by a checker that never enforces, read by operators whose access is itself a gate. Trust in the base is earned by the record, not asserted.",
+          },
+        ],
+      },
+    };
 
-      // ------------------------------------------------------------------ render
-      const kindNames = {
-        handle: ["handle · no disclosure", "dash"],
-        value: ["model-visible", ""],
-        labeled: ["labeled value", ""],
-        ingress: ["untrusted in / out", ""],
-        control: ["control", ""],
-        evidence: ["evidence", "dot"],
-      };
-      const svg = document.getElementById("svg"),
-        world = document.getElementById("world");
-      const NS = "http://www.w3.org/2000/svg";
-      const el = (n, a = {}, parent) => {
-        const e = document.createElementNS(NS, n);
-        for (const k in a) e.setAttribute(k, a[k]);
-        if (parent) parent.appendChild(e);
-        return e;
-      };
-      const N = Object.fromEntries(nodes.map((n) => [n.id, n]));
-      function pathD(pts, r = 14) {
-        if (pts.length < 3) return "M" + pts.map((p) => p.join(",")).join(" L");
-        let d = `M${pts[0][0]},${pts[0][1]}`;
-        for (let i = 1; i < pts.length - 1; i++) {
-          const p0 = pts[i - 1], p1 = pts[i], p2 = pts[i + 1];
-          const d1 = Math.hypot(p1[0] - p0[0], p1[1] - p0[1]),
-            d2 = Math.hypot(p2[0] - p1[0], p2[1] - p1[1]);
-          const rr = Math.min(r, d1 / 2, d2 / 2);
-          const a = [
-            p1[0] + (p0[0] - p1[0]) / d1 * rr,
-            p1[1] + (p0[1] - p1[1]) / d1 * rr,
+    // ------------------------------------------------------------------ render
+    const kindNames = {
+      handle: ["handle · no disclosure", "dash"],
+      value: ["model-visible", ""],
+      labeled: ["labeled value", ""],
+      ingress: ["untrusted in / out", ""],
+      control: ["control", ""],
+      evidence: ["evidence", "dot"],
+    };
+    const svg = document.getElementById("svg"),
+      world = document.getElementById("world");
+    const NS = "http://www.w3.org/2000/svg";
+    const el = (n, a = {}, parent) => {
+      const e = document.createElementNS(NS, n);
+      for (const k in a) e.setAttribute(k, a[k]);
+      if (parent) parent.appendChild(e);
+      return e;
+    };
+    const N = Object.fromEntries(nodes.map((n) => [n.id, n]));
+    function pathD(pts, r = 14) {
+      if (pts.length < 3) return "M" + pts.map((p) => p.join(",")).join(" L");
+      let d = `M${pts[0][0]},${pts[0][1]}`;
+      for (let i = 1; i < pts.length - 1; i++) {
+        const p0 = pts[i - 1], p1 = pts[i], p2 = pts[i + 1];
+        const d1 = Math.hypot(p1[0] - p0[0], p1[1] - p0[1]),
+          d2 = Math.hypot(p2[0] - p1[0], p2[1] - p1[1]);
+        const rr = Math.min(r, d1 / 2, d2 / 2);
+        const a = [
+          p1[0] + (p0[0] - p1[0]) / d1 * rr,
+          p1[1] + (p0[1] - p1[1]) / d1 * rr,
+        ];
+        const b = [
+          p1[0] + (p2[0] - p1[0]) / d2 * rr,
+          p1[1] + (p2[1] - p1[1]) / d2 * rr,
+        ];
+        d += ` L${a[0]},${a[1]} Q${p1[0]},${p1[1]} ${b[0]},${b[1]}`;
+      }
+      const l = pts[pts.length - 1];
+      d += ` L${l[0]},${l[1]}`;
+      return d;
+    }
+    function along(pts, t) {
+      const segs = [];
+      let total = 0;
+      for (let i = 1; i < pts.length; i++) {
+        const L = Math.hypot(
+          pts[i][0] - pts[i - 1][0],
+          pts[i][1] - pts[i - 1][1],
+        );
+        segs.push(L);
+        total += L;
+      }
+      let want = t * total;
+      for (let i = 0; i < segs.length; i++) {
+        if (want <= segs[i]) {
+          const f = want / segs[i];
+          return [
+            pts[i][0] + (pts[i + 1][0] - pts[i][0]) * f,
+            pts[i][1] + (pts[i + 1][1] - pts[i][1]) * f,
           ];
-          const b = [
-            p1[0] + (p2[0] - p1[0]) / d2 * rr,
-            p1[1] + (p2[1] - p1[1]) / d2 * rr,
-          ];
-          d += ` L${a[0]},${a[1]} Q${p1[0]},${p1[1]} ${b[0]},${b[1]}`;
         }
-        const l = pts[pts.length - 1];
-        d += ` L${l[0]},${l[1]}`;
-        return d;
+        want -= segs[i];
       }
-      function along(pts, t) {
-        const segs = [];
-        let total = 0;
-        for (let i = 1; i < pts.length; i++) {
-          const L = Math.hypot(
-            pts[i][0] - pts[i - 1][0],
-            pts[i][1] - pts[i - 1][1],
-          );
-          segs.push(L);
-          total += L;
-        }
-        let want = t * total;
-        for (let i = 0; i < segs.length; i++) {
-          if (want <= segs[i]) {
-            const f = want / segs[i];
-            return [
-              pts[i][0] + (pts[i + 1][0] - pts[i][0]) * f,
-              pts[i][1] + (pts[i + 1][1] - pts[i][1]) * f,
-            ];
-          }
-          want -= segs[i];
-        }
-        return pts[pts.length - 1];
-      }
+      return pts[pts.length - 1];
+    }
 
-      const defs = svg.querySelector("defs");
-      for (const k of Object.keys(kindNames)) {
-        const m = el("marker", {
-          id: "arr-" + k,
-          viewBox: "0 0 10 10",
-          refX: 8,
-          refY: 5,
-          markerWidth: 5,
-          markerHeight: 5,
-          orient: "auto-start-reverse",
-        }, defs);
-        el(
-          "path",
-          { d: "M0,0 L10,5 L0,10 z", style: `fill: var(--k-${k})` },
-          m,
-        );
-      }
+    const defs = svg.querySelector("defs");
+    for (const k of Object.keys(kindNames)) {
+      const m = el("marker", {
+        id: "arr-" + k,
+        viewBox: "0 0 10 10",
+        refX: 8,
+        refY: 5,
+        markerWidth: 5,
+        markerHeight: 5,
+        orient: "auto-start-reverse",
+      }, defs);
+      el(
+        "path",
+        { d: "M0,0 L10,5 L0,10 z", style: `fill: var(--k-${k})` },
+        m,
+      );
+    }
 
-      const gBands = el("g", {}, world),
-        gGroups = el("g", {}, world),
-        gEdges = el("g", {}, world),
-        gNodes = el("g", {}, world),
-        gGates = el("g", {}, world),
-        gThreats = el("g", {}, world);
-      for (const b of bands) {
-        const g = el("g", {}, gBands);
-        el("rect", {
-          class: "band-rect " + b.id,
-          x: b.x,
-          y: b.y,
-          width: b.w,
-          height: b.h,
-        }, g);
-        const tt = el("text", {
-          class: "band-title " + b.id,
-          x: b.x + 20,
-          y: b.y + 38,
-        }, g);
-        tt.textContent = b.title;
-        const st = el(
-          "text",
-          { class: "band-sub", x: b.x + 20, y: b.y + 38 },
-          g,
-        );
-        st.textContent = "· " + b.sub;
-        requestAnimationFrame(() => {
-          st.setAttribute("x", b.x + 20 + tt.getBBox().width + 14);
-        });
-      }
-      const stamp = el("text", { class: "stamp", x: 250, y: 26 }, gBands);
-      stamp.textContent = `snapshot ${SNAPSHOT.date} · labs ${SNAPSHOT.sha}`;
-      document.querySelector("#stage .hud").textContent =
-        `snapshot ${SNAPSHOT.date} · labs ${SNAPSHOT.sha}  —  drag to pan · scroll to zoom · click anything for its story`;
-      const pt = el("text", { class: "group-title", x: 60, y: 540 }, gBands);
-      pt.textContent = "PRINCIPALS";
-      for (const g of groups) {
-        const gg = el("g", {}, gGroups);
-        el("rect", {
-          class: "group-rect",
-          x: g.x,
-          y: g.y,
-          width: g.w,
-          height: g.h,
-        }, gg);
-        const t = el(
-          "text",
-          { class: "group-title", x: g.x + 14, y: g.y + 24 },
-          gg,
-        );
-        t.textContent = g.title;
-      }
-
-      const edgePts = {};
-      for (const e of edges) {
-        const pts = e.pts;
-        edgePts[e.id] = pts;
-        const g = el("g", { class: "edge k-" + e.k, "data-id": e.id }, gEdges);
-        const d = pathD(pts);
-        el("path", { class: "hit", d }, g);
-        const p = el("path", { d }, g);
-        if (!e.bi) p.setAttribute("marker-end", `url(#arr-${e.k})`);
-        if (e.label) {
-          let x, y, anchor = "middle";
-          if (e.lp) {
-            [x, y] = e.lp;
-            anchor = e.lp[2] || "middle";
-          } else {
-            [x, y] = along(pts, 0.5);
-            y -= 9;
-          }
-          const t = el("text", { x, y, "text-anchor": anchor }, g);
-          t.textContent = e.label;
-        }
-      }
-      for (const n of nodes) {
-        const g = el("g", {
-          class: "node" + (n.attach ? " attach" : ""),
-          "data-id": n.id,
-          transform: `translate(${n.x},${n.y})`,
-        }, gNodes);
-        el("rect", { width: n.w, height: n.h }, g);
-        const ig = el("g", {
-          class: "ic",
-          transform: "translate(12,12) scale(1.1)",
-        }, g);
-        ig.innerHTML = icons[n.ic] || "";
-        const t = el("text", { x: 44, y: 32 }, g);
-        t.textContent = n.t;
-        const s = el("text", { class: "sub", x: 44, y: 54 }, g);
-        s.textContent = n.s;
-        (extraLines[n.id] || []).forEach((line, i) => {
-          const x = el("text", { class: "sub", x: 14, y: 78 + i * 20 }, g);
-          x.textContent = line;
-        });
-      }
-      for (const e of edges) {
-        if (e.gate) {
-          const gd = gateDefs[e.gate];
-          const [x, y] = along(edgePts[e.id], e.gt);
-          const g = el("g", {
-            class: "gate " + gd.status,
-            "data-id": e.gate,
-            transform: `translate(${x},${y})`,
-          }, gGates);
-          el("polygon", { points: "0,-24 24,0 0,24 -24,0" }, g);
-          el("path", {
-            class: "sh",
-            d: "M0,-11 l8,3 v5 c0,5 -3.5,9 -8,11 c-4.5,-2 -8,-6 -8,-11 v-5 z",
-            transform: "translate(0,1)",
-          }, g);
-          const l = el("text", {
-            class: "lbl",
-            "text-anchor": "middle",
-            y: e.gabove ? -36 : 44,
-          }, g);
-          l.textContent = gd.t;
-          const l2 = el("text", {
-            class: "st",
-            "text-anchor": "middle",
-            y: e.gabove ? -52 : 60,
-            "data-status": 1,
-            style: `fill: var(--s-${gd.status})`,
-          }, g);
-          l2.textContent = gd.short;
-        }
-      }
-      for (const t of threats) {
-        const g = el("g", {
-          class: "threat c-" + t.c,
-          "data-id": t.id,
-          transform: `translate(${t.x},${t.y})`,
-        }, gThreats);
-        el("polygon", {
-          class: "ring",
-          points: "0,-23 20,-11.5 20,11.5 0,23 -20,11.5 -20,-11.5",
-        }, g);
-        el("polygon", {
-          class: "mk",
-          points: "0,-18 15.6,-9 15.6,9 0,18 -15.6,9 -15.6,-9",
-        }, g);
-        const tx = el("text", { "text-anchor": "middle", y: 5 }, g);
-        tx.textContent = t.n;
-        if (t.c === "residual") {
-          const pg = el("g", {
-            class: "pg",
-            transform: "translate(11,-24) scale(.55)",
-          }, g);
-          pg.innerHTML = icons.person;
-        }
-      }
-
-      // ------------------------------------------------------------------ pan / zoom
-      const stage = document.getElementById("stage");
-      let vb = { x: 0, y: 0, w: W, h: H };
-      function applyVB() {
-        svg.setAttribute("viewBox", `${vb.x} ${vb.y} ${vb.w} ${vb.h}`);
-        const s = stage.getBoundingClientRect().width / vb.w;
-        svg.classList.toggle("z0", s < 0.7);
-        svg.classList.toggle("z1", s >= 0.7 && s < 1.05);
-        svg.classList.toggle("z2", s >= 1.05);
-      }
-      function fit(pad = 40) {
-        const r = stage.getBoundingClientRect();
-        const s = Math.min(r.width / (W + pad * 2), r.height / (H + pad * 2));
-        vb = {
-          w: r.width / s,
-          h: r.height / s,
-          x: -pad - (r.width / s - W - pad * 2) / 2,
-          y: -pad - (r.height / s - H - pad * 2) / 2,
-        };
-        applyVB();
-      }
-      function fitTo(ids, pad = 120) {
-        const boxes = [];
-        for (const id of ids) {
-          const n = N[id];
-          if (n) boxes.push([n.x, n.y, n.x + n.w, n.y + n.h]);
-          const g = gGates.querySelector(`[data-id="${id}"]`);
-          if (g) {
-            const m = g.transform.baseVal.getItem(0).matrix;
-            boxes.push([m.e - 70, m.f - 70, m.e + 70, m.f + 70]);
-          }
-          if (edgePts[id]) {
-            for (const p of edgePts[id]) boxes.push([p[0], p[1], p[0], p[1]]);
-          }
-          const th = threats.find((t) => t.id === id);
-          if (th) boxes.push([th.x - 24, th.y - 24, th.x + 24, th.y + 24]);
-        }
-        if (!boxes.length) return;
-        const x0 = Math.min(...boxes.map((b) => b[0])) - pad,
-          y0 = Math.min(...boxes.map((b) => b[1])) - pad,
-          x1 = Math.max(...boxes.map((b) => b[2])) + pad,
-          y1 = Math.max(...boxes.map((b) => b[3])) + pad;
-        const r = stage.getBoundingClientRect();
-        const s = Math.min(r.width / (x1 - x0), r.height / (y1 - y0), 0.9);
-        const target = { w: r.width / s, h: r.height / s };
-        target.x = (x0 + x1) / 2 - target.w / 2;
-        target.y = (y0 + y1) / 2 - target.h / 2;
-        animateTo(target);
-      }
-      let anim = null;
-      function animateTo(t) {
-        const from = { ...vb }, t0 = performance.now();
-        cancelAnimationFrame(anim);
-        const step = (now) => {
-          const k = Math.min(1, (now - t0) / 420), e = 1 - Math.pow(1 - k, 3);
-          vb = {
-            x: from.x + (t.x - from.x) * e,
-            y: from.y + (t.y - from.y) * e,
-            w: from.w + (t.w - from.w) * e,
-            h: from.h + (t.h - from.h) * e,
-          };
-          applyVB();
-          if (k < 1) anim = requestAnimationFrame(step);
-        };
-        anim = requestAnimationFrame(step);
-      }
-      let drag = null;
-      stage.addEventListener("pointerdown", (ev) => {
-        drag = {
-          x: ev.clientX,
-          y: ev.clientY,
-          vx: vb.x,
-          vy: vb.y,
-          moved: false,
-          target: ev.target,
-        };
-        stage.classList.add("dragging");
-        stage.setPointerCapture(ev.pointerId);
+    const gBands = el("g", {}, world),
+      gGroups = el("g", {}, world),
+      gEdges = el("g", {}, world),
+      gNodes = el("g", {}, world),
+      gGates = el("g", {}, world),
+      gThreats = el("g", {}, world);
+    for (const b of bands) {
+      const g = el("g", {}, gBands);
+      el("rect", {
+        class: "band-rect " + b.id,
+        x: b.x,
+        y: b.y,
+        width: b.w,
+        height: b.h,
+      }, g);
+      const tt = el("text", {
+        class: "band-title " + b.id,
+        x: b.x + 20,
+        y: b.y + 38,
+      }, g);
+      tt.textContent = b.title;
+      const st = el(
+        "text",
+        { class: "band-sub", x: b.x + 20, y: b.y + 38 },
+        g,
+      );
+      st.textContent = "· " + b.sub;
+      requestAnimationFrame(() => {
+        st.setAttribute("x", b.x + 20 + tt.getBBox().width + 14);
       });
-      stage.addEventListener("pointermove", (ev) => {
-        if (!drag) return;
-        const r = stage.getBoundingClientRect();
-        const s = vb.w / r.width;
-        const dx = ev.clientX - drag.x, dy = ev.clientY - drag.y;
-        if (Math.abs(dx) + Math.abs(dy) > 3) drag.moved = true;
-        vb.x = drag.vx - dx * s;
-        vb.y = drag.vy - dy * s;
-        applyVB();
-      });
-      stage.addEventListener("pointerup", (ev) => {
-        const moved = drag && drag.moved;
-        const tgt = drag && drag.target;
-        drag = null;
-        stage.classList.remove("dragging");
-        if (!moved && tgt) {
-          const t = tgt.closest("[data-id]");
-          if (t) select(t.dataset.id);
-        }
-      });
-      stage.addEventListener("wheel", (ev) => {
-        ev.preventDefault();
-        const r = stage.getBoundingClientRect();
-        const mx = vb.x + (ev.clientX - r.left) / r.width * vb.w,
-          my = vb.y + (ev.clientY - r.top) / r.height * vb.h;
-        const f = Math.exp(ev.deltaY * 0.0015);
-        const nw = Math.max(400, Math.min(W * 2, vb.w * f));
-        const k = nw / vb.w;
-        vb = {
-          w: nw,
-          h: vb.h * k,
-          x: mx - (mx - vb.x) * k,
-          y: my - (my - vb.y) * k,
-        };
-        applyVB();
-      }, { passive: false });
-      window.addEventListener("resize", () => fit());
-      fit();
-      document.getElementById("btnFit").onclick = () => {
-        exitStory();
-        fit();
-      };
-      document.getElementById("btnTheme").onclick = function () {
-        const html = document.documentElement;
-        const light = html.dataset.theme !== "light";
-        html.dataset.theme = light ? "light" : "dark";
-        this.textContent = light ? "Dark" : "Light";
-      };
+    }
+    const stamp = el("text", { class: "stamp", x: 250, y: 26 }, gBands);
+    stamp.textContent = `snapshot ${SNAPSHOT.date} · labs ${SNAPSHOT.sha}`;
+    document.querySelector("#stage .hud").textContent =
+      `snapshot ${SNAPSHOT.date} · labs ${SNAPSHOT.sha}  —  drag to pan · scroll to zoom · click anything for its story`;
+    const pt = el("text", { class: "group-title", x: 60, y: 540 }, gBands);
+    pt.textContent = "PRINCIPALS";
+    for (const g of groups) {
+      const gg = el("g", {}, gGroups);
+      el("rect", {
+        class: "group-rect",
+        x: g.x,
+        y: g.y,
+        width: g.w,
+        height: g.h,
+      }, gg);
+      const t = el(
+        "text",
+        { class: "group-title", x: g.x + 14, y: g.y + 24 },
+        gg,
+      );
+      t.textContent = g.title;
+    }
 
-      // ------------------------------------------------------------------ legends + toggles
-      const legend = document.getElementById("legend");
-      const kindOn = new Set(Object.keys(kindNames));
-      for (const k of Object.keys(kindNames)) {
-        const b = document.createElement("button");
-        b.className = "chip";
-        b.innerHTML = `<span class="sw ${kindNames[k][1]}"></span>${
-          kindNames[k][0]
-        }`;
-        b.style.color = `var(--k-${k})`;
-        b.onclick = () => {
-          if (kindOn.has(k)) kindOn.delete(k);
-          else kindOn.add(k);
-          b.classList.toggle("off", !kindOn.has(k));
-          refresh();
-        };
-        legend.appendChild(b);
-      }
-      let showThreats = true, showStatus = true;
-      const classOn = new Set(Object.keys(threatClass));
-      const tlegend = document.getElementById("tlegend");
-      for (const c of Object.keys(threatClass)) {
-        const b = document.createElement("button");
-        b.className = "chip";
-        b.innerHTML = `<span style="color:${
-          threatClass[c].color
-        };font-size:16px;line-height:0">⬢</span>${threatClass[c].name}`;
-        b.onclick = () => {
-          if (classOn.has(c)) classOn.delete(c);
-          else classOn.add(c);
-          b.classList.toggle("off", !classOn.has(c));
-          refresh();
-        };
-        tlegend.appendChild(b);
-      }
-      const glegend = document.getElementById("glegend");
-      for (const s of Object.keys(statusNames)) {
-        const b = document.createElement("span");
-        b.className = "chip";
-        b.style.cssText =
-          "display:inline-flex;align-items:center;gap:6px;font-size:13px;color:var(--muted)";
-        b.innerHTML =
-          `<span style="color:var(--s-${s});font-size:16px;line-height:0">${
-            s === "gap" || s === "intended" ? "◇" : "◆"
-          }</span>${statusNames[s]}`;
-        glegend.appendChild(b);
-      }
-      document.getElementById("btnThreats").onclick = function () {
-        showThreats = !showThreats;
-        this.classList.toggle("on", showThreats);
-        refresh();
-      };
-      document.getElementById("btnStatus").onclick = function () {
-        showStatus = !showStatus;
-        this.classList.toggle("on", showStatus);
-        refresh();
-      };
-
-      // ------------------------------------------------------------------ selection / detail
-      const detail = document.getElementById("detail");
-      let selected = null;
-      let story = null, stepI = 0;
-      const history = [];
-      function statusPill(s) {
-        return `<span class="status ${s}">${statusNames[s]}</span>`;
-      }
-      function linksHtml(links) {
-        return links && links.length
-          ? `<h3>Landed</h3><ul>${
-            links.map(([t, n]) => `<li>${PR(n)} ${t}</li>`).join("")
-          }</ul>`
-          : "";
-      }
-      function closeHtml(c) {
-        return c && c.length
-          ? `<h3>To close the circuit</h3><ul>${
-            c.map((x) => `<li>${x}</li>`).join("")
-          }</ul>`
-          : "";
-      }
-      function threatsHtml(ts) {
-        return ts && ts.length
-          ? `<h3>Threats here</h3><ul>${
-            ts.map((id) => {
-              const t = threats.find((x) => x.id === id);
-              const c = threatClass[t.c];
-              return `<li><a href="#" data-go="${id}">${t.n} · ${t.t}</a> <span class="status" style="background:${c.color};font-size:10px">${c.name}</span></li>`;
-            }).join("")
-          }</ul>`
-          : "";
-      }
-      function whereHtml(ids) {
-        return ids && ids.length
-          ? `<h3>Where</h3><p>${
-            ids.map((id) => {
-              const n = N[id];
-              const g = gateDefs[id];
-              return `<a href="#" data-go="${id}">${
-                n ? n.t : g ? g.t + " gate" : id
-              }</a>`;
-            }).join(" · ")
-          }</p>`
-          : "";
-      }
-      function renderDetail(id) {
-        let html = "";
-        const back = history.length > 1
-          ? `<a href="#" class="bk" data-back="1">← back</a><br>`
-          : "";
-        if (N[id]) {
-          const n = N[id], d = D[id] || {};
-          html = `${back}<span class="kind b-${n.band}">${
-            d.kind || n.band
-          }</span><h2>${n.t}</h2><p class="hint">${n.s}</p>${d.body || ""}${
-            linksHtml(d.links)
-          }${threatsHtml(d.threats)}${closeHtml(d.close)}`;
-        } else if (gateDefs[id]) {
-          const g = gateDefs[id], d = GD[id] || {};
-          html = `${back}<span class="kind">Gate · ${g.boundary}</span>${
-            statusPill(g.status)
-          }<h2>${g.t}</h2>${d.body || ""}${
-            d.why ? `<h3>Why it matters</h3><p>${d.why}</p>` : ""
-          }${linksHtml(d.links)}${threatsHtml(d.threats)}${closeHtml(d.close)}`;
-        } else if (id.startsWith("t")) {
-          const t = threats.find((x) => x.id === id),
-            d = TD[id] || {},
-            c = threatClass[t.c];
-          html =
-            `${back}<span class="kind">Threat ${t.n}</span><span class="status" style="background:${c.color}">${c.name}</span><h2>${t.t}</h2><p class="hint">${c.blurb}</p>${
-              d.body || ""
-            }${d.plan ? `<h3>What closes it</h3><p>${d.plan}</p>` : ""}${
-              whereHtml(d.where)
-            }`;
+    const edgePts = {};
+    for (const e of edges) {
+      const pts = e.pts;
+      edgePts[e.id] = pts;
+      const g = el("g", { class: "edge k-" + e.k, "data-id": e.id }, gEdges);
+      const d = pathD(pts);
+      el("path", { class: "hit", d }, g);
+      const p = el("path", { d }, g);
+      if (!e.bi) p.setAttribute("marker-end", `url(#arr-${e.k})`);
+      if (e.label) {
+        let x, y, anchor = "middle";
+        if (e.lp) {
+          [x, y] = e.lp;
+          anchor = e.lp[2] || "middle";
         } else {
-          const e = edges.find((x) => x.id === id);
-          if (e) {
-            const gd = e.gate && gateDefs[e.gate];
-            html =
-              `${back}<span class="kind" style="color:var(--k-${e.k});border-color:var(--k-${e.k})">${
-                kindNames[e.k][0]
-              }</span><h2>${N[e.from].t} → ${N[e.to].t}</h2>${
-                e.label ? `<p class="hint">${e.label}</p>` : ""
-              }${ED[id] || ""}${
-                gd
-                  ? `<h3>Gate on this edge</h3><p><a href="#" data-go="${e.gate}">${gd.t}</a> ${
-                    statusPill(gd.status)
-                  }</p>`
-                  : ""
-              }`;
-          }
+          [x, y] = along(pts, 0.5);
+          y -= 9;
         }
-        detail.innerHTML = html || welcome();
-        detail.scrollTop = 0;
-        detail.querySelectorAll("[data-go]").forEach((a) =>
-          a.onclick = (ev) => {
-            ev.preventDefault();
-            select(a.dataset.go, true);
-          }
-        );
-        const bk = detail.querySelector("[data-back]");
-        if (bk) {
-          bk.onclick = (ev) => {
-            ev.preventDefault();
-            history.pop();
-            const prev = history.pop();
-            select(prev, true);
-          };
-        }
+        const t = el("text", { x, y, "text-anchor": anchor }, g);
+        t.textContent = e.label;
       }
-      function welcome() {
-        return `<span class="kind">Start here</span><h2>How to read this map</h2><p>Four bands, top to bottom: what we never trust, what we mediate, what we must trust, and how we check ourselves. Data flows left to right; a colleague's request enters at the left and a rendered piece comes back to them there. Only the trusted computing base is tinted: it is the thing this map is about.</p><p><b>Diamonds are gates</b>: the only places a value may cross a boundary. Solid green shipped; solid amber partial; hollow red a gap; dashed gray intended.</p><p><b>Red-ringed hexagons are threats</b>, in three kinds. <span style="color:var(--s-partial)">⬢ closed by planned work</span>: a named gap with an owner. <span style="color:var(--s-shipped)">⬢ guarded by CFC</span>: held today. <span style="color:var(--s-intended)">⬢ remains</span>: CFC cannot close it; people and process hold it. Click one to see where it lives and what holds against it.</p><p><b>Dashed light-blue lines are handles</b>: names for data the model routes without ever holding. That line type is the whole idea. Bright white lines are labeled values inside the base; they never leave it except through a gate.</p><h3>Walks</h3><ul><li><b>The circuit</b>: label at the source → store per path → name don't carry → compute at the data → gated release → every sink a gate → prove it → what is still open.</li><li><b>Demo 1</b>: the Weaver pill, as it ran today.</li><li><b>Demo 2</b>: bills from Gmail and Plaid, with the loom-side gaps named.</li><li><b>Demo 3</b>: a hostile skill with nothing to steal.</li><li><b>Where we trust ourselves</b>: the base, ring by ring.</li></ul><p class="hint">Zoom in for edge labels and gate status captions; they hide at overview so the structure reads first.</p><p class="hint">Snapshot as of ${SNAPSHOT.date}, at labs commit <code>${SNAPSHOT.sha}</code>, fact-checked against the code, the live docs and the issues. Gate statuses follow the boundary inventory on CT-2175, the deviations list in the harness implementation profile, and what merged after both were written. Loom-side claims are from CT-2189 and not verified against loom's code.</p>`;
+    }
+    for (const n of nodes) {
+      const g = el("g", {
+        class: "node" + (n.attach ? " attach" : ""),
+        "data-id": n.id,
+        transform: `translate(${n.x},${n.y})`,
+      }, gNodes);
+      el("rect", { width: n.w, height: n.h }, g);
+      const ig = el("g", {
+        class: "ic",
+        transform: "translate(12,12) scale(1.1)",
+      }, g);
+      ig.innerHTML = icons[n.ic] || "";
+      const t = el("text", { x: 44, y: 32 }, g);
+      t.textContent = n.t;
+      const s = el("text", { class: "sub", x: 44, y: 54 }, g);
+      s.textContent = n.s;
+      (extraLines[n.id] || []).forEach((line, i) => {
+        const x = el("text", { class: "sub", x: 14, y: 78 + i * 20 }, g);
+        x.textContent = line;
+      });
+    }
+    for (const e of edges) {
+      if (e.gate) {
+        const gd = gateDefs[e.gate];
+        const [x, y] = along(edgePts[e.id], e.gt);
+        const g = el("g", {
+          class: "gate " + gd.status,
+          "data-id": e.gate,
+          transform: `translate(${x},${y})`,
+        }, gGates);
+        el("polygon", { points: "0,-24 24,0 0,24 -24,0" }, g);
+        el("path", {
+          class: "sh",
+          d: "M0,-11 l8,3 v5 c0,5 -3.5,9 -8,11 c-4.5,-2 -8,-6 -8,-11 v-5 z",
+          transform: "translate(0,1)",
+        }, g);
+        const l = el("text", {
+          class: "lbl",
+          "text-anchor": "middle",
+          y: e.gabove ? -36 : 44,
+        }, g);
+        l.textContent = gd.t;
+        const l2 = el("text", {
+          class: "st",
+          "text-anchor": "middle",
+          y: e.gabove ? -52 : 60,
+          "data-status": 1,
+          style: `fill: var(--s-${gd.status})`,
+        }, g);
+        l2.textContent = gd.short;
       }
-      function select(id, zoom) {
-        selected = id;
-        if (history[history.length - 1] !== id) history.push(id);
-        renderDetail(id);
-        refresh();
-        if (zoom) fitTo([id], 260);
+    }
+    for (const t of threats) {
+      const g = el("g", {
+        class: "threat c-" + t.c,
+        "data-id": t.id,
+        transform: `translate(${t.x},${t.y})`,
+      }, gThreats);
+      el("polygon", {
+        class: "ring",
+        points: "0,-23 20,-11.5 20,11.5 0,23 -20,11.5 -20,-11.5",
+      }, g);
+      el("polygon", {
+        class: "mk",
+        points: "0,-18 15.6,-9 15.6,9 0,18 -15.6,9 -15.6,-9",
+      }, g);
+      const tx = el("text", { "text-anchor": "middle", y: 5 }, g);
+      tx.textContent = t.n;
+      if (t.c === "residual") {
+        const pg = el("g", {
+          class: "pg",
+          transform: "translate(11,-24) scale(.55)",
+        }, g);
+        pg.innerHTML = icons.person;
       }
+    }
 
-      // ------------------------------------------------------------------ stories
-      const storyBox = document.getElementById("story");
-      function startStory(id) {
-        story = stories[id];
-        stepI = 0;
-        document.querySelectorAll("[data-story]").forEach((b) =>
-          b.classList.toggle("on", b.dataset.story === id)
-        );
-        storyBox.classList.add("on");
+    // ------------------------------------------------------------------ pan / zoom
+    const stage = document.getElementById("stage");
+    let vb = { x: 0, y: 0, w: W, h: H };
+    function applyVB() {
+      svg.setAttribute("viewBox", `${vb.x} ${vb.y} ${vb.w} ${vb.h}`);
+      const s = stage.getBoundingClientRect().width / vb.w;
+      svg.classList.toggle("z0", s < 0.7);
+      svg.classList.toggle("z1", s >= 0.7 && s < 1.05);
+      svg.classList.toggle("z2", s >= 1.05);
+    }
+    function fit(pad = 40) {
+      const r = stage.getBoundingClientRect();
+      const s = Math.min(r.width / (W + pad * 2), r.height / (H + pad * 2));
+      vb = {
+        w: r.width / s,
+        h: r.height / s,
+        x: -pad - (r.width / s - W - pad * 2) / 2,
+        y: -pad - (r.height / s - H - pad * 2) / 2,
+      };
+      applyVB();
+    }
+    function fitTo(ids, pad = 120) {
+      const boxes = [];
+      for (const id of ids) {
+        const n = N[id];
+        if (n) boxes.push([n.x, n.y, n.x + n.w, n.y + n.h]);
+        const g = gGates.querySelector(`[data-id="${id}"]`);
+        if (g) {
+          const m = g.transform.baseVal.getItem(0).matrix;
+          boxes.push([m.e - 70, m.f - 70, m.e + 70, m.f + 70]);
+        }
+        if (edgePts[id]) {
+          for (const p of edgePts[id]) boxes.push([p[0], p[1], p[0], p[1]]);
+        }
+        const th = threats.find((t) => t.id === id);
+        if (th) boxes.push([th.x - 24, th.y - 24, th.x + 24, th.y + 24]);
+      }
+      if (!boxes.length) return;
+      const x0 = Math.min(...boxes.map((b) => b[0])) - pad,
+        y0 = Math.min(...boxes.map((b) => b[1])) - pad,
+        x1 = Math.max(...boxes.map((b) => b[2])) + pad,
+        y1 = Math.max(...boxes.map((b) => b[3])) + pad;
+      const r = stage.getBoundingClientRect();
+      const s = Math.min(r.width / (x1 - x0), r.height / (y1 - y0), 0.9);
+      const target = { w: r.width / s, h: r.height / s };
+      target.x = (x0 + x1) / 2 - target.w / 2;
+      target.y = (y0 + y1) / 2 - target.h / 2;
+      animateTo(target);
+    }
+    let anim = null;
+    function animateTo(t) {
+      const from = { ...vb }, t0 = performance.now();
+      cancelAnimationFrame(anim);
+      const step = (now) => {
+        const k = Math.min(1, (now - t0) / 420), e = 1 - Math.pow(1 - k, 3);
+        vb = {
+          x: from.x + (t.x - from.x) * e,
+          y: from.y + (t.y - from.y) * e,
+          w: from.w + (t.w - from.w) * e,
+          h: from.h + (t.h - from.h) * e,
+        };
+        applyVB();
+        if (k < 1) anim = requestAnimationFrame(step);
+      };
+      anim = requestAnimationFrame(step);
+    }
+    let drag = null;
+    stage.addEventListener("pointerdown", (ev) => {
+      drag = {
+        x: ev.clientX,
+        y: ev.clientY,
+        vx: vb.x,
+        vy: vb.y,
+        moved: false,
+        target: ev.target,
+      };
+      stage.classList.add("dragging");
+      stage.setPointerCapture(ev.pointerId);
+    });
+    stage.addEventListener("pointermove", (ev) => {
+      if (!drag) return;
+      const r = stage.getBoundingClientRect();
+      const s = vb.w / r.width;
+      const dx = ev.clientX - drag.x, dy = ev.clientY - drag.y;
+      if (Math.abs(dx) + Math.abs(dy) > 3) drag.moved = true;
+      vb.x = drag.vx - dx * s;
+      vb.y = drag.vy - dy * s;
+      applyVB();
+    });
+    stage.addEventListener("pointerup", (ev) => {
+      const moved = drag && drag.moved;
+      const tgt = drag && drag.target;
+      drag = null;
+      stage.classList.remove("dragging");
+      if (!moved && tgt) {
+        const t = tgt.closest("[data-id]");
+        if (t) select(t.dataset.id);
+      }
+    });
+    stage.addEventListener("wheel", (ev) => {
+      ev.preventDefault();
+      const r = stage.getBoundingClientRect();
+      const mx = vb.x + (ev.clientX - r.left) / r.width * vb.w,
+        my = vb.y + (ev.clientY - r.top) / r.height * vb.h;
+      const f = Math.exp(ev.deltaY * 0.0015);
+      const nw = Math.max(400, Math.min(W * 2, vb.w * f));
+      const k = nw / vb.w;
+      vb = {
+        w: nw,
+        h: vb.h * k,
+        x: mx - (mx - vb.x) * k,
+        y: my - (my - vb.y) * k,
+      };
+      applyVB();
+    }, { passive: false });
+    window.addEventListener("resize", () => fit());
+    fit();
+    document.getElementById("btnFit").onclick = () => {
+      exitStory();
+      fit();
+    };
+    document.getElementById("btnTheme").onclick = function () {
+      const html = document.documentElement;
+      const light = html.dataset.theme !== "light";
+      html.dataset.theme = light ? "light" : "dark";
+      this.textContent = light ? "Dark" : "Light";
+    };
+
+    // ------------------------------------------------------------------ legends + toggles
+    const legend = document.getElementById("legend");
+    const kindOn = new Set(Object.keys(kindNames));
+    for (const k of Object.keys(kindNames)) {
+      const b = document.createElement("button");
+      b.className = "chip";
+      b.innerHTML = `<span class="sw ${kindNames[k][1]}"></span>${kindNames[k][0]}`;
+      b.style.color = `var(--k-${k})`;
+      b.onclick = () => {
+        if (kindOn.has(k)) kindOn.delete(k);
+        else kindOn.add(k);
+        b.classList.toggle("off", !kindOn.has(k));
+        refresh();
+      };
+      legend.appendChild(b);
+    }
+    let showThreats = true, showStatus = true;
+    const classOn = new Set(Object.keys(threatClass));
+    const tlegend = document.getElementById("tlegend");
+    for (const c of Object.keys(threatClass)) {
+      const b = document.createElement("button");
+      b.className = "chip";
+      b.innerHTML = `<span style="color:${
+        threatClass[c].color
+      };font-size:16px;line-height:0">⬢</span>${threatClass[c].name}`;
+      b.onclick = () => {
+        if (classOn.has(c)) classOn.delete(c);
+        else classOn.add(c);
+        b.classList.toggle("off", !classOn.has(c));
+        refresh();
+      };
+      tlegend.appendChild(b);
+    }
+    const glegend = document.getElementById("glegend");
+    for (const s of Object.keys(statusNames)) {
+      const b = document.createElement("span");
+      b.className = "chip";
+      b.style.cssText =
+        "display:inline-flex;align-items:center;gap:6px;font-size:13px;color:var(--muted)";
+      b.innerHTML =
+        `<span style="color:var(--s-${s});font-size:16px;line-height:0">${
+          s === "gap" || s === "intended" ? "◇" : "◆"
+        }</span>${statusNames[s]}`;
+      glegend.appendChild(b);
+    }
+    document.getElementById("btnThreats").onclick = function () {
+      showThreats = !showThreats;
+      this.classList.toggle("on", showThreats);
+      refresh();
+    };
+    document.getElementById("btnStatus").onclick = function () {
+      showStatus = !showStatus;
+      this.classList.toggle("on", showStatus);
+      refresh();
+    };
+
+    // ------------------------------------------------------------------ selection / detail
+    const detail = document.getElementById("detail");
+    let selected = null;
+    let story = null, stepI = 0;
+    const history = [];
+    function statusPill(s) {
+      return `<span class="status ${s}">${statusNames[s]}</span>`;
+    }
+    function linksHtml(links) {
+      return links && links.length
+        ? `<h3>Landed</h3><ul>${
+          links.map(([t, n]) => `<li>${PR(n)} ${t}</li>`).join("")
+        }</ul>`
+        : "";
+    }
+    function closeHtml(c) {
+      return c && c.length
+        ? `<h3>To close the circuit</h3><ul>${
+          c.map((x) => `<li>${x}</li>`).join("")
+        }</ul>`
+        : "";
+    }
+    function threatsHtml(ts) {
+      return ts && ts.length
+        ? `<h3>Threats here</h3><ul>${
+          ts.map((id) => {
+            const t = threats.find((x) => x.id === id);
+            const c = threatClass[t.c];
+            return `<li><a href="#" data-go="${id}">${t.n} · ${t.t}</a> <span class="status" style="background:${c.color};font-size:10px">${c.name}</span></li>`;
+          }).join("")
+        }</ul>`
+        : "";
+    }
+    function whereHtml(ids) {
+      return ids && ids.length
+        ? `<h3>Where</h3><p>${
+          ids.map((id) => {
+            const n = N[id];
+            const g = gateDefs[id];
+            return `<a href="#" data-go="${id}">${
+              n ? n.t : g ? g.t + " gate" : id
+            }</a>`;
+          }).join(" · ")
+        }</p>`
+        : "";
+    }
+    function renderDetail(id) {
+      let html = "";
+      const back = history.length > 1
+        ? `<a href="#" class="bk" data-back="1">← back</a><br>`
+        : "";
+      if (N[id]) {
+        const n = N[id], d = D[id] || {};
+        html = `${back}<span class="kind b-${n.band}">${
+          d.kind || n.band
+        }</span><h2>${n.t}</h2><p class="hint">${n.s}</p>${d.body || ""}${
+          linksHtml(d.links)
+        }${threatsHtml(d.threats)}${closeHtml(d.close)}`;
+      } else if (gateDefs[id]) {
+        const g = gateDefs[id], d = GD[id] || {};
+        html = `${back}<span class="kind">Gate · ${g.boundary}</span>${
+          statusPill(g.status)
+        }<h2>${g.t}</h2>${d.body || ""}${
+          d.why ? `<h3>Why it matters</h3><p>${d.why}</p>` : ""
+        }${linksHtml(d.links)}${threatsHtml(d.threats)}${closeHtml(d.close)}`;
+      } else if (id.startsWith("t")) {
+        const t = threats.find((x) => x.id === id),
+          d = TD[id] || {},
+          c = threatClass[t.c];
+        html =
+          `${back}<span class="kind">Threat ${t.n}</span><span class="status" style="background:${c.color}">${c.name}</span><h2>${t.t}</h2><p class="hint">${c.blurb}</p>${
+            d.body || ""
+          }${d.plan ? `<h3>What closes it</h3><p>${d.plan}</p>` : ""}${
+            whereHtml(d.where)
+          }`;
+      } else {
+        const e = edges.find((x) => x.id === id);
+        if (e) {
+          const gd = e.gate && gateDefs[e.gate];
+          html =
+            `${back}<span class="kind" style="color:var(--k-${e.k});border-color:var(--k-${e.k})">${
+              kindNames[e.k][0]
+            }</span><h2>${N[e.from].t} → ${N[e.to].t}</h2>${
+              e.label ? `<p class="hint">${e.label}</p>` : ""
+            }${ED[id] || ""}${
+              gd
+                ? `<h3>Gate on this edge</h3><p><a href="#" data-go="${e.gate}">${gd.t}</a> ${
+                  statusPill(gd.status)
+                }</p>`
+                : ""
+            }`;
+        }
+      }
+      detail.innerHTML = html || welcome();
+      detail.scrollTop = 0;
+      detail.querySelectorAll("[data-go]").forEach((a) =>
+        a.onclick = (ev) => {
+          ev.preventDefault();
+          select(a.dataset.go, true);
+        }
+      );
+      const bk = detail.querySelector("[data-back]");
+      if (bk) {
+        bk.onclick = (ev) => {
+          ev.preventDefault();
+          history.pop();
+          const prev = history.pop();
+          select(prev, true);
+        };
+      }
+    }
+    function welcome() {
+      return `<span class="kind">Start here</span><h2>How to read this map</h2><p>Four bands, top to bottom: what we never trust, what we mediate, what we must trust, and how we check ourselves. Data flows left to right; a colleague's request enters at the left and a rendered piece comes back to them there. Only the trusted computing base is tinted: it is the thing this map is about.</p><p><b>Diamonds are gates</b>: the only places a value may cross a boundary. Solid green shipped; solid amber partial; hollow red a gap; dashed gray intended.</p><p><b>Red-ringed hexagons are threats</b>, in three kinds. <span style="color:var(--s-partial)">⬢ closed by planned work</span>: a named gap with an owner. <span style="color:var(--s-shipped)">⬢ guarded by CFC</span>: held today. <span style="color:var(--s-intended)">⬢ remains</span>: CFC cannot close it; people and process hold it. Click one to see where it lives and what holds against it.</p><p><b>Dashed light-blue lines are handles</b>: names for data the model routes without ever holding. That line type is the whole idea. Bright white lines are labeled values inside the base; they never leave it except through a gate.</p><h3>Walks</h3><ul><li><b>The circuit</b>: label at the source → store per path → name don't carry → compute at the data → gated release → every sink a gate → prove it → what is still open.</li><li><b>Demo 1</b>: the Weaver pill, as it ran today.</li><li><b>Demo 2</b>: bills from Gmail and Plaid, with the loom-side gaps named.</li><li><b>Demo 3</b>: a hostile skill with nothing to steal.</li><li><b>Where we trust ourselves</b>: the base, ring by ring.</li></ul><p class="hint">Zoom in for edge labels and gate status captions; they hide at overview so the structure reads first.</p><p class="hint">Snapshot as of ${SNAPSHOT.date}, at labs commit <code>${SNAPSHOT.sha}</code>, fact-checked against the code, the live docs and the issues. Gate statuses follow the boundary inventory on CT-2175, the deviations list in the harness implementation profile, and what merged after both were written. Loom-side claims are from CT-2189 and not verified against loom's code.</p>`;
+    }
+    function select(id, zoom) {
+      selected = id;
+      if (history[history.length - 1] !== id) history.push(id);
+      renderDetail(id);
+      refresh();
+      if (zoom) fitTo([id], 260);
+    }
+
+    // ------------------------------------------------------------------ stories
+    const storyBox = document.getElementById("story");
+    function startStory(id) {
+      story = stories[id];
+      stepI = 0;
+      document.querySelectorAll("[data-story]").forEach((b) =>
+        b.classList.toggle("on", b.dataset.story === id)
+      );
+      storyBox.classList.add("on");
+      showStep();
+    }
+    function exitStory() {
+      story = null;
+      storyBox.classList.remove("on");
+      document.querySelectorAll("[data-story]").forEach((b) =>
+        b.classList.remove("on")
+      );
+      refresh();
+    }
+    function showStep() {
+      const s = story.steps[stepI];
+      document.getElementById("storyN").innerHTML = `${story.title}<small>step ${
+        stepI + 1
+      } of ${story.steps.length} · ← → move · Esc exits</small><div class="dots">${
+        story.steps.map((_, i) => `<i class="${i === stepI ? "on" : ""}"></i>`)
+          .join("")
+      }</div>`;
+      document.getElementById("storyT").innerHTML = `<b>${s.h}</b>${s.t}`;
+      selected = s.sel;
+      history.length = 0;
+      history.push(s.sel);
+      renderDetail(s.sel);
+      refresh();
+      fitTo(s.f, 160);
+      document.getElementById("sNext").textContent =
+        stepI === story.steps.length - 1 ? "Done" : "→";
+      document.getElementById("sPrev").disabled = stepI === 0;
+    }
+    document.querySelectorAll("[data-story]").forEach((b) =>
+      b.onclick = () => startStory(b.dataset.story)
+    );
+    document.getElementById("sPrev").onclick = () => {
+      if (stepI > 0) {
+        stepI--;
         showStep();
       }
-      function exitStory() {
-        story = null;
-        storyBox.classList.remove("on");
-        document.querySelectorAll("[data-story]").forEach((b) =>
-          b.classList.remove("on")
-        );
-        refresh();
-      }
-      function showStep() {
-        const s = story.steps[stepI];
-        document.getElementById("storyN").innerHTML =
-          `${story.title}<small>step ${
-            stepI + 1
-          } of ${story.steps.length} · ← → move · Esc exits</small><div class="dots">${
-            story.steps.map((_, i) =>
-              `<i class="${i === stepI ? "on" : ""}"></i>`
-            ).join("")
-          }</div>`;
-        document.getElementById("storyT").innerHTML = `<b>${s.h}</b>${s.t}`;
-        selected = s.sel;
-        history.length = 0;
-        history.push(s.sel);
-        renderDetail(s.sel);
-        refresh();
-        fitTo(s.f, 160);
-        document.getElementById("sNext").textContent =
-          stepI === story.steps.length - 1 ? "Done" : "→";
-        document.getElementById("sPrev").disabled = stepI === 0;
-      }
-      document.querySelectorAll("[data-story]").forEach((b) =>
-        b.onclick = () => startStory(b.dataset.story)
-      );
-      document.getElementById("sPrev").onclick = () => {
-        if (stepI > 0) {
-          stepI--;
-          showStep();
-        }
-      };
-      document.getElementById("sNext").onclick = () => {
-        if (stepI < story.steps.length - 1) {
-          stepI++;
-          showStep();
-        } else {
-          exitStory();
-          fit();
-        }
-      };
-      document.getElementById("sClose").onclick = () => {
+    };
+    document.getElementById("sNext").onclick = () => {
+      if (stepI < story.steps.length - 1) {
+        stepI++;
+        showStep();
+      } else {
         exitStory();
         fit();
-      };
-      window.addEventListener("keydown", (ev) => {
-        if (!story) return;
-        if (ev.key === "ArrowRight") document.getElementById("sNext").click();
-        if (ev.key === "ArrowLeft") document.getElementById("sPrev").click();
-        if (ev.key === "Escape") document.getElementById("sClose").click();
-      });
+      }
+    };
+    document.getElementById("sClose").onclick = () => {
+      exitStory();
+      fit();
+    };
+    window.addEventListener("keydown", (ev) => {
+      if (!story) return;
+      if (ev.key === "ArrowRight") document.getElementById("sNext").click();
+      if (ev.key === "ArrowLeft") document.getElementById("sPrev").click();
+      if (ev.key === "Escape") document.getElementById("sClose").click();
+    });
 
-      // ------------------------------------------------------------------ refresh classes
-      function refresh() {
-        const focus = story ? new Set(story.steps[stepI].f) : null;
-        const related = new Set();
-        if (selected) {
-          related.add(selected);
-          const e = edges.find((x) => x.id === selected);
-          if (e) {
+    // ------------------------------------------------------------------ refresh classes
+    function refresh() {
+      const focus = story ? new Set(story.steps[stepI].f) : null;
+      const related = new Set();
+      if (selected) {
+        related.add(selected);
+        const e = edges.find((x) => x.id === selected);
+        if (e) {
+          related.add(e.from);
+          related.add(e.to);
+          if (e.gate) related.add(e.gate);
+        }
+        for (const e of edges) {
+          if (e.gate === selected) {
+            related.add(e.id);
             related.add(e.from);
             related.add(e.to);
+          }
+          if (N[selected] && (e.from === selected || e.to === selected)) {
+            related.add(e.id);
             if (e.gate) related.add(e.gate);
           }
-          for (const e of edges) {
-            if (e.gate === selected) {
-              related.add(e.id);
-              related.add(e.from);
-              related.add(e.to);
-            }
-            if (N[selected] && (e.from === selected || e.to === selected)) {
-              related.add(e.id);
-              if (e.gate) related.add(e.gate);
-            }
-          }
-          const td = TD[selected];
-          if (td && td.where) td.where.forEach((w) => related.add(w));
         }
-        world.querySelectorAll("[data-id]").forEach((g) => {
-          const id = g.dataset.id;
-          const isEdge = g.classList.contains("edge");
-          const isThreat = g.classList.contains("threat");
-          const isGate = g.classList.contains("gate");
-          g.classList.toggle("sel", id === selected);
-          let dim = false, foc = false;
-          if (focus) {
-            foc = focus.has(id) || (isEdge && (() => {
-              const e = edges.find((x) => x.id === id);
-              return e && e.gate && focus.has(e.gate);
-            })());
-            dim = !foc;
-          } else if (selected) {
-            foc = related.has(id) && id !== selected;
-            dim = !related.has(id);
-          }
-          if (isEdge) {
-            const e = edges.find((x) => x.id === id);
-            if (!kindOn.has(e.k)) dim = true;
-          }
-          if (isThreat) {
-            g.classList.toggle(
-              "hidden",
-              !showThreats || !classOn.has(threats.find((t) => t.id === id).c),
-            );
-          }
-          if (isGate) {
-            g.querySelector("[data-status]").style.visibility = showStatus
-              ? ""
-              : "hidden";
-            for (const s of Object.keys(statusNames)) {
-              g.classList.toggle(s, showStatus && gateDefs[id].status === s);
-            }
-            g.classList.toggle(
-              "intended",
-              showStatus ? gateDefs[id].status === "intended" : true,
-            );
-          }
-          g.classList.toggle("dim", dim);
-          g.classList.toggle("focus", foc || id === selected);
-        });
+        const td = TD[selected];
+        if (td && td.where) td.where.forEach((w) => related.add(w));
       }
-      renderDetail("");
-      refresh();
+      world.querySelectorAll("[data-id]").forEach((g) => {
+        const id = g.dataset.id;
+        const isEdge = g.classList.contains("edge");
+        const isThreat = g.classList.contains("threat");
+        const isGate = g.classList.contains("gate");
+        g.classList.toggle("sel", id === selected);
+        let dim = false, foc = false;
+        if (focus) {
+          foc = focus.has(id) || (isEdge && (() => {
+            const e = edges.find((x) => x.id === id);
+            return e && e.gate && focus.has(e.gate);
+          })());
+          dim = !foc;
+        } else if (selected) {
+          foc = related.has(id) && id !== selected;
+          dim = !related.has(id);
+        }
+        if (isEdge) {
+          const e = edges.find((x) => x.id === id);
+          if (!kindOn.has(e.k)) dim = true;
+        }
+        if (isThreat) {
+          g.classList.toggle(
+            "hidden",
+            !showThreats || !classOn.has(threats.find((t) => t.id === id).c),
+          );
+        }
+        if (isGate) {
+          g.querySelector("[data-status]").style.visibility = showStatus
+            ? ""
+            : "hidden";
+          for (const s of Object.keys(statusNames)) {
+            g.classList.toggle(s, showStatus && gateDefs[id].status === s);
+          }
+          g.classList.toggle(
+            "intended",
+            showStatus ? gateDefs[id].status === "intended" : true,
+          );
+        }
+        g.classList.toggle("dim", dim);
+        g.classList.toggle("focus", foc || id === selected);
+      });
+    }
+    renderDetail("");
+    refresh();
     </script>
   </body>
 </html>

--- a/packages/cf-harness/docs/system-map/cfc-system-map.html
+++ b/packages/cf-harness/docs/system-map/cfc-system-map.html
@@ -387,6 +387,12 @@
         stroke-dasharray: 6 5;
         rx: 14;
       }
+      .stamp {
+        font-size: 22px;
+        fill: var(--muted);
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+        letter-spacing: 0.04em;
+      }
       .group-title {
         font-size: 14px;
         fill: var(--muted);
@@ -658,6 +664,9 @@
     </div>
     <script>
       // ------------------------------------------------------------------ layout data
+      // The state of this repository the map describes. Bump both when the
+      // map is re-verified; the stamp is drawn in the canvas's top-left corner.
+      const SNAPSHOT = { date: "2026-09-02", sha: "80ddb05554" };
       const W = 2760, H = 1840;
       const bands = [
         {
@@ -2603,6 +2612,10 @@
           st.setAttribute("x", b.x + 20 + tt.getBBox().width + 14);
         });
       }
+      const stamp = el("text", { class: "stamp", x: 250, y: 26 }, gBands);
+      stamp.textContent = `snapshot ${SNAPSHOT.date} · labs ${SNAPSHOT.sha}`;
+      document.querySelector("#stage .hud").textContent =
+        `snapshot ${SNAPSHOT.date} · labs ${SNAPSHOT.sha}  —  drag to pan · scroll to zoom · click anything for its story`;
       const pt = el("text", { class: "group-title", x: 60, y: 540 }, gBands);
       pt.textContent = "PRINCIPALS";
       for (const g of groups) {
@@ -3019,7 +3032,7 @@
         }
       }
       function welcome() {
-        return `<span class="kind">Start here</span><h2>How to read this map</h2><p>Four bands, top to bottom: what we never trust, what we mediate, what we must trust, and how we check ourselves. Data flows left to right; a colleague's request enters at the left and a rendered piece comes back to them there. Only the trusted computing base is tinted: it is the thing this map is about.</p><p><b>Diamonds are gates</b>: the only places a value may cross a boundary. Solid green shipped; solid amber partial; hollow red a gap; dashed gray intended.</p><p><b>Red-ringed hexagons are threats</b>, in three kinds. <span style="color:var(--s-partial)">⬢ closed by planned work</span>: a named gap with an owner. <span style="color:var(--s-shipped)">⬢ guarded by CFC</span>: held today. <span style="color:var(--s-intended)">⬢ remains</span>: CFC cannot close it; people and process hold it. Click one to see where it lives and what holds against it.</p><p><b>Dashed light-blue lines are handles</b>: names for data the model routes without ever holding. That line type is the whole idea. Bright white lines are labeled values inside the base; they never leave it except through a gate.</p><h3>Walks</h3><ul><li><b>The circuit</b>: label at the source → store per path → name don't carry → compute at the data → gated release → every sink a gate → prove it → what is still open.</li><li><b>Demo 1</b>: the Weaver pill, as it ran today.</li><li><b>Demo 2</b>: bills from Gmail and Plaid, with the loom-side gaps named.</li><li><b>Demo 3</b>: a hostile skill with nothing to steal.</li><li><b>Where we trust ourselves</b>: the base, ring by ring.</li></ul><p class="hint">Zoom in for edge labels and gate status captions; they hide at overview so the structure reads first.</p><p class="hint">Snapshot as of 2026-09-02, fact-checked against the code, the live docs and the issues. Gate statuses follow the boundary inventory on CT-2175, the deviations list in the harness implementation profile, and what merged after both were written. Loom-side claims are from CT-2189 and not verified against loom's code.</p>`;
+        return `<span class="kind">Start here</span><h2>How to read this map</h2><p>Four bands, top to bottom: what we never trust, what we mediate, what we must trust, and how we check ourselves. Data flows left to right; a colleague's request enters at the left and a rendered piece comes back to them there. Only the trusted computing base is tinted: it is the thing this map is about.</p><p><b>Diamonds are gates</b>: the only places a value may cross a boundary. Solid green shipped; solid amber partial; hollow red a gap; dashed gray intended.</p><p><b>Red-ringed hexagons are threats</b>, in three kinds. <span style="color:var(--s-partial)">⬢ closed by planned work</span>: a named gap with an owner. <span style="color:var(--s-shipped)">⬢ guarded by CFC</span>: held today. <span style="color:var(--s-intended)">⬢ remains</span>: CFC cannot close it; people and process hold it. Click one to see where it lives and what holds against it.</p><p><b>Dashed light-blue lines are handles</b>: names for data the model routes without ever holding. That line type is the whole idea. Bright white lines are labeled values inside the base; they never leave it except through a gate.</p><h3>Walks</h3><ul><li><b>The circuit</b>: label at the source → store per path → name don't carry → compute at the data → gated release → every sink a gate → prove it → what is still open.</li><li><b>Demo 1</b>: the Weaver pill, as it ran today.</li><li><b>Demo 2</b>: bills from Gmail and Plaid, with the loom-side gaps named.</li><li><b>Demo 3</b>: a hostile skill with nothing to steal.</li><li><b>Where we trust ourselves</b>: the base, ring by ring.</li></ul><p class="hint">Zoom in for edge labels and gate status captions; they hide at overview so the structure reads first.</p><p class="hint">Snapshot as of ${SNAPSHOT.date}, at labs commit <code>${SNAPSHOT.sha}</code>, fact-checked against the code, the live docs and the issues. Gate statuses follow the boundary inventory on CT-2175, the deviations list in the harness implementation profile, and what merged after both were written. Loom-side claims are from CT-2189 and not verified against loom's code.</p>`;
       }
       function select(id, zoom) {
         selected = id;


### PR DESCRIPTION
## What

`packages/cf-harness/docs/system-map/cfc-system-map.html`: a self-contained, pannable map of the harness and the runtime around it, drawn by trust boundary. Four bands from what we never trust to how we check ourselves; every gate on the boundary it decides, colored by status (shipped, partial, gap, intended); every threat classed as closed by planned work, guarded by CFC today, or held by people and process. Click anything for its story; five guided walks follow the CFC circuit, the three demo issues (CT-2190, CT-2189, CT-2091), and the trusted base ring by ring. Light and dark themes for projection.

Presented to the team on 2026-09-02 and approved for the repository.

## Accuracy

Every sentence on the map was fact-checked against the harness and runner code, the live documents (package README, CURRENT_STATE, IMPLEMENTATION_PROFILE deviations, EXPERIMENTAL_OPTIONS) and the issues, including what merged after CT-2175's boundary inventory was written (#6759, #6757). Loom-side connector claims come from CT-2189 and the map says they are not verified against loom's code.

## Keeping it true

The map is hand-authored, not generated. Its README records where each claim comes from, which data tables in the file hold the content, and the accuracy and visual review procedure that shaped this version, so the next update is an edit plus a re-verification rather than a rebuild.

## Checks run

`deno fmt --check`, `deno task check-control-characters`, `deno task check-conflict-markers`. The formatted file was re-verified in a browser (no console errors, walks and selection working).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6780?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

