### PR TITLE
perf(runtime): expose cold resume watch costs

### DIFF
--- a/docs/development/debugging/profiling.md
+++ b/docs/development/debugging/profiling.md
@@ -145,6 +145,23 @@ reads the worker's scheduler, runner and storage rows plus main-thread IPC, with
 row recording set sizes rather than milliseconds will evict real timings — read
 those by name instead of widening the summary.
 
+The storage rows follow one inbound frame in arrival order, each keyed by the
+module that pays for the step: `storage.v2.remote/receive/decodeFrame`
+(websocket decompression), `memory.v2.client/receive/decodeBoundary` then
+`/schemaExpansion` (protocol decoding, and schema expansion only for a frame
+carrying a reference), and `storage.v2.remote/receive/dispatchPayload` — the
+whole synchronous handling of the frame, which for a pushed effect includes
+updating the watch view but not the replica. Replica application is its own
+pair, and every frame the replica ingests lands in one of them:
+`storage.v2/watchRefresh/applySessionSync` for the frames a refresh brought
+back, `storage.v2/watchPush/applySessionSync` for the frames the server pushed.
+Around a refresh, `storage.v2/watchRefresh/watchAddSync` is the request as the
+replica saw it, queue wait included, while `memory.v2.client/watchAdd/request`
+is the round trip alone, so their difference is time spent behind earlier watch
+mutations; `watchRefresh/total` brackets both with application. The
+`runner/start/*Wave` rows bracket each resume pre-sync wave around the per-cell
+`runner/start/resume*` spans.
+
 ## 4. Split until an explosion has an origin
 
 A count that is too high is visible at the top level. The caller that multiplies
@@ -349,8 +366,15 @@ process:
 - `logCounts` — the same per-logger counts, which is how a warning storm shows
   up as a number rather than as a log to grep.
 - `slowQueries` — the last hundred query, watch, or commit operations over
-  100 ms, with the space and the root and watch counts. A `transact` entry
-  also carries the commit's operation and read counts, its outcome (`ok`,
+  100 ms, with the space and the root and watch counts. Query and watch
+  entries attribute the traversal (`rootsVisited`, `rootsElapsedMs`,
+  `slowestRoot`) and carry `managerReads`, the engine document reads across
+  the whole request — the width a root count cannot show, since one root's
+  declaration can fan out over many documents. `session.watch.add` and
+  `session.watch.refresh` entries also carry `upserts`, the snapshots the
+  frame delivered: a wide traversal that yields few is repeated server work,
+  and a wide frame is transport and client-ingest work as well. A `transact`
+  entry also carries the commit's operation and read counts, its outcome (`ok`,
   the error name, or `threw` — a slow rejected commit records like a slow
   applied one), and `lockWaitMs`: how long the commit waited for the space
   publication lock before evaluating. Flush passes hold that same lock, so
@@ -424,6 +448,14 @@ a large batched fan-out and one expensive send are the same number here and
 dividing it to recover a per-frame cost is unsound. Read it as a bound instead —
 a client's push waits at least the refresh delay plus these two — and reach for
 `servingLoop.push` when the question is which sessions a batch served.
+
+`memory/watchAdd/total` is one `session.watch.add` end to end — evaluation
+through response assembly — for every request, where `slowQueries` keeps only
+those over its threshold. `memory/response/prepareSchemas` against
+`memory/response/sendRaw` splits each outbound message, response or effect, into
+schema-table compression and the hand-off to the transport;
+`memory.compression/send/encode` is the websocket compression that follows, on
+whichever side is sending.
 
 ### Profile the process
 

--- a/docs/development/debugging/profiling.md
+++ b/docs/development/debugging/profiling.md
@@ -151,14 +151,22 @@ module that pays for the step: `storage.v2.remote/receive/decodeFrame`
 `/schemaExpansion` (protocol decoding, and schema expansion only for a frame
 carrying a reference), and `storage.v2.remote/receive/dispatchPayload` — the
 whole synchronous handling of the frame, which for a pushed effect includes
-updating the watch view but not the replica. Replica application is its own
-pair, and every frame the replica ingests lands in one of them:
-`storage.v2/watchRefresh/applySessionSync` for the frames a refresh brought
-back, `storage.v2/watchPush/applySessionSync` for the frames the server pushed.
-Around a refresh, `storage.v2/watchRefresh/watchAddSync` is the request as the
-replica saw it, queue wait included, while `memory.v2.client/watchAdd/request`
-is the round trip alone, so their difference is time spent behind earlier watch
-mutations; `watchRefresh/total` brackets both with application. The
+updating the watch view but not the replica. Two rows time replica application:
+`storage.v2/watchRefresh/applySessionSync` covers graph-watch refreshes, and
+`storage.v2/watchPush/applySessionSync` covers the subscription consumer. Direct
+operation-watch and watch-removal application are outside both spans.
+
+Around a graph-watch refresh, `storage.v2/watchRefresh/watchAddSync` includes
+watch-mutation queue wait, the client request, response-order wait in concurrent
+mode, and watch-view application. `memory.v2.client/watchAdd/request` covers
+the client request, including connection readiness, encoding, the transport
+round trip, and response handling;
+`memory.v2.client/watchAdd/apply` covers watch bookkeeping and watch-view
+application. The outer span minus the request span therefore includes
+application and scheduling overhead as well as waiting; it does not isolate
+queue wait. The rows aggregate different call populations, and their percentiles
+cannot be subtracted to recover any of these components. `watchRefresh/total`
+brackets the whole refresh, including replica application. The
 `runner/start/*Wave` rows bracket each resume pre-sync wave around the per-cell
 `runner/start/resume*` spans.
 
@@ -452,9 +460,11 @@ dividing it to recover a per-frame cost is unsound. Read it as a bound instead �
 a client's push waits at least the refresh delay plus these two — and reach for
 `servingLoop.push` when the question is which sessions a batch served.
 
-`memory/watchAdd/total` is one `session.watch.add` end to end — evaluation
-through response assembly — for every request, where `slowQueries` keeps only
-those over its threshold. `memory/response/prepareSchemas` against
+`memory/watchAdd/total` covers each `session.watch.add` handler from admission
+through completion, including duplicate or empty additions, rejected requests,
+and failures. It ends before outbound schema preparation and transport.
+`slowQueries` records successful additions over its threshold, measured from
+evaluation through response assembly. `memory/response/prepareSchemas` against
 `memory/response/sendRaw` splits each outbound message, response or effect, into
 schema-table compression and the hand-off to the transport;
 `memory.compression/send/encode` is the websocket compression that follows, on

