### PR TITLE
refactor(background-piece-service): `WorkerController` sends and receives through `#` members behind `accessForTestingOnly`

### DIFF
--- a/docs/development/waiting-in-tests.md
+++ b/docs/development/waiting-in-tests.md
@@ -666,7 +666,7 @@ Three pieces of the service arm positive-delay timers. `SpaceManager.#execLoop`
 parks on `sleep(pollingIntervalMs)` between polls of its task queue.
 `SpaceManager.stop` races a `setInterval` that watches for the active job to
 finish against a `sleep(deactivationTimeoutMs)` deadline. And
-`WorkerController.exec` arms a `setTimeout(timeoutMs)` that rejects a worker
+`WorkerController.#exec` arms a `setTimeout(timeoutMs)` that rejects a worker
 request the worker never answers. Each of these is scheduled from `src/`, so the
 clock reads it as a production timer. The poll and the deactivation deadline
 reach `setTimeout` indirectly, through the `sleep` helper in

--- a/packages/background-piece-service/src/worker-controller.ts
+++ b/packages/background-piece-service/src/worker-controller.ts
@@ -155,10 +155,6 @@ export class WorkerController extends EventTarget {
   /**
    * The two steps of this instance that a test drives directly: sending a
    * request to the worker, and receiving a message from it.
-   *
-   * The name is the documentation. Nothing here is part of what this class
-   * promises, and code that reaches through it is written against internals
-   * that are free to change.
    */
   get accessForTestingOnly(): {
     exec(type: WorkerIPCMessageType, data?: unknown): Promise<void>;

--- a/packages/background-piece-service/src/worker-controller.ts
+++ b/packages/background-piece-service/src/worker-controller.ts
@@ -89,7 +89,7 @@ export class WorkerController extends EventTarget {
         name: `worker-${this.#did}`,
       },
     );
-    this.#worker.addEventListener("message", this.onWorkerMessage);
+    this.#worker.addEventListener("message", this.#onWorkerMessage);
     this.#worker.addEventListener("error", this.#onWorkerError);
   }
 
