### PR TITLE
perf(cli): scope stepped reads to the requested path

### DIFF
--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -4314,10 +4314,16 @@ export async function getCellValue(
 
   try {
     if (shouldStep) {
-      await timeCliPhase(
-        "getCellValue.step.piece.pull",
-        () => piece.getCell().pull(),
-      );
+      // A nested target pull is itself the demand and storage boundary for
+      // the requested cell. Pulling the canonical piece first widens that
+      // read to every result sibling, which defeats a path-scoped get. Keep
+      // the whole-piece pull only for a path-less whole-result read.
+      if (path.length === 0) {
+        await timeCliPhase(
+          "getCellValue.step.piece.pull",
+          () => piece.getCell().pull(),
+        );
+      }
       const rootCell =
         await (options.input ? piece.input.getCell() : piece.result.getCell());
       const targetCell = rootCell.key(...path);

--- a/packages/cli/test/piece-integration.test.ts
+++ b/packages/cli/test/piece-integration.test.ts
@@ -245,6 +245,18 @@ describe("cf cell get (integration)", { ignore: !API_URL }, () => {
     expect(JSON.parse(stdout.join(""))).toBe("updated-while-stopped");
   });
 
+  it("steps and reads an input path of an unstarted piece", async () => {
+    // The input side of the same fork: the stepped read starts the piece and
+    // pulls the requested input path, without the whole-result pull.
+    const sessionFlags =
+      `--api-url ${API_URL} --identity ${identityPath} --space ${spaceConfig.space} --piece ${staleSessionResultPieceId}`;
+    const { code, stdout, stderr } = await integrationCf(
+      `cell get ${sessionFlags} values --input --step`,
+    );
+    expect(code, stderr.join("\n")).toBe(0);
+    expect(JSON.parse(stdout.join(""))).toEqual(["updated-while-stopped"]);
+  });
+
   it("list and inspect expose the running pattern reference", async () => {
     const listed = await listPieces(spaceConfig);
     const listedPiece = listed.find((piece) => piece.id === pieceId);

--- a/packages/cli/test/piece-integration.test.ts
+++ b/packages/cli/test/piece-integration.test.ts
@@ -46,6 +46,8 @@ const noteEntry: EntryConfig = {
 
 let pieceId = "";
 let sessionResultPieceId = "";
+let coldSessionResultPieceId = "";
+let staleSessionResultPieceId = "";
 let sessionScopedPieceId = "";
 let flags = "";
 let identityPath = "";
@@ -104,6 +106,14 @@ describe("cf cell get (integration)", { ignore: !API_URL }, () => {
     };
     pieceId = await newPiece(spaceConfig, noteEntry);
     sessionResultPieceId = await newPiece(spaceConfig, {
+      mainPath: SESSION_RESULT_PATTERN,
+      rootPath: REPO_ROOT,
+    }, { start: false });
+    coldSessionResultPieceId = await newPiece(spaceConfig, {
+      mainPath: SESSION_RESULT_PATTERN,
+      rootPath: REPO_ROOT,
+    }, { start: false });
+    staleSessionResultPieceId = await newPiece(spaceConfig, {
       mainPath: SESSION_RESULT_PATTERN,
       rootPath: REPO_ROOT,
     }, { start: false });
@@ -207,6 +217,32 @@ describe("cf cell get (integration)", { ignore: !API_URL }, () => {
     );
     expect(code, stderr.join("\n")).toBe(0);
     expect(JSON.parse(stdout.join(""))).toEqual({ value: "session-ready" });
+  });
+
+  it("steps and reads a cold session-scoped result path", async () => {
+    const sessionFlags =
+      `--api-url ${API_URL} --identity ${identityPath} --space ${spaceConfig.space} --piece ${coldSessionResultPieceId}`;
+    const { code, stdout, stderr } = await integrationCf(
+      `cell get ${sessionFlags} value --step`,
+    );
+    expect(code, stderr.join("\n")).toBe(0);
+    expect(JSON.parse(stdout.join(""))).toBe("session-ready");
+  });
+
+  it("reads a current result path after changing an unstarted piece's input", async () => {
+    const sessionFlags =
+      `--api-url ${API_URL} --identity ${identityPath} --space ${spaceConfig.space} --piece ${staleSessionResultPieceId}`;
+    const write = await integrationCf(
+      `cell set ${sessionFlags} values --input`,
+      { stdin: '["updated-while-stopped"]' },
+    );
+    expect(write.code, write.stderr.join("\n")).toBe(0);
+
+    const { code, stdout, stderr } = await integrationCf(
+      `cell get ${sessionFlags} value --step`,
+    );
+    expect(code, stderr.join("\n")).toBe(0);
+    expect(JSON.parse(stdout.join(""))).toBe("updated-while-stopped");
   });
 
   it("list and inspect expose the running pattern reference", async () => {

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -1669,7 +1669,7 @@ describe("cli piece parsing", () => {
     expect(schemaOption.description).toContain("--select field list");
   });
 
-  it("steps, reads, syncs, and stops in one get operation", async () => {
+  it("steps, pulls only the requested result path, syncs, and stops", async () => {
     const order: string[] = [];
     const controller = {
       get: (
@@ -1682,10 +1682,10 @@ describe("cli piece parsing", () => {
         return Promise.resolve({
           input: { get: () => Promise.resolve(undefined) },
           getCell: () => ({
-            pull: () => {
-              order.push("piece.pull");
-              return Promise.resolve();
-            },
+            pull: () =>
+              Promise.reject(
+                new Error("a nested stepped read pulled the piece root"),
+              ),
           }),
           result: {
             getCell: () =>
@@ -1742,7 +1742,6 @@ describe("cli piece parsing", () => {
     expect(value).toBe("ready");
     expect(order).toEqual([
       `get:${PIECE}:true:session`,
-      "piece.pull",
       "result.key:value",
       "result.pull",
       "pieces.synced",

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -1755,6 +1755,81 @@ describe("cli piece parsing", () => {
     ]);
   });
 
+  it("steps an input path read without pulling the piece root either", async () => {
+    // The skipped pull sat ahead of the input/result fork, so the input side
+    // of a stepped path read changed on the same terms as the result side.
+    const order: string[] = [];
+    const controller = {
+      get: (id: string, runIt: boolean) => {
+        order.push(`get:${id}:${runIt}`);
+        return Promise.resolve({
+          getCell: () => ({
+            pull: () =>
+              Promise.reject(
+                new Error("a nested stepped input read pulled the piece root"),
+              ),
+          }),
+          input: {
+            getCell: () =>
+              Promise.resolve({
+                key: (segment: string) => {
+                  order.push(`input.key:${segment}`);
+                  return {
+                    pull: () => {
+                      order.push("input.pull");
+                      return Promise.resolve();
+                    },
+                  };
+                },
+              }),
+            get: () => {
+              order.push("input.get");
+              return Promise.resolve(["updated-while-stopped"]);
+            },
+          },
+          result: { get: () => Promise.resolve(undefined) },
+        });
+      },
+      stopPiece: (id: string) => {
+        order.push(`stop:${id}`);
+        return Promise.resolve();
+      },
+      runtime: {
+        idle: () => {
+          order.push("runtime.idle");
+          return Promise.resolve();
+        },
+      },
+      synced: () => {
+        order.push("pieces.synced");
+        return Promise.resolve();
+      },
+    };
+
+    const value = await getCellValue(
+      { apiUrl: API_URL, space: SPACE, identity: ID, piece: PIECE },
+      ["values"],
+      { step: true, input: true },
+      {
+        loadPieces: () => Promise.resolve(controller as any),
+        resolvePieceAddress: (_pieces, id) => Promise.resolve(id),
+      },
+    );
+
+    expect(value).toEqual(["updated-while-stopped"]);
+    expect(order).toEqual([
+      `get:${PIECE}:true`,
+      "input.key:values",
+      "input.pull",
+      "pieces.synced",
+      "runtime.idle",
+      "pieces.synced",
+      "input.get",
+      "input.key:values",
+      `stop:${PIECE}`,
+    ]);
+  });
+
   it("steps a path-less read through the whole result before syncing", async () => {
     const order: string[] = [];
     const controller = {

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -1755,6 +1755,87 @@ describe("cli piece parsing", () => {
     ]);
   });
 
+  it("steps a path-less read through the whole result before syncing", async () => {
+    const order: string[] = [];
+    const controller = {
+      get: (id: string, runIt: boolean) => {
+        order.push(`get:${id}:${runIt}`);
+        return Promise.resolve({
+          input: { get: () => Promise.resolve(undefined) },
+          getCell: () => ({
+            pull: () => {
+              order.push("piece.pull");
+              return Promise.resolve();
+            },
+          }),
+          result: {
+            getCell: () => {
+              // `rootCell.key(...path)` with an empty path is `key()`: the
+              // root itself, never a descent.
+              const root = {
+                key: (...segments: string[]) => {
+                  if (segments.length > 0) {
+                    throw new Error("a path-less read descended into a key");
+                  }
+                  order.push("result.key:<root>");
+                  return root;
+                },
+                pull: () => {
+                  order.push("result.pull");
+                  return Promise.resolve();
+                },
+              };
+              return Promise.resolve(root);
+            },
+            get: () => {
+              order.push("result.get");
+              return Promise.resolve({ value: "ready" });
+            },
+          },
+        });
+      },
+      stopPiece: (id: string) => {
+        order.push(`stop:${id}`);
+        return Promise.resolve();
+      },
+      runtime: {
+        idle: () => {
+          order.push("runtime.idle");
+          return Promise.resolve();
+        },
+      },
+      synced: () => {
+        order.push("pieces.synced");
+        return Promise.resolve();
+      },
+    };
+
+    const value = await getCellValue(
+      { apiUrl: API_URL, space: SPACE, identity: ID, piece: PIECE },
+      [],
+      { step: true },
+      {
+        loadPieces: () => Promise.resolve(controller as any),
+        resolvePieceAddress: (_pieces, id) => Promise.resolve(id),
+      },
+    );
+
+    expect(value).toEqual({ value: "ready" });
+    // The whole-result pull is the path-less read's materialization step;
+    // a nested read replaces it with its own target pull (the test above).
+    expect(order).toEqual([
+      `get:${PIECE}:true`,
+      "piece.pull",
+      "result.key:<root>",
+      "result.pull",
+      "pieces.synced",
+      "runtime.idle",
+      "pieces.synced",
+      "result.get",
+      `stop:${PIECE}`,
+    ]);
+  });
+
   it("reports schema projection failure when raw result data exists", async () => {
     const rawCell = {
       schema: { type: "object" },


### PR DESCRIPTION
## Summary

- skip the canonical whole-result pull when `cf cell get --step` names a path
- keep the requested target pull and the existing sync / idle / sync convergence barriers
- retain the existing whole-result behavior for path-less reads
- cover cold session-scoped paths and input changes made while a piece is unstarted

## Why

The stepped read lifecycle currently starts the piece, pulls its entire canonical result, and then pulls the requested path separately. On the 157-topic Estuary board, the whole-result pull cost 58.271s while the requested `index` pull cost 28ms. The broad pull adds no path-specific readiness. #4874 landed it first (`79421a5e5`, "materialize piece reads in one session") and then added the target pull and the three convergence barriers (`a64905673`, "await stepped result convergence"), so the mechanism that makes a path read converge postdates the whole-result pull it is replacing here.

This change removes only that redundant broad pull for non-empty paths. Root reads still pull the whole result, and the start / target pull / sync / idle / sync / stop lifecycle is unchanged.

## Measurements

Exact Estuary workload: `cell get <board> index --step --select @,title`

- before: whole-piece pull 58.271s; target pull 28ms
- after: no whole-piece-pull phase; target pull 230ms; 157 rows returned
- after, deep path `index/0/title`: no whole-piece-pull phase; target pull 62ms; correct title returned

The deployment was under variable load, so the phase removal—not total wall time—is the comparable result. The after run also isolated the next cost: selection itself took 76.734s (45.845s output pull + 30.070s storage sync).

## Tests

- focused unit file: 135 steps passed
- CLI live-toolshed integration, server execution ON: 9 steps passed
- CLI live-toolshed integration, server execution OFF: 9 steps passed, including a dedicated never-read cold piece and an unstarted piece whose input changed
- full CLI package suite: 1,987 tests / 2,217 steps passed
- review round: a companion path-less stepped-read unit test, an input-side stepped path unit test, and an `--input --step` integration read on the unstarted piece
- `deno task check`
- `deno fmt --check`
- `deno lint`
- `deno task check-skill-facts`

## Stack

Originally stacked on #6834 for the phase labels the measurements use; #6834 has merged and this PR is rebased onto `main`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6841?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


