### PR TITLE
refactor(data-model)!: the debug renderers take an options bag

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -6,6 +6,8 @@
  */
 
 import type {
+  CompactDebugStringOptions,
+  DebugValueOptions,
   FabricBytes,
   FabricHash,
   FabricValue,
@@ -3260,9 +3262,12 @@ export interface PatternEnvironment {
 export type GetPatternEnvironmentFunction = () => PatternEnvironment;
 export type ToCompactDebugStringFunction = (
   value: unknown,
-  maxLength?: number,
+  options?: CompactDebugStringOptions,
 ) => string;
-export type ToIndentedDebugStringFunction = (value: unknown) => string;
+export type ToIndentedDebugStringFunction = (
+  value: unknown,
+  options?: DebugValueOptions,
+) => string;
 
 /**
  * Compare two cells or values for equality after resolving, i.e. after

--- a/packages/data-model/src/api.ts
+++ b/packages/data-model/src/api.ts
@@ -1,9 +1,9 @@
 /**
  * Pattern-visible declarations for the fabric value type system, and for the
  * options of the debug renderers over it, in the form that `@commonfabric/api`
- * re-exports to patterns. Everything here is an
- * interface, a type, or a `declare const`, except for the one brand-key
- * constant, so the module's only runtime footprint is that constant.
+ * re-exports to patterns. Everything here is an interface, a type, or a
+ * `declare const`, except for the one brand-key constant, so the module's only
+ * runtime footprint is that constant.
  *
  * The canonical implementations live in this module's siblings --
  * `interface.ts`, `fabric-primitives/FabricHash.ts`,

--- a/packages/data-model/src/api.ts
+++ b/packages/data-model/src/api.ts
@@ -24,6 +24,13 @@
  * re-exports it to patterns, and the script that builds the type file the
  * sandbox is served inlines this text rather than following a specifier out of
  * it, so a specifier named here would reach a compiler that resolves none.
+ *
+ * Two modules import this one: `interface.ts`, which re-exports these
+ * declarations to the rest of this package, and `@commonfabric/api`, which
+ * re-exports them to patterns. Every other module in this package takes them
+ * from `interface.ts`. The one exception is a drift guard, which compares an
+ * implementation against the declaration here by name, and so imports it from
+ * here under an `Api` alias.
  */
 
 /**

--- a/packages/data-model/src/api.ts
+++ b/packages/data-model/src/api.ts
@@ -25,12 +25,12 @@
  * sandbox is served inlines this text rather than following a specifier out of
  * it, so a specifier named here would reach a compiler that resolves none.
  *
- * Two modules import this one: `interface.ts`, which re-exports these
+ * Apart from the drift guards, which each compare an implementation against
+ * the declaration here by name and so import it from here under an `Api`
+ * alias, two modules import this one: `interface.ts`, which re-exports these
  * declarations to the rest of this package, and `@commonfabric/api`, which
  * re-exports them to patterns. Every other module in this package takes them
- * from `interface.ts`. The one exception is a drift guard, which compares an
- * implementation against the declaration here by name, and so imports it from
- * here under an `Api` alias.
+ * from `interface.ts`.
  */
 
 /**

--- a/packages/data-model/src/api.ts
+++ b/packages/data-model/src/api.ts
@@ -1,6 +1,7 @@
 /**
- * Pattern-visible declarations for the fabric value type system, in the form
- * that `@commonfabric/api` re-exports to patterns. Everything here is an
+ * Pattern-visible declarations for the fabric value type system, and for the
+ * options of the debug renderers over it, in the form that `@commonfabric/api`
+ * re-exports to patterns. Everything here is an
  * interface, a type, or a `declare const`, except for the one brand-key
  * constant, so the module's only runtime footprint is that constant.
  *
@@ -416,3 +417,37 @@ export interface FabricArray extends ReadonlyArray<FabricValue> {}
  */
 export interface FabricPlainObject
   extends Readonly<Record<string, FabricValue>> {}
+
+/**
+ * Options accepted by `toStructuredDebugValue()`, and by the debug-string
+ * renderers built on it.
+ */
+export interface DebugValueOptions {
+  /**
+   * Maximum depth of result nesting, a positive integer. An item which would
+   * require further nesting is instead converted into a form suggestive of the
+   * elided information. When absent, the depth is the default of the function
+   * called: as deep as reasonably possible for a structured value, and ten
+   * levels for a debug string. A large value is capped; there is no guarantee
+   * about the _actual_ possible maximum depth.
+   */
+  readonly maxDepth?: number;
+
+  /**
+   * Replacer function, called on every value and sub-value encountered, to get
+   * a replacement value to use. A replacer which does not want to replace a
+   * value returns the value it receives, and one which throws is taken to have
+   * declined to replace.
+   */
+  readonly replacer?: (value: any) => any;
+}
+
+/** Options accepted by `toCompactDebugString()`. */
+export interface CompactDebugStringOptions extends DebugValueOptions {
+  /**
+   * Maximum length of the result. When the rendering runs longer, the result
+   * is truncated to this length, which includes a trailing ASCII ellipsis of
+   * `...`. A length below three is taken as three.
+   */
+  readonly maxLength?: number;
+}

--- a/packages/data-model/src/codec-common/BaseDecodeAct.ts
+++ b/packages/data-model/src/codec-common/BaseDecodeAct.ts
@@ -111,7 +111,7 @@ export abstract class BaseDecodeAct<Encoded, SerializedForm = Encoded>
     if (!this.enter(value)) {
       return this.reportMalformed(
         "",
-        toCompactDebugString(value, 50),
+        toCompactDebugString(value, { maxLength: 50 }),
         "circular reference in decoded data",
       );
     }
@@ -238,7 +238,7 @@ export abstract class BaseDecodeAct<Encoded, SerializedForm = Encoded>
         tag,
         this.decodeValue(rawState),
         `tagged value has a malformed tag: ${
-          backtickQuote(toCompactDebugString(tag, 30))
+          backtickQuote(toCompactDebugString(tag, { maxLength: 30 }))
         }`,
       );
     }

--- a/packages/data-model/src/codec-common/BaseDecodeAct.ts
+++ b/packages/data-model/src/codec-common/BaseDecodeAct.ts
@@ -4,6 +4,7 @@ import type {
   NonterminalCodec,
   TerminalCodec,
 } from "@/codec-interface/interface.ts";
+import { toCompactDebugString } from "@/value-debug.ts";
 import { isCodecTypeTag } from "./isCodecTypeTag.ts";
 import { UnknownValue } from "./UnknownValue.ts";
 import type { FabricValue } from "@/interface.ts";
@@ -109,7 +110,7 @@ export abstract class BaseDecodeAct<Encoded, SerializedForm = Encoded>
     if (!this.enter(value)) {
       return this.reportMalformed(
         "",
-        value,
+        toCompactDebugString(value, { maxLength: 50 }),
         "circular reference in decoded data",
       );
     }

--- a/packages/data-model/src/codec-common/BaseDecodeAct.ts
+++ b/packages/data-model/src/codec-common/BaseDecodeAct.ts
@@ -1,18 +1,16 @@
-import { backtickQuote } from "@commonfabric/utils/markdown";
-
 import { deepFreeze } from "@/deep-freeze.ts";
 import { BaseTerminalCodec } from "@/codec-interface/BaseTerminalCodec.ts";
 import type {
   NonterminalCodec,
   TerminalCodec,
 } from "@/codec-interface/interface.ts";
