### PR TITLE
feat(cli): a slug names a collection, and a member resolves through it (S2)

### DIFF
--- a/docs/common/concepts/piece-discovery.md
+++ b/docs/common/concepts/piece-discovery.md
@@ -33,10 +33,12 @@ Slugs have their own discovery boundary, beside the registry's. A slug document
 lives at an ID derived from its name, so nothing can enumerate slugs it was
 never told the names of. The space's **slug index** — one document naming every
 slug assigned through `--slug` or `set-slug` — is what makes the namespace
-enumerable: `cf piece slugs` lists it, resolving each name to the piece it
-addresses. The index records the names only; where a name points remains the
-slug document's own answer. It records assignments made since it existed, so a
-slug written by an older client still resolves but is not listed. A slug may
+enumerable: `cf piece slugs` lists it, resolving each name to where it points —
+the piece it addresses, or, where the name points at a cell inside a piece, that
+piece and the path to the cell. The index records the names only; where a name
+points remains the slug document's own answer. It records assignments made
+since it existed, so a slug written by an older client still resolves but is
+not listed. A slug may
 also name an unregistered piece, which makes the slug listing a discovery path
 the registry does not have.
 

--- a/docs/plans/collection-naming-topics.md
+++ b/docs/plans/collection-naming-topics.md
@@ -147,10 +147,15 @@ Scope: `packages/piece/src/slugs.ts`, `packages/runner/src/slug-resolution.ts`,
 1. `cf piece set-slug top <board>/names` writes a slug at a non-root path,
    and `cf piece slugs` lists it, naming the containing piece. Both demos run
    on the exemplar board.
-2. `resolvePieceAddress` accepts a slug whose target, after the path, is a
-   link to a piece: `cf cell get //<space>/top/42 title`,
+2. A reference that names a collection and then a member resolves to that
+   member: `cf cell get //<space>/top/42 title`,
    `cf piece describe --cell //<space>/top/42`, and
-   `cf piece call --cell //<space>/top/42 <verb>` all reach the member.
+   `cf piece call --cell //<space>/top/42 <verb>` all reach it. A reference
+   that stops at the collection refuses, naming the piece that holds it. The
+   walk lives in `resolvePieceReference`, which takes an address and the path
+   written after it; `resolvePieceAddress` is its no-path case and refuses a
+   collection, because a caller holding an address alone has nothing to walk
+   with.
 3. A slug resolving to a non-piece with no further path fails with a message
    naming the containing piece.
 4. `//<space>/top/999` fails with "no member 999 in top".

--- a/docs/specs/collection-naming.md
+++ b/docs/specs/collection-naming.md
@@ -520,10 +520,16 @@ a writer gap rather than a model gap.
 **3. Give collections member namespaces.** A collection declares the name it
 answers to, its name policy, and forward and reverse resolutions. Whatever
 allocator it needs is its own; a collection that accepts names from people can
-reuse the claim from step 2 at collection scope. Widen `resolvePieceAddress`
-(`packages/piece/src/slugs.ts`), which rejects a name whose target has no
-pattern identity, so that a name pointing at a collection nested in a piece is
-not treated as an error.
+reuse the claim from step 2 at collection scope. Address resolution
+(`packages/piece/src/slugs.ts`) splits along what the caller is asking for. An
+address alone resolves through `resolvePieceAddress`, which names a piece and
+refuses a name pointing at a collection, because a collection is not a piece
+and nothing downstream of it could treat one as such. An address and the path
+written after it resolve together through `resolvePieceReference`, which is
+where the collection is walked: the first segment selects a member and the rest
+stays a cell path inside it. Resolving the two together is what the split is
+for — the path is the part that says which member, so a resolver handed the
+address on its own has nothing to walk with.
 
 **4. Walk segments in the URL layer.** `parseFabricUrl`
 (`packages/runner/src/fabric-url.ts`) reads a trailing segment as a slug and the

--- a/docs/specs/collection-naming.md
+++ b/docs/specs/collection-naming.md
@@ -517,19 +517,24 @@ a target outside that space cannot be written today. Resolution already handles
 it, following a slug's redirect into the space its target link names, so this is
 a writer gap rather than a model gap.
 
-**3. Give collections member namespaces.** A collection declares the name it
-answers to, its name policy, and forward and reverse resolutions. Whatever
-allocator it needs is its own; a collection that accepts names from people can
-reuse the claim from step 2 at collection scope. Address resolution
-(`packages/piece/src/slugs.ts`) splits along what the caller is asking for. An
-address alone resolves through `resolvePieceAddress`, which names a piece and
-refuses a name pointing at a collection, because a collection is not a piece
-and nothing downstream of it could treat one as such. An address and the path
-written after it resolve together through `resolvePieceReference`, which is
-where the collection is walked: the first segment selects a member and the rest
-stays a cell path inside it. Resolving the two together is what the split is
-for — the path is the part that says which member, so a resolver handed the
-address on its own has nothing to walk with.
+**3. Give collections member namespaces.** Two halves, and only the second has
+landed.
+
+Still to build: a collection declares the name it answers to, its name policy,
+and forward and reverse resolutions. Whatever allocator it needs is its own; a
+collection that accepts names from people can reuse the claim from step 2 at
+collection scope, which is itself unbuilt.
+
+Landed: address resolution (`packages/piece/src/slugs.ts`) splits along what
+the caller is asking for. An address alone resolves through
+`resolvePieceAddress`, which names a piece and refuses a name pointing at a
+collection, because a collection is not a piece and nothing downstream of it
+could treat one as such. An address and the path written after it resolve
+together through `resolvePieceReference`, which is where the collection is
+walked: the first segment selects a member and the rest stays a cell path
+inside it. Resolving the two together is what the split is for — the path is
+the part that says which member, so a resolver handed the address on its own
+has nothing to walk with.
 
 **4. Walk segments in the URL layer.** `parseFabricUrl`
 (`packages/runner/src/fabric-url.ts`) reads a trailing segment as a slug and the

--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -1331,19 +1331,20 @@ The slug is validated, then checked for availability, before anything is
 written, so an unusable slug and a slug already naming another piece are both
 structured errors that change nothing. The availability question fails closed: a
 slug is free only on the outcomes that say nothing is there — no document, a
-malformed one, one that is not a piece, one carrying no piece id — and any other
-failure refuses the call saying the availability could not be established,
-because reporting a storage error as a free name would write over whatever is
-there. That check is what stops a caller from taking over a name a person
-already opens: assigning a slug is a blind write, so without it a model naming
-`home` would repoint `home` at whatever it referenced. It is a check and not a
-lock — resolution and assignment are not atomic, so a slug that becomes taken in
-between is still overwritten — and it closes the case that arises rather than a
-race against a concurrent writer. A slug that already points at the very piece
-the token names answers `ok` rather than a refusal: the request is already true.
-`assign_slug` sets the address, not the title: what the piece list displays is
-the pattern's own `NAME` result, so a pattern that wants a title sets `NAME` in
-its source.
+malformed one, one that is not a piece, one carrying no piece id. A slug that
+resolves into a piece rather than to one names a collection, and is refused the
+way a taken name is: it is an address a person opens. Any other failure refuses
+the call saying the availability could not be established, because reporting a
+storage error as a free name would write over whatever is there. That check is
+what stops a caller from taking over a name a person already opens: assigning a
+slug is a blind write, so without it a model naming `home` would repoint `home`
+at whatever it referenced. It is a check and not a lock — resolution and
+assignment are not atomic, so a slug that becomes taken in between is still
+overwritten — and it closes the case that arises rather than a race against a
+concurrent writer. A slug that already points at the very piece the token names
+answers `ok` rather than a refusal: the request is already true. `assign_slug`
+sets the address, not the title: what the piece list displays is the pattern's
+own `NAME` result, so a pattern that wants a title sets `NAME` in its source.
 
 Every `run_pattern` invocation persists a piece in the configured space, named
 or not. A cancelled run stops its piece, but no piece is ever deleted, and each

--- a/packages/cf-harness/src/tools/assign-slug.ts
+++ b/packages/cf-harness/src/tools/assign-slug.ts
@@ -113,7 +113,10 @@ const errorMessage = (error: unknown): string =>
  * two disagree about the rule rather than that the space is empty.
  *
  * The map is total over the code union, so a code added to the resolver does
- * not compile until it is classified here.
+ * not compile until it is classified here. Totality is the point: only
+ * `inside-piece` can reach this from an address with no path, and
+ * `missing-member` is classified because it belongs to the same answer, not
+ * because it arrives.
  */
 const SLUG_CODE_STATES: Readonly<
   Record<

--- a/packages/cf-harness/src/tools/assign-slug.ts
+++ b/packages/cf-harness/src/tools/assign-slug.ts
@@ -155,7 +155,7 @@ const slugAvailability = async (
 ): Promise<
   | { state: "free" }
   | { state: "taken"; pieceId: string }
