### PR TITLE
fix(lunch-poll): a recast writes its own vote and nothing else

### DIFF
--- a/packages/patterns/lunch-poll/main.tsx
+++ b/packages/patterns/lunch-poll/main.tsx
@@ -817,7 +817,14 @@ const castVote = handler<CastVoteEvent, {
     return;
   }
   myVote.set({ voter, optionId, voteType, castAt: now });
-  votes.addUnique(myVote);
+  // Membership is the entity's presence: every path that drops a vote's link
+  // clears its entity too, so a vote that reads as present is already in the
+  // list. Recasting one therefore writes only that vote's own document, and
+  // touches the list on the cast that first puts the vote there. The read of
+  // this voter's own entity above stays a dependency, so a removal racing this
+  // recast still refuses the commit, and the retry sees an absent vote and
+  // adds the membership back.
+  if (existing === undefined) votes.addUnique(myVote);
 });
 
 const resetVotes = handler<ResetVotesEvent, {


### PR DESCRIPTION
`castVote` ended with `votes.addUnique(myVote)` on every path, including the recast that is most of what a poll does. On a vote already in the list that call adds nothing, but it still reads the list and resolves every element's link to decide so — which reads every other voter's vote document, to add a vote that is already there.

Membership is already knowable without the list. Every path that drops a vote's link clears its entity in the same commit, so a vote that reads as present is a vote that is in the list, and `castVote` has read exactly that a few lines above to decide whether this cast is a toggle. So the add belongs on the branch where the vote is new, and a recast now writes one document: its own.

The read of this voter's own vote entity stays, and it is the dependency that keeps this honest. A removal racing a recast refuses the recast, whose retry then finds the vote absent and adds the membership back. That is a conflict between two people editing one vote, which is the case where conflicting is the right answer.

What this does not fix, measured on the multi-runtime harness: a burst of simultaneous recasts already rolled back nothing before this change, and still does, at three voters and at ten. The cost this removes shows up when the list changes underneath — one voter clearing while others recast fell from 93 and 98 to 71 and 91 at ten voters. The remaining refusals are not the scan and not this handler: they are keyed reads holding a precondition on the whole collection, recorded when `elementById` resolves the array's own link. A recast that touches no list still carries `value/votes///link@1`, and any membership write invalidates it. That is the runtime's to answer and it is where the rest of this goes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6820?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

