### PR TITLE
docs(shuttle): the path reference, and the ruling it asks for

### DIFF
--- a/docs/plans/shuttle/pathref.md
+++ b/docs/plans/shuttle/pathref.md
@@ -15,8 +15,9 @@ and hand the place to someone else.
 
 A cell reference cannot say where they are. It names one cell and a position
 inside it — space, piece, document, path, resolved in a single dereference,
-which is what makes it canonical and shareable
-([`cell-reference-grammar`](../../specs/cell-reference-grammar.md)). It has one
+which is what makes it canonical and shareable. (The cell reference grammar is
+a decision record proposed in #6814, not yet in the tree; this document takes
+its decisions as read and cites them by number.) It has one
 document slot because one is enough for an address: reaching a second
 document's contents is two dereferences, and an address describes the
 destination of the last one.
@@ -58,10 +59,13 @@ Shuttle keeps the route today and does not spell it. `place.ts` carries
 type Trail = readonly Position[];
 ```
 
-described as "how shuttle reached it", and uses it for exactly one thing: `..`
-walks back through it where there is one. So the ruling below is not whether to
-model routes. It is whether to make the model shuttle already has renderable,
-typeable, and complete enough to carry a link crossing.
+described as "how shuttle reached it". A descent pushes the level it left onto
+it; `..` walks back out through it; and `cd -` restores the previous place's
+trail along with the place, so returning to where you were returns the route
+that reached it. Nothing else reads it, and nothing prints it. So the ruling
+below is not whether to model routes — shuttle models them and preserves them
+across a `cd -`. It is whether to make that model renderable, typeable, and
+complete enough to carry a link crossing.
 
 Two facts make the fit close. A `Position` names a space, a piece and a path,
 which is what a place is. And a link resolves to `NormalizedLink`, which is

--- a/docs/plans/shuttle/pathref.md
+++ b/docs/plans/shuttle/pathref.md
@@ -1,0 +1,194 @@
+# The path reference
+
+## Status
+
+Proposed. This asks for one ruling — whether shuttle addresses a place by the
+route it walked as well as by the cell that route ends at — and offers a shape
+for the route if the answer is yes. Nothing here is built.
+
+## The problem
+
+A cell's value holds links to other cells, and those cells hold links in turn.
+Browsing means walking through them: into a field, across the link it holds,
+into the document that cell keeps its inputs in, into a field of *that*. A
+person doing this is somewhere, and wants to say where they are, go back out,
+and hand the place to someone else.
+
+A cell reference cannot say where they are. It names one cell and a position
+inside it — space, piece, document, path, resolved in a single dereference,
+which is what makes it canonical and shareable
+([`cell-reference-grammar`](../../specs/cell-reference-grammar.md)). It has one
+document slot because one is enough for an address: reaching a second
+document's contents is two dereferences, and an address describes the
+destination of the last one.
+
+A route is the other thing. It is how the destination was reached, and it is
+not recoverable from the destination.
+
+## The split
+
+Two forms, and neither replaces the other:
+
+- A **cell reference** is where you are. Canonical, one per cell-and-position,
+  shareable with anything that resolves references, and always derivable from
+  the route.
+- A **path reference** is how you got there. It carries the crossings the
+  address forgets, and only shuttle needs it.
+
+This is the split a shell already makes for symbolic links, and for the same
+reasons. `pwd` prints the logical path and `pwd -P` the physical one; `cd ..`
+from `/a/link-to-b/c` returns to `link-to-b` rather than to the real parent of
+`b`. The logical path is kept because a user who walked in expects to walk back
+out the way they came, and because two routes to one destination are different
+places to someone browsing. The physical path is never lost — it is what the
+route resolves to.
+
+## What already exists
+
+Shuttle keeps the route today and does not spell it. `place.ts` carries
+
+```text
+type Trail = readonly Position[];
+```
+
+described as "how shuttle reached it", and uses it for exactly one thing: `..`
+walks back through it where there is one. So the ruling below is not whether to
+model routes. It is whether to make the model shuttle already has renderable,
+typeable, and complete enough to carry a link crossing.
+
+Two facts make the fit close. A `Position` names a space, a piece and a path,
+which is what a place is. And a link resolves to `NormalizedLink`, which is
+`{ id, path, space, scope }` — a position and a scope, not a bare cell. So
+crossing a link produces exactly what a trail already holds, and a trail of
+positions is already the right container for a route.
+
+## The shape
+
+A path reference is an origin and a sequence of steps. Three kinds of step, of
+which shuttle spells two today:
+
+| Step | Meaning | Spelled today |
+| --- | --- | --- |
+| Descend | a key within the current document | `items/0/title` |
+| Cross | follow a link a field holds, into the position it names | — |
+| Enter | the current cell's other document | `#argument`, but only as a suffix on a piece segment |
+
+Descending is what `cd items/0` does now. Crossing is the new act. Entering
+exists in the reference grammar and cannot recur there, because an address has
+one document slot; a route needs it once per cell it passes through, which is
+the whole reason a route is not an address.
+
+## Decisions this needs
+
+Each names what it costs and what I would rule. They are ordered so that an
+earlier answer constrains a later one.
+
+### 1. Is a crossing implicit or written?
+
+A filesystem crosses a symbolic link without being asked: `cd link` works, and
+nothing in the path says a boundary was passed. The alternative is a written
+crossing, which makes a path reference say what it did.
+
+**Recommend implicit.** `cd owner/name` should work whether `owner` holds a
+record or a link, because a person browsing does not know which it is and the
+distinction is not theirs to track. The crossing stays visible where it is
+useful — a listing can mark which rows are links, and `where` can show the
+crossings the current route made — rather than in every string anyone types.
+
+The cost is that a path reference does not carry its own crossings in its
+spelling, so it cannot be resolved without the fabric. That is already true of
+a slug and is what distinguishes this form from an address.
+
+### 2. How does the document axis recur?
+
+After crossing into a cell, `#argument` has to mean *that* cell's arguments.
+The reference grammar puts the member on a piece segment, before the path, and
+parses `#` nowhere else — which is what keeps `#` ordinary data in a path.
+
+Two spellings, and both cost something:
+
+- **As a path segment**, `owner/#argument/theme`. Reads in walking order and
+  needs no new character. It respells `#`, which the reference grammar reserves
+  on the piece segment only, so a path reference and a cell reference would
+  read `#` differently in the same position.
+- **As a suffix on the crossing that produced the cell**,
+  `owner#argument/theme`. Keeps `#` on the segment that names a cell,
+  matching the reference grammar's rule exactly, and reads as "the
+  arguments of what `owner` points at".
+
+**Recommend the suffix.** It preserves one meaning per character across both
+forms: `#` is a member introducer on a segment that names a cell, whether that
+segment is a piece in an address or a crossing in a route. A person who learns
+one has learned the other.
+
+### 3. What does `..` do after a crossing?
+
+**Recommend: back through the crossing**, to the field that held the link, not
+up within the destination cell. That is the shell convention, it is what the
+existing trail already implements for the moves shuttle has, and it is the
+behavior that makes a route worth keeping at all — a `..` that ignores the
+route makes the route decorative.
+
+Reaching the destination's own parent stays available by addressing it: a
+person who wants the cell rather than the route can take the cell reference and
+walk it.
+
+### 4. What does `pwd` print?
+
+`pwd` is ruled complete and pasteable, with no short form, the prompt being the
+short surface. A route does not change that so much as split it: there are now
+two complete answers, the route and the address.
+
+**Recommend `pwd` prints the route and `pwd -P` the address**, matching the
+shell exactly, with `where` showing both since it is the surface for the
+ambient record. The address remains what you hand to anything outside shuttle,
+which is the property that made `pwd` complete in the first place.
+
+### 5. What bounds a route?
+
+An address cannot cycle. A route can: links may point back, so a walk can
+revisit a cell and grow without limit. Nothing here should refuse a cycle —
+walking in a circle is a legitimate thing to do and the fabric permits the
+links — but a route that has revisited a position is worth *saying* so, and an
+unbounded trail is worth a limit that is a limit on memory rather than on where
+a person may go.
+
+**Recommend**: keep the whole route, mark a revisited position where the route
+is printed, and set no maximum until one is measured to matter. A cap chosen
+now would be a number nobody could defend.
+
+## How this sits beside the cell reference grammar
+
+It does not compete with it. Every place a route reaches has a cell reference,
+and shuttle emits one for anything it hands outward — a link, a shared
+address, an argument to `cf`. The route is a shuttle-local convenience for
+walking and for saying where you are while you walk.
+
+Three couplings are worth stating so they are not discovered later:
+
+- **The renderer.** `renderPosition` is the single function in shuttle that
+  composes a reference. A route's rendering must go through the same seam
+  rather than compose its own, or the two forms drift and the migration to
+  `//<space>/` has two places to visit instead of one.
+- **The round trip.** The property that every name a listing prints is one `cd`
+  takes back to that row must extend over routes, not just addresses. It is the
+  test that would prove a route's spelling correct, and it exists already.
+- **The document axis.** The reference grammar models the document as part of a
+  context's location, between the piece and the path. Shuttle pins it to the
+  result and varies the path below it. If a route can enter a document, that
+  asymmetry closes on its own; if this is declined, the asymmetry stays and is
+  worth recording as deliberate.
+
+## Open questions
+
+- **Does a path reference need to be typeable at all?** It has to be
+  *printable*, so a person can see where they are. Whether someone can paste
+  one back is a separate question, and a route that is only printed is a
+  smaller thing to build. The round-trip property argues for typeable, since it
+  is what the existing test drives.
+- **What does a listing show for a row that holds a link?** Marking it is
+  cheap and is where the implicit crossing of decision 1 becomes visible. The
+  form belongs with `ls`, not here.
+- **Does `get` follow a link?** `cd` crossing implicitly does not settle
+  whether a read does. A shell answers this with two verbs rather than one
+  rule, and shuttle may want the same.

