### PR TITLE
fix(cf-harness): the console reads a release off its reason code (CT-2232)

### DIFF
--- a/packages/cf-harness/console/README.md
+++ b/packages/cf-harness/console/README.md
@@ -502,10 +502,14 @@ record of what the run recorded rather than a cell with nothing to hide.
     confidentiality boundary holding back the values of a result the call did
     return, so the count of the positions it held back sits beside it and the
     step itself stays the success its answer states; the dot goes amber only for
-    a call that did not run. A policy event appears beside the decision, which
-    is how a call CFC _allowed_ but whose _observation_ it refused reads as the
-    two separate facts it is. The flow labels the runtime computed for each
-    input position appear here too.
+    a call that did not run. Which of the three it is comes from the `release`
+    record's own reason code wherever a boundary decided, not from the outcome
+    word the run persisted beside it — the same field AUD-16 counts — so a run
+    recorded before that word existed reads here as what its boundary actually
+    decided. A policy event appears beside the decision, which is how a call CFC
+    _allowed_ but whose _observation_ it refused reads as the two separate facts
+    it is. The flow labels the runtime computed for each input position appear
+    here too.
   - **disclosure** — how many bytes the result let across as a plain value, how
     many positions it sealed behind a reference, and the longest run of numbers
     it carried. A long numeric run is called out, in the rail as well: the

