### PR TITLE
perf(cli): defer the space root until first use

### DIFF
--- a/docs/features/authorization-failure-surfacing.md
+++ b/docs/features/authorization-failure-surfacing.md
@@ -85,14 +85,22 @@ changing what the sync barrier does:
 
 ## CLI: surface the denial for the space it was asked to reach
 
-The CLI waits on storage sync in three places — `loadPieces`, the ACL
-operations, and the headless wish read — and none uses a wall-clock guard. Each
-calls `synced()`, then reads `storageManager.authorizationError(space)` for the
-one space it operates on, after that space has been pulled, and throws the real
-`AuthorizationError` when it is set. The ACL check runs after the ACL read or
-write, since that access is what opens and pulls the space; the wish check reads
-only its own space, so a denied cross-space profile load stays the expected "no
-profile yet" absent read.
+The CLI reads `storageManager.authorizationError(space)` for the one space it
+operates on and throws the real `AuthorizationError` when it is set, at three
+places, and none uses a wall-clock guard. They differ in what establishes the
+verdict first:
+
+- `loadPieces` authenticates the space session when the connection opens
+  (`ensureSpaceSession()`), then checks. It does not sync the space cell: by
+  default the space record stays unread until an operation addresses it, so a
+  denial surfaces from the session open itself. A caller that passes
+  `deferSpaceCellSync: false` gets the older eager `synced()` before the same
+  check.
+- The ACL operations check after the ACL read or write, since that access is
+  what pulls the space and records the verdict.
+- The headless wish read checks after its own space's sync, and reads only that
+  space, so a denied cross-space profile load stays the expected "no profile
+  yet" absent read.
 
 The `newPiece` 60-second bound is unrelated and remains. That hang is a scheduler
 `idle()` park in `getResult(piece).pull()` waiting for a pattern to quiesce — a

--- a/packages/cli/lib/acl.ts
+++ b/packages/cli/lib/acl.ts
@@ -23,7 +23,9 @@ export type AclConnectionDeps = Pick<PieceResolutionDeps, "loadPieces">;
 
 // Open the space and hand an ACLManager to `run`. The ACL document is
 // addressed by the space DID and read through the ACLManager, so the space
