### PR TITLE
refactor(html): `WorkerReconciler` keeps its root policy and atom admission in `#` members behind `accessForTestingOnly`

### DIFF
--- a/packages/html/src/worker/reconciler.ts
+++ b/packages/html/src/worker/reconciler.ts
@@ -213,11 +213,8 @@ export class WorkerReconciler {
 
   // Root-of-tree render policy: the host's default ceiling when configured
   // (spec §8.10.6), otherwise the historical unbounded policy. Authored
-  // boundaries can only narrow from here. TypeScript-private rather than a `#`
-  // name, because `runtime-client/test/backends/runtime-processor.test.ts`
-  // reaches it across the package boundary, through the reconciler a mount
-  // holds.
-  private readonly rootRenderPolicy: RenderPolicy;
+  // boundaries can only narrow from here.
+  readonly #rootRenderPolicy: RenderPolicy;
   // Runner-side display-boundary resolver (Epic H3b): rewrites a cell's
   // confidentiality label through the exchange rules before the ceiling fit,
   // admitting `Space(...)`-via-`HasRole` principal forms. Undefined = H3a
@@ -243,10 +240,37 @@ export class WorkerReconciler {
     const ceiling = normalizeRenderConfidentialityCeiling(
       options.renderConfidentialityCeiling,
     );
-    this.rootRenderPolicy = ceiling === undefined ? DEFAULT_RENDER_POLICY : {
+    this.#rootRenderPolicy = ceiling === undefined ? DEFAULT_RENDER_POLICY : {
       declassifyConfidentiality: [],
       maxConfidentiality: [...(ceiling.atoms ?? [])],
       caveatKindAllow: [...(ceiling.caveatKinds ?? [])],
+    };
+  }
+
+  /**
+   * The root render policy and the two admission checks, which a test
+   * drives directly.
+   */
+  get accessForTestingOnly(): {
+    readonly rootRenderPolicy: RenderPolicy;
+    atomRenderableUnderPolicy(atom: unknown, policy: RenderPolicy): boolean;
+    canRenderCellUnderPolicy(
+      cell: Cell<unknown>,
+      policy: RenderPolicy,
+    ): boolean;
+  } {
+    return {
+      rootRenderPolicy: this.#rootRenderPolicy,
+      atomRenderableUnderPolicy: (atom, policy) =>
+        this.#atomRenderableUnderPolicy(atom, policy),
+      // Forwards to the TypeScript-private member so that a test which
+      // replaces it by assignment is honored here too.
+      // TODO(danfuzz): Find a way to make `canRenderCellUnderPolicy()` a `#`
+      // method, which needs `test/worker-reconciler-cell-child.test.ts` to stop
+      // replacing it by assignment: a seam this class offers, or a test written
+      // against the public behavior.
+      canRenderCellUnderPolicy: (cell, policy) =>
+        this.canRenderCellUnderPolicy(cell, policy),
     };
   }
 
@@ -335,14 +359,14 @@ export class WorkerReconciler {
         if (
           !this.canRenderCellUnderPolicy(
             vnode as Cell<unknown>,
-            this.rootRenderPolicy,
+            this.#rootRenderPolicy,
           )
         ) {
           this.#reconcileIntoWrapper(
             ctx,
             wrapperState,
             this.#blockedPlaceholderVNode(),
-            this.rootRenderPolicy,
+            this.#rootRenderPolicy,
           );
           this.#rootChildId = wrapperState.currentChild?.nodeId ?? null;
           return;
@@ -360,7 +384,7 @@ export class WorkerReconciler {
           ctx,
           wrapperState,
           resolvedVnode as WorkerRenderNode,
-          this.rootRenderPolicy,
+          this.#rootRenderPolicy,
         );
         // Track the root child for cleanup
         this.#rootChildId = wrapperState.currentChild?.nodeId ?? null;
@@ -375,7 +399,7 @@ export class WorkerReconciler {
         ctx,
         vnode,
         new Set(),
-        this.rootRenderPolicy,
+        this.#rootRenderPolicy,
       );
       if (state) {
         addCancel(state.cancel);
@@ -1118,9 +1142,9 @@ export class WorkerReconciler {
   }
 
   /**
-   * TypeScript-private rather than a `#` name:
-   * `test/worker-reconciler-cfc-atom-admission.test.ts` drives this member
-   * directly.
+   * TypeScript-private rather than a `#` name, because
+   * `test/worker-reconciler-cell-child.test.ts` replaces this member by
+   * assignment, which a `#` method does not allow.
    */
   private canRenderCellUnderPolicy(
     cell: Cell<unknown>,
@@ -1159,7 +1183,7 @@ export class WorkerReconciler {
         return true;
       }
       return schemaLabels.every((atom) =>
-        this.atomRenderableUnderPolicy(atom, policy)
+        this.#atomRenderableUnderPolicy(atom, policy)
       );
     }
 
@@ -1172,7 +1196,7 @@ export class WorkerReconciler {
       );
     }
     for (const atom of confidentiality) {
-      if (!this.atomRenderableUnderPolicy(atom, policy)) {
+      if (!this.#atomRenderableUnderPolicy(atom, policy)) {
         return false;
       }
     }
@@ -1238,12 +1262,8 @@ export class WorkerReconciler {
    * neither author declassification nor a ceiling entry — even one naming
    * the exported marker string — may admit it. Every other atom checks
    * declassification first, then the ceiling.
-   *
-   * TypeScript-private rather than a `#` name:
-   * `test/worker-reconciler-cfc-atom-admission.test.ts` drives this member
-   * directly.
    */
-  private atomRenderableUnderPolicy(
+  #atomRenderableUnderPolicy(
     atom: unknown,
     policy: RenderPolicy,
   ): boolean {

--- a/packages/html/test/worker-reconciler-cfc-atom-admission.test.ts
+++ b/packages/html/test/worker-reconciler-cfc-atom-admission.test.ts
@@ -18,15 +18,9 @@ import type { RenderPolicy } from "../src/worker/types.ts";
 // fallthrough, all-atoms-admitted loop exit) cover nondeterministically across
 // runs. Calling the admission methods directly pins them to a fixed path.
 
-// Private admission methods on WorkerReconciler, reached through a typed cast
-// rather than `any` so the call sites still type-check.
-type ReconcilerAdmission = {
-  canRenderCellUnderPolicy(cell: unknown, policy: RenderPolicy): boolean;
-  atomRenderableUnderPolicy(atom: unknown, policy: RenderPolicy): boolean;
-};
-
-function admissionSeam(reconciler: WorkerReconciler): ReconcilerAdmission {
-  return reconciler as unknown as ReconcilerAdmission;
+// The admission checks, reached through the reconciler's accessor.
+function admissionSeam(reconciler: WorkerReconciler) {
+  return reconciler.accessForTestingOnly;
 }
 
 Deno.test("worker reconciler CFC atom admission", async (t) => {

--- a/packages/runtime-client/test/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/test/backends/runtime-processor.test.ts
@@ -13,6 +13,7 @@ import {
   realmFromFabricValue,
 } from "@commonfabric/data-model/codecs";
 import { FabricError } from "@commonfabric/data-model/fabric-instances";
+import type { WorkerReconciler } from "@commonfabric/html/worker";
 import {
   FabricBytes,
   FabricEpochNsec,
@@ -5327,8 +5328,8 @@ describe("runtime-processor", () => {
         });
         const mount = state.vdomMounts.get("0 1");
         expect(mount).toBeDefined();
-        const policy = (mount!.reconciler as { rootRenderPolicy?: unknown })
-          .rootRenderPolicy as RootRenderPolicy;
+        const policy = (mount!.reconciler as WorkerReconciler)
+          .accessForTestingOnly.rootRenderPolicy;
         handleVDomUnmount.call(state, {
           type: RequestType.VDomUnmount,
           mountId: 1,

--- a/packages/runtime-client/test/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/test/backends/runtime-processor.test.ts
@@ -5279,10 +5279,8 @@ describe("runtime-processor", () => {
     const handleVDomUnmount =
       (RuntimeProcessor.prototype as any).handleVDomUnmount;
 
-    type RootRenderPolicy = {
-      maxConfidentiality?: readonly unknown[];
-      caveatKindAllow?: readonly string[];
-    };
+    type RootRenderPolicy =
+      WorkerReconciler["accessForTestingOnly"]["rootRenderPolicy"];
 
     async function mountAndGetRootPolicy(
       renderConfidentialityCeiling:


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Fable 5.1)

The root render policy and the per-atom admission check in
`WorkerReconciler` were TypeScript `private`, each with a note naming the
test that reaches it. They are `#` names now, behind an
`accessForTestingOnly` getter, as `docs/development/DEVELOPMENT.md`
§ Classes prescribes.

## Shape of the accessor

The policy is a `readonly` plain property, since the class assigns it once
in the constructor and never again; the atom check is a forwarding arrow.
No object-literal getter, so no `outerThis` alias.

## The member that stays `private`

`canRenderCellUnderPolicy()` is replaced by assignment in
`test/worker-reconciler-cell-child.test.ts`, which a `#` method does not
allow, so it keeps the TypeScript modifier and its note says so. The
accessor forwards to it anyway, so the admission test is typed like the
rest, with a `TODO(danfuzz)` naming what it would take to make it a `#`
method.

## What the tests do now

The admission test's `admissionSeam()` returns the accessor instead of a
cast, and its hand-written admission type is gone. The `runtime-client`
test that reads the root policy across the package boundary now does so
under the reconciler's own type, through a type import from
`@commonfabric/html/worker`.

## Review

Reviewed by a `cf-review` pass: approve, no findings above nit. The nit
is applied: the `runtime-client` test names the root policy's type off the
accessor rather than by a hand-written copy.

## Gates

`deno fmt --check`, `deno lint`, `deno task check`, the `html` suite
(26 passed, 0 failed), and the `runtime-client` suite (27 passed,
0 failed). Of the six packages importing `html`, `runtime-client` is the
one whose tests name a converted member.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6927?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


