### PR TITLE
feat(data-model): the indented debug string renders a multi-line string one line per line

### DIFF
--- a/packages/data-model/src/value-debug.ts
+++ b/packages/data-model/src/value-debug.ts
@@ -828,18 +828,16 @@ class DebugStringifier {
   /**
    * Renders the string-length form: the excerpt as `#renderString()` renders
    * it, followed by the length of the whole. The length follows on the same
-   * line, or on a line of its own, indented by `inner`, when the excerpt
-   * renders on more than one.
+   * line, or when the rendering is multi-line, on a line of its own, indented
+   * by `inner`.
    */
   #renderPartialString(
     partial: { readonly length: number; readonly excerpt: string },
     indent: string,
   ): string {
-    const lines = DebugStringifier.#linesOf(partial.excerpt);
     const inner = this.#innerIndent(indent);
-    const rendered = this.#renderLines(lines, inner);
-    const onOwnLine = (this.#indent !== undefined) && (lines.length > 1);
-    const separator = onOwnLine ? `\n${inner}` : " ";
+    const rendered = this.#renderString(partial.excerpt, indent);
+    const separator = (this.#indent === undefined) ? " " : `\n${inner}`;
 
     return `${rendered} +${separator}... length: ${partial.length}`;
   }
@@ -1173,9 +1171,9 @@ export function toCompactDebugString(
  * length to give. The depth limit and replacer apply to both. A string holding
  * a line break renders one line of the string per line of the result, each
  * quoted, every line but the last followed by ` +`, and every line but the
- * first indented one level further than the value; the length of a string
- * carried in part follows on a line of its own when its excerpt renders on
- * more than one.
+ * first indented one level further than the value; and the length of a string
+ * carried in part follows its excerpt on a line of its own, indented the same
+ * way.
  *
  * @throws {Error} if given invalid `options`.
  */

--- a/packages/data-model/src/value-debug.ts
+++ b/packages/data-model/src/value-debug.ts
@@ -68,6 +68,12 @@ const DEFAULT_MAX_STRING_LINES = 5;
 const LINE_BREAK_REGEX = /\r\n|[\r\n]/g;
 
 /**
+ * Matches the empty position just past each line break, so that splitting a
+ * string on it yields the string's lines with their line breaks kept.
+ */
+const AFTER_LINE_BREAK_REGEX = /(?<=\r\n|\r(?!\n)|\n)/;
+
+/**
  * What a `FabricPrimitive`'s codec hands back to be rendered: the
  * realm-crossing encoding of a terminal codec, or the expansion of a
  * nonterminal one into other `FabricValue`s.
@@ -685,7 +691,7 @@ class DebugStringifier {
       }
 
       case "string": {
-        return JSON.stringify(value);
+        return this.#renderString(value, indent);
       }
 
       case "symbol": {
@@ -783,8 +789,7 @@ class DebugStringifier {
         // render as it is.
         const partial = DebugStringifier.#partialStringOf(payload);
         if (partial !== undefined) {
-          const excerpt = this.#renderSubvalue(partial.excerpt, indent);
-          return `${excerpt} + ... length: ${partial.length}`;
+          return this.#renderPartialString(partial, indent);
         }
         // deno-coverage-ignore-start
         // The conversion is the form's only producer and shapes it no other
@@ -803,6 +808,53 @@ class DebugStringifier {
   /** Returns the indentation for the contents of a container indented by `indent`. */
   #innerIndent(indent: string): string {
     return `${indent}${this.#indent ?? ""}`;
+  }
+
+  /**
+   * Renders the given lines of a string, as `#linesOf()` splits them. When
+   * the rendering is multi-line and there is more than one, each renders
+   * quoted on a line of its own, every line but the last followed by ` +` and
+   * every line but the first indented by `inner`. Otherwise they render as
+   * the one quoted string they came from.
+   */
+  #renderLines(lines: readonly string[], inner: string): string {
+    if ((this.#indent === undefined) || (lines.length === 1)) {
+      return JSON.stringify(lines.join(""));
+    }
+
+    return lines.map((line) => JSON.stringify(line)).join(` +\n${inner}`);
+  }
+
+  /**
+   * Renders the string-length form: the excerpt as `#renderString()` renders
+   * it, followed by the length of the whole. The length follows on the same
+   * line, or on a line of its own, indented by `inner`, when the excerpt
+   * renders on more than one.
+   */
+  #renderPartialString(
+    partial: { readonly length: number; readonly excerpt: string },
+    indent: string,
+  ): string {
+    const lines = DebugStringifier.#linesOf(partial.excerpt);
+    const inner = this.#innerIndent(indent);
+    const rendered = this.#renderLines(lines, inner);
+    const onOwnLine = (this.#indent !== undefined) && (lines.length > 1);
+    const separator = onOwnLine ? `\n${inner}` : " ";
+
+    return `${rendered} +${separator}... length: ${partial.length}`;
+  }
+
+  /**
+   * Renders a string. When the rendering is multi-line and the string holds a
+   * line break, each of its lines renders on a line of its own, the first in
+   * place and the rest indented by the inner indentation of `indent`, joined
+   * by ` +`. Otherwise the string renders whole, quoted.
+   */
+  #renderString(value: string, indent: string): string {
+    return this.#renderLines(
+      DebugStringifier.#linesOf(value),
+      this.#innerIndent(indent),
+    );
   }
 
   //