--- a/docs/development/debugging/profiling.md
+++ b/docs/development/debugging/profiling.md
@@ -366,14 +366,17 @@ process:
 - `logCounts` — the same per-logger counts, which is how a warning storm shows
   up as a number rather than as a log to grep.
 - `slowQueries` — the last hundred query, watch, or commit operations over
-  100 ms, with the space and the root and watch counts. Query and watch
-  entries attribute the traversal (`rootsVisited`, `rootsElapsedMs`,
-  `slowestRoot`) and carry `managerReads`, the engine document reads across
-  the whole request — the width a root count cannot show, since one root's
-  declaration can fan out over many documents. `session.watch.add` and
-  `session.watch.refresh` entries also carry `upserts`, the snapshots the
-  frame delivered: a wide traversal that yields few is repeated server work,
-  and a wide frame is transport and client-ingest work as well. A `transact`
+  100 ms, with the space and the root and watch counts. `graph.query`,
+  `session.watch.set` and `session.watch.add` entries attribute the traversal
+  (`rootsVisited`, `rootsElapsedMs`, `slowestRoot`) and carry `managerReads`,
+  the engine document reads across the whole request — the width a root
+  count cannot show, since one root's declaration can fan out over many
+  documents. `session.watch.add` and `session.watch.refresh` entries also
+  carry `upserts`, the snapshots the frame delivered: a wide traversal that
+  yields few is repeated server work, and a wide frame is transport and
+  client-ingest work as well. A refresh carries only `watches` and `upserts`:
+  it re-evaluates by dirty document rather than by root, so it has no
+  traversal to attribute, and absent is the honest answer there. A `transact`
   entry also carries the commit's operation and read counts, its outcome (`ok`,
   the error name, or `threw` — a slow rejected commit records like a slow
   applied one), and `lockWaitMs`: how long the commit waited for the space

--- a/packages/memory/test/v2-frame-timing.test.ts
+++ b/packages/memory/test/v2-frame-timing.test.ts
@@ -6,6 +6,9 @@ import {
   encodeMemoryBoundary,
   getMemoryProtocolFlags,
   MEMORY_PROTOCOL,
+  type ResponseMessage,
+  type ServerMessage,
+  type SessionOpenAuthMetadata,
 } from "../v2.ts";
 import { Server } from "../v2/server.ts";
 import { testSessionOpenServerOptions } from "./v2-auth-test-helpers.ts";
@@ -24,6 +27,10 @@ import { testSessionOpenServerOptions } from "./v2-auth-test-helpers.ts";
 // those two documents pointing at rows that no longer exist. These tests
 // are that gate, so they assert the names and the split — never a
 // duration, which is a property of the machine.
