### PR TITLE
fix(runner): the #now interval stops when its tick is refused

### DIFF
--- a/packages/runner/src/builtins/wish.ts
+++ b/packages/runner/src/builtins/wish.ts
@@ -45,6 +45,7 @@ import {
   isConflictRejection,
   isStorageTransactionInconsistent,
 } from "../storage/rejection.ts";
+import { isCfcRejectedCommitError } from "../scheduler/cfc-rejection-report.ts";
 import { onSchemaRegistryClear } from "../schema-registry.ts";
 import {
   enrollRuntimeOwnedStore,
@@ -1037,10 +1038,38 @@ function writeIntervalNowTick(
       cell.withTx(tx).set(coarsened);
     }
   }).then(({ error }) => {
-    if (error) {
-      console.error("[wish] #now interval tick failed:", error);
+    if (!error) return;
+    if (isCfcRejectedCommitError(error)) {
+      // CFC enforcement refused the labels this transaction carries, and the
+      // instant being written has no part in that verdict, so the next tick
+      // would carry the same labels to the same cell for the same answer.
+      // The beat stops here rather than schedule one refused write per
+      // interval; the next acquire of this interval starts a fresh one.
+      //
+      // The other two rejections the vocabulary calls terminal leave the
+      // beat running. Each is terminal for its own transaction rather than
+      // for a writer that runs again later: a `SpeculativeBasisError` names
+      // the next derivation as its recovery, and a `RowLabelCommitError`
+      // reads server state a later tick may find changed.
+      stopIntervalNowTimer(timer);
+      console.error(
+        "[wish] #now interval tick refused; the tick is stopped:",
+        error,
+      );
+      return;
     }
+    console.error("[wish] #now interval tick failed:", error);
   });
+}
+
+// Stop a timer's beat. Clearing the pending timeout drops a tick that has not
+// fired; bumping the generation makes one that has fired a no-op. A cleared
+// `timerId` is also what marks the timer as not beating, which is what an
+// acquire reads to decide whether to start one.
+function stopIntervalNowTimer(timer: IntervalNowTimer): void {
+  clearTimeout(timer.timerId);
+  timer.timerId = undefined;
+  timer.generation++;
 }
 
 // Schedule the next tick on a wall-clock-aligned boundary, so patterns cannot
@@ -1081,14 +1110,21 @@ function acquireIntervalNowTimer(
     );
     timer = { cell, timerId: undefined, generation: 0, refCount: 0 };
     timers.set(key, timer);
+  }
 
