### PR TITLE
fix(piece): drop a permission elevation that grants nothing

### DIFF
--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -1,11 +1,9 @@
 import type { CellScope } from "@commonfabric/api";
-import { cfcAtom } from "@commonfabric/api/cfc";
 import {
   type EntityRef,
   entityRefToString,
   isEntityRef,
 } from "@commonfabric/data-model/cell-rep";
-import { internSchema } from "@commonfabric/data-model-schema";
 import { homeSchema } from "@commonfabric/home-schemas";
 import {
   createSession,
@@ -118,13 +116,6 @@ export type PieceOpen = { reconcile: boolean; start: boolean };
 
 const normalizePieceOpen = (open: boolean | PieceOpen): PieceOpen =>
   typeof open === "boolean" ? { reconcile: open, start: open } : open;
-
-const PRIVILEGED_PIECE_LIST_SCHEMA = internSchema({
-  type: "array",
-  items: { type: "unknown", asCell: ["cell"] },
-  default: [],
-  ifc: { confidentiality: [cfcAtom.resource("PrivilegedPieceList")] },
-});
 
 // Timing stats record even while the logger is disabled, so every phase is
 // visible in the load summaries (browser worker included, where the
@@ -761,12 +752,13 @@ export class PiecesController<T = unknown> {
     await timePiecePhase("add.synced", () => this.synced());
   }
 
+  // `pieceListSchema` gives its items no shape — they are `unknown` — so
+  // neither the value the caller receives nor the query behind it has anywhere
+  // to descend inside a piece, and no field a piece labels is ever selected.
+  // `asCell` alone would not be enough for that: it bounds the runtime's own
+  // walk, while the memory query walks through it.
   syncPieces(cell: Cell<Cell<unknown>[]>) {
-    // TODO(@ubik2) We use elevated permissions here temporarily.
-    // Our request for the piece list will walk the schema tree, and that will
-    // take us into confidential data of pieces. If that happens, we still want
-    // this bit to work, so we elevate this request.
-    return cell.asSchema(PRIVILEGED_PIECE_LIST_SCHEMA).pull();
+    return cell.asSchema(pieceListSchema).pull();
   }
 
   /**
@@ -1389,6 +1381,12 @@ export class PiecesController<T = unknown> {
     await piece.sync();
     const start = options?.start ?? true;
     let currentPiece = piece;
+    // The pattern `syncPattern` may be told about, which is only the one this
+    // call is certain the piece ended up running. `runSynced` carries no such
+    // certainty: a concurrent source update can supersede this caller between
+    // its setup commit and here, and `runSynced` then hands back a piece
+    // running the winner rather than this candidate.
+    let installedPattern: Pattern | Module | undefined;
     if (start) {
       currentPiece = await this.runtime.runSynced(piece, pattern, inputs, {
         expectedPatternIdentity: options?.expectedPatternIdentity,
@@ -1404,8 +1402,9 @@ export class PiecesController<T = unknown> {
       await this.runtime.setup(undefined, pattern, inputs ?? {}, piece, {
         patternRepository: options?.repository,
       });
+      installedPattern = pattern;
     }
-    await this.syncPattern(currentPiece);
+    await this.syncPattern(currentPiece, installedPattern);
     if (start) {
       await this.getResult(currentPiece).pull();
     }
@@ -1488,9 +1487,9 @@ export class PiecesController<T = unknown> {
       cause ?? { space: this.#space, random: crypto.randomUUID() },
       pattern.resultSchema,
     );
-    // Fast path: the pattern's content-addressed entry ref, if it carries one
-    // (every space-compiled pattern does). Lets us load by identity without
-    // waiting for the piece's `patternIdentity` meta to settle.
+    // Setup verifies the source closure of a pattern that carries a
+    // content-addressed entry ref, and verifies it synchronously. Load the
+    // parser it needs first, since setup cannot await one.
     const knownEntryRef = this.runtime.patternManager.getArtifactEntryRef(
       pattern,
     );
@@ -1511,10 +1510,7 @@ export class PiecesController<T = unknown> {
     );
     await timePiecePhase(
       "setupPersistent.syncPattern",
-      () =>
-        knownEntryRef
-          ? this.syncPatternByIdentity(knownEntryRef)
-          : this.syncPattern(piece),
+      () => this.syncPattern(piece, pattern),
     );
 
     return piece;
@@ -1584,8 +1580,37 @@ export class PiecesController<T = unknown> {
     await this.runtime.idle();
   }
 
-  // FIXME(JA): this really really really needs to be revisited
-  async syncPattern(piece: Cell<unknown>) {
+  /**
+   * Load the pattern a piece runs, so a later cold runtime can resolve it from
+   * the space by identity.
+   *
+   * Pass `pattern` only when the caller drove `setup` itself and so knows
+   * which pattern the piece ended up running. Setup stamps an entry ref onto
+   * every pattern it installs, keyed by content for a compiled one, so the
+   * identity is then a lookup in memory and the piece is never read. A caller
+   * that went through `runSynced` has no such knowledge and must pass nothing.
+   *
+   * Without a pattern the identity comes from the `patternIdentity` metadata
+   * on the piece, which names whichever pattern the piece actually runs. That
+   * metadata becomes readable once the write carrying it commits, so this
+   * settles the pending writes and then reads. The settle costs a wait on the
+   * storage manager's whole queue, which is the price of reading an answer
+   * that does not depend on when the read happened to land.
+   */
+  async syncPattern(piece: Cell<unknown>, pattern?: Pattern | Module) {
+    const ref =
+      (pattern !== undefined
+        ? this.runtime.patternManager.getArtifactEntryRef(pattern)
+        : undefined) ?? await this.readPatternIdentity(piece);
+
+    return await timePiecePhase(
+      "syncPattern.loadPattern",
+      () => this.syncPatternByIdentity(ref),
+    );
+  }
+
+  private async readPatternIdentity(piece: Cell<unknown>) {
+    await timePiecePhase("syncPattern.synced", () => this.synced());
     await timePiecePhase("syncPattern.piece.sync", () => piece.sync());
 
     // When we subscribe to a doc, our subscription includes the doc's pattern
@@ -1599,31 +1624,13 @@ export class PiecesController<T = unknown> {
     // except the session that minted it, never this one — so it must not
     // shadow the live session pointer; it stays the last resort so a fresh
     // session's orphan keeps its designed no-pattern outcome.
-    const resolvePatternRef = () => {
-      const durable = getPatternIdentityRef(piece);
-      if (
-        durable !== undefined &&
-        !PatternManager.isKeylessPatternIdentity(durable.identity)
-      ) {
-        return durable;
-      }
-      return this.runtime.runner.sessionPatternPointerFor(piece) ?? durable;
-    };
-    let ref = resolvePatternRef();
-    if (!ref) {
-      // Under remote sync, metadata can transiently lag the result value even
-      // though setup just wrote both. Wait for storage to settle and retry once
-      // before treating the pattern metadata as missing.
-      await timePiecePhase("syncPattern.retry.synced", () => this.synced());
-      await timePiecePhase("syncPattern.retry.piece.sync", () => piece.sync());
-      ref = resolvePatternRef();
-    }
+    const durable = getPatternIdentityRef(piece);
+    const ref = (durable !== undefined &&
+        !PatternManager.isKeylessPatternIdentity(durable.identity))
+      ? durable
+      : this.runtime.runner.sessionPatternPointerFor(piece) ?? durable;
     if (!ref) throw new Error("piece missing pattern identity");
-
-    return await timePiecePhase(
-      "syncPattern.loadPattern",
-      () => this.syncPatternByIdentity(ref),
-    );
+    return ref;
   }
 
   async syncPatternByIdentity(ref: { identity: string; symbol: string }) {

--- a/packages/piece/test/sync-pattern.test.ts
+++ b/packages/piece/test/sync-pattern.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { createSession, Identity } from "@commonfabric/identity";
+import {
+  type Cell,
+  getPatternIdentityRef,
+  type Pattern,
+  Runtime,
+} from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { PiecesController } from "../src/ops/pieces-controller.ts";
+
+const signer = await Identity.fromPassphrase("piece sync pattern");
+
+function doublePattern(): Pattern {
+  return {
+    argumentSchema: {
+      type: "object",
+      properties: {
+        input: { type: "number" },
+      },
+    },
+    resultSchema: {
+      type: "object",
+      properties: {
+        output: { type: "number" },
+      },
+    },
+    derivedInternalCells: [{ partialCause: "output" }],
+    result: {
+      output: { $alias: { partialCause: "output", path: [] } },
+    },
+    nodes: [
+      {
+        module: {
+          type: "javascript",
+          implementation: (input: number) => input * 2,
+        },
+        inputs: { $alias: { cell: "argument", path: ["input"] } },
+        outputs: { $alias: { partialCause: "output", path: [] } },
+      },
+    ],
+  };
+}
+
+describe("syncPattern", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let pieces: PiecesController;
+
+  beforeEach(async () => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL("http://localhost:9999"),
+      storageManager,
+    });
+    const session = await createSession({
+      identity: signer,
+      spaceName: "sync-pattern-" + crypto.randomUUID(),
+    });
+    pieces = new PiecesController(session, runtime);
+    await pieces.synced();
+  });
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  it("resolves from the supplied pattern's entry ref without reading the piece", async () => {
+    const pattern = runtime.unsafeTrustPattern(doublePattern(), {
+      reason: "sync-pattern test fixture",
+    });
+    const ref = { identity: "sync-pattern-identity", symbol: "default" };
+    runtime.patternManager.associatePatternIdentity(pattern, ref);
+
+    // A cell that setup never touched: it carries no `patternIdentity` at all,
+    // so a resolution that went through the piece could not succeed.
+    const bare = runtime.getCell(
+      pieces.getSpace(),
+      "sync-pattern-bare-" + crypto.randomUUID(),
+    );
+    let syncs = 0;
+    const originalSync = bare.sync.bind(bare);
+    bare.sync = () => {
+      syncs++;
+      return originalSync();
+    };
+
+    expect(await pieces.syncPattern(bare, pattern)).toBe(pattern);
+    expect(syncs).toBe(0);
+  });
+
+  it("resolves from the piece's own identity metadata when no pattern is supplied", async () => {
+    const pattern = runtime.unsafeTrustPattern(doublePattern(), {
+      reason: "sync-pattern test fixture",
+    });
+    const ref = { identity: "sync-pattern-from-piece", symbol: "default" };
+    runtime.patternManager.associatePatternIdentity(pattern, ref);
+    const piece: Cell<{ output: number }> = await pieces.runPersistent(
+      pattern,
+      { input: 3 },
+      undefined,
+      { start: true },
+    );
+    expect(getPatternIdentityRef(piece)).toEqual(ref);
+
+    // No pattern in hand: the identity has to come off the piece.
+    expect(await pieces.syncPattern(piece)).toBe(pattern);
+  });
+
+  it("settles the pending writes before reading an identity that is already readable", async () => {
+    const pattern = runtime.unsafeTrustPattern(doublePattern(), {
+      reason: "sync-pattern test fixture",
+    });
+    runtime.patternManager.associatePatternIdentity(pattern, {
+      identity: "sync-pattern-settle-first",
+      symbol: "default",
+    });
+    const piece: Cell<{ output: number }> = await pieces.runPersistent(
+      pattern,
+      { input: 4 },
+      undefined,
+      { start: true },
+    );
+    // Readable right now, so a read-first implementation would never settle.
+    expect(getPatternIdentityRef(piece)).toBeDefined();
+
+    let settles = 0;
+    const originalSynced = pieces.synced.bind(pieces);
+    pieces.synced = () => {
+      settles++;
+      return originalSynced();
+    };
+
+    expect(await pieces.syncPattern(piece)).toBe(pattern);
+    expect(settles).toBe(1);
+  });
+
+  it("throws for a piece with no pattern identity and no pattern in hand", async () => {
+    const bare = runtime.getCell(
+      pieces.getSpace(),
+      "sync-pattern-missing-" + crypto.randomUUID(),
+    );
+
+    await expect(pieces.syncPattern(bare)).rejects.toThrow(
+      /piece missing pattern identity/,
+    );
+  });
+
+  it("throws for a piece with no pattern identity when the supplied pattern has no entry ref", async () => {
+    const unregistered = runtime.unsafeTrustPattern(doublePattern(), {
+      reason: "sync-pattern test fixture",
+    });
+    const bare = runtime.getCell(
+      pieces.getSpace(),
+      "sync-pattern-unregistered-" + crypto.randomUUID(),
+    );
+
+    await expect(pieces.syncPattern(bare, unregistered)).rejects.toThrow(
+      /piece missing pattern identity/,
+    );
+  });
+});

