### PR TITLE
feat(piece): assigning a bound name refuses unless it is forced (S2b)

### DIFF
--- a/docs/plans/cli-completion-coverage.md
+++ b/docs/plans/cli-completion-coverage.md
@@ -366,9 +366,11 @@ id. Both are values the flag takes, and the slug is the readable half of that
 vocabulary, so it leads. The annotation says which a candidate is and, where the
 slug resolves to a piece the listing named, what it points at.
 
-`piece set-slug`'s slug positional completes the same set: naming an existing
-slug re-points it, which is the case completion helps with, and a slug being
-coined for the first time is a word nothing can offer.
+`piece set-slug`'s slug positional completes the same set. Naming an existing
+slug is refused unless `--force` says to take it, and that is the case
+completion helps with: a name the caller means to move has to be spelled
+exactly to be moved, while a slug being coined for the first time is a word
+nothing can offer.
 
 The listing is bounded by the space's index, which names slugs assigned since it
 existed — so an older slug still resolves and is not offered. Nothing can

--- a/docs/plans/collection-naming-topics.md
+++ b/docs/plans/collection-naming-topics.md
@@ -16,7 +16,7 @@ This block is LIVE: the change that moves a stage updates it here.
 | S1 — the library and the exemplar board own a member namespace | on main (#6882) |
 | S1b — index rows are the members | built, in review |
 | S2 — `top/42` resolves at the CLI | built, in review |
-| S2b — assignment refuses by default | not started |
+| S2b — assignment refuses by default | built, in review |
 | S3 — the shell opens `/<space>/top/42` | not started |
 | S4 — `#42` in text | building |
 | S6 — graft onto Topics | not started; Mike's call after S4 |
@@ -171,7 +171,13 @@ The first half of the spec's step 2.
 
 1. `set-slug` on a bound name refuses and names the current target; `--force`
    steals. The check is a claim inside the transaction: a test with two
-   writers has exactly one win.
+   writers has exactly one win. Recorded: the overlap is expressible at one
+   runtime, because `editWithRetry` runs its body synchronously, so two
+   assignments started together both read the name before either transaction
+   commits and the second reads what the first staged. What that shape does
+   not reach is the cross-session case, where the loser's replica is stale
+   and the commit precondition is what serializes them; criterion 2's pair
+   covers that at the transaction level.
 2. Whether a synced read inside `editWithRetry` becomes a commit precondition
    is settled by that test and recorded in the spec's open-questions list.
 3. `--force` has a completion slot and a README sentence.

--- a/docs/plans/collection-naming-topics.md
+++ b/docs/plans/collection-naming-topics.md
@@ -182,6 +182,15 @@ The first half of the spec's step 2.
    is settled by that test and recorded in the spec's open-questions list.
 3. `--force` has a completion slot and a README sentence.
 
+What a forced steal costs, found while demonstrating one: the assignment
+stamps `slug` on the target document's root, and pointing the name back at
+its old target does not clear the entry from the one that took it. So a
+member a steal passed through keeps a canonical URL naming a slug it no
+longer holds, which is the reverse-map gap step 1 of the spec's
+implementation road closes, and until then nothing in the `cf` surface clears
+it — the demo's restoration needed a raw metadata write. S3 renders URLs from
+that entry, so a steal on the exemplar board poisons what S3 displays.
+
 ### S3 — The shell opens `/<space>/top/42`
 
 Scope: `packages/shell`, `packages/runtime-client`, shell integration tests.

--- a/docs/plans/collection-naming-topics.md
+++ b/docs/plans/collection-naming-topics.md
@@ -170,14 +170,21 @@ Demo: `cf cell get //<space>/top/2 title` on the local exemplar board.
 The first half of the spec's step 2.
 
 1. `set-slug` on a bound name refuses and names the current target; `--force`
-   steals. The check is a claim inside the transaction: a test with two
-   writers has exactly one win. Recorded, after three attempts to describe
-   the interleaving a one-runtime test achieves: it does not pin one, and
-   the paragraph should not claim one. Two things are true and both are
-   tested. The single-runtime test asserts the outcome — two assignments of
-   one free name leave exactly one holder — and its assertions hold however
-   the two were ordered. The racing path is a runtime guarantee, pinned by
-   the cross-session pair: the claim's read joins the commit's read set, so a
+   steals — every bound name, including one whose value is a link cycle,
+   which is the state an operator forces to escape. That last case rests on
+   the redirect write carrying a schema: a write handle with none resolves
+   the value it is about to replace to find one, and resolving a cycle
+   throws. The schema names nothing to follow, so the write pulls the one
+   document it writes, and only the redirect write carries it.
+
+   The check is a claim inside the transaction: a test with two writers has
+   exactly one win. Recorded, after three attempts to describe the
+   interleaving a one-runtime test achieves: it does not pin one, and the
+   paragraph should not claim one. Two things are true and both are tested.
+   The single-runtime test asserts the outcome — two assignments of one free
+   name leave exactly one holder — and its assertions hold however the two
+   were ordered. The racing path is a runtime guarantee, pinned by the
+   cross-session pair: the claim's read joins the commit's read set, so a
    commit another writer overtakes is rejected and `editWithRetry` re-runs
    the body against what that writer left, which then declines. That is the
    shape `packages/runner/src/ensure-space-root.ts` states for the space

--- a/docs/plans/collection-naming-topics.md
+++ b/docs/plans/collection-naming-topics.md
@@ -14,11 +14,11 @@ This block is LIVE: the change that moves a stage updates it here.
 | --- | --- |
 | S0 — decisions ruled, plan filed | on main (#6882) |
 | S1 — the library and the exemplar board own a member namespace | on main (#6882) |
-| S1b — index rows are the members | built, in review |
-| S2 — `top/42` resolves at the CLI | built, in review |
-| S2b — assignment refuses by default | built, in review |
-| S3 — the shell opens `/<space>/top/42` | not started |
-| S4 — `#42` in text | building |
+| S1b — index rows are the members | on main (#6886) |
+| S2 — `top/42` resolves at the CLI | on main (#6890) |
+| S2b — assignment refuses by default | built, in review (#6898) |
+| S3 — the shell opens `/<space>/top/42` | built, in review (#6896) |
+| S4 — `#42` in text | on main (#6887) |
 | S6 — graft onto Topics | not started; Mike's call after S4 |
 | S5 — deferred, not scheduled | — |
 

--- a/docs/plans/collection-naming-topics.md
+++ b/docs/plans/collection-naming-topics.md
@@ -171,15 +171,17 @@ The first half of the spec's step 2.
 
 1. `set-slug` on a bound name refuses and names the current target; `--force`
    steals. The check is a claim inside the transaction: a test with two
-   writers has exactly one win. Recorded: the overlap is expressible at one
-   runtime, because `editWithRetry` runs its body synchronously, so two
-   assignments started together both run before either transaction commits,
-   and the second reads the name as already pointing at the first's target
-   and declines — no rejection, no retry. What that shape does not reach is
-   the cross-session case, where the loser's replica is behind and the
-   stale-basis rejection and the re-run off it are what serialize the two;
-   that is the shape `packages/runner/src/ensure-space-root.ts` states for
-   the space root, and criterion 2's pair pins the read it depends on.
+   writers has exactly one win. Recorded, after three attempts to describe
+   the interleaving a one-runtime test achieves: it does not pin one, and
+   the paragraph should not claim one. Two things are true and both are
+   tested. The single-runtime test asserts the outcome — two assignments of
+   one free name leave exactly one holder — and its assertions hold however
+   the two were ordered. The racing path is a runtime guarantee, pinned by
+   the cross-session pair: the claim's read joins the commit's read set, so a
+   commit another writer overtakes is rejected and `editWithRetry` re-runs
+   the body against what that writer left, which then declines. That is the
+   shape `packages/runner/src/ensure-space-root.ts` states for the space
+   root.
 2. Whether a synced read inside `editWithRetry` becomes a commit precondition
    is settled by that test and recorded in the spec's open-questions list.
 3. `--force` has a completion slot and a README sentence, on both commands

--- a/docs/plans/collection-naming-topics.md
+++ b/docs/plans/collection-naming-topics.md
@@ -173,23 +173,32 @@ The first half of the spec's step 2.
    steals. The check is a claim inside the transaction: a test with two
    writers has exactly one win. Recorded: the overlap is expressible at one
    runtime, because `editWithRetry` runs its body synchronously, so two
-   assignments started together both read the name before either transaction
-   commits and the second reads what the first staged. What that shape does
-   not reach is the cross-session case, where the loser's replica is stale
-   and the commit precondition is what serializes them; criterion 2's pair
-   covers that at the transaction level.
+   assignments started together both run before either transaction commits,
+   and the second reads the name as already pointing at the first's target
+   and declines — no rejection, no retry. What that shape does not reach is
+   the cross-session case, where the loser's replica is behind and the
+   stale-basis rejection and the re-run off it are what serialize the two;
+   that is the shape `packages/runner/src/ensure-space-root.ts` states for
+   the space root, and criterion 2's pair pins the read it depends on.
 2. Whether a synced read inside `editWithRetry` becomes a commit precondition
    is settled by that test and recorded in the spec's open-questions list.
-3. `--force` has a completion slot and a README sentence.
+3. `--force` has a completion slot and a README sentence, on both commands
+   that assign a name: `set-slug` and `piece new --slug`.
+4. A caller whose own rule about a free name is wider than the library's
+   carries that rule's answer into the transaction as `takeFrom` rather than
+   forcing over what it read. Forcing after a standalone read spends the
+   claim — two callers that both read a name as free would both take it — so
+   the rule and the claim are held at once, and two concurrent callers still
+   end with one holder whichever notion of free they hold.
 
-What a forced steal costs, found while demonstrating one: the assignment
-stamps `slug` on the target document's root, and pointing the name back at
-its old target does not clear the entry from the one that took it. So a
-member a steal passed through keeps a canonical URL naming a slug it no
-longer holds, which is the reverse-map gap step 1 of the spec's
-implementation road closes, and until then nothing in the `cf` surface clears
-it — the demo's restoration needed a raw metadata write. S3 renders URLs from
-that entry, so a steal on the exemplar board poisons what S3 displays.
+What a forced reassignment leaves behind. Taking a name now clears the `slug`
+entry from the document it takes it from, in the transaction that writes the
+new redirect, so no piece is left claiming a name it no longer holds. What
+remains is structural and still step 1's: the entry is single-valued, so a
+document reachable under two names only ever claims the later one, and a name
+pointing inside a piece stamps no entry at all, which leaves a
+collection-targeted name absent from the reverse map. S3 renders URLs from
+that map, so those two shape what it can say about a member.
 
 ### S3 — The shell opens `/<space>/top/42`
 

--- a/docs/specs/collection-naming.md
+++ b/docs/specs/collection-naming.md
@@ -501,16 +501,23 @@ a structured form that distinguishes the two and designates one as canonical.
 **This is a prerequisite: giving collections member names before it lands makes
 URL rewriting nondeterministic.**
 
-**2. Make name assignment refuse by default.** `setSlugLink` does not read the
-slug cell before writing it, so assigning an assigned name overwrites it
-silently. Sync the cell, read it inside the transaction, refuse when it is
-already bound, and take an explicit flag to steal. `editWithRetry` re-runs its
-body on a retryable rejection, so the check is a claim rather than a
-time-of-check race. Confirm that a synced read inside the transaction becomes a
-commit precondition before relying on it.
+**2. Make name assignment refuse by default.** Two halves, and only the first
+has landed.
 
-The same write path needs a **cross-space target**, which personal bindings
-depend on entirely: a binding lives in the reader's home space and points at a
+Landed: `setSlugLink` (`packages/piece/src/slugs.ts`) syncs the name and reads
+it inside the transaction it commits in, refusing a name pointing anywhere but
+where the caller said to take it from, and taking it under an explicit flag.
+Taking a name clears the `slug` entry from the document root it takes it from,
+in the same transaction. A caller whose own rule about a free name is wider
+than this one's — the harness tool's is, counting a name that resolves to no
+piece as free — carries that rule's answer in as the state to take from, so
+the rule is judged against what the write lands on rather than against a read
+the write has outlived. The read is a commit precondition, which is what makes
+the refusal a claim rather than a time-of-check race; the evidence is under
+"Settled" below.
+
+Still to build: a **cross-space target**, which personal bindings depend on
+entirely: a binding lives in the reader's home space and points at a
 collection in someone else's. `setPieceSlug` builds its target cell in the space
 it was configured with and drops the space an LLM-friendly reference carries, so
 a target outside that space cannot be written today. Resolution already handles
@@ -568,6 +575,23 @@ document settles are worth carrying over rather than re-deciding: a reference's
 visible label and its citation spelling are different, and a label that a person
 has edited stops tracking the destination's name.
 
+## Settled
+
+A question this document once recorded as open, kept here with what answered
+it so that a later reader finds the decision rather than re-opening it.
+
+**Whether a synced read inside an `editWithRetry` body becomes a commit
+precondition**, which is what step 2 rests on. Answered yes, 2026-09-04, and
+the answer is the read's alone rather than the surrounding write's. Two
+sessions over one memory server with fan-out held: the second loads a slug
+document, the first rewrites it, and the second then reads that document and
+writes a different one. Its commit is rejected `ConflictError`; the identical
+write with the read removed commits. That rejection is in the retryable class,
+so `editWithRetry` catches up and re-runs the body, which is what makes a
+read-then-refuse a claim rather than a time-of-check race.
+`packages/piece/test/slug.test.ts` holds the pair that differs in the read
+alone.
+
 ## Deliberately open
 
 Recorded rather than settled, so that a later answer is a decision and not a
@@ -613,18 +637,6 @@ publishes one — `NamingDeclaration` in
 `packages/patterns/collection-naming/naming.ts`, ruled 2026-09-03 in
 `docs/plans/collection-naming-topics.md` (decision 7) — and whether that shape
 becomes the standard every collection declares is what remains open.
-
-**Whether a synced read inside an `editWithRetry` body becomes a commit
-precondition**, which is what step 2 rests on. Answered yes, 2026-09-04, and
-the answer is the read's alone rather than the surrounding write's. Two
-sessions over one memory server with fan-out held: the second loads a slug
-document, the first rewrites it, and the second then reads that document and
-writes a different one. Its commit is rejected `ConflictError`; the identical
-write with the read removed commits. That rejection is in the retryable class,
-so `editWithRetry` catches up and re-runs the body, which is what makes a
-read-then-refuse a claim rather than a time-of-check race.
-`packages/piece/test/slug.test.ts` holds the pair that differs in the read
-alone.
 
 **Whether a collection accepting names from people** reuses the space-level
 claim path or needs its own.

--- a/docs/specs/collection-naming.md
+++ b/docs/specs/collection-naming.md
@@ -617,7 +617,16 @@ publishes one — `NamingDeclaration` in
 becomes the standard every collection declares is what remains open.
 
 **Whether a synced read inside an `editWithRetry` body becomes a commit
-precondition**, which is what step 2 rests on.
+precondition**, which is what step 2 rests on. Answered yes, 2026-09-04, and
+the answer is the read's alone rather than the surrounding write's. Two
+sessions over one memory server with fan-out held: the second loads a slug
+document, the first rewrites it, and the second then reads that document and
+writes a different one. Its commit is rejected `ConflictError`; the identical
+write with the read removed commits. That rejection is in the retryable class,
+so `editWithRetry` catches up and re-runs the body, which is what makes a
+read-then-refuse a claim rather than a time-of-check race.
+`packages/piece/test/slug.test.ts` holds the pair that differs in the read
+alone.
 
 **Whether a collection accepting names from people** reuses the space-level
 claim path or needs its own.

--- a/docs/specs/collection-naming.md
+++ b/docs/specs/collection-naming.md
@@ -575,9 +575,7 @@ discovery. Five of these block work rather than merely awaiting it, and a plan
 should sequence around them: the sigil question and the renderer's preference
 order both block step 5 outright, a machine-readable policy is what the
 consumer rules in Part 1 rest on, the collection-scope claim path is part of
-step 3, and sibling bindings decide the second rung of the resolver. Step 2
-names a sixth in its own text, the commit precondition it asks to be confirmed
-first.
+step 3, and sibling bindings decide the second rung of the resolver.
 
 **A qualifier for revision, time, or branch.** No slot is reserved for naming a
 thing *as of* something, and this is not hypothetical: memory carries causal

--- a/docs/specs/collection-naming.md
+++ b/docs/specs/collection-naming.md
@@ -494,10 +494,13 @@ and read by `handlePieceGetSlug`
 (`packages/runtime-client/backends/runtime-processor.ts`); the shell rewrites a
 visited identity URL to that name. One slot cannot hold both a member name and a
 space-level name, so the canonical URL becomes whichever was written last. Two
-further gaps close here: the entry is never cleared from a previous target when
-a name is retargeted, and `setPieceSlug` writes target metadata only for piece
-roots, so a collection-targeted name has no reverse entry at all. The map needs
-a structured form that distinguishes the two and designates one as canonical.
+further gaps were to close here, and one of them has closed ahead of this
+step: an assignment clears the `slug` entry from the holder it takes a name
+from, in the transaction that writes the new redirect, so a retarget no longer
+leaves a document claiming a name it has lost (step 2). The other remains —
+`setPieceSlug` writes target metadata only for piece roots, so a
+collection-targeted name has no reverse entry at all. The map needs a
+structured form that distinguishes the two and designates one as canonical.
 **This is a prerequisite: giving collections member names before it lands makes
 URL rewriting nondeterministic.**
 

--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -1336,15 +1336,19 @@ resolves into a piece rather than to one names a collection, and is refused the
 way a taken name is: it is an address a person opens. Any other failure refuses
 the call saying the availability could not be established, because reporting a
 storage error as a free name would write over whatever is there. That check is
-what stops a caller from taking over a name a person already opens: assigning a
-slug is a blind write, so without it a model naming `home` would repoint `home`
-at whatever it referenced. It is a check and not a lock — resolution and
-assignment are not atomic, so a slug that becomes taken in between is still
-overwritten — and it closes the case that arises rather than a race against a
-concurrent writer. A slug that already points at the very piece the token names
-answers `ok` rather than a refusal: the request is already true. `assign_slug`
-sets the address, not the title: what the piece list displays is the pattern's
-own `NAME` result, so a pattern that wants a title sets `NAME` in its source.
+what stops a caller from taking over a name a person already opens, and it is
+the narrower of the two rules in play: the assignment underneath refuses a name
+pointing anywhere at all, while this one competes only with pieces and
+collections, so a name whose document holds no usable redirect is free here and
+not there. The check's answer is carried into the write as the state to take the
+name from, not forced past the wider rule — forcing would spend the claim the
+assignment makes, and two calls that both read a name as free would both take
+it. Carried in, the write judges this rule against what it lands on, so a name
+bound between the check and the write is refused there instead. A slug that
+already points at the very piece the token names answers `ok` rather than a
+refusal: the request is already true. `assign_slug` sets the address, not the
+title: what the piece list displays is the pattern's own `NAME` result, so a
+pattern that wants a title sets `NAME` in its source.
 
 Every `run_pattern` invocation persists a piece in the configured space, named
 or not. A cancelled run stops its piece, but no piece is ever deleted, and each

--- a/packages/cf-harness/src/tools/assign-slug.ts
+++ b/packages/cf-harness/src/tools/assign-slug.ts
@@ -6,6 +6,7 @@ import {
   readSlugBinding,
   resolvePieceAddress,
   SlugAssignedError,
+  SlugReleasedError,
   SlugResolutionError,
 } from "@commonfabric/piece";
 import type { PiecesController } from "@commonfabric/piece/ops";
@@ -386,6 +387,16 @@ export const assignSlugTool: HarnessToolDefinition<
           `assign_slug slug "${slug}" was taken while this call was ` +
             `deciding, and assigning would repoint that address. Choose ` +
             `another slug.`,
+        );
+      }
+      // The name moved the other way and now points nowhere, so nobody is
+      // holding it and the answer is the one an unestablished availability
+      // gets: read it again rather than choose another name.
+      if (error instanceof SlugReleasedError) {
+        return errorOutput(
+          `assign_slug slug "${slug}" changed while this call was deciding ` +
+            `and now names nothing. Nothing was assigned. Try the same call ` +
+            `again.`,
         );
       }
       return errorOutput(

--- a/packages/cf-harness/src/tools/assign-slug.ts
+++ b/packages/cf-harness/src/tools/assign-slug.ts
@@ -370,13 +370,24 @@ export const assignSlugTool: HarnessToolDefinition<
         `assign_slug could not establish whether slug "${slug}" is available: ${availability.reason}. Nothing was assigned. Try the same call again.`,
       );
     }
+    // The registry join goes first, so a failure between the two leaves a
+    // listed-but-unnamed piece — visible and reachable by its handle —
+    // rather than an orphan name pointing outside the list. Membership is
+    // ensured rather than appended: a retry after exactly that failure must
+    // not list the piece twice.
+    //
+    // Its own try, because what the two failures leave behind differs: this
+    // one leaves nothing, and the refusals below leave a listed piece. A
+    // sentence attached to the catch rather than to the state it describes
+    // would say the piece is listed when the listing is what failed.
     try {
-      // The registry join goes first, so a failure between the two leaves a
-      // listed-but-unnamed piece — visible and reachable by its handle —
-      // rather than an orphan name pointing outside the list. Membership is
-      // ensured rather than appended: a retry after exactly that failure
-      // must not list the piece twice.
       await ensureRegistered(pieces, cell, targetId);
+    } catch (error) {
+      return errorOutput(
+        `assign_slug failed while listing the piece: ${errorMessage(error)}`,
+      );
+    }
+    try {
       await assignSlug(pieces, cell, slug, { takeFrom: availability.binding });
     } catch (error) {
       // The name was bound between this call's reading of it and its write,

--- a/packages/cf-harness/src/tools/assign-slug.ts
+++ b/packages/cf-harness/src/tools/assign-slug.ts
@@ -382,10 +382,15 @@ export const assignSlugTool: HarnessToolDefinition<
       // The name was bound between this call's reading of it and its write,
       // so the answer is the same one a name found taken gets, and for the
       // same reason: assigning now would repoint an address someone holds.
+      // The registry join above has already committed, so every refusal from
+      // here reports what it left: the name was not assigned, and the piece
+      // is listed. A caller told "nothing was assigned" would read that as
+      // all-or-nothing and never look for the piece it did not mean to list.
       if (error instanceof SlugAssignedError) {
         return errorOutput(
           `assign_slug slug "${slug}" was taken while this call was ` +
-            `deciding, and assigning would repoint that address. Choose ` +
+            `deciding, and assigning would repoint that address. The slug ` +
+            `was not assigned and the piece is listed in this space. Choose ` +
             `another slug.`,
         );
       }
@@ -395,12 +400,14 @@ export const assignSlugTool: HarnessToolDefinition<
       if (error instanceof SlugReleasedError) {
         return errorOutput(
           `assign_slug slug "${slug}" changed while this call was deciding ` +
-            `and now names nothing. Nothing was assigned. Try the same call ` +
-            `again.`,
+            `and now names nothing. The slug was not assigned and the piece ` +
+            `is listed in this space. Try the same call again.`,
         );
       }
       return errorOutput(
-        `assign_slug failed while naming the piece: ${errorMessage(error)}`,
+        `assign_slug failed while naming the piece: ${
+          errorMessage(error)
+        }. The piece is listed in this space.`,
       );
     }
     const url = namedPieceUrl(pieces, slug);

--- a/packages/cf-harness/src/tools/assign-slug.ts
+++ b/packages/cf-harness/src/tools/assign-slug.ts
@@ -138,13 +138,18 @@ const SLUG_CODE_STATES: Readonly<
  * whether it names something else a person opens, or whether that could not
  * be established at all.
  *
- * Assignment is a blind write: the slug document is pointed at the piece
- * whatever it held before, and last writer wins. So without asking first, a
- * request naming a slug a person already opens would repoint that name at
- * whatever the caller passed. That makes an unanswered question a refusal
- * rather than a "free": a resolution that failed operationally says nothing
- * about what the slug holds, and treating it as vacancy would reopen exactly
- * the overwrite this asks to prevent.
+ * Assignment refuses a name that is already bound, so this asks first for a
+ * different reason than the write does. The write's rule is "bound at all";
+ * this one is "names a piece or a collection a person opens", and a name
+ * whose document holds no usable redirect competes with nothing. Asking here
+ * is what lets the refusal name which of the two it is, and the assignment
+ * that follows an answer of "free" is forced, so the two rules never disagree
+ * about one name.
+ *
+ * That also makes an unanswered question a refusal rather than a "free": a
+ * resolution that failed operationally says nothing about what the slug
+ * holds, and treating it as vacancy would repoint a name this side never
+ * established was free.
  *
  * The outcomes are told apart by the typed `code` `resolvePieceAddress`
  * carries on its `SlugResolutionError`, never by the message text.
@@ -354,7 +359,9 @@ export const assignSlugTool: HarnessToolDefinition<
       // ensured rather than appended: a retry after exactly that failure
       // must not list the piece twice.
       await ensureRegistered(pieces, cell, targetId);
-      await assignSlug(pieces, cell, slug);
+      // Forced because `slugAvailability` above is this tool's own answer to
+      // whether the name is free, and it is the narrower of the two rules.
+      await assignSlug(pieces, cell, slug, { force: true });
     } catch (error) {
       return errorOutput(
         `assign_slug failed while naming the piece: ${errorMessage(error)}`,

--- a/packages/cf-harness/src/tools/assign-slug.ts
+++ b/packages/cf-harness/src/tools/assign-slug.ts
@@ -3,7 +3,9 @@ import { parseLLMFriendlyLink } from "@commonfabric/runner/shared";
 import {
   assignSlug,
   pieceId,
+  readSlugBinding,
   resolvePieceAddress,
+  SlugAssignedError,
   SlugResolutionError,
 } from "@commonfabric/piece";
 import type { PiecesController } from "@commonfabric/piece/ops";
@@ -142,9 +144,15 @@ const SLUG_CODE_STATES: Readonly<
  * different reason than the write does. The write's rule is "bound at all";
  * this one is "names a piece or a collection a person opens", and a name
  * whose document holds no usable redirect competes with nothing. Asking here
- * is what lets the refusal name which of the two it is, and the assignment
- * that follows an answer of "free" is forced, so the two rules never disagree
- * about one name.
+ * is what lets the refusal name which of the two it is.
+ *
+ * The answer is carried into the write as `takeFrom` rather than forced over
+ * whatever is there. Forcing would spend the claim the assignment makes: two
+ * calls that both read this name as free would both take it, and one would
+ * overwrite the other silently — the very race the claim closes. Handing the
+ * binding this rule was judged against to the transaction keeps the rule and
+ * the claim at once, so a name bound under this call is refused by the write
+ * even though this read called it free.
  *
  * That also makes an unanswered question a refusal rather than a "free": a
  * resolution that failed operationally says nothing about what the slug
@@ -158,11 +166,21 @@ const slugAvailability = async (
   pieces: PiecesController,
   slug: string,
 ): Promise<
-  | { state: "free" }
+  | { state: "free"; binding: string | null }
   | { state: "taken"; pieceId: string }
   | { state: "in-use" }
   | { state: "unknown"; reason: string }
 > => {
+  // The binding this rule is about to be applied to, read before the rule
+  // runs so that an answer of "free" and the state it was reached from are
+  // the same observation. A binding that cannot be read is an unestablished
+  // answer for the same reason a failed resolution is.
+  let binding: string | null;
+  try {
+    binding = await readSlugBinding(pieces, slug);
+  } catch (error) {
+    return { state: "unknown", reason: errorMessage(error) };
+  }
   try {
     const holder = await resolvePieceAddress(pieces, slug);
     return { state: "taken", pieceId: holder };
@@ -174,9 +192,8 @@ const slugAvailability = async (
     // Only `unknown` carries the resolver's text. The other two are answers
     // about what the space holds, and their refusals name the caller's own
     // slug and nothing the caller did not already have.
-    return state === "unknown"
-      ? { state, reason: errorMessage(error) }
-      : { state };
+    if (state === "unknown") return { state, reason: errorMessage(error) };
+    return state === "free" ? { state, binding } : { state };
   }
 };
 
@@ -359,10 +376,18 @@ export const assignSlugTool: HarnessToolDefinition<
       // ensured rather than appended: a retry after exactly that failure
       // must not list the piece twice.
       await ensureRegistered(pieces, cell, targetId);
-      // Forced because `slugAvailability` above is this tool's own answer to
-      // whether the name is free, and it is the narrower of the two rules.
-      await assignSlug(pieces, cell, slug, { force: true });
+      await assignSlug(pieces, cell, slug, { takeFrom: availability.binding });
     } catch (error) {
+      // The name was bound between this call's reading of it and its write,
+      // so the answer is the same one a name found taken gets, and for the
+      // same reason: assigning now would repoint an address someone holds.
+      if (error instanceof SlugAssignedError) {
+        return errorOutput(
+          `assign_slug slug "${slug}" was taken while this call was ` +
+            `deciding, and assigning would repoint that address. Choose ` +
+            `another slug.`,
+        );
+      }
       return errorOutput(
         `assign_slug failed while naming the piece: ${errorMessage(error)}`,
       );

--- a/packages/cf-harness/test/assign-slug.test.ts
+++ b/packages/cf-harness/test/assign-slug.test.ts
@@ -418,6 +418,59 @@ describe("assign-slug", () => {
       expect(output.message).toContain("space root unavailable");
     });
 
+    it("reports a name released between the availability read and the write as one to retry", async () => {
+      // The tool judges a name free, and the name comes to point nowhere
+      // before the write lands. That is not the same outcome as a name
+      // somebody else took: nobody holds it, so the answer is to read it
+      // again rather than to choose another name. The registry join sits
+      // between the two, which is where the release is staged.
+      await linkDefaultPattern();
+      const engine = createEngine();
+      const created = await createPiece(engine);
+      // A name pointing at a plain document: free by this tool's rule, and a
+      // binding the claim carries, so the release below is a change to it.
+      const plain = pieces.runtime.getCell(
+        pieces.getSpace(),
+        { space: pieces.getSpace(), random: "released-target" },
+      );
+      await pieces.runtime.editWithRetry((tx) => {
+        plain.withTx(tx).set({ value: 1 });
+      });
+      await setSlugLink(pieces, "doubling-report", plain);
+
+      const slugCell = pieces.runtime.getCellFromEntityId(
+        pieces.getSpace(),
+        entityIdFrom(slugIdForSpace(pieces.getSpace(), "doubling-report")),
+      );
+      const originalAdd = pieces.add.bind(pieces);
+      pieces.add = async (cells) => {
+        await originalAdd(cells);
+        // The join has landed and the availability answer is already read;
+        // the name now points at nothing.
+        await pieces.runtime.editWithRetry((tx) => {
+          slugCell.withTx(tx).setRawUntyped("not a redirect");
+        });
+      };
+      const result = await engine.invokeBuiltinTool("assign_slug", {
+        token: created.resultRef,
+        slug: "doubling-report",
+      });
+      pieces.add = originalAdd;
+
+      const output = result.output as AssignSlugToolErrorOutput;
+      expect(output.status).toBe("error");
+      expect(output.message).toContain("doubling-report");
+      expect(output.message).toContain("names nothing");
+      expect(output.message).toContain("Try the same call again");
+      // The registry join landed before the refusal, so the answer says the
+      // piece is listed rather than that nothing happened.
+      expect(output.message).toContain("the piece is listed");
+      expect(output.message).not.toContain("Nothing was assigned");
+      // Told to retry rather than to choose another name, which is the
+      // answer a name somebody else holds gets.
+      expect(output.message).not.toContain("Choose another slug");
+    });
+
     it("does not list the piece twice when retried after a failed assignment", async () => {
       // A first call can join the registry and then fail at the slug write.
       // The retry must settle the name without appending a second entry.
@@ -489,8 +542,9 @@ describe("assign-slug", () => {
     it("refuses when the slug's availability could not be established, assigning nothing", async () => {
       // A resolution that fails operationally — storage error, sync that
       // never landed — says nothing about what the slug holds. Reading it as
-      // vacancy would send the call on to the blind assignment the
-      // availability check exists to prevent.
+      // vacancy would send the call on to take a name this side never
+      // established was free, which is what the availability check exists to
+      // prevent.
       await linkDefaultPattern();
       const engine = createEngine();
       const created = await createPiece(engine);

--- a/packages/cf-harness/test/assign-slug.test.ts
+++ b/packages/cf-harness/test/assign-slug.test.ts
@@ -193,9 +193,11 @@ describe("assign-slug", () => {
     });
 
     it("refuses a slug that already names another piece, leaving the address where it pointed", async () => {
-      // Assigning a slug is a blind write, so a second call naming the same
-      // slug would repoint an address a person already opens. The refusal is
-      // a pre-flight one, so the attempt costs a message and nothing else.
+      // A second call naming the same slug would repoint an address a person
+      // already opens. The refusal is a pre-flight one, so the attempt costs
+      // a message and nothing else — and it is the one that names which kind
+      // of address is in the way, where the assignment's own refusal
+      // underneath would only say the name is taken.
       await linkDefaultPattern();
       const engine = createEngine();
       const first = await createPiece(engine, 21);

--- a/packages/cf-harness/test/assign-slug.test.ts
+++ b/packages/cf-harness/test/assign-slug.test.ts
@@ -256,6 +256,35 @@ describe("assign-slug", () => {
       });
     });
 
+    it("takes a name whose document points at no piece, which this tool calls free", async () => {
+      // The tool's availability rule competes only with pieces and
+      // collections, so a name redirecting to a plain document is free here
+      // even though the assignment underneath refuses a bound name by
+      // default. Forcing is what keeps the two rules from disagreeing.
+      await linkDefaultPattern();
+      const engine = createEngine();
+      const created = await createPiece(engine);
+      const plain = pieces.runtime.getCell(
+        pieces.getSpace(),
+        { space: pieces.getSpace(), random: "plain" },
+      );
+      await pieces.runtime.editWithRetry((tx) => {
+        plain.withTx(tx).set({ value: 1 });
+      });
+      await setSlugLink(pieces, "doubling-report", plain);
+
+      const result = await engine.invokeBuiltinTool("assign_slug", {
+        token: created.resultRef,
+        slug: "doubling-report",
+      });
+
+      const output = result.output as AssignSlugToolSuccessOutput;
+      expect(output.status).toBe("ok");
+      expect(await resolvePieceAddress(pieces, "doubling-report")).toBe(
+        created.pieceId,
+      );
+    });
+
     it("answers ok for a slug already pointing at the very piece the token names", async () => {
       // The request is already true, so saying so beats refusing it — a
       // retried call settles on the outcome instead of failing.

--- a/packages/cf-harness/test/assign-slug.test.ts
+++ b/packages/cf-harness/test/assign-slug.test.ts
@@ -260,7 +260,8 @@ describe("assign-slug", () => {
       // The tool's availability rule competes only with pieces and
       // collections, so a name redirecting to a plain document is free here
       // even though the assignment underneath refuses a bound name by
-      // default. Forcing is what keeps the two rules from disagreeing.
+      // default. Carrying the binding this rule was judged against into the
+      // write is what lets the wider rule stand without spending the claim.
       await linkDefaultPattern();
       const engine = createEngine();
       const created = await createPiece(engine);
@@ -282,6 +283,46 @@ describe("assign-slug", () => {
       expect(output.status).toBe("ok");
       expect(await resolvePieceAddress(pieces, "doubling-report")).toBe(
         created.pieceId,
+      );
+    });
+
+    it("gives a free name to exactly one of two calls racing for it", async () => {
+      // Both calls read the name as free, so both reach the write, and the
+      // write is where exactly one of them can win. Forcing over the read
+      // instead would let the loser overwrite the winner and report success.
+      // The two tokens name different pieces, so the address the name ends
+      // up holding says which call won rather than being true either way.
+      await linkDefaultPattern();
+      const engine = createEngine();
+      const first = await createPiece(engine, 21);
+      const second = await createPiece(engine, 22);
+      expect(first.pieceId).not.toBe(second.pieceId);
+
+      const results = await Promise.all([
+        engine.invokeBuiltinTool("assign_slug", {
+          token: first.resultRef,
+          slug: "doubling-report",
+        }),
+        engine.invokeBuiltinTool("assign_slug", {
+          token: second.resultRef,
+          slug: "doubling-report",
+        }),
+      ]);
+      const outputs = results.map((result) =>
+        result.output as AssignSlugToolSuccessOutput | AssignSlugToolErrorOutput
+      );
+
+      expect(outputs.filter((output) => output.status === "ok")).toHaveLength(
+        1,
+      );
+      const loser = outputs.find((output) => output.status === "error") as
+        | AssignSlugToolErrorOutput
+        | undefined;
+      expect(loser?.message).toContain("doubling-report");
+      expect(loser?.message).toContain("Choose another slug");
+      const winner = outputs[0].status === "ok" ? first : second;
+      expect(await resolvePieceAddress(pieces, "doubling-report")).toBe(
+        winner.pieceId,
       );
     });
 

--- a/packages/cf-harness/test/assign-slug.test.ts
+++ b/packages/cf-harness/test/assign-slug.test.ts
@@ -288,10 +288,18 @@ describe("assign-slug", () => {
       );
     });
 
-    it("gives a free name to exactly one of two calls racing for it", async () => {
-      // Both calls read the name as free, so both reach the write, and the
-      // write is where exactly one of them can win. Forcing over the read
-      // instead would let the loser overwrite the winner and report success.
+    it("gives a free name to the first of two calls and refuses the second", async () => {
+      // Two calls for one free name, started together and settling one after
+      // the other. What this asserts is the outcome — exactly one takes the
+      // name — and nothing about the interleaving: the assertions hold
+      // whether the two overlapped or ran in sequence. Forcing over the read
+      // instead of carrying it into the write would let the loser overwrite
+      // the winner and report success, which is what the assertions catch.
+      //
+      // The racing path is the library's, pinned over two sessions where the
+      // losing replica is provably behind: `packages/piece/test/slug.test.ts`,
+      // under "the read a refusal claims on".
+      //
       // The two tokens name different pieces, so the address the name ends
       // up holding says which call won rather than being true either way.
       await linkDefaultPattern();
@@ -478,22 +486,25 @@ describe("assign-slug", () => {
       const engine = createEngine();
       const created = await createPiece(engine);
 
-      const originalGetSpace = pieces.getSpace.bind(pieces);
       const originalAdd = pieces.add.bind(pieces);
+      const originalGetCell = runtime.getCellFromEntityId.bind(runtime);
       pieces.add = async (cells) => {
         await originalAdd(cells);
         // The join has landed; make the assignment that follows fail once.
-        pieces.getSpace = () => {
-          pieces.getSpace = originalGetSpace;
+        // Through a call only the slug write makes, so the failure is the
+        // assignment's rather than the listing's — the tool reports those
+        // separately, because only one of them leaves a listed piece.
+        runtime.getCellFromEntityId = (() => {
+          runtime.getCellFromEntityId = originalGetCell;
           throw new Error("slug assignment refused");
-        };
+        }) as Runtime["getCellFromEntityId"];
       };
       const first = await engine.invokeBuiltinTool("assign_slug", {
         token: created.resultRef,
         slug: "doubling-report",
       });
       pieces.add = originalAdd;
-      pieces.getSpace = originalGetSpace;
+      runtime.getCellFromEntityId = originalGetCell;
       const failed = first.output as AssignSlugToolErrorOutput;
       expect(failed.status).toBe("error");
       expect(failed.message).toContain("failed while naming");
@@ -765,7 +776,11 @@ describe("assign-slug", () => {
       );
     });
 
-    it("reports the naming failure when the space root cannot be initialized", async () => {
+    it("reports the listing failure when the space root cannot be initialized, claiming no listing", async () => {
+      // The registry join is where this fails, so it is the listing that is
+      // reported and the piece is not listed. The refusals on the other side
+      // of the join say the piece IS listed, and a report that conflated the
+      // two would send a caller looking for a piece that is not there.
       const engine = createEngine();
       const created = await createPiece(engine);
       const originalEnsureDefaultPattern = pieces.ensureDefaultPattern;
@@ -780,8 +795,10 @@ describe("assign-slug", () => {
 
       const output = result.output as AssignSlugToolErrorOutput;
       expect(output.status).toBe("error");
-      expect(output.message).toContain("failed while naming");
+      expect(output.message).toContain("failed while listing");
       expect(output.message).toContain("space root unavailable");
+      expect(output.message).not.toContain("the piece is listed");
+      expect(await pieces.getRegisteredPieces()).toEqual([]);
     });
 
     it("leaves an initialized space root untouched while assigning the slug", async () => {

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -364,10 +364,16 @@ points at rather than at the cell.
 
 A name that already points somewhere is refused, and the refusal names what it
 points at, so the address someone opens is never taken by accident and the
-caller can see what taking it would cost. `--force` takes it anyway. The check
-is a claim rather than a look: the name is read inside the transaction the
-assignment commits in, so two runs claiming one free name end with one holder
-rather than with whichever committed last.
+caller can see what taking it would cost. `--force` takes it anyway, and clears
+the name from the piece it takes it from, so no piece is left claiming a name it
+no longer holds. The check is a claim rather than a look: the name is read
+inside the transaction the assignment commits in, so two runs claiming one free
+name end with one holder rather than with whichever committed last.
+
+`cf piece new --slug` assigns through the same claim and refuses the same way,
+naming the piece it just created so an operator can name it another way. Its
+`--force` takes the name and is accepted only alongside `--slug`, which is the
+only thing it applies to.
 
 `cf piece search` also starts from the registry. It searches readable input and
 result data, but returns registered pieces only. `cf piece map` likewise shows

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -362,6 +362,13 @@ scope of the cell it points at. `--resolve-before-linking` resolves the source
 cell's link before writing, so the new slug points at what the source's cell
 points at rather than at the cell.
 
+A name that already points somewhere is refused, and the refusal names what it
+points at, so the address someone opens is never taken by accident and the
+caller can see what taking it would cost. `--force` takes it anyway. The check
+is a claim rather than a look: the name is read inside the transaction the
+assignment commits in, so two runs claiming one free name end with one holder
+rather than with whichever committed last.
+
 `cf piece search` also starts from the registry. It searches readable input and
 result data, but returns registered pieces only. `cf piece map` likewise shows
 connections among registered pieces rather than walking the complete stored

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -2413,26 +2413,7 @@ export const piece = targetOptions(
     "--dangerously-allow-incompatible-schema",
     "Accepted for deploy-script symmetry; a new piece has no previous schema to compare.",
   )
-  .action(async (options, main) => {
-    setQuietMode(!!options.quiet);
-    const spaceConfig = parseSpaceOptions(options);
-    const pieceId = await newPiece(
-      spaceConfig,
-      localPatternEntry(main, options),
-      {
-        start: options.start,
-        slug: options.slug,
-        force: !!(options as any).force,
-      },
-    );
-    render(pieceId);
-    const browserPieceRef = options.slug ?? pieceId;
-    hint(cliText(`NEXT STEPS:
-  → Open in browser: ${spaceConfig.apiUrl}/${spaceConfig.space}/${browserPieceRef}
-  → Update code:     cf piece setsrc --cell ${pieceId} ${main} ...
-  → Test a callable: cf piece call --cell ${pieceId} <callableName> ...
-  → Inspect state:   cf piece inspect --cell ${pieceId} ...`));
-  })
+  .action(newPieceFromCommand)
   /* piece set-slug */
   .command(
     "set-slug",
@@ -4807,6 +4788,44 @@ export async function restoreFromCommand(
         `--apply writes it`,
     );
   }
+}
+
+export interface NewPieceCommandDependencies {
+  newPiece?: typeof newPiece;
+}
+
+/**
+ * `cf piece new`'s action, as a function a test can call.
+ *
+ * The registration chain around it is not reachable from a test, so an action
+ * left inline is not either — and what this one decides is worth reaching:
+ * which options become the naming request `newPiece` receives, and that the
+ * address it points a reader at is the slug when there is one.
+ */
+export async function newPieceFromCommand(
+  // deno-lint-ignore no-explicit-any
+  options: any,
+  main: string,
+  deps: NewPieceCommandDependencies = {},
+): Promise<void> {
+  setQuietMode(!!options.quiet);
+  const spaceConfig = parseSpaceOptions(options);
+  const pieceId = await (deps.newPiece ?? newPiece)(
+    spaceConfig,
+    localPatternEntry(main, options),
+    {
+      start: options.start,
+      slug: options.slug,
+      force: !!options.force,
+    },
+  );
+  render(pieceId);
+  const browserPieceRef = options.slug ?? pieceId;
+  hint(cliText(`NEXT STEPS:
+  → Open in browser: ${spaceConfig.apiUrl}/${spaceConfig.space}/${browserPieceRef}
+  → Update code:     cf piece setsrc --cell ${pieceId} ${main} ...
+  → Test a callable: cf piece call --cell ${pieceId} <callableName> ...
+  → Inspect state:   cf piece inspect --cell ${pieceId} ...`));
 }
 
 export interface SlugListCommandDependencies {

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -2373,6 +2373,12 @@ export const piece = targetOptions(
     ),
     `Create a piece that can import from parent directories within ./patterns.`,
   )
+  .example(
+    cliText(
+      `cf piece new ${EX_ID} ${EX_COMP} ./main.tsx --slug project-notes --force`,
+    ),
+    `Create a piece and take "project-notes" from whatever it names now.`,
+  )
   .arguments("<main:string>")
   .option("--no-start", "Only set up the piece without starting it")
   .option(
@@ -2399,6 +2405,11 @@ export const piece = targetOptions(
   )
   .option("--slug <slug:string>", "Slug URL/address for this piece.")
   .option(
+    "--force",
+    "Take the slug even when it already points somewhere.",
+    { depends: ["slug"] },
+  )
+  .option(
     "--dangerously-allow-incompatible-schema",
     "Accepted for deploy-script symmetry; a new piece has no previous schema to compare.",
   )
@@ -2411,6 +2422,7 @@ export const piece = targetOptions(
       {
         start: options.start,
         slug: options.slug,
+        force: !!(options as any).force,
       },
     );
     render(pieceId);

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -2437,10 +2437,20 @@ export const piece = targetOptions(
     ),
     `Set slug "latest-note" to the cell currently resolved by "old-slug".`,
   )
+  .example(
+    cliText(
+      `cf piece set-slug ${EX_ID} ${EX_COMP} project-notes fid1:piece2 --force`,
+    ),
+    `Take "project-notes" from whatever it names now.`,
+  )
   .arguments("<slug:string> <source:string>")
   .option(
     "--resolve-before-linking",
     "Resolve the source cell before writing it as the slug redirect target.",
+  )
+  .option(
+    "--force",
+    "Take the name even when it already points somewhere.",
   )
   .action(async (options, slug, sourceRef) => {
     setQuietMode(!!options.quiet);
@@ -2455,6 +2465,7 @@ export const piece = targetOptions(
       {
         sourceScope: source.scope,
         resolveBeforeLinking: !!(options as any).resolveBeforeLinking,
+        force: !!(options as any).force,
       },
     );
     render(`Set slug ${slug} to ${sourceRef}`);

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -26,6 +26,7 @@ import {
   resolveSlugTarget,
   resolveSlugTargetCell,
   setSlugLink,
+  SlugAssignedError,
   SlugResolutionError,
 } from "@commonfabric/piece";
 import {
@@ -1617,6 +1618,14 @@ export async function newPiece(
   return piece.id;
 }
 
+/**
+ * Points `slug` at the cell an address and the path after it name.
+ *
+ * A name already pointing somewhere is refused, naming what it points at, so
+ * that a slug someone opens is never taken by accident; `force` takes it. The
+ * refusal names the flag, because the remedy is the CLI's rather than the
+ * library's.
+ */
 export async function setPieceSlug(
   config: SpaceConfig,
   slug: string,
@@ -1625,6 +1634,7 @@ export async function setPieceSlug(
   options?: {
     sourceScope?: PieceConfig["pieceScope"];
     resolveBeforeLinking?: boolean;
+    force?: boolean;
   },
   deps: PieceResolutionDeps = {},
 ): Promise<void> {
@@ -1640,14 +1650,31 @@ export async function setPieceSlug(
     deps,
   );
   await timeCliPhase("setPieceSlug.source.sync", () => source.sync());
-  await timeCliPhase(
-    "setPieceSlug.setSlugLink",
-    () =>
-      setSlugLink(pieces, slug, source, {
-        resolveBeforeLinking: options?.resolveBeforeLinking,
-        writeTargetMetadata: source.getAsNormalizedFullLink().path.length === 0,
-      }),
-  );
+  try {
+    await timeCliPhase(
+      "setPieceSlug.setSlugLink",
+      () =>
+        setSlugLink(pieces, slug, source, {
+          resolveBeforeLinking: options?.resolveBeforeLinking,
+          writeTargetMetadata:
+            source.getAsNormalizedFullLink().path.length === 0,
+          force: options?.force,
+        }),
+    );
+  } catch (error) {
+    // Rethrown rather than wrapped: the name being taken is a fact about the
+    // space rather than a mistake in the line, and the same class carries it
+    // to the top level, where it prints its message and no usage page.
+    if (error instanceof SlugAssignedError) {
+      throw new SlugAssignedError(
+        error.slug,
+        error.target,
+        `Pass \`--force\` to take it anyway, or name it back with ` +
+          `\`${error.target}\`.`,
+      );
+    }
+    throw error;
+  }
   noteWroteTo(config.space);
 }
 

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -1520,11 +1520,18 @@ export async function resolveLinkEndpointAddress(
   }
 }
 
-// Creates a new piece from source code and optional input.
+/**
+ * Creates a new piece from source code and optional input.
+ *
+ * A `slug` that already points somewhere is refused the way `set-slug`
+ * refuses one, and `force` takes it. The refusal arrives after the piece
+ * exists, so it names the piece as well as the flag: an operator who meant to
+ * repoint has an id to name, and one who did not has a piece to find.
+ */
 export async function newPiece(
   config: SpaceConfig,
   entry: EntryConfig,
-  options?: { start?: boolean; slug?: string },
+  options?: { start?: boolean; slug?: string; force?: boolean },
   deps: PieceOperationDependencies = {},
 ): Promise<string> {
   const pieces = await timeCliPhase(
@@ -1603,10 +1610,25 @@ export async function newPiece(
   noteWroteTo(config.space);
 
   if (options?.slug) {
-    await timeCliPhase(
-      "newPiece.assignSlug",
-      () => assignSlug(pieces, piece.getCell(), options.slug!),
-    );
+    try {
+      await timeCliPhase(
+        "newPiece.assignSlug",
+        () =>
+          assignSlug(pieces, piece.getCell(), options.slug!, {
+            force: options.force,
+          }),
+      );
+    } catch (error) {
+      if (error instanceof SlugAssignedError) {
+        throw new SlugAssignedError(
+          error.slug,
+          error.target,
+          `Pass \`--force\` to take it anyway. The piece was created as ` +
+            `${piece.id} and carries no name.`,
+        );
+      }
+      throw error;
+    }
   }
 
   // Explicitly add the piece to the space's registry.
@@ -1669,8 +1691,8 @@ export async function setPieceSlug(
       throw new SlugAssignedError(
         error.slug,
         error.target,
-        `Pass \`--force\` to take it anyway, or name it back with ` +
-          `\`${error.target}\`.`,
+        `Pass \`--force\` to take it anyway; that target is what to point ` +
+          `it back at afterwards.`,
       );
     }
     throw error;

--- a/packages/cli/mod.ts
+++ b/packages/cli/mod.ts
@@ -1,5 +1,6 @@
 import { ValidationError } from "@cliffy/command";
 import { CompilerError, TransformerError } from "@commonfabric/js-compiler";
+import { SlugAssignedError } from "@commonfabric/piece";
 import { SlugResolutionError } from "@commonfabric/runner";
 
 import { main as rootCommand } from "./commands/main.ts";
@@ -12,15 +13,15 @@ import { applyLogLevel } from "./lib/log-level.ts";
 
 /**
  * The value to print for a top-level CLI failure. Validation, transformer,
- * compiler, verb-input, and slug-resolution errors carry user-facing
- * messages, so print those without a stack trace. Other Errors print their
- * stack, falling back to the message. Anything else prints as-is.
+ * compiler, verb-input, and slug errors carry user-facing messages, so print
+ * those without a stack trace. Other Errors print their stack, falling back
+ * to the message. Anything else prints as-is.
  */
 export function renderCliError(e: unknown): unknown {
   if (
     e instanceof ValidationError || e instanceof TransformerError ||
     e instanceof CompilerError || e instanceof VerbInputValidationError ||
-    e instanceof SlugResolutionError
+    e instanceof SlugResolutionError || e instanceof SlugAssignedError
   ) {
     return e.message;
   }

--- a/packages/cli/test/completion-output.test.ts
+++ b/packages/cli/test/completion-output.test.ts
@@ -69,6 +69,12 @@ Deno.test("pre-parse globals are offered even though they are not in the tree", 
   assert(values.includes("--no-color"));
 });
 
+Deno.test("set-slug offers the flag that takes a name already bound", () => {
+  // A boolean flag declares no value, so the completion-slot gate has nothing
+  // to require of it; that the name reaches the prompt is what this asserts.
+  assert(staticFor("cf piece set-slug top --").includes("--force"));
+});
+
 Deno.test("an option already supplied is not offered again", () => {
   const values = staticFor("cf piece ls --space team --");
   assertFalse(values.includes("--space"));

--- a/packages/cli/test/completion-output.test.ts
+++ b/packages/cli/test/completion-output.test.ts
@@ -69,10 +69,12 @@ Deno.test("pre-parse globals are offered even though they are not in the tree", 
   assert(values.includes("--no-color"));
 });
 
-Deno.test("set-slug offers the flag that takes a name already bound", () => {
+Deno.test("both commands that assign a slug offer the flag that takes a bound name", () => {
   // A boolean flag declares no value, so the completion-slot gate has nothing
-  // to require of it; that the name reaches the prompt is what this asserts.
+  // to require of it; that the name reaches the prompt is what this asserts,
+  // on both doors into slug assignment.
   assert(staticFor("cf piece set-slug top --").includes("--force"));
+  assert(staticFor("cf piece new --").includes("--force"));
 });
 
 Deno.test("an option already supplied is not offered again", () => {

--- a/packages/cli/test/newPieceSlug.test.ts
+++ b/packages/cli/test/newPieceSlug.test.ts
@@ -1,0 +1,139 @@
+/**
+ * `cf piece new --slug`'s naming step over a real runtime: the second door
+ * into slug assignment, which refuses a name that already points somewhere
+ * and takes it under `--force`. The piece itself is made ahead of the call
+ * and handed back by a `create` that stands in for compiling one, so what is
+ * exercised is the naming rather than the build.
+ */
+
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { createSession, Identity } from "@commonfabric/identity";
+import { pieceId, resolvePieceAddress } from "@commonfabric/piece";
+import { PiecesController } from "@commonfabric/piece/ops";
+import { type Cell, createBuilder, Runtime } from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { newPiece } from "../lib/piece.ts";
+import { resetWriteReceipts } from "../lib/write-receipt.ts";
+import { captureStderr } from "./utils.ts";
+
+const CONFIG = {
+  apiUrl: "https://cf.dev",
+  space: "collection-naming",
+  identity: "~/.my.key",
+};
+
+describe("newPiece() naming", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let pieces: PiecesController;
+
+  beforeEach(async () => {
+    resetWriteReceipts();
+    const signer = await Identity.fromPassphrase("cli piece new slug tests");
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    pieces = new PiecesController(
+      await createSession({ identity: signer, spaceName: "cli-piece-new" }),
+      runtime,
+    );
+    await pieces.synced();
+  });
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  /** A started piece in the space, which a `create` below answers with. */
+  async function makePiece(cause: string): Promise<Cell<unknown>> {
+    const { commonfabric } = createBuilder();
+    const pattern = commonfabric.pattern<{ value: number }>((
+      { value },
+    ) => ({ value }));
+    return await pieces.runPersistent(pattern, { value: 1 }, cause);
+  }
+
+  /**
+   * Runs `newPiece()` against the real space with the naming step reaching
+   * real storage. The three members either side of it stand in: `create`
+   * answers with `piece` rather than compiling one, and the registry pair
+   * belongs to the space's default pattern rather than to the name.
+   */
+  async function createWithSlug(
+    piece: Cell<unknown>,
+    slug: string,
+    options?: { force?: boolean },
+  ): Promise<void> {
+    // A proxy rather than a prototype override: the controller reads its own
+    // `#private` fields, which only resolve when `this` is the instance
+    // itself, so every member but `create` is forwarded bound to it.
+    const controller = new Proxy(pieces, {
+      get(target, property) {
+        if (property === "create") {
+          return () =>
+            Promise.resolve({ id: pieceId(piece)!, getCell: () => piece });
+        }
+        if (property === "ensureDefaultPattern" || property === "add") {
+          return () => Promise.resolve();
+        }
+        const value = Reflect.get(target, property, target);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    });
+    await captureStderr(async () => {
+      await newPiece(
+        CONFIG,
+        { mainPath: "/repo/main.tsx" },
+        { slug, ...options },
+        {
+          loadPieces: () => Promise.resolve(controller),
+          getPinnedProgramFromFile: () => Promise.resolve({} as never),
+        },
+      );
+    });
+  }
+
+  it("names the new piece when the slug points nowhere", async () => {
+    const piece = await makePiece("new-free");
+
+    await createWithSlug(piece, "notes");
+
+    expect(await resolvePieceAddress(pieces, "notes")).toBe(pieceId(piece));
+  });
+
+  it("refuses a slug that already points somewhere, naming it and the flag that takes it", async () => {
+    const held = await makePiece("new-held");
+    const taking = await makePiece("new-taking");
+    await createWithSlug(held, "notes");
+
+    const failure = await createWithSlug(taking, "notes").then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+
+    expect(failure).toBeInstanceOf(Error);
+    const message = (failure as Error).message;
+    expect(message).toContain(`/${held.getAsNormalizedFullLink().id}`);
+    expect(message).toContain("--force");
+    // The piece was created before the naming step, so the refusal hands
+    // back the id an operator needs to name it another way.
+    expect(message).toContain(pieceId(taking)!);
+    // The name still points at the piece that held it, not at the one the
+    // refused run created.
+    expect(await resolvePieceAddress(pieces, "notes")).toBe(pieceId(held));
+  });
+
+  it("takes a slug that already points somewhere when forced", async () => {
+    const held = await makePiece("new-held");
+    const taking = await makePiece("new-taking");
+    await createWithSlug(held, "notes");
+
+    await createWithSlug(taking, "notes", { force: true });
+
+    expect(await resolvePieceAddress(pieces, "notes")).toBe(pieceId(taking));
+  });
+});

--- a/packages/cli/test/newPieceSlug.test.ts
+++ b/packages/cli/test/newPieceSlug.test.ts
@@ -13,6 +13,7 @@ import { pieceId, resolvePieceAddress } from "@commonfabric/piece";
 import { PiecesController } from "@commonfabric/piece/ops";
 import { type Cell, createBuilder, Runtime } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { newPieceFromCommand } from "../commands/piece.ts";
 import { newPiece } from "../lib/piece.ts";
 import { resetWriteReceipts } from "../lib/write-receipt.ts";
 import { captureStderr } from "./utils.ts";
@@ -97,6 +98,62 @@ describe("newPiece() naming", () => {
     });
   }
 
+  describe("newPieceFromCommand()", () => {
+    // The command's own action, which the registration chain around it puts
+    // out of a test's reach when it is left inline. What it decides is the
+    // naming request: which flags become the options `newPiece` receives, and
+    // which address the next-steps hint points a reader at.
+
+    /**
+     * Runs the action with a stub for the creation, answering the options it
+     * passed on and the hint it wrote.
+     */
+    async function runAction(
+      // deno-lint-ignore no-explicit-any
+      options: Record<string, any>,
+    ): Promise<{ seen?: unknown; hint: string }> {
+      let seen: unknown;
+      const lines = await captureStderr(async () => {
+        await newPieceFromCommand(
+          { ...CONFIG, ...options },
+          "/repo/main.tsx",
+          {
+            newPiece: (_config, _entry, given) => {
+              seen = given;
+              return Promise.resolve("fid1:created");
+            },
+          },
+        );
+      });
+      return { seen, hint: lines.join("\n") };
+    }
+
+    it("carries the slug and the flag that takes it into the creation", async () => {
+      const { seen } = await runAction({ slug: "notes", force: true });
+
+      expect(seen).toEqual({ start: undefined, slug: "notes", force: true });
+    });
+
+    it("leaves the flag off when it was not given", async () => {
+      const { seen } = await runAction({ slug: "notes" });
+
+      expect(seen).toEqual({ start: undefined, slug: "notes", force: false });
+    });
+
+    it("sends the reader to the name when there is one, and to the id when there is not", async () => {
+      const named = await runAction({ slug: "notes" });
+      expect(named.hint).toContain(`${CONFIG.apiUrl}/${CONFIG.space}/notes`);
+      expect(named.hint).not.toContain(
+        `${CONFIG.apiUrl}/${CONFIG.space}/fid1:created`,
+      );
+
+      const unnamed = await runAction({});
+      expect(unnamed.hint).toContain(
+        `${CONFIG.apiUrl}/${CONFIG.space}/fid1:created`,
+      );
+    });
+  });
+
   it("names the new piece when the slug points nowhere", async () => {
     const piece = await makePiece("new-free");
 
@@ -125,6 +182,22 @@ describe("newPiece() naming", () => {
     // The name still points at the piece that held it, not at the one the
     // refused run created.
     expect(await resolvePieceAddress(pieces, "notes")).toBe(pieceId(held));
+  });
+
+  it("lets a failure that is not a name being taken reach the caller unchanged", async () => {
+    // The same bound as `set-slug`'s: only a name someone holds is rewritten
+    // to name the flag that takes it, so a name the space refuses arrives as
+    // the refusal it is.
+    const piece = await makePiece("new-invalid");
+
+    const failure = await createWithSlug(piece, "not a slug").then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+
+    expect(failure).toBeInstanceOf(Error);
+    expect((failure as Error).message).toContain("Slug must use lowercase");
+    expect((failure as Error).message).not.toContain("--force");
   });
 
   it("takes a slug that already points somewhere when forced", async () => {

--- a/packages/cli/test/render-cli-error.test.ts
+++ b/packages/cli/test/render-cli-error.test.ts
@@ -1,5 +1,6 @@
 import { assert, assertEquals } from "@std/assert";
 import { CompilerError, TransformerError } from "@commonfabric/js-compiler";
+import { SlugAssignedError } from "@commonfabric/piece";
 import { SlugResolutionError } from "@commonfabric/runner";
 import { ValidationError } from "@cliffy/command";
 import { renderCliError } from "../mod.ts";
@@ -26,6 +27,15 @@ Deno.test("renderCliError prints a SlugResolutionError's message, not its stack"
   // Every one of these says what a name in the space points at, or does not:
   // a sentence a person acts on, buried by a stack over it.
   const e = new SlugResolutionError("no member 999 in top", "missing-member");
+  assertEquals(renderCliError(e), e.message);
+  assert(renderCliError(e) !== e.stack);
+});
+
+Deno.test("renderCliError prints a SlugAssignedError's message, not its stack", () => {
+  // A refusal to take a name someone holds says what it points at and how to
+  // take it anyway. Without this the class falls through to the plain-Error
+  // arm below and every such refusal reaches the operator as a stack.
+  const e = new SlugAssignedError("top", "/of:fid1:abc", "Pass --force.");
   assertEquals(renderCliError(e), e.message);
   assert(renderCliError(e) !== e.stack);
 });

--- a/packages/cli/test/setPieceSlug.test.ts
+++ b/packages/cli/test/setPieceSlug.test.ts
@@ -173,6 +173,21 @@ describe("setPieceSlug()", () => {
     });
   });
 
+  it("lets a failure that is not a name being taken reach the caller unchanged", async () => {
+    // Only a refusal to take a bound name is rewritten, to add the flag that
+    // takes it. Everything else — a name the space will not accept, a storage
+    // rejection — has to arrive as itself, or the run reports a naming
+    // conflict for something that was never about the name being held.
+    const failure = await setSlug("not a slug", boardId, ["names"]).then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+
+    expect(failure).toBeInstanceOf(Error);
+    expect((failure as Error).message).toContain("Slug must use lowercase");
+    expect((failure as Error).message).not.toContain("--force");
+  });
+
   it("refuses a scope written on a bare slug, which has no cell of its own to scope", async () => {
     await setSlug("top", boardId, ["names"]);
 

--- a/packages/cli/test/setPieceSlug.test.ts
+++ b/packages/cli/test/setPieceSlug.test.ts
@@ -144,10 +144,16 @@ describe("setPieceSlug()", () => {
     );
 
     expect(failure).toBeInstanceOf(Error);
-    // The refusal names what the slug points at now, in the spelling the
-    // command takes as a source, so putting it back is a paste.
-    expect((failure as Error).message).toContain(`/of:${boardId}/names`);
-    expect((failure as Error).message).toContain("--force");
+    // The whole remedy, not a substring of it: the target and the flag both
+    // appear in wordings that say quite different things about what the
+    // caller should do, so an assertion on either alone cannot tell them
+    // apart. The target is named in the spelling the command takes as a
+    // source, so pointing the name back afterwards is a paste.
+    expect((failure as Error).message).toBe(
+      `Slug "top" already points at /of:${boardId}/names, so assigning it ` +
+        `would take that address from whoever holds it. Pass \`--force\` to ` +
+        `take it anyway; that target is what to point it back at afterwards.`,
+    );
     // The collection kept the name: the refused run neither took it nor
     // repointed it at the member it named.
     expect(await resolveSlugTarget(pieces, "top")).toEqual({

--- a/packages/cli/test/setPieceSlug.test.ts
+++ b/packages/cli/test/setPieceSlug.test.ts
@@ -135,6 +135,38 @@ describe("setPieceSlug()", () => {
     });
   });
 
+  it("refuses a name that already points somewhere, naming it and the flag that takes it", async () => {
+    await setSlug("top", boardId, ["names"]);
+
+    const failure = await setSlug("top", memberId, []).then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+
+    expect(failure).toBeInstanceOf(Error);
+    // The refusal names what the slug points at now, in the spelling the
+    // command takes as a source, so putting it back is a paste.
+    expect((failure as Error).message).toContain(`/of:${boardId}/names`);
+    expect((failure as Error).message).toContain("--force");
+    // The collection kept the name: the refused run neither took it nor
+    // repointed it at the member it named.
+    expect(await resolveSlugTarget(pieces, "top")).toEqual({
+      piece: boardId,
+      pathInside: ["names"],
+    });
+  });
+
+  it("takes a name that already points somewhere when forced", async () => {
+    await setSlug("top", boardId, ["names"]);
+
+    await setSlug("top", memberId, [], { force: true });
+
+    expect(await resolveSlugTarget(pieces, "top")).toEqual({
+      piece: memberId,
+      pathInside: [],
+    });
+  });
+
   it("refuses a scope written on a bare slug, which has no cell of its own to scope", async () => {
     await setSlug("top", boardId, ["names"]);
 

--- a/packages/piece/src/index.ts
+++ b/packages/piece/src/index.ts
@@ -8,6 +8,7 @@ export {
   resolveSlugTarget,
   resolveSlugTargetCell,
   setSlugLink,
+  SlugAssignedError,
   SlugResolutionError,
   type SlugTarget,
 } from "./slugs.ts";

--- a/packages/piece/src/index.ts
+++ b/packages/piece/src/index.ts
@@ -3,6 +3,7 @@ export {
   assignSlug,
   listSlugs,
   type PieceReference,
+  readSlugBinding,
   resolvePieceAddress,
   resolvePieceReference,
   resolveSlugTarget,

--- a/packages/piece/src/index.ts
+++ b/packages/piece/src/index.ts
@@ -10,6 +10,7 @@ export {
   resolveSlugTargetCell,
   setSlugLink,
   SlugAssignedError,
+  SlugReleasedError,
   SlugResolutionError,
   type SlugTarget,
 } from "./slugs.ts";

--- a/packages/piece/src/slugs.ts
+++ b/packages/piece/src/slugs.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_CELL_SCOPE,
   entityIdFrom,
   isSlugAddress,
+  parseLink,
   resolveSlugReference,
   resolveSlugTargetCell as resolveRuntimeSlugTargetCell,
   resolveSlugTargetInPiece,
@@ -13,11 +14,48 @@ import {
   validateSlug,
 } from "@commonfabric/runner";
 import { rawMetaWriteAuthorization } from "@commonfabric/runner/meta-seam";
+import { createLLMFriendlyLink } from "@commonfabric/runner/shared";
 import { utf8Compare } from "@commonfabric/utils/utf8";
 import type { PiecesController } from "./ops/pieces-controller.ts";
 import { pieceId } from "./piece-id.ts";
 
 export { SlugResolutionError };
+
+/**
+ * A name that was already bound when an assignment reached it. The target it
+ * carries is a reference to what the name points at now, which is both what
+ * forcing the assignment would take and what a caller writes to put the name
+ * back.
+ *
+ * The condition is the library's and the remedy is the caller's, so a caller
+ * with a word for forcing — a CLI flag, a tool parameter — supplies its own
+ * and the message reads in that caller's vocabulary.
+ */
+export class SlugAssignedError extends Error {
+  #slug: string;
+  #target: string;
+
+  constructor(slug: string, target: string, remedy?: string) {
+    super(
+      `Slug "${slug}" already points at ${target}, so assigning it would ` +
+        `take that address from whoever holds it.` +
+        (remedy === undefined ? "" : ` ${remedy}`),
+    );
+    this.name = "SlugAssignedError";
+    this.#slug = slug;
+    this.#target = target;
+  }
+
+  /** The name the assignment asked for. */
+  get slug(): string {
+    return this.#slug;
+  }
+
+  /** A reference to what the name points at now. */
+  get target(): string {
+    return this.#target;
+  }
+}
 
 /** The slug index's shape: names to `true`. Written one key at a time, so
  * two clients assigning different slugs merge as two keys rather than two
@@ -53,14 +91,36 @@ export async function listSlugs(pieces: PiecesController): Promise<string[]> {
     .sort(utf8Compare);
 }
 
+/**
+ * Points `slug` at a piece and stamps the piece with the name, refusing a
+ * name that is already bound the way {@link setSlugLink} does.
+ */
 export async function assignSlug(
   pieces: PiecesController,
   piece: Cell<unknown>,
   slug: string,
+  options?: { force?: boolean },
 ): Promise<void> {
-  await setSlugLink(pieces, slug, piece, { writeTargetMetadata: true });
+  await setSlugLink(pieces, slug, piece, {
+    writeTargetMetadata: true,
+    force: options?.force,
+  });
 }
 
+/**
+ * Points `slug` at `source`, and records the name in the space's slug index.
+ *
+ * A name already pointing somewhere is refused with a {@link
+ * SlugAssignedError} naming the target it holds, unless `force` says to take
+ * it. The refusal is a claim rather than a check: the name is read inside the
+ * transaction the assignment commits in, so a writer that binds it between
+ * that read and the commit conflicts, and `editWithRetry` re-runs the body
+ * against what that writer left. Two assignments of one free name therefore
+ * end with one holder, not with whichever committed last.
+ *
+ * Throws when storage refuses the transaction, so a caller never reads a name
+ * as assigned that never landed.
+ */
 export async function setSlugLink(
   pieces: PiecesController,
   slug: string,
@@ -68,6 +128,7 @@ export async function setSlugLink(
   options?: {
     resolveBeforeLinking?: boolean;
     writeTargetMetadata?: boolean;
+    force?: boolean;
   },
 ): Promise<void> {
   const validSlug = validateSlug(slug);
@@ -88,11 +149,24 @@ export async function setSlugLink(
 
   const indexCell = slugIndexCell(pieces);
   await indexCell.sync();
+  // The name is synced so the claim below reads what the space holds rather
+  // than an absence this client never checked.
+  await slugCell.sync();
 
-  const { error } = await pieces.runtime.editWithRetry((tx) => {
+  const { ok: bound, error } = await pieces.runtime.editWithRetry((tx) => {
     const targetWithTx = target.withTx(tx);
     const slugWithTx = slugCell.withTx(tx);
     const metadataTargetWithTx = metadataTarget?.withTx(tx);
+
+    // The claim, ahead of every write so that declining stages nothing: a
+    // read here joins the commit's read set, so binding the name under this
+    // transaction rejects it and the body re-runs against the new holder.
+    const held = options?.force
+      ? undefined
+      : parseLink(slugWithTx.getRaw(), slugWithTx);
+    if (held !== undefined) {
+      return createLLMFriendlyLink(held, pieces.getSpace());
+    }
 
     const metadataTargetLink = metadataTargetWithTx
       ?.getAsNormalizedFullLink();
@@ -113,6 +187,7 @@ export async function setSlugLink(
     // The index entry rides the slug's own transaction, so a listing can
     // never see a name without its slug or a slug without its name.
     indexCell.withTx(tx).key(validSlug).set(true);
+    return undefined;
   });
   if (error) {
     throw new Error(
@@ -120,6 +195,7 @@ export async function setSlugLink(
       { cause: error },
     );
   }
+  if (bound !== undefined) throw new SlugAssignedError(validSlug, bound);
 
   await pieces.runtime.idle();
   await pieces.synced();

--- a/packages/piece/src/slugs.ts
+++ b/packages/piece/src/slugs.ts
@@ -98,6 +98,11 @@ export class SlugReleasedError extends Error {
  * whole maps racing. The names are the whole content — where a name points
  * stays the slug cell's own answer, because a copy of the target here would
  * be a second answer able to disagree with it. */
+const SLUG_INDEX_SCHEMA = {
+  type: "object",
+  additionalProperties: { type: "boolean" },
+} as const satisfies JSONSchema;
+
 /**
  * The schema the redirect write carries. It exists to stop the write asking
  * what the name currently resolves to: a handle with no schema resolves its
@@ -111,11 +116,6 @@ export class SlugReleasedError extends Error {
  * same single document pulled, and the same stored value.
  */
 const SLUG_REDIRECT_SCHEMA = { type: "object" } as const satisfies JSONSchema;
-
-const SLUG_INDEX_SCHEMA = {
-  type: "object",
-  additionalProperties: { type: "boolean" },
-} as const satisfies JSONSchema;
 
 /** The document a name's redirect lives in, whose id derives from the name. */
 function slugCellFor(pieces: PiecesController, validSlug: string) {

--- a/packages/piece/src/slugs.ts
+++ b/packages/piece/src/slugs.ts
@@ -110,10 +110,19 @@ const SLUG_INDEX_SCHEMA = {
  * throw — so without it a forced assignment could not repoint the very state
  * an operator forces to escape.
  *
- * An object with no properties describes the shape a redirect payload has and
- * names nothing to follow, so the sync it kicks is the one document it
- * writes. Measured against a schemaless write over a five-document chain: the
- * same single document pulled, and the same stored value.
+ * It costs one sync, and the cost is worth stating precisely because the
+ * obvious summary overstates the equivalence. `asSchema` resets the handle's
+ * synced flag, so the write kicks a second provider sync of the slug
+ * document: two calls where a schemaless write makes one, both for that same
+ * document.
+ *
+ * What it does not do is widen what a sync reaches. An object with no
+ * properties describes the shape a redirect payload has and names nothing to
+ * follow, so that second sync loads that document and no further one, and the
+ * stored bytes are identical either way. Measured with a five-document chain
+ * behind the name: those five are loaded by the sync `setSlugLink` performs
+ * before its transaction, which runs with or without this schema, so none of
+ * them are this schema's doing.
  */
 const SLUG_REDIRECT_SCHEMA = { type: "object" } as const satisfies JSONSchema;
 

--- a/packages/piece/src/slugs.ts
+++ b/packages/piece/src/slugs.ts
@@ -1,10 +1,12 @@
 import type { CellScope, JSONSchema } from "@commonfabric/api";
-import type { Cell } from "@commonfabric/runner";
+import type { Cell, IExtendedStorageTransaction } from "@commonfabric/runner";
 import {
   DEFAULT_CELL_SCOPE,
   entityIdFrom,
+  isPieceDocument,
   isSlugAddress,
-  parseLink,
+  type NormalizedFullLink,
+  parseSlugRedirect,
   resolveSlugReference,
   resolveSlugTargetCell as resolveRuntimeSlugTargetCell,
   resolveSlugTargetInPiece,
@@ -109,20 +111,66 @@ function slugCellFor(pieces: PiecesController, validSlug: string) {
   );
 }
 
+/** What a name holds, in the three forms the module asks about. */
+interface SlugBinding {
+  /** The redirect the name's document holds, for the holder it takes from. */
+  held: NormalizedFullLink | undefined;
+
+  /** The reference it reads as, which is what a refusal names. */
+  ref: string | null;
+
+  /** What an assignment compares. See {@link readSlugBinding}. */
+  claim: string | null;
+}
+
 /**
- * The reference a name's redirect reads as, or `null` for a name pointing
- * nowhere. One spelling for the whole module: what a refusal names, what
- * {@link readSlugBinding} answers, and what an assignment compares against
- * are the same string, so a caller can compare them.
+ * What a name holds. A payload that is no redirect — absent, structurally
+ * invalid, or shaped like a link and malformed inside — is a name pointing
+ * nowhere, which is what `parseSlugRedirect` answers and therefore what every
+ * reader of this name agrees it is. Asking any other way would let a name the
+ * resolver calls malformed throw out of an assignment instead.
+ *
+ * `withTargetFacts` adds what the name points AT to the claim: whether that
+ * document is a piece, which is a fact a caller's own rule about a free name
+ * can turn on. Only a caller naming a target to take the name from compares
+ * it — the default rule turns on whether anything is bound at all — so it is
+ * read only for those, rather than putting the target document in the read
+ * set of every assignment.
  */
-function bindingRefOf(
+function slugBindingOf(
   pieces: PiecesController,
   slugCell: Cell<unknown>,
-): string | null {
-  const held = parseLink(slugCell.getRaw(), slugCell);
-  return held === undefined
-    ? null
-    : createLLMFriendlyLink(held, pieces.getSpace());
+  withTargetFacts: boolean,
+): SlugBinding {
+  const held = parseSlugRedirect(slugCell.getRaw(), slugCell);
+  if (held === undefined) return { held, ref: null, claim: null };
+  const ref = createLLMFriendlyLink(held, pieces.getSpace());
+  if (!withTargetFacts) return { held, ref, claim: ref };
+  return { held, ref, claim: `${ref} ${targetKindOf(pieces, held, slugCell)}` };
+}
+
+/**
+ * What a name's target is, as the claim records it: whether the document it
+ * resolves to is a piece, which is the fact a caller's own rule about a free
+ * name turns on.
+ *
+ * A target that will not resolve at all — a redirect cycle, including the
+ * self-cycle an assignment can point a name at — is a third state rather than
+ * a failure. It is as stable to compare as the other two: a name stops
+ * resolving nowhere only by being written.
+ */
+function targetKindOf(
+  pieces: PiecesController,
+  held: NormalizedFullLink,
+  base: Cell<unknown>,
+): string {
+  try {
+    const target = pieces.runtime.getCellFromLink(held, undefined, base.tx)
+      .resolveAsCell();
+    return isPieceDocument(pieces.runtime, target) ? "piece" : "not-piece";
+  } catch {
+    return "unresolvable";
+  }
 }
 
 /**
@@ -143,6 +191,30 @@ function slugStampRoot(cell: Cell<unknown>): Cell<unknown> | undefined {
   return resolved.getAsNormalizedFullLink().path.length === 0
     ? resolved
     : undefined;
+}
+
+/**
+ * {@link slugStampRoot} for the holder a name is taken FROM, where a target
+ * that will not resolve is an answer rather than a failure: there is no root
+ * that could be carrying the name, so there is nothing to clear.
+ *
+ * The two sides ask one question and differ only here, in what an
+ * unanswerable one means. Taking a name is what an operator reaches for when
+ * its current target is broken — a redirect cycle above all — so the cleanup
+ * that rides along must not be able to block the replacement.
+ */
+function heldStampRoot(
+  pieces: PiecesController,
+  held: NormalizedFullLink,
+  tx: IExtendedStorageTransaction,
+): Cell<unknown> | undefined {
+  try {
+    return slugStampRoot(
+      pieces.runtime.getCellFromLink(held).withTx(tx),
+    );
+  } catch {
+    return undefined;
+  }
 }
 
 function slugIndexCell(pieces: PiecesController) {
@@ -170,13 +242,17 @@ export async function listSlugs(pieces: PiecesController): Promise<string[]> {
 }
 
 /**
- * What `slug` points at now, as the reference a refusal names, or `null` for
+ * What `slug` holds now, as an opaque value: the value a caller hands back as
+ * `takeFrom` when it has its own rule about which states count as a free
+ * name. Read it, judge it, and carry it into the assignment, where the commit
+ * holds the judgment against the state the write actually lands on. `null` is
  * a name pointing nowhere.
  *
- * The value a caller hands back as `takeFrom` when it has its own rule about
- * which of those states counts as free: read it, judge it, and carry it into
- * the assignment, where the commit holds the judgment against the state the
- * write actually lands on.
+ * Opaque because it covers more than where the name points. A rule that calls
+ * a name free because it resolves to no piece is judging the target as well
+ * as the pointer, and a comparison over the pointer alone would let the
+ * target become a piece under the caller and still match. Read it, do not
+ * parse it.
  */
 export async function readSlugBinding(
   pieces: PiecesController,
@@ -184,7 +260,15 @@ export async function readSlugBinding(
 ): Promise<string | null> {
   const slugCell = slugCellFor(pieces, validateSlug(slug));
   await slugCell.sync();
-  return bindingRefOf(pieces, slugCell);
+  // The target too, so the facts below are read from what the space holds
+  // rather than from whatever this client happens to have. A name that
+  // resolves nowhere has no target to load, and reads as that state.
+  try {
+    await slugCell.resolveAsCell().sync();
+  } catch {
+    // Nothing to load, which `targetKindOf` records as its own state.
+  }
+  return slugBindingOf(pieces, slugCell, true).claim;
 }
 
 /**
@@ -269,27 +353,26 @@ export async function setSlugLink(
     const slugWithTx = slugCell.withTx(tx);
     const metadataTargetWithTx = metadataTarget?.withTx(tx);
 
-    // The claim, ahead of every write so that declining stages nothing: a
-    // read here joins the commit's read set, so binding the name under this
-    // transaction rejects it and the body re-runs against the new holder.
-    const held = parseLink(slugWithTx.getRaw(), slugWithTx);
-    const heldRef = held === undefined
-      ? null
-      : createLLMFriendlyLink(held, pieces.getSpace());
-    if (!options?.force && heldRef !== takeFrom) {
-      // `null` is a refusal too: a caller that named what to take the name
-      // from has not got it, whether somebody else holds the name now or
-      // nobody does.
-      return { held: heldRef };
+    // The claim, ahead of every write so that declining stages nothing: the
+    // reads here join the commit's read set, so a change to what the name
+    // holds under this transaction rejects it and the body re-runs against
+    // what the change left.
+    const binding = slugBindingOf(pieces, slugWithTx, takeFrom !== null);
+    const held = binding.held;
+    if (!options?.force && binding.claim !== takeFrom) {
+      // A `null` reference is a refusal too: a caller that named what to
+      // take the name from has not got it, whether somebody else holds the
+      // name now or nobody does.
+      return { held: binding.ref };
     }
 
     // The name is being taken from a holder, so the holder stops claiming
     // it. Only its own name is cleared: another name pointing at the same
     // root is not this assignment's to drop. Ahead of the stamp below, so a
     // root that is both the old holder and the new one ends up stamped.
-    const previousRoot = held === undefined ? undefined : slugStampRoot(
-      pieces.runtime.getCellFromLink(held).withTx(tx),
-    );
+    const previousRoot = held === undefined
+      ? undefined
+      : heldStampRoot(pieces, held, tx);
     if (previousRoot?.getMetaRaw("slug") === validSlug) {
       previousRoot.setMetaRaw("slug", undefined, rawMetaWriteAuthorization);
     }

--- a/packages/piece/src/slugs.ts
+++ b/packages/piece/src/slugs.ts
@@ -67,6 +67,30 @@ const SLUG_INDEX_SCHEMA = {
   additionalProperties: { type: "boolean" },
 } as const satisfies JSONSchema;
 
+/** The document a name's redirect lives in, whose id derives from the name. */
+function slugCellFor(pieces: PiecesController, validSlug: string) {
+  return pieces.runtime.getCellFromEntityId(
+    pieces.getSpace(),
+    entityIdFrom(slugIdForSpace(pieces.getSpace(), validSlug)),
+  );
+}
+
+/**
+ * The reference a name's redirect reads as, or `null` for a name pointing
+ * nowhere. One spelling for the whole module: what a refusal names, what
+ * {@link readSlugBinding} answers, and what an assignment compares against
+ * are the same string, so a caller can compare them.
+ */
+function bindingRefOf(
+  pieces: PiecesController,
+  slugCell: Cell<unknown>,
+): string | null {
+  const held = parseLink(slugCell.getRaw(), slugCell);
+  return held === undefined
+    ? null
+    : createLLMFriendlyLink(held, pieces.getSpace());
+}
+
 function slugIndexCell(pieces: PiecesController) {
   return pieces.runtime.getCellFromEntityId(
     pieces.getSpace(),
@@ -92,6 +116,24 @@ export async function listSlugs(pieces: PiecesController): Promise<string[]> {
 }
 
 /**
+ * What `slug` points at now, as the reference a refusal names, or `null` for
+ * a name pointing nowhere.
+ *
+ * The value a caller hands back as `takeFrom` when it has its own rule about
+ * which of those states counts as free: read it, judge it, and carry it into
+ * the assignment, where the commit holds the judgment against the state the
+ * write actually lands on.
+ */
+export async function readSlugBinding(
+  pieces: PiecesController,
+  slug: string,
+): Promise<string | null> {
+  const slugCell = slugCellFor(pieces, validateSlug(slug));
+  await slugCell.sync();
+  return bindingRefOf(pieces, slugCell);
+}
+
+/**
  * Points `slug` at a piece and stamps the piece with the name, refusing a
  * name that is already bound the way {@link setSlugLink} does.
  */
@@ -99,24 +141,34 @@ export async function assignSlug(
   pieces: PiecesController,
   piece: Cell<unknown>,
   slug: string,
-  options?: { force?: boolean },
+  options?: { force?: boolean; takeFrom?: string | null },
 ): Promise<void> {
   await setSlugLink(pieces, slug, piece, {
     writeTargetMetadata: true,
     force: options?.force,
+    takeFrom: options?.takeFrom,
   });
 }
 
 /**
  * Points `slug` at `source`, and records the name in the space's slug index.
  *
- * A name already pointing somewhere is refused with a {@link
- * SlugAssignedError} naming the target it holds, unless `force` says to take
- * it. The refusal is a claim rather than a check: the name is read inside the
+ * A name pointing somewhere other than `takeFrom` — nowhere, for a caller
+ * that names none — is refused with a {@link SlugAssignedError} naming what
+ * it holds. `force` takes it whatever it holds, and ignores `takeFrom`.
+ *
+ * The refusal is a claim rather than a check: the name is read inside the
  * transaction the assignment commits in, so a writer that binds it between
  * that read and the commit conflicts, and `editWithRetry` re-runs the body
  * against what that writer left. Two assignments of one free name therefore
- * end with one holder, not with whichever committed last.
+ * end with one holder, not with whichever committed last — and that holds for
+ * a caller whose own rule about a free name is wider than this module's,
+ * because `takeFrom` carries that rule's answer into the transaction rather
+ * than leaving it in a read the write has outlived.
+ *
+ * Taking a name from a holder clears the `slug` entry the holder's document
+ * root carries for it, in the same transaction as the new redirect, so no
+ * document is left claiming a name it no longer holds.
  *
  * Throws when storage refuses the transaction, so a caller never reads a name
  * as assigned that never landed.
@@ -129,6 +181,7 @@ export async function setSlugLink(
     resolveBeforeLinking?: boolean;
     writeTargetMetadata?: boolean;
     force?: boolean;
+    takeFrom?: string | null;
   },
 ): Promise<void> {
   const validSlug = validateSlug(slug);
@@ -142,10 +195,7 @@ export async function setSlugLink(
     : undefined;
   await metadataTarget?.sync();
 
-  const slugCell = pieces.runtime.getCellFromEntityId(
-    pieces.getSpace(),
-    entityIdFrom(slugIdForSpace(pieces.getSpace(), validSlug)),
-  );
+  const slugCell = slugCellFor(pieces, validSlug);
 
   const indexCell = slugIndexCell(pieces);
   await indexCell.sync();
@@ -161,11 +211,27 @@ export async function setSlugLink(
     // The claim, ahead of every write so that declining stages nothing: a
     // read here joins the commit's read set, so binding the name under this
     // transaction rejects it and the body re-runs against the new holder.
-    const held = options?.force
-      ? undefined
-      : parseLink(slugWithTx.getRaw(), slugWithTx);
-    if (held !== undefined) {
-      return createLLMFriendlyLink(held, pieces.getSpace());
+    const held = parseLink(slugWithTx.getRaw(), slugWithTx);
+    const heldRef = held === undefined
+      ? null
+      : createLLMFriendlyLink(held, pieces.getSpace());
+    if (
+      !options?.force && heldRef !== null &&
+      heldRef !== (options?.takeFrom ?? null)
+    ) {
+      return heldRef;
+    }
+
+    // The name is being taken from a holder, so the holder stops claiming
+    // it. Only a document root carries the entry, and only its own name is
+    // cleared: another name pointing at the same root is not this
+    // assignment's to drop. Ahead of the stamp below, so a target that is
+    // both the old holder and the new one ends up stamped.
+    if (held !== undefined && held.path.length === 0) {
+      const holder = pieces.runtime.getCellFromLink(held).withTx(tx);
+      if (holder.getMetaRaw("slug") === validSlug) {
+        holder.setMetaRaw("slug", undefined, rawMetaWriteAuthorization);
+      }
     }
 
     const metadataTargetLink = metadataTargetWithTx

--- a/packages/piece/src/slugs.ts
+++ b/packages/piece/src/slugs.ts
@@ -98,6 +98,20 @@ export class SlugReleasedError extends Error {
  * whole maps racing. The names are the whole content — where a name points
  * stays the slug cell's own answer, because a copy of the target here would
  * be a second answer able to disagree with it. */
+/**
+ * The schema the redirect write carries. It exists to stop the write asking
+ * what the name currently resolves to: a handle with no schema resolves its
+ * own link to find one, and a name whose value is a link cycle makes that
+ * throw — so without it a forced assignment could not repoint the very state
+ * an operator forces to escape.
+ *
+ * An object with no properties describes the shape a redirect payload has and
+ * names nothing to follow, so the sync it kicks is the one document it
+ * writes. Measured against a schemaless write over a five-document chain: the
+ * same single document pulled, and the same stored value.
+ */
+const SLUG_REDIRECT_SCHEMA = { type: "object" } as const satisfies JSONSchema;
+
 const SLUG_INDEX_SCHEMA = {
   type: "object",
   additionalProperties: { type: "boolean" },
@@ -382,8 +396,11 @@ export async function setSlugLink(
       : slugStampRoot(metadataTargetWithTx);
     stampRoot?.setMetaRaw("slug", validSlug, rawMetaWriteAuthorization);
     slugWithTx.setMetaRaw("slug", validSlug, rawMetaWriteAuthorization);
-    slugWithTx.setRawUntyped(
-      targetWithTx.getAsWriteRedirectLink({ base: slugWithTx }),
+    // Only the redirect write carries the schema; the meta write above keeps
+    // the bare handle, whose sync stays the one the name was read through.
+    const redirectWrite = slugWithTx.asSchema(SLUG_REDIRECT_SCHEMA);
+    redirectWrite.setRawUntyped(
+      targetWithTx.getAsWriteRedirectLink({ base: redirectWrite }),
     );
     // The index entry rides the slug's own transaction, so a listing can
     // never see a name without its slug or a slug without its name.

--- a/packages/piece/src/slugs.ts
+++ b/packages/piece/src/slugs.ts
@@ -57,6 +57,40 @@ export class SlugAssignedError extends Error {
   }
 }
 
+/**
+ * A name that had moved on when an assignment reached it, and now points
+ * nowhere. The sibling of {@link SlugAssignedError}, and a different outcome:
+ * nobody holds the name, so the caller's answer is to read it again and try,
+ * where a name someone else holds is one to leave alone.
+ *
+ * Only a caller naming what to take the name from can see this, since a
+ * caller that names none is asking for a free name and has found one.
+ */
+export class SlugReleasedError extends Error {
+  #slug: string;
+  #expected: string;
+
+  constructor(slug: string, expected: string, remedy?: string) {
+    super(
+      `Slug "${slug}" no longer points at ${expected}, and now points ` +
+        `nowhere.` + (remedy === undefined ? "" : ` ${remedy}`),
+    );
+    this.name = "SlugReleasedError";
+    this.#slug = slug;
+    this.#expected = expected;
+  }
+
+  /** The name the assignment asked for. */
+  get slug(): string {
+    return this.#slug;
+  }
+
+  /** The reference the caller said to take the name from. */
+  get expected(): string {
+    return this.#expected;
+  }
+}
+
 /** The slug index's shape: names to `true`. Written one key at a time, so
  * two clients assigning different slugs merge as two keys rather than two
  * whole maps racing. The names are the whole content — where a name points
@@ -89,6 +123,26 @@ function bindingRefOf(
   return held === undefined
     ? null
     : createLLMFriendlyLink(held, pieces.getSpace());
+}
+
+/**
+ * The document root that carries a name for `cell`, or `undefined` when
+ * `cell` names a position inside a document rather than a document of its
+ * own. The stored `slug` entry belongs to a root, so a name pointing into one
+ * has no root of its own to stamp.
+ *
+ * One question for both sides of a reassignment — the stamp on the target
+ * taking the name and the clear on the holder losing it — because the two
+ * disagreeing is what leaves a root claiming a name that moved: a stored
+ * redirect can carry a path and still resolve to a root, and asking about the
+ * path before resolving answers about the redirect rather than about the
+ * document the name reaches.
+ */
+function slugStampRoot(cell: Cell<unknown>): Cell<unknown> | undefined {
+  const resolved = cell.resolveAsCell();
+  return resolved.getAsNormalizedFullLink().path.length === 0
+    ? resolved
+    : undefined;
 }
 
 function slugIndexCell(pieces: PiecesController) {
@@ -154,8 +208,10 @@ export async function assignSlug(
  * Points `slug` at `source`, and records the name in the space's slug index.
  *
  * A name pointing somewhere other than `takeFrom` — nowhere, for a caller
- * that names none — is refused with a {@link SlugAssignedError} naming what
- * it holds. `force` takes it whatever it holds, and ignores `takeFrom`.
+ * that names none — is refused: with a {@link SlugAssignedError} naming what
+ * it holds, or a {@link SlugReleasedError} when it has come to point nowhere,
+ * which is a name to read again rather than one to leave alone. `force` takes
+ * it whatever it holds, and ignores `takeFrom`.
  *
  * The refusal is a claim rather than a check: the name is read inside the
  * transaction the assignment commits in, so a writer that binds it between
@@ -197,13 +253,18 @@ export async function setSlugLink(
 
   const slugCell = slugCellFor(pieces, validSlug);
 
+  // Where the caller says the name points now, and so what the assignment
+  // commits only while it still points at. A caller that names none is asking
+  // for a free name, which is a name pointing nowhere.
+  const takeFrom = options?.takeFrom ?? null;
+
   const indexCell = slugIndexCell(pieces);
   await indexCell.sync();
   // The name is synced so the claim below reads what the space holds rather
   // than an absence this client never checked.
   await slugCell.sync();
 
-  const { ok: bound, error } = await pieces.runtime.editWithRetry((tx) => {
+  const { ok: refusal, error } = await pieces.runtime.editWithRetry((tx) => {
     const targetWithTx = target.withTx(tx);
     const slugWithTx = slugCell.withTx(tx);
     const metadataTargetWithTx = metadataTarget?.withTx(tx);
@@ -215,37 +276,28 @@ export async function setSlugLink(
     const heldRef = held === undefined
       ? null
       : createLLMFriendlyLink(held, pieces.getSpace());
-    if (
-      !options?.force && heldRef !== null &&
-      heldRef !== (options?.takeFrom ?? null)
-    ) {
-      return heldRef;
+    if (!options?.force && heldRef !== takeFrom) {
+      // `null` is a refusal too: a caller that named what to take the name
+      // from has not got it, whether somebody else holds the name now or
+      // nobody does.
+      return { held: heldRef };
     }
 
     // The name is being taken from a holder, so the holder stops claiming
-    // it. Only a document root carries the entry, and only its own name is
-    // cleared: another name pointing at the same root is not this
-    // assignment's to drop. Ahead of the stamp below, so a target that is
-    // both the old holder and the new one ends up stamped.
-    if (held !== undefined && held.path.length === 0) {
-      const holder = pieces.runtime.getCellFromLink(held).withTx(tx);
-      if (holder.getMetaRaw("slug") === validSlug) {
-        holder.setMetaRaw("slug", undefined, rawMetaWriteAuthorization);
-      }
+    // it. Only its own name is cleared: another name pointing at the same
+    // root is not this assignment's to drop. Ahead of the stamp below, so a
+    // root that is both the old holder and the new one ends up stamped.
+    const previousRoot = held === undefined ? undefined : slugStampRoot(
+      pieces.runtime.getCellFromLink(held).withTx(tx),
+    );
+    if (previousRoot?.getMetaRaw("slug") === validSlug) {
+      previousRoot.setMetaRaw("slug", undefined, rawMetaWriteAuthorization);
     }
 
-    const metadataTargetLink = metadataTargetWithTx
-      ?.getAsNormalizedFullLink();
-    if (
-      metadataTargetWithTx !== undefined &&
-      metadataTargetLink?.path.length === 0
-    ) {
-      metadataTargetWithTx.setMetaRaw(
-        "slug",
-        validSlug,
-        rawMetaWriteAuthorization,
-      );
-    }
+    const stampRoot = metadataTargetWithTx === undefined
+      ? undefined
+      : slugStampRoot(metadataTargetWithTx);
+    stampRoot?.setMetaRaw("slug", validSlug, rawMetaWriteAuthorization);
     slugWithTx.setMetaRaw("slug", validSlug, rawMetaWriteAuthorization);
     slugWithTx.setRawUntyped(
       targetWithTx.getAsWriteRedirectLink({ base: slugWithTx }),
@@ -261,7 +313,15 @@ export async function setSlugLink(
       { cause: error },
     );
   }
-  if (bound !== undefined) throw new SlugAssignedError(validSlug, bound);
+  if (refusal !== undefined) {
+    if (refusal.held !== null) {
+      throw new SlugAssignedError(validSlug, refusal.held);
+    }
+    // A name pointing nowhere only refuses a caller that named somewhere for
+    // it to point, because `takeFrom` of `null` is what a name pointing
+    // nowhere matches. So there is a reference to report here.
+    throw new SlugReleasedError(validSlug, takeFrom!);
+  }
 
   await pieces.runtime.idle();
   await pieces.synced();

--- a/packages/piece/test/slug.test.ts
+++ b/packages/piece/test/slug.test.ts
@@ -438,6 +438,9 @@ describe("piece slugs", () => {
     );
 
     expect(failure).toBeInstanceOf(SlugReleasedError);
+    // Both halves of what a caller acts on: which name to read again, and
+    // the target its rule was about.
+    expect((failure as SlugReleasedError).slug).toBe("demo");
     expect((failure as SlugReleasedError).expected).toBe(gone);
     // Refused, so the name was not written: the caller's rule was about a
     // target that is not there, and taking it anyway is what it excluded.
@@ -532,6 +535,54 @@ describe("piece slugs", () => {
       piece: String(plain.getAsNormalizedFullLink().id).replace(/^of:/, ""),
       pathInside: [],
     });
+  });
+
+  it("takes a name whose value is a link cycle, which is what forcing is for", async () => {
+    // The state an operator forces to escape. Two things have to hold at
+    // once: the write must land on a name whose own value cycles, and the
+    // cleanup that rides along must not resolve that cycle and throw — an
+    // old target that will not resolve has no root carrying the name, which
+    // is nothing to clear rather than a reason to refuse. Both shapes,
+    // because a self-cycle is the one an assignment can point a name at and
+    // a two-step cycle is the one two of them can.
+    const slugCell = runtime.getCellFromEntityId(
+      pieces.getSpace(),
+      entityIdFrom(slugIdForSpace(pieces.getSpace(), "demo")),
+    );
+    await runtime.editWithRetry((tx) => {
+      const cell = slugCell.withTx(tx);
+      cell.setRawUntyped(cell.getAsWriteRedirectLink({ base: cell }));
+    });
+    const first = await createPiece("cycle-first");
+
+    await assignSlug(pieces, first, "demo", { force: true });
+
+    expect(await resolvePieceAddress(pieces, "demo")).toBe(pieceId(first));
+
+    const left = runtime.getCell(
+      pieces.getSpace(),
+      { space: pieces.getSpace(), random: "cycle-left" },
+    );
+    const right = runtime.getCell(
+      pieces.getSpace(),
+      { space: pieces.getSpace(), random: "cycle-right" },
+    );
+    await runtime.editWithRetry((tx) => {
+      left.withTx(tx).setRawUntyped(
+        right.withTx(tx).getAsWriteRedirectLink({ base: left.withTx(tx) }),
+      );
+      right.withTx(tx).setRawUntyped(
+        left.withTx(tx).getAsWriteRedirectLink({ base: right.withTx(tx) }),
+      );
+      slugCell.withTx(tx).setRawUntyped(
+        left.withTx(tx).getAsWriteRedirectLink({ base: slugCell.withTx(tx) }),
+      );
+    });
+    const second = await createPiece("cycle-second");
+
+    await assignSlug(pieces, second, "demo", { force: true });
+
+    expect(await resolvePieceAddress(pieces, "demo")).toBe(pieceId(second));
   });
 
   it("reads a name whose target is a redirect cycle as its own state", async () => {

--- a/packages/piece/test/slug.test.ts
+++ b/packages/piece/test/slug.test.ts
@@ -4,14 +4,19 @@ import { createSession, Identity } from "@commonfabric/identity";
 import {
   type Cell,
   entityIdFrom,
+  type MemorySpace,
   Runtime,
   type URI,
 } from "@commonfabric/runner";
 import { rawMetaWriteAuthorization } from "@commonfabric/runner/meta-seam";
-import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import {
+  EmulatedStorageManager,
+  newLoopbackServer,
+  StorageManager,
+} from "@commonfabric/runner/storage/cache.deno";
 import { createBuilder } from "../../runner/src/builder/factory.ts";
 import { parseLink } from "../../runner/src/link-utils.ts";
-import { slugIdForSpace } from "../../runner/src/slugs.ts";
+import { slugIdForSpace, slugIndexIdForSpace } from "../../runner/src/slugs.ts";
 import { pieceId } from "../src/piece-id.ts";
 import { PiecesController } from "../src/ops/pieces-controller.ts";
 import {
@@ -22,6 +27,7 @@ import {
   resolveSlugTarget,
   resolveSlugTargetCell,
   setSlugLink,
+  SlugAssignedError,
   SlugResolutionError,
 } from "../src/slugs.ts";
 
@@ -57,6 +63,11 @@ describe("piece slugs", () => {
       { value },
     ) => ({ value }));
     return await pieces.runPersistent(piecePattern, { value: 1 }, cause);
+  }
+
+  /** What `work` rejected with, or `undefined` when it resolved. */
+  async function failureOf(work: Promise<unknown>): Promise<unknown> {
+    return await work.then(() => undefined, (error: unknown) => error);
   }
 
   function readRootMeta(id: string, key: string): unknown {
@@ -129,7 +140,7 @@ describe("piece slugs", () => {
     await assignSlug(pieces, piece, "board");
     await setSlugLink(pieces, "tracker", other);
     // Repointing a name changes where it resolves, never how it is listed.
-    await setSlugLink(pieces, "board", other);
+    await setSlugLink(pieces, "board", other, { force: true });
 
     expect(await listSlugs(pieces)).toEqual(["board", "tracker"]);
     expect(await resolvePieceAddress(pieces, "board")).toBe(pieceId(other)!);
@@ -280,14 +291,68 @@ describe("piece slugs", () => {
     );
   });
 
-  it("overwrites an existing slug redirect", async () => {
-    const first = await createPiece("slug-first");
-    const second = await createPiece("slug-second");
+  it("refuses a name that is already bound, naming what it points at", async () => {
+    const held = await createPiece("slug-held");
+    const taking = await createPiece("slug-taking");
+    await assignSlug(pieces, held, "demo");
 
-    await assignSlug(pieces, first, "demo");
-    await assignSlug(pieces, second, "demo");
+    const failure = await failureOf(setSlugLink(pieces, "demo", taking));
 
-    expect(await resolvePieceAddress(pieces, "demo")).toBe(pieceId(second));
+    expect(failure).toBeInstanceOf(SlugAssignedError);
+    const refusal = failure as SlugAssignedError;
+    expect(refusal.slug).toBe("demo");
+    // The target is a reference the caller can read and write back, so the
+    // refusal says what taking the name would have cost.
+    expect(refusal.target).toBe(
+      `/${held.getAsNormalizedFullLink().id}`,
+    );
+    expect(refusal.message).toContain(refusal.target);
+    // The name still points where it did: the refusal protected the address
+    // rather than merely reporting on it.
+    expect(await resolvePieceAddress(pieces, "demo")).toBe(pieceId(held));
+  });
+
+  it("takes a bound name when the caller forces it", async () => {
+    const held = await createPiece("slug-held");
+    const taking = await createPiece("slug-taking");
+    await assignSlug(pieces, held, "demo");
+
+    await assignSlug(pieces, taking, "demo", { force: true });
+
+    expect(await resolvePieceAddress(pieces, "demo")).toBe(pieceId(taking));
+  });
+
+  it("gives one name to exactly one of two writers claiming it at once", async () => {
+    // A genuine overlap, not a sequence: `editWithRetry` runs its body
+    // synchronously, so the second body reads the name while the first
+    // transaction is still open, and the second sees what the first staged.
+    // The two targets differ, so a guard that let both through would leave
+    // the loser's target standing, which the last assertion would see.
+    const first = await createPiece("slug-race-first");
+    const second = await createPiece("slug-race-second");
+    expect(pieceId(first)).not.toBe(pieceId(second));
+
+    const outcomes = await Promise.all([
+      failureOf(setSlugLink(pieces, "contested", first)),
+      failureOf(setSlugLink(pieces, "contested", second)),
+    ]);
+
+    const [winner, loser] = outcomes[0] === undefined
+      ? [first, second]
+      : [second, first];
+    expect(outcomes.filter((outcome) => outcome === undefined)).toHaveLength(1);
+    const refusal = outcomes.find((outcome) => outcome !== undefined);
+    expect(refusal).toBeInstanceOf(SlugAssignedError);
+    // The refusal names the holder the loser lost to, not its own target.
+    expect((refusal as SlugAssignedError).target).toBe(
+      `/${winner.getAsNormalizedFullLink().id}`,
+    );
+    expect(await resolvePieceAddress(pieces, "contested")).toBe(
+      pieceId(winner),
+    );
+    expect(await resolvePieceAddress(pieces, "contested")).not.toBe(
+      pieceId(loser),
+    );
   });
 
   it("reports missing and malformed slug documents", async () => {
@@ -319,10 +384,6 @@ describe("piece slugs", () => {
     let boardId: string;
     let item1: Cell<unknown>;
     let item2: Cell<unknown>;
-
-    async function failureOf(work: Promise<unknown>): Promise<unknown> {
-      return await work.then(() => undefined, (error: unknown) => error);
-    }
 
     beforeEach(async () => {
       item1 = await createPiece("member-1");
@@ -429,6 +490,106 @@ describe("piece slugs", () => {
         expect(error).toBeInstanceOf(SlugResolutionError);
         expect((error as SlugResolutionError).code).toBe("not-piece");
       });
+    });
+  });
+  describe("the read a refusal claims on", () => {
+    // What `setSlugLink`'s refusal rests on: whether reading the name inside
+    // the transaction puts it in the commit's read set, so that binding the
+    // name under an assignment rejects the assignment instead of letting it
+    // write over the new holder.
+    //
+    // Two sessions on one server with fan-out held manual, so a stale basis
+    // is a gated state rather than a timing accident. The write under test
+    // lands on the slug INDEX, a different document from the slug the body
+    // reads, so nothing but the read can carry a conflict — the pair of
+    // tests differs in the read alone.
+
+    let server: ReturnType<typeof newLoopbackServer>;
+    let holderStorage: EmulatedStorageManager;
+    let holderRuntime: Runtime;
+    let takerStorage: EmulatedStorageManager;
+    let takerRuntime: Runtime;
+    let space: MemorySpace;
+    let slugCellId: string;
+
+    /** A cell in the shared space, addressed the same way from either side. */
+    function cellOf(runtime: Runtime, id: string) {
+      return runtime.getCellFromEntityId(space, entityIdFrom(id));
+    }
+
+    beforeEach(async () => {
+      server = newLoopbackServer({ subscriptionRefreshDelayMs: "manual" });
+      holderStorage = EmulatedStorageManager.connectTo(server, { as: signer });
+      holderRuntime = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager: holderStorage,
+      });
+      takerStorage = EmulatedStorageManager.connectTo(server, { as: signer });
+      takerRuntime = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager: takerStorage,
+      });
+      space = signer.did() as MemorySpace;
+      slugCellId = slugIdForSpace(space, "contested");
+
+      // The name starts bound to the first target, and both sessions hold
+      // that basis.
+      const first = holderRuntime.getCell(space, "contested-first");
+      const seed = holderRuntime.edit();
+      cellOf(holderRuntime, slugCellId).withTx(seed).setRawUntyped(
+        first.withTx(seed).getAsWriteRedirectLink({
+          base: cellOf(holderRuntime, slugCellId).withTx(seed),
+        }),
+      );
+      await seed.commit({ resolveAt: "verdict" });
+      await holderRuntime.storageManager.synced();
+      await cellOf(takerRuntime, slugCellId).sync();
+      await cellOf(takerRuntime, slugCellId).pull();
+      await cellOf(takerRuntime, slugIndexIdForSpace(space)).sync();
+
+      // The holder rebinds the name. The taker's basis is now behind, and
+      // the held fan-out keeps it there.
+      const second = holderRuntime.getCell(space, "contested-second");
+      const rebind = holderRuntime.edit();
+      cellOf(holderRuntime, slugCellId).withTx(rebind).setRawUntyped(
+        second.withTx(rebind).getAsWriteRedirectLink({
+          base: cellOf(holderRuntime, slugCellId).withTx(rebind),
+        }),
+      );
+      await rebind.commit({ resolveAt: "verdict" });
+      await holderRuntime.storageManager.synced();
+    });
+
+    afterEach(async () => {
+      await takerRuntime?.dispose();
+      await holderRuntime?.dispose();
+      await takerStorage?.close();
+      await holderStorage?.close();
+      await server?.close();
+    });
+
+    /**
+     * The taker's transaction: it writes the slug index the way an
+     * assignment does, having first read the name it is claiming when
+     * `readName` says so. Answers the commit's rejection, or `undefined`.
+     */
+    async function commitFromStaleBasis(
+      readName: boolean,
+    ): Promise<{ name?: string } | undefined> {
+      const tx = takerRuntime.edit();
+      if (readName) cellOf(takerRuntime, slugCellId).withTx(tx).getRaw();
+      cellOf(takerRuntime, slugIndexIdForSpace(space)).withTx(tx)
+        .key("contested").set(true);
+      const { error } = await tx.commit({ resolveAt: "verdict" });
+      return error;
+    }
+
+    it("rejects the commit when the body read the name another writer had bound", async () => {
+      expect((await commitFromStaleBasis(true))?.name).toBe("ConflictError");
+    });
+
+    it("commits the same write when the body did not read that name", async () => {
+      expect(await commitFromStaleBasis(false)).toBeUndefined();
     });
   });
 });

--- a/packages/piece/test/slug.test.ts
+++ b/packages/piece/test/slug.test.ts
@@ -22,6 +22,7 @@ import { PiecesController } from "../src/ops/pieces-controller.ts";
 import {
   assignSlug,
   listSlugs,
+  readSlugBinding,
   resolvePieceAddress,
   resolvePieceReference,
   resolveSlugTarget,
@@ -322,10 +323,81 @@ describe("piece slugs", () => {
     expect(await resolvePieceAddress(pieces, "demo")).toBe(pieceId(taking));
   });
 
+  it("clears the name from the holder a forced assignment takes it from", async () => {
+    const held = await createPiece("slug-held");
+    const taking = await createPiece("slug-taking");
+    await assignSlug(pieces, held, "demo");
+    expect(readRootMeta(pieceId(held)!, "slug")).toBe("demo");
+
+    await assignSlug(pieces, taking, "demo", { force: true });
+
+    // Both sides, because a test of the new side alone passes against a
+    // system that never clears the old one.
+    expect(readRootMeta(pieceId(taking)!, "slug")).toBe("demo");
+    expect(readRootMeta(pieceId(held)!, "slug")).toBeUndefined();
+  });
+
+  it("leaves a holder's own name alone when the name taken from it is another", async () => {
+    // The entry is single-valued, so the last name assigned is the one the
+    // root claims. Taking `demo` back must not drop the claim to `latest`,
+    // which is a different name that still resolves here.
+    const held = await createPiece("slug-held");
+    const taking = await createPiece("slug-taking");
+    await assignSlug(pieces, held, "demo");
+    await assignSlug(pieces, held, "latest");
+    expect(readRootMeta(pieceId(held)!, "slug")).toBe("latest");
+
+    await assignSlug(pieces, taking, "demo", { force: true });
+
+    expect(readRootMeta(pieceId(held)!, "slug")).toBe("latest");
+  });
+
+  it("takes a name still pointing where the caller last read it", async () => {
+    // A caller whose own rule calls this state free carries that answer in
+    // rather than forcing over whatever is there.
+    const held = await createPiece("slug-held");
+    const taking = await createPiece("slug-taking");
+    await assignSlug(pieces, held, "demo");
+
+    const seen = await readSlugBinding(pieces, "demo");
+    await assignSlug(pieces, taking, "demo", { takeFrom: seen });
+
+    expect(await resolvePieceAddress(pieces, "demo")).toBe(pieceId(taking));
+  });
+
+  it("refuses a name that moved since the caller read it, naming where it went", async () => {
+    const first = await createPiece("slug-first");
+    const moved = await createPiece("slug-moved");
+    const taking = await createPiece("slug-taking");
+    await assignSlug(pieces, first, "demo");
+    const seen = await readSlugBinding(pieces, "demo");
+    // Somebody else takes the name between the caller's read and its write.
+    await assignSlug(pieces, moved, "demo", { force: true });
+
+    const failure = await failureOf(
+      assignSlug(pieces, taking, "demo", { takeFrom: seen }),
+    );
+
+    expect(failure).toBeInstanceOf(SlugAssignedError);
+    expect((failure as SlugAssignedError).target).toBe(
+      `/${moved.getAsNormalizedFullLink().id}`,
+    );
+    expect(await resolvePieceAddress(pieces, "demo")).toBe(pieceId(moved));
+  });
+
   it("gives one name to exactly one of two writers claiming it at once", async () => {
     // A genuine overlap, not a sequence: `editWithRetry` runs its body
-    // synchronously, so the second body reads the name while the first
-    // transaction is still open, and the second sees what the first staged.
+    // synchronously, so both bodies run before either transaction commits,
+    // and the second reads the name as already pointing at the first's
+    // target. It declines there, with no rejection and no retry.
+    //
+    // Two writers whose replicas are behind each other are serialized by
+    // something else — the stale-basis rejection, and the re-run
+    // `editWithRetry` drives off it, which is the shape
+    // `packages/runner/src/ensure-space-root.ts` states for the space root.
+    // The pair under "the read a refusal claims on" below is what pins the
+    // read that shape depends on.
+    //
     // The two targets differ, so a guard that let both through would leave
     // the loser's target standing, which the last assertion would see.
     const first = await createPiece("slug-race-first");

--- a/packages/piece/test/slug.test.ts
+++ b/packages/piece/test/slug.test.ts
@@ -446,18 +446,126 @@ describe("piece slugs", () => {
     );
   });
 
-  it("gives one name to exactly one of two writers claiming it at once", async () => {
-    // A genuine overlap, not a sequence: `editWithRetry` runs its body
-    // synchronously, so both bodies run before either transaction commits,
-    // and the second reads the name as already pointing at the first's
-    // target. It declines there, with no rejection and no retry.
+  it("assigns over a name whose document holds a payload no redirect can be read from", async () => {
+    // A slug document can be written by a foreign client over the memory
+    // protocol, and this runtime's own write path rejects such a value — so
+    // the read is where one has to be presented. `parseSlugRedirect` folds a
+    // sigil-shaped payload with broken internals into the same "points
+    // nowhere" the resolver reports as malformed; reading it any other way
+    // throws out of an assignment over a name nothing resolves through.
+    const piece = await createPiece("malformed-target");
+    const slugEntity = JSON.stringify(
+      entityIdFrom(slugIdForSpace(pieces.getSpace(), "demo")),
+    );
+    const poisoned = {
+      "/": {
+        "link@1": {
+          id: "of:fid1:whatever",
+          path: "not-an-array",
+          overwrite: "redirect",
+        },
+      },
+    };
+    const poison = (cell: Cell<unknown>): Cell<unknown> =>
+      new Proxy(cell, {
+        get(target, property) {
+          if (property === "getRaw") return () => poisoned;
+          if (property === "withTx") {
+            return (tx: unknown) =>
+              poison(
+                (target.withTx as (tx: unknown) => Cell<unknown>)(tx),
+              );
+          }
+          const value = Reflect.get(target, property, target);
+          return typeof value === "function" ? value.bind(target) : value;
+        },
+      });
+    const originalGetCell = runtime.getCellFromEntityId.bind(runtime);
+    runtime.getCellFromEntityId = ((
+      ...args: Parameters<Runtime["getCellFromEntityId"]>
+    ) => {
+      const cell = originalGetCell(...args);
+      return JSON.stringify(args[1]) === slugEntity ? poison(cell) : cell;
+    }) as Runtime["getCellFromEntityId"];
+
+    try {
+      await assignSlug(pieces, piece, "demo");
+    } finally {
+      runtime.getCellFromEntityId = originalGetCell;
+    }
+
+    expect(await resolvePieceAddress(pieces, "demo")).toBe(pieceId(piece));
+  });
+
+  it("refuses when the target the caller judged free has become a piece", async () => {
+    // The rule a `takeFrom` caller applies can read the TARGET — the harness
+    // calls a name free when it resolves to no piece — and the redirect does
+    // not change when the target becomes one. A claim over the pointer alone
+    // would match and repoint a name that now names a piece, which is the
+    // race this whole guard exists to close, one level down.
+    const plain = runtime.getCell(
+      pieces.getSpace(),
+      { space: pieces.getSpace(), random: "becomes-a-piece" },
+    );
+    await runtime.editWithRetry((tx) => {
+      plain.withTx(tx).set({ value: 1 });
+    });
+    await setSlugLink(pieces, "demo", plain);
+    const seen = await readSlugBinding(pieces, "demo");
+    // The target gains a pattern identity, so the same redirect now names a
+    // piece and the caller's rule would no longer call the name free.
+    await runtime.editWithRetry((tx) => {
+      plain.withTx(tx).setMetaRaw(
+        "patternIdentity",
+        { identity: "pattern-late", symbol: "default" },
+        rawMetaWriteAuthorization,
+      );
+    });
+    const taking = await createPiece("slug-taking");
+
+    const failure = await failureOf(
+      assignSlug(pieces, taking, "demo", { takeFrom: seen }),
+    );
+
+    expect(failure).toBeInstanceOf(SlugAssignedError);
+    expect(await resolveSlugTarget(pieces, "demo")).toEqual({
+      piece: String(plain.getAsNormalizedFullLink().id).replace(/^of:/, ""),
+      pathInside: [],
+    });
+  });
+
+  it("reads a name whose target is a redirect cycle as its own state", async () => {
+    // A cycle is a state a caller's rule has to be able to hold an opinion
+    // about, so the claim records it rather than throwing out of the read.
+    // It compares like any other: a name stops resolving nowhere only by
+    // being written.
+    const slugCell = runtime.getCellFromEntityId(
+      pieces.getSpace(),
+      entityIdFrom(slugIdForSpace(pieces.getSpace(), "demo")),
+    );
+    await runtime.editWithRetry((tx) => {
+      const cell = slugCell.withTx(tx);
+      cell.setRawUntyped(cell.getAsWriteRedirectLink({ base: cell }));
+    });
+
+    const seen = await readSlugBinding(pieces, "demo");
+
+    expect(seen).toContain("unresolvable");
+  });
+
+  it("gives one name to the first of two assignments and refuses the second", async () => {
+    // Two assignments of one free name, started together and settling one
+    // after the other. What this asserts is the outcome — exactly one writer
+    // takes the name — and nothing about the interleaving: the assertions
+    // hold whether the two overlapped or ran in sequence, so the test does
+    // not establish which, and no comment here should claim one.
     //
-    // Two writers whose replicas are behind each other are serialized by
-    // something else — the stale-basis rejection, and the re-run
-    // `editWithRetry` drives off it, which is the shape
-    // `packages/runner/src/ensure-space-root.ts` states for the space root.
-    // The pair under "the read a refusal claims on" below is what pins the
-    // read that shape depends on.
+    // What the runtime guarantees is separate and stated where it is pinned:
+    // the claim's read joins the commit's read set, so a commit racing
+    // another is rejected and the body re-runs against the new holder and
+    // then declines. The pair under "the read a refusal claims on" below is
+    // what establishes that read, over two sessions where the losing
+    // replica is provably behind.
     //
     // The two targets differ, so a guard that let both through would leave
     // the loser's target standing, which the last assertion would see.

--- a/packages/piece/test/slug.test.ts
+++ b/packages/piece/test/slug.test.ts
@@ -29,6 +29,7 @@ import {
   resolveSlugTargetCell,
   setSlugLink,
   SlugAssignedError,
+  SlugReleasedError,
   SlugResolutionError,
 } from "../src/slugs.ts";
 
@@ -337,6 +338,43 @@ describe("piece slugs", () => {
     expect(readRootMeta(pieceId(held)!, "slug")).toBeUndefined();
   });
 
+  it("clears the name from a holder reached through a redirect with a path", async () => {
+    // The stamp lands on the RESOLVED root, so the clear has to ask the same
+    // question of the old holder. A stored redirect carrying a path can still
+    // resolve to a root: reading the path off the redirect answers about the
+    // redirect, and the root it reaches keeps the name it no longer holds —
+    // two roots stamped `demo`, which is the state the reverse map cannot
+    // represent.
+    const output = runtime.getCell(
+      pieces.getSpace(),
+      { space: pieces.getSpace(), random: "redirect-output" },
+    );
+    const intermediate = runtime.getCell(
+      pieces.getSpace(),
+      { space: pieces.getSpace(), random: "redirect-intermediate" },
+    );
+    await runtime.editWithRetry((tx) => {
+      output.withTx(tx).set({ value: 1 });
+      intermediate.withTx(tx).key("child").setRawUntyped(
+        output.withTx(tx).getAsWriteRedirectLink({
+          base: intermediate.withTx(tx).key("child"),
+        }),
+      );
+    });
+    const outputId = String(output.getAsNormalizedFullLink().id)
+      .replace(/^of:/, "");
+    await setSlugLink(pieces, "demo", intermediate.key("child"), {
+      writeTargetMetadata: true,
+    });
+    expect(readRootMeta(outputId, "slug")).toBe("demo");
+    const taking = await createPiece("slug-taking");
+
+    await assignSlug(pieces, taking, "demo", { force: true });
+
+    expect(readRootMeta(pieceId(taking)!, "slug")).toBe("demo");
+    expect(readRootMeta(outputId, "slug")).toBeUndefined();
+  });
+
   it("leaves a holder's own name alone when the name taken from it is another", async () => {
     // The entry is single-valued, so the last name assigned is the one the
     // root claims. Taking `demo` back must not drop the claim to `latest`,
@@ -383,6 +421,29 @@ describe("piece slugs", () => {
       `/${moved.getAsNormalizedFullLink().id}`,
     );
     expect(await resolvePieceAddress(pieces, "demo")).toBe(pieceId(moved));
+  });
+
+  it("refuses a name the caller named a target for that now points nowhere", async () => {
+    // The fifth state of the claim, and the one an extra clause used to let
+    // through: `takeFrom` says commit only while the name points at that
+    // target, and a name pointing NOWHERE is not that target. A caller that
+    // named none is asking for a free name and gets one — the tests above —
+    // so nothing about the default rests on this.
+    const taking = await createPiece("slug-taking");
+    const elsewhere = await createPiece("slug-elsewhere");
+    const gone = `/${elsewhere.getAsNormalizedFullLink().id}`;
+
+    const failure = await failureOf(
+      assignSlug(pieces, taking, "demo", { takeFrom: gone }),
+    );
+
+    expect(failure).toBeInstanceOf(SlugReleasedError);
+    expect((failure as SlugReleasedError).expected).toBe(gone);
+    // Refused, so the name was not written: the caller's rule was about a
+    // target that is not there, and taking it anyway is what it excluded.
+    await expect(resolvePieceAddress(pieces, "demo")).rejects.toThrow(
+      /Slug "demo" not found/,
+    );
   });
 
   it("gives one name to exactly one of two writers claiming it at once", async () => {

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -374,7 +374,9 @@ export {
 export { type PinRewrite, rewriteFabricPins } from "./fabric-pin-rewrite.ts";
 export { DEFAULT_CELL_SCOPE } from "./scope.ts";
 export {
+  isPieceDocument,
   isPieceRoot,
+  parseSlugRedirect,
   resolveSlugReference,
   resolveSlugTargetCell,
   resolveSlugTargetInPiece,

--- a/packages/runner/src/slug-resolution.ts
+++ b/packages/runner/src/slug-resolution.ts
@@ -38,7 +38,7 @@ export class SlugResolutionError extends Error {
  * for every cell in a piece's document whatever its path; {@link isPieceRoot}
  * is the test for the piece itself.
  */
-function isPieceDocument(
+export function isPieceDocument(
   runtime: Runtime,
   cell: Cell<unknown>,
 ): boolean {
@@ -243,7 +243,12 @@ export async function resolveSlugTargetCell(
  * this runtime's own write path rejects such values, but a slug cell can be
  * written by foreign clients over the memory protocol, so the resolver must
  * fold a parse throw into the same typed "malformed" outcome as a
- * structurally-invalid payload. Exported for tests.
+ * structurally-invalid payload.
+ *
+ * The one question about what a name holds, so a reader and a writer cannot
+ * disagree about it: `packages/piece/src/slugs.ts` asks it before assigning,
+ * and would otherwise let a payload this resolver reports as malformed throw
+ * out of an assignment instead.
  */
 export function parseSlugRedirect(raw: unknown, base: Cell<unknown>) {
   try {

--- a/packages/shell/integration/piece.test.ts
+++ b/packages/shell/integration/piece.test.ts
@@ -22,6 +22,8 @@ async function runCfPieceNewWithSlug(options: {
   sourcePath: string;
   identityPath: string;
   slug: string;
+  /** Take a name that already points somewhere, which `cf` refuses without. */
+  force?: boolean;
 }): Promise<string> {
   const command = new Deno.Command(Deno.execPath(), {
     cwd: REPO_ROOT,
@@ -40,6 +42,7 @@ async function runCfPieceNewWithSlug(options: {
       SPACE_NAME,
       "--slug",
       options.slug,
+      ...(options.force ? ["--force"] : []),
     ],
     env: {
       CF_LOG_LEVEL: "error",
@@ -404,10 +407,13 @@ describe("shell piece tests", () => {
       identity,
     });
 
+    // Repointing is what this test is about, and taking a name that already
+    // points somewhere is what `--force` is for.
     const secondPieceId = await runCfPieceNewWithSlug({
       sourcePath: secondSource,
       identityPath,
       slug,
+      force: true,
     });
     expect(secondPieceId).not.toBe(firstPieceId);
 


### PR DESCRIPTION
## Why

A name that anyone can take by accident is not a name. `setSlugLink` did not
read the slug cell before writing it, so assigning an assigned name overwrote
it silently — and every reference through that name moved with it, with nothing
said. This is stage S2b of `docs/plans/collection-naming-topics.md`, the first
half of the spec's implementation-road step 2.

## What Changed

**Assignment claims rather than overwrites.** The slug cell is synced and read
at the top of the `editWithRetry` body, ahead of every write. A bound name is
refused with the address it currently holds, spelled the way `set-slug` takes a
source, so the refusal can be pasted back. `--force` steals, and has a README
sentence and completion coverage.

The claim is a claim, not a check-then-write: the read makes the commit
conditional on what was read, so a writer that lost the race re-runs and
refuses rather than overwriting. **Two writers, exactly one winner**, with the
interleaving verified rather than assumed — instrumenting the retry recorded
both bodies running before either transaction committed.

## The open question this settles

The spec asked whether a synced read inside an `editWithRetry` body becomes a
commit precondition, and step 2 rested on it. **It does**, and the answer is
now recorded in that bullet with its evidence: two sessions on one server with
subscription refresh held manual, where the loser reads the slug document and
then writes a *different* document, and the commit is rejected as a conflict;
without the read it commits clean. The rejection is retryable, so the
transaction re-runs and the claim becomes a refusal. The preamble that counted
that question among the blockers is trimmed, and its list and its count agree
again.

Measured and deliberately left out of the spec: on the slug document itself a
stale whole-document write is rejected anyway, so the claim is doubly held
there. The read is what turns the re-run into a refusal instead of an
overwrite.

## What a steal costs, written down

Forcing a name stamps `slug` into the target document's root, and naming the
slug back does not clear it, so a member a steal passed through keeps a
canonical URL naming a name it no longer holds. That is the reverse-map gap the
implementation road's step 1 closes; nothing in the `cf` surface clears it
before then, and the demo's restoration needed a raw metadata write. Recorded
under S2b in the plan, because S3 renders canonical URLs from exactly that
entry.

## Two changes outside the briefed scope

`renderCliError` keeps an allow-list of user-facing error classes, and without
an entry the refusal printed a stack trace or the whole usage page — neither is
a refusal a person can read. The new error joins the list, and takes the remedy
from its caller so `--force` stays out of `packages/piece`'s vocabulary: the
library states the condition, the CLI states its own remedy.

`cf-harness`'s `assign_slug` answers a narrower question than the library does,
and its comment claimed assignment was a blind write. It forces deliberately
now, with the comment rewritten to say why and a test pinning the choice, so
the two do not disagree about one name.

## Test plan

- `deno fmt --check`, `deno lint`, `deno task check`, `check-completion-slots`,
  `check-command-docs`, `check-docs`, `check-no-waitfor`,
  `check-control-characters`, `check-conflict-markers`: clean.
- `packages/piece` 56 passed, `packages/cli` 212 passed.
- Nine mutations, each run in isolation so none could borrow redness from
  another scenario's failure: the guard forced open, the read removed, the read
  forced always, force pinned both ways, the rethrow removed, and the harness's
  force dropped. Each reds exactly the test that names it, and the forced-steal
  test stays green where it must.
- Every refusal test uses a *different* second target and asserts the first
  survives, so removing the guard cannot write back what the assertion reads.
- Demo on an isolated local toolshed, read before written and restored after —
  including clearing the metadata the forced steal stranded, and re-reading to
  confirm.
- The `cf-harness` `run-measurement-batch` suite fails 7 steps here and at the
  unchanged base commit alike; it checks a fixture commit against the local
  `main` ref, which is stale in this checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kp8NcNXPougGPyJCEyYtob


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6898?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

