### PR TITLE
fix(llm): drop the guard for a message field the protocol never carries

### DIFF
--- a/packages/llm/src/types.ts
+++ b/packages/llm/src/types.ts
@@ -75,6 +75,12 @@ export function isLLMNativeModelToolResults(
   return Array.isArray(input) && input.every(isLLMNativeModelToolResult);
 }
 
+/**
+ * A tool call in its compact form: an identifier, the name of the tool, and
+ * the input to call it with. This is not the shape a tool call has in a
+ * message. There it is a `BuiltInLLMToolCallPart` within the content, naming
+ * those same three things `toolCallId`, `toolName`, and `input`.
+ */
 export type LLMToolCall = {
   id: string;
   name: string;
@@ -158,15 +164,6 @@ export function isLLMContent(input: unknown): input is LLMContent {
   ));
 }
 
-// The parameter is `value` rather than `input` because `LLMToolCall` carries a
-// field of that name, and the guard has to read it.
-export function isLLMToolCall(value: unknown): value is LLMToolCall {
-  return isObjectNotArray(value) &&
-    typeof value.id === "string" &&
-    typeof value.name === "string" &&
-    isObjectNotArray(value.input);
-}
-
 export function isLLMToolResult(input: unknown): input is LLMToolResult {
   return isObjectNotArray(input) &&
     typeof input.toolCallId === "string" &&
@@ -185,8 +182,6 @@ export function isLLMMessage(input: unknown): input is BuiltInLLMMessage {
     (input.role === "user" || input.role === "assistant" ||
       input.role === "tool") &&
     isLLMContent(input.content) &&
-    (!("toolCalls" in input) || (Array.isArray(input.toolCalls) &&
-      input.toolCalls.every((tc: unknown) => isLLMToolCall(tc)))) &&
     (!("toolCallId" in input) || typeof input.toolCallId === "string");
 }
 

--- a/packages/llm/test/types.test.ts
+++ b/packages/llm/test/types.test.ts
@@ -1,28 +1,19 @@
 import { describe, it } from "@std/testing/bdd";
 import { assert } from "@std/assert";
 import { expect } from "@std/expect";
+import type { BuiltInLLMContent } from "@commonfabric/api";
 import {
   DEFAULT_MODEL_NAME,
   GOOGLE_SEARCH_NATIVE_MODEL_TOOL,
   isLLMRequest,
   isLLMTool,
-  isLLMToolCall,
   type LLMTool,
-  type LLMToolCall,
 } from "../src/types.ts";
 
-// These carry their declared types so that renaming a field stops this file
+// This carries its declared type so that renaming a field stops this file
 // compiling. A guard reads fields by name, which no type check reaches, so an
 // untyped fixture would go on agreeing with a guard that the type had left
 // behind.
-
-/** The shape `client.ts` builds from a `tool-call` stream event. */
-const TOOL_CALL: LLMToolCall = {
-  id: "call_1",
-  name: "lookup",
-  input: { term: "fabric" },
-};
-
 const TOOL: LLMTool = {
   description: "Look a term up",
   inputSchema: { type: "object" },
@@ -140,37 +131,36 @@ describe("types", () => {
       ).toBe(false);
     });
 
-    it("returns `true` for a request whose message carries tool calls", () => {
+    it("returns `true` for a message whose content carries a tool call", () => {
+      const content: BuiltInLLMContent = [
+        { type: "text", text: "Looking that up" },
+        {
+          type: "tool-call",
+          toolCallId: "call_1",
+          toolName: "lookup",
+          input: { term: "fabric" },
+        },
+      ];
       expect(
         isLLMRequest({
-          messages: [{
-            role: "assistant",
-            content: "Looking that up",
-            toolCalls: [TOOL_CALL],
-          }],
+          messages: [{ role: "assistant", content }],
           model: DEFAULT_MODEL_NAME,
           cache: true,
         }),
       ).toBe(true);
     });
-  });
 
-  describe("isLLMToolCall()", () => {
-    it("returns `true` for the shape the client builds", () => {
-      expect(isLLMToolCall(TOOL_CALL)).toBe(true);
-    });
-
-    it("returns `false` when the `input` map is missing", () => {
-      expect(isLLMToolCall({ id: "call_1", name: "lookup" })).toBe(false);
-    });
-
-    it("returns `false` for an `input` map given as an array", () => {
-      expect(isLLMToolCall({ ...TOOL_CALL, input: [] })).toBe(false);
-    });
-
-    it("returns `false` when the id or name is not a string", () => {
-      expect(isLLMToolCall({ ...TOOL_CALL, id: 1 })).toBe(false);
-      expect(isLLMToolCall({ ...TOOL_CALL, name: undefined })).toBe(false);
+    it("returns `false` for a content part of an unrecognized type", () => {
+      expect(
+        isLLMRequest({
+          messages: [{
+            role: "assistant",
+            content: [{ type: "tool-invocation", toolCallId: "call_1" }],
+          }],
+          model: DEFAULT_MODEL_NAME,
+          cache: true,
+        }),
+      ).toBe(false);
     });
   });
 


### PR DESCRIPTION
`isLLMMessage()` validated a `toolCalls` field on each message, and `isLLMRequest()` — the gate the toolshed LLM route applies to every incoming payload, refusing a rejected one with a 400 — reached that branch through `isLLMMessages()`. No message in this protocol carries such a field. Tool calls travel inside `content` as parts of type `tool-call`, so the branch was never taken, and `isLLMToolCall()`, whose only caller outside tests was that branch, validated a shape that never arrived.

The message field was the original design, and the move to content parts replaced it without removing the guard or the branch that called it. Four declarations agree that the field does not exist: `BuiltInLLMMessage` is `role` and `content` alone, the route's own Zod `MessageSchema` admits those two plus `nativeModelToolResults`, and the pattern-facing `LLMMessageSchema` requires `role` and `content`. Both producers build content parts: the streaming client converts each staged tool call into a part carrying a `toolCallId`, a `toolName`, and an `input` map, and `generateText.ts` does the same on the server. Every consumer reads those parts, in the runner's `llm-dialog.ts` and in the chat components.

The 400 the branch could produce was a false promise either way. A well-formed `toolCalls` array passed the gate and was then discarded, because `generateText.ts` hands the messages to the AI SDK, whose message schemas strip an unknown key. Nothing bad gets through by removing it: the route's Zod layer still enforces the shape of every content part.

Remove the branch and the guard. `LLMToolCall` stays, and its declaration now says what it is. The type is a tool call in compact form, converted in both directions — the streaming client builds one from a stream event on its way to a content part, and `resolveToolCall` in the runner builds one from a content part that has already arrived, as the dispatch record behind every arm of `ResolvedToolCall`. The comment describes the shape rather than naming those callers, which the comment style guide rules out for an exported symbol: a claim about the wider codebase rots silently, because editing the far end of it brings nobody back here.

Removing `isLLMToolCall()` changes the package's public surface, since `packages/llm/src/index.ts` re-exports everything in `types.ts`. Nothing in this repository imports it.

The test that pinned the removed branch asserted that a request whose message carried a `toolCalls` array was accepted. Two tests cover the representation that is real instead: a message whose `content` carries a `tool-call` part beside a text part is accepted, and a content part of an unrecognized type is refused. The second matters because the tests removed with `isLLMToolCall()` were the file's only assertions of a rejection, and without one a loosening of `isLLMContent()` would pass unnoticed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6891?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

