### PR TITLE
AH-CFC-3 and delegation bound to what the CFC spec requires (CT-2178)

### DIFF
--- a/docs/specs/agent-harness/02-cfc-integration.md
+++ b/docs/specs/agent-harness/02-cfc-integration.md
@@ -30,8 +30,12 @@ contents.
 ## 2. Prompt authority
 
 **AH-CFC-3.** Direct-command authority MUST depend on trusted `PromptSlotBound`
-evidence for the relevant kernel, subject, slot role, and value or snapshot
-digest.
+evidence binding the kernel name, the authenticated subject, the named surface,
+the slot role, and a digest of the exact value carrying the authority. A
+UI-backed surface binds that value through render evidence. A non-UI surface,
+such as a CLI or API route, MUST supply an equivalent trusted input-capture
+record binding the same fields. A surface that cannot supply one MUST NOT mint
+direct-command authority.
 
 **AH-CFC-4.** Context, quoted text, retrieved documents, skills, browser
 observations, child summaries, and previous model output MUST NOT mint
@@ -74,6 +78,15 @@ the model only through the profile's typed deny/recovery channel.
 **AH-CFC-12.** Delegation is a policy transition. A child receives only the
 authority, labels, skills, and capabilities explicitly bound to the child
 profile.
+
+**AH-CFC-12a.** A child profile SHOULD carry a confidentiality ceiling bounding
+what the child may observe, through inherited handles, arguments, mounted files,
+and any other labeled channel. Where a ceiling is in force, a read that would
+observe a value above it MUST be denied even if the parent could have observed
+that value, and resolving an inherited handle into a child input MUST be
+rejected if the resolved value exceeds the ceiling. A deployment MUST state how
+ceilings and observation policies are applied before inherited handles are
+resolved.
 
 **AH-CFC-13.** Child artifacts and raw browser/network observations remain under
 the child boundary. A structured or summarized return is a new observation and

--- a/docs/specs/agent-harness/04-cfc-spec-correspondence.md
+++ b/docs/specs/agent-harness/04-cfc-spec-correspondence.md
@@ -7,7 +7,7 @@ derivation. The authority they derive from is the Common Fabric Contextual Flow
 Control specification, `commontoolsinc/specs`, and in particular
 `cfc/18-runtime-implementation-profiles.md` §18.2-18.4. This document is the
 derivation itself: which CFC section each `AH-CFC` clause rests on, which
-clauses go beyond the authority, which are narrower than it, and which CFC
+clauses go beyond the authority, which if any are narrower than it, and which CFC
 obligations no `AH-CFC` clause carries.
 
 It exists because the audit in `packages/cf-harness/audit` cites `AH-CFC`
@@ -28,9 +28,11 @@ is:
 | `beyond`   | The clause has no CFC counterpart and imposes an obligation the CFC specification does not.                 |
 | `fused`    | The clause draws on more than one CFC section and states them as a single harness obligation.                |
 
-No `AH-CFC` clause **contradicts** the CFC specification. Two are `narrow`, and
-those two are where a conformance claim resting on `AH-CFC` alone would
-overstate what is enforced.
+No `AH-CFC` clause **contradicts** or is narrower than the CFC specification, so
+a conformance claim resting on an `AH-CFC` clause does not overstate what the
+authority requires. What `AH-CFC` does not carry at all is listed under "CFC
+obligations no clause carries" below; a claim resting on `AH-CFC` alone is
+silent there rather than wrong.
 
 ## The pin
 
@@ -52,7 +54,7 @@ was read against.
 
 | Clause     | CFC section | Relation | Notes                                                                                                                                                                                                                                                                                                                 |
 | ---------- | ----------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `AH-CFC-3` | §18.3.1     | `narrow` | **See "Where the derivation is narrow" below.** §18.3.1 requires a UI mint to replay the render reference and requires a non-UI mint to supply "an equivalent trusted input-capture record such as `UserSurfaceInput`" binding subject, surface, value digest, role, and kernel name. `AH-CFC-3` asks for "value or snapshot digest" and does not require the capture record or the subject. |
