### PR TITLE
runner: a caller may supply the genesis ACL a fresh space is born with

### DIFF
--- a/docs/development/CONFIGURATION.md
+++ b/docs/development/CONFIGURATION.md
@@ -167,7 +167,7 @@ registered beside the space key (`registerSpaceIdentity(identity,
 { genesisAcl })`), else the fallback `{ [activeUser]: "OWNER", "*": "WRITE" }`,
 so new non-home spaces that asked for nothing are public read/write until ACL
 management has a UI. Home bootstrap remains owner-only. The wildcard is a
-default, not a fixture: a caller can supply a sealed document at genesis, and
+default, not a fixture: a caller can supply its own document at genesis, and
 the space's owner can narrow it afterwards with `cf acl remove ANYONE` (see
 [tutorial chapter 10](../tutorial/10-identity-and-security.md#reading-and-changing-a-spaces-acl)).
 Whatever writes the ACL must send it as a single whole-document replacement —

--- a/docs/development/CONFIGURATION.md
+++ b/docs/development/CONFIGURATION.md
@@ -162,11 +162,13 @@ configured service DID writes a valid ACL with a concrete OWNER. A populated
 space that has never had an ACL remains authenticated-public READ/WRITE as a
 temporary pre-launch compatibility rule; public access never includes OWNER.
 Retracted, malformed, and ownerless ACLs fail closed.
-Normal fresh named-space bootstrap currently creates
-`{ [activeUser]: "OWNER", "*": "WRITE" }` so new non-home spaces are public
-read/write until ACL management has a UI. Home bootstrap remains owner-only.
-The wildcard is a default, not a fixture: the space's owner can narrow it today
-with `cf acl remove ANYONE` (see
+Normal fresh named-space bootstrap writes the genesis document the caller
+registered beside the space key (`registerSpaceIdentity(identity,
+{ genesisAcl })`), else the fallback `{ [activeUser]: "OWNER", "*": "WRITE" }`,
+so new non-home spaces that asked for nothing are public read/write until ACL
+management has a UI. Home bootstrap remains owner-only. The wildcard is a
+default, not a fixture: a caller can supply a sealed document at genesis, and
+the space's owner can narrow it afterwards with `cf acl remove ANYONE` (see
 [tutorial chapter 10](../tutorial/10-identity-and-security.md#reading-and-changing-a-spaces-acl)).
 Whatever writes the ACL must send it as a single whole-document replacement —
 the server's admission rules for ACL commits are INV-12 and INV-13 in

--- a/docs/features/home-space-internals.md
+++ b/docs/features/home-space-internals.md
@@ -31,5 +31,6 @@ not shared with bootstrap work.
 Unlike named-space bootstrap, the home path also claims a populated legacy
 space with no ACL. `session.open` remains read-only; the claim is an ordinary,
 conflict-checked ACL transaction. See `packages/runner/src/storage/v2.ts`.
-The home ACL is owner-only. Fresh named spaces use the rollout default
+The home ACL is owner-only. Fresh named spaces are born with the genesis
+document registered beside their space key, else the rollout default
 `{ [activeUser]: "OWNER", "*": "WRITE" }` until ACL management has a UI.

--- a/docs/features/self-serve-ingest-channels.md
+++ b/docs/features/self-serve-ingest-channels.md
@@ -51,7 +51,7 @@ target space; server reads it back.
 **It proves the wrong predicate.** The round-trip demonstrates *write*
 capability. Non-home spaces genesis as the document the caller registered
 beside the space key, else the fallback
-`{ [activeUser]: "OWNER", "*": "WRITE" }` (`packages/runner/src/storage/v2.ts:1440-1443`)
+`{ [activeUser]: "OWNER", "*": "WRITE" }` (`packages/runner/src/storage/v2.ts:1564-1566`)
 — and the ingest path registers none, so it gets the fallback — described
 upstream as "the rollout default until ACL management has a UI"
 (`docs/specs/memory-v2/04-protocol.md:742-748`). So on a genesis'd data space,
@@ -86,7 +86,7 @@ future work on its own track." The server cannot ask "was this written by the
 space's owner?"
 
 *Correction worth recording:* a user's **home/identity** space genesises as
-`{ [signer]: "OWNER" }` with **no wildcard** (`v2.ts:1440-1443`), so Option B is
+`{ [signer]: "OWNER" }` with **no wildcard** (`v2.ts:1564-1566`), so Option B is
 sound *for home spaces specifically*. It is unsound for the named data spaces
 the location beacon actually targets. Option B becomes generally sound exactly
 when the wildcard goes away — but a create primitive whose safety depends on a

--- a/docs/features/self-serve-ingest-channels.md
+++ b/docs/features/self-serve-ingest-channels.md
@@ -51,7 +51,9 @@ target space; server reads it back.
 **It proves the wrong predicate.** The round-trip demonstrates *write*
 capability. Non-home spaces genesis as the document the caller registered
 beside the space key, else the fallback
-`{ [activeUser]: "OWNER", "*": "WRITE" }` (`packages/runner/src/storage/v2.ts:1564-1566`)
+`{ [activeUser]: "OWNER", "*": "WRITE" }` (`packages/runner/src/storage/v2.ts`, the
+`bootstrapAcl` selection in `#createInitializedSession`; the fallback shape is
+`defaultGenesisAcl` over `DEFAULT_GENESIS_GRANTS`)
 — and the ingest path registers none, so it gets the fallback — described
 upstream as "the rollout default until ACL management has a UI"
 (`docs/specs/memory-v2/04-protocol.md:742-748`). So on a genesis'd data space,
@@ -86,7 +88,8 @@ future work on its own track." The server cannot ask "was this written by the
 space's owner?"
 
 *Correction worth recording:* a user's **home/identity** space genesises as
-`{ [signer]: "OWNER" }` with **no wildcard** (`v2.ts:1564-1566`), so Option B is
+`{ [signer]: "OWNER" }` with **no wildcard** (the home arm of that same
+`bootstrapAcl` selection), so Option B is
 sound *for home spaces specifically*. It is unsound for the named data spaces
 the location beacon actually targets. Option B becomes generally sound exactly
 when the wildcard goes away — but a create primitive whose safety depends on a

--- a/docs/features/self-serve-ingest-channels.md
+++ b/docs/features/self-serve-ingest-channels.md
@@ -49,9 +49,11 @@ Server issues a nonce + cell cause; caller writes it into that cell in the
 target space; server reads it back.
 
 **It proves the wrong predicate.** The round-trip demonstrates *write*
-capability. Non-home spaces genesis as
-`{ [activeUser]: "OWNER", "*": "WRITE" }` (`packages/runner/src/storage/v2.ts:1179-1181`),
-described upstream as "the rollout default until ACL management has a UI"
+capability. Non-home spaces genesis as the document the caller registered
+beside the space key, else the fallback
+`{ [activeUser]: "OWNER", "*": "WRITE" }` (`packages/runner/src/storage/v2.ts:1440-1443`)
+— and the ingest path registers none, so it gets the fallback — described
+upstream as "the rollout default until ACL management has a UI"
 (`docs/specs/memory-v2/04-protocol.md:742-748`). So on a genesis'd data space,
 *every* authenticated principal — anyone who can generate a keypair — already
 holds WRITE and passes the nonce challenge. The ceremony authorizes precisely
@@ -84,7 +86,7 @@ future work on its own track." The server cannot ask "was this written by the
 space's owner?"
 
 *Correction worth recording:* a user's **home/identity** space genesises as
-`{ [signer]: "OWNER" }` with **no wildcard** (`v2.ts:1179-1181`), so Option B is
+`{ [signer]: "OWNER" }` with **no wildcard** (`v2.ts:1440-1443`), so Option B is
 sound *for home spaces specifically*. It is unsound for the named data spaces
 the location beacon actually targets. Option B becomes generally sound exactly
 when the wildcard goes away — but a create primitive whose safety depends on a

--- a/docs/specs/memory-v2/04-protocol.md
+++ b/docs/specs/memory-v2/04-protocol.md
@@ -930,8 +930,9 @@ mounts the durable session as the active user. The document is whichever the
 caller registered beside the space key
 (`registerSpaceIdentity(identity, { genesisAcl })` — the space is then born
 with exactly that ACL, this admission check is the only validation it
-receives, and an open of a space that already exists proceeds only if it
-carries exactly that document, else is refused), else the fallback
+receives, and an open of a space that already exists proceeds only if it is
+owned exactly as that document says — grants below OWNER are the owner's to
+evolve — else is refused), else the fallback
 `{ [activeUser]: "OWNER", "*": "WRITE" }`. The wildcard grant is the rollout
 default until ACL management has a UI, spelled once as the runner's
 `DEFAULT_GENESIS_GRANTS`; the active user remains the concrete owner who can

--- a/docs/specs/memory-v2/04-protocol.md
+++ b/docs/specs/memory-v2/04-protocol.md
@@ -929,8 +929,9 @@ document against a confirmed absent ACL, closes that bootstrap session, and
 mounts the durable session as the active user. The document is whichever the
 caller registered beside the space key
 (`registerSpaceIdentity(identity, { genesisAcl })` — the space is then born
-with exactly that ACL, and this admission check is the
-only validation it receives), else the fallback
+with exactly that ACL, this admission check is the only validation it
+receives, and an open of a space that already exists proceeds only if it
+carries exactly that document, else is refused), else the fallback
 `{ [activeUser]: "OWNER", "*": "WRITE" }`. The wildcard grant is the rollout
 default until ACL management has a UI, spelled once as the runner's
 `DEFAULT_GENESIS_GRANTS`; the active user remains the concrete owner who can

--- a/docs/specs/memory-v2/04-protocol.md
+++ b/docs/specs/memory-v2/04-protocol.md
@@ -929,7 +929,7 @@ document against a confirmed absent ACL, closes that bootstrap session, and
 mounts the durable session as the active user. The document is whichever the
 caller registered beside the space key
 (`registerSpaceIdentity(identity, { genesisAcl })` — the space is then born
-with exactly that ACL, sealed by construction, and this admission check is the
+with exactly that ACL, and this admission check is the
 only validation it receives), else the fallback
 `{ [activeUser]: "OWNER", "*": "WRITE" }`. The wildcard grant is the rollout
 default until ACL management has a UI, spelled once as the runner's

--- a/docs/specs/memory-v2/04-protocol.md
+++ b/docs/specs/memory-v2/04-protocol.md
@@ -924,12 +924,18 @@ and is refused with "ACL mutations must replace the space-scoped ACL document";
 it must address the whole document instead.
 
 Genesis remains an explicit transaction. For a fresh named space, the storage
-manager briefly authenticates as the derived space identity, writes
-`{ [activeUser]: "OWNER", "*": "WRITE" }` against a confirmed absent ACL,
-closes that bootstrap session, and mounts the durable session as the active
-user. The wildcard grant is the rollout default until ACL management has a UI;
-the active user remains the concrete owner who can later narrow it. This
-preserves user/session-scoped partitioning. When the active identity already is
+manager briefly authenticates as the derived space identity, writes the genesis
+document against a confirmed absent ACL, closes that bootstrap session, and
+mounts the durable session as the active user. The document is whichever the
+caller registered beside the space key
+(`registerSpaceIdentity(identity, { genesisAcl })` — the space is then born
+with exactly that ACL, sealed by construction, and this admission check is the
+only validation it receives), else the fallback
+`{ [activeUser]: "OWNER", "*": "WRITE" }`. The wildcard grant is the rollout
+default until ACL management has a UI, spelled once as the runner's
+`DEFAULT_GENESIS_GRANTS`; the active user remains the concrete owner who can
+later narrow it. This preserves user/session-scoped partitioning. When the
+active identity already is
 the space DID (the home space), the same flow instead writes
 `{ [space]: "OWNER" }`; that narrow path also privatizes a populated legacy
 home with no ACL. Populated named spaces with no ACL remain public under the

--- a/docs/specs/memory-v2/09-invariants.md
+++ b/docs/specs/memory-v2/09-invariants.md
@@ -488,7 +488,9 @@ Checked by: example-based server tests only.
 or write a new space", "the space identity initializes a private space",
 "service DIDs have implicit OWNER and do not claim spaces", "acl observe:
 fresh-space genesis remains a hard invariant", "direct writes cannot create or
-mutate ACL state", "a retracted ACL fails closed instead of becoming public".
+mutate ACL state", "a retracted ACL fails closed instead of becoming public",
+"a genesis ACL without a concrete OWNER is refused and the space stays
+uninitialized".
 
 ### INV-14 — Reconnect convergence
 

--- a/docs/specs/memory-v2/09-invariants.md
+++ b/docs/specs/memory-v2/09-invariants.md
@@ -444,7 +444,7 @@ with could not be removed. Over-acceptance lets the ACL document reach a state
 no admission check ever validated.
 
 Checked by: example-based server tests only — no oracle, TLA+, or differential
-coverage. `packages/memory/test/v2-server-acl-test.ts`: "ACL mutations must
+coverage. `packages/memory/test/v2-server-acl.test.ts`: "ACL mutations must
 preserve a concrete owner" (rejects `delete`, `patch`, `scope: "user"`, and
 empty / wildcard-only-owner / downgraded-owner / invalid-capability values) and
 "ACL mutations are default-branch ACL-only commits" (rejects a non-default
@@ -484,7 +484,7 @@ direct write to the ACL document, so genesis cannot be performed off-protocol.
 Soundness direction: none — exact.
 
 Checked by: example-based server tests only.
-`packages/memory/test/v2-server-acl-test.ts`: "an ordinary opener cannot claim
+`packages/memory/test/v2-server-acl.test.ts`: "an ordinary opener cannot claim
 or write a new space", "the space identity initializes a private space",
 "service DIDs have implicit OWNER and do not claim spaces", "acl observe:
 fresh-space genesis remains a hard invariant", "direct writes cannot create or

--- a/docs/tutorial/10-identity-and-security.md
+++ b/docs/tutorial/10-identity-and-security.md
@@ -97,7 +97,8 @@ valid ACL with at least one concrete OWNER. Named-space bootstrap uses a
 temporary space-identity session to write the genesis ACL, then remounts as
 that user: the document a caller registered beside the space key
 (`registerSpaceIdentity(identity, { genesisAcl })`, so a space can be born
-sealed), else the rollout default of the active user as OWNER plus `"*"`
+with exactly that ACL), else the rollout default of the active user as OWNER
+plus `"*"`
 WRITE. Home spaces use the
 same identity for both roles and remain private by claiming
 `{ [space]: "OWNER" }`, including an ACL-less legacy home.

--- a/docs/tutorial/10-identity-and-security.md
+++ b/docs/tutorial/10-identity-and-security.md
@@ -94,8 +94,11 @@ The server evaluates them per message — session-open, queries, and watches nee
 READ; `transact` needs WRITE; writing the ACL itself needs OWNER. A fresh space
 is read-only until its space identity (or a configured service DID) writes a
 valid ACL with at least one concrete OWNER. Named-space bootstrap uses a
-temporary space-identity session to grant the active user OWNER plus `"*"`
-WRITE as the rollout default, then remounts as that user. Home spaces use the
+temporary space-identity session to write the genesis ACL, then remounts as
+that user: the document a caller registered beside the space key
+(`registerSpaceIdentity(identity, { genesisAcl })`, so a space can be born
+sealed), else the rollout default of the active user as OWNER plus `"*"`
+WRITE. Home spaces use the
 same identity for both roles and remain private by claiming
 `{ [space]: "OWNER" }`, including an ACL-less legacy home.
 

--- a/packages/memory/acl.ts
+++ b/packages/memory/acl.ts
@@ -49,7 +49,7 @@ export function hasConcreteOwner(acl: ACL): boolean {
 /** Whether a stored ACL document is exactly `expected`: same principals,
  *  same capabilities, nothing more. Key order is not part of the contract. */
 export function sameAcl(stored: unknown, expected: ACL): boolean {
-  if (typeof stored !== "object" || stored === null) return false;
+  if (!isObjectNotArray(stored)) return false;
   const actual = stored as Record<string, unknown>;
   const expectedKeys = Object.keys(expected);
   return Object.keys(actual).length === expectedKeys.length &&

--- a/packages/memory/acl.ts
+++ b/packages/memory/acl.ts
@@ -46,6 +46,16 @@ export function hasConcreteOwner(acl: ACL): boolean {
   );
 }
 
+/** Whether a stored ACL document is exactly `expected`: same principals,
+ *  same capabilities, nothing more. Key order is not part of the contract. */
+export function sameAcl(stored: unknown, expected: ACL): boolean {
+  if (typeof stored !== "object" || stored === null) return false;
+  const actual = stored as Record<string, unknown>;
+  const expectedKeys = Object.keys(expected);
+  return Object.keys(actual).length === expectedKeys.length &&
+    expectedKeys.every((key) => actual[key] === expected[key as ACLUser]);
+}
+
 const CapabilityMap: Record<Capability, number> = {
   READ: 0,
   WRITE: 1,

--- a/packages/memory/test/v2-server-acl.test.ts
+++ b/packages/memory/test/v2-server-acl.test.ts
@@ -1323,7 +1323,10 @@ Deno.test("acl enforce: a genesis ACL without a concrete OWNER is refused and th
   // The runner's genesis-supplied ACL option hands the caller's document to
   // this same admission check (no client-side validation): a space identity
   // that tries to mint an unowned or malformed space is refused at genesis
-  // with the existing shape error, and genesis stays owed.
+  // with the existing shape error, and genesis stays owed. This pins
+  // behavior the server already had — no server code changed — rather than
+  // driving new behavior; it reddens when `hasConcreteOwner` is dropped
+  // from `#validateAclCommit` (mutation witnessed).
   const server = createAclServer("memory://acl-genesis-unowned", {
     mode: "enforce",
   });

--- a/packages/memory/test/v2-server-acl.test.ts
+++ b/packages/memory/test/v2-server-acl.test.ts
@@ -2,6 +2,7 @@ import { assert, assertEquals, assertExists, assertRejects } from "@std/assert";
 import { toFileUrl } from "@std/path";
 import { Database } from "@db/sqlite";
 import { Server, SessionRegistry } from "../v2/server.ts";
+import { sameAcl } from "../acl.ts";
 import {
   encodeMemoryBoundary,
   getMemoryProtocolFlags,
@@ -2183,4 +2184,22 @@ Deno.test("OW31 acl enforce: an OWNER-class service envelope stores NO binding â
   } finally {
     await server.close();
   }
+});
+
+Deno.test("sameAcl: exact principals and capabilities, key order free, never an array or scalar", () => {
+  const expected = { [ALICE]: "OWNER" as const, [BOB]: "WRITE" as const };
+  assertEquals(sameAcl({ [BOB]: "WRITE", [ALICE]: "OWNER" }, expected), true);
+  assertEquals(sameAcl({ [ALICE]: "OWNER" }, expected), false, "missing row");
+  assertEquals(
+    sameAcl({ ...expected, [CAROL]: "READ" }, expected),
+    false,
+    "extra row",
+  );
+  assertEquals(sameAcl({ [ALICE]: "OWNER", [BOB]: "READ" }, expected), false);
+  assertEquals(sameAcl(null, expected), false);
+  assertEquals(sameAcl("OWNER", expected), false);
+  // Red-first witnessed: an array is an object with zero keys, so [] matched
+  // an empty expected document.
+  assertEquals(sameAcl([], {}), false);
+  assertEquals(sameAcl(undefined, {}), false);
 });

--- a/packages/memory/test/v2-server-acl.test.ts
+++ b/packages/memory/test/v2-server-acl.test.ts
@@ -1319,6 +1319,76 @@ Deno.test("acl enforce: ACL mutations must preserve a concrete owner", async () 
   }
 });
 
