### PR TITLE
perf(cli): trim callable discovery preflight

### DIFF
--- a/packages/cli/lib/cell-selection.ts
+++ b/packages/cli/lib/cell-selection.ts
@@ -80,6 +80,22 @@ const LINK_MARKER_KEY = "$link";
  */
 const CONCISE_ADDRESS_SUFFIX = "@";
 
+const CLI_TRACE_TIMINGS = Deno.env.get("CF_CLI_TRACE_TIMINGS") === "1";
+
+async function timeSelectionPhase<T>(
+  label: string,
+  run: () => T | Promise<T>,
+): Promise<T> {
+  if (!CLI_TRACE_TIMINGS) return await run();
+  const start = performance.now();
+  try {
+    return await run();
+  } finally {
+    const elapsed = Math.round(performance.now() - start);
+    console.error(`[cf-phase] ${elapsed}ms :: cellSelection.${label}`);
+  }
+}
+
 /**
  * The address a marked position accumulates as the walk descends, which is
  * serialized into the LLM-friendly reference it renders as. `id` keeps its
@@ -3388,7 +3404,7 @@ export async function deriveSelectedValue(
   const outputCell = result.key("value").asSchema(outputSchema);
   try {
     runtime.prepareTxForCommit(tx);
-    const committed = await tx.commit();
+    const committed = await timeSelectionPhase("commit", () => tx.commit());
     if (committed.error !== undefined) {
       throw new CellSelectionError(
         `Could not apply get transform: ${committed.error}`,
@@ -3405,11 +3421,14 @@ export async function deriveSelectedValue(
     // 2026-08-14; packages/cli/README.md names the shape-the-collect
     // alternative); scoping this wait to the transform's own computation is
     // the named follow-up.
-    await outputCell.pull();
-    await runtime.idle();
-    await runtime.storageManager.synced();
-    await outputCell.pull();
-    await runtime.idle();
+    await timeSelectionPhase("output.pull.beforeIdle", () => outputCell.pull());
+    await timeSelectionPhase("runtime.idle.beforeSync", () => runtime.idle());
+    await timeSelectionPhase(
+      "storage.synced",
+      () => runtime.storageManager.synced(),
+    );
+    await timeSelectionPhase("output.pull.afterSync", () => outputCell.pull());
+    await timeSelectionPhase("runtime.idle.afterSync", () => runtime.idle());
     const outputValue = outputCell.get();
     const recorded = errors.slice(errorCountBefore);
     if (recorded.length > 0) {

--- a/packages/cli/lib/cell-selection.ts
+++ b/packages/cli/lib/cell-selection.ts
@@ -37,6 +37,7 @@ import {
   schemaIsObjectShaped,
 } from "./declared-fields.ts";
 import { nearestName } from "./refusal.ts";
+import { timeCliPhase } from "./trace-timing.ts";
 
 type PredicateComparisonOperator = "==" | "!=" | "<" | "<=" | ">" | ">=";
 
@@ -80,21 +81,11 @@ const LINK_MARKER_KEY = "$link";
  */
 const CONCISE_ADDRESS_SUFFIX = "@";
 
