### PR TITLE
fix: admit fabric special objects in the walks and comparisons

### DIFF
--- a/docs/development/DEVELOPMENT.md
+++ b/docs/development/DEVELOPMENT.md
@@ -434,28 +434,29 @@ or a bare `typeof value === "object"` gets the wrong answer: it sees an empty
 record and then merges the value to `{}`, rebuilds it as `{}`, descends into it
 and finds nothing, or writes a property onto it.
 
-These are the whole of what a walk needs, and using them is not optional in
-code that can meet a stored value:
+Four functions from `@commonfabric/data-model` are the whole of what a walk
+needs, and using them is not optional in code that can reach a stored value:
 
-- `isWalkableObjectOrArray(value)` is the container question, and it separates
-  the two special-object arms because they differ on exactly that question. A
-  `FabricPrimitive` answers `false`: it is a leaf, so "carry this value whole"
-  is the whole story, and no path addresses anything inside one. A
+- `isWalkableObjectOrArray(value)` is the container question. A
   `FabricInstance` is refused, because it is a container a walk is *supposed*
   to descend and cannot yet — `false` would claim it holds nothing, `true`
-  would send you into a property surface its codec does not speak for.
-  Everything outside the type is untouched: arrays and non-fabric class
-  instances still answer `true`, so it is a drop-in wherever
-  `isObjectOrArray()` was standing in for the container question.
+  would send you into a property surface its codec does not speak for. Every
+  other `FabricSpecialObject` returns `false`, `FabricPrimitive` and any
+  further subclass alike: `false` says "carry this value whole", which is the
+  complete story for a value no path addresses anything inside of. Everything
+  outside the type is untouched: arrays and non-fabric class instances still
+  return `true`, so it is a drop-in wherever `isObjectOrArray()` was standing
+  in for the container question.
 - A walk that can meet an instance and has a better answer than a throw tests
-  for one first. Three such answers exist. `attestation.ts`'s `resolve()`
-  reports the `TypeMismatchError` its own signature already carries. A walk
-  that can meet a *link* tests `isPrimitiveCellLink()` first, since a link is a
-  reference rather than a container, and under `modernCellRep` it is a
-  `FabricInstance`. And a walk that must not throw at all ends its descent
-  instead: `reactive-dependencies.ts` runs under a storage subscription, which
-  has to keep delivering, so its `isKeyable()` stops at an instance and leaves
-  a path below one unreachable on both sides.
+  for one first. `attestation.ts`'s `resolve()` reports the
+  `TypeMismatchError` its own signature already carries. A walk that can meet a
+  *link* tests `isPrimitiveCellLink()` first, since a link is a reference
+  rather than a container, and under `modernCellRep` it is a `FabricInstance`.
+  And `reactive-dependencies.ts` keeps descending one by property name through
+  its own `isKeyable()`: a throw there costs the rest of the notification being
+  delivered, and `false` would make an instance indistinguishable from a leaf,
+  so a read below one would stop triggering when the instance is deleted or
+  replaced by a scalar.
 - `isWalkableObjectNotArray(value)` is the same test with arrays removed, for a
   walk to which an array is not merely a different shape but something it must
   not treat as a record.
@@ -469,8 +470,8 @@ code that can meet a stored value:
   stored value, a schema default against a materialized one, a write against
   the value it replaces, a request against the snapshot a policy was checked
   over. It asks `valueEqual()` first and falls back to a structural walk that
-  still decides any special object by content, so it is the value model's
-  answer where the model has one. Neither half serves alone: `valueEqual()`
+  still decides any special object by content, so the value model decides
+  wherever it can. Neither half serves alone: `valueEqual()`
   throws on a `Cell` or any other non-fabric instance, and `deepEqual()`
   compares by enumerable own properties, of which a special object has none.
   Where both operands are known to be `FabricValue`s, use `valueEqual()`

--- a/docs/development/DEVELOPMENT.md
+++ b/docs/development/DEVELOPMENT.md
@@ -449,11 +449,14 @@ stored value:
   instances still answer `true`, so it is a drop-in wherever
   `isObjectOrArray()` was standing in for the container question.
 - A walk that can meet an instance and has a better answer than a throw tests
-  for one first. `attestation.ts`'s `resolve()` is the worked example, using
-  the `TypeMismatchError` its own signature already carries; a walk that can
-  meet a *link* tests `isPrimitiveCellLink()` first, since a link is a
+  for one first. Three such answers exist. `attestation.ts`'s `resolve()`
+  reports the `TypeMismatchError` its own signature already carries. A walk
+  that can meet a *link* tests `isPrimitiveCellLink()` first, since a link is a
   reference rather than a container, and under `modernCellRep` it is a
-  `FabricInstance`.
+  `FabricInstance`. And a walk that must not throw at all ends its descent
+  instead: `reactive-dependencies.ts` runs under a storage subscription, which
+  has to keep delivering, so its `isKeyable()` stops at an instance and leaves
+  a path below one unreachable on both sides.
 - `isWalkableObjectNotArray(value)` is the same test with arrays removed, for a
   walk to which an array is not merely a different shape but something it must
   not treat as a record.

--- a/docs/development/DEVELOPMENT.md
+++ b/docs/development/DEVELOPMENT.md
@@ -434,9 +434,8 @@ or a bare `typeof value === "object"` gets the wrong answer: it sees an empty
 record and then merges the value to `{}`, rebuilds it as `{}`, descends into it
 and finds nothing, or writes a property onto it.
 
-Three functions from `@commonfabric/data-model` are the whole of
-what a walk needs, and using them is not optional in code that can meet a
-stored value:
+These are the whole of what a walk needs, and using them is not optional in
+code that can meet a stored value:
 
 - `isWalkableObjectOrArray(value)` is the container question, and it separates
   the two special-object arms because they differ on exactly that question. A

--- a/docs/development/DEVELOPMENT.md
+++ b/docs/development/DEVELOPMENT.md
@@ -449,9 +449,11 @@ needs, and using them is not optional in code that can reach a stored value:
   in for the container question.
 - A walk that can meet an instance and has a better answer than a throw tests
   for one first. `attestation.ts`'s `resolve()` reports the
-  `TypeMismatchError` its own signature already carries. A walk that can meet a
-  *link* tests `isPrimitiveCellLink()` first, since a link is a reference
-  rather than a container, and under `modernCellRep` it is a `FabricInstance`.
+  `TypeMismatchError` its own signature already carries. A walk whose own
+  answer for a link differs from the container question's tests
+  `isPrimitiveCellLink()` first. That predicate speaks only about the sigil
+  form, which is written as a record, so a `FabricLink` reaches the refusal
+  like any other instance.
   And `reactive-dependencies.ts` keeps descending one by property name through
   its own `isKeyable()`: a throw there costs the rest of the notification being
   delivered, and `false` would make an instance indistinguishable from a leaf,

