### PR TITLE
perf(cli): keep callable discovery off the runner

### DIFF
--- a/docs/common/verbs/agents-over-the-cli.md
+++ b/docs/common/verbs/agents-over-the-cli.md
@@ -63,11 +63,12 @@ as `cf cell get`, so a survey can be narrowed on the way out.
 `cf piece verbs --json` is the first call to make against an unfamiliar piece:
 it names the deployed pattern and lists every callable verb with its prose and
 the schemas a payload is judged against, which is what a caller needs to act.
-Each of the reads below is its own cold CLI process that starts the piece, so
-they are not a preflight to run together; reach for the others when the
-question they answer comes up. `cf piece describe` prints the piece's man page
-— what it is, what it holds, what a caller supplies, and what it can do — with
-every sentence compiled from the pattern's own doc comments:
+Each of the reads below is its own cold CLI process. `verbs` and `describe` load
+the stored callable surface and pattern metadata without starting the piece;
+they are still not a preflight to run together, so reach for the others when
+the question they answer comes up. `cf piece describe` prints the piece's man
+page — what it is, what it holds, what a caller supplies, and what it can do —
+with every sentence compiled from the pattern's own doc comments:
 
 ```bash
 cf piece describe --cell <piece>

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -3128,7 +3128,9 @@ async function listCallablesForLoadedPiece(piece: any): Promise<{
   const compiledRead = typeof piece.getPattern === "function"
     ? timeCliPhase(
       "listPieceCallables.pattern",
-      () => piece.getPattern(),
+      // Discovery wants the pattern alone; the default projection would
+      // load every document the result schema reaches (a board's index).
+      () => piece.getPattern({ projectResult: false }),
     ).then((value) => value ?? null).catch(() => null)
     : Promise.resolve(null);
   const [pattern, compiledPattern] = await Promise.all([

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -28,6 +28,7 @@ import {
 import {
   type PatternCompatibilityReport,
   type PatternUpdateReceipt,
+  PieceController,
   type PiecePatternRef,
   PiecesController,
 } from "@commonfabric/piece/ops";
@@ -1847,9 +1848,14 @@ async function tryResolveLivePieceToolCallable(
  * `deps.loadPiece` is absent (the test seam is the one way around it): a verb
  * that creates a piece registers it by sending an event to the default pattern's
  * `addPiece` stream (see `newPiece`), so against an unbootstrapped root it
- * fails with "Cannot add pieces" rather than running slowly. Discovery
- * (`verbs`, `describe`) only reads the addressed piece, so it starts that
- * piece and nothing else.
+ * fails with "Cannot add pieces" rather than running slowly. Dispatch then
+ * starts the addressed piece before resolving the requested callable.
+ *
+ * Discovery (`verbs`, `describe`) only reads the addressed piece's stored
+ * callable surface and pattern metadata. It neither starts the piece nor asks
+ * `PiecesController.get()` to project the piece's full result schema: the
+ * document sync in `getPieceCell()` supplies the canonical result cell and its
+ * metadata, which are the bounded inputs discovery needs.
  *
  * `cf piece call <verb> --help` takes the dispatch path: `executePieceCallable`
  * resolves the verb before it parses the arguments, so it cannot know it is
@@ -1861,7 +1867,7 @@ async function tryResolveLivePieceToolCallable(
 async function loadPieceForCallables(
   config: PieceConfig,
   deps: PieceCallableDependencies,
-  { ensureSpaceRoot }: { ensureSpaceRoot: boolean },
+  { prepareDispatch }: { prepareDispatch: boolean },
 ): Promise<{
   pieces: any;
   piece: any;
@@ -1871,7 +1877,7 @@ async function loadPieceForCallables(
   const pieces = await (deps.loadPieces ?? loadPieces)(config);
   const resolvedConfig = await resolvePieceConfigWithPieces(config, pieces);
 
-  if (!deps.loadPiece && ensureSpaceRoot) {
+  if (!deps.loadPiece && prepareDispatch) {
     try {
       await pieces.ensureDefaultPattern();
     } catch (error) {
@@ -1889,11 +1895,21 @@ async function loadPieceForCallables(
       resolvedConfig.piece,
       resolvedConfig.pieceScope,
     )
-    : pieces.get(
+    : prepareDispatch
+    ? pieces.get(
       resolvedConfig.piece,
       true,
       undefined,
       resolvedConfig.pieceScope,
+    )
+    : new PieceController(
+      pieces,
+      await pieces.getPieceCell(
+        resolvedConfig.piece,
+        { reconcile: true, start: false },
+        undefined,
+        resolvedConfig.pieceScope,
+      ),
     ));
   const space = pieces.getSpace?.() ?? config.space;
   return { pieces, piece, space, resolvedConfig };
@@ -1907,7 +1923,7 @@ async function resolvePieceCallable(
   const { pieces, piece, space, resolvedConfig } = await loadPieceForCallables(
     config,
     deps,
-    { ensureSpaceRoot: true },
+    { prepareDispatch: true },
   );
 
   const onResultCell = await tryResolvePieceCallableAt(
@@ -3057,10 +3073,17 @@ export async function listPieceCallables(
   config: PieceConfig,
   deps: PieceCallableDependencies = {},
 ): Promise<PieceCallablesListing> {
-  const { piece } = await loadPieceForCallables(config, deps, {
-    ensureSpaceRoot: false,
-  });
-  return (await listCallablesForLoadedPiece(piece)).listing;
+  const { piece } = await timeCliPhase(
+    "listPieceCallables.loadPiece",
+    () =>
+      loadPieceForCallables(config, deps, {
+        prepareDispatch: false,
+      }),
+  );
+  return (await timeCliPhase(
+    "listPieceCallables.list",
+    () => listCallablesForLoadedPiece(piece),
+  )).listing;
 }
 
 /** The listing walk over an already-loaded piece, returning the compiled
@@ -3073,14 +3096,15 @@ async function listCallablesForLoadedPiece(piece: any): Promise<{
   listing: PieceCallablesListing;
   compiled: { argumentSchema?: unknown; resultSchema?: unknown } | null;
 }> {
-  let pattern: PiecePatternRef | null = null;
-  if (typeof piece.getPatternRef === "function") {
-    try {
-      pattern = (await piece.getPatternRef()) ?? null;
-    } catch {
-      pattern = null; // Identity is advisory; the listing itself still holds.
-    }
-  }
+  // The authored source reference and the compiled pattern are independent
+  // storage closures. Start both reads together: on a cold CLI process either
+  // can dominate, and serializing them adds their latencies for no benefit.
+  const patternRef = typeof piece.getPatternRef === "function"
+    ? timeCliPhase(
+      "listPieceCallables.patternRef",
+      () => piece.getPatternRef(),
+    ).then((value) => value ?? null).catch(() => null)
+    : Promise.resolve(null);
 
   // The compiled pattern, read once for three independent jobs. Its result
   // properties are candidate NAMES for the sweep below — the only source for a
@@ -3101,25 +3125,20 @@ async function listCallablesForLoadedPiece(piece: any): Promise<{
   // partial answer. What it must not do either is present a shortened list as
   // the whole surface, which is the difference between losing a row's
   // `outputSchema` and losing the row.
-  let graphNames: string[] = [];
-  let handlerResults = new Map<string, JSONSchema | undefined>();
-  let verbProse = new Map<string, DeclaredVerbProse>();
-  let graphConsulted = false;
-  let compiledPattern:
-    | { argumentSchema?: unknown; resultSchema?: unknown }
-    | null = null;
-  if (typeof piece.getPattern === "function") {
-    try {
-      const compiled = await piece.getPattern();
-      graphNames = patternResultNames(compiled);
-      handlerResults = handlerVerbResults(compiled);
-      verbProse = declaredVerbProse(compiled);
-      compiledPattern = compiled ?? null;
-      graphConsulted = true;
-    } catch {
-      // Reported as `incomplete` below rather than swallowed.
-    }
-  }
+  const compiledRead = typeof piece.getPattern === "function"
+    ? timeCliPhase(
+      "listPieceCallables.pattern",
+      () => piece.getPattern(),
+    ).then((value) => value ?? null).catch(() => null)
+    : Promise.resolve(null);
+  const [pattern, compiledPattern] = await Promise.all([
+    patternRef,
+    compiledRead,
+  ]);
+  const graphConsulted = compiledPattern !== null;
+  const graphNames = patternResultNames(compiledPattern);
+  const handlerResults = handlerVerbResults(compiledPattern);
+  const verbProse = declaredVerbProse(compiledPattern);
 
   /**
    * The prose row for a callable, on the same terms `handlerResults` is
@@ -3346,18 +3365,28 @@ export async function describePiece(
   deps: PieceCallableDependencies = {},
 ): Promise<PieceDescription> {
   const { piece } = await loadPieceForCallables(config, deps, {
-    ensureSpaceRoot: false,
+    prepareDispatch: false,
   });
   const { listing, compiled } = await listCallablesForLoadedPiece(piece);
   let name: string | undefined;
   try {
-    const pieceCell = typeof piece.getCell === "function"
-      ? piece.getCell()
-      : undefined;
-    const nameCell = pieceCell?.key?.(NAME);
-    const value = typeof nameCell?.pull === "function"
-      ? await nameCell.pull()
-      : nameCell?.get?.();
+    // A real PieceController was built from getPieceCell(), whose document
+    // sync already brought the NAME field local. Pulling that field opens a
+    // second storage watch and repeats work just to read one advisory string.
+    // Keep the cell fallback for injected adapters that predate name().
+    const value = await timeCliPhase(
+      "describePiece.name",
+      () => {
+        if (typeof piece.name === "function") return piece.name();
+        const pieceCell = typeof piece.getCell === "function"
+          ? piece.getCell()
+          : undefined;
+        const nameCell = pieceCell?.key?.(NAME);
+        return typeof nameCell?.pull === "function"
+          ? nameCell.pull()
+          : nameCell?.get?.();
+      },
+    );
     if (typeof value === "string" && value !== "") name = value;
   } catch {
     // Unnamed is a state, not a failure.

--- a/packages/cli/test/piece-describe.test.ts
+++ b/packages/cli/test/piece-describe.test.ts
@@ -421,21 +421,30 @@ describe("piece-describe", () => {
       space: "home",
     };
 
-    it("starts the addressed piece without starting the space root", async () => {
+    it("loads the addressed piece without starting it or the space root", async () => {
       // Discovery reads the addressed piece and nothing else: the space
-      // root's bootstrap is dispatch's concern (a verb that creates a piece
-      // registers it with the root), not a description's.
-      const getCalls: unknown[][] = [];
+      // root's bootstrap and the target's start are dispatch concerns, not a
+      // description's.
+      const fixture = pieceDouble();
+      const resultRoot = await fixture.result.getCell();
+      const inputRoot = await fixture.input.getCell();
+      const pieceRoot = {
+        ...fixture.getCell(),
+        entityId: { "/": config.piece },
+      };
+      const getPieceCellCalls: unknown[][] = [];
       let ensureCalls = 0;
       const manager = {
         ensureDefaultPattern: () => {
           ensureCalls++;
           return Promise.resolve();
         },
-        get: (...args: unknown[]) => {
-          getCalls.push(args);
-          return Promise.resolve(pieceDouble());
+        getPieceCell: (...args: unknown[]) => {
+          getPieceCellCalls.push(args);
+          return Promise.resolve(pieceRoot);
         },
+        getResult: () => resultRoot,
+        getArgument: () => inputRoot,
         getSpace: () => "home",
       };
 
@@ -444,8 +453,14 @@ describe("piece-describe", () => {
       });
 
       expect(ensureCalls).toBe(0);
-      expect(getCalls).toEqual([[config.piece, true, undefined, undefined]]);
-      expect(description.name).toBe("Work tracker");
+      expect(getPieceCellCalls).toEqual([
+        [
+          config.piece,
+          { reconcile: true, start: false },
+          undefined,
+          undefined,
+        ],
+      ]);
       expect(description.verbs.map((verb) => verb.name)).toEqual(["addItem"]);
     });
 
@@ -469,6 +484,32 @@ describe("piece-describe", () => {
       expect(description.verbs[0].description).toBe(
         "File a new root item on the board.",
       );
+    });
+
+    it("reads a controller's already-loaded name without pulling its cell", async () => {
+      const base = pieceDouble();
+      const baseCell = base.getCell();
+      const piece = pieceDouble({
+        name: () => "Local name",
+        getCell: () => ({
+          ...baseCell,
+          key: (key: unknown) =>
+            key === NAME
+              ? {
+                pull: () => {
+                  throw new Error("pulled the already-loaded name");
+                },
+              }
+              : baseCell.key(key),
+        }),
+      });
+
+      const description = await describePiece(config, {
+        loadPieces: () => Promise.resolve({} as never),
+        loadPiece: () => Promise.resolve(piece as never),
+      });
+
+      expect(description.name).toBe("Local name");
     });
 
     it("describes an unnamed piece without a name key", async () => {

--- a/packages/cli/test/piece-verbs.test.ts
+++ b/packages/cli/test/piece-verbs.test.ts
@@ -255,7 +255,7 @@ function compiledPattern(
 }
 
 describe("listPieceCallables", () => {
-  it("starts the addressed piece without starting the space root", async () => {
+  it("loads the addressed piece without starting it or the space root", async () => {
     const resultRoot = cell(
       { addTopic: { $stream: true } },
       {
@@ -263,22 +263,24 @@ describe("listPieceCallables", () => {
         properties: { addTopic: ADD_TOPIC_EVENT },
       },
     );
-    const piece = {
-      result: { getCell: () => Promise.resolve(resultRoot) },
-      input: { getCell: () => Promise.resolve(cell(undefined, undefined)) },
-      getCell: () => resultRoot,
+    const inputRoot = cell(undefined, undefined);
+    const pieceRoot = {
+      ...pieceRootCell({ addTopic: { $stream: true } }),
+      entityId: { "/": "fid1:piece-stored" },
     };
-    const getCalls: unknown[][] = [];
+    const getPieceCellCalls: unknown[][] = [];
     let ensureCalls = 0;
     const manager = {
       ensureDefaultPattern: () => {
         ensureCalls++;
         return Promise.resolve();
       },
-      get: (...args: unknown[]) => {
-        getCalls.push(args);
-        return Promise.resolve(piece);
+      getPieceCell: (...args: unknown[]) => {
+        getPieceCellCalls.push(args);
+        return Promise.resolve(pieceRoot);
       },
+      getResult: () => resultRoot,
+      getArgument: () => inputRoot,
       getSpace: () => "home",
     };
 
@@ -293,10 +295,62 @@ describe("listPieceCallables", () => {
     );
 
     expect(ensureCalls).toBe(0);
-    expect(getCalls).toEqual([
-      ["fid1:piece-stored", true, undefined, undefined],
+    expect(getPieceCellCalls).toEqual([
+      [
+        "fid1:piece-stored",
+        { reconcile: true, start: false },
+        undefined,
+        undefined,
+      ],
     ]);
     expect(listing.verbs.map((verb) => verb.name)).toEqual(["addTopic"]);
+  });
+
+  it("loads the pattern reference and compiled pattern concurrently", async () => {
+    const resultRoot = cell(
+      { addTopic: { $stream: true } },
+      {
+        type: "object",
+        properties: { addTopic: ADD_TOPIC_EVENT },
+      },
+    );
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => release = resolve);
+    const started: string[] = [];
+    const piece = {
+      result: { getCell: () => Promise.resolve(resultRoot) },
+      input: { getCell: () => Promise.resolve(cell(undefined, undefined)) },
+      getCell: () => resultRoot,
+      getPatternRef: async () => {
+        started.push("reference");
+        await gate;
+        return TEST_PATTERN_REF;
+      },
+      getPattern: async () => {
+        started.push("compiled");
+        await gate;
+        return compiledPattern({ result: {}, nodes: [] });
+      },
+    };
+
+    const pending = listPieceCallables(
+      {
+        apiUrl: "http://localhost:8000",
+        identity: "/tmp/test-identity.pem",
+        piece: "fid1:piece-stored",
+        space: "home",
+      },
+      {
+        loadPieces: () => Promise.resolve({ getSpace: () => "home" } as never),
+        loadPiece: () => Promise.resolve(piece as never),
+      },
+    );
+    for (let i = 0; i < 10 && started.length < 2; i++) await Promise.resolve();
+    const beforeRelease = [...started].sort();
+    release();
+
+    expect(beforeRelease).toEqual(["compiled", "reference"]);
+    await pending;
   });
 
   it("lists handlers and tools with schemas; excludes data; result shadows input", async () => {

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -3738,18 +3738,30 @@ export class PieceController<T = unknown> {
     });
   }
 
-  async getPattern(): Promise<Pattern> {
-    return (await this.#loadCurrentPattern()).pattern;
+  /**
+   * The compiled pattern this piece is pinned to.
+   *
+   * By default the read also projects the result schema, loading every
+   * document it reaches: the source-change and compatibility paths read
+   * through that projection next and rely on it being local. A caller that
+   * wants only the pattern — callable discovery — passes
+   * `projectResult: false`, and the sync is bounded to the result document
+   * that carries the pattern pointer.
+   */
+  async getPattern(
+    options: { projectResult?: boolean } = {},
+  ): Promise<Pattern> {
+    return (await this.#loadCurrentPattern(options)).pattern;
   }
 
-  async #loadCurrentPattern(): Promise<{
+  async #loadCurrentPattern(
+    { projectResult = true }: { projectResult?: boolean } = {},
+  ): Promise<{
     pattern: Pattern;
     ref: { identity: string; symbol: string };
   }> {
-    // The pattern pointer lives on the result document's metadata. Do not
-    // project the result schema here: a caller asking which pattern a piece
-    // uses does not need every document reachable from that result.
-    await this.#cell.asSchema(undefined).sync();
+    if (projectResult) await this.#cell.sync();
+    else await this.#cell.asSchema(undefined).sync();
     const ref = this.#patternPointer();
     if (!ref) throw new Error("piece missing pattern identity");
     const runtime = this.#pieces.runtime;

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -3746,7 +3746,10 @@ export class PieceController<T = unknown> {
     pattern: Pattern;
     ref: { identity: string; symbol: string };
   }> {
-    await this.#cell.sync();
+    // The pattern pointer lives on the result document's metadata. Do not
+    // project the result schema here: a caller asking which pattern a piece
+    // uses does not need every document reachable from that result.
+    await this.#cell.asSchema(undefined).sync();
     const ref = this.#patternPointer();
     if (!ref) throw new Error("piece missing pattern identity");
     const runtime = this.#pieces.runtime;

--- a/packages/piece/test/pull-materialization.test.ts
+++ b/packages/piece/test/pull-materialization.test.ts
@@ -1771,6 +1771,28 @@ describe("piece pull materialization", () => {
     }
   });
 
+  it("loads a pattern through a document-bounded result cell", async () => {
+    const pattern = await runtime.patternManager.compilePattern(
+      compiledMultiplierProgram("bounded-pattern-load", 2),
+      { space: pieces.getSpace() },
+    );
+    const piece = await pieces.runPersistent(
+      pattern,
+      { input: 5 },
+      undefined,
+      { start: false },
+    );
+    const schemas: unknown[] = [];
+    const originalAsSchema = piece.asSchema.bind(piece);
+    piece.asSchema = ((schema: unknown) => {
+      schemas.push(schema);
+      return originalAsSchema(schema as never);
+    }) as typeof piece.asSchema;
+
+    expect(await new PieceController(pieces, piece).getPattern()).toBe(pattern);
+    expect(schemas).toEqual([undefined]);
+  });
+
   it("keeps pattern content refs useful when source programs are unavailable", async () => {
     const identityless = runtime.getCell(
       pieces.getSpace(),

--- a/packages/piece/test/pull-materialization.test.ts
+++ b/packages/piece/test/pull-materialization.test.ts
@@ -1789,8 +1789,13 @@ describe("piece pull materialization", () => {
       return originalAsSchema(schema as never);
     }) as typeof piece.asSchema;
 
-    expect(await new PieceController(pieces, piece).getPattern()).toBe(pattern);
+    const controller = new PieceController(pieces, piece);
+    expect(await controller.getPattern({ projectResult: false })).toBe(pattern);
     expect(schemas).toEqual([undefined]);
+    // The default keeps the projection: no schema-less sibling is synced.
+    schemas.length = 0;
+    expect(await controller.getPattern()).toBe(pattern);
+    expect(schemas).toEqual([]);
   });
 
   it("keeps pattern content refs useful when source programs are unavailable", async () => {

--- a/skills/topics/SKILL.md
+++ b/skills/topics/SKILL.md
@@ -58,9 +58,9 @@ cf piece verbs --cell "$TOPICS_BOARD" --json
 That listing includes the deployed pattern reference, callable prose, and input
 and output schemas. `cf piece describe --cell "$TOPICS_BOARD" --json` returns a
 superset of it (the same verb rows plus name, purpose, state, and inputs) for
-the same bounded discovery load. Neither command starts the piece; the reason
-to default to `verbs` is payload, not time: the listing is the smaller document
-to hold in context, and it is complete for calling. Use `describe` when you need
+the same bounded discovery load. Neither command starts the piece; the reason to
+default to `verbs` is payload, not time: the listing is the smaller document to
+hold in context, and it is complete for calling. Use `describe` when you need
 the piece-wide purpose, state, or input documentation. Use
 `cf piece call --cell "$TOPICS_BOARD" <verb> --help --json` only after choosing
 a verb and when its generated flags or standalone help are useful; help is

--- a/skills/topics/SKILL.md
+++ b/skills/topics/SKILL.md
@@ -58,10 +58,10 @@ cf piece verbs --cell "$TOPICS_BOARD" --json
 That listing includes the deployed pattern reference, callable prose, and input
 and output schemas. `cf piece describe --cell "$TOPICS_BOARD" --json` returns a
 superset of it (the same verb rows plus name, purpose, state, and inputs) for
-the same process and piece start, so the reason to default to `verbs` is
-payload, not time: the listing is the smaller document to hold in context, and
-it is complete for calling. Use `describe` when you need the piece-wide purpose,
-state, or input documentation. Use
+the same bounded discovery load. Neither command starts the piece; the reason
+to default to `verbs` is payload, not time: the listing is the smaller document
+to hold in context, and it is complete for calling. Use `describe` when you need
+the piece-wide purpose, state, or input documentation. Use
 `cf piece call --cell "$TOPICS_BOARD" <verb> --help --json` only after choosing
 a verb and when its generated flags or standalone help are useful; help is
 served through the dispatch path, which also starts the space root, so it is the


### PR DESCRIPTION
## Summary

- load `piece verbs` and `piece describe` without starting the addressed piece or projecting its full result graph
- preserve mutable-source reconciliation and leave actual verb dispatch unchanged
- bound `PieceController.getPattern()` to the result document carrying the pattern pointer
- overlap the independent pattern-source and compiled-pattern reads
- let `piece describe` reuse the already-loaded name instead of opening another watch
- update agent/Topics guidance to match the new discovery behavior

## Estuary measurements

| Operation | Before | Candidate | Change |
|---|---:|---:|---:|
| Board `piece verbs` | 2.961 s median | 2.34 s median (n=5, 2.31–2.46) | ~21% lower |
| Topic `piece verbs` | ~1.46 s median | 1.19 s median (n=5, 1.17–1.20) | ~18% lower |
| Board `piece describe` | 4.08 s median (n=3, 3.99–4.39) | 2.29 s median (n=3, 2.26–2.44) | ~44% lower |

The board verb JSON is byte-identical before and after. The optimized description still returns `Topics (158)`, the same pattern identity, and `addTopic`.

The remaining board floor is now the Topics pattern itself: about 1.4–1.6 seconds for its authored-source and compiled-pattern closures (overlapped). The projected Topic index is not on the discovery path after this change. A durable compact callable manifest is the separate architectural follow-up.

## Verification

- `deno check packages/cli/lib/piece.ts packages/piece/src/ops/piece-controller.ts`
- targeted CLI suites: 23 tests / 219 steps passed
- `packages/piece/test/pull-materialization.test.ts`: 3 tests / 141 steps passed
- live Estuary output and timing checks above

The repository-wide test wrapper ignored file arguments and also encountered unrelated environment failures (OTel export and browser listen permission); those are not counted as gates here.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6863?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

