### PR TITLE
fix(cli): the stderr budget survives a wall-clock diagnostic

### DIFF
--- a/docs/development/TESTING.md
+++ b/docs/development/TESTING.md
@@ -299,9 +299,10 @@ list. A warning about behavior does not, and must keep failing tests.
 
 The budget drops records rather than lines. A logger hands the console the
 values it is reporting, and a console inspects one too wide for a line across
-several, so a dropped warning that leaves a value open takes the lines closing
-it with it. One that balances on its own line takes nothing, and whatever
-follows is held to the budget as usual.
+several, so a dropped warning whose line ends by opening a bracket takes the
+indented lines beneath it and the bracket closing them. One a console fitted on
+a single line takes nothing, and whatever follows it is held to the budget as
+usual.
 
 Writing such a diagnostic so that its own coverage does not move with the clock
 is a separate obligation, and

--- a/docs/development/TESTING.md
+++ b/docs/development/TESTING.md
@@ -299,7 +299,9 @@ list. A warning about behavior does not, and must keep failing tests.
 
 The budget drops records rather than lines. A logger hands the console the
 values it is reporting, and a console inspects one too wide for a line across
-several, so the indented lines under a dropped warning go with it.
+several, so a dropped warning that leaves a value open takes the lines closing
+it with it. One that balances on its own line takes nothing, and whatever
+follows is held to the budget as usual.
 
 Writing such a diagnostic so that its own coverage does not move with the clock
 is a separate obligation, and

--- a/docs/development/TESTING.md
+++ b/docs/development/TESTING.md
@@ -282,6 +282,30 @@ Deno.exit(0);
 
 When adding runtime features, consider adding integration tests to `packages/runner/integration/` that verify the feature works end-to-end. See existing tests like `basic-persistence.test.ts` or `array_push.test.ts` for examples.
 
