### PR TITLE
feat(patterns): collection naming library and exemplar board (S1)

### DIFF
--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -16,6 +16,11 @@ a record: archive it to `docs/history/plans/` following the procedure in
   commit SHA answers for the bytes, the text loads by handle into a child the
   chooser never reads, and a split-mint provenance mark records where it came
   from without declassifying anything.
+- [Collection naming: the first customer](collection-naming-topics.md)
+  builds [Naming in collections](../specs/collection-naming.md) on a parallel
+  exemplar board — a naming library, a member namespace the CLI and the shell
+  resolve as `top/42`, and `#42` in the editor — proven against the Topics
+  shape by a test-only board, and grafted onto Topics once, at the end.
 - [`cf view` language and syntax coverage](cf-view-language-coverage.md)
   orders the remaining language, data, build, and configuration formats needed
   for honest coverage of the active organization repositories.

--- a/docs/plans/collection-naming-topics.md
+++ b/docs/plans/collection-naming-topics.md
@@ -95,7 +95,14 @@ Scope: `packages/patterns/collection-naming/` (new): `naming.ts`, `board.tsx`,
 4. Two overlapping `addItem` calls end with distinct consecutive names. A
    test drives the overlap through the runtime's retry; if the harness cannot
    express the overlap, the allocator is tested against a stale read and the
-   limitation is recorded here.
+   limitation is recorded here. Recorded: the pattern-test harness runs one
+   runtime and dispatches events one at a time, so two `addItem` calls never
+   overlap in it, and the multi-user harness runs its participants
+   concurrently but offers no step that forces two of their events to
+   overlap. `naming.test.tsx` tests the allocator against a stale read on one
+   map cell instead: a first allocation, a concurrent writer's key landing,
+   and a re-run over the map as the winner left it, which takes the next
+   distinct name.
 5. A backfill verb names every unnamed member in filing order, skips named
    ones, and is idempotent: a second run writes nothing.
 6. Index rows carry `name` with a default, so a board holding older members

--- a/docs/plans/collection-naming-topics.md
+++ b/docs/plans/collection-naming-topics.md
@@ -13,7 +13,7 @@ This block is LIVE: the change that moves a stage updates it here.
 | stage | state |
 | --- | --- |
 | S0 — decisions ruled, plan filed | on main with S1 |
-| S1 — the library and the exemplar board own a member namespace | building |
+| S1 — the library and the exemplar board own a member namespace | built, in review |
 | S2 — `top/42` resolves at the CLI | not started |
 | S2b — assignment refuses by default | not started |
 | S3 — the shell opens `/<space>/top/42` | not started |
@@ -123,8 +123,8 @@ Scope: `packages/patterns/collection-naming/` (new): `naming.ts`, `board.tsx`,
     tests, and coverage green.
 
 Demo: local dev server. Two `cf piece call addItem` on the exemplar board
-return names `1` and `2`; `cf cell get $BOARD names --select @` lists both;
-the Topics-shape test is green in the same run.
+return names `1` and `2`; `cf cell get /of:$BOARD names` lists both keys; the
+Topics-shape test is green in the same run.
 
 ### S2 — `top/42` resolves at the CLI
 

--- a/docs/plans/collection-naming-topics.md
+++ b/docs/plans/collection-naming-topics.md
@@ -1,0 +1,198 @@
+# Collection naming: the first customer
+
+The build plan for [Naming in collections](../specs/collection-naming.md),
+carried by a parallel exemplar so that the Topics board is touched once, at
+the end, by a diff the exemplar has already proven. Member names are what the
+spec calls them; for the exemplar and for Topics they are decimal numbers, so a
+member is cited as `top/42`.
+
+## Where this stands — read this first
+
+This block is LIVE: the change that moves a stage updates it here.
+
+| stage | state |
+| --- | --- |
+| S0 — decisions ruled, plan filed | on main with S1 |
+| S1 — the library and the exemplar board own a member namespace | building |
+| S2 — `top/42` resolves at the CLI | not started |
+| S2b — assignment refuses by default | not started |
+| S3 — the shell opens `/<space>/top/42` | not started |
+| S4 — `#42` in text | not started |
+| S6 — graft onto Topics | not started; Mike's call after S4 |
+| S5 — deferred, not scheduled | — |
+
+## Decisions, ruled 2026-09-03
+
+Each of these was a question with a recommendation; the recommendation was
+ruled. A later reversal is a decision recorded here, not a discovery.
+
+1. **The citation form follows the cell reference grammar.** The fully
+   qualified citation is `#//topics-dev/top/42`. The spec's `#@space/...`
+   spelling is amended when that grammar lands. Part 1 of the spec, which
+   governs addressing, is unaffected.
+2. **The reverse-map restructure and the cross-space slug target are
+   deferred.** A board-owned namespace never writes the piece's single `slug`
+   metadata entry, so that restructure gates URL rewriting rather than
+   naming. Nothing here rewrites an identity URL to the member form, and no
+   personal binding is built.
+3. **The namespace is a map cell on the board**, `names: { "42": <link> }`,
+   and the collection's slug points at that cell. Forward resolution is a path
+   read: `parseFabricUrl` already returns the slug and a one-segment path, and
+   the resolver follows the slug, then the link. No segment walk is built for
+   a map-backed collection.
+4. **Names are decimal strings, dense from `1`**, allocated on create as one
+   more than the largest name present, permanent, never reused. Members that
+   predate the namespace are named in filing order by a backfill verb run
+   once. A keyset read of the map conflicts with a concurrent key write
+   (`docs/specs/memory-v2/08-conflict-granularity.md`), so two creators
+   serialize through one retry of `editWithRetry`.
+5. **A member's display name stays its title.** The number renders as a badge
+   and rides the index rows as `name`.
+6. **"In text" means the editor.** Typing `#42` completes to a reference-form
+   mention that shows the number. Pasted text is left alone. The `#` sigil is
+   provisional: the spec leaves tags versus citations open.
+7. **The board publishes a machine-readable `naming` declaration.**
+8. **Models.** Fable implements until Mike says otherwise.
+9. **Slug names.** `top` names the namespace; `topics` may name the board
+   root.
+10. **Estuary is untouched**, read-only calls included, until Mike directs.
+    Deployment and the production backfill are Mike's steps, rehearsed on a
+    clone first.
+11. **The work lands in `packages/patterns/collection-naming/`**: `naming.ts`
+    (the library a collection pattern calls), `board.tsx` and `item.tsx` (the
+    exemplar the demos run on), and tests. `packages/patterns/topics` is not
+    edited until S6.
+12. **The Topics-shape rehearsal is a test-only board** in that directory,
+    composing the real `Topic` from `../topics/topic.tsx` unmodified through
+    the library. Board-side naming is proven there. Item-side display is
+    proven on the exemplar item and grafted onto `topic.tsx` in S6.
+
+## Gates and review
+
+Every stage runs `deno fmt --check`, `deno lint`, `deno task check`, and
+`deno task test` in the packages it touched; `deno task cfcheck` when a pattern
+changed; and the gates in `AGENTS.md` § Automated gates that its files reach —
+`check-command-docs` and `check-completion-slots` for a `cf` option,
+`check-no-waitfor` for a test, `check-docs` for a document. Codex reviews each
+round through `stage-loop`. Nothing merges without Mike.
+
+## Stages
+
+### S1 — The library and the exemplar board own a member namespace
+
+Scope: `packages/patterns/collection-naming/` (new): `naming.ts`, `board.tsx`,
+`item.tsx`, `topics-shape.test.tsx`, unit tests, `README.md`.
+
+1. `naming.ts` exports what a collection pattern calls: allocate the next
+   name inside an action, the names table lift (one row per member,
+   addressed by the member), a backfill over an existing list, and the
+   `naming` declaration type. Nothing in it names topics.
+2. The exemplar board's `addItem` allocates the next name in the same atomic
+   write as the append: the created item is reachable at `names[<n>]`, and
+   the result row carries `name`.
+3. Names are decimal strings, dense from `1`, one more than the largest name
+   present, never reused. An item keeps its name whatever happens to it.
+4. Two overlapping `addItem` calls end with distinct consecutive names. A
+   test drives the overlap through the runtime's retry; if the harness cannot
+   express the overlap, the allocator is tested against a stale read and the
+   limitation is recorded here.
+5. A backfill verb names every unnamed member in filing order, skips named
+   ones, and is idempotent: a second run writes nothing.
+6. Index rows carry `name` with a default, so a board holding older members
+   still reads whole.
+7. The exemplar item renders its own name from the board's names table,
+   wired at creation the way Topics wires `boardCrossrefs`; an item without
+   the wiring shows no name and does not fail.
+8. The board publishes `naming`: `{ name?, policy: { unique, permanent,
+   reuse, allocator }, compact }`.
+9. Allocation reads the namespace's keys without expanding any member: the
+   declared schema holds the values as unread references.
+10. The Topics-shape rehearsal passes: a test-only board over the unmodified
+    `Topic` pattern, wired through `naming.ts`, allocates on create,
+    backfills a pre-existing list, publishes index rows with `name`, and
+    returns the names-table row for a given topic. `topic.tsx` and
+    `topics/main.tsx` are untouched by the stage.
+11. `README.md` describes the library and the exemplar; `cfcheck`, pattern
+    tests, and coverage green.
+
+Demo: local dev server. Two `cf piece call addItem` on the exemplar board
+return names `1` and `2`; `cf cell get $BOARD names --select @` lists both;
+the Topics-shape test is green in the same run.
+
+### S2 — `top/42` resolves at the CLI
+
+Scope: `packages/piece/src/slugs.ts`, `packages/runner/src/slug-resolution.ts`,
+`packages/cli` (`set-slug`, README, completion table).
+
+1. `cf piece set-slug top <board>/names` writes a slug at a non-root path,
+   and `cf piece slugs` lists it, naming the containing piece. Both demos run
+   on the exemplar board.
+2. `resolvePieceAddress` accepts a slug whose target, after the path, is a
+   link to a piece: `cf cell get //<space>/top/42 title`,
+   `cf piece describe --cell //<space>/top/42`, and
+   `cf piece call --cell //<space>/top/42 <verb>` all reach the member.
+3. A slug resolving to a non-piece with no further path fails with a message
+   naming the containing piece.
+4. `//<space>/top/999` fails with "no member 999 in top".
+5. Unit tests in `packages/piece/test/slug.test.ts` and `packages/cli/test`.
+
+Demo: `cf cell get //<space>/top/2 title` on the local exemplar board.
+
+### S2b — Assignment refuses by default
+
+The first half of the spec's step 2.
+
+1. `set-slug` on a bound name refuses and names the current target; `--force`
+   steals. The check is a claim inside the transaction: a test with two
+   writers has exactly one win.
+2. Whether a synced read inside `editWithRetry` becomes a commit precondition
+   is settled by that test and recorded in the spec's open-questions list.
+3. `--force` has a completion slot and a README sentence.
+
+### S3 — The shell opens `/<space>/top/42`
+
+Scope: `packages/shell`, `packages/runtime-client`, shell integration tests.
+
+1. `/<space>/top/42` opens the member piece; the tab shows its title. The
+   exemplar item is the member; the Topics-shape test covers the board side
+   only.
+2. `/<space>/top` opens the board, the piece containing the namespace.
+3. `/<space>/top/999` shows a not-found state naming the collection.
+4. The item header shows the number and a copyable portable reference
+   `//<space>/top/42`; board cards show the number.
+5. A browser integration test covers 1 and 3.
+
+### S4 — `#42` in text
+
+Scope: `packages/ui` cf-code-editor mention completion and pill; the exemplar
+(mentionable rows carry `name`, item output carries `shortName`).
+
+1. Typing `#42` in the exemplar item's body offers the member named 42;
+   picking it inserts a reference-form mention.
+2. A mention pill whose destination publishes a short name shows it beside
+   the label; existing mentions gain it once the destination does.
+3. Autocomplete matches the number as well as the title.
+4. A pasted `#42` stays plain text; the editor's documentation says so and
+   why.
+5. Stretch: the pill's plain-text copy is `//<space>/top/42`.
+
+### S6 — Graft onto Topics
+
+Mike's call, after S4.
+
+1. `topics/main.tsx` adopts `naming.ts` with the wiring the rehearsal board
+   already carries; the diff is the rehearsal board's diff against today's
+   board and nothing more.
+2. `topic.tsx` gains the item-side display the exemplar item proved: the
+   badge and `shortName`.
+3. The production backfill is rehearsed on a clone per
+   `../development/space-clone-rehearsal.md`; the deployed vintage includes
+   #6827 before the backfill runs.
+4. `skills/topics/SKILL.md` describes `top/42` addressing.
+
+### S5 — Deferred, not scheduled
+
+The reverse-map restructure and identity-URL rewrite to the member form;
+cross-space personal bindings (`#top/42` through a home-space slug); the
+compact form `top-42`; prose scanning; the tags-versus-citations sigil
+decision.

--- a/docs/specs/collection-naming.md
+++ b/docs/specs/collection-naming.md
@@ -599,7 +599,11 @@ member carries of its own. Every candidate is verified before display; what is
 unsettled is the order among them.
 
 **Whether a name policy is machine-readable**, so a consumer can branch on it,
-or is documentation that a consumer's author reads.
+or is documentation that a consumer's author reads. The first customer
+publishes one — `NamingDeclaration` in
+`packages/patterns/collection-naming/naming.ts`, ruled 2026-09-03 in
+`docs/plans/collection-naming-topics.md` (decision 7) — and whether that shape
+becomes the standard every collection declares is what remains open.
 
 **Whether a synced read inside an `editWithRetry` body becomes a commit
 precondition**, which is what step 2 rests on.