--- a/docs/plans/shuttle/pathref.md
+++ b/docs/plans/shuttle/pathref.md
@@ -2,9 +2,8 @@
 
 ## Status
 
-Proposed. This asks for one ruling — whether shuttle addresses a place by the
-route it walked as well as by the cell that route ends at — and offers a shape
-for the route if the answer is yes. Nothing here is built.
+Ruled. The split is taken, and the five decisions below carry their rulings.
+Nothing here is built.
 
 ## The problem
 
@@ -24,6 +23,14 @@ destination of the last one.
 
 A route is the other thing. It is how the destination was reached, and it is
 not recoverable from the destination.
+
+The difference is not whether links are crossed. A path already crosses them:
+`resolveLink` resolves to "a document that no longer has any links between the
+top and the value at `link.path`", so a reference whose path runs through a
+chain of links is valid and resolves. It is simply not the canonical spelling
+of where it lands, because the destination has an address of its own. **Both
+forms traverse. A cell reference forgets the crossings; a route remembers
+them.**
 
 ## The split
 
@@ -89,7 +96,7 @@ A filesystem crosses a symbolic link without being asked: `cd link` works, and
 nothing in the path says a boundary was passed. The alternative is a written
 crossing, which makes a path reference say what it did.
 
-**Recommend implicit.** `cd owner/name` should work whether `owner` holds a
+**Ruled implicit.** `cd owner/name` should work whether `owner` holds a
 record or a link, because a person browsing does not know which it is and the
 distinction is not theirs to track. The crossing stays visible where it is
 useful — a listing can mark which rows are links, and `where` can show the
