### PR TITLE
docs(test-selection): drop the arrival journal from the plan

### DIFF
--- a/docs/plans/pull-request-test-selection.md
+++ b/docs/plans/pull-request-test-selection.md
@@ -1,8 +1,11 @@
 # Choosing which tests a pull request runs
 
-Status: proposed. Nothing here is built yet. The record store this plan
-consumes is live and holds the data the design needs; the gaps it does not
-yet hold are listed under [What the store is
+Status: in progress. Part one is built apart from the manifest retention,
+the one-off bootstrap dispatch, and two dashboard tiles; part two is built
+apart from its continuous-integration configuration and the coverage work;
+part three has not started. [The work](#the-work) carries the detail. The
+record store this plan consumes is live and holds the data the design
+needs; the gaps it does not yet hold are listed under [What the store is
 missing](#what-the-store-is-missing) and closed by the first part of the
 work.
 
@@ -1144,16 +1147,16 @@ nothing: their identity is the path already.
 The record schema already carries the field, so no format changes, and
 nothing downstream of the store has to know this happened.
 
-**Nothing has compacted a day yet.** The `aggregated/` area is empty and
-the compactor principal is not provisioned. Compaction collapses a day of
-raw records into a manifest and a few tens of shards, which is the
-difference between reading 15,000 objects for a historical day and reading
-a manifest and seventeen shards. A day is a manifest and shards rather than a single object: a
+**Compaction is live now, and was not when this was written.** The
+compactor's identity was provisioned on 2026-08-31 and its daily workflow
+has rolled up 2026-08-19 through 2026-08-26, which is every day closed
+long enough for it to touch. Compaction collapses a day of raw records
+into a manifest and a few tens of shards, which is the difference between
+reading 15,000 objects for a historical day and reading a manifest and
+seventeen shards. A day is a manifest and shards rather than a single object: a
 day of records is over a gigabyte of NDJSON, against a maximum string
 length of about half that, and an object has to fit in a string both to be
-written and to be read. The compactor is implemented and handles days at
-that size; provisioning it is a small infra change and this plan
-recommends doing it, but does not depend on it.
+written and to be read.
 
 **A re-run's earlier attempts can be stored a second time.** An object's
 day partition comes from the run's start time, and GitHub reports that
@@ -2071,8 +2074,7 @@ The job:
    and source-and-date rollup receipts already folded, along with the
    aggregate they produced.
 2. Applies the one input plan described below. In the steady state this is
-   about 2,000 objects per run until the arrival index replaces the
-   partition listing.
+   about 2,000 objects per run.
 3. Folds them in, ages the decayed counters by a day, classifies each new
    failure as a catch or as flake evidence, scores everything, reads back
    the lane timing records to update the corrections, calls `plan()` with
@@ -2081,110 +2083,46 @@ The job:
 4. Reports, in the job summary, the projected per-lane times, the spread
    between them, what fell off the budget, and anything unschedulable.
 
-A cold start cannot read a window's worth of raw objects in one job; at
-the volume the store now takes, sixty days of them is hundreds of
-thousands. The bootstrap is a manual dispatch with `--bootstrap --days 60`
-and high concurrency, run once; after that the incremental path keeps up.
-The current version-one rollups cannot seed an exact aggregate because
-they carry no coverage position or source-object list. Until the next
-rollup format exists, bootstrap reads raw objects for every source and
-date. Once that format exists, bootstrap reads its shards for each closed
-CI day — some hundreds of objects across the window — and reads later CI
-arrivals and all local records raw. That is what makes any horizon longer
-than this one affordable later.
-
-The manual workflow pins the window and a journal position, then fans out
-one job per source and date. Each job applies the common input plan only to
-discover and normalize its disjoint entries through that position. It
-writes a lossless immutable event shard rather than classifying catches or
-building an aggregate. A final job reads the much smaller set of event
-shards, combines all evidence, performs the single global fold and
-classification, applies later journal entries through the common input
-plan, and publishes one state and manifest.
-
-Every shard name is deterministic and scoped to the bootstrap workflow run,
-window, journal position, source, and date. The shard carries those fields
-and a content digest. The final job checks them against its pinned plan and
-requires exactly the planned shard set. A retried worker accepts a create
-collision only after the existing object's metadata, digest, and bytes
-match what it would write. No shard is a readable publisher state. This is
-how the raw version-one fallback spreads object reads across jobs without
-discarding evidence or creating a second input-selection rule.
+A cold start reads a much wider window. The bootstrap is a manual
+dispatch with `--bootstrap --days 60`, run once, after which the
+incremental path keeps up. Sixty days of raw objects is hundreds of
+thousands at the volume the store now takes, which is more than one job
+can read, and that is where the rollups earn their place: the bootstrap
+takes one rollup for each closed continuous-integration day, standing in
+for that day's thousands of objects, and reads raw only the days no
+rollup covers and every local source.
 
 ### One input plan for bootstrap and ordinary publishing
 
-In the replacement publisher, bootstrap is permission to start from an
-empty aggregate and a larger default window. It is not a second way to
-choose inputs. Both modes apply the same rule independently to each source
-and date:
+Bootstrap is permission to start from an empty aggregate and a larger
+default window. It is not a second way to choose inputs. Both modes apply
+the same rule independently to each source and date:
 
-1. A source-and-date receipt already in the aggregate says its rollup
-   baseline and covered arrival position are folded. Continue with journal
-   entries after that position.
-2. When no raw object from the source and date has been folded, a complete
-   rollup carrying a journal position may supply the initial baseline.
-   Record a receipt scoped to that source and date, then consume later
-   journal entries.
-3. Once any raw object from the source and date is in the aggregate,
-   continue from individually unseen arrivals. Do not switch to a rollup
-   written later, because its records overlap those raw contributions.
-4. A version-one rollup has no coverage position or source-object list. An
-   exact run takes the raw path rather than combining it with later raw
-   arrivals whose overlap cannot be determined.
-
-An existing aggregate seeded from version-one rollups cannot enter this
-path in place. Its date receipt cannot identify which journal entries are
-already in its shards. Migration builds a fresh aggregate from raw objects
-or from the next rollup format and its later journal entries. The current
-manifest remains newest until that bootstrap publishes its replacement.
+1. A receipt in the aggregate says this pair was folded from its rollup.
+   A rollup records neither the objects it covers nor a point it is
+   complete through, so nothing can say how much a raw object of that
+   pair would repeat. The pair is closed rather than combined with
+   objects whose overlap is unknown.
+2. When nothing of the pair is folded and a rollup covers it, the rollup
+   is the baseline and a receipt is written for it. One object stands in
+   for the day's thousands, which is what makes a cold start over a wide
+   window affordable at all.
+3. Everything else reads raw objects, and two different things reach it.
+   A pair with raw contributions already stays raw, because a rollup
+   written afterwards would overlap them. A pair no rollup covers is raw
+   because there is nothing else to read, which is every local source:
+   rollups cover the continuous-integration area alone.
 
 The current rollups cover CI only. Local submissions always take the raw
 path. A date-only `compactedDays` receipt is therefore not sufficient: it
 can make a CI rollup suppress local submissions from the same date. The
-receipt becomes source-scoped before the common input plan uses it.
+receipt is scoped by source as well as by date.
 
-After the next rollup format lands, this rule lets an ordinary publisher
-use a rollup for a previously unseen old date, such as one reached while
-catching up after an outage or after a window expands. It does not make a
-steady-state publisher switch a date from raw objects to a rollup seven
-days later, after the raw contributions are already in its aggregate.
-
-The exact steady-state path adds a Cloud Storage object-finalize
-notification feeding an immutable arrival journal. A journal writer
-assigns the next position and atomically deduplicates both object and
-generation and the logical submission identity. For CI that identity is
-the repository, workflow run, attempt, and artifact; for local records it
-is the repository and report id. The writer then acknowledges the
-notification. An event delivered late is appended after what is already
-present; it cannot appear behind a cursor a publisher has passed. The
-uploader does not perform a second write which can fail after its record
-succeeds.
-
-The notification consumer and the backfill accept only canonical raw
-objects under the CI and local submission prefixes. They reject aggregated
-rollups, test-selection outputs, and the journal's own objects. The journal
-therefore cannot ingest a derived output or recursively ingest itself.
-
-The aggregate carries the last contiguous journal position whose effects
-it contains, in the same immutable state object as those effects. The
-compactor builds the next rollup format from journal entries through a
-position. Its manifest means that every eligible journal entry through the
-position for that source and date was accounted for exactly once in its
-named shards. The common input plan can then fold that baseline and consume
-every later journal entry. The publisher's current listing of the current
-UTC calendar date and the immediately preceding UTC calendar date becomes
-a bounded integrity audit rather than a heuristic that decides which new
-data exists. A rollup manifest carrying its exact source object names can
-prove overlap, but cannot discover later arrivals without the index or
-another listing of that partition.
-
-The arrival index depends on canonical object identity. Before it lands,
-each CI artifact gains the immutable start time of the attempt that
-produced it. GitHub's workflow-run `run_started_at` advances on a rerun;
-using its current value for earlier artifacts changes their date prefix
-and can turn an intended create collision into a duplicate object. The
-relay uses the artifact's attempt number and stable attempt start for both
-its context and its object name.
+This rule lets an ordinary publisher use a rollup for a previously unseen
+old date, such as one reached while catching up after an outage or after
+a window expands. It does not make a steady-state publisher switch a date
+from raw objects to a rollup seven days later, after the raw
+contributions are already in its aggregate.
 
 The publisher needs a writer credential for its own prefix. That is a new
 service account with `objectCreator` on `labs/test-selection/`, reached
@@ -3255,10 +3193,6 @@ answers somewhere people can see them.
       offline against recorded manifests.
 - [x] `tasks/test-selection-publish.ts` and
       `.github/workflows/test-selection.yml`, on a four-hourly cron.
-- [ ] Put an immutable attempt start in each CI artifact and use it for
-      that artifact's context and object name. A later relay of an earlier
-      attempt must collide with its first shipment even when a rerun
-      crossed a date boundary.
 - [ ] Hold manifest retention above the window in which GitHub still
       permits a run to be re-run. A lane resolves the newest manifest at or
       before the commit's date, so the answer is the same for every lane
@@ -3266,38 +3200,14 @@ answers somewhere people can see them.
       A manifest that expires between an attempt and its re-run is the one
       way the two can disagree, and the lifecycle rule is where that is
       settled rather than in anything a lane reads.
-- [ ] Provision the storage-generated arrival journal. Assign contiguous
-      positions and deduplicate object and generation and logical
-      submission identity atomically before acknowledging notifications.
-      Persist the consumed position with the publisher aggregate.
-- [ ] Backfill the journal from the raw object listing while live storage
-      notifications are connected. Deduplicate cross-date CI copies by
-      repository, workflow run, attempt, and artifact. Keep the
-      first-created valid object, record later copies as excluded, and
-      report disagreements in artifact-derived records or stable context.
-      The object-and-generation key deduplicates the listing from live
-      notifications at the handover.
-- [ ] Publish the journal's genesis receipt only after the notification
-      subscription covers the whole listing interval, the listing has
-      completed without a missing page, every listed object is committed,
-      and every notification from the handover is committed or still
-      durably pending. Readers do not use the journal before that receipt.
-- [ ] Build the next rollup format from journal entries through a recorded
-      position, accounting exactly once for every eligible entry through
-      that position for its source and date, and let the input plan
-      consume the journal entries after a rollup's position.
-  - [x] One source-and-date input plan, which bootstrap and ordinary
-        publishing both apply. A flag is permission to start from an
-        empty aggregate and a wider default window, and nothing else
-        decides what is read.
-  - [x] A source-scoped receipt in place of the date-only one, so that a
-        rollup of the shared area cannot say a day is accounted for and
-        take that day's local submissions with it. Local records stay on
-        their raw path until they have rollups of their own.
-- [ ] Rebuild aggregates seeded from version-one rollups; do not migrate
-      their ambiguous date receipts into journal cursors.
-- [ ] Once readers have migrated to the journal, keep partition listing as
-      an integrity audit rather than the discovery authority.
+- [x] One source-and-date input plan, which bootstrap and ordinary
+      publishing both apply. A flag is permission to start from an empty
+      aggregate and a wider default window, and nothing else decides what
+      is read.
+- [x] A source-scoped receipt in place of the date-only one, so that a
+      rollup of the shared area cannot say a day is accounted for and
+      take that day's local submissions with it. Local records stay on
+      their raw path until they have rollups of their own.
 - [ ] The one-off bootstrap dispatch.
 - [x] Repeat the record census after `main` emitted server-execution
       variant records, and replace the plan's projection inputs.

--- a/docs/plans/pull-request-test-selection.md
+++ b/docs/plans/pull-request-test-selection.md
@@ -1149,8 +1149,9 @@ nothing downstream of the store has to know this happened.
 
 **Compaction is live now, and was not when this was written.** The
 compactor's identity was provisioned on 2026-08-31 and its daily workflow
-has rolled up 2026-08-19 through 2026-08-26, which is every day closed
-long enough for it to touch. Compaction collapses a day of raw records
+has rolled up 2026-08-19 through 2026-08-26. The floor is where the store's
+records begin and the ceiling is the seven-day lag, so that range is every
+day it can touch. Compaction collapses a day of raw records
 into a manifest and a few tens of shards, which is the difference between
 reading 15,000 objects for a historical day and reading a manifest and
 seventeen shards. A day is a manifest and shards rather than a single object: a

--- a/docs/specs/test-records.md
+++ b/docs/specs/test-records.md
@@ -217,8 +217,8 @@ produced an artifact inside that artifact. Its context and object name use
 that value on every relay invocation. Late-shipped objects then land in
 the partition where their report was produced, not where it was uploaded.
 A trailing window can make late arrivals likely to be found, but cannot
-make discovery exact; an exact incremental reader needs the arrival index
-described below. The whole dataset is readable by `allUsers`. Writers hold
+make discovery exact; what listing does and does not settle is described
+below. The whole dataset is readable by `allUsers`. Writers hold
 `roles/storage.objectCreator` pinned to their own folder, which cannot
 read, list, overwrite, or delete; nothing already stored can be modified
 by any append credential. An incompatible schema writes under `v2/` and
@@ -277,63 +277,35 @@ exists, not that the shards are one atomic snapshot or that no more objects
 can arrive for that source and date. A reader that finds no manifest reads
 the raw area for that source and date.
 
-The version-one rollup manifest records neither the source object names it
-contains nor an arrival position through which it is complete. An exact
-reader cannot combine one with raw objects from the same source and date:
-it cannot tell whether a raw object is a later arrival or is already in a
-shard. Folding it may count it twice, while suppressing it may lose it. The
-current bootstrap uses a version-one rollup as a one-time baseline and
-closes that date to later raw arrivals. The common publisher path described
-in the test-selection plan requires the next rollup format instead. Its
-receipt is scoped by source as well as by date; a CI receipt cannot
-suppress local submissions.
+The rollup manifest records neither the source object names it contains
+nor a point through which it is complete. A reader cannot combine one with
+raw objects from the same source and date: it cannot tell whether a raw
+object is a later arrival or is already in a shard. Folding it may count it
+twice, while suppressing it may lose it. A reader that folds a rollup
+therefore closes that source and date to later raw arrivals and records a
+receipt saying so. The receipt is scoped by source as well as by date, so a
+receipt for the continuous-integration area cannot suppress that day's
+local submissions.
 
-An aggregate seeded from a version-one rollup cannot migrate in place to
-the arrival index. Its receipt cannot distinguish journal entries already
-represented in its shards from later arrivals. A reader rebuilds such an
-aggregate from raw objects or from the next rollup format and its later
-journal entries. The previous published result stays current until that
-replacement succeeds.
+Discovery is by listing. A reader names the source-and-date partitions of
+the window it reads, lists each one, and folds the objects it has not
+folded already, identified by object name. That costs what the window holds
+rather than what arrived in it. A reader sees every object that arrives for
+a partition while that partition is still inside its window; an object
+arriving after that is not found until something reads a wider one.
 
-The planned arrival index is an ordered record of storage arrivals and
-identifies the created object and its generation. A consumer of Cloud
-Storage object-finalize notifications appends them to a durable journal;
-the uploader does not make a second, non-atomic marker write. Journal
-positions are assigned when an entry commits. Assignment and deduplication
-by object and generation are atomic, as is the uniqueness check on the
-logical submission: repository, workflow run, attempt, and artifact for
-CI; repository and report id for local records. The notification is
-acknowledged only after that commit. A delayed notification therefore
-receives a position after the journal entries already present rather than
-being inserted behind a reader's cursor. A reader advances only through
-contiguous committed positions and persists that cursor with the aggregate
-the entries produced.
+Two limits follow, and both are accepted rather than closed. An object
+arriving for a source and date already folded from its rollup is never
+counted, which needs the relay to write a partition older than the
+compaction lag. And a re-run crossing a UTC midnight ships its earlier
+attempt's artifacts under the later attempt's date, so the same records
+reach two objects and a reader keying on object name folds both. The relay
+contract above is what settles the second.
 
-Only canonical raw objects under `submissions/ci/` and
-`submissions/local/` enter the journal. Rollup shards and manifests,
-test-selection outputs, and the journal's own storage are not inputs. The
-same allowlist governs notification ingestion and the historical backfill,
-so a derived object cannot feed itself back into aggregation.
-
-Before the journal's genesis receipt is published, the backfill groups
-existing CI objects by logical submission. Cross-date objects produced by
-the mutable retry timestamp are one submission, not two arrivals. The
-first-created valid object is retained, later copies are recorded as
-excluded, and a disagreement in their artifact-derived records or stable
-context is reported rather than silently choosing one. The repaired relay
-prevents new copies; the backfill prevents old ones from becoming two
-observations in every rebuilt aggregate.
-
-The compactor builds the next rollup format from journal entries through a
-recorded position. Before it publishes the manifest, it accounts exactly
-once for every eligible entry at or before that position for the manifest's
-source and date. A failed read or incomplete shard leaves the manifest
-absent. An exact reader can then start from the rollup and consume every
-later journal entry, in both a cold start and an ordinary update. Listing a
-trailing window remains a recovery audit rather than the authority for
-finding new objects. Recording the exact source object names in the rollup
-can prove which raw objects overlap it, but does not discover a later
-object without an arrival index or another listing of that partition.
+Recording the exact source object names in a rollup would let a reader
+prove which raw objects overlap it and stop closing the date, at the cost
+of carrying a day of object names in the manifest. That is the change to
+make if a closed partition is ever shown to have lost something.
 
 ## CI movement
 


### PR DESCRIPTION
Six items in the pull-request test-selection plan built a storage-generated arrival journal: an ordered log of object arrivals fed by Cloud Storage notifications, assigning each entry a position and rejecting duplicates in the same transaction, replacing the publisher's listing of day partitions as the way new records are found. They are out of the plan, along with the design they rested on.

The journal was there for three things: counting a duplicated shipment once, combining a rollup exactly with the raw objects that arrived after it was written, and making discovery cost what arrived rather than what the window holds.

Two of the three do not survive contact with how the publisher runs. The steady-state window is two days and the compactor does not touch a day until seven days after it closes, so every day is folded from its raw objects long before a rollup for it exists, and the pair stays on the raw path for good. The branch where a rollup closes a source and date is reached only by a first run over a wide window, or by a recovery from an outage longer than a week. That makes it a one-time set fixed at the bootstrap rather than an exposure that recurs, and the set is currently eight days: the raw area holds 2026-08-19 through 2026-09-03, and rollups cover the first eight of those. Discovery cost is not a live problem either. The quarter-million-object figure the plan projects is the cost of reading three weeks raw, which is what the rollup path exists to avoid.

The third reason is real, and it belongs on the topics board rather than in a plan about choosing which tests a pull request runs: give each continuous-integration artifact an attempt start that does not move between attempts, and derive the object name from it, so a re-run crossing UTC midnight collides with its first shipment instead of being counted twice in churn. That is store work rather than selection work, and the plan's account of what the store is missing already explains the duplication it prevents.

Against those reasons stands what a journal is. It would be the first part of this store that runs when nobody triggered it. Everything there today is buckets, managed folders, service accounts, and workflows that trade a GitHub token and hold no credential at rest. A journal needs a subscription, an always-up consumer, and a transactional store to assign positions in, and none of those exists in the infrastructure repository. The backfill, the genesis receipt, a second rollup format and an aggregate rebuild all sit on top of them.

The cheap repair, if the closed days ever do cost something, is a rollup manifest naming the source objects it contains. A reader could then take the rollup, list the partition, and fold only what the rollup does not name, with no new infrastructure and no journal.

Removing the journal exposed places where "The publisher" had drifted from the code, and correcting them is the other half of this change. The input rule was written as four cases keyed on journal positions. It is three cases keyed on whether a source and date was folded from its rollup, has raw contributions already, or has neither, and it now says that. The cold-start paragraph claimed a bootstrap reads raw objects for every source and date until a later rollup format exists, when the bootstrap in fact takes one rollup for each closed continuous-integration day and reads raw only the days no rollup covers. Two further paragraphs described a fan-out bootstrap workflow writing immutable event shards, which does not exist and is not planned. A third said the receipt would become source-scoped, which it already is.

Two facts elsewhere in the plan had gone stale and are corrected as well. The document opened by saying nothing in it was built, which stopped being true several parts ago. The section on what the store is missing still said the aggregated area was empty and the compactor unprovisioned, while compaction has in fact been running daily since 2026-08-31 and has rolled up eight days.

The record spec still describes the arrival index as planned. Amending it to describe a version-one rollup's inability to combine with later raw arrivals as a property of the format belongs with the rest of the documentation work.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

