### PR TITLE
fix(ci): snapshot Deno dependency hash before tests

### DIFF
--- a/.github/actions/deno-setup/action.yml
+++ b/.github/actions/deno-setup/action.yml
@@ -100,6 +100,18 @@ runs:
         dirname "$bin" >> "$GITHUB_PATH"
         "$bin" --version
 
+    # `actions/cache` evaluates its inputs again during its post-job save. Resolve
+    # the dependency hash before tests can fill the checkout with raw coverage
+    # profiles, so that save reads a stable step output instead of walking the
+    # enlarged workspace again.
+    - name: 🧮 Resolve Deno dependency hash
+      id: dependency-hash
+      if: inputs.cache == 'true'
+      shell: bash
+      env:
+        DEPENDENCY_HASH: ${{ hashFiles('**/deno.jsonc', '**/deno.lock') }}
+      run: printf 'hash=%s\n' "$DEPENDENCY_HASH" >> "$GITHUB_OUTPUT"
+
     # Cache version: bump to invalidate all caches (e.g., v2 -> v3)
     - name: 📦 Cache Deno dependencies
       if: inputs.cache == 'true'
@@ -109,7 +121,7 @@ runs:
           ~/.deno
           ~/.cache/deno
           ~/Library/Caches/deno
-        key: deno-deps-v4-${{ runner.os }}-${{ runner.arch }}-${{ steps.resolve.outputs.version }}-${{ hashFiles('**/deno.jsonc', '**/deno.lock') }}
+        key: deno-deps-v4-${{ runner.os }}-${{ runner.arch }}-${{ steps.resolve.outputs.version }}-${{ steps.dependency-hash.outputs.hash }}
         restore-keys: |
           deno-deps-v4-${{ runner.os }}-${{ runner.arch }}-${{ steps.resolve.outputs.version }}-
           deno-deps-v4-${{ runner.os }}-${{ runner.arch }}-

--- a/docs/development/CI_PERFORMANCE.md
+++ b/docs/development/CI_PERFORMANCE.md
@@ -213,6 +213,24 @@ that reaches the chart without a recognized marker is counted as "other", drawn
 in gray, and listed on standard error when the script runs, so a missing marker
 is easy to find and fix.
 
+## Cache Keys And Post-Job Saves
+
+The combined `actions/cache` action restores during setup and saves in a
+post-job step. GitHub evaluates expressions in the action's inputs again for
+that save. A `hashFiles()` call written directly in `with.key` therefore walks
+the checkout twice: once before the work and once after it.
+
+When a job writes a large generated tree under the checkout, that second walk
+can become much more expensive than the first. The workspace test jobs are the
+important case here: raw V8 coverage can contain hundreds of thousands of files
+by the time post-job steps run.
+
+Resolve any workspace-wide dependency hash in an ordinary setup step and write
+it to `GITHUB_OUTPUT`. Give the cache action that step output as its key. The
+post-job save can reevaluate the output reference safely because its value was
+fixed before the job populated the workspace. The `deno-setup` composite action
+uses this shape for the shared Deno dependency cache.
+
 ## Step And Job Timeouts
 
 Every work step in `.github/workflows/deno.yml` carries its own

--- a/tasks/deno-setup-action.test.ts
+++ b/tasks/deno-setup-action.test.ts
@@ -14,12 +14,12 @@ const ACTION_PATH = join(
   "deno-setup",
   "action.yml",
 );
-const CACHE_MISS_STEP = "    - name: 🧹 Clear Deno toolchain after cache miss";
 
-function cacheMissStep(action: string): string {
-  const start = action.indexOf(CACHE_MISS_STEP);
-  assert(start >= 0, "cache-miss cleanup step not found");
-  const next = action.indexOf("\n    - name:", start + CACHE_MISS_STEP.length);
+function actionStep(action: string, name: string): string {
+  const header = `    - name: ${name}`;
+  const start = action.indexOf(header);
+  assert(start >= 0, `\`${name}\` step not found`);
+  const next = action.indexOf("\n    - name:", start + header.length);
   return action.slice(start, next < 0 ? action.length : next);
 }
 
@@ -55,7 +55,10 @@ Deno.test(
         "key: deno-bin-${{ runner.os }}-${{ runner.arch }}-" +
           "${{ steps.resolve.outputs.version }}",
       );
-      const step = cacheMissStep(action);
+      const step = actionStep(
+        action,
+        "🧹 Clear Deno toolchain after cache miss",
+      );
       assertStringIncludes(
         step,
         "if: steps.deno-toolchain-cache.outputs.cache-hit != 'true'",
@@ -88,5 +91,39 @@ Deno.test(
     } finally {
       await Deno.remove(root, { recursive: true });
     }
+  },
+);
+
+Deno.test(
+  "Deno setup snapshots the dependency hash before registering the cache",
+  async () => {
+    const action = await Deno.readTextFile(ACTION_PATH);
+    const hashStepName = "🧮 Resolve Deno dependency hash";
+    const cacheStepName = "📦 Cache Deno dependencies";
+    const hashStep = actionStep(action, hashStepName);
+    const cacheStep = actionStep(action, cacheStepName);
+
+    assert(
+      action.indexOf(hashStepName) < action.indexOf(cacheStepName),
+      "dependency hash must be resolved before the cache action is registered",
+    );
+    assertStringIncludes(
+      hashStep,
+      "DEPENDENCY_HASH: ${{ hashFiles('**/deno.jsonc', '**/deno.lock') }}",
+    );
+    assertStringIncludes(hashStep, "id: dependency-hash");
+    assertStringIncludes(hashStep, "if: inputs.cache == 'true'");
+    assertStringIncludes(
+      hashStep,
+      `printf 'hash=%s\\n' "$DEPENDENCY_HASH" >> "$GITHUB_OUTPUT"`,
+    );
+    assert(
+      !cacheStep.includes("hashFiles("),
+      "the cache action would reevaluate `hashFiles()` during its post-job save",
+    );
+    assertStringIncludes(
+      cacheStep,
+      "${{ steps.dependency-hash.outputs.hash }}",
+    );
   },
 );


### PR DESCRIPTION
## Summary

- resolve the shared Deno dependency hash once, before test work begins
- give `actions/cache` the stable step output while preserving the existing cache namespace and dependency glob
- document and regression-test the post-job cache-key rule

## Why

PR #6795's `Test (6/8)` job failed on three different runners after all tests, coverage conversion, and artifact uploads had succeeded. The failure came from the `actions/cache` post-job save reevaluating the workspace-wide `hashFiles('**/deno.jsonc', '**/deno.lock')` expression after that shard had generated more than 100,000 raw V8 coverage files.

Capturing the same hash in an ordinary setup step keeps restore behavior and cache compatibility unchanged. At post-job time, the cache action now reevaluates only a small step-output reference instead of recursively walking the enlarged checkout.

## Validation

- `deno fmt --check`
- `deno lint`
- `deno task check`
- `deno test --no-check -A tasks/deno-setup-action.test.ts tasks/ci-workflow.test.ts`
- red/green regression check: the new assertion fails against the old inline `hashFiles()` cache key and passes after the action change
- `tasks/ci-capabilities.test.ts` passes outside the local sandbox; unrelated macOS coverage-fixture failures in the broad `tasks` suite reproduce unchanged on clean `origin/main`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6855?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

