### PR TITLE
fix(cf-harness): show retrospective tool omissions

### DIFF
--- a/packages/cf-harness/ONBOARDING.md
+++ b/packages/cf-harness/ONBOARDING.md
@@ -312,6 +312,7 @@ The same run is on disk:
     ├── <runId>/               # the turn's root run
     │   ├── run-state.json     # status, lineage, postures, input cells, failures
     │   ├── transcript.json    # what the model saw: handles and denials, never payloads
+    │   ├── transcript-omissions.json # rules and full-artifact locations, never withheld values
     │   ├── run-report.json    # model attempts, usage, timeline
     │   ├── policy-snapshot.json
     │   ├── policy-trace.json  # every CFC decision
@@ -327,6 +328,14 @@ every tool result is a record keyed by `outputId`, and the pattern source the
 model wrote is in `tool-outputs/`, not in the transcript. `run-state.json` reads
 `status: "running"` until one terminal write turns it `completed` or `failed`,
 and that same write records `cell-labels.json`.
+
+For a retrospective, use the Timeline. It joins `transcript-omissions.json` to
+the full `tool-outputs/*.json` result and places each withheld location beside
+what the model saw, labeled by the rule that omitted it. CFC-denied content
+stays a redaction marker, and scrubbed Fabric identifiers stay `[fabric-id]`;
+the console does not reveal either value. The join is display-only and never
+changes resume or replay. A run predating the omission artifact says **no
+record** rather than guessing what was withheld.
 
 The **Index** view, at `?view=index`, reads the pattern index through the server
 with your identity; with no index configured it says so.

--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -175,9 +175,9 @@ What works today:
 - optional schema-validated subagent structured returns, with raw child return
   artifacts retained in the child run and open-ended strings linkified before
   the parent sees them
-- persisted run state, transcript, run reports, Loom run manifests, capability
-  snapshots, and tool outputs, plus explicit skill registry and activation
-  artifacts
+- persisted run state, model-facing transcript, transcript omission records, run
+  reports, Loom run manifests, capability snapshots, and tool outputs, plus
+  explicit skill registry and activation artifacts
 - provider-neutral run-report model-attempt diagnostics, one record per attempt,
   naming the provider and the API operation that served it, and timing it twice
   — `durationMs` to the response headers, `responseCompleteDurationMs` to the
@@ -284,21 +284,22 @@ What is not done yet:
 - [src/sqlite-session-store.ts](src/sqlite-session-store.ts)
   - SQLite-backed interactive chat session, turn, and event persistence
 - [src/artifacts.ts](src/artifacts.ts)
-  - persisted run state, run manifest, transcript, run report, capability
-    snapshot, and tool output storage
+  - persisted run state, run manifest, transcript and its omission record, run
+    report, capability snapshot, and tool output storage
 - [src/skills/](src/skills/)
   - Agent Skills registry scanning, validation, and explicit preload context
 - [src/contracts/](src/contracts/)
   - prompt-slot, run-manifest, observation, policy, run-report, subagent, skill,
-    transcript, tool-result, and handle-table contracts
+    transcript, transcript-omission, tool-result, and handle-table contracts
 - [audit/](audit/)
   - the CFC audit: a read-only checker that reads a run family's artifacts and
     reports, per clause of the agent-harness CFC profile, what they establish.
     See [The CFC audit](#the-cfc-audit)
 - [console/](console/)
   - the console: a localhost page that starts a session, watches it live, and
-    reads any run back as a map of its cells, calls and CFC verdicts. See
-    [console/README.md](console/README.md)
+    reads any run back as a map of its cells, calls and CFC verdicts. Its
+    Timeline places the model-facing result beside the full fields withheld from
+    it, labeled by omission rule. See [console/README.md](console/README.md)
 - [integration/](integration/)
   - environment-gated real `runsc-cfc` integration tests
 - [docs/SKILLS_SUPPORT_SPEC.md](docs/SKILLS_SUPPORT_SPEC.md)
@@ -1454,6 +1455,25 @@ dropped and naming the tool output that holds the whole text, the result carries
 the original length beside the truncated field, and the artifact is written
 before the bound is applied.
 
+Every persisted tool result also has an entry in `transcript-omissions.json`.
+That sibling record names the transcript step, output id, omission rule, full
+tool-output artifact path, and JSON pointer; it never copies the withheld
+content. The rule vocabulary is `artifact-only`, `bare-fabric-identifier-scrub`,
+`model-context-truncation`, `observation-denied`, and
+`superseded-run-pattern-diagnostic-collapse`. The console joins those locations
+to the full `tool-outputs/*.json` files only for retrospective display. CFC
+denials remain fixed redaction markers and scrubbed bare Fabric identifiers
+remain `[fabric-id]`, never their withheld values. This reader-side join does
+not change `transcript.json`, provider requests, resume, or replay. Runs created
+before the sibling record existed are labeled as unrecorded rather than
+reconstructed by guesswork.
+
+Superseded `run_pattern` source collapse is not a tool-result omission and is
+therefore outside this record: it replaces an earlier assistant tool-call
+argument. Its transcript marker says which run-pattern-source sidecar retains
+the draft, and the Timeline labels the marker “source replaced by a later
+attempt” rather than presenting it as the original input.
+
 Interactive chat stdio transport:
 
 ```bash
@@ -1911,6 +1931,7 @@ declared it was doing), one per clause family:
 | AUD-14  | under a claimed enforcement posture, every sink releasing with no confidentiality ceiling is named with its recorded reason; a record publishing no deviation while a sink is ungated fails                                                                                                                                                                 | AH-CFC-14, AH-CFC-15                       |
 | AUD-15  | a run whose enforcement **mode** came from a default and landed weaker than the mode its session claims — a silent fallback from an enforcing mode                                                                                                                                                                                                          | AH-CFC-15                                  |
 | AUD-15a | a run whose **flow-label dial** came from a default and landed weaker than the named posture bundle it claims asserts. Ours: no clause names the dial                                                                                                                                                                                                       |                                            |
+| AUD-20  | counts each model-boundary omission by its recorded rule and rejects duplicated or transcript-mismatched results, duplicated rules, and rules with no artifact location. Ours: AH-CFC-16 motivates retained evidence but does not require this accounting artifact                                                                                          |                                            |
 
 Five verdicts, and the distinctions between them are the point. `inconclusive`
 is a check whose evidence was absent or unreadable — it is never `pass`, and
@@ -2014,12 +2035,13 @@ not state the requirement lends specification authority to a check the
 specification never asked for — the same divergence the citation table exists to
 prevent, pointed inward.
 
-Today AUD-1 through AUD-9 and AUD-13 rest on clauses that state what they
-enforce. AUD-14 through AUD-19 are ours: no clause requires that an ungated sink
-be published as a deviation, that a deployment answer on `/api/meta`, that a
-corpus hold one posture, or that the render ceiling be published. They are worth
-checking anyway, and the report says whose requirement they are.
-[audit/citations.ts](audit/citations.ts) holds that table and
+Today AUD-1 through AUD-9, AUD-13, and AUD-15 rest on clauses that state what
+they enforce. AUD-14, AUD-15a, and AUD-16 through AUD-20 are ours: no clause
+requires that an ungated sink be published as a deviation, that a deployment
+answer on `/api/meta`, that a corpus hold one posture, that the render ceiling
+be published, or that model-boundary omissions have their own accounting
+artifact. They are worth checking anyway, and the report says whose requirement
+they are. [audit/citations.ts](audit/citations.ts) holds that table and
 `audit/test/citation-drift.test.ts` reads every cited document and requires each
 quote to still be in it, so a specification edit that invalidates a check breaks
 the suite rather than leaving the check quietly wrong.

--- a/packages/cf-harness/audit/checks/registry.ts
+++ b/packages/cf-harness/audit/checks/registry.ts
@@ -15,4 +15,6 @@ import { type AuditCheck, STRUCTURAL_CHECKS } from "./structural.ts";
 export const RUN_CHECKS: readonly AuditCheck[] = [
   ...STRUCTURAL_CHECKS,
   ...POSTURE_CHECKS,
-];
+].sort((left, right) =>
+  left.id.localeCompare(right.id, undefined, { numeric: true })
+);

--- a/packages/cf-harness/audit/checks/structural.ts
+++ b/packages/cf-harness/audit/checks/structural.ts
@@ -33,6 +33,10 @@ import type {
   HarnessTranscriptMessage,
 } from "../../src/contracts/transcript.ts";
 import { inspectHarnessTranscriptPairing } from "../../src/contracts/transcript.ts";
+import {
+  HARNESS_TRANSCRIPT_OMISSION_RULES,
+  type HarnessTranscriptOmissionRule,
+} from "../../src/contracts/transcript-omissions.ts";
 import { assertValidHarnessHandleTable } from "../../src/handle-table.ts";
 import type { HarnessRunState } from "../../src/run-state.ts";
 import { type CheckCitation, extendsClause, requiredBy } from "../citations.ts";
@@ -1413,6 +1417,160 @@ const evidenceRetention: AuditCheck = {
 };
 
 //
+// AUD-20 omission accounting
+//
+
+/**
+ * AUD-20, which accounts for every model-boundary omission without copying
+ * the withheld value into the accounting artifact.
+ */
+const omissionAccounting: AuditCheck = {
+  id: "AUD-20",
+  title: "omission accounting",
+  // OURS: AH-CFC-16 requires enough evidence to explain exposure and denial,
+  // but it does not require a per-rule omission accounting artifact.
+  citations: extendsClause("AH-CFC-16"),
+  falsifiedBy:
+    "a duplicated or transcript-mismatched result, a result recording one omission rule more than once, or a rule carrying no withheld location; an absent or unreadable omission artifact is inconclusive",
+  inspect(run) {
+    if (run.transcriptOmissions.status !== "present") {
+      if (run.transcriptOmissions.status === "absent") {
+        return {
+          verdict: "inconclusive",
+          message:
+            "this run predates `transcript-omissions.json`, so no per-rule omission count is available",
+          evidence: [{
+            artifact: "transcript-omissions.json",
+            detail: "legacy run",
+          }],
+        };
+      }
+      return notReadable(
+        "transcript-omissions.json",
+        run.transcriptOmissions,
+      );
+    }
+    if (run.transcript.status !== "present") {
+      return notReadable("transcript.json", run.transcript);
+    }
+
+    const errors: CheckEvidence[] = [];
+    const counts = Object.fromEntries(
+      HARNESS_TRANSCRIPT_OMISSION_RULES.map((rule) => [rule, 0]),
+    ) as Record<HarnessTranscriptOmissionRule, number>;
+    const outputIds = new Set<string>();
+    const recordsByTranscriptResult = new Map<string, number>();
+
+    for (
+      const [resultIndex, result] of run.transcriptOmissions.value.results
+        .entries()
+    ) {
+      const pointer = `results[${resultIndex}]`;
+      const transcriptResultKey =
+        `${result.transcriptIndex}\u0000${result.outputId}`;
+      recordsByTranscriptResult.set(
+        transcriptResultKey,
+        (recordsByTranscriptResult.get(transcriptResultKey) ?? 0) + 1,
+      );
+      if (outputIds.has(result.outputId)) {
+        errors.push({
+          artifact: "transcript-omissions.json",
+          pointer: `${pointer}.outputId`,
+          detail: `output id \`${result.outputId}\` is recorded more than once`,
+        });
+      }
+      outputIds.add(result.outputId);
+      const message = run.transcript.value[result.transcriptIndex];
+      if (
+        message?.role !== "tool" ||
+        message.toolCallId !== result.toolCallId ||
+        message.toolName !== result.toolId ||
+        String(message.resultRef?.outputId) !== result.outputId
+      ) {
+        errors.push({
+          artifact: "transcript-omissions.json",
+          pointer,
+          detail: "result identity does not match its transcript tool message",
+        });
+      }
+      const rules = new Set<HarnessTranscriptOmissionRule>();
+      for (const [ruleIndex, rule] of result.rules.entries()) {
+        counts[rule.rule] += 1;
+        if (rules.has(rule.rule)) {
+          errors.push({
+            artifact: "transcript-omissions.json",
+            pointer: `${pointer}.rules[${ruleIndex}]`,
+            detail: `rule \`${rule.rule}\` is recorded more than once`,
+          });
+        }
+        rules.add(rule.rule);
+        if (rule.locations.length === 0) {
+          errors.push({
+            artifact: "transcript-omissions.json",
+            pointer: `${pointer}.rules[${ruleIndex}].locations`,
+            detail: `rule \`${rule.rule}\` names no withheld location`,
+          });
+        }
+        for (const [locationIndex, location] of rule.locations.entries()) {
+          if (location.artifactPath.length === 0) {
+            errors.push({
+              artifact: "transcript-omissions.json",
+              pointer:
+                `${pointer}.rules[${ruleIndex}].locations[${locationIndex}].artifactPath`,
+              detail: `rule \`${rule.rule}\` names an empty artifact path`,
+            });
+          }
+        }
+      }
+    }
+    for (const [transcriptIndex, message] of run.transcript.value.entries()) {
+      if (message.role !== "tool" || message.resultRef === undefined) {
+        continue;
+      }
+      const outputId = String(message.resultRef.outputId);
+      const matches = recordsByTranscriptResult.get(
+        `${transcriptIndex}\u0000${outputId}`,
+      ) ?? 0;
+      if (matches !== 1) {
+        errors.push({
+          artifact: "transcript.json",
+          pointer: `[${transcriptIndex}].resultRef`,
+          detail: `tool result \`${outputId}\` maps to ${
+            count(matches, "omission entry", "omission entries")
+          }; exactly one is required`,
+        });
+      }
+    }
+    if (errors.length > 0) {
+      return {
+        verdict: "fail",
+        message: `${
+          count(
+            errors.length,
+            "omission-accounting error",
+            "omission-accounting errors",
+          )
+        } found`,
+        evidence: errors,
+      };
+    }
+    const total = Object.values(counts).reduce((sum, value) => sum + value, 0);
+    return {
+      verdict: "pass",
+      message: `${count(total, "omission", "omissions")} recorded: ${
+        HARNESS_TRANSCRIPT_OMISSION_RULES.map((rule) =>
+          `\`${rule}\` ${counts[rule]}`
+        ).join("; ")
+      }`,
+      evidence: HARNESS_TRANSCRIPT_OMISSION_RULES.map((rule) => ({
+        artifact: "transcript-omissions.json",
+        detail: `${rule}: ${counts[rule]}`,
+      })),
+    };
+  },
+};
+
+//
 // The registry
 //
 
@@ -1427,6 +1585,7 @@ export const STRUCTURAL_CHECKS: readonly AuditCheck[] = [
   observeDisclosure,
   influenceAccumulation,
   evidenceRetention,
+  omissionAccounting,
 ];
 
 /**

--- a/packages/cf-harness/audit/evidence.ts
+++ b/packages/cf-harness/audit/evidence.ts
@@ -20,6 +20,10 @@ import type { HarnessCfcPolicySnapshot } from "../src/contracts/cfc-policy-snaps
 import type { HarnessPolicyTrace } from "../src/contracts/policy-trace.ts";
 import type { HarnessRunReport } from "../src/contracts/run-report.ts";
 import type { HarnessTranscriptMessage } from "../src/contracts/transcript.ts";
+import {
+  type HarnessTranscriptOmissions,
+  isHarnessTranscriptOmissions,
+} from "../src/contracts/transcript-omissions.ts";
 import type { HarnessRunState } from "../src/run-state.ts";
 
 /**
@@ -73,6 +77,7 @@ export interface RunEvidence {
 
   runState: ArtifactState<HarnessRunState>;
   transcript: ArtifactState<readonly HarnessTranscriptMessage[]>;
+  transcriptOmissions: ArtifactState<HarnessTranscriptOmissions>;
   runReport: ArtifactState<HarnessRunReport>;
   policyTrace: ArtifactState<HarnessPolicyTrace>;
   policySnapshot: ArtifactState<HarnessCfcPolicySnapshot>;
@@ -213,6 +218,11 @@ export const loadRunEvidence = async (input: string): Promise<RunEvidence> => {
       join(runDir, "transcript.json"),
       Array.isArray,
       "an array of transcript messages",
+    ),
+    transcriptOmissions: await loadArtifact<HarnessTranscriptOmissions>(
+      join(runDir, "transcript-omissions.json"),
+      isHarnessTranscriptOmissions,
+      "a transcript-omissions artifact",
     ),
     runReport: await loadArtifact<HarnessRunReport>(
       join(runDir, "run-report.json"),

--- a/packages/cf-harness/audit/test/fixtures/runs/cfc-audit-fixture.subagent.1/transcript-omissions.json
+++ b/packages/cf-harness/audit/test/fixtures/runs/cfc-audit-fixture.subagent.1/transcript-omissions.json
@@ -1,0 +1,5 @@
+{
+  "type": "cf-harness.transcript-omissions",
+  "version": 1,
+  "results": []
+}

--- a/packages/cf-harness/audit/test/fixtures/runs/cfc-audit-fixture/transcript-omissions.json
+++ b/packages/cf-harness/audit/test/fixtures/runs/cfc-audit-fixture/transcript-omissions.json
@@ -1,0 +1,37 @@
+{
+  "type": "cf-harness.transcript-omissions",
+  "version": 1,
+  "results": [
+    {
+      "transcriptIndex": 3,
+      "toolCallId": "call-attested",
+      "toolId": "bash",
+      "outputId": "cfc-audit-fixture:bash:1",
+      "rules": []
+    },
+    {
+      "transcriptIndex": 5,
+      "toolCallId": "call-unattested",
+      "toolId": "bash",
+      "outputId": "cfc-audit-fixture:bash:2",
+      "rules": [
+        {
+          "rule": "observation-denied",
+          "locations": [
+            {
+              "artifactPath": "/Users/ben/.bb/worktrees/env_7rq66gp6pp/labs/packages/cf-harness/audit/test/fixtures/runs/cfc-audit-fixture/tool-outputs/cfc-audit-fixture_bash_2-bash.json",
+              "jsonPointer": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "transcriptIndex": 7,
+      "toolCallId": "call-delegate",
+      "toolId": "delegate_task",
+      "outputId": "cfc-audit-fixture:delegate_task:3",
+      "rules": []
+    }
+  ]
+}

--- a/packages/cf-harness/audit/test/seeded-violations.test.ts
+++ b/packages/cf-harness/audit/test/seeded-violations.test.ts
@@ -398,7 +398,11 @@ describe("seeded violations", () => {
       turnsOnly("AUD-6", "fail", (root) => {
         const transcript = transcriptOf(root);
         const last = transcript.findLast((message) => message.role === "tool")!;
-        transcript.push(structuredClone(last));
+        const orphan = structuredClone(last);
+        if (orphan.role === "tool") {
+          delete orphan.resultRef;
+        }
+        transcript.push(orphan);
       });
     });
   });
@@ -568,6 +572,17 @@ describe("seeded violations", () => {
         ...CLEAN,
         [at("AUD-2")]: "warn",
         [at("AUD-9")]: "warn",
+      });
+    });
+  });
+
+  describe("AUD-20 omission accounting", () => {
+    it("is inconclusive when the run predates omission records", () => {
+      turnsOnly("AUD-20", "inconclusive", (root) => {
+        root.transcriptOmissions = {
+          status: "absent",
+          path: root.transcriptOmissions.path,
+        };
       });
     });
   });

--- a/packages/cf-harness/audit/test/structural.test.ts
+++ b/packages/cf-harness/audit/test/structural.test.ts
@@ -26,6 +26,7 @@ import type {
   HarnessToolActivity,
 } from "../../src/contracts/run-report.ts";
 import type { HarnessTranscriptMessage } from "../../src/contracts/transcript.ts";
+import type { HarnessTranscriptOmissions } from "../../src/contracts/transcript-omissions.ts";
 import type { HarnessRunState } from "../../src/run-state.ts";
 import {
   type AuditCheck,
@@ -144,6 +145,7 @@ const runReport = (
 interface BuiltRun {
   runState?: HarnessRunState;
   transcript?: readonly HarnessTranscriptMessage[];
+  transcriptOmissions?: HarnessTranscriptOmissions;
   runReport?: HarnessRunReport;
   policyTrace?: HarnessPolicyTrace;
   policySnapshot?: Record<string, unknown>;
@@ -159,6 +161,9 @@ const evidenceOf = (built: BuiltRun): RunEvidence => ({
   transcript: built.transcript === undefined
     ? absent()
     : present(built.transcript),
+  transcriptOmissions: built.transcriptOmissions === undefined
+    ? absent()
+    : present(built.transcriptOmissions),
   runReport: built.runReport === undefined
     ? absent()
     : present(built.runReport),
@@ -891,6 +896,268 @@ describe("structural", () => {
       expect(detailsOf(outcome)).toContain(
         "which the result records as `denied`",
       );
+    });
+  });
+
+  describe("AUD-20 omission accounting", () => {
+    it("counts each recorded omission rule", () => {
+      const outcome = inspect("AUD-20", {
+        transcript: [{ role: "user", content: "Run it." }, {
+          role: "assistant",
+          content: "",
+          toolCalls: [{
+            id: "call-1",
+            type: "function",
+            function: { name: "run_pattern", arguments: "{}" },
+          }],
+        }, {
+          role: "tool",
+          toolCallId: "call-1",
+          toolName: "run_pattern",
+          content: "model-facing",
+          resultRef: {
+            type: "cf-harness.tool-result-ref",
+            outputId: `${RUN_ID}:run_pattern:1` as never,
+            toolId: "run_pattern",
+            runId: RUN_ID,
+          },
+        }],
+        transcriptOmissions: {
+          type: "cf-harness.transcript-omissions",
+          version: 1,
+          results: [{
+            transcriptIndex: 2,
+            toolCallId: "call-1",
+            toolId: "run_pattern",
+            outputId: `${RUN_ID}:run_pattern:1`,
+            rules: [
+              {
+                rule: "artifact-only",
+                locations: [{
+                  artifactPath: "tool-outputs/result.json",
+                  jsonPointer: "/rawValue",
+                }],
+              },
+              {
+                rule: "bare-fabric-identifier-scrub",
+                locations: [{
+                  artifactPath: "tool-outputs/result.json",
+                  jsonPointer: "/message",
+                }],
+              },
+            ],
+          }],
+        },
+      });
+
+      expect(outcome.verdict).toBe("pass");
+      expect(outcome.message).toContain("`artifact-only` 1");
+      expect(outcome.message).toContain("`model-context-truncation` 0");
+      expect(detailsOf(outcome)).toContain(
+        "bare-fabric-identifier-scrub: 1",
+      );
+    });
+
+    it("returns `inconclusive` when the run predates omission records", () => {
+      const outcome = inspect("AUD-20", {});
+
+      expect(outcome.verdict).toBe("inconclusive");
+      expect(outcome.message).toContain("predates");
+    });
+
+    it("returns `inconclusive` when a current omission record has no transcript", () => {
+      const outcome = inspect("AUD-20", {
+        transcriptOmissions: {
+          type: "cf-harness.transcript-omissions",
+          version: 1,
+          results: [],
+        },
+      });
+
+      expect(outcome.verdict).toBe("inconclusive");
+      expect(outcome.message).toContain("`transcript.json` is absent");
+    });
+
+    it("returns `inconclusive` when a current omission record has an unreadable transcript", () => {
+      const root = evidenceOf({
+        transcriptOmissions: {
+          type: "cf-harness.transcript-omissions",
+          version: 1,
+          results: [],
+        },
+      });
+      root.transcript = {
+        status: "unparseable",
+        path: "built",
+        detail: "did not parse",
+      };
+
+      const outcome = checkNamed("AUD-20").inspect(root, {
+        root,
+        children: [],
+      });
+
+      expect(outcome.verdict).toBe("inconclusive");
+      expect(outcome.message).toContain("did not parse");
+    });
+
+    it("fails duplicate rules and rules without a location", () => {
+      const outcome = inspect("AUD-20", {
+        transcript: [{
+          role: "tool",
+          toolCallId: "call-1",
+          toolName: "run_pattern",
+          content: "model-facing",
+          resultRef: {
+            type: "cf-harness.tool-result-ref",
+            outputId: `${RUN_ID}:run_pattern:1` as never,
+            toolId: "run_pattern",
+            runId: RUN_ID,
+          },
+        }],
+        transcriptOmissions: {
+          type: "cf-harness.transcript-omissions",
+          version: 1,
+          results: [{
+            transcriptIndex: 0,
+            toolCallId: "call-1",
+            toolId: "run_pattern",
+            outputId: `${RUN_ID}:run_pattern:1`,
+            rules: [{
+              rule: "artifact-only",
+              locations: [{
+                artifactPath: "tool-outputs/result.json",
+                jsonPointer: "/rawValue",
+              }],
+            }, {
+              rule: "artifact-only",
+              locations: [],
+            }],
+          }],
+        },
+      });
+
+      expect(outcome.verdict).toBe("fail");
+      expect(outcome.message).toBe("2 omission-accounting errors found");
+      expect(detailsOf(outcome)).toContain("recorded more than once");
+      expect(detailsOf(outcome)).toContain("names no withheld location");
+    });
+
+    it("fails duplicate results and transcript identity mismatches", () => {
+      const result = {
+        transcriptIndex: 1,
+        toolCallId: "call-1",
+        toolId: "bash",
+        outputId: `${RUN_ID}:bash:1`,
+        rules: [{
+          rule: "artifact-only" as const,
+          locations: [{
+            artifactPath: "tool-outputs/result.json",
+            jsonPointer: "/stdout",
+          }],
+        }],
+      };
+      const outcome = inspect("AUD-20", {
+        transcript: [{ role: "user", content: "Run it." }, {
+          role: "tool",
+          toolCallId: "another-call",
+          toolName: "bash",
+          content: "model-facing",
+        }],
+        transcriptOmissions: {
+          type: "cf-harness.transcript-omissions",
+          version: 1,
+          results: [result, result],
+        },
+      });
+
+      expect(outcome.verdict).toBe("fail");
+      expect(detailsOf(outcome)).toContain("recorded more than once");
+      expect(detailsOf(outcome)).toContain("does not match");
+    });
+
+    it("fails when the omission record covers only part of the transcript", () => {
+      const firstOutputId = `${RUN_ID}:bash:1` as never;
+      const secondOutputId = `${RUN_ID}:bash:2` as never;
+      const toolResult = (
+        toolCallId: string,
+        outputId: typeof firstOutputId,
+      ) => ({
+        role: "tool" as const,
+        toolCallId,
+        toolName: "bash",
+        content: "model-facing",
+        resultRef: {
+          type: "cf-harness.tool-result-ref" as const,
+          outputId,
+          toolId: "bash",
+          runId: RUN_ID,
+        },
+      });
+      const outcome = inspect("AUD-20", {
+        transcript: [
+          toolResult("call-1", firstOutputId),
+          toolResult("call-2", secondOutputId),
+        ],
+        transcriptOmissions: {
+          type: "cf-harness.transcript-omissions",
+          version: 1,
+          results: [{
+            transcriptIndex: 0,
+            toolCallId: "call-1",
+            toolId: "bash",
+            outputId: firstOutputId,
+            rules: [],
+          }],
+        },
+      });
+
+      expect(outcome.verdict).toBe("fail");
+      expect(outcome.evidence).toContainEqual({
+        artifact: "transcript.json",
+        pointer: "[1].resultRef",
+        detail:
+          `tool result \`${secondOutputId}\` maps to 0 omission entries; exactly one is required`,
+      });
+    });
+
+    it("fails a withheld location with an empty artifact path", () => {
+      const outputId = `${RUN_ID}:bash:1` as never;
+      const outcome = inspect("AUD-20", {
+        transcript: [{
+          role: "tool",
+          toolCallId: "call-1",
+          toolName: "bash",
+          content: "model-facing",
+          resultRef: {
+            type: "cf-harness.tool-result-ref",
+            outputId,
+            toolId: "bash",
+            runId: RUN_ID,
+          },
+        }],
+        transcriptOmissions: {
+          type: "cf-harness.transcript-omissions",
+          version: 1,
+          results: [{
+            transcriptIndex: 0,
+            toolCallId: "call-1",
+            toolId: "bash",
+            outputId,
+            rules: [{
+              rule: "model-context-truncation",
+              locations: [{ artifactPath: "", jsonPointer: "/stdout" }],
+            }],
+          }],
+        },
+      });
+
+      expect(outcome.verdict).toBe("fail");
+      expect(outcome.evidence).toContainEqual({
+        artifact: "transcript-omissions.json",
+        pointer: "results[0].rules[0].locations[0].artifactPath",
+        detail: "rule `model-context-truncation` names an empty artifact path",
+      });
     });
   });
 

