### PR TITLE
fix(cf-harness): a withheld release is its own outcome, not a denied call (CT-2232)

### DIFF
--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -1419,16 +1419,20 @@ Whichever way it went, the measurement is also a decision in the run's
 as: `cfc_release_allowed` where the ceiling admitted the values,
 `cfc_release_observed` where a rung below enforcement measured a refusal it did
 not act on, `cfc_release_withheld` where it did, and `cfc_commit_refused` for
-the other boundary, a commit the runner refused. The decision carries a
-`release` record — the boundary, the sink and ceiling the flow was fitted
-against, and the refusal with its attribution — beside the reference to the tool
-output it decided about. It is appended AFTER the allow-side decision for the
-same call, because that decision answers whether the call may run and is
-recorded before it does; a boundary that refuses inside the call cannot appear
-there at all. A call that asks for no values makes no release decision, since
-nothing was measured. Nothing of this reaches the model: the refusal already
-reaches it as `valueError` and `policyRefusal`, and the trace is where an
-operator reads it.
+the other boundary, a commit the runner refused. Each states its own outcome:
+`allowed`, `warned`, `withheld`, and `denied` in that order, counted in the
+trace's `decisionCounts` under those names. `withheld` is its own outcome
+because the call ran and answered with the reference to the result whose values
+were held back; `denied` names a call that did not run, which is what a refused
+commit is. The decision carries a `release` record — the boundary, the sink and
+ceiling the flow was fitted against, and the refusal with its attribution —
+beside the reference to the tool output it decided about. It is appended AFTER
+the allow-side decision for the same call, because that decision answers whether
+the call may run and is recorded before it does; a boundary that refuses inside
+the call cannot appear there at all. A call that asks for no values makes no
+release decision, since nothing was measured. Nothing of this reaches the model:
+the refusal already reaches it as `valueError` and `policyRefusal`, and the
+trace is where an operator reads it.
 
 A result that settles to nothing names its cause when one was observed: when the
 settled result fails the declared `resultSchema` or holds no fields of its own
@@ -2132,7 +2136,7 @@ event or a typed deny observation.
 A release refusal is also not a denied CALL, and AUD-4 leaves it alone for that
 reason: the call completed and answered with a reference to the result whose
 values it withheld, so there is no denied call for the typed deny channel to
-carry.
+carry. Its decision records the outcome `withheld` for the same reason.
 
 AUD-16 reports `inconclusive` where a run's policy decisions could not be read
 from the trace, the run report, or the run state — missing, unparseable, or

--- a/packages/cf-harness/console/README.md
+++ b/packages/cf-harness/console/README.md
@@ -485,7 +485,8 @@ record of what the run recorded rather than a cell with nothing to hide.
 - **Timeline** — the run step by step, scrubbed with arrow keys or the slider. A
   tool call and the result answering it are one step. A coloured dot on each
   step in the rail says how it turned out: green for a result the tool called
-  `ok`, red for one it called an error, amber for a call CFC denied.
+  `ok`, red for one it called an error, amber for a call CFC denied. A call
+  whose result CFC withheld the values of is green: it ran and answered.
 
   A step leads with what it was given and what it holds, and the payloads come
   after:
@@ -496,11 +497,15 @@ record of what the run recorded rather than a cell with nothing to hide.
     leads back to the step that produced it; both spellings resolve alike, since
     `run_pattern` takes a `cfh:a:` token or a whole link and they name one cell.
     A plain value says it is a value.
-  - **cfc** — the decision recorded for that call: allowed or denied, its effect
-    class, and the reason codes behind it. A policy event appears beside it,
-    which is how a call CFC _allowed_ but whose _observation_ it refused reads
-    as the two separate facts it is. The flow labels the runtime computed for
-    each input position appear here too.
+  - **cfc** — the decision recorded for that call: allowed, denied, or withheld,
+    its effect class, and the reason codes behind it. A withheld decision is a
+    confidentiality boundary holding back the values of a result the call did
+    return, so the count of the positions it held back sits beside it and the
+    step itself stays the success its answer states; the dot goes amber only for
+    a call that did not run. A policy event appears beside the decision, which
+    is how a call CFC _allowed_ but whose _observation_ it refused reads as the
+    two separate facts it is. The flow labels the runtime computed for each
+    input position appear here too.
   - **disclosure** — how many bytes the result let across as a plain value, how
     many positions it sealed behind a reference, and the longest run of numbers
     it carried. A long numeric run is called out, in the rail as well: the

