### PR TITLE
fix(test-selection): bring the selection system in line with its plan

### DIFF
--- a/docs/plans/pull-request-test-selection.md
+++ b/docs/plans/pull-request-test-selection.md
@@ -473,14 +473,17 @@ is what the feedback loop then closes. The deploy and attestation jobs stay exac
 are, since they only ever ran on `main`.
 
 **`cli-fuse` carries the fine granularity the rest of this depends on.**
-`packages/cli/integration/fuse-exec.sh` records 25 identities, one for each
-phase it goes through, through the `cf_test_step_begin` markers
-`integration.sh` also uses. Each marker leads the phase it names, so a
-phase that fails is the record that carries the failure, and the two
-phases that bring the mount up and wait for it to hydrate record like the
-rest, so a mount that never comes up is reported as the mount. Scoring, the flake rate and the
-60-second ratchet each get a number per phase where they had one covering
-a FUSE mount, a Toolshed server and everything the script does with them.
+`packages/cli/integration/fuse-exec.sh` records an identity for each phase
+it goes through, through the `cf_test_step_begin` markers `integration.sh`
+also uses. Its 23 phases record under 25 names, because one of them
+announces under one of three sentences depending on how deeply it probes,
+and each of those is an identity of its own. Each marker leads the phase
+it names, so a phase that fails is the record that carries the failure,
+and the two phases that bring the mount up and wait for it to hydrate
+record like the rest, so a mount that never comes up is reported as the
+mount. Scoring, the flake rate and the 60-second ratchet each get a
+number per phase where they had one covering a FUSE mount, a Toolshed
+server and everything the script does with them.
 
 The script also takes a section, so a lane can be pointed at part of it.
 Which phases can stand alone was a question about the script rather than
@@ -490,7 +493,12 @@ is four sections rather than one per phase. A section is a group of phases over 
 mount rather than a phase on its own, because the mount, the daemon and
 the piece cost more than every phase together and each section needs all
 three. Four phases therefore run whichever section was asked for, and are
-not selectable.
+not selectable. A fifth is not selectable for the same reason without
+being in that group: the phase that puts the callable files in place is a
+precondition of three of the four sections, so each of those runs it
+first. The rule the topology applies covers both — a phase more than one
+section runs names no single section, so it is a suite-level record
+rather than one belonging to a unit.
 
 Two dependencies decide where the boundaries fall, and both are about
 state a phase leaves behind. The handler phases assert `messageCount` as
@@ -724,7 +732,7 @@ build's 17,999 executions.
 | One gate command | `repo-gates` | One, named for the gate that ran | Nothing to reach. |
 | One `deno check` invocation | `typecheck` | One, named for the path group it checked, which the task records itself | Nothing to reach. |
 | A whole task carrying one record | `cfcheck`, `pattern-vintage` | One, for everything the task did | Nothing to reach, and nothing finer exists: the suite is its own identity. |
-| A section of `fuse-exec.sh` | `cli-fuse` | The four phases every section runs, and the phases that section selects | Nothing to reach below the section. A mount comes up for the section, not for the phase, so its phases run or are skipped together. |
+| A section of `fuse-exec.sh` | `cli-fuse` | The phases that section alone selects. The phases more than one section runs record against the suite instead, since they name no single section | Nothing to reach below the section. A mount comes up for the section, not for the phase, so its phases run or are skipped together. |
 
 Six of the eight rows are one identity per invocation, which is why this
 change is smaller than removing a concept sounds. The topology does not
@@ -2012,7 +2020,8 @@ The object carries:
   `suiteOverhead` and `correction` per suite;
 - every item: its complete identity or identities, optional variants
   included, its suite, its file, its cost, its score, the inputs behind
-  that score, its flake rate, and its repeat count;
+  that score, its flake rate, its repeat count, and the last day
+  anything ran it, which is what orders the exploration draw;
 - the withheld sets — failing on `main`, and above the flake exclusion
   rate — each with the reason, so a lane can say why something is absent;
 - the tests declared unavailable in a configuration-specific skip
@@ -3119,6 +3128,8 @@ tape measure.
 | `ENVIRONMENTAL_MIN_SOURCES` | 5 | sources | Chosen | How many distinct sources a failure spans inside that window before it reads as the environment. Up when a genuinely broad regression is written off; down when a broken runner's failures still count as catches. |
 | `BREADTH_SATURATION` | 2 | sources | Chosen | Where the breadth term reaches half its ceiling. Up when four sources should outrank one by more; down when one source should already be worth nearly all of it. |
 | `CHURN_WINDOW_DAYS` | 60 | days | Chosen | How far back the decayed counts are read. Past this the weight is under one part in sixteen, so this is a performance decision rather than a policy one. |
+| `SAME_COMMIT_REACH_DAYS` | 2 | days | Chosen | How far back the fold remembers a commit's outcomes, so that a rerun landing in a later batch than the run it repeats is still read as the test disagreeing with itself. Up when reruns land far enough behind that their disagreement is counted as a catch; down when the fold's memory is what will not fit. It costs the number of identities that have failed times the number of commits, so it is the first dial to look at when a publisher run runs out of memory. |
+| `FLAKE_COMMIT_REACH` | 8 | commits | Chosen | How many of the most recently observed commits the fold keeps outcomes at, alongside the span above. Moves for the same two reasons and against the same cost. |
 | `FLAKE_WINDOW_DAYS` | 60 | days | Chosen | Up when a flake rate swings about on too little evidence; down when a test since fixed stays excluded. |
 | `COST_WINDOW_DAYS` | 7 | days | Chosen | Up when cost estimates are noisy; down when durations drift faster than the estimate follows. |
 | `ATTRIBUTION_MAP_DAYS` | 7 | days | Chosen | Up when rebuilding the map costs more than its staleness does; down when changed lines keep resolving to tests that have moved. |
@@ -3270,11 +3281,16 @@ answers somewhere people can see them.
       durably pending. Readers do not use the journal before that receipt.
 - [ ] Build the next rollup format from journal entries through a recorded
       position, accounting exactly once for every eligible entry through
-      that position for its source and date. Give bootstrap and ordinary
-      publishing one source-and-date input planner over those rollups and
-      later journal entries. Replace the date-only compacted receipt and
-      keep local records on their raw path until they have rollups of their
-      own.
+      that position for its source and date, and let the input plan
+      consume the journal entries after a rollup's position.
+  - [x] One source-and-date input plan, which bootstrap and ordinary
+        publishing both apply. A flag is permission to start from an
+        empty aggregate and a wider default window, and nothing else
+        decides what is read.
+  - [x] A source-scoped receipt in place of the date-only one, so that a
+        rollup of the shared area cannot say a day is accounted for and
+        take that day's local submissions with it. Local records stay on
+        their raw path until they have rollups of their own.
 - [ ] Rebuild aggregates seeded from version-one rollups; do not migrate
       their ambiguous date receipts into journal cursors.
 - [ ] Once readers have migrated to the journal, keep partition listing as
@@ -3295,8 +3311,9 @@ answers somewhere people can see them.
         catches, but over unbounded history, so a rate needs the state to
         keep those per day as well as in total.
 - [x] The `deno task test-selection` entry point and its modes: `dials`,
-      `coverage`, `explain <identity>`, and `plan` with `--dry-run`.
-      `--verify` needs the topology and lands with part two.
+      `coverage`, `explain <identity>`, and `plan` with `--dry-run` and
+      `--verify`. Every mode that packs reads the topology, so the
+      capability setup a lane opens is charged here as it is there.
 
 On its own this part gives the repository a flake list derived from
 evidence rather than from anecdote, and a coverage trend nobody has today.
@@ -3316,7 +3333,7 @@ exercised on the branch on its own.
       distinguishes item identities from overlapping suite-level
       measurements, and returns at most one item for an identity that
       several arms or entry points can run. Add `tasks/ci-capabilities.ts`.
-      Twenty suites hold 2,360 units. The repository gates are two
+      Twenty suites hold 2,396 units. The repository gates are two
       suites rather than one, because `mandatory` belongs to a suite and
       the `always` set has to stay tiny: `repo-gates` holds formatting,
       linting and the drift guard, and `repo-checks` holds the rest of
@@ -3327,11 +3344,13 @@ exercised on the branch on its own.
       only the named leaf identity from unknown and coverage rules.
 - [x] Give `packages/cli/integration/fuse-exec.sh` fine granularity.
   - [x] Every phase records, so the suite records 25 identities rather
-        than one. Each marker leads the phase it names, through the same
+        than one, across the 23 phases the script goes through. Each
+        marker leads the phase it names, through the same
         `cf_test_step_begin` `integration.sh` uses, so a phase that fails
-        is the record that carries the failure rather than the script's own
-        record carrying it. The two phases that bring the mount up are the
-        identities this adds beyond the 23 the phases already named.
+        is the record that carries the failure rather than the script's
+        own record carrying it. The two phases that bring the mount up
+        are the identities this adds beyond the phases that already
+        named one.
   - [x] It gains a section dispatch over the four groups of phases that
         stand alone, so `cli-fuse` becomes an item suite like its sibling.
         A section is a group of phases over one mount, and the
@@ -3357,12 +3376,15 @@ exercised on the branch on its own.
       would be found only on `main`.
 - [x] `tasks/check-test-topology.ts`, both halves, wired into
       `repo-gates`, with exact variant matching and one source-item claim
-      allowed per variant. Its first run found ten test files that
-      nothing in this repository executes; they are recorded with the
-      reason each runs nowhere and reported rather than failed on, so a
-      new unclaimed surface still fails. The five projects under
-      `packages/deno-web-test/test/` that the harness drives are declared
-      as the fixtures they are.
+      allowed per variant. Two test files under
+      `packages/cf-harness/integration/` are reached only by a package
+      task nothing dispatches; they are recorded with the reason each
+      runs nowhere and reported rather than failed on, so a new
+      unclaimed surface still fails. Eight paths that look like tests
+      and are not are declared as the fixtures they are: the five
+      projects under `packages/deno-web-test/test/` that the harness
+      drives, and the three command-line tours the verb-session gate
+      holds the documentation to rather than running.
 - [x] Extract the part of `tasks/test-records-gather.ts` that reads records,
       ingests JUnit, and applies a declared variant as the shared gather
       function. Its command-line entry point and `tasks/ci-lane.ts` both

--- a/packages/test-support/src/records/selection.test.ts
+++ b/packages/test-support/src/records/selection.test.ts
@@ -246,6 +246,14 @@ describe("selection", () => {
         "an independence flag that is not one",
         withField("independent", "yes", "entry"),
       ],
+      [
+        "a last run that is not a day",
+        withField("lastRun", 7, "entry"),
+      ],
+      [
+        "a last run that names no day at all",
+        withField("lastRun", "", "entry"),
+      ],
 
       // The lists a manifest carries beside its entries. Each has its own
       // reader, and each rejects the manifest whole.
@@ -466,6 +474,7 @@ describe("selection", () => {
         }],
       });
       manifest.entries[0]!.independent = true;
+      manifest.entries[0]!.lastRun = "2026-08-20";
       manifest.entries[0]!.inputs.lastCatch = "2026-08-20";
       expect(parseManifest(serializeManifest(manifest))).toEqual(manifest);
     });