--- a/packages/cf-harness/console/README.md
+++ b/packages/cf-harness/console/README.md
@@ -508,8 +508,20 @@ record of what the run recorded rather than a cell with nothing to hide.
     never seals a number, so an array of them carries whatever its author chose
     to encode.
 
-  Then the call's input and output as formatted JSON, untruncated, with long
-  lines scrolling inside their block rather than widening the page.
+  Then the call's input and model-facing output as formatted JSON, with long
+  lines scrolling inside their block rather than widening the page. Beside the
+  output, **withheld from the model** expands to the full artifact positions
+  named by `transcript-omissions.json`, each labeled by its omission rule. CFC
+  denials render a redaction marker. Scrubbed Fabric identifiers are shown with
+  `[fabric-id]` in place of their values when the artifact position is
+  available; that fixed marker stands in alone when it is not. A legacy result
+  with no omission record says so instead of inferring omissions from the full
+  result.
+
+  Superseded `run_pattern` source is an assistant argument rather than a tool
+  result, so it is outside the omission record. Where its marker appears, the
+  Timeline says **source replaced by a later attempt** and directs the reader to
+  the run-pattern-source sidecar named by that marker.
 
   A `delegate_task` step names the child it started; opening that child in the
   rail reads its own timeline.
@@ -518,11 +530,12 @@ record of what the run recorded rather than a cell with nothing to hide.
   — so the compile-error and fix rounds are legible rather than lost. Alongside
   them: what `search_patterns` matched and with what score, what
   `record_feedback` reported, and every address `assign_slug` named.
-- **Tool outputs** — each tool result as the model read it, untruncated.
+- **Tool outputs** — the full persisted tool-result artifacts, including fields
+  the model-facing rendering omitted.
 - **Artifacts** — the run's own records: `run-state.json`, `transcript.json`,
-  `run-report.json`, the policy snapshot and trace, the capability snapshot, the
-  cell labels read back from the space, and the skill registry and activations,
-  whichever the run wrote.
+  `transcript-omissions.json`, `run-report.json`, the policy snapshot and trace,
+  the capability snapshot, the cell labels read back from the space, and the
+  skill registry and activations, whichever the run wrote.
 
 Handle scope is reconstructed rather than recorded. A run keeps one handle
 table, its last, so the timeline takes a handle to be in scope from the step its

--- a/packages/cf-harness/console/public/styles/console.css
+++ b/packages/cf-harness/console/public/styles/console.css
@@ -499,6 +499,55 @@ button[disabled] {
   text-transform: none;
 }
 
