### PR TITLE
The flip's documentation floor: the registry alone states the posture, the plan records flips as deltas

### DIFF
--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -35,7 +35,7 @@ was last checked against the code.
 | [`computedCellIds`](#computedcellids)                                       | `EXPERIMENTAL_COMPUTED_CELL_IDS` env, or `RuntimeOptions.experimental`                                                                          | on                                                                                   | Robin McCollum (#4659)                                | graduate to unconditional behavior, then delete flag                                                                                                                                                                              | implemented, on by default                                                      |
 | [`lazyMaterialization`](#lazymaterialization)                               | `EXPERIMENTAL_LAZY_MATERIALIZATION` env, or `RuntimeOptions.experimental`                                                                       | on                                                                                   | Bernhard Seefeld                                      | fold into base read semantics, then delete flag                                                             | implemented, on by default                                         |
 | [`readerSchemaPrecedence`](#readerschemaprecedence)                         | `EXPERIMENTAL_READER_SCHEMA_PRECEDENCE` env, or `RuntimeOptions.experimental`                                                                   | on                                                                                   | Robin McCollum (#6338)                                | graduate to unconditional behavior, then delete flag                                                                                                                                                                              | implemented, on by default                                                      |
-| [`serverExecution`](#serverexecution) | `EXPERIMENTAL_SERVER_EXECUTION` env, or `RuntimeOptions.experimental` | **off** (`SERVER_EXECUTION_DEFAULT_ENABLED = false`; explicit `true` selects the other arm) | Bernhard Seefeld (#5339, server-execution v2 plan Phase 1 stage A; Phase 7 flip-ready #5849) | re-flip ON (the same two-surface change back), soak on main, then delete the flag and OFF path | Phases 1–7 landed; the default rolled back to OFF 2026-09-03 (its section); stable `default`/`opposite` CI roles keep both postures guarded and make a default flip data-only |
+| [`serverExecution`](#serverexecution) | `EXPERIMENTAL_SERVER_EXECUTION` env, or `RuntimeOptions.experimental` | **off** (`SERVER_EXECUTION_DEFAULT_ENABLED = false`; explicit `true` selects the other arm) | Bernhard Seefeld (#5339, server-execution v2 plan Phase 1 stage A; Phase 7 flip-ready #5849) | soak on main at the ON default, then delete the flag and OFF path | Phases 1–7 landed; the section's dated entries carry each flip; stable `default`/`opposite` CI roles keep both postures guarded and make a default flip data-only |
 | [`cfcEnforcementMode`](#cfcenforcementmode)                                 | `RuntimeOptions.cfcEnforcementMode` (`CF_CFC_MODE` in the cf-harness / fuse)                                                                    | `enforce-explicit`                                                                   | Bernhard Seefeld (#3263)                              | tighten default toward `enforce-strict`                                                                                                                                                                                           | active; ladder is permanent                                                     |
 | [`cfcFlowLabels`](#cfcflowlabels)                                           | `RuntimeOptions.cfcFlowLabels`                                                                                                                  | `off`                                                                                | Bernhard Seefeld (#4011)                              | move toward `persist`                                                                                                                                                                                                             | implemented, staged rollout                                                     |
 | [`cfcWriteFloor`](#cfcwritefloor)                                           | `RuntimeOptions.cfcWriteFloor`                                                                                                                  | `off`                                                                                | Bernhard Seefeld (#4479)                              | move toward `enforce`                                                                                                                                                                                                             | implemented, staged rollout                                                     |
@@ -362,15 +362,14 @@ server](#clients-that-are-not-built-alongside-their-server).
     F10 interim — is DELETED). Later stages add their surfaces under
     this same flag; both halves of any coupled behavior move together
     on it.
-- **Current default and planned end state.** **OFF by default** — the ONE
-  first-party default is `SERVER_EXECUTION_DEFAULT_ENABLED` in
-  [`packages/memory/v2/server-execution-default.ts`](../../packages/memory/v2/server-execution-default.ts),
-  value `false` again since the rollback PR (2026-09-03), which returned it
-  from the `true` the flip PR set (2026-08-28, after the plan's Phase-7
-  ordered gates were met: the ON-skip registry EMPTY, OW31's ruled
-  posture built, OW45–OW53 closed, the OW38(ii) benchmark bar ruled met
-  — "topics numbers are fine"; landed flip-READY DARK at `false`
-  2026-08-16 by owner ruling), read by every deployed-topology entry
+- **Current default and planned end state.** The summary table's cell
+  states the current value of the ONE first-party default,
+  `SERVER_EXECUTION_DEFAULT_ENABLED` in
+  [`packages/memory/v2/server-execution-default.ts`](../../packages/memory/v2/server-execution-default.ts)
+  (a test pins the cell to the constant); the dated status entries below
+  carry its history (landed flip-ready dark at `false` 2026-08-16; flipped
+  ON 2026-08-28 after the plan's Phase-7 ordered gates; each later flip has
+  its own entry). It is read by every deployed-topology entry
   point — the `productionServer` / `remoteClient` construction presets
   (toolshed's operator runtime, the background piece service, the CLI,
   every pieces controller and integration harness against a toolshed),
@@ -385,10 +384,11 @@ server](#clients-that-are-not-built-alongside-their-server).
   default is ON). CI resolves stable `default` and `opposite`
   roles through `tasks/server-execution-ci.ts`: `default` leaves the flag
   unset, while `opposite` explicitly selects the inverse and bakes that same
-  value into its toolshed shell. Therefore changing the default requires only
-  changing `SERVER_EXECUTION_DEFAULT_ENABLED` and the current-status prose;
-  workflow job topology, probes, skip placement, coverage ownership, and test
-  record variants follow automatically.
+  value into its toolshed shell. Therefore changing the default is exactly:
+  `SERVER_EXECUTION_DEFAULT_ENABLED`, the summary cell above, a dated status
+  entry here, and a delta in the plan's live coordination block; workflow
+  job topology, probes, skip placement, coverage ownership, test record
+  variants, and every other document follow automatically.
   Single-process harnesses do not
   read the constant: a bare `new Runtime` and the `patternTest` /
   `localDev` / `unitTest` presets have no serving host, so they resolve the
@@ -398,9 +398,9 @@ server](#clients-that-are-not-built-alongside-their-server).
   the lane-posture item the topics measurement report recorded for the
   flip decision); the ON posture's unit coverage sets the
   flag explicitly (the `executor-*` suites) and its integration coverage
-  is the `opposite` CI lanes while the default is rolled back. In CI
-  (testing.md §2), `default` is currently OFF and `opposite` is currently
-  ON. Both are probed through the shared role
+  is whichever CI role resolves ON. In CI (testing.md §2), `default`
+  follows the constant and `opposite` is its explicit inverse; both are
+  probed through the shared role
   resolver; the opposite lane uses `build-toolshed-opposite`, whose shell
   define is baked from the resolved inverse. The
   `deployed-topology-gate` job exercises the real `bg-piece-service`
@@ -409,8 +409,8 @@ server](#clients-that-are-not-built-alongside-their-server).
   with ON-arm skips and OFF-arm authored coverage following the resolved arm.
   Skips are only through `tasks/server-execution-on-skips.ts`, printed loudly
   (EMPTY at the flip, its stated precondition). End
-  state: re-flip ON (the same two-surface change back), soak on main, and
-  then the flag retires and the OFF code path is removed — a separate post-soak
+  state: after a soak on main at the ON default, the flag retires and the
+  OFF code path is removed — a separate post-soak
   PR (the plan's Phase 7 task 2; it also removes the opposite guard lanes and
   `build-toolshed-opposite`).
 - **Status on 2026-09-03 (the ROLLBACK).** The rollback PR (#6840)
@@ -475,9 +475,7 @@ server](#clients-that-are-not-built-alongside-their-server).
   still dark: OFF by default and byte-identical to today; the ON arm now
   actually serves (with the documented two-deriver interim). Stage G
   (effects + outbox) remains.
-- **Path to removal.** Re-flip (the constant → `true` with this registry's
-  status) once the rollback's reason is settled; soak the default on main;
-  then the post-soak PR
+- **Path to removal.** Soak on main at the ON default; then the post-soak PR
   retires the flag, removes the OFF path (and the opposite regression-guard
   lanes + `build-toolshed-opposite`), and closes out this entry.
 

--- a/docs/plans/server-execution-v2.md
+++ b/docs/plans/server-execution-v2.md
@@ -1334,7 +1334,7 @@ client's only computational commit (spec §3.6).
 | Phase 3 ON — events down (D-v2-1) | unchanged | SpaceServer, reacting to the event commit / ONLY the event append; the local run is speculative echo, and the client handler-write commit path DELETES (events.md §7 — F10's interim ends) | unchanged | handler consequences land in the ACTING principal's instances, resolved from the server-stamped `firedAt` (scopes.md §5, protocol.md §2) | commits nothing but intent: event appends + UI-binding writes; echo via overlay |
 | Phase 4 ON — effect channel | unchanged | unchanged | external effects: server only; session effects (navigate): the server COMPUTES the intent, the client ENACTS and acks by nonce (protocol.md §5) | the effects doc is itself a session-scoped instance; the ack is written into the session's own instance (protocol.md §5) | adds the effects-doc subscription and the enact/ack duty (the ack is an authored write) |
 | Phase 5 ON — cross-space | home SpaceServer over foreign reads, under the piece's granted authority / commits HOME only — never derived into a foreign space (protocol.md §2b) | unchanged; cross-space mutation leaves ONLY as outbox event appends; `.inSpace` provisioning lands authored-class, foreign-first, under the event's acting principal | unchanged; the outbox also carries the cross-space appends | foreign reads name their instance explicitly, lease-holder-only (protocol.md §2's read row) | unchanged |
-| Phase 7 flip (FLIP-READY landed DARK 2026-08-16; #6535 flipped the first-party default ON after the ordered gates and began the soak; the rollback PR (2026-09-03) returned it to OFF with the machinery kept; removal is the split-out post-soak PR). **Every cell in this row describes the arm explicit `true` selects; while the default is rolled back, the default arm is the OFF baseline row above, until the re-flip** | SpaceServer | SpaceServer / events only | server, plus the client-enacted channel | unchanged from Phase 5; session-data GC is the remaining owed design (scopes.md §8 item 2) | final: speculate freely, commit only intent; flag retires after the soak |
+| Phase 7 flip (FLIP-READY landed DARK 2026-08-16; flipped ON by #6535 2026-08-28 after the ordered gates; since then a data-only toggle whose flips are dated deltas in the coordination block; removal is the split-out post-soak PR). **Every cell in this row describes the ON arm; whenever the default is OFF, the default arm is the OFF baseline row above and explicit `true` selects this one** | SpaceServer | SpaceServer / events only | server, plus the client-enacted channel | unchanged from Phase 5; session-data GC is the remaining owed design (scopes.md §8 item 2) | final: speculate freely, commit only intent; flag retires after the soak |
 
 A surface a milestone has not yet landed (navigateTo before
 Phase 4, cross-space before Phase 5) has no defined interim
@@ -1958,16 +1958,16 @@ Success criteria:
 
 ## Phase 7 — Flip and retire
 
-**Current scoping (updated 2026-09-03): Phase 7's flip LANDED — #6535
-changed the first-party default to `true` after the ordered gates, merged,
-and began the ON soak — and was ROLLED BACK on 2026-09-03 by the data-only
-rollback PR (the constant to `false` plus status prose, machinery kept);
-explicit `true` selects ON per deployment meanwhile, and the flip's ordered
-gates are the bar for re-flipping. Stable
-`default` and `opposite` CI roles now follow the one default constant, so a
-deliberate rollback changes that value and current-status prose without
-rewiring the workflow. Task 2's OFF-path removal stays split into a separate
-post-soak PR, and task 3 remains the final archive.** The original 2026-08-16
+**Current scoping (updated 2026-09-03): Phase 7's flip mechanism is landed
+and the first-party default is a data-only toggle. The coordination-state
+deltas above are the dated record of each flip (#6535 flipped ON 2026-08-28
+after the ordered gates; every later flip adds a delta), and the registry's
+summary table states the current value. Stable `default` and `opposite` CI
+roles follow the one constant, so a flip in either direction is the
+constant, the registry's cell and dated entry, and a delta above — never a
+workflow edit. The ordered gates below are the bar for any flip to ON.
+Task 2's OFF-path removal stays split into a separate post-soak PR, and
+task 3 remains the final archive.** The original 2026-08-16
 ruling landed the mechanism dark first because, at that time, with
 the constant `true` the REQUIRED default CI lanes went red on merge
 (two two-browser gates stall 300 s under the full ON posture, neither
@@ -2025,9 +2025,9 @@ Preconditions (all RULED 2026-08-15, all landed with this phase):
 
 Tasks:
 
-- [ ] **Default ON — #6535 merged and the soak began; ROLLED BACK on
-      2026-09-03 by the data-only rollback PR, so this box reopens until the
-      re-flip.** The ONE first-party default `SERVER_EXECUTION_DEFAULT_ENABLED`
+- [x] **The flip — landed by #6535 (2026-08-28); the default has since
+      been a data-only toggle, each flip a dated delta in the coordination
+      block above.** The ONE first-party default `SERVER_EXECUTION_DEFAULT_ENABLED`
       (`packages/memory/v2/server-execution-default.ts`; the registry's
       summary table states its current value) is resolved by the
       `productionServer` / `remoteClient`
@@ -2113,12 +2113,11 @@ Tasks:
       cf-harness's fabric session; the CLI lanes probed as `cf`'s gate
       via posture adoption; `PiecesController` hosts on the default
       package/pattern lanes)*;
-      then (6) the flip PR, and the soak starts at ITS merge — **DONE, then
-      ROLLED BACK on 2026-09-03:
-      [#6535](https://github.com/commontoolsinc/labs/pull/6535) is MERGED
-      and its soak ran until the data-only rollback PR returned the default
-      to OFF (the coordination-state deltas above carry both; the ON path
-      stays selectable by explicit `true`).
+      then (6) the flip PR, and the soak starts at ITS merge — **DONE:
+      [#6535](https://github.com/commontoolsinc/labs/pull/6535) is MERGED;
+      the default has since been a data-only toggle, each flip a dated
+      delta in the coordination block above (whichever arm is not the
+      default stays selectable explicitly).
       Its first board surfaced ONE owner-court STOP — RULED AND BUILT,
       no longer standing: the verb DECLARED-RESULT surface was absent
       under ON, because receipts went unwritten under the flag by

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -3510,6 +3510,10 @@ personally; the soak starts at ITS merge.** What it carries:
   the corrected call; under OFF the same id executes. The step's ON
   comment points at this row.
 
+Delta 2026-09-03 — flip records: from here, a flip's record is the
+registry's dated status entry and the plan's coordination delta; this
+register does not repeat it.
+
 Delta 2026-09-03 — the rollback (#6840):
 
 - The first-party default returned to OFF by the first data-only flip:


### PR DESCRIPTION
## Purpose

The one-time pass that sets the documentation floor for a server-execution default flip. After #6840's neutral pass, only two places still narrated the *current* posture at length: the registry entry's own section body, and the plan's Phase 7 scoping, task, step and milestone row, which retold each flip three times. This PR makes both describe the mechanism and treat each flip as a dated record.

## What changes

- **The registry section** no longer restates the value or re-narrates its history inline: the summary cell (pinned to the constant by a test) states the current value, and the dated status entries carry the history. Its CI sentence, end state, path to removal, and summary-row cells are direction-neutral. The section now states the floor exactly: a flip is the constant, the summary cell, a dated status entry, and a plan delta.
- **The plan** treats the flip as landed once (#6535) and every later flip as a dated delta in its live coordination block: the scoping paragraph, the Phase 7 task box, the step-6 text, and the milestone row's qualifier are rewritten in that form, so none of them state the current value.
- **The register** records that from here a flip's record is the registry entry and the plan delta, and that it does not repeat them.

No source, workflow, or test changes. `#6844` (the held re-flip) rebases onto this and shrinks to the floor: the constant, the cell, a two-line status entry, a one-line plan delta.

## Verification

The docs pin and the workflow pins are green; `check-docs` and `check-test-topology` pass. A grep for moment-words in the registry section and the plan's Phase 7 finds none outside dated entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6847?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