+| `AH-CFC-3` | §18.3.1     | `faithful` | §18.3.1 requires a UI mint to replay the render reference and a non-UI mint to supply "an equivalent trusted input-capture record such as `UserSurfaceInput`" binding subject, surface, value digest, role, and kernel name. `AH-CFC-3` requires the same five fields, distinguishes the UI path from the non-UI path, and refuses a surface that can supply neither. |
 | `AH-CFC-4` | §18.3.1     | `faithful` | §18.3.1: "Application code and model output may request that a value be displayed or submitted, but they cannot assign the load-bearing prompt role themselves", and "a README or webpage containing "ignore previous instructions" remains `quote` or ordinary labeled content, even if it is imperatively phrased."     |
 | `AH-CFC-5` | §18.3.1     | `faithful` | §18.3.1's fail-closed list covers a stale target path and a changed source value. `AH-CFC-5` states the same rule for the non-render cases — copying, summarizing, resuming — which §18.3.1 does not enumerate but whose principle it fixes.                                                                             |
 
@@ -76,7 +78,8 @@ was read against.
 
 | Clause      | CFC section          | Relation   | Notes                                                                                                                                                                                                          |
 | ----------- | -------------------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `AH-CFC-12` | §18.2.4.3, §18.3.3   | `narrow`   | **See "Where the derivation is narrow" below.** §18.2.4.3 asks for a confidentiality ceiling that is "an **upper bound** on what the callee is allowed to *observe*", with reads above it denied. `AH-CFC-12` asks only that a child receive what is explicitly bound to its profile, which is capability attenuation and not observation attenuation. |
+| `AH-CFC-12` | §18.2.4.3, §18.3.3   | `faithful` | §18.2.4.3 attenuates a delegation in two dimensions. `AH-CFC-12` carries the capability half: a child receives only what its profile explicitly binds. |
+| `AH-CFC-12a` | §18.2.4.3, §18.2.4.2, §18.3.3 | `faithful` | The observation half. §18.2.4.3 asks for a ceiling that is "an **upper bound** on what the callee is allowed to *observe*", with a read above it denied "even if the parent node could have observed it", and §18.2.4.2 requires handle substitution to respect it. `AH-CFC-12a` states both, and carries §18.3.3's obligation to say how ceilings apply before inherited handles resolve. It follows the CFC section's own modality: the ceiling is a `SHOULD`, and the denial and substitution rules are `MUST` wherever one is in force. |
 | `AH-CFC-13` | §18.2.4, §18.2.4.2   | `faithful` | §18.2.4: schema-based `InjectionSafe` sanitization "is also a trusted-runtime transition, not a sandbox claim", and the runtime may add it "only after it validates the candidate against that trusted schema". §18.2.4.2's sanitizer sub-agent flow is the same shape from the caller's side. |
 
 ### 6. Enforcement modes
@@ -101,63 +104,43 @@ was read against.
 | `AH-CFC-18` | §18.2.4.2, §18.2.4.3, §8.13   | `faithful` | §18.2.4.2: handle substitution "is itself an information flow and MUST be enforced as a read". §18.2.4.3: substitution "MUST respect ceilings". The converse — that minting or returning a handle is not a release — is §18.2.4.2's transfer rule: "a caller may pass the token as an opaque capability, but doing so does not reveal the payload." |
 | `AH-CFC-19` | §18.2.4.2                     | `faithful` | §18.2.4.2 requires handles to be non-enumerable by sandboxed code and resolvable only by the trusted runtime, and labels their metadata separately.                                                                                     |
 
-## Where the derivation is narrow
+## Where the derivation carries weight
 
-Two clauses require less than their CFC counterpart. Both are places where an
-implementation could satisfy `AH-CFC` and still not satisfy
-`CfcAgentHarnessProfile`, which makes them the load-bearing rows of this
-document.
+Two clauses do work that a reader may not expect from their length, because
+each is the whole of what `AH-CFC` says about a mechanism the CFC specification
+develops at length.
 
-### `AH-CFC-3` does not require an input-capture record
+### `AH-CFC-3` carries the whole of prompt-slot binding
 
-§18.3.1 splits prompt-slot minting into two paths. A UI-backed slot binds by
-replaying a render reference: retrieve `renderRef.rootRef` at `renderRef.seq`,
-recompute `snapshotDigest`, resolve `targetPath`, verify the DOM event target
-maps to that node, verify the authenticated `subject` and named `surface`,
-compute `valueDigest`, and mint over all of it. A non-UI surface — a CLI or an
-API route — may mint without `renderRef` "only if they provide an equivalent
-trusted input-capture record such as `UserSurfaceInput` and bind the same
-subject, surface, value digest, role, and kernel name." §18.3.1 then says these
-routes "are implementation profiles with explicit evidence, not fallbacks to
-text-shaped authority."
+§18.3.1 splits minting into two paths. A UI-backed slot binds by replaying a
+render reference: retrieve `renderRef.rootRef` at `renderRef.seq`, recompute
+`snapshotDigest`, resolve `targetPath`, verify the DOM event target maps to that
+node, verify the authenticated `subject` and named `surface`, compute
+`valueDigest`, and mint over all of it. A non-UI surface may mint without
+`renderRef` "only if they provide an equivalent trusted input-capture record
+such as `UserSurfaceInput` and bind the same subject, surface, value digest,
+role, and kernel name" — routes that "are implementation profiles with explicit
+evidence, not fallbacks to text-shaped authority."
 