-import { toCompactDebugString } from "@/value-debug.ts";
 import { isCodecTypeTag } from "./isCodecTypeTag.ts";
 import { UnknownValue } from "./UnknownValue.ts";
 import type { FabricValue } from "@/interface.ts";
 import { BaseCodecAct } from "./BaseCodecAct.ts";
 import { ProblematicStateError } from "./ProblematicStateError.ts";
 import { ProblematicValue } from "./ProblematicValue.ts";
+import { quotedDebugString } from "./quotedDebugString.ts";
 
 /**
  * The state of one act of decoding: what {@link BaseCodecAct} holds, plus how
@@ -111,7 +109,7 @@ export abstract class BaseDecodeAct<Encoded, SerializedForm = Encoded>
     if (!this.enter(value)) {
       return this.reportMalformed(
         "",
-        toCompactDebugString(value, { maxLength: 50 }),
+        value,
         "circular reference in decoded data",
       );
     }
@@ -237,9 +235,7 @@ export abstract class BaseDecodeAct<Encoded, SerializedForm = Encoded>
       return this.reportMalformed(
         tag,
         this.decodeValue(rawState),
-        `tagged value has a malformed tag: ${
-          backtickQuote(toCompactDebugString(tag, { maxLength: 30 }))
-        }`,
+        `tagged value has a malformed tag: ${quotedDebugString(tag)}`,
       );
     }
 

--- a/packages/data-model/src/codec-common/BaseEncodeAct.ts
+++ b/packages/data-model/src/codec-common/BaseEncodeAct.ts
@@ -2,7 +2,6 @@ import { backtickQuote } from "@commonfabric/utils/markdown";
 import { isPlainObject, isUnsafeObjectKey } from "@commonfabric/utils/types";
 
 import { FabricSpecialObject, type FabricValue } from "@/interface.ts";
-import { toCompactDebugString } from "@/value-debug.ts";
 import { BaseTerminalCodec } from "@/codec-interface/BaseTerminalCodec.ts";
 import type {
   CodecForFormat,
@@ -11,6 +10,7 @@ import type {
 } from "@/codec-interface/interface.ts";
 import { BaseCodecAct } from "./BaseCodecAct.ts";
 import { SELF_REP } from "./CodecRegistry.ts";
+import { quotedDebugString } from "./quotedDebugString.ts";
 
 /**
  * One act of encoding: what {@link BaseCodecAct} holds, the walk that turns a
@@ -140,7 +140,7 @@ export abstract class BaseEncodeAct<Encoded, SerializedForm = Encoded>
       const label = (typeName === "object") ? "instance" : typeName;
       throw new Error(
         `Cannot encode ${label} ${
-          backtickQuote(toCompactDebugString(value, { maxLength: 50 }))
+          quotedDebugString(value)
         }: no applicable codec.`,
       );
     }

--- a/packages/data-model/src/codec-common/BaseEncodeAct.ts
+++ b/packages/data-model/src/codec-common/BaseEncodeAct.ts
@@ -140,7 +140,7 @@ export abstract class BaseEncodeAct<Encoded, SerializedForm = Encoded>
       const label = (typeName === "object") ? "instance" : typeName;
       throw new Error(
         `Cannot encode ${label} ${
-          backtickQuote(toCompactDebugString(value, 50))
+          backtickQuote(toCompactDebugString(value, { maxLength: 50 }))
         }: no applicable codec.`,
       );
     }

--- a/packages/data-model/src/codec-common/quotedDebugString.ts
+++ b/packages/data-model/src/codec-common/quotedDebugString.ts
@@ -1,0 +1,16 @@
+import { backtickQuote } from "@commonfabric/utils/markdown";
+
+import { toCompactDebugString } from "@/value-debug.ts";
+
+/** Length a rendering is cut to. */
+const MAX_LENGTH = 50;
+
+/**
+ * Renders `value` for an error message: its compact debug string, cut to a
+ * length which keeps a large value from swamping the message it lands in, as
+ * a backtick-quoted code span. `toCompactDebugString()` returns a fixed string
+ * for what it cannot render, so this holds up on the failure path it serves.
+ */
+export function quotedDebugString(value: unknown): string {
+  return backtickQuote(toCompactDebugString(value, { maxLength: MAX_LENGTH }));
+}

--- a/packages/data-model/src/codec-common/toReportableState.ts
+++ b/packages/data-model/src/codec-common/toReportableState.ts
@@ -46,5 +46,5 @@ export function toReportableState(state: any): FabricValue {
     // cannot classify gets anyway.
   }
 
-  return toCompactDebugString(state, MAX_RENDERED_LENGTH);
+  return toCompactDebugString(state, { maxLength: MAX_RENDERED_LENGTH });
 }

--- a/packages/data-model/src/codec-common/toReportableTag.ts
+++ b/packages/data-model/src/codec-common/toReportableTag.ts
@@ -28,5 +28,5 @@ const MAX_RENDERED_LENGTH = 60;
 export function toReportableTag(tag: any): string {
   return (typeof tag === "string")
     ? tag
-    : toCompactDebugString(tag, MAX_RENDERED_LENGTH);
+    : toCompactDebugString(tag, { maxLength: MAX_RENDERED_LENGTH });
 }

--- a/packages/data-model/src/codec-json/JsonDecodeAct.ts
+++ b/packages/data-model/src/codec-json/JsonDecodeAct.ts
@@ -164,7 +164,7 @@ export class JsonDecodeAct extends BaseDecodeAct<JsonCodecValue, string> {
             CODEC_META_TAGS.hole,
             count,
             `hole: expected a positive integer count, got ${
-              backtickQuote(toCompactDebugString(count, 30))
+              backtickQuote(toCompactDebugString(count, { maxLength: 30 }))
             }`,
           );
         }

--- a/packages/data-model/src/codec-json/JsonDecodeAct.ts
+++ b/packages/data-model/src/codec-json/JsonDecodeAct.ts
@@ -4,8 +4,8 @@ import { isPlainObject, isUnsafeObjectKey } from "@commonfabric/utils/types";
 import type { FabricValue } from "@/interface.ts";
 import { BaseDecodeAct } from "@/codec-common/BaseDecodeAct.ts";
 import { ProblematicStateError } from "@/codec-common/ProblematicStateError.ts";
+import { quotedDebugString } from "@/codec-common/quotedDebugString.ts";
 import { CODEC_META_TAGS } from "@/codec-interface/codec-meta-tags.ts";
-import { toCompactDebugString } from "@/value-debug.ts";
 import { ENCODING_PREFIX_TAG, type JsonCodecValue } from "./interface.ts";
 import {
   isEncodedInstance,
@@ -164,7 +164,7 @@ export class JsonDecodeAct extends BaseDecodeAct<JsonCodecValue, string> {
             CODEC_META_TAGS.hole,
             count,
             `hole: expected a positive integer count, got ${
-              backtickQuote(toCompactDebugString(count, { maxLength: 30 }))
+              quotedDebugString(count)
             }`,
           );
         }

