### PR TITLE
docs(plans): the test-selection infrastructure is applied

### DIFF
--- a/docs/plans/pull-request-test-selection.md
+++ b/docs/plans/pull-request-test-selection.md
@@ -1,11 +1,11 @@
 # Choosing which tests a pull request runs
 
-Status: in progress. Part one is built apart from the manifest retention,
-the one-off bootstrap dispatch, and two dashboard tiles; part two is built
-apart from its continuous-integration configuration and the coverage work;
-part three has not started. [The work](#the-work) carries the detail. The
-record store this plan consumes is live and holds the data the design
-needs; the gaps it does not yet hold are listed under [What the store is
+Status: in progress. Part one is built apart from the one-off bootstrap
+dispatch and one dashboard tile; part two is built apart from its
+continuous-integration configuration and the coverage work; part three has
+not started. [The work](#the-work) carries the detail. The record store
+this plan consumes is live and holds the data the design needs; the gaps
+it does not yet hold are listed under [What the store is
 missing](#what-the-store-is-missing) and closed by the first part of the
 work.
 
@@ -1148,17 +1148,17 @@ nothing: their identity is the path already.
 The record schema already carries the field, so no format changes, and
 nothing downstream of the store has to know this happened.
 
-**Compaction is live now, and was not when this was written.** The
-compactor's identity was provisioned on 2026-08-31 and its daily workflow
-has rolled up 2026-08-19 through 2026-08-26. The floor is where the store's
-records begin and the ceiling is the seven-day lag, so that range is every
-day it can touch. Compaction collapses a day of raw records
+**Compaction is live.** The compactor's identity was provisioned on
+2026-08-31 and its daily workflow has rolled up every day from 2026-08-19
+up to the newest day it has reached. The floor is where the store's
+records begin. The ceiling moves with the daily run, which only touches
+days that closed a week ago. Compaction collapses a day of raw records
 into a manifest and a few tens of shards, which is the difference between
 reading 15,000 objects for a historical day and reading a manifest and
-seventeen shards. A day is a manifest and shards rather than a single object: a
-day of records is over a gigabyte of NDJSON, against a maximum string
-length of about half that, and an object has to fit in a string both to be
-written and to be read.
+seventeen shards. A day is a manifest and shards rather than a single
+object: a day of records is over a gigabyte of NDJSON, against a maximum
+string length of about half that, and an object has to fit in a string
+both to be written and to be read.
 
 **A re-run's earlier attempts can be stored a second time.** An object's
 day partition comes from the run's start time, and GitHub reports that
@@ -2058,8 +2058,8 @@ fourth part only when a variant is present.
 The manifest is untrusted input to the lane runner, and is validated the
 same way record lines are: a malformed manifest is rejected whole, and a
 manifest whose schema version the runner does not know is treated as
-absent. Retention is a bucket lifecycle rule deleting manifests after 30
-days, which the infra change adds.
+absent. Retention is a bucket lifecycle rule deleting manifests after 45
+days.
 
 ## The publisher
 
@@ -2126,14 +2126,14 @@ a window expands. It does not make a steady-state publisher switch a date
 from raw objects to a rollup seven days later, after the raw
 contributions are already in its aggregate.
 
-The publisher needs a writer credential for its own prefix. That is a new
-service account with `objectCreator` on `labs/test-selection/`, reached
-through a Workload Identity provider pinned to exactly this workflow file
-on `main` — the same pattern, and the same security argument, as the relay
-already uses. Nothing else needs a credential: a lane reads the manifest
-it resolves and writes nothing. These are infra-repository changes under `tofu/test-records`, and they must land and be applied before
-these workflows can write. They are the prerequisites [the work](#the-work)
-has that are not ours.
+The publisher needs a writer credential for its own prefix. That is the
+`test-selection-labs` service account with `objectCreator` on
+`labs/test-selection/`, reached through a Workload Identity provider
+pinned to exactly this workflow file on `main` — the same pattern, and
+the same security argument, as the relay already uses. The infra
+repository owns the account and the provider under `tofu/test-records`,
+and both are applied. Nothing else needs a credential: a lane reads the
+manifest it resolves and writes nothing.
 
 When the publisher fails, nothing breaks: the previous manifest is still
 the newest and lanes keep using it. A manifest going stale degrades
@@ -3078,7 +3078,7 @@ tape measure.
 | `ENVIRONMENTAL_MIN_SOURCES` | 5 | sources | Chosen | How many distinct sources a failure spans inside that window before it reads as the environment. Up when a genuinely broad regression is written off; down when a broken runner's failures still count as catches. |
 | `BREADTH_SATURATION` | 2 | sources | Chosen | Where the breadth term reaches half its ceiling. Up when four sources should outrank one by more; down when one source should already be worth nearly all of it. |
 | `CHURN_WINDOW_DAYS` | 60 | days | Chosen | How far back the decayed counts are read. Past this the weight is under one part in sixteen, so this is a performance decision rather than a policy one. |
-| `SAME_COMMIT_REACH_DAYS` | 2 | days | Chosen | How far back the fold remembers a commit's outcomes, so that a rerun landing in a later batch than the run it repeats is still read as the test disagreeing with itself. Up when reruns land far enough behind that their disagreement is counted as a catch; down when the fold's memory is what will not fit. It costs the number of identities that have failed times the number of commits, so it is the first dial to look at when a publisher run runs out of memory. |
+| `SAME_COMMIT_REACH_DAYS` | 2 | days | Chosen | How far back the fold remembers a commit's outcomes, so that a re-run landing in a later batch than the run it repeats is still read as the test disagreeing with itself. Up when re-runs land far enough behind that their disagreement is counted as a catch; down when the fold's memory is what will not fit. It costs the number of identities that have failed times the number of commits, so it is the first dial to look at when a publisher run runs out of memory. |
 | `FLAKE_COMMIT_REACH` | 8 | commits | Chosen | How many of the most recently observed commits the fold keeps outcomes at, alongside the span above. Moves for the same two reasons and against the same cost. |
 | `FLAKE_WINDOW_DAYS` | 60 | days | Chosen | Up when a flake rate swings about on too little evidence; down when a test since fixed stays excluded. |
 | `COST_WINDOW_DAYS` | 7 | days | Chosen | Up when cost estimates are noisy; down when durations drift faster than the estimate follows. |
@@ -3118,19 +3118,21 @@ three reasons that look like they force one turn out not to.
 
 ### The prerequisites that are not ours
 
-The publisher needs a writer credential: a `test-selection` service
-account with `objectCreator` on the manifest and state prefixes and a
-Workload Identity provider pinned to `.github/workflows/test-selection.yml`
-on `main`. Manifest and state objects expire after 30 days, and that
-lifecycle rule is what a lane's resolution rests on: a commit resolves the
-newest manifest at or before its own date, so the manifests a run may need
-have to outlive the window in which GitHub still permits that run to be
-re-run. Where the rerun window is the longer of the two, the retention is
-what to raise. The same infra change provisions the compactor principal. These are
-infra-repository changes under `tofu/test-records`, and they must land and
-be applied before anything here can publish. They are predecessors rather
-than a reason to split this work, and they are the only hard ordering
-outside this repository.
+The publisher needs a writer credential: the `test-selection-labs` service
+account with `objectCreator` on the manifest and state prefixes, and a
+Workload Identity provider pinned to
+`.github/workflows/test-selection.yml` on `main`. Manifest and state
+objects expire after 45 days, and that lifecycle rule is what a lane's
+resolution rests on: a commit resolves the newest manifest at or before
+its own date, so the manifests a run may need have to outlive the window
+in which GitHub still permits that run to be re-run. Where the re-run
+window is the longer of the two, the retention is what to raise. The same
+infra root provisions the compactor principal.
+
+All of that lives in the infra repository under `tofu/test-records`, and
+all of it is applied: the accounts, the grants, the pinned providers, and
+the lifecycle rule. Nothing outside this repository has to happen before
+the work here publishes, so this is not a reason to split it.
 
 ### Proving the topology before merging, not after
 
@@ -3202,7 +3204,7 @@ answers somewhere people can see them.
       offline against recorded manifests.
 - [x] `tasks/test-selection-publish.ts` and
       `.github/workflows/test-selection.yml`, on a four-hourly cron.
-- [ ] Hold manifest retention above the window in which GitHub still
+- [x] Hold manifest retention above the window in which GitHub still
       permits a run to be re-run. A lane resolves the newest manifest at or
       before the commit's date, so the answer is the same for every lane
       and every later attempt as long as the object it names still exists.
@@ -3400,9 +3402,9 @@ exercised on the branch on its own.
 
 ### What would force a split, and what to split first
 
-Nothing mechanical does. The infra credential is a predecessor rather than
-a stage, the topology can be proven on the branch with `ci: full`, and the
-window before the first manifest is one `main` run that the lane fallback
+Nothing mechanical does. The infra credential is already in place, the
+topology can be proven on the branch with `ci: full`, and the window
+before the first manifest is one `main` run that the lane fallback
 already covers.
 
 What could force one is review. This is a large change to the way the


### PR DESCRIPTION
`docs/plans/pull-request-test-selection.md` describes the infrastructure the test-selection publisher depends on as work that has still to land. It has landed and been applied. The figures and the tenses in the document trail it.

The manifest retention figure matters rather than being decoration. A lane resolves the newest manifest generated at or before the commit under test was made, so a manifest expiring between an attempt and its re-run is the one way two attempts of one run can disagree about which tests to run. Somebody checking whether the retention covers the re-run window needs the real number. It is 45 days, in two passages that said 30, one of which named the lifecycle rule as something an infra change adds.

The publisher's credential is described in two passages and argued about in a third: a service account with `objectCreator` on `labs/test-selection/`, a Workload Identity provider pinned to `.github/workflows/test-selection.yml` on `main`, and the compactor principal beside them. All three call these changes that must land and be applied before anything here can publish, and the section on whether the work needs splitting calls the credential a predecessor. They are applied, so none of it is an ordering the work waits on.

Each claim was read from the live project rather than from the infra repository's own account of itself. The bucket carries a delete at age 45 on `labs/test-selection/` with no `isLive` restriction, so it reaches an object in either version state.
`test-selection-labs@commontools-core.iam.gserviceaccount.com` holds `roles/storage.objectCreator` on that folder, and the `selection-labs` provider is active, pinning the repository id, the owner id, `refs/heads/main`, the exact workflow file, and the schedule and dispatch events. The compactor account exists beside it, and the `TEST_SELECTION_*` Actions variables are installed.

Two statements were pinned to values that move, and are bounded by descriptions instead. The status line counted the manifest retention among the parts of part one that are not built, and counted two outstanding dashboard tiles where the coverage debt trend tile left one. The compaction item named 2026-08-26 as the newest day the compactor could reach and called that every day it can touch; the daily run has gone further since. That range now ends at the newest day the run has reached, with the floor and the ceiling given after it in their own sentences, so the next run does not make it wrong again.

The rest is wording in the same passages. The publisher's account is named twice and only one passage carried a name at all, which called it new; both say `test-selection-labs`, which is the account the provider's condition names. In the publisher section, "both are applied" sat two sentences away from the pair it refers to, and the paragraph then called them a prerequisite the work has, immediately after saying they were satisfied; that sentence now follows the pair and names it. The compaction item opened by comparing the system with the state of the document that describes it, which live documentation does not do. The dial table spelled "rerun" where the rest of the document spells "re-run" for the same thing.

The one-off bootstrap dispatch is untouched and remains open. `labs/test-selection/` holds no objects, and every four-hourly publisher run ends with "no aggregate exists yet. A first run reads the whole window and is asked for deliberately, with --bootstrap." That is what still stands between the plan and a first manifest.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6930?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