--- a/packages/patterns/baselines/collection-naming/board.tsx/20260904T001531Z-WRSzkgeFJQmQt1ZM.json
+++ b/packages/patterns/baselines/collection-naming/board.tsx/20260904T001531Z-WRSzkgeFJQmQt1ZM.json
@@ -1,0 +1,285 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "ItemDemand": {
+        "properties": {
+          "createdAt": {
+            "type": "number"
+          },
+          "title": {
+            "default": "",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "createdAt"
+        ],
+        "type": "object"
+      },
+      "NamesMap": {
+        "additionalProperties": {
+          "type": "unknown"
+        },
+        "properties": {},
+        "type": "object"
+      }
+    },
+    "properties": {
+      "items": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "description": "The board's durable item list, in filing order. `addItem` appends here;\na whole-array write forfeits the mergeability the append keeps.",
+        "items": {
+          "$ref": "#/$defs/ItemDemand"
+        },
+        "type": "array"
+      },
+      "names": {
+        "$ref": "#/$defs/NamesMap",
+        "asCell": [
+          "cell"
+        ],
+        "default": {},
+        "description": "The board's member namespace: each name to the item it names, held as an\nunread reference. `addItem` writes one key per create and `backfillNames`\none key per member it names; nothing rewrites the map whole. Reads as\nempty on a board from before it numbered anything, in the default form\n`NamesMap` explains."
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "collection-naming/board.tsx",
+  "resultSchema": {
+    "$defs": {
+      "AddItemEvent": {
+        "properties": {
+          "agentName": {
+            "description": "The agent making this mutation. Fabric records the human principal\nbehind the key; this names which agent acted under it. Required, and\nchecked rather than stored: a create that could be unsigned is a\ntolerance the verb could never withdraw.",
+            "type": "string"
+          },
+          "body": {
+            "description": "The item's initial body, stored verbatim.",
+            "type": "string"
+          },
+          "title": {
+            "description": "The item's title, trimmed before it is stored. Must be non-empty.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "agentName"
+        ],
+        "type": "object"
+      },
+      "BackfillNamesEvent": {
+        "properties": {
+          "agentName": {
+            "description": "The agent running the backfill, checked as `addItem` checks it.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "agentName"
+        ],
+        "type": "object"
+      },
+      "ItemDemand": {
+        "properties": {
+          "createdAt": {
+            "type": "number"
+          },
+          "title": {
+            "default": "",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "createdAt"
+        ],
+        "type": "object"
+      },
+      "ItemIndexRow": {
+        "properties": {
+          "createdAt": {
+            "default": 0,
+            "type": "number"
+          },
+          "member": {
+            "description": "The item, written as a reference and never read through here.",
+            "type": "unknown"
+          },
+          "name": {
+            "default": "",
+            "description": "The board's name for the item. Defaulted so a board holding members\nfrom before it numbered anything still reads whole: a member the board\nhas not named reads as the empty string.",
+            "type": "string"
+          },
+          "title": {
+            "default": "",
+            "type": "string"
+          }
+        },
+        "required": [
+          "member",
+          "title",
+          "createdAt",
+          "name"
+        ],
+        "type": "object"
+      },
+      "NamesMap": {
+        "additionalProperties": {
+          "type": "unknown"
+        },
+        "properties": {},
+        "type": "object"
+      },
+      "NamesTableRow": {
+        "properties": {
+          "member": {
+            "description": "The member. `unknown` because it is written as a reference and only\never compared; anything wider would read the member back whole.",
+            "type": "unknown"
+          },
+          "name": {
+            "description": "The member's name.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "member",
+          "name"
+        ],
+        "type": "object"
+      },
+      "NamingDeclaration": {
+        "properties": {
+          "compact": {
+            "description": "Whether the collection offers the compact spelling that joins its name\nto a member's with a hyphen. Only a collection whose member names cannot\ncontain a hyphen may say so.",
+            "type": "boolean"
+          },
+          "name": {
+            "description": "The collection's own name, which a binding uses to reach it. Absent\nwhen the collection makes no claim about what it is bound as.",
+            "type": "string"
+          },
+          "policy": {
+            "$ref": "#/$defs/NamingPolicy",
+            "description": "The policy the names are held to."
+          }
+        },
+        "required": [
+          "policy",
+          "compact"
+        ],
+        "type": "object"
+      },
+      "NamingPolicy": {
+        "properties": {
+          "allocator": {
+            "description": "What a name is made of: a monotonic sequence, a random code, a string a\nperson chose, or a derivation from the member's own content.",
+            "enum": [
+              "sequence",
+              "random",
+              "human",
+              "derived"
+            ]
+          },
+          "permanent": {
+            "description": "Whether a name, once assigned, is never retired or reassigned.",
+            "type": "boolean"
+          },
+          "reuse": {
+            "description": "Whether a retired name may be given to another member.",
+            "type": "boolean"
+          },
+          "unique": {
+            "description": "Whether a name is unique across the collection's whole history, or\nonly among its current members.",
+            "enum": [
+              "history",
+              "current"
+            ]
+          }
+        },
+        "required": [
+          "unique",
+          "permanent",
+          "reuse",
+          "allocator"
+        ],
+        "type": "object"
+      }
+    },
+    "description": "A board of items that names its members. Survey the board with one bounded\nread of `index`, whose rows carry each item's name; follow a row's `member`\nfor the item itself. File with `addItem`, which allocates the next name in\nthe same write as the append and returns the row, name included. A board\nthat held items before it numbered anything runs `backfillNames` once.",
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "addItem": {
+        "$ref": "#/$defs/AddItemEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "File an item: allocate its name and append it, atomically."
+      },
+      "backfillNames": {
+        "$ref": "#/$defs/BackfillNamesEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Name every unnamed member in filing order. Idempotent."
+      },
+      "index": {
+        "default": [],
+        "description": "The survey surface: one row per item, scalars copied, name included.",
+        "items": {
+          "$ref": "#/$defs/ItemIndexRow"
+        },
+        "type": "array"
+      },
+      "itemCount": {
+        "description": "How many items the board holds.",
+        "type": "number"
+      },
+      "items": {
+        "description": "The board's items, in filing order, through the shape the board demands\nof them.",
+        "items": {
+          "$ref": "#/$defs/ItemDemand"
+        },
+        "type": "array"
+      },
+      "names": {
+        "$ref": "#/$defs/NamesMap",
+        "default": {},
+        "description": "The namespace itself: each name to the item it names. A slug pointing\nhere is what makes a member addressable as `<board>/<name>`. Published\nunder the default its input carries."
+      },
+      "namesTable": {
+        "default": [],
+        "description": "The names table, one row per named member, which every item the board\ncreates reads its own name from. Published so an item composed outside\n`addItem` can be wired to the same table.",
+        "items": {
+          "$ref": "#/$defs/NamesTableRow"
+        },
+        "type": "array"
+      },
+      "naming": {
+        "$ref": "#/$defs/NamingDeclaration",
+        "description": "What the board declares about its names, for a consumer deciding\nwhether a name may be held rather than an identity."
+      }
+    },
+    "required": [
+      "items",
+      "index",
+      "names",
+      "namesTable",
+      "naming",
+      "itemCount",
+      "addItem",
+      "backfillNames",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/collection-naming/board.tsx/20260904T022635Z-OsLnrwxWR4PfC0gG.json
+++ b/packages/patterns/baselines/collection-naming/board.tsx/20260904T022635Z-OsLnrwxWR4PfC0gG.json
@@ -1,0 +1,288 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "ItemDemand": {
+        "properties": {
+          "createdAt": {
+            "type": "number"
+          },
+          "title": {
+            "default": "",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "createdAt"
+        ],
+        "type": "object"
+      },
+      "NamesMap": {
+        "additionalProperties": {
+          "type": "unknown"
+        },
+        "properties": {},
+        "type": "object"
+      }
+    },
+    "description": "What the board holds: its item list and its member namespace.",
+    "properties": {
+      "items": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "description": "The board's durable item list, in filing order. `addItem` appends here; a\nwhole-array write forfeits the mergeability the append keeps.",
+        "items": {
+          "$ref": "#/$defs/ItemDemand"
+        },
+        "type": "array"
+      },
+      "names": {
+        "$ref": "#/$defs/NamesMap",
+        "asCell": [
+          "cell"
+        ],
+        "default": {},
+        "description": "The board's member namespace: each name to the item it names, held as an\nunread reference. `addItem` writes one key per create and `backfillNames`\none key per member it names; nothing rewrites the map whole. Reads as\nempty on a board from before it numbered anything, in the default form\n`NamesMap` explains."
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "collection-naming/board.tsx",
+  "resultSchema": {
+    "$defs": {
+      "AddItemEvent": {
+        "properties": {
+          "agentName": {
+            "description": "The agent making this mutation. Fabric records the human principal\nbehind the key; this names which agent acted under it. Required, and\nchecked rather than stored: a create that could be unsigned is a\ntolerance the verb could never withdraw.",
+            "type": "string"
+          },
+          "body": {
+            "description": "The item's initial body, stored verbatim.",
+            "type": "string"
+          },
+          "title": {
+            "description": "The item's title, trimmed before it is stored. Must be non-empty.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "agentName"
+        ],
+        "type": "object"
+      },
+      "BackfillNamesEvent": {
+        "properties": {
+          "agentName": {
+            "description": "The agent running the backfill, checked as `addItem` checks it.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "agentName"
+        ],
+        "type": "object"
+      },
+      "ItemDemand": {
+        "properties": {
+          "createdAt": {
+            "type": "number"
+          },
+          "title": {
+            "default": "",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "createdAt"
+        ],
+        "type": "object"
+      },
+      "ItemIndexRow": {
+        "properties": {
+          "createdAt": {
+            "default": 0,
+            "description": "When the item was filed (epoch milliseconds).",
+            "type": "number"
+          },
+          "member": {
+            "description": "The item, written as a reference and never read through here.",
+            "type": "unknown"
+          },
+          "name": {
+            "default": "",
+            "description": "The board's name for the item. Defaulted so a board holding members from\nbefore it numbered anything still reads whole: a member the board has\nnot named reads as the empty string.",
+            "type": "string"
+          },
+          "title": {
+            "default": "",
+            "description": "The item's title, as stored.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "member",
+          "title",
+          "createdAt",
+          "name"
+        ],
+        "type": "object"
+      },
+      "NamesMap": {
+        "additionalProperties": {
+          "type": "unknown"
+        },
+        "properties": {},
+        "type": "object"
+      },
+      "NamesTableRow": {
+        "properties": {
+          "member": {
+            "description": "The member. `unknown` because it is written as a reference and only ever\ncompared; anything wider would read the member back whole.",
+            "type": "unknown"
+          },
+          "name": {
+            "description": "The member's name.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "member",
+          "name"
+        ],
+        "type": "object"
+      },
+      "NamingDeclaration": {
+        "properties": {
+          "compact": {
+            "description": "Whether the collection offers the compact spelling that joins its name to\na member's with a hyphen. Only a collection whose member names cannot\ncontain a hyphen may say so.",
+            "type": "boolean"
+          },
+          "name": {
+            "description": "The collection's own name, which a binding uses to reach it. Absent when\nthe collection makes no claim about what it is bound as.",
+            "type": "string"
+          },
+          "policy": {
+            "$ref": "#/$defs/NamingPolicy",
+            "description": "The policy the names are held to."
+          }
+        },
+        "required": [
+          "policy",
+          "compact"
+        ],
+        "type": "object"
+      },
+      "NamingPolicy": {
+        "properties": {
+          "allocator": {
+            "description": "What a name is made of: a monotonic sequence, a random code, a string a\nperson chose, or a derivation from the member's own content.",
+            "enum": [
+              "sequence",
+              "random",
+              "human",
+              "derived"
+            ]
+          },
+          "permanent": {
+            "description": "Whether a name, once assigned, is never retired or reassigned.",
+            "type": "boolean"
+          },
+          "reuse": {
+            "description": "Whether a retired name may be given to another member.",
+            "type": "boolean"
+          },
+          "unique": {
+            "description": "Whether a name is unique across the collection's whole history, or only\namong its current members.",
+            "enum": [
+              "history",
+              "current"
+            ]
+          }
+        },
+        "required": [
+          "unique",
+          "permanent",
+          "reuse",
+          "allocator"
+        ],
+        "type": "object"
+      }
+    },
+    "description": "A board of items that names its members. Survey the board with one bounded\nread of `index`, whose rows carry each item's name; follow a row's `member`\nfor the item itself. File with `addItem`, which allocates the next name in\nthe same write as the append and returns the row, name included. A board\nthat held items before it numbered anything runs `backfillNames` once.",
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "addItem": {
+        "$ref": "#/$defs/AddItemEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "File an item: allocate its name and append it, atomically."
+      },
+      "backfillNames": {
+        "$ref": "#/$defs/BackfillNamesEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Name every unnamed member in filing order. Idempotent."
+      },
+      "index": {
+        "default": [],
+        "description": "The survey surface: one row per item, scalars copied, name included.",
+        "items": {
+          "$ref": "#/$defs/ItemIndexRow"
+        },
+        "type": "array"
+      },
+      "itemCount": {
+        "description": "How many items the board holds.",
+        "type": "number"
+      },
+      "items": {
+        "description": "The board's items, in filing order, through the shape the board demands\nof them.",
+        "items": {
+          "$ref": "#/$defs/ItemDemand"
+        },
+        "type": "array"
+      },
+      "names": {
+        "$ref": "#/$defs/NamesMap",
+        "default": {},
+        "description": "The namespace itself: each name to the item it names. A slug pointing\nhere is what makes a member addressable as `<board>/<name>`. Published\nunder the default its input carries."
+      },
+      "namesTable": {
+        "default": [],
+        "description": "The names table, one row per named member, which every item the board\ncreates reads its own name from. Published so an item composed outside\n`addItem` can be wired to the same table.",
+        "items": {
+          "$ref": "#/$defs/NamesTableRow"
+        },
+        "type": "array"
+      },
+      "naming": {
+        "$ref": "#/$defs/NamingDeclaration",
+        "description": "What the board declares about its names, for a consumer deciding whether\na name may be held rather than an identity."
+      }
+    },
+    "required": [
+      "items",
+      "index",
+      "names",
+      "namesTable",
+      "naming",
+      "itemCount",
+      "addItem",
+      "backfillNames",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/collection-naming/item.tsx/20260904T001531Z-z0Gy14PpefRML1fx.json
+++ b/packages/patterns/baselines/collection-naming/item.tsx/20260904T001531Z-z0Gy14PpefRML1fx.json
@@ -1,0 +1,97 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "NamesTableRow": {
+        "properties": {
+          "member": {
+            "description": "The member. `unknown` because it is written as a reference and only\never compared; anything wider would read the member back whole.",
+            "type": "unknown"
+          },
+          "name": {
+            "description": "The member's name.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "member",
+          "name"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "boardNames": {
+        "asCell": [
+          "readonly"
+        ],
+        "default": [],
+        "description": "The board's names table, one row per named member. The item reads its\nown row out of it and nothing else; absent, the item shows no name.\n\nReadable, not writable: the table is the board's derivation, and an item\nhas no business writing into it.",
+        "items": {
+          "$ref": "#/$defs/NamesTableRow"
+        },
+        "type": "array"
+      },
+      "body": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "description": "The item's body, verbatim Markdown.",
+        "type": "string"
+      },
+      "createdAt": {
+        "default": 0,
+        "description": "When the item was filed (epoch milliseconds), stamped at create.",
+        "type": "number"
+      },
+      "title": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "collection-naming/item.tsx",
+  "resultSchema": {
+    "description": "An item of the exemplar board. The display name stays the title; the\nboard's name for the item rides beside it as `shortName`, and renders as a\nbadge in the header when there is one.",
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "body": {
+        "default": "",
+        "type": "string"
+      },
+      "createdAt": {
+        "description": "When the item was filed (epoch milliseconds).",
+        "type": "number"
+      },
+      "shortName": {
+        "description": "The name the board calls this item by, read out of the board's names\ntable; `undefined` for an item no board has named, or one wired to no\nboard.",
+        "type": [
+          "string",
+          "undefined"
+        ]
+      },
+      "title": {
+        "default": "",
+        "type": "string"
+      }
+    },
+    "required": [
+      "title",
+      "body",
+      "createdAt",
+      "shortName",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/collection-naming/item.tsx/20260904T022635Z-GMG883UMGFeAnh-r.json
+++ b/packages/patterns/baselines/collection-naming/item.tsx/20260904T022635Z-GMG883UMGFeAnh-r.json
@@ -1,0 +1,101 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "NamesTableRow": {
+        "properties": {
+          "member": {
+            "description": "The member. `unknown` because it is written as a reference and only ever\ncompared; anything wider would read the member back whole.",
+            "type": "unknown"
+          },
+          "name": {
+            "description": "The member's name.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "member",
+          "name"
+        ],
+        "type": "object"
+      }
+    },
+    "description": "What an item holds, and the one thing its board hands it.",
+    "properties": {
+      "boardNames": {
+        "asCell": [
+          "readonly"
+        ],
+        "default": [],
+        "description": "The board's names table, one row per named member. The item reads its\nown row out of it and nothing else; absent, the item shows no name.\n\nReadable, not writable: the table is the board's derivation, and an item\nhas no business writing into it.",
+        "items": {
+          "$ref": "#/$defs/NamesTableRow"
+        },
+        "type": "array"
+      },
+      "body": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "description": "The item's body, verbatim Markdown.",
+        "type": "string"
+      },
+      "createdAt": {
+        "default": 0,
+        "description": "When the item was filed (epoch milliseconds), stamped at create.",
+        "type": "number"
+      },
+      "title": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "description": "The item's title, trimmed by the board's create before it is stored.",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "collection-naming/item.tsx",
+  "resultSchema": {
+    "description": "An item of the exemplar board. The display name stays the title; the\nboard's name for the item rides beside it as `shortName`, and renders as a\nbadge in the header when there is one.",
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "body": {
+        "default": "",
+        "description": "The item's body, verbatim Markdown.",
+        "type": "string"
+      },
+      "createdAt": {
+        "description": "When the item was filed (epoch milliseconds).",
+        "type": "number"
+      },
+      "shortName": {
+        "description": "The name the board calls this item by, read out of the board's names\ntable; `undefined` for an item no board has named, or one wired to no\nboard.",
+        "type": [
+          "string",
+          "undefined"
+        ]
+      },
+      "title": {
+        "default": "",
+        "description": "The item's title, as stored.",
+        "type": "string"
+      }
+    },
+    "required": [
+      "title",
+      "body",
+      "createdAt",
+      "shortName",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/collection-naming/README.md
+++ b/packages/patterns/collection-naming/README.md
@@ -34,7 +34,9 @@ collection does with it:
   it may be reused, and what allocates it. `SEQUENCE_NAMING` is the declaration
   for this sequence: unique across history, permanent, never reused, and
   eligible for the compact `<collection>-42` spelling because a decimal name
-  holds no hyphen.
+  holds no hyphen. Its `name` — the collection's own — is optional and absent on
+  the exemplar: the stage that binds the board's namespace as a slug fills it,
+  and that binding is what a resolver can then check the declaration against.
 
 Nothing in the library knows what kind of piece a member is. A member is a cell,
 compared by identity and never read through, which is what keeps every read here
@@ -87,11 +89,12 @@ and needs nothing else.
 Headless, against a deployed board:
 
 ```bash
-cf piece call --piece <board> addItem '{"title":"...","agentName":"Sol"}'
+cf piece call --cell /of:<board> addItem --json '{"title":"...","agentName":"Sol"}'
 # -> { "result": { "item": { "member": { "$link": ... }, "name": "1", ... } } }
-cf cell get --piece <board> names --select @
-cf cell get --piece <board> index
-cf piece call --piece <board> backfillNames '{"agentName":"Sol"}'
+cf cell get /of:<board> names
+# -> { "1": {}, "2": {} }
+cf cell get /of:<board> index
+cf piece call --cell /of:<board> backfillNames --json '{"agentName":"Sol"}'
 ```
 
 ## Tests

--- a/packages/patterns/collection-naming/README.md
+++ b/packages/patterns/collection-naming/README.md
@@ -1,0 +1,119 @@
+# Collection naming
+
+A library a collection pattern calls to give its members names of its own, and
+an exemplar collection that uses it. The design is
+[Naming in collections](../../../docs/specs/collection-naming.md); this
+directory is its first customer. Member names here are decimal strings, dense
+from `1`, so a member is cited as `<collection>/42`.
+
+## The library: `naming.ts`
+
+The namespace is one map cell on the collection, `names: { "42": <member> }`,
+holding each member as an unread reference. The library owns everything a
+collection does with it:
+
+- **Allocation.** `assignName(names, member)` computes the next name — `1` when
+  the map holds none, otherwise one more than the largest present — and records
+  the member under it, in the transaction of the verb that calls it. A keyset
+  read of the map conflicts with a concurrent key write to it, so of two verbs
+  that read the same keys the second to commit is rejected, re-runs against the
+  first one's write, and takes the name after it. `nextNameAmong()` is the rule
+  on its own, over any list of keys.
+- **The names table.** `namesTable` derives one row per named member,
+  `{ member, name }`, each row addressed by the member it describes. A
+  collection derives it once and hands it to every member it creates.
+- **Reverse lookup.** `nameOf(member, table)` returns the name the table gives a
+  member, matched by identity, or `undefined`. `ownName` is the same lookup as a
+  lift, for a member reading its own row out of its collection's table.
+- **The backfill.** `backfillNames(members, names)` names every unnamed member
+  of a list in filing order, skips those already named, and returns exactly the
+  names it wrote — `[]` on a second run, which writes nothing.
+- **The declaration.** `NamingDeclaration` is what a collection publishes so a
+  consumer learns the policy rather than assuming one: whether a name is unique
+  across history or only among current members, whether it is permanent, whether
+  it may be reused, and what allocates it. `SEQUENCE_NAMING` is the declaration
+  for this sequence: unique across history, permanent, never reused, and
+  eligible for the compact `<collection>-42` spelling because a decimal name
+  holds no hyphen.
+
+Nothing in the library knows what kind of piece a member is. A member is a cell,
+compared by identity and never read through, which is what keeps every read here
+— the allocator surveying keys, the table over the map, a member finding its row
+— from expanding a member document.
+
+### Declaring the namespace
+
+A collection declares the map at its input as
+`names?: Writable<Default<NamesMap, {}>>`, written inline at the property, and
+publishes it under the same default. Two details of that spelling decide whether
+the reads above stay bounded:
+
+- The two-argument `Default`. `NamesMap | Default<{}>` adds a bare empty-object
+  arm to the union, and wherever that union reaches a handler unmerged it
+  becomes an `anyOf` whose empty arm reads every value whole; the runtime's
+  merge lets a branch that looked win over the opaque one, so the allocator
+  would expand every member to survey the keys.
+- Inline, not through an alias. The schema generator reads the default off the
+  property's own type node, so a default declared through a type alias is
+  dropped from the schema.
+
+A verb reads its binding through a schema that carries no default, so inside a
+verb the map is `undefined` until the first name is written. `NamesMapCell`
+declares that structurally, and the library's readers take an absent map as
+empty.
+
+## The exemplar: `board.tsx` and `item.tsx`
+
+The board is a collection of items that owns a member namespace, and the demos
+in the plan run on it. Its verbs:
+
+- `addItem({ title, body?, agentName })` allocates the next name and appends the
+  item in one write, so the created item is reachable at `names[<n>]` the moment
+  it exists. It returns the item's index row, name included.
+- `backfillNames({ agentName })` names every unnamed member in filing order and
+  returns the names it wrote. Idempotent.
+
+It publishes `index` (one row per item: the item as a reference, `title`,
+`createdAt`, and `name`, defaulted to the empty string for a member the board
+has not named), `names`, `namesTable`, `naming`, `itemCount`, and a card list
+showing each item with its name.
+
+The item is the member: a title, a body, a filing time, and the board's names
+table wired in at creation as `boardNames`. It reads its own row out of that
+table by identity and publishes the result as `shortName`, rendering it as a
+badge beside the title when it has one. An item wired to no board shows no name
+and needs nothing else.
+
+Headless, against a deployed board:
+
+```bash
+cf piece call --piece <board> addItem '{"title":"...","agentName":"Sol"}'
+# -> { "result": { "item": { "member": { "$link": ... }, "name": "1", ... } } }
+cf cell get --piece <board> names --select @
+cf cell get --piece <board> index
+cf piece call --piece <board> backfillNames '{"agentName":"Sol"}'
+```
+
+## Tests
+
+- `naming.test.tsx` — the sequence rule, the allocator re-run against a stale
+  read (a first allocation, a concurrent writer's key landing, and a re-run over
+  the map as the winner left it, which takes the next distinct name), the
+  reverse lookup, and the declaration.
+- `board.test.tsx` — the exemplar end to end: allocation on create, one more
+  than the largest name present, a name kept through a rename and through
+  leaving the list, the backfill and its idempotence, index rows and the default
+  an unnamed member's row reads as, the item reading its own name, the bound on
+  what a read of the namespace expands, a board given no namespace at all, and
+  the rejections.
+- `topics-shape.test.tsx` — the rehearsal for the Topics board: a test-only
+  board whose members are the real `Topic` pattern, unmodified, wired through
+  the library the way the exemplar is. It proves the board side; the item side
+  is proven on the exemplar item.
+
+## Topics
+
+The Topics board (`../topics/`) is the collection this library exists for. It
+adopts the library with the wiring the rehearsal board already carries, and its
+topic gains the item-side display the exemplar item proves, on the schedule in
+[the plan](../../../docs/plans/collection-naming-topics.md).

--- a/packages/patterns/collection-naming/board.test.tsx
+++ b/packages/patterns/collection-naming/board.test.tsx
@@ -1,0 +1,382 @@
+/**
+ * Pattern tests for the exemplar board and its item: allocation on create,
+ * density, a name never reused, a name kept whatever happens to its item, the
+ * backfill and its idempotence, index rows and the default an unnamed
+ * member's row reads as, the item reading its own name out of the board's
+ * table, the declaration, the bound on what a read of the namespace expands,
+ * and the rejections. Every rejection here is a thrown verb, so the runtime
+ * errors are required, and the count is exact: a guard quietly reverting to
+ * a silent return fails the suite.
+ */
+import {
+  action,
+  assert,
+  Default,
+  equals,
+  NAME,
+  pattern,
+  TESTS,
+  UI,
+  Writable,
+} from "commonfabric";
+import { findElement, hasText } from "../test/vnode-helpers.ts";
+import Board, { type ItemDemand } from "./board.tsx";
+import Item from "./item.tsx";
+import { backfillNames, type NamesMap } from "./naming.ts";
+
+export default pattern(() => {
+  const items = new Writable<ItemDemand[] | Default<[]>>([]);
+  const names = new Writable<NamesMap>({});
+  const board = Board({ items, names });
+
+  const assert_initial = assert(() =>
+    board.itemCount === 0 &&
+    (board.index ?? []).length === 0 &&
+    (board.namesTable ?? []).length === 0 &&
+    Object.keys((board.names ?? {}) as NamesMap).length === 0 &&
+    board[NAME] === "Items (0)"
+  );
+  const assert_empty_board_renders_empty_state = assert(() =>
+    findElement(board[UI], "cf-empty-state") !== undefined &&
+    findElement(board[UI], "cf-badge") === undefined
+  );
+
+  // Allocation on create: the created item is reachable at `names["1"]`,
+  // and its index row and its names-table row both carry the name.
+  const action_add_first = action(() => {
+    board.addItem.send({
+      title: "  First item  ",
+      body: "The first body.",
+      agentName: "Sol",
+    });
+  });
+  const assert_first_is_named_one = assert(() =>
+    board.itemCount === 1 &&
+    board.items?.[0]?.title === "First item" &&
+    board.index?.[0]?.name === "1" &&
+    board.index?.[0]?.title === "First item" &&
+    (board.index?.[0]?.createdAt ?? 0) > 0 &&
+    equals(board.index?.[0]?.member as object, board.items?.[0] as object) &&
+    equals(
+      ((board.names ?? {}) as NamesMap)["1"] as object,
+      board.items?.[0] as object,
+    ) &&
+    board.namesTable?.[0]?.name === "1" &&
+    equals(
+      board.namesTable?.[0]?.member as object,
+      board.items?.[0] as object,
+    )
+  );
+
+  const action_add_second = action(() => {
+    board.addItem.send({ title: "Second item", agentName: "Fable" });
+  });
+  const assert_second_is_named_two = assert(() =>
+    board.itemCount === 2 &&
+    board.index?.[0]?.name === "1" &&
+    board.index?.[1]?.name === "2" &&
+    Object.keys((board.names ?? {}) as NamesMap).join(",") === "1,2" &&
+    board[NAME] === "Items (2)"
+  );
+  const assert_cards_carry_names = assert(() =>
+    findElement(board[UI], "cf-empty-state") === undefined &&
+    hasText(board[UI], "First item") &&
+    hasText(board[UI], "Second item") &&
+    findElement(board[UI], "cf-badge") !== undefined &&
+    hasText(findElement(board[UI], "cf-badge"), "1")
+  );
+
+  // One more than the largest name present, whatever the list holds: a name
+  // the map carries for a member the list does not is still a name in use.
+  const stray = new Writable({ title: "Stray" });
+  const action_hold_a_stray_name = action(() => {
+    names.key("7").set(stray);
+  });
+  const action_add_third = action(() => {
+    board.addItem.send({ title: "Third item", agentName: "Sol" });
+  });
+  const assert_third_follows_the_largest = assert(() =>
+    board.itemCount === 3 &&
+    board.index?.[2]?.name === "8" &&
+    (board.namesTable ?? []).length === 4 &&
+    Object.keys((board.names ?? {}) as NamesMap).join(",") === "1,2,7,8"
+  );
+
+  // A name survives what happens to its item: a rename leaves it, and so
+  // does leaving the list — the entry stays, and the next create skips past
+  // it rather than reusing the freed name.
+  const action_rename_first = action(() => {
+    items.key(0).key("title").set("First item, renamed");
+  });
+  const assert_renamed_item_keeps_its_name = assert(() =>
+    board.index?.[0]?.title === "First item, renamed" &&
+    board.index?.[0]?.name === "1"
+  );
+  const action_remove_second = action(() => {
+    items.removeByValue(items.key(1));
+  });
+  const assert_removed_item_keeps_its_entry = assert(() =>
+    board.itemCount === 2 &&
+    (board.index ?? []).length === 2 &&
+    board.index?.[1]?.name === "8" &&
+    (board.namesTable ?? []).length === 4 &&
+    Object.keys((board.names ?? {}) as NamesMap).join(",") === "1,2,7,8"
+  );
+  const action_add_fourth = action(() => {
+    board.addItem.send({ title: "Fourth item", agentName: "Sol" });
+  });
+  const assert_fourth_does_not_reuse_two = assert(() =>
+    board.itemCount === 3 &&
+    board.index?.[2]?.name === "9" &&
+    Object.keys((board.names ?? {}) as NamesMap).join(",") === "1,2,7,8,9"
+  );
+
+  // The bound: a read of the namespace carries links and nothing behind
+  // them. The stray entry is a cell with a title, so a title in the
+  // serialization would mean a member was expanded. The index carries its
+  // copied scalars and, likewise, nothing behind its references.
+  const assert_namespace_read_expands_no_member = assert(() => {
+    const serialized = JSON.stringify(board.names);
+    return Object.keys((board.names ?? {}) as NamesMap).length === 5 &&
+      !serialized.includes('"title"') &&
+      !serialized.includes('"body"') &&
+      !serialized.includes("vnode");
+  });
+  const assert_index_read_expands_no_member = assert(() => {
+    const serialized = JSON.stringify(board.index);
+    return (board.index ?? []).length === 3 &&
+      serialized.includes('"title"') &&
+      !serialized.includes('"body"') &&
+      !serialized.includes('"shortName"') &&
+      !serialized.includes("vnode");
+  });
+
+  // An item wired to the board's table reads its own name out of it by
+  // identity, and renders it as a badge; an item wired to nothing has no
+  // name, renders no badge, and does not fail.
+  const wired = Item({
+    title: "Wired item",
+    body: "",
+    boardNames: board.namesTable,
+  });
+  const action_name_the_wired_item = action(() => {
+    names.key("12").set(wired);
+  });
+  const assert_wired_item_reads_its_name = assert(() =>
+    wired.shortName === "12" &&
+    wired[NAME] === "Wired item"
+  );
+  const assert_wired_item_renders_its_badge = assert(() =>
+    findElement(wired[UI], "cf-badge") !== undefined &&
+    hasText(findElement(wired[UI], "cf-badge"), "12") &&
+    hasText(wired[UI], "Wired item") &&
+    hasText(wired[UI], "No body yet.")
+  );
+  const solo = Item({ title: "Solo item", body: "A body of its own." });
+  const assert_solo_item_has_no_name = assert(() =>
+    solo.shortName === undefined &&
+    solo[NAME] === "Solo item"
+  );
+  const assert_solo_item_renders_no_badge = assert(() =>
+    findElement(solo[UI], "cf-badge") === undefined &&
+    findElement(solo[UI], "cf-markdown") !== undefined &&
+    hasText(solo[UI], "Solo item")
+  );
+  const untitled = Item({ title: "   " });
+  const assert_untitled_item_has_a_display_name = assert(() =>
+    untitled[NAME] === "(untitled item)"
+  );
+
+  // The backfill, on a board that held items before it numbered anything.
+  // The items are pushed straight into the list, past `addItem`, which is
+  // how a board from before the namespace holds its members.
+  const legacyItems = new Writable<ItemDemand[] | Default<[]>>([]);
+  const legacyNames = new Writable<NamesMap>({});
+  const legacy = Board({ items: legacyItems, names: legacyNames });
+  const assigned = new Writable<string[]>([]);
+
+  const action_file_two_unnamed = action(() => {
+    legacyItems.push(Item({ title: "Older one", createdAt: 1 }));
+    legacyItems.push(Item({ title: "Older two", createdAt: 2 }));
+  });
+  // An unnamed member's row reads its name as the default, so the board
+  // reads whole before anything names it.
+  const assert_unnamed_rows_read_the_default = assert(() =>
+    legacy.itemCount === 2 &&
+    (legacy.index ?? []).length === 2 &&
+    legacy.index?.[0]?.name === "" &&
+    legacy.index?.[1]?.name === "" &&
+    legacy.index?.[1]?.title === "Older two" &&
+    (legacy.namesTable ?? []).length === 0
+  );
+  // The library call itself, so its return is observable: the names it
+  // wrote, in filing order.
+  const action_backfill_directly = action(() => {
+    assigned.set(backfillNames(legacyItems, legacyNames));
+  });
+  const assert_backfill_named_in_filing_order = assert(() =>
+    assigned.get().join(",") === "1,2" &&
+    legacy.index?.[0]?.name === "1" &&
+    legacy.index?.[1]?.name === "2" &&
+    equals(
+      ((legacy.names ?? {}) as NamesMap)["1"] as object,
+      legacy.items?.[0] as object,
+    ) &&
+    equals(
+      ((legacy.names ?? {}) as NamesMap)["2"] as object,
+      legacy.items?.[1] as object,
+    )
+  );
+  // Idempotent: the second run returns no names — it writes exactly the
+  // names it returns — and the map holds what the first run left.
+  const action_backfill_again = action(() => {
+    assigned.set(backfillNames(legacyItems, legacyNames));
+  });
+  const assert_second_backfill_writes_nothing = assert(() =>
+    assigned.get().length === 0 &&
+    Object.keys((legacy.names ?? {}) as NamesMap).join(",") === "1,2" &&
+    equals(
+      ((legacy.names ?? {}) as NamesMap)["1"] as object,
+      legacy.items?.[0] as object,
+    ) &&
+    equals(
+      ((legacy.names ?? {}) as NamesMap)["2"] as object,
+      legacy.items?.[1] as object,
+    )
+  );
+  // The verb, over a list holding a member the create named and one filed
+  // past it: the backfill names the second and skips the first.
+  const action_create_a_named_item = action(() => {
+    legacy.addItem.send({ title: "Named by create", agentName: "Sol" });
+  });
+  const action_file_a_late_unnamed = action(() => {
+    legacyItems.push(Item({ title: "Older three", createdAt: 3 }));
+  });
+  const action_backfill_verb = action(() => {
+    legacy.backfillNames.send({ agentName: "Sol" });
+  });
+  const assert_backfill_skips_the_named = assert(() =>
+    legacy.itemCount === 4 &&
+    legacy.index?.[2]?.name === "3" &&
+    legacy.index?.[2]?.title === "Named by create" &&
+    legacy.index?.[3]?.name === "4" &&
+    legacy.index?.[3]?.title === "Older three" &&
+    Object.keys((legacy.names ?? {}) as NamesMap).join(",") === "1,2,3,4"
+  );
+
+  // A board given no namespace at all — the shape of one deployed before it
+  // numbered anything — reads as having no names, and its first create
+  // materializes the map with the first name.
+  const bare = Board({});
+  const assert_bare_board_has_no_items = assert(() =>
+    bare.itemCount === 0 &&
+    (bare.namesTable ?? []).length === 0
+  );
+  const assert_bare_board_names_read_empty = assert(() => {
+    const map = bare.names;
+    return map === undefined || Object.keys(map).length === 0;
+  });
+  const action_bare_board_creates = action(() => {
+    bare.addItem.send({ title: "First on a bare board", agentName: "Sol" });
+  });
+  const assert_bare_board_wrote_the_map = assert(() =>
+    bare.itemCount === 1 &&
+    Object.keys((bare.names ?? {}) as NamesMap).join(",") === "1"
+  );
+  const assert_bare_board_table_has_the_row = assert(() =>
+    (bare.namesTable ?? []).length === 1 &&
+    bare.namesTable?.[0]?.name === "1"
+  );
+  const assert_bare_board_materialized_its_map = assert(() =>
+    bare.index?.[0]?.name === "1" &&
+    equals(
+      ((bare.names ?? {}) as NamesMap)["1"] as object,
+      bare.items?.[0] as object,
+    )
+  );
+
+  const assert_declaration = assert(() =>
+    board.naming?.policy?.unique === "history" &&
+    board.naming?.policy?.permanent === true &&
+    board.naming?.policy?.reuse === false &&
+    board.naming?.policy?.allocator === "sequence" &&
+    board.naming?.compact === true &&
+    board.naming?.name === undefined
+  );
+
+  // Rejections: each throws, and the assertion after each proves the write
+  // did not land — no item, no name.
+  const action_add_unsigned = action(() => {
+    board.addItem.send({ title: "Unsigned", agentName: "   " });
+  });
+  const action_add_blank_title = action(() => {
+    board.addItem.send({ title: "   ", agentName: "Sol" });
+  });
+  const action_backfill_unsigned = action(() => {
+    legacy.backfillNames.send({ agentName: " " });
+  });
+  const assert_rejections_wrote_nothing = assert(() =>
+    board.itemCount === 3 &&
+    Object.keys((board.names ?? {}) as NamesMap).join(",") ===
+      "1,2,7,8,9,12" &&
+    legacy.itemCount === 4 &&
+    Object.keys((legacy.names ?? {}) as NamesMap).join(",") === "1,2,3,4"
+  );
+
+  return {
+    [UI]: board[UI],
+    expectRuntimeErrors: 3,
+    [TESTS]: [
+      { assertion: assert_initial },
+      { render: board[UI] },
+      { assertion: assert_empty_board_renders_empty_state },
+      { action: action_add_first },
+      { assertion: assert_first_is_named_one },
+      { action: action_add_second },
+      { assertion: assert_second_is_named_two },
+      { render: board[UI] },
+      { assertion: assert_cards_carry_names },
+      { action: action_hold_a_stray_name },
+      { action: action_add_third },
+      { assertion: assert_third_follows_the_largest },
+      { action: action_rename_first },
+      { assertion: assert_renamed_item_keeps_its_name },
+      { action: action_remove_second },
+      { assertion: assert_removed_item_keeps_its_entry },
+      { action: action_add_fourth },
+      { assertion: assert_fourth_does_not_reuse_two },
+      { assertion: assert_namespace_read_expands_no_member },
+      { assertion: assert_index_read_expands_no_member },
+      { render: board[UI] },
+      { action: action_name_the_wired_item },
+      { assertion: assert_wired_item_reads_its_name },
+      { render: wired[UI] },
+      { assertion: assert_wired_item_renders_its_badge },
+      { assertion: assert_solo_item_has_no_name },
+      { render: solo[UI] },
+      { assertion: assert_solo_item_renders_no_badge },
+      { assertion: assert_untitled_item_has_a_display_name },
+      { action: action_file_two_unnamed },
+      { assertion: assert_unnamed_rows_read_the_default },
+      { action: action_backfill_directly },
+      { assertion: assert_backfill_named_in_filing_order },
+      { action: action_backfill_again },
+      { assertion: assert_second_backfill_writes_nothing },
+      { action: action_create_a_named_item },
+      { action: action_file_a_late_unnamed },
+      { action: action_backfill_verb },
+      { assertion: assert_backfill_skips_the_named },
+      { assertion: assert_bare_board_has_no_items },
+      { assertion: assert_bare_board_names_read_empty },
+      { action: action_bare_board_creates },
+      { assertion: assert_bare_board_wrote_the_map },
+      { assertion: assert_bare_board_table_has_the_row },
+      { assertion: assert_bare_board_materialized_its_map },
+      { assertion: assert_declaration },
+      { action: action_add_unsigned },
+      { action: action_add_blank_title },
+      { action: action_backfill_unsigned },
+      { assertion: assert_rejections_wrote_nothing },
+    ],
+  };
+});

--- a/packages/patterns/collection-naming/board.test.tsx
+++ b/packages/patterns/collection-naming/board.test.tsx
@@ -8,6 +8,7 @@
  * errors are required, and the count is exact: a guard quietly reverting to
  * a silent return fails the suite.
  */
+
 import {
   action,
   assert,
@@ -20,7 +21,7 @@ import {
   Writable,
 } from "commonfabric";
 import { findElement, hasText } from "../test/vnode-helpers.ts";
-import Board, { type ItemDemand } from "./board.tsx";
+import Board, { indexRowsOf, type ItemDemand } from "./board.tsx";
 import Item from "./item.tsx";
 import { backfillNames, type NamesMap } from "./naming.ts";
 
@@ -172,6 +173,14 @@ export default pattern(() => {
     hasText(wired[UI], "Wired item") &&
     hasText(wired[UI], "No body yet.")
   );
+  // The index skips a member with nothing behind it yet — one appended a
+  // moment ago, still mid-sync, which reads as `undefined` — and rows the
+  // rest.
+  const midSyncNeighbor = new Writable({ title: "Settled", createdAt: 4 });
+  const assert_index_skips_a_mid_sync_member = assert(() =>
+    indexRowsOf([undefined, midSyncNeighbor], []).length === 1
+  );
+
   const solo = Item({ title: "Solo item", body: "A body of its own." });
   const assert_solo_item_has_no_name = assert(() =>
     solo.shortName === undefined &&
@@ -376,6 +385,7 @@ export default pattern(() => {
       { assertion: assert_wired_item_reads_its_name },
       { render: wired[UI] },
       { assertion: assert_wired_item_renders_its_badge },
+      { assertion: assert_index_skips_a_mid_sync_member },
       { assertion: assert_solo_item_has_no_name },
       { render: solo[UI] },
       { assertion: assert_solo_item_renders_no_badge },

--- a/packages/patterns/collection-naming/board.test.tsx
+++ b/packages/patterns/collection-naming/board.test.tsx
@@ -264,6 +264,30 @@ export default pattern(() => {
     Object.keys((legacy.names ?? {}) as NamesMap).join(",") === "1,2,3,4"
   );
 
+  // One member at two positions, backfilled over an empty namespace: named
+  // once. Membership is asked of identity, never of position, so the second
+  // position finds the name the first one took in this same run.
+  const twinItems = new Writable<ItemDemand[] | Default<[]>>([]);
+  const twinNames = new Writable<NamesMap>({});
+  const twinBoard = Board({ items: twinItems, names: twinNames });
+  const action_list_one_item_twice = action(() => {
+    const twin = Item({ title: "Twin", createdAt: 1 });
+    twinItems.push(twin);
+    twinItems.push(twin);
+  });
+  const action_backfill_the_twins = action(() => {
+    assigned.set(backfillNames(twinItems, twinNames));
+  });
+  const assert_twin_is_named_once = assert(() =>
+    twinBoard.itemCount === 2 &&
+    equals(twinItems.key(0), twinItems.key(1)) &&
+    assigned.get().join(",") === "1" &&
+    Object.keys((twinBoard.names ?? {}) as NamesMap).join(",") === "1" &&
+    (twinBoard.namesTable ?? []).length === 1 &&
+    twinBoard.index?.[0]?.name === "1" &&
+    twinBoard.index?.[1]?.name === "1"
+  );
+
   // A board given no namespace at all — the shape of one deployed before it
   // numbered anything — reads as having no names, and its first create
   // materializes the map with the first name.
@@ -366,6 +390,9 @@ export default pattern(() => {
       { action: action_file_a_late_unnamed },
       { action: action_backfill_verb },
       { assertion: assert_backfill_skips_the_named },
+      { action: action_list_one_item_twice },
+      { action: action_backfill_the_twins },
+      { assertion: assert_twin_is_named_once },
       { assertion: assert_bare_board_has_no_items },
       { assertion: assert_bare_board_names_read_empty },
       { action: action_bare_board_creates },

--- a/packages/patterns/collection-naming/board.tsx
+++ b/packages/patterns/collection-naming/board.tsx
@@ -1,0 +1,318 @@
+/**
+ * The exemplar collection: a board of items that owns a member namespace.
+ * `addItem` allocates the next name and appends the item in one write, so the
+ * created item is reachable at `names[<n>]` the moment it exists;
+ * `backfillNames` names, in filing order, whatever the board held before it
+ * numbered anything. The board publishes its index with each member's name,
+ * the names table its items read their names from, and the declaration a
+ * consumer learns the naming policy from.
+ */
+
+import {
+  action,
+  type ComparableCell,
+  Default,
+  lift,
+  NAME,
+  pattern,
+  type ReadonlyCell,
+  Stream,
+  UI,
+  type VNode,
+  Writable,
+} from "commonfabric";
+
+import Item from "./item.tsx";
+import {
+  assignName,
+  backfillNames,
+  nameOf,
+  type NamesMap,
+  namesTable,
+  type NamesTableRow,
+  type NamingDeclaration,
+  SEQUENCE_NAMING,
+} from "./naming.ts";
+
+/**
+ * What the board reads of a stored item — its demand, not the item's whole
+ * contract. Two scalars cover the index and the cards; `title` carries a
+ * default so a missing path does not make the whole array unreadable, and
+ * `createdAt` is published unconditionally by the item pattern.
+ */
+export interface ItemDemand {
+  title: string | Default<"">;
+  createdAt: number;
+}
+
+export interface BoardInput {
+  /** The board's durable item list, in filing order. `addItem` appends here;
+   * a whole-array write forfeits the mergeability the append keeps. */
+  items?: Writable<ItemDemand[] | Default<[]>>;
+
+  /** The board's member namespace: each name to the item it names, held as an
+   * unread reference. `addItem` writes one key per create and `backfillNames`
+   * one key per member it names; nothing rewrites the map whole. Reads as
+   * empty on a board from before it numbered anything, in the default form
+   * `NamesMap` explains. */
+  // deno-lint-ignore ban-types
+  names?: Writable<Default<NamesMap, {}>>;
+}
+
+export interface AddItemEvent {
+  /** The item's title, trimmed before it is stored. Must be non-empty. */
+  title: string;
+
+  /** The item's initial body, stored verbatim. */
+  body?: string;
+
+  /** The agent making this mutation. Fabric records the human principal
+   * behind the key; this names which agent acted under it. Required, and
+   * checked rather than stored: a create that could be unsigned is a
+   * tolerance the verb could never withdraw. */
+  agentName: string;
+}
+
+/**
+ * One row of the board's index: the item as a reference, the scalars a survey
+ * reads, and the board's name for it.
+ *
+ * The scalars are COPIES, and the copies are what make the index one
+ * self-contained document: a survey reads every row's strings, and a row that
+ * pointed at its item for them would make every reader expand every item.
+ * The reference is what a caller follows for the item itself.
+ */
+export interface ItemIndexRow {
+  /** The item, written as a reference and never read through here. */
+  member: unknown;
+
+  title: string | Default<"">;
+  createdAt: number | Default<0>;
+
+  /** The board's name for the item. Defaulted so a board holding members
+   * from before it numbered anything still reads whole: a member the board
+   * has not named reads as the empty string. */
+  name: string | Default<"">;
+}
+
+export interface AddItemResult {
+  /** The item this call created, as its index row: the reference, the
+   * scalars as stored, and the name the create allocated. */
+  item: ItemIndexRow;
+}
+
+export interface BackfillNamesEvent {
+  /** The agent running the backfill, checked as `addItem` checks it. */
+  agentName: string;
+}
+
+export interface BackfillNamesResult {
+  /** The names this run wrote, in filing order; empty when every member was
+   * already named, which is what a second run returns. */
+  assigned: string[];
+}
+
+/**
+ * A board of items that names its members. Survey the board with one bounded
+ * read of `index`, whose rows carry each item's name; follow a row's `member`
+ * for the item itself. File with `addItem`, which allocates the next name in
+ * the same write as the append and returns the row, name included. A board
+ * that held items before it numbered anything runs `backfillNames` once.
+ */
+export interface BoardOutput {
+  [NAME]: string;
+  [UI]: VNode;
+
+  /** The board's items, in filing order, through the shape the board demands
+   * of them. */
+  items: ItemDemand[];
+
+  /** The survey surface: one row per item, scalars copied, name included. */
+  index: ItemIndexRow[] | Default<[]>;
+
+  /** The namespace itself: each name to the item it names. A slug pointing
+   * here is what makes a member addressable as `<board>/<name>`. Published
+   * under the default its input carries. */
+  // deno-lint-ignore ban-types
+  names: Default<NamesMap, {}>;
+
+  /** The names table, one row per named member, which every item the board
+   * creates reads its own name from. Published so an item composed outside
+   * `addItem` can be wired to the same table. */
+  namesTable: NamesTableRow[] | Default<[]>;
+
+  /** What the board declares about its names, for a consumer deciding
+   * whether a name may be held rather than an identity. */
+  naming: NamingDeclaration;
+
+  /** How many items the board holds. */
+  itemCount: number;
+
+  /** File an item: allocate its name and append it, atomically. */
+  addItem: Stream<AddItemEvent, AddItemResult>;
+
+  /** Name every unnamed member in filing order. Idempotent. */
+  backfillNames: Stream<BackfillNamesEvent, BackfillNamesResult>;
+}
+
+/**
+ * Rejects a mutation loudly. To a headless caller a silent early return is
+ * indistinguishable from success; a throw surfaces as a failed handler
+ * transaction and a nonzero CLI exit. The message carries the verb as a
+ * stable prefix.
+ */
+const reject = (verb: string, reason: string): never => {
+  throw new Error(`${verb} rejected: ${reason}`);
+};
+
+/**
+ * The index rows over `members`, each addressed by the member it describes
+ * and carrying the name `table` gives it. A member with no name gets a row
+ * with no `name` field, which the published row schema's default fills.
+ *
+ * Declared structurally so that a member with nothing behind it yet — one
+ * appended a moment ago, still mid-sync — reads as `undefined` here and gets
+ * no row rather than a junk one; the row appears on the next run.
+ */
+export function indexRowsOf(
+  members: readonly (
+    | { get(): { title?: string; createdAt?: number } | undefined }
+    | undefined
+  )[],
+  table: readonly NamesTableRow[],
+): ItemIndexRow[] {
+  const rows: unknown[] = [];
+  for (const member of members) {
+    const value = member?.get();
+    if (!member || !value) continue;
+    const name = nameOf(member, table);
+    // `name` is left out rather than written empty for an unnamed member, so
+    // the row schema's default is what a reader sees; the cast says that the
+    // schema, not this object, supplies it.
+    const row = {
+      member,
+      title: value.title ?? "",
+      createdAt: value.createdAt ?? 0,
+      ...(name === undefined ? {} : { name }),
+    } as ItemIndexRow;
+    rows.push(Writable.for<ItemIndexRow>(member).set(row));
+  }
+  return rows as ItemIndexRow[];
+}
+
+/**
+ * The board's index, derived once for the whole board. The parameter is an
+ * array of CELLS for the reason the names table's is: the cell is the
+ * identity each row is addressed by, and a cell always writes as a link, so
+ * an unchanged board recomputes to the same rows and writes nothing. Reading
+ * two scalars per member is the entire cost of surveying the board.
+ */
+const indexRows = lift(
+  (
+    { members, table }: {
+      members:
+        | ReadonlyCell<{
+          title: string | Default<"">;
+          createdAt: number | Default<0>;
+        }>[]
+        | Default<[]>;
+      table: { member: ComparableCell<unknown>; name: string }[] | Default<[]>;
+    },
+  ): ItemIndexRow[] =>
+    // A plain array, read once per member: an element read through the
+    // reactive array costs a link resolution per access.
+    indexRowsOf(Array.from(members), table),
+);
+
+export default pattern<BoardInput, BoardOutput>(({ items, names }) => {
+  // `.length` alone is what keeps this cheap: the shrunk schema declares
+  // `items: unknown`, so counting the board expands no item.
+  const itemCount = items.get().length;
+  // Derived once for the whole board; every item reads its own row out of it.
+  const table = namesTable({ names });
+  const index = indexRows({ members: items, table });
+  const hasNoItems = itemCount === 0;
+
+  const addItem = action<AddItemEvent, AddItemResult>(
+    ({ title, body, agentName }) => {
+      const trimmed = (title ?? "").trim();
+      if (!(agentName ?? "").trim()) {
+        reject("addItem", "agentName must be non-blank");
+      }
+      if (!trimmed) reject("addItem", "title must be non-empty");
+      const createdAt = Date.now();
+      const piece = Item({
+        title: trimmed,
+        body: body ?? "",
+        createdAt,
+        // The board's names table, so the item can read its own name out of
+        // the row the board already built for it.
+        boardNames: table,
+      });
+      // The name and the append are one transaction: no reader observes the
+      // item without its name, and a concurrent create serializes on the
+      // map's keys rather than taking the same one.
+      const name = assignName(names, piece);
+      // Mergeable append: concurrent creates all land.
+      items.push(piece);
+      return { item: { member: piece, title: trimmed, createdAt, name } };
+    },
+  );
+
+  const backfill = action<BackfillNamesEvent, BackfillNamesResult>(
+    ({ agentName }) => {
+      if (!(agentName ?? "").trim()) {
+        reject("backfillNames", "agentName must be non-blank");
+      }
+      return { assigned: backfillNames(items, names) };
+    },
+  );
+
+  return {
+    [NAME]: `Items (${itemCount})`,
+    [UI]: (
+      <cf-screen>
+        <cf-vstack slot="header" gap="2" padding="4">
+          <cf-heading level={3}>Items</cf-heading>
+          <cf-text variant="caption" tone="muted">
+            {itemCount} items · each named by the board's sequence
+          </cf-text>
+        </cf-vstack>
+
+        <cf-vstack gap="2" padding="4">
+          {index.map((row) => (
+            <cf-card>
+              <cf-hstack gap="3" align="center">
+                {row.name
+                  ? (
+                    <cf-badge size="sm" color="primary" data-member-name="">
+                      {row.name}
+                    </cf-badge>
+                  )
+                  : null}
+                <cf-text block style="flex: 1; min-width: 0; font-weight: 600;">
+                  {row.title || "(untitled item)"}
+                </cf-text>
+                <cf-cell-link $cell={row.member} label="Open" static />
+              </cf-hstack>
+            </cf-card>
+          ))}
+
+          {hasNoItems
+            ? <cf-empty-state message="No items yet. File one with addItem." />
+            : null}
+        </cf-vstack>
+      </cf-screen>
+    ),
+    items,
+    index,
+    names,
+    namesTable: table,
+    // The sequence policy, claiming no name for the board: what it is bound
+    // as is decided where the binding is made.
+    naming: SEQUENCE_NAMING,
+    itemCount,
+    addItem,
+    backfillNames: backfill,
+  };
+});

--- a/packages/patterns/collection-naming/board.tsx
+++ b/packages/patterns/collection-naming/board.tsx
@@ -45,20 +45,26 @@ export interface ItemDemand {
   createdAt: number;
 }
 
+/** What the board holds: its item list and its member namespace. */
 export interface BoardInput {
-  /** The board's durable item list, in filing order. `addItem` appends here;
-   * a whole-array write forfeits the mergeability the append keeps. */
+  /**
+   * The board's durable item list, in filing order. `addItem` appends here; a
+   * whole-array write forfeits the mergeability the append keeps.
+   */
   items?: Writable<ItemDemand[] | Default<[]>>;
 
-  /** The board's member namespace: each name to the item it names, held as an
+  /**
+   * The board's member namespace: each name to the item it names, held as an
    * unread reference. `addItem` writes one key per create and `backfillNames`
    * one key per member it names; nothing rewrites the map whole. Reads as
    * empty on a board from before it numbered anything, in the default form
-   * `NamesMap` explains. */
+   * `NamesMap` explains.
+   */
   // deno-lint-ignore ban-types
   names?: Writable<Default<NamesMap, {}>>;
 }
 
+/** What `addItem` takes: the item's content and the agent filing it. */
 export interface AddItemEvent {
   /** The item's title, trimmed before it is stored. Must be non-empty. */
   title: string;
@@ -66,10 +72,12 @@ export interface AddItemEvent {
   /** The item's initial body, stored verbatim. */
   body?: string;
 
-  /** The agent making this mutation. Fabric records the human principal
+  /**
+   * The agent making this mutation. Fabric records the human principal
    * behind the key; this names which agent acted under it. Required, and
    * checked rather than stored: a create that could be unsigned is a
-   * tolerance the verb could never withdraw. */
+   * tolerance the verb could never withdraw.
+   */
   agentName: string;
 }
 
@@ -86,29 +94,41 @@ export interface ItemIndexRow {
   /** The item, written as a reference and never read through here. */
   member: unknown;
 
+  /** The item's title, as stored. */
   title: string | Default<"">;
+
+  /** When the item was filed (epoch milliseconds). */
   createdAt: number | Default<0>;
 
-  /** The board's name for the item. Defaulted so a board holding members
-   * from before it numbered anything still reads whole: a member the board
-   * has not named reads as the empty string. */
+  /**
+   * The board's name for the item. Defaulted so a board holding members from
+   * before it numbered anything still reads whole: a member the board has
+   * not named reads as the empty string.
+   */
   name: string | Default<"">;
 }
 
+/** What `addItem` returns. */
 export interface AddItemResult {
-  /** The item this call created, as its index row: the reference, the
-   * scalars as stored, and the name the create allocated. */
+  /**
+   * The item this call created, as its index row: the reference, the scalars
+   * as stored, and the name the create allocated.
+   */
   item: ItemIndexRow;
 }
 
+/** What `backfillNames` takes: the agent running it. */
 export interface BackfillNamesEvent {
   /** The agent running the backfill, checked as `addItem` checks it. */
   agentName: string;
 }
 
+/** What `backfillNames` returns. */
 export interface BackfillNamesResult {
-  /** The names this run wrote, in filing order; empty when every member was
-   * already named, which is what a second run returns. */
+  /**
+   * The names this run wrote, in filing order; empty when every member was
+   * already named, which is what a second run returns.
+   */
   assigned: string[];
 }
 
@@ -123,26 +143,34 @@ export interface BoardOutput {
   [NAME]: string;
   [UI]: VNode;
 
-  /** The board's items, in filing order, through the shape the board demands
-   * of them. */
+  /**
+   * The board's items, in filing order, through the shape the board demands
+   * of them.
+   */
   items: ItemDemand[];
 
   /** The survey surface: one row per item, scalars copied, name included. */
   index: ItemIndexRow[] | Default<[]>;
 
-  /** The namespace itself: each name to the item it names. A slug pointing
+  /**
+   * The namespace itself: each name to the item it names. A slug pointing
    * here is what makes a member addressable as `<board>/<name>`. Published
-   * under the default its input carries. */
+   * under the default its input carries.
+   */
   // deno-lint-ignore ban-types
   names: Default<NamesMap, {}>;
 
-  /** The names table, one row per named member, which every item the board
+  /**
+   * The names table, one row per named member, which every item the board
    * creates reads its own name from. Published so an item composed outside
-   * `addItem` can be wired to the same table. */
+   * `addItem` can be wired to the same table.
+   */
   namesTable: NamesTableRow[] | Default<[]>;
 
-  /** What the board declares about its names, for a consumer deciding
-   * whether a name may be held rather than an identity. */
+  /**
+   * What the board declares about its names, for a consumer deciding whether
+   * a name may be held rather than an identity.
+   */
   naming: NamingDeclaration;
 
   /** How many items the board holds. */

--- a/packages/patterns/collection-naming/item.tsx
+++ b/packages/patterns/collection-naming/item.tsx
@@ -1,0 +1,105 @@
+/**
+ * The exemplar member of a named collection: a title, a body, a filing time,
+ * and the name its board calls it by. The name is not the item's to hold — it
+ * lives in the board's namespace — so the item reads its own row out of the
+ * board's names table by identity, and an item no board has named shows no
+ * name and needs nothing else.
+ */
+
+import {
+  Default,
+  NAME,
+  pattern,
+  type ReadonlyCell,
+  SELF,
+  UI,
+  type VNode,
+  Writable,
+} from "commonfabric";
+
+import { type NamesTableRow, ownName } from "./naming.ts";
+
+export interface ItemInput {
+  title?: Writable<string | Default<"">>;
+
+  /** The item's body, verbatim Markdown. */
+  body?: Writable<string | Default<"">>;
+
+  /** When the item was filed (epoch milliseconds), stamped at create. */
+  createdAt?: number | Default<0>;
+
+  /** The board's names table, one row per named member. The item reads its
+   * own row out of it and nothing else; absent, the item shows no name.
+   *
+   * Readable, not writable: the table is the board's derivation, and an item
+   * has no business writing into it. */
+  boardNames?: ReadonlyCell<NamesTableRow[] | Default<[]>>;
+}
+
+/**
+ * An item of the exemplar board. The display name stays the title; the
+ * board's name for the item rides beside it as `shortName`, and renders as a
+ * badge in the header when there is one.
+ */
+export interface ItemOutput {
+  [NAME]: string;
+  [UI]: VNode;
+  title: string | Default<"">;
+  body: string | Default<"">;
+
+  /** When the item was filed (epoch milliseconds). */
+  createdAt: number;
+
+  /** The name the board calls this item by, read out of the board's names
+   * table; `undefined` for an item no board has named, or one wired to no
+   * board. */
+  shortName: string | undefined;
+}
+
+export default pattern<ItemInput, ItemOutput>(
+  ({ title, body, createdAt, boardNames, [SELF]: self }) => {
+    // The board has already derived the table; this is a lookup by identity,
+    // and it is written as one.
+    const shortName = ownName({ table: boardNames, self });
+    const itemName = title.get().trim() || "(untitled item)";
+    const hasBody = body.get().trim().length > 0;
+
+    return {
+      [NAME]: itemName,
+      [UI]: (
+        <cf-screen>
+          <cf-vstack slot="header" gap="1" padding="4">
+            <cf-hstack gap="2" align="center">
+              {shortName
+                ? (
+                  <cf-badge size="sm" color="primary" data-member-name="">
+                    {shortName}
+                  </cf-badge>
+                )
+                : null}
+              <cf-text block style="font-size: 1.25rem; font-weight: 600;">
+                {itemName}
+              </cf-text>
+            </cf-hstack>
+          </cf-vstack>
+
+          <cf-vstack gap="3" padding="4">
+            <cf-card>
+              {hasBody
+                ? <cf-markdown content={body} />
+                : (
+                  <cf-text tone="muted" block>
+                    No body yet.
+                  </cf-text>
+                )}
+            </cf-card>
+          </cf-vstack>
+        </cf-screen>
+      ),
+      title,
+      body,
+      createdAt,
+      shortName,
+    };
+  },
+);

--- a/packages/patterns/collection-naming/item.tsx
+++ b/packages/patterns/collection-naming/item.tsx
@@ -19,7 +19,9 @@ import {
 
 import { type NamesTableRow, ownName } from "./naming.ts";
 
+/** What an item holds, and the one thing its board hands it. */
 export interface ItemInput {
+  /** The item's title, trimmed by the board's create before it is stored. */
   title?: Writable<string | Default<"">>;
 
   /** The item's body, verbatim Markdown. */
@@ -28,11 +30,13 @@ export interface ItemInput {
   /** When the item was filed (epoch milliseconds), stamped at create. */
   createdAt?: number | Default<0>;
 
-  /** The board's names table, one row per named member. The item reads its
+  /**
+   * The board's names table, one row per named member. The item reads its
    * own row out of it and nothing else; absent, the item shows no name.
    *
    * Readable, not writable: the table is the board's derivation, and an item
-   * has no business writing into it. */
+   * has no business writing into it.
+   */
   boardNames?: ReadonlyCell<NamesTableRow[] | Default<[]>>;
 }
 
@@ -44,15 +48,21 @@ export interface ItemInput {
 export interface ItemOutput {
   [NAME]: string;
   [UI]: VNode;
+
+  /** The item's title, as stored. */
   title: string | Default<"">;
+
+  /** The item's body, verbatim Markdown. */
   body: string | Default<"">;
 
   /** When the item was filed (epoch milliseconds). */
   createdAt: number;
 
-  /** The name the board calls this item by, read out of the board's names
+  /**
+   * The name the board calls this item by, read out of the board's names
    * table; `undefined` for an item no board has named, or one wired to no
-   * board. */
+   * board.
+   */
   shortName: string | undefined;
 }
 

--- a/packages/patterns/collection-naming/naming.test.tsx
+++ b/packages/patterns/collection-naming/naming.test.tsx
@@ -10,7 +10,9 @@ import {
   assignName,
   nameOf,
   type NamesMap,
+  namesTable,
   nextNameAmong,
+  ownName,
   SEQUENCE_NAMING,
 } from "./naming.ts";
 
@@ -106,6 +108,29 @@ export default pattern(() => {
     Object.keys(names.get()).toSorted().join(",") === "007,1,1e3,2,3,4,abc"
   );
 
+  // The table publishes exactly the names the grammar admits. A map holding
+  // `1`, `abc`, and `007` yields one row, and the member stored under the
+  // foreign keys has no name by the table's own lookup.
+  const tableMap = new Writable<NamesMap>({});
+  const named = new Writable({ title: "named" });
+  const underForeign = new Writable({ title: "under a foreign key" });
+  const table = namesTable({ names: tableMap });
+  const nameOfNamed = ownName({ table, self: named });
+  const nameUnderForeign = ownName({ table, self: underForeign });
+  const action_fill_the_table_map = action(() => {
+    tableMap.key("1").set(named);
+    tableMap.key("abc").set(underForeign);
+    tableMap.key("007").set(underForeign);
+  });
+  const assert_table_publishes_only_names = assert(() =>
+    Object.keys(tableMap.get()).toSorted().join(",") === "007,1,abc" &&
+    (table ?? []).length === 1 &&
+    table?.[0]?.name === "1" &&
+    equals(table?.[0]?.member as object, named) &&
+    nameOfNamed === "1" &&
+    nameUnderForeign === undefined
+  );
+
   // The reverse lookup matches by identity, and a member the table does not
   // hold has no name.
   const assert_reverse_lookup = assert(() => {
@@ -141,6 +166,8 @@ export default pattern(() => {
       { action: action_foreign_keys_land },
       { action: action_allocate_after_them },
       { assertion: assert_allocation_ignores_foreign_keys },
+      { action: action_fill_the_table_map },
+      { assertion: assert_table_publishes_only_names },
       { assertion: assert_reverse_lookup },
       { assertion: assert_declaration },
     ],

--- a/packages/patterns/collection-naming/naming.test.tsx
+++ b/packages/patterns/collection-naming/naming.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * Pattern tests for the naming library's own rules, driven on plain cells
+ * with no board: the sequence over the names in use, the allocator re-run
+ * against a stale read — the shape a lost commit race leaves behind — the
+ * reverse lookup, and the declaration.
+ */
+import { action, assert, equals, pattern, TESTS, Writable } from "commonfabric";
+import {
+  assignName,
+  nameOf,
+  type NamesMap,
+  nextNameAmong,
+  SEQUENCE_NAMING,
+} from "./naming.ts";
+
+export default pattern(() => {
+  // The sequence rule, over keys a map could hold: one more than the largest
+  // sequence name present, compared as numbers, and unmoved by a key the
+  // sequence never issued.
+  const assert_sequence_rule = assert(() =>
+    nextNameAmong([]) === "1" &&
+    nextNameAmong(["1", "2"]) === "3" &&
+    nextNameAmong(["2", "10"]) === "11" &&
+    nextNameAmong(["3", "5"]) === "6" &&
+    nextNameAmong(["alpha", "07", "4"]) === "5"
+  );
+
+  // The allocator under a lost race, step by step. A verb reads the keys and
+  // computes its name; a concurrent create commits the same name first; the
+  // runtime rejects the first verb's commit and re-runs it against the map
+  // as the winner left it. The steps below are those three moments on one
+  // map cell: the loser's re-run is `action_loser_reruns`, and what it
+  // proves is that a re-run over the winner's write takes the next distinct
+  // name rather than the one it first computed.
+  const names = new Writable<NamesMap>({});
+  const first = new Writable({ title: "first" });
+  const winner = new Writable({ title: "winner" });
+  const loser = new Writable({ title: "loser" });
+  const issued = new Writable<string[]>([]);
+
+  const action_assign_first = action(() => {
+    issued.push(assignName(names, first));
+  });
+  const action_winner_lands = action(() => {
+    names.key("2").set(winner);
+  });
+  const action_loser_reruns = action(() => {
+    issued.push(assignName(names, loser));
+  });
+
+  const assert_first_is_one = assert(() =>
+    issued.get().join(",") === "1" &&
+    equals(names.get()["1"] as object, first)
+  );
+  const assert_stale_name_was_the_winners = assert(() =>
+    nextNameAmong(["1"]) === "2" &&
+    equals(names.get()["2"] as object, winner)
+  );
+  const assert_rerun_takes_the_next_distinct_name = assert(() =>
+    issued.get().join(",") === "1,3" &&
+    Object.keys(names.get()).join(",") === "1,2,3" &&
+    equals(names.get()["3"] as object, loser)
+  );
+
+  // The reverse lookup matches by identity, and a member the table does not
+  // hold has no name.
+  const assert_reverse_lookup = assert(() => {
+    const table = [
+      { member: first, name: "1" },
+      { member: winner, name: "2" },
+    ];
+    return nameOf(winner, table) === "2" &&
+      nameOf(first, table) === "1" &&
+      nameOf(loser, table) === undefined;
+  });
+
+  const assert_declaration = assert(() =>
+    SEQUENCE_NAMING.policy.unique === "history" &&
+    SEQUENCE_NAMING.policy.permanent === true &&
+    SEQUENCE_NAMING.policy.reuse === false &&
+    SEQUENCE_NAMING.policy.allocator === "sequence" &&
+    SEQUENCE_NAMING.compact === true &&
+    SEQUENCE_NAMING.name === undefined
+  );
+
+  return {
+    [TESTS]: [
+      { assertion: assert_sequence_rule },
+      { action: action_assign_first },
+      { assertion: assert_first_is_one },
+      { action: action_winner_lands },
+      { assertion: assert_stale_name_was_the_winners },
+      { action: action_loser_reruns },
+      { assertion: assert_rerun_takes_the_next_distinct_name },
+      { assertion: assert_reverse_lookup },
+      { assertion: assert_declaration },
+    ],
+  };
+});

--- a/packages/patterns/collection-naming/naming.test.tsx
+++ b/packages/patterns/collection-naming/naming.test.tsx
@@ -4,6 +4,7 @@
  * against a stale read — the shape a lost commit race leaves behind — the
  * reverse lookup, and the declaration.
  */
+
 import { action, assert, equals, pattern, TESTS, Writable } from "commonfabric";
 import {
   assignName,

--- a/packages/patterns/collection-naming/naming.test.tsx
+++ b/packages/patterns/collection-naming/naming.test.tsx
@@ -15,14 +15,37 @@ import {
 
 export default pattern(() => {
   // The sequence rule, over keys a map could hold: one more than the largest
-  // sequence name present, compared as numbers, and unmoved by a key the
-  // sequence never issued.
+  // member name present, compared by length and then lexicographically, and
+  // unmoved by a key the sequence never issued.
   const assert_sequence_rule = assert(() =>
     nextNameAmong([]) === "1" &&
+    nextNameAmong(["0"]) === "1" &&
     nextNameAmong(["1", "2"]) === "3" &&
     nextNameAmong(["2", "10"]) === "11" &&
     nextNameAmong(["3", "5"]) === "6" &&
+    nextNameAmong(["99"]) === "100" &&
+    nextNameAmong(["1299", "1300"]) === "1301" &&
     nextNameAmong(["alpha", "07", "4"]) === "5"
+  );
+
+  // Names never pass through a JavaScript number. Past `2^53` a number
+  // cannot tell adjacent integers apart, and a wide enough one prints in
+  // exponent form; a name is a decimal string at every width.
+  const assert_names_stay_decimal_past_the_safe_integers = assert(() =>
+    nextNameAmong(["9007199254740992"]) === "9007199254740993" &&
+    nextNameAmong(["999999999999999999999999"]) ===
+      "1000000000000000000000000" &&
+    nextNameAmong(["9007199254740992", "9007199254740993"]) ===
+      "9007199254740994"
+  );
+
+  // A key that is not a canonical decimal — a foreign client can write any
+  // key into the map — is not a name: it neither counts as the largest nor
+  // blocks allocation.
+  const assert_foreign_keys_are_not_names = assert(() =>
+    nextNameAmong(["007", "1e3", "abc"]) === "1" &&
+    nextNameAmong(["007", "1e3", "abc", "4"]) === "5" &&
+    nextNameAmong(["+5", "-1", " 6", "6 ", "0x10"]) === "1"
   );
 
   // The allocator under a lost race, step by step. A verb reads the keys and
@@ -62,6 +85,26 @@ export default pattern(() => {
     equals(names.get()["3"] as object, loser)
   );
 
+  // Foreign keys on a real map, as a client over the memory protocol could
+  // leave them: they neither block allocation nor count as the largest, so
+  // the next name follows the sequence's own largest.
+  const foreign = new Writable({ title: "foreign" });
+  const afterForeign = new Writable({ title: "after foreign" });
+  const action_foreign_keys_land = action(() => {
+    names.key("007").set(foreign);
+    names.key("1e3").set(foreign);
+    names.key("abc").set(foreign);
+  });
+  const action_allocate_after_them = action(() => {
+    issued.push(assignName(names, afterForeign));
+  });
+  const assert_allocation_ignores_foreign_keys = assert(() =>
+    issued.get().join(",") === "1,3,4" &&
+    equals(names.get()["4"] as object, afterForeign) &&
+    equals(names.get()["007"] as object, foreign) &&
+    Object.keys(names.get()).toSorted().join(",") === "007,1,1e3,2,3,4,abc"
+  );
+
   // The reverse lookup matches by identity, and a member the table does not
   // hold has no name.
   const assert_reverse_lookup = assert(() => {
@@ -92,6 +135,11 @@ export default pattern(() => {
       { assertion: assert_stale_name_was_the_winners },
       { action: action_loser_reruns },
       { assertion: assert_rerun_takes_the_next_distinct_name },
+      { assertion: assert_names_stay_decimal_past_the_safe_integers },
+      { assertion: assert_foreign_keys_are_not_names },
+      { action: action_foreign_keys_land },
+      { action: action_allocate_after_them },
+      { assertion: assert_allocation_ignores_foreign_keys },
       { assertion: assert_reverse_lookup },
       { assertion: assert_declaration },
     ],

--- a/packages/patterns/collection-naming/naming.ts
+++ b/packages/patterns/collection-naming/naming.ts
@@ -139,25 +139,53 @@ export interface NamesTableRow {
 }
 
 /**
- * Whether `key` is a name the sequence issues: a decimal integer written
- * without leading zeros. Any other key in the map was put there by another
- * allocator and does not move the sequence.
+ * Whether `key` is a member name: a canonical decimal string — `0`, or a
+ * non-zero digit followed by digits, with no leading zeros, no sign, and no
+ * exponent. The map can be written by any client over the memory protocol,
+ * so a key is not guaranteed to be a name this sequence issued; a key
+ * outside the grammar is not a name, and it neither counts as the largest
+ * nor blocks allocation.
  */
-const isSequenceName = (key: string): boolean => /^[1-9][0-9]*$/.test(key);
+const isMemberName = (key: string): boolean => /^(0|[1-9][0-9]*)$/.test(key);
 
 /**
- * The next name the sequence issues over the names in use: `1` when none of
- * them is a sequence name, otherwise one more than the largest. The sequence
+ * Whether canonical decimal `a` is larger than canonical decimal `b`. Names
+ * are compared as strings — by length, then lexicographically — and never
+ * as JavaScript numbers, which lose distinctness past `2^53` and would
+ * reuse a name there.
+ */
+const isLargerName = (a: string, b: string): boolean =>
+  a.length !== b.length ? a.length > b.length : a > b;
+
+/**
+ * Helper for `nextNameAmong()` and `backfillNames()`, which returns the
+ * canonical decimal one larger than `name`, as a string. The trailing run
+ * of nines turns to zeros and the digit before it goes up by one; a name
+ * that is all nines gains a leading `1`.
+ */
+const incrementName = (name: string): string => {
+  const [, head, nines] = name.match(/^([0-9]*?)(9*)$/)!;
+  const zeros = "0".repeat(nines.length);
+  if (head === "") return `1${zeros}`;
+  return `${head.slice(0, -1)}${Number(head.at(-1)) + 1}${zeros}`;
+};
+
+/**
+ * The next name the sequence issues over the keys in use: `1` when none of
+ * them is a member name, otherwise one more than the largest. The sequence
  * is dense from `1` and a name is never reused, so this is the whole of the
  * allocation rule; what makes it safe under concurrency is where it is
- * called, which `assignName()` states.
+ * called, which `assignName()` states. Keys that are not member names —
+ * `isMemberName()` says which — are ignored.
  */
 export function nextNameAmong(names: Iterable<string>): string {
   const largest = Array.from(names)
-    .filter(isSequenceName)
-    .map(Number)
-    .reduce((max, name) => Math.max(max, name), 0);
-  return String(largest + 1);
+    .filter(isMemberName)
+    .reduce<string | undefined>(
+      (max, name) => max === undefined || isLargerName(name, max) ? name : max,
+      undefined,
+    );
+  return largest === undefined ? "1" : incrementName(largest);
 }
 
 /**
@@ -219,8 +247,9 @@ export const namesTable = lift(
  * Names every member of `members` that has no name, in filing order, and
  * returns the names it wrote — exactly the keys it added to `names`, in the
  * order it added them. A member already named is skipped, whatever position
- * it holds. Idempotent: a run over a fully named list writes nothing and
- * returns `[]`.
+ * it holds, and a member listed at two positions is named once: membership
+ * is asked of IDENTITY, never of position. Idempotent: a run over a fully
+ * named list writes nothing and returns `[]`.
  *
  * Called from a verb body for the reason `assignName()` is: the keyset read
  * and the key writes are one transaction, so a create that lands while a
@@ -231,19 +260,24 @@ export function backfillNames(
   names: NamesMapCell,
 ): string[] {
   const map = names.get() ?? {};
-  const held = Object.values(map) as (object | undefined)[];
-  const first = Number(nextNameAmong(Object.keys(map)));
-  // The cell at each position rather than the value read out of it: a cell
-  // is an identity `equals` can match against the map's links, and it is
-  // what the map stores.
-  const unnamed = members.get()
-    .map((_, index) => members.key(index))
-    .filter((member) => !held.some((link) => equals(member, link)));
-  return unnamed.map((member, offset) => {
-    const name = String(first + offset);
-    names.key(name).set(member);
-    return name;
-  });
+  // The members with a name: those the map already holds, and — as the walk
+  // goes — those this run names, so a member met again is not named again.
+  const named = Object.values(map) as (object | undefined)[];
+  const count = members.get().length;
+  const written: string[] = [];
+  let next = nextNameAmong(Object.keys(map));
+  for (let index = 0; index < count; index++) {
+    // The cell at the position rather than the value read out of it: a cell
+    // is an identity `equals` can match against the map's links, and it is
+    // what the map stores.
+    const member = members.key(index);
+    if (named.some((other) => equals(member, other))) continue;
+    names.key(next).set(member);
+    written.push(next);
+    named.push(member);
+    next = incrementName(next);
+  }
+  return written;
 }
 
 /**

--- a/packages/patterns/collection-naming/naming.ts
+++ b/packages/patterns/collection-naming/naming.ts
@@ -226,9 +226,11 @@ export function nameOf(
 
 /**
  * The names table derived from the namespace: one row per named member,
- * addressed by the member. A collection derives this once and hands it to
- * each member it creates, so a member's reverse lookup is a scan of the rows
- * rather than a read of the map.
+ * addressed by the member. The table publishes exactly the names the grammar
+ * admits — `isMemberName()` — so a key a foreign writer put in the map is no
+ * member's name here, as it is no name to the allocator. A collection derives
+ * this once and hands it to each member it creates, so a member's reverse
+ * lookup is a scan of the rows rather than a read of the map.
  */
 export const namesTable = lift(
   (
@@ -242,13 +244,15 @@ export const namesTable = lift(
       names: Default<Record<string, ReadonlyCell<unknown>>, {}>;
     },
   ): NamesTableRow[] => {
-    // An entry with nothing behind it yet (mid-sync) reads as `undefined`,
-    // has no identity to address a row by, and gets no row rather than a
-    // junk one. Nothing else is filtered: the values are cells, so a value a
-    // foreign writer stored under a key — `null`, a scalar — arrives as a
-    // cell too, and telling it apart would mean reading through the member.
+    // An entry under a key the grammar does not admit is not a name and gets
+    // no row. An entry with nothing behind it yet (mid-sync) reads as
+    // `undefined`, has no identity to address a row by, and gets no row
+    // rather than a junk one. Nothing else is filtered: the values are cells,
+    // so a value a foreign writer stored under a name — `null`, a scalar —
+    // arrives as a cell too, and telling it apart would mean reading through
+    // the member.
     const rows: unknown[] = Object.entries(names)
-      .filter(([, member]) => member !== undefined)
+      .filter(([name, member]) => isMemberName(name) && member !== undefined)
       .map(([name, member]) =>
         Writable.for<NamesTableRow>(member).set({ member, name })
       );

--- a/packages/patterns/collection-naming/naming.ts
+++ b/packages/patterns/collection-naming/naming.ts
@@ -35,8 +35,10 @@ import {
  * has one.
  */
 export interface NamingPolicy {
-  /** Whether a name is unique across the collection's whole history, or
-   * only among its current members. */
+  /**
+   * Whether a name is unique across the collection's whole history, or only
+   * among its current members.
+   */
   unique: "history" | "current";
 
   /** Whether a name, once assigned, is never retired or reassigned. */
@@ -45,23 +47,29 @@ export interface NamingPolicy {
   /** Whether a retired name may be given to another member. */
   reuse: boolean;
 
-  /** What a name is made of: a monotonic sequence, a random code, a string a
-   * person chose, or a derivation from the member's own content. */
+  /**
+   * What a name is made of: a monotonic sequence, a random code, a string a
+   * person chose, or a derivation from the member's own content.
+   */
   allocator: "sequence" | "random" | "human" | "derived";
 }
 
 /** What a collection declares about the names it gives its members. */
 export interface NamingDeclaration {
-  /** The collection's own name, which a binding uses to reach it. Absent
-   * when the collection makes no claim about what it is bound as. */
+  /**
+   * The collection's own name, which a binding uses to reach it. Absent when
+   * the collection makes no claim about what it is bound as.
+   */
   name?: string;
 
   /** The policy the names are held to. */
   policy: NamingPolicy;
 
-  /** Whether the collection offers the compact spelling that joins its name
-   * to a member's with a hyphen. Only a collection whose member names cannot
-   * contain a hyphen may say so. */
+  /**
+   * Whether the collection offers the compact spelling that joins its name to
+   * a member's with a hyphen. Only a collection whose member names cannot
+   * contain a hyphen may say so.
+   */
   compact: boolean;
 }
 
@@ -130,8 +138,10 @@ export interface NamesMapCell {
  * writes nothing.
  */
 export interface NamesTableRow {
-  /** The member. `unknown` because it is written as a reference and only
-   * ever compared; anything wider would read the member back whole. */
+  /**
+   * The member. `unknown` because it is written as a reference and only ever
+   * compared; anything wider would read the member back whole.
+   */
   member: unknown;
 
   /** The member's name. */
@@ -232,10 +242,13 @@ export const namesTable = lift(
       names: Default<Record<string, ReadonlyCell<unknown>>, {}>;
     },
   ): NamesTableRow[] => {
-    // An entry with nothing behind it yet (mid-sync) has no identity to
-    // address a row by; it gets no row rather than a junk one.
+    // An entry with nothing behind it yet (mid-sync) reads as `undefined`,
+    // has no identity to address a row by, and gets no row rather than a
+    // junk one. Nothing else is filtered: the values are cells, so a value a
+    // foreign writer stored under a key — `null`, a scalar — arrives as a
+    // cell too, and telling it apart would mean reading through the member.
     const rows: unknown[] = Object.entries(names)
-      .filter(([, member]) => member !== undefined && member !== null)
+      .filter(([, member]) => member !== undefined)
       .map(([name, member]) =>
         Writable.for<NamesTableRow>(member).set({ member, name })
       );

--- a/packages/patterns/collection-naming/naming.ts
+++ b/packages/patterns/collection-naming/naming.ts
@@ -1,0 +1,264 @@
+/**
+ * A member namespace for a collection pattern: the allocator its create verb
+ * calls, the table that gives each member its name by identity, the backfill
+ * that names what the collection held before it numbered anything, and the
+ * declaration the collection publishes so a consumer learns the policy rather
+ * than assuming one. Nothing here knows what kind of piece a member is: a
+ * member is a cell, compared by identity and never read through.
+ *
+ * The namespace is one map cell on the collection, `{ "42": <member> }`,
+ * written one key at a time. A name is a decimal string, dense from `1`, one
+ * more than the largest name present, and never reused: a member keeps its
+ * name whatever happens to it, and an entry outlives the member's place in the
+ * collection's list. Concurrent allocations serialize through the runtime's
+ * commit retry. A keyset read of the map conflicts with a key write to it
+ * (`docs/specs/memory-v2/08-conflict-granularity.md`), so of two verbs that
+ * read the same keys, the second to commit is rejected, re-runs against the
+ * first one's write, and takes the next name.
+ *
+ * `docs/specs/collection-naming.md` is the design this implements.
+ */
+
+import {
+  type ComparableCell,
+  Default,
+  equals,
+  lift,
+  type ReadonlyCell,
+  Writable,
+} from "commonfabric";
+
+/**
+ * What a collection holds its member names to over time. Published beside
+ * the names rather than implied by them, so a consumer that needs a promise
+ * — a printed citation, a reference leaving the fabric — can read whether it
+ * has one.
+ */
+export interface NamingPolicy {
+  /** Whether a name is unique across the collection's whole history, or
+   * only among its current members. */
+  unique: "history" | "current";
+
+  /** Whether a name, once assigned, is never retired or reassigned. */
+  permanent: boolean;
+
+  /** Whether a retired name may be given to another member. */
+  reuse: boolean;
+
+  /** What a name is made of: a monotonic sequence, a random code, a string a
+   * person chose, or a derivation from the member's own content. */
+  allocator: "sequence" | "random" | "human" | "derived";
+}
+
+/** What a collection declares about the names it gives its members. */
+export interface NamingDeclaration {
+  /** The collection's own name, which a binding uses to reach it. Absent
+   * when the collection makes no claim about what it is bound as. */
+  name?: string;
+
+  /** The policy the names are held to. */
+  policy: NamingPolicy;
+
+  /** Whether the collection offers the compact spelling that joins its name
+   * to a member's with a hyphen. Only a collection whose member names cannot
+   * contain a hyphen may say so. */
+  compact: boolean;
+}
+
+/**
+ * The declaration for the sequence this module allocates: unique across
+ * history, permanent, never reused, and eligible for the compact spelling
+ * because a decimal name holds no hyphen. It names no collection; a
+ * collection that declares one spreads this and adds its own `name`.
+ */
+export const SEQUENCE_NAMING: NamingDeclaration = {
+  policy: {
+    unique: "history",
+    permanent: true,
+    reuse: false,
+    allocator: "sequence",
+  },
+  compact: true,
+};
+
+/**
+ * The namespace: each name to the member it names, held as an unread
+ * reference. Declared `unknown` so that a member is stored as a link and a
+ * reader of the map — the allocator surveying its keys, a resolver following
+ * one entry — expands no member it did not follow.
+ *
+ * A collection declares it at its input as `Writable<Default<NamesMap, {}>>`,
+ * written inline at the property rather than through an alias, and both
+ * halves of that are load-bearing. `NamesMap | Default<{}>` adds a bare
+ * empty-object arm to the union, and wherever that union reaches a handler
+ * unmerged it becomes an `anyOf` whose empty arm reads every value whole —
+ * the merge lets a branch that looked win over the opaque one — so the
+ * allocator would expand every member to survey the keys; the two-argument
+ * form keeps the union to the record type. And the schema generator reads
+ * the default off the property's own type node, so a default declared
+ * through an alias is dropped from the schema.
+ */
+export type NamesMap = Record<string, unknown>;
+
+/**
+ * The namespace as a verb holds it: read whole for its keys, written one key
+ * at a time. Nothing here rewrites the map whole, which is what lets two
+ * verbs naming different members merge instead of clobbering each other.
+ *
+ * Declared structurally, with `get()` returning `undefined` for a map nothing
+ * has written yet. A verb reads its binding through a schema that carries no
+ * default, so on a collection that has never named a member the map is
+ * absent inside the verb however the input declares it; the structural
+ * declaration is what makes the readers here handle that where the compiler
+ * can see it. A `Writable<NamesMap>` satisfies it.
+ */
+export interface NamesMapCell {
+  /** The map, or `undefined` before the first name is written. */
+  get(): NamesMap | undefined;
+
+  /** The entry for `name`, to be set to the member it names. */
+  key(name: string): { set(member: unknown): void };
+}
+
+/**
+ * One row of a collection's names table: a member, and the name the
+ * collection calls it by.
+ *
+ * ONE ROW PER NAMED MEMBER, addressed by the member it describes. A row keeps
+ * its identity wherever it sits in the table, so a member looking itself up
+ * by identity finds one row, and a table recomputed over an unchanged map
+ * writes nothing.
+ */
+export interface NamesTableRow {
+  /** The member. `unknown` because it is written as a reference and only
+   * ever compared; anything wider would read the member back whole. */
+  member: unknown;
+
+  /** The member's name. */
+  name: string;
+}
+
+/**
+ * Whether `key` is a name the sequence issues: a decimal integer written
+ * without leading zeros. Any other key in the map was put there by another
+ * allocator and does not move the sequence.
+ */
+const isSequenceName = (key: string): boolean => /^[1-9][0-9]*$/.test(key);
+
+/**
+ * The next name the sequence issues over the names in use: `1` when none of
+ * them is a sequence name, otherwise one more than the largest. The sequence
+ * is dense from `1` and a name is never reused, so this is the whole of the
+ * allocation rule; what makes it safe under concurrency is where it is
+ * called, which `assignName()` states.
+ */
+export function nextNameAmong(names: Iterable<string>): string {
+  const largest = Array.from(names)
+    .filter(isSequenceName)
+    .map(Number)
+    .reduce((max, name) => Math.max(max, name), 0);
+  return String(largest + 1);
+}
+
+/**
+ * Allocates the next name over `names` and records `member` under it, and
+ * returns the name. Called from the body of an `action()` or `handler()`, so
+ * the read of the map's keys and the write of the new key land in one
+ * transaction. That is what makes the name safe: a concurrent create that
+ * read the same keys conflicts on commit, re-runs against this write, and
+ * takes the name after it.
+ */
+export function assignName(names: NamesMapCell, member: unknown): string {
+  const name = nextNameAmong(Object.keys(names.get() ?? {}));
+  names.key(name).set(member);
+  return name;
+}
+
+/**
+ * The name `table` gives `member`, or `undefined` when it has none. Matching
+ * is by identity: `equals` compares what each side refers to, whether it
+ * arrived as a cell or as the raw link a read left behind.
+ */
+export function nameOf(
+  member: object,
+  table: readonly NamesTableRow[],
+): string | undefined {
+  return table.find((row) => equals(member, row.member as object))?.name;
+}
+
+/**
+ * The names table derived from the namespace: one row per named member,
+ * addressed by the member. A collection derives this once and hands it to
+ * each member it creates, so a member's reverse lookup is a scan of the rows
+ * rather than a read of the map.
+ */
+export const namesTable = lift(
+  (
+    { names }: {
+      // A record of CELLS, which is what lets one declaration serve both of
+      // the table's needs: the cell is the member's identity, which addresses
+      // its row, and a cell always writes as a link, so the rows below are
+      // the same documents on every run over the same map. Defaulted in the
+      // form `NamesMap` explains.
+      // deno-lint-ignore ban-types
+      names: Default<Record<string, ReadonlyCell<unknown>>, {}>;
+    },
+  ): NamesTableRow[] => {
+    // An entry with nothing behind it yet (mid-sync) has no identity to
+    // address a row by; it gets no row rather than a junk one.
+    const rows: unknown[] = Object.entries(names)
+      .filter(([, member]) => member !== undefined && member !== null)
+      .map(([name, member]) =>
+        Writable.for<NamesTableRow>(member).set({ member, name })
+      );
+    return rows as NamesTableRow[];
+  },
+);
+
+/**
+ * Names every member of `members` that has no name, in filing order, and
+ * returns the names it wrote — exactly the keys it added to `names`, in the
+ * order it added them. A member already named is skipped, whatever position
+ * it holds. Idempotent: a run over a fully named list writes nothing and
+ * returns `[]`.
+ *
+ * Called from a verb body for the reason `assignName()` is: the keyset read
+ * and the key writes are one transaction, so a create that lands while a
+ * backfill runs serializes with it rather than colliding on a name.
+ */
+export function backfillNames(
+  members: { get(): readonly unknown[]; key(index: number): object },
+  names: NamesMapCell,
+): string[] {
+  const map = names.get() ?? {};
+  const held = Object.values(map) as (object | undefined)[];
+  const first = Number(nextNameAmong(Object.keys(map)));
+  // The cell at each position rather than the value read out of it: a cell
+  // is an identity `equals` can match against the map's links, and it is
+  // what the map stores.
+  const unnamed = members.get()
+    .map((_, index) => members.key(index))
+    .filter((member) => !held.some((link) => equals(member, link)));
+  return unnamed.map((member, offset) => {
+    const name = String(first + offset);
+    names.key(name).set(member);
+    return name;
+  });
+}
+
+/**
+ * A member's own name, looked up in its collection's names table by
+ * identity: `undefined` for a member no table names, or one handed no table.
+ *
+ * Re-runs whenever any row changes, and writes nothing when the row it finds
+ * is unchanged. The parameter declares the rows' members as comparable cells
+ * and nothing more, so surveying the whole table expands no member.
+ */
+export const ownName = lift(
+  (
+    { table, self }: {
+      table: { member: ComparableCell<unknown>; name: string }[] | Default<[]>;
+      self: ComparableCell<unknown>;
+    },
+  ): string | undefined => nameOf(self, table),
+);

--- a/packages/patterns/collection-naming/topics-shape.test.tsx
+++ b/packages/patterns/collection-naming/topics-shape.test.tsx
@@ -1,0 +1,298 @@
+/**
+ * The Topics-shape rehearsal: a test-only board whose members are the real
+ * Topic pattern, unmodified, wired through the naming library the way the
+ * exemplar board is. What it proves is the board side — allocation on
+ * create, the backfill over a list filed before the board numbered anything,
+ * index rows carrying `name`, and the names table giving a topic its name by
+ * identity. The item side is proven on the exemplar item.
+ */
+import {
+  action,
+  assert,
+  type ComparableCell,
+  Default,
+  equals,
+  lift,
+  NAME,
+  pattern,
+  type ReadonlyCell,
+  Stream,
+  TESTS,
+  Writable,
+} from "commonfabric";
+import type { TopicDemand } from "../topics/main.tsx";
+import Topic, {
+  rejectMutation,
+  topicAuthorFromAgent,
+} from "../topics/topic.tsx";
+import {
+  assignName,
+  backfillNames,
+  nameOf,
+  type NamesMap,
+  namesTable,
+  type NamesTableRow,
+  type NamingDeclaration,
+  SEQUENCE_NAMING,
+} from "./naming.ts";
+
+interface ShapeInput {
+  topics?: Writable<TopicDemand[] | Default<[]>>;
+  // deno-lint-ignore ban-types
+  names?: Writable<Default<NamesMap, {}>>;
+}
+
+interface AddShapeEvent {
+  title: string;
+  body?: string;
+  agentName: string;
+}
+
+/** The index row the rehearsal publishes: the topic as a reference, the
+ * scalars a survey reads, and the board's name for it, defaulted. */
+interface ShapeIndexRow {
+  member: unknown;
+  title: string | Default<"">;
+  createdAt: number | Default<0>;
+  name: string | Default<"">;
+}
+
+interface ShapeOutput {
+  [NAME]: string;
+  topics: TopicDemand[];
+  index: ShapeIndexRow[] | Default<[]>;
+  // deno-lint-ignore ban-types
+  names: Default<NamesMap, {}>;
+  namesTable: NamesTableRow[] | Default<[]>;
+  naming: NamingDeclaration;
+  addTopic: Stream<AddShapeEvent, { topic: ShapeIndexRow }>;
+  backfillNames: Stream<{ agentName: string }, { assigned: string[] }>;
+}
+
+/** The rehearsal's index rows, addressed by the topic each describes. */
+const shapeIndex = lift(
+  (
+    { members, table }: {
+      members:
+        | ReadonlyCell<{
+          title: string | Default<"">;
+          createdAt: number | Default<0>;
+        }>[]
+        | Default<[]>;
+      table: { member: ComparableCell<unknown>; name: string }[] | Default<[]>;
+    },
+  ): ShapeIndexRow[] => {
+    const rows: unknown[] = [];
+    for (const member of Array.from(members)) {
+      const value = member?.get();
+      if (!member || !value) continue;
+      const name = nameOf(member, table);
+      const row = {
+        member,
+        title: value.title ?? "",
+        createdAt: value.createdAt ?? 0,
+        ...(name === undefined ? {} : { name }),
+      } as ShapeIndexRow;
+      rows.push(Writable.for<ShapeIndexRow>(member).set(row));
+    }
+    return rows as ShapeIndexRow[];
+  },
+);
+
+/**
+ * A board over real topics that names its members: `addTopic` as the Topics
+ * board writes it, plus the one line that allocates the name in the same
+ * transaction as the append.
+ */
+const ShapeBoard = pattern<ShapeInput, ShapeOutput>(({ topics, names }) => {
+  const topicCount = topics.get().length;
+  const table = namesTable({ names });
+  const index = shapeIndex({ members: topics, table });
+
+  const addTopic = action<AddShapeEvent, { topic: ShapeIndexRow }>(
+    ({ title, body, agentName }) => {
+      const trimmed = (title ?? "").trim();
+      const author = topicAuthorFromAgent(agentName) ??
+        rejectMutation("addTopic", "agentName must be non-blank");
+      if (!trimmed) rejectMutation("addTopic", "title must be non-empty");
+      const createdAt = Date.now();
+      const piece = Topic({
+        title: trimmed,
+        body: body ?? "",
+        createdAt,
+        createdBy: author,
+      });
+      const name = assignName(names, piece);
+      topics.push(piece);
+      return { topic: { member: piece, title: trimmed, createdAt, name } };
+    },
+  );
+
+  const backfill = action<{ agentName: string }, { assigned: string[] }>(
+    ({ agentName }) => {
+      if (!topicAuthorFromAgent(agentName)) {
+        rejectMutation("backfillNames", "agentName must be non-blank");
+      }
+      return { assigned: backfillNames(topics, names) };
+    },
+  );
+
+  return {
+    [NAME]: `Topics (${topicCount})`,
+    topics,
+    index,
+    names,
+    namesTable: table,
+    naming: SEQUENCE_NAMING,
+    addTopic,
+    backfillNames: backfill,
+  };
+});
+
+export default pattern(() => {
+  const topics = new Writable<TopicDemand[] | Default<[]>>([]);
+  const names = new Writable<NamesMap>({});
+  const board = ShapeBoard({ topics, names });
+
+  const assert_initial = assert(() =>
+    (board.topics ?? []).length === 0 &&
+    (board.index ?? []).length === 0 &&
+    (board.namesTable ?? []).length === 0 &&
+    board[NAME] === "Topics (0)"
+  );
+
+  // Allocation on create, through the real Topic's create path.
+  const action_add_first = action(() => {
+    board.addTopic.send({
+      title: "First topic",
+      body: "The living document.",
+      agentName: "Sol",
+    });
+  });
+  const action_add_second = action(() => {
+    board.addTopic.send({ title: "Second topic", agentName: "Fable" });
+  });
+  const assert_allocated_on_create = assert(() =>
+    (board.topics ?? []).length === 2 &&
+    board.topics?.[0]?.title === "First topic" &&
+    board.topics?.[0]?.createdBy?.name === "Sol" &&
+    board.index?.[0]?.name === "1" &&
+    board.index?.[0]?.title === "First topic" &&
+    board.index?.[1]?.name === "2" &&
+    board.index?.[1]?.title === "Second topic" &&
+    equals(
+      ((board.names ?? {}) as NamesMap)["1"] as object,
+      board.topics?.[0] as object,
+    ) &&
+    equals(
+      ((board.names ?? {}) as NamesMap)["2"] as object,
+      board.topics?.[1] as object,
+    )
+  );
+
+  // The names-table row for a given topic, looked up by the identity a
+  // caller holds — here the list position's cell — returns its name.
+  const assert_table_row_for_a_topic = assert(() =>
+    (board.namesTable ?? []).length === 2 &&
+    nameOf(topics.key(0), board.namesTable ?? []) === "1" &&
+    nameOf(topics.key(1), board.namesTable ?? []) === "2"
+  );
+
+  // The bound: topics carry bodies and threads, and neither the namespace
+  // nor the index carries any of it.
+  const assert_reads_expand_no_topic = assert(() => {
+    const namespace = JSON.stringify(board.names);
+    const index = JSON.stringify(board.index);
+    return !namespace.includes('"title"') &&
+      !namespace.includes('"body"') &&
+      index.includes('"title"') &&
+      !index.includes('"body"') &&
+      !index.includes('"comments"') &&
+      !index.includes('"addComment"') &&
+      !index.includes("vnode");
+  });
+
+  // The backfill, on a board whose topics were filed before it numbered
+  // anything: pushed straight into the list, the way an existing board
+  // holds them.
+  const olderTopics = new Writable<TopicDemand[] | Default<[]>>([]);
+  const olderNames = new Writable<NamesMap>({});
+  const older = ShapeBoard({ topics: olderTopics, names: olderNames });
+
+  const action_file_unnamed_topics = action(() => {
+    olderTopics.push(Topic({ title: "Older one", createdAt: 1 }));
+    olderTopics.push(Topic({ title: "Older two", createdAt: 2 }));
+  });
+  const assert_unnamed_rows_read_the_default = assert(() =>
+    (older.index ?? []).length === 2 &&
+    older.index?.[0]?.name === "" &&
+    older.index?.[1]?.name === "" &&
+    (older.namesTable ?? []).length === 0
+  );
+  const action_backfill = action(() => {
+    older.backfillNames.send({ agentName: "Sol" });
+  });
+  const assert_backfilled_in_filing_order = assert(() =>
+    older.index?.[0]?.name === "1" &&
+    older.index?.[0]?.title === "Older one" &&
+    older.index?.[1]?.name === "2" &&
+    older.index?.[1]?.title === "Older two" &&
+    equals(
+      ((older.names ?? {}) as NamesMap)["1"] as object,
+      older.topics?.[0] as object,
+    ) &&
+    equals(
+      ((older.names ?? {}) as NamesMap)["2"] as object,
+      older.topics?.[1] as object,
+    )
+  );
+  const action_backfill_again = action(() => {
+    older.backfillNames.send({ agentName: "Sol" });
+  });
+  const assert_second_backfill_leaves_the_map = assert(() =>
+    Object.keys((older.names ?? {}) as NamesMap).join(",") === "1,2" &&
+    equals(
+      ((older.names ?? {}) as NamesMap)["1"] as object,
+      older.topics?.[0] as object,
+    ) &&
+    equals(
+      ((older.names ?? {}) as NamesMap)["2"] as object,
+      older.topics?.[1] as object,
+    )
+  );
+  // A create after the backfill continues the sequence.
+  const action_add_after_backfill = action(() => {
+    older.addTopic.send({ title: "Newer one", agentName: "Sol" });
+  });
+  const assert_create_continues_the_sequence = assert(() =>
+    (older.topics ?? []).length === 3 &&
+    older.index?.[2]?.name === "3" &&
+    Object.keys((older.names ?? {}) as NamesMap).join(",") === "1,2,3"
+  );
+
+  const assert_declaration = assert(() =>
+    board.naming?.policy?.allocator === "sequence" &&
+    board.naming?.policy?.unique === "history" &&
+    board.naming?.compact === true
+  );
+
+  return {
+    [TESTS]: [
+      { assertion: assert_initial },
+      { action: action_add_first },
+      { action: action_add_second },
+      { assertion: assert_allocated_on_create },
+      { assertion: assert_table_row_for_a_topic },
+      { assertion: assert_reads_expand_no_topic },
+      { action: action_file_unnamed_topics },
+      { assertion: assert_unnamed_rows_read_the_default },
+      { action: action_backfill },
+      { assertion: assert_backfilled_in_filing_order },
+      { action: action_backfill_again },
+      { assertion: assert_second_backfill_leaves_the_map },
+      { action: action_add_after_backfill },
+      { assertion: assert_create_continues_the_sequence },
+      { assertion: assert_declaration },
+    ],
+  };
+});

--- a/packages/patterns/collection-naming/topics-shape.test.tsx
+++ b/packages/patterns/collection-naming/topics-shape.test.tsx
@@ -6,6 +6,7 @@
  * index rows carrying `name`, and the names table giving a topic its name by
  * identity. The item side is proven on the exemplar item.
  */
+
 import {
   action,
   assert,
@@ -25,6 +26,7 @@ import Topic, {
   rejectMutation,
   topicAuthorFromAgent,
 } from "../topics/topic.tsx";
+import { indexRowsOf, type ItemIndexRow } from "./board.tsx";
 import {
   assignName,
   backfillNames,
@@ -48,28 +50,23 @@ interface AddShapeEvent {
   agentName: string;
 }
 
-/** The index row the rehearsal publishes: the topic as a reference, the
- * scalars a survey reads, and the board's name for it, defaulted. */
-interface ShapeIndexRow {
-  member: unknown;
-  title: string | Default<"">;
-  createdAt: number | Default<0>;
-  name: string | Default<"">;
-}
-
 interface ShapeOutput {
   [NAME]: string;
   topics: TopicDemand[];
-  index: ShapeIndexRow[] | Default<[]>;
+  index: ItemIndexRow[] | Default<[]>;
   // deno-lint-ignore ban-types
   names: Default<NamesMap, {}>;
   namesTable: NamesTableRow[] | Default<[]>;
   naming: NamingDeclaration;
-  addTopic: Stream<AddShapeEvent, { topic: ShapeIndexRow }>;
+  addTopic: Stream<AddShapeEvent, { topic: ItemIndexRow }>;
   backfillNames: Stream<{ agentName: string }, { assigned: string[] }>;
 }
 
-/** The rehearsal's index rows, addressed by the topic each describes. */
+/**
+ * The rehearsal's index rows: the exemplar's derivation over the two scalars
+ * a Topic and an item both publish, each row addressed by the topic it
+ * describes.
+ */
 const shapeIndex = lift(
   (
     { members, table }: {
@@ -81,22 +78,7 @@ const shapeIndex = lift(
         | Default<[]>;
       table: { member: ComparableCell<unknown>; name: string }[] | Default<[]>;
     },
-  ): ShapeIndexRow[] => {
-    const rows: unknown[] = [];
-    for (const member of Array.from(members)) {
-      const value = member?.get();
-      if (!member || !value) continue;
-      const name = nameOf(member, table);
-      const row = {
-        member,
-        title: value.title ?? "",
-        createdAt: value.createdAt ?? 0,
-        ...(name === undefined ? {} : { name }),
-      } as ShapeIndexRow;
-      rows.push(Writable.for<ShapeIndexRow>(member).set(row));
-    }
-    return rows as ShapeIndexRow[];
-  },
+  ): ItemIndexRow[] => indexRowsOf(Array.from(members), table),
 );
 
 /**
@@ -109,7 +91,7 @@ const ShapeBoard = pattern<ShapeInput, ShapeOutput>(({ topics, names }) => {
   const table = namesTable({ names });
   const index = shapeIndex({ members: topics, table });
 
-  const addTopic = action<AddShapeEvent, { topic: ShapeIndexRow }>(
+  const addTopic = action<AddShapeEvent, { topic: ItemIndexRow }>(
     ({ title, body, agentName }) => {
       const trimmed = (title ?? "").trim();
       const author = topicAuthorFromAgent(agentName) ??
@@ -246,20 +228,6 @@ export default pattern(() => {
       older.topics?.[1] as object,
     )
   );
-  const action_backfill_again = action(() => {
-    older.backfillNames.send({ agentName: "Sol" });
-  });
-  const assert_second_backfill_leaves_the_map = assert(() =>
-    Object.keys((older.names ?? {}) as NamesMap).join(",") === "1,2" &&
-    equals(
-      ((older.names ?? {}) as NamesMap)["1"] as object,
-      older.topics?.[0] as object,
-    ) &&
-    equals(
-      ((older.names ?? {}) as NamesMap)["2"] as object,
-      older.topics?.[1] as object,
-    )
-  );
   // A create after the backfill continues the sequence.
   const action_add_after_backfill = action(() => {
     older.addTopic.send({ title: "Newer one", agentName: "Sol" });
@@ -268,6 +236,26 @@ export default pattern(() => {
     (older.topics ?? []).length === 3 &&
     older.index?.[2]?.name === "3" &&
     Object.keys((older.names ?? {}) as NamesMap).join(",") === "1,2,3"
+  );
+  // A second backfill, over the list the create has grown, writes nothing:
+  // the map holds what the first run and the create left.
+  const action_backfill_again = action(() => {
+    older.backfillNames.send({ agentName: "Sol" });
+  });
+  const assert_second_backfill_leaves_the_map = assert(() =>
+    Object.keys((older.names ?? {}) as NamesMap).join(",") === "1,2,3" &&
+    equals(
+      ((older.names ?? {}) as NamesMap)["1"] as object,
+      older.topics?.[0] as object,
+    ) &&
+    equals(
+      ((older.names ?? {}) as NamesMap)["2"] as object,
+      older.topics?.[1] as object,
+    ) &&
+    equals(
+      ((older.names ?? {}) as NamesMap)["3"] as object,
+      older.topics?.[2] as object,
+    )
   );
 
   const assert_declaration = assert(() =>
@@ -288,10 +276,22 @@ export default pattern(() => {
       { assertion: assert_unnamed_rows_read_the_default },
       { action: action_backfill },
       { assertion: assert_backfilled_in_filing_order },
-      { action: action_backfill_again },
-      { assertion: assert_second_backfill_leaves_the_map },
       { action: action_add_after_backfill },
       { assertion: assert_create_continues_the_sequence },
+      // Some runs log two `sync-load-failure` lines at teardown, and they are
+      // acceptable. Each Topic's `#profile` wish finds no profile in the test
+      // space and opens its profile-create surface, a sidecar pattern the test
+      // runtime has no server to load (`packages/runner/src/builtins/wish.ts`),
+      // and a topic created late in the run can still be syncing for that when
+      // the harness disposes the runtime after the final assertion; the storage
+      // layer then logs the cut-short sync once per distinct error
+      // (`packages/runner/test/sync-load-failure-surfacing.test.ts`). It turns
+      // on timing, not on wiring: a topic composed with `mentionable` and
+      // `boardCrossrefs` logs the same lines as a bare one. The run ends on
+      // the write-free second backfill so that less is in flight at teardown,
+      // and no assertion here depends on the wish.
+      { action: action_backfill_again },
+      { assertion: assert_second_backfill_leaves_the_map },
       { assertion: assert_declaration },
     ],
   };

--- a/packages/patterns/index.md
+++ b/packages/patterns/index.md
@@ -74,12 +74,13 @@ profile roster — every participant's cross-space profile badge), `self.tsx`,
 
 App and integration directories: `activity-log/`, `agent/`, `airtable/`,
 `auth/`, `base/`, `battleship/`, `budget-tracker/`, `calendar/`, `card-piles/`,
-`contacts/`, `cozy-poll/`, `examples/`, `experimental/` (explicitly unhardened
-explorations), `google/` (the `core/` tree; `google/WIP/` is legacy),
-`habit-tracker/`, `lobby/`, `lunch-poll/`, `profile-group-chat/`,
-`project-list/`, `router/`, `scoped-group-chat/`, `scoped-user-directory/`,
-`scrabble/`, `shared-profile-demo/`, `shared-profile-roster/`, `suggestable/`,
-`weekly-calendar/`.
+`collection-naming/` (the member-naming library and the exemplar board that uses
+it; its README is the reference), `contacts/`, `cozy-poll/`, `examples/`,
+`experimental/` (explicitly unhardened explorations), `google/` (the `core/`
+tree; `google/WIP/` is legacy), `habit-tracker/`, `lobby/`, `lunch-poll/`,
+`profile-group-chat/`, `project-list/`, `router/`, `scoped-group-chat/`,
+`scoped-user-directory/`, `scrabble/`, `shared-profile-demo/`,
+`shared-profile-roster/`, `suggestable/`, `weekly-calendar/`.
 
 Connector-owned patterns live with their connector families: the
 [agent debug view](../connectors/agents/debug-view/README.md) and

--- a/packages/patterns/index.md
+++ b/packages/patterns/index.md
@@ -74,13 +74,14 @@ profile roster — every participant's cross-space profile badge), `self.tsx`,
 
 App and integration directories: `activity-log/`, `agent/`, `airtable/`,
 `auth/`, `base/`, `battleship/`, `budget-tracker/`, `calendar/`, `card-piles/`,
-`collection-naming/` (the member-naming library and the exemplar board that uses
-it; its README is the reference), `contacts/`, `cozy-poll/`, `examples/`,
-`experimental/` (explicitly unhardened explorations), `google/` (the `core/`
-tree; `google/WIP/` is legacy), `habit-tracker/`, `lobby/`, `lunch-poll/`,
-`profile-group-chat/`, `project-list/`, `router/`, `scoped-group-chat/`,
-`scoped-user-directory/`, `scrabble/`, `shared-profile-demo/`,
-`shared-profile-roster/`, `suggestable/`, `weekly-calendar/`.
+`collection-naming/` (the member-naming library and the board that exercises it;
+the library is the reference, the board is a demo), `contacts/`, `cozy-poll/`,
+`examples/`, `experimental/` (explicitly unhardened explorations), `google/`
+(the `core/` tree; `google/WIP/` is legacy), `habit-tracker/`, `lobby/`,
+`lunch-poll/`, `profile-group-chat/`, `project-list/`, `router/`,
+`scoped-group-chat/`, `scoped-user-directory/`, `scrabble/`,
+`shared-profile-demo/`, `shared-profile-roster/`, `suggestable/`,
+`weekly-calendar/`.
 
 Connector-owned patterns live with their connector families: the
 [agent debug view](../connectors/agents/debug-view/README.md) and


### PR DESCRIPTION
## Why

Cross-linking work items needs a name short enough to type and say — `top/42`
rather than a 44-character identity. `docs/specs/collection-naming.md` (#6124)
settled the contract a collection implements to offer one; nothing implemented
it. This is the first customer, built beside Topics rather than in it: Topics
carries the team's real data and is a production migration to change, so the
whole build runs on a parallel exemplar and is proven against the Topics shape
by a test-only board that composes the real `Topic` pattern unmodified. Topics
itself adopts the library once, at the end of the arc, by a diff that board has
already carried.

This is stage S1 of `docs/plans/collection-naming-topics.md`, which lands here
with its twelve decisions ruled 2026-09-03. Later stages resolve `top/42` at the
CLI (S2), open it in the shell (S3), and complete `#42` in the editor (S4).

## What Changed

`packages/patterns/collection-naming/`, new:

- `naming.ts` — the library a collection pattern calls. `assignName` allocates
  the next member name inside an action as one more than the largest canonical
  decimal key in the namespace map, in string arithmetic (a key past 2^53 or a
  foreign non-decimal key can neither be reused nor corrupt the sequence);
  `namesTable` derives one row per member addressed by the member, the
  `crossrefTable` shape; `backfillNames` names unnamed members in filing order,
  once each by identity, and returns exactly the keys it wrote; `ownName` is a
  member's reverse lookup; `NamingDeclaration` and `SEQUENCE_NAMING` are the
  machine-readable policy. Nothing in it names topics.
- `board.tsx`, `item.tsx` — the exemplar collection and member. `addItem`
  allocates and appends in one atomic write and returns the index row with its
  `name`; `backfillNames` is the one-time verb; the board publishes `names`,
  `namesTable`, `index` rows carrying `name` with a default, and `naming`. The
  item renders its badge from the board's table when wired, and nothing when
  not.
- `topics-shape.test.tsx` — the rehearsal: a test-only board over the
  unmodified `Topic` pattern wired through the library; allocation on create,
  backfill over a pre-existing list, index rows with names, and the reverse
  lookup all pass. `packages/patterns/topics/` has no diff.
- `naming.test.tsx`, `board.test.tsx`, `README.md`, and the two contract
  baselines the `pattern-compat` gate requires for new patterns.

`docs/plans/collection-naming-topics.md` (new) and its index entry;
`packages/patterns/index.md` gains one line.

Two things the plan left open and this settles for the exemplar: the namespace
map is typed `Default<NamesMap, {}>` rather than `T | Default<{}>`, because the
union form reaches a handler binding as `anyOf` and expands every map value;
and the harness cannot overlap two verbs, so the concurrency criterion is pinned
by driving the allocator against a stale read on a real map cell, recorded in
the plan under criterion 4.

## Test plan

- `deno fmt --check`, `deno lint`: clean.
- `deno task cfcheck`: 447 pattern files, exit 0, the three new sources in its
  collector.
- `cf test packages/patterns/collection-naming/`: 46 passed (board 28, naming
  9, topics-shape 9). `cf test packages/patterns/topics/topics.test.tsx`: 49
  passed, unchanged.
- `check-no-waitfor`, `check-control-characters`, `check-conflict-markers`,
  `check-docs`: clean. `pattern-compat --only collection-naming`: both
  patterns updatable from every recorded contract.
- Demo on an isolated local toolshed: two `cf piece call addItem` returned
  `name` `1` and `2`; `cf cell get /of:<board> names` prints `{"1": {}, "2": {}}`;
  `index --step --select name,title` lists both; `naming` reads the sequence
  policy.
- Review: codex through stage-loop, two rounds — round 1 found the number
  conversion and the duplicated-member backfill, round 2 passed with no
  findings; cf-review self-review before push found nothing blocking and
  eight improvements, all folded in (README command spellings, comment
  format, one missing test, teardown noise in the rehearsal).

Runner defect found on the way, not fixed here: a canonical decimal object key
longer than ten digits cannot be written through the v2 patch generator (two
array-index predicates in `v2-transaction.ts` disagree). Issue to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kp8NcNXPougGPyJCEyYtob


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6882?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