+.result-pair {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+}
+
+.withheld-pane {
+  border-left: 3px solid #b54708;
+  padding-left: 0.8rem;
+}
+
+.withheld-pane summary {
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 0.72rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.withheld-location {
+  border-top: 1px solid var(--line);
+  margin-top: 0.65rem;
+  padding-top: 0.65rem;
+}
+
+.withheld-rule,
+.withheld-pointer {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  overflow-wrap: anywhere;
+}
+
+.withheld-rule {
+  color: #b54708;
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+
+.withheld-pointer {
+  color: var(--muted);
+  font-size: 0.72rem;
+  margin-top: 0.2rem;
+}
+
+@media (max-width: 900px) {
+  .result-pair {
+    grid-template-columns: 1fr;
+  }
+}
+
 .handles {
   border-collapse: collapse;
   font-size: 0.8rem;

--- a/packages/cf-harness/console/run-store.ts
+++ b/packages/cf-harness/console/run-store.ts
@@ -11,6 +11,9 @@ import type { HarnessRunState } from "../src/run-state.ts";
 import type { HarnessHandleTable } from "../src/contracts/handle-table.ts";
 import type { HarnessTranscriptMessage } from "../src/contracts/transcript.ts";
 import {
+  isHarnessTranscriptOmissions,
+} from "../src/contracts/transcript-omissions.ts";
+import {
   type ConsoleRunLens,
   consoleRunLens,
   type ConsoleRunSummary,
@@ -22,6 +25,8 @@ import {
   consoleRunHandles,
   consoleRunSteps,
   type ConsoleStep,
+  type ConsoleToolOutputArtifact,
+  type ConsoleTranscriptOmissionsState,
 } from "./steps.ts";
 import {
   type ConsoleGraph,
@@ -66,6 +71,28 @@ const readJson = async <Value>(path: string): Promise<Value | undefined> => {
     // A run still being written, or one whose optional artifact was never
     // produced, is a run to describe from what it does have.
     return undefined;
+  }
+};
+
+/** Reads omission evidence without confusing a bad record with no record. */
+const readTranscriptOmissions = async (
+  path: string,
+): Promise<ConsoleTranscriptOmissionsState> => {
+  let text: string;
+  try {
+    text = await Deno.readTextFile(path);
+  } catch (error) {
+    return error instanceof Deno.errors.NotFound
+      ? { status: "absent" }
+      : { status: "unreadable" };
+  }
+  try {
+    const value: unknown = JSON.parse(text);
+    return isHarnessTranscriptOmissions(value)
+      ? { status: "present", value }
+      : { status: "unreadable" };
+  } catch {
+    return { status: "unreadable" };
   }
 };
 
@@ -121,6 +148,7 @@ export interface ConsoleRunDetail {
 const RUN_ARTIFACT_NAMES = [
   "run-state.json",
   "transcript.json",
+  "transcript-omissions.json",
   "run-report.json",
   "run-manifest.json",
   "policy-snapshot.json",
@@ -241,11 +269,25 @@ export const readConsoleRun = async (
   const transcript =
     await readJson<HarnessTranscriptMessage[]>(join(root, "transcript.json")) ??
       [];
+  const omissions = await readTranscriptOmissions(
+    join(root, "transcript-omissions.json"),
+  );
+  const outputNames = await toolOutputNames(root);
+  const toolOutputs: ConsoleToolOutputArtifact[] = [];
+  for (const name of outputNames) {
+    const artifactPath = join(root, "tool-outputs", name);
+    const value = await readJson<unknown>(artifactPath);
+    if (value !== undefined) {
+      toolOutputs.push({ artifactPath, value });
+    }
+  }
   const steps = consoleRunSteps(
     transcript,
     runState.policyDecisions ?? [],
     runState.policyEvents,
     runState.cfcInvocationContexts ?? [],
+    omissions,
+    toolOutputs,
   );
   // A token minted in an earlier turn resolves to nothing in this run's own
   // table, and an argument naming that cell by link would then read as coming
@@ -281,7 +323,7 @@ export const readConsoleRun = async (
     handles: consoleRunHandles(steps, table, labels),
     cellLabels: consoleCellLabelsSummary(labels),
     artifactNames: await namesPresent(root, RUN_ARTIFACT_NAMES),
-    toolOutputNames: await toolOutputNames(root),
+    toolOutputNames: outputNames,
   };
 };
 

--- a/packages/cf-harness/console/src/steps-view.ts
+++ b/packages/cf-harness/console/src/steps-view.ts
@@ -69,6 +69,84 @@ const truncate = (text: string, limit: number): string =>
 const stepLabel = (step: ConsoleStep): string =>
   step.kind === "tool" ? step.toolName ?? "tool" : step.kind;
 
+/** The expandable omission block's label for one tool result. */
+export const withheldSummary = (step: ConsoleStep): string =>
+  step.withheld.status === "unrecorded"
+    ? "withheld from the model · no record"
+    : step.withheld.status === "record-unreadable"
+    ? "withheld from the model · record unreadable"
+    : step.withheld.status === "record-entry-missing"
+    ? "withheld from the model · entry missing"
+    : `withheld from the model · ${step.withheld.locations.length}`;
+
+/** What the full tool artifact records beside the model-facing result. */
+export const withheldView = (step: ConsoleStep): TemplateResult => {
+  if (step.withheld.status === "unrecorded") {
+    return html`
+      <details class="pane withheld-pane">
+        <summary>${withheldSummary(step)}</summary>
+        <p class="empty">
+          No omission record exists for this tool result. Legacy runs cannot be
+          reconstructed honestly from the model-facing transcript alone.
+        </p>
+      </details>
+    `;
+  }
+  if (step.withheld.status === "record-unreadable") {
+    return html`
+      <details class="pane withheld-pane">
+        <summary>${withheldSummary(step)}</summary>
+        <p class="empty">
+          The omission record exists but is unreadable or does not match the
+          current contract. This result cannot be reconstructed honestly.
+        </p>
+      </details>
+    `;
+  }
+  if (step.withheld.status === "record-entry-missing") {
+    return html`
+      <details class="pane withheld-pane">
+        <summary>${withheldSummary(step)}</summary>
+        <p class="empty">
+          The omission record exists but has no entry for this tool result.
+          Which omission rules applied cannot be determined.
+        </p>
+      </details>
+    `;
+  }
+  if (step.withheld.locations.length === 0) {
+    return html`
+      <details class="pane withheld-pane">
+        <summary>${withheldSummary(step)}</summary>
+        <p class="empty">No omission rule applied to this result.</p>
+      </details>
+    `;
+  }
+  return html`
+    <details class="pane withheld-pane">
+      <summary>${withheldSummary(step)}</summary>
+      ${step.withheld.locations.map((location) =>
+        html`
+          <div class="withheld-location">
+            <div class="withheld-rule">${location.rule}</div>
+            <div class="withheld-pointer">
+              ${location.artifactPath}${location.jsonPointer}
+            </div>
+            ${location.available
+              ? html`
+                <pre class="raw">${location.redaction ??
+                  json(location.value)}</pre>
+              `
+              : html`
+                <p class="empty">The recorded artifact position is unavailable.</p>
+              `}
+          </div>
+        `
+      )}
+    </details>
+  `;
+};
+
 export class ConsoleSteps extends LitElement {
   static override properties = {
     steps: { attribute: false },
@@ -170,8 +248,7 @@ export class ConsoleSteps extends LitElement {
                 <span class="step-mint">
                   +${step.handlesIntroduced.length}
                 </span>
-              `}
-              ${step.disclosure === undefined ||
+              `} ${step.disclosure === undefined ||
                   step.disclosure.longestNumericRun < WIDE_NUMERIC_RUN
                 ? nothing
                 : html`
@@ -210,7 +287,7 @@ export class ConsoleSteps extends LitElement {
                     : ""}"
                 >
                   <td>
-                    <console-cell .cell=${handle}></console-cell>
+                    <console-cell .cell="${handle}"></console-cell>
                   </td>
                   <td class="handle-ref">${handle.ref ?? "—"}</td>
                   <td class="handle-at">
@@ -245,8 +322,9 @@ export class ConsoleSteps extends LitElement {
         <div class="pane-head">
           arguments
           <span class="badge ${references.length === 0 ? "none" : "ok"}">
-            ${references.length}
-            ${references.length === 1 ? "reference" : "references"}
+            ${references.length} ${references.length === 1
+              ? "reference"
+              : "references"}
           </span>
         </div>
         <div class="args">
@@ -259,7 +337,9 @@ export class ConsoleSteps extends LitElement {
                 </span>
                 <span class="arg-note">value</span>
                 ${argument.confidentiality.map((name) =>
-                  html`<span class="atom conf">${name}</span>`
+                  html`
+                    <span class="atom conf">${name}</span>
+                  `
                 )}
               </div>
             `
@@ -274,15 +354,17 @@ export class ConsoleSteps extends LitElement {
     return html`
       <div class="arg reference">
         <span class="arg-key">${argument.key}</span>
-        <console-cell .cell=${argument}></console-cell>
+        <console-cell .cell="${argument}"></console-cell>
         ${origin === undefined
-          ? html`<span class="arg-note">from an earlier turn</span>`
+          ? html`
+            <span class="arg-note">from an earlier turn</span>
+          `
           : html`
             <button
               class="arg-origin"
               type="button"
               title="go to the step that produced this"
-              @click=${() => this.#select(origin)}
+              @click="${() => this.#select(origin)}"
             >
               ← step ${origin}
             </button>
@@ -317,8 +399,7 @@ export class ConsoleSteps extends LitElement {
               ${step.policy.reasonCodes.join(", ")}
             </span>
           </div>
-        `}
-        ${step.policyEvents.map((event) =>
+        `} ${step.policyEvents.map((event) =>
           html`
             <div class="cfc-line">
               <span
@@ -327,8 +408,7 @@ export class ConsoleSteps extends LitElement {
               <span class="cfc-reasons">${event.detail ?? ""}</span>
             </div>
           `
-        )}
-        ${labelEntries.length === 0 ? nothing : html`
+        )} ${labelEntries.length === 0 ? nothing : html`
           <table class="labels">
             <tbody>
               ${labelEntries.map((entry) =>
@@ -341,13 +421,18 @@ export class ConsoleSteps extends LitElement {
                     </td>
                     <td class="label-atoms">
                       ${atomNames(entry.label?.confidentiality).length === 0
-                        ? html`<span class="muted">no confidentiality atom</span>`
+                        ? html`
+                          <span class="muted">no confidentiality atom</span>
+                        `
                         : atomNames(entry.label?.confidentiality).map((name) =>
-                          html`<span class="atom conf">${name}</span>`
+                          html`
+                            <span class="atom conf">${name}</span>
+                          `
+                        )} ${atomNames(entry.label?.integrity).map((name) =>
+                          html`
+                            <span class="atom integ">${name}</span>
+                          `
                         )}
-                      ${atomNames(entry.label?.integrity).map((name) =>
-                        html`<span class="atom integ">${name}</span>`
-                      )}
                     </td>
                   </tr>
                 `
@@ -390,9 +475,9 @@ export class ConsoleSteps extends LitElement {
         ${wide
           ? html`
             <div class="body code bad-body">
-              A run of ${disclosure.longestNumericRun} numbers crossed as value.
-              Numbers are never sealed, so an array of them carries whatever its
-              author chose to encode.
+              A run of ${disclosure
+                .longestNumericRun} numbers crossed as value. Numbers are never sealed, so an
+              array of them carries whatever its author chose to encode.
             </div>
           `
           : nothing}
@@ -417,8 +502,9 @@ export class ConsoleSteps extends LitElement {
           <span class="badge ${step.status}">${step.status}</span>
         </div>
       </div>
-      ${this.#handles(step)} ${this.#arguments(step)} ${this.#policy(step)}
-      ${this.#disclosure(step)}
+      ${this.#handles(step)} ${this.#arguments(step)} ${this.#policy(
+        step,
+      )} ${this.#disclosure(step)}
       <div class="pane">
         <div class="pane-head">
           <span class="tool">${step.toolName}</span> input
@@ -426,34 +512,43 @@ export class ConsoleSteps extends LitElement {
         <pre class="raw">${step.input !== undefined
           ? json(step.input)
           : step.inputText ?? "—"}</pre>
-      </div>
-      <div class="pane">
-        <div class="pane-head">
-          <span class="tool">${step
-            .toolName}</span> output ${step.resultRef?.outputId === undefined
-            ? nothing
-            : html`
-              <span class="pane-note">${step.resultRef.outputId}</span>
-            `}
-        </div>
-        <pre class="raw">${step.output !== undefined
-          ? json(step.output)
-          : step.outputText ?? "—"}</pre>
-        ${step.childRunId === undefined ? nothing : html`
-          <button
-            class="secondary"
-            type="button"
-            @click="${() =>
-              this.dispatchEvent(
-                new CustomEvent("open-run", {
-                  detail: step.childRunId,
-                  bubbles: true,
-                }),
-              )}"
-          >
-            Open subagent run
-          </button>
+        ${step.sourceReplacedByLaterAttempt !== true ? nothing : html`
+          <p class="pane-note">
+            Source replaced by a later attempt; see the run-pattern-source sidecar named
+            by the marker.
+          </p>
         `}
+      </div>
+      <div class="result-pair">
+        <div class="pane">
+          <div class="pane-head">
+            <span class="tool">${step
+              .toolName}</span> output ${step.resultRef?.outputId === undefined
+              ? nothing
+              : html`
+                <span class="pane-note">${step.resultRef.outputId}</span>
+              `}
+          </div>
+          <pre class="raw">${step.output !== undefined
+            ? json(step.output)
+            : step.outputText ?? "—"}</pre>
+          ${step.childRunId === undefined ? nothing : html`
+            <button
+              class="secondary"
+              type="button"
+              @click="${() =>
+                this.dispatchEvent(
+                  new CustomEvent("open-run", {
+                    detail: step.childRunId,
+                    bubbles: true,
+                  }),
+                )}"
+            >
+              Open subagent run
+            </button>
+          `}
+        </div>
+        ${withheldView(step)}
       </div>
     `;
   }

--- a/packages/cf-harness/console/steps.ts
+++ b/packages/cf-harness/console/steps.ts
@@ -24,6 +24,13 @@ import type { ToolResultRef } from "../src/contracts/tool-result.ts";
 import type { HarnessPolicyEvent } from "../src/contracts/policy.ts";
 import type { HarnessPolicyDecisionRecord } from "../src/contracts/policy-trace.ts";
 import type { HarnessCfcInvocationContext } from "../src/contracts/cfc-invocation-context.ts";
+import type {
+  HarnessTranscriptOmissionRule,
+  HarnessTranscriptOmissions,
+} from "../src/contracts/transcript-omissions.ts";
+import {
+  scrubBareFabricIdentifiersDeep,
+} from "../src/fabric-identifier-scrub.ts";
 import {
   cellLabelsAt,
   type ConsoleCellLabelIndex,
@@ -168,6 +175,44 @@ export interface ConsoleDisclosure {
   longestNumericRun: number;
 }
 
+/** One full tool-output artifact available to the retrospective reader. */
+export interface ConsoleToolOutputArtifact {
+  artifactPath: string;
+  value: unknown;
+}
+
+/** One artifact position withheld from a model-facing tool result. */
+export interface ConsoleWithheldLocation {
+  rule: HarnessTranscriptOmissionRule;
+  artifactPath: string;
+  jsonPointer: string;
+
+  /** Full operator value, absent where CFC requires a redaction marker. */
+  value?: unknown;
+
+  /** Fixed marker shown instead of a value CFC withheld. */
+  redaction?: string;
+
+  /** Whether the recorded artifact and pointer were available to this read. */
+  available: boolean;
+}
+
+/** What the omission record says about one tool result. */
+export interface ConsoleWithheldResult {
+  status:
+    | "recorded"
+    | "unrecorded"
+    | "record-unreadable"
+    | "record-entry-missing";
+  locations: readonly ConsoleWithheldLocation[];
+}
+
+/** What the console could establish about the run's omission artifact. */
+export type ConsoleTranscriptOmissionsState =
+  | { status: "absent" }
+  | { status: "unreadable" }
+  | { status: "present"; value: HarnessTranscriptOmissions };
+
 /** One step of a run. */
 export interface ConsoleStep {
   index: number;
@@ -186,6 +231,9 @@ export interface ConsoleStep {
   input?: unknown;
 
   inputText?: string;
+
+  /** The call's source was replaced by the superseded-source marker. */
+  sourceReplacedByLaterAttempt?: true;
 
   /** The result the model read, parsed on the same terms as the input. */
   output?: unknown;
@@ -219,6 +267,9 @@ export interface ConsoleStep {
 
   /** What the result let across as value, for a step whose result carries one. */
   disclosure?: ConsoleDisclosure;
+
+  /** Retrospective join from the model-facing result to withheld positions. */
+  withheld: ConsoleWithheldResult;
 
   /**
    * The CFC invocation context recorded for this call. Under a posture that
@@ -260,6 +311,13 @@ const asRecord = (value: unknown): Record<string, unknown> =>
 
 const asString = (value: unknown): string | undefined =>
   typeof value === "string" && value !== "" ? value : undefined;
+
+const sourceWasReplaced = (value: unknown): boolean => {
+  const sourceText = asRecord(value).sourceText;
+  return typeof sourceText === "string" && sourceText.startsWith(
+    "[cf-harness: superseded run_pattern source collapsed",
+  );
+};
 
 /** The tool calls an assistant made, by call id. */
 const toolCallsById = (
@@ -406,6 +464,126 @@ const childRunIdOf = (output: unknown): string | undefined => {
   return typeof childRunId === "string" ? childRunId : undefined;
 };
 
+const artifactName = (path: string): string =>
+  path.split(/[\\/]/).at(-1) ?? path;
+
+const valueAtJsonPointer = (
+  value: unknown,
+  pointer: string,
+): { available: boolean; value?: unknown } => {
+  if (pointer === "") {
+    return { available: true, value };
+  }
+  if (!pointer.startsWith("/")) {
+    return { available: false };
+  }
+  let current = value;
+  for (const encoded of pointer.slice(1).split("/")) {
+    const segment = encoded.replaceAll("~1", "/").replaceAll("~0", "~");
+    if (Array.isArray(current)) {
+      if (!/^\d+$/.test(segment) || Number(segment) >= current.length) {
+        return { available: false };
+      }
+      current = current[Number(segment)];
+      continue;
+    }
+    if (
+      typeof current !== "object" || current === null ||
+      !Object.hasOwn(current, segment)
+    ) {
+      return { available: false };
+    }
+    current = (current as Record<string, unknown>)[segment];
+  }
+  return { available: true, value: current };
+};
+
+const withheldFor = (
+  message: HarnessTranscriptMessage & { role: "tool" },
+  transcriptIndex: number,
+  omissionState:
+    | ConsoleTranscriptOmissionsState
+    | HarnessTranscriptOmissions
+    | undefined,
+  toolOutputs: readonly ConsoleToolOutputArtifact[],
+): ConsoleWithheldResult => {
+  const omissions = omissionState === undefined
+    ? undefined
+    : "status" in omissionState
+    ? omissionState.status === "present" ? omissionState.value : undefined
+    : omissionState;
+  if (omissionState !== undefined && "status" in omissionState) {
+    if (omissionState.status === "unreadable") {
+      return { status: "record-unreadable", locations: [] };
+    }
+  }
+  const outputId = message.resultRef?.outputId;
+  const result = outputId === undefined
+    ? undefined
+    : omissions?.results.find((entry) =>
+      entry.outputId === String(outputId) &&
+      entry.transcriptIndex === transcriptIndex &&
+      entry.toolCallId === message.toolCallId &&
+      entry.toolId === message.toolName
+    );
+  if (result === undefined) {
+    return {
+      status: omissions === undefined ? "unrecorded" : "record-entry-missing",
+      locations: [],
+    };
+  }
+  const rulesAtLocation = new Map<string, Set<HarnessTranscriptOmissionRule>>();
+  for (const rule of result.rules) {
+    for (const location of rule.locations) {
+      const key = `${location.artifactPath}\u0000${location.jsonPointer}`;
+      const rules = rulesAtLocation.get(key) ?? new Set();
+      rules.add(rule.rule);
+      rulesAtLocation.set(key, rules);
+    }
+  }
+  const locations = result.rules.flatMap((rule) =>
+    rule.locations.map((location): ConsoleWithheldLocation => {
+      const artifact = toolOutputs.find((candidate) =>
+        candidate.artifactPath === location.artifactPath ||
+        artifactName(candidate.artifactPath) === artifactName(
+            location.artifactPath,
+          )
+      );
+      const held = artifact === undefined
+        ? { available: false as const }
+        : valueAtJsonPointer(artifact.value, location.jsonPointer);
+      const locationRules = rulesAtLocation.get(
+        `${location.artifactPath}\u0000${location.jsonPointer}`,
+      );
+      const bareIdentifierScrub = locationRules?.has(
+        "bare-fabric-identifier-scrub",
+      ) === true;
+      const scrubbed = held.available && bareIdentifierScrub
+        ? scrubBareFabricIdentifiersDeep(held.value)
+        : held.value;
+      const redaction = locationRules?.has("observation-denied") === true
+        ? "[redacted by CFC]"
+        : bareIdentifierScrub && !held.available
+        ? "[fabric-id]"
+        : bareIdentifierScrub && typeof scrubbed === "string"
+        ? scrubbed
+        : undefined;
+      return {
+        rule: rule.rule,
+        artifactPath: location.artifactPath,
+        jsonPointer: location.jsonPointer,
+        available: held.available,
+        ...(redaction !== undefined
+          ? { redaction }
+          : held.available
+          ? { value: scrubbed }
+          : {}),
+      };
+    })
+  );
+  return { status: "recorded", locations };
+};
+
 /**
  * The steps of a run. A tool call and the result answering it are one step
  * rather than two: what went in and what came back are the pair a person reads
@@ -417,6 +595,8 @@ export const consoleRunSteps = (
   policyDecisions: readonly HarnessPolicyDecisionRecord[] = [],
   policyEvents: readonly HarnessPolicyEvent[] = [],
   invocationContexts: readonly HarnessCfcInvocationContext[] = [],
+  omissions?: ConsoleTranscriptOmissionsState | HarnessTranscriptOmissions,
+  toolOutputs: readonly ConsoleToolOutputArtifact[] = [],
 ): readonly ConsoleStep[] => {
   // An invocation context names the output it was recorded for, which is the
   // same id the transcript's tool message carries as its result reference.
@@ -485,7 +665,7 @@ export const consoleRunSteps = (
     return introduced;
   };
 
-  for (const message of transcript) {
+  for (const [transcriptIndex, message] of transcript.entries()) {
     // An assistant message that only carries tool calls is the call's own
     // step, folded into the tool result below.
     if (
@@ -519,6 +699,10 @@ export const consoleRunSteps = (
           : call !== undefined
           ? { inputText: call.function.arguments }
           : {}),
+        ...(message.toolName === "run_pattern" && parsedInput.ok &&
+            sourceWasReplaced(parsedInput.value)
+          ? { sourceReplacedByLaterAttempt: true as const }
+          : {}),
         ...(parsedOutput.ok
           ? { output: parsedOutput.value }
           : { outputText: message.content }),
@@ -548,6 +732,12 @@ export const consoleRunSteps = (
           : {}),
         policyEvents: events,
         ...(disclosure !== undefined ? { disclosure } : {}),
+        withheld: withheldFor(
+          message,
+          transcriptIndex,
+          omissions,
+          toolOutputs,
+        ),
         ...(() => {
           const invocation = invocationFor(
             message.toolName,
@@ -567,6 +757,7 @@ export const consoleRunSteps = (
       handlesInScope: [...inScope],
       status: "none",
       policyEvents: [],
+      withheld: { status: "recorded", locations: [] },
     });
   }
   return steps;

--- a/packages/cf-harness/docs/CURRENT_STATE.md
+++ b/packages/cf-harness/docs/CURRENT_STATE.md
@@ -1,7 +1,7 @@
 # cf-harness Current State
 
 Status: current implementation reference\
-Last verified: 2026-08-26
+Last verified: 2026-09-03
 
 The [system map](system-map/README.md) moves in lockstep with this current-state
 reference.
@@ -25,11 +25,14 @@ The runtime has four main boundaries:
    The optional `run_pattern` tool is a distinct trusted-host path whose Fabric
    identity stays outside Docker and whose authority is constrained to one
    configured space.
-4. The artifact store records run state, transcript, reports, capability and
-   policy snapshots, tool outputs, child references, skills provenance, and
-   optional product run manifests. It also records the per-cell CFC labels the
-   run's space holds for the cells the run touched — the one artifact a run does
-   not write out of its own knowledge, read back from the space so a reader
+4. The artifact store records run state, the model-facing transcript, a sibling
+   record of the omission rules and full-artifact locations applied to each tool
+   result, reports, capability and policy snapshots, tool outputs, child
+   references, skills provenance, and optional product run manifests. The
+   omission record carries no withheld values and is read only for retrospective
+   display and audit accounting. The store also records the per-cell CFC labels
+   the run's space holds for the cells the run touched — the one artifact a run
+   does not write out of its own knowledge, read back from the space so a reader
    working from the tree alone can see what a cell is labelled.
 
 The Common Fabric runner or another trusted mediator owns authoritative CFC
@@ -83,7 +86,8 @@ The current package provides:
   tool activity, and an `invalid_tool_call` failure record. Only what the model
   cannot correct — transport, engine invariants, artifact persistence,
   cancellation, the turn cap — ends the run;
-- transcript-based resume and durable run artifacts;
+- transcript-based resume and durable run artifacts, with retrospective omission
+  joins kept outside the transcript and provider context;
 - server-side Responses context compaction with a default threshold derived from
   the model's input budget, an explicit override/disable control, retained
   compaction evidence, and tool-call/result-safe transcript pruning;

--- a/packages/cf-harness/docs/IMPLEMENTATION_PROFILE.md
+++ b/packages/cf-harness/docs/IMPLEMENTATION_PROFILE.md
@@ -196,7 +196,11 @@ readiness.
   reserved from normal workspace discovery when the roots overlap. Run-start
   image inputs are integrity-locked. In-run `view_image` observations use
   content-addressed snapshots when an artifact store is present, so regenerating
-  the source file does not change an earlier observation.
+  the source file does not change an earlier observation. Each persisted tool
+  result has a sibling transcript-omission entry naming the omission rule and
+  the full artifact's JSON pointer without copying the withheld value. The
+  console may join those records for retrospective display; resume and replay
+  continue to read only the model-facing transcript.
 
 ## Parent and child surfaces
 

--- a/packages/cf-harness/docs/system-map/cfc-system-map.html
+++ b/packages/cf-harness/docs/system-map/cfc-system-map.html
@@ -669,7 +669,7 @@
     // ------------------------------------------------------------------ layout data
     // The state of this repository the map describes. Bump both when the
     // map is re-verified; the stamp is drawn in the canvas's top-left corner.
-    const SNAPSHOT = { date: "2026-09-04", sha: "8c01de6ceb" };
+    const SNAPSHOT = { date: "2026-09-03", sha: "884a99f898" };
     const W = 2760, H = 1840;
     const bands = [
       {
@@ -1050,7 +1050,7 @@
         w: 300,
         h: 100,
         t: "Run artifacts",
-        s: "transcript · run-state · labels · tool outputs",
+        s: "transcript · omissions · labels · tool outputs",
       },
       {
         id: "audit",
@@ -1061,7 +1061,7 @@
         w: 250,
         h: 100,
         t: "CFC audit checker",
-        s: "AUD-1…9 · 13…19, spec-anchored",
+        s: "AUD-1…9 · 13…20, rule-accounted",
       },
     ];
     const extraLines = {
@@ -1424,7 +1424,7 @@
         to: "artifacts",
         k: "evidence",
         pts: [[800, 640], [775, 640], [775, 1650], [800, 1650]],
-        label: "transcript · run-state · policy snapshot",
+        label: "transcript · omission record · run-state",
         lp: [765, 1330, "end"],
       },
       {
@@ -1701,10 +1701,10 @@
       {
         id: "t20",
         n: 20,
-        c: "upcoming",
+        c: "guarded",
         x: 750,
         y: 1640,
-        t: "The retrospective transcript hides omissions",
+        t: "Retrospective display preserves omission boundaries",
       },
     ];
     const threatClass = {
@@ -1994,14 +1994,13 @@
         kind: "Evidence",
         band: "evidence",
         body:
-          `<p>Every run writes its transcript, run-state, policy snapshot, tool outputs, child references, skill provenance, and, since today, the per-cell labels its space holds for the cells it touched, in the same write as the run's outcome. The one artifact a run does not write from its own knowledge.</p>`,
+          `<p>Every run writes its model-facing transcript and a sibling omission record in the same transcript write. The sibling names rules and full-artifact JSON pointers without copying withheld content. Runs also retain run-state, policy snapshot, full tool outputs, child references, skill provenance, and the per-cell labels their space holds for touched cells.</p>`,
         threats: ["t6", "t8", "t12", "t20"],
         links: [[
           "cell labels recorded in the write that ends the run",
           6757,
         ]],
         close: [
-          "The retrospective transcript does not show what the prompt loop withheld or compressed (CT-2198).",
           "The artifact root is readable from the sandbox (CT-2117).",
         ],
       },
@@ -2009,7 +2008,7 @@
         kind: "Evidence · verifier",
         band: "evidence",
         body:
-          `<p>Runs over any recorded run and grades AUD-1 to AUD-9, AUD-13 to AUD-15a, and deployment checks AUD-16 to AUD-19 as pass, fail, warn or inconclusive against quoted spec clauses; inconclusive is never pass. It reads the shared posture record every surface publishes, checks its total sink registry, and evaluates dial tuples against the enforcement rules in <code>audit/matrix.ts</code>. For AUD-3, files under <code>tool-outputs/</code> stamped <code>cf-harness.subagent-raw-return</code> or <code>cf-harness.run-pattern-source</code> are not tool effects; AUD-9 requires an invocation context only for a side effect that reached the substrate under AUD-2's classifier, and warns when a run recorded no context at all because its artifacts cannot distinguish host-side effects from lost evidence. AUD-16 counts the refusals among the release decisions <code>policy-trace.json</code> carries — the ones that denied — and reports the releases the same boundary measured and admitted or merely observed beside them, which is what tells a gate that passed from a gate that never ran.</p><p>It verifies; it never enforces. Missing evidence is a finding, not proof that a gate ran.</p>`,
+          `<p>Runs over any recorded run and grades AUD-1 to AUD-9, AUD-13 to AUD-15a, and AUD-20, plus deployment checks AUD-16 to AUD-19, as pass, fail, warn or inconclusive against quoted spec clauses; inconclusive is never pass. It reads the shared posture record every surface publishes, checks its total sink registry, and evaluates dial tuples against the enforcement rules in <code>audit/matrix.ts</code>. For AUD-3, files under <code>tool-outputs/</code> stamped <code>cf-harness.subagent-raw-return</code> or <code>cf-harness.run-pattern-source</code> are not tool effects; AUD-9 requires an invocation context only for a side effect that reached the substrate under AUD-2's classifier, and warns when a run recorded no context at all because its artifacts cannot distinguish host-side effects from lost evidence. AUD-20 counts every model-boundary omission by the durable rule record; it extends AH-CFC-16 as our requirement rather than claiming the clause requires that artifact. AUD-16 counts the refusals among the release decisions <code>policy-trace.json</code> carries — the ones that denied — and reports the releases the same boundary measured and admitted or merely observed beside them, which is what tells a gate that passed from a gate that never ran.</p><p>It verifies; it never enforces. Missing evidence is a finding, not proof that a gate ran.</p>`,
         links: [["spec-anchored CFC checker", 6749], [
           "shared posture record, total sink registry, matrix-backed audit checks",
           6755,
@@ -2262,10 +2261,8 @@
         where: ["child_pa", "runner", "g_release", "g_return"],
       },
       t20: {
-        plan:
-          "CT-2198 joins the model-facing transcript to the retained artifact fields and records which omission rule applied.",
         body:
-          `<p>The durable transcript is the rendering the model saw. Full tool outputs remain in artifacts, but the retrospective does not show which fields were withheld, which identifiers were scrubbed, or which earlier diagnostics were collapsed. That hides omissions from an operator reviewing the run later.</p>`,
+          `<p>The durable transcript remains exactly the rendering the model saw. A sibling record names which omission rule applied and where the withheld field remains in the full tool output. The Timeline joins them only for retrospective display: CFC-denied values stay redaction markers, scrubbed identifiers stay placeholders, and neither resume nor replay reads the joined view. Legacy runs are labeled unrecorded rather than reconstructed.</p>`,
         where: ["artifacts", "console"],
       },
       t11: {
@@ -2302,7 +2299,7 @@
       e_runner_artifacts:
         `<p>Labels, decisions, commit refusals and, since today, the cell-label snapshot for touched cells, written in the same write as the run's outcome.</p>`,
       e_parent_artifacts:
-        `<p>The run retains its transcript, state, policy snapshot, and full tool outputs. The transcript is only the model-facing rendering; it does not identify fields withheld or diagnostics compressed from that rendering (CT-2198).</p>`,
+        `<p>The run retains its model-facing transcript, state, policy snapshot, and full tool outputs. In the same transcript write, a sibling record names every omission rule with its artifact path and JSON pointer, but never copies withheld content.</p>`,
       e_audit_operator:
         `<p>Findings for a person to act on. Operator access to raw artifacts is the intended gate that has no code yet.</p>`,
       e_operator_policy:
@@ -2399,7 +2396,7 @@
             ],
             sel: "g_release",
             h: "8 · Where the circuit is still open",
-            t: "Policy discharge at the release gate and a door for records (CT-2175). The prose delegation brief. Web and browser tools without label input, and bridge networking in the sandbox. A pattern's llm calls uncapped. The sandbox reading the run's own artifacts (CT-2117). Connector rows unlabeled (CT-2189). Projected posture, store identity, console concurrency, stale session policy, and substrate liveness remain tracked. Program diagnostics and retrospective omissions are unlabeled boundaries (CT-2199, CT-2198). The display ceiling is off. Operator access is unaudited.",
+            t: "Policy discharge at the release gate and a door for records (CT-2175). The prose delegation brief. Web and browser tools without label input, and bridge networking in the sandbox. A pattern's llm calls uncapped. The sandbox reading the run's own artifacts (CT-2117). Connector rows unlabeled (CT-2189). Projected posture, store identity, console concurrency, stale session policy, and substrate liveness remain tracked. Program diagnostics remain an unlabeled boundary (CT-2199); retrospective omissions now retain their rule and location without crossing back into model context. The display ceiling is off. Operator access is unaudited.",
           },
         ],
       },

--- a/packages/cf-harness/src/artifacts.ts
+++ b/packages/cf-harness/src/artifacts.ts
@@ -20,6 +20,11 @@ import type {
   HarnessSkillResourceReads,
   HarnessSkillScriptExecutions,
 } from "./contracts/skill.ts";
+import {
+  createHarnessTranscriptOmissions,
+  type HarnessTranscriptOmissions,
+  isHarnessTranscriptOmissions,
+} from "./contracts/transcript-omissions.ts";
 import type { HarnessTranscriptMessage } from "./contracts/transcript.ts";
 import type { ToolOutputId } from "./contracts/tool-result.ts";
 import type { HarnessCapabilitySnapshot } from "./diagnostics.ts";
@@ -163,6 +168,30 @@ export class FileSystemHarnessArtifactStore implements HarnessArtifactStore {
   ): Promise<string> {
     await ensureDir(this.runRoot);
     const path = join(this.runRoot, "transcript.json");
+    const omissionsPath = join(this.runRoot, "transcript-omissions.json");
+    let previous: HarnessTranscriptOmissions | undefined;
+    try {
+      const parsed: unknown = JSON.parse(
+        await Deno.readTextFile(omissionsPath),
+      );
+      if (!isHarnessTranscriptOmissions(parsed)) {
+        throw new TypeError(
+          `unsupported transcript omission artifact: ${omissionsPath}`,
+        );
+      }
+      previous = parsed;
+    } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound)) {
+        throw error;
+      }
+    }
+    const omissions = createHarnessTranscriptOmissions(transcript, previous);
+    const hasToolResult = transcript.some((message) => message.role === "tool");
+    if (
+      previous !== undefined || omissions.results.length > 0 || !hasToolResult
+    ) {
+      await writeJsonFile(omissionsPath, omissions);
+    }
     await writeJsonFile(path, transcript);
     return path;
   }

--- a/packages/cf-harness/src/contracts/transcript-omissions.ts
+++ b/packages/cf-harness/src/contracts/transcript-omissions.ts
@@ -1,0 +1,247 @@
+/**
+ * Records the model-context reductions applied to durable tool results. The
+ * record carries locations only; full values remain in their tool-output
+ * artifacts and never enter this file.
+ *
+ * The runtime annotation lives on a transcript message's object identity and
+ * is deliberately absent from its serialized shape. Code that replaces a tool
+ * message before persistence must carry the annotation across by passing the
+ * original message as `inheritFrom` to
+ * `annotateHarnessToolResultOmissions()`.
+ */
+
+import type {
+  HarnessToolTranscriptMessage,
+  HarnessTranscriptMessage,
+} from "./transcript.ts";
+import type { ToolResultRef } from "./tool-result.ts";
+
+/** Stable artifact discriminator for a transcript omission record. */
+export const HARNESS_TRANSCRIPT_OMISSIONS_TYPE =
+  "cf-harness.transcript-omissions" as const;
+
+/** Current transcript omission artifact version. */
+export const HARNESS_TRANSCRIPT_OMISSIONS_VERSION = 1 as const;
+
+/** The model-boundary omission rules which apply to tool results. */
+export const HARNESS_TRANSCRIPT_OMISSION_RULES = [
+  "artifact-only",
+  "bare-fabric-identifier-scrub",
+  "model-context-truncation",
+  "observation-denied",
+  "superseded-run-pattern-diagnostic-collapse",
+] as const;
+
+/** One model-boundary omission rule. */
+export type HarnessTranscriptOmissionRule =
+  typeof HARNESS_TRANSCRIPT_OMISSION_RULES[number];
+
+/** One position in a full tool-output artifact affected by an omission rule. */
+export interface HarnessTranscriptOmissionLocation {
+  artifactPath: string;
+  jsonPointer: string;
+}
+
+/** All positions in one tool result affected by one omission rule. */
+export interface HarnessTranscriptOmissionRuleRecord {
+  rule: HarnessTranscriptOmissionRule;
+  locations: readonly HarnessTranscriptOmissionLocation[];
+}
+
+/** Omission rules recorded for one model-facing tool result. */
+export interface HarnessToolResultOmissions {
+  transcriptIndex: number;
+  toolCallId: string;
+  toolId: string;
+  outputId: string;
+  rules: readonly HarnessTranscriptOmissionRuleRecord[];
+}
+
+/** Durable join between model-facing transcript results and full artifacts. */
+export interface HarnessTranscriptOmissions {
+  type: typeof HARNESS_TRANSCRIPT_OMISSIONS_TYPE;
+  version: typeof HARNESS_TRANSCRIPT_OMISSIONS_VERSION;
+  results: readonly HarnessToolResultOmissions[];
+}
+
+const toolMessageOmissions = Symbol("cf-harness.tool-message-omissions");
+
+type AnnotatedToolMessage = HarnessToolTranscriptMessage & {
+  [toolMessageOmissions]?: readonly HarnessTranscriptOmissionRuleRecord[];
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+/** Whether `value` is a supported omission rule. */
+export const isHarnessTranscriptOmissionRule = (
+  value: unknown,
+): value is HarnessTranscriptOmissionRule =>
+  typeof value === "string" &&
+  (HARNESS_TRANSCRIPT_OMISSION_RULES as readonly string[]).includes(value);
+
+/** Whether `value` has the shape of a transcript omission artifact. */
+export const isHarnessTranscriptOmissions = (
+  value: unknown,
+): value is HarnessTranscriptOmissions => {
+  if (
+    !isRecord(value) || value.type !== HARNESS_TRANSCRIPT_OMISSIONS_TYPE ||
+    value.version !== HARNESS_TRANSCRIPT_OMISSIONS_VERSION ||
+    !Array.isArray(value.results)
+  ) {
+    return false;
+  }
+  return value.results.every((result) =>
+    isRecord(result) && Number.isSafeInteger(result.transcriptIndex) &&
+    (result.transcriptIndex as number) >= 0 &&
+    typeof result.toolCallId === "string" &&
+    typeof result.toolId === "string" && typeof result.outputId === "string" &&
+    Array.isArray(result.rules) && result.rules.every((rule) =>
+      isRecord(rule) && isHarnessTranscriptOmissionRule(rule.rule) &&
+      Array.isArray(rule.locations) && rule.locations.every((location) =>
+        isRecord(location) && typeof location.artifactPath === "string" &&
+        typeof location.jsonPointer === "string"
+      )
+    )
+  );
+};
+
+/**
+ * Creates a rule record for `resultRef`, or `undefined` when no artifact or
+ * affected position exists to join to.
+ */
+export const createHarnessTranscriptOmissionRuleRecord = (
+  rule: HarnessTranscriptOmissionRule,
+  resultRef: ToolResultRef,
+  jsonPointers: readonly string[],
+): HarnessTranscriptOmissionRuleRecord | undefined => {
+  if (resultRef.artifactPath === undefined || jsonPointers.length === 0) {
+    return undefined;
+  }
+  return {
+    rule,
+    locations: [...new Set(jsonPointers)].map((jsonPointer) => ({
+      artifactPath: resultRef.artifactPath!,
+      jsonPointer,
+    })),
+  };
+};
+
+/**
+ * Attaches omission locations to an in-memory tool message. The symbol is
+ * non-enumerable and ignored by JSON serialization, so ordinary object reads,
+ * provider requests, and `transcript.json` keep their established shape.
+ * The annotation belongs to `message`'s object identity: a spread, clone, or
+ * JSON round trip drops it. Code that replaces a tool message before
+ * persistence must pass the original message as `inheritFrom`.
+ */
+export const annotateHarnessToolResultOmissions = (
+  message: HarnessToolTranscriptMessage,
+  records: readonly HarnessTranscriptOmissionRuleRecord[],
+  inheritFrom?: HarnessToolTranscriptMessage,
+): HarnessToolTranscriptMessage => {
+  const annotated = message as AnnotatedToolMessage;
+  const byRule = new Map<
+    HarnessTranscriptOmissionRule,
+    HarnessTranscriptOmissionLocation[]
+  >();
+  for (
+    const record of [
+      ...(inheritFrom === undefined ? [] : omissionsOf(inheritFrom) ?? []),
+      ...(annotated[toolMessageOmissions] ?? []),
+      ...records,
+    ]
+  ) {
+    const locations = byRule.get(record.rule) ?? [];
+    for (const location of record.locations) {
+      if (
+        !locations.some((held) =>
+          held.artifactPath === location.artifactPath &&
+          held.jsonPointer === location.jsonPointer
+        )
+      ) {
+        locations.push(location);
+      }
+    }
+    byRule.set(record.rule, locations);
+  }
+  Object.defineProperty(annotated, toolMessageOmissions, {
+    value: [...byRule].map(([rule, locations]) => ({ rule, locations })),
+    writable: true,
+    configurable: true,
+  });
+  return message;
+};
+
+const omissionsOf = (
+  message: HarnessToolTranscriptMessage,
+): readonly HarnessTranscriptOmissionRuleRecord[] | undefined =>
+  (message as AnnotatedToolMessage)[toolMessageOmissions];
+
+const mergeRuleRecords = (
+  previous: readonly HarnessTranscriptOmissionRuleRecord[],
+  current: readonly HarnessTranscriptOmissionRuleRecord[],
+): HarnessTranscriptOmissionRuleRecord[] => {
+  const byRule = new Map<
+    HarnessTranscriptOmissionRule,
+    HarnessTranscriptOmissionLocation[]
+  >();
+  for (const record of [...previous, ...current]) {
+    const locations = byRule.get(record.rule) ?? [];
+    for (const location of record.locations) {
+      if (
+        !locations.some((held) =>
+          held.artifactPath === location.artifactPath &&
+          held.jsonPointer === location.jsonPointer
+        )
+      ) {
+        locations.push(location);
+      }
+    }
+    byRule.set(record.rule, locations);
+  }
+  return HARNESS_TRANSCRIPT_OMISSION_RULES.flatMap((rule) => {
+    const locations = byRule.get(rule);
+    return locations === undefined ? [] : [{ rule, locations }];
+  });
+};
+
+/**
+ * Builds the durable omission join for `transcript`, retaining entries already
+ * recorded for messages loaded from a prior process.
+ *
+ * A tool result annotated with an empty set is still recorded. That separates
+ * a result known to have no omissions from a legacy result for which no record
+ * exists.
+ */
+export const createHarnessTranscriptOmissions = (
+  transcript: readonly HarnessTranscriptMessage[],
+  previous?: HarnessTranscriptOmissions,
+): HarnessTranscriptOmissions => {
+  const previousByOutput = new Map(
+    (previous?.results ?? []).map((result) => [result.outputId, result]),
+  );
+  const results: HarnessToolResultOmissions[] = [];
+  for (const [transcriptIndex, message] of transcript.entries()) {
+    if (message.role !== "tool" || message.resultRef === undefined) {
+      continue;
+    }
+    const current = omissionsOf(message);
+    const prior = previousByOutput.get(String(message.resultRef.outputId));
+    if (current === undefined && prior === undefined) {
+      continue;
+    }
+    results.push({
+      transcriptIndex,
+      toolCallId: message.toolCallId,
+      toolId: message.toolName,
+      outputId: String(message.resultRef.outputId),
+      rules: mergeRuleRecords(prior?.rules ?? [], current ?? []),
+    });
+  }
+  return {
+    type: HARNESS_TRANSCRIPT_OMISSIONS_TYPE,
+    version: HARNESS_TRANSCRIPT_OMISSIONS_VERSION,
+    results,
+  };
+};

--- a/packages/cf-harness/src/fabric-identifier-scrub.ts
+++ b/packages/cf-harness/src/fabric-identifier-scrub.ts
@@ -1,0 +1,39 @@
+/**
+ * Replaces bare fabric identifiers in model-facing or retrospective text with
+ * a fixed placeholder. Schemed links and harness handle tokens remain intact.
+ */
+export const scrubBareFabricIdentifiers = (text: string): string =>
+  text
+    .replaceAll(/\bdata:[^\s"'`)\]}]+/gi, "[fabric-id]")
+    .replaceAll(/\bdid:[a-z0-9]+:[A-Za-z0-9._%-]+/g, "[fabric-id]")
+    .replaceAll(
+      /(?<![A-Za-z0-9:])[A-Za-z0-9]+:[A-Za-z0-9_-]{43}(?![A-Za-z0-9_-])/g,
+      "[fabric-id]",
+    );
+
+/**
+ * Applies the bare-identifier scrub to every string and object key in a value.
+ * A key that becomes indistinguishable from a sibling is overwritten because
+ * the model-facing or retrospective boundary cannot distinguish it either.
+ */
+export const scrubBareFabricIdentifiersDeep = (value: unknown): unknown => {
+  if (typeof value === "string") {
+    return scrubBareFabricIdentifiers(value);
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => scrubBareFabricIdentifiersDeep(entry));
+  }
+  if (typeof value === "object" && value !== null) {
+    const scrubbed: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(value)) {
+      Object.defineProperty(scrubbed, scrubBareFabricIdentifiers(key), {
+        value: scrubBareFabricIdentifiersDeep(entry),
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
+    }
+    return scrubbed;
+  }
+  return value;
+};

--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -100,6 +100,11 @@ import {
   withheldToolIds,
 } from "./contracts/tool-descriptor.ts";
 import type { ToolOutputId, ToolResultRef } from "./contracts/tool-result.ts";
+import {
+  annotateHarnessToolResultOmissions,
+  createHarnessTranscriptOmissionRuleRecord,
+  type HarnessTranscriptOmissionRuleRecord,
+} from "./contracts/transcript-omissions.ts";
 import type {
   HarnessToolCall,
   HarnessToolTranscriptMessage,
@@ -153,15 +158,16 @@ import { createExploreQueryRunner } from "./docs-corpus/explore.ts";
 import { isEditFileToolSuccessOutput } from "./tools/edit-file.ts";
 import { isStructuredFileToolErrorOutput } from "./tools/file-errors.ts";
 import { isReadFileToolSuccessOutput } from "./tools/read-file.ts";
+import {
+  scrubBareFabricIdentifiers,
+  scrubBareFabricIdentifiersDeep,
+} from "./fabric-identifier-scrub.ts";
 import { BUILTIN_TOOLS, getBuiltinTool } from "./tools/registry.ts";
 import {
   isSearchPatternsToolSuccessOutput,
   type SearchPatternsToolResult,
 } from "./tools/search-patterns.ts";
-import {
-  isRunPatternToolSuccessOutput,
-  scrubBareFabricIdentifiers,
-} from "./tools/run-pattern.ts";
+import { isRunPatternToolSuccessOutput } from "./tools/run-pattern.ts";
 import {
   isRunSkillScriptToolSuccessOutput,
   type RunSkillScriptToolOutput,
@@ -1798,6 +1804,7 @@ interface ModelFacingToolOutputResult {
   output: ModelFacingToolOutput;
   cfcModelContextObservations?:
     readonly HarnessCfcModelContextObservationInput[];
+  omissionRules?: readonly HarnessTranscriptOmissionRuleRecord[];
 }
 
 interface CfcSandboxResultCarrier {
@@ -1834,45 +1841,84 @@ const stripInternalToolFields = (output: unknown): unknown => {
   return publicOutput;
 };
 
-/**
- * Applies the model-boundary scrub to every string a value carries at every
- * depth, its object KEYS included.
- *
- * Scrubbing the free-text fields a tool declares is enough only for a tool
- * whose author-controlled text sits in named fields. It is not enough for one
- * whose output is a structure whose own shape is author-controlled — a
- * disclosed JSON Schema most of all, where the property names are the point of
- * the disclosure and are arbitrary text whoever wrote the schema chose. So the
- * walk reaches keys as well as values.
- *
- * The scrub itself is {@link scrubBareFabricIdentifiers}; this decides only
- * where it lands. A key that scrubs to the same text as a sibling collapses
- * into it, which is the honest outcome: two names differing only in an
- * identifier this boundary refuses to disclose are not distinguishable on the
- * model's side of it either.
- */
-const scrubBareFabricIdentifiersDeep = (value: unknown): unknown => {
+const omissionRules = (
+  ...records: Array<HarnessTranscriptOmissionRuleRecord | undefined>
+): HarnessTranscriptOmissionRuleRecord[] =>
+  records.filter((record) => record !== undefined);
+
+const presentFieldPointers = (
+  output: ReadonlyRecord,
+  fields: readonly string[],
+): string[] =>
+  fields.filter((field) => Object.hasOwn(output, field)).map((field) =>
+    `/${field}`
+  );
+
+const escapeJsonPointerSegment = (segment: string): string =>
+  segment.replaceAll("~", "~0").replaceAll("/", "~1");
+
+/** Positions whose strings or member names carry a bare fabric identifier. */
+const bareFabricIdentifierPointers = (
+  value: unknown,
+  pointer = "",
+): string[] => {
   if (typeof value === "string") {
-    return scrubBareFabricIdentifiers(value);
+    return scrubBareFabricIdentifiers(value) === value ? [] : [pointer];
   }
   if (Array.isArray(value)) {
-    return value.map((entry) => scrubBareFabricIdentifiersDeep(entry));
+    return value.flatMap((entry, index) =>
+      bareFabricIdentifierPointers(entry, `${pointer}/${index}`)
+    );
   }
-  if (isObjectNotArray(value)) {
-    const scrubbed: Record<string, unknown> = {};
-    for (const [key, entry] of Object.entries(value)) {
-      // `defineProperty` rather than assignment, so a scrubbed key of
-      // `__proto__` becomes an own property instead of reaching the prototype.
-      Object.defineProperty(scrubbed, scrubBareFabricIdentifiers(key), {
-        value: scrubBareFabricIdentifiersDeep(entry),
-        writable: true,
-        enumerable: true,
-        configurable: true,
-      });
+  if (!isObjectNotArray(value)) {
+    return [];
+  }
+  return Object.entries(value).flatMap(([key, entry]) => {
+    const childPointer = `${pointer}/${escapeJsonPointerSegment(key)}`;
+    if (scrubBareFabricIdentifiers(key) !== key) {
+      // A JSON Pointer spelling the key would itself copy the identifier into
+      // the omission record. Point at the containing object; the reader
+      // applies the same deep scrub before displaying it.
+      return [pointer];
     }
-    return scrubbed;
+    return [
+      ...bareFabricIdentifierPointers(entry, childPointer),
+    ];
+  });
+};
+
+const truncationPointers = (output: unknown): string[] => {
+  if (!isObjectNotArray(output)) {
+    return [];
   }
-  return value;
+  return [
+    ...(output.stdoutTruncated === true ? ["/stdout"] : []),
+    ...(output.stderrTruncated === true ? ["/stderr"] : []),
+    ...(output.contentTruncated === true ? ["/content"] : []),
+  ];
+};
+
+const deniedObservationPointers = (
+  toolId: BuiltinToolId,
+  result: CfcSandboxResult,
+): string[] => {
+  const streamPointer = (channel: "stdout" | "stderr"): string =>
+    toolId === "read_file"
+      ? "/content"
+      : toolId === "edit_file"
+      ? "/diff"
+      : `/${channel}`;
+  return [
+    ...(result.stdout.policy === "observed" ? [] : [streamPointer("stdout")]),
+    ...(result.stderr.policy === "observed" || toolId === "read_file" ||
+        toolId === "edit_file"
+      ? []
+      : [streamPointer("stderr")]),
+    ...(result.exitCode.policy === "observed" || toolId === "read_file" ||
+        toolId === "edit_file"
+      ? []
+      : ["/exitCode"]),
+  ];
 };
 
 const toolOutputNeedsSandboxMediation = (
@@ -2211,6 +2257,20 @@ const modelContextObservationForExitCode = (
   };
 };
 
+const modelContextTruncationPointers = (
+  streams: readonly {
+    observation: CfcStreamObservation;
+    jsonPointer: string;
+    modelTruncated?: boolean;
+  }[],
+): string[] =>
+  streams.flatMap(({ observation, jsonPointer, modelTruncated }) =>
+    (observation.policy !== "denied" && observation.truncated === true) ||
+      modelTruncated === true
+      ? [jsonPointer]
+      : []
+  );
+
 const renderMediatedBashOutput = (
   output: ReadonlyRecord,
   cfcResult: CfcSandboxResult,
@@ -2275,6 +2335,29 @@ const renderMediatedBashOutput = (
     ...(observations.length > 0
       ? { cfcModelContextObservations: observations }
       : {}),
+    omissionRules: omissionRules(
+      createHarnessTranscriptOmissionRuleRecord(
+        "model-context-truncation",
+        resultRef,
+        modelContextTruncationPointers([
+          {
+            observation: cfcResult.stdout,
+            jsonPointer: "/stdout",
+            modelTruncated: stdout.truncated,
+          },
+          {
+            observation: cfcResult.stderr,
+            jsonPointer: "/stderr",
+            modelTruncated: stderr.truncated,
+          },
+        ]),
+      ),
+      createHarnessTranscriptOmissionRuleRecord(
+        "observation-denied",
+        resultRef,
+        deniedObservationPointers("bash", cfcResult),
+      ),
+    ),
   };
 };
 
@@ -2342,6 +2425,29 @@ const renderMediatedRunSkillScriptOutput = (
     ...(observations.length > 0
       ? { cfcModelContextObservations: observations }
       : {}),
+    omissionRules: omissionRules(
+      createHarnessTranscriptOmissionRuleRecord(
+        "model-context-truncation",
+        resultRef,
+        modelContextTruncationPointers([
+          {
+            observation: cfcResult.stdout,
+            jsonPointer: "/stdout",
+            modelTruncated: stdout.truncated,
+          },
+          {
+            observation: cfcResult.stderr,
+            jsonPointer: "/stderr",
+            modelTruncated: stderr.truncated,
+          },
+        ]),
+      ),
+      createHarnessTranscriptOmissionRuleRecord(
+        "observation-denied",
+        resultRef,
+        deniedObservationPointers("run_skill_script", cfcResult),
+      ),
+    ),
   };
 };
 
@@ -2379,6 +2485,22 @@ const renderMediatedReadFileOutput = (
     ...(observation !== undefined
       ? { cfcModelContextObservations: [observation] }
       : {}),
+    omissionRules: omissionRules(
+      createHarnessTranscriptOmissionRuleRecord(
+        "model-context-truncation",
+        resultRef,
+        modelContextTruncationPointers([{
+          observation: cfcResult.stdout,
+          jsonPointer: "/content",
+          modelTruncated: content.truncated,
+        }]),
+      ),
+      createHarnessTranscriptOmissionRuleRecord(
+        "observation-denied",
+        resultRef,
+        deniedObservationPointers("read_file", cfcResult),
+      ),
+    ),
   };
 };
 
@@ -2407,6 +2529,21 @@ const renderMediatedEditFileOutput = (
     ...(observation !== undefined
       ? { cfcModelContextObservations: [observation] }
       : {}),
+    omissionRules: omissionRules(
+      createHarnessTranscriptOmissionRuleRecord(
+        "model-context-truncation",
+        resultRef,
+        modelContextTruncationPointers([{
+          observation: cfcResult.stdout,
+          jsonPointer: "/diff",
+        }]),
+      ),
+      createHarnessTranscriptOmissionRuleRecord(
+        "observation-denied",
+        resultRef,
+        deniedObservationPointers("edit_file", cfcResult),
+      ),
+    ),
   };
 };
 
@@ -3894,13 +4031,13 @@ export class CfHarnessPromptLoop {
       ...optionalPolicyEventIndexes(policyEventIndexes),
       resultRef: result.resultRef,
     });
-    const toolMessage: HarnessToolTranscriptMessage = {
+    const toolMessage = annotateHarnessToolResultOmissions({
       role: "tool",
       toolCallId: toolCall.id,
       toolName: toolId,
       content: JSON.stringify(modelOutput),
       resultRef: result.resultRef,
-    };
+    }, modelOutputResult.omissionRules ?? []);
     if (isViewImageToolSuccessOutput(result.output)) {
       // The raw path may embed an address a token resolved to, so the
       // followup goes through the same outbound swap as the tool message.
@@ -3980,6 +4117,13 @@ export class CfHarnessPromptLoop {
       });
       return {
         output: redactReadFileStatusObservationError(output, resultRef),
+        omissionRules: omissionRules(
+          createHarnessTranscriptOmissionRuleRecord(
+            "observation-denied",
+            resultRef,
+            ["/path", "/error"],
+          ),
+        ),
       };
     }
     if (toolId === "edit_file" && isStructuredFileToolErrorOutput(output)) {
@@ -4012,11 +4156,27 @@ export class CfHarnessPromptLoop {
       });
       return {
         output: redactEditFileStatusObservationError(output, resultRef),
+        omissionRules: omissionRules(
+          createHarnessTranscriptOmissionRuleRecord(
+            "observation-denied",
+            resultRef,
+            ["/path", "/error"],
+          ),
+        ),
       };
     }
     if (toolId === "web_fetch") {
       return {
         output: toModelFacingWebFetchOutput(output as WebFetchToolOutput),
+        omissionRules: omissionRules(
+          createHarnessTranscriptOmissionRuleRecord(
+            "artifact-only",
+            resultRef,
+            isObjectNotArray(output) && Object.hasOwn(output, "rawContent")
+              ? ["/rawContent"]
+              : [],
+          ),
+        ),
       };
     }
     if (toolId === "run_pattern" && isObjectNotArray(output)) {
@@ -4048,7 +4208,34 @@ export class CfHarnessPromptLoop {
           scrubbed[field] = scrubBareFabricIdentifiers(text);
         }
       }
-      return { output: stripInternalToolFields(scrubbed) };
+      return {
+        output: stripInternalToolFields(scrubbed),
+        omissionRules: omissionRules(
+          createHarnessTranscriptOmissionRuleRecord(
+            "artifact-only",
+            resultRef,
+            presentFieldPointers(output, [
+              "rawValue",
+              "rawCauseMessage",
+              "pieceId",
+              "resultRefSchema",
+              "releaseObservation",
+              "releaseDecision",
+            ]),
+          ),
+          createHarnessTranscriptOmissionRuleRecord(
+            "bare-fabric-identifier-scrub",
+            resultRef,
+            ["message", "valueError"].flatMap((field) => {
+              const text = output[field];
+              return typeof text === "string" &&
+                  scrubBareFabricIdentifiers(text) !== text
+                ? [`/${field}`]
+                : [];
+            }),
+          ),
+        ),
+      };
     }
     if (toolId === "assign_slug" && isObjectNotArray(output)) {
       // The slug is the model's own word and the URL is composed from the
@@ -4058,7 +4245,16 @@ export class CfHarnessPromptLoop {
       if (typeof scrubbed.message === "string") {
         scrubbed.message = scrubBareFabricIdentifiers(scrubbed.message);
       }
-      return { output: stripInternalToolFields(scrubbed) };
+      return {
+        output: stripInternalToolFields(scrubbed),
+        omissionRules: omissionRules(
+          createHarnessTranscriptOmissionRuleRecord(
+            "bare-fabric-identifier-scrub",
+            resultRef,
+            bareFabricIdentifierPointers(output.message, "/message"),
+          ),
+        ),
+      };
     }
     if (toolId === "describe_handle") {
       // A disclosed schema's property names are whoever authored the schema's
@@ -4069,27 +4265,53 @@ export class CfHarnessPromptLoop {
       // keys and all rather than field by field.
       return {
         output: scrubBareFabricIdentifiersDeep(stripInternalToolFields(output)),
+        omissionRules: omissionRules(
+          createHarnessTranscriptOmissionRuleRecord(
+            "bare-fabric-identifier-scrub",
+            resultRef,
+            bareFabricIdentifierPointers(stripInternalToolFields(output)),
+          ),
+        ),
       };
     }
     if (!toolOutputNeedsSandboxMediation(toolId, output)) {
-      return { output: stripInternalToolFields(output) };
+      return {
+        output: stripInternalToolFields(output),
+        omissionRules: omissionRules(
+          createHarnessTranscriptOmissionRuleRecord(
+            "artifact-only",
+            resultRef,
+            isObjectNotArray(output) && Object.hasOwn(output, "exploreRecord")
+              ? ["/exploreRecord"]
+              : [],
+          ),
+        ),
+      };
     }
     if (cfcResult === undefined) {
       const detail =
         `${toolId} output did not include trusted CFC mediation metadata`;
       if (mode === "disabled") {
+        const rendered = toolId === "bash" || toolId === "run_skill_script"
+          ? truncateModelFacingBashOutput(
+            stripInternalToolFields(output),
+            resultRef,
+          )
+          : toolId === "read_file"
+          ? truncateModelFacingReadFileOutput(
+            stripInternalToolFields(output),
+            resultRef,
+          )
+          : stripInternalToolFields(output);
         return {
-          output: toolId === "bash" || toolId === "run_skill_script"
-            ? truncateModelFacingBashOutput(
-              stripInternalToolFields(output),
+          output: rendered,
+          omissionRules: omissionRules(
+            createHarnessTranscriptOmissionRuleRecord(
+              "model-context-truncation",
               resultRef,
-            )
-            : toolId === "read_file"
-            ? truncateModelFacingReadFileOutput(
-              stripInternalToolFields(output),
-              resultRef,
-            )
-            : stripInternalToolFields(output),
+              truncationPointers(rendered),
+            ),
+          ),
         };
       }
       if (mode === "observe") {
@@ -4101,18 +4323,26 @@ export class CfHarnessPromptLoop {
           detail:
             `${detail}; raw output was exposed because CFC is in observe mode`,
         });
+        const rendered = toolId === "bash" || toolId === "run_skill_script"
+          ? truncateModelFacingBashOutput(
+            stripInternalToolFields(output),
+            resultRef,
+          )
+          : toolId === "read_file"
+          ? truncateModelFacingReadFileOutput(
+            stripInternalToolFields(output),
+            resultRef,
+          )
+          : stripInternalToolFields(output);
         return {
-          output: toolId === "bash" || toolId === "run_skill_script"
-            ? truncateModelFacingBashOutput(
-              stripInternalToolFields(output),
+          output: rendered,
+          omissionRules: omissionRules(
+            createHarnessTranscriptOmissionRuleRecord(
+              "model-context-truncation",
               resultRef,
-            )
-            : toolId === "read_file"
-            ? truncateModelFacingReadFileOutput(
-              stripInternalToolFields(output),
-              resultRef,
-            )
-            : stripInternalToolFields(output),
+              truncationPointers(rendered),
+            ),
+          ),
         };
       }
       const denial = makeObservationDenied("not-observable", {
@@ -4127,7 +4357,16 @@ export class CfHarnessPromptLoop {
         detail,
         observationDenied: denial,
       });
-      return { output: denial };
+      return {
+        output: denial,
+        omissionRules: omissionRules(
+          createHarnessTranscriptOmissionRuleRecord(
+            "observation-denied",
+            resultRef,
+            [""],
+          ),
+        ),
+      };
     }
     if (toolId === "bash" && isObjectNotArray(output)) {
       return renderMediatedBashOutput(output, cfcResult, resultRef, toolCallId);

--- a/packages/cf-harness/src/run-pattern-diagnostic-collapse.ts
+++ b/packages/cf-harness/src/run-pattern-diagnostic-collapse.ts
@@ -4,6 +4,10 @@ import type {
   HarnessToolTranscriptMessage,
   HarnessTranscriptMessage,
 } from "./contracts/transcript.ts";
+import {
+  annotateHarnessToolResultOmissions,
+  createHarnessTranscriptOmissionRuleRecord,
+} from "./contracts/transcript-omissions.ts";
 
 /** Statuses whose `message` carries a diagnostic the model writes against. */
 const COLLAPSIBLE_STATUSES = new Set(["compile-error", "error"]);
@@ -102,7 +106,7 @@ const collapsedMessage = (
 ): HarnessToolTranscriptMessage | undefined => {
   const summary = summarize(failure, attempt);
   if (summary.length >= failure.message.length) return undefined;
-  return {
+  const collapsed: HarnessToolTranscriptMessage = {
     ...message,
     content: JSON.stringify({
       ...failure.output,
@@ -111,6 +115,16 @@ const collapsedMessage = (
       messageOriginalLength: failure.message.length,
     }),
   };
+  const omission = message.resultRef === undefined
+    ? undefined
+    : createHarnessTranscriptOmissionRuleRecord(
+      "superseded-run-pattern-diagnostic-collapse",
+      message.resultRef,
+      ["/message"],
+    );
+  return omission === undefined
+    ? collapsed
+    : annotateHarnessToolResultOmissions(collapsed, [omission], message);
 };
 
 /**

--- a/packages/cf-harness/src/tools/run-pattern.ts
+++ b/packages/cf-harness/src/tools/run-pattern.ts
@@ -786,25 +786,6 @@ export const policyRefusalMessage = (
 };
 
 /**
- * Replaces bare fabric identifiers in model-facing diagnostic text with a
- * fixed placeholder. Compiler diagnostics can embed compiler-generated bare
- * tagged hashes (e.g. the `/fid1:.../` virtual module roots), DIDs, and
- * `data:` URIs — none of which the handle boundary swaps, since it only
- * handles the `of:`/`computed:` schemed link forms. A negative lookbehind
- * leaves those schemed forms (and `cfh:` handle tokens) alone: their embedded
- * hash is always preceded by a colon. Raw text stays in the persisted
- * artifact; only the model-facing rendering is scrubbed.
- */
-export const scrubBareFabricIdentifiers = (text: string): string =>
-  text
-    .replaceAll(/\bdata:[^\s"'`)\]}]+/g, "[fabric-id]")
-    .replaceAll(/\bdid:[a-z0-9]+:[A-Za-z0-9._%-]+/g, "[fabric-id]")
-    .replaceAll(
-      /(?<![A-Za-z0-9:])[A-Za-z0-9]+:[A-Za-z0-9_-]{43}(?![A-Za-z0-9_-])/g,
-      "[fabric-id]",
-    );
-
-/**
  * A raw result may hold values `JSON.stringify` cannot carry into the
  * tool-output artifact (a cycle through the reactive graph, say), so the
  * round trip both proves serializability and normalizes cells to their

--- a/packages/cf-harness/test/console/runs.test.ts
+++ b/packages/cf-harness/test/console/runs.test.ts
@@ -11,6 +11,7 @@ import {
 } from "../../console/run-store.ts";
 import { createHarnessRunState } from "../../src/run-state.ts";
 import type { HarnessTranscriptMessage } from "../../src/contracts/transcript.ts";
+import { createToolOutputId } from "../../src/contracts/tool-result.ts";
 import {
   HARNESS_CELL_LABELS_TYPE,
   type HarnessCellLabels,
@@ -326,6 +327,120 @@ describe("console/runs", () => {
           "r1_run_pattern_2-run_pattern.json",
           "r1_run_pattern_10-run_pattern.json",
         ]);
+      });
+    });
+
+    it("joins an omission record to the full tool output", async () => {
+      await withArtifactRoot(async (root) => {
+        await writeRun(root, "r1", "2026-01-01T00:00:01.000Z");
+        const runRoot = join(root, "r1");
+        const outputName = toolOutputName("r1", "run_pattern", 2);
+        const artifactPath = join(runRoot, "tool-outputs", outputName);
+        const outputId = createToolOutputId("r1", "run_pattern", 2);
+        await Deno.writeTextFile(
+          join(runRoot, "transcript.json"),
+          JSON.stringify([
+            call("c1", "run_pattern", { sourceText: "x" }),
+            {
+              role: "tool",
+              toolCallId: "c1",
+              toolName: "run_pattern",
+              content: JSON.stringify({ status: "ok" }),
+              resultRef: {
+                type: "cf-harness.tool-result-ref",
+                outputId,
+                toolId: "run_pattern",
+                runId: "r1",
+                artifactPath,
+              },
+            },
+          ]),
+        );
+        await Deno.writeTextFile(
+          artifactPath,
+          JSON.stringify({ status: "ok", rawValue: "retained" }),
+        );
+        await Deno.writeTextFile(
+          join(runRoot, "transcript-omissions.json"),
+          JSON.stringify({
+            type: "cf-harness.transcript-omissions",
+            version: 1,
+            results: [{
+              transcriptIndex: 1,
+              toolCallId: "c1",
+              toolId: "run_pattern",
+              outputId,
+              rules: [{
+                rule: "artifact-only",
+                locations: [{ artifactPath, jsonPointer: "/rawValue" }],
+              }],
+            }],
+          }),
+        );
+
+        const detail = await readConsoleRun(root, "r1");
+        expect(detail?.steps[0].withheld.locations[0].value).toBe("retained");
+        expect(detail?.artifactNames).toContain("transcript-omissions.json");
+      });
+    });
+
+    it("does not label a malformed omission record as legacy", async () => {
+      await withArtifactRoot(async (root) => {
+        await writeRun(root, "r1", "2026-01-01T00:00:01.000Z");
+        const runRoot = join(root, "r1");
+        await Deno.writeTextFile(
+          join(runRoot, "transcript.json"),
+          JSON.stringify([
+            call("c1", "bash", { command: "pwd" }),
+            result("c1", "bash", { status: "ok" }),
+          ]),
+        );
+        await Deno.writeTextFile(
+          join(runRoot, "transcript-omissions.json"),
+          "{not-json",
+        );
+
+        const detail = await readConsoleRun(root, "r1");
+        expect(detail?.steps[0].withheld.status).toBe("record-unreadable");
+      });
+    });
+
+    it("does not label a wrong-shape omission record as legacy", async () => {
+      await withArtifactRoot(async (root) => {
+        await writeRun(root, "r1", "2026-01-01T00:00:01.000Z");
+        const runRoot = join(root, "r1");
+        await Deno.writeTextFile(
+          join(runRoot, "transcript.json"),
+          JSON.stringify([
+            call("c1", "bash", { command: "pwd" }),
+            result("c1", "bash", { status: "ok" }),
+          ]),
+        );
+        await Deno.writeTextFile(
+          join(runRoot, "transcript-omissions.json"),
+          '{"version":999}',
+        );
+
+        const detail = await readConsoleRun(root, "r1");
+        expect(detail?.steps[0].withheld.status).toBe("record-unreadable");
+      });
+    });
+
+    it("does not label an unreadable omission path as legacy", async () => {
+      await withArtifactRoot(async (root) => {
+        await writeRun(root, "r1", "2026-01-01T00:00:01.000Z");
+        const runRoot = join(root, "r1");
+        await Deno.writeTextFile(
+          join(runRoot, "transcript.json"),
+          JSON.stringify([
+            call("c1", "bash", { command: "pwd" }),
+            result("c1", "bash", { status: "ok" }),
+          ]),
+        );
+        await Deno.mkdir(join(runRoot, "transcript-omissions.json"));
+
+        const detail = await readConsoleRun(root, "r1");
+        expect(detail?.steps[0].withheld.status).toBe("record-unreadable");
       });
     });
 

--- a/packages/cf-harness/test/console/src/steps-view.test.ts
+++ b/packages/cf-harness/test/console/src/steps-view.test.ts
@@ -1,8 +1,36 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { clampSelection } from "../../../console/src/steps-view.ts";
+import {
+  clampSelection,
+  ConsoleSteps,
+  withheldSummary,
+  withheldView,
+} from "../../../console/src/steps-view.ts";
+import {
+  type ConsoleHandle,
+  consoleRunSteps,
+  type ConsoleStep,
+} from "../../../console/steps.ts";
+import type { HarnessTranscriptMessage } from "../../../src/contracts/transcript.ts";
+import { createToolOutputId } from "../../../src/contracts/tool-result.ts";
 
 describe("console/src/steps-view", () => {
+  const templateText = (value: unknown): string => {
+    if (value === null || value === undefined) return "";
+    if (typeof value === "string" || typeof value === "number") {
+      return String(value);
+    }
+    if (Array.isArray(value)) return value.map(templateText).join("");
+    if (typeof value !== "object") return "";
+    const template = value as {
+      strings?: readonly string[];
+      values?: readonly unknown[];
+    };
+    return (template.strings ?? []).map((part, index) =>
+      part + templateText(template.values?.[index])
+    ).join("");
+  };
+
   describe("clampSelection", () => {
     it("keeps a selection the run is long enough to hold", () => {
       expect(clampSelection(3, 9)).toBe(3);
@@ -18,6 +46,276 @@ describe("console/src/steps-view", () => {
 
     it("answers zero for a step before the first", () => {
       expect(clampSelection(-1, 9)).toBe(0);
+    });
+  });
+
+  describe("withheldSummary", () => {
+    const step = (withheld: ConsoleStep["withheld"]): ConsoleStep => ({
+      index: 1,
+      kind: "tool",
+      handlesIntroduced: [],
+      handlesInScope: [],
+      status: "ok",
+      policyEvents: [],
+      withheld,
+    });
+
+    it("labels a legacy result as having no omission record", () => {
+      expect(withheldSummary(step({ status: "unrecorded", locations: [] })))
+        .toBe("withheld from the model · no record");
+    });
+
+    it("labels a recorded result with its withheld position count", () => {
+      expect(withheldSummary(step({
+        status: "recorded",
+        locations: [{
+          rule: "artifact-only",
+          artifactPath: "/run/tool-outputs/result.json",
+          jsonPointer: "/rawValue",
+          value: "retained",
+          available: true,
+        }],
+      }))).toBe("withheld from the model · 1");
+    });
+
+    it("distinguishes an unreadable record from a missing result entry", () => {
+      expect(withheldSummary(step({
+        status: "record-unreadable",
+        locations: [],
+      }))).toContain("record unreadable");
+      expect(withheldSummary(step({
+        status: "record-entry-missing",
+        locations: [],
+      }))).toContain("entry missing");
+    });
+  });
+
+  describe("withheldView", () => {
+    const step = (withheld: ConsoleStep["withheld"]): ConsoleStep => ({
+      index: 1,
+      kind: "tool",
+      handlesIntroduced: [],
+      handlesInScope: [],
+      status: "ok",
+      policyEvents: [],
+      withheld,
+    });
+
+    it("explains why a legacy result cannot be reconstructed", () => {
+      const text = templateText(withheldView(step({
+        status: "unrecorded",
+        locations: [],
+      })));
+      expect(text).toContain("withheld from the model · no record");
+      expect(text).toContain("Legacy runs cannot be");
+      expect(text).toContain("reconstructed honestly");
+    });
+
+    it("states when a recorded result has no omissions", () => {
+      const text = templateText(withheldView(step({
+        status: "recorded",
+        locations: [],
+      })));
+      expect(text).toContain("No omission rule applied to this result");
+    });
+
+    it("does not describe a bad or incomplete current record as legacy", () => {
+      const unreadable = templateText(withheldView(step({
+        status: "record-unreadable",
+        locations: [],
+      })));
+      const incomplete = templateText(withheldView(step({
+        status: "record-entry-missing",
+        locations: [],
+      })));
+
+      expect(unreadable).toContain("exists but is unreadable");
+      expect(incomplete).toContain("exists but has no entry");
+      expect(unreadable).not.toContain("Legacy");
+      expect(incomplete).not.toContain("Legacy");
+    });
+
+    it("renders values, redaction markers, and unavailable positions", () => {
+      const text = templateText(withheldView(step({
+        status: "recorded",
+        locations: [{
+          rule: "artifact-only",
+          artifactPath: "/run/output.json",
+          jsonPointer: "/rawValue",
+          value: { retained: true },
+          available: true,
+        }, {
+          rule: "observation-denied",
+          artifactPath: "/run/output.json",
+          jsonPointer: "/stderr",
+          redaction: "[redacted by CFC]",
+          available: true,
+        }, {
+          rule: "model-context-truncation",
+          artifactPath: "/run/missing.json",
+          jsonPointer: "/stdout",
+          available: false,
+        }],
+      })));
+      expect(text).toContain("artifact-only");
+      expect(text).toContain('{\n  "retained": true\n}');
+      expect(text).toContain("[redacted by CFC]");
+      expect(text).toContain("recorded artifact position is unavailable");
+    });
+
+    it("never renders an available denied value through an overlapping rule", () => {
+      const outputId = createToolOutputId("run", "bash", 1);
+      const artifactPath = "/run/tool-outputs/bash.json";
+      const transcript: HarnessTranscriptMessage[] = [{
+        role: "assistant",
+        content: "",
+        toolCalls: [{
+          id: "call-1",
+          type: "function",
+          function: { name: "bash", arguments: '{"command":"echo"}' },
+        }],
+      }, {
+        role: "tool",
+        toolCallId: "call-1",
+        toolName: "bash",
+        content: "model-facing",
+        resultRef: {
+          type: "cf-harness.tool-result-ref",
+          outputId,
+          toolId: "bash",
+          runId: "run",
+          artifactPath,
+        },
+      }];
+      const locations = [{ artifactPath, jsonPointer: "/stdout" }];
+      const joined = consoleRunSteps(
+        transcript,
+        [],
+        [],
+        [],
+        {
+          type: "cf-harness.transcript-omissions",
+          version: 1,
+          results: [{
+            transcriptIndex: 1,
+            toolCallId: "call-1",
+            toolId: "bash",
+            outputId,
+            rules: [{ rule: "artifact-only", locations }, {
+              rule: "observation-denied",
+              locations,
+            }],
+          }],
+        },
+        [{ artifactPath, value: { stdout: "PLANTED-SECRET" } }],
+      );
+      const text = templateText(withheldView(joined[0]));
+
+      expect(text.match(/\[redacted by CFC\]/g)).toHaveLength(2);
+      expect(text).not.toContain("PLANTED-SECRET");
+    });
+  });
+
+  describe("ConsoleSteps", () => {
+    class TestConsoleSteps extends ConsoleSteps {
+      view() {
+        return this.render();
+      }
+    }
+
+    it("renders the model-facing result beside its retrospective context", () => {
+      const outputId = createToolOutputId("run", "run_pattern", 1);
+      const token = "cfh:a:abcde";
+      const handle: ConsoleHandle = {
+        token,
+        ref: "/of:fid1:cell",
+        introducedAtStep: 0,
+        producedByStep: 0,
+        uses: [],
+        confidentiality: [],
+      };
+      const step: ConsoleStep = {
+        index: 0,
+        kind: "tool",
+        toolName: "run_pattern",
+        toolCallId: "call-1",
+        input: { sourceText: "marker", input: token, count: 2 },
+        sourceReplacedByLaterAttempt: true,
+        output: { status: "ok", value: 4 },
+        resultRef: {
+          type: "cf-harness.tool-result-ref",
+          outputId,
+          toolId: "run_pattern",
+          runId: "run",
+        },
+        childRunId: "run.subagent.1",
+        handlesIntroduced: [token],
+        handlesInScope: [token],
+        status: "ok",
+        policy: {
+          decision: "allowed",
+          effectClass: "side-effect",
+          reasonCodes: ["direct-command"],
+        },
+        policyEvents: [{
+          type: "cf-harness.policy-event",
+          severity: "warning",
+          mode: "observe",
+          toolId: "run_pattern",
+          toolCallId: "call-1",
+          detail: "observed",
+          at: "2026-01-01T00:00:00.000Z",
+        }],
+        disclosure: {
+          valueBytes: 1_024,
+          sealedPositions: 1,
+          longestNumericRun: 32,
+        },
+        withheld: {
+          status: "recorded",
+          locations: [{
+            rule: "artifact-only",
+            artifactPath: "/run/output.json",
+            jsonPointer: "/rawValue",
+            value: "retained",
+            available: true,
+          }],
+        },
+        invocation: {
+          type: "cf-harness.cfc-invocation-context",
+          version: 1,
+          sequence: 1,
+          runId: "run",
+          createdAt: "2026-01-01T00:00:00.000Z",
+          toolId: "run_pattern",
+          toolOutputId: outputId,
+          operation: "command",
+          cfcEnforcementMode: "observe",
+          cwd: "/workspace",
+          runManifest: { present: false },
+          inputs: {},
+          cfcInputLabels: {
+            version: 1,
+            entries: [{
+              path: ["count"],
+              label: {
+                confidentiality: [{ type: "Secret" }],
+                integrity: [{ type: "Trusted" }],
+              },
+            }],
+          },
+        },
+      };
+      const view = new TestConsoleSteps();
+      view.steps = [step];
+      view.handles = [handle];
+
+      const text = templateText(view.view());
+      expect(text).toContain("Source replaced by a later attempt");
+      expect(text).toContain("run-pattern-source sidecar");
+      expect(text).toContain("retained");
+      expect(text).toContain("longest numeric run 32");
+      expect(text).toContain("Open subagent run");
     });
   });
 });

--- a/packages/cf-harness/test/console/steps.test.ts
+++ b/packages/cf-harness/test/console/steps.test.ts
@@ -95,6 +95,18 @@ describe("console/steps", () => {
       expect(steps[1].output).toEqual({ status: "ok" });
     });
 
+    it("marks a run-pattern source replaced by a later attempt", () => {
+      const steps = consoleRunSteps([
+        call("c1", "run_pattern", {
+          sourceText:
+            "[cf-harness: superseded run_pattern source collapsed for model context; attempt 1, 999 characters. The newest run_pattern call carries the source to edit; this attempt's source is preserved in tool output run:run_pattern:1.]",
+        }),
+        result("c1", "run_pattern", { status: "compile-error" }),
+      ]);
+
+      expect(steps[0].sourceReplacedByLaterAttempt).toBe(true);
+    });
+
     it("keeps an assistant message that carries text alongside its calls", () => {
       const steps = consoleRunSteps([
         { role: "assistant", content: "thinking out loud", toolCalls: [] },
@@ -112,6 +124,311 @@ describe("console/steps", () => {
       expect(steps[0].inputText).toBe("{not json");
       expect(steps[0].output).toBeUndefined();
       expect(steps[0].outputText).toBe("plain output");
+    });
+
+    it("joins recorded omissions to full tool-output positions", () => {
+      const outputId = createToolOutputId("run", "run_pattern", 1);
+      const artifactPath = "/moved/run/tool-outputs/result.json";
+      const transcript: HarnessTranscriptMessage[] = [
+        call("c1", "run_pattern", { sourceText: "x" }),
+        {
+          role: "tool",
+          toolCallId: "c1",
+          toolName: "run_pattern",
+          content: JSON.stringify({ status: "compile-error" }),
+          resultRef: {
+            type: "cf-harness.tool-result-ref",
+            outputId,
+            toolId: "run_pattern",
+            runId: "run",
+            artifactPath: "/original/run/tool-outputs/result.json",
+          },
+        },
+      ];
+      const rawDiagnostic =
+        "Failure in fid1:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+      const steps = consoleRunSteps(
+        transcript,
+        [],
+        [],
+        [],
+        {
+          type: "cf-harness.transcript-omissions",
+          version: 1,
+          results: [{
+            transcriptIndex: 1,
+            toolCallId: "c1",
+            toolId: "run_pattern",
+            outputId,
+            rules: [{
+              rule: "artifact-only",
+              locations: [{
+                artifactPath: "/original/run/tool-outputs/result.json",
+                jsonPointer: "/rawValue",
+              }],
+            }, {
+              rule: "bare-fabric-identifier-scrub",
+              locations: [{
+                artifactPath: "/original/run/tool-outputs/result.json",
+                jsonPointer: "/message",
+              }],
+            }, {
+              rule: "superseded-run-pattern-diagnostic-collapse",
+              locations: [{
+                artifactPath: "/original/run/tool-outputs/result.json",
+                jsonPointer: "/diagnostic",
+              }],
+            }, {
+              rule: "bare-fabric-identifier-scrub",
+              locations: [{
+                artifactPath: "/original/run/tool-outputs/result.json",
+                jsonPointer: "/schema/properties",
+              }],
+            }],
+          }],
+        },
+        [{
+          artifactPath,
+          value: {
+            status: "compile-error",
+            rawValue: { retained: true },
+            message: rawDiagnostic,
+            diagnostic: rawDiagnostic,
+            schema: {
+              properties: {
+                "did:key:z6MkSecret": { type: "string" },
+              },
+            },
+          },
+        }],
+      );
+
+      expect(steps[0].withheld.status).toBe("recorded");
+      expect(steps[0].withheld.locations[0].value).toEqual({ retained: true });
+      expect(steps[0].withheld.locations[1].redaction).toBe(
+        "Failure in [fabric-id]",
+      );
+      expect(steps[0].withheld.locations[2].value).toBe(rawDiagnostic);
+      expect(steps[0].withheld.locations[3].value).toEqual({
+        "[fabric-id]": { type: "string" },
+      });
+    });
+
+    it("reports a legacy tool result as unrecorded", () => {
+      const steps = consoleRunSteps([
+        call("c1", "bash", { command: "pwd" }),
+        result("c1", "bash", { status: "ok" }),
+      ]);
+      expect(steps[0].withheld).toEqual({
+        status: "unrecorded",
+        locations: [],
+      });
+    });
+
+    it("distinguishes unreadable and incomplete omission records", () => {
+      const transcript = [
+        call("c1", "bash", { command: "pwd" }),
+        result("c1", "bash", { status: "ok" }),
+      ];
+      const unreadable = consoleRunSteps(
+        transcript,
+        [],
+        [],
+        [],
+        { status: "unreadable" },
+      );
+      const incomplete = consoleRunSteps(
+        transcript,
+        [],
+        [],
+        [],
+        {
+          status: "present",
+          value: {
+            type: "cf-harness.transcript-omissions",
+            version: 1,
+            results: [],
+          },
+        },
+      );
+
+      expect(unreadable[0].withheld.status).toBe("record-unreadable");
+      expect(incomplete[0].withheld.status).toBe("record-entry-missing");
+    });
+
+    it("reports root, array, and unavailable artifact positions honestly", () => {
+      const outputId = createToolOutputId("run", "bash", 1);
+      const artifactPath = "/run/tool-outputs/bash.json";
+      const transcript: HarnessTranscriptMessage[] = [
+        call("c1", "bash", { command: "echo" }),
+        {
+          role: "tool",
+          toolCallId: "c1",
+          toolName: "bash",
+          content: "model-facing",
+          resultRef: {
+            type: "cf-harness.tool-result-ref",
+            outputId,
+            toolId: "bash",
+            runId: "run",
+            artifactPath,
+          },
+        },
+      ];
+      const locations = ["", "/items/0", "/items/no", "not-a-pointer"];
+      const steps = consoleRunSteps(
+        transcript,
+        [],
+        [],
+        [],
+        {
+          type: "cf-harness.transcript-omissions",
+          version: 1,
+          results: [{
+            transcriptIndex: 1,
+            toolCallId: "c1",
+            toolId: "bash",
+            outputId,
+            rules: [{
+              rule: "artifact-only",
+              locations: locations.map((jsonPointer) => ({
+                artifactPath,
+                jsonPointer,
+              })),
+            }, {
+              rule: "observation-denied",
+              locations: [{
+                artifactPath: "/run/tool-outputs/missing.json",
+                jsonPointer: "/stderr",
+              }],
+            }, {
+              rule: "bare-fabric-identifier-scrub",
+              locations: [{
+                artifactPath: "/run/tool-outputs/missing.json",
+                jsonPointer: "/message",
+              }],
+            }],
+          }],
+        },
+        [{ artifactPath, value: { items: ["first"] } }],
+      );
+
+      expect(steps[0].withheld.locations.map((location) => ({
+        available: location.available,
+        value: location.value,
+        redaction: location.redaction,
+      }))).toEqual([
+        { available: true, value: { items: ["first"] }, redaction: undefined },
+        { available: true, value: "first", redaction: undefined },
+        { available: false, value: undefined, redaction: undefined },
+        { available: false, value: undefined, redaction: undefined },
+        {
+          available: false,
+          value: undefined,
+          redaction: "[redacted by CFC]",
+        },
+        { available: false, value: undefined, redaction: "[fabric-id]" },
+      ]);
+    });
+
+    it("redacts an available denied value for every overlapping rule", () => {
+      const outputId = createToolOutputId("run", "bash", 1);
+      const artifactPath = "/run/tool-outputs/bash.json";
+      const transcript: HarnessTranscriptMessage[] = [
+        call("c1", "bash", { command: "echo" }),
+        {
+          role: "tool",
+          toolCallId: "c1",
+          toolName: "bash",
+          content: "model-facing",
+          resultRef: {
+            type: "cf-harness.tool-result-ref",
+            outputId,
+            toolId: "bash",
+            runId: "run",
+            artifactPath,
+          },
+        },
+      ];
+      const locations = [{ artifactPath, jsonPointer: "/stdout" }];
+      const steps = consoleRunSteps(
+        transcript,
+        [],
+        [],
+        [],
+        {
+          type: "cf-harness.transcript-omissions",
+          version: 1,
+          results: [{
+            transcriptIndex: 1,
+            toolCallId: "c1",
+            toolId: "bash",
+            outputId,
+            rules: [{ rule: "artifact-only", locations }, {
+              rule: "observation-denied",
+              locations,
+            }],
+          }],
+        },
+        [{ artifactPath, value: { stdout: "PLANTED-SECRET" } }],
+      );
+
+      expect(steps[0].withheld.locations).toHaveLength(2);
+      expect(
+        steps[0].withheld.locations.every((location) =>
+          location.redaction === "[redacted by CFC]" &&
+          location.value === undefined
+        ),
+      ).toBe(true);
+      expect(JSON.stringify(steps[0].withheld)).not.toContain("PLANTED-SECRET");
+    });
+
+    it("does not join an omission record whose transcript identity differs", () => {
+      const outputId = createToolOutputId("run", "bash", 1);
+      const artifactPath = "/run/tool-outputs/bash.json";
+      const transcript: HarnessTranscriptMessage[] = [
+        call("c1", "bash", { command: "echo" }),
+        {
+          role: "tool",
+          toolCallId: "c1",
+          toolName: "bash",
+          content: "model-facing",
+          resultRef: {
+            type: "cf-harness.tool-result-ref",
+            outputId,
+            toolId: "bash",
+            runId: "run",
+            artifactPath,
+          },
+        },
+      ];
+      const steps = consoleRunSteps(
+        transcript,
+        [],
+        [],
+        [],
+        {
+          type: "cf-harness.transcript-omissions",
+          version: 1,
+          results: [{
+            transcriptIndex: 0,
+            toolCallId: "another-call",
+            toolId: "bash",
+            outputId,
+            rules: [{
+              rule: "artifact-only",
+              locations: [{ artifactPath, jsonPointer: "/stdout" }],
+            }],
+          }],
+        },
+        [{ artifactPath, value: { stdout: "PLANTED-SECRET" } }],
+      );
+
+      expect(steps[0].withheld).toEqual({
+        status: "record-entry-missing",
+        locations: [],
+      });
+      expect(JSON.stringify(steps[0].withheld)).not.toContain("PLANTED-SECRET");
     });
 
     it("names the child a delegate_task step started", () => {

--- a/packages/cf-harness/test/describe-handle.test.ts
+++ b/packages/cf-harness/test/describe-handle.test.ts
@@ -15,6 +15,8 @@ import { PiecesController } from "@commonfabric/piece/ops";
 import { Runtime } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { normalize } from "@std/path/posix";
+import { join } from "@std/path";
+import { createFileSystemHarnessArtifactStore } from "../src/artifacts.ts";
 import { CAPABILITY_PROBE_SENTINEL } from "../src/diagnostics.ts";
 import { CfHarnessEngine } from "../src/engine.ts";
 import { CfHarnessPromptLoop } from "../src/prompt-loop.ts";
@@ -880,102 +882,146 @@ describe("describe_handle", () => {
       // down, so a scrub that reached only the reply's top-level strings
       // would leave them standing.
       const runId = "run-describe-scrub";
-      const minted = await mintAddressHandle(
-        createHarnessHandleTable(runId),
-        REF_A,
-        {
-          schema: {
-            type: "object",
-            properties: {
-              rows: {
-                type: "array",
-                items: {
-                  type: "object",
-                  properties: { [HOSTILE_DID_NAME]: { type: "string" } },
+      const artifactRoot = await Deno.makeTempDir();
+      const artifactStore = createFileSystemHarnessArtifactStore({
+        artifactRoot,
+        runId,
+      });
+      try {
+        const minted = await mintAddressHandle(
+          createHarnessHandleTable(runId),
+          REF_A,
+          {
+            schema: {
+              type: "object",
+              properties: {
+                rows: {
+                  type: "array",
+                  items: {
+                    type: "object",
+                    properties: { [HOSTILE_DID_NAME]: { type: "string" } },
+                  },
                 },
-              },
-              report: {
-                type: "object",
-                properties: { [HOSTILE_HASH_NAME]: { type: "number" } },
+                report: {
+                  type: "object",
+                  properties: { [HOSTILE_HASH_NAME]: { type: "number" } },
+                },
               },
             },
           },
-        },
-      );
-      let calls = 0;
-      const fetchFn: typeof fetch = () => {
-        calls += 1;
-        const payload = calls === 1
-          ? {
-            choices: [{
-              index: 0,
-              message: {
-                role: "assistant",
-                content: "",
-                tool_calls: [{
-                  id: "call-1",
-                  type: "function",
-                  function: {
-                    name: "describe_handle",
-                    arguments: JSON.stringify({ token: minted.token }),
-                  },
-                }],
-              },
-            }],
-          }
-          : {
-            choices: [{
-              index: 0,
-              message: { role: "assistant", content: "Done." },
-            }],
-          };
-        return Promise.resolve(
-          new Response(JSON.stringify(responsesBodyFromChatFixture(payload)), {
-            status: 200,
-          }),
         );
-      };
-      const loop = new CfHarnessPromptLoop({
-        apiKey: "test-key",
-        engine: new CfHarnessEngine({
-          sandboxRuntime: new FakeSandboxRuntime(),
-          runState: createHarnessRunState({
-            runId,
-            cfcEnforcementMode: "disabled",
-            currentDir: "/workspace",
-            model: "gpt-5.4",
-            handleTable: minted.table,
+        let calls = 0;
+        const fetchFn: typeof fetch = () => {
+          calls += 1;
+          const payload = calls === 1
+            ? {
+              choices: [{
+                index: 0,
+                message: {
+                  role: "assistant",
+                  content: "",
+                  tool_calls: [{
+                    id: "call-1",
+                    type: "function",
+                    function: {
+                      name: "describe_handle",
+                      arguments: JSON.stringify({ token: minted.token }),
+                    },
+                  }],
+                },
+              }],
+            }
+            : {
+              choices: [{
+                index: 0,
+                message: { role: "assistant", content: "Done." },
+              }],
+            };
+          return Promise.resolve(
+            new Response(
+              JSON.stringify(responsesBodyFromChatFixture(payload)),
+              {
+                status: 200,
+              },
+            ),
+          );
+        };
+        const loop = new CfHarnessPromptLoop({
+          apiKey: "test-key",
+          engine: new CfHarnessEngine({
+            sandboxRuntime: new FakeSandboxRuntime(),
+            artifactStore,
+            runState: createHarnessRunState({
+              runId,
+              cfcEnforcementMode: "disabled",
+              currentDir: "/workspace",
+              model: "gpt-5.4",
+              handleTable: minted.table,
+            }),
           }),
-        }),
-        fetchFn,
-      });
+          fetchFn,
+        });
 
-      const result = await loop.runTranscript({
-        transcript: [{ role: "user", content: "Describe the handle." }],
-        model: "gpt-5.4",
-      });
+        const result = await loop.runTranscript({
+          transcript: [{ role: "user", content: "Describe the handle." }],
+          model: "gpt-5.4",
+        });
 
-      const toolMessage = result.transcript.find(
-        (message) => message.role === "tool",
-      );
-      expect(toolMessage?.content).toBeDefined();
-      const content = toolMessage!.content!;
-      const parsed = JSON.parse(content) as {
-        schema: {
-          properties: {
-            rows: { items: { properties: Record<string, unknown> } };
-            report: { properties: Record<string, unknown> };
+        const toolMessage = result.transcript.find(
+          (message) => message.role === "tool",
+        );
+        expect(toolMessage?.content).toBeDefined();
+        const content = toolMessage!.content!;
+        const parsed = JSON.parse(content) as {
+          schema: {
+            properties: {
+              rows: { items: { properties: Record<string, unknown> } };
+              report: { properties: Record<string, unknown> };
+            };
           };
         };
-      };
-      expect(Object.keys(parsed.schema.properties.rows.items.properties))
-        .toEqual(["[fabric-id]"]);
-      expect(Object.keys(parsed.schema.properties.report.properties))
-        .toEqual(["[fabric-id]"]);
-      // Stated again over the whole reply, so an identifier that escapes into
-      // some other field fails this too.
-      expect(content).not.toContain("did:key:");
-      expect(content).not.toContain(SCRUB_HASH);
+        expect(Object.keys(parsed.schema.properties.rows.items.properties))
+          .toEqual(["[fabric-id]"]);
+        expect(Object.keys(parsed.schema.properties.report.properties))
+          .toEqual(["[fabric-id]"]);
+        // Stated again over the whole reply, so an identifier that escapes into
+        // some other field fails this too.
+        expect(content).not.toContain("did:key:");
+        expect(content).not.toContain(SCRUB_HASH);
+        const omissionText = await Deno.readTextFile(
+          join(artifactStore.runRoot, "transcript-omissions.json"),
+        );
+        expect(omissionText).not.toContain(HOSTILE_DID_NAME);
+        expect(omissionText).not.toContain(HOSTILE_HASH_NAME);
+        const omissionRecord = JSON.parse(omissionText) as {
+          results: Array<{
+            rules: Array<{
+              rule: string;
+              locations: Array<{ jsonPointer: string }>;
+            }>;
+          }>;
+        };
+        expect(omissionRecord.results[0].rules).toEqual([{
+          rule: "bare-fabric-identifier-scrub",
+          locations: [{
+            artifactPath: join(
+              artifactStore.runRoot,
+              "tool-outputs",
+              `${runId}_describe_handle_1-describe_handle.json`,
+            ),
+            jsonPointer: "/schema/properties/rows/items/properties",
+          }, {
+            artifactPath: join(
+              artifactStore.runRoot,
+              "tool-outputs",
+              `${runId}_describe_handle_1-describe_handle.json`,
+            ),
+            jsonPointer: "/schema/properties/report/properties",
+          }],
+        }]);
+      } finally {
+        await Deno.remove(artifactRoot, { recursive: true });
+      }
     });
 
     it("swaps a disclosed property name that is a link for a handle token", async () => {

--- a/packages/cf-harness/test/prompt-loop-run-pattern.test.ts
+++ b/packages/cf-harness/test/prompt-loop-run-pattern.test.ts
@@ -16,7 +16,11 @@ import { PiecesController } from "@commonfabric/piece/ops";
 import { Runtime } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 
-import type { HarnessArtifactStore } from "../src/artifacts.ts";
+import {
+  FileSystemHarnessArtifactStore,
+  type HarnessArtifactStore,
+} from "../src/artifacts.ts";
+import type { HarnessTranscriptOmissions } from "../src/contracts/transcript-omissions.ts";
 import type { HarnessTranscriptMessage } from "../src/contracts/transcript.ts";
 import { CAPABILITY_PROBE_SENTINEL } from "../src/diagnostics.ts";
 import { CfHarnessEngine } from "../src/engine.ts";
@@ -28,7 +32,7 @@ import type {
   SandboxRuntimeDescription,
   SandboxShellRequest,
 } from "../src/sandbox/types.ts";
-import { scrubBareFabricIdentifiers } from "../src/tools/run-pattern.ts";
+import { scrubBareFabricIdentifiers } from "../src/fabric-identifier-scrub.ts";
 import { responsesBodyFromChatFixture } from "./support/responses-fixture.ts";
 
 class FakeSandboxRuntime implements SandboxRuntime {
@@ -124,6 +128,19 @@ class RecordingArtifactStore implements HarnessArtifactStore {
   }
 }
 
+/** Filesystem store that also snapshots each transcript after its real write. */
+class RecordingFileArtifactStore extends FileSystemHarnessArtifactStore {
+  readonly transcripts: HarnessTranscriptMessage[][] = [];
+
+  override async persistTranscript(
+    transcript: readonly HarnessTranscriptMessage[],
+  ): Promise<string> {
+    const path = await super.persistTranscript(transcript);
+    this.transcripts.push(structuredClone([...transcript]));
+    return path;
+  }
+}
+
 describe("prompt-loop run_pattern model boundary", () => {
   describe("scrubBareFabricIdentifiers()", () => {
     it("replaces bare tagged hashes, DIDs, and data URIs with the placeholder", () => {
@@ -134,6 +151,8 @@ describe("prompt-loop run_pattern model boundary", () => {
       expect(scrubBareFabricIdentifiers("space did:key:z6MkfffTest denied"))
         .toBe("space [fabric-id] denied");
       expect(scrubBareFabricIdentifiers("at data:application/json;base64,AAAA"))
+        .toBe("at [fabric-id]");
+      expect(scrubBareFabricIdentifiers("at DATA:text/plain;base64,AAAA"))
         .toBe("at [fabric-id]");
     });
 
@@ -549,6 +568,7 @@ describe("prompt-loop run_pattern model boundary", () => {
   });
 
   it("collapses the superseded compile diagnostic when a second run_pattern failure arrives", async () => {
+    const artifactRoot = await Deno.makeTempDir();
     const signer = await Identity.fromPassphrase("run-pattern collapse");
     const storageManager = StorageManager.emulate({ as: signer });
     const fabricRuntime = new Runtime({
@@ -565,10 +585,16 @@ describe("prompt-loop run_pattern model boundary", () => {
     await pieces.synced();
     try {
       const runId = "run-pattern-collapse";
-      const artifactStore = new RecordingArtifactStore(runId);
+      const artifactStore = new RecordingFileArtifactStore({
+        artifactRoot,
+        runId,
+      });
+      // The long missing-module name keeps the raw diagnostic larger than its
+      // collapse marker while contributing a Fabric id for the prior scrub.
       const brokenSource = (missing: string) =>
         [
           "import { computed, pattern } from 'commonfabric';",
+          `import { helper } from './${missing}-${"x".repeat(2_000)}.ts';`,
           "export default pattern<{ n: number }, { doubled: number }>(",
           `  ({ n }) => ({ doubled: computed(() => ${missing}(n)) }),`,
           ");",
@@ -640,7 +666,7 @@ describe("prompt-loop run_pattern model boundary", () => {
         "superseded run_pattern diagnostic collapsed",
       );
       expect(contents[0].message).toContain(
-        "attempt 1, compile-error, 2 errors:",
+        "attempt 1, compile-error, first line:",
       );
       expect(contents[0].messageOriginalLength).toBeGreaterThan(
         contents[0].message.length,
@@ -665,15 +691,50 @@ describe("prompt-loop run_pattern model boundary", () => {
         "superseded run_pattern diagnostic collapsed",
       );
       // Both diagnostics stay whole in the tool-output artifacts.
-      const outputs = artifactStore.toolOutputs
-        .filter((entry) => entry.toolId === "run_pattern")
-        .map((entry) => (entry.output as { message: string }).message);
+      const outputs = await Promise.all(
+        result.runState.toolOutputs
+          .filter((entry) => entry.toolId === "run_pattern")
+          .map(async (entry) =>
+            (JSON.parse(await Deno.readTextFile(entry.artifactPath!)) as {
+              message: string;
+            }).message
+          ),
+      );
       expect(outputs.length).toBe(2);
       expect(outputs[0]).toContain("missing-1");
       expect(outputs[1]).toContain("missing-2");
+
+      const omissions = JSON.parse(
+        await Deno.readTextFile(
+          `${artifactStore.runRoot}/transcript-omissions.json`,
+        ),
+      ) as HarnessTranscriptOmissions;
+      const firstResult = omissions.results.find((entry) =>
+        entry.outputId === result.runState.toolOutputs[0].outputId
+      );
+      expect(firstResult).toEqual({
+        transcriptIndex: 2,
+        toolCallId: "call-1",
+        toolId: "run_pattern",
+        outputId: result.runState.toolOutputs[0].outputId,
+        rules: [{
+          rule: "bare-fabric-identifier-scrub",
+          locations: [{
+            artifactPath: result.runState.toolOutputs[0].artifactPath,
+            jsonPointer: "/message",
+          }],
+        }, {
+          rule: "superseded-run-pattern-diagnostic-collapse",
+          locations: [{
+            artifactPath: result.runState.toolOutputs[0].artifactPath,
+            jsonPointer: "/message",
+          }],
+        }],
+      });
     } finally {
       await fabricRuntime.dispose();
       await storageManager.close();
+      await Deno.remove(artifactRoot, { recursive: true });
     }
   });
 

--- a/packages/cf-harness/test/prompt-loop.test.ts
+++ b/packages/cf-harness/test/prompt-loop.test.ts
@@ -11,7 +11,10 @@ import { normalize } from "@std/path/posix";
 
 import type { CfcSandboxResult } from "@commonfabric/runner/cfc";
 
-import type { HarnessArtifactStore } from "../src/artifacts.ts";
+import {
+  createFileSystemHarnessArtifactStore,
+  type HarnessArtifactStore,
+} from "../src/artifacts.ts";
 import { InMemoryHarnessCredentialStore } from "../src/auth/credential-store.ts";
 import { OpenAICodexCredentialResolver } from "../src/auth/openai-codex.ts";
 import {
@@ -20,6 +23,7 @@ import {
 } from "../src/contracts/prompt-slot.ts";
 import type { HarnessSkillActivations } from "../src/contracts/skill.ts";
 import { createToolOutputId } from "../src/contracts/tool-result.ts";
+import type { HarnessTranscriptOmissions } from "../src/contracts/transcript-omissions.ts";
 import { CAPABILITY_PROBE_SENTINEL } from "../src/diagnostics.ts";
 import { CfHarnessEngine } from "../src/engine.ts";
 import {
@@ -1004,6 +1008,8 @@ const observedCfcResult = (
     stdoutLabel?: CfcSandboxResult["stdout"]["label"];
     stderrLabel?: CfcSandboxResult["stderr"]["label"];
     exitCodeLabel?: CfcSandboxResult["exitCode"]["label"];
+    stdoutTruncated?: boolean;
+    stderrTruncated?: boolean;
   } = {},
 ): CfcSandboxResult => ({
   version: 1,
@@ -1015,6 +1021,7 @@ const observedCfcResult = (
       text: stdout,
       label: options.stdoutLabel ?? { confidentiality: ["public"] },
     }],
+    ...(options.stdoutTruncated === true ? { truncated: true } : {}),
   },
   stderr: options.stderrPolicy === "denied"
     ? {
@@ -1031,6 +1038,7 @@ const observedCfcResult = (
         text: options.stderr ?? "",
         label: options.stderrLabel ?? { confidentiality: ["public"] },
       }],
+      ...(options.stderrTruncated === true ? { truncated: true } : {}),
     },
   exitCode: {
     policy: "observed",
@@ -5490,6 +5498,113 @@ Deno.test("CfHarnessPromptLoop truncates large model-facing bash output in obser
   assertEquals(content.exitCode, 0);
 });
 
+Deno.test("CfHarnessPromptLoop retains omission records across provider compaction", async () => {
+  const artifactRoot = await Deno.makeTempDir();
+  const runId = "run-omission-compaction";
+  const hugeStdout = "private".repeat(20_000);
+  const requestBodies: Array<Record<string, unknown>> = [];
+  let turns = 0;
+  try {
+    const artifactStore = createFileSystemHarnessArtifactStore({
+      artifactRoot,
+      runId,
+    });
+    const loop = new CfHarnessPromptLoop({
+      apiKey: "test-key",
+      engine: new CfHarnessEngine({
+        sandboxRuntime: new FakeSandboxRuntime([
+          { stdout: hugeStdout, stderr: "", exitCode: 0 },
+          { stdout: "second\n", stderr: "", exitCode: 0 },
+        ]),
+        artifactStore,
+        runId,
+        model: "gpt-5.4",
+        cfcEnforcementMode: "disabled",
+      }),
+      fetchFn: (_input, init) => {
+        turns += 1;
+        requestBodies.push(JSON.parse(String(init?.body)));
+        const output = turns === 1
+          ? [{
+            type: "function_call",
+            id: "fc-first",
+            call_id: "call-first",
+            name: "bash",
+            arguments: JSON.stringify({ command: "first" }),
+          }]
+          : turns === 2
+          ? [{
+            type: "compaction",
+            id: "cmp-after-first",
+            encrypted_content: "encrypted-compaction",
+          }, {
+            type: "function_call",
+            id: "fc-second",
+            call_id: "call-second",
+            name: "bash",
+            arguments: JSON.stringify({ command: "second" }),
+          }]
+          : [{
+            type: "message",
+            id: "msg-done",
+            role: "assistant",
+            status: "completed",
+            content: [{
+              type: "output_text",
+              text: "Done.",
+              annotations: [],
+            }],
+          }];
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              object: "response",
+              status: "completed",
+              output,
+            }),
+            { status: 200 },
+          ),
+        );
+      },
+    });
+
+    await loop.runPrompt({
+      prompt: "Run both commands.",
+      promptSlotBinding: directPromptSlotBinding,
+    });
+
+    const thirdInput = requestBodies[2].input as Array<Record<string, unknown>>;
+    assertEquals(thirdInput[0]?.type, "compaction");
+    assertEquals(
+      JSON.stringify(thirdInput).includes(
+        createToolOutputId(runId, "bash", 1),
+      ),
+      false,
+    );
+    const omissions = JSON.parse(
+      await Deno.readTextFile(
+        join(artifactStore.runRoot, "transcript-omissions.json"),
+      ),
+    ) as HarnessTranscriptOmissions;
+    const first = omissions.results.find((result) =>
+      result.outputId === createToolOutputId(runId, "bash", 1)
+    );
+    assertEquals(first?.rules, [{
+      rule: "model-context-truncation",
+      locations: [{
+        artifactPath: join(
+          artifactStore.runRoot,
+          "tool-outputs",
+          `${runId}_bash_1-bash.json`,
+        ),
+        jsonPointer: "/stdout",
+      }],
+    }]);
+  } finally {
+    await Deno.remove(artifactRoot, { recursive: true });
+  }
+});
+
 Deno.test("CfHarnessPromptLoop bounds a large model-facing read_file result more tightly than bash output", async () => {
   const fetchCalls: RequestInit[] = [];
   const document = `${"a".repeat(20_000)}MIDDLE${"z".repeat(20_000)}`;
@@ -6011,6 +6126,84 @@ Deno.test("CfHarnessPromptLoop exposes mediated bash output instead of raw stdou
   assertEquals(content.exitCode, 0);
   assertEquals(content.cfc.stdout.policy, "observed");
   assertEquals(content.cfc.stderr.policy, "denied");
+});
+
+Deno.test("CfHarnessPromptLoop records CFC-side stream truncation as a model omission", async () => {
+  const artifactRoot = await Deno.makeTempDir();
+  const runId = "run-mediated-cfc-truncation";
+  try {
+    const artifactStore = createFileSystemHarnessArtifactStore({
+      artifactRoot,
+      runId,
+    });
+    let turn = 0;
+    const loop = new CfHarnessPromptLoop({
+      apiKey: "test-key",
+      engine: new CfHarnessEngine({
+        artifactStore,
+        sandboxRuntime: new FakeSandboxRuntime([{
+          stdout: "raw stdout\n",
+          stderr: "raw stderr\n",
+          exitCode: 0,
+          cfcResult: observedCfcResult("released stdout\n", {
+            stderr: "released stderr\n",
+            stdoutTruncated: true,
+            stderrTruncated: true,
+          }),
+        }]),
+        runId,
+        model: "gpt-5.4",
+        cfcEnforcementMode: "enforce-explicit",
+      }),
+      fetchFn: () => {
+        turn += 1;
+        const message = turn === 1
+          ? {
+            role: "assistant",
+            content: "",
+            tool_calls: [{
+              id: "call-truncated-cfc-result",
+              type: "function",
+              function: {
+                name: "bash",
+                arguments: JSON.stringify({ command: "show partial output" }),
+              },
+            }],
+          }
+          : { role: "assistant", content: "Done." };
+        return Promise.resolve(
+          new Response(JSON.stringify(
+            responsesBodyFromChatFixture({ choices: [{ index: 0, message }] }),
+          )),
+        );
+      },
+    });
+
+    await loop.runPrompt({
+      prompt: "Run a direct command.",
+      promptSlotBinding: directPromptSlotBinding,
+    });
+
+    const omissions = JSON.parse(
+      await Deno.readTextFile(
+        join(artifactStore.runRoot, "transcript-omissions.json"),
+      ),
+    ) as HarnessTranscriptOmissions;
+    assertEquals(omissions.results.length, 1);
+    assertEquals(omissions.results[0].rules, [{
+      rule: "model-context-truncation",
+      locations: ["/stdout", "/stderr"].map((jsonPointer) => ({
+        artifactPath: join(
+          artifactStore.runRoot,
+          "tool-outputs",
+          `${runId}_bash_1-bash.json`,
+        ),
+        jsonPointer,
+      })),
+    }]);
+  } finally {
+    await Deno.remove(artifactRoot, { recursive: true });
+  }
 });
 
 const labelHasConfidentialityValue = (

--- a/packages/cf-harness/test/query-docs.test.ts
+++ b/packages/cf-harness/test/query-docs.test.ts
@@ -8,6 +8,8 @@ import { expect } from "@std/expect";
 import { join, normalize } from "@std/path/posix";
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 
+import { createFileSystemHarnessArtifactStore } from "../src/artifacts.ts";
+import type { HarnessTranscriptOmissions } from "../src/contracts/transcript-omissions.ts";
 import { CfHarnessEngine } from "../src/engine.ts";
 import { checkoutDocsCorpusRoots } from "../src/docs-corpus/corpus.ts";
 import { parentToolIdsForBacking } from "../src/contracts/tool-descriptor.ts";
@@ -34,8 +36,10 @@ import {
 } from "../src/docs-corpus/explore.ts";
 import type {
   HarnessModelAttemptDiagnostic,
+  HarnessModelClient,
   HarnessModelUsage,
 } from "../src/model/client.ts";
+import { CfHarnessPromptLoop } from "../src/prompt-loop.ts";
 import { queryDocsToolDescriptor } from "../src/tools/query-docs.ts";
 import type {
   QueryDocsToolAnswerOutput,
@@ -318,6 +322,105 @@ describe("query-docs", () => {
       const output = result.output as QueryDocsToolAnswerOutput;
 
       expect(output.exploreRecord).toBeUndefined();
+    });
+
+    it("keeps the explore turn in the artifact and records its model-boundary omission", async () => {
+      const runId = "query-docs-omission-test";
+      const artifactStore = createFileSystemHarnessArtifactStore({
+        artifactRoot: `${root}/artifacts`,
+        runId,
+      });
+      let turn = 0;
+      const modelClient: HarnessModelClient = {
+        providerId: "test-provider",
+        complete: () => {
+          turn += 1;
+          if (turn === 1) {
+            return Promise.resolve({
+              assistant: {
+                role: "assistant" as const,
+                content: "",
+                toolCalls: [{
+                  id: "call-query-docs",
+                  type: "function" as const,
+                  function: {
+                    name: "query_docs",
+                    arguments: JSON.stringify({ question: "glazing" }),
+                  },
+                }],
+              },
+            });
+          }
+          return Promise.resolve({
+            assistant: {
+              role: "assistant" as const,
+              content: turn === 2
+                ? JSON.stringify({ answer: "Dip once.", citations: [] })
+                : "Done.",
+            },
+          });
+        },
+      };
+      const engine = new CfHarnessEngine({
+        sandboxRuntime: new FakeSandboxRuntime(),
+        artifactStore,
+        runId,
+        model: "test-model",
+        cfcEnforcementMode: "disabled",
+        docsCorpus: {
+          type: "cf-harness.docs-corpus-record",
+          source: "configured",
+          roots: [root],
+        },
+      });
+      const loop = new CfHarnessPromptLoop({
+        engine,
+        modelClient,
+        allowedToolIds: ["query_docs"],
+      });
+
+      const result = await loop.runPrompt({ prompt: "Look up glazing." });
+      const toolMessage = result.transcript.find((message) =>
+        message.role === "tool"
+      );
+      if (toolMessage?.role !== "tool") {
+        throw new Error("expected query_docs tool message");
+      }
+      const modelFacing = JSON.parse(toolMessage.content) as Record<
+        string,
+        unknown
+      >;
+      expect(modelFacing.exploreRecord).toBeUndefined();
+
+      const outputRef = result.runState.toolOutputs[0];
+      if (outputRef?.artifactPath === undefined) {
+        throw new Error("expected persisted query_docs output");
+      }
+      const fullOutput = JSON.parse(
+        await Deno.readTextFile(outputRef.artifactPath),
+      ) as QueryDocsToolAnswerOutput;
+      expect(fullOutput.exploreRecord?.messages).toHaveLength(2);
+      expect(fullOutput.exploreRecord?.messages[1].content).toContain(
+        "Dip the donut once and let it drain.",
+      );
+      const omissions = JSON.parse(
+        await Deno.readTextFile(
+          `${artifactStore.runRoot}/transcript-omissions.json`,
+        ),
+      ) as HarnessTranscriptOmissions;
+      expect(omissions.results).toEqual([{
+        transcriptIndex: 2,
+        toolCallId: "call-query-docs",
+        toolId: "query_docs",
+        outputId: outputRef.outputId,
+        rules: [{
+          rule: "artifact-only",
+          locations: [{
+            artifactPath: outputRef.artifactPath,
+            jsonPointer: "/exploreRecord",
+          }],
+        }],
+      }]);
     });
 
     it("refuses when the run configures no corpus root", async () => {

--- a/packages/cf-harness/test/run-pattern-policy-trace.test.ts
+++ b/packages/cf-harness/test/run-pattern-policy-trace.test.ts
@@ -29,6 +29,7 @@ import {
   harnessReleaseDecisionOutcome,
 } from "../src/contracts/policy-refusal.ts";
 import type { HarnessPolicyTrace } from "../src/contracts/policy-trace.ts";
+import type { HarnessTranscriptOmissions } from "../src/contracts/transcript-omissions.ts";
 import { CAPABILITY_PROBE_SENTINEL } from "../src/diagnostics.ts";
 import { CfHarnessEngine } from "../src/engine.ts";
 import { CfHarnessPromptLoop } from "../src/prompt-loop.ts";
@@ -264,6 +265,29 @@ describe("run_pattern release decisions in the policy trace", () => {
       expect(release.resultRef?.toolId).toBe("run_pattern");
       expect(release.resultRef?.artifactPath).toContain("tool-outputs");
       expect(trace.decisionCounts.denied).toBe(1);
+      const releaseRef = release.resultRef;
+      if (releaseRef?.artifactPath === undefined) {
+        throw new Error("expected release decision artifact reference");
+      }
+      const omissions = JSON.parse(
+        await Deno.readTextFile(
+          join(
+            artifactRoot,
+            "run-release-decision",
+            "transcript-omissions.json",
+          ),
+        ),
+      ) as HarnessTranscriptOmissions;
+      const resultOmissions = omissions.results.find((result) =>
+        result.outputId === releaseRef.outputId
+      );
+      expect(
+        resultOmissions?.rules.find((rule) => rule.rule === "artifact-only")
+          ?.locations,
+      ).toContainEqual({
+        artifactPath: releaseRef.artifactPath,
+        jsonPointer: "/releaseDecision",
+      });
     } finally {
       await dispose();
       await Deno.remove(artifactRoot, { recursive: true });

--- a/packages/cf-harness/test/run-pattern.test.ts
+++ b/packages/cf-harness/test/run-pattern.test.ts
@@ -23,6 +23,7 @@ import {
   type FabricPatternInstantiations,
 } from "../src/fabric-instantiations.ts";
 import { comparableEntityHash } from "../src/fabric-observations.ts";
+import { scrubBareFabricIdentifiers } from "../src/fabric-identifier-scrub.ts";
 import { resolveWellKnownGrantRefs } from "../src/well-known-grants.ts";
 import { CAPABILITY_PROBE_SENTINEL } from "../src/diagnostics.ts";
 import {
@@ -33,7 +34,6 @@ import {
   type RunPatternToolErrorOutput,
   type RunPatternToolInput,
   type RunPatternToolSuccessOutput,
-  scrubBareFabricIdentifiers,
 } from "../src/tools/run-pattern.ts";
 import type {
   CfcAddress,

--- a/packages/cf-harness/test/transcript-omissions.test.ts
+++ b/packages/cf-harness/test/transcript-omissions.test.ts
@@ -1,0 +1,203 @@
+/** Unit tests for the durable transcript omission record. */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { join } from "@std/path";
+
+import { createFileSystemHarnessArtifactStore } from "../src/artifacts.ts";
+import {
+  annotateHarnessToolResultOmissions,
+  createHarnessTranscriptOmissionRuleRecord,
+  createHarnessTranscriptOmissions,
+  HARNESS_TRANSCRIPT_OMISSION_RULES,
+  type HarnessTranscriptOmissionRule,
+} from "../src/contracts/transcript-omissions.ts";
+import {
+  createToolOutputId,
+  createToolResultRef,
+} from "../src/contracts/tool-result.ts";
+import type { HarnessToolTranscriptMessage } from "../src/contracts/transcript.ts";
+
+describe("transcript omissions", () => {
+  const runId = "omission-run";
+  const outputId = createToolOutputId(runId, "run_pattern", 1);
+  const artifactPath = "/artifacts/omission-run/tool-outputs/result.json";
+  const resultRef = createToolResultRef(
+    outputId,
+    "run_pattern",
+    runId,
+    artifactPath,
+  );
+
+  const message = (
+    rules: readonly HarnessTranscriptOmissionRule[],
+  ): HarnessToolTranscriptMessage =>
+    annotateHarnessToolResultOmissions(
+      {
+        role: "tool",
+        toolCallId: "call-1",
+        toolName: "run_pattern",
+        content: JSON.stringify({ status: "ok", value: "model-facing" }),
+        resultRef,
+      },
+      rules.flatMap((rule, index) => {
+        const record = createHarnessTranscriptOmissionRuleRecord(
+          rule,
+          resultRef,
+          [`/field-${index}`],
+        );
+        return record === undefined ? [] : [record];
+      }),
+    );
+
+  it("records every model-boundary omission rule for its tool result", () => {
+    const record = createHarnessTranscriptOmissions([
+      { role: "user", content: "Run it." },
+      message(HARNESS_TRANSCRIPT_OMISSION_RULES),
+    ]);
+    expect(record.results).toHaveLength(1);
+    expect(record.results[0].transcriptIndex).toBe(1);
+    expect(record.results[0].rules.map((entry) => entry.rule)).toEqual(
+      HARNESS_TRANSCRIPT_OMISSION_RULES,
+    );
+    expect(record.results[0].rules[0].locations).toEqual([{
+      artifactPath,
+      jsonPointer: "/field-0",
+    }]);
+  });
+
+  it("keeps omission metadata out of serialized provider history", () => {
+    const annotated = message(["artifact-only"]);
+    expect(JSON.parse(JSON.stringify(annotated))).toEqual({
+      role: "tool",
+      toolCallId: "call-1",
+      toolName: "run_pattern",
+      content: JSON.stringify({ status: "ok", value: "model-facing" }),
+      resultRef,
+    });
+  });
+
+  it("records a current tool result with no omissions as known empty", () => {
+    const record = createHarnessTranscriptOmissions([message([])]);
+
+    expect(record.results).toHaveLength(1);
+    expect(record.results[0].rules).toEqual([]);
+  });
+
+  it("does not invent a record for an unannotated legacy result", () => {
+    const record = createHarnessTranscriptOmissions([{
+      role: "tool",
+      toolCallId: "legacy-call",
+      toolName: "run_pattern",
+      content: "legacy model-facing result",
+      resultRef,
+    }]);
+
+    expect(record.results).toEqual([]);
+  });
+
+  it("carries an earlier omission across a replacement tool message", () => {
+    const earlier = message(["bare-fabric-identifier-scrub"]);
+    const collapse = createHarnessTranscriptOmissionRuleRecord(
+      "superseded-run-pattern-diagnostic-collapse",
+      resultRef,
+      ["/message"],
+    )!;
+    const replacement = annotateHarnessToolResultOmissions(
+      { ...earlier, content: JSON.stringify({ messageCollapsed: true }) },
+      [collapse],
+      earlier,
+    );
+
+    expect(
+      createHarnessTranscriptOmissions([replacement]).results[0].rules.map(
+        (entry) => entry.rule,
+      ),
+    ).toEqual([
+      "bare-fabric-identifier-scrub",
+      "superseded-run-pattern-diagnostic-collapse",
+    ]);
+  });
+
+  it("writes locations without copying withheld content", async () => {
+    const root = await Deno.makeTempDir();
+    try {
+      const store = createFileSystemHarnessArtifactStore({
+        artifactRoot: root,
+        runId,
+      });
+      const raw = {
+        outputId,
+        status: "ok",
+        rawValue: "WITHHELD-SENTINEL",
+      };
+      const path = await store.persistToolOutput(
+        "run_pattern",
+        outputId,
+        raw,
+      );
+      const ref = createToolResultRef(
+        outputId,
+        "run_pattern",
+        runId,
+        path,
+      );
+      const omission = createHarnessTranscriptOmissionRuleRecord(
+        "artifact-only",
+        ref,
+        ["/rawValue"],
+      )!;
+      await store.persistTranscript([
+        annotateHarnessToolResultOmissions({
+          role: "tool",
+          toolCallId: "call-1",
+          toolName: "run_pattern",
+          content: JSON.stringify({ outputId, status: "ok" }),
+          resultRef: ref,
+        }, [omission]),
+      ]);
+
+      const recordText = await Deno.readTextFile(
+        join(store.runRoot, "transcript-omissions.json"),
+      );
+      expect(recordText).not.toContain("WITHHELD-SENTINEL");
+      expect(JSON.parse(recordText).results[0].rules).toEqual([{
+        rule: "artifact-only",
+        locations: [{ artifactPath: path, jsonPointer: "/rawValue" }],
+      }]);
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  });
+
+  it("retains prior-process rules when a later write adds another rule", () => {
+    const firstMessage = message(["artifact-only"]);
+    const first = createHarnessTranscriptOmissions([firstMessage]);
+    const secondMessage = message(["model-context-truncation"]);
+    const second = createHarnessTranscriptOmissions([secondMessage], first);
+    expect(second.results[0].rules.map((entry) => entry.rule)).toEqual([
+      "artifact-only",
+      "model-context-truncation",
+    ]);
+  });
+
+  it("does not overwrite an unsupported prior omission record", async () => {
+    const root = await Deno.makeTempDir();
+    try {
+      const store = createFileSystemHarnessArtifactStore({
+        artifactRoot: root,
+        runId,
+      });
+      await Deno.mkdir(store.runRoot, { recursive: true });
+      const path = join(store.runRoot, "transcript-omissions.json");
+      await Deno.writeTextFile(path, '{"version":999}');
+
+      await expect(store.persistTranscript([message([])])).rejects.toThrow(
+        "unsupported transcript omission artifact",
+      );
+      expect(await Deno.readTextFile(path)).toBe('{"version":999}');
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- persist `transcript-omissions.json` beside the model-facing transcript, with one enumerated rule set per tool result and artifact-path/JSON-pointer locations only
- join that record to full tool outputs in the console Timeline, keeping CFC-denied observations and scrubbed Fabric identifiers behind fixed markers
- add AUD-20 omission counts with a complete one-to-one transcript join, tests, operator documentation, and the lockstep system-map update

## Boundary and assumptions

- The sibling is reader-side evidence only. Provider requests, `transcript.json`, resume, and replay retain exactly the model-facing rendering.
- Runs predating the sibling are not backfilled. The Timeline says `no record`, and AUD-20 says the run predates the record and returns `inconclusive`.
- Superseded `run_pattern` source collapse remains outside this tool-result record because it rewrites an assistant argument. The Timeline points its marker to the run-pattern-source sidecar. If argument-level omission accounting is wanted later, that is follow-up scope; this PR does not create a new issue or expand the artifact-store API.

## Verification

- rebased onto main `884a99f898`; the system-map snapshot retains both CT-2200 release decisions and CT-2173 `query_docs` exploration
- `deno task test` in `packages/cf-harness` unsandboxed with pinned Deno 2.9.4: 958 passed / 2,135 steps, including real provider-compaction, diagnostic-collapse, CFC-side truncation, release-decision, and `query_docs` omission persistence paths
- repo-wide `deno fmt --check`, `deno lint`, `deno task check`, and `deno task check-docs`
- `deno task console:build`, control-character check, and conflict-marker check
- system map visually checked at 1440×900 with headless Chrome through `@astral/astral`; no screenshot committed
- legacy family `06839f48-c4e8-4273-8c12-4a5a80fd3ab9`: completed parent `a313f4be-5915-484f-a20b-e27e40504f9b` shows all 25 tool results as `withheld from the model · no record`; AUD-20 is inconclusive and says the run predates the record
