### PR TITLE
refactor(cli): callable preflight follow-ups from the #6834 review

### DIFF
--- a/docs/common/verbs/agents-over-the-cli.md
+++ b/docs/common/verbs/agents-over-the-cli.md
@@ -60,10 +60,14 @@ as `cf cell get`, so a survey can be narrowed on the way out.
 
 ## Orienting on one piece
 
-`cf piece describe` is the first call to make against an unfamiliar piece. It
-prints the piece's man page — what it is, what it holds, what a caller supplies,
-and what it can do — with every sentence compiled from the pattern's own doc
-comments:
+`cf piece verbs --json` is the first call to make against an unfamiliar piece:
+it names the deployed pattern and lists every callable verb with its prose and
+the schemas a payload is judged against, which is what a caller needs to act.
+Each of the reads below is its own cold CLI process that starts the piece, so
+they are not a preflight to run together; reach for the others when the
+question they answer comes up. `cf piece describe` prints the piece's man page
+— what it is, what it holds, what a caller supplies, and what it can do — with
+every sentence compiled from the pattern's own doc comments:
 
 ```bash
 cf piece describe --cell <piece>
@@ -99,10 +103,13 @@ it does not:
 | `cf piece verbs --json --all` | the same, plus the wrapper-tier and deprecated verbs the default view withholds |
 | `cf piece call <verb> --help --json` | one verb, in full |
 
-`describe` is where to start and rarely where to stop: it summarizes each verb
-in a line and does not carry the schema a payload has to satisfy. Build a
-payload from the `verbs` listing or from a verb's own help page, both of which
-report the schema the dispatcher will judge the payload against.
+`describe` summarizes each verb in a line and does not carry the schema a
+payload has to satisfy; it is the read for a piece's purpose, state, and inputs
+rather than for calling it. Build a payload from the `verbs` listing or from a
+verb's own help page, both of which report the schema the dispatcher will judge
+the payload against. Of the two, prefer the listing you already have: a verb's
+help page is served through the dispatch path, which also starts the space
+root, so it is the most expensive read on this ladder.
 
 **Both listings hide wrapper-tier and deprecated verbs by default**, and both
 say so rather than hiding them silently: `--json` carries a `hidden` object

--- a/docs/common/verbs/agents-over-the-cli.md
+++ b/docs/common/verbs/agents-over-the-cli.md
@@ -103,13 +103,14 @@ it does not:
 | `cf piece verbs --json --all` | the same, plus the wrapper-tier and deprecated verbs the default view withholds |
 | `cf piece call <verb> --help --json` | one verb, in full |
 
-`describe` summarizes each verb in a line and does not carry the schema a
-payload has to satisfy; it is the read for a piece's purpose, state, and inputs
-rather than for calling it. Build a payload from the `verbs` listing or from a
-verb's own help page, both of which report the schema the dispatcher will judge
-the payload against. Of the two, prefer the listing you already have: a verb's
-help page is served through the dispatch path, which also starts the space
-root, so it is the most expensive read on this ladder.
+The `describe` page summarizes each verb in a line and does not carry the
+schema a payload has to satisfy; `describe --json` carries the same verb rows
+the listing does, schemas included, so prefer `verbs --json` over it for payload
+size, not because `describe` lacks the schema. Build a payload from the `verbs`
+listing or from a verb's own help page, both of which report the schema the
+dispatcher will judge the payload against. Of the two, prefer the listing you
+already have: a verb's help page is served through the dispatch path, which
+also starts the space root, so it is the most expensive read on this ladder.
 
 **Both listings hide wrapper-tier and deprecated verbs by default**, and both
 say so rather than hiding them silently: `--json` carries a `hidden` object

--- a/packages/cli/lib/cell-selection.ts
+++ b/packages/cli/lib/cell-selection.ts
@@ -81,11 +81,12 @@ const LINK_MARKER_KEY = "$link";
  */
 const CONCISE_ADDRESS_SUFFIX = "@";
 
-/** A selection phase in the command's trace, under its own prefix. */
+/** A phase of `deriveSelectedValue`, named for the operation like every other
+ * label. These run INSIDE the caller's `getCellValue.selection` phase. */
 const timeSelectionPhase = <T>(
   label: string,
   run: () => T | Promise<T>,
-): Promise<T> => timeCliPhase(`cellSelection.${label}`, run);
+): Promise<T> => timeCliPhase(`deriveSelectedValue.${label}`, run);
 
 /**
  * The address a marked position accumulates as the walk descends, which is

--- a/packages/cli/lib/cell-selection.ts
+++ b/packages/cli/lib/cell-selection.ts
@@ -82,7 +82,9 @@ const LINK_MARKER_KEY = "$link";
 const CONCISE_ADDRESS_SUFFIX = "@";
 
 /** A phase of `deriveSelectedValue`, named for the operation like every other
- * label. These run INSIDE the caller's `getCellValue.selection` phase. */
+ * label. The six are strict siblings, so they add up; what they must not be
+ * added to is whichever phase encloses the selection — `getCellValue.selection`
+ * on `cf cell get`, and on `cf piece call` and `cf wish` nothing yet. */
 const timeSelectionPhase = <T>(
   label: string,
   run: () => T | Promise<T>,

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -1843,8 +1843,9 @@ async function tryResolveLivePieceToolCallable(
  * Load the target piece and its pieces controller for callable resolution or
  * discovery.
  *
- * Dispatch bootstraps the space root first, unconditionally: a verb that
- * creates a piece registers it by sending an event to the default pattern's
+ * Dispatch bootstraps the space root first, unconditionally whenever
+ * `deps.loadPiece` is absent (the test seam is the one way around it): a verb
+ * that creates a piece registers it by sending an event to the default pattern's
  * `addPiece` stream (see `newPiece`), so against an unbootstrapped root it
  * fails with "Cannot add pieces" rather than running slowly. Discovery
  * (`verbs`, `describe`) only reads the addressed piece, so it starts that

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -108,7 +108,6 @@ import {
   CellSelectionError,
   deriveSelectedValue,
 } from "./cell-selection.ts";
-import { timeCliPhase } from "./trace-timing.ts";
 import { cliCommand } from "./cli-name.ts";
 import {
   type ExecCommandSpec,
@@ -122,6 +121,7 @@ import { stderrConsoleHandler } from "./json-output.ts";
 import { validateEmbeddedSpaces } from "./llm-friendly-ref.ts";
 import { claimProcessDeployment } from "./process-deployment.ts";
 import { deriveDiskHandleId } from "./sqlite-source.ts";
+import { timeCliPhase } from "./trace-timing.ts";
 import { throwOnSpaceAuthorizationError } from "./utils.ts";
 import { startVersionCheck } from "./version-check.ts";
 import { noteWroteTo } from "./write-receipt.ts";
@@ -1839,13 +1839,28 @@ async function tryResolveLivePieceToolCallable(
   return callableKind === "tool" ? callableCell : null;
 }
 
-/** Load the target piece and its pieces controller for callable resolution or
- * discovery. Dispatch may bootstrap the space root before calling; read-only
- * discovery starts only the addressed piece. */
+/**
+ * Load the target piece and its pieces controller for callable resolution or
+ * discovery.
+ *
+ * Dispatch bootstraps the space root first, unconditionally: a verb that
+ * creates a piece registers it by sending an event to the default pattern's
+ * `addPiece` stream (see `newPiece`), so against an unbootstrapped root it
+ * fails with "Cannot add pieces" rather than running slowly. Discovery
+ * (`verbs`, `describe`) only reads the addressed piece, so it starts that
+ * piece and nothing else.
+ *
+ * `cf piece call <verb> --help` takes the dispatch path: `executePieceCallable`
+ * resolves the verb before it parses the arguments, so it cannot know it is
+ * only rendering a page, and pays for the root start the two discovery reads
+ * skip. That makes per-verb help the most expensive of the three reads, not
+ * the cheapest; letting help skip the bootstrap means reordering resolution
+ * and parsing there.
+ */
 async function loadPieceForCallables(
   config: PieceConfig,
-  deps: PieceCallableDependencies = {},
-  ensureSpaceRoot = true,
+  deps: PieceCallableDependencies,
+  { ensureSpaceRoot }: { ensureSpaceRoot: boolean },
 ): Promise<{
   pieces: any;
   piece: any;
@@ -1891,6 +1906,7 @@ async function resolvePieceCallable(
   const { pieces, piece, space, resolvedConfig } = await loadPieceForCallables(
     config,
     deps,
+    { ensureSpaceRoot: true },
   );
 
   const onResultCell = await tryResolvePieceCallableAt(
@@ -3040,7 +3056,9 @@ export async function listPieceCallables(
   config: PieceConfig,
   deps: PieceCallableDependencies = {},
 ): Promise<PieceCallablesListing> {
-  const { piece } = await loadPieceForCallables(config, deps, false);
+  const { piece } = await loadPieceForCallables(config, deps, {
+    ensureSpaceRoot: false,
+  });
   return (await listCallablesForLoadedPiece(piece)).listing;
 }
 
@@ -3326,7 +3344,9 @@ export async function describePiece(
   config: PieceConfig,
   deps: PieceCallableDependencies = {},
 ): Promise<PieceDescription> {
-  const { piece } = await loadPieceForCallables(config, deps, false);
+  const { piece } = await loadPieceForCallables(config, deps, {
+    ensureSpaceRoot: false,
+  });
   const { listing, compiled } = await listCallablesForLoadedPiece(piece);
   let name: string | undefined;
   try {

--- a/packages/cli/lib/trace-timing.ts
+++ b/packages/cli/lib/trace-timing.ts
@@ -3,9 +3,13 @@
  * `CF_CLI_TRACE_TIMINGS=1` (docs/development/CONFIGURATION.md). Every phase
  * line has one shape, `[cf-phase] <ms>ms :: <label>`, so a trace from any
  * command greps the same way. Labels are `<operation>.<step>`, and phases
- * nest: an operation's phase encloses the phases of the operations it calls
- * (`getCellValue.selection` encloses every `deriveSelectedValue.*` line), so
- * the lines of a trace do not sum — total a run from its outermost phases.
+ * can nest: when an operation wraps a call to another traced operation, its
+ * phase encloses theirs — on `cf cell get`, `getCellValue.selection` encloses
+ * the `deriveSelectedValue.*` lines — so the lines of a trace do not sum;
+ * total a run from its outermost phases. Only phases with a common parent are
+ * siblings that add up, and an operation reached without a wrapper (a
+ * selection on `cf piece call` or `cf wish`) reports its own phases with no
+ * encloser at all.
  * The piece package keeps its own `[piece-phase]` lines behind the same
  * variable; together they attribute a command's latency across the
  * CLI/controller boundary.

--- a/packages/cli/lib/trace-timing.ts
+++ b/packages/cli/lib/trace-timing.ts
@@ -2,16 +2,20 @@
  * Phase timing for the CLI's own code paths, written to stderr when
  * `CF_CLI_TRACE_TIMINGS=1` (docs/development/CONFIGURATION.md). Every phase
  * line has one shape, `[cf-phase] <ms>ms :: <label>`, so a trace from any
- * command greps the same way. The piece package keeps its own `[piece-phase]`
- * lines behind the same variable; together they attribute a command's latency
- * across the CLI/controller boundary.
+ * command greps the same way. Labels are `<operation>.<step>`, and phases
+ * nest: an operation's phase encloses the phases of the operations it calls
+ * (`getCellValue.selection` encloses every `deriveSelectedValue.*` line), so
+ * the lines of a trace do not sum — total a run from its outermost phases.
+ * The piece package keeps its own `[piece-phase]` lines behind the same
+ * variable; together they attribute a command's latency across the
+ * CLI/controller boundary.
  */
 
 /** Where a phase reports, and whether it does. Injected by tests; commands
  * use {@link cliPhaseTrace}. */
 export interface PhaseTrace {
-  enabled: boolean;
-  log: (line: string) => void;
+  readonly enabled: boolean;
+  readonly log: (line: string) => void;
 }
 
 /** The process-wide trace: read once, since the flag is a property of the

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -141,6 +141,46 @@ describe("executePieceCallable", () => {
     ).rejects.toThrow('Callable "missing" not found');
   });
 
+  it("bootstraps the space root before resolving, help page included", async () => {
+    // The dispatch arm of `loadPieceForCallables`, pinned from the outside:
+    // a verb that creates a piece registers it through the root's `addPiece`
+    // stream, so dispatch starts the root that `verbs`/`describe` skip. A
+    // help page rides the same path because resolution precedes parsing.
+    const harness = createPieceCallableHarness({
+      callableKind: "handler",
+      cellKey: "refresh",
+      inputSchema: { type: "object", properties: {} },
+    });
+    const order: string[] = [];
+    const manager = {
+      ...harness.pieces,
+      ensureDefaultPattern: () => {
+        order.push("ensureDefaultPattern");
+        return Promise.resolve();
+      },
+      get: (id: string, runIt: boolean) => {
+        order.push(`get:${id}:${runIt}`);
+        return Promise.resolve(harness.piece);
+      },
+    };
+
+    const executed = await executePieceCallable(
+      {
+        apiUrl: "http://localhost:8000",
+        identity: "/tmp/test-identity.pem",
+        piece: "fid1:piece-123",
+        space: "home",
+      },
+      "refresh",
+      ["--help"],
+      { loadPieces: () => Promise.resolve(manager as never) },
+    );
+
+    expect(order).toEqual(["ensureDefaultPattern", "get:fid1:piece-123:true"]);
+    expect(executed.helpText).toContain("refresh");
+    expect(harness.tracker.handlerWrites).toEqual([]);
+  });
+
   it("preserves plain-text mode while resolving a callable", async () => {
     const harness = createPieceCallableHarness({
       callableKind: "handler",

--- a/packages/cli/test/piece-describe.test.ts
+++ b/packages/cli/test/piece-describe.test.ts
@@ -421,6 +421,34 @@ describe("piece-describe", () => {
       space: "home",
     };
 
+    it("starts the addressed piece without starting the space root", async () => {
+      // Discovery reads the addressed piece and nothing else: the space
+      // root's bootstrap is dispatch's concern (a verb that creates a piece
+      // registers it with the root), not a description's.
+      const getCalls: unknown[][] = [];
+      let ensureCalls = 0;
+      const manager = {
+        ensureDefaultPattern: () => {
+          ensureCalls++;
+          return Promise.resolve();
+        },
+        get: (...args: unknown[]) => {
+          getCalls.push(args);
+          return Promise.resolve(pieceDouble());
+        },
+        getSpace: () => "home",
+      };
+
+      const description = await describePiece(config, {
+        loadPieces: () => Promise.resolve(manager as never),
+      });
+
+      expect(ensureCalls).toBe(0);
+      expect(getCalls).toEqual([[config.piece, true, undefined, undefined]]);
+      expect(description.name).toBe("Work tracker");
+      expect(description.verbs.map((verb) => verb.name)).toEqual(["addItem"]);
+    });
+
     it("assembles name, purpose, fields, and verbs from one piece", async () => {
       const description = await describePiece(config, {
         loadPieces: () => Promise.resolve({} as never),

--- a/packages/cli/test/piece-verbs.test.ts
+++ b/packages/cli/test/piece-verbs.test.ts
@@ -2,11 +2,7 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import type { JSONSchema } from "@commonfabric/api";
 import type { PieceCallablesListing } from "../lib/piece.ts";
-import {
-  describePiece,
-  listPieceCallables,
-  partitionVerbListing,
-} from "../lib/piece.ts";
+import { listPieceCallables, partitionVerbListing } from "../lib/piece.ts";
 import { verbListingJson, verbListingLines } from "../commands/piece.ts";
 
 const TEST_PATTERN_REF = {
@@ -301,50 +297,6 @@ describe("listPieceCallables", () => {
       ["fid1:piece-stored", true, undefined, undefined],
     ]);
     expect(listing.verbs.map((verb) => verb.name)).toEqual(["addTopic"]);
-  });
-
-  it("describes the addressed piece without starting the space root", async () => {
-    const resultRoot = cell(
-      { addTopic: { $stream: true } },
-      {
-        type: "object",
-        properties: { addTopic: ADD_TOPIC_EVENT },
-      },
-    );
-    const piece = {
-      result: { getCell: () => Promise.resolve(resultRoot) },
-      input: { getCell: () => Promise.resolve(cell(undefined, undefined)) },
-      getCell: () => resultRoot,
-    };
-    const getCalls: unknown[][] = [];
-    let ensureCalls = 0;
-    const manager = {
-      ensureDefaultPattern: () => {
-        ensureCalls++;
-        return Promise.resolve();
-      },
-      get: (...args: unknown[]) => {
-        getCalls.push(args);
-        return Promise.resolve(piece);
-      },
-      getSpace: () => "home",
-    };
-
-    const description = await describePiece(
-      {
-        apiUrl: "http://localhost:8000",
-        identity: "/tmp/test-identity.pem",
-        piece: "fid1:piece-stored",
-        space: "home",
-      },
-      { loadPieces: () => Promise.resolve(manager as never) },
-    );
-
-    expect(ensureCalls).toBe(0);
-    expect(getCalls).toEqual([
-      ["fid1:piece-stored", true, undefined, undefined],
-    ]);
-    expect(description.verbs.map((verb) => verb.name)).toEqual(["addTopic"]);
   });
 
   it("lists handlers and tools with schemas; excludes data; result shadows input", async () => {

--- a/packages/patterns/topics/README.md
+++ b/packages/patterns/topics/README.md
@@ -176,12 +176,11 @@ Agents are first-class participants. Treat the running piece as authoritative:
 start with `cf piece verbs --piece <piece> --json`, which carries the deployed
 pattern reference and every verb's prose and schemas. Reach for
 `cf piece describe --piece <piece>` when piece-wide purpose, state, or input
-documentation is needed, and for
-`cf piece call --piece <piece> <verb> --help
---json` once a verb is chosen; each
-is its own cold CLI process, so the three are not a default preflight. The
-default verb listing is the contract surface; `--all` additionally shows UI
-wrappers and deprecated verbs. Against a deployed board piece:
+documentation is needed, and once a verb is chosen for its own page:
+`cf piece call --piece <piece> <verb> --help --json`. Each is its own cold CLI
+process, so the three are not a default preflight. The default verb listing is
+the contract surface; `--all` additionally shows UI wrappers and deprecated
+verbs. Against a deployed board piece:
 
 ```bash
 cf piece call --piece <board> \

