### PR TITLE
feat(shuttle): how a line splits, and the printer that inverts it

### DIFF
--- a/docs/plans/shuttle/README.md
+++ b/docs/plans/shuttle/README.md
@@ -244,14 +244,13 @@ invisible, the prompt renders the whole ambient record — place and scope
     (a live region above the prompt) is designed and deferred
     ([`futures.md`](futures.md)).
 
-The line grammar itself — resolution rules, facets, listings, run-state and
-write surfaces, and the redirection/pipe proposals — is drafted in
-[`grammar.md`](grammar.md). The full-screen views are
-designed in [`views.md`](views.md). The order of
+The line grammar itself — from how a line splits into tokens to what an
+operand on one denotes — is drafted in [`grammar.md`](grammar.md). The
+full-screen views are designed in [`views.md`](views.md). The order of
 construction — the `cli` seam PRs and the shuttle milestones they gate — is
-[`build-sequence.md`](build-sequence.md). The trajectory
-past v1 — configuration in the fabric, the session scope as the variable
-store, the scripting layers, and the ranked candidates behind them — is
+[`build-sequence.md`](build-sequence.md). The trajectory past v1 —
+configuration in the fabric, the session scope as the variable store, the
+scripting layers, and the ranked candidates behind them — is
 [`futures.md`](futures.md).
 
 ## The ambient model

--- a/docs/plans/shuttle/README.md
+++ b/docs/plans/shuttle/README.md
@@ -244,15 +244,13 @@ invisible, the prompt renders the whole ambient record — place and scope
     (a live region above the prompt) is designed and deferred
     ([`futures.md`](futures.md)).
 
-The line grammar itself — what a line may say, what its parts denote, and
-what shuttle does and shows in return — is drafted in
-[`grammar.md`](grammar.md). The full-screen views are designed in
-[`views.md`](views.md). The order of
+The line grammar itself — what a line may say, what its parts denote, and what
+shuttle does and shows in return — is drafted in [`grammar.md`](grammar.md). The
+full-screen views are designed in [`views.md`](views.md). The order of
 construction — the `cli` seam PRs and the shuttle milestones they gate — is
-[`build-sequence.md`](build-sequence.md). The trajectory past v1 —
-configuration in the fabric, the session scope as the variable store, the
-scripting layers, and the ranked candidates behind them — is
-[`futures.md`](futures.md).
+[`build-sequence.md`](build-sequence.md). The trajectory past v1 — configuration
+in the fabric, the session scope as the variable store, the scripting layers,
+and the ranked candidates behind them — is [`futures.md`](futures.md).
 
 ## The ambient model
 

--- a/docs/plans/shuttle/README.md
+++ b/docs/plans/shuttle/README.md
@@ -244,9 +244,10 @@ invisible, the prompt renders the whole ambient record — place and scope
     (a live region above the prompt) is designed and deferred
     ([`futures.md`](futures.md)).
 
-The line grammar itself — from how a line splits into tokens to what an
-operand on one denotes — is drafted in [`grammar.md`](grammar.md). The
-full-screen views are designed in [`views.md`](views.md). The order of
+The line grammar itself — what a line may say, what its parts denote, and
+what shuttle does and shows in return — is drafted in
+[`grammar.md`](grammar.md). The full-screen views are designed in
+[`views.md`](views.md). The order of
 construction — the `cli` seam PRs and the shuttle milestones they gate — is
 [`build-sequence.md`](build-sequence.md). The trajectory past v1 —
 configuration in the fabric, the session scope as the variable store, the

--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -158,6 +158,24 @@ Landed:
   revisits this trade rather than inheriting it. No verb reaches the
   connection yet, and the place is untouched.
 