--- a/packages/data-model/src/codec-realm/RealmDecodeAct.ts
+++ b/packages/data-model/src/codec-realm/RealmDecodeAct.ts
@@ -47,7 +47,7 @@ export class RealmDecodeAct
     if (!Array.isArray(data) || (data.length !== 2)) {
       throw new ProblematicStateError(
         "",
-        toCompactDebugString(data, 50),
+        toCompactDebugString(data, { maxLength: 50 }),
         "not a value this format emits: expected a two-element outer envelope",
       );
     }
@@ -57,7 +57,7 @@ export class RealmDecodeAct
     if (!marker) {
       throw new ProblematicStateError(
         "",
-        toCompactDebugString(data, 50),
+        toCompactDebugString(data, { maxLength: 50 }),
         `not a value this format emits: expected an outer envelope headed by a ${
           backtickQuote(REALM_FORMAT_VERSION)
         } marker`,
@@ -96,7 +96,7 @@ export class RealmDecodeAct
     if ((typeof data === "symbol") || (typeof data === "function")) {
       return this.reportMalformed(
         "",
-        toCompactDebugString(data, 50),
+        toCompactDebugString(data, { maxLength: 50 }),
         `Cannot decode ${typeof data}: not a form this format emits.`,
       );
     }
@@ -130,7 +130,7 @@ export class RealmDecodeAct
         "",
         data,
         `Cannot decode ${
-          backtickQuote(toCompactDebugString(data, 50))
+          backtickQuote(toCompactDebugString(data, { maxLength: 50 }))
         }: not a form this format emits.`,
       );
     } finally {

--- a/packages/data-model/src/codec-realm/RealmDecodeAct.ts
+++ b/packages/data-model/src/codec-realm/RealmDecodeAct.ts
@@ -2,9 +2,9 @@ import { backtickQuote } from "@commonfabric/utils/markdown";
 import { isPlainObject, isUnsafeObjectKey } from "@commonfabric/utils/types";
 
 import type { FabricValue } from "@/interface.ts";
-import { toCompactDebugString } from "@/value-debug.ts";
 import { BaseDecodeAct } from "@/codec-common/BaseDecodeAct.ts";
 import { ProblematicStateError } from "@/codec-common/ProblematicStateError.ts";
+import { quotedDebugString } from "@/codec-common/quotedDebugString.ts";
 import {
   REALM_FORMAT_VERSION,
   type RealmCodecValue,
@@ -47,7 +47,7 @@ export class RealmDecodeAct
     if (!Array.isArray(data) || (data.length !== 2)) {
       throw new ProblematicStateError(
         "",
-        toCompactDebugString(data, { maxLength: 50 }),
+        data,
         "not a value this format emits: expected a two-element outer envelope",
       );
     }
@@ -57,7 +57,7 @@ export class RealmDecodeAct
     if (!marker) {
       throw new ProblematicStateError(
         "",
-        toCompactDebugString(data, { maxLength: 50 }),
+        data,
         `not a value this format emits: expected an outer envelope headed by a ${
           backtickQuote(REALM_FORMAT_VERSION)
         } marker`,
@@ -96,7 +96,7 @@ export class RealmDecodeAct
     if ((typeof data === "symbol") || (typeof data === "function")) {
       return this.reportMalformed(
         "",
-        toCompactDebugString(data, { maxLength: 50 }),
+        data,
         `Cannot decode ${typeof data}: not a form this format emits.`,
       );
     }
@@ -130,7 +130,7 @@ export class RealmDecodeAct
         "",
         data,
         `Cannot decode ${
-          backtickQuote(toCompactDebugString(data, { maxLength: 50 }))
+          quotedDebugString(data)
         }: not a form this format emits.`,
       );
     } finally {

--- a/packages/data-model/src/index.ts
+++ b/packages/data-model/src/index.ts
@@ -1,19 +1,8 @@
-/**
- * This module is the package's main entry point, and the canonical public
- * surface for the `FabricValue` types: the type declarations, the
- * `FabricInstance` base class, and the functions that operate on them. Those
- * are spread across several modules, not all of which the package exports on
- * their own, and a caller should not have to know which is which. Alongside
- * them are the operations every `FabricValue` is subject to whatever its
- * class: the deep freeze, the hash, the debug rendering, and the tag vocabulary
- * that names a value's type. The rest of the package -- the codec system and
- * the concrete value classes -- is reached through the exported subpaths named
- * in `deno.jsonc`, not through here.
- */
-
 // Re-export everything from `interface.ts`, which declares the types and the
 // base class.
 export {
+  type CompactDebugStringOptions,
+  type DebugValueOptions,
   type FabricArray,
   type FabricContainerValue,
   type FabricConvertibleValue,
@@ -30,8 +19,6 @@ export {
   type MutableFabricValueLayer,
   type NonNullableFabricValue,
 } from "./interface.ts";
-
-export type { CompactDebugStringOptions, DebugValueOptions } from "./api.ts";
 
 export {
   cloneForMutation,

--- a/packages/data-model/src/index.ts
+++ b/packages/data-model/src/index.ts
@@ -31,6 +31,8 @@ export {
   type NonNullableFabricValue,
 } from "./interface.ts";
 
+export type { CompactDebugStringOptions, DebugValueOptions } from "./api.ts";
+
 export {
   cloneForMutation,
   CloneForMutationError,

--- a/packages/data-model/src/interface.ts
+++ b/packages/data-model/src/interface.ts
@@ -146,8 +146,8 @@ export abstract class FabricPrimitive extends FabricSpecialObject {
  * renderers over them, declared in `api.ts` and re-exported here so that this
  * module carries the whole `FabricValue` vocabulary. `api.ts` is where they
  * have to be declared: it reaches patterns by being inlined into the type
- * module the pattern compiler serves, and so may name no import, which makes
- * it the leaf of this pair.
+ * module the pattern compiler serves, and so must not import anything, which
+ * makes it the leaf of this pair.
  */
 export type {
   CompactDebugStringOptions,

--- a/packages/data-model/src/interface.ts
+++ b/packages/data-model/src/interface.ts
@@ -13,6 +13,8 @@
  */
 
 import type {
+  CompactDebugStringOptions,
+  DebugValueOptions,
   FabricArray,
   FabricContainerValue,
   FabricInstance as ApiFabricInstance,
@@ -140,13 +142,16 @@ export abstract class FabricPrimitive extends FabricSpecialObject {
 //
 
 /**
- * The pattern-visible fabric value types, declared in `api.ts` and re-exported
- * here so that this module carries the whole `FabricValue` vocabulary. `api.ts`
- * is where they have to be declared: it reaches patterns by being inlined into
- * the type module the pattern compiler serves, and so may name no import,
- * which makes it the leaf of this pair.
+ * The pattern-visible fabric value types, and the option types of the debug
+ * renderers over them, declared in `api.ts` and re-exported here so that this
+ * module carries the whole `FabricValue` vocabulary. `api.ts` is where they
+ * have to be declared: it reaches patterns by being inlined into the type
+ * module the pattern compiler serves, and so may name no import, which makes
+ * it the leaf of this pair.
  */
 export type {
+  CompactDebugStringOptions,
+  DebugValueOptions,
   FabricArray,
   FabricContainerValue,
   FabricPlainObject,

--- a/packages/data-model/src/value-debug.ts
+++ b/packages/data-model/src/value-debug.ts
@@ -4,6 +4,7 @@ import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 import { backtickQuote } from "@commonfabric/utils/markdown";
 import { isPlainObject, isUnsafeObjectKey } from "@commonfabric/utils/types";
 
+import type { CompactDebugStringOptions, DebugValueOptions } from "./api.ts";
 import {
   FabricInstance,
   type FabricPlainObject,
@@ -24,10 +25,13 @@ import { NULL_LIVE_ENVIRONMENT } from "@/codec-interface/NullLiveEnvironment.ts"
 import type { RealmCodecValue } from "@/codec-realm/interface.ts";
 
 /**
- * Nesting depth a debug string renders to. TODO(danfuzz): Make this
- * adjustable by the caller, once there is a caller that wants to.
+ * Nesting depth a conversion stops at whatever its options say, so that
+ * converting cannot blow out the stack.
  */
-const DEBUG_STRING_MAX_DEPTH = 10;
+const ABSOLUTE_MAX_DEPTH = 100;
+
+/** Nesting depth a debug string renders to, when its options do not say. */
+const DEFAULT_STRING_MAX_DEPTH = 10;
 
 /**
  * What a `FabricPrimitive`'s codec hands back to be rendered: the
@@ -317,13 +321,16 @@ class DebugConverter {
  * are what records them.
  */
 class DebugStringifier {
+  readonly #options: DebugValueOptions;
   readonly #indent: string | undefined;
 
   /**
    * Constructs an instance which renders using `indent` spaces per nesting
-   * level when given, and on a single line when not.
+   * level when given, and on a single line when not. A value which turns up
+   * unconverted while rendering is converted with `options`.
    */
-  constructor(indent?: number) {
+  constructor(options: DebugValueOptions, indent?: number) {
+    this.#options = options;
     this.#indent = (indent === undefined) ? undefined : " ".repeat(indent);
   }
 
@@ -453,7 +460,7 @@ class DebugStringifier {
       return this.#renderContainer("{", "}", parts, indent);
     } else {
       return this.#renderSubvalue(
-        toStructuredDebugValue(value, DEBUG_STRING_MAX_DEPTH),
+        toStructuredDebugValue(value, this.#options),
         indent,
       );
     }
@@ -715,13 +722,68 @@ class DebugStringifier {
 }
 
 /**
- * Renders the debug-string form of the given value with optional indentation,
- * by converting it with `toStructuredDebugValue()` and rendering the result.
+ * Helper for the entry points, which validates `options` and returns the
+ * maximum nesting depth they call for: their `maxDepth` when present, and
+ * `defaultMaxDepth` when not, either one capped at `ABSOLUTE_MAX_DEPTH`.
+ *
+ * @throws {Error} if `options` is not a plain object, or if its `maxDepth` is
+ * not a positive integer.
  */
-function renderDebugString(value: unknown, indent?: number): string {
+function checkedMaxDepth(
+  options: DebugValueOptions | undefined,
+  defaultMaxDepth: number,
+): number {
+  if ((options !== undefined) && !isPlainObject(options)) {
+    const badOptions = backtickQuote(
+      toCompactDebugString(options, { maxLength: 20 }),
+    );
+    throw new Error(
+      `\`options\` must be a plain object or \`undefined\`; got ${badOptions}`,
+    );
+  }
+
+  const maxDepth = options?.maxDepth;
+
+  switch (typeof maxDepth) {
+    case "number": {
+      if (Number.isSafeInteger(maxDepth) && (maxDepth > 0)) {
+        return Math.min(maxDepth, ABSOLUTE_MAX_DEPTH);
+      }
+      break;
+    }
+    case "undefined": {
+      return Math.min(defaultMaxDepth, ABSOLUTE_MAX_DEPTH);
+    }
+  }
+
+  const badDepth = backtickQuote(
+    toCompactDebugString(maxDepth, { maxLength: 20 }),
+  );
+  throw new Error(
+    `\`maxDepth\` must be a positive integer or \`undefined\`; got ${badDepth}`,
+  );
+}
+
+/**
+ * Renders the debug-string form of the given value with optional indentation,
+ * by converting it with `toStructuredDebugValue()` per `options` and rendering
+ * the result. A depth the options leave unsaid is `DEFAULT_STRING_MAX_DEPTH`.
+ *
+ * @throws {Error} if given invalid `options`.
+ */
+function renderDebugString(
+  value: unknown,
+  options: DebugValueOptions | undefined,
+  indent?: number,
+): string {
+  const converterOptions: DebugValueOptions = {
+    ...options,
+    maxDepth: checkedMaxDepth(options, DEFAULT_STRING_MAX_DEPTH),
+  };
+
   try {
-    const converted = toStructuredDebugValue(value, DEBUG_STRING_MAX_DEPTH);
-    return new DebugStringifier(indent).render(converted);
+    const converted = toStructuredDebugValue(value, converterOptions);
+    return new DebugStringifier(converterOptions, indent).render(converted);
     // deno-coverage-ignore-start
   } catch {
     // Neither the conversion nor the rendering is meant to throw. This `catch`
@@ -734,12 +796,13 @@ function renderDebugString(value: unknown, indent?: number): string {
 
 /**
  * Produces a compact string representation of a value, optionally truncating to
- * a specified maximum length. When truncating is requested and turns out to be
- * necessary, the returned result will be the indicated length, which includes
- * an "ASCII ellipsis" of `...`.
+ * the maximum length given in `options`. When truncating is requested and turns
+ * out to be necessary, the returned result will be the indicated length, which
+ * includes an "ASCII ellipsis" of `...`.
  *
- * The value is first converted with `toStructuredDebugValue()`, and it is that
- * result which gets rendered. This function handles:
+ * The value is first converted with `toStructuredDebugValue()`, passing along
+ * the depth limit and replacer given in `options`, and it is that result which
+ * gets rendered. This function handles:
  * * all normal JSON-compatible values.
  * * other JavaScript primitive values:
  *   * bigints.
@@ -752,8 +815,8 @@ function renderDebugString(value: unknown, indent?: number): string {
  * * objects and arrays with circular references.
  * * arrays with holes.
  *
- * The rendering stops at a fixed nesting depth, below which a value is
- * elided.
+ * The rendering stops at the nesting depth given in `options`, ten levels
+ * when not given, below which a value is elided.
  *
  * How any of these renders is _not_ a contract. The rendering is meant for a
  * human reading a diagnostic, and it changes as that reading is improved;
@@ -765,12 +828,15 @@ function renderDebugString(value: unknown, indent?: number): string {
  * **Note:** In _many_ cases, the output of this function is valid JSON text,
  * but not _all_ cases. This function must _not_ be relied on to produce a
  * parseable string.
+ *
+ * @throws {Error} if given invalid `options`.
  */
 export function toCompactDebugString(
   value: unknown,
-  maxLength?: number,
+  options?: CompactDebugStringOptions,
 ): string {
-  const result = renderDebugString(value);
+  const result = renderDebugString(value, options);
+  const maxLength = options?.maxLength;
 
   if (typeof maxLength === "number") {
     const actualMax = Math.max(Math.floor(maxLength), 3);
@@ -784,11 +850,16 @@ export function toCompactDebugString(
 
 /**
  * Like `toCompactDebugString()`, except that the result is indented by two
- * spaces per nesting level, and is never truncated for length. The depth
- * limit applies to both.
+ * spaces per nesting level, and is never truncated for length, there being no
+ * length to give. The depth limit and replacer apply to both.
+ *
+ * @throws {Error} if given invalid `options`.
  */
-export function toIndentedDebugString(value: unknown): string {
-  return renderDebugString(value, 2);
+export function toIndentedDebugString(
+  value: unknown,
+  options?: DebugValueOptions,
+): string {
+  return renderDebugString(value, options, 2);
 }
 
 /**
@@ -831,56 +902,25 @@ export function toDebugKindString(value: unknown): string {
  * `codec-json` encoding form, and with as little chance for ambiguity as can
  * be reasonably achieved.
  *
- * If a `maxDepth` is supplied as a positive integer, that is the nesting limit
- * of the result. Any items which would require further nesting are instead
- * converted into a form suggestive of the elided information.
- *
- * If a `replacer` is supplied, it is called on every value and sub-value
- * encountered, to get a replacement value to use. If the `replacer` does not
- * want to replace the value, then it should return the value it receives.
+ * The nesting limit of the result and a replacer to consult are the
+ * `maxDepth` and `replacer` of `options`. When there is no limit given, the
+ * result nests as deep as reasonably possible.
  *
  * If the conversion could not be completed (stack overflow, object
  * `toJSON()` conversion error, etc.), this function returns the literal value
  * `{ "/unconvertible": "<errorMessage>" }`.
  *
- * @throws {Error} if given an invalid value for `maxDepth`.
+ * @throws {Error} if given invalid `options`.
  */
 export function toStructuredDebugValue(
   /** Value to convert. */
   value: any,
-  /**
-   * Maximum depth of result nesting. Must be a positive integer or `undefined`
-   * if specified. `undefined` and large integers are taken to mean "as high as
-   * reasonably possible." There is no guarantee about the _actual_ possible
-   * maximum depth.
-   */
-  maxDepth?: number | undefined,
-  /** Replacer function, if desired. */
-  replacer?: (value: any) => any,
+  /** Conversion options, if desired. */
+  options?: DebugValueOptions,
 ): FabricValue {
-  const ACTUAL_MAX = 100; // To prevent blowing out the stack when converting.
-
-  // Validate `maxDepth` and transform as necessary.
-  maxDepth = (() => {
-    switch (typeof maxDepth) {
-      case "number": {
-        if (Number.isSafeInteger(maxDepth) && (maxDepth > 0)) {
-          return Math.min(maxDepth, ACTUAL_MAX);
-        }
-        break;
-      }
-      case "undefined": {
-        return ACTUAL_MAX;
-      }
-    }
-
-    const badDepth = backtickQuote(toCompactDebugString(maxDepth, 20));
-    throw new Error(
-      `\`maxDepth\` must be a positive integer or \`undefined\`; got ${badDepth}`,
-    );
-  })();
+  const maxDepth = checkedMaxDepth(options, ABSOLUTE_MAX_DEPTH);
 
   // We subtract one from `maxDepth` because the "suggestive forms" for elided
   // data all use one layer of depth.
-  return new DebugConverter(value, maxDepth - 1, replacer).convert();
+  return new DebugConverter(value, maxDepth - 1, options?.replacer).convert();
 }

--- a/packages/data-model/src/value-debug.ts
+++ b/packages/data-model/src/value-debug.ts
@@ -4,8 +4,9 @@ import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 import { backtickQuote } from "@commonfabric/utils/markdown";
 import { isPlainObject, isUnsafeObjectKey } from "@commonfabric/utils/types";
 
-import type { CompactDebugStringOptions, DebugValueOptions } from "./api.ts";
 import {
+  type CompactDebugStringOptions,
+  type DebugValueOptions,
   FabricInstance,
   type FabricPlainObject,
   FabricPrimitive,

--- a/packages/data-model/test/codec-common/quotedDebugString.test.ts
+++ b/packages/data-model/test/codec-common/quotedDebugString.test.ts
@@ -2,6 +2,7 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
 import { quotedDebugString } from "@/codec-common/quotedDebugString.ts";
+import { toCompactDebugString } from "@/value-debug.ts";
 
 describe("quotedDebugString()", () => {
   it("returns the compact rendering as a backtick-quoted code span", () => {
@@ -10,10 +11,9 @@ describe("quotedDebugString()", () => {
 
   it("returns a rendering cut to fifty characters, ellipsis included", () => {
     const value = { text: "x".repeat(100) };
-    const quoted = quotedDebugString(value);
-    expect(quoted).toBe("`" + quoted.slice(1, -1) + "`");
-    expect(quoted.slice(1, -1).length).toBe(50);
-    expect(quoted.endsWith("...`")).toBe(true);
+    const whole = toCompactDebugString(value);
+    expect(whole.length).toBeGreaterThan(50);
+    expect(quotedDebugString(value)).toBe(`\`${whole.slice(0, 47)}...\``);
   });
 
   it("returns a quoted rendering for a value the renderer cannot read", () => {

--- a/packages/data-model/test/codec-common/quotedDebugString.test.ts
+++ b/packages/data-model/test/codec-common/quotedDebugString.test.ts
@@ -1,0 +1,29 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { quotedDebugString } from "@/codec-common/quotedDebugString.ts";
+
+describe("quotedDebugString()", () => {
+  it("returns the compact rendering as a backtick-quoted code span", () => {
+    expect(quotedDebugString({ a: [1, "x"] })).toBe('`{a:[1,"x"]}`');
+  });
+
+  it("returns a rendering cut to fifty characters, ellipsis included", () => {
+    const value = { text: "x".repeat(100) };
+    const quoted = quotedDebugString(value);
+    expect(quoted).toBe("`" + quoted.slice(1, -1) + "`");
+    expect(quoted.slice(1, -1).length).toBe(50);
+    expect(quoted.endsWith("...`")).toBe(true);
+  });
+
+  it("returns a quoted rendering for a value the renderer cannot read", () => {
+    const value = {
+      get boom(): number {
+        throw new Error("nope");
+      },
+    };
+    expect(quotedDebugString(value)).toBe(
+      '`{boom:/unconvertible("nope")}`',
+    );
+  });
+});

--- a/packages/data-model/test/value-debug-cases.test.ts
+++ b/packages/data-model/test/value-debug-cases.test.ts
@@ -114,7 +114,7 @@ describe("value-debug-cases", () => {
       const value = evaluateExpression(recorded.expression);
       const actual = {
         indented: toIndentedDebugString(value),
-        compact: toCompactDebugString(value, COMPACT_MAX_LENGTH),
+        compact: toCompactDebugString(value, { maxLength: COMPACT_MAX_LENGTH }),
       };
 
       if (UPDATE_GOLDENS) {

--- a/packages/data-model/test/value-debug-structured.test.ts
+++ b/packages/data-model/test/value-debug-structured.test.ts
@@ -18,7 +18,7 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
-import type { DebugValueOptions } from "@/api.ts";
+import type { DebugValueOptions } from "@/interface.ts";
 import { toStructuredDebugValue } from "@/value-debug.ts";
 import { isValidFabricValue } from "@/type-check.ts";
 import { FabricEpochNsec } from "@/fabric-primitives/FabricEpochNsec.ts";

--- a/packages/data-model/test/value-debug-structured.test.ts
+++ b/packages/data-model/test/value-debug-structured.test.ts
@@ -18,6 +18,7 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
+import type { DebugValueOptions } from "@/api.ts";
 import { toStructuredDebugValue } from "@/value-debug.ts";
 import { isValidFabricValue } from "@/type-check.ts";
 import { FabricEpochNsec } from "@/fabric-primitives/FabricEpochNsec.ts";
@@ -344,14 +345,14 @@ describe("toStructuredDebugValue()", () => {
 
   describe("with `maxDepth`", () => {
     it("returns `/...` and the elided value's kind at the limit", () => {
-      expect(toStructuredDebugValue({ a: { b: 1 } }, 2))
+      expect(toStructuredDebugValue({ a: { b: 1 } }, { maxDepth: 2 }))
         .toEqual({ a: { "/...": "object" } });
-      expect(toStructuredDebugValue({ a: [1, 2] }, 2))
+      expect(toStructuredDebugValue({ a: [1, 2] }, { maxDepth: 2 }))
         .toEqual({ a: { "/...": "array" } });
     });
 
     it("returns the elision at the top level given a `maxDepth` of `1`", () => {
-      expect(toStructuredDebugValue({ a: 1 }, 1))
+      expect(toStructuredDebugValue({ a: 1 }, { maxDepth: 1 }))
         .toEqual({ "/...": "object" });
     });
 
@@ -359,16 +360,17 @@ describe("toStructuredDebugValue()", () => {
       // The converting leaf makes this say that conversion reached the
       // bottom, not merely that nothing was elided on the way.
 
-      expect(toStructuredDebugValue({ a: { b: Symbol("leaf") } }, 3))
-        .toEqual({ a: { b: { "/uniqueSymbol": "leaf" } } });
+      expect(
+        toStructuredDebugValue({ a: { b: Symbol("leaf") } }, { maxDepth: 3 }),
+      ).toEqual({ a: { b: { "/uniqueSymbol": "leaf" } } });
     });
 
     it("returns a `FabricPrimitive` at the limit rather than eliding it", () => {
       // A primitive is atomic, so including it adds no nesting to the result.
 
       const value = new FabricEpochNsec(123n);
-      expect((toStructuredDebugValue({ t: value }, 2) as { t: unknown }).t)
-        .toBe(value);
+      const result = toStructuredDebugValue({ t: value }, { maxDepth: 2 });
+      expect((result as { t: unknown }).t).toBe(value);
     });
 
     it("returns a bounded result for a structure deeper than the default", () => {
@@ -387,35 +389,42 @@ describe("toStructuredDebugValue()", () => {
 
     it("throws given a `maxDepth` that is not a positive integer", () => {
       for (const bad of [0, -1, 1.5, Infinity, NaN]) {
-        expect(() => toStructuredDebugValue({}, bad))
+        expect(() => toStructuredDebugValue({}, { maxDepth: bad }))
           .toThrow("`maxDepth` must be a positive integer or `undefined`");
       }
     });
 
     it("throws given a `maxDepth` that is not a number", () => {
       for (const bad of ["3", null, {}]) {
-        expect(() => toStructuredDebugValue({}, bad as unknown as number))
+        const options = { maxDepth: bad as unknown as number };
+        expect(() => toStructuredDebugValue({}, options))
           .toThrow("`maxDepth` must be a positive integer or `undefined`");
+      }
+    });
+  });
+
+  describe("with `options` that are not a plain object", () => {
+    it("throws, naming the offending value", () => {
+      for (const bad of [100, "3", null, [], new Map()]) {
+        expect(() =>
+          toStructuredDebugValue({}, bad as unknown as DebugValueOptions)
+        ).toThrow("`options` must be a plain object or `undefined`; got `");
       }
     });
   });
 
   describe("with a `replacer`", () => {
     it("returns the replacement in place of the original value", () => {
-      const result = toStructuredDebugValue(
-        { a: 1, b: 2 },
-        undefined,
-        (value) => (value === 1 ? "one" : value),
-      );
+      const result = toStructuredDebugValue({ a: 1, b: 2 }, {
+        replacer: (value) => (value === 1 ? "one" : value),
+      });
       expect(result).toEqual({ a: "one", b: 2 });
     });
 
     it("returns a replacement offered for the top-level value", () => {
-      const result = toStructuredDebugValue(
-        { a: 1 },
-        undefined,
-        (value) => (typeof value === "object" ? "replaced" : value),
-      );
+      const result = toStructuredDebugValue({ a: 1 }, {
+        replacer: (value) => (typeof value === "object" ? "replaced" : value),
+      });
       expect(result).toBe("replaced");
     });
 
@@ -423,11 +432,9 @@ describe("toStructuredDebugValue()", () => {
       // The replacement re-enters conversion, so a value the replacer hands
       // back still gets escaped, tagged, and depth-limited like any other.
 
-      const result = toStructuredDebugValue(
-        { a: 1 },
-        undefined,
-        (value) => (value === 1 ? new Map() : value),
-      );
+      const result = toStructuredDebugValue({ a: 1 }, {
+        replacer: (value) => (value === 1 ? new Map() : value),
+      });
       expect(result).toEqual({ a: { "/Map": "/..." } });
     });
 
@@ -435,14 +442,12 @@ describe("toStructuredDebugValue()", () => {
       // A failed replacement reads as a refusal to replace rather than as a
       // conversion error, so the rest of the result is unaffected.
 
-      const result = toStructuredDebugValue(
-        { a: 1, m: new Map() },
-        undefined,
-        (value) => {
+      const result = toStructuredDebugValue({ a: 1, m: new Map() }, {
+        replacer: (value) => {
           if (value === 1) throw new Error("no thanks");
           return value;
         },
-      );
+      });
       expect(result).toEqual({ a: 1, m: { "/Map": "/..." } });
     });
   });

--- a/packages/data-model/test/value-debug.test.ts
+++ b/packages/data-model/test/value-debug.test.ts
@@ -19,7 +19,10 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
-import type { CompactDebugStringOptions, DebugValueOptions } from "@/api.ts";
+import type {
+  CompactDebugStringOptions,
+  DebugValueOptions,
+} from "@/interface.ts";
 import {
   toCompactDebugString,
   toDebugKindString,

--- a/packages/data-model/test/value-debug.test.ts
+++ b/packages/data-model/test/value-debug.test.ts
@@ -19,6 +19,7 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
+import type { CompactDebugStringOptions, DebugValueOptions } from "@/api.ts";
 import {
   toCompactDebugString,
   toDebugKindString,
@@ -65,7 +66,7 @@ describe("value-debug", () => {
         it("renders the full text when `maxLength` fits the whole thing", () => {
           const item = ["xy", NaN];
           const expected = '["xy",NaN]'; // Note: Length 10.
-          expect(toCompactDebugString(item, len)).toBe(expected);
+          expect(toCompactDebugString(item, { maxLength: len })).toBe(expected);
         });
 
         it("truncates to `maxLength` when it is smaller than the whole rendered length", () => {
@@ -74,10 +75,43 @@ describe("value-debug", () => {
           const whole = toCompactDebugString(item);
           const expected = whole.slice(0, len - 3) + "...";
           expect(whole.length).toBeGreaterThan(len);
-          expect(toCompactDebugString(item, len)).toBe(expected);
-          expect(toCompactDebugString(item, len).length).toBe(len);
+          expect(toCompactDebugString(item, { maxLength: len })).toBe(expected);
+          expect(toCompactDebugString(item, { maxLength: len }).length).toBe(
+            len,
+          );
         });
       }
+    });
+
+    describe("with `maxDepth`", () => {
+      it("renders to the given depth rather than to the default", () => {
+        const value = { a: { b: { c: 1 } } };
+        expect(toCompactDebugString(value, { maxDepth: 2 })).toBe("{a:...}");
+        expect(toCompactDebugString(value, { maxDepth: 3 })).toBe(
+          "{a:{b:...}}",
+        );
+      });
+
+      it("throws given a `maxDepth` that is not a positive integer", () => {
+        expect(() => toCompactDebugString({}, { maxDepth: 0 }))
+          .toThrow("`maxDepth` must be a positive integer or `undefined`");
+      });
+    });
+
+    describe("with a `replacer`", () => {
+      it("renders the replacement in place of the original value", () => {
+        const options: CompactDebugStringOptions = {
+          replacer: (value) => (value === 1 ? "one" : value),
+        };
+        expect(toCompactDebugString({ a: 1, b: 2 }, options))
+          .toBe('{a:"one",b:2}');
+      });
+    });
+
+    it("throws given `options` that are not a plain object", () => {
+      expect(() =>
+        toCompactDebugString({}, 20 as unknown as CompactDebugStringOptions)
+      ).toThrow("`options` must be a plain object or `undefined`; got `20`");
     });
   });
 
@@ -101,6 +135,25 @@ describe("value-debug", () => {
       for (const value of values) {
         expect(toIndentedDebugString(value)).toBe(toCompactDebugString(value));
       }
+    });
+
+    it("renders to the given depth rather than to the default", () => {
+      const value = { a: { b: 1 } };
+      expect(toIndentedDebugString(value, { maxDepth: 2 }))
+        .toBe("{\n  a: ...\n}");
+    });
+
+    it("renders the replacement in place of the original value", () => {
+      const options: DebugValueOptions = {
+        replacer: (value) => (value === 1 ? "one" : value),
+      };
+      expect(toIndentedDebugString({ a: 1 }, options)).toBe('{\n  a: "one"\n}');
+    });
+
+    it("throws given `options` that are not a plain object", () => {
+      expect(() =>
+        toIndentedDebugString({}, null as unknown as DebugValueOptions)
+      ).toThrow("`options` must be a plain object or `undefined`; got `null`");
     });
   });
 

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -10024,7 +10024,7 @@ function describeHandlerStreamFailure(
 
   if (eventTarget.link === undefined) {
     return `${prefix} is not a stream reference (got: ${
-      toCompactDebugString(eventTarget.value, 80)
+      toCompactDebugString(eventTarget.value, { maxLength: 80 })
     })`;
   }
 
@@ -10055,7 +10055,7 @@ function describeHandlerStreamFailure(
 
   return `${prefix} resolves to ${where}, whose value is not a stream ` +
     `marker — { "$stream": true } was overwritten (found: ${
-      toCompactDebugString(eventTarget.value, 80)
+      toCompactDebugString(eventTarget.value, { maxLength: 80 })
     })`;
 }
 

--- a/packages/runner/src/schema-walk.ts
+++ b/packages/runner/src/schema-walk.ts
@@ -208,9 +208,9 @@ const warnNotSchema = (
   logger.warn("non-schema", () => [
     `Ignoring \`${key === undefined ? keyword : `${keyword}/${key}`}\`:`,
     `expected ${expected}, found`,
-    toCompactDebugString(found, 120),
+    toCompactDebugString(found, { maxLength: 120 }),
     "in schema",
-    toCompactDebugString(parent, 500),
+    toCompactDebugString(parent, { maxLength: 500 }),
   ]);
 };
 

--- a/packages/runner/src/storage/transaction-summary.ts
+++ b/packages/runner/src/storage/transaction-summary.ts
@@ -289,7 +289,7 @@ function truncateValue(value: unknown, maxLength: number): unknown {
   }
 
   if (typeof value === "object") {
-    return toCompactDebugString(value, maxLength);
+    return toCompactDebugString(value, { maxLength: maxLength });
   }
 
   return value;

--- a/packages/runner/test/favorites-row-stored-shape.test.ts
+++ b/packages/runner/test/favorites-row-stored-shape.test.ts
@@ -54,7 +54,7 @@ function debugFormContains(value: unknown, text: string): boolean {
     }
     return false;
   };
-  return walk(toStructuredDebugValue(value, 100));
+  return walk(toStructuredDebugValue(value, { maxDepth: 100 }));
 }
 
 const FAVORITES_MANAGER_PATH = fromFileUrl(

--- a/packages/runtime-client/src/backends/client-registry.ts
+++ b/packages/runtime-client/src/backends/client-registry.ts
@@ -253,7 +253,9 @@ export class RuntimeClients {
         // names nothing -- and renders a `FabricPrimitive` as `{}`.
         throw new Error(
           `Invalid IPC request: ${
-            toCompactDebugString(message, MAX_INVALID_REQUEST_RENDER)
+            toCompactDebugString(message, {
+              maxLength: MAX_INVALID_REQUEST_RENDER,
+            })
           }`,
         );
       }

--- a/packages/runtime-client/src/backends/post-to-client.ts
+++ b/packages/runtime-client/src/backends/post-to-client.ts
@@ -86,7 +86,7 @@ function undeliverableMessageFrom(
   error: unknown,
 ): IPCRemotePost {
   const reason = `Undeliverable message: ${describeFailure(error)}: ${
-    toCompactDebugString(message, MAX_UNDELIVERABLE_RENDER)
+    toCompactDebugString(message, { maxLength: MAX_UNDELIVERABLE_RENDER })
   }`;
   const msgId = (message as { msgId?: unknown }).msgId;
 

--- a/packages/runtime-client/src/backends/runtime-processor.ts
+++ b/packages/runtime-client/src/backends/runtime-processor.ts
@@ -624,11 +624,10 @@ function newConsoleDebugReplacer(): (value: any) => any {
  * Exported for testing.
  */
 export function toConsoleDebugValue(value: unknown): FabricValue {
-  return toStructuredDebugValue(
-    value,
-    MAX_CONSOLE_DEBUG_DEPTH,
-    newConsoleDebugReplacer(),
-  );
+  return toStructuredDebugValue(value, {
+    maxDepth: MAX_CONSOLE_DEBUG_DEPTH,
+    replacer: newConsoleDebugReplacer(),
+  });
 }
 
 export const hasExplicitSubscriptionSchema = (schema: unknown): boolean =>
@@ -2110,7 +2109,7 @@ export class RuntimeProcessor {
       // is bounded because the argument is a caller's data.
       throw new Error(
         `A piece's argument must be a record, not: ${
-          toCompactDebugString(argument, 120)
+          toCompactDebugString(argument, { maxLength: 120 })
         }`,
       );
     }

--- a/packages/static/assets/types/commonfabric.d.ts
+++ b/packages/static/assets/types/commonfabric.d.ts
@@ -68,12 +68,12 @@ type Mutable<T> = T extends ReadonlyArray<infer U> ? Mutable<U>[]
  * sandbox is served inlines this text rather than following a specifier out of
  * it, so a specifier named here would reach a compiler that resolves none.
  *
- * Two modules import this one: `interface.ts`, which re-exports these
+ * Apart from the drift guards, which each compare an implementation against
+ * the declaration here by name and so import it from here under an `Api`
+ * alias, two modules import this one: `interface.ts`, which re-exports these
  * declarations to the rest of this package, and `@commonfabric/api`, which
  * re-exports them to patterns. Every other module in this package takes them
- * from `interface.ts`. The one exception is a drift guard, which compares an
- * implementation against the declaration here by name, and so imports it from
- * here under an `Api` alias.
+ * from `interface.ts`.
  */
 
 /**

--- a/packages/static/assets/types/commonfabric.d.ts
+++ b/packages/static/assets/types/commonfabric.d.ts
@@ -44,9 +44,9 @@ type Mutable<T> = T extends ReadonlyArray<infer U> ? Mutable<U>[]
 /**
  * Pattern-visible declarations for the fabric value type system, and for the
  * options of the debug renderers over it, in the form that `@commonfabric/api`
- * re-exports to patterns. Everything here is an
- * interface, a type, or a `declare const`, except for the one brand-key
- * constant, so the module's only runtime footprint is that constant.
+ * re-exports to patterns. Everything here is an interface, a type, or a
+ * `declare const`, except for the one brand-key constant, so the module's only
+ * runtime footprint is that constant.
  *
  * The canonical implementations live in this module's siblings --
  * `interface.ts`, `fabric-primitives/FabricHash.ts`,

--- a/packages/static/assets/types/commonfabric.d.ts
+++ b/packages/static/assets/types/commonfabric.d.ts
@@ -67,6 +67,13 @@ type Mutable<T> = T extends ReadonlyArray<infer U> ? Mutable<U>[]
  * re-exports it to patterns, and the script that builds the type file the
  * sandbox is served inlines this text rather than following a specifier out of
  * it, so a specifier named here would reach a compiler that resolves none.
+ *
+ * Two modules import this one: `interface.ts`, which re-exports these
+ * declarations to the rest of this package, and `@commonfabric/api`, which
+ * re-exports them to patterns. Every other module in this package takes them
+ * from `interface.ts`. The one exception is a drift guard, which compares an
+ * implementation against the declaration here by name, and so imports it from
+ * here under an `Api` alias.
  */
 
 /**

--- a/packages/static/assets/types/commonfabric.d.ts
+++ b/packages/static/assets/types/commonfabric.d.ts
@@ -42,8 +42,9 @@ type Mutable<T> = T extends ReadonlyArray<infer U> ? Mutable<U>[]
 //
 
 /**
- * Pattern-visible declarations for the fabric value type system, in the form
- * that `@commonfabric/api` re-exports to patterns. Everything here is an
+ * Pattern-visible declarations for the fabric value type system, and for the
+ * options of the debug renderers over it, in the form that `@commonfabric/api`
+ * re-exports to patterns. Everything here is an
  * interface, a type, or a `declare const`, except for the one brand-key
  * constant, so the module's only runtime footprint is that constant.
  *
@@ -459,6 +460,40 @@ export interface FabricArray extends ReadonlyArray<FabricValue> {}
  */
 export interface FabricPlainObject
   extends Readonly<Record<string, FabricValue>> {}
+
+/**
+ * Options accepted by `toStructuredDebugValue()`, and by the debug-string
+ * renderers built on it.
+ */
+export interface DebugValueOptions {
+  /**
+   * Maximum depth of result nesting, a positive integer. An item which would
+   * require further nesting is instead converted into a form suggestive of the
+   * elided information. When absent, the depth is the default of the function
+   * called: as deep as reasonably possible for a structured value, and ten
+   * levels for a debug string. A large value is capped; there is no guarantee
+   * about the _actual_ possible maximum depth.
+   */
+  readonly maxDepth?: number;
+
+  /**
+   * Replacer function, called on every value and sub-value encountered, to get
+   * a replacement value to use. A replacer which does not want to replace a
+   * value returns the value it receives, and one which throws is taken to have
+   * declined to replace.
+   */
+  readonly replacer?: (value: any) => any;
+}
+
+/** Options accepted by `toCompactDebugString()`. */
+export interface CompactDebugStringOptions extends DebugValueOptions {
+  /**
+   * Maximum length of the result. When the rendering runs longer, the result
+   * is truncated to this length, which includes a trailing ASCII ellipsis of
+   * `...`. A length below three is taken as three.
+   */
+  readonly maxLength?: number;
+}
 
 //
 // Fabric Execution Value Types
@@ -3682,9 +3717,12 @@ export interface PatternEnvironment {
 export type GetPatternEnvironmentFunction = () => PatternEnvironment;
 export type ToCompactDebugStringFunction = (
   value: unknown,
-  maxLength?: number,
+  options?: CompactDebugStringOptions,
 ) => string;
-export type ToIndentedDebugStringFunction = (value: unknown) => string;
+export type ToIndentedDebugStringFunction = (
+  value: unknown,
+  options?: DebugValueOptions,
+) => string;
 
 /**
  * Compare two cells or values for equality after resolving, i.e. after

--- a/packages/toolshed/routes/storage/memory/memwrite-trace.ts
+++ b/packages/toolshed/routes/storage/memory/memwrite-trace.ts
@@ -105,7 +105,7 @@ export function formatMemWriteTrace(
   // Render via the canonical Fabric debug formatter (handles special
   // primitives/instances, bigints, non-finite numbers; never throws).
   const rendered = hasValue
-    ? toCompactDebugString(valueSource, VALUE_DISPLAY_LEN)
+    ? toCompactDebugString(valueSource, { maxLength: VALUE_DISPLAY_LEN })
     : "";
   return `${base} val=${rendered}`;
 }


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Fable 5.1)

## What

The three debug renderers in `data-model` take an options bag in place of
positional option arguments:

* `toStructuredDebugValue(value, { maxDepth, replacer })`.
* `toIndentedDebugString(value, { maxDepth, replacer })`.
* `toCompactDebugString(value, { maxDepth, replacer, maxLength })`.

The bag's types, `DebugValueOptions` and `CompactDebugStringOptions`, live in
`data-model`'s `api.ts`, which `@commonfabric/api` re-exports, so the
pattern-facing `commonfabric.d.ts` (regenerated here) carries them too. The
package barrel exports them as well.

## Behavior

* A string renderer's nesting depth is now the caller's to set. The former
  fixed depth of ten levels is its default; the structured conversion keeps
  its default of "as deep as reasonably possible."
* An `options` value that is not a plain object is refused with an error
  naming it, which is what an old-style positional call now hits. An invalid
  `maxDepth` is refused as before, from the string renderers as well.
* The lenient handling of `maxLength` (a non-number ignored, a value below
  three taken as three) is unchanged.

## Callers

Every call passing a positional `maxLength` or `maxDepth` is rewritten to the
bag: `data-model`'s codec acts and reportable-tag helpers, `runner`,
`runtime-client`, `toolshed`, and the tests. No pattern passed one.

## Verification

* `deno task check` (under the lenient version gate; `mise` is not on this
  sandbox's path), `deno task cfcheck`, `deno fmt --check`, `deno lint`.
* `deno task test` in `data-model`, `runner`, `runtime-client`, `api`;
  `static`'s `deno-test` half and its `check-commonfabric-types`.
* `toolshed`'s suite fails 21 tests here on `listen()` refused by the agent
  sandbox; the untouched `main` tree fails the same 21.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6825?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

