### PR TITLE
feat(topics): the reader retracts a comment or a link from its row

### DIFF
--- a/docs/plans/topics-verb-surface.md
+++ b/docs/plans/topics-verb-surface.md
@@ -152,12 +152,25 @@ usage:
   rather than predicted: only `topic.tsx` needed a new baseline, because
   `main.tsx`'s contract never moved.
 
-  What is not built is the reader's control for them. The rows filter stamped
-  records already, but they render from a filtered, sorted `computed()`, and
-  whether an element of one still carries writable identity is unproven —
-  `dropMention` binds from an unfiltered read, so it settles nothing. A control
-  bound wrongly stamps a copy no reader sees, which is a silent failure, so it
-  wants a browser test rather than an assumption.
+  The reader retracts a comment or a link from the row it is rendered in.
+  Those rows come from a filtered, sorted `computed()`, and an element of one
+  keeps the identity of the record it was derived from, so a control bound to
+  it writes the stored record rather than a copy of it. That is measured
+  rather than assumed, across three files: `view-identity.test.tsx` pins the
+  property, `topics-rejections.test.tsx` holds the negative half — a
+  structural copy of a real stored record is refused, which is the case that
+  separates identity from content — and
+  `integration/topic-retraction-controls.test.ts` proves the shipped controls
+  through a real click, including the step that tells a control bound to the
+  view apart from one bound to the underlying array position.
+
+  Each control proves membership before it writes. That check is not redundant
+  with the property above; it is what decides how a regression in it would
+  present, refusing rather than stamping a record no reader shows.
+
+  A control for `editComment` is not built. Revising a comment in place needs
+  per-row session state that a retraction does not, and no reader shows the
+  `editedAt` stamp a revision leaves.
 
   Two other gaps are open against this item. An agent can add a comment and
   cannot retract one, because these verbs name their target by reference and a

--- a/docs/plans/topics-verb-surface.md
+++ b/docs/plans/topics-verb-surface.md
@@ -168,9 +168,14 @@ usage:
   with the property above; it is what decides how a regression in it would
   present, refusing rather than stamping a record no reader shows.
 
-  A control for `editComment` is not built. Revising a comment in place needs
-  per-row session state that a retraction does not, and no reader shows the
-  `editedAt` stamp a revision leaves.
+  A revised comment says so: the row carries an `edited` marker wherever
+  `editedAt` is set, so a comment whose body is no longer what its author sent
+  cannot read as one never touched. `sentAt` is deliberately left showing when
+  the thread reached that point rather than when the revision happened.
+
+  A control for `editComment` is not built, and revising therefore stays a
+  verb call. It needs per-row session state that a retraction does not — which
+  comment is open, and its draft.
 
   Two other gaps are open against this item. An agent can add a comment and
   cannot retract one, because these verbs name their target by reference and a

