### PR TITLE
refactor(memory): `Server`'s scheduled refresh pass is a `#` method behind `accessForTestingOnly`

### DIFF
--- a/packages/memory/test/v2-verdict-catchup.test.ts
+++ b/packages/memory/test/v2-verdict-catchup.test.ts
@@ -582,8 +582,7 @@ Deno.test("memory v2 server: a failing timer-driven flush warns and leaves recov
       }
       return originalFlush();
     };
-  await (server as unknown as { flushScheduledSessions(): Promise<void> })
-    .flushScheduledSessions();
+  await server.accessForTestingOnly.flushScheduledSessions();
   assertEquals(committerMessages.length, 0);
 
   // The batch was never consumed (the stub rejected before the pass); a

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -1610,6 +1610,21 @@ export class Server {
     );
   }
 
+  /**
+   * The timer-driven refresh pass, which a test drives directly.
+   *
+   * The name is the documentation. Nothing here is part of what this class
+   * promises, and code that reaches through it is written against internals
+   * that are free to change.
+   */
+  get accessForTestingOnly(): {
+    flushScheduledSessions(): Promise<void>;
+  } {
+    return {
+      flushScheduledSessions: () => this.#flushScheduledSessions(),
+    };
+  }
+
   /** This server's health-route providers, kept so close() can withdraw
    * exactly them and no other server's. */
   #pushPriorityStatsProvider = () => this.pushPriorityStats();
@@ -6362,18 +6377,13 @@ export class Server {
     this.#refreshTurn = armTurn(
       () => {
         this.#refreshTurn = null;
-        void this.flushScheduledSessions();
+        void this.#flushScheduledSessions();
       },
       this.options.subscriptionRefreshDelayMs ?? SUBSCRIPTION_REFRESH_DELAY_MS,
     );
   }
 
-  /**
-   * TypeScript-private rather than a `#` name, because
-   * `test/v2-verdict-catchup.test.ts` reaches this member and a `#` name would
-   * put it out of reach.
-   */
-  private async flushScheduledSessions(): Promise<void> {
+  async #flushScheduledSessions(): Promise<void> {
     await this.#waitForConnectionQueuesToDrain(
       Math.max(
         MIN_REFRESH_QUEUE_DRAIN_WAIT_MS,

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -1612,10 +1612,6 @@ export class Server {
 
   /**
    * The timer-driven refresh pass, which a test drives directly.
-   *
-   * The name is the documentation. Nothing here is part of what this class
-   * promises, and code that reaches through it is written against internals
-   * that are free to change.
    */
   get accessForTestingOnly(): {
     flushScheduledSessions(): Promise<void>;

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -6379,6 +6379,11 @@ export class Server {
     );
   }
 
+  /**
+   * Helper for the refresh timer, which waits for the connection queues to
+   * drain and then flushes the scheduled sessions, logging a failure rather
+   * than throwing it, since the timer has no caller to surface one to.
+   */
   async #flushScheduledSessions(): Promise<void> {
     await this.#waitForConnectionQueuesToDrain(
       Math.max(
@@ -6444,8 +6449,9 @@ export class Server {
    * for other spaces remain independent, so the latency coupling is local to
    * one space.
    *
-   * TypeScript-private rather than a `#` name, because `test/v2-server.test.ts`
-   * reaches this member and a `#` name would put it out of reach.
+   * TypeScript-private rather than a `#` name, because
+   * `test/v2-verdict-catchup.test.ts` replaces this member by assignment,
+   * which a `#` method does not allow.
    */
   private async withSpacePublicationLock<T>(
     space: string,
@@ -6795,8 +6801,8 @@ export class Server {
 
   /**
    * TypeScript-private rather than a `#` name, because
-   * `test/v2-server-acl.test.ts` reaches this member and a `#` name would put
-   * it out of reach.
+   * `test/v2-server-acl.test.ts` replaces this member by assignment, which a
+   * `#` method does not allow.
    */
   private openEngine(space: string): Promise<Engine.Engine> {
     const existing = this.#engines.get(space);


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Fable 5.1)

`flushScheduledSessions()` was TypeScript `private`, carrying a note saying
`test/v2-verdict-catchup.test.ts` reaches it. It is a `#` name now, and the
test reaches it through an `accessForTestingOnly` getter, the idiom #6692
introduced for `IndexTrackingStack`, that forwards to it. The test drops its
`as unknown as {...}` cast for the typed accessor.

## What stays `private`, and why

`withSpacePublicationLock()` and `openEngine()` keep the TypeScript
modifier and their notes. Their tests replace them by assignment, wrapping
the original to observe or gate it, and a `#` method cannot be replaced.
That set is being looked at separately.

## Gates

`deno fmt --check`, `deno lint`, `deno task check`, and the memory suite
(596 passed, 0 failed). The member's name has exactly one reference in the
tree outside its class, the test above, so the suites of the packages that
import `memory` were not run for it.

## Review

Reviewed by a `cf-review` pass (cubic being unavailable): approve. Its one
improvement is applied: the notes on the two members that stay `private`
now say the named test replaces the member by assignment, and the lock's
note names `v2-verdict-catchup.test.ts`, the test that does so. The
converted method gained the doc comment its apology had stood in for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DAWC4oaSp4a6i71xyA1UEq


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6902?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


