### PR TITLE
feat(data-model): the debug renderers take a `maxStringLines`

### DIFF
--- a/packages/data-model/src/api.ts
+++ b/packages/data-model/src/api.ts
@@ -471,9 +471,23 @@ export interface DebugValueOptions {
    * integer, or `Infinity` for as long as the conversion allows. A longer
    * string is converted to a form suggestive of the elision, which carries an
    * excerpt of the string up to the limit and the string's actual length.
-   * When absent, the limit is two hundred. A large value is capped.
+   * When absent, the limit is two hundred, or as long as the conversion
+   * allows when `maxStringLines` is present. A large value is capped.
    */
   readonly maxStringLength?: number;
+
+  /**
+   * Maximum number of lines of a string which is represented whole: a
+   * positive integer, or `Infinity` for as many as the conversion allows. A
+   * line break is a newline, a carriage return, or the two together; one at
+   * the end of the string ends its last line rather than starting another. A
+   * string with more lines is converted to the same form a string past
+   * `maxStringLength` is, carrying an excerpt of the string up to the limit
+   * and the string's actual length; when both limits apply, the excerpt is
+   * the shorter of the two. When absent, the limit is five. A large value is
+   * capped.
+   */
+  readonly maxStringLines?: number;
 
   /**
    * Replacer function, called on every value and sub-value encountered, to get

--- a/packages/data-model/src/api.ts
+++ b/packages/data-model/src/api.ts
@@ -482,10 +482,10 @@ export interface DebugValueOptions {
    * line break is a newline, a carriage return, or the two together; one at
    * the end of the string ends its last line rather than starting another. A
    * string with more lines is converted to the same form a string past
-   * `maxStringLength` is, carrying an excerpt of the string up to the limit
-   * and the string's actual length; when both limits apply, the excerpt is
-   * the shorter of the two. When absent, the limit is five. A large value is
-   * capped.
+   * `maxStringLength` is, carrying an excerpt of the string up to the limit,
+   * line breaks included, and the string's actual length; when both limits
+   * apply, the excerpt is the shorter of the two. When absent, the limit is
+   * five. A large value is capped.
    */
   readonly maxStringLines?: number;
 

--- a/packages/data-model/src/value-debug.ts
+++ b/packages/data-model/src/value-debug.ts
@@ -252,8 +252,9 @@ class DebugConverter {
    * characters up to the length limit, or its first lines up to the line
    * limit, whichever is shorter. A character cut can land inside a surrogate
    * pair, so an excerpt so cut loses a final high surrogate; a line cut lands
-   * on a line break. That form nests two levels, so a result holding one can
-   * run one level past the maximum nesting depth.
+   * just past a line break, which the excerpt keeps. That form nests two
+   * levels, so a result holding one can run one level past the maximum
+   * nesting depth.
    */
   #convertString(value: string): FabricValue {
     const { maxStringLength, maxStringLines } = this.#limits;
@@ -386,20 +387,17 @@ class DebugConverter {
 
   /**
    * Returns the index at which `value` ends were it cut to its first
-   * `maxLines` lines: the index of the line break which ends that many lines,
-   * or the length of `value` when it holds no more lines than that. A line
-   * break at the very end of `value` ends its last line rather than starting
-   * an empty one.
+   * `maxLines` lines: the index just past the line break which ends that many
+   * lines, or the length of `value` when it holds no more lines than that. A
+   * line break at the very end of `value` ends its last line rather than
+   * starting an empty one, which is a consequence of the cut landing past it.
    */
   static #lineCutOf(value: string, maxLines: number): number {
     let lines = 1;
 
     for (const lineBreak of value.matchAll(LINE_BREAK_REGEX)) {
-      const isFinal = (lineBreak.index + lineBreak[0].length) === value.length;
-      if (isFinal) {
-        break;
-      } else if (lines === maxLines) {
-        return lineBreak.index;
+      if (lines === maxLines) {
+        return lineBreak.index + lineBreak[0].length;
       }
       lines++;
     }

--- a/packages/data-model/src/value-debug.ts
+++ b/packages/data-model/src/value-debug.ts
@@ -53,6 +53,21 @@ const ABSOLUTE_MAX_STRING_LENGTH = 100000;
 const DEFAULT_MAX_STRING_LENGTH = 200;
 
 /**
+ * Number of lines of a string a conversion carries whole whatever its options
+ * say, so that a result is bounded in size whatever the input.
+ */
+const ABSOLUTE_MAX_STRING_LINES = 1000;
+
+/**
+ * Number of lines of a string a conversion carries whole, when its options do
+ * not say.
+ */
+const DEFAULT_MAX_STRING_LINES = 5;
+
+/** Matches one line break, of any of the three forms a string can hold. */
+const LINE_BREAK_REGEX = /\r\n|[\r\n]/g;
+
+/**
  * What a `FabricPrimitive`'s codec hands back to be rendered: the
  * realm-crossing encoding of a terminal codec, or the expansion of a
  * nonterminal one into other `FabricValue`s.
@@ -74,6 +89,7 @@ type ConversionLimits = {
   readonly maxDepth: number;
   readonly maxArrayLength: number;
   readonly maxStringLength: number;
+  readonly maxStringLines: number;
 };
 
 /**
@@ -230,23 +246,28 @@ class DebugConverter {
   }
 
   /**
-   * Converts a string. A string longer than the maximum string length is
-   * converted to a `/partialString` form carrying its length and an excerpt:
-   * its first characters up to that limit, less a final high surrogate, so
-   * that the excerpt does not end in half of a surrogate pair. That form
-   * nests two levels, so a result holding one can run one level past the
-   * maximum nesting depth.
+   * Converts a string. A string longer than the maximum string length, or
+   * holding more lines than the maximum string lines, is converted to a
+   * `/partialString` form carrying its length and an excerpt: its first
+   * characters up to the length limit, or its first lines up to the line
+   * limit, whichever is shorter. A character cut can land inside a surrogate
+   * pair, so an excerpt so cut loses a final high surrogate; a line cut lands
+   * on a line break. That form nests two levels, so a result holding one can
+   * run one level past the maximum nesting depth.
    */
   #convertString(value: string): FabricValue {
+    const { maxStringLength, maxStringLines } = this.#limits;
     const length = value.length;
-    const maxLength = this.#limits.maxStringLength;
+    const lengthCut = Math.min(length, maxStringLength);
+    const lineCut = DebugConverter.#lineCutOf(value, maxStringLines);
+    const cut = Math.min(lengthCut, lineCut);
 
-    if (length <= maxLength) {
+    if (cut === length) {
       return value;
     }
 
-    let excerpt = value.slice(0, maxLength);
-    if (/[\uD800-\uDBFF]$/.test(excerpt)) {
+    let excerpt = value.slice(0, cut);
+    if ((cut < lineCut) && /[\uD800-\uDBFF]$/.test(excerpt)) {
       excerpt = excerpt.slice(0, -1);
     }
 
@@ -362,6 +383,29 @@ class DebugConverter {
   //
   // Static members
   //
+
+  /**
+   * Returns the index at which `value` ends were it cut to its first
+   * `maxLines` lines: the index of the line break which ends that many lines,
+   * or the length of `value` when it holds no more lines than that. A line
+   * break at the very end of `value` ends its last line rather than starting
+   * an empty one.
+   */
+  static #lineCutOf(value: string, maxLines: number): number {
+    let lines = 1;
+
+    for (const lineBreak of value.matchAll(LINE_BREAK_REGEX)) {
+      const isFinal = (lineBreak.index + lineBreak[0].length) === value.length;
+      if (isFinal) {
+        break;
+      } else if (lines === maxLines) {
+        return lineBreak.index;
+      }
+      lines++;
+    }
+
+    return value.length;
+  }
 
   /**
    * Produces the `/unconvertible` result form which stands in for a value whose
@@ -920,8 +964,9 @@ function checkedLimit(
 /**
  * Helper for the entry points, which validates `options` and returns the
  * limits they call for: each limit stated, or when not, `defaultMaxDepth` for
- * the depth and the default for either length, all capped at their absolute
- * maximums.
+ * the depth and the default for each of the others, all capped at their
+ * absolute maximums. The string length defaults to `Infinity` rather than
+ * to its usual default when the options state a line count.
  *
  * @throws {Error} if `options` is not a plain object, or if one of its limits
  * is none of a positive integer, `Infinity`, or `undefined`.
@@ -931,6 +976,12 @@ function checkedLimits(
   defaultMaxDepth: number,
 ): ConversionLimits {
   checkOptions(options);
+
+  // A caller who states a line count and no length gets a line bound alone,
+  // not the default length on top of it.
+  const defaultMaxStringLength = (options?.maxStringLines === undefined)
+    ? DEFAULT_MAX_STRING_LENGTH
+    : Infinity;
 
   return {
     maxDepth: checkedLimit(
@@ -948,8 +999,14 @@ function checkedLimits(
     maxStringLength: checkedLimit(
       "maxStringLength",
       options?.maxStringLength,
-      DEFAULT_MAX_STRING_LENGTH,
+      defaultMaxStringLength,
       ABSOLUTE_MAX_STRING_LENGTH,
+    ),
+    maxStringLines: checkedLimit(
+      "maxStringLines",
+      options?.maxStringLines,
+      DEFAULT_MAX_STRING_LINES,
+      ABSOLUTE_MAX_STRING_LINES,
     ),
   };
 }
@@ -1100,12 +1157,15 @@ export function toDebugKindString(value: unknown): string {
  * be reasonably achieved.
  *
  * The limits of the result -- its nesting, the number of elements of an array
- * it represents, and the length of a string it carries whole -- and a replacer
- * to consult are the `maxDepth`, `maxArrayLength`, `maxStringLength`, and
- * `replacer` of `options`. When there is no nesting limit given, the result
- * nests as deep as reasonably possible; when there is no array length given,
- * an array is represented to one hundred elements; and when there is no
- * string length given, a string is carried whole to two hundred characters.
+ * it represents, and the length and number of lines of a string it carries
+ * whole -- and a replacer to consult are the `maxDepth`, `maxArrayLength`,
+ * `maxStringLength`, `maxStringLines`, and `replacer` of `options`. When
+ * there is no nesting limit given, the result nests as deep as reasonably
+ * possible; when there is no array length given, an array is represented to
+ * one hundred elements; when there is no string line count given, a string is
+ * carried whole to five lines; and when there is no string length given, a
+ * string is carried whole to two hundred characters, or as long as the
+ * conversion allows when a line count is given.
  *
  * If the conversion could not be completed (stack overflow, object
  * `toJSON()` conversion error, etc.), this function returns the literal value

--- a/packages/data-model/test/value-debug-cases/string-many-lines.txt
+++ b/packages/data-model/test/value-debug-cases/string-many-lines.txt
@@ -1,0 +1,11 @@
+(() => {
+  // A string of more lines than the default limit of 5 renders as an excerpt
+  // of that many lines, and then its actual length.
+  return { text: ["one", "two", "three", "four", "five", "six", "seven"].join("\n") };
+})()
+
+{
+  text: "one\ntwo\nthree\nfour\nfive" + ... length: 33
+}
+
+{text:"one\ntwo\nthree\nfour\nfive" + ... length: 33}

--- a/packages/data-model/test/value-debug-cases/string-many-lines.txt
+++ b/packages/data-model/test/value-debug-cases/string-many-lines.txt
@@ -1,11 +1,11 @@
 (() => {
   // A string of more lines than the default limit of 5 renders as an excerpt
-  // of that many lines, and then its actual length.
+  // of that many lines, line breaks included, and then its actual length.
   return { text: ["one", "two", "three", "four", "five", "six", "seven"].join("\n") };
 })()
 
 {
-  text: "one\ntwo\nthree\nfour\nfive" + ... length: 33
+  text: "one\ntwo\nthree\nfour\nfive\n" + ... length: 33
 }
 
-{text:"one\ntwo\nthree\nfour\nfive" + ... length: 33}
+{text:"one\ntwo\nthree\nfour\nfive\n" + ... length: 33}

--- a/packages/data-model/test/value-debug-structured.test.ts
+++ b/packages/data-model/test/value-debug-structured.test.ts
@@ -582,6 +582,80 @@ describe("toStructuredDebugValue()", () => {
     });
   });
 
+  describe("with `maxStringLines`", () => {
+    it("returns `/partialString` with the length and the first lines for a string past the limit", () => {
+      expect(toStructuredDebugValue("a\nb\nc\nd", { maxStringLines: 2 }))
+        .toEqual({ "/partialString": { length: 7, excerpt: "a\nb" } });
+    });
+
+    it("returns a string whose line count is the limit whole", () => {
+      expect(toStructuredDebugValue("a\nb", { maxStringLines: 2 }))
+        .toBe("a\nb");
+    });
+
+    it("counts a newline, a carriage return, and the two together as one line break each", () => {
+      expect(toStructuredDebugValue("a\r\nb\rc\nd", { maxStringLines: 3 }))
+        .toEqual({ "/partialString": { length: 8, excerpt: "a\r\nb\rc" } });
+    });
+
+    it("counts a final line break as ending the last line rather than starting another", () => {
+      expect(toStructuredDebugValue("a\nb\n", { maxStringLines: 2 }))
+        .toBe("a\nb\n");
+      expect(toStructuredDebugValue("a\nb\n\n", { maxStringLines: 2 }))
+        .toEqual({ "/partialString": { length: 5, excerpt: "a\nb" } });
+    });
+
+    it("returns whichever excerpt of the two limits is shorter", () => {
+      const value = "abcdefgh\nij";
+      const options = { maxStringLines: 1, maxStringLength: 5 };
+      expect(toStructuredDebugValue(value, options))
+        .toEqual({ "/partialString": { length: 11, excerpt: "abcde" } });
+      expect(
+        toStructuredDebugValue(value, { ...options, maxStringLength: 100 }),
+      )
+        .toEqual({ "/partialString": { length: 11, excerpt: "abcdefgh" } });
+    });
+
+    it("returns a line-cut excerpt whole even when it ends in a high surrogate", () => {
+      expect(toStructuredDebugValue("a\ud800\nb", { maxStringLines: 1 }))
+        .toEqual({ "/partialString": { length: 4, excerpt: "a\ud800" } });
+    });
+
+    it("returns a string of any length whole when only the line limit is given", () => {
+      const value = "x".repeat(250);
+      expect(toStructuredDebugValue(value, { maxStringLines: 1 })).toBe(value);
+    });
+
+    it("returns no more than 5 lines when the limit is not given", () => {
+      const value = "a\nb\nc\nd\ne\nf";
+      expect(toStructuredDebugValue(value))
+        .toEqual({
+          "/partialString": { length: 11, excerpt: "a\nb\nc\nd\ne" },
+        });
+    });
+
+    it("returns no more than 1000 lines given a larger limit", () => {
+      const value = "x\n".repeat(1500) + "x";
+      for (const limit of [2000, Infinity]) {
+        const result = toStructuredDebugValue(
+          value,
+          { maxStringLines: limit },
+        ) as { "/partialString": { length: number; excerpt: string } };
+        expect(result["/partialString"].length).toBe(3001);
+        expect(result["/partialString"].excerpt).toBe("x\n".repeat(999) + "x");
+      }
+    });
+
+    it("throws given a `maxStringLines` that is not a positive integer", () => {
+      for (const bad of [0, -1, 1.5, -Infinity, NaN, "3", null, {}]) {
+        const options = { maxStringLines: bad as unknown as number };
+        expect(() => toStructuredDebugValue("", options)).toThrow(
+          "`maxStringLines` must be a positive integer, `Infinity`, or",
+        );
+      }
+    });
+  });
+
   describe("with `options` that are not a plain object", () => {
     it("throws, naming the offending value", () => {
       for (const bad of [100, "3", null, [], new Map()]) {

--- a/packages/data-model/test/value-debug-structured.test.ts
+++ b/packages/data-model/test/value-debug-structured.test.ts
@@ -585,7 +585,7 @@ describe("toStructuredDebugValue()", () => {
   describe("with `maxStringLines`", () => {
     it("returns `/partialString` with the length and the first lines for a string past the limit", () => {
       expect(toStructuredDebugValue("a\nb\nc\nd", { maxStringLines: 2 }))
-        .toEqual({ "/partialString": { length: 7, excerpt: "a\nb" } });
+        .toEqual({ "/partialString": { length: 7, excerpt: "a\nb\n" } });
     });
 
     it("returns a string whose line count is the limit whole", () => {
@@ -595,14 +595,14 @@ describe("toStructuredDebugValue()", () => {
 
     it("counts a newline, a carriage return, and the two together as one line break each", () => {
       expect(toStructuredDebugValue("a\r\nb\rc\nd", { maxStringLines: 3 }))
-        .toEqual({ "/partialString": { length: 8, excerpt: "a\r\nb\rc" } });
+        .toEqual({ "/partialString": { length: 8, excerpt: "a\r\nb\rc\n" } });
     });
 
     it("counts a final line break as ending the last line rather than starting another", () => {
       expect(toStructuredDebugValue("a\nb\n", { maxStringLines: 2 }))
         .toBe("a\nb\n");
       expect(toStructuredDebugValue("a\nb\n\n", { maxStringLines: 2 }))
-        .toEqual({ "/partialString": { length: 5, excerpt: "a\nb" } });
+        .toEqual({ "/partialString": { length: 5, excerpt: "a\nb\n" } });
     });
 
     it("returns whichever excerpt of the two limits is shorter", () => {
@@ -613,12 +613,12 @@ describe("toStructuredDebugValue()", () => {
       expect(
         toStructuredDebugValue(value, { ...options, maxStringLength: 100 }),
       )
-        .toEqual({ "/partialString": { length: 11, excerpt: "abcdefgh" } });
+        .toEqual({ "/partialString": { length: 11, excerpt: "abcdefgh\n" } });
     });
 
-    it("returns a line-cut excerpt whole even when it ends in a high surrogate", () => {
+    it("returns a line-cut excerpt ending in a high surrogate and its line break", () => {
       expect(toStructuredDebugValue("a\ud800\nb", { maxStringLines: 1 }))
-        .toEqual({ "/partialString": { length: 4, excerpt: "a\ud800" } });
+        .toEqual({ "/partialString": { length: 4, excerpt: "a\ud800\n" } });
     });
 
     it("returns a string of any length whole when only the line limit is given", () => {
@@ -630,7 +630,7 @@ describe("toStructuredDebugValue()", () => {
       const value = "a\nb\nc\nd\ne\nf";
       expect(toStructuredDebugValue(value))
         .toEqual({
-          "/partialString": { length: 11, excerpt: "a\nb\nc\nd\ne" },
+          "/partialString": { length: 11, excerpt: "a\nb\nc\nd\ne\n" },
         });
     });
 
@@ -642,7 +642,7 @@ describe("toStructuredDebugValue()", () => {
           { maxStringLines: limit },
         ) as { "/partialString": { length: number; excerpt: string } };
         expect(result["/partialString"].length).toBe(3001);
-        expect(result["/partialString"].excerpt).toBe("x\n".repeat(999) + "x");
+        expect(result["/partialString"].excerpt).toBe("x\n".repeat(1000));
       }
     });
 

--- a/packages/data-model/test/value-debug.test.ts
+++ b/packages/data-model/test/value-debug.test.ts
@@ -181,9 +181,9 @@ describe("value-debug", () => {
     describe("with `maxStringLines`", () => {
       it("renders the string's first lines, and the string's length after them", () => {
         expect(toCompactDebugString("a\nb\nc", { maxStringLines: 2 }))
-          .toBe('"a\\nb" + ... length: 5');
+          .toBe('"a\\nb\\n" + ... length: 5');
         expect(toCompactDebugString({ s: "a\nb\nc" }, { maxStringLines: 2 }))
-          .toBe('{s:"a\\nb" + ... length: 5}');
+          .toBe('{s:"a\\nb\\n" + ... length: 5}');
       });
 
       it("renders a string whose line count is the limit whole", () => {
@@ -193,7 +193,7 @@ describe("value-debug", () => {
 
       it("renders no more than 5 lines when the limit is not given", () => {
         expect(toCompactDebugString("a\nb\nc\nd\ne\nf"))
-          .toBe('"a\\nb\\nc\\nd\\ne" + ... length: 11');
+          .toBe('"a\\nb\\nc\\nd\\ne\\n" + ... length: 11');
       });
 
       it("throws given a `maxStringLines` that is not a positive integer", () => {
@@ -260,7 +260,7 @@ describe("value-debug", () => {
 
     it("renders a string's first lines and length in the string's place", () => {
       expect(toIndentedDebugString({ s: "a\nb\nc" }, { maxStringLines: 2 }))
-        .toBe('{\n  s: "a\\nb" + ... length: 5\n}');
+        .toBe('{\n  s: "a\\nb\\n" + ... length: 5\n}');
     });
 
     it("renders the replacement in place of the original value", () => {

--- a/packages/data-model/test/value-debug.test.ts
+++ b/packages/data-model/test/value-debug.test.ts
@@ -178,6 +178,31 @@ describe("value-debug", () => {
       });
     });
 
+    describe("with `maxStringLines`", () => {
+      it("renders the string's first lines, and the string's length after them", () => {
+        expect(toCompactDebugString("a\nb\nc", { maxStringLines: 2 }))
+          .toBe('"a\\nb" + ... length: 5');
+        expect(toCompactDebugString({ s: "a\nb\nc" }, { maxStringLines: 2 }))
+          .toBe('{s:"a\\nb" + ... length: 5}');
+      });
+
+      it("renders a string whose line count is the limit whole", () => {
+        expect(toCompactDebugString("a\nb", { maxStringLines: 2 }))
+          .toBe('"a\\nb"');
+      });
+
+      it("renders no more than 5 lines when the limit is not given", () => {
+        expect(toCompactDebugString("a\nb\nc\nd\ne\nf"))
+          .toBe('"a\\nb\\nc\\nd\\ne" + ... length: 11');
+      });
+
+      it("throws given a `maxStringLines` that is not a positive integer", () => {
+        expect(() => toCompactDebugString("", { maxStringLines: 0 })).toThrow(
+          "`maxStringLines` must be a positive integer, `Infinity`, or",
+        );
+      });
+    });
+
     describe("with a `replacer`", () => {
       it("renders the replacement in place of the original value", () => {
         const options: CompactDebugStringOptions = {
@@ -231,6 +256,11 @@ describe("value-debug", () => {
     it("renders a string's excerpt and length in the string's place", () => {
       expect(toIndentedDebugString({ s: "abcdefgh" }, { maxStringLength: 5 }))
         .toBe('{\n  s: "abcde" + ... length: 8\n}');
+    });
+
+    it("renders a string's first lines and length in the string's place", () => {
+      expect(toIndentedDebugString({ s: "a\nb\nc" }, { maxStringLines: 2 }))
+        .toBe('{\n  s: "a\\nb" + ... length: 5\n}');
     });
 
     it("renders the replacement in place of the original value", () => {

--- a/packages/runner/src/builder/module.ts
+++ b/packages/runner/src/builder/module.ts
@@ -366,7 +366,7 @@ export const assertCapture = <T>(
 const ASSERT_RENDER_OPTIONS: DebugValueOptions = {
   maxDepth: Infinity,
   maxArrayLength: Infinity,
-  maxStringLength: Infinity,
+  maxStringLines: Infinity,
 };
 
 /**

--- a/packages/runner/src/builtins/wish.ts
+++ b/packages/runner/src/builtins/wish.ts
@@ -2520,7 +2520,7 @@ export function wish(
           // the difference it reports, so a string is rendered whole.
           await commitPatternErrorUI(
             resultCell,
-            toCompactDebugString(error, { maxStringLength: Infinity }),
+            toCompactDebugString(error, { maxStringLines: Infinity }),
           );
           return;
         }

--- a/packages/runner/src/storage/transaction/attestation.ts
+++ b/packages/runner/src/storage/transaction/attestation.ts
@@ -379,7 +379,7 @@ export const TypeMismatchError = (
  */
 const INCONSISTENCY_RENDER_OPTIONS: DebugValueOptions = {
   maxArrayLength: Infinity,
-  maxStringLength: Infinity,
+  maxStringLines: Infinity,
 };
 
 export const StateInconsistency = (source: {

--- a/packages/runner/test/favorites-row-stored-shape.test.ts
+++ b/packages/runner/test/favorites-row-stored-shape.test.ts
@@ -58,7 +58,7 @@ function debugFormContains(value: unknown, text: string): boolean {
     toStructuredDebugValue(value, {
       maxDepth: 100,
       maxArrayLength: Infinity,
-      maxStringLength: Infinity,
+      maxStringLines: Infinity,
     }),
   );
 }

--- a/packages/runtime-client/src/backends/runtime-processor.ts
+++ b/packages/runtime-client/src/backends/runtime-processor.ts
@@ -631,7 +631,7 @@ function newConsoleDebugReplacer(): (value: any) => any {
 export function toConsoleDebugValue(value: unknown): FabricValue {
   return toStructuredDebugValue(value, {
     maxDepth: MAX_CONSOLE_DEBUG_DEPTH,
-    maxStringLength: Infinity,
+    maxStringLines: Infinity,
     replacer: newConsoleDebugReplacer(),
   });
 }

--- a/packages/static/assets/types/commonfabric.d.ts
+++ b/packages/static/assets/types/commonfabric.d.ts
@@ -525,10 +525,10 @@ export interface DebugValueOptions {
    * line break is a newline, a carriage return, or the two together; one at
    * the end of the string ends its last line rather than starting another. A
    * string with more lines is converted to the same form a string past
-   * `maxStringLength` is, carrying an excerpt of the string up to the limit
-   * and the string's actual length; when both limits apply, the excerpt is
-   * the shorter of the two. When absent, the limit is five. A large value is
-   * capped.
+   * `maxStringLength` is, carrying an excerpt of the string up to the limit,
+   * line breaks included, and the string's actual length; when both limits
+   * apply, the excerpt is the shorter of the two. When absent, the limit is
+   * five. A large value is capped.
    */
   readonly maxStringLines?: number;
 

--- a/packages/static/assets/types/commonfabric.d.ts
+++ b/packages/static/assets/types/commonfabric.d.ts
@@ -514,9 +514,23 @@ export interface DebugValueOptions {
    * integer, or `Infinity` for as long as the conversion allows. A longer
    * string is converted to a form suggestive of the elision, which carries an
    * excerpt of the string up to the limit and the string's actual length.
-   * When absent, the limit is two hundred. A large value is capped.
+   * When absent, the limit is two hundred, or as long as the conversion
+   * allows when `maxStringLines` is present. A large value is capped.
    */
   readonly maxStringLength?: number;
+
+  /**
+   * Maximum number of lines of a string which is represented whole: a
+   * positive integer, or `Infinity` for as many as the conversion allows. A
+   * line break is a newline, a carriage return, or the two together; one at
+   * the end of the string ends its last line rather than starting another. A
+   * string with more lines is converted to the same form a string past
+   * `maxStringLength` is, carrying an excerpt of the string up to the limit
+   * and the string's actual length; when both limits apply, the excerpt is
+   * the shorter of the two. When absent, the limit is five. A large value is
+   * capped.
+   */
+  readonly maxStringLines?: number;
 
   /**
    * Replacer function, called on every value and sub-value encountered, to get


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Fable 5.1)

## What

`toStructuredDebugValue()`, `toIndentedDebugString()`, and
`toCompactDebugString()` take a `maxStringLines` option alongside
`maxStringLength`: default 5, `Infinity` accepted, absolute cap 1000. A string
with more lines than the limit is carried as the same `/partialString` form a
string past the length limit is, with its first lines, line breaks included, as the excerpt:

```
"one\ntwo\nthree\nfour\nfive\n" + ... length: 33
```

## Semantics

* When both limits apply, the excerpt is whichever cut is shorter; either limit
  alone is enough to trigger the form.
* A `maxStringLines` given without a `maxStringLength` makes the length limit
  `Infinity` (which the absolute cap of 100000 still bounds). A caller asking
  for a line bound gets a line bound, not the 200-character default on top of
  it. With neither given, both defaults apply. A `maxStringLength` given alone
  still gets the 5-line default.
* A line break is `\n`, `\r\n`, or a lone `\r`. The cut lands just past the
  line break that ends the last carried line, so the excerpt keeps that break.
  A line break at the very end of the string therefore ends its last line
  rather than opening an empty one, and a five-line stack with a trailing
  newline is carried whole.
* The reported `length` stays the string's `.length` in UTF-16 units. The
  trailing-high-surrogate care applies to a character cut only; a line cut
  lands past a line break and cannot split a pair.
* Validation matches the other limits: positive integer or `Infinity`, else a
  thrown error naming the option.

## Call sites

The five sites that rendered strings whole through `maxStringLength: Infinity`
now say `maxStringLines: Infinity` alone, which by the rule above also lifts
the length limit: `ASSERT_RENDER_OPTIONS` in `runner/src/builder/module.ts`,
`INCONSISTENCY_RENDER_OPTIONS` in `runner/src/storage/transaction/attestation.ts`,
the commit-failure rendering in `runner/src/builtins/wish.ts`,
`toConsoleDebugValue()` in `runtime-client/src/backends/runtime-processor.ts`,
and the walk in `runner/test/favorites-row-stored-shape.test.ts`. The existing
runtime-client test on a 300-character console argument is the live check that
a line bound alone lifts the length bound.

The two bounded-glimpse sites, `SUMMARY_VALUE_OPTIONS` in the transaction
summary and `DEBUGGER_VALUE_OPTIONS` in the shell debugger, keep the 5-line
default.

## Tests

New `with \`maxStringLines\`` blocks on all three entry points cover the cut,
the whole-at-limit case, the three line-break forms, the final-line-break rule,
the shorter-of-two-cuts rule, the surrogate distinction, the length-lifted
rule, the default, the cap, and validation. A new golden,
`value-debug-cases/string-many-lines.txt`, records a seven-line string under
the defaults. `commonfabric.d.ts` is regenerated for the new option.

Backlog: BL-090.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6892?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