-    // Initialize the value if the cell is empty or stale (e.g. after reload),
-    // then start the aligned timer. sample() reads without subscribing the
-    // acquiring action, so ticks never re-trigger it.
+  if (timer.timerId === undefined) {
+    // Nothing is beating this cell — a timer just minted, or one a refused
+    // tick stopped. Initialize the value if the cell is empty or stale (e.g.
+    // after reload, or after a stop the grid moved on from), then start the
+    // aligned timer. sample() reads without subscribing the acquiring
+    // action, so ticks never re-trigger it.
     const coarsened = coarsenTimestamp(Date.now(), intervalMs);
-    const existing = cell.withTx(tx).sample() as number | null | undefined;
+    const existing = timer.cell.withTx(tx).sample() as
+      | number
+      | null
+      | undefined;
     if (existing == null) {
-      cell.withTx(tx).set(coarsened);
+      timer.cell.withTx(tx).set(coarsened);
     } else if (existing !== coarsened) {
       writeIntervalNowTick(runtime, timer, intervalMs);
     }
@@ -1112,13 +1148,11 @@ function releaseIntervalNowTimer(
   if (timer.refCount > 0) return;
 
   // Last user gone: stop the recurring timer and drop the registry entry so an
-  // unused interval no longer consumes resources. Bumping the generation makes
-  // any already-queued tick a no-op. The durable cell (one small value per
-  // distinct interval per space, possibly shared with other tabs) is left in
-  // place; deleting it would race a re-acquire of the same content-addressed
-  // cell and could blank another tab still ticking it.
-  clearTimeout(timer.timerId);
-  timer.generation++;
+  // unused interval no longer consumes resources. The durable cell (one small
+  // value per distinct interval per space, possibly shared with other tabs) is
+  // left in place; deleting it would race a re-acquire of the same
+  // content-addressed cell and could blank another tab still ticking it.
+  stopIntervalNowTimer(timer);
   timers!.delete(key);
 }
 

--- a/packages/runner/src/builtins/wish.ts
+++ b/packages/runner/src/builtins/wish.ts
@@ -1039,7 +1039,11 @@ function writeIntervalNowTick(
     }
   }).then(({ error }) => {
     if (!error) return;
-    if (isCfcRejectedCommitError(error)) {
+    // The generation is what a refusal answers for. A tick armed before the
+    // beat was torn down or restarted speaks for a generation that is gone,
+    // so it reports what it dropped and leaves the timer alone: stopping
+    // there would take down a beat this tick was never part of.
+    if (isCfcRejectedCommitError(error) && generation === timer.generation) {
       // CFC enforcement refused the labels this transaction carries, and the
       // instant being written has no part in that verdict, so the next tick
       // would carry the same labels to the same cell for the same answer.

--- a/packages/runner/test/wish-now-interval.test.ts
+++ b/packages/runner/test/wish-now-interval.test.ts
@@ -158,6 +158,7 @@ describe("interval #now wish", () => {
     await result.pull();
 
     let attempts = 0;
+    let restored = false;
     const reported: string[] = [];
     const originalEditWithRetry = runtime.editWithRetry.bind(runtime);
     const originalConsoleError = console.error;
@@ -178,6 +179,8 @@ describe("interval #now wish", () => {
       reported: () => [...reported],
       grid: () => result.key("nowValue").get()?.result,
       unstub: () => {
+        if (restored) return;
+        restored = true;
         runtime.editWithRetry = originalEditWithRetry;
         console.error = originalConsoleError;
       },
@@ -240,21 +243,6 @@ describe("interval #now wish", () => {
       "revived interval now result",
       CFC_REFUSAL,
     );
-    const frozen = stub.grid()!;
-    await clock.tick(1000);
-    expect(stub.attempts()).toBe(1);
-    stub.unstub();
-
-    // Two more boundaries pass with nothing beating the cell, so the grid is
-    // three instants ahead of what the first wish reads.
-    await clock.tick(1000);
-    await clock.tick(1000);
-    expect(stub.grid()).toBe(frozen);
-    expect(Math.floor(Date.now() / 1000) * 1000).toBe(frozen + 3000);
-
-    const secondPattern = pattern(() => {
-      return { nowValue: wish({ query: "#now/1" }) };
-    });
     const secondResultCell = runtime.getCell<
       { nowValue?: { result?: number } }
     >(
@@ -263,19 +251,130 @@ describe("interval #now wish", () => {
       undefined,
       tx,
     );
-    const second = runtime.run(tx, secondPattern, {}, secondResultCell);
+    try {
+      const frozen = stub.grid()!;
+      await clock.tick(1000);
+      expect(stub.attempts()).toBe(1);
+      stub.unstub();
+
+      // Two more boundaries pass with nothing beating the cell, so the grid
+      // is three instants ahead of what the first wish reads.
+      await clock.tick(1000);
+      await clock.tick(1000);
+      expect(stub.grid()).toBe(frozen);
+      expect(Math.floor(Date.now() / 1000) * 1000).toBe(frozen + 3000);
+
+      const secondPattern = pattern(() => {
+        return { nowValue: wish({ query: "#now/1" }) };
+      });
+      const second = runtime.run(tx, secondPattern, {}, secondResultCell);
+      await tx.commit();
+      tx = runtime.edit();
+      await second.pull();
+
+      expect(stub.grid()).toBe(frozen + 3000);
+
+      // And the revived beat goes on ticking.
+      await clock.tick(1000);
+      expect(stub.grid()).toBe(frozen + 4000);
+    } finally {
+      stub.unstub();
+      runtime.runner.stop(secondResultCell);
+      stub.stopPiece();
+    }
+  });
+
+  it("a refusal from a retired beat leaves the one that replaced it alone", async () => {
+    // Two ticks are in flight at once when the first is refused, so the
+    // second was armed under the generation that stop retires. By the time
+    // it answers, another wish has revived the beat, and the beat it would
+    // stop is not the one it belongs to. It says what it dropped and leaves
+    // the timer running.
+    const wishPattern = pattern(() => {
+      return { nowValue: wish({ query: "#now/1" }) };
+    });
+    const resultCell = runtime.getCell<{ nowValue?: { result?: number } }>(
+      space,
+      "retired beat interval now result",
+      undefined,
+      tx,
+    );
+    const secondResultCell = runtime.getCell<
+      { nowValue?: { result?: number } }
+    >(
+      space,
+      "retired beat second result",
+      undefined,
+      tx,
+    );
+    const result = runtime.run(tx, wishPattern, {}, resultCell);
     await tx.commit();
     tx = runtime.edit();
-    await second.pull();
+    await result.pull();
 
-    expect(stub.grid()).toBe(frozen + 3000);
+    // Every tick's commit waits for this test to answer it, which is what
+    // lets two of them be in flight at the same time.
+    const answers: ((answer: { error?: CommitError }) => void)[] = [];
+    const reported: string[] = [];
+    const originalEditWithRetry = runtime.editWithRetry.bind(runtime);
+    const originalConsoleError = console.error;
+    runtime.editWithRetry = (() => {
+      const { promise, resolve } = Promise.withResolvers<
+        { error?: CommitError }
+      >();
+      answers.push(resolve);
+      return promise;
+    }) as typeof runtime.editWithRetry;
+    console.error = (...args: unknown[]) => {
+      if (typeof args[0] === "string" && args[0].startsWith("[wish] #now ")) {
+        reported.push(args[0]);
+      } else {
+        originalConsoleError(...args);
+      }
+    };
 
-    // And the revived beat goes on ticking.
-    await clock.tick(1000);
-    expect(stub.grid()).toBe(frozen + 4000);
+    try {
+      await clock.tick(1000);
+      await clock.tick(1000);
+      expect(answers.length).toBe(2);
 
-    runtime.runner.stop(secondResultCell);
-    stub.stopPiece();
+      // The first refusal stops the beat it belongs to.
+      answers[0]({ error: CFC_REFUSAL });
+      await clock.settle();
+      expect(reported).toEqual([
+        "[wish] #now interval tick refused; the tick is stopped:",
+      ]);
+
+      // A second wish revives it.
+      const secondPattern = pattern(() => {
+        return { nowValue: wish({ query: "#now/1" }) };
+      });
+      const second = runtime.run(tx, secondPattern, {}, secondResultCell);
+      await tx.commit();
+      tx = runtime.edit();
+      await second.pull();
+      const revived = answers.length;
+
+      // Now the tick armed before the stop answers, with the same refusal.
+      answers[1]({ error: CFC_REFUSAL });
+      await clock.settle();
+      expect(reported).toEqual([
+        "[wish] #now interval tick refused; the tick is stopped:",
+        "[wish] #now interval tick failed:",
+      ]);
+
+      // The revived beat is still beating.
+      await clock.tick(1000);
+      expect(answers.length).toBeGreaterThan(revived);
+    } finally {
+      // Nothing is waiting on the commits still outstanding; answering them
+      // with no error lets their handlers finish as no-ops.
+      for (const answer of answers) answer({});
+      runtime.editWithRetry = originalEditWithRetry;
+      console.error = originalConsoleError;
+      runtime.runner.stop(secondResultCell);
+      runtime.runner.stop(resultCell);
+    }
   });
 
   // The two controls the case above rests on. Each rejection here reaches the

--- a/packages/runner/test/wish-now-interval.test.ts
+++ b/packages/runner/test/wish-now-interval.test.ts
@@ -127,6 +127,210 @@ describe("interval #now wish", () => {
     }
   });
 
+  // The cases below share this: an interval grid ticking, with every tick's
+  // commit answered by `failure` instead of reaching storage, collecting both
+  // report prefixes the tick writes. `attempts` counts the ticks that tried to
+  // commit, `reported` what each of them said.
+  async function stubbedInterval(
+    resultName: string,
+    failure: CommitError,
+  ): Promise<{
+    attempts: () => number;
+    reported: () => string[];
+    grid: () => number | undefined;
+    unstub: () => void;
+    stopPiece: () => void;
+  }> {
+    const wishPattern = pattern(() => {
+      return { nowValue: wish({ query: "#now/1" }) };
+    });
+
+    const resultCell = runtime.getCell<{ nowValue?: { result?: number } }>(
+      space,
+      resultName,
+      undefined,
+      tx,
+    );
+    const result = runtime.run(tx, wishPattern, {}, resultCell);
+    await tx.commit();
+    tx = runtime.edit();
+
+    await result.pull();
+
+    let attempts = 0;
+    const reported: string[] = [];
+    const originalEditWithRetry = runtime.editWithRetry.bind(runtime);
+    const originalConsoleError = console.error;
+    runtime.editWithRetry = (() => {
+      attempts++;
+      return Promise.resolve({ error: failure });
+    }) as typeof runtime.editWithRetry;
+    console.error = (...args: unknown[]) => {
+      if (typeof args[0] === "string" && args[0].startsWith("[wish] #now ")) {
+        reported.push(args[0]);
+      } else {
+        originalConsoleError(...args);
+      }
+    };
+
+    return {
+      attempts: () => attempts,
+      reported: () => [...reported],
+      grid: () => result.key("nowValue").get()?.result,
+      unstub: () => {
+        runtime.editWithRetry = originalEditWithRetry;
+        console.error = originalConsoleError;
+      },
+      stopPiece: () => runtime.runner.stop(resultCell),
+    };
+  }
+
+  // A refusal from the CFC boundary, the shape `rejectCommitBeforeStorage`
+  // mints: a verdict on the labels the transaction carries, which the instant
+  // the tick writes has no part in.
+  const CFC_REFUSAL = {
+    name: "CfcCommitRefusalError" as const,
+    message: "CFC enforcement rejected commit: relevant transaction was " +
+      "not prepared: writer-fit confidentiality misfit for of:grid at / " +
+      "(canWrite, §8.12.4)",
+    reasons: [
+      "writer-fit confidentiality misfit for of:grid at / " +
+      "(canWrite, §8.12.4)",
+    ],
+    refusals: [],
+  } satisfies CommitError;
+
+  it(
+    "stops the #now interval after a refusal from the CFC boundary",
+    async () => {
+      // The next tick would carry the same labels to the same cell and be
+      // refused the same way, so the beat stops on the first one and says so
+      // once.
+      //
+      // `clock.tick` fires every timer armed for the second it advances
+      // through, so the three boundaries after the refusal are the ones a
+      // still-armed interval would have been carried into. Their silence is
+      // the assertion; no wall-clock wait stands behind it.
+      const stub = await stubbedInterval(
+        "cfc refused interval now result",
+        CFC_REFUSAL,
+      );
+      try {
+        await clock.tick(1000);
+        await clock.tick(1000);
+        await clock.tick(1000);
+        await clock.tick(1000);
+        expect(stub.attempts()).toBe(1);
+        expect(stub.reported()).toEqual([
+          "[wish] #now interval tick refused; the tick is stopped:",
+        ]);
+      } finally {
+        stub.unstub();
+        stub.stopPiece();
+      }
+    },
+  );
+
+  it("a wish acquiring the interval after a refusal revives the beat", async () => {
+    // The stop leaves the shared timer in place holding whoever still wants
+    // the interval, so a stopped beat must not reach the instance that asks
+    // for that interval next. That instance revives it, and the wish frozen
+    // by the refusal comes forward with it.
+    const stub = await stubbedInterval(
+      "revived interval now result",
+      CFC_REFUSAL,
+    );
+    const frozen = stub.grid()!;
+    await clock.tick(1000);
+    expect(stub.attempts()).toBe(1);
+    stub.unstub();
+
+    // Two more boundaries pass with nothing beating the cell, so the grid is
+    // three instants ahead of what the first wish reads.
+    await clock.tick(1000);
+    await clock.tick(1000);
+    expect(stub.grid()).toBe(frozen);
+    expect(Math.floor(Date.now() / 1000) * 1000).toBe(frozen + 3000);
+
+    const secondPattern = pattern(() => {
+      return { nowValue: wish({ query: "#now/1" }) };
+    });
+    const secondResultCell = runtime.getCell<
+      { nowValue?: { result?: number } }
+    >(
+      space,
+      "revived interval second result",
+      undefined,
+      tx,
+    );
+    const second = runtime.run(tx, secondPattern, {}, secondResultCell);
+    await tx.commit();
+    tx = runtime.edit();
+    await second.pull();
+
+    expect(stub.grid()).toBe(frozen + 3000);
+
+    // And the revived beat goes on ticking.
+    await clock.tick(1000);
+    expect(stub.grid()).toBe(frozen + 4000);
+
+    runtime.runner.stop(secondResultCell);
+    stub.stopPiece();
+  });
+
+  // The two controls the case above rests on. Each rejection here reaches the
+  // same `.then` and must leave the beat running: three boundaries, three
+  // attempts. `ConflictError` says another writer reached the cell first, and
+  // the next tick can win it. `SpeculativeBasisError` is terminal for its own
+  // transaction — it sits beside the CFC refusal in
+  // `TERMINAL_REJECTION_NAMES` — and names the next derivation as its own
+  // recovery, so a beat is what performs that recovery.
+  //
+  // Each fixture carries the name and the message and not the commit fields
+  // the real rejection also holds, which is what the cast stands in for. The
+  // tick reads the name; `storage/v2.ts` mints the speculative one through a
+  // cast of its own.
+  const KEEPS_BEATING: readonly { label: string; error: CommitError }[] = [
+    {
+      label: "a conflict",
+      error: {
+        name: "ConflictError",
+        message: "stale confirmed read: of:grid at seq 1 conflicted with 2",
+      } as unknown as CommitError,
+    },
+    {
+      label: "a speculative basis refusal",
+      error: {
+        name: "SpeculativeBasisError",
+        message: "authored commit refused: its read basis names speculative " +
+          "overlay layer(s) 3",
+      } as unknown as CommitError,
+    },
+  ];
+
+  for (const { label, error } of KEEPS_BEATING) {
+    it(`keeps the #now interval ticking through ${label}`, async () => {
+      const stub = await stubbedInterval(
+        `${label} interval now result`,
+        error,
+      );
+      try {
+        await clock.tick(1000);
+        await clock.tick(1000);
+        await clock.tick(1000);
+        expect(stub.attempts()).toBe(3);
+        expect(stub.reported()).toEqual([
+          "[wish] #now interval tick failed:",
+          "[wish] #now interval tick failed:",
+          "[wish] #now interval tick failed:",
+        ]);
+      } finally {
+        stub.unstub();
+        stub.stopPiece();
+      }
+    });
+  }
+
   it("#now interval keeps ticking when other dependencies change", async () => {
     // Regression: re-running the wish action (here via an unrelated cell the
     // pattern reads) must not reset or starve the shared interval timer.


### PR DESCRIPTION
The `#now/N` wish grid ticks on a recurring wall-clock-boundary timer, and each tick writes the coarsened instant into a shared cell through `editWithRetry`. That call already declines to retry a rejection re-running cannot resolve, but the timer around it does not: the tick that was refused schedules the next one, which carries the same labels to the same cell and is refused the same way. One refused write becomes a stream of them, one per interval, for as long as the process lives.

Under `cfcEnforcementMode: "enforce-strict"` with the rest of the CFC dials at their strictest rung — the row #6619 defaults to — that is reachable. The agent host's `debug deployment rolls back an aborted registration`
(packages/connectors/agents/host/test/debug-view-deployment-lifecycle.test.ts) deploys a debug view whose pattern wishes `#now/60`, and every tick after that is refused:

  CFC enforcement rejected commit: relevant transaction was not
  prepared: writer-fit confidentiality misfit for of:fid1:... at /
  (canWrite, §8.12.4):
  {"subject":"did:key:...","type":".../cfc/atom/User"}

The armed timer is also what held the process's event loop open, so the case could not end. Deno reports a pending promise once the loop drains, and the loop never drained, so the run continued until something above it gave up. In CI that is the workspace shard's thirty-minute budget, which reports a timeout rather than a test failure and takes the other five packages in the shard down with it.

A commit the CFC boundary refuses carries `CfcCommitRefusalError`: a verdict on the labels the transaction carries, which the instant the tick writes has no part in. The tick reads that class now, through the predicate the scheduler's two commit paths already read it with, stops the beat, and says once that it has stopped. Stopping is the three steps the last holder's release already took — drop the pending timeout, bump the generation so a tick already fired becomes a no-op, and leave nothing armed — so both go through one helper.

The line is drawn at that one class rather than at the whole terminal family. The other two members are terminal for their own transaction and not for a writer that runs again later: a `SpeculativeBasisError` names the next derivation as its recovery, which for a beat is the next tick, and a `RowLabelCommitError` reads server state a later tick may find changed. Both keep the beat.

A stopped beat must also not reach the wish that asks for that interval next, since the shared timer stays in the registry holding whoever still wants it. Acquiring now starts a beat whenever none is running rather than only when the timer is minted, which is the same statement the mint always made — bring the cell forward if it is stale, then arm — reached by a second route. So a refusal costs one report per acquire of the interval rather than one per interval, and no instance is ever handed a grid that has silently stopped advancing.

What the refusal was about is worth stating, because it is not the tick's doing and is not fixed here. The refused document is the `#now` grid cell, keyed on the interval and shared by every piece in the space asking for that interval. #6740 put `wish`'s three node-keyed stores on §8.12.5's route, where the writing transaction declares a policy covering what it carries, and deliberately held this one off; docs/specs/cfc-enforcement-matrix.md §4 records the reason, which is that no one piece's flow join may declare the policy of a store every piece shares. So the grid cell keeps its own ceiling, and it should. The `User` atom the tick carried into it did not come from the tick, whose callback reads and writes one document holding an integer. It came from the test's own `editWithRetry` wrapper, which reads the labeled `agent-sessions-debug-registration` document inside every transaction passing through it, the tick's included, and which stays installed because the case deadlocks before its `finally` runs. The refusal is the ceiling working. Retrying it was the defect.

Four cases in wish-now-interval.test.ts, each of which fails against a different way of getting this wrong. A CFC refusal is answered with one attempt and one report across four interval boundaries; `clock.tick` fires every timer armed for the second it advances through, so the three boundaries after the refusal are the ones a still-armed interval would have been carried into, and their silence is the assertion rather than any elapsed time. Against no stop at all it counts four attempts. A second wish acquiring the interval after a refusal revives the beat and brings the frozen wish forward with it; against an acquire that arms only on the mint, that wish stays frozen three instants behind. And two controls, a conflict and a speculative basis refusal, each keep the beat over three boundaries: the first fails any change that stops on rejections generally, the second any change that stops on the whole terminal family.

Measured with the strict dial row forced on locally, running the shard the CI job runs (`AGENTS_HOST_TEST_SHARD=2/5 deno task test` from packages/connectors/agents/host). Before: the case never ends. It was still running, and logging a fresh refusal every minute, when it was stopped after seventeen of them, while the five other cases in the same file finish in two to six seconds each. After: the shard completes in a little over a minute, the refusal is reported once, and the case fails in forty-odd seconds with "Promise resolution is still pending but the event loop has already resolved". That failure is a second strict-dial defect, which this does not touch and #6619 still needs: `deployAgentSessionsDebugView` is itself refused by writer-fit on two further documents, so the barrier the case waits on is never resolved. The timer loop was hiding it by holding the loop open. At the shipped dial defaults the shard passes, six of six in twenty-eight seconds.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6914?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

