### PR TITLE
test(cli): the drills run the spellings the surface blesses

### DIFF
--- a/docs/plans/cli-surface-shape.md
+++ b/docs/plans/cli-surface-shape.md
@@ -650,7 +650,10 @@ than taking anything away.
    spelling it had, hidden and dated, so a script keeps working while it is
    migrated. The date bounds a guarantee rather than schedules an execution:
    removing those mounts is 7b, a separate change, the way 6b was separate
-   from 6a.
+   from 6a. 7b takes the notice and its dated constant with the mounts, and
+   `packages/cli/test/integration-command-spellings.test.ts` too — the check
+   holding the integration drills to the blessed spellings has nothing left to
+   find once no superseded spelling answers.
 
    The duplicated nouns this step was named for resolve rather than merge.
    `piece inspect` reports on a live piece and `cf inspect` reads a stored

--- a/packages/cli/integration/bulk-survey-drill.sh
+++ b/packages/cli/integration/bulk-survey-drill.sh
@@ -79,7 +79,7 @@ if [ -n "$BOARD" ]; then ok "deployed $BOARD"; else
 fi
 FILED=0
 for title in alpha beta gamma; do
-  if $CF call -q --piece "$BOARD" $ARGS addMember "{\"title\":\"$title\"}" \
+  if $CF piece call -q --piece "$BOARD" $ARGS addMember "{\"title\":\"$title\"}" \
     >/dev/null 2>&1; then
     FILED=$((FILED + 1))
   else
@@ -90,7 +90,7 @@ check "3" "$FILED" "filed alpha, beta, gamma"
 
 step "2. One call seeds the rest of the board-sized set"
 SEED_EXTRA=$((MEMBERS_TOTAL - 3))
