### PR TITLE
feat(shell): a collection member opens from its URL (S3)

### DIFF
--- a/docs/features/host-embedding.md
+++ b/docs/features/host-embedding.md
@@ -101,6 +101,11 @@ DOM). A host embeds by listening for:
   clicks), the detail is an `AppView`. Bind to the common fields —
   space + `pieceId` — and loud-log + no-op anything else.
 
+  A view naming a collection member carries `pieceSlug` **and**
+  `pieceMember`, and the two are one address: a host that binds the slug and
+  drops the member opens the piece holding the collection instead of the
+  member the view named. Carry both, or no-op the view whole.
+
   ```ts
   import type { DID } from "@commonfabric/identity";
 
@@ -112,7 +117,7 @@ DOM). A host embeds by listening for:
   import type { DID } from "@commonfabric/identity";
 
   // Condensed from packages/navigation/src/view.ts
-  type PieceRef = {
+  type PieceViewRef = {
     pieceId?: string;
     // A slug naming a collection, and the member it selects.
     pieceSlug?: string;
@@ -120,8 +125,8 @@ DOM). A host embeds by listening for:
   };
   export type AppView =
     | { builtin: "home" }
-    | ({ spaceName: string; mode?: "embed" } & PieceRef)
-    | ({ spaceDid: DID; mode?: "embed" } & PieceRef);
+    | ({ spaceName: string; mode?: "embed" } & PieceViewRef)
+    | ({ spaceDid: DID; mode?: "embed" } & PieceViewRef);
   ```
 
 - **`cf-replace-navigation`** — same `AppView` detail; replaces the

--- a/docs/features/host-embedding.md
+++ b/docs/features/host-embedding.md
@@ -112,10 +112,16 @@ DOM). A host embeds by listening for:
   import type { DID } from "@commonfabric/identity";
 
   // Condensed from packages/navigation/src/view.ts
+  type PieceRef = {
+    pieceId?: string;
+    // A slug naming a collection, and the member it selects.
+    pieceSlug?: string;
+    pieceMember?: string;
+  };
   export type AppView =
     | { builtin: "home" }
-    | { spaceName: string; pieceId?: string; pieceSlug?: string; mode?: "embed" }
-    | { spaceDid: DID; pieceId?: string; pieceSlug?: string; mode?: "embed" };
+    | ({ spaceName: string; mode?: "embed" } & PieceRef)
+    | ({ spaceDid: DID; mode?: "embed" } & PieceRef);
   ```
 
 - **`cf-replace-navigation`** — same `AppView` detail; replaces the

--- a/docs/plans/collection-naming-topics.md
+++ b/docs/plans/collection-naming-topics.md
@@ -30,7 +30,12 @@ ruled. A later reversal is a decision recorded here, not a discovery.
 1. **The citation form follows the cell reference grammar.** The fully
    qualified citation is `#//topics-dev/top/42`. The spec's `#@space/...`
    spelling is amended when that grammar lands. Part 1 of the spec, which
-   governs addressing, is unaffected.
+   governs addressing, is unaffected. That grammar arrives with #6814; until
+   it does, the spelling that resolves is `/@<space>/...`, and that is what a
+   stage builds and demonstrates. A criterion's examples mean whichever
+   spelling the grammar accepts when the criterion is checked, so a stage
+   landing after #6814 reads them as `//<space>/...` with no criterion
+   rewritten.
 2. **The reverse-map restructure and the cross-space slug target are
    deferred.** A board-owned namespace never writes the piece's single `slug`
    metadata entry, so that restructure gates URL rewriting rather than
@@ -150,9 +155,9 @@ Scope: `packages/piece/src/slugs.ts`, `packages/runner/src/slug-resolution.ts`,
    and `cf piece slugs` lists it, naming the containing piece. Both demos run
    on the exemplar board.
 2. A reference that names a collection and then a member resolves to that
-   member: `cf cell get //<space>/top/42 title`,
-   `cf piece describe --cell //<space>/top/42`, and
-   `cf piece call --cell //<space>/top/42 <verb>` all reach it. A reference
+   member: `cf cell get /@<space>/top/42 title`,
+   `cf piece describe --cell /@<space>/top/42`, and
+   `cf piece call --cell /@<space>/top/42 <verb>` all reach it. A reference
    that stops at the collection refuses, naming the piece that holds it. The
    walk lives in `resolvePieceReference`, which takes an address and the path
    written after it; `resolvePieceAddress` is its no-path case and refuses a
@@ -160,10 +165,10 @@ Scope: `packages/piece/src/slugs.ts`, `packages/runner/src/slug-resolution.ts`,
    with.
 3. A slug resolving to a non-piece with no further path fails with a message
    naming the containing piece.
-4. `//<space>/top/999` fails with "no member 999 in top".
+4. `/@<space>/top/999` fails with "no member 999 in top".
 5. Unit tests in `packages/piece/test/slug.test.ts` and `packages/cli/test`.
 
-Demo: `cf cell get //<space>/top/2 title` on the local exemplar board.
+Demo: `cf cell get /@<space>/top/2 title` on the local exemplar board.
 
 ### S2b — Assignment refuses by default
 
@@ -219,7 +224,7 @@ Scope: `packages/shell`, `packages/runtime-client`, shell integration tests.
 2. `/<space>/top` opens the board, the piece containing the namespace.
 3. `/<space>/top/999` shows a not-found state naming the collection.
 4. The item header shows the number and a copyable portable reference
-   `//<space>/top/42`; board cards show the number.
+   `/@<space>/top/42`; board cards show the number.
 5. A browser integration test covers 1 and 3.
 
 ### S4 — `#42` in text

