### PR TITLE
feat(memory): the connection state a client already decides

### DIFF
--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -199,10 +199,11 @@ Still to come:
   ([`runtime-integration.md`](runtime-integration.md)), so B1 proves that
   rather than rebuilding it — a test that drops the transport under a
   standing watch and shows the subscription still delivering afterwards.
-  What B1 does build is the relay that carries those up, reporting live,
-  reconnecting, and permanently failed, because the storage layer
-  publishes no connection state today and both the prompt and the view
-  markers consume it. No retry loop in shuttle on either half.
+  What B1 does build is the relay that carries the memory client's
+  connection state up, reporting it as live, reconnecting, and permanently
+  failed, because the storage layer publishes none today and both the
+  prompt and the view markers consume it. No retry loop in shuttle on
+  either half.
 
 **B2 — writes, calls, handles** (after A2, A3, and A4 — a failed call or
 write must surface as a value, never reach `Deno.exit`). `set` with

--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -199,10 +199,10 @@ Still to come:
   ([`runtime-integration.md`](runtime-integration.md)), so B1 proves that
   rather than rebuilding it — a test that drops the transport under a
   standing watch and shows the subscription still delivering afterwards.
-  What B1 does build is the observation seam, reporting live,
-  reconnecting, and permanently failed, because no such surface exists
-  today and both the prompt and the view markers consume it. No retry loop
-  in shuttle on either half.
+  What B1 does build is the relay that carries those up, reporting live,
+  reconnecting, and permanently failed, because the storage layer
+  publishes no connection state today and both the prompt and the view
+  markers consume it. No retry loop in shuttle on either half.
 
 **B2 — writes, calls, handles** (after A2, A3, and A4 — a failed call or
 write must surface as a value, never reach `Deno.exit`). `set` with

--- a/docs/plans/shuttle/runtime-integration.md
+++ b/docs/plans/shuttle/runtime-integration.md
@@ -101,16 +101,21 @@ the storage layer reports it:
   state a consumer can read, and it is a per-space poll for permanent
   denial. Its own documentation records a hole: a denial that arrives during
   reconnect is visible only as the session's `closeError`.
-- Nothing exposes "reconnecting" at all. `Client.#reconnecting`,
-  `#connected`, and `#fatalError` are private with no accessor, and
-  `#onClose` swallows the reconnect promise, so a consumer cannot tell quiet
-  because nothing changed from quiet because the socket is down and backoff
-  has reached its thirty-second cap.
+- The memory client reports its own connection state.
+  `Client.connectionState` names which state it is in, and
+  `Client.whenStateChanged()` resolves on the next transition, so a consumer
+  of the client waits on a change rather than polling for one. That surface
+  stops where `isConnected()` does: the storage layer reads neither member,
+  so a consumer above it still cannot tell quiet because nothing changed
+  from quiet because the socket is down and backoff has reached its
+  thirty-second cap.
 
-So the liveness work is an **observation seam**, added where the state
-already lives, reporting live, reconnecting, and permanently failed. That is
-what B1 owes, and the three states are what the prompt and the view markers
-render.
+So the liveness work is a **relay**: carrying the state the memory client
+already reports up through the storage layer to a consumer, as live,
+reconnecting, and permanently failed. That is what B1 owes, and those three
+are what the prompt and the view markers render. The client's own vocabulary
+is wider — it separates a closed client from a failed one — so the relay
+decides what to collapse.
 
 ## Watch mechanics
 

--- a/docs/plans/shuttle/runtime-integration.md
+++ b/docs/plans/shuttle/runtime-integration.md
@@ -103,8 +103,8 @@ the storage layer reports it:
   reconnect is visible only as the session's `closeError`.
 - The memory client reports its own connection state.
   `Client.connectionState` names which state it is in, and
-  `Client.whenStateChanged()` resolves on the next transition, so a consumer
-  of the client waits on a change rather than polling for one. That surface
+  `Client.whenStateChanged()` resolves the next time the client settles it,
+  so a consumer of the client waits rather than polling. That surface
   stops where `isConnected()` does: the storage layer reads neither member,
   so a consumer above it still cannot tell quiet because nothing changed
   from quiet because the socket is down and backoff has reached its

--- a/docs/plans/shuttle/views.md
+++ b/docs/plans/shuttle/views.md
@@ -127,7 +127,7 @@ first work item, made in `packages/cli` where the substrate lives.
   be scope-aware end to end before the raw path can serve an overlay.
 - Guard-plus-`idle()` settling, per `renderVDomToHtml`'s form.
 - The connection's state is visible in the frame (`● live`, cold banner,
-  or a reconnecting marker), read from the observation seam B1 builds —
+  or a reconnecting marker), read from the relay B1 builds —
   the storage layer publishes no connection state today
   ([`runtime-integration.md`](runtime-integration.md)). On reconnect the
   memory client re-arms the watch itself, so the view resyncs and repaints

