### PR TITLE
test(cf-harness): the batch cases declare the git reading they need

### DIFF
--- a/packages/cf-harness/test/run-measurement-batch.test.ts
+++ b/packages/cf-harness/test/run-measurement-batch.test.ts
@@ -1041,6 +1041,16 @@ describe("run-measurement-batch", () => {
       );
     });
 
+    it("asks git itself when given no runner", async () => {
+      // No repository holds the all-zero commit, and a checkout that does not
+      // hold a commit reads as unchecked wherever this runs.
+      const reading = await readAncestry("0".repeat(40), "main");
+      expect(reading.kind).toBe("unchecked");
+      expect(reading.kind === "unchecked" ? reading.reason : "").toContain(
+        `does not hold ${"0".repeat(40)}`,
+      );
+    });
+
     it("returns `unchecked` for a server that reported no commit", async () => {
       expect(await readAncestry(undefined, "main", gitRun(true, true)))
         .toEqual({
@@ -2143,6 +2153,29 @@ describe("run-measurement-batch", () => {
     });
 
     /**
+     * The real posture reader, with the two questions it asks of the local
+     * repository answered by `run` rather than by `git` in the checkout the
+     * tests are started in. The stand-in console reports a commit this
+     * repository's own history holds, so each case says which repository it
+     * means.
+     */
+    const postureAsking = (
+      run: ReturnType<typeof gitRun>,
+    ): typeof preflightPosture =>
+    (fabricApiUrl, base, expectGitSha, fetchImpl, _run, allowDiverged) =>
+      preflightPosture(
+        fabricApiUrl,
+        base,
+        expectGitSha,
+        fetchImpl,
+        run,
+        allowDiverged,
+      );
+
+    /** A repository holding the commit, with it on the base branch. */
+    const POSTURE_ON_THE_BASE_BRANCH = postureAsking(gitRun(true, true));
+
+    /**
      * Runs the command against a stand-in console, in a temporary directory
      * holding the suite it is given and receiving the report it writes.
      * `/api/meta` is served by the same stand-in, so the whole command runs
@@ -2152,7 +2185,7 @@ describe("run-measurement-batch", () => {
       options: FakeConsoleOptions,
       suite: unknown,
       extraArgs: readonly string[] = [],
-      postureReader: typeof preflightPosture = preflightPosture,
+      postureReader: typeof preflightPosture = POSTURE_ON_THE_BASE_BRANCH,
     ): Promise<{ code: number; logs: string[]; dir: string }> => {
       const dir = await Deno.makeTempDir();
       // Registered before anything can throw, so the directory is removed
@@ -2376,25 +2409,32 @@ describe("run-measurement-batch", () => {
       }
     });
 
+    it("runs the batch when the local repository cannot place the server's commit, which is not divergence", async () => {
+      // The shape a shallow clone gives: git answers, and what it answers is
+      // that it does not hold the commit.
+      const { code, dir } = await runMain(
+        {
+          streams: [completedStream()],
+          runId: "fixture-run",
+          artifactRoot: FIXTURE_ROOT,
+        },
+        ONE_TASK,
+        [],
+        postureAsking(gitRun(false, false)),
+      );
+      expect(code).toBe(0);
+      const report = await Deno.readTextFile(`${dir}/out/report.md`);
+      expect(report).toContain(
+        `NOT CHECKED — this clone does not hold ${META.gitSha}`,
+      );
+      const json = JSON.parse(
+        await Deno.readTextFile(`${dir}/out/report.json`),
+      );
+      expect(json.results).toHaveLength(1);
+    });
+
     it("returns 4 for known divergence unless the explicit opt-out is passed", async () => {
-      const postureReader: typeof preflightPosture = (
-        _url,
-        base,
-        _expectGitSha,
-        _fetch,
-        _run,
-        allowDiverged,
-      ) =>
-        Promise.resolve(
-          allowDiverged
-            ? { kind: "read", meta: META, ancestry: { kind: "diverged", base } }
-            : {
-              kind: "refused",
-              meta: META,
-              ancestry: { kind: "diverged", base },
-              reason: `the server is off ${base}`,
-            },
-        );
+      const postureReader = postureAsking(gitRun(true, false));
       const refused = await runMain(
         { streams: [completedStream()] },
         ONE_TASK,
@@ -2496,17 +2536,25 @@ describe("run-measurement-batch", () => {
         const suitePath = `${dir}/suite.json`;
         await Deno.writeTextFile(suitePath, JSON.stringify(ONE_TASK));
         Deno.chdir(dir);
-        await main([
-          suitePath,
-          `--console=${console_.url}`,
-          `--fabric-api-url=${console_.url}`,
-        ], () => {});
+        const code = await main(
+          [
+            suitePath,
+            `--console=${console_.url}`,
+            `--fabric-api-url=${console_.url}`,
+          ],
+          () => {},
+          POSTURE_ON_THE_BASE_BRANCH,
+        );
+        expect(code).toBe(0);
         const measurements = `${dir}/.cf-harness-console/measurements`;
         const written = [...Deno.readDirSync(measurements)];
         expect(written).toHaveLength(1);
-        expect(
-          await Deno.stat(`${measurements}/${written[0].name}/report.md`),
-        ).toBeDefined();
+        const out = `${measurements}/${written[0].name}`;
+        expect(await Deno.stat(`${out}/report.md`)).toBeDefined();
+        // A refusal writes the dated report too, so the result is what says
+        // the batch ran and put its report here.
+        const json = JSON.parse(await Deno.readTextFile(`${out}/report.json`));
+        expect(json.results).toHaveLength(1);
       } finally {
         Deno.chdir(cwd);
         await console_.close();


### PR DESCRIPTION
Six cases under `main()` in the measurement batch runner's test file fail in any checkout whose local `main` branch does not hold the commit the stand-in console reports.

The stand-in console answers `/api/meta` with a fixed `gitSha`, and that sha is a real commit of this repository. `main()` hands the meta reading to `preflightPosture`, which asks the local repository two questions about it: whether the clone holds the commit, and whether the commit is on the base branch, which defaults to the branch named `main`. The `runMain` helper the cases go through left that reader at its production default, so `git cat-file -e` and `git merge-base --is-ancestor` ran in whatever repository the test process happened to be started in.

A checkout that holds the commit but does not have it on `main` — the ordinary state of a long-lived clone that fetches and rebases onto `upstream/main` and never moves its local `main` — answers "not an ancestor". The posture pre-flight reads that as divergence and refuses, the refusal short-circuits the index pre-flight, no task runs, and the report says the pre-flight search was refused. The cases that expect a task to have run then fail, and so does the one that expects exit code 3 for an index refusal, because the commit refusal reaches the exit code first and returns 4.

Continuous integration never sees this, because the test job's checkout is shallow: the commit is absent, the reading falls to unchecked, and the batch runs. Green there and red on a developer's machine is the worst shape for this coupling.

The cases now say which repository they mean, through one factory that takes the real `preflightPosture` and answers git's two questions with the file's existing `gitRun` stub. The reading they get is what they were relying on all along; only its source changes. The real posture reader still runs over a real socket against the stand-in console, so the case for an unexpected commit still exercises it, and the case for known divergence now reads through it as well rather than through a fake that restated its contract. The one case that calls `main()` directly rather than through `runMain` passes the same reader. Nothing in the file spawns `git` for a posture reading any more, which is what makes it independent of where it is started from.

Two cases are added. The first covers the reading a shallow clone gives, where git answers that it does not hold the commit at all. That is unchecked rather than divergence, the batch runs its tasks, and the report records that the commit was not checked and why. Nothing at the `main()` level covered that path before, which is the reason continuous integration stayed green through this. The second calls `readAncestry` with no runner and asks about the all-zero commit, so the runner that spawns `git` is still covered: no repository holds that commit, so the reading is unchecked inside a repository, outside one, shallow or full.

The case that writes its report under a dated directory asserted only that a report file existed there. A refused batch writes that file too, so it passed whether or not anything ran. It now asserts the exit code and that the report names the one task's result.

Reproduced by pointing `GIT_DIR` at a repository holding this repository's objects whose `main` branch predates the fixture commit: the same six cases fail there before this change and pass after it. Also run against a `git` on the path that refuses every call, which leaves the file's one deliberate git invocation as the only one. Line and function coverage of the script stay at 100%.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6915?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

