### PR TITLE
fix(integration): a temporary identity removes its own keyfile

### DIFF
--- a/packages/cf-harness/integration/fabric-session-posture-gate.test.ts
+++ b/packages/cf-harness/integration/fabric-session-posture-gate.test.ts
@@ -49,59 +49,34 @@ describe(
         SERVER_EXECUTION_DEFAULT_ENABLED,
       );
 
-      // The keyfile's path is tracked OUTSIDE the session setup: the outer
-      // `finally` below owns it, so it is removed even when session
-      // construction throws before the inner `try` begins.
-      let identityKeyPath: string | undefined;
+      await using tempIdentity = await writeTempIdentity();
+      const factory = createHarnessFabricSessionFactory({
+        apiUrl: API_URL!,
+        identityKeyPath: tempIdentity.path,
+        space: `cf-harness-posture-gate-${Date.now()}`,
+      });
+      const session = await factory();
       try {
-        const { path } = await writeTempIdentity();
-        identityKeyPath = path;
-        const factory = createHarnessFabricSessionFactory({
-          apiUrl: API_URL!,
-          identityKeyPath: path,
-          space: `cf-harness-posture-gate-${Date.now()}`,
-        });
-        const session = await factory();
-        try {
-          // The client half: the session's runtime resolved the posture from the
-          // deployment with nothing declared locally.
-          expect(session.pieces.runtime.experimental.serverExecution).toBe(
-            SERVER_EXECUTION_DEFAULT_ENABLED,
-          );
+        // The client half: the session's runtime resolved the posture from the
+        // deployment with nothing declared locally.
+        expect(session.pieces.runtime.experimental.serverExecution).toBe(
+          SERVER_EXECUTION_DEFAULT_ENABLED,
+        );
 
-          // One genuine flow through the session: compile + instantiate a
-          // pattern and read its result back through the serving topology.
-          const piece = await session.pieces.create(GATE_PATTERN);
-          const statusCell = (await piece.result.getCell())
-            .asSchema<{ status?: string }>()
-            .key("status");
-          await statusCell.pull();
-          await waitForCellValue<string>(
-            session.pieces.runtime,
-            statusCell,
-            (value) => value === "serving",
-          );
-        } finally {
-          await session.pieces.dispose();
-        }
+        // One genuine flow through the session: compile + instantiate a
+        // pattern and read its result back through the serving topology.
+        const piece = await session.pieces.create(GATE_PATTERN);
+        const statusCell = (await piece.result.getCell())
+          .asSchema<{ status?: string }>()
+          .key("status");
+        await statusCell.pull();
+        await waitForCellValue<string>(
+          session.pieces.runtime,
+          statusCell,
+          (value) => value === "serving",
+        );
       } finally {
-        // `writeTempIdentity`'s own contract: "The caller owns the file and
-        // removes it when done" — otherwise every run leaves a PKCS#8
-        // identity in the system temp dir.
-        const created = identityKeyPath;
-        if (created !== undefined) {
-          await Deno.remove(created).catch((error: unknown) => {
-            // Already gone is the goal state. Anything else is REPORTED,
-            // never thrown: a cleanup throw here would replace the gate's
-            // own failure with a temp-file error.
-            if (!(error instanceof Deno.errors.NotFound)) {
-              console.warn(
-                `cf-harness posture gate: could not remove the temporary ` +
-                  `identity keyfile ${created}: ${error}`,
-              );
-            }
-          });
-        }
+        await session.pieces.dispose();
       }
     });
   },

--- a/packages/cli/test/piece-integration.test.ts
+++ b/packages/cli/test/piece-integration.test.ts
@@ -14,7 +14,10 @@ import { resolve } from "@std/path";
 import type { Identity } from "@commonfabric/identity";
 import { experimentalOptionsForDeployedClient } from "@commonfabric/runner";
 import { PiecesController } from "@commonfabric/piece/ops";
-import { writeTempIdentity } from "@commonfabric/integration/temp-identity";
+import {
+  type TempIdentity,
+  writeTempIdentity,
+} from "@commonfabric/integration/temp-identity";
 import { waitForCellValue } from "@commonfabric/integration/wait-for-cell-value";
 import {
   callPieceHandler,
@@ -51,6 +54,7 @@ let staleSessionResultPieceId = "";
 let sessionScopedPieceId = "";
 let flags = "";
 let identityPath = "";
+let tempIdentity: TempIdentity | undefined;
 let spaceConfig: SpaceConfig;
 // The server-execution arm `cf` itself runs at (server-execution v2,
 // testing.md §2): resolved exactly as the cf binary resolves it — the
@@ -96,7 +100,8 @@ describe("cf cell get (integration)", { ignore: !API_URL }, () => {
       apiUrl: new URL(API_URL!),
       env: Deno.env.get,
     })).serverExecution === true;