@@ -859,6 +911,21 @@ class DebugStringifier {
 
     const { length } = value as FabricPlainObject;
     return (typeof length === "number") ? length : undefined;
+  }
+
+  /**
+   * Returns the lines of the given string, each with its line break kept. A
+   * string ending in a line break has no empty line after it, and the empty
+   * string is one empty line.
+   */
+  static #linesOf(value: string): string[] {
+    const lines = value.split(AFTER_LINE_BREAK_REGEX);
+
+    if ((lines.length > 1) && (lines.at(-1) === "")) {
+      lines.pop();
+    }
+
+    return lines;
   }
 
   /**
@@ -1103,7 +1170,12 @@ export function toCompactDebugString(
 /**
  * Like `toCompactDebugString()`, except that the result is indented by two
  * spaces per nesting level, and is never truncated for length, there being no
- * length to give. The depth limit and replacer apply to both.
+ * length to give. The depth limit and replacer apply to both. A string holding
+ * a line break renders one line of the string per line of the result, each
+ * quoted, every line but the last followed by ` +`, and every line but the
+ * first indented one level further than the value; the length of a string
+ * carried in part follows on a line of its own when its excerpt renders on
+ * more than one.
  *
  * @throws {Error} if given invalid `options`.
  */

--- a/packages/data-model/test/value-debug-cases/fabric-error.txt
+++ b/packages/data-model/test/value-debug-cases/fabric-error.txt
@@ -51,7 +51,8 @@
     type: "Error",
     name: null,
     message: "boom",
-    stack: "Error: boom\n    at frob (file:///example/frob.ts:12:34)"
+    stack: "Error: boom\n" +
+      "    at frob (file:///example/frob.ts:12:34)"
   ),
   bare: /Error(
     type: "Error",
@@ -62,7 +63,8 @@
     type: "TypeError",
     name: null,
     message: "not a thing",
-    stack: "TypeError: not a thing\n    at frob (file:///example/frob.ts:12:34)"
+    stack: "TypeError: not a thing\n" +
+      "    at frob (file:///example/frob.ts:12:34)"
   ),
   "name differs from type": /Error(
     type: "TypeError",
@@ -73,12 +75,14 @@
     type: "Error",
     name: null,
     message: "outer",
-    stack: "Error: outer\n    at frob (file:///example/frob.ts:12:34)",
+    stack: "Error: outer\n" +
+      "    at frob (file:///example/frob.ts:12:34)",
     cause: /Error(
       type: "Error",
       name: null,
       message: "inner",
-      stack: "Error: inner\n    at frob (file:///example/frob.ts:12:34)"
+      stack: "Error: inner\n" +
+        "    at frob (file:///example/frob.ts:12:34)"
     )
   ),
   "with fabric cause": /Error(
@@ -97,7 +101,8 @@
     type: "Error",
     name: null,
     message: "extra",
-    stack: "Error: extra\n    at frob (file:///example/frob.ts:12:34)",
+    stack: "Error: extra\n" +
+      "    at frob (file:///example/frob.ts:12:34)",
     code: 42,
     when: /EpochNsec(1788438896789000000n)
   ),
