### PR TITLE
test(lunch-poll): drop the stale console-warning opt-out from multi-user

### DIFF
--- a/packages/patterns/lunch-poll/multi-user.test.tsx
+++ b/packages/patterns/lunch-poll/multi-user.test.tsx
@@ -186,13 +186,6 @@ export const bob = pattern<{ setup: Setup }>(({ setup }) => {
       { assertion: assert_is_host_now },
       { label: "bob-claimed-host" },
     ],
-    // A vote is a read-modify-write over the shared list, so two viewers
-    // writing at once conflict and the loser retries — the scheduler logs
-    // "commit failed transiently; backing off". That retry IS the designed
-    // behavior here (identity is a cell, which cannot key a mergeable
-    // per-vote write), and every assertion above holds after it, so the
-    // warning is expected rather than a defect.
-    allowConsoleWarnings: true,
   };
 });
 


### PR DESCRIPTION
Removes `allowConsoleWarnings: true` and its justifying comment from the `bob` participant's return block in `packages/patterns/lunch-poll/multi-user.test.tsx`.

**Why the opt-out is stale**

- The comment says two viewers' read-modify-write votes conflict and the scheduler logs `commit failed transiently; backing off` as a warning. That message is emitted with `logger.debug` in `packages/runner/src/scheduler/events.ts` (the `backoff` disposition) on a logger configured at level `warn`, so it never prints. The pattern test runner's capture only sees `console.warn` calls and logger warn/error count deltas (`packages/cli/lib/console-capture.ts`), so a debug-level message cannot surface as a console warning.
- Since #6719 a vote is a keyed write: `castVote` addresses one vote by the voter's profile entity and the option id (`voteKeyFor` / `elementById`) and manages membership with `addUnique` / `removeByValue`. The whole-list conflict the comment describes no longer happens.

**Verification**

- `deno task cf test packages/patterns/lunch-poll/multi-user.test.tsx --root packages/patterns` run three times on this branch (Deno 2.9.4): 11 passed, 0 failed, no `console warning(s)` line in any run.
- The same result was observed with the flag removed during the review of #6795, on that PR's head and on a merge with main.
- `deno fmt` and `deno lint` on the file: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6845?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

