### PR TITLE
refactor(data-model): the debug stringifier names its mode, its indent unit, and its spacer

### DIFF
--- a/packages/data-model/src/value-debug.ts
+++ b/packages/data-model/src/value-debug.ts
@@ -87,6 +87,12 @@ type PrimitiveState = RealmCodecValue | FabricValue;
 type TaggedForm = { readonly tag: string; readonly payload: FabricValue };
 
 /**
+ * The payload of the conversion's string-length form: the length of the
+ * whole string, and the excerpt of it that was carried.
+ */
+type PartialString = { readonly length: number; readonly excerpt: string };
+
+/**
  * The limits a conversion runs within, each resolved from the option of the
  * same name: the limit stated, or its default when none was, capped at its
  * absolute maximum.
@@ -818,48 +824,34 @@ class DebugStringifier {
   }
 
   /**
-   * Renders the given lines of a string, as `#linesOf()` splits them. When
-   * the rendering is multi-line and there is more than one, each renders
-   * quoted on a line of its own, every line but the last followed by ` +` and
-   * every line but the first indented by `inner`. Otherwise they render as
-   * the one quoted string they came from.
-   */
-  #renderLines(lines: readonly string[], inner: string): string {
-    if (this.#isCompact || (lines.length === 1)) {
-      return JSON.stringify(lines.join(""));
-    }
-
-    return lines.map((line) => JSON.stringify(line)).join(` +\n${inner}`);
-  }
-
-  /**
    * Renders the string-length form: the excerpt as `#renderString()` renders
    * it, followed by the length of the whole. The length follows on the same
    * line, or when the rendering is multi-line, on a line of its own, indented
-   * by `inner`.
+   * by the inner indentation of `indent`.
    */
-  #renderPartialString(
-    partial: { readonly length: number; readonly excerpt: string },
-    indent: string,
-  ): string {
-    const inner = this.#innerIndent(indent);
+  #renderPartialString(partial: PartialString, indent: string): string {
     const rendered = this.#renderString(partial.excerpt, indent);
-    const separator = this.#isCompact ? " " : `\n${inner}`;
+    const separator = this.#isCompact ? " " : `\n${this.#innerIndent(indent)}`;
 
     return `${rendered} +${separator}... length: ${partial.length}`;
   }
 
   /**
    * Renders a string. When the rendering is multi-line and the string holds a
-   * line break, each of its lines renders on a line of its own, the first in
-   * place and the rest indented by the inner indentation of `indent`, joined
-   * by ` +`. Otherwise the string renders whole, quoted.
+   * line break, each of its lines renders quoted on a line of its own, every
+   * line but the last followed by ` +` and every line but the first indented
+   * by the inner indentation of `indent`. Otherwise the string renders whole,
+   * quoted.
    */
   #renderString(value: string, indent: string): string {
-    return this.#renderLines(
-      DebugStringifier.#linesOf(value),
-      this.#innerIndent(indent),
-    );
+    const lines = DebugStringifier.#linesOf(value);
+
+    if (this.#isCompact || (lines.length === 1)) {
+      return JSON.stringify(value);
+    }
+
+    const inner = this.#innerIndent(indent);
+    return lines.map((line) => JSON.stringify(line)).join(` +\n${inner}`);
   }
 
   //
