### PR TITLE
refactor(runner): six classes keep their test-driven members as `#` names behind `accessForTestingOnly`

### DIFF
--- a/docs/development/DEVELOPMENT.md
+++ b/docs/development/DEVELOPMENT.md
@@ -259,7 +259,12 @@ exposes, and the name says the rest.
 - Each entry is typed as the class types the member. A stand-in the test
   supplies then declares itself where it is passed in — an `as` on the
   argument, or one small helper taking a `Partial<T>` — rather than on the
-  receiver, and a value the test reads back is what the class holds.
+  receiver, and a value the test reads back is what the class holds. A test
+  holding the value under an interface type narrows it to the class to reach
+  the getter, `tx as ExtendedStorageTransaction`: that is a cast to the real
+  type, which is what the accessor is typed by, and a different
+  implementation behind the interface would leave the read `undefined` and
+  the call throwing rather than passing.
 - It is a public getter, so it sits where the order above puts public getters,
   and first among them.
 - Prose names the member `Class.#member`.

--- a/docs/specs/content-addressed-action-identity.md
+++ b/docs/specs/content-addressed-action-identity.md
@@ -612,7 +612,7 @@ canary test compiling+resolving with `$implRef` stripped.
    the `implementationRef` writer removed the unbounded legacy registry's
    eviction insurance for new data, so E1 ships the replacement: a strong,
    session-lifetime, per-engine content-addressed implementation index
