### PR TITLE
refactor(runtime-client): the worker transport's handlers are `#` fields, the message one behind `accessForTestingOnly`

### DIFF
--- a/packages/runtime-client/src/client/transports/web-worker/transport-web-worker.ts
+++ b/packages/runtime-client/src/client/transports/web-worker/transport-web-worker.ts
@@ -51,8 +51,18 @@ export class WebWorkerRuntimeTransport
         name: "runtime-worker",
       },
     );
-    this.#worker.addEventListener("message", this._handleMessage);
-    this.#worker.addEventListener("error", this._handleError);
+    this.#worker.addEventListener("message", this.#handleMessage);
+    this.#worker.addEventListener("error", this.#handleError);
+  }
+
+  /**
+   * The worker message handler, which a test drives directly to deliver a
+   * message by hand.
+   */
+  get accessForTestingOnly(): {
+    readonly handleMessage: (event: MessageEvent) => void;
+  } {
+    return { handleMessage: this.#handleMessage };
   }
 
   /** @inheritDoc */
@@ -140,12 +150,8 @@ export class WebWorkerRuntimeTransport
    * Handles one message from the worker. What a decode returns is deep-frozen,
    * so a consumer of a response or a notification reads it rather than
    * reshaping it in place.
-   *
-   * TypeScript-private rather than a `#` name, and keeping the `_` the rest of
-   * this sweep drops, because `test/client/transport-web-worker.test.ts`
-   * reaches it under exactly that name to deliver a message by hand.
    */
-  private _handleMessage = (event: MessageEvent): void => {
+  #handleMessage = (event: MessageEvent): void => {
     let data: IPCRemotePost;
 
     try {
@@ -163,7 +169,7 @@ export class WebWorkerRuntimeTransport
       // protect and no one listening for the report: what a failure costs
       // there is `ready()` never settling, and a caller waiting on a promise
       // that will not resolve has no way back. So the failure lands where
-      // `_handleError()` puts a pre-ready one, on the promise itself.
+      // `#handleError()` puts a pre-ready one, on the promise itself.
       if (!this.#ready) {
         this.#readyPromise.reject(
           new Error(
@@ -203,11 +209,10 @@ export class WebWorkerRuntimeTransport
   };
 
   /**
-   * TypeScript-private rather than a `#` name, and keeping the `_` the rest
-   * of this sweep drops, because `test/client/transport-web-worker.test.ts`
-   * reaches it under exactly that name to deliver a message by hand.
+   * Handles a worker error: before the worker is ready it fails the ready
+   * promise, and after that it is emitted as an error notification.
    */
-  private _handleError = (event: ErrorEvent): void => {
+  #handleError = (event: ErrorEvent): void => {
     event.preventDefault();
 
     const error = new Error(

--- a/packages/runtime-client/test/client/transport-web-worker.test.ts
+++ b/packages/runtime-client/test/client/transport-web-worker.test.ts
@@ -78,9 +78,7 @@ function posted(data: unknown): MessageEvent {
 function handlerOf(
   transport: WebWorkerRuntimeTransport,
 ): (event: MessageEvent) => void {
-  return (transport as unknown as {
-    _handleMessage: (event: MessageEvent) => void;
-  })._handleMessage;
+  return transport.accessForTestingOnly.handleMessage;
 }
 
 describe("WebWorkerRuntimeTransport", () => {
@@ -196,7 +194,7 @@ describe("WebWorkerRuntimeTransport", () => {
       // `connect()` awaits `ready()`, so a pre-ready failure reported into an
       // emitter nobody is listening to yet would leave that promise pending
       // for good -- and a caller waiting on a promise that will not settle has
-      // no way back. `_handleError()` puts a pre-ready worker error on the
+      // no way back. `#handleError()` puts a pre-ready worker error on the
       // promise for the same reason; this is the decode's half of that.
       const transport = makeTransport();
       const emitted: unknown[] = [];

--- a/packages/runtime-client/test/client/transport-web-worker.test.ts
+++ b/packages/runtime-client/test/client/transport-web-worker.test.ts
@@ -194,8 +194,9 @@ describe("WebWorkerRuntimeTransport", () => {
       // `connect()` awaits `ready()`, so a pre-ready failure reported into an
       // emitter nobody is listening to yet would leave that promise pending
       // for good -- and a caller waiting on a promise that will not settle has
-      // no way back. `#handleError()` puts a pre-ready worker error on the
-      // promise for the same reason; this is the decode's half of that.
+      // no way back. `WebWorkerRuntimeTransport.#handleError()` puts a
+      // pre-ready worker error on the promise for the same reason; this is the
+      // decode's half of that.
       const transport = makeTransport();
       const emitted: unknown[] = [];
       transport.on("message", (m) => emitted.push(m));


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Fable 5.1)

Both worker-event handlers of `WebWorkerRuntimeTransport` were TypeScript
`private`, each under a note saying `test/client/transport-web-worker.test.ts`
reaches it by its underscore name. The test reaches only the message
handler, to deliver a message by hand. So that one sits behind an
`accessForTestingOnly` getter, as `docs/development/DEVELOPMENT.md`
§ Classes prescribes, and the error handler is a plain `#` field with a
doc comment of its own; the underscore prefixes go with the modifier.

## Shape of the accessor

One `readonly` plain property, since the handler is an arrow field the
class never reassigns. No getter, so no alias.

## What the test does now

Its `handlerOf()` helper returns the accessor's entry instead of a cast,
and the one comment naming the error handler names it as `#handleError()`.

## Review

Reviewed by a `cf-review` pass: clean, approve. Its one wording nit is
applied: the test's comment names the error handler by its class.

## Gates

`deno fmt --check`, `deno lint`, `deno task check`, and the `runtime-client`
suite (27 passed, 0 failed). No other package names either member.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6929?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


