### PR TITLE
refactor(fuse): `FsTree` keeps its CFC entry indexes in a `#` field behind `accessForTestingOnly`

### DIFF
--- a/packages/fuse/tree.test.ts
+++ b/packages/fuse/tree.test.ts
@@ -130,9 +130,7 @@ Deno.test("CFC entry updates rebuild a missing lookup index", () => {
   annotator.annotateJsonScalar(firstIno, ["first"], "old");
   annotator.annotateEntry(parentIno, "first", firstIno);
 
-  const indexes = (tree as unknown as {
-    cfcEntryIndexes: Map<bigint, Map<string, number>>;
-  }).cfcEntryIndexes;
+  const indexes = tree.accessForTestingOnly.cfcEntryIndexes;
   indexes.delete(parentIno);
 
   annotator.annotateEntry(parentIno, "first", firstIno);

--- a/packages/fuse/tree.ts
+++ b/packages/fuse/tree.ts
@@ -97,10 +97,6 @@ export class FsTree {
   /**
    * The lookup index this tree keeps per annotated directory, which a test
    * drives directly.
-   *
-   * The name is the documentation. Nothing here is part of what this class
-   * promises, and code that reaches through it is written against internals
-   * that are free to change.
    */
   get accessForTestingOnly(): {
     cfcEntryIndexes: Map<bigint, Map<string, number>>;

--- a/packages/fuse/tree.ts
+++ b/packages/fuse/tree.ts
@@ -76,11 +76,7 @@ export class FsTree {
   /** Renderers for inodes added by `addGeneratedFile`. */
   #generated: Map<bigint, () => Uint8Array | string> = new Map();
 
-  /**
-   * TypeScript-private rather than a `#` name: `tree.test.ts` drives this
-   * member directly.
-   */
-  private cfcEntryIndexes = new Map<bigint, Map<string, number>>();
+  #cfcEntryIndexes = new Map<bigint, Map<string, number>>();
 
   #unsortedCfcEntryDirectories = new Set<bigint>();
   #nextIno = 2n;
@@ -96,6 +92,22 @@ export class FsTree {
     });
     this.paths.set("/", ROOT_INO);
     this.#inoPaths.set(ROOT_INO, "/");
+  }
+
+  /**
+   * The lookup index this tree keeps per annotated directory, which a test
+   * drives directly.
+   *
+   * The name is the documentation. Nothing here is part of what this class
+   * promises, and code that reaches through it is written against internals
+   * that are free to change.
+   */
+  get accessForTestingOnly(): {
+    cfcEntryIndexes: Map<bigint, Map<string, number>>;
+  } {
+    return {
+      cfcEntryIndexes: this.#cfcEntryIndexes,
+    };
   }
 
   get rootIno(): bigint {
@@ -334,10 +346,10 @@ export class FsTree {
     this.#unsortedCfcEntryDirectories.delete(ino);
     const entries = annotation?.entries?.entries;
     if (!entries) {
-      this.cfcEntryIndexes.delete(ino);
+      this.#cfcEntryIndexes.delete(ino);
       return;
     }
-    this.cfcEntryIndexes.set(
+    this.#cfcEntryIndexes.set(
       ino,
       new Map(entries.map((entry, index) => [entry.name, index])),
     );
@@ -347,10 +359,10 @@ export class FsTree {
     ino: bigint,
     entries: readonly CfcDirectoryEntryAnnotation[],
   ): Map<string, number> {
-    let index = this.cfcEntryIndexes.get(ino);
+    let index = this.#cfcEntryIndexes.get(ino);
     if (!index) {
       index = new Map(entries.map((entry, offset) => [entry.name, offset]));
-      this.cfcEntryIndexes.set(ino, index);
+      this.#cfcEntryIndexes.set(ino, index);
     }
     return index;
   }
@@ -498,7 +510,7 @@ export class FsTree {
     this.inodes.delete(ino);
     this.parents.delete(ino);
     this.#generated.delete(ino);
-    this.cfcEntryIndexes.delete(ino);
+    this.#cfcEntryIndexes.delete(ino);
     this.#unsortedCfcEntryDirectories.delete(ino);
     this.#untrackPath(ino);
   }
@@ -635,7 +647,7 @@ export class FsTree {
     oldNode.cfc = newNode.cfc;
     newNode.cfc = undefined;
     this.#rebuildCfcEntryIndex(oldIno, oldNode.cfc);
-    this.cfcEntryIndexes.delete(newIno);
+    this.#cfcEntryIndexes.delete(newIno);
     this.#unsortedCfcEntryDirectories.delete(newIno);
 
     if (this.#adoptContent(oldNode, newNode)) {
@@ -763,7 +775,7 @@ export class FsTree {
     this.inodes.delete(ino);
     this.parents.delete(ino);
     this.#generated.delete(ino);
-    this.cfcEntryIndexes.delete(ino);
+    this.#cfcEntryIndexes.delete(ino);
     this.#unsortedCfcEntryDirectories.delete(ino);
     this.#untrackPath(ino);
   }

--- a/packages/fuse/tree.ts
+++ b/packages/fuse/tree.ts
@@ -95,8 +95,8 @@ export class FsTree {
   }
 
   /**
-   * The lookup index this tree keeps per annotated directory, which a test
-   * drives directly.
+   * The lookup indexes this tree keeps, one per annotated directory, which a
+   * test drives directly.
    */
   get accessForTestingOnly(): {
     cfcEntryIndexes: Map<bigint, Map<string, number>>;


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Fable 5.1)

`cfcEntryIndexes` was TypeScript `private`, carrying a note saying
`tree.test.ts` reaches it. It is a `#` name now, and the test reaches it
through an `accessForTestingOnly` getter, the idiom #6692 introduced for
`IndexTrackingStack`. The test drops its `as unknown as {...}` cast for the
typed accessor.

The field is a `Map` the class mutates in place and never reassigns, so the
accessor hands the reference over as a plain property; a getter is only
needed where the class replaces the field.

## Gates

`deno fmt --check`, `deno lint`, `deno task check`, and the fuse suite
(382 passed, 0 failed, 1 ignored). `cli` imports `fuse` and never names the
member.

## Review

Reviewed by a `cf-review` pass (cubic being unavailable): approve, no
findings above nit; the one wording nit is applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DAWC4oaSp4a6i71xyA1UEq


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6903?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