-`AH-CFC-3` asks for evidence "for the relevant kernel, subject, slot role, and
-value or snapshot digest." Three differences follow from that phrasing:
+`AH-CFC-3` compresses that into one clause and keeps what makes it load-bearing:
+the five bound fields, the split between the two paths, and the refusal for a
+surface that can supply neither. The render-replay steps themselves stay in
+§18.3.1; a harness implementing a UI surface reads them there.
 
-- The disjunction "value **or** snapshot digest" admits a binding with neither
-  a submitted value bound nor a render replayed.
-- No input-capture record is required, so a non-UI mint has nothing standing in
-  for the render replay.
-- `subject` is named but the clause does not require it to be authenticated.
+### `AH-CFC-12` and `AH-CFC-12a` split attenuation in two
 
-The consequence for a conformance claim: a harness whose surfaces mint
-`direct-command` from constants satisfies `AH-CFC-3` and does not satisfy
-§18.3.1. Anything relying on `AH-CFC-3` to establish that direct-command
-authority is bound to a real user's real submission is relying on the wrong
-clause.
+§18.2.4.3 attenuates a delegation along two axes at once, and separating them
+is what makes each checkable. `AH-CFC-12` governs what a child is *given*.
+`AH-CFC-12a` governs what a child may *observe* through what it was given —
+the ceiling as "an **upper bound** on what the callee is allowed to *observe*
+from the filesystem, CLI args, inherited opaque handles, and any other labeled
+channels", the denial of a read above it "even if the parent node could have
+observed it", and §18.2.4.2's rule that handle substitution respects it.
 
-### `AH-CFC-12` binds capabilities, not observation
-
-§18.2.4.3 is explicit that a delegation's attenuation is about reads: the
-ceiling "is an **upper bound** on what the callee is allowed to *observe* from
-the filesystem, CLI args, inherited opaque handles, and any other labeled
-channels", and "If a read would require observing a value above this ceiling,
-the runtime MUST deny the read (fail closed), even if the parent node could
-have observed it." The mechanism it offers is principal attenuation —
-`principal_callee.principals` a subset of `principal_caller.principals` — and
-§18.2.4.2's handle substitution is required to respect it.
-
-`AH-CFC-12` says a child "receives only the authority, labels, skills, and
-capabilities explicitly bound to the child profile." That governs what the
-child is *given*. It does not bound what the child may *observe* through the
-capabilities it was given. A child handed a read tool and a handle to a cell
-above the parent's intended scope satisfies `AH-CFC-12` and violates
-§18.2.4.3.
-
-`AH-CFC-13` closes the return direction — a child's summary is a new
-observation that must pass mediation — so the gap is one-way: outbound
-containment is derived faithfully, and inbound attenuation is not derived at
-all.
+The two are not interchangeable: a child handed a read tool and a handle to a
+cell above the parent's intended scope satisfies `AH-CFC-12` on its own.
+`AH-CFC-13` closes the return direction, so the three together cover what a
+child receives, what it may observe, and what it may hand back.
 
 ## Where the derivation goes beyond
 
@@ -187,7 +170,7 @@ useful and not derived.
 
 Three parts of the CFC specification's harness surface have no counterpart in
 `02-cfc-integration.md` at all. An implementation could satisfy every
-`AH-CFC-*` clause and be silent on all three.
+`AH-CFC-*` clause and be silent on both.
 
 - **§18.3.2, dynamic tool discovery and labeled tool descriptions.** The whole
   section: descriptor digests, registry snapshot digests, snapshot pinning and
@@ -201,10 +184,8 @@ Three parts of the CFC specification's harness surface have no counterpart in
   prohibition on relabeling by parsing is the negative half; the positive half —
   how a runtime *may* mint structured output from a measured invocation — is
   absent.
-- **§18.2.4.3's ceiling mechanism,** for the reason given above.
-
 A harness conformance statement that claims `CfcAgentHarnessProfile` has to