-// cell's contents are never needed here and their sync is deferred.
+// cell's contents are never needed here and their sync is deferred. That is
+// now `loadPieces`'s default too; it stays explicit here because the check
+// below depends on it, not on whatever the default happens to be.
 async function withAcl<T>(
   config: SpaceConfig,
   run: (acl: ACLManager) => Promise<T>,

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -575,10 +575,12 @@ export interface ConnectionOutput {
  * controller over it: a space session, a runtime carrying that deployment's
  * experimental options, and a server proven live before it returns.
  *
- * The connection authenticates the space session but leaves the space cell
- * unread until an operation addresses it. Piece IDs, slug documents, and
- * content-addressed pattern artifacts can all be reached without that record;
- * registry and default-pattern operations sync the space cell on demand.
+ * By default the connection authenticates the space session but leaves the
+ * space cell unread until an operation addresses it. Piece IDs, slug documents,
+ * and content-addressed pattern artifacts can all be reached without that
+ * record; registry and default-pattern operations sync the space cell on
+ * demand. `deferSpaceCellSync: false` keeps the eager sync for a caller that
+ * needs the complete space record before this returns.
  *
  * Throws when this process is already connected to a different deployment.
  * The settings a connection writes — the LLM endpoint below among them — are

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -154,6 +154,12 @@ export interface SpaceConfig {
   space: string;
   identity: string;
   jsonOutput?: boolean;
+
+  /**
+   * Whether opening the connection defers reading the space cell until an
+   * operation addresses it. Defaults to `true`; pass `false` when the caller
+   * requires the complete space record before `loadPieces()` returns.
+   */
   deferSpaceCellSync?: boolean;
 
   /**
@@ -569,6 +575,11 @@ export interface ConnectionOutput {
  * controller over it: a space session, a runtime carrying that deployment's
  * experimental options, and a server proven live before it returns.
  *
+ * The connection authenticates the space session but leaves the space cell
+ * unread until an operation addresses it. Piece IDs, slug documents, and
+ * content-addressed pattern artifacts can all be reached without that record;
+ * registry and default-pattern operations sync the space cell on demand.
+ *
  * Throws when this process is already connected to a different deployment.
  * The settings a connection writes — the LLM endpoint below among them — are
  * the process's rather than the connection's, so a process serves one
@@ -684,14 +695,15 @@ export async function loadPieces(
       throw new Error(`Could not connect to "${config.apiUrl.toString()}".`);
     }
 
+    const deferSpaceCellSync = config.deferSpaceCellSync !== false;
     const pieces = await timeCliPhase(
       "loadPieces.controller",
       () =>
         new PiecesController(session, runtime, {
-          deferSpaceCellSync: config.deferSpaceCellSync,
+          deferSpaceCellSync,
         }),
     );
-    if (config.deferSpaceCellSync) {
+    if (deferSpaceCellSync) {
       await timeCliPhase(
         "loadPieces.ensureSpaceSession",
         () => pieces.ensureSpaceSession(),

--- a/packages/cli/test/runtime-creation.test.ts
+++ b/packages/cli/test/runtime-creation.test.ts
@@ -64,12 +64,15 @@ describe("CLI runtime creation", () => {
     await Deno.writeFile(keyPath, identity.toPkcs8());
     const originalHealthCheck = Runtime.prototype.healthCheck;
     const originalGetSpaceCell = Runtime.prototype.getSpaceCell;
+    const originalEnsureSpaceSession =
+      PiecesController.prototype.ensureSpaceSession;
     const originalSynced = PiecesController.prototype.synced;
     let manager: PiecesController | undefined;
     Runtime.prototype.healthCheck = () => Promise.resolve(true);
     Runtime.prototype.getSpaceCell = function () {
       return { sync: () => Promise.resolve() } as any;
     };
+    PiecesController.prototype.ensureSpaceSession = () => Promise.resolve();
     PiecesController.prototype.synced = () => Promise.resolve();
 
     try {
@@ -111,6 +114,8 @@ describe("CLI runtime creation", () => {
     } finally {
       Runtime.prototype.healthCheck = originalHealthCheck;
       Runtime.prototype.getSpaceCell = originalGetSpaceCell;
+      PiecesController.prototype.ensureSpaceSession =
+        originalEnsureSpaceSession;
       PiecesController.prototype.synced = originalSynced;
       if (manager) {
         await (manager.runtime.storageManager as unknown as {
@@ -122,7 +127,7 @@ describe("CLI runtime creation", () => {
     }
   });
 
-  it("authenticates a deferred manager without syncing its space cell", async () => {
+  it("defers the space cell by default and admits an eager override", async () => {
     const identity = await Identity.fromPassphrase(
       "piece manager deferred sync test",
       { implementation: "noble" },
@@ -163,19 +168,19 @@ describe("CLI runtime creation", () => {
         await loadPieces({
           apiUrl: "https://toolshed.test",
           identity: keyPath,
-          space: "piece-manager-eager-sync",
+          space: "piece-manager-deferred-sync",
         }),
       );
-      expect(spaceCellSyncCalls).toBe(1);
-      expect(spaceSessionCalls).toBe(0);
-      expect(managerSyncCalls).toBe(1);
+      expect(spaceCellSyncCalls).toBe(0);
+      expect(spaceSessionCalls).toBe(1);
+      expect(managerSyncCalls).toBe(0);
 
       managers.push(
         await loadPieces({
           apiUrl: "https://toolshed.test",
           identity: keyPath,
-          space: "piece-manager-deferred-sync",
-          deferSpaceCellSync: true,
+          space: "piece-manager-eager-sync",
+          deferSpaceCellSync: false,
         }),
       );
       expect(spaceCellSyncCalls).toBe(1);

--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -297,6 +297,11 @@ export class PiecesController<T = unknown> {
        * Open the space's session without syncing the space cell's contents. A
        * caller that reaches pieces by id, and never reads the space record,
        * does not need those contents.
+       *
+       * Defaults to `false` here: `initialize` syncs the space cell before it
+       * returns. The CLI's `loadPieces` defaults the same option to `true`,
+       * so a caller moving between the two surfaces should pass it
+       * explicitly rather than carry one default across to the other.
        */
       deferSpaceCellSync?: boolean;
 


### PR DESCRIPTION
## Summary

- authenticate the requested space when `loadPieces()` opens, but defer reading the complete space root until an operation addresses it
- make the lazy path the CLI-wide default while retaining `deferSpaceCellSync: false` for callers that require an eager root
- keep root-dependent registry and default-pattern operations unchanged; they already synchronize their addressed cells on demand

## Evidence

- `deno fmt --check packages/cli/lib/piece.ts packages/cli/test/runtime-creation.test.ts`
- `deno lint packages/cli/lib/piece.ts packages/cli/test/runtime-creation.test.ts`
- `deno task check`
- CLI package: 1,776 tests passed; the two ambient `NO_COLOR=1` failures passed separately with the color-test environment restored
- live Estuary trace: session authorization completed in ~171 ms and direct piece/path operations proceeded without a `loadPieces.synced` root phase (historically ~849 ms in the same investigation)

## Dependency

Stacked on #6863 so it can reuse the runtime-start tracing and deferred-controller support. The base can move to `main` after #6863 merges.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6871?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

