### PR TITLE
cf-code-editor: drain the collaboration queue until empty so bursts typed during a round trip are never lost

### DIFF
--- a/docs/features/collaborative-fields.md
+++ b/docs/features/collaborative-fields.md
@@ -76,6 +76,11 @@ same transaction stores the submitted projection, appends canonical integrated
 operations, advances the field cursor, and writes the ordinary materialized
 revision.
 
+`cf-code-editor` submits every unconfirmed local update in one apply, and
+edits made while that apply is in flight go out in the next one, until none
+remain. A local update is confirmed by Memory or reported through the editor's
+error and reconciliation events; it is never dropped silently.
+
 One collaborative epoch owns a field until it is explicitly released or its
 entity is deleted. An ordinary write may change other paths, but it cannot
 change an active collaborative path. Deliberate release plus replacement may be

--- a/packages/patterns/integration/cf-code-editor-collaboration.test.ts
+++ b/packages/patterns/integration/cf-code-editor-collaboration.test.ts
@@ -121,6 +121,38 @@ const reconciliationReached = (probe: ProbeApi): boolean => {
     globals.__collaborationReconciliationError !== undefined;
 };
 
+const epochReleaseObserved = (
+  probe: ProbeApi,
+  canonical: string,
+): boolean => {
+  const editor = probe.collect("cf-code-editor")[0] as EditorHost | undefined;
+  return editor?._collaboration?.active === false ||
+    editor?._editorView?.state.doc.toString() === canonical;
+};
+
+async function reconciliationReachedNow(page: Page): Promise<boolean> {
+  return await page.evaluate(() => {
+    const collect = (root: Document | ShadowRoot): Element[] => {
+      const result: Element[] = [];
+      for (const element of root.querySelectorAll("*")) {
+        result.push(element);
+        if (element.shadowRoot) result.push(...collect(element.shadowRoot));
+      }
+      return result;
+    };
+    const editor = collect(document).find((element) =>
+      element.localName === "cf-code-editor"
+    ) as EditorHost | undefined;
+    const globals = globalThis as typeof globalThis & {
+      __collaborationReconciliation?: unknown;
+      __collaborationReconciliationError?: unknown;
+    };
+    return editor?._editorView?.state.readOnly === true &&
+      globals.__collaborationReconciliation !== undefined &&
+      globals.__collaborationReconciliationError !== undefined;
+  });
+}
+
 async function editorContent(page: Page): Promise<string> {
   return await page.evaluate(() => {
     const collect = (root: Document | ShadowRoot): Element[] => {
@@ -1231,17 +1263,23 @@ describe("cf-code-editor collaboration", () => {
       waitForCondition(alicePage, editorContainsTokens, { args: [tokens] }),
       waitForCondition(bobPage, editorContainsTokens, { args: [tokens] }),
     ]);
-    const [aliceContent, bobContent, materialized] = await Promise.all([
+    // Holding every token says each browser has integrated the other's
+    // operations, not that its own are confirmed; confirming them is the
+    // convergence barrier.
+    await Promise.all([
+      confirmPendingCollaborationEdits(alicePage),
+      confirmPendingCollaborationEdits(bobPage),
+    ]);
+    const [aliceContent, bobContent] = await Promise.all([
       editorContent(alicePage),
       editorContent(bobPage),
-      awaitMaterialized(
-        "burstBoth",
-        (value) => tokens.every((token) => value.includes(token)),
-      ),
     ]);
     assertEquals(aliceContent, bobContent);
-    assertEquals(materialized, aliceContent);
     assertEquals(aliceContent.length, "both".length + 12);
+    assertEquals(
+      await awaitMaterialized("burstBoth", (value) => value === aliceContent),
+      aliceContent,
+    );
     assertEquals(await collaborationErrors(alicePage), []);
     assertEquals(await collaborationErrors(bobPage), []);
   });
@@ -1267,7 +1305,16 @@ describe("cf-code-editor collaboration", () => {
     await appendEdit(alicePage, "L3");
 
     await releaseCollaboration(bobPage);
-    await waitForCondition(alicePage, reconciliationReached);
+    // Alice observes the release by failing closed or by adopting the
+    // canonical value; only the first is acceptable, and the wait admits
+    // both so that the second fails the assertion rather than the wait.
+    await waitForCondition(alicePage, epochReleaseObserved, {
+      args: ["epoch!"],
+    });
+    assert(
+      await reconciliationReachedNow(alicePage),
+      "release with pending edits did not reach reconciliation",
+    );
     const detail = await reconciliationDetail(alicePage);
     assertEquals(detail.localValue, "epoch!L1L2L3");
     assertEquals(detail.canonicalValue, "epoch!");

--- a/packages/patterns/integration/cf-code-editor-collaboration.test.ts
+++ b/packages/patterns/integration/cf-code-editor-collaboration.test.ts
@@ -162,6 +162,26 @@ async function dispatchEdit(
   }, { args: [from, to, insert] });
 }
 
+async function appendEdit(page: Page, insert: string): Promise<void> {
+  await page.evaluate((insert) => {
+    const collect = (root: Document | ShadowRoot): Element[] => {
+      const result: Element[] = [];
+      for (const element of root.querySelectorAll("*")) {
+        result.push(element);
+        if (element.shadowRoot) result.push(...collect(element.shadowRoot));
+      }
+      return result;
+    };
+    const editor = collect(document).find((element) =>
+      element.localName === "cf-code-editor"
+    ) as EditorHost | undefined;
+    const view = editor?._editorView;
+    if (!view) throw new Error("collaborative editor is not ready");
+    const end = view.state.doc.length;
+    view.dispatch({ changes: { from: end, to: end, insert } });
+  }, { args: [insert] });
+}
+
 async function enablePresence(
   page: Page,
   participantName: string,
@@ -759,6 +779,18 @@ describe("cf-code-editor collaboration", () => {
         input: { content: "presence" },
         start: true,
       }),
+      burst: await cc.create(source, {
+        input: { content: "burst" },
+        start: true,
+      }),
+      burstBoth: await cc.create(source, {
+        input: { content: "both" },
+        start: true,
+      }),
+      burstEpoch: await cc.create(source, {
+        input: { content: "epoch" },
+        start: true,
+      }),
     };
 
     await new ACLManager(cc.runtime, cc.getSpace()).set(ANYONE_USER, "WRITE");
@@ -1112,6 +1144,137 @@ describe("cf-code-editor collaboration", () => {
     assertEquals(detail.canonicalCursor, null);
     assertEquals(await editorContent(alicePage), "reset!LOCAL");
     assertEquals(latestContent.get("reconcile"), "reset!");
+
+    await cancelApplyGate(alicePage);
+    await awaitApplyCompleted(alicePage);
+    assertEquals(await reconciliationError(alicePage), {
+      message: "CodeMirror operation state changed with local edits pending",
+      name: "CodeMirrorReconciliationError",
+    });
+    assertEquals(await collaborationErrors(bobPage), []);
+  });
+
+  it("submits every edit of a burst typed during one round trip and keeps them across a reload", async () => {
+    // The apply gate holds the first edit's round trip open while six more
+    // edits land, the way keystrokes do when typing outruns the network.
+
+    await navigateBoth(pieces.burst);
+    const alicePage = aliceShell.page();
+    const bobPage = bobShell.page();
+
+    await installNextApplyGate(alicePage);
+    await dispatchEdit(alicePage, 5, 5, "1");
+    await awaitApplyCaptured(alicePage);
+    for (const character of "234567") {
+      await appendEdit(alicePage, character);
+    }
+    await releaseApplyGate(alicePage);
+    await awaitApplyCompleted(alicePage);
+
+    await Promise.all([
+      waitForCondition(alicePage, editorContainsTokens, {
+        args: [["burst1234567"]],
+      }),
+      waitForCondition(bobPage, editorContainsTokens, {
+        args: [["burst1234567"]],
+      }),
+      awaitMaterialized("burst", (value) => value === "burst1234567"),
+    ]);
+    assertEquals(await editorContent(bobPage), "burst1234567");
+
+    await alicePage.reload({ waitUntil: "load" });
+    await alicePage.applyConsoleFormatter();
+    await aliceShell.login(alice);
+    await waitForCondition(alicePage, collaborationReady);
+    await listenForCollaborationErrors(alicePage);
+    assertEquals(await editorContent(alicePage), "burst1234567");
+    assertEquals(await collaborationErrors(alicePage), []);
+    assertEquals(await collaborationErrors(bobPage), []);
+  });
+
+  it("converges bursts typed concurrently in both browsers during one round trip", async () => {
+    await navigateBoth(pieces.burstBoth);
+    const alicePage = aliceShell.page();
+    const bobPage = bobShell.page();
+    const aliceTokens = ["A1", "A2", "A3"];
+    const bobTokens = ["B1", "B2", "B3"];
+    const tokens = [...aliceTokens, ...bobTokens];
+
+    await Promise.all([
+      installNextApplyGate(alicePage),
+      installNextApplyGate(bobPage),
+    ]);
+    await Promise.all([
+      dispatchEdit(alicePage, 4, 4, aliceTokens[0]),
+      dispatchEdit(bobPage, 4, 4, bobTokens[0]),
+    ]);
+    await Promise.all([
+      awaitApplyCaptured(alicePage),
+      awaitApplyCaptured(bobPage),
+    ]);
+    for (const index of [1, 2]) {
+      await Promise.all([
+        appendEdit(alicePage, aliceTokens[index]),
+        appendEdit(bobPage, bobTokens[index]),
+      ]);
+    }
+    await Promise.all([
+      releaseApplyGate(alicePage),
+      releaseApplyGate(bobPage),
+    ]);
+    await Promise.all([
+      awaitApplyCompleted(alicePage),
+      awaitApplyCompleted(bobPage),
+    ]);
+
+    await Promise.all([
+      waitForCondition(alicePage, editorContainsTokens, { args: [tokens] }),
+      waitForCondition(bobPage, editorContainsTokens, { args: [tokens] }),
+    ]);
+    const [aliceContent, bobContent, materialized] = await Promise.all([
+      editorContent(alicePage),
+      editorContent(bobPage),
+      awaitMaterialized(
+        "burstBoth",
+        (value) => tokens.every((token) => value.includes(token)),
+      ),
+    ]);
+    assertEquals(aliceContent, bobContent);
+    assertEquals(materialized, aliceContent);
+    assertEquals(aliceContent.length, "both".length + 12);
+    assertEquals(await collaborationErrors(alicePage), []);
+    assertEquals(await collaborationErrors(bobPage), []);
+  });
+
+  it("reports every edit of a burst when another browser releases the epoch during its round trip", async () => {
+    await navigateBoth(pieces.burstEpoch);
+    const alicePage = aliceShell.page();
+    const bobPage = bobShell.page();
+
+    await dispatchEdit(alicePage, 5, 5, "!");
+    await Promise.all([
+      waitForCondition(alicePage, editorContainsTokens, { args: [["!"]] }),
+      waitForCondition(bobPage, editorContainsTokens, { args: [["!"]] }),
+      awaitMaterialized("burstEpoch", (value) => value === "epoch!"),
+    ]);
+    await confirmPendingCollaborationEdits(alicePage);
+
+    await listenForReconciliation(alicePage);
+    await installNextApplyGate(alicePage);
+    await dispatchEdit(alicePage, 6, 6, "L1");
+    await awaitApplyCaptured(alicePage);
+    await appendEdit(alicePage, "L2");
+    await appendEdit(alicePage, "L3");
+
+    await releaseCollaboration(bobPage);
+    await waitForCondition(alicePage, reconciliationReached);
+    const detail = await reconciliationDetail(alicePage);
+    assertEquals(detail.localValue, "epoch!L1L2L3");
+    assertEquals(detail.canonicalValue, "epoch!");
+    assert(detail.localCursor !== null);
+    assertEquals(detail.canonicalCursor, null);
+    assertEquals(await editorContent(alicePage), "epoch!L1L2L3");
+    assertEquals(latestContent.get("burstEpoch"), "epoch!");
 
     await cancelApplyGate(alicePage);
     await awaitApplyCompleted(alicePage);

--- a/packages/ui/src/v2/components/cf-code-editor/cf-code-editor-collaboration.test.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/cf-code-editor-collaboration.test.ts
@@ -955,6 +955,30 @@ describe("CFCodeEditor collaboration", () => {
     expect(flushes).toBe(2);
   });
 
+  it("reports a final send that fails while detaching", async () => {
+    const events: unknown[] = [];
+    const element = new CFCodeEditor();
+    (element as any)._collaboration = {
+      active: true,
+      stop: () => Promise.reject(new Error("pending edit")),
+    };
+    (element as any).emit = (name: string, detail: unknown) =>
+      events.push([name, detail]);
+    element.collaborative = true;
+
+    (element as any)._cleanupCollaboration();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect((element as any)._collaboration).toBeUndefined();
+    expect(events).toEqual([
+      ["cf-error", {
+        error: new Error("pending edit"),
+        message: "pending edit",
+      }],
+    ]);
+  });
+
   it("detaches without releasing and explicitly releases active collaboration", async () => {
     const events: string[] = [];
     const element = new CFCodeEditor();

--- a/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
@@ -1521,10 +1521,11 @@ export class CFCodeEditor extends BaseElement {
     this._cleanupPresence();
     const collaboration = this._collaboration;
     this._collaboration = undefined;
-    void collaboration?.stop().catch(() => {
-      // The element is disconnecting, so there is no live editor surface on
-      // which to reconcile a failed final send. The controller has already
-      // failed closed and detached its subscription.
+    void collaboration?.stop().catch((cause: unknown) => {
+      // The element is detaching, so there is no editor surface on which to
+      // reconcile a failed final send; the event is what remains of it.
+      const error = cause instanceof Error ? cause : new Error(String(cause));
+      this.emit("cf-error", { error, message: error.message });
     });
   }
 

--- a/packages/ui/src/v2/components/cf-code-editor/codemirror-collaboration.test.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/codemirror-collaboration.test.ts
@@ -1020,6 +1020,149 @@ describe("CodeMirror operation collaboration", () => {
     expect(sendableUpdates(view.state)).toHaveLength(0);
   });
 
+  it("rebases edits recorded during a round trip over an operation that intervened", async () => {
+    // Bob's insertion at the start of the document lands at Memory between
+    // alice's two round trips, so her second submission is integrated after
+    // it and comes back rebased.
+
+    const first = Promise.withResolvers<void>();
+    const firstCaptured = Promise.withResolvers<void>();
+    const applies: ApplyRequest[] = [];
+    const bob = {
+      opId: "op:bob:1",
+      cursor: { epoch: 1, version: 2 },
+      submissionId: "bob:1",
+      payload: {
+        updates: [{
+          clientId: "bob",
+          changes: ChangeSet.of({ from: 0, insert: "b" }, 4).toJSON(),
+        }],
+      } as ApplyOpResolution["operations"][number]["payload"],
+    };
+    const { controller, view, errors } = controllerHarness({
+      initial: inactiveSnapshot("abc"),
+      followups: [
+        activeSnapshotAt("abcX", 1),
+        activeSnapshotAt("babcXY", 3),
+      ],
+      apply: async (request) => {
+        applies.push(request);
+        if (applies.length === 1) {
+          firstCaptured.resolve();
+          await first.promise;
+          return resolutionFor(request);
+        }
+        const own = resolutionFor({
+          ...request,
+          base: { epoch: 1, version: 2 },
+        });
+        return {
+          ...own,
+          from: { epoch: 1, version: 1 },
+          operations: [bob, ...own.operations],
+        };
+      },
+    });
+
+    await controller.start();
+    view.dispatch({ changes: { from: 3, insert: "X" } });
+    const sends = [controller.localDocChanged()];
+    await firstCaptured.promise;
+    view.dispatch({ changes: { from: 4, insert: "Y" } });
+    sends.push(controller.localDocChanged());
+    first.resolve();
+    await Promise.all(sends);
+
+    expect(errors).toEqual([]);
+    expect(applies[1]?.base).toEqual({ epoch: 1, version: 1 });
+    expect(view.state.doc.toString()).toBe("babcXY");
+    expect(sendableUpdates(view.state)).toHaveLength(0);
+    expect(controller.synchronizationSnapshot?.confirmedCursor).toEqual({
+      epoch: 1,
+      version: 3,
+    });
+    await controller.stop();
+  });
+
+  it("fails closed when a round trip confirms none of the submitted edits", async () => {
+    // Memory answers the first submission without integrating it. A
+    // controller that resubmits instead of failing reaches the second apply,
+    // which the harness refuses.
+
+    let applyCount = 0;
+    let cancellations = 0;
+    const { controller, view, errors } = controllerHarness({
+      initial: inactiveSnapshot("abc"),
+      followup: activeSnapshotAt("abc", 0),
+      apply: (request) => {
+        applyCount++;
+        if (applyCount > 1) throw new Error("resubmitted an unconfirmed edit");
+        return {
+          ...resolutionFor(request),
+          to: { epoch: 1, version: 0 },
+          operations: [],
+        };
+      },
+      cancel: () => cancellations++,
+    });
+
+    await controller.start();
+    view.dispatch({ changes: { from: 1, insert: "X" } });
+    await controller.localDocChanged();
+
+    expect(applyCount).toBe(1);
+    expect(errors.map((error) => error.message)).toEqual([
+      "CodeMirror submission confirmed no local update",
+    ]);
+    expect(cancellations).toBe(1);
+    expect(view.state.doc.toString()).toBe("aXbc");
+    expect(sendableUpdates(view.state)).toHaveLength(1);
+  });
+
+  it("submits an edit recorded at any microtask offset from a drain's last confirmation", async () => {
+    // The drain re-reads its queue after each round trip, and `#flush` clears
+    // the in-flight promise a few microtasks later. An edit recorded in
+    // between belongs to neither the finished drain nor a new one unless the
+    // caller re-reads the queue after waiting. Each offset from the
+    // confirmation is one candidate for that window.
+
+    for (let offset = 0; offset < 6; offset++) {
+      const applies: ApplyRequest[] = [];
+      const { controller, view, errors } = controllerHarness({
+        initial: inactiveSnapshot("abc"),
+        followups: [
+          activeSnapshotAt("abcX", 1),
+          activeSnapshotAt("abcXY", 2),
+        ],
+        apply: (request) => {
+          applies.push(request);
+          return resolutionFor(request);
+        },
+      });
+      await controller.start();
+      let late: Promise<void> | undefined;
+      controller.observeSynchronization((snapshot) => {
+        if (late !== undefined || snapshot?.confirmedCursor.version !== 1) {
+          return;
+        }
+        late = Promise.resolve().then(async () => {
+          for (let hop = 0; hop < offset; hop++) await Promise.resolve();
+          view.dispatch({ changes: { from: 4, insert: "Y" } });
+          await controller.localDocChanged();
+        });
+      });
+      view.dispatch({ changes: { from: 3, insert: "X" } });
+      await controller.localDocChanged();
+      await late;
+
+      expect(errors).toEqual([]);
+      expect(applies).toHaveLength(2);
+      expect(view.state.doc.toString()).toBe("abcXY");
+      expect(sendableUpdates(view.state)).toHaveLength(0);
+      await controller.stop();
+    }
+  });
+
   it("isolates synchronization observers from the Memory operation path", async () => {
     const accepted = acceptedResolution("abc", 1, "X");
     const { controller, view, errors } = controllerHarness({

--- a/packages/ui/src/v2/components/cf-code-editor/codemirror-collaboration.test.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/codemirror-collaboration.test.ts
@@ -1262,6 +1262,35 @@ describe("CodeMirror operation collaboration", () => {
     });
   });
 
+  it("leaves the editor alone once disposed during a round trip", async () => {
+    // A superseding controller reinstalls the shared compartment, so a
+    // resolution arriving for the disposed one must not be dispatched.
+
+    const applied = Promise.withResolvers<void>();
+    const captured = Promise.withResolvers<void>();
+    const { controller, view, errors } = controllerHarness({
+      initial: inactiveSnapshot("abc"),
+      followup: activeSnapshotAt("aXbc", 1),
+      apply: async (request) => {
+        captured.resolve();
+        await applied.promise;
+        return resolutionFor(request);
+      },
+    });
+
+    await controller.start();
+    view.dispatch({ changes: { from: 1, insert: "X" } });
+    const sending = controller.localDocChanged();
+    await captured.promise;
+    controller.dispose();
+    const untouched = view.state;
+    applied.resolve();
+    await sending;
+
+    expect(errors).toEqual([]);
+    expect(view.state).toBe(untouched);
+  });
+
   it("isolates synchronization observers from the Memory operation path", async () => {
     const accepted = acceptedResolution("abc", 1, "X");
     const { controller, view, errors } = controllerHarness({

--- a/packages/ui/src/v2/components/cf-code-editor/codemirror-collaboration.test.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/codemirror-collaboration.test.ts
@@ -921,6 +921,55 @@ describe("CodeMirror operation collaboration", () => {
     await controller.stop();
   });
 
+  it("submits edits recorded during an in-flight submission in the next one", async () => {
+    // Only `localDocChanged()` drives the controller here. `stop()` and
+    // `prepareExternalChange()` ask for a complete drain themselves; what this
+    // pins is that ordinary typing during a round trip gets one too.
+
+    const first = Promise.withResolvers<void>();
+    const firstCaptured = Promise.withResolvers<void>();
+    const applies: ApplyRequest[] = [];
+    const { controller, view, errors } = controllerHarness({
+      initial: inactiveSnapshot("abc"),
+      followups: [
+        activeSnapshotAt("abc1", 1),
+        activeSnapshotAt("abc1234567", 7),
+      ],
+      apply: async (request) => {
+        applies.push(request);
+        if (applies.length === 1) {
+          firstCaptured.resolve();
+          await first.promise;
+        }
+        return resolutionFor(request);
+      },
+    });
+
+    await controller.start();
+    view.dispatch({ changes: { from: 3, insert: "1" } });
+    const sends = [controller.localDocChanged()];
+    await firstCaptured.promise;
+    for (const character of "234567") {
+      view.dispatch({
+        changes: { from: view.state.doc.length, insert: character },
+      });
+      sends.push(controller.localDocChanged());
+    }
+    first.resolve();
+    await Promise.all(sends);
+
+    expect(errors).toEqual([]);
+    expect(
+      applies.map((request) => [
+        request.base?.version ?? null,
+        (request.payload as { updates: unknown[] }).updates.length,
+      ]),
+    ).toEqual([[null, 1], [1, 6]]);
+    expect(view.state.doc.toString()).toBe("abc1234567");
+    expect(sendableUpdates(view.state)).toHaveLength(0);
+    await controller.stop();
+  });
+
   it("isolates synchronization observers from the Memory operation path", async () => {
     const accepted = acceptedResolution("abc", 1, "X");
     const { controller, view, errors } = controllerHarness({
@@ -1027,11 +1076,61 @@ function activeSnapshot(
   };
 }
 
+type ApplyRequest = Parameters<RuntimeClient["applyOperation"]>[1];
+
+function activeSnapshotAt(
+  materialized: string,
+  version: number,
+): OperationFieldSnapshot {
+  return {
+    branch: "",
+    id: "of:editor",
+    scopeKey: "space",
+    path,
+    active: true,
+    codec: "codemirror-changeset@1",
+    cursor: { epoch: 1, version },
+    baselineHash: "baseline:abc",
+    materialized,
+    operations: [],
+  };
+}
+
+/**
+ * Resolves `request` the way Memory's changeset codec does with nothing
+ * intervening: every submitted update becomes one integrated operation at the
+ * next version.
+ */
+function resolutionFor(request: ApplyRequest): ApplyOpResolution {
+  const from = request.base ?? { epoch: 1, version: 0 };
+  const updates = (request.payload as { updates: unknown[] }).updates;
+  const operations = updates.map((update, index) => ({
+    opId: `op:${request.submissionId}:${index}`,
+    cursor: { epoch: from.epoch, version: from.version + index + 1 },
+    submissionId: request.submissionId,
+    payload: { updates: [update] } as ApplyOpResolution["operations"][number][
+      "payload"
+    ],
+  }));
+  return {
+    operationIndex: 0,
+    address: { branch: "", id: "of:editor", scopeKey: "space", path },
+    codec: "codemirror-changeset@1",
+    submissionId: request.submissionId,
+    from,
+    to: { epoch: from.epoch, version: from.version + updates.length },
+    operations,
+    duplicate: false,
+  };
+}
+
 function controllerHarness(options: {
   initial: OperationFieldSnapshot;
   followup?: OperationFieldSnapshot;
   followups?: OperationFieldSnapshot[];
-  apply: () => ApplyOpResolution | Promise<ApplyOpResolution>;
+  apply: (
+    request: ApplyRequest,
+  ) => ApplyOpResolution | Promise<ApplyOpResolution>;
   codecs?: string[];
   subscribe?: (callback: (snapshot: OperationFieldSnapshot) => void) => void;
   subscription?: Promise<() => void>;
@@ -1073,7 +1172,8 @@ function controllerHarness(options: {
       return options.subscription ??
         Promise.resolve(() => options.cancel?.());
     },
-    applyOperation: () => Promise.resolve(options.apply()),
+    applyOperation: (_cell: CellHandle<string>, request: ApplyRequest) =>
+      Promise.resolve(options.apply(request)),
     releaseOperationField: () => Promise.resolve(options.release?.()),
     closeOperationSession: () => {
       options.close?.();

--- a/packages/ui/src/v2/components/cf-code-editor/codemirror-collaboration.test.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/codemirror-collaboration.test.ts
@@ -970,6 +970,56 @@ describe("CodeMirror operation collaboration", () => {
     await controller.stop();
   });
 
+  it("stops only after submitting edits recorded during its own submissions", async () => {
+    // A closing controller refuses `localDocChanged()`, so an edit recorded
+    // while one of its submissions is in flight has no caller of its own.
+    // `stop()` carries it in the next round trip rather than failing.
+
+    const gates = [0, 1, 2].map(() => Promise.withResolvers<void>());
+    const captured = [0, 1, 2].map(() => Promise.withResolvers<void>());
+    const applies: ApplyRequest[] = [];
+    const { controller, view, errors } = controllerHarness({
+      initial: inactiveSnapshot("abc"),
+      followups: [
+        activeSnapshotAt("abcX", 1),
+        activeSnapshotAt("abcXY", 2),
+        activeSnapshotAt("abcXYZ", 3),
+      ],
+      apply: async (request) => {
+        const index = applies.length;
+        applies.push(request);
+        captured[index].resolve();
+        await gates[index].promise;
+        return resolutionFor(request);
+      },
+    });
+
+    await controller.start();
+    view.dispatch({ changes: { from: 3, insert: "X" } });
+    const sending = controller.localDocChanged();
+    await captured[0].promise;
+    const stopped = controller.stop();
+    view.dispatch({ changes: { from: 4, insert: "Y" } });
+    gates[0].resolve();
+    await captured[1].promise;
+    view.dispatch({ changes: { from: 5, insert: "Z" } });
+    gates[1].resolve();
+    // A stop that gives up on the pending edit rejects here instead.
+    await Promise.race([captured[2].promise, stopped]);
+    gates[2].resolve();
+    await Promise.all([sending, stopped]);
+
+    expect(errors).toEqual([]);
+    expect(
+      applies.map((request) => [
+        request.base?.version ?? null,
+        (request.payload as { updates: unknown[] }).updates.length,
+      ]),
+    ).toEqual([[null, 1], [1, 1], [2, 1]]);
+    expect(view.state.doc.toString()).toBe("abcXYZ");
+    expect(sendableUpdates(view.state)).toHaveLength(0);
+  });
+
   it("isolates synchronization observers from the Memory operation path", async () => {
     const accepted = acceptedResolution("abc", 1, "X");
     const { controller, view, errors } = controllerHarness({

--- a/packages/ui/src/v2/components/cf-code-editor/codemirror-collaboration.test.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/codemirror-collaboration.test.ts
@@ -1163,6 +1163,105 @@ describe("CodeMirror operation collaboration", () => {
     }
   });
 
+  it("submits an edit once when several waiters wake from the same drain", async () => {
+    // Waiters woken by one drain's end each re-read the queue. Only the first
+    // may own the next drain; the others must see that drain in flight and
+    // wait again, or the same update goes out under two submission ids.
+
+    for (let offset = 0; offset < 6; offset++) {
+      const applies: ApplyRequest[] = [];
+      const { controller, view, errors } = controllerHarness({
+        initial: inactiveSnapshot("abc"),
+        followups: [
+          activeSnapshotAt("abcX", 1),
+          activeSnapshotAt("abcXY", 2),
+        ],
+        apply: (request) => {
+          applies.push(request);
+          return resolutionFor(request);
+        },
+      });
+      await controller.start();
+      let late: Promise<void> | undefined;
+      controller.observeSynchronization((snapshot) => {
+        if (late !== undefined || snapshot?.confirmedCursor.version !== 1) {
+          return;
+        }
+        late = Promise.resolve().then(async () => {
+          for (let hop = 0; hop < offset; hop++) await Promise.resolve();
+          view.dispatch({ changes: { from: 4, insert: "Y" } });
+        });
+      });
+      view.dispatch({ changes: { from: 3, insert: "X" } });
+      const sends = [
+        controller.localDocChanged(),
+        controller.localDocChanged(),
+        controller.localDocChanged(),
+      ];
+      await Promise.all(sends);
+      await late;
+      await controller.localDocChanged();
+
+      expect(errors).toEqual([]);
+      const submitted = applies.flatMap((request) =>
+        (request.payload as { updates: unknown[] }).updates
+      );
+      expect(submitted).toHaveLength(2);
+      expect(view.state.doc.toString()).toBe("abcXY");
+      expect(sendableUpdates(view.state)).toHaveLength(0);
+      await controller.stop();
+    }
+  });
+
+  it("confirms a rewrite Memory suppressed as a duplicate through the intervening operation", async () => {
+    // Bob integrated the same rewrite first, so Memory accepts alice's
+    // submission with no operations of its own; the follow-up query carries
+    // bob's, and its dedupe id confirms alice's queue head.
+
+    const applies: ApplyRequest[] = [];
+    const bobRewrite = {
+      opId: "op:bob:2",
+      cursor: { epoch: 1, version: 2 },
+      submissionId: "bob:2",
+      payload: {
+        updates: [{
+          clientId: "bob",
+          changes: ChangeSet.of({ from: 0, to: 3, insert: "new" }, 3).toJSON(),
+          dedupeId: "title:old:new",
+        }],
+      } as ApplyOpResolution["operations"][number]["payload"],
+    };
+    const { controller, view, errors } = controllerHarness({
+      initial: activeSnapshotAt("old", 1),
+      followup: { ...activeSnapshotAt("new", 2), operations: [bobRewrite] },
+      apply: (request) => {
+        applies.push(request);
+        return {
+          ...resolutionFor(request),
+          from: { epoch: 1, version: 2 },
+          to: { epoch: 1, version: 2 },
+          operations: [],
+        };
+      },
+    });
+
+    await controller.start();
+    view.dispatch({
+      changes: { from: 0, to: 3, insert: "new" },
+      effects: codeMirrorRewriteDedupeEffect.of("title:old:new"),
+    });
+    await controller.localDocChanged();
+
+    expect(errors).toEqual([]);
+    expect(applies).toHaveLength(1);
+    expect(view.state.doc.toString()).toBe("new");
+    expect(sendableUpdates(view.state)).toHaveLength(0);
+    expect(controller.synchronizationSnapshot?.confirmedCursor).toEqual({
+      epoch: 1,
+      version: 2,
+    });
+  });
+
   it("isolates synchronization observers from the Memory operation path", async () => {
     const accepted = acceptedResolution("abc", 1, "X");
     const { controller, view, errors } = controllerHarness({

--- a/packages/ui/src/v2/components/cf-code-editor/codemirror-collaboration.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/codemirror-collaboration.ts
@@ -628,7 +628,9 @@ export class CodeMirrorCollaborationController {
    * submission before the update this caller observed, so waiting and then
    * re-reading is what makes that update the responsibility of a submission
    * serialized after it was recorded: this call's, or that of a drain another
-   * waiter started first.
+   * waiter started first. Waiting again whenever a drain is in flight is what
+   * keeps several waiters woken by the same drain from each starting one and
+   * submitting the same update under two submission ids.
    */
   async #flush(): Promise<void> {
     while (this.#flushPromise !== undefined) {
@@ -702,12 +704,16 @@ export class CodeMirrorCollaborationController {
         ...(base === null ? { baselineHash: this.#baselineHash } : {}),
         payload: submission.payload,
       }, this.#operationSessionId);
+      // A superseding controller owns the compartment once this one is
+      // disposed; a late resolution must not be dispatched into it.
+      if (this.#disposed) return;
       this.#receiveResolution(resolution);
       const snapshot = await this.#runtime.queryOperationField(
         this.#cell,
         this.#cursor ?? undefined,
         this.#operationSessionId,
       );
+      if (this.#disposed) return;
       this.#receive(snapshot);
     } catch (error) {
       this.#fail(error);

--- a/packages/ui/src/v2/components/cf-code-editor/codemirror-collaboration.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/codemirror-collaboration.ts
@@ -365,7 +365,7 @@ export class CodeMirrorCollaborationController {
   /** Confirms every pending edit before a semantic external rewrite. */
   async prepareExternalChange(): Promise<boolean> {
     if (!this.active || this.#failed) return false;
-    await this.#flushAll();
+    await this.#flush();
     return this.active && sendableUpdates(this.#view.state).length === 0;
   }
 
@@ -399,7 +399,7 @@ export class CodeMirrorCollaborationController {
     }
     this.#closing = true;
     try {
-      await this.#flushAll();
+      await this.#flush();
       if (sendableUpdates(this.#view.state).length !== 0) {
         throw new Error(
           "CodeMirror collaboration cannot stop with local edits pending",
@@ -418,7 +418,7 @@ export class CodeMirrorCollaborationController {
     }
     this.#closing = true;
     try {
-      await this.#flushAll();
+      await this.#flush();
       if (sendableUpdates(this.#view.state).length !== 0) {
         throw new Error(
           "CodeMirror collaboration cannot be released with local edits pending",
@@ -443,6 +443,16 @@ export class CodeMirrorCollaborationController {
     }
   }
 
+  /**
+   * Replaces the document and CodeMirror's collaboration state with the
+   * snapshot's canonical epoch.
+   *
+   * Installing discards CodeMirror's unconfirmed queue, which is the only
+   * record of a local edit Memory has not confirmed. An installed controller
+   * holding unconfirmed edits therefore refuses, failing with a
+   * `CodeMirrorReconciliationError` that carries both values, so the host
+   * reports the conflict instead of adopting the canonical value silently.
+   */
   #install(snapshot: OperationFieldSnapshot): void {
     if (typeof snapshot.materialized !== "string") {
       throw new Error("CodeMirror collaboration requires a string field");
@@ -455,6 +465,17 @@ export class CodeMirrorCollaborationController {
       );
     }
     this.#assertFieldIdentity(snapshot);
+    // Before the first installation the compartment holds no collaboration
+    // field, and there is nothing to discard; `#ready` is what says a field
+    // is installed and its queue can be read.
+    if (this.#ready && sendableUpdates(this.#view.state).length !== 0) {
+      throw new CodeMirrorReconciliationError(
+        this.#view.state.doc.toString(),
+        snapshot.materialized,
+        this.#cursor,
+        snapshot.active ? snapshot.cursor : null,
+      );
+    }
     const version = snapshot.cursor?.version ?? 0;
     this.#ready = false;
     // Invalidate observer state before any transaction can map ephemeral
@@ -509,14 +530,6 @@ export class CodeMirrorCollaborationController {
             this.#baselineHash = snapshot.baselineHash;
             return;
           }
-          if (sendableUpdates(this.#view.state).length !== 0) {
-            throw new CodeMirrorReconciliationError(
-              this.#view.state.doc.toString(),
-              snapshot.materialized,
-              this.#cursor,
-              null,
-            );
-          }
           this.#install(snapshot);
           return;
         }
@@ -542,14 +555,6 @@ export class CodeMirrorCollaborationController {
       }
 
       if (snapshot.reset === true) {
-        if (sendableUpdates(this.#view.state).length !== 0) {
-          throw new CodeMirrorReconciliationError(
-            this.#view.state.doc.toString(),
-            snapshot.materialized,
-            this.#cursor,
-            snapshot.cursor,
-          );
-        }
         this.#install(snapshot);
         return;
       }
@@ -559,14 +564,6 @@ export class CodeMirrorCollaborationController {
       if (becameActive) {
         this.#cursor = { epoch: snapshot.cursor.epoch, version: 0 };
       } else if (previousCursor.epoch !== snapshot.cursor.epoch) {
-        if (sendableUpdates(this.#view.state).length !== 0) {
-          throw new CodeMirrorReconciliationError(
-            this.#view.state.doc.toString(),
-            snapshot.materialized,
-            this.#cursor,
-            snapshot.cursor,
-          );
-        }
         this.#install(snapshot);
         return;
       }
@@ -623,35 +620,78 @@ export class CodeMirrorCollaborationController {
     }
   }
 
+  /**
+   * Waits for any running drain, re-reads the queue, and owns the next drain
+   * if unconfirmed updates remain.
+   *
+   * One drain runs at a time. A running drain may have serialized its
+   * submission before the update this caller observed, so waiting and then
+   * re-reading is what makes that update the responsibility of a submission
+   * serialized after it was recorded: this call's, or that of a drain another
+   * waiter started first.
+   */
   async #flush(): Promise<void> {
-    if (this.#flushPromise !== undefined) {
-      return await this.#flushPromise;
+    while (this.#flushPromise !== undefined) {
+      try {
+        await this.#flushPromise;
+      } catch {
+        // The drain's owner receives its rejection; a waiter only needs it
+        // to have settled.
+      }
     }
-    if (!this.#canProcess() || this.#failed) return;
-    const pending = this.#flushOnce();
-    this.#flushPromise = pending;
+    if (
+      !this.#canProcess() || sendableUpdates(this.#view.state).length === 0
+    ) {
+      return;
+    }
+    const drain = this.#drain();
+    this.#flushPromise = drain;
     try {
-      await pending;
+      await drain;
     } finally {
-      if (this.#flushPromise === pending) this.#flushPromise = undefined;
+      if (this.#flushPromise === drain) this.#flushPromise = undefined;
     }
   }
 
-  async #flushAll(): Promise<void> {
-    await this.#flush();
+  /**
+   * Submits unconfirmed local updates, one round trip at a time, until none
+   * remain or this controller can no longer process.
+   *
+   * CodeMirror's unconfirmed queue is the only record of a local edit before
+   * Memory confirms it, so every update recorded there is either confirmed by
+   * a submission or reported through `onError`. An update recorded while a
+   * submission is in flight stays queued, rebased over whatever that
+   * submission integrates, and the next round trip carries it.
+   */
+  async #drain(): Promise<void> {
     while (
       this.#canProcess() && sendableUpdates(this.#view.state).length !== 0
     ) {
-      await this.#flush();
+      // CodeMirror keeps an update's origin transaction across rebases, so
+      // the oldest unconfirmed update still heading the queue after a round
+      // trip means that round trip confirmed nothing, and repeating it would
+      // repeat forever. This bounds each round trip to confirming at least
+      // its oldest update; a later update left unconfirmed heads the next
+      // round trip and is judged there.
+      const oldest = sendableUpdates(this.#view.state)[0].origin;
+      await this.#submit();
+      if (
+        this.#canProcess() &&
+        sendableUpdates(this.#view.state)[0]?.origin === oldest
+      ) {
+        this.#fail(
+          new Error("CodeMirror submission confirmed no local update"),
+        );
+      }
     }
   }
 
-  async #flushOnce(): Promise<void> {
-    const submission = codeMirrorSubmission(this.#view.state);
-    if (submission === undefined) return;
+  /** Submits every unconfirmed update in one apply and integrates the result. */
+  async #submit(): Promise<void> {
     this.#sending = true;
-    let accepted = false;
     try {
+      const submission = codeMirrorSubmission(this.#view.state);
+      if (submission === undefined) return;
       const base = this.#cursor === null
         ? null
         : { epoch: this.#cursor.epoch, version: submission.baseVersion };
@@ -669,17 +709,10 @@ export class CodeMirrorCollaborationController {
         this.#operationSessionId,
       );
       this.#receive(snapshot);
-      accepted = !this.#failed;
     } catch (error) {
       this.#fail(error);
     } finally {
       this.#sending = false;
-    }
-    if (
-      accepted && this.#canProcess() &&
-      codeMirrorSubmission(this.#view.state) !== undefined
-    ) {
-      queueMicrotask(() => void this.#flush());
     }
   }
 


### PR DESCRIPTION
## Why

`cf-code-editor` in `collaborative` mode silently lost keystrokes typed while a commit round trip was in flight. A burst of seven characters produced one integrated operation; the other six stayed in CodeMirror's unconfirmed queue forever, were never sent, and vanished on reload. No error, no reconcile event, clean console.

The controller's tail continuation was the cause, not the transport or the server. After a submission resolved, `#flushOnce` queued `queueMicrotask(() => this.#flush())` to pick up whatever had accumulated. That microtask ran *before* `#flush`'s `finally` cleared `#flushPromise`, so the re-entrant `#flush` saw a flush "in progress", awaited the already-finished promise, and returned. The queue stalled rather than being discarded: after a fast burst, `synchronizationSnapshot.pendingChanges` held six changes while the document held all seven characters.

The invariant this change states in code, on `#drain` and `#install` in `codemirror-collaboration.ts`:

> CodeMirror's unconfirmed queue is the only record of a local edit before Memory confirms it. Every update recorded there is either confirmed by a submission or reported through `onError`. Installing a snapshot discards that queue, so an installed controller holding unconfirmed edits refuses with a `CodeMirrorReconciliationError` carrying both values instead of adopting the canonical value silently.

Loom vendors labs and will pick this up at its next vendor pin bump.

## What changed

- `#flush` is the single drain entry: it waits for any running drain, re-reads the queue, and owns the next drain if updates remain. The re-read is what makes a caller's own edit its responsibility even when it was recorded in the window between a drain's last queue read and the in-flight promise clearing.
- `#drain` submits round trip after round trip until the queue is empty or the controller cannot process. `#flushAll` and the microtask tail are gone; `stop()`, `release()`, and `prepareExternalChange()` call `#flush`.
- A round trip that leaves the same oldest unconfirmed update at the head of the queue fails the controller instead of resubmitting forever. CodeMirror preserves an update's origin transaction across rebases, so that identity is the progress test.
- `#install` owns the guard against discarding unconfirmed edits; the three `#receive` sites that reinstall (inactive, reset, epoch change) dropped their duplicate checks. For an inactive snapshot the reconcile event's canonical cursor stays `null`, as before.
- No changeset composition. The server codec already turns each update in one submission into its own integrated operation, so one round trip carries every pending update; composing would collapse versions and lose `dedupeId`s on rewrites. No protocol or codec change; `clientId` semantics unchanged.
- `#submit` stops after each await once the controller is disposed, so a round trip that outlives a superseding controller never dispatches into the compartment that controller reinstalled. Red-first unit test.
- `_cleanupCollaboration` in `cf-code-editor.ts` emits `cf-error` when the final `stop()` on detach rejects, instead of swallowing it; the controller's own `onError` is ignored once the generation has moved on, so that catch was the only place the failure could surface. Red-first component test.
- `docs/features/collaborative-fields.md` states the submission behavior.

## Test plan

Unit (`codemirror-collaboration.test.ts`, all red-first or mutation-checked):
- burst during an in-flight submission is submitted next (red on main: one apply, six edits stranded)
- `stop()` drains edits recorded during its own submissions (reddens when `#drain` submits once instead of looping)
- edits recorded during a round trip rebase over an operation that intervened at Memory
- a round trip that confirms nothing fails closed (reddens when the guard is removed: the harness sees a resubmission)
- an edit recorded at any microtask offset from a drain's last confirmation is submitted (reddens when `#flush` returns after waiting instead of re-reading the queue)
- several waiters woken by one drain submit an edit once (reddens when `#flush`'s `while` becomes a fall-through `if`: two waiters each start a drain and the same update goes out under two submission ids)
- a rewrite Memory suppressed as a duplicate is confirmed through the intervening operation the follow-up query carries, so the no-progress guard stays quiet on the one legitimate no-operation response

Browser integration (`packages/patterns/integration/cf-code-editor-collaboration.test.ts`, using the existing apply gate so "typed during the round trip" is deterministic):
- single-client burst lands on the other browser and survives a reload — red on main (waiter backstop), green with the fix
- concurrent bursts from both browsers converge — red on main, green with the fix
- burst pending when another browser releases the epoch reaches the reconcile event with every edit — green on main by design (it pins the never-silently-lost half); red when the `#install` guard is removed, together with the pre-existing release test, while both burst tests stay green under that mutation

Full file green with the fix: 10 tests. Repo gates: `deno fmt --check`, `deno lint`, `deno task check`, `check-no-waitfor`, `check-docs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UegM2xENsCCiMjAU5C9mH4
