### PR TITLE
fix(lib-shell): the render ceiling names the acting principal

### DIFF
--- a/packages/lib-shell/src/runtime.ts
+++ b/packages/lib-shell/src/runtime.ts
@@ -1,5 +1,11 @@
 import type { CellScope } from "@commonfabric/api";
-import { createSession, DID, Identity, Session } from "@commonfabric/identity";
+import {
+  createSession,
+  DID,
+  Identity,
+  isDID,
+  Session,
+} from "@commonfabric/identity";
 import { CFC_CONCEPT_KIND, cfcAtom } from "@commonfabric/api/cfc";
 import type { FabricPlainObject } from "@commonfabric/data-model";
 import { entityRefFromString } from "@commonfabric/data-model/cell-rep";
@@ -144,13 +150,19 @@ export type RuntimeInternalsCreateOptions = RuntimeInternalsCallbacks & {
   /**
    * Populate the default render confidentiality ceiling (Epic H3a). When
    * true, the worker's display sinks gate labeled values against the
-   * §8.10.6 profile for this identity and author-supplied render-boundary
-   * declassification is denied. Dogfood flag, default off (= today's
-   * unbounded rendering). Expect over-blocking while exchange resolution
-   * (H3b) is not implemented.
+   * §8.10.6 profile for the acting identity and author-supplied
+   * render-boundary declassification is denied. Dogfood flag, default off
+   * (= today's unbounded rendering). Expect over-blocking while exchange
+   * resolution (H3b) is not implemented.
    */
   cfcRenderCeiling?: boolean;
 
+  /**
+   * The trust the worker runs against. Its `actingPrincipal` is the identity
+   * the runtime acts as, which is also the audience the render ceiling admits
+   * when `cfcRenderCeiling` is on. Omit it to run as the session identity;
+   * pass `null` to run against no snapshot at all.
+   */
   trustSnapshot?: RuntimeTrustSnapshot | null;
 
   /**
@@ -340,11 +352,23 @@ export function createRuntimeClientOptions({
   patternCoverage?: boolean;
   concurrentWatchRefresh?: boolean;
 }) {
+  // The identity the runtime acts and renders as. A delegated host names it
+  // in its own trust snapshot; a snapshot that names nobody leaves the
+  // session identity acting. A name that is not a DID is a host's own
+  // configuration error, and it surfaces here rather than as a ceiling built
+  // for somebody else: the runner reads this same field as a DID, and the
+  // ceiling's entries are identity atoms over one.
+  const namedPrincipal = trustSnapshot?.actingPrincipal;
+  if (namedPrincipal !== undefined && !isDID(namedPrincipal)) {
+    throw new Error(
+      `A trust snapshot's acting principal must be a DID: ${
+        JSON.stringify(namedPrincipal)
+      }`,
+    );
+  }
+  const actingPrincipal = namedPrincipal ?? session.as.did();
   const resolvedTrustSnapshot = trustSnapshot === undefined
-    ? {
-      id: `principal:${session.as.did()}`,
-      actingPrincipal: session.as.did(),
-    }
+    ? { id: `principal:${actingPrincipal}`, actingPrincipal }
     : trustSnapshot ?? undefined;
 
   return {
@@ -360,8 +384,9 @@ export function createRuntimeClientOptions({
     ...(cfcRenderCeiling
       ? {
         renderDeclassificationPolicy: "deny" as const,
+        // A display sink's audience is the identity the runtime renders as.
         renderConfidentialityCeiling: defaultRenderConfidentialityCeiling(
-          session.as.did(),
+          actingPrincipal,
         ),
       }
       : {}),

--- a/packages/lib-shell/src/runtime.ts
+++ b/packages/lib-shell/src/runtime.ts
@@ -354,9 +354,8 @@ export function createRuntimeClientOptions({
 }) {
   // The identity the runtime acts and renders as. A delegated host names it
   // in its own trust snapshot; a snapshot that names nobody leaves the
-  // session identity acting. A name that is not a DID is a host's own
-  // configuration error, and it surfaces here rather than as a ceiling built
-  // for somebody else: the runner reads this same field as a DID, and the
+  // session identity acting, which is the rule the worker applies to the same
+  // field in `runtime-processor.ts`. A named principal must be a DID: the
   // ceiling's entries are identity atoms over one.
   const namedPrincipal = trustSnapshot?.actingPrincipal;
   if (namedPrincipal !== undefined && !isDID(namedPrincipal)) {

--- a/packages/lib-shell/src/runtime.ts
+++ b/packages/lib-shell/src/runtime.ts
@@ -950,15 +950,8 @@ export class RuntimeInternals extends EventTarget {
       `[Identity] User DID: ${identity.did()}`,
     );
 
-    const connection = transport ??
-      await WebWorkerRuntimeTransport.connect({
-        workerUrl: await resolveWorkerUrl({
-          workerUrl,
-          clientVersion,
-          getBuildHash,
-        }),
-      });
-
+    // Built before anything is connected, so a host's bad options are
+    // refused while a worker this page would own is still unspawned.
     const clientOptions = createRuntimeClientOptions({
       session,
       apiUrl,
@@ -972,6 +965,15 @@ export class RuntimeInternals extends EventTarget {
       patternCoverage,
       concurrentWatchRefresh,
     });
+
+    const connection = transport ??
+      await WebWorkerRuntimeTransport.connect({
+        workerUrl: await resolveWorkerUrl({
+          workerUrl,
+          clientVersion,
+          getBuildHash,
+        }),
+      });
     const client = attach
       ? await RuntimeClient.attach(
         connection,

--- a/packages/lib-shell/src/runtime.ts
+++ b/packages/lib-shell/src/runtime.ts
@@ -152,16 +152,16 @@ export type RuntimeInternalsCreateOptions = RuntimeInternalsCallbacks & {
    * true, the worker's display sinks gate labeled values against the
    * §8.10.6 profile for the acting identity and author-supplied
    * render-boundary declassification is denied. Dogfood flag, default off
-   * (= today's unbounded rendering). Expect over-blocking while exchange
-   * resolution (H3b) is not implemented.
+   * (= today's unbounded rendering).
    */
   cfcRenderCeiling?: boolean;
 
   /**
    * The trust the worker runs against. Its `actingPrincipal` is the identity
    * the runtime acts as, which is also the audience the render ceiling admits
-   * when `cfcRenderCeiling` is on. Omit it to run as the session identity;
-   * pass `null` to run against no snapshot at all.
+   * when `cfcRenderCeiling` is on. Omit it to send one naming the session
+   * identity; pass `null` to send none, which leaves the worker to build its
+   * own, naming the session identity as well.
    */
   trustSnapshot?: RuntimeTrustSnapshot | null;
 
@@ -352,11 +352,11 @@ export function createRuntimeClientOptions({
   patternCoverage?: boolean;
   concurrentWatchRefresh?: boolean;
 }) {
-  // The identity the runtime acts and renders as. A delegated host names it
-  // in its own trust snapshot; a snapshot that names nobody leaves the
-  // session identity acting, which is the rule the worker applies to the same
-  // field in `runtime-processor.ts`. A named principal must be a DID: the
-  // ceiling's entries are identity atoms over one.
+  // The identity the runtime renders as. A delegated host names it in its own
+  // trust snapshot; a snapshot that names nobody leaves the session identity
+  // as the render audience, the fallback the worker's own resolver applies to
+  // the same field in `runtime-processor.ts`. A named principal must be a DID:
+  // the ceiling's entries are identity atoms over one.
   const namedPrincipal = trustSnapshot?.actingPrincipal;
   if (namedPrincipal !== undefined && !isDID(namedPrincipal)) {
     throw new Error(

--- a/packages/lib-shell/test/runtime.test.ts
+++ b/packages/lib-shell/test/runtime.test.ts
@@ -791,6 +791,94 @@ describe("RuntimeInternals", () => {
     expect(off.renderConfidentialityCeiling).toBeUndefined();
   });
 
+  it("builds the render ceiling for a host-supplied acting principal", async () => {
+    const identity = await Identity.generate({ implementation: "noble" });
+    const session = await createSession({
+      identity,
+      spaceName: "lib-shell-cfc-render-ceiling-delegated",
+    });
+    const delegate = "did:key:z6MkDelegatedHost";
+
+    const options = createRuntimeClientOptions({
+      session,
+      apiUrl: new URL("http://shell.test/"),
+      // Stated rather than inherited from a host default: what this test is
+      // about is which principal the ceiling admits, not whether a host
+      // builds a ceiling at all.
+      cfcRenderCeiling: true,
+      trustSnapshot: { id: `principal:${delegate}`, actingPrincipal: delegate },
+    });
+
+    // A display sink's audience is whoever the runtime renders as, which a
+    // delegated host names in its own trust snapshot rather than in the
+    // session identity.
+    expect(options.renderConfidentialityCeiling).toEqual(
+      defaultRenderConfidentialityCeiling(delegate),
+    );
+    expect(options.renderConfidentialityCeiling?.atoms).not.toContainEqual({
+      type: "https://commonfabric.org/cfc/atom/User",
+      subject: session.as.did(),
+    });
+  });
+
+  it("falls back to the session identity when nobody is named", async () => {
+    const identity = await Identity.generate({ implementation: "noble" });
+    const session = await createSession({
+      identity,
+      spaceName: "lib-shell-cfc-render-ceiling-fallback",
+    });
+    const sessionCeiling = defaultRenderConfidentialityCeiling(
+      session.as.did(),
+    );
+
+    // `null` asks for no trust snapshot at all, which is a different case
+    // from a snapshot that carries no acting principal. Neither names an
+    // audience, so the session identity is acting in both.
+    const withoutSnapshot = createRuntimeClientOptions({
+      session,
+      apiUrl: new URL("http://shell.test/"),
+      cfcRenderCeiling: true,
+      trustSnapshot: null,
+    });
+    expect(withoutSnapshot.trustSnapshot).toBeUndefined();
+    expect(withoutSnapshot.renderConfidentialityCeiling).toEqual(
+      sessionCeiling,
+    );
+
+    const withoutPrincipal = createRuntimeClientOptions({
+      session,
+      apiUrl: new URL("http://shell.test/"),
+      cfcRenderCeiling: true,
+      trustSnapshot: { id: "principal:loom-host" },
+    });
+    expect(withoutPrincipal.renderConfidentialityCeiling).toEqual(
+      sessionCeiling,
+    );
+  });
+
+  it("refuses an acting principal that is not a DID", async () => {
+    const identity = await Identity.generate({ implementation: "noble" });
+    const session = await createSession({
+      identity,
+      spaceName: "lib-shell-cfc-render-ceiling-non-did",
+    });
+
+    // The ceiling's entries are identity atoms over a DID, and the runner
+    // reads the same field as a DID. Building the ceiling for the session
+    // identity instead would leave the host acting as one principal and
+    // rendering to another.
+    expect(() =>
+      createRuntimeClientOptions({
+        session,
+        apiUrl: new URL("http://shell.test/"),
+        trustSnapshot: {
+          id: "principal:loom-host",
+          actingPrincipal: "loom-host",
+        },
+      })
+    ).toThrow("acting principal must be a DID");
+  });
+
   it("allows hosts to override CFC policy and trust snapshot", async () => {
     const identity = await Identity.generate({ implementation: "noble" });
     const session = await createSession({

--- a/packages/lib-shell/test/runtime.test.ts
+++ b/packages/lib-shell/test/runtime.test.ts
@@ -187,6 +187,23 @@ type NavigationDetail = {
 };
 
 describe("RuntimeInternals", () => {
+  /** Fails the test if anything reaches for a dedicated worker. */
+  async function withNoWorkerConstructible<T>(
+    run: () => Promise<T>,
+  ): Promise<T> {
+    const OriginalWorker = (globalThis as { Worker: unknown }).Worker;
+    (globalThis as { Worker: unknown }).Worker = class {
+      constructor() {
+        throw new Error("a supplied transport must spawn no worker");
+      }
+    };
+    try {
+      return await run();
+    } finally {
+      (globalThis as { Worker: unknown }).Worker = OriginalWorker;
+    }
+  }
+
   describe("getSpaceRootPattern", () => {
     it("caches a successful root-pattern lookup", async () => {
       const client = new MockRuntimeClient();
@@ -1021,6 +1038,26 @@ describe("RuntimeInternals", () => {
     });
   });
 
+  it("refuses bad options before spawning a worker it would own", async () => {
+    const identity = await Identity.generate({ implementation: "noble" });
+
+    // With no transport supplied, `create` spawns the worker itself and owns
+    // it. Options are built first, so a snapshot this host cannot render for
+    // is refused while there is still nothing to dispose.
+    await expect(
+      withNoWorkerConstructible(() =>
+        RuntimeInternals.create({
+          identity,
+          apiUrl: new URL("http://shell.test/"),
+          trustSnapshot: {
+            id: "principal:loom-host",
+            actingPrincipal: "loom-host",
+          },
+        })
+      ),
+    ).rejects.toThrow("acting principal must be a DID");
+  });
+
   describe("worker URL versioning", () => {
     // A deployed page must keep its worker and lazy chunks on the same
     // immutable module graph. Local/legacy builds retain the root worker URL
@@ -1313,23 +1350,6 @@ describe("RuntimeInternals", () => {
       dispose(): Promise<void> {
         this.disposals += 1;
         return Promise.resolve();
-      }
-    }
-
-    /** Fails the test if anything reaches for a dedicated worker. */
-    async function withNoWorkerConstructible<T>(
-      run: () => Promise<T>,
-    ): Promise<T> {
-      const OriginalWorker = (globalThis as { Worker: unknown }).Worker;
-      (globalThis as { Worker: unknown }).Worker = class {
-        constructor() {
-          throw new Error("a supplied transport must spawn no worker");
-        }
-      };
-      try {
-        return await run();
-      } finally {
-        (globalThis as { Worker: unknown }).Worker = OriginalWorker;
       }
     }
 

--- a/packages/lib-shell/test/runtime.test.ts
+++ b/packages/lib-shell/test/runtime.test.ts
@@ -802,9 +802,8 @@ describe("RuntimeInternals", () => {
     const options = createRuntimeClientOptions({
       session,
       apiUrl: new URL("http://shell.test/"),
-      // Stated rather than inherited from a host default: what this test is
-      // about is which principal the ceiling admits, not whether a host
-      // builds a ceiling at all.
+      // Stated, not inherited from a host default: the subject here is
+      // which principal the ceiling admits.
       cfcRenderCeiling: true,
       trustSnapshot: { id: `principal:${delegate}`, actingPrincipal: delegate },
     });
@@ -863,10 +862,8 @@ describe("RuntimeInternals", () => {
       spaceName: "lib-shell-cfc-render-ceiling-non-did",
     });
 
-    // The ceiling's entries are identity atoms over a DID, and the runner
-    // reads the same field as a DID. Building the ceiling for the session
-    // identity instead would leave the host acting as one principal and
-    // rendering to another.
+    // A principal that is not a DID names no audience, and the check runs
+    // whether or not this host asks for a ceiling.
     expect(() =>
       createRuntimeClientOptions({
         session,

--- a/packages/lib-shell/test/runtime.test.ts
+++ b/packages/lib-shell/test/runtime.test.ts
@@ -1043,12 +1043,16 @@ describe("RuntimeInternals", () => {
 
     // With no transport supplied, `create` spawns the worker itself and owns
     // it. Options are built first, so a snapshot this host cannot render for
-    // is refused while there is still nothing to dispose.
+    // is refused while there is still nothing to dispose. The worker URL and
+    // build hash are supplied so that resolving them reaches the spawn, which
+    // the rigged `Worker` constructor is what stops.
     await expect(
       withNoWorkerConstructible(() =>
         RuntimeInternals.create({
           identity,
           apiUrl: new URL("http://shell.test/"),
+          workerUrl: new URL("http://shell.test/worker.js"),
+          getBuildHash: () => Promise.resolve(undefined),
           trustSnapshot: {
             id: "principal:loom-host",
             actingPrincipal: "loom-host",

--- a/packages/runtime-client/src/backends/runtime-processor.ts
+++ b/packages/runtime-client/src/backends/runtime-processor.ts
@@ -491,10 +491,12 @@ export function browserWorkerParamsFromInitializationData(
  *  - the acting user's own identity space (space DID == principal DID) — a
  *    principal definitionally reads its own space;
  *  - the current session workspace (`sessionSpace` = the space the session was
- *    authorized to open) — with `createSession({ spaceName })` the home space
- *    is a derived `spaceIdentity` DID distinct from the principal DID, and it
- *    is the space `session.open` gated on, so an own-workspace `Space(...)`
- *    label resolves rather than over-blocking.
+ *    authorized to open), while the acting principal is the session's own key
+ *    holder — with `createSession({ spaceName })` the home space is a derived
+ *    `spaceIdentity` DID distinct from the principal DID, and it is the space
+ *    `session.open` gated on, so an own-workspace `Space(...)` label resolves
+ *    rather than over-blocking. A principal a host names in the key holder's
+ *    place reaches that space through the membership lookup below.
  *
  * Broader cross-space membership comes from the §4.9.3 membership lookup: a
  * runtime-backed `SpaceMembershipProvider` reads each other space's declared
@@ -517,10 +519,14 @@ export function renderConfidentialityResolverFor(
   }
   const actingPrincipal = runtime.trustSnapshotProvider()?.actingPrincipal ??
     identity.did();
-  const memberSpaces = sessionSpace === undefined ||
-      sessionSpace === actingPrincipal
-    ? [actingPrincipal]
-    : [actingPrincipal, sessionSpace];
+  // `session.open` authorizes the key holder, so the workspace it gated on is
+  // a member for that principal's own renders. A host that names somebody else
+  // as acting has shown nothing about what that principal reads.
+  const ownSessionWorkspace = actingPrincipal === identity.did() &&
+    sessionSpace !== undefined && sessionSpace !== actingPrincipal;
+  const memberSpaces = ownSessionWorkspace
+    ? [actingPrincipal, sessionSpace]
+    : [actingPrincipal];
   return createRenderConfidentialityResolver({
     actingPrincipal,
     trustConfig: runtime.cfcTrustConfig,

--- a/packages/runtime-client/test/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/test/backends/runtime-processor.test.ts
@@ -122,7 +122,7 @@ class SharedV2StorageManager extends V2Storage.StorageManager {
   }
 }
 
-const createRuntime = () => {
+const createRuntime = (actingPrincipal?: string) => {
   const server = new MemoryV2Server.Server({
     authorizeSessionOpen(message) {
       const principal = (message.authorization as { principal?: unknown })
@@ -140,6 +140,12 @@ const createRuntime = () => {
   const runtime = new Runtime({
     apiUrl: new URL("http://localhost/"),
     storageManager,
+    ...(actingPrincipal === undefined ? {} : {
+      trustSnapshotProvider: () => ({
+        id: `principal:${actingPrincipal}`,
+        actingPrincipal,
+      }),
+    }),
   });
   return { runtime, storageManager };
 };
@@ -236,6 +242,50 @@ describe("runtime-processor", () => {
             ceiling,
           ),
         ).toEqual([cfcAtom.space("did:key:z6MkThird")]);
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("withholds the session workspace from a delegated principal", async () => {
+      // `session.open` gated on the workspace for the key holder. A host that
+      // names somebody else as acting has shown nothing about what that
+      // principal reads, so the workspace is left to the ACL lookup, which
+      // grants it nothing here.
+
+      const delegate = "did:key:z6MkDelegatedActingPrincipal";
+      const { runtime, storageManager } = createRuntime(delegate);
+      const sessionSpace = "did:key:z6MkSessionWorkspaceDistinct";
+      try {
+        const resolver = renderConfidentialityResolverFor(
+          runtime,
+          cfcSigner,
+          { atoms: [cfcAtom.user(delegate)] },
+          sessionSpace,
+        );
+        const ceiling = [cfcAtom.user(delegate)];
+        // The key holder's workspace stays blocked for the delegate.
+        expect(
+          atomsOutsideCeiling(
+            resolver!({ confidentiality: [cfcAtom.space(sessionSpace)] }),
+            ceiling,
+          ),
+        ).toEqual([cfcAtom.space(sessionSpace)]);
+        // So does the key holder's own identity space.
+        expect(
+          atomsOutsideCeiling(
+            resolver!({ confidentiality: [cfcAtom.space(cfcSigner.did())] }),
+            ceiling,
+          ),
+        ).toEqual([cfcAtom.space(cfcSigner.did())]);
+        // The delegate's own space still resolves.
+        expect(
+          atomsOutsideCeiling(
+            resolver!({ confidentiality: [cfcAtom.space(delegate)] }),
+            ceiling,
+          ),
+        ).toEqual([]);
       } finally {
         await runtime.dispose();
         await storageManager.close();


### PR DESCRIPTION
A runtime's display sinks gate against a confidentiality ceiling built for one identity: the audience a rendered value is allowed to reach. `createRuntimeClientOptions` built that ceiling from the session identity, so a host that supplied its own trust snapshot got a ceiling naming somebody other than the principal the runtime renders as.

A delegated host is where the two differ. The trust snapshot carries the `actingPrincipal` the runtime acts under, and the render boundary resolves against that, so a ceiling built from the session identity fails in both directions at once. A value labelled for the session identity is admitted to a surface the delegate is looking at, and a value labelled for the delegate — content the runtime could read precisely because it acts as them — is refused.

The acting principal is now resolved once, beside the trust snapshot it comes from, and both the ceiling and the snapshot synthesized for a host that supplied none read that one value. A snapshot that names nobody leaves the session identity acting, which is what the worker does with an absent acting principal.

A snapshot that names an acting principal which is not a DID is refused instead. Both halves of the system already read that field as a DID: the ceiling's entries are identity atoms over one, and the runner refuses such a snapshot downstream when it resolves an owner principal. Falling back to the session identity there would rebuild the very defect this fixes, quietly, with the host acting as one principal and rendering to another.

Three tests: a delegate distinct from the session identity, whose ceiling admits the delegate and not the session; the two ways a caller names nobody, which are different cases, since `trustSnapshot: null` asks for no snapshot at all while a snapshot may simply carry no acting principal; and a non-DID principal, which throws. The first two state `cfcRenderCeiling` rather than relying on a host default, because their subject is which principal the ceiling admits and not whether a host builds one.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6922?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

