### PR TITLE
refactor(ci): make server-execution flips data-only

### DIFF
--- a/.github/actions/test-records-ship/action.yml
+++ b/.github/actions/test-records-ship/action.yml
@@ -45,8 +45,9 @@ runs:
         if [ -n "$SHIP_SHARD" ]; then
           args+=(--shard "$SHIP_SHARD")
         fi
-        if [ -n "$SHIP_VARIANT" ]; then
-          args+=(--variant "$SHIP_VARIANT")
+        RESOLVED_VARIANT="${SHIP_VARIANT:-${CF_TEST_RECORDS_VARIANT:-}}"
+        if [ -n "$RESOLVED_VARIANT" ]; then
+          args+=(--variant "$RESOLVED_VARIANT")
         fi
         while IFS= read -r spec; do
           if [ -n "$spec" ]; then

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -38,8 +38,8 @@ env:
   CLI_WORK_TIMEOUT_MINUTES: &cli-work-timeout 10
   CLI_FUSE_WORK_TIMEOUT_MINUTES: &cli-fuse-work-timeout 15
   CLI_JOB_TIMEOUT_MINUTES: &cli-job-timeout 25
-  # The server-execution posture probes (two curls against a server that is
-  # already up) take this one; sized for a probe, not a suite.
+  # Server-execution role resolution and posture probes take this one; it is
+  # sized for short control-plane checks, not a suite.
   POSTURE_PROBE_TIMEOUT_MINUTES: &posture-probe-timeout 5
 
 # Every step name must begin with a phase-marker emoji (setup / work / shutdown).
@@ -621,23 +621,11 @@ jobs:
           path: ./dist/toolshed
           if-no-files-found: error
 
-  # The OFF-arm toolshed binary (server-execution v2 — the Phase 7 flip
-  # landed: the first-party default is ON; docs/specs/
-  # server-side-execution/testing.md §2): the browser shell's flag is an
-  # esbuild define burned in at build time (unset = the first-party default,
-  # ON since the flip), so the explicit-`false` OFF regression-guard lanes
-  # need a binary whose shell was built with
-  # EXPERIMENTAL_SERVER_EXECUTION=false — an OFF lane on the default binary
-  # above would run an ON shell against an OFF server, the same MIXED
-  # posture the P7 independent review found (finding 7), mirrored. Same
-  # source, same commit; only the shell define differs, and the OFF lanes
-  # VERIFY the posture the binary carries (/api/meta's
-  # `shellServerExecutionDefine`, written by tasks/build-binaries.ts from
-  # this same environment) before they test. Before the flip PR the roles
-  # were inverted: this job baked `true` for the then-explicit-ON lanes.
-  # The post-soak removal PR deletes this job with the OFF path.
-  build-toolshed-off:
-    name: "Build Binary (toolshed, server-execution OFF shell)"
+  # The posture opposite the first-party default must be baked into its own
+  # browser shell. The stable role is resolved from the same constant as the
+  # product default, so changing that constant swaps the two CI arms together.
+  build-toolshed-opposite:
+    name: "Build Binary (toolshed, opposite server-execution shell)"
     runs-on: ubuntu-latest
     timeout-minutes: *job-timeout
     steps:
@@ -650,17 +638,20 @@ jobs:
       - name: 🔍 Verify lock file & install dependencies
         uses: ./.github/actions/deno-install
 
-      - name: 🏗️ Build toolshed binary (OFF-arm shell)
+      - name: 🧭 Resolve opposite server-execution posture
+        timeout-minutes: *posture-probe-timeout
+        run: deno run tasks/server-execution-ci-command.ts env opposite >> "$GITHUB_ENV"
+
+      - name: 🏗️ Build toolshed binary (opposite shell)
         timeout-minutes: *work-timeout
         run: deno task build-binaries toolshed
         env:
           COMMIT_SHA: ${{ github.sha }}
-          EXPERIMENTAL_SERVER_EXECUTION: "false"
 
-      - name: 📤 Upload toolshed binary (OFF-arm shell)
+      - name: 📤 Upload toolshed binary (opposite shell)
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: binary-toolshed-off
+          name: binary-toolshed-opposite
           path: ./dist/toolshed
           if-no-files-found: error
 
@@ -845,6 +836,10 @@ jobs:
       - name: 🔍 Verify lock file & install dependencies
         uses: ./.github/actions/deno-install
 
+      - name: 🧭 Resolve default server-execution posture
+        timeout-minutes: *posture-probe-timeout
+        run: deno run tasks/server-execution-ci-command.ts env default >> "$GITHUB_ENV"
+
       - name: 📥 Download toolshed binary
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -860,13 +855,7 @@ jobs:
           # then returns, so the test steps never race a not-yet-listening
           # server. The server logs to --log-file, which the launcher prints on
           # success and dumps if the server exits before binding.
-          # Flag unset = the first-party default, ON since the Phase 7 flip:
-          # this DEFAULT lane is the ON arm, serving loop and space-root
-          # ensure both at their production defaults (the ensure coverage the
-          # OW45/OW61 rows flagged rides here — `schema-doc-quarantine` log
-          # lines are expected to be ZERO; a live one is contained, not a
-          # process kill, but is evidence of a client absorb/ordering
-          # defect — OW61's residual trigger).
+          # This lane leaves the flag unset and follows the first-party default.
           CFTS_AI_GATEWAY_URL="" \
           CFTS_AI_LLM_ANTHROPIC_API_KEY=fake \
           ./common-binaries/toolshed --port="$TOOLSHED_PORT" \
@@ -884,32 +873,11 @@ jobs:
             echo "AppArmor unprivileged-userns sysctl is unavailable; no change required."
           fi
 
-      # This is the DEFAULT-posture lane (server-execution v2: flag unset =
-      # the first-party default, ON since the Phase 7 flip; testing.md §2)
-      # — the FULL ON posture at the default resolution: the toolshed
-      # serves, the test processes resolve env-else-default (ON), and the
-      # default-built shell's define fallback is the same constant. The
-      # explicit-`false` OFF regression guard is the `-server-execution-off`
-      # lane below (kept until the post-soak removal PR); the probe here
-      # pins that this lane really is ON (server serving, shell define
-      # unset — the default build), so a silent un-flip of the default
-      # cannot move the REQUIRED lanes off the ON posture unnoticed.
-      - name: ✅ Verify the server-execution posture (default posture — server ON, shell define unset)
+      - name: ✅ Verify the default server-execution posture
         timeout-minutes: *posture-probe-timeout
         env:
           TOOLSHED_PORT: 8000
-        run: |
-          META=$(curl -fsS "http://localhost:${TOOLSHED_PORT}/api/meta")
-          STATS=$(curl -fsS "http://localhost:${TOOLSHED_PORT}/api/health/stats")
-          echo "$META"
-          echo "$META" | jq -e '.shellServerExecutionDefine == null' > /dev/null || {
-            echo "::error::binary-toolshed carries a shell built with an explicit EXPERIMENTAL_SERVER_EXECUTION define; the default lane must run the default-built shell (its define fallback is the first-party constant)"
-            exit 1
-          }
-          echo "$STATS" | jq -e '.servingLoop != null' > /dev/null || {
-            echo "::error::the toolshed did not start the serving loop in the DEFAULT lane; the first-party default is ON (the Phase 7 flip) — un-flipping the default is reverting the flip PR, never a silent change"
-            exit 1
-          }
+        run: deno run --allow-net tasks/server-execution-ci-command.ts probe default "http://localhost:${TOOLSHED_PORT}"
 
       - name: 🧪 Run ${{ matrix.step_name }}
         timeout-minutes: *work-timeout
@@ -924,12 +892,14 @@ jobs:
           if [ "$HEADLESS_ENABLED" = "true" ]; then
             export HEADLESS=1
           fi
-          # The explicit ON-arm skip list rides the DEFAULT lanes since the
-          # flip (testing.md §2: default = ON with the skip list, EMPTY at
-          # the flip); the script prints every skip (or that there are
-          # none) and emits the matching --ignore flag, which binds because
-          # the package `integration` tasks hand deno a QUOTED glob.
-          SX_ON_IGNORE=$(deno run --allow-read ../../tasks/server-execution-on-skips.ts ${{ matrix.suite_name }})
+          SX_ON_IGNORE=""
+          if [ "$SERVER_EXECUTION_ENABLED" = "true" ]; then
+            # The skip registry belongs to the ON arm, whichever stable role
+            # currently carries it.
+            SX_ON_IGNORE=$(deno run --allow-read ../../tasks/server-execution-on-skips.ts ${{ matrix.suite_name }})
+          else
+            echo "Server execution is OFF; the ON-arm skip registry does not apply."
+          fi
           API_URL="http://localhost:${TOOLSHED_PORT}/" \
           INTEGRATION_TEST_FLAGS="--junit-path=../../test-results/${JUNIT_NAME}.xml ${SX_ON_IGNORE}" \
           deno task integration
@@ -964,44 +934,32 @@ jobs:
           job: Package Integration Tests (${{ matrix.suite_name }})
           junit: >-
             kind=integration,scope=${{ matrix.suite_name }},prefix=${{ matrix.package_dir }},glob=test-results/${{ matrix.junit_name }}.xml
-  # The server-execution v2 OFF regression guard (docs/specs/
-  # server-side-execution/testing.md §2, roles since the Phase 7 flip): the
-  # same package integration suites, byte-identical workloads, with
-  # EXPERIMENTAL_SERVER_EXECUTION=false on the toolshed server, on the test
-  # processes (the runner integration harness and the runtime-client worker
-  # resolve env-else-default, so the explicit `false` selects the OFF arm —
-  # UNIFORM, not the mixed posture the P7 independent review found), AND in
-  # the binary's baked browser shell (build-toolshed-off) — the FULL OFF
-  # posture, verified by the probe below before the suite runs. The OFF arm
-  # takes no skip list (tasks/server-execution-on-skips.ts binds to the ON
-  # arm — the DEFAULT lanes since the flip). No coverage collection: the
-  # default lane owns coverage, and this arm exists to keep the rollback
-  # lever honest through the soak. The post-soak removal PR deletes this
-  # lane with the OFF path.
-  package-integration-test-server-execution-off:
-    name: "Package Integration Tests / server-execution OFF (${{ matrix.suite_name }})"
+  # The opposite role runs the same suites with an explicit inverse of the
+  # first-party default in the server, test processes, and baked browser shell.
+  package-integration-test-server-execution-opposite:
+    name: "Package Integration Tests / opposite server-execution (${{ matrix.suite_name }})"
     runs-on: ubuntu-latest
     timeout-minutes: *job-timeout
     env:
       CF_TEST_RECORDS_DIR: ${{ github.workspace }}/test-records-spool
-    needs: ["build-toolshed-off"]
+    needs: ["build-toolshed-opposite"]
     strategy:
       fail-fast: false
       matrix:
         include:
           - suite_name: runner
             package_dir: packages/runner
-            junit_name: runner-server-execution-off
+            junit_name: runner-server-execution-opposite
             step_name: runner integration tests
             headless: false
           - suite_name: runtime-client
             package_dir: packages/runtime-client
-            junit_name: runtime-client-server-execution-off
+            junit_name: runtime-client-server-execution-opposite
             step_name: runtime-client integration tests
             headless: false
           - suite_name: shell
             package_dir: packages/shell
-            junit_name: shell-server-execution-off
+            junit_name: shell-server-execution-opposite
             step_name: shell integration tests
             headless: true
     steps:
@@ -1014,13 +972,17 @@ jobs:
       - name: 🔍 Verify lock file & install dependencies
         uses: ./.github/actions/deno-install
 
-      - name: 📥 Download toolshed binary (OFF-arm shell)
+      - name: 🧭 Resolve opposite server-execution posture
+        timeout-minutes: *posture-probe-timeout
+        run: deno run tasks/server-execution-ci-command.ts env opposite >> "$GITHUB_ENV"
+
+      - name: 📥 Download toolshed binary (opposite shell)
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: binary-toolshed-off
+          name: binary-toolshed-opposite
           path: common-binaries
 
-      - name: 🔌 Start Toolshed server for testing (flag OFF)
+      - name: 🔌 Start Toolshed server for testing (opposite posture)
         env:
           TOOLSHED_PORT: 8000
         run: |
@@ -1031,30 +993,14 @@ jobs:
           # success and dumps if the server exits before binding.
           CFTS_AI_GATEWAY_URL="" \
           CFTS_AI_LLM_ANTHROPIC_API_KEY=fake \
-          EXPERIMENTAL_SERVER_EXECUTION=false \
           ./common-binaries/toolshed --port="$TOOLSHED_PORT" \
             --background --log-file="$RUNNER_TEMP/toolshed.log"
 
-      # The posture the binary ACTUALLY carries: the shell define is baked at
-      # build time, so an OFF lane on a default-built binary would silently be
-      # the mixed posture (ON shell against an OFF server); and the server
-      # must really not be serving.
-      - name: ✅ Verify the server-execution posture (server OFF, shell OFF-built)
+      - name: ✅ Verify the opposite server-execution posture
         timeout-minutes: *posture-probe-timeout
         env:
           TOOLSHED_PORT: 8000
-        run: |
-          META=$(curl -fsS "http://localhost:${TOOLSHED_PORT}/api/meta")
-          STATS=$(curl -fsS "http://localhost:${TOOLSHED_PORT}/api/health/stats")
-          echo "$META"
-          echo "$META" | jq -e '.shellServerExecutionDefine == "false"' > /dev/null || {
-            echo "::error::binary-toolshed-off does not carry an OFF-built shell (EXPERIMENTAL_SERVER_EXECUTION=false must reach tasks/build-binaries.ts and the shell build); the OFF lane would run a MIXED posture"
-            exit 1
-          }
-          echo "$STATS" | jq -e '.servingLoop == null' > /dev/null || {
-            echo "::error::the toolshed started the serving loop under EXPERIMENTAL_SERVER_EXECUTION=false; the OFF regression-guard lane's server posture is ON"
-            exit 1
-          }
+        run: deno run --allow-net tasks/server-execution-ci-command.ts probe opposite "http://localhost:${TOOLSHED_PORT}"
 
       # For Astral
       # https://github.com/lino-levan/astral/blob/f5ef833b2c5bde3783564a6b925073d5d46bb4b8/README.md#no-usable-sandbox-with-user-namespace-cloning-enabled
@@ -1068,7 +1014,7 @@ jobs:
             echo "AppArmor unprivileged-userns sysctl is unavailable; no change required."
           fi
 
-      - name: 🧪 Run ${{ matrix.step_name }} (flag OFF)
+      - name: 🧪 Run ${{ matrix.step_name }} (opposite posture)
         timeout-minutes: *work-timeout
         working-directory: ${{ matrix.package_dir }}
         env:
@@ -1080,12 +1026,14 @@ jobs:
           if [ "$HEADLESS_ENABLED" = "true" ]; then
             export HEADLESS=1
           fi
-          # No skip list here: tasks/server-execution-on-skips.ts binds to
-          # the ON arm (the DEFAULT lanes since the flip); the OFF guard
-          # runs the full suite.
+          SX_ON_IGNORE=""
+          if [ "$SERVER_EXECUTION_ENABLED" = "true" ]; then
+            SX_ON_IGNORE=$(deno run --allow-read ../../tasks/server-execution-on-skips.ts ${{ matrix.suite_name }})
+          else
+            echo "Server execution is OFF; the ON-arm skip registry does not apply."
+          fi
           API_URL="http://localhost:${TOOLSHED_PORT}/" \
-          EXPERIMENTAL_SERVER_EXECUTION=false \
-          INTEGRATION_TEST_FLAGS="--junit-path=../../test-results/${JUNIT_NAME}.xml" \
+          INTEGRATION_TEST_FLAGS="--junit-path=../../test-results/${JUNIT_NAME}.xml ${SX_ON_IGNORE}" \
           deno task integration
 
       - name: 📤 Upload test timing data
@@ -1101,10 +1049,9 @@ jobs:
         if: always()
         uses: ./.github/actions/test-records-ship
         with:
-          artifact: package-integration-server-execution-off-${{ matrix.suite_name }}
-          variant: server-execution-off
+          artifact: package-integration-server-execution-opposite-${{ matrix.suite_name }}
           job: >-
-            Package Integration Tests / server-execution OFF
+            Package Integration Tests / opposite server-execution
             (${{ matrix.suite_name }})
           junit: >-
             kind=integration,scope=${{ matrix.suite_name }},prefix=${{ matrix.package_dir }},glob=test-results/${{ matrix.junit_name }}.xml
@@ -1151,6 +1098,10 @@ jobs:
       - name: 🔍 Verify lock file & install dependencies
         uses: ./.github/actions/deno-install
 
+      - name: 🧭 Resolve default server-execution posture
+        timeout-minutes: *posture-probe-timeout
+        run: deno run tasks/server-execution-ci-command.ts env default >> "$GITHUB_ENV"
+
       - name: 📥 Download toolshed binary
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1179,43 +1130,27 @@ jobs:
             ./common-binaries/toolshed --port="$TOOLSHED_PORT" \
             --background --log-file="$RUNNER_TEMP/toolshed.log"
 
-      # The CLI suites are a deployed-topology gate for `cf` under the
-      # flipped server-execution default (the flip PR's own obligation; P7
-      # review finding 8): the default-built toolshed resolves ON, and the
-      # cf binary ADOPTS the server's published posture
-      # (experimentalOptionsForDeployedClient — /api/meta, authority
-      # "server"), so every piece/acl/fuse flow below exercises the CLI ON.
-      # The probe pins BOTH halves. A serving loop alone is only the
-      # server's: it says nothing about the arm `cf` resolves, and a client
-      # on the other arm is exactly the MIXED posture the P7 independent
-      # review found (finding 7) — which would make this lane's ON exercise
-      # a fiction that reads as a pass. So the probe also resolves the
-      # client arm the way `cf` does — an explicit
-      # EXPERIMENTAL_SERVER_EXECUTION wins, else the published posture —
-      # and refuses a run whose two arms disagree.
-      - name: ✅ Verify the server-execution posture (default posture — server ON, cf adopts ON)
+      # The server probe verifies the default server and baked shell. The
+      # client check also verifies that `cf` adopts the published arm rather
+      # than silently creating a mixed posture.
+      - name: ✅ Verify the default server-execution posture and cf adoption
         timeout-minutes: *posture-probe-timeout
         env:
           TOOLSHED_PORT: ${{ matrix.toolshed_port }}
         run: |
+          deno run --allow-net tasks/server-execution-ci-command.ts probe default "http://localhost:${TOOLSHED_PORT}"
           META=$(curl -fsS "http://localhost:${TOOLSHED_PORT}/api/meta")
-          STATS=$(curl -fsS "http://localhost:${TOOLSHED_PORT}/api/health/stats")
-          echo "$META"
-          echo "$STATS" | jq -e '.servingLoop != null' > /dev/null || {
-            echo "::error::the toolshed did not start the serving loop in the CLI lane; the first-party default is ON (the Phase 7 flip) — the CLI would exercise the OFF arm and the deployed-topology gate would be vacuous"
-            exit 1
-          }
-          SERVER_ARM=$(echo "$META" | jq -r '.experimental.serverExecution // "unpublished"')
+          SERVER_ARM=$(echo "$META" | jq -r 'if .experimental.serverExecution == null then "unpublished" else (.experimental.serverExecution | tostring) end')
           CLIENT_ARM="${EXPERIMENTAL_SERVER_EXECUTION:-$SERVER_ARM}"
-          if [ "$SERVER_ARM" != "true" ]; then
-            echo "::error::the toolshed is serving but publishes serverExecution=$SERVER_ARM on /api/meta; cf adopts what is published, so this lane would run a MIXED posture (an OFF client against a serving server)"
+          if [ "$SERVER_ARM" != "$SERVER_EXECUTION_ENABLED" ]; then
+            echo "::error::the toolshed publishes serverExecution=$SERVER_ARM; the resolved default is $SERVER_EXECUTION_ENABLED"
             exit 1
           fi
           if [ "$CLIENT_ARM" != "$SERVER_ARM" ]; then
             echo "::error::MIXED posture in the CLI lane: cf resolves serverExecution=$CLIENT_ARM (an explicit EXPERIMENTAL_SERVER_EXECUTION overrides the deployment's posture) while the toolshed publishes $SERVER_ARM; a mixed run is never a valid arm exercise"
             exit 1
           fi
