### PR TITLE
feat(shuttle): ls, and the two vocabularies a piece is named by

### DIFF
--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -184,11 +184,12 @@ Landed:
   `listSpaceSlugs`, `listPieces` and `listCellKeys`, each of which takes that
   connection as `deps.loadPieces`. A row that failed on its own account is
   still a row and carries what went wrong; a read that failed outright raises.
-  `slugs/` says what it is a listing of. Its index is a record of the names
-  assigned since it existed, which bounds the slugs that resolve in neither
-  direction: one assigned before it is not listed and resolves, and one listed
-  may no longer resolve — nothing removes an index entry, so a slug whose piece
-  is gone stays named — which is why a row carries its error. A slug stands in a place unresolved and the read resolves
+  `slugs/` says what it is a listing of. Its index records the names assigned
+  since it existed, which is not the set of slugs that resolve: one assigned
+  before the index is not listed, and one that is listed may no longer resolve,
+  nothing removing an entry once made. So `ls slugs/` does not enumerate what
+  resolves, and a row carries its own error where the name it lists reaches
+  nothing. A slug stands in a place unresolved and the read resolves
   it the way `--cell` does, which is what makes a slug typed back off a listing
   reach its piece.
 

--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -204,13 +204,13 @@ Landed:
   give its reason. What the first ruling costs is one shape: a key whose first
   character is `#` has no direct spelling — neither the name on its own nor a
   reference names it — and a listing prints no name for it. Some multi-segment
-  operand does reach it, `#` being data in every segment but the first, but a
-  route is not a name; [`grammar.md`](grammar.md) carries the ruling and
+  operand does reach it, `#` being data in a segment that names a data key,
+  but a route is not a name; [`grammar.md`](grammar.md) carries the ruling and
   characterizes the routes no further. Which keys are spelled through one door
   and
   not the other is pinned case by case in
-  `packages/shuttle/test/place.test.ts`, each case under a mutation, so the
-  record moves when the behavior does and not otherwise.
+  `packages/shuttle/test/place.test.ts`, so the record moves when the behavior
+  does and not otherwise.
 
 Still to come:
 

--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -184,8 +184,11 @@ Landed:
   `listSpaceSlugs`, `listPieces` and `listCellKeys`, each of which takes that
   connection as `deps.loadPieces`. A row that failed on its own account is
   still a row and carries what went wrong; a read that failed outright raises.
-  `slugs/` says what it is a listing of, its index being a lower bound on the
-  slugs that resolve. A slug stands in a place unresolved and the read resolves
+  `slugs/` says what it is a listing of. Its index is a record of the names
+  assigned since it existed, which bounds the slugs that resolve in neither
+  direction: one assigned before it is not listed and resolves, and one listed
+  may no longer resolve — nothing removes an index entry, so a slug whose piece
+  is gone stays named — which is why a row carries its error. A slug stands in a place unresolved and the read resolves
   it the way `--cell` does, which is what makes a slug typed back off a listing
   reach its piece.
 
@@ -197,9 +200,13 @@ Landed:
   strings. And every door holds a piece to the slug and handle vocabularies,
   `validatePieceSegment` being called rather than copied, so a walk, a resolved
   target and a settled move hold a piece to what a reference holds one to, and
-  give its reason. What the first ruling costs is one shape: a key whose first character
-  is `#` is reached from the piece it sits in by neither spelling, and a
-  listing prints no name for it. Which keys are spelled through one door and
+  give its reason. What the first ruling costs is one shape: a key whose first
+  character is `#` has no direct spelling — neither the name on its own nor a
+  reference names it — and a listing prints no name for it. A multi-segment
+  operand does reach it, `#` being data in every segment but the first, but
+  that is a route rather than a name, and a route through `..` reads the trail,
+  so it holds from a place reached one way and not from a place reached
+  another. Which keys are spelled through one door and
   not the other is pinned case by case in
   `packages/shuttle/test/place.test.ts`, each case under a mutation, so the
   record moves when the behavior does and not otherwise.

--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -202,11 +202,11 @@ Landed:
   target and a settled move hold a piece to what a reference holds one to, and
   give its reason. What the first ruling costs is one shape: a key whose first
   character is `#` has no direct spelling — neither the name on its own nor a
-  reference names it — and a listing prints no name for it. A multi-segment
-  operand does reach it, `#` being data in every segment but the first, but
-  that is a route rather than a name, and a route through `..` reads the trail,
-  so it holds from a place reached one way and not from a place reached
-  another. Which keys are spelled through one door and
+  reference names it — and a listing prints no name for it. Some multi-segment
+  operand does reach it, `#` being data in every segment but the first, but a
+  route is not a name; [`grammar.md`](grammar.md) carries the ruling and
+  characterizes the routes no further. Which keys are spelled through one door
+  and
   not the other is pinned case by case in
   `packages/shuttle/test/place.test.ts`, each case under a mutation, so the
   record moves when the behavior does and not otherwise.

--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -196,8 +196,8 @@ Landed:
   one `cd` takes back to that row, and leaves the split returning plain
   strings. And every door holds a piece to the slug and handle vocabularies,
   `validatePieceSegment` being called rather than copied, so a walk, a resolved
-  target and a settled move refuse what a reference refuses and give its
-  reason. What the first ruling costs is one shape: a key whose first character
+  target and a settled move hold a piece to what a reference holds one to, and
+  give its reason. What the first ruling costs is one shape: a key whose first character
   is `#` is reached from the piece it sits in by neither spelling, and a
   listing prints no name for it. Which keys are spelled through one door and
   not the other is pinned case by case in

--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -173,16 +173,43 @@ Landed:
   it is whitespace, either quote, the backslash, and the characters the
   grammar spends on structure, collected in one constant rather than counted
   in prose. The characters an operand writes an address with stay out of that
-  set, which is what leaves the relative-segment question below intact: what
-  the pair guarantees is that a printed value splits back into that one
-  value, and whether a quote should also reach the reading of a token is
-  still `ls`'s to settle. No verb reads a line yet.
+  set: what the pair guarantees is that a printed value splits back into that
+  one value, and a quote reaches no further than that. No verb reads a line
+  yet.
+
+- **B1b (slice 3) — `ls`, and the vocabulary a segment speaks**
+  (`packages/shuttle/src/listing.ts`). What stands at a place — a space root's
+  facets, the slugs the index records, the space's pieces, the keys directly
+  under the cell a place names — read over the held connection through
+  `listSpaceSlugs`, `listPieces` and `listCellKeys`, each of which takes that
+  connection as `deps.loadPieces`. A row that failed on its own account is
+  still a row and carries what went wrong; a read that failed outright raises.
+  `slugs/` says what it is a listing of, its index being a lower bound on the
+  slugs that resolve. A slug stands in a place unresolved and the read resolves
+  it the way `--cell` does, which is what makes a slug typed back off a listing
+  reach its piece.
+
+  The slice settles the two questions held for it, both of them recorded in
+  [`grammar.md`](grammar.md). A quote reaches no reading, so a name whose own
+  characters are readings prints as the reference that names it rather than as
+  a quoted spelling of itself — which is what makes every name a listing prints
+  one `cd` takes back to that row, and leaves the split returning plain
+  strings. And every door holds a piece to the slug and handle vocabularies,
+  `validatePieceSegment` being called rather than copied, so a walk, a resolved
+  target and a settled move refuse what a reference refuses and give its
+  reason. What the first ruling costs is one shape: a key whose first character
+  is `#` is reached from the piece it sits in by neither spelling, and a
+  listing prints no name for it. Which keys are spelled through one door and
+  not the other is pinned case by case in
+  `packages/shuttle/test/place.test.ts`, each case under a mutation, so the
+  record moves when the behavior does and not otherwise.
 
 Still to come:
 
 - **The prompt, a readline loop, and the verbs** (B1b for the verbs and
-  the connection, B1c for the prompt) — `cd` / `ls` / `pwd` / `get` over
-  one held `PiecesController`, with `#name` wish targets
+  the connection, B1c for the prompt) — `cd` / `ls` / `pwd` / `get` read off
+  a line and dispatched, over one held `PiecesController` and over the
+  listing above, with `#name` wish targets
   navigable within the connected space (`cd #favorites`, and the `wish`
   verb, over the `./lib/wish` export entry A1 adds; a home-anchored target
   from elsewhere is refused with the reason — decision 5).
@@ -197,36 +224,6 @@ Still to come:
   view substrate's export entries with the prompt: the line editor calls
   those modules, and an entry lands with the milestone that first calls one.
 
-- **Slug and name resolution** (B1b), riding the machinery `--cell` already
-  uses
-  (`resolveStoredPieceAddress`, `listSpaceSlugs`), so no CLI-surface arc
-  step gates B1.
-- **The vocabulary a relative segment speaks.** The walk and a reference
-  read a segment by different rules — the reserved readings
-  [`grammar.md`](grammar.md) states, against a reference's own unescaping
-  and fragment rule — so some keys are spelled through one and not the
-  other, and a segment lifted out of a rendering is an operand in its own
-  right rather than the key it was printed from. Which keys those are, and
-  what each lifted segment does instead of naming its key, is pinned case
-  by case in `packages/shuttle/test/place.test.ts`, each case under a
-  mutation, so the record moves when the behavior does and not otherwise.
-  `ls` settles it, in B1b: how such a key prints and how it is typed back
-  want deciding together.
-
-  Whether a piece is held to the slug and handle vocabularies is the same
-  question, and its answer is a rule rather than a count: a piece is held
-  where it passes through the canonical parse, and nowhere else. A reference
-  is held that way, and a settled move inherits it, the arm being minted
-  from a parsed reference; every other way in admits a piece the fabric
-  would not name, an arm a caller assembles rather than receives included.
-  What is settled is narrower, and in two parts. A path segment that is
-  empty, ends in whitespace, or holds a line break is refused at every door,
-  because a rendering of it would name a different cell. A piece is held to
-  more than that: one holding a line break is refused for the same reason,
-  and one that is empty, ends in whitespace, or holds an `@` is refused
-  because no slug or handle carries such a name.
-  [`grammar.md`](grammar.md) carries why that reason holds, and which of
-  those the canonical parse would take anyway.
 - **`where`** (B1c), the printing surface for the ambient record; later
   milestones add their dimensions to it as they add the dimensions themselves.
   It prints the record `pwd` prints, so it chooses the format for both — a

--- a/docs/plans/shuttle/grammar.md
+++ b/docs/plans/shuttle/grammar.md
@@ -322,9 +322,16 @@ listing prints names rather than routes. Everything on a listed line that is
 not a name is written between angle brackets. A name holding an angle bracket
 is printed quoted, the grammar reserving it, so a line opening with `<` carries
 no name — while a marker's own payload is not escaped, those brackets
-delimiting for a reader and not for a parser. Nothing parses a listed line. A row is one line, so a name carrying a line break
-is described rather than written, and a message carrying one has it written
-as a space.
+delimiting for a reader and not for a parser. Nothing parses a listed line.
+
+A row is one line, and the lines are separated by a newline, so a name holding
+one is described rather than written and a message holding one has it written
+as a space. Nothing else is rewritten. A carriage return, the Unicode line and
+paragraph separators and every other control character are printed as they
+stand, because a name is printed to be typed back and a rewritten one no
+longer names its row — a carriage return returns a terminal's cursor to the
+start of the line, and that is a thing a terminal does rather than a thing the
+name says, the same bound the rendering of a place is held to.
 
 Large collections appear everywhere (a space's pieces, an array of
 thousands). `ls` prints one height-fit page — what the terminal shows

--- a/docs/plans/shuttle/grammar.md
+++ b/docs/plans/shuttle/grammar.md
@@ -211,11 +211,12 @@ is the canonical parse's own — `validatePieceSegment`
 (`packages/cli/lib/llm-friendly-ref.ts`), called rather than copied, so that a
 name in neither vocabulary is refused with one sentence whichever door read
 it. The doors are the reference, a walk into a piece, a target the fabric
-resolved, and a settled move, which is every way a piece reaches a place:
+resolved, and a settled move, which is every door a piece reaches a place
+through:
 `cd slugs/Board` is refused, and the reason it gives is the reason `cd /Board`
 gives. That is what makes a listing's job possible: a name printed as an
-operand is one every door takes, and a name no door takes is one nothing
-prints an operand for.
+operand is one `cd` takes, and a name the rule refuses is one nothing offers
+an operand for.
 
 The vocabulary rule still buys no guarantee that every rendering is
 followable, and it and the rendering rules above catch different names. A
@@ -243,8 +244,8 @@ Those two readings between them leave one key with no **direct** spelling. A
 key whose *first* character is `#` is a wish target when it is the whole
 operand, and a reference carrying a `#` anywhere is refused, so neither door
 names it on its own. Some multi-segment operand still reaches it — `#` is data
-in every segment but the first, and `slugs/board/#key` names it from the space
-root — and which routes reach it from where is not characterized here. That is
+in a segment that names a data key, and `slugs/board/#key` names it from the
+space root — and which routes reach it from where is not characterized here. That is
 what the quoting ruling above costs: the key is reachable by a route rather
 than by a name, and a listing prints no name for such a row, a row's name
 being what it is called and not how to get to it.
@@ -326,8 +327,8 @@ delimiting for a reader and not for a parser. Nothing parses a listed line.
 
 A row is one line, and the lines are separated by a newline, so a name holding
 one is described rather than written and a message holding one has it written
-as a space. Nothing else is rewritten. A carriage return, the Unicode line and
-paragraph separators and every other control character are printed as they
+as a space. The newline's is the only rewrite there is, so a carriage
+return and the Unicode line and paragraph separators are printed as they
 stand, because a name is printed to be typed back and a rewritten one no
 longer names its row — a carriage return returns a terminal's cursor to the
 start of the line, and that is a thing a terminal does rather than a thing the

--- a/docs/plans/shuttle/grammar.md
+++ b/docs/plans/shuttle/grammar.md
@@ -306,7 +306,7 @@ and is not listed (`listSlugs`, `packages/piece/src/slugs.ts`), and a listing
 that implied completeness would be false.
 
 **Every name a listing prints is one `cd` takes back to that row**, and a row
-`cd` cannot reach prints no name at all. Most rows print their own name,
+it has no name for prints none at all. Most rows print their own name,
 written as a token by the rule above — a slug, a handle and an ordinary key
 each print as themselves. A row whose name's own characters are readings —
 a key called `..` or `-`, one holding the separator, one beginning with `@` —
@@ -319,10 +319,13 @@ what `cd` takes, and that is the claim rather than anything about the whole
 line: an error written after a name is text the fabric produced, and an odd
 quote in it leaves the line as a whole refusing to split.
 
-A row nothing reaches prints a marker in place of a name:
-everything on a listed line that is not a name is written between angle
-brackets, and the printer quotes every value holding one, so a line opening
-with `<` carries no name. A row is one line, so a name carrying a line break
+A row with no name prints a marker in its place, and says no more than that:
+a key whose first character is `#` is reached by a route, as above, and a
+listing prints names rather than routes. Everything on a listed line that is
+not a name is written between angle brackets. A name holding an angle bracket
+is printed quoted, the grammar reserving it, so a line opening with `<` carries
+no name — while a marker's own payload is not escaped, those brackets
+delimiting for a reader and not for a parser. Nothing parses a listed line. A row is one line, so a name carrying a line break
 is described rather than written, and a message carrying one has it written
 as a space.
 

