### PR TITLE
feat(cf-harness): the console serves a live pane for one session (CT-2234)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ dist/
 .cf/
 .ct/
 .cf-harness-artifacts/
-.cf-harness-console/
+.cf-harness-console*/
 .cf-harness-hostile-demo*/
 .cf-harness-demo-*/
 claude-research.key

--- a/docs/development/COVERAGE.md
+++ b/docs/development/COVERAGE.md
@@ -49,11 +49,16 @@ and `tasks/write-coverage-lcov.ts` acts on the difference:
   cache holds no transpiled form of it. For a file the debt metric tracks that is
   a file the report should have carried: the script names those files and exits
   non-zero, after writing the report of what did convert so it can be read while
-  the cause is found. Two things cause it. The profiles were collected by one
+  the cause is found. Three things cause it. The profiles were collected by one
   Deno version and reported by another, which happens when a test starts the Deno
   on `PATH` instead of the Deno running it. Or they were collected from a working
   directory under a different Deno configuration, because the cache key covers
-  the configuration in scope where the file was compiled.
+  the configuration in scope where the file was compiled. Or the run that
+  collected them could not write the cache at all, which is what an agent
+  sandbox that denies writes to `DENO_DIR` produces: the tests pass, because
+  the transpiled form is held in memory, and every file is then missing from
+  the report, so `deno coverage` says the profile covered nothing rather than
+  naming the denial. Collect coverage outside the sandbox.
 - `Source not found for "<url>"` — the source is gone, so a test compiled the
   file and then deleted it. No report could name it, so the script warns and
   carries on.

--- a/packages/cf-harness/console/README.md
+++ b/packages/cf-harness/console/README.md
@@ -2,8 +2,9 @@
 
 Type a task, watch the harness work, open what it built — and read what the run
 left behind when the feed's elided summaries are not enough. One Deno HTTP
-server holding one in-process interactive chat service, and one Lit page reading
-its events over Server-Sent Events.
+server holding one in-process interactive chat service, and two Lit pages
+reading its events over Server-Sent Events: the console itself, and the live
+pane a host embeds to show one session working.
 
 The server binds `127.0.0.1`, and it treats loopback as an address rather than
 as an authorization: a page anywhere on the web can drive requests at the
@@ -132,21 +133,23 @@ durable: restarting the server and reopening the page replays the log.
 ## HTTP routes
 
 Every route retains the console's loopback `Host` and `Origin` checks. The token
-column refers to the per-process cookie obtained by loading `/`.
+column refers to the per-process cookie, which is handed to whichever of the two
+pages is loaded — `/` or `/live/<sessionId>` — and to the assets they pull.
 
-| Method | Route                        | Token | Result                                                                                  |
-| ------ | ---------------------------- | ----- | --------------------------------------------------------------------------------------- |
-| `GET`  | `/api/health`                | No    | Console health, configured Fabric API URL, and honestly limited Fabric-session liveness |
-| `POST` | `/api/task`                  | Yes   | Starts a session or a follow-up turn                                                    |
-| `POST` | `/api/cancel`                | Yes   | Cancels the active turn                                                                 |
-| `GET`  | `/api/sessions`              | Yes   | Durable session summaries                                                               |
-| `GET`  | `/api/status`                | Yes   | Session status and artifact roots                                                       |
-| `GET`  | `/api/policy`                | Yes   | What a new session here would run under                                                 |
-| `GET`  | `/api/turns/<turnId>/result` | Yes   | Durable structured result for a completed turn                                          |
-| `GET`  | `/api/events`                | Yes   | Live and replayed chat events over SSE                                                  |
-| `GET`  | `/api/runs`                  | Yes   | Run summaries                                                                           |
-| `GET`  | `/api/runs/<runId>/...`      | Yes   | Run detail, flow, graph, artifacts, and tool outputs                                    |
-| `POST` | `/api/index/call`            | Yes   | One allowlisted pattern-index read                                                      |
+| Method | Route                        | Token | Result                                                                                                                         |
+| ------ | ---------------------------- | ----- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `GET`  | `/api/health`                | No    | Console health, configured Fabric API URL, and honestly limited Fabric-session liveness                                        |
+| `POST` | `/api/task`                  | Yes   | Starts a session or a follow-up turn                                                                                           |
+| `POST` | `/api/cancel`                | Yes   | Cancels the active turn                                                                                                        |
+| `GET`  | `/api/sessions`              | Yes   | Durable session summaries                                                                                                      |
+| `GET`  | `/api/status`                | Yes   | Session status and artifact roots                                                                                              |
+| `GET`  | `/api/policy`                | Yes   | What a new session here would run under                                                                                        |
+| `GET`  | `/api/turns/<turnId>/result` | Yes   | Durable structured result for a completed turn                                                                                 |
+| `GET`  | `/api/events`                | Yes   | Live and replayed chat events over SSE                                                                                         |
+| `GET`  | `/api/runs`                  | Yes   | Run summaries                                                                                                                  |
+| `GET`  | `/api/runs/<runId>/...`      | Yes   | Run detail, flow, graph, artifacts, and tool outputs                                                                           |
+| `POST` | `/api/index/call`            | Yes   | One allowlisted pattern-index read                                                                                             |
+| `GET`  | `/live/<sessionId>`          | No    | The live pane for one session, which is handed the token the way `/` is; takes `?turn=<turnId>` and `?piecesBase=<url-prefix>` |
 
 Health returns `ok`, `fabricApiUrl`, and `fabricSession`. The last field is
 `unverified`: the console has no inspectable Fabric-session connection state,
@@ -252,6 +255,50 @@ appearing, the Runs view below reads it back.
 Cancel stops the running turn. The session survives a cancel and a page reload
 both — the stream resumes from the last event the page rendered rather than
 replaying the feed.
+
+## The live pane
+
+`GET /live/<sessionId>` is the same work in a column, for a host that can show a
+task running beside the thing that asked for it and can only open a plain web
+address. It is served from the same build as the console page and handed the
+same token cookie, so its own script reaches `/api` on this origin and nothing
+else does: the `Host` gate covers it, and the content security policy that keeps
+the console page out of a frame keeps this one out too. It is opened at the top
+level of a view, never framed.
+
+`?turn=<turnId>` narrows the pane to one turn. Without it the pane shows the
+session's activity in order, however many turns it has taken.
+
+`?piecesBase=<url-prefix>` says where the host renders a piece. A piece's own
+address is the one `assign_slug` recorded, which is the Fabric API's; a host
+that shows pieces somewhere else — a pane of its own, say, where the API's
+address answers with a login gate instead of the piece — names its prefix here,
+and every piece link on the page is composed as `<piecesBase>/<space>/<slug>`
+from the space and slug the turn's result carries, each escaped. With no prefix
+named, the recorded URL is used as it stands rather than rebuilt. The prefix has
+to be an absolute `http` or `https` URL: it arrives from whatever opened the
+page and ends up in an `href`, so anything else — a `javascript:` URL, a
+relative path — is refused, the page says so, and the links stay on the recorded
+address. The console composes against a prefix it is given and knows nothing
+about the host that gave it.
+
+The pane reads the same event stream the console page reads, from sequence zero
+— so a pane opened halfway through a turn shows the steps that already happened
+rather than only the ones that follow, and a reconnect resumes from the last
+event it rendered. What the stream carries is the order and the outcome; what a
+call was given, what CFC decided about it, and what it withheld from the model
+come from the turn's own run, which the pane re-reads when one of its tool calls
+completes. The run id of a console turn is the turn id, so no route composes
+that address and no lookup stands between the two.
+
+Each step is one line — the tool, how it ended, and what it was about: the
+numbered `run_pattern` attempt and the compiler's word on it, the slug
+`assign_slug` registered, the query a search was given, the question
+`query_docs` asked. Under a line whose run recorded a CFC decision sits the same
+CFC line the console's timeline draws, and a result that held anything back from
+the model carries the same omission block, openable in place. A completed turn
+ends the pane with the piece link the turn produced, which is what the pane is
+watched for.
 
 ## Sessions
 

