### PR TITLE
feat(data-model): `toCompactDebugString()` takes a `backtickQuote`

### DIFF
--- a/packages/data-model/src/api.ts
+++ b/packages/data-model/src/api.ts
@@ -519,4 +519,12 @@ export interface CompactDebugStringOptions extends DebugValueOptions {
    * as three.
    */
   readonly maxLength?: number;
+
+  /**
+   * Whether to quote the result as a Markdown code span, the way
+   * `backtickQuote()` does, for splicing into message text. `maxLength`
+   * bounds the rendering, not the quoted result. When absent, the result is
+   * not quoted.
+   */
+  readonly backtickQuote?: boolean;
 }

--- a/packages/data-model/src/codec-common/quotedDebugString.ts
+++ b/packages/data-model/src/codec-common/quotedDebugString.ts
@@ -1,5 +1,3 @@
-import { backtickQuote } from "@commonfabric/utils/markdown";
-
 import { toCompactDebugString } from "@/value-debug.ts";
 
 /** Length a rendering is cut to. */
@@ -12,5 +10,8 @@ const MAX_LENGTH = 50;
  * for what it cannot render, so this holds up on the failure path it serves.
  */
 export function quotedDebugString(value: unknown): string {
-  return backtickQuote(toCompactDebugString(value, { maxLength: MAX_LENGTH }));
+  return toCompactDebugString(value, {
+    maxLength: MAX_LENGTH,
+    backtickQuote: true,
+  });
 }

