### PR TITLE
feat(runner): require the builder to bind what a pattern is promised

### DIFF
--- a/.claude/rules/README.md
+++ b/.claude/rules/README.md
@@ -85,11 +85,12 @@ hold the ones only a reviewer will catch.
 
 ## The rules
 
-| Rule                     | Covers                                          |
-| ------------------------ | ----------------------------------------------- |
-| `source-code.md`         | every `.ts` and `.tsx` file                     |
-| `tests.md`               | test, bench, and integration files              |
-| `workspace-packages.md`  | `deno.jsonc`, at the root and in every package  |
-| `documentation.md`       | everything under `docs/`                        |
-| `github-workflows.md`    | `.github/workflows/`                            |
-| `skills.md`              | `skills/`                                       |
+| Rule                              | Covers                                         |
+| --------------------------------- | ---------------------------------------------- |
+| `source-code.md`                  | every `.ts` and `.tsx` file                    |
+| `tests.md`                        | test, bench, and integration files             |
+| `workspace-packages.md`           | `deno.jsonc`, at the root and in every package |
+| `documentation.md`                | everything under `docs/`                       |
+| `github-workflows.md`             | `.github/workflows/`                           |
+| `skills.md`                       | `skills/`                                      |
+| `pattern-visible-declarations.md` | `packages/api`, and what mirrors it            |

--- a/.claude/rules/pattern-visible-declarations.md
+++ b/.claude/rules/pattern-visible-declarations.md
@@ -10,16 +10,18 @@ paths:
 
 # The declarations a pattern compiles against
 
-`packages/api/index.ts` is the whole of the `commonfabric` module's type. What
-the sandbox hands the pattern compiler is
-`packages/static/assets/types/commonfabric.d.ts`, which
-`scripts/generate-commonfabric-types.ts` builds from it -- so an edit here needs
-`deno task gen-commonfabric-types` in `packages/static`, and
-`check-commonfabric-types` fails the build until it has been run. The generator
-inlines the one module `index.ts` imports for its declarations rather than
-following the specifier out, because the compiler that reads the result resolves
-none. Anything else it describes, it describes by declaring
-a second copy of the shape by hand, and the implementation is in
+`packages/api/index.ts` is the whole of the `commonfabric` module's type, and
+what the sandbox hands the pattern compiler is
+`packages/static/assets/types/commonfabric.d.ts`, generated from it by
+`packages/static/scripts/generate-commonfabric-types.ts`. So an edit to the
+declarations takes `deno task gen-commonfabric-types` in `packages/static` with
+it, and `check-commonfabric-types` fails the build until it has been run. The
+generator inlines the modules `index.ts` draws its declarations from rather than
+following a specifier out of them, because the compiler that reads the result
+resolves none.
+
+Anything that file describes and does not implement, it describes by declaring a
+second copy of the shape by hand, and the implementation is in
 `packages/runner/src/builder`, `packages/data-model`, or
 `packages/memory/v2/sqlite`.
 
@@ -43,9 +45,9 @@ Three kinds of failure show up at the object literal in `factory.ts`:
   declaration.
 - A property whose type does not match is drift. The declaration is what pattern
   authors were compiled against, so fix whichever side is wrong on its merits.
-- An excess property is a binding nothing declares. Either declare it, or add it
-  to the members `BuilderFunctionsAndConstants` writes out for itself — the ones
-  a pattern cannot name, which the interface lists with why.
+- An excess property is a binding nothing declares. Either declare it, or add
+  it to the members `BuilderFunctionsAndConstants` writes out for itself — the
+  ones a pattern cannot name, which the interface lists with why.
 
 Two lists in that file are the whole of what escapes this. `DriftingBindings`
 names the bindings that cannot satisfy their declarations today, each with what

--- a/.claude/rules/pattern-visible-declarations.md
+++ b/.claude/rules/pattern-visible-declarations.md
@@ -10,11 +10,15 @@ paths:
 
 # The declarations a pattern compiles against
 
-`packages/api/index.ts` is the whole of the `commonfabric` module's type: the
-sandbox hands it to the pattern compiler as `types/commonfabric.d.ts`, which is
-a symlink to it. The only file it may reach for is `cfc.ts`, which
-`sandbox/runtime-modules.ts` registers alongside it under the same names the
-sandbox gives a pattern. Anything else it describes, it describes by declaring
+`packages/api/index.ts` is the whole of the `commonfabric` module's type. What
+the sandbox hands the pattern compiler is
+`packages/static/assets/types/commonfabric.d.ts`, which
+`scripts/generate-commonfabric-types.ts` builds from it -- so an edit here needs
+`deno task gen-commonfabric-types` in `packages/static`, and
+`check-commonfabric-types` fails the build until it has been run. The generator
+inlines the one module `index.ts` imports for its declarations rather than
+following the specifier out, because the compiler that reads the result resolves
+none. Anything else it describes, it describes by declaring
 a second copy of the shape by hand, and the implementation is in
 `packages/runner/src/builder`, `packages/data-model`, or
 `packages/memory/v2/sqlite`.

--- a/.claude/rules/pattern-visible-declarations.md
+++ b/.claude/rules/pattern-visible-declarations.md
@@ -1,0 +1,60 @@
+---
+paths:
+  - "packages/api/index.ts"
+  - "packages/api/schema.ts"
+  - "packages/data-model/src/**"
+  - "packages/runner/src/builder/factory.ts"
+  - "packages/runner/src/builder/types.ts"
+  - "packages/memory/v2/sqlite/schema.ts"
+---
+
+# The declarations a pattern compiles against
+
+`packages/api/index.ts` is the whole of the `commonfabric` module's type: the
+sandbox hands it to the pattern compiler as `types/commonfabric.d.ts`, which is
+a symlink to it. The only file it may reach for is `cfc.ts`, which
+`sandbox/runtime-modules.ts` registers alongside it under the same names the
+sandbox gives a pattern. Anything else it describes, it describes by declaring
+a second copy of the shape by hand, and the implementation is in
+`packages/runner/src/builder`, `packages/data-model`, or
+`packages/memory/v2/sqlite`.
+
+The fabric value types are not among them: `packages/api` re-exports
+`@commonfabric/data-model/api`, so there is one declaration and each
+implementation asserts against it beside its own definition. What is copied is
+the builder vocabulary, and the compiler compares that too.
+
+## A value: the binding has to satisfy the declaration
+
+The sandbox binds the `commonfabric` module to the object
+`builder/factory.ts` builds, and `BuilderFunctionsAndConstants` in
+`builder/types.ts` is derived from `typeof import("@commonfabric/api")`. So
+adding an `export declare const` to `index.ts` and nothing else makes
+`factory.ts` stop compiling, which is the point: without a binding the
+declaration is a promise the runtime does not keep.
+
+Three kinds of failure show up at the object literal in `factory.ts`:
+
+- A missing property is a declaration with no binding. Bind it, or drop the
+  declaration.
+- A property whose type does not match is drift. The declaration is what pattern
+  authors were compiled against, so fix whichever side is wrong on its merits.
+- An excess property is a binding nothing declares. Either declare it, or add it
+  to the members `BuilderFunctionsAndConstants` writes out for itself — the ones
+  a pattern cannot name, which the interface lists with why.
+
+Two lists in that file are the whole of what escapes this. `DriftingBindings`
+names the bindings that cannot satisfy their declarations today, each with what
+stands in the way; it can only shrink, because `NoStaleDriftingBindings` stops
+compiling when an entry's drift has been fixed and the entry survives.
+`IntentionallyUnrequired` names the declarations that need no binding at all —
+brands, and the CFC vocabulary that `commonfabric/cfc` binds instead. A
+declaration not on that list is required, so adding to it is how you exempt one,
+and the reason goes beside the name.
+
+## `schema.ts` is part of the declared surface
+
+`packages/api/schema.ts` augments several of the interfaces in `index.ts` with
+schema-carrying overloads. Those augmentations are part of what a binding has to
+satisfy, so a signature that looks unimplemented may have its second half
+there.

