### PR TITLE
fix(cli): collapse hidden-file search matches

### DIFF
--- a/packages/cli/lib/view/render.ts
+++ b/packages/cli/lib/view/render.ts
@@ -210,7 +210,7 @@ export interface ViewState {
   /** The selected structure node (WASD navigation), or null. */
   selected: StructureNode | null;
 
-  /** All search matches, document-ordered; null when no active search. */
+  /** Visible search matches, display-ordered; null when no active search. */
   matches: readonly Match[] | null;
 
   /** Index into `matches` of the focused match. */

--- a/packages/cli/lib/view/session.ts
+++ b/packages/cli/lib/view/session.ts
@@ -153,6 +153,11 @@ interface PeekOverlay {
 const HORIZONTAL_STEP = 8;
 const MOUSE_WHEEL_STEP = 3;
 
+/** Whether two search matches occupy the same displayed range. */
+function sameDisplayedMatch(a: Match, b: Match): boolean {
+  return a.line === b.line && a.start === b.start && a.end === b.end;
+}
+
 // Messages shown when a diff's edit policy refuses an edit.
 const NOT_EDITABLE_MSG =
   "This line isn't editable (a removed line or diff structure).";
@@ -849,22 +854,40 @@ export class Session {
     };
   }
 
-  /** The search matches with their line mapped into display rows. */
-  #displayMatches(): Match[] {
-    if (this.#collapsed.size === 0) return this.#matches;
+  /** Maps a source match into the folded display. */
+  #displayMatch(match: Match, fold: FoldPlan): Match {
+    const line = fold.docToDisplay(match.line);
+    if (fold.displayLines[line] === this.#currentDoc.lines[match.line]) {
+      return { ...match, line };
+    }
+    return {
+      ...match,
+      line,
+      start: 0,
+      end: codePointLength(fold.displayLines[line]?.text ?? ""),
+    };
+  }
+
+  /** The visible search matches and the focused index among them. */
+  #displaySearch(): { matches: Match[]; currentMatch: number } {
+    if (this.#collapsed.size === 0) {
+      return { matches: this.#matches, currentMatch: this.#currentMatch };
+    }
     const fold = this.#foldPlan();
-    return this.#matches.map((match) => {
-      const line = fold.docToDisplay(match.line);
-      if (fold.displayLines[line] === this.#currentDoc.lines[match.line]) {
-        return { ...match, line };
-      }
-      return {
-        ...match,
-        line,
-        start: 0,
-        end: codePointLength(fold.displayLines[line]?.text ?? ""),
-      };
-    });
+    const matches: Match[] = [];
+    let currentMatch = 0;
+    for (
+      let sourceIndex = 0;
+      sourceIndex < this.#matches.length;
+      sourceIndex++
+    ) {
+      const match = this.#displayMatch(this.#matches[sourceIndex], fold);
+      const previous = matches.at(-1);
+      const duplicate = previous && sameDisplayedMatch(previous, match);
+      if (!duplicate) matches.push(match);
+      if (sourceIndex === this.#currentMatch) currentMatch = matches.length - 1;
+    }
+    return { matches, currentMatch };
   }
 
   /** The file currently in view: the diff file or transformed-output section
@@ -946,6 +969,7 @@ export class Session {
   }
 
   view(): ViewState {
+    const search = this.#query.length > 0 ? this.#displaySearch() : null;
     const o = this.#overlay;
     const expand = this.#mode === "normal" && !this.#overlay &&
         !this.#cursorOn && this.#chord === null && this.#source?.expandContext
@@ -998,8 +1022,8 @@ export class Session {
         : this.#gutterNumbers(),
       displayMode: this.#displayMode,
       selected: this.#displaySelected(),
-      matches: this.#query.length > 0 ? this.#displayMatches() : null,
-      currentMatch: this.#currentMatch,
+      matches: search?.matches ?? null,
+      currentMatch: search?.currentMatch ?? this.#currentMatch,
       message: this.#message,
       inputLine: this.#mode === "search"
         ? `/${this.#input}`
@@ -1663,6 +1687,25 @@ export class Session {
     }
     const cur = this.#matches[this.#currentMatch];
     let idx = nextMatchIndex(this.#matches, cur.line, cur.start, forward);
+    if (!this.#searchAnchor && this.#collapsed.size > 0) {
+      const fold = this.#foldPlan();
+      const displayed = this.#displayMatch(cur, fold);
+      while (
+        idx !== this.#currentMatch &&
+        sameDisplayedMatch(
+          displayed,
+          this.#displayMatch(this.#matches[idx], fold),
+        )
+      ) {
+        const candidate = this.#matches[idx];
+        idx = nextMatchIndex(
+          this.#matches,
+          candidate.line,
+          candidate.start,
+          forward,
+        );
+      }
+    }
     // An edit-mode search (Ctrl-S) steps only between editable matches.
     if (this.#searchAnchor) idx = this.#firstEditableMatch(idx);
     this.#currentMatch = idx;

--- a/packages/cli/test/view-fold.test.ts
+++ b/packages/cli/test/view-fold.test.ts
@@ -1,4 +1,5 @@
 import { assert, assertEquals } from "@std/assert";
+import { expect } from "@std/expect";
 import { join } from "@std/path";
 import {
   buildFoldPlan,
@@ -710,6 +711,43 @@ Deno.test("fold: a selected node and a search match map onto the summary row", (
     "added",
     "a shown match keeps its source columns",
   );
+});
+
+Deno.test("fold: a collapsed file contributes one searchable match", () => {
+  const diff = [
+    "diff --git a/a.ts b/a.ts",
+    "--- a/a.ts",
+    "+++ b/a.ts",
+    "@@ -1,2 +1,2 @@",
+    "-old needle",
+    "+new needle",
+    " keep needle",
+    "diff --git a/b.ts b/b.ts",
+    "--- a/b.ts",
+    "+++ b/b.ts",
+    "@@ -1 +1,2 @@",
+    " keep",
+    "+needle",
+    "",
+  ].join("\n");
+  const s = foldSession(diff);
+  press(s, "f");
+  press(s, "/");
+  for (const ch of "needle") press(s, ch);
+  press(s, "enter");
+
+  expect(s.view().matches?.length).toBe(2);
+  expect(s.view().currentMatch).toBe(0);
+
+  press(s, "n");
+  const shown = s.view().matches?.[s.view().currentMatch];
+  assert(shown, "the shown file's match is focused");
+  expect(
+    s.displayDoc().lines[shown.line].text.slice(shown.start, shown.end),
+  ).toBe("needle");
+
+  press(s, "N");
+  expect(s.view().currentMatch).toBe(0);
 });
 
 Deno.test("fold: F / E / T / M are refused on a non-diff view", () => {


### PR DESCRIPTION
Search projected every source match in a collapsed diff file onto the same summary row while retaining each source occurrence in navigation. Files with many matches therefore consumed one `n` or `N` press per hidden occurrence.

Deduplicate matches after mapping them into the folded display, map the focused source match into that visible list, and skip source matches that share the focused display range during normal search navigation. Keep edit-mode search source-based because editing expands all folded files.

Cover the visible match count and forward and reverse navigation with a folded two-file diff. The focused fold test fails on the repeated hidden matches without the change and passes with the visible grouping in place.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6792?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

