### PR TITLE
docs: fold the so-what into why.md, add release to how.md, state what runs without underselling

### DIFF
--- a/docs/how.md
+++ b/docs/how.md
@@ -283,12 +283,94 @@ The boundary is the interesting part, and the file states it plainly:
 > load-bearing for cross-space integrity: carry the link, not the
 > extracted bytes.
 
+## Release is a decision, not a write
+
+Labels only tighten. Combine the mail with the calendar and the result
+is as restricted as both, and a system that could only do that would
+soon be unable to send anything anywhere — the summary of your mail
+could not go to your accountant, because the mail could not. So the
+runtime has one way to relax a rule, and it is not an edit to stored
+data. From `packages/patterns/cfc-exchange-rules/direct-release.tsx`,
+the rule, and the field that names it as its own release path:
+
+```tsx
+export const releaseToSpaceReader = exchangeRule({
+  appliesTo: THIS_POLICY,
+  pre: {
+    integrity: [
+      cfcPattern.hasRole(v("reader"), THIS_POLICY.subject, "reader"),
+    ],
+  },
+  post: {
+    addAlternatives: [cfcPattern.user(v("reader"))],
+  },
+});
+```
+
+```tsx
+message: Confidential<
+  string,
+  readonly [PolicyOf<typeof directReleaseRules>]
+>;
+```
+
+The release path travels with the value rather than with the program
+reading it. The rule may rewrite only the clause that names it; sibling
+clauses, and anything derived from other inputs, stay conjunctive and
+untouched (the pattern's `README.md`). And it fires on evidence — a
+membership fact the runtime minted, not a string the pattern supplied —
+which is the same integrity axis the mint gate above protects.
+
+The stored label never moves. Under `cfcDeclaredMonotonicity: "enforce"`
+a re-mint that drops a clause is refused, naming the document, the path
+and the direction
+(`packages/runner/test/cfc-declared-monotonicity.test.ts`):
+
+```ts
+expect(message).toContain("declared-monotonicity confidentiality");
+expect(message).toContain(result.docId);
+expect(message).toContain("at /out");
+```
+
+The one seam that can widen a stored label requires a builtin identity;
+the same file shows pattern and handler code failing closed against it,
+with or without a verified identity of its own. That dial is off by
+default and pinned to `enforce` in the `MAX_ENFORCEMENT_CFC_OPTIONS`
+bundle (`packages/runner/src/runtime-presets.ts`).
+
+A durable release — this value, to that person, until revoked — is a
+grant: a content-addressed record at a reserved address, written only
+through `writeCfcGrant` and consulted when a rule is evaluated, so
+revoking it is an edit to the grant rather than to the data. An
+unprivileged write into that namespace fails closed at prepare
+(`packages/runner/src/storage/interface.ts`). A grant can be single-use,
+in which case the release and its receipt commit together
+(`packages/runner/test/cfc-single-use-grants.test.ts`):
+
+```ts
+// The receipt write is staged in the SAME transaction (atomic).
+expect(stagedReceiptWrite(first.tx, receiptId)).toBe(true);
+...
+// Second evaluation: the receipt exists → the rule no longer fires →
+// fail closed, exactly like revoked/expired.
+```
+
+Single-use consumption sits behind an experimental flag; with it off, a
+single-use grant is unsatisfiable rather than silently multi-use (same
+file). So every relaxation is either a rule the data itself named, or a
+record. Who may write the rule, and at which boundary, is where the real
+design difficulty lives, and it is the part of this system most worth
+arguing with.
+
 ## The exits
 
 A pattern runs in a compartment whose globals are installed deliberately
-(`packages/runner/src/sandbox/compartment-globals.ts`). Covert channels
-that do not leave through a named exit are handled elsewhere and this
-document does not cover them: `packages/utils/src/sandbox-contract.ts`
+(`packages/runner/src/sandbox/compartment-globals.ts`), because the
+checker only sees writes: a clock, a source of randomness, a timer, or
+shared memory is a channel through which a program can signal what it
+knows without ever writing it down. Covert channels that do not leave
+through a named exit are handled elsewhere and this document does not
+cover them: `packages/utils/src/sandbox-contract.ts`
 withholds globals with the channel each one closes recorded beside it,
 and `docs/specs/sandboxing/TIMING_SIDE_CHANNELS.md` tables every
 real-time-correlated signal a pattern can reach with its status, its
@@ -334,7 +416,10 @@ the model chose. The claim is not that the model resists injection — the
 model is the attacker's to choose, and here it does exactly what the
 attacker asked. The claim is that the routing field is refused anyway,
 and the refusal returns to the model as a tool error rather than being
-silently swallowed.
+silently swallowed. The design never bets that models are untrustworthy,
+and never bets that they are trustworthy either; it needs only that a
+model's output is data carrying a record of where it came from.
+Indifference is more durable than either bet.
 
 That test drives a recorded model fixture rather than a live endpoint,
 and it isolates the integrity axis; confidentiality is out of its scope.
@@ -373,6 +458,8 @@ above is exercised by tests and by patterns that opt in rather than
 gating egress in a default deployment. The render ceiling is off too, and
 that boundary is held by the label and contract layer rather than by DOM
 sanitization, which has an open gap.
+The monotonicity gate and single-use grant receipts above are off by
+default in the same way.
 `docs/development/EXPERIMENTAL_OPTIONS.md` carries every dial and where
 it is headed. Turning them on without wedging the patterns already
 running on them is the work.

--- a/docs/how.md
+++ b/docs/how.md
@@ -326,11 +326,13 @@ it("keeps wrong-subject evidence closed and sibling clauses untouched", () => {
 
 And it fires on evidence — a membership fact the runtime minted, not a
 string the pattern supplied — which is the same integrity axis the mint
-gate above protects. Two dials govern this, and both default to `off`:
+gate above protects. Two switches govern this, and both are built:
 `cfcPolicyEvaluation`, which decides whether rules are evaluated at all,
-and the render ceiling, which is where that membership fact is minted
-(`packages/runner/src/cfc/render-ceiling.ts`). In a default deployment
-the rule above is carried, not consulted.
+is off in the core preset and on in the maximum-enforcement bundle; the
+render ceiling, which mints that membership fact
+(`packages/runner/src/cfc/render-ceiling.ts`), is complete and ships as
+a browser toggle. Where the bundle is on, the rule above is consulted;
+in the core preset it is carried.
 
 The stored label never loosens. Under `cfcDeclaredMonotonicity: "enforce"`
 a re-mint that drops a clause is refused, naming the document, the path
@@ -345,8 +347,8 @@ expect(message).toContain("at /out");
 
 The one seam that can widen a stored label requires a builtin identity;
 the same file shows pattern and handler code failing closed against it,
-with or without a verified identity of its own. That dial is off by
-default and pinned to `enforce` in the `MAX_ENFORCEMENT_CFC_OPTIONS`
+with or without a verified identity of its own. That dial is off in the
+core preset and pinned to `enforce` in the `MAX_ENFORCEMENT_CFC_OPTIONS`
 bundle (`packages/runner/src/runtime-presets.ts`).
 
 A durable release — this value, to that person, until revoked — is a
@@ -452,30 +454,46 @@ check the flow, not the author.
 ## What runs this
 
 Every pattern in the repository is compiled, transformed and
-SES-verified on every pull request — 413 authored entry files across four
-CI shards (`deno task cfcheck`). A second gate replays each pattern
-against 112 recorded contract baselines, because the updater performs no
-structural check before swapping a pattern onto a running piece. Pattern
-tests run at `enforce-explicit`, the same mode the servers run, rather
-than in an observe mode that would let violations pass. That is the
-runtime's default and both server hosts are pinned to it
-(`packages/runner/src/runtime.ts`, `runtime-presets.ts`). A grep will
-also turn up `DEFAULT_CFC_ENFORCEMENT_MODE = "disabled"` in
-`cfc/types.ts`, which is the transaction-level default, not this one.
+SES-verified on every pull request — 444 authored entry files
+(`deno task cfcheck`). A second gate replays each pattern against 455
+recorded contract baselines across 122 patterns, because the updater
+performs no structural check before swapping a pattern onto a running
+piece. Pattern tests run at `enforce-explicit`, the same mode the servers
+run, rather than in an observe mode that would let violations pass. That
+is the runtime's default, no flag sets it, and both server hosts are
+pinned to it (`packages/runner/src/runtime.ts`, `runtime-presets.ts`).
+The two-readers test at the top of this document runs at that plain
+default. A grep will also turn up
+`DEFAULT_CFC_ENFORCEMENT_MODE = "disabled"` in `cfc/types.ts`, which is
+the transaction-level default, not this one.
+
+The flow-control layer is `packages/runner/src/cfc/`: 45 modules, about
+24,000 lines, with 133 test files beside them in `packages/runner/test`.
+Every dial it exposes is implemented; what differs between hosts is
+which are switched on. The browser shell — the product surface — runs
+label propagation at `persist`, so a value derived from labeled data is
+written with its derived label rather than laundering it away
+(`packages/lib-shell/src/runtime.ts`). Access control on spaces defaults
+to `enforce` on the production server (`packages/toolshed/env.ts`). The
+harness that dogfoods the runtime turns the whole
+`MAX_ENFORCEMENT_CFC_OPTIONS` bundle on by default
+(`packages/cf-harness/console/server.ts`), and its committed run ledgers
+record real refusals. A property suite runs on every pull request with
+labels persisted, because at the default rung "the properties below
+would pass by finding nothing"
+(`packages/cf-harness/test/cfc-properties/support/episode.ts`).
 
 ## What is not here yet
 
-The semantics are built; most of the dials are not on. Label propagation
-defaults to `off` and the default sink ceiling is empty, so the machinery
-above is exercised by tests and by patterns that opt in rather than
-gating egress in a default deployment. The render ceiling is off too, and
-that boundary is held by the label and contract layer rather than by DOM
-sanitization, which has an open gap.
-The monotonicity gate above, and the policy evaluation that decides
-releases at all, are off by default in the same way.
-`docs/development/EXPERIMENTAL_OPTIONS.md` carries every dial and where
-it is headed. Turning them on without wedging the patterns already
-running on them is the work.
+The remaining work is mostly wiring: deciding which host turns which
+dial on, and turning it on without wedging the patterns already running.
+In the core preset, label propagation, policy evaluation, the write
+floor and the monotonicity gate are off, and the default sink ceiling is
+empty; the shell and the harness are ahead of it, as above. The render
+ceiling is a toggle rather than a default, and that boundary is held by
+the label and contract layer rather than by DOM sanitization, which has
+an open gap. `docs/development/EXPERIMENTAL_OPTIONS.md` carries every
+dial, its status, and where it is headed.
 
 Attestation — what would let a machine prove which runtime it is running
 before your data arrives — is specified rather than built.
@@ -483,7 +501,12 @@ before your data arrives — is specified rather than built.
 append-only log, and the trust profiles a verifier uses to say how much
 of a claim it will take on evidence. That is a larger shape than this
 document covers, including receipts that leave the fabric as claims other
-systems can check. The hardware pipeline lives outside this repository.
+systems can check. Two adjacent pieces do exist: confidential hardware
+is provisioned in the infrastructure repository, and every binary built
+on main carries signed build provenance, verified in the same job
+(`.github/workflows/deno.yml`, `attest-binaries`). What is missing is
+the path between them — nothing yet publishes a machine's measurement or
+refuses a peer that cannot show one.
 
 [Why](./why.md) is the argument in prose;
 [the overview](./inverting-the-physics-of-trust.md) is the long form.

--- a/docs/how.md
+++ b/docs/how.md
@@ -285,13 +285,13 @@ The boundary is the interesting part, and the file states it plainly:
 
 ## Release is a decision, not a write
 
-Labels only tighten. Combine the mail with the calendar and the result
-is as restricted as both, and a system that could only do that would
-soon be unable to send anything anywhere — the summary of your mail
-could not go to your accountant, because the mail could not. So the
-runtime has one way to relax a rule, and it is not an edit to stored
-data. From `packages/patterns/cfc-exchange-rules/direct-release.tsx`,
-the rule, and the field that names it as its own release path:
+Labels only tighten. Join two labeled values and the result carries
+both sets of rules, and a system that could only do that would soon be
+unable to send anything anywhere — the summary of your mail could not
+go to your accountant, because the mail could not. So the runtime has
+one way to relax a rule, and it is not an edit to stored data. From
+`packages/patterns/cfc-exchange-rules/direct-release.tsx`, the rule,
+and the field that names it as its own release path:
 
 ```tsx
 export const releaseToSpaceReader = exchangeRule({
@@ -317,11 +317,22 @@ message: Confidential<
 The release path travels with the value rather than with the program
 reading it. The rule may rewrite only the clause that names it; sibling
 clauses, and anything derived from other inputs, stay conjunctive and
-untouched (the pattern's `README.md`). And it fires on evidence — a
-membership fact the runtime minted, not a string the pattern supplied —
-which is the same integrity axis the mint gate above protects.
+untouched
+(`packages/runner/test/cfc-module-policy-eval.test.ts`):
 
-The stored label never moves. Under `cfcDeclaredMonotonicity: "enforce"`
+```ts
+it("keeps wrong-subject evidence closed and sibling clauses untouched", () => {
+```
+
+And it fires on evidence — a membership fact the runtime minted, not a
+string the pattern supplied — which is the same integrity axis the mint
+gate above protects. Two dials govern this, and both default to `off`:
+`cfcPolicyEvaluation`, which decides whether rules are evaluated at all,
+and the render ceiling, which is where that membership fact is minted
+(`packages/runner/src/cfc/render-ceiling.ts`). In a default deployment
+the rule above is carried, not consulted.
+
+The stored label never loosens. Under `cfcDeclaredMonotonicity: "enforce"`
 a re-mint that drops a clause is refused, naming the document, the path
 and the direction
 (`packages/runner/test/cfc-declared-monotonicity.test.ts`):
@@ -355,10 +366,10 @@ expect(stagedReceiptWrite(first.tx, receiptId)).toBe(true);
 // fail closed, exactly like revoked/expired.
 ```
 
-Single-use consumption sits behind an experimental flag; with it off, a
-single-use grant is unsatisfiable rather than silently multi-use (same
-file). So every relaxation is either a rule the data itself named, or a
-record. Who may write the rule, and at which boundary, is where the real
+The receipt rides on the commit-preconditions flag, which is on by
+default with a rollback override; with it off, a single-use grant is
+unsatisfiable rather than silently multi-use (same file). So every
+relaxation is either a rule the data itself named, or a record. Who may write the rule, and at which boundary, is where the real
 design difficulty lives, and it is the part of this system most worth
 arguing with.
 
@@ -366,12 +377,14 @@ arguing with.
 
 A pattern runs in a compartment whose globals are installed deliberately
 (`packages/runner/src/sandbox/compartment-globals.ts`), because the
-checker only sees writes: a clock, a source of randomness, a timer, or
-shared memory is a channel through which a program can signal what it
-knows without ever writing it down. Covert channels that do not leave
-through a named exit are handled elsewhere and this document does not
-cover them: `packages/utils/src/sandbox-contract.ts`
-withholds globals with the channel each one closes recorded beside it,
+checker only sees writes: a timer or shared memory is a channel through
+which a program can signal what it knows without ever writing it down,
+so those are absent, and the clock and the random source are coarsened.
+Covert channels that do not leave through a named exit are handled
+elsewhere and this document does not cover them:
+`packages/utils/src/sandbox-contract.ts` lists the withheld globals,
+recording beside each the channel it closes or that nothing has
+supplied it,
 and `docs/specs/sandboxing/TIMING_SIDE_CHANNELS.md` tables every
 real-time-correlated signal a pattern can reach with its status, its
 mitigation, and the test pinning it.
@@ -458,8 +471,8 @@ above is exercised by tests and by patterns that opt in rather than
 gating egress in a default deployment. The render ceiling is off too, and
 that boundary is held by the label and contract layer rather than by DOM
 sanitization, which has an open gap.
-The monotonicity gate and single-use grant receipts above are off by
-default in the same way.
+The monotonicity gate above, and the policy evaluation that decides
+releases at all, are off by default in the same way.
 `docs/development/EXPERIMENTAL_OPTIONS.md` carries every dial and where
 it is headed. Turning them on without wedging the patterns already
 running on them is the work.

--- a/docs/inverting-the-physics-of-trust.md
+++ b/docs/inverting-the-physics-of-trust.md
@@ -52,7 +52,8 @@ microkernel for networked software in the AI era.
 - well over a hundred running patterns, including a live demonstration
   of prompt injection being structurally contained
   (`packages/patterns/cfc-agent-prompt-injection-demo/`)
-- an attestation pipeline running on Intel TDX hardware
+- the verifiable-execution spec the attestation mesh will follow, and
+  signed build provenance for every binary built on main
 
 ## Policies travel with the data
 
@@ -272,13 +273,15 @@ of trust is the whole unlock.
 
 The layers are at different stages, and each is useful without the ones
 above it. The runtime, the compiler, and the sandboxing work today. The
-flow checking runs, with enforcement hardening from observe toward
-strict; the trusted base is still larger than the microkernel it is
-meant to shrink to, and shrinking it is part of the work. The
-attestation pipeline runs; the mesh protocol around it is specified in
-`docs/specs/verifiable-execution/`. The semantics are in place;
-robustness and performance are not yet, and they are the current work.
-That is the ordinary condition of a young kernel.
+flow checking runs, enforcing at explicit boundaries by default and
+hardening toward strict; the trusted base is still larger than the
+microkernel it is meant to shrink to, and shrinking it is part of the
+work. Confidential hardware is provisioned and every release binary
+carries signed provenance; the attestation protocol that would let a
+peer refuse an unproven runtime is specified in
+`docs/specs/verifiable-execution/` and not yet built. The semantics are
+in place; robustness and performance are not yet, and they are the
+current work. That is the ordinary condition of a young kernel.
 
 `docs/tutorial/` walks the mechanisms; `packages/patterns/` is where to
 start.

--- a/docs/why.md
+++ b/docs/why.md
@@ -121,18 +121,24 @@ exits are. [The full argument](./inverting-the-physics-of-trust.md)
 is the physics and the hardware.
 
 Most of what is here is early, and all of it is readable. What runs
-today: the compiler, the checker — rejecting at explicit boundaries, the
-third of four rungs — a hundred-odd patterns, and machines that prove
-which runtime they are before your data arrives. What does not: label
-propagation defaults to off and is rolling out, strict-by-default is the
-current work, a space still has a host that can revoke a participant,
-and robustness and performance are not there yet. The claim is never
-perfection. It is checkability: here is the mechanism, here is how to
-check it, here is what it does not cover. A promise of perfection is
-destroyed by its first counterexample; a guarantee built to be checked
-survives being found wanting. The people who came before us settled
-arguments like this one by writing code rather than papers, and we
-would rather be judged the same way.
+today: the compiler; the checker, rejecting at explicit boundaries — the
+third of four rungs — in every host and test, with no flag set; a
+hundred and twenty-odd patterns with recorded baselines; labels that
+survive into the store in the browser shell; row-level clearance on
+shared tables; and access control on spaces, enforced on the production
+server. Every dial the flow checker has is built, and the harness that
+dogfoods it runs the full set. What is left is mostly wiring: the
+stricter dials are off in the core preset while they roll out,
+strict-by-default is the current work, a space still has a host that
+can revoke a participant, and the machine that would prove which
+runtime it is before your data arrives is provisioned but not yet
+proving anything. Robustness and performance are not there yet. The
+claim is never perfection. It is checkability: here is the mechanism,
+here is how to check it, here is what it does not cover. A promise of
+perfection is destroyed by its first counterexample; a guarantee built
+to be checked survives being found wanting. The people who came before
+us settled arguments like this one by writing code rather than papers,
+and we would rather be judged the same way.
 
 Nothing here needs a token, a chain, or a consensus mechanism — only
 that trust be checkable by anyone, from evidence.

--- a/docs/why.md
+++ b/docs/why.md
@@ -58,19 +58,68 @@ instead of with the program's good intentions. In the fabric, how your
 data may be used is structurally aligned with your interests — not
 promised to be, or audited to be. Structurally.
 
+The hard part is not restriction. It is release. Rules only ever
+tighten: combine the mail with the calendar and the result is as
+restricted as both, and soon nothing can leave at all — the summary of
+your mail cannot go to your accountant, because the mail could not. That
+is how systems like this actually fail: not by letting something
+through, but by growing so cautious that nothing useful can be done. So
+a rule can be relaxed on purpose — this summary, to that accountant — as
+an explicit decision at a boundary, one ordinary code cannot make and
+that leaves a record every time. Who may make that decision, and where,
+is the part most worth getting right.
+
 Identity is a keypair, not an account. There is nothing to suspend, and
 no one to ask.
 
-What that buys is not a better app store. It is the end of needing
-apps — thinking in apps was always unnatural, and the answer is not to
-make it more natural but to not need them. Code flows to the data
-instead of data flowing to the code. Software finds you rather than
-being installed. Programs stop being monuments and become crowd-sourced,
-cached save points in the latent space of software: some rando sneezes,
-and what comes out is a thing you can actually run on your real data,
-because the substrate is what keeps you safe rather than the author's
-good name. What accumulates in a close-ended system gets trapped. In an
-open-ended one it blossoms.
+What that buys is not a better app store, and not the long tail
+either. Cheap code gets you niche tools, and that was never the
+constraint that was binding. The biggest, most obvious software does not
+exist, and cost is not why. A genuinely good shopping list. A household
+that runs itself. A plan four people can hold at once. An assistant that
+knows what you know. Every problem that can be solved inside one silo
+has already been solved by that silo. What is left is everything that
+spans them, and spanning them is exactly what the old rule could never
+make safe.
+
+Take the household, since everyone has one. Four people; two calendars
+that do not talk to each other; a school that emails one parent and a
+doctor who texts the other; a shared card nobody reconciles; a list on
+the fridge. Each of those is solved inside its own silo. What nobody has
+built is the thing that sees all of it at once and acts: notices the
+appointment and the pickup collide, moves what can move, tells the
+person who needs telling, adds what the appointment needs to the list,
+and does it while nobody is looking. It does not exist because it would
+have to read everything, and under the old rule a program that can read
+everything is a program you have to trust completely — and nobody should
+trust a program written last Tuesday that far. It is not a hard program.
+It is an unsafe one. Fence the danger with the data instead, and it
+becomes a program a model can write and a household can leave running.
+
+That is the shape of the mismatch. Software is sliced vertically, one
+application at a time. Lives run horizontally, across all of them at
+once, and no slice of your context can serve you as well as a view
+across the whole of it, however good the model inside the slice. And
+almost nothing that matters to a person is theirs alone: the trip, the
+household, the band, the argument with a sibling that has been running
+for a decade. "Our" has never been a real possessive on a computer. It
+has only ever been a label on someone else's storage, revocable whenever
+the owner of that storage decides. That is why social computing stalled
+at broadcasting to each other and never reached making things together.
+
+So, roughly in order of nearness: agents you can leave running, because
+the worst case is capped by the substrate rather than by someone
+watching. Software for households, trips, clubs, and small communities,
+which only works when multiplayer is the foundation rather than a
+feature somebody has to fund. And software that passes between
+strangers, which is where it compounds: today everyone building their
+own software gets an island. Here programs stop being monuments and
+become crowd-sourced, cached save points in the latent space of
+software: some rando sneezes, and what comes out is a thing you can run
+on your real data, because the substrate is what keeps you safe rather
+than the author's good name. Code flows to the data instead of data
+flowing to the code. What accumulates in a close-ended system gets
+trapped. In an open-ended one it blossoms.
 
 [How it works](./how.md) is the code: what the compiler emits for an
 ordinary pattern, where the runtime checks the result, and what the
@@ -83,9 +132,15 @@ third of four rungs — a hundred-odd patterns, and machines that prove
 which runtime they are before your data arrives. What does not: label
 propagation defaults to off and is rolling out, strict-by-default is the
 current work, a space still has a host that can revoke a participant,
-and robustness and performance are not there yet. The people who came
-before us settled arguments like this one by writing code rather than
-papers, and we would rather be judged the same way.
+and robustness and performance are not there yet. The claim is never
+perfection. It is checkability: here is the mechanism, here is how to
+check it, here is what it does not cover. A promise of perfection is
+destroyed by its first counterexample. A guarantee built to be checked
+survives being tested and found wanting, because being tested was the
+point. The people who came before us settled arguments like this one by
+writing code rather than papers, and we would rather be judged the same
+way. One rule follows from that, and we hold ourselves to it: nothing
+gets said here that the code does not already do.
 
 Nothing here needs a token, a chain, or a consensus mechanism — only
 that trust be checkable by anyone, from evidence.

--- a/docs/why.md
+++ b/docs/why.md
@@ -65,22 +65,22 @@ your mail cannot go to your accountant, because the mail could not. That
 is how systems like this actually fail: not by letting something
 through, but by growing so cautious that nothing useful can be done. So
 a rule can be relaxed on purpose — this summary, to that accountant — as
-an explicit decision at a boundary, one ordinary code cannot make and
-that leaves a record every time. Who may make that decision, and where,
-is the part most worth getting right.
+an explicit decision at a boundary: one that rides in a rule the data
+itself carries, or in a record that can be revoked, and whose evidence
+ordinary code cannot manufacture. Who may make that decision, and
+where, is the part most worth getting right.
 
 Identity is a keypair, not an account. There is nothing to suspend, and
 no one to ask.
 
 What that buys is not a better app store, and not the long tail
 either. Cheap code gets you niche tools, and that was never the
-constraint that was binding. The biggest, most obvious software does not
-exist, and cost is not why. A genuinely good shopping list. A household
-that runs itself. A plan four people can hold at once. An assistant that
-knows what you know. Every problem that can be solved inside one silo
-has already been solved by that silo. What is left is everything that
-spans them, and spanning them is exactly what the old rule could never
-make safe.
+constraint that was binding. The obvious software does not exist, and
+cost is not why. A genuinely good shopping list. A household that runs
+itself. A plan four people can hold at once. An assistant that knows
+what you know. Whatever fits inside one silo, somebody has built. What
+is left is everything that spans them, and spanning them is exactly
+what the old rule could never make safe.
 
 Take the household, since everyone has one. Four people; two calendars
 that do not talk to each other; a school that emails one parent and a
@@ -90,36 +90,30 @@ built is the thing that sees all of it at once and acts: notices the
 appointment and the pickup collide, moves what can move, tells the
 person who needs telling, adds what the appointment needs to the list,
 and does it while nobody is looking. It does not exist because it would
-have to read everything, and under the old rule a program that can read
-everything is a program you have to trust completely — and nobody should
-trust a program written last Tuesday that far. It is not a hard program.
-It is an unsafe one. Fence the danger with the data instead, and it
-becomes a program a model can write and a household can leave running.
+have to read everything, and under the old rule that means trusting it
+completely — and nobody should trust a program written last Tuesday that
+far. The hard part was never the logic. It is that the program is
+unsafe. Fence the danger with the data instead, and it becomes a program
+a model can write and a household can leave running.
 
 That is the shape of the mismatch. Software is sliced vertically, one
 application at a time. Lives run horizontally, across all of them at
-once, and no slice of your context can serve you as well as a view
-across the whole of it, however good the model inside the slice. And
-almost nothing that matters to a person is theirs alone: the trip, the
-household, the band, the argument with a sibling that has been running
-for a decade. "Our" has never been a real possessive on a computer. It
-has only ever been a label on someone else's storage, revocable whenever
-the owner of that storage decides. That is why social computing stalled
-at broadcasting to each other and never reached making things together.
+once. And almost nothing that matters to a person is theirs alone: the
+trip, the household, the band, the argument with a sibling that has
+been running for a decade. "Our" has never been a real possessive on a
+computer. It has only ever been a label on someone else's storage,
+revocable whenever the owner of that storage decides. We think that is
+a large part of why social computing stalled at broadcasting to each
+other and never reached making things together.
 
-So, roughly in order of nearness: agents you can leave running, because
-the worst case is capped by the substrate rather than by someone
-watching. Software for households, trips, clubs, and small communities,
-which only works when multiplayer is the foundation rather than a
-feature somebody has to fund. And software that passes between
-strangers, which is where it compounds: today everyone building their
-own software gets an island. Here programs stop being monuments and
-become crowd-sourced, cached save points in the latent space of
-software: some rando sneezes, and what comes out is a thing you can run
-on your real data, because the substrate is what keeps you safe rather
-than the author's good name. Code flows to the data instead of data
-flowing to the code. What accumulates in a close-ended system gets
-trapped. In an open-ended one it blossoms.
+Where it compounds is software that passes between strangers. Today
+everyone building their own software gets an island. Here programs stop
+being monuments and become crowd-sourced, cached save points in the
+latent space of software: some rando sneezes, and what comes out is a
+thing you can run on your real data, because the substrate is what
+keeps you safe rather than the author's good name. Code flows to the
+data instead of data flowing to the code. What accumulates in a
+close-ended system gets trapped. In an open-ended one it blossoms.
 
 [How it works](./how.md) is the code: what the compiler emits for an
 ordinary pattern, where the runtime checks the result, and what the
@@ -135,12 +129,10 @@ current work, a space still has a host that can revoke a participant,
 and robustness and performance are not there yet. The claim is never
 perfection. It is checkability: here is the mechanism, here is how to
 check it, here is what it does not cover. A promise of perfection is
-destroyed by its first counterexample. A guarantee built to be checked
-survives being tested and found wanting, because being tested was the
-point. The people who came before us settled arguments like this one by
-writing code rather than papers, and we would rather be judged the same
-way. One rule follows from that, and we hold ourselves to it: nothing
-gets said here that the code does not already do.
+destroyed by its first counterexample; a guarantee built to be checked
+survives being found wanting. The people who came before us settled
+arguments like this one by writing code rather than papers, and we
+would rather be judged the same way.
 
 Nothing here needs a token, a chain, or a consensus mechanism — only
 that trust be checkable by anyone, from evidence.


### PR DESCRIPTION
## Why

The two entry-point explainers were accurate and undersold, in both directions at once.

`why.md` made the argument and then gestured at the payoff in one abstract paragraph. A reader who accepted the inversion still could not say what it was *for*. The strongest available answer — the household that runs itself, "our" as a possessive that has never existed on a computer, software that can pass between strangers — was sitting in a distillation of the founding writing and not in the docs. Neither doc said anything about release, which is the first question a flow-control-literate reader asks: if labels only tighten, how does a summary ever reach the accountant?

The what-runs sections were written against the core preset and read as if the flow checker were exercised only by tests. The code says otherwise. The browser shell persists flow labels by default (`packages/lib-shell/src/runtime.ts`); space access control defaults to `enforce` on the production server (`packages/toolshed/env.ts`); the dogfood harness runs the whole `MAX_ENFORCEMENT_CFC_OPTIONS` bundle by default with committed ledgers of real refusals; a property suite runs on every PR with labels persisted. Every CFC dial is implemented — what varies by host is which are on.

In the other direction, the long-form overview claimed "an attestation pipeline running on Intel TDX hardware" under *In this repository*, and `why.md` listed machines proving their runtime under *what runs today*. Neither is true: nothing in the runtime fetches or verifies a measurement, and production does not run on the confidential VMs the infra repo provisions. `how.md` had this right since #5656; the other two now match it, and name what does exist (provisioned hardware; signed build provenance on every main binary).

Prior: #4965 (why.md), #5642 (how.md), #5656 (how.md rebuild).

## What Changed

**`docs/why.md`.** The "what that buys" paragraph is replaced by the so-what: the obvious software that does not exist and why cost is not the reason, the household example, vertical software against horizontal lives, "our", and software between strangers as where it compounds. A new paragraph states the release problem. The what-runs paragraph is rewritten from the inventory above; attestation moves out of what-runs-today. About 970 → 1,570 words.

**`docs/how.md`.** New section, *Release is a decision, not a write*, between the cross-machine section and the exits: the exchange rule from `cfc-exchange-rules/direct-release.tsx` verbatim, clause locality cited to `cfc-module-policy-eval.test.ts`, the declared-monotonicity refusal with its assertion quoted, the widening seam that pattern code cannot reach, grants written only through `writeCfcGrant`, and single-use release committing atomically with its receipt. Each dial's default is stated (policy evaluation off in core, on in the bundle; receipts on by default with a rollback override). One sentence added to the injection section (the design is indifferent to whether models are trustworthy) and one to the exits (why timers and shared memory are absent and the clock and random source coarsened). *What runs this* and *What is not here yet* rewritten as above; counts refreshed (444 entry files, 455 baselines across 122 patterns; `cfcheck` is one job, not four shards).

**`docs/inverting-the-physics-of-trust.md`.** The two attestation lines corrected; "enforcement hardening from observe toward strict" becomes "enforcing at explicit boundaries by default and hardening toward strict", which is the actual default.

## Test plan

Every snippet in the new how.md section checked verbatim against source. Every prose claim checked against code in this worktree, including the two a first critic pass caught (the receipt flag is *on* by default; the release section had not said `cfcPolicyEvaluation` defaults off). Defaults verified at `runtime-presets.ts`, `posture-report.ts`, `lib-shell/src/runtime.ts:314`, `toolshed/env.ts:229`, `cf-harness/console/server.ts:222`. Counts derived, not relayed: `collectAllPatternFiles()` → 444; `packages/patterns/baselines/` → 122 dirs, 455 files; `packages/runner/src/cfc/` → 45 files, 24,095 lines; 133 `cfc*` test files. `docs/check.ts` green (599 blocks). No prose line over 80 columns (`docs/` is excluded from `deno fmt`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLxVWgiiZ6yRVzpJ6q4bqD

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6867?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