--- a/docs/plans/shuttle/grammar.md
+++ b/docs/plans/shuttle/grammar.md
@@ -242,15 +242,12 @@ it governs the head and nothing else.
 Those two readings between them leave one key with no **direct** spelling. A
 key whose *first* character is `#` is a wish target when it is the whole
 operand, and a reference carrying a `#` anywhere is refused, so neither door
-names it on its own. A multi-segment operand still reaches it, `#` being data
-in every segment but the first: `slugs/board/#key` names it from the space
-root, and `../board/#key` names it from inside the piece — but only where the
-walk's own trail leads back, so the same string is refused from a piece a
-reference named. That is what the quoting ruling above costs, stated exactly:
-the key is reachable, by a route rather than by a name, and by a route that is
-not the same one from every place. A listing prints no name for such a row —
-a row's name is what it is called and not how to get to it — rather than a
-route, or a name that means something else.
+names it on its own. Some multi-segment operand still reaches it — `#` is data
+in every segment but the first, and `slugs/board/#key` names it from the space
+root — and which routes reach it from where is not characterized here. That is
+what the quoting ruling above costs: the key is reachable by a route rather
+than by a name, and a listing prints no name for such a row, a row's name
+being what it is called and not how to get to it.
 
 A container renders without the leading `/` that marks a reference, so a
 space root and a facet cannot be read back as a piece whose slug happens to

--- a/docs/plans/shuttle/grammar.md
+++ b/docs/plans/shuttle/grammar.md
@@ -95,15 +95,17 @@ an operand, or as the whole of one, rather than by the split, which is what
 puts them with the address characters rather than with the reserved ones.
 
 The two halves are one decision: what the printer writes, the split reads
-back as the one value it was given. That is the whole of the guarantee. What
-a reading then makes of that token is decided where the operand is read, and
-whether a quote should reach that decision — so that a key named `..`, or
-one beginning with `#`, has a spelling that names it — is part of the
-relative-segment question `ls` settles
-([`build-sequence.md`](build-sequence.md)). Ruling that it should has a
-known shape and a known cost: the split would start carrying which parts of
-a token were quoted, which grows the value it returns rather than adding a
-layer over it, and every reading that consults quoting reads that value.
+back as the one value it was given. That is the whole of the guarantee, and
+it stops there: **a quote reaches no reading**. The split returns plain
+strings, so a reading sees the characters a token holds and never how they
+were delivered, and `cd '..'` and `cd ..` are one operand. What names a key
+whose own characters a reading would take is therefore a different spelling
+rather than a different quoting — the reference below, which reads none of
+the relative readings — and that is what a listing prints for such a row.
+Ruling the other way has a known shape and a known cost: the split would
+start carrying which parts of a token were quoted, which grows the value it
+returns rather than adding a layer over it, and every reading that consults
+quoting reads that value.
 
 ## Place resolution
 
@@ -202,11 +204,24 @@ moves the refusal earlier and names the vocabulary where the parse names
 only the failure.
 
 One rule rather than three is a choice about wording, not about safety: the
-redundant cases cost nothing, and the rule buys no guarantee that every
-rendering is followable — a piece like `Not_A_Slug!!` passes it and the
-parse refuses that afterwards. Which pieces are held to the vocabulary at
-all is B1b's question, recorded with the other validation work in
-[`build-sequence.md`](build-sequence.md).
+redundant cases cost nothing.
+
+**Every door holds the piece to the two vocabularies** besides, and the check
+is the canonical parse's own — `validatePieceSegment`
+(`packages/cli/lib/llm-friendly-ref.ts`), called rather than copied, so that a
+name in neither vocabulary is refused with one sentence whichever door read
+it. A reference was already held that way; so are a walk into a piece, a
+target the fabric resolved, and a settled move. `cd slugs/Board` is refused,
+and the reason it gives is the reason `cd /Board` gives. That is what makes a
+listing's job possible: a name printed as an operand is one every door takes,
+and a name no door takes is one nothing prints an operand for.
+
+The vocabulary rule still buys no guarantee that every rendering is
+followable, and the two halves cover different names. A piece holding an `@`
+or ending in whitespace is caught by the rendering rules above rather than by
+the vocabulary, `isPieceHandle` being a length rule that takes either; and a
+path segment holding a `#` reaches a place under the readings below and
+renders as a reference the parse then refuses.
 
 A segment lifted out of a rendering is an operand in its own right, so
 these readings decide it rather than the key it was printed from.
@@ -221,6 +236,15 @@ suffix off before anything parses what it followed, and refuses every other
 fragment. And inside a piece `#` is an ordinary character of a data key,
 under the rule above: the wish reading is decided on the whole operand, so
 it governs the head and nothing else.
+
+Those two readings between them leave one key with no spelling at all. A key
+whose *first* character is `#` is a wish target when it is the whole operand,
+and a reference carrying a `#` anywhere is refused as an unknown suffix, so
+neither door reaches it from the piece it sits in — a later segment does, `#`
+being data everywhere but the head, which is a route out of the facet rather
+than out of the piece. That is what the quoting ruling above costs, and a
+listing prints no name for such a row rather than one that means something
+else.
 
 A container renders without the leading `/` that marks a reference, so a
 space root and a facet cannot be read back as a piece whose slug happens to
@@ -260,6 +284,32 @@ The facet set stays deliberately small; growing it is a design decision,
 not a convenience.
 
 ## Listings, pagination, search
+
+`ls` lists what stands at the place: a space root's facets, the slugs the
+space's index records, the space's pieces, or the keys directly under the
+cell the place names. A row that failed on its own account is still a row —
+a slug the index names and nothing resolves is a name the space has — so it
+carries what went wrong rather than being dropped, and one failed row never
+takes the listing down with it. A read that failed outright is no listing at
+all and raises.
+
+A listing says what it is a listing of wherever its rows are not everything
+standing there. `slugs/` is the case that has such a bound: the index names
+slugs assigned since it existed, so a slug it never recorded still resolves
+and is not listed (`listSlugs`, `packages/piece/src/slugs.ts`), and a listing
+that implied completeness would be false.
+
+**Every name a listing prints is one `cd` takes back to that row**, and a row
+`cd` cannot reach prints no name at all. Most rows print their own name,
+written as a token by the rule above — a slug, a handle and an ordinary key
+each print as themselves. A row whose name's own characters are readings —
+a key called `..`, one holding the separator, one a scope suffix would come
+off — prints the reference that names it instead, which reads none of them
+and unescapes `~1`. A row nothing reaches prints a marker in place of a name:
+everything on a listed line that is not a name is written between angle
+brackets, and the printer quotes every value holding one, so a line opening
+with `<` carries no name. A row is one line, so a name or a message carrying
+a line break is described rather than written.
 
 Large collections appear everywhere (a space's pieces, an array of
 thousands). `ls` prints one height-fit page — what the terminal shows

--- a/docs/plans/shuttle/grammar.md
+++ b/docs/plans/shuttle/grammar.md
@@ -306,7 +306,15 @@ written as a token by the rule above — a slug, a handle and an ordinary key
 each print as themselves. A row whose name's own characters are readings —
 a key called `..` or `-`, one holding the separator, one beginning with `@` —
 prints the reference that names it instead, which reads none of them and
-unescapes `~1`. A row nothing reaches prints a marker in place of a name:
+unescapes `~1`.
+
+The name is the first thing on its line, and the whole of it where the row
+has nothing else to report. What a reader copies off the front is therefore
+what `cd` takes, and that is the claim rather than anything about the whole
+line: an error written after a name is text the fabric produced, and an odd
+quote in it leaves the line as a whole refusing to split.
+
+A row nothing reaches prints a marker in place of a name:
 everything on a listed line that is not a name is written between angle
 brackets, and the printer quotes every value holding one, so a line opening
 with `<` carries no name. A row is one line, so a name carrying a line break

--- a/docs/plans/shuttle/grammar.md
+++ b/docs/plans/shuttle/grammar.md
@@ -210,18 +210,20 @@ redundant cases cost nothing.
 is the canonical parse's own — `validatePieceSegment`
 (`packages/cli/lib/llm-friendly-ref.ts`), called rather than copied, so that a
 name in neither vocabulary is refused with one sentence whichever door read
-it. A reference was already held that way; so are a walk into a piece, a
-target the fabric resolved, and a settled move. `cd slugs/Board` is refused,
-and the reason it gives is the reason `cd /Board` gives. That is what makes a
-listing's job possible: a name printed as an operand is one every door takes,
-and a name no door takes is one nothing prints an operand for.
+it. The doors are the reference, a walk into a piece, a target the fabric
+resolved, and a settled move, which is every way a piece reaches a place:
+`cd slugs/Board` is refused, and the reason it gives is the reason `cd /Board`
+gives. That is what makes a listing's job possible: a name printed as an
+operand is one every door takes, and a name no door takes is one nothing
+prints an operand for.
 
 The vocabulary rule still buys no guarantee that every rendering is
-followable, and the two halves cover different names. A piece holding an `@`
-or ending in whitespace is caught by the rendering rules above rather than by
-the vocabulary, `isPieceHandle` being a length rule that takes either; and a
-path segment holding a `#` reaches a place under the readings below and
-renders as a reference the parse then refuses.
+followable, and it and the rendering rules above catch different names. A
+handle-shaped piece holding an `@` or ending in whitespace is caught by the
+rendering rules above rather than by the vocabulary, `isPieceHandle` being a
+length rule that takes either; and a path segment holding a `#` reaches a
+place under the readings below and renders as a reference the parse then
+refuses.
 
 A segment lifted out of a rendering is an operand in its own right, so
 these readings decide it rather than the key it was printed from.
@@ -239,12 +241,11 @@ it governs the head and nothing else.
 
 Those two readings between them leave one key with no spelling at all. A key
 whose *first* character is `#` is a wish target when it is the whole operand,
-and a reference carrying a `#` anywhere is refused as an unknown suffix, so
-neither door reaches it from the piece it sits in — a later segment does, `#`
-being data everywhere but the head, which is a route out of the facet rather
-than out of the piece. That is what the quoting ruling above costs, and a
-listing prints no name for such a row rather than one that means something
-else.
+and a reference carrying a `#` anywhere is refused, so neither door reaches it
+from the piece it sits in. A later segment does — `#` is data everywhere but
+the head — so the key is reachable from the facet above the piece and not from
+the piece itself. That is what the quoting ruling above costs, and a listing
+prints no name for such a row rather than one that means something else.
 
 A container renders without the leading `/` that marks a reference, so a
 space root and a facet cannot be read back as a piece whose slug happens to
@@ -303,13 +304,14 @@ that implied completeness would be false.
 `cd` cannot reach prints no name at all. Most rows print their own name,
 written as a token by the rule above — a slug, a handle and an ordinary key
 each print as themselves. A row whose name's own characters are readings —
-a key called `..`, one holding the separator, one a scope suffix would come
-off — prints the reference that names it instead, which reads none of them
-and unescapes `~1`. A row nothing reaches prints a marker in place of a name:
+a key called `..` or `-`, one holding the separator, one beginning with `@` —
+prints the reference that names it instead, which reads none of them and
+unescapes `~1`. A row nothing reaches prints a marker in place of a name:
 everything on a listed line that is not a name is written between angle
 brackets, and the printer quotes every value holding one, so a line opening
-with `<` carries no name. A row is one line, so a name or a message carrying
-a line break is described rather than written.
+with `<` carries no name. A row is one line, so a name carrying a line break
+is described rather than written, and a message carrying one has it written
+as a space.
 
 Large collections appear everywhere (a space's pieces, an array of
 thousands). `ls` prints one height-fit page — what the terminal shows

--- a/docs/plans/shuttle/grammar.md
+++ b/docs/plans/shuttle/grammar.md
@@ -239,13 +239,18 @@ fragment. And inside a piece `#` is an ordinary character of a data key,
 under the rule above: the wish reading is decided on the whole operand, so
 it governs the head and nothing else.
 
-Those two readings between them leave one key with no spelling at all. A key
-whose *first* character is `#` is a wish target when it is the whole operand,
-and a reference carrying a `#` anywhere is refused, so neither door reaches it
-from the piece it sits in. A later segment does — `#` is data everywhere but
-the head — so the key is reachable from the facet above the piece and not from
-the piece itself. That is what the quoting ruling above costs, and a listing
-prints no name for such a row rather than one that means something else.
+Those two readings between them leave one key with no **direct** spelling. A
+key whose *first* character is `#` is a wish target when it is the whole
+operand, and a reference carrying a `#` anywhere is refused, so neither door
+names it on its own. A multi-segment operand still reaches it, `#` being data
+in every segment but the first: `slugs/board/#key` names it from the space
+root, and `../board/#key` names it from inside the piece — but only where the
+walk's own trail leads back, so the same string is refused from a piece a
+reference named. That is what the quoting ruling above costs, stated exactly:
+the key is reachable, by a route rather than by a name, and by a route that is
+not the same one from every place. A listing prints no name for such a row —
+a row's name is what it is called and not how to get to it — rather than a
+route, or a name that means something else.
 
 A container renders without the leading `/` that marks a reference, so a
 space root and a facet cannot be read back as a piece whose slug happens to

--- a/docs/plans/shuttle/runtime-integration.md
+++ b/docs/plans/shuttle/runtime-integration.md
@@ -211,9 +211,15 @@ running that command's inline action; and **`ls` composes `listSpaceSlugs`
 and `listPieces` (`lib/piece.ts`) with `listCellKeys`
 (`lib/cell-listing.ts`)**, handing each the held connection as
 `deps.loadPieces`. `listSlugsFromCommand` and `listPiecesFromCommand` are
-not that seam: each parses Cliffy options into its config, renders its rows
-to the process's own stdout, and passes the read no connection at all, so a
-caller holding one would open a second.
+not that seam, and not because they refuse a connection: each takes a `deps`
+with its lister and its renderer both injectable, so a caller can substitute
+a lister bound to a held one. It is what is left after that. The default
+lister is called with a config and no `deps`, so threading a connection means
+substituting the lister; the default renderer writes to the process's own
+stdout, so a caller drawing its own screen substitutes that too; and what the
+wrapper then contributes is `parseSpaceOptions` over a Cliffy options object
+and a `--json` flag. Shuttle builds its own `SpaceConfig` and has no such
+object, so nothing of the wrapper is left to call.
 
 ## Prerequisite work in `packages/cli`
 

--- a/docs/plans/shuttle/runtime-integration.md
+++ b/docs/plans/shuttle/runtime-integration.md
@@ -199,16 +199,21 @@ Not every v1 verb lands on a `*FromCommand` action, and which ones do not
 is what decides whether a bare `Deno.exit` in some Cliffy action is
 shuttle's problem. `get`, `set`, `call` and `describe` go through the
 named exports (`getCellValueFromCommand`, `setCellValueFromCommand`,
-`callFromCommand`, `describePieceFromCommand`); `ls` goes through
-`listPiecesFromCommand` and `listSlugsFromCommand`; `wish` through
-`readWish`. The two that do not are composed from the library instead:
+`callFromCommand`, `describePieceFromCommand`); `wish` goes through
+`readWish`. Three are composed from the library instead:
 **`link` calls `linkPieces` (`lib/piece.ts`) directly**, which is the seam
 A2 gave it and which raises `LinkValidationError` as a value, so the
 inline action behind `cf piece link` — exit and all — is not on shuttle's
