### PR TITLE
fix(cf-harness): preserve pattern index event order

### DIFF
--- a/packages/cf-harness/src/tools/run-pattern.ts
+++ b/packages/cf-harness/src/tools/run-pattern.ts
@@ -498,25 +498,25 @@ const errorMessage = (error: unknown): string =>
  * Reports what a run did with an indexed pattern, without letting the report
  * bear on the run. The index ranks on these events, so a failure to record
  * one costs ranking accuracy and nothing else — it is logged and dropped
- * rather than turned into a tool error for a pattern that ran.
+ * rather than turned into a tool error for a pattern that ran. Resolves after
+ * either path, so callers can preserve report order without awaiting it as part
+ * of the run.
  */
-const recordPatternIndexEvent = (
+const recordPatternIndexEvent = async (
   getClient: HarnessPatternIndexClientFactory,
   patternId: string,
   eventType: PatternIndexEventType,
-): void => {
-  void (async () => {
-    try {
-      const client = await getClient();
-      await client.recordEvent({ patternId, eventType });
-    } catch (error) {
-      console.error(
-        `run_pattern could not record the ${eventType} event for pattern index entry "${patternId}": ${
-          errorMessage(error)
-        }`,
-      );
-    }
-  })();
+): Promise<void> => {
+  try {
+    const client = await getClient();
+    await client.recordEvent({ patternId, eventType });
+  } catch (error) {
+    console.error(
+      `run_pattern could not record the ${eventType} event for pattern index entry "${patternId}": ${
+        errorMessage(error)
+      }`,
+    );
+  }
 };
 
 /**
@@ -1361,14 +1361,26 @@ export const runPatternTool: HarnessToolDefinition<
     // built without an instantiation recorder asks nothing.
     const instantiationStart = session.instantiations?.sequence() ?? 0;
 
+    let patternIndexEventTail: Promise<void> | undefined;
+
     /**
      * Reports this invocation's outcome to the index, when the pattern came
      * from there. A cancelled run reports nothing: it neither succeeded nor
-     * failed, and the index ranks on what a pattern did.
+     * failed, and the index ranks on what a pattern did. Reports start in call
+     * order without being awaited by the run, so a terminal event cannot
+     * overtake `instantiated`.
      */
     const recordOutcome = (eventType: PatternIndexEventType): void => {
       if (patternId !== undefined && getPatternIndexClient !== undefined) {
-        recordPatternIndexEvent(getPatternIndexClient, patternId, eventType);
+        const record = () =>
+          recordPatternIndexEvent(
+            getPatternIndexClient,
+            patternId,
+            eventType,
+          );
+        patternIndexEventTail = patternIndexEventTail === undefined
+          ? record()
+          : patternIndexEventTail.then(record);
       }
     };
 

--- a/packages/cf-harness/test/run-pattern-pattern-index.test.ts
+++ b/packages/cf-harness/test/run-pattern-pattern-index.test.ts
@@ -10,6 +10,9 @@ import {
   Runtime,
 } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import type {
+  FirstPartyHttpSigner,
+} from "@commonfabric/runner/toolshed-http-auth";
 import { CfHarnessEngine } from "../src/engine.ts";
 import type { HarnessFetch } from "../src/contracts/http-fetch.ts";
 import type { FabricPatternInstantiations } from "../src/fabric-instantiations.ts";
@@ -390,6 +393,7 @@ describe("run-pattern over the pattern index", () => {
       startFailure?: string;
       pieces?: PiecesController;
       instantiations?: FabricPatternInstantiations;
+      patternIndexSigner?: FirstPartyHttpSigner;
     } = {},
   ): CfHarnessEngine =>
     new CfHarnessEngine({
@@ -433,7 +437,7 @@ describe("run-pattern over the pattern index", () => {
             new PatternIndexClient({
               baseUrl: "https://index.test",
               fetchFn: index.fetchFn,
-              signer,
+              signer: options.patternIndexSigner ?? signer,
             }),
           ),
       }),
@@ -869,6 +873,28 @@ describe("run-pattern over the pattern index", () => {
     });
 
     it("reports an indexed run whose piece carries a session-only pointer as failed", async () => {
+      // Holding the first event signature makes instantiation slow while the
+      // terminal event is queued, pinning their delivery order independently
+      // of signature latency. Identify event requests from the proof itself so
+      // changes to how the lookup is signed cannot silently bypass the gate.
+      const firstEventSignature = Promise.withResolvers<void>();
+      let recordEventSignatureCount = 0;
+      const patternIndexSigner: FirstPartyHttpSigner = {
+        did: () => signer.did(),
+        async sign(payload) {
+          const proof = new TextDecoder().decode(payload);
+          if (!proof.includes("\npath: /recordEvent\n")) {
+            return { ok: new Uint8Array(64) };
+          }
+          recordEventSignatureCount += 1;
+          if (recordEventSignatureCount === 1) {
+            await firstEventSignature.promise;
+          } else if (recordEventSignatureCount === 2) {
+            queueMicrotask(firstEventSignature.resolve);
+          }
+          return { ok: new Uint8Array(64) };
+        },
+      };
       const index = stubIndex({ "pat-doubler": INDEXED_PATTERN });
       await createEngine(index, {
         instantiations: {
@@ -876,12 +902,15 @@ describe("run-pattern over the pattern index", () => {
           since: () => STRANDED_RECORDS,
           keylessSince: () => STRANDED_RECORDS,
         },
+        patternIndexSigner,
       }).invokeBuiltinTool("run_pattern", {
         patternId: "pat-doubler",
         inputs: { n: 21 },
       });
 
+      firstEventSignature.resolve();
       await index.settled("recordEvent", 2);
+      expect(recordEventSignatureCount).toBe(2);
       expect(
         index.calls.filter((call) => call.fn === "recordEvent")
           .map((call) => call.body.eventType),


### PR DESCRIPTION
## What

- serialize best-effort pattern-index usage events within each `run_pattern` invocation
- keep event recording off the tool result path while preventing a terminal event from overtaking `instantiated`
- make the session-only-pointer regression test force the signing-latency inversion deterministically

## Why

[Main run 33702290600, attempt 1](https://github.com/commontoolsinc/labs/actions/runs/33702290600/attempts/1) exposed an existing race: `recordPatternIndexEvent` launched each report independently, and each request asynchronously acquired the client and signed before sending. The terminal `run_failed` request could therefore reach the index before `instantiated`.

The order is part of the current product contract: `packages/cf-harness/docs/CURRENT_STATE.md` says a run reports `instantiated` and then its terminal outcome, and the existing success/failure assertions pin that sequence. Attempt 2 passed unchanged, confirming that the failure is intermittent rather than an order-insensitive expectation.

## Validation

- with the production change temporarily removed, the controlled-latency test fails with the CI order: `["run_failed", "instantiated"]`
- `packages/cf-harness/test/run-pattern-pattern-index.test.ts`: 47 steps passed
- `packages/cf-harness`: 946 tests / 2,032 steps passed
- `deno fmt --check`
- `deno lint`
- `deno task check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6807?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

