### PR TITLE
refactor(shell): the debugger shows an expanded marker's indented rendering uncut

### DIFF
--- a/packages/js-compiler/source-map.ts
+++ b/packages/js-compiler/source-map.ts
@@ -1,3 +1,4 @@
+import { toIndentedDebugString } from "@commonfabric/data-model";
 import { LRUCache } from "@commonfabric/utils/cache";
 import { MappedPosition, SourceMapConsumer } from "source-map-js";
 
@@ -572,7 +573,7 @@ export function parseSourceMap(stringMap: string): SourceMap {
   }
   if (!isSourceMap(sourceMap)) {
     throw new Error(
-      `Could not parse source map: ${JSON.stringify(sourceMap, null, 2)}`,
+      `Could not parse source map: ${toIndentedDebugString(sourceMap)}`,
     );
   }
   return sourceMap;

--- a/packages/js-compiler/test/source-map.test.ts
+++ b/packages/js-compiler/test/source-map.test.ts
@@ -9,6 +9,7 @@ import {
   getTypeScriptEnvironmentTypes,
   identitySourceMap,
   InMemoryProgram,
+  parseSourceMap,
   type SourceMap,
   SourceMapParser,
   TypeScriptCompiler,
@@ -961,5 +962,13 @@ describe("deferred composition inputs and lazy registration (CT-1819)", () => {
     // evicts rather than grows). A plain Map would give 4096 then 8192.
     expect(afterFirst).toBeLessThan(4096);
     expect(afterSecond).toBe(afterFirst);
+  });
+});
+
+describe("parseSourceMap()", () => {
+  it("throws naming what the document holds, given JSON that is not a source map", () => {
+    expect(() => parseSourceMap('{"foo": 1}')).toThrow(
+      "Could not parse source map: {\n  foo: 1\n}",
+    );
   });
 });

--- a/packages/runner/src/link-types.ts
+++ b/packages/runner/src/link-types.ts
@@ -1,9 +1,10 @@
-import { isObjectNotArray } from "@commonfabric/utils/types";
+import { toCompactDebugString } from "@commonfabric/data-model";
 import {
   isLinkRef,
   linkRefFrom,
   linkRefPayload,
 } from "@commonfabric/data-model/cell-rep";
+import { isObjectNotArray } from "@commonfabric/utils/types";
 import {
   type CellScope,
   type JSONSchema,
@@ -277,7 +278,11 @@ export function parseLinkPrimitive(
       ...(link.overwrite === "redirect" && { overwrite: "redirect" }),
     };
   }
-  throw new Error(`Link is not a primitive: ${value}`);
+  throw new Error(
+    `Link is not a primitive: ${
+      toCompactDebugString(value, { backtickQuote: true })
+    }`,
+  );
 }
 
 /**

--- a/packages/runner/src/pattern-binding.ts
+++ b/packages/runner/src/pattern-binding.ts
@@ -471,7 +471,13 @@ function sendValueToBindingInner<T>(
     // `Object.is`, not `===`: a constant `NaN` binding legitimately matches a
     // produced `NaN`, and `0` vs `-0` is a genuine mismatch.
     if (!Object.is(binding, value)) {
-      throw new Error(`Got ${value} instead of ${binding}`);
+      throw new Error(
+        `Got ${
+          toCompactDebugString(value, { maxLength: MAX_BINDING_RENDER })
+        } instead of ${
+          toCompactDebugString(binding, { maxLength: MAX_BINDING_RENDER })
+        }`,
+      );
     }
   }
 }

--- a/packages/runner/src/runtime-presets.ts
+++ b/packages/runner/src/runtime-presets.ts
@@ -126,6 +126,7 @@
  * the bundle's `enforce` asks for it the same way.
  */
 
