### PR TITLE
fix(tasks): type-check every ui component directory, not the 48 a character class let through

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -251,8 +251,7 @@ difficulties getting coverage checks to pass, consider the information in
 there), and that list now names every workspace package. Most are covered in
 full; a few are partial by design. The `*.input.ts` transformer fixtures under
 `schema-generator` and `ts-transformers` name ambient wrappers the transformer
-supplies, so they do not compile on their own and are left out. `ui` is checked
-only for its `v2` components, and not the outliner among them.
+supplies, so they do not compile on their own and are left out.
 
 Patterns are the exception `deno task check` does not own. It lists some pattern
 directories and checks them through the automatic-JSX environment the rest of

--- a/tasks/typecheck.test.ts
+++ b/tasks/typecheck.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { dirname, fromFileUrl, join } from "@std/path";
+import { walk } from "@std/fs";
+import { dirname, fromFileUrl, join, relative } from "@std/path";
 
 import { recordsSpooledBy } from "@commonfabric/test-support/records";
 
@@ -47,10 +48,7 @@ describe("typecheck", () => {
       expect(byScope.get("test-support")).toContain("packages/test-support");
       // Glob entries expand to repository-relative files.
       expect(byScope.get("tasks")).toContain("tasks/typecheck.ts");
-      // The ui component walk contributes files, none from the outliner.
-      const ui = byScope.get("ui") ?? [];
-      expect(ui.length).toBeGreaterThan(0);
-      expect(ui.every((path) => !path.includes("/outliner/"))).toBe(true);
+      expect(byScope.get("ui")).toContain("packages/ui");
       // Every path in every group belongs to the group's scope.
       for (const [scope, paths] of byScope) {
         for (const path of paths) {
@@ -59,13 +57,34 @@ describe("typecheck", () => {
       }
     });
 
+    it("covers every TypeScript file the ui package holds", async () => {
+      // A group naming part of a package type-checks that part and
+      // reports a clean run over the rest, so what this asserts is
+      // coverage rather than the shape of the entry that gives it. It
+      // reads the tree rather than a fixture, so a directory added to
+      // the package later is held to the same claim.
+
+      const byScope = await collectPathsByScope(REPO_ROOT);
+      const checked = byScope.get("ui") ?? [];
+      const uncovered: string[] = [];
+      for await (
+        const entry of walk(join(REPO_ROOT, "packages", "ui"), {
+          includeDirs: false,
+          exts: [".ts", ".tsx"],
+        })
+      ) {
+        const file = relative(REPO_ROOT, entry.path);
+        const covered = checked.some((checkPath) =>
+          file === checkPath || file.startsWith(`${checkPath}/`)
+        );
+        if (!covered) uncovered.push(file);
+      }
+      expect(uncovered).toEqual([]);
+    });
+
     it("includes iframe guests of either extension under arbitrary names", async () => {
       const root = await Deno.makeTempDir({ prefix: "typecheck-guests-" });
       try {
-        await Deno.mkdir(
-          join(root, "packages", "ui", "src", "v2", "components"),
-          { recursive: true },
-        );
         for (
           const [name, guest] of [
             ["custom-board", "guest.ts"],
@@ -112,6 +131,24 @@ describe("typecheck", () => {
         const result = await checkGroup("probe", [file], false);
         expect(result.success).toBe(false);
         expect(result.output).toContain("TS2322");
+      } finally {
+        await Deno.remove(dir, { recursive: true });
+      }
+    });
+
+    it("fails a group whose path is not in the tree", async () => {
+      // A checked path that went missing would otherwise report a clean
+      // check over a package nothing looked at.
+
+      const dir = await Deno.makeTempDir({ prefix: "typecheck-group-" });
+      try {
+        const result = await checkGroup(
+          "probe",
+          [join(dir, "gone")],
+          false,
+        );
+        expect(result.success).toBe(false);
+        expect(result.output).toContain("Cannot find module");
       } finally {
         await Deno.remove(dir, { recursive: true });
       }
@@ -273,21 +310,6 @@ describe("main()", () => {
     } finally {
       console.log = log;
       console.error = err;
-    }
-  });
-});
-
-describe("collectPathsByScope()", () => {
-  it("raises when the tree holds none of the paths it walks", async () => {
-    // A group that silently collected nothing would report a clean
-    // check over files it never looked at.
-    const root = await Deno.makeTempDir({ prefix: "typecheck-bare-" });
-    try {
-      await expect(collectPathsByScope(root)).rejects.toThrow(
-        "cannot enumerate",
-      );
-    } finally {
-      await Deno.remove(root, { recursive: true });
     }
   });
 });

--- a/tasks/typecheck.ts
+++ b/tasks/typecheck.ts
@@ -80,6 +80,7 @@ const DIRS = [
   "packages/test-support",
   "packages/toolshed",
   "packages/ts-transformers/src",
+  "packages/ui",
   "packages/utils",
 ];
 
@@ -114,44 +115,6 @@ const GLOBS = [
   "packages/patterns/google/WIP/*.tsx",
 ];
 
-// The ui components entry replicates the shell pattern
-// `packages/ui/src/v2/components/*[!outliner]/*.ts*`: a component directory
-// is included unless its name ends with one of the characters of
-// "outliner". The character class reads as a name filter for the outliner
-// component but excludes every directory with one of those trailing
-// letters, and this port preserves that behavior exactly rather than
-// silently widening the checked set.
-const UI_COMPONENTS_DIR = "packages/ui/src/v2/components";
-const UI_EXCLUDED_TRAILING = new Set("outliner");
-
-async function uiComponentFiles(root: string): Promise<string[]> {
-  const files: string[] = [];
-  const directories: Deno.DirEntry[] = [];
-  try {
-    for await (const entry of Deno.readDir(`${root}/${UI_COMPONENTS_DIR}`)) {
-      directories.push(entry);
-    }
-  } catch (error) {
-    // This task is the single type-checking point for these paths, so a
-    // component tree that cannot be enumerated fails the task rather than
-    // silently dropping the whole ui group from coverage.
-    throw new Error(`cannot enumerate ${UI_COMPONENTS_DIR}: ${error}`);
-  }
-  for (const entry of directories) {
-    if (!entry.isDirectory) continue;
-    const last = entry.name.at(-1);
-    if (last !== undefined && UI_EXCLUDED_TRAILING.has(last)) continue;
-    for await (
-      const file of Deno.readDir(`${root}/${UI_COMPONENTS_DIR}/${entry.name}`)
-    ) {
-      if (file.isFile && /\.tsx?$/.test(file.name)) {
-        files.push(`${UI_COMPONENTS_DIR}/${entry.name}/${file.name}`);
-      }
-    }
-  }
-  return files.sort();
-}
-
 /** The owning scope of a checked path: the workspace member's name. */
 export function scopeOfPath(checkPath: string): string {
   const parts = checkPath.split("/");
@@ -180,7 +143,6 @@ export async function collectPathsByScope(
       );
     }
   }
-  paths.push(...await uiComponentFiles(root));
   const byScope = new Map<string, string[]>();
   for (const checkPath of paths.sort()) {
     const scope = scopeOfPath(checkPath);


### PR DESCRIPTION
Fixes #6893.

## Why

`deno task check` reported `Type check complete.` over files it never opened.
The ui group was built by dropping any component directory whose name ends in
one of the characters of `"outliner"` — `new Set("outliner")` is the eight
characters `o u t l i n e r`, so a character class stood where a name filter
was meant:

| component directories | 118 |
| --- | --- |
| excluded by the rule | 70 |
| type-checked | 48 |

Among the 70: `cf-code-editor`, `cf-button`, `cf-chart`, `cf-chat`,
`cf-calendar`, `cf-avatar`, `cf-alert`, `cf-autocomplete`, `cf-badge`.
`packages/ui/src/v2/core/` was in no checked path at all. A change to any of
them passed the gate unchecked — they are type-checked only incidentally by
`deno task test` in `packages/ui`, through whichever test files import them, so
a file no test imports was checked by nothing.

Two things settle what to do, and neither was in the issue.

**The exclusion's target does not exist.** The glob arrived in `4ffd103edf` as
`deno check packages/ui/src/v2/components/*[!outliner]/*.ts*` under the comment
`# TODO(runtime-worker-refactor): Ignore ct-outliner until re-added`. It was
written for `ct-outliner`, which was removed and never re-added. No directory
under `components/` ends in "outliner" today, so the intended exclusion names
nothing while the accidental one drops 70 directories.

**The backlog the issue warned about is zero.** `deno check packages/ui` — all
382 files, components and `core` and the package's own `test` tree — exits 0 at
this commit. Widening surfaces no existing errors, which removes the reason to
keep the exclusion for a subset.

## What Changed

`tasks/typecheck.ts` — the ui component walk, its exclusion, and the guard
around it are replaced by `"packages/ui"` in `DIRS`, the same plain directory
entry every other package gets. The `ui` group goes from 107 files to the whole
package.

`AGENTS.md` — drops the sentence saying `ui` is checked only for its `v2`
components; it is now covered in full like most of the tree.

`tasks/typecheck.test.ts`:

- **New:** `collectPathsByScope()` covers every TypeScript file the ui package
  holds. It walks the real tree rather than a fixture, so a directory added to
  the package later is held to the same claim.
- **New:** `checkGroup()` fails a group whose path is not in the tree. The old
  walk had a `cannot enumerate` guard against silently collecting nothing; a
  constant `DIRS` entry cannot collect nothing, so the property moves to the
  place that now enforces it — `deno check` on a vanished path exits 1.
- **Replaced:** the old ui assertion was
  `ui.every((path) => !path.includes("/outliner/"))`, which passes under both
  the buggy and the correct behavior and so could not fail. Its removal is part
  of the fix.
- **Removed:** the `cannot enumerate` test, whose mechanism is gone.

## Test plan

The new coverage test is red at the parent commit — it names all 275 uncovered
files, the whole of `packages/ui` bar the 107 the old walk collected — and green
here.

The gate itself was mutation-tested, appending
`const probeTypeError: number = "not a number";` to a previously-excluded file:

| | `deno task check --scope=ui` |
| --- | --- |
| parent commit, `cf-code-editor.ts` mutated | `ok  ui (3.6s)` / `Type check complete.` |
| this commit, `cf-code-editor.ts` mutated | `Type check failed in 1 of 1 groups.` |
| this commit, `core/safe-url.ts` mutated | `Type check failed in 1 of 1 groups.` |

The first row is the bug in one line: a clean verdict over a file carrying a
deliberate `TS2322`.

Green locally: `deno task check` (full tree), `deno task test` in `tasks`
(776 passed), `deno fmt --check` and `deno lint` repo-wide,
`check-test-topology`, `check-skill-facts`, `check-unused-deps`,
`check-single-copy-deps`, `check-no-waitfor`, `check-conflict-markers`,
`check-control-characters`.

## Not in this change

A general gate — "no package is silently partial" — would catch this shape
anywhere rather than in ui alone. It needs the deliberately-partial packages
(`schema-generator` and `ts-transformers` fixtures, `patterns`, `cli`) declared
somewhere a test can read, and `AGENTS.md` currently carries that in prose.
Worth doing if a second instance turns up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016et63G85fe5jby8tKxoDV4

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6894?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