-answer all three regardless of what `AH-CFC` asks, because §18.3.3 asks.
+answer both regardless of what `AH-CFC` asks, because §18.3.3 asks.
 
 ## How the audit should cite
 

--- a/packages/cf-harness/docs/IMPLEMENTATION_PROFILE.md
+++ b/packages/cf-harness/docs/IMPLEMENTATION_PROFILE.md
@@ -136,8 +136,8 @@ The four §18.2.7 obligations that are this package's:
 
 The obligation-by-obligation working, with the code each answer rests on, is in
 [`docs/history/packages/cf-harness/cfc-profile-conformance-gap-2026-09-03.md`](../../../docs/history/packages/cf-harness/cfc-profile-conformance-gap-2026-09-03.md).
-How the `AH-CFC-*` clauses relate to the CFC sections above — including the two
-that are narrower than their counterpart — is in
+How the `AH-CFC-*` clauses relate to the CFC sections above, and which CFC
+obligations no clause carries, is in
 [`docs/specs/agent-harness/04-cfc-spec-correspondence.md`](../../../docs/specs/agent-harness/04-cfc-spec-correspondence.md).
 
 ## Capability discovery


### PR DESCRIPTION
Two `AH-CFC-*` clauses required **less** than the CFC specification they derive from (`commontoolsinc/specs` `cfc/18-runtime-implementation-profiles.md`), and each gap licensed a real weakness in what a conforming harness could do. Found by the conformance mapping in #6788; this closes both.

## `AH-CFC-3` — prompt-slot binding

Previously: evidence "for the relevant kernel, subject, slot role, and value **or** snapshot digest."

Against §18.3.1 that omitted the **named surface**, admitted a binding with neither a submitted value bound nor a render replayed, and omitted the **trusted input-capture record** a non-UI surface must supply — the clause that makes a CLI or API route "an implementation profile with explicit evidence, not a fallback to text-shaped authority." §18.3.1 computes a `valueDigest` on *both* paths; the snapshot digest is additional render evidence, never an alternative to it.

Now binds the five fields §18.3.1 binds, distinguishes the UI path from the non-UI one, and refuses a surface that can supply neither.

## `AH-CFC-12a` — delegation bounds observation, not only capability

`AH-CFC-12` bound *capabilities* where §18.2.4.3 bounds *observation*. A child handed a read tool and a handle to a cell above the parent's intended scope satisfied the clause and violated the specification.

`AH-CFC-12` is unchanged and keeps the capability half. New `AH-CFC-12a` adds the observation half: the ceiling as an upper bound on what a child may observe through inherited handles, arguments and mounted files; a read above it denied "even if the parent node could have observed it"; handle substitution rejected where the resolved value exceeds it; and §18.3.3's obligation to state how ceilings apply before inherited handles resolve.

It follows the CFC section's own modality deliberately — §18.2.4.3 makes the ceiling a `SHOULD`, with the denial and substitution rules `MUST` wherever one is in force. The binding obligation for a deployment claiming the profile comes from §18.3.3's checklist.

## Consequences, accepted on purpose

**Each strengthening makes a current behavior non-conformant.** `AH-CFC-3` outlaws minting `direct-command` from a module constant reused across sessions; `AH-CFC-12a` makes capability-only delegation insufficient. That is the intent — the point of deriving from an authority is to stop building to a weakened restatement of it. The remediation is tracked as harness work, not fixed here.

**No audit citation moves.** `AH-CFC-3` is not cited by the audit, and `AH-CFC-12`'s cited sentence is unchanged, so the citation-drift test passes untouched (verified: 33 steps, exit 0). Had either quote moved, the drift test would have required the audit's quotes to move in the same change — which is the mechanism working.

## Also updated

`04-cfc-spec-correspondence.md` records both as faithful derivations rather than narrow ones, adds the `AH-CFC-12a` row, and drops §18.2.4.3's ceiling from the list of CFC obligations no clause carries. §18.3.2 (descriptor snapshots) and §18.2.4.1 (measured tool contracts) remain deliberately underived: a derived clause we can cite no implementation against would add spec surface without changing what we build, and the correspondence document records the gap honestly. `IMPLEMENTATION_PROFILE.md`'s pointer to that document is updated to match.

Gates under pinned Deno 2.9.4, by exit code: `fmt --check` 0 · `lint` 0 · `check-docs` 0 · `check-skill-facts` 0 · citation-drift 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6799?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

