### PR TITLE
feat(data-model): the debug renderers take a `maxStringLength`

### DIFF
--- a/packages/data-model/src/api.ts
+++ b/packages/data-model/src/api.ts
@@ -467,6 +467,15 @@ export interface DebugValueOptions {
   readonly maxArrayLength?: number;
 
   /**
+   * Maximum length of a string which is represented whole: a positive
+   * integer, or `Infinity` for as long as the conversion allows. A longer
+   * string is converted to a form suggestive of the elision, which carries an
+   * excerpt of the string up to the limit and the string's actual length.
+   * When absent, the limit is two hundred. A large value is capped.
+   */
+  readonly maxStringLength?: number;
+
+  /**
    * Replacer function, called on every value and sub-value encountered, to get
    * a replacement value to use. A replacer which does not want to replace a
    * value returns the value it receives, and one which throws is taken to have

--- a/packages/data-model/src/value-debug.ts
+++ b/packages/data-model/src/value-debug.ts
@@ -744,8 +744,12 @@ class DebugStringifier {
           const excerpt = this.#renderSubvalue(partial.excerpt, indent);
           return `${excerpt} + ... length: ${partial.length}`;
         }
+        // deno-coverage-ignore-start
+        // The conversion is the form's only producer and shapes it no other
+        // way, so this fallthrough is a prophylactic no test can reach.
         return this.#renderInstance(tag, payload, indent);
       }
+      // deno-coverage-ignore-stop
 
       default: {
         // A class instance, carried under its class name.
@@ -824,9 +828,13 @@ class DebugStringifier {
     value: FabricValue,
   ): { readonly length: number; readonly excerpt: string } | undefined {
     const length = DebugStringifier.#lengthOf(value);
+    // deno-coverage-ignore-start
+    // The conversion shapes the form no other way; see the `partialString`
+    // arm of `#renderTaggedForm()`.
     if (length === undefined) {
       return undefined;
     }
+    // deno-coverage-ignore-stop
 
     const { excerpt } = value as FabricPlainObject;
     return (typeof excerpt === "string") ? { length, excerpt } : undefined;

--- a/packages/data-model/src/value-debug.ts
+++ b/packages/data-model/src/value-debug.ts
@@ -44,6 +44,15 @@ const ABSOLUTE_MAX_ARRAY_LENGTH = 10000;
 const DEFAULT_MAX_ARRAY_LENGTH = 100;
 
 /**
+ * Length of a string a conversion carries whole whatever its options say, so
+ * that a result is bounded in size whatever the input.
+ */
+const ABSOLUTE_MAX_STRING_LENGTH = 100000;
+
+/** Length of a string a conversion carries whole, when its options do not say. */
+const DEFAULT_MAX_STRING_LENGTH = 200;
+
+/**
  * What a `FabricPrimitive`'s codec hands back to be rendered: the
  * realm-crossing encoding of a terminal codec, or the expansion of a
  * nonterminal one into other `FabricValue`s.
@@ -55,6 +64,17 @@ type PrimitiveState = RealmCodecValue | FabricValue;
  * less its leading slash, and the payload under it.
  */
 type TaggedForm = { readonly tag: string; readonly payload: FabricValue };
+
+/**
+ * The limits a conversion runs within, each resolved from the option of the
+ * same name: the limit stated, or its default when none was, capped at its
+ * absolute maximum.
+ */
+type ConversionLimits = {
+  readonly maxDepth: number;
+  readonly maxArrayLength: number;
+  readonly maxStringLength: number;
+};
 
 /**
  * Returns the class name of the given object, or `<anonymous>` when it has
@@ -72,8 +92,7 @@ function classNameOf(value: object): string {
  */
 class DebugConverter {
   readonly #value: any;
-  readonly #maxDepth: number;
-  readonly #maxArrayLength: number;
+  readonly #limits: ConversionLimits;
   readonly #replacer: undefined | ((value: any) => any);
   readonly #nestingStack = new Map<object, number>();
 
@@ -83,16 +102,13 @@ class DebugConverter {
   constructor(
     /** Value to convert. */
     value: unknown,
-    /** Maximum nesting depth. */
-    maxDepth: number,
-    /** Maximum number of array elements to convert. */
-    maxArrayLength: number,
+    /** Limits to convert within. */
+    limits: ConversionLimits,
     /** Replacer function. */
     replacer?: (value: any) => any,
   ) {
     this.#value = value;
-    this.#maxDepth = maxDepth;
-    this.#maxArrayLength = maxArrayLength;
+    this.#limits = limits;
     this.#replacer = replacer;
   }
 
@@ -129,7 +145,7 @@ class DebugConverter {
    */
   #convertArray(value: any, depth: number): FabricValue {
     const length: number = value.length;
-    const maxLength = this.#maxArrayLength;
+    const maxLength = this.#limits.maxArrayLength;
     const result: FabricValue[] = [];
     // An array is indexable by property name directly, so the index names
     // `Object.keys()` yields are used as they come.
@@ -156,7 +172,7 @@ class DebugConverter {
     }
 
     if (length > maxLength) {
-      result.push({ "/...": { "/length": length } });
+      result.push({ "/...": { length } });
     }
 
     return result;
@@ -178,7 +194,7 @@ class DebugConverter {
       if (
         (matchedGenericName !== "Object") && (matchedGenericName !== className)
       ) {
-        return { [tag]: stringForm };
+        return { [tag]: this.#convertString(stringForm) };
       }
     }
 
@@ -214,6 +230,30 @@ class DebugConverter {
   }
 
   /**
+   * Converts a string. A string longer than the maximum string length is
+   * converted to a `/partialString` form carrying its length and an excerpt:
+   * its first characters up to that limit, less a final high surrogate, so
+   * that the excerpt does not end in half of a surrogate pair. That form
+   * nests two levels, so a result holding one can run one level past the
+   * maximum nesting depth.
+   */
+  #convertString(value: string): FabricValue {
+    const length = value.length;
+    const maxLength = this.#limits.maxStringLength;
+
+    if (length <= maxLength) {
+      return value;
+    }
+
+    let excerpt = value.slice(0, maxLength);
+    if (/[\uD800-\uDBFF]$/.test(excerpt)) {
+      excerpt = excerpt.slice(0, -1);
+    }
+
+    return { "/partialString": { length, excerpt } };
+  }
+
+  /**
    * Converts the given value, which is known to be at the indicated nesting
    * depth.
    */
@@ -231,9 +271,12 @@ class DebugConverter {
       case "bigint":
       case "boolean":
       case "number":
-      case "string":
       case "undefined": {
         return value;
+      }
+
+      case "string": {
+        return this.#convertString(value);
       }
 
       case "symbol": {
@@ -289,7 +332,7 @@ class DebugConverter {
         return { "/circle": nestedAt };
       }
 
-      if (depth >= this.#maxDepth) {
+      if (depth >= this.#limits.maxDepth) {
         return { "/...": toDebugKindString(value) };
       }
 
@@ -684,16 +727,24 @@ class DebugStringifier {
       }
 
       case "...": {
-        // The elision marker: the array-length form when its payload carries
-        // a `/length`, and otherwise the depth-limit form, whose payload --
-        // what kind of value was elided -- is left out of the rendering.
-        const inner = isPlainObject(payload)
-          ? DebugStringifier.#taggedFormOf(payload as FabricPlainObject)
-          : undefined;
-        if ((inner?.tag === "length") && (typeof inner.payload === "number")) {
-          return `... length: ${inner.payload}`;
+        // The elision marker: the array-length form when its payload is an
+        // object holding a `length`, and otherwise the depth-limit form,
+        // whose payload -- what kind of value was elided -- is left out of
+        // the rendering.
+        const length = DebugStringifier.#lengthOf(payload);
+        return (length === undefined) ? "..." : `... length: ${length}`;
+      }
+
+      case "partialString": {
+        // The excerpt of a string too long to carry whole, followed by the
+        // length of the whole. A payload not of that shape falls through to
+        // render as it is.
+        const partial = DebugStringifier.#partialStringOf(payload);
+        if (partial !== undefined) {
+          const excerpt = this.#renderSubvalue(partial.excerpt, indent);
+          return `${excerpt} + ... length: ${partial.length}`;
         }
-        return "...";
+        return this.#renderInstance(tag, payload, indent);
       }
 
       default: {
@@ -751,6 +802,37 @@ class DebugStringifier {
   }
 
   /**
+   * Returns the `length` of the given value when it is a plain object whose
+   * `length` is a number, which is the payload shape of the array-length
+   * form, and `undefined` when it is not.
+   */
+  static #lengthOf(value: FabricValue): number | undefined {
+    if (!isPlainObject(value)) {
+      return undefined;
+    }
+
+    const { length } = value as FabricPlainObject;
+    return (typeof length === "number") ? length : undefined;
+  }
+
+  /**
+   * Returns the length and excerpt of the given value when it is the payload
+   * shape of the string-length form, a plain object whose `length` is a
+   * number and whose `excerpt` is a string, and `undefined` when it is not.
+   */
+  static #partialStringOf(
+    value: FabricValue,
+  ): { readonly length: number; readonly excerpt: string } | undefined {
+    const length = DebugStringifier.#lengthOf(value);
+    if (length === undefined) {
+      return undefined;
+    }
+
+    const { excerpt } = value as FabricPlainObject;
+    return (typeof excerpt === "string") ? { length, excerpt } : undefined;
+  }
+
+  /**
    * Returns the tag and payload of the given plain object when it is one of the
    * conversion's single-key tagged forms, and `undefined` when it is not. No key
    * of an original value can arrive in such a form, because the conversion
@@ -774,8 +856,8 @@ class DebugStringifier {
 }
 
 /**
- * Helper for the entry points, which validates `options` as a whole. What each
- * option holds is validated as it is read, by `checkedLimit()`.
+ * Helper for `checkedLimits()`, which validates `options` as a whole. What
+ * each option holds is validated as it is read, by `checkedLimit()`.
  *
  * @throws {Error} if `options` is not a plain object.
  */
@@ -791,7 +873,7 @@ function checkOptions(options: DebugValueOptions | undefined): void {
 }
 
 /**
- * Helper for the entry points, which validates one of the limit options and
+ * Helper for `checkedLimits()`, which validates one of the limit options and
  * returns the limit it calls for: `value` when present, and `defaultValue`
  * when not, either one capped at `cap`. `name` is the option's name, for the
  * error.
@@ -828,6 +910,43 @@ function checkedLimit(
 }
 
 /**
+ * Helper for the entry points, which validates `options` and returns the
+ * limits they call for: each limit stated, or when not, `defaultMaxDepth` for
+ * the depth and the default for either length, all capped at their absolute
+ * maximums.
+ *
+ * @throws {Error} if `options` is not a plain object, or if one of its limits
+ * is none of a positive integer, `Infinity`, or `undefined`.
+ */
+function checkedLimits(
+  options: DebugValueOptions | undefined,
+  defaultMaxDepth: number,
+): ConversionLimits {
+  checkOptions(options);
+
+  return {
+    maxDepth: checkedLimit(
+      "maxDepth",
+      options?.maxDepth,
+      defaultMaxDepth,
+      ABSOLUTE_MAX_DEPTH,
+    ),
+    maxArrayLength: checkedLimit(
+      "maxArrayLength",
+      options?.maxArrayLength,
+      DEFAULT_MAX_ARRAY_LENGTH,
+      ABSOLUTE_MAX_ARRAY_LENGTH,
+    ),
+    maxStringLength: checkedLimit(
+      "maxStringLength",
+      options?.maxStringLength,
+      DEFAULT_MAX_STRING_LENGTH,
+      ABSOLUTE_MAX_STRING_LENGTH,
+    ),
+  };
+}
+
+/**
  * Renders the debug-string form of the given value with optional indentation,
  * by converting it with `toStructuredDebugValue()` per `options` and rendering
  * the result. A depth the options leave unsaid is `DEFAULT_STRING_MAX_DEPTH`.
@@ -839,24 +958,11 @@ function renderDebugString(
   options: DebugValueOptions | undefined,
   indent?: number,
 ): string {
-  checkOptions(options);
-
-  // Both limits are resolved here, ahead of the `try`, so that an invalid one
+  // The limits are resolved here, ahead of the `try`, so that an invalid one
   // is refused rather than rendered as unrenderable.
   const converterOptions: DebugValueOptions = {
     ...options,
-    maxDepth: checkedLimit(
-      "maxDepth",
-      options?.maxDepth,
-      DEFAULT_STRING_MAX_DEPTH,
-      ABSOLUTE_MAX_DEPTH,
-    ),
-    maxArrayLength: checkedLimit(
-      "maxArrayLength",
-      options?.maxArrayLength,
-      DEFAULT_MAX_ARRAY_LENGTH,
-      ABSOLUTE_MAX_ARRAY_LENGTH,
-    ),
+    ...checkedLimits(options, DEFAULT_STRING_MAX_DEPTH),
   };
 
   try {
@@ -896,7 +1002,10 @@ function renderDebugString(
  * The rendering stops at the nesting depth given in `options`, ten levels
  * when not given, below which a value is elided. It likewise stops at the
  * array length given in `options`, one hundred elements when not given, and
- * says the array's actual length in place of the elements past it.
+ * says the array's actual length in place of the elements past it; and a
+ * string longer than the string length given in `options`, two hundred
+ * characters when not given, renders as an excerpt of that length followed by
+ * the string's actual length.
  *
  * How any of these renders is _not_ a contract. The rendering is meant for a
  * human reading a diagnostic, and it changes as that reading is improved;
@@ -982,11 +1091,13 @@ export function toDebugKindString(value: unknown): string {
  * `codec-json` encoding form, and with as little chance for ambiguity as can
  * be reasonably achieved.
  *
- * The nesting limit of the result, the number of elements of an array it
- * represents, and a replacer to consult are the `maxDepth`, `maxArrayLength`,
- * and `replacer` of `options`. When there is no nesting limit given, the
- * result nests as deep as reasonably possible; when there is no array length
- * given, an array is represented to one hundred elements.
+ * The limits of the result -- its nesting, the number of elements of an array
+ * it represents, and the length of a string it carries whole -- and a replacer
+ * to consult are the `maxDepth`, `maxArrayLength`, `maxStringLength`, and
+ * `replacer` of `options`. When there is no nesting limit given, the result
+ * nests as deep as reasonably possible; when there is no array length given,
+ * an array is represented to one hundred elements; and when there is no
+ * string length given, a string is carried whole to two hundred characters.
  *
  * If the conversion could not be completed (stack overflow, object
  * `toJSON()` conversion error, etc.), this function returns the literal value
@@ -1000,27 +1111,14 @@ export function toStructuredDebugValue(
   /** Conversion options, if desired. */
   options?: DebugValueOptions,
 ): FabricValue {
-  checkOptions(options);
-
-  const maxDepth = checkedLimit(
-    "maxDepth",
-    options?.maxDepth,
-    ABSOLUTE_MAX_DEPTH,
-    ABSOLUTE_MAX_DEPTH,
-  );
-  const maxArrayLength = checkedLimit(
-    "maxArrayLength",
-    options?.maxArrayLength,
-    DEFAULT_MAX_ARRAY_LENGTH,
-    ABSOLUTE_MAX_ARRAY_LENGTH,
-  );
+  const limits = checkedLimits(options, ABSOLUTE_MAX_DEPTH);
 
   // We subtract one from `maxDepth` because the "suggestive forms" for elided
-  // data all use one layer of depth.
+  // data use a layer of depth. The array-length and string-length forms use
+  // two, and so can run one level past the limit.
   return new DebugConverter(
     value,
-    maxDepth - 1,
-    maxArrayLength,
+    { ...limits, maxDepth: limits.maxDepth - 1 },
     options?.replacer,
   ).convert();
 }

--- a/packages/data-model/test/value-debug-cases/string-long.txt
+++ b/packages/data-model/test/value-debug-cases/string-long.txt
@@ -1,0 +1,11 @@
+(() => {
+  // A string longer than the default limit of 200 renders as an excerpt of
+  // that length, and then its actual length.
+  return { text: "abcdefghij".repeat(30) };
+})()
+
+{
+  text: "abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghij" + ... length: 300
+}
+
+{text:"abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghij...

--- a/packages/data-model/test/value-debug-structured.test.ts
+++ b/packages/data-model/test/value-debug-structured.test.ts
@@ -431,7 +431,7 @@ describe("toStructuredDebugValue()", () => {
       expect(result).toEqual([
         1,
         { "/Map": "/..." },
-        { "/...": { "/length": 5 } },
+        { "/...": { length: 5 } },
       ]);
       expect(result.length).toBe(3);
     });
@@ -451,7 +451,7 @@ describe("toStructuredDebugValue()", () => {
       ) as unknown[];
       expect(result.length).toBe(4);
       expect(Object.keys(result)).toEqual(["0", "3"]);
-      expect(result[3]).toEqual({ "/...": { "/length": 6 } });
+      expect(result[3]).toEqual({ "/...": { length: 6 } });
     });
 
     it("returns the length form for a sparse array whose `length` alone is past the limit", () => {
@@ -463,7 +463,7 @@ describe("toStructuredDebugValue()", () => {
       ) as unknown[];
       expect(result.length).toBe(4);
       expect(Object.keys(result)).toEqual(["0", "3"]);
-      expect(result[3]).toEqual({ "/...": { "/length": 500 } });
+      expect(result[3]).toEqual({ "/...": { length: 500 } });
     });
 
     it("returns no more than 100 elements when the limit is not given", () => {
@@ -471,7 +471,7 @@ describe("toStructuredDebugValue()", () => {
       const result = toStructuredDebugValue(value) as unknown[];
       expect(result.length).toBe(101);
       expect(result[99]).toBe(99);
-      expect(result[100]).toEqual({ "/...": { "/length": 150 } });
+      expect(result[100]).toEqual({ "/...": { length: 150 } });
     });
 
     it("returns no more than 10000 elements given a larger limit", () => {
@@ -483,7 +483,7 @@ describe("toStructuredDebugValue()", () => {
         ) as unknown[];
         expect(result.length).toBe(10001);
         expect(result[9999]).toBe(9999);
-        expect(result[10000]).toEqual({ "/...": { "/length": 20000 } });
+        expect(result[10000]).toEqual({ "/...": { length: 20000 } });
       }
     });
 
@@ -495,7 +495,7 @@ describe("toStructuredDebugValue()", () => {
         { a: [1, 2, 3] },
         { maxArrayLength: 1, maxDepth: 3 },
       );
-      expect(result).toEqual({ a: [1, { "/...": { "/length": 3 } }] });
+      expect(result).toEqual({ a: [1, { "/...": { length: 3 } }] });
     });
 
     it("throws given a `maxArrayLength` that is not a positive integer", () => {
@@ -503,6 +503,80 @@ describe("toStructuredDebugValue()", () => {
         const options = { maxArrayLength: bad as unknown as number };
         expect(() => toStructuredDebugValue([], options)).toThrow(
           "`maxArrayLength` must be a positive integer, `Infinity`, or",
+        );
+      }
+    });
+  });
+
+  describe("with `maxStringLength`", () => {
+    it("returns `/partialString` with the length and an excerpt for a string past the limit", () => {
+      expect(toStructuredDebugValue("abcdefgh", { maxStringLength: 5 }))
+        .toEqual({ "/partialString": { length: 8, excerpt: "abcde" } });
+    });
+
+    it("returns a string whose length is the limit whole", () => {
+      expect(toStructuredDebugValue("abcde", { maxStringLength: 5 }))
+        .toBe("abcde");
+    });
+
+    it("returns the form in place of a string inside a container", () => {
+      const partial = { "/partialString": { length: 8, excerpt: "abcde" } };
+      expect(
+        toStructuredDebugValue(
+          { s: "abcdefgh", a: ["abcdefgh"] },
+          { maxStringLength: 5 },
+        ),
+      ).toEqual({ s: partial, a: [partial] });
+    });
+
+    it("returns the form in place of a class instance's `toString()` form", () => {
+      class Foo {
+        toString() {
+          return "abcdefgh";
+        }
+      }
+      expect(toStructuredDebugValue(new Foo(), { maxStringLength: 5 }))
+        .toEqual({
+          "/Foo": { "/partialString": { length: 8, excerpt: "abcde" } },
+        });
+    });
+
+    it("returns an excerpt which does not end in half of a surrogate pair", () => {
+      // The emoji is two UTF-16 units, at indices 2 and 3; a limit of 3 cuts
+      // it in half, and the excerpt stops short of it instead.
+
+      const value = "ab\u{1F600}cd";
+      expect(toStructuredDebugValue(value, { maxStringLength: 3 }))
+        .toEqual({ "/partialString": { length: 6, excerpt: "ab" } });
+      expect(toStructuredDebugValue(value, { maxStringLength: 4 }))
+        .toEqual({ "/partialString": { length: 6, excerpt: "ab\u{1F600}" } });
+    });
+
+    it("returns no more than 200 characters when the limit is not given", () => {
+      const result = toStructuredDebugValue("x".repeat(250)) as {
+        "/partialString": { length: number; excerpt: string };
+      };
+      expect(result["/partialString"].length).toBe(250);
+      expect(result["/partialString"].excerpt).toBe("x".repeat(200));
+    });
+
+    it("returns no more than 100000 characters given a larger limit", () => {
+      const value = "x".repeat(150000);
+      for (const limit of [200000, Infinity]) {
+        const result = toStructuredDebugValue(
+          value,
+          { maxStringLength: limit },
+        ) as { "/partialString": { length: number; excerpt: string } };
+        expect(result["/partialString"].length).toBe(150000);
+        expect(result["/partialString"].excerpt.length).toBe(100000);
+      }
+    });
+
+    it("throws given a `maxStringLength` that is not a positive integer", () => {
+      for (const bad of [0, -1, 1.5, -Infinity, NaN, "3", null, {}]) {
+        const options = { maxStringLength: bad as unknown as number };
+        expect(() => toStructuredDebugValue("", options)).toThrow(
+          "`maxStringLength` must be a positive integer, `Infinity`, or",
         );
       }
     });
@@ -765,6 +839,7 @@ describe("toStructuredDebugValue()", () => {
         () => {},
         [1, , 3],
         Array.from({ length: 101 }, (_, i) => i),
+        "x".repeat(201),
         withOwnProto(),
         { "/circle": 1 },
         cyclic,

--- a/packages/data-model/test/value-debug.test.ts
+++ b/packages/data-model/test/value-debug.test.ts
@@ -153,6 +153,31 @@ describe("value-debug", () => {
       });
     });
 
+    describe("with `maxStringLength`", () => {
+      it("renders an excerpt of the string, and the string's length after it", () => {
+        expect(toCompactDebugString("abcdefgh", { maxStringLength: 5 }))
+          .toBe('"abcde" + ... length: 8');
+        expect(toCompactDebugString({ s: "abcdefgh" }, { maxStringLength: 5 }))
+          .toBe('{s:"abcde" + ... length: 8}');
+      });
+
+      it("renders a string whose length is the limit whole", () => {
+        expect(toCompactDebugString("abcde", { maxStringLength: 5 }))
+          .toBe('"abcde"');
+      });
+
+      it("renders no more than 200 characters when the limit is not given", () => {
+        expect(toCompactDebugString("x".repeat(250)))
+          .toMatch(/^"x{200}" \+ \.\.\. length: 250$/);
+      });
+
+      it("throws given a `maxStringLength` that is not a positive integer", () => {
+        expect(() => toCompactDebugString("", { maxStringLength: 0 })).toThrow(
+          "`maxStringLength` must be a positive integer, `Infinity`, or",
+        );
+      });
+    });
+
     describe("with a `replacer`", () => {
       it("renders the replacement in place of the original value", () => {
         const options: CompactDebugStringOptions = {
@@ -201,6 +226,11 @@ describe("value-debug", () => {
     it("renders the array's length on its own line in place of the elements past the limit", () => {
       expect(toIndentedDebugString([1, , , 4, 5], { maxArrayLength: 3 }))
         .toBe("[\n  1,\n  <2 holes>,\n  ... length: 5\n]");
+    });
+
+    it("renders a string's excerpt and length in the string's place", () => {
+      expect(toIndentedDebugString({ s: "abcdefgh" }, { maxStringLength: 5 }))
+        .toBe('{\n  s: "abcde" + ... length: 8\n}');
     });
 
     it("renders the replacement in place of the original value", () => {

--- a/packages/runner/src/builder/module.ts
+++ b/packages/runner/src/builder/module.ts
@@ -1,4 +1,7 @@
-import { toCompactDebugString } from "@commonfabric/data-model";
+import {
+  type DebugValueOptions,
+  toCompactDebugString,
+} from "@commonfabric/data-model";
 
 import { defineAuthoredDebugAccessors } from "../harness/authored-debug-source.ts";
 import { getVerifiedProvenance } from "../harness/verified-provenance.ts";
@@ -352,20 +355,19 @@ export const assertCapture = <T>(
 };
 
 /**
- * Nesting depth a failing assertion's operand renders to: as deep as the
- * conversion allows. A view tree costs two levels per node and a nested cell
- * three, so the renderer's default depth elides an operand after a handful
- * of nodes, and a diagnostic wants the whole of it.
+ * Rendering options for a failing assertion's operands: as deep, as many
+ * array elements, and as long a string as the conversion allows. A view tree
+ * costs two levels per node and a nested cell three, so the renderer's
+ * default depth elides an operand after a handful of nodes; a list or a
+ * string differs from what was expected at whatever index it does, and the
+ * renderer's default lengths would elide exactly that. A diagnostic wants
+ * the whole of it.
  */
-const ASSERT_RENDER_MAX_DEPTH = Infinity;
-
-/**
- * Number of array elements a failing assertion's operand renders: as many as
- * the conversion allows. A list operand differs from what was expected at
- * whatever index it does, and the renderer's default length would elide the
- * element the assertion turned on.
- */
-const ASSERT_RENDER_MAX_ARRAY_LENGTH = Infinity;
+const ASSERT_RENDER_OPTIONS: DebugValueOptions = {
+  maxDepth: Infinity,
+  maxArrayLength: Infinity,
+  maxStringLength: Infinity,
+};
 
 /**
  * Renders the operands captured by `assertCapture` into the record's `parts`.
@@ -373,8 +375,7 @@ const ASSERT_RENDER_MAX_ARRAY_LENGTH = Infinity;
  * A passing assertion (`ok === true`) returns an empty list without touching
  * the values, so the common case pays nothing to render diagnostics it will
  * never show. Only a failing assertion renders each captured value with
- * `toCompactDebugString`, to `ASSERT_RENDER_MAX_DEPTH` and
- * `ASSERT_RENDER_MAX_ARRAY_LENGTH`.
+ * `toCompactDebugString` with `ASSERT_RENDER_OPTIONS`.
  */
 export const assertRenderParts = (
   ok: boolean,
@@ -382,10 +383,7 @@ export const assertRenderParts = (
 ): AssertPart[] =>
   ok ? [] : parts.map(({ src, value }) => ({
     src,
-    rendered: toCompactDebugString(value, {
-      maxDepth: ASSERT_RENDER_MAX_DEPTH,
-      maxArrayLength: ASSERT_RENDER_MAX_ARRAY_LENGTH,
-    }),
+    rendered: toCompactDebugString(value, ASSERT_RENDER_OPTIONS),
   }));
 
 /**

--- a/packages/runner/src/builtins/wish.ts
+++ b/packages/runner/src/builtins/wish.ts
@@ -2516,7 +2516,12 @@ export function wish(
             return;
           }
           if (disposition === "retry") continue;
-          await commitPatternErrorUI(resultCell, toCompactDebugString(error));
+          // The error's message can be an inconsistency report whose tail is
+          // the difference it reports, so a string is rendered whole.
+          await commitPatternErrorUI(
+            resultCell,
+            toCompactDebugString(error, { maxStringLength: Infinity }),
+          );
           return;
         }
         // Under a serving wave, commit() resolving ok is not durability:

--- a/packages/runner/src/storage/transaction/attestation.ts
+++ b/packages/runner/src/storage/transaction/attestation.ts
@@ -374,11 +374,12 @@ export const TypeMismatchError = (
 
 /**
  * Rendering options for the two values an inconsistency message compares:
- * arrays whole, so that a change past the renderer's default length shows as
- * a difference rather than as two identical renderings.
+ * arrays and strings whole, so that a change past the renderer's default
+ * lengths shows as a difference rather than as two identical renderings.
  */
 const INCONSISTENCY_RENDER_OPTIONS: DebugValueOptions = {
   maxArrayLength: Infinity,
+  maxStringLength: Infinity,
 };
 
 export const StateInconsistency = (source: {

--- a/packages/runner/test/favorites-row-stored-shape.test.ts
+++ b/packages/runner/test/favorites-row-stored-shape.test.ts
@@ -55,7 +55,11 @@ function debugFormContains(value: unknown, text: string): boolean {
     return false;
   };
   return walk(
-    toStructuredDebugValue(value, { maxDepth: 100, maxArrayLength: Infinity }),
+    toStructuredDebugValue(value, {
+      maxDepth: 100,
+      maxArrayLength: Infinity,
+      maxStringLength: Infinity,
+    }),
   );
 }
 

--- a/packages/runner/test/module.test.ts
+++ b/packages/runner/test/module.test.ts
@@ -277,6 +277,16 @@ describe("module", () => {
       expect(part.rendered).toContain(",149]");
       expect(part.rendered).not.toContain("...");
     });
+
+    it("renders a long string operand out to its last character", () => {
+      // The renderer's default length carries a string whole to two hundred
+      // characters; the last one here sits past that.
+
+      const value = `${"x".repeat(299)}END`;
+      const [part] = assertRenderParts(false, [{ src: "text", value }]);
+      expect(part.rendered).toContain('END"');
+      expect(part.rendered).not.toContain("...");
+    });
   });
 
   describe("handler function", () => {

--- a/packages/runtime-client/src/backends/runtime-processor.ts
+++ b/packages/runtime-client/src/backends/runtime-processor.ts
@@ -623,13 +623,16 @@ function newConsoleDebugReplacer(): (value: any) => any {
 
 /**
  * Converts one of a pattern's `console.*` arguments into the value that crosses
- * to the main thread.
+ * to the main thread. A string crosses as whole as the conversion allows:
+ * what a pattern logs is often a stack, a fetched body, or a model's output,
+ * whose tail is the point.
  *
  * Exported for testing.
  */
 export function toConsoleDebugValue(value: unknown): FabricValue {
   return toStructuredDebugValue(value, {
     maxDepth: MAX_CONSOLE_DEBUG_DEPTH,
+    maxStringLength: Infinity,
     replacer: newConsoleDebugReplacer(),
   });
 }

--- a/packages/runtime-client/test/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/test/backends/runtime-processor.test.ts
@@ -1344,6 +1344,14 @@ describe("runtime-processor", () => {
       };
     }
 
+    it("carries a long string whole", () => {
+      // The renderer's default string length would cut what a pattern logs
+      // at two hundred characters; the tail here sits past that.
+
+      const value = `${"x".repeat(299)}END`;
+      expect(toConsoleDebugValue(value)).toBe(value);
+    });
+
     describe("what the transport accepts", () => {
       /**
        * Puts `value` through the ends the notification actually uses: the

--- a/packages/static/assets/types/commonfabric.d.ts
+++ b/packages/static/assets/types/commonfabric.d.ts
@@ -510,6 +510,15 @@ export interface DebugValueOptions {
   readonly maxArrayLength?: number;
 
   /**
+   * Maximum length of a string which is represented whole: a positive
+   * integer, or `Infinity` for as long as the conversion allows. A longer
+   * string is converted to a form suggestive of the elision, which carries an
+   * excerpt of the string up to the limit and the string's actual length.
+   * When absent, the limit is two hundred. A large value is capped.
+   */
+  readonly maxStringLength?: number;
+
+  /**
    * Replacer function, called on every value and sub-value encountered, to get
    * a replacement value to use. A replacer which does not want to replace a
    * value returns the value it receives, and one which throws is taken to have


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Fable 5.1)

## What

`DebugValueOptions` gains `maxStringLength`: the longest string a conversion
carries whole. It defaults to 200, is capped at 100000, and accepts
`Infinity` as "as long as the conversion allows", the same vocabulary the
other two limits use.

A longer string is converted to the form
`{ "/partialString": { length: <length>, excerpt: "<excerpt>" } }`. The
excerpt is the string's first characters up to the limit, with no ellipsis of
its own, less a final high surrogate so that it never ends in half of a
surrogate pair. The string renderers render the form as:

```
"abcdefghij…" + ... length: 300
```

A class instance's `toString()` form goes through the same limit, since a
class whose string form runs to kilobytes is exactly what the limit is for.

## The array form's key

The array-length form's inner key is now a plain `length`, so that the form
reads `{ "/...": { length: 250 } }` and matches the string form's plain keys.
The stringifier recognizes it by shape (a plain object whose `length` is a
number) rather than as a nested tagged form.

## Mechanics

The three limits are resolved together by `checkedLimits()`, which validates
`options` and returns a `ConversionLimits` record that the converter holds,
so the two entry points no longer each repeat the resolution. The plain-object
check stays its own function, `checkOptions()`: folded into the same body, its
type guard narrows `options` to a record of `unknown` and the option reads
lose their types.

The string form nests two levels, like the array form, so a truncated string
sitting at the depth limit runs one level past `maxDepth`; the converter's
doc comment says so, and the comment on the depth subtraction now names both
forms.

## Call sites

The three runner sites that render for a difference, the ones the array
audit found, pass `maxStringLength: Infinity` alongside their array option: a
failing assertion's operands in `assertRenderParts()`, the storage "hash
changed" inconsistency message, and the favorites-row test's structured walk.
The assertion renderer's two constants became one `ASSERT_RENDER_OPTIONS`.

An audit of every use of the renderers against the string default found two
more sites whose consumer wants the tail, and both now pass
`maxStringLength: Infinity`: the conversion of a pattern's `console.*`
arguments on their way to the browser main thread, where what is logged is
often a stack, a fetched body, or a model's output, and the wish sidecar's
rendering of a commit failure into its error UI, where the message can be an
inconsistency report whose difference sits past 200 characters. Every other
site is capped by its own `maxLength`, is a human-facing message, or is a
test whose fixtures stay under the limit.

`commonfabric.d.ts` is regenerated.

## Coverage

In `data-model`, the `partialString` arm's fallthrough for a payload not of
the form's shape, and the shape helper's early return, are marked
`deno-coverage-ignore` with the reason beside each: the conversion is the
form's only producer, every rendering goes through the conversion, and it
never produces any other shape, so the gap is intentional. In `runner`, the
wish sidecar's commit-failure rendering is a reachable path that was already
an uncovered statement on `main`; it now spans more lines, which the count
reads as a rise, and that one is accepted rather than marked.

ACCEPT_COVERAGE_DEBT: packages/runner +2 lines

## Tests

- `value-debug-structured.test.ts`: the form at the top level, a string at
  the limit carried whole, the form inside a container and in place of an
  instance's `toString()` form, the surrogate-pair boundary at both cuts, the
  default of 200, the cap at 100000, and the refused values. A 201-character
  string joins the `FabricValue` result-contract list. The array tests now
  expect `length`.
- `value-debug.test.ts`: the compact and indented renderings, a string at the
  limit, the default, and the refused value.
- A new golden, `string-long`, records a 300-character string at the default.
  The existing `long-string` golden holds exactly 200 characters and is
  unchanged, which pins the boundary.
- `module.test.ts`: a 300-character assertion operand renders to its last
  character.

`deno task check`, `deno lint`, `deno fmt --check`, the data-model suite
(49 passed, 2784 steps), and the two targeted runner test files are green
locally; the full runner suite is running.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6858?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->




