### PR TITLE
test(data-model): the codec-less fabric classes render as recorded case files

### DIFF
--- a/packages/data-model/test/value-debug-cases/rogue-primitive.txt
+++ b/packages/data-model/test/value-debug-cases/rogue-primitive.txt
@@ -1,0 +1,10 @@
+(() => {
+  // A `FabricPrimitive` with no `[CODEC]` makes `codecOf()` throw, and the
+  // renderer reports the class rather than the failure.
+  class RoguePrimitive extends FabricPrimitive {}
+  return new RoguePrimitive();
+})()
+
+/RoguePrimitive(...)
+
+/RoguePrimitive(...)

--- a/packages/data-model/test/value-debug-cases/rogue-special-object.txt
+++ b/packages/data-model/test/value-debug-cases/rogue-special-object.txt
@@ -1,0 +1,12 @@
+(() => {
+  // A `FabricSpecialObject` with no `[CODEC]` makes `codecOf()` throw. The
+  // renderer is most likely to be reached for a value that is already
+  // malformed, so it renders what it can rather than adding a second failure
+  // on top of the first.
+  class RogueSpecial extends FabricSpecialObject {}
+  return new RogueSpecial();
+})()
+
+/RogueSpecial(...)
+
+/RogueSpecial(...)

--- a/packages/data-model/test/value-debug.test.ts
+++ b/packages/data-model/test/value-debug.test.ts
@@ -29,14 +29,13 @@ import { FabricEpochNsec } from "@/fabric-primitives/FabricEpochNsec.ts";
 import { FabricError } from "@/fabric-instances/FabricError.ts";
 import { FabricMap } from "@/fabric-instances/FabricMap.ts";
 import { FabricRegExp } from "@/fabric-primitives/FabricRegExp.ts";
-import { FabricPrimitive, FabricSpecialObject } from "@/interface.ts";
 
 describe("value-debug", () => {
   describe("toCompactDebugString", () => {
     // The renderings themselves are recorded as case files in
     // `value-debug-cases/`. What is here is what a case file cannot express:
-    // a value at the top level, a class the case scope does not include, and
-    // the `maxLength` behavior at more than one length.
+    // a value at the top level, and the `maxLength` behavior at more than one
+    // length.
 
     it("renders a top-level value the same as it renders that value in an array", () => {
       function foo() {}
@@ -59,25 +58,6 @@ describe("value-debug", () => {
         const nested = toCompactDebugString([value]);
         expect(toCompactDebugString(value)).toBe(nested.slice(1, -1));
       }
-    });
-
-    it("renders a `FabricSpecialObject` with no codec under its class name", () => {
-      // A `FabricSpecialObject` with no `[CODEC]` makes `codecOf()` throw.
-      // The formatter is most likely to be reached for a value that is
-      // already malformed, so it renders what it can rather than adding a
-      // second failure on top of the first.
-
-      class RogueSpecial extends FabricSpecialObject {}
-
-      expect(toCompactDebugString(new RogueSpecial()))
-        .toBe("/RogueSpecial(...)");
-    });
-
-    it("renders a `FabricPrimitive` with no codec under its class name", () => {
-      class RoguePrimitive extends FabricPrimitive {}
-
-      expect(toCompactDebugString(new RoguePrimitive()))
-        .toBe("/RoguePrimitive(...)");
     });
 
     describe("with `maxLength`", () => {


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Fable 5.1)

## What changes

`value-debug.test.ts` held two unit tests for classes with no `[CODEC]`: a `FabricSpecialObject` subclass, which renders as `/RogueSpecial(...)`, and a `FabricPrimitive` subclass, which renders as `/RoguePrimitive(...)`. They stayed unit tests while the case-file scope had no base classes to extend. The scope now includes `FabricInstance`, `FabricPrimitive`, `FabricSpecialObject`, and `REALM_CODEC`, so each rendering is recorded as a case file under `value-debug-cases/` the way every other rendering is:

- `rogue-special-object.txt`
- `rogue-primitive.txt`

The two unit tests go, along with the `@/interface.ts` import that served only them, and the block comment naming what a case file cannot express drops the clause about classes outside the scope.

## Verification

- The regenerated goldens read exactly what the deleted assertions pinned.
- Control: with `/RogueSpecial(...)` corrupted to `/RogueSpecial(x)` in the golden, the case test fails on that file alone; restored, it passes.
- `deno task test` in `data-model`: 48 passed, 2727 steps. `deno fmt --check`, `deno lint`, and `deno task check` clean.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