-          echo "cf resolves serverExecution=$CLIENT_ARM against a toolshed publishing $SERVER_ARM and serving."
+          echo "cf resolves serverExecution=$CLIENT_ARM against a toolshed publishing $SERVER_ARM with a matching posture."
 
       - name: 📦 Install CLI integration dependencies
         uses: ./.github/actions/apt-install
@@ -1356,6 +1291,10 @@ jobs:
       - name: 🔍 Verify lock file & install dependencies
         uses: ./.github/actions/deno-install
 
+      - name: 🧭 Resolve default server-execution posture
+        timeout-minutes: *posture-probe-timeout
+        run: deno run tasks/server-execution-ci-command.ts env default >> "$GITHUB_ENV"
+
       # Cross-run compile cache: persist the per-shard compiled-module-byte cache
       # so unchanged patterns reuse last run's emitted bytes (skip the
       # type-check + transform + emit). The key folds in a hash of everything
@@ -1421,41 +1360,9 @@ jobs:
             echo "AppArmor unprivileged-userns sysctl is unavailable; no change required."
           fi
 
-      # V8 runtime coverage via DENO_COVERAGE_DIR only. AUTHORED-pattern
-      # coverage (CF_PATTERN_COVERAGE_DIR) moved to the OFF guard lane with
-      # the flip: instrumentation changes the compiled pattern's bytes, so
-      # under the ON default the client's collector compiles a DIFFERENT
-      # content-addressed variant than the serving side — the client's
-      # speculative `computed:` entries can then never be covered by the
-      # served watermark and authored writes over them are refused
-      # (speculation.md §6; the flip board's deterministic sx2-speculation
-      # red). Until serving-side instrumented-variant parity exists (the
-      # register's recorded post-soak obligation), authored coverage is
-      # collected where a single compiler world holds — the OFF lane.
-      # See docs/development/COVERAGE.md.
-      # This is the DEFAULT-posture lane (server-execution v2: flag unset =
-      # the first-party default, ON since the Phase 7 flip; testing.md §2)
-      # — the FULL ON posture at the default resolution; the
-      # explicit-`false` OFF regression guard is the
-      # `-server-execution-off` lane below (kept until the post-soak
-      # removal PR). The probe pins that this lane really is ON (server
-      # serving, shell define unset — the default build resolves the
-      # constant), so a silent un-flip of the default cannot move the
-      # REQUIRED lanes off the ON posture unnoticed.
-      - name: ✅ Verify the server-execution posture (default posture — server ON, shell define unset)
+      - name: ✅ Verify the default server-execution posture
         timeout-minutes: *posture-probe-timeout
-        run: |
-          META=$(curl -fsS "http://localhost:8000/api/meta")
-          STATS=$(curl -fsS "http://localhost:8000/api/health/stats")
-          echo "$META"
-          echo "$META" | jq -e '.shellServerExecutionDefine == null' > /dev/null || {
-            echo "::error::binary-toolshed carries a shell built with an explicit EXPERIMENTAL_SERVER_EXECUTION define; the default lane must run the default-built shell (its define fallback is the first-party constant)"
-            exit 1
-          }
-          echo "$STATS" | jq -e '.servingLoop != null' > /dev/null || {
-            echo "::error::the toolshed did not start the serving loop in the DEFAULT lane; the first-party default is ON (the Phase 7 flip) — un-flipping the default is reverting the flip PR, never a silent change"
-            exit 1
-          }
+        run: deno run --allow-net tasks/server-execution-ci-command.ts probe default http://localhost:8000
 
       - name: 🧩 Run end-to-end patterns integration tests
         timeout-minutes: *work-timeout
@@ -1466,9 +1373,8 @@ jobs:
           # empty list that runs ZERO test files and exits green. The
           # selector throws on an empty selection (every shard carries the
           # internally-sharded files), so an empty result here is only ever
-          # a failure — reject it loudly as the backstop. The legitimate
-          # empty case lives one stage LATER, after the ON-skip filter,
-          # which rides THIS lane since the flip.
+          # a failure — reject it loudly as the backstop. A legitimate empty
+          # case can occur only after filtering whichever role carries ON.
           SELECTED_FILES=$(deno run --allow-read ../../tasks/select-pattern-integration-files.ts ${{ matrix.shard }}/${{ matrix.total }})
           if [ -z "$SELECTED_FILES" ]; then
             echo "::error::select-pattern-integration-files.ts selected no files for shard ${{ matrix.shard }}/${{ matrix.total }}"
@@ -1477,23 +1383,25 @@ jobs:
           mapfile -t SHARD_FILES <<< "$SELECTED_FILES"
           printf 'Pattern integration shard ${{ matrix.shard }}/${{ matrix.total }} files:\n'
           printf '  %s\n' "${SHARD_FILES[@]}"
-          # The explicit ON-arm skip list rides the DEFAULT lanes since the
-          # flip (testing.md §2: default = ON with the skip list, EMPTY at
-          # the flip), applied by FILTERING this shard's file list (the
-          # script prints every skip, and which of them it dropped from
-          # THIS list, on stderr): `deno test --ignore` binds only to files
-          # deno discovers itself and silently ignores nothing when the
-          # files arrive as explicit arguments, as they do here. Command
-          # substitution (not a process substitution) so a validation
-          # failure in the script fails this step under `bash -e` instead
-          # of reading as an empty list.
-          FILTERED_FILES=$(deno run --allow-read ../../tasks/server-execution-on-skips.ts patterns --filter "${SHARD_FILES[@]}")
-          if [ -z "$FILTERED_FILES" ]; then
-            echo "Every file of this shard is skip-listed for the ON arm; nothing to run."
-            exit 0
+          if [ "$SERVER_EXECUTION_ENABLED" = "true" ]; then
+            # `--ignore` does not bind to explicit file arguments, so the ON
+            # registry filters this shard before Deno receives it.
+            FILTERED_FILES=$(deno run --allow-read ../../tasks/server-execution-on-skips.ts patterns --filter "${SHARD_FILES[@]}")
+            if [ -z "$FILTERED_FILES" ]; then
+              echo "Every file of this shard is skip-listed for the ON arm; nothing to run."
+              exit 0
+            fi
+            mapfile -t TEST_FILES <<< "$FILTERED_FILES"
+          else
+            echo "Server execution is OFF; the ON-arm skip registry does not apply."
+            TEST_FILES=("${SHARD_FILES[@]}")
           fi
-          mapfile -t TEST_FILES <<< "$FILTERED_FILES"
           mkdir -p ../../test-results
+          # Authored-pattern instrumentation is sound only in the OFF arm's
+          # single-compiler world. V8 runtime coverage remains on the default.
+          if [ "$SERVER_EXECUTION_ENABLED" = "false" ]; then
+            export CF_PATTERN_COVERAGE_DIR="${{ github.workspace }}/coverage/lcov/pattern-runtime/pattern-integration-${{ matrix.shard }}"
+          fi
           # --no-check: the Check job type-checks packages/patterns/integration
           # (tasks/check.sh).
           HEADLESS=1 \
@@ -1505,9 +1413,6 @@ jobs:
             --junit-path=../../test-results/patterns-${{ matrix.shard }}.xml \
             "${TEST_FILES[@]}"
 
-      # The default lane is the ON exercise since the flip; its toolshed log
-      # is the first triage artifact for a red shard (the role the old
-      # explicit-ON lane's upload played).
       - name: 📋 Upload toolshed log on failure
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -1553,26 +1458,15 @@ jobs:
           shard: ${{ matrix.shard }}/${{ matrix.total }}
           junit: >-
             kind=integration,scope=patterns,prefix=packages/patterns,glob=test-results/patterns-${{ matrix.shard }}.xml
-  # The server-execution v2 OFF regression guard of the end-to-end pattern
-  # suite (docs/specs/server-side-execution/testing.md §2, roles since the
-  # Phase 7 flip): the same shards, byte-identical workloads, with
-  # EXPERIMENTAL_SERVER_EXECUTION=false on the toolshed server, on the test
-  # processes, AND baked into the binary's browser shell
-  # (build-toolshed-off) — the FULL OFF posture, verified by the probe
-  # below before the shard runs. The OFF arm takes no skip list
-  # (tasks/server-execution-on-skips.ts binds to the ON arm — the DEFAULT
-  # lanes since the flip; the lists were EMPTY across ALL suites at the
-  # flip, the ruled-3b-close lift's precondition). No coverage collection
-  # and no cache save-back: the default lane owns both; the compile byte
-  # cache is restored read-only (compiled bytes do not depend on the
-  # flag). The post-soak removal PR deletes this lane with the OFF path.
-  pattern-integration-test-server-execution-off:
-    name: "Pattern Integration Tests / server-execution OFF (${{ matrix.shard }}/${{ matrix.total }})"
+  # The opposite role runs the same shards with an explicit inverse of the
+  # first-party default in the server, tests, and baked browser shell.
+  pattern-integration-test-server-execution-opposite:
+    name: "Pattern Integration Tests / opposite server-execution (${{ matrix.shard }}/${{ matrix.total }})"
     runs-on: ubuntu-latest
     timeout-minutes: *job-timeout
     env:
       CF_TEST_RECORDS_DIR: ${{ github.workspace }}/test-records-spool
-    needs: ["build-toolshed-off"]
+    needs: ["build-toolshed-opposite"]
     strategy:
       fail-fast: false
       matrix:
@@ -1588,6 +1482,10 @@ jobs:
       - name: 🔍 Verify lock file & install dependencies
         uses: ./.github/actions/deno-install
 
+      - name: 🧭 Resolve opposite server-execution posture
+        timeout-minutes: *posture-probe-timeout
+        run: deno run tasks/server-execution-ci-command.ts env opposite >> "$GITHUB_ENV"
+
       # Read-only seed from the default lane's compile byte cache (same key
       # family): compiled module bytes are a function of sources, not of the
       # runtime flag, so reuse is sound; only the default lane saves. The key
@@ -1601,38 +1499,25 @@ jobs:
           restore-keys: |
             cc-${{ hashFiles('packages/ts-transformers/**', 'packages/js-compiler/**', 'packages/runner/src/harness/**', 'packages/runner/src/pattern-coverage.ts', 'packages/runner/src/sandbox/**', 'packages/schema-generator/**', 'packages/api/**', 'packages/static/assets/types/**', 'deno.jsonc', 'deno.lock') }}-${{ matrix.total }}-${{ matrix.shard }}-
 
-      - name: 📥 Download toolshed binary (OFF-arm shell)
+      - name: 📥 Download toolshed binary (opposite shell)
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: binary-toolshed-off
+          name: binary-toolshed-opposite
           path: common-binaries
 
-      - name: 🔌 Start Toolshed server for testing (flag OFF)
+      - name: 🔌 Start Toolshed server for testing (opposite posture)
         run: |
           chmod +x ./common-binaries/toolshed
           # --background waits until the server has bound its port before it
           # returns, so the test steps never race a not-yet-listening server.
           CFTS_AI_GATEWAY_URL="" \
           CFTS_AI_LLM_ANTHROPIC_API_KEY=fake \
-          EXPERIMENTAL_SERVER_EXECUTION=false \
           ./common-binaries/toolshed \
             --background --log-file="$RUNNER_TEMP/toolshed.log"
 
-      # The posture the binary ACTUALLY carries (see the package OFF lane).
-      - name: ✅ Verify the server-execution posture (server OFF, shell OFF-built)
+      - name: ✅ Verify the opposite server-execution posture
         timeout-minutes: *posture-probe-timeout
-        run: |
-          META=$(curl -fsS "http://localhost:8000/api/meta")
-          STATS=$(curl -fsS "http://localhost:8000/api/health/stats")
-          echo "$META"
-          echo "$META" | jq -e '.shellServerExecutionDefine == "false"' > /dev/null || {
-            echo "::error::binary-toolshed-off does not carry an OFF-built shell (EXPERIMENTAL_SERVER_EXECUTION=false must reach tasks/build-binaries.ts and the shell build); the OFF lane would run a MIXED posture"
-            exit 1
-          }
-          echo "$STATS" | jq -e '.servingLoop == null' > /dev/null || {
-            echo "::error::the toolshed started the serving loop under EXPERIMENTAL_SERVER_EXECUTION=false; the OFF regression-guard lane's server posture is ON"
-            exit 1
-          }
+        run: deno run --allow-net tasks/server-execution-ci-command.ts probe opposite http://localhost:8000
 
       # For Astral
       # https://github.com/lino-levan/astral/blob/f5ef833b2c5bde3783564a6b925073d5d46bb4b8/README.md#no-usable-sandbox-with-user-namespace-cloning-enabled
@@ -1646,7 +1531,7 @@ jobs:
             echo "AppArmor unprivileged-userns sysctl is unavailable; no change required."
           fi
 
-      - name: 🧩 Run end-to-end patterns integration tests (flag OFF)
+      - name: 🧩 Run end-to-end patterns integration tests (opposite posture)
         timeout-minutes: *work-timeout
         working-directory: packages/patterns
         run: |
@@ -1655,48 +1540,47 @@ jobs:
           # empty list that runs ZERO test files and exits green. The
           # selector throws on an empty selection (every shard carries the
           # internally-sharded files), so an empty result here is only ever
-          # a failure — reject it loudly as the backstop. This OFF guard
-          # runs the full shard list, so there is no later legitimate
-          # empty stage: the ON-skip filter rides the DEFAULT lane.
+          # a failure — reject it loudly as the backstop.
           SELECTED_FILES=$(deno run --allow-read ../../tasks/select-pattern-integration-files.ts ${{ matrix.shard }}/${{ matrix.total }})
           if [ -z "$SELECTED_FILES" ]; then
             echo "::error::select-pattern-integration-files.ts selected no files for shard ${{ matrix.shard }}/${{ matrix.total }}"
             exit 1
           fi
-          mapfile -t TEST_FILES <<< "$SELECTED_FILES"
+          mapfile -t SHARD_FILES <<< "$SELECTED_FILES"
           printf 'Pattern integration shard ${{ matrix.shard }}/${{ matrix.total }} files:\n'
-          printf '  %s\n' "${TEST_FILES[@]}"
+          printf '  %s\n' "${SHARD_FILES[@]}"
+          if [ "$SERVER_EXECUTION_ENABLED" = "true" ]; then
+            FILTERED_FILES=$(deno run --allow-read ../../tasks/server-execution-on-skips.ts patterns --filter "${SHARD_FILES[@]}")
+            if [ -z "$FILTERED_FILES" ]; then
+              echo "Every file of this shard is skip-listed for the ON arm; nothing to run."
+              exit 0
+            fi
+            mapfile -t TEST_FILES <<< "$FILTERED_FILES"
+          else
+            echo "Server execution is OFF; the ON-arm skip registry does not apply."
+            TEST_FILES=("${SHARD_FILES[@]}")
+          fi
           mkdir -p ../../test-results
-          # No skip filter here: tasks/server-execution-on-skips.ts binds to
-          # the ON arm (the DEFAULT lanes since the flip); the OFF guard
-          # runs the full shard list.
-          # AUTHORED-pattern coverage rides THIS lane since the flip (see
-          # the default lane's note: instrumentation diverges the compiled
-          # variant from what the serving side compiles, so collecting it
-          # under the ON default is unsound until serving-side variant
-          # parity exists — the register's post-soak obligation). The OFF
-          # arm is a single-compiler world, where the collection is sound.
+          if [ "$SERVER_EXECUTION_ENABLED" = "false" ]; then
+            export CF_PATTERN_COVERAGE_DIR="${{ github.workspace }}/coverage/lcov/pattern-runtime/pattern-integration-${{ matrix.shard }}"
+          fi
           # --no-check: the Check job type-checks packages/patterns/integration
           # (tasks/check.sh).
           HEADLESS=1 \
           API_URL=http://localhost:8000/ \
-          EXPERIMENTAL_SERVER_EXECUTION=false \
           PATTERN_INTEGRATION_SHARD="${{ matrix.shard }}/${{ matrix.total }}" \
           CF_COMPILE_CACHE_FILE="${{ github.workspace }}/.compile-cache/pattern-integration-${{ matrix.shard }}.json" \
-          CF_PATTERN_COVERAGE_DIR="${{ github.workspace }}/coverage/lcov/pattern-runtime/pattern-integration-${{ matrix.shard }}" \
           deno test --no-check --v8-flags=--max-old-space-size=4096 --trace-leaks -A \
-            --junit-path=../../test-results/patterns-server-execution-off-${{ matrix.shard }}.xml \
+            --junit-path=../../test-results/patterns-server-execution-opposite-${{ matrix.shard }}.xml \
             "${TEST_FILES[@]}"
 
-      # The authored-pattern LCOV the harness wrote under pattern-runtime/
-      # (the collection moved here with the flip — see the run step's note).
-      # coverage-check globs every coverage-profile-* artifact, so these
-      # rows keep reaching the gate from the OFF lane.
+      # If this role carries OFF, the harness writes authored-pattern LCOV
+      # under pattern-runtime/. The coverage gate globs every profile artifact.
       - name: 📤 Upload coverage report
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: coverage-profile-pattern-integration-off-${{ matrix.shard }}
+          name: coverage-profile-pattern-integration-opposite-${{ matrix.shard }}
           path: coverage/lcov/
           retention-days: 90
           if-no-files-found: ignore
@@ -1705,7 +1589,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: toolshed-log-pattern-integration-server-execution-off-${{ matrix.shard }}
+          name: toolshed-log-pattern-integration-server-execution-opposite-${{ matrix.shard }}
           path: ${{ runner.temp }}/toolshed.log
           retention-days: 14
           if-no-files-found: ignore
@@ -1714,7 +1598,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: test-timing-pattern-integration-server-execution-off-${{ matrix.shard }}
+          name: test-timing-pattern-integration-server-execution-opposite-${{ matrix.shard }}
           path: test-results/
           retention-days: 90
           if-no-files-found: ignore
@@ -1723,14 +1607,13 @@ jobs:
         if: always()
         uses: ./.github/actions/test-records-ship
         with:
-          artifact: pattern-integration-server-execution-off-${{ matrix.shard }}
-          variant: server-execution-off
+          artifact: pattern-integration-server-execution-opposite-${{ matrix.shard }}
           job: >-
-            Pattern Integration Tests / server-execution OFF
+            Pattern Integration Tests / opposite server-execution
             (${{ matrix.shard }}/${{ matrix.total }})
           shard: ${{ matrix.shard }}/${{ matrix.total }}
           junit: >-
-            kind=integration,scope=patterns,prefix=packages/patterns,glob=test-results/patterns-server-execution-off-${{ matrix.shard }}.xml
+            kind=integration,scope=patterns,prefix=packages/patterns,glob=test-results/patterns-server-execution-opposite-${{ matrix.shard }}.xml
 
   pattern-reload-integration-test:
     name: "Pattern Reload Integration Tests"
@@ -1887,22 +1770,9 @@ jobs:
           job: Pattern Unit Tests (${{ matrix.chunk }}/${{ matrix.total }})
           shard: ${{ matrix.chunk }}/${{ matrix.total }}
 
-  # The deployed-topology posture gates (server-execution v2 Phase 7's flip
-  # PR — its own recorded obligation; the P7 independent review's finding
-  # 8): the presets flip binaries and hosts that no other lane exercises at
-  # the DEFAULT resolution. Two gates against one default-built (ON)
-  # toolshed: the REAL bg-piece-service binary starts, initializes against
-  # the serving toolshed, reports its resolved posture (its startup log
-  # line — the binary has no HTTP surface), and stops cleanly on SIGTERM;
-  # and cf-harness's production fabric-session factory (PKCS#8 identity
-  # from disk → PiecesController.initialize → deployed-client adoption)
-  # resolves ON with nothing declared and serves one genuine piece flow.
-  # The other two topologies ride existing lanes since the flip: the CLI's
-  # gate is cli-integration-test (cf adopts the server's published posture;
-  # probed there), and PiecesController hosts ride the default
-  # package/pattern lanes (sx2-scale's controllers and the
-  # pieces-controller helper). The post-soak removal PR keeps this job —
-  # it gates the surviving default posture, not the OFF path.
+  # These gates exercise production construction paths with the flag unset:
+  # the real bg-piece-service binary and cf-harness's fabric-session factory.
+  # Their expectations follow the same first-party default constant.
   deployed-topology-gate:
     name: "Deployed Topology Posture Gates"
     runs-on: ubuntu-latest