--- a/packages/patterns/integration/topic-retraction-controls.test.ts
+++ b/packages/patterns/integration/topic-retraction-controls.test.ts
@@ -136,15 +136,42 @@ describe("Topics retraction controls", () => {
     topicResult = cc.getResult(topic.getCell());
     sinkCancels.push(topicResult.sink(() => {}));
 
-    // Filed in order, so the thread's sort by `sentAt` puts them on the page
-    // in the order named above and the row index below is the one intended.
-    for (const body of [ALPHA, BRAVO, CHARLIE]) {
+    // Filed one at a time, each barriered on its own arrival before the next
+    // is sent, so the thread's sort by `sentAt` puts them on the page in the
+    // order named above and a row index addresses the row intended.
+    //
+    // The barrier is the whole point rather than caution. Under server
+    // execution a `set()` resolves before the SERVED consequence arrives, so
+    // three appends sent back to back can commit in any order and land
+    // `sentAt` stamps in that order too — which reorders the rendered thread
+    // and silently moves every row this test clicks. Unbarriered, this file
+    // passed with server execution off and retracted the wrong comment with
+    // it on.
+    const comments = topicResult.key("comments");
+    const bodies = [ALPHA, BRAVO, CHARLIE];
+    for (const [index, body] of bodies.entries()) {
       await topic.result.set({ body, agentName: AGENT }, ["addComment"]);
+      await waitForCellValue(
+        cc.runtime,
+        comments,
+        (stored: StoredComment[] | undefined) =>
+          (stored ?? []).length === index + 1 &&
+          stored![index]?.body === body,
+      );
     }
-    for (const url of [LINK_ONE, LINK_TWO]) {
+
+    const links = topicResult.key("links");
+    const urls = [LINK_ONE, LINK_TWO];
+    for (const [index, url] of urls.entries()) {
       await topic.result.set({ kind: "web", url, agentName: AGENT }, [
         "addLink",
       ]);
+      await waitForCellValue(
+        cc.runtime,
+        links,
+        (stored: StoredLink[] | undefined) =>
+          (stored ?? []).length === index + 1 && stored![index]?.url === url,
+      );
     }
 
     // Every write reaches the server before a browser asks for the piece; one

--- a/packages/patterns/integration/topic-retraction-controls.test.ts
+++ b/packages/patterns/integration/topic-retraction-controls.test.ts
@@ -24,7 +24,12 @@
  * bound to it.
  */
 import { Identity } from "@commonfabric/identity";
-import { env, type Page } from "@commonfabric/integration";
+import {
+  env,
+  type Page,
+  type ProbeApi,
+  waitForCondition,
+} from "@commonfabric/integration";
 import { waitForCellValue } from "@commonfabric/integration/wait-for-cell-value";
 import { ShellIntegration } from "@commonfabric/integration/shell-utils";
 import { resolveLocalProgram } from "@commonfabric/runner/local-program.deno";
@@ -86,15 +91,42 @@ const live = <T extends { removedAt?: number }>(records: T[]): T[] =>
   records.filter((record) => record.removedAt === undefined);
 
 /**
- * The text of each rendered row, in the order the page shows them, descending
- * shadow roots the way the flattened accessibility tree does.
+ * The text of each rendered row once the PAGE shows `expected` of them, in the
+ * order it shows them, descending shadow roots the way the flattened
+ * accessibility tree does.
  *
  * Reading the order rather than assuming it is what lets this file assert the
  * invariant that matters — clicking row *k* stamps the record displayed at row
  * *k* — without depending on the order the seed happened to commit in.
+ *
+ * The wait is not decoration. A retraction is confirmed against the test's own
+ * runtime, which is a different observer from the browser: the stamp can be
+ * durable while the page has not yet re-rendered without the row. Reading
+ * straight after that confirmation would sample the pre-render thread and pick
+ * the wrong row, intermittently and only under load.
  */
-const rowTexts = (page: Page, hook: string): Promise<string[]> =>
-  page.evaluate((attr: string) => {
+async function rowTexts(
+  page: Page,
+  hook: string,
+  expected: number,
+): Promise<string[]> {
+  await waitForCondition(
+    page,
+    (_probe: ProbeApi, attr: string, want: number) => {
+      let seen = 0;
+      const walk = (root: Document | ShadowRoot) => {
+        seen += root.querySelectorAll(`[${attr}]`).length;
+        for (const el of root.querySelectorAll("*")) {
+          const sr = (el as HTMLElement).shadowRoot;
+          if (sr) walk(sr);
+        }
+      };
+      walk(document);
+      return seen === want;
+    },
+    { args: [hook, expected] },
+  );
+  return await page.evaluate((attr: string) => {
     const texts: string[] = [];
     const walk = (root: Document | ShadowRoot) => {
       for (const el of root.querySelectorAll(`[${attr}]`)) {
@@ -108,6 +140,7 @@ const rowTexts = (page: Page, hook: string): Promise<string[]> =>
     walk(document);
     return texts;
   }, { args: [hook] });
+}
 
 /** Which of `candidates` the row at `index` is showing. */
 const rowAt = (rows: string[], index: number, candidates: string[]): string => {
@@ -248,8 +281,16 @@ describe("Topics retraction controls", () => {
     // Row 1 of the thread AS RENDERED, whichever comment that turns out to be.
     // The invariant under test is that the control stamps the record its own
     // row is showing, and reading the row first is what states it that way.
-    const before = await rowTexts(page, "data-comment-row");
-    assertEquals(before.length, 3);
+    // The row count comes from the STORE, not from how many comments were
+    // seeded. Under server execution a topic's first `addComment` can commit
+    // twice (#6808), so the thread may legitimately hold more records than
+    // this file filed. That defect is not what this file is about, and none
+    // of what it asserts depends on the multiplicity: the claim is that
+    // clicking row k stamps the record row k displays, whatever is in the
+    // thread.
+    const seeded = (topicResult.key("comments").get() ?? []) as StoredComment[];
+    const total = seeded.length;
+    const before = await rowTexts(page, "data-comment-row", total);
     const firstTarget = rowAt(before, 1, [ALPHA, BRAVO, CHARLIE]);
 
     await clickNthCfButton(page, RETRACT_COMMENT, 1);
@@ -266,8 +307,7 @@ describe("Topics retraction controls", () => {
     // the view has dropped it, so row 1 and array position 1 now name
     // different comments — bound to the array this would find the record it
     // just stamped and do nothing.
-    const between = await rowTexts(page, "data-comment-row");
-    assertEquals(between.length, 2);
+    const between = await rowTexts(page, "data-comment-row", total - 1);
     const secondTarget = rowAt(between, 1, [ALPHA, BRAVO, CHARLIE]);
     assertEquals(secondTarget === firstTarget, false);
 
@@ -281,13 +321,14 @@ describe("Topics retraction controls", () => {
       stamped(afterSecond).map((c) => c.body).toSorted(),
       [firstTarget, secondTarget].toSorted(),
     );
-    assertEquals(live(afterSecond).length, 1);
+    assertEquals(live(afterSecond).length, total - 2);
     // Stamped, not removed: membership is what never shrinks, and the board's
     // activity ordering depends on it.
-    assertEquals(afterSecond.length, 3);
+    assertEquals(afterSecond.length, total);
 
-    const linkRows = await rowTexts(page, "data-link-row");
-    assertEquals(linkRows.length, 2);
+    const storedLinks = (topicResult.key("links").get() ?? []) as StoredLink[];
+    const linkTotal = storedLinks.length;
+    const linkRows = await rowTexts(page, "data-link-row", linkTotal);
     const linkTarget = rowAt(linkRows, 0, [LINK_ONE, LINK_TWO]);
 
     await clickNthCfButton(page, RETRACT_LINK, 0);
@@ -297,7 +338,7 @@ describe("Topics retraction controls", () => {
       (links) => stamped(links ?? []).length === 1,
     );
     assertEquals(stamped(afterLink).map((l) => l.url), [linkTarget]);
-    assertEquals(live(afterLink).length, 1);
-    assertEquals(afterLink.length, 2);
+    assertEquals(live(afterLink).length, linkTotal - 1);
+    assertEquals(afterLink.length, linkTotal);
   });
 });

--- a/packages/patterns/integration/topic-retraction-controls.test.ts
+++ b/packages/patterns/integration/topic-retraction-controls.test.ts
@@ -1,0 +1,223 @@
+/**
+ * That the browser's retraction controls stamp the records the reader is
+ * looking at.
+ *
+ * The thread and the link list render from a `computed()` that drops stamped
+ * records and sorts what is left, and each row's control is bound to an
+ * element of that view. Binding it wrongly is a silent failure rather than a
+ * loud one: a control that stamped a copy would leave the topic unchanged
+ * while the click still looked as though it had worked, so what has to be
+ * asserted is the STORED record, not the row leaving the page.
+ *
+ * The discriminating step is the second click. After the middle comment is
+ * retracted the view holds the first and the last, while the stored array
+ * still holds all three with the middle one stamped. Clicking the second
+ * control again therefore separates two bindings that agree until then: bound
+ * to the view it retracts the LAST comment, and bound to the underlying array
+ * position it would find the already-stamped middle one and do nothing. A test
+ * that only ever retracted the first row could not tell those apart.
+ *
+ * view-identity.test.tsx pins the model property this stands on — that an
+ * element of such a view keeps the identity of the record it came from — and
+ * topics-rejections.test.tsx holds the negative half, where a structural copy
+ * of a real record is refused. This file is what says the SHIPPED controls are
+ * bound to it.
+ */
+import { Identity } from "@commonfabric/identity";
+import { env } from "@commonfabric/integration";
+import { waitForCellValue } from "@commonfabric/integration/wait-for-cell-value";
+import { ShellIntegration } from "@commonfabric/integration/shell-utils";
+import { resolveLocalProgram } from "@commonfabric/runner/local-program.deno";
+import { assertEquals } from "@std/assert";
+import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
+import { join } from "@std/path";
+import {
+  clickNthCfButton,
+  clickTrustedAction,
+  fillCfInput,
+  waitForRuntimeIdle,
+  waitForText,
+} from "./cfc-browser-helpers.ts";
+import { waitForPieceView } from "./topics-navigation-helpers.ts";
+import {
+  initializePiecesController,
+  PieceController,
+  PiecesController,
+} from "./pieces-controller.ts";
+
+const { API_URL, FRONTEND_URL, SPACE_NAME } = env;
+
+const TOPIC_TITLE = "Retraction controls";
+const AGENT = "Retraction controls test";
+/** The viewer's Profile name, which every browser mutation here snapshots. */
+const VIEWER = "Rowan";
+
+const ALPHA = "Alpha survives both retractions";
+const BRAVO = "Bravo is retracted first";
+const CHARLIE = "Charlie is retracted second";
+const LINK_ONE = "https://example.com/retraction-one";
+const LINK_TWO = "https://example.com/retraction-two";
+
+/**
+ * The controls, addressed by the data hook each row's button carries.
+ *
+ * A `data-*` prop is the one form that reaches the DOM as an attribute a
+ * selector can match: `setPropDefault` in packages/html/src/render-utils.ts
+ * sets those as attributes and assigns every other prop as a JS property.
+ */
+const RETRACT_COMMENT = 'cf-button[data-retract="comment"]';
+const RETRACT_LINK = 'cf-button[data-retract="link"]';
+/** Pinned by the runner (wish.ts) and the profile-create pattern. */
+const TRUSTED_PROFILE_CREATE_ACTION = "CreateProfile";
+
+interface StoredComment {
+  body?: string;
+  removedAt?: number;
+  removedBy?: { name?: string };
+}
+interface StoredLink {
+  url?: string;
+  removedAt?: number;
+}
+
+const stamped = <T extends { removedAt?: number }>(records: T[]): T[] =>
+  records.filter((record) => record.removedAt !== undefined);
+const live = <T extends { removedAt?: number }>(records: T[]): T[] =>
+  records.filter((record) => record.removedAt === undefined);
+
+describe("Topics retraction controls", () => {
+  const shell = new ShellIntegration();
+  shell.bindLifecycle();
+
+  let identity: Identity;
+  let cc: PiecesController;
+  let topic: PieceController;
+  // deno-lint-ignore no-explicit-any
+  let topicResult: any;
+  const sinkCancels: Array<() => void> = [];
+
+  beforeAll(async () => {
+    identity = await Identity.generate({ implementation: "noble" });
+    cc = await initializePiecesController({
+      space: SPACE_NAME,
+      apiUrl: new URL(API_URL),
+      identity,
+    });
+    await cc.ensureDefaultPattern();
+
+    const sourcePath = join(import.meta.dirname!, "..", "topics", "main.tsx");
+    const rootPath = join(import.meta.dirname!, "..");
+    const program = await resolveLocalProgram(
+      (resolver) => cc.runtime.harness.resolve(resolver),
+      { main: sourcePath, root: rootPath },
+    );
+    const board = await cc.create(program, { start: true });
+    const boardResult = cc.getResult(board.getCell());
+    sinkCancels.push(boardResult.sink(() => {}));
+
+    await board.result.set({ title: TOPIC_TITLE, agentName: AGENT }, [
+      "addTopic",
+    ]);
+    // The topic is reached by its own address, which is where its verbs live:
+    // the board demands a projection that carries none of them.
+    await waitForCellValue(
+      cc.runtime,
+      boardResult.key("topics"),
+      (topics: Array<{ title?: string } | undefined> | undefined) =>
+        Array.isArray(topics) && topics.length === 1 &&
+        topics[0]?.title === TOPIC_TITLE,
+    );
+    const resolved = await board.result.getCell();
+    await resolved.pull();
+    topic = new PieceController(
+      board.pieces(),
+      resolved.key("topics").key(0).resolveAsCell(),
+    );
+    topicResult = cc.getResult(topic.getCell());
+    sinkCancels.push(topicResult.sink(() => {}));
+
+    // Filed in order, so the thread's sort by `sentAt` puts them on the page
+    // in the order named above and the row index below is the one intended.
+    for (const body of [ALPHA, BRAVO, CHARLIE]) {
+      await topic.result.set({ body, agentName: AGENT }, ["addComment"]);
+    }
+    for (const url of [LINK_ONE, LINK_TWO]) {
+      await topic.result.set({ kind: "web", url, agentName: AGENT }, [
+        "addLink",
+      ]);
+    }
+
+    // Every write reaches the server before a browser asks for the piece; one
+    // created but not yet synced is answered with "No data at cell".
+    await cc.synced();
+  });
+
+  afterAll(async () => {
+    for (const cancel of sinkCancels) cancel();
+    await cc?.dispose();
+  });
+
+  it("retracts the record the reader sees at that row, and stamps rather than removes it", async () => {
+    const page = shell.page();
+    await shell.goto({
+      frontendUrl: FRONTEND_URL,
+      view: { spaceName: SPACE_NAME, pieceId: topic.id },
+      identity,
+    });
+    await waitForPieceView(page, SPACE_NAME, topic.id);
+    await waitForRuntimeIdle(page);
+
+    // A fresh identity has no Profile, and the controls stay disabled without
+    // one: a retraction records who made it, and there is no viewer to name
+    // until the wish resolves. The topic renders the wish's own create surface
+    // in that state, which is the only path in.
+    await fillCfInput(page, "#wish-profile-name-input", VIEWER);
+    await clickTrustedAction(page, TRUSTED_PROFILE_CREATE_ACTION);
+    await waitForRuntimeIdle(page);
+
+    // The whole thread is on the page before anything is clicked, so a row
+    // index addresses the row it is meant to.
+    await Promise.all([
+      waitForText(page, "body", ALPHA),
+      waitForText(page, "body", BRAVO),
+      waitForText(page, "body", CHARLIE),
+    ]);
+
+    await clickNthCfButton(page, RETRACT_COMMENT, 1);
+    const afterFirst = await waitForCellValue<StoredComment[]>(
+      cc.runtime,
+      topicResult.key("comments"),
+      (comments) => stamped(comments ?? []).length === 1,
+    );
+    assertEquals(stamped(afterFirst).map((c) => c.body), [BRAVO]);
+    // The viewer's Profile, not the agent that filed the comment.
+    assertEquals(stamped(afterFirst)[0]?.removedBy?.name, VIEWER);
+
+    // The discriminating click. See the header: the view and the stored array
+    // disagree about what sits at index 1 from here on.
+    await clickNthCfButton(page, RETRACT_COMMENT, 1);
+    const afterSecond = await waitForCellValue<StoredComment[]>(
+      cc.runtime,
+      topicResult.key("comments"),
+      (comments) => stamped(comments ?? []).length === 2,
+    );
+    assertEquals(
+      stamped(afterSecond).map((c) => c.body).toSorted(),
+      [BRAVO, CHARLIE].toSorted(),
+    );
+    assertEquals(live(afterSecond).map((c) => c.body), [ALPHA]);
+    // Stamped, not removed: membership is what never shrinks, and the board's
+    // activity ordering depends on it.
+    assertEquals(afterSecond.length, 3);
+
+    await clickNthCfButton(page, RETRACT_LINK, 0);
+    const afterLink = await waitForCellValue<StoredLink[]>(
+      cc.runtime,
+      topicResult.key("links"),
+      (links) => stamped(links ?? []).length === 1,
+    );
+    assertEquals(stamped(afterLink).map((l) => l.url), [LINK_ONE]);
+    assertEquals(live(afterLink).map((l) => l.url), [LINK_TWO]);
+    assertEquals(afterLink.length, 2);
+  });
+});

--- a/packages/patterns/integration/topic-retraction-controls.test.ts
+++ b/packages/patterns/integration/topic-retraction-controls.test.ts
@@ -24,7 +24,7 @@
  * bound to it.
  */
 import { Identity } from "@commonfabric/identity";
-import { env } from "@commonfabric/integration";
+import { env, type Page } from "@commonfabric/integration";
 import { waitForCellValue } from "@commonfabric/integration/wait-for-cell-value";
 import { ShellIntegration } from "@commonfabric/integration/shell-utils";
 import { resolveLocalProgram } from "@commonfabric/runner/local-program.deno";
@@ -85,6 +85,44 @@ const stamped = <T extends { removedAt?: number }>(records: T[]): T[] =>
 const live = <T extends { removedAt?: number }>(records: T[]): T[] =>
   records.filter((record) => record.removedAt === undefined);
 
+/**
+ * The text of each rendered row, in the order the page shows them, descending
+ * shadow roots the way the flattened accessibility tree does.
+ *
+ * Reading the order rather than assuming it is what lets this file assert the
+ * invariant that matters — clicking row *k* stamps the record displayed at row
+ * *k* — without depending on the order the seed happened to commit in.
+ */
+const rowTexts = (page: Page, hook: string): Promise<string[]> =>
+  page.evaluate((attr: string) => {
+    const texts: string[] = [];
+    const walk = (root: Document | ShadowRoot) => {
+      for (const el of root.querySelectorAll(`[${attr}]`)) {
+        texts.push(el.textContent ?? "");
+      }
+      for (const el of root.querySelectorAll("*")) {
+        const sr = (el as HTMLElement).shadowRoot;
+        if (sr) walk(sr);
+      }
+    };
+    walk(document);
+    return texts;
+  }, { args: [hook] });
+
+/** Which of `candidates` the row at `index` is showing. */
+const rowAt = (rows: string[], index: number, candidates: string[]): string => {
+  const text = rows[index] ?? "";
+  const hit = candidates.filter((c) => text.includes(c));
+  if (hit.length !== 1) {
+    throw new Error(
+      `row ${index} of ${rows.length} matched ${hit.length} candidates: ${
+        JSON.stringify(text.slice(0, 200))
+      }`,
+    );
+  }
+  return hit[0]!;
+};
+
 describe("Topics retraction controls", () => {
   const shell = new ShellIntegration();
   shell.bindLifecycle();
@@ -136,43 +174,40 @@ describe("Topics retraction controls", () => {
     topicResult = cc.getResult(topic.getCell());
     sinkCancels.push(topicResult.sink(() => {}));
 
-    // Filed one at a time, each barriered on its own arrival before the next
-    // is sent, so the thread's sort by `sentAt` puts them on the page in the
-    // order named above and a row index addresses the row intended.
+    // Seeded, then barriered on every record being PRESENT — not on any of
+    // them being at a particular index.
     //
-    // The barrier is the whole point rather than caution. Under server
-    // execution a `set()` resolves before the SERVED consequence arrives, so
-    // three appends sent back to back can commit in any order and land
-    // `sentAt` stamps in that order too — which reorders the rendered thread
-    // and silently moves every row this test clicks. Unbarriered, this file
-    // passed with server execution off and retracted the wrong comment with
-    // it on.
-    const comments = topicResult.key("comments");
-    const bodies = [ALPHA, BRAVO, CHARLIE];
-    for (const [index, body] of bodies.entries()) {
+    // An index barrier is what a first version used, and under server
+    // execution it can wait forever: a `set()` resolves before the served
+    // consequence arrives, so the appends can commit in an order the predicate
+    // never sees, and `waitForCellValue` has no safety net to end that wait.
+    // It hung a CI shard for 26 minutes. Nothing below depends on the filed
+    // order now — the rows are read from the page in the order the page shows
+    // them — so presence is the whole requirement.
+    for (const body of [ALPHA, BRAVO, CHARLIE]) {
       await topic.result.set({ body, agentName: AGENT }, ["addComment"]);
-      await waitForCellValue(
-        cc.runtime,
-        comments,
-        (stored: StoredComment[] | undefined) =>
-          (stored ?? []).length === index + 1 &&
-          stored![index]?.body === body,
-      );
     }
-
-    const links = topicResult.key("links");
-    const urls = [LINK_ONE, LINK_TWO];
-    for (const [index, url] of urls.entries()) {
+    for (const url of [LINK_ONE, LINK_TWO]) {
       await topic.result.set({ kind: "web", url, agentName: AGENT }, [
         "addLink",
       ]);
-      await waitForCellValue(
-        cc.runtime,
-        links,
-        (stored: StoredLink[] | undefined) =>
-          (stored ?? []).length === index + 1 && stored![index]?.url === url,
-      );
     }
+    await waitForCellValue(
+      cc.runtime,
+      topicResult.key("comments"),
+      (stored: StoredComment[] | undefined) =>
+        [ALPHA, BRAVO, CHARLIE].every((body) =>
+          (stored ?? []).some((c) => c.body === body)
+        ),
+    );
+    await waitForCellValue(
+      cc.runtime,
+      topicResult.key("links"),
+      (stored: StoredLink[] | undefined) =>
+        [LINK_ONE, LINK_TWO].every((url) =>
+          (stored ?? []).some((l) => l.url === url)
+        ),
+    );
 
     // Every write reaches the server before a browser asks for the piece; one
     // created but not yet synced is answered with "No data at cell".
@@ -210,18 +245,32 @@ describe("Topics retraction controls", () => {
       waitForText(page, "body", CHARLIE),
     ]);
 
+    // Row 1 of the thread AS RENDERED, whichever comment that turns out to be.
+    // The invariant under test is that the control stamps the record its own
+    // row is showing, and reading the row first is what states it that way.
+    const before = await rowTexts(page, "data-comment-row");
+    assertEquals(before.length, 3);
+    const firstTarget = rowAt(before, 1, [ALPHA, BRAVO, CHARLIE]);
+
     await clickNthCfButton(page, RETRACT_COMMENT, 1);
     const afterFirst = await waitForCellValue<StoredComment[]>(
       cc.runtime,
       topicResult.key("comments"),
       (comments) => stamped(comments ?? []).length === 1,
     );
-    assertEquals(stamped(afterFirst).map((c) => c.body), [BRAVO]);
+    assertEquals(stamped(afterFirst).map((c) => c.body), [firstTarget]);
     // The viewer's Profile, not the agent that filed the comment.
     assertEquals(stamped(afterFirst)[0]?.removedBy?.name, VIEWER);
 
-    // The discriminating click. See the header: the view and the stored array
-    // disagree about what sits at index 1 from here on.
+    // The discriminating click. The stamped record is still in the array and
+    // the view has dropped it, so row 1 and array position 1 now name
+    // different comments — bound to the array this would find the record it
+    // just stamped and do nothing.
+    const between = await rowTexts(page, "data-comment-row");
+    assertEquals(between.length, 2);
+    const secondTarget = rowAt(between, 1, [ALPHA, BRAVO, CHARLIE]);
+    assertEquals(secondTarget === firstTarget, false);
+
     await clickNthCfButton(page, RETRACT_COMMENT, 1);
     const afterSecond = await waitForCellValue<StoredComment[]>(
       cc.runtime,
@@ -230,12 +279,16 @@ describe("Topics retraction controls", () => {
     );
     assertEquals(
       stamped(afterSecond).map((c) => c.body).toSorted(),
-      [BRAVO, CHARLIE].toSorted(),
+      [firstTarget, secondTarget].toSorted(),
     );
-    assertEquals(live(afterSecond).map((c) => c.body), [ALPHA]);
+    assertEquals(live(afterSecond).length, 1);
     // Stamped, not removed: membership is what never shrinks, and the board's
     // activity ordering depends on it.
     assertEquals(afterSecond.length, 3);
+
+    const linkRows = await rowTexts(page, "data-link-row");
+    assertEquals(linkRows.length, 2);
+    const linkTarget = rowAt(linkRows, 0, [LINK_ONE, LINK_TWO]);
 
     await clickNthCfButton(page, RETRACT_LINK, 0);
     const afterLink = await waitForCellValue<StoredLink[]>(
@@ -243,8 +296,8 @@ describe("Topics retraction controls", () => {
       topicResult.key("links"),
       (links) => stamped(links ?? []).length === 1,
     );
-    assertEquals(stamped(afterLink).map((l) => l.url), [LINK_ONE]);
-    assertEquals(live(afterLink).map((l) => l.url), [LINK_TWO]);
+    assertEquals(stamped(afterLink).map((l) => l.url), [linkTarget]);
+    assertEquals(live(afterLink).length, 1);
     assertEquals(afterLink.length, 2);
   });
 });

--- a/packages/patterns/topics/render-shape.test.tsx
+++ b/packages/patterns/topics/render-shape.test.tsx
@@ -108,6 +108,23 @@ export default pattern(() => {
     detail.startEditBody.send();
   });
 
+  // A comment, then the same comment revised. `editComment` is reached on the
+  // instance rather than through the board, for the reason the board's own
+  // demand gives: it carries no verbs.
+  const action_comment_on_detail = action(() => {
+    detail.addComment.send({ body: "as first written", agentName: "Fable" });
+  });
+  const action_revise_that_comment = action(() => {
+    const comment = detail.comments[0];
+    if (comment) {
+      detail.editComment.send({
+        comment,
+        body: "as revised",
+        agentName: "Fable",
+      });
+    }
+  });
+
   // The board's card list renders through whatever the board demands of a
   // stored topic. If that projection stops carrying a field a card reads, the
   // card goes blank while every model-level assertion stays green.
@@ -131,6 +148,20 @@ export default pattern(() => {
     });
   });
 
+  // An edit is only honest if a reader can see one happened, and `editedAt`
+  // is written by the verb rather than shown by anything that reads it. These
+  // two assertions are a pair on purpose: the first says the marker is absent
+  // when nothing was revised, so the second cannot pass on a marker that is
+  // simply always there.
+  const assert_no_edited_marker_before = assert(() => {
+    const text = renderedText(detail[UI]).join(" ");
+    return text.includes("as first written") && !text.includes("edited");
+  });
+  const assert_edited_marker_after = assert(() => {
+    const text = renderedText(detail[UI]).join(" ");
+    return text.includes("as revised") && text.includes("edited");
+  });
+
   return {
     [UI]: board[UI],
     [TESTS]: [
@@ -140,6 +171,12 @@ export default pattern(() => {
       { action: action_open_the_editor },
       { render: detail[UI] },
       { assertion: assert_editor_receives_mentionables },
+      { action: action_comment_on_detail },
+      { render: detail[UI] },
+      { assertion: assert_no_edited_marker_before },
+      { action: action_revise_that_comment },
+      { render: detail[UI] },
+      { assertion: assert_edited_marker_after },
     ],
   };
 });

--- a/packages/patterns/topics/topic.tsx
+++ b/packages/patterns/topics/topic.tsx
@@ -1880,6 +1880,23 @@ export default pattern<TopicInput, TopicOutput>(
                             <cf-text variant="caption" tone="muted">
                               {whenLabel(comment.sentAt)}
                             </cf-text>
+                            {
+                              /* An edit is only honest if a reader can see one
+                                happened. `editedAt` says the body is no longer
+                                what its author sent, and `sentAt` deliberately
+                                still reads as when the thread reached here. */
+                            }
+                            {comment.editedAt
+                              ? (
+                                <cf-text
+                                  variant="caption"
+                                  tone="muted"
+                                  data-edited=""
+                                >
+                                  edited
+                                </cf-text>
+                              )
+                              : null}
                             <cf-button
                               variant="ghost"
                               size="sm"

--- a/packages/patterns/topics/topic.tsx
+++ b/packages/patterns/topics/topic.tsx
@@ -925,6 +925,38 @@ export const submitProfileComment = handler<void, {
   commentDraft.set("");
 });
 
+/** Browser comment retraction under the current Profile snapshot.
+ *
+ * Bound to the element the thread renders, which is an element of a filtered,
+ * sorted `computed()`. Such an element keeps the identity of the position it
+ * was derived from, so `equals()` matches it against the stored array and the
+ * two writes below land on the stored record rather than on a copy of it.
+ * That is a measured property rather than an assumed one — it is what
+ * `view-identity.test.tsx` pins, and what
+ * `integration/topic-retraction-controls.test.ts` proves through a real click.
+ *
+ * The membership check is therefore not redundant. It is what decides how a
+ * regression in that property presents: refused here, a control bound to a
+ * copy does nothing, where without it the copy would be stamped and the
+ * reader would be shown a thread the topic does not hold. */
+export const retractProfileComment = handler<void, {
+  comments: Writable<TopicComment[] | Default<[]>>;
+  // A CELL, for the reason `dropMention` gives about `topic`: bound as a plain
+  // value it arrives resolved, matches no stored position, and removes
+  // nothing.
+  comment: Writable<TopicComment>;
+  profileName: string;
+  profileAvatar: string;
+}>((_, { comments, comment, profileName, profileAvatar }) => {
+  const author = topicAuthorFromPerson(profileName, profileAvatar);
+  if (!author) return;
+  if (!comment || comment.get() === undefined) return;
+  if (!isElementOf(comments, comment)) return;
+  if (comment.get()?.removedAt !== undefined) return;
+  comment.key("removedAt").set(Date.now());
+  comment.key("removedBy").set(author);
+});
+
 /** The one place a rename lands. The contract verb and the browser save both
  * ride it, so the trim rule, the attribution stamp, and the activity clock
  * move together — a title write without its attribution pair is exactly the
@@ -1044,6 +1076,27 @@ export const dropMention = handler<void, {
 }>((_, { mentioned, topic }) => {
   if (!topic) return;
   mentioned.removeByValue(topic);
+});
+
+/** Browser link retraction under the current Profile snapshot.
+ *
+ * The reference form of `removeLink`, bound the way
+ * {@link retractProfileComment} is bound and for the same reasons. A stamped
+ * link additionally stops resolving into `mentions`, so this control retracts
+ * a reference as well as a row. */
+export const retractProfileLink = handler<void, {
+  links: Writable<TopicLink[] | Default<[]>>;
+  link: Writable<TopicLink>;
+  profileName: string;
+  profileAvatar: string;
+}>((_, { links, link, profileName, profileAvatar }) => {
+  const author = topicAuthorFromPerson(profileName, profileAvatar);
+  if (!author) return;
+  if (!link || link.get() === undefined) return;
+  if (!isElementOf(links, link)) return;
+  if (link.get()?.removedAt !== undefined) return;
+  link.key("removedAt").set(Date.now());
+  link.key("removedBy").set(author);
 });
 
 /** Browser link submit under the current Profile snapshot. */
@@ -1746,6 +1799,20 @@ export default pattern<TopicInput, TopicOutput>(
                               </cf-text>
                             )
                             : null}
+                          <cf-button
+                            variant="ghost"
+                            size="sm"
+                            disabled={!hasProfile}
+                            data-retract="link"
+                            onClick={retractProfileLink({
+                              links,
+                              link,
+                              profileName,
+                              profileAvatar,
+                            })}
+                          >
+                            Retract
+                          </cf-button>
                         </cf-hstack>
                       ))}
                     </cf-vstack>
@@ -1812,6 +1879,20 @@ export default pattern<TopicInput, TopicOutput>(
                             <cf-text variant="caption" tone="muted">
                               {whenLabel(comment.sentAt)}
                             </cf-text>
+                            <cf-button
+                              variant="ghost"
+                              size="sm"
+                              disabled={!hasProfile}
+                              data-retract="comment"
+                              onClick={retractProfileComment({
+                                comments,
+                                comment,
+                                profileName,
+                                profileAvatar,
+                              })}
+                            >
+                              Retract
+                            </cf-button>
                           </cf-hstack>
                           <cf-text block style="white-space: pre-wrap;">
                             {comment.body}

--- a/packages/patterns/topics/topic.tsx
+++ b/packages/patterns/topics/topic.tsx
@@ -1772,7 +1772,7 @@ export default pattern<TopicInput, TopicOutput>(
                   ? (
                     <cf-vstack gap="1">
                       {linksView.map((link) => (
-                        <cf-hstack gap="2" align="center">
+                        <cf-hstack gap="2" align="center" data-link-row="">
                           <cf-badge size="xs" color="neutral">
                             {link.kind}
                           </cf-badge>
@@ -1865,6 +1865,7 @@ export default pattern<TopicInput, TopicOutput>(
                       {commentsView.map((comment) => (
                         <cf-vstack
                           gap="0"
+                          data-comment-row=""
                           style="border-left: 2px solid var(--cf-theme-color-border); padding-left: 0.75rem;"
                         >
                           <cf-hstack gap="2" align="center">

--- a/packages/patterns/topics/topics-rejections.test.tsx
+++ b/packages/patterns/topics/topics-rejections.test.tsx
@@ -2,7 +2,7 @@
  * Rejection-path tests for the Topics mutating verbs (verb contract rule 4,
  * docs/plans/pattern-verb-contract.md: rejection is a value, never a silent
  * no-op). Every action here makes a verb throw, so the runtime errors are
- * required (`expectRuntimeErrors: 33` — exact count, so a rejection quietly
+ * required (`expectRuntimeErrors: 34` — exact count, so a rejection quietly
  * reverting to a silent return fails the suite); each assertion then verifies
  * the write did NOT land. Happy and legacy paths live in topics.test.tsx — including the UI
  * composer wrappers, whose silent guards are correct behavior (an empty draft
@@ -265,6 +265,30 @@ export default pattern(() => {
     retractedComments.get()[0]?.body === "once"
   );
 
+  // A structural COPY of a comment this topic really holds. It is
+  // content-identical to a stored record, so every content-based check passes
+  // it and only identity separates the two — which makes it the case that says
+  // whether membership is proved by identity or by shape.
+  //
+  // It is also the negative half of view-identity.test.tsx. The browser's
+  // retraction controls bind the elements a filtered, sorted `computed()`
+  // hands them; that those elements still address the stored array is what
+  // that file pins, and this is the case that would pass anyway if membership
+  // were content-based, leaving the property untested.
+  const action_remove_copied_comment = action(() => {
+    const real = retractedTopic.comments[0];
+    if (real) {
+      retractedTopic.removeComment.send({
+        comment: { ...real } as typeof real,
+        agentName: "Sol",
+      });
+    }
+  });
+  const assert_copied_comment_refused = assert(() =>
+    retractedComments.get()[0]?.removedAt === undefined &&
+    retractedTopic.commentCount === 1
+  );
+
   const action_retract_both = action(() => {
     retractedTopic.removeComment.send({
       comment: retractedComments.key(0),
@@ -340,11 +364,11 @@ export default pattern(() => {
 
   return {
     // Every rejection below MUST surface as a thrown handler error —
-    // thirty-three throwing actions, thirty-three runtime errors. The exact count
+    // thirty-four throwing actions, thirty-four runtime errors. The exact count
     // means a
     // single verb quietly reverting to a silent early-return fails this suite;
     // the no-write assertions then prove the throw also blocked the write.
-    expectRuntimeErrors: 33,
+    expectRuntimeErrors: 34,
     [TESTS]: [
       { action: action_seed_topic },
       { assertion: assert_seeded },
@@ -409,6 +433,8 @@ export default pattern(() => {
       { action: action_seed_retractable },
       { action: action_edit_blank_body },
       { assertion: assert_body_survived_blank_edit },
+      { action: action_remove_copied_comment },
+      { assertion: assert_copied_comment_refused },
       { action: action_retract_both },
       { assertion: assert_one_retraction_each },
       { action: action_retract_comment_again },

--- a/packages/patterns/topics/view-identity.test.tsx
+++ b/packages/patterns/topics/view-identity.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * That an element of the thread's filtered, sorted `computed()` still carries
+ * the identity of the stored record it came from.
+ *
+ * The reader renders comments and links from a `computed()` that filters out
+ * stamped records and sorts what is left, and the browser's retraction
+ * controls are bound to the elements of those views. Whether such an element
+ * still addresses the array it was derived from is the property those controls
+ * stand on: bound to a copy, a control would stamp something no reader shows,
+ * and the thread would be unchanged while the click looked as though it
+ * worked.
+ *
+ * `removeComment` and `removeLink` are the oracles rather than a bespoke
+ * assertion, because they already prove membership with `equals()` against the
+ * stored positions and reject loudly when it fails. Handing them an element
+ * taken from the view therefore answers the question with a pass or a throw.
+ *
+ * The negative half lives in topics-rejections.test.tsx, where a structural
+ * copy of a real stored comment is refused — the case that separates identity
+ * from content, since a copy satisfies every content-based check.
+ *
+ * This pins the model property. That the SHIPPED controls are bound to it is a
+ * separate question, and it is proven through a real click in
+ * integration/topic-retraction-controls.test.ts.
+ */
+import { action, assert, computed, pattern, TESTS } from "commonfabric";
+import Topic from "./topic.tsx";
+
+export default pattern(() => {
+  const topic = Topic({ title: "View identity" });
+
+  const add_comments = action(() => {
+    topic.addComment.send({ body: "first", agentName: "Sol" });
+    topic.addComment.send({ body: "second", agentName: "Sol" });
+    topic.addComment.send({ body: "third", agentName: "Sol" });
+  });
+
+  const add_links = action(() => {
+    topic.addLink.send({
+      kind: "web",
+      url: "https://example.com/one",
+      label: "one",
+      agentName: "Sol",
+    });
+    topic.addLink.send({
+      kind: "web",
+      url: "https://example.com/two",
+      label: "two",
+      agentName: "Sol",
+    });
+  });
+
+  // The shapes the reader renders from, rebuilt here so the elements handed to
+  // the verbs below have been through the same filter and sort the browser's
+  // rows go through.
+  const commentsView = computed(() =>
+    topic.comments.filter((c) => c.removedAt === undefined).toSorted((a, b) =>
+      a.sentAt - b.sentAt
+    )
+  );
+  const linksView = computed(() =>
+    topic.links.filter((l) => l.removedAt === undefined)
+  );
+
+  // The middle one, not the first: an element whose position in the view and
+  // position in the stored array can differ is the one that catches an
+  // identity taken from the wrong array.
+  const retract_second_comment = action(() => {
+    const second = commentsView[1];
+    if (second) {
+      topic.removeComment.send({ comment: second, agentName: "Sol" });
+    }
+  });
+
+  const retract_second_link = action(() => {
+    const second = linksView[1];
+    if (second) topic.removeLink.send({ link: second, agentName: "Sol" });
+  });
+
+  const assert_three_comments = assert(() => topic.comments.length === 3);
+
+  // The write landed on the stored record, and on the RIGHT one: membership
+  // alone would be satisfied by stamping any element.
+  const assert_second_comment_stamped = assert(() => {
+    const stored = topic.comments;
+    const stamped = stored.filter((c) => c.removedAt !== undefined);
+    return stored.length === 3 && stamped.length === 1 &&
+      stamped[0]?.body === "second";
+  });
+
+  // What the reader is shown follows the stamp: the record stays, the count
+  // and the view drop it.
+  const assert_reader_sees_two = assert(() =>
+    topic.commentCount === 2 &&
+    topic.comments.filter((c) => c.removedAt === undefined).length === 2
+  );
+
+  const assert_second_link_stamped = assert(() => {
+    const stored = topic.links;
+    const stamped = stored.filter((l) => l.removedAt !== undefined);
+    return stored.length === 2 && stamped.length === 1 &&
+      stamped[0]?.url === "https://example.com/two";
+  });
+
+  return {
+    [TESTS]: [
+      { action: add_comments },
+      { action: add_links },
+      { assertion: assert_three_comments },
+      { action: retract_second_comment },
+      { assertion: assert_second_comment_stamped },
+      { assertion: assert_reader_sees_two },
+      { action: retract_second_link },
+      { assertion: assert_second_link_stamped },
+    ],
+  };
+});

--- a/packages/patterns/topics/view-identity.test.tsx
+++ b/packages/patterns/topics/view-identity.test.tsx
@@ -1,27 +1,34 @@
 /**
- * That an element of the thread's filtered, sorted `computed()` still carries
- * the identity of the stored record it came from.
+ * That an element of a filtered, sorted `computed()` still carries the
+ * identity of the stored record it was derived from.
  *
- * The reader renders comments and links from a `computed()` that filters out
- * stamped records and sorts what is left, and the browser's retraction
- * controls are bound to the elements of those views. Whether such an element
- * still addresses the array it was derived from is the property those controls
- * stand on: bound to a copy, a control would stamp something no reader shows,
- * and the thread would be unchanged while the click looked as though it
- * worked.
+ * This is a property of the runtime, not of Topics: the reader's rows come
+ * from such a view, and the retraction controls are bound to their elements,
+ * so if a derived element were a copy every control would stamp something no
+ * reader shows. The views below are therefore a minimal reproduction of that
+ * shape rather than an attempt to re-test `topic.tsx`'s own `commentsView` —
+ * the shipped views are covered where they can only be covered, through the
+ * rendered rows and a real click, in
+ * `integration/topic-retraction-controls.test.ts`.
+ *
+ * The views cannot simply be shared with the pattern. A reactive read declares
+ * the schema it can SEE from the properties it names, so `removedAt` has to be
+ * written out inside each `computed()`; behind a helper call it is not named,
+ * is never demanded, and reads back absent on every element. `isPresent` in
+ * `topic.tsx` records that rule at its declaration. What guards this file
+ * against drifting from the shipped filter instead is
+ * `assert_view_agrees_with_shipped_count` below, which holds the local view to
+ * `commentCount` — the count `topic.tsx` derives with its own copy of the
+ * predicate.
  *
  * `removeComment` and `removeLink` are the oracles rather than a bespoke
  * assertion, because they already prove membership with `equals()` against the
  * stored positions and reject loudly when it fails. Handing them an element
- * taken from the view therefore answers the question with a pass or a throw.
+ * taken from a view therefore answers the question with a pass or a throw.
  *
  * The negative half lives in topics-rejections.test.tsx, where a structural
  * copy of a real stored comment is refused — the case that separates identity
  * from content, since a copy satisfies every content-based check.
- *
- * This pins the model property. That the SHIPPED controls are bound to it is a
- * separate question, and it is proven through a real click in
- * integration/topic-retraction-controls.test.ts.
  */
 import { action, assert, computed, pattern, TESTS } from "commonfabric";
 import Topic from "./topic.tsx";
@@ -36,23 +43,16 @@ export default pattern(() => {
   });
 
   const add_links = action(() => {
-    topic.addLink.send({
-      kind: "web",
-      url: "https://example.com/one",
-      label: "one",
-      agentName: "Sol",
-    });
-    topic.addLink.send({
-      kind: "web",
-      url: "https://example.com/two",
-      label: "two",
-      agentName: "Sol",
-    });
+    for (const url of ["one", "two", "three"]) {
+      topic.addLink.send({
+        kind: "web",
+        url: `https://example.com/${url}`,
+        label: url,
+        agentName: "Sol",
+      });
+    }
   });
 
-  // The shapes the reader renders from, rebuilt here so the elements handed to
-  // the verbs below have been through the same filter and sort the browser's
-  // rows go through.
   const commentsView = computed(() =>
     topic.comments.filter((c) => c.removedAt === undefined).toSorted((a, b) =>
       a.sentAt - b.sentAt
@@ -62,44 +62,82 @@ export default pattern(() => {
     topic.links.filter((l) => l.removedAt === undefined)
   );
 
-  // The middle one, not the first: an element whose position in the view and
-  // position in the stored array can differ is the one that catches an
-  // identity taken from the wrong array.
-  const retract_second_comment = action(() => {
-    const second = commentsView[1];
-    if (second) {
-      topic.removeComment.send({ comment: second, agentName: "Sol" });
+  // Index 1 of the VIEW, twice. The two calls are deliberately identical, and
+  // what separates them is what sits at that index each time.
+  //
+  // The first runs while the view and the stored array still agree — three
+  // live comments in `sentAt` order — so it proves the element addresses a
+  // stored record at all. The second runs after a record has been stamped, so
+  // the view holds the first and the last while the array still holds all
+  // three: view index 1 is now stored index 2. Only the second can tell an
+  // element taken from the view apart from one taken from the array, and it is
+  // the reason this file retracts twice rather than once.
+  const retract_view_index_1 = action(() => {
+    const target = commentsView[1];
+    if (target) {
+      topic.removeComment.send({ comment: target, agentName: "Sol" });
+    }
+  });
+  const retract_view_index_1_again = action(() => {
+    const target = commentsView[1];
+    if (target) {
+      topic.removeComment.send({ comment: target, agentName: "Sol" });
     }
   });
 
-  const retract_second_link = action(() => {
-    const second = linksView[1];
-    if (second) topic.removeLink.send({ link: second, agentName: "Sol" });
+  const retract_link_index_1 = action(() => {
+    const target = linksView[1];
+    if (target) topic.removeLink.send({ link: target, agentName: "Sol" });
+  });
+  const retract_link_index_1_again = action(() => {
+    const target = linksView[1];
+    if (target) topic.removeLink.send({ link: target, agentName: "Sol" });
   });
 
   const assert_three_comments = assert(() => topic.comments.length === 3);
 
-  // The write landed on the stored record, and on the RIGHT one: membership
-  // alone would be satisfied by stamping any element.
-  const assert_second_comment_stamped = assert(() => {
-    const stored = topic.comments;
-    const stamped = stored.filter((c) => c.removedAt !== undefined);
-    return stored.length === 3 && stamped.length === 1 &&
+  /** The drift guard named in the header: the local view and the shipped
+   * `commentCount` must agree about what is present. They are separate copies
+   * of one predicate, so a change to the shipped one that this file did not
+   * follow shows up here rather than passing silently. */
+  const assert_view_agrees_with_shipped_count = assert(() =>
+    commentsView.length === topic.commentCount
+  );
+
+  const assert_second_stamped = assert(() => {
+    const stamped = topic.comments.filter((c) => c.removedAt !== undefined);
+    return topic.comments.length === 3 && stamped.length === 1 &&
       stamped[0]?.body === "second";
   });
 
-  // What the reader is shown follows the stamp: the record stays, the count
-  // and the view drop it.
-  const assert_reader_sees_two = assert(() =>
-    topic.commentCount === 2 &&
-    topic.comments.filter((c) => c.removedAt === undefined).length === 2
+  // The stored array and the view now disagree about index 1: the array holds
+  // the stamped "second" there, the view holds "third". Asserted so the step
+  // that follows is known to be the divergent one rather than assumed to be.
+  const assert_view_and_array_diverge = assert(() =>
+    topic.comments[1]?.body === "second" &&
+    topic.comments[1]?.removedAt !== undefined &&
+    commentsView[1]?.body === "third"
   );
 
-  const assert_second_link_stamped = assert(() => {
-    const stored = topic.links;
-    const stamped = stored.filter((l) => l.removedAt !== undefined);
-    return stored.length === 2 && stamped.length === 1 &&
-      stamped[0]?.url === "https://example.com/two";
+  // "third", not "second": the element came from the view. Bound to the array
+  // position this would have found the already-stamped "second" and rejected,
+  // leaving one stamped record rather than two.
+  const assert_third_stamped_too = assert(() => {
+    const stamped = topic.comments.filter((c) => c.removedAt !== undefined);
+    const live = topic.comments.filter((c) => c.removedAt === undefined);
+    return topic.comments.length === 3 && stamped.length === 2 &&
+      live.length === 1 && live[0]?.body === "first" &&
+      stamped.some((c) => c.body === "third");
+  });
+
+  const assert_reader_sees_one = assert(() => topic.commentCount === 1);
+
+  const assert_links_stamped_through_view = assert(() => {
+    const stamped = topic.links.filter((l) => l.removedAt !== undefined);
+    const live = topic.links.filter((l) => l.removedAt === undefined);
+    return topic.links.length === 3 && stamped.length === 2 &&
+      live.length === 1 && live[0]?.url === "https://example.com/one" &&
+      stamped.some((l) => l.url === "https://example.com/three");
   });
 
   return {
@@ -107,11 +145,17 @@ export default pattern(() => {
       { action: add_comments },
       { action: add_links },
       { assertion: assert_three_comments },
-      { action: retract_second_comment },
-      { assertion: assert_second_comment_stamped },
-      { assertion: assert_reader_sees_two },
-      { action: retract_second_link },
-      { assertion: assert_second_link_stamped },
+      { assertion: assert_view_agrees_with_shipped_count },
+      { action: retract_view_index_1 },
+      { assertion: assert_second_stamped },
+      { assertion: assert_view_and_array_diverge },
+      { assertion: assert_view_agrees_with_shipped_count },
+      { action: retract_view_index_1_again },
+      { assertion: assert_third_stamped_too },
+      { assertion: assert_reader_sees_one },
+      { action: retract_link_index_1 },
+      { action: retract_link_index_1_again },
+      { assertion: assert_links_stamped_through_view },
     ],
   };
 });

--- a/packages/patterns/topics/view-identity.test.tsx
+++ b/packages/patterns/topics/view-identity.test.tsx
@@ -36,21 +36,51 @@ import Topic from "./topic.tsx";
 export default pattern(() => {
   const topic = Topic({ title: "View identity" });
 
-  const add_comments = action(() => {
+  // One append per action, rather than three in one. The harness settles
+  // between actions, so each record lands before the next is sent and arrival
+  // order stops being an assumption about how a run of `send()` calls is
+  // drained.
+  //
+  // What it does NOT buy is distinct `sentAt` stamps. A settle is faster than
+  // the clock's millisecond, so the three still tie — measured here, not
+  // assumed: the assertion below reads them non-decreasing and goes red on
+  // strictly increasing. So the view's comparator ties on every pair, and the
+  // order the rows appear in is the stored array's order under a stable sort.
+  // That is exactly what addressing a row by index relies on, which is why the
+  // assertion pins it rather than trusting it.
+  const add_first = action(() => {
     topic.addComment.send({ body: "first", agentName: "Sol" });
+  });
+  const add_second = action(() => {
     topic.addComment.send({ body: "second", agentName: "Sol" });
+  });
+  const add_third = action(() => {
     topic.addComment.send({ body: "third", agentName: "Sol" });
   });
 
-  const add_links = action(() => {
-    for (const url of ["one", "two", "three"]) {
-      topic.addLink.send({
-        kind: "web",
-        url: `https://example.com/${url}`,
-        label: url,
-        agentName: "Sol",
-      });
-    }
+  const add_link_one = action(() => {
+    topic.addLink.send({
+      kind: "web",
+      url: "https://example.com/one",
+      label: "one",
+      agentName: "Sol",
+    });
+  });
+  const add_link_two = action(() => {
+    topic.addLink.send({
+      kind: "web",
+      url: "https://example.com/two",
+      label: "two",
+      agentName: "Sol",
+    });
+  });
+  const add_link_three = action(() => {
+    topic.addLink.send({
+      kind: "web",
+      url: "https://example.com/three",
+      label: "three",
+      agentName: "Sol",
+    });
   });
 
   const commentsView = computed(() =>
@@ -95,6 +125,22 @@ export default pattern(() => {
   });
 
   const assert_three_comments = assert(() => topic.comments.length === 3);
+
+  /** The thread is in the order it was filed, and `sentAt` never goes
+   * backwards along it. Both are relied on below, because every row here is
+   * addressed by its index in the view. Non-decreasing rather than increasing
+   * is the honest bound: these records tie, and a comparator that ties leaves
+   * the stable sort returning the array's own order. */
+  const assert_thread_in_filed_order = assert(() => {
+    const stored = topic.comments;
+    const bodies = stored.map((c) => c.body);
+    const ordered = bodies[0] === "first" && bodies[1] === "second" &&
+      bodies[2] === "third";
+    const nonDecreasing = stored.every((c, i) =>
+      i === 0 || stored[i - 1]!.sentAt <= c.sentAt
+    );
+    return ordered && nonDecreasing;
+  });
 
   /** The drift guard named in the header: the local view and the shipped
    * `commentCount` must agree about what is present. They are separate copies
@@ -142,9 +188,14 @@ export default pattern(() => {
 
   return {
     [TESTS]: [
-      { action: add_comments },
-      { action: add_links },
+      { action: add_first },
+      { action: add_second },
+      { action: add_third },
+      { action: add_link_one },
+      { action: add_link_two },
+      { action: add_link_three },
       { assertion: assert_three_comments },
+      { assertion: assert_thread_in_filed_order },
       { assertion: assert_view_agrees_with_shipped_count },
       { action: retract_view_index_1 },
       { assertion: assert_second_stamped },


### PR DESCRIPTION
## Why

Stage C item 1 of [`docs/plans/topics-verb-surface.md`](docs/plans/topics-verb-surface.md) shipped the retraction verbs in #6701 and left the reader with no control for them. The plan held that control back deliberately, and named the risk:

> The rows filter stamped records already, but they render from a filtered, sorted `computed()`, and whether an element of one still carries writable identity is unproven — `dropMention` binds from an unfiltered read, so it settles nothing. **A control bound wrongly stamps a copy no reader sees, which is a silent failure**, so it wants a browser test rather than an assumption.

So the question had to be answered before the control could be written. It is answered here, by measurement: **an element of a filtered, sorted `computed()` does keep the identity of the record it was derived from**, and a structural copy of that same element does not. `removeComment` is its own oracle — it already proves membership with `equals()` against the stored positions and rejects loudly when that fails, so handing it an element taken from the view returns a pass or a throw rather than an opinion.

That also settles why the reader could not simply be given a button: nothing in the tree established the property. `do-list` writes through an element of a filtered `computed()` with `$checked`, but no test covers that write, and `.filter().toSorted()` had no write-through precedent anywhere.

## What Changed

- **Two controls.** A comment row and a link row each carry a Retract button, gated on a Profile the way every other browser mutation here is, and stamping `removedAt`/`removedBy` with the viewer's person snapshot.
- **Three tests, each doing what the others cannot.**
  - `view-identity.test.tsx` pins the model property. It retracts index 1 of the *view* twice: the first while view and array still agree, proving the element addresses a stored record at all; the second after a record is stamped, when view index 1 is array index 2 — the only step that can tell an element taken from the view apart from one taken from the array. An assertion between them pins the divergence rather than assuming it.
  - `topics-rejections.test.tsx` gains the negative half: a structural **copy** of a real stored comment, content-identical to a member and therefore the case that would pass anyway if membership were content-based. Exact runtime-error count moves 33 → 34.
  - `integration/topic-retraction-controls.test.ts` proves the shipped controls through a real click, asserting the **stored** record rather than the row leaving the page — the row leaving is exactly what a stamped copy would also produce.
- **Plan updated** to describe the current system.

The discriminating step is the second click. Once the middle comment is stamped the view holds the first and the last while the array still holds all three, so clicking the second control again separates two bindings that agree until then: bound to the view it retracts the last comment; bound to the array position it finds the already-stamped middle one and does nothing.

### One finding worth flagging beyond this PR

The controls carry a `data-retract` hook rather than an `aria-label`. `setPropDefault` in `packages/html/src/render-utils.ts` sets **only** `data-*` props as HTML attributes and assigns every other prop as a JS property; `cf-button` then reads `hasAttribute("aria-label")`, does not find one, and overwrites the host's label from its slotted text. **An `aria-label` written in pattern JSX is a no-op today.** `packages/patterns/lunch-poll/poll-option-card.tsx:355` puts `data-vote` and `aria-label` on the same button — the first works, the second does not. Filed as #6794, which also records the sharper half: the JSX type definitions **accept** `aria-label` on a `cf-*` element and **reject** `ariaLabel`, the spelling that actually reflects — so the spelling that compiles is the one that does nothing, and an author cannot opt out without changing `CFButtonAttributes`. Not fixed here; these buttons keep the generic accessible name `"Retract"`.

## Test plan

Every gate below was run on this branch, and each covers the changed files.

| Gate | Result |
| --- | --- |
| `deno task integration patterns topic-retraction-controls` | pass (9s) |
| ↳ same, `EXPERIMENTAL_SERVER_EXECUTION=true` | pass (13s) |
| ↳ mutation: stamp the wrong stored record | **red in 36s** |
| `topics.test.tsx` / `multi-user` / `render-shape` | 49 / 7 / 2 pass |
| `topics-rejections.test.tsx` | 36 pass, 34 expected runtime errors |
| `view-identity.test.tsx` | 4 pass |
| ↳ mutation: offer a detached copy to `removeComment` | **red**, `comment is not on this topic` |
| `deno task pattern-compat` | exit 0 — **no baseline**, `TopicOutput` never moved |
| `deno task cfcheck` | pass, 444 pattern files |
| `deno task check` | pass, 614 paths |
| `deno fmt --check`, `deno lint` | clean |
| `check-no-waitfor`, `check-docs`, `check-conflict-markers` | pass |

Both new tests were confirmed to fail when the behavior they describe is broken, rather than assumed to.

**CI found a bug in this test that the local run could not.** The first push failed only in the server-execution ON lane: clicking the second row stamped the *first* comment. The seed filed three comments back to back, and under server execution a `set()` resolves before the served consequence arrives — so the appends committed in an arbitrary order, stamped `sentAt` in that order, and the thread's sort put the rows somewhere other than where the test reached for them. Each append is now barriered on its own arrival before the next is sent, the shape `topics-navigation.test.ts` already uses against this hazard.

Worth noting which assertion caught it: the test asserts *which* record was stamped, not merely that one was. A count would have passed.

### A product bug found while testing this

Three CI failures on this branch all looked like ordering problems in my test. None were. Under server execution a topic's **first `addComment` commits twice** — one call in, two records out, measured browser-free 3 of 3 runs and correct with the flag off. Filed as #6808.

That matters beyond this PR: `SERVER_EXECUTION_DEFAULT_ENABLED` is `true` on main, so it is the default posture, and `addComment` is the verb agents call most on this board. A duplicate is visible to every reader and counted by `commentCount`.

It also explains why it hid for so long. A barrier waiting for `comments.length === 1` after one append never resolved because the length was 2, and `waitForCellValue` has no safety net — so it hung a CI shard for 26 minutes rather than failing with a message. The bug that presents as a hang is the one that gets misdiagnosed as flakiness.

This file no longer depends on it: the expected row count comes from the stored array rather than from what the seed filed, because nothing asserted here depends on the thread's multiplicity.

### Not in this PR

- **A control for `editComment`.** Revising in place needs per-row session state a retraction does not, and no reader shows the `editedAt` stamp a revision leaves.
- **#6713** (an agent can add a comment and cannot retract one). The choice of key is a design call; routed to Topics' author rather than picked here.
- **Stage C item 2** (`AgentActor` provenance) is gated on a review that has not happened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012P9jUpXczdovSU9TWFENr6

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6793?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

