### PR TITLE
docs(llm): say where the LLM provider abstraction actually lives

### DIFF
--- a/docs/development/CONFIGURATION.md
+++ b/docs/development/CONFIGURATION.md
@@ -43,7 +43,9 @@ Required only if you're running the toolshed.
 
 A provider's models are **only registered when its env var is set**. See
 [`packages/toolshed/routes/ai/llm/models.ts`](../../packages/toolshed/routes/ai/llm/models.ts)
-for the registration logic.
+for the registration logic — that file is the whole provider abstraction, and
+[`docs/features/llm-provider-boundary.md`](../features/llm-provider-boundary.md)
+explains why it lives in the toolshed rather than in `@commonfabric/llm`.
 
 | Var | Provider |
 |---|---|

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -82,6 +82,10 @@ Add a line for each new document to the index below.
   request to the LLM gateway says which workload produced it, what a value is
   allowed to contain given that it reaches the provider, and why the machine
   label is drawn at random and the codebase declared
+- [`llm-provider-boundary.md`](llm-provider-boundary.md) — which side of the
+  language-model boundary owns the model catalog and the provider
+  credentials, why the caller's package cannot hold either, and how a model
+  name is resolved to a provider
 
 ## Patterns, components, and hosts
 

--- a/docs/features/llm-provider-boundary.md
+++ b/docs/features/llm-provider-boundary.md
@@ -1,0 +1,129 @@
+# The language-model provider boundary
+
+Calling a language model from this system crosses one boundary, and the two
+sides of it own different things. Getting the division wrong is the most common
+reason someone cannot find the code they are looking for.
+
+**The caller names a model. The toolshed resolves that name to a provider.**
+
+"Gateway" in this repository means something narrower and is not either side of
+that boundary: it is the internal LLM service at `CFTS_AI_GATEWAY_URL`, one of
+the providers the toolshed can resolve a name to.
+
+## Which side owns what
+
+| | Caller — `@commonfabric/llm` | Server — `packages/toolshed/routes/ai/llm/` |
+|---|---|---|
+| Loaded by | a browser tab, the command line, a background service, and the server too, for the request types | the toolshed server process alone |
+| Knows | the request shape and a model **name** | every registered model, its provider, and its capabilities |
+| Holds | no credential | whatever each provider needs to authenticate |
+| Depends on | `@commonfabric/api`, `@commonfabric/utils`, `@commonfabric/pure-json` | the AI SDK and its four provider packages |
+
+A caller builds an `LLMRequest` whose `model` field is a string and posts it to
+`/api/ai/llm`. The string may be a provider-qualified name, a shorter alias, or
+the `default` alias. Nothing on the caller's side maps any of those to a
+provider, and nothing on the caller's side could work it out unasked. A caller
+that wants the list asks for it, over `GET /api/ai/llm/models`.
+
+## Why the catalog stays on the server's side
+
+The catalog is
+[`packages/toolshed/routes/ai/llm/models.ts`](../../packages/toolshed/routes/ai/llm/models.ts).
+It is five things at once: the model list, the aliases, the capability records,
+the provider clients, and the chain that decides what `default` means.
+
+**The reason that reaches all five is that the catalog is not a constant.**
+Which models a deployment has is decided by the credentials it was configured
+with and by what the gateway answers when the toolshed asks it, so the true
+list exists only at run time and only in the server. A copy shipped to a caller
+would be a guess. This is why the callers that need the list already fetch
+`GET /api/ai/llm/models` rather than importing one — `packages/patterns`
+builds its model pickers that way, and cf-harness derives its own entries from
+the gateway's `/v1/models`. Moving a static catalog to the caller's package
+would create a second answer with no consumer and no way to be right.
+
+Two further facts fence off the provider clients specifically, and they are
+narrower than the reason above rather than independent of it:
+
+- **The clients need credentials.** Anthropic, Groq, and OpenAI register behind
+  an API key from the toolshed's environment; Vertex registers behind a path to
+  a credentials file it reads off disk. A credential belongs in one process.
+- **The clients need the AI SDK.** `createAnthropic`, `createOpenAI`,
+  `createGroq`, and `createVertex` come from packages declared in
+  `packages/toolshed/deno.jsonc`, scoped to the toolshed alone.
+
+The gateway is the exception that shows the shape: its block is gated on a URL
+rather than a key, and it authenticates with a placeholder. It stays here not
+because it is secret but because what it offers is only discoverable from here.
+
+Two rules hold on the caller's side, for two different reasons, and a
+different check keeps each. `@commonfabric/llm` is loaded into a browser worker
+through `@commonfabric/runner` and `runtime-client`, so nothing a browser tab
+may not load belongs there; `packages/llm/test/package-boundary.test.ts` reads
+that package's sources against an allowlist, so a provider SDK, a `node:`
+module, or any dependency nobody thought to ban turns the suite red. And
+`@commonfabric/runner` imports that package, so an import back the other way
+would close a cycle between them — nothing to do with weight. That one is
+`deno task check-package-cycles`, which walks the whole workspace and names
+both directions of the cycle it finds.
+
+## Asking the registry, and waiting only where it helps
+
+Each provider whose key is present adds its models to `MODELS` as `models.ts`
+loads. The gateway's are discovered instead of declared, over a request that
+runs alongside the server binding its port. That leaves two ways to ask:
+
+- `resolveModel(name)` returns any already registered model straight away, and
+  waits only when the name is not registered yet — a `gateway:` name, the
+  `default` alias, or a name that is no model at all, while discovery is still
+  out. There is one such wait per process: once discovery finishes, the first
+  two are registered and every name answers immediately.
+- `whenModelsReady()` waits for the whole list, which is what
+  `GET /api/ai/llm/models` needs: a list quietly missing the gateway's models
+  is a wrong answer rather than an early one.
+
+What the candidates are, what an unreachable gateway does, and which
+environment variable governs each of these belong to
+[`CONFIGURATION.md`](../development/CONFIGURATION.md#llm-providers) and are not
+repeated here.
+
+## Where the boundary leaks
+
+Two places where the division is less clean than the above, both worth knowing
+before relying on it:
+
+- `DEFAULT_GENERATE_OBJECT_MODELS` in
+  [`packages/llm/src/types.ts`](../../packages/llm/src/types.ts) is a
+  provider-qualified model name on the caller's side, and
+  `packages/toolshed/routes/ai/llm/generateObject.ts` imports it back to use as
+  a default. It names an OpenAI model, which registers only where
+  `CFTS_AI_LLM_OPENAI_API_KEY` is set, so on a deployment without that key the
+  `generateObject` default names a model nothing registered.
+- The response shape of `GET /api/ai/llm/models` is caller-facing vocabulary
+  written three times on the server's side — `Capabilities` and
+  `GatewayModelCapabilities` in `models.ts`, and the response schema in
+  `llm.routes.ts` — and read as `any` by the browser code that consumes it.
+  Model metadata carries no credential and needs no provider package, so unlike
+  the catalog itself this part could live beside `LLMRequest` and `LLMResponse`
+  in the caller's package, the way `LLMNativeModelToolId` already does.
+
+## The harness talks to the gateway itself
+
+`packages/cf-harness` is a third place with model code, and it is not part of
+the path above. It speaks the gateway's OpenAI-compatible protocol directly
+rather than going through the toolshed, and builds its own catalog entries from
+what the gateway's `/v1/models` returns — the same discovery the toolshed does,
+run separately for itself. What it hardcodes is narrower: a default model name,
+a subagent model name, and a pricing table. What it shares with the path above
+is the vocabulary in
+[`packages/llm/src/types.ts`](../../packages/llm/src/types.ts) — the native
+model tool identifiers and their results — and nothing else.
+
+## Related documentation
+
+- [`packages/llm/README.md`](../../packages/llm/README.md) — what the caller's
+  package contains
+- [`llm-testing.md`](llm-testing.md) — the test-environment guard, the client
+  mocks, and driving the route against a stand-in model
+- [`gateway-request-provenance.md`](gateway-request-provenance.md) — how a
+  request to the gateway says which workload produced it

--- a/packages/llm/README.md
+++ b/packages/llm/README.md
@@ -1,0 +1,65 @@
+# @commonfabric/llm
+
+The caller's half of the language-model boundary: the request and response
+types, the HTTP client that sends a request to the toolshed, and the check that
+a request survives the trip through JSON.
+
+## The model catalog is not here
+
+If you came looking for the list of models, the aliases, which provider serves a
+given name, or the chain that decides what `default` means, it is in
+[`packages/toolshed/routes/ai/llm/models.ts`](../toolshed/routes/ai/llm/models.ts).
+That file is the whole provider abstraction: it registers a model under a name,
+records what the model can do, and hands back the provider client to call.
+
+The split is deliberate. A caller sets `model` on an `LLMRequest` to a name and
+posts it to `/api/ai/llm`; the toolshed turns that name into a provider to call.
+Which models a deployment has depends on the credentials it was configured with
+and on what the gateway answers when asked, so the real list exists only in the
+server and only at run time. A copy on this side would be a guess, which is why
+a caller that wants the list fetches `GET /api/ai/llm/models` instead of
+importing one.
+
+Two rules follow for this package. It reaches a browser tab, through
+`@commonfabric/runner` and `runtime-client`, so nothing a browser may not load
+belongs here — no provider SDK, no `node:` module;
+[`test/package-boundary.test.ts`](test/package-boundary.test.ts) checks that
+against an allowlist. And `@commonfabric/runner` imports this package, so
+importing the runner back would close a cycle, which the repo-wide
+`deno task check-package-cycles` catches.
+
+[`docs/features/llm-provider-boundary.md`](../../docs/features/llm-provider-boundary.md)
+sets all of this out in full, including the two places the division leaks.
+
+## What is here
+
+- [`src/types.ts`](src/types.ts) — the request and response shapes that cross
+  the boundary, and the predicates that recognize them. `LLMRequest`,
+  `LLMResponse`, `LLMGenerateObjectRequest`, tool calls and tool results, and
+  the native model tools a request may ask a model to run for itself.
+- [`src/client.ts`](src/client.ts) — `LLMClient`, which posts to the toolshed
+  and reassembles a streamed answer. It also carries the mock mode that tests
+  use in place of a live call, and the guard that blocks a live call under
+  `ENV=test` or `CI=true`.
+- [`src/schema-transport.ts`](src/schema-transport.ts) — the check that a schema
+  is still the same schema after a round trip through JSON.
+
+## The routes on the other side
+
+| Route                        | Method | What it does                                 |
+| ---------------------------- | ------ | -------------------------------------------- |
+| `/api/ai/llm/models`         | GET    | The registered models and their capabilities |
+| `/api/ai/llm`                | POST   | Text generation, streamed or whole           |
+| `/api/ai/llm/generateObject` | POST   | Generation constrained to a JSON schema      |
+
+Their handlers are in
+[`packages/toolshed/routes/ai/llm/`](../toolshed/routes/ai/llm/).
+
+## Related documentation
+
+- [`docs/features/llm-provider-boundary.md`](../../docs/features/llm-provider-boundary.md)
+  — what each side of the boundary owns, and how a model name is resolved
+- [`docs/features/llm-testing.md`](../../docs/features/llm-testing.md) — testing
+  patterns and routes that call a model
+- [`docs/development/CONFIGURATION.md`](../../docs/development/CONFIGURATION.md)
+  — the environment variables that decide which providers register

--- a/packages/llm/deno.jsonc
+++ b/packages/llm/deno.jsonc
@@ -2,7 +2,9 @@
   "name": "@commonfabric/llm",
   "tasks": {
     // --no-check: this package is type-checked by `deno task check` (tasks/check.sh).
-    "test": "ENV=test deno test --no-check --allow-env"
+    // --allow-read: test/package-boundary.test.ts reads this package's own
+    // sources, its configuration, and its README.
+    "test": "ENV=test deno test --no-check --allow-env --allow-read"
   },
   "exports": {
     ".": "./src/index.ts",

--- a/packages/llm/src/types.ts
+++ b/packages/llm/src/types.ts
@@ -7,9 +7,16 @@ import type {
 import { isPureJson } from "@commonfabric/pure-json";
 import { isObjectNotArray } from "@commonfabric/utils/types";
 
-// Resolved by the toolshed at startup: prefers gateway:claude-sonnet-4-6 when
-// available, falls back to anthropic:claude-sonnet-4-5 otherwise. See
-// `registerDefaultModel` in packages/toolshed/routes/ai/llm/models.ts.
+/**
+ * The alias a request names to get whichever model the deployment considers
+ * its default. The toolshed picks that model as it starts up, by walking
+ * `DEFAULT_MODEL_CANDIDATES` in `packages/toolshed/routes/ai/llm/models.ts`
+ * and taking the first candidate a provider registered.
+ *
+ * Which models exist is decided there and not here. `README.md` in this
+ * package says why, and `docs/features/llm-provider-boundary.md` describes the
+ * boundary in full.
+ */
 export const DEFAULT_MODEL_NAME: ModelName = "default";
 
 // NOTE(ja): This should be an array of models, the first model will be tried, if it

--- a/packages/llm/test/package-boundary.test.ts
+++ b/packages/llm/test/package-boundary.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Checks that this package stays loadable by a browser tab, which it reaches
+ * through `@commonfabric/runner` and `runtime-client`. Its sources are read
+ * against an allowlist of specifiers, so a provider SDK, a `node:` module, or
+ * any dependency nobody thought to ban fails here.
+ * `docs/features/llm-provider-boundary.md` gives the reasoning.
+ *
+ * Two neighboring rules belong to repo-wide gates rather than to this file. An
+ * import of `@commonfabric/runner` would close a package cycle, which
+ * `check-package-cycles` catches against the real module graph. A dependency
+ * declared and never imported is `check-unused-deps`'s job, so nothing here
+ * reads `deno.jsonc`.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { walk } from "@std/fs/walk";
+import { fromFileUrl, relative } from "@std/path";
+
+const PACKAGE_ROOT = fromFileUrl(new URL("..", import.meta.url));
+
+/**
+ * The non-relative specifiers a shipped source in this package may name.
+ *
+ * An allowlist rather than a list of banned names, so that a dependency
+ * arriving from a direction nobody anticipated is caught too: a provider SDK,
+ * a `node:` module, `@commonfabric/runner`, an HTTP library. Adding an entry
+ * here is the review checkpoint, and the question it puts is whether a browser
+ * tab may load the thing being added.
+ */
+const ALLOWED = [
+  "@commonfabric/api",
+  "@commonfabric/pure-json",
+  "@commonfabric/utils",
+  "@std/",
+];
+
+/** Is `specifier` relative, or allowed exactly, as a subpath, or by prefix? */
+function isAllowed(specifier: string): boolean {
+  if (specifier.startsWith(".")) return true;
+  return ALLOWED.some((allowed) =>
+    allowed.endsWith("/")
+      ? specifier.startsWith(allowed)
+      : specifier === allowed || specifier.startsWith(`${allowed}/`)
+  );
+}
+
+/**
+ * `source` with its block comments and its whole-line `//` comments removed.
+ *
+ * The scan below reads specifiers out of text, and this package documents
+ * itself with `@example` blocks that contain import statements. Without this
+ * step a comment describing the boundary would trip the check that enforces
+ * it. A `//` following code on the same line is left alone, so a URL in a
+ * string keeps its double slash.
+ */
+function withoutComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/^[ \t]*\/\/.*$/gm, "");
+}
+
+/**
+ * Every module specifier `source` imports.
+ *
+ * Reading the text rather than the module graph means a specifier assembled at
+ * run time is not seen. The error runs one way: what is missed is reported as
+ * allowed, never the reverse.
+ */
+function importedSpecifiers(source: string): string[] {
+  const pattern = /(?:from|import)\s*\(?\s*["']([^"']+)["']/g;
+  return [...withoutComments(source).matchAll(pattern)].map((match) =>
+    match[1]
+  );
+}
+
+/**
+ * Every repository path a Markdown document cites, each with the directory it
+ * is written relative to.
+ *
+ * Two forms carry a path. A backticked one is written from the repository
+ * root, the way prose names a file. A link target is written from the
+ * document, and is matched whether or not it opens with a `./` — omitting that
+ * is the ordinary way to link a sibling, and a check that skipped those would
+ * be blind to a document's own neighborhood. A target carrying a colon is a
+ * URL and belongs to no directory here.
+ */
+function citedPaths(
+  markdown: string,
+): { path: string; relativeTo: "repo" | "document" }[] {
+  const cited = new Map<string, "repo" | "document">();
+  const backticked = /`((?:packages|docs|tasks|scripts)\/[^`\s]+)`/g;
+  for (const match of markdown.matchAll(backticked)) {
+    cited.set(match[1], "repo");
+  }
+  const linked = /\]\(([^)#\s:]+)\)/g;
+  for (const match of markdown.matchAll(linked)) {
+    if (match[1].startsWith("/")) continue;
+    if (!cited.has(match[1])) cited.set(match[1], "document");
+  }
+  return [...cited].map(([path, relativeTo]) => ({ path, relativeTo }));
+}
+
+/** The package's shipped sources: its TypeScript, minus its tests. */
+async function readShippedSources(): Promise<{ path: string; text: string }[]> {
+  const sources: { path: string; text: string }[] = [];
+  for await (
+    const entry of walk(PACKAGE_ROOT, { includeDirs: false, exts: [".ts"] })
+  ) {
+    const path = relative(PACKAGE_ROOT, entry.path);
+    if (path.endsWith(".test.ts")) continue;
+    sources.push({ path, text: await Deno.readTextFile(entry.path) });
+  }
+  return sources;
+}
+
+describe("package-boundary", () => {
+  describe("readShippedSources()", () => {
+    it("returns the package's sources and omits its tests", async () => {
+      const paths = (await readShippedSources()).map(({ path }) => path);
+      expect(paths).toContain("src/client.ts");
+      expect(paths).toContain("src/types.ts");
+      expect(paths).not.toContain("src/client.test.ts");
+    });
+  });
+
+  describe("importedSpecifiers()", () => {
+    it("returns a specifier imported by a statement", () => {
+      expect(importedSpecifiers(`import { a } from "@commonfabric/api";`))
+        .toEqual(["@commonfabric/api"]);
+    });
+
+    it("returns a specifier whose statement spans several lines", () => {
+      expect(importedSpecifiers(`import {\n  a,\n} from "ai";`)).toEqual([
+        "ai",
+      ]);
+    });
+
+    it("returns nothing for an import inside a doc comment", () => {
+      expect(importedSpecifiers(`/**\n * import { a } from "ai";\n */`))
+        .toEqual([]);
+    });
+
+    it("returns nothing for a commented-out import", () => {
+      expect(importedSpecifiers(`  // import { a } from "ai";`)).toEqual([]);
+    });
+
+    it("keeps a URL that carries a double slash", () => {
+      expect(importedSpecifiers(`const u = "https://x/y";\nimport "ai";`))
+        .toEqual(["ai"]);
+    });
+  });
+
+  describe("shipped sources", () => {
+    it("name only specifiers this package is allowed to depend on", async () => {
+      const offenses: string[] = [];
+      for (const { path, text } of await readShippedSources()) {
+        for (const specifier of importedSpecifiers(text)) {
+          if (!isAllowed(specifier)) {
+            offenses.push(`${path} imports ${specifier}`);
+          }
+        }
+      }
+      expect(offenses).toEqual([]);
+    });
+  });
+
+  describe("citedPaths()", () => {
+    it("returns a backticked path as written from the repository root", () => {
+      expect(citedPaths("see `packages/llm/src/types.ts` for it"))
+        .toEqual([{ path: "packages/llm/src/types.ts", relativeTo: "repo" }]);
+    });
+
+    it("returns a link target that omits its leading `./`", () => {
+      expect(citedPaths("[types](src/types.ts)"))
+        .toEqual([{ path: "src/types.ts", relativeTo: "document" }]);
+    });
+
+    it("returns a link target that climbs out of the directory", () => {
+      expect(citedPaths("[m](../toolshed/routes/ai/llm/models.ts)")).toEqual([
+        { path: "../toolshed/routes/ai/llm/models.ts", relativeTo: "document" },
+      ]);
+    });
+
+    it("returns nothing for a URL or a bare anchor", () => {
+      expect(citedPaths("[a](https://example.invalid/x) [b](#section)"))
+        .toEqual([]);
+    });
+  });
+
+  describe("README.md", () => {
+    it("cites only repository paths that exist", async () => {
+      const cited = citedPaths(
+        await Deno.readTextFile(`${PACKAGE_ROOT}/README.md`),
+      );
+      expect(cited.length).toBeGreaterThan(0);
+      const missing: string[] = [];
+      for (const { path, relativeTo } of cited) {
+        const base = relativeTo === "repo"
+          ? `${PACKAGE_ROOT}/../..`
+          : PACKAGE_ROOT;
+        try {
+          await Deno.stat(`${base}/${path}`);
+        } catch {
+          missing.push(path);
+        }
+      }
+      expect(missing).toEqual([]);
+    });
+  });
+});