-   (`ExecutableRegistry.verifiedImplementationsByEntryRef`, populated by
+   (`ExecutableRegistry.#verifiedImplementationsByEntryRef`, populated by
    `Engine.#recordModuleProvenance`, surfaced as
    `Engine.getVerifiedImplementation`, consulted by `resolveByImplRef` after
    the bounded artifact index misses). Chosen over refcount pinning (piece

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -318,19 +318,11 @@ export class Engine extends EventTarget {
   #compilerInternals: CompilerInternals | undefined;
   #ctRuntime: Runtime;
 
-  /**
-   * TypeScript-private rather than a `#` name: `test/engine-ses.test.ts` drives
-   * this member directly.
-   */
-  private sesRuntime: SESRuntime | undefined;
+  #sesRuntime: SESRuntime | undefined;
 
   #nextEvalId = 0;
 
-  /**
-   * TypeScript-private rather than a `#` name: `test/engine-ses.test.ts` drives
-   * this member directly.
-   */
-  private readonly executableRegistry = new ExecutableRegistry();
+  readonly #executableRegistry = new ExecutableRegistry();
 
   readonly #consoleShim = createSafeConsoleGlobal(new Console(this));
   readonly #patternCoverageByGraph = new WeakMap<
@@ -347,6 +339,24 @@ export class Engine extends EventTarget {
     super();
     this.#options = options;
     this.#ctRuntime = ctRuntime;
+  }
+
+  /**
+   * The SES runtime, once one has been made, and the implementation index,
+   * which a test reads directly.
+   */
+  get accessForTestingOnly(): {
+    readonly executableRegistry: ExecutableRegistry;
+    readonly sesRuntime: SESRuntime | undefined;
+  } {
+    // deno-lint-ignore no-this-alias
+    const outerThis = this;
+    return {
+      executableRegistry: this.#executableRegistry,
+      get sesRuntime() {
+        return outerThis.#sesRuntime;
+      },
+    };
   }
 
   async initializeRuntime(): Promise<RuntimeInternals> {
@@ -1613,7 +1623,7 @@ export class Engine extends EventTarget {
       // The strong content-addressed implementation index — the resolution
       // (and eviction-insurance) backing for serialized `$implRef`s; see
       // `ExecutableRegistry.registerVerifiedImplementation`.
-      this.executableRegistry.registerVerifiedImplementation(
+      this.#executableRegistry.registerVerifiedImplementation(
         identity,
         symbol,
         implementation as HarnessedFunction,
@@ -1771,7 +1781,7 @@ export class Engine extends EventTarget {
     // be set up.
     // Some tests invoke values outside of this SES runtime, so just
     // execute and return if runtime internals have not been initialized.
-    if (!this.#runtimeInternals && !this.sesRuntime) {
+    if (!this.#runtimeInternals && !this.#sesRuntime) {
       return fn();
     }
     return this.#getSESRuntime().exec(fn);
@@ -1785,14 +1795,14 @@ export class Engine extends EventTarget {
     identity: string,
     symbol: string,
   ): HarnessedFunction | undefined {
-    return this.executableRegistry.getVerifiedImplementation(identity, symbol);
+    return this.#executableRegistry.getVerifiedImplementation(identity, symbol);
   }
 
   unsafeTrustHostValue(
     value: unknown,
     options: UnsafeHostTrustOptions,
   ): void {
-    this.executableRegistry.trustHostValue(value, options);
+    this.#executableRegistry.trustHostValue(value, options);
   }
 
   // Parse an error stack trace, mapping all positions back to original sources.
@@ -1837,20 +1847,20 @@ export class Engine extends EventTarget {
    * Clears accumulated source maps and other state to prevent memory leaks.
    */
   dispose(): void {
-    if (this.sesRuntime) {
-      this.sesRuntime.clear();
+    if (this.#sesRuntime) {
+      this.#sesRuntime.clear();
     }
-    this.sesRuntime = undefined;
+    this.#sesRuntime = undefined;
     this.#runtimeInternals = undefined;
     this.#compilerInternals = undefined;
     this.#nextEvalId = 0;
-    this.executableRegistry.clear();
+    this.#executableRegistry.clear();
   }
 
   #getSESRuntime(): SESRuntime {
-    if (!this.sesRuntime) {
+    if (!this.#sesRuntime) {
       ensureSESLockdown();
-      this.sesRuntime = new SESRuntime({
+      this.#sesRuntime = new SESRuntime({
         globals: createModuleCompartmentGlobals({
           console: this.#consoleShim,
         }),
@@ -1858,7 +1868,7 @@ export class Engine extends EventTarget {
         lockdown: false,
       });
     }
-    return this.sesRuntime;
+    return this.#sesRuntime;
   }
 }
 

--- a/packages/runner/src/harness/executable-registry.ts
+++ b/packages/runner/src/harness/executable-registry.ts
@@ -23,9 +23,7 @@ export class ExecutableRegistry {
   // ref), so resolution must never lose an implementation whose module
   // evaluated this session. Retention is bounded by the set of DISTINCT
   // verified implementations evaluated per session.
-  // TypeScript-private rather than a `#` name: `test/cfc-nonexported-binding-identity.test.ts` drives
-  // this member directly.
-  private readonly verifiedImplementationsByEntryRef = new Map<
+  readonly #verifiedImplementationsByEntryRef = new Map<
     string,
     Map<string, HarnessedFunction>
   >();
@@ -39,8 +37,21 @@ export class ExecutableRegistry {
   #nextHostModuleId = 0;
   readonly #hostRegisteredFunctions = new WeakSet<HarnessedFunction>();
 
+  /** The implementation index, which a test reads directly. */
+  get accessForTestingOnly(): {
+    readonly verifiedImplementationsByEntryRef: Map<
+      string,
+      Map<string, HarnessedFunction>
+    >;
+  } {
+    return {
+      verifiedImplementationsByEntryRef:
+        this.#verifiedImplementationsByEntryRef,
+    };
+  }
+
   clear(): void {
-    this.verifiedImplementationsByEntryRef.clear();
+    this.#verifiedImplementationsByEntryRef.clear();
     this.#nextHostModuleId = 0;
     // `#hostRegisteredFunctions` is a WeakSet (uniterable); entries age out
     // with their functions. Stale membership after clear() is harmless: it
@@ -60,10 +71,10 @@ export class ExecutableRegistry {
     symbol: string,
     implementation: HarnessedFunction,
   ): void {
-    let bucket = this.verifiedImplementationsByEntryRef.get(identity);
+    let bucket = this.#verifiedImplementationsByEntryRef.get(identity);
     if (!bucket) {
       bucket = new Map();
-      this.verifiedImplementationsByEntryRef.set(identity, bucket);
+      this.#verifiedImplementationsByEntryRef.set(identity, bucket);
     }
     bucket.set(symbol, implementation);
   }
@@ -72,7 +83,7 @@ export class ExecutableRegistry {
     identity: string,
     symbol: string,
   ): HarnessedFunction | undefined {
-    return this.verifiedImplementationsByEntryRef.get(identity)?.get(symbol);
+    return this.#verifiedImplementationsByEntryRef.get(identity)?.get(symbol);
   }
 
   /**

--- a/packages/runner/src/sandbox/ses-runtime.ts
+++ b/packages/runner/src/sandbox/ses-runtime.ts
@@ -92,16 +92,19 @@ class SESInternals {
 export class SESRuntime extends EventTarget {
   #internals: SESInternals;
 
-  /**
-   * TypeScript-private rather than a `#` name: `test/runtime.test.ts` drives
-   * this member directly.
-   */
-  private callbackEvaluator: SESCallbackEvaluator;
+  readonly #callbackEvaluator: SESCallbackEvaluator;
 
   constructor(options: SESRuntimeOptions = {}) {
     super();
     this.#internals = new SESInternals(options);
-    this.callbackEvaluator = new SESCallbackEvaluator(options);
+    this.#callbackEvaluator = new SESCallbackEvaluator(options);
+  }
+
+  /** The callback evaluator, which a test reads directly. */
+  get accessForTestingOnly(): {
+    readonly callbackEvaluator: SESCallbackEvaluator;
+  } {
+    return { callbackEvaluator: this.#callbackEvaluator };
   }
 
   /**
@@ -153,12 +156,12 @@ export class SESRuntime extends EventTarget {
   }
 
   evaluateCallback(source: string): unknown {
-    return this.callbackEvaluator.evaluate(source);
+    return this.#callbackEvaluator.evaluate(source);
   }
 
   clear(): void {
     this.#internals.clear();
-    this.callbackEvaluator.clear();
+    this.#callbackEvaluator.clear();
   }
 }
 
@@ -293,16 +296,19 @@ function createCompartment(globals: Record<string, unknown>) {
 class SESCallbackEvaluator {
   #callbackCompartment: SESCompartmentLike | undefined;
 
-  /**
-   * TypeScript-private rather than a `#` name: `test/engine-ses.test.ts` drives
-   * this member directly.
-   */
-  private callbackCreatorCache = new Map<string, () => unknown>();
+  readonly #callbackCreatorCache = new Map<string, () => unknown>();
 
   #options: SESRuntimeOptions;
 
   constructor(options: SESRuntimeOptions = {}) {
     this.#options = options;
+  }
+
+  /** The callback-creator cache, which a test reads directly. */
+  get accessForTestingOnly(): {
+    readonly callbackCreatorCache: Map<string, () => unknown>;
+  } {
+    return { callbackCreatorCache: this.#callbackCreatorCache };
   }
 
   evaluate(source: string): unknown {
@@ -323,12 +329,12 @@ class SESCallbackEvaluator {
   }
 
   clear(): void {
-    this.callbackCreatorCache.clear();
+    this.#callbackCreatorCache.clear();
     this.#callbackCompartment = undefined;
   }
 
   #getCachedCallbackCreator(source: string): () => unknown {
-    const cached = this.callbackCreatorCache.get(source);
+    const cached = this.#callbackCreatorCache.get(source);
     if (cached) {
       return cached;
     }
@@ -339,7 +345,7 @@ class SESCallbackEvaluator {
       throw new Error("Callback source must evaluate to a function creator");
     }
 
-    this.callbackCreatorCache.set(source, creator as () => unknown);
+    this.#callbackCreatorCache.set(source, creator as () => unknown);
     return creator as () => unknown;
   }
 

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -501,6 +501,18 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     this.#cfcInstrumentation = cfcInstrumentation;
   }
 
+  /**
+   * The prepared-digest input this transaction would hand to verification,
+   * which a test reads directly to pin what it carries.
+   */
+  get accessForTestingOnly(): {
+    buildPreparedDigestInput(): PreparedDigestInput;
+  } {
+    return {
+      buildPreparedDigestInput: () => this.#buildPreparedDigestInput(),
+    };
+  }
+
   /** Stage C tuning T1: any transaction activity that could change the
    * flow-label probe's answer moves the epoch. */
   #noteCfcActivity(): void {
@@ -1766,11 +1778,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     return this.#verdict.promise;
   }
 
-  /**
-   * TypeScript-private rather than a `#` name: `test/cfc-boundary.test.ts`
-   * drives this member directly.
-   */
-  private buildPreparedDigestInput(): PreparedDigestInput {
+  #buildPreparedDigestInput(): PreparedDigestInput {
     // Each pushed record is deepFrozen so that every CfcAddress (and every
     // path inside one) that flows into the digest input is immutable from
     // the moment of construction. This makes the records safe to use as
@@ -2162,7 +2170,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
       this.#cfcState.diagnostics.push(...reasons.map(plainReason));
       return "";
     }
-    const preparedInput = this.buildPreparedDigestInput();
+    const preparedInput = this.#buildPreparedDigestInput();
     const digest = preparedDigestFor(preparedInput);
     this.#cfcState.prepare = {
       status: "prepared",
@@ -2813,7 +2821,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
 
       if (this.#cfcState.prepare.status === "prepared") {
         const currentDigest = preparedDigestFor(
-          this.buildPreparedDigestInput(),
+          this.#buildPreparedDigestInput(),
         );
         if (currentDigest !== this.#cfcState.prepare.digest) {
           this.invalidateCfc("prepared-digest-mismatch");

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -1205,11 +1205,16 @@ export class CompoundCycleTracker<
   Value = unknown,
 > {
   // partialKey (identity) → Map<interned extraKey hashString, Value?>
-  // TypeScript-private rather than a `#` name: `test/traverse.test.ts` drives
-  // this member directly.
-  private partial: Map<EqualKey, Map<string, Value | undefined>>;
-  constructor() {
-    this.partial = new Map();
+  readonly #partial = new Map<EqualKey, Map<string, Value | undefined>>();
+
+  /**
+   * The partial-key table, which a test drives directly to watch entries
+   * come and go.
+   */
+  get accessForTestingOnly(): {
+    readonly partial: Map<EqualKey, Map<string, Value | undefined>>;
+  } {
+    return { partial: this.#partial };
   }
 
   include(
@@ -1218,10 +1223,10 @@ export class CompoundCycleTracker<
     value?: Value,
     _context?: unknown,
   ): Disposable | null {
-    let existing = this.partial.get(partialKey);
+    let existing = this.#partial.get(partialKey);
     if (existing === undefined) {
       existing = new Map();
-      this.partial.set(partialKey, existing);
+      this.#partial.set(partialKey, existing);
     }
     const hash = internSchemaAsTaggedHashString(extraKey ?? true);
     if (existing.has(hash)) {
@@ -1230,11 +1235,11 @@ export class CompoundCycleTracker<
     existing.set(hash, value);
     return {
       [Symbol.dispose]: () => {
-        const entries = this.partial.get(partialKey);
+        const entries = this.#partial.get(partialKey);
         if (entries) {
           entries.delete(hash);
           if (entries.size === 0) {
-            this.partial.delete(partialKey);
+            this.#partial.delete(partialKey);
           }
         }
       },
@@ -1243,7 +1248,7 @@ export class CompoundCycleTracker<
 
   // After a failed include (that returns null), we can use getExisting to find the registered value
   getExisting(partialKey: EqualKey, extraKey: ExtraKey): Value | undefined {
-    const existing = this.partial.get(partialKey);
+    const existing = this.#partial.get(partialKey);
     if (existing === undefined) {
       return undefined;
     }

--- a/packages/runner/test/cfc-boundary.test.ts
+++ b/packages/runner/test/cfc-boundary.test.ts
@@ -43,6 +43,7 @@ import { ignoreReadForScheduling } from "../src/scheduler.ts";
 import { LINK_V1_TAG } from "../src/sigil-types.ts";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import { internalVerifierRead } from "../src/storage/reactivity-log.ts";
+import type { ExtendedStorageTransaction } from "../src/storage/extended-storage-transaction.ts";
 import * as V2Storage from "../src/storage/v2.ts";
 import {
   TEST_MEMORY_SERVER_AUTH,
@@ -1729,11 +1730,8 @@ describe("ExtendedStorageTransaction CFC gate", () => {
         }),
       );
 
-      const digestInput = (
-        metadataTx as unknown as {
-          buildPreparedDigestInput(): { consumedReads: unknown[] };
-        }
-      ).buildPreparedDigestInput();
+      const digestInput = (metadataTx as ExtendedStorageTransaction)
+        .accessForTestingOnly.buildPreparedDigestInput();
       expect(digestInput.consumedReads).toEqual([]);
       expect(metadataTx.getCfcState().relevant).toBe(false);
 
@@ -2013,20 +2011,8 @@ describe("ExtendedStorageTransaction CFC gate", () => {
       cell.key("secret").set("same");
       expect(tx.getCfcState().relevant).toBe(true);
 
-      const digestInput = (
-        tx as unknown as {
-          buildPreparedDigestInput(): {
-            attemptedWrites: Array<{
-              space: string;
-              scope: "space";
-              id: string;
-              type: string;
-              path: string[];
-            }>;
-            writes: Array<unknown>;
-          };
-        }
-      ).buildPreparedDigestInput();
+      const digestInput = (tx as ExtendedStorageTransaction)
+        .accessForTestingOnly.buildPreparedDigestInput();
       expect(digestInput.attemptedWrites).toContainEqual({
         space: signer.did(),
         scope: "space",

--- a/packages/runner/test/cfc-nonexported-binding-identity.test.ts
+++ b/packages/runner/test/cfc-nonexported-binding-identity.test.ts
@@ -62,11 +62,8 @@ function recordedBindingPaths(rt: Runtime): string[][] {
   // The binding identity lives on each registered function's content-addressed
   // provenance (the former `verifiedBindingMetadata` map is gone — PR E2);
   // enumerate the engine's implementation index to reach the registered fns.
-  const reg = (rt.harness as any).executableRegistry;
-  const byRef = reg.verifiedImplementationsByEntryRef as Map<
-    string,
-    Map<string, unknown>
-  >;
+  const byRef = rt.harness.accessForTestingOnly.executableRegistry
+    .accessForTestingOnly.verifiedImplementationsByEntryRef;
   const out: string[][] = [];
   for (const bucket of byRef.values()) {
     for (const fn of bucket.values()) {

--- a/packages/runner/test/cfc-prepare-bypass.test.ts
+++ b/packages/runner/test/cfc-prepare-bypass.test.ts
@@ -2,6 +2,7 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "../src/storage/cache.deno.ts";
+import type { ExtendedStorageTransaction } from "../src/storage/extended-storage-transaction.ts";
 import { Runtime } from "../src/runtime.ts";
 import type { JSONSchema } from "../src/builder/types.ts";
 
@@ -64,8 +65,8 @@ describe("CFC prepareCfc verification bypass", () => {
       // public transaction surfaces, there is no way to feed it to prepareCfc:
       // the parameter was removed (audit S2) so verification always runs. Pin
       // that prepareCfc accepts no argument and still rejects the violation.
-      // deno-lint-ignore no-explicit-any
-      const attackerInput = (tx as any).buildPreparedDigestInput?.();
+      const attackerInput = (tx as ExtendedStorageTransaction)
+        .accessForTestingOnly.buildPreparedDigestInput();
       expect(attackerInput).toBeDefined();
       // deno-lint-ignore no-explicit-any
       expect(() => (tx as any).prepareCfc(attackerInput)).not.toThrow();

--- a/packages/runner/test/engine-ses.test.ts
+++ b/packages/runner/test/engine-ses.test.ts
@@ -679,25 +679,15 @@ describe("Engine in SES mode", () => {
 
     expect(next(1)).toBe(2);
     expect(
-      (engine as unknown as {
-        sesRuntime: {
-          callbackEvaluator: {
-            callbackCreatorCache: Map<string, () => unknown>;
-          };
-        };
-      }).sesRuntime.callbackEvaluator.callbackCreatorCache.size,
+      engine.accessForTestingOnly.sesRuntime!.accessForTestingOnly
+        .callbackEvaluator.accessForTestingOnly.callbackCreatorCache.size,
     ).toBe(1);
 
     engine.dispose();
 
     expect(
-      (engine as unknown as {
-        sesRuntime?: {
-          callbackEvaluator: {
-            callbackCreatorCache: Map<string, () => unknown>;
-          };
-        };
-      }).sesRuntime?.callbackEvaluator.callbackCreatorCache.size ?? 0,
+      engine.accessForTestingOnly.sesRuntime?.accessForTestingOnly
+        .callbackEvaluator.accessForTestingOnly.callbackCreatorCache.size ?? 0,
     ).toBe(0);
   });
 });

--- a/packages/runner/test/engine-verified-functions.test.ts
+++ b/packages/runner/test/engine-verified-functions.test.ts
@@ -31,8 +31,7 @@ describe("Engine verified implementation index", () => {
   });
 
   function getExecutableRegistry() {
-    // deno-lint-ignore no-explicit-any
-    return (engine as any).executableRegistry;
+    return engine.accessForTestingOnly.executableRegistry;
   }
 
   it("admits registered implementations by { identity, symbol }", () => {

--- a/packages/runner/test/runtime.test.ts
+++ b/packages/runner/test/runtime.test.ts
@@ -20,17 +20,15 @@ describe("SESRuntime", () => {
 
     expect(next(1)).toBe(2);
     expect(
-      (runtime as unknown as {
-        callbackEvaluator: { callbackCreatorCache: Map<string, () => unknown> };
-      }).callbackEvaluator.callbackCreatorCache.size,
+      runtime.accessForTestingOnly.callbackEvaluator.accessForTestingOnly
+        .callbackCreatorCache.size,
     ).toBe(1);
 
     runtime.clear();
 
     expect(
-      (runtime as unknown as {
-        callbackEvaluator: { callbackCreatorCache: Map<string, () => unknown> };
-      }).callbackEvaluator.callbackCreatorCache.size,
+      runtime.accessForTestingOnly.callbackEvaluator.accessForTestingOnly
+        .callbackCreatorCache.size,
     ).toBe(0);
   });
 });

--- a/packages/runner/test/security.test.ts
+++ b/packages/runner/test/security.test.ts
@@ -327,11 +327,8 @@ describe("SES security regressions", () => {
 
     const { main } = await engine.compileAndEvaluateModules(program);
     const countVerifiedFunctions = () =>
-      (engine as unknown as {
-        executableRegistry: {
-          verifiedImplementationsByEntryRef: Map<string, Map<string, unknown>>;
-        };
-      }).executableRegistry.verifiedImplementationsByEntryRef.values()
+      engine.accessForTestingOnly.executableRegistry.accessForTestingOnly
+        .verifiedImplementationsByEntryRef.values()
         .reduce((n, bucket) => n + bucket.size, 0);
 
     // The nested computation (now the module-scope `__cfLift_N`) and the

--- a/packages/runner/test/traverse.test.ts
+++ b/packages/runner/test/traverse.test.ts
@@ -1723,7 +1723,7 @@ describe("CompoundCycleTracker cleanup", () => {
     const disposable = tracker.include(key, true);
     expect(disposable).not.toBeNull();
     disposable![Symbol.dispose]();
-    expect((tracker as any).partial.size).toBe(0);
+    expect(tracker.accessForTestingOnly.partial.size).toBe(0);
   });
 
   it("retains partial-key entries while sibling entries are live", () => {
@@ -1739,11 +1739,11 @@ describe("CompoundCycleTracker cleanup", () => {
     // Disposing only A must not remove the outer `partial` entry —
     // B's live entry still keys on the same partialKey.
     dispA![Symbol.dispose]();
-    expect((tracker as any).partial.size).toBe(1);
-    expect((tracker as any).partial.get(key)!.size).toBe(1);
+    expect(tracker.accessForTestingOnly.partial.size).toBe(1);
+    expect(tracker.accessForTestingOnly.partial.get(key)!.size).toBe(1);
     // Disposing B then cleans up.
     dispB![Symbol.dispose]();
-    expect((tracker as any).partial.size).toBe(0);
+    expect(tracker.accessForTestingOnly.partial.size).toBe(0);
   });
 });
 


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Fable 5.1)

Six `runner` classes each held one or two members as TypeScript
`private` under a note naming the test that reaches them. They are `#`
names now, behind an `accessForTestingOnly` getter per class, as
`docs/development/DEVELOPMENT.md` § Classes prescribes.

## The six accessors

- `ExecutableRegistry`: the implementation index, a `readonly` plain
  property.
- `Engine`: the SES runtime, a `readonly` getter since `dispose()` clears
  it, and the implementation index, a plain property.
- `SESRuntime`: the callback evaluator, a plain property. Its type is the
  module-internal `SESCallbackEvaluator`, which the type-check and lint
  both accept in a public getter's inline return type.
- `SESCallbackEvaluator`: the creator cache, a plain property.
- `CompoundCycleTracker`: the partial-key table, a plain property. Its
  constructor only assigned that map, so the field is initialized inline
  and the constructor is gone.
- `ExtendedStorageTransaction`: the prepared-digest builder, a forwarding
  arrow.

## What the tests do now

Eight test files drop their `as unknown as {...}` and `as any` casts. Two
shapes are new to this series:

- A reach through two classes chains their accessors, so the SES tests
  read `engine.accessForTestingOnly.sesRuntime!.accessForTestingOnly` and
  on down. Verbose, and honest about every boundary it crosses.
- The transaction tests hold what `runtime.edit()` returns, which is the
  `IExtendedStorageTransaction` interface, and the accessor lives on the
  class. They narrow with `tx as ExtendedStorageTransaction`: a cast to
  the real type, not to a hand-written shape, and the accessor is typed by
  the class from there. `cfc-prepare-bypass.test.ts` needed this most: its
  `(tx as any).buildPreparedDigestInput?.()` would have read `undefined`
  under a `#` name and failed its own `toBeDefined()`.

`docs/specs/content-addressed-action-identity.md` names the index as
`ExecutableRegistry.#verifiedImplementationsByEntryRef`.

## Review

Reviewed by a `cf-review` pass: approve, no blocking findings. It confirmed
the three shapes above and named a gap in the guideline, which this PR
now closes: a sentence in `DEVELOPMENT.md` § Classes on narrowing a value
held under an interface to its class to reach the getter.

## Gates

`deno fmt --check`, `deno lint`, `deno task check`, and the `runner` suite
(1363 passed, 0 failed). No other package names a converted member.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6934?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