--- a/docs/development/DEVELOPMENT.md
+++ b/docs/development/DEVELOPMENT.md
@@ -423,6 +423,51 @@ function processData(data: Data) {
 }
 ```
 
+### Walking or comparing a value
+
+A value the runtime holds may be a `FabricSpecialObject` — a byte sequence, a
+temporal value, a content hash, a regular expression, an error, a link, a map,
+a set. Each of those keeps its state in private fields and has no own
+properties at all, so a walk that decides "may I read this by property name?"
+with `isObjectOrArray()`, `isObjectNotArray()`, `isReadonlyObjectOrArray()`,
+or a bare `typeof value === "object"` gets the wrong answer: it sees an empty
+record and then merges the value to `{}`, rebuilds it as `{}`, descends into it
+and finds nothing, or writes a property onto it.
+
+Three functions from `@commonfabric/data-model` are the whole of
+what a walk needs, and using them is not optional in code that can meet a
+stored value:
+
+- `isWalkableObjectOrArray(value)` is the container question: `isObjectOrArray()`
+  minus the fabric special objects. A `false` answer means "carry this value
+  whole". Arrays and non-fabric class instances still answer `true`, so it is a
+  drop-in wherever `isObjectOrArray()` was standing in for the container
+  question.
+- `isWalkableObjectNotArray(value)` is the same test with arrays removed, for a
+  walk to which an array is not merely a different shape but something it must
+  not treat as a record.
+- `isFabricPlainContainer(value)` asks the same container question of a value
+  the type system already says is a `FabricValue`, and is the one to reach for
+  where a caller holds one. The two differ only on values a `FabricValue`
+  cannot be — a `Cell`, a `Date`, a query-result proxy over one — which the
+  `isWalkable*` pair admits and this refuses.
+- `fabricAwareEqual(a, b)` is the comparison for operands that may hold a
+  `FabricValue` without being known to be one — a schema `const` against a
+  stored value, a schema default against a materialized one, a write against
+  the value it replaces, a request against the snapshot a policy was checked
+  over. It asks `valueEqual()` first and falls back to a structural walk that
+  still decides any special object by content, so it is the value model's
+  answer where the model has one. Neither half serves alone: `valueEqual()`
+  throws on a `Cell` or any other non-fabric instance, and `deepEqual()`
+  compares by enumerable own properties, of which a special object has none.
+  Where both operands are known to be `FabricValue`s, use `valueEqual()`
+  directly instead.
+
+A walk that must not silently pass a `FabricInstance` by — one whose contents
+are reachable only through its codec — refuses it outright rather than walking
+it. Those refusals are discovery instruments; see "Flag-gated tripwires" in
+[EXPERIMENTAL_OPTIONS.md](EXPERIMENTAL_OPTIONS.md).
+
 ### Avoid representing invalid state
 
 Similarly, permissive interfaces (including nullable properties and

--- a/docs/development/DEVELOPMENT.md
+++ b/docs/development/DEVELOPMENT.md
@@ -438,11 +438,22 @@ Three functions from `@commonfabric/data-model` are the whole of
 what a walk needs, and using them is not optional in code that can meet a
 stored value:
 
-- `isWalkableObjectOrArray(value)` is the container question: `isObjectOrArray()`
-  minus the fabric special objects. A `false` answer means "carry this value
-  whole". Arrays and non-fabric class instances still answer `true`, so it is a
-  drop-in wherever `isObjectOrArray()` was standing in for the container
-  question.
+- `isWalkableObjectOrArray(value)` is the container question, and it separates
+  the two special-object arms because they differ on exactly that question. A
+  `FabricPrimitive` answers `false`: it is a leaf, so "carry this value whole"
+  is the whole story, and no path addresses anything inside one. A
+  `FabricInstance` is refused, because it is a container a walk is *supposed*
+  to descend and cannot yet — `false` would claim it holds nothing, `true`
+  would send you into a property surface its codec does not speak for.
+  Everything outside the type is untouched: arrays and non-fabric class
+  instances still answer `true`, so it is a drop-in wherever
+  `isObjectOrArray()` was standing in for the container question.
+- A walk that can meet an instance and has a better answer than a throw tests
+  for one first. `attestation.ts`'s `resolve()` is the worked example, using
+  the `TypeMismatchError` its own signature already carries; a walk that can
+  meet a *link* tests `isPrimitiveCellLink()` first, since a link is a
+  reference rather than a container, and under `modernCellRep` it is a
+  `FabricInstance`.
 - `isWalkableObjectNotArray(value)` is the same test with arrays removed, for a
   walk to which an array is not merely a different shape but something it must
   not treat as a record.

--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -1298,10 +1298,16 @@ site has:
 
 The second is the weaker claim, but it does not fail quietly, and that is the
 point. Add a production use of one of these values and the throw fires — at the
-moment the use is added, in the change that added it — leaving exactly two
-honest ways forward: implement the handling the throw names, or back the use
-out. So the tripwire is its own enforcement, which is why an ungated site is
-legitimate. What it is not is a flag, so do not cite this section as though one
+moment the use is added, in the change that added it. Three honest ways lead
+out of that: implement the handling the throw names, back the use out, or
+establish that the site was never one a refusal belonged at and give it the
+answer it owes. That third one is the rarest, and it carries the heaviest
+burden of proof, since a site that keeps its old answer records a gap instead
+of closing one. `reactive-dependencies.ts` is the worked example: its
+`isKeyable()` descends a `FabricInstance` by property name because refusing
+would cost the rest of a notification's changes and answering `false` would
+lose reachability the walk already reports. So the tripwire is its own
+enforcement, which is why an ungated site is legitimate. What it is not is a flag, so do not cite this section as though one
 stood behind every throw.
 
 Three obligations follow, and they are the reason this is recorded here rather

--- a/packages/data-model/src/index.ts
+++ b/packages/data-model/src/index.ts
@@ -58,6 +58,8 @@ export {
   shallowFabricFromNativeValue,
 } from "./native-conversion.ts";
 
+export { refuseFabricInstance } from "./refuse-fabric-instance.ts";
+
 export { fabricAwareEqual, valueEqual } from "./valueEqual.ts";
 
 export {

--- a/packages/data-model/src/index.ts
+++ b/packages/data-model/src/index.ts
@@ -44,6 +44,8 @@ export {
   isValidFabricPlainObject,
   isValidFabricValue,
   isValidFabricValueLayer,
+  isWalkableObjectNotArray,
+  isWalkableObjectOrArray,
 } from "./type-check.ts";
 
 export {
@@ -56,7 +58,7 @@ export {
   shallowFabricFromNativeValue,
 } from "./native-conversion.ts";
 
-export { valueEqual } from "./valueEqual.ts";
+export { fabricAwareEqual, valueEqual } from "./valueEqual.ts";
 
 export {
   deepFreeze,

--- a/packages/data-model/src/refuse-fabric-instance.ts
+++ b/packages/data-model/src/refuse-fabric-instance.ts
@@ -1,4 +1,4 @@
-import type { FabricInstance } from "@commonfabric/data-model";
+import type { FabricInstance } from "./interface.ts";
 
 /**
  * Builds the refusal a `FabricInstance` gets from a walk that cannot yet

--- a/packages/data-model/src/type-check.ts
+++ b/packages/data-model/src/type-check.ts
@@ -25,6 +25,7 @@ import {
 import {
   isPlainContainer,
   isPlainObject,
+  type ReadonlyRecord,
   unsafeObjectKeyIn,
 } from "@commonfabric/utils/types";
 
@@ -42,6 +43,74 @@ import { VALUE_TAGS } from "./VALUE_TAGS.ts";
 import { tagFromNativeBuiltinClass } from "./tagFromNativeBuiltinClass.ts";
 import { BaseFabricInstance } from "./fabric-bases/BaseFabricInstance.ts";
 import { BaseFabricPrimitive } from "./fabric-bases/BaseFabricPrimitive.ts";
+
+/**
+ * Indicates whether a value's contents are reachable by property name: a
+ * non-`null` object, an array included, that is not a `FabricSpecialObject`.
+ *
+ * This is the question a structural walk asks before it reads, rebuilds,
+ * merges, or descends a value by its keys, and it is the question
+ * `isObjectOrArray()` answers wrong. A `FabricSpecialObject` keeps its state in
+ * private fields and has no own properties at all, so `isObjectOrArray()`
+ * accepts it and the walk then works on an empty record: it merges to `{}`,
+ * compares vacuously equal, descends and finds nothing, or grafts a property
+ * onto a frozen value. Every one of those loses the value the model does hold.
+ *
+ * A `false` answer for a special object tells the walk to stop and carry the
+ * value whole. That is the complete story for a `FabricPrimitive`, which is a
+ * leaf: no path addresses anything inside one, so stopping leaves nothing
+ * unvisited. A `FabricInstance` is a container whose contents are reachable
+ * only through its codec, so stopping there does leave those contents
+ * unvisited -- but property-name access never reached them either, and the
+ * sites that must not pass one by refuse it outright rather than walk it (see
+ * "Flag-gated tripwires" in `docs/development/EXPERIMENTAL_OPTIONS.md`).
+ *
+ * This is the walk-side half of admitting special objects; the compare-side
+ * half is `fabricAwareEqual()`. One keeps a special object out of walks
+ * that would decompose it, the other out of comparisons that would conflate it.
+ *
+ * `isFabricPlainContainer()` asks this same question of a value the type
+ * system already says is a `FabricValue`, and where a caller holds one that is
+ * the predicate to reach for. This one takes `unknown`, which is what the
+ * walks in `runner` hold: a schema node, a pattern binding, a builder
+ * artifact. The two differ on exactly the values a `FabricValue` cannot be --
+ * a `Cell`, a `Date`, a `Map`, a query-result proxy over one -- which this
+ * admits and `isFabricPlainContainer()` refuses. Neither answer is wrong;
+ * subtracting only the fabric special objects is what leaves a walk's
+ * treatment of everything else where it found it.
+ *
+ * Like its `utils` counterparts, the name settles the array question, and the
+ * sibling `isWalkableObjectNotArray()` is the same test with arrays removed.
+ * This is a structural predicate, so it narrows in one direction only and is
+ * overloaded accordingly; see the header of `@commonfabric/utils/types` for
+ * what that means. The narrowed type is read-only: the walks this serves
+ * rebuild containers rather than write through them.
+ */
+export function isWalkableObjectOrArray(value: ReadonlyRecord): boolean;
+export function isWalkableObjectOrArray(
+  value: unknown,
+): value is ReadonlyRecord;
+export function isWalkableObjectOrArray(value: unknown): boolean {
+  return typeof value === "object" && value !== null &&
+    !(value instanceof FabricSpecialObject);
+}
+
+/**
+ * Indicates whether a value's contents are reachable by property name and it is
+ * not an array: {@link isWalkableObjectOrArray} with arrays removed, and
+ * `isObjectNotArray()` with the fabric special objects removed.
+ *
+ * A walk asks this one where an array is not merely a different shape but
+ * something it must not treat as a record -- a property merge, a
+ * record-versus-array container reset.
+ */
+export function isWalkableObjectNotArray(value: ReadonlyRecord): boolean;
+export function isWalkableObjectNotArray(
+  value: unknown,
+): value is ReadonlyRecord;
+export function isWalkableObjectNotArray(value: unknown): boolean {
+  return isWalkableObjectOrArray(value) && !Array.isArray(value);
+}
 
 /**
  * Indicates whether the value is a `FabricValue`, accepting

--- a/packages/data-model/src/type-check.ts
+++ b/packages/data-model/src/type-check.ts
@@ -24,7 +24,7 @@
  * what leaves a walk's treatment of them where it found it. Inside the type it
  * separates the special objects by the question being asked: a
  * `FabricInstance` is a container no walk can descend yet and is refused
- * rather than answered, and every other special object answers `false`.
+ * rather than answered, and every other special object returns `false`.
  */
 
 import { backtickQuote } from "@commonfabric/utils/markdown";
@@ -69,9 +69,10 @@ import { BaseFabricPrimitive } from "./fabric-bases/BaseFabricPrimitive.ts";
  * property onto a frozen value. Every one of those loses the value the model
  * does hold. A `false` answer tells the walk to stop and carry it whole, which
  * is the complete story for a leaf: no path addresses anything inside one, so
- * stopping leaves nothing unvisited. Every special object gets that answer
- * except the one arm below. A `FabricPrimitive` is a leaf by design, and any
- * other subclass is a leaf as far as keys go, having none.
+ * stopping leaves nothing unvisited. Every `FabricSpecialObject` returns
+ * `false` except the one arm below, `FabricPrimitive` and any further
+ * subclass alike: carrying a value whole loses nothing whatever it holds, so
+ * this arm is decided by class rather than by what a subclass declares.
  *
  * A `FabricInstance` gets neither answer, and is refused. It is a container --
  * it holds other `FabricValue`s, and a walk is *supposed* to descend it -- so
@@ -83,9 +84,10 @@ import { BaseFabricPrimitive } from "./fabric-bases/BaseFabricPrimitive.ts";
  * `docs/development/EXPERIMENTAL_OPTIONS.md` governs them all.
  *
  * That shape is also what makes the descent, once it exists, a one-line change
- * here rather than an audit of every caller: a walk able to descend an
- * instance turns this refusal into `true`, and every site that already handles
- * the refusal is already correct.
+ * here for every caller that takes the refusal: a walk able to descend an
+ * instance turns this refusal into `true`. A caller that tests for an instance
+ * ahead of this one does not take the refusal and is not carried by that
+ * change; `reactive-dependencies.ts`'s `isKeyable()` is the one such site.
  *
  * A caller that can meet an instance and has something better to say than a
  * throw -- an error its own signature already carries -- tests for one before
@@ -123,7 +125,7 @@ export function isWalkableObjectOrArray(value: unknown): boolean {
 /**
  * Indicates whether a value's contents are reachable by property name and it
  * is not an array: {@link isWalkableObjectOrArray} with arrays removed, and
- * `isObjectNotArray()` with the fabric primitives removed.
+ * `isObjectNotArray()` with the fabric special objects removed.
  *
  * A walk asks this one where an array is not merely a different shape but
  * something it must not treat as a record -- a property merge, a
@@ -496,9 +498,10 @@ export function isValidFabricPlainObject(
  * Narrows to the container arms of `FabricValue` -- a plain object, an array,
  * or a `FabricInstance` -- that is, the values that hold other `FabricValue`s.
  *
- * Contrast `isFabricObjectOrArray()`, which is one arm wider: it also accepts a
- * `FabricPrimitive`, an object that is not a container. The two are not
- * interchangeable where the answer decides a descent.
+ * Contrast `isFabricObjectOrArray()`, which is one arm wider: it also accepts
+ * a `FabricSpecialObject` that is not a `FabricInstance`, an object that is
+ * not a container. The two are not interchangeable where the result decides a
+ * descent.
  */
 export function isFabricContainerValue(
   value: FabricValue,
@@ -538,9 +541,9 @@ export function isFabricPlainContainer(
  * Contrast `isFabricPlainObject()`, which is strictly narrower at RUNTIME: it
  * accepts only plain objects, rejecting arrays and `FabricSpecialObject`s. The
  * two are not interchangeable. Between them sit
- * `isFabricContainerValue()`, which rejects only the `FabricPrimitive` half of
- * `FabricSpecialObject`, and `isFabricPlainContainer()`, which rejects all of
- * it.
+ * `isFabricContainerValue()`, which rejects every `FabricSpecialObject` that
+ * is not a `FabricInstance`, and `isFabricPlainContainer()`, which rejects all
+ * of them.
  */
 export function isFabricObjectOrArray(
   value: FabricValue,

--- a/packages/data-model/src/type-check.ts
+++ b/packages/data-model/src/type-check.ts
@@ -22,10 +22,9 @@
  * Outside the `FabricValue` type it subtracts nothing: a `Date`, a `Map`, a
  * `Cell` and a query-result proxy over one all still answer `true`, which is
  * what leaves a walk's treatment of them where it found it. Inside the type it
- * separates the two special-object arms, which differ on exactly the question
- * being asked: a `FabricPrimitive` is a leaf and answers `false`, while a
+ * separates the special objects by the question being asked: a
  * `FabricInstance` is a container no walk can descend yet and is refused
- * rather than answered.
+ * rather than answered, and every other special object answers `false`.
  */
 
 import { backtickQuote } from "@commonfabric/utils/markdown";
@@ -47,7 +46,6 @@ import {
   FabricInstance,
   type FabricNativeObject,
   type FabricPlainObject,
-  FabricPrimitive,
   FabricSpecialObject,
   type FabricValue,
   type FabricValueLayer,
@@ -60,18 +58,20 @@ import { BaseFabricPrimitive } from "./fabric-bases/BaseFabricPrimitive.ts";
 
 /**
  * Indicates whether a value's contents are reachable by property name: a
- * non-`null` object, an array included, that is not a `FabricPrimitive`.
+ * non-`null` object, an array included, that is not a `FabricSpecialObject`.
  *
  * This is the question a structural walk asks before it reads, rebuilds,
  * merges, or descends a value by its keys, and it is the question
- * `isObjectOrArray()` answers wrong. A `FabricPrimitive` keeps its state in
+ * `isObjectOrArray()` answers wrong. A special object keeps its state in
  * private fields and has no own properties at all, so `isObjectOrArray()`
  * calls it a record and the walk then works on an empty one: it merges to
  * `{}`, compares vacuously equal, descends and finds nothing, or grafts a
  * property onto a frozen value. Every one of those loses the value the model
  * does hold. A `false` answer tells the walk to stop and carry it whole, which
  * is the complete story for a leaf: no path addresses anything inside one, so
- * stopping leaves nothing unvisited.
+ * stopping leaves nothing unvisited. Every special object gets that answer
+ * except the one arm below. A `FabricPrimitive` is a leaf by design, and any
+ * other subclass is a leaf as far as keys go, having none.
  *
  * A `FabricInstance` gets neither answer, and is refused. It is a container --
  * it holds other `FabricValue`s, and a walk is *supposed* to descend it -- so
@@ -117,7 +117,7 @@ export function isWalkableObjectOrArray(value: unknown): boolean {
   if (value instanceof FabricInstance) {
     refuseFabricInstance(value, "in a structural walk");
   }
-  return !(value instanceof FabricPrimitive);
+  return !(value instanceof FabricSpecialObject);
 }
 
 /**

--- a/packages/data-model/src/type-check.ts
+++ b/packages/data-model/src/type-check.ts
@@ -10,10 +10,18 @@
  * Frozen-ness is a separate question and deliberately not asked here, so a
  * structurally-valid unfrozen value is a member.
  *
- * The narrowings are looser than membership on purpose. They are asked of a
+ * The narrowings are looser than membership on purpose. Most are asked of a
  * value whose type already claims to be a `FabricValue`, and answer only
  * whether it may be read by name; where one accepts something membership
  * refuses, the difference is stated on that narrowing rather than here.
+ *
+ * The `isWalkable*` pair is the exception, and takes `unknown`. A structural
+ * walk holds whatever its caller passed -- a schema node, a pattern binding, a
+ * builder artifact -- and asking it to prove membership first would be asking
+ * a different question than the one it needs answered. So that pair subtracts
+ * the fabric special objects and nothing else: a `Date`, a `Map`, a `Cell`, a
+ * query-result proxy over one all still answer `true`, which is what leaves a
+ * walk's treatment of everything outside the type where it found it.
  */
 
 import { backtickQuote } from "@commonfabric/utils/markdown";

--- a/packages/data-model/src/type-check.ts
+++ b/packages/data-model/src/type-check.ts
@@ -15,13 +15,17 @@
  * whether it may be read by name; where one accepts something membership
  * refuses, the difference is stated on that narrowing rather than here.
  *
- * The `isWalkable*` pair is the exception, and takes `unknown`. A structural
- * walk holds whatever its caller passed -- a schema node, a pattern binding, a
- * builder artifact -- and asking it to prove membership first would be asking
- * a different question than the one it needs answered. So that pair subtracts
- * the fabric special objects and nothing else: a `Date`, a `Map`, a `Cell`, a
- * query-result proxy over one all still answer `true`, which is what leaves a
- * walk's treatment of everything outside the type where it found it.
+ * The `isWalkable*` pair is the exception on both counts. It takes `unknown`,
+ * because a structural walk holds whatever its caller passed -- a schema node,
+ * a pattern binding, a builder artifact -- and asking it to prove membership
+ * first would be asking a different question than the one it needs answered.
+ * Outside the `FabricValue` type it subtracts nothing: a `Date`, a `Map`, a
+ * `Cell` and a query-result proxy over one all still answer `true`, which is
+ * what leaves a walk's treatment of them where it found it. Inside the type it
+ * separates the two special-object arms, which differ on exactly the question
+ * being asked: a `FabricPrimitive` is a leaf and answers `false`, while a
+ * `FabricInstance` is a container no walk can descend yet and is refused
+ * rather than answered.
  */
 
 import { backtickQuote } from "@commonfabric/utils/markdown";
@@ -43,10 +47,12 @@ import {
   FabricInstance,
   type FabricNativeObject,
   type FabricPlainObject,
+  FabricPrimitive,
   FabricSpecialObject,
   type FabricValue,
   type FabricValueLayer,
 } from "./interface.ts";
+import { refuseFabricInstance } from "./refuse-fabric-instance.ts";
 import { VALUE_TAGS } from "./VALUE_TAGS.ts";
 import { tagFromNativeBuiltinClass } from "./tagFromNativeBuiltinClass.ts";
 import { BaseFabricInstance } from "./fabric-bases/BaseFabricInstance.ts";
@@ -54,38 +60,44 @@ import { BaseFabricPrimitive } from "./fabric-bases/BaseFabricPrimitive.ts";
 
 /**
  * Indicates whether a value's contents are reachable by property name: a
- * non-`null` object, an array included, that is not a `FabricSpecialObject`.
+ * non-`null` object, an array included, that is not a `FabricPrimitive`.
  *
  * This is the question a structural walk asks before it reads, rebuilds,
  * merges, or descends a value by its keys, and it is the question
- * `isObjectOrArray()` answers wrong. A `FabricSpecialObject` keeps its state in
+ * `isObjectOrArray()` answers wrong. A `FabricPrimitive` keeps its state in
  * private fields and has no own properties at all, so `isObjectOrArray()`
- * accepts it and the walk then works on an empty record: it merges to `{}`,
- * compares vacuously equal, descends and finds nothing, or grafts a property
- * onto a frozen value. Every one of those loses the value the model does hold.
+ * calls it a record and the walk then works on an empty one: it merges to
+ * `{}`, compares vacuously equal, descends and finds nothing, or grafts a
+ * property onto a frozen value. Every one of those loses the value the model
+ * does hold. A `false` answer tells the walk to stop and carry it whole, which
+ * is the complete story for a leaf: no path addresses anything inside one, so
+ * stopping leaves nothing unvisited.
  *
- * A `false` answer for a special object tells the walk to stop and carry the
- * value whole. That is the complete story for a `FabricPrimitive`, which is a
- * leaf: no path addresses anything inside one, so stopping leaves nothing
- * unvisited. A `FabricInstance` is a container whose contents are reachable
- * only through its codec, so stopping there does leave those contents
- * unvisited -- but property-name access never reached them either, and the
- * sites that must not pass one by refuse it outright rather than walk it (see
- * "Flag-gated tripwires" in `docs/development/EXPERIMENTAL_OPTIONS.md`).
+ * A `FabricInstance` gets neither answer, and is refused. It is a container --
+ * it holds other `FabricValue`s, and a walk is *supposed* to descend it -- so
+ * `false` would be a claim that it holds nothing, and `true` would send the
+ * caller into a property surface its codec does not speak for. The honest
+ * answer is "not yet", which is not a boolean, and the refusal is what carries
+ * it. This is deliberately the same refusal every other walk in the tree
+ * raises; "Flag-gated tripwires" in
+ * `docs/development/EXPERIMENTAL_OPTIONS.md` governs them all.
+ *
+ * That shape is also what makes the descent, once it exists, a one-line change
+ * here rather than an audit of every caller: a walk able to descend an
+ * instance turns this refusal into `true`, and every site that already handles
+ * the refusal is already correct.
+ *
+ * A caller that can meet an instance and has something better to say than a
+ * throw -- an error its own signature already carries -- tests for one before
+ * asking this. `attestation.ts`'s `resolve()` is the worked example, answering
+ * with the type mismatch its `Result` is declared to return.
  *
  * This is the walk-side half of admitting special objects; the compare-side
- * half is `fabricAwareEqual()`. One keeps a special object out of walks
- * that would decompose it, the other out of comparisons that would conflate it.
- *
- * `isFabricPlainContainer()` asks this same question of a value the type
- * system already says is a `FabricValue`, and where a caller holds one that is
- * the predicate to reach for. This one takes `unknown`, which is what the
- * walks in `runner` hold: a schema node, a pattern binding, a builder
- * artifact. The two differ on exactly the values a `FabricValue` cannot be --
- * a `Cell`, a `Date`, a `Map`, a query-result proxy over one -- which this
- * admits and `isFabricPlainContainer()` refuses. Neither answer is wrong;
- * subtracting only the fabric special objects is what leaves a walk's
- * treatment of everything else where it found it.
+ * half is `fabricAwareEqual()`. `isFabricPlainContainer()` asks the container
+ * question of a value the type system already says is a `FabricValue`, and is
+ * what a caller holding one reaches for; this takes `unknown`, which is what
+ * the walks in `runner` hold, and so still admits a `Date`, a `Map`, a `Cell`
+ * and a query-result proxy over one.
  *
  * Like its `utils` counterparts, the name settles the array question, and the
  * sibling `isWalkableObjectNotArray()` is the same test with arrays removed.
@@ -93,24 +105,32 @@ import { BaseFabricPrimitive } from "./fabric-bases/BaseFabricPrimitive.ts";
  * overloaded accordingly; see the header of `@commonfabric/utils/types` for
  * what that means. The narrowed type is read-only: the walks this serves
  * rebuild containers rather than write through them.
+ *
+ * @throws If given a `FabricInstance`.
  */
 export function isWalkableObjectOrArray(value: ReadonlyRecord): boolean;
 export function isWalkableObjectOrArray(
   value: unknown,
 ): value is ReadonlyRecord;
 export function isWalkableObjectOrArray(value: unknown): boolean {
-  return typeof value === "object" && value !== null &&
-    !(value instanceof FabricSpecialObject);
+  if (typeof value !== "object" || value === null) return false;
+  if (value instanceof FabricInstance) {
+    refuseFabricInstance(value, "in a structural walk");
+  }
+  return !(value instanceof FabricPrimitive);
 }
 
 /**
- * Indicates whether a value's contents are reachable by property name and it is
- * not an array: {@link isWalkableObjectOrArray} with arrays removed, and
- * `isObjectNotArray()` with the fabric special objects removed.
+ * Indicates whether a value's contents are reachable by property name and it
+ * is not an array: {@link isWalkableObjectOrArray} with arrays removed, and
+ * `isObjectNotArray()` with the fabric primitives removed.
  *
  * A walk asks this one where an array is not merely a different shape but
  * something it must not treat as a record -- a property merge, a
- * record-versus-array container reset.
+ * record-versus-array container reset. It refuses a `FabricInstance` for the
+ * same reason its sibling does.
+ *
+ * @throws If given a `FabricInstance`.
  */
 export function isWalkableObjectNotArray(value: ReadonlyRecord): boolean;
 export function isWalkableObjectNotArray(

--- a/packages/data-model/src/valueEqual.ts
+++ b/packages/data-model/src/valueEqual.ts
@@ -1,3 +1,4 @@
+import { deepEqual } from "@commonfabric/utils/deep-equal";
 import { backtickQuote } from "@commonfabric/utils/markdown";
 import { isPlainObject } from "@commonfabric/utils/types";
 import { isDeepFrozen } from "./deep-freeze.ts";
@@ -131,6 +132,86 @@ export function valueEqual(a: FabricValue, b: FabricValue): boolean {
 
   // No quick check managed to disqualify full-scale comparison. So it goes.
   return hashStringOf(a) === hashStringOf(b);
+}
+
+/**
+ * Compares two values of unknown type for logical equality: the way
+ * {@link valueEqual} does where the data model can decide them, and the way
+ * `deepEqual()` does where it cannot, with every `FabricSpecialObject` reached
+ * along that second path still decided by content.
+ *
+ * This is the comparison for an operand that is *allowed* to hold a
+ * `FabricValue` without being known to be one: a schema `const` against a
+ * stored value, a schema default against a materialized one, a write against
+ * the value it replaces, a request against the snapshot a policy was checked
+ * over. Neither half serves alone. `valueEqual()` is defined over
+ * `FabricValue`s and throws on any other class instance, which these operands
+ * still carry -- a `Cell`, a query-result proxy. `deepEqual()` compares by
+ * enumerable own-properties, and a special object has none, so on its own it
+ * reads two distinct same-class ones as equal and a gate built on it passes
+ * values it exists to distinguish.
+ *
+ * Asking the model first is what decides a value it admits by content rather
+ * than by property walk, and it is also the cheaper order, `valueEqual()`
+ * comparing deep-frozen operands by a content hash cached on identity.
+ *
+ * The order is visible in one case, and it is a case neither half speaks for.
+ * `valueEqual()` calls a null-prototype object equal to a plain object holding
+ * the same contents, where `deepEqual()` separates them on their constructors;
+ * `isValidFabricValue()` meanwhile does not admit a null-prototype object at
+ * all, so this is two functions answering about a value outside the type
+ * rather than the model settling it. The order here follows what the sites
+ * that need this comparison already did, not that case.
+ *
+ * Cross-kind pairs on the structural path answer `false` rather than throwing:
+ * a special object is equal only to another special object, so pairing one
+ * with a plain record, an array, or any other instance settles the comparison
+ * without asking the data model about a value that is not its business. A pair
+ * whose class cannot yet be hashed still throws, from either path; see
+ * `valueEqual()`.
+ *
+ * The `catch` takes everything, and a narrower one does not work. What it is
+ * for is `valueEqual()` declining operands outside the type, so the obvious
+ * refinement is to ask `isValidFabricValue()` on the way out and re-raise
+ * where both operands are values the model does admit -- a `FabricMap` or a
+ * `FabricSet`, whose codecs are stubs. Measured, that breaks three tests, and
+ * the reason generalizes: what `valueEqual()` can compare is not what the type
+ * admits. `isValidFabricValue()` carries a `seen` set and answers for a cyclic
+ * value; `hashStringOf()` has none and exhausts the stack on one. So a
+ * `RangeError` from a legal cyclic record reaches the same `catch` as a
+ * refusal, and it is not the model reporting on its own values.
+ *
+ * The fallback answering where the hash cannot is the feature rather than the
+ * hazard, which the tempting counter-example gets backwards: comparing
+ * `{ v: aFabricMap }` against `{ v: 5 }` returns `false` here, not because a
+ * failure was swallowed but because a `FabricMap` is not equal to `5` and the
+ * walk can see that without hashing anything. Where a comparison does turn on
+ * a stub class, the two operands meet at `specialObjectEqual()`, which hands
+ * them back to `valueEqual()` and lets the refusal out.
+ *
+ * This is the compare-side half of admitting special objects; the walk-side
+ * half is `isWalkableObjectOrArray()`.
+ */
+export function fabricAwareEqual(a: unknown, b: unknown): boolean {
+  try {
+    return valueEqual(a as FabricValue, b as FabricValue);
+  } catch {
+    return deepEqual(a, b, specialObjectEqual);
+  }
+}
+
+/**
+ * Helper for {@link fabricAwareEqual}, deciding the object pairs in which
+ * either side is a `FabricSpecialObject` and declining the rest.
+ */
+function specialObjectEqual(a: object, b: object): boolean | undefined {
+  const aIsSpecial = a instanceof FabricSpecialObject;
+  const bIsSpecial = b instanceof FabricSpecialObject;
+
+  if (!(aIsSpecial || bIsSpecial)) return undefined;
+  if (!(aIsSpecial && bIsSpecial)) return false;
+
+  return valueEqual(a, b);
 }
 
 /**

--- a/packages/data-model/test/fabricAwareEqual.test.ts
+++ b/packages/data-model/test/fabricAwareEqual.test.ts
@@ -1,0 +1,240 @@
+/**
+ * The comparison for an operand that is allowed to hold a `FabricValue`
+ * without being known to be one.
+ *
+ * Two things are being pinned, and they pull in opposite directions. Every
+ * fabric special object must be decided by content, wherever it sits, because
+ * a property walk sees no content on one and calls every two of the same class
+ * equal. And every value the data model does not own must still be decided the
+ * way `deepEqual()` decides it, because these operands carry those too and
+ * `valueEqual()` refuses them.
+ *
+ * The nesting cases are the ones that matter most: a comparison that only
+ * checked its arguments would pass a fabric value hidden one key down straight
+ * to the property walk that conflates it.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { fabricAwareEqual } from "@/index.ts";
+import { FabricError } from "@/fabric-instances/FabricError.ts";
+import { FabricLink } from "@/fabric-instances/FabricLink.ts";
+import { FabricMap } from "@/fabric-instances/FabricMap.ts";
+import { FabricSet } from "@/fabric-instances/FabricSet.ts";
+import { FabricBytes } from "@/fabric-primitives/FabricBytes.ts";
+import { FabricEpochDay } from "@/fabric-primitives/FabricEpochDay.ts";
+import { FabricEpochNsec } from "@/fabric-primitives/FabricEpochNsec.ts";
+import { FabricHash } from "@/fabric-primitives/FabricHash.ts";
+import { FabricRegExp } from "@/fabric-primitives/FabricRegExp.ts";
+
+/** Fixed `FabricError` state, so two built the same way agree in every slot. */
+const errorState = (message: string) => ({
+  type: "Error",
+  name: "Error",
+  message,
+  stack: undefined,
+  cause: undefined,
+});
+
+/**
+ * A distinct-but-equal pair of each special-object kind, plus a third value of
+ * the same kind that differs. The pairs are built fresh per case so no case
+ * can pass on reference identity.
+ */
+const SPECIAL_OBJECT_KINDS: readonly {
+  name: string;
+  make: () => unknown;
+  makeEqual: () => unknown;
+  makeDifferent: () => unknown;
+}[] = [
+  {
+    name: "FabricBytes",
+    make: () => new FabricBytes(new Uint8Array([1, 2, 3])),
+    makeEqual: () => new FabricBytes(new Uint8Array([1, 2, 3])),
+    makeDifferent: () => new FabricBytes(new Uint8Array([1, 2, 4])),
+  },
+  {
+    name: "FabricEpochNsec",
+    make: () => new FabricEpochNsec(1_700_000_000_000_000_000n),
+    makeEqual: () => new FabricEpochNsec(1_700_000_000_000_000_000n),
+    makeDifferent: () => new FabricEpochNsec(1_700_000_000_000_000_001n),
+  },
+  {
+    name: "FabricEpochDay",
+    make: () => new FabricEpochDay(20_000n),
+    makeEqual: () => new FabricEpochDay(20_000n),
+    makeDifferent: () => new FabricEpochDay(20_001n),
+  },
+  {
+    name: "FabricRegExp",
+    make: () => new FabricRegExp("es2025", "a+", "g"),
+    makeEqual: () => new FabricRegExp("es2025", "a+", "g"),
+    makeDifferent: () => new FabricRegExp("es2025", "b+", "g"),
+  },
+  {
+    name: "FabricHash",
+    make: () => new FabricHash(new Uint8Array([9, 9]), "fid1"),
+    makeEqual: () => new FabricHash(new Uint8Array([9, 9]), "fid1"),
+    makeDifferent: () => new FabricHash(new Uint8Array([9, 8]), "fid1"),
+  },
+  {
+    // Built from explicit state rather than from a thrown `Error`, whose
+    // captured stack differs per construction site and would make two
+    // otherwise-identical errors unequal for a reason unrelated to this.
+    name: "FabricError",
+    make: () => new FabricError(errorState("boom")),
+    makeEqual: () => new FabricError(errorState("boom")),
+    makeDifferent: () => new FabricError(errorState("other")),
+  },
+  {
+    name: "FabricLink",
+    make: () => new FabricLink({ id: "of:fid1:aaa" }),
+    makeEqual: () => new FabricLink({ id: "of:fid1:aaa" }),
+    makeDifferent: () => new FabricLink({ id: "of:fid1:bbb" }),
+  },
+];
+
+describe("fabricAwareEqual()", () => {
+  describe("given a bare special object of each kind", () => {
+    for (const kind of SPECIAL_OBJECT_KINDS) {
+      it(`compares a \`${kind.name}\` by content`, () => {
+        expect(fabricAwareEqual(kind.make(), kind.makeEqual())).toBe(true);
+        expect(fabricAwareEqual(kind.make(), kind.makeDifferent()))
+          .toBe(false);
+      });
+    }
+  });
+
+  describe("given a special object nested inside a container", () => {
+    for (const kind of SPECIAL_OBJECT_KINDS) {
+      it(`compares a \`${kind.name}\` under a record key by content`, () => {
+        expect(
+          fabricAwareEqual({ v: kind.make() }, { v: kind.makeEqual() }),
+        ).toBe(true);
+        expect(
+          fabricAwareEqual({ v: kind.make() }, { v: kind.makeDifferent() }),
+        ).toBe(false);
+      });
+
+      it(`compares a \`${kind.name}\` at an array index by content`, () => {
+        expect(fabricAwareEqual([kind.make()], [kind.makeEqual()]))
+          .toBe(true);
+        expect(fabricAwareEqual([kind.make()], [kind.makeDifferent()]))
+          .toBe(false);
+      });
+
+      it(`compares a \`${kind.name}\` several levels down by content`, () => {
+        const nest = (leaf: unknown) => ({ a: [{ b: { c: leaf } }] });
+        expect(fabricAwareEqual(nest(kind.make()), nest(kind.makeEqual())))
+          .toBe(true);
+        expect(
+          fabricAwareEqual(nest(kind.make()), nest(kind.makeDifferent())),
+        ).toBe(false);
+      });
+    }
+  });
+
+  describe("given a special object whose codec is still a stub", () => {
+    // `FabricMap` and `FabricSet` cannot be hashed, so their content equality
+    // has no answer to give and `valueEqual()` says so by throwing. Reaching
+    // that throw is the point: it names the class that owes the work, where
+    // the property walk would have called every two of them equal and said
+    // nothing. Do not soften this to a `catch`.
+    it("throws for two `FabricMap`s rather than calling them equal", () => {
+      expect(() =>
+        fabricAwareEqual(
+          new FabricMap(new Map([["a", 1]])),
+          new FabricMap(new Map([["a", 2]])),
+        )
+      ).toThrow("not yet implemented");
+    });
+
+    it("throws for two `FabricSet`s rather than calling them equal", () => {
+      expect(() =>
+        fabricAwareEqual(
+          new FabricSet(new Set([1])),
+          new FabricSet(new Set([2])),
+        )
+      ).toThrow("not yet implemented");
+    });
+
+    it("throws for one nested under a record key too", () => {
+      expect(() =>
+        fabricAwareEqual(
+          { v: new FabricSet(new Set([1])) },
+          { v: new FabricSet(new Set([2])) },
+        )
+      ).toThrow("not yet implemented");
+    });
+  });
+
+  describe("given a special object against something else", () => {
+    it("answers `false` against a plain record", () => {
+      const bytes = new FabricBytes(new Uint8Array([1]));
+      expect(fabricAwareEqual(bytes, {})).toBe(false);
+      expect(fabricAwareEqual({}, bytes)).toBe(false);
+    });
+
+    it("answers `false` against an array", () => {
+      const bytes = new FabricBytes(new Uint8Array([1]));
+      expect(fabricAwareEqual(bytes, [])).toBe(false);
+      expect(fabricAwareEqual([], bytes)).toBe(false);
+    });
+
+    it("answers `false` against a special object of another class", () => {
+      expect(
+        fabricAwareEqual(
+          new FabricBytes(new Uint8Array([1])),
+          new FabricEpochNsec(1n),
+        ),
+      ).toBe(false);
+    });
+
+    it("answers `false` against a scalar", () => {
+      const bytes = new FabricBytes(new Uint8Array([1]));
+      expect(fabricAwareEqual(bytes, 1)).toBe(false);
+      expect(fabricAwareEqual(bytes, null)).toBe(false);
+      expect(fabricAwareEqual(bytes, undefined)).toBe(false);
+    });
+
+    it("answers `false` against a non-fabric class instance, without throwing", () => {
+      const bytes = new FabricBytes(new Uint8Array([1]));
+      expect(fabricAwareEqual(bytes, new Date(0))).toBe(false);
+      expect(fabricAwareEqual(new Date(0), bytes)).toBe(false);
+    });
+  });
+
+  describe("given values the data model does not own", () => {
+    it("compares scalars the way `deepEqual()` does", () => {
+      expect(fabricAwareEqual(1, 1)).toBe(true);
+      expect(fabricAwareEqual("a", "a")).toBe(true);
+      expect(fabricAwareEqual(NaN, NaN)).toBe(true);
+      expect(fabricAwareEqual(0, -0)).toBe(false);
+      expect(fabricAwareEqual(1, "1")).toBe(false);
+    });
+
+    it("compares plain containers structurally", () => {
+      expect(fabricAwareEqual({ a: [1, { b: 2 }] }, { a: [1, { b: 2 }] }))
+        .toBe(true);
+      expect(fabricAwareEqual({ a: [1, { b: 2 }] }, { a: [1, { b: 3 }] }))
+        .toBe(false);
+      expect(fabricAwareEqual([1, 2], [1, 2, 3])).toBe(false);
+    });
+
+    it("compares a non-fabric class instance by its own properties", () => {
+      class Point {
+        constructor(readonly x: number) {}
+      }
+      expect(fabricAwareEqual(new Point(1), new Point(1))).toBe(true);
+      expect(fabricAwareEqual(new Point(1), new Point(2))).toBe(false);
+    });
+
+    it("compares a `Date` the way `deepEqual()` does, not by its time", () => {
+      // A `Date` carries no own properties, so the property walk calls any two
+      // equal. `fabricAwareEqual()` widens `deepEqual()` for fabric values
+      // only, and this pins that it does not quietly widen further.
+      expect(fabricAwareEqual(new Date(0), new Date(1))).toBe(true);
+    });
+  });
+});

--- a/packages/data-model/test/refuse-fabric-instance.test.ts
+++ b/packages/data-model/test/refuse-fabric-instance.test.ts
@@ -16,11 +16,11 @@ import {
   FabricMap,
 } from "@commonfabric/data-model/fabric-instances";
 
-import { refuseFabricInstance } from "../src/fabric-special-object.ts";
+import { refuseFabricInstance } from "@/refuse-fabric-instance.ts";
 
 const FABRIC_ERROR = FabricError.fromNativeError(new Error("boom"));
 