@@ -105,17 +110,20 @@
     type: "Error",
     name: null,
     message: "top",
-    stack: "Error: top\n    at frob (file:///example/frob.ts:12:34)",
+    stack: "Error: top\n" +
+      "    at frob (file:///example/frob.ts:12:34)",
     cause: /Error(
       type: "Error",
       name: null,
       message: "middle",
-      stack: "Error: middle\n    at frob (file:///example/frob.ts:12:34)",
+      stack: "Error: middle\n" +
+        "    at frob (file:///example/frob.ts:12:34)",
       cause: /Error(
         type: "Error",
         name: null,
         message: "root",
-        stack: "Error: root\n    at frob (file:///example/frob.ts:12:34)"
+        stack: "Error: root\n" +
+          "    at frob (file:///example/frob.ts:12:34)"
       )
     )
   )

--- a/packages/data-model/test/value-debug-cases/omnibus-string.txt
+++ b/packages/data-model/test/value-debug-cases/omnibus-string.txt
@@ -16,7 +16,8 @@
   empty: "",
   plain: "hello",
   "with quotes": "say \"hi\"",
-  "with newline": "a\nb",
+  "with newline": "a\n" +
+    "b",
   "with backslash": "a\\b",
   "non-ASCII": "héllo ☃",
   "control character": "\u0001",

--- a/packages/data-model/test/value-debug-cases/omnibus-string.txt
+++ b/packages/data-model/test/value-debug-cases/omnibus-string.txt
@@ -33,7 +33,8 @@
   "lone surrogate": "\ud800",
   "in an array": [
     "one line",
-    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" + ... length: 250,
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" +
+      ... length: 250,
     "one\n" +
       "two\n" +
       "three",

--- a/packages/data-model/test/value-debug-cases/omnibus-string.txt
+++ b/packages/data-model/test/value-debug-cases/omnibus-string.txt
@@ -10,6 +10,12 @@
   "reads like a bigint": "42n",
   "reads like a symbol": "@k",
   "lone surrogate": "\ud800",
+  "in an array": [
+    "one line",
+    "x".repeat(250),
+    "one\ntwo\nthree",
+    "one\ntwo\nthree\nfour\nfive\nsix\nseven",
+  ],
 }
 
 {
@@ -24,7 +30,20 @@
   "reads like a token": "undefined",
   "reads like a bigint": "42n",
   "reads like a symbol": "@k",
-  "lone surrogate": "\ud800"
+  "lone surrogate": "\ud800",
+  "in an array": [
+    "one line",
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" + ... length: 250,
+    "one\n" +
+      "two\n" +
+      "three",
+    "one\n" +
+      "two\n" +
+      "three\n" +
+      "four\n" +
+      "five\n" +
+      ... length: 33
+  ]
 }
 
 {empty:"",plain:"hello","with quotes":"say \"hi\"","with newline":"a\nb","with backslash":"a\\b",...

--- a/packages/data-model/test/value-debug-cases/string-long-lines.txt
+++ b/packages/data-model/test/value-debug-cases/string-long-lines.txt
@@ -3,14 +3,12 @@
   // third line renders that line's excerpt with a ` +` of its own, and then
   // the actual length on a line of its own.
   const line = (c) => c.repeat(90) + "\n";
-  return { text: line("a") + line("b") + line("c") };
+  return line("a") + line("b") + line("c");
 })()
 
-{
-  text: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n" +
-    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n" +
-    "cccccccccccccccccc" +
-    ... length: 273
-}
+"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n" +
+  "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n" +
+  "cccccccccccccccccc" +
+  ... length: 273
 