--- a/packages/data-model/src/value-debug.ts
+++ b/packages/data-model/src/value-debug.ts
@@ -1076,6 +1076,15 @@ class DebugStringifier {
 }
 
 /**
+ * Renders a value an option check refuses, for the error which refuses it:
+ * quoted for the message, and cut short, since what the value is matters
+ * more than what it holds.
+ */
+function renderRefused(value: unknown): string {
+  return toCompactDebugString(value, { maxLength: 20, backtickQuote: true });
+}
+
+/**
  * Helper for `checkedLimits()`, which validates `options` as a whole. What
  * each option holds is validated as it is read, by `checkedLimit()`.
  *
@@ -1083,10 +1092,7 @@ class DebugStringifier {
  */
 function checkOptions(options: DebugValueOptions | undefined): void {
   if ((options !== undefined) && !isPlainObject(options)) {
-    const badOptions = toCompactDebugString(options, {
-      maxLength: 20,
-      backtickQuote: true,
-    });
+    const badOptions = renderRefused(options);
     throw new Error(
       `\`options\` must be a plain object or \`undefined\`; got ${badOptions}`,
     );
@@ -1122,10 +1128,7 @@ function checkedLimit(
     }
   }
 
-  const badValue = toCompactDebugString(value, {
-    maxLength: 20,
-    backtickQuote: true,
-  });
+  const badValue = renderRefused(value);
   throw new Error(
     `\`${name}\` must be a positive integer, \`Infinity\`, or \`undefined\`; got ${badValue}`,
   );

--- a/packages/data-model/src/value-debug.ts
+++ b/packages/data-model/src/value-debug.ts
@@ -1083,9 +1083,10 @@ class DebugStringifier {
  */
 function checkOptions(options: DebugValueOptions | undefined): void {
   if ((options !== undefined) && !isPlainObject(options)) {
-    const badOptions = backtickQuote(
-      toCompactDebugString(options, { maxLength: 20 }),
-    );
+    const badOptions = toCompactDebugString(options, {
+      maxLength: 20,
+      backtickQuote: true,
+    });
     throw new Error(
       `\`options\` must be a plain object or \`undefined\`; got ${badOptions}`,
     );
@@ -1121,9 +1122,10 @@ function checkedLimit(
     }
   }
 
-  const badValue = backtickQuote(
-    toCompactDebugString(value, { maxLength: 20 }),
-  );
+  const badValue = toCompactDebugString(value, {
+    maxLength: 20,
+    backtickQuote: true,
+  });
   throw new Error(
     `\`${name}\` must be a positive integer, \`Infinity\`, or \`undefined\`; got ${badValue}`,
   );
@@ -1220,7 +1222,8 @@ function renderDebugString(
  * Produces a compact string representation of a value, optionally truncating to
  * the maximum length given in `options`. When truncating is requested and turns
  * out to be necessary, the returned result will be the indicated length, which
- * includes an "ASCII ellipsis" of `...`.
+ * includes an "ASCII ellipsis" of `...`. When `options` asks for it, the result
+ * is then quoted as a Markdown code span, ready to splice into message text.
  *
  * The value is first converted with `toStructuredDebugValue()`, passing along
  * the depth limit and replacer given in `options`, and it is that result which
@@ -1264,17 +1267,17 @@ export function toCompactDebugString(
   value: unknown,
   options?: CompactDebugStringOptions,
 ): string {
-  const result = renderDebugString(value, options);
+  let result = renderDebugString(value, options);
   const maxLength = options?.maxLength;
 
   if (typeof maxLength === "number") {
     const actualMax = Math.max(Math.floor(maxLength), 3);
     if (result.length > actualMax) {
-      return result.slice(0, actualMax - 3) + "...";
+      result = result.slice(0, actualMax - 3) + "...";
     }
   }
 
-  return result;
+  return (options?.backtickQuote === true) ? backtickQuote(result) : result;
 }
 
 /**

--- a/packages/data-model/src/valueEqual.ts
+++ b/packages/data-model/src/valueEqual.ts
@@ -1,4 +1,3 @@
-import { backtickQuote } from "@commonfabric/utils/markdown";
 import { isPlainObject } from "@commonfabric/utils/types";
 import { isDeepFrozen } from "./deep-freeze.ts";
 import {
@@ -148,7 +147,9 @@ function objectSubtypeOf(
     return "plain";
   } else {
     throw new Error(
-      `Cannot compare value ${backtickQuote(toCompactDebugString(value))}`,
+      `Cannot compare value ${
+        toCompactDebugString(value, { backtickQuote: true })
+      }`,
     );
   }
 }

--- a/packages/data-model/test/value-debug-cases.test.ts
+++ b/packages/data-model/test/value-debug-cases.test.ts
@@ -29,7 +29,6 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
-import { backtickQuote } from "@commonfabric/utils/markdown";
 import { isPlainObject } from "@commonfabric/utils/types";
 
 import { REALM_CODEC } from "@/codec-interface/interface.ts";
@@ -86,9 +85,10 @@ function evaluateExpression(expression: string): Record<string, unknown> {
   const result = fn(...values);
 
   if (!isPlainObject(result, false)) {
-    const rendered = backtickQuote(
-      toCompactDebugString(result, { maxLength: 60 }),
-    );
+    const rendered = toCompactDebugString(result, {
+      maxLength: 60,
+      backtickQuote: true,
+    });
     throw new Error(
       `Case expression must produce a plain object; got ${rendered}`,
     );

--- a/packages/data-model/test/value-debug.test.ts
+++ b/packages/data-model/test/value-debug.test.ts
@@ -99,6 +99,30 @@ describe("value-debug", () => {
       }
     });
 
+    describe("with `backtickQuote`", () => {
+      it("renders the result as a code span", () => {
+        expect(toCompactDebugString({ a: 1 }, { backtickQuote: true }))
+          .toBe("`{a:1}`");
+      });
+
+      it("renders a result holding backticks with a longer delimiter", () => {
+        expect(toCompactDebugString("a`b", { backtickQuote: true }))
+          .toBe('``"a`b"``');
+      });
+
+      it("renders the truncated result as the code span, when both are asked for", () => {
+        const options = { maxLength: 8, backtickQuote: true };
+        expect(toCompactDebugString({ abc: "defghij" }, options))
+          .toBe("`{abc:...`");
+      });
+
+      it("renders the result bare when the option is `false` or absent", () => {
+        expect(toCompactDebugString({ a: 1 }, { backtickQuote: false }))
+          .toBe("{a:1}");
+        expect(toCompactDebugString({ a: 1 })).toBe("{a:1}");
+      });
+    });
+
     describe("with `maxDepth`", () => {
       it("renders to the given depth rather than to the default", () => {
         const value = { a: { b: { c: 1 } } };

--- a/packages/patterns/integration/multi-runtime-worker.ts
+++ b/packages/patterns/integration/multi-runtime-worker.ts
@@ -46,7 +46,6 @@ import {
 } from "./multi-runtime-ipc.ts";
 import { resolveLocalProgram } from "@commonfabric/runner/local-program.deno";
 import { getLoggerCountsBreakdown } from "@commonfabric/utils/logger";
-import { backtickQuote } from "@commonfabric/utils/markdown";
 import { isObjectNotArray } from "@commonfabric/utils/types";
 
 let cc: PiecesController | undefined;
@@ -583,7 +582,9 @@ const handlers: Record<
     if (!isValidFabricValue(counts)) {
       throw new Error(
         "Cannot send logger counts across this boundary, not being a " +
-          `\`FabricValue\`: ${backtickQuote(toCompactDebugString(counts))}`,
+          `\`FabricValue\`: ${
+            toCompactDebugString(counts, { backtickQuote: true })
+          }`,
       );
     }
     return counts;

--- a/packages/runtime-client/src/backends/utils.ts
+++ b/packages/runtime-client/src/backends/utils.ts
@@ -26,7 +26,6 @@ import {
 } from "@commonfabric/runner/shared";
 import { IndexTrackingStack } from "@commonfabric/utils/index-tracking-stack";
 import type { LoggerFlagsBreakdown } from "@commonfabric/utils/logger";
-import { backtickQuote } from "@commonfabric/utils/markdown";
 
 import { isCellRef } from "@/protocol/mod.ts";
 import { CellRef, type LoggerFlagsData, PieceRef } from "@/protocol/types.ts";
@@ -168,7 +167,9 @@ export function assertFabricLoggerFlags(
 
   throw new Error(
     "Cannot send logger flags on this connection, not being a " +
-      `\`FabricValue\`: ${backtickQuote(toCompactDebugString(breakdown))}`,
+      `\`FabricValue\`: ${
+        toCompactDebugString(breakdown, { backtickQuote: true })
+      }`,
   );
 }
 

--- a/packages/static/assets/types/commonfabric.d.ts
+++ b/packages/static/assets/types/commonfabric.d.ts
@@ -562,6 +562,14 @@ export interface CompactDebugStringOptions extends DebugValueOptions {
    * as three.
    */
   readonly maxLength?: number;
+
+  /**
+   * Whether to quote the result as a Markdown code span, the way
+   * `backtickQuote()` does, for splicing into message text. `maxLength`
+   * bounds the rendering, not the quoted result. When absent, the result is
+   * not quoted.
+   */
+  readonly backtickQuote?: boolean;
 }
 
 //


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Fable 5.1)

## What

`CompactDebugStringOptions` gains `backtickQuote?: boolean`. When `true`, the
result of `toCompactDebugString()` comes back quoted as a Markdown code span,
the way `backtickQuote()` quotes it, ready to splice into message text. It is
off when absent. `maxLength` bounds the rendering, not the quoted result, so a
cut rendering is what gets quoted:

```
toCompactDebugString({ abc: "defghij" }, { maxLength: 8, backtickQuote: true })
  // `{abc:...`
```

The leniency matches `maxLength`: `true` quotes, anything else does not.

## Sites

Every place that wrapped a compact rendering in `backtickQuote()` by hand says
the option instead, and four imports of the helper went with the wraps:

* the renderer's own two option-validation errors, in `value-debug.ts`;
* the comparison error in `valueEqual()`;
* `quotedDebugString()` in `codec-common`, which stays as the helper its four
  codec callers use and takes the option in its body;
* the `FabricValue` breakdown messages in `runtime-client`'s backend utilities
  and in the patterns' multi-runtime worker;
* the case-file harness's refusal of a non-object expression.

One rendering spliced into a message stays unquoted, in the runtime
processor's "argument must be a record" error, since quoting it would change
that message rather than tidy its construction.

## Tests

A `backtickQuote` block in `value-debug.test.ts`: the plain quoting, a
rendering that holds a backtick and so takes a longer delimiter, the cut
rendering quoted, and the option `false` or absent. `commonfabric.d.ts` is
regenerated for the new option.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6916?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

