### PR TITLE
feat(shuttle): the connection a shuttle process holds

### DIFF
--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -139,6 +139,19 @@ Landed:
   reference naming its space by name, which is a two-step protocol — the
   caller resolves the name and hands the move back with the space it resolved
   to, and the place is landed or refused there.
+- **B1b (slice 1) — the held connection**
+  (`packages/shuttle/src/connection.ts`). One `PiecesController` for the
+  process, opened on the first ask and served to every ask after, where `cf`
+  builds one per invocation. The connection half of the ambient record maps
+  onto `SpaceConfig` and is handed to `loadPieces`, so shuttle reaches the
+  connect sequence and none of the flag parsing in front of it. The memo is
+  cf-harness's: a rejected construction is not held, so the next ask opens
+  again rather than replaying a terminal failure, which covers the connection
+  that never opened and says nothing about one that later drops. Ownership is
+  named by the source rather than inferred from an overridden collaborator —
+  a connection opened here is closed here, one handed over is left to whoever
+  opened it — so either can be driven with no socket behind it. No verb
+  reaches the connection yet, and the place is untouched.
 
 Still to come:
 
@@ -191,10 +204,8 @@ Still to come:
   while a carriage return, a vertical tab, a form feed, a no-break space and
   the Unicode line and paragraph separators all read back whole and reach only
   a terminal.
-- **Liveness, in two halves.** The held controller is memoized
-  cf-harness-style, which covers the construction that never succeeds —
-  the case that cache actually addresses. Recovery of an *established*
-  connection needs nothing from shuttle: the memory client reconnects and
+- **Liveness, in two halves.** Recovery of an *established* connection needs
+  nothing from shuttle: the memory client reconnects and
   re-arms its watches by itself
   ([`runtime-integration.md`](runtime-integration.md)), so B1 proves that
   rather than rebuilding it — a test that drops the transport under a

--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -150,8 +150,13 @@ Landed:
   that never opened and says nothing about one that later drops. Ownership is
   named by the source rather than inferred from an overridden collaborator —
   a connection opened here is closed here, one handed over is left to whoever
-  opened it — so either can be driven with no socket behind it. No verb
-  reaches the connection yet, and the place is untouched.
+  opened it — so either can be driven with no socket behind it. A close that
+  fails is terminal: the disposal stays rejected and the holder serves nothing
+  after it, which is what a disposal that is process shutdown wants. A
+  `disconnect` verb makes a run carry on past one, and then a single transient
+  teardown error kills the holder for the rest of the run — so that verb
+  revisits this trade rather than inheriting it. No verb reaches the
+  connection yet, and the place is untouched.
 
 Still to come:
 

--- a/packages/shuttle/deno.jsonc
+++ b/packages/shuttle/deno.jsonc
@@ -4,11 +4,11 @@
     // --no-check: this package is type-checked by `deno task check`
     // (tasks/check.sh).
     // --allow-env: `@commonfabric/cli/lib/piece`, the entry `src/connection.ts`
-    // opens its connection through, reads the environment as it loads. The
-    // reads come from its whole transitive graph rather than from that module,
-    // so the grant is broad: a named list of variables would be a hand-copied
-    // enumeration of another package's imports with nothing keeping it in
-    // step.
+    // opens its connection through, reads the environment as it loads — in
+    // that module itself, and throughout its transitive graph. The grant is
+    // broad because a named list of variables would be a hand-copied
+    // enumeration of what that whole graph reads at load, with nothing
+    // keeping it in step.
     "test": "deno test --no-check --allow-env"
   }
 }

--- a/packages/shuttle/deno.jsonc
+++ b/packages/shuttle/deno.jsonc
@@ -3,6 +3,8 @@
   "tasks": {
     // --no-check: this package is type-checked by `deno task check`
     // (tasks/check.sh).
-    "test": "deno test --no-check"
+    // --allow-env: `@commonfabric/cli/lib/piece`, the entry `src/connection.ts`
+    // opens its connection through, reads the environment as it loads.
+    "test": "deno test --no-check --allow-env"
   }
 }

--- a/packages/shuttle/deno.jsonc
+++ b/packages/shuttle/deno.jsonc
@@ -4,7 +4,11 @@
     // --no-check: this package is type-checked by `deno task check`
     // (tasks/check.sh).
     // --allow-env: `@commonfabric/cli/lib/piece`, the entry `src/connection.ts`
-    // opens its connection through, reads the environment as it loads.
+    // opens its connection through, reads the environment as it loads. The
+    // reads come from its whole transitive graph rather than from that module,
+    // so the grant is broad: a named list of variables would be a hand-copied
+    // enumeration of another package's imports with nothing keeping it in
+    // step.
     "test": "deno test --no-check --allow-env"
   }
 }

