### PR TITLE
Release refusals reach policy-trace.json, and AUD-16 counts that channel (CT-2200)

### DIFF
--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -1323,6 +1323,22 @@ what raising it would withhold. The measurement applies no exchange-rule
 rewriting, so a clause a policy evaluation would have discharged is withheld
 here.
 
+Whichever way it went, the measurement is also a decision in the run's
+`policy-trace.json`, in the same record every tool-policy decision is written
+as: `cfc_release_allowed` where the ceiling admitted the values,
+`cfc_release_observed` where a rung below enforcement measured a refusal it did
+not act on, `cfc_release_withheld` where it did, and `cfc_commit_refused` for
+the other boundary, a commit the runner refused. The decision carries a
+`release` record — the boundary, the sink and ceiling the flow was fitted
+against, and the refusal with its attribution — beside the reference to the tool
+output it decided about. It is appended AFTER the allow-side decision for the
+same call, because that decision answers whether the call may run and is
+recorded before it does; a boundary that refuses inside the call cannot appear
+there at all. A call that asks for no values makes no release decision, since
+nothing was measured. Nothing of this reaches the model: the refusal already
+reaches it as `valueError` and `policyRefusal`, and the trace is where an
+operator reads it.
+
 A result that settles to nothing names its cause when one was observed: when the
 settled result fails the declared `resultSchema` or holds no fields of its own
 beyond the framework keys, the tool consults what the session's runtime reported
@@ -1863,12 +1879,12 @@ them the audit stays what it is above — a per-run reading of an artifact tree 
 so an ordinary audit's exit code is not spent on a question nobody asked. A
 Group D finding is stamped `(corpus)` rather than with a run id.
 
-| Check  | Subject                                                                                                                                                                                                                                                                                      | Turned on by                    |
-| ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
-| AUD-16 | how many release refusals the corpus recorded — `policyRefusal` on a tool output, naming the gate (`sink-ceiling`, `writer-fit`) that refused — beside the counts of runs recording `not-attested` and `permissive-if-absent`. Zero warns, and fails when the corpus is declared adversarial | `--corpus`, `--expect-refusals` |
-| AUD-17 | the posture a deployment publishes on `/api/meta`, against the expected-posture spec. A deployment publishing none fails: what it enforces is indistinguishable from the default. So does one publishing a `projected` record — a prediction where an attestation was asked for              | `--toolshed-url`                |
-| AUD-18 | whether every posture record in the corpus is the same one. A run carries no surface identity, so this reads uniformity across records, not a named comparison of two surfaces; the harness's console and CLI diverge by default, so a mixed corpus surfaces that                            | `--corpus`                      |
-| AUD-19 | the shell's render ceiling, which nothing publishes: a permanent `inconclusive` line item, retiring when a publisher exists                                                                                                                                                                  | any deployment flag             |
+| Check  | Subject                                                                                                                                                                                                                                                                                                                                                                                   | Turned on by                    |
+| ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| AUD-16 | how many release refusals the corpus recorded — a `policy-trace.json` decision carrying a `release` record, naming the gate (`sink-ceiling`, `writer-fit`) that refused — beside the count of releases the same boundary measured and admitted, and the counts of runs recording `not-attested` and `permissive-if-absent`. Zero warns, and fails when the corpus is declared adversarial | `--corpus`, `--expect-refusals` |
+| AUD-17 | the posture a deployment publishes on `/api/meta`, against the expected-posture spec. A deployment publishing none fails: what it enforces is indistinguishable from the default. So does one publishing a `projected` record — a prediction where an attestation was asked for                                                                                                           | `--toolshed-url`                |
+| AUD-18 | whether every posture record in the corpus is the same one. A run carries no surface identity, so this reads uniformity across records, not a named comparison of two surfaces; the harness's console and CLI diverge by default, so a mixed corpus surfaces that                                                                                                                         | `--corpus`                      |
+| AUD-19 | the shell's render ceiling, which nothing publishes: a permanent `inconclusive` line item, retiring when a publisher exists                                                                                                                                                                                                                                                               | any deployment flag             |
 
 `--expected-posture` names a JSON profile stating what a posture record is
 supposed to hold — dial rungs, which sinks must carry a ceiling, which may
@@ -1882,23 +1898,36 @@ field held.
 ### What AUD-16 reads
 
 A **release refusal** is a denial a label decided: the boundary records one as a
-structured `policyRefusal` on a tool output, naming the gate that refused
-(`sink-ceiling` — an egress whose confidentiality ceiling the flow exceeded;
-`writer-fit` — a write whose target does not admit what it carries), the sinks
-involved, and the offending atoms. That is the channel AUD-16 counts.
+decision in `policy-trace.json` carrying a `release` record, naming the gate
+that refused (`sink-ceiling` — an egress whose confidentiality ceiling the flow
+exceeded; `writer-fit` — a write whose target does not admit what it carries),
+the sink and ceiling it was fitted against, the offending atoms, and the input
+keys that carried them in. That is the channel AUD-16 counts. The same boundary
+records the releases it admitted, which is what tells a gate that passed from a
+gate that never ran; AUD-16 reports those beside the refusals and counts neither
+as the other.
 
-The policy-decision reason codes are deliberately **not** that channel. Every
-`cfc_*` code comes from one switch in `src/prompt-loop.ts` that turns on the
-tool descriptor's static `effectClass` and on whether the invocation carries
-direct-command evidence — authority, not a label — and the loop records its
-allow-side decision _before_ the tool runs, so a refusal the boundary raises
-inside the tool cannot appear there as a denial at all. A check that counted
+The policy-decision reason codes ALONE are deliberately **not** that channel.
+Every `cfc_observe_*`, `cfc_enforce_*` and `cfc_disabled` code comes from one
+switch in `src/prompt-loop.ts` that turns on the tool descriptor's static
+`effectClass` and on whether the invocation carries direct-command evidence —
+authority, not a label — and the loop records its allow-side decision _before_
+the tool runs. What tells a release decision apart is the `release` record on
+it, which only a boundary that consulted a label writes. A check that counted
 `cfc_`-prefixed codes on denials would report capability denials as release
 refusals, including ones where the `cfc_` code present is the allow-side one
 that passed.
 
-AUD-16 reports `inconclusive` where a run's tool outputs could not be listed: an
-unreadable channel is not an empty one.
+A release refusal is also not a denied CALL, and AUD-4 leaves it alone for that
+reason: the call completed and answered with a reference to the result whose
+values it withheld, so there is no denied call for the typed deny channel to
+carry.
+
+AUD-16 reports `inconclusive` where a run's policy decisions could not be read
+from the trace, the run report, or the run state — missing, unparseable, or
+parsed without the list, which is as unreadable as the other two and is not the
+same fact as a run that decided nothing. An unreadable channel is not an empty
+one.
 
 ### What a recorded posture is
 

--- a/packages/cf-harness/audit/checks/deployment.ts
+++ b/packages/cf-harness/audit/checks/deployment.ts
@@ -52,18 +52,35 @@ export type ToolshedMeta =
 const everyRun = (audit: DeploymentAudit): readonly RunEvidence[] =>
   audit.families.flatMap((family) => [...familyRuns(family)]);
 