--- a/docs/check.vocabulary.json
+++ b/docs/check.vocabulary.json
@@ -53,6 +53,7 @@
     "IAnyCell",
     "IReadable",
     "JSONSchema",
+    "JSONSchemaTypes",
     "JSONValue",
     "LinkScope",
     "Pattern",

--- a/docs/common/conventions/wish.md
+++ b/docs/common/conventions/wish.md
@@ -62,11 +62,13 @@ user browses candidates and clicks "Confirm Selection". Until confirmed,
 
 You can render the built-in UI directly. `[UI]` is optional — a wish that has
 resolved to nothing to show leaves it unset — so read the slot rather than
-rendering the whole state, and let the renderer skip it when it is absent:
+rendering the whole state. Hand it over as the slot itself, rather than wrapping
+it: an element around it is still an element when the slot is unset, and shows
+as an empty box.
 
 ```tsx
 // Shown inside a pattern body.
-return { [UI]: <div>{wishResult[UI]}</div> };
+return { [UI]: wishResult[UI] };
 ```
 
 ## Wishing for a Specific Piece

--- a/docs/common/conventions/wish.md
+++ b/docs/common/conventions/wish.md
@@ -24,7 +24,7 @@ const wishResult = wish<{ content: string }>({ query: "#note" });
 |--------------|---------|-------------------------------------------------------|
 | `result`     | `T`     | The resolved piece (auto-confirmed or user-selected)  |
 | `candidates` | `T[]`   | All matching pieces                                   |
-| `[UI]`       | `VNode` | Built-in UI: picker (multiple matches) or result cell |
+| `[UI]?`      | `VNode` | Built-in UI: picker (multiple matches) or result cell |
 | `error`      | `any`   | Error message if resolution failed                    |
 
 Access the resolved piece via `wishResult.result`:
@@ -60,11 +60,13 @@ user browses candidates and clicks "Confirm Selection". Until confirmed,
 > (CT-1829). Generalizing this "single-best by default; picker opt-in" shape to
 > all wishes is a future step.
 
-You can render the built-in UI directly:
+You can render the built-in UI directly. `[UI]` is optional — a wish that has
+resolved to nothing to show leaves it unset — so read the slot rather than
+rendering the whole state, and let the renderer skip it when it is absent:
 
 ```tsx
 // Shown inside a pattern body.
-return { [UI]: <div>{wishResult}</div> };
+return { [UI]: <div>{wishResult[UI]}</div> };
 ```
 
 ## Wishing for a Specific Piece

--- a/docs/specs/sqlite-builtin/01-api.md
+++ b/docs/specs/sqlite-builtin/01-api.md
@@ -374,11 +374,17 @@ records the op through the storage seam `recordSqliteWrite` → `getNativeCommit
 
 ```ts
 // Shown at module scope.
-export type SqliteColumnSpec = string | JSONSchema;
+export interface SqliteColumnSchema {
+  type: JSONSchemaTypes;
+  sqlType?: string;
+  cfLink?: true;
+  [keyword: string]: FabricValue;
+}
+export type SqliteColumnSpec = string | SqliteColumnSchema;
 export type SqliteTableFunction = (
   columns: Record<string, SqliteColumnSpec>,
 ) => JSONSchema;
-export type SqliteCfLinkFunction = <_T = unknown>() => JSONSchema;
+export type SqliteCfLinkFunction = <_T = unknown>() => SqliteColumnSchema;
 ```
 
 `table(...)` and `cfLink<T>()` compile to plain JSON Schema; `cfLink<T>()` emits

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -2653,7 +2653,12 @@ export type CellFromUrlFunction = (
     url: string;
     hosts?: string[];
   }>,
-) => Reactive<{ pending: boolean; cell?: ReadonlyCell<{ [NAME]: string }> }>;
+  /**
+   * The cell the URL named, once resolved, and absent when it named none. Its
+   * value is unconstrained: a URL addresses any cell, and resolution neither
+   * requires a piece nor supplies one's `[NAME]`.
+   */
+) => Reactive<{ pending: boolean; cell?: ReadonlyCell<unknown> }>;
 
 export type FetchProgramFunction = (
   params: FactoryInput<{ url: string }>,

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -2653,12 +2653,16 @@ export type CellFromUrlFunction = (
     url: string;
     hosts?: string[];
   }>,
+) => Reactive<{
+  pending: boolean;
+
   /**
    * The cell the URL named, once resolved, and absent when it named none. Its
    * value is unconstrained: a URL addresses any cell, and resolution neither
    * requires a piece nor supplies one's `[NAME]`.
    */
-) => Reactive<{ pending: boolean; cell?: ReadonlyCell<unknown> }>;
+  cell?: ReadonlyCell<unknown>;
+}>;
 
 export type FetchProgramFunction = (
   params: FactoryInput<{ url: string }>,

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -2853,8 +2853,24 @@ export type SqliteQueryFunction = <Row = Record<string, unknown>>(
 // folds a `sqlite` op into the caller's commit (atomic with cell writes). There
 // is no standalone reactive sqliteExecute builder.
 
+/**
+ * An explicitly declared column: a JSON Schema type, plus the verbatim SQLite
+ * column type and constraints used to generate the `CREATE TABLE` statement.
+ */
+export interface SqliteColumnSchema {
+  type: JSONSchemaTypes;
+  /** Verbatim SQLite column type/constraints, e.g. `"integer primary key"`.
+   *  Defaults to `"text"` when a column is declared without one. */
+  sqlType?: string;
+  /** Marks a `_cf_link` column: stored as TEXT, surfaced as a `Cell`. */
+  cfLink?: true;
+  /** A column carries the rest of the JSON Schema vocabulary too, and a table
+   *  schema is stored as fabric data, so every member is a fabric value. */
+  [keyword: string]: FabricValue;
+}
+
 /** Column spec for `table()`: a shorthand SQL type string or a column schema. */
-export type SqliteColumnSpec = string | JSONSchema;
+export type SqliteColumnSpec = string | SqliteColumnSchema;
 
 /** A reference to a declared column, handed to a row-label rule as `f.<col>`
  *  (CFC Phase 3; see `@commonfabric/memory/sqlite/row-label`). */
@@ -2922,8 +2938,7 @@ export interface CfSqliteHelpers {
   /** A literal atom (escape hatch). */
   constant(atom: unknown): unknown;
 }
-
-export type SqliteCfLinkFunction = <_T = unknown>() => JSONSchema;
+export type SqliteCfLinkFunction = <_T = unknown>() => SqliteColumnSchema;
 
 export type WishTag = `/${string}` | `#${string}`;
 
@@ -2962,7 +2977,7 @@ export type NavigateToFunction = (cell: Reactive<any>) => Reactive<boolean>;
 export interface WishFunction {
   <T = unknown>(
     target: FactoryInput<WishParams>,
-  ): Reactive<WishState<T> & UIRenderable>;
+  ): Reactive<WishState<T>>;
 }
 
 /**
@@ -3032,10 +3047,6 @@ export type InspectConfLabelFunction = (
   targetPath: FactoryInput<string>,
   query: FactoryInput<ConfLabelQuery>,
 ) => Reactive<InspectConfLabelResult>;
-
-export type CreateNodeFactoryFunction = <T = any, R = any>(
-  moduleSpec: Module,
-) => ModuleFactory<T, R>;
 
 // Symbol used to brand Default<T,V> types so RequireDefaults<T> can detect them.
 // This is a compile-time-only brand; at runtime Default<> is just T.
@@ -3353,9 +3364,6 @@ export declare const wish: WishFunction;
 export declare const multiUserTest: <T extends MultiUserTestDescriptor>(
   descriptor: T,
 ) => T;
-
-export declare const createNodeFactory: CreateNodeFactoryFunction;
-
 /** @deprecated Use Cell.of(defaultValue?) instead */
 export declare const cell: CellTypeConstructor<AsCell>["of"];
 

