### PR TITLE
docs(test-selection): a rollup is not read because of a flag

### DIFF
--- a/.github/workflows/test-selection.yml
+++ b/.github/workflows/test-selection.yml
@@ -24,12 +24,21 @@ on:
     - cron: "17 */4 * * *"
   workflow_dispatch:
     inputs:
+      # The label says what this costs rather than what it reads. A run
+      # with it set starts from an empty aggregate, so the state object it
+      # creates holds what the window shows and nothing earlier, and every
+      # later run reads that one. Nothing in the store is removed: the
+      # identity here holds create and not delete or overwrite, so the
+      # previous state object stays where it is and stops being the newest.
       bootstrap:
-        description: Read the whole window rather than what is unfolded
+        description: >-
+          COLD START, RUN ONCE. Rebuilds the score history from the whole
+          window instead of adding to it. Catches recorded before the
+          window stop counting. Nothing already stored is deleted.
         type: boolean
         default: false
       days:
-        description: Days of submissions to read
+        description: Days of submissions to read (default 2, or 60 with a cold start)
         required: false
 
 permissions:
@@ -52,7 +61,11 @@ jobs:
     # provisioned there is no identity to assume and nothing to create.
     if: vars.TEST_SELECTION_WIF_PROVIDER != ''
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # Six hours is the ceiling for a job on a GitHub-hosted runner: past
+    # it the platform cancels the run whatever this says. A bootstrap
+    # reads sixty days of records in one job, and the four-hourly path
+    # reads two.
+    timeout-minutes: 360
     steps:
       # Every third-party action in this credentialed workflow is pinned to
       # an immutable commit, so a moved tag cannot alter the one privileged

--- a/docs/development/test-selection.md
+++ b/docs/development/test-selection.md
@@ -106,21 +106,48 @@ deliberately: the bootstrap is a manual dispatch with the bootstrap input
 set, run once, and an incremental run that finds no aggregate at all says
 so and stops. After that the incremental path keeps up.
 
-A bootstrap takes each closed day from its rollup where the day has a
-complete one, which is a manifest and a few tens of shards against that
+A bootstrap replaces the score history rather than extending it. It folds
+into an empty aggregate, so the state object it creates holds what its
+window shows and nothing earlier, and every later run reads that one. A
+test's catches accumulate over unbounded history, so the ones counted
+before the window stop counting, and a bootstrap over a narrow window
+throws away more than one over a wide window does. Nothing in the store
+is removed: the publisher's identity holds create and not delete or
+overwrite, so the state object a previous run left stays where it is and
+stops being the newest.
+
+The two paths look back over different windows. An incremental run reads
+two days. A bootstrap reads sixty. The dispatch carries a days input
+naming a window of its own, and it applies in either mode, so a bootstrap
+over a shorter stretch of history is a matter of giving it.
+
+The bootstrap input does not decide whether a run reads a rollup. One
+rule is asked of each source and date the window covers. A pair whose
+rollup is already folded is closed. A pair nothing is folded from is
+taken from its rollup, where a rollup covers it. Everything else is read
+raw. Both modes apply that rule. Their answers differ because their
+aggregates differ, rather than because the input names a second way to
+choose.
+
+A run reaching a pair nothing is folded from takes that day whole from
+its rollup, which is a manifest and a few tens of shards against the
 day's thousands of raw objects. It reads a day whole or not at all: a
 shard it could not read would leave the day partly folded, and recording
 the day as done would then hide the rest of it from every later run. The
 days it did take are recorded, so no later run over a wide window folds
 their raw objects on top and doubles every catch in them.
 
-Only a bootstrap reads a rollup. A rollup is written by the one principal
-here whose credential exists as key material, so it carries weaker
-provenance than the raw records it summarizes, and
+A rollup is written by the one principal here whose credential exists as
+key material, so it carries weaker provenance than the raw records it
+summarizes, and
 [the record spec](../specs/test-records.md#trust-boundaries-for-consumers)
 asks a consumer that feeds decisions to treat it as a cache of a day
-rather than the record of it. Seeding catch counts once, from days closed
-a week or more ago, is that use; the four-hourly path never touches one.
+rather than the record of it. Seeding catch counts from days closed a
+week or more ago is that use. The four-hourly path in its steady state
+reaches no day it could read one from: compaction leaves a partition open
+for a week, and that path reads two days. So a rollup is read by a
+bootstrap, and by a run catching up after an outage or over a window
+somebody widened.
 
 `deno task test-records-compact` is what writes rollups, and an operator
 runs it from a workstation with a downloaded key — nothing federated runs


### PR DESCRIPTION
The publisher's guide said "Only a bootstrap reads a rollup", and that a rollup is something "the four-hourly path never touches". Neither is what the code does. The bootstrap input is permission to start from an empty aggregate over a wider default window; it is not a second way to choose what to read. Both modes ask one rule of each source and date the window covers, and their answers differ only because their aggregates differ. An ordinary run over a day its aggregate has never seen — after an outage, or over a window somebody widened with the days input — takes that day from its rollup exactly as a bootstrap does, which tasks/test-selection-publish.test.ts covers under "takes a rollup on an incremental run over a day it has not seen".

Stating it the old way matters because the paragraph it opens is about provenance: a rollup is written by the one principal here whose credential exists as key material, and the record spec asks a consumer that feeds decisions to treat it as a cache of a day rather than the record of it. A reader who believed only a hand-run bootstrap could reach one would think the scheduled path never depends on that weaker source. It usually does not, but for a reason worth naming: compaction leaves a partition open for a week and the incremental path reads two days, so in the steady state it reaches no day a rollup could stand in for. That is a property of the windows rather than of the flag, and it stops holding the moment a run falls behind.

Also names the two windows, which the guide never gave. An incremental run reads two days and a bootstrap reads sixty, and the days input overrides either.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6822?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