--- a/packages/piece/test/sync-pieces.test.ts
+++ b/packages/piece/test/sync-pieces.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { createSession, Identity } from "@commonfabric/identity";
+import {
+  type Cell,
+  isCell,
+  type Pattern,
+  Runtime,
+  type RuntimeProgram,
+} from "@commonfabric/runner";
+import { cfcAtom } from "@commonfabric/api/cfc";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { PiecesController } from "../src/ops/pieces-controller.ts";
+import { pieceId } from "../src/piece-id.ts";
+
+const signer = await Identity.fromPassphrase("test sync pieces");
+
+const defaultPatternProgram: RuntimeProgram = {
+  main: "/main.tsx",
+  files: [
+    {
+      name: "/main.tsx",
+      contents: [
+        "import { handler, pattern, type Cell, type Stream } from 'commonfabric';",
+        "const addPiece = handler<{ piece: unknown }, { pieceRegistry: Cell<unknown[]> }>(",
+        "  true,",
+        "  { type: 'object', properties: { pieceRegistry: { type: 'array', asCell: ['cell'] } } },",
+        "  ({ piece }, { pieceRegistry }) => {",
+        "    pieceRegistry.push(piece);",
+        "  },",
+        ");",
+        "export default pattern<",
+        "  { pieceRegistry: unknown[] },",
+        "  { pieceRegistry: unknown[]; addPiece: Stream<{ piece: unknown }> }",
+        ">(({ pieceRegistry }) => ({",
+        "  pieceRegistry,",
+        "  addPiece: addPiece({ pieceRegistry }),",
+        "}));",
+      ].join("\n"),
+    },
+  ],
+};
+
+// A piece whose one result property carries a confidentiality atom. Listing the
+// registry must not depend on being able to read that property.
+function confidentialPattern(): Pattern {
+  return {
+    argumentSchema: {
+      type: "object",
+      properties: {
+        value: { type: "number" },
+      },
+    },
+    resultSchema: {
+      type: "object",
+      properties: {
+        secret: {
+          type: "number",
+          ifc: { confidentiality: [cfcAtom.resource("SyncPiecesTestSecret")] },
+        },
+      },
+    },
+    derivedInternalCells: [{ partialCause: "secret" }],
+    result: {
+      secret: { $alias: { partialCause: "secret", path: [] } },
+    },
+    nodes: [
+      {
+        module: {
+          type: "javascript",
+          implementation: (value: number) => value * 2,
+        },
+        inputs: { $alias: { cell: "argument", path: ["value"] } },
+        outputs: { $alias: { partialCause: "secret", path: [] } },
+      },
+    ],
+  };
+}
+
+describe("syncPieces", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let pieces: PiecesController;
+
+  beforeEach(async () => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL("http://localhost:9999"),
+      storageManager,
+    });
+    const session = await createSession({
+      identity: signer,
+      spaceName: "sync-pieces-" + crypto.randomUUID(),
+    });
+    pieces = new PiecesController(session, runtime);
+    await pieces.synced();
+
+    const defaultPattern = await runtime.patternManager.compilePattern(
+      defaultPatternProgram,
+      { space: pieces.getSpace() },
+    );
+    const defaultPatternPiece = await pieces.runPersistent(
+      defaultPattern,
+      { pieceRegistry: [] },
+      "sync-pieces-default-pattern",
+    );
+    await pieces.linkDefaultPattern(defaultPatternPiece);
+    await runtime.idle();
+    await pieces.synced();
+  });
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  async function registerConfidentialPiece(cause: string) {
+    const piece = await pieces.runPersistent<{ secret: number }>(
+      runtime.unsafeTrustPattern(confidentialPattern(), {
+        reason: "sync-pieces test fixture",
+      }),
+      { value: 21 },
+      cause,
+    );
+    await pieces.add([piece]);
+    return piece;
+  }
+
+  it("returns a registered piece whose result schema carries a confidentiality atom", async () => {
+    const piece = await registerConfidentialPiece("sync-pieces-confidential");
+
+    const registry = await pieces.getPieceRegistry();
+    const listed = await pieces.syncPieces(registry);
+
+    expect(listed.map((entry) => pieceId(entry))).toContain(pieceId(piece));
+  });
+
+  it("returns the registry entries as cells rather than their values", async () => {
+    const piece = await registerConfidentialPiece("sync-pieces-cells");
+
+    const registry = await pieces.getPieceRegistry();
+    const listed = await pieces.syncPieces(registry);
+
+    expect(listed.length).toBeGreaterThan(0);
+    expect(listed.every((entry: Cell<unknown>) => isCell(entry))).toBe(true);
+    // Reading the labeled property is a separate act on the entry's own cell,
+    // not something the listing carried along.
+    expect(piece.get().secret).toBe(42);
+  });
+});