-path; and **`verbs` composes `listPieceCallables` (`lib/piece.ts`) with
+path; **`verbs` composes `listPieceCallables` (`lib/piece.ts`) with
 the exported `verbListingLines` / `verbListingJson` / `verbListingNotes`
 and `partitionVerbListing`**, rendering the rows itself rather than
-running that command's inline action.
+running that command's inline action; and **`ls` composes `listSpaceSlugs`
+and `listPieces` (`lib/piece.ts`) with `listCellKeys`
+(`lib/cell-listing.ts`)**, handing each the held connection as
+`deps.loadPieces`. `listSlugsFromCommand` and `listPiecesFromCommand` are
+not that seam: each parses Cliffy options into its config, renders its rows
+to the process's own stdout, and passes the read no connection at all, so a
+caller holding one would open a second.
 
 ## Prerequisite work in `packages/cli`
 

--- a/packages/cli/lib/llm-friendly-ref.ts
+++ b/packages/cli/lib/llm-friendly-ref.ts
@@ -141,8 +141,10 @@ export function namesResolvedParts(ref: NormalizedLLMFriendlyRef): boolean {
  * slug may not, so the segment says which it is before either is checked. A
  * segment that is neither is reported as neither, rather than as a failure of
  * whichever check happened to run last.
+ *
+ * @throws ValidationError when the segment is in neither vocabulary.
  */
-function validatePieceSegment(pieceId: string): void {
+export function validatePieceSegment(pieceId: string): void {
   if (isSlugAddress(pieceId)) {
     if (!isValidSlug(pieceId)) {
       throw new ValidationError(

--- a/packages/shuttle/src/line.ts
+++ b/packages/shuttle/src/line.ts
@@ -38,9 +38,11 @@
  *
  * The characters an operand writes an address with are not here, the `:` of a
  * scheme and of a handle among them. Those are read inside a token by the
- * reference grammar rather than by the split, and which of them a printed
- * value has to carry is the question `ls` settles
- * (`docs/plans/shuttle/build-sequence.md`).
+ * reference grammar rather than by the split, and a quote reaches no reading
+ * (`docs/plans/shuttle/grammar.md`), so quoting them would change nothing a
+ * reading does and would cost the bare printing of every address. A value
+ * whose own characters a reading would take is named by a reference instead,
+ * which reads none of them.
  */
 export const RESERVED_CHARACTERS = "!#%<>|";
 

--- a/packages/shuttle/src/listing.ts
+++ b/packages/shuttle/src/listing.ts
@@ -134,7 +134,8 @@ export async function listPlace(
  * A row is one line, and lines are separated by a newline, so nothing written
  * on a line may put one inside it: a message and a bound each have their
  * newlines written as spaces, and a name carrying one is described rather than
- * written. Every other control character is written as it stands. Rewriting
+ * written. That is the only rewrite there is, so every other control
+ * character is written as it stands. Rewriting
  * one inside a name would leave a token `cd` no longer takes back to the row,
  * which is the guarantee the name is printed for, so what a terminal makes of
  * it is not something this can spend that on.
@@ -236,7 +237,8 @@ function lineFor(row: ListingRow): string {
  *
  * It says no operand rather than that nothing reaches the row, which is the
  * wider claim and a false one: a key whose first character is `#` is reached
- * by a multi-segment operand, `#` being data in every segment but the first.
+ * by a multi-segment operand, `#` being data in a segment that names a data
+ * key.
  * What holds of every row this is written for is that neither the name nor the
  * reference names it, and a name is what a listing prints. The name is shown
  * as it is written and not as something to type — it sits inside a marker,

--- a/packages/shuttle/src/listing.ts
+++ b/packages/shuttle/src/listing.ts
@@ -1,0 +1,247 @@
+/**
+ * What `ls` finds where shuttle stands, and how each row is written back.
+ *
+ * A listing is the first surface that prints a name a person then types, so a
+ * row carries the operand `cd` takes to reach it and not only the name it goes
+ * by. The two are the same string for nearly every row and differ wherever a
+ * name's own characters are readings — a key called `..`, one holding the
+ * separator — which is a question about the place rather than about the
+ * listing, so `operandForChild` answers it and this module asks.
+ *
+ * The reads are `packages/cli`'s, over the connection this process holds: a
+ * space root has nothing to read, the two facets are `listSpaceSlugs` and
+ * `listPieces`, and the keys inside a piece are `listCellKeys`. Each takes the
+ * connection through `deps.loadPieces`, and each raises what it cannot read
+ * rather than listing empty, so a listing that comes back is one that
+ * happened.
+ */
+
+import { listCellKeys } from "@commonfabric/cli/lib/cell-listing";
+import {
+  listPieces,
+  listSpaceSlugs,
+  type PieceConfig,
+  type SpaceConfig,
+} from "@commonfabric/cli/lib/piece";
+
+import type { HeldConnection } from "./connection.ts";
+import { quoteToken } from "./line.ts";
+import {
+  type Facet,
+  FACETS,
+  operandForChild,
+  type PiecePosition,
+  type Place,
+} from "./place.ts";
+
+/**
+ * What a listing of `slugs/` is a listing of. `listSlugs`
+ * (`@commonfabric/piece`) is where that bound is stated and where the reason
+ * for it lives; what this carries is the part a reader of the listing needs,
+ * which is that the rows are not every name the space answers to.
+ */
+const SLUG_INDEX_BOUND = "the space's slug index names these, and a slug it " +
+  "never recorded still resolves";
+
+/** One thing a listing found standing where it was read. */
+export interface ListingRow {
+  /** What the row is called where it stands. */
+  readonly name: string;
+
+  /**
+   * The operand `cd` takes to reach it, written as a token, and absent where
+   * no operand reaches it.
+   */
+  readonly operand?: string;
+
+  /** What the read said is wrong with what the name points at. */
+  readonly error?: string;
+}
+
+/** What `ls` found at a place. */
+export interface Listing {
+  /** The rows, in the order the read listed them. */
+  readonly rows: readonly ListingRow[];
+
+  /**
+   * What the rows are, where they are not everything standing there. A
+   * listing that said nothing would be read as complete.
+   */
+  readonly bound?: string;
+}
+
+/**
+ * The reads a listing is made of, each `packages/cli`'s own. A caller supplies
+ * its own to drive this module with nothing behind it.
+ */
+export interface ListingDeps {
+  /** Lists the slugs the space's index records. */
+  readonly listSpaceSlugs?: typeof listSpaceSlugs;
+
+  /** Lists the space's pieces. */
+  readonly listPieces?: typeof listPieces;
+
+  /** Lists the keys directly under a piece's cell path. */
+  readonly listCellKeys?: typeof listCellKeys;
+}
+
+/**
+ * What `ls` finds at `place`, read over `connection` with `config` saying what
+ * to connect as.
+ *
+ * A row that failed on its own account is still a row: a name the space has
+ * and nothing resolves is a name the space has, so it comes back carrying what
+ * went wrong rather than being dropped or taking the listing down with it. A
+ * read that failed outright is no listing, and raises.
+ *
+ * @throws Whatever the read throws — an unreachable server, an identity that
+ * will not load, a path the piece refuses.
+ */
+export async function listPlace(
+  config: SpaceConfig,
+  place: Place,
+  connection: HeldConnection,
+  deps: ListingDeps = {},
+): Promise<Listing> {
+  const position = place.position;
+  switch (position.kind) {
+    case "root":
+      return { rows: FACETS.map((facet) => rowFor(place, facet)) };
+    case "facet":
+      return await listFacet(config, place, position.facet, connection, deps);
+    case "piece":
+      return await listKeys(config, place, position, connection, deps);
+  }
+}
+
+/**
+ * What `ls` prints for `listing`: one line per row, and one more for a bound.
+ *
+ * A name is the first thing on its line and is written as a token, so what a
+ * reader copies off the front of a line is what `cd` takes. Everything else on
+ * a line is written between angle brackets — the row no operand reaches, a
+ * row's error, and the bound — and the printer quotes every value holding an
+ * angle bracket, so a line opening with `<` carries no name.
+ *
+ * A row is one line, and lines are separated by a newline, so neither a name
+ * nor a message may put one inside a row: a message carrying newlines has them
+ * written as spaces, and a name carrying one is described rather than written.
+ * What a terminal makes of the other control characters is outside that,
+ * exactly as it is for the rendering of a place.
+ */
+export function renderListing(listing: Listing): string {
+  const lines = listing.rows.map(lineFor);
+  if (listing.bound !== undefined) lines.push(marker(listing.bound));
+  return lines.join("\n");
+}
+
+/**
+ * Helper for {@link listPlace}, which is what `facet` lists at `place`.
+ *
+ * The two facets read different things and are written out one arm each rather
+ * than chosen from a table, so that a facet added to {@link FACETS} fails to
+ * compile here instead of silently taking the other one's read.
+ */
+async function listFacet(
+  config: SpaceConfig,
+  place: Place,
+  facet: Facet,
+  connection: HeldConnection,
+  deps: ListingDeps,
+): Promise<Listing> {
+  const loadPieces = () => connection.pieces();
+  switch (facet) {
+    case "slugs": {
+      const slugs = await (deps.listSpaceSlugs ?? listSpaceSlugs)(config, {
+        loadPieces,
+      });
+      return {
+        rows: slugs.map((row) => rowFor(place, row.slug, row.error)),
+        bound: SLUG_INDEX_BOUND,
+      };
+    }
+    case "pieces": {
+      const pieces = await (deps.listPieces ?? listPieces)(config, {
+        loadPieces,
+      });
+      return { rows: pieces.map((row) => rowFor(place, row.id, row.error)) };
+    }
+  }
+}
+
+/**
+ * Helper for {@link listPlace}, which is what the cell `position` names lists
+ * at `place`.
+ *
+ * The piece, the path and the scope all ride the config, which is what makes a
+ * slug typed back from a listing reach its piece: the read resolves the piece
+ * the way `--cell` does. An empty listing means the path names a leaf, and
+ * nothing here can tell that from an empty container, so nothing here says
+ * which it was.
+ */
+async function listKeys(
+  config: SpaceConfig,
+  place: Place,
+  position: PiecePosition,
+  connection: HeldConnection,
+  deps: ListingDeps,
+): Promise<Listing> {
+  const pieceConfig: PieceConfig = {
+    ...config,
+    piece: position.piece,
+    pieceScope: place.scope,
+    piecePath: [...position.path],
+  };
+  const keys = await (deps.listCellKeys ?? listCellKeys)(pieceConfig, "", {}, {
+    loadPieces: () => connection.pieces(),
+  });
+  return { rows: keys.map((key) => rowFor(place, key)) };
+}
+
+/**
+ * Helper for {@link listPlace}, which is the row `name` stands as at `place`,
+ * carrying `error` where the read reported one against it.
+ */
+function rowFor(place: Place, name: string, error?: string): ListingRow {
+  const operand = operandForChild(place, name);
+  return {
+    name,
+    ...(operand === undefined ? {} : { operand: quoteToken(operand) }),
+    ...(error === undefined ? {} : { error }),
+  };
+}
+
+/** Helper for {@link renderListing}, which is the line `row` prints as. */
+function lineFor(row: ListingRow): string {
+  const head = row.operand ?? marker(unreachable(row.name));
+  return row.error === undefined
+    ? head
+    : `${head} ${marker(`error: ${oneLine(row.error)}`)}`;
+}
+
+/**
+ * Helper for {@link renderListing}, which says that no operand reaches a row
+ * called `name`, naming it where a line has room for it.
+ *
+ * A name holding a newline is described rather than written, because a row is
+ * one line. Nothing a reader could have used is lost: such a name is one no
+ * operand reaches, so there was nothing to copy either way.
+ */
+function unreachable(name: string): string {
+  return name.includes("\n")
+    ? "no operand reaches this row, whose name holds a line break"
+    : `no operand reaches ${quoteToken(name)}`;
+}
+
+/** Helper for {@link renderListing}, which writes `text` as a marker. */
+function marker(text: string): string {
+  return `<${text}>`;
+}
+
+/**
+ * Helper for {@link renderListing}, which is `text` with each newline written
+ * as a space, so that it takes one line.
+ */
+function oneLine(text: string): string {
+  return text.replaceAll("\n", " ");
+}

--- a/packages/shuttle/src/listing.ts
+++ b/packages/shuttle/src/listing.ts
@@ -1,19 +1,18 @@
 /**
  * What `ls` finds where shuttle stands, and how each row is written back.
  *
- * A listing is the first surface that prints a name a person then types, so a
- * row carries the operand `cd` takes to reach it and not only the name it goes
- * by. The two are the same string for nearly every row and differ wherever a
- * name's own characters are readings — a key called `..`, one holding the
- * separator — which is a question about the place rather than about the
- * listing, so `operandForChild` answers it and this module asks.
+ * A listing prints names a person then types, so a row carries the operand
+ * `cd` takes to reach it and not only the name it goes by. The two are the
+ * same string for nearly every row and differ wherever a name's own characters
+ * are readings — a key called `..`, one holding the separator — which is a
+ * question about the place rather than about the listing, so
+ * `operandForChild` answers it and this module asks.
  *
  * The reads are `packages/cli`'s, over the connection this process holds: a
  * space root has nothing to read, the two facets are `listSpaceSlugs` and
  * `listPieces`, and the keys inside a piece are `listCellKeys`. Each takes the
- * connection through `deps.loadPieces`, and each raises what it cannot read
- * rather than listing empty, so a listing that comes back is one that
- * happened.
+ * connection through `deps.loadPieces`, which is the seam a held connection
+ * fills.
  */
 
 import { listCellKeys } from "@commonfabric/cli/lib/cell-listing";
@@ -89,10 +88,10 @@ export interface ListingDeps {
  * What `ls` finds at `place`, read over `connection` with `config` saying what
  * to connect as.
  *
- * A row that failed on its own account is still a row: a name the space has
- * and nothing resolves is a name the space has, so it comes back carrying what
- * went wrong rather than being dropped or taking the listing down with it. A
- * read that failed outright is no listing, and raises.
+ * A row the read reported a failure against is still a row: a name the space
+ * has and nothing resolves is a name the space has, so it comes back carrying
+ * what went wrong rather than being dropped, and it never takes the listing
+ * down with it. A read that failed outright is no listing, and raises.
  *
  * @throws Whatever the read throws — an unreachable server, an identity that
  * will not load, a path the piece refuses.
@@ -126,8 +125,10 @@ export async function listPlace(
  * A row is one line, and lines are separated by a newline, so neither a name
  * nor a message may put one inside a row: a message carrying newlines has them
  * written as spaces, and a name carrying one is described rather than written.
- * What a terminal makes of the other control characters is outside that,
- * exactly as it is for the rendering of a place.
+ * Every other control character is written as it stands. Rewriting one inside
+ * a name would leave a token `cd` no longer takes back to the row, which is
+ * the guarantee the name is printed for, so what a terminal makes of it is not
+ * something this can spend that on.
  */
 export function renderListing(listing: Listing): string {
   const lines = listing.rows.map(lineFor);
@@ -173,11 +174,12 @@ async function listFacet(
  * Helper for {@link listPlace}, which is what the cell `position` names lists
  * at `place`.
  *
- * The piece, the path and the scope all ride the config, which is what makes a
- * slug typed back from a listing reach its piece: the read resolves the piece
- * the way `--cell` does. An empty listing means the path names a leaf, and
- * nothing here can tell that from an empty container, so nothing here says
- * which it was.
+ * The piece, the path and the scope all ride the config. A place stands on the
+ * piece as an operand named it, a slug included, so what makes a slug typed
+ * back off a listing reach its piece is the read's own resolution step
+ * (`PieceResolutionDeps.resolvePieceAddress`). An empty listing means the path
+ * names a leaf, and nothing here can tell that from an empty container, so
+ * nothing here says which it was.
  */
 async function listKeys(
   config: SpaceConfig,

--- a/packages/shuttle/src/listing.ts
+++ b/packages/shuttle/src/listing.ts
@@ -117,22 +117,29 @@ export async function listPlace(
  * What `ls` prints for `listing`: one line per row, and one more for a bound.
  *
  * A name is the first thing on its line and is written as a token, so what a
- * reader copies off the front of a line is what `cd` takes. Everything else on
- * a line is written between angle brackets — the row no operand reaches, a
- * row's error, and the bound — and the printer quotes every value holding an
- * angle bracket, so a line opening with `<` carries no name.
+ * reader copies off the front of a line is what `cd` takes. A line that opens
+ * with `<` carries no name — and `quoteToken` is what holds that, not anything
+ * here: `<` is one of the characters the grammar reserves, so a name holding
+ * one is printed quoted and a printed name never opens with it.
  *
- * A row is one line, and lines are separated by a newline, so neither a name
- * nor a message may put one inside a row: a message carrying newlines has them
- * written as spaces, and a name carrying one is described rather than written.
- * Every other control character is written as it stands. Rewriting one inside
- * a name would leave a token `cd` no longer takes back to the row, which is
- * the guarantee the name is printed for, so what a terminal makes of it is not
- * something this can spend that on.
+ * Everything else on a line — the row no operand reaches, a row's error, and
+ * the bound — is written between angle brackets. Those brackets delimit for a
+ * reader and not for a parser: a payload may hold an angle bracket of its own
+ * and nothing escapes it. Nothing parses a listed line, and a form that could
+ * be parsed is a second output form rather than a rule for this one
+ * (`docs/plans/shuttle/futures.md`).
+ *
+ * A row is one line, and lines are separated by a newline, so nothing written
+ * on a line may put one inside it: a message and a bound each have their
+ * newlines written as spaces, and a name carrying one is described rather than
+ * written. Every other control character is written as it stands. Rewriting
+ * one inside a name would leave a token `cd` no longer takes back to the row,
+ * which is the guarantee the name is printed for, so what a terminal makes of
+ * it is not something this can spend that on.
  */
 export function renderListing(listing: Listing): string {
   const lines = listing.rows.map(lineFor);
-  if (listing.bound !== undefined) lines.push(marker(listing.bound));
+  if (listing.bound !== undefined) lines.push(marker(oneLine(listing.bound)));
   return lines.join("\n");
 }
 
@@ -242,7 +249,11 @@ function marker(text: string): string {
 
 /**
  * Helper for {@link renderListing}, which is `text` with each newline written
- * as a space, so that it takes one line.
+ * as a space, so that what is written on a line takes one line. The payloads
+ * that are a caller's own text go through it, the bound as much as an error —
+ * the two agreeing is what keeps "a row is one line" a rule rather than a
+ * habit of one of them. The marker for a row nothing reaches builds its own
+ * text and answers a break by describing the name instead of writing it.
  */
 function oneLine(text: string): string {
   return text.replaceAll("\n", " ");

--- a/packages/shuttle/src/listing.ts
+++ b/packages/shuttle/src/listing.ts
@@ -49,7 +49,9 @@ export interface ListingRow {
 
   /**
    * The operand `cd` takes to reach it, written as a token, and absent where
-   * no operand reaches it.
+   * `operandForChild` offers none. Absent is the narrower claim it makes:
+   * that neither the name nor the reference names the row, not that nothing
+   * reaches it.
    */
   readonly operand?: string;
 
@@ -122,8 +124,8 @@ export async function listPlace(
  * here: `<` is one of the characters the grammar reserves, so a name holding
  * one is printed quoted and a printed name never opens with it.
  *
- * Everything else on a line — the row no operand reaches, a row's error, and
- * the bound — is written between angle brackets. Those brackets delimit for a
+ * Everything else on a line — the row with no operand, a row's error, and the
+ * bound — is written between angle brackets. Those brackets delimit for a
  * reader and not for a parser: a payload may hold an angle bracket of its own
  * and nothing escapes it. Nothing parses a listed line, and a form that could
  * be parsed is a second output form rather than a rule for this one
@@ -222,24 +224,33 @@ function rowFor(place: Place, name: string, error?: string): ListingRow {
 
 /** Helper for {@link renderListing}, which is the line `row` prints as. */
 function lineFor(row: ListingRow): string {
-  const head = row.operand ?? marker(unreachable(row.name));
+  const head = row.operand ?? marker(noOperandFor(row.name));
   return row.error === undefined
     ? head
     : `${head} ${marker(`error: ${oneLine(row.error)}`)}`;
 }
 
 /**
- * Helper for {@link renderListing}, which says that no operand reaches a row
- * called `name`, naming it where a line has room for it.
+ * Helper for {@link renderListing}, which says that a row called `name` has no
+ * operand, showing the name where a line has room for it.
  *
- * A name holding a newline is described rather than written, because a row is
- * one line. Nothing a reader could have used is lost: such a name is one no
- * operand reaches, so there was nothing to copy either way.
+ * It says no operand rather than that nothing reaches the row, which is the
+ * wider claim and a false one: a key whose first character is `#` is reached
+ * by a multi-segment operand, `#` being data in every segment but the first.
+ * What holds of every row this is written for is that neither the name nor the
+ * reference names it, and a name is what a listing prints. The name is shown
+ * as it is written and not as something to type — it sits inside a marker,
+ * which by the rule above carries no name.
+ *
+ * A name holding a newline is described rather than shown, because a row is
+ * one line. That row is also one nothing reaches at all, a segment holding a
+ * break being refused at every door, so what the description withholds is a
+ * string no operand would have carried anyway.
  */
-function unreachable(name: string): string {
+function noOperandFor(name: string): string {
   return name.includes("\n")
-    ? "no operand reaches this row, whose name holds a line break"
-    : `no operand reaches ${quoteToken(name)}`;
+    ? "no operand: a name holding a line break"
+    : `no operand: ${quoteToken(name)}`;
 }
 
 /** Helper for {@link renderListing}, which writes `text` as a marker. */
@@ -252,8 +263,8 @@ function marker(text: string): string {
  * as a space, so that what is written on a line takes one line. The payloads
  * that are a caller's own text go through it, the bound as much as an error —
  * the two agreeing is what keeps "a row is one line" a rule rather than a
- * habit of one of them. The marker for a row nothing reaches builds its own
- * text and answers a break by describing the name instead of writing it.
+ * habit of one of them. The marker for a row with no operand builds its own
+ * text and answers a break by describing the name instead of showing it.
  */
 function oneLine(text: string): string {
   return text.replaceAll("\n", " ");

--- a/packages/shuttle/src/place.ts
+++ b/packages/shuttle/src/place.ts
@@ -883,6 +883,21 @@ function unnameableSegment(segment: PathSegment): Fault | undefined {
 }
 
 /**
+ * The characters the reference grammar reads inside an id segment: the `@` a
+ * scope suffix rides on (`parseScopedIdSegment`), and the `#` an argument
+ * suffix does (`splitArgumentSuffix`). Neither vocabulary holds one — a slug
+ * is lowercase letters, numbers and hyphens, and a handle is base64url — but
+ * `isPieceHandle` is a length rule rather than an alphabet one, so a long
+ * enough piece carries either past the vocabulary check.
+ *
+ * The separator and the escape are deliberately not here. A rendering escapes
+ * both, `/` becoming `~1` and `~` becoming `~0`, so a piece holding one is
+ * read back whole; refusing it would be an alphabet this module does not own,
+ * against a canonical check that owns one and declines to apply it.
+ */
+const READ_INSIDE_AN_ID = ["@", "#"];
+
+/**
  * Helper for the movers, which names what stops a piece from being one a place
  * may stand on, and returns nothing when nothing does.
  *
@@ -899,7 +914,11 @@ function unnameableSegment(segment: PathSegment): Fault | undefined {
  * {@link outsideVocabulary} runs after this door and refuses an empty piece
  * and every colon-less name that is no slug on its own account. What this door
  * adds is the handle-shaped piece: `isPieceHandle` is a length rule, so a
- * trailing space and an `@` both ride past it and are refused here.
+ * trailing space and either of {@link READ_INSIDE_AN_ID} ride past it and are
+ * refused here. Other characters no vocabulary holds ride past it too — a `.`
+ * or an escaped separator — and are admitted, their renderings reading back
+ * whole; what is refused here is what a rendering would lose or a reading
+ * would take.
  */
 function unnameablePiece(piece: string): Fault | undefined {
   if (piece.includes("\n")) {
@@ -909,8 +928,10 @@ function unnameablePiece(piece: string): Fault | undefined {
   if (piece !== piece.trimEnd()) {
     return { what: "a piece ending in whitespace", so: NO_SUCH_NAME };
   }
-  if (piece.includes("@")) {
-    return { what: "a piece holding `@`", so: NO_SUCH_NAME };
+  for (const character of READ_INSIDE_AN_ID) {
+    if (piece.includes(character)) {
+      return { what: `a piece holding \`${character}\``, so: NO_SUCH_NAME };
+    }
   }
   return undefined;
 }

--- a/packages/shuttle/src/place.ts
+++ b/packages/shuttle/src/place.ts
@@ -15,6 +15,7 @@ import type { CellScope } from "@commonfabric/api";
 import {
   type NormalizedLLMFriendlyRef,
   normalizeLLMFriendlyRef,
+  validatePieceSegment,
 } from "@commonfabric/cli/lib/llm-friendly-ref";
 import type { MemorySpace } from "@commonfabric/memory/interface";
 import {
@@ -183,13 +184,12 @@ export function placeAtSpaceRoot(space: MemorySpace): Place {
  * facet are containers and render without one, which is what keeps a
  * container's own rendering from resolving as a piece whose slug happens to
  * match. What holds of a rendering is one property and not a list: `cd` may
- * refuse it, but it never reads one as some other cell. Several things reach
- * the first half — a `#` anywhere, which the reference grammar reserves, and
- * a piece outside the slug and handle vocabularies — and enumerating them
- * here would be a claim that goes stale as the vocabularies move. A piece or
- * segment holding a newline would reach the second half, by splitting the
- * position line into a shorter reference, which is why one is refused before
- * it can reach a place rather than handled here.
+ * refuse it, but it never reads one as some other cell. A `#` reaches the
+ * first half wherever it sits, the reference grammar reserving that character
+ * for the `#argument` suffix. A piece or segment holding a newline would reach
+ * the second half, by splitting the position line into a shorter reference,
+ * which is why one is refused before it can reach a place rather than handled
+ * here.
  *
  * The scope is written on the piece even when it is the base, which is what
  * makes "read from anywhere" true rather than nearly so. Scope is part of a
@@ -291,6 +291,8 @@ export class CurrentPlace {
           `so ${fault.so}.`,
       ));
     }
+    const outside = outsideVocabulary(move.piece);
+    if (outside !== undefined) return this.#commit(outside);
     return this.#commit(land({
       position: {
         kind: "piece",
@@ -612,6 +614,8 @@ function moveIntoPiece(
   }
   const fault = unnameablePiece(scoped.id);
   if (fault !== undefined) return refuseUnnameable(operand, fault);
+  const outside = outsideVocabulary(scoped.id);
+  if (outside !== undefined) return outside;
   return land({
     position: {
       kind: "piece",
@@ -657,6 +661,8 @@ function enterTarget(
         `${badSegment.so}.`,
     );
   }
+  const outside = outsideVocabulary(target.piece);
+  if (outside !== undefined) return outside;
   return land({
     ...place,
     position: {
@@ -785,12 +791,12 @@ function unnameableSegment(segment: PathSegment): Fault | undefined {
  * segment is the suffix and nothing else, so the split finds no id in front of
  * it and the parse refuses the whole reference.
  *
- * The rules that are not the newline answer to {@link NO_SUCH_NAME}
- * instead, which is a
- * weaker claim than the segment rules make and the honest one. This door is
- * the only check for a handle-shaped piece; for an empty one and for anything
- * slug-shaped the parse refuses already, so refusing here moves the refusal
- * earlier and names the vocabulary where the parse names only the failure.
+ * The rules that are not the newline answer to {@link NO_SUCH_NAME} instead,
+ * which is a weaker claim than the segment rules make and the honest one.
+ * {@link outsideVocabulary} runs after this door and refuses an empty piece
+ * and every colon-less name that is no slug on its own account. What this door
+ * adds is the handle-shaped piece: `isPieceHandle` is a length rule, so a
+ * trailing space and an `@` both ride past it and are refused here.
  */
 function unnameablePiece(piece: string): Fault | undefined {
   if (piece.includes("\n")) {
@@ -823,6 +829,28 @@ function firstUnnameableSegment(
  */
 function refuseUnnameable(operand: string, fault: Fault): Step {
   return refuse(`\`${operand}\` has ${fault.what}, so ${fault.so}.`);
+}
+
+/**
+ * Helper for the movers, which refuses `piece` where it is in neither
+ * vocabulary a piece is named by, and returns nothing where it is in one of
+ * them. Every door runs it after its own rendering rules, so a part no
+ * rendering names back is reported as that rather than as a name outside a
+ * vocabulary.
+ *
+ * The rule is `validatePieceSegment`'s
+ * (`packages/cli/lib/llm-friendly-ref.ts`), called rather than copied, so that
+ * a piece any door admits is one a reference could have named and one name
+ * gets one reason whichever door refused it. Its sentence reaches the reader
+ * unaltered.
+ */
+function outsideVocabulary(piece: string): Step | undefined {
+  try {
+    validatePieceSegment(piece);
+  } catch (error) {
+    return refuse(messageOf(error));
+  }
+  return undefined;
 }
 
 /** Helper for the movers, which builds a refusal carrying `reason`. */

--- a/packages/shuttle/src/place.ts
+++ b/packages/shuttle/src/place.ts
@@ -180,11 +180,11 @@ export function placeAtSpaceRoot(space: MemorySpace): Place {
  * `child`, and nothing where no operand reaches that child.
  *
  * Two spellings are offered, the shorter first. The name on its own is what
- * `cd` takes wherever none of the name's own characters is a reading; where
- * one is — a key called `..`, one holding the separator, a name a scope suffix
- * would come off — the reference the child renders as reads none of them and
- * reaches it anyway. A child no rendering names back has neither, and that is
- * what the absent answer means.
+ * `cd` takes wherever `cd` reads that name as data. Where one of the readings
+ * above takes it instead, the reference the child renders as reaches it
+ * anyway: a reference reads none of them, and it escapes the separator where a
+ * relative operand cannot. A child no rendering names back has neither
+ * spelling, and that is what an absent answer means.
  *
  * Each spelling is answered by making the move rather than by a second copy of
  * the readings, so what comes back is an operand `cd` took. The move is made
@@ -939,9 +939,9 @@ function refuseUnnameable(operand: string, fault: Fault): Step {
  *
  * The rule is `validatePieceSegment`'s
  * (`packages/cli/lib/llm-friendly-ref.ts`), called rather than copied, so that
- * a piece any door admits is one a reference could have named and one name
- * gets one reason whichever door refused it. Its sentence reaches the reader
- * unaltered.
+ * a piece is held to the same two vocabularies whichever door admits it and
+ * one name gets one reason whichever door refused it. Its sentence reaches the
+ * reader unaltered.
  */
 function outsideVocabulary(piece: string): Step | undefined {
   try {

--- a/packages/shuttle/src/place.ts
+++ b/packages/shuttle/src/place.ts
@@ -184,14 +184,11 @@ export function placeAtSpaceRoot(space: MemorySpace): Place {
  * above takes it instead, the reference the child renders as reaches it
  * anyway: a reference reads none of them, and it escapes the separator where a
  * relative operand cannot. An absent answer means neither of these reaches
- * the child, which is narrower than nothing reaching it: a multi-segment
+ * the child, which is narrower than nothing reaching it: some multi-segment
  * operand can reach one that neither does, since a walk splits on the
- * separator and reads a head reading only on the whole operand, so `#` is data
- * in every segment but the first. None is looked for. Such an operand is a
- * route rather than a name, and a route through `..` reads the trail, so it
- * would reach the child from a place reached one way and not from a place
- * reached another — which is the guarantee below, read as a rule about what
- * may be offered rather than only about `-`.
+ * separator and reads a head reading only on the whole operand. None is looked
+ * for, and which would work is not a question this answers — what it returns
+ * is a name for the child, and a route is not one.
  *
  * Each spelling is answered by making the move rather than by a second copy of
  * the readings, so what comes back is an operand `cd` took. The move is made

--- a/packages/shuttle/src/place.ts
+++ b/packages/shuttle/src/place.ts
@@ -177,14 +177,21 @@ export function placeAtSpaceRoot(space: MemorySpace): Place {
 
 /**
  * The operand `cd` takes from `place` to the child of its position called
- * `child`, and nothing where no operand reaches that child.
+ * `child`, and nothing where neither spelling it offers reaches that child.
  *
  * Two spellings are offered, the shorter first. The name on its own is what
  * `cd` takes wherever `cd` reads that name as data. Where one of the readings
  * above takes it instead, the reference the child renders as reaches it
  * anyway: a reference reads none of them, and it escapes the separator where a
- * relative operand cannot. A child no rendering names back has neither
- * spelling, and that is what an absent answer means.
+ * relative operand cannot. An absent answer means neither of these reaches
+ * the child, which is narrower than nothing reaching it: a multi-segment
+ * operand can reach one that neither does, since a walk splits on the
+ * separator and reads a head reading only on the whole operand, so `#` is data
+ * in every segment but the first. None is looked for. Such an operand is a
+ * route rather than a name, and a route through `..` reads the trail, so it
+ * would reach the child from a place reached one way and not from a place
+ * reached another — which is the guarantee below, read as a rule about what
+ * may be offered rather than only about `-`.
  *
  * Each spelling is answered by making the move rather than by a second copy of
  * the readings, so what comes back is an operand `cd` took. The move is made

--- a/packages/shuttle/src/place.ts
+++ b/packages/shuttle/src/place.ts
@@ -7,8 +7,9 @@
  * nothing read. The address grammar belongs to the fabric
  * (`normalizeLLMFriendlyRef` over the runner's `parseReferenceParts`) and this
  * module consumes it; what it adds is the navigation spellings that grammar
- * has no room for — `..`, `-`, `/`, and a scope-only `@scope` — and the
- * refusals a place is subject to.
+ * has no room for — `..`, `-`, `/`, and a scope-only `@scope` — the refusals a
+ * place is subject to, and the operand that reaches a child, which is those
+ * same readings asked in the other direction.
  */
 
 import type { CellScope } from "@commonfabric/api";
@@ -172,6 +173,41 @@ export interface ResolvedTarget {
 /** The place a shuttle starts in: the space's root, read at the base scope. */
 export function placeAtSpaceRoot(space: MemorySpace): Place {
   return { position: { kind: "root", space }, scope: "space" };
+}
+
+/**
+ * The operand `cd` takes from `place` to the child of its position called
+ * `child`, and nothing where no operand reaches that child.
+ *
+ * Two spellings are offered, the shorter first. The name on its own is what
+ * `cd` takes wherever none of the name's own characters is a reading; where
+ * one is — a key called `..`, one holding the separator, a name a scope suffix
+ * would come off — the reference the child renders as reads none of them and
+ * reaches it anyway. A child no rendering names back has neither, and that is
+ * what the absent answer means.
+ *
+ * Each spelling is answered by making the move rather than by a second copy of
+ * the readings, so what comes back is an operand `cd` took. The move is made
+ * from a standing with no trail and no previous place, which bounds the answer
+ * in one direction only: `-` is never offered, even where shuttle's own
+ * history would make it reach the child, and what is offered reaches the child
+ * whatever that history holds.
+ */
+export function operandForChild(
+  place: Place,
+  child: string,
+): string | undefined {
+  const position = childPosition(place.position, child);
+  if (position === undefined) return undefined;
+  const goal: Place = { ...place, position };
+  const from: Standing = { place, trail: [] };
+  for (const candidate of [child, renderPosition(goal)]) {
+    const step = movePlace(from, candidate);
+    if (step.kind === "moved" && samePlace(step.to.place, goal)) {
+      return candidate;
+    }
+  }
+  return undefined;
 }
 
 /**
@@ -677,6 +713,64 @@ function enterTarget(
 /** Whether `segment` names one of the facets a space root lists. */
 function isFacet(segment: string): segment is Facet {
   return (FACETS as readonly string[]).includes(segment);
+}
+
+/**
+ * Helper for {@link operandForChild}, which is the position one level inside
+ * `position` called `child`, and nothing where that level has no child of
+ * that name.
+ *
+ * A root's children are its facets and are a closed set, so a name outside it
+ * denotes nothing. A facet's and a piece's are whatever the space holds, so
+ * this builds the position and leaves whether an operand reaches it to the
+ * move that tries one.
+ */
+function childPosition(
+  position: Position,
+  child: string,
+): Position | undefined {
+  switch (position.kind) {
+    case "root":
+      return isFacet(child)
+        ? { kind: "facet", space: position.space, facet: child }
+        : undefined;
+    case "facet":
+      return { kind: "piece", space: position.space, piece: child, path: [] };
+    case "piece":
+      return {
+        ...position,
+        path: [...position.path, linkPathSegmentToCellPathSegment(child)],
+      };
+  }
+}
+
+/**
+ * Helper for {@link operandForChild}, which is whether two places are the same
+ * place: both halves of the pair, since a scope is half of what a place is and
+ * two scopes select two cells at one position.
+ */
+function samePlace(one: Place, other: Place): boolean {
+  return one.scope === other.scope &&
+    samePosition(one.position, other.position);
+}
+
+/**
+ * Helper for {@link samePlace}, which is whether two positions are the same
+ * cell. It is {@link Position}'s own promise read as a comparison: the levels
+ * a position names and nothing about how either was reached.
+ */
+function samePosition(one: Position, other: Position): boolean {
+  if (one.space !== other.space) return false;
+  switch (one.kind) {
+    case "root":
+      return other.kind === "root";
+    case "facet":
+      return other.kind === "facet" && one.facet === other.facet;
+    case "piece":
+      return other.kind === "piece" && one.piece === other.piece &&
+        one.path.length === other.path.length &&
+        one.path.every((segment, index) => segment === other.path[index]);
+  }
 }
 
 /**

--- a/packages/shuttle/src/place.ts
+++ b/packages/shuttle/src/place.ts
@@ -755,12 +755,17 @@ function samePlace(one: Place, other: Place): boolean {
 }
 
 /**
- * Helper for {@link samePlace}, which is whether two positions are the same
- * cell. It is {@link Position}'s own promise read as a comparison: the levels
- * a position names and nothing about how either was reached.
+ * Helper for {@link samePlace}, which is whether two positions of one space
+ * are the same cell. It is {@link Position}'s own promise read as a
+ * comparison: the levels a position names and nothing about how either was
+ * reached.
+ *
+ * The space is not among the levels it compares. One connection fixes the
+ * space for a shuttle's whole run and every door refuses a position outside
+ * it, so the pair this is handed carries one space and a comparison of it
+ * could only ever hold.
  */
 function samePosition(one: Position, other: Position): boolean {
-  if (one.space !== other.space) return false;
   switch (one.kind) {
     case "root":
       return other.kind === "root";

--- a/packages/shuttle/test/listing.test.ts
+++ b/packages/shuttle/test/listing.test.ts
@@ -579,15 +579,26 @@ describe("listing", () => {
       let named = 0;
       let unnamed = 0;
       let reported = 0;
+      let reportedWithoutOperand = 0;
 
       /**
        * Helper for this case, which holds the property over one row and the
        * line it printed, `standing` being a place at the row's own level.
        */
       function check(standing: CurrentPlace, row: ListingRow, line: string) {
+        // Everything true of every line goes above the branch. A row's error
+        // is printed whether or not the row has an operand, and this branch
+        // has twice been where a dimension reached one arm and not the other:
+        // the arm that returns early reads whatever someone remembered to add
+        // to it. Asserting the common half first is what stops the next
+        // dimension from landing on one side.
+        expect(/ <error: [^\n]*>$/.test(line)).toBe(row.error !== undefined);
+        if (row.error !== undefined) reported++;
+
         if (row.operand === undefined) {
           expect(line.startsWith("<")).toBe(true);
           unnamed++;
+          if (row.error !== undefined) reportedWithoutOperand++;
           return;
         }
         expect(line.startsWith("<")).toBe(false);
@@ -603,7 +614,6 @@ describe("listing", () => {
         expect(standing.cd(tokens[0]).kind).toBe("moved");
         expect(standing.place).toEqual(childOf(from, row.name));
         named++;
-        if (row.error !== undefined) reported++;
       }
 
       const sources: {
@@ -664,6 +674,7 @@ describe("listing", () => {
       expect(named).toBeGreaterThan(0);
       expect(unnamed).toBeGreaterThan(0);
       expect(reported).toBeGreaterThan(0);
+      expect(reportedWithoutOperand).toBeGreaterThan(0);
     });
   });
 });

--- a/packages/shuttle/test/listing.test.ts
+++ b/packages/shuttle/test/listing.test.ts
@@ -666,11 +666,15 @@ describe("listing", () => {
         }
       }
 
-      // Every outcome has to occur, or the property above holds for want of
-      // anything to hold over. The named row that also carries an error is the
-      // one the count is here for: it is the only shape where the printed line
-      // and the operand are different strings, so a construction that stopped
-      // building one would leave the line assertions above holding trivially.
+      // Every outcome has to occur, or the property holds for want of anything
+      // to hold over. The error clause above the branch is the strong one: it
+      // holds of every line, named or not, so a row that prints an error it
+      // does not carry, or drops one it does, reds it in either arm. What the
+      // counts add is that both arms are reached and that an error reaches
+      // each of them — `named` and `unnamed` for the arms, `reported` for an
+      // error anywhere, and `reportedWithoutOperand` for the combination that
+      // reaches the marker arm, which is the shape this case twice computed
+      // and did not read.
       expect(named).toBeGreaterThan(0);
       expect(unnamed).toBeGreaterThan(0);
       expect(reported).toBeGreaterThan(0);

--- a/packages/shuttle/test/listing.test.ts
+++ b/packages/shuttle/test/listing.test.ts
@@ -1,8 +1,9 @@
 /**
  * Unit tests for what `ls` finds at a place and how it writes each row back.
  *
- * Every read a listing makes is `packages/cli`'s, and every case here stands
- * its own in through the deps bag, so what is under test is the composing —
+ * Every read a listing makes is `packages/cli`'s, and every case that makes
+ * one stands its own in through the deps bag, so what is under test is the
+ * composing —
  * which read a position takes, what a row carries, and how a row prints — with
  * no socket, no server and no piece behind any of it. What those reads do once
  * called is not this file's subject; that a listing hands each of them the
@@ -671,10 +672,10 @@ describe("listing", () => {
       // holds of every line, named or not, so a row that prints an error it
       // does not carry, or drops one it does, reds it in either arm. What the
       // counts add is that both arms are reached and that an error reaches
-      // each of them — `named` and `unnamed` for the arms, `reported` for an
-      // error anywhere, and `reportedWithoutOperand` for the combination that
-      // reaches the marker arm, which is the shape this case twice computed
-      // and did not read.
+      // each — `named` and `unnamed` for the arms, `reported` for an error
+      // anywhere, and one guard per arm for an error inside it, since the
+      // arms are where a row and its error are printed together and the
+      // marker arm is the one this case twice computed and did not read.
       expect(named).toBeGreaterThan(0);
       expect(unnamed).toBeGreaterThan(0);
       expect(reported).toBeGreaterThan(0);

--- a/packages/shuttle/test/listing.test.ts
+++ b/packages/shuttle/test/listing.test.ts
@@ -421,6 +421,18 @@ describe("listing", () => {
       })).toBe("board <error: No piece. board>");
     });
 
+    it("returns a bound's line breaks written as spaces", () => {
+      // Nothing reaches this through `listPlace`, whose only bound is a module
+      // constant holding no break. `Listing` is a public type and this a
+      // public door, so the case drives the door rather than the path, and
+      // what it holds is that a bound answers to the same one-line rule an
+      // error does.
+
+      expect(renderListing({ rows: [], bound: "Two lines.\nboard" })).toBe(
+        "<Two lines. board>",
+      );
+    });
+
     it("returns the bound on a line of its own, after the rows", () => {
       expect(renderListing({
         rows: [{ name: "board", operand: "board" }],
@@ -434,6 +446,14 @@ describe("listing", () => {
     // prints as a name, `cd` takes back to the row it was printed for; and a
     // row `cd` cannot reach prints no name at all, so nothing on the surface
     // invites a reader to type a string that reaches somewhere else.
+    //
+    // A named row's line never opens with `<`, which is what keeps a name and
+    // a marker apart on one surface. `quoteToken` is the whole of that
+    // mechanism and it lives a module away: `<` is one of the characters the
+    // grammar reserves, so a name holding one is printed quoted and can never
+    // open with it. Nothing in this module would notice if that stopped being
+    // true, which is why the assertion is here and the mutation that reds it
+    // is in `line.ts`.
     //
     // The property is over the front of a printed line and not over the whole
     // of it. A row that carries an error prints the name and then a marker, so
@@ -508,18 +528,13 @@ describe("listing", () => {
      * open a second line with a name on it if the renderer wrote it as it
      * stands.
      *
-     * The break is written as an escape, and no gate would have said so had it
-     * been written as the byte. A quoted string holding a real break does not
-     * parse, so it would have had to become a template literal — and there
-     * `check-control-characters` skips the newline outright, the branch that
-     * counts a line running before the one that tests for a codepoint below
-     * `0x20`, so a literal break never reaches that test. The gate's other
-     * blind spot is the opposite one, and `MARKS` above is where this file met
-     * it: a no-break space and the Unicode line and paragraph separators are
-     * above `U+007F`, so every byte of them is at or above `0x80` and none can
-     * be a byte the test sees. Both holes are in the one gate, which is why a
-     * fixture writes an awkward character as an escape on its own account
-     * rather than on the gate's.
+     * The break is written as an escape, and deliberately.
+     * `check-control-characters` governs a literal control codepoint below
+     * `0x20` other than the newline, so a literal break passes it; and the
+     * characters `MARKS` above spells — a no-break space and the Unicode line
+     * and paragraph separators — sit outside that range altogether. An awkward
+     * character in a fixture is written as an escape on its own account rather
+     * than on a gate's.
      */
     const REPORTED = [
       undefined,
@@ -575,6 +590,7 @@ describe("listing", () => {
           unnamed++;
           return;
         }
+        expect(line.startsWith("<")).toBe(false);
         expect(line.startsWith(row.operand)).toBe(true);
         const rest = line.slice(row.operand.length);
         expect(rest === "").toBe(row.error === undefined);

--- a/packages/shuttle/test/listing.test.ts
+++ b/packages/shuttle/test/listing.test.ts
@@ -435,6 +435,15 @@ describe("listing", () => {
     // row `cd` cannot reach prints no name at all, so nothing on the surface
     // invites a reader to type a string that reaches somewhere else.
     //
+    // The property is over the front of a printed line and not over the whole
+    // of it. A row that carries an error prints the name and then a marker, so
+    // the two are one string for some rows and not for others; and an error is
+    // text the fabric wrote, which may hold an odd quote and leave the line as
+    // a whole refusing to split. What holds of every named row is that the
+    // line opens with the name, that the name is one token `cd` takes back to
+    // the row, and that anything after it is separated from it — which is what
+    // "copied off the front" means and all it can mean.
+    //
     // What varies is as load-bearing as the property. Both kinds of row a
     // listing can name vary — the piece a facet lists and the key a piece
     // holds — and each candidate is driven through the read that produces that
@@ -487,6 +496,27 @@ describe("listing", () => {
     }
 
     /**
+     * Helper for the case below, which is what a listing reports against the
+     * candidate at `index`, and nothing where it reports nothing.
+     *
+     * A row carrying one is the only shape where the printed line and the
+     * operand are different strings, so a construction with none of them says
+     * nothing about the rows the naming rule has most to say about. Two of
+     * these are chosen for what they do to a line rather than for what they
+     * say: one holds an odd quote, so the line as a whole does not split and
+     * only its front can be copied, and one holds a line break — written as an
+     * escape, which `deno task check-control-characters` would not have caught
+     * as a literal — which would open a second line, with a name on it, if the
+     * renderer wrote it as it stands.
+     */
+    const REPORTED = [
+      undefined,
+      "No piece carries that name.",
+      "It's gone.",
+      "Two lines.\nboard",
+    ];
+
+    /**
      * Helper for the case below, which is the place one level inside `place`
      * called `name` — the row's own cell, built from the levels a position
      * names rather than from any operand.
@@ -521,6 +551,7 @@ describe("listing", () => {
     it("prints a name `cd` takes back to the row, and no name for a row it cannot reach", async () => {
       let named = 0;
       let unnamed = 0;
+      let reported = 0;
 
       /**
        * Helper for this case, which holds the property over one row and the
@@ -532,6 +563,10 @@ describe("listing", () => {
           unnamed++;
           return;
         }
+        expect(line.startsWith(row.operand)).toBe(true);
+        const rest = line.slice(row.operand.length);
+        expect(rest === "").toBe(row.error === undefined);
+        if (rest !== "") expect(rest.startsWith(" <")).toBe(true);
         const from = standing.place;
         const split = splitLine(row.operand);
         expect(split.kind).toBe("split");
@@ -540,6 +575,7 @@ describe("listing", () => {
         expect(standing.cd(tokens[0]).kind).toBe("moved");
         expect(standing.place).toEqual(childOf(from, row.name));
         named++;
+        if (row.error !== undefined) reported++;
       }
 
       const sources: {
@@ -549,12 +585,20 @@ describe("listing", () => {
       }[] = [
         {
           standing: () => inFacet("slugs"),
-          deps: (names) => slugIndex(names.map((slug) => ({ slug }))),
+          deps: (names) =>
+            slugIndex(names.map((slug, index) => ({
+              slug,
+              error: REPORTED[index % REPORTED.length],
+            }))),
           names: candidates("boa", "rd"),
         },
         {
           standing: () => inFacet("pieces"),
-          deps: (names) => spacePieces(names.map((id) => ({ id }))),
+          deps: (names) =>
+            spacePieces(names.map((id, index) => ({
+              id,
+              error: REPORTED[index % REPORTED.length],
+            }))),
           names: candidates(HANDLE.slice(0, 10), HANDLE.slice(10)),
         },
         {
@@ -584,10 +628,14 @@ describe("listing", () => {
         }
       }
 
-      // Both outcomes have to occur, or the property above holds for want of
-      // anything to hold over.
+      // Every outcome has to occur, or the property above holds for want of
+      // anything to hold over. The named row that also carries an error is the
+      // one the count is here for: it is the only shape where the printed line
+      // and the operand are different strings, so a construction that stopped
+      // building one would leave the line assertions above holding trivially.
       expect(named).toBeGreaterThan(0);
       expect(unnamed).toBeGreaterThan(0);
+      expect(reported).toBeGreaterThan(0);
     });
   });
 });

--- a/packages/shuttle/test/listing.test.ts
+++ b/packages/shuttle/test/listing.test.ts
@@ -16,7 +16,7 @@
  * a name `cd` takes back to the row it was printed for. It is driven over a
  * construction rather than a hand-listed few, because the interesting names
  * are the ones nobody thinks to list — and its other half matters as much,
- * that a row `cd` cannot reach prints no name at all.
+ * that a row it has no operand for prints no name at all.
  */
 
 import { expect } from "@std/expect";
@@ -397,15 +397,15 @@ describe("listing", () => {
       })).toBe("/@space/of:fid1:x@space/..");
     });
 
-    it("returns a marker in place of a name for a row no operand reaches", () => {
+    it("returns a marker in place of a name for a row with no operand", () => {
       expect(renderListing({ rows: [{ name: "#b" }] })).toBe(
-        "<no operand reaches '#b'>",
+        "<no operand: '#b'>",
       );
     });
 
     it("returns a marker that writes no name where the name holds a line break", () => {
       expect(renderListing({ rows: [{ name: "a\nb" }] })).toBe(
-        "<no operand reaches this row, whose name holds a line break>",
+        "<no operand: a name holding a line break>",
       );
     });
 
@@ -444,8 +444,8 @@ describe("listing", () => {
   describe("naming a row back", () => {
     // The property, over a construction rather than a list: what a listing
     // prints as a name, `cd` takes back to the row it was printed for; and a
-    // row `cd` cannot reach prints no name at all, so nothing on the surface
-    // invites a reader to type a string that reaches somewhere else.
+    // row it has no operand for prints no name at all, so nothing on the
+    // surface invites a reader to type a string that reaches somewhere else.
     //
     // A named row's line never opens with `<`, which is what keeps a name and
     // a marker apart on one surface. `quoteToken` is the whole of that
@@ -575,7 +575,7 @@ describe("listing", () => {
       }
     }
 
-    it("prints a name `cd` takes back to the row, and no name for a row it cannot reach", async () => {
+    it("prints a name `cd` takes back to the row, and no name for a row it has no operand for", async () => {
       let named = 0;
       let unnamed = 0;
       let reported = 0;

--- a/packages/shuttle/test/listing.test.ts
+++ b/packages/shuttle/test/listing.test.ts
@@ -1,0 +1,593 @@
+/**
+ * Unit tests for what `ls` finds at a place and how it writes each row back.
+ *
+ * Every read a listing makes is `packages/cli`'s, and every case here stands
+ * its own in through the deps bag, so what is under test is the composing —
+ * which read a position takes, what a row carries, and how a row prints — with
+ * no socket, no server and no piece behind any of it. What those reads do once
+ * called is not this file's subject; that a listing hands each of them the
+ * connection this process holds is, and three cases pin it.
+ *
+ * The connection is a borrowed one throughout. A listing never opens or closes
+ * one, so which arm a case stands it up through decides nothing here, and the
+ * borrowed arm is the one that needs no opener behind it.
+ *
+ * The property the file exists for is the last group's: a name `ls` prints is
+ * a name `cd` takes back to the row it was printed for. It is driven over a
+ * construction rather than a hand-listed few, because the interesting names
+ * are the ones nobody thinks to list — and its other half matters as much,
+ * that a row `cd` cannot reach prints no name at all.
+ */
+
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import type { SlugSummary, SpaceConfig } from "@commonfabric/cli/lib/piece";
+import type { MemorySpace } from "@commonfabric/memory/interface";
+import type { PiecesController } from "@commonfabric/piece/ops";
+import { linkPathSegmentToCellPathSegment } from "@commonfabric/runner/shared";
+
+import { HeldConnection } from "../src/connection.ts";
+import { splitLine } from "../src/line.ts";
+import {
+  type Listing,
+  type ListingDeps,
+  type ListingRow,
+  listPlace,
+  renderListing,
+} from "../src/listing.ts";
+import { CurrentPlace, type Facet, type Place } from "../src/place.ts";
+
+const SPACE = "did:key:z6MkConnectedSpace" as MemorySpace;
+const HANDLE = "of:fid1:abcdefghijklmnop";
+const OTHER_HANDLE = "of:fid1:qrstuvwxyz012345";
+
+const CONFIG: SpaceConfig = {
+  apiUrl: "https://toolshed.example/",
+  space: SPACE,
+  identity: "/keys/shuttle.pkcs8",
+};
+
+/** Helper for the cases below, which fails whichever read a case reaches. */
+const READS_NOTHING: ListingDeps = {
+  listSpaceSlugs: () => {
+    throw new Error("The slug index was read.");
+  },
+  listPieces: () => {
+    throw new Error("The pieces were read.");
+  },
+  listCellKeys: () => {
+    throw new Error("The cell was read.");
+  },
+};
+
+/** Helper for the cases below, which stands at the space's root. */
+function atSpaceRoot(): CurrentPlace {
+  return new CurrentPlace(SPACE);
+}
+
+/** Helper for the cases below, which stands inside `facet`. */
+function inFacet(facet: Facet): CurrentPlace {
+  const place = atSpaceRoot();
+  place.cd(facet);
+  return place;
+}
+
+/** Helper for the cases below, which stands at a piece, at `path` inside it. */
+function atPiece(...path: string[]): CurrentPlace {
+  const place = atSpaceRoot();
+  place.cd(`/${HANDLE}`);
+  for (const segment of path) place.cd(segment);
+  return place;
+}
+
+/**
+ * Helper for the cases below, which is a connection over a controller nothing
+ * reads. A listing hands the controller to a read and never touches it, so
+ * what a case can see is which read was handed it.
+ */
+function heldConnection(): {
+  connection: HeldConnection;
+  pieces: PiecesController;
+} {
+  const pieces = {
+    dispose: () => Promise.resolve(),
+  } as unknown as PiecesController;
+  return {
+    connection: new HeldConnection({ kind: "borrowed", pieces }),
+    pieces,
+  };
+}
+
+/** Helper for the cases below, which stands `rows` in for the slug index. */
+function slugIndex(rows: SlugSummary[]): ListingDeps {
+  return { ...READS_NOTHING, listSpaceSlugs: () => Promise.resolve(rows) };
+}
+
+/** Helper for the cases below, which stands `rows` in for the space's pieces. */
+function spacePieces(rows: { id: string; error?: string }[]): ListingDeps {
+  return { ...READS_NOTHING, listPieces: () => Promise.resolve(rows) };
+}
+
+/** Helper for the cases below, which stands `keys` in for a cell's keys. */
+function cellKeys(keys: string[]): ListingDeps {
+  return { ...READS_NOTHING, listCellKeys: () => Promise.resolve(keys) };
+}
+
+/** Helper for the cases below, which lists `place` over `deps`. */
+function list(place: CurrentPlace, deps: ListingDeps): Promise<Listing> {
+  return listPlace(CONFIG, place.place, heldConnection().connection, deps);
+}
+
+describe("listing", () => {
+  describe("listPlace()", () => {
+    describe("a space root", () => {
+      it("returns one row per facet the root lists", async () => {
+        const listing = await list(atSpaceRoot(), READS_NOTHING);
+        expect(listing.rows.map((row) => row.name)).toEqual([
+          "slugs",
+          "pieces",
+        ]);
+      });
+
+      it("returns a facet row carrying the operand `cd` takes to it", async () => {
+        const listing = await list(atSpaceRoot(), READS_NOTHING);
+        expect(listing.rows.map((row) => row.operand)).toEqual([
+          "slugs",
+          "pieces",
+        ]);
+      });
+
+      it("returns the facets without reading anything", async () => {
+        let reads = 0;
+        await list(atSpaceRoot(), {
+          listSpaceSlugs: () => {
+            reads++;
+            return Promise.resolve([]);
+          },
+          listPieces: () => {
+            reads++;
+            return Promise.resolve([]);
+          },
+          listCellKeys: () => {
+            reads++;
+            return Promise.resolve([]);
+          },
+        });
+        expect(reads).toBe(0);
+      });
+
+      it("returns no bound, a root listing its whole facet set", async () => {
+        const listing = await list(atSpaceRoot(), READS_NOTHING);
+        expect(listing.bound).toBeUndefined();
+      });
+    });
+
+    describe("`slugs/`", () => {
+      it("returns one row per slug the index named", async () => {
+        const listing = await list(
+          inFacet("slugs"),
+          slugIndex([
+            { slug: "board", piece: HANDLE },
+            { slug: "topics", piece: OTHER_HANDLE },
+          ]),
+        );
+        expect(listing.rows.map((row) => row.name)).toEqual([
+          "board",
+          "topics",
+        ]);
+      });
+
+      it("returns a slug row carrying the operand `cd` takes to its piece", async () => {
+        const listing = await list(
+          inFacet("slugs"),
+          slugIndex([{ slug: "board", piece: HANDLE }]),
+        );
+        expect(listing.rows[0].operand).toBe("board");
+      });
+
+      it("returns the row of a slug that resolved to nothing, carrying its error", async () => {
+        const listing = await list(
+          inFacet("slugs"),
+          slugIndex([{ slug: "board", error: "Slug redirects to no piece." }]),
+        );
+        expect(listing.rows).toEqual([{
+          name: "board",
+          operand: "board",
+          error: "Slug redirects to no piece.",
+        }]);
+      });
+
+      it("returns the rows beside a slug that resolved to nothing", async () => {
+        const listing = await list(
+          inFacet("slugs"),
+          slugIndex([
+            { slug: "board", error: "Slug redirects to no piece." },
+            { slug: "topics", piece: HANDLE },
+          ]),
+        );
+        expect(listing.rows.map((row) => row.name)).toEqual([
+          "board",
+          "topics",
+        ]);
+      });
+
+      it("returns no operand for an index name that is no slug", async () => {
+        const listing = await list(
+          inFacet("slugs"),
+          slugIndex([{ slug: "Board", piece: HANDLE }]),
+        );
+        expect(listing.rows).toEqual([{ name: "Board" }]);
+      });
+
+      it("returns a bound saying the index is what was listed", async () => {
+        const listing = await list(inFacet("slugs"), slugIndex([]));
+        expect(listing.bound).toBe(
+          "the space's slug index names these, and a slug it never recorded " +
+            "still resolves",
+        );
+      });
+    });
+
+    describe("`pieces/`", () => {
+      it("returns one row per piece", async () => {
+        const listing = await list(
+          inFacet("pieces"),
+          spacePieces([{ id: HANDLE }, { id: OTHER_HANDLE }]),
+        );
+        expect(listing.rows.map((row) => row.name)).toEqual([
+          HANDLE,
+          OTHER_HANDLE,
+        ]);
+      });
+
+      it("returns a piece row carrying the operand `cd` takes to it", async () => {
+        const listing = await list(
+          inFacet("pieces"),
+          spacePieces([{ id: HANDLE }]),
+        );
+        expect(listing.rows[0].operand).toBe(HANDLE);
+      });
+
+      it("returns the row of a piece that would not load, carrying its error", async () => {
+        const listing = await list(
+          inFacet("pieces"),
+          spacePieces([{ id: HANDLE, error: "The piece would not load." }]),
+        );
+        expect(listing.rows).toEqual([{
+          name: HANDLE,
+          operand: HANDLE,
+          error: "The piece would not load.",
+        }]);
+      });
+
+      it("returns no bound, a piece listing naming every piece registered", async () => {
+        const listing = await list(inFacet("pieces"), spacePieces([]));
+        expect(listing.bound).toBeUndefined();
+      });
+    });
+
+    describe("inside a piece", () => {
+      it("returns one row per key the cell has", async () => {
+        const listing = await list(atPiece(), cellKeys(["title", "body"]));
+        expect(listing.rows.map((row) => row.name)).toEqual(["title", "body"]);
+      });
+
+      it("returns a key row carrying the operand `cd` takes to it", async () => {
+        const listing = await list(atPiece(), cellKeys(["title"]));
+        expect(listing.rows[0].operand).toBe("title");
+      });
+
+      it("reads the piece the place stands on", async () => {
+        // A slug stands unresolved in the place, so what a listing hands on is
+        // the slug — which is what makes a name typed back off a listing reach
+        // the piece it names, the read resolving it the way `--cell` does.
+        const place = inFacet("slugs");
+        place.cd("board");
+        let piece: string | undefined;
+        await list(place, {
+          ...READS_NOTHING,
+          listCellKeys: (config) => {
+            piece = config.piece;
+            return Promise.resolve([]);
+          },
+        });
+        expect(piece).toBe("board");
+      });
+
+      it("reads at the scope the place reads through", async () => {
+        const place = atPiece();
+        place.cd("@session");
+        let scope: string | undefined;
+        await list(place, {
+          ...READS_NOTHING,
+          listCellKeys: (config) => {
+            scope = config.pieceScope;
+            return Promise.resolve([]);
+          },
+        });
+        expect(scope).toBe("session");
+      });
+
+      it("reads at the path inside the piece the place stands at", async () => {
+        let path: (string | number)[] | undefined;
+        await list(atPiece("topics", "3"), {
+          ...READS_NOTHING,
+          listCellKeys: (config) => {
+            path = config.piecePath;
+            return Promise.resolve([]);
+          },
+        });
+        expect(path).toEqual(["topics", 3]);
+      });
+
+      it("returns no bound, a cell's keys being all of them", async () => {
+        const listing = await list(atPiece(), cellKeys(["title"]));
+        expect(listing.bound).toBeUndefined();
+      });
+    });
+
+    describe("the held connection", () => {
+      // Each read takes its connection through `deps.loadPieces`, and what
+      // each case reads back is what that returns: the one controller this
+      // process holds, rather than one the read would have opened.
+
+      it("hands the slug index the connection this process holds", async () => {
+        const held = heldConnection();
+        let loaded: PiecesController | undefined;
+        await listPlace(CONFIG, inFacet("slugs").place, held.connection, {
+          ...READS_NOTHING,
+          listSpaceSlugs: async (config, deps) => {
+            loaded = await deps?.loadPieces?.(config);
+            return [];
+          },
+        });
+        expect(loaded).toBe(held.pieces);
+      });
+
+      it("hands the piece listing the connection this process holds", async () => {
+        const held = heldConnection();
+        let loaded: PiecesController | undefined;
+        await listPlace(CONFIG, inFacet("pieces").place, held.connection, {
+          ...READS_NOTHING,
+          listPieces: async (config, deps) => {
+            loaded = await deps?.loadPieces?.(config);
+            return [];
+          },
+        });
+        expect(loaded).toBe(held.pieces);
+      });
+
+      it("hands the cell listing the connection this process holds", async () => {
+        const held = heldConnection();
+        let loaded: PiecesController | undefined;
+        await listPlace(CONFIG, atPiece().place, held.connection, {
+          ...READS_NOTHING,
+          listCellKeys: async (config, _path, _options, deps) => {
+            loaded = await deps?.loadPieces?.(config);
+            return [];
+          },
+        });
+        expect(loaded).toBe(held.pieces);
+      });
+    });
+
+    describe("a read that failed outright", () => {
+      it("raises what the read raised", async () => {
+        await expect(list(atPiece(), READS_NOTHING)).rejects.toThrow(
+          "The cell was read.",
+        );
+      });
+    });
+  });
+
+  describe("renderListing()", () => {
+    it("returns one line per row", () => {
+      expect(renderListing({
+        rows: [
+          { name: "title", operand: "title" },
+          { name: "body", operand: "body" },
+        ],
+      })).toBe("title\nbody");
+    });
+
+    it("returns the operand as the line, not the name", () => {
+      expect(renderListing({
+        rows: [{ name: "..", operand: "/@space/of:fid1:x@space/.." }],
+      })).toBe("/@space/of:fid1:x@space/..");
+    });
+
+    it("returns a marker in place of a name for a row no operand reaches", () => {
+      expect(renderListing({ rows: [{ name: "#b" }] })).toBe(
+        "<no operand reaches '#b'>",
+      );
+    });
+
+    it("returns a marker that writes no name where the name holds a line break", () => {
+      expect(renderListing({ rows: [{ name: "a\nb" }] })).toBe(
+        "<no operand reaches this row, whose name holds a line break>",
+      );
+    });
+
+    it("returns a row's error after its name", () => {
+      expect(renderListing({
+        rows: [{ name: "board", operand: "board", error: "No piece there." }],
+      })).toBe("board <error: No piece there.>");
+    });
+
+    it("returns an error's line breaks written as spaces", () => {
+      expect(renderListing({
+        rows: [{ name: "board", operand: "board", error: "No piece.\nboard" }],
+      })).toBe("board <error: No piece. board>");
+    });
+
+    it("returns the bound on a line of its own, after the rows", () => {
+      expect(renderListing({
+        rows: [{ name: "board", operand: "board" }],
+        bound: "these are the ones the index names",
+      })).toBe("board\n<these are the ones the index names>");
+    });
+  });
+
+  describe("naming a row back", () => {
+    // The property, over a construction rather than a list: what a listing
+    // prints as a name, `cd` takes back to the row it was printed for; and a
+    // row `cd` cannot reach prints no name at all, so nothing on the surface
+    // invites a reader to type a string that reaches somewhere else.
+    //
+    // What varies is as load-bearing as the property. Both kinds of row a
+    // listing can name vary — the piece a facet lists and the key a piece
+    // holds — and each candidate is driven through the read that produces that
+    // kind, so a rule that held for one kind and not the other cannot pass.
+    // The marks are the characters a reading is spelled with, at each of the
+    // three places within a name where one can sit, and alone.
+
+    const MARKS = [
+      " ",
+      "\t",
+      "\n",
+      "\r",
+      "\u00a0",
+      "\u2028",
+      "\u2029",
+      "/",
+      "~",
+      "#",
+      "@",
+      "-",
+      ".",
+      "<",
+      ">",
+      "%",
+      "!",
+      "|",
+      "'",
+      '"',
+      "\\",
+    ];
+
+    /**
+     * Helper for the cases below, which is every awkward spelling of a name
+     * whose ordinary spelling is `head` followed by `tail`.
+     */
+    function candidates(head: string, tail: string): string[] {
+      // The digit spellings sit here rather than among the marks: what they
+      // exercise is the conversion a path segment goes through, where a
+      // canonical index becomes a number and everything else stays a string.
+      const values = ["", "3", "0", "01", "1e21", "-1", "1.5", "..", "-"];
+      for (const mark of MARKS) {
+        values.push(
+          mark + head + tail,
+          head + tail + mark,
+          head + mark + tail,
+          mark,
+        );
+      }
+      return values;
+    }
+
+    /**
+     * Helper for the case below, which is the place one level inside `place`
+     * called `name` — the row's own cell, built from the levels a position
+     * names rather than from any operand.
+     */
+    function childOf(place: Place, name: string): Place {
+      const position = place.position;
+      switch (position.kind) {
+        case "root":
+          return {
+            ...place,
+            position: { kind: "facet", space: SPACE, facet: name as Facet },
+          };
+        case "facet":
+          return {
+            ...place,
+            position: { kind: "piece", space: SPACE, piece: name, path: [] },
+          };
+        case "piece":
+          return {
+            ...place,
+            position: {
+              ...position,
+              path: [
+                ...position.path,
+                linkPathSegmentToCellPathSegment(name),
+              ],
+            },
+          };
+      }
+    }
+
+    it("prints a name `cd` takes back to the row, and no name for a row it cannot reach", async () => {
+      let named = 0;
+      let unnamed = 0;
+
+      /**
+       * Helper for this case, which holds the property over one row and the
+       * line it printed, `standing` being a place at the row's own level.
+       */
+      function check(standing: CurrentPlace, row: ListingRow, line: string) {
+        if (row.operand === undefined) {
+          expect(line.startsWith("<")).toBe(true);
+          unnamed++;
+          return;
+        }
+        const from = standing.place;
+        const split = splitLine(row.operand);
+        expect(split.kind).toBe("split");
+        const tokens = split.kind === "split" ? split.tokens : [];
+        expect(tokens.length).toBe(1);
+        expect(standing.cd(tokens[0]).kind).toBe("moved");
+        expect(standing.place).toEqual(childOf(from, row.name));
+        named++;
+      }
+
+      const sources: {
+        standing: () => CurrentPlace;
+        deps: (names: string[]) => ListingDeps;
+        names: string[];
+      }[] = [
+        {
+          standing: () => inFacet("slugs"),
+          deps: (names) => slugIndex(names.map((slug) => ({ slug }))),
+          names: candidates("boa", "rd"),
+        },
+        {
+          standing: () => inFacet("pieces"),
+          deps: (names) => spacePieces(names.map((id) => ({ id }))),
+          names: candidates(HANDLE.slice(0, 10), HANDLE.slice(10)),
+        },
+        {
+          standing: () => atPiece(),
+          deps: (names) => cellKeys(names),
+          names: candidates("b", "c"),
+        },
+        {
+          standing: () => atPiece("topics"),
+          deps: (names) => cellKeys(names),
+          names: candidates("b", "c"),
+        },
+      ];
+
+      for (const source of sources) {
+        const listing = await list(
+          source.standing(),
+          source.deps(source.names),
+        );
+        const lines = renderListing(listing).split("\n");
+        expect(listing.rows.length).toBe(source.names.length);
+        expect(lines.length).toBe(
+          listing.rows.length + (listing.bound === undefined ? 0 : 1),
+        );
+        for (const [index, row] of listing.rows.entries()) {
+          check(source.standing(), row, lines[index]);
+        }
+      }
+
+      // Both outcomes have to occur, or the property above holds for want of
+      // anything to hold over.
+      expect(named).toBeGreaterThan(0);
+      expect(unnamed).toBeGreaterThan(0);
+    });
+  });
+});

--- a/packages/shuttle/test/listing.test.ts
+++ b/packages/shuttle/test/listing.test.ts
@@ -504,10 +504,22 @@ describe("listing", () => {
      * nothing about the rows the naming rule has most to say about. Two of
      * these are chosen for what they do to a line rather than for what they
      * say: one holds an odd quote, so the line as a whole does not split and
-     * only its front can be copied, and one holds a line break — written as an
-     * escape, which `deno task check-control-characters` would not have caught
-     * as a literal — which would open a second line, with a name on it, if the
-     * renderer wrote it as it stands.
+     * only its front can be copied, and one holds a line break, which would
+     * open a second line with a name on it if the renderer wrote it as it
+     * stands.
+     *
+     * The break is written as an escape, and no gate would have said so had it
+     * been written as the byte. A quoted string holding a real break does not
+     * parse, so it would have had to become a template literal — and there
+     * `check-control-characters` skips the newline outright, the branch that
+     * counts a line running before the one that tests for a codepoint below
+     * `0x20`, so a literal break never reaches that test. The gate's other
+     * blind spot is the opposite one, and `MARKS` above is where this file met
+     * it: a no-break space and the Unicode line and paragraph separators are
+     * above `U+007F`, so every byte of them is at or above `0x80` and none can
+     * be a byte the test sees. Both holes are in the one gate, which is why a
+     * fixture writes an awkward character as an escape on its own account
+     * rather than on the gate's.
      */
     const REPORTED = [
       undefined,

--- a/packages/shuttle/test/place.test.ts
+++ b/packages/shuttle/test/place.test.ts
@@ -1506,12 +1506,14 @@ describe("place", () => {
           // argument suffix.
           //
           // One case per character, not one per character per door. The rule
-          // is a single loop inside `unnameablePiece`, which every door
-          // calls, so a character dropped from it is refused nowhere and
-          // reds wherever that character is driven. `#` is driven at this
-          // door because a walk refuses a `#` earlier, naming the suffix,
-          // and so never reaches the rule holding one; `@` is driven through
-          // a walk. That each door calls the rule at all is a separate axis
+          // is a single loop inside `unnameablePiece` that every door calls,
+          // and each character is driven at a door with no earlier check of
+          // its own — `#` here, `@` through a walk — so dropping either from
+          // the loop reds its case. `#` is driven at this door rather than
+          // at a walk because a walk refuses a `#` before the rule runs,
+          // naming the suffix; dropping `#` from the loop therefore leaves
+          // that door refusing it still, which is why the case for it is
+          // here. That each door calls the rule at all is a separate axis
           // with cases of its own, and each frames the one `Fault` it gets
           // back in its own sentence.
 

--- a/packages/shuttle/test/place.test.ts
+++ b/packages/shuttle/test/place.test.ts
@@ -1499,11 +1499,21 @@ describe("place", () => {
         });
 
         it("refuses a target whose piece holds `#` though its length passes for a handle", () => {
-          // The `@` case below is the same defect and the same rule. Both
-          // characters are read inside an id segment, and `isPieceHandle` is a
-          // length rule, so a piece long enough to pass for a handle carries
-          // either past the vocabulary check — and a `#` costs the place its
-          // own rendering, which `cd` then refuses as an argument suffix.
+          // `isPieceHandle` is a length rule, so a piece long enough to
+          // pass for a handle carries either character of
+          // `READ_INSIDE_AN_ID` past the vocabulary check — and a `#` then
+          // costs the place its own rendering, which `cd` refuses as an
+          // argument suffix.
+          //
+          // One case per character, not one per character per door. The rule
+          // is a single loop inside `unnameablePiece`, which every door
+          // calls, so a character dropped from it is refused nowhere and
+          // reds wherever that character is driven. `#` is driven at this
+          // door because a walk refuses a `#` earlier, naming the suffix,
+          // and so never reaches the rule holding one; `@` is driven through
+          // a walk. That each door calls the rule at all is a separate axis
+          // with cases of its own, and each frames the one `Fault` it gets
+          // back in its own sentence.
 
           expect(
             atSpaceRoot().enter(

--- a/packages/shuttle/test/place.test.ts
+++ b/packages/shuttle/test/place.test.ts
@@ -1498,6 +1498,27 @@ describe("place", () => {
           });
         });
 
+        it("refuses a target whose piece holds `#` though its length passes for a handle", () => {
+          // The `@` case below is the same defect and the same rule. Both
+          // characters are read inside an id segment, and `isPieceHandle` is a
+          // length rule, so a piece long enough to pass for a handle carries
+          // either past the vocabulary check — and a `#` costs the place its
+          // own rendering, which `cd` then refuses as an argument suffix.
+
+          expect(
+            atSpaceRoot().enter(
+              { space: SPACE, piece: "of:fid1:abcdefghij#k", path: [] },
+              "#favorites",
+            ),
+          ).toEqual({
+            kind: "refused",
+            reason: "`#favorites` resolves to a piece holding `#`, so no " +
+              "piece carries that name: a slug is lowercase letters, " +
+              "numbers, and single hyphens between words, and a handle is " +
+              "`of:fid1:` and unpadded base64url.",
+          });
+        });
+
         it("refuses a target whose piece is in neither vocabulary", () => {
           // Relayed: `validatePieceSegment`'s own sentence.
 

--- a/packages/shuttle/test/place.test.ts
+++ b/packages/shuttle/test/place.test.ts
@@ -44,6 +44,7 @@ import {
   CurrentPlace,
   FACETS,
   type Move,
+  operandForChild,
   placeAtSpaceRoot,
 } from "../src/place.ts";
 
@@ -95,6 +96,75 @@ describe("place", () => {
       expect(placeAtSpaceRoot(SPACE)).toEqual({
         position: { kind: "root", space: SPACE },
         scope: "space",
+      });
+    });
+  });
+
+  describe("operandForChild()", () => {
+    // The readings `cd()` applies, asked in the other direction. A name whose
+    // own characters are not readings is its own operand; one whose characters
+    // are is reached by the reference the child renders as, which reads none of
+    // them; and a child no rendering names back is reached by neither.
+    //
+    // No case here tells the scope half of the comparison apart from nothing.
+    // Both spellings tried fix the scope at the place's own: the reference is
+    // rendered carrying it, and the one reading that moves a scope takes a
+    // piece segment's suffix with it, which moves the piece too and so fails
+    // the position half first. The comparison is over the pair because a place
+    // is one, and an operand landing on the child at another scope would land
+    // on another cell; this paragraph is read again if a spelling ever moves
+    // the scope while descending.
+
+    it("returns the name itself for a key the name's own reading names", () => {
+      expect(operandForChild(atReferencedPiece().place, "title")).toBe("title");
+    });
+
+    it("returns a facet's own name at a space root", () => {
+      expect(operandForChild(placeAtSpaceRoot(SPACE), "slugs")).toBe("slugs");
+    });
+
+    it("returns nothing at a space root for a name it lists no facet under", () => {
+      expect(operandForChild(placeAtSpaceRoot(SPACE), "fuse")).toBeUndefined();
+    });
+
+    it("returns a piece's own name inside a facet", () => {
+      expect(operandForChild(inSlugs().place, "board")).toBe("board");
+    });
+
+    it("returns a reference for a key called `..`", () => {
+      expect(operandForChild(atReferencedPiece().place, "..")).toBe(
+        `/@${SPACE}/${HANDLE}@space/..`,
+      );
+    });
+
+    it("returns a reference escaping a key that holds the separator", () => {
+      expect(operandForChild(atReferencedPiece().place, "a/b")).toBe(
+        `/@${SPACE}/${HANDLE}@space/a~1b`,
+      );
+    });
+
+    it("returns nothing for a key no rendering names back", () => {
+      expect(operandForChild(atReferencedPiece().place, "a ")).toBeUndefined();
+    });
+
+    it("returns nothing for a key whose first character opens a wish target", () => {
+      expect(operandForChild(atReferencedPiece().place, "#b")).toBeUndefined();
+    });
+
+    it("returns nothing for a piece name in neither vocabulary", () => {
+      expect(operandForChild(inSlugs().place, "Board")).toBeUndefined();
+    });
+
+    it("returns an operand `cd` moves to the child by", () => {
+      const place = atReferencedPiece();
+      const operand = operandForChild(place.place, "..");
+      expect(operand).toBeDefined();
+      place.cd(operand as string);
+      expect(place.place.position).toEqual({
+        kind: "piece",
+        space: SPACE,
+        piece: HANDLE,
+        path: [".."],
       });
     });
   });

--- a/packages/shuttle/test/place.test.ts
+++ b/packages/shuttle/test/place.test.ts
@@ -1143,14 +1143,12 @@ describe("place", () => {
             // A relative operand is not a reference, so the reference
             // grammar's `~1` escaping does not reach it: `~1` is literal
             // here where a reference reads it as a literal `/` inside the
-            // key. The case
-            // below is the consequence — a key holding a `/` has no
-            // relative spelling at all, since neither candidate reaches it
-            // — and both are pinned so that teaching the walk to unescape
-            // reds a case rather than arriving unremarked. Which vocabulary
-            // a relative segment speaks is settled where `ls` decides how
-            // such a key prints, the render and the read wanting to be
-            // decided together.
+            // key. The case below is the consequence — a key holding a `/`
+            // has no relative spelling, the walk splitting on the separator
+            // it holds — and both are pinned so that teaching the walk to
+            // unescape reds a case rather than arriving unremarked. Such a
+            // key is named by a reference instead, which unescapes `~1`, and
+            // that is the spelling `operandForChild` offers for it.
 
             const place = atReferencedPiece();
             place.cd("a~1b");

--- a/packages/shuttle/test/place.test.ts
+++ b/packages/shuttle/test/place.test.ts
@@ -106,14 +106,16 @@ describe("place", () => {
     // are is reached by the reference the child renders as, which reads none of
     // them; and a child no rendering names back is reached by neither.
     //
-    // No case here tells the scope half of the comparison apart from nothing.
-    // Both spellings tried fix the scope at the place's own: the reference is
-    // rendered carrying it, and the one reading that moves a scope takes a
-    // piece segment's suffix with it, which moves the piece too and so fails
-    // the position half first. The comparison is over the pair because a place
-    // is one, and an operand landing on the child at another scope would land
-    // on another cell; this paragraph is read again if a spelling ever moves
-    // the scope while descending.
+    // Two clauses of the comparison behind it have no case, and both are
+    // unreachable from this door rather than untested. Neither spelling tried
+    // moves the scope: the reference is rendered carrying the place's own, and
+    // the one reading that moves a scope takes a piece segment's suffix with
+    // it, which moves the piece too and fails the position clause first. And a
+    // space root's children are a closed set, checked before a candidate is
+    // tried, so a candidate that lands on a facet lands on the facet named.
+    // The comparison is over the whole place because a place is one, and an
+    // operand landing anywhere else would name another cell; this paragraph is
+    // read again if either clause becomes reachable.
 
     it("returns the name itself for a key the name's own reading names", () => {
       expect(operandForChild(atReferencedPiece().place, "title")).toBe("title");

--- a/packages/shuttle/test/place.test.ts
+++ b/packages/shuttle/test/place.test.ts
@@ -13,18 +13,20 @@
  * settling either needs a connection to resolve against. Their cases pin what
  * gets handed on, and that the place did not move.
  *
- * A refusal's text is pinned whole, and three of them are somebody else's
+ * A refusal's text is pinned whole, and four of them are somebody else's
  * words. Shuttle consumes the reference grammar rather than forking it, so a
  * rooted operand's diagnostics come from that layer and reach the reader
  * unaltered — the space-mismatch sentence and the unknown-suffix sentence from
- * `normalizeLLMFriendlyRef` and `splitArgumentSuffix`, and the no-piece-handle
- * sentence from `parseReferenceParts`. Each is marked at its case as relayed.
+ * `normalizeLLMFriendlyRef` and `splitArgumentSuffix`, the no-piece-handle
+ * sentence from `parseReferenceParts`, and the not-a-slug sentence from
+ * `validatePieceSegment`, which every door relays and not the reference alone.
+ * Each is marked at its case as relayed.
  * When one moves upstream, the fix is to copy the new sentence here, never to
  * match a fragment of it: the whole sentence is what pins that the diagnostic
  * arrives intact, and a substring would let a rewording through that says
  * something else. Other diagnostics from that layer reach a reader without a
- * case here — a bad space segment, a piece segment that is neither slug nor
- * handle, a bad scope suffix on a reference — and pinning three of them is
+ * case here — a bad space segment, a piece segment that is no handle and holds
+ * a colon, a bad scope suffix on a reference — and pinning four of them is
  * enough to hold the relay itself, since all of them travel the same path.
  *
  * Every other refusal in this file is shuttle's own, and two of those
@@ -939,6 +941,25 @@ describe("place", () => {
             });
           });
 
+          it("refuses a piece segment that is in neither vocabulary", () => {
+            // Relayed: `validatePieceSegment`'s own sentence, which the walk
+            // calls rather than copies.
+
+            expect(inSlugs().cd("Board")).toEqual({
+              kind: "refused",
+              reason: '"Board" is not a slug: a slug is lowercase letters, ' +
+                "numbers, and single hyphens between words.",
+            });
+          });
+
+          it("gives a piece segment the reason a reference's gets", () => {
+            // Which is the whole of the ruling: a piece is held to the two
+            // vocabularies whichever door reached it, so a name a listing
+            // cannot print as an operand is one no door takes.
+
+            expect(inSlugs().cd("Board")).toEqual(atSpaceRoot().cd("/Board"));
+          });
+
           it("reads a canonical index inside a piece as a number", () => {
             const place = atPiece();
             place.cd("topics/3");
@@ -1407,6 +1428,21 @@ describe("place", () => {
           });
         });
 
+        it("refuses a target whose piece is in neither vocabulary", () => {
+          // Relayed: `validatePieceSegment`'s own sentence.
+
+          expect(
+            atSpaceRoot().enter(
+              { space: SPACE, piece: "Board", path: [] },
+              "#favorites",
+            ),
+          ).toEqual({
+            kind: "refused",
+            reason: '"Board" is not a slug: a slug is lowercase letters, ' +
+              "numbers, and single hyphens between words.",
+          });
+        });
+
         it("refuses a target whose piece holds a line break", () => {
           expect(
             atSpaceRoot().enter(
@@ -1589,6 +1625,27 @@ describe("place", () => {
             kind: "refused",
             reason: `The reference naming space \`estuary\` has a segment ` +
               `ending in whitespace, so a rendering of the place would name a different cell.`,
+          });
+          expect(place.place).toEqual(placeAtSpaceRoot(SPACE));
+        });
+
+        it("refuses a move whose piece is in neither vocabulary", () => {
+          // Relayed: `validatePieceSegment`'s own sentence. A move `cd` minted
+          // carries a piece the reference grammar already held to the two
+          // vocabularies; one a caller assembled carries whatever it was
+          // given, and this door holds that to them too.
+
+          const place = atSpaceRoot();
+          expect(place.settle({
+            kind: "space-by-name",
+            name: "estuary",
+            piece: "Board",
+            path: [],
+            scope: "space",
+          }, SPACE)).toEqual({
+            kind: "refused",
+            reason: '"Board" is not a slug: a slug is lowercase letters, ' +
+              "numbers, and single hyphens between words.",
           });
           expect(place.place).toEqual(placeAtSpaceRoot(SPACE));
         });


### PR DESCRIPTION
## Why

Shuttle can hold a place and split a line, but it cannot yet **look at anything**. `ls` is the first command that reads the fabric, and standing it up forces two questions the earlier slices deferred rather than answered.

**Which names can a listing print?** A row's own name may be characters a reading would take — a name beginning with `#`, or holding `/` or `-`. Printing such a name bare gives the user a string that means something else when typed back. This lands the ruling that **a quote reaches no reading**: `splitLine` keeps returning plain strings, and a row whose own name a reading would take prints as the *rooted reference* that names it, which reads none of the relative readings and unescapes `~1`. So "every name a listing prints is one `cd` takes back to that row" holds without the split changing at all. The cost is named rather than hidden: a key whose **first** character is `#` has neither spelling from the piece it sits in, so `ls` prints no name for it rather than one that means something else. It stays reachable as a later segment.

**Does the walk refuse what the reference refuses?** Two vocabularies name a piece — a handle and a slug — and before this the walk decided that for itself. Now every door calls the canonical `validatePieceSegment` rather than copying its rule, so a refusal from `cd` is *the same sentence* the reference grammar gives. That is asserted directly rather than described: `inSlugs().cd("Board")` equals `atSpaceRoot().cd("/Board")`.

Follows #6756 (the place value), #6796 (the held connection) and #6811 (the line grammar), and rides the `--cell` machinery from #6761.

## What Changed

- **`packages/shuttle/src/listing.ts`** (new) — `listPlace` and `renderListing`. Facets and pieces read through one held connection via `deps.loadPieces`, so a listing never opens a second.
- **`packages/shuttle/src/place.ts`** — `operandForChild` answers what operand reaches a child, and the three doors that admit a piece now call `validatePieceSegment`, each after its own rendering rules so a part no rendering names back keeps its own reason.
- **`packages/cli/lib/llm-friendly-ref.ts`** — `validatePieceSegment` exported, with a `@throws` line documenting the contract shuttle now leans on. No behavior change. This is shuttle's first reach into `cli`'s surface and is deliberate: the alternative is a copy of the rule that can drift from it.
- **Docs** — `grammar.md` gains both rulings and the reason the round-trip claim stops at the front of a printed line; `runtime-integration.md` corrected, because `listPiecesFromCommand`/`listSlugsFromCommand` cannot be the seam (each parses Cliffy options, renders to its own stdout, and passes its read no connection, so a caller holding one would open a second).

An unreachable guard was removed rather than covered: its space check could never fail, because every door already refuses a foreign space.

## Test plan

```
deno fmt --check                    Checked 5719 files
deno lint                           Checked 5531 files
deno task check                     Type check complete.
deno task check-docs                All 599 checked code block(s) passed.
deno task check-control-characters  No control codepoints below 0x20
deno task check-skill-facts         Agent-facing facts OK (49 documents)
deno task test  packages/shuttle    ok | 4 passed (256 steps) | 0 failed
deno task test  packages/cli        ok | 211 passed (217 steps) | 0 failed
coverage-debt   packages/shuttle    0 uncovered lines (unchanged)
```

**38 designated mutations, 36 killed.** The two survivors are recorded in a block comment with the argument that both are unreachable from their only caller (`samePlace`'s scope clause, `samePosition`'s facet clause).

The round-trip property case reads **the line it printed**, not the data behind it — an earlier draft asserted against `row.operand` and was proven blind: run alone against a mutation making a named row print its name, it reported no failures at all. `lineFor` returns the operand only for error-free rows, so errors now ride a third of the constructed rows, including an odd quote (the line then refuses to split, which is why the claim is over the line's front) and an embedded break.

One case pair remains inseparable and is reported as such rather than claimed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BPyjSx5WXYepE9JsK4rBx3


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6835?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

