### PR TITLE
docs(development): how a test reaches a class's private members

### DIFF
--- a/.claude/rules/source-code.md
+++ b/.claude/rules/source-code.md
@@ -26,7 +26,9 @@ and passes: `#privateName` rather than TypeScript's `private`, no enumerable
 properties on a class, and the member order in
 `docs/development/DEVELOPMENT.md`, § Classes. A `private` field is an own
 enumerable property once the modifier is erased, so `private` is not a quieter
-spelling of `#`.
+spelling of `#`. A member kept `private` so that a test can cast its way to it
+is the same defect; the same section says how an `accessForTestingOnly` getter
+hands a test what it needs instead.
 
 ## The document is part of the change
 

--- a/docs/development/DEVELOPMENT.md
+++ b/docs/development/DEVELOPMENT.md
@@ -231,23 +231,24 @@ A test sometimes needs what a class keeps to itself: a threshold to straddle,
 a table to seed, a step to run on its own. Casting the instance to get at it —
 `as unknown as { ... }`, `as never as { ... }`, `as any` — is not the way, and
 the `#` convention takes it off the table: a `#` name is out of a cast's reach,
-and a member left TypeScript-`private` so that a cast can find it is an own
-enumerable property with a comment apologizing for it. The cast also types the
+and a member left TypeScript-`private` so that a cast can find it is, if a
+field, an own enumerable property, and either way a member the class promised
+to keep to itself, with a comment apologizing for it. The cast also types the
 member however the test finds convenient, so nothing checks that what the test
 reads is what the class holds, and a renamed member leaves the test reading
 `undefined` and passing.
 
-The way is one public getter named `accessForTestingOnly`, which hands over
+The way is a public getter named `accessForTestingOnly`, which hands over
 exactly what a test needs and nothing else. The name is the documentation:
 everything behind it is internals free to change, and a reader who sees it in
 a test knows the test is written against them. Its doc comment says what it
 exposes, and the name says the rest.
 
 - Instance members go behind an instance getter; static members behind a
-  static one. A class may have both.
+  static one. A class may have both, and never more than one of each.
 - The getter's return type is written inline on the getter, and the body is an
-  object literal. Nothing else is exported, so the class's public surface grows
-  by one member.
+  object literal. No named type is declared for it, so the class's public
+  surface grows by one member and nothing else.
 - A field the class never reassigns — a `Map` it mutates in place — is handed
   over as a plain property holding the reference. A field the class reassigns
   is a getter, so that a read is live, and gains a setter only when a test
@@ -266,7 +267,7 @@ exposes, and the name says the rest.
 ```ts
 // Shown at module scope.
 
-/** A fryer whose oil temperature a test has to set and whose log it reads. */
+/** A fryer that records the temperature each item was fried at. */
 export class Fryer {
   #temperature = 190;
   #log = new Map<string, number>();
@@ -321,8 +322,10 @@ different answer:
   rewrite the test against public behavior. Until then the member stays
   TypeScript-`private`, with a comment naming the test that replaces it.
 - **A method called off the prototype against a stand-in receiver** —
-  `Class.prototype.step.call(fake, ...)`. A `#` member throws on any receiver
-  that is not a real instance, so the test wants rewriting to build one.
+  `Class.prototype.step.call(fake, ...)`. A `#` method is not on the prototype
+  to be called, and a public method reached that way throws the moment it
+  touches a `#` member of a receiver that is not a real instance, so the test
+  wants rewriting to build one.
 - **A helper that uses no instance state.** Make it `static #` behind the
   static getter, or a module-level function the test imports.
 