@@ -1919,6 +1789,10 @@ jobs:
 
       - name: 🔍 Verify lock file & install dependencies
         uses: ./.github/actions/deno-install
+
+      - name: 🧭 Resolve default server-execution posture
+        timeout-minutes: *posture-probe-timeout
+        run: deno run tasks/server-execution-ci-command.ts env default >> "$GITHUB_ENV"
 
       - name: 📥 Download toolshed binary
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -1939,29 +1813,17 @@ jobs:
           chmod +x ./common-binaries/toolshed
           chmod +x ./common-binaries/bg-piece-service
           # --background waits until the server has bound its port before it
-          # returns. Flag unset = the first-party default (ON since the
-          # flip) — the gates below exercise exactly that resolution.
+          # returns. The flag stays unset so the gates exercise the default.
           CFTS_AI_GATEWAY_URL="" \
           CFTS_AI_LLM_ANTHROPIC_API_KEY=fake \
           ./common-binaries/toolshed --port="$TOOLSHED_PORT" \
             --background --log-file="$RUNNER_TEMP/toolshed.log"
 
-      - name: ✅ Verify the server-execution posture (default posture — server ON, shell define unset)
+      - name: ✅ Verify the default server-execution posture
         timeout-minutes: *posture-probe-timeout
         env:
           TOOLSHED_PORT: 8000
-        run: |
-          META=$(curl -fsS "http://localhost:${TOOLSHED_PORT}/api/meta")
-          STATS=$(curl -fsS "http://localhost:${TOOLSHED_PORT}/api/health/stats")
-          echo "$META"
-          echo "$META" | jq -e '.shellServerExecutionDefine == null' > /dev/null || {
-            echo "::error::binary-toolshed carries a shell built with an explicit EXPERIMENTAL_SERVER_EXECUTION define; the deployed-topology gates must run against the default build"
-            exit 1
-          }
-          echo "$STATS" | jq -e '.servingLoop != null' > /dev/null || {
-            echo "::error::the toolshed did not start the serving loop at the default resolution; the first-party default is ON (the Phase 7 flip) — the deployed-topology gates would be vacuous"
-            exit 1
-          }
+        run: deno run --allow-net tasks/server-execution-ci-command.ts probe default "http://localhost:${TOOLSHED_PORT}"
 
       - name: 🧪 Run bg-piece-service posture gate
         timeout-minutes: *work-timeout
@@ -2028,11 +1890,8 @@ jobs:
       - package-integration-test
       - cli-integration-test
       - pattern-integration-test
-      # The OFF guard pattern lane carries the authored-pattern coverage
-      # since the flip (variant-divergence note on the lanes); the gate
-      # must wait for its artifacts. The post-soak removal PR re-homes
-      # that collection before deleting the lane.
-      - pattern-integration-test-server-execution-off
+      # Whichever pattern lane resolves OFF carries authored-pattern coverage.
+      - pattern-integration-test-server-execution-opposite
       - pattern-reload-integration-test
       - pattern-unit-test
       - generated-patterns-integration-test
@@ -2115,15 +1974,15 @@ jobs:
       - test
       - runner-test
       - build-toolshed
-      - build-toolshed-off
+      - build-toolshed-opposite
       - build-bg-piece-service
       - build-cf
       - generated-patterns-integration-test
       - package-integration-test
-      - package-integration-test-server-execution-off
+      - package-integration-test-server-execution-opposite
       - cli-integration-test
       - pattern-integration-test
-      - pattern-integration-test-server-execution-off
+      - pattern-integration-test-server-execution-opposite
       - pattern-reload-integration-test
       - pattern-unit-test
       - deployed-topology-gate
@@ -2155,10 +2014,8 @@ jobs:
     timeout-minutes: *job-timeout
     # A release artifact must not outlive a failed pattern-migration gate.
     # Production deploys consume this artifact without rerunning those gates.