--- a/packages/cf-harness/console/public/styles/console.css
+++ b/packages/cf-harness/console/public/styles/console.css
@@ -658,6 +658,11 @@ button[disabled] {
   overflow-wrap: anywhere;
 }
 
+.cfc-withheld {
+  color: #b54708;
+  font-size: 0.8rem;
+}
+
 /* The run rail holds long task titles; it must not set the column width. */
 .run-list {
   min-width: 0;

--- a/packages/cf-harness/console/src/steps-view.ts
+++ b/packages/cf-harness/console/src/steps-view.ts
@@ -373,7 +373,11 @@ export class ConsoleSteps extends LitElement {
     `;
   }
 
-  /** What CFC decided about this call, and any event it raised. */
+  /**
+   * What CFC decided about this call, and any event it raised. A withheld
+   * release carries the retrospective's count of the positions it held back,
+   * which is what says the call itself succeeded.
+   */
   #policy(step: ConsoleStep): TemplateResult | typeof nothing {
     const labelEntries = step.invocation?.cfcInputLabels?.entries ?? [];
     if (
@@ -390,7 +394,8 @@ export class ConsoleSteps extends LitElement {
             <span
               class="badge ${step.policy.decision === "denied"
                 ? "denied"
-                : step.policy.decision === "invalid"
+                : step.policy.decision === "invalid" ||
+                    step.policy.decision === "withheld"
                 ? "warn"
                 : "ok"}"
             >${step.policy.decision}</span>
@@ -400,6 +405,11 @@ export class ConsoleSteps extends LitElement {
             <span class="cfc-reasons">
               ${step.policy.reasonCodes.join(", ")}
             </span>
+            ${step.policy.decision === "withheld"
+              ? html`
+                <span class="cfc-withheld">${withheldSummary(step)}</span>
+              `
+              : nothing}
           </div>
         `} ${step.policyEvents.map((event) =>
           html`

--- a/packages/cf-harness/console/steps.ts
+++ b/packages/cf-harness/console/steps.ts
@@ -446,6 +446,10 @@ const statusOf = (
   if (decision?.decision === "invalid") {
     return "error";
   }
+  // A `withheld` decision is deliberately not read here. The call ran and
+  // answered with the reference to the result whose values the boundary held
+  // back, so the step's outcome is the one its own answer states, below; the
+  // boundary shows as the withheld marker beside the CFC line instead.
   const record = typeof output === "object" && output !== null
     ? output as Record<string, unknown>
     : undefined;

--- a/packages/cf-harness/docs/CURRENT_STATE.md
+++ b/packages/cf-harness/docs/CURRENT_STATE.md
@@ -93,6 +93,12 @@ The current package provides:
   `not-run` tool activity and an `invalid_tool_call` failure record. Only what
   the model cannot correct — transport, engine invariants, artifact persistence,
   cancellation, the turn cap — ends the run;
+- a release a confidentiality boundary refused is recorded as a policy decision
+  with the outcome `withheld` rather than `denied`: the call ran and answered
+  with the reference to the result whose values were held back, so the trace
+  counts it in its own bucket, and the console renders the step as the success
+  its answer states with a withheld marker beside the CFC line. `denied` names a
+  call that did not run;
 - transcript-based resume and durable run artifacts, with retrospective omission
   joins kept outside the transcript and provider context;
 - server-side Responses context compaction with a default threshold derived from

--- a/packages/cf-harness/docs/system-map/cfc-system-map.html
+++ b/packages/cf-harness/docs/system-map/cfc-system-map.html
@@ -669,7 +669,7 @@
     // ------------------------------------------------------------------ layout data
     // The state of this repository the map describes. Bump both when the
     // map is re-verified; the stamp is drawn in the canvas's top-left corner.
-    const SNAPSHOT = { date: "2026-09-03", sha: "220c2567e1" };
+    const SNAPSHOT = { date: "2026-09-04", sha: "38ef88a585" };
     const W = 2760, H = 1840;
     const bands = [
       {
@@ -2191,7 +2191,7 @@
       },
       t8: {
         body:
-          `<p>Every release-boundary decision reaches <code>policy-trace.json</code>: released, observed, values withheld, commit refused, each naming its boundary, sink and ceiling. The ones that refused carry the refusal too — its gates, its atoms, and the input key that carried the label — and a decision that released refuses nothing, so it carries none. Each is appended after the allow-side tool decision for the same call, which the prompt loop records before the tool runs, so the order in the trace is the order the two were decided in. AUD-16 counts the refusals in that channel, and an operator reading policy evidence alone now sees the gate decide.</p>`,
+          `<p>Every release-boundary decision reaches <code>policy-trace.json</code>: released, observed, values withheld, commit refused, each naming its boundary, sink and ceiling. The ones that refused carry the refusal too — its gates, its atoms, and the input key that carried the label — and a decision that released refuses nothing, so it carries none. Each is appended after the allow-side tool decision for the same call, which the prompt loop records before the tool runs, so the order in the trace is the order the two were decided in. A withheld release states the outcome <code>withheld</code>, counted in its own bucket: the call ran and answered with the reference to the result, so the console renders that step as the success its answer states with a withheld marker beside the CFC line, and <code>denied</code> names a call that did not run. AUD-16 counts the refusals in that channel, and an operator reading policy evidence alone now sees the gate decide.</p>`,
         where: ["runner", "artifacts", "audit", "g_release"],
       },
       t9: {

--- a/packages/cf-harness/src/contracts/policy-refusal.ts
+++ b/packages/cf-harness/src/contracts/policy-refusal.ts
@@ -182,16 +182,23 @@ export interface HarnessReleaseDecision {
 }
 
 /**
- * The decision a reason code states, which is the whole of the mapping: a
- * withheld release and a refused commit rejected, an observed one did not.
+ * The decision a reason code states, which is the whole of the mapping.
+ *
+ * A withheld release has its own outcome because the call it belongs to ran
+ * and answered: the result exists in the space under its own labels and the
+ * caller holds its reference, with only the values held back. `denied` is
+ * what a call that did not run gets, which is what a refused commit is — the
+ * runner refused the write, so no result landed.
  */
 export const harnessReleaseDecisionOutcome = (
   reasonCode: HarnessReleaseDecisionReasonCode,
-): "allowed" | "warned" | "denied" =>
+): "allowed" | "warned" | "withheld" | "denied" =>
   reasonCode === "cfc_release_allowed"
     ? "allowed"
     : reasonCode === "cfc_release_observed"
     ? "warned"
+    : reasonCode === "cfc_release_withheld"
+    ? "withheld"
     : "denied";
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>

--- a/packages/cf-harness/src/contracts/policy-trace.ts
+++ b/packages/cf-harness/src/contracts/policy-trace.ts
@@ -82,6 +82,12 @@ export interface HarnessPolicyDecisionCounts {
    * field reads it as `?? 0` rather than as a number.
    */
   invalid?: number;
+
+  /**
+   * Results a confidentiality boundary held the values of, on calls that ran
+   * and answered. Read as `?? 0` for the same reason `invalid` is.
+   */
+  withheld?: number;
 }
 
 export interface HarnessPolicyTrace {
@@ -158,6 +164,8 @@ export const countHarnessPolicyDecisions = (
   denied: decisions.filter((decision) => decision.decision === "denied")
     .length,
   invalid: decisions.filter((decision) => decision.decision === "invalid")
+    .length,
+  withheld: decisions.filter((decision) => decision.decision === "withheld")
     .length,
 });
 

--- a/packages/cf-harness/src/contracts/run-report.ts
+++ b/packages/cf-harness/src/contracts/run-report.ts
@@ -30,12 +30,19 @@ import type { HarnessCredentialOwnerRef } from "./run-manifest.ts";
  * which never reached a policy question at all. It is kept in this union so
  * every tool activity carries an outcome, and told apart from `denied` so a
  * malformed call is not counted as a mediated refusal.
+ *
+ * `withheld` is a confidentiality boundary's answer about a call's own
+ * result: the call ran, it answered with the reference to the result, and
+ * only the values were held back. `denied` is reserved for a call that did
+ * not run.
  */
 export type HarnessToolPolicyDecision =
   | "allowed"
   | "warned"
   | "denied"
-  | "invalid";
+  | "invalid"
+  | "withheld";
+
 export type HarnessToolExecutionStatus = "completed" | "failed" | "not-run";
 export type HarnessRunTimelineKind =
   | "run_started"

--- a/packages/cf-harness/test/artifacts.test.ts
+++ b/packages/cf-harness/test/artifacts.test.ts
@@ -596,6 +596,7 @@ Deno.test({
         warned: 0,
         denied: 0,
         invalid: 0,
+        withheld: 0,
       });
       assertEquals(persistedPolicyTrace.decisions[0], {
         type: "cf-harness.policy-decision",
@@ -648,6 +649,7 @@ Deno.test({
         warned: 0,
         denied: 0,
         invalid: 0,
+        withheld: 0,
       });
       assertEquals(persistedReport.policyDecisions, [
         persistedPolicyTrace.decisions[0],
@@ -1642,6 +1644,7 @@ Deno.test({
         warned: 0,
         denied: 1,
         invalid: 0,
+        withheld: 0,
       });
       assertEquals(policyTrace.decisions[0].decision, "denied");
       assertEquals(policyTrace.decisions[0].reasonCodes, [

--- a/packages/cf-harness/test/console/src/steps-view.test.ts
+++ b/packages/cf-harness/test/console/src/steps-view.test.ts
@@ -317,5 +317,44 @@ describe("console/src/steps-view", () => {
       expect(text).toContain("longest numeric run 32");
       expect(text).toContain("Open subagent run");
     });
+
+    it("marks a withheld release beside the CFC line of a step that succeeded", () => {
+      const step: ConsoleStep = {
+        index: 0,
+        kind: "tool",
+        toolName: "run_pattern",
+        toolCallId: "call-1",
+        output: { status: "ok" },
+        handlesIntroduced: [],
+        handlesInScope: [],
+        status: "ok",
+        policy: {
+          decision: "withheld",
+          effectClass: "side-effect",
+          reasonCodes: ["cfc_release_withheld"],
+        },
+        policyEvents: [],
+        withheld: {
+          status: "recorded",
+          locations: [{
+            rule: "artifact-only",
+            artifactPath: "/run/output.json",
+            jsonPointer: "/value",
+            value: "retained",
+            available: true,
+          }],
+        },
+      };
+      const view = new TestConsoleSteps();
+      view.steps = [step];
+
+      const text = templateText(view.view());
+      // The badge names the boundary's own outcome and the marker beside it
+      // counts what the retrospective holds back, so the step reads as the
+      // success it was rather than as a denied call.
+      expect(text).toContain("withheld");
+      expect(text).toContain("withheld from the model \u00b7 1");
+      expect(text).not.toContain("denied");
+    });
   });
 });

--- a/packages/cf-harness/test/console/steps.test.ts
+++ b/packages/cf-harness/test/console/steps.test.ts
@@ -694,6 +694,58 @@ describe("console/steps CFC and disclosure", () => {
     expect(steps[0].policyEvents).toHaveLength(0);
   });
 
+  it("reads a step whose release was withheld as the ok its own answer states", () => {
+    const steps = consoleRunSteps(
+      [
+        call("c1", "run_pattern", { sourceText: "x" }),
+        result("c1", "run_pattern", {
+          status: "ok",
+          resultRef: { outputId: "out-1" },
+          valueError: "the values are withheld; resultRef still names them",
+        }),
+      ],
+      [
+        {
+          type: "cf-harness.policy-decision",
+          sequence: 1,
+          runId: "run-withheld",
+          at: "2026-01-01T00:00:00.000Z",
+          toolActivitySequence: 1,
+          toolCallId: "c1",
+          toolId: "run_pattern",
+          cfcEnforcementMode: "enforce-explicit",
+          decision: "allowed",
+          reasonCodes: ["cfc_enforce_explicit_direct_command"],
+        },
+        {
+          type: "cf-harness.policy-decision",
+          sequence: 2,
+          runId: "run-withheld",
+          at: "2026-01-01T00:00:00.000Z",
+          toolActivitySequence: 1,
+          toolCallId: "c1",
+          toolId: "run_pattern",
+          cfcEnforcementMode: "enforce-explicit",
+          decision: "withheld",
+          reasonCodes: ["cfc_release_withheld"],
+          release: {
+            reasonCode: "cfc_release_withheld",
+            boundary: "release",
+            sink: "run_pattern",
+            ceiling: [],
+          },
+        },
+      ],
+    );
+
+    // The call ran and answered with the reference to its result, so the step
+    // is the success its answer states; the boundary shows as the decision the
+    // CFC line carries, and not as a denial of the call.
+    expect(steps[0].status).toBe("ok");
+    expect(steps[0].policy?.decision).toBe("withheld");
+    expect(steps[0].policy?.reasonCodes).toEqual(["cfc_release_withheld"]);
+  });
+
   it("measures the longest numeric run a result let across as value", () => {
     const bytes = Array.from({ length: 40 }, (_, index) => index);
     const steps = consoleRunSteps([

--- a/packages/cf-harness/test/run-pattern-policy-trace.test.ts
+++ b/packages/cf-harness/test/run-pattern-policy-trace.test.ts
@@ -250,8 +250,12 @@ describe("run_pattern release decisions in the policy trace", () => {
       expect(allowSide.decision).toBe("allowed");
       expect(allowSide.release).toBeUndefined();
       expect(release.sequence).toBeGreaterThan(allowSide.sequence);
-      expect(release.decision).toBe("denied");
+      // The outcome and the reason code state one fact and are read together:
+      // an operator counting withheld releases off the outcome and an audit
+      // keying on the reason code must not be able to disagree.
+      expect(release.decision).toBe("withheld");
       expect(release.reasonCodes).toEqual(["cfc_release_withheld"]);
+      expect(release.release?.reasonCode).toBe("cfc_release_withheld");
       expect(release.release?.boundary).toBe("release");
       expect(release.release?.sink).toBe("run_pattern");
       expect(release.release?.ceiling).toEqual([]);
@@ -264,7 +268,10 @@ describe("run_pattern release decisions in the policy trace", () => {
       // The decision joins to the artifact it decided about.
       expect(release.resultRef?.toolId).toBe("run_pattern");
       expect(release.resultRef?.artifactPath).toContain("tool-outputs");
-      expect(trace.decisionCounts.denied).toBe(1);
+      // The call ran and answered with the reference to its result, so nothing
+      // here was denied.
+      expect(trace.decisionCounts.withheld).toBe(1);
+      expect(trace.decisionCounts.denied).toBe(0);
       const releaseRef = release.resultRef;
       if (releaseRef?.artifactPath === undefined) {
         throw new Error("expected release decision artifact reference");
@@ -322,16 +329,17 @@ describe("run_pattern release decisions in the policy trace", () => {
   });
 
   it("gives each reason code the decision it states", () => {
-    // Two of the four rejected and two did not, and the trace's `denied`,
-    // `warned` and `allowed` counts are read straight off this mapping — an
-    // observed measurement counted as a denial would report an enforcement
-    // that never happened.
+    // The trace's counts are read straight off this mapping. An observed
+    // measurement counted as a denial would report an enforcement that never
+    // happened, and a withheld release counted as one would report a call that
+    // never ran — it ran, and answered with the reference to its result.
+    // Only a refused commit landed no result, which is what `denied` is.
     expect(harnessReleaseDecisionOutcome("cfc_release_allowed"))
       .toBe("allowed");
     expect(harnessReleaseDecisionOutcome("cfc_release_observed"))
       .toBe("warned");
     expect(harnessReleaseDecisionOutcome("cfc_release_withheld"))
-      .toBe("denied");
+      .toBe("withheld");
     expect(harnessReleaseDecisionOutcome("cfc_commit_refused"))
       .toBe("denied");
   });


### PR DESCRIPTION
A `run_pattern` call whose result carries a confidentiality the answer sink does
not admit returns `status: "ok"`, the result handle, and a `valueError` saying
the values are withheld (AH-CFC-18: a handle is not a release). The call ran,
the result exists in the space under its own labels, and the child reads that
correctly and carries on.

The record said otherwise. `harnessReleaseDecisionOutcome` mapped
`cfc_release_withheld` to `denied`, so `decisionCounts.denied` counted it beside
`tool_not_allowed`, the console painted the step with a red DENIED badge over
the tool's own `ok`, and every report read from the trace described the receipt
as denied.

## What changed

- `harnessReleaseDecisionOutcome` answers `withheld` for `cfc_release_withheld`.
  `denied` is left to a call that did not run, which is what `cfc_commit_refused`
  is — the runner refused the write, so no result landed.
- `HarnessToolPolicyDecision` and `HarnessPolicyDecisionCounts` gain `withheld`
  as a sibling of `allowed`, `warned`, `denied` and `invalid`; `total` is the
  decision count, so it sums all five. The `release` field's shape is unchanged,
  and a withheld entry carries `decision: "withheld"` and
  `release.reasonCode: "cfc_release_withheld"` together — pinned in
  `run-pattern-policy-trace.test.ts` so the two cannot drift.
- `console/steps.ts` does not read `withheld` where it reads `invalid`: the step
  takes its status from the tool's own answer, so a withheld release renders
  `ok`. `console/src/steps-view.ts` shows the boundary as a `withheld` badge
  with the retrospective's count of the positions it held back beside it,
  through the `withheldFor` join the step already carries. DENIED — and the
  amber rail dot — stay for a call that did not run.
- Docs in lockstep: the policy-trace vocabulary and the AUD-16 section in
  `packages/cf-harness/README.md`, the Timeline description in
  `console/README.md`, `docs/CURRENT_STATE.md`, and the release-decision entry
  plus `SNAPSHOT` in `docs/system-map/cfc-system-map.html`.
  `docs/IMPLEMENTATION_PROFILE.md` names no decision outcome, so it needed no
  edit — checked rather than assumed.

## Merge order — rebased onto #6872

`packages/cf-harness/audit/` is untouched here. #6872 (CT-2231) landed as
`527c000138`: AUD-16 and `countsAgree` now key on `release.reasonCode` and read
the `withheld` bucket, and a null release entry no longer throws. This branch is
rebased onto that `main`, and `deno task test` in `packages/cf-harness` is
**974 passed, 0 failed** — including
`test/cfc-properties/deny-egress.test.ts` ("records a release refusal in both
channels, and AUD-16 counts the trace"), which passes for the real reason: that
test file is untouched by both PRs and still asserts the verdict is not `fail`
and the message contains `1 release refusal`.

## Live verification

Against the evidence family
`f32f3ed3-85e6-4f22-82f7-8c1da4c87604.subagent.1` from the 2026-09-04 console
rerun, read-only, with each release decision re-derived through the mapping
under test and the transcript run through `consoleRunSteps`:

```
counts { total: 17, allowed: 15, warned: 0, denied: 0, invalid: 0, withheld: 2 }
step 16 run_pattern status: ok decision: withheld | withheld from the model · 5
step 17 run_pattern status: ok decision: withheld | withheld from the model · 5
```

Steps 16 and 17 render `ok` with the withheld marker; the child's counts read
withheld 2, denied 0.

## Gates

Deno 2.9.4. `deno task test` in `packages/cf-harness` (unsandboxed — 23 further
`cli.test.ts`/`prompt-loop.test.ts` failures under the sandbox are its temp-dir
restriction, and all pass unsandboxed), repo-wide `deno fmt --check`,
`deno lint`, `deno task check`, `deno task check-docs`, `check-skill-facts`,
`check-docs-history-index`, `check-conflict-markers`, `check-control-characters`,
`check-command-docs` — all green, verified by exit code.

Linear-issue: Fixes CT-2232

🤖 Generated with [Claude Code](https://claude.com/claude-code)
