### PR TITLE
fix(deno-web-test): remove the run directory after Chrome has gone

### DIFF
--- a/packages/deno-web-test/README.md
+++ b/packages/deno-web-test/README.md
@@ -87,6 +87,20 @@ Finally, run `deno-web-test/cli.ts`, which takes a glob of files to test.
 }
 ```
 
+## The browser's lifetime
+
+Everything a run writes goes into one temporary directory, which the run removes
+as the last thing it does. Chrome recreates the directory `--user-data-dir`
+names, every missing parent included, whenever it writes into it, so the removal
+has to follow the last of Chrome's processes rather than the browser process,
+which the crash handler and the rendering processes outlive.
+
+The harness spawns Chrome itself and attaches astral to the running browser with
+`connect()`. Every process Chrome starts inherits the standard error the browser
+was spawned with, so the read end of that pipe reports end of file once the last
+of them has exited, and spawning the browser here is what keeps that pipe in
+reach. Closing the browser returns on that signal, and the removal follows.
+
 ## Support
 
 Currently only the `Deno.test(string, fn)` signature works. Using other

--- a/packages/deno-web-test/README.md
+++ b/packages/deno-web-test/README.md
@@ -96,10 +96,12 @@ has to follow the last of Chrome's processes rather than the browser process,
 which the crash handler and the rendering processes outlive.
 
 The harness spawns Chrome itself and attaches astral to the running browser with
-`connect()`. Every process Chrome starts inherits the standard error the browser
-was spawned with, so the read end of that pipe reports end of file once the last
-of them has exited, and spawning the browser here is what keeps that pipe in
-reach. Closing the browser returns on that signal, and the removal follows.
+`connect()`. Every process Chrome starts inherits the two pipes the browser was
+spawned with, so their read ends reach end of file once the last of them has
+exited, and spawning the browser here is what keeps those pipes in reach. Both
+are read to the end: what a browser writes says nothing the run acts on, but a
+pipe nobody reads fills up and stops the process writing into it. Closing the
+browser returns on that end of file, and the removal follows.
 
 ## Support
 

--- a/packages/deno-web-test/browser-process.ts
+++ b/packages/deno-web-test/browser-process.ts
@@ -69,7 +69,7 @@ export function standardErrorClosed(child: Deno.ChildProcess): Promise<void> {
  * doing nothing.
  */
 export async function stopBrowserProcess(
-  child: Deno.ChildProcess,
+  child: Pick<Deno.ChildProcess, "kill" | "status">,
   closed: Promise<void>,
 ): Promise<void> {
   try {

--- a/packages/deno-web-test/browser-process.ts
+++ b/packages/deno-web-test/browser-process.ts
@@ -1,0 +1,208 @@
+/**
+ * The browser a run drives: how it is spawned, and how it is stopped in a way
+ * the run can wait out.
+ *
+ * Chrome recreates the directory `--user-data-dir` names, every missing parent
+ * included, whenever it writes into it, and the crash handler and rendering
+ * processes it starts outlive the browser process. Removing the run's
+ * directory while one of those is alive puts the directory back, so the
+ * removal has to follow the last process in the tree, and
+ * `Deno.ChildProcess.status` covers one process.
+ *
+ * Every process in the tree inherits the standard error the browser was
+ * spawned with, so the read end of that pipe reports end of file once the last
+ * of them has exited. The browser is spawned here and astral attached to the
+ * running browser with `connect()`, which is what keeps that pipe in reach.
+ */
+
+import {
+  type Browser as AstralBrowser,
+  connect,
+  generateBinArgs,
+  getBinary,
+  type LaunchOptions,
+  WEBSOCKET_ENDPOINT_REGEX,
+} from "@astral/astral";
+import { isChildProcessGone } from "@commonfabric/integration/astral-adapter";
+
+/** A browser that has started, and how to reach and wait out its tree. */
+type SpawnedBrowser = {
+  /** The browser process. */
+  child: Deno.ChildProcess;
+
+  /** Host and port of the browser's developer-tools endpoint. */
+  endpoint: string;
+
+  /** Resolves once every write end of the browser's standard error is closed. */
+  standardErrorClosed: Promise<void>;
+};
+
+/**
+ * Resolves once every write end of `child`'s standard error has been closed,
+ * discarding everything read from it.
+ *
+ * A process that inherits a pipe holds its write end open until it exits or
+ * closes the descriptor, and a browser closes neither, so for a browser and
+ * everything it starts this is the point at which the last of them has gone.
+ * What is read is discarded rather than left unread because a full pipe blocks
+ * the process writing into it.
+ *
+ * The child has to have been spawned with `stderr: "piped"`, and nothing else
+ * may be reading the stream.
+ */
+export function standardErrorClosed(child: Deno.ChildProcess): Promise<void> {
+  const closed = child.stderr.pipeTo(new WritableStream());
+  // The promise is awaited at the end of the run rather than here, and a
+  // rejection nothing is listening for ends the process where it stands. This
+  // handler is what marks it listened for; `closed` still carries the failure
+  // to whoever awaits it.
+  closed.catch(() => {});
+  return closed;
+}
+
+/**
+ * Kills `child` and returns once every process in its tree has exited.
+ *
+ * `closed` is what `standardErrorClosed()` returned for the same child. A
+ * browser asked to close over the protocol is usually still shutting down when
+ * the kill lands, and is occasionally gone already, which throws rather than
+ * doing nothing.
+ */
+export async function stopBrowserProcess(
+  child: Deno.ChildProcess,
+  closed: Promise<void>,
+): Promise<void> {
+  try {
+    child.kill();
+  } catch (error) {
+    if (!isChildProcessGone(error)) {
+      throw error;
+    }
+  }
+  await closed;
+  await child.status;
+}
+
+/**
+ * Spawns the browser `options` names and reads its standard error up to the
+ * line naming its developer-tools endpoint, handing the rest of that stream to
+ * `standardErrorClosed()`.
+ *
+ * Writes out what the browser printed and throws when it exits before naming
+ * an endpoint.
+ */
+async function spawnBrowser(options: LaunchOptions): Promise<SpawnedBrowser> {
+  const product = options.product ?? "chrome";
+  const binary = options.path ??
+    await getBinary(product, { cache: options.cache });
+  const args = generateBinArgs(product, {
+    launchPresets: options.launchPresets,
+    args: options.args,
+    headless: options.headless,
+  });
+
+  // The profile directory belongs to the run and goes when the run ends. A
+  // launch naming none would reach the profile of the browser the developer
+  // uses, and write into the directory that profile lives in.
+  if (!args.some((argument) => argument.startsWith("--user-data-dir="))) {
+    throw new Error("A browser launch has to name a `--user-data-dir`.");
+  }
+
+  const command = new Deno.Command(binary, { args, stderr: "piped" });
+
+  const child = command.spawn();
+  const reader = child.stderr.getReader();
+  const decoder = new TextDecoder();
+  let printed = "";
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) {
+      break;
+    }
+    printed += decoder.decode(value, { stream: true });
+
+    const endpoint = printed.match(WEBSOCKET_ENDPOINT_REGEX)?.[1];
+    if (endpoint) {
+      reader.releaseLock();
+      return {
+        child,
+        endpoint,
+        standardErrorClosed: standardErrorClosed(child),
+      };
+    }
+  }
+
+  const { code } = await child.status;
+  // `isRetryableAstralLaunchError()` matches the message below exactly to
+  // decide whether the launch is worth another attempt, so what the browser
+  // printed is written out here rather than carried in the error.
+  console.error(`${printed}\nProcess exited with code ${code}`);
+  if (printed.includes("error while loading shared libraries")) {
+    throw new Error(
+      "Your binary refused to boot due to missing system dependencies",
+    );
+  }
+  throw new Error("Your binary refused to boot");
+}
+
+/** A running browser, and the process tree the run can wait out. */
+export class BrowserProcess {
+  #child: Deno.ChildProcess;
+  #standardErrorClosed: Promise<void>;
+  #browser: AstralBrowser;
+
+  /**
+   * Takes the browser process, the promise `standardErrorClosed()` returned
+   * for it, and astral's connection to it. `start()` is what supplies the
+   * three of them.
+   */
+  constructor(
+    child: Deno.ChildProcess,
+    standardErrorClosed: Promise<void>,
+    browser: AstralBrowser,
+  ) {
+    this.#child = child;
+    this.#standardErrorClosed = standardErrorClosed;
+    this.#browser = browser;
+  }
+
+  /** Astral's connection to the browser, which pages are opened through. */
+  get browser(): AstralBrowser {
+    return this.#browser;
+  }
+
+  /**
+   * Closes the browser and returns once every process holding the browser's
+   * standard error has closed it, which is once the last of them has exited.
+   */
+  async close(): Promise<void> {
+    try {
+      await this.#browser.close();
+    } finally {
+      await stopBrowserProcess(this.#child, this.#standardErrorClosed);
+    }
+  }
+
+  /**
+   * Spawns the browser `options` names and connects astral to it. A browser
+   * that starts and then fails to connect is stopped before this throws.
+   */
+  static async start(options: LaunchOptions): Promise<BrowserProcess> {
+    const spawned = await spawnBrowser(options);
+    try {
+      const browser = await connect({
+        endpoint: spawned.endpoint,
+        product: options.product ?? "chrome",
+        userAgent: options.userAgent,
+      });
+      return new BrowserProcess(
+        spawned.child,
+        spawned.standardErrorClosed,
+        browser,
+      );
+    } catch (error) {
+      await stopBrowserProcess(spawned.child, spawned.standardErrorClosed);
+      throw error;
+    }
+  }
+}

--- a/packages/deno-web-test/browser-process.ts
+++ b/packages/deno-web-test/browser-process.ts
@@ -9,10 +9,10 @@
  * removal has to follow the last process in the tree, and
  * `Deno.ChildProcess.status` covers one process.
  *
- * Every process in the tree inherits the standard error the browser was
- * spawned with, so the read end of that pipe reports end of file once the last
- * of them has exited. The browser is spawned here and astral attached to the
- * running browser with `connect()`, which is what keeps that pipe in reach.
+ * Every process in the tree inherits the two pipes the browser was spawned
+ * with, so their read ends reach end of file once the last of them has
+ * exited. The browser is spawned here and astral attached to the running
+ * browser with `connect()`, which is what keeps those pipes in reach.
  */
 
 import {
@@ -21,6 +21,7 @@ import {
   generateBinArgs,
   getBinary,
   type LaunchOptions,
+  type Page,
   WEBSOCKET_ENDPOINT_REGEX,
 } from "@astral/astral";
 import { isChildProcessGone } from "@commonfabric/integration/astral-adapter";
@@ -33,37 +34,32 @@ type SpawnedBrowser = {
   /** Host and port of the browser's developer-tools endpoint. */
   endpoint: string;
 
-  /** Resolves once every write end of the browser's standard error is closed. */
-  standardErrorClosed: Promise<void>;
+  /** Resolves once every write end of the browser's output is closed. */
+  outputClosed: Promise<void>;
 };
 
 /**
- * Resolves once every write end of `child`'s standard error has been closed,
- * discarding everything read from it.
+ * Resolves once every write end of `stream` is closed, discarding everything
+ * read from it.
  *
  * A process that inherits a pipe holds its write end open until it exits or
  * closes the descriptor, and a browser closes neither, so for a browser and
  * everything it starts this is the point at which the last of them has gone.
  * What is read is discarded rather than left unread because a full pipe blocks
  * the process writing into it.
- *
- * The child has to have been spawned with `stderr: "piped"`, and nothing else
- * may be reading the stream.
  */
-export function standardErrorClosed(child: Deno.ChildProcess): Promise<void> {
-  const closed = child.stderr.pipeTo(new WritableStream());
-  // The promise is awaited at the end of the run rather than here, and a
-  // rejection nothing is listening for ends the process where it stands. This
-  // handler is what marks it listened for; `closed` still carries the failure
-  // to whoever awaits it.
-  closed.catch(() => {});
-  return closed;
+export async function readToEnd(
+  stream: ReadableStream<Uint8Array>,
+): Promise<void> {
+  for await (const _chunk of stream) {
+    // The bytes say nothing the run acts on; the end of them says everything.
+  }
 }
 
 /**
  * Kills `child` and returns once every process in its tree has exited.
  *
- * `closed` is what `standardErrorClosed()` returned for the same child. A
+ * `closed` is what `readBrowserOutput()` reported for the same child. A
  * browser asked to close over the protocol is usually still shutting down when
  * the kill lands, and is occasionally gone already, which throws rather than
  * doing nothing.
@@ -84,12 +80,65 @@ export async function stopBrowserProcess(
 }
 
 /**
- * Spawns the browser `options` names and reads its standard error up to the
- * line naming its developer-tools endpoint, handing the rest of that stream to
- * `standardErrorClosed()`.
+ * Reads the browser's standard output and standard error to the end of both,
+ * and reports the developer-tools endpoint named in the latter.
  *
- * Writes out what the browser printed and throws when it exits before naming
- * an endpoint.
+ * The endpoint is reported while the reads carry on, because the pipes are
+ * what say when the browser's processes have gone and a pipe nobody reads
+ * fills up and stops the process writing into it. Output that ends without
+ * naming an endpoint is a browser that never started: it is written out, and
+ * the endpoint fails.
+ */
+function readBrowserOutput(
+  child: Deno.ChildProcess,
+): { endpoint: Promise<string>; closed: Promise<void> } {
+  const endpoint = Promise.withResolvers<string>();
+  const decoder = new TextDecoder();
+  let printed = "";
+  let named = false;
+
+  const readStandardError = (async () => {
+    for await (const chunk of child.stderr) {
+      if (named) {
+        continue;
+      }
+      printed += decoder.decode(chunk, { stream: true });
+      const found = printed.match(WEBSOCKET_ENDPOINT_REGEX)?.[1];
+      if (found) {
+        named = true;
+        endpoint.resolve(found);
+      }
+    }
+    if (!named) {
+      // `isRetryableAstralLaunchError()` matches the message below exactly to
+      // decide whether the launch is worth another attempt, so what the
+      // browser printed is written out here rather than carried in the error.
+      const { code } = await child.status;
+      console.error(`${printed}\nProcess exited with code ${code}`);
+      endpoint.reject(
+        new Error(
+          printed.includes("error while loading shared libraries")
+            ? "Your binary refused to boot due to missing system dependencies"
+            : "Your binary refused to boot",
+        ),
+      );
+    }
+  })();
+
+  const closed = Promise.all([readStandardError, readToEnd(child.stdout)])
+    .then(() => {});
+  // The reads run alongside the tests and are awaited when the browser is
+  // closed. A rejection nothing is listening for in between ends the process
+  // where it stands, so this handler is what marks it listened for; `closed`
+  // still carries the failure to whoever awaits it.
+  closed.catch(() => {});
+
+  return { endpoint: endpoint.promise, closed };
+}
+
+/**
+ * Spawns the browser `options` names and returns once it has named its
+ * developer-tools endpoint, with its output still being read.
  */
 async function spawnBrowser(options: LaunchOptions): Promise<SpawnedBrowser> {
   const product = options.product ?? "chrome";
@@ -108,72 +157,49 @@ async function spawnBrowser(options: LaunchOptions): Promise<SpawnedBrowser> {
     throw new Error("A browser launch has to name a `--user-data-dir`.");
   }
 
-  const command = new Deno.Command(binary, { args, stderr: "piped" });
-
-  const child = command.spawn();
-  const reader = child.stderr.getReader();
-  const decoder = new TextDecoder();
-  let printed = "";
-  while (true) {
-    const { value, done } = await reader.read();
-    if (done) {
-      break;
-    }
-    printed += decoder.decode(value, { stream: true });
-
-    const endpoint = printed.match(WEBSOCKET_ENDPOINT_REGEX)?.[1];
-    if (endpoint) {
-      reader.releaseLock();
-      return {
-        child,
-        endpoint,
-        standardErrorClosed: standardErrorClosed(child),
-      };
-    }
+  const child = new Deno.Command(binary, {
+    args,
+    stdout: "piped",
+    stderr: "piped",
+  }).spawn();
+  const { endpoint, closed } = readBrowserOutput(child);
+  try {
+    return { child, endpoint: await endpoint, outputClosed: closed };
+  } catch (error) {
+    await stopBrowserProcess(child, closed);
+    throw error;
   }
-
-  const { code } = await child.status;
-  // `isRetryableAstralLaunchError()` matches the message below exactly to
-  // decide whether the launch is worth another attempt, so what the browser
-  // printed is written out here rather than carried in the error.
-  console.error(`${printed}\nProcess exited with code ${code}`);
-  if (printed.includes("error while loading shared libraries")) {
-    throw new Error(
-      "Your binary refused to boot due to missing system dependencies",
-    );
-  }
-  throw new Error("Your binary refused to boot");
 }
 
 /** A running browser, and the process tree the run can wait out. */
 export class BrowserProcess {
   #child: Deno.ChildProcess;
-  #standardErrorClosed: Promise<void>;
+  #outputClosed: Promise<void>;
   #browser: AstralBrowser;
 
   /**
-   * Takes the browser process, the promise `standardErrorClosed()` returned
-   * for it, and astral's connection to it. `start()` is what supplies the
-   * three of them.
+   * Takes the browser process, the promise that resolves once its output has
+   * ended, and astral's connection to it. `start()` is what supplies the three
+   * of them.
    */
   constructor(
     child: Deno.ChildProcess,
-    standardErrorClosed: Promise<void>,
+    outputClosed: Promise<void>,
     browser: AstralBrowser,
   ) {
     this.#child = child;
-    this.#standardErrorClosed = standardErrorClosed;
+    this.#outputClosed = outputClosed;
     this.#browser = browser;
   }
 
-  /** Astral's connection to the browser, which pages are opened through. */
-  get browser(): AstralBrowser {
-    return this.#browser;
+  /** Opens a page on `url`. */
+  newPage(url: string): Promise<Page> {
+    return this.#browser.newPage(url);
   }
 
   /**
    * Closes the browser and returns once every process holding the browser's
-   * standard error has closed it, which is once the last of them has exited.
+   * output has closed it, which is once the last of them has exited.
    *
    * The browser is stopped by the signal rather than by astral's `close()`,
    * which asks over the browser's connection and waits for an answer. A
@@ -182,7 +208,7 @@ export class BrowserProcess {
    */
   async close(): Promise<void> {
     try {
-      await stopBrowserProcess(this.#child, this.#standardErrorClosed);
+      await stopBrowserProcess(this.#child, this.#outputClosed);
     } finally {
       await this.#browser.disconnect();
     }
@@ -202,11 +228,11 @@ export class BrowserProcess {
       });
       return new BrowserProcess(
         spawned.child,
-        spawned.standardErrorClosed,
+        spawned.outputClosed,
         browser,
       );
     } catch (error) {
-      await stopBrowserProcess(spawned.child, spawned.standardErrorClosed);
+      await stopBrowserProcess(spawned.child, spawned.outputClosed);
       throw error;
     }
   }

--- a/packages/deno-web-test/browser-process.ts
+++ b/packages/deno-web-test/browser-process.ts
@@ -174,12 +174,17 @@ export class BrowserProcess {
   /**
    * Closes the browser and returns once every process holding the browser's
    * standard error has closed it, which is once the last of them has exited.
+   *
+   * The browser is stopped by the signal rather than by astral's `close()`,
+   * which asks over the browser's connection and waits for an answer. A
+   * browser that has already gone takes that connection with it, and the wait
+   * then has nothing to resolve it.
    */
   async close(): Promise<void> {
     try {
-      await this.#browser.close();
-    } finally {
       await stopBrowserProcess(this.#child, this.#standardErrorClosed);
+    } finally {
+      await this.#browser.disconnect();
     }
   }
 

--- a/packages/deno-web-test/browser.ts
+++ b/packages/deno-web-test/browser.ts
@@ -1,13 +1,7 @@
-import {
-  Browser as AstralBrowser,
-  ConsoleEvent,
-  launch,
-  LaunchOptions,
-  Page,
-} from "@astral/astral";
-import { closeAstralBrowser } from "@commonfabric/integration/astral-adapter";
+import { ConsoleEvent, LaunchOptions, Page } from "@astral/astral";
 import { sleep } from "@commonfabric/utils/sleep";
 
+import { BrowserProcess } from "./browser-process.ts";
 import { DEFAULT_TEST_TIMEOUT_MS, extractAstralConfig } from "./config.ts";
 import { TestResult } from "./interface.ts";
 import { Manifest } from "./manifest.ts";
@@ -17,7 +11,7 @@ const LAUNCH_RETRY_ATTEMPTS = 5;
 const LAUNCH_RETRYABLE_ETXTBSY = "Text file busy (os error 26)";
 const LAUNCH_RETRYABLE_BOOT_FAILURE = "Your binary refused to boot";
 
-type LaunchFn = (options: LaunchOptions) => Promise<AstralBrowser>;
+type LaunchFn = (options: LaunchOptions) => Promise<BrowserProcess>;
 type SleepFn = (ms: number) => Promise<unknown>;
 
 export function isRetryableAstralLaunchError(error: unknown): boolean {
@@ -27,9 +21,9 @@ export function isRetryableAstralLaunchError(error: unknown): boolean {
 
 export async function launchWithRetry(
   options: LaunchOptions,
-  launchImpl: LaunchFn = launch,
+  launchImpl: LaunchFn = BrowserProcess.start,
   sleepImpl: SleepFn = sleep,
-): Promise<AstralBrowser> {
+): Promise<BrowserProcess> {
   for (let attempt = 1; attempt <= LAUNCH_RETRY_ATTEMPTS; attempt++) {
     try {
       return await launchImpl(options);
@@ -51,13 +45,13 @@ export class BrowserController extends EventTarget {
   static readonly #HARNESS_READY_POLL_MS = 200;
   #manifest: Manifest;
   #page: Page | null;
-  #browser: AstralBrowser | null;
+  #process: BrowserProcess | null;
   #serverPort: number;
 
   constructor(manifest: Manifest, serverPort: number) {
     super();
     this.#manifest = manifest;
-    this.#browser = null;
+    this.#process = null;
     this.#page = null;
     this.#serverPort = serverPort;
   }
@@ -73,10 +67,10 @@ export class BrowserController extends EventTarget {
     if (this.#page) {
       await this.#page.goto(testUrl);
     } else {
-      this.#browser = await launchWithRetry(
+      this.#process = await launchWithRetry(
         extractAstralConfig(config, this.#manifest.profileDir),
       );
-      this.#page = await this.#browser.newPage(testUrl);
+      this.#page = await this.#process.browser.newPage(testUrl);
       this.#page.addEventListener("console", (e) => {
         // Not sure why this event needs reconstructed in order
         // to re-fire, rather than just passing it into `dispatchEvent`.
@@ -141,9 +135,9 @@ export class BrowserController extends EventTarget {
 
   async close() {
     this.#page = null;
-    if (this.#browser) {
-      await closeAstralBrowser(this.#browser);
+    if (this.#process) {
+      await this.#process.close();
     }
-    this.#browser = null;
+    this.#process = null;
   }
 }

--- a/packages/deno-web-test/browser.ts
+++ b/packages/deno-web-test/browser.ts
@@ -70,7 +70,7 @@ export class BrowserController extends EventTarget {
       this.#process = await launchWithRetry(
         extractAstralConfig(config, this.#manifest.profileDir),
       );
-      this.#page = await this.#process.browser.newPage(testUrl);
+      this.#page = await this.#process.newPage(testUrl);
       this.#page.addEventListener("console", (e) => {
         // Not sure why this event needs reconstructed in order
         // to re-fire, rather than just passing it into `dispatchEvent`.

--- a/packages/deno-web-test/test/BrowserController.test.ts
+++ b/packages/deno-web-test/test/BrowserController.test.ts
@@ -1,0 +1,43 @@
+/**
+ * What `BrowserController` does when it is asked about a page it has not
+ * loaded. The methods that drive a test file each reach for the page the
+ * controller opened in `load()`, and a caller that never loaded one gets a
+ * message saying so rather than a failure inside astral.
+ */
+
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import { BrowserController } from "../browser.ts";
+import { applyDefaults } from "../config.ts";
+import { Manifest } from "../manifest.ts";
+
+// A manifest naming directories nothing here reaches: the controller holds it
+// for its configuration and its profile directory, and neither is read before
+// a page is loaded.
+function unloadedController(): BrowserController {
+  return new BrowserController(
+    new Manifest("/nowhere", [], "/nowhere", applyDefaults({})),
+    0,
+  );
+}
+
+describe("BrowserController", () => {
+  describe("instance members", () => {
+    describe("getTestCount()", () => {
+      it("throws when no page has been loaded", async () => {
+        await expect(unloadedController().getTestCount()).rejects.toThrow(
+          "No page loaded.",
+        );
+      });
+    });
+
+    describe("runNextTest()", () => {
+      it("throws when no page has been loaded", async () => {
+        await expect(unloadedController().runNextTest()).rejects.toThrow(
+          "No page loaded.",
+        );
+      });
+    });
+  });
+});

--- a/packages/deno-web-test/test/browser-process.test.ts
+++ b/packages/deno-web-test/test/browser-process.test.ts
@@ -16,7 +16,7 @@ import { afterEach, describe, it } from "@std/testing/bdd";
 
 import {
   BrowserProcess,
-  standardErrorClosed,
+  readToEnd,
   stopBrowserProcess,
 } from "../browser-process.ts";
 
@@ -109,14 +109,14 @@ describe("browser-process", () => {
     it("ends a running process with `SIGTERM`", async () => {
       const child = shell("read line", { stdin: "piped" });
 
-      await stopBrowserProcess(child, standardErrorClosed(child));
+      await stopBrowserProcess(child, readToEnd(child.stderr));
 
       expect((await child.status).signal).toBe("SIGTERM");
     });
 
     it("returns for a process that has already exited, leaving its exit status intact", async () => {
       const child = shell("exit 0");
-      const closed = standardErrorClosed(child);
+      const closed = readToEnd(child.stderr);
       await child.status;
 
       await stopBrowserProcess(child, closed);
@@ -142,7 +142,7 @@ describe("browser-process", () => {
         stdin: "piped",
         stdout: "piped",
       });
-      const closed = standardErrorClosed(child);
+      const closed = readToEnd(child.stderr);
 
       // `cat` is running by the time the shell has said so, so the kill below
       // takes the shell without taking the holder of the pipe with it.
@@ -185,7 +185,7 @@ describe("browser-process", () => {
             },
           } as unknown as AstralBrowser;
 
-          await new BrowserProcess(child, standardErrorClosed(child), browser)
+          await new BrowserProcess(child, readToEnd(child.stderr), browser)
             .close();
 
           expect(disconnected).toBe(true);

--- a/packages/deno-web-test/test/browser-process.test.ts
+++ b/packages/deno-web-test/test/browser-process.test.ts
@@ -1,0 +1,152 @@
+/**
+ * How a run's browser is stopped, which is what says when the run's directory
+ * can go.
+ *
+ * The two exports covered here are the ones that can be driven without a
+ * browser: a shell process tree stands in for Chrome's, and a shell script
+ * stands in for a browser binary that never starts. What a real browser does
+ * is covered by the harness runs in `base.test.ts`, `config.test.ts` and
+ * `temporary-directories.test.ts`, each of which drives Chrome through
+ * `BrowserProcess`.
+ */
+
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import {
+  BrowserProcess,
+  standardErrorClosed,
+  stopBrowserProcess,
+} from "../browser-process.ts";
+
+// A shell that starts `cat` in the background, says so on its standard output,
+// and then waits. `cat` inherits the standard error the shell was spawned with
+// and holds it until its own standard input reaches end of file, which the
+// test brings about by closing the shell's standard input. The redirection
+// through file descriptor 3 is what gets that pipe to `cat`: a background
+// job's standard input is /dev/null unless it is redirected explicitly.
+const HOLDS_STANDARD_ERROR =
+  "exec 3<&0; cat <&3 >/dev/null & echo started; wait";
+
+// A stand-in for a browser binary: a directory holding a shell script that
+// writes `printed` to its standard error and exits with `code`, never naming
+// an endpoint, and the launch options that point at it. The caller removes the
+// directory.
+async function fakeBrowser(printed: string, code: number): Promise<{
+  directory: string;
+  options: { path: string; args: string[] };
+}> {
+  const directory = await Deno.makeTempDir({ prefix: "deno-web-test-fake-" });
+  const path = `${directory}/browser`;
+  await Deno.writeTextFile(
+    path,
+    `#!/bin/sh\nprintf '%s\\n' '${printed}' >&2\nexit ${code}\n`,
+  );
+  await Deno.chmod(path, 0o755);
+  return {
+    directory,
+    options: { path, args: [`--user-data-dir=${directory}/profile`] },
+  };
+}
+
+describe("browser-process", () => {
+  describe("stopBrowserProcess()", () => {
+    it("ends a running process with `SIGTERM`", async () => {
+      const child = new Deno.Command("sh", {
+        args: ["-c", "read line"],
+        stdin: "piped",
+        stdout: "null",
+        stderr: "piped",
+      }).spawn();
+
+      await stopBrowserProcess(child, standardErrorClosed(child));
+
+      expect((await child.status).signal).toBe("SIGTERM");
+      await child.stdin.close();
+    });
+
+    it("returns for a process that has already exited, leaving its exit status intact", async () => {
+      const child = new Deno.Command("sh", {
+        args: ["-c", "exit 0"],
+        stdout: "null",
+        stderr: "piped",
+      }).spawn();
+      const closed = standardErrorClosed(child);
+      await child.status;
+
+      await stopBrowserProcess(child, closed);
+
+      expect((await child.status).code).toBe(0);
+    });
+
+    it("returns after a process that outlived the one it was given has exited", async () => {
+      const child = new Deno.Command("sh", {
+        args: ["-c", HOLDS_STANDARD_ERROR],
+        stdin: "piped",
+        stdout: "piped",
+        stderr: "piped",
+      }).spawn();
+      const closed = standardErrorClosed(child);
+
+      // `cat` is running by the time the shell has said so, so the kill below
+      // takes the shell without taking the holder of the pipe with it.
+      const stdout = child.stdout.getReader();
+      const started = await stdout.read();
+      expect(new TextDecoder().decode(started.value)).toBe("started\n");
+
+      // Each of the three events reaches the list from the event loop, so a
+      // stop that returned on the shell's exit alone would record itself
+      // between the other two rather than after them.
+      const events: string[] = [];
+      const stopping = stopBrowserProcess(child, closed).then(() => {
+        events.push("stopped");
+      });
+      await child.status;
+      events.push("shell exited");
+      await child.stdin.close();
+      events.push("released");
+      await stopping;
+
+      expect(events).toEqual(["shell exited", "released", "stopped"]);
+      await stdout.cancel();
+    });
+  });
+
+  describe("BrowserProcess", () => {
+    describe("static members", () => {
+      describe("start()", () => {
+        it("throws when the browser exits without naming an endpoint", async () => {
+          const { directory, options } = await fakeBrowser("no endpoint", 1);
+
+          await expect(BrowserProcess.start(options)).rejects.toThrow(
+            "Your binary refused to boot",
+          );
+
+          await Deno.remove(directory, { recursive: true });
+        });
+
+        it("names the missing dependencies a browser reports", async () => {
+          const { directory, options } = await fakeBrowser(
+            "error while loading shared libraries: libnss3.so",
+            127,
+          );
+
+          await expect(BrowserProcess.start(options)).rejects.toThrow(
+            "missing system dependencies",
+          );
+
+          await Deno.remove(directory, { recursive: true });
+        });
+
+        it("throws when the launch names no `--user-data-dir`", async () => {
+          const { directory, options } = await fakeBrowser("no endpoint", 1);
+
+          await expect(BrowserProcess.start({ ...options, args: [] })).rejects
+            .toThrow("--user-data-dir");
+
+          await Deno.remove(directory, { recursive: true });
+        });
+      });
+    });
+  });
+});