--- a/packages/cf-harness/console/felt.config.ts
+++ b/packages/cf-harness/console/felt.config.ts
@@ -1,12 +1,16 @@
 import { type Config } from "@commonfabric/felt";
 
 /**
- * The console page's build. The page is served by the console server itself
- * rather than by felt, so only `build` is used here: `port` and `hostname`
- * belong to felt's own dev server, which this surface does not run.
+ * The console's build: the operator's page, and the live pane one session is
+ * watched through. Both are served by the console server itself rather than by
+ * felt, so only `build` is used here: `port` and `hostname` belong to felt's
+ * own dev server, which this surface does not run.
  */
 const config: Config = {
-  entries: [{ in: "src/index.ts", out: "scripts/index" }],
+  entries: [
+    { in: "src/index.ts", out: "scripts/index" },
+    { in: "src/live.ts", out: "scripts/live" },
+  ],
   outDir: "dist",
   publicDir: "public",
   watchDir: "src",

--- a/packages/cf-harness/console/public/live.html
+++ b/packages/cf-harness/console/public/live.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>cf-harness live session</title>
+    <link rel="stylesheet" href="/styles/console.css" />
+    <link rel="stylesheet" href="/styles/live.css" />
+  </head>
+  <body class="live">
+    <console-live></console-live>
+    <script type="module" src="/scripts/live.js"></script>
+  </body>
+</html>

--- a/packages/cf-harness/console/public/styles/live.css
+++ b/packages/cf-harness/console/public/styles/live.css
@@ -1,0 +1,184 @@
+/*
+ * The live pane: one session's work, in a column about as wide as a phone.
+ * It loads `console.css` first and takes the shared vocabulary from there —
+ * the badge, the CFC line, the omission block — so a step reads the same here
+ * as it does in the console's own timeline. What this file adds is the column
+ * those pieces sit in, and the dark scheme, because a pane docked beside
+ * another application follows that application's appearance rather than its
+ * own.
+ */
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --ink: #e6e8ee;
+    --muted: #98a1b3;
+    --line: #2b303b;
+    --page: #14171d;
+    --accent: #6ea8ff;
+    --ok: #4cc79a;
+    --bad: #ff7b72;
+  }
+
+  .atom.conf {
+    background: #1d2a44;
+    color: #9dc0ff;
+  }
+
+  .atom.integ {
+    background: #16302a;
+    color: #6fd7ae;
+  }
+
+  /*
+   * The console page names its own light values for these, so the variables
+   * above do not reach them. The pane draws all four — the amber of a withheld
+   * release, and the panel a withheld position's value sits in — so each is
+   * restated here at a weight that reads on the dark page.
+   */
+
+  .badge.warn,
+  .cfc-withheld,
+  .withheld-rule {
+    color: #e8a04a;
+  }
+
+  .withheld-pane {
+    border-left-color: #e8a04a;
+  }
+
+  .raw {
+    background: #1c2028;
+  }
+}
+
+body.live {
+  font-size: 14px;
+}
+
+console-live {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+.live-header {
+  align-items: baseline;
+  border-bottom: 1px solid var(--line);
+  display: flex;
+  gap: 0.5rem;
+  padding: 0.6rem 0.85rem;
+}
+
+.live-state {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.8rem;
+  overflow-wrap: anywhere;
+}
+
+/* The feed scrolls inside itself, so the header stays where it is. */
+.live-feed {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 0.6rem 0.85rem 2rem;
+}
+
+.live-entry {
+  margin-bottom: 0.7rem;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+/* A line a `delegate_task` child produced, set in from its parent's. */
+.live-entry.child {
+  border-left: 2px solid var(--line);
+  padding-left: 0.6rem;
+}
+
+.live-entry.turn {
+  border-bottom: 1px solid var(--line);
+  color: var(--muted);
+  display: flex;
+  font-size: 0.72rem;
+  gap: 0.4rem;
+  letter-spacing: 0.06em;
+  padding-bottom: 0.4rem;
+  text-transform: uppercase;
+}
+
+.live-head {
+  align-items: baseline;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.live-dot {
+  border-radius: 50%;
+  flex: none;
+  height: 0.5rem;
+  transform: translateY(-0.05rem);
+  width: 0.5rem;
+}
+
+.live-dot.running {
+  background: var(--accent);
+}
+
+.live-dot.completed {
+  background: var(--ok);
+}
+
+.live-dot.failed,
+.live-dot.denied {
+  background: var(--bad);
+}
+
+.live-line {
+  color: var(--ink);
+  font-size: 0.82rem;
+  padding-left: 0.9rem;
+}
+
+.live-line.muted {
+  color: var(--muted);
+}
+
+.live-entry.said {
+  white-space: pre-wrap;
+}
+
+.live-final {
+  white-space: pre-wrap;
+}
+
+.live-entry.ended {
+  border-top: 1px solid var(--line);
+  padding-top: 0.6rem;
+}
+
+.piece-link {
+  background: var(--accent);
+  border-radius: 8px;
+  color: #fff;
+  display: block;
+  font-weight: 600;
+  margin-top: 0.6rem;
+  padding: 0.55rem 0.7rem;
+  text-align: center;
+  text-decoration: none;
+}
+
+/*
+ * The console's own panes are laid out for three columns beside each other.
+ * In this pane they are one column, and a result and its omission record read
+ * as two blocks rather than as two half-width ones.
+ */
+.live-entry .pane {
+  margin: 0.35rem 0 0 0.9rem;
+}
+
+.live-entry .raw {
+  font-size: 0.72rem;
+  max-height: 12rem;
+}

--- a/packages/cf-harness/console/server.ts
+++ b/packages/cf-harness/console/server.ts
@@ -173,6 +173,14 @@ const cookieValue = (
 const ASSET_PATH = /^\/(scripts\/|styles\/|build-manifest\.json$|$)/;
 
 /**
+ * The live pane's address, which names the session it shows. It is served the
+ * same built page whatever session it names — the page reads the session out
+ * of its own address — and it is one of the paths served from the build, so it
+ * is handed the token cookie its own script needs to reach `/api`.
+ */
+const LIVE_PATH = /^\/live\/[^/]+\/?$/;
+
+/**
  * What the page is allowed to load and where it may send what it holds.
  * Everything it needs comes from this origin, so `'self'` covers its script,
  * its stylesheet, its fetches and its event stream; `style-src` allows inline
@@ -942,7 +950,10 @@ export class ConsoleServer {
         fabricSession: "unverified",
       });
     }
-    if (request.method === "GET" && ASSET_PATH.test(url.pathname)) {
+    if (
+      request.method === "GET" &&
+      (ASSET_PATH.test(url.pathname) || LIVE_PATH.test(url.pathname))
+    ) {
       const response = await this.#asset(url.pathname);
       response.headers.set(
         "content-security-policy",
@@ -1155,12 +1166,18 @@ export class ConsoleServer {
   }
 
   /**
-   * One file of the built page. The page is a felt build under `dist/`, so a
+   * One file of the built pages. They are a felt build under `dist/`, so a
    * server started before `deno task console:build` has nothing to serve and
    * says which command produces it rather than answering an empty 404.
    */
   async #asset(pathname: string): Promise<Response> {
-    const relativePath = pathname === "/" ? "index.html" : pathname.slice(1);
+    const live = LIVE_PATH.test(pathname);
+    const page = pathname === "/" || live;
+    const relativePath = pathname === "/"
+      ? "index.html"
+      : live
+      ? "live.html"
+      : pathname.slice(1);
     if (relativePath.split("/").some((segment) => segment === "..")) {
       return new Response("not found", { status: 404 });
     }
@@ -1172,7 +1189,7 @@ export class ConsoleServer {
       });
     } catch {
       return new Response(
-        pathname === "/"
+        page
           ? "the console page is not built; run `deno task --cwd packages/cf-harness console:build`"
           : "not found",
         {

--- a/packages/cf-harness/console/src/live-view.ts
+++ b/packages/cf-harness/console/src/live-view.ts
@@ -1,0 +1,835 @@
+/**
+ * One session's work as it happens, in a pane narrow enough to sit beside the
+ * thing that asked for it. A host that can only open a plain web address —
+ * Loom's task panel among them — opens `/live/<sessionId>` and watches the
+ * harness build the piece it asked for, until the piece itself replaces the
+ * pane.
+ *
+ * The event stream is the source. Its durable log is replayed from sequence
+ * zero when the page loads, so a pane opened halfway through a turn shows what
+ * already happened rather than only what comes next, and a reconnect resumes
+ * from the last sequence rendered. Nothing here polls.
+ *
+ * What the stream carries is the order and the outcome; what a call was given,
+ * what CFC decided about it, and what was withheld from the model live in the
+ * run's artifacts. So a run is re-read when one of its tool calls completes —
+ * the turn's own, whose id is the turn id, and a `delegate_task` child's, whose
+ * calls its parent's run does not record — and the two readings are joined by
+ * tool call id. The join is what puts a CFC line under a step in a pane that is
+ * otherwise a feed.
+ */
+
+import { html, LitElement, nothing, type TemplateResult } from "lit";
+import {
+  type ConsoleChatEventEnvelope,
+  type ConsoleRunDetail,
+  readRun,
+} from "./api.ts";
+import { stepPolicyView, withheldView } from "./steps-view.ts";
+import type { ConsoleStep } from "../steps.ts";
+import type { ConsoleTurnResultPiece } from "../turn-result.ts";
+
+/** The `delegate_task` child a line belongs to, for the lines under one. */
+interface LiveSubagent {
+  parentToolCallId: string;
+  profile: string;
+}
+
+/** One line of the feed. */
+export type ConsoleLiveEntry =
+  | { kind: "turn"; key: string; turnId: string; startedAt: string }
+  | {
+    kind: "assistant";
+    key: string;
+    turnId?: string;
+    text: string;
+    subagent?: LiveSubagent;
+  }
+  | {
+    kind: "tool";
+    key: string;
+    turnId?: string;
+    toolCallId: string;
+    toolName: string;
+    status: "running" | "completed" | "failed" | "denied";
+    progress?: string;
+    resultSummary?: string;
+    subagent?: LiveSubagent;
+  }
+  | {
+    kind: "subagent";
+    key: string;
+    turnId?: string;
+    profile: string;
+    goal?: string;
+    status: "running" | "completed" | "failed";
+  }
+  | {
+    kind: "ended";
+    key: string;
+    turnId: string;
+    status: "completed" | "failed" | "canceled";
+    text?: string;
+    pieces: readonly ConsoleTurnResultPiece[];
+
+    /** The space the pieces are in, which composing an address needs. */
+    spaceName?: string;
+  };
+
+/**
+ * The arguments that say what a call was about, in the order a line prefers
+ * them. A tool the run's own reading does not cover — every tool but the four
+ * it names — is described by the first of these its call carried.
+ */
+const SUBJECT_ARGUMENTS = ["question", "query", "path", "slug", "name"];
+
+/** How much of a result or a goal one line carries before it is elided. */
+const LINE_LIMIT = 140;
+
+const elide = (text: string, limit = LINE_LIMIT): string =>
+  text.length > limit ? `${text.slice(0, limit - 1)}…` : text;
+
+/** The whitespace a model's own wording carries, flattened to one line. */
+const oneLine = (text: string): string => text.replace(/\s+/g, " ").trim();
+
+const asRecord = (value: unknown): Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+
+const parsedRecord = (text: string | undefined): Record<string, unknown> => {
+  try {
+    return asRecord(JSON.parse(text ?? ""));
+  } catch {
+    // A result the tool did not write as JSON has no fields to read; the line
+    // falls back to the tool's name, which is still what happened.
+    return {};
+  }
+};
+
+/** What a live address names. */
+export interface ConsoleLiveAddress {
+  /** The session the pane shows, absent for an address naming none. */
+  sessionId?: string;
+
+  /** The one turn the pane is narrowed to, when the address asks for one. */
+  turnId?: string;
+
+  /**
+   * Where the host renders a piece, without its trailing slash. A piece's own
+   * address is the one the run recorded, which is the Fabric API's; a host
+   * that renders pieces somewhere else says where, and the pane composes
+   * against it instead.
+   */
+  piecesBase?: string;
+
+  /** A `piecesBase` the address carried and this refused. */
+  piecesBaseRefused?: true;
+}
+
+/**
+ * A `piecesBase` the pane will compose against, or nothing. It has to be an
+ * absolute `http` or `https` address: the parameter reaches the page from
+ * whatever opened it, and it ends up in an `href`, so a `javascript:` or a
+ * relative path is refused rather than resolved. The trailing slash goes,
+ * because the composition adds its own.
+ */
+const piecesBaseFrom = (raw: string | null): string | undefined => {
+  if (raw === null || raw === "") {
+    return undefined;
+  }
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return undefined;
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    return undefined;
+  }
+  return raw.replace(/\/+$/, "");
+};
+
+/**
+ * Where one piece is opened. The host that renders pieces somewhere other than
+ * the Fabric API says so with `piecesBase`, and the pane composes the address
+ * from the space and the slug the run recorded; with no base named, the URL
+ * the run recorded is used as it stands rather than rebuilt.
+ */
+export const consoleLivePieceHref = (
+  piece: ConsoleTurnResultPiece,
+  spaceName: string | undefined,
+  piecesBase: string | undefined,
+): string =>
+  piecesBase === undefined || spaceName === undefined
+    ? piece.url
+    : `${piecesBase}/${encodeURIComponent(spaceName)}/${
+      encodeURIComponent(piece.slug)
+    }`;
+
+/**
+ * What the address a pane was opened at names. The session is the last segment
+ * of `/live/<sessionId>`, so the pane is a link a host can compose rather than
+ * a query a script has to build, and the turn is `?turn=`.
+ */
+export const consoleLiveAddress = (
+  pathname: string,
+  search = "",
+): ConsoleLiveAddress => {
+  // The segment holds at least one character and decoding never gives back
+  // fewer, so a match always names a session.
+  const match = /^\/live\/([^/]+)\/?$/.exec(pathname);
+  let sessionId: string | undefined;
+  if (match !== null) {
+    try {
+      sessionId = decodeURIComponent(match[1]);
+    } catch {
+      // An escape the address got wrong names no session, so the pane says so
+      // rather than opening a stream for an id it repaired into existence.
+      sessionId = undefined;
+    }
+  }
+  const params = new URLSearchParams(search);
+  const turn = params.get("turn");
+  const rawBase = params.get("piecesBase");
+  const piecesBase = piecesBaseFrom(rawBase);
+  return {
+    ...(sessionId === undefined ? {} : { sessionId }),
+    ...(turn === null || turn === "" ? {} : { turnId: turn }),
+    ...(piecesBase === undefined ? {} : { piecesBase }),
+    ...(rawBase !== null && rawBase !== "" && piecesBase === undefined
+      ? { piecesBaseRefused: true as const }
+      : {}),
+  };
+};
+
+/**
+ * The runs one event says to re-read. A run writes its artifacts as it goes,
+ * so a call that completed is when there is more of its run to read — the
+ * turn's own run, and the `delegate_task` child's run when a child made the
+ * call, because the parent's run does not record it.
+ */
+export const consoleLiveRunReads = (
+  envelope: ConsoleChatEventEnvelope,
+): readonly string[] => {
+  const event = envelope.event;
+  const turnRun = envelope.turnId !== undefined &&
+      (event.kind === "tool_completed" || event.kind === "turn_completed" ||
+        event.kind === "turn_failed")
+    ? [envelope.turnId]
+    : [];
+  const childRun = event.kind === "tool_completed"
+    ? event.subagent?.childRunId
+    : event.kind === "subagent_completed"
+    ? event.subagent.childRunId
+    : undefined;
+  return childRun === undefined ? turnRun : [...turnRun, childRun];
+};
+
+/**
+ * The feed the events add up to, in the order they arrived. One tool call is
+ * one line however many events it produced: a call that started, reported
+ * progress and completed reads as a step that ran and finished, which is what
+ * a pane this narrow has room to say.
+ *
+ * A turn id narrows the feed to that turn. An envelope carrying no turn at all
+ * — the session's own lifecycle — belongs to no turn and is left out of a
+ * narrowed feed rather than shown under whichever turn is open.
+ */
+export const consoleLiveEntries = (
+  envelopes: readonly ConsoleChatEventEnvelope[],
+  turnId?: string,
+): readonly ConsoleLiveEntry[] => {
+  const entries: ConsoleLiveEntry[] = [];
+  const tools = new Map<string, Extract<ConsoleLiveEntry, { kind: "tool" }>>();
+  const subagents = new Map<
+    string,
+    Extract<ConsoleLiveEntry, { kind: "subagent" }>
+  >();
+  let openAssistant:
+    | Extract<ConsoleLiveEntry, { kind: "assistant" }>
+    | undefined;
+  for (
+    const envelope of [...envelopes].sort((left, right) =>
+      left.sequence - right.sequence
+    )
+  ) {
+    if (turnId !== undefined && envelope.turnId !== turnId) {
+      continue;
+    }
+    const event = envelope.event;
+    const named = {
+      key: `${envelope.sequence}`,
+      ...(envelope.turnId !== undefined ? { turnId: envelope.turnId } : {}),
+    };
+    const under = (
+      subagent: { parentToolCallId: string; profile: string } | undefined,
+    ) =>
+      subagent === undefined ? {} : {
+        subagent: {
+          parentToolCallId: subagent.parentToolCallId,
+          profile: subagent.profile,
+        },
+      };
+    // Assistant prose runs until something else happens, so any other event
+    // closes the block the deltas were accumulating into.
+    if (
+      event.kind !== "assistant_delta" && event.kind !== "assistant_completed"
+    ) {
+      openAssistant = undefined;
+    }
+    switch (event.kind) {
+      case "turn_started": {
+        entries.push({
+          kind: "turn",
+          key: named.key,
+          turnId: event.turn.turnId,
+          startedAt: event.turn.startedAt,
+        });
+        break;
+      }
+      case "assistant_delta": {
+        if (openAssistant === undefined) {
+          openAssistant = {
+            kind: "assistant",
+            ...named,
+            text: event.text,
+            ...under(event.subagent),
+          };
+          entries.push(openAssistant);
+        } else {
+          openAssistant.text += event.text;
+        }
+        break;
+      }
+      case "assistant_completed": {
+        // The completed event carries the whole message, so it settles the
+        // text rather than adding to it — however many deltas preceded it.
+        if (openAssistant === undefined) {
+          entries.push({
+            kind: "assistant",
+            ...named,
+            text: event.text,
+            ...under(event.subagent),
+          });
+        } else {
+          openAssistant.text = event.text;
+        }
+        openAssistant = undefined;
+        break;
+      }
+      case "tool_started": {
+        const entry: Extract<ConsoleLiveEntry, { kind: "tool" }> = {
+          kind: "tool",
+          ...named,
+          toolCallId: event.tool.toolCallId,
+          toolName: event.tool.toolId,
+          status: "running",
+          ...under(event.subagent),
+        };
+        tools.set(entry.toolCallId, entry);
+        entries.push(entry);
+        break;
+      }
+      case "tool_progress": {
+        const held = tools.get(event.toolCallId);
+        if (held !== undefined) {
+          held.progress = event.message;
+        }
+        break;
+      }
+      case "tool_completed": {
+        const held = tools.get(event.tool.toolCallId);
+        const entry = held ?? {
+          kind: "tool" as const,
+          ...named,
+          toolCallId: event.tool.toolCallId,
+          toolName: event.tool.toolId,
+          status: "running" as const,
+          ...under(event.subagent),
+        };
+        entry.status = event.status;
+        if (event.resultSummary !== undefined) {
+          entry.resultSummary = event.resultSummary;
+        }
+        if (held === undefined) {
+          entries.push(entry);
+        }
+        break;
+      }
+      case "subagent_started": {
+        const entry: Extract<ConsoleLiveEntry, { kind: "subagent" }> = {
+          kind: "subagent",
+          ...named,
+          profile: event.subagent.profile,
+          ...(event.subagent.goal === undefined || event.subagent.goal === ""
+            ? {}
+            : { goal: event.subagent.goal }),
+          status: "running",
+        };
+        subagents.set(event.subagent.parentToolCallId, entry);
+        entries.push(entry);
+        break;
+      }
+      case "subagent_completed": {
+        const held = subagents.get(event.subagent.parentToolCallId);
+        if (held !== undefined) {
+          held.status = event.status;
+        }
+        break;
+      }
+      case "turn_completed": {
+        // A completed turn's final text is its last assistant message, which
+        // the feed has already rendered; what the closing block adds is the
+        // links the turn produced.
+        entries.push({
+          kind: "ended",
+          key: named.key,
+          turnId: event.turnId,
+          status: "completed",
+          pieces: event.result.pieces,
+          spaceName: event.result.spaceName,
+        });
+        break;
+      }
+      case "turn_failed": {
+        entries.push({
+          kind: "ended",
+          key: named.key,
+          turnId: event.turnId,
+          status: "failed",
+          text: event.error.message,
+          pieces: [],
+        });
+        break;
+      }
+      case "turn_canceled": {
+        entries.push({
+          kind: "ended",
+          key: named.key,
+          turnId: event.turnId,
+          status: "canceled",
+          ...(event.reason === undefined ? {} : { text: event.reason }),
+          pieces: [],
+        });
+        break;
+      }
+      default:
+        break;
+    }
+  }
+  return entries;
+};
+
+/**
+ * What one tool call was about, in a line. The run's own reading of its
+ * transcript supplies what the call was given — the pattern attempt and its
+ * compiler message, the search's query, the name a piece was assigned — and
+ * the step supplies the rest, because a tool the reading does not cover still
+ * carries its arguments. A call whose run has not been read yet has no line,
+ * which is what a step still running looks like.
+ */
+export const consoleLiveToolLine = (
+  entry: Extract<ConsoleLiveEntry, { kind: "tool" }>,
+  detail: ConsoleRunDetail | undefined,
+  step: ConsoleStep | undefined,
+): string | undefined => {
+  const lens = detail?.lens;
+  if (entry.toolName === "run_pattern") {
+    const index = lens?.patternAttempts.findIndex((attempt) =>
+      attempt.toolCallId === entry.toolCallId
+    ) ?? -1;
+    const attempt = index < 0 ? undefined : lens?.patternAttempts[index];
+    const outcome = attempt === undefined
+      ? undefined
+      : attempt.message === undefined
+      ? attempt.status
+      : `${attempt.status}: ${oneLine(attempt.message)}`;
+    const ordinal = index < 0 ? "" : `attempt ${index + 1}`;
+    return elide(
+      [ordinal, outcome].filter((part) =>
+        part !== undefined && part !== ""
+      )
+        .join(" · "),
+    );
+  }
+  if (entry.toolName === "assign_slug") {
+    const piece = lens?.pieces.find((named) =>
+      named.toolCallId === entry.toolCallId
+    );
+    const slug = piece?.slug ?? parsedRecord(entry.resultSummary).slug;
+    return typeof slug === "string" ? slug : undefined;
+  }
+  if (entry.toolName === "search_patterns") {
+    return elide(
+      lens?.searches.find((search) => search.toolCallId === entry.toolCallId)
+        ?.query ?? "",
+    ) || undefined;
+  }
+  const input = asRecord(step?.input);
+  for (const key of SUBJECT_ARGUMENTS) {
+    const value = input[key];
+    if (typeof value === "string" && value !== "") {
+      return elide(oneLine(value));
+    }
+  }
+  return undefined;
+};
+
+/**
+ * What the header says the pane is doing, read off the feed rather than off
+ * the event that arrived. The feed is already narrowed to the turn the address
+ * names, so a header derived from it cannot report a sibling turn's progress
+ * the way one advanced per event does; and what the reader is told is then the
+ * same thing they are shown.
+ */
+export const consoleLiveState = (
+  entries: readonly ConsoleLiveEntry[],
+): string => {
+  for (const entry of [...entries].reverse()) {
+    if (entry.kind === "ended") {
+      return entry.status === "completed" ? "done" : entry.status;
+    }
+    if (entry.kind === "tool" && entry.status === "running") {
+      return entry.toolName;
+    }
+    if (entry.kind === "turn") {
+      return "working";
+    }
+  }
+  return entries.length === 0 ? "connecting" : "working";
+};
+
+/**
+ * Whether a feed scrolled this far is at its tail. The last row is rarely
+ * flush with the bottom of the scroller — a fractional row height leaves a
+ * pixel or two — so a reader is taken to be at the tail when they are within
+ * a row's rounding of it.
+ */
+export const consoleLiveAtTail = (feed: {
+  scrollHeight: number;
+  scrollTop: number;
+  clientHeight: number;
+}): boolean => feed.scrollHeight - feed.scrollTop - feed.clientHeight < 8;
+
+/**
+ * Whether a step held anything back from the model, and so has an omission
+ * block worth opening. A pane this narrow marks the results that withheld
+ * something rather than every result that recorded that it withheld nothing.
+ */
+export const stepWithheldAnything = (step: ConsoleStep): boolean =>
+  step.policy?.decision === "withheld" ||
+  (step.withheld.status === "recorded" && step.withheld.locations.length > 0) ||
+  step.withheld.status === "record-unreadable" ||
+  step.withheld.status === "record-entry-missing";
+
+export class ConsoleLive extends LitElement {
+  static override properties = {
+    sessionId: { attribute: false },
+    turnId: { attribute: false },
+    piecesBase: { attribute: false },
+    piecesBaseRefused: { attribute: false },
+    entries: { attribute: false },
+    details: { attribute: false },
+    state: { attribute: false },
+    error: { attribute: false },
+  };
+
+  /** The session this pane is showing, read from the address it was opened at. */
+  declare sessionId: string | undefined;
+
+  /** The one turn the pane is narrowed to, when the address names one. */
+  declare turnId: string | undefined;
+
+  /** Where the host renders a piece, when the address says somewhere. */
+  declare piecesBase: string | undefined;
+
+  /** Whether the address carried a `piecesBase` this pane refused. */
+  declare piecesBaseRefused: boolean;
+
+  declare entries: readonly ConsoleLiveEntry[];
+
+  /**
+   * The runs read so far, by run id. A turn's own run is filed under the turn
+   * id, which is the run id a console turn takes; a `delegate_task` child's
+   * run is filed under the id the delegation named, because a child's calls
+   * are recorded in the child's own run rather than in its parent's.
+   */
+  declare details: ReadonlyMap<string, ConsoleRunDetail>;
+
+  declare state: string;
+  declare error: string | undefined;
+
+  /** Every envelope rendered, which the feed is recomputed from. */
+  #envelopes: ConsoleChatEventEnvelope[] = [];
+
+  /** The last sequence rendered; every reconnect resumes from it. */
+  #lastSequence = 0;
+
+  #stream: EventSource | undefined;
+
+  /** Which read of a run is the current one, by run id. */
+  #reads = new Map<string, number>();
+
+  /**
+   * Whether the feed is following the tail. A pane watching a task run wants
+   * the newest step in view, and a reader who scrolls up to read an earlier
+   * one wants to stay where they scrolled to.
+   */
+  #pinned = true;
+
+  constructor() {
+    super();
+    this.entries = [];
+    this.details = new Map();
+    this.state = "connecting";
+    this.piecesBaseRefused = false;
+  }
+
+  protected override createRenderRoot(): HTMLElement {
+    return this;
+  }
+
+  protected override updated(): void {
+    if (!this.#pinned) {
+      return;
+    }
+    const feed = this.querySelector(".live-feed");
+    feed?.scrollTo({ top: feed.scrollHeight });
+  }
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    const address = consoleLiveAddress(location.pathname, location.search);
+    this.sessionId = address.sessionId;
+    this.turnId = address.turnId;
+    this.piecesBase = address.piecesBase;
+    this.piecesBaseRefused = address.piecesBaseRefused === true;
+    if (this.sessionId === undefined) {
+      this.state = "no session";
+      this.error = "This address names no session.";
+      return;
+    }
+    this.#subscribe(this.sessionId);
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this.#stream?.close();
+  }
+
+  /**
+   * Opens the stream, replaying everything the session has already recorded.
+   * A reconnect asks from the last sequence rendered, so the feed a reader is
+   * watching is continuous across one.
+   */
+  #subscribe(sessionId: string): void {
+    this.#stream?.close();
+    const stream = new EventSource(
+      `/api/events?sessionId=${
+        encodeURIComponent(sessionId)
+      }&afterSequence=${this.#lastSequence}`,
+    );
+    this.#stream = stream;
+    stream.addEventListener("chat", (message) => {
+      this.#onEvent(JSON.parse((message as MessageEvent<string>).data));
+    });
+    stream.addEventListener("error", () => {
+      if (stream.readyState === EventSource.CLOSED) {
+        this.#subscribe(sessionId);
+      }
+    });
+  }
+
+  #onEvent(envelope: ConsoleChatEventEnvelope): void {
+    if (envelope.sequence <= this.#lastSequence) {
+      return;
+    }
+    this.#lastSequence = envelope.sequence;
+    this.#envelopes.push(envelope);
+    this.entries = consoleLiveEntries(this.#envelopes, this.turnId);
+    this.state = consoleLiveState(this.entries);
+    // The re-read is driven by the event that says there is more of a run to
+    // read, rather than by a clock.
+    for (const runId of consoleLiveRunReads(envelope)) {
+      void this.#readRun(runId);
+    }
+  }
+
+  /**
+   * Re-reads one run. A run with no artifacts yet is not an error to report:
+   * the feed is what the stream said, and the run is what enriches it once it
+   * exists.
+   */
+  async #readRun(runId: string): Promise<void> {
+    const read = (this.#reads.get(runId) ?? 0) + 1;
+    this.#reads.set(runId, read);
+    try {
+      const detail = await readRun(runId);
+      if (this.#reads.get(runId) === read) {
+        this.details = new Map(this.details).set(runId, detail);
+      }
+    } catch {
+      // The run has written nothing yet, or this console does not hold it.
+    }
+  }
+
+  /**
+   * The run that recorded one call, and its step. A call a `delegate_task`
+   * child made is recorded in the child's run rather than in the run of the
+   * turn it happened under, so the call is looked for across every run read
+   * rather than in the one the event was tagged with.
+   */
+  #recordOf(
+    toolCallId: string,
+  ): { detail: ConsoleRunDetail; step: ConsoleStep } | undefined {
+    for (const detail of this.details.values()) {
+      const step = detail.steps.find((candidate) =>
+        candidate.toolCallId === toolCallId
+      );
+      if (step !== undefined) {
+        return { detail, step };
+      }
+    }
+    return undefined;
+  }
+
+  /** Follows the reader, until they scroll away from the tail. */
+  #onScroll(event: Event): void {
+    this.#pinned = consoleLiveAtTail(event.target as HTMLElement);
+  }
+
+  #toolEntry(
+    entry: Extract<ConsoleLiveEntry, { kind: "tool" }>,
+  ): TemplateResult {
+    const record = this.#recordOf(entry.toolCallId);
+    const step = record?.step;
+    const line = consoleLiveToolLine(entry, record?.detail, step);
+    return html`
+      <div class="live-entry tool ${entry.subagent === undefined
+        ? ""
+        : "child"}">
+        <div class="live-head">
+          <span class="live-dot ${entry.status}"></span>
+          <span class="tool">${entry.toolName}</span>
+          ${entry.status === "running" ? nothing : html`
+            <span class="badge ${entry.status === "completed"
+              ? "ok"
+              : "denied"}">${entry.status}</span>
+          `}
+        </div>
+        ${line === undefined ? nothing : html`
+          <div class="live-line">${line}</div>
+        `} ${entry.progress === undefined ? nothing : html`
+          <div class="live-line muted">${elide(entry.progress)}</div>
+        `} ${step === undefined
+          ? nothing
+          : stepPolicyView(step)} ${step === undefined ||
+            !stepWithheldAnything(step)
+          ? nothing
+          : withheldView(step)}
+      </div>
+    `;
+  }
+
+  #entry(entry: ConsoleLiveEntry): TemplateResult {
+    switch (entry.kind) {
+      case "turn":
+        return html`
+          <div class="live-entry turn">
+            <span>task started</span>
+            <span class="muted">
+              ${new Date(entry.startedAt).toLocaleTimeString()}
+            </span>
+          </div>
+        `;
+      case "assistant":
+        return html`
+          <div
+            class="live-entry said ${entry.subagent === undefined
+              ? ""
+              : "child"}"
+          >
+            ${entry.text}
+          </div>
+        `;
+      case "tool":
+        return this.#toolEntry(entry);
+      case "subagent":
+        return html`
+          <div class="live-entry subagent">
+            <div class="live-head">
+              <span class="live-dot ${entry.status}"></span>
+              <span class="tool">${entry.profile}</span>
+              ${entry.status === "running" ? nothing : html`
+                <span class="badge ${entry.status === "completed"
+                  ? "ok"
+                  : "denied"}">${entry.status}</span>
+              `}
+            </div>
+            ${entry.goal === undefined ? nothing : html`
+              <div class="live-line">${elide(oneLine(entry.goal))}</div>
+            `}
+          </div>
+        `;
+      case "ended":
+        return html`
+          <div class="live-entry ended ${entry.status}">
+            <div class="live-head">
+              <span class="badge ${entry.status === "completed"
+                ? "ok"
+                : "denied"}">${entry.status}</span>
+            </div>
+            ${entry.text === undefined ? nothing : html`
+              <div class="live-final">${entry.text}</div>
+            `} ${entry.pieces.map((piece) =>
+              html`
+                <a
+                  class="piece-link"
+                  href="${consoleLivePieceHref(
+                    piece,
+                    entry.spaceName,
+                    this.piecesBase,
+                  )}"
+                  rel="noopener"
+                >
+                  Open ${piece.slug}
+                </a>
+              `
+            )}
+          </div>
+        `;
+    }
+  }
+
+  protected override render(): TemplateResult {
+    return html`
+      <header class="live-header">
+        <span class="live-state">${this.state}</span>
+        ${this.turnId === undefined ? nothing : html`
+          <span class="muted">one turn</span>
+        `}
+      </header>
+      ${this.error === undefined ? nothing : html`
+        <p class="empty bad">${this.error}</p>
+      `} ${this.piecesBaseRefused
+        ? html`
+          <p class="empty bad">
+            The address named a <code>piecesBase</code> that is not an absolute
+            http or https URL. Piece links go to the address the run recorded.
+          </p>
+        `
+        : nothing}
+      <div class="live-feed" @scroll="${(event: Event) =>
+        this.#onScroll(event)}">
+        ${this.entries.length === 0 && this.error === undefined
+          ? html`
+            <p class="empty">Waiting for the first step.</p>
+          `
+          : this.entries.map((entry) => this.#entry(entry))}
+      </div>
+    `;
+  }
+}
+
+customElements.define("console-live", ConsoleLive);

