### PR TITLE
perf(cli): drop global selection sync barrier

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1146,12 +1146,13 @@ reaches stdout, not to control what travels.
 
 A selection also adds a computed read after the call. The shaped readback runs
 through the same shared read step as `cf cell get`, and waits for its output
-with `Cell.pull()`; it does not add an explicit runtime-wide idle and storage
-sync between its readiness and confirmation pulls. `Cell.pull()` still uses the
-runtime scheduler and its manager-wide linked-document convergence pool, so work
-already active in that runtime can still share the wait. When isolating the read
-matters, shape the collect instead: call plain (or `--no-wait`), then
-`cf cell get --cell <receipt id> --select …`.
+with one `Cell.pull()`. That pull drives the output's transitive computation and
+linked-document loads through the runtime scheduler and its manager-wide
+convergence pool, so work already active in that runtime can still share the
+wait. Declared object keys are then ordered locally from the projection before
+rendering; that step starts no graph or storage work. When isolating the read
+matters, shape the collect instead. Call plain (or `--no-wait`), then collect
+from the receipt with `cf cell get --cell <receipt id> --select …`.
 
 Three cases follow from that:
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -886,14 +886,14 @@ about:
 
 See [what a selection means for a call](#what-a-selection-means-for-a-call) for
 the cases where the call's difference shows. `exec` is the same invocation
-reached through a mount, so it meets the value-less verb and the
-graph-quiescence coupling described there; it has neither `--no-wait` nor
-`--show-links`, so the two cases about those flags do not arise. `wish` adds one
-of its own: a query that matched nothing is an ordinary outcome rather than an
-error, so the selection is never reached and the empty result comes back as it
-always did. A selection that keeps nothing over a target that DID resolve is
-refused, because "the wish matched nothing" and "your projection kept nothing"
-are different facts.
+reached through a mount, so it meets the value-less verb and the readiness
+coupling described there; it has neither `--no-wait` nor `--show-links`, so the
+two cases about those flags do not arise. `wish` adds one of its own: a query
+that matched nothing is an ordinary outcome rather than an error, so the
+selection is never reached and the empty result comes back as it always did. A
+selection that keeps nothing over a target that DID resolve is refused, because
+"the wish matched nothing" and "your projection kept nothing" are different
+facts.
 
 `--filter` is jq-inspired rather than a full jq interpreter. It applies only to
 arrays and accepts value paths (`.status`, `.author.name`, `.["display-name"]`,
@@ -1144,13 +1144,13 @@ has happened before the selection applies.) The same holds for a tool, whose
 result is read off the cell the tool wrote. Use a selection to control what
 reaches stdout, not to control what travels.
 
-A selection also couples the call to graph quiescence. The shaped readback runs
-through the same shared read step as `cf cell get`, and that step awaits the CLI
-runtime's global idle plus storage sync before answering — while the plain call
-acknowledges at its own handling's commit. On a piece with heavy derived state,
-a shaped call can therefore wait on unrelated recomputation the handler
-triggered elsewhere in the graph. When that wait matters, shape the collect
-instead: call plain (or `--no-wait`), then
+A selection also adds a computed read after the call. The shaped readback runs
+through the same shared read step as `cf cell get`, and waits for its output
+with `Cell.pull()`; it does not add an explicit runtime-wide idle and storage
+sync between its readiness and confirmation pulls. `Cell.pull()` still uses the
+runtime scheduler and its manager-wide linked-document convergence pool, so work
+already active in that runtime can still share the wait. When isolating the read
+matters, shape the collect instead: call plain (or `--no-wait`), then
 `cf cell get --cell <receipt id> --select …`.
 
 Three cases follow from that:

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1150,9 +1150,11 @@ with one `Cell.pull()`. That pull drives the output's transitive computation and
 linked-document loads through the runtime scheduler and its manager-wide
 convergence pool, so work already active in that runtime can still share the
 wait. Declared object keys are then ordered locally from the projection before
-rendering; that step starts no graph or storage work. When isolating the read
-matters, shape the collect instead. Call plain (or `--no-wait`), then collect
-from the receipt with `cf cell get --cell <receipt id> --select …`.
+rendering, and the keys an open projection retains beyond its declaration follow
+them in the value's own order; that step starts no graph or storage work. When
+isolating the read matters, shape the collect instead. Call plain (or
+`--no-wait`), then collect from the receipt with
+`cf cell get --cell <receipt id> --select …`.
 
 Three cases follow from that:
 

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -191,9 +191,9 @@ export interface CallableExecutionDeps {
    * with `Cell.pull()`, whose scheduler and linked-document convergence pool
    * are runtime/manager-wide; a shaped call can therefore still share a wait
    * with active work that the plain call's transaction-local acknowledgment
-   * does not. It does not separately converge all storage. A verb that returns
-   * nothing keeps returning nothing — there is no value for a selection to be
-   * about. */
+   * does not. Declared object keys are ordered locally from the projection
+   * after that readiness boundary. A verb that returns nothing keeps returning
+   * nothing — there is no value for a selection to be about. */
   selection?: CellSelection;
 
   /** @internal Seam for tests, mirroring `getCellValue`'s. */

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -187,12 +187,12 @@ export interface CallableExecutionDeps {
    * readback has already materialized the whole receipt by the time this
    * applies. (A plain result's receipt does carry a descriptive schema of
    * what it holds — a reactive result's carries none — but either way the
-   * fetch has happened first.) The shared step also awaits the runtime's
-   * global idle plus storage sync, so a shaped call result can wait on
-   * derived recomputation the plain call's transaction-local acknowledgment
-   * does not — a documented cost of shaping at the call
-   * (`deriveSelectedValue`, cell-selection.ts). A verb that returns nothing
-   * keeps returning nothing — there is no value for a selection to be
+   * fetch has happened first.) The shared step waits for its computed output
+   * with `Cell.pull()`, whose scheduler and linked-document convergence pool
+   * are runtime/manager-wide; a shaped call can therefore still share a wait
+   * with active work that the plain call's transaction-local acknowledgment
+   * does not. It does not separately converge all storage. A verb that returns
+   * nothing keeps returning nothing — there is no value for a selection to be
    * about. */
   selection?: CellSelection;
 

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -192,7 +192,8 @@ export interface CallableExecutionDeps {
    * are runtime/manager-wide; a shaped call can therefore still share a wait
    * with active work that the plain call's transaction-local acknowledgment
    * does not. Declared object keys are ordered locally from the projection
-   * after that readiness boundary. A verb that returns nothing keeps returning
+   * after that readiness boundary, with an open projection's retained extras
+   * following in value order. A verb that returns nothing keeps returning
    * nothing — there is no value for a selection to be about. */
   selection?: CellSelection;
 

--- a/packages/cli/lib/cell-selection.ts
+++ b/packages/cli/lib/cell-selection.ts
@@ -3404,17 +3404,20 @@ export async function deriveSelectedValue(
         `Could not apply get transform: ${committed.error}`,
       );
     }
-    // pull() is the narrowest existing readiness boundary for this output: it
-    // drives transitive computations, waits for linked documents those reads
-    // discover, and re-idles after each arrival. Keep the confirmation pull;
-    // besides being cheap once current, it preserves byte-identical projected
-    // object order across get, call, wish, and exec. Explicit runtime.idle()
-    // and storageManager.synced() calls between the pulls instead widen the
-    // boundary to unrelated reactive and storage work without strengthening
-    // the selected output's guarantee.
+    // pull() is the readiness boundary for this output: it drives transitive
+    // computations, waits for linked documents those reads discover, and
+    // re-idles after each arrival.
     await timeSelectionPhase("output.pull", () => outputCell.pull());
-    await timeSelectionPhase("output.pull.confirm", () => outputCell.pull());
     const outputValue = outputCell.get();
+    // Runtime materialization can expose object children in arrival order.
+    // Apply the resolved projection to the value in hand so declared fields
+    // instead follow schema order. This is local value work and starts no graph
+    // or storage operation.
+    const orderedOutput = projection === undefined ? outputValue : projectValue(
+      outputValue,
+      projection.projectionSchema,
+      implicitArrayTraversal,
+    );
     const recorded = errors.slice(errorCountBefore);
     if (recorded.length > 0) {
       // Translate the array-shape errors emitted by the runner filter/map
@@ -3446,10 +3449,10 @@ export async function deriveSelectedValue(
       );
     }
     deps.onOutputCell?.(outputCell);
-    return markers === undefined ? outputValue : await composeLinkAddresses(
+    return markers === undefined ? orderedOutput : await composeLinkAddresses(
       sourcePosition(sourceValueCell, space),
       markers,
-      outputValue,
+      orderedOutput,
       implicitArrayTraversal,
     );
   } finally {

--- a/packages/cli/lib/cell-selection.ts
+++ b/packages/cli/lib/cell-selection.ts
@@ -3404,25 +3404,16 @@ export async function deriveSelectedValue(
         `Could not apply get transform: ${committed.error}`,
       );
     }
-    // This wait is GLOBAL: idle() drains the whole reactive graph and
-    // synced() the whole storage manager, not just this transform. On a
-    // plain `cf cell get` that is benign — nothing else runs in the CLI's
-    // runtime — but a shaped `cf piece call` readback arrives here right after
-    // its handler ran, so the selection waits on whatever derived
-    // recomputation that handler triggered elsewhere, a coupling the plain
-    // call's transaction-local acknowledgment deliberately avoids.
-    // Documented as a known cost of shaping at the call (decided
-    // 2026-08-14; packages/cli/README.md names the shape-the-collect
-    // alternative); scoping this wait to the transform's own computation is
-    // the named follow-up.
-    await timeSelectionPhase("output.pull.beforeIdle", () => outputCell.pull());
-    await timeSelectionPhase("runtime.idle.beforeSync", () => runtime.idle());
-    await timeSelectionPhase(
-      "storage.synced",
-      () => runtime.storageManager.synced(),
-    );
-    await timeSelectionPhase("output.pull.afterSync", () => outputCell.pull());
-    await timeSelectionPhase("runtime.idle.afterSync", () => runtime.idle());
+    // pull() is the narrowest existing readiness boundary for this output: it
+    // drives transitive computations, waits for linked documents those reads
+    // discover, and re-idles after each arrival. Keep the confirmation pull;
+    // besides being cheap once current, it preserves byte-identical projected
+    // object order across get, call, wish, and exec. Explicit runtime.idle()
+    // and storageManager.synced() calls between the pulls instead widen the
+    // boundary to unrelated reactive and storage work without strengthening
+    // the selected output's guarantee.
+    await timeSelectionPhase("output.pull", () => outputCell.pull());
+    await timeSelectionPhase("output.pull.confirm", () => outputCell.pull());
     const outputValue = outputCell.get();
     const recorded = errors.slice(errorCountBefore);
     if (recorded.length > 0) {

--- a/packages/cli/lib/cell-selection.ts
+++ b/packages/cli/lib/cell-selection.ts
@@ -2152,11 +2152,18 @@ function projectValue(
   const properties = schema.properties ?? {};
   const projected: Record<string, unknown> = {};
   if (schema.additionalProperties !== false) {
-    for (const [key, child] of Object.entries(value)) {
+    // Declared keys first, in schema order, so an open projection renders
+    // its declared fields the way a closed one does; the keys it retains
+    // beyond the declaration follow in the value's own order.
+    const keys = [
+      ...Object.keys(properties).filter((key) => key in value),
+      ...Object.keys(value).filter((key) => !(key in properties)),
+    ];
+    for (const key of keys) {
       const childSchema = properties[key] ?? schema.additionalProperties ??
         true;
       projected[key] = projectValue(
-        child,
+        value[key],
         childSchema,
         implicitArrayTraversal,
         keepComposedAddresses,
@@ -3411,8 +3418,10 @@ export async function deriveSelectedValue(
     const outputValue = outputCell.get();
     // Runtime materialization can expose object children in arrival order.
     // Apply the resolved projection to the value in hand so declared fields
-    // instead follow schema order. This is local value work and starts no graph
-    // or storage operation.
+    // instead follow schema order, closed and open projections alike; the
+    // keys an open projection retains beyond its declaration follow, in the
+    // value's own order. This is local value work and starts no graph or
+    // storage operation.
     const orderedOutput = projection === undefined ? outputValue : projectValue(
       outputValue,
       projection.projectionSchema,

--- a/packages/cli/lib/cell-selection.ts
+++ b/packages/cli/lib/cell-selection.ts
@@ -2154,14 +2154,17 @@ function projectValue(
   if (schema.additionalProperties !== false) {
     // Declared keys first, in schema order, so an open projection renders
     // its declared fields the way a closed one does; the keys it retains
-    // beyond the declaration follow in the value's own order.
+    // beyond the declaration follow in the value's own order. Own keys
+    // only: `in` walks the prototype chain, and a stored key spelled like
+    // an `Object.prototype` member (`toString`, `constructor`) is data here.
     const keys = [
-      ...Object.keys(properties).filter((key) => key in value),
-      ...Object.keys(value).filter((key) => !(key in properties)),
+      ...Object.keys(properties).filter((key) => Object.hasOwn(value, key)),
+      ...Object.keys(value).filter((key) => !Object.hasOwn(properties, key)),
     ];
     for (const key of keys) {
-      const childSchema = properties[key] ?? schema.additionalProperties ??
-        true;
+      const childSchema = Object.hasOwn(properties, key)
+        ? properties[key]
+        : schema.additionalProperties ?? true;
       projected[key] = projectValue(
         value[key],
         childSchema,
@@ -2172,7 +2175,9 @@ function projectValue(
     return projected;
   }
   for (const [key, childSchema] of Object.entries(properties)) {
-    if (key in value) {
+    // Own keys only, as above: a declared `toString` the value does not
+    // hold must not emit `Object.prototype.toString`.
+    if (Object.hasOwn(value, key)) {
       projected[key] = projectValue(
         value[key],
         childSchema,
@@ -2359,7 +2364,7 @@ export function selectSourceSchema(
   // those types in hand and applies the rule entire, in
   // {@link outputSchemaWithSourceRequired}.
   const selectedRequired = required?.filter((key) =>
-    key in properties && properties[key] !== false
+    Object.hasOwn(properties, key) && properties[key] !== false
   );
   return {
     ...metadata,
@@ -3413,7 +3418,12 @@ export async function deriveSelectedValue(
     }
     // pull() is the readiness boundary for this output: it drives transitive
     // computations, waits for linked documents those reads discover, and
-    // re-idles after each arrival.
+    // re-idles after each arrival. Nothing downstream re-checks it: the
+    // re-projection below imposes key order locally, so a pull that stopped
+    // short of the fixpoint would no longer show as an out-of-order key (what
+    // the four-entrypoint test could see) but as a silently absent one. The
+    // cold and stale session-scoped integration reads are what stand behind
+    // one pull sufficing.
     await timeSelectionPhase("output.pull", () => outputCell.pull());
     const outputValue = outputCell.get();
     // Runtime materialization can expose object children in arrival order.
@@ -3501,7 +3511,7 @@ function markersHeldBy(
     const properties: Record<string, LinkMarkers> = {};
     for (const [key, child] of Object.entries(markers.properties)) {
       const below = held.flatMap((value) =>
-        isObjectNotArray(value) && key in value
+        isObjectNotArray(value) && Object.hasOwn(value, key)
           ? [(value as Record<string, unknown>)[key]]
           : []
       );

--- a/packages/cli/test/piece-get-transform.test.ts
+++ b/packages/cli/test/piece-get-transform.test.ts
@@ -2053,6 +2053,47 @@ describe("cf cell get transforms", () => {
     }
   });
 
+  it("answers from the selected output without a storage-wide sync", async () => {
+    const setup = runtime.edit();
+    const source = runtime.getCell(
+      space,
+      "transform-output-readiness-source",
+      {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            id: { type: "number" },
+            ignored: { type: "string" },
+          },
+        },
+      },
+      setup,
+    );
+    source.set([
+      { id: 1, ignored: "not selected" },
+      { id: 2, ignored: "not selected" },
+    ]);
+    expect((await setup.commit()).ok).toBeDefined();
+
+    const originalSynced = storageManager.synced.bind(storageManager);
+    let storageWideSyncs = 0;
+    storageManager.synced = () => {
+      storageWideSyncs++;
+      return originalSynced();
+    };
+    try {
+      expect(
+        await deriveSelectedValue(runtime, space, source, {
+          projection: parseSelectProjection("id"),
+        }),
+      ).toEqual([{ id: 1 }, { id: 2 }]);
+      expect(storageWideSyncs).toBe(0);
+    } finally {
+      storageManager.synced = originalSynced;
+    }
+  });
+
   describe("the labels a selection carries", () => {
     // The two assertions here read a derived label component back out of
     // storage through `derivedConfidentiality`. Persisting flow labels

--- a/packages/cli/test/piece-get-transform.test.ts
+++ b/packages/cli/test/piece-get-transform.test.ts
@@ -2053,7 +2053,7 @@ describe("cf cell get transforms", () => {
     }
   });
 
-  it("answers from the selected output without a storage-wide sync", async () => {
+  it("returns projection-ordered output without a storage-wide sync", async () => {
     const setup = runtime.edit();
     const source = runtime.getCell(
       space,
@@ -2064,6 +2064,7 @@ describe("cf cell get transforms", () => {
           type: "object",
           properties: {
             id: { type: "number" },
+            label: { type: "string" },
             ignored: { type: "string" },
           },
         },
@@ -2071,8 +2072,8 @@ describe("cf cell get transforms", () => {
       setup,
     );
     source.set([
-      { id: 1, ignored: "not selected" },
-      { id: 2, ignored: "not selected" },
+      { id: 1, label: "first", ignored: "not selected" },
+      { id: 2, label: "second", ignored: "not selected" },
     ]);
     expect((await setup.commit()).ok).toBeDefined();
 
@@ -2083,11 +2084,16 @@ describe("cf cell get transforms", () => {
       return originalSynced();
     };
     try {
-      expect(
-        await deriveSelectedValue(runtime, space, source, {
-          projection: parseSelectProjection("id"),
-        }),
-      ).toEqual([{ id: 1 }, { id: 2 }]);
+      const result = await deriveSelectedValue(runtime, space, source, {
+        projection: parseSelectProjection("label,id"),
+      });
+      expect(result).toEqual([
+        { label: "first", id: 1 },
+        { label: "second", id: 2 },
+      ]);
+      expect(JSON.stringify(result)).toBe(
+        '[{"label":"first","id":1},{"label":"second","id":2}]',
+      );
       expect(storageWideSyncs).toBe(0);
     } finally {
       storageManager.synced = originalSynced;

--- a/packages/cli/test/piece-get-transform.test.ts
+++ b/packages/cli/test/piece-get-transform.test.ts
@@ -2100,41 +2100,73 @@ describe("cf cell get transforms", () => {
     }
   });
 
-  it("orders an open projection's declared keys first, then retained extras", async () => {
+  it("orders an open projection's declared keys first, then retained extras in value order", async () => {
     const setup = runtime.edit();
+    // The `toString` entry is added by key: in an object literal TypeScript
+    // types a property of that name as `Object.prototype.toString` and
+    // refuses the schema.
+    const sourceProperties: Record<string, JSONSchema> = {
+      id: { type: "number" },
+      zeta: { type: "string" },
+      label: { type: "string" },
+      alpha: { type: "string" },
+    };
+    sourceProperties["toString"] = { type: "string" };
     const source = runtime.getCell(
       space,
       "transform-open-projection-order-source",
-      {
-        type: "array",
-        items: {
-          type: "object",
-          properties: {
-            id: { type: "number" },
-            label: { type: "string" },
-            extra: { type: "string" },
-          },
-        },
-      },
+      { type: "object", properties: sourceProperties },
       setup,
     );
-    source.set([
-      { id: 1, label: "first", extra: "kept" },
-      { id: 2, label: "second", extra: "kept" },
-    ]);
+    // Three extras beyond the declaration, one of them spelled like an
+    // `Object.prototype` member, which `in` would have mistaken for
+    // present-on-every-object and dropped.
+    source.set({
+      id: 1,
+      zeta: "z",
+      label: "first",
+      toString: "own",
+      alpha: "a",
+    });
     expect((await setup.commit()).ok).toBeDefined();
 
-    // Open (`additionalProperties: true`) and declaring `label` before `id`,
-    // against a value stored as id, label, extra: the declaration orders the
-    // keys it names, and what the projection retains beyond it follows.
+    // Open (`additionalProperties: true`) and declaring `label` before `id`:
+    // the declaration orders the keys it names, and what the projection
+    // retains beyond it follows in the order the value holds them — which,
+    // after a storage round trip, is the canonical (sorted) order the
+    // materialized value arrives in, not the order `set()` was handed.
     const result = await deriveSelectedValue(runtime, space, source, {
       projection: await parseSelectionProjection(
-        '{"type":"array","items":{"type":"object","properties":{"label":true,"id":true},"additionalProperties":true}}',
+        '{"type":"object","properties":{"label":true,"id":true},"additionalProperties":true}',
       ),
     });
     expect(JSON.stringify(result)).toBe(
-      '[{"label":"first","id":1,"extra":"kept"},{"label":"second","id":2,"extra":"kept"}]',
+      '{"label":"first","id":1,"alpha":"a","toString":"own","zeta":"z"}',
     );
+  });
+
+  it("a closed projection emits only keys the value holds, prototype names included", async () => {
+    const setup = runtime.edit();
+    const sourceProperties: Record<string, JSONSchema> = {
+      label: { type: "string" },
+    };
+    sourceProperties["toString"] = { type: "string" };
+    const source = runtime.getCell(
+      space,
+      "transform-closed-projection-prototype-source",
+      { type: "object", properties: sourceProperties },
+      setup,
+    );
+    source.set({ label: "only" });
+    expect((await setup.commit()).ok).toBeDefined();
+
+    // `toString` is selected but absent from the value; `in` would have
+    // found `Object.prototype.toString` and emitted the native function.
+    const result = await deriveSelectedValue(runtime, space, source, {
+      projection: parseSelectProjection("label,toString"),
+    }) as Record<string, unknown>;
+    expect(Object.keys(result)).toEqual(["label"]);
+    expect(Object.hasOwn(result, "toString")).toBe(false);
   });
 
   describe("the labels a selection carries", () => {

--- a/packages/cli/test/piece-get-transform.test.ts
+++ b/packages/cli/test/piece-get-transform.test.ts
@@ -2100,6 +2100,43 @@ describe("cf cell get transforms", () => {
     }
   });
 
+  it("orders an open projection's declared keys first, then retained extras", async () => {
+    const setup = runtime.edit();
+    const source = runtime.getCell(
+      space,
+      "transform-open-projection-order-source",
+      {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            id: { type: "number" },
+            label: { type: "string" },
+            extra: { type: "string" },
+          },
+        },
+      },
+      setup,
+    );
+    source.set([
+      { id: 1, label: "first", extra: "kept" },
+      { id: 2, label: "second", extra: "kept" },
+    ]);
+    expect((await setup.commit()).ok).toBeDefined();
+
+    // Open (`additionalProperties: true`) and declaring `label` before `id`,
+    // against a value stored as id, label, extra: the declaration orders the
+    // keys it names, and what the projection retains beyond it follows.
+    const result = await deriveSelectedValue(runtime, space, source, {
+      projection: await parseSelectionProjection(
+        '{"type":"array","items":{"type":"object","properties":{"label":true,"id":true},"additionalProperties":true}}',
+      ),
+    });
+    expect(JSON.stringify(result)).toBe(
+      '[{"label":"first","id":1,"extra":"kept"},{"label":"second","id":2,"extra":"kept"}]',
+    );
+  });
+
   describe("the labels a selection carries", () => {
     // The two assertions here read a derived label component back out of
     // storage through `derivedConfidentiality`. Persisting flow labels

--- a/packages/cli/test/piece-integration.test.ts
+++ b/packages/cli/test/piece-integration.test.ts
@@ -51,6 +51,8 @@ let pieceId = "";
 let sessionResultPieceId = "";
 let coldSessionResultPieceId = "";
 let staleSessionResultPieceId = "";
+let coldSelectionResultPieceId = "";
+let staleSelectionResultPieceId = "";
 let sessionScopedPieceId = "";
 let flags = "";
 let identityPath = "";
@@ -119,6 +121,14 @@ describe("cf cell get (integration)", { ignore: !API_URL }, () => {
       rootPath: REPO_ROOT,
     }, { start: false });
     staleSessionResultPieceId = await newPiece(spaceConfig, {
+      mainPath: SESSION_RESULT_PATTERN,
+      rootPath: REPO_ROOT,
+    }, { start: false });
+    coldSelectionResultPieceId = await newPiece(spaceConfig, {
+      mainPath: SESSION_RESULT_PATTERN,
+      rootPath: REPO_ROOT,
+    }, { start: false });
+    staleSelectionResultPieceId = await newPiece(spaceConfig, {
       mainPath: SESSION_RESULT_PATTERN,
       rootPath: REPO_ROOT,
     }, { start: false });
@@ -258,6 +268,34 @@ describe("cf cell get (integration)", { ignore: !API_URL }, () => {
     );
     expect(code, stderr.join("\n")).toBe(0);
     expect(JSON.parse(stdout.join(""))).toEqual(["updated-while-stopped"]);
+  });
+
+  it("selects a cold session-scoped computed result", async () => {
+    const sessionFlags =
+      `--api-url ${API_URL} --identity ${identityPath} --space ${spaceConfig.space} --piece ${coldSelectionResultPieceId}`;
+    const { code, stdout, stderr } = await integrationCf(
+      `cell get ${sessionFlags} --step --select value`,
+    );
+    expect(code, stderr.join("\n")).toBe(0);
+    expect(JSON.parse(stdout.join(""))).toEqual({ value: "session-ready" });
+  });
+
+  it("selects a current result after changing an unstarted piece's input", async () => {
+    const sessionFlags =
+      `--api-url ${API_URL} --identity ${identityPath} --space ${spaceConfig.space} --piece ${staleSelectionResultPieceId}`;
+    const write = await integrationCf(
+      `cell set ${sessionFlags} values --input`,
+      { stdin: '["selected-while-stopped"]' },
+    );
+    expect(write.code, write.stderr.join("\n")).toBe(0);
+
+    const { code, stdout, stderr } = await integrationCf(
+      `cell get ${sessionFlags} --step --select value`,
+    );
+    expect(code, stderr.join("\n")).toBe(0);
+    expect(JSON.parse(stdout.join(""))).toEqual({
+      value: "selected-while-stopped",
+    });
   });
 
   it("list and inspect expose the running pattern reference", async () => {

--- a/packages/cli/test/read-options-four-ways.test.ts
+++ b/packages/cli/test/read-options-four-ways.test.ts
@@ -333,10 +333,17 @@ describe("read options, four ways", () => {
       "exec": expected,
     });
 
-    // And identically: one rendering, not four that happen to agree in
-    // content. Key order is part of what a caller diffs, so the comparison is
-    // over the bytes `render()` writes.
-    expect(new Set(Object.values(rendered)).size).toBe(1);
+    // And identically in the order the selection names: one expected rendering,
+    // not four values that happen to agree in content. Key order is part of
+    // what a caller diffs, so the comparison is over the bytes `render()`
+    // writes.
+    const expectedRendering = safeStringify(expected);
+    expect(rendered).toEqual({
+      "piece get": expectedRendering,
+      "piece call": expectedRendering,
+      "wish": expectedRendering,
+      "exec": expectedRendering,
+    });
   });
 
   it("names one cell's address through get, call, wish and exec", async () => {


### PR DESCRIPTION
## Summary

- stop selection readback from explicitly idling the whole runtime and syncing the whole storage manager
- use one output `Cell.pull()` as the readiness boundary for transitive computation and linked-document convergence
- deterministically order declared object keys by reapplying the already-resolved projection to the value in hand; this is local value work and starts no graph or storage operation
- cover the absence of a storage-wide sync and byte-exact ordering for arrays of multi-key objects, plus cold and stale session-scoped selection reads in both server-execution modes
- update the CLI readiness documentation to describe the positive guarantee

This is deliberately a separate follow-up to merged #6841. Path-scoped stepping and selection-output readiness are independent performance boundaries with different correctness risks, so each can be reviewed, measured, and reverted on its own.

## Deployed Topics evidence

Command: the documented 157-row `index --step --select @,title,createdAt,lastActivityAt,commentCount,createdBy.kind,createdBy.name` survey against Estuary, with `serverExecution=false`.

Stacked base (#6841):

- target pull: 91 ms
- selection commit: 170 ms
- first output pull: 1.478 s
- explicit storage sync: 30.082 s
- confirmation pull: 245 ms
- selection total: 32.008 s

Initial version of this branch:

- target pull: 123 ms
- selection commit: 211 ms
- first output pull: 2.301 s
- confirmation pull: 29 ms
- selection total: 2.595 s

That removed the repeatable 30-second storage-wide barrier and cut the measured selection phase by 91.9% (12.3x), while returning the same 157 rows. Whole-piece startup remained the largest stepped cost at 11.870 s.

The initial Estuary observation did **not** establish that projected key order was stable across repeated fresh processes. Review reproduced a one-pull ordering race locally, so the follow-up removes the confirmation pull and makes order deterministic locally from the projection. With that fix, five fresh CLI processes against the deployed board all rendered `title,createdAt,lastActivityAt,commentCount` in exactly that order. Each trace contained one output pull and no confirmation pull; this narrower deep-read workload is an ordering check, not a new comparison to the 157-row timing above.

## Review follow-up

- reproduced the one-pull race before the fix (1 failure in 10; diagnostic logging itself perturbed the timing)
- confirmed concise `--select name,bio` resolves to a closed schema (`additionalProperties: false`), so the suspected open-object projection branch was not involved
- removed the second pull and reapplied the resolved projection after readiness, preserving selection order without another graph or storage wait
- changed the array regression to select two fields in non-source order and assert the exact JSON bytes
- strengthened the four-entrypoint test to compare each rendering to the expected selection-order bytes, not merely to one another

## Correctness and checks

- one-pull four-entrypoint stress: 50/50 passes
- byte-exact array-order stress: 25/25 passes
- seven selection-related suites: 7 passed / 190 steps
- full CLI package: parallel 1778 passed / 2029 steps; all-access 1 passed / 3 ignored steps; serial 211 passed / 217 steps
- local Toolshed integration runner passed with server execution OFF and ON, including the projected-read and verb-result walkthroughs
- repository-wide `deno fmt --check`, `deno lint`, and `deno task check`
- `deno task check-docs` (599 code blocks)
- `deno task check-skill-facts` (49 documents)
- GitHub CI: 66 checks passed / 3 skipped / 0 failed

## Remaining boundary

`Cell.pull()` is the narrowest existing output-readiness primitive, but it still uses the runtime-global scheduler and the storage-manager-wide linked-document convergence pool. The Topics `index` also bounds each Topic field width rather than its document count: every row remains a link to the Topic, preserving the important row-address-is-topic-address contract, so a cold survey can still load up to 157 linked documents. Those are separate runtime/index-design investigations, not folded into this targeted barrier removal.
