### PR TITLE
fix(shell): the slug watch owns its own state (#6931)

### DIFF
--- a/packages/shell/src/views/AppView.ts
+++ b/packages/shell/src/views/AppView.ts
@@ -267,9 +267,10 @@ export class XAppView extends BaseView {
    * {@link XAppView.#resolveAgainst} compares against this only through a
    * watch, which is built only for an address that names a reference, and
    * {@link XAppView.#shownPieceId} is read only under one. In the second
-   * state a watch's first answer either differs — a reload — or is the answer
-   * the selection is already applying, and a runtime error naming the
-   * previous piece is attributed to this view until the selection answers.
+   * state a runtime error naming the previous piece is attributed to this
+   * view, and a run whose load fails records nothing — so an address whose
+   * loads keep failing holds that state open.
+   * {@link XAppView.#resolveAgainst} says what the comparison covers there.
    */
   #shownResolution: SlugReferenceTarget | SlugReferenceRefusal | undefined =
     undefined;
@@ -648,10 +649,13 @@ export class XAppView extends BaseView {
       return;
     }
     if (!this.#isCurrentSlugWatch(watch)) return;
-    // The one question. A yes covers every reason the view could be behind —
-    // the reference moved, a member arrived, a refusal changed, a load failed
-    // and left something else on screen — because each of them is the same
-    // fact: what is showing is not this.
+    // The one question, asked of what the selection recorded. A difference
+    // covers the reference moving, a member arriving, and a refusal changing,
+    // and it covers a load that failed before anything was recorded, where
+    // there is nothing for an answer to match. It does not cover a load that
+    // failed under a recorded answer: the selection records a success and a
+    // refusal and nothing at all for a failure, so the earlier answer stands,
+    // an answer equal to it reads as settled, and the view keeps the error.
     const shown = this.#shownResolution;
     if (shown && slugResolutionKey(shown) === slugResolutionKey(landed)) return;
     this.#handleSlugCellUpdate(watch);

--- a/packages/shell/src/views/AppView.ts
+++ b/packages/shell/src/views/AppView.ts
@@ -241,8 +241,8 @@ export class XAppView extends BaseView {
 
   /**
    * The answer the view is SHOWING: the resolution whose piece is on screen,
-   * or whose refusal is the error on screen. Undefined until one of those
-   * has happened.
+   * or whose refusal is the error on screen. Undefined where neither holds —
+   * before the first of them, and after a load that could not finish.
    *
    * One fact, not several about one thing. What was resolved, whether it was
    * applied, which piece it reached, and which answer is newest are all read
@@ -259,18 +259,16 @@ export class XAppView extends BaseView {
    * stopping leaves it standing and the selection is what moves it on.
    *
    * That lifetime qualifies the first sentence. Only the selection moves this
-   * on, and the selection answers only an address that names a reference — so
-   * on an address naming none, and between an address changing and the
-   * selection answering the new one, this names what the view came to show
-   * LAST rather than anything on screen. Both readers are bounded by that
-   * same condition, so neither sees the first state:
+   * on, and the selection reports only for an address that names a reference
+   * — so on an address naming none, and between an address changing and the
+   * run for the new one reporting, this names what the view came to show LAST
+   * rather than anything on screen. Both readers are bounded by that same
+   * condition, so neither sees the first state:
    * {@link XAppView.#resolveAgainst} compares against this only through a
    * watch, which is built only for an address that names a reference, and
    * {@link XAppView.#shownPieceId} is read only under one. In the second
    * state a runtime error naming the previous piece is attributed to this
-   * view, and a run whose load fails records nothing — so an address whose
-   * loads keep failing holds that state open.
-   * {@link XAppView.#resolveAgainst} says what the comparison covers there.
+   * view, which the run reporting ends however it went.
    */
   #shownResolution: SlugReferenceTarget | SlugReferenceRefusal | undefined =
     undefined;
@@ -404,12 +402,20 @@ export class XAppView extends BaseView {
           if (member !== undefined && pathAfter.length > 0) {
             this.#replaceViewWithoutMember(app.view);
           }
-          const pattern = await rt.getPattern(space, pieceId, { scope });
+          let pattern: PieceHandle<NameSchema>;
+          try {
+            pattern = await rt.getPattern(space, pieceId, { scope });
+          } catch (error) {
+            // Around the load alone. The run's outer catch also takes the
+            // refusal's own throw, and recording nothing there would undo
+            // the mark a refusal just made — leaving every poll to re-resolve
+            // an answer the view is already showing.
+            this.#markShown(undefined, signal);
+            throw error;
+          }
           // `landed` and not whatever is current: this run finished THIS
           // answer, and saying so with another's identity is how a slow load
-          // came to claim a newer answer was on screen. A throw above writes
-          // nothing, so the watch's next re-resolution sees the view still
-          // showing something else and asks for this one again.
+          // came to claim a newer answer was on screen.
           this.#markShown(landed, signal);
           if (!signal.aborted) this.#maybeDeliverOpenPath(pattern);
           return pattern;
@@ -566,14 +572,21 @@ export class XAppView extends BaseView {
   }
 
   /**
-   * Record that the view has come to show `answer`.
+   * Record that the view has come to show `answer`, or `undefined` where the
+   * run reached nothing for it to show.
    *
    * The only writer of {@link XAppView.#shownResolution}, and it takes the
    * signal of the run that resolved `answer` so a run the view has moved on
    * from cannot report what it finished as what is on screen.
+   *
+   * Every outcome of a run is reported through here — the piece it loaded,
+   * the refusal it was given, and the load it could not finish. That is what
+   * lets one comparison stand for all of them: an outcome that wrote nothing
+   * would leave the answer before it standing as though it were still what
+   * the view had settled on.
    */
   #markShown(
-    answer: SlugReferenceTarget | SlugReferenceRefusal,
+    answer: SlugReferenceTarget | SlugReferenceRefusal | undefined,
     signal: AbortSignal,
   ): void {
     if (signal.aborted) return;
@@ -650,12 +663,13 @@ export class XAppView extends BaseView {
     }
     if (!this.#isCurrentSlugWatch(watch)) return;
     // The one question, asked of what the selection recorded. A difference
-    // covers the reference moving, a member arriving, and a refusal changing,
-    // and it covers a load that failed before anything was recorded, where
-    // there is nothing for an answer to match. It does not cover a load that
-    // failed under a recorded answer: the selection records a success and a
-    // refusal and nothing at all for a failure, so the earlier answer stands,
-    // an answer equal to it reads as settled, and the view keeps the error.
+    // covers every reason the view could be behind — the reference moved, a
+    // member arrived, a refusal changed, a load failed and left the view on
+    // an error — because each of them is the same fact: what the view
+    // settled on is not this. That holds because every outcome of a run is
+    // recorded, a load that could not finish among them; an outcome that
+    // recorded nothing would leave the answer before it reading as settled,
+    // and the retry it needs would never be asked for.
     const shown = this.#shownResolution;
     if (shown && slugResolutionKey(shown) === slugResolutionKey(landed)) return;
     this.#handleSlugCellUpdate(watch);

--- a/packages/shell/src/views/AppView.ts
+++ b/packages/shell/src/views/AppView.ts
@@ -257,6 +257,19 @@ export class XAppView extends BaseView {
    * which is how a slow load came to claim a newer answer's identity. Its
    * lifetime is the view's display rather than any watch's, so a watch
    * stopping leaves it standing and the selection is what moves it on.
+   *
+   * That lifetime qualifies the first sentence. Only the selection moves this
+   * on, and the selection answers only an address that names a reference — so
+   * on an address naming none, and between an address changing and the
+   * selection answering the new one, this names what the view came to show
+   * LAST rather than anything on screen. Both readers are bounded by that
+   * same condition, so neither sees the first state:
+   * {@link XAppView.#resolveAgainst} compares against this only through a
+   * watch, which is built only for an address that names a reference, and
+   * {@link XAppView.#shownPieceId} is read only under one. In the second
+   * state a watch's first answer either differs — a reload — or is the answer
+   * the selection is already applying, and a runtime error naming the
+   * previous piece is attributed to this view until the selection answers.
    */
   #shownResolution: SlugReferenceTarget | SlugReferenceRefusal | undefined =
     undefined;

--- a/packages/shell/src/views/AppView.ts
+++ b/packages/shell/src/views/AppView.ts
@@ -109,20 +109,71 @@ function project<T extends object>(
 }
 
 /**
- * One live watch on a slug reference: the reference itself, and the runtime
- * and space it is read in. These are every input the watch is built from, so
- * comparing them is what decides whether a running watch already covers what
- * the view now addresses.
+ * One live watch on a slug reference: the reference itself, the runtime and
+ * space it is read in, and everything whose lifetime is this watch's — the
+ * subscription it opens, the poll it schedules, and the pair of flags that
+ * keep its re-resolutions to one at a time.
+ *
+ * The reference, the runtime and the space are every input the watch is built
+ * from, so comparing them is what decides whether a running watch already
+ * covers what the view now addresses.
  *
  * A callback arriving after a view change checks itself by identity against
  * the watch the view is running, so replacing the watch invalidates every
- * callback still holding the old one.
+ * callback still holding the old one. What such a callback writes it writes
+ * on the watch it holds, which is what keeps one watch's state out of every
+ * other watch's reach.
  */
-interface SlugWatch {
-  rt: RuntimeInternals;
-  space: DID;
-  slug: string;
-  member: string | undefined;
+class SlugWatch {
+  /** The runtime the reference is read through. */
+  readonly rt: RuntimeInternals;
+
+  /** The space the reference is read in. */
+  readonly space: DID;
+
+  /** The name at the head of the reference. */
+  readonly slug: string;
+
+  /** The member the reference selects, where it names one. */
+  readonly member: string | undefined;
+
+  /** Cancels the subscription on the slug document, once it is open. */
+  cancel: Cancel | undefined = undefined;
+
+  /** The re-resolution poll, once it is scheduled. */
+  pollInterval: ReturnType<typeof setInterval> | undefined = undefined;
+
+  /** Whether a re-resolution is running; a watch runs one at a time. */
+  refreshRunning = false;
+
+  /** Whether something asked to re-resolve while one was running. */
+  refreshRequested = false;
+
+  /**
+   * Constructs a watch on what `slug` and `member` name in `space`, read
+   * through `rt`.
+   */
+  constructor(
+    rt: RuntimeInternals,
+    space: DID,
+    slug: string,
+    member: string | undefined,
+  ) {
+    this.rt = rt;
+    this.space = space;
+    this.slug = slug;
+    this.member = member;
+  }
+
+  /** Stops this watch, cancelling its subscription and clearing its poll. */
+  stop(): void {
+    this.cancel?.();
+    this.cancel = undefined;
+    if (this.pollInterval !== undefined) {
+      globalThis.clearInterval(this.pollInterval);
+      this.pollInterval = undefined;
+    }
+  }
 }
 
 export class XAppView extends BaseView {
@@ -185,8 +236,7 @@ export class XAppView extends BaseView {
   @state()
   private accessor _slugRevision = 0;
 
-  #slugCancel: Cancel | undefined = undefined;
-  #slugPollInterval: ReturnType<typeof setInterval> | undefined = undefined;
+  /** The watch on the reference the view addresses, while it has one. */
   #slugWatch: SlugWatch | undefined = undefined;
 
   /**
@@ -204,16 +254,12 @@ export class XAppView extends BaseView {
    *
    * Written only by {@link XAppView.#markShown}, and only from the answer the
    * writer itself resolved — never from whatever is current when it finishes,
-   * which is how a slow load came to claim a newer answer's identity.
+   * which is how a slow load came to claim a newer answer's identity. Its
+   * lifetime is the view's display rather than any watch's, so a watch
+   * stopping leaves it standing and the selection is what moves it on.
    */
   #shownResolution: SlugReferenceTarget | SlugReferenceRefusal | undefined =
     undefined;
-
-  /** Whether a re-resolution is running; the watch runs one at a time. */
-  #slugRefreshRunning = false;
-
-  /** Whether something asked to re-resolve while one was running. */
-  #slugRefreshRequested = false;
 
   #selectedPatternTargetId: string | undefined = undefined;
 
@@ -439,10 +485,10 @@ export class XAppView extends BaseView {
     ) {
       return;
     }
-    this.#clearSlugSubscription();
+    this.#stopSlugWatch();
     if (!rt || !space || !slug) return;
 
-    const watch: SlugWatch = { rt, space, slug, member };
+    const watch = new SlugWatch(rt, space, slug, member);
     this.#slugWatch = watch;
     rt.getSlugCell(space, slug).then(async (cell) => {
       if (!this.#isCurrentSlugWatch(watch)) return;
@@ -467,12 +513,12 @@ export class XAppView extends BaseView {
       // on, since a member whose target is not yet a piece is refused, so
       // re-resolving is what notices it becoming one. Whoever makes that
       // observable to a watch can retire this.
-      this.#slugPollInterval = globalThis.setInterval(() => {
+      watch.pollInterval = globalThis.setInterval(() => {
         void this.#refreshSlugTarget(watch);
       }, 1000);
 
       let sawInitialCallback = false;
-      this.#slugCancel = cell.subscribe(() => {
+      watch.cancel = cell.subscribe(() => {
         if (!sawInitialCallback) {
           sawInitialCallback = true;
           return;
@@ -484,24 +530,25 @@ export class XAppView extends BaseView {
       if (rt.signal.aborted) {
         // Drop the watch so a replacement runtime for the same reference
         // subscribes instead of matching the stale one.
-        this.#clearSlugSubscription();
+        this.#stopSlugWatch();
         return;
       }
       console.error("[AppView] Failed to watch slug cell:", error);
     });
   }
 
-  #clearSlugSubscription() {
+  /**
+   * Stop the watch the view is running, and leave it with none.
+   *
+   * A watch owns what is watch-scoped; the view owns what is displayed. The
+   * piece the stopped watch resolved is on screen until something replaces
+   * it, so {@link XAppView.#shownResolution} goes on naming it, and the
+   * selection is what moves that on.
+   */
+  #stopSlugWatch() {
+    const watch = this.#slugWatch;
     this.#slugWatch = undefined;
-    this.#slugCancel?.();
-    if (this.#slugPollInterval !== undefined) {
-      globalThis.clearInterval(this.#slugPollInterval);
-    }
-    this.#slugCancel = undefined;
-    this.#slugPollInterval = undefined;
-    this.#shownResolution = undefined;
-    this.#slugRefreshRunning = false;
-    this.#slugRefreshRequested = false;
+    watch?.stop();
   }
 
   /**
@@ -525,7 +572,7 @@ export class XAppView extends BaseView {
     return shown && !shown.refusal ? shown.pieceId : undefined;
   }
 
-  /** Whether `watch` is still the subscription this view is running. */
+  /** Whether `watch` is still the watch this view is running. */
   #isCurrentSlugWatch(watch: SlugWatch): boolean {
     return this.#slugWatch === watch;
   }
@@ -541,21 +588,25 @@ export class XAppView extends BaseView {
    * removes the question instead of guarding it: there is never a second
    * answer to compare against, and a wake that arrives mid-flight still gets
    * its resolution, immediately after.
+   *
+   * The pair of flags that serializes this lives on `watch`, so a run
+   * finishing after the view has moved on releases the turn it took and reads
+   * the request coalesced behind it, both of them its own.
    */
   async #refreshSlugTarget(watch: SlugWatch): Promise<void> {
     if (!this.#isCurrentSlugWatch(watch)) return;
-    if (this.#slugRefreshRunning) {
-      this.#slugRefreshRequested = true;
+    if (watch.refreshRunning) {
+      watch.refreshRequested = true;
       return;
     }
-    this.#slugRefreshRunning = true;
+    watch.refreshRunning = true;
     try {
       await this.#resolveAgainst(watch);
     } finally {
-      this.#slugRefreshRunning = false;
+      watch.refreshRunning = false;
     }
-    if (!this.#slugRefreshRequested) return;
-    this.#slugRefreshRequested = false;
+    if (!watch.refreshRequested) return;
+    watch.refreshRequested = false;
     await this.#refreshSlugTarget(watch);
   }
 
@@ -573,7 +624,7 @@ export class XAppView extends BaseView {
         // The runtime this subscription polls was disposed (logout,
         // teardown, worker replacement) — stop polling it; a new runtime
         // re-subscribes via #syncSlugSubscription.
-        if (this.#isCurrentSlugWatch(watch)) this.#clearSlugSubscription();
+        if (this.#isCurrentSlugWatch(watch)) this.#stopSlugWatch();
         return;
       }
       // Not a refusal — those arrive as an answer — but a fault in asking: a
@@ -713,7 +764,7 @@ export class XAppView extends BaseView {
       "recreate-space-root-pattern",
       this.#handleRecreateSpaceRootPattern,
     );
-    this.#clearSlugSubscription();
+    this.#stopSlugWatch();
   }
 
   override updated(changedProperties: Map<string, unknown>) {

--- a/packages/shell/test/app-view-collection-member.test.ts
+++ b/packages/shell/test/app-view-collection-member.test.ts
@@ -1015,7 +1015,12 @@ describe("AppView collection members", () => {
         viewOf({ pieceSlug: "top", pieceMember: "42" }),
       );
 
-      view.updated(new Map([["app", undefined]]));
+      // The runtime arrives with the rest of the view's state, as it does on
+      // a first update. Naming it is what installs it, and a runtime is
+      // released only where one was installed before it — so a replacement
+      // that never had a predecessor exercises less of the hand-off than a
+      // replacement has to.
+      view.updated(new Map([["app", undefined], ["rt", undefined]]));
       await first.settle();
       view._selectedPattern.run();
       await view._selectedPattern.taskComplete;
@@ -1035,8 +1040,9 @@ describe("AppView collection members", () => {
       await replacement.settle();
 
       expect(view.accessForTestingOnly.slugRevision).toBe(before);
-      // Nothing here drives an error path, so the whole of what the runtime
-      // is asked for on its way to the watch answered.
+      // Nothing here drives an error path, so every member the hand-off
+      // reaches for answered — the release of the first runtime among them,
+      // which only a replacement reaches.
       expect(errors.lines).toEqual([]);
     } finally {
       errors.restore();

--- a/packages/shell/test/app-view-collection-member.test.ts
+++ b/packages/shell/test/app-view-collection-member.test.ts
@@ -948,6 +948,96 @@ describe("AppView collection members", () => {
     }
   });
 
+  it("retries a load that failed after the watch behind it was replaced", async () => {
+    const restore = installBrowserGlobals();
+    try {
+      const { XAppView } = await import("../src/views/AppView.ts");
+      const first = stubRuntime({ pieceId: "fid1:member-42", pathAfter: [] });
+      const view = appViewOver(
+        XAppView as never,
+        first,
+        viewOf({ pieceSlug: "top", pieceMember: "42" }),
+      );
+
+      // A piece is on screen, so an answer is recorded.
+      view.updated(new Map([["app", undefined], ["rt", undefined]]));
+      await first.settle();
+      view._selectedPattern.run();
+      await view._selectedPattern.taskComplete;
+
+      // A replacement runtime takes over. It reaches the same answer, and the
+      // load of it fails — so what the recorded answer names is not what is
+      // on screen, and the answer alone cannot say so.
+      const replacement = stubRuntime({
+        pieceId: "fid1:member-42",
+        pathAfter: [],
+      });
+      replacement.failLoads(new Error("the socket went away"));
+      view.rt = replacement.rt;
+      view.updated(new Map([["rt", undefined]]));
+      await replacement.settle();
+      view._selectedPattern.run();
+      await view._selectedPattern.taskComplete.catch(() => {});
+      const afterFailedLoad = view.accessForTestingOnly.slugRevision;
+
+      // Nothing about the reference changed, so no later answer differs from
+      // the one recorded. Recovery has to come from the run having reported
+      // that it reached nothing to show.
+      replacement.failLoads(undefined);
+      await replacement.poll();
+
+      expect(view.accessForTestingOnly.slugRevision).toBeGreaterThan(
+        afterFailedLoad,
+      );
+    } finally {
+      restore();
+    }
+  });
+
+  it("retries a load that failed with the reference and its watch unchanged", async () => {
+    const restore = installBrowserGlobals();
+    try {
+      const { XAppView } = await import("../src/views/AppView.ts");
+      const stub = stubRuntime({ pieceId: "fid1:member-42", pathAfter: [] });
+      const view = appViewOver(
+        XAppView as never,
+        stub,
+        viewOf({ pieceSlug: "top", pieceMember: "42" }),
+      );
+
+      view.updated(new Map([["app", undefined], ["rt", undefined]]));
+      await stub.settle();
+      view._selectedPattern.run();
+      await view._selectedPattern.taskComplete;
+
+      // A new app state naming the same reference: every input the watch is
+      // built from is what it was, so the running watch stands and no
+      // teardown runs at all. The selection runs again anyway, and its load
+      // fails.
+      view.app = {
+        identity: {},
+        config: {},
+        view: viewOf({ pieceSlug: "top", pieceMember: "42" }),
+      };
+      view.updated(new Map([["app", undefined]]));
+      await stub.settle();
+      stub.failLoads(new Error("the socket went away"));
+      view._selectedPattern.run();
+      await view._selectedPattern.taskComplete.catch(() => {});
+      const afterFailedLoad = view.accessForTestingOnly.slugRevision;
+
+      stub.failLoads(undefined);
+      await stub.poll();
+
+      expect(view.accessForTestingOnly.slugRevision).toBeGreaterThan(
+        afterFailedLoad,
+      );
+      expect(stub.started.map((call) => call[1])).toContain("fid1:member-42");
+    } finally {
+      restore();
+    }
+  });
+
   it("watches each reference through a slug separately", async () => {
     const restore = installBrowserGlobals();
     try {

--- a/packages/shell/test/app-view-collection-member.test.ts
+++ b/packages/shell/test/app-view-collection-member.test.ts
@@ -163,6 +163,12 @@ interface StubRuntime {
   /** Hold every answer from here on, to be released by hand. */
   hold(): void;
 
+  /** Release the oldest held answer, and let what it finishes settle. */
+  releaseOldest(): Promise<void>;
+
+  /** Release the newest held answer, and let what it finishes settle. */
+  releaseNewest(): Promise<void>;
+
   /** Release the held answers, newest first. */
   releaseNewestFirst(): Promise<void>;
 }
@@ -195,6 +201,8 @@ function stubRuntime(
     holdLoads: () => {},
     releaseLoads: async () => {},
     hold: () => {},
+    releaseOldest: async () => {},
+    releaseNewest: async () => {},
     releaseNewestFirst: async () => {},
   };
   let loadFailure: Error | undefined;
@@ -214,6 +222,14 @@ function stubRuntime(
   let held: Array<() => void> | undefined;
   stub.hold = () => {
     held = [];
+  };
+  stub.releaseOldest = async () => {
+    held?.shift()?.();
+    for (let hop = 0; hop < 6; hop++) await Promise.resolve();
+  };
+  stub.releaseNewest = async () => {
+    held?.pop()?.();
+    for (let hop = 0; hop < 6; hop++) await Promise.resolve();
   };
   stub.releaseNewestFirst = async () => {
     const pending = held ?? [];
@@ -252,6 +268,12 @@ function stubRuntime(
         queue.push(() => resolve(loaded));
       });
     },
+    // What handing a runtime to the view's debugger controller reads. A
+    // replacement runtime goes through that hand-off on its way to the watch.
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    telemetry: () => [],
+    runtime: () => ({ setTelemetryEnabled: () => Promise.resolve() }),
     getSlugCell: () =>
       Promise.resolve({
         subscribe: () => () => {
@@ -341,6 +363,39 @@ function appViewOver(
   element.space = SPACE;
   element.rt = stub.rt;
   return element;
+}
+
+/**
+ * Drive `view` into the state the cases below turn on: the watch it was
+ * running has been replaced, that watch's resolution is still out, and the
+ * watch that replaced it is the one now resolving.
+ *
+ * The address moves off member `42`, which callers open on, and onto member
+ * `43`. That is a different reference and so a different watch. Answers are
+ * held from before the move, so the outgoing watch's resolution is still out
+ * when the incoming one starts. The incoming watch's first answer is
+ * released, because opening its poll and its subscription is what that first
+ * answer finishing does.
+ */
+async function replaceWatchMidResolution(
+  view: AppViewLike,
+  stub: StubRuntime,
+): Promise<void> {
+  view.updated(new Map([["app", undefined]]));
+  await stub.settle();
+
+  stub.hold();
+  await stub.poll();
+
+  view.app = {
+    identity: {},
+    config: {},
+    view: viewOf({ pieceSlug: "top", pieceMember: "43" }),
+  };
+  view.updated(new Map([["app", undefined]]));
+  await stub.settle();
+
+  await stub.releaseNewest();
 }
 
 describe("AppView collection members", () => {
@@ -668,6 +723,68 @@ describe("AppView collection members", () => {
     }
   });
 
+  it("keeps to one resolution in flight when a replaced watch's answer lands", async () => {
+    const restore = installBrowserGlobals();
+    try {
+      const { XAppView } = await import("../src/views/AppView.ts");
+      const stub = stubRuntime({ pieceId: "fid1:first", pathAfter: [] });
+      const view = appViewOver(
+        XAppView as never,
+        stub,
+        viewOf({ pieceSlug: "top", pieceMember: "42" }),
+      );
+
+      await replaceWatchMidResolution(view, stub);
+
+      // The watch the view is running has a resolution out of its own.
+      await stub.poll();
+      const inFlight = stub.resolved.length;
+
+      // The replaced watch's answer lands, and ends the run it started. The
+      // run still out is the running watch's, and is not the replaced
+      // watch's to end — so a poll behind it finds one running, and
+      // coalesces.
+      await stub.releaseOldest();
+      await stub.poll();
+
+      expect(stub.resolved.length).toBe(inFlight);
+    } finally {
+      restore();
+    }
+  });
+
+  it("re-resolves for its own coalesced request when a replaced watch's answer lands", async () => {
+    const restore = installBrowserGlobals();
+    try {
+      const { XAppView } = await import("../src/views/AppView.ts");
+      const stub = stubRuntime({ pieceId: "fid1:first", pathAfter: [] });
+      const view = appViewOver(
+        XAppView as never,
+        stub,
+        viewOf({ pieceSlug: "top", pieceMember: "42" }),
+      );
+
+      await replaceWatchMidResolution(view, stub);
+
+      // The watch the view is running has a resolution out and a poll
+      // coalesced behind it.
+      await stub.poll();
+      await stub.poll();
+
+      // The replaced watch's answer lands. The request coalesced behind the
+      // running watch's resolution was asked of that watch, and is still that
+      // watch's to answer.
+      await stub.releaseOldest();
+      const asked = stub.resolved.length;
+
+      await stub.releaseNewestFirst();
+
+      expect(stub.resolved.length).toBe(asked + 1);
+    } finally {
+      restore();
+    }
+  });
+
   it("applies an answer that took longer than the poll interval", async () => {
     const restore = installBrowserGlobals();
     try {
@@ -835,15 +952,6 @@ describe("AppView collection members", () => {
     }
   });
 
-  it("leaves the process-wide timers as it found them", () => {
-    // Last, and it reads what every test before it did. These are shared with
-    // the whole test process: left replaced, `setInterval` stops scheduling
-    // and `clearInterval` stops cancelling for everything that runs after,
-    // and no assertion anywhere goes red — things simply stop happening.
-    expect(globalThis.setInterval).toBe(NATIVE_TIMERS.setInterval);
-    expect(globalThis.clearInterval).toBe(NATIVE_TIMERS.clearInterval);
-  });
-
   it("stops watching a runtime that has been disposed", async () => {
     const restore = installBrowserGlobals();
     try {
@@ -866,5 +974,50 @@ describe("AppView collection members", () => {
     } finally {
       restore();
     }
+  });
+
+  it("reloads nothing when a replacement watch reaches the answer on screen", async () => {
+    const restore = installBrowserGlobals();
+    try {
+      const { XAppView } = await import("../src/views/AppView.ts");
+      const first = stubRuntime({ pieceId: "fid1:member-42", pathAfter: [] });
+      const view = appViewOver(
+        XAppView as never,
+        first,
+        viewOf({ pieceSlug: "top", pieceMember: "42" }),
+      );
+
+      view.updated(new Map([["app", undefined]]));
+      await first.settle();
+      view._selectedPattern.run();
+      await view._selectedPattern.taskComplete;
+      const before = view.accessForTestingOnly.slugRevision;
+
+      // A replacement runtime can read the same reference to a different
+      // answer, so it gets a watch of its own and the running one stops. The
+      // piece the stopped watch resolved is on screen throughout, and the
+      // view goes on naming it — so the replacement's first answer is the one
+      // the view already has, and asks for no reload.
+      const replacement = stubRuntime({
+        pieceId: "fid1:member-42",
+        pathAfter: [],
+      });
+      view.rt = replacement.rt;
+      view.updated(new Map([["rt", undefined]]));
+      await replacement.settle();
+
+      expect(view.accessForTestingOnly.slugRevision).toBe(before);
+    } finally {
+      restore();
+    }
+  });
+
+  it("leaves the process-wide timers as it found them", () => {
+    // Last, and it reads what every test before it did. These are shared with
+    // the whole test process: left replaced, `setInterval` stops scheduling
+    // and `clearInterval` stops cancelling for everything that runs after,
+    // and no assertion anywhere goes red — things simply stop happening.
+    expect(globalThis.setInterval).toBe(NATIVE_TIMERS.setInterval);
+    expect(globalThis.clearInterval).toBe(NATIVE_TIMERS.clearInterval);
   });
 });

--- a/packages/shell/test/app-view-collection-member.test.ts
+++ b/packages/shell/test/app-view-collection-member.test.ts
@@ -83,6 +83,26 @@ function installBrowserGlobals(): () => void {
   };
 }
 
+/**
+ * Record what `console.error` is given, until `restore` puts it back.
+ *
+ * A test that prints an error it is not about trains a reader to skip this
+ * file's output, which is where the next real diagnostic goes missing. Reading
+ * the log is also the only way a stub too small for what a collaborator calls
+ * shows up at all, where that collaborator logs the failure and carries on.
+ */
+function captureErrors(): { lines: string[]; restore: () => void } {
+  const lines: string[] = [];
+  const real = console.error;
+  console.error = (...args: unknown[]) => lines.push(args.join(" "));
+  return {
+    lines,
+    restore: () => {
+      console.error = real;
+    },
+  };
+}
+
 /** Return the rendered text of nested Lit template results. */
 function templateText(value: unknown): string {
   if (value == null) return "";
@@ -268,12 +288,19 @@ function stubRuntime(
         queue.push(() => resolve(loaded));
       });
     },
-    // What handing a runtime to the view's debugger controller reads. A
-    // replacement runtime goes through that hand-off on its way to the watch.
+    // What handing a runtime to the view's debugger controller reads, here
+    // and on what `runtime()` returns. A replacement runtime goes through
+    // that hand-off on its way to the watch, and the controller reports a
+    // member it cannot call by logging rather than by throwing — so the case
+    // driving that hand-off reads the log, and a member missing from here
+    // fails it.
     addEventListener: () => {},
     removeEventListener: () => {},
     telemetry: () => [],
-    runtime: () => ({ setTelemetryEnabled: () => Promise.resolve() }),
+    runtime: () => ({
+      setTelemetryEnabled: () => Promise.resolve(),
+      setBreakpoints: () => Promise.resolve(),
+    }),
     getSlugCell: () =>
       Promise.resolve({
         subscribe: () => () => {
@@ -978,6 +1005,7 @@ describe("AppView collection members", () => {
 
   it("reloads nothing when a replacement watch reaches the answer on screen", async () => {
     const restore = installBrowserGlobals();
+    const errors = captureErrors();
     try {
       const { XAppView } = await import("../src/views/AppView.ts");
       const first = stubRuntime({ pieceId: "fid1:member-42", pathAfter: [] });
@@ -1007,7 +1035,11 @@ describe("AppView collection members", () => {
       await replacement.settle();
 
       expect(view.accessForTestingOnly.slugRevision).toBe(before);
+      // Nothing here drives an error path, so the whole of what the runtime
+      // is asked for on its way to the watch answered.
+      expect(errors.lines).toEqual([]);
     } finally {
+      errors.restore();
       restore();
     }
   });


### PR DESCRIPTION
## Why

`AppView` stored four watch-scoped fields on the view — `#slugCancel`,
`#slugPollInterval`, `#slugRefreshRunning`, `#slugRefreshRequested`. All four
belong to a single watch, and only their write *positions* differed: two sat
behind an `#isCurrentSlugWatch` check, one was written in a `finally` with no
check at all.

That last one was the live defect (#6931): a watch torn down during an
in-flight resolution cleared its **successor's** running flag, letting two
refreshes run concurrently — the state the serialization exists to prevent —
and then consumed and dropped the successor's coalesced request.

Fixing the one field that bit would have left the two that did not, which is
the one-field-at-a-time pattern that produced eleven instances of this shape
in #6896. So this moves the ownership instead: the watch is a class that holds
its own state and stops itself, and teardown becomes an operation on that
object rather than a sweep of view fields.

The boundary, stated once and built to:

> **The watch owns what is watch-scoped; the view owns what is displayed.**

## What changed

- `SlugWatch` becomes a module-internal class holding `cancel`, `pollInterval`,
  `refreshRunning`, `refreshRequested` beside `rt`/`space`/`slug`/`member`,
  with `stop()`.
- `#clearSlugSubscription` becomes `#stopSlugWatch`, whose whole body is: take
  the watch, drop it, stop it.
- **Teardown no longer clears `#shownResolution`.** That clear was the
  counterexample to a single-writer invariant the file already documented in
  two places — `#shownResolution` says "written only by `#markShown`", and
  `#markShown` says it is the only writer. It is also cheaper: it skips a
  redundant reload of a piece already on screen.

## Test plan

Three cases added, each verified red at the pre-fix HEAD, then each of five
mutations applied in isolation against the final source. Two of those
mutations exist to test the *cheapest way back in* — writing
`this.#slugWatch.refreshRunning` from a callback that already holds `watch`,
which compiles and reads almost identically — and both are caught.

Full gate set green, including a deliberate type error confirming
`deno task check` actually covers the changed files rather than merely
passing.

Browser integration was not run locally (sandbox); CI covers it.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6936?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