--- a/packages/cf-harness/console/steps.ts
+++ b/packages/cf-harness/console/steps.ts
@@ -23,6 +23,12 @@ import type {
 import type { ToolResultRef } from "../src/contracts/tool-result.ts";
 import type { HarnessPolicyEvent } from "../src/contracts/policy.ts";
 import type { HarnessPolicyDecisionRecord } from "../src/contracts/policy-trace.ts";
+import type { HarnessToolPolicyDecision } from "../src/contracts/run-report.ts";
+import {
+  HARNESS_RELEASE_BOUNDARIES,
+  HARNESS_RELEASE_DECISION_REASON_CODES,
+  harnessReleaseDecisionOutcome,
+} from "../src/contracts/policy-refusal.ts";
 import type { HarnessCfcInvocationContext } from "../src/contracts/cfc-invocation-context.ts";
 import type {
   HarnessTranscriptOmissionRule,
@@ -426,6 +432,52 @@ const TOOL_SUCCESS_STATUSES = new Map<string, readonly string[]>([
 /** What a tool this does not name is taken to report success with. */
 const DEFAULT_SUCCESS_STATUSES: readonly string[] = ["ok", "completed"];
 
+/**
+ * What a decision decided, taken from the boundary's own reason code wherever
+ * a boundary decided it.
+ *
+ * The outcome word a run persisted is the word its build could spell, and a
+ * run recorded before a word existed carries the one it had. The reason code
+ * on the `release` record is the fact, and it does not move: a decision
+ * naming `cfc_release_withheld` is a withheld release whatever the trace says
+ * beside it. Reading it this way is what AUD-16 does, so the console and the
+ * audit answer alike over one corpus.
+ *
+ * `denied` is left to a decision with no release record — a call authority
+ * refused, which never ran — and to `cfc_commit_refused`, a write the runner
+ * refused, which landed no result.
+ */
+const outcomeOf = (
+  decision: HarnessPolicyDecisionRecord | undefined,
+): HarnessToolPolicyDecision | undefined => {
+  if (decision === undefined) return undefined;
+  const release = decision.release as
+    | { reasonCode?: unknown; boundary?: unknown }
+    | null
+    | undefined;
+  // `null` as well as absent: a decision persisted with an empty release is a
+  // record this cannot read, and dereferencing it would throw before the step
+  // could be given a status at all.
+  if (release === null || release === undefined) return decision.decision;
+  // Both discriminants are checked against the sets the contract exports for
+  // the purpose, rather than against literals repeated here: a closed union
+  // that gains a member should widen what this reads, not silently stop
+  // matching a record the contract calls valid. A trace is read back through
+  // JSON, so a record answering neither set is a release record this cannot
+  // read — not evidence to rewrite a persisted outcome with, so the persisted
+  // word stands.
+  const boundary = HARNESS_RELEASE_BOUNDARIES.find((known) =>
+    known === release.boundary
+  );
+  if (boundary === undefined) return decision.decision;
+  const reasonCode = HARNESS_RELEASE_DECISION_REASON_CODES.find((known) =>
+    known === release.reasonCode
+  );
+  return reasonCode === undefined
+    ? decision.decision
+    : harnessReleaseDecisionOutcome(reasonCode);
+};
+
 /** How a tool step turned out, read from its own result and CFC's verdict. */
 const statusOf = (
   toolName: string,
@@ -434,8 +486,9 @@ const statusOf = (
   decision: HarnessPolicyDecisionRecord | undefined,
   events: readonly HarnessPolicyEvent[],
 ): ConsoleStepStatus => {
+  const outcome = outcomeOf(decision);
   if (
-    decision?.decision === "denied" ||
+    outcome === "denied" ||
     events.some((event) => event.severity === "denied")
   ) {
     return "denied";
@@ -443,10 +496,10 @@ const statusOf = (
   // A call rejected for its arguments ran nothing, and its answer carries no
   // status field of its own to read that from. It is an error rather than a
   // denial: policy refused it nothing.
-  if (decision?.decision === "invalid") {
+  if (outcome === "invalid") {
     return "error";
   }
-  // A `withheld` decision is deliberately not read here. The call ran and
+  // A `withheld` outcome is deliberately not read here. The call ran and
   // answered with the reference to the result whose values the boundary held
   // back, so the step's outcome is the one its own answer states, below; the
   // boundary shows as the withheld marker beside the CFC line instead.
@@ -732,7 +785,9 @@ export const consoleRunSteps = (
         ...(decision !== undefined
           ? {
             policy: {
-              decision: decision.decision,
+              // The badge and the marker beside it read this word, so the
+              // rule lives here once rather than again at the view.
+              decision: outcomeOf(decision) ?? decision.decision,
               ...(decision.effectClass !== undefined
                 ? { effectClass: decision.effectClass }
                 : {}),

--- a/packages/cf-harness/test/console/src/steps-view.test.ts
+++ b/packages/cf-harness/test/console/src/steps-view.test.ts
@@ -318,6 +318,57 @@ describe("console/src/steps-view", () => {
       expect(text).toContain("Open subagent run");
     });
 
+    it("marks a legacy trace's withheld release, whose persisted word is `denied`", () => {
+      // The whole path, from the record on disk to the badge: a run recorded
+      // before the outcome existed persisted `denied` beside a release that
+      // held values back, and the view must still show the boundary rather
+      // than a denial of a call that ran.
+      const steps = consoleRunSteps(
+        [
+          {
+            role: "assistant",
+            content: "",
+            toolCalls: [{
+              id: "c1",
+              type: "function",
+              function: { name: "run_pattern", arguments: "{}" },
+            }],
+          },
+          {
+            role: "tool",
+            toolCallId: "c1",
+            toolName: "run_pattern",
+            content: JSON.stringify({ status: "ok" }),
+          },
+        ],
+        [{
+          type: "cf-harness.policy-decision",
+          sequence: 1,
+          runId: "run-legacy",
+          at: "2026-01-01T00:00:00.000Z",
+          toolActivitySequence: 1,
+          toolCallId: "c1",
+          toolId: "run_pattern",
+          cfcEnforcementMode: "enforce-explicit",
+          decision: "denied",
+          reasonCodes: ["cfc_release_withheld"],
+          release: {
+            reasonCode: "cfc_release_withheld",
+            boundary: "release",
+            sink: "run_pattern",
+            ceiling: [],
+          },
+        }],
+      );
+      const view = new TestConsoleSteps();
+      view.steps = steps;
+
+      const text = templateText(view.view());
+      expect(steps[0].status).toBe("ok");
+      expect(text).toContain("withheld");
+      expect(text).not.toContain("denied");
+    });
+
     it("marks a withheld release beside the CFC line of a step that succeeded", () => {
       const step: ConsoleStep = {
         index: 0,

--- a/packages/cf-harness/test/console/steps.test.ts
+++ b/packages/cf-harness/test/console/steps.test.ts
@@ -9,6 +9,7 @@ import {
 import type { HarnessTranscriptMessage } from "../../src/contracts/transcript.ts";
 import type { HarnessHandleTable } from "../../src/contracts/handle-table.ts";
 import type { HarnessCfcInvocationContext } from "../../src/contracts/cfc-invocation-context.ts";
+import type { HarnessPolicyDecisionRecord } from "../../src/contracts/policy-trace.ts";
 import { createToolOutputId } from "../../src/contracts/tool-result.ts";
 import {
   HARNESS_CELL_LABELS_TYPE,
@@ -744,6 +745,152 @@ describe("console/steps CFC and disclosure", () => {
     expect(steps[0].status).toBe("ok");
     expect(steps[0].policy?.decision).toBe("withheld");
     expect(steps[0].policy?.reasonCodes).toEqual(["cfc_release_withheld"]);
+  });
+
+  it("reads a legacy trace's withheld release off its reason code, not its outcome word", () => {
+    // A run recorded before the `withheld` outcome existed persisted `denied`
+    // beside a release that held values back. The reason code is the fact and
+    // does not move, so the console reads the step off that — the same field
+    // AUD-16 counts — and an old family reads alike whichever build opens it.
+    const steps = consoleRunSteps(
+      [
+        call("c1", "run_pattern", { sourceText: "x" }),
+        result("c1", "run_pattern", {
+          status: "ok",
+          resultRef: { outputId: "out-1" },
+          valueError: "the values are withheld; resultRef still names them",
+        }),
+      ],
+      [
+        {
+          type: "cf-harness.policy-decision",
+          sequence: 1,
+          runId: "run-legacy",
+          at: "2026-01-01T00:00:00.000Z",
+          toolActivitySequence: 1,
+          toolCallId: "c1",
+          toolId: "run_pattern",
+          cfcEnforcementMode: "enforce-explicit",
+          decision: "allowed",
+          reasonCodes: ["cfc_enforce_explicit_direct_command"],
+        },
+        {
+          type: "cf-harness.policy-decision",
+          sequence: 2,
+          runId: "run-legacy",
+          at: "2026-01-01T00:00:00.000Z",
+          toolActivitySequence: 1,
+          toolCallId: "c1",
+          toolId: "run_pattern",
+          cfcEnforcementMode: "enforce-explicit",
+          decision: "denied",
+          reasonCodes: ["cfc_release_withheld"],
+          release: {
+            reasonCode: "cfc_release_withheld",
+            boundary: "release",
+            sink: "run_pattern",
+            ceiling: [],
+          },
+        },
+      ],
+    );
+
+    expect(steps[0].status).toBe("ok");
+    expect(steps[0].policy?.decision).toBe("withheld");
+  });
+
+  it("keeps `denied` for a decision no boundary decided", () => {
+    // The other half of the rule: a call authority refused carries no release
+    // record, so nothing rewrites its word and the step stays denied.
+    const steps = consoleRunSteps(
+      [
+        call("c1", "write_file", { path: "x" }),
+        result("c1", "write_file", { status: "error" }),
+      ],
+      [{
+        type: "cf-harness.policy-decision",
+        sequence: 1,
+        runId: "run-denied",
+        at: "2026-01-01T00:00:00.000Z",
+        toolActivitySequence: 1,
+        toolCallId: "c1",
+        toolId: "write_file",
+        cfcEnforcementMode: "enforce-explicit",
+        decision: "denied",
+        reasonCodes: ["write_file_enforce_explicit_direct_command"],
+      }],
+    );
+
+    expect(steps[0].status).toBe("denied");
+    expect(steps[0].policy?.decision).toBe("denied");
+  });
+
+  it("keeps the persisted word when the release record answers neither closed set", () => {
+    // A trace is read back through JSON. A release record whose boundary or
+    // reason code is outside the contract's sets is a record the console
+    // cannot read, and an unreadable record is not evidence to rewrite a
+    // persisted outcome with — so the word the run recorded stands. `null` is
+    // the same reading, and would throw if it were dereferenced instead.
+    const legacy = {
+      type: "cf-harness.policy-decision",
+      sequence: 1,
+      runId: "run-malformed",
+      at: "2026-01-01T00:00:00.000Z",
+      toolActivitySequence: 1,
+      toolCallId: "c1",
+      toolId: "run_pattern",
+      cfcEnforcementMode: "enforce-explicit",
+      decision: "denied",
+      reasonCodes: ["cfc_release_withheld"],
+    } as const;
+    const transcript = [
+      call("c1", "run_pattern", { sourceText: "x" }),
+      result("c1", "run_pattern", { status: "ok" }),
+    ];
+    const malformed = [
+      // A boundary outside the set, beside a reason code inside it.
+      { reasonCode: "cfc_release_withheld", boundary: "egress" },
+      // A reason code outside the set, beside a boundary inside it.
+      { reasonCode: "cfc_release_maybe", boundary: "release" },
+      // No discriminant at all, and an empty record.
+      { sink: "run_pattern" },
+      null,
+    ];
+
+    for (const release of malformed) {
+      const steps = consoleRunSteps(transcript, [
+        { ...legacy, release } as unknown as HarnessPolicyDecisionRecord,
+      ]);
+      expect(steps[0].status).toBe("denied");
+      expect(steps[0].policy?.decision).toBe("denied");
+    }
+  });
+
+  it("reads a refused commit as denied, since it landed no result", () => {
+    // A release record does not by itself mean the call answered: the runner
+    // refused this write, so `cfc_commit_refused` keeps the denial.
+    const steps = consoleRunSteps(
+      [
+        call("c1", "run_pattern", { sourceText: "x" }),
+        result("c1", "run_pattern", { status: "ok" }),
+      ],
+      [{
+        type: "cf-harness.policy-decision",
+        sequence: 1,
+        runId: "run-commit",
+        at: "2026-01-01T00:00:00.000Z",
+        toolActivitySequence: 1,
+        toolCallId: "c1",
+        toolId: "run_pattern",
+        cfcEnforcementMode: "enforce-strict",
+        decision: "denied",
+        reasonCodes: ["cfc_commit_refused"],
+        release: { reasonCode: "cfc_commit_refused", boundary: "commit" },
+      }],
+    );
+
+    expect(steps[0].status).toBe("denied");
+    expect(steps[0].policy?.decision).toBe("denied");
   });
 
   it("measures the longest numeric run a result let across as value", () => {


### PR DESCRIPTION
Follow-up to #6873. That PR gave a withheld release its own outcome word; this
one makes the console read the fact rather than the word, so families already on
disk read correctly.

## The finding

After #6873 landed and the demo console relaunched on `bf686fd317`, family
`f32f3ed3-…subagent.1` steps 16 and 17 **still rendered DENIED**.
`console/steps.ts` `statusOf` keyed on the persisted outcome word, and that
family's `policy-trace.json` was written before #6873, so it still says
`denied`.

My verification on #6873 re-derived each decision through the new mapping
instead of reading the persisted record, which is exactly why it passed and the
defect survived. Reproduced here against the untouched persisted trace before
fixing anything:

```
step 16 run_pattern status=denied decision=denied persisted=denied
step 17 run_pattern status=denied decision=denied persisted=denied
```

## The rule

The reason code on the `release` record is the fact, and it does not move; the
outcome word is whatever the recording build could spell. A decision naming
`cfc_release_withheld` is a withheld release however the trace spelled it
beside. That is what AUD-16 does since #6872, so the console and the audit now
answer alike over one corpus.

`denied` is left to a decision with **no** release record — a call authority
refused, which never ran — and to `cfc_commit_refused`, a write the runner
refused, which landed no result.

## Where it lives

`console/steps.ts` gains `outcomeOf`, which reuses `harnessReleaseDecisionOutcome`
rather than re-deriving the mapping, and validates the release record before
trusting it — a trace is read back through JSON. `null` or absent returns the
persisted word without dereferencing; then both discriminants are checked
against the sets the contract exports, `HARNESS_RELEASE_BOUNDARIES` and
`HARNESS_RELEASE_DECISION_REASON_CODES`, the same shape `harnessReleaseDecisionOf`
and the audit's `releaseReasonOf` use. A record failing either is one the console
cannot read, and an unreadable record is not evidence to rewrite a persisted
outcome with, so the recorded word stands.

`statusOf` and the step's `policy.decision` both go through it, so
`steps-view.ts` is **unchanged**: it already picks the withheld badge on
`decision === "withheld"` and now receives the normalized word. The rule is one
predicate at the builder rather than two that can drift — which is the shape of
defect this PR exists to fix.

## Verification, against the persisted record this time

Same family, same files, decisions passed to `consoleRunSteps` exactly as they
sit on disk — no re-derivation:

```
step 16 run_pattern status=ok decision=withheld persisted=denied
step 17 run_pattern status=ok decision=withheld persisted=denied
```

## Tests

Four added to `test/console/steps.test.ts`, every side of the rule:
a legacy entry (`decision: "denied"` with `release.reasonCode:
"cfc_release_withheld"`) reads `ok` + `withheld`; a decision with no release
record stays `denied`; `cfc_commit_refused` stays `denied`; and a malformed
release record — boundary outside the set, reason code outside the set, neither
discriminant, `null` — keeps the persisted word. That last one was checked
against a disabled guard to confirm it can fail. One added to
`test/console/src/steps-view.test.ts` driving the whole path — legacy trace
entry through `consoleRunSteps` into the rendered view — so the badge is pinned
end to end and not only at the builder. Every existing test kept.

## Docs

`console/README.md`'s **cfc** bullet, which states what the pane shows and so
states the rule. The cf-harness `README.md` trace vocabulary describes what is
persisted, not what the console reads, and the system map's release-decision
entry stays true as written — neither needed an edit, checked rather than
assumed, so no `SNAPSHOT` bump.

## Gates

Deno 2.9.4, all by exit code. `deno task test` in `packages/cf-harness`:
**974 passed, 0 failed**. Repo-wide `deno fmt --check`, `deno lint`,
`deno task check`, `check-docs`, `check-skill-facts`, `check-package-cycles`,
`check-conflict-markers`, `check-control-characters`, `check-command-docs`,
`check-docs-history-index` — clean.

Linear-issue: CT-2232

🤖 Generated with [Claude Code](https://claude.com/claude-code)