-const CLI_TRACE_TIMINGS = Deno.env.get("CF_CLI_TRACE_TIMINGS") === "1";
-
-async function timeSelectionPhase<T>(
+/** A selection phase in the command's trace, under its own prefix. */
+const timeSelectionPhase = <T>(
   label: string,
   run: () => T | Promise<T>,
-): Promise<T> {
-  if (!CLI_TRACE_TIMINGS) return await run();
-  const start = performance.now();
-  try {
-    return await run();
-  } finally {
-    const elapsed = Math.round(performance.now() - start);
-    console.error(`[cf-phase] ${elapsed}ms :: cellSelection.${label}`);
-  }
-}
+): Promise<T> => timeCliPhase(`cellSelection.${label}`, run);
 
 /**
  * The address a marked position accumulates as the walk descends, which is

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -108,6 +108,7 @@ import {
   CellSelectionError,
   deriveSelectedValue,
 } from "./cell-selection.ts";
+import { timeCliPhase } from "./trace-timing.ts";
 import { cliCommand } from "./cli-name.ts";
 import {
   type ExecCommandSpec,
@@ -421,8 +422,6 @@ interface PieceOperationDependencies extends PieceResolutionDeps {
   deriveSelectedValue?: typeof deriveSelectedValue;
 }
 
-const CLI_TRACE_TIMINGS = Deno.env.get("CF_CLI_TRACE_TIMINGS") === "1";
-
 interface DisposableRuntime {
   dispose(): Promise<unknown>;
   storageManager?: unknown;
@@ -474,22 +473,6 @@ export async function withRuntimeCleanupOnFailure<T>(
       },
     );
     throw error;
-  }
-}
-
-async function timeCliPhase<T>(
-  label: string,
-  run: () => T | Promise<T>,
-): Promise<T> {
-  if (!CLI_TRACE_TIMINGS) {
-    return await run();
-  }
-  const start = performance.now();
-  try {
-    return await run();
-  } finally {
-    const elapsed = Math.round(performance.now() - start);
-    console.error(`[cf-phase] ${elapsed}ms :: ${label}`);
   }
 }
 

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -1856,13 +1856,13 @@ async function tryResolveLivePieceToolCallable(
   return callableKind === "tool" ? callableCell : null;
 }
 
-/** Load the target piece and its pieces controller for callable
- * resolution/listing —
- * one shared path so `cf piece call` and `cf piece verbs` always see the same
- * piece state. */
+/** Load the target piece and its pieces controller for callable resolution or
+ * discovery. Dispatch may bootstrap the space root before calling; read-only
+ * discovery starts only the addressed piece. */
 async function loadPieceForCallables(
   config: PieceConfig,
   deps: PieceCallableDependencies = {},
+  ensureSpaceRoot = true,
 ): Promise<{
   pieces: any;
   piece: any;
@@ -1872,7 +1872,7 @@ async function loadPieceForCallables(
   const pieces = await (deps.loadPieces ?? loadPieces)(config);
   const resolvedConfig = await resolvePieceConfigWithPieces(config, pieces);
 
-  if (!deps.loadPiece) {
+  if (!deps.loadPiece && ensureSpaceRoot) {
     try {
       await pieces.ensureDefaultPattern();
     } catch (error) {
@@ -3057,7 +3057,7 @@ export async function listPieceCallables(
   config: PieceConfig,
   deps: PieceCallableDependencies = {},
 ): Promise<PieceCallablesListing> {
-  const { piece } = await loadPieceForCallables(config, deps);
+  const { piece } = await loadPieceForCallables(config, deps, false);
   return (await listCallablesForLoadedPiece(piece)).listing;
 }
 
@@ -3343,7 +3343,7 @@ export async function describePiece(
   config: PieceConfig,
   deps: PieceCallableDependencies = {},
 ): Promise<PieceDescription> {
-  const { piece } = await loadPieceForCallables(config, deps);
+  const { piece } = await loadPieceForCallables(config, deps, false);
   const { listing, compiled } = await listCallablesForLoadedPiece(piece);
   let name: string | undefined;
   try {
@@ -4318,36 +4318,60 @@ export async function getCellValue(
     deps.resolvePieceAddress,
   );
   const shouldStep = options.step === true;
-  const piece = await pieces.get(
-    resolvedConfig.piece,
-    shouldStep,
-    undefined,
-    resolvedConfig.pieceScope,
+  const piece = await timeCliPhase(
+    "getCellValue.piece",
+    () =>
+      pieces.get(
+        resolvedConfig.piece,
+        shouldStep,
+        undefined,
+        resolvedConfig.pieceScope,
+      ),
   );
 
   try {
     if (shouldStep) {
-      await piece.getCell().pull();
+      await timeCliPhase(
+        "getCellValue.step.piece.pull",
+        () => piece.getCell().pull(),
+      );
       const rootCell =
         await (options.input ? piece.input.getCell() : piece.result.getCell());
       const targetCell = rootCell.key(...path);
-      await targetCell.pull();
-      await pieces.synced();
-      await pieces.runtime.idle();
-      await pieces.synced();
+      await timeCliPhase(
+        "getCellValue.step.target.pull",
+        () => targetCell.pull(),
+      );
+      await timeCliPhase(
+        "getCellValue.step.synced.beforeIdle",
+        () => pieces.synced(),
+      );
+      await timeCliPhase(
+        "getCellValue.step.runtime.idle",
+        () => pieces.runtime.idle(),
+      );
+      await timeCliPhase(
+        "getCellValue.step.synced.afterIdle",
+        () => pieces.synced(),
+      );
     }
 
     const prop = options.input ? "input" : "result";
     if (options.selection !== undefined) {
+      const selection = options.selection;
       const rootCell = await piece[prop].getCell();
       const targetCell = rootCell.key(...path);
       let selected: unknown;
       try {
-        selected = await (deps.deriveSelectedValue ?? deriveSelectedValue)(
-          pieces.runtime,
-          pieces.getSpace(),
-          targetCell,
-          options.selection,
+        selected = await timeCliPhase(
+          "getCellValue.selection",
+          () =>
+            (deps.deriveSelectedValue ?? deriveSelectedValue)(
+              pieces.runtime,
+              pieces.getSpace(),
+              targetCell,
+              selection,
+            ),
         );
       } catch (error) {
         // The verb refusal wins over every selection error, not only the

--- a/packages/cli/lib/trace-timing.ts
+++ b/packages/cli/lib/trace-timing.ts
@@ -1,0 +1,42 @@
+/**
+ * Phase timing for the CLI's own code paths, written to stderr when
+ * `CF_CLI_TRACE_TIMINGS=1` (docs/development/CONFIGURATION.md). Every phase
+ * line has one shape, `[cf-phase] <ms>ms :: <label>`, so a trace from any
+ * command greps the same way. The piece package keeps its own `[piece-phase]`
+ * lines behind the same variable; together they attribute a command's latency
+ * across the CLI/controller boundary.
+ */
+
+/** Where a phase reports, and whether it does. Injected by tests; commands
+ * use {@link cliPhaseTrace}. */
+export interface PhaseTrace {
+  enabled: boolean;
+  log: (line: string) => void;
+}
+
+/** The process-wide trace: read once, since the flag is a property of the
+ * process rather than of any one call. */
+export const cliPhaseTrace: PhaseTrace = {
+  enabled: Deno.env.get("CF_CLI_TRACE_TIMINGS") === "1",
+  log: (line) => console.error(line),
+};
+
+/**
+ * Run `run` as one named phase. With tracing off this is `run` itself; with
+ * it on, the elapsed time is reported whether the phase returned or threw, so
+ * a failing command's trace still says where its time went.
+ */
+export async function timeCliPhase<T>(
+  label: string,
+  run: () => T | Promise<T>,
+  trace: PhaseTrace = cliPhaseTrace,
+): Promise<T> {
+  if (!trace.enabled) return await run();
+  const start = performance.now();
+  try {
+    return await run();
+  } finally {
+    const elapsed = Math.round(performance.now() - start);
+    trace.log(`[cf-phase] ${elapsed}ms :: ${label}`);
+  }
+}

--- a/packages/cli/test/piece-verbs.test.ts
+++ b/packages/cli/test/piece-verbs.test.ts
@@ -2,7 +2,11 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import type { JSONSchema } from "@commonfabric/api";
 import type { PieceCallablesListing } from "../lib/piece.ts";
-import { listPieceCallables, partitionVerbListing } from "../lib/piece.ts";
+import {
+  describePiece,
+  listPieceCallables,
+  partitionVerbListing,
+} from "../lib/piece.ts";
 import { verbListingJson, verbListingLines } from "../commands/piece.ts";
 
 const TEST_PATTERN_REF = {
@@ -297,6 +301,50 @@ describe("listPieceCallables", () => {
       ["fid1:piece-stored", true, undefined, undefined],
     ]);
     expect(listing.verbs.map((verb) => verb.name)).toEqual(["addTopic"]);
+  });
+
+  it("describes the addressed piece without starting the space root", async () => {
+    const resultRoot = cell(
+      { addTopic: { $stream: true } },
+      {
+        type: "object",
+        properties: { addTopic: ADD_TOPIC_EVENT },
+      },
+    );
+    const piece = {
+      result: { getCell: () => Promise.resolve(resultRoot) },
+      input: { getCell: () => Promise.resolve(cell(undefined, undefined)) },
+      getCell: () => resultRoot,
+    };
+    const getCalls: unknown[][] = [];
+    let ensureCalls = 0;
+    const manager = {
+      ensureDefaultPattern: () => {
+        ensureCalls++;
+        return Promise.resolve();
+      },
+      get: (...args: unknown[]) => {
+        getCalls.push(args);
+        return Promise.resolve(piece);
+      },
+      getSpace: () => "home",
+    };
+
+    const description = await describePiece(
+      {
+        apiUrl: "http://localhost:8000",
+        identity: "/tmp/test-identity.pem",
+        piece: "fid1:piece-stored",
+        space: "home",
+      },
+      { loadPieces: () => Promise.resolve(manager as never) },
+    );
+
+    expect(ensureCalls).toBe(0);
+    expect(getCalls).toEqual([
+      ["fid1:piece-stored", true, undefined, undefined],
+    ]);
+    expect(description.verbs.map((verb) => verb.name)).toEqual(["addTopic"]);
   });
 
   it("lists handlers and tools with schemas; excludes data; result shadows input", async () => {

--- a/packages/cli/test/piece-verbs.test.ts
+++ b/packages/cli/test/piece-verbs.test.ts
@@ -255,6 +255,50 @@ function compiledPattern(
 }
 
 describe("listPieceCallables", () => {
+  it("starts the addressed piece without starting the space root", async () => {
+    const resultRoot = cell(
+      { addTopic: { $stream: true } },
+      {
+        type: "object",
+        properties: { addTopic: ADD_TOPIC_EVENT },
+      },
+    );
+    const piece = {
+      result: { getCell: () => Promise.resolve(resultRoot) },
+      input: { getCell: () => Promise.resolve(cell(undefined, undefined)) },
+      getCell: () => resultRoot,
+    };
+    const getCalls: unknown[][] = [];
+    let ensureCalls = 0;
+    const manager = {
+      ensureDefaultPattern: () => {
+        ensureCalls++;
+        return Promise.resolve();
+      },
+      get: (...args: unknown[]) => {
+        getCalls.push(args);
+        return Promise.resolve(piece);
+      },
+      getSpace: () => "home",
+    };
+
+    const listing = await listPieceCallables(
+      {
+        apiUrl: "http://localhost:8000",
+        identity: "/tmp/test-identity.pem",
+        piece: "fid1:piece-stored",
+        space: "home",
+      },
+      { loadPieces: () => Promise.resolve(manager as never) },
+    );
+
+    expect(ensureCalls).toBe(0);
+    expect(getCalls).toEqual([
+      ["fid1:piece-stored", true, undefined, undefined],
+    ]);
+    expect(listing.verbs.map((verb) => verb.name)).toEqual(["addTopic"]);
+  });
+
   it("lists handlers and tools with schemas; excludes data; result shadows input", async () => {
     const resultRoot = cell(
       {

--- a/packages/cli/test/trace-timing.test.ts
+++ b/packages/cli/test/trace-timing.test.ts
@@ -1,0 +1,35 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { type PhaseTrace, timeCliPhase } from "../lib/trace-timing.ts";
+
+function capturingTrace(enabled: boolean): PhaseTrace & { lines: string[] } {
+  const lines: string[] = [];
+  return { enabled, lines, log: (line) => lines.push(line) };
+}
+
+describe("timeCliPhase", () => {
+  it("is the phase itself when tracing is off", async () => {
+    const trace = capturingTrace(false);
+    const value = await timeCliPhase("quiet", () => Promise.resolve(42), trace);
+    expect(value).toBe(42);
+    expect(trace.lines).toEqual([]);
+  });
+
+  it("reports one [cf-phase] line per phase, elapsed then label", async () => {
+    const trace = capturingTrace(true);
+    const value = await timeCliPhase("sync.piece", () => "done", trace);
+    expect(value).toBe("done");
+    expect(trace.lines).toHaveLength(1);
+    expect(trace.lines[0]).toMatch(/^\[cf-phase\] \d+ms :: sync\.piece$/);
+  });
+
+  it("still reports a phase that threw, and rethrows it", async () => {
+    const trace = capturingTrace(true);
+    const failure = new Error("storage unreachable");
+    await expect(
+      timeCliPhase("sync.piece", () => Promise.reject(failure), trace),
+    ).rejects.toBe(failure);
+    expect(trace.lines).toHaveLength(1);
+    expect(trace.lines[0]).toMatch(/:: sync\.piece$/);
+  });
+});

--- a/packages/patterns/topics/README.md
+++ b/packages/patterns/topics/README.md
@@ -173,11 +173,15 @@ lineage: Linear CT-1878, which this pattern exists to absorb).
 ## Headless / agent use
 
 Agents are first-class participants. Treat the running piece as authoritative:
-start with `cf piece describe --piece <piece>`,
-`cf piece verbs --piece <piece> --json`, and
-`cf piece call --piece <piece> <verb> --help --json`. The default verb listing
-is the contract surface; `--all` additionally shows UI wrappers and deprecated
-verbs. Against a deployed board piece:
+start with `cf piece verbs --piece <piece> --json`, which carries the deployed
+pattern reference and every verb's prose and schemas. Reach for
+`cf piece describe --piece <piece>` when piece-wide purpose, state, or input
+documentation is needed, and for
+`cf piece call --piece <piece> <verb> --help
+--json` once a verb is chosen; each
+is its own cold CLI process, so the three are not a default preflight. The
+default verb listing is the contract surface; `--all` additionally shows UI
+wrappers and deprecated verbs. Against a deployed board piece:
 
 ```bash
 cf piece call --piece <board> \

--- a/skills/topics/SKILL.md
+++ b/skills/topics/SKILL.md
@@ -52,10 +52,15 @@ reference edge, take no `agentName`, and return no value.
 The running piece is authoritative. Orient before mutating it:
 
 ```bash
-cf piece describe --cell "$TOPICS_BOARD"
 cf piece verbs --cell "$TOPICS_BOARD" --json
-cf piece call --cell "$TOPICS_BOARD" addTopic --help --json
 ```
+
+That listing includes the deployed pattern reference, callable prose, and input
+and output schemas. Use `cf piece describe --cell "$TOPICS_BOARD"` only when you
+need piece-wide purpose, state, or input documentation. Use
+`cf piece call --cell "$TOPICS_BOARD" <verb> --help --json` only after choosing
+a verb and when its generated flags or standalone help are useful. Each command
+is an independent cold CLI process, so do not run all three by default.
 
 The deployment can be well behind the checkout the CLI runs from, and that gap
 explains board behavior that would otherwise read as a defect. Ask it which
@@ -71,10 +76,11 @@ anything from a verb that behaves unlike the source in front of you. A gap of
 dozens of commits is ordinary, so which source is running is the first question,
 not the last.
 
-Repeat `describe`, `verbs`, and `call <verb> --help --json` after selecting a
-Topic. `piece verbs` lists contract verbs by default; `--all` additionally shows
-UI wrappers and deprecated verbs. The board's published Topic rows deliberately
-contain no verbs: take a row's address and call that Topic directly.
+Run `piece verbs --json` again after selecting a Topic, and use `describe` or
+per-verb help on demand. `piece verbs` lists contract verbs by default; `--all`
+additionally shows UI wrappers and deprecated verbs. The board's published Topic
+rows deliberately contain no verbs: take a row's address and call that Topic
+directly.
 
 The current declared contract is:
 


### PR DESCRIPTION
## Summary

- skip the unrelated space-root bootstrap when `piece verbs` and `piece describe` discover callables, while still starting the addressed piece for cold-piece correctness
- make `piece verbs --json` the Topics skill default preflight and move `describe` / per-verb help to on-demand use
- extend `CF_CLI_TRACE_TIMINGS=1` across stepped reads and selection convergence so the next latency work is phase-attributable

## Measurements

On the 156-topic Estuary board, the original `piece verbs --json` trace spent 5.247s starting the space root and 6.990s starting the addressed board before listing. This change removes the first phase. End-to-end time remains variable because addressed-piece startup ranged as high as 10.817s during the run.

The new read tracing also explains the projected-index result. In a 135.57s stepped projection, the actual `index` cell pull took 28ms; addressed-piece startup took 12.867s, the unconditional whole-piece pull took 58.271s, and selection convergence took 62.164s. In an unstepped 28.67s projection, selection spent 22.147s in the global storage sync after its first output pull completed in 696ms. The index is bounding its own work and payload, but broad convergence before and after it dominates perceived latency.

This PR instruments but does not alter those convergence semantics. Path-scoped stepping and transform-scoped convergence should be proven separately.

## Verification

- `deno task check`
- `deno fmt --check`
- `deno lint`
- `deno task check-skill-facts`
- CLI package `deno task test`: 1,987 tests / 2,217 steps, 0 failed
- focused callable discovery, description, and piece read tests: 186 steps, 0 failed
- Estuary smoke test returned the unchanged deployed `addTopic` contract