### PR TITLE
ci(cfc-properties): pin actions/checkout and upload-artifact by sha

### DIFF
--- a/.github/workflows/cfc-properties.yml
+++ b/.github/workflows/cfc-properties.yml
@@ -41,7 +41,7 @@ jobs:
       CF_TEST_RECORDS_DIR: ${{ github.workspace }}/test-records-spool
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🦕 Setup Deno
         uses: ./.github/actions/deno-setup
@@ -80,7 +80,7 @@ jobs:
       # reason to look, so the evidence behind them has to outlive the job.
       - name: 📤 Upload the audited artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: cfc-property-artifacts
           path: ${{ runner.temp }}/cfc-properties


### PR DESCRIPTION
The check-action-pins gate added in #6777 fails on main: .github/workflows/cfc-properties.yml names actions/checkout@v7 and actions/upload-artifact@v7 by tag while the other 33 uses pin v7.0.1 by commit. Pin both to the same shas.

Blocks #6823 (its Check job fails on this gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6824?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