@@ -116,22 +123,24 @@ Two spellings, and both cost something:
   matching the reference grammar's rule exactly, and reads as "the
   arguments of what `owner` points at".
 
-**Recommend the suffix.** It preserves one meaning per character across both
+**Ruled the suffix.** It preserves one meaning per character across both
 forms: `#` is a member introducer on a segment that names a cell, whether that
 segment is a piece in an address or a crossing in a route. A person who learns
 one has learned the other.
 
 ### 3. What does `..` do after a crossing?
 
-**Recommend: back through the crossing**, to the field that held the link, not
-up within the destination cell. That is the shell convention, it is what the
+**Ruled: back through the crossing**, to the field that held the link, not up
+within the destination cell. That is the shell convention, it is what the
 existing trail already implements for the moves shuttle has, and it is the
 behavior that makes a route worth keeping at all — a `..` that ignores the
 route makes the route decorative.
 
-Reaching the destination's own parent stays available by addressing it: a
-person who wants the cell rather than the route can take the cell reference and
-walk it.
+There is no other candidate, because a cell has no parent. Only a path has
+one, by dropping its last segment. A crossing that lands at a cell's root
+therefore has nothing above it but the crossing itself; one that lands at a
+path inside the cell has a path-parent, and `..` still takes the crossing
+rather than that parent, so the rule is the same either way.
 
 ### 4. What does `pwd` print?
 
