### PR TITLE
fix(cf-harness): a delegated child records the session posture it runs on (CT-2205)

### DIFF
--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -1904,15 +1904,20 @@ unreadable channel is not an empty one.
 
 A posture record carries its own `provenance`. `resolved` was read off a
 constructed Runtime — an attestation. `projected` was computed from the options
-a runtime will be built with, before it exists — a prediction. The harness
-records `projected`: its fabric session's runtime is built lazily on the first
-`run_pattern`, may never be built at all, and a host may supply its own session
-factory. So AUD-13, AUD-14 and AUD-15 over harness artifacts report on what a
-run **declared it would be at**, and every one of their messages says so. Only
-AUD-17, reading `/api/meta`, weighs an attestation. Re-stamping the run state's
-record from the real runtime once one exists is what would make the harness's
-records attestations too; until then the field is what stops the audit reading
-one for the other.
+a runtime will be built with, before it exists — a prediction. `inherited` is
+the record of the run whose fabric session this run shares, and establishes what
+that run's record establishes. A parent run records `projected`: its fabric
+session's runtime is built lazily on the first `run_pattern` and may never be
+built at all. A delegated child runs on the session its parent built, so it
+records that parent's record as `inherited` — which is what gives AUD-13 and
+AUD-14 something to read on the run where `run_pattern` actually runs. A host
+that injects a session the harness knows nothing else about supplies no record,
+and its run publishes none. So AUD-13, AUD-14 and AUD-15 over harness artifacts
+report on what a run **declared it would be at**, and every one of their
+messages says so. Only AUD-17, reading `/api/meta`, weighs an attestation.
+Re-stamping the run state's record from the real runtime once one exists is what
+would make the harness's records attestations too; until then the field is what
+stops the audit reading one for the other.
 
 The matrix itself is data: [audit/matrix.ts](audit/matrix.ts) holds the
 conforming states and the ordering rules of