-    const { identity, path } = await writeTempIdentity();
+    tempIdentity = await writeTempIdentity();
+    const { identity, path } = tempIdentity;
     identityPath = path;
     const spaceName = `cf-piece-get-test-${Date.now()}`;
     spaceConfig = {
@@ -142,9 +147,7 @@ describe("cf cell get (integration)", { ignore: !API_URL }, () => {
   afterAll(async () => {
     // Ephemeral space names ensure isolation; only the throwaway identity
     // keyfile needs removing.
-    if (identityPath) {
-      await Deno.remove(identityPath);
-    }
+    await tempIdentity?.remove();
   });
 
   it("bad path exits 1 with Available keys: in output", async () => {

--- a/packages/integration/temp-identity.ts
+++ b/packages/integration/temp-identity.ts
@@ -1,27 +1,72 @@
 import { Identity, type IdentityCreateConfig } from "@commonfabric/identity";
 
-export interface TempIdentity {
+/**
+ * The prefix every temporary identity keyfile's name carries. A file left
+ * behind by a process that was killed has nothing but its name to say what
+ * wrote it.
+ */
+export const IDENTITY_KEYFILE_PREFIX = "cf-test-identity-";
+
+/**
+ * A generated identity together with the temporary PKCS8 keyfile holding it.
+ *
+ * The keyfile stays on disk until {@linkcode TempIdentity.remove} runs, so a
+ * caller holds this for as long as it wants the keyfile. `await using` calls
+ * that when the binding leaves scope; a holder outliving one scope — a
+ * `beforeAll` storing it for an `afterAll` — calls it directly.
+ */
+export interface TempIdentity extends AsyncDisposable {
   /** The identity, for in-process use. */
-  identity: Identity;
+  readonly identity: Identity;
 
   /** Path to the PKCS8 keyfile, for a spawned CLI's `--identity` flag. */
-  path: string;
+  readonly path: string;
+
+  /**
+   * Removes the keyfile. A keyfile already gone is the goal state, so a
+   * repeat call succeeds and removes nothing. A removal failing for any
+   * other reason is reported on the console.
+   */
+  remove(): Promise<void>;
 }
 
 /**
  * Generates a fresh identity and writes its PKCS8 keyfile to a temporary
  * file, giving a test both the in-process identity and a keyfile path that a
  * spawned CLI can load. The keyfile parses through the same
- * `Identity.fromPkcs8` path the CLI's `--identity` loading uses. The caller
- * owns the file and removes it when done. Callers that serialize the
- * identity (for example shell login) need `{ implementation: "noble" }`.
+ * `Identity.fromPkcs8` path the CLI's `--identity` loading uses. Callers that
+ * serialize the identity (for example shell login) need
+ * `{ implementation: "noble" }`.
+ *
+ * The result owns the keyfile:
+ *
+ * ```ts
+ * await using temp = await writeTempIdentity();
+ * ```
  */
 export async function writeTempIdentity(
   config: IdentityCreateConfig = {},
 ): Promise<TempIdentity> {
   const pkcs8 = await Identity.generatePkcs8();
   const identity = await Identity.fromPkcs8(pkcs8, config);
-  const path = await Deno.makeTempFile({ prefix: "cf-test-identity-" });
-  await Deno.writeFile(path, pkcs8);
-  return { identity, path };
+  const path = await Deno.makeTempFile({ prefix: IDENTITY_KEYFILE_PREFIX });
+  const remove = async (): Promise<void> => {
+    try {
+      await Deno.remove(path);
+    } catch (error) {
+      // Disposal runs while a test is failing, and a throw from it reaches
+      // the reporter as a `SuppressedError` carrying neither message, so a
+      // removal failure is reported here instead.
+      if (!(error instanceof Deno.errors.NotFound)) {
+        console.warn(`Could not remove the keyfile ${path}: ${error}`);
+      }
+    }
+  };
+  try {
+    await Deno.writeFile(path, pkcs8);
+  } catch (error) {
+    await remove();
+    throw error;
+  }
+  return { identity, path, remove, [Symbol.asyncDispose]: remove };
 }

--- a/packages/integration/test/temp-identity.test.ts
+++ b/packages/integration/test/temp-identity.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { stub } from "@std/testing/mock";
+import { basename } from "@std/path";
+
+import { Identity } from "@commonfabric/identity";
+
+import {
+  IDENTITY_KEYFILE_PREFIX,
+  writeTempIdentity,
+} from "../temp-identity.ts";
+
+describe("temp-identity", () => {
+  // Every test runs against a temporary root of its own, which makes "what
+  // this left behind" the entire content of one directory rather than a
+  // search through the machine's shared one. `Deno.makeTempFile` reads
+  // `TMPDIR` on each call, so redirecting it reaches the keyfile.
+
+  let tempRoot = "";
+  let outerTempDir: string | undefined;
+
+  beforeEach(async () => {
+    tempRoot = await Deno.makeTempDir({ prefix: "temp-identity-test-" });
+    outerTempDir = Deno.env.get("TMPDIR");
+    Deno.env.set("TMPDIR", tempRoot);
+  });
+
+  afterEach(async () => {
+    if (outerTempDir === undefined) {
+      Deno.env.delete("TMPDIR");
+    } else {
+      Deno.env.set("TMPDIR", outerTempDir);
+    }
+    await Deno.remove(tempRoot, { recursive: true });
+  });
+
+  const namesUnderTempRoot = async (): Promise<string[]> => {
+    const names: string[] = [];
+    for await (const entry of Deno.readDir(tempRoot)) names.push(entry.name);
+    return names.sort();
+  };
+
+  describe("writeTempIdentity()", () => {
+    it("writes a keyfile the identity parses back out of", async () => {
+      await using temp = await writeTempIdentity();
+
+      const reloaded = await Identity.fromPkcs8(await Deno.readFile(temp.path));
+      expect(reloaded.did()).toBe(temp.identity.did());
+    });
+
+    it("names the keyfile after the shared prefix", async () => {
+      await using temp = await writeTempIdentity();
+
+      expect(basename(temp.path).startsWith(IDENTITY_KEYFILE_PREFIX)).toBe(
+        true,
+      );
+    });
+
+    it("leaves the temporary directory empty once the binding goes", async () => {
+      {
+        await using temp = await writeTempIdentity();
+        expect(await namesUnderTempRoot()).toEqual([basename(temp.path)]);
+      }
+
+      expect(await namesUnderTempRoot()).toEqual([]);
+    });
+
+    it("leaves the temporary directory empty after `remove()`", async () => {
+      const temp = await writeTempIdentity();
+      expect(await namesUnderTempRoot()).toEqual([basename(temp.path)]);
+
+      await temp.remove();
+
+      expect(await namesUnderTempRoot()).toEqual([]);
+    });
+
+    it("succeeds on a `remove()` of a keyfile already gone", async () => {
+      await using temp = await writeTempIdentity();
+      expect(await namesUnderTempRoot()).toEqual([basename(temp.path)]);
+
+      await temp.remove();
+      await temp.remove();
+
+      expect(await namesUnderTempRoot()).toEqual([]);
+    });
+
+    it("leaves the temporary directory empty when the write fails", async () => {
+      // The names are read from inside the failing write, where the keyfile
+      // the removal has to reclaim is the one entry under the root.
+      const failure = new Error("no space left on device");
+      let namesWhileWriting: string[] = [];
+      const write = stub(Deno, "writeFile", async () => {
+        namesWhileWriting = await namesUnderTempRoot();
+        throw failure;
+      });
+      try {
+        await expect(writeTempIdentity()).rejects.toThrow(failure);
+      } finally {
+        write.restore();
+      }
+
+      expect(namesWhileWriting.length).toBe(1);
+      expect(await namesUnderTempRoot()).toEqual([]);
+    });
+
+    it("reports a removal that fails and lets the caller carry on", async () => {
+      const temp = await writeTempIdentity();
+      const failure = new Deno.errors.PermissionDenied("read-only file system");
+      const remove = stub(Deno, "remove", () => Promise.reject(failure));
+      const warn = stub(console, "warn", () => {});
+      try {
+        await temp.remove();
+      } finally {
+        remove.restore();
+        warn.restore();
+      }
+
+      expect(warn.calls.length).toBe(1);
+      expect(String(warn.calls[0].args[0])).toContain(temp.path);
+      expect(await namesUnderTempRoot()).toEqual([basename(temp.path)]);
+    });
+  });
+});

--- a/packages/shell/integration/piece-menu.test.ts
+++ b/packages/shell/integration/piece-menu.test.ts
@@ -532,7 +532,10 @@ describe("piece context menu", () => {
     // announcement, the portalled overlay, and the worker read all line up.
 
     const page = shell.page();
-    const { identity } = await writeTempIdentity({ implementation: "noble" });
+    await using tempIdentity = await writeTempIdentity({
+      implementation: "noble",
+    });
+    const { identity } = tempIdentity;
 
     await shell.goto({
       frontendUrl: FRONTEND_URL,
@@ -658,198 +661,195 @@ describe("piece context menu", () => {
   it("targets and highlights the innermost nested piece", async () => {
     const page = shell.page();
     const slug = `nested-piece-menu-${crypto.randomUUID()}`;
-    const { identity, path: identityPath } = await writeTempIdentity({
+    await using tempIdentity = await writeTempIdentity({
       implementation: "noble",
     });
+    const { identity, path: identityPath } = tempIdentity;
 
-    try {
-      await createNestedPiece(identityPath, slug);
-      await shell.goto({
-        frontendUrl: FRONTEND_URL,
-        view: { spaceName: SPACE_NAME, pieceSlug: slug },
-        identity,
-      });
-      await waitForCondition(
-        page,
-        (probe) => probe.collect("#inner-piece-button").length === 1,
+    await createNestedPiece(identityPath, slug);
+    await shell.goto({
+      frontendUrl: FRONTEND_URL,
+      view: { spaceName: SPACE_NAME, pieceSlug: slug },
+      identity,
+    });
+    await waitForCondition(
+      page,
+      (probe) => probe.collect("#inner-piece-button").length === 1,
+    );
+
+    const result = await page.evaluate(async () => {
+      const rootView = document.querySelector("x-root-view");
+      const appView = rootView?.shadowRoot?.querySelector("x-app-view");
+      const bodyView = appView?.shadowRoot?.querySelector("x-body-view");
+      const render = bodyView?.shadowRoot?.querySelector("cf-render") as
+        | (HTMLElement & {
+          cell?: { id(): string };
+        })
+        | null;
+      const inner = render?.shadowRoot?.querySelector(
+        "#inner-piece-root",
+      ) as HTMLElement | null;
+      const middle = render?.shadowRoot?.querySelector(
+        "#middle-piece-root",
+      ) as HTMLElement | null;
+      const button = render?.shadowRoot?.querySelector(
+        "#inner-piece-button",
       );
-
-      const result = await page.evaluate(async () => {
-        const rootView = document.querySelector("x-root-view");
-        const appView = rootView?.shadowRoot?.querySelector("x-app-view");
-        const bodyView = appView?.shadowRoot?.querySelector("x-body-view");
-        const render = bodyView?.shadowRoot?.querySelector("cf-render") as
-          | (HTMLElement & {
-            cell?: { id(): string };
-          })
-          | null;
-        const inner = render?.shadowRoot?.querySelector(
-          "#inner-piece-root",
-        ) as HTMLElement | null;
-        const middle = render?.shadowRoot?.querySelector(
-          "#middle-piece-root",
-        ) as HTMLElement | null;
-        const button = render?.shadowRoot?.querySelector(
-          "#inner-piece-button",
-        );
-        const clip = render?.shadowRoot?.querySelector(
-          "#nested-piece-clip",
-        ) as HTMLElement | null;
-        if (!render || !inner || !middle || !button || !clip) {
-          throw new Error("nested piece fixture did not render");
-        }
-
-        const measure = (element: Element): MeasuredRect => {
-          const { x, y, width, height } = element.getBoundingClientRect();
-          return { x, y, width, height };
-        };
-        const outerBefore = measure(render);
-        const middleBefore = measure(middle);
-        const innerBefore = measure(inner);
-        const clipBorder = clip.getBoundingClientRect();
-        const clipScaleX = clipBorder.width / clip.offsetWidth;
-        const clipScaleY = clipBorder.height / clip.offsetHeight;
-        const clipBefore = {
-          x: clipBorder.x + clip.clientLeft * clipScaleX,
-          y: clipBorder.y + clip.clientTop * clipScaleY,
-          width: clip.clientWidth * clipScaleX,
-          height: clip.clientHeight * clipScaleY,
-        };
-        let middlePieceId: string | undefined;
-        render.addEventListener("cf-piece-context-menu", (event) => {
-          event.preventDefault();
-          middlePieceId = (event as CustomEvent<{ pieceId: string }>).detail
-            .pieceId;
-        }, { once: true });
-        middle.dispatchEvent(
-          new MouseEvent("contextmenu", {
-            bubbles: true,
-            composed: true,
-            cancelable: true,
-          }),
-        );
-
-        let innerPieceId: string | undefined;
-        render.addEventListener("cf-piece-context-menu", (event) => {
-          event.preventDefault();
-          innerPieceId = (event as CustomEvent<{ pieceId: string }>).detail
-            .pieceId;
-        }, { once: true });
-        inner.dispatchEvent(
-          new MouseEvent("contextmenu", {
-            bubbles: true,
-            composed: true,
-            cancelable: true,
-          }),
-        );
-
-        let announcedPieceId: string | undefined;
-        render.addEventListener("cf-piece-context-menu", (event) => {
-          announcedPieceId = (event as CustomEvent<{ pieceId: string }>).detail
-            .pieceId;
-        }, { once: true });
-
-        button.dispatchEvent(
-          new MouseEvent("contextmenu", {
-            bubbles: true,
-            composed: true,
-            cancelable: true,
-            clientX: innerBefore.x + 4,
-            clientY: innerBefore.y + 4,
-          }),
-        );
-        const menu = document.querySelector("cf-piece-menu") as
-          | (HTMLElement & { updateComplete: Promise<unknown> })
-          | null;
-        if (!menu) throw new Error("nested piece menu did not open");
-        await menu.updateComplete;
-        const overlay = menu.shadowRoot?.querySelector(
-          ".nested-piece-highlight",
-        );
-        if (!overlay) throw new Error("nested highlight did not render");
-        const overlayStyle = getComputedStyle(overlay);
-        const outerAfter = measure(render);
-        const middleAfter = measure(middle);
-        const innerAfter = measure(inner);
-        const overlayBeforeScroll = measure(overlay);
-        clip.scrollLeft = 24;
-        clip.dispatchEvent(new Event("scroll"));
-        await new Promise<void>((resolve) =>
-          requestAnimationFrame(() => resolve())
-        );
-        await menu.updateComplete;
-        const innerAfterScroll = measure(inner);
-        const overlayAfterScroll = measure(overlay);
-
-        return {
-          outerId: render.cell?.id(),
-          middleId: middlePieceId,
-          innerId: innerPieceId,
-          announcedPieceId,
-          outerMarked: render.hasAttribute("data-cf-piece-menu-open"),
-          innerMarked: inner.hasAttribute("data-cf-piece-menu-open"),
-          outerBefore,
-          outerAfter,
-          middleBefore,
-          middleAfter,
-          innerBefore,
-          innerAfter,
-          clipBefore,
-          overlayBeforeScroll,
-          innerAfterScroll,
-          overlayAfterScroll,
-          visual: {
-            position: overlayStyle.position,
-            pointerEvents: overlayStyle.pointerEvents,
-            backgroundImage: overlayStyle.backgroundImage,
-            boxShadow: overlayStyle.boxShadow,
-            animationName: overlayStyle.animationName,
-            animationIterationCount: overlayStyle.animationIterationCount,
-            reducedMotion: matchMedia("(prefers-reduced-motion: reduce)")
-              .matches,
-          },
-        };
-      });
-
-      expect(result.outerId).toBeDefined();
-      expect(result.middleId).toBeDefined();
-      expect(result.innerId).toBeDefined();
-      expect(result.innerId).not.toBe(result.middleId);
-      expect(result.innerId).not.toBe(result.outerId);
-      expect(result.middleId).not.toBe(result.outerId);
-      expect(result.announcedPieceId).toBe(result.innerId);
-      expect(result.outerMarked).toBe(false);
-      expect(result.innerMarked).toBe(false);
-      expect(result.outerAfter).toEqual(result.outerBefore);
-      expect(result.middleAfter).toEqual(result.middleBefore);
-      expect(result.innerAfter).toEqual(result.innerBefore);
-      const visibleRect = (inner: MeasuredRect, clip: MeasuredRect) => {
-        const x = Math.max(inner.x, clip.x);
-        const y = Math.max(inner.y, clip.y);
-        const right = Math.min(inner.x + inner.width, clip.x + clip.width);
-        const bottom = Math.min(inner.y + inner.height, clip.y + clip.height);
-        return { x, y, width: right - x, height: bottom - y };
-      };
-      expect(result.overlayBeforeScroll).toEqual(
-        visibleRect(result.innerBefore, result.clipBefore),
-      );
-      expect(result.overlayAfterScroll).toEqual(
-        visibleRect(result.innerAfterScroll, result.clipBefore),
-      );
-      expect(result.visual.position).toBe("fixed");
-      expect(result.visual.pointerEvents).toBe("none");
-      expect(result.visual.backgroundImage).not.toBe("none");
-      expect(result.visual.boxShadow).not.toBe("none");
-      if (result.visual.reducedMotion) {
-        expect(result.visual.animationName).toBe("none");
-      } else {
-        expect(result.visual.animationName).toBe(
-          "cf-nested-piece-menu-shine",
-        );
-        expect(result.visual.animationIterationCount).toBe("1");
+      const clip = render?.shadowRoot?.querySelector(
+        "#nested-piece-clip",
+      ) as HTMLElement | null;
+      if (!render || !inner || !middle || !button || !clip) {
+        throw new Error("nested piece fixture did not render");
       }
-    } finally {
-      await Deno.remove(identityPath).catch(() => {});
+
+      const measure = (element: Element): MeasuredRect => {
+        const { x, y, width, height } = element.getBoundingClientRect();
+        return { x, y, width, height };
+      };
+      const outerBefore = measure(render);
+      const middleBefore = measure(middle);
+      const innerBefore = measure(inner);
+      const clipBorder = clip.getBoundingClientRect();
+      const clipScaleX = clipBorder.width / clip.offsetWidth;
+      const clipScaleY = clipBorder.height / clip.offsetHeight;
+      const clipBefore = {
+        x: clipBorder.x + clip.clientLeft * clipScaleX,
+        y: clipBorder.y + clip.clientTop * clipScaleY,
+        width: clip.clientWidth * clipScaleX,
+        height: clip.clientHeight * clipScaleY,
+      };
+      let middlePieceId: string | undefined;
+      render.addEventListener("cf-piece-context-menu", (event) => {
+        event.preventDefault();
+        middlePieceId = (event as CustomEvent<{ pieceId: string }>).detail
+          .pieceId;
+      }, { once: true });
+      middle.dispatchEvent(
+        new MouseEvent("contextmenu", {
+          bubbles: true,
+          composed: true,
+          cancelable: true,
+        }),
+      );
+
+      let innerPieceId: string | undefined;
+      render.addEventListener("cf-piece-context-menu", (event) => {
+        event.preventDefault();
+        innerPieceId = (event as CustomEvent<{ pieceId: string }>).detail
+          .pieceId;
+      }, { once: true });
+      inner.dispatchEvent(
+        new MouseEvent("contextmenu", {
+          bubbles: true,
+          composed: true,
+          cancelable: true,
+        }),
+      );
+
+      let announcedPieceId: string | undefined;
+      render.addEventListener("cf-piece-context-menu", (event) => {
+        announcedPieceId = (event as CustomEvent<{ pieceId: string }>).detail
+          .pieceId;
+      }, { once: true });
+
+      button.dispatchEvent(
+        new MouseEvent("contextmenu", {
+          bubbles: true,
+          composed: true,
+          cancelable: true,
+          clientX: innerBefore.x + 4,
+          clientY: innerBefore.y + 4,
+        }),
+      );
+      const menu = document.querySelector("cf-piece-menu") as
+        | (HTMLElement & { updateComplete: Promise<unknown> })
+        | null;
+      if (!menu) throw new Error("nested piece menu did not open");
+      await menu.updateComplete;
+      const overlay = menu.shadowRoot?.querySelector(
+        ".nested-piece-highlight",
+      );
+      if (!overlay) throw new Error("nested highlight did not render");
+      const overlayStyle = getComputedStyle(overlay);
+      const outerAfter = measure(render);
+      const middleAfter = measure(middle);
+      const innerAfter = measure(inner);
+      const overlayBeforeScroll = measure(overlay);
+      clip.scrollLeft = 24;
+      clip.dispatchEvent(new Event("scroll"));
+      await new Promise<void>((resolve) =>
+        requestAnimationFrame(() => resolve())
+      );
+      await menu.updateComplete;
+      const innerAfterScroll = measure(inner);
+      const overlayAfterScroll = measure(overlay);
+
+      return {
+        outerId: render.cell?.id(),
+        middleId: middlePieceId,
+        innerId: innerPieceId,
+        announcedPieceId,
+        outerMarked: render.hasAttribute("data-cf-piece-menu-open"),
+        innerMarked: inner.hasAttribute("data-cf-piece-menu-open"),
+        outerBefore,
+        outerAfter,
+        middleBefore,
+        middleAfter,
+        innerBefore,
+        innerAfter,
+        clipBefore,
+        overlayBeforeScroll,
+        innerAfterScroll,
+        overlayAfterScroll,
+        visual: {
+          position: overlayStyle.position,
+          pointerEvents: overlayStyle.pointerEvents,
+          backgroundImage: overlayStyle.backgroundImage,
+          boxShadow: overlayStyle.boxShadow,
+          animationName: overlayStyle.animationName,
+          animationIterationCount: overlayStyle.animationIterationCount,
+          reducedMotion: matchMedia("(prefers-reduced-motion: reduce)")
+            .matches,
+        },
+      };
+    });
+
+    expect(result.outerId).toBeDefined();
+    expect(result.middleId).toBeDefined();
+    expect(result.innerId).toBeDefined();
+    expect(result.innerId).not.toBe(result.middleId);
+    expect(result.innerId).not.toBe(result.outerId);
+    expect(result.middleId).not.toBe(result.outerId);
+    expect(result.announcedPieceId).toBe(result.innerId);
+    expect(result.outerMarked).toBe(false);
+    expect(result.innerMarked).toBe(false);
+    expect(result.outerAfter).toEqual(result.outerBefore);
+    expect(result.middleAfter).toEqual(result.middleBefore);
+    expect(result.innerAfter).toEqual(result.innerBefore);
+    const visibleRect = (inner: MeasuredRect, clip: MeasuredRect) => {
+      const x = Math.max(inner.x, clip.x);
+      const y = Math.max(inner.y, clip.y);
+      const right = Math.min(inner.x + inner.width, clip.x + clip.width);
+      const bottom = Math.min(inner.y + inner.height, clip.y + clip.height);
+      return { x, y, width: right - x, height: bottom - y };
+    };
+    expect(result.overlayBeforeScroll).toEqual(
+      visibleRect(result.innerBefore, result.clipBefore),
+    );
+    expect(result.overlayAfterScroll).toEqual(
+      visibleRect(result.innerAfterScroll, result.clipBefore),
+    );
+    expect(result.visual.position).toBe("fixed");
+    expect(result.visual.pointerEvents).toBe("none");
+    expect(result.visual.backgroundImage).not.toBe("none");
+    expect(result.visual.boxShadow).not.toBe("none");
+    if (result.visual.reducedMotion) {
+      expect(result.visual.animationName).toBe("none");
+    } else {
+      expect(result.visual.animationName).toBe(
+        "cf-nested-piece-menu-shine",
+      );
+      expect(result.visual.animationIterationCount).toBe("1");
     }
   });
 });

--- a/packages/shell/integration/piece.test.ts
+++ b/packages/shell/integration/piece.test.ts
@@ -111,11 +111,12 @@ describe("shell piece tests", () => {
 
   it("can view and interact with a piece", async () => {
     const page = shell.page();
-    const { identity, path: identityPath } = await writeTempIdentity({
+    await using tempIdentity = await writeTempIdentity({
       implementation: "noble",
     });
+    const { identity, path: identityPath } = tempIdentity;
     // Initialized as the first step inside the try below, so a failure there
-    // still runs the finally that removes the keyfile.
+    // still runs the finally that tears the runtimes down.
     let cc: PiecesController | undefined;
     let piece: PieceController | undefined;
     const logDebugSnapshot = async (label: string) => {
@@ -355,20 +356,20 @@ describe("shell piece tests", () => {
     } finally {
       // Both disposals are awaited to completion: disposeRuntime() awaits the
       // browser runtime's teardown (worker Dispose round trip and transport
-      // close), and cc.dispose() awaits the in-process runtime's. The keyfile
-      // is only ever read by the already-exited `cf piece new` subprocess, so
-      // nothing outstanding touches it once those return.
+      // close), and cc.dispose() awaits the in-process runtime's. Both
+      // finish before the keyfile goes, since `await using` removes it when
+      // the test's own scope ends.
       await shell.disposeRuntime();
       await cc?.dispose();
-      await Deno.remove(identityPath).catch(() => {});
     }
   });
 
   it("loads a slug piece and reloads when cf piece new repoints the slug", async () => {
     const slug = `slug-repoint-${crypto.randomUUID()}`;
-    const { identity, path: identityPath } = await writeTempIdentity({
+    await using tempIdentity = await writeTempIdentity({
       implementation: "noble",
     });
+    const { identity, path: identityPath } = tempIdentity;
     const firstSource = join(
       import.meta.dirname!,
       "fixtures",
@@ -380,115 +381,108 @@ describe("shell piece tests", () => {
       "slug-piece-v2.tsx",
     );
 
-    try {
-      const firstPieceId = await runCfPieceNewWithSlug({
-        sourcePath: firstSource,
-        identityPath,
-        slug,
-      });
+    const firstPieceId = await runCfPieceNewWithSlug({
+      sourcePath: firstSource,
+      identityPath,
+      slug,
+    });
 
-      await shell.goto({
-        frontendUrl: FRONTEND_URL,
-        view: {
-          spaceName: SPACE_NAME,
-          pieceSlug: slug,
-        },
-        identity,
-      });
-      await waitForSlugPieceMarker(shell, "slug piece v1");
-      await shell.waitForState({
-        view: {
-          spaceName: SPACE_NAME,
-          pieceSlug: slug,
-        },
-        identity,
-      });
+    await shell.goto({
+      frontendUrl: FRONTEND_URL,
+      view: {
+        spaceName: SPACE_NAME,
+        pieceSlug: slug,
+      },
+      identity,
+    });
+    await waitForSlugPieceMarker(shell, "slug piece v1");
+    await shell.waitForState({
+      view: {
+        spaceName: SPACE_NAME,
+        pieceSlug: slug,
+      },
+      identity,
+    });
 
-      const secondPieceId = await runCfPieceNewWithSlug({
-        sourcePath: secondSource,
-        identityPath,
-        slug,
-      });
-      expect(secondPieceId).not.toBe(firstPieceId);
+    const secondPieceId = await runCfPieceNewWithSlug({
+      sourcePath: secondSource,
+      identityPath,
+      slug,
+    });
+    expect(secondPieceId).not.toBe(firstPieceId);
 
-      await waitForSlugPieceMarker(shell, "slug piece v2");
-      const href = await shell.page().evaluate(() => globalThis.location.href);
-      expect(href).toContain(`/${SPACE_NAME}/${slug}`);
-    } finally {
-      await Deno.remove(identityPath).catch(() => {});
-    }
+    await waitForSlugPieceMarker(shell, "slug piece v2");
+    const href = await shell.page().evaluate(() => globalThis.location.href);
+    expect(href).toContain(`/${SPACE_NAME}/${slug}`);
   });
 
   it("tears the runtime down cleanly on logout while a piece is rendered", async () => {
     const slug = `logout-teardown-${crypto.randomUUID()}`;
-    const { identity, path: identityPath } = await writeTempIdentity({
+    await using tempIdentity = await writeTempIdentity({
       implementation: "noble",
     });
+    const { identity, path: identityPath } = tempIdentity;
     const source = join(
       import.meta.dirname!,
       "fixtures",
       "slug-piece-v1.tsx",
     );
 
-    try {
-      await runCfPieceNewWithSlug({ sourcePath: source, identityPath, slug });
+    await runCfPieceNewWithSlug({ sourcePath: source, identityPath, slug });
 
-      await shell.goto({
-        frontendUrl: FRONTEND_URL,
-        view: { spaceName: SPACE_NAME, pieceSlug: slug },
-        identity,
-      });
-      // The piece is rendered: the renderer, the favorites subscription, and
-      // the slug-target poll are all live.
-      await waitForSlugPieceMarker(shell, "slug piece v1");
+    await shell.goto({
+      frontendUrl: FRONTEND_URL,
+      view: { spaceName: SPACE_NAME, pieceSlug: slug },
+      identity,
+    });
+    // The piece is rendered: the renderer, the favorites subscription, and
+    // the slug-target poll are all live.
+    await waitForSlugPieceMarker(shell, "slug piece v1");
 
-      // In-app logout clears the identity, which disposes the runtime via the
-      // RootView swap while those consumers are still active. Proactive
-      // cancellation must tear them all down without recording a console error
-      // — the harness afterEach fails the test on any (no allowlist).
-      //
-      // The RootView task disposes the previous RuntimeInternals fire-and-forget
-      // and drops the promise, so there is nothing to await after the swap. Wrap
-      // dispose() before triggering logout to hold onto the exact promise the
-      // swap starts; awaiting it below settles all disposal-raced async work
-      // (the abort's synchronous consumer teardowns, the worker Dispose round
-      // trip, and the transport close) on a real completion instead of a timer.
-      await shell.page().evaluate(async () => {
-        const rootView = document.querySelector("x-root-view") as
-          | { _rt?: { value?: { dispose(): Promise<void> } } }
-          | null;
-        const internals = rootView?._rt?.value;
-        if (!internals) {
-          throw new Error(
-            "Runtime internals not available to observe disposal",
-          );
-        }
-        const global = globalThis as unknown as {
-          __ctRuntimeDisposed?: Promise<void>;
-        };
-        global.__ctRuntimeDisposed = undefined;
-        const disposeInternals = internals.dispose.bind(internals);
-        internals.dispose = () => {
-          global.__ctRuntimeDisposed = disposeInternals();
-          return global.__ctRuntimeDisposed;
-        };
-        await globalThis.app.setIdentity(undefined);
-      });
-      // The swap clears the global only after it has called the wrapped
-      // dispose(), so once the runtime is gone the disposal promise is stashed.
-      await waitForCondition(
-        shell.page(),
-        () => !globalThis.commonfabric?.rt,
-      );
-      // Await the disposal the swap started, so all disposal-raced async work
-      // has settled before afterEach inspects the recorded console errors.
-      await shell.page().evaluate(async () => {
-        await (globalThis as unknown as {
-          __ctRuntimeDisposed?: Promise<void>;
-        }).__ctRuntimeDisposed;
-      });
-    } finally {
-      await Deno.remove(identityPath).catch(() => {});
-    }
+    // In-app logout clears the identity, which disposes the runtime via the
+    // RootView swap while those consumers are still active. Proactive
+    // cancellation must tear them all down without recording a console error
+    // — the harness afterEach fails the test on any (no allowlist).
+    //
+    // The RootView task disposes the previous RuntimeInternals fire-and-forget
+    // and drops the promise, so there is nothing to await after the swap. Wrap
+    // dispose() before triggering logout to hold onto the exact promise the
+    // swap starts; awaiting it below settles all disposal-raced async work
+    // (the abort's synchronous consumer teardowns, the worker Dispose round
+    // trip, and the transport close) on a real completion instead of a timer.
+    await shell.page().evaluate(async () => {
+      const rootView = document.querySelector("x-root-view") as
+        | { _rt?: { value?: { dispose(): Promise<void> } } }
+        | null;
+      const internals = rootView?._rt?.value;
+      if (!internals) {
+        throw new Error(
+          "Runtime internals not available to observe disposal",
+        );
+      }
+      const global = globalThis as unknown as {
+        __ctRuntimeDisposed?: Promise<void>;
+      };
+      global.__ctRuntimeDisposed = undefined;
+      const disposeInternals = internals.dispose.bind(internals);
+      internals.dispose = () => {
+        global.__ctRuntimeDisposed = disposeInternals();
+        return global.__ctRuntimeDisposed;
+      };
+      await globalThis.app.setIdentity(undefined);
+    });
+    // The swap clears the global only after it has called the wrapped
+    // dispose(), so once the runtime is gone the disposal promise is stashed.
+    await waitForCondition(
+      shell.page(),
+      () => !globalThis.commonfabric?.rt,
+    );
+    // Await the disposal the swap started, so all disposal-raced async work
+    // has settled before afterEach inspects the recorded console errors.
+    await shell.page().evaluate(async () => {
+      await (globalThis as unknown as {
+        __ctRuntimeDisposed?: Promise<void>;
+      }).__ctRuntimeDisposed;
+    });
   });
 });


### PR DESCRIPTION
`writeTempIdentity()` writes a PKCS8 keyfile to the system temporary directory and hands back the path. Its contract put the removal on the caller, and that leaked two ways.

One caller does not remove it. The piece context menu test in `packages/shell/integration/piece-menu.test.ts` takes only the `identity` from the result and drops the path, so every run of the shell integration lane leaves one `cf-test-identity-<hex>` file behind. The other six call sites do remove it, each with its own hand-written `try`/`finally`.

`writeTempIdentity()` also leaked on its own failure path. The file exists from the moment `Deno.makeTempFile` returns, so a `Deno.writeFile` that throws takes the only reference to it out of reach.

A removal every caller has to remember is a leak waiting to come back, so the removal moves to the thing that made the file. `TempIdentity` is now an `AsyncDisposable` carrying a `remove()`, which `await using` calls when the binding leaves scope. That is what the callers with a `try`/`finally` become, and it is what the one without was missing. A write that fails removes the file it created before it re-raises. The `beforeAll`/`afterAll` pair in the cf command-line piece test straddles the scope a binding covers, so it holds the result across the hooks and calls `remove()` from the `afterAll`.

A removal that fails is reported on the console rather than thrown. `[Symbol.asyncDispose]` is that same function, and a disposal that throws while the test body has already failed reaches the reporter as a `SuppressedError`, which on Deno 2.9.4 prints only its own line:

    error: SuppressedError: An error was suppressed during disposal

Neither the test's failure message nor the removal's appears, so a keyfile that could not be unlinked would erase the result of whatever test was running. A throwaway keyfile is never the thing under test and the caller has nothing to do about one that will not unlink, while the test's own failure is what the run is for. A keyfile already gone is the goal state, so a repeat `remove()` succeeds and reports nothing.

The same shape closes the same kind of leak for the browser profile directory in `packages/integration/browser.ts`.

Verification. `packages/integration/test/temp-identity.test.ts` points `TMPDIR` at a directory of its own and asserts, for each removal path, that the keyfile is there and then that the directory holds nothing — so what it pins is "nothing was left behind" rather than one named file's absence, and it cannot pass vacuously if the redirect ever stops reaching `Deno.makeTempFile`. The write-failure case reads the directory from inside the failing write, where the keyfile the removal has to reclaim is the one entry in it. Each assertion was confirmed to fail with a leftover `cf-test-identity-<hex>` entry when the matching removal is taken out. `deno coverage` over that file reports 100% of the branches, functions and lines of `temp-identity.ts`. The `SuppressedError` behavior was measured with a probe test that throws from its body and rejects from `[Symbol.asyncDispose]`.

The three integration suites that use a test identity were then run against local dev servers with `TMPDIR` pointing at a fresh empty directory, and none left a `cf-test-identity-` entry in it: the shell lane, `packages/cli/test/piece-integration.test.ts`, and the cf-harness deployed-topology posture gate. As a control, the same shell lane run from the unmodified tree left exactly one such file.

`deno task check`, repository-wide `deno fmt --check` and `deno lint`, `deno task check-no-waitfor`, and the `deno task test` suites of `integration`, `cli`, `cf-harness` and `shell` all pass.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6889?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

