### PR TITLE
An author can ask the documentation a question (CT-2173)

### DIFF
--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -143,6 +143,10 @@ What works today:
     registry and a Fabric session are configured; resolves a discovery id to a
     full GitHub commit, checks the complete recursive tree, and returns a handle
     or a first-class refusal, never skill text)
+  - `query_docs` (present when the run resolves a documentation corpus; asks one
+    question of operator-provisioned reference material and returns a bounded
+    answer plus inert citations, never the documents; see
+    [Querying the documentation corpus](#querying-the-documentation-corpus))
 - composing published patterns: source the model authors may
   `import Sub from "cf:pattern:<patternId>"`, and `run_pattern` fetches and
   compiles each named pattern into the space before compiling the source that
@@ -166,7 +170,8 @@ What works today:
   event persistence
 - single-child subagent delegation with fresh child prompt context, explicit
   default/browser/web_fetch/web_search/pattern-author child profiles, retained
-  child run references, and a sanitized summary/state return channel
+  child run references, and a sanitized summary/state return channel, plus the
+  internal `explore` profile `query_docs` runs, which a delegation cannot name
 - optional schema-validated subagent structured returns, with raw child return
   artifacts retained in the child run and open-ended strings linkified before
   the parent sees them
@@ -1107,6 +1112,52 @@ channels of one conceptual kind: an id names hashed information stored
 somewhere, attached metadata accompanies it, and trusted-side code resolves it.
 They deliberately remain separate until experience supplies a concrete reason to
 unify them.
+
+### Querying the documentation corpus
+
+`query_docs` takes one question and returns a short answer with the sections it
+came from. It is on the parent surface and on the `pattern-author` child's,
+which is where it matters: that child has no `delegate_task` and the subagent
+manifest pins the depth at one, so an explore agent is a tool on its surface or
+it is unreachable from the one context that needs it.
+
+The corpus is Markdown split at headings into sections, read on the host from
+the roots the run resolved and never through the sandbox mount. Configure them
+with a repeatable `--docs-corpus-root <path>`. A run that names none and is
+running out of a labs checkout defaults to that checkout's `docs/common`,
+`docs/development`, and `skills`, so a console started with no documentation
+configuration is not documentation-blind. Either way the resolved roots and
+where they came from are recorded in `run-state.json` under `docsCorpus` and
+printed in operator output as a `docsCorpus:` line; a run that resolved none
+says so on that line, and `query_docs` is absent from its tool surface.
+
+Every section the loader admits carries an integrity endorsement — a `Resource`
+atom of class `CommonFabricHarnessOperatorProvisionedReference` whose subject is
+the root it was read under, minted from the operator's own configuration and
+never from the read bytes. Only an endorsed section is eligible for an answer,
+so text written into the workspace by an earlier child is not corpus and cannot
+reach one. Operator-provisioned documentation is trusted for confidentiality —
+we mount it, and it carries no secret — and endorsed for integrity provenance,
+which is what lets a reader of a run tell reference material apart from
+workspace text rather than trusting the mount.
+
+The answer is produced by the `explore` profile: a cheap model with no tools at
+all, one turn, handed the selected sections and nothing else. It is one model
+call rather than a child run, so no subagent is spawned and the depth-one
+invariant is untouched; the call is recorded like every other, as a model
+attempt in the run report and with its tokens in the run's descendant usage.
+What was sent — the model, the question, each section by path and heading with
+the endorsement atoms it carries, and the two messages verbatim — is kept on the
+tool-output artifact under the call's output id as `exploreRecord`, and stripped
+before the answer reaches the caller.
+
+A citation is a path and a heading. It carries no text and no handle, so
+following one is a separate `read_file`. A citation naming a section the corpus
+does not hold is dropped rather than returned.
+
+Not built yet: the optional `fullTextRef`, a capability-scoped handle over the
+retrieved text minted by the route `acquire_skill` uses, and any policy that
+would declassify it.
 
 ### Running patterns against a Fabric space
 

--- a/packages/cf-harness/docs/CURRENT_STATE.md
+++ b/packages/cf-harness/docs/CURRENT_STATE.md
@@ -49,7 +49,27 @@ The current package provides:
 - sandboxed shell, file, image, web-fetch, skills, edit/write, and delegation
   tools;
 - one child at a time through `default`, `browser`, `web_fetch`, `web_search`,
-  and `pattern-author` profiles;
+  and `pattern-author` profiles, beside the internal `explore` profile that
+  `query_docs` runs and no delegation may name;
+- documentation a child can look something up in: `query_docs` takes one
+  question, selects the matching sections of the operator-provisioned corpus on
+  the host, and returns a bounded answer with inert path-and-heading citations.
+  A run configures the corpus with a repeatable `--docs-corpus-root`, and a run
+  out of a labs checkout that names none defaults to that checkout's
+  `docs/common`, `docs/development`, and `skills`; the resolved roots and their
+  source are recorded in run state and printed in operator output, and a run
+  that resolves none does not offer the tool. Every admitted section carries a
+  `Resource` integrity endorsement of class
+  `CommonFabricHarnessOperatorProvisionedReference` naming the root it was read
+  under, and only an endorsed section is eligible for an answer, so workspace
+  text cannot reach one. The answer comes from one model call under a profile
+  with no tools, recorded as a model attempt with its tokens in descendant
+  usage, and what was sent is kept on the tool-output artifact and stripped
+  before the caller sees it. That call carries no declaration ceiling and runs
+  no boundary policy evaluation, so it sits outside the posture's caveat policy:
+  the corpus is trusted for confidentiality, which is what makes a sink with no
+  ceiling the right shape for it and also the whole of what holds it — the
+  endorsement is an integrity claim and gates nothing on the way out;
 - schema-validated, sanitized child returns with raw child evidence retained
   outside the ordinary parent return channel;
 - image inputs and structured top-level batch results;

--- a/packages/cf-harness/docs/IMPLEMENTATION_PROFILE.md
+++ b/packages/cf-harness/docs/IMPLEMENTATION_PROFILE.md
@@ -203,19 +203,20 @@ readiness.
 Current selectable parent tools are `bash`, `read_file`, `view_image`,
 `web_fetch`, `read_skill_resource`, `run_skill_script`, `edit_file`,
 `write_file`, `delegate_task`, `describe_handle`, `run_pattern`, `assign_slug`,
-`search_patterns`, `record_feedback`, `search_skills`, and `acquire_skill`.
-Individual runs receive only their configured subset; `web_fetch` and
-`run_skill_script` are not in the ordinary default surface. The last five are
-gated on the backing a run can supply — a fabric session for `run_pattern`,
+`search_patterns`, `record_feedback`, `search_skills`, `acquire_skill`, and
+`query_docs`. Individual runs receive only their configured subset; `web_fetch`
+and `run_skill_script` are not in the ordinary default surface. The last seven
+are gated on the backing a run can supply — a fabric session for `run_pattern`,
 `assign_slug`, and `acquire_skill`, the pattern index for `search_patterns` and
-`record_feedback`, and configured skills.sh discovery for `search_skills` — and
-a tool the run cannot back is absent from the surface rather than present and
-failing, so an explicit allowlist naming it does not conjure it. `run_pattern`
-additionally requires the three `--fabric-*` session flags. `browser` exists
-only as a built-in used by the authorized browser child profile and cannot be
-selected as a parent CLI tool; it drives the host `agent-browser` CLI through a
-typed action vocabulary, with the Browser Access CDP endpoint attached by the
-harness rather than written by the model.
+`record_feedback`, configured skills.sh discovery for `search_skills`, and a
+resolved documentation corpus for `query_docs` — and a tool the run cannot back
+is absent from the surface rather than present and failing, so an explicit
+allowlist naming it does not conjure it. `run_pattern` additionally requires the
+three `--fabric-*` session flags. `browser` exists only as a built-in used by
+the authorized browser child profile and cannot be selected as a parent CLI
+tool; it drives the host `agent-browser` CLI through a typed action vocabulary,
+with the Browser Access CDP endpoint attached by the harness rather than written
+by the model.
 
 `describe_handle` reports the referent's structural schema and path segments,
 never its value. It prefers the session Fabric's declared shape when available
@@ -237,16 +238,24 @@ separately records its Fabric CFC enforcement and flow-label posture.
 
 Current child profiles are `default`, `browser`, `web_fetch`, `web_search`, and
 `pattern-author`. Each profile supplies an exact tool/network/skill policy.
-Parent skills and authority do not transfer implicitly.
+Parent skills and authority do not transfer implicitly. Beside them sits one
+internal profile, `explore`: no tools, one turn, a cheap model override, and a
+bounded answer-and-citations return contract it holds authority over. Its call
+declares no ceiling and evaluates no boundary policy, so it is outside the
+posture's caveat policy — admissible because the corpus it reads is trusted for
+confidentiality by ruling, and no wider. No delegation may name it — it is what
+`query_docs` runs, on a corpus the harness supplies, and a delegation naming it
+would put a model with no documentation in front of a schema asking for
+citations.
 
-The `pattern-author` profile combines `run_pattern`, `read_file`, `bash`, and
-`read_skill_resource` without workspace writes. It preloads the available
-`pattern-dev` and `pattern-schema` skills, receives a 24-turn budget for
-compile-and-repair loops, and defaults to a discriminated success/failure return
-contract whose success arm carries the result reference. Sandboxed children
-inherit the parent's working directory within their host-backed mounts;
-host-command children begin at the engine workspace rather than inheriting a
-parent directory they cannot resolve.
+The `pattern-author` profile combines `run_pattern`, `read_file`, `bash`,
+`read_skill_resource`, and `query_docs` without workspace writes. It preloads
+the available `pattern-dev` and `pattern-schema` skills, receives a 24-turn
+budget for compile-and-repair loops, and defaults to a discriminated
+success/failure return contract whose success arm carries the result reference.
+Sandboxed children inherit the parent's working directory within their
+host-backed mounts; host-command children begin at the engine workspace rather
+than inheriting a parent directory they cannot resolve.
 
 ## Lifecycle and evidence
 

--- a/packages/cf-harness/docs/system-map/cfc-system-map.html
+++ b/packages/cf-harness/docs/system-map/cfc-system-map.html
@@ -669,7 +669,7 @@
     // ------------------------------------------------------------------ layout data
     // The state of this repository the map describes. Bump both when the
     // map is re-verified; the stamp is drawn in the canvas's top-left corner.
-    const SNAPSHOT = { date: "2026-09-03", sha: "890911a59b" };
+    const SNAPSHOT = { date: "2026-09-04", sha: "8c01de6ceb" };
     const W = 2760, H = 1840;
     const bands = [
       {
@@ -1245,6 +1245,16 @@
         to: "mount",
         k: "control",
         pts: [[1880, 740], [1800, 740]],
+      },
+      {
+        id: "e_query_docs",
+        from: "child_pa",
+        to: "docs",
+        k: "value",
+        bi: true,
+        pts: [[1500, 600], [1560, 600], [1560, 880], [2005, 880], [2005, 780]],
+        label: "query_docs",
+        lp: [1700, 872],
       },
       {
         id: "e_web_www",
@@ -1903,7 +1913,7 @@
         kind: "Trusted text",
         band: "agent",
         body:
-          `<p>Repository documentation the pattern-author child reads to write patterns. Ruled (CT-2173): trusted for confidentiality, labeled for integrity; context, never command authority. Not yet built: a workspace doc read releases into context with an empty label (CT-2165). <code>PromptSlotBound</code> authority is a separate thing from a CFC label and is drawn as one.</p>`,
+          `<p>Repository documentation the pattern-author child reads to write patterns, and the corpus <code>query_docs</code> answers out of: trusted for confidentiality, endorsed for integrity; context, never command authority. Each section the harness reads under a resolved <code>--docs-corpus-root</code> carries a <code>Resource</code> integrity atom naming that root, and only an endorsed section is eligible for an answer, so text written into the workspace cannot reach one. Still open: an ordinary <code>read_file</code> of a workspace doc releases into context with an empty label (CT-2165). <code>PromptSlotBound</code> authority is a separate thing from a CFC label and is drawn as one.</p>`,
       },
       apps: {
         kind: "Fabric app",
@@ -2283,6 +2293,8 @@
         `<p>Delegation seeds the child's handle table with the parent entries the brief names, and nothing else. The brief itself is prose.</p>`,
       e_child_parent:
         `<p>Return is validated, sanitized and re-minted through the parent's boundary. Raw child evidence is retained outside the parent's return channel. CT-2036 tracks inert numeric fields that can encode sealed strings; CT-2199 tracks program text and diagnostics crossing in the summary.</p>`,
+      e_query_docs:
+        `<p><code>query_docs</code> is how a pattern-author child reaches documentation it has no path to: the child has no <code>delegate_task</code> and the subagent manifest pins the depth at one, so an explore agent is a tool on this surface or it is unreachable. The harness selects the matching sections on the host, an <code>explore</code> profile with no tools at all answers out of them in one model call, and the child receives a bounded answer plus inert citations — a path and a heading, never the text. What was sent is kept on the tool-output artifact and stripped before the child sees it.</p><p>Not yet built: the optional <code>fullTextRef</code>, a capability-scoped handle over the retrieved text by the <code>acquire_skill</code> route, and any policy that would declassify it.</p>`,
       e_skillssh:
         `<p><code>acquire_skill</code>: fetch a skill from skills.sh, pin it by digest, stamp ExternalIngest, return a capability-typed handle.</p>`,
       e_web_www:

--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -59,6 +59,11 @@ import {
 } from "./contracts/subagent.ts";
 import { type BuiltinToolId } from "./contracts/tool-descriptor.ts";
 import { renderCfcPostureReport } from "./cfc-posture.ts";
+import {
+  describeHarnessDocsCorpus,
+  type HarnessDocsCorpusRecord,
+  harnessDocsCorpusRecordsEqual,
+} from "./contracts/docs-corpus.ts";
 import type {
   HarnessTranscriptEvent,
   HarnessTranscriptMessage,
@@ -172,6 +177,7 @@ const CLI_STRING_FLAGS = [
   "compact-threshold",
   "prompt-cache-mode",
   "skills-root",
+  "docs-corpus-root",
   "skills-registry-url",
   "skill",
   "skill-script-execution-target",
@@ -212,10 +218,12 @@ const CLI_BOOLEAN_FLAGS = [
   "print-transcript",
   "stream-events",
   "no-skill-catalog",
+  "no-docs-corpus",
   "no-pattern-index-publish",
 ] as const;
 const CLI_COLLECT_FLAGS = [
   "allow-tool",
+  "docs-corpus-root",
   "allow-skill-script",
   "allow-subagent-profile",
   "skill",
@@ -472,10 +480,11 @@ Options:
   --workspace <path>            Workspace host path (defaults to current directory)
   --cwd <path>                  Initial working directory inside the workspace
   --focus-root <path>           Narrow exploration to a workspace subpath when possible
-  --allow-tool <tool>           Restrict available tools (repeatable: bash | read_file | view_image | web_fetch | read_skill_resource | run_skill_script | edit_file | write_file | delegate_task | describe_handle | run_pattern | assign_slug | search_patterns | record_feedback | search_skills | acquire_skill);
+  --allow-tool <tool>           Restrict available tools (repeatable: bash | read_file | view_image | web_fetch | read_skill_resource | run_skill_script | edit_file | write_file | delegate_task | describe_handle | run_pattern | assign_slug | search_patterns | record_feedback | search_skills | acquire_skill | query_docs);
                                 run_pattern, assign_slug, and acquire_skill additionally require the three --fabric-* session flags,
                                 search_patterns and record_feedback require --pattern-index-url,
-                                and search_skills and acquire_skill require --skills-registry-url
+                                search_skills and acquire_skill require --skills-registry-url,
+                                and query_docs requires a resolved documentation corpus
   --allow-skill-script <spec>   Allow exact skill script execution (repeatable: skill:scripts/path)
   --allow-subagent-profile <p>  Authorize delegate_task to spawn a profile (repeatable: default | browser | web_fetch | web_search)
   --output-mode <mode>          operator | batch (default: operator)
@@ -487,11 +496,13 @@ Options:
   --resume-run <path>           Resume from a run root or run-state.json path
   --system-prompt <text>        Optional system prompt
   --skills-root <path>          Skill root containing <name>/SKILL.md
+  --docs-corpus-root <path>     Reference tree query_docs answers out of (repeatable)
   --skills-registry-url <url>  Registry origin enabling search_skills discovery and pinned acquire_skill
   --skill <name>                Preload a skill for this run (repeatable)
   --skill-script-execution-target <target>
                                 Execute skill scripts in sandbox or host (default: sandbox)
   --no-skill-catalog            Disable automatic skill catalog disclosure
+  --no-docs-corpus              Resolve no documentation corpus, so query_docs is absent
   --model <name>                Model name (default: ${DEFAULT_MODEL})
   --model-provider <provider>   openai-compatible-gateway | openai-codex
                                 (no default; select one here, through
@@ -635,6 +646,7 @@ const CLI_PARENT_TOOL_IDS = [
   "record_feedback",
   "search_skills",
   "acquire_skill",
+  "query_docs",
 ] as const satisfies readonly BuiltinToolId[];
 
 const uniqueStrings = <T extends string>(
@@ -947,7 +959,8 @@ const parseBrowserAccessLease = (
   };
 };
 
-const parseSkillNames = (
+/** The distinct non-empty values of a repeatable option. */
+const parseRepeatedValues = (
   input: string | readonly string[] | undefined,
 ): readonly string[] => {
   if (input === undefined) {
@@ -1260,7 +1273,31 @@ export const parseCfHarnessCliArgs = async (
       "--skills-root",
     ).sandboxPath
     : undefined;
-  const skillNames = parseSkillNames(
+  // Naming no root is not the same as wanting none: the default comes from the
+  // checkout the harness runs out of, applied where every surface resolves its
+  // configuration, so a console started with no documentation flag is not
+  // documentation-blind.
+  const configuredDocsCorpusRoots = parseRepeatedValues(
+    args["docs-corpus-root"] as string | readonly string[] | undefined,
+  ).map((root) => resolve(workspace, root));
+  // `--no-docs-corpus` wins over a named root: an operator who asked for no
+  // corpus and also named one has said two things, and the safe reading of the
+  // pair is the one that reaches for less documentation rather than more.
+  const docsCorpus: HarnessDocsCorpusRecord | undefined =
+    args["no-docs-corpus"] === true
+      ? {
+        type: "cf-harness.docs-corpus-record",
+        source: "configured",
+        roots: [],
+      }
+      : configuredDocsCorpusRoots.length === 0
+      ? undefined
+      : {
+        type: "cf-harness.docs-corpus-record",
+        source: "configured",
+        roots: configuredDocsCorpusRoots,
+      };
+  const skillNames = parseRepeatedValues(
     args.skill as string | readonly string[] | undefined,
   );
   if (skillNames.length > 0 && skillsRoot === undefined) {
@@ -1821,6 +1858,7 @@ export const parseCfHarnessCliArgs = async (
       ? { systemPrompt: args["system-prompt"] }
       : {}),
     ...(skillsRoot !== undefined ? { skillsRoot } : {}),
+    ...(docsCorpus !== undefined ? { docsCorpus } : {}),
     ...(skillsRootSandboxPath !== undefined ? { skillsRootSandboxPath } : {}),
     skillNames,
     allowedSkillScripts,
@@ -2470,6 +2508,10 @@ const summarizeToolCallArguments = (
         return typeof parsed.id === "string"
           ? `id=${JSON.stringify(parsed.id)}`
           : undefined;
+      case "query_docs":
+        return typeof parsed.question === "string"
+          ? `question=${JSON.stringify(parsed.question)}`
+          : undefined;
       case "record_feedback": {
         // The note is the model's prose about a run and can quote what the
         // pattern produced, so the line names the verdict and the pattern
@@ -2569,6 +2611,12 @@ export const formatCfHarnessCliResult = (
       lines.push(...renderCfcPostureReport(posture.record));
     }
   }
+  const docsCorpus = result.runState.docsCorpus;
+  lines.push(
+    docsCorpus === undefined || docsCorpus.roots.length === 0
+      ? "docsCorpus: none — query_docs is absent and children cannot look documentation up"
+      : `docsCorpus: ${docsCorpus.source} ${docsCorpus.roots.join(", ")}`,
+  );
   if (
     result.runState.wellKnownGrants !== undefined &&
     result.runState.wellKnownGrants.length > 0
@@ -3180,6 +3228,22 @@ export const runCfHarnessCli = async (
       ) {
         throw new Error(
           "no API key configured; set CF_HARNESS_API_KEY or OPENAI_API_KEY",
+        );
+      }
+      // The documentation a run answered out of is part of what it is. An
+      // operator repeating the flags with different roots is asking for a
+      // different run, so the resume is refused rather than quietly answering
+      // later questions from another tree; omitting them keeps the record.
+      const recordedDocsCorpus = artifacts.runState.docsCorpus;
+      if (
+        parsed.docsCorpus !== undefined && recordedDocsCorpus !== undefined &&
+        !harnessDocsCorpusRecordsEqual(parsed.docsCorpus, recordedDocsCorpus)
+      ) {
+        throw new HarnessControlError(
+          "provider-mismatch",
+          `resume docs corpus mismatch: run uses ${
+            describeHarnessDocsCorpus(recordedDocsCorpus)
+          }, requested ${describeHarnessDocsCorpus(parsed.docsCorpus)}`,
         );
       }
       const recordedRunManifest = artifacts.runState.runManifest;

--- a/packages/cf-harness/src/config.ts
+++ b/packages/cf-harness/src/config.ts
@@ -15,6 +15,8 @@ import type {
   HarnessSkillScriptExecutionTarget,
 } from "./contracts/skill.ts";
 import type { HarnessBrowserAccessLease } from "./contracts/browser-access.ts";
+import type { HarnessDocsCorpusRecord } from "./contracts/docs-corpus.ts";
+import { resolveHarnessDocsCorpus } from "./docs-corpus/corpus.ts";
 import type { DockerRunscSandboxConfig } from "./sandbox/types.ts";
 
 export const DEFAULT_GATEWAY_BASE_URL = "https://llm.stage.commontools.dev/";
@@ -109,6 +111,15 @@ interface HarnessCommonConfig {
   credentialOwner?: HarnessCredentialOwnerRef;
   harnessHomeIdentity?: string;
   skillsRoot?: string;
+
+  /**
+   * Host directories of operator-provisioned reference material `query_docs`
+   * answers out of, and where they came from. Read-only by use: the harness
+   * reads them and never writes to them, and no other path admits a document
+   * into the corpus. A run naming none does not offer the tool.
+   */
+  docsCorpus?: HarnessDocsCorpusRecord;
+
   allowedSkillScripts?: readonly HarnessAllowedSkillScript[];
   skillScriptExecutionTarget: HarnessSkillScriptExecutionTarget;
   browserAccess?: HarnessBrowserAccessLease;
@@ -173,6 +184,7 @@ export interface ResolveHarnessConfigOptions {
   cwd?: string;
   model?: string;
   skillsRoot?: string;
+  docsCorpus?: HarnessDocsCorpusRecord;
   allowedSkillScripts?: readonly HarnessAllowedSkillScript[];
   skillScriptExecutionTarget?: HarnessSkillScriptExecutionTarget;
   browserAccess?: HarnessBrowserAccessLease;
@@ -333,6 +345,10 @@ export const resolveHarnessConfig = (
       "gateway URL/auth configuration cannot be combined with openai-codex",
     );
   }
+  // Naming no corpus root is not the same as wanting no corpus: the default
+  // is the checkout the harness runs out of, resolved here so that every
+  // surface — the CLI, the console, a child engine — reaches the same answer.
+  const docsCorpus = resolveHarnessDocsCorpus(options.docsCorpus);
   const common: HarnessCommonConfig = {
     ...(options.cwd !== undefined ? { cwd: options.cwd } : {}),
     ...(options.model !== undefined ? { model: options.model } : {}),
@@ -342,6 +358,7 @@ export const resolveHarnessConfig = (
     ...(options.skillsRoot !== undefined
       ? { skillsRoot: options.skillsRoot }
       : {}),
+    ...(docsCorpus !== undefined ? { docsCorpus } : {}),
     ...(options.allowedSkillScripts !== undefined
       ? { allowedSkillScripts: options.allowedSkillScripts }
       : {}),

--- a/packages/cf-harness/src/contracts/docs-corpus.ts
+++ b/packages/cf-harness/src/contracts/docs-corpus.ts
@@ -1,0 +1,123 @@
+/**
+ * Contract shapes of the documentation corpus `query_docs` answers out of, and
+ * the integrity endorsement that says where a piece of it came from.
+ *
+ * The endorsement is the whole trust story of this corpus. Operator-provisioned
+ * reference material is trusted for confidentiality — the operator mounted it,
+ * it carries no secret — and endorsed for integrity provenance, so a reader of
+ * a run can tell reference material apart from a file some earlier child wrote
+ * into the workspace. A section carrying no endorsement is not corpus, and an
+ * answer cannot be built out of it.
+ *
+ * Shapes and the mint only. Reading the roots lives in `../docs-corpus/`.
+ */
+
+import { cfcAtom, type CfcResourceAtom } from "@commonfabric/api/cfc";
+
+/**
+ * Resource classes the harness names in a label of its own, following the
+ * `CFC_<subsystem>_ATOM_CLASS` table `CFC_FUSE_ATOM_CLASS` establishes: a
+ * class string under the existing `Resource` atom family rather than a new
+ * atom type in the spec registry.
+ */
+export const CFC_HARNESS_ATOM_CLASS = {
+  OperatorProvisionedReference:
+    "CommonFabricHarnessOperatorProvisionedReference",
+} as const;
+
+/**
+ * The integrity endorsement carried by a section the corpus admitted, naming
+ * the configured root it was read under.
+ *
+ * Every field is host-observed: the class is this module's constant and the
+ * subject is the operator's own root path, so nothing in the read bytes can
+ * decide what the atom says about them.
+ */
+export const operatorProvisionedReferenceAtom = (
+  corpusRoot: string,
+): CfcResourceAtom =>
+  cfcAtom.resource(
+    CFC_HARNESS_ATOM_CLASS.OperatorProvisionedReference,
+    corpusRoot,
+  );
+
+/** Whether `atom` endorses a value as operator-provisioned reference material. */
+export const isOperatorProvisionedReferenceAtom = (
+  atom: CfcResourceAtom,
+): boolean =>
+  atom.class === CFC_HARNESS_ATOM_CLASS.OperatorProvisionedReference;
+
+/**
+ * One addressable piece of the corpus: the text under a single heading of a
+ * single Markdown file, with the endorsement the loader stamped on it.
+ *
+ * The heading is the address as much as the path is. A query returns the
+ * section rather than the file, so a citation names a place a reader can open
+ * rather than a document they then have to search.
+ */
+export interface HarnessDocsCorpusSection {
+  /** Corpus-relative path of the file, in `<root name>/<path>` form. */
+  path: string;
+
+  /**
+   * Heading text the section sits under, without its `#` markers. Empty for
+   * the text above a file's first heading.
+   */
+  heading: string;
+
+  text: string;
+
+  /** The endorsement, which is what made this text eligible for an answer. */
+  integrity: readonly CfcResourceAtom[];
+}
+
+/**
+ * Where an answer came from, as the child may name it. A citation carries no
+ * text and no handle: what it addresses is a place in the corpus, and reading
+ * that place is a separate act by whoever is entitled to.
+ */
+export interface HarnessDocsCitation {
+  path: string;
+  heading: string;
+}
+
+/**
+ * Where this run's corpus came from. `checkout-default` is the labs checkout
+ * the harness is running out of, which is what a console started with no
+ * documentation configuration gets; `configured` is an operator's own
+ * `--docs-corpus-root`. Recorded in run state and printed in operator output,
+ * because a dial nobody can see is a dial nobody can question.
+ */
+export type HarnessDocsCorpusSource = "configured" | "checkout-default";
+
+/** The corpus dial this run resolved, as it stands before any load. */
+export interface HarnessDocsCorpusRecord {
+  type: "cf-harness.docs-corpus-record";
+  source: HarnessDocsCorpusSource;
+  roots: readonly string[];
+}
+
+/** Whether two corpus records name the same documentation from the same place. */
+export const harnessDocsCorpusRecordsEqual = (
+  left: HarnessDocsCorpusRecord,
+  right: HarnessDocsCorpusRecord,
+): boolean =>
+  left.source === right.source &&
+  left.roots.length === right.roots.length &&
+  left.roots.every((root, index) => root === right.roots[index]);
+
+/** A corpus record as an operator message names it. */
+export const describeHarnessDocsCorpus = (
+  record: HarnessDocsCorpusRecord,
+): string =>
+  record.roots.length === 0
+    ? "no corpus"
+    : `${record.source} ${record.roots.join(", ")}`;
+
+/** The citation form of a section. */
+export const citationOfSection = (
+  section: HarnessDocsCorpusSection,
+): HarnessDocsCitation => ({
+  path: section.path,
+  heading: section.heading,
+});

--- a/packages/cf-harness/src/contracts/subagent.ts
+++ b/packages/cf-harness/src/contracts/subagent.ts
@@ -21,7 +21,15 @@ export const BROWSER_SUBAGENT_PROFILE = "browser" as const;
 export const WEB_FETCH_SUBAGENT_PROFILE = "web_fetch" as const;
 export const WEB_SEARCH_SUBAGENT_PROFILE = "web_search" as const;
 export const PATTERN_AUTHOR_SUBAGENT_PROFILE = "pattern-author" as const;
+export const EXPLORE_SUBAGENT_PROFILE = "explore" as const;
 export const WEB_SEARCH_SUBAGENT_MODEL = "gemini-3.5-flash" as const;
+
+/**
+ * The model an explore turn runs on. A profile's `modelOverride` reaches the
+ * provider verbatim as the request's `model`, so this is the gateway's own
+ * name for the model and carries no routing prefix.
+ */
+export const EXPLORE_SUBAGENT_MODEL = "gemini-3.5-flash" as const;
 export const DEFAULT_SUBAGENT_MAX_MODEL_TURNS = 8;
 export const MAX_SUBAGENT_MAX_MODEL_TURNS = 64;
 export const MAX_DELEGATE_PATTERN_REFS = 8;
@@ -79,6 +87,11 @@ export const WEB_SEARCH_SUBAGENT_ALLOWED_TOOL_IDS =
  * configured pattern index: an author that can find an existing pattern for
  * the job should compose it rather than write one, and say how the one it ran
  * turned out.
+ *
+ * `query_docs` is how an author reaches documentation it has no path to. A
+ * child cannot delegate — this profile has no `delegate_task`, and the
+ * subagent manifest pins the depth at one — so an explore agent is a tool on
+ * this surface or it is unreachable from the one context that needs it.
  */
 export const PATTERN_AUTHOR_SUBAGENT_ALLOWED_TOOL_IDS = [
   "bash",
@@ -88,7 +101,17 @@ export const PATTERN_AUTHOR_SUBAGENT_ALLOWED_TOOL_IDS = [
   "run_pattern",
   "search_patterns",
   "record_feedback",
+  "query_docs",
 ] as const satisfies readonly BuiltinToolId[];
+
+/**
+ * Tool surface of the `explore` profile: none at all. The child is handed the
+ * documentation sections it may answer out of and has no way to reach anything
+ * else — no file it could read, no command it could run, no space it could
+ * touch. Read-only is the profile's shape rather than a rule applied to it.
+ */
+export const EXPLORE_SUBAGENT_ALLOWED_TOOL_IDS =
+  [] as const satisfies readonly BuiltinToolId[];
 
 export const NO_HOST_TOOL_IDS = [] as const satisfies readonly BuiltinToolId[];
 export const BROWSER_SUBAGENT_HOST_TOOL_IDS = [
@@ -271,10 +294,61 @@ export const PATTERN_AUTHOR_RETURN_SCHEMA: JSONSchema = {
   ],
 };
 
+/** Longest answer the `explore` profile may return, in characters. */
+export const MAX_EXPLORE_ANSWER_LENGTH = 2_000;
+
+/** Most citations one explore answer may name. */
+export const MAX_EXPLORE_CITATIONS = 8;
+
+/**
+ * Return contract of the `explore` profile: a bounded answer and the places it
+ * came from, and nothing else.
+ *
+ * The bound on `answer` is what keeps the asking child's context intact — the
+ * point of asking a question rather than reading a file is that the reply is
+ * the size of an answer. The citations are inert: a path and a heading address
+ * a place in the corpus, carrying no text and no handle, so reading that place
+ * stays a separate act by whoever is entitled to it.
+ */
+export const EXPLORE_RETURN_SCHEMA: JSONSchema = {
+  type: "object",
+  properties: {
+    answer: {
+      type: "string",
+      maxLength: MAX_EXPLORE_ANSWER_LENGTH,
+      description:
+        "The answer to the question, drawn only from the supplied sections.",
+    },
+    citations: {
+      type: "array",
+      maxItems: MAX_EXPLORE_CITATIONS,
+      items: {
+        type: "object",
+        properties: {
+          path: {
+            type: "string",
+            description: "Corpus path of a supplied section, exactly as given.",
+          },
+          heading: {
+            type: "string",
+            description: "Heading of that section, exactly as given.",
+          },
+        },
+        required: ["path", "heading"],
+        additionalProperties: false,
+      },
+      description: "The sections the answer was drawn from.",
+    },
+  },
+  required: ["answer", "citations"],
+  additionalProperties: false,
+};
+
 export const WEB_SEARCH_SUBAGENT_NATIVE_MODEL_TOOL_IDS = [
   GOOGLE_SEARCH_NATIVE_MODEL_TOOL,
 ] as const satisfies readonly HarnessNativeModelToolId[];
 
+/** The profiles a `delegate_task` call may name. */
 export const HARNESS_SUBAGENT_PROFILES = [
   DEFAULT_SUBAGENT_PROFILE,
   BROWSER_SUBAGENT_PROFILE,
@@ -283,7 +357,23 @@ export const HARNESS_SUBAGENT_PROFILES = [
   PATTERN_AUTHOR_SUBAGENT_PROFILE,
 ] as const;
 
-export type HarnessSubagentProfile = typeof HARNESS_SUBAGENT_PROFILES[number];
+/**
+ * The profiles the harness runs on a caller's behalf rather than on a
+ * delegation's. `explore` is one because its answer is only as good as the
+ * corpus it was handed, and the harness is what hands it one: a delegation
+ * naming it directly would put a model with no documentation in front of a
+ * schema that asks for citations, which is the failure this profile exists to
+ * end rather than to reproduce.
+ */
+export const HARNESS_INTERNAL_SUBAGENT_PROFILES = [
+  EXPLORE_SUBAGENT_PROFILE,
+] as const;
+
+export type HarnessDelegableSubagentProfile =
+  typeof HARNESS_SUBAGENT_PROFILES[number];
+export type HarnessSubagentProfile =
+  | HarnessDelegableSubagentProfile
+  | typeof HARNESS_INTERNAL_SUBAGENT_PROFILES[number];
 export type HarnessSubagentModelSource = "parent" | "profile";
 export type HarnessNativeModelToolId = LLMNativeModelToolId;
 export type HarnessSubagentRunStatus = "completed" | "failed";
@@ -411,9 +501,27 @@ export const PATTERN_AUTHOR_SUBAGENT_PROFILE_CONFIG:
     returnPolicy: DEFAULT_SUBAGENT_RETURN_POLICY,
   };
 
+/**
+ * The `explore` profile: a cheap model, no tools, one turn, and a return
+ * contract it does not share authority over. Every property is the same
+ * decision — the child answers one question out of the text it was handed, and
+ * a single turn is all that takes.
+ */
+export const EXPLORE_SUBAGENT_PROFILE_CONFIG: HarnessSubagentProfileConfig = {
+  type: "cf-harness.subagent-profile-config",
+  profile: EXPLORE_SUBAGENT_PROFILE,
+  allowedToolIds: EXPLORE_SUBAGENT_ALLOWED_TOOL_IDS,
+  hostToolIds: NO_HOST_TOOL_IDS,
+  modelOverride: EXPLORE_SUBAGENT_MODEL,
+  maxModelTurns: 1,
+  returnSchema: EXPLORE_RETURN_SCHEMA,
+  returnContractAuthority: "profile",
+  returnPolicy: DEFAULT_SUBAGENT_RETURN_POLICY,
+};
+
 export const isHarnessSubagentProfile = (
   input: string,
-): input is HarnessSubagentProfile =>
+): input is HarnessDelegableSubagentProfile =>
   (HARNESS_SUBAGENT_PROFILES as readonly string[]).includes(input);
 
 export const getHarnessSubagentProfileConfig = (
@@ -430,6 +538,8 @@ export const getHarnessSubagentProfileConfig = (
       return WEB_SEARCH_SUBAGENT_PROFILE_CONFIG;
     case PATTERN_AUTHOR_SUBAGENT_PROFILE:
       return PATTERN_AUTHOR_SUBAGENT_PROFILE_CONFIG;
+    case EXPLORE_SUBAGENT_PROFILE:
+      return EXPLORE_SUBAGENT_PROFILE_CONFIG;
   }
 };
 

--- a/packages/cf-harness/src/contracts/tool-descriptor.ts
+++ b/packages/cf-harness/src/contracts/tool-descriptor.ts
@@ -17,7 +17,8 @@ export type BuiltinToolId =
   | "search_patterns"
   | "record_feedback"
   | "search_skills"
-  | "acquire_skill";
+  | "acquire_skill"
+  | "query_docs";
 
 export const DEFAULT_PARENT_TOOL_IDS = [
   "bash",
@@ -45,6 +46,16 @@ const FABRIC_SESSION_TOOL_IDS: ReadonlySet<BuiltinToolId> = new Set(
  */
 const PATTERN_INDEX_TOOL_IDS: ReadonlySet<BuiltinToolId> = new Set(
   ["search_patterns", "record_feedback"] as const,
+);
+
+/**
+ * The tool gated on a configured documentation corpus. A run given no corpus
+ * root has nothing for an explore child to answer out of, so the tool is
+ * absent rather than present and answering every question with the same
+ * refusal.
+ */
+const DOCS_CORPUS_TOOL_IDS: ReadonlySet<BuiltinToolId> = new Set(
+  ["query_docs"] as const,
 );
 
 /** The metadata-only tool gated on configured skills.sh discovery. */
@@ -75,6 +86,7 @@ export interface HarnessToolBackingAvailability {
   skillsShSearchAvailable: boolean;
   skillsShAcquisitionAvailable: boolean;
   skillRegistryAvailable: boolean;
+  docsCorpusAvailable: boolean;
 }
 
 /** The gated tools this run cannot back, and so does not offer. */
@@ -89,6 +101,7 @@ export const withheldToolIds = (
       ? []
       : SKILLS_SH_ACQUISITION_TOOL_IDS),
     ...(availability.skillRegistryAvailable ? [] : SKILL_REGISTRY_TOOL_IDS),
+    ...(availability.docsCorpusAvailable ? [] : DOCS_CORPUS_TOOL_IDS),
   ]);
 
 /**
@@ -113,6 +126,7 @@ export const parentToolIdsForBacking = (
     ...(availability.skillsShAcquisitionAvailable
       ? SKILLS_SH_ACQUISITION_TOOL_IDS
       : []),
+    ...(availability.docsCorpusAvailable ? DOCS_CORPUS_TOOL_IDS : []),
   ].filter((toolId, index, ids) =>
     !withheld.has(toolId) && ids.indexOf(toolId) === index
   );

--- a/packages/cf-harness/src/docs-corpus/corpus.ts
+++ b/packages/cf-harness/src/docs-corpus/corpus.ts
@@ -1,0 +1,289 @@
+/**
+ * Loading the documentation corpus `query_docs` answers out of.
+ *
+ * The corpus is read on the host, from the roots the operator configured, and
+ * never through the sandbox mount. That is what makes the endorsement below
+ * honest: a section's provenance is the root it was found under, which the
+ * operator named, rather than a path a child chose. Nothing else is admitted,
+ * so a file some earlier child wrote into the workspace is not corpus and
+ * cannot reach an answer.
+ *
+ * Reads only. Nothing here creates, moves, or writes a file.
+ */
+
+import { utf8Compare } from "@commonfabric/utils/utf8";
+import { basename, dirname, fromFileUrl, join } from "@std/path";
+
+import {
+  type HarnessDocsCorpusRecord,
+  type HarnessDocsCorpusSection,
+  operatorProvisionedReferenceAtom,
+} from "../contracts/docs-corpus.ts";
+import { splitMarkdownSections } from "./sections.ts";
+
+/** Largest single document the corpus reads, in bytes. */
+export const MAX_CORPUS_FILE_BYTES = 512_000;
+
+/** Total document bytes one corpus load reads. */
+export const MAX_CORPUS_BYTES = 16_000_000;
+
+/** Directory names the walk does not descend into. */
+const SKIPPED_DIRECTORY_NAMES = new Set(["node_modules"]);
+
+/** A configured root, and the name its documents are addressed under. */
+export interface HarnessDocsCorpusRoot {
+  /** The name a corpus path opens with, unique across the corpus. */
+  name: string;
+
+  hostPath: string;
+}
+
+export interface HarnessDocsCorpus {
+  type: "cf-harness.docs-corpus";
+  roots: readonly HarnessDocsCorpusRoot[];
+  sections: readonly HarnessDocsCorpusSection[];
+  files: number;
+
+  /**
+   * Whether the walk stopped on {@link MAX_CORPUS_BYTES} with roots left to
+   * read. A corpus that says so holds some of the configured material rather
+   * than all of it, and an answer built from it may be missing a section the
+   * question had a better one in.
+   */
+  truncated: boolean;
+}
+
+/**
+ * The roots as they are addressed, in configuration order. Two roots sharing a
+ * basename would put two different documents at one corpus path, so the second
+ * takes a numbered name; the citation stays a unique address either way.
+ */
+export const namedCorpusRoots = (
+  hostPaths: readonly string[],
+): readonly HarnessDocsCorpusRoot[] => {
+  const used = new Set<string>();
+  return hostPaths.map((hostPath) => {
+    const base = basename(hostPath) || "root";
+    let name = base;
+    let ordinal = 2;
+    while (used.has(name)) {
+      name = `${base}-${ordinal}`;
+      ordinal += 1;
+    }
+    used.add(name);
+    return { name, hostPath };
+  });
+};
+
+const isMarkdownPath = (path: string): boolean =>
+  path.toLowerCase().endsWith(".md");
+
+const isDirectory = (path: string): boolean => {
+  try {
+    return Deno.statSync(path).isDirectory;
+  } catch {
+    return false;
+  }
+};
+
+interface WalkState {
+  sections: HarnessDocsCorpusSection[];
+  files: number;
+  bytes: number;
+  truncated: boolean;
+}
+
+/**
+ * Reads one document through a single open handle: the size the budget is
+ * checked against and the bytes admitted come from the same file, so a path
+ * replaced between two calls cannot have its old size admit its new contents.
+ *
+ * The one window this does not close is a symlink swapped in for a regular
+ * file between the directory walk and the open. Deno's `open` has no
+ * `O_NOFOLLOW`, so a no-follow open cannot be expressed here; what stands
+ * against it is that the roots are operator-provisioned trees the harness only
+ * reads, and the walk refuses a symlink it sees.
+ */
+const readDocument = async (
+  state: WalkState,
+  root: HarnessDocsCorpusRoot,
+  hostPath: string,
+  corpusPath: string,
+): Promise<void> => {
+  const file = await Deno.open(hostPath, { read: true });
+  try {
+    const info = await file.stat();
+    if (!info.isFile || info.size > MAX_CORPUS_FILE_BYTES) {
+      return;
+    }
+    if (state.bytes + info.size > MAX_CORPUS_BYTES) {
+      state.truncated = true;
+      return;
+    }
+    const bytes = new Uint8Array(info.size);
+    let filled = 0;
+    while (filled < bytes.length) {
+      const read = await file.read(bytes.subarray(filled));
+      if (read === null) {
+        break;
+      }
+      filled += read;
+    }
+    state.bytes += filled;
+    state.files += 1;
+    state.sections.push(...splitMarkdownSections({
+      path: corpusPath,
+      integrity: [operatorProvisionedReferenceAtom(root.hostPath)],
+    }, new TextDecoder().decode(bytes.subarray(0, filled))));
+  } finally {
+    file.close();
+  }
+};
+
+const walkDirectory = async (
+  state: WalkState,
+  root: HarnessDocsCorpusRoot,
+  hostPath: string,
+  corpusPath: string,
+): Promise<void> => {
+  const entries: Deno.DirEntry[] = [];
+  for await (const entry of Deno.readDir(hostPath)) {
+    entries.push(entry);
+  }
+  // Directory order is a filesystem detail, and a corpus that changed between
+  // two loads of the same tree would make a query's selection unreproducible.
+  // The comparator is the repository's own, so the order does not depend on
+  // the host's default locale either.
+  entries.sort((left, right) => utf8Compare(left.name, right.name));
+  for (const entry of entries) {
+    // A symlink is followed by neither branch. Following one would let a link
+    // planted under a root address a file the operator never provisioned, and
+    // the endorsement would name a root that file does not live under.
+    if (entry.isSymlink || entry.name.startsWith(".")) {
+      continue;
+    }
+    const childHostPath = join(hostPath, entry.name);
+    const childCorpusPath = `${corpusPath}/${entry.name}`;
+    if (entry.isDirectory && !SKIPPED_DIRECTORY_NAMES.has(entry.name)) {
+      await walkDirectory(state, root, childHostPath, childCorpusPath);
+      continue;
+    }
+    if (entry.isFile && isMarkdownPath(entry.name)) {
+      await readDocument(state, root, childHostPath, childCorpusPath);
+    }
+  }
+};
+
+/**
+ * The corpus held by `hostPaths`, with the endorsement stamped on every
+ * section of it. A root that does not exist contributes nothing rather than
+ * failing the load: an operator whose configuration names a tree this host
+ * does not carry gets an answer out of the trees it does.
+ */
+export const loadHarnessDocsCorpus = async (
+  hostPaths: readonly string[],
+): Promise<HarnessDocsCorpus> => {
+  const roots = namedCorpusRoots(hostPaths);
+  const state: WalkState = {
+    sections: [],
+    files: 0,
+    bytes: 0,
+    truncated: false,
+  };
+  for (const root of roots) {
+    let info: Deno.FileInfo;
+    try {
+      info = await Deno.stat(root.hostPath);
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        continue;
+      }
+      throw error;
+    }
+    if (info.isDirectory) {
+      await walkDirectory(state, root, root.hostPath, root.name);
+    } else if (info.isFile && isMarkdownPath(root.hostPath)) {
+      await readDocument(state, root, root.hostPath, root.name);
+    }
+  }
+  return {
+    type: "cf-harness.docs-corpus",
+    roots,
+    sections: state.sections,
+    files: state.files,
+    truncated: state.truncated,
+  };
+};
+
+/**
+ * The reference trees of the labs checkout the harness is running out of, or
+ * an empty list when it is not running out of one.
+ *
+ * A console started with no documentation configuration is a console whose
+ * children cannot find the documentation they need, which is the failure this
+ * corpus exists to end. The walk goes up from the directory `moduleUrl` names
+ * looking for a directory carrying all three of `docs/common`,
+ * `docs/development` and `skills`, so a checkout answers and a package
+ * installed from the registry does not.
+ *
+ * Synchronous because the answer decides a tool surface: every surface that
+ * states its tool policy has to reach the same one, and one of them states it
+ * before any run exists.
+ */
+export const checkoutDocsCorpusRootsFrom = (
+  moduleUrl: string,
+): readonly string[] => {
+  // A module addressed by anything but a file URL — a compiled binary, an
+  // `https:` import — sits in no checkout, and asking `fromFileUrl` about it
+  // throws. This runs inside configuration resolution, where a throw would
+  // take down every surface, so anything that is not a file URL answers "no
+  // checkout" instead.
+  let directory: string;
+  try {
+    const parsed = new URL(moduleUrl);
+    if (parsed.protocol !== "file:") {
+      return [];
+    }
+    directory = dirname(fromFileUrl(parsed));
+  } catch {
+    return [];
+  }
+  const checkoutRoots = ["docs/common", "docs/development", "skills"];
+  while (true) {
+    const candidates = checkoutRoots.map((root) => join(directory, root));
+    if (candidates.every(isDirectory)) {
+      return candidates;
+    }
+    const parent = dirname(directory);
+    if (parent === directory) {
+      return [];
+    }
+    directory = parent;
+  }
+};
+
+/** {@link checkoutDocsCorpusRootsFrom} for this module's own location. */
+export const checkoutDocsCorpusRoots = (): readonly string[] =>
+  checkoutDocsCorpusRootsFrom(import.meta.url);
+
+/**
+ * The corpus dial a run resolves: what the operator configured, or the
+ * checkout's own reference trees, or nothing at all — in which case the run
+ * offers no `query_docs` and says so.
+ *
+ * This is the one derivation of the dial, so a surface stating its tool policy
+ * and the engine offering the tools reach the same answer.
+ */
+export const resolveHarnessDocsCorpus = (
+  configured?: HarnessDocsCorpusRecord,
+): HarnessDocsCorpusRecord | undefined => {
+  if (configured !== undefined) {
+    return configured;
+  }
+  const roots = checkoutDocsCorpusRoots();
+  return roots.length === 0 ? undefined : {
+    type: "cf-harness.docs-corpus-record",
+    source: "checkout-default",
+    roots,
+  };
+};

--- a/packages/cf-harness/src/docs-corpus/explore.ts
+++ b/packages/cf-harness/src/docs-corpus/explore.ts
@@ -1,0 +1,208 @@
+/**
+ * Running one explore query: a cheap model, the sections it may answer out of,
+ * and a bounded reply.
+ *
+ * The `explore` profile has no tools, so there is no tool loop to run — a
+ * single model turn is the whole of it, and the harness stays a caller of the
+ * model rather than the parent of another agent. That is what keeps the
+ * subagent depth invariant out of this path: `query_docs` starts no child run.
+ */
+
+import {
+  EXPLORE_RETURN_SCHEMA,
+  EXPLORE_SUBAGENT_MODEL,
+  MAX_EXPLORE_ANSWER_LENGTH,
+  MAX_EXPLORE_CITATIONS,
+} from "../contracts/subagent.ts";
+import {
+  citationOfSection,
+  type HarnessDocsCitation,
+  type HarnessDocsCorpusSection,
+} from "../contracts/docs-corpus.ts";
+import type {
+  HarnessModelAttemptDiagnostic,
+  HarnessModelClient,
+  HarnessModelUsage,
+} from "../model/client.ts";
+import type { HarnessTranscriptMessage } from "../contracts/transcript.ts";
+import { parseStructuredResultJson } from "../structured-result.ts";
+
+export interface HarnessExploreQueryRequest {
+  question: string;
+  sections: readonly HarnessDocsCorpusSection[];
+  signal?: AbortSignal;
+}
+
+/**
+ * What the harness sent the provider for one explore turn, verbatim. The
+ * corpus is trusted for confidentiality so no release gate stands between a
+ * section and the provider — which is exactly why the record is not optional:
+ * an audit and a retrospective read what left from here.
+ */
+export interface HarnessExploreQuerySent {
+  model: string;
+  messages: readonly { role: "system" | "user"; content: string }[];
+}
+
+export interface HarnessExploreQueryReply {
+  answer: string;
+  citations: readonly HarnessDocsCitation[];
+  sent: HarnessExploreQuerySent;
+}
+
+/**
+ * What `query_docs` calls to turn a question and a selection of sections into
+ * an answer. A run that has no model client to spend has no runner, and the
+ * tool says so rather than answering out of nothing.
+ */
+export type HarnessExploreQueryRunner = (
+  request: HarnessExploreQueryRequest,
+) => Promise<HarnessExploreQueryReply>;
+
+const EXPLORE_SYSTEM_PROMPT = [
+  "You answer one documentation question out of the sections supplied to you,",
+  "and nothing else. You have no tools and no other source.",
+  "Answer only from the supplied sections. Where they do not answer the",
+  "question, say so plainly and cite nothing: an invented answer costs the",
+  "reader more than an absent one.",
+  "Cite the sections you drew on by their exact path and heading.",
+  `Keep the answer under ${MAX_EXPLORE_ANSWER_LENGTH} characters.`,
+  "Reply with JSON matching this schema and no other text:",
+  JSON.stringify(EXPLORE_RETURN_SCHEMA),
+].join("\n");
+
+const sectionBlock = (section: HarnessDocsCorpusSection): string =>
+  [
+    `--- path: ${section.path}`,
+    `--- heading: ${section.heading}`,
+    section.text,
+  ].join("\n");
+
+/** The one user message an explore turn is given. */
+export const exploreQueryPrompt = (
+  request: HarnessExploreQueryRequest,
+): string =>
+  [
+    `Question: ${request.question}`,
+    "",
+    "Sections:",
+    ...request.sections.map(sectionBlock),
+  ].join("\n\n");
+
+/**
+ * The identity of a section for citation matching. A newline separates the two
+ * parts because neither can hold one: a corpus path is a single path segment
+ * chain and a heading is one line of a document, so no pair of distinct
+ * sections can collide on this key.
+ */
+const sectionKey = (citation: HarnessDocsCitation): string =>
+  `${citation.path}\n${citation.heading}`;
+
+/**
+ * The reply's citations, keeping only those naming a section the child was
+ * actually given. A citation is an address a reader will follow, so one the
+ * corpus does not hold is worse than none: it sends them to a document that
+ * says nothing about the answer, or to no document at all.
+ */
+export const admitCitations = (
+  value: unknown,
+  sections: readonly HarnessDocsCorpusSection[],
+): readonly HarnessDocsCitation[] => {
+  const supplied = new Map(
+    sections.map((section) => {
+      const citation = citationOfSection(section);
+      return [sectionKey(citation), citation];
+    }),
+  );
+  const admitted: HarnessDocsCitation[] = [];
+  const seen = new Set<string>();
+  for (const entry of Array.isArray(value) ? value : []) {
+    if (typeof entry !== "object" || entry === null) {
+      continue;
+    }
+    const { path, heading } = entry as Record<string, unknown>;
+    if (typeof path !== "string" || typeof heading !== "string") {
+      continue;
+    }
+    const key = sectionKey({ path, heading });
+    const citation = supplied.get(key);
+    if (citation === undefined || seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    admitted.push(citation);
+    if (admitted.length >= MAX_EXPLORE_CITATIONS) {
+      break;
+    }
+  }
+  return admitted;
+};
+
+/**
+ * The reply a model turn produced, held to the profile's contract: the answer
+ * clipped to its bound, and only citations the corpus can back.
+ */
+export const readExploreQueryReply = (
+  content: string,
+  sections: readonly HarnessDocsCorpusSection[],
+  sent: HarnessExploreQuerySent,
+): HarnessExploreQueryReply => {
+  const parsed = parseStructuredResultJson(content, {
+    emptyMessage: "explore reply was empty",
+    invalidMessage: "explore reply was not valid JSON",
+  });
+  const record = typeof parsed === "object" && parsed !== null
+    ? parsed as Record<string, unknown>
+    : {};
+  const answer = typeof record.answer === "string" ? record.answer : "";
+  return {
+    answer: answer.slice(0, MAX_EXPLORE_ANSWER_LENGTH),
+    citations: admitCitations(record.citations, sections),
+    sent,
+  };
+};
+
+/**
+ * An explore runner over `modelClient`. The model is the profile's own
+ * override rather than the run's: which model answers a documentation question
+ * is an operator's choice about cost, not a caller's about the question.
+ */
+export const createExploreQueryRunner = (options: {
+  modelClient: HarnessModelClient;
+  runId: string;
+
+  /** Where this turn's provider attempts are recorded, as any turn's are. */
+  onAttempt?: (attempt: HarnessModelAttemptDiagnostic) => void | Promise<void>;
+
+  /** Where this turn's tokens are counted, beside a delegation's. */
+  onUsage?: (usage: HarnessModelUsage) => void;
+}): HarnessExploreQueryRunner =>
+async (request) => {
+  const messages = [
+    { role: "system", content: EXPLORE_SYSTEM_PROMPT },
+    { role: "user", content: exploreQueryPrompt(request) },
+  ] as const satisfies readonly HarnessTranscriptMessage[];
+  const sent: HarnessExploreQuerySent = {
+    model: EXPLORE_SUBAGENT_MODEL,
+    messages: messages.map((message) => ({ ...message })),
+  };
+  const result = await options.modelClient.complete({
+    model: EXPLORE_SUBAGENT_MODEL,
+    transcript: messages,
+    tools: [],
+    nativeModelToolIds: [],
+    runId: options.runId,
+    ...(request.signal !== undefined ? { signal: request.signal } : {}),
+    ...(options.onAttempt !== undefined
+      ? { onAttempt: options.onAttempt }
+      : {}),
+  });
+  if (result.usage !== undefined) {
+    options.onUsage?.(result.usage);
+  }
+  return readExploreQueryReply(
+    result.assistant.content,
+    request.sections,
+    sent,
+  );
+};

--- a/packages/cf-harness/src/docs-corpus/sections.ts
+++ b/packages/cf-harness/src/docs-corpus/sections.ts
@@ -1,0 +1,201 @@
+/**
+ * Splitting Markdown into addressable sections, and choosing the few a
+ * question is answered out of.
+ *
+ * A section rather than a file is the unit here because the whole point of the
+ * tool is that a child stops paying for a document to read a rule. Selection is
+ * lexical and deterministic: the same question over the same corpus chooses the
+ * same sections, which is what makes a query reproducible from a run's record.
+ */
+
+import { utf8Compare } from "@commonfabric/utils/utf8";
+
+import type { HarnessDocsCorpusSection } from "../contracts/docs-corpus.ts";
+
+/** Longest section text the corpus keeps, in characters. */
+export const MAX_SECTION_TEXT_LENGTH = 4_000;
+
+/** How many sections an answer is built out of unless a caller says fewer. */
+export const DEFAULT_SELECTED_SECTIONS = 8;
+
+/** Total characters of section text one query may put in front of the model. */
+export const MAX_SELECTED_SECTION_CHARS = 24_000;
+
+/**
+ * Words carrying no discrimination between documentation sections. Scoring
+ * them would rank a section by how much English it contains rather than by
+ * how much of the question it answers.
+ */
+const STOP_WORDS = new Set([
+  "a",
+  "all",
+  "and",
+  "are",
+  "can",
+  "does",
+  "doing",
+  "for",
+  "from",
+  "how",
+  "into",
+  "not",
+  "should",
+  "that",
+  "the",
+  "this",
+  "use",
+  "using",
+  "was",
+  "what",
+  "when",
+  "where",
+  "which",
+  "why",
+  "with",
+  "you",
+  "your",
+]);
+
+const HEADING_PATTERN = /^(#{1,6})\s+(.*)$/;
+
+const trimSectionText = (lines: readonly string[]): string => {
+  const text = lines.join("\n").trim();
+  return text.length > MAX_SECTION_TEXT_LENGTH
+    ? text.slice(0, MAX_SECTION_TEXT_LENGTH)
+    : text;
+};
+
+/**
+ * The sections of one Markdown document. Text above the first heading becomes
+ * a section with an empty heading, so a document's opening paragraph — which
+ * is where a short skill file says what it is for — is reachable rather than
+ * dropped.
+ *
+ * A fenced code block is passed through verbatim, backtick-fenced or
+ * tilde-fenced alike: a `#` inside one is a shell comment or a CSS id, and
+ * reading it as a heading would split a section in the middle of an example.
+ */
+export const splitMarkdownSections = (
+  document: Omit<HarnessDocsCorpusSection, "heading" | "text">,
+  text: string,
+): readonly HarnessDocsCorpusSection[] => {
+  const sections: HarnessDocsCorpusSection[] = [];
+  let heading = "";
+  let lines: string[] = [];
+  let inFence = false;
+  const flush = () => {
+    const sectionText = trimSectionText(lines);
+    if (sectionText.length > 0) {
+      sections.push({ ...document, heading, text: sectionText });
+    }
+    lines = [];
+  };
+  for (const line of text.split("\n")) {
+    const trimmed = line.trimStart();
+    if (trimmed.startsWith("```") || trimmed.startsWith("~~~")) {
+      inFence = !inFence;
+      lines.push(line);
+      continue;
+    }
+    const match = inFence ? null : HEADING_PATTERN.exec(line);
+    if (match === null) {
+      lines.push(line);
+      continue;
+    }
+    flush();
+    heading = match[2].trim();
+  }
+  flush();
+  return sections;
+};
+
+/** The scoring terms of a question, lowercased and stripped of stop words. */
+export const questionTerms = (question: string): readonly string[] => {
+  const terms = new Set<string>();
+  for (const raw of question.toLowerCase().split(/[^a-z0-9_]+/)) {
+    if (raw.length >= 3 && !STOP_WORDS.has(raw)) {
+      terms.add(raw);
+    }
+  }
+  return [...terms];
+};
+
+const occurrences = (haystack: string, term: string): number => {
+  let count = 0;
+  let index = haystack.indexOf(term);
+  while (index !== -1) {
+    count += 1;
+    index = haystack.indexOf(term, index + term.length);
+  }
+  return count;
+};
+
+/**
+ * How well a section answers a question. A term in the heading or the path
+ * counts for more than a term in the body: a heading is the section's own
+ * claim about its subject, and a body mention may be an aside.
+ */
+export const scoreSection = (
+  section: HarnessDocsCorpusSection,
+  terms: readonly string[],
+): number => {
+  const heading = section.heading.toLowerCase();
+  const path = section.path.toLowerCase();
+  const body = section.text.toLowerCase();
+  let score = 0;
+  for (const term of terms) {
+    score += occurrences(heading, term) * 8;
+    score += occurrences(path, term) * 4;
+    score += Math.min(occurrences(body, term), 8);
+  }
+  return score;
+};
+
+export interface SelectSectionsOptions {
+  maxSections?: number;
+  maxChars?: number;
+}
+
+/**
+ * The sections a question is answered out of, best first. Sections scoring
+ * zero are left out rather than padding the selection: a question the corpus
+ * says nothing about is better answered with nothing than with the first
+ * eight documents in path order.
+ *
+ * Ties break on path and heading under the repository's code-point comparator,
+ * so the selection is a function of the corpus and the question alone rather
+ * than of the host's default locale.
+ */
+export const selectSections = (
+  sections: readonly HarnessDocsCorpusSection[],
+  question: string,
+  options: SelectSectionsOptions = {},
+): readonly HarnessDocsCorpusSection[] => {
+  const terms = questionTerms(question);
+  if (terms.length === 0) {
+    return [];
+  }
+  const maxSections = options.maxSections ?? DEFAULT_SELECTED_SECTIONS;
+  const maxChars = options.maxChars ?? MAX_SELECTED_SECTION_CHARS;
+  const scored = sections
+    .map((section) => ({ section, score: scoreSection(section, terms) }))
+    .filter((entry) => entry.score > 0)
+    .sort((left, right) =>
+      right.score - left.score ||
+      utf8Compare(left.section.path, right.section.path) ||
+      utf8Compare(left.section.heading, right.section.heading)
+    );
+  const selected: HarnessDocsCorpusSection[] = [];
+  let chars = 0;
+  for (const entry of scored) {
+    if (selected.length >= maxSections) {
+      break;
+    }
+    if (chars + entry.section.text.length > maxChars) {
+      continue;
+    }
+    selected.push(entry.section);
+    chars += entry.section.text.length;
+  }
+  return selected;
+};

--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -24,6 +24,12 @@ import {
 } from "./config.ts";
 import { harnessFabricSessionPosture } from "./cfc-posture.ts";
 import {
+  type HarnessDocsCorpus,
+  loadHarnessDocsCorpus,
+} from "./docs-corpus/corpus.ts";
+import type { HarnessExploreQueryRunner } from "./docs-corpus/explore.ts";
+import type { HarnessDocsCorpusRecord } from "./contracts/docs-corpus.ts";
+import {
   createHarnessCfcInvocationContext,
   type HarnessCfcInvocationContext,
   type HarnessCfcInvocationInputLabelPath,
@@ -194,6 +200,10 @@ import type {
   SearchSkillsToolOutput,
 } from "./tools/search-skills.ts";
 import {
+  type QueryDocsToolInput,
+  type QueryDocsToolOutput,
+} from "./tools/query-docs.ts";
+import {
   type ViewImageToolInput,
   type ViewImageToolOutput,
 } from "./tools/view-image.ts";
@@ -224,6 +234,7 @@ export interface BuiltinToolInputMap {
   record_feedback: RecordFeedbackToolInput;
   search_skills: SearchSkillsToolInput;
   acquire_skill: AcquireSkillToolInput;
+  query_docs: QueryDocsToolInput;
 }
 
 export interface BuiltinToolOutputMap {
@@ -244,6 +255,7 @@ export interface BuiltinToolOutputMap {
   record_feedback: RecordFeedbackToolOutput;
   search_skills: SearchSkillsToolOutput;
   acquire_skill: AcquireSkillToolOutput;
+  query_docs: QueryDocsToolOutput;
 }
 
 interface ToolOutputWithId {
@@ -460,6 +472,8 @@ export class CfHarnessEngine {
   readonly #skillsShSearchClientFactory?: HarnessSkillsShSearchClientFactory;
   readonly #skillsShAcquisitionClientFactory?:
     HarnessSkillsShAcquisitionClientFactory;
+  #docsCorpus?: Promise<HarnessDocsCorpus>;
+  #exploreQueryRunner?: HarnessExploreQueryRunner;
   #patternIndexPublications?: PatternIndexPublicationLedger;
   readonly #taskText?: string;
   readonly #inputCells: readonly HarnessInputCellSpec[];
@@ -825,6 +839,7 @@ export class CfHarnessEngine {
         artifactRoot: this.artifactStore?.runRoot,
         runManifest: this.config.runManifest,
         runManifestPath: this.config.runManifestPath,
+        docsCorpus: this.config.docsCorpus,
         lineage: options.lineage,
         now: this.#now(),
       });
@@ -940,6 +955,43 @@ export class CfHarnessEngine {
     | HarnessSkillsShSearchClientFactory
     | undefined {
     return this.#skillsShSearchClientFactory;
+  }
+
+  /** Whether this run configures a documentation corpus for `query_docs`. */
+  get docsCorpusAvailable(): boolean {
+    return (this.docsCorpus?.roots ?? []).length > 0;
+  }
+
+  /**
+   * The corpus this run answers out of. A resumed run keeps the corpus it was
+   * created with, whatever this process was configured with: the run recorded
+   * which documentation shaped it, and answering later questions out of a
+   * different tree — or offering the tool on a run that disabled it — would
+   * make that record a lie. Configuration answers only for a state that
+   * carries no record of its own.
+   */
+  get docsCorpus(): HarnessDocsCorpusRecord | undefined {
+    return this.#runState.docsCorpus ?? this.config.docsCorpus;
+  }
+
+  /**
+   * The run's documentation corpus, loaded once. The load walks the operator's
+   * roots on the host, so it is held for the run rather than repeated per
+   * question: the roots are read-only reference material, and a query that
+   * reloaded them would pay a filesystem walk to learn the same thing.
+   */
+  getDocsCorpus(): Promise<HarnessDocsCorpus> {
+    this.#docsCorpus ??= loadHarnessDocsCorpus(this.docsCorpus?.roots ?? []);
+    return this.#docsCorpus;
+  }
+
+  /**
+   * Gives this run a way to answer a documentation question. The model belongs
+   * to the prompt loop, so the loop supplies the runner and the engine carries
+   * it to the tool.
+   */
+  setExploreQueryRunner(runner: HarnessExploreQueryRunner): void {
+    this.#exploreQueryRunner = runner;
   }
 
   /** Whether this run can acquire a pinned external skill. */
@@ -1996,6 +2048,12 @@ export class CfHarnessEngine {
           patternIndexPublishDiscoverable: this.patternIndexPublishDiscoverable,
           patternIndexPublications: this.patternIndexPublications,
         }
+        : {}),
+      ...(this.docsCorpusAvailable
+        ? { getDocsCorpus: () => this.getDocsCorpus() }
+        : {}),
+      ...(this.#exploreQueryRunner !== undefined
+        ? { runExploreQuery: this.#exploreQueryRunner }
         : {}),
       ...(this.#skillsShSearchClientFactory !== undefined
         ? { getSkillsShSearchClient: this.#skillsShSearchClientFactory }

--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -149,6 +149,7 @@ import {
   parseSubagentReturnSchema,
   validateAndSanitizeSubagentReturn,
 } from "./subagent-return.ts";
+import { createExploreQueryRunner } from "./docs-corpus/explore.ts";
 import { isEditFileToolSuccessOutput } from "./tools/edit-file.ts";
 import { isStructuredFileToolErrorOutput } from "./tools/file-errors.ts";
 import { isReadFileToolSuccessOutput } from "./tools/read-file.ts";
@@ -1813,11 +1814,21 @@ const cfcResultFromOutput = (
     ? output.cfcResult as CfcSandboxResult
     : undefined;
 
-const stripInternalCfcFields = (output: unknown): unknown => {
+/**
+ * The fields a tool result keeps on its artifact and does not put in front of
+ * the model: the sandbox's own CFC result, and the record of what a
+ * `query_docs` explore turn sent the provider. Both exist for a reader of the
+ * run, and both would cost the model context it asked a tool to save it.
+ */
+const stripInternalToolFields = (output: unknown): unknown => {
   if (!isObjectNotArray(output)) {
     return output;
   }
-  const { cfcResult: _cfcResult, ...publicOutput } = output as
+  const {
+    cfcResult: _cfcResult,
+    exploreRecord: _exploreRecord,
+    ...publicOutput
+  } = output as
     & CfcSandboxResultCarrier
     & Record<string, unknown>;
   return publicOutput;
@@ -2304,7 +2315,7 @@ const renderMediatedRunSkillScriptOutput = (
   ].filter((observation) =>
     observation !== undefined
   ) as HarnessCfcModelContextObservationInput[];
-  const publicOutput = stripInternalCfcFields(output) as Record<
+  const publicOutput = stripInternalToolFields(output) as Record<
     string,
     unknown
   >;
@@ -2383,7 +2394,7 @@ const renderMediatedEditFileOutput = (
     resultRef,
     toolCallId,
   );
-  const publicOutput = stripInternalCfcFields(output) as Record<
+  const publicOutput = stripInternalToolFields(output) as Record<
     string,
     unknown
   >;
@@ -2648,6 +2659,7 @@ export class CfHarnessPromptLoop {
       // has yet to scan still knows it will, and one that never will offers
       // neither tool.
       skillRegistryAvailable: this.engine.config.skillsRoot !== undefined,
+      docsCorpusAvailable: this.engine.docsCorpusAvailable,
     };
   }
 
@@ -2859,6 +2871,18 @@ export class CfHarnessPromptLoop {
         modelTurn: modelTurns,
       });
     };
+    // `query_docs` spends a model turn, and the model client is this loop's.
+    // Installing the runner here rather than at construction is what puts that
+    // turn in the same two records every other model call lands in: an attempt
+    // in the run report, and its tokens beside a delegation's.
+    this.engine.setExploreQueryRunner(
+      createExploreQueryRunner({
+        modelClient: this.modelClient,
+        runId: this.engine.getRunState().runId,
+        onAttempt: recordModelAttempt,
+        onUsage: (usage) => descendantUsage.push(usage),
+      }),
+    );
     await this.engine.ensureDiagnosticsInitialized();
     this.engine.startRun();
     if (options.promptSlotBinding !== undefined) {
@@ -3928,7 +3952,7 @@ export class CfHarnessPromptLoop {
     }
     if (toolId === "read_file" && isReadFileStatusObservationError(output)) {
       if (mode === "disabled") {
-        return { output: stripInternalCfcFields(output) };
+        return { output: stripInternalToolFields(output) };
       }
       if (mode === "observe") {
         await writePolicyEvent({
@@ -3939,7 +3963,7 @@ export class CfHarnessPromptLoop {
           detail:
             `${READ_FILE_STATUS_OBSERVATION_DETAIL}; raw error was exposed because CFC is in observe mode`,
         });
-        return { output: stripInternalCfcFields(output) };
+        return { output: stripInternalToolFields(output) };
       }
       const denial = makeObservationDenied("not-observable", {
         detail: READ_FILE_STATUS_OBSERVATION_DETAIL,
@@ -3960,7 +3984,7 @@ export class CfHarnessPromptLoop {
     }
     if (toolId === "edit_file" && isStructuredFileToolErrorOutput(output)) {
       if (mode === "disabled") {
-        return { output: stripInternalCfcFields(output) };
+        return { output: stripInternalToolFields(output) };
       }
       if (mode === "observe") {
         await writePolicyEvent({
@@ -3971,7 +3995,7 @@ export class CfHarnessPromptLoop {
           detail:
             `${EDIT_FILE_STATUS_OBSERVATION_DETAIL}; raw error was exposed because CFC is in observe mode`,
         });
-        return { output: stripInternalCfcFields(output) };
+        return { output: stripInternalToolFields(output) };
       }
       const denial = makeObservationDenied("not-observable", {
         detail: EDIT_FILE_STATUS_OBSERVATION_DETAIL,
@@ -4024,7 +4048,7 @@ export class CfHarnessPromptLoop {
           scrubbed[field] = scrubBareFabricIdentifiers(text);
         }
       }
-      return { output: stripInternalCfcFields(scrubbed) };
+      return { output: stripInternalToolFields(scrubbed) };
     }
     if (toolId === "assign_slug" && isObjectNotArray(output)) {
       // The slug is the model's own word and the URL is composed from the
@@ -4034,7 +4058,7 @@ export class CfHarnessPromptLoop {
       if (typeof scrubbed.message === "string") {
         scrubbed.message = scrubBareFabricIdentifiers(scrubbed.message);
       }
-      return { output: stripInternalCfcFields(scrubbed) };
+      return { output: stripInternalToolFields(scrubbed) };
     }
     if (toolId === "describe_handle") {
       // A disclosed schema's property names are whoever authored the schema's
@@ -4044,11 +4068,11 @@ export class CfHarnessPromptLoop {
       // context, at any depth of the schema, so the whole reply is scrubbed
       // keys and all rather than field by field.
       return {
-        output: scrubBareFabricIdentifiersDeep(stripInternalCfcFields(output)),
+        output: scrubBareFabricIdentifiersDeep(stripInternalToolFields(output)),
       };
     }
     if (!toolOutputNeedsSandboxMediation(toolId, output)) {
-      return { output: stripInternalCfcFields(output) };
+      return { output: stripInternalToolFields(output) };
     }
     if (cfcResult === undefined) {
       const detail =
@@ -4057,15 +4081,15 @@ export class CfHarnessPromptLoop {
         return {
           output: toolId === "bash" || toolId === "run_skill_script"
             ? truncateModelFacingBashOutput(
-              stripInternalCfcFields(output),
+              stripInternalToolFields(output),
               resultRef,
             )
             : toolId === "read_file"
             ? truncateModelFacingReadFileOutput(
-              stripInternalCfcFields(output),
+              stripInternalToolFields(output),
               resultRef,
             )
-            : stripInternalCfcFields(output),
+            : stripInternalToolFields(output),
         };
       }
       if (mode === "observe") {
@@ -4080,15 +4104,15 @@ export class CfHarnessPromptLoop {
         return {
           output: toolId === "bash" || toolId === "run_skill_script"
             ? truncateModelFacingBashOutput(
-              stripInternalCfcFields(output),
+              stripInternalToolFields(output),
               resultRef,
             )
             : toolId === "read_file"
             ? truncateModelFacingReadFileOutput(
-              stripInternalCfcFields(output),
+              stripInternalToolFields(output),
               resultRef,
             )
-            : stripInternalCfcFields(output),
+            : stripInternalToolFields(output),
         };
       }
       const denial = makeObservationDenied("not-observable", {
@@ -4134,7 +4158,7 @@ export class CfHarnessPromptLoop {
         toolCallId,
       );
     }
-    return { output: stripInternalCfcFields(output) };
+    return { output: stripInternalToolFields(output) };
   }
 
   async #invokeBuiltinTool<TToolId extends BuiltinToolId>(
@@ -4249,6 +4273,11 @@ export class CfHarnessPromptLoop {
         : parentRunState.currentDir,
       ...(this.engine.config.skillsRoot !== undefined
         ? { skillsRoot: this.engine.config.skillsRoot }
+        : {}),
+      // The child asks the same corpus the parent does: documentation a run is
+      // provisioned with is the run's, not one context's within it.
+      ...(this.engine.docsCorpus !== undefined
+        ? { docsCorpus: this.engine.docsCorpus }
         : {}),
       ...(profileConfig.allowedSkillScripts !== undefined
         ? { allowedSkillScripts: profileConfig.allowedSkillScripts }

--- a/packages/cf-harness/src/run-state.ts
+++ b/packages/cf-harness/src/run-state.ts
@@ -9,6 +9,7 @@ import {
   type HarnessCfcModelContextObservationInput,
 } from "./contracts/cfc-model-context.ts";
 import type { HarnessCellLabels } from "./contracts/cell-labels.ts";
+import type { HarnessDocsCorpusRecord } from "./contracts/docs-corpus.ts";
 import type { HarnessCfcPolicySnapshot } from "./contracts/cfc-policy-snapshot.ts";
 import type { HarnessHandleTable } from "./contracts/handle-table.ts";
 import type { HarnessWellKnownGrant } from "./contracts/well-known-grants.ts";
@@ -170,6 +171,7 @@ export interface HarnessRunState {
 
   cellLabelsPath?: string;
   handleTable?: HarnessHandleTable;
+  docsCorpus?: HarnessDocsCorpusRecord;
   wellKnownGrants?: HarnessWellKnownGrant[];
   inputCells?: HarnessInputCell[];
   policyEvents: HarnessPolicyEvent[];
@@ -220,6 +222,7 @@ export interface CreateHarnessRunStateOptions {
   cellLabels?: HarnessCellLabels;
   cellLabelsPath?: string;
   handleTable?: HarnessHandleTable;
+  docsCorpus?: HarnessDocsCorpusRecord;
   wellKnownGrants?: HarnessWellKnownGrant[];
   inputCells?: HarnessInputCell[];
   policyDecisions?: HarnessPolicyDecisionRecord[];
@@ -336,6 +339,9 @@ export const createHarnessRunState = (
       : {}),
     ...(options.handleTable !== undefined
       ? { handleTable: structuredClone(options.handleTable) }
+      : {}),
+    ...(options.docsCorpus !== undefined
+      ? { docsCorpus: structuredClone(options.docsCorpus) }
       : {}),
     ...(options.wellKnownGrants !== undefined
       ? { wellKnownGrants: structuredClone(options.wellKnownGrants) }

--- a/packages/cf-harness/src/session-assembly.ts
+++ b/packages/cf-harness/src/session-assembly.ts
@@ -35,6 +35,8 @@ import type {
   HarnessAllowedSkillScript,
   HarnessSkillScriptExecutionTarget,
 } from "./contracts/skill.ts";
+import type { HarnessDocsCorpusRecord } from "./contracts/docs-corpus.ts";
+import { resolveHarnessDocsCorpus } from "./docs-corpus/corpus.ts";
 import type { HarnessSubagentProfile } from "./contracts/subagent.ts";
 import {
   type BuiltinToolId,
@@ -87,6 +89,9 @@ export interface HarnessSessionConfig {
 
   /** Skills preloaded into the run's opening context, by name. */
   skillNames: readonly string[];
+
+  /** Reference trees `query_docs` answers out of, and where they came from. */
+  docsCorpus?: HarnessDocsCorpusRecord;
 
   allowedSkillScripts: readonly HarnessAllowedSkillScript[];
   skillScriptExecutionTarget: HarnessSkillScriptExecutionTarget;
@@ -145,6 +150,8 @@ export const harnessSessionToolBacking = (
   skillsShSearchAvailable: config.skillsSh !== undefined,
   skillsShAcquisitionAvailable: config.skillsSh !== undefined,
   skillRegistryAvailable: config.skillsRoot !== undefined,
+  docsCorpusAvailable:
+    (resolveHarnessDocsCorpus(config.docsCorpus)?.roots ?? []).length > 0,
 });
 
 /**
@@ -220,6 +227,9 @@ export const harnessSessionEngineOptions = (
       : {}),
     ...(config.skillsRoot !== undefined
       ? { skillsRoot: config.skillsRoot }
+      : {}),
+    ...(config.docsCorpus !== undefined
+      ? { docsCorpus: config.docsCorpus }
       : {}),
     ...(config.allowedSkillScripts.length > 0
       ? { allowedSkillScripts: config.allowedSkillScripts }

--- a/packages/cf-harness/src/tools/query-docs.ts
+++ b/packages/cf-harness/src/tools/query-docs.ts
@@ -1,0 +1,329 @@
+/**
+ * The `query_docs` tool: one documentation question, one bounded answer, and
+ * the places it came from.
+ *
+ * The corpus is operator-provisioned reference material read on the host, and
+ * every section of it carries an integrity endorsement naming the root it was
+ * provisioned under. That endorsement is what makes a section eligible: text
+ * written into the workspace is not corpus, so it cannot reach an answer, and
+ * a reader of the run can tell the two apart by the label rather than by trust
+ * in a mount.
+ */
+
+import type { JSONSchema } from "@commonfabric/api";
+
+import {
+  CFC_HARNESS_ATOM_CLASS,
+  type HarnessDocsCitation,
+  type HarnessDocsCorpusSection,
+  isOperatorProvisionedReferenceAtom,
+} from "../contracts/docs-corpus.ts";
+import {
+  EXPLORE_SUBAGENT_PROFILE,
+  MAX_EXPLORE_ANSWER_LENGTH,
+  MAX_EXPLORE_CITATIONS,
+} from "../contracts/subagent.ts";
+import type { HarnessToolDescriptor } from "../contracts/tool-descriptor.ts";
+import { admitCitations } from "../docs-corpus/explore.ts";
+import { selectSections } from "../docs-corpus/sections.ts";
+import type { HarnessToolDefinition } from "./types.ts";
+
+export interface QueryDocsToolInput {
+  question: string;
+  maxCitations?: number;
+}
+
+export interface QueryDocsToolAnswerOutput {
+  outputId: string;
+  status: "ok";
+  answer: string;
+  citations: readonly HarnessDocsCitation[];
+
+  /**
+   * The endorsement classes carried by the sections the answer was built out
+   * of. Empty exactly when the corpus held nothing for the question, which is
+   * the one case where no reference material was read.
+   */
+  provenance: { integrity: readonly string[] };
+
+  /** What the corpus held, and how much of it the question reached. */
+  searched: { corpusSections: number; readSections: number };
+
+  /**
+   * What the explore turn was given and what it was sent to, kept on the
+   * artifact and stripped before the answer reaches the caller. The caller
+   * asked a question and is owed an answer; a reader of the run is owed the
+   * bytes that left for the provider, and the two are not the same audience.
+   *
+   * Absent where the corpus matched nothing, which is the one answer no
+   * explore turn was spent on.
+   */
+  exploreRecord?: HarnessQueryDocsExploreRecord;
+}
+
+/** One explore turn, as the run's artifact records it. */
+export interface HarnessQueryDocsExploreRecord {
+  type: "cf-harness.query-docs-explore-record";
+  profile: typeof EXPLORE_SUBAGENT_PROFILE;
+  model: string;
+  question: string;
+
+  /** The sections the turn was given, with the endorsement each carries. */
+  sections: readonly {
+    path: string;
+    heading: string;
+    chars: number;
+    integrity: readonly string[];
+  }[];
+
+  messages: readonly { role: string; content: string }[];
+}
+
+export interface QueryDocsToolErrorOutput {
+  outputId: string;
+  status: "error";
+  message: string;
+}
+
+export type QueryDocsToolOutput =
+  | QueryDocsToolAnswerOutput
+  | QueryDocsToolErrorOutput;
+
+export const queryDocsToolDescriptor: HarnessToolDescriptor = {
+  toolId: "query_docs",
+  title: "Query Docs",
+  description:
+    "Ask one question of the operator-provisioned documentation and get a short answer plus the sections it came from. A cheap model reads the matching sections on the trusted host side; you receive the answer, never the documents. Citations are addresses — a path and a heading — and carry no text, so open one with read_file when the answer is not enough. Reach for this instead of guessing at an import, an API, or a rule.",
+  effectClass: "read",
+  inputSchema: {
+    type: "object",
+    properties: {
+      question: {
+        type: "string",
+        minLength: 3,
+        description:
+          "The question to answer, in a sentence. Name the symbol, error text, or rule you are stuck on.",
+      },
+      maxCitations: {
+        type: "integer",
+        minimum: 1,
+        maximum: MAX_EXPLORE_CITATIONS,
+        description:
+          "Most sections to answer out of. Values above the cap read as the cap.",
+      },
+    },
+    required: ["question"],
+    additionalProperties: false,
+  } satisfies JSONSchema,
+  outputSchema: {
+    oneOf: [{
+      type: "object",
+      properties: {
+        outputId: { type: "string" },
+        status: { type: "string", enum: ["ok"] },
+        answer: { type: "string", maxLength: MAX_EXPLORE_ANSWER_LENGTH },
+        citations: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              path: { type: "string" },
+              heading: { type: "string" },
+            },
+            required: ["path", "heading"],
+            additionalProperties: false,
+          },
+        },
+        provenance: {
+          type: "object",
+          properties: {
+            integrity: { type: "array", items: { type: "string" } },
+          },
+          required: ["integrity"],
+          additionalProperties: false,
+        },
+        searched: {
+          type: "object",
+          properties: {
+            corpusSections: { type: "integer", minimum: 0 },
+            readSections: { type: "integer", minimum: 0 },
+          },
+          required: ["corpusSections", "readSections"],
+          additionalProperties: false,
+        },
+        exploreRecord: {
+          type: "object",
+          properties: {
+            type: {
+              type: "string",
+              enum: ["cf-harness.query-docs-explore-record"],
+            },
+            profile: { type: "string", enum: [EXPLORE_SUBAGENT_PROFILE] },
+            model: { type: "string" },
+            question: { type: "string" },
+            sections: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: {
+                  path: { type: "string" },
+                  heading: { type: "string" },
+                  chars: { type: "integer", minimum: 0 },
+                  integrity: { type: "array", items: { type: "string" } },
+                },
+                required: ["path", "heading", "chars", "integrity"],
+                additionalProperties: false,
+              },
+            },
+            messages: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: {
+                  role: { type: "string" },
+                  content: { type: "string" },
+                },
+                required: ["role", "content"],
+                additionalProperties: false,
+              },
+            },
+          },
+          required: [
+            "type",
+            "profile",
+            "model",
+            "question",
+            "sections",
+            "messages",
+          ],
+          additionalProperties: false,
+        },
+      },
+      required: [
+        "outputId",
+        "status",
+        "answer",
+        "citations",
+        "provenance",
+        "searched",
+      ],
+      additionalProperties: false,
+    }, {
+      type: "object",
+      properties: {
+        outputId: { type: "string" },
+        status: { type: "string", enum: ["error"] },
+        message: { type: "string" },
+      },
+      required: ["outputId", "status", "message"],
+      additionalProperties: false,
+    }],
+  } satisfies JSONSchema,
+  tags: ["docs", "search", "explore"],
+};
+
+const NO_MATCH_ANSWER =
+  "The documentation corpus holds nothing about that question.";
+
+/**
+ * The sections an answer may be built out of: those carrying the
+ * operator-provisioned endorsement, and no others. The filter runs over what
+ * the loader produced rather than trusting it, so a corpus assembled by some
+ * other route cannot smuggle an unendorsed section into an answer.
+ */
+const endorsedSections = (
+  sections: readonly HarnessDocsCorpusSection[],
+): readonly HarnessDocsCorpusSection[] =>
+  sections.filter((section) =>
+    section.integrity.some(isOperatorProvisionedReferenceAtom)
+  );
+
+const errorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);
+
+export const queryDocsTool: HarnessToolDefinition<
+  QueryDocsToolInput,
+  QueryDocsToolOutput
+> = {
+  descriptor: queryDocsToolDescriptor,
+  async invoke(context, input) {
+    const outputId = context.nextOutputId("query_docs");
+    const errorOutput = (message: string): QueryDocsToolErrorOutput => ({
+      outputId,
+      status: "error",
+      message,
+    });
+    if (context.getDocsCorpus === undefined) {
+      return errorOutput(
+        "query_docs requires a documentation corpus; configure --docs-corpus-root",
+      );
+    }
+    if (context.runExploreQuery === undefined) {
+      return errorOutput("query_docs requires the host explore query runner");
+    }
+    try {
+      const corpus = await context.getDocsCorpus();
+      const eligible = endorsedSections(corpus.sections);
+      const sections = selectSections(eligible, input.question, {
+        maxSections: Math.min(
+          input.maxCitations ?? MAX_EXPLORE_CITATIONS,
+          MAX_EXPLORE_CITATIONS,
+        ),
+      });
+      const searched = {
+        corpusSections: eligible.length,
+        readSections: sections.length,
+      };
+      if (sections.length === 0) {
+        return {
+          outputId,
+          status: "ok",
+          answer: NO_MATCH_ANSWER,
+          citations: [],
+          provenance: { integrity: [] },
+          searched,
+        };
+      }
+      const reply = await context.runExploreQuery({
+        question: input.question,
+        sections,
+        ...(context.signal !== undefined ? { signal: context.signal } : {}),
+      });
+      return {
+        outputId,
+        status: "ok",
+        answer: reply.answer,
+        // The reply's citations are held to the sections this call selected,
+        // here rather than only where a reply is parsed: what a citation
+        // addresses is the tool's contract with its caller, so the tool is
+        // where an address the corpus cannot back stops.
+        citations: admitCitations(reply.citations, sections),
+        provenance: {
+          integrity: [CFC_HARNESS_ATOM_CLASS.OperatorProvisionedReference],
+        },
+        searched,
+        exploreRecord: {
+          type: "cf-harness.query-docs-explore-record",
+          profile: EXPLORE_SUBAGENT_PROFILE,
+          model: reply.sent.model,
+          question: input.question,
+          sections: sections.map((section) => ({
+            path: section.path,
+            heading: section.heading,
+            chars: section.text.length,
+            integrity: section.integrity.map((atom) => atom.class),
+          })),
+          messages: reply.sent.messages.map((message) => ({ ...message })),
+        },
+      };
+    } catch (error) {
+      // A cancelled run is the loop's to end, not a failure the model reacts
+      // to: answering an aborted query with a tool error would have the child
+      // spend its next turn on a run that is already over.
+      if (context.signal?.aborted === true) {
+        throw error;
+      }
+      return errorOutput(`query_docs failed: ${errorMessage(error)}`);
+    }
+  },
+};

--- a/packages/cf-harness/src/tools/registry.ts
+++ b/packages/cf-harness/src/tools/registry.ts
@@ -6,6 +6,7 @@ import { browserTool } from "./browser.ts";
 import { delegateTaskTool } from "./delegate-task.ts";
 import { describeHandleTool } from "./describe-handle.ts";
 import { editFileTool } from "./edit-file.ts";
+import { queryDocsTool } from "./query-docs.ts";
 import { readFileTool } from "./read-file.ts";
 import { readSkillResourceTool } from "./read-skill-resource.ts";
 import { recordFeedbackTool } from "./record-feedback.ts";
@@ -36,6 +37,7 @@ export const BUILTIN_TOOLS = [
   recordFeedbackTool,
   searchSkillsTool,
   acquireSkillTool,
+  queryDocsTool,
 ] as const;
 
 export const BUILTIN_TOOL_REGISTRY = new Map<

--- a/packages/cf-harness/src/tools/types.ts
+++ b/packages/cf-harness/src/tools/types.ts
@@ -17,6 +17,8 @@ import type {
   HarnessSkillScriptExecutionTarget,
 } from "../contracts/skill.ts";
 import type { HarnessBrowserAccessLease } from "../contracts/browser-access.ts";
+import type { HarnessDocsCorpus } from "../docs-corpus/corpus.ts";
+import type { HarnessExploreQueryRunner } from "../docs-corpus/explore.ts";
 import type { HarnessHandleTable } from "../contracts/handle-table.ts";
 import type { HarnessFabricSession } from "../fabric-session.ts";
 import type { PatternIndexClient } from "../pattern-index/client.ts";
@@ -68,6 +70,21 @@ export interface HarnessToolContext {
    * `run_pattern`'s `patternId` argument unusable.
    */
   getPatternIndexClient?: () => Promise<PatternIndexClient>;
+
+  /**
+   * The run's documentation corpus, lazy and cached by the engine. Undefined
+   * when the run configures no corpus root, which also keeps `query_docs` out
+   * of the tool surface.
+   */
+  getDocsCorpus?: () => Promise<HarnessDocsCorpus>;
+
+  /**
+   * Answers one documentation question out of the sections the tool selected,
+   * on the trusted host side. The tool holds the corpus and the caller's
+   * question; this holds the model. Undefined for an invocation outside a
+   * prompt loop, which has no model to spend.
+   */
+  runExploreQuery?: HarnessExploreQueryRunner;
 
   /**
    * The run's skills.sh discovery client, lazy and cached by the engine.

--- a/packages/cf-harness/test/artifacts.test.ts
+++ b/packages/cf-harness/test/artifacts.test.ts
@@ -1,3 +1,4 @@
+import { checkoutDocsCorpusRoots } from "../src/docs-corpus/corpus.ts";
 import { assert, assertEquals, assertThrows } from "@std/assert";
 import { join } from "@std/path";
 import { normalize } from "@std/path/posix";
@@ -262,6 +263,11 @@ Deno.test({
           },
         }],
         currentDir: "/workspace",
+        docsCorpus: {
+          type: "cf-harness.docs-corpus-record",
+          source: "checkout-default",
+          roots: checkoutDocsCorpusRoots(),
+        },
         artifactRoot: runRoot,
         capabilitySnapshot: {
           type: "cf-harness.capability-snapshot",
@@ -557,6 +563,7 @@ Deno.test({
           "write_file",
           "delegate_task",
           "describe_handle",
+          "query_docs",
         ],
       });
       assertEquals(persistedPolicySnapshot.subagents.allowedProfiles, [
@@ -702,7 +709,7 @@ Deno.test({
         {
           model: "gpt-5.4",
           messageCount: 1,
-          toolCount: 8,
+          toolCount: 9,
         },
       );
       assert(

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -116,6 +116,56 @@ Deno.test("parseCfHarnessCliArgs resolves defaults from cwd and positional promp
   assertEquals(parsed.imageAttachments, []);
 });
 
+Deno.test("parseCfHarnessCliArgs collects every --docs-corpus-root", async () => {
+  const parsed = await parseCfHarnessCliArgs(
+    [
+      "--docs-corpus-root",
+      "reference/one",
+      "--docs-corpus-root",
+      "reference/two",
+      "Ask",
+    ],
+    { cwd: "/tmp/project", env: {} },
+  );
+
+  if ("help" in parsed) {
+    throw new Error("expected config result");
+  }
+  assertEquals(parsed.docsCorpus, {
+    type: "cf-harness.docs-corpus-record",
+    source: "configured",
+    roots: ["/tmp/project/reference/one", "/tmp/project/reference/two"],
+  });
+});
+
+Deno.test("parseCfHarnessCliArgs lets --no-docs-corpus override a named root", async () => {
+  const parsed = await parseCfHarnessCliArgs(
+    ["--docs-corpus-root", "reference", "--no-docs-corpus", "Ask"],
+    { cwd: "/tmp/project", env: {} },
+  );
+
+  if ("help" in parsed) {
+    throw new Error("expected config result");
+  }
+  assertEquals(parsed.docsCorpus, {
+    type: "cf-harness.docs-corpus-record",
+    source: "configured",
+    roots: [],
+  });
+});
+
+Deno.test("parseCfHarnessCliArgs leaves the corpus unset when no docs flag is given", async () => {
+  const parsed = await parseCfHarnessCliArgs(["Ask"], {
+    cwd: "/tmp/project",
+    env: {},
+  });
+
+  if ("help" in parsed) {
+    throw new Error("expected config result");
+  }
+  assertEquals(parsed.docsCorpus, undefined);
+});
+
 Deno.test("parseCfHarnessCliArgs resolves image attachments within the workspace", async () => {
   const workspace = await Deno.makeTempDir();
   const launcherCwd = await Deno.makeTempDir();
@@ -4821,6 +4871,7 @@ Deno.test("formatCfHarnessCliResult includes policy event summaries", () => {
       "status: completed",
       "modelTurns: 1",
       "cfcMode: observe (harness)",
+      "docsCorpus: none — query_docs is absent and children cannot look documentation up",
       "policyEvents: 1",
       "- warning bash: bash would require direct-command authorization in enforce modes",
       "",
@@ -6380,6 +6431,84 @@ Deno.test("resume preserves the recorded Codex provider and continuation", async
   );
   assertEquals(mismatchIo.stderr, [
     "resume provider mismatch: run uses openai-codex, requested openai-compatible-gateway\n",
+  ]);
+});
+
+Deno.test("CLI resume keeps the corpus the run recorded and refuses a differing one", async () => {
+  const transcript = [{ role: "user" as const, content: "Ask" }];
+  const readRunArtifacts = () =>
+    Promise.resolve({
+      runRoot: "/tmp/project/.cf-harness-artifacts/run-docs-resume",
+      runStatePath:
+        "/tmp/project/.cf-harness-artifacts/run-docs-resume/run-state.json",
+      transcriptPath:
+        "/tmp/project/.cf-harness-artifacts/run-docs-resume/transcript.json",
+      runState: {
+        runId: "run-docs-resume",
+        status: "failed" as const,
+        createdAt: "2026-09-04T12:00:00.000Z",
+        updatedAt: "2026-09-04T12:00:01.000Z",
+        cfcEnforcementMode: "disabled" as const,
+        currentDir: "/workspace",
+        model: "gpt-5.4",
+        modelProvider: "openai-compatible-gateway" as const,
+        docsCorpus: {
+          type: "cf-harness.docs-corpus-record" as const,
+          source: "configured" as const,
+          roots: ["/tmp/project/recorded-reference"],
+        },
+        policyEvents: [],
+        toolOutputs: [],
+      },
+      transcript,
+    });
+
+  const { io, stderr } = createIoBuffers();
+  let resumedCorpus: unknown;
+  assertEquals(
+    await runCfHarnessCli(
+      ["--resume-run", "/tmp/project/.cf-harness-artifacts/run-docs-resume"],
+      {
+        io,
+        cwd: "/tmp/project",
+        env: { CF_HARNESS_API_KEY: "gateway-key" },
+        readRunArtifacts,
+        createPromptLoop: (options) => {
+          resumedCorpus = options.engine?.docsCorpus;
+          return {
+            runPrompt: () => Promise.reject(new Error("unexpected prompt")),
+            runTranscript: () =>
+              Promise.resolve(completedCliResult("run-docs-resume")),
+          };
+        },
+      },
+    ),
+    0,
+  );
+  assertEquals(stderr, []);
+  assertEquals(resumedCorpus, {
+    type: "cf-harness.docs-corpus-record",
+    source: "configured",
+    roots: ["/tmp/project/recorded-reference"],
+  });
+
+  const mismatchIo = createIoBuffers();
+  assertEquals(
+    await runCfHarnessCli([
+      "--resume-run",
+      "/tmp/project/.cf-harness-artifacts/run-docs-resume",
+      "--docs-corpus-root",
+      "other-reference",
+    ], {
+      io: mismatchIo.io,
+      cwd: "/tmp/project",
+      env: { CF_HARNESS_API_KEY: "gateway-key" },
+      readRunArtifacts,
+    }),
+    1,
+  );
+  assertEquals(mismatchIo.stderr, [
+    "resume docs corpus mismatch: run uses configured /tmp/project/recorded-reference, requested configured /tmp/project/other-reference\n",
   ]);
 });
 

--- a/packages/cf-harness/test/config.test.ts
+++ b/packages/cf-harness/test/config.test.ts
@@ -1,3 +1,4 @@
+import { checkoutDocsCorpusRoots } from "../src/docs-corpus/corpus.ts";
 import { assertEquals, assertThrows } from "@std/assert";
 import type { CfcEnforcementMode } from "@commonfabric/runner/cfc";
 import {
@@ -200,6 +201,11 @@ Deno.test("resolveHarnessConfig preserves legacy gateway fields for openai-codex
     skillScriptExecutionTarget: "sandbox",
     cfcEnforcementMode: "enforce-explicit",
     cfcEnforcementModeSource: "default",
+    docsCorpus: {
+      type: "cf-harness.docs-corpus-record",
+      source: "checkout-default",
+      roots: checkoutDocsCorpusRoots(),
+    },
   });
   assertThrows(
     () =>

--- a/packages/cf-harness/test/docs-corpus.test.ts
+++ b/packages/cf-harness/test/docs-corpus.test.ts
@@ -1,0 +1,235 @@
+/**
+ * The documentation corpus `query_docs` answers out of: how a Markdown file
+ * becomes addressable sections, which sections a question reaches, and the
+ * endorsement that says a section is operator-provisioned reference material.
+ */
+
+import { expect } from "@std/expect";
+import { join } from "@std/path";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
+import {
+  CFC_HARNESS_ATOM_CLASS,
+  isOperatorProvisionedReferenceAtom,
+  operatorProvisionedReferenceAtom,
+} from "../src/contracts/docs-corpus.ts";
+import {
+  checkoutDocsCorpusRoots,
+  checkoutDocsCorpusRootsFrom,
+  loadHarnessDocsCorpus,
+  resolveHarnessDocsCorpus,
+} from "../src/docs-corpus/corpus.ts";
+import {
+  selectSections,
+  splitMarkdownSections,
+} from "../src/docs-corpus/sections.ts";
+
+const document = {
+  path: "docs/example.md",
+  integrity: [operatorProvisionedReferenceAtom("/host/docs")],
+};
+
+describe("docs-corpus", () => {
+  describe("splitMarkdownSections()", () => {
+    it("returns one section per heading", () => {
+      const sections = splitMarkdownSections(
+        document,
+        "# Title\n\nOpening.\n\n## Glazing\n\nDip once.\n",
+      );
+
+      expect(sections.map((section) => section.heading)).toEqual([
+        "Title",
+        "Glazing",
+      ]);
+      expect(sections[1].text).toBe("Dip once.");
+    });
+
+    it("returns the text above the first heading under an empty heading", () => {
+      const sections = splitMarkdownSections(
+        document,
+        "Preamble about fryers.\n\n# Title\n\nBody.\n",
+      );
+
+      expect(sections[0].heading).toBe("");
+      expect(sections[0].text).toBe("Preamble about fryers.");
+    });
+
+    it("returns a fenced `#` line as part of its own section", () => {
+      const sections = splitMarkdownSections(
+        document,
+        "# Title\n\n```sh\n# not a heading\nfry\n```\n",
+      );
+
+      expect(sections).toHaveLength(1);
+      expect(sections[0].text).toContain("# not a heading");
+    });
+
+    it("returns a tilde-fenced `#` line as part of its own section", () => {
+      const sections = splitMarkdownSections(
+        document,
+        "# Title\n\n~~~sh\n# not a heading\nfry\n~~~\n",
+      );
+
+      expect(sections).toHaveLength(1);
+      expect(sections[0].text).toContain("# not a heading");
+    });
+  });
+
+  describe("selectSections()", () => {
+    const sections = splitMarkdownSections(
+      document,
+      "# Glazing\n\nDip the donut once.\n\n# Frying\n\nGlazing comes later.\n",
+    );
+
+    it("returns the heading match ahead of the body mention", () => {
+      const selected = selectSections(sections, "how do I do glazing?");
+
+      expect(selected.map((section) => section.heading)).toEqual([
+        "Glazing",
+        "Frying",
+      ]);
+    });
+
+    it("returns nothing for a question the corpus shares no term with", () => {
+      expect(selectSections(sections, "sourdough starter hydration")).toEqual(
+        [],
+      );
+    });
+
+    it("returns no more sections than the caller asked for", () => {
+      const selected = selectSections(sections, "glazing", { maxSections: 1 });
+
+      expect(selected).toHaveLength(1);
+    });
+  });
+
+  describe("loadHarnessDocsCorpus()", () => {
+    let root: string;
+
+    beforeEach(async () => {
+      root = await Deno.makeTempDir({ prefix: "cf-harness-docs-corpus-" });
+      await Deno.mkdir(join(root, "guides"));
+      await Deno.writeTextFile(
+        join(root, "guides", "glazing.md"),
+        "# Glazing\n\nDip once.\n",
+      );
+      await Deno.writeTextFile(join(root, "notes.txt"), "not markdown");
+    });
+
+    afterEach(async () => {
+      await Deno.remove(root, { recursive: true });
+    });
+
+    it("stamps the operator-provisioned endorsement on every section", async () => {
+      const corpus = await loadHarnessDocsCorpus([root]);
+
+      expect(corpus.sections).toHaveLength(1);
+      expect(corpus.sections[0].integrity[0].class).toBe(
+        CFC_HARNESS_ATOM_CLASS.OperatorProvisionedReference,
+      );
+      expect(corpus.sections[0].integrity[0].subject).toBe(root);
+      expect(
+        corpus.sections.every((section) =>
+          section.integrity.some(isOperatorProvisionedReferenceAtom)
+        ),
+      ).toBe(true);
+    });
+
+    it("returns a corpus path opening with the root's name", async () => {
+      const corpus = await loadHarnessDocsCorpus([root]);
+
+      expect(corpus.sections[0].path).toBe(
+        `${corpus.roots[0].name}/guides/glazing.md`,
+      );
+    });
+
+    it("returns nothing for a file that is not Markdown", async () => {
+      const corpus = await loadHarnessDocsCorpus([root]);
+
+      expect(corpus.files).toBe(1);
+      expect(
+        corpus.sections.some((section) => section.path.endsWith("notes.txt")),
+      ).toBe(false);
+    });
+
+    it("returns nothing read through a symlink planted under the root", async () => {
+      const outside = await Deno.makeTempDir({ prefix: "cf-harness-outside-" });
+      try {
+        await Deno.writeTextFile(
+          join(outside, "smuggled.md"),
+          "# Smuggled\n\nWritten elsewhere.\n",
+        );
+        await Deno.symlink(
+          join(outside, "smuggled.md"),
+          join(root, "smuggled.md"),
+        );
+        const corpus = await loadHarnessDocsCorpus([root]);
+
+        expect(
+          corpus.sections.some((section) => section.heading === "Smuggled"),
+        ).toBe(false);
+      } finally {
+        await Deno.remove(outside, { recursive: true });
+      }
+    });
+
+    it("returns distinct names for two roots sharing a basename", async () => {
+      const sibling = join(root, "guides");
+      const corpus = await loadHarnessDocsCorpus([sibling, sibling]);
+
+      expect(corpus.roots.map((entry) => entry.name)).toEqual([
+        "guides",
+        "guides-2",
+      ]);
+    });
+
+    it("returns an empty corpus for a root this host does not carry", async () => {
+      const corpus = await loadHarnessDocsCorpus([join(root, "absent")]);
+
+      expect(corpus.sections).toEqual([]);
+      expect(corpus.files).toBe(0);
+    });
+  });
+
+  describe("resolveHarnessDocsCorpus()", () => {
+    it("returns the configured record unchanged", () => {
+      const configured = {
+        type: "cf-harness.docs-corpus-record" as const,
+        source: "configured" as const,
+        roots: ["/host/reference"],
+      };
+
+      expect(resolveHarnessDocsCorpus(configured)).toBe(configured);
+    });
+
+    it("returns the checkout trees when nothing was configured", () => {
+      const resolved = resolveHarnessDocsCorpus();
+
+      expect(resolved?.source).toBe("checkout-default");
+      expect(resolved?.roots).toEqual(checkoutDocsCorpusRoots());
+    });
+  });
+
+  describe("checkoutDocsCorpusRoots()", () => {
+    it("returns the reference trees of the checkout it runs out of", () => {
+      const roots = checkoutDocsCorpusRoots();
+
+      expect(roots).toHaveLength(3);
+      expect(roots[0].endsWith(join("docs", "common"))).toBe(true);
+      expect(roots[1].endsWith(join("docs", "development"))).toBe(true);
+      expect(roots[2].endsWith("skills")).toBe(true);
+      for (const root of roots) {
+        expect(Deno.statSync(root).isDirectory).toBe(true);
+      }
+    });
+
+    it("returns nothing for a module that is not addressed by a file URL", () => {
+      expect(checkoutDocsCorpusRootsFrom("https://example.test/corpus.ts"))
+        .toEqual([]);
+    });
+
+    it("returns nothing for a module URL that does not parse", () => {
+      expect(checkoutDocsCorpusRootsFrom("not a url")).toEqual([]);
+    });
+  });
+});

--- a/packages/cf-harness/test/engine.test.ts
+++ b/packages/cf-harness/test/engine.test.ts
@@ -1,3 +1,4 @@
+import { checkoutDocsCorpusRoots } from "../src/docs-corpus/corpus.ts";
 import { assertEquals, assertRejects, assertThrows } from "@std/assert";
 import { normalize } from "@std/path/posix";
 import type { HarnessArtifactStore } from "../src/artifacts.ts";
@@ -136,6 +137,11 @@ Deno.test("CfHarnessEngine builds a default docker-runsc sandbox when given a wo
     updatedAt: "2026-04-15T19:00:00.000Z",
     cfcEnforcementMode: "enforce-explicit",
     currentDir: "/workspace",
+    docsCorpus: {
+      type: "cf-harness.docs-corpus-record",
+      source: "checkout-default",
+      roots: checkoutDocsCorpusRoots(),
+    },
     modelProvider: "openai-compatible-gateway",
     modelAuthSource: "api-key",
     policyEvents: [],

--- a/packages/cf-harness/test/prompt-loop-subagent-handles.test.ts
+++ b/packages/cf-harness/test/prompt-loop-subagent-handles.test.ts
@@ -628,6 +628,7 @@ describe("prompt-loop cross-agent address handles", () => {
       "read_file",
       "read_skill_resource",
       "describe_handle",
+      "query_docs",
     ]);
     const runRef = result.runState.subagentRuns?.[0];
     expect(runRef?.manifest.allowedToolIds).not.toContain("run_pattern");

--- a/packages/cf-harness/test/prompt-loop.test.ts
+++ b/packages/cf-harness/test/prompt-loop.test.ts
@@ -1170,6 +1170,7 @@ Deno.test("CfHarnessPromptLoop runs a tool call and returns the final assistant 
       "write_file",
       "delegate_task",
       "describe_handle",
+      "query_docs",
     ],
   );
   assertEquals(
@@ -2014,6 +2015,7 @@ Deno.test("CfHarnessPromptLoop advertises run_pattern in the default tool surfac
       "run_pattern",
       "assign_slug",
       "describe_handle",
+      "query_docs",
     ],
   );
 });
@@ -2162,6 +2164,7 @@ Deno.test("CfHarnessPromptLoop advertises the pattern-index tools in the default
       "describe_handle",
       "search_patterns",
       "record_feedback",
+      "query_docs",
     ],
   );
 });
@@ -2317,6 +2320,7 @@ Deno.test("CfHarnessPromptLoop withholds the pattern-index tools from the patter
     "read_skill_resource",
     "describe_handle",
     "run_pattern",
+    "query_docs",
   ]);
 });
 
@@ -2616,6 +2620,7 @@ Deno.test("CfHarnessPromptLoop delegates one fresh child run and returns a summa
       "write_file",
       "delegate_task",
       "describe_handle",
+      "query_docs",
     ],
   );
   assertEquals(
@@ -3505,6 +3510,7 @@ Deno.test("CfHarnessPromptLoop keeps browser unavailable to the parent by defaul
       "write_file",
       "delegate_task",
       "describe_handle",
+      "query_docs",
     ],
   );
   assertEquals(denied.detail, "browser is not allowed in this run");

--- a/packages/cf-harness/test/query-docs.test.ts
+++ b/packages/cf-harness/test/query-docs.test.ts
@@ -1,0 +1,535 @@
+/**
+ * The model-facing documentation query tool: what it hands the explore
+ * profile, what it hands back, and the endorsement that decides which text is
+ * eligible for an answer.
+ */
+
+import { expect } from "@std/expect";
+import { join, normalize } from "@std/path/posix";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
+import { CfHarnessEngine } from "../src/engine.ts";
+import { checkoutDocsCorpusRoots } from "../src/docs-corpus/corpus.ts";
+import { parentToolIdsForBacking } from "../src/contracts/tool-descriptor.ts";
+import {
+  createHarnessRunState,
+  type HarnessRunState,
+} from "../src/run-state.ts";
+import {
+  CFC_HARNESS_ATOM_CLASS,
+  isOperatorProvisionedReferenceAtom,
+} from "../src/contracts/docs-corpus.ts";
+import {
+  EXPLORE_SUBAGENT_PROFILE_CONFIG,
+  MAX_EXPLORE_ANSWER_LENGTH,
+  PATTERN_AUTHOR_SUBAGENT_ALLOWED_TOOL_IDS,
+} from "../src/contracts/subagent.ts";
+import type {
+  HarnessExploreQueryReply,
+  HarnessExploreQueryRequest,
+} from "../src/docs-corpus/explore.ts";
+import {
+  createExploreQueryRunner,
+  readExploreQueryReply,
+} from "../src/docs-corpus/explore.ts";
+import type {
+  HarnessModelAttemptDiagnostic,
+  HarnessModelUsage,
+} from "../src/model/client.ts";
+import { queryDocsToolDescriptor } from "../src/tools/query-docs.ts";
+import type {
+  QueryDocsToolAnswerOutput,
+  QueryDocsToolErrorOutput,
+} from "../src/tools/query-docs.ts";
+import type {
+  SandboxCommandRequest,
+  SandboxCommandResult,
+  SandboxRuntime,
+  SandboxRuntimeDescription,
+  SandboxShellRequest,
+} from "../src/sandbox/types.ts";
+
+class FakeSandboxRuntime implements SandboxRuntime {
+  describe(): SandboxRuntimeDescription {
+    return {
+      kind: "docker-runsc-cfc",
+      defaultWorkingDirectory: this.defaultWorkingDirectory(),
+      cfc: { runtimeRequested: true, workspaceMountPath: "/workspace" },
+    };
+  }
+
+  resolvePath(path: string, cwd = this.defaultWorkingDirectory()): string {
+    return normalize(path.startsWith("/") ? path : join(cwd, path));
+  }
+
+  isPathWithinWorkspace(path: string): boolean {
+    return path === "/workspace" || path.startsWith("/workspace/");
+  }
+
+  isPathWithinAllowedRoots(path: string): boolean {
+    return this.isPathWithinWorkspace(path);
+  }
+
+  defaultWorkingDirectory(): string {
+    return "/workspace";
+  }
+
+  run(_request: SandboxCommandRequest): Promise<SandboxCommandResult> {
+    return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 });
+  }
+
+  runShell(_request: SandboxShellRequest): Promise<SandboxCommandResult> {
+    return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 });
+  }
+}
+
+const GLAZING_DOC = [
+  "# Glazing",
+  "",
+  "Dip the donut once and let it drain.",
+  "",
+  "# Frying",
+  "",
+  "Hold the fryer at 190 degrees.",
+  "",
+].join("\n");
+
+const SENT = {
+  model: "stub-explore-model",
+  messages: [
+    { role: "system" as const, content: "explore system prompt" },
+    { role: "user" as const, content: "explore user prompt" },
+  ],
+};
+
+describe("query-docs", () => {
+  let root: string;
+  let requests: HarnessExploreQueryRequest[];
+
+  beforeEach(async () => {
+    root = await Deno.makeTempDir({ prefix: "cf-harness-query-docs-" });
+    await Deno.writeTextFile(`${root}/glazing.md`, GLAZING_DOC);
+    requests = [];
+  });
+
+  afterEach(async () => {
+    await Deno.remove(root, { recursive: true });
+  });
+
+  const createEngine = (
+    options: {
+      corpus?: boolean;
+      reply?: (
+        request: HarnessExploreQueryRequest,
+      ) => Omit<HarnessExploreQueryReply, "sent">;
+    } = {},
+  ): CfHarnessEngine => {
+    const engine = new CfHarnessEngine({
+      sandboxRuntime: new FakeSandboxRuntime(),
+      runId: `query-docs-test-${crypto.randomUUID()}`,
+      cfcEnforcementMode: "disabled",
+      // A run wanting no corpus says so; the checkout the tests run out of
+      // would otherwise supply the default.
+      ...(options.corpus === false
+        ? {
+          docsCorpus: {
+            type: "cf-harness.docs-corpus-record" as const,
+            source: "configured" as const,
+            roots: [],
+          },
+        }
+        : {
+          docsCorpus: {
+            type: "cf-harness.docs-corpus-record" as const,
+            source: "configured" as const,
+            roots: [root],
+          },
+        }),
+    });
+    if (options.reply !== undefined) {
+      const reply = options.reply;
+      engine.setExploreQueryRunner((request) => {
+        requests.push(request);
+        return Promise.resolve({ ...reply(request), sent: SENT });
+      });
+    }
+    return engine;
+  };
+
+  describe("the descriptor", () => {
+    it("returns a read-effect tool taking a question and nothing else", () => {
+      expect(queryDocsToolDescriptor.effectClass).toBe("read");
+      const schema = queryDocsToolDescriptor.inputSchema as {
+        required: readonly string[];
+        additionalProperties: boolean;
+        properties: Record<string, unknown>;
+      };
+      expect(schema.required).toEqual(["question"]);
+      expect(schema.additionalProperties).toBe(false);
+      expect(Object.keys(schema.properties).sort()).toEqual([
+        "maxCitations",
+        "question",
+      ]);
+    });
+  });
+
+  describe("invoking it", () => {
+    it("returns the explore answer, its citations, and the endorsement", async () => {
+      const engine = createEngine({
+        reply: (request) => ({
+          answer: "Dip the donut once.",
+          citations: [{
+            path: request.sections[0].path,
+            heading: request.sections[0].heading,
+          }],
+        }),
+      });
+
+      const result = await engine.invokeBuiltinTool("query_docs", {
+        question: "how do I do glazing?",
+      });
+      const output = result.output as QueryDocsToolAnswerOutput;
+
+      expect(output.status).toBe("ok");
+      expect(output.answer).toBe("Dip the donut once.");
+      expect(output.citations[0].heading).toBe("Glazing");
+      expect(output.provenance.integrity).toEqual([
+        CFC_HARNESS_ATOM_CLASS.OperatorProvisionedReference,
+      ]);
+      expect(output.searched.readSections).toBe(requests[0].sections.length);
+    });
+
+    it("hands the explore profile only endorsed sections", async () => {
+      const engine = createEngine({
+        reply: () => ({ answer: "Dip once.", citations: [] }),
+      });
+
+      await engine.invokeBuiltinTool("query_docs", {
+        question: "glazing",
+      });
+
+      expect(requests).toHaveLength(1);
+      expect(requests[0].sections.length).toBeGreaterThan(0);
+      expect(
+        requests[0].sections.every((section) =>
+          section.integrity.some(isOperatorProvisionedReferenceAtom)
+        ),
+      ).toBe(true);
+    });
+
+    it("returns a citation carrying a path and a heading and no text", async () => {
+      const engine = createEngine({
+        reply: (request) => ({
+          answer: "Dip the donut once.",
+          citations: [{
+            path: request.sections[0].path,
+            heading: request.sections[0].heading,
+          }],
+        }),
+      });
+
+      const result = await engine.invokeBuiltinTool("query_docs", {
+        question: "glazing",
+      });
+      const output = result.output as QueryDocsToolAnswerOutput;
+
+      expect(Object.keys(output.citations[0]).sort()).toEqual([
+        "heading",
+        "path",
+      ]);
+    });
+
+    it("returns no citation for a section the corpus does not hold", async () => {
+      const engine = createEngine({
+        reply: () => ({
+          answer: "Read the fryer manual.",
+          citations: [{ path: "invented/manual.md", heading: "Fryers" }],
+        }),
+      });
+
+      const result = await engine.invokeBuiltinTool("query_docs", {
+        question: "glazing",
+      });
+      const output = result.output as QueryDocsToolAnswerOutput;
+
+      expect(output.citations).toEqual([]);
+    });
+
+    it("answers without calling the model when nothing matches", async () => {
+      const engine = createEngine({
+        reply: () => ({ answer: "unreached", citations: [] }),
+      });
+
+      const result = await engine.invokeBuiltinTool("query_docs", {
+        question: "sourdough starter hydration",
+      });
+      const output = result.output as QueryDocsToolAnswerOutput;
+
+      expect(requests).toEqual([]);
+      expect(output.status).toBe("ok");
+      expect(output.provenance.integrity).toEqual([]);
+      expect(output.searched.readSections).toBe(0);
+    });
+
+    it("reports a failed explore turn as a tool error", async () => {
+      const engine = createEngine();
+      engine.setExploreQueryRunner(() =>
+        Promise.reject(new Error("model unavailable"))
+      );
+
+      const result = await engine.invokeBuiltinTool("query_docs", {
+        question: "glazing",
+      });
+      const output = result.output as QueryDocsToolErrorOutput;
+
+      expect(output.status).toBe("error");
+      expect(output.message).toContain("model unavailable");
+    });
+
+    it("records the sections it sent, with their endorsement atoms", async () => {
+      const engine = createEngine({
+        reply: () => ({ answer: "Dip once.", citations: [] }),
+      });
+
+      const result = await engine.invokeBuiltinTool("query_docs", {
+        question: "glazing",
+      });
+      const output = result.output as QueryDocsToolAnswerOutput;
+      const record = output.exploreRecord;
+
+      expect(record?.model).toBe(SENT.model);
+      expect(record?.question).toBe("glazing");
+      expect(record?.sections[0].integrity).toEqual([
+        CFC_HARNESS_ATOM_CLASS.OperatorProvisionedReference,
+      ]);
+      expect(record?.messages.map((message) => message.content)).toEqual(
+        SENT.messages.map((message) => message.content),
+      );
+    });
+
+    it("records no explore turn for an answer no turn was spent on", async () => {
+      const engine = createEngine({
+        reply: () => ({ answer: "unreached", citations: [] }),
+      });
+
+      const result = await engine.invokeBuiltinTool("query_docs", {
+        question: "sourdough starter hydration",
+      });
+      const output = result.output as QueryDocsToolAnswerOutput;
+
+      expect(output.exploreRecord).toBeUndefined();
+    });
+
+    it("refuses when the run configures no corpus root", async () => {
+      const engine = createEngine({ corpus: false });
+
+      const result = await engine.invokeBuiltinTool("query_docs", {
+        question: "glazing",
+      });
+      const output = result.output as QueryDocsToolErrorOutput;
+
+      expect(engine.docsCorpusAvailable).toBe(false);
+      expect(output.status).toBe("error");
+      expect(output.message).toContain("--docs-corpus-root");
+    });
+  });
+
+  describe("the bounded reply", () => {
+    const sections = [{
+      path: "docs/glazing.md",
+      heading: "Glazing",
+      text: "Dip once.",
+      integrity: [],
+    }];
+
+    it("returns an over-long answer clipped to the profile's bound", () => {
+      const reply = readExploreQueryReply(
+        JSON.stringify({ answer: "x".repeat(9_000), citations: [] }),
+        sections,
+        SENT,
+      );
+
+      expect(reply.answer).toHaveLength(MAX_EXPLORE_ANSWER_LENGTH);
+    });
+
+    it("throws for a reply that is not JSON", () => {
+      expect(() => readExploreQueryReply("Sorry, I cannot.", sections, SENT))
+        .toThrow("not valid JSON");
+    });
+  });
+
+  describe("createExploreQueryRunner()", () => {
+    it("returns the reply and reports the turn's attempt and usage", async () => {
+      const attempts: string[] = [];
+      const usage: HarnessModelUsage[] = [];
+      const runner = createExploreQueryRunner({
+        modelClient: {
+          providerId: "stub",
+          complete: (request) => {
+            request.onAttempt?.(
+              { operation: "responses" } as HarnessModelAttemptDiagnostic,
+            );
+            return Promise.resolve({
+              assistant: {
+                role: "assistant",
+                content: JSON.stringify({
+                  answer: "Dip once.",
+                  citations: [{ path: "docs/glazing.md", heading: "Glazing" }],
+                }),
+              },
+              usage: { totalTokens: 41 },
+            });
+          },
+        },
+        runId: "explore-runner-test",
+        onAttempt: (attempt) => {
+          attempts.push(attempt.operation);
+        },
+        onUsage: (turnUsage) => {
+          usage.push(turnUsage);
+        },
+      });
+
+      const reply = await runner({
+        question: "glazing",
+        sections: [{
+          path: "docs/glazing.md",
+          heading: "Glazing",
+          text: "Dip once.",
+          integrity: [],
+        }],
+      });
+
+      expect(reply.answer).toBe("Dip once.");
+      expect(reply.citations).toEqual([{
+        path: "docs/glazing.md",
+        heading: "Glazing",
+      }]);
+      expect(attempts).toEqual(["responses"]);
+      expect(usage).toEqual([{ totalTokens: 41 }]);
+      expect(reply.sent.messages.map((message) => message.role)).toEqual([
+        "system",
+        "user",
+      ]);
+      expect(reply.sent.messages[1].content).toContain("docs/glazing.md");
+    });
+  });
+
+  describe("a run started from a checkout with no documentation flags", () => {
+    // The engine is constructed the way a bare `deno task run` constructs one:
+    // no docs options at all. What this pins is that the surface advertising
+    // the tool and the engine backing it reach the same corpus.
+
+    it("answers query_docs out of the checkout's own reference trees", async () => {
+      const engine = new CfHarnessEngine({
+        sandboxRuntime: new FakeSandboxRuntime(),
+        runId: `query-docs-default-${crypto.randomUUID()}`,
+        cfcEnforcementMode: "disabled",
+      });
+      engine.setExploreQueryRunner((request) =>
+        Promise.resolve({
+          answer: "Answered from the checkout.",
+          citations: request.sections.slice(0, 1).map((section) => ({
+            path: section.path,
+            heading: section.heading,
+          })),
+          sent: SENT,
+        })
+      );
+
+      expect(engine.docsCorpusAvailable).toBe(true);
+      expect(engine.docsCorpus?.source).toBe("checkout-default");
+      expect(engine.docsCorpus?.roots).toEqual(checkoutDocsCorpusRoots());
+      const corpus = await engine.getDocsCorpus();
+      expect(corpus.files).toBeGreaterThan(0);
+
+      const result = await engine.invokeBuiltinTool("query_docs", {
+        question: "what does a pattern handler do?",
+      });
+      const output = result.output as QueryDocsToolAnswerOutput;
+      expect(output.status).toBe("ok");
+      expect(output.answer).toBe("Answered from the checkout.");
+      expect(output.citations.length).toBeGreaterThan(0);
+    });
+
+    it("offers query_docs on the parent tool surface", () => {
+      expect(parentToolIdsForBacking({
+        fabricSessionAvailable: false,
+        patternIndexAvailable: false,
+        skillsShSearchAvailable: false,
+        skillsShAcquisitionAvailable: false,
+        skillRegistryAvailable: false,
+        docsCorpusAvailable: true,
+      })).toContain("query_docs");
+    });
+
+    it("records the resolved corpus in run state", () => {
+      const engine = new CfHarnessEngine({
+        sandboxRuntime: new FakeSandboxRuntime(),
+        runId: `query-docs-record-${crypto.randomUUID()}`,
+        cfcEnforcementMode: "disabled",
+      });
+
+      expect(engine.getRunState().docsCorpus).toEqual({
+        type: "cf-harness.docs-corpus-record",
+        source: "checkout-default",
+        roots: checkoutDocsCorpusRoots(),
+      });
+    });
+  });
+
+  describe("a resumed run", () => {
+    const recorded = {
+      type: "cf-harness.docs-corpus-record" as const,
+      source: "configured" as const,
+      roots: ["/host/recorded-reference"],
+    };
+
+    const resumedEngine = (runState: Record<string, unknown>) =>
+      new CfHarnessEngine({
+        sandboxRuntime: new FakeSandboxRuntime(),
+        cfcEnforcementMode: "disabled",
+        runState: {
+          ...createHarnessRunState({
+            runId: "run-resumed",
+            cfcEnforcementMode: "disabled",
+            currentDir: "/workspace",
+          }),
+          ...runState,
+        } as HarnessRunState,
+      });
+
+    it("answers out of the corpus the run recorded, not this process's default", () => {
+      const engine = resumedEngine({ docsCorpus: recorded });
+
+      expect(engine.docsCorpus).toEqual(recorded);
+      expect(engine.docsCorpusAvailable).toBe(true);
+    });
+
+    it("keeps query_docs absent for a run that recorded no corpus", () => {
+      const engine = resumedEngine({
+        docsCorpus: {
+          type: "cf-harness.docs-corpus-record",
+          source: "configured",
+          roots: [],
+        },
+      });
+
+      expect(engine.docsCorpusAvailable).toBe(false);
+    });
+  });
+
+  describe("the surfaces that offer it", () => {
+    it("is on the `pattern-author` tool surface", () => {
+      expect(PATTERN_AUTHOR_SUBAGENT_ALLOWED_TOOL_IDS).toContain("query_docs");
+    });
+
+    it("runs an `explore` profile with no tools at all", () => {
+      expect(EXPLORE_SUBAGENT_PROFILE_CONFIG.allowedToolIds).toEqual([]);
+      expect(EXPLORE_SUBAGENT_PROFILE_CONFIG.hostToolIds).toEqual([]);
+      expect(EXPLORE_SUBAGENT_PROFILE_CONFIG.returnContractAuthority).toBe(
+        "profile",
+      );
+    });
+  });
+});

--- a/packages/cf-harness/test/tools-registry.test.ts
+++ b/packages/cf-harness/test/tools-registry.test.ts
@@ -29,8 +29,9 @@ Deno.test("builtin tool registry includes the agreed first-pass tool floor", () 
     "record_feedback",
     "search_skills",
     "acquire_skill",
+    "query_docs",
   ]);
-  assertEquals(BUILTIN_TOOL_REGISTRY.size, 17);
+  assertEquals(BUILTIN_TOOL_REGISTRY.size, 18);
   assertEquals(
     [...DEFAULT_PARENT_TOOL_IDS],
     [


### PR DESCRIPTION
## What this is

CT-2173 phase 1: `query_docs`, a tool on the parent and `pattern-author`
surfaces that answers one documentation question out of operator-provisioned
reference material and returns a bounded answer plus inert citations.

The priority behind it is Ben's: the agent has to stop being unable to find the
documentation it needs. It is a tool rather than a delegation because that is
forced — `pattern-author` has no `delegate_task` and the subagent manifest pins
the depth at one, so an explore agent is a tool on that surface or it is
unreachable from the one context that needs it.

## Assumptions stated rather than asked

- **The explore runner is one `modelClient.complete()` call, not a child
  engine.** A child engine would put the explore run at depth 2, and
  `HarnessSubagentRunManifest.depth` is the literal `1`. A profile with no tools
  needs no tool loop, so the invariant is untouched rather than widened. The
  supervisor accepted this shape mid-flight.
- **`explore` is not delegable.** It sits in `HARNESS_INTERNAL_SUBAGENT_PROFILES`
  rather than `HARNESS_SUBAGENT_PROFILES`, so `delegate_task` cannot name it. A
  delegation to it would put a model with no corpus in front of a schema asking
  for citations, which is the failure this issue exists to end.
- **The endorsement is a `Resource` class, not a new spec atom type.** I looked
  for an existing operator-provisioned or trusted-source term in
  `packages/runner/src/cfc` and there is none — that tree has no subsystem
  resource-class table at all. The only precedent in the repo is
  `CFC_FUSE_ATOM_CLASS` in `packages/api/cfc.ts` (`CommonFabricFuse*` values
  under the existing `Resource` atom family), plus bare inline class strings
  (`CredentialSecret`, `PrivilegedPieceList`). So this follows that table's
  naming exactly: `CFC_HARNESS_ATOM_CLASS.OperatorProvisionedReference` =
  `CommonFabricHarnessOperatorProvisionedReference`, harness-local because
  nothing outside the harness consumes it.
- **`--docs-corpus-root` and `--no-docs-corpus` are plain config, not
  experimental**, so they are documented in the package README rather than
  registered in `EXPERIMENTAL_OPTIONS.md`.

## The endorsement, and CT-2165

Operator-provisioned documentation is trusted for confidentiality and endorsed
for integrity provenance. The endorsement is **stamped** by the corpus loader on
every section it admits, from the operator's own root path — host-observed,
never read out of the file's bytes. It is **consulted** twice: at admission,
where a section carrying no endorsement is not eligible for an answer, so text
smuggled into the workspace by an earlier child cannot reach one; and on the way
out, where the answer's provenance names the class and the artifact records the
atoms of every section that was read. That is CT-2165's ruling made mechanical
for this surface. CT-2165's other half — an ordinary `read_file` of a workspace
doc releasing with an empty label — is untouched and still open.

## Defaults, printed and recorded

A run resolves its corpus once, in `resolveHarnessConfig`, so the CLI, the
console and a child engine reach the same answer: `--docs-corpus-root` if given;
otherwise the labs checkout the harness runs out of (`docs/common`,
`docs/development`, `skills`); otherwise nothing, and the tool is absent.
`--no-docs-corpus` asks for none explicitly. The resolved roots and their source
land in `run-state.json` under `docsCorpus` and in operator output as a
`docsCorpus:` line, which says so plainly when a run resolved none.

This is why several existing expectations moved: `query_docs` is now in the
default parent surface of a run started from a checkout, which is the point.

## Recording the model call

The explore turn reports its attempt through the run's `onAttempt` and its
tokens into descendant usage, the same two records every other model call lands
in. What was sent — the model, the question, each section by path and heading
with its endorsement atoms, and both messages verbatim — is kept on the
tool-output artifact under the call's output id as `exploreRecord`, and stripped
before the answer reaches the caller (`stripInternalToolFields`, which already
did this job for `cfcResult`).

## What phase 1 leaves

The optional `fullTextRef` as a capability-scoped handle minted by the
`acquire_skill` route; any declassification policy for it; and every tuning
question — search-first versus act-first, whether
`PATTERN_AUTHOR_SUBAGENT_SKILL_NAMES` shrinks, decomposing the large guides into
rule-sized anchors. All named in the README and in the system map's panel copy.

## Verification

`deno task test` in `packages/cf-harness` (948 passed, unsandboxed), repo-wide
`deno fmt --check`, `deno lint`, `deno task check`, `deno task check-docs`,
`deno task check-skill-facts`, `check-command-docs`, `check-no-waitfor`,
`check-control-characters`, `check-conflict-markers`, `check-package-cycles` —
all green under the pinned Deno 2.9.4. The system map's data tables gained the
`query_docs` edge and its panel copy, `SNAPSHOT` is bumped, and it was rendered
headlessly at 1440x900 against a local static server for the visual check; no
screenshot is committed. No live model session was run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6804?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



## Review fixes (supervisor cf-review)

- **Blocking, fixed:** `sectionKey` in `docs-corpus/explore.ts` held a literal
  NUL as its separator, which made git read the file as binary and would have
  failed `check-control-characters` once committed. It is now a `\n` escape,
  which neither a corpus path nor a heading can contain. A scan of every
  `.ts` under `packages/cf-harness` confirms no raw codepoint below 0x20
  remains outside tab, newline and carriage return, and the gate passes on the
  committed tree.
- **`fromFileUrl` guard:** the walk is now
  `checkoutDocsCorpusRootsFrom(moduleUrl)`, which returns `[]` for a URL that
  is not `file:` and for one that does not parse, with
  `checkoutDocsCorpusRoots()` applying it to `import.meta.url`. It runs inside
  `resolveHarnessConfig`, so a throw there would take every surface down. Two
  tests cover both branches.
- **Model id form:** the bare `gemini-3.5-flash` is correct and is the form the
  `web_search` profile's `modelOverride` already uses
  (`src/contracts/subagent.ts`, `WEB_SEARCH_SUBAGENT_MODEL`). A profile's
  `modelOverride` reaches the provider verbatim: `resolveSubagentModel`
  (`src/prompt-loop.ts:1235-1241`) returns it unchanged and it becomes the
  request's `model`, which `test/prompt-loop.test.ts:3403` pins as
  `"gemini-3.5-flash"` in the request body for a `web_search` delegation. The
  `google:gemini-3.5-flash` in `test/openai-client.test.ts:131` is a hand-built
  raw client call for native-tool routing, not the profile path. The constant
  now carries a doc comment saying the override reaches the provider verbatim.