--- a/docs/development/DEVELOPMENT.md
+++ b/docs/development/DEVELOPMENT.md
@@ -225,6 +225,111 @@ abstract class Fryer {
 }
 ```
 
+#### Making a private member reachable from a test
+
+A test sometimes needs what a class keeps to itself: a threshold to straddle,
+a table to seed, a step to run on its own. Casting the instance to get at it —
+`as unknown as { ... }`, `as never as { ... }`, `as any` — is not the way, and
+the `#` convention takes it off the table: a `#` name is out of a cast's reach,
+and a member left TypeScript-`private` so that a cast can find it is an own
+enumerable property with a comment apologizing for it. The cast also types the
+member however the test finds convenient, so nothing checks that what the test
+reads is what the class holds, and a renamed member leaves the test reading
+`undefined` and passing.
+
+The way is one public getter named `accessForTestingOnly`, which hands over
+exactly what a test needs and nothing else. The name is the documentation:
+everything behind it is internals free to change, and a reader who sees it in
+a test knows the test is written against them. Its doc comment says what it
+exposes and that none of it is part of the class's contract.
+
+- Instance members go behind an instance getter; static members behind a
+  static one. A class may have both.
+- The getter's return type is written inline on the getter, and the body is an
+  object literal. Nothing else is exported, so the class's public surface grows
+  by one member.
+- A field the class never reassigns — a `Map` it mutates in place — is handed
+  over as a plain property holding the reference. A field the class reassigns
+  is a getter, so that a read is live, and gains a setter only when a test
+  assigns it. A method is an arrow forwarding to the `#` method. An
+  object-literal getter cannot see the class's `this`, so an accessor with one
+  takes `const outerThis = this;` under `// deno-lint-ignore no-this-alias`;
+  an accessor of plain properties and arrows needs no alias.
+- Each entry is typed as the class types the member. A stand-in the test
+  supplies then declares itself where it is passed in — an `as` on the
+  argument, or one small helper taking a `Partial<T>` — rather than on the
+  receiver, and a value the test reads back is what the class holds.
+- It is a public getter, so it sits where the order above puts public getters,
+  and first among them.
+- Prose names the member `Class.#member`.
+
+```ts
+// Shown at module scope.
+
+/** A fryer whose oil temperature a test has to set and whose log it reads. */
+export class Fryer {
+  #temperature = 190;
+  #log = new Map<string, number>();
+
+  /**
+   * The oil temperature, the batch log, and the drain step, which a test
+   * drives directly.
+   *
+   * The name is the documentation. Nothing here is part of what this class
+   * promises, and code that reaches through it is written against internals
+   * that are free to change.
+   */
+  get accessForTestingOnly(): {
+    temperature: number;
+    log: Map<string, number>;
+    drain(): void;
+  } {
+    // deno-lint-ignore no-this-alias
+    const outerThis = this;
+    return {
+      get temperature() {
+        return outerThis.#temperature;
+      },
+      set temperature(value) {
+        outerThis.#temperature = value;
+      },
+      log: this.#log,
+      drain: () => this.#drain(),
+    };
+  }
+
+  /** Fries one item at the current temperature. */
+  fry(item: string): void {
+    this.#log.set(item, this.#temperature);
+  }
+
+  #drain(): void {
+    this.#temperature = 20;
+  }
+}
+
+// In a test:
+const fryer = new Fryer();
+fryer.accessForTestingOnly.temperature = 200;
+fryer.fry("cruller");
+fryer.accessForTestingOnly.drain();
+```
+
+Three things a test reaches for that the getter does not cover, each wanting a
+different answer:
+
+- **A method the test replaces by assignment** — `obj.step = fake; ...;
+  obj.step = original`. A `#` method cannot be reassigned, and the getter only
+  forwards, so the test is asking for a seam the class does not offer. Offer
+  one — a collaborator passed to the constructor, a hook the class calls — or
+  rewrite the test against public behavior. Until then the member stays
+  TypeScript-`private`, with a comment naming the test that replaces it.
+- **A method called off the prototype against a stand-in receiver** —
+  `Class.prototype.step.call(fake, ...)`. A `#` member throws on any receiver
+  that is not a real instance, so the test wants rewriting to build one.
+- **A helper that uses no instance state.** Make it `static #` behind the
+  static getter, or a module-level function the test imports.
+
 ### Comments
 
 - Comments explain **why**, not what, and describe the system as it stands.

--- a/docs/development/DEVELOPMENT.md
+++ b/docs/development/DEVELOPMENT.md
@@ -241,7 +241,7 @@ The way is one public getter named `accessForTestingOnly`, which hands over
 exactly what a test needs and nothing else. The name is the documentation:
 everything behind it is internals free to change, and a reader who sees it in
 a test knows the test is written against them. Its doc comment says what it
-exposes and that none of it is part of the class's contract.
+exposes, and the name says the rest.
 
 - Instance members go behind an instance getter; static members behind a
   static one. A class may have both.