@@ -139,10 +148,17 @@ walk it.
 short surface. A route does not change that so much as split it: there are now
 two complete answers, the route and the address.
 
-**Recommend `pwd` prints the route and `pwd -P` the address**, matching the
-shell exactly, with `where` showing both since it is the surface for the
-ambient record. The address remains what you hand to anything outside shuttle,
-which is the property that made `pwd` complete in the first place.
+**Ruled: `pwd` prints the route**, and the canonical address is a `where`
+dimension rather than a `pwd` flag. `-P` would name it wrongly: it means the
+same path physically resolved, and the address is not that — it is a different
+address, a different piece with different segments, arrived at by forgetting
+the route rather than by resolving it.
+
+What `pwd` gets instead is a mode over the same route: how much of each
+crossing to show. The route is the answer at every setting, and the settings
+differ in annotation. The address stays what you hand to anything outside
+shuttle, which is the property that made `pwd` complete in the first place, and
+`where` is where it is printed.
 
 ### 5. What bounds a route?
 
@@ -153,9 +169,9 @@ links — but a route that has revisited a position is worth *saying* so, and an
 unbounded trail is worth a limit that is a limit on memory rather than on where
 a person may go.
 
-**Recommend**: keep the whole route, mark a revisited position where the route
-is printed, and set no maximum until one is measured to matter. A cap chosen
-now would be a number nobody could defend.
+**Ruled**: no bound. Keep the whole route and let `where` note a revisited
+position, since walking in a circle is a legitimate thing to do and a cap
+chosen now would be a number nobody could defend.
 
 ## How this sits beside the cell reference grammar
 
@@ -181,14 +197,18 @@ Three couplings are worth stating so they are not discovered later:
 
 ## Open questions
 
-- **Does a path reference need to be typeable at all?** It has to be
-  *printable*, so a person can see where they are. Whether someone can paste
-  one back is a separate question, and a route that is only printed is a
-  smaller thing to build. The round-trip property argues for typeable, since it
-  is what the existing test drives.
+- **Typeable, not only printable.** Pasting a route back and having it work is
+  wanted, and nothing argues against it — the round-trip property already
+  drives exactly that for the forms shuttle prints today.
 - **What does a listing show for a row that holds a link?** Marking it is
   cheap and is where the implicit crossing of decision 1 becomes visible. The
   form belongs with `ls`, not here.
