### PR TITLE
refactor(iframe-sandbox): the sandbox element keeps its frame and its ready step in `#` members behind `accessForTestingOnly`

### DIFF
--- a/packages/iframe-sandbox/src/common-iframe-sandbox.ts
+++ b/packages/iframe-sandbox/src/common-iframe-sandbox.ts
@@ -37,6 +37,29 @@ export class CommonIframeSandboxElement extends LitElement {
     this.requestUpdate("bridge", previousValue);
   }
 
+  /**
+   * The frame, the window whose readiness was last acted on, and the
+   * outer-ready step, which a test drives directly: it asserts the
+   * outer-ready refusal where the refusal is made, since a frame reports
+   * itself ready exactly once, from a window nothing outside this element
+   * can speak for.
+   */
+  get accessForTestingOnly(): {
+    readonly iframeRef: Ref<HTMLIFrameElement>;
+    readonly readyWindow: Window | undefined;
+    onOuterReady(source: Window): void;
+  } {
+    // deno-lint-ignore no-this-alias
+    const outerThis = this;
+    return {
+      iframeRef: this.#iframeRef,
+      get readyWindow() {
+        return outerThis.#readyWindow;
+      },
+      onOuterReady: (source) => this.#onOuterReady(source),
+    };
+  }
+
   @property({ attribute: "load-state", reflect: true })
   accessor loadState: CommonIframeLoadState = "";
 