--- a/packages/test-support/src/records/selection.ts
+++ b/packages/test-support/src/records/selection.ts
@@ -68,6 +68,14 @@ export interface ManifestEntry {
   repeats: number;
 
   /**
+   * The last day anything is known to have run it, absent where nothing
+   * within the aggregate's reach has. The exploration draw takes the
+   * longest-unrun first, so this is what stops the draw sampling the
+   * same corpus with replacement forever.
+   */
+  lastRun?: string;
+
+  /**
    * Whether it has been shown to pass as the only test in its unit. Until
    * it has, its siblings are not skipped and the unit is what runs.
    */
@@ -290,6 +298,9 @@ function parseEntry(value: unknown): ManifestEntry | undefined {
   ) {
     return undefined;
   }
+  if (value.lastRun !== undefined && !isNonEmptyString(value.lastRun)) {
+    return undefined;
+  }
   const entry: ManifestEntry = {
     test,
     suite: value.suite,
@@ -300,6 +311,7 @@ function parseEntry(value: unknown): ManifestEntry | undefined {
     flakeRate: value.flakeRate,
     repeats: value.repeats,
   };
+  if (value.lastRun !== undefined) entry.lastRun = value.lastRun;
   if (value.independent !== undefined) entry.independent = value.independent;
   return entry;
 }

--- a/tasks/ci-lane.test.ts
+++ b/tasks/ci-lane.test.ts
@@ -1,12 +1,17 @@
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
-import { testIdentityKey } from "@commonfabric/test-support/records";
+import {
+  type TestIdentity,
+  testIdentityKey,
+  type TestRecord,
+} from "@commonfabric/test-support/records";
 import { loadTopology } from "./test-topology.ts";
 
 import {
   batchesOf,
   changedFiles,
   describePlan,
+  describeWithheld,
   everyBatch,
   main,
   mandatoryFor,
@@ -551,6 +556,47 @@ describe("running a lane's work", () => {
     expect(printed).toContain("build-binary toolshed");
   });
 
+  it("says what each batch costs and why each test is in it", () => {
+    // "Why did my test not run" is the question a selected run provokes,
+    // and a summary naming only the suites cannot begin to answer it.
+    const entry: ManifestEntry = {
+      test: { k: "unit", s: "bakery", n: "glaze > sets" },
+      suite: "workspace-unit",
+      unit: "packages/bakery/glaze.test.ts",
+      cost: 1.5,
+      score: 0.5,
+      inputs: { catches: 0, mainCatches: 0, sources: 0, churn: 0 },
+      flakeRate: 0,
+      repeats: 1,
+    };
+    const lines: string[] = [];
+    const log = console.log;
+    console.log = (line: string) => lines.push(line);
+    try {
+      describePlan(
+        lane,
+        [{
+          suite: runnable(["true"], "workspace-unit"),
+          units: [{ unit: "packages/bakery/glaze.test.ts", skip: [] }],
+          repeats: 2,
+        }],
+        ["deno"],
+        { objectName: "manifest-x.json.gz" },
+        [],
+        {
+          selections: [{ entry, reason: "value", repeats: 2 }],
+          projectedSeconds: 96,
+        },
+      );
+    } finally {
+      console.log = log;
+    }
+    const printed = lines.join("\n");
+    expect(printed).toContain("Projected: 96s");
+    expect(printed).toContain("3.0s");
+    expect(printed).toContain("value 1");
+  });
+
   it("says it is running unselected when there is no manifest", () => {
     const lines: string[] = [];
     const log = console.log;
@@ -561,6 +607,44 @@ describe("running a lane's work", () => {
       console.log = log;
     }
     expect(lines.join("\n")).toContain("the store is unreachable");
+  });
+
+  it("names what the manifest withheld, and what came back", () => {
+    const red = { k: "unit", s: "bakery", n: "glaze > sets" };
+    const flaky = { k: "unit", s: "bakery", n: "proof > rises" };
+    const lines: string[] = [];
+    const log = console.log;
+    console.log = (line: string) => lines.push(line);
+    try {
+      describeWithheld(
+        [
+          { test: red, suite: "workspace-unit", reason: "main-red" },
+          { test: flaky, suite: "workspace-unit", reason: "flaky" },
+        ],
+        new Map([[testIdentityKey(red), "changed"]]),
+      );
+    } finally {
+      console.log = log;
+    }
+    const printed = lines.join("\n");
+    expect(printed).toContain("already failing in the latest run on `main`");
+    expect(printed).toContain("too noisy to judge a change by");
+    // The change reaches the failing one, which is very likely a fix, so
+    // it runs in spite of being withheld.
+    expect(printed).toContain("yes, the change reaches it");
+    expect(printed).toContain("| no |");
+  });
+
+  it("says nothing about a manifest that withheld nothing", () => {
+    const lines: string[] = [];
+    const log = console.log;
+    console.log = (line: string) => lines.push(line);
+    try {
+      describeWithheld([], new Map());
+    } finally {
+      console.log = log;
+    }
+    expect(lines).toEqual([]);
   });
 });
 
@@ -638,7 +722,7 @@ describe("planning a lane the manifest chose", () => {
     // rather than by anything coordinating them.
     const counted = (printed: string): number =>
       printed.split("\n")
-        .map((line) => /^\| \S+ \| (\d+) \| \d+ \|$/.exec(line))
+        .map((line) => /^\| \S+ \| (\d+) \| /.exec(line))
         .reduce((total, row) => total + (row === null ? 0 : Number(row[1])), 0);
     let placed = 0;
     for (const lane of [1, 2, 3, 4, 5]) {
@@ -885,45 +969,99 @@ describe("what a lane records about itself", () => {
     await Deno.remove(spool, { recursive: true });
   });
 
-  it("marks a batch's records with the variant its suite declares", async () => {
+  /**
+   * A batch whose one invocation spools exactly this record, run against
+   * a suite declaring the surface and variant given.
+   */
+  async function spooling(
+    record: TestIdentity,
+    declared: Partial<Suite>,
+  ): Promise<{
+    ok: boolean;
+    records: TestRecord[];
+    conflicts: TestRecord[];
+  }> {
     const workDir = await Deno.makeTempDir({ prefix: "lane-variant-" });
     const written = JSON.stringify({
       line: "record",
-      test: { k: "integration", s: "runner", n: "attaches" },
+      test: record,
       outcome: "pass",
       durationMs: 1,
     });
-    const result = await runBatch(
-      {
-        suite: suite({
-          id: "package-integration-on",
-          variant: "server-execution",
-          units: ["one"],
-          command: (_units, context) =>
-            Promise.resolve([{
-              command: [
-                Deno.execPath(),
-                "eval",
-                `Deno.writeTextFileSync(
-                  Deno.env.get("CF_TEST_RECORDS_DIR") + "/fragment-a.ndjson",
-                  ${JSON.stringify(written + "\n")},
-                )`,
-              ],
-              cwd: context.root,
-            }]),
-        }),
-        units: [],
-        repeats: 1,
-      },
-      lane,
-      workDir,
-      undefined,
-      {},
-    );
+    try {
+      return await runBatch(
+        {
+          suite: suite({
+            id: "package-integration-on",
+            units: ["one"],
+            command: (_units, context) =>
+              Promise.resolve([{
+                command: [
+                  Deno.execPath(),
+                  "eval",
+                  `Deno.writeTextFileSync(
+                    Deno.env.get("CF_TEST_RECORDS_DIR") + "/fragment-a.ndjson",
+                    ${JSON.stringify(written + "\n")},
+                  )`,
+                ],
+                cwd: context.root,
+              }]),
+            ...declared,
+          }),
+          units: [],
+          repeats: 1,
+        },
+        lane,
+        workDir,
+        undefined,
+        {},
+      );
+    } finally {
+      await Deno.remove(workDir, { recursive: true });
+    }
+  }
+
+  it("marks a batch's records with the variant its suite declares", async () => {
     // A variant belongs to the suite that ran, not to the producer that
     // reported, so it is written on regardless of what the producer said.
+    const result = await spooling(
+      { k: "integration", s: "runner", n: "attaches" },
+      {
+        variant: "server-execution",
+        recordSurfaces: [{ kind: "integration", scope: "runner" }],
+      },
+    );
     expect(result.records[0]!.test.v).toBe("server-execution");
-    await Deno.remove(workDir, { recursive: true });
+    expect(result.conflicts).toEqual([]);
+  });
+
+  it("leaves a record off the suite's surfaces as its producer wrote it", async () => {
+    const result = await spooling(
+      { k: "integration", s: "runner", n: "attaches" },
+      {
+        variant: "server-execution",
+        recordSurfaces: [{ kind: "integration", scope: "shell" }],
+      },
+    );
+    expect(result.records[0]!.test.v).toBeUndefined();
+    expect(result.conflicts.length).toBe(1);
+    expect(result.ok).toBe(true);
+  });
+
+  it("reports a producer's own variant in a default batch", async () => {
+    // The execution was a default one, so a marker on its record
+    // describes a configuration that did not run.
+    const result = await spooling(
+      {
+        k: "integration",
+        s: "runner",
+        n: "attaches",
+        v: "server-execution",
+      },
+      { recordSurfaces: [{ kind: "integration", scope: "runner" }] },
+    );
+    expect(result.records[0]!.test.v).toBe("server-execution");
+    expect(result.conflicts.length).toBe(1);
   });
 
   it("says how far past a lane's budget the mandatory set went", async () => {

--- a/tasks/ci-lane.test.ts
+++ b/tasks/ci-lane.test.ts
@@ -10,6 +10,7 @@ import { loadTopology } from "./test-topology.ts";
 import {
   batchesOf,
   changedFiles,
+  describeConflicts,
   describePlan,
   describeWithheld,
   everyBatch,
@@ -635,6 +636,40 @@ describe("running a lane's work", () => {
     expect(printed).toContain("| no |");
   });
 
+  it("names the records no suite describes", () => {
+    // The only report they get before the store half of the drift guard
+    // fails on them on the next run on `main`.
+    const lines: string[] = [];
+    const log = console.log;
+    console.log = (line: string) => lines.push(line);
+    try {
+      describeConflicts([{
+        line: "record",
+        test: { k: "integration", s: "runner", n: "attaches" },
+        outcome: "pass",
+        durationMs: 1,
+      }]);
+    } finally {
+      console.log = log;
+    }
+    expect(lines.join("\n")).toContain(
+      testIdentityKey({ k: "integration", s: "runner", n: "attaches" }),
+    );
+    expect(lines.join("\n")).toContain("kept as written");
+  });
+
+  it("says nothing when every record was one its suite describes", () => {
+    const lines: string[] = [];
+    const log = console.log;
+    console.log = (line: string) => lines.push(line);
+    try {
+      describeConflicts([]);
+    } finally {
+      console.log = log;
+    }
+    expect(lines).toEqual([]);
+  });
+
   it("says nothing about a manifest that withheld nothing", () => {
     const lines: string[] = [];
     const log = console.log;
@@ -710,6 +745,28 @@ describe("planning a lane the manifest chose", () => {
     }
     return lines.join("\n");
   }
+
+  it("refuses a lane the plan has no share for", async () => {
+    // Taking an empty share instead would run nothing and exit zero,
+    // reporting a pass over a set no lane ran.
+    await expect(runLane(
+      {
+        lane: 3,
+        of: 2,
+        full: false,
+        dryRun: true,
+        root,
+        at: "2026-09-01T00:00:00Z",
+      },
+      {
+        manifest: () =>
+          Promise.resolve({
+            manifest: manifestOf([{}]),
+            objectName: "manifest-fixture.json.gz",
+          }),
+      },
+    )).rejects.toThrow("lane 3 has no share of a plan for 2 lanes");
+  });
 
   it("names the manifest it planned from", async () => {
     const printed = await planned([]);

--- a/tasks/ci-lane.ts
+++ b/tasks/ci-lane.ts
@@ -748,10 +748,20 @@ export async function runLane(
       const mine = laid.lanes.find((lane) =>
         lane.lane === options.lane
       );
-      batches = batchesOf(suites, manifest.manifest, mine?.selections ?? []);
+      if (mine === undefined) {
+        // A lane outside the run it belongs to. Taking an empty share
+        // instead would run nothing and exit zero, reporting a pass over
+        // a set no lane ran, which is the one failure of this design
+        // that would be silent.
+        throw new RangeError(
+          `lane ${options.lane} has no share of a plan for ${options.of} ` +
+            `lanes`,
+        );
+      }
+      batches = batchesOf(suites, manifest.manifest, mine.selections);
       chosen = {
-        selections: mine?.selections ?? [],
-        projectedSeconds: mine?.projectedSeconds ?? 0,
+        selections: mine.selections,
+        projectedSeconds: mine.projectedSeconds,
       };
       sayWithheld = () => describeWithheld(laid.withheld, mandatory);
       // A discretionary identity costing more than a lane's hard bound

--- a/tasks/ci-lane.ts
+++ b/tasks/ci-lane.ts
@@ -40,7 +40,7 @@ import {
   type Selection,
   type SelectionReason,
 } from "./test-selection/plan.ts";
-import type { Manifest } from "./test-selection/manifest.ts";
+import type { Manifest, WithheldReason } from "./test-selection/manifest.ts";
 import { LANE_BUDGET_SECONDS, LANES } from "./test-selection/policy.ts";
 
 /** What the lane was asked to do. */
@@ -457,6 +457,13 @@ export function spoolRecords(
  * before the next can reuse a path the runner owns. Every repeat must
  * pass: a repeat is not a retry, and three runs of a test is strictly
  * stricter than one.
+ *
+ * A record whose kind and scope are outside the suite's declared
+ * surfaces, or that a producer marked with a variant the batch did not
+ * run in, is kept as its producer wrote it and reported. The batch is
+ * not failed for it: the mistake is in the metadata, and the tests it
+ * came with either passed or did not. The record then belongs to no
+ * suite, which is what the store half of the drift guard fails on.
  */
 export async function runBatch(
   batch: Batch,
@@ -464,8 +471,14 @@ export async function runBatch(
   workDir: string,
   spool: string | undefined,
   env: Record<string, string>,
-): Promise<{ ok: boolean; records: TestRecord[]; seconds: number }> {
+): Promise<{
+  ok: boolean;
+  records: TestRecord[];
+  conflicts: TestRecord[];
+  seconds: number;
+}> {
   const records: TestRecord[] = [];
+  const conflicts: TestRecord[] = [];
   let ok = true;
   let seconds = 0;
   for (let run = 1; run <= batch.repeats; run++) {
@@ -488,22 +501,23 @@ export async function runBatch(
       });
       seconds += outcome.seconds;
       if (!outcome.ok) ok = false;
-      records.push(
-        ...await collectRecords({
-          spoolDir: batchSpool,
-          junit: (invocation.junit ?? []).map((output) => ({
-            kind: output.kind,
-            scope: output.scope,
-            glob: output.path,
-            ...(output.filePrefix === undefined
-              ? {}
-              : { prefix: output.filePrefix }),
-          })),
-          ...(batch.suite.variant === undefined
+      const collected = await collectRecords({
+        spoolDir: batchSpool,
+        junit: (invocation.junit ?? []).map((output) => ({
+          kind: output.kind,
+          scope: output.scope,
+          glob: output.path,
+          ...(output.filePrefix === undefined
             ? {}
-            : { variant: batch.suite.variant }),
-        }),
-      );
+            : { prefix: output.filePrefix }),
+        })),
+        surfaces: batch.suite.recordSurfaces,
+        ...(batch.suite.variant === undefined
+          ? {}
+          : { variant: batch.suite.variant }),
+      });
+      records.push(...collected.records);
+      conflicts.push(...collected.conflicts);
       await Deno.remove(batchSpool, { recursive: true }).catch(() => {});
       await Deno.mkdir(batchSpool, { recursive: true });
     }
@@ -514,16 +528,110 @@ export async function runBatch(
       timingRecord(`ci-lane batch ${batch.suite.id}`, seconds, ok),
     ]);
   }
-  return { ok, records, seconds };
+  return { ok, records, conflicts, seconds };
 }
 
-/** Prints what the lane is about to do, for the job summary. */
+/** Says something both on the lane's output and in the job summary. */
+function say(lines: readonly string[]): void {
+  const text = `${lines.join("\n")}\n`;
+  console.log(text);
+  const summary = Deno.env.get("GITHUB_STEP_SUMMARY");
+  if (summary !== undefined && summary.length > 0) {
+    Deno.writeTextFileSync(summary, text, { append: true });
+  }
+}
+
+/**
+ * Names the records this lane produced that no suite describes, which is
+ * the only report they get before the store half of the drift guard
+ * fails on them.
+ */
+export function describeConflicts(conflicts: readonly TestRecord[]): void {
+  if (conflicts.length === 0) return;
+  say([
+    "These records name a surface the suite that ran them does not " +
+    "declare, so they were kept as written rather than marked:",
+    "",
+    ...conflicts.map((record) => `- ${testIdentityKey(record.test)}`),
+  ]);
+}
+
+/** What a withheld identity is absent for, in words. */
+const WITHHELD_REASONS: Record<WithheldReason, string> = {
+  "main-red": "already failing in the latest run on `main`",
+  flaky: "too noisy to judge a change by",
+};
+
+/**
+ * Names what the manifest withheld from selection, so that what a lane
+ * did not run is visible rather than quietly absent.
+ *
+ * An identity the change made mandatory comes back in spite of being
+ * withheld, since a change touching what a failing test covers is very
+ * likely a fix and must be allowed to prove itself. Saying which of them
+ * that happened to is the difference between "this did not run" and
+ * "this ran because you touched it".
+ */
+export function describeWithheld(
+  withheld: Manifest["withheld"],
+  mandatory: ReadonlyMap<string, SelectionReason>,
+): void {
+  if (withheld.length === 0) return;
+  const lines = [
+    "Withheld from selection, so no lane chose them:",
+    "",
+    "| Identity | Suite | Withheld because | Ran anyway |",
+    "| --- | --- | --- | --- |",
+  ];
+  for (const entry of withheld) {
+    const back = mandatory.has(testIdentityKey(entry.test));
+    lines.push(
+      `| ${testIdentityKey(entry.test)} | ${entry.suite} | ` +
+        `${WITHHELD_REASONS[entry.reason]} | ` +
+        `${back ? "yes, the change reaches it" : "no"} |`,
+    );
+  }
+  say(lines);
+}
+
+/** What one suite's share of a lane was chosen for, and what it costs. */
+function chosenFor(
+  suite: string,
+  selections: readonly Selection[],
+): { identities: number; seconds: number; why: string } {
+  const mine = selections.filter((s) => s.entry.suite === suite);
+  const reasons = new Map<SelectionReason, number>();
+  let seconds = 0;
+  for (const selection of mine) {
+    reasons.set(selection.reason, (reasons.get(selection.reason) ?? 0) + 1);
+    seconds += selection.entry.cost * selection.repeats;
+  }
+  return {
+    identities: mine.length,
+    seconds,
+    why: [...reasons].sort().map(([reason, count]) => `${reason} ${count}`)
+      .join(", "),
+  };
+}
+
+/**
+ * Prints what the lane is about to do, for the job summary.
+ *
+ * Where the lane is running a selection, each batch says what it is
+ * expected to take and why each of its identities was chosen. "Why did
+ * my test not run" is the question a selected run provokes, and a
+ * summary that only names the suites cannot begin to answer it. The
+ * seconds are the tests' own measured time and not what the lane will
+ * take: the overheads the packer charged on top are per lane rather than
+ * per identity, and `projectedSeconds` is where the whole figure is.
+ */
 export function describePlan(
   options: LaneOptions,
   batches: readonly Batch[],
   capabilities: readonly CapabilityId[],
   manifest: { objectName?: string; absent?: string },
   unschedulable: readonly string[] = [],
+  chosen?: { selections: readonly Selection[]; projectedSeconds: number },
 ): void {
   const lines: string[] = [];
   lines.push(`## Lane ${options.lane} of ${options.of}`);
@@ -535,13 +643,32 @@ export function describePlan(
   );
   lines.push("");
   lines.push(`Capabilities: ${capabilities.join(", ") || "none"}`);
-  lines.push("");
-  lines.push("| Suite | Units | Repeats |");
-  lines.push("| --- | --- | --- |");
-  for (const batch of batches) {
+  if (chosen !== undefined) {
+    lines.push("");
     lines.push(
-      `| ${batch.suite.id} | ${batch.units.length} | ${batch.repeats} |`,
+      `Projected: ${chosen.projectedSeconds.toFixed(0)}s of ` +
+        `${LANE_BUDGET_SECONDS}s`,
     );
+  }
+  lines.push("");
+  if (chosen === undefined) {
+    lines.push("| Suite | Units | Repeats |");
+    lines.push("| --- | --- | --- |");
+    for (const batch of batches) {
+      lines.push(
+        `| ${batch.suite.id} | ${batch.units.length} | ${batch.repeats} |`,
+      );
+    }
+  } else {
+    lines.push("| Suite | Units | Tests | Their own time | Repeats | Chosen |");
+    lines.push("| --- | --- | --- | --- | --- | --- |");
+    for (const batch of batches) {
+      const share = chosenFor(batch.suite.id, chosen.selections);
+      lines.push(
+        `| ${batch.suite.id} | ${batch.units.length} | ${share.identities} | ` +
+          `${share.seconds.toFixed(1)}s | ${batch.repeats} | ${share.why} |`,
+      );
+    }
   }
   if (unschedulable.length > 0) {
     lines.push("");
@@ -549,12 +676,7 @@ export function describePlan(
     lines.push("");
     for (const entry of unschedulable) lines.push(`- ${entry}`);
   }
-  const text = `${lines.join("\n")}\n`;
-  console.log(text);
-  const summary = Deno.env.get("GITHUB_STEP_SUMMARY");
-  if (summary !== undefined && summary.length > 0) {
-    Deno.writeTextFileSync(summary, text, { append: true });
-  }
+  say(lines);
 }
 
 /** What the lane reaches for beyond its own arguments. */
@@ -585,6 +707,10 @@ export async function runLane(
   let batches: Batch[];
   let unschedulable: string[] = [];
   let fetched: { objectName?: string; absent?: string } = {};
+  let sayWithheld = (): void => {};
+  let chosen:
+    | { selections: readonly Selection[]; projectedSeconds: number }
+    | undefined;
   if (options.full) {
     batches = everyBatch(suites, options.lane, options.of);
     fetched = { absent: "running everything, so nothing is selected" };
@@ -623,6 +749,11 @@ export async function runLane(
         lane.lane === options.lane
       );
       batches = batchesOf(suites, manifest.manifest, mine?.selections ?? []);
+      chosen = {
+        selections: mine?.selections ?? [],
+        projectedSeconds: mine?.projectedSeconds ?? 0,
+      };
+      sayWithheld = () => describeWithheld(laid.withheld, mandatory);
       // A discretionary identity costing more than a lane's hard bound
       // runs nowhere, because a lane holding it would be killed before it
       // reported anything. Naming it is what turns that into something
@@ -647,7 +778,15 @@ export async function runLane(
   for (const batch of batches) {
     for (const capability of batch.suite.needs) needs.add(capability);
   }
-  describePlan(options, batches, [...needs].sort(), fetched, unschedulable);
+  describePlan(
+    options,
+    batches,
+    [...needs].sort(),
+    fetched,
+    unschedulable,
+    chosen,
+  );
+  sayWithheld();
   if (options.dryRun) return true;
 
   const workDir = await Deno.makeTempDir({ prefix: "ci-lane-" });
@@ -666,6 +805,7 @@ export async function runLane(
     );
   }
   let ok = true;
+  const conflicts: TestRecord[] = [];
   try {
     for (const batch of batches) {
       // A failure never stops the lane: one failing batch would otherwise
@@ -673,6 +813,7 @@ export async function runLane(
       // lane is what it measured.
       const result = await runBatch(batch, options, workDir, spool, opened.env);
       if (!result.ok) ok = false;
+      conflicts.push(...result.conflicts);
     }
   } finally {
     await opened.close();
@@ -680,6 +821,7 @@ export async function runLane(
     // it, so it goes whether the batches passed, failed, or never ran.
     await Deno.remove(workDir, { recursive: true }).catch(() => {});
   }
+  describeConflicts(conflicts);
   return ok;
 }
 

--- a/tasks/test-records-gather.ts
+++ b/tasks/test-records-gather.ts
@@ -97,6 +97,30 @@ export interface CollectOptions {
    * producer that reported.
    */
   variant?: string;
+
+  /**
+   * The kinds and scopes this execution's records may carry. Given, a
+   * record outside them is not one the caller's topology describes, and
+   * neither is one a producer marked with a variant of its own where
+   * none was declared. Such a record keeps what its producer wrote and
+   * is reported rather than being given a configuration it did not run
+   * in. Absent, every record takes the declared variant.
+   */
+  surfaces?: ReadonlyArray<{ kind: string; scope: string }>;
+}
+
+/** What one execution left behind. */
+export interface Collected {
+  /** Everything it recorded, the conflicts among them. */
+  records: TestRecord[];
+
+  /**
+   * Those of them the declared surfaces do not describe. They are kept
+   * as their producer wrote them rather than dropped, so they reach the
+   * store, belong to no suite there, and the store half of the topology
+   * drift guard is what fails on them.
+   */
+  conflicts: TestRecord[];
 }
 
 /**
@@ -111,7 +135,7 @@ export interface CollectOptions {
  */
 export async function collectRecords(
   options: CollectOptions,
-): Promise<TestRecord[]> {
+): Promise<Collected> {
   if (options.variant !== undefined && options.variant.length === 0) {
     throw new Error("a declared variant must not be empty");
   }
@@ -160,10 +184,23 @@ export async function collectRecords(
     }
   }
 
-  if (options.variant !== undefined) {
-    for (const record of records) record.test.v = options.variant;
+  const conflicts: TestRecord[] = [];
+  for (const record of records) {
+    if (options.surfaces !== undefined) {
+      const described = options.surfaces.some((surface) =>
+        surface.kind === record.test.k && surface.scope === record.test.s
+      );
+      // A record marked with a variant where none was declared is the
+      // other half of the same mistake: the execution was a default one,
+      // so a marker on it describes a configuration that did not run.
+      if (!described || (options.variant === undefined && record.test.v)) {
+        conflicts.push(record);
+        continue;
+      }
+    }
+    if (options.variant !== undefined) record.test.v = options.variant;
   }
-  return records;
+  return { records, conflicts };
 }
 
 export interface GatherOptions {
@@ -178,7 +215,7 @@ export interface GatherOptions {
 
 /** Gathers the spool and JUnit files into the artifact directory. */
 export async function gather(options: GatherOptions): Promise<void> {
-  const records = await collectRecords({
+  const { records } = await collectRecords({
     ...(options.spoolDir === undefined ? {} : { spoolDir: options.spoolDir }),
     junit: options.junit,
     ...(options.variant === undefined ? {} : { variant: options.variant }),

--- a/tasks/test-selection-publish.test.ts
+++ b/tasks/test-selection-publish.test.ts
@@ -345,6 +345,67 @@ describe("publish()", () => {
     expect(lines.join("\n")).toContain("1 identities no suite claims");
   });
 
+  it("carries what each configuration declares unavailable", async () => {
+    // A lane reads it to say why a test is absent. Without it the test
+    // looks merely unrecorded, which is reported and never failed on.
+    const { store, created } = fakeStore(seed());
+    await publish(
+      ["--bootstrap", "--days", "1"],
+      store,
+      NOW,
+      () =>
+        Promise.resolve([{
+          ...TOPOLOGY[0]!,
+          variant: "server-execution",
+          unavailable: [{
+            unit: "packages/memory/test/space.test.ts",
+            leafName: "space > writes a fact",
+            phase: "phase-2",
+            reason: "the ON arm cannot run it yet",
+          }],
+        }]),
+    );
+    const manifestName = [...created.keys()].find((name) =>
+      name.includes("/manifest-")
+    );
+    const manifest = parseManifest(
+      await gunzipToText(created.get(manifestName!)!),
+    );
+    expect(manifest!.unavailable).toEqual([{
+      suite: "workspace-unit",
+      variant: "server-execution",
+      unit: "packages/memory/test/space.test.ts",
+      leafName: "space > writes a fact",
+      phase: "phase-2",
+      reason: "the ON arm cannot run it yet",
+    }]);
+  });
+
+  it("says how many identities measure a suite rather than a unit", async () => {
+    // An overlapping whole-invocation record names no unit, so nothing
+    // can be asked to run one, and it must not be summed with the steps
+    // inside it either.
+    const lines: string[] = [];
+    const log = console.log;
+    console.log = (line: string) => lines.push(line);
+    const { store } = fakeStore(seed());
+    try {
+      await publish(
+        ["--bootstrap", "--days", "1"],
+        store,
+        NOW,
+        () =>
+          Promise.resolve([{
+            ...TOPOLOGY[0]!,
+            locate: () => ({ level: "suite" as const }),
+          }]),
+      );
+    } finally {
+      console.log = log;
+    }
+    expect(lines.join("\n")).toContain("1 identities measure a suite");
+  });
+
   it("folds from the state it left rather than the objects again", async () => {
     const { store, created } = fakeStore(seed());
     await publish(["--bootstrap", "--days", "1"], store, NOW, suites);

--- a/tasks/test-selection-publish.test.ts
+++ b/tasks/test-selection-publish.test.ts
@@ -4,6 +4,7 @@ import { expect } from "@std/expect";
 import {
   byDayThenName,
   dayPartitions,
+  inputChoice,
   parseArgs,
   partitionOf,
   publish,
@@ -18,7 +19,29 @@ import {
   type TestRecord,
 } from "@commonfabric/test-support/records";
 import { reportFromText } from "./test-selection/build.ts";
+import type { Suite } from "./test-topology/suite.ts";
 import { join } from "@std/path";
+
+/**
+ * A topology holding the one suite these cases record against. Supplied
+ * rather than read from the tree: what the publisher does with a
+ * classified identity is the subject, and walking the repository for
+ * every case would make each of them depend on what the tree holds.
+ */
+const TOPOLOGY: Suite[] = [{
+  id: "workspace-unit",
+  recordSurfaces: [{ kind: "unit", scope: "memory" }],
+  needs: ["deno"],
+  units: ["packages/memory/test/space.test.ts"],
+  unavailable: [],
+  locate: (record) =>
+    record.test.k === "unit" && record.test.s === "memory"
+      ? { level: "unit", unit: "packages/memory/test/space.test.ts" }
+      : undefined,
+  command: () => Promise.resolve([]),
+}];
+
+const suites = () => Promise.resolve(TOPOLOGY);
 
 const CI = (day: string, run: string) =>
   `labs/test-records/submissions/ci/v1/${day}/run-${run}-a.ndjson`;
@@ -89,6 +112,38 @@ describe("test-selection-publish", () => {
 
     it("reads nothing out of a name that carries no day", () => {
       expect(partitionOf("labs/test-selection/v1/state/x.json.gz")).toBe("");
+    });
+  });
+
+  describe("inputChoice()", () => {
+    it("passes over a pair whose receipt says its rollup is folded", () => {
+      // Rollups of this format carry no record of which arrivals they
+      // cover, so nothing can say how much a raw object would repeat.
+      expect(
+        inputChoice({ settled: true, foldedRaw: false, rollup: true }),
+      ).toBe("settled");
+      expect(
+        inputChoice({ settled: true, foldedRaw: true, rollup: true }),
+      ).toBe("settled");
+    });
+
+    it("takes the rollup of a pair nothing has been folded from", () => {
+      expect(
+        inputChoice({ settled: false, foldedRaw: false, rollup: true }),
+      ).toBe("rollup");
+    });
+
+    it("keeps a pair with raw contributions on the raw path", () => {
+      // A rollup written afterwards would overlap them.
+      expect(
+        inputChoice({ settled: false, foldedRaw: true, rollup: true }),
+      ).toBe("raw");
+    });
+
+    it("reads raw where there is no rollup, which is every local source", () => {
+      expect(
+        inputChoice({ settled: false, foldedRaw: false, rollup: false }),
+      ).toBe("raw");
     });
   });
 
@@ -192,6 +247,30 @@ function object(
   return buildObjectBody(context, [record]);
 }
 
+/** One object holding one run of one test on somebody's workstation. */
+function localObject(commit: string, at: string): string {
+  const context: RunContext = {
+    schema: 1,
+    line: "context",
+    reportId: `report-${commit}`,
+    repo: "commontoolsinc/labs",
+    commit,
+    dirty: false,
+    branch: "fix-writes",
+    env: "local",
+    os: "linux",
+    arch: "x86_64",
+    denoVersion: "2.9.4",
+    startedAt: at,
+  };
+  return buildObjectBody(context, [{
+    line: "record",
+    test: { k: "unit", s: "memory", n: "space > writes" },
+    outcome: "fail",
+    durationMs: 40,
+  }]);
+}
+
 /** The two runs a fresh store is seeded with: a failure, then its fix. */
 function seed(): Record<string, string> {
   return {
@@ -207,13 +286,14 @@ describe("publish()", () => {
     // An absent aggregate is either a genuine first run or one that went
     // missing, and an incremental run cannot tell the two apart.
     const { store, created } = fakeStore(seed());
-    expect(await publish(["--days", "1"], store, NOW)).toBe(1);
+    expect(await publish(["--days", "1"], store, NOW, suites)).toBe(1);
     expect(created.size).toBe(0);
   });
 
   it("writes a manifest and a state from a bootstrap", async () => {
     const { store, created } = fakeStore(seed());
-    expect(await publish(["--bootstrap", "--days", "1"], store, NOW)).toBe(0);
+    expect(await publish(["--bootstrap", "--days", "1"], store, NOW, suites))
+      .toBe(0);
     const names = [...created.keys()];
     const manifestName = names.find((name) => name.includes("/manifest-"));
     expect(manifestName).toBeDefined();
@@ -224,13 +304,50 @@ describe("publish()", () => {
     );
     expect(manifest).toBeDefined();
     expect(manifest!.entries.length).toBe(1);
+    // The suite and the unit are the topology's, which is what a lane
+    // looks a suite up by and what the packer charges overheads to. A
+    // surface derived from the record's own kind and scope would match
+    // no suite the tree holds, and every selection naming it would be
+    // dropped for naming a suite that does not exist.
+    expect(manifest!.entries[0]!.suite).toBe("workspace-unit");
+    expect(manifest!.entries[0]!.unit).toBe(
+      "packages/memory/test/space.test.ts",
+    );
     // The failure at c1 that c2 went on to fix is a catch on main.
     expect(manifest!.entries[0]!.inputs.mainCatches).toBe(1);
   });
 
+  it("leaves out an identity no suite claims, and says how many", async () => {
+    // Nothing can be asked to run it, so carrying it would put an entry
+    // in the manifest that every pass would consider and no lane could
+    // place. Saying how many there are is what keeps that visible.
+    const lines: string[] = [];
+    const log = console.log;
+    console.log = (line: string) => lines.push(line);
+    const { store, created } = fakeStore(seed());
+    try {
+      await publish(
+        ["--bootstrap", "--days", "1"],
+        store,
+        NOW,
+        () => Promise.resolve([]),
+      );
+    } finally {
+      console.log = log;
+    }
+    const manifestName = [...created.keys()].find((name) =>
+      name.includes("/manifest-")
+    );
+    const manifest = parseManifest(
+      await gunzipToText(created.get(manifestName!)!),
+    );
+    expect(manifest!.entries).toEqual([]);
+    expect(lines.join("\n")).toContain("1 identities no suite claims");
+  });
+
   it("folds from the state it left rather than the objects again", async () => {
     const { store, created } = fakeStore(seed());
-    await publish(["--bootstrap", "--days", "1"], store, NOW);
+    await publish(["--bootstrap", "--days", "1"], store, NOW, suites);
     const first = created.size;
     const readObjects: string[] = [];
     const watched: StoreAccess = {
@@ -240,7 +357,7 @@ describe("publish()", () => {
         return store.read(name);
       },
     };
-    expect(await publish(["--days", "1"], watched, NOW)).toBe(0);
+    expect(await publish(["--days", "1"], watched, NOW, suites)).toBe(0);
     expect(readObjects).toEqual([]);
     expect(created.size).toBeGreaterThan(first);
   });
@@ -254,13 +371,13 @@ describe("publish()", () => {
           ? Promise.reject(new Error("unreachable"))
           : store.list(prefix),
     };
-    expect(await publish(["--days", "1"], broken, NOW)).toBe(1);
+    expect(await publish(["--days", "1"], broken, NOW, suites)).toBe(1);
     expect(created.size).toBe(0);
   });
 
   it("refuses to publish from a window it could only partly read", async () => {
     const { store, created } = fakeStore(seed());
-    await publish(["--bootstrap", "--days", "1"], store, NOW);
+    await publish(["--bootstrap", "--days", "1"], store, NOW, suites);
     const after = created.size;
     const broken: StoreAccess = {
       ...store,
@@ -270,7 +387,7 @@ describe("publish()", () => {
           ? store.list(prefix)
           : Promise.resolve([CI(DAY, "9")]),
     };
-    expect(await publish(["--days", "1"], broken, NOW)).toBe(1);
+    expect(await publish(["--days", "1"], broken, NOW, suites)).toBe(1);
     expect(created.size).toBe(after);
   });
 
@@ -280,6 +397,7 @@ describe("publish()", () => {
       ["--bootstrap", "--days", "1", "--dry-run"],
       store,
       NOW,
+      suites,
     );
     expect(code).toBe(0);
     expect(created.size).toBe(0);
@@ -288,14 +406,19 @@ describe("publish()", () => {
   it("creates nothing without a credential", async () => {
     const { store, created } = fakeStore(seed());
     const anonymous: StoreAccess = { ...store, token: () => undefined };
-    const code = await publish(["--bootstrap", "--days", "1"], anonymous, NOW);
+    const code = await publish(
+      ["--bootstrap", "--days", "1"],
+      anonymous,
+      NOW,
+      suites,
+    );
     expect(created.size).toBe(0);
     expect(code).toBe(0);
   });
 
   it("reports a malformed command line rather than publishing", async () => {
     const { store, created } = fakeStore(seed());
-    expect(await publish(["--nonsense"], store, NOW)).toBe(2);
+    expect(await publish(["--nonsense"], store, NOW, suites)).toBe(2);
     expect(created.size).toBe(0);
   });
 });
@@ -311,6 +434,7 @@ describe("publish() --out", () => {
         ["--bootstrap", "--days", "1", "--dry-run", "--out", out],
         store,
         NOW,
+        suites,
       );
       expect(code).toBe(0);
       // A dry run creates nothing in the store, and the directory is how
@@ -342,6 +466,7 @@ describe("publish() --out", () => {
           ["--bootstrap", "--days", "1", "--dry-run", "--out", out],
           store,
           NOW,
+          suites,
         ),
       ).toBe(0);
       expect((await Deno.stat(join(out, "manifest.json"))).isFile).toBe(true);
@@ -369,16 +494,19 @@ describe("publish() over a day that has been compacted", () => {
         return store.read(name);
       },
     };
-    expect(await publish(["--bootstrap", "--days", "1"], watched, NOW)).toBe(0);
+    expect(await publish(["--bootstrap", "--days", "1"], watched, NOW, suites))
+      .toBe(0);
     expect(read).toEqual([ROLLUP]);
   });
 
-  it("does not read the rollup on an incremental run", async () => {
+  it("asks nothing about a source and date already settled", async () => {
+    // The receipt answers, so the store is not asked at all. It is the
+    // rule that decides, rather than which flag the run was given.
     const { store } = fakeStore({
       ...seed(),
       [ROLLUP]: object("c3", "fail", "2026-08-20T03:00:00.000Z"),
     }, { [DAY]: [ROLLUP] });
-    await publish(["--bootstrap", "--days", "1"], store, NOW);
+    await publish(["--bootstrap", "--days", "1"], store, NOW, suites);
     const asked: string[] = [];
     const watched: StoreAccess = {
       ...store,
@@ -387,8 +515,89 @@ describe("publish() over a day that has been compacted", () => {
         return store.rollupShards(day);
       },
     };
-    expect(await publish(["--days", "1"], watched, NOW)).toBe(0);
+    expect(await publish(["--days", "1"], watched, NOW, suites)).toBe(0);
     expect(asked).toEqual([]);
+  });
+
+  it("takes a rollup on an incremental run over a day it has not seen", async () => {
+    // One rule, so a run catching up after an outage or a widened window
+    // reaches a day the same way a bootstrap does. A flag is permission
+    // to start from an empty aggregate and a wider window, not a second
+    // way to choose inputs.
+    const older = "2026/08/19";
+    const olderRollup =
+      `labs/test-records/aggregated/v1/${older}/shard-0.ndjson`;
+    const { store } = fakeStore({
+      ...seed(),
+      [CI(older, "9")]: object("c9", "pass", "2026-08-19T01:00:00.000Z"),
+      [olderRollup]: object("c9", "pass", "2026-08-19T01:00:00.000Z"),
+    }, { [older]: [olderRollup] });
+    // The first run's window holds only the newer day, so the older one
+    // is a day the aggregate has never seen.
+    expect(await publish(["--bootstrap", "--days", "1"], store, NOW, suites))
+      .toBe(0);
+    const read: string[] = [];
+    const watched: StoreAccess = {
+      ...store,
+      read: (name) => {
+        read.push(name);
+        return store.read(name);
+      },
+    };
+    expect(await publish(["--days", "2"], watched, NOW, suites)).toBe(0);
+    expect(read).toContain(olderRollup);
+    expect(read).not.toContain(CI(older, "9"));
+  });
+
+  it("stays on the raw path for a day it already holds raw objects from", async () => {
+    // A rollup written afterwards would overlap those contributions, and
+    // nothing in one of this format says by how much, so the pair that
+    // has raw objects in the aggregate keeps taking raw ones.
+    const { store } = fakeStore(seed());
+    await publish(["--bootstrap", "--days", "1"], store, NOW, suites);
+    const read: string[] = [];
+    const asked: string[] = [];
+    const later: StoreAccess = {
+      ...store,
+      // The rollup arrives after the raw objects were folded, which is
+      // the order compaction runs in.
+      rollupShards: (day) => {
+        asked.push(day);
+        return Promise.resolve(day === DAY ? [ROLLUP] : undefined);
+      },
+      read: (name) => {
+        read.push(name);
+        return store.read(name);
+      },
+    };
+    expect(await publish(["--days", "1"], later, NOW, suites)).toBe(0);
+    expect(read).not.toContain(ROLLUP);
+    // Nor was the store asked: the aggregate already answers for the pair.
+    expect(asked).toEqual([]);
+  });
+
+  it("still reads the local submissions of a settled day", async () => {
+    // Rollups cover the continuous-integration area alone. A receipt
+    // naming the day by itself would say the day is accounted for, and
+    // the local submissions of that day — the evidence the score weighs
+    // highest — would never be read.
+    const local = LOCAL(DAY, "ianh");
+    const { store } = fakeStore({
+      [ROLLUP]: object("c3", "pass", "2026-08-20T03:00:00.000Z"),
+      [local]: localObject("c4", "2026-08-20T04:00:00.000Z"),
+    }, { [DAY]: [ROLLUP] });
+    const read: string[] = [];
+    const watched: StoreAccess = {
+      ...store,
+      read: (name) => {
+        read.push(name);
+        return store.read(name);
+      },
+    };
+    expect(await publish(["--bootstrap", "--days", "1"], watched, NOW, suites))
+      .toBe(0);
+    expect(read).toContain(ROLLUP);
+    expect(read).toContain(local);
   });
 
   it("leaves a day open when a shard of its rollup will not read", async () => {
@@ -411,7 +620,8 @@ describe("publish() over a day that has been compacted", () => {
           : store.read(name);
       },
     };
-    expect(await publish(["--bootstrap", "--days", "1"], broken, NOW)).toBe(0);
+    expect(await publish(["--bootstrap", "--days", "1"], broken, NOW, suites))
+      .toBe(0);
     // The run carried on and folded the day's raw objects instead.
     expect(read).toContain(CI(DAY, "1"));
     expect(read).toContain(CI(DAY, "2"));
@@ -424,7 +634,7 @@ describe("publish() over an aggregate it cannot make sense of", () => {
 
   it("refuses rather than starting again from nothing", async () => {
     const { store, created } = fakeStore(seed());
-    await publish(["--bootstrap", "--days", "1"], store, NOW);
+    await publish(["--bootstrap", "--days", "1"], store, NOW, suites);
     const state = [...created.keys()].find((name) => name.includes("/state/"))!;
     const after = created.size;
     const broken: StoreAccess = {
@@ -434,7 +644,7 @@ describe("publish() over an aggregate it cannot make sense of", () => {
           ? Promise.resolve('{"schema":1,"nonsense":true}')
           : store.readText(name),
     };
-    expect(await publish(["--days", "1"], broken, NOW)).toBe(1);
+    expect(await publish(["--days", "1"], broken, NOW, suites)).toBe(1);
     expect(created.size).toBe(after);
   });
 });
@@ -475,19 +685,19 @@ describe("publish() over a store that answers badly", () => {
 
   it("refuses when the aggregate object will not read", async () => {
     const { store, created } = fakeStore(seed());
-    await publish(["--bootstrap", "--days", "1"], store, NOW);
+    await publish(["--bootstrap", "--days", "1"], store, NOW, suites);
     const after = created.size;
     const broken: StoreAccess = {
       ...store,
       readText: () => Promise.reject(new Error("that object is gone")),
     };
-    expect(await publish(["--days", "1"], broken, NOW)).toBe(1);
+    expect(await publish(["--days", "1"], broken, NOW, suites)).toBe(1);
     expect(created.size).toBe(after);
   });
 
   it("refuses when the submissions cannot be listed", async () => {
     const { store, created } = fakeStore(seed());
-    await publish(["--bootstrap", "--days", "1"], store, NOW);
+    await publish(["--bootstrap", "--days", "1"], store, NOW, suites);
     const after = created.size;
     const broken: StoreAccess = {
       ...store,
@@ -496,7 +706,7 @@ describe("publish() over a store that answers badly", () => {
           ? Promise.reject(new Error("the store is unreachable"))
           : store.list(prefix),
     };
-    expect(await publish(["--days", "1"], broken, NOW)).toBe(1);
+    expect(await publish(["--days", "1"], broken, NOW, suites)).toBe(1);
     expect(created.size).toBe(after);
   });
 });
@@ -518,7 +728,8 @@ describe("publish() reporting what no lane can hold", () => {
     const log = console.log;
     console.log = (...parts: unknown[]) => said.push(parts.join(" "));
     try {
-      expect(await publish(["--bootstrap", "--days", "1"], store, NOW)).toBe(0);
+      expect(await publish(["--bootstrap", "--days", "1"], store, NOW, suites))
+        .toBe(0);
     } finally {
       console.log = log;
     }

--- a/tasks/test-selection-publish.ts
+++ b/tasks/test-selection-publish.ts
@@ -7,10 +7,16 @@
  *   deno run -A tasks/test-selection-publish.ts [--days N] [--bootstrap]
  *     [--out <dir>] [--dry-run] [--concurrency N]
  *
- * The incremental path reads the newest aggregate and fetches only the
- * objects it has not already folded, which in the steady state is about
- * two thousand of them. A cold start cannot read three weeks of history
- * in one job, so `--bootstrap` is the one-off that does, run by hand.
+ * A run reads the newest aggregate and folds what that aggregate does not
+ * already hold, which in the steady state is about two thousand objects.
+ * A cold start has no aggregate to read and cannot fold three weeks of
+ * raw history in one job either, so `--bootstrap` is the one-off that
+ * starts from an empty one over a wider window, run by hand.
+ *
+ * That is the whole of what the flag does. What to read is `inputChoice`
+ * asked of each source and date the window covers, and both modes ask it
+ * alike; their answers differ because their aggregates differ, and not
+ * because one of them chooses inputs a second way.
  *
  * When the publisher fails nothing breaks: the previous manifest is still
  * the newest one and lanes keep using it. A manifest going stale degrades
@@ -38,11 +44,17 @@ import { rollupShards } from "./test-records-compact.ts";
 import {
   type AggregateState,
   buildManifest,
+  CI_SOURCE,
   dayOf,
   emptyAggregate,
   Fold,
+  locateSurfaces,
   parseAggregate,
+  partitionOf,
+  type Unplaced,
 } from "./test-selection/build.ts";
+import { capabilitiesBySuite, loadTopology } from "./test-topology.ts";
+import type { Suite } from "./test-topology/suite.ts";
 import {
   manifestBody,
   manifestObjectName,
@@ -75,13 +87,16 @@ export interface StoreAccess {
    * which shards it holds. Reading those replaces reading the day's
    * thousands of raw objects.
    *
-   * Only a bootstrap reads them, and not because the incremental path
-   * declines to: compaction waits a week for late arrivals, and the
-   * window that path reads is two days, so it never reaches a day that
-   * has one. A rollup is a read optimization rather than the record of
-   * its day — an object arriving after its shard is written stays in the
-   * raw area alone — which suits seeding sixty days of catch counts once
-   * and would not suit the run that keeps the manifest current.
+   * Neither mode asks for one because of the flag it was given: the rule
+   * asks wherever a source and date is one nothing has been folded from
+   * yet. In the steady state the incremental path never reaches such a
+   * day, because compaction waits a week for late arrivals and that path
+   * reads two days, so in practice this answers a bootstrap and a run
+   * catching up after an outage or a widened window.
+   *
+   * A rollup is a read optimization rather than the record of its day —
+   * an object arriving after its shard is written stays in the raw area
+   * alone — so a pair taken this way keeps only what the rollup held.
    */
   rollupShards(day: string): Promise<string[] | undefined>;
 
@@ -222,37 +237,75 @@ async function mapConcurrent<T, R>(
 }
 
 /**
- * Every submission object under the days asked for, across both areas.
- * A continuous-integration object's day is a path segment, so its day is
- * a prefix and one listing per day is exact. A local object's path puts
- * the reporting person ahead of the day, so that area is listed once and
+ * Every submission object of the days each area was asked for. A
+ * continuous-integration object's day is a path segment, so its day is a
+ * prefix and one listing per day is exact. A local object's path puts the
+ * reporting person ahead of the day, so that area is listed once and
  * filtered.
+ *
+ * The two areas are asked for different days because the rule answers
+ * differently for them. A continuous-integration day whose rollup is
+ * folded owes nothing more; no local day is ever in that position, since
+ * rollups cover the continuous-integration area alone.
  */
 async function listSubmissions(
   store: StoreAccess,
-  days: readonly string[],
+  ciDays: readonly string[],
+  localDays: readonly string[],
 ): Promise<string[]> {
-  const wanted = new Set(days);
+  const wanted = new Set(localDays);
   const names: string[] = [];
   // A listing that fails is not an empty day. Folding what did list and
   // publishing from it would score every identity in the missing day as
   // though it had not run, and the manifest saying so would become the
   // one every lane obeys. The run ends instead, and the previous manifest
   // stays newest.
-  for (const day of days) {
+  for (const day of ciDays) {
     names.push(...await store.list(`${ciSubmissionsPrefix()}/v1/${day}/`));
   }
   const local = `${storePrefix()}/submissions/local/`;
   for (const name of await store.list(local)) {
-    const day = name.match(/\/v1\/(\d{4}\/\d{2}\/\d{2})\//)?.[1];
-    if (day !== undefined && wanted.has(day)) names.push(name);
+    const day = partitionOf(name);
+    if (day.length > 0 && wanted.has(day)) names.push(name);
   }
   return [...new Set(names)].sort(byDayThenName);
 }
 
-/** The day partition in a submission object's name. */
-export function partitionOf(objectName: string): string {
-  return objectName.match(/\/v1\/(\d{4}\/\d{2}\/\d{2})\//)?.[1] ?? "";
+/** What one source and date still owes the aggregate. */
+export type InputChoice = "settled" | "rollup" | "raw";
+
+/**
+ * What one source and date still has to give, which is the whole of how
+ * this program chooses what to read.
+ *
+ * A bootstrap and an ordinary run apply it alike. A bootstrap is
+ * permission to start from an empty aggregate and, by default, a wider
+ * window; it is not a second way to choose inputs. Both then ask this of
+ * each source and date the window covers, and the answers differ only
+ * because the aggregates differ.
+ *
+ * `settled` — a receipt says this pair's rollup is folded. Rollups of
+ * this format carry no record of which arrivals they cover, so nothing
+ * can say how much a raw object of that pair would repeat. The pair is
+ * closed rather than combined with objects whose overlap is unknown.
+ *
+ * `rollup` — nothing of this pair is folded and a rollup covers it, so
+ * the rollup is the baseline and a receipt is written for it. One object
+ * stands in for the day's thousands, which is what makes a cold start
+ * over a wide window affordable at all.
+ *
+ * `raw` — everything else, and two different things reach it. A pair
+ * with raw contributions already stays raw, because a rollup written
+ * afterwards would overlap them. A pair no rollup covers is raw because
+ * there is nothing else to read, which is every local source: rollups
+ * cover the continuous-integration area alone.
+ */
+export function inputChoice(
+  known: { settled: boolean; foldedRaw: boolean; rollup: boolean },
+): InputChoice {
+  if (known.settled) return "settled";
+  if (known.foldedRaw || !known.rollup) return "raw";
+  return "rollup";
 }
 
 /**
@@ -337,6 +390,7 @@ export async function publish(
   args: readonly string[],
   store: StoreAccess = liveStore(storeBucket()),
   now: Date = new Date(),
+  topology: () => Promise<readonly Suite[]> = () => loadTopology(),
 ): Promise<number> {
   const options = parseArgs(args);
   if (options === undefined) {
@@ -386,43 +440,69 @@ export async function publish(
     }
   };
 
-  // A bootstrap folds each closed day from its rollup where one exists,
-  // which is one object against the day's thousands. The days it takes
-  // this way are recorded, so no later run over a wide window folds their
-  // raw objects on top of them and doubles every catch in them.
-  const compacted: string[] = [];
-  if (options.bootstrap) {
-    for (const day of partitions) {
-      const shards = await store.rollupShards(day);
-      if (shards === undefined) continue;
-      try {
-        // A day is folded whole or not at all: a shard that failed to
-        // read would leave the day partly folded, and marking it
-        // compacted would then hide the rest of it from every later run.
-        const reports = await mapConcurrent(
-          shards,
-          options.concurrency,
-          (objectName) => store.read(objectName),
-        );
-        for (const report of reports) noteReport(report);
-        fold.add(reports);
-        fold.markCompacted(day);
-        compacted.push(day);
-      } catch (error) {
-        console.warn(
-          `test selection: reading the rollup of ${day} failed: ${error}`,
-        );
-      }
+  // What each source and date still owes, from the one rule both modes
+  // apply. Only the continuous-integration area can answer anything but
+  // `raw`, because it is the only one rollups cover, so it is the only
+  // one the store is asked about — and it is asked only where the answer
+  // could be a rollup, so a run over days it has already read raw asks
+  // nothing.
+  const rollups = new Map<string, readonly string[]>();
+  const ciDays: string[] = [];
+  for (const date of partitions) {
+    const settled = fold.settled(CI_SOURCE, date);
+    const foldedRaw = fold.hasRaw(CI_SOURCE, date);
+    const shards = settled || foldedRaw
+      ? undefined
+      : await store.rollupShards(date);
+    switch (
+      inputChoice({ settled, foldedRaw, rollup: shards !== undefined })
+    ) {
+      case "rollup":
+        rollups.set(date, shards!);
+        break;
+      case "raw":
+        ciDays.push(date);
+        break;
+      case "settled":
+        break;
     }
+  }
+
+  let settled = 0;
+  for (const [date, shards] of rollups) {
+    try {
+      // A pair is folded whole or not at all: a shard that failed to read
+      // would leave it partly folded, and writing its receipt would then
+      // hide the rest of it from every later run.
+      const reports = await mapConcurrent(
+        shards,
+        options.concurrency,
+        (objectName) => store.read(objectName),
+      );
+      for (const report of reports) noteReport(report);
+      fold.add(reports);
+      fold.markSettled(CI_SOURCE, date);
+      settled++;
+    } catch (error) {
+      console.warn(
+        `test selection: reading the rollup of ${date} failed: ${error}`,
+      );
+      // No receipt was written, so the pair still owes what it owed, and
+      // the raw path is what is left to read it by.
+      ciDays.push(date);
+    }
+  }
+  if (rollups.size > 0) {
     console.log(
-      `test selection: folded ${compacted.length} day(s) from their rollups`,
+      `test selection: folded ${settled} day(s) from their rollups`,
     );
   }
 
-  const open = partitions.filter((day) => !fold.knowsDay(day));
   let listed: string[];
   try {
-    listed = await listSubmissions(store, open);
+    // Every day of the window for the local area: no local pair is ever
+    // settled, so the rule answers `raw` for each of them.
+    listed = await listSubmissions(store, ciDays, partitions);
   } catch (error) {
     console.warn(`test selection: listing the submissions failed: ${error}`);
     console.warn(
@@ -433,7 +513,7 @@ export async function publish(
   }
   const fresh = listed.filter((name) => !fold.knows(name));
   console.log(
-    `test selection: ${listed.length} object(s) under ${open.length} ` +
+    `test selection: ${listed.length} object(s) under ${ciDays.length} ` +
       `open day(s), ${fresh.length} not yet folded`,
   );
 
@@ -468,20 +548,40 @@ export async function publish(
   }
   const folded = fold.finish();
 
+  // The topology is what says where an identity runs. Its suite
+  // identifiers and units are what a lane looks a suite up by and what
+  // the packer charges overheads and capabilities against, so a manifest
+  // built without it names surfaces nothing in the tree answers to.
+  const suites = await topology();
+  const { placed, unplaced } = locateSurfaces(suites, folded.surfaces);
+  const states = new Map(
+    [...folded.states].filter(([key]) => placed.has(key)),
+  );
+
   const manifest = buildManifest({
-    states: folded.states,
+    states,
     mainRed: folded.mainRed,
-    surfaces: folded.surfaces,
+    surfaces: placed,
     today,
     generatedAt: startedAt.toISOString(),
     seed: ulid(),
     commit,
     runs: runs.size,
   });
+  manifest.unavailable = suites.flatMap((suite) =>
+    suite.unavailable.map((entry) => ({
+      suite: suite.id,
+      ...(suite.variant === undefined ? {} : { variant: suite.variant }),
+      unit: entry.unit,
+      ...(entry.leafName === undefined ? {} : { leafName: entry.leafName }),
+      ...(entry.phase === undefined ? {} : { phase: entry.phase }),
+      reason: entry.reason,
+    }))
+  );
   const reference = plan({
     manifest,
     mandatory: new Map(),
-    capabilities: new Map(),
+    capabilities: capabilitiesBySuite(suites),
   });
   // What the packer refused, from the packer, carrying the cost the bound
   // was compared against rather than a raw one that leaves out every
@@ -499,7 +599,7 @@ export async function publish(
       })),
   }));
 
-  summarize(manifest, reference, folded.observations);
+  summarize(manifest, reference, folded.observations, unplaced);
 
   if (options.out !== undefined) {
     await Deno.mkdir(options.out, { recursive: true });
@@ -543,11 +643,27 @@ function summarize(
   manifest: ReturnType<typeof buildManifest>,
   reference: ReturnType<typeof plan>,
   observations: number,
+  unplaced: Unplaced,
 ): void {
   console.log(
     `test selection: folded ${observations} execution(s) into ` +
       `${manifest.entries.length} identities`,
   );
+  if (unplaced.suiteLevel.length > 0) {
+    console.log(
+      `test selection: ${unplaced.suiteLevel.length} identities measure a ` +
+        `suite rather than anything a lane can be asked to run`,
+    );
+  }
+  if (unplaced.unclaimed.length > 0) {
+    // Almost always an identity whose records predate the registration
+    // preload, so nothing knows which file registers it. It is placed
+    // again the first time it runs and records one.
+    console.log(
+      `test selection: ${unplaced.unclaimed.length} identities no suite ` +
+        `claims, so no lane can run them`,
+    );
+  }
   const held = new Map<string, number>();
   for (const entry of manifest.withheld) {
     held.set(entry.reason, (held.get(entry.reason) ?? 0) + 1);
@@ -586,7 +702,13 @@ function summarize(
 }
 
 // Re-exported so an offline check can build the same day list.
-export { dayOf, manifestPrefix, newestAtOrBefore, serializeManifest };
+export {
+  dayOf,
+  manifestPrefix,
+  newestAtOrBefore,
+  partitionOf,
+  serializeManifest,
+};
 
 if (import.meta.main) {
   Deno.exit(await publish(Deno.args));

--- a/tasks/test-selection.test.ts
+++ b/tasks/test-selection.test.ts
@@ -517,6 +517,41 @@ describe("dispatch()", () => {
     expect(result.out).toContain("accounts for every unit");
   });
 
+  it("passes over a unit the configuration declares unavailable", async () => {
+    // A manifest holding nothing for a test that does not run is the
+    // manifest being right, so it is not something to fail on.
+    const suite = suiteHolding([
+      "packages/memory/test/memory.test.ts",
+      "packages/memory/test/skipped.test.ts",
+    ]);
+    const result = await ran(["plan", "--verify"], {
+      topology: () =>
+        Promise.resolve([{
+          ...suite,
+          unavailable: [{
+            unit: "packages/memory/test/skipped.test.ts",
+            phase: "phase-2",
+            reason: "the server-execution arm cannot run it yet",
+          }],
+        }]),
+    });
+    expect(result.code).toBe(0);
+    expect(result.out).not.toContain("skipped.test.ts");
+  });
+
+  it("reports a manifest entry the tree no longer enumerates", async () => {
+    // Nothing can be asked to run it, and the packer drops it without a
+    // word, so reporting it is the only place it is ever mentioned. It
+    // does not fail: a manifest is hours old, so a unit deleted since it
+    // was published is expected to linger in it.
+    const result = await ran(["plan", "--verify"], {
+      topology: () => Promise.resolve([suiteHolding(["packages/memory/x.ts"])]),
+    });
+    expect(result.out).toContain(
+      "no longer enumerates packages/memory/test/memory.test.ts",
+    );
+  });
+
   it("fails --verify on a unit the manifest holds nothing for", async () => {
     // Every lane treats such a unit as unknown and therefore mandatory,
     // so a manifest missing many of them is a run that selects nothing

--- a/tasks/test-selection.test.ts
+++ b/tasks/test-selection.test.ts
@@ -21,6 +21,7 @@ import {
   sampleManifest,
 } from "./test-selection/testing.ts";
 import type { ManifestEntry } from "./test-selection/manifest.ts";
+import type { Suite } from "./test-topology/suite.ts";
 import {
   DIALS,
   EXCLUDED_FROM_COVERAGE_GATE,
@@ -28,6 +29,27 @@ import {
 } from "./test-selection/policy.ts";
 
 const TEST = { k: "unit", s: "memory", n: "space > writes" };
+
+/**
+ * One suite enumerating exactly these units. The manifest fixtures put
+ * their entries under `workspace-unit`, so a topology naming that suite
+ * is what the two are compared through.
+ */
+function suiteHolding(units: readonly string[]): Suite {
+  return {
+    id: "workspace-unit",
+    recordSurfaces: [{ kind: "unit", scope: "memory" }],
+    needs: ["deno"],
+    units: [...units],
+    unavailable: [],
+    locate: () => undefined,
+    command: () => Promise.resolve([]),
+  };
+}
+
+const TOPOLOGY: Suite[] = [
+  suiteHolding(["packages/memory/test/memory.test.ts"]),
+];
 
 describe("test-selection", () => {
   describe("parseIdentityArgument()", () => {
@@ -153,7 +175,7 @@ describe("test-selection", () => {
           sampleEntry({ k: "unit", s: "memory", n: "two" }, { cost: 1 }),
         ],
       });
-      const text = planLines(manifest, undefined).join("\n");
+      const text = planLines(manifest, TOPOLOGY, undefined).join("\n");
       expect(text).toContain("2 known identities");
       expect(text).toContain(`${LANES} lanes`);
       expect(text).toContain("lane 1:");
@@ -163,7 +185,7 @@ describe("test-selection", () => {
       const manifest = sampleManifest({
         entries: [sampleEntry({ k: "unit", s: "memory", n: "one" })],
       });
-      const text = planLines(manifest, 3).join("\n");
+      const text = planLines(manifest, TOPOLOGY, 3).join("\n");
       expect(text).toContain("lane 3:");
       expect(text).not.toContain("lane 1:");
     });
@@ -174,7 +196,7 @@ describe("test-selection", () => {
           cost: 10_000,
         })],
       });
-      expect(planLines(manifest, undefined).join("\n")).toContain(
+      expect(planLines(manifest, TOPOLOGY, undefined).join("\n")).toContain(
         "unschedulable",
       );
     });
@@ -252,7 +274,7 @@ describe("verdictFor()", () => {
 
   it("reports a test the packer takes, and how often it takes it", () => {
     const manifest = sampleManifest({ entries: [entry("cheap", 0.1)] });
-    const verdict = verdictFor(manifest, {
+    const verdict = verdictFor(manifest, TOPOLOGY, {
       k: "unit",
       s: "memory",
       n: "cheap",
@@ -276,7 +298,7 @@ describe("verdictFor()", () => {
       },
     });
     const test = { k: "unit", s: "memory", n: "heavy" };
-    const verdict = verdictFor(manifest, test);
+    const verdict = verdictFor(manifest, TOPOLOGY, test);
     expect(verdict.unschedulable).toBe(true);
     expect(verdict.loneSeconds).toBeCloseTo(600, 5);
     // What `explain` prints is that figure, not the entry's own 200: a
@@ -288,18 +310,24 @@ describe("verdictFor()", () => {
   });
 
   it("reports a test no lane could hold as unschedulable, not selected", () => {
-    const verdict = verdictFor(manifestOf(entry("enormous", 100_000)), {
-      k: "unit",
-      s: "memory",
-      n: "enormous",
-    });
+    const verdict = verdictFor(
+      manifestOf(entry("enormous", 100_000)),
+      TOPOLOGY,
+      {
+        k: "unit",
+        s: "memory",
+        n: "enormous",
+      },
+    );
     expect(verdict.selected).toBe(false);
     expect(verdict.unschedulable).toBe(true);
   });
 
   it("reports a test the manifest has never heard of as unselected", () => {
     const manifest = manifestOf(entry("cheap", 0.1));
-    expect(verdictFor(manifest, { k: "unit", s: "memory", n: "absent" }))
+    expect(
+      verdictFor(manifest, TOPOLOGY, { k: "unit", s: "memory", n: "absent" }),
+    )
       .toEqual({ selected: false });
   });
 
@@ -310,11 +338,17 @@ describe("verdictFor()", () => {
       }),
     );
     expect(
-      verdictFor(manifest, { k: "unit", s: "memory", n: "both", v: "on" })
+      verdictFor(manifest, TOPOLOGY, {
+        k: "unit",
+        s: "memory",
+        n: "both",
+        v: "on",
+      })
         .selected,
     ).toBe(true);
     expect(
-      verdictFor(manifest, { k: "unit", s: "memory", n: "both" }).selected,
+      verdictFor(manifest, TOPOLOGY, { k: "unit", s: "memory", n: "both" })
+        .selected,
     ).toBe(false);
   });
 });
@@ -361,6 +395,7 @@ describe("dispatch()", () => {
         members: () => Promise.resolve(["packages/memory"]),
         aliases: () =>
           Promise.resolve({ resolve: (test: TestIdentity) => test }),
+        topology: () => Promise.resolve(TOPOLOGY),
         ...sources,
       } as Sources);
       return { code, out: out.join("\n"), err: err.join("\n") };
@@ -476,15 +511,26 @@ describe("dispatch()", () => {
     expect(result.stop?.message).toContain("whole number from 1 to");
   });
 
-  it("stops on --verify before reading a manifest", async () => {
-    // The mode does not read one, so a store it never needed must not be
-    // what it fails on.
+  it("verifies the manifest against the tree", async () => {
+    const result = await ran(["plan", "--verify"]);
+    expect(result.code).toBe(0);
+    expect(result.out).toContain("accounts for every unit");
+  });
+
+  it("fails --verify on a unit the manifest holds nothing for", async () => {
+    // Every lane treats such a unit as unknown and therefore mandatory,
+    // so a manifest missing many of them is a run that selects nothing
+    // and tests everything.
     const result = await ran(["plan", "--verify"], {
-      manifest: () => {
-        throw new Error("--verify must not read a manifest");
-      },
+      topology: () =>
+        Promise.resolve([
+          suiteHolding([
+            "packages/memory/test/memory.test.ts",
+            "unrun.test.ts",
+          ]),
+        ]),
     });
-    expect(result.code).toBe(2);
-    expect(result.stop?.message).toContain("test topology");
+    expect(result.code).toBe(1);
+    expect(result.out).toContain("no identity for workspace-unit: unrun");
   });
 });

--- a/tasks/test-selection.ts
+++ b/tasks/test-selection.ts
@@ -457,7 +457,7 @@ const LIVE: Sources = {
   manifest: newestManifest,
   members: gatedMembers,
   aliases: loadAliasResolver,
-  topology: () => loadTopology(),
+  topology: loadTopology,
 };
 
 /**

--- a/tasks/test-selection.ts
+++ b/tasks/test-selection.ts
@@ -29,6 +29,8 @@ import {
   LANES,
 } from "./test-selection/policy.ts";
 import { fetchManifest } from "./test-selection/store.ts";
+import { capabilitiesBySuite, loadTopology } from "./test-topology.ts";
+import { type Suite, unavailableUnits } from "./test-topology/suite.ts";
 import type { Manifest } from "./test-selection/manifest.ts";
 import { plan } from "./test-selection/plan.ts";
 import { readWorkspaceMembers } from "./workspace-tests.ts";
@@ -262,22 +264,27 @@ function laneLine(
 
 /**
  * The packing, over a manifest and no diff, as a lane would compute it.
- * Which capabilities a suite needs is declared by the topology, which
- * lands with part two, so until then the map is empty and a lane's
- * capability setup costs nothing here. The publisher computes its
- * reference plan the same way and for the same reason.
+ * The capabilities a suite opens are most of what a lane's budget goes
+ * on, so the topology is what makes this the answer a lane would give
+ * rather than one that leaves the setup out. The publisher computes its
+ * reference plan the same way.
  */
-function planFor(manifest: Manifest) {
-  return plan({ manifest, mandatory: new Map(), capabilities: new Map() });
+function planFor(manifest: Manifest, suites: readonly Suite[]) {
+  return plan({
+    manifest,
+    mandatory: new Map(),
+    capabilities: capabilitiesBySuite(suites),
+  });
 }
 
 /** What `plan --dry-run` prints, as lines. */
 export function planLines(
   manifest: Manifest,
+  suites: readonly Suite[],
   laneNumber: number | undefined,
 ): string[] {
   const lines: string[] = [];
-  const result = planFor(manifest);
+  const result = planFor(manifest, suites);
   const lanes = laneNumber === undefined
     ? result.lanes
     : result.lanes.filter((lane) => lane.lane === laneNumber);
@@ -328,9 +335,10 @@ export function planLines(
  */
 export function verdictFor(
   manifest: Manifest,
+  suites: readonly Suite[],
   test: TestIdentity,
 ): PlanVerdict {
-  const result = planFor(manifest);
+  const result = planFor(manifest, suites);
   const key = testIdentityKey(test);
   const taken = result.lanes.flatMap((lane) => lane.selections).find((
     selection,
@@ -345,6 +353,73 @@ export function verdictFor(
     verdict.loneSeconds = refused.cost;
   }
   return verdict;
+}
+
+/** What comparing the manifest against the working tree found. */
+export interface Verification {
+  lines: string[];
+
+  /** Whether anything it found should stop a build. */
+  fails: boolean;
+}
+
+/**
+ * Whether the newest manifest accounts for the tree in front of it.
+ *
+ * Two directions, and they are not the same claim. A unit the topology
+ * enumerates that the manifest holds nothing for is one every lane
+ * treats as unknown and therefore mandatory, so a manifest missing many
+ * of them is a run that selects nothing and tests everything. That is
+ * what this fails on, and it is the check to run before anything depends
+ * on selection working.
+ *
+ * A manifest entry naming a suite or unit the tree no longer holds is
+ * work no lane can be asked to do, and the packer drops it silently. It
+ * is reported rather than failed on, the way the drift guard reports its
+ * own reverse direction: a manifest is hours old by construction, so a
+ * unit deleted since it was published is expected to linger in it.
+ */
+export function verifyLines(
+  manifest: Manifest,
+  suites: readonly Suite[],
+): Verification {
+  const held = new Set(
+    manifest.entries.map((entry) => `${entry.suite}\t${entry.unit}`),
+  );
+  const enumerated = new Set<string>();
+  const missing: string[] = [];
+  for (const suite of suites) {
+    // A unit this configuration declares unavailable does not run, so a
+    // manifest holding nothing for it is the manifest being right.
+    const unavailable = unavailableUnits(suite);
+    for (const unit of suite.units) {
+      if (unavailable.has(unit)) continue;
+      enumerated.add(`${suite.id}\t${unit}`);
+      if (!held.has(`${suite.id}\t${unit}`)) {
+        missing.push(`${suite.id}: ${unit}`);
+      }
+    }
+  }
+  const stale = [...held].filter((key) => !enumerated.has(key)).sort();
+  const lines = [
+    `manifest of ${manifest.generatedAt}, from ${manifest.runs} runs at ` +
+    `${manifest.commit}`,
+    `${enumerated.size} units enumerated, ${manifest.entries.length} ` +
+    `identities in the manifest`,
+  ];
+  for (const unit of missing.sort()) {
+    lines.push(`  no identity for ${unit}, so every lane runs it as unknown`);
+  }
+  for (const key of stale) {
+    const [suite, unit] = key.split("\t") as [string, string];
+    lines.push(
+      `  reported: ${suite} no longer enumerates ${unit}, so nothing runs it`,
+    );
+  }
+  if (missing.length === 0) {
+    lines.push("  the manifest accounts for every unit the topology holds");
+  }
+  return { lines, fails: missing.length > 0 };
 }
 
 /** The manifest the newest publisher run wrote, or nothing with a reason. */
@@ -373,12 +448,16 @@ export interface Sources {
   aliases(): Promise<{
     resolve(test: TestIdentity, day: string): TestIdentity;
   }>;
+
+  /** The suites, read from the working tree. */
+  topology(): Promise<readonly Suite[]>;
 }
 
 const LIVE: Sources = {
   manifest: newestManifest,
   members: gatedMembers,
   aliases: loadAliasResolver,
+  topology: () => loadTopology(),
 };
 
 /**
@@ -425,11 +504,12 @@ export async function dispatch(
         test,
         manifest.generatedAt.slice(0, 10),
       );
+      const suites = await sources.topology();
       for (
         const line of explainLines(
           manifest,
           resolved,
-          verdictFor(manifest, resolved),
+          verdictFor(manifest, suites, resolved),
         )
       ) {
         console.log(line);
@@ -437,14 +517,8 @@ export async function dispatch(
       return 0;
     }
     case "plan": {
-      // Before the manifest, because this mode does not read one and
-      // would otherwise fail on a store it never needed.
-      if (args.includes("--verify")) {
-        fail(
-          "plan --verify needs the test topology, which is not in the tree " +
-            "yet.\nSee docs/plans/pull-request-test-selection.md, part two.",
-        );
-      }
+      // Before the manifest, because a lane number this cannot read is a
+      // mistake to report rather than a reason to reach for the store.
       const laneNumber = laneArgument(args);
       // Silently filtering every lane would exit zero having printed
       // nothing, which reads as "this lane runs no tests".
@@ -453,7 +527,15 @@ export async function dispatch(
       }
       const manifest = await sources.manifest();
       if (manifest === undefined) return 1;
-      for (const line of planLines(manifest, laneNumber)) console.log(line);
+      const suites = await sources.topology();
+      if (args.includes("--verify")) {
+        const verification = verifyLines(manifest, suites);
+        for (const line of verification.lines) console.log(line);
+        return verification.fails ? 1 : 0;
+      }
+      for (const line of planLines(manifest, suites, laneNumber)) {
+        console.log(line);
+      }
       return 0;
     }
     default:

--- a/tasks/test-selection/build.test.ts
+++ b/tasks/test-selection/build.test.ts
@@ -16,6 +16,7 @@ import {
   Fold,
   foldReports,
   identityOfKey,
+  lastRun,
   localReporter,
   locateSurfaces,
   parseAggregate,
@@ -546,6 +547,22 @@ describe("build", () => {
       expect(unplaced.unclaimed).toEqual([KEY]);
     });
 
+    it("passes over a key that names no identity", () => {
+      // The surfaces come from a stored aggregate, which is untrusted
+      // input like every other object in the store, so a key nothing can
+      // read is skipped rather than thrown on.
+      const { placed, unplaced } = locateSurfaces(
+        [claiming("workspace-unit", () => ({ level: "unit", unit: "one" }))],
+        new Map([["not an identity key", {
+          suite: "unit:memory",
+          unit: "space > writes",
+          fromFile: false,
+        }]]),
+      );
+      expect(placed.size).toBe(0);
+      expect(unplaced).toEqual({ suiteLevel: [], unclaimed: [] });
+    });
+
     it("passes on an identity two suites claim", () => {
       // Two claims on one identity is a topology defect that the drift
       // guard fails on, and placing it either way would put the work in
@@ -611,6 +628,20 @@ describe("build", () => {
       expect(manifest.withheld.map((held) => held.reason)).toEqual([
         "main-red",
       ]);
+    });
+
+    it("takes the last day an identity actually ran, not the last it holds", () => {
+      // A day can be carried with no runs in it once the counters have
+      // been aged, and reading that as the last run would tell the
+      // exploration draw a test it has been ignoring was just run.
+      expect(lastRun({
+        ...emptyState(),
+        runsByDay: { "2026-08-18": 3, "2026-08-19": 0, "2026-08-20": 0 },
+      })).toBe("2026-08-18");
+    });
+
+    it("has no last day for an identity nothing has run", () => {
+      expect(lastRun(emptyState())).toBeUndefined();
     });
 
     it("carries the last day anything ran an identity", () => {

--- a/tasks/test-selection/build.test.ts
+++ b/tasks/test-selection/build.test.ts
@@ -10,12 +10,14 @@ import {
 
 import {
   buildManifest,
+  CI_SOURCE,
   dayOf,
   emptyAggregate,
   Fold,
   foldReports,
   identityOfKey,
   localReporter,
+  locateSurfaces,
   parseAggregate,
   provenance,
   readReport,
@@ -24,6 +26,7 @@ import {
   reportFromText,
 } from "./build.ts";
 import { parseManifest, serializeManifest } from "./manifest.ts";
+import type { Suite } from "../test-topology/suite.ts";
 import {
   daysBetween,
   emptyState,
@@ -285,35 +288,80 @@ describe("build", () => {
         NO_ALIASES,
         "2026-08-20",
       );
-      expect(fold.knowsDay("2026/08/10")).toBe(false);
-      fold.markCompacted("2026/08/10");
-      expect(fold.knowsDay("2026/08/10")).toBe(true);
-      expect(fold.finish().aggregate.compactedDays).toEqual(["2026/08/10"]);
+      expect(fold.settled(CI_SOURCE, "2026/08/10")).toBe(false);
+      fold.markSettled(CI_SOURCE, "2026/08/10");
+      expect(fold.settled(CI_SOURCE, "2026/08/10")).toBe(true);
+      expect(fold.finish().aggregate.compacted).toEqual(["ci\t2026/08/10"]);
     });
 
-    it("carries the compacted days across a saved aggregate", () => {
+    it("leaves a local source of a settled day still owing", () => {
+      // Rollups cover the continuous-integration area alone, so a receipt
+      // naming the day by itself would say the day is accounted for and
+      // that day's local submissions would never be read.
+      const fold = new Fold(
+        emptyAggregate("2026-08-20"),
+        NO_ALIASES,
+        "2026-08-20",
+      );
+      fold.markSettled(CI_SOURCE, "2026/08/10");
+      expect(fold.settled("local/ianh", "2026/08/10")).toBe(false);
+    });
+
+    it("knows which source and date it holds raw objects from", () => {
+      // A rollup written after them would overlap what they contributed,
+      // and nothing in one of this format says by how much.
+      const fold = new Fold(
+        {
+          ...emptyAggregate("2026-08-20"),
+          folded: [CI_NAME, LOCAL_NAME],
+        },
+        NO_ALIASES,
+        "2026-08-20",
+      );
+      expect(fold.hasRaw(CI_SOURCE, "2026/08/20")).toBe(true);
+      expect(fold.hasRaw("local/ianh", "2026/08/20")).toBe(true);
+      expect(fold.hasRaw(CI_SOURCE, "2026/08/19")).toBe(false);
+      expect(fold.hasRaw("local/someone-else", "2026/08/20")).toBe(false);
+    });
+
+    it("carries the settled pairs across a saved aggregate", () => {
       const first = new Fold(
         emptyAggregate("2026-08-20"),
         NO_ALIASES,
         "2026-08-20",
       );
-      first.markCompacted("2026/08/10");
+      first.markSettled(CI_SOURCE, "2026/08/10");
       const saved = parseAggregate(
         JSON.stringify(first.finish().aggregate),
       );
       expect(saved).toBeDefined();
       const second = new Fold(saved!, NO_ALIASES, "2026-08-21");
-      expect(second.knowsDay("2026/08/10")).toBe(true);
+      expect(second.settled(CI_SOURCE, "2026/08/10")).toBe(true);
     });
 
-    it("reads an aggregate written before rollups as compacting nothing", () => {
+    it("reads an aggregate written before rollups as settling nothing", () => {
       const older = { ...emptyAggregate("2026-08-20") } as Record<
         string,
         unknown
       >;
-      delete older.compactedDays;
+      delete older.compacted;
       const parsed = parseAggregate(JSON.stringify(older));
-      expect(parsed?.compactedDays).toEqual([]);
+      expect(parsed?.compacted).toEqual([]);
+    });
+
+    it("reads a receipt naming a day alone as the shared area's", () => {
+      // That area is the only one a rollup has ever covered, so nothing
+      // else could have written the receipt, and reading it forward is
+      // exact rather than a guess.
+      const older = { ...emptyAggregate("2026-08-20") } as Record<
+        string,
+        unknown
+      >;
+      delete older.compacted;
+      older.compactedDays = ["2026/08/10"];
+      expect(parseAggregate(JSON.stringify(older))?.compacted).toEqual([
+        "ci\t2026/08/10",
+      ]);
     });
 
     it("carries what the cross-run rules saw into the next run", () => {
@@ -381,7 +429,7 @@ describe("build", () => {
         day: "2026-08-20",
         folded: [],
         states: {},
-        compactedDays: [],
+        compacted: [],
       };
       const refused: Array<[string, unknown]> = [
         ["a document that is not an object", 7],
@@ -393,9 +441,9 @@ describe("build", () => {
         ["null states", { ...whole, states: null }],
         [
           "a compacted list that is not one",
-          { ...whole, compactedDays: "2026-08-20" },
+          { ...whole, compacted: "2026-08-20" },
         ],
-        ["a compacted day that is not one", { ...whole, compactedDays: [7] }],
+        ["a settled pair that is not one", { ...whole, compacted: [7] }],
       ];
       for (const [what, value] of refused) {
         expect(parseAggregate(JSON.stringify(value)), what).toBeUndefined();
@@ -411,7 +459,7 @@ describe("build", () => {
         folded: [],
         states: {},
       };
-      expect(parseAggregate(JSON.stringify(before))?.compactedDays).toEqual([]);
+      expect(parseAggregate(JSON.stringify(before))?.compacted).toEqual([]);
     });
   });
 
@@ -434,6 +482,85 @@ describe("build", () => {
       expect(identityOfKey("not json")).toBeUndefined();
       expect(identityOfKey('["unit","memory"]')).toBeUndefined();
       expect(identityOfKey('["unit",1,"a"]')).toBeUndefined();
+    });
+  });
+
+  describe("locateSurfaces()", () => {
+    /** A suite claiming what a case tells it to. */
+    function claiming(id: string, locate: Suite["locate"]): Suite {
+      return {
+        id,
+        recordSurfaces: [{ kind: "unit", scope: "memory" }],
+        needs: ["deno"],
+        units: [],
+        unavailable: [],
+        locate,
+        command: () => Promise.resolve([]),
+      };
+    }
+
+    it("names the suite and unit the topology says, not the record's own", () => {
+      const { placed } = locateSurfaces(
+        [claiming("workspace-unit", () => ({
+          level: "unit",
+          unit: "packages/memory/test/space.test.ts",
+        }))],
+        new Map([[KEY, {
+          suite: "unit:memory",
+          unit: "packages/memory/test/space.test.ts",
+          fromFile: true,
+        }]]),
+      );
+      expect(placed.get(KEY)).toEqual({
+        suite: "workspace-unit",
+        unit: "packages/memory/test/space.test.ts",
+        fromFile: true,
+      });
+    });
+
+    it("passes on an identity that measures the suite rather than a unit", () => {
+      // An overlapping whole-invocation record names no unit, so nothing
+      // can be asked to run one of them.
+      const { placed, unplaced } = locateSurfaces(
+        [claiming("cli-core", () => ({ level: "suite" }))],
+        new Map([[KEY, {
+          suite: "unit:memory",
+          unit: "space > writes",
+          fromFile: false,
+        }]]),
+      );
+      expect(placed.size).toBe(0);
+      expect(unplaced.suiteLevel).toEqual([KEY]);
+    });
+
+    it("passes on an identity no suite claims", () => {
+      const { placed, unplaced } = locateSurfaces(
+        [claiming("workspace-unit", () => undefined)],
+        new Map([[KEY, {
+          suite: "unit:memory",
+          unit: "space > writes",
+          fromFile: false,
+        }]]),
+      );
+      expect(placed.size).toBe(0);
+      expect(unplaced.unclaimed).toEqual([KEY]);
+    });
+
+    it("passes on an identity two suites claim", () => {
+      // Two claims on one identity is a topology defect that the drift
+      // guard fails on, and placing it either way would put the work in
+      // whichever suite happened to come first.
+      const unit = { level: "unit" as const, unit: "one" };
+      const { placed, unplaced } = locateSurfaces(
+        [claiming("a", () => unit), claiming("b", () => unit)],
+        new Map([[KEY, {
+          suite: "unit:memory",
+          unit: "space > writes",
+          fromFile: false,
+        }]]),
+      );
+      expect(placed.size).toBe(0);
+      expect(unplaced.unclaimed).toEqual([KEY]);
     });
   });
 
@@ -484,6 +611,38 @@ describe("build", () => {
       expect(manifest.withheld.map((held) => held.reason)).toEqual([
         "main-red",
       ]);
+    });
+
+    it("carries the last day anything ran an identity", () => {
+      // The exploration draw takes the longest-unrun first, so without
+      // this it has nothing to order by and sweeps nothing.
+      const folded = foldReports(
+        emptyAggregate("2026-08-19"),
+        [
+          stored(CI_NAME, context(), [record()]),
+          stored(
+            `${CI_NAME}2`,
+            context({
+              commit: "c2",
+              startedAt: "2026-08-19T00:00:00.000Z",
+            }),
+            [record()],
+          ),
+        ],
+        NO_ALIASES,
+        "2026-08-20",
+      );
+      const manifest = buildManifest({
+        states: folded.states,
+        mainRed: folded.mainRed,
+        surfaces: folded.surfaces,
+        today: "2026-08-20",
+        generatedAt: "2026-08-20T04:00:00.000Z",
+        seed: "01K3",
+        commit: "c1",
+        runs: 2,
+      });
+      expect(manifest.entries[0]!.lastRun).toBe("2026-08-20");
     });
   });
 });

--- a/tasks/test-selection/build.ts
+++ b/tasks/test-selection/build.ts
@@ -39,6 +39,8 @@ import {
   trimWindows,
   value,
 } from "./score.ts";
+import { claimsFor } from "../test-topology.ts";
+import type { Suite } from "../test-topology/suite.ts";
 import {
   type Calibration,
   dialSnapshot,
@@ -80,12 +82,19 @@ export interface AggregateState {
   context?: StoredFoldContext;
 
   /**
-   * Days folded from a rollup rather than from their raw objects,
-   * "yyyy/mm/dd". A rollup carries a day's reports whole, so its raw
-   * objects are not in `folded` and a later run over a wide window would
-   * otherwise fold that day a second time and double every catch in it.
+   * The source-and-date pairs folded from a rollup rather than from their
+   * raw objects, each `"<source>\t<date>"`. A rollup carries its pair's
+   * reports whole, so those raw objects are not in `folded` and a later
+   * run over a wide window would otherwise fold them on top of it and
+   * double every catch in them.
+   *
+   * Scoped to the source and not only to the date, because rollups cover
+   * the continuous-integration area alone. A receipt naming the date by
+   * itself would say the day is accounted for, and the local submissions
+   * of that day — the evidence the score weighs highest — would never be
+   * read.
    */
-  compactedDays: string[];
+  compacted: string[];
 
   states: Record<string, IdentityState>;
 }
@@ -97,9 +106,32 @@ export function emptyAggregate(day: string): AggregateState {
     day,
     folded: [],
     context: serializeContext(emptyContext()),
-    compactedDays: [],
+    compacted: [],
     states: {},
   };
+}
+
+/** The submission area an object was written into. */
+export const CI_SOURCE = "ci";
+
+/**
+ * The area a submission object belongs to: the shared
+ * continuous-integration one, or one person's own. It is what a rollup
+ * covers and what a receipt is scoped to.
+ */
+export function sourceOf(objectName: string): string {
+  const who = localReporter(objectName);
+  return who === undefined ? CI_SOURCE : `local/${who}`;
+}
+
+/** The day partition in a submission object's name. */
+export function partitionOf(objectName: string): string {
+  return objectName.match(/\/v1\/(\d{4}\/\d{2}\/\d{2})\//)?.[1] ?? "";
+}
+
+/** How a source and a date name one pair, for a receipt or a lookup. */
+export function sourceDateKey(source: string, date: string): string {
+  return `${source}\t${date}`;
 }
 
 /**
@@ -137,17 +169,25 @@ export function parseAggregate(text: string): AggregateState | undefined {
   // The context is an optimization rather than a stored fact, so an
   // aggregate written without one, or with a malformed one, simply starts
   // the two cross-run rules from nothing.
-  const compactedDays = state.compactedDays ?? [];
-  if (!Array.isArray(compactedDays)) return undefined;
-  for (const day of compactedDays) {
-    if (typeof day !== "string") return undefined;
+  //
+  // A receipt written before the source was part of one names a date
+  // alone. Reading it forward as the continuous-integration area is
+  // exact rather than a guess: that area is the only one a rollup has
+  // ever covered, so nothing else could have written the receipt.
+  const written = state.compacted ?? state.compactedDays ?? [];
+  if (!Array.isArray(written)) return undefined;
+  for (const pair of written) {
+    if (typeof pair !== "string") return undefined;
   }
+  const compacted = state.compacted === undefined
+    ? (written as string[]).map((day) => sourceDateKey(CI_SOURCE, day))
+    : written as string[];
   return {
     schema: MANIFEST_SCHEMA_VERSION,
     day: state.day,
     folded: state.folded as string[],
     context: serializeContext(parseContext(state.context)),
-    compactedDays: compactedDays as string[],
+    compacted,
     states: state.states as Record<string, IdentityState>,
   };
 }
@@ -278,6 +318,78 @@ export function recordSurface(
   return { suite, unit: file ?? test.n, fromFile: file !== undefined };
 }
 
+/** What the topology could not place, and why. */
+export interface Unplaced {
+  /**
+   * Identities whose only claim is on the suite as a whole: the
+   * overlapping whole-invocation measurements a script records beside
+   * its own steps. They name no unit, so nothing can be asked to run one
+   * of them, and summing them with their own steps would count that work
+   * twice.
+   */
+  suiteLevel: string[];
+
+  /**
+   * Identities no suite claims at a unit level. An identity recorded
+   * before the registration preload carried its file is the usual one:
+   * the store knows the test and nothing knows which file registers it,
+   * so it will be placed again the first time it runs and records one.
+   */
+  unclaimed: string[];
+}
+
+/**
+ * Where each identity runs, as the topology says rather than as its own
+ * record surface guesses.
+ *
+ * Both halves of the system key on the suite identifier and unit a
+ * manifest carries: the lane runner asks the topology for the suite by
+ * that name, and the packer charges that suite's overhead and its
+ * capabilities. A manifest naming a surface derived from the record's
+ * own kind and scope matches no suite, so every unit reads as unknown
+ * and every selection is dropped for naming a suite the tree does not
+ * hold.
+ *
+ * An identity this cannot place is left out of the manifest rather than
+ * carried under a name nothing can run, and is reported so that the two
+ * reasons for it stay visible.
+ */
+export function locateSurfaces(
+  suites: readonly Suite[],
+  surfaces: ReadonlyMap<string, Surface>,
+): { placed: Map<string, Surface>; unplaced: Unplaced } {
+  const placed = new Map<string, Surface>();
+  const unplaced: Unplaced = { suiteLevel: [], unclaimed: [] };
+  for (const [key, surface] of surfaces) {
+    const test = identityOfKey(key);
+    if (test === undefined) continue;
+    const claims = claimsFor(suites, {
+      test,
+      // The unit a record's own surface fell back to is the file where
+      // one was recorded, and the identity's own name where none was.
+      // Only the first is a file, and only that is what `locate` joins
+      // on.
+      ...(surface.fromFile ? { file: surface.unit } : {}),
+    });
+    // Two suites claiming one identity is a topology defect rather than
+    // an ambiguity to settle here, and the drift guard is what fails on
+    // it. Placing it either way would put the work in whichever suite
+    // came first.
+    const unit = claims.length === 1 ? claims[0]!.unit : undefined;
+    if (unit !== undefined) {
+      placed.set(key, {
+        suite: claims[0]!.suite.id,
+        unit,
+        fromFile: surface.fromFile,
+      });
+      continue;
+    }
+    if (claims.length === 1) unplaced.suiteLevel.push(key);
+    else unplaced.unclaimed.push(key);
+  }
+  return { placed, unplaced };
+}
+
 /** How many times a lane runs an identity, given how flaky it is. */
 export function repeatsFor(rate: number): number {
   if (rate > FLAKE_EXCLUSION_RATE) return 1;
@@ -332,6 +444,21 @@ export function identityOfKey(key: string): TestIdentity | undefined {
   return test;
 }
 
+/**
+ * The last day this identity is known to have run. The run counts are
+ * kept per day and aged rather than kept forever, so an identity nothing
+ * has run inside that reach has no answer, which the exploration draw
+ * reads as the longest unrun of all.
+ */
+export function lastRun(state: IdentityState): string | undefined {
+  let latest: string | undefined;
+  for (const [day, runs] of Object.entries(state.runsByDay)) {
+    if (runs <= 0) continue;
+    if (latest === undefined || day > latest) latest = day;
+  }
+  return latest;
+}
+
 /** Builds a manifest from folded state. */
 export function buildManifest(input: BuildInput): Manifest {
   const entries: ManifestEntry[] = [];
@@ -347,6 +474,7 @@ export function buildManifest(input: BuildInput): Manifest {
     // the difference between a rounded float and a full one is megabytes.
     inputs.catches = round(inputs.catches, 2);
     inputs.churn = round(inputs.churn, 6);
+    const ran = lastRun(state);
     entries.push({
       test,
       suite: surface.suite,
@@ -356,6 +484,7 @@ export function buildManifest(input: BuildInput): Manifest {
       inputs,
       flakeRate: round(rate, 4),
       repeats: repeatsFor(rate),
+      ...(ran === undefined ? {} : { lastRun: ran }),
     });
     if (input.mainRed.has(key)) {
       withheld.push({ test, suite: surface.suite, reason: "main-red" });
@@ -400,7 +529,13 @@ export class Fold {
   readonly #samples = new Map<string, Map<string, DaySamples>>();
   readonly #folded: string[];
   readonly #foldedIndex: Set<string>;
-  readonly #compactedDays: string[];
+  readonly #compacted: string[];
+
+  /**
+   * The source-and-date pairs `folded` holds raw objects from, which is
+   * what says a rollup written later would overlap them.
+   */
+  readonly #rawPairs: Set<string>;
   readonly #resolver: AliasResolver;
   readonly #today: string;
   #observations = 0;
@@ -421,7 +556,12 @@ export class Fold {
     // object per run, and the list grows without bound, so the question
     // is answered against a set rather than by scanning.
     this.#foldedIndex = new Set(this.#folded);
-    this.#compactedDays = [...aggregate.compactedDays];
+    this.#compacted = [...aggregate.compacted];
+    this.#rawPairs = new Set(
+      this.#folded.map((name) =>
+        sourceDateKey(sourceOf(name), partitionOf(name))
+      ),
+    );
     this.#resolver = resolver;
     this.#today = today;
   }
@@ -437,20 +577,31 @@ export class Fold {
   }
 
   /**
-   * Whether this day was folded from a rollup. Its raw objects are not in
-   * `folded`, so a caller listing them has to ask about the day instead
-   * or it will fold the day twice.
+   * Whether this source and date were folded from a rollup. Their raw
+   * objects are not in `folded`, so a caller listing them has to ask
+   * about the pair instead or it will fold the pair twice.
    */
-  knowsDay(day: string): boolean {
-    return this.#compactedDays.includes(day);
+  settled(source: string, date: string): boolean {
+    return this.#compacted.includes(sourceDateKey(source, date));
   }
 
   /**
-   * Records that a day came from its rollup, so no later run folds the
-   * raw objects the rollup summarizes.
+   * Whether any raw object of this source and date is already folded. A
+   * rollup written later would overlap those contributions, and nothing
+   * in a rollup of this format says by how much, so a pair that answers
+   * yes stays on the raw path.
    */
-  markCompacted(day: string): void {
-    if (!this.#compactedDays.includes(day)) this.#compactedDays.push(day);
+  hasRaw(source: string, date: string): boolean {
+    return this.#rawPairs.has(sourceDateKey(source, date));
+  }
+
+  /**
+   * Records that a source and date came from their rollup, so no later
+   * run folds the raw objects the rollup summarizes.
+   */
+  markSettled(source: string, date: string): void {
+    const key = sourceDateKey(source, date);
+    if (!this.#compacted.includes(key)) this.#compacted.push(key);
   }
 
   /**
@@ -540,7 +691,7 @@ export class Fold {
         day: this.#today,
         folded: this.#folded,
         context: serializeContext(this.#context),
-        compactedDays: this.#compactedDays,
+        compacted: this.#compacted,
         states: Object.fromEntries(this.#states),
       },
       states: this.#states,

--- a/tasks/test-selection/plan.test.ts
+++ b/tasks/test-selection/plan.test.ts
@@ -381,6 +381,40 @@ describe("plan", () => {
       const reasons = new Set(selected(result).map((s) => s.reason));
       expect(reasons.has("exploration")).toBe(true);
     });
+
+    it("draws the longest-unrun first", () => {
+      // What makes the draw a sweep of the corpus rather than a sample
+      // of it: everything ran yesterday except one that has not run for
+      // a year, and that one is what the draw reaches for.
+      const manifest = sampleManifest({
+        entries: entries(60, (i) => ({
+          cost: 1,
+          score: 0.05,
+          lastRun: i === 41 ? "2025-09-01" : "2026-08-31",
+        })),
+      });
+      const result = run(manifest, { budgetSeconds: 2, lanes: 1 });
+      const drawn = selected(result).filter((s) => s.reason === "exploration");
+      expect(drawn.length).toBeGreaterThan(0);
+      expect(testIdentityKey(drawn[0]!.entry.test)).toBe(
+        testIdentityKey({ k: "unit", s: "memory", n: "case 41" }),
+      );
+    });
+
+    it("draws an identity nothing has run ahead of every day there is", () => {
+      const manifest = sampleManifest({
+        entries: entries(60, (i) => ({
+          cost: 1,
+          score: 0.05,
+          ...(i === 17 ? {} : { lastRun: "2020-01-01" }),
+        })),
+      });
+      const result = run(manifest, { budgetSeconds: 2, lanes: 1 });
+      const drawn = selected(result).filter((s) => s.reason === "exploration");
+      expect(testIdentityKey(drawn[0]!.entry.test)).toBe(
+        testIdentityKey({ k: "unit", s: "memory", n: "case 17" }),
+      );
+    });
   });
 
   describe("capabilities", () => {

--- a/tasks/test-selection/plan.ts
+++ b/tasks/test-selection/plan.ts
@@ -490,16 +490,29 @@ export function plan(input: PlanInput): Plan {
     withRepeats,
   );
 
-  // Exploration: a seeded draw over what the value ordering did not pick,
-  // so the whole corpus is swept over time rather than sampled with
+  // Exploration: a draw over what the value ordering did not pick, so
+  // the whole corpus is swept over time rather than sampled with
   // replacement forever.
+  //
+  // Longest-unrun first, with the seeded shuffle breaking ties. Sweeping
+  // is what the ordering buys: a test the draw reaches goes to the back
+  // of the queue until everything else has had a turn, where a shuffle
+  // alone would keep drawing from the whole corpus and leave part of it
+  // unvisited for as long as chance allowed. It also covers whatever the
+  // value model is currently blind to, without anything having to know
+  // what that is.
   const pool = remaining();
   const order = seededOrder(manifest.seed, pool.length);
+  const drawn = order.map((i) => pool[i]!);
+  // An identity nothing has run inside the aggregate's reach carries no
+  // day at all, and it is the one most worth drawing, so it sorts ahead
+  // of every day there is.
+  drawn.sort((a, b) => (a.lastRun ?? "").localeCompare(b.lastRun ?? ""));
   fill(
     input,
     lanes,
     taken,
-    order.map((i) => pool[i]!),
+    drawn,
     "exploration",
     mandatoryLoad +
       left * (FILL_VALUE_SHARE + FILL_DENSITY_SHARE + FILL_EXPLORATION_SHARE),

--- a/tasks/test-topology.test.ts
+++ b/tasks/test-topology.test.ts
@@ -9,7 +9,6 @@ import {
   topologyUnits,
 } from "./test-topology.ts";
 import { CAPABILITIES } from "./ci-capabilities.ts";
-import { stepArms } from "./test-topology/cli.ts";
 
 const suites = await loadTopology(
   new URL("..", import.meta.url).pathname.replace(/\/$/, ""),
@@ -142,39 +141,42 @@ describe("reading the topology as a whole", () => {
   });
 });
 
-describe("reading the command-line dispatch table", () => {
-  it("takes the arm that runs a step alone, never a group arm", () => {
-    const arms = stepArms([
-      'case "$SECTION" in',
-      "  all)",
-      "    cf_test_step_begin one",
-      "    run_one",
-      "    cf_test_step_begin two",
-      "    run_two",
-      "    ;;",
-      "  one-only)",
-      "    cf_test_step_begin one",
-      "    run_one",
-      "    ;;",
-      "  two)",
-      "    cf_test_step_begin two",
-      "    run_two",
-      "    ;;",
-      "esac",
-    ].join("\n"));
-    expect([...arms]).toEqual([["one", "one-only"], ["two", "two"]]);
-  });
-
-  it("gives every recorded step of the real script an arm of its own", async () => {
+describe("what the command-line dispatch table becomes", () => {
+  /** Every step the dispatch script begins itself. */
+  async function recordedSteps(): Promise<string[]> {
     const script = await Deno.readTextFile(
       new URL("../packages/cli/integration/integration.sh", import.meta.url),
     );
-    const arms = stepArms(script);
-    const all = new Set<string>();
-    for (const line of script.split("\n")) {
-      const begins = /^ {4}cf_test_step_begin (\S+)$/.exec(line);
-      if (begins !== null) all.add(begins[1]!);
+    return [
+      ...new Set(
+        [...script.matchAll(/^ {4}cf_test_step_begin (\S+)$/gm)]
+          .map((found) => found[1]!),
+      ),
+    ];
+  }
+
+  it("makes a unit of every recorded step, and of nothing else", async () => {
+    // Both halves matter. A step with no arm running it alone is a step
+    // nothing can be asked to run; a group arm that became a unit would
+    // run steps another unit already holds, and the packer would pay for
+    // them twice.
+    const steps = await recordedSteps();
+    const suite = suiteById(suites, "cli-core")!;
+    const fromSteps = suite.units
+      .filter((unit) => unit.startsWith("integration.sh "))
+      .map((unit) => unit.slice("integration.sh ".length));
+    expect(fromSteps.sort()).toEqual(steps.sort());
+  });
+
+  it("gives each recorded step's identity to its own unit", async () => {
+    for (const step of await recordedSteps()) {
+      const name = `integration.sh ${step}`;
+      expect([
+        name,
+        suiteById(suites, "cli-core")!.locate({
+          test: { k: "integration", s: "cli", n: name },
+        }),
+      ]).toEqual([name, { level: "unit", unit: name }]);
     }
-    expect([...all].filter((step) => !arms.has(step))).toEqual([]);
   });
 });

--- a/tasks/test-topology/cli.test.ts
+++ b/tasks/test-topology/cli.test.ts
@@ -1,6 +1,10 @@
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
-import { loadCliSuites, stepArms } from "./cli.ts";
+import { dispatchArms, loadCliSuites, phaseAnnouncements } from "./cli.ts";
+
+/** The reader `integration.sh`'s arms are read with. */
+const stepsForTest = (body: string): string[] =>
+  [...body.matchAll(/^ {4}cf_test_step_begin (\S+)$/gm)].map((f) => f[1]!);
 import type { Suite } from "./suite.ts";
 
 const root = new URL("../..", import.meta.url).pathname.replace(/\/$/, "");
@@ -51,24 +55,80 @@ describe("the command-line suites", () => {
 
   it("keeps the three suites' records apart by name", () => {
     const [core, fuse, deno] = ["cli-core", "cli-fuse", "cli-deno"].map(byId);
-    const step = { k: "integration", s: "cli", n: "fuse-exec.sh mounts" };
+    const step = {
+      k: "integration",
+      s: "cli",
+      n: "fuse-exec.sh Legacy handler write-through still works",
+    };
     expect(fuse.locate({ test: step })).toEqual({
       level: "unit",
-      unit: "fuse-exec.sh",
+      unit: "fuse-exec.sh writes",
     });
     expect(core.locate({ test: step })).toBeUndefined();
     expect(deno.locate({ test: step })).toBeUndefined();
   });
 
-  it("runs the FUSE script whole, because it cannot be asked for less", async () => {
-    const fuse = byId("cli-fuse");
-    expect(fuse.units).toEqual(["fuse-exec.sh"]);
-    const [invocation] = await fuse.command(
-      [{ unit: "fuse-exec.sh", skip: [] }],
+  it("claims no record its script's arms do not run", () => {
+    // Claiming one by the name it starts with would put every
+    // unaccounted record beyond the drift guard's reach, since a claim
+    // is what stops the guard failing on it.
+    for (const id of ["cli-core", "cli-fuse"]) {
+      const suite = byId(id);
+      const script = suite.units[0]!.split(" ")[0];
+      expect(
+        suite.locate({
+          test: { k: "integration", s: "cli", n: `${script} no such step` },
+        }),
+      ).toBeUndefined();
+    }
+  });
+
+  it("makes each FUSE section a unit and leaves `all` to hand runs", () => {
+    expect(byId("cli-fuse").units).toEqual([
+      "fuse-exec.sh callables",
+      "fuse-exec.sh exec",
+      "fuse-exec.sh status",
+      "fuse-exec.sh writes",
+    ]);
+  });
+
+  it("dispatches the section a unit names", async () => {
+    const invocations = await byId("cli-fuse").command(
+      [{ unit: "fuse-exec.sh status", skip: [] }],
       context,
     );
-    expect(invocation!.command).toEqual(["./integration/fuse-exec.sh"]);
-    expect(await fuse.command([], context)).toEqual([]);
+    expect(invocations.length).toBe(1);
+    expect(invocations[0]!.command).toEqual(["./integration/fuse-exec.sh"]);
+    expect(invocations[0]!.env?.CF_FUSE_INTEGRATION_SECTION).toBe("status");
+    expect(await byId("cli-fuse").command([], context)).toEqual([]);
+  });
+
+  it("gives a phase to the one section that runs it", () => {
+    // The whole point of the sections: a phase only `writes` runs is
+    // scored and scheduled as part of `writes` and nothing else.
+    expect(
+      byId("cli-fuse").locate({
+        test: {
+          k: "integration",
+          s: "cli",
+          n: "fuse-exec.sh Legacy handler write-through still works",
+        },
+      }),
+    ).toEqual({ level: "unit", unit: "fuse-exec.sh writes" });
+  });
+
+  it("holds a phase several sections run to the suite", () => {
+    // It runs whenever any section does, which is what makes the
+    // sections independent, so it belongs to none of them.
+    expect(
+      byId("cli-fuse").locate({
+        test: {
+          k: "integration",
+          s: "cli",
+          n: "fuse-exec.sh Mounted callable entries exist",
+        },
+      }),
+    ).toEqual({ level: "suite" });
   });
 
   it("accounts for the scripts its steps call", () => {
@@ -90,16 +150,93 @@ describe("the command-line suites", () => {
   });
 });
 
-describe("reading a script with no dispatch table", () => {
-  it("finds no arms rather than guessing at them", () => {
+describe("reading a script's dispatch table", () => {
+  /** A table in the shape both scripts write one in. */
+  const table = [
+    'case "$SECTION" in',
+    "  all)",
+    "    cf_test_step_begin one",
+    "    cf_test_step_begin two",
+    "    ;;",
+    "  just-one)",
+    "    cf_test_step_begin one",
+    "    ;;",
+    "  quiet)",
+    "    echo nothing to record",
+    "    ;;",
+    "  *)",
+    '    error "Unknown section: $SECTION"',
+    "    ;;",
+    "esac",
+    "",
+  ].join("\n");
+
+  it("reads each arm against what the reader finds in it", () => {
+    expect([...dispatchArms(table, stepsForTest)]).toEqual([
+      ["all", ["one", "two"]],
+      ["just-one", ["one"]],
+    ]);
+  });
+
+  it("passes over the unknown-section arm and one naming no work", () => {
+    // Either would become a unit that then runs whatever the script does
+    // with it.
+    const arms = dispatchArms(table, stepsForTest);
+    expect(arms.has("*")).toBe(false);
+    expect(arms.has("quiet")).toBe(false);
+  });
+
+  it("finds no arms in a script that has no table", () => {
     // A script that lost its table has no arms to enumerate, and
     // inventing some would schedule work nothing can run.
-    expect([...stepArms("#!/usr/bin/env bash\necho hello\n")]).toEqual([]);
+    expect([...dispatchArms("#!/usr/bin/env bash\necho hello\n", stepsForTest)])
+      .toEqual([]);
+  });
+});
+
+describe("reading what a FUSE phase announces", () => {
+  const script = [
+    "run_mount() {",
+    '  phase "the mount"',
+    "}",
+    "run_probe() {",
+    '  if [ "$DEEP" = "1" ]; then',
+    '    phase "the deep probe"',
+    "  else",
+    '    phase "the probe, skipped"',
+    "  fi",
+    "}",
+    "",
+  ].join("\n");
+
+  it("names each phase by the sentence its function announces", () => {
+    // The table names a phase by identifier and the record carries the
+    // sentence, so this is what joins the two.
+    expect(phaseAnnouncements(script).get("mount")).toEqual(["the mount"]);
+  });
+
+  it("takes every name a phase announces conditionally", () => {
+    // A phase that announces one of two sentences records under either,
+    // and both are that phase, so both reach the section running it.
+    expect(phaseAnnouncements(script).get("probe")).toEqual([
+      "the deep probe",
+      "the probe, skipped",
+    ]);
+  });
+
+  it("finds nothing in a script with no phase functions", () => {
+    expect([...phaseAnnouncements("#!/usr/bin/env bash\necho hello\n").keys()])
+      .toEqual([]);
   });
 });
 
 describe("deciding which scripts a suite is built from", () => {
-  /** A root holding one dispatch script, with the text given. */
+  /**
+   * A root holding one dispatch script, with the text given, beside an
+   * empty FUSE script. Both are read when the suites are built, and the
+   * FUSE script being present is what makes passing over it a decision
+   * rather than the same silence a missing script would get.
+   */
   async function rooted(script: string): Promise<string> {
     const at = await Deno.makeTempDir({ prefix: "cli-sources-" });
     await Deno.mkdir(`${at}/packages/cli/integration`, { recursive: true });
@@ -107,6 +244,7 @@ describe("deciding which scripts a suite is built from", () => {
       `${at}/packages/cli/integration/integration.sh`,
       script,
     );
+    await Deno.writeTextFile(`${at}/packages/cli/integration/fuse-exec.sh`, "");
     return at;
   }
 
@@ -115,9 +253,6 @@ describe("deciding which scripts a suite is built from", () => {
     // claim a surface `cli-fuse` already holds, and the drift guard
     // reports a surface claimed twice.
     const at = await rooted("#!/usr/bin/env bash\n./fuse-exec.sh run\n");
-    // Present in the tree, so passing over it is a decision rather than
-    // the same silence a missing script would get.
-    await Deno.writeTextFile(`${at}/packages/cli/integration/fuse-exec.sh`, "");
     try {
       const sources = (await loadCliSuites(at))
         .find((suite) => suite.id === "cli-core")!.sources;

--- a/tasks/test-topology/cli.ts
+++ b/tasks/test-topology/cli.ts
@@ -7,13 +7,19 @@
  * and the Deno-based tests to `cli-deno`, which is an ordinary `deno
  * test` file suite.
  *
- * `integration.sh` records its whole invocation as well as each step, and
- * the same task identity appears whichever arm dispatched it. That record
- * proves the topology knows the surface, but it names no single unit and
- * must not be summed with its own steps, so it locates to the suite.
+ * The two shell suites share a shape rather than a script. Each is one
+ * script with a `case "$SECTION" in` table, dispatched by an environment
+ * variable, whose arms run work that records itself. What differs is how
+ * far an arm sits from the records it causes — `integration.sh` names
+ * each step where it begins it, and `fuse-exec.sh` names a phase whose
+ * function announces the sentence the record carries — and which arms a
+ * lane may be pointed at. So the table is read once, the attribution and
+ * the command are written once, and each suite supplies the two answers
+ * that are its own.
  */
 
 import * as path from "@std/path";
+import type { CapabilityId } from "../ci-capabilities.ts";
 import {
   claimsIdentity,
   fileSuite,
@@ -29,53 +35,173 @@ const CLI_DIR = "packages/cli/integration";
 /** The one record surface all three suites share. */
 const SURFACE = [{ kind: "integration", scope: "cli" }] as const;
 
+/** Where a script's dispatch runs, repository-relative. */
+const PACKAGE_DIR = "packages/cli";
+
 /**
- * The dispatch table's arms, read from the script. A step arm runs
- * exactly one step and is what the suite enumerates; a group arm runs
- * several and exists for people running the script by hand, so it is
- * never a unit and never makes an identity ambiguous.
+ * The arms of a script's `case "$SECTION" in` table, against whatever the
+ * reader finds in each arm's body, in the order the table writes them.
+ *
+ * The unknown-section arm reports rather than naming work, and an arm the
+ * reader finds nothing in names none, so neither becomes a unit that
+ * would then run whatever the script does with it.
  */
-export function stepArms(script: string): Map<string, string> {
-  const lines = script.split("\n");
-  const open = lines.indexOf('case "$SECTION" in');
-  if (open < 0) return new Map();
-  const byStep = new Map<string, string>();
-  let section: string | undefined;
-  let steps: string[] = [];
-  const close = (): void => {
-    // A step reachable from several arms belongs to exactly one of them:
-    // the arm that runs it alone. The first such arm wins, which is the
-    // order the table itself is written in.
-    if (section !== undefined && steps.length === 1 && !byStep.has(steps[0]!)) {
-      byStep.set(steps[0]!, section);
-    }
-    steps = [];
-  };
-  for (const line of lines.slice(open + 1)) {
-    if (line === "esac") break;
-    const opened = /^ {2}(\S+)\)$/.exec(line);
-    if (opened !== null) {
-      close();
-      section = opened[1];
-      continue;
-    }
-    const begins = /^ {4}cf_test_step_begin (\S+)$/.exec(line);
-    if (begins !== null) steps.push(begins[1]!);
+export function dispatchArms(
+  script: string,
+  read: (body: string) => readonly string[],
+): Map<string, string[]> {
+  const arms = new Map<string, string[]>();
+  const open = script.indexOf('case "$SECTION" in');
+  if (open < 0) return arms;
+  const table = script.slice(open, script.indexOf("\nesac", open));
+  for (
+    const [, arm, body] of table.matchAll(/^ {2}(\S+)\)\n(.*?)^ {4};;$/gms)
+  ) {
+    if (arm === "*") continue;
+    const found = read(body!);
+    if (found.length > 0) arms.set(arm!, [...found]);
   }
-  close();
-  return byStep;
+  return arms;
 }
 
-/** The scripts beside `integration.sh` that record one identity each. */
+/** The steps an arm of the dispatch script begins itself. */
+function stepsIn(body: string): string[] {
+  return [...body.matchAll(/^ {4}cf_test_step_begin (\S+)$/gm)]
+    .map((found) => found[1]!);
+}
+
+/** What a suite over one sectioned script is built from. */
+interface SectionSuiteOptions {
+  id: string;
+  needs: readonly CapabilityId[];
+
+  /** The script, which is also what its records are named for. */
+  script: string;
+
+  /** The variable its dispatch reads, which the command sets. */
+  variable: string;
+
+  /** Each arm of its table, against the records that arm runs. */
+  arms: ReadonlyMap<string, readonly string[]>;
+
+  /**
+   * What to call the unit an arm becomes, or nothing for an arm no lane
+   * may be pointed at. A group arm exists for people running the script
+   * by hand, and making one a unit would run work another unit already
+   * holds.
+   */
+  unitOf(arm: string, records: readonly string[]): string | undefined;
+
+  /** Scripts beside it that record one identity each and run as themselves. */
+  standalone?: readonly string[];
+
+  /** Tree paths the suite accounts for. */
+  sources: readonly string[];
+}
+
+/**
+ * A suite whose runner is one shell script that takes a section.
+ *
+ * Which arms are units is the suite's own answer, and everything after it
+ * follows from that answer alone. A record exactly one unit runs belongs
+ * to that unit. A record several units run belongs to none of them: it is
+ * setup they share — a mount, a piece, the files a phase puts in place —
+ * and charging it to one of them would count it against work the others
+ * pay for too, so it measures the suite. A record no unit runs is claimed
+ * by nothing, which is the drift guard's business to report: a step the
+ * script begins that no arm runs alone is a step nothing can be asked to
+ * run.
+ */
+function sectionSuite(options: SectionSuiteOptions): Suite {
+  const armOf = new Map<string, string>();
+  const units: string[] = [];
+  /** Every unit that runs each record, by the record's own name. */
+  const running = new Map<string, string[]>();
+  for (const [arm, records] of options.arms) {
+    const unit = options.unitOf(arm, records);
+    if (unit === undefined) continue;
+    units.push(unit);
+    armOf.set(unit, arm);
+    for (const record of records) {
+      const name = `${options.script} ${record}`;
+      running.set(name, [...running.get(name) ?? [], unit]);
+    }
+  }
+  // A script beside the dispatch one, which takes no section and records
+  // under its own name. It is its own unit and its own record.
+  for (const name of options.standalone ?? []) {
+    units.push(name);
+    armOf.set(name, "");
+    running.set(name, [name]);
+  }
+  units.sort();
+
+  return {
+    id: options.id,
+    recordSurfaces: SURFACE,
+    needs: options.needs,
+    units,
+    unavailable: [],
+    sources: [...options.sources].sort(),
+    locate(record): Location | undefined {
+      if (!claimsIdentity({ recordSurfaces: SURFACE }, record.test)) {
+        return undefined;
+      }
+      const name = record.test.n;
+      // The script's own whole-invocation record. It measures the
+      // invocation rather than any one unit, and the same identity
+      // appears whichever arm dispatched it, so summing it with the
+      // records inside it would count that work twice.
+      if (name === options.script) return { level: "suite" };
+      const holders = running.get(name);
+      if (holders === undefined) return undefined;
+      return holders.length === 1
+        ? { level: "unit", unit: holders[0]! }
+        : { level: "suite" };
+    },
+    command(requests: readonly UnitRequest[], context): Promise<Invocation[]> {
+      const cwd = path.join(context.root, PACKAGE_DIR);
+      const invocations: Invocation[] = [];
+      for (const request of requests) {
+        const arm = armOf.get(request.unit);
+        if (arm === undefined) continue;
+        invocations.push(
+          arm === "" ? { command: [`./integration/${request.unit}`], cwd } : {
+            command: [`./integration/${options.script}`],
+            cwd,
+            env: { [options.variable]: arm },
+          },
+        );
+      }
+      return Promise.resolve(invocations);
+    },
+  };
+}
+
+/** The script whose arms are this package's integration steps. */
+const DISPATCH_SCRIPT = "integration.sh";
+
+/** The FUSE script, whose arms are groups of phases over one mount. */
+const FUSE_SCRIPT = "fuse-exec.sh";
+
+/** The arm that runs everything, which exists for hand runs. */
+const WHOLE_SCRIPT_ARM = "all";
+
+/** The scripts beside the dispatch one that record one identity each. */
 const STANDALONE_SCRIPTS = ["acl.sh"];
 
 /**
  * The dispatch suite. A unit is one arm of `integration.sh` that runs one
  * step, or one of the standalone scripts beside it.
+ *
+ * The step is what the unit is named for, because a unit holding one
+ * record is that record as far as the store is concerned, and the store
+ * is what the manifest keys on. The arm that runs it is what the command
+ * reaches for.
  */
 async function cliCoreSuite(root: string): Promise<Suite> {
   const script = await Deno.readTextFile(
-    path.join(root, CLI_DIR, "integration.sh"),
+    path.join(root, CLI_DIR, DISPATCH_SCRIPT),
   );
   // The scripts this suite runs: the dispatch script, the standalone
   // scripts beside it, and whichever scripts its steps call. Read from
@@ -83,11 +209,11 @@ async function cliCoreSuite(root: string): Promise<Suite> {
   // one accounts for it without anybody remembering to say so. A script
   // nothing calls is left unclaimed on purpose — that is a test surface
   // running nowhere, and the drift guard exists to say so.
-  const sources = new Set<string>([`${CLI_DIR}/integration.sh`]);
+  const sources = new Set<string>([`${CLI_DIR}/${DISPATCH_SCRIPT}`]);
   for (const name of STANDALONE_SCRIPTS) sources.add(`${CLI_DIR}/${name}`);
   for (const [called] of script.matchAll(/(?:^|[\s"'/])([\w.-]+\.sh)\b/g)) {
     const name = called.replace(/^[\s"'/]/, "");
-    if (name === "fuse-exec.sh") continue;
+    if (name === FUSE_SCRIPT) continue;
     try {
       await Deno.stat(path.join(root, CLI_DIR, name));
       sources.add(`${CLI_DIR}/${name}`);
@@ -96,102 +222,95 @@ async function cliCoreSuite(root: string): Promise<Suite> {
       // script builds for something it writes.
     }
   }
-  const arms = stepArms(script);
-  // A unit is named for the record its step writes, which is what the
-  // store speaks in; the arm that runs it is what the command reaches
-  // for.
-  const armOf = new Map<string, string>();
-  const units: string[] = [];
-  for (const [step, section] of arms) {
-    const unit = `integration.sh ${step}`;
-    units.push(unit);
-    armOf.set(unit, section);
-  }
-  for (const name of STANDALONE_SCRIPTS) {
-    units.push(name);
-    armOf.set(name, "");
-  }
-  units.sort();
-
-  return {
+  return sectionSuite({
     id: "cli-core",
-    recordSurfaces: SURFACE,
     needs: ["deno", "toolshed", "cf", "jq"],
-    units,
-    unavailable: [],
-    sources: [...sources].sort(),
-    locate(record): Location | undefined {
-      if (!claimsIdentity({ recordSurfaces: SURFACE }, record.test)) {
-        return undefined;
-      }
-      const name = record.test.n;
-      if (armOf.has(name)) return { level: "unit", unit: name };
-      // The whole-invocation record of a script whose steps this suite
-      // holds. It measures the invocation rather than any one step.
-      if (name === "integration.sh") return { level: "suite" };
-      return undefined;
-    },
-    command(requests, context): Promise<Invocation[]> {
-      const cwd = path.join(context.root, "packages/cli");
-      const invocations: Invocation[] = [];
-      for (const request of requests) {
-        const arm = armOf.get(request.unit);
-        if (arm === undefined) continue;
-        invocations.push(
-          arm === ""
-            ? {
-              command: [`./integration/${request.unit}`],
-              cwd,
-            }
-            : {
-              command: ["./integration/integration.sh"],
-              cwd,
-              env: { CF_CLI_INTEGRATION_SECTION: arm },
-            },
-        );
-      }
-      return Promise.resolve(invocations);
-    },
-  };
+    script: DISPATCH_SCRIPT,
+    variable: "CF_CLI_INTEGRATION_SECTION",
+    arms: dispatchArms(script, stepsIn),
+    // An arm that runs one step is that step's unit; an arm that runs
+    // several is a group, and the steps in it have arms of their own.
+    unitOf: (_arm, records) =>
+      records.length === 1 ? `${DISPATCH_SCRIPT} ${records[0]}` : undefined,
+    standalone: STANDALONE_SCRIPTS,
+    sources: [...sources],
+  });
+}
+
+/** How a FUSE phase records: the sentences its function announces. */
+export type PhaseAnnouncements = Map<string, string[]>;
+
+/**
+ * The sentences each phase of the FUSE script announces itself with,
+ * which are the names its records carry.
+ *
+ * More than one where a phase announces conditionally, and every one of
+ * them names that phase. Read from the phase functions rather than from
+ * the dispatch table, because the two name a phase differently: the table
+ * names it by identifier, and the record carries the sentence.
+ */
+export function phaseAnnouncements(script: string): PhaseAnnouncements {
+  const announcements: PhaseAnnouncements = new Map();
+  const functions = script.split(/^run_([a-z0-9_]+)\(\) \{$/m);
+  for (let i = 1; i < functions.length; i += 2) {
+    announcements.set(
+      functions[i]!.replaceAll("_", "-"),
+      [...functions[i + 1]!.matchAll(/^\s*phase "([^"]*)"/gm)]
+        .map((found) => found[1]!),
+    );
+  }
+  return announcements;
+}
+
+/** The phases an arm of the FUSE script selects. */
+function phasesIn(body: string): string[] {
+  const listed = body.match(/PHASES=\(([^)]*)\)/s)?.[1];
+  return listed === undefined
+    ? []
+    : listed.split(/\s+/).filter((word) => word.length > 0);
+}
+
+/** The phases the FUSE script runs whichever arm was asked for. */
+function preludeOf(script: string): string[] {
+  return script.match(/^PRELUDE=\(([^)]*)\)/m)?.[1]
+    ?.split(/\s+/).filter((word) => word.length > 0) ?? [];
 }
 
 /**
- * The FUSE script, which records one identity per phase it completes and
- * runs whole here.
+ * The FUSE script, whose units are the sections of it that stand alone.
  *
- * The script itself can be asked for a quarter of its work — it takes a
- * section, and four of them stand alone. This suite does not use that
- * yet, because a record and a section are named differently: the
- * dispatch table names phases by identifier, and a phase records itself
- * under the sentence it announces. Attributing a record to a section
- * therefore means reading each phase's function for the announcements
- * inside it, which is its own change.
+ * A section is a group of phases over one mount rather than a phase on
+ * its own: the mount, the daemon and the piece cost more than every phase
+ * together, and each section needs all three. So a phase is an identity
+ * and a section is what a lane can be pointed at, and there is nothing
+ * finer for the topology to reach.
+ *
+ * The prelude belongs to every arm, because every arm runs it. Saying so
+ * here rather than treating it as a case of its own is what puts its
+ * phases under several units, and the shared rule then makes them the
+ * suite's — which is the same answer, reached the same way, as for the
+ * phase that puts the callable files in place ahead of three sections.
  */
-function cliFuseSuite(): Suite {
-  const unit = "fuse-exec.sh";
-  return {
+function cliFuseSuite(script: string): Suite {
+  const prelude = preludeOf(script);
+  const announced = phaseAnnouncements(script);
+  const arms = new Map<string, string[]>();
+  for (const [arm, phases] of dispatchArms(script, phasesIn)) {
+    arms.set(
+      arm,
+      [...prelude, ...phases].flatMap((phase) => announced.get(phase) ?? []),
+    );
+  }
+  return sectionSuite({
     id: "cli-fuse",
-    recordSurfaces: SURFACE,
     needs: ["deno", "toolshed", "cf", "fuse"],
-    units: [unit],
-    unavailable: [],
-    sources: [`${CLI_DIR}/fuse-exec.sh`],
-    locate(record): Location | undefined {
-      if (!claimsIdentity({ recordSurfaces: SURFACE }, record.test)) {
-        return undefined;
-      }
-      return record.test.n === unit || record.test.n.startsWith(`${unit} `)
-        ? { level: "unit", unit }
-        : undefined;
-    },
-    command(requests: readonly UnitRequest[], context): Promise<Invocation[]> {
-      if (requests.length === 0) return Promise.resolve([]);
-      return Promise.resolve([{
-        command: ["./integration/fuse-exec.sh"],
-        cwd: path.join(context.root, "packages/cli"),
-      }]);
-    },
-  };
+    script: FUSE_SCRIPT,
+    variable: "CF_FUSE_INTEGRATION_SECTION",
+    arms,
+    unitOf: (arm) =>
+      arm === WHOLE_SCRIPT_ARM ? undefined : `${FUSE_SCRIPT} ${arm}`,
+    sources: [`${CLI_DIR}/${FUSE_SCRIPT}`],
+  });
 }
 
 /** The Deno-based command-line integration tests. */
@@ -214,5 +333,11 @@ function cliDenoSuite(): Suite {
 
 /** Every command-line suite, read from the working tree. */
 export async function loadCliSuites(root: string): Promise<Suite[]> {
-  return [await cliCoreSuite(root), cliFuseSuite(), cliDenoSuite()];
+  return [
+    await cliCoreSuite(root),
+    cliFuseSuite(
+      await Deno.readTextFile(path.join(root, CLI_DIR, FUSE_SCRIPT)),
+    ),
+    cliDenoSuite(),
+  ];
 }


### PR DESCRIPTION
Eight places where what is built and what
docs/plans/pull-request-test-selection.md specifies had come apart, all of them in parts the plan already marks as done. Four of the eight are silent failures rather than missing features: the system would run, and would run the wrong tests or read the wrong records, without saying so.

**The publisher never asked the topology where a test runs.** Every manifest entry carries the suite that runs a test and the unit that suite can be pointed at, and both halves of the system key on them: the lane runner looks a suite up by that identifier to build a command, the packer charges that suite's fitted overhead and its capabilities, and the unknown-identity rule asks whether the manifest holds anything for a suite and unit the tree enumerates. The publisher was written before the topology existed and grouped each identity by its own record surface instead, producing a suite named `unit:memory` and a unit that was the record's file where one was captured and the test's own name where none was. Nothing in the tree answers to `unit:memory`, so the two consumers fail in opposite directions and neither says a word. `mandatoryFor` finds no entry under any suite identifier the topology holds and concludes that every unit in the repository is one no manifest has seen, which makes all of them mandatory. `batchesOf` looks each selection's suite up, finds nothing, and drops the selection. Between them a lane would run everything it was not asked to run and none of what it was.

The publisher now resolves each identity through `locate()`, which is what the plan has it for: the store speaks in identities, the runners take files and section names, and `locate` is the bridge. An identity that resolves to no unit is left out rather than carried under a name nothing can run, and the run says how many and which of the two reasons it was — a whole-invocation record that names no unit, or an identity no suite claims, which today is mostly one whose records predate the registration preload. Two things the topology was already the only source of come with it: the reference packing is charged the capabilities each suite opens, and the manifest carries what each configuration declares unavailable.

**The publisher chose its inputs two ways, and one of them dropped every local record of a compacted day.** The plan gives bootstrap and ordinary publishing one input plan, applied to each source and date: a bootstrap is permission to start from an empty aggregate and a wider default window, and not a second way to choose what to read. Only a bootstrap looked for a rollup, and it recorded what it took by date alone.

That date-only receipt is the part that loses data. Rollups cover the shared continuous-integration area and nothing else — `aggregated/ci/` is the whole of what the compactor writes. A receipt naming the day by itself says the day is accounted for, so the day is dropped from the listing, and the listing is where the local submissions of that day would have been found. Every local record of every day a bootstrap took from a rollup was therefore never read, and the receipt persists, so no later run reads them either. Those are the records the score weighs double, on the argument that somebody at a workstation finding a test red because of what they had just written is the best evidence this system can receive.

So a receipt is a source and a date, and `inputChoice` is what both modes ask of each pair: `settled` where a receipt says the pair's rollup is folded, since rollups of this format carry no record of which arrivals they cover and nothing can say how much a raw object would repeat; `rollup` where nothing of the pair is folded and one covers it; and `raw` for everything else, which a pair with raw contributions reaches because a rollup written afterwards would overlap them, and every local source reaches because no rollup covers one. An aggregate carrying receipts written before the source was part of one reads them forward as the shared area's, which is exact rather than a guess.

Two consequences follow from there being one rule rather than two paths. A run catching up after an outage, or over a widened window, reaches an unseen old day by its rollup rather than by its thousands of objects. And a bootstrap over a day whose raw objects are already in the aggregate stays on the raw path, where before the question could not arise because the two cases lived in different code.

**The FUSE script's sections were not its units.** The plan has `cli-fuse` scheduling the four sections of
`packages/cli/integration/fuse-exec.sh` that stand alone. The script grew that dispatch table and the topology went on treating the whole script as one unit — one holding twenty-five identities that ignored the skip list it was handed, so a lane budgeting for the three phases it selected ran all twenty-five, and the cost model had no way to see it.

That script and `integration.sh` are the same thing twice: one shell script, a `case "$SECTION" in` table, an environment variable naming the arm, and work inside the arms that records itself through `cf_test_step_begin`. So the table is read once, by a reader the caller hands in, and a suite over a sectioned script is built once. What differs between the two is only how far an arm sits from the records it causes — the dispatch script names each step where it begins it, and the FUSE script names a phase whose function announces the sentence the record carries — and which arms a lane may be pointed at.

Stating the attribution rule once is what showed the two suites were applying the same one. A record exactly one unit runs belongs to that unit. A record several units run belongs to none of them: it is setup they share, and charging it to one would count it against work the others pay for too. A record no unit runs is claimed by nothing. The FUSE prelude then stops being a case of its own — it is what every arm runs, so it is folded into every arm's records, and the shared rule puts its phases against the suite for the same reason it does the phase that puts the callable files in place ahead of three sections.

That tightens one answer the old FUSE suite gave. It claimed any record whose name merely began with `fuse-exec.sh `, and a claim is what stops the drift guard failing on a record, so one no arm runs was claimed rather than reported. It is now unclaimed, as its sibling's equivalent has always been.

**A record the suite does not describe was given a variant it never ran in.** The plan has the lane runner check a batch's direct records against the suite that ran them before applying that suite's variant. The gather function applied it to everything it read. That takes a record that was merely mislabeled — the wrong kind and scope, or a marker a producer supplied in a default batch — and gives it a plausible identity in a history it does not belong to, which nothing downstream can catch. Such records are now kept as their producer wrote them, shipped so that the store half of the drift guard fails on them, and named in the summary. The batch is not failed for one: the mistake is in the metadata.

The other four are narrower.

`plan --verify` was a stub that stopped with "needs the test topology, which is not in the tree yet". It compares the newest manifest against the working tree, failing on a unit the manifest holds nothing for and reporting a manifest entry the tree no longer holds. `plan --dry-run` and `explain` read the topology as well, for the reason written beside the empty map they used to pass: the capabilities a suite opens are most of what a lane's budget goes on.

The exploration draw was a uniform shuffle, which is the sample with replacement the plan names as the thing to avoid: a test can go unvisited for as long as chance allows. It now takes the longest-unrun first, with the shuffle breaking ties, which makes it a sweep. The manifest gains the day each identity last ran, read out of the run counts the aggregate already keeps for the churn term.

The lane's job summary dropped the withheld set that `plan()` hands it, so a test held back for being red on `main` or too noisy to judge by simply stopped appearing. It now prints both with the reason in words, and says which of them ran anyway because the change reaches what they cover. The summary's batch table also says what each batch is expected to cost and what its tests were chosen for, which is what "why did my test not run" needs and a list of suite names cannot give.

Four figures in the plan itself were out of date: two dials missing from the table that claims to hold every one, the topology's size, the drift guard's declared lists, and what the FUSE script records.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6781?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

