### PR TITLE
docs(memory): explain evaluation-cache coverage

### DIFF
--- a/docs/development/debugging/profiling.md
+++ b/docs/development/debugging/profiling.md
@@ -356,6 +356,16 @@ process:
   publication lock before evaluating. Flush passes hold that same lock, so
   a `transact` whose `lockWaitMs` dominates its elapsed time was queued
   behind fan-out, not expensive itself.
+  Read the traversal fields with the query evaluation cache's coverage in
+  mind. The cache serves only whole, current-state evaluations: an eligible
+  `graph.query` (without `atSeq` or keyed snapshots), each branch group
+  established by `session.watch.set`, and a `session.watch.add` group when that
+  session has no tracked graph for the branch yet. A subsequent
+  `session.watch.add` for an already tracked branch extends the session's graph
+  through `extendTrackedGraph()` and bypasses the cache because its result
+  depends on what the session already covers. A page load that grows its watch
+  set in batches therefore re-walks those later batches. Nonzero `rootsVisited`
+  there is expected extension work, not evidence of a cache miss.
 - `documentCaches` — the memory server's decoded-document cache, one entry
   per open space (`Engine.documentCache` in `packages/memory/v2/engine.ts`)
   under the server's `totalBudgetBytes` (beside it the total `bytes`, and

--- a/packages/memory/v2/query.ts
+++ b/packages/memory/v2/query.ts
@@ -568,6 +568,14 @@ export type QueryEvaluationCacheDiagnostics = {
  * watch corpus between two commits (a reconnect stampede after a process
  * death is this, at its worst).
  *
+ * Only whole, current-state evaluations consult the cache: an eligible
+ * `graph.query` (without `atSeq` or keyed snapshots), a whole watch-set
+ * establishment, and `session.watch.add` when the session has no tracked graph
+ * for that branch. A subsequent `session.watch.add` for an already tracked
+ * branch extends the session's graph through `extendTrackedGraph()`. An
+ * extension depends on the graph's existing coverage, so it neither serves nor
+ * records a cache entry.
+ *
  * Scope purity decides who may share an entry. An evaluation whose whole
  * reach — tracked, missed, and loaded — resolved under the `space` scope is
  * identical for every identity and is shared across them; one that touched


### PR DESCRIPTION
## Summary

- document which query entry points use `QueryEvaluationCache`
- explain why incremental `session.watch.add` extensions bypass it
- clarify how to interpret `rootsVisited` during batched page loads

This extracts the durable documentation from #6778 without adding its health
endpoint, counters, or runtime behavior changes.

## Testing

- `deno fmt --check`
- `deno lint`
- `deno task check`
- `deno task check-docs`
- `deno task check-conflict-markers`
- `cd packages/memory && deno task test` (596 passed, 464 steps)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6848?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