--- a/packages/cf-harness/audit/checks/deployment.ts
+++ b/packages/cf-harness/audit/checks/deployment.ts
@@ -331,18 +331,19 @@ const toolshedPosture = (audit: DeploymentAudit): CheckResult | undefined => {
     );
   }
   if (meta.cfc.provenance !== "resolved") {
-    // A deployment publishing a projection has published what it expects to
-    // be at rather than what it is at, and a client adopting it would be
-    // adopting a prediction. `/api/meta` is served from a constructed
-    // Runtime, so this cannot be a shape the route produces — it is a
-    // deployment answering the question with the wrong kind of record.
+    // A deployment publishing anything but an attestation has published what
+    // it expects to be at, or what some other host is at, rather than what it
+    // is at, and a client adopting it would be adopting one of those.
+    // `/api/meta` is served from a constructed Runtime, so this cannot be a
+    // shape the route produces — it is a deployment answering the question
+    // with the wrong kind of record.
     return corpusResult(
       audit,
       "AUD-17",
       "toolshed posture",
       citations,
       "fail",
-      `\`${meta.url}\` publishes a projected posture, which is what a runtime is expected to resolve rather than what one attested`,
+      `\`${meta.url}\` publishes a \`${meta.cfc.provenance}\` posture, which is what a runtime is expected to resolve or what another host resolved, rather than what this one attested`,
       [{
         artifact: "/api/meta",
         pointer: "cfc.provenance",
@@ -407,28 +408,41 @@ const toolshedPosture = (audit: DeploymentAudit): CheckResult | undefined => {
 // artifacts do not yet carry.
 //
 
-/** The distinct posture records the corpus recorded, keyed by their JSON. */
-const distinctRecords = (
+/**
+ * The distinct postures the corpus recorded, each with the runs that recorded
+ * it, keyed by the posture's JSON.
+ *
+ * The key leaves out the provenance, which says how a run came by its record
+ * rather than what the posture is. A delegated child runs on its parent's
+ * session and republishes its parent's record as `inherited`, so keying on
+ * the stamp would count one posture as two and report a divergence where one
+ * runtime served both.
+ */
+const distinctPostures = (
   audit: DeploymentAudit,
-): ReadonlyMap<string, readonly string[]> => {
-  const byRecord = new Map<string, string[]>();
+): ReadonlyMap<string, { record: CfcPostureReport; runIds: string[] }> => {
+  const byPosture = new Map<
+    string,
+    { record: CfcPostureReport; runIds: string[] }
+  >();
   for (const run of everyRun(audit)) {
     const record = recordOf(run);
     if (record === undefined) continue;
-    const key = JSON.stringify(record);
-    const held = byRecord.get(key);
+    const { provenance: _provenance, ...posture } = record;
+    const key = JSON.stringify(posture);
+    const held = byPosture.get(key);
     if (held === undefined) {
-      byRecord.set(key, [run.runId]);
+      byPosture.set(key, { record, runIds: [run.runId] });
     } else {
-      held.push(run.runId);
+      held.runIds.push(run.runId);
     }
   }
-  return byRecord;
+  return byPosture;
 };
 
 const postureUniformity = (audit: DeploymentAudit): CheckResult => {
   const citations = extendsClause("AH-CFC-14", "AH-CFC-15");
-  const records = distinctRecords(audit);
+  const records = distinctPostures(audit);
   if (records.size === 0) {
     return corpusResult(
       audit,
@@ -439,17 +453,21 @@ const postureUniformity = (audit: DeploymentAudit): CheckResult => {
       "no run of this corpus recorded a posture record, so there was nothing to compare",
     );
   }
-  const evidence: CheckEvidence[] = [...records].map(([key, runIds]) => ({
-    detail: `${runIds.length} run(s) — ${runIds.join(", ")} — at ${
-      (JSON.parse(key) as CfcPostureReport).enforcementMode.rung
-    } / flow ${(JSON.parse(key) as CfcPostureReport).flowLabels.rung}`,
+  const evidence: CheckEvidence[] = [...records.values()].map((
+    { record, runIds },
+  ) => ({
+    detail: `${runIds.length} run(s) — ${
+      runIds.join(", ")
+    } — at ${record.enforcementMode.rung} / flow ${record.flowLabels.rung}`,
   }));
-  const mismatched = audit.expected === undefined ? [] : [...records].flatMap((
-    [key, runIds],
-  ) =>
-    postureMismatches(audit.expected!, JSON.parse(key) as CfcPostureReport)
-      .map((mismatch) => ({ runIds, mismatch }))
-  );
+  const mismatched = audit.expected === undefined
+    ? []
+    : [...records.values()].flatMap(({ record, runIds }) =>
+      postureMismatches(audit.expected!, record).map((mismatch) => ({
+        runIds,
+        mismatch,
+      }))
+    );
   if (mismatched.length > 0) {
     return corpusResult(
       audit,

--- a/packages/cf-harness/audit/checks/posture.ts
+++ b/packages/cf-harness/audit/checks/posture.ts
@@ -15,13 +15,18 @@
  * What a recorded posture IS, is the other thing to hold on to. The harness
  * writes its record before the session's runtime exists, so the record is a
  * projection — what the run expected to be at — and it says so
- * (`provenance`). A finding here therefore reports on a declaration, and every
- * message says which it read: a projected record establishes nothing about
- * what a runtime honored, and an audit that let one read as an attestation
- * would be the very confusion it exists to catch.
+ * (`provenance`); a delegated child, which runs on the session its parent
+ * built, carries that parent's record and says that instead. A finding here
+ * therefore reports on a declaration, and every message says which it read: a
+ * projected record establishes nothing about what a runtime honored, and an
+ * audit that let one read as an attestation would be the very confusion it
+ * exists to catch.
  */
 
-import type { CfcPostureReport } from "@commonfabric/runner/cfc";
+import type {
+  CfcPostureProvenance,
+  CfcPostureReport,
+} from "@commonfabric/runner/cfc";
 
 import type { HarnessCfcPolicySnapshot } from "../../src/contracts/cfc-policy-snapshot.ts";
 import type { HarnessFabricSessionCfcPosture } from "../../src/run-state.ts";
@@ -114,13 +119,21 @@ const tupleOf = (
  *
  * A projected record is the run's claim about a runtime that had not been
  * constructed when the claim was written; a resolved one is a reading of a
- * runtime that had. The words go in every message rather than in a footnote,
- * because a reader acting on the finding is deciding what the run establishes.
+ * runtime that had; an inherited one is the record of the run whose session
+ * this one shares, and establishes what that run's record establishes. The
+ * words go in every message rather than in a footnote, because a reader
+ * acting on the finding is deciding what the run establishes.
  */
-const readAs = (record: CfcPostureReport): string =>
-  record.provenance === "projected"
-    ? "recorded posture (projected before the session runtime was constructed)"
-    : "resolved posture";
+const READ_AS: Record<CfcPostureProvenance, string> = {
+  projected:
+    "recorded posture (projected before the session runtime was constructed)",
+  inherited:
+    "inherited posture (the record of the run whose fabric session this run shares)",
+  resolved: "resolved posture",
+};
+
+/** How a finding names the record it read. */
+const readAs = (record: CfcPostureReport): string => READ_AS[record.provenance];
 
 const renderTuple = (tuple: MatrixDialTuple): string =>
   `${tuple.enforcementMode} / flow ${tuple.flowLabels} / floor ${tuple.writeFloor} / trigger ${tuple.triggerReadGating} / policy ${tuple.policyEvaluation}`;

--- a/packages/cf-harness/audit/test/deployment.test.ts
+++ b/packages/cf-harness/audit/test/deployment.test.ts
@@ -14,6 +14,7 @@ import { join } from "@std/path";
 
 import {
   cfcPostureReport,
+  inheritedCfcPostureReport,
   RUNTIME_CFC_DIAL_DEFAULTS,
 } from "@commonfabric/runner/cfc";
 import { MAX_ENFORCEMENT_SINK_CEILINGS } from "@commonfabric/runner";
@@ -509,6 +510,23 @@ describe("Group D deployment checks", () => {
       expect(parity?.verdict).toBe("pass");
       // One record, both runs named under it: two entries here would be two
       // postures the corpus never had.
+      expect(parity?.evidence.length).toBe(1);
+      expect(parity?.evidence[0]?.detail).toContain("2 run(s)");
+    });
+
+    it("reads a delegated child's inherited record as its parent's posture", () => {
+      const results = auditDeployment({
+        families: [
+          familyRecording(MAX_ENFORCEMENT_RECORD),
+          familyRecording(inheritedCfcPostureReport(MAX_ENFORCEMENT_RECORD)),
+        ],
+        paths: [FIXTURE_RUNS_DIR],
+        expectRefusals: false,
+      });
+      // One session, one posture: the stamp says how the second run came by
+      // the record, not that the corpus holds two of them.
+      const parity = results.find((result) => result.checkId === "AUD-18");
+      expect(parity?.verdict).toBe("pass");
       expect(parity?.evidence.length).toBe(1);
       expect(parity?.evidence[0]?.detail).toContain("2 run(s)");
     });

--- a/packages/cf-harness/audit/test/seeded-violations.test.ts
+++ b/packages/cf-harness/audit/test/seeded-violations.test.ts
@@ -16,6 +16,8 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { join } from "@std/path";
 
+import { inheritedCfcPostureReport } from "@commonfabric/runner/cfc";
+
 import type { HarnessCfcInvocationContext } from "../../src/contracts/cfc-invocation-context.ts";
 import type { HarnessHandleEntry } from "../../src/contracts/handle-table.ts";
 import type {
@@ -203,6 +205,26 @@ const withSessionPosture = (
 
 /** Every verdict of the family once a conforming session posture is installed. */
 const SESSION_CLEAN = verdicts(withSessionPosture(() => {}));
+
+/**
+ * The family with the conforming posture on its root and the same posture,
+ * stamped `inherited`, on every child — a delegation as the harness records
+ * one, where the child runs on the session its parent built.
+ */
+const withInheritedChildPosture = (): RunFamily => {
+  const audited = withSessionPosture(() => {});
+  const parentRecord = CONFORMING_SESSION_POSTURE.record!;
+  for (const child of audited.children) {
+    stateOf(child).fabricSessionCfc = {
+      ...structuredClone(CONFORMING_SESSION_POSTURE),
+      record: inheritedCfcPostureReport(parentRecord),
+    };
+  }
+  return audited;
+};
+
+/** The key a check's verdict on `run` is held under. */
+const on = (checkId: string, runId: string): string => `${checkId}@${runId}`;
 
 /**
  * Asserts that seeding `mutate` into the session posture turns exactly
@@ -450,6 +472,39 @@ describe("seeded violations", () => {
       expect(SESSION_CLEAN[at("AUD-14")]).toBe("warn");
       expect(SESSION_CLEAN[at("AUD-15")]).toBe("not-applicable");
       expect(SESSION_CLEAN[at("AUD-15a")]).toBe("pass");
+    });
+  });
+
+  describe("a delegated child's inherited posture", () => {
+    it("evaluates the two record-reading checks on the child rather than leaving them inconclusive", () => {
+      // The child is where `run_pattern` runs, so a child recording no
+      // posture record leaves the run that exercises the sinks as the one
+      // whose sink registry the audit cannot establish. Inheriting the
+      // parent's record is what gives these two checks something to read.
+      const inherited = verdicts(withInheritedChildPosture());
+      const childIds = family.children.map((child) => child.runId);
+      expect(childIds.length).toBeGreaterThan(0);
+      expect(inherited).toEqual({
+        ...SESSION_CLEAN,
+        ...Object.fromEntries(childIds.flatMap((runId) => [
+          [on("AUD-13", runId), "pass"],
+          [on("AUD-14", runId), "warn"],
+          [on("AUD-15", runId), "not-applicable"],
+          [on("AUD-15a", runId), "pass"],
+        ])),
+      });
+    });
+
+    it("leaves both inconclusive on a child that recorded the dials without the record", () => {
+      const withoutRecord = withInheritedChildPosture();
+      for (const child of withoutRecord.children) {
+        delete stateOf(child).fabricSessionCfc!.record;
+      }
+      const verdictMap = verdicts(withoutRecord);
+      for (const child of withoutRecord.children) {
+        expect(verdictMap[on("AUD-13", child.runId)]).toBe("inconclusive");
+        expect(verdictMap[on("AUD-14", child.runId)]).toBe("inconclusive");
+      }
     });
   });
 

--- a/packages/cf-harness/docs/CURRENT_STATE.md
+++ b/packages/cf-harness/docs/CURRENT_STATE.md
@@ -188,7 +188,9 @@ The current package provides:
   dials, independent of the harness's own `--cfc-enforcement-mode`, and the
   resolved posture (each dial's value and whether the operator, the named
   bundle, or the default supplied it) is recorded as `fabricSessionCfc` in run
-  state and the run report, and printed in the operator summary;
+  state and the run report, and printed in the operator summary — the whole
+  posture record with it, which a delegated child carries from its parent
+  stamped `inherited` because it runs on that parent's session;
 - an opt-in pattern index (`--pattern-index-url`, or its
   `CF_HARNESS_PATTERN_INDEX_URL` environment fallback), which needs the fabric
   session configuration: index requests are signed with the session identity

--- a/packages/cf-harness/docs/system-map/cfc-system-map.html
+++ b/packages/cf-harness/docs/system-map/cfc-system-map.html
@@ -669,7 +669,7 @@
     // ------------------------------------------------------------------ layout data
     // The state of this repository the map describes. Bump both when the
     // map is re-verified; the stamp is drawn in the canvas's top-left corner.
-    const SNAPSHOT = { date: "2026-09-03", sha: "871c7cc7ed" };
+    const SNAPSHOT = { date: "2026-09-03", sha: "c5a138a11b" };
     const W = 2760, H = 1840;
     const bands = [
       {
@@ -2008,9 +2008,6 @@
           "what the audit found",
           6754,
         ]],
-        close: [
-          "Record the Fabric-session posture in child run state so AUD-13 and AUD-14 can reach a conclusive verdict (CT-2205).",
-        ],
       },
     };
     const GD = {
@@ -2220,7 +2217,7 @@
         plan:
           "CT-2195 re-stamps the harness's projected posture from the real Runtime once the Fabric session exists.",
         body:
-          `<p>The harness records its Fabric-session posture before the lazy Runtime exists. The record says <code>provenance: projected</code>, so it is an honest prediction rather than an attestation, and an injected session factory suppresses it entirely. <b>Open:</b> a run that constructs the session still never replaces that prediction with the resolved Runtime's posture.</p>`,
+          `<p>The harness records its Fabric-session posture before the lazy Runtime exists. The record says <code>provenance: projected</code>, so it is an honest prediction rather than an attestation, a delegated child, which runs on its parent's session, carries the parent's record stamped <code>inherited</code>, and an injected session the harness was given no record for suppresses it entirely. <b>Open:</b> a run that constructs the session still never replaces that prediction with the resolved Runtime's posture.</p>`,
         where: ["policy", "console", "artifacts"],
       },
       t15: {
@@ -2474,7 +2471,7 @@
             f: ["g_render", "e_render", "weaver", "person"],
             sel: "g_render",
             h: "The person sees values",
-            t: "Display is a release. The render ceiling decides what the panel shows to the person who owns the data. Acceptance: over the root and child, the checker reports FAIL 0 WARN 3 INCONCLUSIVE 2. On the root, AUD-2 warns that no tool side effect reached the substrate, AUD-9 warns that no invocation context was retained, and AUD-14 warns that its LLM-class sinks are ungated (threat t13). AUD-13 and AUD-14 are inconclusive on the child because its run state records no Fabric-session posture record; CT-2205 is what stands between this run and a conclusive audit.",
+            t: "Display is a release. The render ceiling decides what the panel shows to the person who owns the data. On the root, AUD-2 warns that no tool side effect reached the substrate, AUD-9 warns that no invocation context was retained, and AUD-14 warns that its LLM-class sinks are ungated (threat t13). The child carries the parent's posture record, stamped <code>inherited</code> because it runs on the parent's session, so AUD-13 grades its dials and AUD-14 warns on the same LLM-class gap.",
           },
         ],
       },

--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -6,7 +6,11 @@ import {
 } from "@std/path";
 import { normalize as normalizeSandboxPath } from "@std/path/posix";
 
-import type { CfcLabelView } from "@commonfabric/runner/cfc";
+import {
+  type CfcLabelView,
+  type CfcPostureReport,
+  inheritedCfcPostureReport,
+} from "@commonfabric/runner/cfc";
 
 import {
   createFileSystemHarnessArtifactStore,
@@ -270,6 +274,19 @@ export interface CreateHarnessEngineOptions
    * of the parent tool surface.
    */
   fabricSessionFactory?: HarnessFabricSessionFactory;
+
+  /**
+   * The posture record of the run whose fabric session `fabricSessionFactory`
+   * hands this one — a delegating parent's, for the child that shares it.
+   *
+   * Only a caller that knows the injected factory returns a session it
+   * already published a record for can supply this; a host injecting a
+   * session this engine knows nothing about has no record to pass and its run
+   * publishes none. Ignored when no factory is injected, because the config
+   * then describes the session this engine builds and the record comes from
+   * it.
+   */
+  inheritedFabricSessionPosture?: CfcPostureReport;
 
   /**
    * Injection seam for the pattern-index client, mirroring
@@ -702,8 +719,21 @@ export class CfHarnessEngine {
     // exists to make visible — so the record is omitted and the two itemized
     // dials stand alone, which is what the config still truthfully says was
     // asked for.
+    // Unless the caller says whose runtime it handed over. A delegating
+    // parent passes the record it published for the session it shares, and
+    // the child republishes it as `inherited`: the posture of a run executing
+    // on a runtime someone else built is not unknown, it is that runtime's,
+    // and a child recording nothing is what leaves the run that actually
+    // exercises the sinks unauditable (CT-2205).
     const sessionFactoryOverridesConfig = options.fabricSessionFactory !==
       undefined;
+    const sessionRecord = sessionFactoryOverridesConfig
+      ? (options.inheritedFabricSessionPosture === undefined
+        ? undefined
+        : inheritedCfcPostureReport(options.inheritedFabricSessionPosture))
+      : this.config.fabricSession === undefined
+      ? undefined
+      : harnessFabricSessionPosture(this.config.fabricSession);
     const fabricSessionCfc = this.config.fabricSession !== undefined
       ? {
         enforcementMode: this.config.fabricSession.cfcEnforcementMode ??
@@ -724,9 +754,7 @@ export class CfHarnessEngine {
         ...(this.config.fabricSession.cfcPosture !== undefined
           ? { posture: this.config.fabricSession.cfcPosture }
           : {}),
-        ...(sessionFactoryOverridesConfig
-          ? {}
-          : { record: harnessFabricSessionPosture(this.config.fabricSession) }),
+        ...(sessionRecord !== undefined ? { record: sessionRecord } : {}),
       }
       : undefined;
     // A resumed run keeps its recorded fabric-session posture, so a session
@@ -756,16 +784,16 @@ export class CfHarnessEngine {
         recorded.enforcementMode !== fabricSessionCfc.enforcementMode ||
         recorded.flowLabels !== fabricSessionCfc.flowLabels ||
         recorded.posture !== fabricSessionCfc.posture ||
-        // A resume whose session comes from an injected factory publishes no
-        // record, so a recorded one cannot be current: it describes a runtime
-        // this resume is not building.
-        (sessionFactoryOverridesConfig && recorded.record !== undefined) ||
         // The whole record too, where the run recorded one. The two dials
         // above can agree while a dial neither of them names has moved under
         // the run — a changed runtime default, a changed posture bundle — and
         // a resume that kept the recorded record would attest a posture the
         // executing runtime is not at. A run that recorded no record predates
-        // one and is compared on the dials alone.
+        // one and is compared on the dials alone. This is also what refuses a
+        // resume that drops the session the record came from: a run that
+        // recorded an inherited record and is resumed without the parent
+        // session behind it resolves a different record, or none, and either
+        // way the artifacts would stop describing what executes.
         (recorded.record !== undefined &&
           JSON.stringify(recorded.record) !==
             JSON.stringify(fabricSessionCfc.record))

--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -4248,7 +4248,20 @@ export class CfHarnessPromptLoop {
       // factory alone reads as a run with an index and no space to run what
       // the index returns, which is a combination the config layer refuses.
       ...(this.engine.fabricSessionFactory !== undefined
-        ? { fabricSessionFactory: this.engine.fabricSessionFactory }
+        ? {
+          fabricSessionFactory: this.engine.fabricSessionFactory,
+          // And the posture record of that session, which the child publishes
+          // as inherited. The child is where `run_pattern` runs, so it is the
+          // run whose sink registry an audit most needs; recording nothing
+          // there leaves the two posture checks inconclusive on the run that
+          // actually exercises the sinks (CT-2205).
+          ...(parentRunState.fabricSessionCfc?.record !== undefined
+            ? {
+              inheritedFabricSessionPosture:
+                parentRunState.fabricSessionCfc.record,
+            }
+            : {}),
+        }
         : {}),
       ...(this.engine.config.fabricSession !== undefined
         ? { fabricSession: this.engine.config.fabricSession }

--- a/packages/cf-harness/src/run-state.ts
+++ b/packages/cf-harness/src/run-state.ts
@@ -113,7 +113,10 @@ export interface HarnessFabricSessionCfcPosture {
    * Absent too when a host supplied its own session factory. That factory
    * overrides the configuration this record is projected from, so the
    * configuration no longer describes the runtime that will execute, and a
-   * record from it would assert a posture nothing honors.
+   * record from it would assert a posture nothing honors. The exception is a
+   * host that says whose session it handed over: a delegated child runs on
+   * its parent's session, so it carries the parent's record stamped
+   * `inherited` rather than none.
    */
   record?: CfcPostureReport;
 }

--- a/packages/cf-harness/test/engine.test.ts
+++ b/packages/cf-harness/test/engine.test.ts
@@ -278,6 +278,35 @@ Deno.test("CfHarnessEngine publishes no posture record when a session factory ov
   });
 });
 
+Deno.test("CfHarnessEngine records an inherited posture record when the injected session is one it was given the record for", () => {
+  // The delegating parent's shape: the child runs on the session its parent
+  // built, so its posture is that session's rather than unknown, and the
+  // record says where it came from.
+  const posturedSession = {
+    apiUrl: "https://toolshed.example/",
+    identityKeyPath: "/keys/agent.pkcs8",
+    space: "my-space",
+    cfcPosture: "max-enforcement",
+  } as const;
+  const parentRecord = recordFor(posturedSession);
+  const child = new CfHarnessEngine({
+    workspaceHostPath: "/host/project",
+    fabricSession: posturedSession,
+    fabricSessionFactory: () =>
+      Promise.reject(new Error("never built in this test")),
+    inheritedFabricSessionPosture: parentRecord,
+  });
+
+  assertEquals(child.getRunState().fabricSessionCfc, {
+    enforcementMode: "enforce-explicit",
+    enforcementModeSource: "preset-pin",
+    flowLabels: "persist",
+    flowLabelsSource: "posture",
+    posture: "max-enforcement",
+    record: { ...parentRecord, provenance: "inherited" },
+  });
+});
+
 Deno.test("CfHarnessEngine refuses to resume a recorded record under an overriding session factory", () => {
   // The recorded record describes a runtime this resume is not building, so
   // carrying it forward would publish a posture the executing session may not

--- a/packages/cf-harness/test/subagent-fabric-posture.test.ts
+++ b/packages/cf-harness/test/subagent-fabric-posture.test.ts
@@ -1,0 +1,173 @@
+/**
+ * A delegated child runs on the session its parent built, so it records the
+ * posture that session is at rather than none. The child is where
+ * `run_pattern` runs, which makes it the run an audit most needs a sink
+ * registry from.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { join } from "@std/path";
+import { normalize } from "@std/path/posix";
+
+import { CfHarnessEngine } from "../src/engine.ts";
+import { CfHarnessPromptLoop } from "../src/prompt-loop.ts";
+import { CAPABILITY_PROBE_SENTINEL } from "../src/diagnostics.ts";
+import { harnessFabricSessionPosture } from "../src/cfc-posture.ts";
+import { readHarnessRunState } from "../src/artifacts.ts";
+import { responsesBodyFromChatFixture } from "./support/responses-fixture.ts";
+import type {
+  SandboxCommandRequest,
+  SandboxCommandResult,
+  SandboxRuntime,
+  SandboxRuntimeDescription,
+  SandboxShellRequest,
+} from "../src/sandbox/types.ts";
+
+class FakeSandboxRuntime implements SandboxRuntime {
+  describe(): SandboxRuntimeDescription {
+    return {
+      kind: "docker-runsc-cfc",
+      defaultWorkingDirectory: this.defaultWorkingDirectory(),
+      cfc: { runtimeRequested: true, workspaceMountPath: "/workspace" },
+    };
+  }
+
+  resolvePath(path: string, cwd = this.defaultWorkingDirectory()): string {
+    return normalize(path.startsWith("/") ? path : `${cwd}/${path}`);
+  }
+
+  isPathWithinWorkspace(path: string): boolean {
+    return path === "/workspace" || path.startsWith("/workspace/");
+  }
+
+  isPathWithinAllowedRoots(path: string): boolean {
+    return this.isPathWithinWorkspace(path);
+  }
+
+  defaultWorkingDirectory(): string {
+    return "/workspace";
+  }
+
+  run(_request: SandboxCommandRequest): Promise<SandboxCommandResult> {
+    return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 });
+  }
+
+  runShell(request: SandboxShellRequest): Promise<SandboxCommandResult> {
+    if (request.command.includes(CAPABILITY_PROBE_SENTINEL)) {
+      return Promise.resolve({
+        stdout: "bash\tpresent\t/bin/bash\tGNU bash, version 5.2.26(1)-release",
+        stderr: "",
+        exitCode: 0,
+      });
+    }
+    return Promise.resolve({ stdout: "ok", stderr: "", exitCode: 0 });
+  }
+}
+
+/**
+ * The session the parent is configured for. Nothing constructs it: the
+ * factory is built lazily on the first `run_pattern` call, and this run makes
+ * none, which is the case the record exists to speak for.
+ */
+const SESSION = {
+  apiUrl: "https://toolshed.example/",
+  identityKeyPath: "/keys/agent.pkcs8",
+  space: "my-space",
+  cfcPosture: "max-enforcement",
+} as const;
+
+const delegateCallTurn = (id: string, goal: string) => ({
+  choices: [{
+    index: 0,
+    message: {
+      role: "assistant",
+      content: "",
+      tool_calls: [{
+        id,
+        type: "function",
+        function: {
+          name: "delegate_task",
+          arguments: JSON.stringify({ goal }),
+        },
+      }],
+    },
+  }],
+});
+
+const finalTurn = (content: string) => ({
+  choices: [{ index: 0, message: { role: "assistant", content } }],
+});
+
+const scriptedFetch = (payloads: readonly unknown[]): typeof fetch => {
+  let served = 0;
+  return () => {
+    const payload = payloads[served];
+    served += 1;
+    if (payload === undefined) {
+      throw new Error("scripted fetch ran out of payloads");
+    }
+    return Promise.resolve(
+      new Response(JSON.stringify(responsesBodyFromChatFixture(payload)), {
+        status: 200,
+      }),
+    );
+  };
+};
+
+describe("subagent fabric-session posture", () => {
+  it("records the parent's posture on the delegated child, stamped inherited", async () => {
+    const artifactRoot = await Deno.makeTempDir({
+      prefix: "cf-harness-subagent-posture-",
+    });
+    try {
+      const runId = "run-subagent-posture";
+      const loop = new CfHarnessPromptLoop({
+        apiKey: "test-key",
+        engine: new CfHarnessEngine({
+          artifactRoot,
+          sandboxRuntime: new FakeSandboxRuntime(),
+          runId,
+          model: "gpt-5.4",
+          cfcEnforcementMode: "disabled",
+          fabricSession: SESSION,
+        }),
+        fetchFn: scriptedFetch([
+          delegateCallTurn("call-delegate", "Inspect the workspace."),
+          finalTurn("Child done."),
+          finalTurn("Parent done."),
+        ]),
+      });
+
+      await loop.runPrompt({ prompt: "Delegate the inspection." });
+
+      const parentState = await readHarnessRunState(
+        join(artifactRoot, runId, "run-state.json"),
+      );
+      const childState = await readHarnessRunState(
+        join(artifactRoot, `${runId}.subagent.1`, "run-state.json"),
+      );
+
+      // The parent's own record is the projection its session config
+      // resolves; the child's is that record and says where it came from.
+      expect(parentState.fabricSessionCfc?.record).toEqual(
+        harnessFabricSessionPosture(SESSION),
+      );
+      expect(childState.fabricSessionCfc?.record).toEqual({
+        ...harnessFabricSessionPosture(SESSION),
+        provenance: "inherited",
+      });
+      // The itemized dials the child records are the parent's too: one
+      // session, one set of dials, whichever run reads them.
+      expect(childState.fabricSessionCfc?.enforcementMode).toBe(
+        parentState.fabricSessionCfc?.enforcementMode,
+      );
+      expect(childState.fabricSessionCfc?.flowLabels).toBe(
+        parentState.fabricSessionCfc?.flowLabels,
+      );
+      expect(childState.fabricSessionCfc?.posture).toBe("max-enforcement");
+    } finally {
+      await Deno.remove(artifactRoot, { recursive: true });
+    }
+  });
+});

--- a/packages/runner/src/cfc/mod.ts
+++ b/packages/runner/src/cfc/mod.ts
@@ -269,6 +269,7 @@ export {
 } from "./external-ingest.ts";
 export {
   cfcPostureReport,
+  inheritedCfcPostureReport,
   projectedCfcPostureReport,
   resolveCfcDials,
   RUNTIME_CFC_DIAL_DEFAULTS,

--- a/packages/runner/src/cfc/posture-report.ts
+++ b/packages/runner/src/cfc/posture-report.ts
@@ -25,9 +25,11 @@
  * two are not interchangeable. A projection is a claim about a path that has
  * not run, and an artifact asserting a posture the path did not honor is
  * exactly what an audit of these records exists to catch, so the record must
- * not be able to pass one off as the other. The two entry points below are the
- * only ways this code builds one, and each stamps its own provenance from how
- * it was called rather than from an argument.
+ * not be able to pass one off as the other. The three entry points below are
+ * the only ways this code builds one, and each stamps its own provenance from
+ * how it was called rather than from an argument. The third is a host that
+ * runs on another host's runtime and republishes that host's record, which is
+ * a third thing again: it neither read a runtime nor predicted one.
  *
  * What that buys and what it does not: no production path can mislabel a
  * record, and a reader of one built here can trust the stamp. It is NOT an
@@ -69,8 +71,12 @@ import type {
  * - `projected` — computed from the options a runtime WILL be constructed
  *   with, before it exists. A prediction: this is what the surface expects,
  *   and nothing has yet honored it.
+ * - `inherited` — the record of the host whose runtime this one is also
+ *   running on. Neither an attestation nor a prediction of its own: the
+ *   values are that host's, and what they establish is what its own record
+ *   establishes, which a reader gets by reading that record's provenance.
  */
-export type CfcPostureProvenance = "resolved" | "projected";
+export type CfcPostureProvenance = "resolved" | "projected" | "inherited";
 
 /**
  * One dial's resolved rung, with what that rung decides on.
@@ -118,7 +124,10 @@ export interface CfcPostureDeviation {
 
 /** What a runtime is enforcing, as one record. */
 export interface CfcPostureReport {
-  /** Whether this record attests a constructed runtime or predicts one. */
+  /**
+   * Whether this record attests a constructed runtime, predicts one, or
+   * carries the record of the host whose runtime this one runs on.
+   */
   readonly provenance: CfcPostureProvenance;
 
   readonly enforcementMode: CfcDialReport;
@@ -417,3 +426,25 @@ export const projectedCfcPostureReport = (
     cfcSinkMaxConfidentiality: options.cfcSinkMaxConfidentiality ??
       DEFAULT_SINK_MAX_CONFIDENTIALITY,
   });
+
+/**
+ * The record for a host executing on another host's runtime: `parent`'s
+ * record, restamped `inherited`.
+ *
+ * A host that neither constructed a runtime nor holds the options one will be
+ * constructed from has a third relationship to the posture — it is running on
+ * someone else's runtime, and that runtime's posture is its own. Recomputing
+ * the values from the parent's configuration would be a second reading that
+ * can disagree with the first; publishing nothing would leave a run whose
+ * posture is known reading as one whose posture is not.
+ *
+ * The values are carried across whatever `parent`'s own provenance is, so a
+ * parent record that becomes an attestation makes the inherited record carry
+ * an attested runtime's values without this code changing. What the stamp
+ * says is where the values came from, never how strong they are: an inherited
+ * record establishes exactly what the parent's record establishes, and a
+ * reader who needs to know which reads that record.
+ */
+export const inheritedCfcPostureReport = (
+  parent: CfcPostureReport,
+): CfcPostureReport => ({ ...parent, provenance: "inherited" });

--- a/packages/runner/test/cfc-posture-report.test.ts
+++ b/packages/runner/test/cfc-posture-report.test.ts
@@ -16,6 +16,7 @@ import { expect } from "@std/expect";
 
 import {
   cfcPostureReport,
+  inheritedCfcPostureReport,
   KNOWN_SINKS,
   projectedCfcPostureReport,
   RUNTIME_CFC_DIAL_DEFAULTS,
@@ -51,6 +52,44 @@ describe("the CFC posture record", () => {
       });
       expect(record.policyEvaluation.diagnosticOnly).toBe(false);
       expect(record.policyEvaluation.decidesOn).toContain("rewritten label");
+    });
+  });
+
+  describe("inheritance", () => {
+    it("carries every value of the parent's record across, and only restamps it", () => {
+      // A host running on another host's runtime publishes that runtime's
+      // posture. Recomputing the values would be a second reading that can
+      // disagree with the first, which is what the one record exists to rule
+      // out.
+      const parent = projectedCfcPostureReport(
+        presetCfcOptions({ cfcPosture: "max-enforcement" }),
+      );
+      const inherited = inheritedCfcPostureReport(parent);
+      expect(inherited.provenance).toBe("inherited");
+      expect(inherited).toEqual({ ...parent, provenance: "inherited" });
+    });
+
+    it("stamps a resolved parent's record the same way", async () => {
+      // What CT-2195 lands on: the parent's record becomes an attestation,
+      // and the inheriting host carries the attested values without this
+      // code changing.
+      const options = runtimePresets.remoteClient({
+        apiUrl: new URL(import.meta.url),
+        storageManager: StorageManager.emulate({ as: signer }),
+        experimental: {},
+        cfcPosture: "max-enforcement",
+      });
+      const runtime = new Runtime(options);
+      try {
+        const parent = cfcPostureReport(runtime);
+        expect(inheritedCfcPostureReport(parent)).toEqual({
+          ...parent,
+          provenance: "inherited",
+        });
+      } finally {
+        await runtime.dispose();
+        await options.storageManager.close();
+      }
     });
   });
 

--- a/packages/toolshed/routes/meta/meta.handlers.ts
+++ b/packages/toolshed/routes/meta/meta.handlers.ts
@@ -49,9 +49,12 @@ export const MetaResponseSchema = z.object({
   cfc: z.object({
     // `resolved` here always: the route publishes what a constructed Runtime
     // is at. A surface that publishes before its runtime exists says
-    // `projected`, and the field is what keeps a reader from taking one for
-    // the other.
-    provenance: z.enum(["resolved", "projected"]),
+    // `projected`, and one running on another host's runtime says
+    // `inherited`; the field is what keeps a reader from taking one for
+    // another. The enum states the shared record's whole vocabulary rather
+    // than the one value this route emits, so a client reading the schema
+    // reads the record's shape.
+    provenance: z.enum(["resolved", "projected", "inherited"]),
     enforcementMode: CfcDialSchema,
     flowLabels: CfcDialSchema,
     writeFloor: CfcDialSchema,


### PR DESCRIPTION
## What

A delegated child records the fabric-session posture it actually runs on.

The child runs `run_pattern` on the session its parent built, which makes it the
run whose sink registry an audit most needs. It recorded none: `engine.ts` omits
the posture record whenever a `fabricSessionFactory` is injected — an injected
factory overrides the config the record is projected from, so a record projected
from that config would assert a posture nothing honors — and delegation is
exactly that injection, handing the child the parent's factory. AUD-13 and
AUD-14 were therefore INCONCLUSIVE on every child, and inconclusive is never
pass.

A child's posture is not unknown; it is its parent's, and the parent's record
describes it.

- `packages/runner/src/cfc/posture-report.ts` gains `inherited` in the record's
  provenance vocabulary and `inheritedCfcPostureReport()`, which restamps a
  parent record without recomputing its values. Nothing is recomputed, so when
  CT-2195 makes the parent's record `resolved`, the child inherits an attested
  runtime's values with no change here.
- `engine.ts` takes `inheritedFabricSessionPosture` and publishes it as the
  record when a factory is injected. A host injecting a session the harness has
  no record for still publishes none — the reasoning in the comment near the
  omission is intact, and the engine test that pins it is unchanged.
- `prompt-loop.ts` passes the parent's record beside the factory it already
  passes to the child engine.
- AUD-18 now keys the corpus on the posture rather than on the stamp: one
  session serving a parent and a child is one posture, not two surfaces that
  diverge. Without this the fix would have turned every delegating corpus
  yellow.
- `toolshed`'s `/api/meta` schema enum states the record's whole vocabulary;
  the route still publishes `resolved` only.

## Verification

`deno task cfc-audit` over a locally generated family with a delegated child
(the same shape as the CT-2190 family — parent under `--fabric-cfc-posture
max-enforcement`, one `delegate_task`), before and after:

```
before:  26 checks over 2 runs — FAIL 0  WARN 3  INCONCLUSIVE 2  N/A 8  PASS 13
           AUD-13 conforming matrix point — demo-run.subagent.1   INCONCLUSIVE
           AUD-14 ungated sink coverage   — demo-run.subagent.1   INCONCLUSIVE
after:   26 checks over 2 runs — FAIL 0  WARN 4  INCONCLUSIVE 0  N/A 8  PASS 14
           AUD-13 — demo-run.subagent.1   PASS
           AUD-14 — demo-run.subagent.1   WARN  (the published llm-sink gap, as on the parent)
```

The CT-2190 family named in the issue (`06839f48-c4e8-4273-8c12-4a5a80fd3ab9`,
console dir `env_z45ir4sefi/.cf-harness-console-weaver-demo`) is not on this
machine, and it predates the fix in any case: its artifacts are frozen, so
re-auditing them would still report the two INCONCLUSIVEs. Showing the
acceptance green needs a fresh run of that demo on this branch, which is the
supervisor's.

Tests: an engine case for the inherited record; a delegation case
(`test/subagent-fabric-posture.test.ts`) reading the child's `run-state.json`
off disk; seeded audit cases for a child whose record is inherited (AUD-13/14
evaluate) and for one that recorded the dials without it (both inconclusive —
the shape CT-2205 found); an AUD-18 case; runner cases for the restamp from a
projected and from a resolved parent.

Gates: `deno task test` in `packages/cf-harness` (948 passed) and `packages/runner`
(1358 passed), unsandboxed; repo-wide `deno fmt --check`, `deno lint`,
`deno task check`, `deno task check-docs`. One pre-existing local failure in
`packages/toolshed/routes/meta/meta.test.ts` asserts this machine's `SERVER_DID`
and is unrelated.

## Docs

Under the lockstep rule: the package README's "What a recorded posture is",
`docs/CURRENT_STATE.md`, and the system map's t14 card, whose sentence said an
injected session factory suppresses the record entirely. `SNAPSHOT` bumped.

Linear-issue: Fixes CT-2205

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6800?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