--- a/packages/cf-harness/console/src/live.ts
+++ b/packages/cf-harness/console/src/live.ts
@@ -1,0 +1,3 @@
+/** The live page's entry point: registering the pane registers the rest. */
+
+import "./live-view.ts";

--- a/packages/cf-harness/console/src/steps-view.ts
+++ b/packages/cf-harness/console/src/steps-view.ts
@@ -147,6 +147,91 @@ export const withheldView = (step: ConsoleStep): TemplateResult => {
   `;
 };
 
+/**
+ * What CFC decided about one call, and any event it raised. A withheld
+ * release carries the retrospective's count of the positions it held back,
+ * which is what says the call itself succeeded.
+ */
+export const stepPolicyView = (
+  step: ConsoleStep,
+): TemplateResult | typeof nothing => {
+  const labelEntries = step.invocation?.cfcInputLabels?.entries ?? [];
+  if (
+    step.policy === undefined && step.policyEvents.length === 0 &&
+    labelEntries.length === 0
+  ) {
+    return nothing;
+  }
+  return html`
+    <div class="pane">
+      <div class="pane-head">cfc</div>
+      ${step.policy === undefined ? nothing : html`
+        <div class="cfc-line">
+          <span
+            class="badge ${step.policy.decision === "denied"
+              ? "denied"
+              : step.policy.decision === "invalid" ||
+                  step.policy.decision === "withheld"
+              ? "warn"
+              : "ok"}"
+          >${step.policy.decision}</span>
+          ${step.policy.effectClass === undefined ? nothing : html`
+            <span class="cfc-effect">${step.policy.effectClass}</span>
+          `}
+          <span class="cfc-reasons">
+            ${step.policy.reasonCodes.join(", ")}
+          </span>
+          ${step.policy.decision === "withheld"
+            ? html`
+              <span class="cfc-withheld">${withheldSummary(step)}</span>
+            `
+            : nothing}
+        </div>
+      `} ${step.policyEvents.map((event) =>
+        html`
+          <div class="cfc-line">
+            <span
+              class="badge ${event.severity === "denied" ? "denied" : "warn"}"
+            >${event.severity}</span>
+            <span class="cfc-reasons">${event.detail ?? ""}</span>
+          </div>
+        `
+      )} ${labelEntries.length === 0 ? nothing : html`
+        <table class="labels">
+          <tbody>
+            ${labelEntries.map((entry) =>
+              html`
+                <tr>
+                  <td class="label-path">
+                    ${entry.path.length === 0
+                      ? "(whole input)"
+                      : entry.path.join(".")}
+                  </td>
+                  <td class="label-atoms">
+                    ${atomNames(entry.label?.confidentiality).length === 0
+                      ? html`
+                        <span class="muted">no confidentiality atom</span>
+                      `
+                      : atomNames(entry.label?.confidentiality).map((name) =>
+                        html`
+                          <span class="atom conf">${name}</span>
+                        `
+                      )} ${atomNames(entry.label?.integrity).map((name) =>
+                        html`
+                          <span class="atom integ">${name}</span>
+                        `
+                      )}
+                  </td>
+                </tr>
+              `
+            )}
+          </tbody>
+        </table>
+      `}
+    </div>
+  `;
+};
+
 export class ConsoleSteps extends LitElement {
   static override properties = {
     steps: { attribute: false },
@@ -374,89 +459,6 @@ export class ConsoleSteps extends LitElement {
   }
 
   /**
-   * What CFC decided about this call, and any event it raised. A withheld
-   * release carries the retrospective's count of the positions it held back,
-   * which is what says the call itself succeeded.
-   */
-  #policy(step: ConsoleStep): TemplateResult | typeof nothing {
-    const labelEntries = step.invocation?.cfcInputLabels?.entries ?? [];
-    if (
-      step.policy === undefined && step.policyEvents.length === 0 &&
-      labelEntries.length === 0
-    ) {
-      return nothing;
-    }
-    return html`
-      <div class="pane">
-        <div class="pane-head">cfc</div>
-        ${step.policy === undefined ? nothing : html`
-          <div class="cfc-line">
-            <span
-              class="badge ${step.policy.decision === "denied"
-                ? "denied"
-                : step.policy.decision === "invalid" ||
-                    step.policy.decision === "withheld"
-                ? "warn"
-                : "ok"}"
-            >${step.policy.decision}</span>
-            ${step.policy.effectClass === undefined ? nothing : html`
-              <span class="cfc-effect">${step.policy.effectClass}</span>
-            `}
-            <span class="cfc-reasons">
-              ${step.policy.reasonCodes.join(", ")}
-            </span>
-            ${step.policy.decision === "withheld"
-              ? html`
-                <span class="cfc-withheld">${withheldSummary(step)}</span>
-              `
-              : nothing}
-          </div>
-        `} ${step.policyEvents.map((event) =>
-          html`
-            <div class="cfc-line">
-              <span
-                class="badge ${event.severity === "denied" ? "denied" : "warn"}"
-              >${event.severity}</span>
-              <span class="cfc-reasons">${event.detail ?? ""}</span>
-            </div>
-          `
-        )} ${labelEntries.length === 0 ? nothing : html`
-          <table class="labels">
-            <tbody>
-              ${labelEntries.map((entry) =>
-                html`
-                  <tr>
-                    <td class="label-path">
-                      ${entry.path.length === 0
-                        ? "(whole input)"
-                        : entry.path.join(".")}
-                    </td>
-                    <td class="label-atoms">
-                      ${atomNames(entry.label?.confidentiality).length === 0
-                        ? html`
-                          <span class="muted">no confidentiality atom</span>
-                        `
-                        : atomNames(entry.label?.confidentiality).map((name) =>
-                          html`
-                            <span class="atom conf">${name}</span>
-                          `
-                        )} ${atomNames(entry.label?.integrity).map((name) =>
-                          html`
-                            <span class="atom integ">${name}</span>
-                          `
-                        )}
-                    </td>
-                  </tr>
-                `
-              )}
-            </tbody>
-          </table>
-        `}
-      </div>
-    `;
-  }
-
-  /**
    * What the result let across as a value. The harness seals a string the
    * schema does not pin to an enum or a const, but never a number — so an
    * array of them is a channel as wide as its author cared to make it, and
@@ -514,7 +516,7 @@ export class ConsoleSteps extends LitElement {
           <span class="badge ${step.status}">${step.status}</span>
         </div>
       </div>
-      ${this.#handles(step)} ${this.#arguments(step)} ${this.#policy(
+      ${this.#handles(step)} ${this.#arguments(step)} ${stepPolicyView(
         step,
       )} ${this.#disclosure(step)}
       <div class="pane">

--- a/packages/cf-harness/test/console/felt.config.test.ts
+++ b/packages/cf-harness/test/console/felt.config.test.ts
@@ -1,0 +1,43 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { fromFileUrl, join } from "@std/path";
+import config from "../../console/felt.config.ts";
+
+describe("felt.config", () => {
+  const consoleRoot = fromFileUrl(new URL("../../console", import.meta.url));
+
+  /** Every script a served page asks the browser to load. */
+  const scriptsNamedBy = (page: string): readonly string[] => {
+    const markup = Deno.readTextFileSync(join(consoleRoot, "public", page));
+    return [...markup.matchAll(/<script[^>]+src="([^"]+)"/g)].map((match) =>
+      match[1]
+    );
+  };
+
+  it("emits a bundle for every script the console's pages name", () => {
+    // A page whose script has no entry is served, loads nothing, and shows an
+    // empty body with no error anywhere — so what the markup asks for and what
+    // the build emits are pinned against each other rather than kept in
+    // agreement by hand.
+    const emitted = config.entries.map((entry) => `/${entry.out}.js`);
+
+    for (const page of ["index.html", "live.html"]) {
+      for (const script of scriptsNamedBy(page)) {
+        expect(emitted).toContain(script);
+      }
+    }
+  });
+
+  it("builds each entry from a source file that is there", () => {
+    for (const entry of config.entries) {
+      expect(Deno.statSync(join(consoleRoot, entry.in)).isFile).toBe(true);
+    }
+  });
+
+  it("serves the built pages from the directory the server reads", () => {
+    // `ConsoleServer.#asset` resolves against `dist/`, and the page files come
+    // from `publicDir`; a build writing anywhere else serves nothing.
+    expect(config.outDir).toBe("dist");
+    expect(config.publicDir).toBe("public");
+  });
+});