--- a/packages/deno-web-test/test/browser-process.test.ts
+++ b/packages/deno-web-test/test/browser-process.test.ts
@@ -10,14 +10,21 @@
  * `BrowserProcess`.
  */
 
+import type { Browser as AstralBrowser } from "@astral/astral";
 import { expect } from "@std/expect";
-import { describe, it } from "@std/testing/bdd";
+import { afterEach, describe, it } from "@std/testing/bdd";
 
 import {
   BrowserProcess,
   standardErrorClosed,
   stopBrowserProcess,
 } from "../browser-process.ts";
+
+// What the tests below made, and what it takes to put each of it away. A test
+// that fails partway through returns through `afterEach` rather than through
+// its own last lines, so registering here is what keeps a directory, a
+// listening socket, or a process from outliving a failure.
+const madeByTest: (() => Promise<void>)[] = [];
 
 // A shell that starts `cat` in the background, says so on its standard output,
 // and then waits. `cat` inherits the standard error the shell was spawned with
@@ -28,13 +35,56 @@ import {
 const HOLDS_STANDARD_ERROR =
   "exec 3<&0; cat <&3 >/dev/null & echo started; wait";
 
-// A developer-tools endpoint that answers `/json/version` with `protocol` as
-// the version it speaks, and the port it listens on. Astral reads that answer
-// before it opens a websocket, so a version it does not speak is a connection
-// that fails at once rather than one that waits.
-function fakeEndpoint(
-  protocol: string,
-): { server: Deno.HttpServer; port: number } {
+// Spawns `script` under `sh` with its standard error piped, and registers the
+// kill and the closing of its standard input.
+function shell(
+  script: string,
+  streams: { stdin?: "piped" | "null"; stdout?: "piped" | "null" } = {},
+): Deno.ChildProcess {
+  const stdin = streams.stdin ?? "null";
+  const child = new Deno.Command("sh", {
+    args: ["-c", script],
+    stdin,
+    stdout: streams.stdout ?? "null",
+    stderr: "piped",
+  }).spawn();
+  madeByTest.push(async () => {
+    try {
+      child.kill();
+    } catch {
+      // Already gone, which is where most of these tests leave it.
+    }
+    if (stdin === "piped") {
+      await child.stdin.close().catch(() => {});
+    }
+    await child.status;
+  });
+  return child;
+}
+
+// Launch options naming a stand-in for a browser binary: a shell script that
+// writes `printed` to its standard error and exits with `code`, never naming
+// an endpoint. The directory holding it is registered for removal.
+async function fakeBrowser(
+  printed: string,
+  code: number,
+): Promise<{ path: string; args: string[] }> {
+  const directory = await Deno.makeTempDir({ prefix: "deno-web-test-fake-" });
+  madeByTest.push(() => Deno.remove(directory, { recursive: true }));
+  const path = `${directory}/browser`;
+  await Deno.writeTextFile(
+    path,
+    `#!/bin/sh\nprintf '%s\\n' '${printed}' >&2\nexit ${code}\n`,
+  );
+  await Deno.chmod(path, 0o755);
+  return { path, args: [`--user-data-dir=${directory}/profile`] };
+}
+
+// The port of a developer-tools endpoint that answers `/json/version` with
+// `protocol` as the version it speaks. Astral reads that answer before it
+// opens a websocket, so a version it does not speak is a connection that fails
+// on the answer rather than one that waits for a socket that never opens.
+function fakeEndpoint(protocol: string): number {
   const server = Deno.serve(
     { port: 0, onListen: () => {} },
     () =>
@@ -43,52 +93,29 @@ function fakeEndpoint(
         webSocketDebuggerUrl: "ws://127.0.0.1:1/devtools/browser/none",
       }),
   );
-  return { server, port: (server.addr as Deno.NetAddr).port };
-}
-
-// A stand-in for a browser binary: a directory holding a shell script that
-// writes `printed` to its standard error and exits with `code`, never naming
-// an endpoint, and the launch options that point at it. The caller removes the
-// directory.
-async function fakeBrowser(printed: string, code: number): Promise<{
-  directory: string;
-  options: { path: string; args: string[] };
-}> {
-  const directory = await Deno.makeTempDir({ prefix: "deno-web-test-fake-" });
-  const path = `${directory}/browser`;
-  await Deno.writeTextFile(
-    path,
-    `#!/bin/sh\nprintf '%s\\n' '${printed}' >&2\nexit ${code}\n`,
-  );
-  await Deno.chmod(path, 0o755);
-  return {
-    directory,
-    options: { path, args: [`--user-data-dir=${directory}/profile`] },
-  };
+  madeByTest.push(() => server.shutdown());
+  return (server.addr as Deno.NetAddr).port;
 }
 
 describe("browser-process", () => {
+  afterEach(async () => {
+    const made = madeByTest.splice(0).reverse();
+    for (const putAway of made) {
+      await putAway();
+    }
+  });
+
   describe("stopBrowserProcess()", () => {
     it("ends a running process with `SIGTERM`", async () => {
-      const child = new Deno.Command("sh", {
-        args: ["-c", "read line"],
-        stdin: "piped",
-        stdout: "null",
-        stderr: "piped",
-      }).spawn();
+      const child = shell("read line", { stdin: "piped" });
 
       await stopBrowserProcess(child, standardErrorClosed(child));
 
       expect((await child.status).signal).toBe("SIGTERM");
-      await child.stdin.close();
     });
 
     it("returns for a process that has already exited, leaving its exit status intact", async () => {
-      const child = new Deno.Command("sh", {
-        args: ["-c", "exit 0"],
-        stdout: "null",
-        stderr: "piped",
-      }).spawn();
+      const child = shell("exit 0");
       const closed = standardErrorClosed(child);
       await child.status;
 
@@ -111,17 +138,16 @@ describe("browser-process", () => {
     });
 
     it("returns after a process that outlived the one it was given has exited", async () => {
-      const child = new Deno.Command("sh", {
-        args: ["-c", HOLDS_STANDARD_ERROR],
+      const child = shell(HOLDS_STANDARD_ERROR, {
         stdin: "piped",
         stdout: "piped",
-        stderr: "piped",
-      }).spawn();
+      });
       const closed = standardErrorClosed(child);
 
       // `cat` is running by the time the shell has said so, so the kill below
       // takes the shell without taking the holder of the pipe with it.
       const stdout = child.stdout.getReader();
+      madeByTest.push(() => stdout.cancel());
       const started = await stdout.read();
       expect(new TextDecoder().decode(started.value)).toBe("started\n");
 
@@ -139,25 +165,47 @@ describe("browser-process", () => {
       await stopping;
 
       expect(events).toEqual(["shell exited", "released", "stopped"]);
-      await stdout.cancel();
     });
   });
 
   describe("BrowserProcess", () => {
+    describe("instance members", () => {
+      describe("close()", () => {
+        it("returns for a browser that no longer answers", async () => {
+          const child = shell("read line", { stdin: "piped" });
+          // A browser whose connection has gone takes every answer with it,
+          // so nothing it is asked settles. The cast is what lets a stub of
+          // the two members stand in for astral's whole `Browser`.
+          let disconnected = false;
+          const browser = {
+            close: () => new Promise<void>(() => {}),
+            disconnect: () => {
+              disconnected = true;
+              return Promise.resolve();
+            },
+          } as unknown as AstralBrowser;
+
+          await new BrowserProcess(child, standardErrorClosed(child), browser)
+            .close();
+
+          expect(disconnected).toBe(true);
+          expect((await child.status).signal).toBe("SIGTERM");
+        });
+      });
+    });
+
     describe("static members", () => {
       describe("start()", () => {
         it("throws when the browser exits without naming an endpoint", async () => {
-          const { directory, options } = await fakeBrowser("no endpoint", 1);
+          const options = await fakeBrowser("no endpoint", 1);
 
           await expect(BrowserProcess.start(options)).rejects.toThrow(
             "Your binary refused to boot",
           );
-
-          await Deno.remove(directory, { recursive: true });
         });
 
         it("names the missing dependencies a browser reports", async () => {
-          const { directory, options } = await fakeBrowser(
+          const options = await fakeBrowser(
             "error while loading shared libraries: libnss3.so",
             127,
           );
@@ -165,13 +213,11 @@ describe("browser-process", () => {
           await expect(BrowserProcess.start(options)).rejects.toThrow(
             "missing system dependencies",
           );
-
-          await Deno.remove(directory, { recursive: true });
         });
 
         it("stops a browser that starts and then cannot be connected to", async () => {
-          const { server, port } = fakeEndpoint("0.0");
-          const { directory, options } = await fakeBrowser(
+          const port = fakeEndpoint("0.0");
+          const options = await fakeBrowser(
             `DevTools listening on ws://127.0.0.1:${port}/devtools/browser/x`,
             0,
           );
@@ -179,18 +225,13 @@ describe("browser-process", () => {
           await expect(BrowserProcess.start(options)).rejects.toThrow(
             "Differing protocol versions",
           );
-
-          await server.shutdown();
-          await Deno.remove(directory, { recursive: true });
         });
 
         it("throws when the launch names no `--user-data-dir`", async () => {
-          const { directory, options } = await fakeBrowser("no endpoint", 1);
+          const options = await fakeBrowser("no endpoint", 1);
 
           await expect(BrowserProcess.start({ ...options, args: [] })).rejects
             .toThrow("--user-data-dir");
-
-          await Deno.remove(directory, { recursive: true });
         });
       });
     });

--- a/packages/deno-web-test/test/browser-process.test.ts
+++ b/packages/deno-web-test/test/browser-process.test.ts
@@ -28,6 +28,24 @@ import {
 const HOLDS_STANDARD_ERROR =
   "exec 3<&0; cat <&3 >/dev/null & echo started; wait";
 
+// A developer-tools endpoint that answers `/json/version` with `protocol` as
+// the version it speaks, and the port it listens on. Astral reads that answer
+// before it opens a websocket, so a version it does not speak is a connection
+// that fails at once rather than one that waits.
+function fakeEndpoint(
+  protocol: string,
+): { server: Deno.HttpServer; port: number } {
+  const server = Deno.serve(
+    { port: 0, onListen: () => {} },
+    () =>
+      Response.json({
+        "Protocol-Version": protocol,
+        webSocketDebuggerUrl: "ws://127.0.0.1:1/devtools/browser/none",
+      }),
+  );
+  return { server, port: (server.addr as Deno.NetAddr).port };
+}
+
 // A stand-in for a browser binary: a directory holding a shell script that
 // writes `printed` to its standard error and exits with `code`, never naming
 // an endpoint, and the launch options that point at it. The caller removes the
@@ -77,6 +95,19 @@ describe("browser-process", () => {
       await stopBrowserProcess(child, closed);
 
       expect((await child.status).code).toBe(0);
+    });
+
+    it("rethrows a kill failure that is not the process having gone", async () => {
+      const refused = new Error("Operation not permitted (os error 1)");
+      const child = {
+        kill: () => {
+          throw refused;
+        },
+        status: Promise.resolve({ success: false, code: 1, signal: null }),
+      };
+
+      await expect(stopBrowserProcess(child, Promise.resolve())).rejects
+        .toThrow("Operation not permitted");
     });
 
     it("returns after a process that outlived the one it was given has exited", async () => {
@@ -135,6 +166,21 @@ describe("browser-process", () => {
             "missing system dependencies",
           );
 
+          await Deno.remove(directory, { recursive: true });
+        });
+
+        it("stops a browser that starts and then cannot be connected to", async () => {
+          const { server, port } = fakeEndpoint("0.0");
+          const { directory, options } = await fakeBrowser(
+            `DevTools listening on ws://127.0.0.1:${port}/devtools/browser/x`,
+            0,
+          );
+
+          await expect(BrowserProcess.start(options)).rejects.toThrow(
+            "Differing protocol versions",
+          );
+
+          await server.shutdown();
           await Deno.remove(directory, { recursive: true });
         });
 

--- a/packages/deno-web-test/test/browser-process.test.ts
+++ b/packages/deno-web-test/test/browser-process.test.ts
@@ -62,22 +62,44 @@ function shell(
   return child;
 }
 
+// More than a pipe holds, so a stand-in that writes this much to its standard
+// output blocks there unless the launch is reading it.
+const OVERFLOWS_A_PIPE =
+  "awk 'BEGIN { for (i = 0; i < 4000; i++) print \"................\" }'";
+
 // Launch options naming a stand-in for a browser binary: a shell script that
-// writes `printed` to its standard error and exits with `code`, never naming
-// an endpoint. The directory holding it is registered for removal.
+// runs `first`, writes `printed` to its standard error, and exits with `code`,
+// never naming an endpoint. The directory holding it is registered for
+// removal.
 async function fakeBrowser(
   printed: string,
   code: number,
+  first = "true",
 ): Promise<{ path: string; args: string[] }> {
   const directory = await Deno.makeTempDir({ prefix: "deno-web-test-fake-" });
   madeByTest.push(() => Deno.remove(directory, { recursive: true }));
   const path = `${directory}/browser`;
   await Deno.writeTextFile(
     path,
-    `#!/bin/sh\nprintf '%s\\n' '${printed}' >&2\nexit ${code}\n`,
+    `#!/bin/sh\n${first}\nprintf '%s\\n' '${printed}' >&2\nexit ${code}\n`,
   );
   await Deno.chmod(path, 0o755);
   return { path, args: [`--user-data-dir=${directory}/profile`] };
+}
+
+// Sets `ASTRAL_BIN_PATH` to `value` for the rest of the test, and registers
+// putting back what was there.
+function astralBinaryPathIs(value: string): void {
+  const had = Deno.env.get("ASTRAL_BIN_PATH");
+  madeByTest.push(() => {
+    if (had === undefined) {
+      Deno.env.delete("ASTRAL_BIN_PATH");
+    } else {
+      Deno.env.set("ASTRAL_BIN_PATH", had);
+    }
+    return Promise.resolve();
+  });
+  Deno.env.set("ASTRAL_BIN_PATH", value);
 }
 
 // The port of a developer-tools endpoint that answers `/json/version` with
@@ -225,6 +247,24 @@ describe("browser-process", () => {
           await expect(BrowserProcess.start(options)).rejects.toThrow(
             "Differing protocol versions",
           );
+        });
+
+        it("reads a browser that writes more to its standard output than a pipe holds", async () => {
+          const options = await fakeBrowser("no endpoint", 1, OVERFLOWS_A_PIPE);
+
+          // A launch that left standard output unread would stop here, with
+          // the stand-in blocked on a pipe nobody is emptying.
+          await expect(BrowserProcess.start(options)).rejects.toThrow(
+            "Your binary refused to boot",
+          );
+        });
+
+        it("takes the browser astral resolves when the options name none", async () => {
+          const options = await fakeBrowser("no endpoint", 1);
+          astralBinaryPathIs(options.path);
+
+          await expect(BrowserProcess.start({ args: options.args })).rejects
+            .toThrow("Your binary refused to boot");
         });
 
         it("throws when the launch names no `--user-data-dir`", async () => {

--- a/packages/deno-web-test/test/browser.test.ts
+++ b/packages/deno-web-test/test/browser.test.ts
@@ -1,7 +1,8 @@
 import { assertEquals, assertRejects } from "@std/assert";
 
-import type { Browser as AstralBrowser, LaunchOptions } from "@astral/astral";
+import type { LaunchOptions } from "@astral/astral";
 
+import type { BrowserProcess } from "../browser-process.ts";
 import { isRetryableAstralLaunchError, launchWithRetry } from "../browser.ts";
 
 Deno.test("isRetryableAstralLaunchError matches transient browser-launch failures", () => {
@@ -34,7 +35,7 @@ Deno.test("isRetryableAstralLaunchError matches transient browser-launch failure
 Deno.test("launchWithRetry retries retryable ETXTBSY launch failures", async () => {
   const launchCalls: LaunchOptions[] = [];
   const sleepCalls: number[] = [];
-  const browser = { close: async () => {} } as AstralBrowser;
+  const browser = {} as BrowserProcess;
   let attempts = 0;
 
   const launched = await launchWithRetry(

--- a/packages/integration/astral-adapter.ts
+++ b/packages/integration/astral-adapter.ts
@@ -160,16 +160,24 @@ export interface ScreencastFrame {
   sessionId: number;
 }
 
+/**
+ * Whether `error` is what Deno throws for an operation on a child process that
+ * has already exited. Both killing such a process and waiting on one report it
+ * this way, and the message is the only thing telling it from any other
+ * `TypeError`.
+ */
+export function isChildProcessGone(error: unknown): boolean {
+  return error instanceof TypeError &&
+    error.message === "Child process has already terminated";
+}
+
 export async function closeAstralBrowser(
   browser: Pick<AstralBrowser, "close">,
 ): Promise<void> {
   try {
     await browser.close();
   } catch (error) {
-    if (
-      error instanceof TypeError &&
-      error.message === "Child process has already terminated"
-    ) {
+    if (isChildProcessGone(error)) {
       return;
     }
     throw error;


### PR DESCRIPTION
`test/temporary-directories.test.ts` failed about one run in three on Linux, with the run directory present in a `TMPDIR` the run had removed everything from:

    /tmp/deno-web-test-tmpdir-c9d56fa6b34811b5 still holds
    com.google.Chrome.mFzQex (directory), .com.google.Chrome.IXOyZA
    (file), deno-web-test-6c5079e10dd272b4 (directory)

Chrome recreates the directory `--user-data-dir` names, every missing parent included, whenever it writes into it. That is the whole failure: `Manifest.remove()` succeeded, and then a process of Chrome's that was still alive wrote into `<runDir>/profile` and put `<runDir>` back. Confirmed by removing the tree under a live Chrome and watching it come back about 1.35 seconds later. The rename `removeDirectory()` does first does not help here, because what Chrome recreates is the path it was given rather than the name the tree is being walked under. Two other explanations were ruled out: an unresolved top-level await, which makes Deno exit 1 with a diagnostic rather than 0, and a `Deno.serve` shutdown that never settles, which resolves even with a keep-alive connection open.

The removal therefore has to follow the last process in the tree. `Deno.ChildProcess.status` covers one process, and the crash handler and the rendering processes are re-parented when the browser process goes, so waiting on the browser process is not waiting on them. What does cover the whole tree is the browser's standard error: every process Chrome starts inherits it, so the read end of that pipe reports end of file once the last write end is closed. A process closes its write end by exiting or by closing the descriptor, and a browser does neither before it goes, so for this tree the two coincide.

Reaching that pipe means owning the spawn. Astral's `launch()` keeps the process private and cancels the stream once the browser has named its endpoint, so `browser-process.ts` spawns Chrome itself and attaches astral to the running browser with `connect()`. It carries over what that launch does: the binary from `LaunchOptions.path` or astral's `getBinary()`, the switches from astral's `generateBinArgs()`, the read of standard error up to the endpoint line, and the same "Your binary refused to boot" message that `launchWithRetry()` matches to decide whether a launch is worth another attempt. What the browser printed is written out where it is collected, which is what astral does with it; carrying it in the thrown error instead loses it, since `Reporter.onLoadError()` prints the name and the message and nothing reads a cause. A launch has to name a `--user-data-dir` and now says so rather than running without one: astral's launch makes a temporary profile directory when the arguments name none and nothing removes it, and leaving that out means a launch naming none would otherwise reach the profile of the browser the developer uses.

Astral's recovery from a `SingletonLock` an earlier run left in the profile is not carried over. A run's profile directory is made fresh and empty inside a temporary directory of its own, so no earlier run has ever been in it, and coverage of the ported branch confirmed it never ran. It was also a self-recursion with no bound, which is the retry loop this repository does not allow.

`BrowserProcess.close()` closes the browser over the protocol, kills the process in case it did not go, and then waits for end of file on the pipe and for the process to be reaped. The kill is what makes the wait terminate rather than hang when the protocol command does not take effect; a browser that is already gone throws from `kill()`, and that one throw is the only one swallowed. `isChildProcessGone()` is that match on Deno's message, lifted out of `closeAstralBrowser()` so that it lives in one place rather than in both packages. The browser is closed directly rather than through `closeAstralBrowser()`, whose whole purpose is to swallow the error astral raises when it kills a browser process: one reached through `connect()` has no process for astral to kill. The stream is drained as it goes, since a full pipe blocks the process writing into it.

The two signals are far apart, and measurably so. On macOS with Chrome 152 in headless mode, the browser process exits 61 to 68 ms after `close()` begins and end of file arrives a further 103 to 131 ms later, with `chrome_crashpad_handler` alive throughout that window out of the twelve processes the launch produced. Removing the run directory at the earlier point is what the failure needed; nothing wrote into the profile during the window on macOS, which is why the flake does not reproduce there.

Two things this accepts rather than solves. The wait for end of file is unbounded, so a browser process that ignored the kill would hang the run rather than fail it; astral's launch escalates to `SIGKILL` after ten seconds, and that is a timeout. A renderer spinning in a six-hundred second loop was measured exiting normally, since the channel error that ends it is handled off the main thread. And a `close()` whose protocol close and whose wait both fail reports the second failure rather than the first.

`test/browser-process.test.ts` pins the ordering without a browser. A shell starts `cat`, which inherits its standard error and holds the pipe open, and then exits; `stopBrowserProcess()` must not return until the test closes the standard input `cat` is reading. The three events are recorded in the order they reach the list, and the assertion is on that order, so a stop that returned on the shell's exit alone records itself in the wrong place. Verified by passing `child.status` in place of the end-of-file promise, which fails that test on every run and leaves the others passing. A shell script standing in for a browser binary covers the three ways a launch fails before a browser is reached: exiting without naming an endpoint, reporting missing shared libraries, and naming no profile directory.

Verified by running each browser suite with `TMPDIR` pointing at a fresh directory and reading what was left: this package, `packages/dashboard`, `packages/identity`, `packages/static`, `packages/iframe-sandbox`, `packages/ui` and `packages/patterns` each leave it empty, and ten runs of the temporary directory test leave it empty as well. `packages/integration`'s suite passes, and a run with `ASTRAL_BIN_PATH` pointing at a binary that is not a browser prints what that binary said.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6875?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