--- a/packages/api/schema.ts
+++ b/packages/api/schema.ts
@@ -452,7 +452,7 @@ declare module "commonfabric" {
     <S extends JSONSchema = JSONSchema>(
       target: FactoryInput<WishParams>,
       schema: S,
-    ): Reactive<WishState<Schema<S>> & UIRenderable>;
+    ): Reactive<WishState<Schema<S>>>;
   }
 
   // Augment IResolvable with schema-based getArgumentCell overload

--- a/packages/memory/v2/sqlite/schema.ts
+++ b/packages/memory/v2/sqlite/schema.ts
@@ -7,21 +7,21 @@
 // These helpers compile to plain data; the transformer/runtime do not special-
 // case them.
 
-import type { FabricValue } from "@commonfabric/api";
+import type {
+  FabricValue,
+  JSONSchemaTypes,
+  SqliteColumnSchema,
+  SqliteColumnSpec,
+} from "@commonfabric/api";
 import { CF_LINK_SUFFIX, isCfLinkColumn } from "./columns.ts";
 import { buildRowLabelSpec, type RowLabelRule } from "./row-label.ts";
 
-export type ColumnSchema = {
-  type: string;
-
-  /** Verbatim SQLite column type/constraints for DDL, e.g. "integer primary key". */
-  sqlType: string;
-
-  /** Marks a `_cf_link` column (stored TEXT, surfaced as a Cell). */
-  cfLink?: true;
-
-  [key: string]: FabricValue;
-};
+/**
+ * One column of a table as this module stores it: what
+ * `@commonfabric/api` declares to a pattern author, with the `sqlType` that
+ * `normalizeColumn` supplies for a column declared without one.
+ */
+export type ColumnSchema = SqliteColumnSchema & { sqlType: string };
 
 export type TableSchema = {
   type: "object";
@@ -31,7 +31,7 @@ export type TableSchema = {
 };
 
 /** Column spec: a shorthand SQL type string, or an explicit column schema. */
-export type ColumnSpec = string | ColumnSchema;
+export type ColumnSpec = SqliteColumnSpec;
 
 /** A `_cf_link` column: TEXT in SQLite, a Cell<T> in TypeScript. */
 export function cfLink<_T = unknown>(): ColumnSchema {
@@ -64,7 +64,7 @@ export function assertSafeColumn(name: string, sqlType: string): void {
 }
 
 // Map the leading SQL type word to a JSON Schema `type`.
-function jsonTypeForSql(sqlType: string): string {
+function jsonTypeForSql(sqlType: string): JSONSchemaTypes {
   const head = sqlType.trim().toLowerCase().split(/\s+/)[0] ?? "";
   switch (head) {
     case "integer":

--- a/packages/patterns/shared-profile-demo/main.tsx
+++ b/packages/patterns/shared-profile-demo/main.tsx
@@ -25,7 +25,7 @@ export default pattern(
             </h2>
             <div id="shared-profile-name">{displayName}</div>
             <div id="shared-profile-status">{status}</div>
-            <div id="shared-profile-wish-ui">{profileWish}</div>
+            <div id="shared-profile-wish-ui">{profileWish[UI]}</div>
           </cf-vstack>
         </cf-screen>
       ),

--- a/packages/patterns/test/source-coverage/commonfabric-shim.test.ts
+++ b/packages/patterns/test/source-coverage/commonfabric-shim.test.ts
@@ -446,13 +446,25 @@ export function byRef(_ref: string): () => Record<string, never> {
   return () => ({});
 }
 
-export function createNodeFactory(): unknown {
-  return undefined;
-}
-
 export function __cf_data<T>(value: T): T {
   return value;
 }
+
+//
+// Real implementation pass-through, second group
+//
+
+// Plain data and one pure predicate, which `@commonfabric/api` both declares
+// and implements. The real `commonfabric` surface passes these through from
+// there rather than faking them, so this does too -- a fake would be a second
+// copy of a list whose whole point is to have one.
+export {
+  CFC_CANONICAL_ALIAS_NAMES,
+  FABRIC_PRIMITIVE_SCHEMA_TYPES,
+  FABRIC_SPECIAL_OBJECT_BRAND,
+  isFabricPrimitiveSchemaType,
+  MERGEABLE_OP_METHODS,
+} from "@commonfabric/api";
 
 export function findEventHandlers(
   node: unknown,

--- a/packages/runner/src/builder/built-in.ts
+++ b/packages/runner/src/builder/built-in.ts
@@ -10,6 +10,7 @@ import type {
   BuiltInLLMGenerateObjectState,
   BuiltInLLMParams,
   BuiltInLLMState,
+  CellFromUrlFunction,
   ConfLabelQuery,
   FetchBinaryResult,
   FetchOptions,
@@ -176,12 +177,7 @@ export const fetchJson = createNodeFactory({
 export const cellFromUrl = createNodeFactory({
   type: "ref",
   implementation: "cellFromUrl",
-}) as (
-  params: FactoryInput<{
-    url: string;
-    hosts?: string[];
-  }>,
-) => Reactive<{ pending: boolean; cell?: unknown }>;
+}) as CellFromUrlFunction;
 
 export const fetchJsonUnchecked = createNodeFactory({
   type: "ref",

--- a/packages/runner/src/builder/factory.ts
+++ b/packages/runner/src/builder/factory.ts
@@ -107,6 +107,13 @@ import {
   UI,
   WebhookConfigSchema,
 } from "./types.ts";
+import {
+  CFC_CANONICAL_ALIAS_NAMES,
+  FABRIC_PRIMITIVE_SCHEMA_TYPES,
+  FABRIC_SPECIAL_OBJECT_BRAND,
+  isFabricPrimitiveSchemaType,
+  MERGEABLE_OP_METHODS,
+} from "@commonfabric/api";
 
 // Runtime implementation of toSchema - this should never be called
 // The TypeScript transformer should replace all calls at compile time
@@ -180,7 +187,12 @@ export const createBuilder = (options: CreateBuilderOptions = {}): {
     }
   };
 
-  const commonfabric = {
+  // Annotated rather than cast, so the object literal is checked against the
+  // declarations a pattern compiles against: a missing binding, a binding whose
+  // type has drifted from its declaration, and a binding nothing declares are
+  // each an error here. `__cfHelpers` is the one member that cannot be written
+  // in the literal, because its value is the literal.
+  const surface: Omit<BuilderFunctionsAndConstants, "__cfHelpers"> = {
     // Pattern creation
     pattern: trustedPattern,
     patternTool: trustedPatternTool,
@@ -302,6 +314,16 @@ export const createBuilder = (options: CreateBuilderOptions = {}): {
     AuthSchema,
     WebhookConfigSchema,
 
+    // The names `@commonfabric/api` both declares and implements, passed
+    // through so a pattern that imports one reads the value rather than
+    // `undefined`: the sandbox resolves `commonfabric` to this object, not to
+    // that module.
+    FABRIC_PRIMITIVE_SCHEMA_TYPES,
+    isFabricPrimitiveSchemaType,
+    FABRIC_SPECIAL_OBJECT_BRAND,
+    MERGEABLE_OP_METHODS,
+    CFC_CANONICAL_ALIAS_NAMES,
+
     // Render utils
     h,
     UiAction,
@@ -331,10 +353,13 @@ export const createBuilder = (options: CreateBuilderOptions = {}): {
 
     // Value comparison helper exposed for pattern code
     valueEqual,
-  } as BuilderFunctionsAndConstants & {
-    __cfHelpers?: BuilderFunctionsAndConstants;
   };
-  commonfabric.__cfHelpers = commonfabric;
+
+  // The helpers object the transformer's output reaches for is this same
+  // surface, so it can only be attached once the surface exists.
+  const commonfabric: BuilderFunctionsAndConstants = Object.assign(surface, {
+    __cfHelpers: surface,
+  });
 
   return {
     commonfabric,

--- a/packages/runner/src/builder/types.ts
+++ b/packages/runner/src/builder/types.ts
@@ -1,90 +1,21 @@
 import type {
-  ActionFunction,
-  AsCell,
-  AsComparableCell,
-  AsOpaqueCell,
-  AsReadonlyCell,
   AssertCaptureFunction,
-  AssertFunction,
   AssertRenderPartsFunction,
-  AsStream,
-  AsWriteonlyCell,
-  ByRefFunction,
   Cell,
-  CellFromUrlFunction,
   CellScope,
-  CellTypeConstructor,
-  CfDataFunction,
-  CfSqliteHelpers,
-  CompileAndRunFunction,
-  ComputedFunction,
-  DataFileFunction,
-  EntityRefToStringFunction,
-  EqualsFunction,
   FabricExecValue,
   FactoryInput,
-  FetchBinaryFunction,
-  FetchJsonFunction,
-  FetchJsonUncheckedFunction,
-  FetchProgramFunction,
-  FetchTextFunction,
-  GenerateObjectFunction,
-  GenerateTextFunction,
-  GetEntityIdFunction,
-  GetPatternEnvironmentFunction,
-  HandlerFunction,
   HFunction,
-  IfElseFunction,
-  InspectConfLabelFunction,
   JSONSchema,
   JSONValue,
-  JSXElement,
-  LiftFunction,
-  LLMDialogFunction,
-  LLMFunction,
   Module,
-  NavigateToFunction,
   Pattern,
-  PatternToolFunction,
   Reactive,
   schema as schemaFunction,
   SELF as SELFSymbol,
-  SqliteCfLinkFunction,
-  SqliteDatabaseFunction,
-  SqliteQueryFunction,
-  SqliteTableFunction,
-  StreamDataFunction,
-  StrFunction,
-  UiActionProps,
-  UiDisclosureProps,
-  UiPromptSlotProps,
-  UIVariantFunction,
-  UnlessFunction,
-  WhenFunction,
-  WishFunction,
 } from "@commonfabric/api";
-import { toSchema } from "@commonfabric/api";
+import type * as DeclaredApi from "@commonfabric/api";
 import type { Schema } from "@commonfabric/api/schema";
-import {
-  type FabricInstance,
-  type FabricPrimitive,
-  type FabricSpecialObject,
-  type toCompactDebugString,
-  type toIndentedDebugString,
-  type valueEqual,
-} from "@commonfabric/data-model";
-import type {
-  FabricError,
-  FabricLink,
-} from "@commonfabric/data-model/fabric-instances";
-import type {
-  FabricBytes,
-  FabricEpochDay,
-  FabricEpochNsec,
-  FabricHash,
-  FabricKeyPair,
-  FabricRegExp,
-} from "@commonfabric/data-model/fabric-primitives";
 import {
   CHIP_UI,
   FRAMEWORK_RESULT_KEYS,
@@ -95,6 +26,11 @@ import {
   TYPE,
   UI,
 } from "@commonfabric/utils/framework-result-keys";
+import type { entityRefToString } from "@commonfabric/data-model/cell-rep";
+import type { FabricKeyPair } from "@commonfabric/data-model/fabric-primitives";
+import type { valueEqual } from "@commonfabric/data-model";
+import type * as RowLabelHelpers from "@commonfabric/memory/sqlite/row-label";
+import type { cfLink, table } from "@commonfabric/memory/sqlite/schema";
 import { isObjectNotArray } from "@commonfabric/utils/types";
 
 import type { ImplementationIdentity } from "../cfc/types.ts";
@@ -397,120 +333,177 @@ export type Frame = {
   inSpaceCounter?: number;
 };
 
-// Builder functions interface
-export interface BuilderFunctionsAndConstants {
-  // Pattern creation
+/**
+ * The type of the `commonfabric` module as pattern code sees it. A pattern
+ * compiles against `types/commonfabric.d.ts`, which is `packages/api/index.ts`,
+ * and the sandbox binds that same module name to the object `createBuilder()`
+ * returns. So these declarations describe that object, and every value they
+ * declare has to be there.
+ *
+ * `@commonfabric/api/schema` adds schema-carrying overloads to several of these
+ * declarations by module augmentation, and this file imports it above, so those
+ * overloads are part of what is required here.
+ */
+type DeclaredSurface = typeof DeclaredApi;
+
+/**
+ * The bindings whose implementation type does not satisfy the type
+ * `@commonfabric/api` declares for them, each mapped to the type the binding
+ * actually has. Every other name on the pattern surface is required to match
+ * its declaration exactly, so this is the whole of what the compiler is not
+ * checking.
+ *
+ * - `table` takes a column map, and a parameter is checked the other way round
+ *   from a result: the declared `Record<string, SqliteColumnSpec>` has to be
+ *   assignable to the implementation's own generic column map, which it is not.
+ * - `cfSqlite` gathers `table` with the row-label helpers, whose declarations
+ *   say `unknown` where the implementation says which label shape it takes. So
+ *   the whole namespace is taken from the implementation, which is also what
+ *   keeps its members agreeing with each other: a rule built from the helpers
+ *   has to be one `table` accepts.
+ * - `entityRefToString` and `valueEqual` come from `@commonfabric/data-model`
+ *   and take fabric values as parameters, so the same reversal applies. The
+ *   pattern-visible `FabricHash` and `FabricValue` are structural views of
+ *   classes whose private fields no interface can carry, which is why no
+ *   declaration can be assignable to them.
+ * - `FabricKeyPair` is the one fabric class in the same position: its second
+ *   constructor takes the key bytes, so the declared `FabricBytes` would have
+ *   to be assignable to the class. Its instance side is compared, both here and
+ *   by the `satisfies` beside the class.
+ *
+ * {@link StaleDriftingBinding} keeps this set from outliving its reasons.
+ */
+interface DriftingBindings {
+  table: typeof table;
+  cfSqlite:
+    & Pick<
+      typeof RowLabelHelpers,
+      Exclude<keyof DeclaredSurface["cfSqlite"], "table" | "cfLink">
+    >
+    & { table: typeof table; cfLink: typeof cfLink };
+  entityRefToString: typeof entityRefToString;
+  valueEqual: typeof valueEqual;
+  FabricKeyPair: typeof FabricKeyPair;
+}
+
+/**
+ * A member of {@link DriftingBindings} whose implementation has come back into
+ * line with its declaration. Such a member no longer needs an entry, and the
+ * assertion below stops compiling until the entry is removed -- so the set can
+ * only shrink.
+ */
+type StaleDriftingBinding = {
+  [K in keyof DriftingBindings]: DriftingBindings[K] extends DeclaredSurface[K]
+    ? K
+    : never;
+}[keyof DriftingBindings];
+
+/** Fails to compile when `T` is anything but `never`. */
+type AssertNever<T extends never> = T;
+
+/** Fails to compile unless `Bound` satisfies `Declared`. */
+type AssertSatisfies<Bound extends Declared, Declared> = Bound;
+
+export type NoStaleDriftingBindings = AssertNever<StaleDriftingBinding>;
+
+/**
+ * `pattern` is the one name below written out because its binding is a
+ * different type rather than a richer one, so it is the one name the interface
+ * cannot check for itself. This says what the two still have in common:
+ * whatever else `PatternBuilder` carries, a pattern author's call has to be one
+ * `PatternFunction` describes.
+ */
+export type PatternBuilderSatisfiesDeclaration = AssertSatisfies<
+  PatternBuilder,
+  DeclaredSurface["pattern"]
+>;
+
+/**
+ * Every declared name the interface below does not require, written out.
+ *
+ * This was once two rules -- drop a `unique symbol`, drop anything the CFC
+ * authoring vocabulary also exports -- which read well and were the wrong
+ * shape. A rule reaches as far as it reaches, so a declaration that fell
+ * through one would not fail; it would quietly stop being required, which is
+ * the one outcome all of this exists to prevent. `SELF` was the standing proof:
+ * a `unique symbol` and so a brand by that rule, yet a real value a pattern
+ * reads, required only because someone noticed and wrote it back in.
+ *
+ * Written out instead, the default is the safe one. A declaration is required
+ * unless it appears here, so a new one is checked without anyone deciding
+ * anything, and exempting one is a visible edit to this list with its reason
+ * beside it.
+ */
+type IntentionallyUnrequired =
+  // Brands. Each keys a branded type and has no runtime existence.
+  | "CELL_BRAND"
+  | "CELL_INNER_TYPE"
+  | "CELL_LIKE"
+  | "CELL_RESULT_TYPE"
+  | "DEFAULT_MARKER"
+  | "FRAMEWORK_PROVIDED_MARKER"
+  | "SCOPE_BRAND"
+  // The CFC authoring vocabulary. `packages/api/index.ts` re-exports the types
+  // out of `cfc.ts` with `export type *`, and TypeScript carries the value
+  // meaning of those names into the module's type even though nothing is
+  // re-exported at runtime. Their runtime home is `commonfabric/cfc`, bound
+  // alongside this module in `sandbox/runtime-modules.ts`. Not
+  // `CFC_CANONICAL_ALIAS_NAMES`, which `index.ts` re-exports as a value, so a
+  // pattern reaches that one through `commonfabric` and it is required.
+  | "CFC_ATOM_TYPE"
+  | "CFC_COMPILED_BY_ATOM"
+  | "CFC_COMPILED_BY_ATOM_PREFIX"
+  | "CFC_CONCEPT_KIND"
+  | "CFC_FUSE_ATOM_CLASS"
+  | "CFC_RUNTIME_SUBJECT"
+  | "THIS_POLICY"
+  | "cfcAtom"
+  | "cfcPattern"
+  | "exchangeRule"
+  | "exchangeRules"
+  | "v";
+
+/**
+ * A name exempted above that `@commonfabric/api` no longer declares. Its entry
+ * exempts nothing, and is either a typo or what a removed declaration left
+ * behind, so this stops compiling until the entry goes.
+ */
+export type NoStaleIntentionallyUnrequired = AssertNever<
+  Exclude<IntentionallyUnrequired, keyof DeclaredSurface>
+>;
+
+/**
+ * The `commonfabric` module the sandbox hands a pattern.
+ *
+ * Every value `@commonfabric/api` declares is required here, with the declared
+ * type, because that is what a pattern was type-checked against: a declaration
+ * with no binding behind it compiles and then reads as `undefined` when the
+ * pattern runs. What the members below add to that is a binding whose type says
+ * more than the declaration does, and the bindings a pattern cannot name at
+ * all.
+ */
+export interface BuilderFunctionsAndConstants extends
+  Omit<
+    DeclaredSurface,
+    IntentionallyUnrequired | keyof DriftingBindings | "pattern"
+  >,
+  DriftingBindings {
+  /**
+   * Carries the pattern-building methods (`inSpace`, and the rest) alongside
+   * the call signature `PatternFunction` declares.
+   */
   pattern: PatternBuilder;
-  patternTool: PatternToolFunction;
 
-  // Module creation
-  lift: LiftFunction;
-  handler: HandlerFunction;
-  action: ActionFunction;
-  computed: ComputedFunction;
-  assert: AssertFunction;
-
-  // Operand recording for `assert` bodies. The assert-diagnostics transformer
-  // emits calls to these against the injected `__cfHelpers` object; they are
-  // not meant to be called from authored code. `assertCapture` stashes each
-  // operand's resolved value; `assertRenderParts` renders them into the
-  // record's `parts`, but only when the assertion failed.
+  // The rest of this interface is what the sandbox binds beyond what
+  // `@commonfabric/api` declares. Pattern source cannot name any of it: the
+  // assert-diagnostics transformer reaches the two operand recorders through
+  // the injected `__cfHelpers` object, JSX lowering emits calls to `h`, and the
+  // two schemas are read by the runner rather than by pattern code.
   assertCapture: AssertCaptureFunction;
   assertRenderParts: AssertRenderPartsFunction;
-
-  // Built-in modules
-  str: StrFunction;
-  ifElse: IfElseFunction;
-  when: WhenFunction;
-  unless: UnlessFunction;
-  uiVariant: UIVariantFunction;
-  llm: LLMFunction;
-  llmDialog: LLMDialogFunction;
-  generateObject: GenerateObjectFunction;
-  generateText: GenerateTextFunction;
-  fetchBinary: FetchBinaryFunction;
-  cellFromUrl: CellFromUrlFunction;
-  fetchText: FetchTextFunction;
-  fetchJson: FetchJsonFunction;
-  fetchJsonUnchecked: FetchJsonUncheckedFunction;
-  fetchProgram: FetchProgramFunction;
-  streamData: StreamDataFunction;
-  compileAndRun: CompileAndRunFunction;
-  dataFile: DataFileFunction;
-  sqliteDatabase: SqliteDatabaseFunction;
-  sqliteQuery: SqliteQueryFunction;
-  table: SqliteTableFunction;
-  cfLink: SqliteCfLinkFunction;
-  cfSqlite: CfSqliteHelpers;
-  navigateTo: NavigateToFunction;
-  inspectConfLabel: InspectConfLabelFunction;
-  wish: WishFunction;
-
-  // Cell creation
-  cell: CellTypeConstructor<AsCell>["of"];
-  equals: EqualsFunction;
-
-  // Cell constructors with static methods
-  Cell: CellTypeConstructor<AsCell>;
-  Writable: CellTypeConstructor<AsCell>; // Alias for Cell with clearer write-access semantics
-  OpaqueCell: CellTypeConstructor<AsOpaqueCell>;
-  Stream: CellTypeConstructor<AsStream>;
-  ComparableCell: CellTypeConstructor<AsComparableCell>;
-  ReadonlyCell: CellTypeConstructor<AsReadonlyCell>;
-  WriteonlyCell: CellTypeConstructor<AsWriteonlyCell>;
-
-  // Utility
-  byRef: ByRefFunction;
-
-  // Environment
-  getPatternEnvironment: GetPatternEnvironmentFunction;
-
-  // Entity utilities
-  getEntityId: GetEntityIdFunction;
-  entityRefToString: EntityRefToStringFunction;
-
-  // Constants
-  SELF: typeof SELF;
-  TYPE: typeof TYPE;
-  NAME: typeof NAME;
-  UI: typeof UI;
-  TILE_UI: typeof TILE_UI;
-  CHIP_UI: typeof CHIP_UI;
-  FS: typeof FS;
-
-  // Schema utilities
-  schema: typeof schema;
-  toSchema: typeof toSchema;
-  __cf_data: CfDataFunction;
+  h: HFunction;
   AuthSchema: typeof AuthSchema;
   WebhookConfigSchema: typeof WebhookConfigSchema;
-
-  // Render utils
-  h: HFunction;
-  UiAction: (props: UiActionProps) => JSXElement;
-  UiPromptSlot: (props: UiPromptSlotProps) => JSXElement;
-  UiDisclosure: (props: UiDisclosureProps) => JSXElement;
-
-  // `FabricSpecialObject` classes, in the order they are declared in
-  // api/index.ts.
-  FabricSpecialObject: typeof FabricSpecialObject;
-  FabricInstance: typeof FabricInstance;
-  FabricPrimitive: typeof FabricPrimitive;
-  FabricEpochNsec: typeof FabricEpochNsec;
-  FabricEpochDay: typeof FabricEpochDay;
-  FabricHash: typeof FabricHash;
-  FabricLink: typeof FabricLink;
-  FabricBytes: typeof FabricBytes;
-  FabricRegExp: typeof FabricRegExp;
-  FabricKeyPair: typeof FabricKeyPair;
-  FabricError: typeof FabricError;
-
-  // Debug stringifiers
-  toCompactDebugString: typeof toCompactDebugString;
-  toIndentedDebugString: typeof toIndentedDebugString;
-
-  // Value comparison
-  valueEqual: typeof valueEqual;
 }
 
 // Runtime interface needed by createCell

--- a/packages/runner/test/builder-api-surface.test.ts
+++ b/packages/runner/test/builder-api-surface.test.ts
@@ -1,0 +1,135 @@
+/**
+ * The `commonfabric` module a pattern imports has two halves that are written
+ * in different packages. Its types are `packages/api/index.ts`, handed to the
+ * pattern compiler as `types/commonfabric.d.ts`; its values are the object
+ * `builder/factory.ts` builds, handed to the sandbox by
+ * `sandbox/runtime-modules.ts`. A declaration with no value behind it compiles
+ * and then reads as `undefined` when the pattern runs, and a value whose shape
+ * has moved away from its declaration is worse: the pattern compiles against a
+ * promise the runtime does not keep.
+ *
+ * `BuilderFunctionsAndConstants` is what stops that, by requiring the built
+ * object to carry every value `@commonfabric/api` declares with the declared
+ * type. That requirement is enforced by the type checker, so the checks here
+ * are of two kinds: `@ts-expect-error` pins that fail the type check if the
+ * requirement ever stops rejecting a mismatch, and runtime assertions covering
+ * the last step, where the built object is frozen and handed over.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { createBuilder } from "../src/builder/factory.ts";
+import type {
+  BuilderFunctionsAndConstants,
+  NoStaleDriftingBindings,
+  NoStaleIntentionallyUnrequired,
+  PatternBuilderSatisfiesDeclaration,
+} from "../src/builder/types.ts";
+import { getRuntimeModuleExports } from "../src/sandbox/runtime-modules.ts";
+
+/**
+ * What the object literal in `builder/factory.ts` is checked against.
+ * `__cfHelpers` is left out there too: its value is the object itself, so it is
+ * attached once the object exists rather than written in the literal.
+ */
+type Surface = Omit<BuilderFunctionsAndConstants, "__cfHelpers">;
+
+/** Fails to compile unless `Bound` satisfies `Declared`. */
+type Satisfies<Bound extends Declared, Declared> = Bound;
+
+// Each pin below is a mismatch the requirement has to reject. `@ts-expect-error`
+// inverts the sense of the line it precedes: the type check fails when the line
+// compiles. So a requirement that stopped catching one of these would show up
+// here rather than nowhere.
+//
+// `navigateTo` stands in for the whole surface. Nothing about it is special --
+// the requirement is written once, over every name at once, rather than per
+// name -- and it has the plainest signature to misstate.
+
+/** A declared name whose binding has gone missing. */
+export type MissingBindingIsRejected = Satisfies<
+  // @ts-expect-error every value `@commonfabric/api` declares has to be bound
+  Omit<Surface, "navigateTo">,
+  Surface
+>;
+
+/** A binding whose result type has moved away from its declaration. */
+export type DriftedBindingIsRejected = Satisfies<
+  // @ts-expect-error a binding has to satisfy the type declared for it
+  & Omit<Surface, "navigateTo">
+  & { navigateTo: (cell: unknown) => string },
+  Surface
+>;
+
+/**
+ * A binding nothing declares, which pattern source could not name and would sit
+ * on the surface unreachable. Written as a value because what rejects it is the
+ * check on a fresh object literal, which has no type-level equivalent.
+ *
+ * Never called; the body is here for the type checker to read.
+ */
+export function undeclaredBindingIsRejected(surface: Surface): Surface {
+  return {
+    ...surface,
+    // @ts-expect-error a binding needs a declaration, or a member of its own
+    neitherDeclaredNorExpected: 1,
+  };
+}
+
+// The pins above all turn on `navigateTo`, so they say nothing about how far
+// the requirement reaches. What decides that is the list of declared names
+// `types.ts` exempts, and the assertions it carries beside that list. These
+// reach for them, so a name leaving the requirement fails here too rather than
+// only where the runner's own type check would report it.
+export type NoExemptionOutlivesItsDeclaration = NoStaleIntentionallyUnrequired;
+export type ThePatternBindingStillSatisfiesItsDeclaration =
+  PatternBuilderSatisfiesDeclaration;
+export type NoDriftEntryOutlivesItsReason = NoStaleDriftingBindings;
+
+describe("the commonfabric surface handed to a pattern", () => {
+  // Read as plain records: the question is what the objects carry at runtime,
+  // which is the one thing their static types cannot answer.
+  const built = createBuilder().commonfabric as unknown as Record<
+    string,
+    unknown
+  >;
+  const delivered = getRuntimeModuleExports()
+    .runtimeExports["commonfabric"] as unknown as Record<string, unknown>;
+
+  // What the sandbox hands over is the built surface after
+  // `freezeSandboxValue()`, and the step between the two is where a name could
+  // be dropped or the whole object replaced by a wrapper. The type checker sees
+  // neither: `runtime-modules.ts` states no type for what it exposes.
+  it("hands over the built surface, hardened", () => {
+    expect(Object.keys(delivered).sort()).toEqual(Object.keys(built).sort());
+    expect(Object.isFrozen(delivered)).toBe(true);
+  });
+
+  // `BuilderFunctionsAndConstants` drops the CFC authoring vocabulary whole,
+  // because `packages/api/index.ts` re-exports those types with `export type *`
+  // and TypeScript carries their value meaning into the module's type even
+  // though nothing is re-exported at runtime. That subtraction is by name, so
+  // it is the one place a real binding could fall out of the requirement
+  // unnoticed -- a name that came to be exported by both modules would stop
+  // being checked rather than fail. Nothing declares that cannot happen, so it
+  // is checked here instead.
+  it("keeps no CFC vocabulary name but the one declared as a value", () => {
+    const vocabulary = Object.keys(
+      getRuntimeModuleExports()
+        .runtimeExports["commonfabric/cfc"] as unknown as Record<
+          string,
+          unknown
+        >,
+    );
+    const bound = vocabulary.filter((name) => name in delivered);
+
+    expect(bound).toEqual(["CFC_CANONICAL_ALIAS_NAMES"]);
+  });
+
+  it("points `__cfHelpers` back at the surface itself", () => {
+    // The assert-diagnostics transformer emits `__cfHelpers.lift(...)` and the
+    // rest against this, so it has to be the same vocabulary a pattern reaches
+    // by name.
+    expect(delivered.__cfHelpers).toBe(delivered);
+  });
+});

--- a/packages/runner/test/builder-api-surface.test.ts
+++ b/packages/runner/test/builder-api-surface.test.ts
@@ -84,24 +84,33 @@ export function undeclaredBindingIsRejected(surface: Surface): Surface {
   };
 }
 
-// `@commonfabric/api/schema` adds schema-carrying overloads to several of the
-// declarations by module augmentation, and those overloads are part of what a
-// binding has to satisfy. This pins one of them, `wish`'s second argument, so
-// that changing its shape has to be done here as well as there.
-//
-// It does not pin that the augmentation reaches the requirement at all. An
-// augmentation applies across the whole program rather than per module, so
-// this file importing `schema.ts` puts the overloads in scope however
-// `builder/types.ts` is written, and no assertion here can see that import go.
-export type SchemaOverloadsAreRequired = Satisfies<
-  Surface["wish"],
-  {
-    <S extends JSONSchema>(
-      target: FactoryInput<WishParams>,
-      schema: S,
-    ): Reactive<WishState<Schema<S>>>;
-  }
->;
+/**
+ * `@commonfabric/api/schema` adds schema-carrying overloads to several of the
+ * declarations by module augmentation, and those overloads are part of what a
+ * binding has to satisfy. This pins the one on `wish` by calling it: an
+ * overload set that had lost the second parameter would not accept this call,
+ * where a type-level assignment would still hold, since a function of fewer
+ * parameters satisfies one that declares more.
+ *
+ * It does not pin that the augmentation reaches the requirement at all. An
+ * augmentation applies across the whole program rather than per module, so this
+ * file importing `schema.ts` puts the overloads in scope however
+ * `builder/types.ts` is written, and no assertion here can see that import go.
+ *
+ * Never called; the body is here for the type checker to read.
+ */
+export function wishTakesASchema(
+  wish: Surface["wish"],
+): Reactive<WishState<{ note: string }>> {
+  return wish(
+    { query: "#note" },
+    {
+      type: "object",
+      properties: { note: { type: "string" } },
+      required: ["note"],
+    } as const,
+  );
+}
 
 // The pins above all turn on `navigateTo`, so they say nothing about how far
 // the requirement reaches. What decides that is the list of declared names

--- a/packages/runner/test/builder-api-surface.test.ts
+++ b/packages/runner/test/builder-api-surface.test.ts
@@ -18,6 +18,14 @@
 
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import type {
+  FactoryInput,
+  JSONSchema,
+  Reactive,
+  WishParams,
+  WishState,
+} from "@commonfabric/api";
+import type { Schema } from "@commonfabric/api/schema";
 import { createBuilder } from "../src/builder/factory.ts";
 import type {
   BuilderFunctionsAndConstants,
@@ -75,6 +83,25 @@ export function undeclaredBindingIsRejected(surface: Surface): Surface {
     neitherDeclaredNorExpected: 1,
   };
 }
+
+// `@commonfabric/api/schema` adds schema-carrying overloads to several of the
+// declarations by module augmentation, and those overloads are part of what a
+// binding has to satisfy. This pins one of them, `wish`'s second argument, so
+// that changing its shape has to be done here as well as there.
+//
+// It does not pin that the augmentation reaches the requirement at all. An
+// augmentation applies across the whole program rather than per module, so
+// this file importing `schema.ts` puts the overloads in scope however
+// `builder/types.ts` is written, and no assertion here can see that import go.
+export type SchemaOverloadsAreRequired = Satisfies<
+  Surface["wish"],
+  {
+    <S extends JSONSchema>(
+      target: FactoryInput<WishParams>,
+      schema: S,
+    ): Reactive<WishState<Schema<S>>>;
+  }
+>;
 
 // The pins above all turn on `navigateTo`, so they say nothing about how far
 // the requirement reaches. What decides that is the list of declared names

--- a/packages/runner/test/builder-api-surface.test.ts
+++ b/packages/runner/test/builder-api-surface.test.ts
@@ -18,14 +18,10 @@
 
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import type {
-  FactoryInput,
-  JSONSchema,
-  Reactive,
-  WishParams,
-  WishState,
-} from "@commonfabric/api";
-import type { Schema } from "@commonfabric/api/schema";
+import type { Reactive, WishState } from "@commonfabric/api";
+// Imported for the module augmentation it carries as much as for the type: the
+// schema-carrying overloads it adds are part of what the pin below calls.
+import "@commonfabric/api/schema";
 import { createBuilder } from "../src/builder/factory.ts";
 import type {
   BuilderFunctionsAndConstants,

--- a/packages/static/assets/types/commonfabric.d.ts
+++ b/packages/static/assets/types/commonfabric.d.ts
@@ -3142,12 +3142,16 @@ export type CellFromUrlFunction = (
     url: string;
     hosts?: string[];
   }>,
+) => Reactive<{
+  pending: boolean;
+
   /**
    * The cell the URL named, once resolved, and absent when it named none. Its
    * value is unconstrained: a URL addresses any cell, and resolution neither
    * requires a piece nor supplies one's `[NAME]`.
    */
-) => Reactive<{ pending: boolean; cell?: ReadonlyCell<unknown> }>;
+  cell?: ReadonlyCell<unknown>;
+}>;
 
 export type FetchProgramFunction = (
   params: FactoryInput<{ url: string }>,

--- a/packages/static/assets/types/commonfabric.d.ts
+++ b/packages/static/assets/types/commonfabric.d.ts
@@ -3142,7 +3142,12 @@ export type CellFromUrlFunction = (
     url: string;
     hosts?: string[];
   }>,
-) => Reactive<{ pending: boolean; cell?: ReadonlyCell<{ [NAME]: string }> }>;
+  /**
+   * The cell the URL named, once resolved, and absent when it named none. Its
+   * value is unconstrained: a URL addresses any cell, and resolution neither
+   * requires a piece nor supplies one's `[NAME]`.
+   */
+) => Reactive<{ pending: boolean; cell?: ReadonlyCell<unknown> }>;
 
 export type FetchProgramFunction = (
   params: FactoryInput<{ url: string }>,
@@ -3342,8 +3347,24 @@ export type SqliteQueryFunction = <Row = Record<string, unknown>>(
 // folds a `sqlite` op into the caller's commit (atomic with cell writes). There
 // is no standalone reactive sqliteExecute builder.
 
+/**
+ * An explicitly declared column: a JSON Schema type, plus the verbatim SQLite
+ * column type and constraints used to generate the `CREATE TABLE` statement.
+ */
+export interface SqliteColumnSchema {
+  type: JSONSchemaTypes;
+  /** Verbatim SQLite column type/constraints, e.g. `"integer primary key"`.
+   *  Defaults to `"text"` when a column is declared without one. */
+  sqlType?: string;
+  /** Marks a `_cf_link` column: stored as TEXT, surfaced as a `Cell`. */
+  cfLink?: true;
+  /** A column carries the rest of the JSON Schema vocabulary too, and a table
+   *  schema is stored as fabric data, so every member is a fabric value. */
+  [keyword: string]: FabricValue;
+}
+
 /** Column spec for `table()`: a shorthand SQL type string or a column schema. */
-export type SqliteColumnSpec = string | JSONSchema;
+export type SqliteColumnSpec = string | SqliteColumnSchema;
 
 /** A reference to a declared column, handed to a row-label rule as `f.<col>`
  *  (CFC Phase 3; see `@commonfabric/memory/sqlite/row-label`). */
@@ -3411,8 +3432,7 @@ export interface CfSqliteHelpers {
   /** A literal atom (escape hatch). */
   constant(atom: unknown): unknown;
 }
-
-export type SqliteCfLinkFunction = <_T = unknown>() => JSONSchema;
+export type SqliteCfLinkFunction = <_T = unknown>() => SqliteColumnSchema;
 
 export type WishTag = `/${string}` | `#${string}`;
 
@@ -3451,7 +3471,7 @@ export type NavigateToFunction = (cell: Reactive<any>) => Reactive<boolean>;
 export interface WishFunction {
   <T = unknown>(
     target: FactoryInput<WishParams>,
-  ): Reactive<WishState<T> & UIRenderable>;
+  ): Reactive<WishState<T>>;
 }
 
 /**
@@ -3521,10 +3541,6 @@ export type InspectConfLabelFunction = (
   targetPath: FactoryInput<string>,
   query: FactoryInput<ConfLabelQuery>,
 ) => Reactive<InspectConfLabelResult>;
-
-export type CreateNodeFactoryFunction = <T = any, R = any>(
-  moduleSpec: Module,
-) => ModuleFactory<T, R>;
 
 // Symbol used to brand Default<T,V> types so RequireDefaults<T> can detect them.
 // This is a compile-time-only brand; at runtime Default<> is just T.
@@ -3842,9 +3858,6 @@ export declare const wish: WishFunction;
 export declare const multiUserTest: <T extends MultiUserTestDescriptor>(
   descriptor: T,
 ) => T;
-
-export declare const createNodeFactory: CreateNodeFactoryFunction;
-
 /** @deprecated Use Cell.of(defaultValue?) instead */
 export declare const cell: CellTypeConstructor<AsCell>["of"];
 

--- a/packages/ts-transformers/test/core/commonfabric-runtime-registry.test.ts
+++ b/packages/ts-transformers/test/core/commonfabric-runtime-registry.test.ts
@@ -75,12 +75,21 @@ function extractInjectedCallableExports(sourceText: string): string[] {
     }
   }
 
+  // The object literal is the one annotated with the builder surface type.
+  // `factory.ts` annotates it rather than casting, so the compiler checks it
+  // against what `@commonfabric/api` declares; that annotation is the durable
+  // marker for it, where the name of the local holding it is not.
+  const isBuilderSurfaceAnnotation = (node: ts.VariableDeclaration) =>
+    node.type !== undefined &&
+    sourceText.slice(node.type.pos, node.type.end).includes(
+      "BuilderFunctionsAndConstants",
+    );
+
   let commonfabricObject: ts.ObjectLiteralExpression | undefined;
   ts.forEachChild(sourceFile, function visit(node) {
     if (
       ts.isVariableDeclaration(node) &&
-      ts.isIdentifier(node.name) &&
-      node.name.text === "commonfabric" &&
+      isBuilderSurfaceAnnotation(node) &&
       node.initializer
     ) {
       const initializer = unwrapExpression(node.initializer);

--- a/packages/ts-transformers/test/core/commonfabric-runtime-registry.test.ts
+++ b/packages/ts-transformers/test/core/commonfabric-runtime-registry.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals } from "@std/assert";
+import { assertEquals } from "@std/assert";
 import { describe, it } from "@std/testing/bdd";
 
 import ts from "typescript";
@@ -79,13 +79,18 @@ function extractInjectedCallableExports(sourceText: string): string[] {
   // `factory.ts` annotates it rather than casting, so the compiler checks it
   // against what `@commonfabric/api` declares; that annotation is the durable
   // marker for it, where the name of the local holding it is not.
+  //
+  // More than one declaration names that type, so every match is collected and
+  // exactly one is required to carry a literal. Taking the first would bind
+  // this guard to traversal order, and a second literal appearing later would
+  // narrow what it reads without failing.
   const isBuilderSurfaceAnnotation = (node: ts.VariableDeclaration) =>
     node.type !== undefined &&
     sourceText.slice(node.type.pos, node.type.end).includes(
       "BuilderFunctionsAndConstants",
     );
 
-  let commonfabricObject: ts.ObjectLiteralExpression | undefined;
+  const candidates: ts.ObjectLiteralExpression[] = [];
   ts.forEachChild(sourceFile, function visit(node) {
     if (
       ts.isVariableDeclaration(node) &&
@@ -94,29 +99,20 @@ function extractInjectedCallableExports(sourceText: string): string[] {
     ) {
       const initializer = unwrapExpression(node.initializer);
       if (ts.isObjectLiteralExpression(initializer)) {
-        commonfabricObject = initializer;
+        candidates.push(initializer);
         return;
       }
-    }
-
-    if (
-      ts.isPropertyAssignment(node) &&
-      getPropertyNameText(node.name) === "commonfabric"
-    ) {
-      const initializer = unwrapExpression(node.initializer);
-      if (ts.isObjectLiteralExpression(initializer)) {
-        commonfabricObject = initializer;
-        return;
-      }
-      return;
     }
     ts.forEachChild(node, visit);
   });
 
-  assert(
-    commonfabricObject,
-    "Failed to locate createBuilder().commonfabric object in runner builder factory",
+  assertEquals(
+    candidates.length,
+    1,
+    "Expected exactly one object literal annotated with the builder surface " +
+      `type in runner builder factory, found ${candidates.length}`,
   );
+  const commonfabricObject = candidates[0];
 
   const injectedExports = new Set<string>();
   for (const property of commonfabricObject.properties) {


### PR DESCRIPTION
`packages/api/index.ts` is the whole of what a pattern compiles against. Its fabric value types are re-exported from `@commonfabric/data-model`, so there is one declaration and each implementation asserts against it where it sits. The builder vocabulary is not: `runner/src/builder` implements it, `packages/api` declares it a second time by hand, and nothing compared the two. Changing a signature meant remembering to edit both, and forgetting meant author code type-checking against a promise the runtime does not keep.

The sandbox binds the `commonfabric` module to the object `builder/factory.ts` builds, so `BuilderFunctionsAndConstants` is now derived from `@commonfabric/api` rather than written out by hand, and `factory.ts` annotates its object literal instead of casting it. A missing binding, a binding whose type has drifted, and a binding nothing declares are each a type error at the literal. That replaces about 120 hand-written members, and the imports that existed only to restate what the declarations already said.

Two lists are the whole of what escapes this, and each is held still by an assertion that stops compiling when it goes stale. `IntentionallyUnrequired` names the declarations that need no binding: the brands, and the CFC authoring vocabulary that `commonfabric/cfc` binds instead. A declaration not on that list is required, so a new one is checked without anybody deciding anything. `DriftingBindings` names the five bindings that cannot satisfy their declarations today, each with what stands in the way -- every one of them takes a fabric value as a parameter, and a parameter is checked the other way round from a result, so the declaration would have to be assignable to a class whose private fields no interface can carry. `pattern` is written out separately, its binding being a different type rather than a richer one, with an assertion for what the two still have in common.

Turning this on found seven mismatches, fixed here:

- `wish` promised a `[UI]` the resolver leaves unset on its pending, no-match and empty-resolution paths, and hid the `schema` argument the implementation accepts. Correcting it is source-breaking for pattern authors: rendering a wish whole no longer compiles, reading its `[UI]` does. In this repository that was one pattern and one document.
- `createNodeFactory` was declared and never bound, so a pattern using it compiled and then read `undefined`. Removed rather than bound: it takes a raw module spec, and granting that to pattern code is a decision to make on its own merits.
- `FABRIC_SPECIAL_OBJECT_BRAND`, `MERGEABLE_OP_METHODS`, `FABRIC_PRIMITIVE_SCHEMA_TYPES`, `isFabricPrimitiveSchemaType` and `CFC_CANONICAL_ALIAS_NAMES` are declared and implemented in the api package, but a pattern's `commonfabric` resolves to the builder object, not that module, so each read `undefined`. Now bound.
- `table()` and `cfLink()` returned shapes unrelated to the `JSONSchema` they were declared to return, because the SQLite column type was a bare `string`. `packages/api` now declares `SqliteColumnSchema` and the memory package uses that declaration instead of a copy.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6865?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

