### PR TITLE
fix(data-model): `FabricError.fromNativeError()` returns a valid `FabricValue` throughout

### DIFF
--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -559,20 +559,25 @@ export class FabricError extends FabricNativeWrapper<Error> {
 
   /**
    * Constructs from a `FabricErrorState` record. All state values must
-   * already be in `FabricValue` form -- the conversion layer is
-   * responsible for ensuring this when converting from a native `Error`.
-   * Unsafe keys (`__proto__`, `constructor`) and fixed-schema slot names
-   * are silently skipped in `extras`.
+   * already be in `FabricValue` form. Unsafe keys (`__proto__`,
+   * `constructor`) and fixed-schema slot names are silently skipped in
+   * `extras`.
    */
   constructor(state: FabricErrorState);
 
   /**
-   * Shallow conversion from a native `Error`, used by the shallow
-   * conversion layer (Section 8.2). The error's `.cause` and custom
-   * properties are stored as-is; the deep conversion path converts them
-   * when needed.
+   * Conversion from a native `Error`. The error's `.cause` and custom
+   * properties go through `options.convert`: by default one that holds a
+   * valid `FabricValue` as it stands and puts anything else through the
+   * deep conversion of Section 8.2 without freezing, so the result is a
+   * valid `FabricValue` throughout. The shallow conversion layer passes an
+   * identity converter and stores them as they stand, for the deep path to
+   * convert when it rebuilds the instance.
    */
-  static fromNativeError(error: Error): FabricError;
+  static fromNativeError(
+    error: Error,
+    options?: { readonly convert?: (value: unknown) => FabricValue },
+  ): FabricError;
 
   // Extras-bag access (the bag is not exposed as an own property).
   // `setExtra`/`deleteExtra` throw on a frozen instance, on fixed-schema

--- a/packages/connectors/agents/connector/src/stable-fabric-value.ts
+++ b/packages/connectors/agents/connector/src/stable-fabric-value.ts
@@ -82,7 +82,12 @@ function replaceCellsWithLinks(
     const error = value as Error;
     const existing = seen.get(error);
     if (existing) return existing;
-    const converted = FabricError.fromNativeError(error);
+    // Converted shallowly on purpose: the walk below converts `cause` and the
+    // extras itself, and registers `converted` first so that a reference back
+    // to `error` resolves to it.
+    const converted = FabricError.fromNativeError(error, {
+      convert: (nested) => nested as FabricValue,
+    });
     seen.set(error, converted);
     if (error.cause !== undefined) {
       converted.cause = replaceCellsWithLinks(

--- a/packages/connectors/agents/connector/src/stable-fabric-value.ts
+++ b/packages/connectors/agents/connector/src/stable-fabric-value.ts
@@ -44,17 +44,17 @@ function hasToJson(
 function replaceCellsWithLinks(
   value: unknown,
   seen: WeakMap<object, unknown>,
-  activeToJson = new WeakSet<object>(),
+  active = new WeakSet<object>(),
 ): unknown {
   if (isCellResultForDereferencing(value)) {
     return replaceCellsWithLinks(
       getCellOrThrow(value).getAsLink(),
       seen,
-      activeToJson,
+      active,
     );
   }
   if (isCell(value)) {
-    return replaceCellsWithLinks(value.getAsLink(), seen, activeToJson);
+    return replaceCellsWithLinks(value.getAsLink(), seen, active);
   }
   if (Array.isArray(value)) {
     if (!isArrayWithOnlyIndexProperties(value)) {
@@ -69,7 +69,7 @@ function replaceCellsWithLinks(
         converted[index] = replaceCellsWithLinks(
           value[index],
           seen,
-          activeToJson,
+          active,
         );
       } else {
         converted.length = index + 1;
@@ -82,27 +82,23 @@ function replaceCellsWithLinks(
     const error = value as Error;
     const existing = seen.get(error);
     if (existing) return existing;
-    // Converted shallowly on purpose: the walk below converts `cause` and the
-    // extras itself, and registers `converted` first so that a reference back
-    // to `error` resolves to it.
-    const converted = FabricError.fromNativeError(error, {
-      convert: (nested) => nested as FabricValue,
-    });
-    seen.set(error, converted);
-    if (error.cause !== undefined) {
-      converted.cause = replaceCellsWithLinks(
-        error.cause,
-        seen,
-        activeToJson,
-      ) as FabricValue;
+    if (active.has(error)) {
+      throw new Error("Cannot store circular reference through an error");
     }
-    for (const [key, child] of converted.extraEntries()) {
-      converted.setExtra(
-        key,
-        replaceCellsWithLinks(child, seen, activeToJson) as FabricValue,
-      );
+    // `cause` and the extras are converted by this walk, and the instance is
+    // built from the results, so a reference back to `error` from inside them
+    // has nothing to resolve to and is refused.
+    active.add(error);
+    try {
+      const converted = FabricError.fromNativeError(error, {
+        convert: (nested) =>
+          replaceCellsWithLinks(nested, seen, active) as FabricValue,
+      });
+      seen.set(error, converted);
+      return converted;
+    } finally {
+      active.delete(error);
     }
-    return converted;
   }
   if (
     nativeTag !== null &&
@@ -113,20 +109,20 @@ function replaceCellsWithLinks(
   }
   if (hasToJson(value)) {
     if (seen.has(value)) return seen.get(value);
-    if (activeToJson.has(value)) {
+    if (active.has(value)) {
       throw new Error("Cannot store circular toJSON conversion");
     }
-    activeToJson.add(value);
+    active.add(value);
     try {
       const converted = replaceCellsWithLinks(
         value.toJSON(),
         seen,
-        activeToJson,
+        active,
       );
       seen.set(value, converted);
       return converted;
     } finally {
-      activeToJson.delete(value);
+      active.delete(value);
     }
   }
   if (isPlainRecord(value)) {
@@ -138,7 +134,7 @@ function replaceCellsWithLinks(
     seen.set(value, converted);
     for (const [key, child] of Object.entries(value)) {
       Object.defineProperty(converted, key, {
-        value: replaceCellsWithLinks(child, seen, activeToJson),
+        value: replaceCellsWithLinks(child, seen, active),
         configurable: true,
         enumerable: true,
         writable: true,

--- a/packages/connectors/agents/connector/test/stable-fabric-value.test.ts
+++ b/packages/connectors/agents/connector/test/stable-fabric-value.test.ts
@@ -1,0 +1,29 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { FabricError } from "@commonfabric/data-model/fabric-instances";
+import { FabricEpochNsec } from "@commonfabric/data-model/fabric-primitives";
+
+import { stableFabricValue } from "../src/stable-fabric-value.ts";
+
+describe("stableFabricValue()", () => {
+  describe("given an `Error`", () => {
+    it("returns a `FabricError` whose `cause` and extras are converted", () => {
+      const error = Object.assign(
+        new Error("outer", { cause: new Error("inner") }),
+        { when: new Date(0) },
+      );
+      const captured = stableFabricValue(error) as FabricError;
+      expect(captured).toBeInstanceOf(FabricError);
+      expect(captured.cause).toBeInstanceOf(FabricError);
+      expect((captured.cause as FabricError).message).toBe("inner");
+      expect(captured.getExtra("when")).toBeInstanceOf(FabricEpochNsec);
+    });
+
+    it("throws given a cycle through `cause`", () => {
+      const error = new Error("loop") as Error & { cause: unknown };
+      error.cause = { back: error };
+      expect(() => stableFabricValue(error)).toThrow("circular reference");
+    });
+  });
+});

--- a/packages/data-model/src/api.ts
+++ b/packages/data-model/src/api.ts
@@ -327,9 +327,24 @@ export interface FabricError extends FabricInstance {
   extraEntries(): IterableIterator<[string, FabricValue]>;
 }
 
+/** Options accepted by `FabricError.fromNativeError()`. */
+export interface FromNativeErrorOptions {
+  /**
+   * Converter applied to the error's `cause` and to each of its custom
+   * enumerable properties, whose result is what the instance holds. When
+   * absent, a value that is already a valid `FabricValue` is held as it
+   * stands, and anything else is converted the way `fabricFromNativeValue()`
+   * converts it, without freezing.
+   */
+  readonly convert?: (value: unknown) => FabricValue;
+}
+
 export interface FabricErrorConstructor {
   new (state: FabricErrorState): FabricError;
-  fromNativeError(error: Error): FabricError;
+  fromNativeError(
+    error: Error,
+    options?: FromNativeErrorOptions,
+  ): FabricError;
   prototype: FabricError;
 }
 

--- a/packages/data-model/src/fabric-instances/FabricError.ts
+++ b/packages/data-model/src/fabric-instances/FabricError.ts
@@ -557,8 +557,18 @@ export class FabricError extends FabricNativeWrapper<Error>
     const type = (typeof className === "string") && (className !== "")
       ? className
       : "Error";
-    const { name: rawName, message, stack, cause } = error;
+    const {
+      name: rawName,
+      message: rawMessage,
+      stack,
+      cause: rawCause,
+    } = error;
     const name = (rawName === type) ? null : rawName;
+    // `message` is normally inherited from `Error.prototype`, so a severed
+    // prototype leaves a message-less error without one at all. `FabricError`
+    // declares a `string`, and the empty string is what such an error means.
+    const message = (typeof rawMessage === "string") ? rawMessage : "";
+    const cause = (rawCause === undefined) ? undefined : convert(rawCause);
     const extras: Array<[string, FabricValue]> = [];
     for (const key of Object.keys(error)) {
       if (isUnsafeObjectKey(key) || FABRIC_ERROR_RESERVED_KEYS.has(key)) {
@@ -569,17 +579,7 @@ export class FabricError extends FabricNativeWrapper<Error>
         convert((error as unknown as Record<string, unknown>)[key]),
       ]);
     }
-    return new FabricError({
-      type,
-      name,
-      // `message` is normally inherited from `Error.prototype`, so a severed
-      // prototype leaves a message-less error without one at all. `FabricError`
-      // declares a `string`, and the empty string is what such an error means.
-      message: (typeof message === "string") ? message : "",
-      stack,
-      cause: (cause === undefined) ? undefined : convert(cause),
-      extras,
-    });
+    return new FabricError({ type, name, message, stack, cause, extras });
   }
 }
 

--- a/packages/data-model/src/fabric-instances/FabricError.ts
+++ b/packages/data-model/src/fabric-instances/FabricError.ts
@@ -557,13 +557,8 @@ export class FabricError extends FabricNativeWrapper<Error>
     const type = (typeof className === "string") && (className !== "")
       ? className
       : "Error";
-    // Each slot is read once. A slot behind a getter that were read for what
-    // kind of thing it holds and again for what it is could answer the two
-    // reads differently.
-    const rawName = error.name;
+    const { name: rawName, message, stack, cause } = error;
     const name = (rawName === type) ? null : rawName;
-    const message = error.message;
-    const cause = error.cause;
     const extras: Array<[string, FabricValue]> = [];
     for (const key of Object.keys(error)) {
       if (isUnsafeObjectKey(key) || FABRIC_ERROR_RESERVED_KEYS.has(key)) {
@@ -581,7 +576,7 @@ export class FabricError extends FabricNativeWrapper<Error>
       // prototype leaves a message-less error without one at all. `FabricError`
       // declares a `string`, and the empty string is what such an error means.
       message: (typeof message === "string") ? message : "",
-      stack: error.stack,
+      stack,
       cause: (cause === undefined) ? undefined : convert(cause),
       extras,
     });

--- a/packages/data-model/src/fabric-instances/FabricError.ts
+++ b/packages/data-model/src/fabric-instances/FabricError.ts
@@ -557,9 +557,12 @@ export class FabricError extends FabricNativeWrapper<Error>
     const type = (typeof className === "string") && (className !== "")
       ? className
       : "Error";
-    const name = error.name === type ? null : error.name;
-    // Read once: a `cause` behind a getter is read for whether there is one
-    // and again for what it is, and the two reads need not agree.
+    // Each slot is read once. A slot behind a getter that were read for what
+    // kind of thing it holds and again for what it is could answer the two
+    // reads differently.
+    const rawName = error.name;
+    const name = (rawName === type) ? null : rawName;
+    const message = error.message;
     const cause = error.cause;
     const extras: Array<[string, FabricValue]> = [];
     for (const key of Object.keys(error)) {
@@ -577,7 +580,7 @@ export class FabricError extends FabricNativeWrapper<Error>
       // `message` is normally inherited from `Error.prototype`, so a severed
       // prototype leaves a message-less error without one at all. `FabricError`
       // declares a `string`, and the empty string is what such an error means.
-      message: (typeof error.message === "string") ? error.message : "",
+      message: (typeof message === "string") ? message : "",
       stack: error.stack,
       cause: (cause === undefined) ? undefined : convert(cause),
       extras,

--- a/packages/data-model/src/fabric-instances/FabricError.ts
+++ b/packages/data-model/src/fabric-instances/FabricError.ts
@@ -37,8 +37,27 @@ import {
 } from "@/codec-interface/interface.ts";
 import { deepFreeze } from "@/deep-freeze.ts";
 import { FrozenSet } from "@/frozen-builtins.ts";
-import type { FabricPlainObject, FabricValue } from "@/interface.ts";
-import { errorClassFromType } from "@/native-conversion.ts";
+import type {
+  FabricPlainObject,
+  FabricValue,
+  FromNativeErrorOptions,
+} from "@/interface.ts";
+import {
+  errorClassFromType,
+  fabricFromNativeValue,
+} from "@/native-conversion.ts";
+import { isValidFabricValue } from "@/type-check.ts";
+
+/**
+ * Helper for `FabricError.fromNativeError()`, which converts a nested value
+ * the way its default does: a valid `FabricValue` is held as it stands, and
+ * anything else goes through `fabricFromNativeValue()` without freezing.
+ */
+function convertNestedNativeValue(value: unknown): FabricValue {
+  return isValidFabricValue(value)
+    ? value
+    : fabricFromNativeValue(value, false);
+}
 
 /**
  * Reserved key set for `FabricError`'s extras bag: these names belong to the
@@ -137,10 +156,8 @@ export class FabricError extends FabricNativeWrapper<Error>
 
   /**
    * Constructs an instance from a `FabricErrorState` record. All state values
-   * must already be in `FabricValue` form -- the conversion layer is
-   * responsible for ensuring this when constructing from a native `Error`. Use
-   * `FabricError.fromNativeError()` for shallow conversion from a native
-   * `Error`.
+   * must already be in `FabricValue` form. Use `FabricError.fromNativeError()`
+   * to construct from a native `Error`.
    */
   constructor(state: FabricErrorState) {
     super();
@@ -504,12 +521,23 @@ export class FabricError extends FabricNativeWrapper<Error>
   }
 
   /**
-   * Shallow conversion from a native `Error`. Used by the shallow conversion
-   * layer (`shallowFabricFromNativeValueModern`). The error's `.cause` and
-   * custom properties are stored as-is (cast to `FabricValue`); the deep
-   * conversion path is responsible for converting them when needed.
+   * Converts a native `Error` into an instance. The fixed slots are read off
+   * the error, and `cause` and every custom enumerable property go through
+   * `options.convert`. By default a nested value that is already a valid
+   * `FabricValue` is held as it stands, and anything else is converted the
+   * way `fabricFromNativeValue()` converts it, without freezing, so that the
+   * result is a valid `FabricValue` throughout. The instance itself is not
+   * frozen.
+   *
+   * @throws If `convert` throws, which by default it does for a nested value
+   * that cannot be converted and for a cycle through `cause`.
    */
-  static fromNativeError(error: Error): FabricError {
+  static fromNativeError(
+    error: Error,
+    options?: FromNativeErrorOptions,
+  ): FabricError {
+    const convert = options?.convert ?? convertNestedNativeValue;
+
     // The class is read from the prototype, not from the value. An own
     // `constructor` property is ordinary data, and this name is stored and
     // used to rebuild the error on the way back, so reading it off the value
@@ -537,7 +565,7 @@ export class FabricError extends FabricNativeWrapper<Error>
       }
       extras.push([
         key,
-        (error as unknown as Record<string, FabricValue>)[key],
+        convert((error as unknown as Record<string, unknown>)[key]),
       ]);
     }
     return new FabricError({
@@ -548,7 +576,7 @@ export class FabricError extends FabricNativeWrapper<Error>
       // declares a `string`, and the empty string is what such an error means.
       message: (typeof error.message === "string") ? error.message : "",
       stack: error.stack,
-      cause: error.cause as FabricValue | undefined,
+      cause: (error.cause === undefined) ? undefined : convert(error.cause),
       extras,
     });
   }

--- a/packages/data-model/src/fabric-instances/FabricError.ts
+++ b/packages/data-model/src/fabric-instances/FabricError.ts
@@ -558,6 +558,9 @@ export class FabricError extends FabricNativeWrapper<Error>
       ? className
       : "Error";
     const name = error.name === type ? null : error.name;
+    // Read once: a `cause` behind a getter is read for whether there is one
+    // and again for what it is, and the two reads need not agree.
+    const cause = error.cause;
     const extras: Array<[string, FabricValue]> = [];
     for (const key of Object.keys(error)) {
       if (isUnsafeObjectKey(key) || FABRIC_ERROR_RESERVED_KEYS.has(key)) {
@@ -576,7 +579,7 @@ export class FabricError extends FabricNativeWrapper<Error>
       // declares a `string`, and the empty string is what such an error means.
       message: (typeof error.message === "string") ? error.message : "",
       stack: error.stack,
-      cause: (error.cause === undefined) ? undefined : convert(error.cause),
+      cause: (cause === undefined) ? undefined : convert(cause),
       extras,
     });
   }

--- a/packages/data-model/src/index.ts
+++ b/packages/data-model/src/index.ts
@@ -13,6 +13,7 @@ export {
   FabricSpecialObject,
   type FabricValue,
   type FabricValueLayer,
+  type FromNativeErrorOptions,
   type MutableFabricArrayLayer,
   type MutableFabricContainerValueLayer,
   type MutableFabricPlainObjectLayer,

--- a/packages/data-model/src/interface.ts
+++ b/packages/data-model/src/interface.ts
@@ -22,6 +22,7 @@ import type {
   FabricPrimitive as ApiFabricPrimitive,
   FabricSpecialObject as ApiFabricSpecialObject,
   FabricValue,
+  FromNativeErrorOptions,
   NonNullableFabricValue,
 } from "./api.ts";
 
@@ -156,6 +157,7 @@ export type {
   FabricContainerValue,
   FabricPlainObject,
   FabricValue,
+  FromNativeErrorOptions,
   NonNullableFabricValue,
 };
 

--- a/packages/data-model/src/native-conversion.ts
+++ b/packages/data-model/src/native-conversion.ts
@@ -216,12 +216,15 @@ export function shallowFabricFromNativeObjectElseUndefined(
   switch (tagFromNativeValue(value)) {
     case VALUE_TAGS.Error: {
       // Shallow conversion, so the native `Error` is wrapped without recursing
-      // into its internals (`cause`, custom properties): the result is only a
-      // _shallow_ `FabricError`, whose `.cause` may still be a raw `Error`. A
-      // caller needing a proper (fully-`FabricValue`) one uses the deep
-      // `fabricFromNativeValue()`; the cell write paths do so at the points
+      // into its internals: `cause` and the custom properties are stored as
+      // they stand, and the result is only a _shallow_ `FabricError`, whose
+      // `.cause` may still be a raw `Error`. A caller needing a proper
+      // (fully-`FabricValue`) one uses the deep `fabricFromNativeValue()`,
+      // which rebuilds those slots; the cell write paths do so at the points
       // where they treat a `FabricError` as an atomic leaf.
-      return Object.freeze(FabricError.fromNativeError(value as Error));
+      return Object.freeze(FabricError.fromNativeError(value as Error, {
+        convert: (nested) => nested as FabricValue,
+      }));
     }
 
     case VALUE_TAGS.Date: {

--- a/packages/data-model/src/native-conversion.ts
+++ b/packages/data-model/src/native-conversion.ts
@@ -222,6 +222,12 @@ export function shallowFabricFromNativeObjectElseUndefined(
       // (fully-`FabricValue`) one uses the deep `fabricFromNativeValue()`,
       // which rebuilds those slots; the cell write paths do so at the points
       // where they treat a `FabricError` as an atomic leaf.
+      //
+      // The identity converter is a type lie: it says the values it hands
+      // back are `FabricValue`s, and they are whatever the native error held.
+      // TODO(danfuzz): Address this type lie, for example by giving the deep
+      // walk an error arm of its own so that no shallow instance is ever
+      // built.
       return Object.freeze(FabricError.fromNativeError(value as Error, {
         convert: (nested) => nested as FabricValue,
       }));

--- a/packages/data-model/test/deep-freeze.test.ts
+++ b/packages/data-model/test/deep-freeze.test.ts
@@ -355,9 +355,11 @@ describe("deep-freeze", () => {
         // the recursed `cause`.
         expect(result).toBe(fe);
         expect(Object.isFrozen(fe)).toBe(true);
-        // There is no wrapped-`Error` slot to check directly: the native
-        // projection is lazy, and any projection that gets built is frozen.
-        expect(Object.isFrozen(inner)).toBe(true);
+        // The recursed `cause` is the converted `FabricError`; `inner` itself
+        // is the conversion's input, which it leaves alone.
+        expect(fe.cause).toBeInstanceOf(FabricError);
+        expect(Object.isFrozen(fe.cause)).toBe(true);
+        expect(Object.isFrozen(inner)).toBe(false);
       });
 
       it("recurses into nested `FabricValue`s", () => {

--- a/packages/data-model/test/fabric-instances/FabricError.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricError.test.ts
@@ -31,6 +31,7 @@ import { CODEC } from "@/codec-interface/interface.ts";
 import { CODEC_TYPE_TAGS } from "@/codec-interface/codec-type-tags.ts";
 import { NULL_LIVE_ENVIRONMENT } from "@/codec-interface/NullLiveEnvironment.ts";
 import { FabricError } from "@/fabric-instances/FabricError.ts";
+import { FabricEpochNsec } from "@/fabric-primitives/FabricEpochNsec.ts";
 import { FabricNativeWrapper } from "@/fabric-instances/FabricNativeWrapper.ts";
 import {
   deepFreeze,
@@ -629,6 +630,46 @@ describe("FabricError", () => {
   });
 
   describe("static members", () => {
+    describe("fromNativeError()", () => {
+      it("returns an instance whose `cause` and extras are converted", () => {
+        const inner = new Error("inner");
+        const outer = Object.assign(new Error("outer", { cause: inner }), {
+          when: new Date(0),
+        });
+        const fe = FabricError.fromNativeError(outer);
+        expect(fe.cause).toBeInstanceOf(FabricError);
+        expect((fe.cause as FabricError).message).toBe("inner");
+        expect(fe.getExtra("when")).toBeInstanceOf(FabricEpochNsec);
+      });
+
+      it("returns an unfrozen instance", () => {
+        const fe = FabricError.fromNativeError(new Error("mutable"));
+        expect(Object.isFrozen(fe)).toBe(false);
+      });
+
+      it("returns `cause` and the extras as `options.convert` returns them", () => {
+        const cause = new Error("kept");
+        const error = Object.assign(new Error("outer", { cause }), { n: 1 });
+        const fe = FabricError.fromNativeError(error, {
+          convert: (value) => (value === cause) ? "was cause" : "was extra",
+        });
+        expect(fe.cause).toBe("was cause");
+        expect(fe.getExtra("n")).toBe("was extra");
+      });
+
+      it("throws given an extra that cannot be converted", () => {
+        const error = Object.assign(new Error("bad"), { fn: () => 1 });
+        expect(() => FabricError.fromNativeError(error)).toThrow();
+      });
+
+      it("throws given a cycle through `cause`", () => {
+        const error = new Error("loop") as Error & { cause: unknown };
+        error.cause = { back: error };
+        expect(() => FabricError.fromNativeError(error))
+          .toThrow("circular reference");
+      });
+    });
+
     describe("[CODEC]", () => {
       const codec = FabricError[CODEC];
       const expectedTag = CODEC_TYPE_TAGS.Error;

--- a/packages/static/assets/types/commonfabric.d.ts
+++ b/packages/static/assets/types/commonfabric.d.ts
@@ -370,9 +370,24 @@ export interface FabricError extends FabricInstance {
   extraEntries(): IterableIterator<[string, FabricValue]>;
 }
 
+/** Options accepted by `FabricError.fromNativeError()`. */
+export interface FromNativeErrorOptions {
+  /**
+   * Converter applied to the error's `cause` and to each of its custom
+   * enumerable properties, whose result is what the instance holds. When
+   * absent, a value that is already a valid `FabricValue` is held as it
+   * stands, and anything else is converted the way `fabricFromNativeValue()`
+   * converts it, without freezing.
+   */
+  readonly convert?: (value: unknown) => FabricValue;
+}
+
 export interface FabricErrorConstructor {
   new (state: FabricErrorState): FabricError;
-  fromNativeError(error: Error): FabricError;
+  fromNativeError(
+    error: Error,
+    options?: FromNativeErrorOptions,
+  ): FabricError;
   prototype: FabricError;
 }
 


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Fable 5.1)

## What

`FabricError.fromNativeError()` returns a valid `FabricValue` throughout.
It used to cast the native error's `cause` and custom enumerable properties
into `FabricValue`-typed slots without converting them, so the result could
hold a native `Error` cause or a `Date` extra while `isValidFabricValue()`
still said `true` of it (an instance is a member by type). A probe on `main`
showed both.

## How

* The default conversion of a nested value: a valid `FabricValue` is held as
  it stands (so an already-fabric `cause` keeps its identity, which the
  deep-freeze and encode tests rely on), and anything else goes through
  `fabricFromNativeValue()` without freezing. An unconvertible extra or a
  cycle through `cause` throws.
* `options.convert` lets a caller convert the nested values itself. The
  shallow conversion layer passes an identity converter, so its documented
  shallow behavior and the deep walk's shared cycle map are unchanged. The
  agents connector passes its own cell-to-link walk, so its `FabricError` is
  built from converted `cause` and extras rather than filled in afterwards;
  a reference back to the error from inside its innards is refused by the
  walk's re-entry guard.
* `FromNativeErrorOptions` is declared in `api.ts` and reaches the
  pattern-facing type file (regenerated). The formal spec's `FabricError`
  declaration says the same.
* One test changed meaning: the deep-freeze delegation test asserted that the
  raw native inner error got frozen, which was the shallow behavior. It now
  asserts the held `cause` is frozen and that the input is left alone.

## Prep for

The debug-renderer change that lays a `FabricInstance` out with its state,
where a `FabricError`'s native cause rendered as a native error and made
this visible.

## Verification

`deno task check`, `cfcheck`, `check-docs`, `fmt --check`, `lint`; suites for
data-model, runner, and the agents connector.