-{text:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...
+"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\nbbbb...

--- a/packages/data-model/test/value-debug-cases/string-long-lines.txt
+++ b/packages/data-model/test/value-debug-cases/string-long-lines.txt
@@ -1,0 +1,16 @@
+(() => {
+  // A multi-line string cut by the default length limit of 200 inside its
+  // third line renders that line's excerpt with a ` +` of its own, and then
+  // the actual length on a line of its own.
+  const line = (c) => c.repeat(90) + "\n";
+  return { text: line("a") + line("b") + line("c") };
+})()
+
+{
+  text: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n" +
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n" +
+    "cccccccccccccccccc" +
+    ... length: 273
+}
+
+{text:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...

--- a/packages/data-model/test/value-debug-cases/string-long.txt
+++ b/packages/data-model/test/value-debug-cases/string-long.txt
@@ -5,7 +5,8 @@
 })()
 
 {
-  text: "abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghij" + ... length: 300
+  text: "abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghij" +
+    ... length: 300
 }
 
 {text:"abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghij...

--- a/packages/data-model/test/value-debug-cases/string-many-lines.txt
+++ b/packages/data-model/test/value-debug-cases/string-many-lines.txt
@@ -1,16 +1,14 @@
 (() => {
   // A string of more lines than the default limit of 5 renders as an excerpt
   // of that many lines, line breaks included, and then its actual length.
-  return { text: ["one", "two", "three", "four", "five", "six", "seven"].join("\n") };
+  return ["one", "two", "three", "four", "five", "six", "seven"].join("\n");
 })()
 
-{
-  text: "one\n" +
-    "two\n" +
-    "three\n" +
-    "four\n" +
-    "five\n" +
-    ... length: 33
-}
+"one\n" +
+  "two\n" +
+  "three\n" +
+  "four\n" +
+  "five\n" +
+  ... length: 33
 
-{text:"one\ntwo\nthree\nfour\nfive\n" + ... length: 33}
+"one\ntwo\nthree\nfour\nfive\n" + ... length: 33

--- a/packages/data-model/test/value-debug-cases/string-many-lines.txt
+++ b/packages/data-model/test/value-debug-cases/string-many-lines.txt
@@ -5,7 +5,12 @@
 })()
 
 {
-  text: "one\ntwo\nthree\nfour\nfive\n" + ... length: 33
+  text: "one\n" +
+    "two\n" +
+    "three\n" +
+    "four\n" +
+    "five\n" +
+    ... length: 33
 }
 
 {text:"one\ntwo\nthree\nfour\nfive\n" + ... length: 33}

--- a/packages/data-model/test/value-debug-cases/top-level-string.txt
+++ b/packages/data-model/test/value-debug-cases/top-level-string.txt
@@ -1,5 +1,6 @@
 "a string with \"quotes\" and a\nnewline"
 
-"a string with \"quotes\" and a\nnewline"
+"a string with \"quotes\" and a\n" +
+  "newline"
 
 "a string with \"quotes\" and a\nnewline"