--- a/packages/shuttle/src/connection.ts
+++ b/packages/shuttle/src/connection.ts
@@ -1,0 +1,163 @@
+/**
+ * The one connection a shuttle process holds: a `PiecesController` opened
+ * once and served to every read and write for the rest of the run. Who holds
+ * the controller, for how long, and who closes it are all decisions a
+ * long-lived process has to make, and this module is where they are made.
+ *
+ * The connect sequence belongs to `loadPieces` (`@commonfabric/cli/lib/piece`),
+ * which this module calls. What it adds is a memo, and the memo covers the
+ * connection that never opened: a rejected construction is not held, so a
+ * later ask opens again. A connection that opens and then drops is outside
+ * that entirely — nothing here observes a drop, retries one, or reports one.
+ */
+
+import { loadPieces, type SpaceConfig } from "@commonfabric/cli/lib/piece";
+import type { PiecesController } from "@commonfabric/piece/ops";
+
+/**
+ * The connection half of the ambient record: what one shuttle process
+ * connects as, fixed for its whole run.
+ */
+export interface ConnectionRecord {
+  /** The deployment to connect to. */
+  readonly apiUrl: string;
+
+  /** The space to open, as a `did:key:` DID or as a space name. */
+  readonly space: string;
+
+  /** The identity to act as, as the path to its PKCS#8 key file. */
+  readonly identity: string;
+}
+
+/** Opens a connection over `config` and returns the controller on it. */
+export type ConnectionOpener = (
+  config: SpaceConfig,
+) => Promise<PiecesController>;
+
+/**
+ * Where a {@link HeldConnection} gets its controller, and with it who closes
+ * it: a connection opened here is closed here, and one opened elsewhere is
+ * closed by whoever opened it. Ownership is a property of the source, so it
+ * holds whatever opener sits under either arm.
+ */
+export type ConnectionSource =
+  /** Opened here, from `record`, and closed here. */
+  | {
+    /** Names this arm of {@link ConnectionSource}. */
+    readonly kind: "owned";
+
+    /** What to connect as. */
+    readonly record: ConnectionRecord;
+
+    /** What opens it; `loadPieces` where the source names none. */
+    readonly open?: ConnectionOpener;
+  }
+  /** Already open, and closed by whoever opened it. */
+  | {
+    /** Names this arm of {@link ConnectionSource}. */
+    readonly kind: "borrowed";
+
+    /** The controller to serve. */
+    readonly pieces: PiecesController;
+  };
+
+/**
+ * Helper for {@link HeldConnection}, which returns the {@link SpaceConfig}
+ * `record` denotes: the record's three dimensions, and nothing else the
+ * config admits.
+ */
+function spaceConfigFor(record: ConnectionRecord): SpaceConfig {
+  return {
+    apiUrl: record.apiUrl,
+    space: record.space,
+    identity: record.identity,
+  };
+}
+
+/**
+ * The holder of a shuttle process's connection. It opens one on the first
+ * ask, hands that same one to every ask after, and on disposal closes
+ * whatever it opened.
+ *
+ * Per instance rather than per process, so that more than one connection
+ * stays reachable.
+ */
+export class HeldConnection implements AsyncDisposable {
+  #open: () => Promise<PiecesController>;
+  #owned: boolean;
+  #pieces: Promise<PiecesController> | undefined;
+  #disposed = false;
+
+  /**
+   * Constructs an instance serving the connection `source` names. An owned
+   * source is opened on the first ask; a borrowed one is open already.
+   */
+  constructor(source: ConnectionSource) {
+    if (source.kind === "borrowed") {
+      this.#open = () => Promise.resolve(source.pieces);
+      this.#owned = false;
+    } else {
+      const open = source.open ?? loadPieces;
+      const config = spaceConfigFor(source.record);
+      this.#open = () => open(config);
+      this.#owned = true;
+    }
+  }
+
+  /**
+   * The connection, opened on the first ask and shared by every ask after.
+   * An ask made while a construction is in flight joins that construction
+   * rather than starting a second one.
+   *
+   * A rejected construction is not held: the rejection reaches every caller
+   * awaiting that attempt, and the next ask opens again rather than replaying
+   * a terminal failure for the rest of the run. That covers the connection
+   * that never opened, which is the whole of what it covers.
+   *
+   * Throws once this instance is disposed: a disposed holder serves nothing,
+   * whether or not it closed anything.
+   */
+  pieces(): Promise<PiecesController> {
+    if (this.#disposed) {
+      throw new Error("This connection is disposed.");
+    }
+    if (this.#pieces === undefined) {
+      const attempt: Promise<PiecesController> = Promise.resolve()
+        .then(this.#open)
+        .catch((error) => {
+          // Only while this attempt is still the held one, so unholding a
+          // failure can never take a later, live connection with it. Nothing
+          // reaches the other branch as things stand: an ask starts an
+          // attempt only where nothing is held, and only a failure unholds.
+          if (this.#pieces === attempt) this.#pieces = undefined;
+          throw error;
+        });
+      this.#pieces = attempt;
+    }
+    return this.#pieces;
+  }
+
+  /**
+   * Closes the connection this instance opened, and refuses to serve one
+   * afterwards. Closing again does nothing.
+   *
+   * A connection this instance was handed is left open: it is the caller's to
+   * close, and closing it would take down a socket still in use. Where no ask
+   * opened one there is nothing to close, and a construction that rejected
+   * handed this instance no controller either, so its rejection is neither
+   * closed nor re-raised here.
+   */
+  async dispose(): Promise<void> {
+    if (this.#disposed) return;
+    this.#disposed = true;
+    const held = this.#pieces;
+    if (!this.#owned || held === undefined) return;
+    const pieces = await held.catch(() => undefined);
+    await pieces?.dispose();
+  }
+
+  /** @inheritDoc */
+  async [Symbol.asyncDispose](): Promise<void> {
+    await this.dispose();
+  }
+}

--- a/packages/shuttle/src/connection.ts
+++ b/packages/shuttle/src/connection.ts
@@ -141,6 +141,12 @@ export class HeldConnection implements AsyncDisposable {
    * Closes the connection this instance opened, and refuses to serve one
    * afterwards. Closing again does nothing.
    *
+   * A construction still in flight is awaited and its connection closed, so
+   * that a disposal crossing a connect strands nothing; the ask that started
+   * it still resolves with that connection. `loadPieces` takes no signal to
+   * stop on, so what it opens exists whether or not anyone is still waiting
+   * for it, and closing it is the only thing that can be done about it.
+   *
    * A connection this instance was handed is left open: it is the caller's to
    * close, and closing it would take down a socket still in use. Where no ask
    * opened one there is nothing to close, and a construction that rejected

--- a/packages/shuttle/src/connection.ts
+++ b/packages/shuttle/src/connection.ts
@@ -117,11 +117,13 @@ export class HeldConnection implements AsyncDisposable {
    * a terminal failure for the rest of the run. That covers the connection
    * that never opened, which is the whole of what it covers.
    *
-   * Throws once this instance is disposed, and throws where every other
-   * failure here rejects: asking a disposed holder is a mistake in the
-   * caller rather than a connection that would not open, and the two are
-   * worth telling apart at the call. A caller that wants them together
-   * catches around the call and not only on the promise.
+   * Throws once a disposal has begun — which refuses a call made from
+   * inside the connection's own close, and not only one made after that
+   * close finished — and throws where every other failure here rejects:
+   * asking a disposed holder is a mistake in the caller rather than a
+   * connection that would not open, and the two are worth telling apart at
+   * the call. A caller that wants them together catches around the call and
+   * not only on the promise.
    */
   pieces(): Promise<PiecesController> {
     if (this.#disposal !== undefined) {
@@ -149,6 +151,12 @@ export class HeldConnection implements AsyncDisposable {
    * closes twice nor reports done while the first is still closing, and a
    * close that failed reports the same failure to each of them.
    *
+   * A close that fails is terminal. The disposal stays rejected, so every
+   * later call reports that same failure, nothing retries the close, and
+   * this instance serves nothing again — over a connection that may be
+   * part-way torn down. That is the bound on it: what suits a disposal which
+   * is process shutdown does not suit one a run carries on past.
+   *
    * A construction still in flight is awaited and its connection closed, so
    * that a disposal crossing a connect strands nothing; the ask that started
    * it still resolves with that connection. `loadPieces` takes no signal to
@@ -173,9 +181,14 @@ export class HeldConnection implements AsyncDisposable {
 
   /**
    * Helper for {@link HeldConnection.dispose}, which does the closing that
-   * every call to it shares. Nothing between here and its first `await`
-   * re-enters this instance, which is what lets `dispose()` hold the promise
-   * this returns rather than having to hold a flag before calling it.
+   * every call to it shares. Nothing before its first `await` runs code a
+   * caller supplied: two `#private` field reads, which no getter can
+   * intercept, and `catch` on a native promise. So the window before
+   * `dispose()` holds what this returns cannot be re-entered, rather than
+   * merely happening not to be — and an `async` function never throws
+   * synchronously, so that hold always happens. Which is what lets
+   * `dispose()` memoize the result instead of setting a flag ahead of the
+   * call.
    */
   async #disposeOnce(): Promise<void> {
     const held = this.#pieces;

--- a/packages/shuttle/src/connection.ts
+++ b/packages/shuttle/src/connection.ts
@@ -5,10 +5,13 @@
  * long-lived process has to make, and this module is where they are made.
  *
  * The connect sequence belongs to `loadPieces` (`@commonfabric/cli/lib/piece`),
- * which this module calls. What it adds is a memo, and the memo covers the
- * connection that never opened: a rejected construction is not held, so a
- * later ask opens again. A connection that opens and then drops is outside
- * that entirely — nothing here observes a drop, retries one, or reports one.
+ * which this module calls. What it adds is two memos, whose retry policies
+ * are opposites. A construction is not held when it fails, so a later ask
+ * opens again; that covers the connection that never opened, and a connection
+ * that opens and then drops is outside it entirely, since nothing here
+ * observes a drop, retries one, or reports one. A disposal is held whatever
+ * it does, so a close that fails is terminal and the holder serves nothing
+ * after it.
  */
 
 import { loadPieces, type SpaceConfig } from "@commonfabric/cli/lib/piece";
@@ -186,8 +189,8 @@ export class HeldConnection implements AsyncDisposable {
    * intercept, and `catch` on a native promise. So the window before
    * `dispose()` holds what this returns cannot be re-entered, rather than
    * merely happening not to be — and an `async` function never throws
-   * synchronously, so that hold always happens. Which is what lets
-   * `dispose()` memoize the result instead of setting a flag ahead of the
+   * synchronously, so that hold always happens, which is what lets
+   * `dispose()` memoize the result rather than set a flag ahead of the
    * call.
    */
   async #disposeOnce(): Promise<void> {

--- a/packages/shuttle/src/connection.ts
+++ b/packages/shuttle/src/connection.ts
@@ -79,14 +79,17 @@ function spaceConfigFor(record: ConnectionRecord): SpaceConfig {
  * ask, hands that same one to every ask after, and on disposal closes
  * whatever it opened.
  *
- * Per instance rather than per process, so that more than one connection
- * stays reachable.
+ * Per instance rather than per process, because a module-global holder would
+ * be module-global mutable state (`docs/development/DEVELOPMENT.md`, "Avoid
+ * Singletons"). How many connections one process may hold at a time is a
+ * different question, settled in `docs/plans/shuttle/runtime-integration.md`
+ * rather than here.
  */
 export class HeldConnection implements AsyncDisposable {
   #open: () => Promise<PiecesController>;
   #owned: boolean;
   #pieces: Promise<PiecesController> | undefined;
-  #disposed = false;
+  #disposal: Promise<void> | undefined;
 
   /**
    * Constructs an instance serving the connection `source` names. An owned
@@ -114,11 +117,14 @@ export class HeldConnection implements AsyncDisposable {
    * a terminal failure for the rest of the run. That covers the connection
    * that never opened, which is the whole of what it covers.
    *
-   * Throws once this instance is disposed: a disposed holder serves nothing,
-   * whether or not it closed anything.
+   * Throws once this instance is disposed, and throws where every other
+   * failure here rejects: asking a disposed holder is a mistake in the
+   * caller rather than a connection that would not open, and the two are
+   * worth telling apart at the call. A caller that wants them together
+   * catches around the call and not only on the promise.
    */
   pieces(): Promise<PiecesController> {
-    if (this.#disposed) {
+    if (this.#disposal !== undefined) {
       throw new Error("This connection is disposed.");
     }
     if (this.#pieces === undefined) {
@@ -139,7 +145,9 @@ export class HeldConnection implements AsyncDisposable {
 
   /**
    * Closes the connection this instance opened, and refuses to serve one
-   * afterwards. Closing again does nothing.
+   * afterwards. Every call returns the one disposal, so a second neither
+   * closes twice nor reports done while the first is still closing, and a
+   * close that failed reports the same failure to each of them.
    *
    * A construction still in flight is awaited and its connection closed, so
    * that a disposal crossing a connect strands nothing; the ask that started
@@ -153,17 +161,26 @@ export class HeldConnection implements AsyncDisposable {
    * handed this instance no controller either, so its rejection is neither
    * closed nor re-raised here.
    */
-  async dispose(): Promise<void> {
-    if (this.#disposed) return;
-    this.#disposed = true;
-    const held = this.#pieces;
-    if (!this.#owned || held === undefined) return;
-    const pieces = await held.catch(() => undefined);
-    await pieces?.dispose();
+  dispose(): Promise<void> {
+    this.#disposal ??= this.#disposeOnce();
+    return this.#disposal;
   }
 
   /** @inheritDoc */
   async [Symbol.asyncDispose](): Promise<void> {
     await this.dispose();
+  }
+
+  /**
+   * Helper for {@link HeldConnection.dispose}, which does the closing that
+   * every call to it shares. Nothing between here and its first `await`
+   * re-enters this instance, which is what lets `dispose()` hold the promise
+   * this returns rather than having to hold a flag before calling it.
+   */
+  async #disposeOnce(): Promise<void> {
+    const held = this.#pieces;
+    if (!this.#owned || held === undefined) return;
+    const pieces = await held.catch(() => undefined);
+    await pieces?.dispose();
   }
 }

--- a/packages/shuttle/test/connection.test.ts
+++ b/packages/shuttle/test/connection.test.ts
@@ -102,6 +102,18 @@ describe("connection", () => {
           expect(calls).toBe(1);
         });
 
+        it("returns the connection it opened to an ask made after the construction settles", async () => {
+          const controller = stubController();
+          let calls = 0;
+          const connection = new HeldConnection(owning(() => {
+            calls += 1;
+            return Promise.resolve(controller.pieces);
+          }));
+          expect(await connection.pieces()).toBe(controller.pieces);
+          expect(await connection.pieces()).toBe(controller.pieces);
+          expect(calls).toBe(1);
+        });
+
         it("opens with the `SpaceConfig` the record denotes, carrying the record's three dimensions and nothing else", async () => {
           const controller = stubController();
           const configs: SpaceConfig[] = [];
@@ -213,6 +225,18 @@ describe("connection", () => {
           await connection.pieces();
           await connection.dispose();
           await connection.dispose();
+          expect(controller.closed()).toBe(1);
+        });
+
+        it("closes a construction that was still in flight when disposal began", async () => {
+          const controller = stubController();
+          const opening = Promise.withResolvers<PiecesController>();
+          const connection = new HeldConnection(owning(() => opening.promise));
+          const asked = connection.pieces();
+          const disposing = connection.dispose();
+          opening.resolve(controller.pieces);
+          expect(await asked).toBe(controller.pieces);
+          await disposing;
           expect(controller.closed()).toBe(1);
         });
 

--- a/packages/shuttle/test/connection.test.ts
+++ b/packages/shuttle/test/connection.test.ts
@@ -56,13 +56,20 @@ interface StubController {
  * Helper for the cases below, which stands in for the controller a connection
  * carries. Nothing here reads a controller, so it reports one thing only —
  * how many times it was closed — which is what every ownership case turns on.
+ *
+ * A `closeError` makes its close fail, which is the second observable a case
+ * has of the closing: a failure only reaches a caller of `dispose()` through
+ * an `await`, so it separates a close that is awaited from one that is
+ * merely started, where the count alone cannot.
  */
-function stubController(): StubController {
+function stubController(closeError?: Error): StubController {
   let closed = 0;
   const pieces = {
     dispose: () => {
       closed += 1;
-      return Promise.resolve();
+      return closeError === undefined
+        ? Promise.resolve()
+        : Promise.reject(closeError);
     },
   } as unknown as PiecesController;
   return { pieces, closed: () => closed };
@@ -217,7 +224,7 @@ describe("connection", () => {
           expect(controller.closed()).toBe(0);
         });
 
-        it("closes the connection once, however many times it runs", async () => {
+        it("closes the connection once across repeated disposals", async () => {
           const controller = stubController();
           const connection = new HeldConnection(
             owning(() => Promise.resolve(controller.pieces)),
@@ -225,6 +232,63 @@ describe("connection", () => {
           await connection.pieces();
           await connection.dispose();
           await connection.dispose();
+          expect(controller.closed()).toBe(1);
+        });
+
+        it("returns the same disposal to a call made while the first is running", async () => {
+          const controller = stubController();
+          const opening = Promise.withResolvers<PiecesController>();
+          const connection = new HeldConnection(owning(() => opening.promise));
+          const asked = connection.pieces();
+          const first = connection.dispose();
+          const second = connection.dispose();
+          expect(second).toBe(first);
+          opening.resolve(controller.pieces);
+          expect(await asked).toBe(controller.pieces);
+          await second;
+          expect(controller.closed()).toBe(1);
+        });
+
+        it("returns the failure a close raises", async () => {
+          const controller = stubController(
+            new Error("socket teardown failed"),
+          );
+          const connection = new HeldConnection(
+            owning(() => Promise.resolve(controller.pieces)),
+          );
+          await connection.pieces();
+          await expect(connection.dispose()).rejects.toThrow(
+            "socket teardown failed",
+          );
+        });
+
+        it("returns the failure a close raises where the construction was still in flight", async () => {
+          const controller = stubController(
+            new Error("socket teardown failed"),
+          );
+          const opening = Promise.withResolvers<PiecesController>();
+          const connection = new HeldConnection(owning(() => opening.promise));
+          const asked = connection.pieces();
+          const disposing = connection.dispose();
+          opening.resolve(controller.pieces);
+          expect(await asked).toBe(controller.pieces);
+          await expect(disposing).rejects.toThrow("socket teardown failed");
+        });
+
+        it("returns the same failure to a disposal asked for again", async () => {
+          const controller = stubController(
+            new Error("socket teardown failed"),
+          );
+          const connection = new HeldConnection(
+            owning(() => Promise.resolve(controller.pieces)),
+          );
+          await connection.pieces();
+          await expect(connection.dispose()).rejects.toThrow(
+            "socket teardown failed",
+          );
+          await expect(connection.dispose()).rejects.toThrow(
+            "socket teardown failed",
+          );
           expect(controller.closed()).toBe(1);
         });
 

--- a/packages/shuttle/test/connection.test.ts
+++ b/packages/shuttle/test/connection.test.ts
@@ -171,6 +171,20 @@ describe("connection", () => {
           expect(calls).toBe(2);
         });
 
+        it("hands one failing construction to every ask waiting on it", async () => {
+          let calls = 0;
+          const connection = new HeldConnection(owning(() => {
+            calls += 1;
+            return Promise.reject(new Error("no route to the deployment"));
+          }));
+          const first = connection.pieces();
+          const second = connection.pieces();
+          expect(second).toBe(first);
+          await expect(first).rejects.toThrow("no route to the deployment");
+          await expect(second).rejects.toThrow("no route to the deployment");
+          expect(calls).toBe(1);
+        });
+
         it("returns a rejection where the opener throws rather than throwing at the ask", async () => {
           const connection = new HeldConnection(owning(() => {
             throw new Error("no identity at that path");
@@ -345,6 +359,22 @@ describe("connection", () => {
             "socket teardown failed",
           );
           expect(controller.closed()).toBe(1);
+        });
+
+        it("throws from `pieces()` once a close has failed", async () => {
+          const controller = stubController(
+            new Error("socket teardown failed"),
+          );
+          const connection = new HeldConnection(
+            owning(() => Promise.resolve(controller.pieces)),
+          );
+          await connection.pieces();
+          await expect(connection.dispose()).rejects.toThrow(
+            "socket teardown failed",
+          );
+          expect(() => connection.pieces()).toThrow(
+            "This connection is disposed.",
+          );
         });
 
         it("closes a construction that was still in flight when disposal began", async () => {

--- a/packages/shuttle/test/connection.test.ts
+++ b/packages/shuttle/test/connection.test.ts
@@ -54,13 +54,12 @@ interface StubController {
 
 /**
  * Helper for the cases below, which stands in for the controller a connection
- * carries. Nothing here reads a controller, so it reports one thing only —
- * how many times it was closed — which is what every ownership case turns on.
- *
- * A `closeError` makes its close fail, which is the second observable a case
- * has of the closing: a failure only reaches a caller of `dispose()` through
- * an `await`, so it separates a close that is awaited from one that is
- * merely started, where the count alone cannot.
+ * carries. Nothing here reads a controller, so what it reports is the two
+ * things a close can be observed by: how many times it ran, which is what the
+ * ownership cases turn on, and whether it failed, where a case hands it a
+ * `closeError`. The failure is what separates a close that is awaited from
+ * one merely started, which the count cannot, since a failure reaches a
+ * caller of `dispose()` only through an `await`.
  */
 function stubController(closeError?: Error): StubController {
   let closed = 0;
@@ -247,6 +246,29 @@ describe("connection", () => {
           expect(await asked).toBe(controller.pieces);
           await second;
           expect(controller.closed()).toBe(1);
+        });
+
+        it("settles a second disposal only once the close they share has finished", async () => {
+          // A gate inside the close, and a ledger either side of it. The
+          // order the two entries land in is the whole assertion, so nothing
+          // here counts microtasks or waits on a clock.
+
+          const order: string[] = [];
+          const closing = Promise.withResolvers<void>();
+          const pieces = {
+            dispose: () => closing.promise.then(() => order.push("closed")),
+          } as unknown as PiecesController;
+          const connection = new HeldConnection(
+            owning(() => Promise.resolve(pieces)),
+          );
+          await connection.pieces();
+          const first = connection.dispose();
+          const second = connection.dispose().then(() => {
+            order.push("second disposal settled");
+          });
+          closing.resolve();
+          await Promise.all([first, second]);
+          expect(order).toEqual(["closed", "second disposal settled"]);
         });
 
         it("returns the failure a close raises", async () => {

--- a/packages/shuttle/test/connection.test.ts
+++ b/packages/shuttle/test/connection.test.ts
@@ -54,12 +54,16 @@ interface StubController {
 
 /**
  * Helper for the cases below, which stands in for the controller a connection
- * carries. Nothing here reads a controller, so what it reports is the two
- * things a close can be observed by: how many times it ran, which is what the
- * ownership cases turn on, and whether it failed, where a case hands it a
- * `closeError`. The failure is what separates a close that is awaited from
- * one merely started, which the count cannot, since a failure reaches a
- * caller of `dispose()` only through an `await`.
+ * carries. Nothing here reads a controller, so what this helper reports is
+ * two things: how many times the close ran, which is what the ownership cases
+ * turn on, and whether it failed, where a case hands it a `closeError`. The
+ * failure is what separates a close that is awaited from one merely started,
+ * which the count cannot, since a failure reaches a caller of `dispose()`
+ * only through an `await`.
+ *
+ * When a close finished is a third observable and not one of these. The case
+ * that turns on it builds a controller of its own, with a gate inside the
+ * close.
  */
 function stubController(closeError?: Error): StubController {
   let closed = 0;
@@ -186,6 +190,29 @@ describe("connection", () => {
             "This connection is disposed.",
           );
         });
+
+        it("throws where the connection's own close asks for one", async () => {
+          let refused: unknown;
+          const pieces = {
+            dispose: () => {
+              try {
+                connection.pieces();
+              } catch (error) {
+                refused = error;
+              }
+              return Promise.resolve();
+            },
+          } as unknown as PiecesController;
+          const connection = new HeldConnection(
+            owning(() => Promise.resolve(pieces)),
+          );
+          await connection.pieces();
+          await connection.dispose();
+          expect(refused).toBeInstanceOf(Error);
+          expect((refused as Error).message).toBe(
+            "This connection is disposed.",
+          );
+        });
       });
 
       describe("dispose()", () => {
@@ -249,14 +276,20 @@ describe("connection", () => {
         });
 
         it("settles a second disposal only once the close they share has finished", async () => {
-          // A gate inside the close, and a ledger either side of it. The
-          // order the two entries land in is the whole assertion, so nothing
-          // here counts microtasks or waits on a clock.
+          // A gate inside the close, and a ledger recording what settles
+          // once it opens. The close puts a tick between the gate and its own
+          // entry, which is what leaves the order to the code under test: with
+          // the entry in the gate's first reaction, a close that is started
+          // and never awaited still records first, off queue position alone,
+          // and reads exactly like one that was awaited. The real
+          // implementation orders the two the same way at any tick count, so
+          // the tick buys sensitivity and costs no stability.
 
           const order: string[] = [];
           const closing = Promise.withResolvers<void>();
           const pieces = {
-            dispose: () => closing.promise.then(() => order.push("closed")),
+            dispose: () =>
+              closing.promise.then(() => {}).then(() => order.push("closed")),
           } as unknown as PiecesController;
           const connection = new HeldConnection(
             owning(() => Promise.resolve(pieces)),

--- a/packages/shuttle/test/connection.test.ts
+++ b/packages/shuttle/test/connection.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Unit tests for the connection a shuttle process holds. Every case stands a
+ * `HeldConnection` over an opener of its own, so what is under test is the
+ * holding — when a connection is opened, how many times, which one every ask
+ * gets, and who closes it — with no socket, no server and no clock anywhere
+ * behind it. What `loadPieces` does once called is not this file's subject.
+ *
+ * Two bounds on what these cases pin are worth stating, because both look
+ * covered from the descriptions alone.
+ *
+ * The cases around a failed construction pin a connection that never opened.
+ * None of them says anything about a connection that opens and later drops:
+ * the module holds no opinion about one, so there is nothing here to pin.
+ *
+ * And no case drives the guard in `pieces()` that clears the memo only while
+ * the failing attempt is still the held one. Two writers touch that memo — an
+ * ask, which holds an attempt, and that attempt's own failure, which unholds
+ * it; disposal reads it and never writes. An ask starts a second attempt only
+ * where nothing is held, and only a failure unholds, so every failure runs the
+ * guard while its own attempt is still the held one and the guard's other
+ * branch is unreachable from outside. An unconditional clear would behave
+ * identically at every door, which is why no case can tell them apart. The
+ * guard stays as what keeps the memo safe to unhold from somewhere other than
+ * a failure, and this paragraph is read again if anything ever unholds it.
+ */
+
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import type { SpaceConfig } from "@commonfabric/cli/lib/piece";
+import type { PiecesController } from "@commonfabric/piece/ops";
+
+import {
+  type ConnectionOpener,
+  type ConnectionRecord,
+  type ConnectionSource,
+  HeldConnection,
+} from "../src/connection.ts";
+
+const RECORD: ConnectionRecord = {
+  apiUrl: "https://toolshed.example/",
+  space: "did:key:z6MkConnectedSpace",
+  identity: "/keys/shuttle.pkcs8",
+};
+
+/** What {@link stubController} hands a case. */
+interface StubController {
+  /** The controller a connection serves and may close. */
+  readonly pieces: PiecesController;
+
+  /** How many times it has been closed. */
+  closed(): number;
+}
+
+/**
+ * Helper for the cases below, which stands in for the controller a connection
+ * carries. Nothing here reads a controller, so it reports one thing only —
+ * how many times it was closed — which is what every ownership case turns on.
+ */
+function stubController(): StubController {
+  let closed = 0;
+  const pieces = {
+    dispose: () => {
+      closed += 1;
+      return Promise.resolve();
+    },
+  } as unknown as PiecesController;
+  return { pieces, closed: () => closed };
+}
+
+/** Helper for the cases below, which names a source `open` opens. */
+function owning(open: ConnectionOpener): ConnectionSource {
+  return { kind: "owned", record: RECORD, open };
+}
+
+describe("connection", () => {
+  describe("HeldConnection", () => {
+    describe("constructor()", () => {
+      it("opens nothing until a connection is asked for", () => {
+        let calls = 0;
+        new HeldConnection(owning(() => {
+          calls += 1;
+          return Promise.resolve(stubController().pieces);
+        }));
+        expect(calls).toBe(0);
+      });
+    });
+
+    describe("instance members", () => {
+      describe("pieces()", () => {
+        it("returns the same connection for every ask, having opened one", async () => {
+          const controller = stubController();
+          let calls = 0;
+          const connection = new HeldConnection(owning(() => {
+            calls += 1;
+            return Promise.resolve(controller.pieces);
+          }));
+          const first = connection.pieces();
+          const second = connection.pieces();
+          expect(second).toBe(first);
+          expect(await first).toBe(controller.pieces);
+          expect(calls).toBe(1);
+        });
+
+        it("opens with the `SpaceConfig` the record denotes, carrying the record's three dimensions and nothing else", async () => {
+          const controller = stubController();
+          const configs: SpaceConfig[] = [];
+          const connection = new HeldConnection(owning((config) => {
+            configs.push(config);
+            return Promise.resolve(controller.pieces);
+          }));
+          await connection.pieces();
+          expect(configs).toEqual([{
+            apiUrl: RECORD.apiUrl,
+            space: RECORD.space,
+            identity: RECORD.identity,
+          }]);
+        });
+
+        it("joins a construction already in flight rather than starting a second one", async () => {
+          const controller = stubController();
+          const opening = Promise.withResolvers<PiecesController>();
+          let calls = 0;
+          const connection = new HeldConnection(owning(() => {
+            calls += 1;
+            return opening.promise;
+          }));
+          const first = connection.pieces();
+          const second = connection.pieces();
+          opening.resolve(controller.pieces);
+          expect(await first).toBe(controller.pieces);
+          expect(await second).toBe(controller.pieces);
+          expect(calls).toBe(1);
+        });
+
+        it("opens again on the next ask once a construction rejects", async () => {
+          const controller = stubController();
+          let calls = 0;
+          const connection = new HeldConnection(owning(() => {
+            calls += 1;
+            return calls === 1
+              ? Promise.reject(new Error("no route to the deployment"))
+              : Promise.resolve(controller.pieces);
+          }));
+          await expect(connection.pieces()).rejects.toThrow(
+            "no route to the deployment",
+          );
+          expect(await connection.pieces()).toBe(controller.pieces);
+          expect(calls).toBe(2);
+        });
+
+        it("returns a rejection where the opener throws rather than throwing at the ask", async () => {
+          const connection = new HeldConnection(owning(() => {
+            throw new Error("no identity at that path");
+          }));
+          const asked = connection.pieces();
+          await expect(asked).rejects.toThrow("no identity at that path");
+        });
+
+        it("throws once the connection is disposed", async () => {
+          const controller = stubController();
+          const connection = new HeldConnection(
+            owning(() => Promise.resolve(controller.pieces)),
+          );
+          await connection.pieces();
+          await connection.dispose();
+          expect(() => connection.pieces()).toThrow(
+            "This connection is disposed.",
+          );
+        });
+      });
+
+      describe("dispose()", () => {
+        it("closes the connection it opened", async () => {
+          const controller = stubController();
+          {
+            await using connection = new HeldConnection(
+              owning(() => Promise.resolve(controller.pieces)),
+            );
+            await connection.pieces();
+          }
+          expect(controller.closed()).toBe(1);
+        });
+
+        it("leaves a connection it was handed open", async () => {
+          const controller = stubController();
+          const connection = new HeldConnection({
+            kind: "borrowed",
+            pieces: controller.pieces,
+          });
+          expect(await connection.pieces()).toBe(controller.pieces);
+          await connection.dispose();
+          expect(controller.closed()).toBe(0);
+        });
+
+        it("closes nothing where no ask opened a connection", async () => {
+          const controller = stubController();
+          let calls = 0;
+          const connection = new HeldConnection(owning(() => {
+            calls += 1;
+            return Promise.resolve(controller.pieces);
+          }));
+          await connection.dispose();
+          expect(calls).toBe(0);
+          expect(controller.closed()).toBe(0);
+        });
+
+        it("closes the connection once, however many times it runs", async () => {
+          const controller = stubController();
+          const connection = new HeldConnection(
+            owning(() => Promise.resolve(controller.pieces)),
+          );
+          await connection.pieces();
+          await connection.dispose();
+          await connection.dispose();
+          expect(controller.closed()).toBe(1);
+        });
+
+        it("returns rather than re-raising a construction in flight that then fails", async () => {
+          const opening = Promise.withResolvers<PiecesController>();
+          const connection = new HeldConnection(owning(() => opening.promise));
+          const asked = connection.pieces();
+          const disposing = connection.dispose();
+          opening.reject(new Error("no route to the deployment"));
+          await expect(asked).rejects.toThrow("no route to the deployment");
+          await disposing;
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Why

`cf` builds a `PiecesController` per invocation; a shell pays that sequence once
and holds it. This is the holder, and nothing else — B1b's first slice, before
any verb uses it.

It lands on its own because B1a took twenty-nine rounds as one PR, and the tail
was dominated by claims of coverage outrunning what was covered. A door added
alone is checkable: a missing case shows as an absent diff. Doors arriving
together are not. B1b adds several, so they arrive one at a time.

Follows #6756.

## What Changed

**`packages/shuttle/src/connection.ts`** — `HeldConnection`, and two memos with
deliberately opposite retry policies.

- **The connection memo** is cf-harness's shape
  (`packages/cf-harness/src/fabric-session.ts`): the cache clears on a rejected
  construction and on nothing else, so concurrent asks join one construction and
  a failure is retried rather than replayed.
- **The disposal memo** is the opposite: `#disposal ??= #disposeOnce()` is held
  whatever it does. A second caller joins the first rather than reporting done
  while the connection is still open, and a close that fails re-surfaces the same
  failure to a retry instead of swallowing it.
- **Ownership is an arm of the source, not an inference.** A connection this
  module opened is its to close; one it was handed is the caller's.
  `packages/cli/lib/acl.ts` carries the same rule and infers it from a deps bag,
  which would have made the owned arm reachable only through a real socket.
- **A failed close is terminal**, and the contract says so: the disposal stays
  rejected, nothing retries, and the holder serves nothing again. That suits a
  disposal which is process shutdown; `build-sequence.md` records that a
  `disconnect` verb revisits the trade.

It consumes `loadPieces` rather than re-implementing the connect sequence, and
constructs `SpaceConfig` from the ambient record directly.

**`packages/shuttle/test/connection.test.ts`** — 20 cases.

**Documentation.** Three surfaces said B1 *builds* the connection-observation
seam. It consumes one, filed as #6782 against `packages/memory/v2`;
`runtime-integration.md` is the home and the other two point at it.

## Test plan

- `deno fmt --check`, `deno lint`, `deno task check`, `deno task check-docs`,
  `deno task check-no-waitfor`, `deno task check-package-cycles`,
  `deno task check-skill-facts` — green.
- `deno task test` in `packages/shuttle` — 161 steps, 0 failed.
- Coverage debt for `packages/shuttle`: **0**, unmoved across five rounds.
- 18 mutations over 20 cases, and — the property that matters — **each case is
  verified to red under the mutation its own name forbids**, not merely to be red
  under something. That check found a case which passed for the wrong reason: the
  ordering case greened under an unawaited close, because its fixture decided the
  outcome by promise-queue position rather than by the code under test.

`--allow-env` is added to the test task: the entry this module opens its
connection through reads the environment as it loads, in that module and
throughout its transitive graph. A scoped list was measured — the graph demanded
fourteen distinct variables and was still asking, most from the npm `typescript`
package, which moves on a version bump.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6796?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