--- a/packages/memory/test/v2-client-connection-state.test.ts
+++ b/packages/memory/test/v2-client-connection-state.test.ts
@@ -38,6 +38,16 @@ const openOk = (requestId: string): FabricValue => ({
   },
 });
 
+const retriableDenial = (requestId: string): FabricValue => ({
+  type: "response",
+  requestId,
+  error: {
+    name: "AuthorizationError",
+    message: "memory session.open challenge expired",
+    retriable: true,
+  },
+});
+
 /** What a reconnect's `hello` receives, which is what decides whether that
  *  reconnect completes, stalls, or is given up on. */
 type ReconnectHello = "ok" | "mismatch" | "silence";
@@ -52,9 +62,14 @@ class SeverableTransport implements Transport {
   /** Runs at the top of each `session.open`, the mount's included. */
   onSessionOpen: () => void = () => {};
 
+  /** Whether to deny the reopen a reconnect performs, retriably. The mount's
+   *  own open is always answered, so a test reaches this by severing. */
+  denyReopen = false;
+
   #receiver: (payload: string) => void = () => {};
   #closeReceiver: (error?: Error) => void = () => {};
   #helloCount = 0;
+  #openCount = 0;
   readonly #reconnectHello: ReconnectHello;
 
   constructor(reconnectHello: ReconnectHello) {
@@ -86,8 +101,13 @@ class SeverableTransport implements Transport {
         this.#respondToHello();
         return Promise.resolve();
       case "session.open":
+        this.#openCount += 1;
         this.onSessionOpen();
-        this.#respond(openOk(message.requestId!));
+        this.#respond(
+          this.denyReopen && this.#openCount > 1
+            ? retriableDenial(message.requestId!)
+            : openOk(message.requestId!),
+        );
         return Promise.resolve();
       default:
         throw new Error(`Unhandled message: ${message.type}`);
@@ -203,6 +223,66 @@ describe("Client", () => {
         } finally {
           await client.close();
         }
+      });
+
+      it("moves back to `reconnecting` when reopening a session fails", async () => {
+        const { transport, client } = await connectSeverable("ok");
+        transport.denyReopen = true;
+
+        try {
+          const severed = client.whenStateChanged();
+          transport.sever();
+          await severed;
+
+          // The handshake succeeds, so the client is connected again before
+          // it reopens its sessions. The reopen is then denied for a reason a
+          // retry can change, which drops it back without a fresh close.
+          const reconnected = client.whenStateChanged();
+          await reconnected;
+          expect(client.connectionState).toBe("connected");
+
+          const lost = client.whenStateChanged();
+          await lost;
+
+          expect(client.connectionState).toBe("reconnecting");
+          expect(client.isConnected()).toBe(false);
+        } finally {
+          await client.close();
+        }
+      });
+
+      it("moves to `closed` when a failed client is closed", async () => {
+        const { transport, client } = await connectSeverable("mismatch");
+
+        const severed = client.whenStateChanged();
+        transport.sever();
+        await severed;
+        const gaveUp = client.whenStateChanged();
+        await gaveUp;
+        expect(client.connectionState).toBe("failed");
+
+        const closed = client.whenStateChanged();
+        await client.close();
+        await closed;
+
+        expect(client.connectionState).toBe("closed");
+      });
+
+      it("wakes a waiter on a closed client when it is closed again", async () => {
+        // The wakeup is unconditional rather than conditioned on the state
+        // having moved. Suppressing it would need a second copy of the state
+        // to compare against, and a notification missed at any write site
+        // would then leave that copy stale, turning a missed wakeup into a
+        // suppressed later one.
+
+        const { client } = await connectSeverable("ok");
+        await client.close();
+
+        const changed = client.whenStateChanged();
+        await client.close();
+        await changed;
+
+        expect(client.connectionState).toBe("closed");
       });
 
       it("moves to `closed` when the client is closed", async () => {

--- a/packages/memory/test/v2-client-connection-state.test.ts
+++ b/packages/memory/test/v2-client-connection-state.test.ts
@@ -1,0 +1,241 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import type { FabricValue } from "@commonfabric/data-model";
+import {
+  decodeMemoryBoundary,
+  encodeMemoryBoundary,
+  getMemoryProtocolFlags,
+  MEMORY_PROTOCOL,
+} from "../v2.ts";
+import { connect, type ConnectionState, type Transport } from "../v2/client.ts";
+
+const TEST_AUDIENCE = "did:key:z6Mk-connection-state-audience";
+
+const helloOk = (flags = getMemoryProtocolFlags()): FabricValue => ({
+  type: "hello.ok",
+  protocol: MEMORY_PROTOCOL,
+  flags,
+  sessionOpen: {
+    audience: TEST_AUDIENCE,
+    challenge: { value: "challenge:connection-state", expiresAt: 1_000_000 },
+  },
+});
+
+const openOk = (requestId: string): FabricValue => ({
+  type: "response",
+  requestId,
+  ok: {
+    sessionId: "session-A",
+    sessionToken: "token:session-A",
+    serverSeq: 0,
+    sessionOpen: {
+      audience: TEST_AUDIENCE,
+      challenge: {
+        value: `challenge:connection-state:${requestId}`,
+        expiresAt: 1_000_000,
+      },
+    },
+  },
+});
+
+/** What a reconnect's `hello` receives, which is what decides whether that
+ *  reconnect completes, stalls, or is given up on. */
+type ReconnectHello = "ok" | "mismatch" | "silence";
+
+/**
+ * A transport that answers the first `hello` compatibly and can be severed on
+ * demand, the way a lost socket severs a real one. Every `session.open` runs
+ * `onSessionOpen` before it is answered, so a test can read the client from
+ * inside the reopen that a completing reconnect performs.
+ */
+class SeverableTransport implements Transport {
+  /** Runs at the top of each `session.open`, the mount's included. */
+  onSessionOpen: () => void = () => {};
+
+  #receiver: (payload: string) => void = () => {};
+  #closeReceiver: (error?: Error) => void = () => {};
+  #helloCount = 0;
+  readonly #reconnectHello: ReconnectHello;
+
+  constructor(reconnectHello: ReconnectHello) {
+    this.#reconnectHello = reconnectHello;
+  }
+
+  setReceiver(receiver: (payload: string) => void): void {
+    this.#receiver = receiver;
+  }
+
+  setCloseReceiver(receiver: (error?: Error) => void): void {
+    this.#closeReceiver = receiver;
+  }
+
+  /** Drops the connection by firing the close receiver the client registered,
+   *  which is the same entry point a real transport's socket loss takes. */
+  sever(): void {
+    this.#closeReceiver(new Error("socket lost"));
+  }
+
+  send(payload: string): Promise<void> {
+    const message = decodeMemoryBoundary(payload) as {
+      type: string;
+      requestId?: string;
+    };
+    switch (message.type) {
+      case "hello":
+        this.#helloCount += 1;
+        this.#respondToHello();
+        return Promise.resolve();
+      case "session.open":
+        this.onSessionOpen();
+        this.#respond(openOk(message.requestId!));
+        return Promise.resolve();
+      default:
+        throw new Error(`Unhandled message: ${message.type}`);
+    }
+  }
+
+  close(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  #respondToHello(): void {
+    if (this.#helloCount === 1 || this.#reconnectHello === "ok") {
+      this.#respond(helloOk());
+      return;
+    }
+    if (this.#reconnectHello === "mismatch") {
+      const flags = getMemoryProtocolFlags();
+      this.#respond(helloOk({ ...flags, modernCellRep: !flags.modernCellRep }));
+    }
+    // "silence" answers nothing, leaving the reconnect in flight. `close()`
+    // still ends it: rejecting the pending hello unblocks the handshake, and
+    // the reconnect loop then sees the client closed and stops.
+  }
+
+  #respond(message: FabricValue): void {
+    this.#receiver(encodeMemoryBoundary(message));
+  }
+}
+
+const connectSeverable = async (reconnectHello: ReconnectHello) => {
+  const transport = new SeverableTransport(reconnectHello);
+  const client = await connect({ transport });
+  await client.mount("did:key:z6Mk-connection-state-space");
+  return { transport, client };
+};
+
+describe("Client", () => {
+  describe("instance members", () => {
+    describe("connectionState and whenStateChanged()", () => {
+      // Each case drives one transition and reads it back through both
+      // members: `whenStateChanged()` says when to look, `.connectionState`
+      // says what is there. Every wait here resolves on an event the client
+      // raises — a severed socket, a refused handshake, a `close()` — so
+      // nothing polls and nothing sleeps.
+      //
+      // Each waiter is registered before the transition it observes. That is
+      // how a caller uses it too: the loop in the doc comment reads the getter
+      // and calls `whenStateChanged()` in one synchronous step, with no chance
+      // for the state to move in between.
+
+      it("returns `connected` for a client whose transport is up", async () => {
+        const { client } = await connectSeverable("ok");
+
+        try {
+          expect(client.connectionState).toBe("connected");
+          expect(client.isConnected()).toBe(true);
+        } finally {
+          await client.close();
+        }
+      });
+
+      it("moves to `reconnecting` when the transport is severed", async () => {
+        const { transport, client } = await connectSeverable("silence");
+
+        try {
+          const changed = client.whenStateChanged();
+          transport.sever();
+          await changed;
+
+          expect(client.connectionState).toBe("reconnecting");
+          expect(client.isConnected()).toBe(false);
+        } finally {
+          await client.close();
+        }
+      });
+
+      it("moves back to `connected` when a reconnect succeeds", async () => {
+        const { transport, client } = await connectSeverable("ok");
+
+        try {
+          const severed = client.whenStateChanged();
+          transport.sever();
+          await severed;
+          expect(client.connectionState).toBe("reconnecting");
+
+          const restored = client.whenStateChanged();
+          await restored;
+
+          expect(client.connectionState).toBe("connected");
+          expect(client.isConnected()).toBe(true);
+        } finally {
+          await client.close();
+        }
+      });
+
+      it("moves to `failed` when the client gives up reconnecting", async () => {
+        const { transport, client } = await connectSeverable("mismatch");
+
+        try {
+          const severed = client.whenStateChanged();
+          transport.sever();
+          await severed;
+          expect(client.connectionState).toBe("reconnecting");
+
+          // The refused handshake is still travelling: its rejection was
+          // queued behind this waiter's wakeup, so registering the next waiter
+          // here happens before the client gives up.
+          const gaveUp = client.whenStateChanged();
+          await gaveUp;
+
+          expect(client.connectionState).toBe("failed");
+          expect(client.isConnected()).toBe(false);
+        } finally {
+          await client.close();
+        }
+      });
+
+      it("moves to `closed` when the client is closed", async () => {
+        const { client } = await connectSeverable("ok");
+        const changed = client.whenStateChanged();
+
+        await client.close();
+        await changed;
+
+        expect(client.connectionState).toBe("closed");
+        expect(client.isConnected()).toBe(false);
+      });
+
+      it("returns `connected` while a reconnect reopens its sessions", async () => {
+        const { transport, client } = await connectSeverable("ok");
+        const readings: ConnectionState[] = [];
+
+        try {
+          // The reopen runs after the reconnect's handshake has marked the
+          // client connected and before the reconnect itself has finished, so
+          // it is the one moment the two are true at once.
+          transport.onSessionOpen = () => {
+            readings.push(client.connectionState);
+          };
+          transport.sever();
+          await client.restoreConnection();
+
+          expect(readings).toEqual(["connected"]);
+          expect(client.isConnected()).toBe(true);
+        } finally {
+          await client.close();
+        }
+      });
+    });
+  });
+});

--- a/packages/memory/test/v2-client-connection-state.test.ts
+++ b/packages/memory/test/v2-client-connection-state.test.ts
@@ -16,7 +16,7 @@
  * promise nothing will resolve, and Deno fails the run on the drained event
  * loop with `Promise resolution is still pending but the event loop has
  * already resolved`, the transcript's last unfinished line naming the case.
- * Where a later transition resolves that waiter instead, the case fails on
+ * Where a later notification resolves that waiter instead, the case fails on
  * the state it then reads, as an ordinary value diff. Both land immediately:
  * nothing here waits out a timeout, so neither reads as a flake.
  */
@@ -170,13 +170,21 @@ const connectSeverable = async (reconnectHello: ReconnectHello) => {
 describe("Client", () => {
   describe("instance members", () => {
     describe("connectionState and whenStateChanged()", () => {
-      // Each case drives one notification and reads it back through both
-      // members: `whenStateChanged()` says when to look, `.connectionState`
-      // says what is there. Usually that notification carries a transition;
-      // the closed-client case is here because one of them does not. Every
-      // wait resolves on an event the client raises — a severed socket, a
-      // refused handshake, a `close()` — so nothing polls and nothing
-      // sleeps.
+      // `whenStateChanged()` says when to look and `.connectionState` says
+      // what is there, and most cases here use both, driving the client
+      // through one to three notifications and waiting on each in turn. Two
+      // use the getter alone, where what is under test is what it returns
+      // rather than when.
+      //
+      // A notification need not carry a transition. A second `close()`
+      // raises one that does not, and so does the reconnect loop's catch on
+      // a refused handshake, where the client is `reconnecting` both before
+      // the notification and after it. So a case asserts the state it reads
+      // on waking, never that a wakeup means a change.
+      //
+      // Every wait resolves on an event the client raises: a severed
+      // socket, a refused handshake or reopen, a `close()`. Nothing polls
+      // and nothing sleeps.
       //
       // Each waiter is registered before the notification it observes. That
       // is how a caller uses it too: the loop in the doc comment reads the
@@ -327,8 +335,10 @@ describe("Client", () => {
 
         try {
           // The reopen runs after the reconnect's handshake has marked the
-          // client connected and before the reconnect itself has finished, so
-          // it is the one moment the two are true at once.
+          // client connected and before the reconnect itself has finished.
+          // The window stays open until the `finally` clears `#reconnecting`
+          // a microtask after the loop returns; this hook is where a
+          // synchronous reader can catch it.
           transport.onSessionOpen = () => {
             readings.push(client.connectionState);
           };

--- a/packages/memory/test/v2-client-connection-state.test.ts
+++ b/packages/memory/test/v2-client-connection-state.test.ts
@@ -1,8 +1,10 @@
 /**
  * Covers the connection state `Client` reports and the promise it hands a
- * caller waiting for that state to move. The states are the branches
- * `#ensureConnected()` takes, and the getter is held here both to that order
- * and to agreement with `isConnected()`.
+ * caller waiting for the next report of it. The states are the branches
+ * `#ensureConnected()` takes, and the cases hold the getter to the part of
+ * that order a caller can observe — `#connected` ahead of the fall through
+ * to `reconnecting`, and `#closed` ahead of `#fatalError` — checking it
+ * against `isConnected()` where the two are meant to agree.
  *
  * The transport these cases run on can be severed on demand by firing the
  * close receiver the client registered, which is the entry point a lost

--- a/packages/memory/test/v2-client-connection-state.test.ts
+++ b/packages/memory/test/v2-client-connection-state.test.ts
@@ -1,3 +1,22 @@
+/**
+ * Covers the connection state `Client` reports and the promise it hands a
+ * caller waiting for that state to move. The states are the branches
+ * `#ensureConnected()` takes, and the getter is held here both to that order
+ * and to agreement with `isConnected()`.
+ *
+ * The transport these cases run on can be severed on demand by firing the
+ * close receiver the client registered, which is the entry point a lost
+ * socket takes. Each transition is therefore observed as it happens rather
+ * than waited out: nothing polls and nothing sleeps.
+ *
+ * What that costs is worth knowing before reading a failure here. A
+ * transition the client makes without notifying leaves a case awaiting a
+ * promise that never resolves, so the suite hangs rather than failing an
+ * assertion. With no timeout in the wait there is nothing to cut it short and
+ * call it a miss, which makes the hang the honest signal: it is evidence of a
+ * missing notification, not a flake.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import type { FabricValue } from "@commonfabric/data-model";

--- a/packages/memory/test/v2-client-connection-state.test.ts
+++ b/packages/memory/test/v2-client-connection-state.test.ts
@@ -170,16 +170,18 @@ const connectSeverable = async (reconnectHello: ReconnectHello) => {
 describe("Client", () => {
   describe("instance members", () => {
     describe("connectionState and whenStateChanged()", () => {
-      // Each case drives one transition and reads it back through both
+      // Each case drives one notification and reads it back through both
       // members: `whenStateChanged()` says when to look, `.connectionState`
-      // says what is there. Every wait here resolves on an event the client
-      // raises — a severed socket, a refused handshake, a `close()` — so
-      // nothing polls and nothing sleeps.
+      // says what is there. Usually that notification carries a transition;
+      // the closed-client case is here because one of them does not. Every
+      // wait resolves on an event the client raises — a severed socket, a
+      // refused handshake, a `close()` — so nothing polls and nothing
+      // sleeps.
       //
-      // Each waiter is registered before the transition it observes. That is
-      // how a caller uses it too: the loop in the doc comment reads the getter
-      // and calls `whenStateChanged()` in one synchronous step, with no chance
-      // for the state to move in between.
+      // Each waiter is registered before the notification it observes. That
+      // is how a caller uses it too: the loop in the doc comment reads the
+      // getter and calls `whenStateChanged()` in one synchronous step, with
+      // no chance for the state to move in between.
 
       it("returns `connected` for a client whose transport is up", async () => {
         const { client } = await connectSeverable("ok");

--- a/packages/memory/test/v2-client-connection-state.test.ts
+++ b/packages/memory/test/v2-client-connection-state.test.ts
@@ -9,12 +9,14 @@
  * socket takes. Each transition is therefore observed as it happens rather
  * than waited out: nothing polls and nothing sleeps.
  *
- * What that costs is worth knowing before reading a failure here. A
+ * How a failure here reads is worth knowing before debugging one. A
  * transition the client makes without notifying leaves a case awaiting a
- * promise that never resolves, so the suite hangs rather than failing an
- * assertion. With no timeout in the wait there is nothing to cut it short and
- * call it a miss, which makes the hang the honest signal: it is evidence of a
- * missing notification, not a flake.
+ * promise nothing will resolve, and Deno fails the run on the drained event
+ * loop with `Promise resolution is still pending but the event loop has
+ * already resolved`, the transcript's last unfinished line naming the case.
+ * Where a later transition resolves that waiter instead, the case fails on
+ * the state it then reads, as an ordinary value diff. Both land immediately:
+ * nothing here waits out a timeout, so neither reads as a flake.
  */
 
 import { describe, it } from "@std/testing/bdd";

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -205,11 +205,11 @@ export class Client {
   #fatalError: Error | null = null;
 
   /**
-   * The promise handed to every current `whenStateChanged()` caller, or
-   * `null` when nobody is waiting. One promise is shared by all waiters, and
-   * clearing it as the client notifies is what makes a waiter that
-   * re-registers wait for the next notification rather than see again the
-   * one it has just observed.
+   * The resolvers for the promise `whenStateChanged()` hands out, or `null`
+   * when nobody has called since the last notification. One set serves every
+   * caller waiting on the same notification, and clearing it as the client
+   * notifies is what makes a caller that registers again wait for the next
+   * one rather than see the notification it has just observed.
    */
   #stateChanged: PromiseWithResolvers<void> | null = null;
 

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -206,9 +206,10 @@ export class Client {
 
   /**
    * The promise handed to every current `whenStateChanged()` caller, or
-   * `null` when nobody is waiting. One promise is shared by all waiters and
-   * replaced on each change, so a waiter that re-registers gets the next
-   * transition rather than the one it has just observed.
+   * `null` when nobody is waiting. One promise is shared by all waiters, and
+   * clearing it as the client notifies is what makes a waiter that
+   * re-registers wait for the next notification rather than see again the
+   * one it has just observed.
    */
   #stateChanged: PromiseWithResolvers<void> | null = null;
 

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -426,9 +426,11 @@ export class Client {
    * A wakeup carrying no change is harmless for the same reason: the loop
    * re-tests and waits again. Calling `close()` on a closed client is one.
    *
-   * The bound on it: `failed` and `closed` are terminal, so once the client
-   * reaches either, this never resolves and a loop of the shape above never
-   * leaves. Test for those states rather than waiting through them.
+   * The bound on it: `closed` is the one state nothing follows. Closing an
+   * already-closed client still wakes a waiter, which reads `closed` again,
+   * so a loop waiting for any other state never leaves. `failed` is left
+   * only by `close()`, never by a reconnect. Test for both rather than
+   * waiting through them.
    */
   whenStateChanged(): Promise<void> {
     this.#stateChanged ??= Promise.withResolvers<void>();
@@ -650,6 +652,7 @@ export class Client {
           return;
         } catch (error) {
           this.#connected = false;
+          this.#noteStateChange();
           const err = error instanceof Error ? error : new Error(String(error));
           if (isPermanentConnectionFailure(err)) {
             // A handshake the server refuses identically every time (a

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -387,11 +387,16 @@ export class Client {
 
   /**
    * The state this client is in now, decided in the branch order
-   * `#ensureConnected()` uses so that `connected` here means what
-   * `isConnected()` means. The order is what makes them agree across the
+   * `#ensureConnected()` uses. Reading `#connected` before falling through to
+   * `reconnecting` is what makes this agree with `isConnected()` across the
    * window a successful reconnect opens, where the handshake has already
    * marked the client connected while the reconnect it belongs to is still in
-   * flight: both read `#connected` first, and so both call the transport up.
+   * flight.
+   *
+   * The agreement stops there rather than holding in general. A `close()`
+   * landing while a handshake continuation is queued leaves `#connected` true
+   * under `#closed`, and this reports `closed` where `isConnected()` reports
+   * `true`. Where they differ, this is the accurate one.
    */
   get connectionState(): ConnectionState {
     if (this.#closed) return "closed";
@@ -662,9 +667,11 @@ export class Client {
             // Redundant today: the notification at the top of this catch
             // has already woken every waiter, and none of them resumes
             // until this block finishes, so each reads the state this
-            // line settles. It stays because every write to a state
-            // field notifies for its own write, which is what lets the
-            // set of those writes be checked rather than reasoned about.
+            // line settles. It stays because no write to a field
+            // `.connectionState` reads leaves its block without a
+            // notification covering it, and that rule is what lets the
+            // write sites be checked rather than reasoned about one by
+            // one.
             this.#noteStateChange();
             this.#rejectPending(err);
             return;

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -64,6 +64,18 @@ export type ConnectOptions = {
   signal?: AbortSignal;
 };
 
+/**
+ * The connection states a `Client` distinguishes, one member per branch of
+ * its `#ensureConnected()` guard — the decision every request passes through,
+ * which reads the same fields to settle whether to proceed, to reconnect, or
+ * to throw. A branch added to that guard is a member owed here.
+ */
+export type ConnectionState =
+  | "connected"
+  | "reconnecting"
+  | "failed"
+  | "closed";
+
 export type MountOptions = {
   sessionId?: string;
   seenSeq?: number;
@@ -192,6 +204,14 @@ export class Client {
   // for other spaces on this client alive.
   #fatalError: Error | null = null;
 
+  /**
+   * The promise handed to every current `whenStateChanged()` caller, or
+   * `null` when nobody is waiting. One promise is shared by all waiters and
+   * replaced on each change, so a waiter that re-registers gets the next
+   * transition rather than the one it has just observed.
+   */
+  #stateChanged: PromiseWithResolvers<void> | null = null;
+
   readonly #transport: Transport;
 
   private constructor(
@@ -235,6 +255,7 @@ export class Client {
   async close(): Promise<void> {
     this.#closed = true;
     this.#connected = false;
+    this.#noteStateChange();
     this.#cancelReconnectDelay?.();
     this.#rejectPending(new Error("memory client closed"));
     await Promise.all([...this.#spaces].map((space) => space.close()));
@@ -364,6 +385,56 @@ export class Client {
     return this.#connected;
   }
 
+  /**
+   * The state this client is in now, decided in the branch order
+   * `#ensureConnected()` uses so that `connected` here means what
+   * `isConnected()` means. The order is what makes them agree across the
+   * window a successful reconnect opens, where the handshake has already
+   * marked the client connected while the reconnect it belongs to is still in
+   * flight: both read `#connected` first, and so both call the transport up.
+   */
+  get connectionState(): ConnectionState {
+    if (this.#closed) return "closed";
+    if (this.#fatalError) return "failed";
+    if (this.#connected) return "connected";
+    return "reconnecting";
+  }
+
+  /**
+   * Resolves when `.connectionState` next changes, so that a caller waits on
+   * a transition without registering and removing a listener:
+   *
+   * ```js
+   * while (client.connectionState !== desired) {
+   *   await client.whenStateChanged();
+   * }
+   * ```
+   *
+   * That loop reads the getter and calls this in one synchronous step, which
+   * is what stops a transition slipping between the two. A caller that awaits
+   * anything else in between can miss one.
+   *
+   * It yields no value, deliberately: the state can change again between the
+   * resolution and the caller resuming, so anything handed over would be
+   * stale by construction. Losing a socket shows it concretely. `#onClose()`
+   * marks the client disconnected and arms the reconnect a few statements
+   * later, and a waiter resumes on a microtask, after both — so re-reading
+   * the getter yields `reconnecting`, true at the moment it is read, where a
+   * value captured at the transition would report a disconnection that was
+   * never observable for a whole turn.
+   *
+   * A wakeup carrying no change is harmless for the same reason: the loop
+   * re-tests and waits again. Calling `close()` on a closed client is one.
+   *
+   * The bound on it: `failed` and `closed` are terminal, so once the client
+   * reaches either, this never resolves and a loop of the shape above never
+   * leaves. Test for those states rather than waiting through them.
+   */
+  whenStateChanged(): Promise<void> {
+    this.#stateChanged ??= Promise.withResolvers<void>();
+    return this.#stateChanged.promise;
+  }
+
   sessionOpenAuthContext(): SessionOpenAuthContext {
     if (this.#sessionOpenAuthContext === null) {
       const error = new Error(
@@ -402,6 +473,7 @@ export class Client {
         ack.promise,
       ]);
       this.#connected = true;
+      this.#noteStateChange();
     } finally {
       this.#helloPending = null;
     }
@@ -549,6 +621,7 @@ export class Client {
       return;
     }
     this.#connected = false;
+    this.#noteStateChange();
     for (const session of this.#spaces) {
       session.handleDisconnect();
     }
@@ -583,6 +656,7 @@ export class Client {
             // protocol-flag mismatch). Stop looping and remember the failure so
             // every present and future request fails fast with it.
             this.#fatalError = err;
+            this.#noteStateChange();
             this.#rejectPending(err);
             return;
           }
@@ -620,6 +694,18 @@ export class Client {
         resolve();
       };
     });
+  }
+
+  /**
+   * Wakes every caller waiting on `whenStateChanged()`. Runs after a write
+   * that can move `.connectionState`, including one that leaves it where it
+   * was: a wakeup with nothing behind it costs a waiter one re-read, which is
+   * the loop it is already in.
+   */
+  #noteStateChange(): void {
+    const waiting = this.#stateChanged;
+    this.#stateChanged = null;
+    waiting?.resolve();
   }
 
   #rejectPending(error: Error): void {

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -659,6 +659,12 @@ export class Client {
             // protocol-flag mismatch). Stop looping and remember the failure so
             // every present and future request fails fast with it.
             this.#fatalError = err;
+            // Redundant today: the notification at the top of this catch
+            // has already woken every waiter, and none of them resumes
+            // until this block finishes, so each reads the state this
+            // line settles. It stays because every write to a state
+            // field notifies for its own write, which is what lets the
+            // set of those writes be checked rather than reasoned about.
             this.#noteStateChange();
             this.#rejectPending(err);
             return;

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -406,8 +406,9 @@ export class Client {
   }
 
   /**
-   * Resolves when `.connectionState` next changes, so that a caller waits on
-   * a transition without registering and removing a listener:
+   * Resolves the next time the client settles its connection state, which is
+   * usually a change to `.connectionState` and sometimes is not. A caller
+   * waits on that instead of registering and removing a listener:
    *
    * ```js
    * while (client.connectionState !== desired) {
@@ -416,17 +417,16 @@ export class Client {
    * ```
    *
    * That loop reads the getter and calls this in one synchronous step, which
-   * is what stops a transition slipping between the two. A caller that awaits
+   * is what stops a change slipping between the two. A caller that awaits
    * anything else in between can miss one.
    *
-   * It yields no value, deliberately: the state can change again between the
+   * It yields no value, deliberately: the state can move again between the
    * resolution and the caller resuming, so anything handed over would be
-   * stale by construction. Losing a socket shows it concretely. `#onClose()`
-   * marks the client disconnected and arms the reconnect a few statements
-   * later, and a waiter resumes on a microtask, after both — so re-reading
-   * the getter yields `reconnecting`, true at the moment it is read, where a
-   * value captured at the transition would report a disconnection that was
-   * never observable for a whole turn.
+   * stale by construction. Giving up on a reconnect shows it concretely. The
+   * reconnect loop's catch settles on `reconnecting` and notifies, then
+   * records a permanent failure in the same synchronous block, so a waiter
+   * resuming on a microtask reads `failed` — the state when it looks, not
+   * the one that held when it was woken.
    *
    * A wakeup carrying no change is harmless for the same reason: the loop
    * re-tests and waits again. Calling `close()` on a closed client is one.


### PR DESCRIPTION
## Why

`Client` tracks four connection conditions and exposes one boolean, so a consumer
cannot tell "reconnecting" from "permanently failed" from "closed". Those call for
different behaviour — one is transient and worth indicating, one is terminal with a
reason, one is terminal and expected — and today they render identically.

Closes #6782, which @danfuzz reviewed and recommended the shape for.

**Four states, not the three the issue named.** `#ensureConnected()` already
branches on `#closed` → throws "memory client is closed", `#fatalError` → throws the
protocol error, `#connected` → returns, else → reconnect. The enum mirrors that guard
rather than inventing a set, and the doc names the guard as its source rather than
writing the number down. The issue as filed missed `#closed`, which `close()` sets
while leaving `#fatalError` null; that correction is recorded on the issue.

## What Changed

**`packages/memory/v2/client.ts`** — additive only. 89 insertions, **zero deletions**;
`isConnected()` and every existing signature are byte-identical, and no caller gains
an obligation.

- `ConnectionState` and a `connectionState` getter, in `#ensureConnected()`'s branch
  order — so it agrees with `isConnected()` across the reconnect window, where
  `#hello()` sets `#connected` true while `#reconnecting` is still non-null.
- `whenStateChanged(): Promise<void>`, so a consumer waits rather than polls. It
  resolves with **`void` deliberately**: the state may move again before the caller's
  continuation runs, so a returned value would be stale by construction. The doc
  carries the worked case rather than the abstract rule.
- A notification at every write to a field the getter reads. The rule is that no such
  write leaves its block without a notification covering it — which is what lets the
  write sites be checked rather than reasoned about one at a time.

**`packages/memory/test/v2-client-connection-state.test.ts`** — 9 cases over a
severable transport, reusing the close receiver `v2-client-reconnect-auth.test.ts`
already registers rather than forking a mechanism. Every transition is observed as it
happens: no sleep, no poll, no timeout.

**Documentation.** Three shuttle plan documents said B1 *builds* an observation seam.
The client now reports its own state, so they say what B1 owes instead: the storage
layer relays neither member, which is the half still outstanding.

## Test plan

- `deno fmt --check`, `deno lint`, `deno task check`, `deno task check-docs`,
  `deno task check-no-waitfor` — green.
- `deno task test` in `packages/memory` — 596 passed, 0 failed.
- Coverage: neutral. An earlier "−3" was withdrawn as run-to-run noise on a
  race-dependent path, after both sides measured on byte-identical trees. The direct
  claim holds instead: none of the added lines appears in the uncovered set.
- Ten mutations, each named against the cases it reds — including one per notification
  site, so removing any single notification fails a case that names the transition it
  drops.

## For the owner

This implements a decision made while @seefeldb was away, in his subsystem. The issue
records the four-state ruling, the reasoning, and two corrections to my original
filing — a missed fourth state, and a false claim that no prior art existed for
severing a transport under test. It is his to redirect.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6803?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