+Deno.test("acl enforce: a genesis ACL without a concrete OWNER is refused and the space stays uninitialized", async () => {
+  // The runner's genesis-supplied ACL option hands the caller's document to
+  // this same admission check (no client-side validation): a space identity
+  // that tries to mint an unowned or malformed space is refused at genesis
+  // with the existing shape error, and genesis stays owed.
+  const server = createAclServer("memory://acl-genesis-unowned", {
+    mode: "enforce",
+  });
+  const space = "did:key:z6Mk-acl-genesis-unowned";
+  const authority = await connect(server);
+  try {
+    const opened = await openSession(authority, space, space);
+    assertExists(opened.ok, "space identity should open its own space");
+    const unowned: Record<string, unknown>[] = [
+      {},
+      { "*": "OWNER" },
+      { "*": "OWNER", [ALICE]: "WRITE" },
+      { [ALICE]: "WRITE", [BOB]: "READ" },
+      { [ALICE]: "ADMIN" },
+    ];
+    let localSeq = 1;
+    for (const acl of unowned) {
+      const response = await transactSet(
+        authority,
+        space,
+        opened.ok.sessionId,
+        `of:${space}`,
+        acl,
+        localSeq++,
+      );
+      assertEquals(response.error?.name, "ProtocolError");
+      assertEquals(
+        response.error?.message,
+        "ACL must be valid and retain at least one concrete OWNER",
+      );
+    }
+    // Still fresh: an ordinary write is refused for want of genesis, and
+    // there is no ACL document.
+    const ordinary = await transactSet(
+      authority,
+      space,
+      opened.ok.sessionId,
+      "of:after-refused-genesis",
+      { value: 1 },
+      localSeq++,
+    );
+    assertEquals(ordinary.error?.name, "AuthorizationError");
+    assertEquals(
+      ordinary.error?.message,
+      `Space ${space} requires an ACL genesis commit before ordinary writes`,
+    );
+    assertEquals(await server.readDocument(space, `of:${space}`), null);
+
+    // A concrete OWNER then initializes it — the check refused the
+    // document, not the identity.
+    const sealed = await transactSet(
+      authority,
+      space,
+      opened.ok.sessionId,
+      `of:${space}`,
+      { [space]: "OWNER", [ALICE]: "WRITE" },
+      localSeq++,
+    );
+    assertExists(sealed.ok);
+    assertEquals(sealed.ok.seq, 1, "the genesis ACL is the first commit");
+  } finally {
+    await server.close();
+  }
+});
+
 Deno.test("acl enforce: ACL mutations are default-branch ACL-only commits", async () => {
   const server = createAclServer("memory://acl-validate-commit-shape", {
     mode: "enforce",

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -3349,7 +3349,8 @@ export class Runtime {
    * when this resolution creates it (its first and only commit — no
    * world-writable default is ever written), validated by the memory
    * server's genesis admission; on a space that already exists the open
-   * proceeds only if it carries exactly that document, else refuses. It is
+   * proceeds only if it is owned exactly as the document says, else
+   * refuses. It is
    * refused together with `owner` (two descriptions of one document), for
    * a bare DID (no key to register against), and for a name already
    * resolved — by anything, including a pattern's `inSpace(name)` — unless

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -3348,9 +3348,16 @@ export class Runtime {
    * `options.genesisAcl` is the exact ACL document the space is born with
    * when this resolution creates it (its first and only commit — no
    * world-writable default is ever written), validated by the memory
-   * server's genesis admission. It is inert on a space that already
-   * exists, and is refused together with `owner` (two descriptions of one
-   * document); see `IStorageManager.registerSpaceIdentity`. A SERVING
+   * server's genesis admission; on a space that already exists the open
+   * proceeds only if it carries exactly that document, else refuses. It is
+   * refused together with `owner` (two descriptions of one document), for
+   * a bare DID (no key to register against), and for a name already
+   * resolved — by anything, including a pattern's `inSpace(name)` — unless
+   * with the identical document; see `IStorageManager.registerSpaceIdentity`.
+   * The name is cached at resolution, before the server can refuse the
+   * document, so a refusal surfaced later (on the first sync) has no
+   * correction path through this method: register a corrected document
+   * with the storage manager directly, or use a fresh runtime. A SERVING
    * runtime refuses it outright: served provisioning names the run's
    * acting user OWNER through the OW31 owner path, and a document that
    * bypassed that path could name any principal — including the service —

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -38,6 +38,7 @@ import { isDeno } from "@commonfabric/utils/env";
 import { PatternEnvironment, setPatternEnvironment } from "./builder/env.ts";
 import { popFrame, pushFrame } from "./builder/pattern.ts";
 import { getDirectTransactionReadActivities } from "./storage/transaction-inspection.ts";
+import { sameAcl } from "@commonfabric/memory/acl";
 import type {
   ACL,
   ChangeGroup,
@@ -1031,6 +1032,9 @@ export class Runtime {
 
   /** Cache of resolved PatternFactory.inSpace("name") space DIDs. */
   readonly #spaceNameToDid = new Map<string, MemorySpace>();
+  /** The genesisAcl each name was first resolved with, so an identical
+   * re-resolution is a retry and a different one is refused. */
+  readonly #spaceNameGenesisAcls = new Map<string, ACL>();
 
   #defaultFrame?: Frame;
   #queues = new Map<string, AsyncSemaphoreQueue>();
@@ -3358,6 +3362,31 @@ export class Runtime {
     options?: { owner?: DID; genesisAcl?: ACL },
   ): Promise<MemorySpace> {
     const cached = this.resolveSpaceNameSync(name);
+    if (options?.genesisAcl !== undefined) {
+      // A document the resolution cannot honor is refused, never dropped:
+      // the caller asked for a space born closed.
+      if (isMemorySpaceDID(name)) {
+        throw new Error(
+          `space-name resolution for the DID ${name} cannot register a ` +
+            "genesisAcl: the runtime derives no space key for a bare DID, " +
+            "so nothing would write the document (register the identity " +
+            "with the storage manager directly)",
+        );
+      }
+      if (cached !== undefined) {
+        const recorded = this.#spaceNameGenesisAcls.get(name);
+        if (recorded === undefined || !sameAcl(recorded, options.genesisAcl)) {
+          throw new Error(
+            `space-name "${name}" was already resolved` +
+              (recorded === undefined
+                ? " without a genesisAcl"
+                : " with a different genesisAcl") +
+              "; the supplied document cannot be the space's genesis",
+          );
+        }
+        return cached;
+      }
+    }
     if (cached !== undefined) return cached;
     if (this.servingPosture && options?.genesisAcl !== undefined) {
       throw new Error(
@@ -3399,6 +3428,9 @@ export class Runtime {
     }
     const did = session.space as MemorySpace;
     this.#spaceNameToDid.set(name, did);
+    if (options?.genesisAcl !== undefined) {
+      this.#spaceNameGenesisAcls.set(name, { ...options.genesisAcl });
+    }
     return did;
   }
 

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -1035,6 +1035,10 @@ export class Runtime {
   /** The genesisAcl each name was first resolved with, so an identical
    * re-resolution is a retry and a different one is refused. */
   readonly #spaceNameGenesisAcls = new Map<string, ACL>();
+  /** Resolutions in flight, by name: a second caller joins the first
+   * rather than racing it to registration, so two documents for one name
+   * cannot both register before either is cached. */
+  readonly #spaceNameResolutions = new Map<string, Promise<MemorySpace>>();
 
   #defaultFrame?: Frame;
   #queues = new Map<string, AsyncSemaphoreQueue>();
@@ -3369,6 +3373,34 @@ export class Runtime {
     name: string,
     options?: { owner?: DID; genesisAcl?: ACL },
   ): Promise<MemorySpace> {
+    if (options?.owner !== undefined && options?.genesisAcl !== undefined) {
+      // Two descriptions of one document: refused before anything else,
+      // cached path included, mirroring registerSpaceIdentity.
+      throw new Error(
+        `space-name resolution for "${name}": supply either owner or ` +
+          "genesisAcl, not both — genesisAcl is the whole genesis document, " +
+          "and owner only names the OWNER of the default one",
+      );
+    }
+    if (
+      options?.genesisAcl !== undefined &&
+      this.storageManager.registerSpaceIdentity === undefined
+    ) {
+      // No seam to hand the document to; the optional call below would
+      // drop it and the space would be born with the default.
+      throw new Error(
+        `space-name resolution for "${name}" cannot register a genesisAcl: ` +
+          "this storage manager has no registerSpaceIdentity seam, so " +
+          "nothing would write the document",
+      );
+    }
+    const inFlight = this.#spaceNameResolutions.get(name);
+    if (inFlight !== undefined) {
+      // Join the resolution already under way, then take the cached path:
+      // an identical document is a retry, a different one is refused.
+      await inFlight.catch(() => {});
+      return await this.resolveSpaceName(name, options);
+    }
     const cached = this.resolveSpaceNameSync(name);
     if (options?.genesisAcl !== undefined) {
       // A document the resolution cannot honor is refused, never dropped:
@@ -3413,33 +3445,47 @@ export class Runtime {
           "genesis would name the SERVICE as owner",
       );
     }
-    const session = await createSession({
-      identity: this.storageManager.as as unknown as Identity,
-      spaceName: name,
-    });
-    // Register the derived identity only as fresh-space ACL bootstrap
-    // authority. Storage continues to authenticate ordinary reads and writes
-    // as the active user (`storageManager.as`), so resolving a name does not
-    // grant an existing space's key to the caller.
-    if (session.spaceIdentity) {
-      this.storageManager.registerSpaceIdentity?.(
-        session.spaceIdentity,
-        options?.owner !== undefined || options?.genesisAcl !== undefined
-          ? {
-            ...(options.owner !== undefined ? { owner: options.owner } : {}),
-            ...(options.genesisAcl !== undefined
-              ? { genesisAcl: options.genesisAcl }
-              : {}),
-          }
-          : undefined,
-      );
+    const resolution = (async (): Promise<MemorySpace> => {
+      const session = await createSession({
+        identity: this.storageManager.as as unknown as Identity,
+        spaceName: name,
+      });
+      if (options?.genesisAcl !== undefined && !session.spaceIdentity) {
+        throw new Error(
+          `space-name resolution for "${name}" derived no space identity, ` +
+            "so the supplied genesisAcl could not be registered",
+        );
+      }
+      // Register the derived identity only as fresh-space ACL bootstrap
+      // authority. Storage continues to authenticate ordinary reads and
+      // writes as the active user (`storageManager.as`), so resolving a name
+      // does not grant an existing space's key to the caller.
+      if (session.spaceIdentity) {
+        this.storageManager.registerSpaceIdentity?.(
+          session.spaceIdentity,
+          options?.owner !== undefined || options?.genesisAcl !== undefined
+            ? {
+              ...(options.owner !== undefined ? { owner: options.owner } : {}),
+              ...(options.genesisAcl !== undefined
+                ? { genesisAcl: options.genesisAcl }
+                : {}),
+            }
+            : undefined,
+        );
+      }
+      const did = session.space as MemorySpace;
+      this.#spaceNameToDid.set(name, did);
+      if (options?.genesisAcl !== undefined) {
+        this.#spaceNameGenesisAcls.set(name, { ...options.genesisAcl });
+      }
+      return did;
+    })();
+    this.#spaceNameResolutions.set(name, resolution);
+    try {
+      return await resolution;
+    } finally {
+      this.#spaceNameResolutions.delete(name);
     }
-    const did = session.space as MemorySpace;
-    this.#spaceNameToDid.set(name, did);
-    if (options?.genesisAcl !== undefined) {
-      this.#spaceNameGenesisAcls.set(name, { ...options.genesisAcl });
-    }
-    return did;
   }
 
   // Convenience methods that delegate to the runner

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -3346,7 +3346,12 @@ export class Runtime {
    * world-writable default is ever written), validated by the memory
    * server's genesis admission. It is inert on a space that already
    * exists, and is refused together with `owner` (two descriptions of one
-   * document); see `IStorageManager.registerSpaceIdentity`.
+   * document); see `IStorageManager.registerSpaceIdentity`. A SERVING
+   * runtime refuses it outright: served provisioning names the run's
+   * acting user OWNER through the OW31 owner path, and a document that
+   * bypassed that path could name any principal — including the service —
+   * on a space the acting user asked for. A creator that wants a sealed
+   * space mints it from its own (client) runtime.
    */
   async resolveSpaceName(
     name: string,
@@ -3354,6 +3359,14 @@ export class Runtime {
   ): Promise<MemorySpace> {
     const cached = this.resolveSpaceNameSync(name);
     if (cached !== undefined) return cached;
+    if (this.servingPosture && options?.genesisAcl !== undefined) {
+      throw new Error(
+        `space-name resolution for "${name}" on a serving runtime does not ` +
+          "accept genesisAcl: served provisioning names the run's acting " +
+          "identity OWNER through the owner path (OW31, RULED 2026-08-18), " +
+          "and a caller-supplied document would bypass it",
+      );
+    }
     if (this.servingPosture && options?.owner === undefined) {
       throw new Error(
         `space-name resolution for "${name}" on a serving runtime requires ` +

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -39,6 +39,7 @@ import { PatternEnvironment, setPatternEnvironment } from "./builder/env.ts";
 import { popFrame, pushFrame } from "./builder/pattern.ts";
 import { getDirectTransactionReadActivities } from "./storage/transaction-inspection.ts";
 import type {
+  ACL,
   ChangeGroup,
   CommitError,
   DID,
@@ -3339,10 +3340,17 @@ export class Runtime {
    * mint a service-owned space (builtins.md §5; protocol.md §2b). On a
    * client the owner is omitted and the genesis names the manager's own
    * signer — the active user, byte-identical to before.
+   *
+   * `options.genesisAcl` is the exact ACL document the space is born with
+   * when this resolution creates it (its first and only commit — no
+   * world-writable default is ever written), validated by the memory
+   * server's genesis admission. It is inert on a space that already
+   * exists, and is refused together with `owner` (two descriptions of one
+   * document); see `IStorageManager.registerSpaceIdentity`.
    */
   async resolveSpaceName(
     name: string,
-    options?: { owner?: DID },
+    options?: { owner?: DID; genesisAcl?: ACL },
   ): Promise<MemorySpace> {
     const cached = this.resolveSpaceNameSync(name);
     if (cached !== undefined) return cached;
@@ -3366,7 +3374,14 @@ export class Runtime {
     if (session.spaceIdentity) {
       this.storageManager.registerSpaceIdentity?.(
         session.spaceIdentity,
-        options?.owner !== undefined ? { owner: options.owner } : undefined,
+        options?.owner !== undefined || options?.genesisAcl !== undefined
+          ? {
+            ...(options.owner !== undefined ? { owner: options.owner } : {}),
+            ...(options.genesisAcl !== undefined
+              ? { genesisAcl: options.genesisAcl }
+              : {}),
+          }
+          : undefined,
       );
     }
     const did = session.space as MemorySpace;

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -3396,9 +3396,10 @@ export class Runtime {
     }
     const inFlight = this.#spaceNameResolutions.get(name);
     if (inFlight !== undefined) {
-      // Join the resolution already under way, then take the cached path:
-      // an identical document is a retry, a different one is refused.
-      await inFlight.catch(() => {});
+      // Join the resolution already under way — its rejection is this
+      // caller's too — then take the cached path: an identical document is
+      // a retry, a different one is refused.
+      await inFlight;
       return await this.resolveSpaceName(name, options);
     }
     const cached = this.resolveSpaceNameSync(name);

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -285,7 +285,10 @@ export interface IStorageManager extends IStorageSubscriptionCapability {
    * (its first and only commit; no intermediate default is ever written),
    * validated by the memory server's genesis admission rather than here.
    * It is inert outside true genesis and never reaches the home arm.
-   * Supplying it together with `owner` is refused.
+   * Supplying it together with `owner` in one registration is refused; a
+   * later registration for the same space replaces an earlier one. A
+   * manager that cannot bootstrap an ACL refuses it rather than accept a
+   * document it would never write.
    */
   registerSpaceIdentity?(
     identity: Signer,

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -284,11 +284,15 @@ export interface IStorageManager extends IStorageSubscriptionCapability {
    * `options.genesisAcl` is the exact document a fresh space is born with
    * (its first and only commit; no intermediate default is ever written),
    * validated by the memory server's genesis admission rather than here.
-   * It is inert outside true genesis and never reaches the home arm.
-   * Supplying it together with `owner` in one registration is refused; a
-   * later registration for the same space replaces an earlier one. A
-   * manager that cannot bootstrap an ACL refuses it rather than accept a
-   * document it would never write.
+   * It is a demand: the open proceeds only if the space is fresh or already
+   * carries exactly that document, and is refused otherwise — never
+   * silently entered under a different ACL. It never reaches the home arm.
+   * The signer that will open the space must be granted at least READ by
+   * it. Supplying it together with `owner` in one registration is refused;
+   * a later registration for the same space replaces an earlier one, but
+   * not once the space's first mount has begun. A manager that cannot
+   * bootstrap an ACL refuses it rather than accept a document it would
+   * never write.
    */
   registerSpaceIdentity?(
     identity: Signer,

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -284,9 +284,10 @@ export interface IStorageManager extends IStorageSubscriptionCapability {
    * `options.genesisAcl` is the exact document a fresh space is born with
    * (its first and only commit; no intermediate default is ever written),
    * validated by the memory server's genesis admission rather than here.
-   * It is a demand: the open proceeds only if the space is fresh or already
-   * carries exactly that document, and is refused otherwise — never
-   * silently entered under a different ACL. It never reaches the home arm.
+   * It is a demand: the open proceeds only if the space is fresh or is
+   * already owned exactly as the document says (grants below OWNER are the
+   * owner's to evolve), and is refused otherwise — never silently entered
+   * under someone else's ACL. It never reaches the home arm.
    * The signer that will open the space must be granted at least READ by
    * it. Supplying it together with `owner` in one registration is refused;
    * a later registration for the same space replaces an earlier one, but

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -31,6 +31,7 @@ import type { Cancel } from "../cancel.ts";
 import type { EntityId } from "../create-ref.ts";
 import type { MergeableOpDelta } from "./mergeable-ops.ts";
 import {
+  type ACL,
   type AuthorizationError as IAuthorizationError,
   type ConflictError as IConflictError,
   type ConnectionError as IConnectionError,
@@ -77,7 +78,17 @@ import type {
 import type { NormalizedFullLink } from "../link-types.ts";
 import { RAW_META_WRITE } from "../meta-seam.ts";
 import { BaseMemoryAddress } from "../traverse.ts";
-export type { DID, MediaType, MemorySpace, Result, Signer, State, Unit, URI };
+export type {
+  ACL,
+  DID,
+  MediaType,
+  MemorySpace,
+  Result,
+  Signer,
+  State,
+  Unit,
+  URI,
+};
 export type ChangeGroup = unknown;
 
 /**
@@ -269,8 +280,17 @@ export interface IStorageManager extends IStorageSubscriptionCapability {
    * and names the ACTING user OWNER — the serving identity appears nowhere
    * in the ACL). Absent, the genesis owner is the manager's own signer —
    * the active user on a client, byte-identical to the pre-OW31 shape.
+   *
+   * `options.genesisAcl` is the exact document a fresh space is born with
+   * (its first and only commit; no intermediate default is ever written),
+   * validated by the memory server's genesis admission rather than here.
+   * It is inert outside true genesis and never reaches the home arm.
+   * Supplying it together with `owner` is refused.
    */
-  registerSpaceIdentity?(identity: Signer, options?: { owner?: string }): void;
+  registerSpaceIdentity?(
+    identity: Signer,
+    options?: { owner?: string; genesisAcl?: ACL },
+  ): void;
 
   /**
    * Force `space`'s provider session — and with it any fresh-space ACL

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -617,6 +617,13 @@ export const DEFAULT_GENESIS_GRANTS: Readonly<ACL> = Object.freeze({
   "*": "WRITE",
 });
 
+/** The fallback genesis document for a fresh non-home space: `owner` as
+ *  OWNER plus the rollout default grants. */
+const defaultGenesisAcl = (owner: string): ACL => ({
+  [owner]: "OWNER",
+  ...DEFAULT_GENESIS_GRANTS,
+});
+
 export interface Options {
   as: Signer;
 
@@ -910,15 +917,14 @@ export class StorageManager implements IStorageManager {
 
   #spaceIdentities = new Map<MemorySpace, Signer>();
 
-  /** Genesis ACL owners registered beside a space identity (OW31): the
-   * ACTING user a serving-side provisioning run supplied. Keyed apart so
-   * the client path (no owner registered) stays byte-identical. */
-  #spaceGenesisOwners = new Map<MemorySpace, string>();
-
-  /** Genesis ACL documents registered beside a space identity: the exact
-   * document the space is born with, in place of the owner + rollout
-   * default shape. Keyed apart from the owners so a space names one or
-   * the other, never both. */
+  /** Genesis ACL documents registered beside a space identity — the exact
+   * document a fresh space is born with. `{ owner }` (OW31: the ACTING
+   * user a serving-side provisioning run supplied) is stored here already
+   * expanded into the fallback shape, so there is one representation and
+   * one reader. Absent (every client that registered nothing), the
+   * fallback is computed at genesis from the signer, byte-identical to the
+   * pre-OW31 shape. A later registration for the same space replaces an
+   * earlier one, as re-registering an owner always did. */
   #spaceGenesisAcls = new Map<MemorySpace, ACL>();
 
   /** Seed map from Options — fixed for the manager's lifetime. */
@@ -1117,7 +1123,7 @@ export class StorageManager implements IStorageManager {
     }
     this.#spaceIdentities.set(space, identity);
     if (owner !== undefined) {
-      this.#spaceGenesisOwners.set(space, owner);
+      this.#spaceGenesisAcls.set(space, defaultGenesisAcl(owner));
     }
     if (genesisAcl !== undefined) {
       // Snapshot: what genesis writes is what was registered, not what the
@@ -1142,14 +1148,6 @@ export class StorageManager implements IStorageManager {
     return this.#servingHomeSpace !== undefined
       ? { actingAs: "space-owner" }
       : {};
-  }
-
-  /** The fallback genesis document for a fresh non-home space no caller
-   *  supplied one for: the registered owner (else the signer) as OWNER,
-   *  plus the rollout default grants. */
-  #defaultGenesisAcl(space: MemorySpace, signer: Signer): ACL {
-    const genesisOwner = this.#spaceGenesisOwners.get(space) ?? signer.did();
-    return { [genesisOwner]: "OWNER", ...DEFAULT_GENESIS_GRANTS };
   }
 
   /** The serving manager's HOME space (Options.servingHomeSpace) —
@@ -1434,15 +1432,15 @@ export class StorageManager implements IStorageManager {
           try {
             // The HOME arm is untouched — a home space is its own
             // identity and owner, and no registered document reaches it.
-            // Non-home: the caller's registered genesis document verbatim
-            // (sealed by construction), else the fallback shape whose
-            // owner is the acting user registered beside the space
-            // identity (OW31, RULED 2026-08-18) or, absent that, the
-            // signer — the active user on a client.
+            // Non-home: the document registered beside the space identity
+            // — a caller's own, or the fallback shape around the acting
+            // user a serving run supplied (OW31, RULED 2026-08-18) — else
+            // the fallback shape around the signer, the active user on a
+            // client.
             const bootstrapAcl = isHomeSpace
               ? { [signer.did()]: "OWNER" }
               : this.#spaceGenesisAcls.get(space) ??
-                this.#defaultGenesisAcl(space, signer);
+                defaultGenesisAcl(signer.did());
             await bootstrap.session.transact({
               localSeq: 1,
               reads: {

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -1133,10 +1133,18 @@ export class StorageManager implements IStorageManager {
    * it did not ask for. It is validated by the memory server's own
    * genesis admission (a concrete OWNER, an ACL-only commit; INV-12/13),
    * never here: a refused document leaves the space uninitialized and
-   * the open rejects. It is inert outside true genesis (a populated
-   * ACL-less space, a retracted ACL) and never reaches the home arm.
-   * `owner` and `genesisAcl` are two descriptions of one document, so
-   * supplying both is refused rather than silently ranked.
+   * the open rejects, and a corrected registration may retry. The
+   * document is a demand: the space's first open on this manager
+   * proceeds only if the space is fresh (the document becomes its only
+   * commit) or already carries exactly that document; a space populated
+   * before genesis, or claimed by another initializer with a different
+   * ACL, is refused rather than silently entered under the other ACL's
+   * grant. It never reaches the home arm. A caller that will open the
+   * space itself must grant its own signer at least READ, or every open
+   * after genesis is refused by the server. `owner` and `genesisAcl` are
+   * two descriptions of one document, so supplying both in one
+   * registration is refused rather than silently ranked; a registration
+   * after the space's first mount has begun is refused too.
    */
   registerSpaceIdentity(
     identity: Signer,

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -4,7 +4,7 @@ import {
   hasDataUriScheme,
   valueFromDataUri,
 } from "@commonfabric/data-model/codec-data-uri";
-import { aclDocId } from "@commonfabric/memory/acl";
+import { aclDocId, sameAcl } from "@commonfabric/memory/acl";
 import type { ACL, Entity } from "@commonfabric/memory/interface";
 import {
   type AuthorizationError as IAuthorizationError,
@@ -624,16 +624,6 @@ const defaultGenesisAcl = (owner: string): ACL => ({
   ...DEFAULT_GENESIS_GRANTS,
 });
 
-/** Whether a stored ACL document is exactly `expected`: same principals,
- *  same capabilities, nothing more. Key order is not part of the contract. */
-const sameAcl = (stored: unknown, expected: ACL): boolean => {
-  if (typeof stored !== "object" || stored === null) return false;
-  const actual = stored as Record<string, unknown>;
-  const expectedKeys = Object.keys(expected);
-  return Object.keys(actual).length === expectedKeys.length &&
-    expectedKeys.every((key) => actual[key] === expected[key as keyof ACL]);
-};
-
 export interface Options {
   as: Signer;
 
@@ -1150,6 +1140,18 @@ export class StorageManager implements IStorageManager {
         `registerSpaceIdentity(${space}): supply either owner or genesisAcl, ` +
           "not both — genesisAcl is the whole genesis document, and owner " +
           "only names the OWNER of the default one",
+      );
+    }
+    if (
+      genesisAcl !== undefined &&
+      this.#sessionFactory.supportsAclBootstrap !== true
+    ) {
+      // A document nobody will write is a seal that never lands; the
+      // caller asked for a closed space and would get an ACL-less one.
+      throw new Error(
+        `registerSpaceIdentity(${space}): this manager's session factory ` +
+          "cannot bootstrap an ACL, so the supplied genesisAcl would never " +
+          "be written",
       );
     }
     this.#spaceIdentities.set(space, identity);

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -939,14 +939,24 @@ export class StorageManager implements IStorageManager {
    * detached session resumable by its token for a TTL, so the next attempt
    * must present that token or be refused with "resume token is no longer
    * valid" — a wedge that hid the real error until the manager closed.
-   * Scoped to the route generation it was minted under: a token belongs
-   * to one host, and a replay after a route replacement must not present
-   * the old host's token to the new one. Consumed by the next attempt on
-   * the same route; cleared once a session is handed to the provider. */
+   * Recorded as soon as the manager-wide session is mounted (every later
+   * throw leaves it detached), deleted the moment a session is handed to
+   * the provider, and cleared by close(), which rotates the session id
+   * the entry names. Scoped to the route generation it was minted under:
+   * a token belongs to one host, and a replay after a route replacement
+   * must not present the old host's token to the new one. */
   #detachedSessionResumes = new Map<
     MemorySpace,
     { options: MemoryV2Client.MountOptions; routeGeneration: number }
   >();
+
+  /** Where each space's first mount stands on this manager: an attempt in
+   * flight (the registered document is being read), or a session handed to
+   * the provider (the document was consulted, or the space needed none). A
+   * genesisAcl registered in either state could never be the space's
+   * genesis, so registration refuses. A failed attempt leaves no entry — the
+   * caller may correct the document and retry — and close() clears it. */
+  #genesisPhase = new Map<MemorySpace, "in-flight" | "handed-off">();
 
   /** Seed map from Options — fixed for the manager's lifetime. */
   #seedHosts: Record<string, string>;
@@ -1140,6 +1150,15 @@ export class StorageManager implements IStorageManager {
         `registerSpaceIdentity(${space}): supply either owner or genesisAcl, ` +
           "not both — genesisAcl is the whole genesis document, and owner " +
           "only names the OWNER of the default one",
+      );
+    }
+    if (genesisAcl !== undefined && this.#genesisPhase.has(space)) {
+      // The document is read during the space's first mount; that mount is
+      // under way or done, without it.
+      throw new Error(
+        `registerSpaceIdentity(${space}): the space is already open on this ` +
+          "manager, so the supplied genesisAcl could never be its genesis — " +
+          "register the document before the first open",
       );
     }
     if (
@@ -1380,6 +1399,9 @@ export class StorageManager implements IStorageManager {
     };
     routeSignal.addEventListener("abort", closeActiveClients, { once: true });
     let completed = false;
+    if (this.#genesisPhase.get(space) !== "handed-off") {
+      this.#genesisPhase.set(space, "in-flight");
+    }
 
     try {
       assertCurrentRoute();
@@ -1398,18 +1420,72 @@ export class StorageManager implements IStorageManager {
           routeSignal,
         ),
       );
-      if (this.#sessionFactory.supportsAclBootstrap !== true) {
+      // The manager-wide session is mounted; from here until a session is
+      // handed to the provider, any throw leaves it resumable only by its
+      // token. Remember how, so the next attempt is not refused for want
+      // of the token (and so the next attempt's error is the real one).
+      // Also what the final user mount below resumes: the
+      // construction-wide manager session, never a replacement of that
+      // still-live id without its token.
+      const resumeNormal: MemoryV2Client.MountOptions = {
+        sessionId: normal.session.sessionId,
+        seenSeq: normal.session.serverSeq,
+        ...(normal.session.sessionToken !== undefined
+          ? { sessionToken: normal.session.sessionToken }
+          : {}),
+        ...this.#servingActingAs(),
+      };
+      this.#detachedSessionResumes.set(space, {
+        options: resumeNormal,
+        routeGeneration,
+      });
+      const handOff = (opened: OpenedSpaceSession): OpenedSpaceSession => {
+        this.#detachedSessionResumes.delete(space);
+        this.#genesisPhase.set(space, "handed-off");
         completed = true;
-        return normal;
+        return opened;
+      };
+      if (this.#sessionFactory.supportsAclBootstrap !== true) {
+        return handOff(normal);
       }
       const isHomeSpace = signer.did() === space;
       const spaceIdentity = isHomeSpace
         ? signer
         : this.#spaceIdentities.get(space);
       if (spaceIdentity === undefined) {
-        completed = true;
-        return normal;
+        return handOff(normal);
       }
+
+      // A caller's own genesis document (never the home arm's) is a
+      // demand, not a preference: this open proceeds only if the space is
+      // fresh (then the document is written) or already carries exactly
+      // that document (a reopen). Anything else — a space populated
+      // before genesis, a genesis another initializer won with a
+      // different ACL, in whichever window it landed — is not the space
+      // the caller asked for, and the reopen below would otherwise
+      // succeed under the winner's grant with nothing reported. Fail
+      // closed.
+      const registered = this.#spaceGenesisAcls.get(space);
+      const demanded = !isHomeSpace && registered?.supplied === true
+        ? registered.document
+        : undefined;
+      const assertDemandedDocumentStands = (stored: unknown): void => {
+        if (demanded !== undefined && !sameAcl(stored, demanded)) {
+          throw new Error(
+            `genesis of ${space} was claimed with a different ACL; the ` +
+              "supplied genesis document was not applied and the space is " +
+              "not the one the caller asked for",
+          );
+        }
+      };
+      const aclValueOf = (
+        entities: Array<
+          { id: string; scope?: string; document?: { value?: unknown } | null }
+        >,
+      ): unknown =>
+        entities.find((entity) =>
+          entity.id === aclId && (entity.scope ?? "space") === "space"
+        )?.document?.value ?? null;
 
       const openedServerSeq = normal.session.serverSeq;
       const aclId = aclDocId(space);
@@ -1423,34 +1499,15 @@ export class StorageManager implements IStorageManager {
       const aclNeverCreated = aclSnapshot?.seq === 0 &&
         aclSnapshot.document === null;
       if (!aclNeverCreated || (!isHomeSpace && openedServerSeq !== 0)) {
-        completed = true;
-        return normal;
+        assertDemandedDocumentStands(aclValueOf(aclResult.entities));
+        return handOff(normal);
       }
 
       // Do not reuse the bootstrap session for replica work: both it and the
       // replica allocate localSeq from 1, and named spaces must switch back from
       // the space signer to the active user before any user-scoped operation.
-      // Preserve the normal session token before detaching it so the final user
-      // mount resumes the construction-wide manager session instead of trying to
-      // replace that still-live id without its token.
-      const resumeNormal: MemoryV2Client.MountOptions = {
-        sessionId: normal.session.sessionId,
-        seenSeq: normal.session.serverSeq,
-        ...(normal.session.sessionToken !== undefined
-          ? { sessionToken: normal.session.sessionToken }
-          : {}),
-        ...this.#servingActingAs(),
-      };
       activeClients.delete(normal.client);
       await normal.client.close();
-      // From here until the resume below hands a session to the provider,
-      // a failure leaves the manager-wide session detached; remember how
-      // to resume it so the next attempt is not refused for want of the
-      // token (and so the next attempt's error is the real one).
-      this.#detachedSessionResumes.set(space, {
-        options: resumeNormal,
-        routeGeneration,
-      });
       assertCurrentRoute();
       let bootstrapSessionId = crypto.randomUUID();
       while (bootstrapSessionId === this.#sessionId) {
@@ -1479,11 +1536,15 @@ export class StorageManager implements IStorageManager {
         // case and must not be claimed. Home remains the explicit exception.
         const aclStillNeverCreated = snapshot?.seq === 0 &&
           snapshot.document === null;
-        const registered = this.#spaceGenesisAcls.get(space);
         if (
-          aclStillNeverCreated &&
-          (isHomeSpace || current.serverSeq === 0)
+          !aclStillNeverCreated ||
+          (!isHomeSpace && current.serverSeq !== 0)
         ) {
+          // Claimed (or populated) between the first inspection and this
+          // recheck: the default path reopens as the user below; a
+          // demanded document must already be what stands.
+          assertDemandedDocumentStands(aclValueOf(current.entities));
+        } else {
           try {
             // The HOME arm is untouched — a home space is its own
             // identity and owner, and no registered document reaches it.
@@ -1522,28 +1583,13 @@ export class StorageManager implements IStorageManager {
             }
             // Default path: reopening as the user below is the authoritative
             // outcome — it succeeds only if the winning ACL grants access.
-            // Supplied path: that reasoning inverts. The caller's purpose
-            // was a space born with exactly its document; if the winner
-            // wrote a different one (the wildcard default, say) the reopen
-            // would succeed under the winner's grant and nothing would
-            // report that the seal never landed. Fail closed: refuse unless
-            // the space carries exactly the supplied document.
-            if (!isHomeSpace && registered?.supplied === true) {
+            // A demanded document: the winner's must be exactly it.
+            if (demanded !== undefined) {
               const after = await bootstrap.session.queryGraph({
                 roots: [{ id: aclId, selector: { path: [], schema: false } }],
               });
               assertCurrentRoute();
-              const winner = after.entities.find((entity) =>
-                entity.id === aclId && (entity.scope ?? "space") === "space"
-              )?.document?.value;
-              if (!sameAcl(winner, registered.document)) {
-                throw new Error(
-                  `genesis of ${space} was claimed concurrently with a ` +
-                    "different ACL; the supplied genesis document was not " +
-                    "applied and the space is not the one the caller asked " +
-                    "for",
-                );
-              }
+              assertDemandedDocumentStands(aclValueOf(after.entities));
             }
           }
         }
@@ -1561,10 +1607,12 @@ export class StorageManager implements IStorageManager {
           routeSignal,
         ),
       );
-      completed = true;
-      return resumed;
+      return handOff(resumed);
     } finally {
       if (!completed) {
+        if (this.#genesisPhase.get(space) === "in-flight") {
+          this.#genesisPhase.delete(space);
+        }
         routeSignal.removeEventListener("abort", closeActiveClients);
         await Promise.allSettled(
           [...activeClients].map((client) => client.close()),
@@ -1574,6 +1622,10 @@ export class StorageManager implements IStorageManager {
   }
 
   async close(): Promise<void> {
+    // A detached-session resume names the session id this close rotates;
+    // presenting it afterwards would mount the OLD id under a stale token.
+    this.#detachedSessionResumes.clear();
+    this.#genesisPhase.clear();
     // The lease releases AFTER teardown drains: a queued sync frame applied
     // during provider destruction still registers its schema documents
     // inside this session's epoch, not after the clear.
@@ -1602,6 +1654,8 @@ export class StorageManager implements IStorageManager {
   }
 
   async closeNow(): Promise<void> {
+    this.#detachedSessionResumes.clear();
+    this.#genesisPhase.clear();
     try {
       if (this.#providers.size === 0) {
         return;

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -624,6 +624,16 @@ const defaultGenesisAcl = (owner: string): ACL => ({
   ...DEFAULT_GENESIS_GRANTS,
 });
 
+/** Whether a stored ACL document is exactly `expected`: same principals,
+ *  same capabilities, nothing more. Key order is not part of the contract. */
+const sameAcl = (stored: unknown, expected: ACL): boolean => {
+  if (typeof stored !== "object" || stored === null) return false;
+  const actual = stored as Record<string, unknown>;
+  const expectedKeys = Object.keys(expected);
+  return Object.keys(actual).length === expectedKeys.length &&
+    expectedKeys.every((key) => actual[key] === expected[key as keyof ACL]);
+};
+
 export interface Options {
   as: Signer;
 
@@ -924,8 +934,29 @@ export class StorageManager implements IStorageManager {
    * one reader. Absent (every client that registered nothing), the
    * fallback is computed at genesis from the signer, byte-identical to the
    * pre-OW31 shape. A later registration for the same space replaces an
-   * earlier one, as re-registering an owner always did. */
-  #spaceGenesisAcls = new Map<MemorySpace, ACL>();
+   * earlier one, as re-registering an owner always did. `supplied` marks a
+   * caller's own document — the one registration whose genesis must land
+   * exactly or be reported (see the ConflictError arm of
+   * `#createInitializedSession`). */
+  #spaceGenesisAcls = new Map<
+    MemorySpace,
+    { document: ACL; supplied: boolean }
+  >();
+
+  /** Resume options for a space's manager-wide session that
+   * `#createInitializedSession` detached ahead of a bootstrap that then
+   * failed (a refused genesis, a lost route). The memory server keeps a
+   * detached session resumable by its token for a TTL, so the next attempt
+   * must present that token or be refused with "resume token is no longer
+   * valid" — a wedge that hid the real error until the manager closed.
+   * Scoped to the route generation it was minted under: a token belongs
+   * to one host, and a replay after a route replacement must not present
+   * the old host's token to the new one. Consumed by the next attempt on
+   * the same route; cleared once a session is handed to the provider. */
+  #detachedSessionResumes = new Map<
+    MemorySpace,
+    { options: MemoryV2Client.MountOptions; routeGeneration: number }
+  >();
 
   /** Seed map from Options — fixed for the manager's lifetime. */
   #seedHosts: Record<string, string>;
@@ -1123,12 +1154,18 @@ export class StorageManager implements IStorageManager {
     }
     this.#spaceIdentities.set(space, identity);
     if (owner !== undefined) {
-      this.#spaceGenesisAcls.set(space, defaultGenesisAcl(owner));
+      this.#spaceGenesisAcls.set(space, {
+        document: defaultGenesisAcl(owner),
+        supplied: false,
+      });
     }
     if (genesisAcl !== undefined) {
       // Snapshot: what genesis writes is what was registered, not what the
       // caller's object holds by the time the space is first opened.
-      this.#spaceGenesisAcls.set(space, { ...genesisAcl });
+      this.#spaceGenesisAcls.set(space, {
+        document: { ...genesisAcl },
+        supplied: true,
+      });
     }
   }
 
@@ -1344,11 +1381,18 @@ export class StorageManager implements IStorageManager {
 
     try {
       assertCurrentRoute();
+      // A previous attempt on this same route that detached the
+      // manager-wide session and then failed left it resumable only by
+      // token; present it. A resume minted under another route is stale.
+      const detached = this.#detachedSessionResumes.get(space);
+      this.#detachedSessionResumes.delete(space);
       const normal = track(
         await this.#sessionFactory.create(
           space,
           signer,
-          { sessionId: this.#sessionId, ...this.#servingActingAs() },
+          detached !== undefined && detached.routeGeneration === routeGeneration
+            ? detached.options
+            : { sessionId: this.#sessionId, ...this.#servingActingAs() },
           routeSignal,
         ),
       );
@@ -1397,6 +1441,14 @@ export class StorageManager implements IStorageManager {
       };
       activeClients.delete(normal.client);
       await normal.client.close();
+      // From here until the resume below hands a session to the provider,
+      // a failure leaves the manager-wide session detached; remember how
+      // to resume it so the next attempt is not refused for want of the
+      // token (and so the next attempt's error is the real one).
+      this.#detachedSessionResumes.set(space, {
+        options: resumeNormal,
+        routeGeneration,
+      });
       assertCurrentRoute();
       let bootstrapSessionId = crypto.randomUUID();
       while (bootstrapSessionId === this.#sessionId) {
@@ -1425,6 +1477,7 @@ export class StorageManager implements IStorageManager {
         // case and must not be claimed. Home remains the explicit exception.
         const aclStillNeverCreated = snapshot?.seq === 0 &&
           snapshot.document === null;
+        const registered = this.#spaceGenesisAcls.get(space);
         if (
           aclStillNeverCreated &&
           (isHomeSpace || current.serverSeq === 0)
@@ -1439,8 +1492,7 @@ export class StorageManager implements IStorageManager {
             // client.
             const bootstrapAcl = isHomeSpace
               ? { [signer.did()]: "OWNER" }
-              : this.#spaceGenesisAcls.get(space) ??
-                defaultGenesisAcl(signer.did());
+              : registered?.document ?? defaultGenesisAcl(signer.did());
             await bootstrap.session.transact({
               localSeq: 1,
               reads: {
@@ -1462,11 +1514,34 @@ export class StorageManager implements IStorageManager {
             });
           } catch (error) {
             // A concurrent space-authorized initializer may win between the
-            // point read and commit. Reopening as the user below is the
-            // authoritative outcome: it succeeds only if the winning ACL grants
-            // access. Other failures are real bootstrap errors.
+            // point read and commit. Other failures are real bootstrap errors.
             if (!(error instanceof Error) || error.name !== "ConflictError") {
               throw error;
+            }
+            // Default path: reopening as the user below is the authoritative
+            // outcome — it succeeds only if the winning ACL grants access.
+            // Supplied path: that reasoning inverts. The caller's purpose
+            // was a space born with exactly its document; if the winner
+            // wrote a different one (the wildcard default, say) the reopen
+            // would succeed under the winner's grant and nothing would
+            // report that the seal never landed. Fail closed: refuse unless
+            // the space carries exactly the supplied document.
+            if (!isHomeSpace && registered?.supplied === true) {
+              const after = await bootstrap.session.queryGraph({
+                roots: [{ id: aclId, selector: { path: [], schema: false } }],
+              });
+              assertCurrentRoute();
+              const winner = after.entities.find((entity) =>
+                entity.id === aclId && (entity.scope ?? "space") === "space"
+              )?.document?.value;
+              if (!sameAcl(winner, registered.document)) {
+                throw new Error(
+                  `genesis of ${space} was claimed concurrently with a ` +
+                    "different ACL; the supplied genesis document was not " +
+                    "applied and the space is not the one the caller asked " +
+                    "for",
+                );
+              }
             }
           }
         }

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -1138,18 +1138,18 @@ export class StorageManager implements IStorageManager {
    * session (which signs as the SPACE identity, an implicit owner)
    * never does either.
    */
+  #servingActingAs(): { actingAs?: "space-owner" } {
+    return this.#servingHomeSpace !== undefined
+      ? { actingAs: "space-owner" }
+      : {};
+  }
+
   /** The fallback genesis document for a fresh non-home space no caller
    *  supplied one for: the registered owner (else the signer) as OWNER,
    *  plus the rollout default grants. */
   #defaultGenesisAcl(space: MemorySpace, signer: Signer): ACL {
     const genesisOwner = this.#spaceGenesisOwners.get(space) ?? signer.did();
     return { [genesisOwner]: "OWNER", ...DEFAULT_GENESIS_GRANTS };
-  }
-
-  #servingActingAs(): { actingAs?: "space-owner" } {
-    return this.#servingHomeSpace !== undefined
-      ? { actingAs: "space-owner" }
-      : {};
   }
 
   /** The serving manager's HOME space (Options.servingHomeSpace) —

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -5,7 +5,7 @@ import {
   valueFromDataUri,
 } from "@commonfabric/data-model/codec-data-uri";
 import { aclDocId } from "@commonfabric/memory/acl";
-import type { Entity } from "@commonfabric/memory/interface";
+import type { ACL, Entity } from "@commonfabric/memory/interface";
 import {
   type AuthorizationError as IAuthorizationError,
   type ConflictError as IConflictError,
@@ -602,6 +602,21 @@ const dropMaterializedSuffix = (
   }
 };
 
+/**
+ * The grants a fresh non-home space's genesis ACL carries BESIDE its
+ * concrete OWNER when the caller supplied no document of its own: the
+ * rollout default, world-writable until ACL management has a UI
+ * (04-protocol.md §4.5). It is the FALLBACK, not the rule — a caller
+ * holding the space key names the exact document through
+ * `registerSpaceIdentity(identity, { genesisAcl })` and the fallback is
+ * never consulted. Retiring the wildcard is one edit here (`{}`), and one
+ * deliberate rollout decision; nothing else in the genesis path spells the
+ * wildcard out.
+ */
+export const DEFAULT_GENESIS_GRANTS: Readonly<ACL> = Object.freeze({
+  "*": "WRITE",
+});
+
 export interface Options {
   as: Signer;
 
@@ -900,6 +915,12 @@ export class StorageManager implements IStorageManager {
    * the client path (no owner registered) stays byte-identical. */
   #spaceGenesisOwners = new Map<MemorySpace, string>();
 
+  /** Genesis ACL documents registered beside a space identity: the exact
+   * document the space is born with, in place of the owner + rollout
+   * default shape. Keyed apart from the owners so a space names one or
+   * the other, never both. */
+  #spaceGenesisAcls = new Map<MemorySpace, ACL>();
+
   /** Seed map from Options — fixed for the manager's lifetime. */
   #seedHosts: Record<string, string>;
 
@@ -1068,12 +1089,40 @@ export class StorageManager implements IStorageManager {
    * identity appears nowhere in the ACL. Absent (every client), the owner
    * is the manager's signer: the active user, the pre-OW31 shape
    * byte-for-byte.
+   *
+   * `options.genesisAcl` names the EXACT document a fresh space is born
+   * with — its first and only genesis commit, with no intermediate
+   * default ever written — so a space is never in a world-writable state
+   * it did not ask for. It is validated by the memory server's own
+   * genesis admission (a concrete OWNER, an ACL-only commit; INV-12/13),
+   * never here: a refused document leaves the space uninitialized and
+   * the open rejects. It is inert outside true genesis (a populated
+   * ACL-less space, a retracted ACL) and never reaches the home arm.
+   * `owner` and `genesisAcl` are two descriptions of one document, so
+   * supplying both is refused rather than silently ranked.
    */
-  registerSpaceIdentity(identity: Signer, options?: { owner?: string }): void {
-    this.#spaceIdentities.set(identity.did() as MemorySpace, identity);
+  registerSpaceIdentity(
+    identity: Signer,
+    options?: { owner?: string; genesisAcl?: ACL },
+  ): void {
+    const space = identity.did() as MemorySpace;
     const owner = options?.owner;
+    const genesisAcl = options?.genesisAcl;
+    if (owner !== undefined && genesisAcl !== undefined) {
+      throw new Error(
+        `registerSpaceIdentity(${space}): supply either owner or genesisAcl, ` +
+          "not both — genesisAcl is the whole genesis document, and owner " +
+          "only names the OWNER of the default one",
+      );
+    }
+    this.#spaceIdentities.set(space, identity);
     if (owner !== undefined) {
-      this.#spaceGenesisOwners.set(identity.did() as MemorySpace, owner);
+      this.#spaceGenesisOwners.set(space, owner);
+    }
+    if (genesisAcl !== undefined) {
+      // Snapshot: what genesis writes is what was registered, not what the
+      // caller's object holds by the time the space is first opened.
+      this.#spaceGenesisAcls.set(space, { ...genesisAcl });
     }
   }
 
@@ -1089,6 +1138,14 @@ export class StorageManager implements IStorageManager {
    * session (which signs as the SPACE identity, an implicit owner)
    * never does either.
    */
+  /** The fallback genesis document for a fresh non-home space no caller
+   *  supplied one for: the registered owner (else the signer) as OWNER,
+   *  plus the rollout default grants. */
+  #defaultGenesisAcl(space: MemorySpace, signer: Signer): ACL {
+    const genesisOwner = this.#spaceGenesisOwners.get(space) ?? signer.did();
+    return { [genesisOwner]: "OWNER", ...DEFAULT_GENESIS_GRANTS };
+  }
+
   #servingActingAs(): { actingAs?: "space-owner" } {
     return this.#servingHomeSpace !== undefined
       ? { actingAs: "space-owner" }
@@ -1247,8 +1304,10 @@ export class StorageManager implements IStorageManager {
    * durable session always authenticates as `signer`, preserving user/session
    * scope partitioning.
    *
-   * Named-space keys only initialize a truly fresh space, with the active user
-   * as OWNER and wildcard WRITE as the rollout default. Populated ACL-less
+   * Named-space keys only initialize a truly fresh space: with the genesis
+   * document the caller registered beside the key, else the fallback — the
+   * active user (or the registered owner) as OWNER plus the
+   * `DEFAULT_GENESIS_GRANTS` rollout wildcard. Populated ACL-less
    * spaces are the temporary public-compatibility case and stay public. The
    * home identity (`signer.did() === space`) is the explicit private exception:
    * it claims a never-created owner-only ACL even when legacy data already
@@ -1373,15 +1432,17 @@ export class StorageManager implements IStorageManager {
           (isHomeSpace || current.serverSeq === 0)
         ) {
           try {
-            // Non-home genesis owner (OW31, RULED 2026-08-18): the acting
-            // user registered beside the space identity, else the signer
-            // (the active user on a client). The HOME arm is untouched —
-            // a home space is its own identity and owner.
-            const genesisOwner = this.#spaceGenesisOwners.get(space) ??
-              signer.did();
+            // The HOME arm is untouched — a home space is its own
+            // identity and owner, and no registered document reaches it.
+            // Non-home: the caller's registered genesis document verbatim
+            // (sealed by construction), else the fallback shape whose
+            // owner is the acting user registered beside the space
+            // identity (OW31, RULED 2026-08-18) or, absent that, the
+            // signer — the active user on a client.
             const bootstrapAcl = isHomeSpace
               ? { [signer.did()]: "OWNER" }
-              : { [genesisOwner]: "OWNER", "*": "WRITE" };
+              : this.#spaceGenesisAcls.get(space) ??
+                this.#defaultGenesisAcl(space, signer);
             await bootstrap.session.transact({
               localSeq: 1,
               reads: {

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -4,7 +4,7 @@ import {
   hasDataUriScheme,
   valueFromDataUri,
 } from "@commonfabric/data-model/codec-data-uri";
-import { aclDocId, sameAcl } from "@commonfabric/memory/acl";
+import { aclDocId } from "@commonfabric/memory/acl";
 import type { ACL, Entity } from "@commonfabric/memory/interface";
 import {
   type AuthorizationError as IAuthorizationError,
@@ -624,6 +624,28 @@ const defaultGenesisAcl = (owner: string): ACL => ({
   ...DEFAULT_GENESIS_GRANTS,
 });
 
+/** The concrete OWNER principals of a stored ACL document (a non-object
+ *  has none). */
+const ownersOf = (document: unknown): string[] =>
+  typeof document === "object" && document !== null
+    ? Object.entries(document as Record<string, unknown>)
+      .filter(([principal, capability]) =>
+        principal !== "*" && capability === "OWNER"
+      )
+      .map(([principal]) => principal)
+      .sort()
+    : [];
+
+/** Whether a stored ACL document is owned exactly as `expected` says: the
+ *  same concrete OWNER set, no more, no fewer. Grants below OWNER are the
+ *  owner's to evolve and are not compared. */
+const sameOwners = (stored: unknown, expected: ACL): boolean => {
+  const actual = ownersOf(stored);
+  const wanted = ownersOf(expected);
+  return actual.length === wanted.length &&
+    actual.every((principal, index) => principal === wanted[index]);
+};
+
 export interface Options {
   as: Signer;
 
@@ -956,7 +978,10 @@ export class StorageManager implements IStorageManager {
    * genesisAcl registered in either state could never be the space's
    * genesis, so registration refuses. A failed attempt leaves no entry — the
    * caller may correct the document and retry — and close() clears it. */
-  #genesisPhase = new Map<MemorySpace, "in-flight" | "handed-off">();
+  #genesisPhase = new Map<
+    MemorySpace,
+    { phase: "in-flight"; attempt: symbol } | { phase: "handed-off" }
+  >();
 
   /** Seed map from Options — fixed for the manager's lifetime. */
   #seedHosts: Record<string, string>;
@@ -1136,10 +1161,13 @@ export class StorageManager implements IStorageManager {
    * the open rejects, and a corrected registration may retry. The
    * document is a demand: the space's first open on this manager
    * proceeds only if the space is fresh (the document becomes its only
-   * commit) or already carries exactly that document; a space populated
-   * before genesis, or claimed by another initializer with a different
-   * ACL, is refused rather than silently entered under the other ACL's
-   * grant. It never reaches the home arm. A caller that will open the
+   * commit) or is already owned exactly as the document says — a seal
+   * asserts ownership, and grants below OWNER are the owner's to evolve
+   * afterwards, so a creator's restart survives its own grants; a space
+   * populated before genesis, a retracted ACL, or a genesis another
+   * initializer won under a different owner is refused rather than
+   * silently entered under someone else's ACL. It never reaches the
+   * home arm. A caller that will open the
    * space itself must grant its own signer at least READ, or every open
    * after genesis is refused by the server. `owner` and `genesisAcl` are
    * two descriptions of one document, so supplying both in one
@@ -1407,8 +1435,12 @@ export class StorageManager implements IStorageManager {
     };
     routeSignal.addEventListener("abort", closeActiveClients, { once: true });
     let completed = false;
-    if (this.#genesisPhase.get(space) !== "handed-off") {
-      this.#genesisPhase.set(space, "in-flight");
+    // Attempts can overlap across a route replacement; each marks its own
+    // in-flight entry and clears only its own on failure, so a superseded
+    // attempt's exit never unmarks its successor.
+    const attempt = Symbol("genesis attempt");
+    if (this.#genesisPhase.get(space)?.phase !== "handed-off") {
+      this.#genesisPhase.set(space, { phase: "in-flight", attempt });
     }
 
     try {
@@ -1449,7 +1481,7 @@ export class StorageManager implements IStorageManager {
       });
       const handOff = (opened: OpenedSpaceSession): OpenedSpaceSession => {
         this.#detachedSessionResumes.delete(space);
-        this.#genesisPhase.set(space, "handed-off");
+        this.#genesisPhase.set(space, { phase: "handed-off" });
         completed = true;
         return opened;
       };
@@ -1465,35 +1497,58 @@ export class StorageManager implements IStorageManager {
       }
 
       // A caller's own genesis document (never the home arm's) is a
-      // demand, not a preference: this open proceeds only if the space is
-      // fresh (then the document is written) or already carries exactly
-      // that document (a reopen). Anything else — a space populated
-      // before genesis, a genesis another initializer won with a
-      // different ACL, in whichever window it landed — is not the space
-      // the caller asked for, and the reopen below would otherwise
-      // succeed under the winner's grant with nothing reported. Fail
-      // closed.
+      // demand, not a preference. On a fresh space it is written verbatim.
+      // Otherwise the space must be OWNED exactly as the document says: a
+      // seal asserts ownership, and grants evolve afterwards under the
+      // owner's authority (a share space's owner admitting guests), so an
+      // exact-document rule would refuse the creator's own restart after
+      // the first grant. What the ownership rule still refuses — at either
+      // inspection, and after a lost genesis race in whichever window it
+      // landed — is every case where the reopen below would otherwise
+      // succeed under someone else's ACL with nothing reported: a space
+      // populated with no ACL, a retracted ACL, a genesis another
+      // initializer won with a different owner (the wildcard default names
+      // the other user). Fail closed, and say what stands.
       const registered = this.#spaceGenesisAcls.get(space);
       const demanded = !isHomeSpace && registered?.supplied === true
         ? registered.document
         : undefined;
-      const assertDemandedDocumentStands = (stored: unknown): void => {
-        if (demanded !== undefined && !sameAcl(stored, demanded)) {
+      const assertDemandedOwnershipStands = (
+        snapshot:
+          | { seq?: number; document?: { value?: unknown } | null }
+          | undefined,
+      ): void => {
+        if (demanded === undefined) return;
+        const stored = snapshot?.document?.value ?? null;
+        const stands = stored === null
+          ? (snapshot?.seq ?? 0) > 0
+            ? "has a retracted ACL (a tombstone)"
+            : "is populated with no ACL (the legacy-public case)"
+          : sameOwners(stored, demanded)
+          ? undefined
+          : `is owned by ${ownersOf(stored).join(", ") || "nobody"}, not ${
+            ownersOf(demanded).join(", ")
+          }`;
+        if (stands !== undefined) {
           throw new Error(
-            `genesis of ${space} was claimed with a different ACL; the ` +
-              "supplied genesis document was not applied and the space is " +
-              "not the one the caller asked for",
+            `${space} ${stands}; the supplied genesis document cannot be ` +
+              "its genesis and the space is not the one the caller asked for",
           );
         }
       };
-      const aclValueOf = (
+      const aclSnapshotOf = (
         entities: Array<
-          { id: string; scope?: string; document?: { value?: unknown } | null }
+          {
+            id: string;
+            scope?: string;
+            seq?: number;
+            document?: { value?: unknown } | null;
+          }
         >,
-      ): unknown =>
+      ) =>
         entities.find((entity) =>
           entity.id === aclId && (entity.scope ?? "space") === "space"
-        )?.document?.value ?? null;
+        );
 
       const openedServerSeq = normal.session.serverSeq;
       const aclId = aclDocId(space);
@@ -1501,13 +1556,11 @@ export class StorageManager implements IStorageManager {
         roots: [{ id: aclId, selector: { path: [], schema: false } }],
       });
       assertCurrentRoute();
-      const aclSnapshot = aclResult.entities.find((entity) =>
-        entity.id === aclId && (entity.scope ?? "space") === "space"
-      );
+      const aclSnapshot = aclSnapshotOf(aclResult.entities);
       const aclNeverCreated = aclSnapshot?.seq === 0 &&
         aclSnapshot.document === null;
       if (!aclNeverCreated || (!isHomeSpace && openedServerSeq !== 0)) {
-        assertDemandedDocumentStands(aclValueOf(aclResult.entities));
+        assertDemandedOwnershipStands(aclSnapshot);
         return handOff(normal);
       }
 
@@ -1535,9 +1588,7 @@ export class StorageManager implements IStorageManager {
           roots: [{ id: aclId, selector: { path: [], schema: false } }],
         });
         assertCurrentRoute();
-        const snapshot = current.entities.find((entity) =>
-          entity.id === aclId && (entity.scope ?? "space") === "space"
-        );
+        const snapshot = aclSnapshotOf(current.entities);
         // Recheck emptiness in the authority session. In `off` mode an
         // unrelated writer can still populate the space between the first
         // inspection and bootstrap; that turns it into the named legacy-public
@@ -1550,8 +1601,8 @@ export class StorageManager implements IStorageManager {
         ) {
           // Claimed (or populated) between the first inspection and this
           // recheck: the default path reopens as the user below; a
-          // demanded document must already be what stands.
-          assertDemandedDocumentStands(aclValueOf(current.entities));
+          // demanded document's ownership must already be what stands.
+          assertDemandedOwnershipStands(snapshot);
         } else {
           try {
             // The HOME arm is untouched — a home space is its own
@@ -1591,13 +1642,14 @@ export class StorageManager implements IStorageManager {
             }
             // Default path: reopening as the user below is the authoritative
             // outcome — it succeeds only if the winning ACL grants access.
-            // A demanded document: the winner's must be exactly it.
+            // A demanded document: the winner must own the space as it
+            // says.
             if (demanded !== undefined) {
               const after = await bootstrap.session.queryGraph({
                 roots: [{ id: aclId, selector: { path: [], schema: false } }],
               });
               assertCurrentRoute();
-              assertDemandedDocumentStands(aclValueOf(after.entities));
+              assertDemandedOwnershipStands(aclSnapshotOf(after.entities));
             }
           }
         }
@@ -1618,7 +1670,8 @@ export class StorageManager implements IStorageManager {
       return handOff(resumed);
     } finally {
       if (!completed) {
-        if (this.#genesisPhase.get(space) === "in-flight") {
+        const phase = this.#genesisPhase.get(space);
+        if (phase?.phase === "in-flight" && phase.attempt === attempt) {
           this.#genesisPhase.delete(space);
         }
         routeSignal.removeEventListener("abort", closeActiveClients);

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -4,7 +4,7 @@ import {
   hasDataUriScheme,
   valueFromDataUri,
 } from "@commonfabric/data-model/codec-data-uri";
-import { aclDocId } from "@commonfabric/memory/acl";
+import { aclDocId, sameAcl } from "@commonfabric/memory/acl";
 import type { ACL, Entity } from "@commonfabric/memory/interface";
 import {
   type AuthorizationError as IAuthorizationError,
@@ -624,21 +624,20 @@ const defaultGenesisAcl = (owner: string): ACL => ({
   ...DEFAULT_GENESIS_GRANTS,
 });
 
-/** The concrete OWNER principals of a stored ACL document (a non-object
- *  has none). */
+/** The OWNER principals of a stored ACL document, the wildcard included —
+ *  a space with `"*": "OWNER"` is owned by everyone, and a document that
+ *  did not say so is not what stands (a non-object has none). */
 const ownersOf = (document: unknown): string[] =>
   typeof document === "object" && document !== null
     ? Object.entries(document as Record<string, unknown>)
-      .filter(([principal, capability]) =>
-        principal !== "*" && capability === "OWNER"
-      )
+      .filter(([, capability]) => capability === "OWNER")
       .map(([principal]) => principal)
       .sort()
     : [];
 
 /** Whether a stored ACL document is owned exactly as `expected` says: the
- *  same concrete OWNER set, no more, no fewer. Grants below OWNER are the
- *  owner's to evolve and are not compared. */
+ *  same OWNER set, no more, no fewer. Grants below OWNER are the owner's to
+ *  evolve and are not compared. */
 const sameOwners = (stored: unknown, expected: ACL): boolean => {
   const actual = ownersOf(stored);
   const wanted = ownersOf(expected);
@@ -1166,8 +1165,12 @@ export class StorageManager implements IStorageManager {
    * afterwards, so a creator's restart survives its own grants; a space
    * populated before genesis, a retracted ACL, or a genesis another
    * initializer won under a different owner is refused rather than
-   * silently entered under someone else's ACL. It never reaches the
-   * home arm. A caller that will open the
+   * silently entered under someone else's ACL. A genesis race this
+   * attempt loses (the space was fresh when it looked) is held to the
+   * exact document: what stands was written moments ago, not evolved,
+   * and the likely winner — the same user's other runtime writing the
+   * wildcard default — is precisely what the seal refused. It never
+   * reaches the home arm. A caller that will open the
    * space itself must grant its own signer at least READ, or every open
    * after genesis is refused by the server. `owner` and `genesisAcl` are
    * two descriptions of one document, so supplying both in one
@@ -1513,10 +1516,18 @@ export class StorageManager implements IStorageManager {
       const demanded = !isHomeSpace && registered?.supplied === true
         ? registered.document
         : undefined;
+      // `reopen`: the space was not fresh when this attempt first looked —
+      // ownership must match, grants may have evolved. `race`: the space
+      // WAS fresh at this attempt's first inspection, so whatever stands
+      // was written moments ago by a concurrent initializer, not evolved;
+      // the exact document must stand. The likely race is one user's two
+      // runtimes — a sealer against a pattern's default — where the owner
+      // sets agree and the wildcard is exactly what the seal refused.
       const assertDemandedOwnershipStands = (
         snapshot:
           | { seq?: number; document?: { value?: unknown } | null }
           | undefined,
+        arm: "reopen" | "race",
       ): void => {
         if (demanded === undefined) return;
         const stored = snapshot?.document?.value ?? null;
@@ -1524,6 +1535,10 @@ export class StorageManager implements IStorageManager {
           ? (snapshot?.seq ?? 0) > 0
             ? "has a retracted ACL (a tombstone)"
             : "is populated with no ACL (the legacy-public case)"
+          : arm === "race"
+          ? sameAcl(stored, demanded)
+            ? undefined
+            : "was claimed concurrently with a different ACL"
           : sameOwners(stored, demanded)
           ? undefined
           : `is owned by ${ownersOf(stored).join(", ") || "nobody"}, not ${
@@ -1560,7 +1575,7 @@ export class StorageManager implements IStorageManager {
       const aclNeverCreated = aclSnapshot?.seq === 0 &&
         aclSnapshot.document === null;
       if (!aclNeverCreated || (!isHomeSpace && openedServerSeq !== 0)) {
-        assertDemandedOwnershipStands(aclSnapshot);
+        assertDemandedOwnershipStands(aclSnapshot, "reopen");
         return handOff(normal);
       }
 
@@ -1601,8 +1616,8 @@ export class StorageManager implements IStorageManager {
         ) {
           // Claimed (or populated) between the first inspection and this
           // recheck: the default path reopens as the user below; a
-          // demanded document's ownership must already be what stands.
-          assertDemandedOwnershipStands(snapshot);
+          // demanded document must already be exactly what stands.
+          assertDemandedOwnershipStands(snapshot, "race");
         } else {
           try {
             // The HOME arm is untouched — a home space is its own
@@ -1642,14 +1657,16 @@ export class StorageManager implements IStorageManager {
             }
             // Default path: reopening as the user below is the authoritative
             // outcome — it succeeds only if the winning ACL grants access.
-            // A demanded document: the winner must own the space as it
-            // says.
+            // A demanded document: the winner's must be exactly it.
             if (demanded !== undefined) {
               const after = await bootstrap.session.queryGraph({
                 roots: [{ id: aclId, selector: { path: [], schema: false } }],
               });
               assertCurrentRoute();
-              assertDemandedOwnershipStands(aclSnapshotOf(after.entities));
+              assertDemandedOwnershipStands(
+                aclSnapshotOf(after.entities),
+                "race",
+              );
             }
           }
         }

--- a/packages/runner/test/memory-v2-acl-bootstrap.test.ts
+++ b/packages/runner/test/memory-v2-acl-bootstrap.test.ts
@@ -1,15 +1,25 @@
-import { assert, assertEquals, assertExists } from "@std/assert";
+import {
+  assert,
+  assertEquals,
+  assertExists,
+  assertRejects,
+  assertThrows,
+} from "@std/assert";
 import { toFileUrl } from "@std/path";
 import { Identity } from "@commonfabric/identity";
 import type { MemorySpace, Signer, URI } from "@commonfabric/memory/interface";
 import * as MemoryV2Client from "@commonfabric/memory/v2/client";
 import * as MemoryV2Server from "@commonfabric/memory/v2/server";
-import { selectDocHead } from "@commonfabric/memory/v2/engine";
+import {
+  selectCommitsSince,
+  selectDocHead,
+} from "@commonfabric/memory/v2/engine";
 import {
   type Options,
   type SessionFactory,
   StorageManager,
 } from "../src/storage/v2.ts";
+import { Runtime } from "../src/runtime.ts";
 
 const TEST_AUDIENCE = "did:key:z6Mk-runner-acl-bootstrap-audience";
 
@@ -534,6 +544,342 @@ Deno.test("storage without the space signer cannot initialize a foreign space", 
     });
     assertExists(write.error, "ordinary writes must not create the space");
   } finally {
+    await manager.close();
+    await server.close();
+  }
+});
+
+//
+// Genesis-supplied ACL: a caller that holds the space key may name the
+// exact document a fresh space is born with, so the space is never in a
+// world-writable state it did not ask for. Absent, the rollout default
+// (owner + wildcard WRITE — the tests above) is the fallback. The option
+// is inert outside true genesis: a populated ACL-less space, a retracted
+// ACL, and the home arm all behave as if it were never supplied.
+//
+
+Deno.test("a supplied genesis ACL is the space's first and only commit — no wildcard row ever existed", async () => {
+  const daemon = await Identity.fromPassphrase("acl genesis supplied daemon");
+  const spaceIdentity = await Identity.fromPassphrase(
+    "acl genesis supplied space",
+  );
+  const space = spaceIdentity.did();
+  const aclId = `of:${space}` as URI;
+  const server = createServer("runner-acl-genesis-supplied");
+  const factory = new RecordingLoopbackSessionFactory(server);
+  const manager = TestStorageManager.overServer({ as: daemon }, factory);
+  // The downstream shape Loom's share mint wants: the space key is the only
+  // OWNER, the minting daemon is a WRITE principal, nobody else is named.
+  const supplied = {
+    [space]: "OWNER" as const,
+    [daemon.did()]: "WRITE" as const,
+  };
+  manager.registerSpaceIdentity(spaceIdentity, { genesisAcl: supplied });
+  try {
+    const sync = await manager.open(space).sync(aclId);
+    assert(!sync.error, sync.error?.message);
+
+    // The server's stored history, not the client's belief: seq 1 is the
+    // ACL, it is the only commit, and its value is exactly the document.
+    const engine = await server.engineForSpace(space);
+    assertEquals(
+      selectDocHead(engine, { id: aclId, scopeKey: "space" }),
+      1,
+      "the supplied ACL must be the space's first commit",
+    );
+    assertEquals(
+      selectCommitsSince(engine, { fromSeq: 0 }).map((commit) => commit.seq),
+      [1],
+      "genesis must be the only commit — no intermediate default was written",
+    );
+    assertEquals((await server.readDocument(space, aclId))?.value, supplied);
+    assert(
+      !("*" in (await server.readDocument(space, aclId))!.value as object),
+      "no wildcard row",
+    );
+    assertEquals(factory.principals, [
+      daemon.did(),
+      spaceIdentity.did(),
+      daemon.did(),
+    ]);
+
+    // Behavioral proof the wildcard never applied: a stranger's write is
+    // refused where the rollout default would have admitted it.
+    const stranger = await Identity.fromPassphrase(
+      "acl genesis supplied stranger",
+    );
+    const strangerFactory = new RecordingLoopbackSessionFactory(server);
+    await assertRejects(
+      () => strangerFactory.create(space, stranger),
+      Error,
+      undefined,
+      "an unnamed principal must not even open a sealed space",
+    );
+  } finally {
+    await manager.close();
+    await server.close();
+  }
+});
+
+Deno.test("a supplied genesis ACL without a concrete OWNER is refused by the server and the space stays uninitialized", async () => {
+  const daemon = await Identity.fromPassphrase("acl genesis unowned daemon");
+  const spaceIdentity = await Identity.fromPassphrase(
+    "acl genesis unowned space",
+  );
+  const space = spaceIdentity.did();
+  const aclId = `of:${space}` as URI;
+  const server = createServer("runner-acl-genesis-unowned");
+  const factory = new RecordingLoopbackSessionFactory(server);
+  const manager = TestStorageManager.overServer({ as: daemon }, factory);
+  // Structurally a valid ACL, but its only OWNER is the wildcard — the
+  // server's existing genesis check refuses it; the client adds no check.
+  manager.registerSpaceIdentity(spaceIdentity, {
+    genesisAcl: { "*": "OWNER", [daemon.did()]: "WRITE" },
+  });
+  try {
+    await assertRejects(
+      () => manager.ensureSpaceInitialized(space),
+      Error,
+      "concrete OWNER",
+    );
+    // Uninitialized: no ACL, no commits, and ordinary writes still need
+    // genesis (the client could not mint an unowned space).
+    assertEquals(await server.readDocument(space, aclId), null);
+    const engine = await server.engineForSpace(space);
+    assertEquals(selectCommitsSince(engine, { fromSeq: 0 }), []);
+    assertEquals(factory.principals, [daemon.did(), spaceIdentity.did()]);
+  } finally {
+    await manager.close();
+    await server.close();
+  }
+});
+
+Deno.test("registerSpaceIdentity refuses a genesis ACL together with an owner, and snapshots the document", async () => {
+  const user = await Identity.fromPassphrase("acl genesis both user");
+  const spaceIdentity = await Identity.fromPassphrase(
+    "acl genesis both space",
+  );
+  const space = spaceIdentity.did();
+  const server = createServer("runner-acl-genesis-both");
+  const factory = new RecordingLoopbackSessionFactory(server);
+  const manager = TestStorageManager.overServer({ as: user }, factory);
+  try {
+    // Two descriptions of one document: refused rather than silently
+    // preferring one.
+    assertThrows(
+      () =>
+        manager.registerSpaceIdentity(spaceIdentity, {
+          owner: user.did(),
+          genesisAcl: { [user.did()]: "OWNER" },
+        }),
+      Error,
+      "genesisAcl",
+    );
+    // The document is copied at registration: a caller mutating their
+    // object afterwards cannot change what genesis writes.
+    const supplied: Record<string, "READ" | "WRITE" | "OWNER"> = {
+      [user.did()]: "OWNER",
+    };
+    manager.registerSpaceIdentity(spaceIdentity, { genesisAcl: supplied });
+    supplied["*"] = "WRITE";
+    const sync = await manager.open(space).sync(`of:${space}` as URI);
+    assert(!sync.error, sync.error?.message);
+    assertEquals((await server.readDocument(space, `of:${space}`))?.value, {
+      [user.did()]: "OWNER",
+    });
+  } finally {
+    await manager.close();
+    await server.close();
+  }
+});
+
+/** Open `space` on a fresh manager over `store`, with or without a supplied
+ * genesis ACL, and report what the server holds afterwards. The two arms of
+ * an "inert outside genesis" test must agree on every field. */
+const observeOpen = async (
+  store: URL,
+  user: Signer,
+  spaceIdentity: Signer,
+  probe: URI,
+  genesisAcl?: Record<string, "READ" | "WRITE" | "OWNER">,
+) => {
+  const space = spaceIdentity.did() as MemorySpace;
+  const server = createServer("unused", { store });
+  const factory = new RecordingLoopbackSessionFactory(server);
+  const manager = TestStorageManager.overServer({ as: user }, factory);
+  manager.registerSpaceIdentity(
+    spaceIdentity,
+    genesisAcl !== undefined ? { genesisAcl } : undefined,
+  );
+  try {
+    const sync = await manager.open(space).sync(probe);
+    const engine = await server.engineForSpace(space);
+    return {
+      syncFailed: sync.error !== undefined,
+      acl: (await server.readDocument(space, `of:${space}`))?.value ?? null,
+      commits: selectCommitsSince(engine, { fromSeq: 0 }).map((c) => c.seq),
+      principals: [...factory.principals],
+    };
+  } finally {
+    await manager.close();
+    await server.close();
+  }
+};
+
+Deno.test("a supplied genesis ACL is inert on a populated ACL-less named space (legacy public stays public)", async () => {
+  const directory = await Deno.makeTempDir({
+    prefix: "runner-acl-genesis-legacy-",
+  });
+  const store = toFileUrl(`${directory}/`);
+  const user = await Identity.fromPassphrase("acl genesis legacy user");
+  const spaceIdentity = await Identity.fromPassphrase(
+    "acl genesis legacy space",
+  );
+  const space = spaceIdentity.did();
+  try {
+    const seedServer = createServer("unused", { store, mode: "off" });
+    try {
+      await seedServer.writeDocument(space, "of:legacy-named", {
+        legacy: true,
+      });
+    } finally {
+      await seedServer.close();
+    }
+    const without = await observeOpen(
+      store,
+      user,
+      spaceIdentity,
+      "of:legacy-named" as URI,
+    );
+    const withAcl = await observeOpen(
+      store,
+      user,
+      spaceIdentity,
+      "of:legacy-named" as URI,
+      { [space]: "OWNER" },
+    );
+    assertEquals(withAcl, without);
+    assertEquals(without.acl, null, "the legacy space must not be claimed");
+    assertEquals(without.principals, [user.did()], "no bootstrap session");
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+// Mutation note: the legacy-space test above reddens when the option is
+// let past the client's true-genesis preconditions (witnessed). This one
+// does not — a retracted ACL fails closed at the SERVER before any
+// bootstrap session can act, in both arms — so it pins that the option
+// changes no observable outcome there, not that a client guard exists.
+Deno.test("a supplied genesis ACL is inert on a retracted named ACL (a tombstone is never recreated)", async () => {
+  const directory = await Deno.makeTempDir({
+    prefix: "runner-acl-genesis-retracted-",
+  });
+  const store = toFileUrl(`${directory}/`);
+  const user = await Identity.fromPassphrase("acl genesis retracted user");
+  const spaceIdentity = await Identity.fromPassphrase(
+    "acl genesis retracted space",
+  );
+  const space = spaceIdentity.did();
+  const aclId = `of:${space}` as URI;
+  try {
+    const seedServer = createServer("unused", { store, mode: "off" });
+    try {
+      await seedServer.writeDocument(space, aclId, { [user.did()]: "OWNER" });
+      const seeded = await new RecordingLoopbackSessionFactory(seedServer)
+        .create(space, user);
+      try {
+        await seeded.session.transact({
+          localSeq: 1,
+          reads: { confirmed: [], pending: [] },
+          operations: [{ op: "delete", id: aclId }],
+        });
+      } finally {
+        await seeded.client.close();
+      }
+      assertEquals(await seedServer.readDocument(space, aclId), null);
+    } finally {
+      await seedServer.close();
+    }
+    const without = await observeOpen(store, user, spaceIdentity, aclId);
+    const withAcl = await observeOpen(store, user, spaceIdentity, aclId, {
+      [space]: "OWNER",
+    });
+    assertEquals(withAcl, without);
+    assertEquals(without.acl, null, "the tombstone must stand");
+    assertEquals(without.commits, [1, 2], "no third commit");
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("a genesis ACL registered under the home identity does not reach the home arm", async () => {
+  const user = await Identity.fromPassphrase("acl genesis home user");
+  const space = user.did();
+  const server = createServer("runner-acl-genesis-home");
+  const factory = new RecordingLoopbackSessionFactory(server);
+  const manager = TestStorageManager.overServer({ as: user }, factory);
+  // The home arm is not generalized over: it claims owner-only regardless.
+  manager.registerSpaceIdentity(user, {
+    genesisAcl: { "*": "WRITE", [space]: "OWNER" },
+  });
+  try {
+    const sync = await manager.open(space).sync(`of:${space}` as URI);
+    assert(!sync.error, sync.error?.message);
+    assertEquals((await server.readDocument(space, `of:${space}`))?.value, {
+      [space]: "OWNER",
+    });
+    // The home arm's own three-session dance, every one as the home identity.
+    assertEquals(factory.principals, [space, space, space]);
+  } finally {
+    await manager.close();
+    await server.close();
+  }
+});
+
+Deno.test("runtime.resolveSpaceName threads a supplied genesis ACL to the named space's first commit", async () => {
+  const user = await Identity.fromPassphrase("acl genesis resolve user");
+  const member = await Identity.fromPassphrase("acl genesis resolve member");
+  const server = createServer("runner-acl-genesis-resolve");
+  const factory = new RecordingLoopbackSessionFactory(server);
+  const manager = TestStorageManager.overServer({ as: user }, factory);
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager: manager,
+  });
+  try {
+    const supplied = {
+      [user.did()]: "OWNER" as const,
+      [member.did()]: "WRITE" as const,
+    };
+    // The public seam: the name resolves to a DID and registers the derived
+    // space key with the document, and the first open writes it verbatim.
+    const space = await runtime.resolveSpaceName("genesis-acl-probe", {
+      genesisAcl: supplied,
+    });
+    await manager.ensureSpaceInitialized(space);
+    const engine = await server.engineForSpace(space);
+    assertEquals(
+      selectCommitsSince(engine, { fromSeq: 0 }).map((commit) => commit.seq),
+      [1],
+    );
+    assertEquals(
+      (await server.readDocument(space, `of:${space}`))?.value,
+      supplied,
+    );
+    // A serving-posture refusal is unchanged by the new option: owner is
+    // still required there (OW31), and the two cannot be combined.
+    await assertRejects(
+      () =>
+        runtime.resolveSpaceName("genesis-acl-both", {
+          owner: user.did(),
+          genesisAcl: supplied,
+        }),
+      Error,
+      "not both",
+    );
+  } finally {
+    await runtime.dispose();
     await manager.close();
     await server.close();
   }

--- a/packages/runner/test/memory-v2-acl-bootstrap.test.ts
+++ b/packages/runner/test/memory-v2-acl-bootstrap.test.ts
@@ -921,3 +921,196 @@ Deno.test("a serving runtime refuses a supplied genesis ACL explicitly (OW31 pro
     await server.close();
   }
 });
+
+/** A bootstrap-capable factory whose SPACE-identity session holds its
+ * transact at a gate the test opens, so a concurrent initializer can land
+ * between the sealer's recheck and its commit — the interleaving the
+ * ConflictError swallow exists for. No timers: the runner's test clock
+ * freezes wall-clock sleeps armed from test files. */
+class GatedGenesisSessionFactory extends RecordingLoopbackSessionFactory {
+  readonly #space: string;
+  readonly #gate: Promise<void>;
+  /** Resolves once the gated transact has been entered (past the recheck). */
+  readonly held: Promise<void>;
+  #markHeld!: () => void;
+  constructor(
+    server: MemoryV2Server.Server,
+    space: string,
+    gate: Promise<void>,
+  ) {
+    super(server);
+    this.#space = space;
+    this.#gate = gate;
+    this.held = new Promise<void>((resolve) => {
+      this.#markHeld = resolve;
+    });
+  }
+  override async create(
+    space: MemorySpace,
+    signer?: Signer,
+    requested: MemoryV2Client.MountOptions = {},
+  ) {
+    const opened = await super.create(space, signer, requested);
+    if (signer?.did() === this.#space) {
+      const session = opened.session as unknown as {
+        transact: (...args: unknown[]) => Promise<unknown>;
+      };
+      const transact = session.transact.bind(session);
+      session.transact = async (...args: unknown[]) => {
+        this.#markHeld();
+        await this.#gate;
+        return await transact(...args);
+      };
+    }
+    return opened;
+  }
+}
+
+const gate = (): { opened: Promise<void>; open: () => void } => {
+  let open!: () => void;
+  const opened = new Promise<void>((resolve) => {
+    open = resolve;
+  });
+  return { opened, open };
+};
+
+Deno.test("a sealer that loses the genesis race to a different document is told, not silently admitted under the winner's wildcard", async () => {
+  const alice = await Identity.fromPassphrase("acl genesis race alice");
+  const bob = await Identity.fromPassphrase("acl genesis race bob");
+  const spaceIdentity = await Identity.fromPassphrase("acl genesis race space");
+  const space = spaceIdentity.did();
+  const aclId = `of:${space}` as URI;
+  const server = createServer("runner-acl-genesis-race");
+  // Alice seals; her bootstrap commit is held until Bob's default genesis
+  // has landed.
+  const aliceGate = gate();
+  const aliceFactory = new GatedGenesisSessionFactory(
+    server,
+    space,
+    aliceGate.opened,
+  );
+  const aliceManager = TestStorageManager.overServer(
+    { as: alice },
+    aliceFactory,
+  );
+  const bobManager = TestStorageManager.overServer(
+    { as: bob, spaceIdentity },
+    new RecordingLoopbackSessionFactory(server),
+  );
+  const sealed = { [space]: "OWNER" as const, [alice.did()]: "WRITE" as const };
+  aliceManager.registerSpaceIdentity(spaceIdentity, { genesisAcl: sealed });
+  try {
+    const aliceOpen = aliceManager.ensureSpaceInitialized(space);
+    await aliceFactory.held;
+    const bobSync = await bobManager.open(space).sync("of:race-bob" as URI);
+    assert(!bobSync.error, bobSync.error?.message);
+    aliceGate.open();
+    // Red-first witnessed: the swallow let Alice's open SUCCEED — the
+    // winner's wildcard granted her access — with her document discarded
+    // and nothing reported.
+    await assertRejects(() => aliceOpen, Error, "different ACL");
+    // The winner's document stands; Alice's was never applied.
+    assertEquals((await server.readDocument(space, aclId))?.value, {
+      [bob.did()]: "OWNER",
+      "*": "WRITE",
+    });
+  } finally {
+    await aliceManager.close();
+    await bobManager.close();
+    await server.close();
+  }
+});
+
+Deno.test("two sealers racing with the SAME document both succeed (the conflict is benign)", async () => {
+  const alice = await Identity.fromPassphrase("acl genesis same-doc alice");
+  const bob = await Identity.fromPassphrase("acl genesis same-doc bob");
+  const spaceIdentity = await Identity.fromPassphrase(
+    "acl genesis same-doc space",
+  );
+  const space = spaceIdentity.did();
+  const server = createServer("runner-acl-genesis-same-doc");
+  const sealed = {
+    [space]: "OWNER" as const,
+    [alice.did()]: "WRITE" as const,
+    [bob.did()]: "WRITE" as const,
+  };
+  const aliceGate = gate();
+  const aliceFactory = new GatedGenesisSessionFactory(
+    server,
+    space,
+    aliceGate.opened,
+  );
+  const aliceManager = TestStorageManager.overServer(
+    { as: alice },
+    aliceFactory,
+  );
+  const bobManager = TestStorageManager.overServer(
+    { as: bob },
+    new RecordingLoopbackSessionFactory(server),
+  );
+  aliceManager.registerSpaceIdentity(spaceIdentity, { genesisAcl: sealed });
+  bobManager.registerSpaceIdentity(spaceIdentity, { genesisAcl: sealed });
+  try {
+    const aliceOpen = aliceManager.ensureSpaceInitialized(space);
+    await aliceFactory.held;
+    await bobManager.ensureSpaceInitialized(space);
+    aliceGate.open();
+    await aliceOpen;
+    assertEquals(
+      (await server.readDocument(space, `of:${space}`))?.value,
+      sealed,
+    );
+    const engine = await server.engineForSpace(space);
+    assertEquals(
+      selectCommitsSince(engine, { fromSeq: 0 }).map((commit) => commit.seq),
+      [1],
+    );
+  } finally {
+    await aliceManager.close();
+    await bobManager.close();
+    await server.close();
+  }
+});
+
+Deno.test("a refused genesis does not wedge the space: retries surface the real error and a corrected document recovers", async () => {
+  const daemon = await Identity.fromPassphrase("acl genesis recover daemon");
+  const spaceIdentity = await Identity.fromPassphrase(
+    "acl genesis recover space",
+  );
+  const space = spaceIdentity.did();
+  const aclId = `of:${space}` as URI;
+  const server = createServer("runner-acl-genesis-recover");
+  const factory = new RecordingLoopbackSessionFactory(server);
+  const manager = TestStorageManager.overServer({ as: daemon }, factory);
+  manager.registerSpaceIdentity(spaceIdentity, {
+    genesisAcl: { "*": "OWNER", [daemon.did()]: "WRITE" },
+  });
+  try {
+    await assertRejects(
+      () => manager.ensureSpaceInitialized(space),
+      Error,
+      "concrete OWNER",
+    );
+    // Red-first witnessed: the second attempt failed with "resume token is
+    // no longer valid" — the manager-wide session had been detached by the
+    // first attempt and never resumed — and so did every attempt after
+    // the document was corrected, until manager.close() rotated the id.
+    await assertRejects(
+      () => manager.ensureSpaceInitialized(space),
+      Error,
+      "concrete OWNER",
+    );
+    const corrected = {
+      [space]: "OWNER" as const,
+      [daemon.did()]: "WRITE" as const,
+    };
+    manager.registerSpaceIdentity(spaceIdentity, { genesisAcl: corrected });
+    await manager.ensureSpaceInitialized(space);
+    assertEquals((await server.readDocument(space, aclId))?.value, corrected);
+    const sync = await manager.open(space).sync(aclId);
+    assert(!sync.error, sync.error?.message);
+  } finally {
+    await manager.close();
+    await server.close();
+  }
+});

--- a/packages/runner/test/memory-v2-acl-bootstrap.test.ts
+++ b/packages/runner/test/memory-v2-acl-bootstrap.test.ts
@@ -553,9 +553,11 @@ Deno.test("storage without the space signer cannot initialize a foreign space", 
 // Genesis-supplied ACL: a caller that holds the space key may name the
 // exact document a fresh space is born with, so the space is never in a
 // world-writable state it did not ask for. Absent, the rollout default
-// (owner + wildcard WRITE — the tests above) is the fallback. The option
-// is inert outside true genesis: a populated ACL-less space, a retracted
-// ACL, and the home arm all behave as if it were never supplied.
+// (owner + wildcard WRITE — the tests above) is the fallback. Outside true
+// genesis the option fails closed rather than going inert: a populated
+// ACL-less space and a lost race refuse the open, a retracted ACL is
+// refused by the server before the client can act, and the home arm never
+// consults the document.
 //
 
 Deno.test("a supplied genesis ACL is the space's first and only commit — no wildcard row ever existed", async () => {
@@ -902,21 +904,25 @@ Deno.test("a serving runtime refuses a supplied genesis ACL explicitly (OW31 pro
     // genesis "would name the SERVICE as owner"), and a document plus an
     // owner hit registerSpaceIdentity's not-both refusal — a closed door
     // by accident rather than by decision.
-    for (
-      const options of [
-        { genesisAcl: { [alice.did()]: "OWNER" as const } },
-        {
+    await assertRejects(
+      () =>
+        runtime.resolveSpaceName("genesis-acl-serving", {
+          genesisAcl: { [alice.did()]: "OWNER" },
+        }),
+      Error,
+      "serving runtime does not accept genesisAcl",
+    );
+    // With an owner beside it, the not-both refusal comes first — the same
+    // precedence as registerSpaceIdentity, on every runtime.
+    await assertRejects(
+      () =>
+        runtime.resolveSpaceName("genesis-acl-serving", {
           owner: alice.did(),
-          genesisAcl: { [alice.did()]: "OWNER" as const },
-        },
-      ]
-    ) {
-      await assertRejects(
-        () => runtime.resolveSpaceName("genesis-acl-serving", options),
-        Error,
-        "serving runtime does not accept genesisAcl",
-      );
-    }
+          genesisAcl: { [alice.did()]: "OWNER" },
+        }),
+      Error,
+      "not both",
+    );
     assertEquals(
       runtime.resolveSpaceNameSync("genesis-acl-serving"),
       undefined,
@@ -1652,6 +1658,119 @@ Deno.test("a wildcard OWNER counts as an owner: a space owned by everyone is not
       "owned by",
     );
   } finally {
+    await manager.close();
+    await server.close();
+  }
+});
+
+Deno.test("runtime.resolveSpaceName refuses owner beside genesisAcl even on a cached name, and refuses a genesisAcl its storage manager cannot register", async () => {
+  const user = await Identity.fromPassphrase("acl genesis cubic user");
+  const server = createServer("runner-acl-genesis-cubic");
+  const manager = TestStorageManager.overServer(
+    { as: user },
+    new RecordingLoopbackSessionFactory(server),
+  );
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager: manager,
+  });
+  const sealed = { [user.did()]: "OWNER" as const };
+  try {
+    await runtime.resolveSpaceName("genesis-acl-owner-and-doc", {
+      genesisAcl: sealed,
+    });
+    // Red-first witnessed: the cached path returned the DID and silently
+    // dropped the conflicting owner.
+    await assertRejects(
+      () =>
+        runtime.resolveSpaceName("genesis-acl-owner-and-doc", {
+          owner: user.did(),
+          genesisAcl: sealed,
+        }),
+      Error,
+      "not both",
+    );
+    // A storage manager with no registerSpaceIdentity seam has nowhere to
+    // put the document; the optional call used to drop it silently.
+    const seamless = new Proxy(manager, {
+      get(target, property, receiver) {
+        if (property === "registerSpaceIdentity") return undefined;
+        const value = Reflect.get(target, property, receiver);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    });
+    const bare = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: seamless,
+    });
+    try {
+      await assertRejects(
+        () =>
+          bare.resolveSpaceName("genesis-acl-no-seam", { genesisAcl: sealed }),
+        Error,
+        "cannot register",
+      );
+      assertEquals(bare.resolveSpaceNameSync("genesis-acl-no-seam"), undefined);
+    } finally {
+      await bare.dispose();
+    }
+  } finally {
+    await runtime.dispose();
+    await manager.close();
+    await server.close();
+  }
+});
+
+Deno.test("runtime.resolveSpaceName: two concurrent resolutions of one uncached name with different documents cannot both register", async () => {
+  const user = await Identity.fromPassphrase("acl genesis concurrent user");
+  const other = await Identity.fromPassphrase("acl genesis concurrent other");
+  const server = createServer("runner-acl-genesis-concurrent");
+  const factory = new RecordingLoopbackSessionFactory(server);
+  const manager = TestStorageManager.overServer({ as: user }, factory);
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager: manager,
+  });
+  const first = { [user.did()]: "OWNER" as const };
+  const second = {
+    [user.did()]: "OWNER" as const,
+    [other.did()]: "WRITE" as const,
+  };
+  try {
+    // Red-first witnessed: both passed the cache check before either
+    // registration, the second overwrote the first, and the space was born
+    // with the SECOND document while the first caller believed it sealed.
+    const [a, b] = await Promise.allSettled([
+      runtime.resolveSpaceName("genesis-acl-concurrent", { genesisAcl: first }),
+      runtime.resolveSpaceName("genesis-acl-concurrent", {
+        genesisAcl: second,
+      }),
+    ]);
+    assertEquals(a.status, "fulfilled", "the first resolution wins");
+    assertEquals(b.status, "rejected", "the conflicting second is refused");
+    assert(
+      b.status === "rejected" &&
+        String(b.reason).includes("different genesisAcl"),
+      String((b as PromiseRejectedResult).reason),
+    );
+    const space = (a as PromiseFulfilledResult<MemorySpace>).value;
+    // An identical concurrent request is a retry and shares the outcome.
+    const [c, d] = await Promise.all([
+      runtime.resolveSpaceName("genesis-acl-concurrent-same", {
+        genesisAcl: first,
+      }),
+      runtime.resolveSpaceName("genesis-acl-concurrent-same", {
+        genesisAcl: first,
+      }),
+    ]);
+    assertEquals(c, d);
+    await manager.ensureSpaceInitialized(space);
+    assertEquals(
+      (await server.readDocument(space, `of:${space}`))?.value,
+      first,
+    );
+  } finally {
+    await runtime.dispose();
     await manager.close();
     await server.close();
   }

--- a/packages/runner/test/memory-v2-acl-bootstrap.test.ts
+++ b/packages/runner/test/memory-v2-acl-bootstrap.test.ts
@@ -1775,3 +1775,57 @@ Deno.test("runtime.resolveSpaceName: two concurrent resolutions of one uncached 
     await server.close();
   }
 });
+
+Deno.test("runtime.resolveSpaceName: a joiner shares a failed resolution's rejection rather than retrying on its own", async () => {
+  const user = await Identity.fromPassphrase("acl genesis joiner user");
+  const server = createServer("runner-acl-genesis-joiner");
+  const factory = new RecordingLoopbackSessionFactory(server);
+  (factory as { supportsAclBootstrap: boolean }).supportsAclBootstrap = false;
+  const manager = TestStorageManager.overServer({ as: user }, factory);
+  let registrations = 0;
+  // Every registration is refused (the factory cannot bootstrap); count them.
+  const counting = new Proxy(manager, {
+    get(target, property, receiver) {
+      if (property === "registerSpaceIdentity") {
+        return (...args: unknown[]) => {
+          registrations++;
+          return (target.registerSpaceIdentity as (...a: unknown[]) => void)(
+            ...args,
+          );
+        };
+      }
+      const value = Reflect.get(target, property, receiver);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  });
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager: counting,
+  });
+  try {
+    // Red-first witnessed: the joiner swallowed the first rejection and ran
+    // a second registration attempt of its own (registrations === 2).
+    const outcomes = await Promise.allSettled([
+      runtime.resolveSpaceName("genesis-acl-joiner", {
+        genesisAcl: { [user.did()]: "OWNER" },
+      }),
+      runtime.resolveSpaceName("genesis-acl-joiner", {
+        genesisAcl: { [user.did()]: "OWNER" },
+      }),
+    ]);
+    assertEquals(outcomes.map((o) => o.status), ["rejected", "rejected"]);
+    for (const outcome of outcomes) {
+      assert(
+        String((outcome as PromiseRejectedResult).reason).includes(
+          "cannot bootstrap",
+        ),
+      );
+    }
+    assertEquals(registrations, 1, "one attempt, shared by both callers");
+    assertEquals(runtime.resolveSpaceNameSync("genesis-acl-joiner"), undefined);
+  } finally {
+    await runtime.dispose();
+    await manager.close();
+    await server.close();
+  }
+});

--- a/packages/runner/test/memory-v2-acl-bootstrap.test.ts
+++ b/packages/runner/test/memory-v2-acl-bootstrap.test.ts
@@ -726,7 +726,7 @@ const observeOpen = async (
   }
 };
 
-Deno.test("a supplied genesis ACL is inert on a populated ACL-less named space (legacy public stays public)", async () => {
+Deno.test("a supplied genesis ACL on a populated ACL-less named space is refused, and the space is not claimed", async () => {
   const directory = await Deno.makeTempDir({
     prefix: "runner-acl-genesis-legacy-",
   });
@@ -745,12 +745,19 @@ Deno.test("a supplied genesis ACL is inert on a populated ACL-less named space (
     } finally {
       await seedServer.close();
     }
+    // Without a document the legacy-public rule stands, as before.
     const without = await observeOpen(
       store,
       user,
       spaceIdentity,
       "of:legacy-named" as URI,
     );
+    assertEquals(without.syncFailed, false, "legacy-public reads succeed");
+    assertEquals(without.acl, null, "the legacy space must not be claimed");
+    assertEquals(without.principals, [user.did()], "no bootstrap session");
+    // Red-first witnessed: with a document the open SUCCEEDED and the
+    // sealer was handed the legacy-public space with no error. The space
+    // is not the one the caller asked for; fail closed.
     const withAcl = await observeOpen(
       store,
       user,
@@ -758,20 +765,18 @@ Deno.test("a supplied genesis ACL is inert on a populated ACL-less named space (
       "of:legacy-named" as URI,
       { [space]: "OWNER" },
     );
-    assertEquals(withAcl, without);
-    assertEquals(without.syncFailed, false, "legacy-public reads succeed");
-    assertEquals(without.acl, null, "the legacy space must not be claimed");
-    assertEquals(without.principals, [user.did()], "no bootstrap session");
+    assertEquals(withAcl.syncFailed, true, "the sealer is refused");
+    assertEquals(withAcl.acl, null, "still not claimed");
+    assertEquals(withAcl.commits, without.commits, "nothing written");
+    assertEquals(withAcl.principals, [user.did()], "no bootstrap session");
   } finally {
     await Deno.remove(directory, { recursive: true });
   }
 });
 
-// Mutation note: the legacy-space test above reddens when the option is
-// let past the client's true-genesis preconditions (witnessed). This one
-// does not — a retracted ACL fails closed at the SERVER before any
-// bootstrap session can act, in both arms — so it pins that the option
-// changes no observable outcome there, not that a client guard exists.
+// A retracted ACL fails closed at the SERVER before any bootstrap session
+// can act, in both arms, so this pins that the option changes no
+// observable outcome there rather than exercising a client guard.
 Deno.test("a supplied genesis ACL is inert on a retracted named ACL (a tombstone is never recreated)", async () => {
   const directory = await Deno.makeTempDir({
     prefix: "runner-acl-genesis-retracted-",
@@ -932,17 +937,20 @@ Deno.test("a serving runtime refuses a supplied genesis ACL explicitly (OW31 pro
 class GatedGenesisSessionFactory extends RecordingLoopbackSessionFactory {
   readonly #space: string;
   readonly #gate: Promise<void>;
-  /** Resolves once the gated transact has been entered (past the recheck). */
+  readonly #method: "transact" | "queryGraph";
+  /** Resolves once the gated call has been entered. */
   readonly held: Promise<void>;
   #markHeld!: () => void;
   constructor(
     server: MemoryV2Server.Server,
     space: string,
     gate: Promise<void>,
+    method: "transact" | "queryGraph" = "transact",
   ) {
     super(server);
     this.#space = space;
     this.#gate = gate;
+    this.#method = method;
     this.held = new Promise<void>((resolve) => {
       this.#markHeld = resolve;
     });
@@ -954,14 +962,15 @@ class GatedGenesisSessionFactory extends RecordingLoopbackSessionFactory {
   ) {
     const opened = await super.create(space, signer, requested);
     if (signer?.did() === this.#space) {
-      const session = opened.session as unknown as {
-        transact: (...args: unknown[]) => Promise<unknown>;
-      };
-      const transact = session.transact.bind(session);
-      session.transact = async (...args: unknown[]) => {
+      const session = opened.session as unknown as Record<
+        string,
+        (...args: unknown[]) => Promise<unknown>
+      >;
+      const original = session[this.#method].bind(session);
+      session[this.#method] = async (...args: unknown[]) => {
         this.#markHeld();
         await this.#gate;
-        return await transact(...args);
+        return await original(...args);
       };
     }
     return opened;
@@ -1198,6 +1207,210 @@ Deno.test("registerSpaceIdentity refuses a genesis ACL on a manager whose sessio
     );
     // The owner option keeps its pre-existing, ignorable semantics.
     manager.registerSpaceIdentity(spaceIdentity, { owner: user.did() });
+  } finally {
+    await manager.close();
+    await server.close();
+  }
+});
+
+Deno.test("a manager reused after close() mounts its NEW session id (no stale detached resume survives close)", async () => {
+  const user = await Identity.fromPassphrase("acl genesis reuse user");
+  const spaceIdentity = await Identity.fromPassphrase(
+    "acl genesis reuse space",
+  );
+  const space = spaceIdentity.did();
+  const server = createServer("runner-acl-genesis-reuse");
+  const factory = new RecordingLoopbackSessionFactory(server);
+  const manager = TestStorageManager.overServer(
+    { as: user, spaceIdentity },
+    factory,
+  );
+  try {
+    // Plain default genesis — the path every client runs.
+    const first = await manager.open(space).sync(`of:${space}` as URI);
+    assert(!first.error, first.error?.message);
+    const firstId = manager.scopeKeyIdentity().sessionId;
+    await manager.close();
+    // Red-first witnessed: the reopen presented the pre-close session id and
+    // its pre-rotation token — "resume token is no longer valid".
+    const second = await manager.open(space).sync(`of:${space}` as URI);
+    assert(!second.error, second.error?.message);
+    const secondId = manager.scopeKeyIdentity().sessionId;
+    assert(firstId !== secondId, "close() rotates the session id");
+    assertEquals(
+      factory.sessions.at(-1)?.requested.sessionId,
+      secondId,
+      "the reopen mounts the manager's current session id",
+    );
+    assertEquals(factory.sessions.at(-1)?.actualSessionId, secondId);
+  } finally {
+    await manager.close();
+    await server.close();
+  }
+});
+
+Deno.test("a refused genesis, then close(), then a corrected document: the recovery mounts the NEW session id", async () => {
+  const daemon = await Identity.fromPassphrase(
+    "acl genesis close-recover daemon",
+  );
+  const spaceIdentity = await Identity.fromPassphrase(
+    "acl genesis close-recover space",
+  );
+  const space = spaceIdentity.did();
+  const server = createServer("runner-acl-genesis-close-recover");
+  const factory = new RecordingLoopbackSessionFactory(server);
+  const manager = TestStorageManager.overServer({ as: daemon }, factory);
+  manager.registerSpaceIdentity(spaceIdentity, {
+    genesisAcl: { "*": "OWNER", [daemon.did()]: "WRITE" },
+  });
+  try {
+    await assertRejects(
+      () => manager.ensureSpaceInitialized(space),
+      Error,
+      "concrete OWNER",
+    );
+    await manager.close();
+    const corrected = {
+      [space]: "OWNER" as const,
+      [daemon.did()]: "WRITE" as const,
+    };
+    manager.registerSpaceIdentity(spaceIdentity, { genesisAcl: corrected });
+    await manager.ensureSpaceInitialized(space);
+    // Red-first witnessed: the recovery succeeded but on the OLD session id
+    // while scopeKeyIdentity() reported the new one.
+    assertEquals(
+      factory.sessions.at(-1)?.actualSessionId,
+      manager.scopeKeyIdentity().sessionId,
+    );
+    assertEquals(
+      (await server.readDocument(space, `of:${space}`))?.value,
+      corrected,
+    );
+  } finally {
+    await manager.close();
+    await server.close();
+  }
+});
+
+Deno.test("a sealer that loses the race in the RECHECK window (before its commit) is told too", async () => {
+  const alice = await Identity.fromPassphrase("acl genesis recheck alice");
+  const bob = await Identity.fromPassphrase("acl genesis recheck bob");
+  const spaceIdentity = await Identity.fromPassphrase(
+    "acl genesis recheck space",
+  );
+  const space = spaceIdentity.did();
+  const server = createServer("runner-acl-genesis-recheck");
+  // Alice's bootstrap session is held at its RECHECK query, so Bob's default
+  // genesis lands between Alice's first inspection and her recheck.
+  const aliceGate = gate();
+  const aliceFactory = new GatedGenesisSessionFactory(
+    server,
+    space,
+    aliceGate.opened,
+    "queryGraph",
+  );
+  const aliceManager = TestStorageManager.overServer(
+    { as: alice },
+    aliceFactory,
+  );
+  const bobManager = TestStorageManager.overServer(
+    { as: bob, spaceIdentity },
+    new RecordingLoopbackSessionFactory(server),
+  );
+  aliceManager.registerSpaceIdentity(spaceIdentity, {
+    genesisAcl: { [space]: "OWNER", [alice.did()]: "WRITE" },
+  });
+  try {
+    const aliceOpen = aliceManager.ensureSpaceInitialized(space);
+    await aliceFactory.held;
+    const bobSync = await bobManager.open(space).sync("of:recheck-bob" as URI);
+    assert(!bobSync.error, bobSync.error?.message);
+    aliceGate.open();
+    // Red-first witnessed: the recheck found the ACL created, skipped the
+    // bootstrap arm with no conflict to catch, and Alice's open SUCCEEDED
+    // under Bob's wildcard.
+    await assertRejects(() => aliceOpen, Error, "different ACL");
+    assertEquals((await server.readDocument(space, `of:${space}`))?.value, {
+      [bob.did()]: "OWNER",
+      "*": "WRITE",
+    });
+  } finally {
+    await aliceManager.close();
+    await bobManager.close();
+    await server.close();
+  }
+});
+
+Deno.test("a sealer opening a space that already carries exactly its document proceeds (a reopen is not a conflict)", async () => {
+  const alice = await Identity.fromPassphrase("acl genesis reopen alice");
+  const spaceIdentity = await Identity.fromPassphrase(
+    "acl genesis reopen space",
+  );
+  const space = spaceIdentity.did();
+  const server = createServer("runner-acl-genesis-reopen");
+  const sealed = { [space]: "OWNER" as const, [alice.did()]: "WRITE" as const };
+  const first = TestStorageManager.overServer(
+    { as: alice },
+    new RecordingLoopbackSessionFactory(server),
+  );
+  first.registerSpaceIdentity(spaceIdentity, { genesisAcl: sealed });
+  const secondFactory = new RecordingLoopbackSessionFactory(server);
+  const second = TestStorageManager.overServer({ as: alice }, secondFactory);
+  second.registerSpaceIdentity(spaceIdentity, { genesisAcl: sealed });
+  try {
+    await first.ensureSpaceInitialized(space);
+    await first.close();
+    // A second manager (a restart, say) with the same document finds the
+    // space already sealed as asked: no genesis, no refusal.
+    const sync = await second.open(space).sync(`of:${space}` as URI);
+    assert(!sync.error, sync.error?.message);
+    assertEquals(secondFactory.principals, [alice.did()], "no bootstrap");
+    // But a different document on the same existing space is refused.
+    const third = TestStorageManager.overServer(
+      { as: alice },
+      new RecordingLoopbackSessionFactory(server),
+    );
+    third.registerSpaceIdentity(spaceIdentity, {
+      genesisAcl: { [space]: "OWNER" },
+    });
+    try {
+      await assertRejects(
+        () => third.ensureSpaceInitialized(space),
+        Error,
+        "different ACL",
+      );
+    } finally {
+      await third.close();
+    }
+  } finally {
+    await second.close();
+    await server.close();
+  }
+});
+
+Deno.test("registerSpaceIdentity refuses a genesis ACL once the space's provider exists (it could never be written)", async () => {
+  const user = await Identity.fromPassphrase("acl genesis late-register user");
+  const spaceIdentity = await Identity.fromPassphrase(
+    "acl genesis late-register space",
+  );
+  const space = spaceIdentity.did();
+  const server = createServer("runner-acl-genesis-late-register");
+  const manager = TestStorageManager.overServer(
+    { as: user },
+    new RecordingLoopbackSessionFactory(server),
+  );
+  try {
+    const sync = await manager.open(space).sync(`of:${space}` as URI);
+    assert(!sync.error, sync.error?.message);
+    // Red-first witnessed: accepted, never written — ACL null, no error.
+    assertThrows(
+      () =>
+        manager.registerSpaceIdentity(spaceIdentity, {
+          genesisAcl: { [space]: "OWNER" },
+        }),
+      Error,
+      "already open",
+    );
   } finally {
     await manager.close();
     await server.close();

--- a/packages/runner/test/memory-v2-acl-bootstrap.test.ts
+++ b/packages/runner/test/memory-v2-acl-bootstrap.test.ts
@@ -1019,7 +1019,7 @@ Deno.test("a sealer that loses the genesis race to a different document is told,
     // Red-first witnessed: the swallow let Alice's open SUCCEED — the
     // winner's wildcard granted her access — with her document discarded
     // and nothing reported.
-    await assertRejects(() => aliceOpen, Error, "owned by");
+    await assertRejects(() => aliceOpen, Error, "different ACL");
     // The winner's document stands; Alice's was never applied.
     assertEquals((await server.readDocument(space, aclId))?.value, {
       [bob.did()]: "OWNER",
@@ -1329,7 +1329,7 @@ Deno.test("a sealer that loses the race in the RECHECK window (before its commit
     // Red-first witnessed: the recheck found the ACL created, skipped the
     // bootstrap arm with no conflict to catch, and Alice's open SUCCEEDED
     // under Bob's wildcard.
-    await assertRejects(() => aliceOpen, Error, "owned by");
+    await assertRejects(() => aliceOpen, Error, "different ACL");
     assertEquals((await server.readDocument(space, `of:${space}`))?.value, {
       [bob.did()]: "OWNER",
       "*": "WRITE",
@@ -1564,5 +1564,95 @@ Deno.test("a demanded document on a retracted ACL is refused naming the tombston
     }
   } finally {
     await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("a sealer that loses the race to its OWN other runtime's default is refused: same owner, but the wildcard stands", async () => {
+  const alice = await Identity.fromPassphrase("acl genesis same-owner alice");
+  const member = await Identity.fromPassphrase("acl genesis same-owner member");
+  const spaceIdentity = await Identity.fromPassphrase(
+    "acl genesis same-owner space",
+  );
+  const space = spaceIdentity.did();
+  const server = createServer("runner-acl-genesis-same-owner");
+  const aliceGate = gate();
+  const sealerFactory = new GatedGenesisSessionFactory(
+    server,
+    space,
+    aliceGate.opened,
+  );
+  const sealer = TestStorageManager.overServer({ as: alice }, sealerFactory);
+  sealer.registerSpaceIdentity(spaceIdentity, {
+    genesisAcl: { [alice.did()]: "OWNER", [member.did()]: "WRITE" },
+  });
+  // Alice's OTHER runtime — a pattern's inSpace(name), no document — races
+  // with the rollout default { alice: OWNER, "*": WRITE }.
+  const other = TestStorageManager.overServer(
+    { as: alice, spaceIdentity },
+    new RecordingLoopbackSessionFactory(server),
+  );
+  try {
+    const sealerOpen = sealer.ensureSpaceInitialized(space);
+    await sealerFactory.held;
+    await other.ensureSpaceInitialized(space);
+    aliceGate.open();
+    // Red-first witnessed: the owner sets matched, so the sealer was
+    // ADMITTED into a world-writable space with nothing reported.
+    await assertRejects(() => sealerOpen, Error, "different ACL");
+    assertEquals((await server.readDocument(space, `of:${space}`))?.value, {
+      [alice.did()]: "OWNER",
+      "*": "WRITE",
+    });
+  } finally {
+    await sealer.close();
+    await other.close();
+    await server.close();
+  }
+});
+
+Deno.test("a wildcard OWNER counts as an owner: a space owned by everyone is not owned as the document says", async () => {
+  const daemon = await Identity.fromPassphrase("acl genesis wild-owner daemon");
+  const spaceIdentity = await Identity.fromPassphrase(
+    "acl genesis wild-owner space",
+  );
+  const space = spaceIdentity.did();
+  const aclId = `of:${space}` as URI;
+  const server = createServer("runner-acl-genesis-wild-owner");
+  // The server accepts a wildcard OWNER beside a concrete one at genesis.
+  const authority = await new RecordingLoopbackSessionFactory(server).create(
+    space,
+    spaceIdentity,
+  );
+  try {
+    await authority.session.transact({
+      localSeq: 1,
+      reads: { confirmed: [], pending: [] },
+      operations: [{
+        op: "set",
+        id: aclId,
+        value: { value: { "*": "OWNER", [space]: "OWNER" } },
+      }],
+    });
+  } finally {
+    await authority.client.close();
+  }
+  const manager = TestStorageManager.overServer(
+    { as: daemon },
+    new RecordingLoopbackSessionFactory(server),
+  );
+  manager.registerSpaceIdentity(spaceIdentity, {
+    genesisAcl: { [space]: "OWNER", [daemon.did()]: "WRITE" },
+  });
+  try {
+    // Red-first witnessed: the wildcard was dropped from the owner set, the
+    // sets matched, and the sealer was admitted to a space owned by everyone.
+    await assertRejects(
+      () => manager.ensureSpaceInitialized(space),
+      Error,
+      "owned by",
+    );
+  } finally {
+    await manager.close();
+    await server.close();
   }
 });

--- a/packages/runner/test/memory-v2-acl-bootstrap.test.ts
+++ b/packages/runner/test/memory-v2-acl-bootstrap.test.ts
@@ -759,6 +759,7 @@ Deno.test("a supplied genesis ACL is inert on a populated ACL-less named space (
       { [space]: "OWNER" },
     );
     assertEquals(withAcl, without);
+    assertEquals(without.syncFailed, false, "legacy-public reads succeed");
     assertEquals(without.acl, null, "the legacy space must not be claimed");
     assertEquals(without.principals, [user.did()], "no bootstrap session");
   } finally {
@@ -806,6 +807,7 @@ Deno.test("a supplied genesis ACL is inert on a retracted named ACL (a tombstone
       [space]: "OWNER",
     });
     assertEquals(withAcl, without);
+    assertEquals(without.syncFailed, true, "a retracted ACL fails closed");
     assertEquals(without.acl, null, "the tombstone must stand");
     assertEquals(without.commits, [1, 2], "no third commit");
   } finally {
@@ -1109,6 +1111,93 @@ Deno.test("a refused genesis does not wedge the space: retries surface the real 
     assertEquals((await server.readDocument(space, aclId))?.value, corrected);
     const sync = await manager.open(space).sync(aclId);
     assert(!sync.error, sync.error?.message);
+  } finally {
+    await manager.close();
+    await server.close();
+  }
+});
+
+Deno.test("runtime.resolveSpaceName refuses a genesis ACL it cannot honor: a cached name, a bare DID; an identical re-resolution is fine", async () => {
+  const user = await Identity.fromPassphrase("acl genesis cached user");
+  const server = createServer("runner-acl-genesis-cached");
+  const factory = new RecordingLoopbackSessionFactory(server);
+  const manager = TestStorageManager.overServer({ as: user }, factory);
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager: manager,
+  });
+  const sealed = { [user.did()]: "OWNER" as const };
+  try {
+    // Red-first witnessed: the cache short-circuit returned before
+    // registration, so a name anything else had already resolved made the
+    // sealing call a silent no-op and the space was born with the default.
+    const first = await runtime.resolveSpaceName("genesis-acl-cached");
+    await assertRejects(
+      () =>
+        runtime.resolveSpaceName("genesis-acl-cached", { genesisAcl: sealed }),
+      Error,
+      "already resolved",
+    );
+    // A bare DID derives no key, so there is nothing to register the
+    // document against; refuse rather than open an ACL-less space.
+    await assertRejects(
+      () => runtime.resolveSpaceName(first, { genesisAcl: sealed }),
+      Error,
+      "DID",
+    );
+    // The same caller resolving the same name with the same document is a
+    // retry, not a conflict.
+    const space = await runtime.resolveSpaceName("genesis-acl-retry", {
+      genesisAcl: sealed,
+    });
+    assertEquals(
+      await runtime.resolveSpaceName("genesis-acl-retry", {
+        genesisAcl: sealed,
+      }),
+      space,
+    );
+    await assertRejects(
+      () =>
+        runtime.resolveSpaceName("genesis-acl-retry", {
+          genesisAcl: { [user.did()]: "OWNER", "*": "READ" },
+        }),
+      Error,
+      "already resolved",
+    );
+    await manager.ensureSpaceInitialized(space);
+    assertEquals(
+      (await server.readDocument(space, `of:${space}`))?.value,
+      sealed,
+    );
+  } finally {
+    await runtime.dispose();
+    await manager.close();
+    await server.close();
+  }
+});
+
+Deno.test("registerSpaceIdentity refuses a genesis ACL on a manager whose session factory cannot bootstrap", async () => {
+  const user = await Identity.fromPassphrase("acl genesis no-bootstrap user");
+  const spaceIdentity = await Identity.fromPassphrase(
+    "acl genesis no-bootstrap space",
+  );
+  const server = createServer("runner-acl-genesis-no-bootstrap");
+  const factory = new RecordingLoopbackSessionFactory(server);
+  (factory as { supportsAclBootstrap: boolean }).supportsAclBootstrap = false;
+  const manager = TestStorageManager.overServer({ as: user }, factory);
+  try {
+    // Red-first witnessed: the document was accepted and never written —
+    // the space opened ACL-less with no error.
+    assertThrows(
+      () =>
+        manager.registerSpaceIdentity(spaceIdentity, {
+          genesisAcl: { [user.did()]: "OWNER" },
+        }),
+      Error,
+      "cannot bootstrap",
+    );
+    // The owner option keeps its pre-existing, ignorable semantics.
+    manager.registerSpaceIdentity(spaceIdentity, { owner: user.did() });
   } finally {
     await manager.close();
     await server.close();

--- a/packages/runner/test/memory-v2-acl-bootstrap.test.ts
+++ b/packages/runner/test/memory-v2-acl-bootstrap.test.ts
@@ -1019,7 +1019,7 @@ Deno.test("a sealer that loses the genesis race to a different document is told,
     // Red-first witnessed: the swallow let Alice's open SUCCEED — the
     // winner's wildcard granted her access — with her document discarded
     // and nothing reported.
-    await assertRejects(() => aliceOpen, Error, "different ACL");
+    await assertRejects(() => aliceOpen, Error, "owned by");
     // The winner's document stands; Alice's was never applied.
     assertEquals((await server.readDocument(space, aclId))?.value, {
       [bob.did()]: "OWNER",
@@ -1329,7 +1329,7 @@ Deno.test("a sealer that loses the race in the RECHECK window (before its commit
     // Red-first witnessed: the recheck found the ACL created, skipped the
     // bootstrap arm with no conflict to catch, and Alice's open SUCCEEDED
     // under Bob's wildcard.
-    await assertRejects(() => aliceOpen, Error, "different ACL");
+    await assertRejects(() => aliceOpen, Error, "owned by");
     assertEquals((await server.readDocument(space, `of:${space}`))?.value, {
       [bob.did()]: "OWNER",
       "*": "WRITE",
@@ -1365,19 +1365,20 @@ Deno.test("a sealer opening a space that already carries exactly its document pr
     const sync = await second.open(space).sync(`of:${space}` as URI);
     assert(!sync.error, sync.error?.message);
     assertEquals(secondFactory.principals, [alice.did()], "no bootstrap");
-    // But a different document on the same existing space is refused.
+    // But a document asserting a different OWNER set on the same existing
+    // space is refused, and the refusal says what stands.
     const third = TestStorageManager.overServer(
       { as: alice },
       new RecordingLoopbackSessionFactory(server),
     );
     third.registerSpaceIdentity(spaceIdentity, {
-      genesisAcl: { [space]: "OWNER" },
+      genesisAcl: { [alice.did()]: "OWNER" },
     });
     try {
       await assertRejects(
         () => third.ensureSpaceInitialized(space),
         Error,
-        "different ACL",
+        "owned by",
       );
     } finally {
       await third.close();
@@ -1414,5 +1415,154 @@ Deno.test("registerSpaceIdentity refuses a genesis ACL once the space's provider
   } finally {
     await manager.close();
     await server.close();
+  }
+});
+
+Deno.test("a sealer's reopen survives the owner granting rows: ownership is what a seal asserts, grants evolve", async () => {
+  const daemon = await Identity.fromPassphrase("acl genesis evolve daemon");
+  const guest = await Identity.fromPassphrase("acl genesis evolve guest");
+  const spaceIdentity = await Identity.fromPassphrase(
+    "acl genesis evolve space",
+  );
+  const space = spaceIdentity.did();
+  const aclId = `of:${space}` as URI;
+  const server = createServer("runner-acl-genesis-evolve");
+  const sealed = {
+    [space]: "OWNER" as const,
+    [daemon.did()]: "WRITE" as const,
+  };
+  const first = TestStorageManager.overServer(
+    { as: daemon },
+    new RecordingLoopbackSessionFactory(server),
+  );
+  first.registerSpaceIdentity(spaceIdentity, { genesisAcl: sealed });
+  try {
+    await first.ensureSpaceInitialized(space);
+    await first.close();
+    // The OWNER (the space key) grants a guest READ — Loom's share-acl arc.
+    const owner = await new RecordingLoopbackSessionFactory(server).create(
+      space,
+      spaceIdentity,
+    );
+    try {
+      await owner.session.transact({
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id: aclId,
+          value: { value: { ...sealed, [guest.did()]: "READ" } },
+        }],
+      });
+    } finally {
+      await owner.client.close();
+    }
+    // Red-first witnessed: the daemon's restart, registering the SAME
+    // document by name, was refused with "claimed with a different ACL" —
+    // a false statement about a document that WAS applied at seq 1.
+    const restarted = TestStorageManager.overServer(
+      { as: daemon },
+      new RecordingLoopbackSessionFactory(server),
+    );
+    restarted.registerSpaceIdentity(spaceIdentity, { genesisAcl: sealed });
+    try {
+      await restarted.ensureSpaceInitialized(space);
+      assertEquals((await server.readDocument(space, aclId))?.value, {
+        ...sealed,
+        [guest.did()]: "READ",
+      });
+    } finally {
+      await restarted.close();
+    }
+    // A default-wildcard winner still fails the ownership check: its OWNER
+    // is another principal (pinned by the race tests); so does a space
+    // whose owner has been replaced.
+    const transferred = await new RecordingLoopbackSessionFactory(server)
+      .create(space, spaceIdentity);
+    try {
+      await transferred.session.transact({
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id: aclId,
+          value: { value: { [guest.did()]: "OWNER", [daemon.did()]: "WRITE" } },
+        }],
+      });
+    } finally {
+      await transferred.client.close();
+    }
+    const after = TestStorageManager.overServer(
+      { as: daemon },
+      new RecordingLoopbackSessionFactory(server),
+    );
+    after.registerSpaceIdentity(spaceIdentity, { genesisAcl: sealed });
+    try {
+      await assertRejects(
+        () => after.ensureSpaceInitialized(space),
+        Error,
+        "owned by",
+      );
+    } finally {
+      await after.close();
+    }
+  } finally {
+    await server.close();
+  }
+});
+
+Deno.test("a demanded document on a retracted ACL is refused naming the tombstone", async () => {
+  const directory = await Deno.makeTempDir({
+    prefix: "runner-acl-genesis-tombstone-",
+  });
+  const store = toFileUrl(`${directory}/`);
+  const user = await Identity.fromPassphrase("acl genesis tombstone user");
+  const spaceIdentity = await Identity.fromPassphrase(
+    "acl genesis tombstone space",
+  );
+  const space = spaceIdentity.did();
+  const aclId = `of:${space}` as URI;
+  try {
+    // Seed and retract in `off` mode, then open in `off` mode too: the
+    // server's fail-closed session open is out of the way, so the client's
+    // own refusal is what the test observes.
+    const seedServer = createServer("unused", { store, mode: "off" });
+    try {
+      await seedServer.writeDocument(space, aclId, { [space]: "OWNER" });
+      const seeded = await new RecordingLoopbackSessionFactory(seedServer)
+        .create(space, spaceIdentity);
+      try {
+        await seeded.session.transact({
+          localSeq: 1,
+          reads: { confirmed: [], pending: [] },
+          operations: [{ op: "delete", id: aclId }],
+        });
+      } finally {
+        await seeded.client.close();
+      }
+    } finally {
+      await seedServer.close();
+    }
+    const server = createServer("unused", { store, mode: "off" });
+    const manager = TestStorageManager.overServer(
+      { as: user },
+      new RecordingLoopbackSessionFactory(server),
+    );
+    manager.registerSpaceIdentity(spaceIdentity, {
+      genesisAcl: { [space]: "OWNER" },
+    });
+    try {
+      await assertRejects(
+        () => manager.ensureSpaceInitialized(space),
+        Error,
+        "retracted",
+      );
+      assertEquals(await server.readDocument(space, aclId), null);
+    } finally {
+      await manager.close();
+      await server.close();
+    }
+  } finally {
+    await Deno.remove(directory, { recursive: true });
   }
 });

--- a/packages/runner/test/memory-v2-acl-bootstrap.test.ts
+++ b/packages/runner/test/memory-v2-acl-bootstrap.test.ts
@@ -867,17 +867,54 @@ Deno.test("runtime.resolveSpaceName threads a supplied genesis ACL to the named 
       (await server.readDocument(space, `of:${space}`))?.value,
       supplied,
     );
-    // A serving-posture refusal is unchanged by the new option: owner is
-    // still required there (OW31), and the two cannot be combined.
-    await assertRejects(
-      () =>
-        runtime.resolveSpaceName("genesis-acl-both", {
-          owner: user.did(),
-          genesisAcl: supplied,
-        }),
-      Error,
-      "not both",
+  } finally {
+    await runtime.dispose();
+    await manager.close();
+    await server.close();
+  }
+});
+
+Deno.test("a serving runtime refuses a supplied genesis ACL explicitly (OW31 provisioning names the acting user, not a document)", async () => {
+  const service = await Identity.fromPassphrase("acl genesis serving service");
+  const alice = await Identity.fromPassphrase("acl genesis serving alice");
+  const server = createServer("runner-acl-genesis-serving");
+  const factory = new RecordingLoopbackSessionFactory(server);
+  const manager = TestStorageManager.overServer(
+    { as: service, servingHomeSpace: service.did() },
+    factory,
+  );
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager: manager,
+    servingPosture: true,
+    experimental: { serverExecution: true },
+  });
+  try {
+    // Red-first witnessed: before the explicit refusal, a document alone
+    // hit OW31's owner-required refusal (whose message wrongly says the
+    // genesis "would name the SERVICE as owner"), and a document plus an
+    // owner hit registerSpaceIdentity's not-both refusal — a closed door
+    // by accident rather than by decision.
+    for (
+      const options of [
+        { genesisAcl: { [alice.did()]: "OWNER" as const } },
+        {
+          owner: alice.did(),
+          genesisAcl: { [alice.did()]: "OWNER" as const },
+        },
+      ]
+    ) {
+      await assertRejects(
+        () => runtime.resolveSpaceName("genesis-acl-serving", options),
+        Error,
+        "serving runtime does not accept genesisAcl",
+      );
+    }
+    assertEquals(
+      runtime.resolveSpaceNameSync("genesis-acl-serving"),
+      undefined,
     );
+    assertEquals(factory.principals, [], "no session was ever opened");
   } finally {
     await runtime.dispose();
     await manager.close();

--- a/packages/runner/test/memory-v2-acl-bootstrap.test.ts
+++ b/packages/runner/test/memory-v2-acl-bootstrap.test.ts
@@ -592,11 +592,11 @@ Deno.test("a supplied genesis ACL is the space's first and only commit — no wi
       [1],
       "genesis must be the only commit — no intermediate default was written",
     );
-    assertEquals((await server.readDocument(space, aclId))?.value, supplied);
-    assert(
-      !("*" in (await server.readDocument(space, aclId))!.value as object),
-      "no wildcard row",
-    );
+    const stored = (await server.readDocument(space, aclId))?.value as
+      | Record<string, unknown>
+      | undefined;
+    assertEquals(stored, supplied);
+    assert(stored !== undefined && !("*" in stored), "no wildcard row");
     assertEquals(factory.principals, [
       daemon.did(),
       spaceIdentity.did(),


### PR DESCRIPTION
## Why

Every non-home space in labs is born `{ <owner>: OWNER, "*": WRITE }`. The document is fixed inside the runner's `#createInitializedSession`, so an ACL-bounded consumer (Loom's share mint) has to let a space be born world-writable and then rewrite the ACL in a second, space-key-signed commit. Loom's own design lists that as a stopgap whose exit is this change ("ACL rewritten after genesis, not at it"). The window is small and the DID is unpublished until the rewrite lands, so it is not an active leak, but it is a correctness smell every ACL-aware consumer has to work around, and the wildcard default is not something to keep shipping now that ACL enforcement is on by default.

This lets a caller who holds the space key supply the genesis document, so a space is born with exactly the ACL it asked for and is never in a world-writable state it did not ask for. The default is unchanged today; retiring the wildcard later is one edit to one named constant.

## What changed

- **One seam, the one OW31 already uses.** `registerSpaceIdentity(identity, { genesisAcl })` on the runner `StorageManager`, beside the existing `{ owner }`, threaded from `runtime.resolveSpaceName(name, { genesisAcl })`. The genesis fires from whichever sync first touches the space, so the document rides with the space key rather than with `open()`.
- **Sealed by construction.** A supplied document is the space's first and only commit; no intermediate default is written. The server's existing genesis admission (concrete OWNER, ACL-only commit; INV-12/13) is the only validation. A refused document leaves the space uninitialized and the open rejects.
- **Fail closed, everywhere a seal could silently not land.** A supplied document is a demand: the open proceeds only if the space is fresh (document written) or already owned exactly as the document says (a reopen; grants below OWNER are the owner's to evolve, so a creator's restart survives its own grants). A space populated before genesis, a retracted ACL, a genesis another initializer won (in either race window, compared as the exact document, since the likely winner is the same user's other runtime writing the wildcard), a cached name resolved without the document, a bare DID, a serving runtime, a manager whose factory cannot bootstrap, or a registration after the first mount began: all refused with a message naming what stands, never dropped.
- **No wedge after a refusal.** The manager-wide session a failed bootstrap detached is remembered per space (scoped to route generation, cleared on `close()`), so retries surface the real error and a corrected document recovers.
- **`DEFAULT_GENESIS_GRANTS`** (`{ "*": "WRITE" }`) is the single spelling of the rollout wildcard; the `owner` path is stored already expanded into the fallback shape, so there is one genesis-document map and one reader.
- **Home arm untouched.** A document registered under a home identity never reaches it.
- Docs: protocol spec, INV-13's checked-by list, identity tutorial, CONFIGURATION, home-space internals, and the ingest-channels record (its genesis claim and citations).

**One ruling to flag, mine:** the brief said the option is "inert outside true genesis". Built literally, a sealer handed a legacy-public space with a clean sync is the exact outcome the option exists to prevent, so non-fresh opens with a supplied document are refused unless ownership matches. The retracted-ACL case is unchanged (the server fails it closed first). If Tony prefers strictly inert, it is the `assertDemandedOwnershipStands` call at the first-inspection arm.

**Downstream note for Loom:** the share-substrate sidecar today writes genesis itself, bypassing `StorageManager`, so adopting this means either routing the mint through the manager or simply writing the desired document in its own genesis. Either way the post-genesis rewrite goes.

## Test plan

Red-first throughout (each test's comment records what it witnessed red), plus mutation checks: dropping the server's `hasConcreteOwner` reddens the server pin; reverting the runtime threading reddens the runtime test; letting the option past the genesis preconditions reddens the legacy-space test.

- Runner `memory-v2-acl-bootstrap.test.ts` (+22 tests): supplied document is the only commit and a stranger cannot open; unowned document refused server-side and the space stays uninitialized; owner+genesisAcl refused; snapshotting; legacy-populated refused, retracted unchanged, tombstone named; home arm untouched; runtime threading; serving runtime refuses; cached name / bare DID / identical retry; non-bootstrap factory refuses; late registration refuses; both race windows refused (transact-gated and queryGraph-gated, on explicit gates since the runner clock freezes test sleeps); same-document race benign; same-signer default race refused; exact-document reopen proceeds, evolved grants proceed, different owner set and wildcard owner refused; refused genesis recovers; reuse after `close()` mounts the new session id.
- Memory `v2-server-acl.test.ts` (+1): genesis without a concrete OWNER refused with the existing error; ordinary write still needs genesis; a concrete owner then seals at seq 1.
- Full `packages/runner` and `packages/memory` test tasks green locally; `deno task check`, `deno fmt --check`, `deno lint` clean.
- Adversarial review: two opus critics (correctness, labs idiom) and a fable gate over four rounds; every finding is folded in (nine of them were reproduced defects, two of which were regressions on the default path caught before push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F9nrX2HxBGB7U6ygjjYsus


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6935?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

