### PR TITLE
fix(tasks): check the tasks subdirectories, and record why static's type bundles are out

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -251,7 +251,11 @@ difficulties getting coverage checks to pass, consider the information in
 there), and that list now names every workspace package. Most are covered in
 full; a few are partial by design. The `*.input.ts` transformer fixtures under
 `schema-generator` and `ts-transformers` name ambient wrappers the transformer
-supplies, so they do not compile on their own and are left out.
+supplies, so they do not compile on their own and are left out. The declaration
+bundles under `packages/static/assets/types` are left out for the same reason:
+they are the ambient types handed to the in-memory pattern compiler, so they
+redeclare what `packages/html` declares and use ambient-context forms that do
+not compile beside the tree they describe.
 
 Patterns are the exception `deno task check` does not own. It lists some pattern
 directories and checks them through the automatic-JSX environment the rest of

--- a/tasks/typecheck.test.ts
+++ b/tasks/typecheck.test.ts
@@ -16,6 +16,16 @@ import {
 
 const REPO_ROOT = dirname(dirname(fromFileUrl(import.meta.url)));
 
+/**
+ * Trees the task checks in full. What a package's own test run checks is
+ * whatever its test files happen to import, and the `tasks` run passes
+ * `--no-check`, so coverage here is what the repository actually relies
+ * on. A tree checked only in part belongs elsewhere:
+ * `packages/static/assets/types` holds declaration bundles that do not
+ * compile on their own, and patterns answer to `deno task cfcheck`.
+ */
+const FULLY_CHECKED_TREES = ["packages/ui", "tasks"];
+
 describe("typecheck", () => {
   describe("scopeOfPath()", () => {
     it("returns the workspace member owning a path", () => {
@@ -47,8 +57,9 @@ describe("typecheck", () => {
       expect(byScope.get("runner")).toContain("packages/runner");
       expect(byScope.get("test-support")).toContain("packages/test-support");
       // Glob entries expand to repository-relative files.
-      expect(byScope.get("tasks")).toContain("tasks/typecheck.ts");
+      expect(byScope.get("scripts")).toContain("scripts/bundle.ts");
       expect(byScope.get("ui")).toContain("packages/ui");
+      expect(byScope.get("tasks")).toContain("tasks");
       // Every path in every group belongs to the group's scope.
       for (const [scope, paths] of byScope) {
         for (const path of paths) {
@@ -57,27 +68,29 @@ describe("typecheck", () => {
       }
     });
 
-    it("covers every TypeScript file the ui package holds", async () => {
-      // A group naming part of a package type-checks that part and
-      // reports a clean run over the rest, so what this asserts is
-      // coverage rather than the shape of the entry that gives it. It
-      // reads the tree rather than a fixture, so a directory added to
-      // the package later is held to the same claim.
+    it("covers every TypeScript file in the trees it checks in full", async () => {
+      // An entry naming part of a tree type-checks that part and reports
+      // a clean run over the rest, so what this asserts is coverage
+      // rather than the shape of the entry that gives it. These trees
+      // are read from disk rather than from a fixture, so a directory
+      // added to one later is held to the same claim.
 
-      const byScope = await collectPathsByScope(REPO_ROOT);
-      const checked = byScope.get("ui") ?? [];
+      const checked = [...(await collectPathsByScope(REPO_ROOT)).values()]
+        .flat();
       const uncovered: string[] = [];
-      for await (
-        const entry of walk(join(REPO_ROOT, "packages", "ui"), {
-          includeDirs: false,
-          exts: [".ts", ".tsx"],
-        })
-      ) {
-        const file = relative(REPO_ROOT, entry.path);
-        const covered = checked.some((checkPath) =>
-          file === checkPath || file.startsWith(`${checkPath}/`)
-        );
-        if (!covered) uncovered.push(file);
+      for (const tree of FULLY_CHECKED_TREES) {
+        for await (
+          const entry of walk(join(REPO_ROOT, tree), {
+            includeDirs: false,
+            exts: [".ts", ".tsx"],
+          })
+        ) {
+          const file = relative(REPO_ROOT, entry.path);
+          const covered = checked.some((checkPath) =>
+            file === checkPath || file.startsWith(`${checkPath}/`)
+          );
+          if (!covered) uncovered.push(file);
+        }
       }
       expect(uncovered).toEqual([]);
     });

--- a/tasks/typecheck.ts
+++ b/tasks/typecheck.ts
@@ -82,11 +82,11 @@ const DIRS = [
   "packages/ts-transformers/src",
   "packages/ui",
   "packages/utils",
+  "tasks",
 ];
 
 // Glob patterns, expanded the way the shell used to expand them.
 const GLOBS = [
-  "tasks/*.ts",
   "scripts/*.ts",
   "packages/cli/*.ts",
   "packages/static/*.ts",


### PR DESCRIPTION
Follow-up to #6894, from measuring the rest of the tree for the same shape.

## Why

#6894 fixed one silently-partial tree. Measuring every workspace package the
same way turned up six partial ones, three of them undocumented. This addresses
two; `packages/cli` is deliberately left alone.

**`tasks` — accidental.** `"tasks/*.ts"` is a single-level glob, so
`tasks/check-test-topology.ts` is checked and `tasks/test-topology/gates.ts` is
not. Thirteen test files were checked by nothing:

- Nothing imports a test file, so the module graph from the checked entry points
  never reaches one. (The fifteen *source* files under those directories **were**
  already checked transitively — `tasks/check-test-topology.ts` imports them.)
- `tasks/deno.jsonc` runs its suite with `--no-check`, so the test run doesn't
  check them either.

Among the thirteen are the tests for `test-selection/` and `test-topology/` —
the machinery that decides which tests CI runs.

**`packages/static/assets/types` — deliberate, and now recorded.** These seven
files do not type-check standalone and should not be added: `jsx.d.ts` is
byte-identical to `packages/html/src/jsx.d.ts` (same md5, hence
`TS2300 Duplicate identifier 'Element'`), and `commonfabric.d.ts` uses
ambient-context initializers (`TS1039`, `TS1254`). They are the ambient types
handed to the in-memory pattern compiler. The omission was right and unwritten;
`AGENTS.md` now carries it beside the transformer-fixture exemption it already
documents.

## What Changed

`tasks/typecheck.ts` — `"tasks"` becomes a `DIRS` entry; the single-level
`"tasks/*.ts"` glob is dropped. `deno check tasks` is already clean across all
188 files, so this carries no backlog.

`tasks/typecheck.test.ts` — the ui coverage test from #6894 generalizes over a
`FULLY_CHECKED_TREES` list (`packages/ui`, `tasks`). A sibling assertion used
`tasks/typecheck.ts` as its example of a *glob* entry expanding to a file; that
is now a directory entry, so it points at `scripts/bundle.ts`, which still is
one.

`AGENTS.md` — records the `packages/static/assets/types` exemption.

## Test plan

The coverage test is red at the parent commit, naming all 28 files under the two
subdirectories, and green here.

The gate was mutation-tested. The first probe is the one worth reading, because
it **failed to discriminate** and corrected the diagnosis:

| mutation | before | after |
| --- | --- | --- |
| `TS2322` into `test-topology/gates.ts` | `Type check failed` | `Type check failed` |
| `TS2322` into `test-topology/gates.test.ts` | `ok  tasks (2.8s)` / `Type check complete.` | `Type check failed in 1 of 1 groups.` |

The first row is why this PR claims thirteen files rather than twenty-eight:
`gates.ts` was already reachable by import. The second row is the real gap.

Green locally: `deno fmt --check`, `deno lint`, `deno task check` (full tree),
`deno task test` in `tasks` (776 passed), `check-test-topology`,
`check-skill-facts`, `check-no-waitfor`, `check-conflict-markers`,
`check-control-characters`, `check-unused-deps`.

## Not in this change

`packages/cli` is also partial — 24 files under `fixtures/` and `integration/`,
checked by nothing (`cfcheck` walks only `packages/patterns` plus two connector
trees, and `packages/cli/test/run-tests.ts` sets `--no-check`). They all pass
`deno check` today, but 20 are `.tsx` patterns, and patterns compile under
classic-`h` JSX while `deno task check` uses automatic JSX. Adding them here
would check them under the wrong runtime; extending `cfcheck`'s tree list is
plausibly the right home. That is a call for whoever owns cfcheck.

`scripts/*.ts` was checked for the same single-level-glob defect and does not
have it — no `.ts` files in subdirectories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016et63G85fe5jby8tKxoDV4

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6897?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

