### PR TITLE
refactor(patterns): two patterns render a debug value through the renderer's own limits

### DIFF
--- a/packages/patterns/system/home-ben.tsx
+++ b/packages/patterns/system/home-ben.tsx
@@ -5,6 +5,7 @@ import {
   handler,
   NAME,
   pattern,
+  toCompactDebugString,
   UI,
   Writable,
 } from "commonfabric";
@@ -79,9 +80,8 @@ function captureSnapshot(
 
     const value = schemaCell.get();
     if (value !== undefined) {
-      const str = JSON.stringify(value);
-      // Capture up to 2000 chars to give LLM more context about content
-      valueExcerpt = str.length > 2000 ? str.slice(0, 2000) + "..." : str;
+      // Up to 2000 characters, to give the LLM context about the content.
+      valueExcerpt = toCompactDebugString(value, { maxLength: 2000 });
     }
   } catch {
     // Ignore errors - excerpt is optional

--- a/packages/patterns/test/data-model-test.tsx
+++ b/packages/patterns/test/data-model-test.tsx
@@ -6,12 +6,10 @@
  * JavaScript expression typed into the UI, stores the result in a cell, and
  * renders back a description of what came out, so that the round trip through
  * storage can be inspected for values whose handling is hard to predict:
- * `undefined`, `null`, `NaN`, the infinities, a nested container.
- *
- * A signed zero is not among them, and the display is why: everything the
- * description does not special-case goes through
- * `JSON.stringify`, which renders `-0` as `0`. Reading this probe as evidence
- * about `-0` would therefore be reading the renderer, not the round trip.
+ * `undefined`, `null`, `NaN`, the infinities, a signed zero, a nested
+ * container. The description renders through the debug renderer, which
+ * writes each of those as itself, `-0` included, so what the display shows
+ * is the round trip and not the renderer.
  *
  * Nothing here asserts anything, so nothing here can fail. What it produces is
  * a display for a person to read, and the `VERSION` string exists so that a
@@ -25,6 +23,7 @@ import {
   NAME,
   pattern,
   Stream,
+  toIndentedDebugString,
   UI,
   type VNode,
   Writable,
@@ -33,21 +32,7 @@ import {
 const VERSION = "v26";
 
 function describeValue(val: any): string {
-  const type = typeof val;
-  let repr: string;
-  if (val === undefined) repr = "undefined";
-  else if (val === null) repr = "null";
-  else if (val !== val) repr = "NaN";
-  else if (val === Infinity) repr = "Infinity";
-  else if (val === -Infinity) repr = "-Infinity";
-  else {
-    try {
-      repr = JSON.stringify(val, null, 2);
-    } catch {
-      repr = String(val);
-    }
-  }
-  return `typeof: ${type}\n\nvalue:  ${repr}`;
+  return `typeof: ${typeof val}\n\nvalue:  ${toIndentedDebugString(val)}`;
 }
 
 function nowTimestamp(): string {


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Fable 5.1)

## What

Two pattern sources shaped a debug value by hand where the debug renderers'
options now do it directly, the same shape the recent diagnostics changes
removed across the rest of the tree. Pattern sources were left out of that
sweep because pattern bytes can be contract-bearing; this change is the
experiment of touching them, and it measures the cost.

- **The home pattern's favorite excerpt** was a `JSON.stringify` cut at 2000
  characters with a trailing `...`. A bigint or a fabric primitive anywhere
  in the value made `stringify` throw, and the `catch` around it silently
  produced no excerpt at all. It is now `toCompactDebugString()` under a
  `maxLength` of 2000: the cut says so, keys lose their quotes, and nothing
  in the value erases the excerpt.
- **The data-model probe's description** hand-cased `NaN` and the infinities
  around a `JSON.stringify` with a `String()` fallback. It is now the
  indented rendering, which writes every value the probe is for as itself,
  `-0` included. The file's header had warned that the display folds `-0`
  into `0` and so cannot be read as evidence about it; that is no longer
  true, and the header says what is.

A third site the audit named, in the record extractor, was deleted by an
unrelated change before this one and needs nothing.

## The measurement

Both files have recorded baselines under `packages/patterns/baselines/`.
`deno task pattern-compat` after the edit reports exactly what it reports
before it: 323 patterns updatable from every recorded contract, the same two
pre-existing notes on the topic pattern, exit 0. The reason is specific:
neither file's baseline embeds a `moduleIdentity`, the content hash that
makes any byte change to a pattern's source a contract change. Only 32 of
the 414 baseline files do, for 13 patterns, and these two are not among
them. So the hazard the carve-out guards against is real for those 13 and
absent for the rest, which is narrower than the carve-out itself.

Also green on the edit: `deno task cfcheck` over 405 pattern files,
`deno task pattern-vintage` (8 vintages replayed, 77 targets updated with no
state stranded), `deno task check-pattern-tiers`, and the system-patterns
pattern test through `cf test`, whose four assertions pass exactly as they
do on `main`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6876?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