+### Diagnostics a test must not fail on
+
+Some of the runtime's warnings report wall time rather than behavior: the
+slow-traversal report in `packages/runner/src/traverse.ts`, above 100ms, and
+the slow-`Cell.get` report in `packages/runner/src/cell.ts`, above 50ms. A busy
+machine crosses those thresholds and an idle one does not, so a test that
+counted such a warning would pass or fail on how loaded the machine was.
+
+`packages/cli/lib/perf-diagnostic-logs.ts` holds the one list of them, by
+logger name and key prefix, and both places that hold a run's warnings to
+account read it: the pattern test runner, which fails a test on a logger
+warning the pattern did not allow, and the stderr budget the CLI tests assert
+in `packages/cli/test/utils.ts`. A new timing-triggered warning belongs on that
+list. A warning about behavior does not, and must keep failing tests.
+
+The budget drops records rather than lines. A logger hands the console the
+values it is reporting, and a console inspects one too wide for a line across
+several, so the indented lines under a dropped warning go with it.
+
+Writing such a diagnostic so that its own coverage does not move with the clock
+is a separate obligation, and
+[`COVERAGE.md`](COVERAGE.md#diagnostics-that-fire-on-wall-clock-time) carries
+it.
+
 ### Recording browser integration tests as video demos
 
 Selected `patterns` and `shell` browser integration tests can be recorded with

--- a/packages/cli/lib/console-capture.ts
+++ b/packages/cli/lib/console-capture.ts
@@ -13,6 +13,8 @@
  * globals, so each captures its own deltas.
  */
 
+import { isPerfDiagnosticWarnKey } from "./perf-diagnostic-logs.ts";
+
 interface LevelCounts {
   error: number;
   warn: number;
@@ -25,27 +27,6 @@ interface LoggerGlobal {
 
 /** Per-(logger, key) snapshot of error/warn counts at a point in time. */
 export type LoggerErrorWarnSnapshot = Map<string, LevelCounts>;
-
-/**
- * Warn-level logger keys that are PERF DIAGNOSTICS: they fire based on wall
- * time (machine speed, load), not program behavior, so failing a test on them
- * would be pure flake. They stay visible in the console; they just don't fail
- * tests. Keep this list to timing-triggered diagnostics only — behavioral
- * warnings must keep failing tests.
- */
-const PERF_DIAGNOSTIC_WARN_KEYS: ReadonlyArray<
-  { logger: string; keyPrefix: string }
-> = [
-  // cell.ts: logger.warn(`get >NNNms`, ...) — slow Cell.get, 10ms buckets.
-  { logger: "cell", keyPrefix: "get >" },
-  // traverse.ts: logger.warn("slow-traverse", ...) — slow traversal report.
-  { logger: "traverse", keyPrefix: "slow-traverse" },
-];
-
-const isPerfDiagnosticWarnKey = (loggerName: string, key: string): boolean =>
-  PERF_DIAGNOSTIC_WARN_KEYS.some((entry) =>
-    entry.logger === loggerName && key.startsWith(entry.keyPrefix)
-  );
 
 const loggerGlobals = (): Record<string, LoggerGlobal> => {
   const global = globalThis as unknown as {
@@ -79,8 +60,8 @@ export function snapshotLoggerErrorWarnCounts(): LoggerErrorWarnSnapshot {
 /**
  * Diff current logger counts against the pre-run snapshot and append a
  * `[logger:<name>] <n> error(s)/warning(s) (key: <key>)` line per (logger,
- * key) that logged during the run. Perf-diagnostic warn keys (see above) are
- * skipped.
+ * key) that logged during the run. A warn key that
+ * `perf-diagnostic-logs.ts` names a perf diagnostic is skipped.
  */
 export function appendLoggerDeltaMessages(
   snapshot: LoggerErrorWarnSnapshot,

--- a/packages/cli/lib/perf-diagnostic-logs.ts
+++ b/packages/cli/lib/perf-diagnostic-logs.ts
@@ -1,0 +1,37 @@
+/**
+ * The warn-level logger keys that are PERF DIAGNOSTICS.
+ *
+ * A perf diagnostic fires on wall time — how fast the machine is and how
+ * loaded it happens to be — rather than on anything the program did. Failing a
+ * test on one would make that test's outcome a function of load, so every
+ * place that holds a run's warnings to account skips them: the pattern test
+ * runner's logger count deltas in `console-capture.ts`, and the stderr budget
+ * the CLI tests assert in `test/utils.ts`. They stay visible in the console
+ * either way, which is what they are for.
+ *
+ * Keep the list to timing-triggered diagnostics only. A warning about behavior
+ * must keep failing tests.
+ */
+
+const PERF_DIAGNOSTIC_WARN_KEYS: ReadonlyArray<
+  { logger: string; keyPrefix: string }
+> = [
+  // cell.ts: logger.warn(`get >NNNms`, ...) — slow Cell.get, 10ms buckets.
+  { logger: "cell", keyPrefix: "get >" },
+  // traverse.ts: logger.warn("slow-traverse", ...) — slow traversal report.
+  { logger: "traverse", keyPrefix: "slow-traverse" },
+];
+
+/**
+ * True when `key`, logged by `loggerName`, names a perf diagnostic. A key that
+ * carries a measurement, as the slow-`Cell.get` report's bucket does, matches
+ * on its prefix.
+ */
+export function isPerfDiagnosticWarnKey(
+  loggerName: string,
+  key: string,
+): boolean {
+  return PERF_DIAGNOSTIC_WARN_KEYS.some((entry) =>
+    entry.logger === loggerName && key.startsWith(entry.keyPrefix)
+  );
+}

--- a/packages/cli/test/exec-read-options.test.ts
+++ b/packages/cli/test/exec-read-options.test.ts
@@ -19,7 +19,7 @@ import {
   type CellSelection,
   parseCellSelectionOptions,
 } from "../lib/cell-selection.ts";
-import { cf, isIgnorableDenoWarningLine } from "./utils.ts";
+import { cf, relevantStderr } from "./utils.ts";
 
 /**
  * `cf exec`'s read options and the shape it emits.
@@ -515,8 +515,8 @@ describe("cf exec read options", () => {
     const { code, stderr } = await cf(
       `exec --select id ${missing} --query milk`,
     );
-    const relevant = stderr.filter((line) =>
-      !line.includes("deno run ") && !isIgnorableDenoWarningLine(line)
+    const relevant = relevantStderr(stderr).filter((line) =>
+      !line.includes("deno run ")
     ).join("\n");
 
     expect(code).not.toBe(0);
@@ -541,8 +541,8 @@ describe("cf exec read options", () => {
     );
 
     expect(code).not.toBe(0);
-    const relevant = stderr.filter((line) =>
-      !line.includes("deno run ") && !isIgnorableDenoWarningLine(line)
+    const relevant = relevantStderr(stderr).filter((line) =>
+      !line.includes("deno run ")
     );
     expect(relevant.join("\n")).toContain("--schema");
     expect(relevant.join("\n")).toContain("--select");

--- a/packages/cli/test/exec.test.ts
+++ b/packages/cli/test/exec.test.ts
@@ -21,7 +21,7 @@ import {
 import { writeMountState } from "../lib/fuse.ts";
 import { CF_RUNTIME_ERROR_LOG } from "../lib/callable.ts";
 import type { SpaceConfig } from "../lib/piece.ts";
-import { cf, isIgnorableDenoWarningLine } from "./utils.ts";
+import { cf, relevantStderr } from "./utils.ts";
 
 function makeSpec(
   callableKind: "handler" | "tool",
@@ -1975,15 +1975,15 @@ describe("exec command user-facing errors", () => {
     expect(code).toBe(1);
     expect(stdout).toEqual([]);
 
-    const relevantStderr = stderr.filter((line) =>
-      !line.includes("deno run ") && !isIgnorableDenoWarningLine(line)
+    const relevant = relevantStderr(stderr).filter((line) =>
+      !line.includes("deno run ")
     );
 
-    expect(relevantStderr).toEqual([
+    expect(relevant).toEqual([
       `Path is not within a mounted cf fuse filesystem: ${missingPath}`,
     ]);
-    expect(relevantStderr.join("\n")).not.toMatch(/\n\s*at\s+/);
-    expect(relevantStderr.join("\n")).not.toMatch(
+    expect(relevant.join("\n")).not.toMatch(/\n\s*at\s+/);
+    expect(relevant.join("\n")).not.toMatch(
       /executeMountedCallableFile|resolveMountedCallableFile/,
     );
   });

--- a/packages/cli/test/perf-diagnostic-logs.test.ts
+++ b/packages/cli/test/perf-diagnostic-logs.test.ts
@@ -1,3 +1,12 @@
+/**
+ * Covers `isPerfDiagnosticWarnKey()`, which decides whether a warn-level
+ * logger key names a perf diagnostic: a warning that fires on how long
+ * something took, and so on how fast the machine is and how loaded it happens
+ * to be, rather than on anything the program did. The list of them exists so
+ * that a run's warnings can be held to account without a test's outcome
+ * turning on the load, and each case here puts a key on one side of it.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 

--- a/packages/cli/test/perf-diagnostic-logs.test.ts
+++ b/packages/cli/test/perf-diagnostic-logs.test.ts
@@ -1,0 +1,22 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { isPerfDiagnosticWarnKey } from "../lib/perf-diagnostic-logs.ts";
+
+describe("isPerfDiagnosticWarnKey()", () => {
+  it("returns `true` for the key a slow traversal reports under", () => {
+    expect(isPerfDiagnosticWarnKey("traverse", "slow-traverse")).toBe(true);
+  });
+
+  it("returns `true` for a slow `Cell.get`, whose key carries its bucket", () => {
+    expect(isPerfDiagnosticWarnKey("cell", "get >210ms")).toBe(true);
+  });
+
+  it("returns `false` for a perf key another logger emitted", () => {
+    expect(isPerfDiagnosticWarnKey("cell", "slow-traverse")).toBe(false);
+  });
+
+  it("returns `false` for another key of a logger that has a perf key", () => {
+    expect(isPerfDiagnosticWarnKey("cell", "pull")).toBe(false);
+  });
+});

--- a/packages/cli/test/stderr-budget.test.ts
+++ b/packages/cli/test/stderr-budget.test.ts
@@ -1,3 +1,17 @@
+/**
+ * Covers the stderr budget the CLI tests hold a command to:
+ * `relevantStderr()`, which says which of the lines a command wrote to stderr
+ * a test has business counting, and `checkStderr()`, which holds that count
+ * to the one line `deno task` echoes.
+ *
+ * What the budget counts is a record rather than a line, because a console
+ * handed a value too wide for one line writes it back across several. So the
+ * fixtures come from a real logger rather than being written out here: the
+ * prefix a logger writes and the shape a console gives a spilled value are
+ * the two things the budget reads, and a string composed here would pin these
+ * tests to a guess at that shape instead of to the shape itself.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 

--- a/packages/cli/test/stderr-budget.test.ts
+++ b/packages/cli/test/stderr-budget.test.ts
@@ -89,6 +89,15 @@ const REPORTED_LINK = {
   type: "application/json",
 };
 
+// The same link, with a path segment that is a bracket. A segment is
+// arbitrary text, and a console prints this one in its quotes, indented, on a
+// line of the record's own.
+const LINK_WITH_A_BRACKET_IN_ITS_PATH = { ...REPORTED_LINK, path: ["["] };
+
+// A link narrow enough for a console to print on one line, holding the same
+// bracket.
+const NARROW_LINK_WITH_A_BRACKET = { path: ["["] };
+
 describe("stderr budget", () => {
   describe("relevantStderr()", () => {
     it("keeps a line the command itself wrote", () => {
@@ -177,6 +186,38 @@ describe("stderr budget", () => {
       ]);
     });
 
+    it("keeps an indented line that follows a report whose value holds a bracket", () => {
+      const report = logLines(
+        "warn",
+        "cell",
+        "get >210ms",
+        "get() took 213ms",
+        LINK_WITH_A_BRACKET_IN_ITS_PATH,
+      );
+
+      expect(report.length).toBeGreaterThan(1);
+      expect(relevantStderr([TASK_ECHO, ...report, STACK_LINE])).toEqual([
+        TASK_ECHO,
+        STACK_LINE,
+      ]);
+    });
+
+    it("keeps an indented line that follows a report holding a bracket on one line", () => {
+      const report = logLines(
+        "warn",
+        "cell",
+        "get >210ms",
+        "get() took 213ms",
+        NARROW_LINK_WITH_A_BRACKET,
+      );
+
+      expect(report.length).toBe(1);
+      expect(relevantStderr([TASK_ECHO, ...report, STACK_LINE])).toEqual([
+        TASK_ECHO,
+        STACK_LINE,
+      ]);
+    });
+
     it("keeps an error a logger wrote under a perf-diagnostic key", () => {
       const report = logLines("error", "traverse", "slow-traverse", "321ms");
 
@@ -213,6 +254,22 @@ describe("stderr budget", () => {
 
     it("throws where an indented line follows a slow-traversal report", async () => {
       const report = logLines("warn", "traverse", "slow-traverse", "321ms");
+
+      await captureStderr(() => {
+        expect(() => checkStderr([TASK_ECHO, ...report, STACK_LINE]))
+          .toThrow();
+        return Promise.resolve();
+      });
+    });
+
+    it("throws where an indented line follows a report whose value holds a bracket", async () => {
+      const report = logLines(
+        "warn",
+        "cell",
+        "get >210ms",
+        "get() took 213ms",
+        LINK_WITH_A_BRACKET_IN_ITS_PATH,
+      );
 
       await captureStderr(() => {
         expect(() => checkStderr([TASK_ECHO, ...report, STACK_LINE]))

--- a/packages/cli/test/stderr-budget.test.ts
+++ b/packages/cli/test/stderr-budget.test.ts
@@ -62,6 +62,24 @@ function render(prefix: string, values: unknown[]): string {
   ].join(" ");
 }
 
+// A slow-traversal report as a console renders it, its prefix wrapped in the
+// escapes that color it. The prefix is the first space-delimited token of the
+// line, which is what the logger hands the console separately from the rest.
+function coloredSlowTraverseLine(): string {
+  const [prefix, ...rest] = logLines(
+    "warn",
+    "traverse",
+    "slow-traverse",
+    "321ms",
+  )[0].split(" ");
+  return `\x1b[36m${prefix}\x1b[0m ${rest.join(" ")}`;
+}
+
+// A line of a stack trace, which is indented and holds a balanced pair of
+// parentheses, so nothing about its own shape says whether it continues the
+// line above it.
+const STACK_LINE = "    at executeCommand (cli.ts:42:7)";
+
 // The link a slow-`Cell.get` report names. It is too wide for one line, so a
 // console inspects it across several.
 const REPORTED_LINK = {
@@ -101,15 +119,18 @@ describe("stderr budget", () => {
     });
 
     it("drops a report whose prefix a console colored", () => {
-      const [prefix, ...rest] = logLines(
-        "warn",
-        "traverse",
-        "slow-traverse",
-        "321ms",
-      )[0].split(" ");
-      const colored = `\x1b[36m${prefix}\x1b[0m ${rest.join(" ")}`;
+      expect(relevantStderr([TASK_ECHO, coloredSlowTraverseLine()])).toEqual([
+        TASK_ECHO,
+      ]);
+    });
 
-      expect(relevantStderr([TASK_ECHO, colored])).toEqual([TASK_ECHO]);
+    it("keeps a line that follows a report whose prefix a console colored", () => {
+      const colored = coloredSlowTraverseLine();
+
+      expect(relevantStderr([TASK_ECHO, colored, "no such piece"])).toEqual([
+        TASK_ECHO,
+        "no such piece",
+      ]);
     });
 
     it("drops every line of a report whose value a console inspected", () => {
@@ -125,11 +146,34 @@ describe("stderr budget", () => {
       expect(relevantStderr([TASK_ECHO, ...report])).toEqual([TASK_ECHO]);
     });
 
+    it("drops every line of a report whose message closes a bracket it never opened", () => {
+      const report = logLines(
+        "warn",
+        "cell",
+        "get >210ms",
+        "get() took 213ms)",
+        REPORTED_LINK,
+      );
+
+      expect(report.length).toBeGreaterThan(1);
+      expect(relevantStderr([TASK_ECHO, ...report])).toEqual([TASK_ECHO]);
+    });
+
     it("keeps a command's line that follows an ignorable record", () => {
       const report = logLines("warn", "traverse", "slow-traverse", "321ms");
 
       expect(relevantStderr([...report, "no such piece"])).toEqual([
         "no such piece",
+      ]);
+    });
+
+    it("keeps an indented line that follows a report closing on its own line", () => {
+      const report = logLines("warn", "traverse", "slow-traverse", "321ms");
+
+      expect(report.length).toBe(1);
+      expect(relevantStderr([TASK_ECHO, ...report, STACK_LINE])).toEqual([
+        TASK_ECHO,
+        STACK_LINE,
       ]);
     });
 
@@ -163,6 +207,16 @@ describe("stderr budget", () => {
 
       await captureStderr(() => {
         expect(() => checkStderr([TASK_ECHO, "no such piece"])).toThrow();
+        return Promise.resolve();
+      });
+    });
+
+    it("throws where an indented line follows a slow-traversal report", async () => {
+      const report = logLines("warn", "traverse", "slow-traverse", "321ms");
+
+      await captureStderr(() => {
+        expect(() => checkStderr([TASK_ECHO, ...report, STACK_LINE]))
+          .toThrow();
         return Promise.resolve();
       });
     });

--- a/packages/cli/test/stderr-budget.test.ts
+++ b/packages/cli/test/stderr-budget.test.ts
@@ -1,0 +1,170 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { decode } from "@commonfabric/utils/encoding";
+import { getLogger } from "@commonfabric/utils/logger";
+import { captureStderr, checkStderr, relevantStderr } from "./utils.ts";
+
+// The line `deno task` echoes before it runs the CLI. Every command the tests
+// spawn goes through that task, so it is the one line a passing budget holds.
+const TASK_ECHO =
+  "Task cli-no-pwd-override CF_CLI_NAME=cf deno run --allow-net ./mod.ts 'id'";
+
+/**
+ * Emits `key` and `messages` through a real logger named `loggerName` at
+ * `level`, and returns the stderr lines it writes.
+ *
+ * The prefix carries a timestamp and a shape only the logger knows, and a
+ * console inspects a value too wide for a line across several, so both come
+ * from the real thing rather than being written out here.
+ *
+ * A logger writes straight to stderr under `LOG_TO_STDERR` and through a
+ * console otherwise, and both are captured, so what these tests hold is the
+ * same either way. On the console path `%c` heads the prefix and its CSS
+ * follows as a separate argument, which a console consumes to color what comes
+ * next; rendering the rest is what the logger's own stderr path does with it.
+ */
+function logLines(
+  level: "warn" | "error",
+  loggerName: string,
+  key: string,
+  ...messages: unknown[]
+): string[] {
+  const logger = getLogger(loggerName, { enabled: true, level: "warn" });
+  const lines: string[] = [];
+  const originalConsole = console[level];
+  const originalWrite = Deno.stderr.writeSync;
+  console[level] = (...args: unknown[]) => {
+    const [prefix, _color, ...rest] = args as [string, string, ...unknown[]];
+    lines.push(render(prefix.replace("%c", ""), rest));
+  };
+  Deno.stderr.writeSync = (bytes: Uint8Array) => {
+    lines.push(decode(bytes).trimEnd());
+    return bytes.byteLength;
+  };
+  try {
+    logger[level](key, ...messages);
+  } finally {
+    console[level] = originalConsole;
+    Deno.stderr.writeSync = originalWrite;
+  }
+  return lines.join("\n").split("\n");
+}
+
+// Renders one log record the way the logger renders it for stderr: each value
+// that is not already a string inspected, and the lot joined by spaces.
+function render(prefix: string, values: unknown[]): string {
+  return [
+    prefix,
+    ...values.map((value) =>
+      typeof value === "string" ? value : Deno.inspect(value, { colors: false })
+    ),
+  ].join(" ");
+}
+
+// The link a slow-`Cell.get` report names. It is too wide for one line, so a
+// console inspects it across several.
+const REPORTED_LINK = {
+  id: "of:baedreiaddonutdonutdonutdonutdonutdonutdonutdonutdonutdonut",
+  path: ["value", "items", "0", "label"],
+  space: "did:key:z6MkdonutdonutdonutdonutdonutdonutdonutdonutdonutXY",
+  type: "application/json",
+};
+
+describe("stderr budget", () => {
+  describe("relevantStderr()", () => {
+    it("keeps a line the command itself wrote", () => {
+      expect(relevantStderr([TASK_ECHO, "no such piece"])).toEqual([
+        TASK_ECHO,
+        "no such piece",
+      ]);
+    });
+
+    it("drops the lines Deno writes for a cold module cache", () => {
+      expect(relevantStderr([
+        "Download https://jsr.io/@std/path/1.0.0/mod.ts",
+        TASK_ECHO,
+      ])).toEqual([TASK_ECHO]);
+    });
+
+    it("drops a slow-traversal report, which fires on wall time", () => {
+      const report = logLines(
+        "warn",
+        "traverse",
+        "slow-traverse",
+        "321ms",
+        "doc=of:donut/application/json",
+      );
+
+      expect(report.length).toBe(1);
+      expect(relevantStderr([TASK_ECHO, ...report])).toEqual([TASK_ECHO]);
+    });
+
+    it("drops a report whose prefix a console colored", () => {
+      const [prefix, ...rest] = logLines(
+        "warn",
+        "traverse",
+        "slow-traverse",
+        "321ms",
+      )[0].split(" ");
+      const colored = `\x1b[36m${prefix}\x1b[0m ${rest.join(" ")}`;
+
+      expect(relevantStderr([TASK_ECHO, colored])).toEqual([TASK_ECHO]);
+    });
+
+    it("drops every line of a report whose value a console inspected", () => {
+      const report = logLines(
+        "warn",
+        "cell",
+        "get >210ms",
+        "get() took 213ms",
+        REPORTED_LINK,
+      );
+
+      expect(report.length).toBeGreaterThan(1);
+      expect(relevantStderr([TASK_ECHO, ...report])).toEqual([TASK_ECHO]);
+    });
+
+    it("keeps a command's line that follows an ignorable record", () => {
+      const report = logLines("warn", "traverse", "slow-traverse", "321ms");
+
+      expect(relevantStderr([...report, "no such piece"])).toEqual([
+        "no such piece",
+      ]);
+    });
+
+    it("keeps an error a logger wrote under a perf-diagnostic key", () => {
+      const report = logLines("error", "traverse", "slow-traverse", "321ms");
+
+      expect(relevantStderr(report)).toEqual(report);
+    });
+
+    it("keeps a warning a logger wrote about behavior", () => {
+      const report = logLines("warn", "cell", "pull", "no such document");
+
+      expect(relevantStderr(report)).toEqual(report);
+    });
+  });
+
+  describe("checkStderr()", () => {
+    it("accepts stderr holding only the task echo", () => {
+      checkStderr([TASK_ECHO]);
+    });
+
+    it("accepts a slow-traversal report beside the task echo", () => {
+      const report = logLines("warn", "traverse", "slow-traverse", "321ms");
+
+      checkStderr([TASK_ECHO, ...report]);
+    });
+
+    it("throws where the command wrote a line of its own", async () => {
+      // `checkStderr` prints the whole of stderr before it rethrows, so the
+      // failing call runs under a captured console.
+
+      await captureStderr(() => {
+        expect(() => checkStderr([TASK_ECHO, "no such piece"])).toThrow();
+        return Promise.resolve();
+      });
+    });
+  });
+});

--- a/packages/cli/test/utils.ts
+++ b/packages/cli/test/utils.ts
@@ -29,13 +29,14 @@ function isPerfDiagnosticLogLine(line: string): boolean {
   return isPerfDiagnosticWarnKey(loggerName, keyAndMessage);
 }
 
-// True when `line` opens a record a test has no business asserting on: noise
-// Deno itself writes, and the runtime's perf diagnostics. Neither says
-// anything about the command that ran — Deno's lines report the state of the
-// module cache, and a perf diagnostic reports how loaded the machine was — so
-// a test counting them would pass or fail on a fact about the machine.
+// True when `line`, which comes with its ANSI escapes stripped, opens a record
+// a test has no business asserting on: noise Deno itself writes, and the
+// runtime's perf diagnostics. Neither says anything about the command that ran
+// — Deno's lines report the state of the module cache, and a perf diagnostic
+// reports how loaded the machine was — so a test counting them would pass or
+// fail on a fact about the machine.
 function isIgnorableStderrLine(line: string): boolean {
-  const trimmed = stripAnsi(line).trimStart();
+  const trimmed = line.trimStart();
   return trimmed.startsWith(
     "Warning The following peer dependency issues were found:",
   ) ||
@@ -50,45 +51,47 @@ function isIgnorableStderrLine(line: string): boolean {
     isPerfDiagnosticLogLine(trimmed);
 }
 
-// The bracket characters a console pairs off when it inspects a value.
-const OPENING_BRACKETS = "([{";
-const CLOSING_BRACKETS = ")]}";
-
-// How many brackets stand open after `line`, given that `openBefore` of them
-// already did. `line` comes with its ANSI escapes stripped, because each of
-// those carries a `[` that pairs with nothing. The count floors at zero, so
-// that a closer with no opener above it — one inside a message, say — cannot
-// carry a deficit down into the lines below.
-function bracketsStillOpen(openBefore: number, line: string): number {
-  let open = openBefore;
-  for (const character of line) {
-    if (OPENING_BRACKETS.includes(character)) open += 1;
-    else if (CLOSING_BRACKETS.includes(character)) open = Math.max(0, open - 1);
-  }
-  return open;
-}
+// A console handed a value too wide for one line spills it over several, and
+// the shape of that spill is what says which lines below a record belong to
+// it. The bracket the console opens ends the line it opened on, every line of
+// the value is indented, and the bracket closes alone at column 0. Text the
+// value holds passes for neither end, because a console prints a string in its
+// quotes: a `[` in one never ends the line, and a `}` in one is indented and
+// quoted rather than standing alone.
+const OPENS_SPILLED_VALUE = /[[({]$/;
+const INSIDE_SPILLED_VALUE = /^\s/;
+const CLOSES_SPILLED_VALUE = /^[)\]}]+$/;
 
 /**
  * The lines of `stderr` a test has business asserting on: everything left
  * once the ignorable records are dropped.
  *
  * A record rather than a line, so that an ignorable line takes with it the
- * lines a console spilled inspecting a value it was handed. The brackets are
- * what say how far that reaches: the record runs until the value its first
- * line left open is closed again, so an ignorable line that balances takes
- * nothing with it, whatever the line beneath it happens to look like.
+ * lines a console spilled inspecting a value it was handed. Only a line ending
+ * in the bracket that opens such a value starts a record, and the record ends
+ * at the bracket closing it, so an ignorable line a console fitted on its own
+ * takes nothing with it whatever the line beneath happens to look like.
+ *
+ * A record a console shaped some other way is under-consumed rather than
+ * over-consumed: where something follows the value on the line closing it,
+ * that line is left for the budget, which fails the test reading it rather
+ * than hiding whatever the command wrote next.
  */
 export function relevantStderr(stderr: string[]): string[] {
   const relevant: string[] = [];
-  let open = 0;
+  let spilling = false;
   for (const line of stderr) {
     const plain = stripAnsi(line);
-    if (open > 0) {
-      open = bracketsStillOpen(open, plain);
-      continue;
+    if (spilling) {
+      if (CLOSES_SPILLED_VALUE.test(plain)) {
+        spilling = false;
+        continue;
+      }
+      if (INSIDE_SPILLED_VALUE.test(plain)) continue;
+      spilling = false;
     }
     if (isIgnorableStderrLine(plain)) {
-      open = bracketsStillOpen(0, plain);
+      spilling = OPENS_SPILLED_VALUE.test(plain);
       continue;
     }
     relevant.push(line);

--- a/packages/cli/test/utils.ts
+++ b/packages/cli/test/utils.ts
@@ -50,30 +50,47 @@ function isIgnorableStderrLine(line: string): boolean {
     isPerfDiagnosticLogLine(trimmed);
 }
 
-// True when `line` continues the record above it rather than opening one of
-// its own. A logger hands the console the values it reports, and a console
-// inspects one too wide for a line across several: the lines after the first
-// are indented, and the bracket the first opened closes alone on the last.
-const CONTINUATION_LINE = /^\s|^[\]})]+,?$/;
+// The bracket characters a console pairs off when it inspects a value.
+const OPENING_BRACKETS = "([{";
+const CLOSING_BRACKETS = ")]}";
+
+// How many brackets stand open after `line`, given that `openBefore` of them
+// already did. `line` comes with its ANSI escapes stripped, because each of
+// those carries a `[` that pairs with nothing. The count floors at zero, so
+// that a closer with no opener above it — one inside a message, say — cannot
+// carry a deficit down into the lines below.
+function bracketsStillOpen(openBefore: number, line: string): number {
+  let open = openBefore;
+  for (const character of line) {
+    if (OPENING_BRACKETS.includes(character)) open += 1;
+    else if (CLOSING_BRACKETS.includes(character)) open = Math.max(0, open - 1);
+  }
+  return open;
+}
 
 /**
  * The lines of `stderr` a test has business asserting on: everything left
  * once the ignorable records are dropped.
  *
- * A record rather than a line, so that an ignorable line takes the
- * continuations beneath it along with it. A budget over lines alone would
- * count the tail of an inspected value as though the command had written it.
+ * A record rather than a line, so that an ignorable line takes with it the
+ * lines a console spilled inspecting a value it was handed. The brackets are
+ * what say how far that reaches: the record runs until the value its first
+ * line left open is closed again, so an ignorable line that balances takes
+ * nothing with it, whatever the line beneath it happens to look like.
  */
 export function relevantStderr(stderr: string[]): string[] {
   const relevant: string[] = [];
-  let ignoring = false;
+  let open = 0;
   for (const line of stderr) {
-    if (isIgnorableStderrLine(line)) {
-      ignoring = true;
+    const plain = stripAnsi(line);
+    if (open > 0) {
+      open = bracketsStillOpen(open, plain);
       continue;
     }
-    if (ignoring && CONTINUATION_LINE.test(stripAnsi(line))) continue;
-    ignoring = false;
+    if (isIgnorableStderrLine(plain)) {
+      open = bracketsStillOpen(0, plain);
+      continue;
+    }
     relevant.push(line);
   }
   return relevant;

--- a/packages/cli/test/utils.ts
+++ b/packages/cli/test/utils.ts
@@ -2,6 +2,7 @@ import { expect } from "@std/expect/expect";
 import { join } from "@std/path";
 
 import { decode, encode } from "@commonfabric/utils/encoding";
+import { isPerfDiagnosticWarnKey } from "../lib/perf-diagnostic-logs.ts";
 
 // Decodes a `Uint8Array` into an array of strings for each line.
 export function bytesToLines(stream: Uint8Array): string[] {
@@ -15,7 +16,25 @@ export function stripAnsi(text: string): string {
   return text.replace(ANSI_RE, "");
 }
 
-export function isIgnorableDenoWarningLine(line: string): boolean {
+// A tagged logger writes `[WARN][<logger>::<HH:MM:SS.mmm>] <key> <message…>`,
+// straight to stderr under LOG_TO_STDERR and through `console.warn` otherwise,
+// which Deno also sends to stderr.
+const TAGGED_WARN_LINE = /^\[WARN\]\[(.+)::\d\d:\d\d:\d\d\.\d\d\d\] (.*)$/;
+
+// True when `line` is one a logger wrote at warn level for a perf diagnostic.
+function isPerfDiagnosticLogLine(line: string): boolean {
+  const match = TAGGED_WARN_LINE.exec(line);
+  if (match === null) return false;
+  const [, loggerName, keyAndMessage] = match;
+  return isPerfDiagnosticWarnKey(loggerName, keyAndMessage);
+}
+
+// True when `line` opens a record a test has no business asserting on: noise
+// Deno itself writes, and the runtime's perf diagnostics. Neither says
+// anything about the command that ran — Deno's lines report the state of the
+// module cache, and a perf diagnostic reports how loaded the machine was — so
+// a test counting them would pass or fail on a fact about the machine.
+function isIgnorableStderrLine(line: string): boolean {
   const trimmed = stripAnsi(line).trimStart();
   return trimmed.startsWith(
     "Warning The following peer dependency issues were found:",
@@ -27,11 +46,45 @@ export function isIgnorableDenoWarningLine(line: string): boolean {
     // is cold, which happens on a fresh machine and after any change that
     // invalidates the cache, such as a Deno version bump.
     trimmed.startsWith("Download ") ||
-    /^[└├]/u.test(trimmed);
+    /^[└├]/u.test(trimmed) ||
+    isPerfDiagnosticLogLine(trimmed);
 }
 
+// True when `line` continues the record above it rather than opening one of
+// its own. A logger hands the console the values it reports, and a console
+// inspects one too wide for a line across several: the lines after the first
+// are indented, and the bracket the first opened closes alone on the last.
+const CONTINUATION_LINE = /^\s|^[\]})]+,?$/;
+
+/**
+ * The lines of `stderr` a test has business asserting on: everything left
+ * once the ignorable records are dropped.
+ *
+ * A record rather than a line, so that an ignorable line takes the
+ * continuations beneath it along with it. A budget over lines alone would
+ * count the tail of an inspected value as though the command had written it.
+ */
+export function relevantStderr(stderr: string[]): string[] {
+  const relevant: string[] = [];
+  let ignoring = false;
+  for (const line of stderr) {
+    if (isIgnorableStderrLine(line)) {
+      ignoring = true;
+      continue;
+    }
+    if (ignoring && CONTINUATION_LINE.test(stripAnsi(line))) continue;
+    ignoring = false;
+    relevant.push(line);
+  }
+  return relevant;
+}
+
+/**
+ * Asserts that the only thing the command wrote to stderr is the line
+ * `deno task` echoes naming what it ran.
+ */
 export function checkStderr(stderr: string[]) {
-  const relevant = stderr.filter((line) => !isIgnorableDenoWarningLine(line));
+  const relevant = relevantStderr(stderr);
   try {
     expect(relevant.length).toBe(1);
   } catch (e) {


### PR DESCRIPTION
## Why

Closes #6810.

`checkStderr` (`packages/cli/test/utils.ts`) allowed exactly one line of stderr
past a list of Deno's own noise. That list encoded the assumption that nothing
else writes to stderr, and the assumption is false: `packages/runner`'s
`slow-traverse` warning fires on elapsed wall time — `SLOW_TRAVERSE_MS = 100`,
and `if (elapsed <= SLOW_TRAVERSE_MS) return;` — so on a machine loaded enough
for one traversal to cross 100ms, a second line appears and a test that never
went near the runner turns red.

That makes the test's outcome a function of how busy the machine is rather
than of the code it covers, which is a defect rather than a flake. It fired
three times over 2026-09-02/03, on two branches that touched neither file.

The repository already knows these warnings are not evidence:
`console-capture.ts` carried a `PERF_DIAGNOSTIC_WARN_KEYS` list so the pattern
test runner would not fail a test on one. The stderr budget did not read it.

## What Changed

- `packages/cli/lib/perf-diagnostic-logs.ts` (new) holds the list of warn keys
  that fire on wall time, with `isPerfDiagnosticWarnKey()`. Both places that
  hold a run's warnings to account now read one list: the pattern test runner's
  logger count deltas, and the CLI tests' stderr budget.
- `isIgnorableDenoWarningLine` becomes `isIgnorableStderrLine` — it no longer
  covers only Deno's noise — and the budget moves behind a new
  `relevantStderr()`, which the two `exec` test files also use in place of
  repeating the filter.
- `relevantStderr()` drops **records**, not lines. A logger hands the console
  the values it reports, and a console inspects one too wide for a line across
  several: the slow-`Cell.get` diagnostic reports a link, which spills over six
  lines. So the same defect cannot arrive through the other listed diagnostic.
- `docs/development/TESTING.md` gains "Diagnostics a test must not fail on",
  naming the one list and the rule for adding to it.

### How a record's end is decided, and the two rules that came before

A record ends by the shape a console actually emits: it opens only where an
ignorable line **ends** with an opening bracket, runs through indented lines,
and ends at a line that is only closing brackets. Quoted text can impersonate
neither end — a `[` inside a string never ends the line, and a `}` inside one
renders indented and quoted rather than alone at column 0.

Two earlier rules in this branch decided it by a proxy instead, and both turned
a real violation into a **false pass** in `checkStderr` — the inverse of the
flake this PR exists to fix. They are recorded here because the shape is worth
recognizing, and because the tests that catch them are in the diff:

1. **Positional** — any indented line after an ignorable one. It swallows a
   command's own stack frame that happens to follow a diagnostic.
2. **Bracket counting** — track the brackets a record leaves open. A link whose
   path holds a bracket renders `path: [ "[" ]` on a single line and latches
   the counter positive for the rest of the stream.

Quote-aware counting does not rescue rule 2: `Deno.inspect({ a: 'he said "hi"' })`
renders `{ a: 'he said "hi"' }`, because Deno switches to single quotes when a
string contains a double quote, so a `"`-only scanner mis-pairs on real output
and one honoring both breaks on an apostrophe in an unquoted message.

The shape rule fails in the safe direction by construction. A record a console
shaped some other way is **under**-consumed, which leaves a line for the budget
to fail on rather than hiding whatever the command wrote next.

## Test plan

- `packages/cli/test/stderr-budget.test.ts` and
  `packages/cli/test/perf-diagnostic-logs.test.ts` (new). Every fixture is
  emitted through a **real logger** and captured from both of its emit paths
  (`LOG_TO_STDERR` and the console), rather than written out by hand, so a
  change to the logger's prefix or to how a console spills a wide value reds
  these tests instead of leaving them agreeing with themselves. Both files pass
  with and without `LOG_TO_STDERR=1`.
- Each rule above was confirmed **red before green**: the tests for rule 2's
  defect were run against rule 2 and seen to fail before the fix landed.
- Mutation-checked, one mutation per element of the rule — never opening a
  record, opening on every ignorable line, matching an opener anywhere rather
  than at the end, dropping the closing-bracket branch, dropping the indented
  branch, dropping the ANSI strip, and restoring each earlier rule. Every one
  reds, and each reds the case written for it.
- `deno task check`, `deno fmt --check`, `deno lint packages/cli`,
  `deno task check-docs`, and the `check-*` gates all pass.
- `packages/cli` full suite green: 1774 + 1 + 211 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FxZgfAjopJFZrvVsaf1yua
