### PR TITLE
perf(scheduler): a node records its invalid causes by key

### DIFF
--- a/docs/specs/scheduler-v2/README.md
+++ b/docs/specs/scheduler-v2/README.md
@@ -228,7 +228,7 @@ interface SchedulerNode {
   // Dynamic:
   reads: ReadSet;                // registered read set (drives the reader index)
   status: "never-ran" | "clean" | "invalid";
-  invalidCauses: Address[];      // CFC trigger reads (§10); cleared on run
+  invalidCauses: Map<Key, Address>; // CFC trigger reads (§10), one per address; cleared on run
   liveRefs: number;              // demand refcount (§5)
   provisionalDemand: boolean;    // (§5.3)
   gate: GateState;               // debounce/throttle/backoff (§8)
@@ -478,7 +478,7 @@ ancestor-path, or child-key-set changes.
 `markInvalid(N, cause)`:
 
 ```
-N.invalidCauses += cause                       // CFC §8.9.2 accumulation
+N.invalidCauses[key(cause)] = cause            // CFC §8.9.2 accumulation; an address already recorded stays recorded once
 if N.status == "clean": N.status = "invalid"
 ```
 

--- a/docs/specs/scheduler-v2/README.md
+++ b/docs/specs/scheduler-v2/README.md
@@ -228,7 +228,7 @@ interface SchedulerNode {
   // Dynamic:
   reads: ReadSet;                // registered read set (drives the reader index)
   status: "never-ran" | "clean" | "invalid";
-  invalidCauses: Map<Key, Address>; // CFC trigger reads (§10), one per address; cleared on run
+  invalidCauses: Map<string, Address>; // CFC trigger reads (§10), keyed by address; cleared on run
   liveRefs: number;              // demand refcount (§5)
   provisionalDemand: boolean;    // (§5.3)
   gate: GateState;               // debounce/throttle/backoff (§8)

--- a/packages/runner/src/scheduler/facade.ts
+++ b/packages/runner/src/scheduler/facade.ts
@@ -2757,7 +2757,7 @@ export class Scheduler {
     if (record.status === "invalid") {
       this.nodes.setStatus(action, "clean");
     }
-    record.invalidCauses = [];
+    record.invalidCauses.clear();
   }
 
   private markAndScheduleInvalidAction(

--- a/packages/runner/src/scheduler/invalidation.ts
+++ b/packages/runner/src/scheduler/invalidation.ts
@@ -285,7 +285,7 @@ export function markInvalid(
 }
 
 /**
- * Dedup key for a pending invalid cause. Scope participates (an
+ * The key a pending invalid cause is recorded under. Scope participates (an
  * omitted scope normalizes to `space`, matching storage), and JSON keeps
  * path segments unambiguous: ["a","b"] never collides with ["a/b"].
  */
@@ -299,26 +299,29 @@ function invalidCauseKey(address: IMemorySpaceAddress): string {
 }
 
 /**
- * Add a pending invalid cause, deduping repeats of the same address across
- * notifications and retry restoration.
+ * Record a pending invalid cause. An address already recorded — by an
+ * earlier notification, or by a retry restoring what its run took — stays
+ * recorded once, at the position it first arrived.
  */
 export function addInvalidCause(
   record: SchedulerNode,
   address: IMemorySpaceAddress,
 ): void {
   const key = invalidCauseKey(address);
-  if (record.invalidCauses.some((cause) => invalidCauseKey(cause) === key)) {
-    return;
-  }
-  record.invalidCauses.push(address);
+  if (record.invalidCauses.has(key)) return;
+  record.invalidCauses.set(key, address);
 }
 
+/**
+ * Hand the pending invalid causes to the run that consumes them, in arrival
+ * order, leaving none recorded.
+ */
 export function takeInvalidCauses(
   record: SchedulerNode,
 ): readonly IMemorySpaceAddress[] | undefined {
-  if (record.invalidCauses.length === 0) return undefined;
-  const causes = record.invalidCauses;
-  record.invalidCauses = [];
+  if (record.invalidCauses.size === 0) return undefined;
+  const causes = [...record.invalidCauses.values()];
+  record.invalidCauses.clear();
   return causes;
 }
 

--- a/packages/runner/src/scheduler/node-record.ts
+++ b/packages/runner/src/scheduler/node-record.ts
@@ -33,7 +33,14 @@ export interface SchedulerNode {
   children?: Set<Action>;
   status: NodeStatus;
   declaredReads: IMemorySpaceAddress[];
-  invalidCauses: IMemorySpaceAddress[];
+
+  /**
+   * The addresses whose changes invalidated this node since it last ran, in
+   * arrival order, keyed by `invalidCauseKey` (scheduler/invalidation.ts) so
+   * that a cause arriving again — from a later notification, or restored by
+   * a retry — is recorded once. Taken by the run that consumes them.
+   */
+  invalidCauses: Map<string, IMemorySpaceAddress>;
   liveRefs: number;
   provisionalDemand: boolean;
   provisionalDemandPass?: number;
@@ -115,7 +122,7 @@ export class NodeRegistry {
       kind,
       status: "never-ran",
       declaredReads: [],
-      invalidCauses: [],
+      invalidCauses: new Map(),
       liveRefs: 0,
       provisionalDemand: false,
       gate: { backoffStreak: 0, convergenceHoldPasses: 0 },

--- a/packages/runner/src/scheduler/registration.ts
+++ b/packages/runner/src/scheduler/registration.ts
@@ -468,7 +468,7 @@ function clearActionSchedulingState(
   state.pending.delete(action);
   const record = state.nodes.get(action);
   if (record) {
-    record.invalidCauses = [];
+    record.invalidCauses.clear();
     // Stage B: the fan-out record (known-scope ratchet, per-instance
     // logs) is scheduling state of the LIVE subscription — a re-registered
     // action starts unnarrowed and re-learns by its probe run.

--- a/packages/runner/test/scheduler-cfc-trigger-reads.test.ts
+++ b/packages/runner/test/scheduler-cfc-trigger-reads.test.ts
@@ -4,6 +4,7 @@ import type { MemorySpace } from "@commonfabric/memory/interface";
 import { Runtime } from "../src/runtime.ts";
 import { MAX_RETRIES_FOR_REACTIVE } from "../src/scheduler/constants.ts";
 import {
+  addInvalidCause,
   markInvalid,
   processStorageNotification,
   type StorageNotificationState,
@@ -85,7 +86,7 @@ describe("invalid cause dedup keys", () => {
       },
     );
 
-    expect(record.invalidCauses.length).toBe(3);
+    expect(record.invalidCauses.size).toBe(3);
   });
 });
 
@@ -180,7 +181,7 @@ describe("trigger reads follow the scheduling decision", () => {
 
       process(state, makeCommitNotification(sourceTx));
 
-      expect(state.nodes.get(action)?.invalidCauses.length).toBe(0);
+      expect(state.nodes.get(action)?.invalidCauses.size).toBe(0);
     });
 
     it(`${mode}: skip-same-change-group records no trigger read`, () => {
@@ -197,7 +198,7 @@ describe("trigger reads follow the scheduling decision", () => {
 
       process(state, makeCommitNotification(sourceTx));
 
-      expect(state.nodes.get(action)?.invalidCauses.length).toBe(0);
+      expect(state.nodes.get(action)?.invalidCauses.size).toBe(0);
     });
 
     it(`${mode}: a scheduling change records the trigger read`, () => {
@@ -209,10 +210,9 @@ describe("trigger reads follow the scheduling decision", () => {
 
       process(state, makeCommitNotification({} as IStorageTransaction));
 
-      const causes = state.nodes.get(action)?.invalidCauses;
-      expect(causes).toBeDefined();
-      expect(causes!.length).toBe(1);
-      expect(causes![0]).toMatchObject({
+      const causes = [...state.nodes.get(action)!.invalidCauses.values()];
+      expect(causes.length).toBe(1);
+      expect(causes[0]).toMatchObject({
         space,
         id: "of:cell",
         path: [],
@@ -408,16 +408,17 @@ describe("unsubscribe clears pending trigger reads", () => {
       }).nodes;
       const record = nodes.get(action);
       expect(record).toBeDefined();
-      record!.invalidCauses = [{
+      addInvalidCause(record!, {
         space,
         scope: "space",
         id: "of:stale",
         path: ["value"],
-      }];
+      });
+      expect(record!.invalidCauses.size).toBe(1);
 
       runtime.scheduler.unsubscribe(action);
 
-      expect(record!.invalidCauses.length).toBe(0);
+      expect(record!.invalidCauses.size).toBe(0);
     } finally {
       await runtime.dispose();
       await storageManager.close();

--- a/packages/runner/test/scheduler-invalid-causes.bench.ts
+++ b/packages/runner/test/scheduler-invalid-causes.bench.ts
@@ -1,0 +1,67 @@
+/**
+ * Benchmarks for recording a scheduler node's pending invalid causes.
+ *
+ * `addInvalidCause` runs once per (change × triggered action) inside the
+ * storage commit notification (`processStorageNotification`), synchronously
+ * with the commit, so its cost is paid before the writer's transaction
+ * returns. The shapes below hold the number of causes one node accumulates
+ * before it runs, which is what decides whether recording them stays linear:
+ * a commit that touches many paths of a document a node reads, and the same
+ * causes arriving again from a retry's restoration.
+ *
+ * The `benchmarks.yml` workflow runs this file on main and publishes the
+ * results in its `bench-results` artifact, which the team ops dashboard
+ * charts on its /bench page.
+ */
+
+import type { MemorySpace } from "@commonfabric/memory/interface";
+
+import type { IMemorySpaceAddress } from "../src/storage/interface.ts";
+import {
+  addInvalidCause,
+  takeInvalidCauses,
+} from "../src/scheduler/invalidation.ts";
+import { NodeRegistry } from "../src/scheduler/node-record.ts";
+
+const SPACE: MemorySpace =
+  "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSdoom8Beere1L9DwwTm";
+
+/** One address per path of one document, the shape a list write produces. */
+function causesFor(count: number): IMemorySpaceAddress[] {
+  const causes: IMemorySpaceAddress[] = [];
+  for (let index = 0; index < count; index++) {
+    causes.push({
+      space: SPACE,
+      id: "of:votes",
+      type: "application/json",
+      path: ["value", String(index), "castAt"],
+    });
+  }
+  return causes;
+}
+
+for (const count of [64, 512, 2048]) {
+  const causes = causesFor(count);
+  const nodes = new NodeRegistry();
+  const record = nodes.register(() => {}, "computation");
+
+  Deno.bench({
+    name: `record ${count} distinct causes on one node`,
+    group: `invalid causes ×${count}`,
+    baseline: true,
+    fn: () => {
+      for (const cause of causes) addInvalidCause(record, cause);
+      takeInvalidCauses(record);
+    },
+  });
+
+  Deno.bench({
+    name: `record ${count} causes, then the same ${count} again`,
+    group: `invalid causes ×${count}`,
+    fn: () => {
+      for (const cause of causes) addInvalidCause(record, cause);
+      for (const cause of causes) addInvalidCause(record, cause);
+      takeInvalidCauses(record);
+    },
+  });
+}

--- a/packages/runner/test/scheduler-test-utils.ts
+++ b/packages/runner/test/scheduler-test-utils.ts
@@ -135,7 +135,7 @@ function getStaleSchedulerInternals(
       ) =>
         | {
           status: "never-ran" | "clean" | "invalid";
-          invalidCauses: unknown[];
+          invalidCauses: Map<string, unknown>;
         }
         | undefined;
     };
@@ -158,7 +158,7 @@ function getStaleSchedulerInternals(
       if (record.status === "invalid") {
         record.status = "clean";
       }
-      record.invalidCauses = [];
+      record.invalidCauses.clear();
     },
     markDirty: (action) => internal.markAndScheduleInvalidAction(action),
     registerEffect: (action) => {

--- a/packages/runner/test/scheduler-v2-cutover.test.ts
+++ b/packages/runner/test/scheduler-v2-cutover.test.ts
@@ -901,7 +901,7 @@ describe("scheduler v2 cutover fixtures", () => {
         get(action: Action): {
           status: string;
           declaredReads: unknown[];
-          invalidCauses: unknown[];
+          invalidCauses: Map<string, unknown>;
         } | undefined;
       };
     };
@@ -913,7 +913,7 @@ describe("scheduler v2 cutover fixtures", () => {
       const record = internal.nodes.get(writer);
       expect(record?.status).toBe("never-ran");
       expect(record?.declaredReads).toEqual([sourceAddress]);
-      expect(record?.invalidCauses).toEqual([]);
+      expect(record?.invalidCauses.size).toBe(0);
       expect(runs).toBe(0);
 
       source.withTx(tx).send(2);
@@ -921,7 +921,7 @@ describe("scheduler v2 cutover fixtures", () => {
       tx = runtime.edit();
       await runtime.scheduler.idle();
 
-      expect(internal.nodes.get(writer)?.invalidCauses).toEqual([]);
+      expect(internal.nodes.get(writer)?.invalidCauses.size).toBe(0);
       expect(runs).toBe(0);
       expect(output.get()).toBe(0);
     } finally {


### PR DESCRIPTION
## What

`addInvalidCause` deduped a node's pending invalid causes by scanning the node's array and computing a JSON key for every existing cause on every add. That is quadratic in the causes a node accumulates before it runs. A storage commit notification adds one cause per (change × triggered action), synchronously inside `notifyOptimistic`, so the writer's own transaction paid the scan before it returned.

The node now records causes in a `Map` keyed by the same key, in arrival order. Adding is a lookup; `takeInvalidCauses` hands the run the values; the three sites that reset the array clear the map. `docs/specs/scheduler-v2/README.md` says so in the node shape and the `markInvalid` sketch.

## Why now

Measured live on the estuary lunch poll (main @ be4bd524, server-execution OFF on both ends, 14 options, 31 votes, one browser): a vote takes ~1.6 s from click to the voter's own render, all of it one synchronous worker task. V8 sampling attributes ~1.05 s of that task to `markAndScheduleInvalidAction → markInvalid → addInvalidCause`, with 1.04 s self time in the key function alone. The scheduler's settle afterwards is ~100–130 ms and traversal is 7 ms. The other two contributors (CFC prepare's deep-equal label dedupe, ~0.27 s; telemetry `cell.update` dispatch, ~0.22 s) are separate follow-ups.

## Benchmark

`packages/runner/test/scheduler-invalid-causes.bench.ts` (new, picked up by the benchmarks workflow's `packages/runner/test/*.bench.ts` glob):

| causes on one node | before: distinct | before: +same again | after: distinct | after: +same again |
| --- | --- | --- | --- | --- |
| 64 | 188 µs | 374 µs | 9.5 µs | 18.3 µs |
| 512 | 11.4 ms | 22.9 ms | 80 µs | 145 µs |
| 2,048 | 181 ms | 363 ms | 320 µs | 588 µs |

"Before" is this bench run against main's sources.

## Verification

- `packages/runner` full suite: 1362 passed (8287 steps), 0 failed.
- Scheduler subset (`test/scheduler*.test.ts`, `pull-notifications-shaping`): 56 passed (451 steps).
- `deno fmt --check` repo-wide, `deno lint`, `deno check` on the touched files.
- Tests that read the record's causes moved from `.length`/`toEqual([])` to `.size`; the one that injected a stale cause now goes through `addInvalidCause`.

Estuary re-measurement with the same click timer after this deploys is the next step; the profile and analyser are in the lunch-poll perf workline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6880?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