--- a/skills/topics/SKILL.md
+++ b/skills/topics/SKILL.md
@@ -56,11 +56,17 @@ cf piece verbs --cell "$TOPICS_BOARD" --json
 ```
 
 That listing includes the deployed pattern reference, callable prose, and input
-and output schemas. Use `cf piece describe --cell "$TOPICS_BOARD"` only when you
-need piece-wide purpose, state, or input documentation. Use
+and output schemas. `cf piece describe --cell "$TOPICS_BOARD" --json` returns a
+superset of it (the same verb rows plus name, purpose, state, and inputs) for
+the same process and piece start, so the reason to default to `verbs` is
+payload, not time: the listing is the smaller document to hold in context, and
+it is complete for calling. Use `describe` when you need the piece-wide purpose,
+state, or input documentation. Use
 `cf piece call --cell "$TOPICS_BOARD" <verb> --help --json` only after choosing
-a verb and when its generated flags or standalone help are useful. Each command
-is an independent cold CLI process, so do not run all three by default.
+a verb and when its generated flags or standalone help are useful; help is
+served through the dispatch path, which also starts the space root, so it is the
+most expensive of the three. Each command is an independent cold CLI process, so
+do not run all three by default.
 
 The deployment can be well behind the checkout the CLI runs from, and that gap
 explains board behavior that would otherwise read as a defect. Ask it which


### PR DESCRIPTION
## Summary

Follow-ups from @mpsalisbury's review of #6834 (all non-blocking there), landed together:

- `loadPieceForCallables` takes `{ ensureSpaceRoot }` as a named option at all three call sites instead of a defaulted positional boolean. Its doc comment now records *why* dispatch needs the space root (registration sends an event to the root's `addPiece` stream, so an unbootstrapped root fails with "Cannot add pieces") and that `cf piece call <verb> --help` still pays for it, because `executePieceCallable` resolves before it parses.
- The dispatch arm is pinned: a test through `executePieceCallable … --help` asserts the root is bootstrapped before the piece is started (nothing asserted the `true` arm before; it was a default parameter).
- The `describePiece` root-skip pin moves out of the `listPieceCallables` block into the describe suite, on that suite's own `pieceDouble()`, retiring the copied fixture.
- Selection phases are labelled `deriveSelectedValue.*` (operation-named, like every other label), and the trace helper's header says phases nest so trace lines are not summed. `PhaseTrace` members are `readonly`; the `trace-timing` import is in alphabetical order.
- `docs/common/verbs/agents-over-the-cli.md` leads with `verbs --json` instead of `describe`, matching the topics skill and README. The skill answers the review question directly: `describe --json` is a superset for the same process and piece start, so `verbs` is the default for payload size, not time; and per-verb help is the most expensive of the three reads. The README keeps the help command on one line.

Not taken here (larger, named in the review as possible follow-ups): letting `--help` skip the bootstrap, which needs the resolve/parse order in `executePieceCallable` untangled; and one phase-timing helper shared with `packages/piece`.

## Verification

- `deno fmt --check` (repo), `deno lint`, `deno task check`, `deno task check-skill-facts` (49 documents OK)
- focused: `piece-call`, `piece-describe`, `piece-verbs` test files — 22 passed / 215 steps
- mutations: flipping dispatch's arm to `false` fails the new dispatch pin; flipping describe's arm to `true` fails the moved describe pin
- full `packages/cli` suite with coverage (same method as the CI gate): 0 failures; `packages/cli` uncovered lines 2631 vs 2635 on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6843?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

