### PR TITLE
refactor(background-piece-service): `SpaceManager` keeps its state in `#` fields behind `accessForTestingOnly`

### DIFF
--- a/docs/development/waiting-in-tests.md
+++ b/docs/development/waiting-in-tests.md
@@ -662,7 +662,7 @@ clock for the same reason the runner does: the service's own machinery is
 time-coupled, so freezing every positive-delay timer would deadlock a plain test
 on the service's own loop rather than on any sleep the test wrote.
 
-Three pieces of the service arm positive-delay timers. `SpaceManager.execLoop`
+Three pieces of the service arm positive-delay timers. `SpaceManager.#execLoop`
 parks on `sleep(pollingIntervalMs)` between polls of its task queue.
 `SpaceManager.stop` races a `setInterval` that watches for the active job to
 finish against a `sleep(deactivationTimeoutMs)` deadline. And

--- a/packages/background-piece-service/src/space-manager.ts
+++ b/packages/background-piece-service/src/space-manager.ts
@@ -68,37 +68,37 @@ export class SpaceManager {
     setupWorkerController(): Promise<void>;
   } {
     // deno-lint-ignore no-this-alias
-    const manager = this;
+    const outerThis = this;
     return {
       get activePiece() {
-        return manager.#activePiece;
+        return outerThis.#activePiece;
       },
       set activePiece(value) {
-        manager.#activePiece = value;
+        outerThis.#activePiece = value;
       },
       get enabledPieces() {
-        return manager.#enabledPieces;
+        return outerThis.#enabledPieces;
       },
       get failureTracking() {
-        return manager.#failureTracking;
+        return outerThis.#failureTracking;
       },
       get isRunning() {
-        return manager.#isRunning;
+        return outerThis.#isRunning;
       },
       set isRunning(value) {
-        manager.#isRunning = value;
+        outerThis.#isRunning = value;
       },
       get pendingTasks() {
-        return manager.#pendingTasks;
+        return outerThis.#pendingTasks;
       },
       set pendingTasks(value) {
-        manager.#pendingTasks = value;
+        outerThis.#pendingTasks = value;
       },
       get workerController() {
-        return manager.#workerController;
+        return outerThis.#workerController;
       },
       set workerController(value) {
-        manager.#workerController = value;
+        outerThis.#workerController = value;
       },
       execLoop: () => this.#execLoop(),
       processPiece: (pieceId, entry) => this.#processPiece(pieceId, entry),

--- a/packages/background-piece-service/src/space-manager.ts
+++ b/packages/background-piece-service/src/space-manager.ts
@@ -23,48 +23,15 @@ type Task = {
 export class SpaceManager {
   #did: string;
   #pollingIntervalMs: number;
-
-  /**
-   * TypeScript-private rather than a `#` name: `test/service-modules.test.ts`
-   * drives this member directly.
-   */
-  private enabledPieces = new Map<string, Cell<BGPieceEntry>>();
-
-  /**
-   * TypeScript-private rather than a `#` name: `test/service-modules.test.ts`
-   * drives this member directly.
-   */
-  private activePiece: Cell<BGPieceEntry> | null = null;
-
+  #enabledPieces = new Map<string, Cell<BGPieceEntry>>();
+  #activePiece: Cell<BGPieceEntry> | null = null;
   #deactivationTimeoutMs: number;
-
-  /**
-   * TypeScript-private rather than a `#` name: `test/service-modules.test.ts`
-   * drives this member directly.
-   */
-  private workerController!: WorkerController;
-
+  #workerController!: WorkerController;
   #rerunIntervalMs: number;
-
-  /**
-   * TypeScript-private rather than a `#` name: `test/service-modules.test.ts`
-   * drives this member directly.
-   */
-  private pendingTasks: Task[] = [];
-
-  /**
-   * TypeScript-private rather than a `#` name: `test/service-modules.test.ts`
-   * drives this member directly.
-   */
-  private failureTracking = new Map<string, number>();
-
+  #pendingTasks: Task[] = [];
+  #failureTracking = new Map<string, number>();
   #workerOptions: WorkerOptions;
-
-  /**
-   * TypeScript-private rather than a `#` name: `test/service-modules.test.ts`
-   * drives this member directly.
-   */
-  private isRunning = false;
+  #isRunning = false;
 
   constructor(options: PieceSchedulerOptions) {
     this.#did = options.did;
@@ -72,11 +39,71 @@ export class SpaceManager {
     this.#deactivationTimeoutMs = options.deactivationTimeoutMs ?? 10000;
     this.#rerunIntervalMs = options.rerunIntervalMs ?? 60000;
     this.#workerOptions = options;
-    this.setupWorkerController();
+    this.#setupWorkerController();
 
     console.log(
       `${this.#did} Piece scheduler initialized | pollingIntervalMs: ${this.#pollingIntervalMs} | deactivationTimeoutMs: ${this.#deactivationTimeoutMs} | rerunIntervalMs: ${this.#rerunIntervalMs}`,
     );
+  }
+
+  /**
+   * The state and the steps of this instance that a test drives directly:
+   * the scheduling tables, the running flag, the worker controller, and the
+   * loop and the two steps it takes. A field is read and written through
+   * this object as through the instance itself.
+   *
+   * The name is the documentation. Nothing here is part of what this class
+   * promises, and code that reaches through it is written against internals
+   * that are free to change.
+   */
+  get accessForTestingOnly(): {
+    activePiece: Cell<BGPieceEntry> | null;
+    enabledPieces: Map<string, Cell<BGPieceEntry>>;
+    failureTracking: Map<string, number>;
+    isRunning: boolean;
+    pendingTasks: Task[];
+    workerController: WorkerController;
+    execLoop(): Promise<void>;
+    processPiece(pieceId: string, entry: Cell<BGPieceEntry>): Promise<void>;
+    setupWorkerController(): Promise<void>;
+  } {
+    // deno-lint-ignore no-this-alias
+    const manager = this;
+    return {
+      get activePiece() {
+        return manager.#activePiece;
+      },
+      set activePiece(value) {
+        manager.#activePiece = value;
+      },
+      get enabledPieces() {
+        return manager.#enabledPieces;
+      },
+      get failureTracking() {
+        return manager.#failureTracking;
+      },
+      get isRunning() {
+        return manager.#isRunning;
+      },
+      set isRunning(value) {
+        manager.#isRunning = value;
+      },
+      get pendingTasks() {
+        return manager.#pendingTasks;
+      },
+      set pendingTasks(value) {
+        manager.#pendingTasks = value;
+      },
+      get workerController() {
+        return manager.#workerController;
+      },
+      set workerController(value) {
+        manager.#workerController = value;
+      },
+      execLoop: () => this.#execLoop(),
+      processPiece: (pieceId, entry) => this.#processPiece(pieceId, entry),
+      setupWorkerController: () => this.#setupWorkerController(),
+    };
   }
 
   #pushTask(
@@ -86,32 +113,32 @@ export class SpaceManager {
   ) {
     const when = whenInMs ?? this.#rerunIntervalMs;
     const timestamp = Date.now() + when;
-    this.pendingTasks.push({
+    this.#pendingTasks.push({
       pieceId,
       timestamp,
       entry,
     });
 
-    this.pendingTasks.sort((a, b) => a.timestamp - b.timestamp);
+    this.#pendingTasks.sort((a, b) => a.timestamp - b.timestamp);
   }
 
   #updatePieceStatus(b: BGPieceEntry, c: Cell<BGPieceEntry>) {
     const pieceId = b.pieceId;
     const enabled = !b.disabledAt;
-    const currentlyScheduled = this.enabledPieces.has(pieceId) ||
-      this.activePiece?.get().pieceId === pieceId;
+    const currentlyScheduled = this.#enabledPieces.has(pieceId) ||
+      this.#activePiece?.get().pieceId === pieceId;
 
     if (enabled) {
       // if we aren't already scheduling this piece, add it to the list
       if (!currentlyScheduled) {
-        this.enabledPieces.set(pieceId, c);
+        this.#enabledPieces.set(pieceId, c);
         this.#pushTask(pieceId, c, 0);
       }
     } else {
       // if we are disabling a piece, remove it from the list
       if (currentlyScheduled) {
-        this.enabledPieces.delete(pieceId);
-        this.pendingTasks = this.pendingTasks.filter((r) =>
+        this.#enabledPieces.delete(pieceId);
+        this.#pendingTasks = this.#pendingTasks.filter((r) =>
           r.pieceId !== pieceId
         );
       }
@@ -122,7 +149,7 @@ export class SpaceManager {
   watch(entries: Cell<BGPieceEntry>[]): Cancel {
     const [cancel, addCancel] = useCancelGroup();
 
-    const scheduled = Array.from(this.enabledPieces.keys());
+    const scheduled = Array.from(this.#enabledPieces.keys());
     const desired = new Set();
 
     for (const entry of entries) {
@@ -137,38 +164,38 @@ export class SpaceManager {
     const toRemove = scheduled.filter((pieceId) => !desired.has(pieceId));
 
     for (const pieceId of toRemove) {
-      this.enabledPieces.delete(pieceId);
-      this.pendingTasks = this.pendingTasks.filter((task) =>
+      this.#enabledPieces.delete(pieceId);
+      this.#pendingTasks = this.#pendingTasks.filter((task) =>
         task.pieceId !== pieceId
       );
     }
 
     console.log(
-      `${this.#did} Piece scheduling ${this.enabledPieces.size} piece updaters`,
+      `${this.#did} Piece scheduling ${this.#enabledPieces.size} piece updaters`,
     );
     return cancel;
   }
 
   start(): void {
-    if (this.isRunning) {
+    if (this.#isRunning) {
       return;
     }
-    this.isRunning = true;
+    this.#isRunning = true;
     console.log(`${this.#did} Piece scheduler starting...`);
-    this.execLoop();
+    this.#execLoop();
   }
 
   async stop(): Promise<void> {
     console.log(`${this.#did} Stopping piece scheduler...`);
-    this.isRunning = false;
+    this.#isRunning = false;
 
     // Wait for active jobs to finish with a timeout
-    if (this.activePiece) {
+    if (this.#activePiece) {
       await Promise.race([
         sleep(this.#deactivationTimeoutMs),
         new Promise((resolve) => {
           const checkInterval = setInterval(() => {
-            if (!this.activePiece) {
+            if (!this.#activePiece) {
               clearInterval(checkInterval);
               resolve(true);
             }
@@ -177,44 +204,36 @@ export class SpaceManager {
       ]);
     }
 
-    await this.workerController.shutdown();
+    await this.#workerController.shutdown();
   }
 
-  /**
-   * TypeScript-private rather than a `#` name: `test/service-modules.test.ts`
-   * drives this member directly.
-   */
-  private async execLoop(): Promise<void> {
-    while (this.isRunning) {
-      if (!this.workerController.isReady()) {
+  async #execLoop(): Promise<void> {
+    while (this.#isRunning) {
+      if (!this.#workerController.isReady()) {
         await sleep(this.#pollingIntervalMs);
         continue;
       }
 
-      if (this.activePiece) {
+      if (this.#activePiece) {
         await sleep(this.#pollingIntervalMs);
         continue;
       }
 
       if (
-        this.pendingTasks.length === 0 ||
-        this.pendingTasks[0].timestamp > Date.now()
+        this.#pendingTasks.length === 0 ||
+        this.#pendingTasks[0].timestamp > Date.now()
       ) {
         await sleep(this.#pollingIntervalMs);
         continue;
       }
 
-      const { pieceId, entry, timestamp: _ } = this.pendingTasks.shift()!;
+      const { pieceId, entry, timestamp: _ } = this.#pendingTasks.shift()!;
 
-      this.processPiece(pieceId, entry);
+      this.#processPiece(pieceId, entry);
     }
   }
 
-  /**
-   * TypeScript-private rather than a `#` name: `test/service-modules.test.ts`
-   * drives this member directly.
-   */
-  private async processPiece(pieceId: string, entry: Cell<BGPieceEntry>) {
+  async #processPiece(pieceId: string, entry: Cell<BGPieceEntry>) {
     const raw = entry.get();
 
     if (raw.disabledAt) {
@@ -224,10 +243,10 @@ export class SpaceManager {
 
     console.log(`${this.#did} Starting ${raw.integration} ${raw.pieceId}`);
 
-    this.activePiece = entry;
+    this.#activePiece = entry;
 
     try {
-      await this.workerController.runPiece(entry);
+      await this.#workerController.runPiece(entry);
       this.#onProcessSuccess(pieceId, entry);
     } catch (error) {
       const errorString = error instanceof Error
@@ -236,13 +255,13 @@ export class SpaceManager {
       console.error(`${this.#did} ${errorString}`);
       this.#onProcessFail(pieceId, entry, errorString);
     }
-    this.activePiece = null;
+    this.#activePiece = null;
   }
 
   #onProcessSuccess(pieceId: string, entry: Cell<BGPieceEntry>) {
     // If previous runs have failed, clear out the counter
-    if (this.failureTracking.has(pieceId)) {
-      this.failureTracking.delete(pieceId);
+    if (this.#failureTracking.has(pieceId)) {
+      this.#failureTracking.delete(pieceId);
     }
 
     entry.runtime.editWithRetry((tx) => {
@@ -252,7 +271,7 @@ export class SpaceManager {
       });
     });
 
-    if (this.enabledPieces.has(pieceId)) {
+    if (this.#enabledPieces.has(pieceId)) {
       this.#pushTask(pieceId, entry);
     }
   }
@@ -262,15 +281,15 @@ export class SpaceManager {
     entry: Cell<BGPieceEntry>,
     error: string,
   ) {
-    const failureCount = (this.failureTracking.get(pieceId) ?? 0) + 1;
+    const failureCount = (this.#failureTracking.get(pieceId) ?? 0) + 1;
 
     // If we've received graph errors 3 times in a row,
     // disable the piece.
     if (failureCount >= 3) {
-      this.failureTracking.delete(pieceId);
+      this.#failureTracking.delete(pieceId);
       this.#disablePiece(pieceId, entry, error);
     } else {
-      this.failureTracking.set(pieceId, failureCount);
+      this.#failureTracking.set(pieceId, failureCount);
       entry.runtime.editWithRetry((tx) => {
         entry.withTx(tx).update({
           lastRun: Date.now(),
@@ -278,7 +297,7 @@ export class SpaceManager {
         });
       });
 
-      if (this.enabledPieces.has(pieceId)) {
+      if (this.#enabledPieces.has(pieceId)) {
         // Apply a linear backoff for the next attempts
         this.#pushTask(
           pieceId,
@@ -302,13 +321,15 @@ export class SpaceManager {
       });
     });
 
-    this.enabledPieces.delete(pieceId);
-    this.pendingTasks = this.pendingTasks.filter((r) => r.pieceId !== pieceId);
+    this.#enabledPieces.delete(pieceId);
+    this.#pendingTasks = this.#pendingTasks.filter((r) =>
+      r.pieceId !== pieceId
+    );
   }
 
   #disableSpace(reason: string) {
     console.log(`${this.#did} Disabling space: ${reason}`);
-    for (const [pieceId, entry] of this.enabledPieces.entries()) {
+    for (const [pieceId, entry] of this.#enabledPieces.entries()) {
       this.#disablePiece(pieceId, entry, reason);
     }
   }
@@ -331,21 +352,17 @@ export class SpaceManager {
     const reason =
       `TerminalError: All pieces in this space have been disabled: ${event.error?.message}`;
     this.#disableSpace(reason);
-    this.setupWorkerController();
+    this.#setupWorkerController();
   };
 
-  /**
-   * TypeScript-private rather than a `#` name: `test/service-modules.test.ts`
-   * drives this member directly.
-   */
-  private async setupWorkerController() {
-    const previousWorker = this.workerController;
+  async #setupWorkerController() {
+    const previousWorker = this.#workerController;
     const newWorker = new WorkerController(this.#workerOptions);
     newWorker.addEventListener(
       "error",
       this.#onTerminalError,
     );
-    this.workerController = newWorker;
+    this.#workerController = newWorker;
 
     if (previousWorker) {
       console.log(`${this.#did} Restarting Worker Controller`);
@@ -366,7 +383,7 @@ export class SpaceManager {
       // Disable all pieces in this space and attempt to recreate the worker.
       console.error(`${this.#did} failed to initialize: ${e}`);
       this.#disableSpace(`Failed to initialize worker.`);
-      this.setupWorkerController();
+      this.#setupWorkerController();
     }
   }
 }

--- a/packages/background-piece-service/src/space-manager.ts
+++ b/packages/background-piece-service/src/space-manager.ts
@@ -49,9 +49,7 @@ export class SpaceManager {
   /**
    * The state and the steps of this instance that a test drives directly:
    * the scheduling tables, the running flag, the worker controller, and the
-   * loop and the two steps it takes. A field this class reassigns is read and
-   * written through this object as through the instance itself; the two
-   * tables it never reassigns are handed over as they are.
+   * loop and the two steps it takes.
    */
   get accessForTestingOnly(): {
     activePiece: Cell<BGPieceEntry> | null;

--- a/packages/background-piece-service/src/space-manager.ts
+++ b/packages/background-piece-service/src/space-manager.ts
@@ -52,10 +52,6 @@ export class SpaceManager {
    * loop and the two steps it takes. A field this class reassigns is read and
    * written through this object as through the instance itself; the two
    * tables it never reassigns are handed over as they are.
-   *
-   * The name is the documentation. Nothing here is part of what this class
-   * promises, and code that reaches through it is written against internals
-   * that are free to change.
    */
   get accessForTestingOnly(): {
     activePiece: Cell<BGPieceEntry> | null;

--- a/packages/background-piece-service/src/space-manager.ts
+++ b/packages/background-piece-service/src/space-manager.ts
@@ -48,8 +48,8 @@ export class SpaceManager {
 
   /**
    * The state and the steps of this instance that a test drives directly:
-   * the scheduling tables, the running flag, the worker controller, and the
-   * loop and the two steps it takes.
+   * the scheduling tables, the piece in flight, the running flag, the worker
+   * controller, and the loop and the two steps it takes.
    */
   get accessForTestingOnly(): {
     activePiece: Cell<BGPieceEntry> | null;

--- a/packages/background-piece-service/src/space-manager.ts
+++ b/packages/background-piece-service/src/space-manager.ts
@@ -49,8 +49,9 @@ export class SpaceManager {
   /**
    * The state and the steps of this instance that a test drives directly:
    * the scheduling tables, the running flag, the worker controller, and the
-   * loop and the two steps it takes. A field is read and written through
-   * this object as through the instance itself.
+   * loop and the two steps it takes. A field this class reassigns is read and
+   * written through this object as through the instance itself; the two
+   * tables it never reassigns are handed over as they are.
    *
    * The name is the documentation. Nothing here is part of what this class
    * promises, and code that reaches through it is written against internals
@@ -76,12 +77,8 @@ export class SpaceManager {
       set activePiece(value) {
         outerThis.#activePiece = value;
       },
-      get enabledPieces() {
-        return outerThis.#enabledPieces;
-      },
-      get failureTracking() {
-        return outerThis.#failureTracking;
-      },
+      enabledPieces: this.#enabledPieces,
+      failureTracking: this.#failureTracking,
       get isRunning() {
         return outerThis.#isRunning;
       },

--- a/packages/background-piece-service/test/clock-preload.ts
+++ b/packages/background-piece-service/test/clock-preload.ts
@@ -1,7 +1,7 @@
 // Runs before every test module in this package (wired in through `--preload`
 // on the package's test task). It installs the shared fake clock in
 // "auto-advance" mode: the service's own positive-delay timers (armed from
-// `src/` — `SpaceManager.execLoop`'s poll interval, `SpaceManager.stop`'s
+// `src/` — `SpaceManager.#execLoop`'s poll interval, `SpaceManager.stop`'s
 // deactivation deadline, and `WorkerController.exec`'s request timeout, all
 // reached through the `sleep` helper in `@commonfabric/utils`) advance logical
 // time on their own, so a poll elapses instantly and an unanswered worker

--- a/packages/background-piece-service/test/service-modules.test.ts
+++ b/packages/background-piece-service/test/service-modules.test.ts
@@ -111,6 +111,17 @@ class FakeEntryCell {
   }
 }
 
+/**
+ * Installs a stand-in for `manager`'s worker controller, supplying only the
+ * members the case exercises.
+ */
+function installWorker(
+  manager: SpaceManager,
+  stub: Partial<WorkerController>,
+): void {
+  manager.accessForTestingOnly.workerController = stub as WorkerController;
+}
+
 class FakePiecesCell {
   syncCount = 0;
   schemaSyncCount = 0;
@@ -545,9 +556,9 @@ describe("SpaceManager", () => {
         rerunIntervalMs: 5,
       });
 
-      (manager as never as { workerController: unknown }).workerController = {
+      installWorker(manager, {
         isReady: () => true,
-        runPiece: (cell: FakeEntryCell) => {
+        runPiece: (cell) => {
           workerCalls.push(cell.get().pieceId);
           return Promise.resolve();
         },
@@ -555,22 +566,19 @@ describe("SpaceManager", () => {
           workerCalls.push("shutdown");
           return Promise.resolve();
         },
-      };
+      });
 
       const cancel = manager.watch([entry as never]);
       assertEquals(
-        (manager as never as { enabledPieces: Map<string, unknown> })
-          .enabledPieces.has(PIECE_ID),
+        manager.accessForTestingOnly.enabledPieces.has(PIECE_ID),
         true,
       );
 
-      await (manager as never as {
-        processPiece: (pieceId: string, entry: FakeEntryCell) => Promise<void>;
-      }).processPiece(PIECE_ID, entry);
+      await manager.accessForTestingOnly.processPiece(PIECE_ID, entry as never);
       assertEquals(workerCalls, [PIECE_ID]);
       assertEquals(entry.value.status, "Success");
 
-      (manager as never as { workerController: unknown }).workerController = {
+      installWorker(manager, {
         isReady: () => true,
         runPiece: () => {
           throw new Error("graph failed");
@@ -579,23 +587,15 @@ describe("SpaceManager", () => {
           workerCalls.push("shutdown");
           return Promise.resolve();
         },
-      };
-      await (manager as never as {
-        processPiece: (pieceId: string, entry: FakeEntryCell) => Promise<void>;
-      }).processPiece(PIECE_ID, entry);
+      });
+      await manager.accessForTestingOnly.processPiece(PIECE_ID, entry as never);
       assertEquals(entry.value.status, "graph failed");
-      await (manager as never as {
-        processPiece: (pieceId: string, entry: FakeEntryCell) => Promise<void>;
-      }).processPiece(PIECE_ID, entry);
-      await (manager as never as {
-        processPiece: (pieceId: string, entry: FakeEntryCell) => Promise<void>;
-      }).processPiece(PIECE_ID, entry);
+      await manager.accessForTestingOnly.processPiece(PIECE_ID, entry as never);
+      await manager.accessForTestingOnly.processPiece(PIECE_ID, entry as never);
       assert(entry.value.disabledAt > 0);
       assertStringIncludes(entry.value.status, "Disabled: graph failed");
 
-      await (manager as never as {
-        processPiece: (pieceId: string, entry: FakeEntryCell) => Promise<void>;
-      }).processPiece(PIECE_ID, entry);
+      await manager.accessForTestingOnly.processPiece(PIECE_ID, entry as never);
       manager.watch([]);
       cancel();
       await manager.stop();
@@ -612,10 +612,10 @@ describe("SpaceManager", () => {
         pollingIntervalMs: 1,
         deactivationTimeoutMs: 1,
       });
-      (manager as never as { workerController: unknown }).workerController = {
+      installWorker(manager, {
         isReady: () => false,
         shutdown: async () => {},
-      };
+      });
 
       manager.start();
       manager.start();
@@ -626,7 +626,7 @@ describe("SpaceManager", () => {
       await manager.stop();
       await clock.tick(1);
       assertEquals(
-        (manager as never as { isRunning: boolean }).isRunning,
+        manager.accessForTestingOnly.isRunning,
         false,
       );
     });
@@ -645,34 +645,30 @@ describe("SpaceManager", () => {
         deactivationTimeoutMs: 10,
       });
 
-      (manager as never as { workerController: unknown }).workerController = {
+      installWorker(manager, {
         isReady: () => true,
         shutdown: () => {
           shutdowns.push("shutdown");
           return Promise.resolve();
         },
-      };
+      });
 
       manager.watch([first as never, second as never]);
       first.set({ ...first.value, disabledAt: Date.now() });
       assertEquals(
-        (manager as never as { enabledPieces: Map<string, unknown> })
-          .enabledPieces.has(PIECE_ID),
+        manager.accessForTestingOnly.enabledPieces.has(PIECE_ID),
         false,
       );
 
       manager.watch([first as never]);
       assertEquals(
-        (manager as never as { enabledPieces: Map<string, unknown> })
-          .enabledPieces.has(OTHER_PIECE_ID),
+        manager.accessForTestingOnly.enabledPieces.has(OTHER_PIECE_ID),
         false,
       );
 
-      (manager as never as { activePiece: FakeEntryCell | null }).activePiece =
-        second;
+      manager.accessForTestingOnly.activePiece = second as never;
       setTimeout(() => {
-        (manager as never as { activePiece: FakeEntryCell | null })
-          .activePiece = null;
+        manager.accessForTestingOnly.activePiece = null;
       }, 0);
       await manager.stop();
       assertEquals(shutdowns, ["shutdown"]);
@@ -690,78 +686,70 @@ describe("SpaceManager", () => {
         deactivationTimeoutMs: 1,
       });
 
-      (manager as never as { workerController: unknown }).workerController = {
+      installWorker(manager, {
         isReady: () => false,
         shutdown: () => Promise.resolve(),
-      };
-      (manager as never as { isRunning: boolean }).isRunning = true;
+      });
+      manager.accessForTestingOnly.isRunning = true;
       // isReady() === false: the loop parks on sleep(pollingIntervalMs). Let it
       // reach the park, clear isRunning, then fire the parked sleep so it exits.
-      const idleLoop = (manager as never as { execLoop: () => Promise<void> })
-        .execLoop();
+      const idleLoop = manager.accessForTestingOnly.execLoop();
       await clock.settle();
-      (manager as never as { isRunning: boolean }).isRunning = false;
+      manager.accessForTestingOnly.isRunning = false;
       await clock.tick(1);
       await idleLoop;
 
-      (manager as never as { workerController: unknown }).workerController = {
+      installWorker(manager, {
         isReady: () => true,
         shutdown: () => Promise.resolve(),
-      };
-      (manager as never as { activePiece: FakeEntryCell | null }).activePiece =
-        entry;
-      (manager as never as { isRunning: boolean }).isRunning = true;
+      });
+      manager.accessForTestingOnly.activePiece = entry as never;
+      manager.accessForTestingOnly.isRunning = true;
       // isReady() === true with an active piece: the loop parks until the active
       // piece clears.
-      const activeLoop = (manager as never as { execLoop: () => Promise<void> })
-        .execLoop();
+      const activeLoop = manager.accessForTestingOnly.execLoop();
       await clock.settle();
-      (manager as never as { activePiece: FakeEntryCell | null }).activePiece =
-        null;
-      (manager as never as { isRunning: boolean }).isRunning = false;
+      manager.accessForTestingOnly.activePiece = null;
+      manager.accessForTestingOnly.isRunning = false;
       await clock.tick(1);
       await activeLoop;
 
-      (manager as never as { pendingTasks: unknown[] }).pendingTasks = [{
+      manager.accessForTestingOnly.pendingTasks = [{
         pieceId: PIECE_ID,
-        entry,
+        entry: entry as never,
         timestamp: Date.now() + 10,
       }];
-      (manager as never as { isRunning: boolean }).isRunning = true;
+      manager.accessForTestingOnly.isRunning = true;
       // The only pending task is scheduled in the future: the loop parks until
       // it comes due.
-      const futureLoop = (manager as never as { execLoop: () => Promise<void> })
-        .execLoop();
+      const futureLoop = manager.accessForTestingOnly.execLoop();
       await clock.settle();
-      (manager as never as { isRunning: boolean }).isRunning = false;
+      manager.accessForTestingOnly.isRunning = false;
       await clock.tick(1);
       await futureLoop;
 
       const calls: string[] = [];
-      (manager as never as { workerController: unknown }).workerController = {
+      installWorker(manager, {
         isReady: () => true,
         runPiece: () => {
           calls.push("run");
-          (manager as never as { isRunning: boolean }).isRunning = false;
+          manager.accessForTestingOnly.isRunning = false;
           return Promise.resolve();
         },
         shutdown: () => Promise.resolve(),
-      };
-      (manager as never as { enabledPieces: Map<string, FakeEntryCell> })
-        .enabledPieces.set(PIECE_ID, entry);
-      (manager as never as { failureTracking: Map<string, number> })
-        .failureTracking.set(PIECE_ID, 1);
-      (manager as never as { pendingTasks: unknown[] }).pendingTasks = [{
+      });
+      manager.accessForTestingOnly.enabledPieces.set(PIECE_ID, entry as never);
+      manager.accessForTestingOnly.failureTracking.set(PIECE_ID, 1);
+      manager.accessForTestingOnly.pendingTasks = [{
         pieceId: PIECE_ID,
-        entry,
+        entry: entry as never,
         timestamp: Date.now() - 1,
       }];
-      (manager as never as { isRunning: boolean }).isRunning = true;
-      await (manager as never as { execLoop: () => Promise<void> }).execLoop();
+      manager.accessForTestingOnly.isRunning = true;
+      await manager.accessForTestingOnly.execLoop();
       assertEquals(calls, ["run"]);
       assertEquals(
-        (manager as never as { failureTracking: Map<string, number> })
-          .failureTracking.has(PIECE_ID),
+        manager.accessForTestingOnly.failureTracking.has(PIECE_ID),
         false,
       );
       await manager.stop();
@@ -833,16 +821,14 @@ describe("SpaceManager", () => {
         deactivationTimeoutMs: 1,
       });
       let removed = false;
-      (manager as never as { workerController: unknown }).workerController = {
+      installWorker(manager, {
         removeEventListener: () => {
           removed = true;
         },
         shutdown: () => Promise.reject(new Error("old shutdown failed")),
-      };
+      });
 
-      await (manager as never as {
-        setupWorkerController: () => Promise<void>;
-      }).setupWorkerController();
+      await manager.accessForTestingOnly.setupWorkerController();
       await clock.settle();
 
       assertEquals(removed, true);

--- a/packages/background-piece-service/test/service-modules.test.ts
+++ b/packages/background-piece-service/test/service-modules.test.ts
@@ -536,11 +536,11 @@ describe("BackgroundPieceService", () => {
 describe("SpaceManager", () => {
   // One freezeAround wraps this whole describe, so its timer map and logical
   // clock persist across cases. Several cases leave a fire-and-forget
-  // WorkerController.shutdown() (from setupWorkerController) parked on a worker
-  // that never answers, so its cleanup timeout lingers in the map. Dropping
-  // every pending timer after each case keeps a leftover from firing in a later
-  // case — here or in a following describe once this one's trailing
-  // auto-advance runs.
+  // WorkerController.shutdown() (from `#setupWorkerController`) parked on a
+  // worker that never answers, so its cleanup timeout lingers in the map.
+  // Dropping every pending timer after each case keeps a leftover from firing
+  // in a later case — here or in a following describe once this one's
+  // trailing auto-advance runs.
   afterEach(() => clock.reset());
 
   it("schedules, runs, retries, disables, and removes pieces", async () => {
@@ -590,6 +590,9 @@ describe("SpaceManager", () => {
       });
       await manager.accessForTestingOnly.processPiece(PIECE_ID, entry as never);
       assertEquals(entry.value.status, "graph failed");
+      // A failed run clears the active slot, which is what lets `stop()` return
+      // without waiting out the deactivation deadline.
+      assertEquals(manager.accessForTestingOnly.activePiece, null);
       await manager.accessForTestingOnly.processPiece(PIECE_ID, entry as never);
       await manager.accessForTestingOnly.processPiece(PIECE_ID, entry as never);
       assert(entry.value.disabledAt > 0);
@@ -619,7 +622,7 @@ describe("SpaceManager", () => {
 
       manager.start();
       manager.start();
-      // execLoop parks on sleep(pollingIntervalMs) each pass; let it reach the
+      // `#execLoop` parks on sleep(pollingIntervalMs) each pass; let it reach the
       // first park, stop it, then fire the parked sleep so the loop observes
       // isRunning === false and exits.
       await clock.settle();
@@ -748,6 +751,12 @@ describe("SpaceManager", () => {
       manager.accessForTestingOnly.isRunning = true;
       await manager.accessForTestingOnly.execLoop();
       assertEquals(calls, ["run"]);
+      // The loop consumed the due task, and the successful run put the next
+      // run in its place.
+      assertEquals(manager.accessForTestingOnly.pendingTasks.length, 1);
+      assert(
+        manager.accessForTestingOnly.pendingTasks[0].timestamp > Date.now(),
+      );
       assertEquals(
         manager.accessForTestingOnly.failureTracking.has(PIECE_ID),
         false,


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Fable 5.1)

The nine members `test/service-modules.test.ts` reaches were TypeScript
`private`, each carrying a note saying so. They are `#` names now, and the
test reaches them through an `accessForTestingOnly` getter, the idiom
#6692 introduced for `IndexTrackingStack`, here in its instance form.

## Shape of the accessor

The getter returns an object literal typed inline. A field the class
reassigns (`activePiece`, `isRunning`, `pendingTasks`, `workerController`)
is a getter, so a read stays live, and a setter, because the test assigns
each of them. The two tables the class only mutates in place
(`enabledPieces`, `failureTracking`) are handed over as plain properties.
The loop and its two steps are forwarding arrows. Object-literal getters
cannot capture `this` lexically, so the getter takes a `this` alias named
`outerThis` under `no-this-alias`.

## What the test does now

Every `as never as {...}` cast on the manager is gone; the test reads and
writes the typed accessor. A stand-in worker controller goes in through one
helper, `installWorker(manager, stub: Partial<WorkerController>)`, which
carries the one cast a partial stand-in needs.

The typed accessor refused one line the old cast had let through: the test
had typed `enabledPieces` as `Map<string, FakeEntryCell>`, and the accessor
types it as the class does, so the `as never` moved from the receiver to
the fake cell being put in.

## Prose

`clock-preload.ts` and `docs/development/waiting-in-tests.md` named
`SpaceManager.execLoop`; both name `SpaceManager.#execLoop` now.

## Coverage

The ratchet counts the getters the suite never reads. Two of the three now
are, by assertions that guard behavior nothing had pinned: a failed run
clears the active slot, which is what lets `stop()` return without waiting
out the deactivation deadline, and a successful pass of the loop consumes
the due task and puts the next run in its place. What remains is the
`workerController` getter, which the suite only assigns. A test reading it
back would only be re-lighting the line, and dropping the getter would make
a future read return `undefined` without a word, which is the hazard the
accessor exists to remove. So that rise is accepted.

ACCEPT_COVERAGE_DEBT: packages/background-piece-service +3 lines

## Gates

`deno fmt --check`, `deno lint`, `deno task check`, and the package suite
(14 passed, 0 failed, run outside the sandbox because the OpenTelemetry
test binds a loopback server). No other package imports this one.

## Review

Reviewed by a `cf-review` pass (cubic being unavailable): sound, no
blocking findings. Its improvement is applied, the two behavior assertions
above; its nits are applied, the two bare member names in test comments now
read as `#` names and the getter's doc comment names the piece in flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DAWC4oaSp4a6i71xyA1UEq


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6899?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