+import { toCompactDebugString } from "@commonfabric/data-model";
 import { SERVER_EXECUTION_DEFAULT_ENABLED } from "@commonfabric/memory/v2/server-execution-default";
 import {
   type CfcEnforcementMode,
@@ -412,7 +413,9 @@ export function parseServerExperimentalOptions(
     if (typeof value !== "boolean") {
       console.warn(
         `[runtime-presets] Ignoring server-published ${key}=` +
-          `${JSON.stringify(value)} — expected a boolean.`,
+          `${
+            toCompactDebugString(value, { backtickQuote: true })
+          } — expected a boolean.`,
       );
       continue;
     }

--- a/packages/runner/test/link-types.test.ts
+++ b/packages/runner/test/link-types.test.ts
@@ -2,7 +2,9 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import {
   linkPathSegmentToCellPathSegment,
+  parseLinkPrimitive,
   parseScopedIdSegment,
+  type PrimitiveCellLink,
 } from "../src/link-types.ts";
 
 describe("link-types", () => {
@@ -62,6 +64,15 @@ describe("link-types", () => {
     it("throws when no id precedes the suffix", () => {
       expect(() => parseScopedIdSegment("@user")).toThrow(
         /Invalid scope suffix/,
+      );
+    });
+  });
+
+  describe("parseLinkPrimitive()", () => {
+    it("throws naming the value, given a value that is not a link", () => {
+      const value = { x: 1 } as unknown as PrimitiveCellLink;
+      expect(() => parseLinkPrimitive(value)).toThrow(
+        "Link is not a primitive: `{x:1}`",
       );
     });
   });

--- a/packages/runner/test/pattern-binding.test.ts
+++ b/packages/runner/test/pattern-binding.test.ts
@@ -234,6 +234,10 @@ describe("pattern-binding", () => {
       // A genuine mismatch throws.
       expect(() => sendValueToBinding(tx, testCell, argumentCellLink, 42, 43))
         .toThrow("Got 43 instead of 42");
+      // A produced object is rendered, not stringified as `[object Object]`.
+      expect(() =>
+        sendValueToBinding(tx, testCell, argumentCellLink, 42, { a: 1 })
+      ).toThrow("Got {a:1} instead of 42");
     });
 
     it("normalizes cell values before writing a narrower scoped binding", () => {

--- a/packages/runner/test/runtime-presets.test.ts
+++ b/packages/runner/test/runtime-presets.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "@std/testing/bdd";
-import { expect } from "@std/expect";
 import { stub } from "@std/testing/mock";
+import { expect } from "@std/expect";
 import {
   ADOPT_SERVER_FLAGS_ENV,
   adoptServerExperimentalOptions,

--- a/packages/runner/test/runtime-presets.test.ts
+++ b/packages/runner/test/runtime-presets.test.ts
@@ -1,5 +1,6 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { stub } from "@std/testing/mock";
 import {
   ADOPT_SERVER_FLAGS_ENV,
   adoptServerExperimentalOptions,
@@ -407,6 +408,19 @@ describe("runtimePresets conformance (CT-1814)", () => {
           serverExecution: false,
           readerSchemaPrecedence: false,
         });
+      });
+
+      it("warns naming the value, and skips the flag, given a value that is not a boolean", () => {
+        const warn = stub(console, "warn");
+        let parsed;
+        try {
+          parsed = parseServerExperimentalOptions({ modernCellRep: "yes" });
+        } finally {
+          warn.restore();
+        }
+        expect(parsed).toEqual({ readerSchemaPrecedence: false });
+        expect(warn.calls.length).toBe(1);
+        expect(warn.calls[0].args[0]).toContain('modernCellRep=`"yes"`');
       });
 
       it("adopts legacy false for an absent readerSchemaPrecedence declaration", () => {

--- a/packages/shell/src/views/DebuggerView.ts
+++ b/packages/shell/src/views/DebuggerView.ts
@@ -39,13 +39,6 @@ const DEBUGGER_VALUE_OPTIONS: DebugValueOptions = {
 };
 
 /**
- * Longest text an expanded marker's detail shows. The indented rendering has
- * no length option of its own, and a marker with many keys at every level
- * within the depth limit still runs long, so the display bounds itself.
- */
-const MAX_MARKER_DETAIL_LENGTH = 10000;
-
-/**
  * Hierarchical topic definitions for filtering telemetry events.
  * Topics can have subtopics for more granular filtering.
  */
@@ -1133,17 +1126,6 @@ export class XDebuggerView extends LitElement {
     }
 
     return false;
-  }
-
-  /**
-   * Renders the detail an expanded marker shows: the indented rendering, cut
-   * to `MAX_MARKER_DETAIL_LENGTH` with a trailing `...` when it runs longer.
-   */
-  private markerDetail(marker: RuntimeTelemetryMarkerResult): string {
-    const text = toIndentedDebugString(marker, DEBUGGER_VALUE_OPTIONS);
-    return (text.length > MAX_MARKER_DETAIL_LENGTH)
-      ? `${text.slice(0, MAX_MARKER_DETAIL_LENGTH - 3)}...`
-      : text;
   }
 
   private matchesSearch(marker: RuntimeTelemetryMarkerResult): boolean {
@@ -2703,7 +2685,10 @@ export class XDebuggerView extends LitElement {
                         Copy Full
                       </button>
                     </div>
-                    <pre>${this.markerDetail(marker)}</pre>
+                    <pre>${toIndentedDebugString(
+                      marker,
+                      DEBUGGER_VALUE_OPTIONS,
+                    )}</pre>
                   </div>
                 `
                 : ""}

--- a/packages/shell/src/views/DebuggerView.ts
+++ b/packages/shell/src/views/DebuggerView.ts
@@ -40,8 +40,9 @@ const DEBUGGER_VALUE_OPTIONS: DebugValueOptions = {
 
 /**
  * Rendering options for the runs of a non-idempotent report. The panel is an
- * inspector, so every run and every cell each one read or wrote is shown,
- * deep enough to reach the values; only a long string is still cut.
+ * inspector, so every run and every cell a run read or wrote is shown, deep
+ * enough to reach the values; a long string, or a value nested past the
+ * depth, is still cut.
  */
 const RUN_DETAIL_OPTIONS: DebugValueOptions = {
   ...DEBUGGER_VALUE_OPTIONS,
@@ -101,12 +102,13 @@ export type SubtopicKey<T extends TopicKey> =
  */
 export class XDebuggerView extends LitElement {
   // The members below stay TypeScript-private rather than becoming `#` names,
-  // which is the convention elsewhere. `test/disposal-handling.test.ts` calls
-  // this view's handlers off `XDebuggerView.prototype` against a stand-in
-  // receiver: a plain object supplying `getLoggerRegistry`,
-  // `debuggerController`, and the rest as ordinary properties. A `#` name is
-  // scoped to real instances, so each of those calls would throw. Converting
-  // the class means rewriting that suite to build real views.
+  // which is the convention elsewhere. `test/disposal-handling.test.ts` and
+  // `test/XDebuggerView.test.ts` call this view's methods off
+  // `XDebuggerView.prototype` against a stand-in receiver: a plain object
+  // supplying `getLoggerRegistry`, `debuggerController`, and the rest as
+  // ordinary properties. A `#` name is scoped to real instances, so each of
+  // those calls would throw. Converting the class means rewriting both suites
+  // to build real views.
 
   static override styles = css`
     :host {

--- a/packages/shell/src/views/DebuggerView.ts
+++ b/packages/shell/src/views/DebuggerView.ts
@@ -39,6 +39,15 @@ const DEBUGGER_VALUE_OPTIONS: DebugValueOptions = {
 };
 
 /**
+ * Rendering options for the runs of a non-idempotent report: the debugger's,
+ * but deep enough to reach the values under each run's `reads` and `writes`.
+ */
+const RUN_DETAIL_OPTIONS: DebugValueOptions = {
+  ...DEBUGGER_VALUE_OPTIONS,
+  maxDepth: 6,
+};
+
+/**
  * Hierarchical topic definitions for filtering telemetry events.
  * Topics can have subtopics for more granular filtering.
  */
@@ -2544,7 +2553,10 @@ export class XDebuggerView extends LitElement {
                             </summary>
                             <pre
                               style="margin: 0.25rem 0 0; font-size: 0.625rem; color: #cbd5e1; overflow: auto; max-height: 8rem;"
-                            >${JSON.stringify(report.runs, null, 2)}</pre>
+                            >${toIndentedDebugString(
+                              report.runs,
+                              RUN_DETAIL_OPTIONS,
+                            )}</pre>
                           </details>
                         </div>
                       `,

--- a/packages/shell/src/views/DebuggerView.ts
+++ b/packages/shell/src/views/DebuggerView.ts
@@ -39,12 +39,15 @@ const DEBUGGER_VALUE_OPTIONS: DebugValueOptions = {
 };
 
 /**
- * Rendering options for the runs of a non-idempotent report: the debugger's,
- * but deep enough to reach the values under each run's `reads` and `writes`.
+ * Rendering options for the runs of a non-idempotent report. The panel is an
+ * inspector, so every run and every cell each one read or wrote is shown,
+ * deep enough to reach the values; only a long string is still cut.
  */
 const RUN_DETAIL_OPTIONS: DebugValueOptions = {
   ...DEBUGGER_VALUE_OPTIONS,
   maxDepth: 6,
+  maxArrayLength: Infinity,
+  maxProperties: Infinity,
 };
 
 /**

--- a/packages/shell/src/views/RootView.ts
+++ b/packages/shell/src/views/RootView.ts
@@ -1,3 +1,4 @@
+import { toCompactDebugString } from "@commonfabric/data-model";
 import { type DID, type Identity, KeyStore } from "@commonfabric/identity";
 import { resolveSpaceDid, RuntimeInternals } from "@commonfabric/lib-shell";
 import {
@@ -638,7 +639,11 @@ export class XRootView extends BaseView implements ShellApp {
       case "set-config":
         return this.setConfig(command.key, command.value);
     }
-    throw new Error(`Received a non-command: ${JSON.stringify(command)}`);
+    throw new Error(
+      `Received a non-command: ${
+        toCompactDebugString(command, { maxLength: 200, backtickQuote: true })
+      }`,
+    );
   }
 
   state(): AppState {

--- a/packages/shell/test/DebuggerView.test.ts
+++ b/packages/shell/test/DebuggerView.test.ts
@@ -21,23 +21,30 @@ function templateMarkup(value: unknown): string {
 describe("XDebuggerView", () => {
   describe("instance members", () => {
     describe("renderDiagnosis()", () => {
-      it("renders a non-idempotent report's runs, a `bigint` write included", () => {
+      it("renders every run of a non-idempotent report and every cell it wrote, a `bigint` included", () => {
         // A run's reads and writes are `FabricValue`s, which a `bigint` is.
         // The method reads the controller's result and the duration off
         // `this`, so a stand-in carrying those two is enough to render it.
+        // The run count and the write count both exceed the debugger's usual
+        // array and property limits, so the panel showing the last of each
+        // is what the assertions pin.
 
+        const writes = Object.fromEntries(
+          Array.from({ length: 25 }, (_, i) => [`out${i}`, BigInt(i)]),
+        );
+        const runs = Array.from({ length: 8 }, (_, i) => ({
+          timestamp: i,
+          reads: { in: 1 },
+          writes,
+        }));
         const result = {
           duration: 5000,
           busyTime: 100,
           cycles: [],
           nonIdempotent: [{
             actionId: "action-1",
-            runs: [{
-              timestamp: 1,
-              reads: { in: 1 },
-              writes: { out: 12345678901234567890n },
-            }],
-            differingWriteKeys: ["out"],
+            runs,
+            differingWriteKeys: ["out0"],
           }],
         };
         const view = {
@@ -52,7 +59,9 @@ describe("XDebuggerView", () => {
         }).renderDiagnosis;
 
         const markup = templateMarkup(render.call(view));
-        expect(markup).toContain("out: 12345678901234567890n");
+        expect(markup).toContain("timestamp: 7");
+        expect(markup).toContain("out24: 24n");
+        expect(markup).not.toContain("/...");
       });
     });
   });

--- a/packages/shell/test/DebuggerView.test.ts
+++ b/packages/shell/test/DebuggerView.test.ts
@@ -1,0 +1,59 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { XDebuggerView } from "../src/views/DebuggerView.ts";
+
+/** Flattens a Lit template result, its values included, to its markup. */
+function templateMarkup(value: unknown): string {
+  if (Array.isArray(value)) return value.map(templateMarkup).join("");
+  if (value === null || value === undefined) return "";
+  if (typeof value !== "object") return String(value);
+  const template = value as {
+    strings?: readonly string[];
+    values?: readonly unknown[];
+  };
+  if (template.strings === undefined) return "";
+  return template.strings.map((part, index) =>
+    part + templateMarkup(template.values?.[index])
+  ).join("");
+}
+
+describe("XDebuggerView", () => {
+  describe("instance members", () => {
+    describe("renderDiagnosis()", () => {
+      it("renders a non-idempotent report's runs, a `bigint` write included", () => {
+        // A run's reads and writes are `FabricValue`s, which a `bigint` is.
+        // The method reads the controller's result and the duration off
+        // `this`, so a stand-in carrying those two is enough to render it.
+
+        const result = {
+          duration: 5000,
+          busyTime: 100,
+          cycles: [],
+          nonIdempotent: [{
+            actionId: "action-1",
+            runs: [{
+              timestamp: 1,
+              reads: { in: 1 },
+              writes: { out: 12345678901234567890n },
+            }],
+            differingWriteKeys: ["out"],
+          }],
+        };
+        const view = {
+          debuggerController: {
+            getIsDiagnosing: () => false,
+            getDiagnosisResult: () => result,
+          },
+          diagnosisDurationMs: 5000,
+        };
+        const render = (XDebuggerView.prototype as unknown as {
+          renderDiagnosis(this: unknown): unknown;
+        }).renderDiagnosis;
+
+        const markup = templateMarkup(render.call(view));
+        expect(markup).toContain("out: 12345678901234567890n");
+      });
+    });
+  });
+});

--- a/packages/shell/test/XDebuggerView.test.ts
+++ b/packages/shell/test/XDebuggerView.test.ts
@@ -2,21 +2,7 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
 import { XDebuggerView } from "../src/views/DebuggerView.ts";
-
-/** Flattens a Lit template result, its values included, to its markup. */
-function templateMarkup(value: unknown): string {
-  if (Array.isArray(value)) return value.map(templateMarkup).join("");
-  if (value === null || value === undefined) return "";
-  if (typeof value !== "object") return String(value);
-  const template = value as {
-    strings?: readonly string[];
-    values?: readonly unknown[];
-  };
-  if (template.strings === undefined) return "";
-  return template.strings.map((part, index) =>
-    part + templateMarkup(template.values?.[index])
-  ).join("");
-}
+import { templateMarkup } from "./lit-template-markup.ts";
 
 describe("XDebuggerView", () => {
   describe("instance members", () => {
@@ -61,7 +47,8 @@ describe("XDebuggerView", () => {
         const markup = templateMarkup(render.call(view));
         expect(markup).toContain("timestamp: 7");
         expect(markup).toContain("out24: 24n");
-        expect(markup).not.toContain("/...");
+        expect(markup).not.toContain("... length:");
+        expect(markup).not.toContain("... count:");
       });
     });
   });

--- a/packages/shell/test/lit-template-markup.ts
+++ b/packages/shell/test/lit-template-markup.ts
@@ -1,0 +1,17 @@
+/**
+ * Flattens a Lit template result, its values included, to its markup, so
+ * that a test can assert on what a render method produced without a DOM.
+ */
+export function templateMarkup(value: unknown): string {
+  if (Array.isArray(value)) return value.map(templateMarkup).join("");
+  if (value === null || value === undefined) return "";
+  if (typeof value !== "object") return String(value);
+  const template = value as {
+    strings?: readonly string[];
+    values?: readonly unknown[];
+  };
+  if (template.strings === undefined) return "";
+  return template.strings.map((part, index) =>
+    part + templateMarkup(template.values?.[index])
+  ).join("");
+}

--- a/packages/shell/test/lit-template-markup.ts
+++ b/packages/shell/test/lit-template-markup.ts
@@ -1,6 +1,12 @@
+import { toCompactDebugString } from "@commonfabric/data-model";
+
 /**
  * Flattens a Lit template result, its values included, to its markup, so
- * that a test can assert on what a render method produced without a DOM.
+ * that a test can assert on what a render method produced without a DOM. A
+ * value that is an object other than a template result, such as one bound to
+ * an element property, is rendered as its compact debug string rather than
+ * dropped, so that content it holds is in the markup for an assertion to
+ * find.
  */
 export function templateMarkup(value: unknown): string {
   if (Array.isArray(value)) return value.map(templateMarkup).join("");
@@ -10,7 +16,7 @@ export function templateMarkup(value: unknown): string {
     strings?: readonly string[];
     values?: readonly unknown[];
   };
-  if (template.strings === undefined) return "";
+  if (template.strings === undefined) return toCompactDebugString(value);
   return template.strings.map((part, index) =>
     part + templateMarkup(template.values?.[index])
   ).join("");

--- a/packages/shell/test/root-view.test.ts
+++ b/packages/shell/test/root-view.test.ts
@@ -99,6 +99,20 @@ function templateMarkup(value: unknown): string {
 }
 
 describe("XRootView", () => {
+  it("throws naming the value, given a command event carrying a non-command", async () => {
+    const restore = installBrowserGlobals();
+    try {
+      const { XRootView } = await import("../src/views/RootView.ts");
+      const view = new XRootView();
+      const event = new CustomEvent("command", { detail: { type: "bogus" } });
+      expect(() => view.onCommand(event)).toThrow(
+        'Received a non-command: `{type:"bogus"}`',
+      );
+    } finally {
+      restore();
+    }
+  });
+
   it("constructs with default app state and renders the app view", async () => {
     const restore = installBrowserGlobals();
     try {

--- a/packages/shell/test/root-view.test.ts
+++ b/packages/shell/test/root-view.test.ts
@@ -11,6 +11,7 @@ import {
   NotificationType,
   RuntimeErrorCode,
 } from "@commonfabric/runtime-client";
+import { templateMarkup } from "./lit-template-markup.ts";
 
 // XRootView is a Lit element; load and exercise it under a minimal browser
 // shim, mirroring login-view.test.ts. Constructing it runs its field
@@ -82,20 +83,6 @@ function installBrowserGlobals(): () => void {
 function templateStrings(value: unknown): string {
   const result = value as { strings?: readonly string[] };
   return (result?.strings ?? []).join("");
-}
-
-function templateMarkup(value: unknown): string {
-  if (Array.isArray(value)) return value.map(templateMarkup).join("");
-  if (value === null || value === undefined) return "";
-  if (typeof value !== "object") return String(value);
-  const template = value as {
-    strings?: readonly string[];
-    values?: readonly unknown[];
-  };
-  if (template.strings === undefined) return "";
-  return template.strings.map((part, index) =>
-    part + templateMarkup(template.values?.[index])
-  ).join("");
 }
 
 describe("XRootView", () => {


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Fable 5.1)

Two things, both about debug rendering outside `data-model`.

## The debugger's marker-detail cut goes

The shell's debugger view rendered an expanded telemetry marker with `toIndentedDebugString()` under `DEBUGGER_VALUE_OPTIONS` and then cut the text at ten thousand characters with a trailing `...`. The cut predates the renderer's `maxProperties` option, and with the options bounding every axis it does little: a typical marker renders in under a thousand characters, and the worst case the options allow, four hundred two-hundred-character strings within the depth limit, runs to about eighty-five thousand, a long but readable page rather than something to protect against. Measured under the view's exact options:

| marker shape | indented length |
|---|---|
| 8 keys of 4 keys of short strings | 834 |
| 20 keys of 20 keys of 200-character strings | 85,252 |
| 20 of 20 of 20 of 200-character strings | 5,652 |

So the cut goes, along with `MAX_MARKER_DETAIL_LENGTH` and the `markerDetail()` helper that existed to hold it; the render sits at its one call site. The rendering options are unchanged. No test pinned the cut.

## An audit of debug stringifying across the tree

A sweep of every non-test `JSON.stringify()`, every debug-renderer call, and the raw `${value}` interpolations into error messages, asking where the current renderers, with their bounds on depth, array length, property count, string length and lines, and the `backtickQuote` option, do a better job than what is there. Six sites change, and each gains a test that reaches it and asserts the rendering:

* `runner/src/link-types.ts`, `parseLinkPrimitive()`: `Link is not a primitive: ${value}` rendered any object as `[object Object]`; it now renders the value, backtick-quoted.
* `runner/src/pattern-binding.ts`, the constant-binding mismatch: `Got ${value} instead of ${binding}` had the same `[object Object]` problem; both sides now render under `MAX_BINDING_RENDER`, as the file's other bindings do.
* `runner/src/runtime-presets.ts`: the warning about a non-boolean server-published option renders the value backtick-quoted, in the message style the tree uses, instead of through `JSON.stringify()`.
* `shell/src/views/RootView.ts`: `Received a non-command:` renders the value bounded at 200 characters and backtick-quoted, where `JSON.stringify()` was unbounded.
* `shell/src/views/DebuggerView.ts`: the non-idempotent report's "Show run details" panel rendered `report.runs` with `JSON.stringify()`; its `reads` and `writes` are `FabricValue`s, so a `bigint` in one would throw inside the template. It now renders with `RUN_DETAIL_OPTIONS`: the debugger's options with the depth raised to reach the values under each run, and the array and property limits lifted, since the panel is an inspector and elided cells are the data it exists to show; only a long string is still cut.
* `js-compiler/source-map.ts`: `Could not parse source map:` dumped the whole parsed value, `mappings` and all, into the error; it now renders bounded. This is `js-compiler`'s first import from `data-model`; the workspace resolves it without a manifest entry, and `check-package-cycles` is unchanged.

The tests are the differential: run against `main`'s versions of the six source files, exactly those six cases fail, and nothing else does. Before them, only the pattern-binding mismatch was executed by any test in its package's suite; the other five added lines had zero hits in a local coverage run.

Left as they are, by class:

* Two sites the audit first changed and then put back, because no unit test reaches them honestly: the inconsistent-partial-cause error in `runner/src/builder/pattern.ts`, an internal invariant over `JSONValue`s, and the empty-schema-subscription diagnostic in `runtime-client`'s `runtime-processor.ts`, which fires inside a live subscription's sink over JSON-shaped values.

* `JSON.stringify(aString)` as a quoting idiom in a message, several dozen sites, most in `cf-harness`'s CLI, `memory`'s row labels, `state-inspector`'s option errors, and `cli`'s path errors. For a string the two renderers agree, so a swap is churn.
* Values that are JSON by construction, where `JSON.stringify()` is adequate: a JSON-RPC error object in the codex driver, a link payload in the agents connector, ajv's `validator.errors` in toolshed, plain config records in `cf-harness`.
* Wire, storage, cache-key, clipboard, and file destinations, where JSON is the format and not a rendering.
* `${err}` and `String(err)` on an `Error`, several hundred sites: the renderer's `/Error(...)` form is not an improvement on `.message` there.
* `Deno.inspect()` in `utils`'s logger and in `toolshed`'s background console, which show an `Error`'s stack, and `utils` cannot depend on `data-model` in any case.
* `cli/lib/callable.ts`'s address refusal, whose value is a string and whose JSON-quoted form tests pin.
* The agents `debug-view` connector's `json()` formatter, a pattern-side renderer that could use the `toIndentedDebugString` the pattern surface exports; left for its owners.

Gates: shell `deno task test` 58/193, js-compiler 16/158, runner 1363/8318 on the swaps and the three touched test files again after the tests, runtime-client 27/584, `deno fmt --check` and `deno lint` on the touched files, `deno task check`, `check-package-cycles`.
