### PR TITLE
refactor: diagnostics render a value through the debug renderer's own limits

### DIFF
--- a/packages/cf-harness/scripts/run-measurement-batch.ts
+++ b/packages/cf-harness/scripts/run-measurement-batch.ts
@@ -42,6 +42,8 @@ import { parseArgs } from "@std/cli/parse-args";
 import { ensureDir } from "@std/fs";
 import { isAbsolute, join } from "@std/path";
 
+import { toCompactDebugString } from "@commonfabric/data-model";
+
 import type { ConsolePolicyReport } from "../console/policy.ts";
 import type {
   HarnessChatEventEnvelope,
@@ -967,7 +969,7 @@ export class ConsoleClient {
       return {
         kind: "refused",
         reason: `the index answered with no results array: ${
-          JSON.stringify(answer).slice(0, 200)
+          toCompactDebugString(answer, { maxLength: 200 })
         }`,
       };
     }

--- a/packages/cli/lib/test-runner.ts
+++ b/packages/cli/lib/test-runner.ts
@@ -38,7 +38,10 @@ import {
 } from "@commonfabric/test-support/records";
 
 import { internSchema } from "@commonfabric/data-model-schema";
-import { toCompactDebugString } from "@commonfabric/data-model";
+import {
+  toCompactDebugString,
+  toDebugKindString,
+} from "@commonfabric/data-model";
 import { Identity } from "@commonfabric/identity";
 import { resolveLocalProgram } from "@commonfabric/runner/local-program.deno";
 import {
@@ -1367,7 +1370,7 @@ export async function runTestPattern(
     if (!Array.isArray(testSteps)) {
       throw new Error(
         "Test pattern must return { [TESTS]: TestStep[] }. Got: " +
-          toCompactDebugString(typeof testSteps),
+          toDebugKindString(testSteps),
       );
     }
 

--- a/packages/html/src/debug.ts
+++ b/packages/html/src/debug.ts
@@ -89,11 +89,9 @@ export function formatTree(node: unknown, indent = 0): string {
   }
   if (typeof node !== "object") return `${pad}${String(node)}`;
 
-  // A `FabricSpecialObject` keeps its state in private fields and has zero
-  // enumerable own properties, so `stringify()` renders one as `{}` -- and
-  // does so silently, since the `catch` below fires only on a throw and
-  // `stringify()` does not throw on one. The debug renderer knows what to do
-  // with one.
+  // A `FabricSpecialObject` is rendered before the vdom-node check below
+  // reads it: one can carry a `name` of its own, as a `FabricError` does,
+  // which would pass for a node's.
   if (node instanceof FabricSpecialObject) {
     return `${pad}${toCompactDebugString(node)}`;
   }
@@ -108,12 +106,8 @@ export function formatTree(node: unknown, indent = 0): string {
 
   const name = obj.name as string | undefined;
   if (!name) {
-    // Not a vdom node — try to stringify
-    try {
-      return `${pad}${JSON.stringify(node)}`;
-    } catch {
-      return `${pad}[object]`;
-    }
+    // Not a vdom node.
+    return `${pad}${toCompactDebugString(node)}`;
   }
 
   // Format props
@@ -124,18 +118,8 @@ export function formatTree(node: unknown, indent = 0): string {
     for (const [key, value] of Object.entries(props)) {
       if (isCellHandle(value)) {
         propParts.push(`${key}=<cell>`);
-      } else if (typeof value === "string") {
-        propParts.push(`${key}="${value}"`);
-      } else if (value instanceof FabricSpecialObject) {
-        // Named rather than stringified, for the reason given at the node case
-        // above: `stringify()` renders one as `{}` and does not throw doing so.
-        propParts.push(`${key}=${toCompactDebugString(value)}`);
       } else {
-        try {
-          propParts.push(`${key}=${JSON.stringify(value)}`);
-        } catch {
-          propParts.push(`${key}=[object]`);
-        }
+        propParts.push(`${key}=${toCompactDebugString(value)}`);
       }
     }
     if (propParts.length > 0) {

--- a/packages/runner/src/executor/space-server.ts
+++ b/packages/runner/src/executor/space-server.ts
@@ -35,6 +35,7 @@
 // seal; the durable outbound-append rows deliver and retire through
 // the outbox; `memo.*`/`outbox.*` counters are live.
 
+import { toCompactDebugString } from "@commonfabric/data-model";
 import {
   type AdmittedCommitNotice,
   type Server as MemoryServer,
@@ -3061,7 +3062,9 @@ export class SpaceServer implements TransactionSealDestination {
           if (viewEntry?.eventId !== entry.eventId) {
             logger.warn("event-view-lag", () => [
               `drain deferring ${entry.eventId}: replica view holds ` +
-              `${JSON.stringify(viewEntry)} at index ${index}; ` +
+              `${
+                toCompactDebugString(viewEntry, { maxLength: 200 })
+              } at index ${index}; ` +
               "later-arrived events wait behind it",
             ]);
             // The same barrier as above: the deferred entry's

--- a/packages/runner/src/pattern-binding.ts
+++ b/packages/runner/src/pattern-binding.ts
@@ -3,6 +3,7 @@ import { deepEqual } from "@commonfabric/utils/deep-equal";
 import {
   FabricInstance,
   FabricPrimitive,
+  toCompactDebugString,
   valueEqual,
 } from "@commonfabric/data-model";
 import { deepFrozenCloneAndInternSchema } from "@commonfabric/data-model-schema";
@@ -48,6 +49,13 @@ import type {
 } from "./builder/types.ts";
 import { isCellScope, scopeRank } from "./scope.ts";
 import { getServerExecutionConfig } from "@commonfabric/memory/v2";
+
+/**
+ * Longest rendering of a binding an error message carries. A binding can
+ * hold anything a cell can, and the message names it rather than carrying
+ * it.
+ */
+const MAX_BINDING_RENDER = 200;
 
 type SendValueToBindingOptions = {
   narrowestReadScope?: CellScope;
@@ -266,7 +274,9 @@ function sendValueToBindingInner<T>(
       const alias = binding.$alias;
       if ((alias.defer ?? 0) > 0) {
         throw new Error(
-          `Cannot write to deferred alias: ${JSON.stringify(binding)}`,
+          `Cannot write to deferred alias: ${
+            toCompactDebugString(binding, { maxLength: MAX_BINDING_RENDER })
+          }`,
         );
       }
       if (alias.partialCause !== undefined) {
@@ -285,7 +295,9 @@ function sendValueToBindingInner<T>(
         );
       } else if (typeof alias.cell !== "string") {
         throw new Error(
-          "Invalid pseudo-alias cell: " + JSON.stringify(binding),
+          `Invalid pseudo-alias cell: ${
+            toCompactDebugString(binding, { maxLength: MAX_BINDING_RENDER })
+          }`,
         );
       } else {
         // Certain strings have special meaning as the cell id

--- a/packages/runner/src/storage/transaction-summary.ts
+++ b/packages/runner/src/storage/transaction-summary.ts
@@ -33,7 +33,10 @@ const SUMMARY_VALUE_OPTIONS: CompactDebugStringOptions = {
 };
 
 /**
- * Condensed summary of a transaction suitable for LLM consumption
+ * Summary of a transaction. Its `summary` line, and the rendering
+ * `formatTransactionSummary()` makes of it, are condensed for an LLM to
+ * read; `writes` carries each written value as it was written, unbounded,
+ * and is not itself meant to be serialized or handed to one.
  */
 export interface TransactionSummary {
   /** Human-readable one-line summary */
@@ -45,7 +48,7 @@ export interface TransactionSummary {
     writes: number;
   };
 
-  /** Actual writes with values */
+  /** Actual writes, with their values as written */
   writes: WriteDetail[];
 }
 
@@ -62,10 +65,10 @@ export interface WriteDetail {
   /** Path that was written to */
   path: string;
 
-  /** The value that was written */
+  /** The value that was written, as written: a rendering bounds it, this does not */
   value: unknown;
 
-  /** The previous value (if available) */
+  /** The previous value, as it was, if available */
   previousValue?: unknown;
 
   /** Whether this was a deletion */
@@ -73,11 +76,12 @@ export interface WriteDetail {
 }
 
 /**
- * Create a condensed transaction summary from an IExtendedStorageTransaction
+ * Create a transaction summary from an IExtendedStorageTransaction, whose
+ * summary line is condensed and whose writes carry their values as written
  *
  * @param tx - The completed transaction
  * @param space - Optional memory space to filter changes (defaults to first space found)
- * @returns Condensed summary for LLM consumption
+ * @returns Summary, its `summary` line condensed for LLM consumption
  */
 export function summarizeTransaction(
   tx: IExtendedStorageTransaction,

--- a/packages/runner/src/storage/transaction-summary.ts
+++ b/packages/runner/src/storage/transaction-summary.ts
@@ -5,7 +5,10 @@
  * into concise summaries suitable for LLMs to help humans debug software behavior.
  */
 
-import { toCompactDebugString } from "@commonfabric/data-model";
+import {
+  type CompactDebugStringOptions,
+  toCompactDebugString,
+} from "@commonfabric/data-model";
 
 import { entityUriSchemePrefix } from "../entity-kind.ts";
 import type { MemorySpace } from "../runtime.ts";
@@ -17,6 +20,17 @@ import {
   getDirectTransactionReactivityLog,
   getTransactionWriteDetails,
 } from "./transaction-inspection.ts";
+
+/**
+ * Rendering options for a written value in a summary line: a glimpse of the
+ * value, bounded on every axis, since a line names what changed rather than
+ * carrying it.
+ */
+const SUMMARY_VALUE_OPTIONS: CompactDebugStringOptions = {
+  maxLength: 100,
+  maxArrayLength: 2,
+  maxStringLength: 50,
+};
 
 /**
  * Condensed summary of a transaction suitable for LLM consumption
@@ -154,11 +168,14 @@ function formatWrite(write: WriteDetail): string {
     return `${write.path}: deleted`;
   }
 
-  const newVal = formatValueForSummary(write.value);
+  const newVal = toCompactDebugString(write.value, SUMMARY_VALUE_OPTIONS);
 
   // If we have previous value, show before → after
   if (write.previousValue !== undefined) {
-    const oldVal = formatValueForSummary(write.previousValue);
+    const oldVal = toCompactDebugString(
+      write.previousValue,
+      SUMMARY_VALUE_OPTIONS,
+    );
     return `${write.path}: ${oldVal} → ${newVal}`;
   }
 
@@ -262,37 +279,13 @@ function extractWrites(
       objectId: shortenId(fullObjectId),
       fullObjectId,
       path,
-      value: truncateValue(value, 100),
-      previousValue: truncateValue(detail.previousValue, 100),
+      value,
+      previousValue: detail.previousValue,
       isDeleted,
     });
   }
 
   return writes;
-}
-
-/**
- * Truncate a value for display
- */
-function truncateValue(value: unknown, maxLength: number): unknown {
-  if (value === undefined) return undefined;
-  if (value === null) return null;
-
-  if (typeof value === "string") {
-    return value.length > maxLength
-      ? value.substring(0, maxLength) + "..."
-      : value;
-  }
-
-  if (Array.isArray(value)) {
-    return `[Array: ${value.length} items]`;
-  }
-
-  if (typeof value === "object") {
-    return toCompactDebugString(value, { maxLength: maxLength });
-  }
-
-  return value;
 }
 
 /**
@@ -326,7 +319,7 @@ function generateSummary(
     if (write.isDeleted) {
       parts.push(`Deleted ${write.path}`);
     } else {
-      const valueStr = formatValueForSummary(write.value);
+      const valueStr = toCompactDebugString(write.value, SUMMARY_VALUE_OPTIONS);
       parts.push(`${write.path} = ${valueStr}`);
     }
   }
@@ -336,24 +329,6 @@ function generateSummary(
   }
 
   return parts.join("; ");
-}
-
-/**
- * Format a value for the summary line
- */
-function formatValueForSummary(value: unknown): string {
-  if (value === undefined) return "undefined";
-  if (value === null) return "null";
-  if (typeof value === "string") {
-    const truncated = value.length > 50
-      ? value.substring(0, 50) + "..."
-      : value;
-    return `"${truncated}"`;
-  }
-  if (typeof value === "number" || typeof value === "boolean") {
-    return String(value);
-  }
-  return toCompactDebugString(value);
 }
 
 /**

--- a/packages/runner/test/transaction-summary.test.ts
+++ b/packages/runner/test/transaction-summary.test.ts
@@ -1,4 +1,5 @@
 import { assertEquals } from "@std/assert";
+import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
 import {
   debugTransactionWrites,
@@ -365,7 +366,7 @@ describe("transaction-summary", () => {
     );
   });
 
-  it("should truncate verbose write values in summaries", () => {
+  it("renders a verbose write value bounded in the summary line, and carries it whole in the summary", () => {
     const longText = "x".repeat(120);
     const tx = createInspectableTransaction(
       [
@@ -417,11 +418,18 @@ describe("transaction-summary", () => {
     );
 
     const summary = summarizeTransaction(tx, "did:key:test" as any);
+    const formatted = formatTransactionSummary(tx, "did:key:test" as any);
 
     assertEquals(summary.writes[0].objectId, "a-very-long-object-i...");
-    assertEquals(summary.writes[0].value, `${"x".repeat(100)}...`);
-    assertEquals(summary.writes[1].value, "[Array: 3 items]");
-    assertEquals(summary.writes[2].value, "{nested:{count:1}}");
+    expect(summary.writes[0].value).toBe(longText);
+    expect(summary.writes[1].value).toEqual([1, 2, 3]);
+    expect(summary.writes[2].value).toEqual({ nested: { count: 1 } });
+    expect(formatted).toContain(
+      `long = "${"x".repeat(50)}" + ... length: 120`,
+    );
+    expect(formatted).toContain("items = [1,2,... length: 3]");
+    expect(formatted).toContain("details = {nested:{count:1}}");
+    expect(formatted).toContain("done = true");
     assertEquals(
       summarizeTransaction(
         createInspectableTransaction([{
@@ -437,13 +445,8 @@ describe("transaction-summary", () => {
       ).writes[0].value,
       null,
     );
-    assertEquals(summary.summary.includes("... and 1 more"), true);
-    assertEquals(
-      formatTransactionSummary(tx, "did:key:test" as any).includes(
-        "Object a-very-long-object-i...",
-      ),
-      true,
-    );
+    expect(summary.summary).toContain("... and 1 more");
+    expect(formatted).toContain("Object a-very-long-object-i...");
   });
 
   it("should debug journal write activity", () => {

--- a/packages/runtime-client/src/client/connection.ts
+++ b/packages/runtime-client/src/client/connection.ts
@@ -1,3 +1,4 @@
+import { toCompactDebugString } from "@commonfabric/data-model";
 import { defer, type Deferred } from "@commonfabric/utils/defer";
 import { getLogger } from "@commonfabric/utils/logger";
 import { unrefTimer } from "@commonfabric/utils/sleep";
@@ -41,6 +42,13 @@ import { RuntimeTransport } from "./transport.ts";
 import { EventEmitter } from "./emitter.ts";
 import { $onCellUpdate, CellHandle } from "@/cell-handle.ts";
 import { cellRefToKey } from "@/shared/utils.ts";
+
+/**
+ * Longest rendering of an unknown notification a warning carries. What
+ * arrives is bounded only by the transport, and a warning names it rather
+ * than carrying it.
+ */
+const MAX_UNKNOWN_NOTIFICATION_RENDER = 512;
 
 const ipcLogger = getLogger("runtime-client");
 
@@ -586,7 +594,13 @@ export class RuntimeConnection extends EventEmitter<RuntimeConnectionEvents> {
       } else if (isEventNeedsAttentionNotification(message)) {
         this.emit("eventneedsattention", message);
       } else {
-        console.warn(`Unknown notification: ${JSON.stringify(message)}`);
+        console.warn(
+          `Unknown notification: ${
+            toCompactDebugString(message, {
+              maxLength: MAX_UNKNOWN_NOTIFICATION_RENDER,
+            })
+          }`,
+        );
       }
       return;
     }

--- a/packages/shell/src/views/DebuggerView.ts
+++ b/packages/shell/src/views/DebuggerView.ts
@@ -25,13 +25,6 @@ import type { Logger, LoggerBreakdown } from "@commonfabric/utils/logger";
  * metadata as enumerable properties on the function, which is what the
  * replacer keeps of one.
  */
-/**
- * Longest text an expanded marker's detail shows. The indented rendering has
- * no length option of its own, and a marker with many keys at every level
- * within the depth limit still runs long, so the display bounds itself.
- */
-const MAX_MARKER_DETAIL_LENGTH = 10000;
-
 const DEBUGGER_VALUE_OPTIONS: DebugValueOptions = {
   maxDepth: 3,
   maxArrayLength: 5,
@@ -41,6 +34,13 @@ const DEBUGGER_VALUE_OPTIONS: DebugValueOptions = {
       ? { name: value.name || "[anonymous]", ...value }
       : value,
 };
+
+/**
+ * Longest text an expanded marker's detail shows. The indented rendering has
+ * no length option of its own, and a marker with many keys at every level
+ * within the depth limit still runs long, so the display bounds itself.
+ */
+const MAX_MARKER_DETAIL_LENGTH = 10000;
 
 /**
  * Hierarchical topic definitions for filtering telemetry events.

--- a/packages/shell/src/views/DebuggerView.ts
+++ b/packages/shell/src/views/DebuggerView.ts
@@ -25,6 +25,13 @@ import type { Logger, LoggerBreakdown } from "@commonfabric/utils/logger";
  * metadata as enumerable properties on the function, which is what the
  * replacer keeps of one.
  */
+/**
+ * Longest text an expanded marker's detail shows. The indented rendering has
+ * no length option of its own, and a marker with many keys at every level
+ * within the depth limit still runs long, so the display bounds itself.
+ */
+const MAX_MARKER_DETAIL_LENGTH = 10000;
+
 const DEBUGGER_VALUE_OPTIONS: DebugValueOptions = {
   maxDepth: 3,
   maxArrayLength: 5,
@@ -1123,6 +1130,17 @@ export class XDebuggerView extends LitElement {
     }
 
     return false;
+  }
+
+  /**
+   * Renders the detail an expanded marker shows: the indented rendering, cut
+   * to `MAX_MARKER_DETAIL_LENGTH` with a trailing `...` when it runs longer.
+   */
+  private markerDetail(marker: RuntimeTelemetryMarkerResult): string {
+    const text = toIndentedDebugString(marker, DEBUGGER_VALUE_OPTIONS);
+    return (text.length > MAX_MARKER_DETAIL_LENGTH)
+      ? `${text.slice(0, MAX_MARKER_DETAIL_LENGTH - 3)}...`
+      : text;
   }
 
   private matchesSearch(marker: RuntimeTelemetryMarkerResult): boolean {
@@ -2682,10 +2700,7 @@ export class XDebuggerView extends LitElement {
                         Copy Full
                       </button>
                     </div>
-                    <pre>${toIndentedDebugString(
-                      marker,
-                      DEBUGGER_VALUE_OPTIONS,
-                    )}</pre>
+                    <pre>${this.markerDetail(marker)}</pre>
                   </div>
                 `
                 : ""}

--- a/packages/shell/src/views/DebuggerView.ts
+++ b/packages/shell/src/views/DebuggerView.ts
@@ -20,19 +20,36 @@ import "./SchedulerGraphView.ts";
 import type { Logger, LoggerBreakdown } from "@commonfabric/utils/logger";
 
 /**
+ * Most properties of an object the debugger renders before standing in a
+ * count for the whole object. The renderer bounds depth, arrays, and
+ * strings, but walks every property of an object within those bounds, and
+ * the search renders every marker on each keystroke; a wide object is cut
+ * off before the walk rather than after it.
+ */
+const MAX_MARKER_OBJECT_KEYS = 20;
+
+/**
  * Rendering options for a value shown in the debugger: a bounded glimpse,
- * since a marker can hold anything a cell can. An action carries its
- * metadata as enumerable properties on the function, which is what the
- * replacer keeps of one.
+ * since a marker can hold anything a cell can. The replacer keeps an
+ * action's metadata, which it carries as enumerable properties on the
+ * function, and stands a count in for an object wider than
+ * `MAX_MARKER_OBJECT_KEYS`.
  */
 const DEBUGGER_VALUE_OPTIONS: DebugValueOptions = {
   maxDepth: 3,
   maxArrayLength: 5,
   maxStringLength: 200,
-  replacer: (value) =>
-    (typeof value === "function")
-      ? { name: value.name || "[anonymous]", ...value }
-      : value,
+  replacer: (value) => {
+    if (typeof value === "function") {
+      return { name: value.name || "[anonymous]", ...value };
+    } else if (isObjectOrArray(value) && !Array.isArray(value)) {
+      const count = Object.keys(value).length;
+      if (count > MAX_MARKER_OBJECT_KEYS) {
+        return `[Object with ${count} keys]`;
+      }
+    }
+    return value;
+  },
 };
 
 /**

--- a/packages/shell/src/views/DebuggerView.ts
+++ b/packages/shell/src/views/DebuggerView.ts
@@ -1,3 +1,8 @@
+import {
+  type DebugValueOptions,
+  toCompactDebugString,
+  toIndentedDebugString,
+} from "@commonfabric/data-model";
 import type {
   LoggerMetadata,
   RuntimeTelemetryMarkerResult,
@@ -13,6 +18,22 @@ import { ResizableDrawerController } from "../lib/resizable-drawer-controller.ts
 import "./SchedulerGraphView.ts";
 
 import type { Logger, LoggerBreakdown } from "@commonfabric/utils/logger";
+
+/**
+ * Rendering options for a value shown in the debugger: a bounded glimpse,
+ * since a marker can hold anything a cell can. An action carries its
+ * metadata as enumerable properties on the function, which is what the
+ * replacer keeps of one.
+ */
+const DEBUGGER_VALUE_OPTIONS: DebugValueOptions = {
+  maxDepth: 3,
+  maxArrayLength: 5,
+  maxStringLength: 200,
+  replacer: (value) =>
+    (typeof value === "function")
+      ? { name: value.name || "[anonymous]", ...value }
+      : value,
+};
 
 /**
  * Hierarchical topic definitions for filtering telemetry events.
@@ -1108,8 +1129,12 @@ export class XDebuggerView extends LitElement {
     if (!this.searchText) return true;
 
     const searchLower = this.searchText.toLowerCase();
-    // Use truncated stringify to avoid serializing huge objects on every search
-    const markerStr = this.safeJsonStringify(marker, 5000).toLowerCase();
+    // A bounded rendering, so that a search does not render a huge marker
+    // whole each keystroke.
+    const markerStr = toCompactDebugString(marker, {
+      ...DEBUGGER_VALUE_OPTIONS,
+      maxLength: 5000,
+    }).toLowerCase();
     return markerStr.includes(searchLower);
   }
 
@@ -1265,7 +1290,10 @@ export class XDebuggerView extends LitElement {
                 ? value.toString()
                 : typeof value === "number"
                 ? value.toString()
-                : this.safeJsonStringify(value, 100)}</span>
+                : toCompactDebugString(value, {
+                  ...DEBUGGER_VALUE_OPTIONS,
+                  maxLength: 100,
+                })}</span>
             </div>
           `);
         }
@@ -1273,95 +1301,6 @@ export class XDebuggerView extends LitElement {
     }
 
     return details;
-  }
-
-  /**
-   * Safely stringify a value with size limits to prevent context blowout.
-   * Truncates large strings, arrays, and objects.
-   */
-  private safeJsonStringify(
-    value: unknown,
-    maxLength: number,
-    indent?: number,
-  ): string {
-    const truncatedValue = this.truncateValue(value, 3); // Max depth 3
-    try {
-      const json = JSON.stringify(truncatedValue, null, indent);
-      if (json.length > maxLength) {
-        return json.slice(0, maxLength - 3) + "...";
-      }
-      return json;
-    } catch {
-      return "[Unable to serialize]";
-    }
-  }
-
-  /**
-   * Recursively truncate a value to prevent huge objects from being serialized.
-   * Replaces functions, large strings, large arrays, and deep objects with summaries.
-   */
-  private truncateValue(value: unknown, maxDepth: number): unknown {
-    if (maxDepth <= 0) {
-      return "[...]";
-    }
-
-    if (value === null || value === undefined) {
-      return value;
-    }
-
-    if (typeof value === "function") {
-      // Serialize functions as objects with name + all enumerable properties
-      const fn = value as unknown as
-        & { name?: string }
-        & Record<string, unknown>;
-      const result: Record<string, unknown> = {
-        name: fn.name || "[anonymous]",
-      };
-      // Copy enumerable properties (actions often have metadata attached)
-      for (const key of Object.keys(fn)) {
-        result[key] = this.truncateValue(fn[key], maxDepth - 1);
-      }
-      return result;
-    }
-
-    if (typeof value === "string") {
-      if (value.length > 200) {
-        return value.slice(0, 197) + "...";
-      }
-      return value;
-    }
-
-    if (typeof value === "number" || typeof value === "boolean") {
-      return value;
-    }
-
-    if (Array.isArray(value)) {
-      if (value.length > 10) {
-        return [
-          ...value.slice(0, 5).map((v) => this.truncateValue(v, maxDepth - 1)),
-          `[... ${value.length - 5} more items]`,
-        ];
-      }
-      return value.map((v) => this.truncateValue(v, maxDepth - 1));
-    }
-
-    if (typeof value === "object") {
-      const obj = value as Record<string, unknown>;
-      const keys = Object.keys(obj);
-
-      // Skip huge objects entirely (likely cell values or function metadata)
-      if (keys.length > 20) {
-        return `[Object with ${keys.length} keys]`;
-      }
-
-      const result: Record<string, unknown> = {};
-      for (const key of keys) {
-        result[key] = this.truncateValue(obj[key], maxDepth - 1);
-      }
-      return result;
-    }
-
-    return String(value);
   }
 
   //
@@ -2743,7 +2682,10 @@ export class XDebuggerView extends LitElement {
                         Copy Full
                       </button>
                     </div>
-                    <pre>${this.safeJsonStringify(marker, 10000, 2)}</pre>
+                    <pre>${toIndentedDebugString(
+                      marker,
+                      DEBUGGER_VALUE_OPTIONS,
+                    )}</pre>
                   </div>
                 `
                 : ""}

--- a/tasks/test-records-mint.ts
+++ b/tasks/test-records-mint.ts
@@ -15,6 +15,7 @@
  */
 
 import { join } from "@std/path";
+import { toCompactDebugString } from "@commonfabric/data-model";
 import { readEnv } from "@commonfabric/test-support/records";
 import {
   isRecipient,
@@ -143,7 +144,7 @@ export async function ensureServiceAccount(
     if (created.status !== 200) {
       throw new Error(
         `creating ${email} failed: HTTP ${created.status} ${
-          JSON.stringify(created.json).slice(0, 200)
+          toCompactDebugString(created.json, { maxLength: 200 })
         }`,
       );
     }
@@ -188,7 +189,7 @@ export async function ensurePersonFolder(
   if (created.status !== 200 && created.status !== 409) {
     throw new Error(
       `creating folder ${folder} failed: HTTP ${created.status} ${
-        JSON.stringify(created.json).slice(0, 200)
+        toCompactDebugString(created.json, { maxLength: 200 })
       }`,
     );
   }
@@ -231,7 +232,7 @@ export async function ensurePersonFolder(
     if (!isAccountNotVisible(updated.status, updated.json, email)) {
       throw new Error(
         `granting ${role} on ${folder} failed: HTTP ${updated.status} ${
-          JSON.stringify(updated.json).slice(0, 200)
+          toCompactDebugString(updated.json, { maxLength: 200 })
         }`,
       );
     }
@@ -308,7 +309,7 @@ export async function mintKey(
   if (minted.status !== 200) {
     throw new Error(
       `minting a key for ${email} failed: HTTP ${minted.status} ${
-        JSON.stringify(minted.json).slice(0, 200)
+        toCompactDebugString(minted.json, { maxLength: 200 })
       }`,
     );
   }


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Fable 5.1)

## What

The debug renderers in `data-model` (`toCompactDebugString()`,
`toIndentedDebugString()`, `toStructuredDebugValue()`) now bound a rendering
on every axis a diagnostic wants bounded: `maxDepth`, `maxArrayLength`,
`maxStringLength`, and, for the compact string, `maxLength`. Across the tree,
a number of diagnostics were still doing that bounding by hand: walking a
value to a depth, cutting a string and appending `...`, replacing an array
with its count, or reaching for `JSON.stringify` inside a `try`. This change
replaces each of those with a single renderer call under the options that say
what the hand code was doing, and deletes the hand code.

A rendering is allowed to change where the spirit holds: a value is still
shown as a bounded glimpse, and where a limit cuts it, the rendering now says
so and says how much there was.

## The sites

**The transaction summary** (`runner/src/storage/transaction-summary.ts`),
whose formatted string is the tool-call result the LLM dialog builtin returns
for a handler invocation. It had two shapers around the renderer: one
flattened a written value on its way into the structured summary (a string
cut at 100, an array replaced by `[Array: N items]`, an object replaced by its
compact rendering), and the other re-rendered that form for the summary line
(quoting a string and cutting it at 50), so an object write read as the
quoted rendering of a rendering. Both are gone. A `WriteDetail` carries the
value as written, and the line renders it under one options constant: the
whole rendering to 100 characters, a string to 50, an array to its first two
elements. A line now reads `long = "xxxx…" + ... length: 120`,
`items = [1,2,... length: 3]`, and `details = {nested:{count:1}}`; scalars are
unchanged. The structured summary keeps the raw value rather than a bounded
structured form, because re-rendering a structured debug value is not
idempotent: its tagged keys begin with a slash, which a second pass escapes.
Its docs say so: the `summary` line and the formatted rendering are the
condensed parts, and `writes` carries each value as written.

**The shell's debugger view** rendered a telemetry marker through a depth-3
walk of its own (strings cut at 200, arrays over ten reduced to five and a
count, objects over twenty keys replaced by a count, functions expanded to
their metadata) and then `JSON.stringify` with a cut. One options constant
carries the depth, array, and string limits, and a replacer keeps an action's
function metadata; the two private methods are gone. The panel changes from
JSON syntax to the debug syntax: `[1,2,3,4,5,... length: 12]` where before it
was `[1,2,3,4,5,"[... 7 more items]"]`, and `...` for a depth-elided value
where before it was `"[...]"`. The twenty-key cap stays, carried by the
replacer: an object wider than twenty properties renders as
`[Object with N keys]` before it is walked, since the renderer walks every
property of an object within its other bounds and the search renders every
marker on each keystroke. The marker detail, whose indented form has no
`maxLength` of its own, cuts its text at ten thousand characters as before.

**Four `JSON.stringify` diagnostics** on values that can hold a bigint or a
fabric primitive, on which `stringify` throws or renders `{}`: the runtime
client's warning for an unknown notification, the two binding errors in the
runner's pattern binding, and the space server's event-view-lag warning. Each
now renders compactly under a `maxLength`.

**The html vdom dump** stringified a non-node and a prop inside a `try`, with
a `[object]` fallback and a special case for fabric special objects. The
renderer never throws and knows those objects, so the cases fold into one; a
string prop is now JSON-quoted rather than wrapped in bare quotes. The
node-level special-object check stays, for a different reason than the one it
used to give: a `FabricError` carries a `name`, and would otherwise pass for
a vdom node.

**The CLI test runner's "must return a list" error** rendered `typeof`, so it
said `"object"` for `null` and a record alike; `toDebugKindString()` says
which.

**Two scripts**, the test-records minting task and the cf-harness measurement
batch, cut a `JSON.stringify` of an HTTP body at 200 characters with no
ellipsis; `maxLength` cuts and says so.

## Left as they are

Three more sites of the same shape are in pattern sources and stay untouched
here, because pattern bytes are contract-bearing and the package's tests are
source-sensitive: a favorite-excerpt `JSON.stringify(...).slice(0, 2000)` in
`system/home-ben.tsx`, a `typeof`-switching formatter in
`record/extraction/extractor-module.tsx`, and a hand-cased value describer in
`test/data-model-test.tsx`. Three others are judgment calls and also stay: the
piece menu's data panel (JSON syntax, handle and stream stubs, view keys
dropped at the top level), the CLI piece inspector's `--summary` (which shows
`Array(N)` and `[Object]` where the renderer's depth form shows only `...`),
and the integration harness's `Deno.inspect` at depth 0 for a non-`Error`
thrown value.

Everything else that shapes a value by hand was judged to be doing something
the renderer does not: a fixed summary schema with an exported type, output
that must stay JSON, an abbreviated identifier or prose preview, or a package
that cannot import `data-model`.

## Tests

The transaction summary's verbose-value test now pins the formatted line for
each kind of value, and that the structured summary carries the value whole;
every other pin in that file is unchanged. No test pinned any of the other
hand shapings. The html, shell, runtime-client, cli, and runner suites pass,
as do the workspace type check, lint, and format check.