-- **Does `get` follow a link?** `cd` crossing implicitly does not settle
-  whether a read does. A shell answers this with two verbs rather than one
-  rule, and shuttle may want the same.
+- **`get` follows a link.** `cd` crossing implicitly and a read not following
+  would be the surprise, and the alternative asks a person to split a path into
+  the part `cd` takes and the part `get` takes, which nothing about the path
+  tells them. Seeing the link itself stays available as a *mode* on the read
+  rather than a second verb: `LastNode` is already `"value" | "writeRedirect" |
+  "top"`, so stopping a resolution before a crossing is a supported act, and
+  `--select '@'` already answers a position's address. What `set` does through
+  a link is a separate question, and a real one, because a write-redirect link
+  carries `overwrite: "redirect"` — it is about the write path, not this one.


### PR DESCRIPTION
## Why

Shuttle has to browse deeply into structures. A cell's value holds links to other cells, those cells hold links in turn, and each keeps its inputs in a second document — so walking around means crossing between cells and between documents, repeatedly.

**A cell reference cannot say where that walk has got to.** It names one cell and a position inside it, resolved in a single dereference, which is exactly what makes it canonical and shareable (#6814). It has one document slot because one is enough for an *address*: reaching a second document's contents is two dereferences, and an address describes the destination of the last one.

A route is the other thing, and it is not recoverable from the destination. This proposes the split — a cell reference for **where you are**, a path reference for **how you got there** — and asks for one ruling on whether to make it, plus five on its shape.

The argument that it is the right split: a shell already makes it, for symbolic links, for the same two reasons. `cd ..` from `/a/link-to-b/c` returns to `link-to-b` rather than to `b`'s real parent, and two routes to one destination are different places to someone browsing. `pwd` prints the logical path, `pwd -P` the physical one, and the physical one is never lost because it is what the route resolves to.

**Shuttle already keeps the route and does not spell it.** `place.ts` carries `type Trail = readonly Position[]`, described as "how shuttle reached it" and used today for exactly one thing: making `..` behave. And a link resolves to `NormalizedLink` — `{ id, path, space, scope }`, a position and a scope rather than a bare cell — so crossing one produces precisely what a trail already holds. The ruling is not whether to model routes. It is whether to make the model that exists renderable, typeable, and able to carry a crossing.

## What Changed

One new document, `docs/plans/shuttle/pathref.md`. No code.

It states the split, what already exists, and the shape: a route is an origin and a sequence of steps, of three kinds — **descend** a key (`cd items/0`, spelled today), **cross** a link (new), and **enter** a cell's other document (`#argument`, which exists in the reference grammar and cannot recur there, since an address has one document slot and a route needs one per cell it passes through).

Five decisions, each with a recommendation and its cost, ordered so an earlier answer constrains a later one:

1. **Is a crossing implicit or written?** — implicit, as a filesystem crosses a symlink.
2. **How does the document axis recur?** — as a suffix on the crossing (`owner#argument/theme`), which keeps one meaning per character across both forms.
3. **What does `..` do after a crossing?** — back through it, the shell convention and what the trail already implements.
4. **What does `pwd` print?** — the route, with `pwd -P` for the address.
5. **What bounds a route?** — nothing; links may cycle, so mark a revisited position and set no cap until one is measured.

Three couplings to the cell reference grammar are stated so they are not discovered later: the single renderer seam (`renderPosition`), the round-trip property that would prove a route's spelling correct, and the document-axis asymmetry — shuttle pins the document to the result while varying the path below it, which closes on its own if a route can enter a document.

## Test plan

Documentation only.

```
deno task check-docs                All 589 checked code block(s) passed.
deno task check-control-characters  clean
deno task check-conflict-markers    clean
line width                          0 lines over 80 outside tables
```

`docs/` is excluded from `deno fmt`, so the wrapping is hand-checked rather than tool-enforced.

Every factual claim is checked against source: `Trail`'s type and doc comment in `packages/shuttle/src/place.ts`; `NormalizedLink`'s fields in `packages/runner/src/link-types.ts`; `renderPosition` being the only reference-composing function in `packages/shuttle`; and #6814's D6 and D10 for the member spelling and the context's location ladder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BPyjSx5WXYepE9JsK4rBx3


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6877?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