@@ -99,7 +99,7 @@ export class WorkerController extends EventTarget {
     }
     this.#state = WorkerState.Initializing;
     try {
-      await this.exec(WorkerIPCMessageType.Initialize, {
+      await this.#exec(WorkerIPCMessageType.Initialize, {
         did: this.#did,
         toolshedUrl: this.#toolshedUrl,
         encodedIdentity: realmValueFromKeyPair(this.#identity.keyPair),
@@ -118,7 +118,7 @@ export class WorkerController extends EventTarget {
     if (this.#state !== WorkerState.Ready) {
       throw new Error("Worker not ready.");
     }
-    return await this.exec(WorkerIPCMessageType.Run, {
+    return await this.#exec(WorkerIPCMessageType.Run, {
       pieceId: bg.get().pieceId,
     });
   }
@@ -138,7 +138,7 @@ export class WorkerController extends EventTarget {
     this.#pending.clear();
 
     try {
-      await this.exec(WorkerIPCMessageType.Cleanup);
+      await this.#exec(WorkerIPCMessageType.Cleanup);
     } catch (err) {
       console.warn(
         `Failed to shutdown worker gracefully: ${err}`,
@@ -153,12 +153,25 @@ export class WorkerController extends EventTarget {
   }
 
   /**
-   * Sends a message and returns a promise that resolves with the response.
+   * The two steps of this instance that a test drives directly: sending a
+   * request to the worker, and receiving a message from it.
    *
-   * TypeScript-private rather than a `#` name: `test/service-modules.test.ts`
-   * drives this member directly.
+   * The name is the documentation. Nothing here is part of what this class
+   * promises, and code that reaches through it is written against internals
+   * that are free to change.
    */
-  private exec(type: WorkerIPCMessageType, data?: unknown): Promise<void> {
+  get accessForTestingOnly(): {
+    exec(type: WorkerIPCMessageType, data?: unknown): Promise<void>;
+    onWorkerMessage(event: MessageEvent): void;
+  } {
+    return {
+      exec: (type, data) => this.#exec(type, data),
+      onWorkerMessage: (event) => this.#onWorkerMessage(event),
+    };
+  }
+
+  /** Sends a message and returns a promise that resolves with the response. */
+  #exec(type: WorkerIPCMessageType, data?: unknown): Promise<void> {
     const msgId = this.#msgId++;
 
     const message: Record<string, unknown> = {
@@ -202,11 +215,7 @@ export class WorkerController extends EventTarget {
     });
   }
 
-  /**
-   * TypeScript-private rather than a `#` name: `test/service-modules.test.ts`
-   * drives this member directly.
-   */
-  private onWorkerMessage = (event: MessageEvent) => {
+  #onWorkerMessage = (event: MessageEvent) => {
     const response = event.data;
     if (!isWorkerIPCResponse(response)) {
       console.error(

--- a/packages/background-piece-service/src/worker-controller.ts
+++ b/packages/background-piece-service/src/worker-controller.ts
@@ -93,6 +93,20 @@ export class WorkerController extends EventTarget {
     this.#worker.addEventListener("error", this.#onWorkerError);
   }
 
+  /**
+   * The two steps of this instance that a test drives directly: sending a
+   * request to the worker, and receiving a message from it.
+   */
+  get accessForTestingOnly(): {
+    exec(type: WorkerIPCMessageType, data?: unknown): Promise<void>;
+    onWorkerMessage(event: MessageEvent): void;
+  } {
+    return {
+      exec: (type, data) => this.#exec(type, data),
+      onWorkerMessage: (event) => this.#onWorkerMessage(event),
+    };
+  }
+
   async startInitialize() {
     if (this.#state !== WorkerState.Uninitialized) {
       throw new Error("Worker is not uninitialized.");
@@ -152,20 +166,6 @@ export class WorkerController extends EventTarget {
     return this.#state === WorkerState.Ready;
   }
 
-  /**
-   * The two steps of this instance that a test drives directly: sending a
-   * request to the worker, and receiving a message from it.
-   */
-  get accessForTestingOnly(): {
-    exec(type: WorkerIPCMessageType, data?: unknown): Promise<void>;
-    onWorkerMessage(event: MessageEvent): void;
-  } {
-    return {
-      exec: (type, data) => this.#exec(type, data),
-      onWorkerMessage: (event) => this.#onWorkerMessage(event),
-    };
-  }
-
   /** Sends a message and returns a promise that resolves with the response. */
   #exec(type: WorkerIPCMessageType, data?: unknown): Promise<void> {
     const msgId = this.#msgId++;
@@ -211,6 +211,10 @@ export class WorkerController extends EventTarget {
     });
   }
 
+  /**
+   * Handles one message from the worker: a `ready` starts initialization,
+   * and anything else settles the pending request it answers.
+   */
   #onWorkerMessage = (event: MessageEvent) => {
     const response = event.data;
     if (!isWorkerIPCResponse(response)) {

--- a/packages/background-piece-service/test/clock-preload.ts
+++ b/packages/background-piece-service/test/clock-preload.ts
@@ -2,7 +2,7 @@
 // on the package's test task). It installs the shared fake clock in
 // "auto-advance" mode: the service's own positive-delay timers (armed from
 // `src/` — `SpaceManager.#execLoop`'s poll interval, `SpaceManager.stop`'s
-// deactivation deadline, and `WorkerController.exec`'s request timeout, all
+// deactivation deadline, and `WorkerController.#exec`'s request timeout, all
 // reached through the `sleep` helper in `@commonfabric/utils`) advance logical
 // time on their own, so a poll elapses instantly and an unanswered worker
 // request times out without real sleeping, while a wall-clock sleep armed from a

--- a/packages/background-piece-service/test/service-modules.test.ts
+++ b/packages/background-piece-service/test/service-modules.test.ts
@@ -1050,9 +1050,9 @@ describe("WorkerController", () => {
       });
       await assertRejects(
         () =>
-          (timeoutController as never as {
-            exec: (type: WorkerIPCMessageType) => Promise<void>;
-          }).exec(WorkerIPCMessageType.Cleanup),
+          timeoutController.accessForTestingOnly.exec(
+            WorkerIPCMessageType.Cleanup,
+          ),
         Error,
         "Worker timed out.",
       );
@@ -1084,19 +1084,17 @@ describe("WorkerController", () => {
       );
       assertThrows(
         () =>
-          (controller as never as {
-            exec: (type: WorkerIPCMessageType) => Promise<void>;
-          }).exec(WorkerIPCMessageType.Initialize),
+          controller.accessForTestingOnly.exec(WorkerIPCMessageType.Initialize),
         Error,
         "invalid IPC request.",
       );
 
-      (controller as never as {
-        onWorkerMessage: (event: MessageEvent) => void;
-      }).onWorkerMessage(new MessageEvent("message", { data: { bad: true } }));
-      (controller as never as {
-        onWorkerMessage: (event: MessageEvent) => void;
-      }).onWorkerMessage(new MessageEvent("message", { data: { msgId: 999 } }));
+      controller.accessForTestingOnly.onWorkerMessage(
+        new MessageEvent("message", { data: { bad: true } }),
+      );
+      controller.accessForTestingOnly.onWorkerMessage(
+        new MessageEvent("message", { data: { msgId: 999 } }),
+      );
     });
   });
 
@@ -1135,13 +1133,11 @@ describe("WorkerController", () => {
       const worker = MockWorker.instances.at(-1)!;
       worker.respond = false;
 
-      const pending = (controller as never as {
-        exec: (type: WorkerIPCMessageType) => Promise<void>;
-      }).exec(WorkerIPCMessageType.Cleanup);
+      const pending = controller.accessForTestingOnly.exec(
+        WorkerIPCMessageType.Cleanup,
+      );
       const message = worker.messages.at(-1) as { msgId: number };
-      (controller as never as {
-        onWorkerMessage: (event: MessageEvent) => void;
-      }).onWorkerMessage(
+      controller.accessForTestingOnly.onWorkerMessage(
         new MessageEvent("message", {
           data: { msgId: message.msgId, error: "worker failed" },
         }),


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Fable 5.1)

`exec()` and the `onWorkerMessage` handler were TypeScript `private`, each
carrying a note saying `test/service-modules.test.ts` reaches it. They are
`#` names now, and the test reaches them through an `accessForTestingOnly`
getter, the idiom #6692 introduced for `IndexTrackingStack`.

The accessor exposes only methods, so it is two forwarding arrows and needs
no `this` alias. The test drops its `as never as {...}` casts for the typed
accessor.

## Prose

`clock-preload.ts` and `docs/development/waiting-in-tests.md` named
`WorkerController.exec`; both name `WorkerController.#exec` now.

## Relation to #6899

That PR converted `SpaceManager` in the same package and has merged. This
branch is rebased onto it, keeping both `#` names in the one line of
`clock-preload.ts` the two shared.

## Gates

`deno fmt --check`, `deno lint`, `deno task check`, and the package suite
(14 passed, 0 failed, run outside the sandbox because the OpenTelemetry
test binds a loopback server). No other package imports this one.

## Review

Reviewed by a `cf-review` pass (cubic being unavailable): mergeable. Its
one improvement is applied: the getter now sits ahead of the public
methods, where § Classes puts a public getter. The message handler gained a
doc comment. The reviewer confirmed with `git merge-tree` that this branch
and #6899 conflict in one hunk of `clock-preload.ts` in either order.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6900?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