+//
+// The response halves (`memory/response/prepareSchemas` and `/sendRaw`)
+// and the watch.add total (`memory/watchAdd/total`) are documented in the
+// same place and gated here for the same reason.
 
 const HELLO = {
   type: "hello",
@@ -47,6 +54,49 @@ const flushCounts = (): { queue: number; refresh: number } => {
     queue: timing.getTimeStats("memory", "flush", "queue")?.count ?? 0,
     refresh: timing.getTimeStats("memory", "flush", "refresh")?.count ?? 0,
   };
+};
+
+const responseCounts = (): { prepareSchemas: number; sendRaw: number } => {
+  const timing = getLogger("memory");
+  return {
+    prepareSchemas:
+      timing.getTimeStats("memory", "response", "prepareSchemas")?.count ?? 0,
+    sendRaw: timing.getTimeStats("memory", "response", "sendRaw")?.count ?? 0,
+  };
+};
+
+const watchAddCount = (): number =>
+  getLogger("memory").getTimeStats("memory", "watchAdd", "total")?.count ?? 0;
+
+/** Hello, then a session open answered with the challenge hello.ok issued. */
+const openSession = async (
+  server: Server,
+  space: string,
+): Promise<{
+  connection: ReturnType<Server["connect"]>;
+  sessionId: string;
+}> => {
+  const messages: ServerMessage[] = [];
+  const connection = server.connect((message) => messages.push(message));
+  await connection.receive(encodeMemoryBoundary(HELLO));
+  const hello = messages.shift() as
+    | { type: string; sessionOpen?: SessionOpenAuthMetadata }
+    | undefined;
+  expect(hello?.type).toBe("hello.ok");
+  const sessionOpen = hello!.sessionOpen!;
+  await connection.receive(encodeMemoryBoundary({
+    type: "session.open",
+    requestId: "open",
+    space,
+    session: {},
+    invocation: {
+      aud: sessionOpen.audience,
+      challenge: sessionOpen.challenge.value,
+    },
+  }));
+  const opened = messages.shift() as ResponseMessage<{ sessionId: string }>;
+  expect(opened.ok).toBeDefined();
+  return { connection, sessionId: opened.ok!.sessionId };
 };
 
 describe("v2 server frame timing", () => {
@@ -98,6 +148,53 @@ describe("v2 server frame timing", () => {
       const after = frameCounts();
       expect(after.queue - before.queue).toBe(3);
       expect(after.handle - before.handle).toBe(3);
+    } finally {
+      await server.close();
+    }
+  });
+  it("splits every outbound message into schema preparation and the transport hand-off", async () => {
+    const server = new Server({
+      ...testSessionOpenServerOptions,
+      store: new URL("memory://frame-timing-response"),
+    });
+    try {
+      const before = responseCounts();
+      const connection = server.connect(() => {});
+      await connection.receive(encodeMemoryBoundary(HELLO));
+
+      // One frame in, one message out: `hello.ok` leaves through the same
+      // send as every response and effect, so each half counts once.
+      const after = responseCounts();
+      expect(after.prepareSchemas - before.prepareSchemas).toBe(1);
+      expect(after.sendRaw - before.sendRaw).toBe(1);
+    } finally {
+      await server.close();
+    }
+  });
+  it("times a watch.add end to end under its own key", async () => {
+    const space = "did:key:z6Mk-frame-timing-watch-add";
+    const server = new Server({
+      ...testSessionOpenServerOptions,
+      store: new URL("memory://frame-timing-watch-add"),
+    });
+    try {
+      const { connection, sessionId } = await openSession(server, space);
+      const before = watchAddCount();
+      await connection.receive(encodeMemoryBoundary({
+        type: "session.watch.add",
+        requestId: "watch",
+        space,
+        sessionId,
+        watches: [{
+          id: "watch-id",
+          kind: "graph",
+          query: {
+            roots: [{ id: "of:timed", selector: { path: [], schema: true } }],
+          },
+        }],
+      }));
+
+      expect(watchAddCount() - before).toBe(1);
     } finally {
       await server.close();
     }

--- a/packages/memory/test/v2-frame-timing.test.ts
+++ b/packages/memory/test/v2-frame-timing.test.ts
@@ -9,6 +9,7 @@ import {
   type ResponseMessage,
   type ServerMessage,
   type SessionOpenAuthMetadata,
+  type WatchAddRequest,
 } from "../v2.ts";
 import { Server } from "../v2/server.ts";
 import { testSessionOpenServerOptions } from "./v2-auth-test-helpers.ts";
@@ -75,6 +76,7 @@ const openSession = async (
 ): Promise<{
   connection: ReturnType<Server["connect"]>;
   sessionId: string;
+  messages: ServerMessage[];
 }> => {
   const messages: ServerMessage[] = [];
   const connection = server.connect((message) => messages.push(message));
@@ -96,7 +98,7 @@ const openSession = async (
   }));
   const opened = messages.shift() as ResponseMessage<{ sessionId: string }>;
   expect(opened.ok).toBeDefined();
-  return { connection, sessionId: opened.ok!.sessionId };
+  return { connection, sessionId: opened.ok!.sessionId, messages };
 };
 
 describe("v2 server frame timing", () => {
@@ -171,7 +173,7 @@ describe("v2 server frame timing", () => {
       await server.close();
     }
   });
-  it("times a watch.add end to end under its own key", async () => {
+  it("times a watch.add handler under its own key", async () => {
     const space = "did:key:z6Mk-frame-timing-watch-add";
     const server = new Server({
       ...testSessionOpenServerOptions,
@@ -194,6 +196,138 @@ describe("v2 server frame timing", () => {
         }],
       }));
 
+      expect(watchAddCount() - before).toBe(1);
+    } finally {
+      await server.close();
+    }
+  });
+  it("times duplicate and empty watch additions even when they return no changes", async () => {
+    const space = "did:key:z6Mk-frame-timing-watch-add-no-op";
+    const server = new Server({
+      ...testSessionOpenServerOptions,
+      store: new URL("memory://frame-timing-watch-add-no-op"),
+    });
+    try {
+      const { sessionId } = await openSession(server, space);
+      const request: WatchAddRequest = {
+        type: "session.watch.add",
+        requestId: "watch",
+        space,
+        sessionId,
+        watches: [{
+          id: "watch-id",
+          kind: "graph",
+          query: {
+            roots: [{ id: "of:timed", selector: { path: [], schema: true } }],
+          },
+        }],
+      };
+      expect((await server.watchAdd(request)).ok).toBeDefined();
+
+      const beforeDuplicate = watchAddCount();
+      const duplicate = await server.watchAdd(request);
+      expect(duplicate.ok?.sync).toMatchObject({ upserts: [], removes: [] });
+      expect(watchAddCount() - beforeDuplicate).toBe(1);
+
+      const beforeEmpty = watchAddCount();
+      const empty = await server.watchAdd({ ...request, watches: [] });
+      expect(empty.ok?.sync).toMatchObject({ upserts: [], removes: [] });
+      expect(watchAddCount() - beforeEmpty).toBe(1);
+    } finally {
+      await server.close();
+    }
+  });
+  it("times a watch addition rejected for changing an existing watch", async () => {
+    const space = "did:key:z6Mk-frame-timing-watch-add-conflict";
+    const server = new Server({
+      ...testSessionOpenServerOptions,
+      store: new URL("memory://frame-timing-watch-add-conflict"),
+    });
+    try {
+      const { sessionId } = await openSession(server, space);
+      const request: WatchAddRequest = {
+        type: "session.watch.add",
+        requestId: "watch",
+        space,
+        sessionId,
+        watches: [{
+          id: "watch-id",
+          kind: "graph",
+          query: {
+            roots: [{ id: "of:timed", selector: { path: [], schema: true } }],
+          },
+        }],
+      };
+      expect((await server.watchAdd(request)).ok).toBeDefined();
+
+      const before = watchAddCount();
+      const rejected = await server.watchAdd({
+        ...request,
+        watches: [{
+          id: "watch-id",
+          kind: "graph",
+          query: {
+            roots: [{ id: "of:other", selector: { path: [], schema: true } }],
+          },
+        }],
+      });
+      expect(rejected.error?.name).toBe("ProtocolError");
+      expect(watchAddCount() - before).toBe(1);
+    } finally {
+      await server.close();
+    }
+  });
+  it("times a watch addition rejected before evaluation for an unknown session", async () => {
+    const server = new Server({
+      ...testSessionOpenServerOptions,
+      store: new URL("memory://frame-timing-watch-add-unknown-session"),
+    });
+    try {
+      const before = watchAddCount();
+      const rejected = await server.watchAdd({
+        type: "session.watch.add",
+        requestId: "watch",
+        space: "did:key:z6Mk-frame-timing-watch-add-unknown-session",
+        sessionId: "never-opened",
+        watches: [],
+      });
+      expect(rejected.error?.name).toBe("SessionError");
+      expect(watchAddCount() - before).toBe(1);
+    } finally {
+      await server.close();
+    }
+  });
+  it("times a watch addition whose evaluation throws", async () => {
+    const space = "did:key:z6Mk-frame-timing-watch-add-query-error";
+    const server = new Server({
+      ...testSessionOpenServerOptions,
+      store: new URL("memory://frame-timing-watch-add-query-error"),
+    });
+    try {
+      const { connection, sessionId, messages } = await openSession(
+        server,
+        space,
+      );
+      const before = watchAddCount();
+      // A wire client can omit the required selector. Evaluation must answer
+      // with a QueryError, and the failed work still belongs in the total.
+      await connection.receive(encodeMemoryBoundary({
+        type: "session.watch.add",
+        requestId: "watch",
+        space,
+        sessionId,
+        watches: [{
+          id: "broken",
+          kind: "graph",
+          query: { roots: [{ id: "of:timed" }] },
+        }],
+      }));
+      expect(messages).toHaveLength(1);
+      expect(messages[0]).toMatchObject({
+        type: "response",
+        requestId: "watch",
+        error: { name: "QueryError" },
+      });
       expect(watchAddCount() - before).toBe(1);
     } finally {
       await server.close();

--- a/packages/memory/test/v2-server-slow-query.test.ts
+++ b/packages/memory/test/v2-server-slow-query.test.ts
@@ -15,10 +15,13 @@ import {
 
 const TEST_AUDIENCE = "did:key:z6Mk-memory-v2-slow-query-test-audience";
 
-const createServer = (store: string) =>
+const createServer = (
+  store: string,
+  subscriptionRefreshDelayMs: number | "manual" = 0,
+) =>
   new Server({
     store: new URL(store),
-    subscriptionRefreshDelayMs: 0,
+    subscriptionRefreshDelayMs,
     authorizeSessionOpen() {
       return "did:key:z6Mk-memory-v2-slow-query-principal";
     },
@@ -297,6 +300,63 @@ describe("v2 server slow queries", () => {
       expect(slowest!.path).toBe("");
       expect(slowest!.reads).toBeGreaterThan(0);
       expect(slowest!.walk.dagTraversals).toBeGreaterThan(0);
+    } finally {
+      connection.close();
+    }
+  });
+
+  it("records the upserts a slow watch.refresh delivered", async () => {
+    const space = "did:key:z6Mk-slow-query-watch-refresh";
+    // Manual refresh: the flush below is the refresh under test, not a
+    // timer racing it.
+    const server = createServer("memory://slow-query-watch-refresh", "manual");
+    const messages: ServerMessage[] = [];
+    const connection = server.connect((message) => messages.push(message));
+    try {
+      const sessionId = await openSession(connection, messages, space);
+      const seeded = await server.transact(
+        transactMessage(space, sessionId, {
+          localSeq: 1,
+          reads: { confirmed: [], pending: [] },
+          operations: [
+            { op: "set", id: "of:refreshed", value: { value: { n: 1 } } },
+          ],
+        }),
+      );
+      expect(seeded.error).toBeUndefined();
+      await connection.receive(encodeMemoryBoundary({
+        type: "session.watch.add",
+        requestId: "watch-refresh",
+        space,
+        sessionId,
+        watches: [{
+          id: "watch-refresh-id",
+          kind: "graph",
+          query: {
+            roots: [
+              { id: "of:refreshed", selector: { path: [], schema: true } },
+            ],
+          },
+        }],
+      }));
+
+      // A refresh re-evaluates by dirty document, so it has no roots to
+      // attribute (see `rootsVisited`); the width it delivered is the one
+      // shape it can report. Same clock trick as the watch.add case.
+      performance.now = () => {
+        nowOffsetMs += 60;
+        return realNow() + nowOffsetMs;
+      };
+      await server.writeDocument(space, "of:refreshed", { n: 2 });
+      await server.flushSessions();
+
+      const entry = getSlowQueries().find((slow) =>
+        slow.space === space && slow.operation === "session.watch.refresh"
+      );
+      expect(entry).toBeDefined();
+      expect(entry!.watches).toBe(1);
+      expect(entry!.upserts).toBe(1);
+      expect(entry!.rootsVisited).toBeUndefined();
     } finally {
       connection.close();
     }

--- a/packages/memory/test/v2-server-slow-query.test.ts
+++ b/packages/memory/test/v2-server-slow-query.test.ts
@@ -288,6 +288,8 @@ describe("v2 server slow queries", () => {
       expect(entry!.rootsVisited).toBe(2);
       expect(entry!.rootsElapsedMs).toBeGreaterThan(0);
       expect(entry!.rootsElapsedMs).toBeLessThanOrEqual(entry!.elapsed);
+      expect(entry!.managerReads).toBeGreaterThanOrEqual(2);
+      expect(entry!.upserts).toBe(2);
       const slowest = entry!.slowestRoot;
       expect(slowest).toBeDefined();
       expect(["of:watched:one", "of:watched:two"]).toContain(slowest!.id);

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -1,5 +1,6 @@
 import type { FabricPlainObject, FabricValue } from "@commonfabric/api";
 import { toCompactDebugString } from "@commonfabric/data-model";
+import { getLogger } from "@commonfabric/utils/logger";
 import { unsafeObjectKeyIn } from "@commonfabric/utils/types";
 
 import {
@@ -45,6 +46,11 @@ import type { Server } from "./server.ts";
 import { containsReservedSchemaRefSubstring } from "./sync-schema-ref.ts";
 import { expandServerMessageSchemas } from "./sync-schema-table.ts";
 import { type ArmedTurn, armTurn } from "./turn.ts";
+
+const logger = getLogger("memory.v2.client", {
+  enabled: true,
+  level: "error",
+});
 
 export type Transport = {
   /** Whether this transport can exchange negotiated compression envelopes. */
@@ -494,13 +500,17 @@ export class Client {
   #onMessage(payload: string): void {
     let message: unknown;
     try {
+      const decodeStart = performance.now();
       message = decodeMemoryBoundary(payload);
+      logger.time(decodeStart, "receive", "decodeBoundary");
       // A frame whose raw text lacks every reserved reference prefix cannot
       // carry a schema reference (strings serialize verbatim — see the note
       // on encodeMemoryBoundary), so the expansion walk over its upserts is
       // skipped entirely.
       if (containsReservedSchemaRefSubstring(payload)) {
+        const schemaExpansionStart = performance.now();
         message = expandServerMessageSchemas(message);
+        logger.time(schemaExpansionStart, "receive", "schemaExpansion");
       }
     } catch (cause) {
       const error = new Error("Unable to parse memory server message", {
@@ -1122,15 +1132,20 @@ export class SpaceSession {
   async watchAddSync(watches: WatchSpec[]): Promise<WatchMutationResult> {
     this.#assertOpen();
     return await this.#runWatchMutation(
-      () =>
-        this.#client.request<WatchAddResult>({
+      async () => {
+        const requestStart = performance.now();
+        const result = await this.#client.request<WatchAddResult>({
           type: "session.watch.add",
           requestId: crypto.randomUUID(),
           space: this.space,
           sessionId: this.#sessionId,
           watches,
-        }),
+        });
+        logger.time(requestStart, "watchAdd", "request");
+        return result;
+      },
       (result) => {
+        const applyStart = performance.now();
         this.#noteResult(result.serverSeq);
         this.#watchSpecs = [
           ...new Map(
@@ -1144,11 +1159,13 @@ export class SpaceSession {
           this.#watchView.applySync(result.sync, false);
         }
         this.#scheduleAck(result.serverSeq);
-        return {
+        const mutation = {
           view: this.#watchView,
           precedingSyncs: this.#takePrecedingWatchSyncs(),
           sync: result.sync,
         };
+        logger.time(applyStart, "watchAdd", "apply");
+        return mutation;
       },
     );
   }

--- a/packages/memory/v2/message-compression.ts
+++ b/packages/memory/v2/message-compression.ts
@@ -4,6 +4,8 @@
  * payload travels without another encoding layer.
  */
 
+import { getLogger } from "@commonfabric/utils/logger";
+
 /** Frames produced by the compression encoder. */
 export type EncodedMemoryMessage = string | Uint8Array<ArrayBuffer>;
 
@@ -30,6 +32,11 @@ const MEMORY_COMPRESSION_THRESHOLD_BYTES = 1_024;
 
 /** Maximum expanded size accepted from one compression envelope. */
 export const MAX_DECOMPRESSED_MEMORY_MESSAGE_BYTES = 256 * 1_024 * 1_024;
+
+const logger = getLogger("memory.compression", {
+  enabled: true,
+  level: "error",
+});
 
 const MAX_GZIP_MEMORY_MESSAGE_BYTES = MAX_DECOMPRESSED_MEMORY_MESSAGE_BYTES +
   1_024 * 1_024;
@@ -89,9 +96,11 @@ export class MemoryMessageCompressionChannel {
     const compressionEnabled = this.#sendCompressionEnabled;
     const send = this.#outgoing.then(async () => {
       if (this.#closed) return;
+      const encodeStart = performance.now();
       const frame = compressionEnabled
         ? await encodeCompressedMemoryMessage(payload)
         : payload;
+      logger.time(encodeStart, "send", "encode");
       if (!this.#closed) {
         // Every send stays on this queue, including uncompressed control and
         // pre-negotiation frames. A mode change therefore cannot move its

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -271,7 +271,9 @@ export type SlowQuery = {
   /** Query and watch operations: summed elapsed time of those root visits.
    * Against the entry's own `elapsed` this is the share of the request
    * that traversal accounts for; the remainder is entity assembly,
-   * schema-closure staging, and operation-field attachment. */
+   * schema-closure staging, operation-field attachment, and (for
+   * `watch.add`, whose `elapsed` runs through response assembly) mapping
+   * the delivered snapshots to the wire. */
   rootsElapsedMs?: number;
 
   /** Query and watch operations: engine document reads across every branch

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -280,10 +280,12 @@ export type SlowQuery = {
    * the complete request rather than only its costliest root. */
   managerReads?: number;
 
-  /** watch.add only: changed entity snapshots returned to the client. This is
-   * the delivered-width counterpart to `watches` and `managerReads`: a wide
-   * traversal that yields few upserts is repeated server work, while a wide
-   * response is also transport and client-ingest work. */
+  /** watch.add and watch.refresh: changed entity snapshots delivered to the
+   * client. This is the delivered-width counterpart to `watches` and
+   * `managerReads`: a wide traversal that yields few upserts is repeated
+   * server work, while a wide frame is also transport and client-ingest
+   * work. A refresh that produced no upserts answers with an empty catch-up
+   * and is not recorded, so a refresh entry never reports zero here. */
   upserts?: number;
 
   /** Query and watch operations: the costliest single root, which is what
@@ -5451,6 +5453,7 @@ export class Server {
             }
             recordSlowQueryDuration("session.watch.refresh", space, startedAt, {
               watches: session.watches.length,
+              upserts: upserts.length,
             });
             const message = await finishCatchUp({
               type: "sync",

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -274,6 +274,18 @@ export type SlowQuery = {
    * schema-closure staging, and operation-field attachment. */
   rootsElapsedMs?: number;
 
+  /** Query and watch operations: engine document reads across every branch
+   * group. Unlike `rootsVisited`, this exposes roots whose declarations fan
+   * out over many documents, and unlike `slowestRoot.reads`, it accounts for
+   * the complete request rather than only its costliest root. */
+  managerReads?: number;
+
+  /** watch.add only: changed entity snapshots returned to the client. This is
+   * the delivered-width counterpart to `watches` and `managerReads`: a wide
+   * traversal that yields few upserts is repeated server work, while a wide
+   * response is also transport and client-ingest work. */
+  upserts?: number;
+
   /** Query and watch operations: the costliest single root, which is what
    * a watch COUNT cannot say. A `watch.add` unions the roots of every
    * watch it carries, so 78 watches and 5,377 watches are the same
@@ -289,12 +301,14 @@ export type SlowQuery = {
 type RootAttribution = {
   rootsVisited: number;
   rootsElapsedMs: number;
+  managerReads: number;
   slowestRoot?: SlowestQueryRoot;
 };
 
 const createRootAttribution = (): RootAttribution => ({
   rootsVisited: 0,
   rootsElapsedMs: 0,
+  managerReads: 0,
 });
 
 /**
@@ -310,6 +324,7 @@ const foldRootAttribution = (
 ): void => {
   into.rootsVisited += stats.rootsVisited;
   into.rootsElapsedMs += stats.rootsElapsedMs;
+  into.managerReads += stats.managerReads;
   if (
     stats.slowestRoot !== undefined &&
     (into.slowestRoot === undefined ||
@@ -759,9 +774,14 @@ class Connection {
   }
 
   #send(message: ServerMessage): void {
-    this.#sendRaw(
-      this.#syncSchemaTable ? compressServerMessageSchemas(message) : message,
-    );
+    const schemaStart = performance.now();
+    const prepared = this.#syncSchemaTable
+      ? compressServerMessageSchemas(message)
+      : message;
+    timing.time(schemaStart, "memory", "response", "prepareSchemas");
+    const sendStart = performance.now();
+    this.#sendRaw(prepared);
+    timing.time(sendStart, "memory", "response", "sendRaw");
   }
 
   hasSession(space: string, sessionId: string): boolean {
@@ -4694,13 +4714,7 @@ export class Server {
       session.lastSyncedSeq = serverSeq;
       session.operationCursors = nextOperationCursors;
       this.#notifyDemandChanged(message.space, "watch", session.principal);
-      recordSlowQueryDuration(
-        "session.watch.add",
-        message.space,
-        startedAt,
-        { watches: message.watches.length, ...attribution },
-      );
-      return {
+      const response: ResponseMessage<WatchAddResult> = {
         type: "response",
         requestId: message.requestId,
         ok: {
@@ -4716,6 +4730,18 @@ export class Server {
           },
         },
       };
+      recordSlowQueryDuration(
+        "session.watch.add",
+        message.space,
+        startedAt,
+        {
+          watches: message.watches.length,
+          upserts: upserts.length,
+          ...attribution,
+        },
+      );
+      timing.time(startedAt, "memory", "watchAdd", "total");
+      return response;
     } catch (error) {
       // Evaluation state is staged (the session's graphs and watches are
       // assigned only on success), so a failure answers the requester —

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -4496,7 +4496,20 @@ export class Server {
     }
   }
 
+  /** Add session watches, timing admission through the handler's completion. */
   async watchAdd(
+    message: WatchAddRequest,
+  ): Promise<ResponseMessage<WatchAddResult>> {
+    const startedAt = performance.now();
+    try {
+      return await this.#watchAdd(message);
+    } finally {
+      timing.time(startedAt, "memory", "watchAdd", "total");
+    }
+  }
+
+  /** Helper for watchAdd(), which authorizes, evaluates, and installs watches. */
+  async #watchAdd(
     message: WatchAddRequest,
   ): Promise<ResponseMessage<WatchAddResult>> {
     const session = this.#sessions.get(message.space, message.sessionId);
@@ -4744,7 +4757,6 @@ export class Server {
           ...attribution,
         },
       );
-      timing.time(startedAt, "memory", "watchAdd", "total");
       return response;
     } catch (error) {
       // Evaluation state is staged (the session's graphs and watches are

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -6307,6 +6307,7 @@ export class Runner {
     pattern: Module | Pattern,
     inputs?: any,
   ): Promise<boolean> {
+    const mentionedInputsStart = performance.now();
     const seen = new Set<Cell<any>>();
     const promises = new Set<Promise<any>>();
 
@@ -6329,8 +6330,15 @@ export class Runner {
 
     syncAllMentionedCells(inputs);
     await Promise.all(promises);
+    logger.time(
+      mentionedInputsStart,
+      "start",
+      "resumeMentionedInputSyncWave",
+    );
 
+    const resultSyncStart = performance.now();
     await resultCell.sync();
+    logger.time(resultSyncStart, "start", "resumeResultSync");
 
     // We could support this by replicating what happens in runner, but since
     // we're calling this again when returning false, this is good enough for now.
@@ -6459,11 +6467,11 @@ export class Runner {
     ) {
       cells.push(resultCell.key(UI).asSchema(rendererVDOMSchema));
     }
-
     // Per-cell spans: `n` in the timing stats is the number of cells this
     // resume pre-synced, total/max its round-trip cost (spans overlap, so the
     // wall cost is bounded by the enclosing `#syncCellsForRunningPattern()`
     // span).
+    const cellSyncWaveStart = performance.now();
     await Promise.all(cells.map((cell) => {
       const c = documentBoundedResumeCell(cell);
       const cellSyncStart = performance.now();
@@ -6471,6 +6479,7 @@ export class Runner {
         logger.time(cellSyncStart, "start", "resumeCellSync")
       );
     }));
+    logger.time(cellSyncWaveStart, "start", "resumeCellSyncWave");
 
     // Second wave: argument LINK TARGETS. An argument document synced above
     // may hold a link to a document nothing in this pattern tree owns (the
@@ -6482,6 +6491,7 @@ export class Runner {
     // pass subscribed such targets in aborted transactions before any
     // commit). Each root's declared schema bounds its scan — see the method
     // for the exact rules and the fallback where a declaration runs out.
+    const followupSyncStart = performance.now();
     await Promise.all([
       this.#syncArgumentLinkTargets(
         argumentRoots,
@@ -6492,6 +6502,7 @@ export class Runner {
       // and it must finish before instantiation runs those children.
       this.#syncResumeListChildren(instances),
     ]);
+    logger.time(followupSyncStart, "start", "resumeFollowupSync");
 
     return true;
   }
@@ -6561,6 +6572,7 @@ export class Runner {
     }));
     let wave = 0;
     while (frontier.length > 0) {
+      const waveStart = performance.now();
       const targets: PendingTarget[] = [];
       const targetPromises: Promise<any>[] = [];
       const enqueue = (
@@ -6680,6 +6692,7 @@ export class Runner {
         }
       }
       await Promise.all(targetPromises);
+      logger.time(waveStart, "start", `${timingLabel}Wave`);
       frontier = targets;
       wave++;
     }
@@ -6772,6 +6785,7 @@ export class Runner {
         ]);
         return moving;
       }
+      const syncWaveStart = performance.now();
       await Promise.all(fresh.map((cell) => {
         const syncStart = performance.now();
         return Promise.resolve(documentBoundedResumeCell(cell).sync())
@@ -6785,6 +6799,11 @@ export class Runner {
             logger.time(syncStart, "start", "resumeListChildSync")
           );
       }));
+      logger.time(
+        syncWaveStart,
+        "start",
+        "resumeListSlotResolutionSyncWave",
+      );
     }
   }
 
@@ -6963,7 +6982,9 @@ export class Runner {
       } finally {
         planTx.abort("resume list children: read-only derivation");
       }
+      const syncWaveStart = performance.now();
       await Promise.all(promises);
+      logger.time(syncWaveStart, "start", "resumeListChildSyncWave");
       frontier = next;
     }
   }

--- a/packages/runner/src/storage/v2-remote-session.ts
+++ b/packages/runner/src/storage/v2-remote-session.ts
@@ -10,7 +10,13 @@ import {
   isMemoryMessageFrame,
   parseMemoryCompressionControlMessage,
 } from "@commonfabric/memory/v2/message-compression";
+import { getLogger } from "@commonfabric/utils/logger";
 import { normalizeSpaceHost, SpaceHostValidationError } from "../space-host.ts";
+
+const logger = getLogger("storage.v2.remote", {
+  enabled: true,
+  level: "error",
+});
 
 export interface SessionFactory {
   /** Opt in to StorageManager's ACL genesis handshake. Scripted factories used
@@ -269,6 +275,7 @@ export class WebSocketTransport implements MemoryClient.Transport {
               throw new Error("Unsupported memory websocket frame type");
             }
             let payload: string;
+            const decodeStart = performance.now();
             if (this.#receiveCompressionEnabled) {
               payload = await decodeCompressedMemoryMessage(frame);
             } else {
@@ -279,6 +286,7 @@ export class WebSocketTransport implements MemoryClient.Transport {
               }
               payload = frame;
             }
+            logger.time(decodeStart, "receive", "decodeFrame");
             if (this.#socket !== socket) return;
             const control = parseMemoryCompressionControlMessage(payload);
             if (control) {
@@ -291,11 +299,13 @@ export class WebSocketTransport implements MemoryClient.Transport {
               }
               return;
             }
+            const receiverStart = performance.now();
             try {
               this.#receiver(payload);
             } catch (cause) {
               reportError(cause);
             }
+            logger.time(receiverStart, "receive", "dispatchPayload");
           } catch (cause) {
             if (this.#socket !== socket) return;
             const error = new Error(

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -5526,10 +5526,10 @@ export class SpaceReplica
         ]);
       } finally {
         // The push-side counterpart of `watchRefresh/applySessionSync`:
-        // frames the server pushed apply here, off the subscription
-        // iterator, never inside a refresh. Between the two keys every
-        // frame the replica ingests is timed, so a slow trickle and a
-        // slow initial sync read as different rows.
+        // this key times application from the subscription iterator;
+        // the refresh key times application during graph-watch refreshes.
+        // Direct operation-watch and watch-removal application have no
+        // span under either key.
         logger.time(applyStart, "watchPush", "applySessionSync");
       }
     }

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -5292,11 +5292,18 @@ export class SpaceReplica
         },
       }));
 
+      // Both sub-spans record in `finally` blocks, as `total` below does: a
+      // refresh that fails inside the request or inside application still
+      // paid for it, and a success-only span would leave that share in
+      // `total` alone, so the halves would not add up across outcomes.
       const watchAddStart = performance.now();
-      const { view, precedingSyncs, sync } = await session.watchAddSync(
-        watches,
-      );
-      logger.time(watchAddStart, "watchRefresh", "watchAddSync");
+      let mutation: MemoryV2Client.WatchMutationResult;
+      try {
+        mutation = await session.watchAddSync(watches);
+      } finally {
+        logger.time(watchAddStart, "watchRefresh", "watchAddSync");
+      }
+      const { view, precedingSyncs, sync } = mutation;
 
       if (this.#closed) {
         view.close();
@@ -5318,9 +5325,10 @@ export class SpaceReplica
         // overwrites `#watchView`.
         view.close();
         throw error;
+      } finally {
+        // deno-coverage-ignore-stop
+        logger.time(applyStart, "watchRefresh", "applySessionSync");
       }
-      // deno-coverage-ignore-stop
-      logger.time(applyStart, "watchRefresh", "applySessionSync");
       this.#consumeWatchView(view);
       return { ok: {} };
     } catch (error) {

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -5217,6 +5217,7 @@ export class SpaceReplica
     type: "pull" | "integrate" = "pull",
     watchBranch = "",
   ): Promise<Result<Unit, PullError>> {
+    const refreshStart = performance.now();
     try {
       const { session } = await this.#activeSessionHandle();
       // Per-session (no global): mirror the storage setting onto the session so
@@ -5291,9 +5292,11 @@ export class SpaceReplica
         },
       }));
 
+      const watchAddStart = performance.now();
       const { view, precedingSyncs, sync } = await session.watchAddSync(
         watches,
       );
+      logger.time(watchAddStart, "watchRefresh", "watchAddSync");
 
       if (this.#closed) {
         view.close();
@@ -5301,6 +5304,7 @@ export class SpaceReplica
       }
 
       this.#watchView = view;
+      const applyStart = performance.now();
       try {
         for (const precedingSync of precedingSyncs) {
           this.#applySessionSync(precedingSync, "integrate");
@@ -5316,10 +5320,13 @@ export class SpaceReplica
         throw error;
       }
       // deno-coverage-ignore-stop
+      logger.time(applyStart, "watchRefresh", "applySessionSync");
       this.#consumeWatchView(view);
       return { ok: {} };
     } catch (error) {
       return { error: toPullError(error) };
+    } finally {
+      logger.time(refreshStart, "watchRefresh", "total");
     }
   }
 

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -5507,6 +5507,7 @@ export class SpaceReplica
       if (next.done || this.#closed) {
         return;
       }
+      const applyStart = performance.now();
       try {
         this.#applySessionSync(next.value, "integrate");
       } catch (error) {
@@ -5523,6 +5524,13 @@ export class SpaceReplica
           "consumer continues:",
           error,
         ]);
+      } finally {
+        // The push-side counterpart of `watchRefresh/applySessionSync`:
+        // frames the server pushed apply here, off the subscription
+        // iterator, never inside a refresh. Between the two keys every
+        // frame the replica ingests is timed, so a slow trickle and a
+        // slow initial sync read as different rows.
+        logger.time(applyStart, "watchPush", "applySessionSync");
       }
     }
   }

--- a/packages/runner/test/executor-cooperative-yield.test.ts
+++ b/packages/runner/test/executor-cooperative-yield.test.ts
@@ -74,9 +74,13 @@ const burn = (ms: number): void => {
 const WALK_STEPS = 30;
 const STEP_MS = 40;
 
+/** Reads the expiry as a millisecond timestamp through SQLite's REAL accessor. */
 const leaseExpiry = (engine: Engine.Engine): number =>
   (engine.database.prepare(
-    `SELECT expires_at FROM execution_lease WHERE space = :space`,
+    // The engine's INTEGER accessor truncates to 32 bits; millisecond
+    // timestamps are exactly representable as REAL values.
+    `SELECT CAST(expires_at AS REAL) AS expires_at
+     FROM execution_lease WHERE space = :space`,
   ).get({ space }) as { expires_at: number } | undefined)?.expires_at ?? 0;
 
 describe("stage C tuning T3: cooperative yield + mid-wave renew", () => {
@@ -260,7 +264,7 @@ describe("stage C tuning T3: cooperative yield + mid-wave renew", () => {
     const engine = await activate();
     const spaceServer = host.spaceServer(space)!;
     const expiryAtStart = leaseExpiry(engine);
-    expect(expiryAtStart).toBeGreaterThan(0);
+    expect(expiryAtStart).toBeGreaterThan(Date.now());
     const seqBefore = Engine.serverSeq(engine);
     const derivedBefore = host.stats().derivedCommits;
 

--- a/packages/runner/test/memory-v2-subscription.test.ts
+++ b/packages/runner/test/memory-v2-subscription.test.ts
@@ -902,6 +902,41 @@ describe("Memory v2 storage notifications", () => {
     expect(subscription.pulls).toHaveLength(1);
   });
 
+  it("times the replica's application of a pushed frame under its own key", async () => {
+    // `watchRefresh/applySessionSync` covers the frames a refresh brought
+    // back; frames the server PUSHES apply off the subscription iterator
+    // under `watchPush/applySessionSync`. Both keys are named in
+    // docs/development/debugging/profiling.md; this pins the push one.
+    const subscription = new Subscription();
+    storageManager.subscribe(subscription);
+    const uri = `of:memory-v2-push-timing-${Date.now()}` as URI;
+    const write = (n: number) =>
+      remoteSession.transact({
+        localSeq: remoteLocalSeq++,
+        reads: { confirmed: [], pending: [] },
+        operations: [{ op: "set", id: uri, value: { value: { n } } }],
+      });
+    await write(1);
+    const provider = storageManager.open(space);
+    await provider.sync(uri, { path: [], schema: true });
+
+    const timing = getLogger("storage.v2");
+    const pushApplies = () =>
+      timing.getTimeStats("watchPush", "applySessionSync")?.count ?? 0;
+    const before = pushApplies();
+    await write(2);
+    await waitFor(
+      () =>
+        subscription.notifications.some((notification) =>
+          notification.type === "integrate" &&
+          "changes" in notification &&
+          [...notification.changes].some((change) => change.address.id === uri)
+        ),
+      1_000,
+    );
+    expect(pushApplies() - before).toBeGreaterThanOrEqual(1);
+  });
+
   it("expands subscribed graph state to previously existing hidden docs after a root retarget", async () => {
     const subscription = new Subscription();
     storageManager.subscribe(subscription);

--- a/packages/runner/test/memory-v2-subscription.test.ts
+++ b/packages/runner/test/memory-v2-subscription.test.ts
@@ -12,6 +12,7 @@ import {
 import * as MemoryV2Client from "@commonfabric/memory/v2/client";
 import type { Server as MemoryV2Server } from "@commonfabric/memory/v2/server";
 import { defer } from "@commonfabric/utils/defer";
+import { getLogger } from "@commonfabric/utils/logger";
 
 import { Runtime } from "../src/runtime.ts";
 import { StorageManager } from "../src/storage/cache.deno.ts";
@@ -719,6 +720,52 @@ describe("Memory v2 storage notifications", () => {
 
     expect(result.error?.message).toBe("memory replica closed");
     expect((await view.subscribeSync().next()).done).toBe(true);
+    await testStorageManager.closeNow();
+  });
+
+  it("records a refresh's request span when the request itself fails", async () => {
+    // The refresh's sub-spans record in `finally` blocks, like its `total`:
+    // a failed refresh paid for its request, and a success-only span would
+    // leave that cost in `total` alone, so the halves would not add up
+    // across outcomes. Counts only — a duration is a property of the
+    // machine.
+    const timing = getLogger("storage.v2");
+    const counts = () => ({
+      watchAdd: timing.getTimeStats("watchRefresh", "watchAddSync")?.count ??
+        0,
+      apply: timing.getTimeStats("watchRefresh", "applySessionSync")?.count ??
+        0,
+      total: timing.getTimeStats("watchRefresh", "total")?.count ?? 0,
+    });
+    const client = {
+      close: () => Promise.resolve(),
+    } as unknown as MemoryV2Client.Client;
+    const session = {
+      watchAddSync: () => Promise.reject(new Error("scripted watch failure")),
+    } as unknown as MemoryV2Client.SpaceSession;
+    const sessionFactory: SessionFactory = {
+      create: () => Promise.resolve({ client, session }),
+    };
+    class TestStorageManager extends V2StorageManager {
+      constructor() {
+        super({ as: signer, memoryHost: new URL("memory://") }, sessionFactory);
+      }
+    }
+    const testStorageManager = new TestStorageManager();
+    const provider = testStorageManager.open(space);
+    const replica = provider.replica as SpaceReplica;
+
+    const before = counts();
+    const result = await replica.accessForTestingOnly.refreshWatchSet([[
+      { id: "of:failed-refresh" as URI, type: "application/json" as MIME },
+      { path: [], schema: false },
+    ]]);
+    const after = counts();
+
+    expect(result.error?.message).toBe("scripted watch failure");
+    expect(after.watchAdd - before.watchAdd).toBe(1);
+    expect(after.apply - before.apply).toBe(0);
+    expect(after.total - before.total).toBe(1);
     await testStorageManager.closeNow();
   });
 


### PR DESCRIPTION
Cold pattern resume can spend time in several dependent watch requests, but the existing measurements do not separate all of the server, transport, and replica work. This change adds reusable timing boundaries so those costs can be attributed on both the browser and worker-thread paths.

- Records direct-cell, argument-link, list-slot, and list-child resume waves.
- Separates watch requests, compression, boundary decoding, schema preparation and expansion, transport dispatch, and replica application. Refresh request/application spans and subscription-consumer application record in `finally` blocks.
- Records server `watch.add` timing from admission through handler completion, including duplicate and empty additions, rejected requests, and evaluation failures. Slow-query timing retains its evaluation-through-response-assembly boundary.
- Documents the overlap between client request, queue/order wait, and watch-view application; subtracting the request span does not isolate queue wait. Replica application spans cover graph-watch refreshes and the subscription consumer; direct operation-watch and watch-removal application are outside them.
- Adds manager-read and delivered-upsert counts to slow-query diagnostics, with documentation specifying which operations carry each field.
- Pins timing keys by invocation counts and delivered width by upsert counts. Regression cases cover duplicate/empty additions, conflicting watch IDs, unknown sessions, and evaluation errors.

The cooperative-yield test reads its lease expiry through SQLite’s REAL accessor, preserving the full millisecond timestamp. Its initial guard compares against the current time, so a truncated positive value cannot pass either. This corrects the test’s timestamp read without changing production lease behavior.

Validation for `4dc539846` (the main-conflict resolution preserves exactly the tested tree):

- Repo-wide `deno fmt --check`, `deno lint`, and `deno task check` passed.
- Full memory suite: 602 tests, 509 steps, zero failures.
- Full runner suite: 1,390 tests, 8,408 steps, zero failures.
- Documentation check: all 595 checked code blocks passed.
- Four new timing regression cases failed before the coverage fix; all nine frame-timing steps passed afterward.
- Cooperative-yield failure reproduced before the timestamp correction; all four steps passed afterward and the full suite passes with the stronger guard.
- Earlier timing-pin validation also mutation-checked removal of the recorded spans and fields.

The prior alternating local benchmark on the 135-topic rehearsal clone found no detectable instrumentation overhead: adjacent clean-main median 3.536 s, confirming instrumented median 3.398 s. An earlier instrumented block was noisy at 3.986 s; these samples establish parity, not a speedup. That benchmark predates the final timing-coverage fixes; no new performance claim is made from the test runs.

Derived-root expansion and changes to the runner’s fallback walks are separate follow-up work.