--- a/docs/plans/collection-naming-topics.md
+++ b/docs/plans/collection-naming-topics.md
@@ -16,7 +16,7 @@ This block is LIVE: the change that moves a stage updates it here.
 | S1 — the library and the exemplar board own a member namespace | on main (#6882) |
 | S1b — index rows are the members | on main (#6886) |
 | S2 — `top/42` resolves at the CLI | on main (#6890) |
-| S2b — assignment refuses by default | built, in review (#6898) |
+| S2b — assignment refuses by default | on main (#6898) |
 | S3 — the shell opens `/<space>/top/42` | built, in review (#6896) |
 | S4 — `#42` in text | on main (#6887) |
 | S6 — graft onto Topics | not started; Mike's call after S4 |
@@ -30,12 +30,12 @@ ruled. A later reversal is a decision recorded here, not a discovery.
 1. **The citation form follows the cell reference grammar.** The fully
    qualified citation is `#//topics-dev/top/42`. The spec's `#@space/...`
    spelling is amended when that grammar lands. Part 1 of the spec, which
-   governs addressing, is unaffected. That grammar arrives with #6814; until
-   it does, the spelling that resolves is `/@<space>/...`, and that is what a
-   stage builds and demonstrates. A criterion's examples mean whichever
-   spelling the grammar accepts when the criterion is checked, so a stage
-   landing after #6814 reads them as `//<space>/...` with no criterion
-   rewritten.
+   governs addressing, is unaffected. #6814 records that decision and changes
+   no parser, so until one accepts `//<space>/...` the spelling that resolves
+   is `/@<space>/...`, and that is what a stage builds and demonstrates. A
+   criterion's examples mean whichever spelling the reference parser accepts
+   when the criterion is checked, so the switch follows that parser rather
+   than any pull request.
 2. **The reverse-map restructure and the cross-space slug target are
    deferred.** A board-owned namespace never writes the piece's single `slug`
    metadata entry, so that restructure gates URL rewriting rather than
@@ -216,15 +216,22 @@ that map, so those two shape what it can say about a member.
 
 ### S3 — The shell opens `/<space>/top/42`
 
-Scope: `packages/shell`, `packages/runtime-client`, shell integration tests.
+Scope: `packages/navigation` (the member in a view and its URL),
+`packages/runtime-client` (the resolution the worker answers),
+`packages/lib-shell` (the hop that carries it, and the piece cache it keys),
+`packages/shell`, and shell integration tests.
 
 1. `/<space>/top/42` opens the member piece; the tab shows its title. The
    exemplar item is the member; the Topics-shape test covers the board side
    only.
 2. `/<space>/top` opens the board, the piece containing the namespace.
 3. `/<space>/top/999` shows a not-found state naming the collection.
-4. The item header shows the number and a copyable portable reference
-   `/@<space>/top/42`; board cards show the number.
+4. The item's own header shows the number, and the shell's header offers a
+   copyable portable reference `/@<space>/top/42`; board cards show the
+   number. (Two headers, which is how this was read when the criterion was
+   delivered and accepted: the badge is the item pattern's, while only the
+   shell knows the space and the collection's name, so only the shell can
+   compose the reference.)
 5. A browser integration test covers 1 and 3.
 
 ### S4 — `#42` in text
@@ -241,7 +248,7 @@ mention).
 3. Autocomplete matches the number as well as the title.
 4. A pasted `#42` stays plain text; the editor's documentation says so and
    why.
-5. Stretch: the pill's plain-text copy is `//<space>/top/42`.
+5. Stretch: the pill's plain-text copy is `/@<space>/top/42`.
 
 ### S6 — Graft onto Topics
 

--- a/docs/specs/collection-naming.md
+++ b/docs/specs/collection-naming.md
@@ -546,20 +546,23 @@ inside it. Resolving the two together is what the split is for — the path is
 the part that says which member, so a resolver handed the address on its own
 has nothing to walk with.
 
-**4. Walk segments in the URL layer.** `parseFabricUrl`
-(`packages/runner/src/fabric-url.ts`) reads a trailing segment as a slug and the
-rest as a cell path. Resolution of `<space>/<collection>/<member>` follows from
-letting a resolved collection resolve the next segment, and the same step covers
-an item's collections. The slug grammar in `packages/runner/src/slugs.ts` does
-not change.
+**4. Walk segments in the URL layer.** Landed for the shell's page URLs.
+`urlToAppView` (`packages/navigation/src/view.ts`) reads the segment after a
+slug as the member name and carries it in the view, which serializes back to
+`<space>/<collection>/<member>`. Resolution is a separate worker round trip,
+`slug:resolve`
+(`packages/runtime-client/src/backends/runtime-processor.ts`), which hands the
+reference to the runner's walk and answers with the piece the shell then
+starts; a collection named with no member after it opens the piece holding the
+collection, the shell following the refusal that names it. The slug grammar in
+`packages/runner/src/slugs.ts` does not change.
 
-Where the walk lives has to be decided before it is written. `parseFabricUrl`
-states that it is deliberately pure and synchronous, and it names turning a
-space name into a DID as the kind of work that belongs outside it. Walking into
-a collection is that kind of work — it syncs and reads a cell — so the walk
-belongs beside the parse rather than inside it, or the function's contract
-changes deliberately. Reading the segments apart from resolving them is the
-split to preserve.
+Where the walk lives is what that split settles. `parseFabricUrl`
+(`packages/runner/src/fabric-url.ts`) is deliberately pure and synchronous, and
+names turning a space name into a DID as the kind of work that belongs outside
+it. Walking into a collection is that kind of work — it syncs and reads a cell
+— so the walk sits beside the parse rather than inside it, and every reader of
+these URLs keeps reading the segments apart from resolving them.
 
 **5. Add the prose layer.** Sigil parsing, canonicalize-on-write,
 context-computed rendering with round-trip verification, the two render modes,

--- a/docs/specs/collection-naming.md
+++ b/docs/specs/collection-naming.md
@@ -546,16 +546,18 @@ inside it. Resolving the two together is what the split is for — the path is
 the part that says which member, so a resolver handed the address on its own
 has nothing to walk with.
 
-**4. Walk segments in the URL layer.** Landed for the shell's page URLs.
-`urlToAppView` (`packages/navigation/src/view.ts`) reads the segment after a
-slug as the member name and carries it in the view, which serializes back to
-`<space>/<collection>/<member>`. Resolution is a separate worker round trip,
-`slug:resolve`
+**4. Walk segments in the URL layer.** Built for the shell's page URLs, in
+review. `urlToAppView` (`packages/navigation/src/view.ts`) reads the segment
+after a slug as the member name and carries it in the view, which serializes
+back to `<space>/<collection>/<member>`. Resolution is a separate worker round
+trip, `slug:resolve`
 (`packages/runtime-client/src/backends/runtime-processor.ts`), which hands the
-reference to the runner's walk and answers with the piece the shell then
-starts; a collection named with no member after it opens the piece holding the
-collection, the shell following the refusal that names it. The slug grammar in
-`packages/runner/src/slugs.ts` does not change.
+reference to the runner's walk and answers with the piece and whatever the walk
+did not spend. A name with no member after it is a different question of the
+same slug — which piece is this name inside — and `resolveSlugTargetInPiece`
+answers it directly, so `<space>/top` opens the piece holding the collection.
+The slug grammar in `packages/runner/src/slugs.ts` does not change, and a
+member answers to it too.
 
 Where the walk lives is what that split settles. `parseFabricUrl`
 (`packages/runner/src/fabric-url.ts`) is deliberately pure and synchronous, and

--- a/packages/lib-shell/src/runtime.ts
+++ b/packages/lib-shell/src/runtime.ts
@@ -573,6 +573,26 @@ export class RuntimeInternals extends EventTarget {
     return await this.#client.getPieceSlug(id, space);
   }
 
+  /**
+   * The id of the piece a slug reference names: the piece the slug reaches,
+   * or the member of the collection it names. Not cached and not started —
+   * `getPattern` on the id this answers with is what does both, and keying
+   * that cache on the piece rather than on the reference is what lets a
+   * reference reaching a new piece load it.
+   *
+   * @throws When the slug does not resolve, when the collection holds no
+   *   such member, or when what the reference reaches is not a piece.
+   */
+  async resolveSlug(
+    space: DID,
+    slug: string,
+    member?: string,
+  ): Promise<string> {
+    this.#check();
+    const piece = await this.#client.resolveSlug(slug, space, member);
+    return piece.id();
+  }
+
   async removePiece(space: DID, id: string): Promise<boolean> {
     this.#check();
     return await this.#client.removePiece(id, space);

--- a/packages/lib-shell/src/runtime.ts
+++ b/packages/lib-shell/src/runtime.ts
@@ -1,3 +1,4 @@
+import type { CellScope } from "@commonfabric/api";
 import { createSession, DID, Identity, Session } from "@commonfabric/identity";
 import { CFC_CONCEPT_KIND, cfcAtom } from "@commonfabric/api/cfc";
 import type { FabricPlainObject } from "@commonfabric/data-model";
@@ -371,6 +372,51 @@ export function createRuntimeClientOptions({
   };
 }
 
+/** One loaded piece, and whether the load started it. */
+interface PatternCacheEntry {
+  promise: Promise<PieceHandle<NameSchema>>;
+  started: boolean;
+}
+
+/** Where a slug reference lands, as a page address can carry it. */
+export interface SlugReferenceTarget {
+  /** The piece the reference reached, in the routing form of its id. */
+  pieceId: string;
+
+  /**
+   * The scope the piece's document sits in. A member reached through a link
+   * into a narrower scope is a piece like any other, and its id addresses it
+   * only alongside this — which is why it is carried rather than assumed.
+   */
+  scope: CellScope;
+
+  /**
+   * What is left of the reference after that piece. Empty where a member
+   * named a member; the member itself where the slug named a piece at its
+   * root, whose address does not include it — an address the caller has to
+   * settle before citing what it is showing.
+   */
+  pathAfter: string[];
+
+  /** Absent, which is what distinguishes a landing from a refusal. */
+  refusal?: undefined;
+}
+
+/**
+ * Why a slug reference reached no piece. A name nobody bound, or a member a
+ * collection does not hold, is an answer to the question asked rather than a
+ * fault, and a caller tells the two apart by which of these it gets.
+ */
+export interface SlugReferenceRefusal {
+  refusal: {
+    /** Which refusal it is, as the runner's slug resolution names them. */
+    code: string;
+
+    /** What to tell a reader, naming the collection and member it knows. */
+    message: string;
+  };
+}
+
 /**
  * RuntimeInternals bundles all resources bound to an identity/host pair:
  * ONE runtime serving all of that identity's spaces over one worker.
@@ -393,9 +439,22 @@ export class RuntimeInternals extends EventTarget {
     DID,
     { pattern: Promise<PieceHandle<NameSchema>>; started: boolean }
   > = new Map();
+  /**
+   * Loaded pieces, nested space → scope → id: a piece's whole address, held
+   * as the three things it is. One id in two scopes is two documents, and an
+   * id carries colons of its own (`of:fid1:…` beside `fid1:…`), so an
+   * address flattened into one string is one a reader has to take apart
+   * again — and taking it apart is what answered about one piece and evicted
+   * another. Nested, there is nothing to parse: a lookup walks to the entry
+   * and an eviction deletes from the map it sits in.
+   *
+   * An entry carries whether the load was STARTED: a started piece answers a
+   * caller that only reads it, while one loaded without starting does not
+   * answer a caller that needs it running.
+   */
   #patternCache: Map<
-    string,
-    { promise: Promise<PieceHandle<NameSchema>>; started: boolean }
+    DID,
+    Map<CellScope, Map<string, PatternCacheEntry>>
   > = new Map();
   // TODO(runtime-worker-refactor)
   #telemetryMarkers: RuntimeTelemetryMarkerResult[] = [];
@@ -416,6 +475,20 @@ export class RuntimeInternals extends EventTarget {
     this.#client.on("navigaterequest", this.#onNavigateRequest);
     this.#client.on("error", this.#onError);
     this.#client.on("telemetry", this.#onTelemetry);
+  }
+
+  /**
+   * How many spaces the pattern cache is holding levels for, which a test
+   * reads to check that an eviction left none behind.
+   */
+  get accessForTestingOnly(): { readonly patternCacheSize: number } {
+    // deno-lint-ignore no-this-alias
+    const outerThis = this;
+    return {
+      get patternCacheSize() {
+        return outerThis.#patternCache.size;
+      },
+    };
   }
 
   runtime(): RuntimeClient {
@@ -514,42 +587,92 @@ export class RuntimeInternals extends EventTarget {
    * (starting every registered piece on reload cost about ten seconds of
    * dependency collection, either during reload or on the first interaction).
    *
-   * Cached per (space, id) — a pattern's address. A cache entry created
-   * with `start: false` is upgraded (re-fetched with start) when a
+   * Cached per (space, scope, id) — a pattern's whole address. A cache entry
+   * created with `start: false` is upgraded (re-fetched with start) when a
    * starting caller asks for the same pattern.
    */
   getPattern(
     space: DID,
     id: string,
-    options?: { start?: boolean },
+    options?: { start?: boolean; scope?: CellScope },
   ): Promise<PieceHandle<NameSchema>> {
     this.#check();
     const start = options?.start ?? true;
-    const key = `${space}:${id}`;
-    const cached = this.#patternCache.get(key);
+    // One id in two scopes is two documents, so a caller that named no scope
+    // asks about the space's.
+    const scope = options?.scope ?? "space";
+    const byId = this.#patternCacheSlot(space, scope);
+    const cached = byId.get(id);
     if (cached && (cached.started || !start)) {
       return cached.promise;
     }
     const promise = (async () => {
-      const piece = await this.#client.getPiece<NameSchema>(id, space, start);
+      const piece = await this.#client.getPiece<NameSchema>(
+        id,
+        space,
+        start,
+        scope,
+      );
       if (!piece) {
         throw new Error(`Pattern not found: ${id}`);
       }
       return piece;
     })();
-    const entry = { promise, started: start };
-    this.#patternCache.set(key, entry);
+    const entry: PatternCacheEntry = { promise, started: start };
+    byId.set(id, entry);
     // Evict on rejection so the next request retries.
     promise.catch(() => {
-      if (this.#patternCache.get(key) === entry) {
-        this.#patternCache.delete(key);
-      }
+      if (byId.get(id) === entry) this.#dropPattern(space, scope, id);
     });
     return promise;
   }
 
+  /**
+   * Drop every cached load of `id` in `space`, whatever scope it was loaded
+   * in. A caller naming a piece to invalidate knows the piece, not which
+   * scope some other caller reached it through, and an entry left behind is
+   * a stale piece handed to the next reader.
+   *
+   * Reached by walking the address rather than by matching a spelling of it.
+   */
   invalidatePattern(space: DID, id: string): void {
-    this.#patternCache.delete(`${space}:${id}`);
+    for (const scope of [...this.#patternCache.get(space)?.keys() ?? []]) {
+      this.#dropPattern(space, scope, id);
+    }
+  }
+
+  /**
+   * Drop one loaded piece, and any level of the cache it was the last thing
+   * in. A nested map holds a level per address component, so a level left
+   * empty is a space or a scope the runtime goes on holding for a piece it
+   * no longer has — and a run of failed lookups is a run of them.
+   */
+  #dropPattern(space: DID, scope: CellScope, id: string): void {
+    const byScope = this.#patternCache.get(space);
+    const byId = byScope?.get(scope);
+    if (!byScope || !byId) return;
+    byId.delete(id);
+    if (byId.size > 0) return;
+    byScope.delete(scope);
+    if (byScope.size === 0) this.#patternCache.delete(space);
+  }
+
+  /** The map holding what `space` has loaded in `scope`, created on demand. */
+  #patternCacheSlot(
+    space: DID,
+    scope: CellScope,
+  ): Map<string, PatternCacheEntry> {
+    let byScope = this.#patternCache.get(space);
+    if (!byScope) {
+      byScope = new Map();
+      this.#patternCache.set(space, byScope);
+    }
+    let byId = byScope.get(scope);
+    if (!byId) {
+      byId = new Map();
+      byScope.set(scope, byId);
+    }
+    return byId;
   }
 
   async refreshPattern(
@@ -574,23 +697,43 @@ export class RuntimeInternals extends EventTarget {
   }
 
   /**
-   * The id of the piece a slug reference names: the piece the slug reaches,
-   * or the member of the collection it names. Not cached and not started —
-   * `getPattern` on the id this answers with is what does both, and keying
-   * that cache on the piece rather than on the reference is what lets a
-   * reference reaching a new piece load it.
+   * Where a slug reference lands. Not cached and not started — `getPattern`
+   * on the id this answers with is what does both, and keying that cache on
+   * the piece rather than on the reference is what lets a reference reaching
+   * a new piece load it.
    *
-   * @throws When the slug does not resolve, when the collection holds no
-   *   such member, or when what the reference reaches is not a piece.
+   * A name nobody bound, and a member a collection does not hold, come back
+   * as a {@link SlugReferenceRefusal} rather than as a throw: they answer the
+   * question asked, and a caller that cannot tell them from a transport fault
+   * reports "ask again" for a name that will never resolve.
+   *
+   * @throws When the piece sits outside the space asked about. Only the id
+   *   and the scope travel on to `getPattern`, which takes the space from the
+   *   view, so a reference reaching another space is refused here in those
+   *   terms rather than reported as a piece that does not exist.
+   * @throws When the resolution itself fails — a transport fault, a document
+   *   that will not decode.
    */
   async resolveSlug(
     space: DID,
     slug: string,
     member?: string,
-  ): Promise<string> {
+  ): Promise<SlugReferenceTarget | SlugReferenceRefusal> {
     this.#check();
-    const piece = await this.#client.resolveSlug(slug, space, member);
-    return piece.id();
+    const landed = await this.#client.resolveSlug(slug, space, member);
+    if (landed.refusal) return { refusal: landed.refusal };
+    const reached = landed.piece.cell().ref();
+    if (reached.space !== space) {
+      throw new Error(
+        `Slug reference "${slug}" reaches a piece in space ${reached.space}, ` +
+          `and this view addresses ${space}.`,
+      );
+    }
+    return {
+      pieceId: landed.piece.id(),
+      scope: reached.scope,
+      pathAfter: landed.pathAfter,
+    };
   }
 
   async removePiece(space: DID, id: string): Promise<boolean> {

--- a/packages/lib-shell/test/runtime.test.ts
+++ b/packages/lib-shell/test/runtime.test.ts
@@ -93,16 +93,74 @@ class MockRuntimeClient {
    * START the piece (CT-1623: name listings must not start every piece) and
    * which space each call targets. */
   getPieceCalls: Array<
-    { pieceId: string; runIt: boolean | undefined; space: DID }
+    {
+      pieceId: string;
+      runIt: boolean | undefined;
+      space: DID;
+      scope?: string;
+    }
   > = [];
+
+  /** When set, the next `getPiece` rejects rather than answering. */
+  failNextGetPiece = false;
 
   getPiece(
     pieceId: string,
     space: DID,
     runIt?: boolean,
+    scope?: string,
   ): Promise<{ id: () => string }> {
-    this.getPieceCalls.push({ pieceId, runIt, space });
+    this.getPieceCalls.push({ pieceId, runIt, space, scope });
+    if (this.failNextGetPiece) {
+      this.failNextGetPiece = false;
+      return Promise.reject(new Error("the socket went away"));
+    }
     return Promise.resolve({ id: () => pieceId });
+  }
+
+  /**
+   * Where the next `resolveSlug` lands. A test sets its space and scope to
+   * say what the walk reached, that ref being the whole of what the caller
+   * can check the reference against.
+   */
+  slugReference: {
+    pieceId: string;
+    pathAfter: string[];
+    space: DID;
+    scope: string;
+  } | undefined = undefined;
+
+  resolveSlugCalls: Array<
+    { slug: string; space: DID; member: string | undefined }
+  > = [];
+
+  /** What the next `resolveSlug` refuses with, when it refuses. */
+  slugRefusal: { code: string; message: string } | undefined = undefined;
+
+  resolveSlug(
+    slug: string,
+    space: DID,
+    member?: string,
+  ): Promise<{
+    piece?: { id(): string; cell(): { ref(): { space: DID; scope: string } } };
+    pathAfter?: string[];
+    refusal?: { code: string; message: string };
+  }> {
+    this.resolveSlugCalls.push({ slug, space, member });
+    if (this.slugRefusal) {
+      return Promise.resolve({ refusal: this.slugRefusal });
+    }
+    const reference = this.slugReference;
+    if (!reference) return Promise.reject(new Error(`asking failed`));
+    return Promise.resolve({
+      piece: {
+        id: () => reference.pieceId,
+        cell: () => ({
+          ref: () => ({ space: reference.space, scope: reference.scope }),
+        }),
+      },
+      pathAfter: reference.pathAfter,
+    });
   }
 
   dispose(): Promise<void> {
@@ -282,6 +340,202 @@ describe("RuntimeInternals", () => {
       await expect(runtime.getSlug(spaceDid, "piece-789")).resolves.toBe(
         "demo",
       );
+    } finally {
+      await runtime.dispose();
+    }
+  });
+
+  describe("resolveSlug", () => {
+    const space = "did:key:z6Mk-lib-shell-slug-reference" as DID;
+
+    it("returns the piece a member reference reached", async () => {
+      const client = new MockRuntimeClient();
+      client.slugReference = {
+        pieceId: "fid1:member-42",
+        pathAfter: [],
+        space,
+        scope: "space",
+      };
+      const runtime = new RuntimeInternals(client as any);
+
+      try {
+        await expect(runtime.resolveSlug(space, "top", "42")).resolves.toEqual({
+          pieceId: "fid1:member-42",
+          scope: "space",
+          pathAfter: [],
+        });
+        // The slug and the member cross as they were written, in the order
+        // the client reads them.
+        expect(client.resolveSlugCalls).toEqual([
+          { slug: "top", space, member: "42" },
+        ]);
+      } finally {
+        await runtime.dispose();
+      }
+    });
+
+    it("hands back a member the walk did not spend", async () => {
+      const client = new MockRuntimeClient();
+      // A slug naming a piece at its root spends nothing, so the member is
+      // left over rather than silently becoming part of that piece's address.
+      client.slugReference = {
+        pieceId: "fid1:plain",
+        pathAfter: ["42"],
+        space,
+        scope: "space",
+      };
+      const runtime = new RuntimeInternals(client as any);
+
+      try {
+        await expect(runtime.resolveSlug(space, "plain", "42")).resolves
+          .toEqual({
+            pieceId: "fid1:plain",
+            scope: "space",
+            pathAfter: ["42"],
+          });
+      } finally {
+        await runtime.dispose();
+      }
+    });
+
+    it("refuses a piece in another space, in those terms", async () => {
+      const client = new MockRuntimeClient();
+      // Following a member's links can land outside the space the reference
+      // was read in, and only the id crosses on to `getPattern`, which
+      // re-derives the space from the view. Refusing here says so; letting it
+      // through would report a piece that does not exist.
+      client.slugReference = {
+        pieceId: "fid1:elsewhere",
+        pathAfter: [],
+        space: "did:key:z6Mk-lib-shell-other-space" as DID,
+        scope: "space",
+      };
+      const runtime = new RuntimeInternals(client as any);
+
+      try {
+        await expect(runtime.resolveSlug(space, "top", "42")).rejects.toThrow(
+          "did:key:z6Mk-lib-shell-other-space",
+        );
+      } finally {
+        await runtime.dispose();
+      }
+    });
+
+    it("returns a piece in a narrower scope, carrying that scope", async () => {
+      const client = new MockRuntimeClient();
+      // A member reached through a user- or session-scoped link is a piece
+      // like any other. Refusing it would turn a working address into a load
+      // error; what it needs is its scope carried, because the id alone
+      // addresses nothing.
+      client.slugReference = {
+        pieceId: "fid1:mine-only",
+        pathAfter: [],
+        space,
+        scope: "user",
+      };
+      const runtime = new RuntimeInternals(client as any);
+
+      try {
+        await expect(runtime.resolveSlug(space, "top", "42")).resolves.toEqual({
+          pieceId: "fid1:mine-only",
+          scope: "user",
+          pathAfter: [],
+        });
+      } finally {
+        await runtime.dispose();
+      }
+    });
+
+    it("returns a refusal rather than throwing one", async () => {
+      const client = new MockRuntimeClient();
+      client.slugRefusal = {
+        code: "missing-member",
+        message: "no member 999 in top",
+      };
+      const runtime = new RuntimeInternals(client as any);
+
+      try {
+        await expect(runtime.resolveSlug(space, "top", "999")).resolves
+          .toEqual({
+            refusal: {
+              code: "missing-member",
+              message: "no member 999 in top",
+            },
+          });
+      } finally {
+        await runtime.dispose();
+      }
+    });
+
+    it("guards resolveSlug after dispose", async () => {
+      const client = new MockRuntimeClient();
+      const runtime = new RuntimeInternals(client as any);
+      await runtime.dispose();
+
+      await expect(runtime.resolveSlug(space, "top", "42")).rejects.toThrow(
+        "RuntimeInternals disposed.",
+      );
+    });
+  });
+
+  it("invalidates one piece without evicting another whose id ends the same", async () => {
+    // `of:fid1:X` and `fid1:X` are both id spellings this tree handles, and
+    // they are different pieces. Matching a flattened `<space>:<scope>:<id>`
+    // key by its ends answers about one and evicts the other.
+    const space = "did:key:z6Mk-lib-shell-invalidate" as DID;
+    const client = new MockRuntimeClient();
+    const runtime = new RuntimeInternals(client as any);
+
+    try {
+      await runtime.getPattern(space, "fid1:XYZ");
+      await runtime.getPattern(space, "of:fid1:XYZ");
+      const before = client.getPieceCalls.length;
+
+      runtime.invalidatePattern(space, "fid1:XYZ");
+
+      // The one named is gone and reloads; the other is still cached and
+      // answers without a second trip to the worker.
+      await runtime.getPattern(space, "of:fid1:XYZ");
+      expect(client.getPieceCalls.length).toBe(before);
+      await runtime.getPattern(space, "fid1:XYZ");
+      expect(client.getPieceCalls.length).toBe(before + 1);
+    } finally {
+      await runtime.dispose();
+    }
+  });
+
+  it("caches one id in two scopes as two pieces", async () => {
+    const space = "did:key:z6Mk-lib-shell-scope-cache" as DID;
+    const client = new MockRuntimeClient();
+    const runtime = new RuntimeInternals(client as any);
+
+    try {
+      await runtime.getPattern(space, "fid1:XYZ", { scope: "space" });
+      await runtime.getPattern(space, "fid1:XYZ", { scope: "user" });
+
+      // Two documents, so two loads — a cache keyed on the id alone would
+      // have handed the second caller the first one's piece.
+      expect(client.getPieceCalls).toEqual([
+        { pieceId: "fid1:XYZ", runIt: true, space, scope: "space" },
+        { pieceId: "fid1:XYZ", runIt: true, space, scope: "user" },
+      ]);
+    } finally {
+      await runtime.dispose();
+    }
+  });
+
+  it("leaves no empty levels behind when a load fails", async () => {
+    // A nested cache holds a level per address component, so evicting only
+    // the piece leaves the scope and the space it sat in — and a run of
+    // failed lookups is a run of those, held for the runtime's lifetime.
+    const space = "did:key:z6Mk-lib-shell-cache-levels" as DID;
+    const client = new MockRuntimeClient();
+    client.failNextGetPiece = true;
+    const runtime = new RuntimeInternals(client as any);
+
+    try {
+      await expect(runtime.getPattern(space, "fid1:gone")).rejects.toThrow();
+      expect(runtime.accessForTestingOnly.patternCacheSize).toBe(0);
     } finally {
       await runtime.dispose();
     }
@@ -812,7 +1066,7 @@ describe("RuntimeInternals", () => {
       try {
         await runtime.getPattern(spaceDid, "piece-1");
         expect(client.getPieceCalls).toEqual([
-          { pieceId: "piece-1", runIt: true, space: spaceDid },
+          { pieceId: "piece-1", runIt: true, space: spaceDid, scope: "space" },
         ]);
       } finally {
         await runtime.dispose();
@@ -824,7 +1078,7 @@ describe("RuntimeInternals", () => {
       try {
         await runtime.getPattern(spaceDid, "piece-1", { start: false });
         expect(client.getPieceCalls).toEqual([
-          { pieceId: "piece-1", runIt: false, space: spaceDid },
+          { pieceId: "piece-1", runIt: false, space: spaceDid, scope: "space" },
         ]);
       } finally {
         await runtime.dispose();
@@ -837,8 +1091,8 @@ describe("RuntimeInternals", () => {
         await runtime.getPattern(spaceDid, "piece-1", { start: false });
         await runtime.getPattern(spaceDid, "piece-1");
         expect(client.getPieceCalls).toEqual([
-          { pieceId: "piece-1", runIt: false, space: spaceDid },
-          { pieceId: "piece-1", runIt: true, space: spaceDid },
+          { pieceId: "piece-1", runIt: false, space: spaceDid, scope: "space" },
+          { pieceId: "piece-1", runIt: true, space: spaceDid, scope: "space" },
         ]);
       } finally {
         await runtime.dispose();
@@ -852,7 +1106,7 @@ describe("RuntimeInternals", () => {
         await runtime.getPattern(spaceDid, "piece-1");
         await runtime.getPattern(spaceDid, "piece-1", { start: false });
         expect(client.getPieceCalls).toEqual([
-          { pieceId: "piece-1", runIt: true, space: spaceDid },
+          { pieceId: "piece-1", runIt: true, space: spaceDid, scope: "space" },
         ]);
       } finally {
         await runtime.dispose();
@@ -865,7 +1119,7 @@ describe("RuntimeInternals", () => {
         await runtime.getPattern(spaceDid, "piece-1", { start: false });
         await runtime.getPattern(spaceDid, "piece-1", { start: false });
         expect(client.getPieceCalls).toEqual([
-          { pieceId: "piece-1", runIt: false, space: spaceDid },
+          { pieceId: "piece-1", runIt: false, space: spaceDid, scope: "space" },
         ]);
       } finally {
         await runtime.dispose();
@@ -886,8 +1140,8 @@ describe("RuntimeInternals", () => {
   });
 
   describe("getPattern multi-space", () => {
-    // One runtime serves every space; a pattern's address is (space, id)
-    // and the cache is keyed by that address.
+    // One runtime serves every space; a pattern's address is
+    // (space, scope, id) and the cache is keyed by that whole address.
 
     const homeDid = "did:key:z6Mk-lib-shell-runtime-home" as DID;
     const otherDid = "did:key:z6Mk-lib-shell-runtime-other" as DID;
@@ -903,22 +1157,22 @@ describe("RuntimeInternals", () => {
       try {
         await runtime.getPattern(otherDid, "piece-1");
         expect(client.getPieceCalls).toEqual([
-          { pieceId: "piece-1", runIt: true, space: otherDid },
+          { pieceId: "piece-1", runIt: true, space: otherDid, scope: "space" },
         ]);
       } finally {
         await runtime.dispose();
       }
     });
 
-    it("caches per (space, id) — same id in two spaces are distinct", async () => {
+    it("caches per address — one id in two spaces is two pieces", async () => {
       const { client, runtime } = makeRuntime();
       try {
         await runtime.getPattern(homeDid, "piece-1");
         await runtime.getPattern(otherDid, "piece-1");
         await runtime.getPattern(otherDid, "piece-1");
         expect(client.getPieceCalls).toEqual([
-          { pieceId: "piece-1", runIt: true, space: homeDid },
-          { pieceId: "piece-1", runIt: true, space: otherDid },
+          { pieceId: "piece-1", runIt: true, space: homeDid, scope: "space" },
+          { pieceId: "piece-1", runIt: true, space: otherDid, scope: "space" },
         ]);
       } finally {
         await runtime.dispose();
@@ -934,9 +1188,9 @@ describe("RuntimeInternals", () => {
         await runtime.getPattern(homeDid, "piece-1"); // still cached
         await runtime.getPattern(otherDid, "piece-1"); // re-fetched
         expect(client.getPieceCalls).toEqual([
-          { pieceId: "piece-1", runIt: true, space: homeDid },
-          { pieceId: "piece-1", runIt: true, space: otherDid },
-          { pieceId: "piece-1", runIt: true, space: otherDid },
+          { pieceId: "piece-1", runIt: true, space: homeDid, scope: "space" },
+          { pieceId: "piece-1", runIt: true, space: otherDid, scope: "space" },
+          { pieceId: "piece-1", runIt: true, space: otherDid, scope: "space" },
         ]);
       } finally {
         await runtime.dispose();

--- a/packages/navigation/src/view.ts
+++ b/packages/navigation/src/view.ts
@@ -10,6 +10,14 @@ const EMBED_PATH_PREFIX = ".embed";
 export type PieceViewRef = {
   pieceId?: string;
   pieceSlug?: string;
+
+  /**
+   * The member `pieceSlug` names, when that slug names a collection rather
+   * than a piece: `/<space>/top/42` holds the slug `top` and the member `42`.
+   * One segment reaches a member, so a member's own fields never compete for
+   * it, and a view carrying one without a slug addresses nothing.
+   */
+  pieceMember?: string;
 };
 
 export type AppViewModeRef = {
@@ -59,18 +67,30 @@ export function isAppView(view: unknown): view is AppView {
     return isAppBuiltInView(view.builtin) && !("mode" in view);
   }
   if (!isAppViewModeRef(view)) return false;
+  if (!isPieceViewRef(view)) return false;
   if ("spaceName" in view) {
-    return typeof view.spaceName === "string" && !!view.spaceName &&
-      !("pieceId" in view && "pieceSlug" in view);
+    return typeof view.spaceName === "string" && !!view.spaceName;
   }
   if ("spaceDid" in view) {
-    return isDID(view.spaceDid) && !("pieceId" in view && "pieceSlug" in view);
+    return isDID(view.spaceDid);
   }
   return false;
 }
 
 function isAppViewModeRef(view: object): view is AppViewModeRef {
   return !("mode" in view) || view.mode === "embed";
+}
+
+/**
+ * Whether a view's piece reference addresses one thing: an id or a slug but
+ * never both, and a member only under the slug whose collection holds it.
+ */
+function isPieceViewRef(view: object): view is PieceViewRef {
+  if ("pieceId" in view && "pieceSlug" in view) return false;
+  const member = "pieceMember" in view ? view.pieceMember : undefined;
+  const slug = "pieceSlug" in view ? view.pieceSlug : undefined;
+  return member === undefined ||
+    (typeof member === "string" && typeof slug === "string" && !!slug);
 }
 
 /**
@@ -122,23 +142,26 @@ export function appViewToUrlPath(view: AppView): `/${string}` {
         return `/`;
     }
   } else if ("spaceName" in view) {
-    const pieceSlug = "pieceSlug" in view ? view.pieceSlug : undefined;
-    const pieceId = "pieceId" in view ? view.pieceId : undefined;
-    return pieceSlug
-      ? `${prefix}/${view.spaceName}/${pieceSlug}`
-      : pieceId
-      ? `${prefix}/${view.spaceName}/${pieceId}`
-      : `${prefix}/${view.spaceName}`;
+    return `${prefix}/${view.spaceName}${pieceUrlSegments(view)}`;
   } else if ("spaceDid" in view) {
-    const pieceSlug = "pieceSlug" in view ? view.pieceSlug : undefined;
-    const pieceId = "pieceId" in view ? view.pieceId : undefined;
-    return pieceSlug
-      ? `${prefix}/${view.spaceDid}/${pieceSlug}`
-      : pieceId
-      ? `${prefix}/${view.spaceDid}/${pieceId}`
-      : `${prefix}/${view.spaceDid}`;
+    return `${prefix}/${view.spaceDid}${pieceUrlSegments(view)}`;
   }
   return `/`;
+}
+
+/**
+ * The segments a view's piece reference adds after its space, empty for a
+ * view naming no piece. A member follows the slug it belongs to; an id
+ * carries none, a member being a collection's name for one of its own.
+ */
+function pieceUrlSegments(view: PieceViewRef): string {
+  const pieceSlug = "pieceSlug" in view ? view.pieceSlug : undefined;
+  const pieceId = "pieceId" in view ? view.pieceId : undefined;
+  const pieceMember = "pieceMember" in view ? view.pieceMember : undefined;
+  if (pieceSlug) {
+    return pieceMember ? `/${pieceSlug}/${pieceMember}` : `/${pieceSlug}`;
+  }
+  return pieceId ? `/${pieceId}` : "";
 }
 
 export function urlToAppView(url: URL): AppView {
@@ -148,6 +171,12 @@ export function urlToAppView(url: URL): AppView {
   if (mode) segments.shift();
   const [first, pieceId] = [segments[0], segments[1]];
   const modeRef: AppViewModeRef = mode ? { mode } : {};
+  // The segment after a slug selects a member of the collection it names.
+  // Reading it apart from resolving it is what keeps this pure: whether the
+  // slug names a collection at all is the resolver's question. Exactly one
+  // segment reaches a member, so anything past it is no part of the address.
+  const member = segments[2] || undefined;
+  const memberRef: PieceViewRef = member ? { pieceMember: member } : {};
   // `?path=` is the piece deep link (e.g. a cabinet page Mobile Loom should
   // open). Captured here — the only place the query survives boot — and
   // delivered once by the shell after the piece loads.
@@ -160,12 +189,24 @@ export function urlToAppView(url: URL): AppView {
   if (isDID(first)) {
     if (!pieceId) return { spaceDid: first, ...modeRef, ...openRef };
     return isSlugAddress(pieceId)
-      ? { spaceDid: first, pieceSlug: pieceId, ...modeRef, ...openRef }
+      ? {
+        spaceDid: first,
+        pieceSlug: pieceId,
+        ...memberRef,
+        ...modeRef,
+        ...openRef,
+      }
       : { spaceDid: first, pieceId, ...modeRef, ...openRef };
   } else {
     if (!pieceId) return { spaceName: first, ...modeRef, ...openRef };
     return isSlugAddress(pieceId)
-      ? { spaceName: first, pieceSlug: pieceId, ...modeRef, ...openRef }
+      ? {
+        spaceName: first,
+        pieceSlug: pieceId,
+        ...memberRef,
+        ...modeRef,
+        ...openRef,
+      }
       : { spaceName: first, pieceId, ...modeRef, ...openRef };
   }
 }

--- a/packages/navigation/src/view.ts
+++ b/packages/navigation/src/view.ts
@@ -1,5 +1,5 @@
 import { DID, isDID } from "@commonfabric/identity";
-import { isSlugAddress } from "@commonfabric/runner/slugs";
+import { isSlugAddress, isValidSlug } from "@commonfabric/runner/slugs";
 
 export type AppBuiltInView = "home";
 
@@ -84,13 +84,22 @@ function isAppViewModeRef(view: object): view is AppViewModeRef {
 /**
  * Whether a view's piece reference addresses one thing: an id or a slug but
  * never both, and a member only under the slug whose collection holds it.
+ *
+ * A member is held to the grammar the name in front of it answers to, which
+ * `docs/specs/collection-naming.md` fixes as the slug grammar for both. That
+ * is what makes a member one URL segment: `appViewToUrlPath` writes it
+ * verbatim and `urlToAppView` reads it back verbatim, so a value carrying a
+ * separator, resolving away, or reading as empty would name something other
+ * than what it says — an empty member addresses the collection's own piece
+ * rather than a member of it.
  */
 function isPieceViewRef(view: object): view is PieceViewRef {
   if ("pieceId" in view && "pieceSlug" in view) return false;
   const member = "pieceMember" in view ? view.pieceMember : undefined;
   const slug = "pieceSlug" in view ? view.pieceSlug : undefined;
   return member === undefined ||
-    (typeof member === "string" && typeof slug === "string" && !!slug);
+    (typeof member === "string" && isValidSlug(member) &&
+      typeof slug === "string" && !!slug);
 }
 
 /**

--- a/packages/navigation/test/view.test.ts
+++ b/packages/navigation/test/view.test.ts
@@ -30,6 +30,40 @@ describe("view", () => {
     );
   });
 
+  it("parses and serializes a collection member route", () => {
+    expect(urlToAppView(new URL("http://common.test/space/top/42"))).toEqual({
+      spaceName: "space",
+      pieceSlug: "top",
+      pieceMember: "42",
+    });
+    expect(urlToAppView(new URL(`http://common.test/${SPACE_DID}/top/42`)))
+      .toEqual({ spaceDid: SPACE_DID, pieceSlug: "top", pieceMember: "42" });
+    expect(
+      appViewToUrlPath({
+        spaceName: "space",
+        pieceSlug: "top",
+        pieceMember: "42",
+      }),
+    ).toBe("/space/top/42");
+    expect(
+      appViewToUrlPath({
+        spaceDid: SPACE_DID,
+        pieceSlug: "top",
+        pieceMember: "42",
+      }),
+    ).toBe(`/${SPACE_DID}/top/42`);
+  });
+
+  it("reads one segment after a slug as the member", () => {
+    // A member's own fields are a cell path inside the piece it resolves to,
+    // so nothing past the first segment is part of the address.
+    expect(urlToAppView(new URL("http://common.test/space/top/42/title")))
+      .toEqual({ spaceName: "space", pieceSlug: "top", pieceMember: "42" });
+    // An id names its piece outright, and member names belong to collections.
+    expect(urlToAppView(new URL("http://common.test/space/fid1:abc/42")))
+      .toEqual({ spaceName: "space", pieceId: "fid1:abc" });
+  });
+
   it("routes a bare origin to the home view", () => {
     expect(urlToAppView(new URL("http://common.test/"))).toEqual({
       builtin: "home",
@@ -146,6 +180,21 @@ describe("view", () => {
       isAppView({ spaceName: "space", pieceId: "fid1:abc", pieceSlug: "d" }),
     )
       .toBe(false);
+  });
+
+  it("rejects a member with no collection to belong to", () => {
+    expect(isAppView({ spaceName: "space", pieceMember: "42" })).toBe(false);
+    expect(
+      isAppView({ spaceName: "space", pieceId: "fid1:abc", pieceMember: "42" }),
+    ).toBe(false);
+    expect(
+      isAppView({ spaceName: "space", pieceSlug: "top", pieceMember: "42" }),
+    ).toBe(true);
+    // The shell carries a key through whether or not the view has a value
+    // for it, so a member key holding nothing reaches this the same way.
+    expect(
+      isAppView({ spaceName: "space", pieceMember: undefined }),
+    ).toBe(true);
   });
 
   it("compares two views by their contents", () => {

--- a/packages/navigation/test/view.test.ts
+++ b/packages/navigation/test/view.test.ts
@@ -197,6 +197,39 @@ describe("view", () => {
     ).toBe(true);
   });
 
+  it("rejects a member that is no single URL segment", () => {
+    // An empty member serializes to the collection's own URL, so a view
+    // holding one addresses the piece that holds the collection while
+    // claiming to address a member of it.
+    expect(
+      isAppView({ spaceName: "space", pieceSlug: "top", pieceMember: "" }),
+    ).toBe(false);
+    // Naming no member at all is how a view addresses the collection, and it
+    // stays valid: the field is optional, not empty-able.
+    expect(isAppView({ spaceName: "space", pieceSlug: "top" })).toBe(true);
+    // A separator would round-trip as two segments, the second of them read
+    // as no part of the address.
+    expect(
+      isAppView({ spaceName: "space", pieceSlug: "top", pieceMember: "4/2" }),
+    ).toBe(false);
+    // `..` resolves away before a parser ever sees it as a segment.
+    expect(
+      isAppView({ spaceName: "space", pieceSlug: "top", pieceMember: ".." }),
+    ).toBe(false);
+  });
+
+  it("reads a member out of a URL without holding it to that grammar", () => {
+    // Reading segments apart from resolving them is what keeps the parse
+    // pure, so a member no collection could have named still parses and is
+    // refused by name where the reference resolves. This is the same
+    // permissiveness the parse already gives a piece id it never validates.
+    expect(urlToAppView(new URL("http://common.test/space/top/NOPE"))).toEqual({
+      spaceName: "space",
+      pieceSlug: "top",
+      pieceMember: "NOPE",
+    });
+  });
+
   it("compares two views by their contents", () => {
     const view = { spaceName: "space", pieceSlug: "demo" } as const;
     expect(isAppViewEqual(view, view)).toBe(true);

--- a/packages/runtime-client/src/backends/runtime-processor.ts
+++ b/packages/runtime-client/src/backends/runtime-processor.ts
@@ -65,6 +65,8 @@ import {
   popFrame,
   pushFrame,
   resolveExternalRootRefForStructure,
+  resolveSlugReference,
+  resolveSlugTargetInPiece,
   Runtime,
   runtimePresets,
   RuntimeTelemetry,
@@ -196,6 +198,7 @@ import {
   type SettleStatsResponse,
   type SetTriggerTraceEnabledRequest,
   type SetWriteStackTraceMatchersRequest,
+  type SlugResolveRequest,
   type SlugResponse,
   type SpaceAclResponse,
   type SpaceGetAclRequest,
@@ -2219,6 +2222,48 @@ export class RuntimeProcessor {
     return { slug: typeof slug === "string" ? slug : undefined };
   }
 
+  /**
+   * The piece a slug reference names, unstarted: the piece the slug reaches
+   * when the reference stops there, and the member the collection holds when
+   * the reference names one. Starting and caching stay with
+   * {@link handlePieceGet}, which a caller reaches through this piece's id.
+   *
+   * Fails as the runner's resolution fails — `missing-member` for a member
+   * the collection does not hold, naming both, and `not-piece` for a target
+   * that is neither a piece nor a member of one.
+   */
+  async handleSlugResolve(
+    request: SlugResolveRequest,
+  ): Promise<PieceResponse> {
+    const cc = this.getSpaceCtx(request.space);
+    const space = cc.getSpace();
+    if (request.member === undefined) {
+      // A slug pointing inside a piece rather than at its root names a
+      // collection, and the runner refuses such a reference with no member
+      // after it, naming the piece that holds it. A page URL names a piece to
+      // render, so the refusal is followed to that piece — which is what
+      // `/<space>/top` opens — and the path from its root down to the
+      // collection is dropped, no page rendering a cell inside a piece.
+      const { piece } = await resolveSlugTargetInPiece(
+        this.runtime,
+        space,
+        request.slug,
+      );
+      return { piece: createPieceRef(piece) };
+    }
+    // The member segment is what the walk spends, so a collection leaves
+    // nothing after the piece. A slug naming a piece root spends nothing, and
+    // the segment stays a cell path inside it, dropped here as the URL layer
+    // drops the segments written after an id.
+    const { piece } = await resolveSlugReference(
+      this.runtime,
+      space,
+      request.slug,
+      [request.member],
+    );
+    return { piece: createPieceRef(piece) };
+  }
+
   async handlePieceRemove(
     request: PieceRemoveRequest,
   ): Promise<BooleanResponse> {
@@ -2764,6 +2809,8 @@ export class RuntimeProcessor {
         return await this.handlePieceGet(request);
       case RequestType.PieceGetSlug:
         return await this.handlePieceGetSlug(request);
+      case RequestType.SlugResolve:
+        return await this.handleSlugResolve(request);
       case RequestType.PieceRemove:
         return await this.handlePieceRemove(request);
       case RequestType.PieceStart:

--- a/packages/runtime-client/src/backends/runtime-processor.ts
+++ b/packages/runtime-client/src/backends/runtime-processor.ts
@@ -73,6 +73,7 @@ import {
   RuntimeTelemetryEvent,
   setPatternEnvironment,
   type SigilLink,
+  SlugResolutionError,
   SpaceHostValidationError,
 } from "@commonfabric/runner";
 import type { RuntimeOptions } from "@commonfabric/runner";
@@ -198,6 +199,7 @@ import {
   type SettleStatsResponse,
   type SetTriggerTraceEnabledRequest,
   type SetWriteStackTraceMatchersRequest,
+  type SlugReferenceResponse,
   type SlugResolveRequest,
   type SlugResponse,
   type SpaceAclResponse,
@@ -2155,15 +2157,31 @@ export class RuntimeProcessor {
     };
   }
 
+  // Resolves a redirect here rather than through the runner's slug
+  // resolution, which `handleSlugResolve` uses. Do not copy the bare
+  // `parseLink` below into a new caller: a slug cell can be written by a
+  // foreign client over the memory protocol, and `parseSlugRedirect` in
+  // `packages/runner/src/slug-resolution.ts` exists to fold the TypeError a
+  // sigil-shaped payload with broken internals throws into a typed refusal.
+  // These are one walk with two implementations, and this is the copy to
+  // retire.
+  //
   // TODO(runtime-worker-refactor): Can this fail? What if the cell
   // is not a piece cell?
   async handlePieceGet(
     request: PieceGetRequest,
   ): Promise<PieceResponse> {
     const cc = this.getSpaceCtx(request.space);
+    // Probed in the scope the request names, because the id alone names a
+    // different document in every other scope: reading the default one would
+    // ask whether some unrelated document is a redirect.
     const requestedCell = this.runtime.getCellFromEntityId(
       cc.getSpace(),
       entityIdFrom(request.pieceId),
+      [],
+      undefined,
+      undefined,
+      request.scope ?? "space",
     );
     await requestedCell.sync();
     const redirect = parseLink(
@@ -2202,6 +2220,8 @@ export class RuntimeProcessor {
     const cell = await cc.getPieceCell(
       request.pieceId,
       request.runIt ?? false,
+      undefined,
+      request.scope,
     );
 
     return {
@@ -2223,10 +2243,21 @@ export class RuntimeProcessor {
   }
 
   /**
-   * The piece a slug reference names, unstarted: the piece the slug reaches
-   * when the reference stops there, and the member the collection holds when
-   * the reference names one. Starting and caching stay with
+   * Where a slug reference lands, unstarted: the piece it reached, and the
+   * segments the walk did not spend. Starting and caching stay with
    * {@link handlePieceGet}, which a caller reaches through this piece's id.
+   *
+   * A reference naming no member asks a different question of the same slug —
+   * which piece is this name inside — because a page URL names a piece to
+   * render and a collection is a cell within one. {@link
+   * resolveSlugTargetInPiece} answers exactly that, so `/<space>/top` opens
+   * the piece holding the collection; the path from that piece's root down to
+   * the collection is no part of a page address and is dropped here.
+   *
+   * A reference naming a member spends that member only where the slug names
+   * a collection. A slug naming a piece at its root spends nothing, and the
+   * member comes back in `pathAfter` for the caller to reckon with, rather
+   * than being dropped into a page whose address still carries it.
    *
    * Fails as the runner's resolution fails — `missing-member` for a member
    * the collection does not hold, naming both, and `not-piece` for a target
@@ -2234,34 +2265,37 @@ export class RuntimeProcessor {
    */
   async handleSlugResolve(
     request: SlugResolveRequest,
-  ): Promise<PieceResponse> {
+  ): Promise<SlugReferenceResponse> {
     const cc = this.getSpaceCtx(request.space);
     const space = cc.getSpace();
-    if (request.member === undefined) {
-      // A slug pointing inside a piece rather than at its root names a
-      // collection, and the runner refuses such a reference with no member
-      // after it, naming the piece that holds it. A page URL names a piece to
-      // render, so the refusal is followed to that piece — which is what
-      // `/<space>/top` opens — and the path from its root down to the
-      // collection is dropped, no page rendering a cell inside a piece.
-      const { piece } = await resolveSlugTargetInPiece(
+    try {
+      if (request.member === undefined) {
+        const { piece } = await resolveSlugTargetInPiece(
+          this.runtime,
+          space,
+          request.slug,
+        );
+        return { piece: createPieceRef(piece), pathAfter: [] };
+      }
+      const { piece, pathAfter } = await resolveSlugReference(
         this.runtime,
         space,
         request.slug,
+        [request.member],
       );
-      return { piece: createPieceRef(piece) };
+      return { piece: createPieceRef(piece), pathAfter };
+    } catch (error) {
+      // A reference reaching nothing is what the caller asked about, so it
+      // comes back as an answer. Everything else — a transport fault, a
+      // document that will not decode — stays an error, which is the only
+      // way a caller can tell "this name is not bound" from "ask again".
+      if (error instanceof SlugResolutionError) {
+        return {
+          refusal: { code: error.code ?? "unresolved", message: error.message },
+        };
+      }
+      throw error;
     }
-    // The member segment is what the walk spends, so a collection leaves
-    // nothing after the piece. A slug naming a piece root spends nothing, and
-    // the segment stays a cell path inside it, dropped here as the URL layer
-    // drops the segments written after an id.
-    const { piece } = await resolveSlugReference(
-      this.runtime,
-      space,
-      request.slug,
-      [request.member],
-    );
-    return { piece: createPieceRef(piece) };
   }
 
   async handlePieceRemove(

--- a/packages/runtime-client/src/protocol/types.ts
+++ b/packages/runtime-client/src/protocol/types.ts
@@ -1,3 +1,4 @@
+import type { CellScope } from "@commonfabric/api";
 import type { MetaField } from "@commonfabric/runner";
 import type {
   FabricArray,
@@ -2112,6 +2113,13 @@ export type PieceGetRequest = BaseRequest & {
    * The space the piece lives in.
    */
   space: DID;
+
+  /**
+   * The scope the piece's document sits in, defaulting to the space. A piece
+   * reached through a link into a narrower scope is addressed by its id plus
+   * that scope, and the id alone reaches nothing.
+   */
+  scope?: CellScope;
 };
 
 /** The {@link RequestType.PieceGetSlug} request. */
@@ -2970,6 +2978,66 @@ export type PieceResponse = {
   piece: PieceRef;
 };
 
+/**
+ * Why a slug reference reached nothing. This is an outcome, not a failure:
+ * a name nobody has bound, or a member a collection does not hold, is what a
+ * reader is asking about, so it crosses as data and leaves the error channel
+ * to transport and decoding faults.
+ */
+export type SlugRefusal = {
+  /**
+   * Which refusal it is, as the runner's slug resolution names them.
+   */
+  code: string;
+
+  /**
+   * What to tell a reader, naming the collection and the member where the
+   * refusal knows them.
+   */
+  message: string;
+};
+
+/**
+ * Where a slug reference landed: the piece it reached and the segments the
+ * walk did not spend, or the refusal that says it reached nothing.
+ *
+ * The two are arms of a union rather than optional fields of one object, so
+ * that a response carrying both cannot be built. Written as optionals, the
+ * contradiction is a shape the type admits and only a reader can catch, and a
+ * reader that checks the refusal first reports a malformed answer as an
+ * ordinary "no such member".
+ */
+export type SlugReferenceResponse =
+  | {
+    /**
+     * The piece the reference reached.
+     */
+    piece: PieceRef;
+
+    /**
+     * What is left of the reference after the piece. Empty where the member
+     * named a member; the member itself where the slug named a piece at its
+     * root, which spends no segment and leaves the member a cell path the
+     * piece's own address does not include.
+     */
+    pathAfter: string[];
+
+    /** Absent, which is what makes this the landing arm. */
+    refusal?: undefined;
+  }
+  | {
+    /** Absent, which is what makes this the refusal arm. */
+    piece?: undefined;
+
+    /** Absent with the piece. */
+    pathAfter?: undefined;
+
+    /**
+     * Why the reference reached nothing.
+     */
+    refusal: SlugRefusal;
+  };
+
 /** A piece's slug, `undefined` where the piece has none. */
 export type SlugResponse = {
   /**
@@ -3337,6 +3405,7 @@ export type RemoteResponse =
   | TriggerTraceResponse
   | WriteStackTraceResponse
   | PieceResponse
+  | SlugReferenceResponse
   | PieceSourceResponse
   | PieceSourceRevisionResponse
   | PieceUpdateSourceResponse
@@ -3600,7 +3669,7 @@ export type Commands = {
   };
   [RequestType.SlugResolve]: {
     request: SlugResolveRequest;
-    response: PieceResponse;
+    response: SlugReferenceResponse;
   };
   [RequestType.PieceRemove]: {
     request: PieceRemoveRequest;

--- a/packages/runtime-client/src/protocol/types.ts
+++ b/packages/runtime-client/src/protocol/types.ts
@@ -380,6 +380,12 @@ export enum RequestType {
   /** Reads a piece's slug, which a piece need not have. */
   PieceGetSlug = "piece:getSlug",
 
+  /**
+   * Answers with the piece a slug reference names, without starting it: the
+   * piece the slug reaches, or the member of the collection it names.
+   */
+  SlugResolve = "slug:resolve",
+
   /** Removes a piece from its space's list. */
   PieceRemove = "piece:remove",
 
@@ -2123,6 +2129,28 @@ export type PieceGetSlugRequest = BaseRequest & {
   space: DID;
 };
 
+/** The {@link RequestType.SlugResolve} request. */
+export type SlugResolveRequest = BaseRequest & {
+  type: RequestType.SlugResolve;
+
+  /**
+   * The slug to resolve.
+   */
+  slug: string;
+
+  /**
+   * The member to select out of the collection the slug names, absent where
+   * the reference stops at the slug. One member name, never a path: a
+   * member's own fields are addressed inside the piece it resolves to.
+   */
+  member?: string;
+
+  /**
+   * The space the slug is bound in.
+   */
+  space: DID;
+};
+
 /** The {@link RequestType.PieceRemove} request. */
 export type PieceRemoveRequest = BaseRequest & {
   type: RequestType.PieceRemove;
@@ -2828,6 +2856,7 @@ export type IPCClientRequest =
   | RecreateSpaceRootPatternRequest
   | PieceGetRequest
   | PieceGetSlugRequest
+  | SlugResolveRequest
   | PieceRemoveRequest
   | PieceStartRequest
   | PieceStopRequest
@@ -3568,6 +3597,10 @@ export type Commands = {
   [RequestType.PieceGetSlug]: {
     request: PieceGetSlugRequest;
     response: SlugResponse;
+  };
+  [RequestType.SlugResolve]: {
+    request: SlugResolveRequest;
+    response: PieceResponse;
   };
   [RequestType.PieceRemove]: {
     request: PieceRemoveRequest;

--- a/packages/runtime-client/src/runtime-client.ts
+++ b/packages/runtime-client/src/runtime-client.ts
@@ -5,6 +5,7 @@
  * for interacting with cells across the worker boundary.
  */
 
+import type { CellScope } from "@commonfabric/api";
 import type { FabricPlainObject, FabricValue } from "@commonfabric/data-model";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import type { DID, Identity } from "@commonfabric/identity";
@@ -64,6 +65,7 @@ import {
   type PieceUpdateSourceResponse,
   RequestType,
   type RuntimeSecurityContext,
+  type SlugRefusal,
   type SpaceAclCapability,
   type SpaceAclView,
   TelemetryNotification,
@@ -604,12 +606,14 @@ export class RuntimeClient extends EventEmitter<RuntimeClientEvents> {
     pieceId: string,
     space: DID,
     runIt?: boolean,
+    scope?: CellScope,
   ): Promise<PieceHandle<T> | null> {
     const response = await this.#conn.request<RequestType.PieceGet>({
       type: RequestType.PieceGet,
       pieceId: pieceId,
       runIt,
       space,
+      scope,
     });
 
     if (!response) return null;
@@ -735,21 +739,30 @@ export class RuntimeClient extends EventEmitter<RuntimeClientEvents> {
   }
 
   /**
-   * The piece a slug reference names: the piece the slug reaches, or the
-   * member of the collection it names. The piece comes back unstarted —
-   * {@link getPiece}, addressed by its id, is what starts one.
+   * Where a slug reference lands: the piece it reached, and the segments the
+   * walk did not spend. The piece comes back unstarted — {@link getPiece},
+   * addressed by its id, is what starts one.
+   *
+   * A name nobody bound, a member a collection does not hold, and a target
+   * that is no piece all come back as a `refusal`: they answer the question
+   * asked, and a caller has to tell them from a fault in the asking, which
+   * wants a retry rather than a report.
    *
    * @param member One member name, absent where the reference stops at the
    *   slug. A member's own fields are a cell path inside the piece it
    *   resolves to, never a second member name.
-   * @throws When the slug does not resolve, when the collection holds no
-   *   such member, or when what the reference reaches is not a piece.
+   * @throws When the asking itself fails — a transport that dropped, a
+   *   document that will not decode — or when the answer is neither a piece
+   *   nor a refusal.
    */
   async resolveSlug<T = unknown>(
     slug: string,
     space: DID,
     member?: string,
-  ): Promise<PieceHandle<T>> {
+  ): Promise<
+    | { piece: PieceHandle<T>; pathAfter: string[]; refusal?: undefined }
+    | { piece?: undefined; pathAfter?: undefined; refusal: SlugRefusal }
+  > {
     const response = await this.#conn.request<RequestType.SlugResolve>({
       type: RequestType.SlugResolve,
       slug,
@@ -757,7 +770,35 @@ export class RuntimeClient extends EventEmitter<RuntimeClientEvents> {
       space,
     });
 
-    return new PieceHandle<T>(this, response.piece);
+    // The type makes a response carrying both arms unconstructable; a message
+    // off the wire is not type-checked, so the same exclusivity is asserted
+    // here rather than restated. Exactly one arm: both and neither are the
+    // same fault, and reading the refusal first would report either of them
+    // as an ordinary "no such member".
+    const landed = response.piece !== undefined;
+    const refused = response.refusal !== undefined;
+    if (landed === refused) {
+      throw new Error(
+        `Resolving the slug "${slug}" answered with ${
+          landed
+            ? "both a piece and a refusal"
+            : "neither a piece nor a refusal"
+        }.`,
+      );
+    }
+    if (response.refusal) return { refusal: response.refusal };
+    if (response.piece === undefined || response.pathAfter === undefined) {
+      // A landing is the piece AND what the walk did not spend. Defaulting
+      // the path would turn a truncated answer into "the member was spent",
+      // which is the fact a citation is offered on.
+      throw new Error(
+        `Resolving the slug "${slug}" answered with a piece and no path.`,
+      );
+    }
+    return {
+      piece: new PieceHandle<T>(this, response.piece),
+      pathAfter: response.pathAfter,
+    };
   }
 
   async removePiece(pieceId: string, space: DID): Promise<boolean> {

--- a/packages/runtime-client/src/runtime-client.ts
+++ b/packages/runtime-client/src/runtime-client.ts
@@ -734,6 +734,32 @@ export class RuntimeClient extends EventEmitter<RuntimeClientEvents> {
     return response.slug;
   }
 
+  /**
+   * The piece a slug reference names: the piece the slug reaches, or the
+   * member of the collection it names. The piece comes back unstarted —
+   * {@link getPiece}, addressed by its id, is what starts one.
+   *
+   * @param member One member name, absent where the reference stops at the
+   *   slug. A member's own fields are a cell path inside the piece it
+   *   resolves to, never a second member name.
+   * @throws When the slug does not resolve, when the collection holds no
+   *   such member, or when what the reference reaches is not a piece.
+   */
+  async resolveSlug<T = unknown>(
+    slug: string,
+    space: DID,
+    member?: string,
+  ): Promise<PieceHandle<T>> {
+    const response = await this.#conn.request<RequestType.SlugResolve>({
+      type: RequestType.SlugResolve,
+      slug,
+      member,
+      space,
+    });
+
+    return new PieceHandle<T>(this, response.piece);
+  }
+
   async removePiece(pieceId: string, space: DID): Promise<boolean> {
     const res = await this.#conn.request<RequestType.PieceRemove>({
       type: RequestType.PieceRemove,

--- a/packages/runtime-client/test/backends/slug-resolve.test.ts
+++ b/packages/runtime-client/test/backends/slug-resolve.test.ts
@@ -1,3 +1,13 @@
+/**
+ * How the worker reads a slug reference: which of the runner's two questions
+ * it asks, and what it reports of the answer.
+ *
+ * The walk itself is covered in `packages/runner/test/slug-resolution.test.ts`,
+ * so the fixture here is the smallest thing reference resolution reads —
+ * documents stamped with a `patternIdentity`, which is what makes a document a
+ * piece, and a board holding its members at `names`. Nothing runs.
+ */
+
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
@@ -5,21 +15,15 @@ import { Identity } from "@commonfabric/identity";
 import {
   type Cell,
   entityIdFrom,
+  getPatternIdentityRef,
   Runtime,
   slugIdForSpace,
 } from "@commonfabric/runner";
 import { rawMetaWriteAuthorization } from "@commonfabric/runner/meta-seam";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 
-import { RequestType } from "@/protocol/mod.ts";
 import { RuntimeProcessor } from "@/backends/runtime-processor.ts";
-
-// The handler's own job is choosing how to read a reference and reporting
-// what it reached; the walk it delegates to is covered in
-// packages/runner/test/slug-resolution.test.ts. So the fixture here is the
-// smallest thing that reference resolution reads: documents stamped with a
-// `patternIdentity`, which is what makes a document a piece, and a board
-// holding its members at `names`. Nothing runs.
+import { RequestType } from "@/protocol/mod.ts";
 
 const signer = await Identity.fromPassphrase("runtime-client slug resolve");
 const space = signer.did();
@@ -106,33 +110,210 @@ describe("handleSlugResolve()", () => {
     await storageManager?.close();
   });
 
-  it("answers with the member a reference names", async () => {
+  it("returns the member a reference names, spending the segment", async () => {
     const response = await resolve("top", "2");
     expect(response).toEqual({
       piece: { cell: { id: idOf(item2), space, scope: "space", path: [] } },
+      pathAfter: [],
     });
   });
 
-  it("answers with the piece that holds a collection named alone", async () => {
-    // The runner refuses `top` with no member, naming the piece the
-    // collection sits in. A page URL names a piece to render, so that piece
-    // is what the shell opens — at its root, not at the collection.
+  it("returns the piece that holds a collection named alone", async () => {
+    // A name with no member after it asks which piece the name is inside,
+    // and a page URL names a piece to render, so that piece is what the
+    // shell opens — at its root, not at the collection.
     const response = await resolve("top");
     expect(response).toEqual({
       piece: { cell: { id: idOf(board), space, scope: "space", path: [] } },
+      pathAfter: [],
     });
   });
 
-  it("answers with the piece a slug names at its root", async () => {
+  it("returns the piece a slug names at its root", async () => {
     const response = await resolve("board");
     expect(response).toEqual({
       piece: { cell: { id: idOf(board), space, scope: "space", path: [] } },
+      pathAfter: [],
     });
   });
 
-  it("refuses a member the collection does not hold, naming both", async () => {
-    await expect(resolve("top", "999")).rejects.toThrow(
-      "no member 999 in top",
+  it("hands back a member a slug naming a piece never spent", async () => {
+    // `board` names a piece at its root, which holds no member namespace, so
+    // the segment after it selects nothing: it stays a cell path inside that
+    // piece. Reporting it is what lets a caller tell the two apart — the
+    // piece is the same either way, and only this says whether the address
+    // that reached it included the segment.
+    const response = await resolve("board", "2");
+    expect(response).toEqual({
+      piece: { cell: { id: idOf(board), space, scope: "space", path: [] } },
+      pathAfter: ["2"],
+    });
+  });
+
+  it("leaves a watch asleep when a member becomes a piece", async () => {
+    // The residue, and the whole reason a poll sits beside the subscription.
+    // Whether a document is a piece is metadata — `isPieceRoot` reads
+    // `patternIdentity` — and the sink follows values. So a member whose
+    // target is not yet a piece resolves as a refusal, and the write that
+    // makes it one moves nothing the read set covers.
+    const bare = runtime.getCell(space, { space, random: "not-yet-a-piece" });
+    await runtime.editWithRetry((tx) => {
+      bare.withTx(tx).set({ title: "not yet a piece" });
+      board.withTx(tx).key("names").key("6").set(bare);
+    });
+    const slugCell = runtime.getCellFromEntityId(
+      space,
+      entityIdFrom(slugIdForSpace(space, "top")),
     );
+    let woke = 0;
+    const cancel = slugCell.sink(() => {
+      woke++;
+    });
+    await runtime.idle();
+    const atSubscribe = woke;
+
+    await runtime.editWithRetry((tx) => {
+      bare.withTx(tx).setMetaRaw(
+        "patternIdentity",
+        { identity: "pattern-late", symbol: "default" },
+        rawMetaWriteAuthorization,
+      );
+    });
+    await runtime.idle();
+    cancel();
+
+    // The write landed — this is a miss, not a no-op.
+    expect(getPatternIdentityRef(bare)).toBeDefined();
+    expect(woke).toBe(atSubscribe);
+  });
+
+  it("returns a refusal naming the member and the collection", async () => {
+    // Data, not a throw: the error channel belongs to faults in asking, and
+    // a caller has to tell "this name is not bound" from "ask again".
+    expect(await resolve("top", "999")).toEqual({
+      refusal: { code: "missing-member", message: "no member 999 in top" },
+    });
+  });
+
+  it("throws a fault in asking rather than returning it as a refusal", async () => {
+    // The separation this handler exists to make. A transport that dropped
+    // or a document that will not decode says nothing about whether the name
+    // is bound, and folding it into a refusal would tell a reader "no such
+    // member" about a collection nobody managed to read.
+    const processor = {
+      getSpaceCtx: () => ({ getSpace: () => space }),
+      runtime: {
+        getCellFromEntityId: () => {
+          throw new Error("the socket went away");
+        },
+      },
+    };
+    await expect(
+      (RuntimeProcessor.prototype as unknown as {
+        handleSlugResolve(this: unknown, request: unknown): Promise<unknown>;
+      }).handleSlugResolve.call(processor, {
+        type: RequestType.SlugResolve,
+        space,
+        slug: "top",
+        member: "2",
+      }),
+    ).rejects.toThrow("the socket went away");
+  });
+
+  it("routes a slug reference request to the resolution", async () => {
+    // The request type is declared in the enum, the union and the command
+    // map, and every one of those can be right while the dispatch switch has
+    // no arm for it — in which case the worker answers nothing and the shell
+    // waits forever. Only driving the dispatcher proves the wiring.
+    const processor = {
+      getSpaceCtx: () => ({ getSpace: () => space }),
+      runtime,
+      // The dispatch calls the handler through `this`, so the stub carries
+      // the real one: what is under test is which method the arm reaches.
+      handleSlugResolve: (RuntimeProcessor.prototype as unknown as {
+        handleSlugResolve: unknown;
+      }).handleSlugResolve,
+    };
+    const response = await (RuntimeProcessor.prototype as unknown as {
+      handleRequest(
+        this: unknown,
+        request: unknown,
+      ): Promise<{ piece: { cell: unknown }; pathAfter: string[] }>;
+    }).handleRequest.call(processor, {
+      type: RequestType.SlugResolve,
+      space,
+      slug: "top",
+      member: "2",
+    });
+
+    expect(response).toEqual({
+      piece: { cell: { id: idOf(item2), space, scope: "space", path: [] } },
+      pathAfter: [],
+    });
+  });
+
+  it("wakes a watch on the slug when the collection gains a member", async () => {
+    // The shell watches a collection reference by subscribing to the slug
+    // cell, and polls beside that subscription. This pair of tests measures
+    // how far that subscription reaches, because what it covers decides what
+    // the poll is for; neither states a bound the other has not measured.
+    // Here: the read set follows the redirect into the map, so a key landing
+    // there wakes the watch with no write to the slug document at all.
+    //
+    // Every write the setup needs happens BEFORE the sink, so that the one
+    // write after it is the collection update. A member document created
+    // while the sink was live would be a second candidate for the wake, and
+    // the count could not tell which of them caused it.
+    const item3 = await pieceDocument("item-3", { title: "Kiln log" });
+    const slugCell = runtime.getCellFromEntityId(
+      space,
+      entityIdFrom(slugIdForSpace(space, "top")),
+    );
+    let woke = 0;
+    const cancel = slugCell.sink(() => {
+      woke++;
+    });
+    await runtime.idle();
+    const atSubscribe = woke;
+
+    // The only write from here to the assertion, and it touches the board's
+    // document rather than the slug's.
+    await runtime.editWithRetry((tx) => {
+      board.withTx(tx).key("names").key("3").set(item3);
+    });
+    await runtime.idle();
+    cancel();
+
+    expect(woke).toBeGreaterThan(atSubscribe);
+  });
+
+  it("wakes a watch on the slug when a member it holds changes", async () => {
+    // And it does not stop at the map: a member the map holds is read
+    // through it, so a change inside one wakes the watch just as a key
+    // landing in the map does. Where it does stop is not measured, so
+    // neither test claims it — and `AppView`'s poll says the same, that what
+    // it adds over the subscription is unknown rather than small.
+    const item3 = await pieceDocument("item-3", { title: "Kiln log" });
+    await runtime.editWithRetry((tx) => {
+      board.withTx(tx).key("names").key("3").set(item3);
+    });
+    const slugCell = runtime.getCellFromEntityId(
+      space,
+      entityIdFrom(slugIdForSpace(space, "top")),
+    );
+    let woke = 0;
+    const cancel = slugCell.sink(() => {
+      woke++;
+    });
+    await runtime.idle();
+    const atSubscribe = woke;
+
+    await runtime.editWithRetry((tx) => {
+      item3.withTx(tx).key("title").set("Kiln log, revised");
+    });
+    await runtime.idle();
+    cancel();
+
+    expect(woke).toBeGreaterThan(atSubscribe);
   });
 });

--- a/packages/runtime-client/test/backends/slug-resolve.test.ts
+++ b/packages/runtime-client/test/backends/slug-resolve.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { Identity } from "@commonfabric/identity";
+import {
+  type Cell,
+  entityIdFrom,
+  Runtime,
+  slugIdForSpace,
+} from "@commonfabric/runner";
+import { rawMetaWriteAuthorization } from "@commonfabric/runner/meta-seam";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+import { RequestType } from "@/protocol/mod.ts";
+import { RuntimeProcessor } from "@/backends/runtime-processor.ts";
+
+// The handler's own job is choosing how to read a reference and reporting
+// what it reached; the walk it delegates to is covered in
+// packages/runner/test/slug-resolution.test.ts. So the fixture here is the
+// smallest thing that reference resolution reads: documents stamped with a
+// `patternIdentity`, which is what makes a document a piece, and a board
+// holding its members at `names`. Nothing runs.
+
+const signer = await Identity.fromPassphrase("runtime-client slug resolve");
+const space = signer.did();
+
+describe("handleSlugResolve()", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let board: Cell<unknown>;
+  let item2: Cell<unknown>;
+
+  /** A document that reads as a piece, holding `content`. */
+  async function pieceDocument(
+    cause: string,
+    content: unknown,
+  ): Promise<Cell<unknown>> {
+    const cell = runtime.getCell(space, { space, random: cause });
+    await runtime.editWithRetry((tx) => {
+      const withTx = cell.withTx(tx);
+      withTx.set(content);
+      withTx.setMetaRaw(
+        "patternIdentity",
+        { identity: `pattern-${cause}`, symbol: "default" },
+        rawMetaWriteAuthorization,
+      );
+    });
+    return cell;
+  }
+
+  /** Bind `slug` to `target` the way `set-slug` does. */
+  async function pointSlug(slug: string, target: Cell<unknown>): Promise<void> {
+    const slugCell = runtime.getCellFromEntityId(
+      space,
+      entityIdFrom(slugIdForSpace(space, slug)),
+    );
+    await runtime.editWithRetry((tx) => {
+      const slugWithTx = slugCell.withTx(tx);
+      slugWithTx.setRawUntyped(
+        target.withTx(tx).getAsWriteRedirectLink({ base: slugWithTx }),
+      );
+    });
+  }
+
+  /** Call the handler over a processor that is nothing but this space. */
+  function resolve(
+    slug: string,
+    member?: string,
+  ): Promise<{ piece: { cell: unknown } }> {
+    const processor = {
+      getSpaceCtx: () => ({ getSpace: () => space }),
+      runtime,
+    };
+    return (RuntimeProcessor.prototype as unknown as {
+      handleSlugResolve(
+        this: unknown,
+        request: unknown,
+      ): Promise<{ piece: { cell: unknown } }>;
+    }).handleSlugResolve.call(processor, {
+      type: RequestType.SlugResolve,
+      space,
+      slug,
+      member,
+    });
+  }
+
+  function idOf(cell: Cell<unknown>): string {
+    return cell.getAsNormalizedFullLink().id;
+  }
+
+  beforeEach(async () => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    const item1 = await pieceDocument("item-1", { title: "Glaze recipes" });
+    item2 = await pieceDocument("item-2", { title: "Oven schedule" });
+    board = await pieceDocument("board", { names: { "1": item1, "2": item2 } });
+    await pointSlug("board", board);
+    await pointSlug("top", board.key("names"));
+  });
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  it("answers with the member a reference names", async () => {
+    const response = await resolve("top", "2");
+    expect(response).toEqual({
+      piece: { cell: { id: idOf(item2), space, scope: "space", path: [] } },
+    });
+  });
+
+  it("answers with the piece that holds a collection named alone", async () => {
+    // The runner refuses `top` with no member, naming the piece the
+    // collection sits in. A page URL names a piece to render, so that piece
+    // is what the shell opens — at its root, not at the collection.
+    const response = await resolve("top");
+    expect(response).toEqual({
+      piece: { cell: { id: idOf(board), space, scope: "space", path: [] } },
+    });
+  });
+
+  it("answers with the piece a slug names at its root", async () => {
+    const response = await resolve("board");
+    expect(response).toEqual({
+      piece: { cell: { id: idOf(board), space, scope: "space", path: [] } },
+    });
+  });
+
+  it("refuses a member the collection does not hold, naming both", async () => {
+    await expect(resolve("top", "999")).rejects.toThrow(
+      "no member 999 in top",
+    );
+  });
+});

--- a/packages/runtime-client/test/runtime-client.test.ts
+++ b/packages/runtime-client/test/runtime-client.test.ts
@@ -164,6 +164,275 @@ describe("RuntimeClient", () => {
     });
   });
 
+  describe("getPiece", () => {
+    it("sends the scope alongside the id, an id alone naming no document", async () => {
+      const space = "did:key:z6Mk-runtime-client-piece";
+      const requests: unknown[] = [];
+      const conn = {
+        on: () => {},
+        request: (message: unknown) => {
+          requests.push(message);
+          return Promise.resolve({
+            piece: {
+              cell: { id: "of:fid1:mine", space, scope: "user", path: [] },
+            },
+          });
+        },
+      } as unknown as never;
+      const client = new (RuntimeClient as unknown as {
+        new (conn: never, options: unknown): RuntimeClient;
+      })(conn, undefined);
+
+      // A piece in a narrower scope is addressed by its id AND that scope;
+      // the worker builds the cell from both, so a scope left behind here
+      // reaches a document that does not exist.
+      const piece = await client.getPiece(
+        "fid1:mine",
+        space as never,
+        true,
+        "user",
+      );
+
+      expect(requests).toEqual([{
+        type: RequestType.PieceGet,
+        pieceId: "fid1:mine",
+        runIt: true,
+        space,
+        scope: "user",
+      }]);
+      expect(piece?.id()).toBe("fid1:mine");
+    });
+
+    it("leaves the scope out when the caller names none", async () => {
+      const space = "did:key:z6Mk-runtime-client-piece";
+      const requests: unknown[] = [];
+      const conn = {
+        on: () => {},
+        request: (message: unknown) => {
+          requests.push(message);
+          return Promise.resolve({
+            piece: {
+              cell: { id: "of:fid1:ours", space, scope: "space", path: [] },
+            },
+          });
+        },
+      } as unknown as never;
+      const client = new (RuntimeClient as unknown as {
+        new (conn: never, options: unknown): RuntimeClient;
+      })(conn, undefined);
+
+      await client.getPiece("fid1:ours", space as never);
+
+      expect(requests).toEqual([{
+        type: RequestType.PieceGet,
+        pieceId: "fid1:ours",
+        runIt: undefined,
+        space,
+        scope: undefined,
+      }]);
+    });
+
+    it("returns null where the worker answers with no piece", async () => {
+      const space = "did:key:z6Mk-runtime-client-piece";
+      const conn = {
+        on: () => {},
+        request: () => Promise.resolve(null),
+      } as unknown as never;
+      const client = new (RuntimeClient as unknown as {
+        new (conn: never, options: unknown): RuntimeClient;
+      })(conn, undefined);
+
+      await expect(client.getPiece("fid1:gone", space as never)).resolves
+        .toBeNull();
+    });
+  });
+
+  describe("resolveSlug", () => {
+    it("asks the worker where a slug reference lands", async () => {
+      const space = "did:key:z6Mk-runtime-client-slug";
+      const piece = {
+        cell: { id: "of:fid1:member", space, scope: "space", path: [] },
+      };
+      const requests: unknown[] = [];
+      const conn = {
+        on: () => {},
+        request: (message: unknown) => {
+          requests.push(message);
+          return Promise.resolve({ piece, pathAfter: [] });
+        },
+      } as unknown as never;
+      const client = new (RuntimeClient as unknown as {
+        new (conn: never, options: unknown): RuntimeClient;
+      })(conn, undefined);
+
+      const landed = await client.resolveSlug("top", space as never, "42");
+      if (landed.refusal) throw new Error("the worker answered with a piece");
+
+      // The slug, the space and the member cross in the fields the worker
+      // reads them from. This method takes them in a different order than it
+      // sends them, so which value lands in which field is the thing to hold.
+      expect(requests).toEqual([{
+        type: RequestType.SlugResolve,
+        slug: "top",
+        member: "42",
+        space,
+      }]);
+      // The piece comes back as a handle over the ref the worker answered
+      // with, in the routing form of its id.
+      expect(landed.piece.id()).toBe("fid1:member");
+      expect(landed.pathAfter).toEqual([]);
+    });
+
+    it("asks for no member where the reference stops at the slug", async () => {
+      const space = "did:key:z6Mk-runtime-client-slug";
+      const requests: unknown[] = [];
+      const conn = {
+        on: () => {},
+        request: (message: unknown) => {
+          requests.push(message);
+          return Promise.resolve({
+            piece: {
+              cell: { id: "of:fid1:board", space, scope: "space", path: [] },
+            },
+            pathAfter: [],
+          });
+        },
+      } as unknown as never;
+      const client = new (RuntimeClient as unknown as {
+        new (conn: never, options: unknown): RuntimeClient;
+      })(conn, undefined);
+
+      const landed = await client.resolveSlug("top", space as never);
+
+      expect(requests).toEqual([{
+        type: RequestType.SlugResolve,
+        slug: "top",
+        member: undefined,
+        space,
+      }]);
+      // What came back matters as much as what went out: a board reached
+      // with a member still to spend is a different answer than a board
+      // reached with none.
+      if (landed.refusal) throw new Error("the worker answered with a piece");
+      expect(landed.piece.id()).toBe("fid1:board");
+      expect(landed.pathAfter).toEqual([]);
+    });
+
+    it("carries back a member the walk did not spend", async () => {
+      const space = "did:key:z6Mk-runtime-client-slug";
+      const conn = {
+        on: () => {},
+        request: () =>
+          Promise.resolve({
+            piece: {
+              cell: { id: "of:fid1:plain", space, scope: "space", path: [] },
+            },
+            pathAfter: ["42"],
+          }),
+      } as unknown as never;
+      const client = new (RuntimeClient as unknown as {
+        new (conn: never, options: unknown): RuntimeClient;
+      })(conn, undefined);
+
+      // The leftover is what tells a caller the segment named nothing, so it
+      // has to survive this hop rather than being read off the piece.
+      const landed = await client.resolveSlug("plain", space as never, "42");
+      if (landed.refusal) throw new Error("the worker answered with a piece");
+      expect(landed.piece.id()).toBe("fid1:plain");
+      expect(landed.pathAfter).toEqual(["42"]);
+    });
+
+    it("returns a refusal as an answer rather than throwing it", async () => {
+      const space = "did:key:z6Mk-runtime-client-slug";
+      const conn = {
+        on: () => {},
+        request: () =>
+          Promise.resolve({
+            refusal: {
+              code: "missing-member",
+              message: "no member 999 in top",
+            },
+          }),
+      } as unknown as never;
+      const client = new (RuntimeClient as unknown as {
+        new (conn: never, options: unknown): RuntimeClient;
+      })(conn, undefined);
+
+      // A name nobody bound is what the caller asked about. Throwing it would
+      // make it indistinguishable from a transport that dropped, and the two
+      // want opposite responses: report the one, retry the other.
+      const landed = await client.resolveSlug("top", space as never, "999");
+      expect(landed.refusal).toEqual({
+        code: "missing-member",
+        message: "no member 999 in top",
+      });
+      expect(landed.piece).toBeUndefined();
+    });
+
+    it("refuses an answer carrying both a piece and a refusal", async () => {
+      const space = "did:key:z6Mk-runtime-client-slug";
+      const conn = {
+        on: () => {},
+        request: () =>
+          Promise.resolve({
+            piece: {
+              cell: { id: "of:fid1:board", space, scope: "space", path: [] },
+            },
+            pathAfter: [],
+            refusal: { code: "missing-member", message: "no member 9 in top" },
+          }),
+      } as unknown as never;
+      const client = new (RuntimeClient as unknown as {
+        new (conn: never, options: unknown): RuntimeClient;
+      })(conn, undefined);
+
+      // The type cannot express this; a message off the wire can. Reading the
+      // refusal first would report a protocol fault as a name that is not
+      // bound, and the caller would tell a reader so.
+      await expect(client.resolveSlug("top", space as never)).rejects.toThrow(
+        "both a piece and a refusal",
+      );
+    });
+
+    it("refuses a landing that carries no path", async () => {
+      const space = "did:key:z6Mk-runtime-client-slug";
+      const conn = {
+        on: () => {},
+        request: () =>
+          Promise.resolve({
+            piece: {
+              cell: { id: "of:fid1:board", space, scope: "space", path: [] },
+            },
+          }),
+      } as unknown as never;
+      const client = new (RuntimeClient as unknown as {
+        new (conn: never, options: unknown): RuntimeClient;
+      })(conn, undefined);
+
+      // Defaulting the missing path to `[]` would say the member was spent,
+      // which is the fact the citation is offered on.
+      await expect(client.resolveSlug("top", space as never, "42")).rejects
+        .toThrow("a piece and no path");
+    });
+
+    it("refuses an answer that is neither a piece nor a refusal", async () => {
+      const space = "did:key:z6Mk-runtime-client-slug";
+      const conn = {
+        on: () => {},
+        request: () => Promise.resolve({}),
+      } as unknown as never;
+      const client = new (RuntimeClient as unknown as {
+        new (conn: never, options: unknown): RuntimeClient;
+      })(conn, undefined);
+
+      // Silently reporting "no piece" for a malformed answer would read as a
+      // name that does not resolve, which is a different fact entirely.
+      await expect(client.resolveSlug("top", space as never)).rejects.toThrow(
+        "neither a piece nor a refusal",
+      );
+    });
+  });
+
   describe("getPieceSource", () => {
     it("asks the worker for one piece's source state", async () => {
       const source = {

--- a/packages/shell/AGENTS.md
+++ b/packages/shell/AGENTS.md
@@ -80,6 +80,7 @@ runtime and gives a user a way to move around their spaces. Entry point is
 | How a command is applied       | `onCommand` and the state setters in `src/views/RootView.ts`                                                 |
 | How a navigation becomes one   | `Navigation` in `src/lib/navigation.ts`                                                                      |
 | What a URL means, embed mode   | `packages/navigation/src/view.ts`                                                                            |
+| How a slug reaches a piece     | `handleSlugResolve` in `packages/runtime-client/src/backends/runtime-processor.ts`                           |
 | How the runtime is mounted     | `RuntimeInternals` in `packages/lib-shell/src/runtime.ts`                                                    |
 | Coding style and test commands | [`DEVELOPMENT.md`](../../docs/development/DEVELOPMENT.md), [`TESTING.md`](../../docs/development/TESTING.md) |
 | Writing a `cf-` component      | the `lit-component` skill                                                                                    |

--- a/packages/shell/README.md
+++ b/packages/shell/README.md
@@ -14,7 +14,15 @@
 The shell supports these browser URL forms:
 
 - `/<space-name-or-did>`: opens the space root pattern.
-- `/<space-name-or-did>/<piece-id-or-slug>`: opens a specific piece.
+- `/<space-name-or-did>/<piece-id-or-slug>`: opens a specific piece. Where the
+  slug names a collection rather than a piece, this opens the piece that holds
+  the collection.
+- `/<space-name-or-did>/<collection-slug>/<member>`: opens the member the
+  collection calls `<member>`. One segment reaches one member, so a member's own
+  fields never answer to the collection's namespace. A member the collection
+  does not hold is reported by name, alongside the collection's. The header
+  offers the member's portable reference, `/@<space>/<collection>/<member>`,
+  which resolves wherever a reference is read.
 - `/.embed/<space-name-or-did>/<piece-id-or-slug>`: opens the same piece in
   embed mode.
 

--- a/packages/shell/README.md
+++ b/packages/shell/README.md
@@ -22,7 +22,11 @@ The shell supports these browser URL forms:
   fields never answer to the collection's namespace. A member the collection
   does not hold is reported by name, alongside the collection's. The header
   offers the member's portable reference, `/@<space>/<collection>/<member>`,
-  which resolves wherever a reference is read.
+  which carries its own space and so depends on no binding of the reader's. `cf`
+  resolves it; this shell's own URLs and a pattern's `cellFromUrl` do not read
+  that grammar. Where the slug names a piece rather than a collection there are
+  no members to name, so the segment is dropped and the address settles on the
+  piece the page is showing.
 - `/.embed/<space-name-or-did>/<piece-id-or-slug>`: opens the same piece in
   embed mode.
 

--- a/packages/shell/integration/collection-member.test.ts
+++ b/packages/shell/integration/collection-member.test.ts
@@ -1,9 +1,19 @@
+/**
+ * The shell opening `/<space>/<collection>/<member>` in a browser, over a real
+ * board filed by `cf`.
+ *
+ * What is proven here and nowhere else is the whole chain standing up at once:
+ * a slug bound inside a piece, a worker resolving the reference through it,
+ * and a rendered page that is the member rather than the board.
+ */
+
 import { join, resolve } from "@std/path";
 import { describe, it } from "@std/testing/bdd";
 
 import { env, waitForCondition } from "@commonfabric/integration";
 import { ShellIntegration } from "@commonfabric/integration/shell-utils";
 import { writeTempIdentity } from "@commonfabric/integration/temp-identity";
+import { runDenoCommandWithTemporaryLock } from "@commonfabric/test-support/isolated-deno";
 
 import "../src/globals.ts";
 
@@ -29,10 +39,15 @@ async function cf(
   args: string[],
   tail: string[] = [],
 ): Promise<string> {
-  const command = new Deno.Command(Deno.execPath(), {
-    cwd: REPO_ROOT,
-    args: [
+  // Through the temporary lock, because a nested Deno resolves dependencies
+  // of its own and would refresh the repository's `deno.lock` as a side
+  // effect of a test that only means to read a board back.
+  const result = await runDenoCommandWithTemporaryLock({
+    root: REPO_ROOT,
+    args: (lockPath) => [
       "run",
+      "--lock",
+      lockPath,
       "-A",
       join(REPO_ROOT, "packages", "cli", "mod.ts"),
       ...args,
@@ -46,7 +61,6 @@ async function cf(
     ],
     env: { CF_LOG_LEVEL: "error" },
   });
-  const result = await command.output();
   const stdout = decoder.decode(result.stdout);
   if (!result.success) {
     throw new Error(
@@ -90,65 +104,76 @@ async function fileBoardWithMembers(
 }
 
 describe("shell collection members", () => {
-  const shell = new ShellIntegration({
-    allowedConsoleErrors: ["[AppView] Failed to load selected piece:"],
+  // Two suites because they tolerate different things. Opening a member must
+  // record no console error at all; only the suite whose subject IS a failed
+  // load allows the one that failure reports, so a regression breaking the
+  // happy path cannot hide inside an allowance written for the other.
+  describe("opening one", () => {
+    const shell = new ShellIntegration();
+    shell.bindLifecycle();
+
+    it("opens the member a collection reference names", async () => {
+      await using tempIdentity = await writeTempIdentity({
+        implementation: "noble",
+      });
+      const { identity, path: identityPath } = tempIdentity;
+      const slug = `members-${crypto.randomUUID()}`;
+      await fileBoardWithMembers(identityPath, slug, [
+        "Glaze recipes",
+        "Oven schedule",
+      ]);
+
+      await shell.goto({
+        frontendUrl: FRONTEND_URL,
+        view: { spaceName: SPACE_NAME, pieceSlug: slug, pieceMember: "2" },
+        identity,
+      });
+
+      // One badge, reading the board's name for this member. The board
+      // renders one per item, so a page carrying exactly one is the member's.
+      await waitForCondition(shell.page(), (probe) => {
+        const badges = probe.collect("[data-member-name]");
+        return badges.length === 1 && probe.deepText(badges[0]).trim() === "2";
+      });
+      // The tab names the piece the shell opened. Member 2 is the second item
+      // filed, and the board would name itself for its item count instead.
+      await waitForCondition(
+        shell.page(),
+        () => document.title === "Oven schedule",
+      );
+    });
   });
-  shell.bindLifecycle();
 
-  it("opens the member a collection reference names", async () => {
-    await using tempIdentity = await writeTempIdentity({
-      implementation: "noble",
+  describe("naming one that is not there", () => {
+    const shell = new ShellIntegration({
+      allowedConsoleErrors: ["[AppView] Failed to load selected piece:"],
     });
-    const { identity, path: identityPath } = tempIdentity;
-    const slug = `members-${crypto.randomUUID()}`;
-    await fileBoardWithMembers(identityPath, slug, [
-      "Glaze recipes",
-      "Oven schedule",
-    ]);
+    shell.bindLifecycle();
 
-    await shell.goto({
-      frontendUrl: FRONTEND_URL,
-      view: { spaceName: SPACE_NAME, pieceSlug: slug, pieceMember: "2" },
-      identity,
+    it("reports a member the collection does not hold, naming both", async () => {
+      await using tempIdentity = await writeTempIdentity({
+        implementation: "noble",
+      });
+      const { identity, path: identityPath } = tempIdentity;
+      const slug = `missing-${crypto.randomUUID()}`;
+      await fileBoardWithMembers(identityPath, slug, ["Glaze recipes"]);
+
+      await shell.goto({
+        frontendUrl: FRONTEND_URL,
+        view: { spaceName: SPACE_NAME, pieceSlug: slug, pieceMember: "999" },
+        identity,
+      });
+
+      await waitForCondition(
+        shell.page(),
+        (probe, expected: string) =>
+          probe.collect(".load-error").some((element) => {
+            const text = probe.deepText(element).replace(/\s+/g, " ").trim();
+            return text.includes("We could not load this piece") &&
+              text.includes(expected);
+          }),
+        { args: [`no member 999 in ${slug}`] },
+      );
     });
-
-    // One badge, reading the board's name for this member. The board renders
-    // one per item, so a page carrying exactly one is the member's own.
-    await waitForCondition(shell.page(), (probe) => {
-      const badges = probe.collect("[data-member-name]");
-      return badges.length === 1 && probe.deepText(badges[0]).trim() === "2";
-    });
-    // The tab names the piece the shell opened. Member 2 is the second item
-    // filed, and the board would name itself for its item count instead.
-    await waitForCondition(
-      shell.page(),
-      () => document.title === "Oven schedule",
-    );
-  });
-
-  it("reports a member the collection does not hold, naming both", async () => {
-    await using tempIdentity = await writeTempIdentity({
-      implementation: "noble",
-    });
-    const { identity, path: identityPath } = tempIdentity;
-    const slug = `missing-${crypto.randomUUID()}`;
-    await fileBoardWithMembers(identityPath, slug, ["Glaze recipes"]);
-
-    await shell.goto({
-      frontendUrl: FRONTEND_URL,
-      view: { spaceName: SPACE_NAME, pieceSlug: slug, pieceMember: "999" },
-      identity,
-    });
-
-    await waitForCondition(
-      shell.page(),
-      (probe, expected: string) =>
-        probe.collect(".load-error").some((element) => {
-          const text = probe.deepText(element).replace(/\s+/g, " ").trim();
-          return text.includes("We could not load this piece") &&
-            text.includes(expected);
-        }),
-      { args: [`no member 999 in ${slug}`] },
-    );
   });
 });

--- a/packages/shell/integration/collection-member.test.ts
+++ b/packages/shell/integration/collection-member.test.ts
@@ -1,0 +1,154 @@
+import { join, resolve } from "@std/path";
+import { describe, it } from "@std/testing/bdd";
+
+import { env, waitForCondition } from "@commonfabric/integration";
+import { ShellIntegration } from "@commonfabric/integration/shell-utils";
+import { writeTempIdentity } from "@commonfabric/integration/temp-identity";
+
+import "../src/globals.ts";
+
+const { API_URL, SPACE_NAME, FRONTEND_URL } = env;
+const REPO_ROOT = resolve(import.meta.dirname!, "../../..");
+const BOARD_SOURCE = join(
+  REPO_ROOT,
+  "packages",
+  "patterns",
+  "collection-naming",
+  "board.tsx",
+);
+const decoder = new TextDecoder();
+
+/**
+ * Run one `cf` command against the space these tests share. The identity and
+ * server flags land between `args` and `tail`, because a callable name opens
+ * the section its own arguments sit in: `cf piece call` reads everything past
+ * the name as the handler's input.
+ */
+async function cf(
+  identityPath: string,
+  args: string[],
+  tail: string[] = [],
+): Promise<string> {
+  const command = new Deno.Command(Deno.execPath(), {
+    cwd: REPO_ROOT,
+    args: [
+      "run",
+      "-A",
+      join(REPO_ROOT, "packages", "cli", "mod.ts"),
+      ...args,
+      "--identity",
+      identityPath,
+      "--api-url",
+      API_URL,
+      "--space",
+      SPACE_NAME,
+      ...tail,
+    ],
+    env: { CF_LOG_LEVEL: "error" },
+  });
+  const result = await command.output();
+  const stdout = decoder.decode(result.stdout);
+  if (!result.success) {
+    throw new Error(
+      `cf ${args.join(" ")} failed with ${result.code}\nstdout:\n${stdout}` +
+        `\nstderr:\n${decoder.decode(result.stderr)}`,
+    );
+  }
+  return stdout;
+}
+
+/**
+ * File the exemplar board, give it one member per title, and bind `slug` to
+ * the map it keeps them in. That binding is what makes `<slug>/<member>` an
+ * address: the slug points inside the board rather than at its root, which is
+ * what tells a resolver it names a collection.
+ */
+async function fileBoardWithMembers(
+  identityPath: string,
+  slug: string,
+  titles: readonly string[],
+): Promise<string> {
+  const created = await cf(identityPath, ["piece", "new", BOARD_SOURCE]);
+  const boardId = created.match(/fid1:[^\s]+/)?.[0];
+  if (!boardId) {
+    throw new Error(`cf piece new did not print a fid1 id:\n${created}`);
+  }
+  for (const title of titles) {
+    await cf(
+      identityPath,
+      ["piece", "call", "--cell", `/of:${boardId}`],
+      ["addItem", JSON.stringify({ title, agentName: "shell integration" })],
+    );
+  }
+  await cf(identityPath, [
+    "piece",
+    "set-slug",
+    slug,
+    `/of:${boardId}/names`,
+  ]);
+  return boardId;
+}
+
+describe("shell collection members", () => {
+  const shell = new ShellIntegration({
+    allowedConsoleErrors: ["[AppView] Failed to load selected piece:"],
+  });
+  shell.bindLifecycle();
+
+  it("opens the member a collection reference names", async () => {
+    await using tempIdentity = await writeTempIdentity({
+      implementation: "noble",
+    });
+    const { identity, path: identityPath } = tempIdentity;
+    const slug = `members-${crypto.randomUUID()}`;
+    await fileBoardWithMembers(identityPath, slug, [
+      "Glaze recipes",
+      "Oven schedule",
+    ]);
+
+    await shell.goto({
+      frontendUrl: FRONTEND_URL,
+      view: { spaceName: SPACE_NAME, pieceSlug: slug, pieceMember: "2" },
+      identity,
+    });
+
+    // One badge, reading the board's name for this member. The board renders
+    // one per item, so a page carrying exactly one is the member's own.
+    await waitForCondition(shell.page(), (probe) => {
+      const badges = probe.collect("[data-member-name]");
+      return badges.length === 1 && probe.deepText(badges[0]).trim() === "2";
+    });
+    // The tab names the piece the shell opened. Member 2 is the second item
+    // filed, and the board would name itself for its item count instead.
+    await waitForCondition(
+      shell.page(),
+      () => document.title === "Oven schedule",
+    );
+  });
+
+  it("reports a member the collection does not hold, naming both", async () => {
+    await using tempIdentity = await writeTempIdentity({
+      implementation: "noble",
+    });
+    const { identity, path: identityPath } = tempIdentity;
+    const slug = `missing-${crypto.randomUUID()}`;
+    await fileBoardWithMembers(identityPath, slug, ["Glaze recipes"]);
+
+    await shell.goto({
+      frontendUrl: FRONTEND_URL,
+      view: { spaceName: SPACE_NAME, pieceSlug: slug, pieceMember: "999" },
+      identity,
+    });
+
+    await waitForCondition(
+      shell.page(),
+      (probe, expected: string) =>
+        probe.collect(".load-error").some((element) => {
+          const text = probe.deepText(element).replace(/\s+/g, " ").trim();
+          return text.includes("We could not load this piece") &&
+            text.includes(expected);
+        }),
+      { args: [`no member 999 in ${slug}`] },
+    );
+  });
+});

--- a/packages/shell/src/lib/navigation.ts
+++ b/packages/shell/src/lib/navigation.ts
@@ -140,6 +140,9 @@ function mapNavigationView(
     view = {
       ...("pieceId" in view ? { pieceId: view.pieceId } : undefined),
       ...("pieceSlug" in view ? { pieceSlug: view.pieceSlug } : undefined),
+      ...("pieceMember" in view
+        ? { pieceMember: view.pieceMember }
+        : undefined),
       ...("mode" in view ? { mode: view.mode } : undefined),
       spaceName: currentSpaceName,
     };

--- a/packages/shell/src/lib/navigation.ts
+++ b/packages/shell/src/lib/navigation.ts
@@ -137,15 +137,11 @@ function mapNavigationView(
     "spaceDid" in view && view.spaceDid && currentSpaceName &&
     view.spaceDid === currentSpaceDID
   ) {
-    view = {
-      ...("pieceId" in view ? { pieceId: view.pieceId } : undefined),
-      ...("pieceSlug" in view ? { pieceSlug: view.pieceSlug } : undefined),
-      ...("pieceMember" in view
-        ? { pieceMember: view.pieceMember }
-        : undefined),
-      ...("mode" in view ? { mode: view.mode } : undefined),
-      spaceName: currentSpaceName,
-    };
+    // Only the space key is exchanged. Everything else the view holds is
+    // carried by spreading what is left, so a field added to a view later
+    // survives without this having to be taught about it.
+    const { spaceDid: _replaced, ...rest } = view;
+    view = { ...rest, spaceName: currentSpaceName };
   }
   return preserveAppViewMode(currentView, view);
 }

--- a/packages/shell/src/views/AppView.ts
+++ b/packages/shell/src/views/AppView.ts
@@ -25,6 +25,21 @@ import { RuntimeInternals } from "../lib/runtime.ts";
 import { BaseView, createDefaultAppState } from "./BaseView.ts";
 import type { LoadError } from "./BodyView.ts";
 
+/**
+ * One live watch on a slug reference: the reference itself, the runtime and
+ * space it is read in, and the identity of the subscription it belongs to.
+ * `token` and `key` are what a callback arriving after a view change checks
+ * itself against.
+ */
+interface SlugWatch {
+  rt: RuntimeInternals;
+  space: DID;
+  slug: string;
+  member: string | undefined;
+  token: number;
+  key: string;
+}
+
 export class XAppView extends BaseView {
   static override styles = css`
     :host {
@@ -90,6 +105,15 @@ export class XAppView extends BaseView {
   #slugSubscriptionKey: string | undefined = undefined;
   #slugSubscriptionToken = 0;
   #slugTargetKey: string | undefined = undefined;
+
+  /**
+   * What the last resolution of the slug reference produced: the piece it
+   * reached, or the failure it reported. A reference that resolves to nothing
+   * is a target state like any other, and comparing against it is what
+   * notices a member arriving later.
+   */
+  #slugResolutionKey: string | undefined = undefined;
+
   #selectedPatternTargetId: string | undefined = undefined;
 
   #debuggerController = new DebuggerController(this);
@@ -160,10 +184,18 @@ export class XAppView extends BaseView {
       try {
         await prepareNamedSpace(app, rt, space);
         if ("pieceSlug" in app.view && app.view.pieceSlug) {
-          const pieceId = slugIdForSpace(space, app.view.pieceSlug);
-          const target = await rt.getPattern(space, pieceId, { start: false });
+          // The reference is resolved before the piece is asked for, because
+          // which piece a slug names is a question about the space and not
+          // about the piece: a slug into a collection names the member the
+          // path after it selects, and one into a piece at any other depth
+          // names the piece that holds it.
+          const pieceId = await rt.resolveSlug(
+            space,
+            app.view.pieceSlug,
+            "pieceMember" in app.view ? app.view.pieceMember : undefined,
+          );
           if (signal.aborted) return;
-          this.#selectedPatternTargetId = target.id();
+          this.#selectedPatternTargetId = pieceId;
           const pattern = await rt.getPattern(space, pieceId);
           if (!signal.aborted) this.#maybeDeliverOpenPath(pattern);
           return pattern;
@@ -239,32 +271,36 @@ export class XAppView extends BaseView {
     const slug = "pieceSlug" in this.app.view
       ? this.app.view.pieceSlug
       : undefined;
-    const key = rt && space && slug ? `${space}:${slug}` : undefined;
+    const member = "pieceMember" in this.app.view
+      ? this.app.view.pieceMember
+      : undefined;
+    // The member is part of what is watched: two references through the same
+    // slug reach different pieces, so one subscription cannot stand for both.
+    const key = rt && space && slug
+      ? `${space}:${slug}:${member ?? ""}`
+      : undefined;
 
     if (key === this.#slugSubscriptionKey) return;
     this.#clearSlugSubscription();
     if (!rt || !space || !slug || !key) return;
 
     this.#slugSubscriptionKey = key;
-    const token = ++this.#slugSubscriptionToken;
+    const watch: SlugWatch = {
+      rt,
+      space,
+      slug,
+      member,
+      token: ++this.#slugSubscriptionToken,
+      key,
+    };
     rt.getSlugCell(space, slug).then(async (cell) => {
-      if (
-        this.#slugSubscriptionToken !== token ||
-        this.#slugSubscriptionKey !== key
-      ) {
-        return;
-      }
+      if (!this.#isCurrentSlugWatch(watch)) return;
 
-      await this.#refreshSlugTarget(rt, space, slug, token, key, false);
-      if (
-        this.#slugSubscriptionToken !== token ||
-        this.#slugSubscriptionKey !== key
-      ) {
-        return;
-      }
+      await this.#refreshSlugTarget(watch, false);
+      if (!this.#isCurrentSlugWatch(watch)) return;
 
       this.#slugPollInterval = globalThis.setInterval(() => {
-        void this.#refreshSlugTarget(rt, space, slug, token, key, true);
+        void this.#refreshSlugTarget(watch, true);
       }, 1000);
 
       let sawInitialCallback = false;
@@ -273,13 +309,13 @@ export class XAppView extends BaseView {
           sawInitialCallback = true;
           return;
         }
-        void this.#refreshSlugTarget(rt, space, slug, token, key, true);
+        void this.#refreshSlugTarget(watch, true);
       });
     }).catch((error) => {
-      if (this.#slugSubscriptionToken !== token) return;
+      if (this.#slugSubscriptionToken !== watch.token) return;
       if (rt.signal.aborted) {
         // Reset the subscription key so a replacement runtime for the
-        // same space/slug re-subscribes instead of matching the stale key.
+        // same reference re-subscribes instead of matching the stale key.
         this.#clearSlugSubscription();
         return;
       }
@@ -297,64 +333,67 @@ export class XAppView extends BaseView {
     this.#slugPollInterval = undefined;
     this.#slugSubscriptionKey = undefined;
     this.#slugTargetKey = undefined;
+    this.#slugResolutionKey = undefined;
   }
 
-  async #refreshSlugTarget(
-    rt: RuntimeInternals,
-    space: DID,
-    slug: string,
-    token: number,
-    key: string,
-    notify: boolean,
-  ) {
-    if (
-      this.#slugSubscriptionToken !== token ||
-      this.#slugSubscriptionKey !== key
-    ) {
-      return;
-    }
+  /** Whether `watch` is still the subscription this view is running. */
+  #isCurrentSlugWatch(watch: SlugWatch): boolean {
+    return this.#slugSubscriptionToken === watch.token &&
+      this.#slugSubscriptionKey === watch.key;
+  }
 
-    let targetKey: string;
+  /**
+   * Re-resolve the reference `watch` follows, and reload the view when it
+   * reaches somewhere else than it did. `notify` is false for the first
+   * resolution, which records where the reference points without reloading a
+   * view already loading it.
+   */
+  async #refreshSlugTarget(watch: SlugWatch, notify: boolean) {
+    if (!this.#isCurrentSlugWatch(watch)) return;
+
+    let target: string | undefined;
+    let resolution: string;
     try {
-      const slugId = slugIdForSpace(space, slug);
-      rt.invalidatePattern(space, slugId);
-      const pattern = await rt.getPattern(space, slugId, { start: false });
-      targetKey = pattern.id();
+      target = await watch.rt.resolveSlug(
+        watch.space,
+        watch.slug,
+        watch.member,
+      );
+      resolution = target;
     } catch (error) {
-      if (rt.signal.aborted) {
+      if (watch.rt.signal.aborted) {
         // The runtime this subscription polls was disposed (logout,
         // teardown, worker replacement) — stop polling it; a new runtime
         // re-subscribes via #syncSlugSubscription.
-        if (
-          this.#slugSubscriptionToken === token &&
-          this.#slugSubscriptionKey === key
-        ) {
-          this.#clearSlugSubscription();
-        }
+        if (this.#isCurrentSlugWatch(watch)) this.#clearSlugSubscription();
         return;
       }
-      if (notify) {
-        console.error("[AppView] Failed to refresh slug target:", error);
-      }
-      return;
+      resolution = `unresolved: ${
+        error instanceof Error ? error.message : String(error)
+      }`;
     }
-    if (targetKey === this.#slugTargetKey) return;
-    this.#slugTargetKey = targetKey;
+    if (!this.#isCurrentSlugWatch(watch)) return;
+    if (resolution === this.#slugResolutionKey) return;
+    this.#slugResolutionKey = resolution;
+    this.#slugTargetKey = target;
     if (notify) {
-      this.#handleSlugCellUpdate(rt, space, slug);
+      this.#handleSlugCellUpdate(watch);
     }
   }
 
-  #handleSlugCellUpdate(rt: RuntimeInternals, space: DID, slug: string) {
+  #handleSlugCellUpdate(watch: SlugWatch) {
+    const member = "pieceMember" in this.app.view
+      ? this.app.view.pieceMember
+      : undefined;
     if (
-      this.rt !== rt ||
+      this.rt !== watch.rt ||
       !("pieceSlug" in this.app.view) ||
-      this.app.view.pieceSlug !== slug
+      this.app.view.pieceSlug !== watch.slug ||
+      member !== watch.member
     ) {
       return;
     }
 
-    rt.invalidatePattern(space, slugIdForSpace(space, slug));
     this._slugRevision++;
   }
 
@@ -497,6 +536,31 @@ export class XAppView extends BaseView {
     }
   }
 
+  /**
+   * How the piece this view addresses is cited from anywhere:
+   * `/@<space>/<collection>/<member>`, the spelling every reader of a
+   * reference resolves. Only a member of a named collection has one — a piece
+   * reached by identity carries its own, and a collection's name with no
+   * member after it names no piece at all.
+   *
+   * The space is taken from the view rather than from the resolved DID: a
+   * space name derives that DID for everyone, so a name travels as far as the
+   * DID does and reads better where it lands.
+   */
+  #getPieceReference(): string | undefined {
+    const view = this.app.view;
+    if (!("pieceSlug" in view) || !view.pieceSlug) return;
+    const member = "pieceMember" in view ? view.pieceMember : undefined;
+    if (!member) return;
+    const space = "spaceName" in view
+      ? view.spaceName
+      : "spaceDid" in view
+      ? view.spaceDid
+      : undefined;
+    if (!space) return;
+    return `/@${space}/${view.pieceSlug}/${member}`;
+  }
+
   #getRuntimeLoadError(): LoadError | undefined {
     const event = this.runtimeLoadErrors.findLast((candidate) =>
       this.#runtimeErrorMatchesView(candidate)
@@ -607,6 +671,7 @@ export class XAppView extends BaseView {
             .keyStore="${this.keyStore}"
             .pieceTitle="${this.pieceTitle}"
             .pieceId="${pieceId}"
+            .pieceReference="${this.#getPieceReference()}"
             .isViewingDefaultPattern="${isViewingDefaultPattern}"
             .showDebuggerView="${config.showDebuggerView ?? false}"
           ></x-header-view>

--- a/packages/shell/src/views/AppView.ts
+++ b/packages/shell/src/views/AppView.ts
@@ -21,23 +21,108 @@ import { CellEventTarget, CellUpdateEvent } from "../lib/cell-event-target.ts";
 import { DebuggerController } from "../lib/debugger-controller.ts";
 import { GlobalShortcutsController } from "../lib/global-shortcuts-controller.ts";
 import { prepareNamedSpace } from "../lib/named-space.ts";
-import { RuntimeInternals } from "../lib/runtime.ts";
+import {
+  RuntimeInternals,
+  type SlugReferenceRefusal,
+  type SlugReferenceTarget,
+} from "../lib/runtime.ts";
 import { BaseView, createDefaultAppState } from "./BaseView.ts";
 import type { LoadError } from "./BodyView.ts";
 
 /**
- * One live watch on a slug reference: the reference itself, the runtime and
- * space it is read in, and the identity of the subscription it belongs to.
- * `token` and `key` are what a callback arriving after a view change checks
- * itself against.
+ * Which fields of a resolution the view's state depends on.
+ *
+ * Every field of {@link SlugReferenceTarget} is classified here, and the
+ * `satisfies` is what makes that exhaustive: a field added to that type
+ * without a line here does not compile, so the omission that this key's
+ * earlier versions kept making cannot be written. Classifying one `false` is
+ * a decision a reviewer sees rather than an absence nobody notices.
+ *
+ * - `pieceId` — which piece is rendered.
+ * - `scope` — which document that piece is; one id in two scopes is two.
+ * - `pathAfter` — whether the address keeps its member, and whether that
+ *   member may be cited.
+ * - `refusal` — always absent on this arm, where it marks the landing rather
+ *   than carrying anything. Including a constant would say nothing.
+ */
+const SEMANTIC_RESOLUTION_FIELDS = {
+  pieceId: true,
+  scope: true,
+  pathAfter: true,
+  refusal: false,
+} as const satisfies Record<keyof Required<SlugReferenceTarget>, boolean>;
+
+/**
+ * Which fields of a refusal the view's state depends on, classified and
+ * closed the same way.
+ *
+ * - `code` — which refusal it is. A closed set, and the outcomes read
+ *   differently: an unbound name and a collection missing a member are
+ *   different things to be told, so collapsing them into one value leaves a
+ *   reader on the wrong message about the wrong thing.
+ * - `message` — its wording, which is derived from the code and the
+ *   reference. The reference is fixed for one watch, so the message adds
+ *   nothing the code does not already separate, and keying on prose is what
+ *   made a message that varied read as the reference having moved.
+ */
+const SEMANTIC_REFUSAL_FIELDS = {
+  code: true,
+  message: false,
+} as const satisfies Record<
+  keyof SlugReferenceRefusal["refusal"],
+  boolean
+>;
+
+/**
+ * How one resolution is compared against the last: the fields
+ * {@link SEMANTIC_RESOLUTION_FIELDS} marks as decisive, in a fixed order.
+ *
+ * A key naming a subset of what the view derives calls two different answers
+ * the same, and the state built from the older one stands under the newer.
+ * Reading every field off the answer instead would cure that and buy a second
+ * fault: a field that varies per resolution and means nothing would reload
+ * the view on every poll. Projecting an explicitly classified set has neither
+ * — a new field cannot be silently omitted, because it does not compile, and
+ * cannot be silently included, because someone has to write which it is.
+ */
+function slugResolutionKey(
+  landed: SlugReferenceTarget | SlugReferenceRefusal,
+): string {
+  return landed.refusal
+    ? project("refusal", landed.refusal, SEMANTIC_REFUSAL_FIELDS)
+    : project("target", landed, SEMANTIC_RESOLUTION_FIELDS);
+}
+
+/** The decisive fields of `answer`, in a fixed order, under `arm`. */
+function project<T extends object>(
+  arm: string,
+  answer: T,
+  semantic: Record<keyof T, boolean>,
+): string {
+  const fields = (Object.keys(semantic) as (keyof T)[]).sort();
+  return JSON.stringify([
+    arm,
+    ...fields
+      .filter((field) => semantic[field])
+      .map((field) => [field, answer[field]]),
+  ]);
+}
+
+/**
+ * One live watch on a slug reference: the reference itself, and the runtime
+ * and space it is read in. These are every input the watch is built from, so
+ * comparing them is what decides whether a running watch already covers what
+ * the view now addresses.
+ *
+ * A callback arriving after a view change checks itself by identity against
+ * the watch the view is running, so replacing the watch invalidates every
+ * callback still holding the old one.
  */
 interface SlugWatch {
   rt: RuntimeInternals;
   space: DID;
   slug: string;
   member: string | undefined;
-  token: number;
-  key: string;
 }
 
 export class XAppView extends BaseView {
@@ -102,19 +187,57 @@ export class XAppView extends BaseView {
 
   #slugCancel: Cancel | undefined = undefined;
   #slugPollInterval: ReturnType<typeof setInterval> | undefined = undefined;
-  #slugSubscriptionKey: string | undefined = undefined;
-  #slugSubscriptionToken = 0;
-  #slugTargetKey: string | undefined = undefined;
+  #slugWatch: SlugWatch | undefined = undefined;
 
   /**
-   * What the last resolution of the slug reference produced: the piece it
-   * reached, or the failure it reported. A reference that resolves to nothing
-   * is a target state like any other, and comparing against it is what
-   * notices a member arriving later.
+   * The answer the view is SHOWING: the resolution whose piece is on screen,
+   * or whose refusal is the error on screen. Undefined until one of those
+   * has happened.
+   *
+   * One fact, not several about one thing. What was resolved, whether it was
+   * applied, which piece it reached, and which answer is newest are all read
+   * off this — so there is no second slot for one of them to disagree with,
+   * and a re-resolution asks one question: is this what the view is showing?
+   * A no is the whole of the work to do, whether the reference moved, a
+   * member arrived, a refusal changed, or a load failed and left the view on
+   * something else.
+   *
+   * Written only by {@link XAppView.#markShown}, and only from the answer the
+   * writer itself resolved — never from whatever is current when it finishes,
+   * which is how a slow load came to claim a newer answer's identity.
    */
-  #slugResolutionKey: string | undefined = undefined;
+  #shownResolution: SlugReferenceTarget | SlugReferenceRefusal | undefined =
+    undefined;
+
+  /** Whether a re-resolution is running; the watch runs one at a time. */
+  #slugRefreshRunning = false;
+
+  /** Whether something asked to re-resolve while one was running. */
+  #slugRefreshRequested = false;
 
   #selectedPatternTargetId: string | undefined = undefined;
+
+  /**
+   * Whether the member the view carries named a member of a collection, as
+   * the last resolution answered. A citation is offered on this rather than
+   * on the view alone, so a segment that named nothing is never cited as
+   * though it named the piece on screen.
+   */
+  #namedAMember = false;
+
+  /**
+   * The revision the slug watch bumps to make the selection run again, which
+   * a test reads to tell a reload from a resolution that changed nothing.
+   */
+  get accessForTestingOnly(): { readonly slugRevision: number } {
+    // deno-lint-ignore no-this-alias
+    const outerThis = this;
+    return {
+      get slugRevision() {
+        return outerThis._slugRevision;
+      },
+    };
+  }
 
   #debuggerController = new DebuggerController(this);
   #keyboard = new GlobalShortcutsController(this);
@@ -181,6 +304,11 @@ export class XAppView extends BaseView {
     > => {
       if (!rt || !space) return;
       this.#selectedPatternTargetId = undefined;
+      // Cleared before the resolution rather than after it: what the last
+      // reference turned out to be says nothing about this one, and a
+      // citation offered in between would be the previous answer standing
+      // under the current address.
+      this.#namedAMember = false;
       try {
         await prepareNamedSpace(app, rt, space);
         if ("pieceSlug" in app.view && app.view.pieceSlug) {
@@ -189,14 +317,40 @@ export class XAppView extends BaseView {
           // about the piece: a slug into a collection names the member the
           // path after it selects, and one into a piece at any other depth
           // names the piece that holds it.
-          const pieceId = await rt.resolveSlug(
+          const member = "pieceMember" in app.view
+            ? app.view.pieceMember
+            : undefined;
+          const landed = await rt.resolveSlug(
             space,
             app.view.pieceSlug,
-            "pieceMember" in app.view ? app.view.pieceMember : undefined,
+            member,
           );
           if (signal.aborted) return;
+          if (landed.refusal) {
+            // A refusal is the reference's answer, and the load-error surface
+            // is where a reader is told it, in the refusal's own words. That
+            // surface IS the view showing this answer, so it is shown before
+            // it is thrown.
+            this.#markShown(landed, signal);
+            throw new Error(landed.refusal.message);
+          }
+          const { pieceId, scope, pathAfter } = landed;
+          this.#namedAMember = member !== undefined && pathAfter.length === 0;
           this.#selectedPatternTargetId = pieceId;
-          const pattern = await rt.getPattern(space, pieceId);
+          // A slug naming a piece at its root spends no member, so the
+          // segment named nothing and the piece's address does not include
+          // it. Drop it, which is how an address the shell cannot honor
+          // normalizes — the same replacement a visited identity URL gets.
+          if (member !== undefined && pathAfter.length > 0) {
+            this.#replaceViewWithoutMember(app.view);
+          }
+          const pattern = await rt.getPattern(space, pieceId, { scope });
+          // `landed` and not whatever is current: this run finished THIS
+          // answer, and saying so with another's identity is how a slow load
+          // came to claim a newer answer was on screen. A throw above writes
+          // nothing, so the watch's next re-resolution sees the view still
+          // showing something else and asks for this one again.
+          this.#markShown(landed, signal);
           if (!signal.aborted) this.#maybeDeliverOpenPath(pattern);
           return pattern;
         }
@@ -274,33 +428,47 @@ export class XAppView extends BaseView {
     const member = "pieceMember" in this.app.view
       ? this.app.view.pieceMember
       : undefined;
-    // The member is part of what is watched: two references through the same
-    // slug reach different pieces, so one subscription cannot stand for both.
-    const key = rt && space && slug
-      ? `${space}:${slug}:${member ?? ""}`
-      : undefined;
-
-    if (key === this.#slugSubscriptionKey) return;
+    // Every input the watch is built from is compared, the runtime among
+    // them: a reference reads the same and reaches a different answer under a
+    // replacement runtime, and two members of one collection are two
+    // references reaching two pieces.
+    const running = this.#slugWatch;
+    if (
+      running && running.rt === rt && running.space === space &&
+      running.slug === slug && running.member === member
+    ) {
+      return;
+    }
     this.#clearSlugSubscription();
-    if (!rt || !space || !slug || !key) return;
+    if (!rt || !space || !slug) return;
 
-    this.#slugSubscriptionKey = key;
-    const watch: SlugWatch = {
-      rt,
-      space,
-      slug,
-      member,
-      token: ++this.#slugSubscriptionToken,
-      key,
-    };
+    const watch: SlugWatch = { rt, space, slug, member };
+    this.#slugWatch = watch;
     rt.getSlugCell(space, slug).then(async (cell) => {
       if (!this.#isCurrentSlugWatch(watch)) return;
 
-      await this.#refreshSlugTarget(watch, false);
+      // Asks like every later resolution, and needs no flag saying it is
+      // the first: the selection marks what the view came to SHOW, so an
+      // answer matching that returns early however it arrived. One that
+      // differs — because the member landed while this subscription was
+      // still opening — reloads a view that would otherwise sit on the
+      // failure forever.
+      await this.#refreshSlugTarget(watch);
       if (!this.#isCurrentSlugWatch(watch)) return;
 
+      // What this poll is for, measured in
+      // `packages/runtime-client/test/backends/slug-resolve.test.ts`. The
+      // subscription reaches further than the slug document: a member
+      // landing in the collection wakes it, a change inside a member wakes
+      // it, and so does a change at the end of a link chain a member is
+      // reached through. What it misses is a metadata write — a document
+      // gaining the pattern identity that MAKES it a piece — because the
+      // read set follows values. That is the one case slug resolution turns
+      // on, since a member whose target is not yet a piece is refused, so
+      // re-resolving is what notices it becoming one. Whoever makes that
+      // observable to a watch can retire this.
       this.#slugPollInterval = globalThis.setInterval(() => {
-        void this.#refreshSlugTarget(watch, true);
+        void this.#refreshSlugTarget(watch);
       }, 1000);
 
       let sawInitialCallback = false;
@@ -309,13 +477,13 @@ export class XAppView extends BaseView {
           sawInitialCallback = true;
           return;
         }
-        void this.#refreshSlugTarget(watch, true);
+        void this.#refreshSlugTarget(watch);
       });
     }).catch((error) => {
-      if (this.#slugSubscriptionToken !== watch.token) return;
+      if (!this.#isCurrentSlugWatch(watch)) return;
       if (rt.signal.aborted) {
-        // Reset the subscription key so a replacement runtime for the
-        // same reference re-subscribes instead of matching the stale key.
+        // Drop the watch so a replacement runtime for the same reference
+        // subscribes instead of matching the stale one.
         this.#clearSlugSubscription();
         return;
       }
@@ -324,42 +492,82 @@ export class XAppView extends BaseView {
   }
 
   #clearSlugSubscription() {
-    this.#slugSubscriptionToken++;
+    this.#slugWatch = undefined;
     this.#slugCancel?.();
     if (this.#slugPollInterval !== undefined) {
       globalThis.clearInterval(this.#slugPollInterval);
     }
     this.#slugCancel = undefined;
     this.#slugPollInterval = undefined;
-    this.#slugSubscriptionKey = undefined;
-    this.#slugTargetKey = undefined;
-    this.#slugResolutionKey = undefined;
+    this.#shownResolution = undefined;
+    this.#slugRefreshRunning = false;
+    this.#slugRefreshRequested = false;
+  }
+
+  /**
+   * Record that the view has come to show `answer`.
+   *
+   * The only writer of {@link XAppView.#shownResolution}, and it takes the
+   * signal of the run that resolved `answer` so a run the view has moved on
+   * from cannot report what it finished as what is on screen.
+   */
+  #markShown(
+    answer: SlugReferenceTarget | SlugReferenceRefusal,
+    signal: AbortSignal,
+  ): void {
+    if (signal.aborted) return;
+    this.#shownResolution = answer;
+  }
+
+  /** The piece the view is showing, when a slug reference reached one. */
+  get #shownPieceId(): string | undefined {
+    const shown = this.#shownResolution;
+    return shown && !shown.refusal ? shown.pieceId : undefined;
   }
 
   /** Whether `watch` is still the subscription this view is running. */
   #isCurrentSlugWatch(watch: SlugWatch): boolean {
-    return this.#slugSubscriptionToken === watch.token &&
-      this.#slugSubscriptionKey === watch.key;
+    return this.#slugWatch === watch;
   }
 
   /**
-   * Re-resolve the reference `watch` follows, and reload the view when it
-   * reaches somewhere else than it did. `notify` is false for the first
-   * resolution, which records where the reference points without reloading a
-   * view already loading it.
+   * Re-resolve the reference `watch` follows, and ask the selection to run
+   * again when the answer is not what the view is showing.
+   *
+   * One at a time. A resolution slower than the poll's interval would
+   * otherwise have a second issued behind it, and two answers in flight is
+   * the whole of the ordering problem — which is newer, and may an older one
+   * still be applied. Running one and coalescing whatever asked meanwhile
+   * removes the question instead of guarding it: there is never a second
+   * answer to compare against, and a wake that arrives mid-flight still gets
+   * its resolution, immediately after.
    */
-  async #refreshSlugTarget(watch: SlugWatch, notify: boolean) {
+  async #refreshSlugTarget(watch: SlugWatch): Promise<void> {
     if (!this.#isCurrentSlugWatch(watch)) return;
-
-    let target: string | undefined;
-    let resolution: string;
+    if (this.#slugRefreshRunning) {
+      this.#slugRefreshRequested = true;
+      return;
+    }
+    this.#slugRefreshRunning = true;
     try {
-      target = await watch.rt.resolveSlug(
+      await this.#resolveAgainst(watch);
+    } finally {
+      this.#slugRefreshRunning = false;
+    }
+    if (!this.#slugRefreshRequested) return;
+    this.#slugRefreshRequested = false;
+    await this.#refreshSlugTarget(watch);
+  }
+
+  /** One re-resolution: ask, and reload the view when the answer differs. */
+  async #resolveAgainst(watch: SlugWatch): Promise<void> {
+    let landed: SlugReferenceTarget | SlugReferenceRefusal;
+    try {
+      landed = await watch.rt.resolveSlug(
         watch.space,
         watch.slug,
         watch.member,
       );
-      resolution = target;
     } catch (error) {
       if (watch.rt.signal.aborted) {
         // The runtime this subscription polls was disposed (logout,
@@ -368,17 +576,21 @@ export class XAppView extends BaseView {
         if (this.#isCurrentSlugWatch(watch)) this.#clearSlugSubscription();
         return;
       }
-      resolution = `unresolved: ${
-        error instanceof Error ? error.message : String(error)
-      }`;
+      // Not a refusal — those arrive as an answer — but a fault in asking: a
+      // transport that dropped, a document that would not decode. It says
+      // nothing about where the reference points, so what the view shows
+      // stands and the load path is what reports the fault to a reader.
+      console.error("[AppView] Failed to re-resolve a slug reference:", error);
+      return;
     }
     if (!this.#isCurrentSlugWatch(watch)) return;
-    if (resolution === this.#slugResolutionKey) return;
-    this.#slugResolutionKey = resolution;
-    this.#slugTargetKey = target;
-    if (notify) {
-      this.#handleSlugCellUpdate(watch);
-    }
+    // The one question. A yes covers every reason the view could be behind —
+    // the reference moved, a member arrived, a refusal changed, a load failed
+    // and left something else on screen — because each of them is the same
+    // fact: what is showing is not this.
+    const shown = this.#shownResolution;
+    if (shown && slugResolutionKey(shown) === slugResolutionKey(landed)) return;
+    this.#handleSlugCellUpdate(watch);
   }
 
   #handleSlugCellUpdate(watch: SlugWatch) {
@@ -429,18 +641,41 @@ export class XAppView extends BaseView {
     this.pieceTitle = event.detail ?? "";
   };
 
+  /**
+   * Drop the member from the address, leaving the collection's name. A
+   * segment the walk did not spend named nothing, so the page it opened is
+   * the one the name alone addresses, and the URL says so.
+   */
+  #replaceViewWithoutMember(view: typeof this.app.view) {
+    if (!("pieceSlug" in view) || !view.pieceSlug) return;
+    this.preserveRuntimeErrorsForNextViewChange?.();
+    const { pieceMember: _dropped, ...rest } = view;
+    this.#replaceView(rest);
+  }
+
   #replacePieceUrlWithSlug(view: typeof this.app.view, slug: string) {
     try {
       validateSlug(slug);
     } catch {
       return;
     }
+    if (!("pieceId" in view)) return;
     this.preserveRuntimeErrorsForNextViewChange?.();
-    if ("spaceName" in view) {
-      replaceNavigation({ spaceName: view.spaceName, pieceSlug: slug });
-    } else if ("spaceDid" in view) {
-      replaceNavigation({ spaceDid: view.spaceDid, pieceSlug: slug });
-    }
+    const { pieceId: _replaced, pieceMember: _dropped, ...rest } = view;
+    this.#replaceView({ ...rest, pieceSlug: slug });
+  }
+
+  /**
+   * Ask for `view` in place of the one showing, which is how an address the
+   * shell settles differently from the one asked for is written back.
+   *
+   * Only what the caller changed is different: what a view is being read as
+   * — embedded, or carrying a `?path=` deep link — outlives a correction to
+   * what it names, and rebuilding a view from the fields a caller remembered
+   * is how the rest of it goes missing.
+   */
+  #replaceView(view: typeof this.app.view) {
+    replaceNavigation(view);
   }
 
   #isRecreatingSpaceRootPattern = false;
@@ -538,16 +773,19 @@ export class XAppView extends BaseView {
 
   /**
    * How the piece this view addresses is cited from anywhere:
-   * `/@<space>/<collection>/<member>`, the spelling every reader of a
-   * reference resolves. Only a member of a named collection has one — a piece
-   * reached by identity carries its own, and a collection's name with no
-   * member after it names no piece at all.
+   * `/@<space>/<collection>/<member>`, the spelling `cf` resolves and which
+   * depends on no binding of the reader's. Only a member of a named
+   * collection has one — a piece
+   * reached by identity carries its own, a collection's name with no member
+   * after it names no piece at all, and a segment the walk did not spend
+   * named nothing to cite.
    *
    * The space is taken from the view rather than from the resolved DID: a
    * space name derives that DID for everyone, so a name travels as far as the
    * DID does and reads better where it lands.
    */
   #getPieceReference(): string | undefined {
+    if (!this.#namedAMember) return;
     const view = this.app.view;
     if (!("pieceSlug" in view) || !view.pieceSlug) return;
     const member = "pieceMember" in view ? view.pieceMember : undefined;
@@ -585,7 +823,7 @@ export class XAppView extends BaseView {
         ? [this._spaceRootPattern.value?.id()]
         : "pieceSlug" in this.app.view
         ? [
-          this.#slugTargetKey ?? this.#selectedPatternTargetId ??
+          this.#shownPieceId ?? this.#selectedPatternTargetId ??
             (this._selectedPattern.status === TaskStatus.COMPLETE
               ? this._selectedPattern.value?.id()
               : undefined),

--- a/packages/shell/src/views/HeaderView.ts
+++ b/packages/shell/src/views/HeaderView.ts
@@ -609,7 +609,7 @@ export class XHeaderView extends BaseView {
   #resizeTimer?: ReturnType<typeof setTimeout>;
 
   /**
-   * The favorites subscription step, the favorite-toggle guard, and the two
+   * The favorites subscription step, the favorite-toggle guard, and the three
    * click handlers, which a test drives directly.
    */
   get accessForTestingOnly(): {
@@ -617,6 +617,7 @@ export class XHeaderView extends BaseView {
     ensureFavoritesSubscription(): void;
     handleLogoClick(e: Event): void;
     handleToggleFavorite(e: Event): Promise<void>;
+    copyReference(e: Event): Promise<void>;
   } {
     // deno-lint-ignore no-this-alias
     const outerThis = this;
@@ -627,6 +628,7 @@ export class XHeaderView extends BaseView {
       ensureFavoritesSubscription: () => this.#ensureFavoritesSubscription(),
       handleLogoClick: (e) => this.#handleLogoClick(e),
       handleToggleFavorite: (e) => this.#handleToggleFavorite(e),
+      copyReference: (e) => this.#handleCopyReference(e),
     };
   }
 
@@ -930,8 +932,10 @@ export class XHeaderView extends BaseView {
 
   /**
    * Copy this piece's portable reference to the clipboard. It carries its own
-   * space, so it resolves for whoever receives it and wherever a reference is
-   * read — a pattern, this shell, or `cf`.
+   * space, so it depends on no binding of the copier's and resolves for
+   * whoever receives it — in `cf`, and in anything else that opens a session
+   * before it reads. Neither this shell's own URLs nor a pattern's
+   * `cellFromUrl` reads this grammar today.
    */
   async #handleCopyReference(e: Event) {
     e.preventDefault();

--- a/packages/shell/src/views/HeaderView.ts
+++ b/packages/shell/src/views/HeaderView.ts
@@ -461,6 +461,18 @@ export class XHeaderView extends BaseView {
       min-width: 0;
     }
 
+    .menu-item-detail {
+      font-family: var(--font-primary, ui-monospace, monospace);
+      font-size: 0.75rem;
+      line-height: 1.5rem;
+      margin-left: auto;
+      opacity: 0.7;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      min-width: 0;
+    }
+
     .divider {
       height: 1rem;
       display: flex;
@@ -488,6 +500,14 @@ export class XHeaderView extends BaseView {
 
   @property({ attribute: false })
   accessor pieceId: string | undefined = undefined;
+
+  /**
+   * How this piece is cited from anywhere, when it is a member of a named
+   * collection: `/@<space>/<collection>/<member>`. Undefined for a piece
+   * reached any other way, whose identity is already portable.
+   */
+  @property({ attribute: false })
+  accessor pieceReference: string | undefined = undefined;
 
   @property({ attribute: false })
   accessor spaceName: string | undefined = undefined;
@@ -909,6 +929,24 @@ export class XHeaderView extends BaseView {
   }
 
   /**
+   * Copy this piece's portable reference to the clipboard. It carries its own
+   * space, so it resolves for whoever receives it and wherever a reference is
+   * read — a pattern, this shell, or `cf`.
+   */
+  async #handleCopyReference(e: Event) {
+    e.preventDefault();
+    e.stopPropagation();
+    const reference = this.pieceReference;
+    if (!reference) return;
+    try {
+      await navigator.clipboard.writeText(reference);
+    } catch {
+      console.warn("Failed to copy reference to clipboard");
+    }
+    this.menuOpen = false;
+  }
+
+  /**
    * Toggle the current piece's favorite status. Uses optimistic UI —
    * updates local state immediately, then syncs with the server.
    * Rolls back local state on error. Guarded against double-clicks
@@ -1114,6 +1152,23 @@ export class XHeaderView extends BaseView {
                 <span class="menu-item-icon">${iconLink()}</span>
                 <span class="menu-item-label">Copy link</span>
               </button>
+
+              ${this.pieceReference
+                ? html`
+                  <button
+                    class="menu-item"
+                    role="menuitem"
+                    test-id="header-copy-reference"
+                    @click="${this.#handleCopyReference}"
+                  >
+                    <span class="menu-item-icon">${iconLink()}</span>
+                    <span class="menu-item-label">Copy reference</span>
+                    <code class="menu-item-detail">
+                      ${this.pieceReference}
+                    </code>
+                  </button>
+                `
+                : nothing}
 
               <button
                 class="menu-item"

--- a/packages/shell/test/app-view-collection-member.test.ts
+++ b/packages/shell/test/app-view-collection-member.test.ts
@@ -1,0 +1,166 @@
+// deno-lint-ignore-file cf-imports/no-inline-module-import -- the view's module
+// graph reaches @commonfabric/ui, whose components extend a bare HTMLElement as
+// they load, so it can only load once the test has installed one.
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import type { DID } from "@commonfabric/identity";
+
+function installBrowserGlobals(): () => void {
+  const originals = new Map<string, PropertyDescriptor | undefined>();
+  function setGlobal(name: string, value: unknown): void {
+    originals.set(name, Object.getOwnPropertyDescriptor(globalThis, name));
+    Object.defineProperty(globalThis, name, {
+      configurable: true,
+      writable: true,
+      value,
+    });
+  }
+  class TestHTMLElement extends EventTarget {
+    attachShadow() {
+      return {
+        adoptedStyleSheets: [],
+        appendChild() {},
+        append() {},
+      };
+    }
+  }
+  setGlobal("window", globalThis);
+  setGlobal("HTMLElement", TestHTMLElement);
+  setGlobal("customElements", {
+    define() {},
+    get() {},
+    whenDefined: () => Promise.resolve(),
+  });
+  setGlobal("document", {
+    documentElement: { style: {} },
+    addEventListener() {},
+    removeEventListener() {},
+    createElement: () => ({
+      style: {},
+      setAttribute() {},
+      append() {},
+      appendChild() {},
+    }),
+    createTreeWalker: () => ({}),
+  });
+  setGlobal("devicePixelRatio", 1);
+  setGlobal("screen", { deviceXDPI: 1, logicalXDPI: 1 });
+  setGlobal("navigator", { platform: "", userAgent: "deno" });
+  setGlobal("location", {
+    protocol: "http:",
+    host: "localhost:8000",
+    hostname: "localhost",
+    href: "http://localhost:8000/naming-demo/top/42",
+  });
+
+  return () => {
+    for (const [name, descriptor] of originals) {
+      if (descriptor) Object.defineProperty(globalThis, name, descriptor);
+      else Reflect.deleteProperty(globalThis, name);
+    }
+  };
+}
+
+/** Return the rendered text of nested Lit template results. */
+function templateText(value: unknown): string {
+  if (value == null) return "";
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) return value.map(templateText).join("");
+  if (typeof value !== "object") return String(value);
+  const template = value as {
+    strings?: readonly string[];
+    values?: readonly unknown[];
+  };
+  const strings = template.strings ?? [];
+  const values = template.values ?? [];
+  let text = "";
+  for (let index = 0; index < strings.length; index++) {
+    text += strings[index];
+    if (index < values.length) text += templateText(values[index]);
+  }
+  return text;
+}
+
+const SPACE = "did:key:z6Mk-shell-collection-member" as DID;
+
+describe("AppView collection members", () => {
+  it("selects the member the reference names", async () => {
+    const restore = installBrowserGlobals();
+    try {
+      const { XAppView } = await import("../src/views/AppView.ts");
+      const resolved: unknown[][] = [];
+      const started: unknown[][] = [];
+      const view = new XAppView();
+      view.app = {
+        identity: {},
+        config: {},
+        view: { spaceDid: SPACE, pieceSlug: "top", pieceMember: "42" },
+      } as never;
+      view.space = SPACE;
+      view.rt = {
+        signal: new AbortController().signal,
+        resolveSlug: (...args: unknown[]) => {
+          resolved.push(args);
+          return Promise.resolve("fid1:member-42");
+        },
+        getPattern: (...args: unknown[]) => {
+          started.push(args);
+          return Promise.resolve({ id: () => "fid1:member-42" });
+        },
+      } as never;
+
+      view._selectedPattern.run();
+      await view._selectedPattern.taskComplete;
+
+      expect(resolved).toEqual([[SPACE, "top", "42"]]);
+      // The piece started is the one the reference resolved to, never the
+      // document the slug itself lives in.
+      expect(started).toEqual([[SPACE, "fid1:member-42"]]);
+    } finally {
+      restore();
+    }
+  });
+
+  it("cites a member by a reference carrying its own space", async () => {
+    const restore = installBrowserGlobals();
+    try {
+      const { XAppView } = await import("../src/views/AppView.ts");
+      const view = new XAppView();
+      view.app = {
+        identity: {},
+        config: {},
+        view: {
+          spaceName: "naming-demo",
+          pieceSlug: "top",
+          pieceMember: "42",
+        },
+      } as never;
+      view.space = SPACE;
+
+      expect(templateText(view.render())).toContain("/@naming-demo/top/42");
+    } finally {
+      restore();
+    }
+  });
+
+  it("cites nothing for a reference that stops at the collection", async () => {
+    const restore = installBrowserGlobals();
+    try {
+      const { XAppView } = await import("../src/views/AppView.ts");
+      const view = new XAppView();
+      view.app = {
+        identity: {},
+        config: {},
+        view: { spaceName: "naming-demo", pieceSlug: "top" },
+      } as never;
+      view.space = SPACE;
+
+      // A collection's name with no member after it names no piece, so there
+      // is nothing for a reference to resolve to.
+      expect(templateText(view.render())).not.toContain("/@naming-demo/top");
+    } finally {
+      restore();
+    }
+  });
+});

--- a/packages/shell/test/app-view-collection-member.test.ts
+++ b/packages/shell/test/app-view-collection-member.test.ts
@@ -2,9 +2,22 @@
 // graph reaches @commonfabric/ui, whose components extend a bare HTMLElement as
 // they load, so it can only load once the test has installed one.
 
+/**
+ * What the shell does with `/<space>/<collection>/<member>`: which piece it
+ * selects, which address it settles on, what it offers to cite, and how the
+ * watch behind it behaves as the reference stops and starts resolving.
+ *
+ * The view is driven directly rather than through a runtime. Every fact these
+ * tests are about is settled between a resolution's answer and the view's own
+ * state, so a stub answering as the worker would is the whole environment they
+ * need — and holding a resolution at a chosen outcome is the only way to
+ * assert what the view made of it.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import type { DID } from "@commonfabric/identity";
+import type { AppView } from "@commonfabric/navigation";
 
 function installBrowserGlobals(): () => void {
   const originals = new Map<string, PropertyDescriptor | undefined>();
@@ -53,7 +66,15 @@ function installBrowserGlobals(): () => void {
     hostname: "localhost",
     href: "http://localhost:8000/naming-demo/top/42",
   });
-
+  // Captured but not replaced: `stubRuntime` installs its own timer
+  // functions, and recording the originals here is what puts them back. They
+  // are process-wide, so a test that left them replaced would quietly stop
+  // every later test from scheduling — with nothing going red to say so.
+  // Captured but not replaced: `stubRuntime` installs its own timer
+  // functions, and recording the originals here is what puts them back.
+  for (const name of ["setInterval", "clearInterval"]) {
+    originals.set(name, Object.getOwnPropertyDescriptor(globalThis, name));
+  }
   return () => {
     for (const [name, descriptor] of originals) {
       if (descriptor) Object.defineProperty(globalThis, name, descriptor);
@@ -82,41 +103,268 @@ function templateText(value: unknown): string {
   return text;
 }
 
+/** Where a resolution lands, as the runtime answers it. */
+interface Resolved {
+  pieceId: string;
+  pathAfter: string[];
+  scope?: string;
+}
+
+/**
+ * A reference that reached nothing, as the runtime answers it: a resolved
+ * value, not a rejection. Modelling it as a throw would drive the fault path
+ * instead — the one a dropped transport takes — and prove nothing about what
+ * happens when a name simply is not bound.
+ */
+interface Refused {
+  refusal: { code: string; message: string };
+}
+
+/**
+ * A runtime that answers resolutions from a value the test controls, over a
+ * slug cell whose poll the test fires by hand.
+ *
+ * The interval is captured rather than scheduled. A wait on wall-clock time
+ * would decide nothing these tests are about, and the callback is the subject:
+ * firing it is how a test says "the reference was re-resolved" without
+ * standing still for a second to let it happen.
+ */
+interface StubRuntime {
+  /** Stands in for `RuntimeInternals`. */
+  rt: unknown;
+
+  /** The arguments of each resolution, in order. */
+  resolved: unknown[][];
+
+  /** The arguments of each `getPattern`, in order. */
+  started: unknown[][];
+
+  /** How many times the slug subscription has been cancelled. */
+  cancels: number;
+
+  /** Answer every resolution from here on with `next`. */
+  answer(next: Resolved | Refused | Error): void;
+
+  /** Fire the watch's poll once, and let what it starts settle. */
+  poll(): Promise<void>;
+
+  /** Let the subscription's own opening settle, without firing the poll. */
+  settle(): Promise<void>;
+
+  /** Fail every piece load from here on, or none when given `undefined`. */
+  failLoads(error: Error | undefined): void;
+
+  /** Hold every piece load from here on, to be released by hand. */
+  holdLoads(): void;
+
+  /** Release the held loads and let what they finish settle. */
+  releaseLoads(): Promise<void>;
+
+  /** Hold every answer from here on, to be released by hand. */
+  hold(): void;
+
+  /** Release the held answers, newest first. */
+  releaseNewestFirst(): Promise<void>;
+}
+
+function stubRuntime(
+  first: Resolved | Refused | Error,
+  aborted = false,
+): StubRuntime {
+  const resolved: unknown[][] = [];
+  const started: unknown[][] = [];
+  let answer = first;
+  let poll: (() => void) | undefined;
+  const stub: StubRuntime = {
+    resolved,
+    started,
+    cancels: 0,
+    answer: (next) => {
+      answer = next;
+    },
+    poll: async () => {
+      poll?.();
+      // A resolution and the reload it may start are each a microtask hop.
+      for (let hop = 0; hop < 4; hop++) await Promise.resolve();
+    },
+    settle: async () => {
+      for (let hop = 0; hop < 6; hop++) await Promise.resolve();
+    },
+    rt: undefined,
+    failLoads: () => {},
+    holdLoads: () => {},
+    releaseLoads: async () => {},
+    hold: () => {},
+    releaseNewestFirst: async () => {},
+  };
+  let loadFailure: Error | undefined;
+  stub.failLoads = (error) => {
+    loadFailure = error;
+  };
+  let heldLoads: Array<() => void> | undefined;
+  stub.holdLoads = () => {
+    heldLoads = [];
+  };
+  stub.releaseLoads = async () => {
+    const pending = heldLoads ?? [];
+    heldLoads = undefined;
+    for (const release of pending) release();
+    for (let hop = 0; hop < 6; hop++) await Promise.resolve();
+  };
+  let held: Array<() => void> | undefined;
+  stub.hold = () => {
+    held = [];
+  };
+  stub.releaseNewestFirst = async () => {
+    const pending = held ?? [];
+    held = undefined;
+    for (const release of [...pending].reverse()) release();
+    for (let hop = 0; hop < 6; hop++) await Promise.resolve();
+  };
+  stub.rt = {
+    signal: { aborted },
+    // A named space resolves to its DID before anything else runs; these
+    // tests address one space and it is the one they were handed.
+    resolveSpaceName: () => Promise.resolve(SPACE),
+    resolveSlug: (...args: unknown[]) => {
+      resolved.push(args);
+      const settled = answer instanceof Error
+        ? Promise.reject(answer)
+        : "refusal" in answer
+        ? Promise.resolve(answer)
+        : Promise.resolve({ scope: "space", ...answer });
+      settled.catch(() => {});
+      if (!held) return settled;
+      // Held: the caller decides when this answer lands, and in what order
+      // relative to the calls made after it.
+      const queue = held;
+      return new Promise((resolve, reject) => {
+        queue.push(() => settled.then(resolve, reject));
+      });
+    },
+    getPattern: (...args: unknown[]) => {
+      started.push(args);
+      if (loadFailure) return Promise.reject(loadFailure);
+      const loaded = { id: () => "fid1:whatever" };
+      if (!heldLoads) return Promise.resolve(loaded);
+      const queue = heldLoads;
+      return new Promise((resolve) => {
+        queue.push(() => resolve(loaded));
+      });
+    },
+    getSlugCell: () =>
+      Promise.resolve({
+        subscribe: () => () => {
+          stub.cancels++;
+        },
+      }),
+    invalidatePattern: () => {},
+  };
+  // Replaced, never scheduled: the poll is the subject, and firing it by
+  // hand is what a test does instead of standing still for a second.
+  // `installBrowserGlobals` captured these and puts them back.
+  Object.defineProperty(globalThis, "setInterval", {
+    configurable: true,
+    writable: true,
+    value: (callback: () => void) => {
+      poll = callback;
+      return 0 as unknown as number;
+    },
+  });
+  Object.defineProperty(globalThis, "clearInterval", {
+    configurable: true,
+    writable: true,
+    value: () => {},
+  });
+  return stub;
+}
+
 const SPACE = "did:key:z6Mk-shell-collection-member" as DID;
+
+/**
+ * The timer functions as this module found them, before any test ran. Every
+ * test here replaces them, and they are process-wide.
+ */
+const NATIVE_TIMERS = {
+  setInterval: globalThis.setInterval,
+  clearInterval: globalThis.clearInterval,
+} as const;
+
+/**
+ * Fire the watch's poll, and let the selection run if the watch asked for it.
+ *
+ * That second half is what Lit does when `_slugRevision` changes, and it is
+ * what marks a resolution APPLIED — the view has come to show what the answer
+ * named. A test that polls without it leaves every answer unapplied, which is
+ * a state the shell never sits in.
+ */
+async function pollAndSettle(
+  view: AppViewLike,
+  stub: StubRuntime,
+): Promise<void> {
+  const before = view.accessForTestingOnly.slugRevision;
+  await stub.poll();
+  if (view.accessForTestingOnly.slugRevision === before) return;
+  view._selectedPattern.run();
+  await view._selectedPattern.taskComplete.catch(() => {});
+}
+
+/** A view of the demo space holding `overrides`. */
+function viewOf(overrides: Record<string, unknown>): AppView {
+  return { spaceName: "naming-demo", ...overrides } as AppView;
+}
+
+/**
+ * What these tests set and read. All of it is the view's public surface
+ * except the slug revision, which comes through the class's own testing
+ * accessor: typed as the class types it, so a renamed member is a type error
+ * rather than an `undefined` that every comparison here would accept.
+ */
+interface AppViewLike {
+  app: unknown;
+  space: DID | undefined;
+  rt: unknown;
+  render(): unknown;
+  updated(changed: Map<string, unknown>): void;
+  _selectedPattern: { run(): void; taskComplete: Promise<unknown> };
+  readonly accessForTestingOnly: { readonly slugRevision: number };
+}
+
+/** A view element wired to `stub` and addressing `view`. */
+function appViewOver(
+  XAppView: new () => unknown,
+  stub: StubRuntime,
+  view: AppView,
+): AppViewLike {
+  const element = new XAppView() as AppViewLike;
+  element.app = { identity: {}, config: {}, view };
+  element.space = SPACE;
+  element.rt = stub.rt;
+  return element;
+}
 
 describe("AppView collection members", () => {
   it("selects the member the reference names", async () => {
     const restore = installBrowserGlobals();
     try {
       const { XAppView } = await import("../src/views/AppView.ts");
-      const resolved: unknown[][] = [];
-      const started: unknown[][] = [];
-      const view = new XAppView();
-      view.app = {
-        identity: {},
-        config: {},
-        view: { spaceDid: SPACE, pieceSlug: "top", pieceMember: "42" },
-      } as never;
-      view.space = SPACE;
-      view.rt = {
-        signal: new AbortController().signal,
-        resolveSlug: (...args: unknown[]) => {
-          resolved.push(args);
-          return Promise.resolve("fid1:member-42");
-        },
-        getPattern: (...args: unknown[]) => {
-          started.push(args);
-          return Promise.resolve({ id: () => "fid1:member-42" });
-        },
-      } as never;
+      const stub = stubRuntime({ pieceId: "fid1:member-42", pathAfter: [] });
+      const view = appViewOver(
+        XAppView as never,
+        stub,
+        viewOf({ pieceSlug: "top", pieceMember: "42" }),
+      );
 
       view._selectedPattern.run();
       await view._selectedPattern.taskComplete;
 
-      expect(resolved).toEqual([[SPACE, "top", "42"]]);
+      expect(stub.resolved).toEqual([[SPACE, "top", "42"]]);
       // The piece started is the one the reference resolved to, never the
-      // document the slug itself lives in.
-      expect(started).toEqual([[SPACE, "fid1:member-42"]]);
+      // document the slug itself lives in — and it is loaded in the scope
+      // the resolution reached it in, which its id alone does not carry.
+      expect(stub.started).toEqual([
+        [SPACE, "fid1:member-42", { scope: "space" }],
+      ]);
     } finally {
       restore();
     }
@@ -126,17 +374,15 @@ describe("AppView collection members", () => {
     const restore = installBrowserGlobals();
     try {
       const { XAppView } = await import("../src/views/AppView.ts");
-      const view = new XAppView();
-      view.app = {
-        identity: {},
-        config: {},
-        view: {
-          spaceName: "naming-demo",
-          pieceSlug: "top",
-          pieceMember: "42",
-        },
-      } as never;
-      view.space = SPACE;
+      const stub = stubRuntime({ pieceId: "fid1:member-42", pathAfter: [] });
+      const view = appViewOver(
+        XAppView as never,
+        stub,
+        viewOf({ pieceSlug: "top", pieceMember: "42" }),
+      );
+
+      view._selectedPattern.run();
+      await view._selectedPattern.taskComplete;
 
       expect(templateText(view.render())).toContain("/@naming-demo/top/42");
     } finally {
@@ -148,17 +394,475 @@ describe("AppView collection members", () => {
     const restore = installBrowserGlobals();
     try {
       const { XAppView } = await import("../src/views/AppView.ts");
-      const view = new XAppView();
+      const stub = stubRuntime({ pieceId: "fid1:board", pathAfter: [] });
+      const view = appViewOver(
+        XAppView as never,
+        stub,
+        viewOf({ pieceSlug: "top" }),
+      );
+
+      view._selectedPattern.run();
+      await view._selectedPattern.taskComplete;
+
+      // A collection's name with no member after it names no member, so
+      // there is nothing for a citation to resolve to.
+      expect(templateText(view.render())).not.toContain("/@naming-demo/top");
+    } finally {
+      restore();
+    }
+  });
+
+  it("drops a member the walk did not spend, and cites nothing for it", async () => {
+    const restore = installBrowserGlobals();
+    const replaced: AppView[] = [];
+    const listener = (event: Event) => {
+      replaced.push((event as CustomEvent<AppView>).detail);
+    };
+    globalThis.addEventListener("cf-replace-navigation", listener);
+    try {
+      const { XAppView } = await import("../src/views/AppView.ts");
+      // A slug naming a piece at its root spends no segment, so the walk
+      // hands the member back: it named nothing, and the page is the one the
+      // collection's name alone addresses.
+      const stub = stubRuntime({ pieceId: "fid1:plain", pathAfter: ["42"] });
+      const view = appViewOver(
+        XAppView as never,
+        stub,
+        viewOf({ pieceSlug: "plain", pieceMember: "42" }),
+      );
+
+      view._selectedPattern.run();
+      await view._selectedPattern.taskComplete;
+
+      // The address settles on what the page is showing.
+      expect(replaced).toEqual([{
+        spaceName: "naming-demo",
+        pieceSlug: "plain",
+      }]);
+      // And nothing offers `/@naming-demo/plain/42`, which would cite a cell
+      // inside the piece rather than the piece the reader is looking at.
+      expect(templateText(view.render())).not.toContain("/@naming-demo/plain");
+    } finally {
+      globalThis.removeEventListener("cf-replace-navigation", listener);
+      restore();
+    }
+  });
+
+  it("re-resolves the reference until it reaches somewhere else", async () => {
+    const restore = installBrowserGlobals();
+    try {
+      const { XAppView } = await import("../src/views/AppView.ts");
+      const stub = stubRuntime({ pieceId: "fid1:member-42", pathAfter: [] });
+      const view = appViewOver(
+        XAppView as never,
+        stub,
+        viewOf({ pieceSlug: "top", pieceMember: "42" }),
+      );
+
+      view.updated(new Map([["app", undefined]]));
+      await stub.poll();
+      const asked = stub.resolved.length;
+
+      stub.answer({ pieceId: "fid1:member-42-replaced", pathAfter: [] });
+      await stub.poll();
+
+      // Re-resolving is what notices a member pointed elsewhere; no event
+      // reports it, the slug document being the only thing watched.
+      expect(stub.resolved.length).toBeGreaterThan(asked);
+      expect(stub.resolved.at(-1)).toEqual([SPACE, "top", "42"]);
+    } finally {
+      restore();
+    }
+  });
+
+  it("opens a member that only arrives later", async () => {
+    const restore = installBrowserGlobals();
+    try {
+      const { XAppView } = await import("../src/views/AppView.ts");
+      const stub = stubRuntime({
+        refusal: { code: "missing-member", message: "no member 42 in top" },
+      });
+      const view = appViewOver(
+        XAppView as never,
+        stub,
+        viewOf({ pieceSlug: "top", pieceMember: "42" }),
+      );
+
+      view.updated(new Map([["app", undefined]]));
+      await pollAndSettle(view, stub);
+      const afterFailing = view.accessForTestingOnly.slugRevision;
+
+      // The same refusal again is no news — it is the answer the view is
+      // already showing — so nothing reloads.
+      stub.answer({
+        refusal: { code: "missing-member", message: "no member 42 in top" },
+      });
+      await pollAndSettle(view, stub);
+      expect(view.accessForTestingOnly.slugRevision).toBe(afterFailing);
+
+      // The member appearing is news, and the reload it triggers goes and
+      // gets it.
+      stub.answer({ pieceId: "fid1:member-42", pathAfter: [] });
+      await stub.poll();
+      expect(view.accessForTestingOnly.slugRevision).toBeGreaterThan(
+        afterFailing,
+      );
+
+      view._selectedPattern.run();
+      await view._selectedPattern.taskComplete;
+      expect(stub.started.map((call) => call[1])).toContain("fid1:member-42");
+    } finally {
+      restore();
+    }
+  });
+
+  it("stops citing a member once the collection stops holding one", async () => {
+    const restore = installBrowserGlobals();
+    const replaced: AppView[] = [];
+    const listener = (event: Event) => {
+      replaced.push((event as CustomEvent<AppView>).detail);
+    };
+    globalThis.addEventListener("cf-replace-navigation", listener);
+    try {
+      const { XAppView } = await import("../src/views/AppView.ts");
+      const stub = stubRuntime({ pieceId: "fid1:member-42", pathAfter: [] });
+      const view = appViewOver(
+        XAppView as never,
+        stub,
+        viewOf({ pieceSlug: "top", pieceMember: "42" }),
+      );
+
+      view._selectedPattern.run();
+      await view._selectedPattern.taskComplete;
+      view.updated(new Map([["app", undefined]]));
+      await stub.poll();
+      expect(templateText(view.render())).toContain("/@naming-demo/top/42");
+
+      // `top` is repointed at that very piece's own root. The reference now
+      // reaches the SAME piece and spends nothing, so a comparison holding
+      // only the piece calls this no change — and everything derived from the
+      // member standing would go on standing under an address that no longer
+      // names one.
+      const before = view.accessForTestingOnly.slugRevision;
+      stub.answer({ pieceId: "fid1:member-42", pathAfter: ["42"] });
+      await stub.poll();
+
+      // The watch has to see this as a new answer. It is the only thing that
+      // reruns the selection, and everything below is what the rerun settles.
+      expect(view.accessForTestingOnly.slugRevision).toBeGreaterThan(before);
+
+      view._selectedPattern.run();
+      await view._selectedPattern.taskComplete;
+
+      expect(replaced).toEqual([{
+        spaceName: "naming-demo",
+        pieceSlug: "top",
+      }]);
+      expect(templateText(view.render())).not.toContain("/@naming-demo/top/42");
+    } finally {
+      globalThis.removeEventListener("cf-replace-navigation", listener);
+      restore();
+    }
+  });
+
+  it("reloads when only the scope of the answer changes", async () => {
+    const restore = installBrowserGlobals();
+    try {
+      const { XAppView } = await import("../src/views/AppView.ts");
+      const stub = stubRuntime({
+        pieceId: "fid1:member-42",
+        pathAfter: [],
+        scope: "space",
+      });
+      const view = appViewOver(
+        XAppView as never,
+        stub,
+        viewOf({ pieceSlug: "top", pieceMember: "42" }),
+      );
+
+      view.updated(new Map([["app", undefined]]));
+      await stub.poll();
+      const before = view.accessForTestingOnly.slugRevision;
+
+      // Same piece, same leftover, different scope: a different document,
+      // and the only field that says so. A comparison built from a list of
+      // fields is one this walks straight past.
+      stub.answer({
+        pieceId: "fid1:member-42",
+        pathAfter: [],
+        scope: "user",
+      });
+      await stub.poll();
+
+      expect(view.accessForTestingOnly.slugRevision).toBeGreaterThan(before);
+    } finally {
+      restore();
+    }
+  });
+
+  it("opens a member that arrives while the watch is still opening", async () => {
+    const restore = installBrowserGlobals();
+    try {
+      const { XAppView } = await import("../src/views/AppView.ts");
+      // The selected task refuses: member 42 is not there yet.
+      const stub = stubRuntime({
+        refusal: { code: "missing-member", message: "no member 42 in top" },
+      });
+      const view = appViewOver(
+        XAppView as never,
+        stub,
+        viewOf({ pieceSlug: "top", pieceMember: "42" }),
+      );
+
+      view._selectedPattern.run();
+      await view._selectedPattern.taskComplete.catch(() => {});
+      const before = view.accessForTestingOnly.slugRevision;
+
+      // The member lands in the window between that failure and the watch's
+      // first resolution, so the watch's FIRST answer already differs from
+      // what the task saw. Nothing later reports it: the failed task does not
+      // rerun on its own, and every poll after this one matches what the
+      // first recorded.
+      stub.answer({ pieceId: "fid1:member-42", pathAfter: [] });
+      view.updated(new Map([["app", undefined]]));
+      await stub.settle();
+
+      expect(view.accessForTestingOnly.slugRevision).toBeGreaterThan(before);
+    } finally {
+      restore();
+    }
+  });
+
+  it("resolves one at a time, coalescing a poll fired while one is running", async () => {
+    const restore = installBrowserGlobals();
+    try {
+      const { XAppView } = await import("../src/views/AppView.ts");
+      const stub = stubRuntime({ pieceId: "fid1:first", pathAfter: [] });
+      const view = appViewOver(
+        XAppView as never,
+        stub,
+        viewOf({ pieceSlug: "top", pieceMember: "42" }),
+      );
+
+      view.updated(new Map([["app", undefined]]));
+      await stub.settle();
+
+      // The resolver is slower than the interval, so a second poll fires
+      // while the first is still out.
+      stub.hold();
+      const before = stub.resolved.length;
+      await stub.poll();
+      await stub.poll();
+      await stub.poll();
+
+      // One in flight, whatever the polls did — two answers at once is the
+      // whole of the ordering problem, and there is never a second.
+      expect(stub.resolved.length).toBe(before + 1);
+
+      // What the extra polls asked for is not lost: one more resolution runs
+      // as soon as the first finishes.
+      await stub.releaseNewestFirst();
+      expect(stub.resolved.length).toBe(before + 2);
+    } finally {
+      restore();
+    }
+  });
+
+  it("applies an answer that took longer than the poll interval", async () => {
+    const restore = installBrowserGlobals();
+    try {
+      const { XAppView } = await import("../src/views/AppView.ts");
+      const stub = stubRuntime({ pieceId: "fid1:first", pathAfter: [] });
+      const view = appViewOver(
+        XAppView as never,
+        stub,
+        viewOf({ pieceSlug: "top", pieceMember: "42" }),
+      );
+
+      view.updated(new Map([["app", undefined]]));
+      await stub.settle();
+      view._selectedPattern.run();
+      await view._selectedPattern.taskComplete;
+      const before = view.accessForTestingOnly.slugRevision;
+
+      // A slow resolution finds the reference somewhere new. Under a guard
+      // that asks "am I the newest ISSUED", the polls behind it would each
+      // supersede it and the view would never learn anything at all.
+      stub.hold();
+      stub.answer({ pieceId: "fid1:moved", pathAfter: [] });
+      await stub.poll();
+      await stub.poll();
+      await stub.releaseNewestFirst();
+
+      expect(view.accessForTestingOnly.slugRevision).toBeGreaterThan(before);
+    } finally {
+      restore();
+    }
+  });
+
+  it("does not call a slow load's answer the newer one that arrived meanwhile", async () => {
+    const restore = installBrowserGlobals();
+    try {
+      const { XAppView } = await import("../src/views/AppView.ts");
+      const stub = stubRuntime({ pieceId: "fid1:A", pathAfter: [] });
+      const view = appViewOver(
+        XAppView as never,
+        stub,
+        viewOf({ pieceSlug: "top", pieceMember: "42" }),
+      );
+      view.updated(new Map([["app", undefined]]));
+      await stub.settle();
+
+      // The selection resolves A and waits in the load.
+      stub.holdLoads();
+      view._selectedPattern.run();
+      await stub.settle();
+
+      // The reference moves to B while that load is out, and the watch asks
+      // for a rerun.
+      stub.answer({ pieceId: "fid1:B", pathAfter: [] });
+      await stub.poll();
+
+      // A's load finishes. What is on screen is A, and saying so is all it
+      // may say: reporting "the newest answer is showing" would claim B.
+      await stub.releaseLoads();
+      const afterA = view.accessForTestingOnly.slugRevision;
+
+      // So a resolution finding B is still news, and the view goes and gets
+      // it rather than taking an early return on a claim that it already has.
+      await stub.poll();
+      expect(view.accessForTestingOnly.slugRevision).toBeGreaterThan(afterA);
+    } finally {
+      restore();
+    }
+  });
+
+  it("reloads when one refusal gives way to a different one", async () => {
+    const restore = installBrowserGlobals();
+    try {
+      const { XAppView } = await import("../src/views/AppView.ts");
+      // `top` is not bound at all, so the reader is told the name is not
+      // found.
+      const stub = stubRuntime({
+        refusal: { code: "missing", message: 'Slug "top" not found.' },
+      });
+      const view = appViewOver(
+        XAppView as never,
+        stub,
+        viewOf({ pieceSlug: "top", pieceMember: "999" }),
+      );
+
+      view.updated(new Map([["app", undefined]]));
+      await stub.settle();
+      const before = view.accessForTestingOnly.slugRevision;
+
+      // `top` is then bound to a collection that has no member 999. Still a
+      // refusal, and a different one: keeping the first would leave the
+      // reader on the wrong error about the wrong thing.
+      stub.answer({
+        refusal: { code: "missing-member", message: "no member 999 in top" },
+      });
+      await stub.poll();
+
+      expect(view.accessForTestingOnly.slugRevision).toBeGreaterThan(before);
+    } finally {
+      restore();
+    }
+  });
+
+  it("retries a load that failed after the reference resolved", async () => {
+    const restore = installBrowserGlobals();
+    try {
+      const { XAppView } = await import("../src/views/AppView.ts");
+      const stub = stubRuntime({ pieceId: "fid1:member-42", pathAfter: [] });
+      const view = appViewOver(
+        XAppView as never,
+        stub,
+        viewOf({ pieceSlug: "top", pieceMember: "42" }),
+      );
+
+      // The reference resolves, and loading the piece it names fails — a
+      // dropped connection, say. The answer is identified and the view is
+      // not showing it.
+      stub.failLoads(new Error("the socket went away"));
+      view.updated(new Map([["app", undefined]]));
+      await pollAndSettle(view, stub);
+      const afterFailedLoad = view.accessForTestingOnly.slugRevision;
+
+      // Nothing about the reference has changed, so no later poll brings a
+      // new answer. Recovery has to come from the answer still being
+      // unhandled — otherwise the view sits on the error for good.
+      stub.failLoads(undefined);
+      await pollAndSettle(view, stub);
+
+      expect(view.accessForTestingOnly.slugRevision).toBeGreaterThan(
+        afterFailedLoad,
+      );
+      expect(stub.started.map((call) => call[1])).toContain("fid1:member-42");
+    } finally {
+      restore();
+    }
+  });
+
+  it("watches each reference through a slug separately", async () => {
+    const restore = installBrowserGlobals();
+    try {
+      const { XAppView } = await import("../src/views/AppView.ts");
+      const stub = stubRuntime({ pieceId: "fid1:member-1", pathAfter: [] });
+      const view = appViewOver(
+        XAppView as never,
+        stub,
+        viewOf({ pieceSlug: "top", pieceMember: "1" }),
+      );
+
+      view.updated(new Map([["app", undefined]]));
+      await stub.poll();
+
+      // Two members of one collection are two references reaching two
+      // pieces, so the second cannot ride the first's subscription.
       view.app = {
         identity: {},
         config: {},
-        view: { spaceName: "naming-demo", pieceSlug: "top" },
+        view: viewOf({ pieceSlug: "top", pieceMember: "2" }),
       } as never;
-      view.space = SPACE;
+      view.updated(new Map([["app", undefined]]));
+      await stub.poll();
 
-      // A collection's name with no member after it names no piece, so there
-      // is nothing for a reference to resolve to.
-      expect(templateText(view.render())).not.toContain("/@naming-demo/top");
+      expect(stub.cancels).toBe(1);
+      expect(stub.resolved.map((call) => call[2])).toContain("2");
+    } finally {
+      restore();
+    }
+  });
+
+  it("leaves the process-wide timers as it found them", () => {
+    // Last, and it reads what every test before it did. These are shared with
+    // the whole test process: left replaced, `setInterval` stops scheduling
+    // and `clearInterval` stops cancelling for everything that runs after,
+    // and no assertion anywhere goes red — things simply stop happening.
+    expect(globalThis.setInterval).toBe(NATIVE_TIMERS.setInterval);
+    expect(globalThis.clearInterval).toBe(NATIVE_TIMERS.clearInterval);
+  });
+
+  it("stops watching a runtime that has been disposed", async () => {
+    const restore = installBrowserGlobals();
+    try {
+      const { XAppView } = await import("../src/views/AppView.ts");
+      const stub = stubRuntime(new Error("runtime gone"), true);
+      const view = appViewOver(
+        XAppView as never,
+        stub,
+        viewOf({ pieceSlug: "top", pieceMember: "42" }),
+      );
+
+      view.updated(new Map([["app", undefined]]));
+      await stub.poll();
+
+      // A disposed runtime cannot answer, and asking it forever is no
+      // recovery: the watch drops so a replacement runtime takes it up.
+      const asked = stub.resolved.length;
+      await stub.poll();
+      expect(stub.resolved.length).toBe(asked);
     } finally {
       restore();
     }

--- a/packages/shell/test/header-view-piece-reference.test.ts
+++ b/packages/shell/test/header-view-piece-reference.test.ts
@@ -1,0 +1,208 @@
+// deno-lint-ignore-file cf-imports/no-inline-module-import -- the view's module
+// graph reaches @commonfabric/ui, whose components extend a bare HTMLElement as
+// they load, so it can only load once the test has installed one.
+
+/**
+ * The header's offer to copy a piece's portable reference: when it is there to
+ * take, and that what it writes is the reference itself.
+ *
+ * A reference travels — into a commit message, a chat, another space's
+ * pattern — and nothing downstream can tell a wrong one from a right one, so
+ * what reaches the clipboard is checked against what was handed in rather than
+ * against the shape of a reference.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+/**
+ * What these tests set and read. `pieceReference` and `render` are public;
+ * the handler is reached through the class's own testing accessor, which
+ * types it as the class does — a cast would type it as this file finds
+ * convenient, and a renamed member would read `undefined` and pass.
+ */
+interface HeaderViewLike {
+  pieceReference: string | undefined;
+  menuOpen: boolean;
+  render(): unknown;
+  readonly accessForTestingOnly: {
+    copyReference(event: Event): Promise<void>;
+  };
+}
+
+/** A clipboard that records what it was given, or refuses. */
+function clipboardThat(refuses = false) {
+  const written: string[] = [];
+  return {
+    written,
+    api: {
+      writeText: (text: string) => {
+        if (refuses) return Promise.reject(new Error("clipboard denied"));
+        written.push(text);
+        return Promise.resolve();
+      },
+    },
+  };
+}
+
+function installBrowserGlobals(clipboard: unknown): () => void {
+  const originals = new Map<string, PropertyDescriptor | undefined>();
+  function setGlobal(name: string, value: unknown): void {
+    originals.set(name, Object.getOwnPropertyDescriptor(globalThis, name));
+    Object.defineProperty(globalThis, name, {
+      configurable: true,
+      writable: true,
+      value,
+    });
+  }
+  class TestHTMLElement extends EventTarget {
+    attachShadow() {
+      return { adoptedStyleSheets: [], appendChild() {}, append() {} };
+    }
+  }
+  setGlobal("window", globalThis);
+  setGlobal("HTMLElement", TestHTMLElement);
+  setGlobal("customElements", {
+    define() {},
+    get() {},
+    whenDefined: () => Promise.resolve(),
+  });
+  setGlobal("document", {
+    documentElement: { style: {} },
+    addEventListener() {},
+    removeEventListener() {},
+    createElement: () => ({
+      style: {},
+      setAttribute() {},
+      append() {},
+      appendChild() {},
+    }),
+    createTreeWalker: () => ({}),
+  });
+  setGlobal("devicePixelRatio", 1);
+  setGlobal("screen", { deviceXDPI: 1, logicalXDPI: 1 });
+  setGlobal("navigator", { platform: "", userAgent: "deno", clipboard });
+  setGlobal("location", {
+    protocol: "http:",
+    host: "localhost:8000",
+    hostname: "localhost",
+    href: "http://localhost:8000/naming-demo/top/42",
+  });
+  return () => {
+    for (const [name, descriptor] of originals) {
+      if (descriptor) Object.defineProperty(globalThis, name, descriptor);
+      else Reflect.deleteProperty(globalThis, name);
+    }
+  };
+}
+
+/** Return the rendered text of nested Lit template results. */
+function templateText(value: unknown): string {
+  if (value == null) return "";
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) return value.map(templateText).join("");
+  if (typeof value !== "object") return String(value);
+  const template = value as {
+    strings?: readonly string[];
+    values?: readonly unknown[];
+  };
+  const strings = template.strings ?? [];
+  const values = template.values ?? [];
+  let text = "";
+  for (let index = 0; index < strings.length; index++) {
+    text += strings[index];
+    if (index < values.length) text += templateText(values[index]);
+  }
+  return text;
+}
+
+/** A click, as the menu entry dispatches one. */
+function click(): Event {
+  return { preventDefault() {}, stopPropagation() {} } as unknown as Event;
+}
+
+const REFERENCE = "/@naming-demo/top/42";
+
+describe("HeaderView piece reference", () => {
+  it("copies the reference it was handed, character for character", async () => {
+    const clipboard = clipboardThat();
+    const restore = installBrowserGlobals(clipboard.api);
+    try {
+      const { XHeaderView } = await import("../src/views/HeaderView.ts");
+      const view = new XHeaderView() as unknown as HeaderViewLike;
+      view.pieceReference = REFERENCE;
+      view.menuOpen = true;
+
+      await view.accessForTestingOnly.copyReference(click());
+
+      expect(clipboard.written).toEqual([REFERENCE]);
+      // Taking the offer closes the menu, as every other entry does.
+      expect(view.menuOpen).toBe(false);
+    } finally {
+      restore();
+    }
+  });
+
+  it("shows the reference beside the entry that copies it", async () => {
+    const clipboard = clipboardThat();
+    const restore = installBrowserGlobals(clipboard.api);
+    try {
+      const { XHeaderView } = await import("../src/views/HeaderView.ts");
+      const view = new XHeaderView() as unknown as HeaderViewLike;
+      view.pieceReference = REFERENCE;
+
+      // Shown as well as copied: a reader who cannot paste — reading over a
+      // shoulder, or off a screenshot — can still retype it.
+      expect(templateText(view.render())).toContain(REFERENCE);
+    } finally {
+      restore();
+    }
+  });
+
+  it("offers nothing for a piece that has no member reference", async () => {
+    const clipboard = clipboardThat();
+    const restore = installBrowserGlobals(clipboard.api);
+    try {
+      const { XHeaderView } = await import("../src/views/HeaderView.ts");
+      const view = new XHeaderView() as unknown as HeaderViewLike;
+      view.pieceReference = undefined;
+      view.menuOpen = true;
+
+      expect(templateText(view.render())).not.toContain("Copy reference");
+      // And nothing reaches the clipboard if the entry is driven anyway,
+      // rather than an empty string landing there.
+      await view.accessForTestingOnly.copyReference(click());
+      expect(clipboard.written).toEqual([]);
+      expect(view.menuOpen).toBe(true);
+    } finally {
+      restore();
+    }
+  });
+
+  it("survives a clipboard that refuses", async () => {
+    const clipboard = clipboardThat(true);
+    const restore = installBrowserGlobals(clipboard.api);
+    const warnings: unknown[] = [];
+    const realWarn = console.warn;
+    console.warn = (...args: unknown[]) => warnings.push(args[0]);
+    try {
+      const { XHeaderView } = await import("../src/views/HeaderView.ts");
+      const view = new XHeaderView() as unknown as HeaderViewLike;
+      view.pieceReference = REFERENCE;
+      view.menuOpen = true;
+
+      // A browser can deny clipboard access outright. The control reports it
+      // and closes, rather than rejecting into a click handler where nothing
+      // is listening.
+      await view.accessForTestingOnly.copyReference(click());
+
+      expect(warnings).toEqual([
+        "Failed to copy reference to clipboard",
+      ]);
+      expect(view.menuOpen).toBe(false);
+    } finally {
+      console.warn = realWarn;
+      restore();
+    }
+  });
+});

--- a/packages/shell/test/load-errors.test.ts
+++ b/packages/shell/test/load-errors.test.ts
@@ -481,12 +481,13 @@ describe("load-errors", () => {
           }
         });
 
-        it("resolves a slug target before starting its piece", async () => {
+        it("resolves a slug reference before starting the piece it names", async () => {
           const restore = installBrowserGlobals();
           try {
             const { XAppView } = await import("../src/views/AppView.ts");
             const space = "did:key:z6Mk-shell-slug-target-error" as DID;
-            const calls: unknown[][] = [];
+            const resolved: unknown[][] = [];
+            const started: unknown[][] = [];
             const view = new XAppView();
             view.app = {
               identity: {},
@@ -496,8 +497,12 @@ describe("load-errors", () => {
             view.space = space;
             view.rt = {
               signal: new AbortController().signal,
+              resolveSlug: (...args: unknown[]) => {
+                resolved.push(args);
+                return Promise.resolve("fid1:slug-target");
+              },
               getPattern: (...args: unknown[]) => {
-                calls.push(args);
+                started.push(args);
                 return Promise.resolve({ id: () => "fid1:slug-target" });
               },
             } as never;
@@ -505,9 +510,8 @@ describe("load-errors", () => {
             view._selectedPattern.run();
             await view._selectedPattern.taskComplete;
 
-            expect(calls).toHaveLength(2);
-            expect(calls[0]?.[2]).toEqual({ start: false });
-            expect(calls[1]?.[2]).toBeUndefined();
+            expect(resolved).toEqual([[space, "broken-piece", undefined]]);
+            expect(started).toEqual([[space, "fid1:slug-target"]]);
           } finally {
             restore();
           }

--- a/packages/shell/test/load-errors.test.ts
+++ b/packages/shell/test/load-errors.test.ts
@@ -486,8 +486,10 @@ describe("load-errors", () => {
           try {
             const { XAppView } = await import("../src/views/AppView.ts");
             const space = "did:key:z6Mk-shell-slug-target-error" as DID;
-            const resolved: unknown[][] = [];
-            const started: unknown[][] = [];
+            // One log, so the ORDER the name claims is what is checked;
+            // two arrays would prove both calls happened and nothing about
+            // which came first.
+            const calls: Array<{ call: string; args: unknown[] }> = [];
             const view = new XAppView();
             view.app = {
               identity: {},
@@ -498,11 +500,15 @@ describe("load-errors", () => {
             view.rt = {
               signal: new AbortController().signal,
               resolveSlug: (...args: unknown[]) => {
-                resolved.push(args);
-                return Promise.resolve("fid1:slug-target");
+                calls.push({ call: "resolveSlug", args });
+                return Promise.resolve({
+                  pieceId: "fid1:slug-target",
+                  pathAfter: [],
+                  scope: "space",
+                });
               },
               getPattern: (...args: unknown[]) => {
-                started.push(args);
+                calls.push({ call: "getPattern", args });
                 return Promise.resolve({ id: () => "fid1:slug-target" });
               },
             } as never;
@@ -510,8 +516,16 @@ describe("load-errors", () => {
             view._selectedPattern.run();
             await view._selectedPattern.taskComplete;
 
-            expect(resolved).toEqual([[space, "broken-piece", undefined]]);
-            expect(started).toEqual([[space, "fid1:slug-target"]]);
+            expect(calls).toEqual([
+              {
+                call: "resolveSlug",
+                args: [space, "broken-piece", undefined],
+              },
+              {
+                call: "getPattern",
+                args: [space, "fid1:slug-target", { scope: "space" }],
+              },
+            ]);
           } finally {
             restore();
           }

--- a/packages/shell/test/navigation.test.ts
+++ b/packages/shell/test/navigation.test.ts
@@ -174,6 +174,32 @@ describe("navigation", () => {
     );
   });
 
+  it("keeps the member when it names the space rather than its DID", () => {
+    withNavigation(
+      "http://common.test/my-space",
+      { view: { spaceName: "my-space" }, runtimeSpace: SPACE_DID as DID },
+      (_navigation, recorded) => {
+        globalThis.dispatchEvent(
+          new CustomEvent("cf-navigate", {
+            detail: {
+              spaceDid: SPACE_DID,
+              pieceSlug: "top",
+              pieceMember: "42",
+            },
+          }),
+        );
+        expect(recorded.push.at(-1)).toEqual({
+          state: {
+            pieceSlug: "top",
+            pieceMember: "42",
+            spaceName: "my-space",
+          },
+          url: "/my-space/top/42",
+        });
+      },
+    );
+  });
+
   it("keeps a DID that names a space other than the running one", () => {
     const otherDid = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
     withNavigation(

--- a/packages/shell/test/navigation.test.ts
+++ b/packages/shell/test/navigation.test.ts
@@ -200,6 +200,40 @@ describe("navigation", () => {
     );
   });
 
+  it("keeps every field of a view whose space it renames", () => {
+    // The mapping exchanges one key. Naming the others one at a time is what
+    // dropped whichever the list had not been taught about, so this asserts
+    // over a view holding every field at once rather than over the one that
+    // was last forgotten.
+    withNavigation(
+      "http://common.test/.embed/my-space",
+      {
+        view: { spaceName: "my-space", mode: "embed" },
+        runtimeSpace: SPACE_DID as DID,
+      },
+      (_navigation, recorded) => {
+        globalThis.dispatchEvent(
+          new CustomEvent("cf-navigate", {
+            detail: {
+              spaceDid: SPACE_DID,
+              pieceSlug: "top",
+              pieceMember: "42",
+              mode: "embed",
+              openPath: "People/Zora/about.md",
+            },
+          }),
+        );
+        expect(recorded.push.at(-1)?.state).toEqual({
+          spaceName: "my-space",
+          pieceSlug: "top",
+          pieceMember: "42",
+          mode: "embed",
+          openPath: "People/Zora/about.md",
+        });
+      },
+    );
+  });
+
   it("keeps a DID that names a space other than the running one", () => {
     const otherDid = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
     withNavigation(


### PR DESCRIPTION
## Why

A short name is only as good as the places it works. `top/42` resolves at the
CLI since #6890, but the shell — where a person actually clicks, and what a
pasted link opens — still knew nothing about collections: a URL naming a member
either failed or quietly opened the board. This is stage S3 of
`docs/plans/collection-naming-topics.md`, and it consumes the resolution that
stage landed rather than adding a second copy of it.

## What Changed

`/<space>/top/42` opens the member and titles the tab with it. `/<space>/top`
opens the board — not by parsing the resolver's refusal, but by calling the
function S2 already built to answer "which piece holds this collection", so the
prose of an error is never load-bearing. `/<space>/top/999` surfaces the
resolver's own words, `no member 999 in top`, through the load-error path the
shell already uses for a slug that does not resolve; no new error taxonomy.

The member's number reaches the item header and the board cards from the item's
own `shortName`, which the exemplar already published, so no pattern changed. A
**Copy reference** control sits beside Copy link on a member view.

**What the conversion drops, enumerated**, because the three defects S2 fixed
were all a resolution step returning less than it reached:

- The leftover path. A collection reference spends its one segment, so nothing
  is left behind — but a slug naming a **piece root** does not spend it, and
  that case was mishandled: the segment was dropped while the URL kept it, and
  the Copy reference control offered a citation naming a cell inside the piece
  rather than the page being shown. Found by review, fixed here rather than
  written down; an earlier draft of this description called the drop
  "undroppable by construction", which was false.
- The path from the board's root down to its namespace is dropped, because a
  page URL renders a piece and there is no page for a cell inside one.
- URL segments past the member are dropped, matching how segments after a piece
  id have always been dropped, and asserted.

One thing that would have shipped silently: the view mapper rebuilds a view
field by field when mapping a space DID onto its name, so without carrying the
member there, navigating to one would have landed on the board. Tested.

## Spelling

The plan's criteria spelled examples `//<space>/top/42`, the form decision 1
rules arrives with #6814. It does not parse today — that address answers
"Target must include a piece handle", while `/@<space>/top/2` returns the
title — so the copy control emits the form that resolves. Decision 1 now says
which spelling is current and that a criterion's examples mean whichever the
grammar accepts when it is checked, so nothing needs rewriting when #6814 lands.
The status table is swept to match main, each number verified against its
commit.

## Test plan

- `deno fmt --check`, `deno lint`, `deno task check`: clean.
- `packages/shell` 58 passed, `packages/runtime-client` 28, `packages/navigation`
  3, `packages/lib-shell` 5.
- `deno task integration shell` 9 passed, 1 failed; `integration runtime-client`
  1 passed. The failure is pre-existing and unrelated — `header-menu.test.ts`
  clicks a trigger with no layout box because the harness window is 756px and
  the breadcrumbs hide below 769px, and its wait checks length rather than
  whether the element rendered. Confirmed by reproducing it with the changed
  view file reverted to base while the rest of the change stood.
- A new browser test covers a member opening and a missing member, verified by
  two isolated mutations: the shell forgetting the member reds both, and the
  refusal no longer naming the collection reds the second alone with the first
  ignored so it could not lend redness.
- The doc, history-index, no-waitfor, control-character, conflict-marker,
  dependency, completion-slot and command-doc gates all pass.
- Review: codex through stage-loop and the repository's house review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kp8NcNXPougGPyJCEyYtob


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6896?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->




## One thing worth carrying past this branch

Eight instances of a single defect shape landed in this stage: a key, guard,
or description narrower than the state derived from it. A dedupe key on
`pieceId` while the citation read `pathAfter`; a subscription key omitting
the runtime it polls through; a pattern cache key gaining `scope` while its
invalidator kept deleting `${space}:${id}`; a type made exclusive while the
wire guard that reads untyped messages was not; and three more.

The part worth recording is that **the last three were each created by the
fix for the previous one.** `pathAfter` was added to the key to close one
finding; `scope` was added to the target in the same round and not to the
key; the key's own fix then traded silent staleness for a reload every
poll. Each fix was correct about the instance in front of it and left the
mechanism running.

What ended it was not care. It was a compile error — an explicit projection
closed by `satisfies Record<keyof Required<SlugReferenceTarget>, boolean>`,
so a new field on the target fails to build until someone classifies it as
semantic or not. The residual risk stops being structural and becomes
judgemental: a field classified wrongly is a decision visible in review,
not a silent gap in a list.

The generalizable claim: "remember to update X when you change Y" is not a
mitigation, and the moment to reach for the type system is the second
instance, not the seventh.

### The eighth was visible, which is the result

The compile-time check was predicted to move the risk from a silent gap to a
reviewable decision. It did. The eighth instance was a field classified
`refusal: false` in that projection — a decision written down where a
reviewer could read it, which a reviewer then read and disagreed with. It
cost one fix rather than a round of forensics. That is the check working,
not failing, and it is the only one of the eight that was visible before it
shipped.

The classification it settled on is neither of the obvious two: `refusal`
projects to its `code`. Keying the whole refusal would restore the original
defect, since `message` is prose that varies; dropping it collapses
`missing` and `missing-member` into one value and leaves a reader on the
wrong error. The code is a closed set whose distinctions are exactly the
ones a reader sees.

### A second habit worth carrying

Five times in this stage a correct procedure produced a wrong answer because
its scope went unstated: a search over added lines only, a search over three
spellings of a concept with more, a rename applied to one of two sites, a
probe whose instrumentation began after the thing it measured, and a sweep
over `src` that did not cover tests. Twice more, a new test passed with the
fix it was written for deleted.

The habit that fixes this is not "check twice". It is to **state the bound
of a check in the same breath as its result** — "four composite keys and 22
prose mentions across four packages' `src`" is a claim someone can falsify;
"I searched for it" is not.


## A known defect ships with this

The watch's serialization keeps its running and requested flags on the view,
while the invariant they enforce belongs to one watch. So a navigation or
runtime replacement landing inside an in-flight resolution can clear a
successor's flag and drop its coalesced request.

It costs redundant work and under a second of latency, and it **cannot put a
wrong piece on screen** — with the resolution state collapsed, a refresh reads
and pokes the selection rather than writing. Filed as **#6931** with the trace
and an inventory of the other three fields scoped the same way, two of which
are safe only because of where their write happens to sit.

Landing rather than fixing in place was a deliberate call: the local fix moves
two of four identically-scoped fields, which is the one-at-a-time pattern that
produced the instances this description already discusses. The ownership
change is its own work.