-SEEDED=$($CF call -q --piece "$BOARD" $ARGS seedMembers \
+SEEDED=$($CF piece call -q --piece "$BOARD" $ARGS seedMembers \
   "{\"count\":$SEED_EXTRA}" 2>/dev/null | jq -r '.result.filed // empty')
 check "$SEED_EXTRA" "$SEEDED" "one call filed the remaining $SEED_EXTRA"
 
@@ -170,7 +170,7 @@ check "$HOLDER_FACTS" "$PIN_FACTS" \
   "inspect's source pin matches the survey's holder row, symbol included"
 
 step "9. A change shows on the next survey (live read)"
-$CF call -q --piece "$BOARD" $ARGS addMember '{"title":"delta"}' \
+$CF piece call -q --piece "$BOARD" $ARGS addMember '{"title":"delta"}' \
   >/dev/null 2>&1 || bad "addMember delta failed"
 AFTER=$($CF piece survey -q --piece "$BOARD" --path items $ARGS \
   2>/dev/null | head -1 | jq -r '.enumerated.collection')

--- a/packages/cli/integration/completion-over-the-cli.sh
+++ b/packages/cli/integration/completion-over-the-cli.sh
@@ -307,7 +307,7 @@ check "1" "$(printf '%s' "$ARGUMENT_KEYS" | grep -c 'settings')" \
 
 # The suffix rides the bare slug the same way, because the slug names the
 # piece the reference names.
-check "1" "$(succeeds $CF get --quiet --piece "board#argument" $ARGS)" \
+check "1" "$(succeeds $CF cell get --quiet --piece "board#argument" $ARGS)" \
   "the suffix on a bare slug is a --piece value the command accepts too"
 check "$ARGUMENT_KEYS" \
   "$(candidates_at "cf cell get $LINE_ARGS --piece board#argument ")" \

--- a/packages/cli/integration/verb-session-gaps.sh
+++ b/packages/cli/integration/verb-session-gaps.sh
@@ -90,7 +90,7 @@ if [ -n "$BOARD" ]; then ok "deployed $BOARD"; else
   bad "deploy failed"
   exit 1
 fi
-SLUG_NAME=$($CF get --quiet --piece board $ARGS '$NAME' 2>/dev/null | tr -d '"')
+SLUG_NAME=$($CF cell get --quiet --piece board $ARGS '$NAME' 2>/dev/null | tr -d '"')
 check "Work tracker" "$SLUG_NAME" "the slug resolves everywhere --piece is taken"
 # The arrival name is discoverable as well as resolvable: the slug index
 # lists what the deploy's --slug wrote — the same wiring the demo's act 1
@@ -156,7 +156,7 @@ $CF piece describe --piece board $ARGS --json 2>/dev/null |
   bad "describe --json is missing purpose, state, or the verb rows"
 
 step "3. Ask what a verb wants — flags and prose, both derived"
-HELP=$($CF call --piece board $ARGS addItem --help 2>/dev/null)
+HELP=$($CF piece call --piece board $ARGS addItem --help 2>/dev/null)
 echo "$HELP" | grep -q -- "--title" &&
   ok "the flag is derived from the event schema" ||
   bad "no --title flag in the generated help"
@@ -220,7 +220,7 @@ fi
 # wide open. It is recorded in the walkthrough's table instead, against #5559.
 
 step "4. A create hands back the piece, and the address chains"
-R=$($CF call --quiet --show-links --piece board $ARGS \
+R=$($CF piece call --quiet --show-links --piece board $ARGS \
   addItem '{"title":"Login rewrite"}' 2>/dev/null)
 check "Login rewrite" "$(echo "$R" | jq -r '.result.item["$NAME"] // empty')" \
   "the result carries the created item"
@@ -234,13 +234,13 @@ fi
 # the writes landed; each call's exit code is checked too, because the
 # readback runs after the write commits — a readback failure leaves the count
 # intact, and only the exit code shows it.
-$CF call --quiet --piece "$EPIC" $ARGS \
+$CF piece call --quiet --piece "$EPIC" $ARGS \
   addChild '{"title":"Session cookies"}' >/dev/null 2>&1 ||
   bad "addChild (Session cookies) exited nonzero"
-$CF call --quiet $ARGS "$EPIC" \
+$CF piece call --quiet $ARGS "$EPIC" \
   addChild '{"title":"CSRF tokens"}' >/dev/null 2>&1 ||
   bad "addChild (CSRF tokens, positional address) exited nonzero"
-KIDS=$($CF get --quiet --piece "$EPIC" children $ARGS \
+KIDS=$($CF cell get --quiet --piece "$EPIC" children $ARGS \
   --schema '{"type":"array","items":{"type":"object","properties":{"title":true}}}' \
   2>/dev/null)
 check "2" "$(echo "$KIDS" | jq -r 'length')" \
@@ -255,7 +255,7 @@ check "addChild,archive,blockOn,finish,recordNote" \
   "an item lists its own verbs, and not the board's"
 
 step "5. Read addresses instead of contents"
-ADDR=$($CF get --quiet --piece "$EPIC" children $ARGS \
+ADDR=$($CF cell get --quiet --piece "$EPIC" children $ARGS \
   --schema '{"type":"array","items":{"$link":true,"type":"object","properties":{"title":true}}}' \
   2>/dev/null)
 check "true" "$(echo "$ADDR" | jq -c '[.[] | has("$link") and (.title|length>0)] | all')" \
@@ -268,7 +268,7 @@ KID=$(echo "$ADDR" | jq -r '.[] | select(.title=="Session cookies") | .["$link"]
 # nothing about the answer moved. The check above is what gives it force —
 # were the first read already empty, two empty reads would agree and this
 # would pass saying nothing.
-AGAIN=$($CF get --quiet --piece "$EPIC" children $ARGS \
+AGAIN=$($CF cell get --quiet --piece "$EPIC" children $ARGS \
   --schema '{"type":"array","items":{"$link":true,"type":"object","properties":{"title":true}}}' \
   2>/dev/null)
 check "$ADDR" "$AGAIN" "the same read, run again, answers the same"
@@ -286,29 +286,29 @@ step "6. Two routes hand back an address, and either one addresses the piece"
 # on which it "closes", and a gap that can never fire is a gap that reports
 # nothing. What a caller does depend on is asserted instead — either address,
 # fed back to --piece, reads the same piece.
-MADE=$($CF call --quiet --show-links --piece board $ARGS \
+MADE=$($CF piece call --quiet --show-links --piece board $ARGS \
   addItem '{"title":"Rate limiting"}' 2>/dev/null |
   jq -r '.links["/item"] // empty')
-VIA_READ=$($CF get --quiet --piece board items $ARGS --step \
+VIA_READ=$($CF cell get --quiet --piece board items $ARGS --step \
   --schema '{"type":"array","items":{"$link":true,"type":"object","properties":{"title":true}}}' \
   2>/dev/null | jq -r '.[] | select(.title=="Rate limiting") | .["$link"]')
 if [ -z "$MADE" ] || [ -z "$VIA_READ" ]; then
   bad "one of the two routes produced no address (call=$MADE read=$VIA_READ)"
 else
   # Both must work as --piece. That is the property a caller depends on.
-  M_T=$($CF get --quiet --piece "$MADE" title $ARGS 2>/dev/null | tr -d '"')
-  R_T=$($CF get --quiet --piece "$VIA_READ" title $ARGS 2>/dev/null | tr -d '"')
+  M_T=$($CF cell get --quiet --piece "$MADE" title $ARGS 2>/dev/null | tr -d '"')
+  R_T=$($CF cell get --quiet --piece "$VIA_READ" title $ARGS 2>/dev/null | tr -d '"')
   check "Rate limiting" "$M_T" "the address the call returned addresses the piece"
   check "Rate limiting" "$R_T" "the address the read returned addresses the piece too"
   # The same address, standing bare in the first position with the path
   # embedded — the spelling the demo teaches from act 4 on. An address begins
   # with `/` and a relative path never does, so nothing marks it but itself.
-  P_T=$($CF get --quiet "$VIA_READ/title" $ARGS 2>/dev/null | tr -d '"')
+  P_T=$($CF cell get --quiet "$VIA_READ/title" $ARGS 2>/dev/null | tr -d '"')
   check "Rate limiting" "$P_T" "the address stands positional, carrying its path"
 fi
 
 step "7. A verb returns what only the pattern could compute"
-N=$($CF call --quiet --piece "$EPIC" $ARGS \
+N=$($CF piece call --quiet --piece "$EPIC" $ARGS \
   recordNote '{"body":"blocked on the cookie spec"}' 2>/dev/null)
 check "1" "$(echo "$N" | jq -r '.result.noteCount // empty')" \
   "recordNote returns the count after the append"
@@ -321,13 +321,13 @@ AT=$(echo "$N" | jq -r '.result.note.at // 0')
 # so an envelope shows the original count and body whether or not a second
 # append actually landed. Only reading the item's own `notes` afterwards can
 # tell those apart, which makes the live length the discriminator for both.
-notes_len() { $CF get --quiet --piece "$EPIC" $ARGS notes 2>/dev/null | jq 'length'; }
+notes_len() { $CF cell get --quiet --piece "$EPIC" $ARGS notes 2>/dev/null | jq 'length'; }
 LIVE0=$(notes_len)
 RCPT=$(echo "$N" | jq -r '.receipt // empty')
 if [ -z "$RCPT" ]; then
   bad "the settled envelope named no receipt to read back"
 else
-  RB=$($CF get --quiet --piece "$RCPT" $ARGS --select note,noteCount 2>/dev/null)
+  RB=$($CF cell get --quiet --piece "$RCPT" $ARGS --select note,noteCount 2>/dev/null)
   check "blocked on the cookie spec" "$(echo "$RB" | jq -r '.note.body // empty')" \
     "the receipt address holds the outcome that handling committed"
   check "1" "$(echo "$RB" | jq -r '.noteCount // empty')" \
@@ -339,10 +339,10 @@ fi
 # The other route: no address kept, so the id is the handle. The replay carries
 # a DIFFERENT payload on purpose, so a returned body of the FIRST text is
 # evidence the second call's event never became an outcome.
-R1=$($CF call --quiet --piece "$EPIC" $ARGS --invocation note-retry \
+R1=$($CF piece call --quiet --piece "$EPIC" $ARGS --invocation note-retry \
   recordNote '{"body":"first attempt"}' 2>/dev/null)
 LIVE1=$(notes_len)
-R2=$($CF call --quiet --piece "$EPIC" $ARGS --invocation note-retry \
+R2=$($CF piece call --quiet --piece "$EPIC" $ARGS --invocation note-retry \
   recordNote '{"body":"a different body entirely"}' 2>/dev/null)
 check "first attempt" "$(echo "$R2" | jq -r '.result.note.body // empty')" \
   "replaying a settled id hands back the original result, not the new payload"
@@ -365,14 +365,14 @@ check "$LIVE1" "$(notes_len)" \
 
 step "8. Finishing reports what the caller could not know"
 # Exit code checked for the same reason as step 4's creates.
-$CF call --quiet --piece "$KID" $ARGS \
+$CF piece call --quiet --piece "$KID" $ARGS \
   addChild '{"title":"Rotate signing key"}' >/dev/null 2>&1 ||
   bad "addChild (Rotate signing key) exited nonzero"
 # Unshaped: a PROJECTED read of this path fails once `finish` has run, while
 # the same path unshaped resolves fine. Counting is all this step needs.
-DIRECT=$($CF get --quiet --piece "$EPIC" children $ARGS --step 2>/dev/null |
+DIRECT=$($CF cell get --quiet --piece "$EPIC" children $ARGS --step 2>/dev/null |
   jq -r 'length')
-F=$($CF call --quiet --piece "$EPIC" $ARGS \
+F=$($CF piece call --quiet --piece "$EPIC" $ARGS \
   finish '{"body":"shipping behind a flag"}' 2>/dev/null)
 OPEN=$(echo "$F" | jq -r '.result.openBelow // empty')
 # Captured rather than hard-coded: the property is that it counted deeper than
@@ -384,7 +384,7 @@ else
 fi
 
 step "9. A value-less verb settles with the empty witness"
-V=$($CF call --quiet --piece "$KID" $ARGS archive '{}' 2>/dev/null)
+V=$($CF piece call --quiet --piece "$KID" $ARGS archive '{}' 2>/dev/null)
 check "settled" "$(echo "$V" | jq -r '.status')" "archive settled"
 check "{}" "$(echo "$V" | jq -c '.result // {}')" "its result is the empty witness"
 
@@ -398,7 +398,7 @@ step "10. A reference argument dispatches — the envelope, and the address as e
 # refuses the two payloads that could only ever be mistakes at a reference
 # position. Every spelling is asserted apart, so none can hide behind
 # another.
-OTHER=$($CF get --quiet --piece board items $ARGS \
+OTHER=$($CF cell get --quiet --piece board items $ARGS \
   --schema '{"type":"array","items":{"$link":true}}' 2>/dev/null |
   jq -r '.[0]["$link"] // empty')
 if [ -z "$OTHER" ] || [ -z "${KID:-}" ]; then
@@ -407,22 +407,22 @@ else
   # The envelope: assembled from the very address the read above emitted, so
   # the target is one the session was handed.
   SIGIL="{\"on\":{\"/\":{\"link@1\":{\"id\":\"${OTHER#/}\"}}}}"
-  BLOCKED=$($CF call --quiet --piece "$KID" $ARGS \
+  BLOCKED=$($CF piece call --quiet --piece "$KID" $ARGS \
     blockOn "$SIGIL" 2>/dev/null)
   check "1" "$(echo "$BLOCKED" | jq -r '.result.blockedOnCount // empty')" \
     "a link envelope names an existing item, and the edge lands"
   # And the edge is the target rather than a copy: the address under
   # blockedOn is the address the envelope named.
-  EDGE=$($CF get --quiet --piece "$KID" blockedOn $ARGS \
+  EDGE=$($CF cell get --quiet --piece "$KID" blockedOn $ARGS \
     --schema '{"type":"array","items":{"$link":true}}' 2>/dev/null |
     jq -r '.[0]["$link"] // empty')
   check "$OTHER" "$EDGE" "the edge reads back as the address that was named"
   # The emitted spelling: the same address, fed back exactly as printed.
-  BLOCKED2=$($CF call --quiet --piece "$KID" $ARGS \
+  BLOCKED2=$($CF piece call --quiet --piece "$KID" $ARGS \
     blockOn "{\"on\":\"$OTHER\"}" 2>/dev/null)
   check "2" "$(echo "$BLOCKED2" | jq -r '.result.blockedOnCount // empty')" \
     "the address a read emits, fed back as written, dispatches"
-  EDGE2=$($CF get --quiet --piece "$KID" blockedOn $ARGS \
+  EDGE2=$($CF cell get --quiet --piece "$KID" blockedOn $ARGS \
     --schema '{"type":"array","items":{"$link":true}}' 2>/dev/null |
     jq -r '.[1]["$link"] // empty')
   check "$OTHER" "$EDGE2" "and its edge is the target, not a copy"
@@ -430,7 +430,7 @@ else
   # SPECIFIC message: a renamed verb or a server hiccup also exits nonzero,
   # and a probe that reads any failure as the refusal is a probe that cannot
   # fail.
-  NOT_ERR=$($CF call --quiet --piece "$KID" $ARGS \
+  NOT_ERR=$($CF piece call --quiet --piece "$KID" $ARGS \
     blockOn '{"on":"not-an-address"}' 2>&1 >/dev/null)
   NOT_RC=$?
   if [ "$NOT_RC" != "0" ] && printf '%s' "$NOT_ERR" | grep -q "is not an address"; then
@@ -438,7 +438,7 @@ else
   else
     bad "the not-an-address refusal did not fire (rc=$NOT_RC): $NOT_ERR"
   fi
-  COPY_ERR=$($CF call --quiet --piece "$KID" $ARGS \
+  COPY_ERR=$($CF piece call --quiet --piece "$KID" $ARGS \
     blockOn '{"on":{"title":"a copy"}}' 2>&1 >/dev/null)
   COPY_RC=$?
   if [ "$COPY_RC" != "0" ] && printf '%s' "$COPY_ERR" | grep -q "detached document"; then
@@ -453,16 +453,16 @@ step "11. a verb returning a child piece renders the circle as an address"
 # readback bounds the result with the verb's own declared result and renders
 # the position where the declared type re-enters itself as an address, so the
 # whole outcome is JSON and the write it reports stays legible.
-BEFORE=$($CF get --quiet --piece "$EPIC" children $ARGS --step 2>/dev/null |
+BEFORE=$($CF cell get --quiet --piece "$EPIC" children $ARGS --step 2>/dev/null |
   jq -r 'length')
-CALLED=$($CF call --quiet --piece "$EPIC" $ARGS \
+CALLED=$($CF piece call --quiet --piece "$EPIC" $ARGS \
   addChild '{"title":"Cycle probe"}' 2>/dev/null)
 RC=$?
 check "0" "$RC" "addChild readback on a doubly-linked tree"
 BACKREF=$(printf '%s' "$CALLED" | jq -r '.result.item.parent["$link"] // ""')
 check "/of:" "${BACKREF:0:4}" \
   "the position that closes the circle returns an address"
-AFTER=$($CF get --quiet --piece "$EPIC" children $ARGS --step 2>/dev/null |
+AFTER=$($CF cell get --quiet --piece "$EPIC" children $ARGS --step 2>/dev/null |
   jq -r 'length')
 check "$((BEFORE + 1))" "$AFTER" "the write the result describes landed"
 
@@ -484,7 +484,7 @@ check "" \
 # on its own address. That is what makes an empty `ls` uninformative rather
 # than conclusive, and it is the inference the document exists to block.
 check "Login rewrite" \
-  "$($CF get --quiet --piece "$EPIC" title $ARGS 2>/dev/null | jq -r '. // empty')" \
+  "$($CF cell get --quiet --piece "$EPIC" title $ARGS 2>/dev/null | jq -r '. // empty')" \
   "the unlisted item still reads through the address the create returned"
 
 ELAPSED=$(($(date +%s) - START))

--- a/packages/cli/test/integration-command-spellings.test.ts
+++ b/packages/cli/test/integration-command-spellings.test.ts
@@ -47,10 +47,10 @@ const SUPERSEDED: readonly Spelling[] = [
 ];
 
 /**
- * How a drill names the CLI: `cf` itself, or the `$CF` — `${CF}` too — that the
- * scripts run their commands through. A pattern that saw only the literal word
- * would find nothing in any of these files, and would report a clean scan of a
- * script that had gone back to the old spellings everywhere.
+ * How a drill names the CLI. Some write the word, which those scripts bind to
+ * a shell function; the rest write `$CF`, or `${CF}`. A pattern that saw
+ * only the word finds nothing at all in a drill of the second kind, and reports
+ * one that had gone back to the old spellings everywhere as clean.
  */
 const INVOCATION = String.raw`(?:cf|\$\{?CF\}?)`;
 

--- a/packages/cli/test/integration-command-spellings.test.ts
+++ b/packages/cli/test/integration-command-spellings.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Every `cf` command the integration drills run is written in the spelling the
+ * surface blesses.
+ *
+ * Each command sits under the noun it acts on, and the spelling it replaced is
+ * still mounted — hidden from help and from completion, carrying a notice, and
+ * guaranteed only until the date `COMMAND_SPELLING_END_DATE` names in
+ * `packages/cli/lib/deprecated-spelling.ts`. That mount is what makes a drill's
+ * own result no evidence about the spellings it writes: a drill that went back
+ * to a superseded one passes every assertion it makes, and keeps passing until
+ * the mount is removed, at which point it fails on a day nothing about it
+ * changed. So this reads the text of the scripts instead of a run of them.
+ *
+ * `packages/cli/README.md` carries the same table under "Superseded spellings",
+ * as the surface's own record of what to write instead.
+ *
+ * The scan does not tell a command from a comment, and that is deliberate:
+ * prose in a drill that teaches a superseded spelling wants the same edit as a
+ * line that runs one.
+ *
+ * TODO(mike): Delete this file once `cf` mounts no superseded spelling. The
+ * scan has nothing left to find then, and a check whose subject is gone reads
+ * as a rule about something the CLI still does.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+/** The directory holding the drills. */
+const DRILLS = new URL("../integration/", import.meta.url);
+
+/**
+ * A superseded command spelling and the one that replaced it, each written as
+ * the words that follow `cf`.
+ */
+type Spelling = readonly [superseded: string, blessed: string];
+
+/** Every spelling a moved command still answers to, against what to write. */
+const SUPERSEDED: readonly Spelling[] = [
+  ["get", "cell get"],
+  ["set", "cell set"],
+  ["call", "piece call"],
+  ["piece get-label", "cell get-label"],
+  ["piece set-label", "cell set-label"],
+  ["piece recreate-root", "space recreate-root"],
+  ["piece set-home", "space set-home"],
+];
+
+/**
+ * How a drill names the CLI: `cf` itself, or the `$CF` — `${CF}` too — that the
+ * scripts run their commands through. A pattern that saw only the literal word
+ * would find nothing in any of these files, and would report a clean scan of a
+ * script that had gone back to the old spellings everywhere.
+ */
+const INVOCATION = String.raw`(?:cf|\$\{?CF\}?)`;
+
+/**
+ * The pattern that finds one spelling.
+ *
+ * The boundaries are `(?![\w-])` rather than `\b`, because `\b` sits between
+ * `set` and the `-` of `set-label`: a word boundary would read every
+ * `cf cell set-label` as a use of the superseded `cf set`. The words of a
+ * spelling are joined by `\s+` so a command recovered from a wrap, whose words
+ * are several spaces apart, reads the same as one written on a single line.
+ */
+function spellingPattern(superseded: string): RegExp {
+  const words = superseded.split(" ").join(String.raw`\s+`);
+  return new RegExp(
+    String.raw`(?<![\w-])${INVOCATION}\s+${words}(?![\w-])`,
+    "g",
+  );
+}
+
+/**
+ * The script with its line breaks turned into whitespace, so a command wrapped
+ * across lines reads as the one run of words it is.
+ *
+ * One character replaces one character, so an index into the result still names
+ * a position in the script it came from. A backslash continuation loses its
+ * backslash as well, since the backslash stands where the space between two
+ * words would otherwise be.
+ */
+function flatten(script: string): string {
+  return script.replace(/\\\n/g, "  ").replaceAll("\n", " ");
+}
+
+/** The line the character at `index` sits on, counting from one. */
+function lineOf(script: string, index: number): number {
+  let line = 1;
+  for (let at = 0; at < index; at++) {
+    if (script[at] === "\n") line += 1;
+  }
+  return line;
+}
+
+/** Where in `script` each invocation of `spelling` begins. */
+function invocationsOf(script: string, spelling: string): number[] {
+  return [...flatten(script).matchAll(spellingPattern(spelling))]
+    .map((match) => match.index ?? 0);
+}
+
+/**
+ * Every superseded spelling `script` invokes, each reported with the line it
+ * sits on and the spelling to write in its place, in the order they appear.
+ */
+function findSupersededSpellings(
+  name: string,
+  script: string,
+  table: readonly Spelling[] = SUPERSEDED,
+): string[] {
+  const found: { at: number; report: string }[] = [];
+  for (const [superseded, blessed] of table) {
+    for (const at of invocationsOf(script, superseded)) {
+      found.push({
+        at,
+        report: `${name}:${lineOf(script, at)}: 'cf ${superseded}' is ` +
+          `superseded; spell it 'cf ${blessed}'`,
+      });
+    }
+  }
+  return found.sort((one, other) => one.at - other.at)
+    .map((finding) => finding.report);
+}
+
+/** The drills the checks below name, and so must have been read. */
+const WATCHED = [
+  "bulk-survey-drill.sh",
+  "completion-over-the-cli.sh",
+  "verb-session-gaps.sh",
+];
+
+/** Every drill in the integration directory, by name, with its text. */
+const drills: { name: string; text: string }[] = [];
+for await (const entry of Deno.readDir(DRILLS)) {
+  if (!entry.isFile || !entry.name.endsWith(".sh")) continue;
+  drills.push({
+    name: entry.name,
+    text: await Deno.readTextFile(new URL(entry.name, DRILLS)),
+  });
+}
+drills.sort((one, other) => one.name.localeCompare(other.name));
+
+describe("integration-command-spellings", () => {
+  it("reads the drills its cases depend on", () => {
+    // Names files rather than counting them. A scan of a directory it failed
+    // to read reports nothing wrong with every script in it, and reads exactly
+    // like a scan that found every script clean.
+
+    const names = drills.map((drill) => drill.name);
+    expect(WATCHED.filter((name) => !names.includes(name))).toEqual([]);
+  });
+
+  it("sees the blessed spellings those drills run", () => {
+    // The pattern read against the scripts rather than against a fixture. One
+    // blind to `$CF` finds nothing in a drill that writes every command
+    // through the variable, and reports it clean; the check below cannot tell
+    // that from a drill that is already right. Finding what these three do run
+    // is what separates the two.
+
+    expect(WATCHED.map((name) => {
+      const text = drills.find((drill) => drill.name === name)?.text ?? "";
+      const runs = invocationsOf(text, "cell get").length +
+        invocationsOf(text, "piece call").length;
+      return `${name} runs ${runs > 0 ? "a" : "no"} blessed spelling`;
+    })).toEqual(WATCHED.map((name) => `${name} runs a blessed spelling`));
+  });
+
+  it("runs no superseded command spelling in any drill", () => {
+    expect(
+      drills.flatMap((drill) =>
+        findSupersededSpellings(drill.name, drill.text)
+      ),
+    ).toEqual([]);
+  });
+
+  describe("findSupersededSpellings()", () => {
+    // The cases the scan exists for, and the cases that would make it fire on
+    // a drill that is already right. Without these the check above is a
+    // comparison of two empty arrays, which holds whatever the pattern does.
+
+    it("reports a spelling written through the `$CF` variable", () => {
+      expect(
+        findSupersededSpellings(
+          "drill.sh",
+          `$CF call -q --piece "$BOARD" addMember '{"title":"alpha"}'`,
+        ),
+      ).toEqual([
+        "drill.sh:1: 'cf call' is superseded; spell it 'cf piece call'",
+      ]);
+    });
+
+    it("reports a spelling written through the `${CF}` variable", () => {
+      expect(findSupersededSpellings("drill.sh", "${CF} get --quiet name"))
+        .toEqual([
+          "drill.sh:1: 'cf get' is superseded; spell it 'cf cell get'",
+        ]);
+    });
+
+    it("reports a spelling written as the literal command", () => {
+      expect(findSupersededSpellings("drill.sh", "cf piece set-home --reset"))
+        .toEqual([
+          "drill.sh:1: 'cf piece set-home' is superseded; spell it " +
+          "'cf space set-home'",
+        ]);
+    });
+
+    it("reports a spelling split across a backslash continuation", () => {
+      // The wrap a shell script writes to keep a long command under the line
+      // width. A line-based scan sees `$CF` on one line and `get` on the next
+      // and reads neither half as a command.
+
+      expect(
+        findSupersededSpellings(
+          "drill.sh",
+          ["KIDS=$($CF \\", '  get --quiet --piece "$EPIC" children)']
+            .join("\n"),
+        ),
+      ).toEqual([
+        "drill.sh:1: 'cf get' is superseded; spell it 'cf cell get'",
+      ]);
+    });
+
+    it("reports a spelling split across a bare line break", () => {
+      expect(
+        findSupersededSpellings(
+          "drill.sh",
+          ["run_step() {", "  $CF", "    piece get-label --piece board", "}"]
+            .join("\n"),
+        ),
+      ).toEqual([
+        "drill.sh:2: 'cf piece get-label' is superseded; spell it " +
+        "'cf cell get-label'",
+      ]);
+    });
+
+    it("reports each spelling against the line it sits on", () => {
+      expect(
+        findSupersededSpellings(
+          "drill.sh",
+          ["$CF piece survey --piece board", "", "$CF set --piece board x 1"]
+            .join("\n"),
+        ),
+      ).toEqual([
+        "drill.sh:3: 'cf set' is superseded; spell it 'cf cell set'",
+      ]);
+    });
+
+    it("returns nothing for the spellings the surface blesses", () => {
+      expect(
+        findSupersededSpellings(
+          "drill.sh",
+          [
+            "$CF cell get --quiet --piece board name",
+            "$CF cell set --piece board name x",
+            "$CF cell get-label --piece board",
+            "$CF cell set-label --piece board",
+            "$CF piece call --piece board addItem '{}'",
+            "$CF space recreate-root --space x",
+            "$CF space set-home --reset",
+          ].join("\n"),
+        ),
+      ).toEqual([]);
+    });
+
+    it("returns nothing for a longer name a superseded spelling opens", () => {
+      // `cf cell set-label` opens with the letters of `cf set` only after the
+      // noun, but `cf get-label` and `cf set-home` open with them directly.
+      // A `\b` boundary matches between `set` and `-`, so a pattern written
+      // with one reads all three as a use of `cf get` or `cf set`.
+
+      expect(
+        findSupersededSpellings(
+          "drill.sh",
+          ["$CF get-label --piece board", "$CF set-home --reset", "$CF getter"]
+            .join("\n"),
+        ),
+      ).toEqual([]);
+    });
+
+    it("returns nothing for a name the invocation is only part of", () => {
+      expect(
+        findSupersededSpellings(
+          "drill.sh",
+          ["$CFG get --piece board", "self-cf get --piece board"].join("\n"),
+        ),
+      ).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## Why

Step 7 (#6703) put each `cf` command under the noun it acts on, and left the
spellings it replaced answering — hidden from help and completion — until
**2026-09-11**. Three integration scripts still run the superseded ones, so
they break on the day the mounts are removed rather than on the day someone
reads them.

Splitting this out is deliberate. Migrating a caller does not depend on when
the mounts are removed, while the removal itself has to be swept against the
tree as it stands that day: main landed four separate new uses of the old
spellings during step 7's own review, including a new onboarding document. So
the sweep cannot be done in advance, and this can. Doing it now leaves step 7b
a deletion rather than a deletion plus a migration.

## What Changed

`verb-session-gaps.sh` (33), `bulk-survey-drill.sh` (3), and one line in
`completion-over-the-cli.sh` now write `cf cell get` and `cf piece call`.

That last one is worth naming: it is an execution check sitting directly above
a completion probe the step 7 sweep did move, so the two lines disagreed about
which spelling the section was testing.

## Test plan

- Every changed line is the same line with one word replaced. Verified
  mechanically rather than by reading: each removed line, put through the
  rename, equals its added line — 37 of 37, no unexplained additions.
- `bash -n` clean on every script in `packages/cli/integration/`.
- `deno fmt --check`, `deno lint`, `check-verb-session-sync`,
  `check-command-docs`, `check-skill-facts`, `check-conflict-markers`,
  `check-control-characters`: all green.
- **Not run here:** these drills need a live toolshed, so they are verified by
  inspection and shell syntax only. CI runs them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMYkpetkiepdqUhJDK3T9h

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6784?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