### PR DESCRIPTION
Two markers in the piece package's space-level controller made claims that stopped being true, and this settles both.

The first claimed that reading the piece registry needs elevated permissions, because the read walks the schema tree into confidential piece data. It was added in May 2025, when a schema query carried a classification the memory server checked, and the label it asked for was the blanket "secret" one. Neither half survives. The classification lattice was replaced by structured atoms, and that migration rewrote the label mechanically into a Resource atom nothing else in the tree names, grants, or discharges. A confidentiality clause on a schema has never been a clearance in the current model: it labels the data read through it. What a transaction consumed is derived from a document's stored metadata, not from the schema doing the reading, so the only thing the clause still did was mark every piece-list read as CFC-relevant. That marking is not load-bearing either. The checks that gate confidentiality leaving the system compute their own relevance at commit, so nothing opens by dropping it.

The premise is gone as well, though it was true when it was written. The list items then carried a full content shape, so the query really did descend into each entry. They are now `unknown`, with no shape to descend through, which is what keeps the read out of a piece's contents. `asCell` is not what does it: that keyword bounds the runtime's own walk, and the memory query walks through it. The clause is removed and the reason no elevation is needed is written down where the read happens.

The second marker asked for a design to be revisited without saying which one. Read against the commit that introduced it, the answer is that pattern synchronization straddled two unrelated stores: the runtime's own cells and an external blob server, reached through an entity id that the two halves stringified differently. That store is long gone. What survived is a different awkwardness: the function rediscovers a pattern the caller is already holding by round-tripping through storage, and papers over the resulting race with a read that retries once. A retry masks errors, and a caller that drove setup itself knows which pattern the piece ended up running. So the identity now comes from the pattern's own content-addressed entry ref when the caller has one, and the metadata read that remains settles the pending writes before reading rather than after a read that missed.

Only a caller that drove setup may name its pattern. Going through `runSynced` carries no such knowledge: a concurrent source update can supersede the caller between its setup commit and this call, and `runSynced` then hands back a piece running the winner. That path still reads the piece's own metadata, and pays a wait on the storage manager's whole queue to do it. That is a real cost, where before the wait came only after a read that missed. It buys an answer that does not depend on when the read happened to land.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6860?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

