### PR TITLE
refactor: import within a package by path, not by package name

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -148,7 +148,8 @@
     },
     "plugins": [
       "./tasks/lint-bench-console.ts",
-      "./tasks/lint-inline-imports.ts"
+      "./tasks/lint-inline-imports.ts",
+      "./tasks/lint-self-import.ts"
     ]
   },
   "fmt": {

--- a/docs/development/DEVELOPMENT.md
+++ b/docs/development/DEVELOPMENT.md
@@ -29,7 +29,19 @@ about one aspect of the runtime, are indexed in
 - Group imports by source: standard library, external, then internal, with a
   blank line between the groups.
 - Prefer named exports over default exports.
-- Use package names for internal imports.
+- Use package names to import from another package.
+- Use relative paths to import from within your own package. A file that names
+  the package it belongs to reaches a file of that same package the long way
+  round, through the `exports` map and back, so one module ends up with two
+  spellings. Naming the bare package name is worse than that. The entry point
+  reaches every module the package exports, so naming it from inside completes
+  a cycle, and the order in which the package's modules initialize starts to
+  depend on the order the entry point lists its exports. The
+  `cf-package/no-self-import` lint rule (`tasks/lint-self-import.ts`,
+  registered in the root `deno.jsonc`) reports both forms, so a plain
+  `deno lint` catches them. It exempts a package's own tests, which name their
+  package on purpose: the surface a consumer sees is the thing they are there
+  to check.
 - Destructure when importing multiple names from the same module.
 - Import either from `@commonfabric/api` (internal API) or
   `@commonfabric/api/interface` (external API), but not both.

--- a/packages/integration/shell-utils.ts
+++ b/packages/integration/shell-utils.ts
@@ -4,14 +4,6 @@ import { ConsoleEvent, PageErrorEvent } from "@astral/astral";
 import { jsonFromFabricValue } from "@commonfabric/data-model/codecs";
 import { Identity } from "@commonfabric/identity";
 import {
-  Browser,
-  dismissDialogs,
-  env,
-  Page,
-  pipeConsole,
-  type PresentationParticipant,
-} from "@commonfabric/integration";
-import {
   AppView,
   appViewToUrlPath,
   isAppViewEqual,
@@ -21,11 +13,15 @@ import {
   type SerializedIdentity,
 } from "@commonfabric/shell/app-state";
 
+import { Browser } from "./browser.ts";
 import { describeThrown } from "./describe-thrown.ts";
+import * as env from "./env.ts";
+import { dismissDialogs, Page, pipeConsole } from "./page.ts";
 import {
   collectPatternCoverage,
   enablePatternCoverage,
 } from "./pattern-coverage.ts";
+import type { PresentationParticipant } from "./presentation/config.ts";
 import { getPresentationSession } from "./presentation/session.ts";
 import {
   assertShellDocument,

--- a/packages/runner/src/embedded-schemas.ts
+++ b/packages/runner/src/embedded-schemas.ts
@@ -12,7 +12,7 @@
  */
 
 import type { JSONSchema } from "@commonfabric/api";
-import { rendererVDOMSchema, vnodeSchema } from "@commonfabric/runner/schemas";
+import { rendererVDOMSchema, vnodeSchema } from "./schemas.ts";
 
 export const embeddedSchemas: Record<string, JSONSchema> = {
   "https://commonfabric.org/schemas/vdom.json": rendererVDOMSchema,

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -20,7 +20,6 @@ import {
   setCommitPreconditionsConfig,
   setServerExecutionConfig,
 } from "@commonfabric/memory/v2";
-import { RuntimeTelemetry } from "@commonfabric/runner";
 import {
   getContentAddressedSchemasConfig,
   setContentAddressedSchemasConfig,
@@ -165,7 +164,7 @@ import {
   type RuntimeWritePolicyAuthorization,
   runtimeWritePolicyAuthorized,
 } from "./cfc/types.ts";
-import type { NonIdempotentReport } from "./telemetry.ts";
+import { type NonIdempotentReport, RuntimeTelemetry } from "./telemetry.ts";
 import {
   createUnsafeHostTrustToken,
   type UnsafeHostTrust,

--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -43,16 +43,6 @@ import {
   externalResolutionMissCount,
   onSchemaRegistryClear,
 } from "./schema-registry.ts";
-import {
-  canBranchMatch,
-  combineOptionalSchema,
-  combineSchema,
-  combineSchemaForLink,
-  createDefaultTraversalContext,
-  IObjectCreator,
-  mergeAnyOfMatches,
-  SchemaObjectTraverser,
-} from "@commonfabric/runner/traverse";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
 import { getLogger } from "@commonfabric/utils/logger";
 import {
@@ -83,6 +73,16 @@ import { ignoreReadForScheduling } from "./scheduler.ts";
 import { arrayMatchesPositionally } from "./schema-match.ts";
 import { canFollowScopedLink, isCellScope } from "./scope.ts";
 import { internalVerifierRead } from "./storage/reactivity-log.ts";
+import {
+  canBranchMatch,
+  combineOptionalSchema,
+  combineSchema,
+  combineSchemaForLink,
+  createDefaultTraversalContext,
+  IObjectCreator,
+  mergeAnyOfMatches,
+  SchemaObjectTraverser,
+} from "./traverse.ts";
 
 const logger = getLogger("validateAndTransform", {
   enabled: true,

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -47,7 +47,6 @@ import {
   type URI,
   type Variant,
 } from "@commonfabric/memory/interface";
-import { BaseMemoryAddress } from "@commonfabric/runner/traverse";
 import type { Immutable } from "@commonfabric/utils/types";
 
 import { Cell } from "../cell.ts";
@@ -77,6 +76,7 @@ import type {
 } from "../cfc/mod.ts";
 import type { NormalizedFullLink } from "../link-types.ts";
 import { RAW_META_WRITE } from "../meta-seam.ts";
+import { BaseMemoryAddress } from "../traverse.ts";
 export type { DID, MediaType, MemorySpace, Result, Signer, State, Unit, URI };
 export type ChangeGroup = unknown;
 

--- a/packages/runtime-client/src/backends/runtime-processor.ts
+++ b/packages/runtime-client/src/backends/runtime-processor.ts
@@ -86,7 +86,6 @@ import {
 import { hashStringForEntityAddress } from "@commonfabric/runner/entity-kind";
 import { NameSchema, rendererVDOMSchema } from "@commonfabric/runner/schemas";
 import { linkRefPayload } from "@commonfabric/runner/shared";
-import { RemoteResponse } from "@commonfabric/runtime-client";
 import {
   getLogger,
   getLoggerCountsBreakdown,
@@ -218,7 +217,7 @@ import {
   type WriteStackTraceResponse,
 } from "@/protocol/mod.ts";
 
-import type { VDomOp } from "@/protocol/types.ts";
+import type { RemoteResponse, VDomOp } from "@/protocol/types.ts";
 import {
   normalizeOrigin,
   normalizeSpaceHostMap,

--- a/packages/runtime-client/src/protocol/types.ts
+++ b/packages/runtime-client/src/protocol/types.ts
@@ -26,6 +26,7 @@ import type {
   JSONValue,
   NormalizedFullLink,
   PatternCoverageData,
+  RuntimeTelemetryMarkerResult,
   SchedulerDiagnosisResult,
   SchedulerGraphSnapshot,
   SettleStats,
@@ -34,7 +35,6 @@ import type {
   WriteStackTraceEntry,
   WriteStackTraceMatcher,
 } from "@commonfabric/runner/shared";
-import { RuntimeTelemetryMarkerResult } from "@commonfabric/runtime-client";
 export type { JSONObject, JSONSchema, JSONValue, Program };
 
 export type { CfcLabelView };

--- a/packages/utils/src/equal-ignoring-symbols.ts
+++ b/packages/utils/src/equal-ignoring-symbols.ts
@@ -1,6 +1,7 @@
 import { expect } from "@std/expect";
 import type { Async, Expected } from "@std/expect";
-import { isObjectOrArray } from "@commonfabric/utils/types";
+
+import { isObjectOrArray } from "./types.ts";
 
 /**
  * Strips all symbol properties from an object, recursively.

--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -174,7 +174,7 @@
  * ```
  */
 
-import { isDeno } from "@commonfabric/utils/env";
+import { isDeno } from "./env.ts";
 
 /**
  * A message argument: either the value to log, or a function returning it,

--- a/tasks/lint-self-import.test.ts
+++ b/tasks/lint-self-import.test.ts
@@ -230,6 +230,65 @@ describe("lint-self-import", () => {
     expect(messages).toEqual([]);
   });
 
+  it("reports a type written as an inline `import(...)`", () => {
+    const messages = fixture(RUNNER).diagnose(
+      "src/runtime.ts",
+      `type T = import("@commonfabric/runner").Runtime;`,
+    );
+    expect(messages.length).toBe(1);
+    expect(messages[0]).toContain(BARREL);
+  });
+
+  it("reads a second file against the package it already resolved", () => {
+    // The owning package is cached per directory, so the second file in a
+    // directory takes a different path to the same answer than the first.
+    const pkg = fixture(RUNNER);
+    const first = pkg.diagnose(
+      "src/runtime.ts",
+      `import { Runtime } from "@commonfabric/runner";`,
+    );
+    const second = pkg.diagnose(
+      "src/schema.ts",
+      `import { walk } from "@commonfabric/runner/traverse";`,
+    );
+    expect(first.length).toBe(1);
+    expect(first[0]).toContain(BARREL);
+    expect(second.length).toBe(1);
+    expect(second[0]).toContain("Import `./traverse.ts` instead.");
+  });
+
+  it("prefers deno.json to deno.jsonc, as Deno itself does", () => {
+    // Deno takes deno.json whole and ignores the other file, so a name in the
+    // ignored one is not the package's name.
+    const pkg = fixture({ name: "@commonfabric/ignored" });
+    Deno.writeTextFileSync(
+      resolve(pkg.root, "deno.json"),
+      JSON.stringify(RUNNER),
+    );
+    const messages = pkg.diagnose(
+      "src/runtime.ts",
+      `import { Runtime } from "@commonfabric/runner";`,
+    );
+    expect(messages.length).toBe(1);
+    expect(messages[0]).toContain(BARREL);
+  });
+
+  it("throws when a package configuration cannot be read at all", () => {
+    // A configuration that is unreadable is not a package without a name: Deno
+    // fails on the same file, and swallowing it here would quietly stop the
+    // rule from checking anything under that directory.
+    const root = Deno.makeTempDirSync({ prefix: "lint-self-import-" });
+    fixtureRoots.push(root);
+    Deno.mkdirSync(resolve(root, "deno.json"));
+    expect(() =>
+      Deno.lint.runPlugin(
+        plugin,
+        resolve(root, "src/main.ts"),
+        `import { Runtime } from "@commonfabric/runner";`,
+      )
+    ).toThrow();
+  });
+
   it("reports a package that names itself in a bare exports string", () => {
     const messages = fixture({
       name: "@commonfabric/leb128",

--- a/tasks/lint-self-import.test.ts
+++ b/tasks/lint-self-import.test.ts
@@ -1,0 +1,244 @@
+/// <reference lib="deno.unstable" />
+
+/**
+ * Runs the `cf-package/no-self-import` rule over short files and checks which
+ * of the two messages, if either, it reports. The rule reads the file's package
+ * out of the nearest Deno configuration on disk, so each case writes a package
+ * into a temporary directory and names a file inside it.
+ */
+
+import { afterAll, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { resolve } from "@std/path";
+import plugin from "./lint-self-import.ts";
+
+/** A package written to disk, ready for the rule to read. */
+interface Fixture {
+  /** The absolute directory the package sits in. */
+  readonly root: string;
+  /** Lints `source` as the package file at `path`, returning the messages. */
+  diagnose(path: string, source: string): string[];
+}
+
+/** Every directory `fixture` has made, for `afterAll` to remove. */
+const fixtureRoots: string[] = [];
+
+/**
+ * Writes a package whose configuration is `config`, and returns a handle that
+ * lints files against it. The directory goes under a fresh temporary root, so
+ * the walk up from a file cannot reach this repository's own configurations.
+ */
+function fixture(config: Record<string, unknown>): Fixture {
+  const root = Deno.makeTempDirSync({ prefix: "lint-self-import-" });
+  fixtureRoots.push(root);
+  Deno.writeTextFileSync(
+    resolve(root, "deno.jsonc"),
+    `// a comment, because this is JSONC\n${JSON.stringify(config)}\n`,
+  );
+  return {
+    root,
+    diagnose(path, source) {
+      return Deno.lint.runPlugin(plugin, resolve(root, path), source)
+        .map((diagnostic) => diagnostic.message);
+    },
+  };
+}
+
+const RUNNER = {
+  name: "@commonfabric/runner",
+  exports: {
+    ".": "./src/index.ts",
+    "./traverse": "./src/traverse.ts",
+  },
+};
+
+/** The distinguishing phrase of each of the rule's two messages. */
+const BARREL = "is the entry point of the package this file belongs to";
+const SUBPATH = "gives one module two spellings";
+
+describe("lint-self-import", () => {
+  afterAll(() => {
+    for (const root of fixtureRoots) Deno.removeSync(root, { recursive: true });
+  });
+
+  it("reports an import of the package's own entry point", () => {
+    const messages = fixture(RUNNER).diagnose(
+      "src/runtime.ts",
+      `import { RuntimeTelemetry } from "@commonfabric/runner";`,
+    );
+    expect(messages.length).toBe(1);
+    expect(messages[0]).toContain(BARREL);
+  });
+
+  it("gives general advice for an entry-point import, whose path is the barrel", () => {
+    const messages = fixture(RUNNER).diagnose(
+      "src/storage/interface.ts",
+      `import { Runtime } from "@commonfabric/runner";`,
+    );
+    expect(messages[0]).toContain(
+      "Import the module that defines it by relative path instead.",
+    );
+    expect(messages[0]).not.toContain("index.ts");
+  });
+
+  it("reports an import of the package's own subpath export", () => {
+    const messages = fixture(RUNNER).diagnose(
+      "src/schema.ts",
+      `import { walk } from "@commonfabric/runner/traverse";`,
+    );
+    expect(messages.length).toBe(1);
+    expect(messages[0]).toContain(SUBPATH);
+    expect(messages[0]).toContain("Import `./traverse.ts` instead.");
+  });
+
+  it("gives general advice for a subpath the exports map omits", () => {
+    const messages = fixture(RUNNER).diagnose(
+      "src/schema.ts",
+      `import { walk } from "@commonfabric/runner/nowhere";`,
+    );
+    expect(messages.length).toBe(1);
+    expect(messages[0]).toContain(
+      "Import the module that defines it by relative path instead.",
+    );
+  });
+
+  it("reports a re-export of the package's own entry point", () => {
+    const messages = fixture(RUNNER).diagnose(
+      "src/shared.ts",
+      `export * from "@commonfabric/runner";`,
+    );
+    expect(messages.length).toBe(1);
+    expect(messages[0]).toContain(BARREL);
+  });
+
+  it("reports a named re-export from the package's own name", () => {
+    const messages = fixture(RUNNER).diagnose(
+      "src/shared.ts",
+      `export { Runtime } from "@commonfabric/runner";`,
+    );
+    expect(messages.length).toBe(1);
+    expect(messages[0]).toContain(BARREL);
+  });
+
+  it("reports a dynamic import of the package's own name", () => {
+    const messages = fixture(RUNNER).diagnose(
+      "src/lazy.ts",
+      `export const load = () => import("@commonfabric/runner");`,
+    );
+    expect(messages.length).toBe(1);
+    expect(messages[0]).toContain(BARREL);
+  });
+
+  it("reports a type-only import of the package's own name", () => {
+    const messages = fixture(RUNNER).diagnose(
+      "src/runtime.ts",
+      `import type { Runtime } from "@commonfabric/runner";`,
+    );
+    expect(messages.length).toBe(1);
+    expect(messages[0]).toContain(BARREL);
+  });
+
+  it("returns nothing for an import of another package", () => {
+    const messages = fixture(RUNNER).diagnose(
+      "src/runtime.ts",
+      `import { isRecord } from "@commonfabric/utils/types";`,
+    );
+    expect(messages).toEqual([]);
+  });
+
+  it("returns nothing for a package whose name only prefixes this one's", () => {
+    const messages = fixture(RUNNER).diagnose(
+      "src/runtime.ts",
+      `import { x } from "@commonfabric/runner-client";`,
+    );
+    expect(messages).toEqual([]);
+  });
+
+  it("returns nothing for a relative import", () => {
+    const messages = fixture(RUNNER).diagnose(
+      "src/runtime.ts",
+      `import { RuntimeTelemetry } from "./telemetry.ts";`,
+    );
+    expect(messages).toEqual([]);
+  });
+
+  it("returns nothing for a file under the package's test directory", () => {
+    const messages = fixture(RUNNER).diagnose(
+      "test/runtime.test.ts",
+      `import { Runtime } from "@commonfabric/runner";`,
+    );
+    expect(messages).toEqual([]);
+  });
+
+  it("returns nothing for a file under the package's integration directory", () => {
+    const messages = fixture(RUNNER).diagnose(
+      "integration/boot.ts",
+      `import { Runtime } from "@commonfabric/runner";`,
+    );
+    expect(messages).toEqual([]);
+  });
+
+  it("returns nothing for a test file beside the source it tests", () => {
+    const messages = fixture(RUNNER).diagnose(
+      "src/runtime.test.ts",
+      `import { Runtime } from "@commonfabric/runner";`,
+    );
+    expect(messages).toEqual([]);
+  });
+
+  it("returns nothing for a benchmark file", () => {
+    const messages = fixture(RUNNER).diagnose(
+      "src/runtime.bench.ts",
+      `import { Runtime } from "@commonfabric/runner";`,
+    );
+    expect(messages).toEqual([]);
+  });
+
+  it("returns nothing for a file whose package configuration does not parse", () => {
+    const root = Deno.makeTempDirSync({ prefix: "lint-self-import-" });
+    fixtureRoots.push(root);
+    Deno.writeTextFileSync(resolve(root, "deno.jsonc"), "{ this is not json");
+    const messages = Deno.lint.runPlugin(
+      plugin,
+      resolve(root, "src/main.ts"),
+      `import { Runtime } from "@commonfabric/runner";`,
+    ).map((diagnostic) => diagnostic.message);
+    expect(messages).toEqual([]);
+  });
+
+  it("returns nothing for a file whose package declares no name", () => {
+    const messages = fixture({ exports: { ".": "./mod.ts" } }).diagnose(
+      "src/main.ts",
+      `import { Runtime } from "@commonfabric/runner";`,
+    );
+    expect(messages).toEqual([]);
+  });
+
+  it("stops the search for a package at the nearest configuration", () => {
+    // A workspace member with no name of its own sits inside a package that has
+    // one. Its files belong to the member, so the enclosing name is another
+    // package's and free to import.
+    const outer = fixture(RUNNER);
+    const inner = resolve(outer.root, "nested");
+    Deno.mkdirSync(inner);
+    Deno.writeTextFileSync(resolve(inner, "deno.jsonc"), "{}\n");
+    const messages = Deno.lint.runPlugin(
+      plugin,
+      resolve(inner, "main.ts"),
+      `import { Runtime } from "@commonfabric/runner";`,
+    ).map((diagnostic) => diagnostic.message);
+    expect(messages).toEqual([]);
+  });
+
+  it("reports a package that names itself in a bare exports string", () => {
+    const messages = fixture({
+      name: "@commonfabric/leb128",
+      exports: "./src/mod.ts",
+    }).diagnose(
+      "src/encode.ts",
+      `import { decode } from "@commonfabric/leb128";`,
+    );
+    expect(messages.length).toBe(1);
+    expect(messages[0]).toContain(BARREL);
+  });
+});

--- a/tasks/lint-self-import.ts
+++ b/tasks/lint-self-import.ts
@@ -19,6 +19,12 @@
  *     back, so the same file arrives under two spellings, and the shorter one
  *     stops being a reliable way to find who depends on what.
  *
+ * The rule reads every form that names a module: the `import` and `export ...
+ * from` declarations, a dynamic `import()`, and a type written
+ * `import("...").Name`. That last one is reported for completeness rather than
+ * because it is expected — `cf-imports/no-inline-type-import` rejects the form
+ * outright, so one reaches here only in a file that has suppressed that rule.
+ *
  * A file under a package's `test/` or `integration/` directory is exempt, as is
  * one named `*.test.ts` or `*.bench.ts` anywhere in the package. A test that
  * names its own package is reaching for the surface a consumer sees, which is
@@ -41,6 +47,17 @@ const TEST_DIRECTORY_NAMES: ReadonlySet<string> = new Set([
 
 /** The file names that are a test wherever in a package they sit. */
 const TEST_FILE_PATTERN = /\.(?:test|bench)\.tsx?$/;
+
+/** Either separator `relative()` can return, the host deciding which. */
+const PATH_SEPARATOR = /[/\\]/;
+
+/**
+ * A type written `import("...").Name`, which holds its specifier inside a
+ * literal type rather than directly as the declaration forms do.
+ */
+interface InlineTypeImport {
+  readonly argument?: { readonly literal?: { readonly value?: unknown } };
+}
 
 /** The package a file belongs to, as much of it as this rule reads. */
 interface OwningPackage {
@@ -127,7 +144,7 @@ function computeOwner(directory: string): OwningPackage | null {
 
 /** True when `filename` is one of its package's tests rather than its source. */
 function isTestFile(root: string, filename: string): boolean {
-  const parts = relative(root, filename).split("/");
+  const parts = relative(root, filename).split(PATH_SEPARATOR);
   const base = parts.pop() ?? "";
   return TEST_FILE_PATTERN.test(base) ||
     parts.some((part) => TEST_DIRECTORY_NAMES.has(part));
@@ -135,7 +152,7 @@ function isTestFile(root: string, filename: string): boolean {
 
 /** The specifier that reaches `to` from the file at `from`. */
 function relativeSpecifier(from: string, to: string): string {
-  const path = relative(dirname(from), to);
+  const path = relative(dirname(from), to).replaceAll("\\", "/");
   return path.startsWith(".") ? path : `./${path}`;
 }
 
@@ -207,6 +224,11 @@ export default {
           ExportAllDeclaration: (node) => check(node, node.source),
           ExportNamedDeclaration: (node) => check(node, node.source),
           ImportExpression: (node) => check(node, node.source),
+          TSImportType: (node) =>
+            check(
+              node,
+              (node as unknown as InlineTypeImport).argument?.literal,
+            ),
         };
       },
     },

--- a/tasks/lint-self-import.ts
+++ b/tasks/lint-self-import.ts
@@ -1,0 +1,214 @@
+/// <reference lib="deno.unstable" />
+
+/**
+ * A lint rule that stops a file from naming its own package in an import.
+ *
+ * A workspace package is meant to be named from outside it. From inside, the
+ * name resolves through the package's `exports` map and lands back on a file
+ * that a relative specifier would have reached directly. Two things follow, and
+ * the rule reports both:
+ *
+ *   - The bare package name is the entry point, and the entry point reaches
+ *     every module the package exports. Naming it from inside adds the edge
+ *     back, so the module graph gains a cycle. When the import brings in a
+ *     value rather than a type that cycle is there at run time, and the order
+ *     in which the modules of the package initialize starts to depend on the
+ *     order in which the entry point lists its exports.
+ *   - A subpath such as `@scope/pkg/thing` names one module rather than the
+ *     whole package, so it adds no cycle. It still leaves the package and comes
+ *     back, so the same file arrives under two spellings, and the shorter one
+ *     stops being a reliable way to find who depends on what.
+ *
+ * A file under a package's `test/` or `integration/` directory is exempt, as is
+ * one named `*.test.ts` or `*.bench.ts` anywhere in the package. A test that
+ * names its own package is reaching for the surface a consumer sees, which is
+ * the thing it is there to check.
+ *
+ * See docs/development/DEVELOPMENT.md.
+ */
+
+import { parse as parseJsonc } from "@std/jsonc";
+import { dirname, relative, resolve } from "@std/path";
+
+/** The file names a Deno configuration is allowed to take. */
+const CONFIG_FILE_NAMES = ["deno.json", "deno.jsonc"] as const;
+
+/** The directories of a package that hold its tests rather than its source. */
+const TEST_DIRECTORY_NAMES: ReadonlySet<string> = new Set([
+  "test",
+  "integration",
+]);
+
+/** The file names that are a test wherever in a package they sit. */
+const TEST_FILE_PATTERN = /\.(?:test|bench)\.tsx?$/;
+
+/** The package a file belongs to, as much of it as this rule reads. */
+interface OwningPackage {
+  /** The directory holding the package's Deno configuration. */
+  readonly root: string;
+  /** The name that configuration declares. */
+  readonly name: string;
+  /** The `exports` map, from specifier suffix to a path under `root`. */
+  readonly exports: ReadonlyMap<string, string>;
+}
+
+/**
+ * Resolved owners, keyed by directory. A lint run reads many files of the same
+ * package, and this is what keeps that to one pass up the tree per directory.
+ */
+const ownerByDirectory = new Map<string, OwningPackage | null>();
+
+/**
+ * The Deno configuration written in `directory`, or null when there is none.
+ * A file that is there but does not parse reads as an empty configuration:
+ * Deno reports that itself, and a lint rule that threw over it would take the
+ * whole run down over a file it only wanted a name from.
+ */
+function readConfig(directory: string): Record<string, unknown> | null {
+  for (const name of CONFIG_FILE_NAMES) {
+    let text: string;
+    try {
+      text = Deno.readTextFileSync(resolve(directory, name));
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) continue;
+      throw error;
+    }
+    let parsed: unknown;
+    try {
+      parsed = parseJsonc(text);
+    } catch {
+      return {};
+    }
+    return parsed !== null && typeof parsed === "object"
+      ? parsed as Record<string, unknown>
+      : {};
+  }
+  return null;
+}
+
+/** The `exports` map of a configuration, keeping the entries that are paths. */
+function exportMap(exports: unknown): ReadonlyMap<string, string> {
+  const map = new Map<string, string>();
+  if (typeof exports === "string") {
+    map.set(".", exports);
+  } else if (exports !== null && typeof exports === "object") {
+    for (const [key, value] of Object.entries(exports)) {
+      if (typeof value === "string") map.set(key, value);
+    }
+  }
+  return map;
+}
+
+/**
+ * The package that owns files in `directory`. The nearest enclosing directory
+ * with a Deno configuration is the package, and a configuration that declares
+ * no name gives a package that cannot be named, so the walk stops there rather
+ * than crediting the files to an enclosing package that does have a name.
+ */
+function ownerOf(directory: string): OwningPackage | null {
+  if (ownerByDirectory.has(directory)) {
+    return ownerByDirectory.get(directory) ?? null;
+  }
+  const owner = computeOwner(directory);
+  ownerByDirectory.set(directory, owner);
+  return owner;
+}
+
+function computeOwner(directory: string): OwningPackage | null {
+  const config = readConfig(directory);
+  if (config === null) {
+    const parent = dirname(directory);
+    return parent === directory ? null : ownerOf(parent);
+  }
+  const name = config.name;
+  if (typeof name !== "string" || name === "") return null;
+  return { root: directory, name, exports: exportMap(config.exports) };
+}
+
+/** True when `filename` is one of its package's tests rather than its source. */
+function isTestFile(root: string, filename: string): boolean {
+  const parts = relative(root, filename).split("/");
+  const base = parts.pop() ?? "";
+  return TEST_FILE_PATTERN.test(base) ||
+    parts.some((part) => TEST_DIRECTORY_NAMES.has(part));
+}
+
+/** The specifier that reaches `to` from the file at `from`. */
+function relativeSpecifier(from: string, to: string): string {
+  const path = relative(dirname(from), to);
+  return path.startsWith(".") ? path : `./${path}`;
+}
+
+/** The advice given when the rule cannot name the file to import. */
+const GENERAL_ADVICE =
+  "Import the module that defines it by relative path instead.";
+
+/**
+ * What to import instead: the module the offending subpath resolves to, named
+ * relative to the offending file. A subpath the `exports` map does not carry
+ * resolves to nothing, and the advice stays general.
+ */
+function suggestion(
+  owner: OwningPackage,
+  filename: string,
+  specifier: string,
+): string {
+  const target = owner.exports.get(`.${specifier.slice(owner.name.length)}`);
+  if (target === undefined) return GENERAL_ADVICE;
+  const path = relativeSpecifier(filename, resolve(owner.root, target));
+  return `Import \`${path}\` instead.`;
+}
+
+function message(
+  owner: OwningPackage,
+  filename: string,
+  specifier: string,
+): string {
+  // The entry point gets no file named for it: the relative path to it reaches
+  // the same barrel, so the fix is a path to whichever module defines the
+  // imported name, which the rule does not know.
+  if (specifier === owner.name) {
+    return `\`${specifier}\` is the entry point of the package this file ` +
+      "belongs to. Importing it from inside the package puts a cycle in the " +
+      "module graph, and makes the order in which this module initializes " +
+      `depend on the order the entry point lists its exports. ${GENERAL_ADVICE}`;
+  }
+  return `\`${specifier}\` is an export of the package this file belongs to, ` +
+    "and it resolves back to a file inside that package. Naming it this way " +
+    `gives one module two spellings. ${suggestion(owner, filename, specifier)}`;
+}
+
+export default {
+  name: "cf-package",
+  rules: {
+    "no-self-import": {
+      create(context) {
+        const owner = ownerOf(dirname(context.filename));
+        if (owner === null) return {};
+        if (isTestFile(owner.root, context.filename)) return {};
+
+        // Every node that carries a module specifier carries it as `source`,
+        // which is a string literal except in the dynamic-import form, where it
+        // is an arbitrary expression that only sometimes is one.
+        const check = (node: Deno.lint.Node, source: unknown) => {
+          const value = (source as { value?: unknown } | null)?.value;
+          if (typeof value !== "string") return;
+          if (value !== owner.name && !value.startsWith(`${owner.name}/`)) {
+            return;
+          }
+          context.report({
+            node,
+            message: message(owner, context.filename, value),
+          });
+        };
+
+        return {
+          ImportDeclaration: (node) => check(node, node.source),
+          ExportAllDeclaration: (node) => check(node, node.source),
+          ExportNamedDeclaration: (node) => check(node, node.source),
+          ImportExpression: (node) => check(node, node.source),
+        };
+      },
+    },
+  },
+} satisfies Deno.lint.Plugin;


### PR DESCRIPTION
`packages/runner/src/runtime.ts` is the composition root of the runtime, and it reached `RuntimeTelemetry` through `@commonfabric/runner` — its own package's entry point — rather than through `./telemetry.ts`, where the class is defined. `RuntimeTelemetry` is a class, so that import is present at run time and not only during type checking.

The entry point's first line is `export { Runtime } from "./runtime.ts"`. Anything that imported the package therefore began evaluating the entry point, went straight into `runtime.ts`, and came back into an entry point that had not finished. It worked because the only use of the binding is a `new RuntimeTelemetry()` inside a constructor, which does not run until long after both modules have finished evaluating. Moving one line in the entry point could have changed that, and the failure would have presented as a class that is undefined for no reason a reading of either file explains.

Eight more places named their own package, and all of them are fixed here. Three more imported an entry point: `shell-utils.ts` in the integration package, and the protocol types and runtime processor in the runtime client. Five named a subpath export of their own package instead: three in the runner reaching `traverse.ts` and `schemas.ts`, and two in utils reaching `types.ts` and `env.ts`. A subpath adds no cycle, because it names one module rather than the whole package, but it still leaves the package and comes back, so one file ends up with two spellings and neither is a reliable way to find who depends on what. Each moved import lands in the sorted position its new specifier gives it, which is why two of these diffs are larger than one line.

A new lint rule, `cf-package/no-self-import` in
`tasks/lint-self-import.ts`, reports both forms, so a plain `deno lint` catches the next one. It finds a file's package by walking up to the nearest Deno configuration that declares a name, then reports any import specifier that is that name or starts with it followed by a slash. It reads the package's `exports` map as well, so a report about a subpath can name the file to import instead. A package's own tests are exempt, whether they sit under `test/` or `integration/` or are named `*.test.ts` or `*.bench.ts`: a test that names its own package is checking the surface a consumer sees, which is the thing it is there for. The rule is a sibling of `check-package-cycles`, which rules out a cycle between two packages; this one rules out the cycle a package makes with itself.

The imports section of `docs/development/DEVELOPMENT.md` had one bullet covering imports between packages and imports within one. It now has two, and the second states the rule and its reasoning.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6866?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

