### PR TITLE
refactor(shell): four views keep their test-driven members as `#` names behind `accessForTestingOnly`

### DIFF
--- a/docs/specs/computed-cell-identity.md
+++ b/docs/specs/computed-cell-identity.md
@@ -585,7 +585,7 @@ changes here:
   analysis (`capability-analysis.ts`) is the natural place to detect the
   calls, including through module-scope helpers via its interprocedural
   summaries.
-- Deferred tooling gap: `SchedulerGraphView.extractEntityId` (shell) groups
+- Deferred tooling gap: `XSchedulerGraph.#extractEntityId` (shell) groups
   graph nodes by scheme-stripped entity id, so an `of:` doc and a
   `computed:` doc minted from the same cause would be conflated into one
   group in the debug graph. This is more than cosmetic debt: the scheduler

--- a/packages/shell/integration/piece.test.ts
+++ b/packages/shell/integration/piece.test.ts
@@ -129,11 +129,13 @@ describe("shell piece tests", () => {
           const rootView = document.querySelector("x-root-view");
           const typedRootView = rootView as
             | {
-              _rt?: {
-                status?: unknown;
-                value?: unknown;
-                error?: {
-                  message?: string;
+              accessForTestingOnly?: {
+                rt?: {
+                  status?: unknown;
+                  value?: unknown;
+                  error?: {
+                    message?: string;
+                  };
                 };
               };
               app?: {
@@ -172,9 +174,11 @@ describe("shell piece tests", () => {
             href: globalThis.location.href,
             hasRuntime: !!globalThis.commonfabric?.rt,
             hasRootView: !!rootView,
-            rootRuntimeStatus: typedRootView?._rt?.status,
-            hasRootRuntimeValue: !!typedRootView?._rt?.value,
-            rootRuntimeError: typedRootView?._rt?.error?.message,
+            rootRuntimeStatus: typedRootView?.accessForTestingOnly?.rt?.status,
+            hasRootRuntimeValue: !!typedRootView?.accessForTestingOnly?.rt
+              ?.value,
+            rootRuntimeError: typedRootView?.accessForTestingOnly?.rt?.error
+              ?.message,
             rootHasIdentity: !!typedRootView?.app?.identity,
             hasAppView: !!appView,
             patternsStatus: appView?._patterns?.status,
@@ -452,9 +456,13 @@ describe("shell piece tests", () => {
     // trip, and the transport close) on a real completion instead of a timer.
     await shell.page().evaluate(async () => {
       const rootView = document.querySelector("x-root-view") as
-        | { _rt?: { value?: { dispose(): Promise<void> } } }
+        | {
+          accessForTestingOnly?: {
+            rt?: { value?: { dispose(): Promise<void> } };
+          };
+        }
         | null;
-      const internals = rootView?._rt?.value;
+      const internals = rootView?.accessForTestingOnly?.rt?.value;
       if (!internals) {
         throw new Error(
           "Runtime internals not available to observe disposal",

--- a/packages/shell/src/views/DeviceLinkView.ts
+++ b/packages/shell/src/views/DeviceLinkView.ts
@@ -165,6 +165,11 @@ export class XDeviceLinkView extends LitElement {
   // `setTimeout` is typed as Node's `Timeout` under this config, not `number`.
   #guardTimer: ReturnType<typeof setTimeout> | undefined;
 
+  /** The answer step of this dialog, which a test drives directly. */
+  get accessForTestingOnly(): { finish(accepted: boolean): void } {
+    return { finish: (accepted) => this.#finish(accepted) };
+  }
+
   override firstUpdated() {
     // Schedule the guard release FIRST — before anything below that could throw
     // — so a failure activating the dialog can never leave the accept button
@@ -174,7 +179,7 @@ export class XDeviceLinkView extends LitElement {
     }, TAP_THROUGH_GUARD_MS);
 
     const dialog = this.renderRoot.querySelector("dialog");
-    activateModalDialog(dialog, () => this.finish(false));
+    activateModalDialog(dialog, () => this.#finish(false));
 
     // Focus the heading, NOT a button. WebKit scrolls a modal to its focused
     // element; with the accept button disabled during the guard, focus would
@@ -191,11 +196,7 @@ export class XDeviceLinkView extends LitElement {
     super.disconnectedCallback();
   }
 
-  /**
-   * TypeScript-private rather than a `#` name: `test/device-link.test.ts`
-   * drives this member directly.
-   */
-  private finish(accepted: boolean) {
+  #finish(accepted: boolean) {
     // Exactly one answer, ever: a double-tap must not dispatch twice.
     if (this.#answered) return;
     // Accept is inert during the tap-through guard; Cancel is always allowed.
@@ -219,7 +220,7 @@ export class XDeviceLinkView extends LitElement {
             Reveal the code again on the Pair screen and rescan it.
           </p>
           <div class="actions">
-            <button @click="${() => this.finish(false)}">Continue</button>
+            <button @click="${() => this.#finish(false)}">Continue</button>
           </div>
         </dialog>
       `;
@@ -239,7 +240,7 @@ export class XDeviceLinkView extends LitElement {
           <div class="did">${this.incomingDid}</div>
           <div class="actions">
             <button
-              @click="${() => this.finish(true)}"
+              @click="${() => this.#finish(true)}"
               ?disabled="${this.guarded}"
             >
               Continue
@@ -271,12 +272,12 @@ export class XDeviceLinkView extends LitElement {
         </p>
         <div class="actions">
           <button
-            @click="${() => this.finish(true)}"
+            @click="${() => this.#finish(true)}"
             ?disabled="${this.guarded}"
           >
             ${replacing ? "Replace identity" : "Continue"}
           </button>
-          <button @click="${() => this.finish(false)}">Cancel</button>
+          <button @click="${() => this.#finish(false)}">Cancel</button>
         </div>
       </dialog>
     `;

--- a/packages/shell/src/views/DeviceLinkView.ts
+++ b/packages/shell/src/views/DeviceLinkView.ts
@@ -196,6 +196,7 @@ export class XDeviceLinkView extends LitElement {
     super.disconnectedCallback();
   }
 
+  /** Answers the dialog once, dispatching the result the host listens for. */
   #finish(accepted: boolean) {
     // Exactly one answer, ever: a double-tap must not dispatch twice.
     if (this.#answered) return;

--- a/packages/shell/src/views/HeaderView.ts
+++ b/packages/shell/src/views/HeaderView.ts
@@ -550,11 +550,8 @@ export class XHeaderView extends BaseView {
    * Idempotent while a subscription is live. After teardown — a disconnect or
    * a runtime swap clears `#unsubscribeFavorites` — the next call re-subscribes,
    * so a reconnected header is not left without favorites.
-   *
-   * TypeScript-private rather than a `#` name:
-   * `test/header-view-favorites.test.ts` drives this member directly.
    */
-  private _ensureFavoritesSubscription(): void {
+  #ensureFavoritesSubscription(): void {
     if (this.#unsubscribeFavorites) return;
     this.#setupFavoritesSubscription();
   }
@@ -587,6 +584,28 @@ export class XHeaderView extends BaseView {
   }
 
   #resizeTimer?: ReturnType<typeof setTimeout>;
+
+  /**
+   * The favorites subscription step, the favorite-toggle guard, and the two
+   * click handlers, which a test drives directly.
+   */
+  get accessForTestingOnly(): {
+    isFavoriteLoading: boolean;
+    ensureFavoritesSubscription(): void;
+    handleLogoClick(e: Event): void;
+    handleToggleFavorite(e: Event): Promise<void>;
+  } {
+    // deno-lint-ignore no-this-alias
+    const outerThis = this;
+    return {
+      get isFavoriteLoading() {
+        return outerThis.#isFavoriteLoading;
+      },
+      ensureFavoritesSubscription: () => this.#ensureFavoritesSubscription(),
+      handleLogoClick: (e) => this.#handleLogoClick(e),
+      handleToggleFavorite: (e) => this.#handleToggleFavorite(e),
+    };
+  }
 
   override connectedCallback(): void {
     super.connectedCallback();
@@ -643,7 +662,7 @@ export class XHeaderView extends BaseView {
       this.#cleanupFavoritesSubscription();
       // If the menu is already open when a runtime arrives, the favorites
       // surface is showing, so subscribe now; otherwise wait for the first open.
-      if (this.menuOpen) this._ensureFavoritesSubscription();
+      if (this.menuOpen) this.#ensureFavoritesSubscription();
     }
     // One runtime serves every space, so a space switch no longer
     // replaces rt — the per-space pieces cache must invalidate on the
@@ -758,15 +777,12 @@ export class XHeaderView extends BaseView {
 
   /**
    * Open the main dropdown menu and move focus to the close button.
-   *
-   * TypeScript-private rather than a `#` name:
-   * `test/header-view-favorites.test.ts` drives this member directly.
    */
-  private handleLogoClick(e: Event) {
+  #handleLogoClick(e: Event) {
     e.preventDefault();
     e.stopPropagation();
     this.menuOpen = true;
-    this._ensureFavoritesSubscription();
+    this.#ensureFavoritesSubscription();
     this.updateComplete.then(() => {
       this.renderRoot.querySelector<HTMLElement>(".menu-close")?.focus();
     });
@@ -889,35 +905,29 @@ export class XHeaderView extends BaseView {
     this.menuOpen = false;
   }
 
+  /** Whether a favorite toggle is in flight, which refuses a second one. */
+  #isFavoriteLoading = false;
+
   /**
    * Toggle the current piece's favorite status. Uses optimistic UI —
    * updates local state immediately, then syncs with the server.
    * Rolls back local state on error. Guarded against double-clicks
-   * with _isFavoriteLoading to prevent conflicting requests.
-   *
-   * TypeScript-private rather than a `#` name:
-   * `test/header-view-favorites.test.ts` drives this member directly.
+   * with `#isFavoriteLoading` to prevent conflicting requests.
    */
-  private _isFavoriteLoading = false;
-
-  /**
-   * TypeScript-private rather than a `#` name:
-   * `test/header-view-favorites.test.ts` drives this member directly.
-   */
-  private async handleToggleFavorite(e: Event) {
+  async #handleToggleFavorite(e: Event) {
     e.preventDefault();
     e.stopPropagation();
     const space = this.space;
-    if (!this.rt || !space || !this.pieceId || this._isFavoriteLoading) {
+    if (!this.rt || !space || !this.pieceId || this.#isFavoriteLoading) {
       return;
     }
 
     const currentlyFavorite = this.#isFavorite();
     this._localIsFavorite = !currentlyFavorite;
-    this._isFavoriteLoading = true;
+    this.#isFavoriteLoading = true;
     // Favoriting touches the home pattern anyway; start reflecting server
     // state from here on if the menu was never opened.
-    this._ensureFavoritesSubscription();
+    this.#ensureFavoritesSubscription();
 
     try {
       if (currentlyFavorite) {
@@ -934,7 +944,7 @@ export class XHeaderView extends BaseView {
       console.error("[HeaderView] Error toggling favorite:", err);
       this._localIsFavorite = undefined;
     } finally {
-      this._isFavoriteLoading = false;
+      this.#isFavoriteLoading = false;
     }
   }
 
@@ -953,7 +963,7 @@ export class XHeaderView extends BaseView {
         <div class="header-start">
           <button
             class="nav-picker"
-            @click="${this.handleLogoClick}"
+            @click="${this.#handleLogoClick}"
             aria-haspopup="true"
             aria-expanded="${this.menuOpen}"
             aria-label="Open menu"
@@ -1086,7 +1096,7 @@ export class XHeaderView extends BaseView {
                   <button
                     class="menu-item"
                     role="menuitem"
-                    @click="${this.handleToggleFavorite}"
+                    @click="${this.#handleToggleFavorite}"
                   >
                     <span class="menu-item-icon">${iconStar(isFavorite)}</span>
                     <span class="menu-item-label">${isFavorite

--- a/packages/shell/src/views/HeaderView.ts
+++ b/packages/shell/src/views/HeaderView.ts
@@ -590,7 +590,7 @@ export class XHeaderView extends BaseView {
    * click handlers, which a test drives directly.
    */
   get accessForTestingOnly(): {
-    isFavoriteLoading: boolean;
+    readonly isFavoriteLoading: boolean;
     ensureFavoritesSubscription(): void;
     handleLogoClick(e: Event): void;
     handleToggleFavorite(e: Event): Promise<void>;

--- a/packages/shell/src/views/HeaderView.ts
+++ b/packages/shell/src/views/HeaderView.ts
@@ -525,6 +525,9 @@ export class XHeaderView extends BaseView {
 
   #unsubscribeFavorites: (() => void) | undefined;
 
+  /** Whether a favorite toggle is in flight, which refuses a second one. */
+  #isFavoriteLoading = false;
+
   /** Subscribe to the favorites list so the menu reflects current state. */
   #setupFavoritesSubscription(): void {
     this.#cleanupFavoritesSubscription();
@@ -904,9 +907,6 @@ export class XHeaderView extends BaseView {
     }
     this.menuOpen = false;
   }
-
-  /** Whether a favorite toggle is in flight, which refuses a second one. */
-  #isFavoriteLoading = false;
 
   /**
    * Toggle the current piece's favorite status. Uses optimistic UI —

--- a/packages/shell/src/views/RootView.ts
+++ b/packages/shell/src/views/RootView.ts
@@ -334,9 +334,9 @@ export class XRootView extends BaseView implements ShellApp {
    * a test drives directly.
    */
   get accessForTestingOnly(): {
-    onBeforeUnload: (event: BeforeUnloadEvent) => void;
+    readonly onBeforeUnload: (event: BeforeUnloadEvent) => void;
     rt: Task<[AppState | undefined], RuntimeInternals | undefined>;
-    runtimeGeneration: number;
+    readonly runtimeGeneration: number;
   } {
     // deno-lint-ignore no-this-alias
     const outerThis = this;

--- a/packages/shell/src/views/RootView.ts
+++ b/packages/shell/src/views/RootView.ts
@@ -162,9 +162,7 @@ export class XRootView extends BaseView implements ShellApp {
   // Invalidates callbacks from replaced workers. A coded compiler-load error
   // can arrive through either a request reply or an asynchronous runtime error;
   // only the currently-owned worker may trigger one replacement.
-  // TypeScript-private rather than a `#` name, because `test/root-view.test.ts`
-  // drives this member directly.
-  private _runtimeGeneration = 0;
+  #runtimeGeneration = 0;
   #preserveRuntimeErrorsForNextViewChange = false;
 
   readonly preserveRuntimeErrorsForNextViewChange = (): void => {
@@ -173,10 +171,10 @@ export class XRootView extends BaseView implements ShellApp {
 
   readonly _handleRuntimeError = (
     event: ErrorNotification,
-    generation = this._runtimeGeneration,
+    generation = this.#runtimeGeneration,
   ): void => {
     console.error("[RuntimeClient Error]", event);
-    if (generation !== this._runtimeGeneration) {
+    if (generation !== this.#runtimeGeneration) {
       return;
     }
 
@@ -200,8 +198,8 @@ export class XRootView extends BaseView implements ShellApp {
     // before terminating it; the replacement gets a fresh module map and can
     // retry the compiler chunk when the user retries the operation.
     this._runtimeLoadErrors = [];
-    this._runtimeGeneration++;
-    this._rt.run([this.app]);
+    this.#runtimeGeneration++;
+    this.#rt.run([this.app]);
   };
 
   @property()
@@ -224,9 +222,7 @@ export class XRootView extends BaseView implements ShellApp {
   // change; one runtime serves every space. This is manually run in `updated()`
   // because we want to compare to previous values, leaving this function
   // responsible for cleaning up previous runtimes, and creating a new one.
-  // TypeScript-private rather than a `#` name, because `test/root-view.test.ts`
-  // drives this member directly.
-  private _rt = new Task<[AppState | undefined], RuntimeInternals | undefined>(
+  #rt = new Task<[AppState | undefined], RuntimeInternals | undefined>(
     this,
     {
       // Do not define `args` -- this is run in "manual mode",
@@ -235,9 +231,9 @@ export class XRootView extends BaseView implements ShellApp {
       // whereas in a task we don't have access to necessary info
       // like previous app state.
       task: async ([app]: [AppState | undefined], { signal }) => {
-        const generation = ++this._runtimeGeneration;
+        const generation = ++this.#runtimeGeneration;
         this._runtimeLoadErrors = [];
-        const previous = this._rt.value;
+        const previous = this.#rt.value;
         if (previous) {
           this.runtime?.off(
             "eventneedsattention",
@@ -333,6 +329,31 @@ export class XRootView extends BaseView implements ShellApp {
     },
   );
 
+  /**
+   * The runtime task, its generation counter, and the unload handler, which
+   * a test drives directly.
+   */
+  get accessForTestingOnly(): {
+    onBeforeUnload: (event: BeforeUnloadEvent) => void;
+    rt: Task<[AppState | undefined], RuntimeInternals | undefined>;
+    runtimeGeneration: number;
+  } {
+    // deno-lint-ignore no-this-alias
+    const outerThis = this;
+    return {
+      onBeforeUnload: this.#onBeforeUnload,
+      get rt() {
+        return outerThis.#rt;
+      },
+      set rt(value) {
+        outerThis.#rt = value;
+      },
+      get runtimeGeneration() {
+        return outerThis.#runtimeGeneration;
+      },
+    };
+  }
+
   override connectedCallback(): void {
     super.connectedCallback();
     // A Lit element can be detached and reattached without rebuilding its
@@ -345,7 +366,7 @@ export class XRootView extends BaseView implements ShellApp {
       "theme-preference-changed",
       this.#onThemeChanged,
     );
-    globalThis.addEventListener("beforeunload", this._onBeforeUnload);
+    globalThis.addEventListener("beforeunload", this.#onBeforeUnload);
   }
 
   override disconnectedCallback(): void {
@@ -355,7 +376,7 @@ export class XRootView extends BaseView implements ShellApp {
       "theme-preference-changed",
       this.#onThemeChanged,
     );
-    globalThis.removeEventListener("beforeunload", this._onBeforeUnload);
+    globalThis.removeEventListener("beforeunload", this.#onBeforeUnload);
     super.disconnectedCallback();
   }
 
@@ -366,9 +387,7 @@ export class XRootView extends BaseView implements ShellApp {
   // unconfirmed, ask the browser to confirm leaving instead of silently losing
   // them. Commits confirm quickly (typically well under a second), so the
   // prompt only appears in the narrow window a reload would actually lose data.
-  // TypeScript-private rather than a `#` name, because `test/root-view.test.ts`
-  // drives this member directly.
-  private _onBeforeUnload = (event: BeforeUnloadEvent): void => {
+  #onBeforeUnload = (event: BeforeUnloadEvent): void => {
     if (this.runtime?.hasPendingWrites()) {
       event.preventDefault();
     }
@@ -406,7 +425,7 @@ export class XRootView extends BaseView implements ShellApp {
       shouldRecreateRuntime(previous, current);
 
     if (flipState || stateChanged) {
-      this._rt.run([current]);
+      this.#rt.run([current]);
     }
   }
 
@@ -493,7 +512,7 @@ export class XRootView extends BaseView implements ShellApp {
     // the telemetry sink lives across navigations.
     this.#telemetry?.setSpace(space);
     if (space !== undefined) {
-      void this.#refreshEventAttention(space, this._runtimeGeneration);
+      void this.#refreshEventAttention(space, this.#runtimeGeneration);
     }
   }
 
@@ -527,7 +546,7 @@ export class XRootView extends BaseView implements ShellApp {
     try {
       const notices = await runtime.listEventAttention(space);
       if (
-        generation !== this._runtimeGeneration || runtime !== this.runtime ||
+        generation !== this.#runtimeGeneration || runtime !== this.runtime ||
         space !== this.space ||
         this.#eventAttentionRefreshOwners.get(space) !== owner
       ) return;
@@ -556,7 +575,7 @@ export class XRootView extends BaseView implements ShellApp {
       ];
     } catch (error) {
       if (
-        generation === this._runtimeGeneration && runtime === this.runtime &&
+        generation === this.#runtimeGeneration && runtime === this.runtime &&
         space === this.space &&
         this.#eventAttentionRefreshOwners.get(space) === owner
       ) {
@@ -679,15 +698,15 @@ export class XRootView extends BaseView implements ShellApp {
 
   override render() {
     const loadError: LoadError | undefined = this._spaceResolutionError ??
-      (this._rt.status === TaskStatus.ERROR
-        ? { kind: "space", error: this._rt.error }
+      (this.#rt.status === TaskStatus.ERROR
+        ? { kind: "space", error: this.#rt.error }
         : undefined);
     return html`
       <cf-theme .theme="${{ colorScheme: this._themePreference }}">
         <x-app-view
           .app="${this.app}"
           .keyStore="${this.keyStore}"
-          .rt="${this._rt.value}"
+          .rt="${this.#rt.value}"
           .space="${this.space}"
           .spaceLoadError="${loadError}"
           .runtimeLoadErrors="${this._runtimeLoadErrors}"

--- a/packages/shell/src/views/SchedulerGraphView.ts
+++ b/packages/shell/src/views/SchedulerGraphView.ts
@@ -1153,6 +1153,18 @@ export class XSchedulerGraph extends LitElement {
   // Minimum effective node size before we boost triggered nodes
   static readonly #READABLE_THRESHOLD = 50;
 
+  /** The two action-id label helpers, which a test drives directly. */
+  static get accessForTestingOnly(): {
+    extractEntityId(actionId: string): string | undefined;
+    truncateLabel(label: string, maxLen?: number): string;
+  } {
+    return {
+      extractEntityId: (actionId) => XSchedulerGraph.#extractEntityId(actionId),
+      truncateLabel: (label, maxLen) =>
+        XSchedulerGraph.#truncateLabel(label, maxLen),
+    };
+  }
+
   override connectedCallback() {
     super.connectedCallback();
     this.#updateLayout();
@@ -1263,7 +1275,7 @@ export class XSchedulerGraph extends LitElement {
       if (hiddenNodes.has(node.id)) continue;
 
       g.setNode(node.id, {
-        label: this.truncateLabel(node.id),
+        label: XSchedulerGraph.#truncateLabel(node.id),
         width: NODE_WIDTH,
         height: NODE_HEIGHT,
         type: node.type,
@@ -1352,11 +1364,8 @@ export class XSchedulerGraph extends LitElement {
    * Examples:
    * - "sink:did:key:z6Mkk.../of:fid1:abc.../value" → "sink:...c.../value"
    * - "parentAction" → "parentAction"
-   *
-   * TypeScript-private rather than a `#` name:
-   * `test/entity-id-scheme-parsing.test.ts` drives this member directly.
    */
-  private truncateLabel(label: string, maxLen = 20): string {
+  static #truncateLabel(label: string, maxLen = 20): string {
     // Simple case - short enough already
     if (label.length <= maxLen) return label;
 
@@ -1435,11 +1444,8 @@ export class XSchedulerGraph extends LitElement {
    * Handles formats like:
    * - sink:did:key:.../of:entityId/path
    * - action:pattern:did:key:.../computed:entityId/path
-   *
-   * TypeScript-private rather than a `#` name:
-   * `test/entity-id-scheme-parsing.test.ts` drives this member directly.
    */
-  private extractEntityId(actionId: string): string | undefined {
+  static #extractEntityId(actionId: string): string | undefined {
     const entityUri = entityUriFromActionId(actionId);
     if (entityUri) return entityUri;
 
@@ -1469,7 +1475,7 @@ export class XSchedulerGraph extends LitElement {
     // Group nodes by entity ID
     const nodesByEntity = new Map<string, SchedulerGraphNode[]>();
     for (const node of nodes) {
-      const entityId = this.extractEntityId(node.id);
+      const entityId = XSchedulerGraph.#extractEntityId(node.id);
       if (entityId) {
         if (!nodesByEntity.has(entityId)) {
           nodesByEntity.set(entityId, []);
@@ -2140,7 +2146,7 @@ export class XSchedulerGraph extends LitElement {
       if (group.children.length === 0) continue;
 
       const { bounds, parent } = group;
-      const label = this.truncateLabel(parent.label, 12);
+      const label = XSchedulerGraph.#truncateLabel(parent.label, 12);
 
       results.push(svgTag`
         <g class="parent-group">

--- a/packages/shell/test/device-link.test.ts
+++ b/packages/shell/test/device-link.test.ts
@@ -1080,14 +1080,12 @@ describe("the tap-through guard actually releases", () => {
       );
 
       // Before the timer fires, accept is inert...
-      // deno-lint-ignore no-explicit-any
-      (view as any).finish(true);
+      view.accessForTestingOnly.finish(true);
       assertEquals(answers, [], "accept must be inert during the guard");
 
       assert(fire, "the guard timer must have been scheduled");
       fire!(); // ...and after it fires, accept works.
-      // deno-lint-ignore no-explicit-any
-      (view as any).finish(true);
+      view.accessForTestingOnly.finish(true);
       assertEquals(answers, [true], "accept must work once the guard lifts");
     } finally {
       globalThis.setTimeout = realSet;

--- a/packages/shell/test/entity-id-scheme-parsing.test.ts
+++ b/packages/shell/test/entity-id-scheme-parsing.test.ts
@@ -28,20 +28,16 @@ Deno.test("normalizeEntityId prefixes bare ids and passes schemed ids through", 
 });
 
 Deno.test("SchedulerGraphView preserves entity URI schemes when parsing action ids", () => {
-  const proto = XSchedulerGraph.prototype as unknown as {
-    extractEntityId(actionId: string): string | undefined;
-    truncateLabel(label: string, maxLen?: number): string;
-  };
+  const helpers = XSchedulerGraph.accessForTestingOnly;
 
   // extractEntityId: the scheme precedes the entity id and remains part of its
   // identity.
   assertEquals(
-    proto.extractEntityId.call(proto, "sink:did:key:z6Mkabc/of:fid1:AAA/path"),
+    helpers.extractEntityId("sink:did:key:z6Mkabc/of:fid1:AAA/path"),
     "of:fid1:AAA",
   );
   assertEquals(
-    proto.extractEntityId.call(
-      proto,
+    helpers.extractEntityId(
       "action:pattern:did:key:z6Mkabc/computed:fid1:BBB/value",
     ),
     "computed:fid1:BBB",
@@ -49,14 +45,12 @@ Deno.test("SchedulerGraphView preserves entity URI schemes when parsing action i
 
   // truncateLabel: schemed segments are recognized so the label keeps the
   // entity tail and path instead of blind truncation.
-  const ofLabel = proto.truncateLabel.call(
-    proto,
+  const ofLabel = helpers.truncateLabel(
     "sink:did:key:z6MkabcdefghijkLMNOP/of:fid1:AAAABBBBCCCCDDDD/value",
   );
   assertEquals(ofLabel.includes("DDDD"), true);
   assertEquals(ofLabel.includes("value"), true);
-  const computedLabel = proto.truncateLabel.call(
-    proto,
+  const computedLabel = helpers.truncateLabel(
     "sink:did:key:z6MkabcdefghijkLMNOP/computed:fid1:EEEEFFFFGGGGHHHH/count",
   );
   assertEquals(computedLabel.includes("HHHH"), true);

--- a/packages/shell/test/header-view-favorites.test.ts
+++ b/packages/shell/test/header-view-favorites.test.ts
@@ -4,23 +4,22 @@
 
 import { assert, assertEquals, assertFalse } from "@std/assert";
 
+import type { XHeaderView as HeaderViewClass } from "../src/views/HeaderView.ts";
+
 // Exercises the lazy favorites-subscription paths in HeaderView. The header
 // resolves the home space's default pattern only when its favorites surface is
 // first opened (menu open or favorite toggle), not at login, so the home
 // pattern's one-time creation does not contend with the user's first write.
 
 // The members the tests drive, typed loosely so fakes can stand in for the
-// runtime and the private methods/state are reachable without leaking `any`.
+// runtime; the private steps and state are reached through the accessor.
 interface HeaderViewLike {
   rt: unknown;
   space: unknown;
   pieceId: unknown;
   menuOpen: boolean;
-  _isFavoriteLoading: boolean;
-  _ensureFavoritesSubscription(): void;
+  accessForTestingOnly: HeaderViewClass["accessForTestingOnly"];
   willUpdate(changed: Map<string, unknown>): void;
-  handleLogoClick(e: Event): void;
-  handleToggleFavorite(e: Event): Promise<void>;
   disconnectedCallback(): void;
 }
 
@@ -123,16 +122,16 @@ Deno.test("favorites stay unsubscribed until a runtime exists and a surface open
     const rt = makeRuntime();
 
     // No runtime yet: requesting the subscription is a no-op.
-    view._ensureFavoritesSubscription();
+    view.accessForTestingOnly.ensureFavoritesSubscription();
     assertEquals(rt.subscribeCount, 0);
 
     // Runtime present: the first request subscribes exactly once.
     view.rt = rt;
-    view._ensureFavoritesSubscription();
+    view.accessForTestingOnly.ensureFavoritesSubscription();
     assertEquals(rt.subscribeCount, 1);
 
     // Idempotent: a repeat request does not subscribe again.
-    view._ensureFavoritesSubscription();
+    view.accessForTestingOnly.ensureFavoritesSubscription();
     assertEquals(rt.subscribeCount, 1);
   } finally {
     restore();
@@ -148,14 +147,14 @@ Deno.test("a new runtime re-arms the lazy subscription", async () => {
     const closed = new XHeaderView() as unknown as HeaderViewLike;
     const first = makeRuntime();
     closed.rt = first;
-    closed._ensureFavoritesSubscription();
+    closed.accessForTestingOnly.ensureFavoritesSubscription();
     assertEquals(first.subscribeCount, 1);
 
     // Swapping the runtime tears down the old subscription; with the menu
     // closed nothing resubscribes yet, but the next open does.
     closed.willUpdate(new Map([["rt", undefined]]));
     assertEquals(first.unsubscribeCount, 1);
-    closed._ensureFavoritesSubscription();
+    closed.accessForTestingOnly.ensureFavoritesSubscription();
     assertEquals(first.subscribeCount, 2);
 
     // Menu already open when the runtime arrives: subscribe immediately.
@@ -178,7 +177,7 @@ Deno.test("opening the header menu requests the favorites subscription", async (
     const rt = makeRuntime();
     view.rt = rt;
 
-    view.handleLogoClick(fakeEvent());
+    view.accessForTestingOnly.handleLogoClick(fakeEvent());
     assert(view.menuOpen);
     assertEquals(rt.subscribeCount, 1);
   } finally {
@@ -197,9 +196,9 @@ Deno.test("toggling a favorite requests the subscription and swallows a disposal
     ok.rt = okRt;
     ok.space = "did:key:test";
     ok.pieceId = "piece-1";
-    await ok.handleToggleFavorite(fakeEvent());
+    await ok.accessForTestingOnly.handleToggleFavorite(fakeEvent());
     assertEquals(okRt.subscribeCount, 1);
-    assertFalse(ok._isFavoriteLoading);
+    assertFalse(ok.accessForTestingOnly.isFavoriteLoading);
 
     // A write cancelled by a disposed runtime is swallowed, not surfaced.
     const racing = new XHeaderView() as unknown as HeaderViewLike;
@@ -207,8 +206,8 @@ Deno.test("toggling a favorite requests the subscription and swallows a disposal
     racing.rt = racingRt;
     racing.space = "did:key:test";
     racing.pieceId = "piece-2";
-    await racing.handleToggleFavorite(fakeEvent());
-    assertFalse(racing._isFavoriteLoading);
+    await racing.accessForTestingOnly.handleToggleFavorite(fakeEvent());
+    assertFalse(racing.accessForTestingOnly.isFavoriteLoading);
   } finally {
     restore();
   }
@@ -223,7 +222,7 @@ Deno.test("favorites re-subscribe after the header disconnects and reopens", asy
     view.rt = rt;
 
     // Opening the menu subscribes.
-    view._ensureFavoritesSubscription();
+    view.accessForTestingOnly.ensureFavoritesSubscription();
     assertEquals(rt.subscribeCount, 1);
 
     // Disconnecting tears the subscription down.
@@ -231,7 +230,7 @@ Deno.test("favorites re-subscribe after the header disconnects and reopens", asy
     assertEquals(rt.unsubscribeCount, 1);
 
     // Reopening after reconnect must subscribe again, not skip on stale state.
-    view._ensureFavoritesSubscription();
+    view.accessForTestingOnly.ensureFavoritesSubscription();
     assertEquals(rt.subscribeCount, 2);
   } finally {
     restore();

--- a/packages/shell/test/load-errors.test.ts
+++ b/packages/shell/test/load-errors.test.ts
@@ -198,12 +198,7 @@ describe("load-errors", () => {
               ...view.app,
               identity: await Identity.generate({ implementation: "noble" }),
             };
-            const task = (view as unknown as {
-              _rt: {
-                run(args: [typeof view.app]): void;
-                taskComplete: Promise<unknown>;
-              };
-            })._rt;
+            const task = view.accessForTestingOnly.rt;
 
             task.run([view.app]);
             await task.taskComplete.catch(() => undefined);

--- a/packages/shell/test/root-view.test.ts
+++ b/packages/shell/test/root-view.test.ts
@@ -467,27 +467,26 @@ describe("XRootView", () => {
       view.connectedCallback();
       view.disconnectedCallback();
 
-      const handler = view.accessForTestingOnly.onBeforeUnload as (
-        event: { preventDefault: () => void },
-      ) => void;
-      let prevented = 0;
-      const event = () => ({ preventDefault: () => prevented++ });
+      const handler = view.accessForTestingOnly.onBeforeUnload;
+      // A cancelable event records the prompt as `defaultPrevented`.
+      const unload = () => {
+        const event = new Event("beforeunload", { cancelable: true });
+        handler(event as BeforeUnloadEvent);
+        return event.defaultPrevented;
+      };
       const setRuntime = (runtime: unknown) =>
         (view as unknown as { runtime: unknown }).runtime = runtime;
 
       // No runtime yet: nothing to lose, so no prompt.
-      handler(event());
-      expect(prevented).toBe(0);
+      expect(unload()).toBe(false);
 
       // A runtime with no unconfirmed writes: no prompt.
       setRuntime({ hasPendingWrites: () => false });
-      handler(event());
-      expect(prevented).toBe(0);
+      expect(unload()).toBe(false);
 
       // Unconfirmed writes in flight: prompt the user before unload.
       setRuntime({ hasPendingWrites: () => true });
-      handler(event());
-      expect(prevented).toBe(1);
+      expect(unload()).toBe(true);
     } finally {
       restore();
     }

--- a/packages/shell/test/root-view.test.ts
+++ b/packages/shell/test/root-view.test.ts
@@ -132,12 +132,10 @@ describe("XRootView", () => {
       const { XRootView } = await import("../src/views/RootView.ts");
       const view = new XRootView();
       const runs: unknown[] = [];
-      const internals = view as unknown as {
-        _rt: { run(args: unknown): void };
-        _runtimeGeneration: number;
-      };
-      internals._rt = { run: (args) => runs.push(args) };
-      const failedGeneration = internals._runtimeGeneration;
+      view.accessForTestingOnly.rt = {
+        run: (args: unknown) => runs.push(args),
+      } as never;
+      const failedGeneration = view.accessForTestingOnly.runtimeGeneration;
       const event: ErrorNotification = {
         type: NotificationType.ErrorReport,
         message: "Failed to load the compiler stack",
@@ -196,12 +194,7 @@ describe("XRootView", () => {
           "root-view-runtime-error-callback-test",
         ),
       };
-      const task = (view as unknown as {
-        _rt: {
-          run(args: [typeof view.app]): void;
-          taskComplete: Promise<unknown>;
-        };
-      })._rt;
+      const task = view.accessForTestingOnly.rt;
 
       task.run([view.app]);
       await task.taskComplete;
@@ -438,12 +431,7 @@ describe("XRootView", () => {
       await view.spaceResolved();
       expect(view.getRuntimeSpaceDID()).toBe(atlas);
 
-      const task = (view as unknown as {
-        _rt: {
-          run(args: [typeof view.app]): void;
-          taskComplete: Promise<unknown>;
-        };
-      })._rt;
+      const task = view.accessForTestingOnly.rt;
 
       // One runtime creation starts and a second supersedes it, which is what
       // a compiler stack reload does to a creation already under way.
@@ -479,9 +467,9 @@ describe("XRootView", () => {
       view.connectedCallback();
       view.disconnectedCallback();
 
-      const handler = (view as unknown as {
-        _onBeforeUnload: (event: { preventDefault: () => void }) => void;
-      })._onBeforeUnload;
+      const handler = view.accessForTestingOnly.onBeforeUnload as (
+        event: { preventDefault: () => void },
+      ) => void;
       let prevented = 0;
       const event = () => ({ preventDefault: () => prevented++ });
       const setRuntime = (runtime: unknown) =>


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Fable 5.1)

Four `shell` views held the members their tests reach as TypeScript
`private`, each with a note naming the test. They are `#` names now, behind
an `accessForTestingOnly` getter per class, as
`docs/development/DEVELOPMENT.md` § Classes prescribes. One PR for the
package because each class is small; happy to split if that reads better.

## The four accessors

- `XRootView`: the runtime `Task` is a getter and a setter, because
  `test/root-view.test.ts` stubs it; the generation counter is a getter,
  since the class advances it; the `beforeunload` handler is an arrow field
  the class never reassigns, so it is a plain property.
- `XHeaderView`: the favorite-toggle guard is a getter, and the favorites
  subscription step and the two click handlers are forwarding arrows.
- `XDeviceLinkView`: one forwarding arrow, for the answer step.
- `XSchedulerGraph`: its two action-id label helpers use no instance state,
  so they are `static #` behind a static getter, the shape #6692 introduced.

## What the tests do now

Every cast onto a converted member is gone. The header test's stand-in
type keeps only the Lit-decorated members it assigns and gains the
accessor's type from the class, through a type import aliased so it does
not shadow the test's dynamic import. The root-view test's stubbed task
declares itself as a stand-in where it is assigned. The scheduler-graph
test calls the helpers instead of `Class.prototype.m.call(proto, ...)`.

`integration/piece.test.ts`, the browser test, reads the runtime task
through the accessor inside its `page.evaluate` bodies. It is type-checked
here, since `packages/shell` is one type-check scope, but not run, as it
needs the local servers.

## Also in the diff

`XHeaderView`'s favorite-toggle doc comment sat on the guard field; it now
sits on the method it describes, and the field has its own line.
`docs/specs/computed-cell-identity.md` names the entity-id helper as
`XSchedulerGraph.#extractEntityId`.

## Review

Reviewed by a `cf-review` pass: approve, no blocking findings. Its two
improvements are applied: the `beforeunload` test drives the handler with a
real cancelable `Event` and reads `defaultPrevented`, so no cast narrows
the handler, and the favorite-toggle guard field sits with the other
private instance variables. `#finish` gained the doc comment its apology
had stood in for. The setter-less accessor entries are `readonly` in their
types, the rule cubic surfaced on #6918.

## Gates

`deno fmt --check`, `deno lint`, `deno task check`, and the `shell` suite
(57 passed, 0 failed).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6921?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


