### PR TITLE
fix(deno-web-test): a run removes the directories it made

### DIFF
--- a/packages/deno-web-test/README.md
+++ b/packages/deno-web-test/README.md
@@ -98,5 +98,6 @@ For testing `deno-web-test` itself, the test suites (running in Deno itself) run
 `deno-web-test` for subprojects to test features. Due to being in a workspace,
 and not wanting to clutter the workspace with these test directories, and Deno
 attempting to enforce this, the test packages are moved to a temporary directory
-and the test task rewritten to target the local `cli.ts` export. This could be
-relaxed if moved outside of the workspace.
+and the test task rewritten to target the local `cli.ts` export. That directory
+is removed once the run it was made for has finished. This could be relaxed if
+moved outside of the workspace.

--- a/packages/deno-web-test/browser.ts
+++ b/packages/deno-web-test/browser.ts
@@ -73,7 +73,9 @@ export class BrowserController extends EventTarget {
     if (this.#page) {
       await this.#page.goto(testUrl);
     } else {
-      this.#browser = await launchWithRetry(extractAstralConfig(config));
+      this.#browser = await launchWithRetry(
+        extractAstralConfig(config, this.#manifest.profileDir),
+      );
       this.#page = await this.#browser.newPage(testUrl);
       this.#page.addEventListener("console", (e) => {
         // Not sure why this event needs reconstructed in order

--- a/packages/deno-web-test/cli.ts
+++ b/packages/deno-web-test/cli.ts
@@ -12,23 +12,28 @@ if (stderrBoundary) {
 
 // {*_,*.,}test.{ts, tsx, mts, js, mjs, jsx}
 const manifest = await Manifest.create(Deno.cwd(), [...Deno.args]);
-await buildTestDir(manifest);
-
 const server = new TestServer(manifest);
-server.start(manifest.requestedPort);
-const port = server.port();
+let success = false;
 
-if (!port) {
-  throw new Error(
-    `Server could not listen on requested port ${manifest.requestedPort}.`,
-  );
+// `Deno.exit()` ends the process where it stands. The status is held here
+// and the exit comes after the removal below.
+try {
+  await buildTestDir(manifest);
+
+  server.start(manifest.requestedPort);
+  const port = server.port();
+
+  if (!port) {
+    throw new Error(
+      `Server could not listen on requested port ${manifest.requestedPort}.`,
+    );
+  }
+
+  const runner = new Runner(manifest, port);
+  success = await runner.run();
+} finally {
+  await server.stop();
+  await manifest.remove();
 }
 
-const runner = new Runner(manifest, port);
-const success = await runner.run();
-
-if (!success) {
-  Deno.exit(1);
-} else {
-  Deno.exit(0);
-}
+Deno.exit(success ? 0 : 1);

--- a/packages/deno-web-test/config.ts
+++ b/packages/deno-web-test/config.ts
@@ -100,11 +100,17 @@ export const extractAstralConfig = (
   if ("product" in config) astralConfig.product = config.product;
 
   // The browser keeps its profile in `profileDir`, which belongs to the run
-  // and goes when the run ends.
+  // and goes when the run ends. Astral reads `--user-data-dir` to tell
+  // whether the launch names a profile at all, so it goes in whatever the
+  // product; Firefox reads the directory from `-profile`, and is given the
+  // same one.
   astralConfig.args = [
     ...config.args ?? [],
     `--user-data-dir=${profileDir}`,
   ];
+  if (config.product === "firefox") {
+    astralConfig.args.push("-profile", profileDir);
+  }
 
   // Left unset, astral downloads a browser of its own choosing, whose version
   // is a constant inside astral rather than anything decided here. A system

--- a/packages/deno-web-test/config.ts
+++ b/packages/deno-web-test/config.ts
@@ -91,11 +91,20 @@ export const applyDefaults = (config: object): Config => {
   return applied;
 };
 
-export const extractAstralConfig = (config: Config): LaunchOptions => {
+export const extractAstralConfig = (
+  config: Config,
+  profileDir: string,
+): LaunchOptions => {
   const astralConfig: LaunchOptions = {};
   if ("headless" in config) astralConfig.headless = config.headless;
   if ("product" in config) astralConfig.product = config.product;
-  if ("args" in config) astralConfig.args = config.args;
+
+  // The browser keeps its profile in `profileDir`, which belongs to the run
+  // and goes when the run ends.
+  astralConfig.args = [
+    ...config.args ?? [],
+    `--user-data-dir=${profileDir}`,
+  ];
 
   // Left unset, astral downloads a browser of its own choosing, whose version
   // is a constant inside astral rather than anything decided here. A system

--- a/packages/deno-web-test/manifest.ts
+++ b/packages/deno-web-test/manifest.ts
@@ -1,6 +1,7 @@
 import * as path from "@std/path";
 
 import { Config, getConfig } from "./config.ts";
+import { removeDirectory } from "./remove-directory.ts";
 
 // The name a run's directory carries. A directory a killed run leaves behind
 // has nothing but its name to say what made it.
@@ -57,15 +58,10 @@ export class Manifest {
   }
 
   // Removes everything the run wrote, both directories above included. The
-  // rename goes first: removing a tree walks it and then removes the root,
-  // and a process writing by the path the run handed it would put an entry
-  // back into a directory the walk had already been through. Under the new
-  // name it writes to a path that no longer resolves, and the walk sees a
-  // tree nothing can add to.
+  // browser has to be closed and the static server stopped first, so that
+  // nothing the run started is writing to either directory as it goes.
   async remove(): Promise<void> {
-    const removing = `${this.#runDir}.removing`;
-    await Deno.rename(this.#runDir, removing);
-    await Deno.remove(removing, { recursive: true });
+    await removeDirectory(this.#runDir);
   }
 
   static async create(projectDir: string, tests: string[]): Promise<Manifest> {
@@ -76,8 +72,15 @@ export class Manifest {
       await Deno.makeTempDir({ prefix: RUN_DIRECTORY_PREFIX }),
       config,
     );
-    await Deno.mkdir(manifest.serverDir);
-    await Deno.mkdir(manifest.profileDir);
+    try {
+      await Deno.mkdir(manifest.serverDir);
+      await Deno.mkdir(manifest.profileDir);
+    } catch (error) {
+      // The temporary directory is already there, and nobody holds the
+      // manifest to remove it with.
+      await manifest.remove();
+      throw error;
+    }
     return manifest;
   }
 }

--- a/packages/deno-web-test/manifest.ts
+++ b/packages/deno-web-test/manifest.ts
@@ -1,35 +1,79 @@
+import * as path from "@std/path";
+
 import { Config, getConfig } from "./config.ts";
 
 export class Manifest {
-  // The root directory path of the project being tested.
-  readonly projectDir: string;
-  // An array of relative paths to tests
-  // from `projectDir`.
-  readonly tests: string[];
-  // The root directory path of the static server.
-  readonly serverDir: string;
-  // The requested port the static server is being served on.
-  // If `0` (the default), the actual listening port will be different.
-  readonly requestedPort: number;
-  // Configuration defined via `deno-web-test.config.ts`
-  readonly config: Config;
+  readonly #projectDir: string;
+  readonly #tests: string[];
+  readonly #runDir: string;
+  readonly #config: Config;
 
   constructor(
     projectDir: string,
     tests: string[],
-    serverDir: string,
+    runDir: string,
     config: Config,
   ) {
-    this.projectDir = projectDir;
-    this.tests = tests;
-    this.serverDir = serverDir;
-    this.requestedPort = 0;
-    this.config = config;
+    this.#projectDir = projectDir;
+    this.#tests = tests;
+    this.#runDir = runDir;
+    this.#config = config;
+  }
+
+  // The root directory path of the project being tested.
+  get projectDir(): string {
+    return this.#projectDir;
+  }
+
+  // An array of relative paths to tests
+  // from `projectDir`.
+  get tests(): string[] {
+    return this.#tests;
+  }
+
+  // The root directory path of the static server.
+  get serverDir(): string {
+    return path.join(this.#runDir, "server");
+  }
+
+  // The directory the browser keeps its profile in.
+  get profileDir(): string {
+    return path.join(this.#runDir, "profile");
+  }
+
+  // The requested port the static server is being served on.
+  // If `0` (the default), the actual listening port will be different.
+  get requestedPort(): number {
+    return 0;
+  }
+
+  // Configuration defined via `deno-web-test.config.ts`
+  get config(): Config {
+    return this.#config;
+  }
+
+  // Removes everything the run wrote, both directories above included. The
+  // rename goes first: removing a tree walks it and then removes the root,
+  // and a process writing by the path the run handed it would put an entry
+  // back into a directory the walk had already been through. Under the new
+  // name it writes to a path that no longer resolves, and the walk sees a
+  // tree nothing can add to.
+  async remove(): Promise<void> {
+    const removing = `${this.#runDir}.removing`;
+    await Deno.rename(this.#runDir, removing);
+    await Deno.remove(removing, { recursive: true });
   }
 
   static async create(projectDir: string, tests: string[]): Promise<Manifest> {
-    const serverDir = await Deno.makeTempDir();
     const config = await getConfig(projectDir);
-    return new Manifest(projectDir, tests, serverDir, config);
+    const manifest = new Manifest(
+      projectDir,
+      tests,
+      await Deno.makeTempDir({ prefix: "deno-web-test-" }),
+      config,
+    );
+    await Deno.mkdir(manifest.serverDir);
+    await Deno.mkdir(manifest.profileDir);
+    return manifest;
   }
 }

--- a/packages/deno-web-test/manifest.ts
+++ b/packages/deno-web-test/manifest.ts
@@ -2,6 +2,10 @@ import * as path from "@std/path";
 
 import { Config, getConfig } from "./config.ts";
 
+// The name a run's directory carries. A directory a killed run leaves behind
+// has nothing but its name to say what made it.
+export const RUN_DIRECTORY_PREFIX = "deno-web-test-";
+
 export class Manifest {
   readonly #projectDir: string;
   readonly #tests: string[];
@@ -69,7 +73,7 @@ export class Manifest {
     const manifest = new Manifest(
       projectDir,
       tests,
-      await Deno.makeTempDir({ prefix: "deno-web-test-" }),
+      await Deno.makeTempDir({ prefix: RUN_DIRECTORY_PREFIX }),
       config,
     );
     await Deno.mkdir(manifest.serverDir);

--- a/packages/deno-web-test/remove-directory.ts
+++ b/packages/deno-web-test/remove-directory.ts
@@ -1,0 +1,16 @@
+/**
+ * Removes `directory` and everything under it, under a name nothing else
+ * holds.
+ *
+ * Removing a tree walks it and then removes the root. A process writing into
+ * the tree by the path it was given can put an entry back into a directory
+ * the walk has already been through, leaving the root non-empty by the time
+ * the walk reaches it. The rename is one operation that cannot half-happen:
+ * after it, a write to the old path finds nothing to write into, and the walk
+ * sees a tree nothing can add to.
+ */
+export async function removeDirectory(directory: string): Promise<void> {
+  const removing = `${directory}.removing`;
+  await Deno.rename(directory, removing);
+  await Deno.remove(removing, { recursive: true });
+}

--- a/packages/deno-web-test/runner.ts
+++ b/packages/deno-web-test/runner.ts
@@ -75,7 +75,6 @@ export class Runner {
           await this.browser.load(tsTestPath);
         } catch (e: unknown) {
           this.reporter.onLoadError(tsTestPath, e as TestResultError);
-          await this.browser.close();
           return false;
         }
 
@@ -100,14 +99,16 @@ export class Runner {
         }
         this.reporter.onFileEnd(tsTestPath);
       }
+
+      const summary = summarize(this.results);
+      this.reporter.onRunEnd(summary);
+      return summary.failed.length === 0;
     } finally {
       recordsFragment?.close();
+      // The manifest's directories are removed once this returns, so the
+      // browser closes first, whichever way the run ended.
+      await this.browser.close();
     }
-
-    const summary = summarize(this.results);
-    this.reporter.onRunEnd(summary);
-    await this.browser.close();
-    return summary.failed.length === 0;
   }
 
   onConsole(e: ConsoleEvent) {

--- a/packages/deno-web-test/test/astral-config.test.ts
+++ b/packages/deno-web-test/test/astral-config.test.ts
@@ -54,6 +54,15 @@ describe("extractAstralConfig()", () => {
       .toEqual([`--user-data-dir=${PROFILE_DIR}`]);
   });
 
+  it('names it again in Firefox\'s spelling for `product: "firefox"`', () => {
+    // `--user-data-dir` is what astral reads to tell whether the launch names
+    // a profile, and Firefox reads `-profile`. Both name the run's own
+    // directory, which is the one the run removes when it ends.
+
+    expect(extractAstralConfig({ product: "firefox" }, PROFILE_DIR).args)
+      .toEqual([`--user-data-dir=${PROFILE_DIR}`, "-profile", PROFILE_DIR]);
+  });
+
   describe("the browser binary", () => {
     it("supplies one for an unstated product, which astral takes as Chrome", () => {
       withBinaryOverride(EXISTING_FILE, () => {

--- a/packages/deno-web-test/test/astral-config.test.ts
+++ b/packages/deno-web-test/test/astral-config.test.ts
@@ -16,6 +16,9 @@ import { extractAstralConfig } from "../config.ts";
 /** A path that exists, whatever machine this runs on: this file. */
 const EXISTING_FILE = new URL(import.meta.url).pathname;
 
+/** A stand-in for the profile directory a run hands the launch. */
+const PROFILE_DIR = "/profile-dir";
+
 /** Runs the body with `ASTRAL_BIN_PATH` set as given, then puts it back. */
 function withBinaryOverride(value: string | undefined, body: () => void) {
   const previous = Deno.env.get("ASTRAL_BIN_PATH");
@@ -40,22 +43,27 @@ describe("extractAstralConfig()", () => {
     const config = extractAstralConfig({
       headless: false,
       args: ["--flag"],
-    });
+    }, PROFILE_DIR);
 
     expect(config.headless).toBe(false);
-    expect(config.args).toEqual(["--flag"]);
+    expect(config.args).toEqual(["--flag", `--user-data-dir=${PROFILE_DIR}`]);
+  });
+
+  it("names the profile directory it is given", () => {
+    expect(extractAstralConfig({}, PROFILE_DIR).args)
+      .toEqual([`--user-data-dir=${PROFILE_DIR}`]);
   });
 
   describe("the browser binary", () => {
     it("supplies one for an unstated product, which astral takes as Chrome", () => {
       withBinaryOverride(EXISTING_FILE, () => {
-        expect(extractAstralConfig({}).path).toBe(EXISTING_FILE);
+        expect(extractAstralConfig({}, PROFILE_DIR).path).toBe(EXISTING_FILE);
       });
     });
 
     it('supplies one for `product: "chrome"`', () => {
       withBinaryOverride(EXISTING_FILE, () => {
-        expect(extractAstralConfig({ product: "chrome" }).path)
+        expect(extractAstralConfig({ product: "chrome" }, PROFILE_DIR).path)
           .toBe(EXISTING_FILE);
       });
     });
@@ -68,7 +76,7 @@ describe("extractAstralConfig()", () => {
       // `ASTRAL_BIN_PATH` itself, which is why one being set here must still
       // produce no `path`.
       withBinaryOverride(EXISTING_FILE, () => {
-        expect(extractAstralConfig({ product: "firefox" }).path)
+        expect(extractAstralConfig({ product: "firefox" }, PROFILE_DIR).path)
           .toBe(undefined);
       });
     });

--- a/packages/deno-web-test/test/manifest.test.ts
+++ b/packages/deno-web-test/test/manifest.test.ts
@@ -1,0 +1,61 @@
+/**
+ * `Manifest` owns one temporary directory per run and hands out the two paths
+ * inside it. What is pinned here is that the directory is there while the run
+ * needs it, that it is gone afterwards, and that its name says what made it,
+ * which is what `temporary-directories.test.ts` reads a finished run against.
+ */
+
+import { existsSync } from "@std/fs/exists";
+import { basename, dirname } from "@std/path";
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { Manifest, RUN_DIRECTORY_PREFIX } from "../manifest.ts";
+
+/** A directory with no `deno-web-test.config.ts`, so the run takes defaults. */
+const PROJECT_DIR = import.meta.dirname as string;
+
+describe("Manifest", () => {
+  describe("instance members", () => {
+    describe("remove()", () => {
+      it("removes the server and profile directories and the one holding them", async () => {
+        const manifest = await Manifest.create(PROJECT_DIR, []);
+        const runDirectory = dirname(manifest.serverDir);
+
+        await manifest.remove();
+
+        expect(existsSync(manifest.serverDir)).toBe(false);
+        expect(existsSync(manifest.profileDir)).toBe(false);
+        expect(existsSync(runDirectory)).toBe(false);
+      });
+    });
+  });
+
+  describe("static members", () => {
+    describe("create()", () => {
+      it("makes the server and profile directories inside one temporary directory", async () => {
+        const manifest = await Manifest.create(PROJECT_DIR, []);
+
+        try {
+          expect(Deno.statSync(manifest.serverDir).isDirectory).toBe(true);
+          expect(Deno.statSync(manifest.profileDir).isDirectory).toBe(true);
+          expect(dirname(manifest.serverDir))
+            .toBe(dirname(manifest.profileDir));
+        } finally {
+          await manifest.remove();
+        }
+      });
+
+      it("names that directory with the run-directory prefix", async () => {
+        const manifest = await Manifest.create(PROJECT_DIR, []);
+
+        try {
+          expect(basename(dirname(manifest.serverDir)))
+            .toMatch(new RegExp(`^${RUN_DIRECTORY_PREFIX}`));
+        } finally {
+          await manifest.remove();
+        }
+      });
+    });
+  });
+});

--- a/packages/deno-web-test/test/temporary-directories.test.ts
+++ b/packages/deno-web-test/test/temporary-directories.test.ts
@@ -15,6 +15,7 @@
 import { describe, it } from "@std/testing/bdd";
 
 import { RUN_DIRECTORY_PREFIX } from "../manifest.ts";
+import { removeDirectory } from "../remove-directory.ts";
 import { runDenoWebTest } from "./utils.ts";
 
 describe("a harness run", () => {
@@ -27,12 +28,7 @@ describe("a harness run", () => {
     });
     const left = [...Deno.readDirSync(temporaryDirectory)];
 
-    // Renaming the directory before walking it takes it out from under
-    // anything writing to the path the run was given, so that nothing can
-    // appear inside it while the walk is under way.
-    const removing = `${temporaryDirectory}.removing`;
-    await Deno.rename(temporaryDirectory, removing);
-    await Deno.remove(removing, { recursive: true });
+    await removeDirectory(temporaryDirectory);
 
     run.assert(run.success, "the run passed");
     run.assert(

--- a/packages/deno-web-test/test/temporary-directories.test.ts
+++ b/packages/deno-web-test/test/temporary-directories.test.ts
@@ -1,16 +1,20 @@
 /**
  * What a harness run leaves in the directory it makes its temporary files in.
  *
- * The run is given a `TMPDIR` of this test's own, so that what it makes there
- * stands alone. Chrome's crash handler, zygote, and GPU processes are
- * re-parented when the browser process goes, and they write into whatever
- * directory `TMPDIR` names, so entries of Chrome's can appear here once the
- * run has ended. The directories are the run's own, and those are what the
- * assertion reads.
+ * The run is given a `TMPDIR` of this test's own, and does not have it to
+ * itself: Chrome writes its own scratch files into the directory `TMPDIR`
+ * names and leaves some of them behind, files and directories alike, and its
+ * crash handler, zygote, and GPU processes are re-parented when the browser
+ * process goes, so more can land there after the run has ended and a run that
+ * has ended cannot be waited for. What the run makes for itself carries the
+ * prefix `Manifest.create()` gives it, and the assertion reads that.
+ * `manifest.test.ts` is what pins the prefix onto the directory, so that a run
+ * making no such directory would fail there rather than pass silently here.
  */
 
 import { describe, it } from "@std/testing/bdd";
 
+import { RUN_DIRECTORY_PREFIX } from "../manifest.ts";
 import { runDenoWebTest } from "./utils.ts";
 
 describe("a harness run", () => {
@@ -32,7 +36,7 @@ describe("a harness run", () => {
 
     run.assert(run.success, "the run passed");
     run.assert(
-      !left.some((entry) => entry.isDirectory),
+      !left.some((entry) => entry.name.startsWith(RUN_DIRECTORY_PREFIX)),
       `${temporaryDirectory} still holds ${
         left.map((entry) =>
           `${entry.name} (${entry.isDirectory ? "directory" : "file"})`

--- a/packages/deno-web-test/test/temporary-directories.test.ts
+++ b/packages/deno-web-test/test/temporary-directories.test.ts
@@ -1,0 +1,43 @@
+/**
+ * What a harness run leaves in the directory it makes its temporary files in.
+ *
+ * The run is given a `TMPDIR` of this test's own, so that what it makes there
+ * stands alone. Chrome's crash handler, zygote, and GPU processes are
+ * re-parented when the browser process goes, and they write into whatever
+ * directory `TMPDIR` names, so entries of Chrome's can appear here once the
+ * run has ended. The directories are the run's own, and those are what the
+ * assertion reads.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+
+import { runDenoWebTest } from "./utils.ts";
+
+describe("a harness run", () => {
+  it("leaves no directory of its own in the temporary directory", async () => {
+    const temporaryDirectory = await Deno.makeTempDir({
+      prefix: "deno-web-test-tmpdir-",
+    });
+    const run = await runDenoWebTest("success-project", {
+      TMPDIR: temporaryDirectory,
+    });
+    const left = [...Deno.readDirSync(temporaryDirectory)];
+
+    // Renaming the directory before walking it takes it out from under
+    // anything writing to the path the run was given, so that nothing can
+    // appear inside it while the walk is under way.
+    const removing = `${temporaryDirectory}.removing`;
+    await Deno.rename(temporaryDirectory, removing);
+    await Deno.remove(removing, { recursive: true });
+
+    run.assert(run.success, "the run passed");
+    run.assert(
+      !left.some((entry) => entry.isDirectory),
+      `${temporaryDirectory} still holds ${
+        left.map((entry) =>
+          `${entry.name} (${entry.isDirectory ? "directory" : "file"})`
+        ).join(", ")
+      }`,
+    );
+  });
+});

--- a/packages/deno-web-test/test/utils.ts
+++ b/packages/deno-web-test/test/utils.ts
@@ -175,8 +175,8 @@ export class HarnessRun {
   }
 }
 
-// Runs deno-web-test in `projectDir` and caches
-// the results for multiple test usages.
+// Runs deno-web-test in `projectDir` with `environment` added to the
+// variables it inherits, and caches the results for multiple test usages.
 //
 // Due to running within a workspace, these test subprojects
 // need to be workspace members in order to run deno tasks.
@@ -184,8 +184,10 @@ export class HarnessRun {
 // before running tests.
 export const runDenoWebTest = async (
   projectDir: string,
+  environment: Record<string, string> = {},
 ): Promise<HarnessRun> => {
-  const fromCache = DenoWebTestCache.get(projectDir);
+  const cacheKey = `${projectDir} ${JSON.stringify(environment)}`;
+  const fromCache = DenoWebTestCache.get(cacheKey);
   if (fromCache) {
     return fromCache;
   }
@@ -238,13 +240,19 @@ export const runDenoWebTest = async (
       // directory rather than tests of this repository, so the child is
       // given no spool to write them to.
       [RECORDS_DIR_VARIABLE]: "",
+      ...environment,
     },
-  }).output().then((output) =>
-    new HarnessRun(
-      projectDir,
-      sanitizeDenoWebTestOutput(output, stderrBoundary),
+  }).output()
+    .then((output) =>
+      new HarnessRun(
+        projectDir,
+        sanitizeDenoWebTestOutput(output, stderrBoundary),
+      )
     )
-  );
-  DenoWebTestCache.set(projectDir, run);
+    // The copy is the run's working directory, and a `HarnessRun` holds what
+    // the run printed rather than anything under it, so the copy goes once
+    // the run has ended.
+    .finally(() => Deno.remove(tmp, { recursive: true }));
+  DenoWebTestCache.set(cacheKey, run);
   return run;
 };

--- a/packages/deno-web-test/test/utils.ts
+++ b/packages/deno-web-test/test/utils.ts
@@ -5,6 +5,8 @@ import { parse as parseJsonc } from "@std/jsonc";
 import { decode } from "@commonfabric/utils/encoding";
 import { RECORDS_DIR_VARIABLE } from "@commonfabric/test-support/records";
 
+import { removeDirectory } from "../remove-directory.ts";
+
 const dirname = import.meta.dirname as string;
 const CLI_PATH = path.join(dirname, "..", "cli.ts");
 const DenoWebTestCache: Map<string, Promise<HarnessRun>> = new Map();
@@ -242,17 +244,20 @@ export const runDenoWebTest = async (
       [RECORDS_DIR_VARIABLE]: "",
       ...environment,
     },
-  }).output()
-    .then((output) =>
-      new HarnessRun(
-        projectDir,
-        sanitizeDenoWebTestOutput(output, stderrBoundary),
-      )
+  }).output().then((output) =>
+    new HarnessRun(
+      projectDir,
+      sanitizeDenoWebTestOutput(output, stderrBoundary),
     )
-    // The copy is the run's working directory, and a `HarnessRun` holds what
-    // the run printed rather than anything under it, so the copy goes once
-    // the run has ended.
-    .finally(() => Deno.remove(tmp, { recursive: true }));
+  );
   DenoWebTestCache.set(cacheKey, run);
+
+  // The copy is the run's working directory, and a `HarnessRun` holds what
+  // the run printed rather than anything under it, so the copy goes once the
+  // run has settled, whichever way it settled. What the cache holds is the
+  // run, so a removal that fails says so here without becoming what every
+  // later caller reads.
+  await Promise.allSettled([run]);
+  await removeDirectory(tmp);
   return run;
 };


### PR DESCRIPTION
The browser test harness made two temporary directories per run and removed neither. `Manifest.create()` made one to serve the bundled tests and the harness files from. Astral's `launch()` made the other for Chrome's profile, which it does whenever the launch names no `--user-data-dir`. Both were still there when the process exited, and `cli.ts` called `Deno.exit()` directly, which ends the process where it stands, so there was nowhere for a removal to have gone even if one had been written. Every package whose tests run in a browser goes through this harness, so every browser test run on a developer's machine and in continuous integration added two more. On the machine this was written on, the temporary directory holds 42,883 entries.

The run now owns one directory, made with a `deno-web-test-` prefix so that anything a killed run leaves says where it came from. The static server's root and the browser's profile are subdirectories of it. `Manifest` holds the run directory and derives both paths from it, and `Manifest.remove()` removes the three of them together. `extractAstralConfig()` takes the profile directory and puts a `--user-data-dir` for it in the launch arguments, which is what stops astral making one of its own. It builds a fresh argument array rather than passing the config's, which astral pushes onto.

`cli.ts` runs the whole thing inside a `try`/`finally` that stops the static server and removes the run directory, and computes the exit code afterwards, so `Deno.exit()` is the last thing the process does. `TestServer.stop()` had no callers before this. `Runner.run()` closes the browser in a `finally` rather than on each of the two paths that used to close it, so a run that ends by throwing leaves no browser behind either.

Ordering is most of what makes the removal safe. `Runner.run()` returns only after the browser is closed and the static server is stopped, so nothing the run started is writing to either directory when it goes. Chrome's crash handler, zygote, and GPU processes are re-parented rather than waited for, and Chrome's caches for the GPU and for the profile's components sit inside the profile directory, so whether they touch it after the browser has gone is a real question. Measured on macOS with Chrome 152 in headless mode, they do not: at the moment `close()` returns, `lsof` reports no process holding a file anywhere under the profile, and nothing under it changes over the following three seconds -- no file added, removed, or rewritten -- across five rounds. Removing the profile directly on the line after `close()` returned succeeded ten times out of ten. What those processes do write into is the directory `TMPDIR` names, which is the parent of the run directory rather than anything inside it.

That measurement covers one of the two platforms this runs on, so the removal does not rest on it. Removing a tree walks it and then removes the root, which is the shape that failed for
`packages/dashboard/test/runner.ts`: a process writing into the tree during the walk left the root non-empty by the time the walk reached it, and the removal threw "Directory not empty" with every test passing. So `Manifest.remove()` renames the run directory first, in one atomic operation that cannot half-happen, and walks the tree under its new name. A process writing by the path the run handed it is then writing to a path that no longer resolves, so its create fails and the walk sees a tree nothing can add to. Chrome addresses these files by absolute path, so the new name is out of its reach. Nothing observed here needed that step, and what it buys is that Linux, where continuous integration runs and where the dashboard's failure was seen, and Windows, where an open file blocks a delete, get the same answer by construction rather than by a measurement only macOS could supply.

`test/temporary-directories.test.ts` runs the harness against the `success-project` fixture with `TMPDIR` pointing at a directory of its own and reads what is left there. Written and run against the harness as it stood first, where it failed naming both directories:

    /var/folders/.../deno-web-test-tmpdir-3134acae765890a9 still holds
    83b09e65692a26d9 (directory), ab7d2c8ce00cc396 (directory)

The assertion is about directories rather than about the directory being empty, because a file of Chrome's can appear there after the run has ended and a run that has finished cannot be waited for. The test's own teardown renames before it walks, for the reason above. `runDenoWebTest()` grows a parameter for the environment variables to add to the ones the harness inherits, since pointing the run at a directory is the whole method here, and its cache is keyed on that as well as on the project.

`runDenoWebTest()` had a leak of its own alongside the harness's two. It copies a test project out of the workspace, because a project inside the workspace has to be a workspace member to run a deno task and these fixtures are not members, and it removed that copy at no point: a run of this package's suite left six behind, one per project a test ran. The copy is the run's working directory and nothing reads it once the run has ended, since a `HarnessRun` holds the exit status and both streams as already-captured bytes, so the removal hangs off the same promise the `HarnessRun` is built on.

Verified by running each browser suite with `TMPDIR` pointing at a fresh directory and reading what was left in it. `packages/dashboard`, `packages/identity`, `packages/static`, `packages/iframe-sandbox`, `packages/ui`, and this package's own suite each leave it empty, where the dashboard added two entries per run before this change. Ten stress iterations across `packages/iframe-sandbox` and `packages/dashboard` removed the run directory without complaint.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6853?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