-    # Since the flip, deployed-topology-gate is in the list for the same
-    # reason: it exercises the very binaries this job attests (toolshed
-    # serving at the default posture; bg-piece-service resolving it), and a
-    # binary that fails its posture gate must not reach a deploy.
+    # The deployed-topology gate exercises the binaries this job attests at
+    # the first-party default, so a binary that fails it must not deploy.
     needs:
       [
         "test",

--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -21,7 +21,7 @@ in the same change.
 flags](#appendix-a-removed-and-never-shipped-flags) rather than deleting the
 > record, so the history stays discoverable.
 
-**Last reviewed:** 2026-08-28. Each flag's section carries the date its status
+**Last reviewed:** 2026-09-02. Each flag's section carries the date its status
 was last checked against the code.
 
 ## Summary table
@@ -35,7 +35,7 @@ was last checked against the code.
 | [`computedCellIds`](#computedcellids)                                       | `EXPERIMENTAL_COMPUTED_CELL_IDS` env, or `RuntimeOptions.experimental`                                                                          | on                                                                                   | Robin McCollum (#4659)                                | graduate to unconditional behavior, then delete flag                                                                                                                                                                              | implemented, on by default                                                      |
 | [`lazyMaterialization`](#lazymaterialization)                               | `EXPERIMENTAL_LAZY_MATERIALIZATION` env, or `RuntimeOptions.experimental`                                                                       | on                                                                                   | Bernhard Seefeld                                      | fold into base read semantics, then delete flag                                                             | implemented, on by default                                         |
 | [`readerSchemaPrecedence`](#readerschemaprecedence)                         | `EXPERIMENTAL_READER_SCHEMA_PRECEDENCE` env, or `RuntimeOptions.experimental`                                                                   | on                                                                                   | Robin McCollum (#6338)                                | graduate to unconditional behavior, then delete flag                                                                                                                                                                              | implemented, on by default                                                      |
-| [`serverExecution`](#serverexecution) | `EXPERIMENTAL_SERVER_EXECUTION` env, or `RuntimeOptions.experimental` | **on** (`SERVER_EXECUTION_DEFAULT_ENABLED = true` — the ONE first-party default, FLIPPED by the flip PR 2026-08-28; explicit `false` = the OFF arm / rollback lever) | Bernhard Seefeld (#5339, server-execution v2 plan Phase 1 stage A; Phase 7 flip-ready #5849) | soak on main (started at the flip PR's merge), then delete the flag and the OFF path (the split-out post-soak PR, which also removes the OFF guard lanes) | Phases 1–7 landed; the flip PR made ON the default everywhere the deployed-topology presets reach; OFF stays fully selectable through the soak and is CI-guarded on an OFF-built binary |
+| [`serverExecution`](#serverexecution) | `EXPERIMENTAL_SERVER_EXECUTION` env, or `RuntimeOptions.experimental` | **on** (`SERVER_EXECUTION_DEFAULT_ENABLED = true`; explicit `false` = rollback) | Bernhard Seefeld (#5339, server-execution v2 plan Phase 1 stage A; Phase 7 flip-ready #5849) | soak on main, then delete the flag and OFF path | Phases 1–7 landed; stable `default`/`opposite` CI roles keep both postures guarded and make a default flip data-only |
 | [`cfcEnforcementMode`](#cfcenforcementmode)                                 | `RuntimeOptions.cfcEnforcementMode` (`CF_CFC_MODE` in the cf-harness / fuse)                                                                    | `enforce-explicit`                                                                   | Bernhard Seefeld (#3263)                              | tighten default toward `enforce-strict`                                                                                                                                                                                           | active; ladder is permanent                                                     |
 | [`cfcFlowLabels`](#cfcflowlabels)                                           | `RuntimeOptions.cfcFlowLabels`                                                                                                                  | `off`                                                                                | Bernhard Seefeld (#4011)                              | move toward `persist`                                                                                                                                                                                                             | implemented, staged rollout                                                     |
 | [`cfcWriteFloor`](#cfcwritefloor)                                           | `RuntimeOptions.cfcWriteFloor`                                                                                                                  | `off`                                                                                | Bernhard Seefeld (#4479)                              | move toward `enforce`                                                                                                                                                                                                             | implemented, staged rollout                                                     |
@@ -380,10 +380,13 @@ server](#clients-that-are-not-built-alongside-their-server).
   `EXPERIMENTAL_SERVER_EXECUTION=false` (or `experimental.serverExecution:
   false`, or the shell define `"false"`) selects the OFF arm — THE
   ROLLBACK LEVER through the soak — and an explicit `true` the ON arm,
-  regardless of the constant. Un-flipping the default is reverting the
-  flip PR (repo convention: a flip is reverted by reverting the PR that
-  only flips — it carries the constant, the absolute pin, the CI lane
-  roles + probes, the deployed-topology gates, and this entry together).
+  regardless of the constant. CI resolves stable `default` and `opposite`
+  roles through `tasks/server-execution-ci.ts`: `default` leaves the flag
+  unset, while `opposite` explicitly selects the inverse and bakes that same
+  value into its toolshed shell. Therefore changing the default requires only
+  changing `SERVER_EXECUTION_DEFAULT_ENABLED` and the current-status prose;
+  workflow job topology, probes, skip placement, coverage ownership, and test
+  record variants follow automatically.
   Single-process harnesses do not
   read the constant: a bare `new Runtime` and the `patternTest` /
   `localDev` / `unitTest` presets have no serving host, so they resolve the
@@ -393,20 +396,25 @@ server](#clients-that-are-not-built-alongside-their-server).
   the lane-posture item the topics measurement report recorded for the
   flip decision); the ON posture's unit coverage sets the
   flag explicitly (the `executor-*` suites) and its integration coverage
-  is the DEFAULT CI lanes. In CI (testing.md §2) the DEFAULT lanes are
-  the ON posture (probed: serving loop present, shell define unset), the
-  explicit-`false` lanes on an OFF-BUILT binary (`build-toolshed-off`;
-  the shell define is baked at build) are the OFF regression guard, the
+  is the DEFAULT CI lanes. In CI (testing.md §2), `default` is currently ON
+  and `opposite` is currently OFF. Both are probed through the shared role
+  resolver; the opposite lane uses `build-toolshed-opposite`, whose shell
+  define is baked from the resolved inverse. The
   `deployed-topology-gate` job exercises the real `bg-piece-service`
   binary and cf-harness's fabric session at the default resolution, and
   the CLI lanes probe the server their `cf` adopts its posture from —
-  with ON-arm skips only through `tasks/server-execution-on-skips.ts`,
-  printed loudly (EMPTY at the flip, its stated precondition). End
+  with ON-arm skips and OFF-arm authored coverage following the resolved arm.
+  Skips are only through `tasks/server-execution-on-skips.ts`, printed loudly
+  (EMPTY at the flip, its stated precondition). End
   state: after a soak on main (which started at the flip PR's merge) the
   flag retires and the OFF code path is removed — a separate post-soak
-  PR (the plan's Phase 7 task 2, split from the flip because stacked PRs
-  cannot soak; it also removes the OFF guard lanes and
-  `build-toolshed-off`).
+  PR (the plan's Phase 7 task 2; it also removes the opposite guard lanes and
+  `build-toolshed-opposite`).
+- **Status on 2026-09-02 (toggle hygiene).** The default remains ON and runtime
+  behavior is unchanged. CI now expresses the two postures as stable roles
+  derived from the one default constant. A rollback-default PR can therefore
+  be a constant change plus its status documentation; it does not duplicate or
+  mechanically invert the workflow.
 - **Status on 2026-08-28 (the FLIP).** The flip PR set the constant `true`
   after every ordered gate was met on main (the ON-skip registry EMPTY
   across all four suites — the ruled-3b-close lift #6528; OW31's ruled
@@ -414,7 +422,7 @@ server](#clients-that-are-not-built-alongside-their-server).
   OW45–OW53 CLOSED; the OW38(ii) performance bar RULED met by the owner
   on the topics measurement). It carried the lane-role swap (default
   lanes = the ON arm, probed; explicit-`false` lanes = the OFF guard on
-  `build-toolshed-off`), the deployed-topology gates (the
+  the then-named `build-toolshed-off`), the deployed-topology gates (the
   `bg-piece-service` binary and cf-harness's fabric session at the
   default resolution; the CLI lanes probed as `cf`'s gate;
   `PiecesController` hosts riding the default lanes), and the
@@ -456,9 +464,8 @@ server](#clients-that-are-not-built-alongside-their-server).
   (effects + outbox) remains.
 - **Path to removal.** The flip PR (the constant → `true`) after the
   ordered gates above; soak the default on main; then the post-soak PR
-  retires the flag, removes the OFF path (and the OFF regression-guard CI
-  lanes + the OFF-built binary the flip PR introduces by inverting
-  `build-toolshed-on`), and closes out this entry.
+  retires the flag, removes the OFF path (and the opposite regression-guard
+  lanes + `build-toolshed-opposite`), and closes out this entry.
 
 ---
 

--- a/docs/development/TESTING.md
+++ b/docs/development/TESTING.md
@@ -97,14 +97,16 @@ a focused browser regression with a plain Deno unit test for any extracted
 policy or state machine, because code executed inside Chrome does not enter
 Deno's V8 coverage profile.
 
-### Running a test under the server-execution ON arm
+### Running a test under a server-execution posture
 
-`serverExecution` is off by default, and CI runs the ON arm as its own lanes on
-a toolshed binary built with `EXPERIMENTAL_SERVER_EXECUTION=true`.
-[EXPERIMENTAL_OPTIONS.md](EXPERIMENTAL_OPTIONS.md#serverexecution) covers the
-flag itself.
+`serverExecution` is currently ON by default. CI keeps stable `default` and
+`opposite` roles; `tasks/server-execution-ci.ts` derives their actual ON/OFF
+posture from the first-party default constant. The opposite toolshed binary is
+built with an explicit inverse so its browser shell, server, and test processes
+stay aligned. [EXPERIMENTAL_OPTIONS.md](EXPERIMENTAL_OPTIONS.md#serverexecution)
+covers the flag itself.
 
-Running one of those tests locally means putting the flag on every process the
+Running an explicit posture locally means putting the flag on every process the
 test spans, not only the one `deno test` starts. A pattern integration test
 drives a runtime in the test process and commits through a toolshed, and the
 per-class commit admission rows are enforced by the memory server under the
@@ -148,9 +150,9 @@ worth avoiding here.
 None of this reaches a test that opens a browser. The shell's half of the
 posture is a build-time define that the local dev servers do not carry:
 `/api/meta` reports `shellServerExecutionDefine` as null whatever the toolshed
-was started with, where CI's ON lane requires `"true"`. So this recipe covers a
-browser-free test, whose whole posture is the test process and the toolshed. A
-browser test on a faithful ON arm needs the built binary.
+was started with. That is faithful only to the default role, whose shell follows
+the first-party constant. A browser test on the opposite role needs a binary
+built with the same explicit flag as the server and test process.
 
 ### Tests that start Deno
 

--- a/docs/development/test-records.md
+++ b/docs/development/test-records.md
@@ -19,13 +19,14 @@ A test's identity has three required parts: **kind** (`unit`, `browser`,
 (the owning workspace member, or `repo`), and **name** (whatever the test's
 own runner reports — a bdd describe chain, a pattern file path, a task name,
 a script step). An optional **variant** separates the same test running
-in a non-default configuration. The default configuration is unmarked. Since
-the server-execution flip (2026-08-28) the default deployed-topology lanes
-run the ON posture unmarked — continuing the history of the previously
-unmarked default jobs — and the surviving explicit OFF regression-guard jobs
-use `server-execution-off`. The pre-flip explicit-ON jobs'
-`server-execution` marker is retired; their history stays queryable under
-it. The single-process default jobs (the unit suites, `cf test`, the
+in a non-default configuration. The default configuration is unmarked. The
+server-execution deployed-topology lanes use stable `default` and `opposite`
+roles. `default` follows the first-party constant and stays unmarked;
+`opposite` uses `server-execution` when it resolves ON and
+`server-execution-off` when it resolves OFF. Since the 2026-08-28 flip, that
+means unmarked ON and marked OFF; the pre-flip explicit-ON history remains
+queryable under `server-execution`. The single-process default jobs (the unit
+suites, `cf test`, the
 no-server pattern-unit lane) never read that default and stay ambient-OFF,
 so they are unmarked for the older reason: the flip does not reach them
 (`docs/specs/test-records.md`). One record is one JSON line; one uploaded
@@ -233,9 +234,12 @@ nothing authored by anyone else; other fork runs still run their tests
 normally and simply ship no records. Re-running the relay, or
 dispatching it with a run id, re-ships idempotently.
 
-The shared `test-records-ship` action accepts an optional `variant` input.
-It applies the value to every spooled and JUnit-derived record in that job.
-Leave it unset for the default configuration.
+The shared `test-records-ship` action accepts an optional `variant` input and
+also reads the CI-only `CF_TEST_RECORDS_VARIANT` fallback. An explicit input
+wins. This lets a workflow resolve a stable role to a variant once at job scope
+without duplicating that expression at every shipping step. The action applies
+the resolved value to every spooled and JUnit-derived record in that job; leave
+both surfaces unset for the default configuration.
 
 The relay runs its parser from the default branch. Land parser, relay, reader,
 and action support for a new optional record field before any test workflow

--- a/docs/plans/pull-request-test-selection.md
+++ b/docs/plans/pull-request-test-selection.md
@@ -304,8 +304,10 @@ because one runner does not imply one scope: `workspace-unit` spans every
 workspace package, and the package integration command spans `runner`,
 `runtime-client`, and `shell`. The optional `variant` is suite-wide because
 the suite declares the configuration in which every one of its items runs.
-Default suites omit it. Since the server-execution flip, the two explicit OFF
-suites set it to `server-execution-off`.
+Default suites omit it. The server-execution `opposite` suites derive their
+variant from the posture they actually exercise: `server-execution` for ON or
+`server-execution-off` for OFF. The current default is ON, so today the
+opposite suites use `server-execution-off`.
 
 `enumerate()` is what makes a new test visible without a workflow edit. It
 reads the working tree — usually a file glob, sometimes a list parsed out
@@ -397,34 +399,33 @@ table is the migration's checklist.
 | `pattern-vintage` | `Pattern Update State and Baseline Integrity` | — | `deno`, `git-history` |
 | `generated-patterns` | `Generated Patterns Integration Tests (1..2)` | — | `deno`, `compile-cache` |
 | `package-integration` | `Package Integration Tests (3 suites)` | — | `deno`, `toolshed`, `browser` |
-| `package-integration-off` | the server-execution OFF arm | `server-execution-off` | `deno`, `toolshed-baked-off`, `browser` |
+| `package-integration-opposite` | the posture opposite the server-execution default | resolved arm variant | `deno`, `toolshed-baked-opposite`, `browser` |
 | `deployed-topology` | the background-service and cf-harness default-posture gates | — | `deno`, `toolshed`, `bg-piece-service-binary` |
 | `cli-core` | `CLI Integration Tests (3 suites)` | — | `deno`, `toolshed`, `cf`, `jq` |
 | `cli-fuse` | the FUSE steps of the third CLI suite | — | `deno`, `toolshed`, `cf`, `fuse` |
 | `cli-deno` | the Deno-based CLI integration step | — | `deno`, `toolshed`, `cf` |
 | `pattern-integration` | `Pattern Integration Tests (1..10)` | — | `deno`, `toolshed`, `browser`, `compile-cache` |
-| `pattern-integration-off` | the server-execution OFF arm | `server-execution-off` | `deno`, `toolshed-baked-off`, `browser` |
+| `pattern-integration-opposite` | the posture opposite the server-execution default | resolved arm variant | `deno`, `toolshed-baked-opposite`, `browser` |
 | `pattern-reload` | `Pattern Reload Integration Tests` | — | `deno`, `local-dev-servers`, `browser` |
 | `pattern-unit` | `Pattern Unit Tests (1..4)` | — | `deno`, `cf`, `compile-cache` |
 | `binaries` | the compile inside `Build Binary (toolshed)` and the two beside it | — | `deno` |
-| `binaries-off` | the compile inside `Build Binary (toolshed, server-execution OFF shell)` | `server-execution-off` | `deno` |
+| `binaries-opposite` | the toolshed compile whose shell is opposite the server-execution default | resolved arm variant | `deno` |
 
-The server-execution flip moved the unmarked `package-integration` and
-`pattern-integration` suites to the ON posture without changing their record
-identity. Their pre-flip explicit-ON counterparts became explicit-OFF suites
-under `server-execution-off`. No identity alias joins these histories: the
-unmarked default continues by construction, and each non-default posture has
+The server-execution suites now keep stable `default` and `opposite` roles.
+`default` follows the one first-party constant without changing its unmarked
+record identity. `opposite` explicitly selects the inverse, and its record
+marker names that actual posture. No identity alias joins these histories: the
+unmarked default continues by construction, and each non-default posture keeps
 its own marker.
 
 ### Declared unavailable tests
 
 A configuration-specific skip is neither an unknown test nor evidence that
-the topology missed a surface. The default suites, which run the
-server-execution ON posture since the flip, therefore read
-`tasks/server-execution-on-skips.ts` as part of their topology. The explicit
-OFF suites run every file. The skip registry remains the single source of
-truth for the phase and reason; the selection system does not grow a second
-list.
+the topology missed a surface. Whichever role resolves the server-execution ON
+posture reads `tasks/server-execution-on-skips.ts` as part of its topology;
+the role that resolves OFF runs every file. The skip registry remains the
+single source of truth for the phase and reason; the selection system does not
+grow a second list.
 
 A whole-file entry removes that file from the variant suite's enumerated
 items. The manifest reports it as unavailable under that suite and variant,
@@ -449,9 +450,9 @@ servers and its command line from source and compiles nothing, so a
 compile that breaks would be found on `main`, after the change that broke
 it has merged — where today it is caught before it lands. So `binaries`
 makes each shipped binary a unit whose test is that it still compiles,
-and `binaries-off` does the same for the toolshed under the explicit-OFF
-server-execution define, which is the same build in a different
-configuration and therefore a variant of it rather than a second test.
+and `binaries-opposite` does the same for the toolshed under the define
+opposite the default, which is the same build in a different configuration and
+therefore a variant of it rather than a second test.
 
 Every one of those builds passes `--no-check`, so this is not a second
 type check: `deno task check` owns that. What a compile catches that
@@ -1027,7 +1028,7 @@ batches.
 | `git-history` | Unshallows the checkout | 3–10 seconds |
 | `toolshed` | A Toolshed server listening on an allocated port | see below |
 | `local-dev-servers` | The whole local dev stack, brought up by `deno task integration` on a chosen port offset | 15–20 seconds |
-| `toolshed-baked-off` | The same, from a binary whose shell carries the explicit-OFF server-execution define | 42 seconds to build, or 17 to restore |
+| `toolshed-baked-opposite` | The same, from a binary whose shell carries the server-execution define opposite the default | 42 seconds to build, or 17 to restore |
 | `bg-piece-service-binary` | The compiled background service used by its deployed-topology gate | about 30 seconds to build, or under a second to restore |
 | `cf` | The `cf` command-line tool on the path | as above |
 | `compile-cache` | Restores a pattern compile byte cache | 3 seconds |
@@ -1045,8 +1046,8 @@ source costs a few seconds. The full run on `main` keeps the
 compiled-binary path, because it needs the binary anyway for attestation
 and deployment.
 
-**`toolshed-baked-off` cannot.** The server-execution OFF arm depends on a
-compile-time define baked into the browser shell inside the binary, and a
+**`toolshed-baked-opposite` cannot.** The server-execution opposite arm depends
+on a compile-time define baked into the browser shell inside the binary, and a
 source run cannot reproduce that. So that capability has a different
 provider: restore the binary from the Actions cache if the key hits, and
 build it in place if it does not. The lane workflow carries one fixed

--- a/docs/plans/server-execution-v2.md
+++ b/docs/plans/server-execution-v2.md
@@ -32,15 +32,27 @@ tables with the v2 basis index — and partly a build. The spec §5
 deletion list is enforced by deleting on main and *not rebuilding*,
 with the survival test as the gate on anything that feels needed.
 
-## Coordination state (2026-08-28) — read this first
+## Coordination state (2026-09-02) — read this first
 
 The arc's coordination state is carried HERE, on the branch, not in any
 agent's memory (owner directive 2026-08-18). This block is LIVE: update
 it in the PR that moves the state.
 
+**Delta 2026-09-02 (post-flip toggle hygiene): #6535 is MERGED and the soak
+is running with the default ON. This follow-up keeps that behavior unchanged
+while replacing the hard-coded ON-default/OFF-guard workflow inversion with
+stable `default` and `opposite` roles resolved by
+`tasks/server-execution-ci.ts`. The binary define, server/test environment,
+posture probes, ON skip placement, OFF authored coverage, topology capability,
+and non-default record variant now follow that one mapping. Once it lands, a
+default rollback is the constant change plus its current-status documentation;
+the workflow does not need another role swap. #6552 remains available as the
+pre-hygiene emergency rollback and can be superseded by that smaller follow-up
+when appropriate.**
+
 **Delta 2026-08-28, last updated 2026-08-29 (the FLIP PR —
-[#6535](https://github.com/commontoolsinc/labs/pull/6535), OPEN, the
-owner merges it personally; the soak starts at ITS merge): `SERVER_EXECUTION_DEFAULT_ENABLED` →
+[#6535](https://github.com/commontoolsinc/labs/pull/6535), now MERGED; the
+soak started at its merge): `SERVER_EXECUTION_DEFAULT_ENABLED` →
 `true`, with every ordered gate met on main at the base (22c93b540 —
 rebased onto it 2026-08-29, from e16780fca and originally 4e02f75c4;
 the gate claims re-verified at each new base): the
@@ -58,14 +70,14 @@ one). The OFF-world half of those same findings landed separately on
 main as
 [#6545](https://github.com/commontoolsinc/labs/pull/6545) — the GitHub
 connector host adopting the deployment's posture, and the pattern
-shard selectors failing loudly on an empty selection — which is the
-base this branch now sits on. The PR carries,
+shard selectors failing loudly on an empty selection — which landed before
+the flip. The PR carries,
 beside the one-liner and the absolute pin's re-tense: the LANE-ROLE SWAP
 (default lanes = the ON arm, probed serving-loop-present +
-shell-define-unset, carrying the empty ON skip list; the pre-flip
-explicit-`true` lanes become the explicit-`false` OFF regression guard
-on `build-toolshed-off` — the inversion of `build-toolshed-on` — with
-variant `server-execution-off`, per testing.md §2's identity contract);
+shell-define-unset, carrying the empty ON skip list; the opposite lanes
+are the explicit-`false` OFF regression guard on
+`build-toolshed-opposite`, with variant `server-execution-off`, per
+testing.md §2's identity contract);
 the DEPLOYED-TOPOLOGY obligation discharged (the Phase 7 table row):
 a new `deployed-topology-gate` job runs the REAL `bg-piece-service`
 binary (startup posture log line asserted; clean SIGTERM) and
@@ -1311,7 +1323,7 @@ client's only computational commit (spec §3.6).
 | Phase 3 ON — events down (D-v2-1) | unchanged | SpaceServer, reacting to the event commit / ONLY the event append; the local run is speculative echo, and the client handler-write commit path DELETES (events.md §7 — F10's interim ends) | unchanged | handler consequences land in the ACTING principal's instances, resolved from the server-stamped `firedAt` (scopes.md §5, protocol.md §2) | commits nothing but intent: event appends + UI-binding writes; echo via overlay |
 | Phase 4 ON — effect channel | unchanged | unchanged | external effects: server only; session effects (navigate): the server COMPUTES the intent, the client ENACTS and acks by nonce (protocol.md §5) | the effects doc is itself a session-scoped instance; the ack is written into the session's own instance (protocol.md §5) | adds the effects-doc subscription and the enact/ack duty (the ack is an authored write) |
 | Phase 5 ON — cross-space | home SpaceServer over foreign reads, under the piece's granted authority / commits HOME only — never derived into a foreign space (protocol.md §2b) | unchanged; cross-space mutation leaves ONLY as outbox event appends; `.inSpace` provisioning lands authored-class, foreign-first, under the event's acting principal | unchanged; the outbox also carries the cross-space appends | foreign reads name their instance explicitly, lease-holder-only (protocol.md §2's read row) | unchanged |
-| Phase 7 flip (FLIP-READY landed DARK 2026-08-16 by owner ruling: the mechanism is in, `SERVER_EXECUTION_DEFAULT_ENABLED = false`, the ON posture selectable by explicit `true`; the flip itself is a separate one-line PR after the ordered gates below; OFF path KEPT as the rollback lever through the soak; removal is the split-out post-soak PR) | SpaceServer only once flipped; today the OFF baseline by default, the ON arm selectable by explicit `true` | SpaceServer / events only | server, plus the client-enacted channel | unchanged from Phase 5; session-data GC is the remaining owed design (scopes.md §8 item 2); OW17's replica per-instance keying is the flip's blocker at scoped cardinality ≥ 2 | final: speculate freely, commit only intent; flag retires after the soak |
+| Phase 7 flip (FLIP-READY landed DARK 2026-08-16; #6535 flipped the first-party default ON after the ordered gates and began the soak; explicit `false` remains the rollback lever; removal is the split-out post-soak PR) | SpaceServer by default; the explicit OFF arm retains the client baseline | SpaceServer / events only | server, plus the client-enacted channel | unchanged from Phase 5; session-data GC is the remaining owed design (scopes.md §8 item 2) | final: speculate freely, commit only intent; flag retires after the soak |
 
 A surface a milestone has not yet landed (navigateTo before
 Phase 4, cross-space before Phase 5) has no defined interim
@@ -1935,19 +1947,17 @@ Success criteria:
 
 ## Phase 7 — Flip and retire
 
-**Scoping (coordinator, 2026-08-15; OWNER RULED 2026-08-16): this
-phase delivers FLIP-READY, LANDED DARK — the mechanism merges with the
-first-party default `false`; THE FLIP IS ITS OWN SEPARATE ONE-LINE PR
-(repo convention: a flip is reverted by reverting the PR that only
-flips), owed AFTER the ON posture works and is performant. Task 2's
-OFF-path REMOVAL stays SPLIT OUT into a separate post-flip, post-soak
-PR** — stacked PRs get no CI matrix, so the soak can only start once the
-flip merges to main, and the flag must remain the rollback lever through
-the soak. The plan is NOT archived here (task 3 is close-out after the
-soak). Ruling rationale (the independent review's verdict, adopted): with
+**Current scoping (updated 2026-09-02): Phase 7's flip is DONE — #6535
+changed the first-party default to `true` after the ordered gates, merged,
+and began the ON soak. Explicit `false` remains the rollback lever. Stable
+`default` and `opposite` CI roles now follow the one default constant, so a
+deliberate rollback changes that value and current-status prose without
+rewiring the workflow. Task 2's OFF-path removal stays split into a separate
+post-soak PR, and task 3 remains the final archive.** The original 2026-08-16
+ruling landed the mechanism dark first because, at that time, with
 the constant `true` the REQUIRED default CI lanes went red on merge
 (two two-browser gates stall 300 s under the full ON posture, neither
-skip-listed), the ON posture today breaks every two-user browser
+skip-listed), the ON posture at that time broke every two-user browser
 journey (OW32's client-side non-settling loop, unattributed) and the
 piece-creation/compiler surfaces (OW28), and "flip-ready (true) and hold
 the merge" parks the train behind several stages of work; landing dark
@@ -2001,25 +2011,22 @@ Preconditions (all RULED 2026-08-15, all landed with this phase):
 
 Tasks:
 
-- [ ] **Default ON — FLIP-READY LANDED DARK (2026-08-16, owner ruling);
-      the flip itself is a separate one-line PR, NOT yet landed.** What
-      is in: the ONE first-party default `SERVER_EXECUTION_DEFAULT_
-      ENABLED` (`packages/memory/v2/server-execution-default.ts`) — value
-      `false` today — resolved by the `productionServer` / `remoteClient`
+- [x] **Default ON — #6535 merged and the soak is in progress.** The ONE
+      first-party default `SERVER_EXECUTION_DEFAULT_ENABLED`
+      (`packages/memory/v2/server-execution-default.ts`) is `true` today,
+      resolved by the `productionServer` / `remoteClient`
       presets, the shell define fallback, and toolshed's serving-host
       gate + memory ACL principal lists (the DELEGATING class since
       OW31's build); explicit `true` = the ON arm,
       explicit `false` = the OFF arm; the single-process presets keep the
-      OFF baseline by construction (EXPERIMENTAL_OPTIONS.md); the ONE
-      absolute pin (`packages/toolshed/lib/server-execution-flag.test.
-      ts`) states the current default so a silent flip either way cannot
-      hide behind the relative pins. CI (testing.md §2): the DEFAULT
-      lanes are the OFF posture (a probe pins server-not-serving + shell
-      define unset), the explicit-`true` ON lanes run on `build-toolshed-
-      on` (shell define baked `true`) with the FULL ON posture verified
-      before each suite (`/api/meta.shellServerExecutionDefine === "true"`,
-      `/api/health/stats.servingLoop` present) and the Deno-side test
-      clients declaring the posture from the env (uniform, not mixed);
+      OFF baseline by construction (EXPERIMENTAL_OPTIONS.md). CI
+      (testing.md §2) now uses stable `default` and `opposite` roles:
+      default is ON today with its shell define unset, and opposite is the
+      explicit-`false` OFF regression guard on `build-toolshed-opposite`.
+      Both postures are verified before each suite: `/api/meta` must match
+      the resolved role and `/api/health/stats.servingLoop` must be present
+      exactly on the ON arm. Deno-side test clients declare the posture from
+      the environment (uniform, not mixed);
       the ON skip list — made EFFECTIVE by the fixer (it had been inert
       since Phase 4: `deno test --ignore` never applied to explicitly
       listed files) — held `phase-7` entries at this ruling's date:
@@ -2031,9 +2038,8 @@ Tasks:
       OW33) *— since lifted arc-by-arc: the ON-skip registry is EMPTY
       across all four suites (#6528, the ruled-3b-close lift — the
       Coordination-state delta above), so gate (5)'s list-EMPTY half
-      below is MET*. **THE FLIP PR (one line: the constant → `true`, plus the
-      absolute pin, the lane roles + probes, EXPERIMENTAL_OPTIONS.md)
-      lands only after these ORDERED GATES, in this order:** (1) OW32 —
+      below is MET*. **The flip PR landed only after these ORDERED GATES,
+      in this order:** (1) OW32 —
       the client-side scheduler-non-settling loop TRIAGED and fixed (the
       two two-browser gates green 5/5 fresh-store under the full ON
       posture) — *triaged 2026-08-16 (a client speculation
@@ -2091,12 +2097,11 @@ Tasks:
       cf-harness's fabric session; the CLI lanes probed as `cf`'s gate
       via posture adoption; `PiecesController` hosts on the default
       package/pattern lanes)*;
-      then (6) the flip PR, and the soak starts at ITS merge — **IN
-      PROGRESS 2026-08-28: the flip PR is
-      [#6535](https://github.com/commontoolsinc/labs/pull/6535), OPEN
-      (the coordination-state delta above carries its contents; the
-      owner reads and merges it personally — the soak starts at that
-      merge, and the OFF path stays the rollback lever through it).
+      then (6) the flip PR, and the soak starts at ITS merge — **DONE:
+      [#6535](https://github.com/commontoolsinc/labs/pull/6535) is MERGED
+      and the soak is in progress (the coordination-state delta above
+      carries its contents; the OFF path stays the rollback lever through
+      the soak).
       Its first board surfaced ONE owner-court STOP — RULED AND BUILT,
       no longer standing: the verb DECLARED-RESULT surface was absent
       under ON, because receipts went unwritten under the flag by
@@ -2121,9 +2126,8 @@ Tasks:
 - [ ] Retire the flag; OFF path removed; `EXPERIMENTAL_OPTIONS.md` entry
       closed out — **SPLIT OUT: the post-soak removal PR** (named here as
       the flip's follow-up; it also removes the OFF regression-guard CI
-      lanes and the OFF-built binary job — `build-toolshed-off`, which
-      the flip PR introduced by inverting the pre-flip
-      `build-toolshed-on` — while the `deployed-topology-gate` job
+      lanes and the opposite-built binary job —
+      `build-toolshed-opposite` — while the `deployed-topology-gate` job
       STAYS: it gates the surviving default posture, not the OFF path).
 - [ ] Archive this plan to `docs/history/plans/` per the lifecycle
       (close-out, after the soak and the removal PR).

--- a/docs/specs/server-side-execution/testing.md
+++ b/docs/specs/server-side-execution/testing.md
@@ -41,71 +41,49 @@ not-yet-implemented phases via explicit skip lists per phase, never via
 silent filtering. (v1's terminal failure mode: the flags-on branch never
 went through CI at all.)
 
-*Phase 7 FLIPPED (the flip PR, 2026-08-28, after the plan's ordered
-gates: `SERVER_EXECUTION_DEFAULT_ENABLED = true`; landed FLIP-READY DARK
-2026-08-16 by owner ruling, roles inverted until the flip). The arms
-since the flip: the DEFAULT lanes (flag unset = the first-party default,
-ON) ARE the ON arm in the FULL posture — the toolshed serves, the test
-processes RESOLVE the posture env-else-default (the runner integration
-tests that talk to the lane's toolshed; the runtime-client worker host —
-never a bare/ambient client, the mixed posture the Phase-7 review found,
-which under default-ON a raw env read would resurrect), and the
-default-built browser shell's define fallback is the same constant. TWO
-files on the default pattern lane deliberately read the RAW env instead,
-and are exceptions rather than drift:
-`packages/patterns/integration/topic-board-child-contract.test.ts` and
-`packages/patterns/integration/convergence-storm.test.ts` key their
-ON-arm STEP-skip guard (`onArmStepSkip`) off it. Neither takes a RUNTIME
-posture from that read — the runtimes there adopt the lane toolshed's
-published posture (and the storm harness resolves env-else-default) — so
-the raw key decides only whether a listed step is skipped. With the
-skip registry EMPTY the guards are inert everywhere; the raw key leaves
-them undefined on the default (ON) lane, so a future entry for either
-file fails LOUD there (the step runs and reds, never a silent skip),
-which is the trigger to convert the key. Each file's own comment carries
-this. A posture PROBE before each suite pins serving-loop PRESENT
-(`/api/health/stats.servingLoop`) and shell define UNSET (`/api/meta`'s
-`shellServerExecutionDefine` null), so a silent un-flip of the default
-cannot move the REQUIRED lanes off ON. The explicit
-`EXPERIMENTAL_SERVER_EXECUTION=false` lanes are the OFF regression
-guard — the rollback lever kept honest through the soak — on an
-OFF-built binary (`build-toolshed-off`, the define `"false"`), VERIFIED
-by the same probe (`shellServerExecutionDefine === "false"`,
-`servingLoop` absent) before the suite runs; they retire with the OFF
-path in the post-soak removal PR. Skips only via
-`tasks/server-execution-on-skips.ts` (file entries; STEP entries for a
-one-file suite, guarded in-file and bound to the register), printed
-loudly, riding the DEFAULT lanes (the ON arm — the OFF guard never
-skips), EMPTY at the flip (its stated precondition) — and, since
-2026-08-16, actually EFFECTIVE: `deno test --ignore` binds only to
-files deno discovers itself, so the package `integration` tasks hand
-deno a quoted glob and the pattern shards filter their file list
-through the script (`--filter`); until then every listed skip ran. The
-deployed-topology binaries the presets flip carry their own gates since
-the flip PR (its recorded obligation; P7 review finding 8): the
-`deployed-topology-gate` job runs the real `bg-piece-service` binary
-and cf-harness's fabric-session factory against the default (ON)
-toolshed, posture-asserted; the CLI lanes are `cf`'s gate (it adopts
-the server's published posture; the lane probes the server half); and
-`PiecesController` hosts ride the default package/pattern lanes
-(sx2-scale's controllers, the pieces-controller helper). Single-process
-suites (the unit suites, `cf test`, the runner integration files that
-serve toolshed's `app.ts` in-process — the serving loop starts in the
-binary's `index.ts`, not in `app.ts`) are not arms of this contract:
-they have no serving host and run the derive-and-commit model (the
-ambient baseline, OFF) by construction (EXPERIMENTAL_OPTIONS.md) — the
-flip does not reach them.*
+*Phase 7 FLIPPED (2026-08-28):
+`SERVER_EXECUTION_DEFAULT_ENABLED = true`. CI names the two exercised
+postures by stable role rather than by today's value:
+
+- `default` leaves `EXPERIMENTAL_SERVER_EXECUTION` unset and follows the
+  first-party constant. It is ON today.
+- `opposite` explicitly selects the inverse and uses a toolshed whose browser
+  shell has that same value baked in. It is OFF today.
+
+`tasks/server-execution-ci.ts` is the single mapping from those roles to the
+resolved value, label, record variant, runtime environment, baked shell define,
+and posture probe. Changing the first-party default therefore swaps which role
+is ON and which is OFF without rewriting workflow topology. Before each suite,
+the probe checks `/api/meta.experimental.serverExecution`, the shell define,
+and presence (ON) or absence (OFF) of `/api/health/stats.servingLoop`; a mixed
+server/client/shell posture is never a valid arm exercise.
+
+The ON-only skip registry in `tasks/server-execution-on-skips.ts` follows the
+role that resolves ON, is printed loudly, and was EMPTY at the flip. The OFF
+arm always runs every file. The two pattern step guards named in their source
+files remain exceptions that read the raw environment only to decide whether a
+registered step is skipped; their runtimes still adopt the lane toolshed's
+published posture. Authored-pattern coverage follows the role that resolves
+OFF, while the default role retains V8 coverage. The default role's test-record
+identity remains unmarked; the opposite role gets the variant for its actual
+posture (`server-execution` for ON or `server-execution-off` for OFF).
+
+The deployed-topology gates follow `default`: the real
+`bg-piece-service` binary and cf-harness fabric-session factory run against the
+default toolshed, the CLI adopts and verifies the server's published posture,
+and `PiecesController` hosts ride the default package/pattern lanes.
+Single-process suites (the unit suites, `cf test`, and runner integration files
+that serve toolshed's `app.ts` in-process) have no serving host and remain the
+ambient derive-and-commit model (OFF) by construction.*
 
 Test-record identity follows the [test-run record
-contract](../test-records.md). The current default arm (ON since the flip)
-leaves the shipping action's `variant` input unset, continuing the existing
-unmarked history. The explicit OFF package and pattern jobs set it to
-`server-execution-off`, so the regression guard keeps its own history; the
-pre-flip explicit-ON arm's `server-execution` marker retired with the flip
-(its history stays queryable under that variant). Any additional
-non-default arm uses its own stable variant. The workflow tests assert both
-that non-default arms carry their exact marker and that the default arm
-remains unmarked.
+contract](../test-records.md). The `default` role leaves the shipping action's
+variant unset, continuing the existing unmarked history. The `opposite` role
+uses the marker for the posture it actually exercises: `server-execution` when
+ON, or `server-execution-off` when OFF. Today that means unmarked ON and marked
+OFF. The pre-flip explicit-ON history stays queryable under
+`server-execution`. Workflow tests assert both the dynamic opposite marker and
+the unmarked default.
 
 ## 3. The watermark replaces polling
 

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -3510,6 +3510,17 @@ personally; the soak starts at ITS merge.** What it carries:
   the corrected call; under OFF the same id executes. The step's ON
   comment points at this row.
 
+Delta 2026-09-03 — post-flip toggle hygiene:
+
+- The absolute literal default pin introduced by #6535 is retired. Stable
+  `default` / `opposite` roles already keep both arms exercised, and
+  `tasks/server-execution-ci.test.ts` now pins the source default to the
+  current-status row in `EXPERIMENTAL_OPTIONS.md`: an isolated constant edit
+  reds, while an intentional flip changes only the constant and that status.
+- The locally persistent opposite-binary cache includes its baked `true` or
+  `false` posture in the filename, so a default flip cannot restore a shell
+  compiled for the former opposite arm.
+
 Delta 2026-08-16 — fan-out stage A (OW17 leg 1: the instance-keyed
 serving replica + wire; the client arrival gate):
 

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -3515,8 +3515,15 @@ Delta 2026-09-03 — post-flip toggle hygiene:
 - The absolute literal default pin introduced by #6535 is retired. Stable
   `default` / `opposite` roles already keep both arms exercised, and
   `tasks/server-execution-ci.test.ts` now pins the source default to the
-  current-status row in `EXPERIMENTAL_OPTIONS.md`: an isolated constant edit
-  reds, while an intentional flip changes only the constant and that status.
+  current-status cell in `EXPERIMENTAL_OPTIONS.md` (the posture word, the
+  constant's value, and the rollback arm): an isolated constant edit reds,
+  while an intentional flip changes only the constant and that status. The
+  workflow itself is pinned literal-free: no step may select an arm by a
+  literal `EXPERIMENTAL_SERVER_EXECUTION` value outside a comment.
+- The workflow-facing command adapter is exercised as the program CI invokes
+  (no permissions, exact output, exit 1 on a bad role) rather than opted out
+  of coverage, and the topology's unreadable-directory guard holds on both of
+  its readers.
 - The locally persistent opposite-binary cache includes its baked `true` or
   `false` posture in the filename, so a default flip cannot restore a shell
   compiled for the former opposite arm.

--- a/docs/specs/test-records.md
+++ b/docs/specs/test-records.md
@@ -26,14 +26,14 @@ A test's identity has three required parts, scoped within a repository:
   piece-values`), or a task-plus-item pair (`cfcheck <file>`,
   `pattern-compat <key>`, `pattern-vintage <testKey> <tier> <stamp>`).
 - **variant**, when present — a stable name for a non-default configuration
-  that runs the same test. The default configuration has no variant. Since
-  the server-execution flip (2026-08-28) the default DEPLOYED-TOPOLOGY
-  lanes — the ones that run a test process against a serving toolshed —
-  run the ON posture unmarked, continuing the history of the previously
-  unmarked default jobs; the surviving explicit OFF regression-guard jobs
-  use `server-execution-off` so their history remains separate. The
-  pre-flip explicit-ON jobs' `server-execution` marker is retired; their
-  history stays queryable under it. The claim is deliberately narrow: the
+  that runs the same test. The default configuration has no variant. The
+  server-execution deployed-topology lanes have stable `default` and
+  `opposite` roles. `default` follows the first-party constant and remains
+  unmarked; `opposite` receives the marker for the posture it actually runs:
+  `server-execution` for ON or `server-execution-off` for OFF. Since the
+  2026-08-28 flip, that resolves to unmarked ON and marked OFF. The pre-flip
+  explicit-ON history remains queryable under `server-execution`. The claim is
+  deliberately narrow: the
   single-process default jobs (the unit suites, `cf test`, the no-server
   pattern-unit lane — the `patternTest` / `unitTest` presets) never read
   the first-party default and stay ambient-OFF by construction, so they

--- a/packages/background-piece-service/integration/posture-gate.test.ts
+++ b/packages/background-piece-service/integration/posture-gate.test.ts
@@ -1,13 +1,10 @@
 /**
- * Deployed-topology posture gate for the `bg-piece-service` BINARY
- * (server-execution v2 Phase 7's flip PR — the plan's own obligation, and
- * the P7 independent review's finding 8: the deployed-topology binaries the
- * presets flip were built by CI but exercised ON by no gate).
+ * Deployed-topology posture gate for the `bg-piece-service` binary.
  *
  * What it proves, on the real compiled binary against a real serving
  * toolshed: the binary STARTS, initializes its service (a genuine flow —
  * identity, session open, and the BG-pieces read/watch against the
- * toolshed), and RESOLVES the first-party server-execution default ON (the
+ * toolshed), and resolves the first-party server-execution default (the
  * `productionServer` preset's env-else-`SERVER_EXECUTION_DEFAULT_ENABLED`
  * resolution — exactly the path the flip changes, which explicit-env lanes
  * never exercise). The binary has no HTTP surface, so its startup posture
@@ -25,6 +22,7 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { defer } from "@commonfabric/utils/defer";
+import { SERVER_EXECUTION_DEFAULT_ENABLED } from "@commonfabric/memory/v2/server-execution-default";
 
 const BIN = Deno.env.get("BG_PIECE_SERVICE_BIN");
 const API_URL = Deno.env.get("API_URL");
@@ -73,7 +71,7 @@ describe(
   "bg-piece-service deployed-topology posture gate",
   { ignore: !BIN || !API_URL },
   () => {
-    it("the binary starts against the serving toolshed, resolves the default posture ON, and stops cleanly", async () => {
+    it("starts against toolshed, resolves the default posture, and stops cleanly", async () => {
       // The gate exercises the DEFAULT resolution (unset flag → the
       // first-party constant). An inherited explicit value would make it
       // vacuously test the env path instead — refuse to run that way.
@@ -145,7 +143,7 @@ describe(
         expect(
           postures,
           `expected exactly one posture line in:\n${lines.join("\n")}`,
-        ).toEqual(["ON"]);
+        ).toEqual([SERVER_EXECUTION_DEFAULT_ENABLED ? "ON" : "OFF"]);
       } finally {
         // Clean shutdown is part of the gate: the SIGTERM handler stops the
         // service and exits 0.

--- a/packages/cf-harness/integration/fabric-session-posture-gate.test.ts
+++ b/packages/cf-harness/integration/fabric-session-posture-gate.test.ts
@@ -1,14 +1,11 @@
 /**
- * Deployed-topology posture gate for cf-harness's FABRIC SESSION
- * (server-execution v2 Phase 7's flip PR — the plan's own obligation, and
- * the P7 independent review's finding 8: cf-harness resolves the flag by
- * the presets, and no gate exercised that resolution ON).
+ * Deployed-topology posture gate for cf-harness's fabric session.
  *
  * What it proves, against a real serving toolshed: the harness's OWN
  * production session path — `createHarnessFabricSessionFactory` (PKCS#8
  * identity from disk → `PiecesController.initialize` → deployed-client
  * posture adoption → the remoteClient preset) — resolves the flipped
- * first-party default ON with NOTHING declared in the environment, and the
+ * first-party default with nothing declared in the environment, and the
  * session executes one genuine flow (compile + instantiate a pattern,
  * read a served result back). The explicit-env ON lanes never exercised
  * this unset-flag path; the flip changes exactly it.
@@ -25,6 +22,7 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { writeTempIdentity } from "@commonfabric/integration/temp-identity";
 import { waitForCellValue } from "@commonfabric/integration/wait-for-cell-value";
+import { SERVER_EXECUTION_DEFAULT_ENABLED } from "@commonfabric/memory/v2/server-execution-default";
 import { createHarnessFabricSessionFactory } from "../src/fabric-session.ts";
 
 const API_URL = Deno.env.get("API_URL");
@@ -37,17 +35,19 @@ describe(
   "cf-harness deployed-topology posture gate",
   { ignore: !API_URL },
   () => {
-    it("the fabric session resolves the flipped default ON and serves one genuine flow", async () => {
+    it("resolves the default posture and completes one genuine flow", async () => {
       // The gate exercises the DEFAULT resolution (unset flag → server
       // adoption → the first-party constant). An inherited explicit value
       // would make it vacuously test the env path instead.
       expect(Deno.env.get("EXPERIMENTAL_SERVER_EXECUTION")).toBe(undefined);
 
       // The server half of the posture, probed from the gate itself: the
-      // lane's toolshed really serves (the default binary since the flip).
+      // lane's toolshed matches the default binary's posture.
       const stats = await (await fetch(new URL("/api/health/stats", API_URL)))
         .json() as { servingLoop?: unknown };
-      expect(stats.servingLoop != null).toBe(true);
+      expect(stats.servingLoop != null).toBe(
+        SERVER_EXECUTION_DEFAULT_ENABLED,
+      );
 
       // The keyfile's path is tracked OUTSIDE the session setup: the outer
       // `finally` below owns it, so it is removed even when session
@@ -63,10 +63,10 @@ describe(
         });
         const session = await factory();
         try {
-          // The client half: the session's runtime resolved ON from the
+          // The client half: the session's runtime resolved the posture from the
           // deployment with nothing declared locally.
           expect(session.pieces.runtime.experimental.serverExecution).toBe(
-            true,
+            SERVER_EXECUTION_DEFAULT_ENABLED,
           );
 
           // One genuine flow through the session: compile + instantiate a

--- a/packages/memory/v2/server-execution-default.ts
+++ b/packages/memory/v2/server-execution-default.ts
@@ -16,15 +16,15 @@
  * the OW38(ii) benchmark bar ruled met); `false` is the pre-flip behavior
  * byte-for-byte. An explicit `EXPERIMENTAL_SERVER_EXECUTION=true|false`
  * (or `experimental.serverExecution`) selects an arm regardless of this
- * value: an explicit `false` is the ROLLBACK LEVER (and CI's OFF
- * regression guard, run on an OFF-built binary) and stays selectable
- * through the post-flip soak. Un-flipping is reverting the flip PR (repo
- * convention: a flip is reverted by reverting the PR that only flips),
- * never a hand edit here; the flip PR changes this value AND the absolute
- * pin in
- * `packages/toolshed/lib/server-execution-flag.test.ts` (which states the
- * current default so a silent flip either way cannot hide behind
- * relative pins), the CI lane roles, and EXPERIMENTAL_OPTIONS.md together.
+ * value. CI's stable `default` / `opposite` roles derive both postures
+ * from this resolver, so both arms stay guarded without role renames or
+ * source edits. While the default is ON, explicit `false` is the rollback
+ * lever (and the relationship reverses symmetrically if the default flips).
+ * To change the first-party default, update this value and the status row
+ * in `docs/development/EXPERIMENTAL_OPTIONS.md` in the same PR; a test
+ * intentionally pins that pair so an isolated one-token change fails.
+ * Do not rewrite role names, build jobs, or tests for a flip: they all
+ * follow the default through `tasks/server-execution-ci.ts`.
  * After the soak, the post-soak removal PR (Phase 7's split-out task)
  * retires the flag, the OFF path, and the OFF guard lanes.
  *

--- a/packages/toolshed/lib/server-execution-flag.test.ts
+++ b/packages/toolshed/lib/server-execution-flag.test.ts
@@ -9,27 +9,13 @@ import {
 // The toolshed process's ONE flag resolution (server-execution v2 Phase 7,
 // the flip): unset means the FIRST-PARTY DEFAULT — the value of
 // `SERVER_EXECUTION_DEFAULT_ENABLED`, whichever it is — and an explicit
-// "false" is the OFF arm, an explicit "true" the ON arm. Pinned against
-// the constant, not a literal, so the tests state the contract rather
-// than the current default — except the ONE absolute pin below.
+// "false" is the OFF arm and an explicit "true" the ON arm. Tests pin the
+// contract against the constant rather than duplicating its current value,
+// so a deliberate default change stays a one-value edit while CI exercises
+// both resolved roles.
 
 const envOf = (values: Record<string, string | undefined>) => (name: string) =>
   values[name];
-
-describe("the flipped posture (server-execution v2 Phase 7, the flip PR — default ON after the plan's ordered gates)", () => {
-  it("the first-party default IS ON — flipped by the flip PR (docs/plans/server-execution-v2.md Phase 7 task 1), which updates this pin, the CI lane roles, and EXPERIMENTAL_OPTIONS.md together; un-flipping is reverting that PR, never an edit here", () => {
-    // Every other flip pin in the tree is deliberately RELATIVE to the
-    // constant (so the flip PR is one line plus this pin); this is the
-    // one ABSOLUTE pin, so a silent flip in EITHER direction cannot hide
-    // behind green relative pins — flipped silently OFF, the default
-    // lanes (the ON arm since the flip) would run OFF with every test
-    // still green while the explicit-`false` OFF guard lanes ran the
-    // same arm twice; flipped silently ON before the flip PR, the
-    // REQUIRED default lanes would have carried an unreviewed posture
-    // change (the P7 independent review's blocker class).
-    expect(SERVER_EXECUTION_DEFAULT_ENABLED).toBe(true);
-  });
-});
 
 describe("serverExecutionEnabledFromEnv", () => {
   it("resolves an UNSET flag to the first-party default", () => {
@@ -38,7 +24,7 @@ describe("serverExecutionEnabledFromEnv", () => {
     );
   });
 
-  it("honors an explicit value either way (both arms stay selectable — CI's explicit-`true` lanes run the ON posture on an ON-built binary)", () => {
+  it("honors an explicit value either way so both CI arms stay selectable", () => {
     expect(
       serverExecutionEnabledFromEnv(
         envOf({ EXPERIMENTAL_SERVER_EXECUTION: "false" }),

--- a/packages/toolshed/lib/server-execution.test.ts
+++ b/packages/toolshed/lib/server-execution.test.ts
@@ -107,9 +107,8 @@ describe("serverExecutionPolicyFromEnv", () => {
 describe("startServerExecutionHost OFF witness", () => {
   // The OFF witness for the serving-loop bootstrap (OW45 arm-B
   // server-ensure stage 1's explicit pin; the arc's OFF byte-identity
-  // bar): with the flag OFF — explicitly "false", the rollback arm (the
-  // first-party default is ON since the Phase 7 flip PR) —
-  // `startServerExecutionHost`
+  // bar): with the flag OFF — whether selected by the default or an
+  // explicit "false" override — `startServerExecutionHost`
   // returns undefined, so NO ExecutorHost exists, NO SpaceServer is ever
   // built, and the server-side space-root ensure path added by stage 1
   // (the SpaceServer activation owed-step) structurally does not exist
@@ -119,11 +118,12 @@ describe("startServerExecutionHost OFF witness", () => {
   // The options are untouchable fakes on purpose: the flag check is the
   // function's FIRST act, so the OFF arm must touch neither the server
   // nor the identity — any use throws and fails the pin. The same
-  // untouchables give the UNSET arm its witness in the other direction
-  // since the flip: unset resolves the first-party default (ON), the gate
-  // opens, and the construction's first touch of the identity is the
-  // proof — the full ON construction is exercised by the integration
-  // lanes and the deployed-topology gate, not here.
+  // untouchables also witness whichever direction UNSET resolves: if the
+  // first-party default is ON, the gate opens and the construction's first
+  // touch of the identity is the proof. The full ON construction is exercised
+  // by the integration lanes and the deployed-topology gate, not here. Which
+  // outcome UNSET takes is deliberately relative to the one default constant,
+  // so changing that constant does not require re-tensing this test.
 
   const untouchable = <T extends object>(label: string): T =>
     new Proxy({} as T, {
@@ -131,29 +131,26 @@ describe("startServerExecutionHost OFF witness", () => {
         throw new Error(
           `${label}.${String(property)} touched — on the OFF arm the ` +
             "flag check must precede any use (the pin's failure); on " +
-            "the unset arm, since the flip, this touch is the " +
-            "gate-opened witness",
+            "the unset ON arm, this touch is the gate-opened witness",
         );
       },
     });
 
-  it("resolves the UNSET flag to the first-party default — ON since the flip PR: the gate opens (witnessed by the identity being touched), never the silent OFF arm", () => {
-    // Relative to the constant on purpose (the one absolute pin lives in
-    // server-execution-flag.test.ts): if the default were OFF this would
-    // return undefined without touching anything; with the flipped
-    // default the bootstrap proceeds past the gate and its first act on
-    // the ON path — logging the serving identity — touches the
-    // untouchable, which is exactly the witness that unset no longer
-    // resolves OFF.
-    expect(SERVER_EXECUTION_DEFAULT_ENABLED).toBe(true);
-    expect(() =>
+  it("resolves the UNSET flag to the first-party default", () => {
+    const start = () =>
       startServerExecutionHost({
         server: untouchable<MemoryServer>("server"),
         identity: untouchable<Identity>("identity"),
         apiUrl: new URL("http://toolshed.test"),
         envGet: () => undefined,
-      })
-    ).toThrow("identity.did touched");
+      });
+    if (SERVER_EXECUTION_DEFAULT_ENABLED) {
+      // The ON path gets past the gate and first touches the identity.
+      expect(start).toThrow("identity.did touched");
+    } else {
+      // The OFF path returns before touching either untouchable dependency.
+      expect(start()).toBeUndefined();
+    }
   });
 
   it("is inert with the flag explicitly false", () => {
@@ -184,8 +181,7 @@ describe("startServerExecutionHost OFF witness", () => {
     it("adds nothing while the serving loop is off", () => {
       publishExperimentalPosture({ modernCellRep: false });
       try {
-        // Explicit "false" — the OFF arm's selector since the flip made
-        // the unset default ON.
+        // Explicit "false" always selects the OFF arm.
         startServerExecutionHost({
           server: untouchable<MemoryServer>("server"),
           identity: untouchable<Identity>("identity"),

--- a/packages/toolshed/lib/server-execution.ts
+++ b/packages/toolshed/lib/server-execution.ts
@@ -5,10 +5,9 @@
 // server: the admission-side observer (plane b) activates spaces, lease
 // writes ride the direct engine plane (plane c), and the serving
 // runtimes' storage sessions are in-process loopback connections with the
-// SAME signed session-open production clients present (plane a). OFF (the
-// explicit-`false` rollback arm; the first-party default is ON since the
-// Phase 7 flip), nothing here runs and toolshed is byte-identical to the
-// pre-v2 behavior.
+// SAME signed session-open production clients present (plane a). OFF,
+// whether selected by the default or an explicit override, nothing here
+// runs and toolshed is byte-identical to the pre-v2 behavior.
 
 import {
   type EnvReader,

--- a/tasks/build-binaries.ts
+++ b/tasks/build-binaries.ts
@@ -262,6 +262,10 @@ async function buildShell(config: BuildConfig): Promise<void> {
       stdout: "inherit",
       stderr: "inherit",
       env: {
+        // `clearEnv` remains false, so this child inherits the caller's
+        // EXPERIMENTAL_SERVER_EXECUTION value and bakes the same posture as
+        // the parent binary build. This is load-bearing for the opposite
+        // CI lane's cache-miss path.
         COMMIT_SHA: Deno.env.get("COMMIT_SHA") || mode,
       },
     }).output();
@@ -474,10 +478,10 @@ export async function prepareWorkspace(
     // define read from this same environment in packages/shell/felt.config.ts
     // when buildShell runs below): the raw `EXPERIMENTAL_SERVER_EXECUTION`
     // value, or null when unset — the shell then follows the first-party
-    // default (ON since the Phase 7 flip). Surfaced on toolshed's /api/meta
-    // as `shellServerExecutionDefine` so CI's posture probes can verify the
-    // binary they run: the explicit-`false` OFF guard lanes require an
-    // OFF-built shell, and the default lanes require the define UNSET
+    // default. Surfaced on toolshed's /api/meta as
+    // `shellServerExecutionDefine` so CI's posture probes can verify the
+    // binary they run: the opposite lanes require an explicitly built shell,
+    // and the default lanes require the define unset
     // (docs/specs/server-side-execution/testing.md §2; the shell define is
     // baked, so a lane on the wrong binary would silently be a mixed
     // posture). Written to both markers because

--- a/tasks/ci-capabilities.test.ts
+++ b/tasks/ci-capabilities.test.ts
@@ -10,6 +10,7 @@ import {
   pidOfBackgroundLaunch,
   resolveCapabilities,
 } from "./ci-capabilities.ts";
+import { serverExecutionCiLane } from "./server-execution-ci.ts";
 
 describe("ci capabilities", () => {
   it("opens what a capability is built on before the capability", () => {
@@ -61,7 +62,7 @@ describe("ci capabilities", () => {
       "jq",
       "local-dev-servers",
       "toolshed",
-      "toolshed-baked-off",
+      "toolshed-baked-opposite",
     ]);
   });
 
@@ -359,8 +360,12 @@ describe("opening a capability on a machine that answers", () => {
   });
 
   it("builds the server-execution binary only when none was restored", async () => {
-    const answers = { "toolshed-off": "listening (pid 999999). Logs: x\n" };
-    const openOff = async (restored: boolean) => {
+    const opposite = serverExecutionCiLane("opposite");
+    const binaryName = `toolshed-baked-${opposite.experimentalValue}`;
+    const answers = {
+      [binaryName]: "listening (pid 999999). Logs: x\n",
+    };
+    const openOpposite = async (restored: boolean) => {
       const m = machine(answers);
       const root = await Deno.makeTempDir({ prefix: "capability-" });
       // What a build leaves behind, so the copy into the cache has
@@ -370,11 +375,11 @@ describe("opening a capability on a machine that answers", () => {
       if (restored) {
         await Deno.mkdir(`${root}/${BINARY_CACHE_DIR}`, { recursive: true });
         await Deno.writeTextFile(
-          `${root}/${BINARY_CACHE_DIR}/toolshed-off`,
+          `${root}/${BINARY_CACHE_DIR}/${binaryName}`,
           "",
         );
       }
-      const opened = await openCapabilities(["toolshed-baked-off"], {
+      const opened = await openCapabilities(["toolshed-baked-opposite"], {
         root,
         dryRun: false,
         workDir: root,
@@ -386,8 +391,8 @@ describe("opening a capability on a machine that answers", () => {
     };
     // A cache miss builds; a restore does not, which is the difference
     // between forty seconds and seventeen on every lane that needs it.
-    expect(await openOff(false)).toBe(true);
-    expect(await openOff(true)).toBe(false);
+    expect(await openOpposite(false)).toBe(true);
+    expect(await openOpposite(true)).toBe(false);
   });
 
   it("builds the background service binary only when none was restored", async () => {

--- a/tasks/ci-capabilities.ts
+++ b/tasks/ci-capabilities.ts
@@ -6,10 +6,10 @@
  * once, and runs the batches inside it. Naming them is what lets two ways
  * of providing the same thing coexist: `toolshed` runs the default posture
  * from source, which is cheap enough for a pull request, while
- * `toolshed-baked-off` restores or builds a binary because the explicit-OFF
- * server-execution posture is baked into the browser shell inside it and a
- * source run cannot reproduce that. A suite says which it needs and neither
- * the workflow nor the other suites know the difference.
+ * `toolshed-baked-opposite` restores or builds a binary because the posture
+ * opposite the first-party default is baked into the browser shell inside it
+ * and a source run cannot reproduce that. A suite says which it needs and
+ * neither the workflow nor the other suites know the difference.
  *
  * Every capability is idempotent: opening one that is already open is the
  * same as not opening it. The lane runner relies on that when a batch it
@@ -17,6 +17,7 @@
  */
 
 import * as path from "@std/path";
+import { serverExecutionCiLane } from "./server-execution-ci.ts";
 
 /** Every piece of setup a suite may ask for. */
 export type CapabilityId =
@@ -26,7 +27,7 @@ export type CapabilityId =
   | "browser"
   | "git-history"
   | "toolshed"
-  | "toolshed-baked-off"
+  | "toolshed-baked-opposite"
   | "bg-piece-service-binary"
   | "cf"
   | "local-dev-servers"
@@ -379,18 +380,24 @@ const toolshed: Capability = {
 };
 
 /**
- * The same server with server execution explicitly off, from a compiled
- * binary. The OFF posture is a compile-time define baked into the browser
- * shell inside the binary, so a source run cannot reproduce it. The lane's
- * workflow restores the binary from the Actions cache before the runner starts;
- * building it here is what happens when that cache missed.
+ * The same server with the posture opposite the first-party default, from a
+ * compiled binary. The posture is a compile-time define baked into the browser
+ * shell, so a source run cannot reproduce it. The lane's workflow restores the
+ * binary from the Actions cache before the runner starts; building it here is
+ * what happens when that cache missed.
  */
-const toolshedBakedOff: Capability = {
-  id: "toolshed-baked-off",
-  description: "a Toolshed server with server execution OFF in its baked shell",
+const toolshedBakedOpposite: Capability = {
+  id: "toolshed-baked-opposite",
+  description: "a Toolshed server with the opposite posture in its baked shell",
   needs: ["deno"],
   async open(context) {
-    const binary = path.join(context.root, BINARY_CACHE_DIR, "toolshed-off");
+    const opposite = serverExecutionCiLane("opposite");
+    const experimentalValue = String(opposite.enabled);
+    const binary = path.join(
+      context.root,
+      BINARY_CACHE_DIR,
+      `toolshed-baked-${experimentalValue}`,
+    );
     if (!context.dryRun) {
       let present = true;
       try {
@@ -410,7 +417,7 @@ const toolshedBakedOff: Capability = {
             cwd: context.root,
             env: {
               ...Deno.env.toObject(),
-              EXPERIMENTAL_SERVER_EXECUTION: "false",
+              EXPERIMENTAL_SERVER_EXECUTION: experimentalValue,
             },
           },
         );
@@ -425,7 +432,7 @@ const toolshedBakedOff: Capability = {
     return await startToolshed(context, {
       command: [binary],
       cwd: context.root,
-      env: { EXPERIMENTAL_SERVER_EXECUTION: "false" },
+      env: { EXPERIMENTAL_SERVER_EXECUTION: experimentalValue },
     });
   },
 };
@@ -532,7 +539,7 @@ export const CAPABILITIES: ReadonlyMap<CapabilityId, Capability> = new Map(
     browser,
     gitHistory,
     toolshed,
-    toolshedBakedOff,
+    toolshedBakedOpposite,
     bgPieceServiceBinary,
     cf,
     localDevServers,

--- a/tasks/ci-workflow.test.ts
+++ b/tasks/ci-workflow.test.ts
@@ -1005,12 +1005,9 @@ Deno.test("server-execution CI uses stable default and opposite roles", async ()
         runStep,
       ]
     ) {
-      assert(
-        !withoutComments(stepBlock(job, stepName)).includes(
-          "EXPERIMENTAL_SERVER_EXECUTION=false",
-        ),
-        `${jobId}: "${stepName}" must inherit the shared opposite posture`,
-      );
+      // The selecting steps exist under these names and, like every other
+      // step (asserted over the whole workflow below), carry no literal arm.
+      stepBlock(job, stepName);
     }
     assertStringIncludes(
       job,
@@ -1023,6 +1020,20 @@ Deno.test("server-execution CI uses stable default and opposite roles", async ()
       `${jobId}: the opposite lane runs the opposite-built binary`,
     );
   }
+
+  // No step anywhere selects an arm by literal: every assignment of the flag
+  // is the resolve step's output, so a flip of the default moves both roles
+  // together and a value pinned by hand cannot turn a flip into a mixed
+  // posture. Comments are stripped so a note naming a value is not read as
+  // setting it; the CLI lane's `${EXPERIMENTAL_SERVER_EXECUTION:-…}` is a
+  // read, not an assignment, and does not match.
+  const literal = withoutComments(contents).match(
+    /EXPERIMENTAL_SERVER_EXECUTION\s*[:=]\s*"?(?:true|false)/,
+  );
+  assert(
+    literal === null,
+    `deno.yml selects a server-execution arm by literal: ${literal?.[0]}`,
+  );
 
   const buildOpposite = jobBlock(contents, "build-toolshed-opposite");
   assertStringIncludes(

--- a/tasks/ci-workflow.test.ts
+++ b/tasks/ci-workflow.test.ts
@@ -517,13 +517,10 @@ Deno.test("pattern shard selection fails loudly instead of running an empty shar
 
   const contents = withoutComments(await workflow("deno.yml"));
   for (
-    // Both pattern shard lanes under their post-flip names: the DEFAULT
-    // lane (the ON arm since the flip) and the explicit-`false` OFF
-    // regression guard — the pre-flip `-server-execution-on` job with its
-    // role inverted, which is where this pin's second job went.
+    // Both stable pattern roles use the same selector contract.
     const jobId of [
       "pattern-integration-test",
-      "pattern-integration-test-server-execution-off",
+      "pattern-integration-test-server-execution-opposite",
     ]
   ) {
     const job = jobBlock(contents, jobId);
@@ -879,24 +876,25 @@ Deno.test("test-records-ship forwards its optional variant input", async () => {
   );
   assertStringIncludes(action, "  variant:\n");
   assertStringIncludes(action, "SHIP_VARIANT: ${{ inputs.variant }}");
-  assertStringIncludes(action, 'args+=(--variant "$SHIP_VARIANT")');
+  assertStringIncludes(
+    action,
+    'RESOLVED_VARIANT="${SHIP_VARIANT:-${CF_TEST_RECORDS_VARIANT:-}}"',
+  );
+  assertStringIncludes(action, 'args+=(--variant "$RESOLVED_VARIANT")');
 });
 
-Deno.test("server-execution OFF jobs ship records under their variant; the default (ON since the flip) stays unmarked", async () => {
-  // testing.md §2's test-record identity contract, post-flip: the DEFAULT
-  // configuration (ON since the Phase 7 flip) continues the existing
-  // unmarked history, and the surviving explicit-OFF regression guard is
-  // marked `server-execution-off`. (The pre-flip explicit-ON arm's
-  // `server-execution` marker retired with the flip — its history stays
-  // queryable under that variant.)
+Deno.test("server-execution records follow the stable default and opposite roles", async () => {
+  // The default continues the unmarked history. The opposite role exports the
+  // actual implementation arm as CF_TEST_RECORDS_VARIANT, which the shipping
+  // action consumes without hard-coding ON or OFF in the workflow.
   const contents = withoutComments(await workflow("deno.yml"));
   const packageJob = jobBlock(
     contents,
-    "package-integration-test-server-execution-off",
+    "package-integration-test-server-execution-opposite",
   );
   const patternJob = jobBlock(
     contents,
-    "pattern-integration-test-server-execution-off",
+    "pattern-integration-test-server-execution-opposite",
   );
   assertStringIncludes(
     packageJob,
@@ -909,11 +907,11 @@ Deno.test("server-execution OFF jobs ship records under their variant; the defau
   );
   assertStringIncludes(
     patternJob,
-    "--junit-path=../../test-results/patterns-server-execution-off-${{ matrix.shard }}.xml",
+    "--junit-path=../../test-results/patterns-server-execution-opposite-${{ matrix.shard }}.xml",
   );
   assertStringIncludes(
     stepBlock(patternJob, "📤 Ship test records"),
-    "glob=test-results/patterns-server-execution-off-${{ matrix.shard }}.xml",
+    "glob=test-results/patterns-server-execution-opposite-${{ matrix.shard }}.xml",
   );
 
   for (
@@ -928,23 +926,26 @@ Deno.test("server-execution OFF jobs ship records under their variant; the defau
 
   for (
     const jobId of [
-      "package-integration-test-server-execution-off",
-      "pattern-integration-test-server-execution-off",
+      "package-integration-test-server-execution-opposite",
+      "pattern-integration-test-server-execution-opposite",
     ]
   ) {
-    const ship = stepBlock(jobBlock(contents, jobId), "📤 Ship test records");
-    assertStringIncludes(ship, "variant: server-execution-off");
+    const job = jobBlock(contents, jobId);
+    assertStringIncludes(
+      stepBlock(job, "🧭 Resolve opposite server-execution posture"),
+      "tasks/server-execution-ci-command.ts env opposite",
+    );
+    const ship = stepBlock(job, "📤 Ship test records");
+    assert(
+      !ship.includes("variant:"),
+      `${jobId}: the arm variant must come from the shared role resolver`,
+    );
   }
 });
 
-Deno.test("server-execution lane roles match the flipped default (testing.md §2)", async () => {
-  // The flip PR's lane-role swap, pinned: the DEFAULT lanes are the ON
-  // exercise (probe: serving loop PRESENT, shell define unset) and carry
-  // the ON-arm skip list; the explicit-`false` lanes are the OFF
-  // regression guard on the OFF-built binary (probe: serving loop ABSENT,
-  // define "false") and take no skip list. A partial revert that swapped
-  // one half back would otherwise leave a lane silently testing the wrong
-  // arm with every test green.
+Deno.test("server-execution CI uses stable default and opposite roles", async () => {
+  // Both roles resolve from one helper. The default keeps the flag unset; the
+  // opposite build, server, and test processes inherit its explicit inverse.
   const contents = await workflow("deno.yml");
 
   for (
@@ -953,90 +954,100 @@ Deno.test("server-execution lane roles match the flipped default (testing.md §2
     const job = jobBlock(contents, jobId);
     assertStringIncludes(
       job,
-      "✅ Verify the server-execution posture (default posture — server ON, shell define unset)",
-      `${jobId}: the default lane must probe the ON posture`,
+      "tasks/server-execution-ci-command.ts env default",
+      `${jobId}: the default lane must resolve from the shared helper`,
     );
     assertStringIncludes(
       job,
-      ".servingLoop != null",
-      `${jobId}: the default lane's probe must require the serving loop`,
+      "tasks/server-execution-ci-command.ts probe default",
+      `${jobId}: the default lane must use the shared posture probe`,
     );
     assertStringIncludes(
       job,
       "server-execution-on-skips.ts",
-      `${jobId}: the ON-arm skip list rides the default lanes since the flip`,
+      `${jobId}: the lane must be able to carry the ON-arm skip list`,
+    );
+    assertStringIncludes(
+      job,
+      '[ "$SERVER_EXECUTION_ENABLED" = "true" ]',
+      `${jobId}: the skip list must apply only when this role is ON`,
     );
   }
 
-  // Each step that SELECTS the arm carries its own assertion: the step
-  // that starts the toolshed, and the step that runs the test processes.
-  // A job-wide substring is satisfied by any single occurrence — the
-  // posture probe's `::error::` prose selects nothing and satisfies it —
-  // so the two selecting steps could disagree, and a lane that starts its
-  // server on one arm while running its tests on the other is a MIXED
-  // posture that every test still passes. The posture probe cannot stand
-  // in for this: it reads the SERVER, so the arm the test processes run
-  // under is unexamined unless asserted here. Comments are stripped on
-  // both, so a note naming an arm never counts as selecting it.
+  // The opposite job resolves its role once into the job environment. Both
+  // the toolshed and test steps inherit it; no step may pin today's inverse
+  // value independently and turn a future flip into a mixed posture.
   for (
     const { jobId, runStep } of [
       {
-        jobId: "package-integration-test-server-execution-off",
-        runStep: "🧪 Run ${{ matrix.step_name }} (flag OFF)",
+        jobId: "package-integration-test-server-execution-opposite",
+        runStep: "🧪 Run ${{ matrix.step_name }} (opposite posture)",
       },
       {
-        jobId: "pattern-integration-test-server-execution-off",
-        runStep: "🧩 Run end-to-end patterns integration tests (flag OFF)",
+        jobId: "pattern-integration-test-server-execution-opposite",
+        runStep:
+          "🧩 Run end-to-end patterns integration tests (opposite posture)",
       },
     ]
   ) {
     const job = jobBlock(contents, jobId);
+    assertStringIncludes(
+      job,
+      "tasks/server-execution-ci-command.ts env opposite",
+    );
+    assertStringIncludes(
+      job,
+      "tasks/server-execution-ci-command.ts probe opposite",
+    );
     for (
       const stepName of [
-        "🔌 Start Toolshed server for testing (flag OFF)",
+        "🔌 Start Toolshed server for testing (opposite posture)",
         runStep,
       ]
     ) {
-      assertStringIncludes(
-        withoutComments(stepBlock(job, stepName)),
-        "EXPERIMENTAL_SERVER_EXECUTION=false",
-        `${jobId}: "${stepName}" must select the OFF arm explicitly`,
+      assert(
+        !withoutComments(stepBlock(job, stepName)).includes(
+          "EXPERIMENTAL_SERVER_EXECUTION=false",
+        ),
+        `${jobId}: "${stepName}" must inherit the shared opposite posture`,
       );
     }
     assertStringIncludes(
       job,
-      ".servingLoop == null",
-      `${jobId}: the OFF guard's probe must require the serving loop absent`,
+      '[ "$SERVER_EXECUTION_ENABLED" = "true" ]',
+      `${jobId}: the ON-arm skip list follows the resolved posture`,
     );
     assertStringIncludes(
       job,
-      "binary-toolshed-off",
-      `${jobId}: the OFF guard runs the OFF-built binary`,
-    );
-    assert(
-      !withoutComments(job).includes("server-execution-on-skips.ts"),
-      `${jobId}: the OFF arm takes no skip list`,
+      "binary-toolshed-opposite",
+      `${jobId}: the opposite lane runs the opposite-built binary`,
     );
   }
 
-  const buildOff = jobBlock(contents, "build-toolshed-off");
+  const buildOpposite = jobBlock(contents, "build-toolshed-opposite");
   assertStringIncludes(
-    buildOff,
-    'EXPERIMENTAL_SERVER_EXECUTION: "false"',
-    "build-toolshed-off must bake the OFF define into the shell",
+    buildOpposite,
+    "tasks/server-execution-ci-command.ts env opposite",
+    "the opposite build must bake the posture resolved by the shared helper",
   );
 
-  // The deployed-topology gates (the flip PR's own obligation — P7 review
-  // finding 8): the real bg-piece-service binary and cf-harness's fabric
-  // session, exercised at the DEFAULT (ON) resolution.
+  // The real bg-piece-service binary and cf-harness fabric session are always
+  // exercised at the first-party default resolution.
   const gate = jobBlock(contents, "deployed-topology-gate");
   assertStringIncludes(gate, "binary-bg-piece-service");
   assertStringIncludes(gate, "integration/posture-gate.test.ts");
   assertStringIncludes(gate, "integration/fabric-session-posture-gate.test.ts");
-  assertStringIncludes(gate, ".servingLoop != null");
+  assertStringIncludes(
+    gate,
+    "tasks/server-execution-ci-command.ts env default",
+  );
+  assertStringIncludes(
+    gate,
+    "tasks/server-execution-ci-command.ts probe default",
+  );
 });
 
-Deno.test("the CLI lane refuses a mixed server-execution posture", async () => {
+Deno.test("the CLI lane follows the default and refuses a mixed posture", async () => {
   // `cf` is a deployed CLIENT: it ADOPTS the arm the server publishes on
   // /api/meta (experimentalOptionsForDeployedClient, authority "server")
   // unless an explicit EXPERIMENTAL_SERVER_EXECUTION overrides it. A
@@ -1048,13 +1059,13 @@ Deno.test("the CLI lane refuses a mixed server-execution posture", async () => {
   const job = jobBlock(contents, "cli-integration-test");
   const probe = stepBlock(
     job,
-    "✅ Verify the server-execution posture (default posture — server ON, cf adopts ON)",
+    "✅ Verify the default server-execution posture and cf adoption",
   );
 
   assertStringIncludes(
     probe,
-    ".servingLoop != null",
-    "the CLI probe must require the server's serving loop",
+    "tasks/server-execution-ci-command.ts probe default",
+    "the CLI probe must verify the resolved default server posture",
   );
   assertStringIncludes(
     probe,
@@ -1071,13 +1082,18 @@ Deno.test("the CLI lane refuses a mixed server-execution posture", async () => {
     '[ "$CLIENT_ARM" != "$SERVER_ARM" ]',
     "the CLI probe must fail on a client/server arm disagreement",
   );
+  assertStringIncludes(
+    probe,
+    'if .experimental.serverExecution == null then "unpublished"',
+    "the CLI probe must preserve a published JSON false rather than treating it as absent",
+  );
 });
 
-Deno.test("server-execution OFF pattern failures upload the toolshed log", async () => {
+Deno.test("both server-execution pattern roles upload failure logs", async () => {
   const contents = await workflow("deno.yml");
   const patternJob = jobBlock(
     contents,
-    "pattern-integration-test-server-execution-off",
+    "pattern-integration-test-server-execution-opposite",
   );
   const upload = stepBlock(patternJob, "📋 Upload toolshed log on failure");
 
@@ -1085,14 +1101,12 @@ Deno.test("server-execution OFF pattern failures upload the toolshed log", async
   assertStringIncludes(upload, "uses: actions/upload-artifact@");
   assertStringIncludes(
     upload,
-    "name: toolshed-log-pattern-integration-server-execution-off-${{ matrix.shard }}",
+    "name: toolshed-log-pattern-integration-server-execution-opposite-${{ matrix.shard }}",
   );
   assertStringIncludes(upload, "path: ${{ runner.temp }}/toolshed.log");
   assertStringIncludes(upload, "retention-days: 14");
   assertStringIncludes(upload, "if-no-files-found: ignore");
 
-  // The default lane is the ON exercise since the flip; it carries the
-  // same triage affordance.
   const defaultJob = jobBlock(contents, "pattern-integration-test");
   const defaultUpload = stepBlock(
     defaultJob,

--- a/tasks/ci-workflow.test.ts
+++ b/tasks/ci-workflow.test.ts
@@ -1024,11 +1024,13 @@ Deno.test("server-execution CI uses stable default and opposite roles", async ()
   // No step anywhere selects an arm by literal: every assignment of the flag
   // is the resolve step's output, so a flip of the default moves both roles
   // together and a value pinned by hand cannot turn a flip into a mixed
-  // posture. Comments are stripped so a note naming a value is not read as
-  // setting it; the CLI lane's `${EXPERIMENTAL_SERVER_EXECUTION:-…}` is a
-  // read, not an assignment, and does not match.
+  // posture. Every assignment form counts — a YAML `env:` entry in either
+  // quote style, a shell `NAME=value`, and the shell default-assignment
+  // `${NAME:=value}`. Comments are stripped so a note naming a value is not
+  // read as setting it; the CLI lane's `${EXPERIMENTAL_SERVER_EXECUTION:-…}`
+  // is a read, not an assignment, and does not match.
   const literal = withoutComments(contents).match(
-    /EXPERIMENTAL_SERVER_EXECUTION\s*[:=]\s*"?(?:true|false)/,
+    /EXPERIMENTAL_SERVER_EXECUTION\s*(?::=|[:=])\s*['"]?(?:true|false)\b/,
   );
   assert(
     literal === null,

--- a/tasks/server-execution-ci-command.ts
+++ b/tasks/server-execution-ci-command.ts
@@ -1,5 +1,3 @@
-// deno-coverage-ignore-file -- trivial command-line adapter; the command is tested through its library entrypoint.
-
 import { runServerExecutionCiCommand } from "./server-execution-ci.ts";
 
 await runServerExecutionCiCommand(Deno.args);

--- a/tasks/server-execution-ci-command.ts
+++ b/tasks/server-execution-ci-command.ts
@@ -1,0 +1,5 @@
+// deno-coverage-ignore-file -- trivial command-line adapter; the command is tested through its library entrypoint.
+
+import { runServerExecutionCiCommand } from "./server-execution-ci.ts";
+
+await runServerExecutionCiCommand(Deno.args);

--- a/tasks/server-execution-ci.test.ts
+++ b/tasks/server-execution-ci.test.ts
@@ -1,0 +1,204 @@
+/** Tests the stable server-execution CI role mapping. */
+
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import { SERVER_EXECUTION_DEFAULT_ENABLED } from "@commonfabric/memory/v2/server-execution-default";
+import {
+  assertServerExecutionCiPosture,
+  runServerExecutionCiCommand,
+  serverExecutionCiEnvironment,
+  serverExecutionCiLane,
+} from "./server-execution-ci.ts";
+
+describe("server-execution-ci", () => {
+  it("resolves the default role from the first-party constant", () => {
+    expect(serverExecutionCiLane("default").enabled).toBe(
+      SERVER_EXECUTION_DEFAULT_ENABLED,
+    );
+  });
+
+  it("keeps the documented current posture aligned with the default", async () => {
+    const registry = await Deno.readTextFile(
+      new URL(
+        "../docs/development/EXPERIMENTAL_OPTIONS.md",
+        import.meta.url,
+      ),
+    );
+    const summary = registry.split("\n").find((line) =>
+      line.startsWith("| [`serverExecution`](#serverexecution)")
+    );
+    expect(summary).toBeDefined();
+    expect(summary!).toContain(
+      `SERVER_EXECUTION_DEFAULT_ENABLED = ${SERVER_EXECUTION_DEFAULT_ENABLED}`,
+    );
+  });
+
+  for (const defaultEnabled of [false, true]) {
+    describe(`with the default ${defaultEnabled ? "ON" : "OFF"}`, () => {
+      it("leaves the default role implicit and selects its opposite explicitly", () => {
+        const defaultLane = serverExecutionCiLane("default", defaultEnabled);
+        const oppositeLane = serverExecutionCiLane(
+          "opposite",
+          defaultEnabled,
+        );
+
+        expect(defaultLane).toEqual({
+          role: "default",
+          enabled: defaultEnabled,
+          label: defaultEnabled ? "ON" : "OFF",
+        });
+        expect(oppositeLane).toEqual({
+          role: "opposite",
+          enabled: !defaultEnabled,
+          label: defaultEnabled ? "OFF" : "ON",
+          recordVariant: defaultEnabled
+            ? "server-execution-off"
+            : "server-execution",
+          experimentalValue: defaultEnabled ? "false" : "true",
+        });
+      });
+
+      it("exports the actual arm and only makes the opposite role explicit", () => {
+        expect(
+          serverExecutionCiEnvironment("default", defaultEnabled),
+        ).toEqual([
+          `SERVER_EXECUTION_ENABLED=${defaultEnabled}`,
+          "CF_TEST_RECORDS_VARIANT=",
+        ]);
+        expect(
+          serverExecutionCiEnvironment("opposite", defaultEnabled),
+        ).toEqual([
+          `SERVER_EXECUTION_ENABLED=${!defaultEnabled}`,
+          `CF_TEST_RECORDS_VARIANT=${
+            defaultEnabled ? "server-execution-off" : "server-execution"
+          }`,
+          `EXPERIMENTAL_SERVER_EXECUTION=${!defaultEnabled}`,
+        ]);
+      });
+
+      it("accepts a uniform server and baked-shell posture", () => {
+        for (const role of ["default", "opposite"] as const) {
+          const lane = serverExecutionCiLane(role, defaultEnabled);
+          expect(() =>
+            assertServerExecutionCiPosture(
+              role,
+              {
+                experimental: { serverExecution: lane.enabled },
+                shellServerExecutionDefine: lane.experimentalValue ?? null,
+              },
+              { servingLoop: lane.enabled ? {} : null },
+              defaultEnabled,
+            )
+          ).not.toThrow();
+        }
+      });
+    });
+  }
+
+  it("rejects mixed and misreported postures", () => {
+    expect(() =>
+      assertServerExecutionCiPosture(
+        "default",
+        {
+          experimental: { serverExecution: true },
+          shellServerExecutionDefine: null,
+        },
+        { servingLoop: null },
+        true,
+      )
+    ).toThrow("serving loop is absent");
+    expect(() =>
+      assertServerExecutionCiPosture(
+        "opposite",
+        {
+          experimental: { serverExecution: true },
+          shellServerExecutionDefine: "false",
+        },
+        { servingLoop: null },
+        true,
+      )
+    ).toThrow("publishes serverExecution=true");
+    expect(() =>
+      assertServerExecutionCiPosture(
+        "opposite",
+        {
+          experimental: { serverExecution: false },
+          shellServerExecutionDefine: "true",
+        },
+        { servingLoop: null },
+        true,
+      )
+    ).toThrow("shell define is true");
+  });
+
+  it("runs the environment command and rejects malformed commands", async () => {
+    const logged: string[] = [];
+    await runServerExecutionCiCommand(
+      ["env", "opposite"],
+      fetch,
+      (message) => logged.push(message),
+    );
+    expect(logged).toEqual([
+      serverExecutionCiEnvironment("opposite").join("\n"),
+    ]);
+
+    await expect(
+      runServerExecutionCiCommand(["env", "sideways"]),
+    ).rejects.toThrow("Expected server-execution CI role");
+    await expect(
+      runServerExecutionCiCommand(["probe", "default"]),
+    ).rejects.toThrow("Expected `env <role>` or `probe <role> <toolshed-url>`");
+  });
+
+  it("probes both roles and reports HTTP failures", async () => {
+    const requested: string[] = [];
+    const logged: string[] = [];
+    for (const role of ["default", "opposite"] as const) {
+      const lane = serverExecutionCiLane(role);
+      const fetcher = (input: string | URL | Request): Promise<Response> => {
+        const url = String(input);
+        requested.push(url);
+        const body = url.endsWith("/api/meta")
+          ? {
+            experimental: { serverExecution: lane.enabled },
+            shellServerExecutionDefine: lane.experimentalValue ?? null,
+          }
+          : { servingLoop: lane.enabled ? {} : null };
+        return Promise.resolve(Response.json(body));
+      };
+      await runServerExecutionCiCommand(
+        ["probe", role, "https://example.test/"],
+        fetcher,
+        (message) => logged.push(message),
+      );
+    }
+    expect(requested).toEqual([
+      "https://example.test/api/meta",
+      "https://example.test/api/health/stats",
+      "https://example.test/api/meta",
+      "https://example.test/api/health/stats",
+    ]);
+    expect(logged).toEqual([
+      `Verified default server-execution lane (${
+        serverExecutionCiLane("default").label
+      }).`,
+      `Verified opposite server-execution lane (${
+        serverExecutionCiLane("opposite").label
+      }).`,
+    ]);
+
+    const failedFetch = (input: string | URL | Request): Promise<Response> =>
+      Promise.resolve(
+        new Response(null, {
+          status: String(input).endsWith("/api/meta") ? 503 : 500,
+        }),
+      );
+    await expect(
+      runServerExecutionCiCommand(
+        ["probe", "default", "https://example.test"],
+        failedFetch,
+      ),
+    ).rejects.toThrow("meta=503, stats=500");
+  });
+});

--- a/tasks/server-execution-ci.test.ts
+++ b/tasks/server-execution-ci.test.ts
@@ -1,6 +1,7 @@
 /** Tests the stable server-execution CI role mapping. */
 
 import { expect } from "@std/expect";
+import { fromFileUrl } from "@std/path";
 import { describe, it } from "@std/testing/bdd";
 
 import { SERVER_EXECUTION_DEFAULT_ENABLED } from "@commonfabric/memory/v2/server-execution-default";
@@ -29,8 +30,42 @@ describe("server-execution-ci", () => {
       line.startsWith("| [`serverExecution`](#serverexecution)")
     );
     expect(summary).toBeDefined();
+    // The whole status cell, so the posture word, the constant's value and
+    // the rollback arm cannot drift apart from each other or from the code.
+    const enabled = SERVER_EXECUTION_DEFAULT_ENABLED;
     expect(summary!).toContain(
-      `SERVER_EXECUTION_DEFAULT_ENABLED = ${SERVER_EXECUTION_DEFAULT_ENABLED}`,
+      `| **${enabled ? "on" : "off"}** ` +
+        `(\`SERVER_EXECUTION_DEFAULT_ENABLED = ${enabled}\`; ` +
+        `explicit \`${!enabled}\` = rollback) |`,
+    );
+  });
+
+  it("runs as the program the workflow invokes, with no permissions", async () => {
+    // CI's resolve and probe steps run the adapter as a program
+    // (`deno run tasks/server-execution-ci-command.ts …`, no flags), so it is
+    // exercised the same way: it needs no permission, prints exactly the
+    // library's lines, and turns a bad role into a failing step.
+    const adapter = fromFileUrl(
+      new URL("./server-execution-ci-command.ts", import.meta.url),
+    );
+    const run = (...args: string[]) =>
+      new Deno.Command(Deno.execPath(), {
+        args: ["run", adapter, ...args],
+        cwd: fromFileUrl(new URL("..", import.meta.url)),
+        stdout: "piped",
+        stderr: "piped",
+      }).output();
+
+    const env = await run("env", "opposite");
+    expect(env.success).toBe(true);
+    expect(new TextDecoder().decode(env.stdout)).toBe(
+      `${serverExecutionCiEnvironment("opposite").join("\n")}\n`,
+    );
+
+    const bad = await run("env", "sideways");
+    expect(bad.code).toBe(1);
+    expect(new TextDecoder().decode(bad.stderr)).toContain(
+      "Expected server-execution CI role",
     );
   });
 

--- a/tasks/server-execution-ci.ts
+++ b/tasks/server-execution-ci.ts
@@ -1,0 +1,135 @@
+/**
+ * Defines the two server-execution roles CI carries through a default flip.
+ * The default role leaves the flag unset; the opposite role selects the other
+ * arm explicitly, so one constant change moves their assignments together.
+ */
+
+import { SERVER_EXECUTION_DEFAULT_ENABLED } from "@commonfabric/memory/v2/server-execution-default";
+
+/** Stable role of a server-execution CI lane. */
+export type ServerExecutionCiRole = "default" | "opposite";
+
+/** Complete posture of one server-execution CI lane. */
+export interface ServerExecutionCiLane {
+  /** Role which stays stable when the first-party default changes. */
+  readonly role: ServerExecutionCiRole;
+
+  /** Whether this lane runs the server-execution implementation. */
+  readonly enabled: boolean;
+
+  /** Human-readable form used by CI logs and job summaries. */
+  readonly label: "ON" | "OFF";
+
+  /** Explicit flag value for the opposite role; absent for the default role. */
+  readonly experimentalValue?: "true" | "false";
+
+  /** Test-record variant for the non-default role; default stays unmarked. */
+  readonly recordVariant?: "server-execution" | "server-execution-off";
+}
+
+/** Returns the two-arm CI posture for `role`. */
+export function serverExecutionCiLane(
+  role: ServerExecutionCiRole,
+  defaultEnabled = SERVER_EXECUTION_DEFAULT_ENABLED,
+): ServerExecutionCiLane {
+  const enabled = role === "default" ? defaultEnabled : !defaultEnabled;
+  return {
+    role,
+    enabled,
+    label: enabled ? "ON" : "OFF",
+    ...(role === "default" ? {} : {
+      experimentalValue: enabled ? "true" : "false",
+      recordVariant: enabled ? "server-execution" : "server-execution-off",
+    } as const),
+  };
+}
+
+/** Returns the lines a workflow writes to `$GITHUB_ENV` for `role`. */
+export function serverExecutionCiEnvironment(
+  role: ServerExecutionCiRole,
+  defaultEnabled = SERVER_EXECUTION_DEFAULT_ENABLED,
+): string[] {
+  const lane = serverExecutionCiLane(role, defaultEnabled);
+  return [
+    `SERVER_EXECUTION_ENABLED=${lane.enabled}`,
+    `CF_TEST_RECORDS_VARIANT=${lane.recordVariant ?? ""}`,
+    ...(lane.experimentalValue === undefined
+      ? []
+      : [`EXPERIMENTAL_SERVER_EXECUTION=${lane.experimentalValue}`]),
+  ];
+}
+
+/** Verifies the server and baked shell both carry the requested lane posture. */
+export function assertServerExecutionCiPosture(
+  role: ServerExecutionCiRole,
+  meta: Record<string, unknown>,
+  stats: Record<string, unknown>,
+  defaultEnabled = SERVER_EXECUTION_DEFAULT_ENABLED,
+): void {
+  const lane = serverExecutionCiLane(role, defaultEnabled);
+  const experimental = meta.experimental as
+    | Record<string, unknown>
+    | undefined;
+  const published = experimental?.serverExecution;
+  if (published !== lane.enabled) {
+    throw new Error(
+      `${role} lane publishes serverExecution=${published}; expected ${lane.enabled}`,
+    );
+  }
+
+  const expectedDefine = lane.experimentalValue ?? null;
+  if (meta.shellServerExecutionDefine !== expectedDefine) {
+    throw new Error(
+      `${role} lane shell define is ${meta.shellServerExecutionDefine}; ` +
+        `expected ${expectedDefine}`,
+    );
+  }
+
+  const serving = stats.servingLoop !== null && stats.servingLoop !== undefined;
+  if (serving !== lane.enabled) {
+    throw new Error(
+      `${role} lane serving loop is ${serving ? "present" : "absent"}; ` +
+        `expected server execution ${lane.label}`,
+    );
+  }
+}
+
+/** Runs the small workflow-facing CLI. Exported so its error paths stay tested. */
+export async function runServerExecutionCiCommand(
+  args: readonly string[],
+  fetcher: typeof fetch = fetch,
+  log: (message: string) => void = console.log,
+): Promise<void> {
+  const [command, role, baseUrl] = args;
+  if (role !== "default" && role !== "opposite") {
+    throw new Error(
+      "Expected server-execution CI role `default` or `opposite`.",
+    );
+  }
+  if (command === "env") {
+    log(serverExecutionCiEnvironment(role).join("\n"));
+  } else if (command === "probe" && baseUrl !== undefined) {
+    const url = baseUrl.replace(/\/$/, "");
+    const [metaResponse, statsResponse] = await Promise.all([
+      fetcher(`${url}/api/meta`),
+      fetcher(`${url}/api/health/stats`),
+    ]);
+    if (!metaResponse.ok || !statsResponse.ok) {
+      throw new Error(
+        `Posture probe failed: meta=${metaResponse.status}, stats=${statsResponse.status}`,
+      );
+    }
+    const meta = await metaResponse.json() as Record<string, unknown>;
+    const stats = await statsResponse.json() as Record<string, unknown>;
+    assertServerExecutionCiPosture(role, meta, stats);
+    log(
+      `Verified ${role} server-execution lane (${
+        serverExecutionCiLane(role).label
+      }).`,
+    );
+  } else {
+    throw new Error(
+      "Expected `env <role>` or `probe <role> <toolshed-url>`.",
+    );
+  }
+}

--- a/tasks/server-execution-on-skips.ts
+++ b/tasks/server-execution-on-skips.ts
@@ -2,19 +2,13 @@
 
 // The EXPLICIT per-phase skip lists of the server-execution v2 ON arm
 // (docs/specs/server-side-execution/testing.md §2): in CI the integration
-// suites run twice — the DEFAULT lanes (flag unset = the first-party
-// default, ON since the Phase 7 flip: these lanes ARE the ON arm and
-// carry this list) and the explicit-`EXPERIMENTAL_SERVER_EXECUTION=false`
-// OFF regression-guard lanes (the toolshed server OFF, the test processes
-// OFF, AND the binary's baked browser shell OFF-built —
-// `build-toolshed-off`; kept until the post-soak removal PR). The ON arm
-// may skip a test only by listing it here, with the plan phase whose
-// not-yet-landed surface it exercises and a reason. Never by silent
+// suites run twice — a default role (flag unset = the first-party default)
+// and an opposite role (the inverse explicitly selected in the server, test
+// processes, and baked browser shell). Whichever role resolves ON carries
+// this list. The ON arm may skip a test only by listing it here, with the plan
+// phase whose not-yet-landed surface it exercises and a reason. Never by silent
 // filtering: the CI step prints every skip from this file, and an empty
-// list means the ON arm runs the full suite — the OFF guard never skips.
-// The flip PR landed with this list EMPTY (its stated precondition);
-// before it the roles were inverted (default = OFF, explicit-`true` = the
-// ON arm on `build-toolshed-on`).
+// list means the ON arm runs the full suite — the OFF arm never skips.
 //
 // An entry retires when its phase lands (docs/plans/server-execution-v2.md);
 // a file listed here that no longer exists fails the run, so the lists

--- a/tasks/test-topology.test.ts
+++ b/tasks/test-topology.test.ts
@@ -9,6 +9,7 @@ import {
   topologyUnits,
 } from "./test-topology.ts";
 import { CAPABILITIES } from "./ci-capabilities.ts";
+import { serverExecutionCiLane } from "./server-execution-ci.ts";
 
 const suites = await loadTopology(
   new URL("..", import.meta.url).pathname.replace(/\/$/, ""),
@@ -35,14 +36,18 @@ describe("the test topology", () => {
   });
 
   it("lets a default suite and a variant suite hold one source file", () => {
-    const on = suites.find((suite) => suite.id === "package-integration")!;
-    const off = suites.find((suite) => suite.id === "package-integration-off")!;
+    const defaults = suites.find((suite) =>
+      suite.id === "package-integration"
+    )!;
+    const opposite = suites.find((suite) =>
+      suite.id === "package-integration-opposite"
+    )!;
     // Pinned to a runner-scope file rather than whichever unit sorts
     // first: a record's scope has to match the part that holds the file,
     // and taking the first shared unit would make this fail for the
     // wrong reason the day a whole-file skip changes the order.
-    const shared = on.units.filter((unit) =>
-      off.units.includes(unit) && unit.startsWith("packages/runner/")
+    const shared = defaults.units.filter((unit) =>
+      opposite.units.includes(unit) && unit.startsWith("packages/runner/")
     );
     expect(shared.length > 0).toBe(true);
     // They are distinct execution surfaces, so the same file being a unit
@@ -58,9 +63,12 @@ describe("the test topology", () => {
       expect(
         claimsFor(suites, {
           ...record,
-          test: { ...record.test, v: "server-execution-off" },
+          test: {
+            ...record.test,
+            v: serverExecutionCiLane("opposite").recordVariant,
+          },
         }).map((claim) => claim.suite.id),
-      ).toEqual(["package-integration-off"]);
+      ).toEqual(["package-integration-opposite"]);
     }
   });
 

--- a/tasks/test-topology/binaries.test.ts
+++ b/tasks/test-topology/binaries.test.ts
@@ -1,5 +1,6 @@
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
+import { serverExecutionCiLane } from "../server-execution-ci.ts";
 import { loadBinarySuites } from "./binaries.ts";
 import type { Suite } from "./suite.ts";
 
@@ -19,21 +20,22 @@ describe("the binary build suites", () => {
     // The same build under a different compile-time define, which is
     // what a variant is. One configuration's record must never stand in
     // for the other's.
-    const off = byId("binaries-off");
-    expect(off.variant).toBe("server-execution-off");
-    expect(off.units).toEqual(["toolshed"]);
+    const oppositeLane = serverExecutionCiLane("opposite");
+    const opposite = byId("binaries-opposite");
+    expect(opposite.variant).toBe(oppositeLane.recordVariant);
+    expect(opposite.units).toEqual(["toolshed"]);
     expect(
-      off.locate({
+      opposite.locate({
         test: { k: "gate", s: "repo", n: "build-binary toolshed" },
       }),
     ).toBeUndefined();
     expect(
-      off.locate({
+      opposite.locate({
         test: {
           k: "gate",
           s: "repo",
           n: "build-binary toolshed",
-          v: "server-execution-off",
+          v: oppositeLane.recordVariant,
         },
       }),
     ).toEqual({ level: "unit", unit: "toolshed" });
@@ -64,11 +66,14 @@ describe("the binary build suites", () => {
   });
 
   it("builds the server-execution shell with the define set", () => {
-    return byId("binaries-off").command(
+    const opposite = serverExecutionCiLane("opposite");
+    return byId("binaries-opposite").command(
       [{ unit: "toolshed", skip: [] }],
       { root: "/repo", outputDir: "/out" },
     ).then((made) => {
-      expect(made[0]!.env?.EXPERIMENTAL_SERVER_EXECUTION).toBe("false");
+      expect(made[0]!.env?.EXPERIMENTAL_SERVER_EXECUTION).toBe(
+        String(opposite.enabled),
+      );
     });
   });
 });

--- a/tasks/test-topology/binaries.ts
+++ b/tasks/test-topology/binaries.ts
@@ -31,6 +31,7 @@
  */
 
 import { BINARY_NAMES, type BinaryName } from "../build-binaries.ts";
+import { serverExecutionCiLane } from "../server-execution-ci.ts";
 import {
   claimsIdentity,
   type Invocation,
@@ -38,7 +39,6 @@ import {
   type Suite,
   type Unit,
 } from "./suite.ts";
-import { SERVER_EXECUTION_OFF_VARIANT } from "./patterns.ts";
 
 /** What a unit's record is named for. */
 const PREFIX = "build-binary";
@@ -107,11 +107,12 @@ function binarySuite(
  * two configurations, two histories that never stand in for each other.
  */
 export function loadBinarySuites(): Suite[] {
+  const opposite = serverExecutionCiLane("opposite");
   return [
     binarySuite("binaries", BINARY_NAMES),
-    binarySuite("binaries-off", ["toolshed"], {
-      variant: SERVER_EXECUTION_OFF_VARIANT,
-      env: { EXPERIMENTAL_SERVER_EXECUTION: "false" },
+    binarySuite("binaries-opposite", ["toolshed"], {
+      variant: opposite.recordVariant,
+      env: { EXPERIMENTAL_SERVER_EXECUTION: String(opposite.enabled) },
     }),
   ];
 }

--- a/tasks/test-topology/package-integration.ts
+++ b/tasks/test-topology/package-integration.ts
@@ -1,8 +1,8 @@
 /**
  * The package integration suites: the runner, the runtime client and the
- * shell, each driving a real Toolshed server, and the same three again
- * with server execution explicitly off. The deployed-topology suite owns
- * the background service and cf-harness gates that exercise the default-ON
+ * shell, each driving a real Toolshed server, and the same three again in
+ * the posture opposite the first-party default. The deployed-topology suite
+ * owns the background service and cf-harness gates that exercise the default
  * production construction paths.
  *
  * One runner does not imply one scope here. The three packages share a
@@ -15,13 +15,13 @@ import {
   SERVER_EXECUTION_ON_SKIPS,
   type ServerExecutionSuite,
 } from "../server-execution-on-skips.ts";
+import { serverExecutionCiLane } from "../server-execution-ci.ts";
 import {
   type FilePart,
   fileSuite,
   type Suite,
   unavailableFrom,
 } from "./suite.ts";
-import { SERVER_EXECUTION_OFF_VARIANT } from "./patterns.ts";
 
 /** The packages the suite spans, and what each one's tests need. */
 const PACKAGES: ReadonlyArray<
@@ -55,18 +55,21 @@ async function integrationFiles(
   return found.sort();
 }
 
-/** The default-ON suite, its explicit-OFF arm, and the deployed-topology gate. */
+/** The default suite, its explicit opposite, and the deployed-topology gate. */
 export async function loadPackageIntegrationSuites(
   root: string,
+  defaultEnabled = serverExecutionCiLane("default").enabled,
 ): Promise<Suite[]> {
   const defaults: FilePart[] = [];
-  const off: FilePart[] = [];
+  const opposites: FilePart[] = [];
+  const defaultLane = serverExecutionCiLane("default", defaultEnabled);
+  const oppositeLane = serverExecutionCiLane("opposite", defaultEnabled);
   for (const { scope, headless } of PACKAGES) {
     const packageDir = `packages/${scope}`;
     const files = await integrationFiles(root, packageDir);
     const junit = { kind: "integration", scope, filePrefix: packageDir };
     const env: Record<string, string> = headless ? { HEADLESS: "1" } : {};
-    const { whole, unavailable } = unavailableFrom(
+    const on = unavailableFrom(
       SERVER_EXECUTION_ON_SKIPS[scope],
       packageDir,
     );
@@ -75,15 +78,23 @@ export async function loadPackageIntegrationSuites(
       flags: ["-A"],
       env,
       junit,
-      files: files.filter((file) => !whole.has(file)),
-      unavailable,
+      files: defaultLane.enabled
+        ? files.filter((file) => !on.whole.has(file))
+        : files,
+      unavailable: defaultLane.enabled ? on.unavailable : [],
     });
-    off.push({
+    opposites.push({
       packageDir,
       flags: ["-A"],
-      env: { ...env, EXPERIMENTAL_SERVER_EXECUTION: "false" },
+      env: {
+        ...env,
+        EXPERIMENTAL_SERVER_EXECUTION: String(oppositeLane.enabled),
+      },
       junit,
-      files,
+      files: oppositeLane.enabled
+        ? files.filter((file) => !on.whole.has(file))
+        : files,
+      unavailable: oppositeLane.enabled ? on.unavailable : [],
     });
   }
   const backgroundPostureGate =
@@ -128,10 +139,10 @@ export async function loadPackageIntegrationSuites(
       parts: defaults,
     }),
     fileSuite({
-      id: "package-integration-off",
-      variant: SERVER_EXECUTION_OFF_VARIANT,
-      needs: ["deno", "toolshed-baked-off", "browser"],
-      parts: off,
+      id: "package-integration-opposite",
+      variant: oppositeLane.recordVariant,
+      needs: ["deno", "toolshed-baked-opposite", "browser"],
+      parts: opposites,
     }),
     deployedTopology,
   ];

--- a/tasks/test-topology/patterns.test.ts
+++ b/tasks/test-topology/patterns.test.ts
@@ -214,12 +214,19 @@ describe("enumerating a tree that cannot be read", () => {
     // Passing over a missing directory is right; passing over one that
     // cannot be read would take tests out of the topology without a
     // word, and the drift guard would then report success over a
-    // shorter list than the tree holds.
-    const root = await obstructed(
-      "packages/connectors/agents/debug-view",
-    );
-    await expect(loadPatternSuites(root)).rejects.toThrow();
-    await Deno.remove(root, { recursive: true });
+    // shorter list than the tree holds. Both readers are held to it: the
+    // integration directory is read flat and the pattern trees are
+    // walked, and each has its own rethrow.
+    for (
+      const directory of [
+        "packages/patterns/integration",
+        "packages/connectors/agents/debug-view",
+      ]
+    ) {
+      const root = await obstructed(directory);
+      await expect(loadPatternSuites(root)).rejects.toThrow();
+      await Deno.remove(root, { recursive: true });
+    }
   });
 
   it("raises for a package integration directory it cannot read", async () => {

--- a/tasks/test-topology/patterns.test.ts
+++ b/tasks/test-topology/patterns.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
 import { SKIP_LIST_VARIABLE } from "@commonfabric/test-support/records";
+import { serverExecutionCiLane } from "../server-execution-ci.ts";
 import { loadPatternSuites } from "./patterns.ts";
 import { loadPackageIntegrationSuites } from "./package-integration.ts";
 import type { Suite } from "./suite.ts";
@@ -29,14 +30,42 @@ describe("the pattern and package suites", () => {
     expect(invocation!.junit?.[0]?.scope).toBe("patterns");
   });
 
-  it("runs the server-execution OFF arm with the define set", async () => {
-    const suite = byId("pattern-integration-off");
+  it("runs the opposite arm with an explicit define and history", async () => {
+    const opposite = serverExecutionCiLane("opposite");
+    const suite = byId("pattern-integration-opposite");
     const [invocation] = await suite.command(
       [{ unit: suite.units[0]!, skip: [] }],
       { root, outputDir: await outputDir() },
     );
-    expect(invocation!.env?.EXPERIMENTAL_SERVER_EXECUTION).toBe("false");
-    expect(suite.variant).toBe("server-execution-off");
+    expect(invocation!.env?.EXPERIMENTAL_SERVER_EXECUTION).toBe(
+      String(opposite.enabled),
+    );
+    expect(suite.variant).toBe(opposite.recordVariant);
+  });
+
+  it("moves the test surfaces with the roles after a default flip", async () => {
+    const defaultEnabled = !serverExecutionCiLane("default").enabled;
+    const opposite = serverExecutionCiLane("opposite", defaultEnabled);
+    const flipped = [
+      ...await loadPatternSuites(root, defaultEnabled),
+      ...await loadPackageIntegrationSuites(root, defaultEnabled),
+    ];
+    for (
+      const id of [
+        "pattern-integration-opposite",
+        "package-integration-opposite",
+      ]
+    ) {
+      const suite = flipped.find((candidate) => candidate.id === id)!;
+      expect(suite.variant).toBe(opposite.recordVariant);
+      const [invocation] = await suite.command(
+        [{ unit: suite.units[0]!, skip: [] }],
+        { root, outputDir: await outputDir() },
+      );
+      expect(invocation!.env?.EXPERIMENTAL_SERVER_EXECUTION).toBe(
+        String(opposite.enabled),
+      );
+    }
   });
 
   it("names a skip list only where a leaf inside a unit is skipped", async () => {
@@ -186,7 +215,9 @@ describe("enumerating a tree that cannot be read", () => {
     // cannot be read would take tests out of the topology without a
     // word, and the drift guard would then report success over a
     // shorter list than the tree holds.
-    const root = await obstructed("packages/patterns/integration");
+    const root = await obstructed(
+      "packages/connectors/agents/debug-view",
+    );
     await expect(loadPatternSuites(root)).rejects.toThrow();
     await Deno.remove(root, { recursive: true });
   });

--- a/tasks/test-topology/patterns.ts
+++ b/tasks/test-topology/patterns.ts
@@ -13,6 +13,7 @@
 import * as path from "@std/path";
 import { PATTERN_TREES } from "../pattern-files.ts";
 import { SERVER_EXECUTION_ON_SKIPS } from "../server-execution-on-skips.ts";
+import { serverExecutionCiLane } from "../server-execution-ci.ts";
 import {
   fileSuite,
   type Invocation,
@@ -20,9 +21,6 @@ import {
   type Suite,
   unavailableFrom,
 } from "./suite.ts";
-
-/** The variant the explicit server-execution OFF arms mark their records with. */
-export const SERVER_EXECUTION_OFF_VARIANT = "server-execution-off";
 
 /** Test files directly inside a directory, repository-relative and sorted. */
 async function filesIn(
@@ -73,7 +71,10 @@ async function patternTestFiles(root: string): Promise<string[]> {
 }
 
 /** The integration suites over `packages/patterns/integration/`. */
-async function patternIntegrationSuites(root: string): Promise<Suite[]> {
+async function patternIntegrationSuites(
+  root: string,
+  defaultEnabled: boolean,
+): Promise<Suite[]> {
   const packageDir = "packages/patterns";
   const files = await filesIn(root, `${packageDir}/integration`);
   const flags = [
@@ -87,6 +88,8 @@ async function patternIntegrationSuites(root: string): Promise<Suite[]> {
     filePrefix: packageDir,
   };
   const on = unavailableFrom(SERVER_EXECUTION_ON_SKIPS.patterns, packageDir);
+  const defaultLane = serverExecutionCiLane("default", defaultEnabled);
+  const oppositeLane = serverExecutionCiLane("opposite", defaultEnabled);
   return [
     fileSuite({
       id: "pattern-integration",
@@ -96,20 +99,33 @@ async function patternIntegrationSuites(root: string): Promise<Suite[]> {
         flags,
         env: { HEADLESS: "1" },
         junit,
-        files: files.filter((file) => !on.whole.has(file)),
-        unavailable: on.unavailable,
+        files: defaultLane.enabled
+          ? files.filter((file) => !on.whole.has(file))
+          : files,
+        unavailable: defaultLane.enabled ? on.unavailable : [],
       }],
     }),
     fileSuite({
-      id: "pattern-integration-off",
-      variant: SERVER_EXECUTION_OFF_VARIANT,
-      needs: ["deno", "toolshed-baked-off", "browser", "compile-cache"],
+      id: "pattern-integration-opposite",
+      variant: oppositeLane.recordVariant,
+      needs: [
+        "deno",
+        "toolshed-baked-opposite",
+        "browser",
+        "compile-cache",
+      ],
       parts: [{
         packageDir,
         flags,
-        env: { HEADLESS: "1", EXPERIMENTAL_SERVER_EXECUTION: "false" },
+        env: {
+          HEADLESS: "1",
+          EXPERIMENTAL_SERVER_EXECUTION: String(oppositeLane.enabled),
+        },
         junit,
-        files,
+        files: oppositeLane.enabled
+          ? files.filter((file) => !on.whole.has(file))
+          : files,
+        unavailable: oppositeLane.enabled ? on.unavailable : [],
       }],
     }),
   ];
@@ -227,9 +243,12 @@ async function generatedPatternSuite(root: string): Promise<Suite> {
 }
 
 /** Every pattern suite, read from the working tree. */
-export async function loadPatternSuites(root: string): Promise<Suite[]> {
+export async function loadPatternSuites(
+  root: string,
+  defaultEnabled = serverExecutionCiLane("default").enabled,
+): Promise<Suite[]> {
   return [
-    ...await patternIntegrationSuites(root),
+    ...await patternIntegrationSuites(root, defaultEnabled),
     patternReloadSuite(),
     await patternUnitSuite(root),
     await generatedPatternSuite(root),


### PR DESCRIPTION
## Summary

- replace hard-coded ON-default/OFF-guard CI roles with stable `default` and `opposite` roles
- derive runtime env, baked shell define, posture probes, ON skips, OFF authored coverage, topology capabilities, and test-record variants from one helper
- keep today's default ON and preserve the two-arm test coverage introduced by #6535

After this lands, flipping the first-party default changes `SERVER_EXECUTION_DEFAULT_ENABLED` plus current-status documentation; the CI topology follows automatically.

#6552 remains untouched as the pre-hygiene emergency rollback. A later minimal OFF-default PR can supersede it once this is green.

## Verification

- `deno task check`
- `deno task check-docs`
- `deno task check-test-topology`
- `deno test -A tasks/server-execution-ci.test.ts tasks/test-topology.test.ts tasks/test-topology/patterns.test.ts tasks/test-topology/binaries.test.ts tasks/ci-workflow.test.ts`
- `deno test -A tasks/ci-capabilities.test.ts`
- targeted `deno lint` and `deno fmt --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6805?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

