### PR TITLE
fix(cli): a multi-user test's enforcement mode reaches its workers

### DIFF
--- a/packages/cli/lib/multi-user-test-runner.ts
+++ b/packages/cli/lib/multi-user-test-runner.ts
@@ -46,6 +46,7 @@
  * after a marker is therefore read once, and a false value is a failure.
  */
 
+import type { CfcEnforcementMode } from "@commonfabric/runner/cfc";
 import { Identity, realmValueFromKeyPair } from "@commonfabric/identity";
 import { StandaloneMemoryServer } from "@commonfabric/memory/v2/standalone";
 import type {
@@ -195,11 +196,45 @@ interface ParticipantState {
   allowConsoleWarnings: boolean;
 }
 
+/**
+ * Check one participant against the rung the run named.
+ *
+ * A participant builds its own runtime in its own worker, so the mode a run
+ * names is honored in as many places as there are participants. The rung read
+ * back off each built runtime is checked here, and the participant that is not
+ * on it is named. A run that names no mode leaves every participant to its
+ * preset.
+ */
+export function assertParticipantRung(
+  participant: string,
+  named: CfcEnforcementMode | undefined,
+  reached: CfcEnforcementMode,
+): void {
+  if (named !== undefined && reached !== named) {
+    throw new Error(
+      `participant "${participant}" came up at CFC ${reached}, not the ` +
+        `${named} this run names`,
+    );
+  }
+}
+
 export async function runMultiUserTestPattern(
   testPath: string,
   meta: MultiUserDescriptorMeta,
   options: TestRunnerOptions = {},
 ): Promise<TestRunResult> {
+  // A caller supplying a store means to read what the run wrote, and to be
+  // told what it instantiated (see `TestRunnerOptions.storageHost`). The
+  // participants do both in workers of their own, against a storage server
+  // this function starts, so the caller's store and observer come back empty
+  // while the participants' assertions pass.
+  if (options.storageHost !== undefined) {
+    throw new Error(
+      `${testPath} is a multi-user test: its participants run in workers of ` +
+        `their own, against a storage server this runner starts, so a ` +
+        `caller-supplied \`storageHost\` would be handed back unwritten`,
+    );
+  }
   const startTime = performance.now();
   const stepTimeout = options.timeout ?? 5000;
   const results: TestResult[] = [];
@@ -245,7 +280,15 @@ export async function runMultiUserTestPattern(
           participant: spec.name,
           participants: meta.participants.map((p) => p.name),
           seedDefaults: index === 0,
+          // A test that names a mode names it for every participant, the way
+          // the single-user runner honors it.
+          cfcEnforcementMode: options.cfcEnforcementMode,
         }) as ParticipantInitResult;
+        assertParticipantRung(
+          spec.name,
+          options.cfcEnforcementMode,
+          init.cfcEnforcementMode,
+        );
         participants.push({
           spec,
           worker,

--- a/packages/cli/lib/multi-user-test-worker.ts
+++ b/packages/cli/lib/multi-user-test-worker.ts
@@ -29,6 +29,11 @@
 
 import type { RealmEncodedValue } from "@commonfabric/data-model/codec-realm";
 import {
+  CFC_ENFORCEMENT_MODES,
+  type CfcEnforcementMode,
+  isCfcEnforcementMode,
+} from "@commonfabric/runner/cfc";
+import {
   createSession,
   Identity,
   keyPairFromRealmValue,
@@ -96,6 +101,13 @@ export interface ParticipantInitResult {
   expectNonIdempotent: boolean;
   allowConsoleErrors: boolean;
   allowConsoleWarnings: boolean;
+
+  /**
+   * The CFC enforcement mode this participant's runtime resolved to, read off
+   * the runtime itself. The orchestrator checks it against the mode the run
+   * named, so a participant that came up on another rung says so.
+   */
+  cfcEnforcementMode: CfcEnforcementMode;
 }
 
 const SETUP_CAUSE = "multi-user-test-setup";
@@ -270,6 +282,27 @@ function classifyStep(stepCell: Cell<unknown>, index: number): StepMeta {
   );
 }
 
+/**
+ * The CFC enforcement mode an `init` request names, if it names one.
+ *
+ * The request crosses a worker boundary as plain data, so the name arrives
+ * untyped. A name off the ladder is reported here rather than installed: the
+ * ladder is a closed set, and a runtime holding a mode outside it is on no
+ * rung.
+ */
+function requestedEnforcementMode(
+  input: unknown,
+): CfcEnforcementMode | undefined {
+  if (input === undefined) return undefined;
+  if (!isCfcEnforcementMode(input)) {
+    throw new Error(
+      `Initialization \`cfcEnforcementMode\` is ${String(input)}, not one ` +
+        `of ${CFC_ENFORCEMENT_MODES.join(", ")}`,
+    );
+  }
+  return input;
+}
+
 const handlers: Record<
   string,
   (args: Record<string, unknown>) => Promise<unknown>
@@ -279,6 +312,7 @@ const handlers: Record<
    * participant pattern, and return the classified step list.
    */
   async init(args) {
+    const requestedMode = requestedEnforcementMode(args.cfcEnforcementMode);
     const identity = await Identity.fromKeyPair(
       keyPairFromRealmValue(
         args.identity as RealmEncodedValue,
@@ -314,6 +348,9 @@ const handlers: Record<
       experimental: experimentalOptionsFromEnv(Deno.env.get),
       errorHandlers: [(error: Error) => runtimeErrors.push(String(error))],
       moduleByteCache: getDefaultModuleByteCache(),
+      ...(requestedMode !== undefined
+        ? { cfcEnforcementMode: requestedMode }
+        : {}),
     }));
     runtime.enableIdempotencyCheck();
     // Channel 1: capture pattern-code console.error / console.warn calls.
@@ -487,6 +524,7 @@ const handlers: Record<
       allowConsoleWarnings:
         await (resultCell.key("allowConsoleWarnings") as Cell<unknown>)
           .pull() === true,
+      cfcEnforcementMode: rt().cfcEnforcementMode,
     };
     return result;
   },

--- a/packages/cli/lib/test-runner.ts
+++ b/packages/cli/lib/test-runner.ts
@@ -421,6 +421,10 @@ export interface TestRunnerOptions {
    * run reached: the runtime that wrote it can no longer commit into it. A
    * teardown that does not complete is RAISED, so a caller never reads a store
    * whose writer never stopped.
+   *
+   * A multi-user test refuses this option: its participants instantiate and
+   * write in workers of their own, against a storage server the multi-user
+   * runner starts, so neither the store nor the observer below would see them.
    */
   storageHost?: {
     identity: Identity;

--- a/packages/cli/test/multi-user-test-runner.test.ts
+++ b/packages/cli/test/multi-user-test-runner.test.ts
@@ -15,6 +15,11 @@
  * propagation gap itself is too small to observe in a fixture this size — the
  * barrier's discriminating coverage is the pattern-test corpus, where removing
  * it fails seven assertions across `topics`, `lobby`, and `cfc-group-chat-demo`.
+ *
+ * Also here: the CFC enforcement mode a run names reaches every participant.
+ * Each participant builds its own runtime in its own worker, so a mode the
+ * orchestrator holds and does not forward leaves every one of them on the
+ * preset's rung while the run reads as though it named one.
  */
 
 import { describe, it } from "@std/testing/bdd";
@@ -22,8 +27,12 @@ import { expect } from "@std/expect";
 import { resolve } from "@std/path";
 import { Identity, realmValueFromKeyPair } from "@commonfabric/identity";
 import { StandaloneMemoryServer } from "@commonfabric/memory/v2/standalone";
-import { runTests } from "../lib/test-runner.ts";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { CFC_ENFORCEMENT_MODES } from "@commonfabric/runner/cfc";
+import { runTestPattern, runTests } from "../lib/test-runner.ts";
+import { assertParticipantRung } from "../lib/multi-user-test-runner.ts";
 import type {
+  ParticipantInitResult,
   WorkerRequest,
   WorkerResponse,
 } from "../lib/multi-user-test-worker.ts";
@@ -213,6 +222,123 @@ describe(
       } finally {
         for (const client of workers.values()) await client.close();
         await server.close().catch(() => {});
+      }
+    });
+
+    /** One participant's `init`, driven directly so its answer is readable. */
+    async function initParticipant(
+      server: StandaloneMemoryServer,
+      args: Record<string, unknown>,
+    ): Promise<ParticipantInitResult> {
+      const client = new ParticipantWorkerClient("alice");
+      try {
+        const identity = await Identity.fromPassphrase("test-runner alice", {
+          implementation: "noble",
+        });
+        return await client.call("init", {
+          identity: realmValueFromKeyPair(identity.keyPair),
+          spaceName: crypto.randomUUID(),
+          apiUrl: server.url.href,
+          testPath: fixture("marker-barrier.test.tsx"),
+          root: FIXTURES,
+          participant: "alice",
+          participants: ["alice"],
+          seedDefaults: true,
+          ...args,
+        }) as ParticipantInitResult;
+      } finally {
+        await client.close();
+      }
+    }
+
+    it("runs every participant at the mode the run names", async () => {
+      // The rung is checked against what each participant's own runtime
+      // answers with, so a mode that reached the orchestrator alone — or
+      // reached one worker and not the next — is named rather than run past.
+
+      const { failed, results } = await runTests(
+        fixture("marker-barrier.test.tsx"),
+        { root: FIXTURES, cfcEnforcementMode: "observe" },
+      );
+      expect(results[0].error).toBeUndefined();
+      expect(failed).toBe(0);
+    });
+
+    it("names the participant that came up on another rung", () => {
+      // The check's own report. A worker cannot be made to disagree with the
+      // orchestrator from out here, so the message is read from the check
+      // rather than from a run that provoked it.
+
+      expect(() =>
+        assertParticipantRung("alice", "observe", "enforce-explicit")
+      ).toThrow(
+        'participant "alice" came up at CFC enforce-explicit, not the ' +
+          "observe this run names",
+      );
+      expect(() => assertParticipantRung("alice", "observe", "observe"))
+        .not.toThrow();
+      expect(() => assertParticipantRung("alice", undefined, "enforce-strict"))
+        .not.toThrow();
+    });
+
+    it("builds a participant's runtime at each rung init names", async () => {
+      // Every rung, not just a relaxed one: a worker that answered `disabled`
+      // whatever it was asked would satisfy a single-rung reading, and
+      // `disabled` is the rung that turns CFC off altogether.
+
+      const server = StandaloneMemoryServer.start();
+      try {
+        for (const rung of CFC_ENFORCEMENT_MODES) {
+          const init = await initParticipant(server, {
+            cfcEnforcementMode: rung,
+          });
+          expect(init.cfcEnforcementMode).toBe(rung);
+        }
+        // Naming none leaves the preset to decide, which is what makes the
+        // readings above statements about the request. The rung named here is
+        // `runtimePresets.patternTest`'s pin, so a move there lands as a
+        // failure in this test rather than as a quietly different harness.
+        expect((await initParticipant(server, {})).cfcEnforcementMode)
+          .toBe("enforce-explicit");
+      } finally {
+        await server.close().catch(() => {});
+      }
+    });
+
+    it("reports a mode that is not on the ladder, naming it", async () => {
+      // The name is read before anything else `init` is given, so this needs
+      // no space, no server and no test file.
+
+      const client = new ParticipantWorkerClient("alice");
+      try {
+        await expect(
+          client.call("init", { cfcEnforcementMode: "enforce-ish" }),
+        ).rejects.toThrow(
+          "`cfcEnforcementMode` is enforce-ish, not one of ",
+        );
+      } finally {
+        await client.close();
+      }
+    });
+
+    it("reports a caller-supplied store on a multi-user test", async () => {
+      // The participants instantiate and write in workers of their own, so
+      // the caller's store and observer come back empty while their
+      // assertions pass. Saying so is what keeps the vintage capture from
+      // reading the same run as a pattern that instantiated nothing.
+
+      const identity = await Identity.fromPassphrase("multi-user storage host");
+      const storageManager = StorageManager.emulate({ as: identity });
+      try {
+        const result = await runTestPattern(
+          fixture("marker-barrier.test.tsx"),
+          { root: FIXTURES, storageHost: { identity, storageManager } },
+        );
+        expect(result.error).toContain("is a multi-user test");
+        expect(result.error).toContain("`storageHost`");
+        expect(result.results).toEqual([]);
+      } finally {
+        await storageManager.close();
       }
     });
 

--- a/tasks/pattern-vintage-run.test.ts
+++ b/tasks/pattern-vintage-run.test.ts
@@ -1740,6 +1740,40 @@ describe("the vintage gate, end to end", () => {
       expect(await collectVintages(roots.vintagesRoot)).toEqual([]);
     });
 
+    it("refuses a multi-user test, saying the run did not complete", async () => {
+      // A multi-user test's participants instantiate and write in workers of
+      // their own, against a storage server the runner starts, so this
+      // capture's store and observer would see nothing. The runner refuses the
+      // store rather than handing one back unwritten, and a refusal is a run
+      // that did not complete rather than a pattern whose tests failed.
+
+      await setSubjectTest(
+        [
+          "import { assert, multiUserTest, pattern, TESTS } from 'commonfabric';",
+          `import Subject from './${KEY}';`,
+          "export const setup = pattern(() => ({ subject: Subject({}) }));",
+          "export const alice = pattern(() => ({",
+          "  [TESTS]: [{ assertion: assert(() => true) }],",
+          "}));",
+          "export default multiUserTest({ setup, participants: { alice } });",
+          "",
+        ].join("\n"),
+      );
+
+      const { captured, problems } = await captureMissing(
+        roots,
+        [TEST_KEY],
+        new Date("2026-07-29T12:00:00.000Z"),
+      );
+
+      expect(captured).toEqual([]);
+      expect(problems).toHaveLength(1);
+      expect(problems[0]).toContain("the run did not complete");
+      expect(problems[0]).toContain("is a multi-user test");
+      expect(problems[0]).not.toContain("its own tests did not pass");
+      expect(await collectVintages(roots.vintagesRoot)).toEqual([]);
+    });
+
     it("refuses a test that asserts nothing", async () => {
       // A run with no assertions cannot have driven the pattern anywhere, so the
       // fixture would hold a bare materialized root — which is the shape that

--- a/tasks/pattern-vintage-run.ts
+++ b/tasks/pattern-vintage-run.ts
@@ -1155,15 +1155,23 @@ export async function captureVintage(
         },
       },
     });