-describe("fabric-special-object", () => {
+describe("refuse-fabric-instance", () => {
   describe("refuseFabricInstance", () => {
     /** Runs the refusal and hands back the `Error` it threw. */
     function thrownBy(

--- a/packages/data-model/test/type-check.test.ts
+++ b/packages/data-model/test/type-check.test.ts
@@ -1169,18 +1169,23 @@ describe("type-check", () => {
         ).toBe(false);
       });
 
-      it("returns `false` for each `FabricInstance` kind", () => {
-        expect(
-          isWalkableObjectOrArray(FabricError.fromNativeError(new Error("x"))),
-        )
-          .toBe(false);
-        expect(isWalkableObjectOrArray(new FabricMap(new Map([["a", 1]]))))
-          .toBe(false);
-        expect(isWalkableObjectOrArray(new FabricSet(new Set([1])))).toBe(
-          false,
-        );
-        expect(isWalkableObjectOrArray(new FabricLink({ id: "of:fid1:abc" })))
-          .toBe(false);
+      it("throws for each `FabricInstance` kind", () => {
+        // An instance is a container, so neither answer is available yet:
+        // `false` claims it holds nothing, and `true` sends the caller into a
+        // property surface its codec does not speak for.
+
+        for (
+          const instance of [
+            FabricError.fromNativeError(new Error("x")),
+            new FabricMap(new Map([["a", 1]])),
+            new FabricSet(new Set([1])),
+            new FabricLink({ id: "of:fid1:abc" }),
+          ]
+        ) {
+          expect(() => isWalkableObjectOrArray(instance)).toThrow(
+            "`FabricInstance`) in a structural walk",
+          );
+        }
       });
     });
 
@@ -1215,11 +1220,14 @@ describe("type-check", () => {
       expect(isWalkableObjectNotArray([1, 2, 3])).toBe(false);
     });
 
-    it("returns `false` for a `FabricSpecialObject`", () => {
+    it("returns `false` for a `FabricPrimitive`", () => {
       expect(isWalkableObjectNotArray(new FabricBytes(new Uint8Array([1]))))
         .toBe(false);
-      expect(isWalkableObjectNotArray(new FabricMap(new Map([["a", 1]]))))
-        .toBe(false);
+    });
+
+    it("throws for a `FabricInstance`", () => {
+      expect(() => isWalkableObjectNotArray(new FabricMap(new Map([["a", 1]]))))
+        .toThrow("`FabricInstance`) in a structural walk");
     });
 
     it("returns `false` for a value with no contents to walk", () => {

--- a/packages/data-model/test/type-check.test.ts
+++ b/packages/data-model/test/type-check.test.ts
@@ -687,6 +687,12 @@ describe("type-check", () => {
     });
 
     describe("given a non-container `FabricValue`", () => {
+      it("returns `false` for a direct `FabricSpecialObject` subclass", () => {
+        class DirectSpecialObject extends FabricSpecialObject {}
+
+        expect(isWalkableObjectNotArray(new DirectSpecialObject())).toBe(false);
+      });
+
       it("returns `false` for a `FabricPrimitive`", () => {
         // The whole of the difference from `isFabricObjectOrArray()`, which
         // accepts these: a `FabricPrimitive` self-freezes at construction and
@@ -1170,16 +1176,13 @@ describe("type-check", () => {
         ).toBe(false);
       });
 
-      it("returns `false` for a direct subclass that is neither arm", () => {
-        // The `false` arm is every special object other than an instance, and
-        // not the `FabricPrimitive` half of the pair alone. A subclass this
-        // module knows nothing else about still has no own properties, so it
-        // is a leaf as far as keys go.
+      it("returns `false` for a direct `FabricSpecialObject` subclass", () => {
+        // Every special object the refusal above does not claim is carried
+        // whole, decided by class rather than by what the subclass declares.
 
         class DirectSpecialObject extends FabricSpecialObject {}
 
         expect(isWalkableObjectOrArray(new DirectSpecialObject())).toBe(false);
-        expect(isWalkableObjectNotArray(new DirectSpecialObject())).toBe(false);
       });
 
       it("throws for each `FabricInstance` kind", () => {

--- a/packages/data-model/test/type-check.test.ts
+++ b/packages/data-model/test/type-check.test.ts
@@ -26,6 +26,8 @@ import {
   isValidFabricPlainObject,
   isValidFabricValue,
   isValidFabricValueLayer,
+  isWalkableObjectNotArray,
+  isWalkableObjectOrArray,
 } from "@/type-check.ts";
 import type { FabricValue } from "@/interface.ts";
 import { VALUE_TAGS } from "@/VALUE_TAGS.ts";
@@ -34,8 +36,14 @@ import { codecClasses } from "@/fabric-primitives/index.ts";
 import { shallowFabricFromNativeValue } from "@/native-conversion.ts";
 import { LAYER_CORPUS, PlainClass } from "./fabric-value-corpus.ts";
 import { FabricError } from "@/fabric-instances/FabricError.ts";
+import { FabricLink } from "@/fabric-instances/FabricLink.ts";
+import { FabricMap } from "@/fabric-instances/FabricMap.ts";
+import { FabricSet } from "@/fabric-instances/FabricSet.ts";
 import { FabricBytes } from "@/fabric-primitives/FabricBytes.ts";
+import { FabricEpochDay } from "@/fabric-primitives/FabricEpochDay.ts";
 import { FabricEpochNsec } from "@/fabric-primitives/FabricEpochNsec.ts";
+import { FabricHash } from "@/fabric-primitives/FabricHash.ts";
+import { FabricRegExp } from "@/fabric-primitives/FabricRegExp.ts";
 
 describe("type-check", () => {
   describe("isValidFabricValueLayer()", () => {
@@ -1118,6 +1126,106 @@ describe("type-check", () => {
           );
         });
       }
+    });
+  });
+
+  describe("isWalkableObjectOrArray()", () => {
+    describe("given a container a walk may read by property name", () => {
+      it("returns `true` for a plain object", () => {
+        expect(isWalkableObjectOrArray({})).toBe(true);
+        expect(isWalkableObjectOrArray({ a: 1, b: "two" })).toBe(true);
+      });
+
+      it("returns `true` for a null-prototype object", () => {
+        expect(isWalkableObjectOrArray(Object.create(null))).toBe(true);
+      });
+
+      it("returns `true` for an array", () => {
+        expect(isWalkableObjectOrArray([])).toBe(true);
+        expect(isWalkableObjectOrArray([1, 2, 3])).toBe(true);
+      });
+
+      it("returns `true` for a non-fabric class instance", () => {
+        // The predicate subtracts exactly the fabric special objects from
+        // `isObjectOrArray()`; it is not the narrower plain-container question.
+        expect(isWalkableObjectOrArray(new Date())).toBe(true);
+        expect(isWalkableObjectOrArray(new Map())).toBe(true);
+        expect(isWalkableObjectOrArray(/regex/)).toBe(true);
+      });
+    });
+
+    describe("given a `FabricSpecialObject`", () => {
+      it("returns `false` for each `FabricPrimitive` kind", () => {
+        expect(isWalkableObjectOrArray(new FabricBytes(new Uint8Array([1, 2]))))
+          .toBe(false);
+        expect(isWalkableObjectOrArray(new FabricEpochNsec(1n))).toBe(false);
+        expect(isWalkableObjectOrArray(new FabricEpochDay(1n))).toBe(false);
+        expect(isWalkableObjectOrArray(new FabricRegExp("es2025", "a+", "g")))
+          .toBe(false);
+        expect(
+          isWalkableObjectOrArray(
+            new FabricHash(new Uint8Array([1, 2]), "fid1"),
+          ),
+        ).toBe(false);
+      });
+
+      it("returns `false` for each `FabricInstance` kind", () => {
+        expect(
+          isWalkableObjectOrArray(FabricError.fromNativeError(new Error("x"))),
+        )
+          .toBe(false);
+        expect(isWalkableObjectOrArray(new FabricMap(new Map([["a", 1]]))))
+          .toBe(false);
+        expect(isWalkableObjectOrArray(new FabricSet(new Set([1])))).toBe(
+          false,
+        );
+        expect(isWalkableObjectOrArray(new FabricLink({ id: "of:fid1:abc" })))
+          .toBe(false);
+      });
+    });
+
+    describe("given a value with no contents to walk", () => {
+      it("returns `false` for `null` and `undefined`", () => {
+        expect(isWalkableObjectOrArray(null)).toBe(false);
+        expect(isWalkableObjectOrArray(undefined)).toBe(false);
+      });
+
+      it("returns `false` for a scalar", () => {
+        expect(isWalkableObjectOrArray(1)).toBe(false);
+        expect(isWalkableObjectOrArray("a")).toBe(false);
+        expect(isWalkableObjectOrArray(true)).toBe(false);
+        expect(isWalkableObjectOrArray(42n)).toBe(false);
+        expect(isWalkableObjectOrArray(Symbol.for("s"))).toBe(false);
+      });
+
+      it("returns `false` for a function", () => {
+        expect(isWalkableObjectOrArray(() => {})).toBe(false);
+      });
+    });
+  });
+
+  describe("isWalkableObjectNotArray()", () => {
+    it("returns `true` for a plain object", () => {
+      expect(isWalkableObjectNotArray({})).toBe(true);
+      expect(isWalkableObjectNotArray({ a: 1 })).toBe(true);
+    });
+
+    it("returns `false` for an array", () => {
+      expect(isWalkableObjectNotArray([])).toBe(false);
+      expect(isWalkableObjectNotArray([1, 2, 3])).toBe(false);
+    });
+
+    it("returns `false` for a `FabricSpecialObject`", () => {
+      expect(isWalkableObjectNotArray(new FabricBytes(new Uint8Array([1]))))
+        .toBe(false);
+      expect(isWalkableObjectNotArray(new FabricMap(new Map([["a", 1]]))))
+        .toBe(false);
+    });
+
+    it("returns `false` for a value with no contents to walk", () => {
+      expect(isWalkableObjectNotArray(null)).toBe(false);
+      expect(isWalkableObjectNotArray(undefined)).toBe(false);
+      expect(isWalkableObjectNotArray(1)).toBe(false);
     });
   });
 });

--- a/packages/data-model/test/type-check.test.ts
+++ b/packages/data-model/test/type-check.test.ts
@@ -29,6 +29,7 @@ import {
   isWalkableObjectNotArray,
   isWalkableObjectOrArray,
 } from "@/type-check.ts";
+import { FabricSpecialObject } from "@/interface.ts";
 import type { FabricValue } from "@/interface.ts";
 import { VALUE_TAGS } from "@/VALUE_TAGS.ts";
 import { tagFromNativeValue } from "@/native-type-tags.ts";
@@ -1167,6 +1168,18 @@ describe("type-check", () => {
             new FabricHash(new Uint8Array([1, 2]), "fid1"),
           ),
         ).toBe(false);
+      });
+
+      it("returns `false` for a direct subclass that is neither arm", () => {
+        // The `false` arm is every special object other than an instance, and
+        // not the `FabricPrimitive` half of the pair alone. A subclass this
+        // module knows nothing else about still has no own properties, so it
+        // is a leaf as far as keys go.
+
+        class DirectSpecialObject extends FabricSpecialObject {}
+
+        expect(isWalkableObjectOrArray(new DirectSpecialObject())).toBe(false);
+        expect(isWalkableObjectNotArray(new DirectSpecialObject())).toBe(false);
       });
 
       it("throws for each `FabricInstance` kind", () => {

--- a/packages/piece/src/ops/clone-data-guards.ts
+++ b/packages/piece/src/ops/clone-data-guards.ts
@@ -9,7 +9,10 @@ import {
   type IExtendedStorageTransaction,
 } from "@commonfabric/runner";
 import { cfcLabelViewForCellFailClosed } from "@commonfabric/runner/cfc";
-import { FabricInstance, FabricPrimitive } from "@commonfabric/data-model";
+import {
+  FabricInstance,
+  isWalkableObjectOrArray,
+} from "@commonfabric/data-model";
 import { commitPreconditionValueHash } from "@commonfabric/memory/v2";
 
 export function cloneCellKey(cell: Cell<unknown>): string {
@@ -34,10 +37,7 @@ export function assertNoCloneFabricInstance(
       "piece data containing FabricInstance values cannot be copied",
     );
   }
-  if (
-    value === null || typeof value !== "object" ||
-    value instanceof FabricPrimitive || seen.has(value)
-  ) {
+  if (!isWalkableObjectOrArray(value) || seen.has(value)) {
     return;
   }
   seen.add(value);

--- a/packages/piece/src/ops/clone-data-snapshot.ts
+++ b/packages/piece/src/ops/clone-data-snapshot.ts
@@ -10,7 +10,11 @@ import {
   isCellResult,
   isStream,
 } from "@commonfabric/runner";
-import { FabricInstance, FabricPrimitive } from "@commonfabric/data-model";
+import {
+  FabricInstance,
+  FabricSpecialObject,
+  isWalkableObjectOrArray,
+} from "@commonfabric/data-model";
 import {
   assertCloneDataUnlabeled,
   assertNoCloneFabricInstance,
@@ -54,10 +58,7 @@ export function snapshotCloneValue(
       "piece data containing FabricInstance values cannot be copied",
     );
   }
-  if (
-    value === null || typeof value !== "object" ||
-    value instanceof FabricPrimitive
-  ) {
+  if (!isWalkableObjectOrArray(value)) {
     return value;
   }
 
@@ -142,8 +143,7 @@ export async function preloadCloneValue(
   assertCloneDataUnlabeled(value);
   if (
     value === null || typeof value !== "object" ||
-    value instanceof FabricPrimitive || value instanceof FabricInstance ||
-    seen.has(value)
+    value instanceof FabricSpecialObject || seen.has(value)
   ) {
     return;
   }

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -1,5 +1,5 @@
 import type { CellKind, LinkScope } from "@commonfabric/api";
-import { taggedHashStringOf } from "@commonfabric/data-model";
+import { fabricAwareEqual, taggedHashStringOf } from "@commonfabric/data-model";
 import { getLogger } from "@commonfabric/utils/logger";
 import {
   applyPieceSourceTransition,
@@ -1819,12 +1819,7 @@ function linkMatchesCommittedState(
     ...basePath,
     ...suppliedLink.path,
   ]);
-  // TODO(danfuzz): `deepEqual` compares class instances by enumerable
-  // own-props, of which a `FabricLink` has none — under the modern cell rep
-  // any two `FabricLink`s compare equal, so a link pointing somewhere else
-  // entirely passes as "restoring committed bytes" and skips the rebuild
-  // rules. Fails open; `valueEqual` is the fabric-aware comparison.
-  return deepEqual(committed, suppliedLink.value);
+  return fabricAwareEqual(committed, suppliedLink.value);
 }
 
 /** Wrap a per-concern failure in the uniform supplied-link rejection. */

--- a/packages/piece/src/schema-compatibility.ts
+++ b/packages/piece/src/schema-compatibility.ts
@@ -1,5 +1,4 @@
 import {
-  deepEqual,
   extractDefaultValues,
   type JSONSchema,
   type Pattern,
@@ -15,7 +14,7 @@ import {
 } from "@commonfabric/runner/cfc";
 import { isFabricPrimitiveSchemaType } from "@commonfabric/api";
 import { internSchema } from "@commonfabric/data-model-schema";
-import { type FabricValue, valueEqual } from "@commonfabric/data-model";
+import { fabricAwareEqual } from "@commonfabric/data-model";
 
 type SchemaObject = Exclude<JSONSchema, boolean>;
 type SchemaRole = "argument" | "result";
@@ -146,14 +145,6 @@ const SEMANTIC_EXTENSION_KEYS = [
   "scope",
   "writeOnly",
 ] as const;
-
-const fabricAwareEqual = (left: unknown, right: unknown): boolean => {
-  try {
-    return valueEqual(left as FabricValue, right as FabricValue);
-  } catch {
-    return deepEqual(left, right);
-  }
-};
 
 /**
  * The keys inside a `writeAuthorizedBy` writer claim's `__ctWriterIdentityOf`

--- a/packages/runner/src/builder/node-utils.ts
+++ b/packages/runner/src/builder/node-utils.ts
@@ -4,7 +4,7 @@ import { isObjectOrArray } from "@commonfabric/utils/types";
 import { isCell } from "../cell.ts";
 import { ContextualFlowControl } from "../cfc.ts";
 import type { CfcConfClause } from "../cfc/clause.ts";
-import { refuseFabricInstance } from "../fabric-special-object.ts";
+import { refuseFabricInstance } from "@commonfabric/data-model";
 import {
   getCellOrThrow,
   isCellResultForDereferencing,

--- a/packages/runner/src/builder/pattern.ts
+++ b/packages/runner/src/builder/pattern.ts
@@ -1,5 +1,9 @@
 import type { JSONSchemaObj } from "@commonfabric/api";
-import { hashStringOf, toCompactDebugString } from "@commonfabric/data-model";
+import {
+  hashStringOf,
+  isWalkableObjectOrArray,
+  toCompactDebugString,
+} from "@commonfabric/data-model";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
 import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
 
@@ -935,17 +939,15 @@ function assignComputedCellKinds(
       }
       return;
     }
-    // TODO(danfuzz): `isObjectOrArray` admits a `FabricInstance`, whose
-    // `Object.entries` are empty, so it takes this branch and collects
-    // nothing instead of falling to the fail-safe `collectAll()` below. A
-    // cell root reachable only through the instance's codec contents is
-    // then never disqualified from the `computed` tag — the ack-and-drop
-    // this function exists to prevent. (A `FabricPrimitive` passes the same
-    // gate, harmlessly: it holds no cell roots.)
-    if (isObjectOrArray(target) && !isReactive(target)) {
-      const properties = isObjectNotArray(schema.properties)
-        ? schema.properties
-        : undefined;
+    // A special object falls to the fail-safe `collectAll()` below: its
+    // contents are not reachable by property name, so walking one here would
+    // collect nothing and leave a cell root inside it undisqualified from the
+    // `computed` tag -- the ack-and-drop this function exists to prevent.
+    if (isWalkableObjectOrArray(target) && !isReactive(target)) {
+      const properties =
+        isObjectOrArray(schema.properties) && !Array.isArray(schema.properties)
+          ? schema.properties
+          : undefined;
       for (const [key, child] of Object.entries(target)) {
         const childSchema = properties !== undefined && key in properties
           ? properties[key]

--- a/packages/runner/src/builder/to-encodable-form.ts
+++ b/packages/runner/src/builder/to-encodable-form.ts
@@ -8,7 +8,7 @@ import {
   FabricPrimitive,
   shallowFabricFromNativeObjectElseUndefined,
 } from "@commonfabric/data-model";
-import { refuseFabricInstance } from "../fabric-special-object.ts";
+import { refuseFabricInstance } from "@commonfabric/data-model";
 import { type AliasBinding, isAliasBinding } from "../alias-binding.ts";
 import {
   type FabricExecPlainObject,

--- a/packages/runner/src/builder/traverse-utils.ts
+++ b/packages/runner/src/builder/traverse-utils.ts
@@ -1,6 +1,6 @@
 import { isObjectOrArray } from "@commonfabric/utils/types";
 import { FabricInstance, FabricPrimitive } from "@commonfabric/data-model";
-import { refuseFabricInstance } from "../fabric-special-object.ts";
+import { refuseFabricInstance } from "@commonfabric/data-model";
 import { type FactoryInput, isPattern, isReactive } from "./types.ts";
 import { noteDerivedCopy } from "./pattern-metadata.ts";
 import { isCell } from "../cell.ts";

--- a/packages/runner/src/builder/traverse-utils.ts
+++ b/packages/runner/src/builder/traverse-utils.ts
@@ -1,5 +1,5 @@
 import { isObjectOrArray } from "@commonfabric/utils/types";
-import { FabricInstance, FabricPrimitive } from "@commonfabric/data-model";
+import { FabricInstance, FabricSpecialObject } from "@commonfabric/data-model";
 import { refuseFabricInstance } from "@commonfabric/data-model";
 import { type FactoryInput, isPattern, isReactive } from "./types.ts";
 import { noteDerivedCopy } from "./pattern-metadata.ts";
@@ -49,16 +49,16 @@ export function traverseValue(
     );
   }
 
-  // Traverse value. A `FabricPrimitive` is an atomic value whose state lives in
-  // private fields (zero enumerable own-props); descending into one would
-  // rebuild it as `{}`, corrupting it. It has already been shown to `fn` above
-  // like any other leaf — here we just decline to descend, so the original
-  // instance passes through intact.
+  // Traverse value. A `FabricSpecialObject` is an atomic value whose state
+  // lives in private fields (zero enumerable own-props); descending into one
+  // would rebuild it as `{}`, corrupting it. It has already been shown to `fn`
+  // above like any other leaf — here we just decline to descend, so the
+  // original instance passes through intact.
   if (
     !isReactive(value) &&
     !isCell(value) &&
     !isCellResultForDereferencing(value) &&
-    !((value as object) instanceof FabricPrimitive) &&
+    !((value as object) instanceof FabricSpecialObject) &&
     (isObjectOrArray(value) || isPattern(value))
   ) {
     if (Array.isArray(value)) {

--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -5,6 +5,7 @@ import {
   FabricInstance,
   FabricPrimitive,
   type FabricValue,
+  isWalkableObjectOrArray,
 } from "@commonfabric/data-model";
 import {
   entityRefToString,
@@ -282,24 +283,24 @@ function resolveRefsForLLM(
     // Recurse into object properties (does not increment refDepth)
     //
     // TODO(danfuzz): this rebuild recurses into every object-valued key, so it
-    // also descends into `default`/`examples` VALUES — and a
-    // `FabricSpecialObject` there comes out as `{}` (`Object.entries` sees none
-    // of its state). The sibling `simplifySchemaForContext` carries `default`
-    // by reference via `PRESERVE_KEYS`; this walk wants the same treatment for
-    // value-bearing keys.
+    // also descends into `default`/`examples` VALUES, and rewrites whatever
+    // schema keywords it finds spelled inside one. The sibling
+    // `simplifySchemaForContext` carries `default` by reference via
+    // `PRESERVE_KEYS`; this walk wants the same treatment for value-bearing
+    // keys.
+    //
+    // A `FabricSpecialObject` is carried by reference either way: the rebuild
+    // reads a node by property name and would answer `{}` for one.
     const result: any = {};
     for (const [key, value] of Object.entries(nodeObj)) {
       if (key === "$defs") continue; // strip $defs from output
       if (Array.isArray(value)) {
         result[key] = value.map((item) =>
-          typeof item === "object" && item !== null || typeof item === "boolean"
+          isWalkableObjectOrArray(item) || typeof item === "boolean"
             ? resolve(item, refDepth, activeRefs)
             : item
         );
-      } else if (
-        typeof value === "object" && value !== null ||
-        typeof value === "boolean"
-      ) {
+      } else if (isWalkableObjectOrArray(value) || typeof value === "boolean") {
         result[key] = resolve(value, refDepth, activeRefs);
       } else {
         result[key] = value;

--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -77,7 +77,7 @@ import {
 } from "../cfc/types.ts";
 import { getEntityId } from "../create-ref.ts";
 import { entityUriSchemePrefix } from "../entity-kind.ts";
-import { refuseFabricInstance } from "../fabric-special-object.ts";
+import { refuseFabricInstance } from "@commonfabric/data-model";
 import { resolveLink } from "../link-resolution.ts";
 import {
   createLLMFriendlyLink,

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -2680,24 +2680,8 @@ export class CellImpl<T extends FabricValue>
       throw new Error("Can't remove from non-array value");
     }
     const array = got as ElemT[];
-    // TODO(danfuzz): `typeof ref === "object"` routes a `FabricPrimitive`
-    // (or `FabricInstance`) ref to `areLinksSame`, which parses both
-    // operands as links and returns `false` when either is not one — so a
-    // fabric-valued ref matches only by reference identity, never by value,
-    // and the call otherwise silently no-ops. The sibling `removeByValue`
-    // has the right shape: link comparison for cells, `valueEqual` (which
-    // has a fabric arm) for everything else.
     const index = typeof ref === "object"
-      ? array.findIndex((item) =>
-        areLinksSame(
-          item,
-          ref,
-          this as unknown as Cell<any>,
-          true, // resolveBeforeComparing
-          this.tx,
-          this.runtime,
-        )
-      )
+      ? array.findIndex((item) => this.refMatchesElement(ref, item))
       // Primitives match by `Object.is` (`NaN` is findable; `0` and `-0` are
       // distinct), unlike `indexOf`'s `===`.
       : array.findIndex((item) => Object.is(item, ref));
@@ -2721,24 +2705,42 @@ export class CellImpl<T extends FabricValue>
       throw new Error("Can't remove from non-array value");
     }
     const array = got as ElemT[];
-    // TODO(danfuzz): same gap as `remove()` above — a fabric-valued `ref`
-    // reaches `areLinksSame` and matches only by reference identity, never
-    // by value, so the call otherwise silently no-ops.
     // Cast needed: TS can't prove ElemT[] reconstitutes to T
     const newArray = array.filter((item) =>
       typeof ref === "object"
-        ? !areLinksSame(
-          item,
-          ref,
-          this as unknown as Cell<any>,
-          true, // resolveBeforeComparing
-          this.tx,
-          this.runtime,
-        )
+        ? !this.refMatchesElement(ref, item)
         // As in `remove()`: primitives match by `Object.is`.
         : !Object.is(item, ref)
     ) as unknown as T;
     this.set(newArray);
+  }
+
+  /**
+   * Whether an object-valued `remove()`/`removeAll()` argument names the given
+   * array element. A cell or a link names its element by link, which is what
+   * `areLinksSame()` decides. A `FabricSpecialObject` keeps its state in
+   * private fields, so a link comparison can only tell whether the two are the
+   * same object -- and two equal fabric values written at different times never
+   * are. Those name their element by content, the way `removeByValue()`
+   * matches.
+   */
+  private refMatchesElement(ref: unknown, element: unknown): boolean {
+    if (
+      areLinksSame(
+        element,
+        ref,
+        this as unknown as Cell<any>,
+        true, // resolveBeforeComparing
+        this.tx,
+        this.runtime,
+      )
+    ) {
+      return true;
+    }
+
+    return ref instanceof FabricSpecialObject &&
+      element instanceof FabricSpecialObject &&
+      valueEqual(element, ref);
   }
 
   equals(other: any): boolean {

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -119,7 +119,7 @@ import {
   dataUriFromValueWithResolvedLinks,
   findAndInlineDataUriLinks,
 } from "./data-uri.ts";
-import { refuseFabricInstance } from "./fabric-special-object.ts";
+import { refuseFabricInstance } from "@commonfabric/data-model";
 import { type LastNode, resolveLink } from "./link-resolution.ts";
 import {
   areLinksSame,

--- a/packages/runner/src/cfc/link-label-view.ts
+++ b/packages/runner/src/cfc/link-label-view.ts
@@ -20,7 +20,7 @@ import {
 } from "@commonfabric/data-model/cell-rep";
 import { IndexTrackingStack } from "@commonfabric/utils/index-tracking-stack";
 import { isObjectOrArray } from "@commonfabric/utils/types";
-import { refuseFabricInstance } from "../fabric-special-object.ts";
+import { refuseFabricInstance } from "@commonfabric/data-model";
 import type { CellLinkRefPayload, SigilLink } from "../sigil-types.ts";
 import type { CfcLabelView } from "./label-view-core.ts";
 

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -15,9 +15,11 @@ import {
 import {
   cloneForMutation,
   type CloneForMutationResult,
+  fabricAwareEqual,
   FabricInstance,
   FabricPrimitive,
   isFabricObjectOrArray,
+  isWalkableObjectOrArray,
   valueEqual,
 } from "@commonfabric/data-model";
 import type { MemorySpace, URI } from "@commonfabric/memory/interface";
@@ -1328,7 +1330,16 @@ const stripWriterIdentityStamp = (value: unknown): unknown => {
   if (Array.isArray(value)) {
     return value.map(stripWriterIdentityStamp);
   }
-  if (!isObjectOrArray(value)) {
+  // A fabric-valued node -- a schema `default`, say -- is carried by
+  // reference: rebuilding one by its properties would answer `{}` and erase
+  // the difference between two schemas that differ only there.
+  //
+  // TODO(danfuzz): this still rebuilds every plain record it meets, schema
+  // `default` VALUES included, so a default that happens to spell `file`
+  // beside `bundleId` has the stamp keys stripped out of it and compares
+  // equal to one that never carried them. Value-bearing keys want to be
+  // carried by reference too.
+  if (!isWalkableObjectOrArray(value)) {
     return value;
   }
 
@@ -1345,18 +1356,11 @@ const stripWriterIdentityStamp = (value: unknown): unknown => {
   return next;
 };
 
-// TODO(danfuzz): `stripWriterIdentityStamp` rebuilds every record node it
-// meets, including schema `default` VALUES, and a `FabricSpecialObject`
-// rebuilds as `{}` — so two schemas whose only difference is a
-// `FabricSpecialObject`-valued default compare equal here, and the candidate's
-// default is silently discarded by the merge-skip decisions this feeds. The
-// strip wants to carry value-bearing keys by reference and the comparison wants
-// a fabric-aware equality.
 const schemasEqualIgnoringWriterStamp = (
   left: JSONSchema,
   right: JSONSchema,
 ): boolean =>
-  deepEqual(
+  fabricAwareEqual(
     stripWriterIdentityStamp(left),
     stripWriterIdentityStamp(right),
   );
@@ -1881,19 +1885,16 @@ export const flowReadExcluded = (
 // non-link leaf (string, number, boolean, null) makes the value content.
 // Such writes get `structure` (shape-only) stamps instead of covering
 // `derived` ones — see `pureLinkContainerPaths`.
-// TODO(danfuzz): `isObjectOrArray` admits a `FabricSpecialObject`, whose
-// `Object.values` are empty and vacuously "all links" — so a `FabricBytes`
-// leaf, or a `FabricInstance` with real contents, classifies as pure link
-// structure and the write receives shape-only stamps in place of its content
-// label. Fails open. Wants a `FabricSpecialObject` test taking the
-// content-bearing (`false`) arm.
+// A `FabricSpecialObject` is a content leaf like any other: its state is
+// private, so enumerating it answers "no members" and would classify a byte
+// blob as pure structure.
 const isPureLinkStructure = (value: unknown): boolean => {
   if (value === undefined) return true;
   if (isPrimitiveCellLink(value)) return true;
   if (Array.isArray(value)) {
     return value.every((member) => isPureLinkStructure(member));
   }
-  if (isObjectOrArray(value)) {
+  if (isWalkableObjectOrArray(value)) {
     return Object.values(value).every((member) => isPureLinkStructure(member));
   }
   return false;
@@ -1925,11 +1926,9 @@ const pureLinkContainerPaths = (
     );
     return;
   }
-  // TODO(danfuzz): same `isObjectOrArray` gap as `isPureLinkStructure` above: a
-  // `FabricPrimitive` is pushed as if it were a container (a stamp path for
-  // an opaque leaf), and a `FabricInstance`'s codec contents are never
-  // enumerated, so nothing nested in one gets a per-slot stamp.
-  if (isObjectOrArray(value)) {
+  // A `FabricSpecialObject` mints no path here: it is a content leaf, not a
+  // container whose shape the writing transaction computed.
+  if (isWalkableObjectOrArray(value)) {
     out.push(path);
     for (const [key, member] of Object.entries(value)) {
       pureLinkContainerPaths(member, [...path, key], out);
@@ -3060,15 +3059,14 @@ const linkedWriteValueForPolicy = (
   });
 };
 
-// TODO(danfuzz): this descent (and `changedValuesAtPatternPath` below) gates on
-// `typeof value === "object"` and then `head in value`, both true-shaped for a
-// `FabricSpecialObject` — but no key of an instance's codec contents is an own
-// (or any) property, so a pattern path into one resolves to no values and the
-// policy condition it feeds is never evaluated for that content.
-// `changedValuesAtPatternPath`'s leaf case additionally compares with
-// `deepEqual`, which calls two same-class `FabricSpecialObject`s equal
-// regardless of contents, so a genuine change reads as "unchanged". Both fail
-// open.
+// A path segment never addresses anything inside a `FabricSpecialObject`, so
+// this descent and `changedValuesAtPatternPath` below both stop at one rather
+// than resolving the segment against its class surface.
+//
+// TODO(danfuzz): for a `FabricInstance` that is still an incomplete answer.
+// No key of its codec contents is reachable by property name, so a pattern
+// path into one resolves to no values and the policy condition it feeds is
+// never evaluated for that content. Fails open.
 const valuesAtPatternPath = (
   value: unknown,
   path: readonly string[],
@@ -3087,7 +3085,7 @@ const valuesAtPatternPath = (
     );
   }
 
-  if (value === null || value === undefined || typeof value !== "object") {
+  if (!isWalkableObjectOrArray(value)) {
     return [];
   }
   if (!(head in value)) {
@@ -3102,7 +3100,7 @@ const changedValuesAtPatternPath = (
   path: readonly string[],
 ): unknown[] => {
   if (path.length === 0) {
-    return deepEqual(value, previousValue) ? [] : [value];
+    return fabricAwareEqual(value, previousValue) ? [] : [value];
   }
 
   const [head, ...rest] = path;
@@ -3118,12 +3116,10 @@ const changedValuesAtPatternPath = (
     );
   }
 
-  if (value === null || value === undefined || typeof value !== "object") {
+  if (!isWalkableObjectOrArray(value)) {
     return [];
   }
-  const previousChild = previousValue !== null &&
-      previousValue !== undefined &&
-      typeof previousValue === "object"
+  const previousChild = isWalkableObjectOrArray(previousValue)
     ? (previousValue as Record<string, unknown>)[head]
     : undefined;
   if (!(head in value)) {
@@ -3217,20 +3213,14 @@ const policySchemaMatchesValue = (
     }
     return policySchemaMatchesValue(resolved, value, schemaRoot);
   }
-  // TODO(danfuzz): these `deepEqual` checks call two same-class fabric
-  // values equal regardless of contents, so a fabric-valued `const`/`enum`
-  // condition matches the wrong value; and the `properties` arm below admits
-  // a `FabricSpecialObject` through `isObjectOrArray` and reads `undefined` for
-  // every key, matching vacuously. Each fails open — the ifc entry applies
-  // (or the policy passes) with nothing actually checked. `valueEqual` and a
-  // `FabricSpecialObject` gate are the fabric-aware shapes;
-  // `schemaTypeMatchesValue` below already carries the type half.
-  if (schema.const !== undefined && !deepEqual(schema.const, value)) {
+  if (
+    schema.const !== undefined && !fabricAwareEqual(schema.const, value)
+  ) {
     return false;
   }
   if (
     Array.isArray(schema.enum) &&
-    !schema.enum.some((candidate) => deepEqual(candidate, value))
+    !schema.enum.some((candidate) => fabricAwareEqual(candidate, value))
   ) {
     return false;
   }
@@ -3254,7 +3244,9 @@ const policySchemaMatchesValue = (
       policySchemaMatchesValue(branch, value, schemaRoot)
     );
   }
-  if (isObjectOrArray(value) && isObjectOrArray(schema.properties)) {
+  // A special object has no property for a `properties` condition to read, so
+  // it falls past this arm rather than matching every child vacuously.
+  if (isWalkableObjectOrArray(value) && isObjectOrArray(schema.properties)) {
     return Object.entries(schema.properties).every(([key, childSchema]) =>
       value[key] === undefined ||
       policySchemaMatchesValue(childSchema, value[key], schemaRoot)
@@ -3443,11 +3435,7 @@ const ifcEntryAppliesToAttemptedWrite = (
     sawTargetWrite = true;
     const writePath = write.address.path.slice(1).map((entry) => String(entry));
     if (pathPatternMatches(path, writePath)) {
-      // TODO(danfuzz): `deepEqual` calls two same-class `FabricSpecialObject`s
-      // equal regardless of contents, so a genuine change to a slot holding
-      // one reads as "unchanged" and the ifc entry is skipped. Fails open;
-      // `valueEqual` is the fabric-aware comparison.
-      return !deepEqual(write.value, write.previousValue) &&
+      return !fabricAwareEqual(write.value, write.previousValue) &&
         wildcardPolicyMatchesValue(tx, target, schema, write.value, root);
     }
     if (concretePathHasPrefix(prefix, writePath)) {
@@ -4239,13 +4227,7 @@ const verifyExactCopyRequirements = (
       path: sourcePath,
     });
 
-    // TODO(danfuzz): `deepEqual` calls two same-class `FabricSpecialObject`s
-    // equal regardless of contents — under the modern cell rep even two
-    // `FabricLink`s to different documents — so an `exactCopyOf` claim over
-    // `FabricSpecialObject`-valued state verifies for values that are not
-    // copies, and the source label is carried anyway. Fails open; wants
-    // `valueEqual`.
-    if (!deepEqual(sourceValue, targetValue)) {
+    if (!fabricAwareEqual(sourceValue, targetValue)) {
       return `exactCopyOf failed at /${entry.path.join("/")}`;
     }
   }
@@ -4311,10 +4293,7 @@ const verifyProjectionRequirements = (
       path: sourcePath,
     });
 
-    // TODO(danfuzz): same `deepEqual` gap as `verifyExactCopyRequirements`
-    // above — fabric-valued state verifies as a projection when it is not
-    // one. Fails open; wants `valueEqual`.
-    if (!deepEqual(sourceValue, targetValue)) {
+    if (!fabricAwareEqual(sourceValue, targetValue)) {
       return `projection claim failed at /${entry.path.join("/")}`;
     }
   }

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -31,7 +31,7 @@ import { encodePointer } from "../../../memory/v2/path.ts";
 import type { JSONSchema } from "../builder/types.ts";
 import { ContextualFlowControl } from "../cfc.ts";
 import { entityKindOfIdString } from "../entity-kind.ts";
-import { refuseFabricInstance } from "../fabric-special-object.ts";
+import { refuseFabricInstance } from "@commonfabric/data-model";
 import {
   containsExternalSchemaRef,
   decomposeSchema,
@@ -1329,6 +1329,12 @@ const linkWritesCoverCfcAffectedPaths = (
 const stripWriterIdentityStamp = (value: unknown): unknown => {
   if (Array.isArray(value)) {
     return value.map(stripWriterIdentityStamp);
+  }
+  // A link is carried whole. It is a reference rather than a record of the
+  // writer's, so there is no stamp inside one to strip -- and under
+  // `modernCellRep` it is a `FabricLink`, which the walk question refuses.
+  if (isPrimitiveCellLink(value)) {
+    return value;
   }
   // A fabric-valued node -- a schema `default`, say -- is carried by
   // reference: rebuilding one by its properties would answer `{}` and erase
@@ -3085,7 +3091,11 @@ const valuesAtPatternPath = (
     );
   }
 
-  if (!isWalkableObjectOrArray(value)) {
+  // A pattern path does not descend through a link: the reference is the
+  // value at that slot, and what it points at is resolved elsewhere. Asked
+  // before the walk question, because `modernCellRep` makes a link a
+  // `FabricLink`, which that question refuses.
+  if (isPrimitiveCellLink(value) || !isWalkableObjectOrArray(value)) {
     return [];
   }
   if (!(head in value)) {
@@ -3116,10 +3126,13 @@ const changedValuesAtPatternPath = (
     );
   }
 
-  if (!isWalkableObjectOrArray(value)) {
+  // As in `valuesAtPatternPath`: a link ends the descent, and the test comes
+  // before the walk question for the same reason.
+  if (isPrimitiveCellLink(value) || !isWalkableObjectOrArray(value)) {
     return [];
   }
-  const previousChild = isWalkableObjectOrArray(previousValue)
+  const previousChild = !isPrimitiveCellLink(previousValue) &&
+      isWalkableObjectOrArray(previousValue)
     ? (previousValue as Record<string, unknown>)[head]
     : undefined;
   if (!(head in value)) {
@@ -3246,7 +3259,13 @@ const policySchemaMatchesValue = (
   }
   // A special object has no property for a `properties` condition to read, so
   // it falls past this arm rather than matching every child vacuously.
-  if (isWalkableObjectOrArray(value) && isObjectOrArray(schema.properties)) {
+  // A link matches by what it is, not by what a `properties` condition would
+  // read off it; and under `modernCellRep` asking the walk question of one
+  // refuses.
+  if (
+    !isPrimitiveCellLink(value) && isWalkableObjectOrArray(value) &&
+    isObjectOrArray(schema.properties)
+  ) {
     return Object.entries(schema.properties).every(([key, childSchema]) =>
       value[key] === undefined ||
       policySchemaMatchesValue(childSchema, value[key], schemaRoot)

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -1330,9 +1330,8 @@ const stripWriterIdentityStamp = (value: unknown): unknown => {
   if (Array.isArray(value)) {
     return value.map(stripWriterIdentityStamp);
   }
-  // A link is carried whole. It is a reference rather than a record of the
-  // writer's, so there is no stamp inside one to strip -- and under
-  // `modernCellRep` it is a `FabricLink`, which the walk question refuses.
+  // A sigil link is carried whole. It is a reference rather than a record of
+  // the writer's, so there is no stamp inside one to strip.
   if (isPrimitiveCellLink(value)) {
     return value;
   }
@@ -3091,10 +3090,10 @@ const valuesAtPatternPath = (
     );
   }
 
-  // A pattern path does not descend through a link: the reference is the
-  // value at that slot, and what it points at is resolved elsewhere. Asked
-  // before the walk question, because `modernCellRep` makes a link a
-  // `FabricLink`, which that question refuses.
+  // A pattern path does not descend through a sigil link: the reference is
+  // the value at that slot, and what it points at is resolved elsewhere.
+  // Asked before the walk question, which reads a sigil link as the record it
+  // is written as and would descend into it.
   if (isPrimitiveCellLink(value) || !isWalkableObjectOrArray(value)) {
     return [];
   }
@@ -3259,9 +3258,11 @@ const policySchemaMatchesValue = (
   }
   // A special object has no property for a `properties` condition to read, so
   // it falls past this arm rather than matching every child vacuously.
-  // A link matches by what it is, not by what a `properties` condition would
-  // read off it; and under `modernCellRep` asking the walk question of one
-  // refuses.
+  // A sigil link matches by what it is, not by what a `properties` condition
+  // would read off the record it is written as. Descending one reaches values
+  // the walk question refuses, which is what a modern argument link arriving
+  // here does; `isPrimitiveCellLink()` speaks only about the sigil form, so a
+  // `FabricLink` reaching this arm is refused rather than matched.
   if (
     !isPrimitiveCellLink(value) && isWalkableObjectOrArray(value) &&
     isObjectOrArray(schema.properties)

--- a/packages/runner/src/cfc/schema-merge.ts
+++ b/packages/runner/src/cfc/schema-merge.ts
@@ -1,11 +1,8 @@
+import { isWalkableObjectOrArray } from "@commonfabric/data-model";
 import type { CfcAtom } from "@commonfabric/api/cfc";
 import { internSchema } from "@commonfabric/data-model-schema";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
-import {
-  isObjectNotArray,
-  isObjectOrArray,
-  isReadonlyObjectOrArray,
-} from "@commonfabric/utils/types";
+import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
 
 import type { JSONSchema, JSONSchemaObj } from "../builder/types.ts";
 import { forEachSubschema } from "../schema-walk.ts";
@@ -502,11 +499,9 @@ const mergeRequired = (
   return merged;
 };
 
-// TODO(danfuzz): `isReadonlyObjectOrArray` admits a `FabricSpecialObject` on either
-// side, and the spread copies zero properties from one — so two fabric
-// defaults merge to `{}`, and a plain-record `existing` plus a fabric
-// `candidate` silently drops the candidate's value. Wants a
-// `FabricSpecialObject` test taking the `candidate` arm.
+// A fabric-valued default on either side takes the `candidate` arm: a special
+// object has no properties for the spread to copy, so merging one yields `{}`
+// and loses whichever side held the value.
 const mergeDefaults = (
   existing: JSONSchemaObj["default"],
   candidate: JSONSchemaObj["default"],
@@ -517,7 +512,7 @@ const mergeDefaults = (
   if (candidate === undefined) {
     return existing;
   }
-  if (isReadonlyObjectOrArray(existing) && isReadonlyObjectOrArray(candidate)) {
+  if (isWalkableObjectOrArray(existing) && isWalkableObjectOrArray(candidate)) {
     return { ...existing, ...candidate };
   }
   return candidate;

--- a/packages/runner/src/cfc/schema-sanitization.ts
+++ b/packages/runner/src/cfc/schema-sanitization.ts
@@ -12,13 +12,12 @@ import {
 } from "@commonfabric/data-model-schema";
 import {
   cloneIfNecessary,
+  fabricAwareEqual,
   type FabricPlainObject,
   FabricPrimitive,
   type FabricValue,
   isFabricPlainObject,
-  valueEqual,
 } from "@commonfabric/data-model";
-import { deepEqual } from "@commonfabric/utils/deep-equal";
 import {
   isObjectNotArray,
   isObjectOrArray,
@@ -675,14 +674,6 @@ const isAbsentOptional = (
   (value as Record<string, unknown>)[key] === undefined &&
   !requiredKeys.has(key);
 
-const schemaValueEqual = (left: unknown, right: unknown): boolean => {
-  try {
-    return valueEqual(left as FabricValue, right as FabricValue);
-  } catch {
-    return deepEqual(left, right);
-  }
-};
-
 const SUPPORTED_SCHEMA_TYPES = new Set([
   "unknown",
   "string",
@@ -1114,7 +1105,7 @@ const validateSchemaDefinitionInternal = (
       for (let index = 0; index < schema.enum.length; index++) {
         if (
           schema.enum.slice(0, index).some((entry) =>
-            schemaValueEqual(entry, schema.enum![index])
+            fabricAwareEqual(entry, schema.enum![index])
           )
         ) {
           return `${path}.enum: values must be unique`;
@@ -1806,13 +1797,13 @@ const validateAgainstSchemaInternal = (
 
     if (
       Array.isArray(schema.enum) &&
-      !schema.enum.some((entry) => schemaValueEqual(entry, value))
+      !schema.enum.some((entry) => fabricAwareEqual(entry, value))
     ) {
       return mismatch("value is not in enum");
     }
     if (
       Object.hasOwn(schema, "const") &&
-      !schemaValueEqual(schema.const, value)
+      !fabricAwareEqual(schema.const, value)
     ) {
       return mismatch("value does not match const");
     }
@@ -2095,7 +2086,7 @@ function validateStrictSchemaConstraints(
         if (!Object.hasOwn(value, index)) continue;
         if (
           value.slice(0, index).some((entry) =>
-            schemaValueEqual(entry, value[index])
+            fabricAwareEqual(entry, value[index])
           )
         ) {
           return mismatch("array items are not unique");

--- a/packages/runner/src/cfc/sink-request.ts
+++ b/packages/runner/src/cfc/sink-request.ts
@@ -1,4 +1,4 @@
-import { deepEqual } from "@commonfabric/utils/deep-equal";
+import { fabricAwareEqual } from "@commonfabric/data-model";
 import type { FabricValue } from "@commonfabric/api";
 import type { IExtendedStorageTransaction } from "../storage/interface.ts";
 import { createFrozenRequestSnapshot } from "./request-snapshot.ts";
@@ -74,13 +74,7 @@ export function verifySinkRequestRelease(
     return `missing sink-request policy input for ${sink}`;
   }
 
-  // TODO(danfuzz): `deepEqual` compares class instances by enumerable
-  // own-props, so two same-class `FabricPrimitive`s (or `FabricInstance`s)
-  // compare equal regardless of contents — a request differing from its
-  // policy-checked snapshot only in fabric content passes this release gate.
-  // Fails open; `valueEqual` from `data-model` is the fabric-aware
-  // comparison.
-  if (!deepEqual(match.request, request)) {
+  if (!fabricAwareEqual(match.request, request)) {
     return `sink-request policy input mismatch for ${sink}`;
   }
 

--- a/packages/runner/src/cfc/structured-result.ts
+++ b/packages/runner/src/cfc/structured-result.ts
@@ -1,4 +1,8 @@
 import type { JSONSchema } from "@commonfabric/api";
+import {
+  FabricSpecialObject,
+  isWalkableObjectOrArray,
+} from "@commonfabric/data-model";
 import { isObjectOrArray } from "@commonfabric/utils/types";
 import { isSubschema } from "../schema-walk.ts";
 import { cfcOpaqueLinkForPath } from "./observation.ts";
@@ -397,10 +401,6 @@ const itemSchemaForIndex = (
   return combineAllOf(itemSchemas);
 };
 
-// TODO(danfuzz): Latent — schemas don't admit `Fabric*` values on this path
-// today, but will in the not-too-distant future; at that point this guard-less
-// `isObjectOrArray`-walk fails (a `FabricPrimitive` is decomposed, a `FabricInstance`
-// is walked by internal slots rather than codec contents). Mark ahead of that.
 const sanitizeValueWithOpaqueLinks = (
   value: unknown,
   schema: JSONSchema,
@@ -443,7 +443,20 @@ const sanitizeValueWithOpaqueLinks = (
     });
     return { value: items, linkedStringCount, sealedPaths };
   }
-  if (isObjectOrArray(value)) {
+  if (value instanceof FabricSpecialObject) {
+    // Sealed, not shown and not walked. A special object holds its state
+    // behind no property name, so the record arm below cannot measure it
+    // against the schema the way the unmodeled-key policy measures a record --
+    // and a value this cannot model is a value whose contents may themselves
+    // be data. Sealing is the same answer that policy gives, arrived at for
+    // the same reason.
+    return {
+      value: cfcOpaqueLinkForPath(opaqueHandleId, path),
+      linkedStringCount: 0,
+      sealedPaths: [[...path]],
+    };
+  }
+  if (isWalkableObjectOrArray(value)) {
     if (
       valueIsOpaqueLinkObject(value) &&
       schemaAcceptsOpaqueLinkObject(schema, value, fullSchema, reserved)

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -12,6 +12,7 @@ import {
   type FabricPlainObject,
   FabricSpecialObject,
   type FabricValue,
+  isWalkableObjectNotArray,
   shallowFabricFromNativeObjectElseUndefined,
   toCompactDebugString,
 } from "@commonfabric/data-model";
@@ -19,7 +20,7 @@ import { linkRefFrom, linkRefPayload } from "@commonfabric/data-model/cell-rep";
 import { isFabricDataUri } from "@commonfabric/data-model/codec-data-uri";
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 import { getLogger } from "@commonfabric/utils/logger";
-import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 
 import { type CellScope, type JSONSchema } from "./builder/types.ts";
 import {
@@ -674,8 +675,7 @@ export function normalizeAndDiff(
     if (
       state.nextAnchorId !== undefined &&
       isArrayElement &&
-      isObjectNotArray(newValue) &&
-      !(newValue instanceof FabricSpecialObject) &&
+      isWalkableObjectNotArray(newValue) &&
       !isCellLink(newValue) &&
       seenLink.path.length > 0
     ) {
@@ -1316,8 +1316,7 @@ export function normalizeAndDiff(
   if (
     state.nextAnchorId !== undefined &&
     isArrayElement &&
-    isObjectNotArray(newValue) &&
-    !(newValue instanceof FabricSpecialObject) &&
+    isWalkableObjectNotArray(newValue) &&
     !isCellLink(newValue)
   ) {
     if (Object.is(currentValue, newValue)) {
@@ -1579,21 +1578,19 @@ export function normalizeAndDiff(
     );
     // If the current value is not a (regular) object, set it to an empty object.
     // Note that the alias case is handled above.
-    // We use `isObjectNotArray` (not `isObjectOrArray`) here deliberately: `isObjectOrArray` is true
-    // for arrays (`typeof [] === "object"`), whereas `isObjectNotArray` excludes them.
     // Resetting on an array→object transition is required; otherwise per-key
     // writes land in a slot whose stored parent is still an array and storage
     // rejects them with a TypeMismatchError. This mirrors the array branch
     // above, which resets a mismatched container via `value: []`.
     //
-    // TODO(danfuzz): `isObjectNotArray` is also true for a `FabricSpecialObject`, so
-    // a stored special object (which reaches storage whole via this
-    // function's `FabricSpecialObject` branch above) is treated as an
-    // existing plain record: no reset is emitted, its zero keys yield no
-    // removals, and the per-key child writes land in slots whose stored
-    // parent is still the special object. The special-object→object
-    // transition wants the same reset the array→object one gets.
-    if (!isObjectNotArray(currentValue) || isPrimitiveCellLink(currentValue)) {
+    // A stored special object gets that same reset, for the same reason: it
+    // reaches storage whole via the branch above, its zero keys yield no
+    // removals, and without a reset the per-key child writes would land in
+    // slots whose stored parent is still the special object.
+    if (
+      !isWalkableObjectNotArray(currentValue) ||
+      isPrimitiveCellLink(currentValue)
+    ) {
       diffLogger.debug(
         "diff",
         () =>

--- a/packages/runner/src/data-uri.ts
+++ b/packages/runner/src/data-uri.ts
@@ -37,7 +37,7 @@ import { isObjectOrArray } from "@commonfabric/utils/types";
 
 import { type Cell, isCell } from "./cell.ts";
 import { ContextualFlowControl } from "./cfc.ts";
-import { refuseFabricInstance } from "./fabric-special-object.ts";
+import { refuseFabricInstance } from "@commonfabric/data-model";
 import { isPrimitiveCellLink, type NormalizedLink } from "./link-types.ts";
 import {
   createSigilLinkFromParsedLink,

--- a/packages/runner/src/link-utils.ts
+++ b/packages/runner/src/link-utils.ts
@@ -2,6 +2,7 @@ import {
   deepFreeze,
   type FabricValue,
   isDeepFrozen,
+  isWalkableObjectOrArray,
   toCompactDebugString,
 } from "@commonfabric/data-model";
 import { linkRefFrom, linkRefPayload } from "@commonfabric/data-model/cell-rep";
@@ -655,16 +656,18 @@ function recursiveStripAsCellFromSchema(
   // Recursively process all object properties
   //
   // TODO(danfuzz): this loop filters by key name only, so it also descends
-  // into `default` and `examples` VALUES, and the recursion's shallow copy
-  // (`{ ...schema }` above) rebuilds whatever it meets: a fabric-valued
-  // default (which `Cell.of()` embeds into schemas) comes out as `{}` in the
-  // sanitized schema that rides on links. Value-bearing keys want to be
+  // into `default` and `examples` VALUES, and rewrites whatever schema
+  // keywords it finds spelled inside one. Value-bearing keys want to be
   // carried by reference, the way `simplifySchemaForContext` preserves them.
   for (const [key, value] of Object.entries(result)) {
     // Skip $ref - it's just a string pointer, not a schema to process
     if (key === "$ref") continue;
 
-    if (value && typeof value === "object") {
+    // A fabric value is carried by reference: the rebuild below reads it by
+    // property name and would answer `{}`, so a fabric-valued default (which
+    // `Cell.of()` embeds into schemas) would be lost from the sanitized
+    // schema that rides on links.
+    if (isWalkableObjectOrArray(value)) {
       if (key === "$defs") {
         // Process each definition in $defs (they contain schemas that may have asCell/asStream)
         const processedDefs: Record<string, any> = {};
@@ -673,7 +676,7 @@ function recursiveStripAsCellFromSchema(
             value as Record<string, any>,
           )
         ) {
-          if (defSchema && typeof defSchema === "object") {
+          if (isWalkableObjectOrArray(defSchema)) {
             processedDefs[defName] = recursiveStripAsCellFromSchema(
               defSchema,
               context,
@@ -687,7 +690,7 @@ function recursiveStripAsCellFromSchema(
       } else if (Array.isArray(value)) {
         // Handle arrays
         result[key] = value.map((item) =>
-          typeof item === "object" && item !== null
+          isWalkableObjectOrArray(item)
             ? recursiveStripAsCellFromSchema(
               item,
               context,

--- a/packages/runner/src/path-utils.ts
+++ b/packages/runner/src/path-utils.ts
@@ -1,5 +1,4 @@
-import { valueEqual } from "@commonfabric/data-model";
-import { isObjectOrArray } from "@commonfabric/utils/types";
+import { isWalkableObjectOrArray, valueEqual } from "@commonfabric/data-model";
 
 /**
  * Read one path segment out of a data container WITHOUT falling through to the
@@ -46,15 +45,11 @@ export function setValueAtPath(
     // prototype member would otherwise look like an existing non-object and
     // get descended into rather than created.
     //
-    // TODO(danfuzz): a `FabricSpecialObject` at a spine slot passes this
-    // test — it is its parent's own value and `typeof` "object" — so the
-    // walk descends into it; the next segment then reads `undefined` off
-    // its empty own surface, and the assignment writes the intermediate
-    // onto the special object itself: a `TypeError` on a frozen value, a
-    // codec-invisible graft on an unfrozen instance. (`getValueAtPath` and
-    // `hasValueAtPath` below return `undefined`/`false` for any path into
-    // a `FabricInstance`'s codec contents.)
-    if (typeof ownSegment(parent, key) !== "object") {
+    // A special object at a spine slot is replaced rather than descended, the
+    // same as a scalar: it holds no slot for the next segment, so writing
+    // through it would raise a `TypeError` on a frozen value or graft a
+    // property its codec never reads onto an unfrozen one.
+    if (!isWalkableObjectOrArray(ownSegment(parent, key))) {
       parent[key] = typeof path[i + 1] === "number" ? [] : {};
     }
     parent = parent[key];
@@ -87,7 +82,10 @@ export function getValueAtPath(obj: any, path: readonly PropertyKey[]): any {
 export function hasValueAtPath(obj: any, path: PropertyKey[]): boolean {
   let current = obj;
   for (const key of path) {
-    if (!isObjectOrArray(current) || !Object.hasOwn(current, key as string)) {
+    if (
+      !isWalkableObjectOrArray(current) ||
+      !Object.hasOwn(current, key as string)
+    ) {
       return false;
     }
     current = (current as Record<PropertyKey, unknown>)[key];

--- a/packages/runner/src/pattern-binding.ts
+++ b/packages/runner/src/pattern-binding.ts
@@ -1,8 +1,10 @@
 import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
 import {
+  fabricAwareEqual,
   FabricInstance,
   FabricPrimitive,
+  isWalkableObjectOrArray,
   toCompactDebugString,
   valueEqual,
 } from "@commonfabric/data-model";
@@ -449,12 +451,12 @@ function sendValueToBindingInner<T>(
         );
       }
     }
-    // TODO(danfuzz): Latent — schemas don't admit `Fabric*` values on this path
-    // today, but will in the not-too-distant future; at that point this
-    // guard-less walk keys a live `FabricValue` against the binding shape (a
-    // `FabricPrimitive` is decomposed, a `FabricInstance` is walked by internal
-    // slots rather than codec contents). Mark ahead of that.
-  } else if (isObjectOrArray(binding) && isObjectOrArray(value)) {
+    // A special object on either side is not keyed against the other: it is
+    // not a record, whatever its `typeof` says, so it falls to the constant
+    // comparison below rather than being decomposed key by key.
+  } else if (
+    isWalkableObjectOrArray(binding) && isWalkableObjectOrArray(value)
+  ) {
     for (const key of Object.keys(binding)) {
       if (key in value) {
         sendValueToBindingInner(
@@ -467,10 +469,14 @@ function sendValueToBindingInner<T>(
         );
       }
     }
-  } else if (!isObjectOrArray(binding) || Object.keys(binding).length !== 0) {
-    // `Object.is`, not `===`: a constant `NaN` binding legitimately matches a
-    // produced `NaN`, and `0` vs `-0` is a genuine mismatch.
-    if (!Object.is(binding, value)) {
+  } else if (
+    !isWalkableObjectOrArray(binding) || Object.keys(binding).length !== 0
+  ) {
+    // `fabricAwareEqual`, not `===`: it leads with `Object.is`, so a
+    // constant `NaN` binding legitimately matches a produced `NaN` and `0` vs
+    // `-0` is a genuine mismatch, and it compares a constant fabric binding by
+    // content rather than by identity.
+    if (!fabricAwareEqual(binding, value)) {
       throw new Error(`Got ${value} instead of ${binding}`);
     }
   }
@@ -875,17 +881,13 @@ export function findAllWriteRedirectCells<T>(
     } else if (Array.isArray(binding)) {
       // If the binding is an array, recurse into each element.
       for (const value of binding) find(value, baseCell);
-      // A `FabricPrimitive` reaches the `isObjectOrArray` branch below, and is
-      // harmless there. This walk collects write-redirect links, and a
-      // primitive is an opaque scalar: it can contain no redirect, and its
-      // state lives in private fields, so `Object.values()` yields nothing and
-      // the recursion ends immediately. Decomposition would matter to a walk
-      // that REBUILT its input; this one only reads.
+      // A special object ends the walk. A `FabricPrimitive` is an opaque
+      // scalar and can contain no redirect.
       //
-      // TODO(danfuzz): Latent — a `FabricInstance` is not harmless in the same
-      // way. It is a container reached by its codec contents rather than by
-      // property name, so a write redirect nested inside one is missed here.
-    } else if (isObjectOrArray(binding) && !isCellLink(binding)) {
+      // TODO(danfuzz): a `FabricInstance` can hold one, and its contents are
+      // reached by its codec rather than by property name, so a write redirect
+      // nested inside one is still missed here.
+    } else if (isWalkableObjectOrArray(binding) && !isCellLink(binding)) {
       // If the binding is an object, recurse into each value.
       for (const value of Object.values(binding)) find(value, baseCell);
     }

--- a/packages/runner/src/query-result-proxy.ts
+++ b/packages/runner/src/query-result-proxy.ts
@@ -1,4 +1,7 @@
-import { FabricPrimitive } from "@commonfabric/data-model";
+import {
+  FabricPrimitive,
+  isWalkableObjectOrArray,
+} from "@commonfabric/data-model";
 import { isObjectOrArray } from "@commonfabric/utils/types";
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 import { isStreamValue } from "./builder/types.ts";
@@ -801,15 +804,10 @@ export function isCellResult(value: any): value is CellResult<any> {
 export function snapshotQueryResult<T>(value: T): T {
   const seen = new WeakMap<object, unknown>();
   const snapshot = (current: unknown): unknown => {
-    // TODO(danfuzz): the leaf test covers `FabricPrimitive` but not
-    // `FabricInstance`, so an instance (live traffic — the fetch builtins
-    // store a `FabricError` result) falls to the `Object.keys` rebuild below
-    // and snapshots as `{}`, its codec contents lost. It wants the same
-    // leaf-through treatment until a codec-contents walk exists.
-    if (
-      current === null || typeof current !== "object" ||
-      current instanceof FabricPrimitive
-    ) return current;
+    // A special object leafs through whole. It has no own properties for the
+    // rebuild below to copy, so snapshotting one by its keys would answer
+    // `{}` and lose the value.
+    if (!isWalkableObjectOrArray(current)) return current;
     const existing = seen.get(current);
     if (existing !== undefined) return existing;
     if (Array.isArray(current)) {

--- a/packages/runner/src/reactive-dependencies.ts
+++ b/packages/runner/src/reactive-dependencies.ts
@@ -105,13 +105,15 @@ export function addressesToPathByEntity(
 /**
  * Whether the descent below may address `value` by key.
  *
- * A `FabricInstance` answers `false` here, ending the descent at it. This walk
- * runs under a storage subscription, which has to keep delivering, so an
- * instance it cannot address is left to reachability: a path continuing below
- * one is absent on both sides at the same depth, and triggers nothing.
+ * This is {@link isWalkableObjectOrArray} with its refusal of a
+ * `FabricInstance` replaced by `true`. The descent reads an instance by
+ * property name, reaching the accessors a `FabricError` carries and finding
+ * nothing on a `FabricMap`. Answering `false` would make an instance
+ * indistinguishable from a leaf, and a read below one would then stop
+ * triggering when the instance is deleted or replaced by a scalar.
  */
 function isKeyable(value: unknown): boolean {
-  return !(value instanceof FabricInstance) && isWalkableObjectOrArray(value);
+  return value instanceof FabricInstance || isWalkableObjectOrArray(value);
 }
 
 /**
@@ -164,17 +166,18 @@ export function determineTriggeredActions(
   const beforeValues: FabricValue[] = [before];
   const afterValues: FabricValue[] = [after];
 
-  // *LastObject: Last key-able object along currentPath. A special object is
-  // not key-able: its state sits behind no property name, so the descent stops
-  // at one and a path continuing below reads as unreachable rather than as
-  // present-and-empty.
+  // *LastObject: Last key-able object along currentPath. A `FabricPrimitive`
+  // is not key-able: its state sits behind no property name, so the descent
+  // stops at one and a path continuing below reads as unreachable rather than
+  // as present-and-empty.
   //
-  // TODO(danfuzz): stopping is the right answer for a `FabricPrimitive` and
-  // an incomplete one for a `FabricInstance`. A subscriber path continuing
-  // below an instance is unreachable on both sides at the same depth, so its
-  // action still never triggers however the instance's contents changed. The
-  // `shallowEqual` marker at the bottom of this file covers the leaf
-  // comparison; this is the descent's half of the same gap.
+  // TODO(danfuzz): a `FabricInstance` is descended by property name, which
+  // reaches what its class exposes that way and not what its codec holds. A
+  // subscriber path below a `FabricMap` or `FabricSet` therefore reads as
+  // present-and-empty on both sides, and its action never triggers however
+  // the contents changed. The `shallowEqual` marker at the bottom of this
+  // file covers the leaf comparison; this is the descent's half of the same
+  // gap.
   let beforeLastObject = isKeyable(before) ? 0 : -1;
   let afterLastObject = isKeyable(after) ? 0 : -1;
 

--- a/packages/runner/src/reactive-dependencies.ts
+++ b/packages/runner/src/reactive-dependencies.ts
@@ -1,5 +1,6 @@
 import { isPlainContainer } from "@commonfabric/utils/types";
 import {
+  FabricInstance,
   type FabricValue,
   isWalkableObjectOrArray,
   valueEqual,
@@ -102,6 +103,18 @@ export function addressesToPathByEntity(
 }
 
 /**
+ * Whether the descent below may address `value` by key.
+ *
+ * A `FabricInstance` answers `false` here, ending the descent at it. This walk
+ * runs under a storage subscription, which has to keep delivering, so an
+ * instance it cannot address is left to reachability: a path continuing below
+ * one is absent on both sides at the same depth, and triggers nothing.
+ */
+function isKeyable(value: unknown): boolean {
+  return !(value instanceof FabricInstance) && isWalkableObjectOrArray(value);
+}
+
+/**
  * Determines the actions that are triggered based on the changes to the data.
  *
  * Functionally equivalent looking for any `!deepEqual` for `getAtPath` for all
@@ -162,8 +175,8 @@ export function determineTriggeredActions(
   // action still never triggers however the instance's contents changed. The
   // `shallowEqual` marker at the bottom of this file covers the leaf
   // comparison; this is the descent's half of the same gap.
-  let beforeLastObject = isWalkableObjectOrArray(before) ? 0 : -1;
-  let afterLastObject = isWalkableObjectOrArray(after) ? 0 : -1;
+  let beforeLastObject = isKeyable(before) ? 0 : -1;
+  let afterLastObject = isKeyable(after) ? 0 : -1;
 
   while (subscribers.length > 0) {
     // Pull the next path from the queue
@@ -183,13 +196,13 @@ export function determineTriggeredActions(
     for (let i = overlap; i < targetPath.length; i++) {
       if (i <= beforeLastObject) {
         beforeValues[i + 1] = (beforeValues[i] as Keyable)[targetPath[i]!];
-        if (isWalkableObjectOrArray(beforeValues[i + 1])) {
+        if (isKeyable(beforeValues[i + 1])) {
           beforeLastObject = i + 1;
         } else beforeLastObject = i;
       }
       if (i <= afterLastObject) {
         afterValues[i + 1] = (afterValues[i] as Keyable)[targetPath[i]!];
-        if (isWalkableObjectOrArray(afterValues[i + 1])) {
+        if (isKeyable(afterValues[i + 1])) {
           afterLastObject = i + 1;
         } else afterLastObject = i;
       }

--- a/packages/runner/src/reactive-dependencies.ts
+++ b/packages/runner/src/reactive-dependencies.ts
@@ -1,5 +1,9 @@
-import { isObjectOrArray, isPlainContainer } from "@commonfabric/utils/types";
-import { type FabricValue, valueEqual } from "@commonfabric/data-model";
+import { isPlainContainer } from "@commonfabric/utils/types";
+import {
+  type FabricValue,
+  isWalkableObjectOrArray,
+  valueEqual,
+} from "@commonfabric/data-model";
 import type { ScopeKeyIdentity } from "@commonfabric/memory/v2";
 import { isPrimitiveCellLink } from "./link-utils.ts";
 import { normalizeCellScope } from "./scope.ts";
@@ -147,17 +151,19 @@ export function determineTriggeredActions(
   const beforeValues: FabricValue[] = [before];
   const afterValues: FabricValue[] = [after];
 
-  // *LastObject: Last key-able object along currentPath
+  // *LastObject: Last key-able object along currentPath. A special object is
+  // not key-able: its state sits behind no property name, so the descent stops
+  // at one and a path continuing below reads as unreachable rather than as
+  // present-and-empty.
   //
-  // TODO(danfuzz): `isObjectOrArray` counts a `FabricSpecialObject` as key-able, so
-  // the descent below indexes into one: every key reads `undefined` (or, via
-  // the prototype chain, an accessor result) on both the before and after
-  // side, so a subscriber path continuing below a `FabricInstance` compares
-  // equal-by-vacancy and its action never triggers, however the instance's
-  // contents changed. The `shallowEqual` marker at the bottom of this file
-  // covers the leaf comparison; this is the descent's half of the same gap.
-  let beforeLastObject = isObjectOrArray(before) ? 0 : -1;
-  let afterLastObject = isObjectOrArray(after) ? 0 : -1;
+  // TODO(danfuzz): stopping is the right answer for a `FabricPrimitive` and
+  // an incomplete one for a `FabricInstance`. A subscriber path continuing
+  // below an instance is unreachable on both sides at the same depth, so its
+  // action still never triggers however the instance's contents changed. The
+  // `shallowEqual` marker at the bottom of this file covers the leaf
+  // comparison; this is the descent's half of the same gap.
+  let beforeLastObject = isWalkableObjectOrArray(before) ? 0 : -1;
+  let afterLastObject = isWalkableObjectOrArray(after) ? 0 : -1;
 
   while (subscribers.length > 0) {
     // Pull the next path from the queue
@@ -177,13 +183,15 @@ export function determineTriggeredActions(
     for (let i = overlap; i < targetPath.length; i++) {
       if (i <= beforeLastObject) {
         beforeValues[i + 1] = (beforeValues[i] as Keyable)[targetPath[i]!];
-        if (isObjectOrArray(beforeValues[i + 1])) beforeLastObject = i + 1;
-        else beforeLastObject = i;
+        if (isWalkableObjectOrArray(beforeValues[i + 1])) {
+          beforeLastObject = i + 1;
+        } else beforeLastObject = i;
       }
       if (i <= afterLastObject) {
         afterValues[i + 1] = (afterValues[i] as Keyable)[targetPath[i]!];
-        if (isObjectOrArray(afterValues[i + 1])) afterLastObject = i + 1;
-        else afterLastObject = i;
+        if (isWalkableObjectOrArray(afterValues[i + 1])) {
+          afterLastObject = i + 1;
+        } else afterLastObject = i;
       }
     }
     currentPath = targetPath;

--- a/packages/runner/src/runner-utils.ts
+++ b/packages/runner/src/runner-utils.ts
@@ -1,13 +1,13 @@
 import {
+  fabricAwareEqual,
   type FabricValue,
   isFabricPlainObject,
   isValidFabricPlainObject,
+  isWalkableObjectOrArray,
   shallowMutableClone,
-  valueEqual,
 } from "@commonfabric/data-model";
 import { linkRefFrom } from "@commonfabric/data-model/cell-rep";
 import { internSchema } from "@commonfabric/data-model-schema";
-import { deepEqual } from "@commonfabric/utils/deep-equal";
 import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
 import {
   isModule,
@@ -31,19 +31,6 @@ import {
   isCellKind,
   isSchemaScope,
 } from "./scope.ts";
-
-const schemaDefaultValueEqual = (left: unknown, right: unknown): boolean => {
-  try {
-    return valueEqual(left as FabricValue, right as FabricValue);
-  } catch {
-    if (Object.is(left, right)) return true;
-    try {
-      return deepEqual(left, right);
-    } catch {
-      return false;
-    }
-  }
-};
 
 type ActiveDefaultMergePairs = WeakMap<
   object,
@@ -291,7 +278,7 @@ function extractDefaultValuesInternal(
       ).map((candidate) => candidate.value);
       return validCandidates.length > 0 &&
           validCandidates.every((candidate) =>
-            schemaDefaultValueEqual(candidate, validCandidates[0])
+            fabricAwareEqual(candidate, validCandidates[0])
           )
         ? validCandidates[0]
         : NO_SCHEMA_DEFAULT;
@@ -303,22 +290,17 @@ function extractDefaultValuesInternal(
       canonical.properties &&
       isObjectOrArray(canonical.properties)
     ) {
-      // TODO(danfuzz): `isObjectOrArray` admits a `FabricSpecialObject`, so a
-      // fabric-valued `default` under an object-with-properties schema skips
-      // this scalar return and proceeds below: `shallowMutableClone` returns
-      // a `FabricPrimitive` by identity (it is inherently frozen), so the
-      // first property-default assignment throws a `TypeError`; a
-      // `FabricInstance` gets own data properties grafted onto its clone
-      // that its codec never reads, and ships as the pattern's argument
-      // default. Wants a `FabricSpecialObject` test taking this return.
+      // A fabric-valued default takes this return alongside the scalars: it
+      // carries no properties for the assembly below to build on, and is
+      // already the whole of what the schema declares.
       if (
         Object.hasOwn(canonical, "default") &&
-        !isObjectOrArray(canonical.default)
+        !isWalkableObjectOrArray(canonical.default)
       ) {
         return canonical.default;
       }
       const hasObjectDefault = Object.hasOwn(canonical, "default") &&
-        isObjectOrArray(canonical.default);
+        isWalkableObjectOrArray(canonical.default);
       // Mutable top-level copy of the schema default, so injecting top-level
       // property defaults below doesn't mutate the schema's own default object.
       // Only top-level keys are written here, and the result is normalized
@@ -327,7 +309,7 @@ function extractDefaultValuesInternal(
       // children as inexpensive defense-in-depth against accidental deeper
       // mutation of the shared default.
       const obj = shallowMutableClone(
-        isObjectOrArray(canonical.default) ? canonical.default : {},
+        isWalkableObjectOrArray(canonical.default) ? canonical.default : {},
       ) as Record<string, FabricValue>;
       for (
         const [propKey, propSchema] of Object.entries(canonical.properties)
@@ -606,7 +588,7 @@ function mergeSchemaDefaultsInternal(
       if (
         acceptedCandidates.length > 0 &&
         acceptedCandidates.every((candidate) =>
-          schemaDefaultValueEqual(candidate, acceptedCandidates[0])
+          fabricAwareEqual(candidate, acceptedCandidates[0])
         )
       ) {
         return acceptedCandidates[0];
@@ -695,7 +677,7 @@ function mergeSchemaDefaultsInternal(
           activePairs,
         );
       }
-      return schemaDefaultValueEqual(result, value) ? value : result;
+      return fabricAwareEqual(result, value) ? value : result;
     }
 
     const objectSchema = typeof resolved === "object" && resolved !== null &&
@@ -781,9 +763,7 @@ function mergeSchemaDefaultsInternal(
         });
       }
     }
-    return valuePresent && schemaDefaultValueEqual(result, value)
-      ? value
-      : result;
+    return valuePresent && fabricAwareEqual(result, value) ? value : result;
   } finally {
     if (trackedSchema !== undefined) activeSchemas?.delete(trackedSchema);
   }

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -5,6 +5,7 @@ import {
   hashOf,
   hashStringOf,
   isDeepFrozen,
+  isWalkableObjectOrArray,
   nativeFromFabricValue,
   toCompactDebugString,
   valueEqual,
@@ -574,7 +575,7 @@ const recordOutputSchemaPolicyInputs = (
     );
   }
 
-  if (isObjectOrArray(outputBinding) && !isCellLink(outputBinding)) {
+  if (isWalkableObjectOrArray(outputBinding) && !isCellLink(outputBinding)) {
     for (const [key, child] of Object.entries(outputBinding)) {
       recordOutputSchemaPolicyInputs(
         tx,
@@ -649,11 +650,11 @@ const recordRawBuiltinBindingSchemaPolicyInputs = (
     return;
   }
 
-  // TODO(danfuzz): same gap as `recordOutputSchemaPolicyInputs()` above:
-  // `isObjectOrArray` admits a `FabricSpecialObject`, whose empty entries end the
-  // descent, so a link inside a `FabricInstance`'s codec contents records no
-  // policy input. Fails closed, as there.
-  if (isObjectOrArray(outputBinding) && !isCellLink(outputBinding)) {
+  // TODO(danfuzz): same gap as `recordOutputSchemaPolicyInputs()` above: the
+  // descent stops at a `FabricSpecialObject`, so a link inside a
+  // `FabricInstance`'s codec contents records no policy input. Fails closed,
+  // as there.
+  if (isWalkableObjectOrArray(outputBinding) && !isCellLink(outputBinding)) {
     for (const child of Object.values(outputBinding)) {
       recordRawBuiltinBindingSchemaPolicyInputs(
         tx,
@@ -807,12 +808,11 @@ export function firstResolvedOutputRedirect(
     }
     return undefined;
   }
-  // TODO(danfuzz): `isObjectOrArray` admits a `FabricSpecialObject`, whose empty
-  // entries end the descent, so a write-redirect link inside a
-  // `FabricInstance`'s codec contents is invisible here. The caller then
-  // sees no redirect and silently skips the sub-pattern's owned-cell
-  // pre-sync keyed off it.
-  if (isObjectOrArray(binding) && !isCellLink(binding)) {
+  // TODO(danfuzz): the descent stops at a `FabricSpecialObject`, so a
+  // write-redirect link inside a `FabricInstance`'s codec contents is
+  // invisible here. The caller then sees no redirect and silently skips the
+  // sub-pattern's owned-cell pre-sync keyed off it.
+  if (isWalkableObjectOrArray(binding) && !isCellLink(binding)) {
     for (const child of Object.values(binding)) {
       const found = firstResolvedOutputRedirect(
         runtime,
@@ -5891,11 +5891,10 @@ export class Runner {
 
       if (link) {
         promises.add(this.runtime.getCellFromLink(link).sync());
-      } else if (isObjectOrArray(value)) {
-        // TODO(danfuzz): `isObjectOrArray` admits a `FabricSpecialObject`, and
-        // `for..in` sees none of its state, so a link nested in a
-        // `FabricInstance`'s codec contents is never synced here — the cold
-        // target this pre-sync exists to warm.
+      } else if (isWalkableObjectOrArray(value)) {
+        // TODO(danfuzz): the walk stops at a `FabricSpecialObject`, so a link
+        // nested in a `FabricInstance`'s codec contents is never synced here
+        // — the cold target this pre-sync exists to warm.
         for (const key in value) syncAllMentionedCells(value[key]);
       }
     };
@@ -6213,13 +6212,12 @@ export class Runner {
           );
           return;
         }
-        if (!isObjectOrArray(value)) return;
+        if (!isWalkableObjectOrArray(value)) return;
         if (!declared) {
-          // TODO(danfuzz): `isObjectOrArray` admits a `FabricSpecialObject`,
-          // and `for..in` sees none of its state, so a link inside a
-          // `FabricInstance` held in a raw argument value is never pre-synced
-          // — a cold target can then enter the commit basis, the exact
-          // failure this walk exists to prevent.
+          // TODO(danfuzz): the walk stops at a `FabricSpecialObject`, so a
+          // link inside a `FabricInstance` held in a raw argument value is
+          // never pre-synced — a cold target can then enter the commit basis,
+          // the exact failure this walk exists to prevent.
           for (const key in value) {
             // The undeclared scan keeps the remaining share of the overall
             // two-hop budget; the clamp states that transition explicitly.

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -73,7 +73,7 @@ import {
 } from "./cfc.ts";
 import { findAndInlineDataUriLinks } from "./data-uri.ts";
 import type { EntityKind } from "./entity-kind.ts";
-import { refuseFabricInstance } from "./fabric-special-object.ts";
+import { refuseFabricInstance } from "@commonfabric/data-model";
 import { MAX_PATH_RESOLUTION_LENGTH, resolveLink } from "./link-resolution.ts";
 import { FILTER_INPUT_SCHEMA } from "./builtins/filter.ts";
 import { FLATMAP_INPUT_SCHEMA } from "./builtins/flatmap.ts";

--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -5,10 +5,12 @@ import {
 } from "@commonfabric/api";
 import {
   cloneIfNecessary,
+  fabricAwareEqual,
   FabricInstance,
   FabricPrimitive,
   type FabricValue,
   isDeepFrozen,
+  isWalkableObjectOrArray,
   shallowMutableClone,
 } from "@commonfabric/data-model";
 import {
@@ -43,13 +45,8 @@ import {
   externalResolutionMissCount,
   onSchemaRegistryClear,
 } from "./schema-registry.ts";
-import { deepEqual } from "@commonfabric/utils/deep-equal";
 import { getLogger } from "@commonfabric/utils/logger";
-import {
-  isObjectNotArray,
-  isObjectOrArray,
-  isReadonlyObjectOrArray,
-} from "@commonfabric/utils/types";
+import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
 
 import { toMemorySpaceAddress } from "../src/link-utils.ts";
 import { type JSONSchema, type SchemaScope } from "./builder/types.ts";
@@ -289,18 +286,14 @@ const matchesConcreteValue = (
   if (!canBranchMatch(resolved, value)) {
     return false;
   }
-  // TODO(danfuzz): Latent — schemas don't admit `Fabric*` values on this
-  // validation path today, but will in the not-too-distant future; at that
-  // point these `deepEqual(const/enum, value)` checks mishandle a
-  // `FabricValue` (same-class `FabricPrimitive`s compare equal regardless of
-  // value). Mark ahead of that; use a Fabric-aware equality when the path
-  // becomes live.
-  if (resolved.const !== undefined && !deepEqual(resolved.const, value)) {
+  if (
+    resolved.const !== undefined && !fabricAwareEqual(resolved.const, value)
+  ) {
     return false;
   }
   if (
     Array.isArray(resolved.enum) &&
-    !resolved.enum.some((candidate) => deepEqual(candidate, value))
+    !resolved.enum.some((candidate) => fabricAwareEqual(candidate, value))
   ) {
     return false;
   }
@@ -866,17 +859,12 @@ export function mergeDefaults(
 
   // TODO(seefeld): What's the right thing to do for arrays?
   //
-  // TODO(danfuzz): `isReadonlyObjectOrArray` admits a `FabricSpecialObject` on
-  // either side, and the spread copies zero properties from one, so a
-  // fabric-valued default here merges to `{}` (or silently drops the other
-  // side's contribution). Reachable: the schema generator emits
-  // `{ type: "object" }` for the fabric-backed natives (`Date`, `RegExp`,
-  // `Uint8Array`), so a `Cell` of one of those with an object default in its
-  // schema takes the spread arm. Wants a `FabricSpecialObject` test choosing
-  // the `defaultValue` arm.
+  // A fabric-valued default on either side takes the `defaultValue` arm: a
+  // special object has no properties for the spread to copy, so merging one
+  // yields `{}` and loses whichever side held the value.
   const mergedDefault = base.type === "object" &&
-      isReadonlyObjectOrArray(base.default) &&
-      isReadonlyObjectOrArray(defaultValue)
+      isWalkableObjectOrArray(base.default) &&
+      isWalkableObjectOrArray(defaultValue)
     ? { ...base.default, ...defaultValue } as JSONValue
     : defaultValue as JSONValue;
 

--- a/packages/runner/src/shared.ts
+++ b/packages/runner/src/shared.ts
@@ -4,7 +4,7 @@
  * /!\ interfaces and utilities.
  */
 
-export { refuseFabricInstance } from "./fabric-special-object.ts";
+export { refuseFabricInstance } from "@commonfabric/data-model";
 export {
   isStoredArgumentSchemaRefusal,
   STORED_ARGUMENT_SCHEMA_REFUSAL,

--- a/packages/runner/src/storage/selector-tracker.ts
+++ b/packages/runner/src/storage/selector-tracker.ts
@@ -1,5 +1,8 @@
 import type { FabricValue, SchemaPathSelector } from "@commonfabric/api";
-import { isDeepFrozen } from "@commonfabric/data-model";
+import {
+  isDeepFrozen,
+  isWalkableObjectOrArray,
+} from "@commonfabric/data-model";
 import {
   hashSchema,
   internSchema,
@@ -383,16 +386,18 @@ export class SelectorTracker<T = Result<Unit, Error>> {
       return byContent;
     }
     // TODO(danfuzz): this rebuild filters by key name only, so it also
-    // rebuilds `default`/`examples` VALUES: `isObjectOrArray` admits a
-    // `FabricSpecialObject` and `Object.entries` sees none of its state, so
-    // a fabric-valued default standardizes to `{}` — losing the value in the
-    // interned schema and making two schemas that differ only in such a
-    // default intern identically. Value-bearing keys want to pass through by
-    // reference.
+    // rebuilds `default`/`examples` VALUES, dropping an `asCell` that a
+    // default value happens to spell. Value-bearing keys want to pass
+    // through by reference.
+    //
+    // A fabric value passes through by reference either way: the rebuild
+    // reads a node by property name and would standardize one to `{}`,
+    // losing it from the interned schema and making two schemas that differ
+    // only in such a default intern identically.
     const traverse = (
       value: Readonly<any>,
     ): FabricValue => {
-      if (isObjectOrArray(value)) {
+      if (isWalkableObjectOrArray(value)) {
         if (Array.isArray(value)) {
           return value.map((val) => traverse(val));
         } else {

--- a/packages/runner/src/storage/transaction/attestation.ts
+++ b/packages/runner/src/storage/transaction/attestation.ts
@@ -1,5 +1,6 @@
 import {
   type DebugValueOptions,
+  FabricInstance,
   type FabricPlainObject,
   FabricSpecialObject,
   type FabricValue,
@@ -212,10 +213,28 @@ export const resolve = (
 
   while (++at < path.length) {
     const key = path[at];
-    // A special object takes the mismatch arm below alongside the scalars: a
-    // path does not address anything inside one, so reporting the slot
-    // absent-but-writable would invite a write onto a value that holds no
-    // such slot.
+    // A `FabricInstance` is tested for before the walk question is asked,
+    // because this function has a better answer than the refusal that question
+    // raises: it is declared to return a `TypeMismatchError`, and a path
+    // reaching a value it cannot address by key is what that error is for. The
+    // resolution stops either way; saying so in band lets a caller handle it
+    // like every other unresolvable address instead of unwinding.
+    //
+    // Live traffic arrives here: the fetch builtins store a `FabricError` as a
+    // result, and resolving a link whose path continues past one lands exactly
+    // on this. Before this test the slot read as absent AND writable, which
+    // invited a write onto a value holding no such slot.
+    if (value instanceof FabricInstance) {
+      return {
+        error: TypeMismatchError(
+          { ...address, path: path.slice(0, at + 1) },
+          value.constructor.name,
+          "read",
+        ),
+      };
+    }
+    // A `FabricPrimitive` takes the mismatch arm below alongside the scalars:
+    // a path does not address anything inside a leaf.
     if (isWalkableObjectOrArray(value)) {
       const record = value as FabricPlainObject;
       value = Object.hasOwn(record, key) ? record[key] : undefined;

--- a/packages/runner/src/storage/transaction/attestation.ts
+++ b/packages/runner/src/storage/transaction/attestation.ts
@@ -77,10 +77,13 @@ export const UnsupportedMediaTypeError = (
 /**
  * Reads requested `address` from the provided `source` attestation and either
  * succeeds with derived {@link IAttestation} with the given `address` or fails
- * with inconsistency error if resolving an `address` encounters a non-object
- * along the path. Note it will succeed with `undefined` if last component of
- * the path does not exist on the object. Below are some examples illustrating
- * read behavior
+ * with inconsistency error if resolving an `address` encounters a value it
+ * cannot address by key along the path. A non-object is one such value; so is
+ * a `FabricSpecialObject`, which holds its state behind no property name, and
+ * which therefore stops a resolution the way a scalar does rather than
+ * reporting the slot beneath it as absent. Note it will succeed with
+ * `undefined` if last component of the path does not exist on the object.
+ * Below are some examples illustrating read behavior
  *
  * ```ts
  * const address = {
@@ -178,7 +181,9 @@ export const claim = (
  * Attempts to resolve given `address` from the `source` attestation. Function
  * succeeds with derived attestation that will have provided `address` or fails
  * with a not found error if the path doesn't exist, or a type mismatch error if
- * resolving an address encounters non-object along the resolution path.
+ * resolving an address encounters a value it cannot address by key along the
+ * resolution path -- a non-object, or a `FabricSpecialObject`, whose state
+ * sits behind no property name.
  */
 export const resolve = (
   source: IAttestation,

--- a/packages/runner/src/storage/transaction/attestation.ts
+++ b/packages/runner/src/storage/transaction/attestation.ts
@@ -1,7 +1,9 @@
 import {
   type DebugValueOptions,
   type FabricPlainObject,
+  FabricSpecialObject,
   type FabricValue,
+  isWalkableObjectOrArray,
   toCompactDebugString,
   valueEqual,
 } from "@commonfabric/data-model";
@@ -13,7 +15,6 @@ import {
 } from "@commonfabric/data-model/codec-data-uri";
 import { LRUCache } from "@commonfabric/utils/cache";
 import { getLogger } from "@commonfabric/utils/logger";
-import { isObjectOrArray } from "@commonfabric/utils/types";
 
 import type {
   IAttestation,
@@ -206,13 +207,11 @@ export const resolve = (
 
   while (++at < path.length) {
     const key = path[at];
-    // TODO(danfuzz): `isObjectOrArray` admits a `FabricSpecialObject`, so descending
-    // into one lands in this arm and reads `undefined` instead of reaching
-    // the `TypeMismatchError` arm below the way a scalar does. The caller
-    // then treats the slot as absent-but-writable, and a path into a
-    // `FabricInstance`'s codec contents reads as missing rather than being
-    // refused or resolved.
-    if (isObjectOrArray(value)) {
+    // A special object takes the mismatch arm below alongside the scalars: a
+    // path does not address anything inside one, so reporting the slot
+    // absent-but-writable would invite a write onto a value that holds no
+    // such slot.
+    if (isWalkableObjectOrArray(value)) {
       const record = value as FabricPlainObject;
       value = Object.hasOwn(record, key) ? record[key] : undefined;
     } else {
@@ -223,8 +222,14 @@ export const resolve = (
           error: NotFound(source, address, path.slice(0, Math.max(0, at))),
         };
       }
-      // Type mismatch - trying to access property on non-object
-      const actualType = value === null ? "null" : typeof value;
+      // Type mismatch - trying to access property on non-object. A special
+      // object names its class, `typeof` "object" being no help in saying
+      // which value refused the path.
+      const actualType = value === null
+        ? "null"
+        : value instanceof FabricSpecialObject
+        ? value.constructor.name
+        : typeof value;
       return {
         error: TypeMismatchError(
           { ...address, path: path.slice(0, at + 1) },

--- a/packages/runner/src/storage/v2-path.ts
+++ b/packages/runner/src/storage/v2-path.ts
@@ -17,12 +17,12 @@ const hasOwnPathSegment = (
   segment: string | number,
 ): boolean => Object.hasOwn(value, segment);
 
-// Both descents below stop at a `FabricSpecialObject`, so a path into one
-// reports absent / `undefined` -- the same answer `getAtPath` in
-// `traverse.ts` gives for the same address. For a `FabricPrimitive` that is
-// the whole story: it is a leaf, and no path addresses anything inside one.
-// For a `FabricInstance` it is what property-name access can say, its
-// contents being reachable only through its codec.
+// Both descents below stop at a `FabricPrimitive`, so a path into one reports
+// absent / `undefined` -- the same answer `getAtPath` in `traverse.ts` gives
+// for the same address, and the whole story for a leaf that no path addresses
+// anything inside of. A `FabricInstance` is refused rather than answered
+// about, by the same predicate and for the same reason it is refused
+// everywhere else.
 export const hasValueAtPath = (
   root: FabricValue | undefined,
   path: readonly string[],

--- a/packages/runner/src/storage/v2-path.ts
+++ b/packages/runner/src/storage/v2-path.ts
@@ -1,6 +1,6 @@
+import { isWalkableObjectOrArray } from "@commonfabric/data-model";
 import type { FabricValue } from "@commonfabric/api";
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
-import { isObjectOrArray } from "@commonfabric/utils/types";
 
 export type ReadPathOptions = {
   allowArrayLength?: boolean;
@@ -17,12 +17,12 @@ const hasOwnPathSegment = (
   segment: string | number,
 ): boolean => Object.hasOwn(value, segment);
 
-// TODO(danfuzz): both descents below treat a `FabricSpecialObject` as a
-// record with no own keys, so any path into a `FabricInstance`'s codec
-// contents reports absent / `undefined`. That answer is right for a
-// `FabricPrimitive` (a leaf) but accidental for an instance — and it
-// disagrees with `getAtPath` in `traverse.ts`, whose `in`-based descent
-// resolves the same address through the instance's prototype surface.
+// Both descents below stop at a `FabricSpecialObject`, so a path into one
+// reports absent / `undefined` -- the same answer `getAtPath` in
+// `traverse.ts` gives for the same address. For a `FabricPrimitive` that is
+// the whole story: it is a leaf, and no path addresses anything inside one.
+// For a `FabricInstance` it is what property-name access can say, its
+// contents being reachable only through its codec.
 export const hasValueAtPath = (
   root: FabricValue | undefined,
   path: readonly string[],
@@ -45,7 +45,7 @@ export const hasValueAtPath = (
       current = current[index];
       continue;
     }
-    if (!isObjectOrArray(current)) {
+    if (!isWalkableObjectOrArray(current)) {
       return false;
     }
     const record = current as Record<string, unknown>;
@@ -79,7 +79,7 @@ export const readValueAtPath = (
       current = current[index];
       continue;
     }
-    if (!isObjectOrArray(current)) {
+    if (!isWalkableObjectOrArray(current)) {
       return undefined;
     }
     const record = current as Record<string, unknown>;

--- a/packages/runner/src/storage/v2-transaction.ts
+++ b/packages/runner/src/storage/v2-transaction.ts
@@ -3,6 +3,7 @@ import {
   cloneIfNecessary,
   deepFreeze,
   isDeepFrozen,
+  isWalkableObjectOrArray,
   valueEqual,
 } from "@commonfabric/data-model";
 import { hasDataUriScheme } from "@commonfabric/data-model/codec-data-uri";
@@ -749,17 +750,16 @@ const isSubsumedByTailSplice = (
     Number(childSegment) >= spliceCandidate.tailSpliceStartIndex;
 };
 
-// TODO(danfuzz): `isObjectOrArray` admits a `FabricSpecialObject` on both sides, so
-// two special objects — or one against a plain `{}` — compare by their empty
-// key sets and report "unchanged" without ever reaching the fabric-aware
-// `valueEqual` fallback. An in-place fabric change at an ancestor prefix then
-// emits no reactivity path. `differential.ts` guards its sibling walk with an
-// explicit `FabricSpecialObject` test for exactly this reason.
+// A special object on either side falls to the `valueEqual` comparison below
+// rather than being compared by key set: its state sits behind no key, so two
+// distinct ones would compare by their empty key sets and report "unchanged",
+// leaving an in-place fabric change at an ancestor prefix with no reactivity
+// path. `differential.ts` guards its sibling walk the same way.
 const shallowStructureChanged = (
   before: FabricValue | undefined,
   after: FabricValue | undefined,
 ): boolean => {
-  if (isObjectOrArray(before) && isObjectOrArray(after)) {
+  if (isWalkableObjectOrArray(before) && isWalkableObjectOrArray(after)) {
     const beforeKeys = Object.keys(before);
     const afterKeys = Object.keys(after);
     if (beforeKeys.length !== afterKeys.length) {

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -1,5 +1,9 @@
 import type { FabricValue, SchemaPathSelector } from "@commonfabric/api";
-import { cloneIfNecessary, hashStringOf } from "@commonfabric/data-model";
+import {
+  cloneIfNecessary,
+  hashStringOf,
+  isWalkableObjectOrArray,
+} from "@commonfabric/data-model";
 import {
   hasDataUriScheme,
   valueFromDataUri,
@@ -2155,12 +2159,12 @@ export class StorageManager implements IStorageManager {
       return;
     }
 
-    // TODO(danfuzz): `isObjectOrArray` admits a `FabricSpecialObject`, whose
-    // `Object.keys` are empty, so a cell link held inside a `FabricInstance`
-    // reconstructed from the data URI is never found here and its target
-    // document is never synced — the later read finds it absent. (A
-    // `FabricPrimitive` ends the walk harmlessly; it is a leaf.)
-    if (isObjectOrArray(value)) {
+    // TODO(danfuzz): the walk stops at a `FabricSpecialObject`, so a cell link
+    // held inside a `FabricInstance` reconstructed from the data URI is never
+    // found here and its target document is never synced — the later read
+    // finds it absent. (Stopping at a `FabricPrimitive` costs nothing; it is a
+    // leaf.)
+    if (isWalkableObjectOrArray(value)) {
       for (const key of Object.keys(value)) {
         const child = value[key];
         if (

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -2223,11 +2223,12 @@ export function getAtPath(
         value: curDoc.value.length,
       };
     } else if (isWalkableObjectOrArray(curDoc.value) && part in curDoc.value) {
-      // A special object is not descended: `in` consults the prototype chain,
-      // which for one of these resolves the class surface rather than the
-      // value -- `"slice"` on a `FabricBytes` would answer with a function as
-      // the next doc value. Such a path falls to the arm below and reads as
-      // absent, which is what a path into a leaf is.
+      // A `FabricPrimitive` is not descended: `in` consults the prototype
+      // chain, which for one of these resolves the class surface rather than
+      // the value -- `"slice"` on a `FabricBytes` would name a function as the
+      // next doc value. Such a path falls to the arm below and reads as
+      // absent, which is what a path into a leaf is. A `FabricInstance` does
+      // not reach that arm at all: the predicate refuses one.
       const cursorObj = curDoc.value as Immutable<JSONObject>;
       curDoc = {
         ...curDoc,

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -11,6 +11,8 @@ import {
   type FabricValue,
   hashStringOf,
   isDeepFrozen,
+  isWalkableObjectNotArray,
+  isWalkableObjectOrArray,
   toIndentedDebugString,
 } from "@commonfabric/data-model";
 import { linkRefFrom } from "@commonfabric/data-model/cell-rep";
@@ -1629,16 +1631,11 @@ export function mergeAnyOfMatches<T>(
   // schema, but the address is ignored, and a second option where
   // address is set, and name is ignored, we want to include both.
   if (matches.length > 1) {
-    // If all our matches are non-array objects, merge the properties.
-    //
-    // TODO(danfuzz): `isObjectNotArray` admits a `FabricSpecialObject`, whose state
-    // lives in private fields, so `Object.assign` copies nothing from it: a
-    // `FabricPrimitive` that matches more than one branch (say, an `anyOf` of
-    // its specific type name and `"object"`, which the subtype rule also
-    // accepts) merges to a plain `{}` and the value is lost. The merge wants
-    // a `FabricSpecialObject` test ahead of this point, returning the value
-    // whole rather than merging it.
-    if (matches.every((v) => isObjectNotArray(v))) {
+    // If all our matches are non-array objects, merge the properties. A
+    // special object among them sends the whole set to the first-match return
+    // below: it has no properties for `Object.assign` to copy, so merging one
+    // yields `{}` and the value is lost.
+    if (matches.every((v) => isWalkableObjectNotArray(v))) {
       const unified: Record<string, T> = {};
       for (const match of matches) {
         for (const [key, value] of Object.entries(match as object)) {
@@ -1950,7 +1947,7 @@ export abstract class BaseObjectTraverser {
           };
           const val = this.traverseDAG(
             itemDoc,
-            isObjectNotArray(defaultValue)
+            isWalkableObjectNotArray(defaultValue)
               ? (defaultValue as JSONObject)[k]
               : undefined,
           )!;
@@ -2225,18 +2222,12 @@ export function getAtPath(
         },
         value: curDoc.value.length,
       };
-    } else if (isObjectOrArray(curDoc.value) && part in curDoc.value) {
-      // TODO(danfuzz): `isObjectOrArray` admits a `FabricSpecialObject`, and `in`
-      // consults the prototype chain, so this arm descends a special object
-      // by its class surface rather than its codec contents: on a
-      // `FabricError` (live traffic — the fetch builtins store one),
-      // `"message"` resolves through a prototype accessor and `"slice"` on a
-      // `FabricBytes` yields a function as the next doc value, while the
-      // instance's actual contents are unreachable and fall to the debug-log
-      // arm below. The schema-declared-name descents elsewhere in this file
-      // use own-property checks for the same reason; this value-side descent
-      // wants that too, plus codec-contents addressing for a
-      // `FabricInstance`.
+    } else if (isWalkableObjectOrArray(curDoc.value) && part in curDoc.value) {
+      // A special object is not descended: `in` consults the prototype chain,
+      // which for one of these resolves the class surface rather than the
+      // value -- `"slice"` on a `FabricBytes` would answer with a function as
+      // the next doc value. Such a path falls to the arm below and reads as
+      // absent, which is what a path into a leaf is.
       const cursorObj = curDoc.value as Immutable<JSONObject>;
       curDoc = {
         ...curDoc,

--- a/packages/runner/test/cell-callbacks.test.ts
+++ b/packages/runner/test/cell-callbacks.test.ts
@@ -5,6 +5,7 @@ import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 
 import { DATA_URI_MEDIA_TYPE } from "@commonfabric/data-model/codec-data-uri";
+import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 
 import "@commonfabric/utils/equal-ignoring-symbols";
 
@@ -623,6 +624,69 @@ describe("Cell commit callbacks", () => {
       expect(result.length).toBe(2);
       expect(result[0].name).toBe("bob");
       expect(result[1].name).toBe("alice-copy");
+    });
+
+    it("should remove a fabric element matching by content", () => {
+      // A special object keeps its state in private fields, so a link
+      // comparison can only tell whether two are the same object -- and a
+      // value read back out of the array never is. It matches by content, the
+      // way `removeByValue()` matches.
+      const frame = pushFrame();
+      const cell = runtime.getCell<FabricBytes[]>(
+        space,
+        "remove-fabric-test",
+        { type: "array" },
+        tx,
+      );
+
+      cell.set([
+        new FabricBytes(new Uint8Array([1, 2])),
+        new FabricBytes(new Uint8Array([3, 4])),
+      ]);
+      cell.remove(new FabricBytes(new Uint8Array([1, 2])));
+      popFrame(frame);
+
+      const result = cell.get();
+      expect(result.length).toBe(1);
+      expect(result[0].slice()).toEqual(new Uint8Array([3, 4]));
+    });
+
+    it("should remove all fabric elements matching by content", () => {
+      const frame = pushFrame();
+      const cell = runtime.getCell<FabricBytes[]>(
+        space,
+        "removeall-fabric-test",
+        { type: "array" },
+        tx,
+      );
+
+      cell.set([
+        new FabricBytes(new Uint8Array([1, 2])),
+        new FabricBytes(new Uint8Array([3, 4])),
+        new FabricBytes(new Uint8Array([1, 2])),
+      ]);
+      cell.removeAll(new FabricBytes(new Uint8Array([1, 2])));
+      popFrame(frame);
+
+      const result = cell.get();
+      expect(result.length).toBe(1);
+      expect(result[0].slice()).toEqual(new Uint8Array([3, 4]));
+    });
+
+    it("should keep a fabric element whose content differs", () => {
+      const frame = pushFrame();
+      const cell = runtime.getCell<FabricBytes[]>(
+        space,
+        "remove-fabric-miss-test",
+        { type: "array" },
+        tx,
+      );
+
+      cell.set([new FabricBytes(new Uint8Array([1, 2]))]);
+      cell.remove(new FabricBytes(new Uint8Array([9, 9])));
+      popFrame(frame);
+
+      expect(cell.get().length).toBe(1);
     });
 
     it("should do nothing when removing element not in array", () => {

--- a/packages/runner/test/cfc-schema-merge.test.ts
+++ b/packages/runner/test/cfc-schema-merge.test.ts
@@ -6,6 +6,7 @@ import {
   mergeCfcSchemaEnvelopes,
 } from "../src/cfc/schema-merge.ts";
 import { storedSchemaCoversCandidateEnvelope } from "../src/cfc/prepare.ts";
+import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 
 describe("mergeCfcSchemaEnvelopes", () => {
   describe("observes through a merge", () => {
@@ -1413,5 +1414,48 @@ describe("cfcSchemaMergeIssue", () => {
     expect(mergeArrayIdentities).toThrow(
       "writeAuthorizedBy must remain stable",
     );
+  });
+});
+
+// A fabric-valued default has no properties for a schema comparison to read,
+// so a comparison built on a property walk calls two schemas that differ only
+// there equal -- and coverage=true skips the merge, discarding the candidate's
+// default.
+describe("schema comparison over a fabric-valued default", () => {
+  const withDefault = (bytes: readonly number[]) => ({
+    type: "object",
+    properties: {
+      a: {
+        type: "object",
+        default: new FabricBytes(new Uint8Array(bytes)) as never,
+      },
+    },
+  } as const);
+
+  it("does not judge differing fabric defaults covered", () => {
+    expect(
+      storedSchemaCoversCandidateEnvelope(
+        withDefault([1, 2]),
+        withDefault([3]),
+      ),
+    ).toBe(false);
+  });
+
+  it("still judges equal fabric defaults covered", () => {
+    expect(
+      storedSchemaCoversCandidateEnvelope(
+        withDefault([1, 2]),
+        withDefault([1, 2]),
+      ),
+    ).toBe(true);
+  });
+
+  it("merges a fabric default onto a plain one rather than to `{}`", () => {
+    const merged = mergeCfcSchemaEnvelopes({
+      type: "object",
+      properties: { a: { type: "object", default: { x: 1 } } },
+    }, withDefault([7])) as JSONSchemaObj;
+    const properties = merged.properties as Record<string, JSONSchemaObj>;
+    expect(properties.a.default).toBeInstanceOf(FabricBytes);
   });
 });

--- a/packages/runner/test/cfc-schema-sanitization.test.ts
+++ b/packages/runner/test/cfc-schema-sanitization.test.ts
@@ -1781,6 +1781,33 @@ describe("schema-based prompt injection sanitization compatibility", () => {
     });
   });
 
+  it("seals a `FabricSpecialObject` rather than showing it", () => {
+    // A special object holds its state behind no property name, so the record
+    // arm cannot measure it against the schema the way the unmodeled-key
+    // policy measures a record. Sealing is the fail-closed answer, and the
+    // one that policy already gives for a key it cannot model; passing the
+    // value through would show contents nothing had checked.
+
+    const schema = {
+      type: "object",
+      properties: { blob: { type: "object" } },
+      required: ["blob"],
+      additionalProperties: false,
+    } as const satisfies JSONSchema;
+
+    const sanitized = validateAndSanitizeSchemaValueWithOpaqueLinks({
+      schema,
+      value: { blob: new FabricBytes(new Uint8Array([1, 2, 3])) },
+      opaqueHandleId: "child-run-1",
+    });
+
+    expect(sanitized).toEqual({
+      value: { blob: { "@link": "opaque:child-run-1#/blob" } },
+      linkedStringCount: 0,
+      sealedPaths: [["blob"]],
+    });
+  });
+
   it("sanitizes tuple (prefixItems) elements against their slot schema", () => {
     // CT-1895: itemSchemaForIndex collected only `items` (+allOf), so tuple
     // elements sanitized against an unconstrained schema — a raw string in a

--- a/packages/runner/test/fabric-special-object-walks.test.ts
+++ b/packages/runner/test/fabric-special-object-walks.test.ts
@@ -71,6 +71,12 @@ interface SpecialObjectKind {
   readonly make: () => FabricValue;
   /** Whether the kind's codec can freeze and hash it. */
   readonly storable: boolean;
+  /**
+   * Whether the kind is a `FabricInstance`. A walk carries a
+   * `FabricPrimitive` through as the leaf it is, and refuses an instance,
+   * which is a container it cannot descend yet.
+   */
+  readonly isInstance: boolean;
 }
 
 const SPECIAL_OBJECTS: readonly SpecialObjectKind[] = [
@@ -79,30 +85,35 @@ const SPECIAL_OBJECTS: readonly SpecialObjectKind[] = [
     cls: FabricBytes,
     make: () => new FabricBytes(new Uint8Array([1, 2, 3])),
     storable: true,
+    isInstance: false,
   },
   {
     name: "FabricEpochNsec",
     cls: FabricEpochNsec,
     make: () => new FabricEpochNsec(1_700n),
     storable: true,
+    isInstance: false,
   },
   {
     name: "FabricEpochDay",
     cls: FabricEpochDay,
     make: () => new FabricEpochDay(20_000n),
     storable: true,
+    isInstance: false,
   },
   {
     name: "FabricRegExp",
     cls: FabricRegExp,
     make: () => new FabricRegExp("es2025", "a+", "g"),
     storable: true,
+    isInstance: false,
   },
   {
     name: "FabricHash",
     cls: FabricHash,
     make: () => new FabricHash(new Uint8Array([9, 9]), "fid1"),
     storable: true,
+    isInstance: false,
   },
   {
     name: "FabricError",
@@ -116,28 +127,39 @@ const SPECIAL_OBJECTS: readonly SpecialObjectKind[] = [
         cause: undefined,
       }),
     storable: true,
+    isInstance: true,
   },
   {
     name: "FabricLink",
     cls: FabricLink,
     make: () => new FabricLink({ id: "of:fid1:aaa" }),
     storable: true,
+    isInstance: true,
   },
   {
     name: "FabricMap",
     cls: FabricMap,
     make: () => new FabricMap(new Map([["a", 1]])),
     storable: false,
+    isInstance: true,
   },
   {
     name: "FabricSet",
     cls: FabricSet,
     make: () => new FabricSet(new Set([1, 2])),
     storable: false,
+    isInstance: true,
   },
 ];
 
-const STORABLE_SPECIAL_OBJECTS = SPECIAL_OBJECTS.filter((k) => k.storable);
+/**
+ * The walks below carry a leaf through and refuse a container, so every case
+ * that asserts carrying runs over the primitives. The instances get one suite
+ * of their own, at the bottom, asserting the refusal instead.
+ */
+const FABRIC_PRIMITIVES = SPECIAL_OBJECTS.filter((k) => !k.isInstance);
+const FABRIC_INSTANCES = SPECIAL_OBJECTS.filter((k) => k.isInstance);
+const STORABLE_PRIMITIVES = FABRIC_PRIMITIVES.filter((k) => k.storable);
 
 /** Runs `body` once per kind in `kinds`, naming the kind in the case. */
 function forEachSpecialObject(
@@ -153,7 +175,7 @@ function forEachSpecialObject(
 describe("fabric special objects through the runner's walks", () => {
   describe("mergeDefaults()", () => {
     forEachSpecialObject(
-      STORABLE_SPECIAL_OBJECTS,
+      STORABLE_PRIMITIVES,
       (name) => `keeps a \`${name}\` default rather than merging it to \`{}\``,
       (kind, special) => {
         const merged = mergeDefaults(
@@ -166,7 +188,7 @@ describe("fabric special objects through the runner's walks", () => {
     );
 
     forEachSpecialObject(
-      STORABLE_SPECIAL_OBJECTS,
+      STORABLE_PRIMITIVES,
       (name) => `keeps a \`${name}\` on both sides of the merge`,
       (kind, special) => {
         // Both sides are `type: "object"` shaped, which is what the schema
@@ -196,7 +218,7 @@ describe("fabric special objects through the runner's walks", () => {
 
   describe("mergeAnyOfMatches()", () => {
     forEachSpecialObject(
-      SPECIAL_OBJECTS,
+      FABRIC_PRIMITIVES,
       (name) => `returns a \`${name}\` matched by two branches whole`,
       (_kind, special) => {
         expect(mergeAnyOfMatches([special, special])).toBe(special);
@@ -210,7 +232,7 @@ describe("fabric special objects through the runner's walks", () => {
 
   describe("snapshotQueryResult()", () => {
     forEachSpecialObject(
-      SPECIAL_OBJECTS,
+      FABRIC_PRIMITIVES,
       (name) => `snapshots a \`${name}\` by identity`,
       (_kind, special) => {
         expect(snapshotQueryResult(special)).toBe(special);
@@ -218,7 +240,7 @@ describe("fabric special objects through the runner's walks", () => {
     );
 
     forEachSpecialObject(
-      SPECIAL_OBJECTS,
+      FABRIC_PRIMITIVES,
       (name) => `snapshots a \`${name}\` held under a key by identity`,
       (_kind, special) => {
         const snapshot = snapshotQueryResult({ a: [{ b: special }] });
@@ -237,7 +259,7 @@ describe("fabric special objects through the runner's walks", () => {
 
   describe("extractDefaultValues()", () => {
     forEachSpecialObject(
-      STORABLE_SPECIAL_OBJECTS,
+      STORABLE_PRIMITIVES,
       (name) => `returns a \`${name}\` default under a property schema`,
       (kind, special) => {
         // The property-defaults assembly below this return would clone the
@@ -265,7 +287,7 @@ describe("fabric special objects through the runner's walks", () => {
 
   describe("sanitizeSchemaForLinks()", () => {
     forEachSpecialObject(
-      STORABLE_SPECIAL_OBJECTS,
+      STORABLE_PRIMITIVES,
       (name) => `carries a \`${name}\` schema default by reference`,
       (_kind, special) => {
         const sanitized = sanitizeSchemaForLinks({
@@ -287,7 +309,7 @@ describe("fabric special objects through the runner's walks", () => {
 
   describe("setValueAtPath()", () => {
     forEachSpecialObject(
-      SPECIAL_OBJECTS,
+      FABRIC_PRIMITIVES,
       (name) => `replaces a \`${name}\` spine slot rather than writing into it`,
       (_kind, special) => {
         const obj: Record<string, unknown> = { a: special };
@@ -297,7 +319,7 @@ describe("fabric special objects through the runner's walks", () => {
     );
 
     forEachSpecialObject(
-      SPECIAL_OBJECTS,
+      FABRIC_PRIMITIVES,
       (name) => `writes a \`${name}\` into a leaf slot`,
       (_kind, special) => {
         const obj: Record<string, unknown> = {};
@@ -309,7 +331,7 @@ describe("fabric special objects through the runner's walks", () => {
 
   describe("path reads", () => {
     forEachSpecialObject(
-      SPECIAL_OBJECTS,
+      FABRIC_PRIMITIVES,
       (name) => `report no path inside a \`${name}\``,
       (_kind, special) => {
         const root = { a: special };
@@ -327,7 +349,7 @@ describe("fabric special objects through the runner's walks", () => {
     );
 
     forEachSpecialObject(
-      SPECIAL_OBJECTS,
+      FABRIC_PRIMITIVES,
       (name) => `read a \`${name}\` at its own path`,
       (_kind, special) => {
         const root = { a: special };
@@ -337,5 +359,45 @@ describe("fabric special objects through the runner's walks", () => {
         expect(readValueAtPath(root as FabricValue, ["a"])).toBe(special);
       },
     );
+  });
+
+  describe("a `FabricInstance` in any of them", () => {
+    // The refusal is the whole point of separating the two kinds. A
+    // `FabricPrimitive` is a leaf and every walk above carries one through; an
+    // instance is a container the walks cannot descend yet, so answering at all
+    // would be answering wrongly, in one direction or the other. When the
+    // codec-mediated descent lands, these are the cases that change.
+
+    for (const kind of FABRIC_INSTANCES) {
+      it(`is refused by \`mergeAnyOfMatches()\` for a \`${kind.name}\``, () => {
+        const special = kind.make();
+        expect(() => mergeAnyOfMatches([special, special])).toThrow(
+          "`FabricInstance`) in a structural walk",
+        );
+      });
+
+      it(`is refused by \`snapshotQueryResult()\` for a \`${kind.name}\``, () => {
+        expect(() => snapshotQueryResult({ a: kind.make() })).toThrow(
+          "`FabricInstance`) in a structural walk",
+        );
+      });
+
+      it(`is refused by \`setValueAtPath()\` for a \`${kind.name}\``, () => {
+        const obj: Record<string, unknown> = { a: kind.make() };
+        expect(() => setValueAtPath(obj, ["a", "b"], 1)).toThrow(
+          "`FabricInstance`) in a structural walk",
+        );
+      });
+
+      it(`is refused by the stored path read for a \`${kind.name}\``, () => {
+        const root = { a: kind.make() } as FabricValue;
+        expect(() => hasStoredValueAtPath(root, ["a", "b"])).toThrow(
+          "`FabricInstance`) in a structural walk",
+        );
+        expect(() => readValueAtPath(root, ["a", "b"])).toThrow(
+          "`FabricInstance`) in a structural walk",
+        );
+      });
+    }
   });
 });

--- a/packages/runner/test/fabric-special-object-walks.test.ts
+++ b/packages/runner/test/fabric-special-object-walks.test.ts
@@ -1,0 +1,341 @@
+/**
+ * A `FabricSpecialObject` survives the runner's structural walks.
+ *
+ * Every walk here used to ask `isObjectOrArray()` -- "is this an object?" --
+ * as a stand-in for "may I read this by property name?". A special object
+ * answers yes to the first and no to the second: its state lives in private
+ * fields and it has no own properties at all. So each walk saw an empty
+ * record, and each lost the value in its own way -- merged it to `{}`, rebuilt
+ * it as `{}`, descended into it and found nothing, or wrote a property onto
+ * it. They now ask `isWalkableObjectOrArray()`, and the cases below are that
+ * one predicate observed from each walk's own doorstep.
+ *
+ * The suite runs over every special-object kind rather than a representative
+ * one, because the kinds differ in what a naive walk does to them: a
+ * `FabricBytes` answers to `"slice"` through its prototype where a
+ * `FabricEpochNsec` does not, and a `FabricError` answers to `"message"`. A
+ * walk fixed only for the kind it was reported against would keep passing a
+ * one-kind test.
+ *
+ * Two axes cut across the kinds and decide what a case may assert. A walk that
+ * only carries a value asserts identity. A walk that runs the value through
+ * schema interning gets a deep-frozen copy of an unfrozen instance, so it
+ * asserts the class instead -- which is the whole of what was being lost.
+ * `FabricMap` and `FabricSet` have stub codecs and cannot be frozen or hashed
+ * at all, so they take part only in the walks that touch neither.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import {
+  FabricError,
+  FabricLink,
+  FabricMap,
+  FabricSet,
+} from "@commonfabric/data-model/fabric-instances";
+import {
+  FabricBytes,
+  FabricEpochDay,
+  FabricEpochNsec,
+  FabricHash,
+  FabricRegExp,
+} from "@commonfabric/data-model/fabric-primitives";
+import type {
+  FabricSpecialObject,
+  FabricValue,
+} from "@commonfabric/data-model";
+
+import { mergeDefaults } from "../src/schema.ts";
+import { mergeAnyOfMatches } from "../src/traverse.ts";
+import { snapshotQueryResult } from "../src/query-result-proxy.ts";
+import { extractDefaultValues } from "../src/runner-utils.ts";
+import { sanitizeSchemaForLinks } from "../src/link-utils.ts";
+import {
+  getValueAtPath,
+  hasValueAtPath,
+  setValueAtPath,
+} from "../src/path-utils.ts";
+import {
+  hasValueAtPath as hasStoredValueAtPath,
+  readValueAtPath,
+} from "../src/storage/v2-path.ts";
+import type { JSONSchema } from "../src/builder/types.ts";
+
+interface SpecialObjectKind {
+  /** Class name, so a failure says which kind broke. */
+  readonly name: string;
+  /** The class itself, for the cases that can only assert the class. */
+  // deno-lint-ignore no-explicit-any
+  readonly cls: new (...args: any[]) => FabricSpecialObject;
+  readonly make: () => FabricValue;
+  /** Whether the kind's codec can freeze and hash it. */
+  readonly storable: boolean;
+}
+
+const SPECIAL_OBJECTS: readonly SpecialObjectKind[] = [
+  {
+    name: "FabricBytes",
+    cls: FabricBytes,
+    make: () => new FabricBytes(new Uint8Array([1, 2, 3])),
+    storable: true,
+  },
+  {
+    name: "FabricEpochNsec",
+    cls: FabricEpochNsec,
+    make: () => new FabricEpochNsec(1_700n),
+    storable: true,
+  },
+  {
+    name: "FabricEpochDay",
+    cls: FabricEpochDay,
+    make: () => new FabricEpochDay(20_000n),
+    storable: true,
+  },
+  {
+    name: "FabricRegExp",
+    cls: FabricRegExp,
+    make: () => new FabricRegExp("es2025", "a+", "g"),
+    storable: true,
+  },
+  {
+    name: "FabricHash",
+    cls: FabricHash,
+    make: () => new FabricHash(new Uint8Array([9, 9]), "fid1"),
+    storable: true,
+  },
+  {
+    name: "FabricError",
+    cls: FabricError,
+    make: () =>
+      new FabricError({
+        type: "Error",
+        name: "Error",
+        message: "boom",
+        stack: undefined,
+        cause: undefined,
+      }),
+    storable: true,
+  },
+  {
+    name: "FabricLink",
+    cls: FabricLink,
+    make: () => new FabricLink({ id: "of:fid1:aaa" }),
+    storable: true,
+  },
+  {
+    name: "FabricMap",
+    cls: FabricMap,
+    make: () => new FabricMap(new Map([["a", 1]])),
+    storable: false,
+  },
+  {
+    name: "FabricSet",
+    cls: FabricSet,
+    make: () => new FabricSet(new Set([1, 2])),
+    storable: false,
+  },
+];
+
+const STORABLE_SPECIAL_OBJECTS = SPECIAL_OBJECTS.filter((k) => k.storable);
+
+/** Runs `body` once per kind in `kinds`, naming the kind in the case. */
+function forEachSpecialObject(
+  kinds: readonly SpecialObjectKind[],
+  description: (name: string) => string,
+  body: (kind: SpecialObjectKind, special: FabricValue) => void,
+): void {
+  for (const kind of kinds) {
+    it(description(kind.name), () => body(kind, kind.make()));
+  }
+}
+
+describe("fabric special objects through the runner's walks", () => {
+  describe("mergeDefaults()", () => {
+    forEachSpecialObject(
+      STORABLE_SPECIAL_OBJECTS,
+      (name) => `keeps a \`${name}\` default rather than merging it to \`{}\``,
+      (kind, special) => {
+        const merged = mergeDefaults(
+          { type: "object", default: { a: 1 } },
+          special,
+        );
+        expect((merged as { default: unknown }).default)
+          .toBeInstanceOf(kind.cls);
+      },
+    );
+
+    forEachSpecialObject(
+      STORABLE_SPECIAL_OBJECTS,
+      (name) => `keeps a \`${name}\` on both sides of the merge`,
+      (kind, special) => {
+        // Both sides are `type: "object"` shaped, which is what the schema
+        // generator emits for the fabric-backed natives, so this is the arm a
+        // `Cell` of one of those with an object default actually takes.
+        const merged = mergeDefaults(
+          { type: "object", default: special as never },
+          special,
+        );
+        expect((merged as { default: unknown }).default)
+          .toBeInstanceOf(kind.cls);
+      },
+    );
+
+    it("still merges two plain-record defaults", () => {
+      const merged = mergeDefaults(
+        { type: "object", default: { a: 1, b: 2 } },
+        { b: 3, c: 4 } as FabricValue,
+      );
+      expect((merged as { default: unknown }).default).toEqual({
+        a: 1,
+        b: 3,
+        c: 4,
+      });
+    });
+  });
+
+  describe("mergeAnyOfMatches()", () => {
+    forEachSpecialObject(
+      SPECIAL_OBJECTS,
+      (name) => `returns a \`${name}\` matched by two branches whole`,
+      (_kind, special) => {
+        expect(mergeAnyOfMatches([special, special])).toBe(special);
+      },
+    );
+
+    it("still merges the properties of two plain-record matches", () => {
+      expect(mergeAnyOfMatches([{ a: 1 }, { b: 2 }])).toEqual({ a: 1, b: 2 });
+    });
+  });
+
+  describe("snapshotQueryResult()", () => {
+    forEachSpecialObject(
+      SPECIAL_OBJECTS,
+      (name) => `snapshots a \`${name}\` by identity`,
+      (_kind, special) => {
+        expect(snapshotQueryResult(special)).toBe(special);
+      },
+    );
+
+    forEachSpecialObject(
+      SPECIAL_OBJECTS,
+      (name) => `snapshots a \`${name}\` held under a key by identity`,
+      (_kind, special) => {
+        const snapshot = snapshotQueryResult({ a: [{ b: special }] });
+        expect(snapshot.a[0].b).toBe(special);
+      },
+    );
+
+    it("still detaches a plain container", () => {
+      const source = { a: [1, 2] };
+      const snapshot = snapshotQueryResult(source);
+      expect(snapshot).toEqual(source);
+      expect(snapshot).not.toBe(source);
+      expect(snapshot.a).not.toBe(source.a);
+    });
+  });
+
+  describe("extractDefaultValues()", () => {
+    forEachSpecialObject(
+      STORABLE_SPECIAL_OBJECTS,
+      (name) => `returns a \`${name}\` default under a property schema`,
+      (kind, special) => {
+        // The property-defaults assembly below this return would clone the
+        // default and assign to it, which a frozen special object refuses
+        // outright and an unfrozen instance accepts as a graft its codec
+        // never reads.
+        const schema = {
+          type: "object",
+          properties: { a: { type: "string", default: "x" } },
+          default: special as never,
+        } as const satisfies JSONSchema;
+        expect(extractDefaultValues(schema)).toBeInstanceOf(kind.cls);
+      },
+    );
+
+    it("still assembles property defaults over a plain-record default", () => {
+      const schema = {
+        type: "object",
+        properties: { a: { type: "string", default: "x" } },
+        default: { b: 1 },
+      } as const satisfies JSONSchema;
+      expect(extractDefaultValues(schema)).toEqual({ a: "x", b: 1 });
+    });
+  });
+
+  describe("sanitizeSchemaForLinks()", () => {
+    forEachSpecialObject(
+      STORABLE_SPECIAL_OBJECTS,
+      (name) => `carries a \`${name}\` schema default by reference`,
+      (_kind, special) => {
+        const sanitized = sanitizeSchemaForLinks({
+          type: "object",
+          default: special as never,
+        }) as { default: unknown };
+        expect(sanitized.default).toBe(special);
+      },
+    );
+
+    it("still strips `asCell` from a subschema", () => {
+      const sanitized = sanitizeSchemaForLinks({
+        type: "object",
+        properties: { a: { type: "string", asCell: ["cell"] } },
+      }) as { properties: { a: Record<string, unknown> } };
+      expect(sanitized.properties.a.asCell).toBeUndefined();
+    });
+  });
+
+  describe("setValueAtPath()", () => {
+    forEachSpecialObject(
+      SPECIAL_OBJECTS,
+      (name) => `replaces a \`${name}\` spine slot rather than writing into it`,
+      (_kind, special) => {
+        const obj: Record<string, unknown> = { a: special };
+        expect(setValueAtPath(obj, ["a", "b"], 1)).toBe(true);
+        expect(obj).toEqual({ a: { b: 1 } });
+      },
+    );
+
+    forEachSpecialObject(
+      SPECIAL_OBJECTS,
+      (name) => `writes a \`${name}\` into a leaf slot`,
+      (_kind, special) => {
+        const obj: Record<string, unknown> = {};
+        expect(setValueAtPath(obj, ["a", "b"], special)).toBe(true);
+        expect((obj.a as Record<string, unknown>).b).toBe(special);
+      },
+    );
+  });
+
+  describe("path reads", () => {
+    forEachSpecialObject(
+      SPECIAL_OBJECTS,
+      (name) => `report no path inside a \`${name}\``,
+      (_kind, special) => {
+        const root = { a: special };
+        // `"slice"` and `"message"` resolve through the prototype of some of
+        // these; a path names data, and none of that is data.
+        for (const segment of ["slice", "message", "length", "source"]) {
+          expect(hasValueAtPath(root, ["a", segment])).toBe(false);
+          expect(getValueAtPath(root, ["a", segment])).toBeUndefined();
+          expect(hasStoredValueAtPath(root as FabricValue, ["a", segment]))
+            .toBe(false);
+          expect(readValueAtPath(root as FabricValue, ["a", segment]))
+            .toBeUndefined();
+        }
+      },
+    );
+
+    forEachSpecialObject(
+      SPECIAL_OBJECTS,
+      (name) => `read a \`${name}\` at its own path`,
+      (_kind, special) => {
+        const root = { a: special };
+        expect(hasValueAtPath(root, ["a"])).toBe(true);
+        expect(getValueAtPath(root, ["a"])).toBe(special);
+        expect(hasStoredValueAtPath(root as FabricValue, ["a"])).toBe(true);
+        expect(readValueAtPath(root as FabricValue, ["a"])).toBe(special);
+      },
+    );
+  });
+});

--- a/packages/runner/test/reactive-dependencies.test.ts
+++ b/packages/runner/test/reactive-dependencies.test.ts
@@ -2,7 +2,10 @@ import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
 
 import { type FabricValue } from "@commonfabric/data-model";
-import { FabricMap } from "@commonfabric/data-model/fabric-instances";
+import {
+  FabricError,
+  FabricMap,
+} from "@commonfabric/data-model/fabric-instances";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import type { MemorySpace } from "@commonfabric/memory/interface";
 
@@ -2034,21 +2037,78 @@ describe("determineTriggeredActions", () => {
       ).toThrow("`FabricMap`: not yet implemented");
     });
 
-    it("does not trigger a read below an instance it cannot descend", () => {
-      // An instance is a container this walk cannot address by key. A
-      // subscription that throws stops delivering, so the descent ends here
-      // as it does at any other value with no reachable keys, and the read
-      // below reads as unreachable on both sides.
+    it("triggers a read below an instance replaced by a scalar", () => {
+      // `value.a.b` is reachable while `a` is a container and absent once it
+      // is a scalar, so the two sides stop at different depths and the read
+      // is triggered. The same holds for each transition below.
 
-      const action = createAction("readBelowInstance");
+      const action = createAction("instanceToScalar");
       const dependencies = new Map<Action, SortedAndCompactPaths>([
         [action, [["value", "a", "b"]]],
       ]);
       const before = { value: { a: new FabricMap(new Map([["b", 1]])) } };
-      const after = { value: { a: new FabricMap(new Map([["b", 2]])) } };
+      const after = { value: { a: 5 } };
 
-      const result = determineTriggeredActions(dependencies, before, after);
-      expect(result).toEqual([]);
+      expect(determineTriggeredActions(dependencies, before, after))
+        .toEqual([action]);
+    });
+
+    it("triggers a read below an instance that was deleted", () => {
+      const action = createAction("instanceDeleted");
+      const dependencies = new Map<Action, SortedAndCompactPaths>([
+        [action, [["value", "a", "b"]]],
+      ]);
+      const before = { value: { a: new FabricMap(new Map([["b", 1]])) } };
+      const after = { value: {} };
+
+      expect(determineTriggeredActions(dependencies, before, after))
+        .toEqual([action]);
+    });
+
+    it("triggers a read below a scalar replaced by an instance", () => {
+      const action = createAction("scalarToInstance");
+      const dependencies = new Map<Action, SortedAndCompactPaths>([
+        [action, [["value", "a", "b"]]],
+      ]);
+      const before = { value: { a: 5 } };
+      const after = { value: { a: new FabricMap(new Map([["b", 1]])) } };
+
+      expect(determineTriggeredActions(dependencies, before, after))
+        .toEqual([action]);
+    });
+
+    it("triggers a read below an error that was deleted", () => {
+      const action = createAction("errorDeleted");
+      const dependencies = new Map<Action, SortedAndCompactPaths>([
+        [action, [["value", "a", "message"]]],
+      ]);
+      const before = {
+        value: { a: FabricError.fromNativeError(new Error("boom")) },
+      };
+      const after = { value: {} };
+
+      expect(determineTriggeredActions(dependencies, before, after))
+        .toEqual([action]);
+    });
+
+    it("triggers a read of a property an error carries when it changes", () => {
+      // A `FabricInstance` is not stateless with respect to property names:
+      // `FabricError` reaches `message`, `name` and `type` through prototype
+      // accessors, so a descent through one reads values rather than vacancy.
+
+      const action = createAction("errorMessageChanged");
+      const dependencies = new Map<Action, SortedAndCompactPaths>([
+        [action, [["value", "a", "message"]]],
+      ]);
+      const before = {
+        value: { a: FabricError.fromNativeError(new Error("boom one")) },
+      };
+      const after = {
+        value: { a: FabricError.fromNativeError(new Error("boom two")) },
+      };
+
+      expect(determineTriggeredActions(dependencies, before, after))
+        .toEqual([action]);
     });
 
     it("triggers on a special object replaced at the read's own path", () => {

--- a/packages/runner/test/reactive-dependencies.test.ts
+++ b/packages/runner/test/reactive-dependencies.test.ts
@@ -1,8 +1,9 @@
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
 
-import type { FabricValue } from "@commonfabric/data-model";
+import { type FabricValue } from "@commonfabric/data-model";
 import { FabricMap } from "@commonfabric/data-model/fabric-instances";
+import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import type { MemorySpace } from "@commonfabric/memory/interface";
 
 import {
@@ -1975,6 +1976,39 @@ describe("determineTriggeredActions", () => {
       expect(result).toEqual([action]);
     });
 
+    it("does not trigger a read below a special object that was replaced", () => {
+      // A special object is not key-able: no property name reaches its state,
+      // so the descent stops at one and a read below it is unreachable on
+      // both sides rather than present-and-empty.
+
+      const action = createAction("readBelowSpecialObject");
+      const dependencies = new Map<Action, SortedAndCompactPaths>([
+        [action, [["value", "a", "b"]]],
+      ]);
+      const before = { value: { a: new FabricBytes(new Uint8Array([1])) } };
+      const after = { value: { a: new FabricBytes(new Uint8Array([2])) } };
+
+      const result = determineTriggeredActions(dependencies, before, after);
+      expect(result).toEqual([]);
+    });
+
+    it("does not trigger a read below a scalar that became a special object", () => {
+      // The reachability verdict follows the value's kind and not its
+      // `typeof`: `value.a.b` was absent before and is absent after, because
+      // a path does not address anything inside a leaf, whatever kind of leaf
+      // it is.
+
+      const action = createAction("scalarBecameSpecialObject");
+      const dependencies = new Map<Action, SortedAndCompactPaths>([
+        [action, [["value", "a", "b"]]],
+      ]);
+      const before = { value: { a: 1 } };
+      const after = { value: { a: new FabricBytes(new Uint8Array([1])) } };
+
+      const result = determineTriggeredActions(dependencies, before, after);
+      expect(result).toEqual([]);
+    });
+
     it("propagates the failure from a value it cannot compare", () => {
       // A non-recursive read compares an opaque leaf by value, and a class
       // whose comparison is an unimplemented stub cannot answer. The failure is
@@ -2000,6 +2034,24 @@ describe("determineTriggeredActions", () => {
           { nonRecursive: true },
         )
       ).toThrow("not yet implemented");
+    });
+
+    it("triggers on a special object replaced at the read's own path", () => {
+      const action = createAction("nonRecursiveSpecialLeaf");
+      const dependencies = new Map<Action, SortedAndCompactPaths>([
+        [action, [["value", "a"]]],
+      ]);
+      const before = { value: { a: new FabricBytes(new Uint8Array([1])) } };
+      const after = { value: { a: new FabricBytes(new Uint8Array([2])) } };
+
+      const result = determineTriggeredActions(
+        dependencies,
+        before,
+        after,
+        ["value", "a"],
+        { nonRecursive: true },
+      );
+      expect(result).toEqual([action]);
     });
 
     it("triggers on same-path write for non-recursive reads", () => {

--- a/packages/runner/test/reactive-dependencies.test.ts
+++ b/packages/runner/test/reactive-dependencies.test.ts
@@ -2009,14 +2009,18 @@ describe("determineTriggeredActions", () => {
       expect(result).toEqual([]);
     });
 
-    it("propagates the failure from a value it cannot compare", () => {
-      // A non-recursive read compares an opaque leaf by value, and a class
-      // whose comparison is an unimplemented stub cannot answer. The failure is
-      // deliberately left to propagate rather than being caught and turned into
-      // "changed": a stub announcing itself loudly is worth more than a quiet
-      // answer derived from an unfinished class, and swallowing it would let
-      // that class shape behavior here. `FabricMap` stands in for any value
-      // whose comparison is unavailable.
+    it("propagates the failure from a value it cannot descend", () => {
+      // The descent refuses a `FabricInstance` before any comparison is
+      // reached: an instance is a container this walk cannot address by key,
+      // and the alternative is the equal-by-vacancy answer that reads every
+      // key off it as `undefined` on both sides and triggers nothing however
+      // its contents changed. The failure is deliberately left to propagate
+      // rather than being caught and turned into "unchanged".
+      //
+      // A comparison that cannot answer is a separate refusal, raised by
+      // `valueEqual()` and covered in `data-model`. It is unreachable from
+      // here now, because every class whose comparison is an unimplemented
+      // stub is an instance, and the descent stops at one first.
 
       const action = createAction("nonRecursiveUncomparableLeaf");
       const dependencies = new Map<Action, SortedAndCompactPaths>([
@@ -2033,7 +2037,7 @@ describe("determineTriggeredActions", () => {
           ["value", "a"],
           { nonRecursive: true },
         )
-      ).toThrow("not yet implemented");
+      ).toThrow("`FabricInstance`) in a structural walk");
     });
 
     it("triggers on a special object replaced at the read's own path", () => {

--- a/packages/runner/test/reactive-dependencies.test.ts
+++ b/packages/runner/test/reactive-dependencies.test.ts
@@ -2009,18 +2009,12 @@ describe("determineTriggeredActions", () => {
       expect(result).toEqual([]);
     });
 
-    it("propagates the failure from a value it cannot descend", () => {
-      // The descent refuses a `FabricInstance` before any comparison is
-      // reached: an instance is a container this walk cannot address by key,
-      // and the alternative is the equal-by-vacancy answer that reads every
-      // key off it as `undefined` on both sides and triggers nothing however
-      // its contents changed. The failure is deliberately left to propagate
-      // rather than being caught and turned into "unchanged".
-      //
-      // A comparison that cannot answer is a separate refusal, raised by
-      // `valueEqual()` and covered in `data-model`. It is unreachable from
-      // here now, because every class whose comparison is an unimplemented
-      // stub is an instance, and the descent stops at one first.
+    it("propagates the failure from a leaf it cannot compare", () => {
+      // The descent ends quietly at a value it cannot address by key, but a
+      // read landing on such a value still has to compare it, and a class
+      // whose comparison is an unimplemented stub cannot answer. That failure
+      // is left to propagate rather than being caught and turned into
+      // "unchanged", which would report a changed value as unchanged.
 
       const action = createAction("nonRecursiveUncomparableLeaf");
       const dependencies = new Map<Action, SortedAndCompactPaths>([
@@ -2037,7 +2031,24 @@ describe("determineTriggeredActions", () => {
           ["value", "a"],
           { nonRecursive: true },
         )
-      ).toThrow("`FabricInstance`) in a structural walk");
+      ).toThrow("`FabricMap`: not yet implemented");
+    });
+
+    it("does not trigger a read below an instance it cannot descend", () => {
+      // An instance is a container this walk cannot address by key. A
+      // subscription that throws stops delivering, so the descent ends here
+      // as it does at any other value with no reachable keys, and the read
+      // below reads as unreachable on both sides.
+
+      const action = createAction("readBelowInstance");
+      const dependencies = new Map<Action, SortedAndCompactPaths>([
+        [action, [["value", "a", "b"]]],
+      ]);
+      const before = { value: { a: new FabricMap(new Map([["b", 1]])) } };
+      const after = { value: { a: new FabricMap(new Map([["b", 2]])) } };
+
+      const result = determineTriggeredActions(dependencies, before, after);
+      expect(result).toEqual([]);
     });
 
     it("triggers on a special object replaced at the read's own path", () => {

--- a/packages/utils/src/deep-equal.ts
+++ b/packages/utils/src/deep-equal.ts
@@ -1,6 +1,18 @@
 import { isObjectOrArray } from "./types.ts";
 
 /**
+ * Comparator a caller supplies to {@link deepEqual} for the object pairs it
+ * knows more about than a property walk can discover. It is consulted for every
+ * pair of non-`null` objects the walk reaches, the arguments included, before
+ * the walk reads either one's keys.
+ *
+ * A `boolean` result settles that pair, and the walk neither descends into it
+ * nor compares its constructors. `undefined` declines the pair, leaving the
+ * ordinary property comparison to decide it.
+ */
+export type ObjectEqual = (a: object, b: object) => boolean | undefined;
+
+/**
  * Performs a deep equality comparison between two values.
  *
  * - Handles primitives, arrays, and plain objects
@@ -10,20 +22,22 @@ import { isObjectOrArray } from "./types.ts";
  *
  * @param a - First value to compare
  * @param b - Second value to compare
+ * @param objectEqual - Comparator consulted for each pair of objects reached,
+ *   before their properties are read. Omitted, every pair is compared by its
+ *   properties.
  * @returns True if the values are deeply equal
  *
- * **Not for `FabricValue`s.** This function compares class instances by
- * enumerable own-props, so two same-class `FabricPrimitive` values (state in
+ * **Not for `FabricValue`s on its own.** This function compares class instances
+ * by enumerable own-props, so two same-class `FabricPrimitive` values (state in
  * private `#fields`, zero own-props) compare equal regardless of value, and
  * `FabricInstance` values compare by internal slots rather than logical
- * contents. Use `data-model`'s `valueEqual()` for any `FabricValue` comparison.
- *
- * This is a property of the function, not a defect awaiting repair: `utils`
- * sits below `data-model` and cannot reach the codecs that decide fabric
- * equality, and a second implementation here would duplicate `valueEqual()`
- * rather than extend it. The scope is the fix.
+ * contents. `utils` sits below `data-model` and cannot reach the codecs that
+ * decide fabric equality, so the knowledge arrives through `objectEqual`:
+ * `data-model`'s `fabricAwareEqual()` is this walk carrying a comparator
+ * that hands every fabric value to `valueEqual()`. Use that, or `valueEqual()`
+ * directly, for any comparison whose operands can hold a `FabricValue`.
  */
-export function deepEqual(a: any, b: any): boolean {
+export function deepEqual(a: any, b: any, objectEqual?: ObjectEqual): boolean {
   if (Object.is(a, b)) return true;
 
   if (!(isObjectOrArray(a) && isObjectOrArray(b))) {
@@ -32,6 +46,11 @@ export function deepEqual(a: any, b: any): boolean {
 
   // At this point, we're looking at a pair of non-null records (e.g. plain
   // objects, arrays, or instances).
+
+  if (objectEqual !== undefined) {
+    const answer = objectEqual(a, b);
+    if (answer !== undefined) return answer;
+  }
 
   // Note: Even if they have the same `constructor`, it's technically possible
   // for `a` and `b` to have different prototypes, in which case it's possible
@@ -57,7 +76,7 @@ export function deepEqual(a: any, b: any): boolean {
   const bIsArray = Array.isArray(b);
   if (!(aIsArray || bIsArray)) {
     // General record (non-array object) comparison.
-    return checkSpecificProps(a, b, keysA);
+    return checkSpecificProps(a, b, keysA, objectEqual);
   }
 
   if (!(aIsArray && bIsArray)) {
@@ -80,7 +99,7 @@ export function deepEqual(a: any, b: any): boolean {
 
     indexCount++; // Assume non-hole to start. Might get reversed below.
 
-    if (!deepEqual(aValue, bValue)) {
+    if (!deepEqual(aValue, bValue, objectEqual)) {
       return false;
     }
 
@@ -107,7 +126,7 @@ export function deepEqual(a: any, b: any): boolean {
   // and ES (as of ES2015) guarantees that all the indexed properties are
   // listed first in the result from `Object.keys()`, so we slice those off
   // and just check the remainder.
-  return checkSpecificProps(a, b, keysA.slice(indexCount));
+  return checkSpecificProps(a, b, keysA.slice(indexCount), objectEqual);
 }
 
 /**
@@ -118,18 +137,20 @@ export function deepEqual(a: any, b: any): boolean {
  * @param a - First record (properties assumed to exist here)
  * @param b - Second record (properties checked via `hasOwn` before access)
  * @param keysToCheck - Property keys to compare
+ * @param objectEqual - Comparator to carry into the recursion
  * @returns `true` if all specified properties exist on `b` and are deeply equal
  */
 function checkSpecificProps(
   a: Record<string, unknown>,
   b: Record<string, unknown>,
   keysToCheck: string[],
+  objectEqual: ObjectEqual | undefined,
 ): boolean {
   for (const key of keysToCheck) {
     const aValue = a[key];
     const bValue = b[key];
 
-    if (!deepEqual(aValue, bValue)) {
+    if (!deepEqual(aValue, bValue, objectEqual)) {
       return false;
     }
 

--- a/packages/utils/test/deep-equal.test.ts
+++ b/packages/utils/test/deep-equal.test.ts
@@ -301,4 +301,68 @@ describe("deepEqual()", () => {
       expect(deepEqual(plain, nullProto)).toBe(false);
     });
   });
+
+  describe("with an `objectEqual` comparator", () => {
+    // The knowledge this walk cannot have on its own arrives here. A class
+    // whose state is private reads as an empty record to a property walk, so
+    // without the comparator every two of them compare equal; `data-model`
+    // supplies one deciding exactly that case for fabric values.
+    class Opaque {
+      readonly #value: number;
+      constructor(value: number) {
+        this.#value = value;
+      }
+      get value(): number {
+        return this.#value;
+      }
+    }
+
+    const byOpaqueValue = (a: object, b: object): boolean | undefined =>
+      a instanceof Opaque && b instanceof Opaque
+        ? a.value === b.value
+        : undefined;
+
+    it("returns `true` for two private-state instances without one", () => {
+      expect(deepEqual(new Opaque(1), new Opaque(2))).toBe(true);
+    });
+
+    it("decides the arguments themselves", () => {
+      expect(deepEqual(new Opaque(1), new Opaque(2), byOpaqueValue))
+        .toBe(false);
+      expect(deepEqual(new Opaque(1), new Opaque(1), byOpaqueValue)).toBe(true);
+    });
+
+    it("decides a pair reached under a record key", () => {
+      expect(
+        deepEqual({ v: new Opaque(1) }, { v: new Opaque(2) }, byOpaqueValue),
+      ).toBe(false);
+    });
+
+    it("decides a pair reached at an array index", () => {
+      expect(deepEqual([new Opaque(1)], [new Opaque(2)], byOpaqueValue))
+        .toBe(false);
+    });
+
+    it("decides a pair reached under an array's named property", () => {
+      const withNamed = (value: number) => {
+        const array: unknown[] & { extra?: unknown } = [1];
+        array.extra = new Opaque(value);
+        return array;
+      };
+      expect(deepEqual(withNamed(1), withNamed(2), byOpaqueValue)).toBe(false);
+      expect(deepEqual(withNamed(1), withNamed(1), byOpaqueValue)).toBe(true);
+    });
+
+    it("leaves a declined pair to the property comparison", () => {
+      expect(deepEqual({ a: 1 }, { a: 1 }, byOpaqueValue)).toBe(true);
+      expect(deepEqual({ a: 1 }, { a: 2 }, byOpaqueValue)).toBe(false);
+    });
+
+    it("skips the constructor check for a pair it settles", () => {
+      // A `true` answer stands even where the property walk would have
+      // refused the pair outright.
+      const alwaysEqual = () => true;
+      expect(deepEqual({ a: 1 }, [1, 2, 3], alwaysEqual)).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
A `FabricSpecialObject` -- a byte sequence, a temporal value, a content hash, a regular expression, an error, a link, a map, a set -- keeps its state in private fields and has no own properties at all. Two dozen walks across the runner decided "may I read this by property name?" by asking `isObjectOrArray()`, `isObjectNotArray()`, or a bare `typeof value === "object"`, all of which answer yes for one. Each walk then worked on what looked like an empty record, and each lost the value in its own way: a schema default merged to `{}`, a query-result snapshot rebuilt as `{}`, a path descent resolved `"slice"` on a byte sequence through the prototype chain and carried a function forward as the next value, a property-default assembly wrote onto a frozen value.

The same value model has a second half. `deepEqual()` compares by enumerable own properties, so two distinct byte sequences compare equal, and gates built on it -- a schema `const`, an `exactCopyOf` claim, a sink-request release check -- passed values they exist to distinguish.

Both halves are one bit of missing knowledge, so this adds one function for each rather than a branch at each site.

`isWalkableObjectOrArray()` in `data-model` is `isObjectOrArray()` minus the fabric special objects, and answers the container question every one of these walks was asking. A `false` result means "carry this value whole", which is the complete story for a `FabricPrimitive`: it is a leaf, and no path addresses anything inside one. Its sibling `isWalkableObjectNotArray()` is the same test with arrays removed, for the walks to which an array is not merely a different shape. Both follow the naming rule `utils/types` sets out, which is that a predicate over object shape settles the array question in its own name. `isFabricPlainContainer()` asks the same thing of a value the type system already says is a `FabricValue`; the two differ on exactly the values a `FabricValue` cannot be -- a `Cell`, a `Date`, a query-result proxy over one -- and each names the other.

`fabricAwareEqual()` is the comparison for an operand allowed to hold a `FabricValue` without being known to be one. It asks `valueEqual()` first and falls back to a structural walk that still decides any special object by content, so `deepEqual()` gains an optional comparator, consulted for each pair of objects it reaches before it reads their keys. `utils` sits below `data-model` and cannot reach the codecs that decide fabric equality; the injection point is how that knowledge arrives, and the comment there saying the limitation was permanent is updated to say so.

Three packages had already written that comparison privately, under three names -- `fabricAwareEqual` in `piece`'s schema compatibility, `schemaValueEqual` in the CFC schema sanitizer, and `schemaDefaultValueEqual` in `runner-utils` -- and a fourth site, `piece-controller`'s supplied-link check, wanted it and had only `deepEqual()`. That fourth one was live: under the modern cell rep any two `FabricLink`s compare equal there, so a link pointing somewhere else entirely passed as "restoring committed bytes" and skipped the rebuild rules. All four now share the one function, and the three copies go.

The `valueEqual()`-first order is the more correct one, not merely the cheaper. The two halves disagree on exactly one thing: `valueEqual()` calls a null-prototype object equal to a plain object holding the same contents, where `deepEqual()` separates them on their constructors. A record is a record in the value model. Measured before adopting it: a probe on all three copies, comparing each against the structural walk on every pair the suites produce, found zero disagreements across `runner`'s 8212 steps and `piece`'s 770.

`fabricAwareEqual()` catches everything the model raises, and the doc comment says why a narrower one does not work: asking `isValidFabricValue()` on the way out, so that a stub codec announces itself instead of being answered around, fails three tests. What `valueEqual()` can compare is not what the type admits -- `isValidFabricValue()` carries a `seen` set and answers for a cyclic value, while `hashStringOf()` has none and exhausts the stack on one, so a `RangeError` from a legal cyclic record reaches the same `catch` as a refusal. Where a comparison does turn on a stub class the operands meet at `specialObjectEqual()`, which lets the refusal out, so that case is loud already.

One walk wanted the opposite of the general treatment. `sanitizeValueWithOpaqueLinks` replaces content the schema does not model with an opaque link, so that a reader is never shown data nothing checked; carrying a special object through whole would have shown the contents of a `FabricBytes` or a `FabricError` unsanitized. It seals instead, which is the answer its own unmodeled-key policy already gives.

The `FabricInstance` refusals are deliberately untouched. Those walks cannot descend an instance's codec contents because that traversal does not exist yet, and they refuse rather than guess -- the discovery instruments described under "Flag-gated tripwires" in EXPERIMENTAL_OPTIONS.md. Nothing here forces support for them, and the markers naming that gap stay, including at four sites where stopping a walk at a special object leaves the instance half of the complaint standing: a subscriber path below one still never triggers on a change within it, a write redirect nested in one is still missed, a pattern path into one still resolves to no values, and the writer-stamp strip still rebuilds the plain records it meets.

Two classes are honestly beyond reach: `FabricMap` and `FabricSet` have stub codecs, so their content equality has no answer to give and `valueEqual()` says so by throwing. A test pins that throw rather than softening it, on the same reasoning the reactive layer already applies: a stub announcing itself is worth more than a quiet answer derived from an unfinished class.

Tests run each special-object kind through every walk, rather than a representative one, because the kinds differ in what a naive walk does to them -- a byte sequence answers to `"slice"` where a temporal value does not, and an error answers to `"message"`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6859?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