+/**
+ * The run's policy decisions, from the first artifact that carries a list of
+ * them.
+ *
+ * An artifact that parsed but holds no `decisions` array is not a run that
+ * decided nothing: it is an artifact this reader cannot answer from, and
+ * falling through to the next one is what keeps a refusal held in the report
+ * or the run state from disappearing behind a truncated trace. `undefined`
+ * where no artifact carries one.
+ */
 const decisionsOf = (
   run: RunEvidence,
-): readonly HarnessPolicyDecisionRecord[] => {
-  if (run.policyTrace.status === "present") {
-    return run.policyTrace.value.decisions ?? [];
+): readonly HarnessPolicyDecisionRecord[] | undefined => {
+  if (
+    run.policyTrace.status === "present" &&
+    Array.isArray(run.policyTrace.value.decisions)
+  ) {
+    return run.policyTrace.value.decisions;
   }
-  if (run.runReport.status === "present") {
-    return run.runReport.value.policyDecisions ?? [];
+  if (
+    run.runReport.status === "present" &&
+    Array.isArray(run.runReport.value.policyDecisions)
+  ) {
+    return run.runReport.value.policyDecisions;
   }
-  return run.runState.status === "present"
-    ? run.runState.value.policyDecisions ?? []
-    : [];
+  return run.runState.status === "present" &&
+      Array.isArray(run.runState.value.policyDecisions)
+    ? run.runState.value.policyDecisions
+    : undefined;
 };
 
 const snapshotOf = (
@@ -110,101 +127,124 @@ const count = (total: number, singular: string, plural: string): string =>
 /**
  * A release refusal, as a run writes one down.
  *
- * The boundary records these as structured `policyRefusal` objects on a tool
- * output — `gates` naming what refused (`sink-ceiling` is an egress whose
- * confidentiality ceiling the flow exceeded, `writer-fit` a write whose target
- * does not admit what it carries), beside the offending atoms and the input
- * keys that carried them in. That is the channel where a label deciding an
- * outcome is legible.
+ * The boundary that refused records a `release` decision in `policy-trace.json`
+ * — the same record every tool-policy decision is written as, carrying the
+ * gate that refused (`sink-ceiling` is an egress whose confidentiality ceiling
+ * the flow exceeded, `writer-fit` a write whose target does not admit what it
+ * carries), the sink and ceiling it was fitted against, the offending atoms,
+ * and the input keys that carried them in. That is the channel where a label
+ * deciding an outcome is legible.
  *
- * The policy-decision reason codes are NOT that channel, and reading them for
- * this is the mistake to avoid. Every `cfc_*` code comes from one switch in
+ * The policy-decision REASON CODES alone are NOT that channel, and reading
+ * them for this is the mistake to avoid. Every `cfc_observe_*`,
+ * `cfc_enforce_*` and `cfc_disabled` code comes from one switch in
  * `prompt-loop.ts` that turns on the tool descriptor's static `effectClass`
  * and on whether the invocation carries direct-command evidence — authority,
  * not a label — and the loop records its allow-side decision before the tool
- * runs, so a refusal the boundary raises inside the tool cannot appear there
- * as a denial at all.
+ * runs. What tells a release decision apart is the `release` record on it,
+ * which only a boundary that consulted a label writes.
  */
 interface ReleaseRefusal {
   runId: string;
-  fileName: string;
+  source: string;
+  sequence: number;
   gates: readonly string[];
   sinks: readonly string[];
 }
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
-
-const stringsOf = (value: unknown): readonly string[] =>
-  Array.isArray(value) ? value.filter((one) => typeof one === "string") : [];
+/**
+ * Every release refusal one run's decisions record.
+ *
+ * A decision that measured the boundary and released, and one an observe-stage
+ * posture measured without acting on, are decisions too — they are what says
+ * the boundary ran — but neither is a refusal, so neither is counted here.
+ */
+const releaseRefusalsOf = (
+  run: RunEvidence,
+): readonly ReleaseRefusal[] =>
+  (decisionsOf(run) ?? [])
+    .filter((decision) =>
+      decision.release !== undefined && decision.decision === "denied"
+    )
+    .map((decision) => ({
+      runId: run.runId,
+      source: sourceOf(run),
+      sequence: decision.sequence,
+      gates: decision.release?.refusal?.gates ?? [],
+      sinks: sinksOf(decision.release!),
+    }));
 
 /**
- * Every `policyRefusal` a tool output carries, wherever it sits in it.
- *
- * A walk rather than a path: the refusal rides on the tool-output envelope
- * whose shape has moved between generations, and a reader that knew only
- * today's path would silently find none in an older tree — which is the
- * failure this whole check exists to avoid.
+ * The sinks a decision refused at: the ones the refusal names, and otherwise
+ * the one the harness fitted against. A commit refusal names its own; a
+ * release refusal the harness measured carries the sink on the decision.
  */
-const releaseRefusalsIn = (
-  runId: string,
-  fileName: string,
-  value: unknown,
-): readonly ReleaseRefusal[] => {
-  const found: ReleaseRefusal[] = [];
-  const walk = (node: unknown): void => {
-    if (Array.isArray(node)) {
-      for (const one of node) walk(one);
-      return;
-    }
-    if (!isRecord(node)) return;
-    const refusal = node.policyRefusal;
-    if (isRecord(refusal)) {
-      found.push({
-        runId,
-        fileName,
-        gates: stringsOf(refusal.gates),
-        sinks: stringsOf(refusal.sinks),
-      });
-    }
-    for (const one of Object.values(node)) walk(one);
-  };
-  walk(value);
-  return found;
+const sinksOf = (
+  release: NonNullable<HarnessPolicyDecisionRecord["release"]>,
+): readonly string[] => {
+  const named = release.refusal?.sinks ?? [];
+  return named.length > 0
+    ? named
+    : release.sink === undefined
+    ? []
+    : [release.sink];
 };
 
 /** Every release refusal the corpus recorded. */
 const labelDrivenRefusals = (
   audit: DeploymentAudit,
-): readonly ReleaseRefusal[] =>
-  everyRun(audit).flatMap((run) =>
-    run.toolOutputs.status === "present"
-      ? run.toolOutputs.entries.flatMap((entry) =>
-        entry.value === undefined
-          ? []
-          : releaseRefusalsIn(run.runId, entry.fileName, entry.value)
-      )
-      : []
+): readonly ReleaseRefusal[] => everyRun(audit).flatMap(releaseRefusalsOf);
+
+/** Release measurements that refused nothing, which say the boundary ran. */
+const releasesMeasured = (audit: DeploymentAudit): number =>
+  everyRun(audit).reduce(
+    (total, run) =>
+      total +
+      (decisionsOf(run) ?? []).filter((decision) =>
+        decision.release !== undefined && decision.decision !== "denied"
+      ).length,
+    0,
   );
 
-/** Every denial of the corpus, whatever decided it. */
+/** Every denial of the corpus an authority rather than a label decided. */
 const allDenials = (audit: DeploymentAudit): number =>
   everyRun(audit).reduce(
     (total, run) =>
       total +
-      decisionsOf(run).filter((decision) => decision.decision === "denied")
-        .length,
+      (decisionsOf(run) ?? []).filter((decision) =>
+        decision.decision === "denied" && decision.release === undefined
+      ).length,
     0,
   );
 
-/** Runs whose tool outputs this host could not read. */
-const unreadableOutputs = (audit: DeploymentAudit): readonly RunEvidence[] =>
-  everyRun(audit).filter((run) => run.toolOutputs.status === "unparseable");
+/** Which artifact a run's decisions were read from, for a finding to cite. */
+const sourceOf = (run: RunEvidence): string =>
+  run.policyTrace.status === "present" &&
+    Array.isArray(run.policyTrace.value.decisions)
+    ? "policy-trace.json"
+    : run.runReport.status === "present" &&
+        Array.isArray(run.runReport.value.policyDecisions)
+    ? "run-report.json"
+    : "run-state.json";
+
+/**
+ * Runs whose decisions this host could not read from any artifact.
+ *
+ * A run that answers `undefined` to {@link decisionsOf} said nothing about
+ * its decisions anywhere — every artifact that would carry them is missing,
+ * unparseable, or parsed without the list. None of those is an empty channel,
+ * and reporting them as one would answer "no refusal here" to a question this
+ * host cannot see the evidence for.
+ */
+const unreadableDecisions = (
+  audit: DeploymentAudit,
+): readonly RunEvidence[] =>
+  everyRun(audit).filter((run) => decisionsOf(run) === undefined);
 
 const refusalLiveness = (audit: DeploymentAudit): CheckResult => {
   const refusals = labelDrivenRefusals(audit);
   const runs = everyRun(audit);
-  const unreadable = unreadableOutputs(audit);
+  const unreadable = unreadableDecisions(audit);
   const notAttested = runs.filter((run) =>
     snapshotOf(run)?.cfc.substrateStatus === "not-attested"
   );
@@ -217,13 +257,24 @@ const refusalLiveness = (audit: DeploymentAudit): CheckResult => {
     .sort();
   const evidence: CheckEvidence[] = [
     {
-      artifact: "tool-outputs/",
-      pointer: "policyRefusal",
+      artifact: "policy-trace.json",
+      pointer: "decisions[].release",
       detail: `${
         count(refusals.length, "release refusal", "release refusals")
       } across ${count(runs.length, "run", "runs")}${
         gates.length === 0 ? "" : ` (gates: ${gates.join(", ")})`
       }${sinks.length === 0 ? "" : ` (sinks: ${sinks.join(", ")})`}`,
+    },
+    {
+      artifact: "policy-trace.json",
+      pointer: "decisions[].release",
+      detail: `${
+        count(
+          releasesMeasured(audit),
+          "release the same boundary measured and did not refuse",
+          "releases the same boundary measured and did not refuse",
+        )
+      }`,
     },
     {
       detail: `${
@@ -254,9 +305,9 @@ const refusalLiveness = (audit: DeploymentAudit): CheckResult => {
       "refusal liveness",
       extendsClause("AH-CFC-11", "AH-CFC-15"),
       "inconclusive",
-      `the tool outputs of ${
+      `the policy decisions of ${
         count(unreadable.length, "run", "runs")
-      } could not be listed, so whether this corpus holds a release refusal is not established`,
+      } could not be read, so whether this corpus holds a release refusal is not established`,
       evidence,
     );
   }

--- a/packages/cf-harness/audit/checks/structural.ts
+++ b/packages/cf-harness/audit/checks/structural.ts
@@ -729,7 +729,12 @@ const denialsOf = (run: RunEvidence): readonly DenialRecord[] => {
   };
   const found = decisionsOf(run);
   for (const decision of found?.decisions ?? []) {
-    if (decision.decision === "denied") {
+    // A release refusal denied the VALUES of a result, not the call: the call
+    // completed and answered with a reference to the result it withheld, so
+    // there is no denied call for the typed deny channel to carry and no
+    // withheld observation for a message to leak. AUD-16 is where those are
+    // counted. A decision carrying no `release` denied the call itself.
+    if (decision.decision === "denied" && decision.release === undefined) {
       remember({
         toolCallId: decision.toolCallId,
         artifact: found!.source,

--- a/packages/cf-harness/audit/test/deployment.test.ts
+++ b/packages/cf-harness/audit/test/deployment.test.ts
@@ -112,7 +112,11 @@ const familyRefusing = (
 };
 
 /**
- * The fixture family with a `policyRefusal` seeded onto a tool output.
+ * The fixture family with a release refusal seeded onto its policy trace.
+ *
+ * The refusal is seeded ONLY there, and the fixture's tool outputs are left
+ * as they are: the check reads the decision channel, and a case that seeded
+ * both could not tell which one it read.
  *
  * `attested` additionally clears the two fields that weaken a posture, so the
  * only difference between the two positive arms is the thing that arm is
@@ -124,34 +128,32 @@ const familyRefusingRelease = (
   attested = false,
 ): RunFamily => {
   const root = structuredClone(family.root);
-  if (root.toolOutputs.status !== "present") {
-    throw new Error("the fixture's tool outputs did not load");
+  if (root.policyTrace.status !== "present") {
+    throw new Error("the fixture's policy trace did not load");
   }
-  const [first] = root.toolOutputs.entries;
-  if (first === undefined) {
-    throw new Error("the fixture recorded no tool output");
-  }
-  root.toolOutputs = {
-    ...root.toolOutputs,
-    entries: [
-      {
-        ...first,
-        value: {
-          outputId: first.fileName,
-          status: "error",
-          message: "refused",
-          policyRefusal: {
-            gates,
-            sinks,
-            offendingAtoms: ["medical"],
-            inputKeys: ["patient"],
-            attribution: "complete",
-          },
+  const trace = root.policyTrace.value as unknown as {
+    decisions: Record<string, unknown>[];
+  };
+  trace.decisions = [
+    ...trace.decisions,
+    {
+      decision: "denied",
+      reasonCodes: ["cfc_release_withheld"],
+      release: {
+        reasonCode: "cfc_release_withheld",
+        boundary: "release",
+        sink: sinks[0] ?? "run_pattern",
+        ceiling: [],
+        refusal: {
+          gates,
+          sinks,
+          offendingAtoms: ["medical"],
+          inputKeys: ["patient"],
+          attribution: "complete",
         },
       },
-      ...root.toolOutputs.entries.slice(1),
-    ],
-  };
+    },
+  ];
   if (attested && root.policySnapshot.status === "present") {
     const snapshot = root.policySnapshot.value as {
       cfc: { substrateStatus?: string; absenceBehavior?: string };
@@ -228,10 +230,11 @@ describe("Group D deployment checks", () => {
       ).toBe("fail");
     });
 
-    it("counts a sink-ceiling refusal a tool output recorded", () => {
-      // The channel a release refusal is actually written to: the boundary
-      // records it on the tool output, naming the gate that refused and the
-      // sink whose ceiling the flow exceeded.
+    it("counts a sink-ceiling refusal present only in the policy trace", () => {
+      // The channel a release refusal is written to: a decision in the trace
+      // carrying a `release` record, naming the gate that refused and the
+      // sink whose ceiling the flow exceeded. The fixture's tool outputs hold
+      // no refusal at all, so a count of one is a count of the trace.
       const results = auditDeployment({
         families: [familyRefusingRelease(["sink-ceiling"], ["fetchText"])],
         paths: [FIXTURE_RUNS_DIR],
@@ -283,7 +286,7 @@ describe("Group D deployment checks", () => {
       });
       expect(verdictOf(results, "AUD-16")).toBe("fail");
       expect(
-        results.find((result) => result.checkId === "AUD-16")?.evidence[1]
+        results.find((result) => result.checkId === "AUD-16")?.evidence[2]
           ?.detail,
       ).toContain("decide on authority rather than on a label");
     });
@@ -312,18 +315,54 @@ describe("Group D deployment checks", () => {
           families: [{ root, children: [] }],
           paths: [FIXTURE_RUNS_DIR],
           expectRefusals: false,
-        }).find((result) => result.checkId === "AUD-16")?.evidence[1]?.detail,
+        }).find((result) => result.checkId === "AUD-16")?.evidence[2]?.detail,
       ).toContain("1 tool-policy denial");
     });
 
-    it("is inconclusive when a run's tool outputs could not be listed", () => {
+    it("is inconclusive when the trace parsed without a decisions array and no other artifact carries one", () => {
+      // A truncated trace is not a run that decided nothing. Reading its
+      // missing list as an empty one would answer "no refusal here" to a
+      // question this host cannot see the evidence for.
+      const root = structuredClone(
+        familyRefusingRelease(
+          ["sink-ceiling"],
+          ["run_pattern"],
+        ).root,
+      );
+      if (
+        root.policyTrace.status !== "present" ||
+        root.runReport.status !== "present" ||
+        root.runState.status !== "present"
+      ) {
+        throw new Error("the fixture's policy artifacts did not load");
+      }
+      delete (root.policyTrace.value as { decisions?: unknown }).decisions;
+      delete (root.runReport.value as { policyDecisions?: unknown })
+        .policyDecisions;
+      delete (root.runState.value as { policyDecisions?: unknown })
+        .policyDecisions;
+      expect(
+        verdictOf(
+          auditDeployment({
+            families: [{ root, children: [] }],
+            paths: [FIXTURE_RUNS_DIR],
+            expectRefusals: true,
+          }),
+          "AUD-16",
+        ),
+      ).toBe("inconclusive");
+    });
+
+    it("is inconclusive when a run's decisions could not be read anywhere", () => {
       // An unreadable channel is not an empty one, and must not report as one.
+      // All three artifacts that carry the decisions have to be gone, since
+      // the reader drops to the next one it can read.
       const root = structuredClone(family.root);
-      root.toolOutputs = {
-        status: "unparseable",
-        path: root.toolOutputs.path,
-        detail: "could not be listed",
-      };
+      const unparseable = (path: string) =>
+        ({ status: "unparseable", path, detail: "could not be read" }) as const;
+      root.policyTrace = unparseable(root.policyTrace.path);
+      root.runReport = unparseable(root.runReport.path);
+      root.runState = unparseable(root.runState.path);
       expect(
         verdictOf(
           auditDeployment({

--- a/packages/cf-harness/docs/system-map/cfc-system-map.html
+++ b/packages/cf-harness/docs/system-map/cfc-system-map.html
@@ -669,7 +669,7 @@
     // ------------------------------------------------------------------ layout data
     // The state of this repository the map describes. Bump both when the
     // map is re-verified; the stamp is drawn in the canvas's top-left corner.
-    const SNAPSHOT = { date: "2026-09-03", sha: "c5a138a11b" };
+    const SNAPSHOT = { date: "2026-09-03", sha: "890911a59b" };
     const W = 2760, H = 1840;
     const bands = [
       {
@@ -1595,7 +1595,7 @@
       {
         id: "t8",
         n: 8,
-        c: "upcoming",
+        c: "guarded",
         x: 1120,
         y: 1470,
         t: "A refusal the decision channel cannot see",
@@ -1991,7 +1991,6 @@
           6757,
         ]],
         close: [
-          "Release refusals are structured in tool outputs and AUD-16 counts them there, but they remain absent from <code>policy-trace.json</code> (CT-2200).",
           "The retrospective transcript does not show what the prompt loop withheld or compressed (CT-2198).",
           "The artifact root is readable from the sandbox (CT-2117).",
         ],
@@ -2000,7 +1999,7 @@
         kind: "Evidence · verifier",
         band: "evidence",
         body:
-          `<p>Runs over any recorded run and grades AUD-1 to AUD-9, AUD-13 to AUD-15a, and deployment checks AUD-16 to AUD-19 as pass, fail, warn or inconclusive against quoted spec clauses; inconclusive is never pass. It reads the shared posture record every surface publishes, checks its total sink registry, and evaluates dial tuples against the enforcement rules in <code>audit/matrix.ts</code>. For AUD-3, files under <code>tool-outputs/</code> stamped <code>cf-harness.subagent-raw-return</code> or <code>cf-harness.run-pattern-source</code> are not tool effects; AUD-9 requires an invocation context only for a side effect that reached the substrate under AUD-2's classifier, and warns when a run recorded no context at all because its artifacts cannot distinguish host-side effects from lost evidence. AUD-16 counts structured <code>policyRefusal</code> records in tool outputs; CT-2200 moves those release decisions into <code>policy-trace.json</code>.</p><p>It verifies; it never enforces. Missing evidence is a finding, not proof that a gate ran.</p>`,
+          `<p>Runs over any recorded run and grades AUD-1 to AUD-9, AUD-13 to AUD-15a, and deployment checks AUD-16 to AUD-19 as pass, fail, warn or inconclusive against quoted spec clauses; inconclusive is never pass. It reads the shared posture record every surface publishes, checks its total sink registry, and evaluates dial tuples against the enforcement rules in <code>audit/matrix.ts</code>. For AUD-3, files under <code>tool-outputs/</code> stamped <code>cf-harness.subagent-raw-return</code> or <code>cf-harness.run-pattern-source</code> are not tool effects; AUD-9 requires an invocation context only for a side effect that reached the substrate under AUD-2's classifier, and warns when a run recorded no context at all because its artifacts cannot distinguish host-side effects from lost evidence. AUD-16 counts the refusals among the release decisions <code>policy-trace.json</code> carries — the ones that denied — and reports the releases the same boundary measured and admitted or merely observed beside them, which is what tells a gate that passed from a gate that never ran.</p><p>It verifies; it never enforces. Missing evidence is a finding, not proof that a gate ran.</p>`,
         links: [["spec-anchored CFC checker", 6749], [
           "shared posture record, total sink registry, matrix-backed audit checks",
           6755,
@@ -2090,7 +2089,6 @@
         links: [["ceiling gates values, not the handle", 6759]],
         close: [
           "The fit skips the runner's policy evaluation, so no exchange rule can discharge <code>finance</code> here yet. Policy A vs policy B (released under one, refused under the other) is the smallest honest experiment (CT-2175).",
-          "Record each release refusal in <code>policy-trace.json</code>, then make AUD-16 read that decision channel instead of tool outputs (CT-2200).",
         ],
         threats: ["t8", "t19"],
       },
@@ -2183,10 +2181,8 @@
         where: ["thirdparty", "connectors", "sqlite", "g_conn"],
       },
       t8: {
-        plan:
-          "CT-2200 records every release refusal in policy-trace.json and makes AUD-16 count that decision channel; AUD-16 counts policyRefusal records in tool outputs today; attribution fixed in #6759.",
         body:
-          `<p>Release refusals are structured in tool outputs today: each <code>policyRefusal</code> names its gates, sinks, atoms, and the input that carried the label, and AUD-16 counts those records. They are absent from <code>policy-trace.json</code> because the prompt loop records its allow-side tool decision before the release boundary runs. CT-2200 moves every release decision into that trace and makes AUD-16 read the decision channel. A gate whose decision is missing from the trace is invisible to an operator reading policy evidence alone.</p>`,
+          `<p>Every release-boundary decision reaches <code>policy-trace.json</code>: released, observed, values withheld, commit refused, each naming its boundary, sink and ceiling. The ones that refused carry the refusal too — its gates, its atoms, and the input key that carried the label — and a decision that released refuses nothing, so it carries none. Each is appended after the allow-side tool decision for the same call, which the prompt loop records before the tool runs, so the order in the trace is the order the two were decided in. AUD-16 counts the refusals in that channel, and an operator reading policy evidence alone now sees the gate decide.</p>`,
         where: ["runner", "artifacts", "audit", "g_release"],
       },
       t9: {
@@ -2366,7 +2362,7 @@
             ],
             sel: "audit",
             h: "7 · Prove it",
-            t: "Labels and decisions are written with the outcome. The checker grades the record, shared posture, sink registry and deployment matrix against quoted spec clauses; inconclusive is never pass. AUD-16 counts release refusals in tool outputs today; CT-2200 moves them into the policy trace.",
+            t: "Labels and decisions are written with the outcome. The checker grades the record, shared posture, sink registry and deployment matrix against quoted spec clauses; inconclusive is never pass. AUD-16 counts the refusals among the release decisions the policy trace carries, and reports the admitted releases beside them.",
           },
           {
             f: [
@@ -2391,7 +2387,7 @@
             ],
             sel: "g_release",
             h: "8 · Where the circuit is still open",
-            t: "Policy discharge at the release gate and a door for records (CT-2175). The prose delegation brief. Web and browser tools without label input, and bridge networking in the sandbox. A pattern's llm calls uncapped. The sandbox reading the run's own artifacts (CT-2117). Connector rows unlabeled (CT-2189). Refusals absent from policy-trace (CT-2200). Projected posture, store identity, console concurrency, stale session policy, and substrate liveness remain tracked. Program diagnostics and retrospective omissions are unlabeled boundaries (CT-2199, CT-2198). The display ceiling is off. Operator access is unaudited.",
+            t: "Policy discharge at the release gate and a door for records (CT-2175). The prose delegation brief. Web and browser tools without label input, and bridge networking in the sandbox. A pattern's llm calls uncapped. The sandbox reading the run's own artifacts (CT-2117). Connector rows unlabeled (CT-2189). Projected posture, store identity, console concurrency, stale session policy, and substrate liveness remain tracked. Program diagnostics and retrospective omissions are unlabeled boundaries (CT-2199, CT-2198). The display ceiling is off. Operator access is unaudited.",
           },
         ],
       },
@@ -2563,7 +2559,7 @@
             ],
             sel: "audit",
             h: "The attempt is on the record",
-            t: "Skill provenance, the tool proposals, the refusal. AUD-16 counts the refusal in tool outputs today. Open: CT-2200 moves it into the policy trace, and the ingest stamp still needs to be read at the egress gate.",
+            t: "Skill provenance, the tool proposals, the refusal. AUD-16 counts the refusal where the policy trace records it. Open: the ingest stamp still needs to be read at the egress gate.",
           },
         ],
       },

--- a/packages/cf-harness/src/contracts/policy-refusal.ts
+++ b/packages/cf-harness/src/contracts/policy-refusal.ts
@@ -1,0 +1,226 @@
+/**
+ * What a confidentiality boundary refused, and what the boundary decided.
+ *
+ * Two shapes live here. {@link HarnessPolicyRefusal} is the runner's
+ * `CfcRefusalDetail` folded into the terms a caller can act on: the gate, the
+ * sinks, the offending atoms, and the keys of the caller's own inputs that
+ * carried them in. {@link HarnessReleaseDecision} is what a boundary decided
+ * about one tool result, refusal or not, which is what a policy-trace decision
+ * carries when a label rather than an authority decided the outcome.
+ *
+ * They sit in `contracts/` rather than in the tool that mints them because
+ * they are one representation with two readers: the tool that measured the
+ * boundary writes them onto its output, and the prompt loop appends them to
+ * `policy-trace.json` as decisions. A release site the runner comes to own
+ * — the model-context sink resolver — writes the same two shapes.
+ */
+
+import type { JSONSchema } from "@commonfabric/api";
+import type {
+  CfcRefusalAttribution,
+  CfcRefusalGate,
+} from "@commonfabric/runner/cfc";
+
+/**
+ * What a boundary refused, in terms the caller can act on: the boundary that
+ * refused, the label atoms outside it, and the keys of the call's own
+ * `inputs` that carried those atoms in. When `attribution` is `complete`, a
+ * run without those keys meets the boundary.
+ *
+ * Everything here reaches the model as it stands wherever a tool returns it —
+ * a model-facing rendering scrubs free text and passes a structured field
+ * through untouched. So nothing here is a document id, a space, or a path
+ * into a document: an offending read that no input key accounts for is
+ * counted rather than named.
+ */
+export interface HarnessPolicyRefusal {
+  /**
+   * The rules that refused, deduplicated. `sink-ceiling` is an egress whose
+   * confidentiality ceiling the flow exceeded; `writer-fit` is a write whose
+   * target does not admit what the write carries.
+   */
+  gates: readonly CfcRefusalGate[];
+
+  /**
+   * The sinks whose ceilings refused, deduplicated. Empty when what refused
+   * was a write rather than an egress.
+   */
+  sinks: readonly string[];
+
+  /**
+   * The label atoms outside what the boundary admits, rendered as the
+   * boundary renders them.
+   */
+  offendingAtoms: readonly string[];
+
+  /**
+   * Offending atoms left out of `offendingAtoms`. A structured atom can
+   * carry the principal that introduced it, and there is no seam that
+   * redacts a rendered atom, so it is counted rather than named.
+   */
+  withheldAtomCount?: number;
+
+  /**
+   * The keys of the call's own `inputs` whose values carried the offending
+   * atoms in — the inputs to drop and retry without.
+   */
+  inputKeys: readonly string[];
+
+  /**
+   * Offending reads that no key of the call's `inputs` accounts for, counted
+   * by document.
+   */
+  unattributedInputCount?: number;
+
+  /**
+   * Whether `inputKeys` is the whole remedy. `complete` — every offending
+   * atom came in through them, so a run without them proceeds. `partial` —
+   * dropping them narrows the flow without necessarily clearing it. `none` —
+   * nothing was attributed to an input of this call.
+   */
+  attribution: CfcRefusalAttribution;
+}
+
+/** {@link HarnessPolicyRefusal}, as a tool's output schema states it. */
+export const HARNESS_POLICY_REFUSAL_SCHEMA = {
+  type: "object",
+  properties: {
+    gates: {
+      type: "array",
+      items: { type: "string", enum: ["sink-ceiling", "writer-fit"] },
+    },
+    sinks: { type: "array", items: { type: "string" } },
+    offendingAtoms: { type: "array", items: { type: "string" } },
+    withheldAtomCount: { type: "integer", minimum: 0 },
+    inputKeys: { type: "array", items: { type: "string" } },
+    unattributedInputCount: { type: "integer", minimum: 0 },
+    attribution: {
+      type: "string",
+      enum: ["complete", "partial", "none"],
+    },
+  },
+  required: [
+    "gates",
+    "sinks",
+    "offendingAtoms",
+    "inputKeys",
+    "attribution",
+  ],
+  additionalProperties: false,
+} satisfies JSONSchema;
+
+/**
+ * Which boundary decided, which decides what became of the result: a refused
+ * commit landed no result, while a refused release has one, in the space
+ * under its own labels, whose reference the caller holds with the values
+ * withheld.
+ */
+export type HarnessReleaseBoundary = "commit" | "release";
+
+/** The boundaries, as values, so a record read back off disk can be checked. */
+export const HARNESS_RELEASE_BOUNDARIES: readonly HarnessReleaseBoundary[] = [
+  "commit",
+  "release",
+];
+
+/**
+ * What a boundary decided about one tool result.
+ *
+ * The four members are the whole of what a release boundary can decide, and
+ * each names its own decision — see {@link harnessReleaseDecisionOutcome}.
+ * `released` and `observed` are the two non-rejecting ones: the values went
+ * out either way, and `observed` says a measurement found something the
+ * enforcement ladder was not turned up far enough to act on, which is what
+ * lets an observe-stage rollout size what raising it would withhold.
+ */
+export type HarnessReleaseDecisionReasonCode =
+  | "cfc_release_allowed"
+  | "cfc_release_observed"
+  | "cfc_release_withheld"
+  | "cfc_commit_refused";
+
+/**
+ * The reason codes, as values, so a record read back off disk can be checked
+ * against the union rather than asserted into it.
+ */
+export const HARNESS_RELEASE_DECISION_REASON_CODES:
+  readonly HarnessReleaseDecisionReasonCode[] = [
+    "cfc_release_allowed",
+    "cfc_release_observed",
+    "cfc_release_withheld",
+    "cfc_commit_refused",
+  ];
+
+/**
+ * What a boundary decided about one tool result, refusal or not.
+ *
+ * The tool that measured the boundary writes this onto its output, where the
+ * model-facing rendering strips it; the prompt loop reads it back off the
+ * persisted output and appends it to the run's policy trace as a decision,
+ * beside the tool-result reference that names the artifact it belongs to.
+ */
+export interface HarnessReleaseDecision {
+  reasonCode: HarnessReleaseDecisionReasonCode;
+  boundary: HarnessReleaseBoundary;
+
+  /**
+   * The sink whose ceiling the flow was fitted against, where the harness
+   * performed the fit itself. Absent for a commit refusal, which the runner
+   * raised at the pattern's own sink requests — `refusal.sinks` names those.
+   */
+  sink?: string;
+
+  /**
+   * What that sink admits, rendered as an atom is rendered wherever it is
+   * displayed. Empty is "public only" and is not the same as absent, which
+   * is a fit this record does not state a ceiling for.
+   */
+  ceiling?: readonly string[];
+
+  /** What the fit refused. Absent on `cfc_release_allowed`, which refused nothing. */
+  refusal?: HarnessPolicyRefusal;
+}
+
+/**
+ * The decision a reason code states, which is the whole of the mapping: a
+ * withheld release and a refused commit rejected, an observed one did not.
+ */
+export const harnessReleaseDecisionOutcome = (
+  reasonCode: HarnessReleaseDecisionReasonCode,
+): "allowed" | "warned" | "denied" =>
+  reasonCode === "cfc_release_allowed"
+    ? "allowed"
+    : reasonCode === "cfc_release_observed"
+    ? "warned"
+    : "denied";
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+/**
+ * The boundary decision a tool output states, if it states one.
+ *
+ * Read structurally rather than by tool id: the tool that measures a release
+ * boundary is the one that knows it did, and a release site added later says
+ * so the same way.
+ */
+export const harnessReleaseDecisionOf = (
+  output: unknown,
+): HarnessReleaseDecision | undefined => {
+  if (!isRecord(output)) return undefined;
+  const decision = output.releaseDecision;
+  if (!isRecord(decision)) return undefined;
+  // Both discriminants are checked against their closed sets rather than
+  // asserted: a tool output is read back through JSON, and a value outside
+  // either union would otherwise reach `policy-trace.json` as a reason code
+  // no reader of the trace can branch on. An unrecognized decision answers
+  // `undefined`, so the loop records nothing rather than something it cannot
+  // describe.
+  const { reasonCode, boundary } = decision;
+  return HARNESS_RELEASE_DECISION_REASON_CODES.includes(
+      reasonCode as HarnessReleaseDecisionReasonCode,
+    ) &&
+      HARNESS_RELEASE_BOUNDARIES.includes(boundary as HarnessReleaseBoundary)
+    ? decision as unknown as HarnessReleaseDecision
+    : undefined;
+};

--- a/packages/cf-harness/src/contracts/policy-trace.ts
+++ b/packages/cf-harness/src/contracts/policy-trace.ts
@@ -1,9 +1,14 @@
 import type { CfcEnforcementMode } from "@commonfabric/runner/cfc";
 import type { HarnessCfcInvocationContext } from "./cfc-invocation-context.ts";
+import type {
+  HarnessReleaseDecision,
+  HarnessReleaseDecisionReasonCode,
+} from "./policy-refusal.ts";
 import type { PromptSlotBinding } from "./prompt-slot.ts";
 import type { HarnessToolEffectClass } from "./tool-descriptor.ts";
 import type { HarnessToolInputSummary } from "./policy.ts";
 import type { HarnessToolPolicyDecision } from "./run-report.ts";
+import type { ToolResultRef } from "./tool-result.ts";
 
 export type HarnessPolicyDecisionReasonCode =
   | "tool_not_allowed"
@@ -25,7 +30,8 @@ export type HarnessPolicyDecisionReasonCode =
   | "write_file_enforce_strict_requires_direct_command"
   | "subagent_profile_allowed"
   | "subagent_profile_not_allowed"
-  | "invalid_tool_call";
+  | "invalid_tool_call"
+  | HarnessReleaseDecisionReasonCode;
 
 export interface HarnessPolicyDecisionRecord {
   type: "cf-harness.policy-decision";
@@ -44,6 +50,24 @@ export interface HarnessPolicyDecisionRecord {
   toolInputSummary?: HarnessToolInputSummary;
   policyEventIndexes?: readonly number[];
   subagentProfile?: string;
+
+  /**
+   * What a confidentiality boundary decided about the call's own result, on
+   * the decision that records it. A label decided this one; every other
+   * decision in the trace turns on authority, and the two are told apart by
+   * this field rather than by reading a reason code for a shape it does not
+   * carry.
+   */
+  release?: HarnessReleaseDecision;
+
+  /**
+   * The tool result the decision belongs to, as the tool activity names it:
+   * the output id and, where the run persists artifacts, the path of the
+   * tool-output file. Present on a decision made from a result rather than
+   * before one existed, which is every release decision and no allow-side
+   * one.
+   */
+  resultRef?: ToolResultRef;
 }
 
 export interface HarnessPolicyDecisionCounts {
@@ -112,6 +136,8 @@ export const createHarnessPolicyDecisionRecord = (
   ...(options.subagentProfile !== undefined
     ? { subagentProfile: options.subagentProfile }
     : {}),
+  ...(options.release !== undefined ? { release: options.release } : {}),
+  ...(options.resultRef !== undefined ? { resultRef: options.resultRef } : {}),
 });
 
 export const countHarnessPolicyDecisions = (

--- a/packages/cf-harness/src/index.ts
+++ b/packages/cf-harness/src/index.ts
@@ -47,6 +47,7 @@ export * from "./contracts/run-manifest.ts";
 export * from "./contracts/invalid-tool-call.ts";
 export * from "./contracts/observation.ts";
 export * from "./contracts/policy.ts";
+export * from "./contracts/policy-refusal.ts";
 export * from "./contracts/policy-trace.ts";
 export * from "./contracts/run-report.ts";
 export * from "./contracts/skill.ts";

--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -36,6 +36,10 @@ import {
   type ObservationDenied,
 } from "./contracts/observation.ts";
 import {
+  harnessReleaseDecisionOf,
+  harnessReleaseDecisionOutcome,
+} from "./contracts/policy-refusal.ts";
+import {
   createHarnessPolicyTrace,
   type HarnessPolicyDecisionReasonCode,
 } from "./contracts/policy-trace.ts";
@@ -3802,6 +3806,31 @@ export class CfHarnessPromptLoop {
       throw error;
     }
     this.#recordPatternSearchResult(toolId, result.output);
+    // A confidentiality boundary inside the tool decided about the tool's own
+    // result, so its decision is appended AFTER the allow-side decision above
+    // and after the output it belongs to is persisted. The allow-side
+    // decision answers whether the call may run and is recorded before it
+    // does; a boundary that refuses inside the call cannot appear there at
+    // all, which is why the trace showed a run in which policy never said no.
+    // The order in the trace is the order the two were decided in, and the
+    // result reference joins the second to the artifact it decided about.
+    const releaseDecision = harnessReleaseDecisionOf(result.output);
+    if (releaseDecision !== undefined) {
+      await this.engine.recordPolicyDecision({
+        toolActivitySequence: sequence,
+        toolCallId: toolCall.id,
+        toolId,
+        effectClass: tool.descriptor.effectClass,
+        cfcEnforcementMode: this.engine.getRunState().cfcEnforcementMode,
+        decision: harnessReleaseDecisionOutcome(releaseDecision.reasonCode),
+        reasonCodes: [releaseDecision.reasonCode],
+        ...(promptSlotBinding !== undefined
+          ? { promptSlot: promptSlotBinding }
+          : {}),
+        release: releaseDecision,
+        resultRef: result.resultRef,
+      });
+    }
     // Before the outbound swap, so the token it mints for the result cell
     // already carries the shape the compiler knew.
     await this.#recordRunPatternResultShape(
@@ -3972,7 +4001,10 @@ export class CfHarnessPromptLoop {
       // redundant with `resultRef` since the piece cell is the result cell.
       // It also keeps the pattern's result schema, which reaches the model
       // through `describe_handle` on the minted token rather than inline.
-      // The model sees `resultRef` and the schema-sanitized `value`.
+      // The model sees `resultRef` and the schema-sanitized `value`. The
+      // boundary decision goes the same way: the policy trace is where a
+      // decision about this result is read, and restating it to the model
+      // beside `policyRefusal` would say the same thing twice.
       // Free-text diagnostic fields can embed compiler-generated bare
       // fabric identifiers the handle boundary never swaps, so those fields
       // are scrubbed here; the artifact keeps the raw text.
@@ -3982,6 +4014,7 @@ export class CfHarnessPromptLoop {
         pieceId: _pieceId,
         resultRefSchema: _resultRefSchema,
         releaseObservation: _releaseObservation,
+        releaseDecision: _releaseDecision,
         ...publicOutput
       } = output;
       const scrubbed: Record<string, unknown> = { ...publicOutput };

--- a/packages/cf-harness/src/tools/run-pattern.ts
+++ b/packages/cf-harness/src/tools/run-pattern.ts
@@ -15,6 +15,7 @@ import {
   type CfcRefusalDetail,
   type CfcRefusalGate,
   describeSinkReleaseRefusal,
+  renderCfcAtom,
   selectReferencedCfcSchemaDefs,
   validateAgainstSchema,
 } from "@commonfabric/runner/cfc";
@@ -30,6 +31,12 @@ import {
   type PiecesController,
 } from "@commonfabric/piece/ops";
 import { isObjectNotArray } from "@commonfabric/utils/types";
+import {
+  HARNESS_POLICY_REFUSAL_SCHEMA,
+  type HarnessPolicyRefusal,
+  type HarnessReleaseBoundary,
+  type HarnessReleaseDecision,
+} from "../contracts/policy-refusal.ts";
 import type { HarnessToolDescriptor } from "../contracts/tool-descriptor.ts";
 import { keylessInstantiation } from "../fabric-instantiations.ts";
 import {
@@ -103,6 +110,17 @@ export interface RunPatternToolSuccessOutput {
   resultRef: string;
 
   /**
+   * What the release boundary decided about this call's own result: released,
+   * observed, or withheld, with the sink and ceiling it was fitted against
+   * and what the fit refused. Artifact-only, like `releaseObservation`: the
+   * prompt loop strips it from the model-facing rendering and appends it to
+   * the run's policy trace, where a decision a label drove sits beside the
+   * decisions authority drove. Absent on a run that asked for no values,
+   * since nothing was measured.
+   */
+  releaseDecision?: HarnessReleaseDecision;
+
+  /**
    * What the release measurement refused, on a run the enforcement ladder did
    * not reject it on. Artifact-only, like the other fields the prompt loop
    * strips: the values went out, so the model has nothing to act on, while an
@@ -110,7 +128,7 @@ export interface RunPatternToolSuccessOutput {
    * start withholding. Absent, like `policyRefusal`, on a run that asked for
    * no values, since nothing was measured.
    */
-  releaseObservation?: RunPatternPolicyRefusal;
+  releaseObservation?: HarnessPolicyRefusal;
 
   /**
    * What the answer's own sink refused to release and which of this call's
@@ -120,7 +138,7 @@ export interface RunPatternToolSuccessOutput {
    * is the values alone. `valueError` states the same refusal as an
    * instruction.
    */
-  policyRefusal?: RunPatternPolicyRefusal;
+  policyRefusal?: HarnessPolicyRefusal;
 
   /**
    * The compiled pattern's result schema — the shape of whatever
@@ -215,67 +233,6 @@ export interface RunPatternPublicationReport {
   syntheticInputsComplete: boolean;
 }
 
-/**
- * What a boundary refused, in terms the caller can act on: the boundary that
- * refused, the label atoms outside it, and the keys of this
- * call's own `inputs` that carried those atoms in. When `attribution` is
- * `complete`, a run without those keys meets the boundary.
- *
- * Everything here reaches the model as it stands — the model-facing
- * rendering strips `rawValue`, `rawCauseMessage`, `pieceId` and
- * `resultRefSchema` and scrubs the free-text fields, and a structured field
- * passes through untouched. So nothing here is a document id, a space, or a
- * path into a document: an offending read that no input key accounts for is
- * counted rather than named.
- */
-export interface RunPatternPolicyRefusal {
-  /**
-   * The rules that refused, deduplicated. `sink-ceiling` is an egress whose
-   * confidentiality ceiling the flow exceeded; `writer-fit` is a write whose
-   * target does not admit what the write carries.
-   */
-  gates: readonly CfcRefusalGate[];
-
-  /**
-   * The sinks whose ceilings refused, deduplicated. Empty when what refused
-   * was a write rather than an egress.
-   */
-  sinks: readonly string[];
-
-  /**
-   * The label atoms outside what the boundary admits, rendered as the
-   * boundary renders them.
-   */
-  offendingAtoms: readonly string[];
-
-  /**
-   * Offending atoms left out of `offendingAtoms`. A structured atom can
-   * carry the principal that introduced it, and there is no seam that
-   * redacts a rendered atom, so it is counted rather than named.
-   */
-  withheldAtomCount?: number;
-
-  /**
-   * The keys of this call's own `inputs` whose values carried the offending
-   * atoms in — the inputs to drop and retry without.
-   */
-  inputKeys: readonly string[];
-
-  /**
-   * Offending reads that no key of this call's `inputs` accounts for,
-   * counted by document.
-   */
-  unattributedInputCount?: number;
-
-  /**
-   * Whether `inputKeys` is the whole remedy. `complete` — every offending
-   * atom came in through them, so a run without them proceeds. `partial` —
-   * dropping them narrows the flow without necessarily clearing it. `none` —
-   * nothing was attributed to an input of this call.
-   */
-  attribution: CfcRefusalAttribution;
-}
-
 export interface RunPatternToolErrorOutput {
   outputId: string;
   status: "compile-error" | "error" | "cancelled";
@@ -302,7 +259,15 @@ export interface RunPatternToolErrorOutput {
    * this — the result landed and its reference is returned — so it rides on
    * the success output instead.
    */
-  policyRefusal?: RunPatternPolicyRefusal;
+  policyRefusal?: HarnessPolicyRefusal;
+
+  /**
+   * What the commit boundary decided, on the error a refused commit produces.
+   * Artifact-only on the same terms as the success output's, and the same
+   * shape: a refusal the runner raised is a decision of the same kind as one
+   * the harness measured.
+   */
+  releaseDecision?: HarnessReleaseDecision;
 }
 
 export type RunPatternToolOutput =
@@ -316,34 +281,6 @@ export const isRunPatternToolSuccessOutput = (
   "status" in output && output.status === "ok" &&
   "resultRef" in output && typeof output.resultRef === "string" &&
   "resultRefSchema" in output;
-
-/** `RunPatternPolicyRefusal`, as the output schema states it. */
-const RUN_PATTERN_POLICY_REFUSAL_SCHEMA = {
-  type: "object",
-  properties: {
-    gates: {
-      type: "array",
-      items: { type: "string", enum: ["sink-ceiling", "writer-fit"] },
-    },
-    sinks: { type: "array", items: { type: "string" } },
-    offendingAtoms: { type: "array", items: { type: "string" } },
-    withheldAtomCount: { type: "integer", minimum: 0 },
-    inputKeys: { type: "array", items: { type: "string" } },
-    unattributedInputCount: { type: "integer", minimum: 0 },
-    attribution: {
-      type: "string",
-      enum: ["complete", "partial", "none"],
-    },
-  },
-  required: [
-    "gates",
-    "sinks",
-    "offendingAtoms",
-    "inputKeys",
-    "attribution",
-  ],
-  additionalProperties: false,
-} satisfies JSONSchema;
 
 export const runPatternToolDescriptor: HarnessToolDescriptor = {
   toolId: "run_pattern",
@@ -407,7 +344,7 @@ export const runPatternToolDescriptor: HarnessToolDescriptor = {
         value: {},
         linkedStringCount: { type: "integer", minimum: 0 },
         valueError: { type: "string" },
-        policyRefusal: RUN_PATTERN_POLICY_REFUSAL_SCHEMA,
+        policyRefusal: HARNESS_POLICY_REFUSAL_SCHEMA,
         rawValue: {},
         patternPublication: {
           type: "object",
@@ -460,7 +397,7 @@ export const runPatternToolDescriptor: HarnessToolDescriptor = {
         message: { type: "string" },
         pieceId: { type: "string" },
         rawCauseMessage: { type: "string" },
-        policyRefusal: RUN_PATTERN_POLICY_REFUSAL_SCHEMA,
+        policyRefusal: HARNESS_POLICY_REFUSAL_SCHEMA,
       },
       required: ["outputId", "status", "message"],
       additionalProperties: false,
@@ -738,7 +675,7 @@ const namableRefusalAtom = (rendered: string): boolean => {
 export const runPatternPolicyRefusal = (
   refusals: readonly CfcRefusalDetail[],
   inputKeysFor: (read: CfcAddress) => readonly string[],
-): RunPatternPolicyRefusal | undefined =>
+): HarnessPolicyRefusal | undefined =>
   nonEmpty(refusals) ? foldPolicyRefusals(refusals, inputKeysFor) : undefined;
 
 /** Whether `items` has a first element, narrowing to the tuple that says so. */
@@ -749,7 +686,7 @@ const nonEmpty = <T>(items: readonly T[]): items is readonly [T, ...T[]] =>
 const foldPolicyRefusals = (
   refusals: readonly [CfcRefusalDetail, ...CfcRefusalDetail[]],
   inputKeysFor: (read: CfcAddress) => readonly string[],
-): RunPatternPolicyRefusal => {
+): HarnessPolicyRefusal => {
   const gates: CfcRefusalGate[] = [];
   const sinks: string[] = [];
   const offendingAtoms: string[] = [];
@@ -805,21 +742,13 @@ const quoteAll = (values: readonly string[]): string =>
   values.map((value) => `"${value}"`).join(", ");
 
 /**
- * Which boundary a refusal came from, which decides what the caller is told
- * became of the result: a refused commit landed no result, while a refused
- * release has one, in the space under its own labels, whose reference the
- * caller holds with the values withheld.
- */
-export type RunPatternRefusalBoundary = "commit" | "release";
-
-/**
  * The refusal stated as an instruction: what refused, which of the caller's
  * inputs carried what it refused, and whether dropping those inputs is the
  * whole remedy or only narrows the flow.
  */
 export const policyRefusalMessage = (
-  refusal: RunPatternPolicyRefusal,
-  boundaryRefused: RunPatternRefusalBoundary,
+  refusal: HarnessPolicyRefusal,
+  boundaryRefused: HarnessReleaseBoundary,
 ): string => {
   const boundary = refusal.sinks.length > 0
     ? `the sink${refusal.sinks.length > 1 ? "s" : ""} ${
@@ -1008,10 +937,22 @@ export const runPatternTool: HarnessToolDefinition<
   descriptor: runPatternToolDescriptor,
   async invoke(context, input) {
     const outputId = context.nextOutputId("run_pattern");
+    /**
+     * What the release boundary decided, once it has decided. Declared here
+     * so {@link errorOutput} can carry it: every exit below the fit is an
+     * exit the boundary already decided at, and an exit that had to remember
+     * to attach the decision is an exit that can forget to.
+     */
+    let releaseDecision: HarnessReleaseDecision | undefined = undefined;
     const errorOutput = (
       status: RunPatternToolErrorOutput["status"],
       message: string,
-    ): RunPatternToolErrorOutput => ({ outputId, status, message });
+    ): RunPatternToolErrorOutput => ({
+      outputId,
+      status,
+      message,
+      ...(releaseDecision !== undefined ? { releaseDecision } : {}),
+    });
 
     /**
      * `detail` is what the cancellation left behind that the caller would
@@ -1488,7 +1429,7 @@ export const runPatternTool: HarnessToolDefinition<
      */
     const describeRefusal = async (
       details: readonly [CfcRefusalDetail, ...CfcRefusalDetail[]],
-    ): Promise<RunPatternPolicyRefusal> => {
+    ): Promise<HarnessPolicyRefusal> => {
       let argumentHash: string | undefined;
       try {
         argumentHash = comparableEntityHash(
@@ -1522,6 +1463,9 @@ export const runPatternTool: HarnessToolDefinition<
       details: readonly CfcRefusalDetail[],
       rawCauseMessage: string,
     ) => {
+      // The commit boundary's own decision, and not the release measurement
+      // beside it: nothing landed, so what the ceiling would have admitted of
+      // a result that does not exist is not a decision about this run.
       recordOutcome("run_failed");
       const policyRefusal = nonEmpty(details)
         ? await describeRefusal(details)
@@ -1536,6 +1480,18 @@ export const runPatternTool: HarnessToolDefinition<
         pieceId: piece.id,
         rawCauseMessage,
         ...(policyRefusal !== undefined ? { policyRefusal } : {}),
+        // The commit boundary states no sink or ceiling of its own: the
+        // runner refused at the pattern's own sink requests, which the
+        // refusal names, rather than at a fit this tool performed. Stated
+        // after the spread above, so it stands in place of the release
+        // measurement's own decision where both exist: nothing landed, so
+        // what the ceiling would have admitted of a result that does not
+        // exist is not a decision about this run.
+        releaseDecision: {
+          reasonCode: "cfc_commit_refused",
+          boundary: "commit",
+          ...(policyRefusal !== undefined ? { refusal: policyRefusal } : {}),
+        } satisfies HarnessReleaseDecision,
       };
     };
 
@@ -1628,6 +1584,48 @@ export const runPatternTool: HarnessToolDefinition<
       stopPiece(piece.getCell());
       return cancelledOutput();
     }
+
+    // The measurement is read HERE, before the exits below, because every
+    // one of them is an exit the boundary already decided at: a run whose
+    // result fails to settle after the fit still had the fit performed, and a
+    // decision left behind at such an exit is the very decision the trace was
+    // missing. What it found goes one of two ways. Where the ladder
+    // rejects, the values are withheld and the refusal reaches the model as
+    // data and as an instruction, with its reason kept for the artifact.
+    // Where it does not, the values go out and the measurement is still an
+    // answer about this run, which only the artifact can carry.
+    const withheldRefusal = releaseGateRejects ? releaseRefusal : undefined;
+    const withheld = withheldRefusal === undefined
+      ? undefined
+      : await describeRefusal([withheldRefusal]);
+    const releaseObservation =
+      releaseGateRejects || releaseRefusal === undefined
+        ? undefined
+        : await describeRefusal([releaseRefusal]);
+    const measured = withheld ?? releaseObservation;
+    /**
+     * The same measurement said as a decision, which is what reaches the
+     * run's policy trace. Present exactly where a measurement happened — a
+     * call that asked for no values measured nothing, and a decision about a
+     * boundary nothing crossed would be a record of an event that did not
+     * occur.
+     *
+     * The ceiling is stated whichever way the decision went. A released
+     * answer and a withheld one differ in what the same ceiling admitted, and
+     * an operator reading only the refusals would be reading the ladder's
+     * effect without its terms.
+     */
+    releaseDecision = parsedResultSchema === undefined ? undefined : {
+      reasonCode: withheld !== undefined
+        ? "cfc_release_withheld"
+        : releaseObservation !== undefined
+        ? "cfc_release_observed"
+        : "cfc_release_allowed",
+      boundary: "release",
+      sink: RUN_PATTERN_ANSWER_SINK,
+      ceiling: RUN_PATTERN_ANSWER_CEILING.map(renderCfcAtom),
+      ...(measured !== undefined ? { refusal: measured } : {}),
+    };
 
     let value: unknown;
     let linkedStringCount: number | undefined;
@@ -1756,20 +1754,6 @@ export const runPatternTool: HarnessToolDefinition<
     if (valueError === undefined) {
       recordOutcome("run_succeeded");
     }
-    // What the measurement found goes one of two ways. Where the ladder
-    // rejects, the values are withheld and the refusal reaches the model as
-    // data and as an instruction, with its reason kept for the artifact.
-    // Where it does not, the values go out and the measurement is still an
-    // answer about this run, which only the artifact can carry.
-    const withheldRefusal = releaseGateRejects ? releaseRefusal : undefined;
-    const withheld = withheldRefusal === undefined
-      ? undefined
-      : await describeRefusal([withheldRefusal]);
-    const releaseObservation =
-      releaseGateRejects || releaseRefusal === undefined
-        ? undefined
-        : await describeRefusal([releaseRefusal]);
-
     /**
      * The render gate: what the pattern's own `$UI` does before the pattern
      * is contributed to the index.
@@ -2029,6 +2013,7 @@ export const runPatternTool: HarnessToolDefinition<
         }),
       ...(rawValue !== undefined ? { rawValue } : {}),
       ...(releaseObservation !== undefined ? { releaseObservation } : {}),
+      ...(releaseDecision !== undefined ? { releaseDecision } : {}),
       ...(publication !== undefined ? { patternPublication: publication } : {}),
       ...(retainedCauses.length > 0
         ? { rawCauseMessage: retainedCauses.join("\n\n") }

--- a/packages/cf-harness/test/run-pattern-policy-trace.test.ts
+++ b/packages/cf-harness/test/run-pattern-policy-trace.test.ts
@@ -1,0 +1,314 @@
+/**
+ * Where `run_pattern`'s release-boundary decisions land: `policy-trace.json`,
+ * beside the tool-policy decisions the prompt loop records before a call runs.
+ *
+ * The loop records its allow-side decision before the tool runs, so a
+ * boundary that refuses inside the call cannot appear there. What is under
+ * test is that the second decision is appended after it, in the order the two
+ * were decided in, carrying the refusal's attribution and the reference to
+ * the tool output it decided about.
+ */
+
+import { expect } from "@std/expect";
+import { join } from "@std/path";
+import { normalize } from "@std/path/posix";
+import { describe, it } from "@std/testing/bdd";
+
+import { createSession, Identity } from "@commonfabric/identity";
+import { PiecesController } from "@commonfabric/piece/ops";
+import { Runtime } from "@commonfabric/runner";
+import { createLLMFriendlyLink } from "@commonfabric/runner/shared";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+import {
+  SEED_ENVELOPE_SCHEMA_HASH,
+  writeSeedEnvelopeDoc,
+} from "../../runner/test/cfc-seed-envelope.ts";
+import {
+  harnessReleaseDecisionOf,
+  harnessReleaseDecisionOutcome,
+} from "../src/contracts/policy-refusal.ts";
+import type { HarnessPolicyTrace } from "../src/contracts/policy-trace.ts";
+import { CAPABILITY_PROBE_SENTINEL } from "../src/diagnostics.ts";
+import { CfHarnessEngine } from "../src/engine.ts";
+import { CfHarnessPromptLoop } from "../src/prompt-loop.ts";
+import type {
+  SandboxCommandRequest,
+  SandboxCommandResult,
+  SandboxRuntime,
+  SandboxRuntimeDescription,
+  SandboxShellRequest,
+} from "../src/sandbox/types.ts";
+import { responsesBodyFromChatFixture } from "./support/responses-fixture.ts";
+
+const signer = await Identity.fromPassphrase("cf-harness release decisions");
+
+/** A pattern whose answer widens with the labelled input it is handed. */
+const SECRET_LENGTH_PATTERN_SOURCE = [
+  "import { computed, pattern, Reactive } from 'commonfabric';",
+  "interface Source { secret: string; }",
+  "interface Input { amount: number; source: Reactive<Source>; }",
+  "interface Output { total: number; }",
+  "export default pattern<Input, Output>(({ amount, source }) => ({",
+  "  total: computed(() => amount + (source.secret ?? '').length),",
+  "}));",
+  "",
+].join("\n");
+
+const TOTAL_RESULT_SCHEMA = {
+  type: "object",
+  properties: { total: { type: "number" } },
+  required: ["total"],
+} as const;
+
+class FakeSandboxRuntime implements SandboxRuntime {
+  describe(): SandboxRuntimeDescription {
+    return {
+      kind: "docker-runsc-cfc",
+      defaultWorkingDirectory: this.defaultWorkingDirectory(),
+      cfc: { runtimeRequested: true, workspaceMountPath: "/workspace" },
+    };
+  }
+
+  resolvePath(path: string, cwd = this.defaultWorkingDirectory()): string {
+    return normalize(path.startsWith("/") ? path : `${cwd}/${path}`);
+  }
+
+  isPathWithinWorkspace(path: string): boolean {
+    return path === "/workspace" || path.startsWith("/workspace/");
+  }
+
+  isPathWithinAllowedRoots(path: string): boolean {
+    return this.isPathWithinWorkspace(path);
+  }
+
+  defaultWorkingDirectory(): string {
+    return "/workspace";
+  }
+
+  run(_request: SandboxCommandRequest): Promise<SandboxCommandResult> {
+    return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 });
+  }
+
+  runShell(request: SandboxShellRequest): Promise<SandboxCommandResult> {
+    return Promise.resolve(
+      request.command.includes(CAPABILITY_PROBE_SENTINEL)
+        ? {
+          stdout:
+            "bash\tpresent\t/bin/bash\tGNU bash, version 5.2.26(1)-release",
+          stderr: "",
+          exitCode: 0,
+        }
+        : { stdout: "", stderr: "", exitCode: 0 },
+    );
+  }
+}
+
+/** A fabric session that withholds what its ceiling refuses. */
+async function createStrictFabric() {
+  const storage = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    apiUrl: new URL("http://toolshed.test"),
+    storageManager: storage,
+    cfcEnforcementMode: "enforce-strict",
+    cfcFlowLabels: "persist",
+  });
+  const pieces = new PiecesController(
+    await createSession({
+      identity: signer,
+      spaceName: `release-decisions-${crypto.randomUUID()}`,
+    }),
+    runtime,
+  );
+  await pieces.synced();
+  return {
+    runtime,
+    pieces,
+    space: pieces.getSpace(),
+    dispose: async () => {
+      await runtime.dispose();
+      await storage.close();
+    },
+  };
+}
+
+/**
+ * Seeds a document whose `secret` field carries confidentiality, and answers
+ * the link an agent would pass as the input naming it.
+ */
+async function seedLabelledSecret(
+  runtime: Runtime,
+  space: ReturnType<PiecesController["getSpace"]>,
+): Promise<string> {
+  const seed = runtime.edit();
+  const sourceCell = runtime.getCell(
+    space,
+    "release-decision-source",
+    { type: "object", properties: { secret: { type: "string" } } },
+    seed,
+  );
+  writeSeedEnvelopeDoc(seed, space);
+  seed.writeOrThrow({
+    space,
+    scope: "space",
+    id: sourceCell.getAsNormalizedFullLink().id,
+    path: [],
+  }, {
+    value: { secret: "s3cr3t" },
+    cfc: {
+      version: 1,
+      schemaHash: SEED_ENVELOPE_SCHEMA_HASH,
+      labelMap: {
+        version: 1,
+        entries: [{ path: ["secret"], label: { confidentiality: ["secret"] } }],
+      },
+    },
+  });
+  expect((await seed.commit()).ok).toBeDefined();
+  return createLLMFriendlyLink(sourceCell.getAsNormalizedFullLink(), space);
+}
+
+describe("run_pattern release decisions in the policy trace", () => {
+  it("appends the withheld-values decision after the allow-side decision of the same call", async () => {
+    const artifactRoot = await Deno.makeTempDir({
+      prefix: "cf-harness-release-decisions-",
+    });
+    const { runtime, pieces, space, dispose } = await createStrictFabric();
+    try {
+      const sourceRef = await seedLabelledSecret(runtime, space);
+      let turns = 0;
+      const fetchFn: typeof fetch = (_input, init) => {
+        turns += 1;
+        const payload = turns === 1
+          ? {
+            choices: [{
+              index: 0,
+              message: {
+                role: "assistant",
+                content: "",
+                tool_calls: [{
+                  id: "call-run-pattern",
+                  type: "function",
+                  function: {
+                    name: "run_pattern",
+                    arguments: JSON.stringify({
+                      sourceText: SECRET_LENGTH_PATTERN_SOURCE,
+                      inputs: { amount: 2, source: sourceRef },
+                      resultSchema: TOTAL_RESULT_SCHEMA,
+                    }),
+                  },
+                }],
+              },
+            }],
+          }
+          : {
+            choices: [{
+              index: 0,
+              message: { role: "assistant", content: "Done." },
+            }],
+          };
+        return Promise.resolve(
+          new Response(
+            JSON.stringify(responsesBodyFromChatFixture(payload, init?.body)),
+            { status: 200 },
+          ),
+        );
+      };
+      const loop = new CfHarnessPromptLoop({
+        apiKey: "test-key",
+        engine: new CfHarnessEngine({
+          artifactRoot,
+          sandboxRuntime: new FakeSandboxRuntime(),
+          runId: "run-release-decision",
+          model: "gpt-5.4",
+          // The harness's own ladder decides whether the CALL may run, and
+          // an enforcing rung there would refuse it for want of
+          // direct-command authority before the boundary under test ran. The
+          // release is decided by the fabric runtime's mode, which is
+          // `enforce-strict` above.
+          cfcEnforcementMode: "disabled",
+          fabricSessionFactory: () => Promise.resolve({ pieces }),
+        }),
+        fetchFn,
+      });
+
+      await loop.runPrompt({ prompt: "Run the pattern over the source." });
+
+      const trace = JSON.parse(
+        await Deno.readTextFile(
+          join(artifactRoot, "run-release-decision", "policy-trace.json"),
+        ),
+      ) as HarnessPolicyTrace;
+      const forCall = trace.decisions.filter((decision) =>
+        decision.toolCallId === "call-run-pattern"
+      );
+      expect(forCall.length).toBe(2);
+      const [allowSide, release] = forCall;
+      // The order in the trace is the order the two were decided in: whether
+      // the call may run, then what the boundary inside it did.
+      expect(allowSide.decision).toBe("allowed");
+      expect(allowSide.release).toBeUndefined();
+      expect(release.sequence).toBeGreaterThan(allowSide.sequence);
+      expect(release.decision).toBe("denied");
+      expect(release.reasonCodes).toEqual(["cfc_release_withheld"]);
+      expect(release.release?.boundary).toBe("release");
+      expect(release.release?.sink).toBe("run_pattern");
+      expect(release.release?.ceiling).toEqual([]);
+      expect(release.release?.refusal?.gates).toEqual(["sink-ceiling"]);
+      expect(release.release?.refusal?.offendingAtoms).toEqual(['"secret"']);
+      // The attribution names the input to drop, which is the whole of what
+      // the caller can act on.
+      expect(release.release?.refusal?.inputKeys).toEqual(["source"]);
+      expect(release.release?.refusal?.attribution).toBe("complete");
+      // The decision joins to the artifact it decided about.
+      expect(release.resultRef?.toolId).toBe("run_pattern");
+      expect(release.resultRef?.artifactPath).toContain("tool-outputs");
+      expect(trace.decisionCounts.denied).toBe(1);
+    } finally {
+      await dispose();
+      await Deno.remove(artifactRoot, { recursive: true });
+    }
+  });
+
+  it("reads no decision off an output whose reason code or boundary is not one the trace carries", () => {
+    // A tool output is read back through JSON, so the two discriminants are
+    // checked against their closed sets rather than asserted into them: a
+    // value outside either would reach the trace as a reason code no reader
+    // of it can branch on, and the loop records nothing instead.
+    const decision = {
+      reasonCode: "cfc_release_withheld",
+      boundary: "release",
+      sink: "run_pattern",
+    };
+    expect(harnessReleaseDecisionOf({ releaseDecision: decision }))
+      .toEqual(decision);
+    expect(
+      harnessReleaseDecisionOf({
+        releaseDecision: { ...decision, reasonCode: "cfc_release_maybe" },
+      }),
+    ).toBeUndefined();
+    expect(
+      harnessReleaseDecisionOf({
+        releaseDecision: { ...decision, boundary: "egress" },
+      }),
+    ).toBeUndefined();
+    expect(harnessReleaseDecisionOf({ releaseDecision: "withheld" }))
+      .toBeUndefined();
+    expect(harnessReleaseDecisionOf({})).toBeUndefined();
+  });
+
+  it("gives each reason code the decision it states", () => {
+    // Two of the four rejected and two did not, and the trace's `denied`,
+    // `warned` and `allowed` counts are read straight off this mapping — an
+    // observed measurement counted as a denial would report an enforcement
+    // that never happened.
+    expect(harnessReleaseDecisionOutcome("cfc_release_allowed"))
+      .toBe("allowed");
+    expect(harnessReleaseDecisionOutcome("cfc_release_observed"))
+      .toBe("warned");
+    expect(harnessReleaseDecisionOutcome("cfc_release_withheld"))
+      .toBe("denied");
+    expect(harnessReleaseDecisionOutcome("cfc_commit_refused"))
+      .toBe("denied");
+  });
+});

--- a/packages/cf-harness/test/run-pattern.test.ts
+++ b/packages/cf-harness/test/run-pattern.test.ts
@@ -1114,6 +1114,13 @@ describe("run-pattern", () => {
       expect(output.message).not.toContain("of:doc");
       expect(output.rawCauseMessage).toContain("of:doc");
       expect(output.pieceId).toBeDefined();
+      // The decision the run's policy trace carries: the commit boundary
+      // refused, and it states no sink or ceiling of its own, since the
+      // runner refused at the pattern's own sink requests.
+      expect(output.releaseDecision).toEqual({
+        reasonCode: "cfc_commit_refused",
+        boundary: "commit",
+      });
     });
 
     it("names the clause and the gate when the refused commit carried structured refusals", async () => {
@@ -1151,6 +1158,8 @@ describe("run-pattern", () => {
       // Document identifiers stay out of the model-facing message either way.
       expect(output.message).not.toContain("of:ledger");
       expect(output.rawCauseMessage).toContain("of:ledger");
+      expect(output.releaseDecision?.reasonCode).toBe("cfc_commit_refused");
+      expect(output.releaseDecision?.refusal).toEqual(output.policyRefusal);
     });
 
     it("returns an error naming the policy refusal when the answer carries a label the model may not read", async () => {
@@ -1533,6 +1542,15 @@ describe("run-pattern", () => {
         // the rung would refuse is recorded for whoever is staging it.
         expect(output.releaseObservation?.offendingAtoms).toEqual(['"secret"']);
         expect(output.releaseObservation?.inputKeys).toEqual(["source"]);
+        // The measurement said as a decision: it did not reject, and it
+        // carries the same attribution the observation does.
+        expect(output.releaseDecision).toEqual({
+          reasonCode: "cfc_release_observed",
+          boundary: "release",
+          sink: "run_pattern",
+          ceiling: [],
+          refusal: output.releaseObservation,
+        });
       } finally {
         await dispose();
       }
@@ -1569,6 +1587,15 @@ describe("run-pattern", () => {
         const output = result.output as RunPatternToolSuccessOutput;
         expect(output.status).toBe("ok");
         expect((output.value as { total: number }).total).toBe(3);
+        // The boundary ran and admitted the flow, which the trace records as
+        // readily as a refusal: an operator reading only refusals cannot tell
+        // a gate that passed from one that never ran.
+        expect(output.releaseDecision).toEqual({
+          reasonCode: "cfc_release_allowed",
+          boundary: "release",
+          sink: "run_pattern",
+          ceiling: [],
+        });
       } finally {
         await dispose();
       }
@@ -1658,6 +1685,9 @@ describe("run-pattern", () => {
         expect(output.valueError).toBeUndefined();
         expect(output.policyRefusal).toBeUndefined();
         expect(output.releaseObservation).toBeUndefined();
+        // Nothing was measured, so the trace records no decision about a
+        // boundary this call never reached.
+        expect(output.releaseDecision).toBeUndefined();
         // The result did derive from the labeled input: the reference names
         // exactly what the ceiling withholds as a value.
         expect((output.rawValue as { totalSpending: number }).totalSpending)
@@ -1703,8 +1733,67 @@ describe("run-pattern", () => {
         );
         expect(output.policyRefusal?.gates).toEqual(["sink-ceiling"]);
         expect(output.policyRefusal?.offendingAtoms).toEqual(['"finance"']);
+        expect(output.releaseDecision).toEqual({
+          reasonCode: "cfc_release_withheld",
+          boundary: "release",
+          sink: "run_pattern",
+          ceiling: [],
+          refusal: output.policyRefusal,
+        });
+        expect(output.releaseDecision?.refusal?.inputKeys).toEqual(["account"]);
         expect((output.rawValue as { totalSpending: number }).totalSpending)
           .toBe(145);
+      } finally {
+        await dispose();
+      }
+    });
+
+    it("keeps the withheld decision on a run that fails to settle after the fit", async () => {
+      // The fit runs before the result is read for its value, so a run that
+      // exits at a settle failure is a run the boundary already decided at.
+      // The decision is attached to that exit too: dropping it there would
+      // lose the trace's record of exactly the refusals a failing run
+      // provoked.
+      const { runtime, pieces, space, dispose } = await createStrictFabric();
+      try {
+        const sourceRef = await seedLabelledSecret(
+          runtime,
+          space,
+          "release-decision-settle-failure",
+        );
+        const result = await createStrictEngine(pieces).invokeBuiltinTool(
+          "run_pattern",
+          {
+            sourceText: [
+              "import { computed, pattern, Reactive } from 'commonfabric';",
+              "interface Source { secret: string; }",
+              "interface Input { amount: number; source: Reactive<Source>; }",
+              "interface Output { total: number; boom: number; }",
+              "export default pattern<Input, Output>(({ amount, source }) => ({",
+              "  total: computed(() => amount + (source.secret ?? '').length),",
+              "  boom: computed(() => { throw new Error('boom in lift'); }),",
+              "}));",
+              "",
+            ].join("\n"),
+            inputs: { amount: 2, source: sourceRef },
+            resultSchema: {
+              type: "object",
+              properties: {
+                total: { type: "number" },
+                boom: { type: "number" },
+              },
+              required: ["total", "boom"],
+            },
+          },
+        );
+        const output = result.output as RunPatternToolErrorOutput;
+        expect(output.status).toBe("error");
+        expect(output.message).toContain("failed while settling");
+        expect(output.releaseDecision?.reasonCode).toBe("cfc_release_withheld");
+        expect(output.releaseDecision?.refusal?.offendingAtoms).toEqual([
+          '"secret"',
+        ]);
+        expect(output.releaseDecision?.refusal?.inputKeys).toEqual(["source"]);
       } finally {
         await dispose();
       }


### PR DESCRIPTION
Every release-boundary decision `run_pattern` makes is now a decision in `policy-trace.json`, and AUD-16 reads refusals from there instead of from tool outputs.

## What lands

**One representation, shared.** `RunPatternPolicyRefusal` moves out of the tool into `src/contracts/policy-refusal.ts` as `HarnessPolicyRefusal`, beside `HarnessReleaseDecision` — the boundary (`commit`/`release`), the sink and ceiling the flow was fitted against, and the refusal with its attribution. `HarnessPolicyDecisionRecord` gains `release` (that shape) and `resultRef` (the existing `ToolResultRef`, as the tool activity already carries it, which is where the tool-output artifact path comes from). No harness-only record: a release decision is a policy-trace decision like every other, told apart from an authority decision by the `release` field rather than by reading a reason code for a shape it does not carry.

**Four reason codes**, added to the existing closed union: `cfc_release_allowed`, `cfc_release_observed` (an observe-posture measurement — a decision that did not reject, recorded as `warned`), `cfc_release_withheld`, `cfc_commit_refused`. None matches `modeOfReasonCode`'s mode families, so AUD-2 is unaffected.

**Where the decision is appended** — the question the prompt asked to be decided and documented. The tool writes the decision onto its own output (artifact-only, stripped model-side like `releaseObservation`); the prompt loop reads it back with `harnessReleaseDecisionOf` and appends it **after** the allow-side decision for the same call, once the output artifact is persisted and its `resultRef` exists. That order is the order the two were decided in: the allow-side decision answers whether the call may run and is recorded before it does, which is exactly why a refusal raised inside the tool could not appear in the trace at all. The reader is structural rather than keyed on `run_pattern`, so a release site the runner comes to own (the CT-2175 model-context sink resolver) writes the same two shapes and needs no new loop wiring.

**A call that asks for no values makes no decision** — nothing was measured, and a decision about a boundary nothing crossed would record an event that did not occur.

**AUD-16** counts `release` decisions that denied, and reports beside them the releases the same boundary measured and admitted — which is what tells a gate that passed from a gate that never ran. `inconclusive` now means the decisions could not be read from the trace, the run report, or the run state.

**AUD-4** skips a decision carrying a `release` record. A release refusal denied the *values*; the call completed and answered with a reference to the result it withheld, so there is no denied call for the typed deny channel to carry and no withheld observation for a message to leak. Without this the new denials would have failed AUD-4 on every run that had one.

## Assumptions stated rather than asked

- **No policy event is minted for a release refusal.** `classifyHarnessPolicyEventFailure` turns a `denied` event into a run failure record, which would make a successful run report as failed; and AUD-4's typed-deny half would still not apply, for the reason above. AH-CFC-11's event obligation for this boundary is left where the CT-2175 recommendation puts it — with the runner-side resolver that would raise it.
- **The output schema does not advertise `releaseDecision`**, matching `releaseObservation`, which the schema has never listed either: both are artifact-only.
- **AUD-16 is trace-only, not "trace or tool outputs."** A pre-fix corpus therefore reads as refusal-free (below). The issue asks for the decision channel; a reader that fell back to tool outputs would keep the two channels able to disagree.

## Verification

- `deno task test` in `packages/cf-harness`, unsandboxed: **947 passed, 0 failed**. `deno fmt --check`, `deno lint`, `deno task check`, `deno task check-docs` (599 blocks), `check-skill-facts` all green repo-wide. `packages/runner` is untouched.
- New: `test/run-pattern-policy-trace.test.ts` drives the prompt loop over a labelled input at an `enforce-strict` fabric and reads the persisted `policy-trace.json` — two decisions on the one `toolCallId`, allow-side first, then `denied`/`cfc_release_withheld` carrying `sink: "run_pattern"`, `ceiling: []`, `gates: ["sink-ceiling"]`, `inputKeys: ["source"]`, `attribution: "complete"`, and a `resultRef` naming the tool-output artifact.
- `test/run-pattern.test.ts` pins each decision kind on the tool's own output: allowed, observed (with the observation's attribution), withheld (with `inputKeys: ["account"]`), commit-refused in both its arms, and absent where no `resultSchema` asked for values.
- `audit/test/deployment.test.ts`: the AUD-16 fixtures now seed the refusal **only** into the policy trace and leave the fixture's tool outputs alone, so the count of one is a count of the trace.

### The CT-2190 run family `06839f48-c4e8-4273-8c12-4a5a80fd3ab9`

Copied to `$TMPDIR` from the `env_z45ir4sefi` checkout and audited with `deno task cfc-audit <runs> --corpus`. That family predates this change: its child holds one release refusal in `tool-outputs/…_run_pattern_14-run_pattern.json` (`sink-ceiling`, `run_pattern`, `"finance"`, `inputKeys: ["account"]`), and its two policy traces hold 20 decisions, all `allowed`, with the word "sink" in neither file.

- **What AUD-16 reports on it now:** `warn` — *"no run of this corpus recorded a release refusal, so the corpus shows the machinery loaded and never shows it deciding"*, with `0 release refusals across 2 runs`; `fail` under `--expect-refusals`. The refusal in the tool output is no longer counted, which is the intended consequence of moving the channel.
- **What it will report once a run is recorded under the fix:** I appended, by hand, the decision the fixed code would have written for that same call (derived mechanically from the tool output beside it) to a copy of the child's trace. AUD-16 then reads *"1 release refusal across 2 runs, refused by sink-ceiling, weakened by 2 runs recording `not-attested` and 2 runs `permissive-if-absent`"*, evidence `policy-trace.json decisions[].release`. Every other check keeps its verdict — the corpus totals are identical either way (29 checks, FAIL 0, WARN 4, INCONCLUSIVE 3, N/A 4, PASS 18), so AUD-3 and AUD-4 are unmoved by the extra denied decision. The live re-run is the supervisor's.

## Docs

README's AUD-16 row, "What AUD-16 reads", and the `run_pattern` release section (what the trace now records and where it is appended). No `IMPLEMENTATION_PROFILE.md` deviation closes — deviation 6 is about side effects gated on authority rather than flow, which is unchanged. System map, under the lockstep rule: the audit node body, the checker node, t8's plan and body, the artifacts close list, the "Prove it" and hostile-skill walk steps, and the "what is still open" list; t8 moves from `upcoming` to `guarded`; `SNAPSHOT` bumped to `2026-09-03 / c5a138a11b`. Data tables only — no coordinate moved.

**Visual check**: headless Chrome via `@astral/astral` at 1440×900 against `python3 -m http.server 8765 --bind 127.0.0.1`, unsandboxed; no screenshot committed. The map renders with zero page console errors, the stamp reads `snapshot 2026-09-03 · labs c5a138a11b`, and clicking threat 8 opens it as a green "guarded by CFC" hexagon with the new body and its `WHERE` links (Runner, CFC kernel, Run artifacts, CFC audit checker, Value release gate) intact. Nothing collides or overlaps: the only geometry-adjacent change is one threat's status color.

## Concurrency

CT-2205 (child runs inheriting the parent's posture record) is in flight in another thread over `src/engine.ts`, subagent construction, and audit test seeds. This change touches `engine.ts` not at all; the overlap is `audit/test/deployment.test.ts`, where it edits only the AUD-16 block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6801?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