--- a/packages/data-model/test/value-debug.test.ts
+++ b/packages/data-model/test/value-debug.test.ts
@@ -259,7 +259,7 @@ describe("value-debug", () => {
 
     it("renders a string's excerpt and length in the string's place", () => {
       expect(toIndentedDebugString({ s: "abcdefgh" }, { maxStringLength: 5 }))
-        .toBe('{\n  s: "abcde" + ... length: 8\n}');
+        .toBe('{\n  s: "abcde" +\n    ... length: 8\n}');
     });
 
     it("renders a string's first lines and length in the string's place", () => {
@@ -299,9 +299,9 @@ describe("value-debug", () => {
           .toBe('"abc\\n" +\n  "d" +\n  ... length: 7');
       });
 
-      it("renders a partial string's one-line excerpt and length on one line", () => {
+      it("renders a partial string's one-line excerpt with the length on the line after", () => {
         expect(toIndentedDebugString("abc\ndef", { maxStringLines: 1 }))
-          .toBe('"abc\\n" + ... length: 7');
+          .toBe('"abc\\n" +\n  ... length: 7');
       });
 
       it("renders a class instance's `toString()` form the same way", () => {

--- a/packages/data-model/test/value-debug.test.ts
+++ b/packages/data-model/test/value-debug.test.ts
@@ -65,6 +65,10 @@ describe("value-debug", () => {
       }
     });
 
+    it("renders a string holding a line break on one line, the break escaped", () => {
+      expect(toCompactDebugString({ s: "a\nb" })).toBe('{s:"a\\nb"}');
+    });
+
     describe("with `maxLength`", () => {
       it("renders the full text given a `maxLength` of `Infinity`", () => {
         const item = { text: "x".repeat(200) };
@@ -260,7 +264,55 @@ describe("value-debug", () => {
 
     it("renders a string's first lines and length in the string's place", () => {
       expect(toIndentedDebugString({ s: "a\nb\nc" }, { maxStringLines: 2 }))
-        .toBe('{\n  s: "a\\nb\\n" + ... length: 5\n}');
+        .toBe('{\n  s: "a\\n" +\n    "b\\n" +\n    ... length: 5\n}');
+    });
+
+    describe("with a string holding a line break", () => {
+      it("renders each line quoted on a line of its own, joined by ` +`", () => {
+        expect(toIndentedDebugString("a\nb\nc"))
+          .toBe('"a\\n" +\n  "b\\n" +\n  "c"');
+      });
+
+      it("renders the lines after the first one level further in than the value", () => {
+        expect(toIndentedDebugString({ s: "a\nb" }))
+          .toBe('{\n  s: "a\\n" +\n    "b"\n}');
+        expect(toIndentedDebugString({ o: { s: "a\nb" } }))
+          .toBe('{\n  o: {\n    s: "a\\n" +\n      "b"\n  }\n}');
+        expect(toIndentedDebugString(["a\nb"]))
+          .toBe('[\n  "a\\n" +\n    "b"\n]');
+      });
+
+      it("renders a carriage return, with or without a newline, as a line break", () => {
+        expect(toIndentedDebugString("a\r\nb\rc"))
+          .toBe('"a\\r\\n" +\n  "b\\r" +\n  "c"');
+      });
+
+      it("renders a string ending in a line break with no empty line after it", () => {
+        expect(toIndentedDebugString("a\nb\n")).toBe('"a\\n" +\n  "b\\n"');
+        expect(toIndentedDebugString("a\n")).toBe('"a\\n"');
+      });
+
+      it("renders a partial string's length on a line of its own", () => {
+        expect(toIndentedDebugString("a\nb\nc", { maxStringLines: 2 }))
+          .toBe('"a\\n" +\n  "b\\n" +\n  ... length: 5');
+        expect(toIndentedDebugString("abc\ndef", { maxStringLength: 5 }))
+          .toBe('"abc\\n" +\n  "d" +\n  ... length: 7');
+      });
+
+      it("renders a partial string's one-line excerpt and length on one line", () => {
+        expect(toIndentedDebugString("abc\ndef", { maxStringLines: 1 }))
+          .toBe('"abc\\n" + ... length: 7');
+      });
+
+      it("renders a class instance's `toString()` form the same way", () => {
+        class Foo {
+          toString() {
+            return "a\nb";
+          }
+        }
+        expect(toIndentedDebugString({ foo: new Foo() }))
+          .toBe('{\n  foo: /Foo("a\\n" +\n    "b")\n}');
+      });
     });
 
     it("renders the replacement in place of the original value", () => {


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Fable 5.1)

## What

In `toIndentedDebugString()`, a string holding a line break renders as one
quoted line per line of the string. Every line but the last is followed by
` +`, and every line but the first is indented one level further than the
value it belongs to:

```
{
  text: "one\n" +
    "two\n" +
    "three"
}
```

A partial string's excerpt renders the same way, with `... length: N` on a
line of its own:

```
{
  text: "one\n" +
    "two\n" +
    "three\n" +
    "four\n" +
    "five\n" +
    ... length: 33
}
```

## Details

* A line break is `\n`, `\r\n`, or a lone `\r`, each kept at the end of its
  line. A string ending in a line break has no empty line after it, so `"a\n"`
  renders as before, on one line.
* A character cut inside a line renders that line's excerpt with a ` +` of its
  own, then the length line: `"g" +` / `... length: 11`.
* A one-line excerpt gets the same treatment, so the form has one shape:
  `"abcde" +` / `  ... length: 8`.
* A class instance's `toString()` form takes the same shape inside its
  parentheses: `/Foo("a\n" +` / `  "b")`.
* `toCompactDebugString()` is unchanged: one line, breaks escaped.

## Tests

New cases under the indented renderer cover each of the above, and a compact
case pins the single line. Goldens: `fabric-error`, `omnibus-string`,
`string-many-lines`, and `top-level-string` re-recorded in the new shape, and a
new `string-long-lines` records a character cut inside the third line of a
multi-line string. No caller outside data-model's own tests pins the indented
rendering of a multi-line string; the assertion diagnostics and the CLI diff
lines render through the compact form.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6895?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