@@ -274,10 +274,6 @@ export class Fryer {
   /**
    * The oil temperature, the batch log, and the drain step, which a test
    * drives directly.
-   *
-   * The name is the documentation. Nothing here is part of what this class
-   * promises, and code that reaches through it is written against internals
-   * that are free to change.
    */
   get accessForTestingOnly(): {
     temperature: number;

--- a/docs/development/unit-test-coding-style.md
+++ b/docs/development/unit-test-coding-style.md
@@ -410,3 +410,16 @@ as `FabricHash {}` rather than as a hash string, which is the tell. A
 confidently reported defect that turns out not to exist costs more than a
 missed gap: it consumes the reporter, the reviewer, and everyone downstream of
 both.
+
+**A cast onto a class's internals reads whatever it is told to.** Writing
+`(thing as unknown as { count: number }).count` declares the member's name and
+type from the test's side, and nothing checks either. Rename the member and
+the read yields `undefined`, which `assert(!thing.count)` accepts, so the test
+stays green while asserting nothing. Reach internals through the class's
+`accessForTestingOnly` getter instead, which types each member as the class
+does and turns a wrong name into a type error;
+[`DEVELOPMENT.md`](DEVELOPMENT.md#making-a-private-member-reachable-from-a-test)
+says how a class shapes one, and what to do about the reaches it cannot
+cover. A stand-in the test hands the class declares itself as one where it is
+passed in, with an `as` on the argument or a small typed helper, never with a
+cast on the receiver.

--- a/packages/utils/src/index-tracking-stack.ts
+++ b/packages/utils/src/index-tracking-stack.ts
@@ -254,11 +254,6 @@ export class IndexTrackingStack<T = unknown> {
   /**
    * The heights this class arranges itself around, for a test or a benchmark
    * to bound its cases with.
-   *
-   * The name is the documentation. These are a tuning decision, not part of
-   * what this class promises, and code that reads them is written against a
-   * number that is free to move. A test that has to straddle a threshold has
-   * no other way to find it, which is the whole of why this exists.
    */
   static get accessForTestingOnly(): {
     ADD_INDEX_AT: number;

--- a/skills/writing-code/SKILL.md
+++ b/skills/writing-code/SKILL.md
@@ -68,7 +68,10 @@ example:
 
 - **Class shape.** `#privateName` over TypeScript's `private`; a class exposes
   no enumerable properties; members run in the order § Classes gives. A
-  `private` field type-checks clean and is still an own enumerable property.
+  `private` field type-checks clean and is still an own enumerable property. A
+  test that needs a `#` member reaches it through an `accessForTestingOnly`
+  getter, never through a cast on the instance; § Classes says how that getter
+  is shaped and what it cannot cover.
 - **Import grouping and collation.** Every specifier naming the same package
   sits in one contiguous run. Nothing sorts imports here.
 - **Word choice.** American spelling, and one word per concept — this reaches


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Fable 5.1)

The `#` convention in `DEVELOPMENT.md` § Classes says what a private member
looks like and not what a test does when it needs one. What the tree did
instead was leave the member TypeScript-`private` with a note naming the
test, and cast the instance from the test's side. #6692 introduced a better
answer for `IndexTrackingStack`, a public getter named
`accessForTestingOnly`, and #6899, #6900, #6902, and #6903 apply it to four
more classes. This PR writes the idiom down so that it lands ahead of them,
and so the next class gets it from the guidelines rather than from an
example.

## What it adds

`DEVELOPMENT.md` § Classes gains a subsection, "Making a private member
reachable from a test". It says why the cast is the wrong tool (it types the
member from the test's side, so a renamed member reads `undefined` and a
truthiness assertion stays green), then the getter's shape as the four
conversions settled it:

- an instance getter for instance members, a static one for static;
- an inline return type and an object literal, so the public surface grows
  by one member;
- a plain property for a field the class never reassigns, a getter for one
  it does, a setter only where a test assigns it, and a forwarding arrow for
  a method, with `const outerThis = this;` under `no-this-alias` when the
  literal has a getter;
- each entry typed as the class types the member, so a stand-in declares
  itself where it is passed in rather than on the receiver;
- where it sits in the member order, and that prose names the member
  `Class.#member`.

A checked example follows, and then the three reaches the getter cannot
cover with what each wants instead: a method the test replaces by
assignment (offer a seam or rewrite the test; until then the member stays
`private` with a note), a method called off the prototype against a
stand-in receiver (build a real instance), and a helper using no instance
state (`static #`, or a module-level function).

`unit-test-coding-style.md` gains the test-side hazard under "Hazards
specific to this repository", pointing at that section. The `writing-code`
skill's class-shape tell and `.claude/rules/source-code.md` each gain a
sentence naming the getter.

## The accessor's doc comment

With the idiom in the guidelines, the getter's doc comment says what it
exposes and nothing more; the name is the hook to the guideline. The
example is written that way, and `IndexTrackingStack`'s accessor, the one
in the tree, drops the paragraph that had been carrying the explanation.

## Gates

`deno task check-docs development` (143 blocks, the new example among
them), `deno task check-skill-facts`, `deno fmt --check` and `deno lint` on
the skill file and the `utils` source, and the `utils` suite (100 passed,
0 failed). `deno fmt` excludes `docs/` and `.claude/`, so the added
Markdown lines were held to 80 columns by hand.

## Review

Reviewed by a `cf-review` pass (cubic being unavailable): no blocking
findings; its three wording corrections and three nits are applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DAWC4oaSp4a6i71xyA1UEq