@@ -938,9 +930,7 @@ class DebugStringifier {
    * shape of the string-length form, a plain object whose `length` is a
    * number and whose `excerpt` is a string, and `undefined` when it is not.
    */
-  static #partialStringOf(
-    value: FabricValue,
-  ): { readonly length: number; readonly excerpt: string } | undefined {
+  static #partialStringOf(value: FabricValue): PartialString | undefined {
     const length = DebugStringifier.#lengthOf(value);
     // deno-coverage-ignore-start
     // The conversion shapes the form no other way; see the `partialString`

--- a/packages/data-model/src/value-debug.ts
+++ b/packages/data-model/src/value-debug.ts
@@ -453,6 +453,10 @@ class DebugStringifier {
   readonly #spacer: string;
   readonly #colon: string;
 
+  /** `#renderRealmState()` as a function, for passing to a renderer of parts. */
+  readonly #renderRealmStateFn = (v: PrimitiveState, i: string): string =>
+    this.#renderRealmState(v, i);
+
   /**
    * Constructs an instance which renders using `indent` spaces per nesting
    * level when given, and on a single line when not. A value which turns up
@@ -557,14 +561,12 @@ class DebugStringifier {
     }
 
     const open = `/${DebugStringifier.#typeNameOf(tag)}(`;
-    const realm = (v: PrimitiveState, i: string) =>
-      this.#renderRealmState(v, i);
 
     if (isPlainObject(state)) {
       const parts = this.#renderProperties(
         state as { readonly [key: string]: PrimitiveState },
         indent,
-        realm,
+        this.#renderRealmStateFn,
         false,
       );
       return this.#renderContainer(open, ")", parts, indent);
@@ -580,20 +582,19 @@ class DebugStringifier {
    * the conversion.
    */
   #renderRealmState(value: PrimitiveState, indent: string): string {
-    const realm = (v: PrimitiveState, i: string) =>
-      this.#renderRealmState(v, i);
-
     if (value instanceof ArrayBuffer) {
       return DebugStringifier.#renderBuffer(value);
     } else if (Array.isArray(value)) {
       const inner = this.#innerIndent(indent);
-      const parts = value.map((element) => realm(element, inner));
+      const parts = value.map((element) =>
+        this.#renderRealmState(element, inner)
+      );
       return this.#renderContainer("[", "]", parts, indent);
     } else if (isPlainObject(value)) {
       const parts = this.#renderProperties(
         value as { readonly [key: string]: PrimitiveState },
         indent,
-        realm,
+        this.#renderRealmStateFn,
         false,
       );
       return this.#renderContainer("{", "}", parts, indent);

--- a/packages/data-model/src/value-debug.ts
+++ b/packages/data-model/src/value-debug.ts
@@ -450,6 +450,8 @@ class DebugConverter {
 class DebugStringifier {
   readonly #options: DebugValueOptions;
   readonly #singleIndent: string | undefined;
+  readonly #spacer: string;
+  readonly #colon: string;
 
   /**
    * Constructs an instance which renders using `indent` spaces per nesting
@@ -461,6 +463,8 @@ class DebugStringifier {
     this.#singleIndent = (indent === undefined)
       ? undefined
       : " ".repeat(indent);
+    this.#spacer = this.#isCompact ? "" : " ";
+    this.#colon = `:${this.#spacer}`;
   }
 
   //
@@ -673,12 +677,13 @@ class DebugStringifier {
     unescape = true,
   ): string[] {
     const inner = this.#innerIndent(indent);
-    const separator = this.#isCompact ? ":" : ": ";
 
     return Object.entries(value).map(([key, subvalue]) => {
       const original = (unescape && (key[0] === "/")) ? key.slice(1) : key;
       const rendered = render(subvalue, inner);
-      return `${DebugStringifier.#renderKey(original)}${separator}${rendered}`;
+      return `${
+        DebugStringifier.#renderKey(original)
+      }${this.#colon}${rendered}`;
     });
   }
 

--- a/packages/data-model/src/value-debug.ts
+++ b/packages/data-model/src/value-debug.ts
@@ -443,7 +443,7 @@ class DebugConverter {
  */
 class DebugStringifier {
   readonly #options: DebugValueOptions;
-  readonly #indent: string | undefined;
+  readonly #singleIndent: string | undefined;
 
   /**
    * Constructs an instance which renders using `indent` spaces per nesting
@@ -452,7 +452,9 @@ class DebugStringifier {
    */
   constructor(options: DebugValueOptions, indent?: number) {
     this.#options = options;
-    this.#indent = (indent === undefined) ? undefined : " ".repeat(indent);
+    this.#singleIndent = (indent === undefined)
+      ? undefined
+      : " ".repeat(indent);
   }
 
   //
@@ -462,6 +464,11 @@ class DebugStringifier {
   /** Renders the given value. */
   render(value: FabricValue): string {
     return this.#renderSubvalue(value, "");
+  }
+
+  /** Whether this instance renders on a single line, with no indentation. */
+  get #isCompact(): boolean {
+    return this.#singleIndent === undefined;
   }
 
   /**
@@ -505,7 +512,7 @@ class DebugStringifier {
   ): string {
     if (parts.length === 0) {
       return `${open}${close}`;
-    } else if (this.#indent === undefined) {
+    } else if (this.#isCompact) {
       return `${open}${parts.join(",")}${close}`;
     }
 
@@ -660,7 +667,7 @@ class DebugStringifier {
     unescape = true,
   ): string[] {
     const inner = this.#innerIndent(indent);
-    const separator = (this.#indent === undefined) ? ":" : ": ";
+    const separator = this.#isCompact ? ":" : ": ";
 
     return Object.entries(value).map(([key, subvalue]) => {
       const original = (unescape && (key[0] === "/")) ? key.slice(1) : key;
@@ -807,7 +814,7 @@ class DebugStringifier {
 
   /** Returns the indentation for the contents of a container indented by `indent`. */
   #innerIndent(indent: string): string {
-    return `${indent}${this.#indent ?? ""}`;
+    return this.#isCompact ? indent : `${indent}${this.#singleIndent}`;
   }
 
   /**
@@ -818,7 +825,7 @@ class DebugStringifier {
    * the one quoted string they came from.
    */
   #renderLines(lines: readonly string[], inner: string): string {
-    if ((this.#indent === undefined) || (lines.length === 1)) {
+    if (this.#isCompact || (lines.length === 1)) {
       return JSON.stringify(lines.join(""));
     }
 
@@ -837,7 +844,7 @@ class DebugStringifier {
   ): string {
     const inner = this.#innerIndent(indent);
     const rendered = this.#renderString(partial.excerpt, indent);
-    const separator = (this.#indent === undefined) ? " " : `\n${inner}`;
+    const separator = this.#isCompact ? " " : `\n${inner}`;
 
     return `${rendered} +${separator}... length: ${partial.length}`;
   }


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Fable 5.1)

## What

A readability pass over `DebugStringifier` in `value-debug.ts`. No rendering
changes: the goldens under `value-debug-cases/` are untouched, and every test
passes as it stands.

* **`#singleIndent`** holds the per-level indentation, in place of a field
  named `#indent` that shared its name with the `indent` argument every
  rendering method threads through.
* **`get #isCompact()`** says which mode the instance is in, in place of
  testing that field against `undefined` at each site. `#innerIndent()` is
  written through both: the indent as given when compact, the indent plus one
  unit when not.
* **`#spacer` and `#colon`**: the space the indented rendering puts after
  punctuation and the compact one leaves out, and a colon followed by it,
  which is what `#renderProperties()` joins a key and value with.
* **`#renderString()` splits its own lines.** The separate line renderer had
  one caller once the partial-string renderer came to call `#renderString()`.
* **`PartialString`** names the payload shape of the string-length form, which
  its renderer's parameter and its shape check's return both wrote out.
* **`#renderRealmStateFn`** is `#renderRealmState()` as a bound function, held
  once, in place of a closure over it defined in each of the two methods that
  hand it to `#renderProperties()`.

One thing of the same kind is left as it is, being a larger shape change: the
bare `false` those two sites pass as `#renderProperties()`'s `unescape` flag.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6904?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