-  | { state: "in-use"; reason: string }
+  | { state: "in-use" }
   | { state: "unknown"; reason: string }
 > => {
   try {
@@ -166,8 +166,12 @@ const slugAvailability = async (
         error.code !== undefined
       ? SLUG_CODE_STATES[error.code]
       : "unknown";
-    if (state === "free") return { state };
-    return { state, reason: errorMessage(error) };
+    // Only `unknown` carries the resolver's text. The other two are answers
+    // about what the space holds, and their refusals name the caller's own
+    // slug and nothing the caller did not already have.
+    return state === "unknown"
+      ? { state, reason: errorMessage(error) }
+      : { state };
   }
 };
 
@@ -335,7 +339,7 @@ export const assignSlugTool: HarnessToolDefinition<
     }
     if (availability.state === "in-use") {
       return errorOutput(
-        `assign_slug slug "${slug}" already names a collection in this space, and assigning would repoint that address. Choose another slug. The resolver reported: ${availability.reason}`,
+        `assign_slug slug "${slug}" already names a collection in this space, and assigning would repoint that address. Choose another slug.`,
       );
     }
     if (availability.state === "unknown") {

--- a/packages/cf-harness/src/tools/assign-slug.ts
+++ b/packages/cf-harness/src/tools/assign-slug.ts
@@ -60,7 +60,7 @@ export const assignSlugToolDescriptor: HarnessToolDescriptor = {
   toolId: "assign_slug",
   title: "Assign Slug",
   description:
-    "Register the piece behind a handle token in the space's piece list and give it a named address a person can open. Use it after run_pattern when a piece deserves a name; a piece never named stays out of the list, which is what pure computation wants. A slug that already names another piece is refused rather than repointed.",
+    "Register the piece behind a handle token in the space's piece list and give it a named address a person can open. Use it after run_pattern when a piece deserves a name; a piece never named stays out of the list, which is what pure computation wants. A slug already naming another piece, or a collection, is refused rather than repointed.",
   effectClass: "side-effect",
   inputSchema: {
     type: "object",
@@ -98,25 +98,42 @@ const errorMessage = (error: unknown): string =>
   error instanceof Error ? error.message : String(error);
 
 /**
- * The `SlugResolutionError` codes that positively say the slug names no
- * piece: its document is absent, holds no usable redirect, or redirects to
- * something that is not a piece. Each is a statement about what the space
- * holds, arrived at by reading it, so each means the slug is free — a
- * name only ever competes with a piece.
+ * What each `SlugResolutionError` code says about the name.
  *
- * Every other outcome is a failure to establish anything: a storage error, a
- * sync that never landed, a lost connection. `invalid` sits on that side too
- * — the slug was validated before this is asked, so a resolver calling it
- * unusable means the two disagree about the rule rather than that the space
- * is empty.
+ * `free` is a positive statement about what the space holds, arrived at by
+ * reading it: the slug's document is absent, holds no usable redirect, or
+ * redirects to something that is not a piece, and a name only ever competes
+ * with a piece. `in-use` is equally positive the other way — the name
+ * resolves to a collection, which is a thing a person opens, so assigning
+ * over it would take the address away from whoever holds it.
+ *
+ * `unknown` is a failure to establish anything: a storage error, a sync that
+ * never landed, a lost connection. `invalid` sits there too — the slug was
+ * validated before this is asked, so a resolver calling it unusable means the
+ * two disagree about the rule rather than that the space is empty.
+ *
+ * The map is total over the code union, so a code added to the resolver does
+ * not compile until it is classified here.
  */
-const VACANT_SLUG_CODES: ReadonlySet<
-  NonNullable<SlugResolutionError["code"]>
-> = new Set(["missing", "malformed", "not-piece", "missing-piece-id"]);
+const SLUG_CODE_STATES: Readonly<
+  Record<
+    NonNullable<SlugResolutionError["code"]>,
+    "free" | "in-use" | "unknown"
+  >
+> = {
+  invalid: "unknown",
+  missing: "free",
+  malformed: "free",
+  "not-piece": "free",
+  "missing-piece-id": "free",
+  "inside-piece": "in-use",
+  "missing-member": "in-use",
+};
 
 /**
  * Whether `slug` already names a piece in the session's space — and which —
- * or whether that could not be established at all.
+ * whether it names something else a person opens, or whether that could not
+ * be established at all.
  *
  * Assignment is a blind write: the slug document is pointed at the piece
  * whatever it held before, and last writer wins. So without asking first, a
@@ -126,8 +143,8 @@ const VACANT_SLUG_CODES: ReadonlySet<
  * about what the slug holds, and treating it as vacancy would reopen exactly
  * the overwrite this asks to prevent.
  *
- * The two are told apart by the typed `code` `resolvePieceAddress` carries
- * on its `SlugResolutionError`, never by the message text.
+ * The outcomes are told apart by the typed `code` `resolvePieceAddress`
+ * carries on its `SlugResolutionError`, never by the message text.
  */
 const slugAvailability = async (
   pieces: PiecesController,
@@ -135,19 +152,19 @@ const slugAvailability = async (
 ): Promise<
   | { state: "free" }
   | { state: "taken"; pieceId: string }
+  | { state: "in-use"; reason: string }
   | { state: "unknown"; reason: string }
 > => {
   try {
     const holder = await resolvePieceAddress(pieces, slug);
     return { state: "taken", pieceId: holder };
   } catch (error) {
-    if (
-      error instanceof SlugResolutionError && error.code !== undefined &&
-      VACANT_SLUG_CODES.has(error.code)
-    ) {
-      return { state: "free" };
-    }
-    return { state: "unknown", reason: errorMessage(error) };
+    const state = error instanceof SlugResolutionError &&
+        error.code !== undefined
+      ? SLUG_CODE_STATES[error.code]
+      : "unknown";
+    if (state === "free") return { state };
+    return { state, reason: errorMessage(error) };
   }
 };
 
@@ -311,6 +328,11 @@ export const assignSlugTool: HarnessToolDefinition<
       }
       return errorOutput(
         `assign_slug slug "${slug}" already names another piece in this space, and assigning would repoint that address. Choose another slug.`,
+      );
+    }
+    if (availability.state === "in-use") {
+      return errorOutput(
+        `assign_slug slug "${slug}" already names a collection in this space, and assigning would repoint that address. Choose another slug. The resolver reported: ${availability.reason}`,
       );
     }
     if (availability.state === "unknown") {

--- a/packages/cf-harness/test/assign-slug.test.ts
+++ b/packages/cf-harness/test/assign-slug.test.ts
@@ -11,7 +11,12 @@ import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { normalize } from "@std/path/posix";
 import { createSession, Identity } from "@commonfabric/identity";
-import { assignSlug, resolvePieceAddress } from "@commonfabric/piece";
+import {
+  assignSlug,
+  resolvePieceAddress,
+  resolveSlugTarget,
+  setSlugLink,
+} from "@commonfabric/piece";
 import { PiecesController } from "@commonfabric/piece/ops";
 import {
   entityIdFrom,
@@ -213,6 +218,38 @@ describe("assign-slug", () => {
       expect(await resolvePieceAddress(pieces, "doubling-report")).toBe(
         first.pieceId,
       );
+    });
+
+    it("refuses a slug that names a collection, leaving the address where it pointed", async () => {
+      // A slug pointing at a cell inside a piece names a collection, which is
+      // an address a person opens as much as a piece is. Reading that as an
+      // operational failure would report a positive statement about what the
+      // space holds as a "try again", and reading it as vacancy would repoint
+      // the name.
+      await linkDefaultPattern();
+      const engine = createEngine();
+      const held = await createPiece(engine, 21);
+      const taking = await createPiece(engine, 22);
+      const cell = pieces.runtime.getCellFromLink(
+        parseLLMFriendlyLink(held.resultRef, pieces.getSpace()),
+      );
+      await cell.sync();
+      await setSlugLink(pieces, "doubling-report", cell.key("doubled"));
+
+      const result = await engine.invokeBuiltinTool("assign_slug", {
+        token: taking.resultRef,
+        slug: "doubling-report",
+      });
+      const output = result.output as AssignSlugToolErrorOutput;
+      expect(output.status).toBe("error");
+      expect(output.message).toContain("already names a collection");
+      expect(output.message).not.toContain("could not establish");
+      // The name still points into the piece it pointed into, so the refusal
+      // protected the address rather than merely reporting on it.
+      expect(await resolveSlugTarget(pieces, "doubling-report")).toEqual({
+        piece: held.pieceId,
+        pathInside: ["doubled"],
+      });
     });
 
     it("answers ok for a slug already pointing at the very piece the token names", async () => {

--- a/packages/cf-harness/test/assign-slug.test.ts
+++ b/packages/cf-harness/test/assign-slug.test.ts
@@ -244,6 +244,10 @@ describe("assign-slug", () => {
       expect(output.status).toBe("error");
       expect(output.message).toContain("already names a collection");
       expect(output.message).not.toContain("could not establish");
+      // The refusal names the caller's own slug and nothing behind it, the
+      // way the refusal for a name already taken by a piece does: the address
+      // the name resolves to stays trusted-side.
+      expect(output.message).not.toContain(held.pieceId);
       // The name still points into the piece it pointed into, so the refusal
       // protected the address rather than merely reporting on it.
       expect(await resolveSlugTarget(pieces, "doubling-report")).toEqual({

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -122,6 +122,25 @@ way and once the session opens when only a derivation can compare them. An
 address printed by one command therefore composes into the next with no flag
 beside it, whatever space the reader has configured.
 
+A slug may name a collection rather than a piece.
+`cf piece set-slug top
+/of:fid1:…/names` points `top` at the map a board keeps
+its members in, keyed by member name, and `/top/2` then names member `2`. Where
+the slug points is what decides how the path after it reads. A slug that points
+at a piece names that piece, and the path is a cell path inside it, as it is
+after a handle: `/tracker/items/0` is `items/0` inside the piece `tracker`
+names, whatever `items` holds. A slug that points anywhere else names a
+collection: the first segment selects a member, the cell that member holds is
+the piece, and the segments after it are a cell path inside that member. So
+`cf cell get /top/2 title` reads member `2`'s title,
+`cf piece describe --cell /top/2` describes it, and
+`cf piece call --cell /top/2 <verb>` calls it. A collection's name with no
+member after it is refused, naming the piece that holds the collection; a member
+the collection does not hold is refused as `no member 999 in top`. This is the
+rule wherever a `--cell` or positional address names the target, and for the
+source of `set-slug`; a `cf piece link` endpoint resolves its slug to a piece
+and reads the path inside that piece.
+
 Beside the reference, the CLI's bare form — `pieceId[@scope]`,
 `pieceId[@scope]/path` at link endpoints, and slugs — is a convenience alias for
 interactive use. New reference-syntax capabilities land in the reference first;
@@ -300,10 +319,20 @@ still following an origin is not there: restoring severs the origin, so the run
 writes and names the origin it would cut.
 
 `cf piece slugs` lists the space's slug index: every name assigned through
-`--slug` or `set-slug`, each resolved to the piece it names. The index records
+`--slug` or `set-slug`, each resolved to where it points — the piece it names,
+or for a slug into a cell inside a piece, that piece and the path, printed
+`fid1:…/names` in the table and as a `path` array in the JSON. The index records
 assignments made since it existed, so a slug written by an older client still
 resolves but is not listed — a slug document's id is derived from its name, and
 nothing can enumerate names it was never told.
+
+`cf piece set-slug <slug> <source>` takes any address as its source. A handle
+with a path, `/of:fid1:…/names`, names a cell inside that piece, which is how a
+collection gets its name. A slug with a path after it resolves as a target does,
+so `set-slug two /top/2` names member `2`. A bare slug names whatever that slug
+points at, piece or not, which is how a collection's name is aliased.
+`--resolve-before-linking` resolves the source cell's link before writing, so
+the new slug points at what the source's cell points at rather than at the cell.
 
 `cf piece search` also starts from the registry. It searches readable input and
 result data, but returns registered pieces only. `cf piece map` likewise shows

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -135,20 +135,25 @@ the piece, and the segments after it are a cell path inside that member. So
 `cf piece describe --cell /top/2` describes it, and
 `cf piece call --cell /top/2 <verb>` calls it. Exactly one segment reaches a
 member, so a field of a member never answers to the collection's namespace:
-`/top/2/comments` is the `comments` field of member `2`, never a member named
-`comments` of whatever `2` holds.
+`/top/2/title` is the `title` field of member `2`, never a member named `title`
+of whatever `2` holds. This is how an address reads wherever a `--cell` or
+positional one names the target, at both `cf piece link` endpoints, and for the
+source of `set-slug`.
 
 A collection's name with no member after it is refused, naming the piece that
 holds the collection; a member the collection does not hold is refused as
 `no member 999 in top`. The map itself is addressed by the `piece/path` handle
 `cf piece slugs` prints for the name, never by the name, which addresses
-members: `cf piece inspect --cell /of:fid1:…/names` shows the map, and
-`cf piece inspect --cell /top` is the refusal. Writing follows the same rule:
-`cf cell set /top/2 title <value>` writes the title, while a `cf cell set` whose
-address stops at `/top/2` is refused, because the address alone reaches the
-member's whole cell, and replacing that is what a path spells out. This is the
-rule wherever a `--cell` or positional address names the target, at both
-`cf piece link` endpoints, and for the source of `set-slug`.
+members: `cf cell get /of:fid1:…/names` reads the map and prints the member
+names it holds. `cf piece inspect` takes a piece id rather than a cell inside
+one, so it has no spelling for the map at all; given the name instead, as
+`cf piece inspect --cell /top`, it meets the collection's refusal the way every
+other command does. A write takes a path inside the member the address reaches,
+and the value on stdin: `echo '"Oven schedule"' | cf cell set /top/2 title`. A
+`cf cell set` whose address stops at `/top/2` is refused, because the address
+alone reaches the member's whole cell and replacing that is what a path spells
+out. The one spelling that does replace a whole cell is an explicit empty
+positional, `cf cell set <address> ""`, which has always named the root.
 
 Beside the reference, the CLI's bare form — `pieceId[@scope]`,
 `pieceId[@scope]/path` at link endpoints, and slugs — is a convenience alias for

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -123,8 +123,7 @@ address printed by one command therefore composes into the next with no flag
 beside it, whatever space the reader has configured.
 
 A slug may name a collection rather than a piece.
-`cf piece set-slug top
-/of:fid1:…/names` points `top` at the map a board keeps
+`cf piece set-slug top /of:fid1:…/names` points `top` at the map a board keeps
 its members in, keyed by member name, and `/top/2` then names member `2`. Where
 the slug points is what decides how the path after it reads. A slug that points
 at a piece names that piece, and the path is a cell path inside it, as it is
@@ -134,12 +133,22 @@ collection: the first segment selects a member, the cell that member holds is
 the piece, and the segments after it are a cell path inside that member. So
 `cf cell get /top/2 title` reads member `2`'s title,
 `cf piece describe --cell /top/2` describes it, and
-`cf piece call --cell /top/2 <verb>` calls it. A collection's name with no
-member after it is refused, naming the piece that holds the collection; a member
-the collection does not hold is refused as `no member 999 in top`. This is the
-rule wherever a `--cell` or positional address names the target, and for the
-source of `set-slug`; a `cf piece link` endpoint resolves its slug to a piece
-and reads the path inside that piece.
+`cf piece call --cell /top/2 <verb>` calls it. Exactly one segment reaches a
+member, so a field of a member never answers to the collection's namespace:
+`/top/2/comments` is the `comments` field of member `2`, never a member named
+`comments` of whatever `2` holds.
+
+A collection's name with no member after it is refused, naming the piece that
+holds the collection; a member the collection does not hold is refused as
+`no member 999 in top`. The map itself is addressed by the `piece/path` handle
+`cf piece slugs` prints for the name, never by the name, which addresses
+members: `cf piece inspect --cell /of:fid1:…/names` shows the map, and
+`cf piece inspect --cell /top` is the refusal. Writing follows the same rule:
+`cf cell set /top/2 title <value>` writes the title, while a `cf cell set` whose
+address stops at `/top/2` is refused, because the address alone reaches the
+member's whole cell, and replacing that is what a path spells out. This is the
+rule wherever a `--cell` or positional address names the target, at both
+`cf piece link` endpoints, and for the source of `set-slug`.
 
 Beside the reference, the CLI's bare form — `pieceId[@scope]`,
 `pieceId[@scope]/path` at link endpoints, and slugs — is a convenience alias for
@@ -330,9 +339,11 @@ nothing can enumerate names it was never told.
 with a path, `/of:fid1:…/names`, names a cell inside that piece, which is how a
 collection gets its name. A slug with a path after it resolves as a target does,
 so `set-slug two /top/2` names member `2`. A bare slug names whatever that slug
-points at, piece or not, which is how a collection's name is aliased.
-`--resolve-before-linking` resolves the source cell's link before writing, so
-the new slug points at what the source's cell points at rather than at the cell.
+points at, piece or not, which is how a collection's name is aliased; a scope
+written on a bare slug is refused, because the slug's own redirect names the
+scope of the cell it points at. `--resolve-before-linking` resolves the source
+cell's link before writing, so the new slug points at what the source's cell
+points at rather than at the cell.
 
 `cf piece search` also starts from the registry. It searches readable input and
 result data, but returns registered pieces only. `cf piece map` likewise shows

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -266,10 +266,16 @@ in-scope identity that the collection lacks makes the survey exit nonzero,
 naming the piece. A `--list` survey reads exactly the pieces named and makes no
 containment claim; each entry takes either reference form, and a canonical
 entry's embedded space composes the way it does on `--cell` — supplying the
-space when `--space` is absent, agreeing with it otherwise. Read-only. To watch
-the surface work rather than read about it, `integration/bulk-ops-demo.sh`
-narrates the whole of it — survey, repair, retarget, and the reversal — end to
-end against a running server.
+space when `--space` is absent, agreeing with it otherwise. Read-only.
+
+The holder is a piece and `--path` names the collection inside it, so neither
+the holder's address nor a `--list` entry carries a path of its own, and one
+that does is refused rather than dropped. A collection's member is therefore
+addressed as a holder by its own handle rather than as `/top/2`.
+
+To watch the surface work rather than read about it,
+`integration/bulk-ops-demo.sh` narrates the whole of it — survey, repair,
+retarget, and the reversal — end to end against a running server.
 
 `cf piece repair` runs a caller-supplied fixer — a TypeScript module whose
 default export is a pure transform from a piece's stored input document to the
@@ -339,6 +345,12 @@ or for a slug into a cell inside a piece, that piece and the path, printed
 assignments made since it existed, so a slug written by an older client still
 resolves but is not listed — a slug document's id is derived from its name, and
 nothing can enumerate names it was never told.
+
+Completion for a `piece/path` slot — both `cf piece link` endpoints and the
+source of `set-slug` — offers the space's slugs and piece ids before the
+separator and that piece's cell keys after it. After a slug naming a collection
+it offers nothing: reading the member names means reading the map, and that is a
+second load for a keystroke to start.
 
 `cf piece set-slug <slug> <source>` takes any address as its source. A handle
 with a path, `/of:fid1:…/names`, names a cell inside that piece, which is how a

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -20,7 +20,7 @@ import {
   type RestorableRevision,
 } from "@commonfabric/piece/ops";
 import ports from "@commonfabric/ports" with { type: "json" };
-import { parseCellPath, UI } from "@commonfabric/runner";
+import { isSlugAddress, parseCellPath, UI } from "@commonfabric/runner";
 import {
   encodeJsonPointer,
   parseScopedIdSegment,
@@ -100,6 +100,7 @@ import {
   newPiece,
   partitionVerbListing,
   PieceConfig,
+  pieceIdOnlyPathRefusal,
   PieceResultProjectionError,
   PieceVerbReadError,
   recreateSpaceRootPattern,
@@ -120,6 +121,7 @@ import type {
   ExecutedPieceCallable,
   PieceCallablesListing,
   PieceInspection,
+  SlugSummary,
 } from "../lib/piece.ts";
 import { render, safeStringify } from "../lib/render.ts";
 import { newSessionId } from "../lib/session.ts";
@@ -642,12 +644,13 @@ export function renderPieceSummaries(
   if (rows.length > 1) render(Table.from(rows).toString());
 }
 
-/** `cf piece slugs` output: one row per indexed name, the piece it resolves
- * to where it resolves to one, and the resolution's own error where it does
- * not. The error rides the JSON too — a machine reader has no table to read
- * a `<error: …>` marker off. */
+/** `cf piece slugs` output: one row per indexed name, where it points — the
+ * piece, or the piece and the path inside it, printed `piece/path` in the
+ * table and as a `path` array in the JSON — and the resolution's own error
+ * where it points into no piece. The error rides the JSON too — a machine
+ * reader has no table to read a `<error: …>` marker off. */
 export function renderSlugSummaries(
-  slugs: Array<{ slug: string; piece?: string; error?: string }>,
+  slugs: SlugSummary[],
   json: boolean,
 ): void {
   if (json) {
@@ -655,6 +658,7 @@ export function renderSlugSummaries(
       slugs.map((entry) => ({
         slug: entry.slug,
         piece: entry.piece ?? null,
+        ...(entry.path !== undefined ? { path: entry.path } : {}),
         ...(entry.error !== undefined ? { error: entry.error } : {}),
       })),
       { json: true },
@@ -666,7 +670,11 @@ export function renderSlugSummaries(
     ["SLUG", "PIECE"],
     ...slugs.map((entry) => [
       entry.slug,
-      entry.error !== undefined ? `<error: ${entry.error}>` : entry.piece!,
+      entry.error !== undefined
+        ? `<error: ${entry.error}>`
+        : entry.path !== undefined
+        ? `${entry.piece}/${entry.path.join("/")}`
+        : entry.piece!,
     ]),
   ];
   if (rows.length > 1) render(Table.from(rows).toString());
@@ -4989,13 +4997,16 @@ export function parsePieceOptions(
     );
   }
   const config = options as PieceConfig;
-  if (config.piecePath?.length && !parseOptions?.acceptsPath) {
-    throw new ValidationError(
-      `The piece reference embeds a path ("${
-        config.piecePath.join("/")
-      }") but this command takes a piece id only.`,
-      { exitCode: 1 },
-    );
+  // A slug's path is not refused here: a slug may name a collection, whose
+  // member the path selects, and only resolution can tell. What the walk
+  // leaves is refused there, in these words.
+  if (
+    config.piecePath?.length && !parseOptions?.acceptsPath &&
+    !isSlugAddress(config.piece)
+  ) {
+    throw new ValidationError(pieceIdOnlyPathRefusal(config.piecePath), {
+      exitCode: 1,
+    });
   }
   if (config.pieceInput && !parseOptions?.acceptsArgument) {
     throw new ValidationError(

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -99,6 +99,7 @@ import {
   MapFormat,
   newPiece,
   partitionVerbListing,
+  pathRequiredRefusal,
   PieceConfig,
   pieceIdOnlyPathRefusal,
   PieceResultProjectionError,
@@ -3335,12 +3336,17 @@ export async function getCellValueFromCommand(
 
 /**
  * The `cf cell set` action, with the same positional-address intake as
- * {@link getCellValueFromCommand}. The write needs a path spelled somewhere
- * — embedded in the address, positionally, or both — and an explicit empty
- * positional (`""`) is a spelling: it has always named the root, and the
- * fuse integration writes a whole input cell with it. What is refused is a
- * bare positional address with no path anywhere, so a pasted address cannot
- * silently overwrite a whole cell.
+ * {@link getCellValueFromCommand}. The write needs a path inside the piece it
+ * reaches, spelled in the address, positionally, or both. An explicit empty
+ * positional (`""`) is the exception, and the only spelling under which a
+ * write lands on a whole cell: it has always named the root, and the fuse
+ * integration writes a whole input cell with it. Everything else that reaches
+ * a root is refused, so no address silently overwrites a cell.
+ *
+ * Refused at two points, because the two halves are known at different
+ * moments. A line carrying no path at all is refused here, before stdin is
+ * drained; a line whose path a collection spends reaching a member is refused
+ * by the write, which is where what the address resolves to is known.
  */
 export async function setCellValueFromCommand(
   options: PieceLabelCLIOptions,
@@ -3355,21 +3361,26 @@ export async function setCellValueFromCommand(
     { acceptsPath: true, acceptsArgument: true },
   );
   const pathSegments = mergePiecePath(pieceConfig, target.pathString);
+  // An empty positional is the one spelling that names the root, so it is
+  // the one spelling under which a write may land on a whole cell.
+  const rootSpelled = target.pathString === "";
   if (pathSegments.length === 0 && target.pathString === undefined) {
-    throw new ValidationError(
-      `A path is required: embed it in the address (/of:.../title) or ` +
-        `pass it as an argument ("" writes the root).`,
-      { exitCode: 1 },
-    );
+    throw new ValidationError(pathRequiredRefusal(), { exitCode: 1 });
   }
   const value = await (deps.drainStdin ?? drainStdin)();
-  await (deps.setCellValue ?? setCellValue)(pieceConfig, pathSegments, value, {
-    input: options.input || pieceConfig.pieceInput,
-  });
-  (deps.render ?? render)(`Set value at path: ${pathSegments.join("/")}`);
+  const written = await (deps.setCellValue ?? setCellValue)(
+    pieceConfig,
+    pathSegments,
+    value,
+    {
+      input: options.input || pieceConfig.pieceInput,
+      refuseRootWrite: !rootSpelled,
+    },
+  );
+  (deps.render ?? render)(`Set value at path: ${written.path.join("/")}`);
   (deps.hint ?? hint)(
     cliText(
-      `TIP: Computed values may be stale. Run 'cf piece step --cell ${pieceConfig.piece} ...' to trigger recomputation.`,
+      `TIP: Computed values may be stale. Run 'cf piece step --cell ${written.piece} ...' to trigger recomputation.`,
     ),
   );
 }

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -3378,9 +3378,16 @@ export async function setCellValueFromCommand(
     },
   );
   (deps.render ?? render)(`Set value at path: ${written.path.join("/")}`);
+  // The address as written is what a reader pastes into the next command, and
+  // it still names the piece written to whenever the walk spent none of the
+  // path. Where the walk spent some, the address names a collection and only
+  // the piece it reached says what was written.
+  const wroteTo = written.path.length === pathSegments.length
+    ? pieceConfig.piece
+    : written.piece;
   (deps.hint ?? hint)(
     cliText(
-      `TIP: Computed values may be stale. Run 'cf piece step --cell ${written.piece} ...' to trigger recomputation.`,
+      `TIP: Computed values may be stale. Run 'cf piece step --cell ${wroteTo} ...' to trigger recomputation.`,
     ),
   );
 }
@@ -3945,6 +3952,19 @@ export function readBulkSelection(
     throw new ValidationError(
       "A scoped piece cannot hold the selected collection; drop the " +
         "@scope suffix.",
+      { exitCode: 1 },
+    );
+  }
+  // The holder is a piece, and `--path` is what names the collection inside
+  // it, so a path on the address has nowhere to go. Refused here rather than
+  // carried, because this is where the selector is built and a path it does
+  // not carry is a path the run would drop. The `--list` branch above refuses
+  // its own entries' paths for the same reason.
+  if (pieceConfig.piecePath?.length) {
+    throw new ValidationError(
+      `A bulk operation reads whole pieces; drop the path on ` +
+        `${JSON.stringify(pieceConfig.piecePath.join("/"))} and name the ` +
+        `collection with --path.`,
       { exitCode: 1 },
     );
   }

--- a/packages/cli/integration/completion-over-the-cli.sh
+++ b/packages/cli/integration/completion-over-the-cli.sh
@@ -252,6 +252,15 @@ check "slug for Completion fixture" \
 step "3. The slug reaches its own positional too"
 check "board" "$(candidates_at "cf piece set-slug $LINE_ARGS ")" \
   "piece set-slug completes the slugs it can re-point"
+# A slug's source is a cell, not a piece: the name a collection gets is the
+# path inside the board that holds it, so the source slot spans a piece and
+# the keys under it, the way a link endpoint does.
+check ":cf:nospace" "$(directives_at "cf piece set-slug $LINE_ARGS name ")" \
+  "its source holds the cursor for the separator a path continues with"
+check "1" "$(complete_at "cf piece set-slug $LINE_ARGS name ${BOARD%??????????}" |
+  grep -c "^$BOARD\$")" "the source offers a piece before the separator"
+check "1" "$(complete_at "cf piece set-slug $LINE_ARGS name $BOARD/rev" |
+  grep -c "^$BOARD/revision\$")" "and that piece's keys after it"
 
 step "4. Both spellings of an option complete the same values"
 # `--piece=<TAB>` and `--piece <TAB>` are one slot. The inline spelling is the

--- a/packages/cli/lib/bulk.ts
+++ b/packages/cli/lib/bulk.ts
@@ -42,12 +42,16 @@ import {
 import { retargetPieces } from "@commonfabric/piece/ops/bulk-retarget";
 import type { JSONSchema, RuntimeProgram } from "@commonfabric/runner";
 
-import { loadPieces, type PieceConfig, type SpaceConfig } from "./piece.ts";
+import {
+  loadPieces,
+  type PieceConfig,
+  type PieceResolutionDeps,
+  resolveAddressedPieceId,
+  type SpaceConfig,
+} from "./piece.ts";
 
-export interface SourcePinDependencies {
-  loadPieces?: typeof loadPieces;
-  resolvePieceAddress?: typeof resolvePieceAddress;
-}
+/** What {@link readSourcePin} resolves its address and connection through. */
+export type SourcePinDependencies = PieceResolutionDeps;
 
 /**
  * Read one piece's source pin — reference, current revision when a log
@@ -62,10 +66,7 @@ export async function readSourcePin(
   deps: SourcePinDependencies = {},
 ): Promise<PiecePin | undefined> {
   const pieces = await (deps.loadPieces ?? loadPieces)(config);
-  const piece = await (deps.resolvePieceAddress ?? resolvePieceAddress)(
-    pieces,
-    config.piece,
-  );
+  const piece = await resolveAddressedPieceId(pieces, config, deps);
   return await readPiecePin(pieces, piece, new Map(), config.pieceScope);
 }
 
@@ -437,9 +438,7 @@ export interface RestoreRunRequest {
   apply?: boolean;
 }
 
-export interface RestoreRunDependencies {
-  loadPieces?: typeof loadPieces;
-  resolvePieceAddress?: typeof resolvePieceAddress;
+export interface RestoreRunDependencies extends PieceResolutionDeps {
   restorePiece?: typeof restorePiece;
 }
 
@@ -454,10 +453,7 @@ export async function runRestore(
   deps: RestoreRunDependencies = {},
 ): Promise<RestoreOutcome> {
   const pieces = await (deps.loadPieces ?? loadPieces)(config);
-  const piece = await (deps.resolvePieceAddress ?? resolvePieceAddress)(
-    pieces,
-    config.piece,
-  );
+  const piece = await resolveAddressedPieceId(pieces, config, deps);
   return await (deps.restorePiece ?? restorePiece)(pieces, piece, {
     ...(request.revisionId === undefined
       ? {}

--- a/packages/cli/lib/bulk.ts
+++ b/packages/cli/lib/bulk.ts
@@ -46,7 +46,7 @@ import {
   loadPieces,
   type PieceConfig,
   type PieceResolutionDeps,
-  resolveAddressedPieceId,
+  resolveAddressedPieceConfig,
   type SpaceConfig,
 } from "./piece.ts";
 
@@ -66,8 +66,13 @@ export async function readSourcePin(
   deps: SourcePinDependencies = {},
 ): Promise<PiecePin | undefined> {
   const pieces = await (deps.loadPieces ?? loadPieces)(config);
-  const piece = await resolveAddressedPieceId(pieces, config, deps);
-  return await readPiecePin(pieces, piece, new Map(), config.pieceScope);
+  const resolved = await resolveAddressedPieceConfig(pieces, config, deps);
+  return await readPiecePin(
+    pieces,
+    resolved.piece,
+    new Map(),
+    resolved.pieceScope,
+  );
 }
 
 /**
@@ -453,16 +458,18 @@ export async function runRestore(
   deps: RestoreRunDependencies = {},
 ): Promise<RestoreOutcome> {
   const pieces = await (deps.loadPieces ?? loadPieces)(config);
-  const piece = await resolveAddressedPieceId(pieces, config, deps);
-  return await (deps.restorePiece ?? restorePiece)(pieces, piece, {
+  const resolved = await resolveAddressedPieceConfig(pieces, config, deps);
+  return await (deps.restorePiece ?? restorePiece)(pieces, resolved.piece, {
     ...(request.revisionId === undefined
       ? {}
       : { revisionId: request.revisionId }),
     ...(request.apply === true ? { apply: true } : {}),
-    // The scope the address carried, threaded the way `readSourcePin`
+    // The scope the address resolved to, threaded the way `readSourcePin`
     // threads it: a scoped reference names a different cell, so a run that
     // dropped it would list and restore a piece nobody asked about.
-    ...(config.pieceScope === undefined ? {} : { scope: config.pieceScope }),
+    ...(resolved.pieceScope === undefined
+      ? {}
+      : { scope: resolved.pieceScope }),
   });
 }
 

--- a/packages/cli/lib/completion/providers.ts
+++ b/packages/cli/lib/completion/providers.ts
@@ -616,12 +616,14 @@ export function shapeProjectionCandidates(
 }
 
 /**
- * `pieceId/path/to/field` endpoints for `cf piece link`.
+ * A `pieceId/path/to/field` token, completed in both halves.
  *
- * Before the `/` the candidates are piece ids; after it they are that piece's
- * cell keys, so both halves of a link reference complete.
+ * Before the `/` the candidates are what a `--cell` takes — the space's slugs
+ * and its piece ids; after it they are that piece's cell keys, so one slot
+ * spans two vocabularies. `nospace` holds the cursor at the separator, which
+ * continues the same word.
  */
-async function linkEndpointCandidates(
+async function pieceWithPathCandidates(
   line: CompletionLine,
 ): Promise<ProviderResult> {
   const typed = line.word;
@@ -641,7 +643,7 @@ async function linkEndpointCandidates(
   const keys = await listCellKeys({ ...config, piece: pieceId }, parentPath);
   if (keys.length === 0) return NOTHING;
 
-  const prefix = linkEndpointPrefix(pieceId, parentPath);
+  const prefix = pieceWithPathPrefix(pieceId, parentPath);
   return {
     candidates: keys.map((key) => ({ value: `${prefix}${key}` })),
     directives: [{ kind: "nospace" }],
@@ -649,10 +651,11 @@ async function linkEndpointCandidates(
 }
 
 /**
- * Prefix for a `piece link` endpoint candidate. The empty parent path is the
- * case that matters: `id//key` would be a different, invalid reference.
+ * Prefix a `pieceId/path` candidate carries, so the shell replaces the whole
+ * token. The empty parent path is the case that matters: `id//key` would be a
+ * different, invalid reference.
  */
-export function linkEndpointPrefix(
+export function pieceWithPathPrefix(
   pieceId: string,
   parentPath: string,
 ): string {
@@ -1042,13 +1045,15 @@ const ARGUMENT_PROVIDERS: Readonly<
   "set:addressOrPath": cellPathCandidates,
   "cell set:path": cellPathCandidates,
   "set:path": cellPathCandidates,
-  "piece link:source": linkEndpointCandidates,
-  "piece link:target": linkEndpointCandidates,
+  "piece link:source": pieceWithPathCandidates,
+  "piece link:target": pieceWithPathCandidates,
   // Naming an existing slug re-points it, which is the case completion helps
   // with; a slug being coined for the first time is a word nothing can offer.
   "piece set-slug:slug": slugCandidates,
-  // The target a slug redirects to takes what `--cell` takes.
-  "piece set-slug:source": pieceCandidates,
+  // A slug redirects to a cell, which is a piece and a path inside it — the
+  // spelling that points a name at a collection. Same grammar as a link
+  // endpoint, so the same candidates.
+  "piece set-slug:source": pieceWithPathCandidates,
   "piece new:main": patternFiles,
   "piece setsrc:main": patternFiles,
   "check:files": patternFiles,

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -1384,7 +1384,14 @@ async function resolvePieceTargetWithPieces(
   );
   const { piecePath: _embedded, ...rest } = config;
   return {
-    config: { ...rest, piece: resolved.piece },
+    config: {
+      ...rest,
+      piece: resolved.piece,
+      // The stored link is the authority on which instance of an id a member
+      // is, so a scope the walk reached it through stands over the one the
+      // command was addressing under.
+      ...(resolved.scope !== undefined && { pieceScope: resolved.scope }),
+    },
     path: resolved.pathAfter,
   };
 }
@@ -1445,21 +1452,22 @@ export async function resolvePieceConfig(
 }
 
 /**
- * The piece a config addresses, for a command whose intake is a piece and
- * nothing inside it.
+ * The config a command whose intake is a piece and nothing inside it should
+ * act on: the piece the address reached, and the scope it was reached
+ * through.
  *
  * Every such command resolves through here, because the refusal it owes a
  * caller cannot be raised at the parse: a slug's embedded path may be spent
  * selecting a member, and only the walk can tell that from a cell path the
  * command has no use for. A command that resolved the address on its own
- * would take the piece and drop the path without saying so.
+ * would take the piece and drop the rest of what the walk reached.
  */
-export async function resolveAddressedPieceId(
+export async function resolveAddressedPieceConfig(
   pieces: PiecesController,
   config: PieceConfig,
   deps: PieceResolutionDeps = {},
-): Promise<string> {
-  return (await resolvePieceConfigWithPieces(config, pieces, deps)).piece;
+): Promise<PieceConfig> {
+  return await resolvePieceConfigWithPieces(config, pieces, deps);
 }
 
 /**
@@ -1661,10 +1669,14 @@ async function resolveSlugSourceCell(
       () => resolveSlugTargetCell(pieces, sourcePieceId),
     );
   }
-  const { piece, pathAfter: path } = await timeCliPhase(
+  const { piece, pathAfter: path, scope } = await timeCliPhase(
     "setPieceSlug.resolveSource",
     () => pieceReferenceResolver(deps)(pieces, sourcePieceId, sourcePath),
   );
+  // A member reached through a narrowed link is that instance, so the cell
+  // the slug is pointed at is read at the scope the walk reached, not the one
+  // the command was addressing under.
+  const resolvedScope = scope ?? sourceScope;
   if (path.length === 0) {
     return pieces.runtime.getCellFromEntityId(
       pieces.getSpace(),
@@ -1672,12 +1684,12 @@ async function resolveSlugSourceCell(
       [],
       undefined,
       undefined,
-      sourceScope,
+      resolvedScope,
     );
   }
   const holder = await timeCliPhase(
     "setPieceSlug.getSourcePiece",
-    () => pieces.get(piece, false, undefined, sourceScope),
+    () => pieces.get(piece, false, undefined, resolvedScope),
   );
   return holder.getCell().key(...path);
 }
@@ -3705,11 +3717,14 @@ export async function linkPieces(
   // Both halves name the piece the walk reached rather than the token that
   // reached it: an address naming a collection's member checks its path on
   // the member, and a message pairing that path with the collection's name
-  // would describe a read nobody made.
+  // would describe a read nobody made. The scope travels with each half for
+  // the same reason — it says which instance of that id the link named.
   const resolvedSourcePieceId = source.piece;
   const resolvedSourcePath = source.pathAfter;
+  const resolvedSourceScope = source.scope ?? options?.sourceScope;
   const resolvedTargetPieceId = target.piece;
   const resolvedTargetPath = target.pathAfter;
+  const resolvedTargetScope = target.scope ?? options?.targetScope;
 
   // Validate that source and target pieces/paths exist by reading them
   if (!options?.allowNonExisting) {
@@ -3724,7 +3739,7 @@ export async function linkPieces(
           resolvedSourcePieceId,
           false,
           undefined,
-          options?.sourceScope,
+          resolvedSourceScope,
         ),
     );
     const sourceHasPattern =
@@ -3768,7 +3783,7 @@ export async function linkPieces(
           resolvedTargetPieceId,
           false,
           undefined,
-          options?.targetScope,
+          resolvedTargetScope,
         ),
     );
     const targetHasPattern =
@@ -3819,7 +3834,15 @@ export async function linkPieces(
         resolvedSourcePath,
         resolvedTargetPieceId,
         resolvedTargetPath,
-        options,
+        {
+          ...options,
+          ...(resolvedSourceScope === undefined
+            ? {}
+            : { sourceScope: resolvedSourceScope }),
+          ...(resolvedTargetScope === undefined
+            ? {}
+            : { targetScope: resolvedTargetScope }),
+        },
       ),
   );
   noteWroteTo(config.space);
@@ -3882,7 +3905,7 @@ export async function linkSqliteDiskSource(
   );
   await pieces.link(id, [], resolvedTarget.piece, resolvedTarget.pathAfter, {
     start: options?.start,
-    targetScope: options?.targetScope,
+    targetScope: resolvedTarget.scope ?? options?.targetScope,
   });
   await pieces.synced();
 }

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -4189,7 +4189,13 @@ export async function inspectPiece(
   } catch (error) {
     if (
       error instanceof SlugResolutionError &&
-      error.code === "not-piece"
+      error.code === "not-piece" &&
+      // The fallback reports the cell the slug itself points at, which is an
+      // answer only where the address named the slug and nothing after it.
+      // With a path, `not-piece` says the member that path selected is no
+      // piece, and reporting the slug's own target would answer about
+      // something the caller did not ask for.
+      !config.piecePath?.length
     ) {
       return await inspectSlugTargetCell(pieces, config.piece);
     }

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -1,6 +1,7 @@
 import { ensureDir } from "@std/fs";
 import { dirname, join } from "@std/path";
 
+import { ValidationError } from "@cliffy/command";
 import type { CellScope, JSONSchema } from "@commonfabric/api";
 import {
   FabricPrimitive,
@@ -21,7 +22,6 @@ import {
   listSlugs,
   pieceId,
   type PieceReference,
-  resolvePieceAddress as resolveStoredPieceAddress,
   resolvePieceReference as resolveStoredPieceReference,
   resolveSlugTarget,
   resolveSlugTargetCell,
@@ -737,8 +737,12 @@ export async function listSpaceSlugs(
   return Promise.all(
     slugs.map(async (slug) => {
       try {
-        const { piece, path } = await resolveSlugTarget(pieces, slug);
-        return { slug, piece, ...(path.length > 0 && { path }) };
+        const { piece, pathInside } = await resolveSlugTarget(pieces, slug);
+        return {
+          slug,
+          piece,
+          ...(pathInside.length > 0 && { path: pathInside }),
+        };
       } catch (err) {
         return {
           slug,
@@ -1340,7 +1344,7 @@ function pieceReferenceResolver(
   if (resolveAddress) {
     return async (pieces, token, path) => ({
       piece: await resolveAddress(pieces, token),
-      path: [...path],
+      pathAfter: [...path],
     });
   }
   return resolveStoredPieceReference;
@@ -1379,7 +1383,10 @@ async function resolvePieceTargetWithPieces(
     path,
   );
   const { piecePath: _embedded, ...rest } = config;
-  return { config: { ...rest, piece: resolved.piece }, path: resolved.path };
+  return {
+    config: { ...rest, piece: resolved.piece },
+    path: resolved.pathAfter,
+  };
 }
 
 /**
@@ -1399,7 +1406,9 @@ async function resolvePieceConfigWithPieces(
     deps,
   );
   if (target.path.length > 0) {
-    throw new Error(pieceIdOnlyPathRefusal(target.path));
+    throw new ValidationError(pieceIdOnlyPathRefusal(target.path), {
+      exitCode: 1,
+    });
   }
   return target.config;
 }
@@ -1417,6 +1426,16 @@ export function pieceIdOnlyPathRefusal(
   }") but this command takes a piece id only.`;
 }
 
+/**
+ * The refusal a write meets when it names no path inside the piece it
+ * reaches: a bare address must not replace a whole cell, and a caller that
+ * means the root says so with an explicit empty path.
+ */
+export function pathRequiredRefusal(): string {
+  return `A path is required: embed it in the address (/of:.../title) or ` +
+    `pass it as an argument ("" writes the root).`;
+}
+
 export async function resolvePieceConfig(
   config: PieceConfig,
   deps: PieceResolutionDeps = {},
@@ -1425,15 +1444,24 @@ export async function resolvePieceConfig(
   return await resolvePieceConfigWithPieces(config, pieces, deps);
 }
 
+/**
+ * Resolves a link endpoint's address together with the path written after it,
+ * as every address resolves: a slug naming a collection spends the first
+ * segment on the member, and what is left is a cell path inside the piece the
+ * endpoint reached.
+ *
+ * `options.allowMissingSlugFallback` keeps an id-shaped token that names no
+ * slug document, so an endpoint may be a piece the space has not seen.
+ */
 export async function resolveLinkEndpointAddress(
   pieces: PiecesController,
   token: string,
-  resolver: PieceResolutionDeps["resolvePieceAddress"] =
-    resolveStoredPieceAddress,
+  path: readonly (string | number)[],
+  deps: PieceResolutionDeps = {},
   options?: { allowMissingSlugFallback?: boolean },
-): Promise<string> {
+): Promise<PieceReference> {
   try {
-    return await resolver(pieces, token);
+    return await pieceReferenceResolver(deps)(pieces, token, path);
   } catch (error) {
     if (
       options?.allowMissingSlugFallback &&
@@ -1445,7 +1473,7 @@ export async function resolveLinkEndpointAddress(
       // non-hash string reach `entityIdFrom`.
       !isSlugAddress(token)
     ) {
-      return token;
+      return { piece: token, pathAfter: [...path] };
     }
     throw error;
   }
@@ -1558,16 +1586,18 @@ export async function setPieceSlug(
     sourceScope?: PieceConfig["pieceScope"];
     resolveBeforeLinking?: boolean;
   },
+  deps: PieceResolutionDeps = {},
 ): Promise<void> {
   const pieces = await timeCliPhase(
     "setPieceSlug.loadPieces",
-    () => loadPieces(config),
+    () => (deps.loadPieces ?? loadPieces)(config),
   );
   const source = await resolveSlugSourceCell(
     pieces,
     sourcePieceId,
     sourcePath,
     options?.sourceScope,
+    deps,
   );
   await timeCliPhase("setPieceSlug.source.sync", () => source.sync());
   await timeCliPhase(
@@ -1588,23 +1618,34 @@ export async function setPieceSlug(
  * slug with a path after it resolves the way every address does, so `/top/2`
  * is the member piece and `/top/2/title` a cell inside it. A bare slug is the
  * cell it points at, piece or not: naming one slug's target by another is an
- * alias, and an alias of a collection's name needs no piece behind it.
+ * alias, and an alias of a collection's name needs no piece behind it. That
+ * one target is the slug's own redirect, which names its own scope, so a
+ * scope written beside a bare slug is refused rather than dropped.
  */
 async function resolveSlugSourceCell(
   pieces: PiecesController,
   sourcePieceId: string,
   sourcePath: (string | number)[],
   sourceScope: PieceConfig["pieceScope"],
+  deps: PieceResolutionDeps,
 ): Promise<Cell<unknown>> {
   if (isSlugAddress(sourcePieceId) && sourcePath.length === 0) {
+    if (sourceScope !== undefined) {
+      throw new ValidationError(
+        `Slug "${sourcePieceId}" points at a cell whose own redirect names ` +
+          `its scope, so \`@${sourceScope}\` has nothing to apply to. Name ` +
+          `the cell itself to scope it.`,
+        { exitCode: 1 },
+      );
+    }
     return await timeCliPhase(
       "setPieceSlug.resolveSource",
       () => resolveSlugTargetCell(pieces, sourcePieceId),
     );
   }
-  const { piece, path } = await timeCliPhase(
+  const { piece, pathAfter: path } = await timeCliPhase(
     "setPieceSlug.resolveSource",
-    () => resolveStoredPieceReference(pieces, sourcePieceId, sourcePath),
+    () => pieceReferenceResolver(deps)(pieces, sourcePieceId, sourcePath),
   );
   if (path.length === 0) {
     return pieces.runtime.getCellFromEntityId(
@@ -3628,25 +3669,25 @@ export async function linkPieces(
     "linkPieces.loadPieces",
     () => (deps.loadPieces ?? loadPieces)(config),
   );
-  const resolvedSourcePieceId = await timeCliPhase(
+  const source = await timeCliPhase(
     "linkPieces.resolveSource",
     () =>
       resolveLinkEndpointAddress(
         pieces,
         sourcePieceId,
-        deps.resolvePieceAddress,
+        sourcePath,
+        deps,
         { allowMissingSlugFallback: true },
       ),
   );
-  const resolvedTargetPieceId = await timeCliPhase(
+  const target = await timeCliPhase(
     "linkPieces.resolveTarget",
-    () =>
-      resolveLinkEndpointAddress(
-        pieces,
-        targetPieceId,
-        deps.resolvePieceAddress,
-      ),
+    () => resolveLinkEndpointAddress(pieces, targetPieceId, targetPath, deps),
   );
+  const resolvedSourcePieceId = source.piece;
+  const resolvedSourcePath = source.pathAfter;
+  const resolvedTargetPieceId = target.piece;
+  const resolvedTargetPath = target.pathAfter;
 
   // Validate that source and target pieces/paths exist by reading them
   if (!options?.allowNonExisting) {
@@ -3668,18 +3709,18 @@ export async function linkPieces(
       getPatternIdentityRef(sourcePiece.getCell()) !== undefined;
     if (!sourceHasPattern) {
       errors.push(`Source piece ${sourcePieceId} does not have pattern`);
-    } else if (sourcePath.length > 0) {
+    } else if (resolvedSourcePath.length > 0) {
       const sourceData = await timeCliPhase(
         "linkPieces.readSourceResult",
         () => sourcePiece.result.get(),
       );
       // Check source path resolves
       let current: any = sourceData;
-      for (const segment of sourcePath) {
+      for (const segment of resolvedSourcePath) {
         if (current == null || typeof current !== "object") {
           errors.push(
             `Source path "${
-              sourcePath.join("/")
+              resolvedSourcePath.join("/")
             }" does not exist on piece ${sourcePieceId}`,
           );
           break;
@@ -3689,7 +3730,7 @@ export async function linkPieces(
       if (current === undefined) {
         errors.push(
           `Source path "${
-            sourcePath.join("/")
+            resolvedSourcePath.join("/")
           }" does not exist on piece ${sourcePieceId}`,
         );
       }
@@ -3710,18 +3751,18 @@ export async function linkPieces(
       getPatternIdentityRef(targetPiece.getCell()) !== undefined;
     if (!targetHasPattern) {
       errors.push(`Target piece ${targetPieceId} does not have pattern`);
-    } else if (targetPath.length > 0) {
+    } else if (resolvedTargetPath.length > 0) {
       // Check target path resolves on the input cell
       const targetData = await timeCliPhase(
         "linkPieces.readTargetInput",
         () => targetPiece.input.get(),
       );
       let current: any = targetData;
-      for (const segment of targetPath) {
+      for (const segment of resolvedTargetPath) {
         if (current == null || typeof current !== "object") {
           errors.push(
             `Target path "${
-              targetPath.join("/")
+              resolvedTargetPath.join("/")
             }" does not exist on piece ${targetPieceId}`,
           );
           break;
@@ -3731,7 +3772,7 @@ export async function linkPieces(
       if (current === undefined) {
         errors.push(
           `Target path "${
-            targetPath.join("/")
+            resolvedTargetPath.join("/")
           }" does not exist on piece ${targetPieceId}`,
         );
       }
@@ -3749,9 +3790,9 @@ export async function linkPieces(
     () =>
       pieces.link(
         resolvedSourcePieceId,
-        sourcePath,
+        resolvedSourcePath,
         resolvedTargetPieceId,
-        targetPath,
+        resolvedTargetPath,
         options,
       ),
   );
@@ -3811,8 +3852,9 @@ export async function linkSqliteDiskSource(
   const resolvedTarget = await resolveLinkEndpointAddress(
     pieces,
     targetPieceId,
+    targetPath,
   );
-  await pieces.link(id, [], resolvedTarget, targetPath, {
+  await pieces.link(id, [], resolvedTarget.piece, resolvedTarget.pathAfter, {
     start: options?.start,
     targetScope: options?.targetScope,
   });
@@ -4657,16 +4699,34 @@ export async function getCellValue(
 }
 
 /**
- * Writes `value` at `path` on a piece's result cell, or on its arguments cell
- * under `options.input`, and receipts the space the write landed in.
+ * Where a {@link setCellValue} write landed: the piece it reached, and the
+ * path inside that piece it was written at.
+ */
+export interface CellWriteTarget {
+  /** The id of the piece written to. */
+  piece: string;
+
+  /** The path inside that piece, empty for a write at its root. */
+  path: (string | number)[];
+}
+
+/**
+ * Writes `value` at the path `addressedPath` resolves to on a piece's result
+ * cell, or on its arguments cell under `options.input`, receipts the space
+ * the write landed in, and reports where it landed.
+ *
+ * `options.refuseRootWrite` refuses a write whose resolved path is empty.
+ * Only resolution can decide that: a slug naming a collection spends the
+ * leading segments reaching the member, so an address carrying a path can
+ * still reach a piece's root.
  */
 export async function setCellValue(
   config: PieceConfig,
   addressedPath: (string | number)[],
   value: unknown,
-  options?: { input?: boolean },
+  options?: { input?: boolean; refuseRootWrite?: boolean },
   deps: PieceResolutionDeps = {},
-): Promise<void> {
+): Promise<CellWriteTarget> {
   const pieces = await (deps.loadPieces ?? loadPieces)(config);
   const { config: resolvedConfig, path } = await resolvePieceTargetWithPieces(
     config,
@@ -4674,6 +4734,9 @@ export async function setCellValue(
     pieces,
     deps,
   );
+  if (options?.refuseRootWrite && path.length === 0) {
+    throw new ValidationError(pathRequiredRefusal(), { exitCode: 1 });
+  }
   const piece = await pieces.get(
     resolvedConfig.piece,
     false,
@@ -4686,6 +4749,7 @@ export async function setCellValue(
     await piece.result.set(value, path);
   }
   noteWroteTo(config.space);
+  return { piece: resolvedConfig.piece, path };
 }
 
 /**

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -1445,6 +1445,24 @@ export async function resolvePieceConfig(
 }
 
 /**
+ * The piece a config addresses, for a command whose intake is a piece and
+ * nothing inside it.
+ *
+ * Every such command resolves through here, because the refusal it owes a
+ * caller cannot be raised at the parse: a slug's embedded path may be spent
+ * selecting a member, and only the walk can tell that from a cell path the
+ * command has no use for. A command that resolved the address on its own
+ * would take the piece and drop the path without saying so.
+ */
+export async function resolveAddressedPieceId(
+  pieces: PiecesController,
+  config: PieceConfig,
+  deps: PieceResolutionDeps = {},
+): Promise<string> {
+  return (await resolvePieceConfigWithPieces(config, pieces, deps)).piece;
+}
+
+/**
  * Resolves a link endpoint's address together with the path written after it,
  * as every address resolves: a slug naming a collection spends the first
  * segment on the member, and what is left is a cell path inside the piece the
@@ -3684,6 +3702,10 @@ export async function linkPieces(
     "linkPieces.resolveTarget",
     () => resolveLinkEndpointAddress(pieces, targetPieceId, targetPath, deps),
   );
+  // Both halves name the piece the walk reached rather than the token that
+  // reached it: an address naming a collection's member checks its path on
+  // the member, and a message pairing that path with the collection's name
+  // would describe a read nobody made.
   const resolvedSourcePieceId = source.piece;
   const resolvedSourcePath = source.pathAfter;
   const resolvedTargetPieceId = target.piece;
@@ -3708,7 +3730,9 @@ export async function linkPieces(
     const sourceHasPattern =
       getPatternIdentityRef(sourcePiece.getCell()) !== undefined;
     if (!sourceHasPattern) {
-      errors.push(`Source piece ${sourcePieceId} does not have pattern`);
+      errors.push(
+        `Source piece ${resolvedSourcePieceId} does not have pattern`,
+      );
     } else if (resolvedSourcePath.length > 0) {
       const sourceData = await timeCliPhase(
         "linkPieces.readSourceResult",
@@ -3721,7 +3745,7 @@ export async function linkPieces(
           errors.push(
             `Source path "${
               resolvedSourcePath.join("/")
-            }" does not exist on piece ${sourcePieceId}`,
+            }" does not exist on piece ${resolvedSourcePieceId}`,
           );
           break;
         }
@@ -3731,7 +3755,7 @@ export async function linkPieces(
         errors.push(
           `Source path "${
             resolvedSourcePath.join("/")
-          }" does not exist on piece ${sourcePieceId}`,
+          }" does not exist on piece ${resolvedSourcePieceId}`,
         );
       }
     }
@@ -3750,7 +3774,9 @@ export async function linkPieces(
     const targetHasPattern =
       getPatternIdentityRef(targetPiece.getCell()) !== undefined;
     if (!targetHasPattern) {
-      errors.push(`Target piece ${targetPieceId} does not have pattern`);
+      errors.push(
+        `Target piece ${resolvedTargetPieceId} does not have pattern`,
+      );
     } else if (resolvedTargetPath.length > 0) {
       // Check target path resolves on the input cell
       const targetData = await timeCliPhase(
@@ -3763,7 +3789,7 @@ export async function linkPieces(
           errors.push(
             `Target path "${
               resolvedTargetPath.join("/")
-            }" does not exist on piece ${targetPieceId}`,
+            }" does not exist on piece ${resolvedTargetPieceId}`,
           );
           break;
         }
@@ -3773,7 +3799,7 @@ export async function linkPieces(
         errors.push(
           `Target path "${
             resolvedTargetPath.join("/")
-          }" does not exist on piece ${targetPieceId}`,
+          }" does not exist on piece ${resolvedTargetPieceId}`,
         );
       }
     }

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -20,7 +20,10 @@ import {
   assignSlug,
   listSlugs,
   pieceId,
+  type PieceReference,
   resolvePieceAddress as resolveStoredPieceAddress,
+  resolvePieceReference as resolveStoredPieceReference,
+  resolveSlugTarget,
   resolveSlugTargetCell,
   setSlugLink,
   SlugResolutionError,
@@ -405,10 +408,26 @@ export interface ExecutedPieceCallable {
 
 export interface PieceResolutionDeps {
   loadPieces?: typeof loadPieces;
+
+  /**
+   * Resolves an address to a piece id. Injected, it stands in for
+   * `resolvePieceReference` as well: the address names the piece, and the
+   * path a command addresses stays a cell path inside it.
+   */
   resolvePieceAddress?: (
     pieces: PiecesController,
     token: string,
   ) => Promise<string>;
+
+  /**
+   * Resolves an address and the path after it to a piece and the path left
+   * inside it — the step a slug that names a collection resolves through.
+   */
+  resolvePieceReference?: (
+    pieces: PiecesController,
+    token: string,
+    path: readonly (string | number)[],
+  ) => Promise<PieceReference>;
 }
 
 interface PieceOperationDependencies extends PieceResolutionDeps {
@@ -686,21 +705,29 @@ export async function listPieces(
   );
 }
 
-/** One `cf piece slugs` row: a name the space's slug index records, and the
- * piece it resolves to. A row carries `error` instead of `piece` when the
- * name does not resolve to one — a slug pointing at a plain cell path, or at
- * a document that no longer loads, is still a name the space has, and a
- * listing that dropped it would misreport the namespace. */
+/** One `cf piece slugs` row: a name the space's slug index records, and
+ * where it points — a piece, or with `path` a cell inside one, which is how a
+ * collection's name is listed. A row carries `error` instead of `piece` when
+ * the name points into no piece — a slug pointing at a plain document, or at
+ * one that no longer loads, is still a name the space has, and a listing that
+ * dropped it would misreport the namespace. */
 export interface SlugSummary {
   slug: string;
   piece?: string;
+
+  /**
+   * The path inside `piece` the slug points at; absent when the slug names
+   * the piece itself.
+   */
+  path?: string[];
+
   error?: string;
 }
 
-/** Every slug the space's index records, each resolved to the piece id
- * `--cell` would resolve it to. The index bounds the listing: it names
- * slugs assigned since it existed, so an older slug still resolves but is
- * not listed — nothing can enumerate what it was never told the name of. */
+/** Every slug the space's index records, each resolved to the piece it points
+ * into and the path inside it. The index bounds the listing: it names slugs
+ * assigned since it existed, so an older slug still resolves but is not
+ * listed — nothing can enumerate what it was never told the name of. */
 export async function listSpaceSlugs(
   config: SpaceConfig,
   deps: PieceOperationDependencies = {},
@@ -710,7 +737,8 @@ export async function listSpaceSlugs(
   return Promise.all(
     slugs.map(async (slug) => {
       try {
-        return { slug, piece: await resolveStoredPieceAddress(pieces, slug) };
+        const { piece, path } = await resolveSlugTarget(pieces, slug);
+        return { slug, piece, ...(path.length > 0 && { path }) };
       } catch (err) {
         return {
           slug,
@@ -1298,16 +1326,95 @@ export async function searchPieces(
   );
 }
 
+/**
+ * The reference resolver a command's deps select: an injected
+ * `resolvePieceReference` as it is; an injected `resolvePieceAddress` lifted
+ * to one, so that it names the piece and the path stays a cell path inside
+ * it; and the stored resolution otherwise.
+ */
+function pieceReferenceResolver(
+  deps: PieceResolutionDeps,
+): NonNullable<PieceResolutionDeps["resolvePieceReference"]> {
+  if (deps.resolvePieceReference) return deps.resolvePieceReference;
+  const resolveAddress = deps.resolvePieceAddress;
+  if (resolveAddress) {
+    return async (pieces, token, path) => ({
+      piece: await resolveAddress(pieces, token),
+      path: [...path],
+    });
+  }
+  return resolveStoredPieceReference;
+}
+
+/**
+ * A command's target once its address has resolved: the piece, and the cell
+ * path inside it that the command addresses.
+ */
+interface ResolvedPieceTarget {
+  /** The config, naming the piece by id and carrying no embedded path. */
+  config: PieceConfig;
+
+  /** The cell path inside the piece. */
+  path: (string | number)[];
+}
+
+/**
+ * Resolves the piece a config addresses and the cell path inside it, from
+ * the address and `path` — the whole path the command addresses, the
+ * reference's embedded segments followed by its positional ones. A slug that
+ * names a collection spends the leading segments reaching the member, which
+ * is why the path resolves with the address rather than after it. The config
+ * returned carries no `piecePath`: the path returned is the whole of what is
+ * left to address.
+ */
+async function resolvePieceTargetWithPieces(
+  config: PieceConfig,
+  path: readonly (string | number)[],
+  pieces: PiecesController,
+  deps: PieceResolutionDeps = {},
+): Promise<ResolvedPieceTarget> {
+  const resolved = await pieceReferenceResolver(deps)(
+    pieces,
+    config.piece,
+    path,
+  );
+  const { piecePath: _embedded, ...rest } = config;
+  return { config: { ...rest, piece: resolved.piece }, path: resolved.path };
+}
+
+/**
+ * Like {@link resolvePieceTargetWithPieces}, for a command whose intake is a
+ * piece and nothing inside it: the reference's embedded path is what
+ * resolves, and a segment left after the piece is refused.
+ */
 async function resolvePieceConfigWithPieces(
   config: PieceConfig,
   pieces: PiecesController,
-  resolver: PieceResolutionDeps["resolvePieceAddress"] =
-    resolveStoredPieceAddress,
+  deps: PieceResolutionDeps = {},
 ): Promise<PieceConfig> {
-  return {
-    ...config,
-    piece: await resolver(pieces, config.piece),
-  };
+  const target = await resolvePieceTargetWithPieces(
+    config,
+    config.piecePath ?? [],
+    pieces,
+    deps,
+  );
+  if (target.path.length > 0) {
+    throw new Error(pieceIdOnlyPathRefusal(target.path));
+  }
+  return target.config;
+}
+
+/**
+ * The refusal for a path on a command that takes a piece and nothing inside
+ * it. Raised at parse time for a handle, whose path can only be a cell path,
+ * and after resolution for a slug, whose path a collection may have spent.
+ */
+export function pieceIdOnlyPathRefusal(
+  path: readonly (string | number)[],
+): string {
+  return `The piece reference embeds a path ("${
+    path.join("/")
+  }") but this command takes a piece id only.`;
 }
 
 export async function resolvePieceConfig(
@@ -1315,11 +1422,7 @@ export async function resolvePieceConfig(
   deps: PieceResolutionDeps = {},
 ): Promise<PieceConfig> {
   const pieces = await (deps.loadPieces ?? loadPieces)(config);
-  return await resolvePieceConfigWithPieces(
-    config,
-    pieces,
-    deps.resolvePieceAddress,
-  );
+  return await resolvePieceConfigWithPieces(config, pieces, deps);
 }
 
 export async function resolveLinkEndpointAddress(
@@ -1460,40 +1563,64 @@ export async function setPieceSlug(
     "setPieceSlug.loadPieces",
     () => loadPieces(config),
   );
-  const resolvedSourcePieceId = await timeCliPhase(
-    "setPieceSlug.resolveSource",
-    () => resolveStoredPieceAddress(pieces, sourcePieceId),
+  const source = await resolveSlugSourceCell(
+    pieces,
+    sourcePieceId,
+    sourcePath,
+    options?.sourceScope,
   );
-  const source = sourcePath.length === 0
-    ? pieces.runtime.getCellFromEntityId(
-      pieces.getSpace(),
-      entityIdFrom(resolvedSourcePieceId),
-      [],
-      undefined,
-      undefined,
-      options?.sourceScope,
-    )
-    : (await timeCliPhase(
-      "setPieceSlug.getSourcePiece",
-      () => {
-        return pieces.get(
-          resolvedSourcePieceId,
-          false,
-          undefined,
-          options?.sourceScope,
-        );
-      },
-    )).getCell().key(...sourcePath);
   await timeCliPhase("setPieceSlug.source.sync", () => source.sync());
   await timeCliPhase(
     "setPieceSlug.setSlugLink",
     () =>
       setSlugLink(pieces, slug, source, {
         resolveBeforeLinking: options?.resolveBeforeLinking,
-        writeTargetMetadata: sourcePath.length === 0,
+        writeTargetMetadata: source.getAsNormalizedFullLink().path.length === 0,
       }),
   );
   noteWroteTo(config.space);
+}
+
+/**
+ * Helper for `setPieceSlug()`, which reads the cell a slug's source names.
+ *
+ * A handle names a piece, and the path after it a cell inside that piece. A
+ * slug with a path after it resolves the way every address does, so `/top/2`
+ * is the member piece and `/top/2/title` a cell inside it. A bare slug is the
+ * cell it points at, piece or not: naming one slug's target by another is an
+ * alias, and an alias of a collection's name needs no piece behind it.
+ */
+async function resolveSlugSourceCell(
+  pieces: PiecesController,
+  sourcePieceId: string,
+  sourcePath: (string | number)[],
+  sourceScope: PieceConfig["pieceScope"],
+): Promise<Cell<unknown>> {
+  if (isSlugAddress(sourcePieceId) && sourcePath.length === 0) {
+    return await timeCliPhase(
+      "setPieceSlug.resolveSource",
+      () => resolveSlugTargetCell(pieces, sourcePieceId),
+    );
+  }
+  const { piece, path } = await timeCliPhase(
+    "setPieceSlug.resolveSource",
+    () => resolveStoredPieceReference(pieces, sourcePieceId, sourcePath),
+  );
+  if (path.length === 0) {
+    return pieces.runtime.getCellFromEntityId(
+      pieces.getSpace(),
+      entityIdFrom(piece),
+      [],
+      undefined,
+      undefined,
+      sourceScope,
+    );
+  }
+  const holder = await timeCliPhase(
+    "setPieceSlug.getSourcePiece",
+    () => pieces.get(piece, false, undefined, sourceScope),
+  );
+  return holder.getCell().key(...path);
 }
 
 /** Replaces the piece's source and returns its setup transaction receipt. */
@@ -1507,7 +1634,7 @@ export async function setPiecePattern(
   const resolvedConfig = await resolvePieceConfigWithPieces(
     config,
     pieces,
-    deps.resolvePieceAddress,
+    deps,
   );
   const piece = await pieces.get(
     resolvedConfig.piece,
@@ -1547,7 +1674,7 @@ export async function checkPiecePattern(
   const resolvedConfig = await resolvePieceConfigWithPieces(
     config,
     pieces,
-    deps.resolvePieceAddress,
+    deps,
   );
   const piece = await pieces.get(
     resolvedConfig.piece,
@@ -3989,7 +4116,7 @@ export async function inspectPiece(
     resolvedConfig = await resolvePieceConfigWithPieces(
       config,
       pieces,
-      deps.resolvePieceAddress,
+      deps,
     );
   } catch (error) {
     if (
@@ -4207,15 +4334,16 @@ async function verbReadRefusalOrNull(
  */
 export async function getCellCfcLabel(
   config: PieceConfig,
-  path: (string | number)[],
+  addressedPath: (string | number)[],
   options: { input?: boolean } = {},
   deps: PieceOperationDependencies = {},
 ): Promise<CfcLabelView | null> {
   const pieces = await (deps.loadPieces ?? loadPieces)(config);
-  const resolvedConfig = await resolvePieceConfigWithPieces(
+  const { config: resolvedConfig, path } = await resolvePieceTargetWithPieces(
     config,
+    addressedPath,
     pieces,
-    deps.resolvePieceAddress,
+    deps,
   );
   const piece = await pieces.get(
     resolvedConfig.piece,
@@ -4240,17 +4368,18 @@ export async function getCellCfcLabel(
  */
 export async function setCellCfcLabel(
   config: PieceConfig,
-  path: (string | number)[],
+  addressedPath: (string | number)[],
   input: unknown,
   options: { input?: boolean } = {},
   deps: PieceOperationDependencies = {},
 ): Promise<CfcLabelView | null> {
   const update = parseCellCfcLabelUpdate(input);
   const pieces = await (deps.loadPieces ?? loadPieces)(config);
-  const resolvedConfig = await resolvePieceConfigWithPieces(
+  const { config: resolvedConfig, path } = await resolvePieceTargetWithPieces(
     config,
+    addressedPath,
     pieces,
-    deps.resolvePieceAddress,
+    deps,
   );
   const piece = await pieces.get(
     resolvedConfig.piece,
@@ -4342,15 +4471,16 @@ export async function setCellCfcLabel(
 
 export async function getCellValue(
   config: PieceConfig,
-  path: (string | number)[],
+  addressedPath: (string | number)[],
   options: GetCellValueOptions = {},
   deps: PieceOperationDependencies = {},
 ): Promise<unknown> {
   const pieces = await (deps.loadPieces ?? loadPieces)(config);
-  const resolvedConfig = await resolvePieceConfigWithPieces(
+  const { config: resolvedConfig, path } = await resolvePieceTargetWithPieces(
     config,
+    addressedPath,
     pieces,
-    deps.resolvePieceAddress,
+    deps,
   );
   const shouldStep = options.step === true;
   const piece = await timeCliPhase(
@@ -4532,16 +4662,17 @@ export async function getCellValue(
  */
 export async function setCellValue(
   config: PieceConfig,
-  path: (string | number)[],
+  addressedPath: (string | number)[],
   value: unknown,
   options?: { input?: boolean },
   deps: PieceResolutionDeps = {},
 ): Promise<void> {
   const pieces = await (deps.loadPieces ?? loadPieces)(config);
-  const resolvedConfig = await resolvePieceConfigWithPieces(
+  const { config: resolvedConfig, path } = await resolvePieceTargetWithPieces(
     config,
+    addressedPath,
     pieces,
-    deps.resolvePieceAddress,
+    deps,
   );
   const piece = await pieces.get(
     resolvedConfig.piece,
@@ -4613,7 +4744,7 @@ export async function stepPiece(
   const resolvedConfig = await resolvePieceConfigWithPieces(
     config,
     pieces,
-    deps.resolvePieceAddress,
+    deps,
   );
   const piece = await timeCliPhase(
     "stepPiece.getPiece",
@@ -4647,7 +4778,7 @@ export async function removePiece(
   const resolvedConfig = await resolvePieceConfigWithPieces(
     config,
     pieces,
-    deps.resolvePieceAddress,
+    deps,
   );
   const removed = await pieces.remove(resolvedConfig.piece);
 

--- a/packages/cli/mod.ts
+++ b/packages/cli/mod.ts
@@ -1,5 +1,6 @@
 import { ValidationError } from "@cliffy/command";
 import { CompilerError, TransformerError } from "@commonfabric/js-compiler";
+import { SlugResolutionError } from "@commonfabric/runner";
 
 import { main as rootCommand } from "./commands/main.ts";
 import { parse } from "./commands/mod.ts";
@@ -11,14 +12,15 @@ import { applyLogLevel } from "./lib/log-level.ts";
 
 /**
  * The value to print for a top-level CLI failure. Validation, transformer,
- * compiler, and verb-input errors carry user-facing messages, so print those
- * without a stack trace. Other Errors print their stack, falling back to the
- * message. Anything else prints as-is.
+ * compiler, verb-input, and slug-resolution errors carry user-facing
+ * messages, so print those without a stack trace. Other Errors print their
+ * stack, falling back to the message. Anything else prints as-is.
  */
 export function renderCliError(e: unknown): unknown {
   if (
     e instanceof ValidationError || e instanceof TransformerError ||
-    e instanceof CompilerError || e instanceof VerbInputValidationError
+    e instanceof CompilerError || e instanceof VerbInputValidationError ||
+    e instanceof SlugResolutionError
   ) {
     return e.message;
   }

--- a/packages/cli/test/completion-providers.test.ts
+++ b/packages/cli/test/completion-providers.test.ts
@@ -12,8 +12,8 @@ import {
   completionProviderKeys,
   descendProjection,
   entityListingView,
-  linkEndpointPrefix,
   liveCandidates,
+  pieceWithPathPrefix,
   projectionKeys,
   resolvePieceContext,
   resolveSpaceContext,
@@ -1241,9 +1241,9 @@ Deno.test("shaping: a typed path splits into parent and replacement prefix", () 
   });
 });
 
-Deno.test("shaping: a link endpoint prefix never doubles the separator", () => {
+Deno.test("shaping: a piece-and-path prefix never doubles the separator", () => {
   // `id//key` would be a different, invalid reference.
-  assertEquals(linkEndpointPrefix("fid1:a", ""), "fid1:a/");
-  assertEquals(linkEndpointPrefix("fid1:a", "items"), "fid1:a/items/");
-  assertEquals(linkEndpointPrefix("fid1:a", "items/0"), "fid1:a/items/0/");
+  assertEquals(pieceWithPathPrefix("fid1:a", ""), "fid1:a/");
+  assertEquals(pieceWithPathPrefix("fid1:a", "items"), "fid1:a/items/");
+  assertEquals(pieceWithPathPrefix("fid1:a", "items/0"), "fid1:a/items/0/");
 });

--- a/packages/cli/test/inspectPiece.test.ts
+++ b/packages/cli/test/inspectPiece.test.ts
@@ -1,0 +1,100 @@
+/**
+ * `cf piece inspect` against a slug, over a real runtime: which piece an
+ * address reaches, and which addresses fall back to reporting the cell the
+ * slug points at instead of a piece. The member is a piece the controller
+ * ran; the board holding the collection is a document stamped with a pattern
+ * identity, which is what the resolvers read.
+ */
+
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { createSession, Identity } from "@commonfabric/identity";
+import { pieceId, setSlugLink } from "@commonfabric/piece";
+import { PiecesController } from "@commonfabric/piece/ops";
+import { type Cell, createBuilder, Runtime } from "@commonfabric/runner";
+import { rawMetaWriteAuthorization } from "@commonfabric/runner/meta-seam";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { inspectPiece } from "../lib/piece.ts";
+
+const CONFIG = {
+  apiUrl: "https://cf.dev",
+  space: "collection-naming",
+  identity: "~/.my.key",
+  piece: "top",
+};
+
+describe("inspectPiece()", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let pieces: PiecesController;
+  let memberId: string;
+
+  beforeEach(async () => {
+    const signer = await Identity.fromPassphrase("cli inspect tests");
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    const session = await createSession({
+      identity: signer,
+      spaceName: "cli-inspect",
+    });
+    pieces = new PiecesController(session, runtime);
+    await pieces.synced();
+    const { commonfabric } = createBuilder();
+    const memberPattern = commonfabric.pattern<{ value: number }>((
+      { value },
+    ) => ({ value }));
+    const member = await pieces.runPersistent(memberPattern, { value: 1 }, "m");
+    memberId = pieceId(member)!;
+    // Member `3` is a plain record, which is what makes the two addresses
+    // below differ: one reaches a piece and the other reaches no piece at all.
+    const board: Cell<unknown> = runtime.getCell(
+      pieces.getSpace(),
+      { space: pieces.getSpace(), random: "board" },
+    );
+    const plain = runtime.getCell(
+      pieces.getSpace(),
+      { space: pieces.getSpace(), random: "plain" },
+    );
+    await runtime.editWithRetry((tx) => {
+      plain.withTx(tx).set({ value: 1 });
+      const withTx = board.withTx(tx);
+      withTx.set({ names: { "2": member, "3": { plain: true } } });
+      withTx.setMetaRaw(
+        "patternIdentity",
+        { identity: "pattern-board", symbol: "default" },
+        rawMetaWriteAuthorization,
+      );
+    });
+    await setSlugLink(pieces, "top", board.key("names"));
+    await setSlugLink(pieces, "plain", plain);
+  });
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  /** The connection held, so the address is all that decides the answer. */
+  const held = { loadPieces: () => Promise.resolve(pieces) };
+
+  it("reports the member the path selects", async () => {
+    expect((await inspectPiece({ ...CONFIG, piecePath: [2] }, held)).id)
+      .toBe(memberId);
+  });
+
+  it("refuses a member that is no piece rather than reporting the collection", async () => {
+    // The fallback below answers for a slug that names a cell, and a caller
+    // who named a member is not asking about the cell the slug points at.
+    // Reporting it would answer a question nobody put.
+    await expect(inspectPiece({ ...CONFIG, piecePath: [3] }, held))
+      .rejects.toThrow(/"top\/3" does not name a piece/);
+  });
+
+  it("reports the cell a slug points at when the address names no member", async () => {
+    expect((await inspectPiece({ ...CONFIG, piece: "plain" }, held)).id)
+      .toBe("plain");
+  });
+});

--- a/packages/cli/test/piece-connection.test.ts
+++ b/packages/cli/test/piece-connection.test.ts
@@ -96,44 +96,104 @@ describe("piece-connection", () => {
       };
     }
 
-    it("writes the value at the path on the resolved piece's result cell", async () => {
+    it("writes the value at the path on the resolved piece's result cell, and reports where it landed", async () => {
       resetWriteReceipts();
       const writes: CellWrite[] = [];
-      const lines = await captureStderr(() =>
-        setCellValue(
+      let landed: unknown;
+      const lines = await captureStderr(async () => {
+        landed = await setCellValue(
           config,
           ["items", 0, "title"],
           "Milk",
           undefined,
           overResolving(stubController(writes)),
-        )
-      );
+        );
+      });
       expect(writes).toEqual([{
         piece: RESOLVED_PIECE,
         cell: "result",
         value: "Milk",
         path: ["items", 0, "title"],
       }]);
+      // The receipt a caller prints names the piece written to rather than
+      // the address that reached it, which is not the same thing once a
+      // collection's name has spent segments getting there.
+      expect(landed).toEqual({
+        piece: RESOLVED_PIECE,
+        path: ["items", 0, "title"],
+      });
       expect(lines).toContain(`wrote to space ${SPACE}`);
     });
 
     it("writes to the arguments cell given `input`", async () => {
       resetWriteReceipts();
       const writes: CellWrite[] = [];
-      await captureStderr(() =>
-        setCellValue(
+      await captureStderr(async () => {
+        await setCellValue(
           config,
           ["title"],
           "Bread",
           { input: true },
           overResolving(stubController(writes)),
-        )
-      );
+        );
+      });
       expect(writes).toEqual([{
         piece: RESOLVED_PIECE,
         cell: "input",
         value: "Bread",
         path: ["title"],
+      }]);
+    });
+
+    /**
+     * A held connection whose reference resolver spends the whole addressed
+     * path reaching a piece, the way a collection's name resolves a member:
+     * what comes back has nothing left to address inside it.
+     */
+    function overCollection(pieces: PiecesController): PieceResolutionDeps {
+      return {
+        loadPieces: () => Promise.resolve(pieces),
+        resolvePieceReference: () =>
+          Promise.resolve({ piece: RESOLVED_PIECE, pathAfter: [] }),
+      };
+    }
+
+    it("refuses a write that resolves to a whole cell under `refuseRootWrite`", async () => {
+      // The address carries a path, so nothing before resolution can tell
+      // that the write would land on a whole cell: the segments are spent
+      // selecting the member. Refusing after resolution is what keeps an
+      // address alone from replacing everything the member holds.
+      resetWriteReceipts();
+      const writes: CellWrite[] = [];
+      await expect(
+        setCellValue(
+          config,
+          ["2"],
+          "Milk",
+          { refuseRootWrite: true },
+          overCollection(stubController(writes)),
+        ),
+      ).rejects.toThrow(/A path is required/);
+      expect(writes).toEqual([]);
+    });
+
+    it("writes a whole cell where the caller allows a root write", async () => {
+      resetWriteReceipts();
+      const writes: CellWrite[] = [];
+      await captureStderr(async () => {
+        await setCellValue(
+          config,
+          ["2"],
+          { title: "Milk" },
+          { refuseRootWrite: false },
+          overCollection(stubController(writes)),
+        );
+      });
+      expect(writes).toEqual([{
+        piece: RESOLVED_PIECE,
+        cell: "result",
+        value: { title: "Milk" },
+        path: [],
       }]);
     });
   });
@@ -251,6 +311,39 @@ describe("piece-connection", () => {
         targetPath: ["feed"],
       }]);
       expect(lines).toContain(`wrote to space ${SPACE}`);
+    });
+
+    it("spends an endpoint's leading segments on the member and links what is left", async () => {
+      // A collection's name reaches a link endpoint the way it reaches every
+      // other address: `/top/2/items` is `items` on the piece member `2`
+      // holds, so that is the path validated and the path linked.
+      resetWriteReceipts();
+      const links: LinkCall[] = [];
+      await captureStderr(() =>
+        linkPieces(
+          config,
+          "top",
+          ["2", "items"],
+          "target-slug",
+          ["feed"],
+          undefined,
+          {
+            loadPieces: () => Promise.resolve(stubController(links, endpoints)),
+            resolvePieceReference: (_pieces, token, path) =>
+              Promise.resolve(
+                token === "top"
+                  ? { piece: "fid1:source", pathAfter: path.slice(1) }
+                  : { piece: "fid1:target", pathAfter: [...path] },
+              ),
+          },
+        )
+      );
+      expect(links).toEqual([{
+        source: "fid1:source",
+        sourcePath: ["items"],
+        target: "fid1:target",
+        targetPath: ["feed"],
+      }]);
     });
 
     it("throws for a path neither endpoint holds, and links nothing", async () => {

--- a/packages/cli/test/piece-reference.test.ts
+++ b/packages/cli/test/piece-reference.test.ts
@@ -59,7 +59,7 @@ describe("piece-reference", () => {
       const seen = {};
       const resolved = await resolvePieceConfig(
         { ...CONFIG, piece: "top", piecePath: [2] },
-        resolving({ piece: MEMBER, path: [] }, seen),
+        resolving({ piece: MEMBER, pathAfter: [] }, seen),
       );
       expect(seen).toEqual({ token: "top", path: [2] });
       expect(resolved.piece).toBe(MEMBER);
@@ -70,7 +70,7 @@ describe("piece-reference", () => {
       await expect(
         resolvePieceConfig(
           { ...CONFIG, piece: "top", piecePath: [2, "title"] },
-          resolving({ piece: MEMBER, path: ["title"] }, {}),
+          resolving({ piece: MEMBER, pathAfter: ["title"] }, {}),
         ),
       ).rejects.toThrow(
         /embeds a path \("title"\) but this command takes a piece id only/,
@@ -122,7 +122,7 @@ describe("piece-reference", () => {
           resolvePieceReference: (_pieces, token, path) => {
             seen.token = token;
             seen.path = path;
-            return Promise.resolve({ piece: MEMBER, path: ["title"] });
+            return Promise.resolve({ piece: MEMBER, pathAfter: ["title"] });
           },
         },
       );

--- a/packages/cli/test/piece-reference.test.ts
+++ b/packages/cli/test/piece-reference.test.ts
@@ -1,0 +1,139 @@
+/**
+ * The CLI's half of resolving a reference whose slug names a collection: the
+ * parse lets a slug's embedded path through where a handle's is refused, a
+ * command that takes a piece and nothing inside it walks that path and refuses
+ * what the walk leaves, and a command that reads at a path hands the whole
+ * addressed path to the reference resolver and reads at what comes back. The
+ * walk itself runs against a real runtime in
+ * `packages/piece/test/slug.test.ts`; here it is a double, so what is pinned
+ * is the plumbing around it.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import type { PieceReference } from "@commonfabric/piece";
+import { parsePieceOptions } from "../commands/piece.ts";
+import { getCellValue, resolvePieceConfig } from "../lib/piece.ts";
+
+const CONFIG = {
+  apiUrl: "https://cf.dev",
+  space: "common-knowledge",
+  identity: "~/.my.key",
+};
+const HANDLE = "of:fid1:baedreiabcdefghijklmnopqrstuvwxyz0123456789";
+const MEMBER = "of:fid1:baedreimemberabcdefghijklmnopqrstuvwxyz01234";
+
+describe("piece-reference", () => {
+  describe("parsePieceOptions()", () => {
+    it("carries a slug's embedded path where the command takes a piece id only, and refuses a handle's", () => {
+      expect(parsePieceOptions({ ...CONFIG, cell: "/top/2" })).toMatchObject({
+        piece: "top",
+        piecePath: [2],
+      });
+      expect(() => parsePieceOptions({ ...CONFIG, cell: `/${HANDLE}/items` }))
+        .toThrow(/takes a piece id only/);
+    });
+  });
+
+  describe("resolvePieceConfig()", () => {
+    /** Deps whose reference resolver returns `result` and records its call. */
+    function resolving(
+      result: PieceReference,
+      seen: { token?: string; path?: unknown },
+    ) {
+      return {
+        loadPieces: () => Promise.resolve({} as never),
+        resolvePieceReference: (
+          _pieces: unknown,
+          token: string,
+          path: readonly (string | number)[],
+        ) => {
+          seen.token = token;
+          seen.path = path;
+          return Promise.resolve(result);
+        },
+      };
+    }
+
+    it("walks a slug's embedded path through the reference resolver and drops it from the config", async () => {
+      const seen = {};
+      const resolved = await resolvePieceConfig(
+        { ...CONFIG, piece: "top", piecePath: [2] },
+        resolving({ piece: MEMBER, path: [] }, seen),
+      );
+      expect(seen).toEqual({ token: "top", path: [2] });
+      expect(resolved.piece).toBe(MEMBER);
+      expect(Object.hasOwn(resolved, "piecePath")).toBe(false);
+    });
+
+    it("refuses the segments the walk leaves, in the parse's words", async () => {
+      await expect(
+        resolvePieceConfig(
+          { ...CONFIG, piece: "top", piecePath: [2, "title"] },
+          resolving({ piece: MEMBER, path: ["title"] }, {}),
+        ),
+      ).rejects.toThrow(
+        /embeds a path \("title"\) but this command takes a piece id only/,
+      );
+    });
+
+    it("keeps the path a cell path inside the piece an injected address resolver names", async () => {
+      // An injected `resolvePieceAddress` names the piece and nothing more,
+      // so the embedded path is left over and refused here.
+      await expect(
+        resolvePieceConfig({ ...CONFIG, piece: "top", piecePath: [2] }, {
+          loadPieces: () => Promise.resolve({} as never),
+          resolvePieceAddress: () => Promise.resolve(MEMBER),
+        }),
+      ).rejects.toThrow(/embeds a path \("2"\)/);
+    });
+  });
+
+  describe("getCellValue()", () => {
+    it("hands the whole addressed path to the reference resolver and reads at the path it returns", async () => {
+      const seen: {
+        token?: string;
+        path?: unknown;
+        got?: unknown;
+        read?: unknown;
+      } = {};
+      const piece = {
+        result: {
+          get: (path: unknown) => {
+            seen.read = path;
+            return Promise.resolve("Oven schedule");
+          },
+          getCell: () => Promise.resolve({ key: () => ({ key: () => ({}) }) }),
+        },
+      };
+      const pieces = {
+        get: (id: string) => {
+          seen.got = id;
+          return Promise.resolve(piece);
+        },
+      };
+
+      const value = await getCellValue(
+        { ...CONFIG, piece: "top", piecePath: [2] },
+        [2, "title"],
+        {},
+        {
+          loadPieces: () => Promise.resolve(pieces as never),
+          resolvePieceReference: (_pieces, token, path) => {
+            seen.token = token;
+            seen.path = path;
+            return Promise.resolve({ piece: MEMBER, path: ["title"] });
+          },
+        },
+      );
+
+      expect(value).toBe("Oven schedule");
+      expect(seen).toEqual({
+        token: "top",
+        path: [2, "title"],
+        got: MEMBER,
+        read: ["title"],
+      });
+    });
+  });
+});

--- a/packages/cli/test/piece-reference.test.ts
+++ b/packages/cli/test/piece-reference.test.ts
@@ -12,8 +12,14 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import type { PieceReference } from "@commonfabric/piece";
+import type { RestoreOutcome } from "@commonfabric/piece/ops";
 import { parsePieceOptions } from "../commands/piece.ts";
-import { getCellValue, resolvePieceConfig } from "../lib/piece.ts";
+import { readSourcePin, runRestore } from "../lib/bulk.ts";
+import {
+  getCellValue,
+  type PieceResolutionDeps,
+  resolvePieceConfig,
+} from "../lib/piece.ts";
 
 const CONFIG = {
   apiUrl: "https://cf.dev",
@@ -86,6 +92,66 @@ describe("piece-reference", () => {
           resolvePieceAddress: () => Promise.resolve(MEMBER),
         }),
       ).rejects.toThrow(/embeds a path \("2"\)/);
+    });
+  });
+
+  describe("commands whose intake is a piece and nothing inside it", () => {
+    // Each hands the library a piece id and no path, and the parse lets a
+    // slug's embedded path through because only the walk can tell a member
+    // from a cell path. So a segment the walk leaves is refused here. Dropped
+    // instead, `cf piece restore --apply` would restore the whole piece the
+    // address's first segment reached, saying nothing about the rest.
+
+    const ADDRESSED = { ...CONFIG, piece: "top", piecePath: [2, "title"] };
+
+    /** Deps whose walk reaches {@link MEMBER} and leaves `pathAfter`. */
+    function walkLeaving(
+      pathAfter: (string | number)[],
+    ): PieceResolutionDeps {
+      return {
+        loadPieces: () => Promise.resolve({} as never),
+        resolvePieceReference: () =>
+          Promise.resolve({ piece: MEMBER, pathAfter }),
+      };
+    }
+
+    const OUTCOME: RestoreOutcome = {
+      piece: MEMBER,
+      revisions: [],
+      restored: false,
+    };
+
+    const entryPoints: ReadonlyArray<
+      [string, (deps: PieceResolutionDeps) => Promise<unknown>]
+    > = [
+      ["readSourcePin()", (deps) => readSourcePin(ADDRESSED, deps)],
+      ["runRestore()", (deps) =>
+        runRestore(ADDRESSED, { apply: true }, {
+          ...deps,
+          restorePiece: () => Promise.resolve(OUTCOME),
+        })],
+    ];
+
+    for (const [name, run] of entryPoints) {
+      it(`${name} refuses the segments the walk leaves`, async () => {
+        await expect(run(walkLeaving(["title"]))).rejects.toThrow(
+          /embeds a path \("title"\) but this command takes a piece id only/,
+        );
+      });
+    }
+
+    it("runRestore() writes the piece the walk reached when it leaves nothing", async () => {
+      const restored: string[] = [];
+      await runRestore({ ...CONFIG, piece: "top", piecePath: [2] }, {
+        apply: true,
+      }, {
+        ...walkLeaving([]),
+        restorePiece: (_pieces, piece) => {
+          restored.push(piece);
+          return Promise.resolve(OUTCOME);
+        },
+      });
+      expect(restored).toEqual([MEMBER]);
     });
   });
 

--- a/packages/cli/test/piece-slugs.test.ts
+++ b/packages/cli/test/piece-slugs.test.ts
@@ -1,12 +1,18 @@
 /**
- * `cf piece slugs` at its three seams: the lib listing over an index-cell
- * double (name filtering and per-row error isolation — the happy resolution
- * path runs against a real runtime in `packages/piece/test/slug.test.ts`),
- * the renderer's JSON and table shapes, and the command wiring.
+ * `cf piece slugs` at its three seams: the lib listing — over an index-cell
+ * double for name filtering and per-row error isolation, and over a real
+ * runtime for where a name points, a piece or a cell inside one — the
+ * renderer's JSON and table shapes, and the command wiring.
  */
 
-import { describe, it } from "@std/testing/bdd";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { createSession, Identity } from "@commonfabric/identity";
+import { pieceId, setSlugLink } from "@commonfabric/piece";
+import { PiecesController } from "@commonfabric/piece/ops";
+import { type Cell, Runtime } from "@commonfabric/runner";
+import { rawMetaWriteAuthorization } from "@commonfabric/runner/meta-seam";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { decode } from "@commonfabric/utils/encoding";
 import { listSpaceSlugs } from "../lib/piece.ts";
 import {
@@ -85,13 +91,70 @@ describe("piece-slugs", () => {
         }),
       ).toEqual([]);
     });
+
+    describe("over a real runtime", () => {
+      // The board is a document stamped as a piece's, which is what the
+      // resolution reads; nothing runs. `board` names it, and `top` names the
+      // collection it keeps at `names`.
+
+      let storageManager: ReturnType<typeof StorageManager.emulate>;
+      let runtime: Runtime;
+      let pieces: PiecesController;
+      let board: Cell<unknown>;
+
+      beforeEach(async () => {
+        const signer = await Identity.fromPassphrase("cf piece slugs listing");
+        storageManager = StorageManager.emulate({ as: signer });
+        runtime = new Runtime({
+          apiUrl: new URL(import.meta.url),
+          storageManager,
+        });
+        const session = await createSession({
+          identity: signer,
+          spaceName: "piece-slugs-listing",
+        });
+        pieces = new PiecesController(session, runtime);
+        await pieces.synced();
+        board = runtime.getCell(
+          pieces.getSpace(),
+          { space: pieces.getSpace(), random: "board" },
+        );
+        await runtime.editWithRetry((tx) => {
+          const withTx = board.withTx(tx);
+          withTx.set({ names: {} });
+          withTx.setMetaRaw(
+            "patternIdentity",
+            { identity: "pattern-board", symbol: "default" },
+            rawMetaWriteAuthorization,
+          );
+        });
+        await setSlugLink(pieces, "board", board);
+        await setSlugLink(pieces, "top", board.key("names"));
+      });
+
+      afterEach(async () => {
+        await runtime.dispose();
+        await storageManager.close();
+      });
+
+      it("lists a slug into a piece with the containing piece and the path, and one to a piece with no path", async () => {
+        const rows = await listSpaceSlugs(CONFIG, {
+          loadPieces: () => Promise.resolve(pieces),
+        });
+        expect(rows).toEqual([
+          { slug: "board", piece: pieceId(board) },
+          { slug: "top", piece: pieceId(board), path: ["names"] },
+        ]);
+      });
+    });
   });
 
   describe("renderSlugSummaries", () => {
-    it("renders rows as JSON with a null piece and the error carried through", () => {
+    it("renders rows as JSON with a null piece, the path where there is one, and the error carried through", () => {
       const json = captureStdout(() =>
         renderSlugSummaries([
           { slug: "board", piece: "fid1:abc" },
+          { slug: "top", piece: "fid1:abc", path: ["names"] },
           {
             slug: "broken",
             error: "redirects to a document that is not a piece",
@@ -100,6 +163,7 @@ describe("piece-slugs", () => {
       );
       expect(JSON.parse(json)).toEqual([
         { slug: "board", piece: "fid1:abc" },
+        { slug: "top", piece: "fid1:abc", path: ["names"] },
         {
           slug: "broken",
           piece: null,
@@ -108,10 +172,11 @@ describe("piece-slugs", () => {
       ]);
     });
 
-    it("renders a SLUG/PIECE table with an error marker, and nothing when empty", () => {
+    it("renders a SLUG/PIECE table with `piece/path` for a slug into a piece and an error marker, and nothing when empty", () => {
       const table = captureStdout(() =>
         renderSlugSummaries([
           { slug: "board", piece: "fid1:abc" },
+          { slug: "top", piece: "fid1:abc", path: ["names"] },
           { slug: "broken", error: "no longer loads" },
         ], false)
       );
@@ -119,6 +184,7 @@ describe("piece-slugs", () => {
       expect(table).toContain("PIECE");
       expect(table).toContain("board");
       expect(table).toContain("fid1:abc");
+      expect(table).toContain("fid1:abc/names");
       expect(table).toContain("<error: no longer loads>");
 
       expect(captureStdout(() => renderSlugSummaries([], false))).toBe("");

--- a/packages/cli/test/piece-survey.test.ts
+++ b/packages/cli/test/piece-survey.test.ts
@@ -227,6 +227,21 @@ describe("piece-survey", () => {
       expect(hints).toEqual(["members: 1 on idA#default"]);
     });
 
+    it("refuses a path on the holder's address, which the selector cannot carry", async () => {
+      // `--path` names the collection, so a path on the address has nowhere
+      // to go. The parse lets a slug's through — only the walk can tell a
+      // member from a cell path — and a selector built without it would run
+      // against the piece the first segment named and say nothing.
+      await expect(
+        surveyFromCommand(
+          { ...OPTIONS, cell: "/board/topics", path: "topics" },
+          {
+            runSurvey: () => Promise.resolve(COMPLETE),
+          },
+        ),
+      ).rejects.toThrow(/drop the path on "topics"/);
+    });
+
     it("refuses a --side that is neither input nor result", async () => {
       await expect(
         surveyFromCommand({ ...OPTIONS, path: "topics", side: "bogus" }, {

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -938,19 +938,29 @@ describe("cli piece parsing", () => {
     const base = { apiUrl: API_URL, space: SPACE, identity: ID, quiet: true };
     const rendered: string[] = [];
     const hints: string[] = [];
-    await setCellValueFromCommand(base, "/top/2", "title", {
+    const reporting = {
       drainStdin: (() => Promise.resolve("Oven schedule")) as never,
-      setCellValue: (() =>
-        Promise.resolve({ piece: LLM_HANDLE, path: ["title"] })) as never,
+      setCellValue:
+        (() =>
+          Promise.resolve({ piece: LLM_HANDLE, path: ["title"] })) as never,
       render: ((text: string) => {
         rendered.push(text);
       }) as never,
       hint: ((text: string) => {
         hints.push(text);
       }) as never,
-    });
+    };
+    await setCellValueFromCommand(base, "/top/2", "title", reporting);
     expect(rendered).toEqual(["Set value at path: title"]);
     expect(hints[0]).toContain(`cf piece step --cell ${LLM_HANDLE}`);
+
+    // Where the walk spends nothing the address still names the piece, and
+    // the next command is one the reader can paste as they typed it.
+    rendered.length = 0;
+    hints.length = 0;
+    await setCellValueFromCommand(base, "/tracker", "title", reporting);
+    expect(rendered).toEqual(["Set value at path: title"]);
+    expect(hints[0]).toContain("cf piece step --cell tracker");
   });
 
   it("parsePieceOptions() throws on incomplete input", () => {

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -806,14 +806,18 @@ describe("cli piece parsing", () => {
         drainStdin: (() => Promise.resolve(30)) as never,
         setCellValue: ((...args: unknown[]) => {
           writes.push(args);
-          return Promise.resolve();
+          return Promise.resolve({ piece: "thermostat", path: ["target"] });
         }) as never,
         render: (() => {}) as never,
       },
     );
     expect(writes).toHaveLength(1);
     expect(writes[0]?.[0]).toMatchObject({ piece: "thermostat" });
-    expect(writes[0]?.slice(1)).toEqual([["target"], 30, { input: true }]);
+    expect(writes[0]?.slice(1)).toEqual([
+      ["target"],
+      30,
+      { input: true, refuseRootWrite: true },
+    ]);
   });
 
   it("getCellValueFromCommand() leaves an unresolved path on the caller's sinks rather than exiting", async () => {
@@ -858,14 +862,18 @@ describe("cli piece parsing", () => {
       drainStdin: (() => Promise.resolve("Milk")) as never,
       setCellValue: ((...args: unknown[]) => {
         writes.push(args);
-        return Promise.resolve();
+        return Promise.resolve({
+          piece: LLM_HANDLE,
+          path: args[1] as (string | number)[],
+        });
       }) as never,
       render: (() => {}) as never,
       hint: ((text: string) => {
         hints.push(text);
       }) as never,
     };
-    // The embedded path alone satisfies the path requirement.
+    // The embedded path alone satisfies the path requirement, and the write
+    // is still held to a path inside whatever piece the address reaches.
     await setCellValueFromCommand(
       base,
       `/${LLM_HANDLE}/title`,
@@ -875,21 +883,38 @@ describe("cli piece parsing", () => {
     expect(writes[0]?.slice(1)).toEqual([
       ["title"],
       "Milk",
-      { input: undefined },
+      { input: undefined, refuseRootWrite: true },
+    ]);
+    // A positional that is not the empty one is a path, not a root: what it
+    // reaches after resolution is still held to a path inside the piece.
+    await setCellValueFromCommand(base, "/top", "2", deps);
+    expect(writes[1]?.slice(1)).toEqual([
+      [2],
+      "Milk",
+      { input: undefined, refuseRootWrite: true },
     ]);
     expect(hints[0]).toContain("cf piece step");
     // An explicit empty positional has always named the root — the fuse
     // integration writes a whole input cell with `piece set "" --input` —
-    // so it stays a valid spelling, in both target forms.
+    // so it stays a valid spelling, in both target forms, and it is the one
+    // spelling that lets a write land on a whole cell.
     await setCellValueFromCommand(
       { ...base, cell: `/${LLM_HANDLE}`, input: true },
       "",
       undefined,
       deps,
     );
-    expect(writes[1]?.slice(1)).toEqual([[], "Milk", { input: true }]);
+    expect(writes[2]?.slice(1)).toEqual([
+      [],
+      "Milk",
+      { input: true, refuseRootWrite: false },
+    ]);
     await setCellValueFromCommand(base, `/${LLM_HANDLE}`, "", deps);
-    expect(writes[2]?.slice(1)).toEqual([[], "Milk", { input: undefined }]);
+    expect(writes[3]?.slice(1)).toEqual([
+      [],
+      "Milk",
+      { input: undefined, refuseRootWrite: false },
+    ]);
     // What stays refused is no path in any spelling: a bare pasted address
     // must not silently overwrite a whole cell.
     await expect(
@@ -904,6 +929,28 @@ describe("cli piece parsing", () => {
         deps,
       ),
     ).rejects.toThrow(/A path is required/);
+  });
+
+  it("setCellValueFromCommand() reports the piece and the path the write landed on", async () => {
+    // A collection's name spends its leading segments reaching a member, so
+    // the address the line carries names neither the piece written to nor the
+    // path written at. Both come back from the write.
+    const base = { apiUrl: API_URL, space: SPACE, identity: ID, quiet: true };
+    const rendered: string[] = [];
+    const hints: string[] = [];
+    await setCellValueFromCommand(base, "/top/2", "title", {
+      drainStdin: (() => Promise.resolve("Oven schedule")) as never,
+      setCellValue: (() =>
+        Promise.resolve({ piece: LLM_HANDLE, path: ["title"] })) as never,
+      render: ((text: string) => {
+        rendered.push(text);
+      }) as never,
+      hint: ((text: string) => {
+        hints.push(text);
+      }) as never,
+    });
+    expect(rendered).toEqual(["Set value at path: title"]);
+    expect(hints[0]).toContain(`cf piece step --cell ${LLM_HANDLE}`);
   });
 
   it("parsePieceOptions() throws on incomplete input", () => {
@@ -4713,11 +4760,14 @@ describe("cli piece parsing", () => {
     expect(resolved.piece).toBe("of:fid1:piece-123");
   });
 
-  it("preserves URI link endpoints without slug lookup", async () => {
+  it("preserves URI link endpoints and their paths without slug lookup", async () => {
     const token = "of:fid1:piece-123";
-    const resolved = await resolveLinkEndpointAddress({} as any, token);
+    const resolved = await resolveLinkEndpointAddress({} as any, token, [
+      "items",
+      0,
+    ]);
 
-    expect(resolved).toBe(token);
+    expect(resolved).toEqual({ piece: token, pathAfter: ["items", 0] });
   });
 
   it("rejects a bare endpoint with no slug document, even with the fallback", async () => {
@@ -4729,10 +4779,13 @@ describe("cli piece parsing", () => {
     await expect(resolveLinkEndpointAddress(
       manager as any,
       token,
-      () =>
-        Promise.reject(
-          new SlugResolutionError(`Slug "${token}" not found.`, "missing"),
-        ),
+      [],
+      {
+        resolvePieceAddress: () =>
+          Promise.reject(
+            new SlugResolutionError(`Slug "${token}" not found.`, "missing"),
+          ),
+      },
       { allowMissingSlugFallback: true },
     )).rejects.toThrow(/Slug "a-bare-name" not found/);
   });
@@ -4743,10 +4796,13 @@ describe("cli piece parsing", () => {
     await expect(resolveLinkEndpointAddress(
       manager as any,
       token,
-      () =>
-        Promise.reject(
-          new SlugResolutionError(`Slug "${token}" not found.`, "missing"),
-        ),
+      [],
+      {
+        resolvePieceAddress: () =>
+          Promise.reject(
+            new SlugResolutionError(`Slug "${token}" not found.`, "missing"),
+          ),
+      },
     )).rejects.toThrow(/Slug "demo" not found/);
   });
 });

--- a/packages/cli/test/render-cli-error.test.ts
+++ b/packages/cli/test/render-cli-error.test.ts
@@ -1,5 +1,6 @@
 import { assert, assertEquals } from "@std/assert";
 import { CompilerError, TransformerError } from "@commonfabric/js-compiler";
+import { SlugResolutionError } from "@commonfabric/runner";
 import { ValidationError } from "@cliffy/command";
 import { renderCliError } from "../mod.ts";
 
@@ -17,6 +18,14 @@ Deno.test("renderCliError prints a CompilerError's message, not its stack", () =
 
 Deno.test("renderCliError prints a ValidationError's message, not its stack", () => {
   const e = new ValidationError("bad option");
+  assertEquals(renderCliError(e), e.message);
+  assert(renderCliError(e) !== e.stack);
+});
+
+Deno.test("renderCliError prints a SlugResolutionError's message, not its stack", () => {
+  // Every one of these says what a name in the space points at, or does not:
+  // a sentence a person acts on, buried by a stack over it.
+  const e = new SlugResolutionError("no member 999 in top", "missing-member");
   assertEquals(renderCliError(e), e.message);
   assert(renderCliError(e) !== e.stack);
 });

--- a/packages/cli/test/scoped-member.test.ts
+++ b/packages/cli/test/scoped-member.test.ts
@@ -1,0 +1,128 @@
+/**
+ * A collection member held through a scoped link, read and written through
+ * the collection's name. Scope selects which instance of an id is addressed,
+ * so the walk reaching a narrowed link is the only thing that says which cell
+ * `/top/<name>` means; an address that dropped it would read and write the
+ * space-wide instance of the same id instead.
+ */
+
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { createSession, Identity } from "@commonfabric/identity";
+import { resolvePieceReference, setSlugLink } from "@commonfabric/piece";
+import { PiecesController } from "@commonfabric/piece/ops";
+import { type Cell, entityIdFrom, Runtime } from "@commonfabric/runner";
+import { rawMetaWriteAuthorization } from "@commonfabric/runner/meta-seam";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { getCellValue, setCellValue } from "../lib/piece.ts";
+import { resetWriteReceipts } from "../lib/write-receipt.ts";
+import { captureStderr } from "./utils.ts";
+
+const CONFIG = {
+  apiUrl: "https://cf.dev",
+  space: "collection-naming",
+  identity: "~/.my.key",
+  piece: "top",
+};
+
+describe("scoped-member", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let pieces: PiecesController;
+  let spaceInstance: Cell<unknown>;
+  let sessionInstance: Cell<unknown>;
+  let memberId: string;
+
+  /** Stamps a document as a piece's, which is what the resolvers read. */
+  function stampAsPiece(
+    cell: Cell<unknown>,
+    tx: Parameters<
+      Parameters<Runtime["editWithRetry"]>[0]
+    >[0],
+  ): void {
+    cell.withTx(tx).setMetaRaw(
+      "patternIdentity",
+      { identity: "pattern-item", symbol: "default" },
+      rawMetaWriteAuthorization,
+    );
+  }
+
+  beforeEach(async () => {
+    resetWriteReceipts();
+    const signer = await Identity.fromPassphrase("cli scoped member tests");
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    const session = await createSession({
+      identity: signer,
+      spaceName: "cli-scoped-member",
+    });
+    pieces = new PiecesController(session, runtime);
+    await pieces.synced();
+    const space = pieces.getSpace();
+
+    // One id, two instances. The board's member `2` links to the session one,
+    // so the two titles are what tells the instances apart.
+    spaceInstance = runtime.getCell(space, { space, random: "item" });
+    memberId = spaceInstance.getAsNormalizedFullLink().id.replace(/^of:/, "");
+    sessionInstance = runtime.getCellFromEntityId(
+      space,
+      entityIdFrom(memberId),
+      [],
+      undefined,
+      undefined,
+      "session",
+    );
+    const board = runtime.getCell(space, { space, random: "board" });
+    await runtime.editWithRetry((tx) => {
+      spaceInstance.withTx(tx).set({ title: "the space-wide instance" });
+      stampAsPiece(spaceInstance, tx);
+      sessionInstance.withTx(tx).set({ title: "the session instance" });
+      stampAsPiece(sessionInstance, tx);
+      board.withTx(tx).set({ names: { "2": sessionInstance } });
+      board.withTx(tx).setMetaRaw(
+        "patternIdentity",
+        { identity: "pattern-board", symbol: "default" },
+        rawMetaWriteAuthorization,
+      );
+    });
+    await setSlugLink(pieces, "top", board.key("names"));
+  });
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  /** The connection held, so the address is all that decides the answer. */
+  const held = { loadPieces: () => Promise.resolve(pieces) };
+
+  it("reports the scope the walk reached the member through", async () => {
+    expect(await resolvePieceReference(pieces, "top", ["2"])).toEqual({
+      piece: memberId,
+      scope: "session",
+      pathAfter: [],
+    });
+  });
+
+  it("reads the instance the member's link names, not the space-wide one", async () => {
+    expect(await getCellValue(CONFIG, ["2", "title"], {}, held))
+      .toBe("the session instance");
+  });
+
+  it("writes to the instance the member's link names", async () => {
+    await captureStderr(async () => {
+      await setCellValue(CONFIG, ["2", "title"], "rewritten", undefined, held);
+    });
+    await sessionInstance.sync();
+    await spaceInstance.sync();
+    expect((sessionInstance.get() as { title: string }).title)
+      .toBe("rewritten");
+    // The other instance of the same id is untouched, which is the whole of
+    // what the scope was carrying.
+    expect((spaceInstance.get() as { title: string }).title)
+      .toBe("the space-wide instance");
+  });
+});

--- a/packages/cli/test/setPieceSlug.test.ts
+++ b/packages/cli/test/setPieceSlug.test.ts
@@ -1,0 +1,148 @@
+/**
+ * `cf piece set-slug`'s source resolution over a real runtime: which cell each
+ * spelling of a source names, whether the piece a name lands on is stamped
+ * with it, and the scope a bare slug leaves nothing to apply to. The members
+ * are pieces the controller ran; the board holding the collection is a
+ * document stamped with a pattern identity, which is what the resolvers read.
+ */
+
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { createSession, Identity } from "@commonfabric/identity";
+import { pieceId, resolveSlugTarget } from "@commonfabric/piece";
+import { PiecesController } from "@commonfabric/piece/ops";
+import {
+  type Cell,
+  createBuilder,
+  Runtime,
+  type URI,
+} from "@commonfabric/runner";
+import { rawMetaWriteAuthorization } from "@commonfabric/runner/meta-seam";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { setPieceSlug } from "../lib/piece.ts";
+import { resetWriteReceipts } from "../lib/write-receipt.ts";
+import { captureStderr } from "./utils.ts";
+
+const CONFIG = {
+  apiUrl: "https://cf.dev",
+  space: "collection-naming",
+  identity: "~/.my.key",
+};
+
+describe("setPieceSlug()", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let pieces: PiecesController;
+  let board: Cell<unknown>;
+  let boardId: string;
+  let memberId: string;
+
+  beforeEach(async () => {
+    resetWriteReceipts();
+    const signer = await Identity.fromPassphrase("cli set-slug tests");
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    const session = await createSession({
+      identity: signer,
+      spaceName: "cli-set-slug",
+    });
+    pieces = new PiecesController(session, runtime);
+    await pieces.synced();
+    const { commonfabric } = createBuilder();
+    const memberPattern = commonfabric.pattern<{ value: number }>((
+      { value },
+    ) => ({ value }));
+    const member = await pieces.runPersistent(memberPattern, { value: 1 }, "m");
+    memberId = pieceId(member)!;
+    board = runtime.getCell(
+      pieces.getSpace(),
+      { space: pieces.getSpace(), random: "board" },
+    );
+    await runtime.editWithRetry((tx) => {
+      const withTx = board.withTx(tx);
+      withTx.set({ names: { "2": member } });
+      withTx.setMetaRaw(
+        "patternIdentity",
+        { identity: "pattern-board", symbol: "default" },
+        rawMetaWriteAuthorization,
+      );
+    });
+    boardId = pieceId(board)!;
+  });
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  /** The `slug` meta entry on a document's root, or `undefined` for none. */
+  function slugMetaOf(id: string): unknown {
+    return runtime.readTx().readOrThrow({
+      space: pieces.getSpace(),
+      id: `of:${id}` as URI,
+      scope: "space",
+      path: ["slug"],
+    });
+  }
+
+  /** Runs `setPieceSlug()` with the connection held, swallowing its receipt. */
+  async function setSlug(
+    slug: string,
+    source: string,
+    path: (string | number)[],
+    options?: Parameters<typeof setPieceSlug>[4],
+  ): Promise<void> {
+    await captureStderr(() =>
+      setPieceSlug(CONFIG, slug, source, path, options, {
+        loadPieces: () => Promise.resolve(pieces),
+      })
+    );
+  }
+
+  it("names the cell a handle's path selects, and stamps no piece with the name", async () => {
+    // The name is the collection's, and the collection is not a piece, so
+    // there is no piece whose one `slug` entry this name could claim.
+    await setSlug("top", boardId, ["names"]);
+
+    expect(await resolveSlugTarget(pieces, "top")).toEqual({
+      piece: boardId,
+      pathInside: ["names"],
+    });
+    expect(slugMetaOf(boardId)).toBeUndefined();
+  });
+
+  it("names the member a slug's path selects, and stamps that member with the name", async () => {
+    await setSlug("top", boardId, ["names"]);
+    await setSlug("two", "top", ["2"]);
+
+    expect(await resolveSlugTarget(pieces, "two")).toEqual({
+      piece: memberId,
+      pathInside: [],
+    });
+    expect(slugMetaOf(memberId)).toBe("two");
+  });
+
+  it("names whatever a bare slug points at, which is how a collection's name is aliased", async () => {
+    await setSlug("top", boardId, ["names"]);
+    await setSlug("board-names", "top", []);
+
+    expect(await resolveSlugTarget(pieces, "board-names")).toEqual({
+      piece: boardId,
+      pathInside: ["names"],
+    });
+  });
+
+  it("refuses a scope written on a bare slug, which has no cell of its own to scope", async () => {
+    await setSlug("top", boardId, ["names"]);
+
+    await expect(
+      setSlug("alias", "top", [], { sourceScope: "session" }),
+    ).rejects.toThrow(/has nothing to apply to/);
+    await expect(resolveSlugTarget(pieces, "alias")).rejects.toThrow(
+      /not found/,
+    );
+  });
+});

--- a/packages/piece/src/index.ts
+++ b/packages/piece/src/index.ts
@@ -2,8 +2,12 @@ export { pieceId } from "./piece-id.ts";
 export {
   assignSlug,
   listSlugs,
+  type PieceReference,
   resolvePieceAddress,
+  resolvePieceReference,
+  resolveSlugTarget,
   resolveSlugTargetCell,
   setSlugLink,
   SlugResolutionError,
+  type SlugTarget,
 } from "./slugs.ts";

--- a/packages/piece/src/slugs.ts
+++ b/packages/piece/src/slugs.ts
@@ -132,8 +132,8 @@ export interface PieceReference {
   /** The piece's id. */
   piece: string;
 
-  /** The segments after the piece, a cell path inside it. */
-  path: (string | number)[];
+  /** The segments left to address after the piece, a cell path inside it. */
+  pathAfter: (string | number)[];
 }
 
 /**
@@ -146,7 +146,7 @@ export interface SlugTarget {
   piece: string;
 
   /** The path from the piece's root to the target. */
-  path: string[];
+  pathInside: string[];
 }
 
 /**
@@ -165,7 +165,7 @@ export async function resolvePieceReference(
   path: readonly (string | number)[],
 ): Promise<PieceReference> {
   if (!isSlugAddress(token)) {
-    return { piece: token, path: [...path] };
+    return { piece: token, pathAfter: [...path] };
   }
   const target = await resolveSlugReference(
     pieces.runtime,
@@ -173,7 +173,10 @@ export async function resolvePieceReference(
     token,
     path,
   );
-  return { piece: pieceIdOrThrow(token, target.piece), path: target.path };
+  return {
+    piece: pieceIdOrThrow(token, target.piece),
+    pathAfter: target.pathAfter,
+  };
 }
 
 /**
@@ -202,12 +205,15 @@ export async function resolveSlugTarget(
     pieces.getSpace(),
     token,
   );
-  return { piece: pieceIdOrThrow(token, target.piece), path: target.path };
+  return {
+    piece: pieceIdOrThrow(token, target.piece),
+    pathInside: target.pathInside,
+  };
 }
 
 /**
- * Helper for the resolvers above, which reads a piece's id off its root cell
- * and refuses a cell that has none.
+ * Helper for `resolvePieceReference()` and `resolveSlugTarget()`, which reads
+ * a piece's id off its root cell and refuses a cell that has none.
  */
 function pieceIdOrThrow(token: string, piece: Cell<unknown>): string {
   const id = pieceId(piece);

--- a/packages/piece/src/slugs.ts
+++ b/packages/piece/src/slugs.ts
@@ -1,6 +1,7 @@
-import type { JSONSchema } from "@commonfabric/api";
+import type { CellScope, JSONSchema } from "@commonfabric/api";
 import type { Cell } from "@commonfabric/runner";
 import {
+  DEFAULT_CELL_SCOPE,
   entityIdFrom,
   isSlugAddress,
   resolveSlugReference,
@@ -132,6 +133,13 @@ export interface PieceReference {
   /** The piece's id. */
   piece: string;
 
+  /**
+   * The scope the piece was reached through, where that narrows the default.
+   * Absent otherwise, which leaves whatever scope the caller was addressing
+   * under standing.
+   */
+  scope?: CellScope;
+
   /** The segments left to address after the piece, a cell path inside it. */
   pathAfter: (string | number)[];
 }
@@ -173,8 +181,14 @@ export async function resolvePieceReference(
     token,
     path,
   );
+  // Scope selects which instance of an id is addressed, so a member held
+  // through a narrowed link is a different cell from the one the id alone
+  // names. Reporting it is what keeps a read and a write on that member from
+  // landing on the space-wide instance instead.
+  const { scope } = target.piece.getAsNormalizedFullLink();
   return {
     piece: pieceIdOrThrow(token, target.piece),
+    ...(scope !== undefined && scope !== DEFAULT_CELL_SCOPE && { scope }),
     pathAfter: target.pathAfter,
   };
 }

--- a/packages/piece/src/slugs.ts
+++ b/packages/piece/src/slugs.ts
@@ -1,19 +1,20 @@
 import type { JSONSchema } from "@commonfabric/api";
 import type { Cell } from "@commonfabric/runner";
-import { utf8Compare } from "@commonfabric/utils/utf8";
 import {
   entityIdFrom,
-  getPatternIdentityRef,
   isSlugAddress,
+  resolveSlugReference,
   resolveSlugTargetCell as resolveRuntimeSlugTargetCell,
+  resolveSlugTargetInPiece,
   slugIdForSpace,
   slugIndexIdForSpace,
   SlugResolutionError,
   validateSlug,
 } from "@commonfabric/runner";
-import { pieceId } from "./piece-id.ts";
-import type { PiecesController } from "./ops/pieces-controller.ts";
 import { rawMetaWriteAuthorization } from "@commonfabric/runner/meta-seam";
+import { utf8Compare } from "@commonfabric/utils/utf8";
+import type { PiecesController } from "./ops/pieces-controller.ts";
+import { pieceId } from "./piece-id.ts";
 
 export { SlugResolutionError };
 
@@ -123,31 +124,93 @@ export async function setSlugLink(
   await pieces.synced();
 }
 
+/**
+ * A piece and a cell path inside it, as an address and the path written
+ * after it resolve.
+ */
+export interface PieceReference {
+  /** The piece's id. */
+  piece: string;
+
+  /** The segments after the piece, a cell path inside it. */
+  path: (string | number)[];
+}
+
+/**
+ * Where a slug points: the piece whose document holds the target, and the
+ * path from that document's root to the target, which is empty when the slug
+ * names the piece itself.
+ */
+export interface SlugTarget {
+  /** The id of the piece the target sits in. */
+  piece: string;
+
+  /** The path from the piece's root to the target. */
+  path: string[];
+}
+
+/**
+ * Resolves an address and the path written after it to a piece and the cell
+ * path inside it. A handle names its piece and the path is returned whole. A
+ * slug resolves as the runtime's `resolveSlugReference` does: to the piece it
+ * names, with the path returned whole, or through the collection it names to
+ * the member the path's first segment selects, with the rest of the path.
+ *
+ * Fails as `resolveSlugReference` fails, and with `missing-piece-id` when the
+ * piece reached has no id.
+ */
+export async function resolvePieceReference(
+  pieces: PiecesController,
+  token: string,
+  path: readonly (string | number)[],
+): Promise<PieceReference> {
+  if (!isSlugAddress(token)) {
+    return { piece: token, path: [...path] };
+  }
+  const target = await resolveSlugReference(
+    pieces.runtime,
+    pieces.getSpace(),
+    token,
+    path,
+  );
+  return { piece: pieceIdOrThrow(token, target.piece), path: target.path };
+}
+
+/**
+ * Resolves an address to a piece id: a handle as itself, and a slug as
+ * {@link resolvePieceReference} resolves it with no path, so a slug that
+ * names a collection rather than a piece is refused.
+ */
 export async function resolvePieceAddress(
   pieces: PiecesController,
   token: string,
 ): Promise<string> {
-  if (!isSlugAddress(token)) {
-    return token;
-  }
+  return (await resolvePieceReference(pieces, token, [])).piece;
+}
 
-  const target = await resolveSlugTargetCell(pieces, token);
-  // A KEYLESS piece carries no durable pointer (the never-durable
-  // contract; L3(a), RULED 2026-08-27): in the session that set it up the
-  // runner's session pointer vouches for it. A fresh session cannot vouch
-  // for a keyless target — which matches the contract: nothing keyless is
-  // loadable there anyway.
-  if (
-    getPatternIdentityRef(target) === undefined &&
-    pieces.runtime.runner.sessionPatternPointerFor(target) === undefined
-  ) {
-    throw new SlugResolutionError(
-      `Slug "${token}" redirects to a document that is not a piece.`,
-      "not-piece",
-    );
-  }
+/**
+ * Resolves a slug to the piece its target sits in and the path to the target
+ * inside it. Fails with `not-piece` when that document is no piece, and with
+ * `missing-piece-id` when it has no id.
+ */
+export async function resolveSlugTarget(
+  pieces: PiecesController,
+  token: string,
+): Promise<SlugTarget> {
+  const target = await resolveSlugTargetInPiece(
+    pieces.runtime,
+    pieces.getSpace(),
+    token,
+  );
+  return { piece: pieceIdOrThrow(token, target.piece), path: target.path };
+}
 
-  const id = pieceId(target);
+/**
+ * Helper for the resolvers above, which reads a piece's id off its root cell
+ * and refuses a cell that has none.
+ */
+function pieceIdOrThrow(token: string, piece: Cell<unknown>): string {
+  const id = pieceId(piece);
   if (!id) {
     throw new SlugResolutionError(
       `Slug "${token}" redirects to a document without a piece id.`,

--- a/packages/piece/test/slug.test.ts
+++ b/packages/piece/test/slug.test.ts
@@ -348,22 +348,22 @@ describe("piece slugs", () => {
     describe("resolvePieceReference()", () => {
       it("returns the member the first segment selects, and the rest of the path", async () => {
         expect(await resolvePieceReference(pieces, "top", ["2", "value"]))
-          .toEqual({ piece: pieceId(item2), path: ["value"] });
+          .toEqual({ piece: pieceId(item2), pathAfter: ["value"] });
       });
 
       it("reads a numeric segment as the member name it denotes", async () => {
         expect(await resolvePieceReference(pieces, "top", [1]))
-          .toEqual({ piece: pieceId(item1), path: [] });
+          .toEqual({ piece: pieceId(item1), pathAfter: [] });
       });
 
       it("returns the piece and the whole path when the slug names a piece root", async () => {
         expect(await resolvePieceReference(pieces, "one", ["value"]))
-          .toEqual({ piece: pieceId(item1), path: ["value"] });
+          .toEqual({ piece: pieceId(item1), pathAfter: ["value"] });
       });
 
       it("returns a handle and its path untouched", async () => {
         expect(await resolvePieceReference(pieces, "of:fid1:piece-123", ["x"]))
-          .toEqual({ piece: "of:fid1:piece-123", path: ["x"] });
+          .toEqual({ piece: "of:fid1:piece-123", pathAfter: ["x"] });
       });
 
       it("fails with `missing-member` when the collection holds no such name", async () => {
@@ -407,12 +407,12 @@ describe("piece slugs", () => {
     describe("resolveSlugTarget()", () => {
       it("returns the containing piece and the path for a slug into a piece", async () => {
         expect(await resolveSlugTarget(pieces, "top"))
-          .toEqual({ piece: boardId, path: ["names"] });
+          .toEqual({ piece: boardId, pathInside: ["names"] });
       });
 
       it("returns an empty path for a slug that names a piece", async () => {
         expect(await resolveSlugTarget(pieces, "one"))
-          .toEqual({ piece: pieceId(item1), path: [] });
+          .toEqual({ piece: pieceId(item1), pathInside: [] });
       });
 
       it("fails with `not-piece` for a slug to a plain document", async () => {

--- a/packages/piece/test/slug.test.ts
+++ b/packages/piece/test/slug.test.ts
@@ -1,7 +1,13 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { createSession, Identity } from "@commonfabric/identity";
-import { entityIdFrom, Runtime, type URI } from "@commonfabric/runner";
+import {
+  type Cell,
+  entityIdFrom,
+  Runtime,
+  type URI,
+} from "@commonfabric/runner";
+import { rawMetaWriteAuthorization } from "@commonfabric/runner/meta-seam";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { createBuilder } from "../../runner/src/builder/factory.ts";
 import { parseLink } from "../../runner/src/link-utils.ts";
@@ -12,8 +18,11 @@ import {
   assignSlug,
   listSlugs,
   resolvePieceAddress,
+  resolvePieceReference,
+  resolveSlugTarget,
   resolveSlugTargetCell,
   setSlugLink,
+  SlugResolutionError,
 } from "../src/slugs.ts";
 
 const signer = await Identity.fromPassphrase("piece slug tests");
@@ -298,5 +307,128 @@ describe("piece slugs", () => {
     await expect(resolvePieceAddress(pieces, "malformed")).rejects.toThrow(
       /does not contain a valid redirect/,
     );
+  });
+
+  describe("a slug that names a collection", () => {
+    // The members are pieces the controller ran. The board is a document
+    // stamped as a piece's, holding its collection at `names` keyed by member
+    // name, with one key holding a plain value for a member that is no
+    // piece. `top` points at the collection and `one` at the first member.
+
+    let board: Cell<unknown>;
+    let boardId: string;
+    let item1: Cell<unknown>;
+    let item2: Cell<unknown>;
+
+    async function failureOf(work: Promise<unknown>): Promise<unknown> {
+      return await work.then(() => undefined, (error: unknown) => error);
+    }
+
+    beforeEach(async () => {
+      item1 = await createPiece("member-1");
+      item2 = await createPiece("member-2");
+      board = runtime.getCell(
+        pieces.getSpace(),
+        { space: pieces.getSpace(), random: "board" },
+      );
+      await runtime.editWithRetry((tx) => {
+        const withTx = board.withTx(tx);
+        withTx.set({ names: { "1": item1, "2": item2, "3": { plain: true } } });
+        withTx.setMetaRaw(
+          "patternIdentity",
+          { identity: "pattern-board", symbol: "default" },
+          rawMetaWriteAuthorization,
+        );
+      });
+      boardId = pieceId(board)!;
+      await setSlugLink(pieces, "top", board.key("names"));
+      await assignSlug(pieces, item1, "one");
+    });
+
+    describe("resolvePieceReference()", () => {
+      it("returns the member the first segment selects, and the rest of the path", async () => {
+        expect(await resolvePieceReference(pieces, "top", ["2", "value"]))
+          .toEqual({ piece: pieceId(item2), path: ["value"] });
+      });
+
+      it("reads a numeric segment as the member name it denotes", async () => {
+        expect(await resolvePieceReference(pieces, "top", [1]))
+          .toEqual({ piece: pieceId(item1), path: [] });
+      });
+
+      it("returns the piece and the whole path when the slug names a piece root", async () => {
+        expect(await resolvePieceReference(pieces, "one", ["value"]))
+          .toEqual({ piece: pieceId(item1), path: ["value"] });
+      });
+
+      it("returns a handle and its path untouched", async () => {
+        expect(await resolvePieceReference(pieces, "of:fid1:piece-123", ["x"]))
+          .toEqual({ piece: "of:fid1:piece-123", path: ["x"] });
+      });
+
+      it("fails with `missing-member` when the collection holds no such name", async () => {
+        const error = await failureOf(
+          resolvePieceReference(pieces, "top", ["999"]),
+        );
+        expect(error).toBeInstanceOf(SlugResolutionError);
+        expect((error as SlugResolutionError).code).toBe("missing-member");
+        expect((error as Error).message).toBe("no member 999 in top");
+      });
+
+      it("fails with `inside-piece` naming the containing piece when no member follows the collection's name", async () => {
+        for (
+          const work of [
+            resolvePieceReference(pieces, "top", []),
+            resolvePieceAddress(pieces, "top"),
+          ]
+        ) {
+          const error = await failureOf(work);
+          expect(error).toBeInstanceOf(SlugResolutionError);
+          expect((error as SlugResolutionError).code).toBe("inside-piece");
+          expect((error as Error).message).toContain(
+            `inside piece ${boardId}`,
+          );
+          expect((error as Error).message).toContain("top/<name>");
+        }
+      });
+
+      it("fails with `not-piece` when the member holds no piece", async () => {
+        const error = await failureOf(
+          resolvePieceReference(pieces, "top", ["3"]),
+        );
+        expect(error).toBeInstanceOf(SlugResolutionError);
+        expect((error as SlugResolutionError).code).toBe("not-piece");
+        expect((error as Error).message).toMatch(
+          /"top\/3" does not name a piece/,
+        );
+      });
+    });
+
+    describe("resolveSlugTarget()", () => {
+      it("returns the containing piece and the path for a slug into a piece", async () => {
+        expect(await resolveSlugTarget(pieces, "top"))
+          .toEqual({ piece: boardId, path: ["names"] });
+      });
+
+      it("returns an empty path for a slug that names a piece", async () => {
+        expect(await resolveSlugTarget(pieces, "one"))
+          .toEqual({ piece: pieceId(item1), path: [] });
+      });
+
+      it("fails with `not-piece` for a slug to a plain document", async () => {
+        const plain = runtime.getCell(
+          pieces.getSpace(),
+          { space: pieces.getSpace(), random: "plain" },
+        );
+        await runtime.editWithRetry((tx) => {
+          plain.withTx(tx).set({ value: 1 });
+        });
+        await setSlugLink(pieces, "plain", plain);
+
+        const error = await failureOf(resolveSlugTarget(pieces, "plain"));
+        expect(error).toBeInstanceOf(SlugResolutionError);
+        expect((error as SlugResolutionError).code).toBe("not-piece");
+      });
+    });
   });
 });

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -373,6 +373,12 @@ export {
 } from "./sandbox/fabric-import-specifier.ts";
 export { type PinRewrite, rewriteFabricPins } from "./fabric-pin-rewrite.ts";
 export {
+  isPieceDocument,
+  isPieceRoot,
+  resolveSlugReference,
   resolveSlugTargetCell,
+  resolveSlugTargetInPiece,
+  type SlugReferenceTarget,
   SlugResolutionError,
+  type SlugTargetInPiece,
 } from "./slug-resolution.ts";

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -372,6 +372,7 @@ export {
   parseFabricRef,
 } from "./sandbox/fabric-import-specifier.ts";
 export { type PinRewrite, rewriteFabricPins } from "./fabric-pin-rewrite.ts";
+export { DEFAULT_CELL_SCOPE } from "./scope.ts";
 export {
   isPieceRoot,
   resolveSlugReference,

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -373,7 +373,6 @@ export {
 } from "./sandbox/fabric-import-specifier.ts";
 export { type PinRewrite, rewriteFabricPins } from "./fabric-pin-rewrite.ts";
 export {
-  isPieceDocument,
   isPieceRoot,
   resolveSlugReference,
   resolveSlugTargetCell,

--- a/packages/runner/src/slug-resolution.ts
+++ b/packages/runner/src/slug-resolution.ts
@@ -62,7 +62,7 @@ export interface SlugTargetInPiece {
   piece: Cell<unknown>;
 
   /** The path from that root to the target. */
-  path: string[];
+  pathInside: string[];
 }
 
 /**
@@ -73,8 +73,8 @@ export interface SlugReferenceTarget<Segment extends string | number> {
   /** The piece's root cell. */
   piece: Cell<unknown>;
 
-  /** The segments after the piece, a cell path inside it. */
-  path: Segment[];
+  /** The segments left to address after the piece, a cell path inside it. */
+  pathAfter: Segment[];
 }
 
 /**
@@ -98,7 +98,7 @@ export async function resolveSlugTargetInPiece(
     scope: link.scope,
     path: [],
   });
-  return { piece, path: [...link.path] };
+  return { piece, pathInside: [...link.path] };
 }
 
 /**
@@ -108,16 +108,17 @@ export async function resolveSlugTargetInPiece(
  * cell path inside it, returned whole. A slug whose target is any other cell
  * names a collection: the target is a map from member name to member, the
  * first segment of the path selects a member, and the cell that member holds,
- * followed through its link, is the piece. The walk goes on while the cell
- * reached is not a piece root, so a nested map spends one segment per level.
- * Whichever way the piece was reached, the segments after it are a cell path
- * inside it.
+ * followed through its links, is the piece. Exactly one segment reaches a
+ * member, so an item's own fields and a collection's member names stay
+ * different namespaces — a member name never competes for the segment after
+ * an item. Whichever way the piece was reached, the segments after it are a
+ * cell path inside it.
  *
  * Fails, as a `SlugResolutionError`, with `inside-piece` when the target is a
  * cell inside a piece and the path is empty, naming that piece; with
  * `not-piece` when the target is neither a piece nor inside one and the path
- * is empty, or when the segments run out before a piece is reached; and with
- * `missing-member` when a segment selects nothing. A slug that does not
+ * is empty, or when the member the segment selects is no piece; and with
+ * `missing-member` when the segment selects nothing. A slug that does not
  * resolve fails as {@link resolveSlugTargetCell} does.
  */
 export async function resolveSlugReference<Segment extends string | number>(
@@ -128,7 +129,7 @@ export async function resolveSlugReference<Segment extends string | number>(
 ): Promise<SlugReferenceTarget<Segment>> {
   const target = await resolveSlugTargetCell(runtime, space, token);
   if (isPieceRoot(runtime, target)) {
-    return { piece: target, path: [...path] };
+    return { piece: target, pathAfter: [...path] };
   }
   if (path.length === 0) {
     throw isPieceDocument(runtime, target)
@@ -141,33 +142,27 @@ export async function resolveSlugReference<Segment extends string | number>(
       : notPiece(token);
   }
 
-  // Each level is followed through its link before its keys are read: the
-  // map a collection holds is reached from the containing piece through a
-  // link, and a key read on the unresolved cell would look the member up in
-  // the wrong document.
-  let map = target;
-  const walked: string[] = [];
-  for (let index = 0; index < path.length; index++) {
-    map = await followAndLoad(map);
-    const member = String(path[index]);
-    const held = map.key(member);
-    if (held.getRaw() === undefined) {
-      throw new SlugResolutionError(
-        `no member ${member} in ${[token, ...walked].join("/")}`,
-        "missing-member",
-      );
-    }
-    walked.push(member);
-    const reached = await followAndLoad(held);
-    if (isPieceRoot(runtime, reached)) {
-      return { piece: reached, path: path.slice(index + 1) };
-    }
-    map = reached;
+  // The map is followed through its link before its keys are read: a
+  // collection is reached from the containing piece through a link, and a key
+  // read on the unresolved cell would look the member up in the wrong
+  // document. The member's own link chain is followed the same way.
+  const map = await followAndLoad(target);
+  const member = String(path[0]);
+  const held = map.key(member);
+  if (held.getRaw() === undefined) {
+    throw new SlugResolutionError(
+      `no member ${member} in ${token}`,
+      "missing-member",
+    );
   }
-  throw new SlugResolutionError(
-    `"${[token, ...walked].join("/")}" does not name a piece.`,
-    "not-piece",
-  );
+  const reached = await followAndLoad(held);
+  if (!isPieceRoot(runtime, reached)) {
+    throw new SlugResolutionError(
+      `"${token}/${member}" does not name a piece.`,
+      "not-piece",
+    );
+  }
+  return { piece: reached, pathAfter: path.slice(1) };
 }
 
 /**
@@ -195,7 +190,10 @@ async function followAndLoad(cell: Cell<unknown>): Promise<Cell<unknown>> {
   }
 }
 
-/** Helper for the resolvers above, which builds the `not-piece` failure. */
+/**
+ * Helper for `resolveSlugReference()` and `resolveSlugTargetInPiece()`, which
+ * builds the `not-piece` failure.
+ */
 function notPiece(token: string): SlugResolutionError {
   return new SlugResolutionError(
     `Slug "${token}" redirects to a document that is not a piece.`,

--- a/packages/runner/src/slug-resolution.ts
+++ b/packages/runner/src/slug-resolution.ts
@@ -1,11 +1,19 @@
 import type { Cell } from "./cell.ts";
+import { entityIdFrom } from "./create-ref.ts";
+import { areNormalizedLinksSame } from "./link-types.ts";
+import { parseLink } from "./link-utils.ts";
+import { cellEntityIdString } from "./piece-helpers.ts";
+import { getPatternIdentityRef } from "./runner.ts";
 import type { Runtime } from "./runtime.ts";
 import type { URI } from "./sigil-types.ts";
-import type { MemorySpace } from "./storage/interface.ts";
-import { parseLink } from "./link-utils.ts";
 import { slugIdForSpace, validateSlug } from "./slugs.ts";
-import { entityIdFrom } from "./create-ref.ts";
+import type { MemorySpace } from "./storage/interface.ts";
 
+/**
+ * A slug that did not resolve, with a `code` saying how. `inside-piece` and
+ * `missing-member` come from resolving a slug that names a collection;
+ * `not-piece` is the target that is neither a piece nor a member of one.
+ */
 export class SlugResolutionError extends Error {
   constructor(
     message: string,
@@ -14,11 +22,185 @@ export class SlugResolutionError extends Error {
       | "missing"
       | "malformed"
       | "not-piece"
+      | "inside-piece"
+      | "missing-member"
       | "missing-piece-id",
   ) {
     super(message);
     this.name = "SlugResolutionError";
   }
+}
+
+/**
+ * Whether `cell`'s document is a piece: it carries a pattern pointer, either
+ * the durable `patternIdentity` or the session pointer a keyless piece has in
+ * the runner that set it up. The pointer is the document's, so this holds
+ * for every cell in a piece's document whatever its path; {@link isPieceRoot}
+ * is the test for the piece itself.
+ */
+export function isPieceDocument(
+  runtime: Runtime,
+  cell: Cell<unknown>,
+): boolean {
+  return getPatternIdentityRef(cell) !== undefined ||
+    runtime.runner.sessionPatternPointerFor(cell) !== undefined;
+}
+
+/** Whether `cell` is a piece: the root of a document a piece owns. */
+export function isPieceRoot(runtime: Runtime, cell: Cell<unknown>): boolean {
+  return cell.getAsNormalizedFullLink().path.length === 0 &&
+    isPieceDocument(runtime, cell);
+}
+
+/**
+ * Where a slug's redirect lands, as the piece whose document holds it: the
+ * document's root cell, and the path from there to the target, which is
+ * empty when the slug names the piece itself.
+ */
+export interface SlugTargetInPiece {
+  /** The root cell of the document the slug's target sits in. */
+  piece: Cell<unknown>;
+
+  /** The path from that root to the target. */
+  path: string[];
+}
+
+/**
+ * Where a slug reference lands: the piece reached, as its root cell, and the
+ * segments left after it, which are a cell path inside that piece.
+ */
+export interface SlugReferenceTarget<Segment extends string | number> {
+  /** The piece's root cell. */
+  piece: Cell<unknown>;
+
+  /** The segments after the piece, a cell path inside it. */
+  path: Segment[];
+}
+
+/**
+ * Resolves a slug to the piece its target sits in and the path to the target
+ * inside it. Fails with `not-piece` when the target's document is no piece,
+ * and as {@link resolveSlugTargetCell} fails when the slug does not resolve.
+ */
+export async function resolveSlugTargetInPiece(
+  runtime: Runtime,
+  space: MemorySpace,
+  token: string,
+): Promise<SlugTargetInPiece> {
+  const target = await resolveSlugTargetCell(runtime, space, token);
+  if (!isPieceDocument(runtime, target)) {
+    throw notPiece(token);
+  }
+  const link = target.getAsNormalizedFullLink();
+  const piece = link.path.length === 0 ? target : runtime.getCellFromLink({
+    id: link.id,
+    space: link.space,
+    scope: link.scope,
+    path: [],
+  });
+  return { piece, path: [...link.path] };
+}
+
+/**
+ * Resolves a slug and the path written after it to a piece.
+ *
+ * A slug whose target is a piece root names that piece, and the path is a
+ * cell path inside it, returned whole. A slug whose target is any other cell
+ * names a collection: the target is a map from member name to member, the
+ * first segment of the path selects a member, and the cell that member holds,
+ * followed through its link, is the piece. The walk goes on while the cell
+ * reached is not a piece root, so a nested map spends one segment per level.
+ * Whichever way the piece was reached, the segments after it are a cell path
+ * inside it.
+ *
+ * Fails, as a `SlugResolutionError`, with `inside-piece` when the target is a
+ * cell inside a piece and the path is empty, naming that piece; with
+ * `not-piece` when the target is neither a piece nor inside one and the path
+ * is empty, or when the segments run out before a piece is reached; and with
+ * `missing-member` when a segment selects nothing. A slug that does not
+ * resolve fails as {@link resolveSlugTargetCell} does.
+ */
+export async function resolveSlugReference<Segment extends string | number>(
+  runtime: Runtime,
+  space: MemorySpace,
+  token: string,
+  path: readonly Segment[],
+): Promise<SlugReferenceTarget<Segment>> {
+  const target = await resolveSlugTargetCell(runtime, space, token);
+  if (isPieceRoot(runtime, target)) {
+    return { piece: target, path: [...path] };
+  }
+  if (path.length === 0) {
+    throw isPieceDocument(runtime, target)
+      ? new SlugResolutionError(
+        `Slug "${token}" redirects to a cell inside piece ${
+          cellEntityIdString(target)
+        }; name a member, e.g. ${token}/<name>.`,
+        "inside-piece",
+      )
+      : notPiece(token);
+  }
+
+  // Each level is followed through its link before its keys are read: the
+  // map a collection holds is reached from the containing piece through a
+  // link, and a key read on the unresolved cell would look the member up in
+  // the wrong document.
+  let map = target;
+  const walked: string[] = [];
+  for (let index = 0; index < path.length; index++) {
+    map = await followAndLoad(map);
+    const member = String(path[index]);
+    const held = map.key(member);
+    if (held.getRaw() === undefined) {
+      throw new SlugResolutionError(
+        `no member ${member} in ${[token, ...walked].join("/")}`,
+        "missing-member",
+      );
+    }
+    walked.push(member);
+    const reached = await followAndLoad(held);
+    if (isPieceRoot(runtime, reached)) {
+      return { piece: reached, path: path.slice(index + 1) };
+    }
+    map = reached;
+  }
+  throw new SlugResolutionError(
+    `"${[token, ...walked].join("/")}" does not name a piece.`,
+    "not-piece",
+  );
+}
+
+/**
+ * Helper for `resolveSlugReference()`, which follows `cell`'s link to the
+ * cell it lands on and loads that cell's document. A link is read out of a
+ * loaded document, so following stops at the first document not yet loaded;
+ * each round loads what the last one reached and follows again, until
+ * following moves nowhere. A cycle of links ends in `resolveAsCell()`'s own
+ * refusal.
+ */
+async function followAndLoad(cell: Cell<unknown>): Promise<Cell<unknown>> {
+  let current = cell;
+  for (;;) {
+    await current.sync();
+    const next = current.resolveAsCell();
+    if (
+      areNormalizedLinksSame(
+        next.getAsNormalizedFullLink(),
+        current.getAsNormalizedFullLink(),
+      )
+    ) {
+      return current;
+    }
+    current = next;
+  }
+}
+
+/** Helper for the resolvers above, which builds the `not-piece` failure. */
+function notPiece(token: string): SlugResolutionError {
+  return new SlugResolutionError(
+    `Slug "${token}" redirects to a document that is not a piece.`,
+    "not-piece",
+  );
 }
 
 export async function resolveSlugTargetCell(

--- a/packages/runner/src/slug-resolution.ts
+++ b/packages/runner/src/slug-resolution.ts
@@ -38,7 +38,7 @@ export class SlugResolutionError extends Error {
  * for every cell in a piece's document whatever its path; {@link isPieceRoot}
  * is the test for the piece itself.
  */
-export function isPieceDocument(
+function isPieceDocument(
   runtime: Runtime,
   cell: Cell<unknown>,
 ): boolean {

--- a/packages/runner/test/slug-resolution.test.ts
+++ b/packages/runner/test/slug-resolution.test.ts
@@ -1,14 +1,21 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
+import type { Cell } from "../src/cell.ts";
 import { Runtime } from "../src/runtime.ts";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import { parseLink } from "../src/link-utils.ts";
+import { rawMetaWriteAuthorization } from "../src/meta-seam.ts";
+import { cellEntityIdString } from "../src/piece-helpers.ts";
 import { slugIdForSpace } from "../src/slugs.ts";
 import { entityIdFrom } from "../src/create-ref.ts";
 import {
+  isPieceRoot,
   parseSlugRedirect,
+  resolveSlugReference,
   resolveSlugTargetCell,
+  resolveSlugTargetInPiece,
+  SlugResolutionError,
 } from "../src/slug-resolution.ts";
 
 const signer = await Identity.fromPassphrase("runner slug resolution tests");
@@ -101,5 +108,177 @@ describe("slug resolution", () => {
     expect(
       parseSlugRedirect("not a redirect", base),
     ).toBeUndefined();
+  });
+
+  describe("a slug that names a collection", () => {
+    // A piece here is a document stamped with a `patternIdentity`, which is
+    // what the resolvers read; nothing runs. The board holds its collection
+    // at `names`, keyed by member name, each member a link to an item's
+    // document, with one key holding a plain value for a member that is no
+    // piece. `top` points at the collection, `board` at the board itself,
+    // and `plain` at a document that is no piece at all.
+
+    let board: Cell<unknown>;
+    let item1: Cell<unknown>;
+    let item2: Cell<unknown>;
+
+    async function pieceDocument(
+      cause: string,
+      content: unknown,
+    ): Promise<Cell<unknown>> {
+      const cell = runtime.getCell(space, { space, random: cause });
+      await runtime.editWithRetry((tx) => {
+        const withTx = cell.withTx(tx);
+        withTx.set(content);
+        withTx.setMetaRaw(
+          "patternIdentity",
+          { identity: `pattern-${cause}`, symbol: "default" },
+          rawMetaWriteAuthorization,
+        );
+      });
+      return cell;
+    }
+
+    async function pointSlug(
+      slug: string,
+      target: Cell<unknown>,
+    ): Promise<void> {
+      const slugCell = runtime.getCellFromEntityId(
+        space,
+        entityIdFrom(slugIdForSpace(space, slug)),
+      );
+      await runtime.editWithRetry((tx) => {
+        const slugWithTx = slugCell.withTx(tx);
+        slugWithTx.setRawUntyped(
+          target.withTx(tx).getAsWriteRedirectLink({ base: slugWithTx }),
+        );
+      });
+    }
+
+    function idOf(cell: Cell<unknown>): string {
+      return cell.getAsNormalizedFullLink().id;
+    }
+
+    beforeEach(async () => {
+      item1 = await pieceDocument("item-1", { title: "Glaze recipes" });
+      item2 = await pieceDocument("item-2", { title: "Oven schedule" });
+      // Member `4` reaches its piece through a document that is nothing but
+      // a link to it, the way a member stored by reference does.
+      const viaLink = runtime.getCell(space, { space, random: "via-link" });
+      const plain = runtime.getCell(space, { space, random: "plain" });
+      await runtime.editWithRetry((tx) => {
+        viaLink.withTx(tx).set(item2);
+        plain.withTx(tx).set({ value: 1 });
+      });
+      board = await pieceDocument("board", {
+        names: { "1": item1, "2": item2, "3": { plain: true }, "4": viaLink },
+      });
+      await pointSlug("board", board);
+      await pointSlug("top", board.key("names"));
+      await pointSlug("plain", plain);
+    });
+
+    describe("resolveSlugReference()", () => {
+      it("returns the piece and the whole path when the slug names a piece root", async () => {
+        const target = await resolveSlugReference(runtime, space, "board", [
+          "names",
+          "1",
+        ]);
+        expect(idOf(target.piece)).toBe(idOf(board));
+        expect(target.path).toEqual(["names", "1"]);
+      });
+
+      it("returns the member piece and the rest of the path when the slug names a collection", async () => {
+        const target = await resolveSlugReference(runtime, space, "top", [
+          "2",
+          "title",
+        ]);
+        expect(idOf(target.piece)).toBe(idOf(item2));
+        expect(target.piece.getAsNormalizedFullLink().path).toEqual([]);
+        expect(target.path).toEqual(["title"]);
+      });
+
+      it("reads a numeric segment as the member name it denotes", async () => {
+        const target = await resolveSlugReference(runtime, space, "top", [1]);
+        expect(idOf(target.piece)).toBe(idOf(item1));
+        expect(target.path).toEqual([]);
+      });
+
+      it("follows a member through a chain of links to the piece at its end", async () => {
+        const target = await resolveSlugReference(runtime, space, "top", [
+          "4",
+          "title",
+        ]);
+        expect(idOf(target.piece)).toBe(idOf(item2));
+        expect(target.path).toEqual(["title"]);
+      });
+
+      it("fails with `missing-member` naming the collection when a segment selects nothing", async () => {
+        const error = await resolveSlugReference(runtime, space, "top", [
+          "999",
+        ]).catch((error: unknown) => error);
+        expect(error).toBeInstanceOf(SlugResolutionError);
+        expect((error as SlugResolutionError).code).toBe("missing-member");
+        expect((error as Error).message).toBe("no member 999 in top");
+      });
+
+      it("fails with `inside-piece` naming the containing piece when the slug names a collection and the path is empty", async () => {
+        const error = await resolveSlugReference(runtime, space, "top", [])
+          .catch((error: unknown) => error);
+        expect(error).toBeInstanceOf(SlugResolutionError);
+        expect((error as SlugResolutionError).code).toBe("inside-piece");
+        expect((error as Error).message).toContain(
+          `inside piece ${cellEntityIdString(board)}`,
+        );
+        expect((error as Error).message).toContain("top/<name>");
+      });
+
+      it("fails with `not-piece` when the segments run out before a piece", async () => {
+        const error = await resolveSlugReference(runtime, space, "top", ["3"])
+          .catch((error: unknown) => error);
+        expect(error).toBeInstanceOf(SlugResolutionError);
+        expect((error as SlugResolutionError).code).toBe("not-piece");
+        expect((error as Error).message).toMatch(
+          /"top\/3" does not name a piece/,
+        );
+      });
+
+      it("fails with `not-piece` for a slug to a plain document and no path", async () => {
+        const error = await resolveSlugReference(runtime, space, "plain", [])
+          .catch((error: unknown) => error);
+        expect(error).toBeInstanceOf(SlugResolutionError);
+        expect((error as SlugResolutionError).code).toBe("not-piece");
+        expect((error as Error).message).toMatch(/not a piece/);
+      });
+    });
+
+    describe("resolveSlugTargetInPiece()", () => {
+      it("returns the containing piece's root and the path to the target", async () => {
+        const target = await resolveSlugTargetInPiece(runtime, space, "top");
+        expect(idOf(target.piece)).toBe(idOf(board));
+        expect(target.piece.getAsNormalizedFullLink().path).toEqual([]);
+        expect(target.path).toEqual(["names"]);
+      });
+
+      it("returns an empty path for a slug that names the piece itself", async () => {
+        const target = await resolveSlugTargetInPiece(runtime, space, "board");
+        expect(idOf(target.piece)).toBe(idOf(board));
+        expect(target.path).toEqual([]);
+      });
+
+      it("fails with `not-piece` for a slug to a plain document", async () => {
+        const error = await resolveSlugTargetInPiece(runtime, space, "plain")
+          .catch((error: unknown) => error);
+        expect(error).toBeInstanceOf(SlugResolutionError);
+        expect((error as SlugResolutionError).code).toBe("not-piece");
+      });
+    });
+
+    describe("isPieceRoot()", () => {
+      it("returns `true` for a piece's root and `false` for a cell inside it", () => {
+        expect(isPieceRoot(runtime, board)).toBe(true);
+        expect(isPieceRoot(runtime, board.key("names"))).toBe(false);
+      });
+    });
   });
 });

--- a/packages/runner/test/slug-resolution.test.ts
+++ b/packages/runner/test/slug-resolution.test.ts
@@ -114,9 +114,10 @@ describe("slug resolution", () => {
     // A piece here is a document stamped with a `patternIdentity`, which is
     // what the resolvers read; nothing runs. The board holds its collection
     // at `names`, keyed by member name, each member a link to an item's
-    // document, with one key holding a plain value for a member that is no
-    // piece. `top` points at the collection, `board` at the board itself,
-    // and `plain` at a document that is no piece at all.
+    // document, with two keys holding plain values for members that are no
+    // piece — one of them a record whose own key names a piece. `top` points
+    // at the collection, `board` at the board itself, and `plain` at a
+    // document that is no piece at all.
 
     let board: Cell<unknown>;
     let item1: Cell<unknown>;
@@ -162,16 +163,24 @@ describe("slug resolution", () => {
     beforeEach(async () => {
       item1 = await pieceDocument("item-1", { title: "Glaze recipes" });
       item2 = await pieceDocument("item-2", { title: "Oven schedule" });
-      // Member `4` reaches its piece through a document that is nothing but
-      // a link to it, the way a member stored by reference does.
+      // Member `4` reaches its piece through documents that are nothing but
+      // links to it, the way a member stored by reference does.
       const viaLink = runtime.getCell(space, { space, random: "via-link" });
+      const viaLink2 = runtime.getCell(space, { space, random: "via-link-2" });
       const plain = runtime.getCell(space, { space, random: "plain" });
       await runtime.editWithRetry((tx) => {
-        viaLink.withTx(tx).set(item2);
+        viaLink2.withTx(tx).set(item2);
+        viaLink.withTx(tx).set(viaLink2);
         plain.withTx(tx).set({ value: 1 });
       });
       board = await pieceDocument("board", {
-        names: { "1": item1, "2": item2, "3": { plain: true }, "4": viaLink },
+        names: {
+          "1": item1,
+          "2": item2,
+          "3": { plain: true },
+          "4": viaLink,
+          "5": { "6": item1 },
+        },
       });
       await pointSlug("board", board);
       await pointSlug("top", board.key("names"));
@@ -185,7 +194,7 @@ describe("slug resolution", () => {
           "1",
         ]);
         expect(idOf(target.piece)).toBe(idOf(board));
-        expect(target.path).toEqual(["names", "1"]);
+        expect(target.pathAfter).toEqual(["names", "1"]);
       });
 
       it("returns the member piece and the rest of the path when the slug names a collection", async () => {
@@ -195,13 +204,13 @@ describe("slug resolution", () => {
         ]);
         expect(idOf(target.piece)).toBe(idOf(item2));
         expect(target.piece.getAsNormalizedFullLink().path).toEqual([]);
-        expect(target.path).toEqual(["title"]);
+        expect(target.pathAfter).toEqual(["title"]);
       });
 
       it("reads a numeric segment as the member name it denotes", async () => {
         const target = await resolveSlugReference(runtime, space, "top", [1]);
         expect(idOf(target.piece)).toBe(idOf(item1));
-        expect(target.path).toEqual([]);
+        expect(target.pathAfter).toEqual([]);
       });
 
       it("follows a member through a chain of links to the piece at its end", async () => {
@@ -210,7 +219,7 @@ describe("slug resolution", () => {
           "title",
         ]);
         expect(idOf(target.piece)).toBe(idOf(item2));
-        expect(target.path).toEqual(["title"]);
+        expect(target.pathAfter).toEqual(["title"]);
       });
 
       it("fails with `missing-member` naming the collection when a segment selects nothing", async () => {
@@ -233,13 +242,29 @@ describe("slug resolution", () => {
         expect((error as Error).message).toContain("top/<name>");
       });
 
-      it("fails with `not-piece` when the segments run out before a piece", async () => {
+      it("fails with `not-piece` when the member the segment selects is no piece", async () => {
         const error = await resolveSlugReference(runtime, space, "top", ["3"])
           .catch((error: unknown) => error);
         expect(error).toBeInstanceOf(SlugResolutionError);
         expect((error as SlugResolutionError).code).toBe("not-piece");
         expect((error as Error).message).toMatch(
           /"top\/3" does not name a piece/,
+        );
+      });
+
+      it("spends one segment on the member and reads no second one as a member name", async () => {
+        // Member `5` is a plain record whose own key `6` holds a piece.
+        // Reading that key as a member name would let a field inside an item
+        // answer to the collection's namespace, so the refusal names the one
+        // segment that was spent and stops there.
+        const error = await resolveSlugReference(runtime, space, "top", [
+          "5",
+          "6",
+        ]).catch((error: unknown) => error);
+        expect(error).toBeInstanceOf(SlugResolutionError);
+        expect((error as SlugResolutionError).code).toBe("not-piece");
+        expect((error as Error).message).toBe(
+          '"top/5" does not name a piece.',
         );
       });
 
@@ -257,13 +282,13 @@ describe("slug resolution", () => {
         const target = await resolveSlugTargetInPiece(runtime, space, "top");
         expect(idOf(target.piece)).toBe(idOf(board));
         expect(target.piece.getAsNormalizedFullLink().path).toEqual([]);
-        expect(target.path).toEqual(["names"]);
+        expect(target.pathInside).toEqual(["names"]);
       });
 
       it("returns an empty path for a slug that names the piece itself", async () => {
         const target = await resolveSlugTargetInPiece(runtime, space, "board");
         expect(idOf(target.piece)).toBe(idOf(board));
-        expect(target.path).toEqual([]);
+        expect(target.pathInside).toEqual([]);
       });
 
       it("fails with `not-piece` for a slug to a plain document", async () => {


### PR DESCRIPTION
## Why

A collection that numbers its members is only useful if `top/42` reaches the
member from anywhere the fabric is addressed. Today a slug can point at a cell
nested inside a piece — `set-slug` accepts a source path — but nothing reads
the segments after it: `resolvePieceAddress` resolved such a slug to its
containing piece and dropped the path, because the pattern pointer it checks
is document-level. So `cf cell get /top/42 title` silently read the board's
`title`, and there was no way to name a member at all.

This is stage S2 of `docs/plans/collection-naming-topics.md` (decision 3: the
namespace is a map cell on the board and the collection's slug points at it, so
forward resolution is a path read). It is independent of S1 (#6882): nothing
here depends on the exemplar's code, only its demo does.

## What Changed

**Where the slug points decides how the path after it reads.** A slug whose
target is a piece root names that piece, and the path is a cell path inside it
— unchanged, and pinned by tests that a `value` segment after such a slug is not
walked. A slug whose target is any other cell names a collection: the first
segment selects a member, the cell it holds is followed through its links to a
piece root, and the remaining segments are a cell path inside that member.

- `packages/runner/src/slug-resolution.ts` — `resolveSlugReference(runtime,
  space, slug, path)` returns the member's root cell and the leftover path;
  `resolveSlugTargetInPiece` for listings; `isPieceRoot` (only an empty path
  with a pattern pointer counts). Each hop of a member's link chain is loaded
  before it is followed (`names/42 → link document → piece root` is what the
  store holds). The walk lives in the runner so the shell (S3) can call it with
  `parseFabricUrl`'s result. New error codes: `inside-piece` (a bare `/top`:
  "redirects to a cell inside piece <id>; name a member, e.g. top/<name>") and
  `missing-member` ("no member 999 in top").
- `packages/piece/src/slugs.ts` — `resolvePieceReference(pieces, token, path)`
  maps the walk's cells to ids; `resolvePieceAddress` is its no-path case;
  `resolveSlugTarget` for the listing.
- `packages/cli` — the read, write, and label commands resolve the whole
  addressed path with the address; id-only commands walk the reference's path
  and refuse a remainder in the parser's own words. `cf piece slugs` lists a
  nested target as `piece/path` (and `path` in `--json`) instead of failing the
  listing. A bare-slug `set-slug` source now aliases the cell that slug points
  at rather than flattening to its containing piece. README gains the rule and
  an example.
- Tests: +12 runner, +10 piece, a new `piece-reference.test.ts` and extended
  `piece-slugs.test.ts` in cli (31 cases across the four).

**Two data-loss regressions, found in review and fixed here.** A member address
with nothing after it let `cf cell set` replace the member's whole result cell:
the guard against exactly that tested the path *before* resolution, and
resolution then spent the segment reaching the member and handed an empty path
to the setter. It is refused after resolution now, and the receipt names what
was written and where. Separately, relaxing the parse-time guard so a slug's
path could reach the resolver left three id-only commands dropping that path in
silence — `cf piece restore --apply` among them, which would have restored a
whole piece. All three route through one shared resolver now, with a test per
entry point.

The second one is worth stating as a rule, because the obvious enumeration
misses it: the guard protected `config.piecePath`, and every consumer of that
field was already fine. The commands that broke never read it at all — they take
a piece id and let the rest fall on the floor, which is why the guard existed
and why no search for the field could have found them. What to enumerate when a
guard is relaxed is **what it used to refuse**, then where each of those cases
goes now.

Boundaries, deliberate and documented where each refusal is described: a bulk
holder's address carries no path of its own, so one written there is refused
rather than dropped, and a collection's member is addressed as a holder by its
own handle; completion after a slug naming a collection offers nothing, since
reading the member names means a second load per keystroke. The `//space`
spelling arrives with #6814.

## Test plan

- `deno fmt --check`, `deno lint`, `deno task check`: clean.
- `deno task test` in runner (1359 passed), piece (54), cli (211).
- `check-no-waitfor`, `check-completion-slots`, `check-command-docs`,
  `check-control-characters`, `check-conflict-markers`: clean.
- Demo against the S1 exemplar on an isolated toolshed: `set-slug top
  /of:<board>/names`; `cf cell get /top/2 title` → "Oven schedule";
  `/@naming-demo/top/2 title` the same; `piece describe --cell /top/2` describes
  the member; `piece call --cell /top/2 <verb>` reaches the member; `/top/999`
  → "no member 999 in top"; bare `/top` → the inside-piece message; `piece
  slugs` lists `top  fid1:…/names`.
- Review: codex through stage-loop and the repository's house review, three
  rounds. Codex passed the first two rounds clean; the house review found both
  regressions above, and verified on the third round that all nine of its
  earlier findings were genuinely answered.
- The `packages/cf-harness` `run-measurement-batch` suite fails 7 steps in any
  checkout whose local `main` ref is behind the commit its fixture pins — it
  runs `git merge-base --is-ancestor <sha> main` against the local ref. Nothing
  in this change touches that script or its test.


ACCEPT_COVERAGE_DEBT: packages/runner +3 lines

The three lines are `packages/runner/src/scheduler/work-oracle.ts` 208-210,
which this branch does not touch — its only runner changes are
`slug-resolution.ts`, its test, and one export. The gate's own comment
diagnoses them as inconsistently covered on `main`, and the lines sit inside a
scheduling branch guarded by `isRunnableSchedulingSeed(state, record, now)`:
a clock reading, and a path reached only when work lands in a particular
order. That is the flake shape the gate's prompt describes, not a regression
this change introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kp8NcNXPougGPyJCEyYtob


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6890?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