+    // A run that did not complete reached no state to pin, and its cause is
+    // its own — a file the runner refused to run this way says so, and reading
+    // that as a test failure would blame the pattern for it.
+    if (result.error !== undefined) {
+      throw new Error(
+        `cannot capture ${testKey}: the run did not complete, so it reached ` +
+          `no state to record: ${result.error}`,
+      );
+    }
     // A failed test run would record a state the pattern never legitimately
     // reaches, so refuse rather than pin it.
     const failed = result.results.filter((r) => !r.passed && !r.skipped);
-    if (result.error !== undefined || failed.length > 0) {
+    if (failed.length > 0) {
       throw new Error(
         `cannot capture ${testKey}: its own tests did not pass, so the ` +
           `fixture would record a state the pattern never reaches: ${
-            result.error ??
-              failed.map((r) => `${r.name}: ${r.error}`).join("; ")
+            failed.map((r) => `${r.name}: ${r.error}`).join("; ")
           }`,
       );
     }


### PR DESCRIPTION
`TestRunnerOptions.cfcEnforcementMode` lets one test run at a rung of its own. The single-user runner honors it. The multi-user runner did not: each participant runs in its own worker, the worker built its runtime from the fields the `init` request carried, and that request never carried the mode. A multi-user test naming a mode got it in the parent and nowhere else, silently, with every participant on whatever the preset supplied. Nothing sets the option today, so this was a trap for its first caller rather than a failure anyone had hit.

The runner now forwards the option over `init`, and the worker states it when the request carries one, otherwise leaving the preset to decide as before.

Forwarding alone would be a claim nobody checks, so `init` answers with the rung the participant's runtime resolved to, read off the runtime, and the orchestrator checks that against the mode the run named. A participant on another rung is named, with both rungs, rather than run past. That is what makes the fix hold for every participant instead of for whichever one a test happened to look at: mis-plumbing that mapped every named mode onto `disabled` — CFC off altogether — is a reported failure rather than a green run.

The name arrives untyped, having crossed a worker boundary as plain data, so the worker reads it back through `isCfcEnforcementMode` instead of casting. The ladder is a closed set and a runtime holding a name outside it is on no rung: `cfcEnforcementStrictness` returns nothing for one, so every floor comparison reads false, while the commit gates test the mode only against `disabled` and `observe` and so take it for enforcing.

The same trap sits one field over. A caller passing `storageHost` means to read what the run wrote and to be told what it instantiated. A multi-user test does both in workers of its own, against a storage server the runner starts, so the caller's store and observer come back empty while the participants' assertions pass. The multi-user runner now refuses the option. The pattern-vintage capture read that same run as a pattern that instantiated nothing upgradable; it now separates a run that did not complete from a run whose tests failed, so a refusal is not reported as the pattern's fault.

Left alone: `moduleByteCache` is also dropped on this path, and should be. It is a compile cache, so the worker's own is not a different answer, and refusing it would fail a directory run that shares one cache across files.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6926?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

