### PR TITLE
fix(runner): a failing assertion renders its operands to full depth

### DIFF
--- a/packages/data-model/src/api.ts
+++ b/packages/data-model/src/api.ts
@@ -446,10 +446,11 @@ export interface FabricPlainObject
  */
 export interface DebugValueOptions {
   /**
-   * Maximum depth of result nesting, a positive integer. An item which would
-   * require further nesting is instead converted into a form suggestive of the
-   * elided information. When absent, the depth is the default of the function
-   * called: as deep as reasonably possible for a structured value, and ten
+   * Maximum depth of result nesting: a positive integer, or `Infinity` for as
+   * deep as the conversion allows. An item which would require further
+   * nesting is instead converted into a form suggestive of the elided
+   * information. When absent, the depth is the default of the function
+   * called: as deep as the conversion allows for a structured value, and ten
    * levels for a debug string. A large value is capped; there is no guarantee
    * about the _actual_ possible maximum depth.
    */
@@ -467,9 +468,10 @@ export interface DebugValueOptions {
 /** Options accepted by `toCompactDebugString()`. */
 export interface CompactDebugStringOptions extends DebugValueOptions {
   /**
-   * Maximum length of the result. When the rendering runs longer, the result
-   * is truncated to this length, which includes a trailing ASCII ellipsis of
-   * `...`. A length below three is taken as three.
+   * Maximum length of the result, or `Infinity` for no limit. When the
+   * rendering runs longer, the result is truncated to this length, which
+   * includes a trailing ASCII ellipsis of `...`. A length below three is taken
+   * as three.
    */
   readonly maxLength?: number;
 }

--- a/packages/data-model/src/value-debug.ts
+++ b/packages/data-model/src/value-debug.ts
@@ -741,7 +741,7 @@ class DebugStringifier {
  * `defaultMaxDepth` when not, either one capped at `ABSOLUTE_MAX_DEPTH`.
  *
  * @throws {Error} if `options` is not a plain object, or if its `maxDepth` is
- * not a positive integer.
+ * neither a positive integer nor `Infinity`.
  */
 function checkedMaxDepth(
   options: DebugValueOptions | undefined,
@@ -760,7 +760,10 @@ function checkedMaxDepth(
 
   switch (typeof maxDepth) {
     case "number": {
-      if (Number.isSafeInteger(maxDepth) && (maxDepth > 0)) {
+      if (
+        (Number.isSafeInteger(maxDepth) && (maxDepth > 0)) ||
+        (maxDepth === Infinity)
+      ) {
         return Math.min(maxDepth, ABSOLUTE_MAX_DEPTH);
       }
       break;
@@ -774,7 +777,7 @@ function checkedMaxDepth(
     toCompactDebugString(maxDepth, { maxLength: 20 }),
   );
   throw new Error(
-    `\`maxDepth\` must be a positive integer or \`undefined\`; got ${badDepth}`,
+    `\`maxDepth\` must be a positive integer, \`Infinity\`, or \`undefined\`; got ${badDepth}`,
   );
 }
 

--- a/packages/data-model/test/value-debug-structured.test.ts
+++ b/packages/data-model/test/value-debug-structured.test.ts
@@ -387,10 +387,26 @@ describe("toStructuredDebugValue()", () => {
       expect(at).toEqual({ "/...": "object" });
     });
 
+    it("returns a result as deep as the conversion allows given `Infinity`", () => {
+      let value: unknown = 1;
+      for (let i = 0; i < 300; i++) value = { o: value };
+
+      let at = toStructuredDebugValue(value, { maxDepth: Infinity }) as Record<
+        string,
+        unknown
+      >;
+      let levels = 0;
+      while (at && (typeof at === "object") && ("o" in at)) {
+        at = at.o as Record<string, unknown>;
+        levels++;
+      }
+      expect(levels).toBe(99);
+    });
+
     it("throws given a `maxDepth` that is not a positive integer", () => {
-      for (const bad of [0, -1, 1.5, Infinity, NaN]) {
+      for (const bad of [0, -1, 1.5, -Infinity, NaN]) {
         expect(() => toStructuredDebugValue({}, { maxDepth: bad }))
-          .toThrow("`maxDepth` must be a positive integer or `undefined`");
+          .toThrow("`maxDepth` must be a positive integer, `Infinity`, or");
       }
     });
 
@@ -398,7 +414,7 @@ describe("toStructuredDebugValue()", () => {
       for (const bad of ["3", null, {}]) {
         const options = { maxDepth: bad as unknown as number };
         expect(() => toStructuredDebugValue({}, options))
-          .toThrow("`maxDepth` must be a positive integer or `undefined`");
+          .toThrow("`maxDepth` must be a positive integer, `Infinity`, or");
       }
     });
   });

--- a/packages/data-model/test/value-debug.test.ts
+++ b/packages/data-model/test/value-debug.test.ts
@@ -102,6 +102,15 @@ describe("value-debug", () => {
         );
       });
 
+      it("renders past the default depth given `Infinity`", () => {
+        let value: unknown = "leaf";
+        for (let i = 0; i < 20; i++) value = { o: value };
+        expect(toCompactDebugString(value, { maxDepth: Infinity }))
+          .toContain('"leaf"');
+        expect(toIndentedDebugString(value, { maxDepth: Infinity }))
+          .toContain('"leaf"');
+      });
+
       it("throws given a `maxDepth` that is not a positive integer", () => {
         expect(() => toCompactDebugString({}, { maxDepth: 0 }))
           .toThrow("`maxDepth` must be a positive integer, `Infinity`, or");

--- a/packages/data-model/test/value-debug.test.ts
+++ b/packages/data-model/test/value-debug.test.ts
@@ -66,6 +66,12 @@ describe("value-debug", () => {
     });
 
     describe("with `maxLength`", () => {
+      it("renders the full text given a `maxLength` of `Infinity`", () => {
+        const item = { text: "x".repeat(200) };
+        expect(toCompactDebugString(item, { maxLength: Infinity }))
+          .toBe(toCompactDebugString(item));
+      });
+
       for (const len of [10, 25, 100]) {
         it("renders the full text when `maxLength` fits the whole thing", () => {
           const item = ["xy", NaN];
@@ -98,7 +104,7 @@ describe("value-debug", () => {
 
       it("throws given a `maxDepth` that is not a positive integer", () => {
         expect(() => toCompactDebugString({}, { maxDepth: 0 }))
-          .toThrow("`maxDepth` must be a positive integer or `undefined`");
+          .toThrow("`maxDepth` must be a positive integer, `Infinity`, or");
       });
     });
 

--- a/packages/runner/src/builder/module.ts
+++ b/packages/runner/src/builder/module.ts
@@ -352,12 +352,20 @@ export const assertCapture = <T>(
 };
 
 /**
+ * Nesting depth a failing assertion's operand renders to: as deep as the
+ * conversion allows. A view tree costs two levels per node and a nested cell
+ * three, so the renderer's default depth elides an operand after a handful
+ * of nodes, and a diagnostic wants the whole of it.
+ */
+const ASSERT_RENDER_MAX_DEPTH = Number.MAX_SAFE_INTEGER;
+
+/**
  * Renders the operands captured by `assertCapture` into the record's `parts`.
  *
  * A passing assertion (`ok === true`) returns an empty list without touching
  * the values, so the common case pays nothing to render diagnostics it will
  * never show. Only a failing assertion renders each captured value with
- * `toCompactDebugString`.
+ * `toCompactDebugString`, to `ASSERT_RENDER_MAX_DEPTH`.
  */
 export const assertRenderParts = (
   ok: boolean,
@@ -365,7 +373,9 @@ export const assertRenderParts = (
 ): AssertPart[] =>
   ok ? [] : parts.map(({ src, value }) => ({
     src,
-    rendered: toCompactDebugString(value),
+    rendered: toCompactDebugString(value, {
+      maxDepth: ASSERT_RENDER_MAX_DEPTH,
+    }),
   }));
 
 /**

--- a/packages/runner/src/builder/module.ts
+++ b/packages/runner/src/builder/module.ts
@@ -357,7 +357,7 @@ export const assertCapture = <T>(
  * three, so the renderer's default depth elides an operand after a handful
  * of nodes, and a diagnostic wants the whole of it.
  */
-const ASSERT_RENDER_MAX_DEPTH = Number.MAX_SAFE_INTEGER;
+const ASSERT_RENDER_MAX_DEPTH = Infinity;
 
 /**
  * Renders the operands captured by `assertCapture` into the record's `parts`.

--- a/packages/runner/test/module.test.ts
+++ b/packages/runner/test/module.test.ts
@@ -255,6 +255,18 @@ describe("module", () => {
         { src: "items", rendered: "[1,-2]" },
       ]);
     });
+
+    it("renders a deeply nested operand down to its leaf", () => {
+      // A view tree nests two levels per node, so a diagnostic for one soon
+      // runs past the renderer's default depth; the leaf here sits well past
+      // it.
+
+      let value: unknown = "leaf";
+      for (let i = 0; i < 30; i++) value = { children: [value] };
+      const [part] = assertRenderParts(false, [{ src: "tree", value }]);
+      expect(part.rendered).toContain('"leaf"');
+      expect(part.rendered).not.toContain("...");
+    });
   });
 
   describe("handler function", () => {

--- a/packages/static/assets/types/commonfabric.d.ts
+++ b/packages/static/assets/types/commonfabric.d.ts
@@ -489,10 +489,11 @@ export interface FabricPlainObject
  */
 export interface DebugValueOptions {
   /**
-   * Maximum depth of result nesting, a positive integer. An item which would
-   * require further nesting is instead converted into a form suggestive of the
-   * elided information. When absent, the depth is the default of the function
-   * called: as deep as reasonably possible for a structured value, and ten
+   * Maximum depth of result nesting: a positive integer, or `Infinity` for as
+   * deep as the conversion allows. An item which would require further
+   * nesting is instead converted into a form suggestive of the elided
+   * information. When absent, the depth is the default of the function
+   * called: as deep as the conversion allows for a structured value, and ten
    * levels for a debug string. A large value is capped; there is no guarantee
    * about the _actual_ possible maximum depth.
    */
@@ -510,9 +511,10 @@ export interface DebugValueOptions {
 /** Options accepted by `toCompactDebugString()`. */
 export interface CompactDebugStringOptions extends DebugValueOptions {
   /**
-   * Maximum length of the result. When the rendering runs longer, the result
-   * is truncated to this length, which includes a trailing ASCII ellipsis of
-   * `...`. A length below three is taken as three.
+   * Maximum length of the result, or `Infinity` for no limit. When the
+   * rendering runs longer, the result is truncated to this length, which
+   * includes a trailing ASCII ellipsis of `...`. A length below three is taken
+   * as three.
    */
   readonly maxLength?: number;
 }


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Fable 5.1)

## What

A failing pattern-test assertion renders its operands to full depth.
`assertRenderParts()` passes the debug renderer a `maxDepth` of "as deep as
the conversion allows", where before it took the renderer's default of ten
levels.

## Why

A view tree costs two levels per node and a nested cell three, so the
default elided a failing `[UI]` assertion's operand after about five nodes,
where the same diagnostic used to print the whole tree. The depth option
landed in #6825; this is the caller that wanted it.

## Side quest

`maxDepth` and `maxLength` accept `Infinity`, which says "as deep as the
conversion allows" and "no length limit" outright where a large integer only
implied them; the conversion's own ceiling still applies to depth. The
assertion renderer passes `Infinity`. Both option docs and the pattern-facing
type file say so.

## Tests

A thirty-deep operand renders down to its leaf with nothing elided;
`maxDepth: Infinity` converts to the conversion's ceiling, and renders past
the default depth through both string renderers; `maxLength: Infinity`
truncates nothing.

## Verification

`deno check` and `lint` on the two files; the runner suite.

## Coverage

`packages/runner/src/speculation/overlay-destination.ts:1773` flipped on
the third head with the file untouched by this PR and byte-identical across
all three heads; the runner group's count is known to vary on identical
source.

ACCEPT_COVERAGE_DEBT: packages/runner +1 line