@@ -58,13 +81,9 @@ export class CommonIframeSandboxElement extends LitElement {
 
   /**
    * The frame this element renders, held so the guest can be reached through
-   * it. TypeScript-private rather than `#`, as `readyWindow` and
-   * `onOuterReady` also are, because `test/iframe.browser.test.ts` reaches for
-   * all three: it asserts the outer-ready refusal where the refusal is made,
-   * and a frame reports itself ready exactly once, from a window nothing
-   * outside this element can speak for.
+   * it.
    */
-  private iframeRef: Ref<HTMLIFrameElement> = createRef();
+  readonly #iframeRef: Ref<HTMLIFrameElement> = createRef();
 
   /**
    * The outer-frame window whose `ready` this element last acted on, once one
@@ -72,7 +91,7 @@ export class CommonIframeSandboxElement extends LitElement {
    * one already in hand: detaching the element discards the frame's browsing
    * context, so the frame reattaching brings is a different window.
    */
-  private readyWindow: Window | undefined;
+  #readyWindow: Window | undefined;
 
   /**
    * Handles the outer frame reporting itself ready, which it does on its own
@@ -92,11 +111,11 @@ export class CommonIframeSandboxElement extends LitElement {
    * from the same window is this element's model of the frame's lifetime being
    * wrong rather than a frame having been replaced.
    */
-  private onOuterReady(source: Window) {
-    if (source === this.readyWindow) {
+  #onOuterReady(source: Window) {
+    if (source === this.#readyWindow) {
       throw new Error(`common-iframe-sandbox: Already initialized.`);
     }
-    this.readyWindow = source;
+    this.#readyWindow = source;
     this.#releaseGuest();
     if (this.src) {
       this.#loadInnerDoc();
@@ -116,7 +135,7 @@ export class CommonIframeSandboxElement extends LitElement {
     // The guest is the inner frame, which is a frame of the outer one. A
     // cross-origin frame is unreachable for anything but this: indexed access
     // and `postMessage`, which is what a transfer rides.
-    const guestWindow = this.iframeRef.value?.contentWindow?.frames[0];
+    const guestWindow = this.#iframeRef.value?.contentWindow?.frames[0];
     if (!guestWindow) {
       console.error("common-iframe-sandbox: No guest frame to open a port to.");
       return;
@@ -136,7 +155,7 @@ export class CommonIframeSandboxElement extends LitElement {
 
   /** Handles a message from the outer frame. */
   #onMessage = (event: MessageEvent) => {
-    if (event.source !== this.iframeRef.value?.contentWindow) {
+    if (event.source !== this.#iframeRef.value?.contentWindow) {
       return;
     }
 
@@ -189,7 +208,7 @@ export class CommonIframeSandboxElement extends LitElement {
         return;
       }
       case IPC.IPCGuestMessageType.Ready: {
-        this.onOuterReady(event.source as Window);
+        this.#onOuterReady(event.source as Window);
         return;
       }
     }
@@ -248,7 +267,7 @@ export class CommonIframeSandboxElement extends LitElement {
 
   /** Sends `message` to the outer frame. */
   #toOuterFrame(message: IPC.IPCHostMessage) {
-    this.iframeRef.value?.contentWindow?.postMessage(message, "*");
+    this.#iframeRef.value?.contentWindow?.postMessage(message, "*");
   }
 
   /** The outer frame's message listener, as `globalThis` holds it. */
@@ -278,7 +297,7 @@ export class CommonIframeSandboxElement extends LitElement {
    */
   protected override updated(changed: PropertyValues) {
     super.updated(changed);
-    if (!this.readyWindow) return;
+    if (!this.#readyWindow) return;
     if (changed.has("src") || (changed.has("bridge") && this.src)) {
       this.#loadInnerDoc();
     }
@@ -288,7 +307,7 @@ export class CommonIframeSandboxElement extends LitElement {
   override render() {
     return html`
       <iframe
-        ${ref(this.iframeRef)}
+        ${ref(this.#iframeRef)}
         allow="clipboard-write"
         sandbox="allow-scripts allow-pointer-lock allow-popups allow-popups-to-escape-sandbox"
         .srcdoc="${OuterFrame}"

--- a/packages/iframe-sandbox/src/common-iframe-sandbox.ts
+++ b/packages/iframe-sandbox/src/common-iframe-sandbox.ts
@@ -37,29 +37,6 @@ export class CommonIframeSandboxElement extends LitElement {
     this.requestUpdate("bridge", previousValue);
   }
 
-  /**
-   * The frame, the window whose readiness was last acted on, and the
-   * outer-ready step, which a test drives directly: it asserts the
-   * outer-ready refusal where the refusal is made, since a frame reports
-   * itself ready exactly once, from a window nothing outside this element
-   * can speak for.
-   */
-  get accessForTestingOnly(): {
-    readonly iframeRef: Ref<HTMLIFrameElement>;
-    readonly readyWindow: Window | undefined;
-    onOuterReady(source: Window): void;
-  } {
-    // deno-lint-ignore no-this-alias
-    const outerThis = this;
-    return {
-      iframeRef: this.#iframeRef,
-      get readyWindow() {
-        return outerThis.#readyWindow;
-      },
-      onOuterReady: (source) => this.#onOuterReady(source),
-    };
-  }
-
   @property({ attribute: "load-state", reflect: true })
   accessor loadState: CommonIframeLoadState = "";
 
@@ -92,6 +69,29 @@ export class CommonIframeSandboxElement extends LitElement {
    * context, so the frame reattaching brings is a different window.
    */
   #readyWindow: Window | undefined;
+
+  /**
+   * The frame, the window whose readiness was last acted on, and the
+   * outer-ready step, which a test drives directly: it asserts the
+   * outer-ready refusal where the refusal is made, since a frame reports
+   * itself ready exactly once, from a window nothing outside this element
+   * can speak for.
+   */
+  get accessForTestingOnly(): {
+    readonly iframeRef: Ref<HTMLIFrameElement>;
+    readonly readyWindow: Window | undefined;
+    onOuterReady(source: Window): void;
+  } {
+    // deno-lint-ignore no-this-alias
+    const outerThis = this;
+    return {
+      iframeRef: this.#iframeRef,
+      get readyWindow() {
+        return outerThis.#readyWindow;
+      },
+      onOuterReady: (source) => this.#onOuterReady(source),
+    };
+  }
 
   /**
    * Handles the outer frame reporting itself ready, which it does on its own
@@ -290,7 +290,7 @@ export class CommonIframeSandboxElement extends LitElement {
 
   /**
    * Reloads on a change to `src` or `bridge`, once the frame is ready; until
-   * then `onOuterReady` does the first load. Reacting here rather than in the
+   * then `#onOuterReady` does the first load. Reacting here rather than in the
    * setters folds a batch of changes into one load: assigning both properties
    * asks for one document, carrying both new values, rather than reloading
    * the old document under the new bridge on the way.

--- a/packages/iframe-sandbox/test/iframe.browser.test.ts
+++ b/packages/iframe-sandbox/test/iframe.browser.test.ts
@@ -501,11 +501,7 @@ ${GUEST_EPILOG}`;
     // ready once and nothing outside it can send that message: the element
     // takes it only from the window it rendered. So the refusal is asserted
     // where it is made.
-    const inner = iframe as unknown as {
-      iframeRef: { value?: HTMLIFrameElement };
-      onOuterReady: (source: Window) => void;
-      readyWindow?: Window;
-    };
+    const inner = iframe.accessForTestingOnly;
     const reporting = inner.iframeRef.value!.contentWindow!;
     assertEquals(inner.readyWindow, reporting);
 
@@ -549,9 +545,7 @@ ${GUEST_EPILOG}`;
     // a successor shows activity -- so a guest refusing the extra offer keeps
     // the session it has, subscriptions included. The repeat is synthesized,
     // as the real one turns on navigation timing inside the frame.
-    const inner = iframe as unknown as {
-      iframeRef: { value?: HTMLIFrameElement };
-    };
+    const inner = iframe.accessForTestingOnly;
     globalThis.dispatchEvent(
       new MessageEvent("message", {
         data: { type: "load" },
@@ -589,14 +583,11 @@ ${GUEST_EPILOG}`;
     // frame reports itself ready once, and the report cannot be sent from
     // anywhere else. A window this element has not seen stands for the frame a
     // reattach would bring.
-    const inner = iframe as unknown as {
-      onOuterReady: (source: Window) => void;
-      loadState: string;
-    };
+    const inner = iframe.accessForTestingOnly;
     // @ts-ignore This is a lit property.
     iframe.src = "";
     inner.onOuterReady({} as Window);
-    assertEquals(inner.loadState, "");
+    assertEquals(iframe.loadState, "");
   } finally {
     cleanupFixtures();
   }


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Fable 5.1)

The frame ref, the window whose readiness was last acted on, and the
outer-ready step in `CommonIframeSandboxElement` were TypeScript
`private`, under one note saying the browser test reaches all three. They
are `#` names now, behind an `accessForTestingOnly` getter, as
`docs/development/DEVELOPMENT.md` § Classes prescribes.

## Shape of the accessor

The frame ref is a `readonly` plain property, since the class creates it
once and never reassigns it; the ready window is a `readonly` getter,
since the class replaces it on each outer-ready report; the step is a
forwarding arrow. The getter is what makes the `outerThis` alias
necessary.

## What the test does now

`test/iframe.browser.test.ts` drops its three `as unknown as {...}` casts
for the accessor. Its read of `loadState` moves to the element itself,
that being a public Lit property the cast had bundled in with the private
ones. The reason the test reaches in at all is unchanged, and now sits on
the accessor's doc comment: a frame reports itself ready exactly once,
from a window nothing outside the element can speak for, so the
outer-ready refusal is asserted where it is made.

## Review

Reviewed by a `cf-review` pass: mergeable, no blocking findings. Its
improvement is applied: the one doc comment still naming `onOuterReady`
without the `#` now has it. Its placement nit is applied too: the accessor
sits after the `#` fields rather than between two Lit-exposed properties.
The suite, unit and browser, is green after both.

## Coverage

The ratchet counts the accessor's lines as uncovered. The one test that
reads them is the browser pass, which runs the element in Chrome through
`deno-web-test`, and `docs/development/COVERAGE.md` says browser execution
never enters the Deno V8 profile the ratchet is scored on. A Deno-side
test reading the accessor would only be re-lighting lines the browser
suite already exercises, so the rise is accepted.

ACCEPT_COVERAGE_DEBT: packages/iframe-sandbox +11 lines

## Gates

`deno fmt --check`, `deno lint`, `deno task check`, and the package's
`deno task test`: the unit pass (7 passed, 0 failed) and the browser pass
through `deno-web-test` (53 passed, 0 failed), the latter run outside the
sandbox. No other package names a converted member.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6928?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