--- a/packages/toolshed/README.md
+++ b/packages/toolshed/README.md
@@ -42,6 +42,16 @@ toolshed/
 └── index.ts      # Main hono entry point
 ```
 
+### The LLM provider abstraction
+
+The model catalog, the aliases, the capability records, the provider clients,
+and the chain that decides what `default` means are all in
+[`routes/ai/llm/models.ts`](routes/ai/llm/models.ts). `@commonfabric/llm` is the
+caller's side of that boundary and holds none of it: it names a model and posts
+the request here.
+[`docs/features/llm-provider-boundary.md`](../../docs/features/llm-provider-boundary.md)
+gives the reasoning.
+
 ### Gateway request provenance
 
 The LLM gateway attributes its spend by what a caller says about itself, so the

--- a/packages/toolshed/routes/ai/llm/models.ts
+++ b/packages/toolshed/routes/ai/llm/models.ts
@@ -1,3 +1,16 @@
+/**
+ * The provider abstraction for language models: the model catalog, the
+ * aliases, the capability records, the provider clients, and the chain that
+ * decides what `default` means. A request names a model; this is where that
+ * name becomes a provider to call.
+ *
+ * Which models a deployment has depends on the credentials it was configured
+ * with and, for the gateway's, on what the gateway answers when asked. Both
+ * are known only to this process, which is what keeps the catalog here rather
+ * than in the caller's package. `docs/features/llm-provider-boundary.md` sets
+ * out the boundary, and `packages/llm/README.md` redirects a reader who looked
+ * in the caller's package first.
+ */
 import { anthropic, createAnthropic } from "@ai-sdk/anthropic";
 import { createVertex, vertex } from "@ai-sdk/google-vertex";
 import { createGroq, groq } from "@ai-sdk/groq";


### PR DESCRIPTION
Everyone who needs the model catalog looks in `packages/llm` first. It is not there. The model definitions, the aliases, the capability records, the provider clients, and the chain that decides what `default` means are all in `packages/toolshed/routes/ai/llm/models.ts`, and nothing in `packages/llm` said so. The package had no README at all, so opening the directory told a reader only that it holds an HTTP client and some types.

The division is correct and this change signposts rather than migrates. The reason that reaches the whole catalog is that the catalog is not a constant: which models a deployment has is decided by the credentials it was configured with and by what the gateway answers when the toolshed asks it, so the true list exists only at run time and only in the server. A copy shipped to a caller would be a guess, and the callers that need the list already fetch `GET /api/ai/llm/models` rather than importing one. Two narrower facts fence off the provider clients specifically: Anthropic, Groq, and OpenAI register behind an API key from the toolshed's environment while Vertex registers behind a path to a credentials file, and the AI SDK the clients are built from is declared in the toolshed's own configuration alone. The gateway is the case that shows the shape, since its block is gated on a URL rather than a key and authenticates with a placeholder: what keeps it server-side is not secrecy but that only the server can discover what it offers.

`packages/llm` gains a README that names the catalog's home in its second heading and summarizes why. A new
`docs/features/llm-provider-boundary.md` carries the argument in full, along with how `resolveModel` and `whenModelsReady` differ, and a section recording the two places the division leaks. `models.ts` gains a file header saying the reader has arrived at the provider abstraction. The toolshed README and the configuration reference link to the new document.

Two rules govern what the caller's package may depend on, and a different check keeps each. It is loaded into a browser worker through `@commonfabric/runner` and `runtime-client`, so nothing a browser tab may not load belongs there; the new
`packages/llm/test/package-boundary.test.ts` reads its sources against an allowlist of permitted specifiers, which catches a provider SDK, a `node:` module, an `npm:`-qualified specifier, and any dependency nobody thought to ban. Importing `@commonfabric/runner` back would instead close a package cycle, and the repo-wide `deno task check-package-cycles` owns that one, judging it against the real module graph.

One stale comment is corrected on the way past. The note on `DEFAULT_MODEL_NAME` described a two-entry fallback chain that has had three entries for some time, and named an outcome the code cannot produce. It now points at `DEFAULT_MODEL_CANDIDATES` instead of restating it, which is what let it drift.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6870?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

