### PR TITLE
fix(lunch-poll): the join button waits for the profile document

### DIFF
--- a/packages/patterns/lunch-poll/participant-identity-card.test.tsx
+++ b/packages/patterns/lunch-poll/participant-identity-card.test.tsx
@@ -84,6 +84,23 @@ export default pattern(() => {
     profileName: lateName,
     profileAvatar: "",
   });
+  // Lane 4 — the OTHER transient: the display name has resolved but the
+  // profile DOCUMENT has not been pulled yet (a reference into the viewer's
+  // own space, still on its way under a slow link). The button must wait for
+  // the document rather than offer a join that `joinAs` will refuse, and a
+  // refusal left by a headless caller must clear on its own once the document
+  // reads present — without another join.
+  const docLateUsers = new Writable<User[] | Default<[]>>([]);
+  const docLateHost = Writable.of<HostValue>(DEFAULT_HOST);
+  // A cell with no value yet is exactly what an unpulled document reads as.
+  const docLateProfile = new Writable<LunchProfile>();
+  const docLateCard = ParticipantIdentityCard({
+    users: docLateUsers,
+    host: docLateHost,
+    profile: docLateProfile,
+    profileName: "Doc",
+    profileAvatar: "",
+  });
   const otherAlexCard = ParticipantIdentityCard({
     users,
     host,
@@ -121,6 +138,15 @@ export default pattern(() => {
   const action_late_join_after_resolve = action(() => {
     lateCard.joinAs.send({});
   });
+  const action_doc_late_join_too_early = action(() => {
+    docLateCard.joinAs.send({});
+  });
+  const action_doc_late_document_arrives = action(() => {
+    docLateProfile.set({ name: "Doc" });
+  });
+  const action_doc_late_join = action(() => {
+    docLateCard.joinAs.send({});
+  });
 
   // === Assertions ===
 
@@ -154,6 +180,37 @@ export default pattern(() => {
     lateCard.joinMessage === ""
   );
 
+  // While the document is on its way the button is there but waits, saying
+  // so, and a headless join in that window is refused loudly as before.
+  const assert_doc_late_button_waits = assert(() => {
+    const ui = docLateCard[UI];
+    const button = findByProp(ui, "id", "lp-join-button");
+    return button !== undefined &&
+      readValue(propsOf(button)?.disabled) === true &&
+      hasText(ui, "Loading your profile…") &&
+      !hasText(ui, "Join as Doc");
+  });
+  const assert_doc_late_join_refused = assert(() =>
+    (docLateUsers.get() ?? []).length === 0 &&
+    docLateCard.isJoined === false &&
+    docLateCard.joinMessage === JOIN_NEEDS_PROFILE
+  );
+  // Once the document reads present the button enables and the stale
+  // complaint clears — with no further join sent.
+  const assert_doc_late_heals_without_a_click = assert(() => {
+    const ui = docLateCard[UI];
+    const button = findByProp(ui, "id", "lp-join-button");
+    return button !== undefined &&
+      readValue(propsOf(button)?.disabled) !== true &&
+      hasText(ui, "Join as Doc") &&
+      docLateCard.joinMessage === "" &&
+      (docLateUsers.get() ?? []).length === 0;
+  });
+  const assert_doc_late_joined = assert(() =>
+    (docLateUsers.get() ?? []).length === 1 &&
+    docLateCard.isJoined === true &&
+    docLateCard.joinMessage === ""
+  );
   const assert_offers_join_with_profile = assert(() => {
     const ui = alexCard[UI];
     return hasText(ui, "Join as Alex") &&
@@ -216,6 +273,13 @@ export default pattern(() => {
       { action: action_late_identity_resolves },
       { action: action_late_join_after_resolve },
       { assertion: assert_late_join_healed },
+      { assertion: assert_doc_late_button_waits },
+      { action: action_doc_late_join_too_early },
+      { assertion: assert_doc_late_join_refused },
+      { action: action_doc_late_document_arrives },
+      { assertion: assert_doc_late_heals_without_a_click },
+      { action: action_doc_late_join },
+      { assertion: assert_doc_late_joined },
       { assertion: assert_offers_join_with_profile },
       { action: action_join_as_alex },
       { assertion: assert_joined_and_hosts },

--- a/packages/patterns/lunch-poll/participant-identity-card.test.tsx
+++ b/packages/patterns/lunch-poll/participant-identity-card.test.tsx
@@ -195,15 +195,19 @@ export default pattern(() => {
     docLateCard.isJoined === false &&
     docLateCard.joinMessage === JOIN_NEEDS_PROFILE
   );
-  // Once the document reads present the button enables and the stale
-  // complaint clears — with no further join sent.
-  const assert_doc_late_heals_without_a_click = assert(() => {
+  // Once the document reads present the button enables and the on-screen
+  // complaint goes away — with no further join sent. The EXPORTED verdict
+  // does not: the earlier attempt was refused and nothing has joined, so a
+  // headless caller reading `joinMessage` must not be told otherwise.
+  const assert_doc_late_heals_on_screen_only = assert(() => {
     const ui = docLateCard[UI];
     const button = findByProp(ui, "id", "lp-join-button");
     return button !== undefined &&
       readValue(propsOf(button)?.disabled) !== true &&
       hasText(ui, "Join as Doc") &&
-      docLateCard.joinMessage === "" &&
+      findByProp(ui, "data-join-message", true) === undefined &&
+      docLateCard.joinMessage === JOIN_NEEDS_PROFILE &&
+      docLateCard.isJoined === false &&
       (docLateUsers.get() ?? []).length === 0;
   });
   const assert_doc_late_joined = assert(() =>
@@ -277,7 +281,7 @@ export default pattern(() => {
       { action: action_doc_late_join_too_early },
       { assertion: assert_doc_late_join_refused },
       { action: action_doc_late_document_arrives },
-      { assertion: assert_doc_late_heals_without_a_click },
+      { assertion: assert_doc_late_heals_on_screen_only },
       { action: action_doc_late_join },
       { assertion: assert_doc_late_joined },
       { assertion: assert_offers_join_with_profile },

--- a/packages/patterns/lunch-poll/participant-identity-card.tsx
+++ b/packages/patterns/lunch-poll/participant-identity-card.tsx
@@ -244,10 +244,15 @@ export default pattern<
       profile !== undefined && profile.get() !== undefined
     );
     const canJoin = computed(() => hasProfile && profileLoaded);
-    // Derived, not just stored: a complaint left by a join that raced the
-    // profile document is stale the moment a join would succeed, which is
-    // when the name and the document both read present.
-    const joinNotice = computed(() => canJoin ? "" : (joinMessage.get() ?? ""));
+    // The exported verdict is the handler's, unchanged: a headless caller
+    // (the deploy doc's CLI smoke test) reads it to learn whether its join
+    // landed, and a refusal that raced the profile document is still a
+    // refusal — that caller has not joined, and `isJoined` says so too. The
+    // rendered notice is the derived one: on screen, a complaint left by such
+    // a race is stale the moment a join would succeed, which is when the
+    // name and the document both read present and the button is live.
+    const joinVerdict = computed(() => joinMessage.get() ?? "");
+    const joinNotice = computed(() => canJoin ? "" : joinVerdict);
     const canonicalProfileName = computed(() => trimmedName(profileName));
     const hostName = computed(() => {
       const current = (host?.get() ?? {}).profile;
@@ -381,7 +386,7 @@ export default pattern<
       ),
       isJoined,
       isAdmin,
-      joinMessage: joinNotice,
+      joinMessage: joinVerdict,
       joinAs: boundJoin,
       claimHost: boundClaimHost,
     };

--- a/packages/patterns/lunch-poll/participant-identity-card.tsx
+++ b/packages/patterns/lunch-poll/participant-identity-card.tsx
@@ -205,7 +205,6 @@ export default pattern<
     // different sessions of the same user (the lot-watch `reporterName`
     // scoping).
     const joinMessage = new Writable.perUser("");
-    const joinNotice = computed(() => joinMessage.get() ?? "");
     const boundJoin = joinAs({
       users,
       host,
@@ -232,6 +231,23 @@ export default pattern<
       return equals(current, mine);
     });
     const hasProfile = computed(() => trimmedName(profileName) !== "");
+    // The profile DOCUMENT must read as present before a join can land, and
+    // `#profileName` resolving does not say that it does: the `#profile` wish
+    // hands the cell out as a reference, and under a slow link its document
+    // is still on its way from the viewer's own space when the name string
+    // has already arrived. A click in that window reached `joinAs`, read the
+    // profile as absent, and left the complaint below on screen with a live
+    // button beside it; the next click succeeded. Reading the document here
+    // is what asks the runtime to pull it, and re-runs when it arrives, so the
+    // button waits for the identity it would store.
+    const profileLoaded = computed(() =>
+      profile !== undefined && profile.get() !== undefined
+    );
+    const canJoin = computed(() => hasProfile && profileLoaded);
+    // Derived, not just stored: a complaint left by a join that raced the
+    // profile document is stale the moment a join would succeed, which is
+    // when the name and the document both read present.
+    const joinNotice = computed(() => canJoin ? "" : (joinMessage.get() ?? ""));
     const canonicalProfileName = computed(() => trimmedName(profileName));
     const hostName = computed(() => {
       const current = (host?.get() ?? {}).profile;
@@ -305,9 +321,12 @@ export default pattern<
                       id="lp-join-button"
                       variant="primary"
                       aria-label="Join the poll with your profile"
+                      disabled={!canJoin}
                       onClick={() => boundJoin.send({})}
                     >
-                      Join as {canonicalProfileName}
+                      {profileLoaded
+                        ? `Join as ${canonicalProfileName}`
+                        : "Loading your profile…"}
                     </cf-button>
                   </div>
                 )


### PR DESCRIPTION
## Summary

- the lunch poll's join button waits for the viewer's profile document to read as present, instead of offering a join the handler will refuse
- the "Join needs a resolved profile" complaint is derived, so one left by a click that raced the document clears on its own once a join would succeed
- a new test lane covers the document-late transient beside the existing name-late one

## Why

Under network latency, joining the poll intermittently failed on the first click and succeeded on the second. Measured with an 80 ms one-way delay in front of a local toolshed, three of four first clicks were refused; every refused run joined in under 10 ms on a second click.

The card gated the join button on `#profileName` resolving, but `joinAs` stores the profile cell and requires its document to read as present. The `#profile` wish hands that cell out as a reference without pulling its document (by design, so the profile list stays shallow), so under a slow link the name string arrives first, the button renders, the click reaches the handler while the document is still on its way, the handler refuses and stores the complaint, and nothing ever re-runs it or clears the message. The user sees a live button beside a permanent refusal.

The card now reads the profile document in a computed, which is also what asks the runtime to pull it, and disables the button with "Loading your profile…" until it reads present. The complaint is derived from the same condition.

Verified in a real browser through the same 80 ms delay: with the fix, four of four runs joined on the first enabled click. The runtime side of this (the `#profile` wish could pull the default candidate's document, and idle could account for outstanding pulls) is worth its own conversation; this change is the pattern's half.

## Verification

- `deno fmt --check`, `deno lint`, `deno task check`, `deno task cfcheck`
- the seven lunch-poll pattern tests (participant-identity-card grows from 10 to 14 assertions)
- `deno task pattern-compat --only lunch-poll`, `deno task pattern-vintage` (no contract change: the card's inputs and outputs are unchanged)
- the browser probe from #6795's investigation, four iterations at 80 ms one-way latency


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6842?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

