### PR TITLE
test(agents-host): the deployment watcher observes without reading

### DIFF
--- a/docs/development/TESTING.md
+++ b/docs/development/TESTING.md
@@ -314,6 +314,36 @@ is a separate obligation, and
 [`COVERAGE.md`](COVERAGE.md#diagnostics-that-fire-on-wall-clock-time) carries
 it.
 
+### A test double over `editWithRetry` must not read as it observes
+
+`Runtime.editWithRetry` is the seam a test replaces when it wants to watch or
+delay one particular commit. It is also how much of what the runtime commits
+on a transaction of its own reaches storage: the compile cache's write-back,
+which the pattern manager keeps independent of whatever asked for the compile,
+and a `#now` wish's interval tick, among others. A double installed to watch
+one commit runs for those too.
+
+What that costs depends on what the double does. Reading a document inside a
+transaction joins that document's confidentiality label onto the transaction's
+flow join, and the join lands on every document that transaction writes. With
+`cfcFlowLabels: "persist"` the label is stamped on all of them durably, and
+section 8.12.2's ratchet does not take it back. Add
+`cfcEnforcementMode: "enforce-strict"` and the writer-fit check refuses the
+commit wherever the written document declares no ceiling covering the label,
+which the documents a compile-cache write-back writes do not. See
+[the enforcement matrix](../specs/cfc-enforcement-matrix.md) section 4 for the
+check.
+
+Forcing that row on refuses the write-back of the debug-view deployment's own
+compile. `writeBackCompileCache` rethrows the refusal, so the deployment
+promise rejects. A case waiting for a commit further along the deployment then
+waits forever, and the reason string names documents the case never mentions.
+
+So a double observes the transaction rather than reading through it. To ask
+whether the wrapped action wrote a particular document, walk the transaction's
+own write set with `getWriteDetails`, which adds nothing to the read set.
+`debug-view-deployment-lifecycle.test.ts` asks that way.
+
 ### Recording browser integration tests as video demos
 
 Selected `patterns` and `shell` browser integration tests can be recorded with

--- a/packages/connectors/agents/host/test/debug-view-deployment-lifecycle.test.ts
+++ b/packages/connectors/agents/host/test/debug-view-deployment-lifecycle.test.ts
@@ -10,7 +10,10 @@ import {
 } from "@commonfabric/agents-connector/fabric-graph";
 import { createSession } from "@commonfabric/identity";
 import { PiecesController } from "@commonfabric/piece/ops";
-import { Runtime } from "@commonfabric/runner";
+import {
+  type IExtendedStorageTransaction,
+  Runtime,
+} from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 
 import type { Cell } from "../../../../runner/src/builder/types.ts";
@@ -324,6 +327,22 @@ Deno.test("debug deployment rolls back an aborted registration", async () => {
       const originalStartPiece = manager.startPiece;
       const originalEditWithRetry = runtime.editWithRetry.bind(runtime);
       const originalStop = runtime.runner.stop.bind(runtime.runner);
+      // The registration carries the owner's `User` label, which a read of it
+      // inside a transaction joins onto everything that transaction writes.
+      // This wrapper adds nothing to the read set of what it observes.
+      const registrationLink = registration.getAsNormalizedFullLink();
+      const wroteRegistration = (
+        transaction: IExtendedStorageTransaction,
+      ): boolean => {
+        const writes = transaction.getWriteDetails?.(registrationLink.space);
+        if (writes === undefined) {
+          throw new Error("transaction does not report its write set");
+        }
+        for (const write of writes) {
+          if (write.address.id === registrationLink.id) return true;
+        }
+        return false;
+      };
       let candidatePiece: Cell<unknown> | undefined;
       let candidateWasStopped = false;
       let interceptRegistrationCommit = false;
@@ -342,18 +361,10 @@ Deno.test("debug deployment rolls back an aborted registration", async () => {
         if (interceptRegistrationCommit) commitCount++;
         let shouldIntercept = false;
         const result = await originalEditWithRetry((transaction) => {
-          const registrationBefore = transaction.readValueOrThrow(
-            registration.getAsNormalizedFullLink(),
-          );
           const result = action(transaction);
-          const registrationAfter = transaction.readValueOrThrow(
-            registration.getAsNormalizedFullLink(),
-          );
-          const registrationChanged = JSON.stringify(registrationBefore) !==
-            JSON.stringify(registrationAfter);
           shouldIntercept = interceptRegistrationCommit &&
             (options.interceptPrivateRegistration
-              ? registrationChanged
+              ? wroteRegistration(transaction)
               : commitCount === 1);
           if (shouldIntercept) {
             const originalCommit = transaction.commit.bind(transaction);


### PR DESCRIPTION
Under the strictest CFC dial row — the row #6619 defaults to — the case `debug deployment rolls back an aborted registration` did not pass. `deployAgentSessionsDebugView` rejected with a `CfcCommitRefusalError` naming two documents at path `/`, both over the acting identity's own `User` atom:

  writer-fit confidentiality misfit for of:fid1:... at / (canWrite,
  §8.12.4): {"subject":"did:key:...",
  "type":"https://commonfabric.org/cfc/atom/User"}

The rejection arrived before the registration commit the case intercepts, so the barrier the case waits on inside `abortRegistration` was never resolved, its `finally` never ran, and Deno reported a pending promise about forty seconds in. The pending promise was the visible symptom.

The two documents are per-import-edge documents belonging to the compile cache's write-back: the `{specifier, link}` pair for one import edge of a source document and the same edge of a compiled one, each split into a document of its own by `anchorValueAsEntity`. The parent cache documents are not refused, and their novelty at that position is the link into `imports`, which §4 of the enforcement matrix puts outside the writer-fit check; the children hold a value and are measured against their own ceiling, which is empty. Route 2 of §8.12.5 is not open to either. A compile-cache document is keyed on a module identity rather than on a node, so it is one of the stores §4 holds off the route, and `anchorValueAsEntity` records its marker for a child only when the parent is a store the runtime owns.

The `User` atom reaches that transaction from the case itself. To hold one particular commit open, the case replaces `runtime.editWithRetry`, and the replacement read the `agent-sessions-debug-registration` document before and after every action passing through it, comparing the two values to decide whether the action had changed the registration. Much of what the runtime commits on a transaction of its own goes through that same seam, the compile cache's write-back included, and the write-back is on its own transaction precisely so that it stays independent of whatever asked for the compile. The read put the owner's label into it, and the strict rung refused the commit. `writeBackCompileCache` logs `compile-cache-writeback-failed` and rethrows, so that log line and the deployment's rejection are one failure rather than two.

The watcher now takes its answer from the transaction's write set. `IExtendedStorageTransaction` declares `getWriteDetails`, which reports what the wrapped action staged and adds nothing to the read set. That is the question the interception meant to ask: the private-registration update writes the document with `setRawUntyped`, and the value comparison was standing in for that write. The method is optional on the interface, so a transaction that does not answer throws rather than reporting that nothing was written, which would hang the case on its barrier instead of failing it. The predicate sits behind the branch that consults it, since the mode that intercepts on the commit count never asks. Pointing it at an id nothing writes fails the case, so it is load-bearing rather than incidentally satisfied.

The same read also refused the debug view's `#now/60` wish tick, once per interval, and that refusal goes with it. The runner change that stops a refused tick from rearming is separate, and is what makes this failure report as a failure rather than hang.

Measured with the strict row forced on by setting
`RUNTIME_CFC_DIAL_DEFAULTS` and `presetCfcOptions` to it: the shard holding this case goes from five of six to six of six, and all five shards of the agent host's test package pass, ninety-six cases, with no writer-fit misfit in any of them. The package also passes at the shipped defaults.

Nothing in the runner changes, because the refusal does not look like a production shape. The write-back's transaction is its own and reads only the cache documents it is about to write, and the file's other five cases deploy the debug view under the strict row without trouble. Reaching for a route, a declared ceiling, or a narrower join on the deploying transaction would each have paid for a label that had no business being there.

`docs/development/TESTING.md` carries the finding, because this is the second test to meet it through the same wrapper. It records the cost that lands one rung earlier as well: at `cfcFlowLabels: "persist"` without `enforce-strict` the label is not refused, it is stamped on every document the transaction writes, and §8.12.2's ratchet does not take it back.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6923?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