--- a/packages/cf-harness/test/console/server.test.ts
+++ b/packages/cf-harness/test/console/server.test.ts
@@ -1460,6 +1460,57 @@ describe("console/server", () => {
     });
   });
 
+  describe("the live pane", () => {
+    it("hands the live pane the same token cookie the console page carries", async () => {
+      const response = await server.handle(getRequest("/live/session-1"));
+      await response.body?.cancel();
+
+      const setCookie = response.headers.get("set-cookie") ?? "";
+      expect(setCookie).toMatch(/^cf_harness_console_token=.+/);
+      expect(setCookie).toContain("SameSite=Strict");
+      expect(setCookie).toContain("HttpOnly");
+      expect(setCookie).toContain("Path=/");
+    });
+
+    it("confines the live pane with the page's content security policy", async () => {
+      const response = await server.handle(getRequest("/live/session-1"));
+      await response.body?.cancel();
+
+      const policy = response.headers.get("content-security-policy") ?? "";
+      expect(policy).toContain("default-src 'self'");
+      // The pane is opened at the top level of its own view, never framed.
+      expect(policy).toContain("frame-ancestors 'none'");
+    });
+
+    it("hands that cookie to a pane whose session id the address escaped", async () => {
+      const response = await server.handle(getRequest("/live/session%2F1"));
+      await response.body?.cancel();
+
+      expect(response.headers.get("set-cookie")).toMatch(
+        /^cf_harness_console_token=/,
+      );
+    });
+
+    it("answers 403 for a live pane request naming another host", async () => {
+      const response = await server.handle(
+        getRequest("/live/session-1", { host: "evil.test:8100" }),
+      );
+      await response.body?.cancel();
+
+      expect(response.status).toBe(403);
+    });
+
+    it("answers 404 without a token for a path below the session segment", async () => {
+      const response = await server.handle(
+        getRequest("/live/session-1/turn-1"),
+      );
+      await response.body?.cancel();
+
+      expect(response.status).toBe(404);
+      expect(response.headers.get("set-cookie")).toBeNull();
+    });
+  });
+
   describe("request authorization", () => {
     it("hands the page a strictly same-site token cookie", async () => {
       const response = await server.handle(getRequest("/"));

--- a/packages/cf-harness/test/console/src/live-view.test.ts
+++ b/packages/cf-harness/test/console/src/live-view.test.ts
@@ -1,0 +1,1530 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { join } from "@std/path";
+import {
+  ConsoleLive,
+  consoleLiveAddress,
+  consoleLiveAtTail,
+  consoleLiveEntries,
+  type ConsoleLiveEntry,
+  consoleLivePieceHref,
+  consoleLiveRunReads,
+  consoleLiveState,
+  consoleLiveToolLine,
+  stepWithheldAnything,
+} from "../../../console/src/live-view.ts";
+import "../../../console/src/live.ts";
+import { readConsoleRun } from "../../../console/run-store.ts";
+import type { ConsoleRunDetail } from "../../../console/run-store.ts";
+import type {
+  ConsoleChatEventEnvelope,
+  ConsoleChatStructuredEvent,
+} from "../../../console/turn-result.ts";
+import type { ConsoleStep } from "../../../console/steps.ts";
+import {
+  HARNESS_CHAT_EVENT_TYPE,
+  HARNESS_CHAT_PROTOCOL_VERSION,
+} from "../../../src/contracts/interactive-chat.ts";
+
+describe("console/src/live-view", () => {
+  const templateText = (value: unknown): string => {
+    if (value === null || value === undefined) return "";
+    if (typeof value === "string" || typeof value === "number") {
+      return String(value);
+    }
+    if (Array.isArray(value)) return value.map(templateText).join("");
+    if (typeof value !== "object") return "";
+    const template = value as {
+      strings?: readonly string[];
+      values?: readonly unknown[];
+    };
+    return (template.strings ?? []).map((part, index) =>
+      part + templateText(template.values?.[index])
+    ).join("");
+  };
+
+  /** The log a page reads, numbered in the order the events were emitted. */
+  const log = (
+    ...events: readonly (
+      | ConsoleChatStructuredEvent
+      | { turnId: string; event: ConsoleChatStructuredEvent }
+    )[]
+  ): readonly ConsoleChatEventEnvelope[] =>
+    events.map((entry, index) => {
+      const tagged = "event" in entry
+        ? entry
+        : { turnId: "turn-1", event: entry };
+      return {
+        type: HARNESS_CHAT_EVENT_TYPE,
+        protocolVersion: HARNESS_CHAT_PROTOCOL_VERSION,
+        sessionId: "session-1",
+        turnId: tagged.turnId,
+        sequence: index + 1,
+        emittedAt: "2026-01-01T00:00:00.000Z",
+        event: tagged.event,
+      };
+    });
+
+  /** A turn that ended having named one piece, in the space it built it in. */
+  const COMPLETED_WITH_PIECE: ConsoleChatStructuredEvent = {
+    kind: "turn_completed",
+    turnId: "turn-1",
+    result: {
+      pieces: [{
+        slug: "reading-list",
+        url: "http://localhost:8000/my-space/reading-list",
+      }],
+      spaceName: "my-space",
+      finalText: "built it",
+    },
+  };
+
+  /** The result a completed turn carries when it named no piece. */
+  const EMPTY_RESULT = {
+    pieces: [],
+    spaceName: "console-test",
+    finalText: "",
+  };
+
+  const turnStarted: ConsoleChatStructuredEvent = {
+    kind: "turn_started",
+    turn: {
+      turnId: "turn-1",
+      status: "running",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    },
+  };
+
+  const toolStarted = (
+    toolCallId: string,
+    toolId: string,
+  ): ConsoleChatStructuredEvent => ({
+    kind: "tool_started",
+    tool: { toolCallId, toolId },
+  });
+
+  const toolCompleted = (
+    toolCallId: string,
+    toolId: string,
+    resultSummary?: string,
+  ): ConsoleChatStructuredEvent => ({
+    kind: "tool_completed",
+    tool: { toolCallId, toolId },
+    status: "completed",
+    ...(resultSummary === undefined ? {} : { resultSummary }),
+  });
+
+  const toolEntry = (
+    entries: readonly ConsoleLiveEntry[],
+    toolCallId: string,
+  ): Extract<ConsoleLiveEntry, { kind: "tool" }> => {
+    const entry = entries.find((candidate) =>
+      candidate.kind === "tool" && candidate.toolCallId === toolCallId
+    );
+    if (entry === undefined || entry.kind !== "tool") {
+      throw new Error(`no tool entry for ${toolCallId}`);
+    }
+    return entry;
+  };
+
+  describe("the page's entry point", () => {
+    it("registers the element the live page's markup names", () => {
+      // `live.ts` is what the built script runs, and registering the element
+      // is the whole of what it does; an unregistered `<console-live>` is an
+      // empty pane with no error anywhere.
+      expect(customElements.get("console-live")).toBe(ConsoleLive);
+    });
+  });
+
+  describe("consoleLiveAddress()", () => {
+    it("returns the session the live address names", () => {
+      expect(consoleLiveAddress("/live/session-1")).toEqual({
+        sessionId: "session-1",
+      });
+    });
+
+    it("returns the session named with a trailing slash", () => {
+      expect(consoleLiveAddress("/live/session-1/").sessionId).toBe(
+        "session-1",
+      );
+    });
+
+    it("returns the session id an address escaped, decoded", () => {
+      expect(consoleLiveAddress("/live/session%2F1").sessionId).toBe(
+        "session/1",
+      );
+    });
+
+    it("returns no session for an escape the address got wrong", () => {
+      expect(consoleLiveAddress("/live/session%E0%A4%A")).toEqual({});
+    });
+
+    it("returns no session for a path below the session segment", () => {
+      expect(consoleLiveAddress("/live/session-1/turn-1")).toEqual({});
+    });
+
+    it("returns no session for the console's own page", () => {
+      expect(consoleLiveAddress("/")).toEqual({});
+    });
+
+    it("returns no session for a live address naming none", () => {
+      expect(consoleLiveAddress("/live/")).toEqual({});
+    });
+
+    it("returns the turn a focused address names", () => {
+      expect(consoleLiveAddress("/live/session-1", "?turn=turn-1")).toEqual({
+        sessionId: "session-1",
+        turnId: "turn-1",
+      });
+    });
+
+    it("returns the piece base a host renders pieces at", () => {
+      expect(consoleLiveAddress(
+        "/live/session-1",
+        "?piecesBase=http%3A%2F%2Flocalhost%3A9901%2Fpattern-pane",
+      )).toEqual({
+        sessionId: "session-1",
+        piecesBase: "http://localhost:9901/pattern-pane",
+      });
+    });
+
+    it("returns a piece base without the trailing slash it was given", () => {
+      // The composition adds its own separator, and two would name a path
+      // segment that is not there.
+      expect(
+        consoleLiveAddress(
+          "/live/session-1",
+          "?piecesBase=https%3A%2F%2Fhost.test%2Fpieces%2F%2F",
+        ).piecesBase,
+      ).toBe("https://host.test/pieces");
+    });
+
+    it("refuses a piece base that could run as script", () => {
+      const address = consoleLiveAddress(
+        "/live/session-1",
+        "?piecesBase=javascript%3Aalert(1)",
+      );
+
+      expect(address.piecesBase).toBeUndefined();
+      expect(address.piecesBaseRefused).toBe(true);
+    });
+
+    it("refuses a piece base that names no host", () => {
+      const address = consoleLiveAddress(
+        "/live/session-1",
+        "?piecesBase=%2Fpattern-pane",
+      );
+
+      expect(address.piecesBase).toBeUndefined();
+      expect(address.piecesBaseRefused).toBe(true);
+    });
+
+    it("refuses a piece base on a scheme a link must not carry", () => {
+      expect(
+        consoleLiveAddress("/live/session-1", "?piecesBase=file%3A%2F%2F%2Fetc")
+          .piecesBase,
+      ).toBeUndefined();
+    });
+
+    it("returns no refusal for an address naming no piece base at all", () => {
+      expect(consoleLiveAddress("/live/session-1").piecesBaseRefused)
+        .toBeUndefined();
+    });
+
+    it("returns no turn for a `turn` the address left empty", () => {
+      expect(consoleLiveAddress("/live/session-1", "?turn=")).toEqual({
+        sessionId: "session-1",
+      });
+    });
+  });
+
+  describe("consoleLiveEntries()", () => {
+    it("returns one line per tool call however many events it produced", () => {
+      const entries = consoleLiveEntries(log(
+        turnStarted,
+        toolStarted("call-1", "run_pattern"),
+        { kind: "tool_progress", toolCallId: "call-1", message: "compiling" },
+        toolCompleted("call-1", "run_pattern", '{"status":"ok"}'),
+      ));
+
+      expect(entries.filter((entry) => entry.kind === "tool")).toHaveLength(1);
+      expect(toolEntry(entries, "call-1").status).toBe("completed");
+      expect(toolEntry(entries, "call-1").progress).toBe("compiling");
+    });
+
+    it("returns what a turn already under way did, from the replayed log", () => {
+      // The whole of the backfill: a pane opened mid-turn reads the durable
+      // log from sequence zero, and what it renders is every step that has
+      // already happened rather than only the ones that follow.
+      const entries = consoleLiveEntries(log(
+        turnStarted,
+        toolStarted("call-1", "search_patterns"),
+        toolCompleted("call-1", "search_patterns"),
+        { kind: "assistant_completed", text: "found one" },
+        toolStarted("call-2", "run_pattern"),
+      ));
+
+      expect(entries.map((entry) => entry.kind)).toEqual([
+        "turn",
+        "tool",
+        "assistant",
+        "tool",
+      ]);
+      expect(toolEntry(entries, "call-2").status).toBe("running");
+    });
+
+    it("returns the events out of order in the order they were emitted", () => {
+      const [started, tool] = log(turnStarted, toolStarted("call-1", "x"));
+
+      expect(consoleLiveEntries([tool, started]).map((entry) => entry.kind))
+        .toEqual(["turn", "tool"]);
+    });
+
+    it("returns a line for an event that belongs to no turn", () => {
+      const [envelope] = log(toolStarted("call-1", "read_file"));
+      const sessionWide = { ...envelope, turnId: undefined };
+
+      expect(toolEntry(consoleLiveEntries([sessionWide]), "call-1").turnId)
+        .toBeUndefined();
+    });
+
+    it("returns only the turn a focused feed names", () => {
+      const entries = consoleLiveEntries(
+        log(
+          { turnId: "turn-1", event: toolStarted("call-1", "run_pattern") },
+          { turnId: "turn-2", event: toolStarted("call-2", "assign_slug") },
+        ),
+        "turn-2",
+      );
+
+      expect(entries).toHaveLength(1);
+      expect(toolEntry(entries, "call-2").toolName).toBe("assign_slug");
+    });
+
+    it("returns the whole assistant message the completed event settled", () => {
+      const entries = consoleLiveEntries(log(
+        { kind: "assistant_delta", text: "half a thought" },
+        { kind: "assistant_completed", text: "half a thought" },
+      ));
+
+      expect(entries).toHaveLength(1);
+      expect(entries[0].kind === "assistant" && entries[0].text).toBe(
+        "half a thought",
+      );
+    });
+
+    it("returns the deltas of a message no completed event settled", () => {
+      const entries = consoleLiveEntries(log(
+        { kind: "assistant_delta", text: "half " },
+        { kind: "assistant_delta", text: "a thought" },
+      ));
+
+      expect(entries[0].kind === "assistant" && entries[0].text).toBe(
+        "half a thought",
+      );
+    });
+
+    it("returns the piece links a completed turn handed back", () => {
+      const entries = consoleLiveEntries(log({
+        kind: "turn_completed",
+        turnId: "turn-1",
+        finalText: "built it",
+        result: {
+          pieces: [{ slug: "reading-list", url: "http://localhost:8000/s/r" }],
+          spaceName: "s",
+          finalText: "built it",
+        },
+      }));
+
+      // The final text is the turn's last assistant message, which the feed
+      // already carries, so the closing block is the links and nothing else.
+      expect(entries[0]).toEqual({
+        kind: "ended",
+        key: "1",
+        turnId: "turn-1",
+        status: "completed",
+        pieces: [{ slug: "reading-list", url: "http://localhost:8000/s/r" }],
+        spaceName: "s",
+      });
+    });
+
+    it("returns the error a failed turn reported", () => {
+      const entries = consoleLiveEntries(log({
+        kind: "turn_failed",
+        turnId: "turn-1",
+        error: { code: "internal_error", message: "the sandbox is down" },
+      }));
+
+      expect(entries[0].kind === "ended" && entries[0].text).toBe(
+        "the sandbox is down",
+      );
+    });
+
+    it("returns a line for a call whose start the feed never carried", () => {
+      // A pane that resumed mid-call is handed the completion without the
+      // start, and the step still belongs in the feed.
+      const entries = consoleLiveEntries(log(
+        toolCompleted("call-1", "assign_slug", '{"slug":"reading-list"}'),
+      ));
+
+      expect(entries).toHaveLength(1);
+      expect(toolEntry(entries, "call-1").status).toBe("completed");
+      expect(toolEntry(entries, "call-1").resultSummary).toBe(
+        '{"slug":"reading-list"}',
+      );
+    });
+
+    it("returns the reason a canceled turn gave", () => {
+      const entries = consoleLiveEntries(log({
+        kind: "turn_canceled",
+        turnId: "turn-1",
+        reason: "the operator stopped it",
+      }));
+
+      expect(entries[0]).toEqual({
+        kind: "ended",
+        key: "1",
+        turnId: "turn-1",
+        status: "canceled",
+        text: "the operator stopped it",
+        pieces: [],
+      });
+    });
+
+    it("returns a canceled turn that gave no reason", () => {
+      const entries = consoleLiveEntries(log({
+        kind: "turn_canceled",
+        turnId: "turn-1",
+      }));
+
+      expect(entries[0].kind === "ended" && entries[0].text).toBeUndefined();
+    });
+
+    it("returns the child a delegated call belongs to on its lines", () => {
+      const subagent = {
+        parentToolCallId: "call-1",
+        profile: "pattern-author" as const,
+        childRunId: "turn-1.subagent.1",
+      };
+      const entries = consoleLiveEntries(log(
+        {
+          kind: "tool_started",
+          tool: { toolCallId: "call-2", toolId: "x" },
+          subagent,
+        },
+      ));
+
+      expect(toolEntry(entries, "call-2").subagent).toEqual({
+        parentToolCallId: "call-1",
+        profile: "pattern-author",
+      });
+    });
+
+    it("ignores an event kind the feed draws nothing for", () => {
+      expect(consoleLiveEntries(log({
+        kind: "file_changed",
+        change: { kind: "create", path: "/workspace/a.tsx" },
+      }))).toEqual([]);
+    });
+
+    it("returns a subagent line carrying its profile and its verdict", () => {
+      const subagent = {
+        parentToolCallId: "call-1",
+        profile: "pattern-author" as const,
+        goal: "write the card",
+      };
+      const entries = consoleLiveEntries(log(
+        { kind: "subagent_started", subagent },
+        { kind: "subagent_completed", subagent, status: "failed" },
+      ));
+
+      expect(entries).toEqual([{
+        kind: "subagent",
+        key: "1",
+        turnId: "turn-1",
+        profile: "pattern-author",
+        goal: "write the card",
+        status: "failed",
+      }]);
+    });
+  });
+
+  describe("consoleLiveRunReads()", () => {
+    it("returns the turn's own run for a call that completed", () => {
+      expect(consoleLiveRunReads(
+        log(toolCompleted("call-1", "run_pattern"))[0],
+      )).toEqual(["turn-1"]);
+    });
+
+    it("returns the turn's own run for a turn that completed", () => {
+      expect(consoleLiveRunReads(
+        log({
+          kind: "turn_completed",
+          turnId: "turn-1",
+          result: EMPTY_RESULT,
+        })[0],
+      )).toEqual(["turn-1"]);
+    });
+
+    it("returns the turn's own run for a turn that failed", () => {
+      expect(consoleLiveRunReads(
+        log({
+          kind: "turn_failed",
+          turnId: "turn-1",
+          error: { code: "internal_error", message: "down" },
+        })[0],
+      )).toEqual(["turn-1"]);
+    });
+
+    it("returns the child's run beside the turn's for a delegated call", () => {
+      // The parent's run does not record what a child called, so the child's
+      // own run is what carries the step the feed is about to enrich.
+      expect(consoleLiveRunReads(
+        log({
+          kind: "tool_completed",
+          tool: { toolCallId: "call-2", toolId: "run_pattern" },
+          status: "completed",
+          subagent: {
+            parentToolCallId: "call-1",
+            profile: "pattern-author",
+            childRunId: "turn-1.subagent.1",
+          },
+        })[0],
+      )).toEqual(["turn-1", "turn-1.subagent.1"]);
+    });
+
+    it("returns the child's run when the child reported it on completing", () => {
+      expect(consoleLiveRunReads(
+        log({
+          kind: "subagent_completed",
+          status: "completed",
+          subagent: {
+            parentToolCallId: "call-1",
+            profile: "pattern-author",
+            childRunId: "turn-1.subagent.1",
+          },
+        })[0],
+      )).toEqual(["turn-1.subagent.1"]);
+    });
+
+    it("returns no run for a call that only started", () => {
+      expect(consoleLiveRunReads(log(toolStarted("call-1", "run_pattern"))[0]))
+        .toEqual([]);
+    });
+
+    it("returns no run for a child whose delegation named none", () => {
+      expect(consoleLiveRunReads(
+        log({
+          kind: "subagent_completed",
+          status: "failed",
+          subagent: { parentToolCallId: "call-1", profile: "pattern-author" },
+        })[0],
+      )).toEqual([]);
+    });
+  });
+
+  describe("consoleLivePieceHref()", () => {
+    const piece = { slug: "reading list", url: "http://localhost:8000/s/r" };
+
+    it("returns the address the run recorded when no base is named", () => {
+      expect(consoleLivePieceHref(piece, "my space", undefined)).toBe(
+        "http://localhost:8000/s/r",
+      );
+    });
+
+    it("returns an address under the base a host renders pieces at", () => {
+      expect(consoleLivePieceHref(
+        piece,
+        "my space",
+        "http://localhost:9901/pattern-pane",
+      )).toBe("http://localhost:9901/pattern-pane/my%20space/reading%20list");
+    });
+
+    it("returns the recorded address for a result naming no space", () => {
+      // Without the space there is nothing to compose against, and inventing
+      // one would send the reader to a piece that is not theirs.
+      expect(consoleLivePieceHref(piece, undefined, "http://host.test/p")).toBe(
+        "http://localhost:8000/s/r",
+      );
+    });
+  });
+
+  describe("stepWithheldAnything()", () => {
+    const step = (
+      withheld: ConsoleStep["withheld"],
+      policy?: ConsoleStep["policy"],
+    ): ConsoleStep => ({
+      index: 0,
+      kind: "tool",
+      toolName: "run_pattern",
+      toolCallId: "call-1",
+      handlesIntroduced: [],
+      handlesInScope: [],
+      status: "ok",
+      policyEvents: [],
+      withheld,
+      ...(policy === undefined ? {} : { policy }),
+    });
+
+    it("returns `true` for a release the boundary withheld from", () => {
+      expect(stepWithheldAnything(step({
+        status: "unrecorded",
+        locations: [],
+      }, {
+        decision: "withheld",
+        reasonCodes: ["cfc_release_withheld"],
+      }))).toBe(true);
+    });
+
+    it("returns `true` for a result whose record holds a withheld position", () => {
+      expect(stepWithheldAnything(step({
+        status: "recorded",
+        locations: [{
+          rule: "artifact-only",
+          artifactPath: "/run/output.json",
+          jsonPointer: "/rawValue",
+          available: true,
+        }],
+      }))).toBe(true);
+    });
+
+    it("returns `true` for a record the console could not read", () => {
+      expect(stepWithheldAnything(step({
+        status: "record-unreadable",
+        locations: [],
+      }))).toBe(true);
+    });
+
+    it("returns `true` for a record holding no entry for this result", () => {
+      expect(stepWithheldAnything(step({
+        status: "record-entry-missing",
+        locations: [],
+      }))).toBe(true);
+    });
+
+    it("returns `false` for a result no omission rule applied to", () => {
+      // A narrow pane marks what was held back, not every result that
+      // recorded holding nothing back.
+      expect(stepWithheldAnything(step({ status: "recorded", locations: [] })))
+        .toBe(false);
+    });
+  });
+
+  describe("consoleLiveAtTail()", () => {
+    it("returns `true` for a feed scrolled to its bottom", () => {
+      expect(consoleLiveAtTail({
+        scrollHeight: 1000,
+        scrollTop: 700,
+        clientHeight: 300,
+      })).toBe(true);
+    });
+
+    it("returns `true` for a feed a row's rounding short of its bottom", () => {
+      expect(consoleLiveAtTail({
+        scrollHeight: 1000,
+        scrollTop: 693,
+        clientHeight: 300,
+      })).toBe(true);
+    });
+
+    it("returns `false` for a reader who scrolled up to an earlier step", () => {
+      expect(consoleLiveAtTail({
+        scrollHeight: 1000,
+        scrollTop: 200,
+        clientHeight: 300,
+      })).toBe(false);
+    });
+  });
+
+  describe("consoleLiveState()", () => {
+    it("returns `connecting` for a feed with no events yet", () => {
+      expect(consoleLiveState([])).toBe("connecting");
+    });
+
+    it("returns `working` for a turn that has started and called nothing", () => {
+      expect(consoleLiveState(consoleLiveEntries(log(turnStarted)))).toBe(
+        "working",
+      );
+    });
+
+    it("returns the name of the tool a turn is running", () => {
+      expect(consoleLiveState(consoleLiveEntries(log(
+        turnStarted,
+        toolStarted("call-1", "run_pattern"),
+      )))).toBe("run_pattern");
+    });
+
+    it("returns `working` between one call finishing and the next starting", () => {
+      expect(consoleLiveState(consoleLiveEntries(log(
+        turnStarted,
+        toolStarted("call-1", "run_pattern"),
+        toolCompleted("call-1", "run_pattern"),
+      )))).toBe("working");
+    });
+
+    it("returns `done` for a turn that completed", () => {
+      expect(consoleLiveState(consoleLiveEntries(log(
+        turnStarted,
+        { kind: "turn_completed", turnId: "turn-1", result: EMPTY_RESULT },
+      )))).toBe("done");
+    });
+
+    it("returns `failed` for a turn that failed", () => {
+      expect(consoleLiveState(consoleLiveEntries(log(
+        turnStarted,
+        {
+          kind: "turn_failed",
+          turnId: "turn-1",
+          error: { code: "internal_error", message: "the sandbox is down" },
+        },
+      )))).toBe("failed");
+    });
+
+    it("returns the focused turn's state while a sibling turn runs", () => {
+      // The header is read off the feed, which the address has already
+      // narrowed, so a second turn's progress cannot be reported as this
+      // pane's.
+      const envelopes = log(
+        { turnId: "turn-1", event: turnStarted },
+        {
+          turnId: "turn-1",
+          event: {
+            kind: "turn_completed",
+            turnId: "turn-1",
+            result: EMPTY_RESULT,
+          },
+        },
+        { turnId: "turn-2", event: toolStarted("call-2", "run_pattern") },
+      );
+
+      expect(consoleLiveState(consoleLiveEntries(envelopes, "turn-1"))).toBe(
+        "done",
+      );
+      expect(consoleLiveState(consoleLiveEntries(envelopes))).toBe(
+        "run_pattern",
+      );
+    });
+  });
+
+  describe("consoleLiveToolLine()", () => {
+    const entry = (
+      toolCallId: string,
+      toolName: string,
+      resultSummary?: string,
+    ): Extract<ConsoleLiveEntry, { kind: "tool" }> => ({
+      kind: "tool",
+      key: "1",
+      turnId: "turn-1",
+      toolCallId,
+      toolName,
+      status: "completed",
+      ...(resultSummary === undefined ? {} : { resultSummary }),
+    });
+
+    const detail = (
+      lens: Partial<ConsoleRunDetail["lens"]>,
+    ): ConsoleRunDetail =>
+      ({
+        lens: {
+          patternAttempts: [],
+          searches: [],
+          feedback: [],
+          pieces: [],
+          ...lens,
+        },
+      }) as ConsoleRunDetail;
+
+    it("returns the numbered attempt and the compiler's word for `run_pattern`", () => {
+      expect(consoleLiveToolLine(
+        entry("call-2", "run_pattern"),
+        detail({
+          patternAttempts: [
+            { toolCallId: "call-1", inputNames: [], status: "error" },
+            {
+              toolCallId: "call-2",
+              inputNames: [],
+              status: "error",
+              message: "Type\n  mismatch",
+            },
+          ],
+        }),
+        undefined,
+      )).toBe("attempt 2 · error: Type mismatch");
+    });
+
+    it("returns the slug `assign_slug` registered", () => {
+      expect(consoleLiveToolLine(
+        entry("call-1", "assign_slug"),
+        detail({
+          pieces: [{
+            toolCallId: "call-1",
+            slug: "reading-list",
+            url: "http://localhost:8000/s/reading-list",
+          }],
+        }),
+        undefined,
+      )).toBe("reading-list");
+    });
+
+    it("returns the slug from the result of a call the run has not been read for", () => {
+      expect(consoleLiveToolLine(
+        entry("call-1", "assign_slug", '{"slug":"reading-list"}'),
+        undefined,
+        undefined,
+      )).toBe("reading-list");
+    });
+
+    it("returns `undefined` for a result the tool did not write as JSON", () => {
+      expect(consoleLiveToolLine(
+        entry("call-1", "assign_slug", "the slug is reading-list"),
+        undefined,
+        undefined,
+      )).toBeUndefined();
+    });
+
+    it("returns the query `search_patterns` was given", () => {
+      expect(consoleLiveToolLine(
+        entry("call-1", "search_patterns"),
+        detail({
+          searches: [{ toolCallId: "call-1", query: "reading list", hits: [] }],
+        }),
+        undefined,
+      )).toBe("reading list");
+    });
+
+    it("returns the question `query_docs` asked, from the step's own input", () => {
+      const step: ConsoleStep = {
+        index: 0,
+        kind: "tool",
+        toolName: "query_docs",
+        toolCallId: "call-1",
+        input: { question: "how does\na handler write?" },
+        handlesIntroduced: [],
+        handlesInScope: [],
+        status: "ok",
+        policyEvents: [],
+        withheld: { status: "unrecorded", locations: [] },
+      };
+
+      expect(
+        consoleLiveToolLine(entry("call-1", "query_docs"), undefined, step),
+      )
+        .toBe("how does a handler write?");
+    });
+
+    it("returns `undefined` for a search whose run holds no record of it", () => {
+      expect(consoleLiveToolLine(
+        entry("call-1", "search_patterns"),
+        detail({ searches: [] }),
+        undefined,
+      )).toBeUndefined();
+    });
+
+    it("returns `undefined` for a naming whose result never reached the pane", () => {
+      expect(
+        consoleLiveToolLine(
+          entry("call-1", "assign_slug"),
+          undefined,
+          undefined,
+        ),
+      )
+        .toBeUndefined();
+    });
+
+    it("returns a question elided to the width a line has for it", () => {
+      const step: ConsoleStep = {
+        index: 0,
+        kind: "tool",
+        toolName: "query_docs",
+        toolCallId: "call-1",
+        input: { question: "w".repeat(400) },
+        handlesIntroduced: [],
+        handlesInScope: [],
+        status: "ok",
+        policyEvents: [],
+        withheld: { status: "unrecorded", locations: [] },
+      };
+      const line = consoleLiveToolLine(
+        entry("call-1", "query_docs"),
+        undefined,
+        step,
+      );
+
+      expect(line).toHaveLength(140);
+      expect(line?.endsWith("…")).toBe(true);
+    });
+
+    it("returns `undefined` for a call nothing has been read about yet", () => {
+      expect(
+        consoleLiveToolLine(entry("call-1", "read_file"), undefined, undefined),
+      ).toBeUndefined();
+    });
+  });
+
+  describe("ConsoleLive", () => {
+    // The pane reaches the page through three Web APIs — the address it was
+    // opened at, the event stream, and the fetch its run reads go out on.
+    // Each block below stands one of them up so the lifecycle can be driven
+    // without a browser; what a browser is still needed for is the rendered
+    // DOM, which `updated()` and the scroll handler touch.
+
+    class TestConsoleLive extends ConsoleLive {
+      #detailWrites = 0;
+      #waiting: { target: number; resolve: () => void }[] = [];
+
+      view() {
+        return this.render();
+      }
+
+      /**
+       * A connected pane schedules updates, and committing one needs a DOM to
+       * write into. These tests render by calling `view()` themselves, so the
+       * scheduled commit is dropped rather than run against nothing.
+       */
+      protected override performUpdate(): void {}
+
+      /** Runs what Lit runs once a commit has landed. */
+      commit() {
+        this.updated();
+      }
+
+      /** Hands the reader's scrolling to the feed's own handler. */
+      readerScrolled(feed: FakeFeed) {
+        this.#scrollHandler()({ target: feed } as unknown as Event);
+      }
+
+      /**
+       * The feed's `@scroll` binding, out of the template it is written in.
+       * The handler is private and reachable only from the markup, which is
+       * where the pane wires it, so the test takes the same route the browser
+       * does rather than a seam opened for it.
+       */
+      #scrollHandler(): (event: Event) => void {
+        const handlers = (this.view().values ?? []).filter((value) =>
+          typeof value === "function"
+        );
+        expect(handlers).toHaveLength(1);
+        return handlers[0] as (event: Event) => void;
+      }
+
+      /**
+       * Resolves once `count` run reads have written their detail onto the
+       * pane. A read is started by an event and finishes on its own, so the
+       * test waits on the write itself rather than on a clock.
+       */
+      detailsWritten(count: number): Promise<void> {
+        if (this.#detailWrites >= count) {
+          return Promise.resolve();
+        }
+        return new Promise((resolve) => {
+          this.#waiting.push({ target: count, resolve });
+        });
+      }
+
+      override requestUpdate(
+        name?: PropertyKey,
+        oldValue?: unknown,
+        options?: never,
+      ): void {
+        super.requestUpdate(name, oldValue, options);
+        // The base constructor writes `details` before this subclass's own
+        // fields are installed, and that write is not one a test waits on.
+        if (name !== "details" || !(#detailWrites in this)) {
+          return;
+        }
+        this.#detailWrites += 1;
+        this.#waiting = this.#waiting.filter((waiter) => {
+          if (this.#detailWrites < waiter.target) {
+            return true;
+          }
+          waiter.resolve();
+          return false;
+        });
+      }
+    }
+
+    /**
+     * A run on disk, read back the way the live pane reads one. Going through
+     * the store is what makes the join real: the transcript is what the steps
+     * are built from, and the tool call id is what ties a step to the line the
+     * stream already put in the feed.
+     */
+    const runDetail = async (): Promise<ConsoleRunDetail> => {
+      const artifactRoot = await Deno.makeTempDir({
+        prefix: "cf-harness-console-live-",
+      });
+      try {
+        const root = join(artifactRoot, "turn-1");
+        await Deno.mkdir(root, { recursive: true });
+        await Deno.writeTextFile(
+          join(root, "transcript.json"),
+          JSON.stringify([
+            {
+              role: "assistant",
+              content: "",
+              toolCalls: [{
+                id: "call-1",
+                type: "function",
+                function: {
+                  name: "run_pattern",
+                  arguments: JSON.stringify({ sourceText: "the pattern" }),
+                },
+              }],
+            },
+            {
+              role: "tool",
+              toolCallId: "call-1",
+              toolName: "run_pattern",
+              content: JSON.stringify({ status: "ok" }),
+            },
+          ]),
+        );
+        await Deno.writeTextFile(
+          join(root, "run-state.json"),
+          JSON.stringify({
+            runId: "turn-1",
+            status: "running",
+            createdAt: "2026-01-01T00:00:00.000Z",
+            updatedAt: "2026-01-01T00:00:01.000Z",
+            cfcEnforcementMode: "enforce-explicit",
+            currentDir: "/workspace",
+            toolOutputs: [],
+            policyEvents: [],
+            policyDecisions: [{
+              type: "cf-harness.policy-decision",
+              sequence: 1,
+              runId: "turn-1",
+              at: "2026-01-01T00:00:01.000Z",
+              toolActivitySequence: 1,
+              toolCallId: "call-1",
+              toolId: "run_pattern",
+              cfcEnforcementMode: "enforce-explicit",
+              decision: "denied",
+              reasonCodes: ["cfc_release_withheld"],
+              release: {
+                reasonCode: "cfc_release_withheld",
+                boundary: "release",
+                sink: "run_pattern",
+                ceiling: [],
+              },
+            }],
+          }),
+        );
+        const detail = await readConsoleRun(artifactRoot, "turn-1");
+        if (detail === undefined) {
+          throw new Error("the written run was not readable");
+        }
+        return detail;
+      } finally {
+        await Deno.remove(artifactRoot, { recursive: true });
+      }
+    };
+
+    /** One `EventSource` the test drives instead of a server. */
+    class FakeEventSource {
+      static readonly CLOSED = 2;
+      static opened: FakeEventSource[] = [];
+      readyState = 0;
+      closed = false;
+      readonly listeners = new Map<string, (event: unknown) => void>();
+
+      constructor(readonly url: string) {
+        FakeEventSource.opened.push(this);
+      }
+
+      addEventListener(kind: string, listener: (event: unknown) => void) {
+        this.listeners.set(kind, listener);
+      }
+
+      close() {
+        this.closed = true;
+      }
+
+      /** Delivers one envelope the way the server's `chat` frame does. */
+      deliver(envelope: ConsoleChatEventEnvelope) {
+        this.listeners.get("chat")?.({ data: JSON.stringify(envelope) });
+      }
+
+      fail(readyState: number) {
+        this.readyState = readyState;
+        this.listeners.get("error")?.({});
+      }
+    }
+
+    /** Stands up the address, the stream and the fetch, and takes them down. */
+    const paneAt = (
+      pathname: string,
+      search = "",
+      runs: Record<string, unknown> = {},
+    ): { view: TestConsoleLive; stop: () => void } => {
+      const realEventSource = globalThis.EventSource;
+      const realFetch = globalThis.fetch;
+      const realLocation = Object.getOwnPropertyDescriptor(
+        globalThis,
+        "location",
+      );
+      FakeEventSource.opened = [];
+      Object.defineProperty(globalThis, "location", {
+        value: { pathname, search },
+        configurable: true,
+      });
+      // deno-lint-ignore no-explicit-any
+      globalThis.EventSource = FakeEventSource as any;
+      globalThis.fetch = (input: string | URL | Request) => {
+        const runId = String(input).replace("/api/runs/", "");
+        const held = runs[runId];
+        return Promise.resolve(
+          held === undefined
+            ? new Response("not found", { status: 404 })
+            : Response.json(held),
+        );
+      };
+      const view = new TestConsoleLive();
+      view.connectedCallback();
+      return {
+        view,
+        stop: () => {
+          view.disconnectedCallback();
+          globalThis.EventSource = realEventSource;
+          globalThis.fetch = realFetch;
+          if (realLocation === undefined) {
+            Reflect.deleteProperty(globalThis, "location");
+          } else {
+            Object.defineProperty(globalThis, "location", realLocation);
+          }
+        },
+      };
+    };
+
+    /** A scroller, as much of one as the pane reads and writes. */
+    class FakeFeed {
+      scrolledTo: number | undefined;
+
+      constructor(
+        readonly scrollHeight: number,
+        public scrollTop: number,
+        readonly clientHeight: number,
+      ) {}
+
+      scrollTo(options: { top: number }) {
+        this.scrolledTo = options.top;
+      }
+    }
+
+    /** A pane whose feed element is the one handed in. */
+    const paneShowing = (feed: FakeFeed): TestConsoleLive => {
+      const view = new TestConsoleLive();
+      Object.defineProperty(view, "querySelector", { value: () => feed });
+      return view;
+    };
+
+    it("scrolls a feed that is following the tail to the newest step", () => {
+      const feed = new FakeFeed(1000, 700, 300);
+      paneShowing(feed).commit();
+
+      expect(feed.scrolledTo).toBe(1000);
+    });
+
+    it("leaves a feed alone once the reader has scrolled up from the tail", () => {
+      // The whole point of the pin: a reader holding an earlier step in view
+      // must not be dragged to the bottom by the next event that arrives.
+      const feed = new FakeFeed(1000, 200, 300);
+      const view = paneShowing(feed);
+      view.readerScrolled(feed);
+      view.commit();
+
+      expect(feed.scrolledTo).toBeUndefined();
+    });
+
+    it("follows the tail again once the reader scrolls back to it", () => {
+      const feed = new FakeFeed(1000, 200, 300);
+      const view = paneShowing(feed);
+      view.readerScrolled(feed);
+      feed.scrollTop = 700;
+      view.readerScrolled(feed);
+      view.commit();
+
+      expect(feed.scrolledTo).toBe(1000);
+    });
+
+    it("subscribes to the session its address names, from the first event", () => {
+      const { view, stop } = paneAt("/live/session-1");
+      try {
+        expect(view.sessionId).toBe("session-1");
+        expect(FakeEventSource.opened).toHaveLength(1);
+        expect(FakeEventSource.opened[0].url).toBe(
+          "/api/events?sessionId=session-1&afterSequence=0",
+        );
+      } finally {
+        stop();
+      }
+    });
+
+    it("narrows to the turn its address focuses", () => {
+      const { view, stop } = paneAt("/live/session-1", "?turn=turn-9");
+      try {
+        expect(view.turnId).toBe("turn-9");
+      } finally {
+        stop();
+      }
+    });
+
+    it("opens no stream for an address that names no session", () => {
+      const { view, stop } = paneAt("/console");
+      try {
+        expect(FakeEventSource.opened).toHaveLength(0);
+        expect(view.state).toBe("no session");
+        expect(view.error).toBe("This address names no session.");
+      } finally {
+        stop();
+      }
+    });
+
+    it("draws the feed and the header from the events the stream delivers", () => {
+      const { view, stop } = paneAt("/live/session-1");
+      try {
+        const [started, tool] = log(
+          turnStarted,
+          toolStarted("call-1", "run_pattern"),
+        );
+        FakeEventSource.opened[0].deliver(started);
+        FakeEventSource.opened[0].deliver(tool);
+
+        expect(view.entries.map((entry) => entry.kind)).toEqual([
+          "turn",
+          "tool",
+        ]);
+        expect(view.state).toBe("run_pattern");
+      } finally {
+        stop();
+      }
+    });
+
+    it("draws an event delivered twice once", () => {
+      // A resumed stream and the live callback both carry the envelopes
+      // emitted while the backfill was in flight.
+      const { view, stop } = paneAt("/live/session-1");
+      try {
+        const [started] = log(turnStarted);
+        FakeEventSource.opened[0].deliver(started);
+        FakeEventSource.opened[0].deliver(started);
+
+        expect(view.entries).toHaveLength(1);
+      } finally {
+        stop();
+      }
+    });
+
+    it("resumes a closed stream from the last event it drew", () => {
+      const { stop } = paneAt("/live/session-1");
+      try {
+        const [started] = log(turnStarted);
+        FakeEventSource.opened[0].deliver(started);
+        FakeEventSource.opened[0].fail(FakeEventSource.CLOSED);
+
+        expect(FakeEventSource.opened).toHaveLength(2);
+        expect(FakeEventSource.opened[1].url).toBe(
+          "/api/events?sessionId=session-1&afterSequence=1",
+        );
+      } finally {
+        stop();
+      }
+    });
+
+    it("holds a stream that reports an error it has not closed over", () => {
+      const { stop } = paneAt("/live/session-1");
+      try {
+        FakeEventSource.opened[0].fail(0);
+
+        expect(FakeEventSource.opened).toHaveLength(1);
+      } finally {
+        stop();
+      }
+    });
+
+    it("closes the stream when the pane goes away", () => {
+      const { stop } = paneAt("/live/session-1");
+      const stream = FakeEventSource.opened[0];
+      stop();
+
+      expect(stream.closed).toBe(true);
+    });
+
+    it("reads the run of a turn whose call completed, and the child's", async () => {
+      const detail = await runDetail();
+      const { view, stop } = paneAt("/live/session-1", "", {
+        "turn-1": detail,
+        "turn-1.subagent.1": detail,
+      });
+      try {
+        const [completed] = log({
+          kind: "tool_completed",
+          tool: { toolCallId: "call-1", toolId: "run_pattern" },
+          status: "completed",
+          subagent: {
+            parentToolCallId: "call-0",
+            profile: "pattern-author",
+            childRunId: "turn-1.subagent.1",
+          },
+        });
+        FakeEventSource.opened[0].deliver(completed);
+        await view.detailsWritten(2);
+
+        expect([...view.details.keys()].sort()).toEqual([
+          "turn-1",
+          "turn-1.subagent.1",
+        ]);
+      } finally {
+        stop();
+      }
+    });
+
+    it("keeps the feed when a run has written no artifacts yet", () => {
+      const { view, stop } = paneAt("/live/session-1");
+      try {
+        const [completed] = log(toolCompleted("call-1", "run_pattern"));
+        FakeEventSource.opened[0].deliver(completed);
+
+        // A 404 is a run that has not written its artifacts yet, not a fault
+        // to report; nothing can reach `details` for it, so there is no write
+        // to wait on and the feed stands on what the stream said.
+        expect(view.details.size).toBe(0);
+        expect(view.error).toBeUndefined();
+        expect(view.entries).toHaveLength(1);
+      } finally {
+        stop();
+      }
+    });
+
+    it("renders a step's CFC line and its withheld marker beside the live line", async () => {
+      const detail = await runDetail();
+      const view = new TestConsoleLive();
+      view.entries = consoleLiveEntries(log(
+        turnStarted,
+        toolStarted("call-1", "run_pattern"),
+        toolCompleted("call-1", "run_pattern", '{"status":"ok"}'),
+      ));
+      view.details = new Map([["turn-1", detail]]);
+
+      const text = templateText(view.view());
+      expect(text).toContain("run_pattern");
+      expect(text).toContain("attempt 1 · ok");
+      // The release held values back and the call itself succeeded, so the
+      // pane says withheld rather than denied — the same reading the console's
+      // own timeline gives the step. The CFC line carries the reason code, and
+      // the omission block beside it is the retrospective's own words.
+      expect(text).toContain("cfc_release_withheld");
+      expect(text).toContain("No omission record exists for this tool result");
+      expect(text).not.toContain("denied");
+    });
+
+    it("renders a turn line, prose, a subagent and the piece link it ended with", () => {
+      const view = new TestConsoleLive();
+      view.entries = consoleLiveEntries(log(
+        turnStarted,
+        {
+          kind: "subagent_started",
+          subagent: {
+            parentToolCallId: "call-1",
+            profile: "pattern-author",
+            goal: "write   the\ncard",
+          },
+        },
+        { kind: "assistant_completed", text: "here is what I did" },
+        {
+          kind: "turn_completed",
+          turnId: "turn-1",
+          result: {
+            pieces: [{
+              slug: "reading-list",
+              url: "http://localhost:8000/s/reading-list",
+            }],
+            spaceName: "s",
+            finalText: "here is what I did",
+          },
+        },
+      ));
+
+      const text = templateText(view.view());
+      expect(text).toContain("task started");
+      expect(text).toContain("pattern-author");
+      // The goal is a model's own wording, so the line it goes on flattens it.
+      expect(text).toContain("write the card");
+      expect(text).toContain("here is what I did");
+      expect(text).toContain("Open");
+      expect(text).toContain("reading-list");
+      expect(text).toContain("completed");
+    });
+
+    it("renders a delegated call and its prose set in from the parent's", () => {
+      const subagent = {
+        parentToolCallId: "call-1",
+        profile: "pattern-author" as const,
+      };
+      const view = new TestConsoleLive();
+      view.entries = consoleLiveEntries(log(
+        {
+          kind: "tool_started",
+          tool: { toolCallId: "call-2", toolId: "run_pattern" },
+          subagent,
+        },
+        { kind: "assistant_completed", text: "the child said this", subagent },
+      ));
+
+      // The rule down the left is what says whose work a line is; without it
+      // a child's calls read as the turn's own.
+      const text = templateText(view.view());
+      expect(text).toContain("live-entry tool child");
+      expect(text).toContain("live-entry said child");
+    });
+
+    it("renders a call that failed as its own outcome", () => {
+      const view = new TestConsoleLive();
+      view.entries = consoleLiveEntries(log(
+        toolStarted("call-1", "run_pattern"),
+        {
+          kind: "tool_completed",
+          tool: { toolCallId: "call-1", toolId: "run_pattern" },
+          status: "failed",
+        },
+      ));
+
+      const text = templateText(view.view());
+      expect(text).toContain("failed");
+      expect(text).toContain("live-dot failed");
+    });
+
+    it("renders the piece link at the address the run recorded", () => {
+      const view = new TestConsoleLive();
+      view.entries = consoleLiveEntries(log(COMPLETED_WITH_PIECE));
+
+      expect(templateText(view.view())).toContain(
+        "http://localhost:8000/my-space/reading-list",
+      );
+    });
+
+    it("renders the piece link under the base the address named", () => {
+      // The whole point of the parameter: a host that renders pieces in its
+      // own pane cannot send a reader to the Fabric API, which answers a pane
+      // with its login gate rather than the piece.
+      const view = new TestConsoleLive();
+      view.piecesBase = "http://localhost:9901/pattern-pane";
+      view.entries = consoleLiveEntries(log(COMPLETED_WITH_PIECE));
+
+      const text = templateText(view.view());
+      expect(text).toContain(
+        "http://localhost:9901/pattern-pane/my-space/reading-list",
+      );
+      expect(text).not.toContain("http://localhost:8000/my-space/reading-list");
+    });
+
+    it("renders why a refused piece base is not being used", () => {
+      const view = new TestConsoleLive();
+      view.piecesBaseRefused = true;
+
+      expect(templateText(view.view())).toContain(
+        "Piece links go to the address the run recorded.",
+      );
+    });
+
+    it("renders the error a failed turn ended with", () => {
+      const view = new TestConsoleLive();
+      view.entries = consoleLiveEntries(log({
+        kind: "turn_failed",
+        turnId: "turn-1",
+        error: { code: "internal_error", message: "the sandbox is down" },
+      }));
+
+      const text = templateText(view.view());
+      expect(text).toContain("failed");
+      expect(text).toContain("the sandbox is down");
+    });
+
+    it("renders the verdict a subagent finished on", () => {
+      const subagent = {
+        parentToolCallId: "call-1",
+        profile: "pattern-author" as const,
+      };
+      const view = new TestConsoleLive();
+      view.entries = consoleLiveEntries(log(
+        { kind: "subagent_started", subagent },
+        { kind: "subagent_completed", subagent, status: "failed" },
+      ));
+
+      const text = templateText(view.view());
+      expect(text).toContain("pattern-author");
+      expect(text).toContain("failed");
+    });
+
+    it("renders a subagent that finished its work", () => {
+      const subagent = {
+        parentToolCallId: "call-1",
+        profile: "pattern-author" as const,
+      };
+      const view = new TestConsoleLive();
+      view.entries = consoleLiveEntries(log(
+        { kind: "subagent_started", subagent },
+        { kind: "subagent_completed", subagent, status: "completed" },
+      ));
+
+      expect(templateText(view.view())).toContain("completed");
+    });
+
+    it("renders a running subagent without a verdict", () => {
+      const view = new TestConsoleLive();
+      view.entries = consoleLiveEntries(log({
+        kind: "subagent_started",
+        subagent: { parentToolCallId: "call-1", profile: "pattern-author" },
+      }));
+
+      const text = templateText(view.view());
+      expect(text).toContain("pattern-author");
+      expect(text).not.toContain("completed");
+    });
+
+    it("renders the progress a running call reported", () => {
+      const view = new TestConsoleLive();
+      view.entries = consoleLiveEntries(log(
+        toolStarted("call-1", "bash"),
+        { kind: "tool_progress", toolCallId: "call-1", message: "compiling" },
+      ));
+
+      expect(templateText(view.view())).toContain("compiling");
+    });
+
+    it("renders an address that names no session as the reason it shows nothing", () => {
+      const view = new TestConsoleLive();
+      view.error = "This address names no session.";
+
+      const text = templateText(view.view());
+      expect(text).toContain("This address names no session.");
+      expect(text).not.toContain("Waiting for the first step");
+    });
+
+    it("renders a session whose first step has not arrived", () => {
+      expect(templateText(new TestConsoleLive().view())).toContain(
+        "Waiting for the first step",
+      );
+    });
+
+    it("renders the chip that says the pane is narrowed to one turn", () => {
+      const view = new TestConsoleLive();
+      view.turnId = "turn-1";
+
+      expect(templateText(view.view())).toContain("one turn");
+    });
+
+    it("renders a tool line with no run read for it yet", () => {
+      const view = new TestConsoleLive();
+      view.entries = consoleLiveEntries(log(
+        turnStarted,
+        toolStarted("call-1", "run_pattern"),
+      ));
+
+      const text = templateText(view.view());
+      expect(text).toContain("run_pattern");
+      expect(text).not.toContain("withheld");
+    });
+  });
+});

--- a/packages/cf-harness/test/console/src/steps-view.test.ts
+++ b/packages/cf-harness/test/console/src/steps-view.test.ts
@@ -1,8 +1,10 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { nothing } from "lit";
 import {
   clampSelection,
   ConsoleSteps,
+  stepPolicyView,
   withheldSummary,
   withheldView,
 } from "../../../console/src/steps-view.ts";
@@ -46,6 +48,38 @@ describe("console/src/steps-view", () => {
 
     it("answers zero for a step before the first", () => {
       expect(clampSelection(-1, 9)).toBe(0);
+    });
+  });
+
+  describe("stepPolicyView", () => {
+    const step = (policy?: ConsoleStep["policy"]): ConsoleStep => ({
+      index: 1,
+      kind: "tool",
+      toolName: "read_file",
+      handlesIntroduced: [],
+      handlesInScope: [],
+      status: "ok",
+      policyEvents: [],
+      withheld: { status: "recorded", locations: [] },
+      ...(policy === undefined ? {} : { policy }),
+    });
+
+    it("renders nothing for a step whose run recorded no CFC decision", () => {
+      // A step with no decision, no event and no labels has no CFC pane to
+      // draw, and an empty one would read as a decision that was not made.
+      expect(stepPolicyView(step())).toBe(nothing);
+    });
+
+    it("renders the decision and its reasons for a step that carries one", () => {
+      const text = templateText(stepPolicyView(step({
+        decision: "allowed",
+        effectClass: "side-effect",
+        reasonCodes: ["cfc_enforce_explicit_direct_command"],
+      })));
+
+      expect(text).toContain("allowed");
+      expect(text).toContain("side-effect");
+      expect(text).toContain("cfc_enforce_explicit_direct_command");
     });
   });
 


### PR DESCRIPTION
`GET /live/<sessionId>` on the console — optionally `?turn=<turnId>` — is a
chrome-free column showing one session's work as it happens, for a host that can
show a task running beside the thing that asked for it and can only open a plain
web address. Loom opens it in a task panel while a `/cf-harness` turn runs, until
the piece the turn built replaces it.

## The route

Served from the same felt build as the console page and handed the same
per-process token cookie, so its own script reaches `/api` on this origin and
nothing else does. It joins the asset allowlist rather than growing the API:
nothing new on `/api`. The `Host` gate covers it like every other route, and the
content security policy that keeps the console page out of a frame keeps this
one out too — the pane is opened at the top level of a view, never framed.

## What it shows

The event stream is the source, read from sequence zero, so a pane opened halfway
through a turn shows the steps that already happened rather than only the ones
that follow; a reconnect resumes from the last event rendered. Nothing polls.

What the stream carries is the order and the outcome. What a call was given, what
CFC decided about it, and what it withheld from the model come from the run's own
artifacts, re-read when one of its tool calls completes — the turn's run, whose id
is the turn id, and a `delegate_task` child's run, whose calls its parent's run
does not record. The two readings join by tool call id.

Each step is one line: the tool, how it ended, and what it was about — the
numbered `run_pattern` attempt and the compiler's word on it, the slug
`assign_slug` registered, a search's query, the question `query_docs` asked. Under
it sits the console timeline's own CFC line, lifted out of the step scrubber as
`stepPolicyView` so both surfaces draw one, and the same omission block for a
result that held anything back. A completed turn ends the pane with the piece
link.

## The URL contract

```
GET /live/<sessionId>
GET /live/<sessionId>?turn=<turnId>
GET /live/<sessionId>?piecesBase=<url-prefix>
```

`?turn=<turnId>` narrows the pane to one turn; without it the pane shows the
session's activity in order.

`?piecesBase=<url-prefix>` says where the host renders a piece. A piece's own
address is the one `assign_slug` recorded, which is the Fabric API's — and a
host that shows pieces in a pane of its own gets that API's login gate rather
than the piece. With the prefix named, every piece link on the page is composed
as `<piecesBase>/<encodeURIComponent(space)>/<encodeURIComponent(slug)>` from
the space and slug the turn's result carries; without it, the recorded URL is
used verbatim rather than rebuilt. The prefix has to be an absolute `http` or
`https` URL — it arrives from whatever opened the page and ends up in an
`href` — so a `javascript:` URL or a relative path is refused, the page says
so, and the links stay on the recorded address. The console composes against a
prefix it is handed and knows nothing about the host that handed it over.

Verified against the running console, all five cases:

| address | piece link |
| --- | --- |
| no parameter | `http://localhost:8001/ben-loom-dev-6/tiny-hello-card` |
| `piecesBase=http://localhost:9901/pattern-pane` | `http://localhost:9901/pattern-pane/ben-loom-dev-6/tiny-hello-card` |
| the same with a trailing slash | the same, with no doubled separator |
| `piecesBase=javascript:alert(1)` | refused; recorded address, and the page says why |
| `piecesBase=/pattern-pane` | refused; recorded address, and the page says why |

## The one-line `.gitignore` widening

`.gitignore` matched `.cf-harness-console/` exactly, so a console directory with
any suffix was untracked but **not** ignored. The workaround for CT-2156 —
concurrent consoles corrupting a shared `CF_HARNESS_CONSOLE_DIR` — is to give
each console its own directory, so the recommended practice walked operators
straight into committing run artifacts and a `sessions.sqlite`. Verifying this PR
I did exactly that, and caught 10,248 lines of run state in a push. Widened to
`.cf-harness-console*/`, which also covers the demo console's directory.

## Coverage

The gate caught 157 uncovered lines this branch added. They are covered rather
than accepted, and the shape of the fix follows `COVERAGE.md`'s own guidance —
policy and state transitions moved out of the element into ordinary modules and
exercised from plain Deno tests: `consoleLiveAddress`, `consoleLiveRunReads` and
`consoleLiveAtTail`. Rendering is covered by rendering every entry kind; the
stream lifecycle by a fake `EventSource` and a stubbed fetch, which pins the
resume contract — the reconnect asks from the last sequence drawn, an envelope
delivered twice draws once, and a stream reporting an error it has not closed
over is not resubscribed. Two branches were removed rather than covered, both
unreachable: the empty-session-id arm of the address parse (the path segment is
`[^/]+`, and decoding never returns fewer characters), and `?? ""` in
`#subscribe`, which now takes the session id as a parameter so the invariant is
in the signature. `live-view.ts`, `live.ts` and `felt.config.ts` are at 100% of
lines, branches and functions.

## Verified live

Against the demo console's fabric env (space `ben-loom-dev-6`) on a spare port
with its own console directory. Real tasks: the steps appeared as they happened,
the questions and numbered attempts filled in from the runs, the CFC lines and
`withheld from the model · N` markers rendered, and the piece link appeared at the
end. Reloading a finished session reproduced the whole feed from the durable log.
Checked at a 400px pane width in light and dark.

Linear-issue: CT-2234

🤖 Generated with [Claude Code](https://claude.com/claude-code)