+- **B1b (slice 2) — the line grammar** (`packages/shuttle/src/line.ts`). How
+  a line becomes tokens, and how a value prints as one of them. `cf` is
+  handed words the operating system's shell already split; shuttle is handed
+  the line, and both halves are its own. The split is POSIX quoting —
+  whitespace separates, single quotes are literal, double quotes group, a
+  backslash escapes one character, and runs that touch are one token — and a
+  line is refused for one of two reasons: a quote that never closes, naming
+  the column it opened at, and a trailing backslash with nothing to escape.
+  The printer quotes only where quoting is needed, which is what keeps a
+  slug, a handle, a flag and a path each printing as themselves; what forces
+  it is whitespace, either quote, the backslash, and the characters the
+  grammar spends on structure, collected in one constant rather than counted
+  in prose. The characters an operand writes an address with stay out of that
+  set, which is what leaves the relative-segment question below intact: what
+  the pair guarantees is that a printed value splits back into that one
+  value, and whether a quote should also reach the reading of a token is
+  still `ls`'s to settle. No verb reads a line yet.
+
 Still to come:
 
 - **The prompt, a readline loop, and the verbs** (B1b for the verbs and

--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -163,9 +163,10 @@ Landed:
   handed words the operating system's shell already split; shuttle is handed
   the line, and both halves are its own. The split is POSIX quoting —
   whitespace separates, single quotes are literal, double quotes group, a
-  backslash escapes one character, and runs that touch are one token — and a
-  line is refused for one of two reasons: a quote that never closes, naming
-  the column it opened at, and a trailing backslash with nothing to escape.
+  backslash escapes one character and between double quotes only a quote or
+  another backslash, and runs that touch are one token — and a line is
+  refused for one of two reasons: a quote that never closes, naming the
+  column it opened at, and a trailing backslash with nothing to escape.
   The printer quotes only where quoting is needed, which is what keeps a
   slug, a handle, a flag and a path each printing as themselves; what forces
   it is whitespace, either quote, the backslash, and the characters the
@@ -184,6 +185,16 @@ Still to come:
   navigable within the connected space (`cd #favorites`, and the `wish`
   verb, over the `./lib/wish` export entry A1 adds; a home-anchored target
   from elsewhere is refused with the reason — decision 5).
+
+  The line editor is the view substrate's rather than `node:readline`'s.
+  `EditBuffer` (`packages/cli/lib/view/editbuffer.ts`) holds the motions and
+  the substrate's key handler binds them to emacs keys, and `decodeKeys`
+  (`packages/cli/lib/view/keys.ts`) supplies the key stream a binding table
+  reads — where `node:readline` offers no keymap hook at all, so a second
+  binding table is unreachable behind it. That is what keeps modal editing
+  an option later ([`futures.md`](futures.md)), and it brings the view
+  substrate's export entries forward from B3, where A1 left them.
+
 - **Slug and name resolution** (B1b), riding the machinery `--cell` already
   uses
   (`resolveStoredPieceAddress`, `listSpaceSlugs`), so no CLI-surface arc

--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -25,8 +25,9 @@ empty — right for tab completion, wrong for `ls` — so the listing raises
 its errors and completion's provider dispatch swallows them at its own
 call site. Keep the list to what shuttle names — an export entry is a
 contract, and the short list is the record of which internals have a
-second caller. (The view substrate's entries wait for B3, which is when
-they earn their place on that record.)
+second caller. (The view substrate's entries are not on it, nothing having
+named them yet; each lands with the milestone that first calls it, which is
+how a module earns its place on that record.)
 
 **A2 — connection injection for the write path.** Done (#6646). The write
 path takes the connection as a parameter, so a held `PiecesController`
@@ -192,8 +193,9 @@ Still to come:
   (`packages/cli/lib/view/keys.ts`) supplies the key stream a binding table
   reads — where `node:readline` offers no keymap hook at all, so a second
   binding table is unreachable behind it. That is what keeps modal editing
-  an option later ([`futures.md`](futures.md)), and it brings the view
-  substrate's export entries forward from B3, where A1 left them.
+  an option later ([`futures.md`](futures.md)), and it is what brings the
+  view substrate's export entries with the prompt: the line editor calls
+  those modules, and an entry lands with the milestone that first calls one.
 
 - **Slug and name resolution** (B1b), riding the machinery `--cell` already
   uses
@@ -270,14 +272,14 @@ schema-derived flag machinery `cf` already exports (`pieceCallRawArgs`,
 `pieceCallInvocation`), so no arc step gates it either. Reaching-in-warms
 lands here, since `set` is what makes stale computed state visible.
 
-**B3 — watch and views** (after A4; view-substrate export entries added
-here). `Cell.sink` with the guard-plus-`idle()` settling discipline; the
-value, list, and structured piece-overview views on the `cf view` pager
-substrate; session watches (`watch`, `watches`, `unwatch`) with prompt
-event lines. Governed by [`views.md`](views.md); it opens with the two
-experiments and the raw-document-subscription proving test from issue
-[#6534](https://github.com/commontoolsinc/labs/issues/6534), falling back
-to the capped deep sink if the seam disappoints.
+**B3 — watch and views** (after A4; the substrate modules it is first to call
+bring their export entries with them). `Cell.sink` with the guard-plus-`idle()`
+settling discipline; the value, list, and structured piece-overview views on
+the `cf view` pager substrate; session watches (`watch`, `watches`, `unwatch`)
+with prompt event lines. Governed by [`views.md`](views.md); it opens with the
+two experiments and the raw-document-subscription proving test from issue
+[#6534](https://github.com/commontoolsinc/labs/issues/6534), falling back to
+the capped deep sink if the seam disappoints.
 
 **B4 — externals and escapes.** `>` and `<` to and from `file:` externals
 under the scheme-absolute rule; the external working location

--- a/docs/plans/shuttle/futures.md
+++ b/docs/plans/shuttle/futures.md
@@ -89,6 +89,23 @@ decisions point here where they defer.
   its v1 member, and `set x - < https://…` joins when a use rules it in.
 - **`search`.** A `search <query>` verb at any place, over what stands
   below it. Pipes over `ls` cover the interim.
+- **A canonical output form.** A second form for everything shuttle prints:
+  RFC 6901 pointers, no shuttle quoting, exactly what `cf` parses. `pwd`,
+  `ls` and `get` all print, so the fork is a dimension of the output rather
+  than one verb's flag, and the switch is a `where` dimension — the form is
+  an ambient property of the whole run, and `where` is the ambient record's
+  one surface (decision 22). It arrives when a caller exists to want it, and
+  the scripting bundle above is where one does: stable machine-readable
+  output is part of that bundle rather than of the interactive surface.
+- **Vim keybindings, as a `where` dimension.** Modal editing at the prompt,
+  an option and never a default. What keeps it reachable is that the line
+  editor is built on the view substrate rather than on `node:readline`,
+  which offers no keymap hook at all: `EditBuffer`
+  (`packages/cli/lib/view/editbuffer.ts`) holds the motions, bound to emacs
+  keys by the substrate's own key handler, and `decodeKeys`
+  (`packages/cli/lib/view/keys.ts`) supplies the key stream a binding table
+  reads. So what this costs is a second binding table over motions that
+  already exist, plus the mode the table switches on.
 - **Which space a piece is in.** Naming the space that holds an arbitrary
   piece, rather than the one the place stands in. It is a query over the
   fabric and not a dimension of the ambient record, so it arrives with

--- a/docs/plans/shuttle/futures.md
+++ b/docs/plans/shuttle/futures.md
@@ -98,14 +98,11 @@ decisions point here where they defer.
   the scripting bundle above is where one does: stable machine-readable
   output is part of that bundle rather than of the interactive surface.
 - **Vim keybindings, as a `where` dimension.** Modal editing at the prompt,
-  an option and never a default. What keeps it reachable is that the line
-  editor is built on the view substrate rather than on `node:readline`,
-  which offers no keymap hook at all: `EditBuffer`
-  (`packages/cli/lib/view/editbuffer.ts`) holds the motions, bound to emacs
-  keys by the substrate's own key handler, and `decodeKeys`
-  (`packages/cli/lib/view/keys.ts`) supplies the key stream a binding table
-  reads. So what this costs is a second binding table over motions that
-  already exist, plus the mode the table switches on.
+  an option and never a default. What it costs is a second binding table
+  over motions the line editor already drives, plus the mode the table
+  switches on — which is what B1c's choice of substrate buys, and why that
+  choice is recorded with B1c rather than here
+  ([`build-sequence.md`](build-sequence.md)).
 - **Which space a piece is in.** Naming the space that holds an arbitrary
   piece, rather than the one the place stands in. It is a query over the
   fabric and not a dimension of the ambient record, so it arrives with

--- a/docs/plans/shuttle/grammar.md
+++ b/docs/plans/shuttle/grammar.md
@@ -21,6 +21,61 @@ machine" everywhere it appears: line-initial `! <cmd>` runs any local
 program, `|!` is the same escape in a pipeline, and `!cf …` is the special
 case that also injects place-derived flags.
 
+## Splitting the line
+
+`cf` never splits a line: it is handed `Deno.args`, already split by the
+operating system's shell, and the reference grammar it reads those words
+through has no rule for one. Shuttle is handed the line itself, so the split
+is shuttle's, and it is POSIX's:
+
+- **Whitespace separates tokens**, and a run of it separates no more than
+  one.
+- **Single quotes are literal**: what sits between them is the token's,
+  whatever it is.
+- **Double quotes group**, and a backslash between them escapes the
+  character after it, as one outside quotes does.
+- **Runs that touch are one token**, so `a"b c"d` is `ab cd`, and an empty
+  pair of quotes is a token that is the empty string.
+- A quote that never closes, and a trailing backslash with nothing to
+  escape, are refused with the reason. Nothing else refuses a line: one
+  that splits says only that, and whether its tokens name anything is
+  every later reading's question.
+
+Quoting is what makes a value holding whitespace one operand, which is what
+the write surface below needs. `set draft '{"title": "a b"}'` is three
+tokens; the same line with the quotes left off is four, and the JSON's own
+quotes come off two of them, so what `set` would read is `{title:` rather
+than an object. A verb reads a token, and nothing reassembles one.
+
+**On output, a value is printed as a token**: bare where nothing in it would
+end the token early or read as structure, and quoted where something would.
+GNU `ls` has printed names this way since 8.25, so the habit is already in
+every terminal user's hands, and the point of it is that the common case
+stays bare — a slug, a handle, a flag and a path each print as themselves.
+
+What forces quoting is whitespace, either quote, the backslash, and the
+characters this grammar spends on structure rather than on data: the pipe,
+the `!` that marks a local program, the two redirection operators, the `#` a
+wish target and an argument suffix are written with, and the `%` a numbered
+handle is. Each is ruled elsewhere in this document; collected here, they
+are the set a printed value is held against, and a value holding one is
+quoted wherever in the value it sits — a printer is handed a value and no
+position, so it quotes on the character rather than on the reading.
+
+The characters an operand writes an address with — the `/` between segments,
+the `@` of a scope suffix, `-`, `..` — are deliberately not in that set.
+Those are read inside a token by the place resolution below rather than by
+the split, and quoting on them would cost the bare printing of every handle,
+slug and path while buying the split nothing.
+
+The two halves are one decision: what the printer writes, the split reads
+back as the one value it was given. That is the whole of the guarantee. What
+a reading then makes of that token is decided where the operand is read, and
+whether a quote should reach that decision — so that a key named `..`, or
+one beginning with `#`, has a spelling that names it — is part of the
+relative-segment question `ls` settles
+([`build-sequence.md`](build-sequence.md)).
+
 ## Place resolution
 
 A reference on the line resolves against the place, right-anchored, exactly
@@ -312,7 +367,8 @@ produce.
 ## Writes
 
 - `set <path> <value>` — the value parses as JSON; a bare word is a string
-  where that is unambiguous. `set <path> -` reads stdin.
+  where that is unambiguous, and a value holding whitespace is quoted, being
+  one token like any other operand. `set <path> -` reads stdin.
 - `edit <path>` — opens `$EDITOR` on the current value, writes back on save
   (the view substrate's editing buffers already do the hard part).
 - `link <target> <path>` — writes a cell reference, the fabric's link

--- a/docs/plans/shuttle/grammar.md
+++ b/docs/plans/shuttle/grammar.md
@@ -29,11 +29,18 @@ through has no rule for one. Shuttle is handed the line itself, so the split
 is shuttle's, and it is POSIX's:
 
 - **Whitespace separates tokens**, and a run of it separates no more than
-  one.
+  one. Whitespace is JavaScript's own class, which is what `trim` removes,
+  so a no-break space and the Unicode line separator separate a line as a
+  space does — a reader cannot see either, and the realistic way an operand
+  acquires one is a paste out of a document. The pair stays consistent about
+  them: what separates here is what the printer quotes, so a value holding
+  one still reads back whole.
 - **Single quotes are literal**: what sits between them is the token's,
   whatever it is.
-- **Double quotes group**, and a backslash between them escapes the
-  character after it, as one outside quotes does.
+- **Double quotes group**, and a backslash between them escapes a double
+  quote or another backslash and is otherwise a character of the token, so
+  `"C:\path"` keeps its backslash. Outside quotes a backslash escapes
+  whatever follows it.
 - **Runs that touch are one token**, so `a"b c"d` is `ab cd`, and an empty
   pair of quotes is a token that is the empty string.
 - A quote that never closes, and a trailing backslash with nothing to
@@ -63,10 +70,13 @@ quoted wherever in the value it sits — a printer is handed a value and no
 position, so it quotes on the character rather than on the reading.
 
 The characters an operand writes an address with — the `/` between segments,
-the `@` of a scope suffix, `-`, `..` — are deliberately not in that set.
-Those are read inside a token by the place resolution below rather than by
-the split, and quoting on them would cost the bare printing of every handle,
-slug and path while buying the split nothing.
+the `@` of a scope suffix, `-`, `..` — are deliberately not in that set, and
+that exclusion is what makes the output rule worth having rather than a
+detail of it. Those characters are read inside a token by the place
+resolution below rather than by the split, so quoting on them would buy the
+split nothing and would cost the bare printing of every handle, every slug,
+every path and every flag — which is to say nearly everything shuttle
+prints, leaving nothing conditional about conditional quoting.
 
 The two halves are one decision: what the printer writes, the split reads
 back as the one value it was given. That is the whole of the guarantee. What
@@ -74,7 +84,10 @@ a reading then makes of that token is decided where the operand is read, and
 whether a quote should reach that decision — so that a key named `..`, or
 one beginning with `#`, has a spelling that names it — is part of the
 relative-segment question `ls` settles
-([`build-sequence.md`](build-sequence.md)).
+([`build-sequence.md`](build-sequence.md)). Ruling that it should has a
+known shape and a known cost: the split would start carrying which parts of
+a token were quoted, which grows the value it returns rather than adding a
+layer over it, and every reading that consults quoting reads that value.
 
 ## Place resolution
 

--- a/docs/plans/shuttle/grammar.md
+++ b/docs/plans/shuttle/grammar.md
@@ -47,6 +47,13 @@ is shuttle's, and it is POSIX's:
   escape, are refused with the reason. Nothing else refuses a line: one
   that splits says only that, and whether its tokens name anything is
   every later reading's question.
+- **A line is one line**, and a terminator on it is whoever read it to
+  strip. Line terminators are in the separator class, so text carrying one
+  splits across the break into a single run of tokens: a pasted second line
+  arrives as more operands of the first command rather than as a command of
+  its own. A line break cannot refuse instead, because a value holding one
+  prints between single quotes and reading that back is the round trip
+  below.
 
 Quoting is what makes a value holding whitespace one operand, which is what
 the write surface below needs. `set draft '{"title": "a b"}'` is three
@@ -77,6 +84,14 @@ resolution below rather than by the split, so quoting on them would buy the
 split nothing and would cost the bare printing of every handle, every slug,
 every path and every flag — which is to say nearly everything shuttle
 prints, leaving nothing conditional about conditional quoting.
+
+The `:` is the one character this grammar spends on structure that the set
+still leaves out. It marks a scheme and the `x:` base, which by the rule
+above would reserve it; but it is also in every handle — `of:fid1:…` — so
+quoting on it would quote every reference that prints, which is the cost
+the exclusion exists to avoid. A scheme is read at the head of an operand
+rather than by the split, which is what puts `:` with the address
+characters and not with the structural ones.
 
 The two halves are one decision: what the printer writes, the split reads
 back as the one value it was given. That is the whole of the guarantee. What

--- a/docs/plans/shuttle/grammar.md
+++ b/docs/plans/shuttle/grammar.md
@@ -51,9 +51,10 @@ is shuttle's, and it is POSIX's:
   strip. Line terminators are in the separator class, so text carrying one
   splits across the break into a single run of tokens: a pasted second line
   arrives as more operands of the first command rather than as a command of
-  its own. A line break cannot refuse instead, because a value holding one
-  prints between single quotes and reading that back is the round trip
-  below.
+  its own. That is a choice and not a necessity — every value the printer
+  writes that holds a line break lands inside quotes, so refusing an
+  unquoted one would leave the round trip below whole. The round trip says
+  the choice is safe, not that it was forced.
 
 Quoting is what makes a value holding whitespace one operand, which is what
 the write surface below needs. `set draft '{"title": "a b"}'` is three
@@ -85,13 +86,13 @@ split nothing and would cost the bare printing of every handle, every slug,
 every path and every flag — which is to say nearly everything shuttle
 prints, leaving nothing conditional about conditional quoting.
 
-The `:` is the one character this grammar spends on structure that the set
-still leaves out. It marks a scheme and the `x:` base, which by the rule
-above would reserve it; but it is also in every handle — `of:fid1:…` — so
-quoting on it would quote every reference that prints, which is the cost
-the exclusion exists to avoid. A scheme is read at the head of an operand
-rather than by the split, which is what puts `:` with the address
-characters and not with the structural ones.
+Some characters this grammar spends on structure are left out all the same,
+and the same cost is the reason. `:` marks a scheme and the `x:` base, and
+it also sits in every handle — `of:fid1:…` — so reserving it would quote
+every reference that prints. `-` is the previous place and the stdin
+sentinel, and it opens every long flag. Each of them is read at the head of
+an operand, or as the whole of one, rather than by the split, which is what
+puts them with the address characters rather than with the reserved ones.
 
 The two halves are one decision: what the printer writes, the split reads
 back as the one value it was given. That is the whole of the guarantee. What

--- a/docs/plans/shuttle/views.md
+++ b/docs/plans/shuttle/views.md
@@ -89,7 +89,9 @@ pattern to follow rather than import — shuttle views hold different state.
 shuttle wants; `mod.ts` and `loadinput.ts` own the rest of `cf view`'s
 stdio — probing whether stdout and stdin are terminals, writing plain
 output, reading a piped document — which is one-shot-command concern a
-shell drives for itself. The export entries for these modules land with B3.
+shell drives for itself. Each of these modules brings its export entry with
+the milestone that first calls it
+([`build-sequence.md`](build-sequence.md)).
 
 One adaptation to verify early in B3: `cf view` pages a static document,
 so its frame loop may be key-driven only. Shuttle views repaint on two

--- a/packages/shuttle/src/line.ts
+++ b/packages/shuttle/src/line.ts
@@ -14,6 +14,13 @@
  * What a token then means is decided elsewhere — `place.ts` reads an operand
  * as a reference or as one of the navigation spellings, and a verb reads its
  * own. This module bounds where a token ends and says nothing past that.
+ *
+ * `packages/cli` splits a line too, in `tokenizeLine` under `lib/completion/`,
+ * and this is not a second copy of it. That one reconstructs what bash would
+ * have done to a *partial* line: it takes a cursor offset, always ends with an
+ * empty word for the cursor to sit in, and refuses nothing, a half-typed line
+ * being its normal input. It is also not an export entry of that package, so
+ * nothing here could call it.
  */
 
 /**
@@ -44,6 +51,13 @@ export const RESERVED_CHARACTERS = "!#%<>|";
 const SYNTAX_CHARACTERS = "\"'\\";
 
 /**
+ * What a backslash escapes between double quotes: a double quote, and another
+ * backslash. Every other character there is literal, so a path or a JSON
+ * escape written between double quotes arrives as it was typed.
+ */
+const DOUBLE_QUOTE_ESCAPES = '"\\';
+
+/**
  * What separates two tokens. The definition is JavaScript's own — what
  * `String.prototype.trim` removes — so a token this module split and an
  * operand a caller trimmed agree about where a value's edges are.
@@ -63,9 +77,10 @@ export type LineSplit =
  *
  * Whitespace separates tokens, and a run of it separates no more than one.
  * Single quotes are literal, so what sits between them is the token's own
- * whatever it is. Double quotes group, and inside them a backslash escapes
- * the character after it, as one outside quotes does. Runs that touch are one
- * token, so `a"b c"d` is the single token `ab cd`, and an empty pair of
+ * whatever it is. Double quotes group, and between them a backslash escapes
+ * one of {@link DOUBLE_QUOTE_ESCAPES} and is otherwise a character of the
+ * token; outside quotes it escapes whatever follows it. Runs that touch are
+ * one token, so `a"b c"d` is the single token `ab cd`, and an empty pair of
  * quotes is a token that is the empty string.
  *
  * A line is refused for one of two reasons, both of them a token with no end:
@@ -86,13 +101,16 @@ export function splitLine(line: string): LineSplit {
       if (character === quote) {
         quote = undefined;
       } else if (
-        character === "\\" && quote === '"' && index + 1 < line.length
+        character === "\\" && quote === '"' && index + 1 < line.length &&
+        DOUBLE_QUOTE_ESCAPES.includes(line[index + 1])
       ) {
         current += line[++index];
       } else {
-        // A backslash with nothing after it lands here, and the line then ends
-        // with the quote still open, so the unterminated-quote refusal below
-        // is what the caller reads rather than a second reason for one fault.
+        // A backslash escaping nothing lands here and is a character of the
+        // token like any other. Where it is the line's last character, the
+        // line then ends with the quote still open, so what the caller reads
+        // is the unterminated-quote refusal below rather than a second reason
+        // for one fault.
         current += character;
       }
       continue;

--- a/packages/shuttle/src/line.ts
+++ b/packages/shuttle/src/line.ts
@@ -17,9 +17,9 @@
  *
  * `packages/cli` splits a line too, in `tokenizeLine` under `lib/completion/`,
  * and this is not a second copy of it. That one reconstructs what bash would
- * have done to a *partial* line: it reads up to a cursor offset and its last
- * word is whatever the cursor sits in, which is empty only where the cursor
- * follows a separator; it separates on the space and the tab alone; and it
+ * have done to a *partial* line: it reads up to a cursor offset and always
+ * pushes a last word for the cursor to sit in, so its list is never empty
+ * where this one's is; it separates on the space and the tab alone; and it
  * refuses nothing, a half-typed line being its normal input. It is also not an
  * export entry of that package, so nothing here could call it.
  */
@@ -90,12 +90,13 @@ export type LineSplit =
  * Nothing else refuses a line here, so a line that splits says only that; it
  * says nothing about whether its tokens name anything.
  *
- * `line` is one line, and a terminator on it is the caller's to strip. The
+ * `line` is one line, and a terminator on it is whoever read it to strip. The
  * separator class holds the line terminators, so text carrying one splits
  * across the break into a single run of tokens rather than into two commands.
- * A newline cannot refuse instead: {@link quoteToken} writes a value holding
- * one between single quotes, and reading that back is the round trip the two
- * halves guarantee.
+ * That is a choice and not a necessity: every value {@link quoteToken} writes
+ * that holds a line break lands inside quotes, so a rule refusing an unquoted
+ * one would leave the round trip whole. What the round trip settles is that
+ * the choice is safe, not that it was forced.
  */
 export function splitLine(line: string): LineSplit {
   const tokens: string[] = [];
@@ -182,10 +183,10 @@ export function quoteToken(value: string): string {
 
 /**
  * Helper for {@link splitLine}, which is the 1-based column of the character
- * at `index`, counted in code points. The number exists for a person to find
- * that character with, so it counts what a reader counts rather than the code
- * units the string is stored in: an emoji ahead of the quote is one column and
- * not two.
+ * at `index`, counted in code points. The number is there for a person to find
+ * that character with, and a code point is the unit this can count: it is
+ * neither the code unit the string is stored in, nor the grapheme cluster a
+ * reader sees as one character.
  */
 function columnOf(line: string, index: number): number {
   return [...line.slice(0, index)].length + 1;

--- a/packages/shuttle/src/line.ts
+++ b/packages/shuttle/src/line.ts
@@ -17,10 +17,11 @@
  *
  * `packages/cli` splits a line too, in `tokenizeLine` under `lib/completion/`,
  * and this is not a second copy of it. That one reconstructs what bash would
- * have done to a *partial* line: it takes a cursor offset, always ends with an
- * empty word for the cursor to sit in, and refuses nothing, a half-typed line
- * being its normal input. It is also not an export entry of that package, so
- * nothing here could call it.
+ * have done to a *partial* line: it reads up to a cursor offset and its last
+ * word is whatever the cursor sits in, which is empty only where the cursor
+ * follows a separator; it separates on the space and the tab alone; and it
+ * refuses nothing, a half-typed line being its normal input. It is also not an
+ * export entry of that package, so nothing here could call it.
  */
 
 /**
@@ -35,9 +36,10 @@
  * position would have left the character ordinary, and is the price of a
  * printer that needs to know nothing about where its output lands.
  *
- * The characters an operand writes an address with are not here. Those are
- * read inside a token by the reference grammar rather than by the split, and
- * which of them a printed value has to carry is the question `ls` settles
+ * The characters an operand writes an address with are not here, the `:` of a
+ * scheme and of a handle among them. Those are read inside a token by the
+ * reference grammar rather than by the split, and which of them a printed
+ * value has to carry is the question `ls` settles
  * (`docs/plans/shuttle/build-sequence.md`).
  */
 export const RESERVED_CHARACTERS = "!#%<>|";
@@ -87,6 +89,13 @@ export type LineSplit =
  * a quote that never closes, and a trailing backslash with nothing to escape.
  * Nothing else refuses a line here, so a line that splits says only that; it
  * says nothing about whether its tokens name anything.
+ *
+ * `line` is one line, and a terminator on it is the caller's to strip. The
+ * separator class holds the line terminators, so text carrying one splits
+ * across the break into a single run of tokens rather than into two commands.
+ * A newline cannot refuse instead: {@link quoteToken} writes a value holding
+ * one between single quotes, and reading that back is the round trip the two
+ * halves guarantee.
  */
 export function splitLine(line: string): LineSplit {
   const tokens: string[] = [];
@@ -143,7 +152,8 @@ export function splitLine(line: string): LineSplit {
 
   if (quote !== undefined) {
     return refuse(
-      `The \`${quote}\` opened at column ${openedAt + 1} is never closed.`,
+      `The \`${quote}\` opened at column ${columnOf(line, openedAt)} is ` +
+        `never closed.`,
     );
   }
   if (started) tokens.push(current);
@@ -168,6 +178,17 @@ export function quoteToken(value: string): string {
   if (!needsQuoting(value)) return value;
   if (!value.includes("'")) return `'${value}'`;
   return `"${value.replaceAll(/["\\]/g, "\\$&")}"`;
+}
+
+/**
+ * Helper for {@link splitLine}, which is the 1-based column of the character
+ * at `index`, counted in code points. The number exists for a person to find
+ * that character with, so it counts what a reader counts rather than the code
+ * units the string is stored in: an emoji ahead of the quote is one column and
+ * not two.
+ */
+function columnOf(line: string, index: number): number {
+  return [...line.slice(0, index)].length + 1;
 }
 
 /** Helper for {@link splitLine}, which builds a refusal carrying `reason`. */

--- a/packages/shuttle/src/line.ts
+++ b/packages/shuttle/src/line.ts
@@ -2,10 +2,9 @@
  * How a shuttle line splits into tokens, and how a value prints as one of
  * them.
  *
- * `cf` never does either. The operating system's shell splits a command line
- * and hands over the words it made, and every grammar below that reads what
- * arrives. Shuttle reads its own line, so the split is shuttle's, and so is
- * the printing that inverts it.
+ * `cf` never does either: it is handed `Deno.args`, split for it already by
+ * the operating system's shell. Shuttle reads its own line, so the split is
+ * shuttle's, and so is the printing that inverts it.
  *
  * The two halves live in one module because they are one decision: what
  * {@link quoteToken} writes, {@link splitLine} reads back as the one value it
@@ -134,10 +133,10 @@ export function splitLine(line: string): LineSplit {
 }
 
 /**
- * Returns `value` written as one token of a line: bare where nothing in it
- * would end the token early or be read as structure, and quoted where
- * something would. {@link splitLine} reads what this returns back as exactly
- * `value`, whatever `value` holds.
+ * Returns `value` written as one token of a line: bare where it holds
+ * nothing that ends a token and nothing the grammar reserves, and quoted
+ * where it holds one of those. {@link splitLine} reads what this returns back
+ * as exactly `value`, whatever `value` holds.
  *
  * That round trip is the whole of the guarantee. What an operand reading then
  * does with the token is decided where the operand is read, and nothing here
@@ -163,9 +162,8 @@ function refuse(reason: string): LineSplit {
  * come back as itself: it is empty, or it holds a separator, a syntax
  * character, or one of {@link RESERVED_CHARACTERS}.
  *
- * An empty value is in that list for a reason the others are not: it needs
- * quoting to be a token at all, since nothing written bare occupies no
- * characters.
+ * The empty value is in that list for a reason the others are not: a token
+ * written bare cannot be empty, so quoting is what makes it a token at all.
  */
 function needsQuoting(value: string): boolean {
   if (value === "") return true;

--- a/packages/shuttle/src/line.ts
+++ b/packages/shuttle/src/line.ts
@@ -1,0 +1,181 @@
+/**
+ * How a shuttle line splits into tokens, and how a value prints as one of
+ * them.
+ *
+ * `cf` never does either. The operating system's shell splits a command line
+ * and hands over the words it made, and every grammar below that reads what
+ * arrives. Shuttle reads its own line, so the split is shuttle's, and so is
+ * the printing that inverts it.
+ *
+ * The two halves live in one module because they are one decision: what
+ * {@link quoteToken} writes, {@link splitLine} reads back as the one value it
+ * was given. That is what lets a value print bare where nothing in it needs
+ * more, which is the common case and the point.
+ *
+ * What a token then means is decided elsewhere — `place.ts` reads an operand
+ * as a reference or as one of the navigation spellings, and a verb reads its
+ * own. This module bounds where a token ends and says nothing past that.
+ */
+
+/**
+ * The characters shuttle's line grammar spends on structure rather than on
+ * data: the pipe, the local-program escape, the two redirection operators,
+ * the `#` a wish target and an argument suffix are written with, and the `%`
+ * a numbered handle is (`docs/plans/shuttle/grammar.md`).
+ *
+ * A value holding one of these is printed quoted wherever in the value it
+ * sits. {@link quoteToken} is handed a value and no position, so it quotes on
+ * the character rather than on the reading — which quotes values whose
+ * position would have left the character ordinary, and is the price of a
+ * printer that needs to know nothing about where its output lands.
+ *
+ * The characters an operand spells an address with are not here. Those are
+ * read inside a token by the reference grammar rather than by the split, and
+ * which of them a printed value has to carry is the question `ls` settles
+ * (`docs/plans/shuttle/build-sequence.md`).
+ */
+export const RESERVED_CHARACTERS = "!#%<>|";
+
+/**
+ * The characters {@link splitLine} reads as syntax rather than as data: the
+ * two quotes it groups with, and the backslash it escapes with. A value
+ * holding one is printed quoted too, and this is the half of that rule the
+ * split itself forces.
+ */
+const SYNTAX_CHARACTERS = "\"'\\";
+
+/**
+ * What separates two tokens. The definition is JavaScript's own — what
+ * `String.prototype.trim` removes — so a token this module split and an
+ * operand a caller trimmed agree about where a value's edges are.
+ */
+const SEPARATOR = /\s/;
+
+/** What splitting a line produced. */
+export type LineSplit =
+  /** The line split, and `tokens` are its tokens in the order written. */
+  | { readonly kind: "split"; readonly tokens: readonly string[] }
+  /** The line is refused, for the reason given. */
+  | { readonly kind: "refused"; readonly reason: string };
+
+/**
+ * Splits `line` into the tokens it is written as, or refuses it with the
+ * reason.
+ *
+ * Whitespace separates tokens, and a run of it separates no more than one.
+ * Single quotes are literal, so what sits between them is the token's own
+ * whatever it is. Double quotes group, and inside them a backslash escapes
+ * the character after it, as one outside quotes does. Runs that touch are one
+ * token, so `a"b c"d` is the single token `ab cd`, and an empty pair of
+ * quotes is a token that is the empty string.
+ *
+ * A line is refused for one of two reasons, both of them a token with no end:
+ * a quote that never closes, and a trailing backslash with nothing to escape.
+ * Nothing else refuses a line here, so a line that splits says only that; it
+ * says nothing about whether its tokens name anything.
+ */
+export function splitLine(line: string): LineSplit {
+  const tokens: string[] = [];
+  let current = "";
+  let started = false;
+  let quote: string | undefined;
+  let openedAt = 0;
+
+  for (let index = 0; index < line.length; index++) {
+    const character = line[index];
+    if (quote !== undefined) {
+      if (character === quote) {
+        quote = undefined;
+      } else if (
+        character === "\\" && quote === '"' && index + 1 < line.length
+      ) {
+        current += line[++index];
+      } else {
+        // A backslash with nothing after it lands here, and the line then ends
+        // with the quote still open, so the unterminated-quote refusal below
+        // is what the caller reads rather than a second reason for one fault.
+        current += character;
+      }
+      continue;
+    }
+    if (SEPARATOR.test(character)) {
+      if (started) {
+        tokens.push(current);
+        current = "";
+        started = false;
+      }
+      continue;
+    }
+    // Set before the branches rather than in each of them, so that an empty
+    // pair of quotes opens a token the way a character does.
+    started = true;
+    if (character === "'" || character === '"') {
+      quote = character;
+      openedAt = index;
+      continue;
+    }
+    if (character === "\\") {
+      if (index + 1 === line.length) {
+        return refuse("The line ends in a `\\`, which has nothing to escape.");
+      }
+      current += line[++index];
+      continue;
+    }
+    current += character;
+  }
+
+  if (quote !== undefined) {
+    return refuse(
+      `The \`${quote}\` opened at column ${openedAt + 1} is never closed.`,
+    );
+  }
+  if (started) tokens.push(current);
+  return { kind: "split", tokens };
+}
+
+/**
+ * Returns `value` written as one token of a line: bare where nothing in it
+ * would end the token early or be read as structure, and quoted where
+ * something would. {@link splitLine} reads what this returns back as exactly
+ * `value`, whatever `value` holds.
+ *
+ * That round trip is the whole of the guarantee. What an operand reading then
+ * does with the token is decided where the operand is read, and nothing here
+ * tells a reading that a quote delivered its token.
+ *
+ * Single quotes are the first choice, since nothing between them needs an
+ * escape. A value holding one is written in double quotes instead, with its
+ * own quotes and backslashes escaped.
+ */
+export function quoteToken(value: string): string {
+  if (!needsQuoting(value)) return value;
+  if (!value.includes("'")) return `'${value}'`;
+  return `"${value.replaceAll(/["\\]/g, "\\$&")}"`;
+}
+
+/** Helper for {@link splitLine}, which builds a refusal carrying `reason`. */
+function refuse(reason: string): LineSplit {
+  return { kind: "refused", reason };
+}
+
+/**
+ * Helper for {@link quoteToken}, which is whether `value` needs quoting to
+ * come back as itself: it is empty, or it holds a separator, a syntax
+ * character, or one of {@link RESERVED_CHARACTERS}.
+ *
+ * An empty value is in that list for a reason the others are not: it needs
+ * quoting to be a token at all, since nothing written bare occupies no
+ * characters.
+ */
+function needsQuoting(value: string): boolean {
+  if (value === "") return true;
+  for (const character of value) {
+    if (
+      SEPARATOR.test(character) || SYNTAX_CHARACTERS.includes(character) ||
+      RESERVED_CHARACTERS.includes(character)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/packages/shuttle/src/line.ts
+++ b/packages/shuttle/src/line.ts
@@ -29,7 +29,7 @@
  * position would have left the character ordinary, and is the price of a
  * printer that needs to know nothing about where its output lands.
  *
- * The characters an operand spells an address with are not here. Those are
+ * The characters an operand writes an address with are not here. Those are
  * read inside a token by the reference grammar rather than by the split, and
  * which of them a printed value has to carry is the question `ls` settles
  * (`docs/plans/shuttle/build-sequence.md`).

--- a/packages/shuttle/test/line.test.ts
+++ b/packages/shuttle/test/line.test.ts
@@ -38,8 +38,12 @@ describe("line", () => {
       });
     });
 
-    it("separates on every whitespace character, not on the space alone", () => {
-      expect(splitLine("a\tb\nc\rd e")).toEqual({
+    it("separates on a whitespace character that is not the space", () => {
+      // Every separator here is written as an escape, and none of them is
+      // a line break: an invisible character in a fixture is unreadable,
+      // and a line break would tie this case to the one below it.
+
+      expect(splitLine("a\tb\rc\vd\fe")).toEqual({
         kind: "split",
         tokens: ["a", "b", "c", "d", "e"],
       });
@@ -189,7 +193,7 @@ describe("line", () => {
         });
       });
 
-      it("counts the column in code points, so a wide character ahead of the quote is one", () => {
+      it("counts the column in code points, so a character stored as two code units counts one", () => {
         expect(splitLine("\u{1f369} 'a b")).toEqual({
           kind: "refused",
           reason: "The `'` opened at column 3 is never closed.",

--- a/packages/shuttle/test/line.test.ts
+++ b/packages/shuttle/test/line.test.ts
@@ -123,6 +123,24 @@ describe("line", () => {
       });
     });
 
+    it("returns a reserved character between double quotes as a character of the token", () => {
+      // The construction at the end of this file cannot reach this: a value
+      // takes the double-quoted form only where it holds a `\'`, and no value
+      // that construction builds pairs one with a reserved character. So the
+      // grouping half of the double-quote rule is driven here or nowhere.
+
+      for (const character of RESERVED_CHARACTERS) {
+        expect(splitLine(`"a${character}b"`)).toEqual({
+          kind: "split",
+          tokens: [`a${character}b`],
+        });
+      }
+      expect(splitLine('a"b#c"d')).toEqual({
+        kind: "split",
+        tokens: ["ab#cd"],
+      });
+    });
+
     it("returns the character after a backslash outside quotes, and not the backslash", () => {
       expect(splitLine("a\\ b")).toEqual({ kind: "split", tokens: ["a b"] });
     });
@@ -265,6 +283,11 @@ describe("line", () => {
       // What the two halves owe each other, held over a construction rather
       // than over a list: a listed set is a slice of the class, and the
       // values nobody lists are the ones that break a printer.
+      //
+      // One crossing it cannot reach, however long it runs: a value takes
+      // the double-quoted form only where it holds a `'`, and no mark here
+      // pairs one with a reserved character. The splitting case above
+      // drives that crossing directly.
 
       const marks = [
         "",

--- a/packages/shuttle/test/line.test.ts
+++ b/packages/shuttle/test/line.test.ts
@@ -45,6 +45,22 @@ describe("line", () => {
       });
     });
 
+    it("separates on a no-break space and on the Unicode line separator, neither of which a reader sees", () => {
+      // The realistic way an operand acquires one is a paste out of a
+      // document. The pair stays consistent about them either way: what
+      // separates here is what the printer quotes, so a value holding one
+      // still round-trips.
+
+      expect(splitLine("a\u00a0b")).toEqual({
+        kind: "split",
+        tokens: ["a", "b"],
+      });
+      expect(splitLine("a\u2028b")).toEqual({
+        kind: "split",
+        tokens: ["a", "b"],
+      });
+    });
+
     it("returns no tokens for a line holding separators alone", () => {
       expect(splitLine("  \t ")).toEqual({ kind: "split", tokens: [] });
     });
@@ -63,7 +79,15 @@ describe("line", () => {
       });
     });
 
-    it("returns a backslash inside single quotes as a character of the token", () => {
+    it("returns a backslash inside single quotes as a character of the token, even before one double quotes would escape", () => {
+      // The character after the backslash is what makes this discriminate.
+      // Before an ordinary one the two quote rules agree, so a fixture
+      // there would pass whether or not single quotes escape.
+
+      expect(splitLine("'a\\\"b'")).toEqual({
+        kind: "split",
+        tokens: ['a\\"b'],
+      });
       expect(splitLine("'a\\b'")).toEqual({
         kind: "split",
         tokens: ["a\\b"],
@@ -81,6 +105,17 @@ describe("line", () => {
       expect(splitLine('"a\\"b"')).toEqual({
         kind: "split",
         tokens: ['a"b'],
+      });
+      expect(splitLine('"a\\\\b"')).toEqual({
+        kind: "split",
+        tokens: ["a\\b"],
+      });
+    });
+
+    it("returns a backslash inside double quotes as a character of the token where it escapes neither quote nor backslash", () => {
+      expect(splitLine('"C:\\path"')).toEqual({
+        kind: "split",
+        tokens: ["C:\\path"],
       });
     });
 

--- a/packages/shuttle/test/line.test.ts
+++ b/packages/shuttle/test/line.test.ts
@@ -10,11 +10,12 @@
  * fragment of it, since a fragment lets a rewording through that says
  * something else.
  *
- * Two properties are checked over a construction rather than over listed
- * values, because listing them is what leaves a class unguarded: every
- * character the grammar reserves forces quoting, and every awkward value
- * prints as text that splits back into that one value. The construction is
- * where a value nobody would have listed gets driven.
+ * Two of them are checked over a construction rather than over listed
+ * outcomes, because a list is a slice of a class and the rest of the class is
+ * where a gap hides: that every character the grammar reserves forces
+ * quoting, and that a printed value splits back into the one value it was
+ * printed from. The construction is where a value nobody would have listed
+ * gets driven.
  */
 
 import { expect } from "@std/expect";
@@ -24,7 +25,7 @@ import { quoteToken, RESERVED_CHARACTERS, splitLine } from "../src/line.ts";
 
 describe("line", () => {
   describe("RESERVED_CHARACTERS", () => {
-    it("holds the pipe, the local escape, the redirections, `#` and `%`", () => {
+    it("holds the pipe, the local escape, the redirections, `#` and `%`, and nothing else", () => {
       expect(RESERVED_CHARACTERS).toBe("!#%<>|");
     });
   });
@@ -48,7 +49,7 @@ describe("line", () => {
       expect(splitLine("  \t ")).toEqual({ kind: "split", tokens: [] });
     });
 
-    it("returns a run of separators as one separator", () => {
+    it("returns no empty token for a run of separators, or for one at either edge", () => {
       expect(splitLine("  cd   board  ")).toEqual({
         kind: "split",
         tokens: ["cd", "board"],
@@ -199,7 +200,7 @@ describe("line", () => {
       }
     });
 
-    it("returns for every awkward value text that splits back into that one value", () => {
+    it("returns text that splits back into the value it was printed from, for every value the construction drives", () => {
       // What the two halves owe each other, held over a construction rather
       // than over a list: a listed set is a slice of the class, and the
       // values nobody lists are the ones that break a printer.

--- a/packages/shuttle/test/line.test.ts
+++ b/packages/shuttle/test/line.test.ts
@@ -137,6 +137,16 @@ describe("line", () => {
       });
     });
 
+    it("returns one run of tokens for text carrying a line break, the break separating like any other", () => {
+      // A terminator is the caller's to strip, and a paste of two lines is
+      // one caller's problem rather than two commands here.
+
+      expect(splitLine("set x 1\nset y 2")).toEqual({
+        kind: "split",
+        tokens: ["set", "x", "1", "set", "y", "2"],
+      });
+    });
+
     describe("a JSON value on the line", () => {
       // The case the split exists for. A JSON object holds a space after
       // every comma and colon a person writes, so the value it is written as
@@ -179,6 +189,13 @@ describe("line", () => {
         });
       });
 
+      it("counts the column in code points, so a wide character ahead of the quote is one", () => {
+        expect(splitLine("\u{1f369} 'a b")).toEqual({
+          kind: "refused",
+          reason: "The `'` opened at column 3 is never closed.",
+        });
+      });
+
       it("refuses a line ending in a backslash", () => {
         expect(splitLine("cd a\\")).toEqual({
           kind: "refused",
@@ -216,11 +233,16 @@ describe("line", () => {
     });
 
     it("returns a value holding a syntax character in single quotes", () => {
-      expect(quoteToken('say "hi"')).toBe("'say \"hi\"'");
+      // Neither value holds a separator or a reserved character, so each
+      // rests on the syntax character alone. A fixture that also holds a
+      // space passes whether or not the quote is in the set.
+
+      expect(quoteToken('a"b')).toBe("'a\"b'");
       expect(quoteToken("a\\b")).toBe("'a\\b'");
     });
 
     it("returns a value holding a single quote in double quotes, its own quotes escaped", () => {
+      expect(quoteToken("a'b")).toBe('"a\'b"');
       expect(quoteToken('it\'s "x"')).toBe('"it\'s \\"x\\""');
     });
 

--- a/packages/shuttle/test/line.test.ts
+++ b/packages/shuttle/test/line.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Unit tests for the line split and the printer that inverts it. Both halves
+ * are pure functions over strings, so a case hands one a string and reads the
+ * value back: no connection, no terminal, and no line loop stands behind any
+ * of it.
+ *
+ * Each case is written against one mutation of `src/line.ts` — the one its
+ * description forbids — so that a case which stops discriminating stops
+ * passing. A case pinning a refusal pins the whole sentence rather than a
+ * fragment of it, since a fragment lets a rewording through that says
+ * something else.
+ *
+ * Two properties are checked over a construction rather than over listed
+ * values, because listing them is what leaves a class unguarded: every
+ * character the grammar reserves forces quoting, and every awkward value
+ * prints as text that splits back into that one value. The construction is
+ * where a value nobody would have listed gets driven.
+ */
+
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import { quoteToken, RESERVED_CHARACTERS, splitLine } from "../src/line.ts";
+
+describe("line", () => {
+  describe("RESERVED_CHARACTERS", () => {
+    it("holds the pipe, the local escape, the redirections, `#` and `%`", () => {
+      expect(RESERVED_CHARACTERS).toBe("!#%<>|");
+    });
+  });
+
+  describe("splitLine()", () => {
+    it("returns one token per run of characters between separators", () => {
+      expect(splitLine("cd slugs/board")).toEqual({
+        kind: "split",
+        tokens: ["cd", "slugs/board"],
+      });
+    });
+
+    it("separates on every whitespace character, not on the space alone", () => {
+      expect(splitLine("a\tb\nc\rd e")).toEqual({
+        kind: "split",
+        tokens: ["a", "b", "c", "d", "e"],
+      });
+    });
+
+    it("returns no tokens for a line holding separators alone", () => {
+      expect(splitLine("  \t ")).toEqual({ kind: "split", tokens: [] });
+    });
+
+    it("returns a run of separators as one separator", () => {
+      expect(splitLine("  cd   board  ")).toEqual({
+        kind: "split",
+        tokens: ["cd", "board"],
+      });
+    });
+
+    it("returns what single quotes hold as one token, whitespace and all", () => {
+      expect(splitLine("get 'a b'")).toEqual({
+        kind: "split",
+        tokens: ["get", "a b"],
+      });
+    });
+
+    it("returns a backslash inside single quotes as a character of the token", () => {
+      expect(splitLine("'a\\b'")).toEqual({
+        kind: "split",
+        tokens: ["a\\b"],
+      });
+    });
+
+    it("returns what double quotes hold as one token, whitespace and all", () => {
+      expect(splitLine('get "a b"')).toEqual({
+        kind: "split",
+        tokens: ["get", "a b"],
+      });
+    });
+
+    it("returns the character after a backslash inside double quotes, and not the backslash", () => {
+      expect(splitLine('"a\\"b"')).toEqual({
+        kind: "split",
+        tokens: ['a"b'],
+      });
+    });
+
+    it("returns the character after a backslash outside quotes, and not the backslash", () => {
+      expect(splitLine("a\\ b")).toEqual({ kind: "split", tokens: ["a b"] });
+    });
+
+    it("returns quoted and bare runs that touch as one token", () => {
+      expect(splitLine('a"b c"d')).toEqual({
+        kind: "split",
+        tokens: ["ab cd"],
+      });
+    });
+
+    it("returns an empty pair of quotes as a token that is the empty string", () => {
+      expect(splitLine("set x ''")).toEqual({
+        kind: "split",
+        tokens: ["set", "x", ""],
+      });
+    });
+
+    describe("a JSON value on the line", () => {
+      // The case the split exists for. A JSON object holds a space after
+      // every comma and colon a person writes, so the value it is written as
+      // survives only where quoting is what bounds the token.
+
+      it("returns a quoted JSON value as one token", () => {
+        expect(splitLine('set draft \'{"title": "a b"}\'')).toEqual({
+          kind: "split",
+          tokens: ["set", "draft", '{"title": "a b"}'],
+        });
+      });
+
+      it("returns an unquoted JSON value as one token per run, its quotes taken off", () => {
+        expect(splitLine('set draft {"title": "a b"}')).toEqual({
+          kind: "split",
+          tokens: ["set", "draft", "{title:", "a b}"],
+        });
+      });
+    });
+
+    describe("refusals", () => {
+      it("refuses a line whose `'` is never closed", () => {
+        expect(splitLine("cd 'a b")).toEqual({
+          kind: "refused",
+          reason: "The `'` opened at column 4 is never closed.",
+        });
+      });
+
+      it('refuses a line whose `"` is never closed, naming that quote', () => {
+        expect(splitLine('"a b')).toEqual({
+          kind: "refused",
+          reason: 'The `"` opened at column 1 is never closed.',
+        });
+      });
+
+      it("names the column the unclosed quote opened at", () => {
+        expect(splitLine('get "a b')).toEqual({
+          kind: "refused",
+          reason: 'The `"` opened at column 5 is never closed.',
+        });
+      });
+
+      it("refuses a line ending in a backslash", () => {
+        expect(splitLine("cd a\\")).toEqual({
+          kind: "refused",
+          reason: "The line ends in a `\\`, which has nothing to escape.",
+        });
+      });
+
+      it("refuses a line ending in a backslash inside a quote, naming the quote rather than the backslash", () => {
+        // Both faults are one token with no end, and the quote is the one
+        // that says where it started.
+
+        expect(splitLine('"a\\')).toEqual({
+          kind: "refused",
+          reason: 'The `"` opened at column 1 is never closed.',
+        });
+      });
+    });
+  });
+
+  describe("quoteToken()", () => {
+    it("returns a value holding nothing that needs quoting unchanged", () => {
+      expect(quoteToken("of:fid1:abcdefghijklmnop@space")).toBe(
+        "of:fid1:abcdefghijklmnop@space",
+      );
+      expect(quoteToken("topics/3")).toBe("topics/3");
+      expect(quoteToken("--json")).toBe("--json");
+    });
+
+    it("returns a value holding a separator in single quotes", () => {
+      expect(quoteToken("a b")).toBe("'a b'");
+    });
+
+    it("returns the empty value as an empty pair of quotes", () => {
+      expect(quoteToken("")).toBe("''");
+    });
+
+    it("returns a value holding a syntax character in single quotes", () => {
+      expect(quoteToken('say "hi"')).toBe("'say \"hi\"'");
+      expect(quoteToken("a\\b")).toBe("'a\\b'");
+    });
+
+    it("returns a value holding a single quote in double quotes, its own quotes escaped", () => {
+      expect(quoteToken('it\'s "x"')).toBe('"it\'s \\"x\\""');
+    });
+
+    it("escapes a backslash in the double-quoted form", () => {
+      expect(quoteToken("it's a\\b")).toBe('"it\'s a\\\\b"');
+    });
+
+    it("quotes a value holding a reserved character, wherever in the value it sits", () => {
+      for (const character of RESERVED_CHARACTERS) {
+        expect(quoteToken(`a${character}b`)).toBe(`'a${character}b'`);
+        expect(quoteToken(`${character}ab`)).toBe(`'${character}ab'`);
+      }
+    });
+
+    it("returns for every awkward value text that splits back into that one value", () => {
+      // What the two halves owe each other, held over a construction rather
+      // than over a list: a listed set is a slice of the class, and the
+      // values nobody lists are the ones that break a printer.
+
+      const marks = [
+        "",
+        " ",
+        "\t",
+        "\n",
+        "\r",
+        "\v",
+        "\f",
+        "\u00a0",
+        "\u2028",
+        "\u2029",
+        "\ufeff",
+        "'",
+        '"',
+        "\\",
+        "\\'",
+        "'\"",
+        "~",
+        ".",
+        "-",
+        "..",
+        "/",
+        "@",
+        ":",
+        "%1",
+        "€",
+        "🍩",
+        ...RESERVED_CHARACTERS,
+      ];
+      const values: string[] = [];
+      for (const mark of marks) {
+        values.push(mark, `a${mark}`, `${mark}b`, `a${mark}b`, mark + mark);
+      }
+      for (const value of values) {
+        expect(splitLine(quoteToken(value))).toEqual({
+          kind: "split",
+          tokens: [value],
+        });
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Why

Shuttle is the first surface in this system that has to split a command line
itself. `cf` reads `Deno.args` — the operating system's shell tokenizes for it,
so nothing here has ever had to decide where one argument ends and the next
begins. The design had never said how: `grammar.md`'s *The line* gave a shape
and stopped, and the word "quote" appeared in no shuttle document.

`ls` is blocked on this rather than on escaping, because **how a key prints and
how it is typed back are one decision**. Quoting is what makes the answer
conditional — the common case stays bare, and only an awkward value pays.

The case that forces a real tokenizer is `set`, whose value is JSON: a value
holding whitespace becomes one operand only through quoting, which naive
splitting cannot give you.

Follows #6796.

## What Changed

**`packages/shuttle/src/line.ts`** — the line's two halves, which are inverses.

- `splitLine(line)` — POSIX quoting. Single quotes literal; double quotes group;
  a backslash escapes one character, and **inside double quotes only a quote or
  another backslash**, so `"C:\path"` survives and JSON escapes pass through. A
  line is refused for a quote that never closes — naming the column it opened
  at, counted in code points — or a trailing backslash with nothing to escape.
- `quoteToken(value)` — bare unless the value holds a separator, a quoting
  character, or a reserved one. Single quotes first, double when the value holds
  a `'`. This is what GNU `ls` has done since 8.25.
- `RESERVED_CHARACTERS` is exported so tests drive the set rather than count it.
  `@`, `-`, `/` and `..` are deliberately out: place resolution reads them
  *inside* a token, so quoting them would quote every handle, slug, path and
  flag and leave nothing conditional about conditional quoting.

**A line is one line.** The separator class holds the terminators, so a pasted
second line arrives as more operands rather than a command of its own. That is a
choice, not a necessity — every newline-bearing value the printer emits lands
inside quotes, so refusing an unquoted one would leave the round trip whole.

**Documentation.** `grammar.md` gains *Splitting the line*. `futures.md` records
two deferred options the ruling opens: a canonical output form as a `where`
dimension, and vim keybindings, which B1c's substrate choice keeps possible.

## The property this exists for

Anything `quoteToken` emits, `splitLine` returns unchanged. Established by
driving rather than arguing: **1,885 exhaustive values** over a 12-character
adversarial alphabet, **200,000 random values**, and **50,000 multi-token
lines** — zero failures. Both quote kinds together, a lone backslash, empty, a
reserved character beside a quote, pure whitespace.

A non-breaking space, U+2028 and a BOM all split a line exactly as a space does
— `/\s/` and `String.prototype.trim` agree on all 65,536 BMP code points. That
is survivable only because the printer quotes everything it splits on.

## Test plan

- `deno fmt --check`, `deno lint`, `deno task check`, `deno task check-docs`,
  `deno task check-no-waitfor`, `deno task check-package-cycles`,
  `deno task check-control-characters` — green.
- `deno task test` in `packages/shuttle` — 199 steps, 0 failed.
- Coverage debt for `packages/shuttle`: **0**, unmoved.
- 31 cases, each verified to red under **the mutation its own name forbids** —
  and the sweep compares kill-sets, not counts, because a set-wide mutation is
  satisfied by any one member. That check caught a case which stopped
  discriminating when the backslash rule narrowed, and three pairs separating
  nothing.

One fixture in this file contained a literal no-break space for four review
rounds, displaying as an ordinary one in every diff. `check-control-characters`
covers only codepoints below 0x20. Every separator in it is now an escape.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6811?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

