### PR TITLE
refactor(runner, piece): five members no test reaches are `#` names

### DIFF
--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -1605,7 +1605,7 @@ export class PiecesController<T = unknown> {
     const ref =
       (pattern !== undefined
         ? this.runtime.patternManager.getArtifactEntryRef(pattern)
-        : undefined) ?? await this.readPatternIdentity(piece);
+        : undefined) ?? await this.#readPatternIdentity(piece);
 
     return await timePiecePhase(
       "syncPattern.loadPattern",
@@ -1613,7 +1613,7 @@ export class PiecesController<T = unknown> {
     );
   }
 
-  private async readPatternIdentity(piece: Cell<unknown>) {
+  async #readPatternIdentity(piece: Cell<unknown>) {
     await timePiecePhase("syncPattern.synced", () => this.synced());
     await timePiecePhase("syncPattern.piece.sync", () => piece.sync());
 

--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -1397,11 +1397,7 @@ class TransformObjectCreator
   implements IObjectCreator<AnyCellWrapping<FabricValue>> {
   #runtime: Runtime;
 
-  /**
-   * TypeScript-private rather than a `#` name: `test/schema-streams.test.ts`
-   * drives this member directly.
-   */
-  private tx: IExtendedStorageTransaction;
+  #tx: IExtendedStorageTransaction;
 
   #synced: boolean;
   #baseLink: NormalizedFullLink;
@@ -1415,7 +1411,7 @@ class TransformObjectCreator
     cfcLabelView: CfcLabelView | undefined,
   ) {
     this.#runtime = runtime;
-    this.tx = tx;
+    this.#tx = tx;
     this.#synced = synced;
     this.#baseLink = baseLink;
     this.#cfcLabelView = cfcLabelView;
@@ -1522,7 +1518,7 @@ class TransformObjectCreator
   ): T | undefined {
     return processDefaultValue(
       this.#runtime,
-      this.tx,
+      this.#tx,
       link,
       value,
       this.#synced,
@@ -1548,7 +1544,7 @@ class TransformObjectCreator
     return createOpaqueReference(
       this.#runtime,
       link,
-      this.tx,
+      this.#tx,
       this.#synced,
       this.#labelViewFor(link),
     ) as AnyCellWrapping<FabricValue>;
@@ -1568,7 +1564,7 @@ class TransformObjectCreator
       value,
       this.#runtime,
       link,
-      this.tx,
+      this.#tx,
       this.#synced,
       this.#labelViewFor(link),
     );
@@ -1588,7 +1584,7 @@ class TransformObjectCreator
     if (link.schema === undefined || link.schema === true) {
       return createQueryResultProxy(
         this.#runtime,
-        this.tx,
+        this.#tx,
         link,
         0,
         this.#labelViewFor(link),
@@ -1634,7 +1630,7 @@ class TransformObjectCreator
             ...handleLink,
             schema: unwrapAsCellSchema(schema as JSONSchemaObj),
           },
-          getTransactionForChildCells(this.tx),
+          getTransactionForChildCells(this.#tx),
           this.#synced,
           cellKind,
           this.#labelViewFor(link),
@@ -1645,7 +1641,7 @@ class TransformObjectCreator
       if (ContextualFlowControl.isTrueSchema(schema)) {
         return createQueryResultProxy(
           this.#runtime,
-          this.tx,
+          this.#tx,
           link,
           0,
           this.#labelViewFor(link),
@@ -1657,7 +1653,7 @@ class TransformObjectCreator
         // processDefaultValue already annotates with back to cell
         return processDefaultValue(
           this.#runtime,
-          this.tx,
+          this.#tx,
           link,
           schema.default,
           this.#synced,
@@ -1688,7 +1684,7 @@ class TransformObjectCreator
             if (valueObj[propName] === undefined) {
               valueObj[propName] = processDefaultValue(
                 this.#runtime,
-                this.tx,
+                this.#tx,
                 {
                   ...link,
                   path: [...link.path, propName],
@@ -1709,7 +1705,7 @@ class TransformObjectCreator
       value,
       this.#runtime,
       link,
-      this.tx,
+      this.#tx,
       this.#synced,
       this.#labelViewFor(link),
     );

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -1755,15 +1755,14 @@ export class StorageManager implements IStorageManager {
     };
   }
 
-  /** Log a sync failure that would otherwise resolve silently, once per
+  /**
+   * Logs a sync failure that would otherwise resolve silently, once per
    * distinct (space, error) pair. The error name and message are the wire
-   * server's own words — for an ACL denial that includes the principal and
+   * server's own words: for an ACL denial that includes the principal and
    * space (`Principal <did> lacks READ on space <did>`), which is exactly
-   * what a caller staring at an unexplained `undefined` needs. *
-   * TypeScript-private rather than a `#` name:
-   * `test/array-ref-defs-propagation.test.ts` drives this member directly.
+   * what a caller staring at an unexplained `undefined` needs.
    */
-  private logSyncLoadFailure(
+  #logSyncLoadFailure(
     space: MemorySpace,
     id: URI,
     failure: unknown,
@@ -1914,7 +1913,7 @@ export class StorageManager implements IStorageManager {
       // into the same silent undefined. Surface the failure; the pending-load
       // ledger below still carries it to scheduler waiters.
       if (loadFailure !== undefined) {
-        this.logSyncLoadFailure(space, id, loadFailure);
+        this.#logSyncLoadFailure(space, id, loadFailure);
       }
       return cell;
     } catch (error) {
@@ -1959,7 +1958,7 @@ export class StorageManager implements IStorageManager {
       );
       loadFailure = result.error;
       if (loadFailure !== undefined) {
-        this.logSyncLoadFailure(address.space, address.id, loadFailure);
+        this.#logSyncLoadFailure(address.space, address.id, loadFailure);
         this.retractDocPullKick(address.space, address.id, scope, identity);
       }
     } catch (error) {
@@ -2012,7 +2011,7 @@ export class StorageManager implements IStorageManager {
         // Same silent-collapse hazard as syncCell: a link-target pull that
         // resolves while carrying an error reads as an absent target.
         if (result.error !== undefined) {
-          this.logSyncLoadFailure(address.space, address.id, result.error);
+          this.#logSyncLoadFailure(address.space, address.id, result.error);
         }
         releaseLoad(result.error);
         return result;

--- a/packages/runner/src/traverse-recorder.ts
+++ b/packages/runner/src/traverse-recorder.ts
@@ -95,11 +95,7 @@ const DEFAULT_MAX_INVOCATIONS = 20_000;
 export class TraverseCaptureRecorder {
   #docs = new Map<string, FabricValue>();
 
-  /**
-   * TypeScript-private rather than a `#` name:
-   * `test/traverse-replay/profile.ts` drives this member directly.
-   */
-  private invocations: TraverseFixtureInvocation[] = [];
+  #invocations: TraverseFixtureInvocation[] = [];
 
   #selectors: SchemaPathSelector[] = [];
   #selectorIndex = new Map<string, number>();
@@ -110,8 +106,12 @@ export class TraverseCaptureRecorder {
   #memoIds = new WeakMap<object, number>();
   #nextMemoId = 0;
   #capHit = false;
+  #maxInvocations: number;
 
-  constructor(private maxInvocations = DEFAULT_MAX_INVOCATIONS) {}
+  /** Constructs an instance that records at most `maxInvocations`. */
+  constructor(maxInvocations = DEFAULT_MAX_INVOCATIONS) {
+    this.#maxInvocations = maxInvocations;
+  }
 
   #idFor(map: WeakMap<object, number>, obj: object, next: () => number) {
     let id = map.get(obj);
@@ -159,18 +159,18 @@ export class TraverseCaptureRecorder {
     context: { includeMeta: boolean },
     memo: object | undefined,
   ): void {
-    if (this.invocations.length >= this.maxInvocations) {
+    if (this.#invocations.length >= this.#maxInvocations) {
       if (!this.#capHit) {
         this.#capHit = true;
         logger.warn("capture", () => [
-          `invocation cap (${this.maxInvocations}) hit; later traversals ` +
+          `invocation cap (${this.#maxInvocations}) hit; later traversals ` +
           "are not recorded (docs still are)",
         ]);
       }
       return;
     }
     const { space, id, type, path, scope } = doc.address;
-    this.invocations.push({
+    this.#invocations.push({
       address: {
         space,
         id,
@@ -196,11 +196,8 @@ export class TraverseCaptureRecorder {
    * Capture the full doc behind `address` (value at path `[]`) once per doc.
    * Reads through the *unwrapped* tx with a scheduling-ignored meta so the
    * extra read does not perturb reactivity logs.
-   *
-   * TypeScript-private rather than a `#` name:
-   * `test/traverse-replay/profile.ts` drives this member directly.
    */
-  private captureDoc(
+  #captureDoc(
     tx: IExtendedStorageTransaction,
     address: IMemorySpaceAddress,
   ): void {
@@ -238,7 +235,7 @@ export class TraverseCaptureRecorder {
       get(target, prop) {
         if (prop === "read" || prop === "readOrThrow") {
           return (address: IMemorySpaceAddress, options?: IReadOptions) => {
-            recorder.captureDoc(target, address);
+            recorder.#captureDoc(target, address);
             // deno-lint-ignore no-explicit-any
             return (target as any)[prop](address, options);
           };
@@ -251,7 +248,7 @@ export class TraverseCaptureRecorder {
           ) => {
             const firstPath = paths[0];
             if (firstPath !== undefined) {
-              recorder.captureDoc(target, {
+              recorder.#captureDoc(target, {
                 ...address,
                 path: [...firstPath],
               });
@@ -279,7 +276,7 @@ export class TraverseCaptureRecorder {
       docs: Object.fromEntries(
         [...this.#docs.entries()].sort(([a], [b]) => a < b ? -1 : 1),
       ),
-      invocations: this.invocations,
+      invocations: this.#invocations,
     };
   }
 
@@ -292,7 +289,7 @@ export class TraverseCaptureRecorder {
     Deno.writeTextFileSync(path, JSON.stringify(fixture));
     logger.info("capture", () => [
       `wrote ${path}: ${this.#docs.size} docs, ` +
-      `${this.invocations.length} invocations, ` +
+      `${this.#invocations.length} invocations, ` +
       `${this.#selectors.length} selectors, ${this.#links.length} links`,
     ]);
   }


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Fable 5.1)

Five TypeScript-`private` members each carried a note naming a test that
drives them directly. A search of the tree says none does. The recorder's
tests read `invocations` off the fixture that `toFixture()` returns, not
off the recorder; the `test/traverse-replay/profile.ts` two notes cite no
longer exists; and nothing anywhere names `logSyncLoadFailure`,
`readPatternIdentity`, or the object creator's `tx`. So these are plain
`#` conversions with no accessor, the ordinary form
`docs/development/DEVELOPMENT.md` § Classes asks for.

## The five

- `PiecesController.#readPatternIdentity()` in `piece`.
- `TraverseCaptureRecorder`'s `#invocations` and `#captureDoc()`, and
  `#maxInvocations`, which was a constructor parameter property and is a
  field the constructor assigns.
- `StorageManager.#logSyncLoadFailure()`. Its doc comment had run into its
  note on one line, so the comment is written out whole.
- `TransformObjectCreator.#tx` in `schema.ts`.

## Review

Reviewed by a `cf-review` pass: approve, no findings. It verified the
no-reach claim member by member across the whole tree, and that every
script under `test/traverse-replay/` type-checks against the `#` names,
which none could if it reached them.

## Gates

`deno fmt --check`, `deno lint`, `deno task check`, the `runner` suite
(1363 passed, 0 failed), and the `piece` suite (56 passed, 0 failed).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6933?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


