### PR TITLE
feat(patterns): Topics adopts the member namespace (S6, items 1-3 and 5)

### DIFF
--- a/docs/common/conventions/mentionable.md
+++ b/docs/common/conventions/mentionable.md
@@ -55,8 +55,9 @@ or derived INDEX ROWS standing for them: entries shaped `{ [NAME], piece }`,
 where the strings are the row's own copies and `piece` holds the actual
 piece as a reference. A board-sized producer reaches for rows so that every
 reader of the universe loads one document instead of every listed piece;
-the Topics board's `mentionable` is the worked example
-(`TopicMentionableRow` in `packages/patterns/topics/main.tsx`).
+the Topics board's `mentionable` is the worked example, derived through the
+library both it and the collection-naming exemplar share (`MentionableRow` in
+`packages/patterns/collection-naming/mentionable.ts`).
 
 `piece` is therefore a RESERVED key on this contract: an entry carrying one
 IS a row, and the editors store what `piece` names — never the entry — as

--- a/docs/plans/collection-naming-topics.md
+++ b/docs/plans/collection-naming-topics.md
@@ -17,9 +17,9 @@ This block is LIVE: the change that moves a stage updates it here.
 | S1b — index rows are the members | on main (#6886) |
 | S2 — `top/42` resolves at the CLI | on main (#6890) |
 | S2b — assignment refuses by default | on main (#6898) |
-| S3 — the shell opens `/<space>/top/42` | built, in review (#6896) |
+| S3 — the shell opens `/<space>/top/42` | on main (#6896) |
 | S4 — `#42` in text | on main (#6887) |
-| S6 — graft onto Topics | not started; Mike's call after S4 |
+| S6 — graft onto Topics | items 1, 2, 3, 5 built; item 4 is Mike's call |
 | S5 — deferred, not scheduled | — |
 
 ## Decisions, ruled 2026-09-03
@@ -266,9 +266,28 @@ Mike's call, after S4.
    `mentionableIndex` are a fork of the Topics pair differing only by that
    property, so this step is where the fork ends: one of the two goes, and the
    survivor is the one both boards derive their universe through.
+
+   Recorded: the survivor is one derivation, `mentionableIndex` and
+   `mentionableRowsOf` in `packages/patterns/collection-naming/mentionable.ts`,
+   which both boards import; `MentionableRow` is the row type both publish, and
+   `TopicMentionableRow` and `ItemMentionableRow` are gone. Neither board could
+   import the other's copy: a pattern module carries its imports into its own
+   compiled program, so the exemplar would ship the Topics board or Topics
+   would ship the exemplar. It is not in `naming.ts` either, because that
+   module never reads through a member and this derivation reads three display
+   strings off each one.
 4. The production backfill is rehearsed on a clone per
    `../development/space-clone-rehearsal.md`; the deployed vintage includes
-   #6827 before the backfill runs.
+   #6827 before the backfill runs. Not started, and one decision items 1-3
+   could not make for it stands: a topic filed before the namespace reads its
+   name only once `namesTable` is link-bound onto it, and nothing in a pattern
+   can reach a member's argument to do that.
+
+   The graft's own contract IS applicable over the deployed one — every row
+   demand declares `shortName` optional rather than defaulted, which is what
+   keeps it so — so the update needs no schema flag. It does need `--root` at
+   or above `packages/patterns`, because the board imports the naming library
+   from a sibling directory and the default program root is the entry's own.
 5. `skills/topics/SKILL.md` describes `top/42` addressing.
 
 ### S5 — Deferred, not scheduled

--- a/packages/cli/integration/topics-restore-drill.sh
+++ b/packages/cli/integration/topics-restore-drill.sh
@@ -88,13 +88,40 @@ step "deploy the topics board into a fresh space ($SPACE)"
 # snapshot is taken from the database file itself.
 ls "$ENGINE_DIR" 2> /dev/null | grep '\.sqlite$' | sort > "$WORK/dbs-before" ||
   true
-BOARD="$(
-  $CF piece new "$REPO_ROOT/packages/patterns/topics/main.tsx" \
-    --space "$SPACE" --api-url "$API_URL" 2> /dev/null |
-    grep -o 'fid1:[A-Za-z0-9_-]*' | head -1
-)"
+# `--root` is the repository root because the board imports the member-naming
+# library from a sibling directory (`../collection-naming/`). Without it the
+# program root is the entry's own directory, every such import is refused as
+# escaping it, and no fid is printed. Any deploy of this board needs the same
+# flag, which is why the failure is captured and shown rather than discarded:
+# a deploy that refuses and a deploy that prints nothing look identical once
+# stderr is dropped, and only one of them is this script's fault.
+#
+# The two streams stay apart, and the match is a WHOLE LINE. Under `-q` today
+# stdout carries the new piece's id and nothing else, while every diagnostic,
+# hint and log line goes to stderr. Merging them and taking the first `fid1:`
+# token anywhere would accept a token out of a message — a source reference in
+# a warning, an id inside a suggested command — and the drill would then run
+# against a board that does not exist, failing several steps later with a
+# message about something else.
+#
+# What the anchor buys is narrower than "stdout holds only the id", and the
+# difference matters to whoever next asks whether this still holds. `grep -x`
+# accepts a LINE that is a fid and nothing more, so a fid embedded in a longer
+# line cannot match however the streams are arranged. It does NOT require
+# stdout to hold that line alone: a future `cf` printing something beside the
+# id would keep working, and silently. What breaks this is stdout ceasing to
+# carry a bare fid line at all, and that failure is loud — nothing matches,
+# `BOARD` is empty, and the step stops here naming what it did not find.
+$CF piece new -q "$REPO_ROOT/packages/patterns/topics/main.tsx" \
+  --root "$REPO_ROOT" --space "$SPACE" --api-url "$API_URL" \
+  > "$WORK/deploy.out" 2> "$WORK/deploy.err"
+BOARD="$(grep -xE 'fid1:[A-Za-z0-9_-]+' "$WORK/deploy.out" | head -1)"
 [ -n "$BOARD" ] && ok "board deployed: $BOARD" || {
-  bad "board deploy printed no fid"
+  bad "board deploy produced no bare fid line on stdout"
+  echo "--- deploy stdout ---" >&2
+  cat "$WORK/deploy.out" >&2
+  echo "--- deploy stderr ---" >&2
+  cat "$WORK/deploy.err" >&2
   exit 1
 }
 
@@ -117,6 +144,13 @@ fi
   bad "no topic address"
   exit 1
 }
+# The name the create allocated, beside the topic it created. A caller reads
+# this rather than waiting for the topic's own `shortName` derivation, and a
+# pattern test cannot see it — a verb's result reaches its caller through the
+# handling's receipt. This is the first topic on a fresh board, so `1`.
+CREATED_NAME="$(jq -r '.result.name // empty' "$WORK/create.json")"
+[ "$CREATED_NAME" = "1" ] && ok "create returned the allocated name: 1" ||
+  bad "create returned name '$CREATED_NAME', expected 1"
 $CF piece call -q --piece "$TOPIC_ALIAS" --space "$SPACE" \
   --api-url "$API_URL" addComment \
   '{"body":"first drill comment","agentName":"drill"}' > /dev/null 2>&1
@@ -208,6 +242,44 @@ deno run --allow-run --allow-read --allow-env \
   --piece "$TOPIC" --api-url "$API_URL" 2> /dev/null |
   grep -q "nothing to restore" &&
   ok "second restore is a no-op" || bad "second restore was not a no-op"
+
+step "the namespace verbs' own results"
+# `backfillNames` returns the names it wrote. Asserted here rather than in a
+# pattern test for the reason the create's `name` is: a verb's result reaches
+# its caller through the handling's receipt, and `send()` hands a pattern test
+# nothing.
+#
+# The board's one topic was named by its create, so a backfill over it as it
+# stands writes nothing — and an implementation that never wrote anything would
+# pass that just as well. So the namespace is emptied first, which is the state
+# a board filed before it numbered anything is actually in: members in the
+# list, no names for them. Now the run has something to write, and `assigned`
+# has to carry it. Last step in the drill, since it leaves the namespace
+# rebuilt rather than as the restore left it.
+printf '{}' | $CF cell set -q --piece "$BOARD" --space "$SPACE" \
+  --api-url "$API_URL" names > /dev/null 2>&1
+CLEARED="$(
+  $CF cell get -q --piece "$BOARD" --space "$SPACE" --api-url "$API_URL" \
+    names 2> /dev/null | jq -c 'keys'
+)"
+[ "$CLEARED" = "[]" ] && ok "namespace emptied for the backfill" ||
+  bad "namespace did not empty: $CLEARED"
+BACKFILL="$(
+  $CF piece call -q --piece "$BOARD" --space "$SPACE" --api-url "$API_URL" \
+    backfillNames \
+    '{"agentName":"drill"}' 2> /dev/null
+)"
+ASSIGNED="$(printf '%s\n' "$BACKFILL" | jq -c '.result.assigned // empty')"
+[ "$ASSIGNED" = '["1"]' ] &&
+  ok "backfill reported the name it wrote: [\"1\"]" ||
+  bad "backfill reported '$ASSIGNED', expected [\"1\"]"
+# And it wrote what it reported, rather than reporting a name it never stored.
+REFILLED="$(
+  $CF cell get -q --piece "$BOARD" --space "$SPACE" --api-url "$API_URL" \
+    names 2> /dev/null | jq -c 'keys'
+)"
+[ "$REFILLED" = '["1"]' ] && ok "the namespace carries the name it reported" ||
+  bad "namespace holds $REFILLED after the backfill"
 
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/packages/patterns/baselines/collection-naming/board.tsx/20260905T003604Z-uX940wR7R4lVwuOt.json
+++ b/packages/patterns/baselines/collection-naming/board.tsx/20260905T003604Z-uX940wR7R4lVwuOt.json
@@ -1,0 +1,317 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "ItemIndexRow": {
+        "properties": {
+          "createdAt": {
+            "description": "When the item was filed (epoch milliseconds), which the item pattern\npublishes unconditionally.",
+            "type": "number"
+          },
+          "shortName": {
+            "default": "",
+            "description": "The board's name for the item, as the item reads it out of the board's\nnames table. Coalesced to the empty string for an item whose lookup has\nproduced no value — one created a moment ago, or one from before the\nboard numbered anything — so the row itself never carries the\nmixed-version undefined.",
+            "type": [
+              "string",
+              "undefined"
+            ]
+          },
+          "title": {
+            "default": "",
+            "description": "The item's title. Defaulted so a missing path does not make the whole\narray unreadable.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "createdAt",
+          "shortName"
+        ],
+        "type": "object"
+      },
+      "NamesMap": {
+        "additionalProperties": {
+          "type": "unknown"
+        },
+        "properties": {},
+        "type": "object"
+      }
+    },
+    "description": "What the board holds: its item list and its member namespace.",
+    "properties": {
+      "items": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "description": "The board's durable item list, in filing order. `addItem` appends here; a\nwhole-array write forfeits the mergeability the append keeps.",
+        "items": {
+          "$ref": "#/$defs/ItemIndexRow"
+        },
+        "type": "array"
+      },
+      "names": {
+        "$ref": "#/$defs/NamesMap",
+        "asCell": [
+          "cell"
+        ],
+        "default": {},
+        "description": "The board's member namespace: each name to the item it names, held as an\nunread reference. `addItem` writes one key per create and `backfillNames`\none key per member it names; nothing rewrites the map whole. Reads as\nempty on a board from before it numbered anything, in the default form\n`NamesMap` explains."
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "collection-naming/board.tsx",
+  "resultSchema": {
+    "$defs": {
+      "AddItemEvent": {
+        "properties": {
+          "agentName": {
+            "description": "The agent making this mutation. Fabric records the human principal\nbehind the key; this names which agent acted under it. Required, and\nchecked rather than stored: a create that could be unsigned is a\ntolerance the verb could never withdraw.",
+            "type": "string"
+          },
+          "body": {
+            "description": "The item's initial body, stored verbatim.",
+            "type": "string"
+          },
+          "title": {
+            "description": "The item's title, trimmed before it is stored. Must be non-empty.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "agentName"
+        ],
+        "type": "object"
+      },
+      "BackfillNamesEvent": {
+        "properties": {
+          "agentName": {
+            "description": "The agent running the backfill, checked as `addItem` checks it.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "agentName"
+        ],
+        "type": "object"
+      },
+      "ItemIndexRow": {
+        "properties": {
+          "createdAt": {
+            "description": "When the item was filed (epoch milliseconds), which the item pattern\npublishes unconditionally.",
+            "type": "number"
+          },
+          "shortName": {
+            "default": "",
+            "description": "The board's name for the item, as the item reads it out of the board's\nnames table. Coalesced to the empty string for an item whose lookup has\nproduced no value — one created a moment ago, or one from before the\nboard numbered anything — so the row itself never carries the\nmixed-version undefined.",
+            "type": [
+              "string",
+              "undefined"
+            ]
+          },
+          "title": {
+            "default": "",
+            "description": "The item's title. Defaulted so a missing path does not make the whole\narray unreadable.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "createdAt",
+          "shortName"
+        ],
+        "type": "object"
+      },
+      "MentionableRow": {
+        "properties": {
+          "$NAME": {
+            "type": "string"
+          },
+          "piece": {
+            "type": "unknown"
+          },
+          "shortName": {
+            "default": "",
+            "type": "string"
+          },
+          "title": {
+            "default": "",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "shortName",
+          "piece",
+          "$NAME"
+        ],
+        "type": "object"
+      },
+      "NamesMap": {
+        "additionalProperties": {
+          "type": "unknown"
+        },
+        "properties": {},
+        "type": "object"
+      },
+      "NamesTableRow": {
+        "properties": {
+          "member": {
+            "description": "The member. `unknown` because it is written as a reference and only ever\ncompared; anything wider would read the member back whole.",
+            "type": "unknown"
+          },
+          "name": {
+            "description": "The member's name.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "member",
+          "name"
+        ],
+        "type": "object"
+      },
+      "NamingDeclaration": {
+        "properties": {
+          "compact": {
+            "description": "Whether the collection offers the compact spelling that joins its name to\na member's with a hyphen. Only a collection whose member names cannot\ncontain a hyphen may say so.",
+            "type": "boolean"
+          },
+          "name": {
+            "description": "The collection's own name, which a binding uses to reach it. Absent when\nthe collection makes no claim about what it is bound as.",
+            "type": "string"
+          },
+          "policy": {
+            "$ref": "#/$defs/NamingPolicy",
+            "description": "The policy the names are held to."
+          }
+        },
+        "required": [
+          "policy",
+          "compact"
+        ],
+        "type": "object"
+      },
+      "NamingPolicy": {
+        "properties": {
+          "allocator": {
+            "description": "What a name is made of: a monotonic sequence, a random code, a string a\nperson chose, or a derivation from the member's own content.",
+            "enum": [
+              "sequence",
+              "random",
+              "human",
+              "derived"
+            ]
+          },
+          "permanent": {
+            "description": "Whether a name, once assigned, is never retired or reassigned.",
+            "type": "boolean"
+          },
+          "reuse": {
+            "description": "Whether a retired name may be given to another member.",
+            "type": "boolean"
+          },
+          "unique": {
+            "description": "Whether a name is unique across the collection's whole history, or only\namong its current members.",
+            "enum": [
+              "history",
+              "current"
+            ]
+          }
+        },
+        "required": [
+          "unique",
+          "permanent",
+          "reuse",
+          "allocator"
+        ],
+        "type": "object"
+      }
+    },
+    "description": "A board of items that names its members. Survey the board with one bounded\nread of `index`: a row is its item, so select the row's own address\nalongside `title` and `shortName`, and use that address for the item's own\nreads. File with `addItem`, which allocates the next name in the same write\nas the append and returns the item with the name it allocated. A board that\nheld items before it numbered anything runs `backfillNames` once.",
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "addItem": {
+        "$ref": "#/$defs/AddItemEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "File an item: allocate its name and append it, atomically."
+      },
+      "backfillNames": {
+        "$ref": "#/$defs/BackfillNamesEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Name every unnamed member in filing order. Idempotent."
+      },
+      "index": {
+        "default": [],
+        "description": "The survey surface: the items themselves, declared through the row\nschema. A row IS its item, so a row's own address is the item's, and an\nindex into this array is not a stable address.",
+        "items": {
+          "$ref": "#/$defs/ItemIndexRow"
+        },
+        "type": "array"
+      },
+      "itemCount": {
+        "description": "How many items the board holds.",
+        "type": "number"
+      },
+      "items": {
+        "description": "The board's items, in filing order, through the shape the board demands\nof them.",
+        "items": {
+          "$ref": "#/$defs/ItemIndexRow"
+        },
+        "type": "array"
+      },
+      "mentionable": {
+        "default": [],
+        "description": "The board's mention universe, under the name the item pattern's editor\nautocompletes over — what `addItem` wires into each item it creates. One\nderived document of copies, each holding its item as an unread reference\nand carrying the board's name for it, so `#42` finds a member without\nexpanding one; see `MentionableRow` in `mentionable.ts`.",
+        "items": {
+          "$ref": "#/$defs/MentionableRow"
+        },
+        "tags": [
+          "42"
+        ],
+        "type": "array"
+      },
+      "names": {
+        "$ref": "#/$defs/NamesMap",
+        "default": {},
+        "description": "The namespace itself: each name to the item it names. A slug pointing\nhere is what makes a member addressable as `<board>/<name>`. Published\nunder the default its input carries."
+      },
+      "namesTable": {
+        "default": [],
+        "description": "The names table, one row per named member, which every item the board\ncreates reads its own name from. Published so an item composed outside\n`addItem` can be wired to the same table.",
+        "items": {
+          "$ref": "#/$defs/NamesTableRow"
+        },
+        "type": "array"
+      },
+      "naming": {
+        "$ref": "#/$defs/NamingDeclaration",
+        "description": "What the board declares about its names, for a consumer deciding whether\na name may be held rather than an identity."
+      }
+    },
+    "required": [
+      "items",
+      "index",
+      "names",
+      "namesTable",
+      "naming",
+      "mentionable",
+      "itemCount",
+      "addItem",
+      "backfillNames",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/collection-naming/item.tsx/20260905T003605Z-gslMTuThImQHhkVQ.json
+++ b/packages/patterns/baselines/collection-naming/item.tsx/20260905T003605Z-gslMTuThImQHhkVQ.json
@@ -1,0 +1,224 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "ItemMentionRef": {
+        "properties": {
+          "destination": {
+            "type": "unknown"
+          },
+          "modifiedTitle": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "destination",
+          "modifiedTitle"
+        ],
+        "type": "object"
+      },
+      "ItemMentionRefMap": {
+        "additionalProperties": {
+          "$ref": "#/$defs/ItemMentionRef"
+        },
+        "properties": {},
+        "type": "object"
+      },
+      "ItemMentionable": {
+        "properties": {
+          "$NAME": {
+            "default": "",
+            "type": [
+              "string",
+              "undefined"
+            ]
+          },
+          "shortName": {
+            "default": "",
+            "type": "string"
+          },
+          "title": {
+            "default": "",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "shortName",
+          "$NAME"
+        ],
+        "type": "object"
+      },
+      "NamesTableRow": {
+        "properties": {
+          "member": {
+            "description": "The member. `unknown` because it is written as a reference and only ever\ncompared; anything wider would read the member back whole.",
+            "type": "unknown"
+          },
+          "name": {
+            "description": "The member's name.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "member",
+          "name"
+        ],
+        "type": "object"
+      }
+    },
+    "description": "What an item holds, and what its board hands it.",
+    "properties": {
+      "boardNames": {
+        "asCell": [
+          "readonly"
+        ],
+        "default": [],
+        "description": "The board's names table, one row per named member. The item reads its\nown row out of it and nothing else; absent, the item shows no name.\n\nReadable, not writable: the table is the board's derivation, and an item\nhas no business writing into it.",
+        "items": {
+          "$ref": "#/$defs/NamesTableRow"
+        },
+        "type": "array"
+      },
+      "body": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "description": "The item's body, verbatim Markdown.",
+        "type": "string"
+      },
+      "createdAt": {
+        "default": 0,
+        "description": "When the item was filed (epoch milliseconds), stamped at create.",
+        "type": "number"
+      },
+      "mentionable": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "description": "The board's mention universe — what the body editor completes over.\nWired at creation to the board's mention index, one derived document of\nrows (`MentionableRow` in `mentionable.ts`). Absent, the editor simply\noffers no completions.",
+        "items": {
+          "$ref": "#/$defs/ItemMentionable"
+        },
+        "type": "array"
+      },
+      "references": {
+        "$ref": "#/$defs/ItemMentionRefMap",
+        "asCell": [
+          "cell"
+        ],
+        "default": {},
+        "description": "Where this item's `[Label][key]` mentions point, keyed by the token that\nappears in the body. The editor owns the contents; this pattern owns the\ncell, which is what makes a mention durable and — because each entry\nholds the destination as a REFERENCE — what makes the reference a\nquestion about cell identity rather than about text.\n\nThe default has to match the one `ItemOutput` publishes. A map published\nunder a different default than its input carries cannot be materialized."
+      },
+      "title": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "description": "The item's title, trimmed by the board's create before it is stored.",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "collection-naming/item.tsx",
+  "resultSchema": {
+    "$defs": {
+      "ItemMentionRef": {
+        "properties": {
+          "destination": {
+            "type": "unknown"
+          },
+          "modifiedTitle": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "destination",
+          "modifiedTitle"
+        ],
+        "type": "object"
+      },
+      "ItemMentionRefMap": {
+        "additionalProperties": {
+          "$ref": "#/$defs/ItemMentionRef"
+        },
+        "properties": {},
+        "type": "object"
+      }
+    },
+    "description": "An item of the exemplar board. The display name stays the title; the\nboard's name for the item rides beside it as `shortName`, and renders as a\nbadge in the header when there is one.",
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "body": {
+        "default": "",
+        "description": "The item's body, verbatim Markdown.",
+        "type": "string"
+      },
+      "cancelEditBody": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "Close the editor, leaving both drafts behind.",
+        "tier": "wrapper"
+      },
+      "createdAt": {
+        "description": "When the item was filed (epoch milliseconds).",
+        "type": "number"
+      },
+      "references": {
+        "$ref": "#/$defs/ItemMentionRefMap",
+        "default": {},
+        "description": "Where this item's mentions point, keyed by the token in the body. Written\nwhole by the save, out of the draft the editor minted into, in the same\ntransaction as the prose those tokens sit in."
+      },
+      "saveBody": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "Write the drafted body and its mention map together, and close.",
+        "tier": "wrapper"
+      },
+      "shortName": {
+        "description": "The name the board calls this item by, read out of the board's names\ntable; `undefined` for an item no board has named, or one wired to no\nboard.\n\nPublished under the name a mention pill reads it by\n(`Mentionable.shortName` in `packages/ui/src/v2/core/mentionable.ts`), so\na mention of this item elsewhere gains the number as soon as the board\nnames it.",
+        "type": [
+          "string",
+          "undefined"
+        ]
+      },
+      "startEditBody": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "Open the body editor on the stored body and its mention map.\n\nThese three are the whole editing surface, and opening is a verb rather\nthan a flag on purpose: the drafts are seeded here and nowhere else, so a\nsurface that could raise an `editingBody` flag directly would open an\neditor showing nothing and then save that over the stored body. No such\nflag is reachable — an unpublished session cell cannot be written from\noutside, and publishing one as a plain `PerSession<boolean>` is not an\noption either, because a published value carrying one cannot serve as an\naction's captured state, which is what naming a member makes of it.",
+        "tier": "wrapper"
+      },
+      "title": {
+        "default": "",
+        "description": "The item's title, as stored.",
+        "type": "string"
+      }
+    },
+    "required": [
+      "title",
+      "body",
+      "createdAt",
+      "shortName",
+      "references",
+      "startEditBody",
+      "saveBody",
+      "cancelEditBody",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/topics/main.tsx/20260905T021503Z-DBE_bqVhJLAC2xLu.json
+++ b/packages/patterns/baselines/topics/main.tsx/20260905T021503Z-DBE_bqVhJLAC2xLu.json
@@ -1,0 +1,549 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "NamesMap": {
+        "additionalProperties": {
+          "type": "unknown"
+        },
+        "properties": {},
+        "type": "object"
+      },
+      "TopicAuthor": {
+        "properties": {
+          "avatar": {
+            "type": "string"
+          },
+          "kind": {
+            "description": "Open for the same reason `TopicLinkKind` is: this is provided data, so a\nclosed set here could never gain `\"service\"` or whatever acts next.\nWell-known values are `\"person\"` and `\"agent\"`, the latter marking an\nagent acting with its human user's key.",
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "name"
+        ],
+        "type": "object"
+      },
+      "TopicDemand": {
+        "properties": {
+          "$NAME": {
+            "default": "",
+            "description": "The display name, which the board's mention index copies into each\ntopic's row — the label every `@`-mention completion carries. The index\nlift states the same three-string demand for itself; this entry is the\nboard-level record of it.",
+            "type": [
+              "string",
+              "undefined"
+            ]
+          },
+          "body": {
+            "default": "",
+            "type": "string"
+          },
+          "commentCount": {
+            "default": 0,
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "createdAt": {
+            "description": "When the topic was filed (epoch milliseconds), stamped at create.",
+            "type": "number"
+          },
+          "createdBy": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/TopicAuthor"
+              },
+              {
+                "type": "undefined"
+              }
+            ],
+            "default": {
+              "kind": "person",
+              "name": ""
+            }
+          },
+          "lastActivityAt": {
+            "default": 0,
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "mentions": {
+            "default": [],
+            "items": {
+              "type": "unknown"
+            },
+            "type": "array"
+          },
+          "shortName": {
+            "description": "The board's name for the topic, as the topic reads it out of the board's\nnames table. The card renders it as a badge and the mention index copies\nit into the topic's universe row, so `#42` matches without expanding a\ntopic.\n\nOPTIONAL rather than defaulted, and the spelling is what keeps this demand\napplicable over a board deployed before the namespace: a defaulted\nproperty moves the demand's defaults below an array constraint the\ncompatibility proof cannot show stable under default insertion, while an\noptional one simply tolerates a topic that publishes none. A topic whose\nlookup has produced no value — one filed a moment ago, or one from before\nthe board numbered anything — is absent here rather than blank, and every\nconsumer treats the two the same.",
+            "tags": [
+              "42"
+            ],
+            "type": "string"
+          },
+          "title": {
+            "default": "",
+            "description": "The topic's title. Defaulted rather than required, like every other\nfield a board card renders: the card list is a mapped sub-pattern, so\nthis type reaches a piece holding topics written before the field\nexisted as the argument schema its update is checked against, and a\nrequired property those topics lack refuses that update outright.\n`deno task pattern-vintage` is what catches it, by replaying a real\ndeployed board.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "body",
+          "mentions",
+          "$NAME",
+          "title",
+          "createdAt",
+          "commentCount",
+          "lastActivityAt"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "names": {
+        "$ref": "#/$defs/NamesMap",
+        "asCell": [
+          "cell"
+        ],
+        "default": {},
+        "description": "The board's member namespace: each name to the topic it names, held as an\nunread reference. `addTopic` writes one key per create and `backfillNames`\none key per member it names; nothing rewrites the map whole. Reads as empty\non a board from before it numbered anything, in the default form `NamesMap`\nexplains."
+      },
+      "topics": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "description": "The board's durable topic list. `addTopic` appends here; direct writes\nare legitimate but unattributed, and a whole-array write forfeits the\nmergeability the verb's append keeps.",
+        "items": {
+          "$ref": "#/$defs/TopicDemand"
+        },
+        "type": "array"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "topics/main.tsx",
+  "resultSchema": {
+    "$defs": {
+      "AddTopicEvent": {
+        "properties": {
+          "agentName": {
+            "description": "The agent making this mutation. The authenticated principal remains the\nhuman whose identity key invoked the stream; this is the agent's explicit\ncontent-level signature under that shared principal.\n\nRequired, for the reason given on `AgentAuthoredEvent`: acceptance widens\ncompatibly and narrows only through a break, so tolerating an unsigned\ncreate is a tolerance that could never be withdrawn.",
+            "type": "string"
+          },
+          "body": {
+            "description": "The topic's initial living-document body. A topic born with a body\nappears with it atomically — no reader observes the title-only halfway\nstate, and no follow-up `setBody` call is needed to finish a create\n(verb contract: the atomic-unit rule).",
+            "type": "string"
+          },
+          "title": {
+            "description": "The topic's title, trimmed before it is stored. Must be non-empty.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "agentName"
+        ],
+        "type": "object"
+      },
+      "BackfillNamesEvent": {
+        "properties": {
+          "agentName": {
+            "description": "The agent running the backfill, checked as `addTopic` checks it.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "agentName"
+        ],
+        "type": "object"
+      },
+      "MentionableRow": {
+        "properties": {
+          "$NAME": {
+            "type": "string"
+          },
+          "piece": {
+            "type": "unknown"
+          },
+          "shortName": {
+            "default": "",
+            "type": "string"
+          },
+          "title": {
+            "default": "",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "shortName",
+          "piece",
+          "$NAME"
+        ],
+        "type": "object"
+      },
+      "NamesMap": {
+        "additionalProperties": {
+          "type": "unknown"
+        },
+        "properties": {},
+        "type": "object"
+      },
+      "NamesTableRow": {
+        "properties": {
+          "member": {
+            "description": "The member. `unknown` because it is written as a reference and only ever\ncompared; anything wider would read the member back whole.",
+            "type": "unknown"
+          },
+          "name": {
+            "description": "The member's name.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "member",
+          "name"
+        ],
+        "type": "object"
+      },
+      "NamingDeclaration": {
+        "properties": {
+          "compact": {
+            "description": "Whether the collection offers the compact spelling that joins its name to\na member's with a hyphen. Only a collection whose member names cannot\ncontain a hyphen may say so.",
+            "type": "boolean"
+          },
+          "name": {
+            "description": "The collection's own name, which a binding uses to reach it. Absent when\nthe collection makes no claim about what it is bound as.",
+            "type": "string"
+          },
+          "policy": {
+            "$ref": "#/$defs/NamingPolicy",
+            "description": "The policy the names are held to."
+          }
+        },
+        "required": [
+          "policy",
+          "compact"
+        ],
+        "type": "object"
+      },
+      "NamingPolicy": {
+        "properties": {
+          "allocator": {
+            "description": "What a name is made of: a monotonic sequence, a random code, a string a\nperson chose, or a derivation from the member's own content.",
+            "enum": [
+              "sequence",
+              "random",
+              "human",
+              "derived"
+            ]
+          },
+          "permanent": {
+            "description": "Whether a name, once assigned, is never retired or reassigned.",
+            "type": "boolean"
+          },
+          "reuse": {
+            "description": "Whether a retired name may be given to another member.",
+            "type": "boolean"
+          },
+          "unique": {
+            "description": "Whether a name is unique across the collection's whole history, or only\namong its current members.",
+            "enum": [
+              "history",
+              "current"
+            ]
+          }
+        },
+        "required": [
+          "unique",
+          "permanent",
+          "reuse",
+          "allocator"
+        ],
+        "type": "object"
+      },
+      "TopicAuthor": {
+        "properties": {
+          "avatar": {
+            "type": "string"
+          },
+          "kind": {
+            "description": "Open for the same reason `TopicLinkKind` is: this is provided data, so a\nclosed set here could never gain `\"service\"` or whatever acts next.\nWell-known values are `\"person\"` and `\"agent\"`, the latter marking an\nagent acting with its human user's key.",
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "name"
+        ],
+        "type": "object"
+      },
+      "TopicCrossrefRow": {
+        "properties": {
+          "mentionedBy": {
+            "items": {
+              "type": "unknown"
+            },
+            "type": "array"
+          },
+          "topic": {
+            "description": "The topic this row is about. `unknown` because it is written as a\nreference and only ever compared — `equals` takes the raw link. Anything\nwider retrieves the piece instead of pointing at it: declared `object`,\nthis field reads back as the whole expanded topic, `$UI` tree included.",
+            "type": "unknown"
+          }
+        },
+        "required": [
+          "topic",
+          "mentionedBy"
+        ],
+        "type": "object"
+      },
+      "TopicDemand": {
+        "properties": {
+          "$NAME": {
+            "default": "",
+            "description": "The display name, which the board's mention index copies into each\ntopic's row — the label every `@`-mention completion carries. The index\nlift states the same three-string demand for itself; this entry is the\nboard-level record of it.",
+            "type": [
+              "string",
+              "undefined"
+            ]
+          },
+          "body": {
+            "default": "",
+            "type": "string"
+          },
+          "commentCount": {
+            "default": 0,
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "createdAt": {
+            "description": "When the topic was filed (epoch milliseconds), stamped at create.",
+            "type": "number"
+          },
+          "createdBy": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/TopicAuthor"
+              },
+              {
+                "type": "undefined"
+              }
+            ],
+            "default": {
+              "kind": "person",
+              "name": ""
+            }
+          },
+          "lastActivityAt": {
+            "default": 0,
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "mentions": {
+            "default": [],
+            "items": {
+              "type": "unknown"
+            },
+            "type": "array"
+          },
+          "shortName": {
+            "description": "The board's name for the topic, as the topic reads it out of the board's\nnames table. The card renders it as a badge and the mention index copies\nit into the topic's universe row, so `#42` matches without expanding a\ntopic.\n\nOPTIONAL rather than defaulted, and the spelling is what keeps this demand\napplicable over a board deployed before the namespace: a defaulted\nproperty moves the demand's defaults below an array constraint the\ncompatibility proof cannot show stable under default insertion, while an\noptional one simply tolerates a topic that publishes none. A topic whose\nlookup has produced no value — one filed a moment ago, or one from before\nthe board numbered anything — is absent here rather than blank, and every\nconsumer treats the two the same.",
+            "tags": [
+              "42"
+            ],
+            "type": "string"
+          },
+          "title": {
+            "default": "",
+            "description": "The topic's title. Defaulted rather than required, like every other\nfield a board card renders: the card list is a mapped sub-pattern, so\nthis type reaches a piece holding topics written before the field\nexisted as the argument schema its update is checked against, and a\nrequired property those topics lack refuses that update outright.\n`deno task pattern-vintage` is what catches it, by replaying a real\ndeployed board.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "body",
+          "mentions",
+          "$NAME",
+          "title",
+          "createdAt",
+          "commentCount",
+          "lastActivityAt"
+        ],
+        "type": "object"
+      },
+      "TopicIndexRow": {
+        "properties": {
+          "commentCount": {
+            "default": 0,
+            "description": "Coalesced to 0 for a cold or older topic whose derived path is absent,\nso the row itself never carries the mixed-version undefined.",
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "createdAt": {
+            "type": "number"
+          },
+          "createdBy": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/TopicAuthor"
+              },
+              {
+                "type": "undefined"
+              }
+            ],
+            "default": {
+              "kind": "person",
+              "name": ""
+            },
+            "description": "Who filed the topic. A record without structured authorship materializes\nthe inert `{ kind: \"person\", name: \"\" }` default, which\n`topicAuthorLabel()` renders as `someone`."
+          },
+          "lastActivityAt": {
+            "default": 0,
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "shortName": {
+            "description": "The board's name for the topic. Optional rather than defaulted, unlike\nthe two above, for the reason `TopicDemand.shortName` states: a default\nhere is what makes the row demand inapplicable over a deployed board.",
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "createdAt",
+          "commentCount",
+          "lastActivityAt"
+        ],
+        "type": "object"
+      }
+    },
+    "description": "Topics — a tracker over #topic pieces: durable units of shared attention\n(CT-1878). Deliberately minimal: no statuses, labels, or assignees; topics\nsort by last activity. Replaces Linear / GitHub issues / loose process docs\nfor the team; PR workflows stay in GitHub and arrive here as links.\n\nHeadless use: survey the whole board with one bounded read of `index` — a\nrow is its Topic, so select the row's own address alongside `title` and use\nthat canonical address as the piece for the Topic's reads and verbs.\nFile with `addTopic`, title and optional initial body in one call, then work\non the Topic directly: the body is its living document, the thread its\nappend-only deliberation. Sign every authored-content mutation with\n`agentName`; Fabric records the human principal behind the key, and the name\nsays which agent acted under it. Reference-only `mention` and `unmention`\ncalls carry no content signature.",
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "addTopic": {
+        "$ref": "#/$defs/AddTopicEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "File a topic. The atomic unit takes the initial body with the title, so\nno reader observes a title-only halfway state and no follow-up `setBody`\nfinishes a create. Returns the created topic as its survey row — the\nreference plus the write-time facts the pattern resolved."
+      },
+      "backfillNames": {
+        "$ref": "#/$defs/BackfillNamesEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Name every unnamed member in filing order. Idempotent. A member filed\npast `addTopic` also needs a one-time link-bind of `namesTable` onto it\nbefore its row and its universe entry show the name, the same operator\nstep `mentionable` states for itself."
+      },
+      "crossrefs": {
+        "default": [],
+        "description": "The board's mention pivot, one row per topic: the topic, and the topics\nthat mention it. Published so a topic composed outside `addTopic` can be\nwired to the same table the board's own children read — the graph is\nderived once, here, and never per topic.",
+        "items": {
+          "$ref": "#/$defs/TopicCrossrefRow"
+        },
+        "type": "array"
+      },
+      "index": {
+        "default": [],
+        "description": "The full-board survey surface: one bounded row per topic, carrying the\nscalars a survey reads. A row IS its topic, so a row's own address is the\ntopic's — `--select index[].@` reads it, and an index into this array is\nnot a stable address.",
+        "items": {
+          "$ref": "#/$defs/TopicIndexRow"
+        },
+        "type": "array"
+      },
+      "mentionable": {
+        "default": [],
+        "description": "The board's mention universe, under the name the topic pattern's editor\nautocompletes over — what `addTopic` wires into each child. One derived\ndocument of copies, each holding its topic as an unread reference and\ncarrying the board's name for it, rather than the topics themselves, so a\nreader of the universe expands no topic and `#42` finds a member without\nexpanding one; see `MentionableRow` in\n`../collection-naming/mentionable.ts`.",
+        "items": {
+          "$ref": "#/$defs/MentionableRow"
+        },
+        "tags": [
+          "42"
+        ],
+        "type": "array"
+      },
+      "names": {
+        "$ref": "#/$defs/NamesMap",
+        "default": {},
+        "description": "The namespace itself: each name to the topic it names. A slug pointing\nhere is what makes a member addressable as `<collection>/<name>`.\nPublished under the default its input carries."
+      },
+      "namesTable": {
+        "default": [],
+        "description": "The names table, one row per named member, which every topic the board\ncreates reads its own name from. Published so a topic composed outside\n`addTopic` can be wired to the same table.",
+        "items": {
+          "$ref": "#/$defs/NamesTableRow"
+        },
+        "type": "array"
+      },
+      "naming": {
+        "$ref": "#/$defs/NamingDeclaration",
+        "description": "What the board declares about its names, for a consumer deciding whether\na name may be held rather than an identity."
+      },
+      "newTitle": {
+        "description": "Session-local draft for the footer composer (exposed for embedding and\nheadless driving, like the chat exemplar's drafts).",
+        "type": "string"
+      },
+      "submitTopic": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "Submit the footer composer as the current viewer's canonical Profile.",
+        "tier": "wrapper"
+      },
+      "topicCount": {
+        "description": "How many topics the board holds, nulls included.",
+        "type": "number"
+      },
+      "topics": {
+        "description": "The board's topics, in filing order, through the shape the board demands\nof them: the display scalars and the mention universe, and no verbs. A\ncaller that means to mutate a topic addresses the topic itself, where its\nown schema governs. Survey through `index` instead; read this when you\nalready know which topic you are expanding.",
+        "items": {
+          "$ref": "#/$defs/TopicDemand"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "topics",
+      "mentionable",
+      "names",
+      "namesTable",
+      "naming",
+      "topicCount",
+      "crossrefs",
+      "index",
+      "addTopic",
+      "backfillNames",
+      "submitTopic",
+      "$NAME",
+      "$UI"
+    ],
+    "tags": [
+      "topic"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/topics/topic.tsx/20260905T021503Z-Y-lXQUSup41JBSeM.json
+++ b/packages/patterns/baselines/topics/topic.tsx/20260905T021503Z-Y-lXQUSup41JBSeM.json
@@ -1,0 +1,1037 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "NamesTableRow": {
+        "properties": {
+          "member": {
+            "description": "The member. `unknown` because it is written as a reference and only ever\ncompared; anything wider would read the member back whole.",
+            "type": "unknown"
+          },
+          "name": {
+            "description": "The member's name.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "member",
+          "name"
+        ],
+        "type": "object"
+      },
+      "TopicAuthor": {
+        "properties": {
+          "avatar": {
+            "type": "string"
+          },
+          "kind": {
+            "description": "Open for the same reason `TopicLinkKind` is: this is provided data, so a\nclosed set here could never gain `\"service\"` or whatever acts next.\nWell-known values are `\"person\"` and `\"agent\"`, the latter marking an\nagent acting with its human user's key.",
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "name"
+        ],
+        "type": "object"
+      },
+      "TopicComment": {
+        "properties": {
+          "author": {
+            "$ref": "#/$defs/TopicAuthor",
+            "description": "Snapshot taken at write time (profile enrichment comes later; never gate\nauthorship on a profile wish — CT-1879). Comments carry no minted id:\narray elements have stable entity identity; future editing addresses\nelements by reference (`equals()`), not by a synthetic key.\n\nOptional because durable Topics may contain a comment without structured\nauthorship. Current `addComment` calls require `agentName` and always write\nthis snapshot."
+          },
+          "body": {
+            "default": "",
+            "type": "string"
+          },
+          "editedAt": {
+            "description": "When the body was last revised, absent on a comment never edited. The\noriginal `sentAt` and `author` are left alone: an edit changes what was\nsaid, not who said it or when the thread reached this point.",
+            "type": "number"
+          },
+          "removedAt": {
+            "description": "Set when the comment was retracted, and the retraction is the whole of\nit — the record stays, carrying what it always said. A reader hides it;\n`commentCount` stops counting it; `lastActivityOf` keeps reading its\n`sentAt`, which is what stops a retraction moving a topic backwards in\nthe board's ordering.",
+            "type": "number"
+          },
+          "removedBy": {
+            "$ref": "#/$defs/TopicAuthor"
+          },
+          "sentAt": {
+            "default": 0,
+            "type": "number"
+          }
+        },
+        "required": [
+          "body",
+          "sentAt"
+        ],
+        "type": "object"
+      },
+      "TopicCrossrefRow": {
+        "properties": {
+          "mentionedBy": {
+            "items": {
+              "type": "unknown"
+            },
+            "type": "array"
+          },
+          "topic": {
+            "description": "The topic this row is about. `unknown` because it is written as a\nreference and only ever compared — `equals` takes the raw link. Anything\nwider retrieves the piece instead of pointing at it: declared `object`,\nthis field reads back as the whole expanded topic, `$UI` tree included.",
+            "type": "unknown"
+          }
+        },
+        "required": [
+          "topic",
+          "mentionedBy"
+        ],
+        "type": "object"
+      },
+      "TopicLink": {
+        "properties": {
+          "addedAt": {
+            "type": "number"
+          },
+          "addedBy": {
+            "$ref": "#/$defs/TopicAuthor"
+          },
+          "kind": {
+            "default": "web",
+            "type": "string"
+          },
+          "label": {
+            "default": "",
+            "type": "string"
+          },
+          "removedAt": {
+            "description": "As on a comment, and with one consequence of its own: a retracted link\nstops resolving into `mentions`, so the reference it contributed goes\nwith it rather than outliving the link that made it.",
+            "type": "number"
+          },
+          "removedBy": {
+            "$ref": "#/$defs/TopicAuthor"
+          },
+          "url": {
+            "default": "",
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "url",
+          "label"
+        ],
+        "type": "object"
+      },
+      "TopicMentionRef": {
+        "properties": {
+          "destination": {
+            "type": "unknown"
+          },
+          "modifiedTitle": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "destination",
+          "modifiedTitle"
+        ],
+        "type": "object"
+      },
+      "TopicMentionRefMap": {
+        "additionalProperties": {
+          "$ref": "#/$defs/TopicMentionRef"
+        },
+        "properties": {},
+        "type": "object"
+      },
+      "TopicMentionable": {
+        "properties": {
+          "$NAME": {
+            "default": "",
+            "type": [
+              "string",
+              "undefined"
+            ]
+          },
+          "shortName": {
+            "type": "string"
+          },
+          "title": {
+            "default": "",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "$NAME"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "boardCrossrefs": {
+        "asCell": [
+          "readonly"
+        ],
+        "default": [],
+        "description": "The board's mention pivot, one row per topic. A topic reads its own row\nout of it and nothing else; see `backlinksOf`. Absent, a topic simply shows\nno inbound references.\n\nReadable, not writable: the pivot is the board's derivation, and a topic\nhas no business writing into it. Declaring the narrower cell says so where\na reader can see it, rather than leaving it to convention.",
+        "items": {
+          "$ref": "#/$defs/TopicCrossrefRow"
+        },
+        "type": "array"
+      },
+      "boardNames": {
+        "asCell": [
+          "readonly"
+        ],
+        "default": [],
+        "description": "The board's names table, one row per named topic. The topic reads its own\nrow out of it and nothing else; absent, the topic shows no number.\n\nReadable, not writable, for the reason `boardCrossrefs` states: the table\nis the board's derivation, and a topic has no business writing into it.\nWired at creation by the board's create, and rewired onto a topic filed\nbefore the namespace as a one-time link-bind — the same operator step\n`mentionable` states for itself.",
+        "items": {
+          "$ref": "#/$defs/NamesTableRow"
+        },
+        "type": "array"
+      },
+      "body": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "description": "The topic's living document: durable conclusions get folded up into the\nbody; the comment thread below holds the deliberation.",
+        "type": "string"
+      },
+      "bodyUpdatedAt": {
+        "asCell": [
+          "cell"
+        ],
+        "default": 0,
+        "type": "number"
+      },
+      "bodyUpdatedBy": {
+        "$ref": "#/$defs/TopicAuthor",
+        "asCell": [
+          "cell"
+        ],
+        "default": {
+          "kind": "person",
+          "name": ""
+        }
+      },
+      "comments": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/TopicComment"
+        },
+        "type": "array"
+      },
+      "createdAt": {
+        "default": 0,
+        "type": "number"
+      },
+      "createdBy": {
+        "$ref": "#/$defs/TopicAuthor"
+      },
+      "links": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/TopicLink"
+        },
+        "type": "array"
+      },
+      "mentionable": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "description": "The board's mention universe — what the body editor autocompletes\nover. Wired at creation to the board's mention index (one derived\ndocument of copies; `MentionableRow` in\n`../collection-naming/mentionable.ts`), and rewired onto a piece from\nbefore the index as a one-time link-bind. A plain list of the pieces\nthemselves also satisfies the demand — a board not yet rewired, or a\ncomposer without a board. Absent, the editor simply offers no\ncompletions.",
+        "items": {
+          "$ref": "#/$defs/TopicMentionable"
+        },
+        "type": "array"
+      },
+      "mentioned": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "description": "Pieces this topic references outside its prose — what `mention` records.\n\nIts own list rather than an entry in `references`, because that map belongs\nto the body editor: the editor mints its keys, rewrites its labels, and\ncollects entries whose token has left the document. A verb writing there\nwould be writing into somebody else's bookkeeping. Here there is nothing to\nkey by, because there is nothing to point back at from the prose — a\nreference outside a sentence is just a link in a list.",
+        "items": {
+          "type": "unknown"
+        },
+        "type": "array"
+      },
+      "references": {
+        "$ref": "#/$defs/TopicMentionRefMap",
+        "asCell": [
+          "cell"
+        ],
+        "default": {},
+        "description": "Where this topic's `[Label][key]` mentions point, keyed by the token that\nappears in the body. The editor owns the contents; this pattern owns the\ncell, which is what makes a mention durable and — because each entry holds\nthe destination as a REFERENCE — what makes the reference graph a question\nabout cell identity rather than about text.\n\nThe default has to match the one `TopicOutput` publishes. A map published\nunder a different default than its input carries cannot be materialized."
+      },
+      "title": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "type": "string"
+      },
+      "titleUpdatedAt": {
+        "asCell": [
+          "cell"
+        ],
+        "default": 0,
+        "type": "number"
+      },
+      "titleUpdatedBy": {
+        "$ref": "#/$defs/TopicAuthor",
+        "asCell": [
+          "cell"
+        ],
+        "default": {
+          "kind": "person",
+          "name": ""
+        },
+        "description": "Attribution of the last rename, stamped by `setTitle` — the same pair\nthe body keeps, because a title is the other editable scalar."
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "topics/topic.tsx",
+  "resultSchema": {
+    "$defs": {
+      "AddCommentEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Fabric authenticates the write with that key; this says\nwhich agent acted under it.\n\nRequired so every authored-content call carries structured attribution.\nAuthenticated execution provenance can supersede the field by relaxing it\nto optional without breaking existing callers.",
+            "type": "string"
+          },
+          "body": {
+            "description": "The comment text, appended verbatim after trimming. Must be non-empty:\nan empty body rejects rather than recording a blank thread entry.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "body",
+          "agentName"
+        ],
+        "type": "object"
+      },
+      "AddLinkEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Fabric authenticates the write with that key; this says\nwhich agent acted under it.\n\nRequired so every authored-content call carries structured attribution.\nAuthenticated execution provenance can supersede the field by relaxing it\nto optional without breaking existing callers.",
+            "type": "string"
+          },
+          "kind": {
+            "description": "What the link points at — a rendering hint, not a behavior switch.\nOptional because the handler defaults it to `\"web\"`, and a caller should\nnot be made to supply a field the verb never needed.",
+            "type": "string"
+          },
+          "label": {
+            "description": "Display label. Optional, and a blank one falls back to the URL.",
+            "type": "string"
+          },
+          "url": {
+            "description": "The link target. Must be http(s): anything else rejects, because a\nuser-supplied scheme on a shared surface is script execution in every\nviewer's session.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "url",
+          "agentName"
+        ],
+        "type": "object"
+      },
+      "EditCommentEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Fabric authenticates the write with that key; this says\nwhich agent acted under it.\n\nRequired so every authored-content call carries structured attribution.\nAuthenticated execution provenance can supersede the field by relaxing it\nto optional without breaking existing callers.",
+            "type": "string"
+          },
+          "body": {
+            "description": "The complete replacement text, trimmed. Must be non-empty: emptying a\ncomment is a retraction, and `removeComment` is what says so.",
+            "type": "string"
+          },
+          "comment": {
+            "description": "The comment to revise, named and checked as in `RemoveCommentEvent`,\nand additionally naming `body`, which this verb writes.",
+            "properties": {
+              "body": {
+                "default": "",
+                "type": "string"
+              },
+              "editedAt": {
+                "type": "number"
+              },
+              "removedAt": {
+                "type": "number"
+              },
+              "sentAt": {
+                "default": 0,
+                "type": "number"
+              }
+            },
+            "required": [
+              "sentAt",
+              "body"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "comment",
+          "body",
+          "agentName"
+        ],
+        "type": "object"
+      },
+      "MentionEvent": {
+        "properties": {
+          "topic": {
+            "description": "The piece to reference — the piece itself, not an address. Identity here\nis the cell, so this is what a caller passes and what gets stored.\n\nDeclared through the one field every Topic has rather than `unknown`. The\ncell declaration marks this as a reference position, so the CLI resolves a\ncanonical `/of:...` value from an inline JSON event into the live piece\nlink. It also bounds the validation read: `topic.get()` is `undefined` for\na value that is not a reference and an object for any piece, and `mention`\nchecks it before storing anything.\n\n`title` is also the most this can safely name: this schema reaches every\ntopic in `mentionable`, so a property without a default would be demanded\nof topics written before it existed and refuse their update. `title`\ncarries one, and that default does double duty — it is also why the check\nadmits a piece that is not a topic at all, which reads back `{ title: \"\" }`\nrather than `undefined`. `deno task pattern-vintage` proves the update side\nby replaying a real board.\n\nNothing reads THROUGH it beyond that one field — the value is stored and\ncompared.",
+            "properties": {
+              "title": {
+                "default": "",
+                "type": "string"
+              }
+            },
+            "required": [
+              "title"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "RemoveCommentEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Fabric authenticates the write with that key; this says\nwhich agent acted under it.\n\nRequired so every authored-content call carries structured attribution.\nAuthenticated execution provenance can supersede the field by relaxing it\nto optional without breaking existing callers.",
+            "type": "string"
+          },
+          "comment": {
+            "description": "The comment to retract — the stored element, not a copy of its fields.\nNames only what this verb reads and writes, for the reason\n`MentionEvent.topic` names only `title`: the declaration bounds the\nvalidation read, and a payload that is not a reference reads back\n`undefined` and is refused rather than silently matching nothing.\n`sentAt` carries a default, so it is what makes a real element read back\nas an object; the stamp fields are optional, which is what lets this\nschema reach comments written before they existed.",
+            "properties": {
+              "removedAt": {
+                "type": "number"
+              },
+              "removedBy": {
+                "$ref": "#/$defs/TopicAuthor"
+              },
+              "sentAt": {
+                "default": 0,
+                "type": "number"
+              }
+            },
+            "required": [
+              "sentAt"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "comment",
+          "agentName"
+        ],
+        "type": "object"
+      },
+      "RemoveLinkEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Fabric authenticates the write with that key; this says\nwhich agent acted under it.\n\nRequired so every authored-content call carries structured attribution.\nAuthenticated execution provenance can supersede the field by relaxing it\nto optional without breaking existing callers.",
+            "type": "string"
+          },
+          "link": {
+            "description": "The stored link element. What a reader passes, from the row it renders.\nNamed as in `RemoveCommentEvent`, with `url` playing the defaulted-field\nrole `sentAt` plays there.",
+            "properties": {
+              "removedAt": {
+                "type": "number"
+              },
+              "removedBy": {
+                "$ref": "#/$defs/TopicAuthor"
+              },
+              "url": {
+                "default": "",
+                "type": "string"
+              }
+            },
+            "required": [
+              "url"
+            ],
+            "type": "object"
+          },
+          "url": {
+            "description": "The link's URL, for a caller that cannot pass a reference. Retracts the\nmost recently added link still present with this URL, so retracting twice\nretracts two rather than re-stamping one.\n\nSequentially. Two concurrent retractions naming the same URL both resolve\nthe same newest-present element and merge into one stamped record, so\nthey retract one link between them rather than two. Naming the link by\nreference is what makes a caller's target unambiguous under concurrency;\nthis spelling trades that for being reachable at all.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "agentName"
+        ],
+        "type": "object"
+      },
+      "SetBodyEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Fabric authenticates the write with that key; this says\nwhich agent acted under it.\n\nRequired so every authored-content call carries structured attribution.\nAuthenticated execution provenance can supersede the field by relaxing it\nto optional without breaking existing callers.",
+            "type": "string"
+          },
+          "body": {
+            "description": "The complete replacement body, persisted verbatim — no trimming, so\nwhitespace-sensitive Markdown survives. An empty body is legal: clearing\na living document is an edit, not an error.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "body",
+          "agentName"
+        ],
+        "type": "object"
+      },
+      "SetTitleEvent": {
+        "properties": {
+          "agentName": {
+            "description": "The agent making this mutation, stored as structured attribution beside\nthe write time. Required so every successful rename is attributed.",
+            "type": "string"
+          },
+          "title": {
+            "description": "The new title, trimmed before it is stored. Must be non-empty.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "agentName"
+        ],
+        "type": "object"
+      },
+      "TopicAuthor": {
+        "properties": {
+          "avatar": {
+            "type": "string"
+          },
+          "kind": {
+            "description": "Open for the same reason `TopicLinkKind` is: this is provided data, so a\nclosed set here could never gain `\"service\"` or whatever acts next.\nWell-known values are `\"person\"` and `\"agent\"`, the latter marking an\nagent acting with its human user's key.",
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "name"
+        ],
+        "type": "object"
+      },
+      "TopicComment": {
+        "properties": {
+          "author": {
+            "$ref": "#/$defs/TopicAuthor",
+            "description": "Snapshot taken at write time (profile enrichment comes later; never gate\nauthorship on a profile wish — CT-1879). Comments carry no minted id:\narray elements have stable entity identity; future editing addresses\nelements by reference (`equals()`), not by a synthetic key.\n\nOptional because durable Topics may contain a comment without structured\nauthorship. Current `addComment` calls require `agentName` and always write\nthis snapshot."
+          },
+          "body": {
+            "default": "",
+            "type": "string"
+          },
+          "editedAt": {
+            "description": "When the body was last revised, absent on a comment never edited. The\noriginal `sentAt` and `author` are left alone: an edit changes what was\nsaid, not who said it or when the thread reached this point.",
+            "type": "number"
+          },
+          "removedAt": {
+            "description": "Set when the comment was retracted, and the retraction is the whole of\nit — the record stays, carrying what it always said. A reader hides it;\n`commentCount` stops counting it; `lastActivityOf` keeps reading its\n`sentAt`, which is what stops a retraction moving a topic backwards in\nthe board's ordering.",
+            "type": "number"
+          },
+          "removedBy": {
+            "$ref": "#/$defs/TopicAuthor"
+          },
+          "sentAt": {
+            "default": 0,
+            "type": "number"
+          }
+        },
+        "required": [
+          "body",
+          "sentAt"
+        ],
+        "type": "object"
+      },
+      "TopicLink": {
+        "properties": {
+          "addedAt": {
+            "type": "number"
+          },
+          "addedBy": {
+            "$ref": "#/$defs/TopicAuthor"
+          },
+          "kind": {
+            "default": "web",
+            "type": "string"
+          },
+          "label": {
+            "default": "",
+            "type": "string"
+          },
+          "removedAt": {
+            "description": "As on a comment, and with one consequence of its own: a retracted link\nstops resolving into `mentions`, so the reference it contributed goes\nwith it rather than outliving the link that made it.",
+            "type": "number"
+          },
+          "removedBy": {
+            "$ref": "#/$defs/TopicAuthor"
+          },
+          "url": {
+            "default": "",
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "url",
+          "label"
+        ],
+        "type": "object"
+      },
+      "TopicMentionRef": {
+        "properties": {
+          "destination": {
+            "type": "unknown"
+          },
+          "modifiedTitle": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "destination",
+          "modifiedTitle"
+        ],
+        "type": "object"
+      },
+      "TopicMentionRefMap": {
+        "additionalProperties": {
+          "$ref": "#/$defs/TopicMentionRef"
+        },
+        "properties": {},
+        "type": "object"
+      },
+      "TopicSummary": {
+        "properties": {
+          "commentCount": {
+            "default": 0,
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "createdAt": {
+            "description": "When the topic was filed (epoch milliseconds), stamped at create.",
+            "type": "number"
+          },
+          "createdBy": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/TopicAuthor"
+              },
+              {
+                "type": "undefined"
+              }
+            ],
+            "default": {
+              "kind": "person",
+              "name": ""
+            }
+          },
+          "lastActivityAt": {
+            "default": 0,
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "title": {
+            "default": "",
+            "description": "The topic's title. Defaulted rather than required, like every other\nfield a board card renders: the card list is a mapped sub-pattern, so\nthis type reaches a piece holding topics written before the field\nexisted as the argument schema its update is checked against, and a\nrequired property those topics lack refuses that update outright.\n`deno task pattern-vintage` is what catches it, by replaying a real\ndeployed board.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "createdAt",
+          "commentCount",
+          "lastActivityAt"
+        ],
+        "type": "object"
+      },
+      "UnmentionEvent": {
+        "properties": {
+          "topic": {
+            "description": "Declared and checked exactly as `MentionEvent.topic` is, and for the same\nreason: a payload that is not a reference matches no stored entry, so\nwithout the check it would remove nothing and report success.",
+            "properties": {
+              "title": {
+                "default": "",
+                "type": "string"
+              }
+            },
+            "required": [
+              "title"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      }
+    },
+    "description": "A #topic — one durable unit of shared attention: a title, a living body\ndocument, a flat chronological comment thread, typed links out to other\ncore objects (PRs, agent sessions, web pages), and the references it makes\nto sibling pieces.\n\nDurable conclusions get folded up into the body — revise it whole with\n`setBody`; the thread holds the deliberation as point-in-time `addComment`\nrecords. The thread only ever grows: `removeComment` and `removeLink` stamp\na record as retracted and leave it where it is, and `editComment` revises a\nbody in place, so what a reader shows is the array filtered rather than the\narray itself. Sign every authored-content mutation with `agentName`:\nFabric records the human principal behind the key; the name says which\nagent acted under it. Reference-only `mention` and `unmention` calls carry\nno content signature. The session-draft cells and `submit*` streams below\nbelong to the rendered page, not the headless contract — they read state\nonly this session holds.",
+    "properties": {
+      "$NAME": {
+        "default": "",
+        "description": "The topic's display name. Like the other derived display fields, a cold\nretained topic may not have produced this path yet; its persisted title\nremains authoritative until it does.",
+        "type": [
+          "string",
+          "undefined"
+        ]
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "addComment": {
+        "$ref": "#/$defs/AddCommentEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Append to the thread — a point-in-time record of progress or\ndeliberation; durable conclusions belong in the body. Returns the\ncomment as recorded, resolved author and `sentAt` included."
+      },
+      "addLink": {
+        "$ref": "#/$defs/AddLinkEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Attach a typed outbound link — a PR, an agent session, a web page.\nReturns the link as recorded, resolved `addedBy` and `addedAt`\nincluded. Appends merge and nothing dedupes: a repeated URL is two\nentries."
+      },
+      "body": {
+        "default": "",
+        "description": "The living document, verbatim Markdown. `setBody` replaces it whole.",
+        "type": "string"
+      },
+      "bodyDraft": {
+        "type": "string"
+      },
+      "bodyUpdatedAt": {
+        "type": [
+          "number",
+          "undefined"
+        ]
+      },
+      "bodyUpdatedBy": {
+        "anyOf": [
+          {
+            "type": "undefined"
+          },
+          {
+            "$ref": "#/$defs/TopicAuthor"
+          }
+        ]
+      },
+      "cancelEditBody": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI wrapper: close the body editor; the session drafts are the discard.",
+        "tier": "wrapper"
+      },
+      "cancelEditTitle": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI wrapper: close the rename editor; the session draft is the discard.",
+        "tier": "wrapper"
+      },
+      "commentCount": {
+        "default": 0,
+        "type": [
+          "number",
+          "undefined"
+        ]
+      },
+      "commentDraft": {
+        "description": "Session-local composer/edit state. These controls belong to a direct Topic\ninstance, not the shared TopicPiece projection used by the tracker's list.",
+        "type": "string"
+      },
+      "comments": {
+        "description": "The thread, in arrival order, each record carrying its author snapshot\nand `sentAt`.\n\nMEMBERSHIP is append-only; a record is not. Nothing is ever removed from\nthis array — `removeComment` stamps `removedAt` and leaves the record in\nplace, and `editComment` revises a body and stamps `editedAt` — so a\nreader that wants the live thread filters on `removedAt` rather than\ntaking the array as it stands. `commentCount` is that filtered count.",
+        "items": {
+          "$ref": "#/$defs/TopicComment"
+        },
+        "type": "array"
+      },
+      "createdAt": {
+        "description": "When the topic was filed (epoch milliseconds), stamped at create.",
+        "type": "number"
+      },
+      "createdBy": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/TopicAuthor"
+          },
+          {
+            "type": "undefined"
+          }
+        ],
+        "default": {
+          "kind": "person",
+          "name": ""
+        }
+      },
+      "editComment": {
+        "$ref": "#/$defs/EditCommentEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Revise a comment's body in place, naming it by reference. Stamps\n`editedAt` and leaves `author` and `sentAt` as they were. Outside the\nprojection for the reason `removeComment` states."
+      },
+      "editingBody": {
+        "description": "Whether the body editor is open.\n\nA bare session-scoped value rather than a cell-wrapped one, and that\nspelling costs a capability worth knowing about before reaching for it: a\nverb cannot take a whole Topic as captured state while any required\nproperty is published this way. The piece does not materialize through the\nverb's state schema, so the argument arrives undefined and the runtime\ndeclines to run the verb at all — \"stream action argument is undefined\n(potential schema mismatch)\", logged rather than thrown, with the write\nsilently absent.\n\nNothing needs that today. A board names a member by writing the piece into\nits namespace, and every path that does so builds the piece inside the\nverb (`addTopic`, the browser composer) or writes a list POSITION rather\nthan a held piece (`backfillNames`). Cell-wrapping these two would buy the\ncapability at the cost of a `scope changed` break on every deployed Topic,\nso it waits for a verb that needs it.",
+        "scope": "session",
+        "type": "boolean"
+      },
+      "editingTitle": {
+        "description": "Whether the rename editor is open. Bare for the reason `editingBody`\nstates, and the constraint is per property: cell-wrapping one and not the\nother buys nothing.",
+        "scope": "session",
+        "type": "boolean"
+      },
+      "lastActivityAt": {
+        "default": 0,
+        "type": [
+          "number",
+          "undefined"
+        ]
+      },
+      "linkKindDraft": {
+        "type": "string"
+      },
+      "linkLabelDraft": {
+        "type": "string"
+      },
+      "linkUrlDraft": {
+        "type": "string"
+      },
+      "links": {
+        "description": "Typed outbound links, in arrival order, each carrying its author snapshot\nand `addedAt`. Append-only in membership on the same terms as `comments`:\n`removeLink` stamps rather than removes, and a stamped link additionally\nstops resolving into `mentions`.",
+        "items": {
+          "$ref": "#/$defs/TopicLink"
+        },
+        "type": "array"
+      },
+      "mention": {
+        "$ref": "#/$defs/MentionEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Reference another piece from this topic — the payload is the piece\nitself, stored as a reference. Takes no `agentName` and returns no value;\nFabric retains the authenticated principal behind the edge."
+      },
+      "mentioned": {
+        "default": [],
+        "description": "Pieces referenced outside the prose, recorded by `mention`.",
+        "items": {
+          "type": "unknown"
+        },
+        "type": "array"
+      },
+      "mentions": {
+        "default": [],
+        "description": "Every piece this topic's prose and links point at, as references.\n\nThe board's pivot is declared over this and nothing else, so what one topic\ncosts a full-board scan is exactly this list of identities. Declared\n`unknown[]` because these are references, and comparing them never reads\nwhat is behind them.\n\nThe cell annotation that makes them comparable belongs to the READER, not\nhere: the pivot declares its own view of this list as\n`TopicMentionSource.mentions: ComparableCell<unknown>[]`, and that is what\nmakes its graph settle rather than depend on load order. A published\n`unknown[]` is what each reader annotates for itself.\n\nThe default stands alone: a declared default and `| undefined` collide,\nand the default is what a topic deployed before this path existed\nmaterializes against.",
+        "items": {
+          "type": "unknown"
+        },
+        "type": "array"
+      },
+      "referencedBy": {
+        "default": [],
+        "description": "The topics that mention this one, read out of the board's pivot.\n\nDeclared through `TopicSummary` rather than `TopicPiece`, and that is\nload-bearing rather than stingy: a topic whose backlinks were topics would\nbe a type that contains itself, and resolving one from a list would walk\nthe graph. The summary carries no reference of its own, so it terminates.\nA reader that wants more follows the link, which resolves whole.",
+        "items": {
+          "$ref": "#/$defs/TopicSummary"
+        },
+        "type": "array"
+      },
+      "references": {
+        "$ref": "#/$defs/TopicMentionRefMap",
+        "default": {},
+        "description": "Where this topic's `[Label][key]` mentions point. Durable content, like\n`links`. The body editor works on a session copy of this map, which a save\npublishes here whole, beside the prose whose tokens name its entries."
+      },
+      "referencesDraft": {
+        "$ref": "#/$defs/TopicMentionRefMap",
+        "description": "The body draft's mention map, staged so Cancel can discard it.\n\n`cf-code-editor` writes an entry the moment a mention is inserted and\ndrops one the moment its token leaves the document, neither of them\nwaiting for Save. Pointed at the durable map while `$value` holds a\nsession draft, those writes would outlive a discarded edit: a canceled\ninsertion would leave an edge no token names, and a canceled deletion\nwould strip the destination from a token the durable body still carries.\nThe editor's own ordering assumes its two bindings share a lifetime, so\nthis gives them one."
+      },
+      "removeComment": {
+        "$ref": "#/$defs/RemoveCommentEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Retract a comment, naming it by reference. The record is stamped rather\nthan deleted, so the thread keeps its evidence while a reader stops\nshowing it and `commentCount` stops counting it.\n\nHere rather than on `TopicPiece`, for the reason `setTitle` is: boards\nstore that projection, so it is a demand on every topic they already\nhold, and a required verb added to it would refuse every one deployed\nbefore the verb existed. A verb has no default to be rescued by, so there\nis no compatible way to demand a new one. Addressing the topic directly\nreaches all three of these."
+      },
+      "removeLink": {
+        "$ref": "#/$defs/RemoveLinkEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Retract a link, by reference or by `url`. Stamped like a comment, and a\nretracted link stops resolving into `mentions`. The url spelling exists\nbecause a link record carries no fid for a CLI caller to name. Outside\nthe projection for the reason `removeComment` states."
+      },
+      "saveBody": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI wrapper: publish the session body and mention-map drafts whole,\nattributed to the viewer's Profile — the contract verb is `setBody`.",
+        "tier": "wrapper"
+      },
+      "saveTitle": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI wrapper: save the session title draft under the viewer's Profile —\nthe contract verb is `setTitle`, and both land through the same core, so\na browser rename stamps the same attribution and moves the same activity\nclock.",
+        "tier": "wrapper"
+      },
+      "setBody": {
+        "$ref": "#/$defs/SetBodyEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Replace the living document whole — read it, revise it, write it back\ncomplete; the body is one value with whole-value conflict semantics.\nRequires `agentName` and returns the persisted body with its attribution."
+      },
+      "setTitle": {
+        "$ref": "#/$defs/SetTitleEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Rename the topic. Requires `agentName` and returns the persisted title\nwith its attribution. This direct-address verb stays outside the board's\nnarrow `TopicPiece` demand."
+      },
+      "shortName": {
+        "description": "The name the board calls this topic by, read out of the board's names\ntable by identity. The display name stays the title — this rides beside\nit, under the name a mention pill reads it by (`Mentionable.shortName` in\n`packages/ui/src/v2/core/mentionable.ts`), so a mention of this topic\nelsewhere gains the number as soon as the board names it.\n\nAbsent for a topic no board has named, or one wired to no board: the\nlookup produces nothing and the property is simply not there. Every\nconsumer treats that as no name — the badge renders nothing, a universe\nrow matches no `#42` query, and a mention pill shows no number\n(`_trackRefShortName` in\n`packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts` reads an\nabsent name exactly as it reads a blank one).\n\nOptional rather than defaulted, and the difference is the whole reason\nthis projection still applies over a deployed board: this is what a\nboard's stored list is validated against, and a defaulted property there\nmoves the demand's defaults below an array constraint the compatibility\nproof cannot show stable under default insertion.",
+        "tags": [
+          "42"
+        ],
+        "type": "string"
+      },
+      "startEditBody": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI wrapper: open the body editor, seeding the session drafts from the\ndurable body and mention map.",
+        "tier": "wrapper"
+      },
+      "startEditTitle": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI wrapper: open the rename editor, seeding the session draft from the\ndurable title.",
+        "tier": "wrapper"
+      },
+      "submitComment": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI wrapper: append the session comment draft under the viewer's\nProfile. Reads session-local state, so it is a silent no-op headless —\nthe contract verb is `addComment`.",
+        "tier": "wrapper"
+      },
+      "submitLink": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI wrapper: append the session link drafts under the viewer's Profile —\nthe contract verb is `addLink`.",
+        "tier": "wrapper"
+      },
+      "title": {
+        "default": "",
+        "description": "The topic's title. Defaulted rather than required, like every other\nfield a board card renders: the card list is a mapped sub-pattern, so\nthis type reaches a piece holding topics written before the field\nexisted as the argument schema its update is checked against, and a\nrequired property those topics lack refuses that update outright.\n`deno task pattern-vintage` is what catches it, by replaying a real\ndeployed board.",
+        "type": "string"
+      },
+      "titleDraft": {
+        "type": "string"
+      },
+      "titleUpdatedAt": {
+        "type": [
+          "number",
+          "undefined"
+        ]
+      },
+      "titleUpdatedBy": {
+        "anyOf": [
+          {
+            "type": "undefined"
+          },
+          {
+            "$ref": "#/$defs/TopicAuthor"
+          }
+        ],
+        "description": "Attribution of the last rename; unset until the first `setTitle`.\nBeside `setTitle` rather than on the projection, for the same reason."
+      },
+      "unmention": {
+        "$ref": "#/$defs/UnmentionEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Stop referencing a piece: removes every `mention`-made entry naming it.\nReferences made in the prose are retracted by editing the prose, not by\nthis. Takes no `agentName` and returns no value."
+      }
+    },
+    "required": [
+      "commentDraft",
+      "bodyDraft",
+      "editingBody",
+      "titleDraft",
+      "editingTitle",
+      "linkUrlDraft",
+      "linkLabelDraft",
+      "linkKindDraft",
+      "referencesDraft",
+      "setTitle",
+      "removeComment",
+      "editComment",
+      "removeLink",
+      "startEditTitle",
+      "saveTitle",
+      "cancelEditTitle",
+      "submitComment",
+      "startEditBody",
+      "saveBody",
+      "cancelEditBody",
+      "submitLink",
+      "$UI",
+      "body",
+      "comments",
+      "links",
+      "mentions",
+      "references",
+      "mentioned",
+      "referencedBy",
+      "addComment",
+      "addLink",
+      "setBody",
+      "mention",
+      "unmention",
+      "$NAME",
+      "title",
+      "createdAt",
+      "commentCount",
+      "lastActivityAt"
+    ],
+    "tags": [
+      "topic"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/collection-naming/README.md
+++ b/packages/patterns/collection-naming/README.md
@@ -1,7 +1,9 @@
 # Collection naming
 
 A library a collection pattern calls to give its members names of its own, and
-an exemplar collection that uses it. The design is
+an exemplar collection that uses it. The Topics board in
+[`../topics/`](../topics/README.md) is the collection it exists for and calls
+the same library. The design is
 [Naming in collections](../../../docs/specs/collection-naming.md); this
 directory is its first customer. Member names here are decimal strings, dense
 from `1`, so a member is cited as `<collection>/42`.
@@ -38,10 +40,10 @@ collection does with it:
   the exemplar: the stage that binds the board's namespace as a slug fills it,
   and that binding is what a resolver can then check the declaration against.
 
-Nothing in the library knows what kind of piece a member is. A member is a cell,
-compared by identity and never read through, which is what keeps every read here
-— the allocator surveying keys, the table over the map, a member finding its row
-— from expanding a member document.
+Nothing in `naming.ts` knows what kind of piece a member is. A member is a cell,
+compared by identity and never read through, which is what keeps every read
+there — the allocator surveying keys, the table over the map, a member finding
+its row — from expanding a member document.
 
 ### Declaring the namespace
 
@@ -63,6 +65,28 @@ A verb reads its binding through a schema that carries no default, so inside a
 verb the map is `undefined` until the first name is written. `NamesMapCell`
 declares that structurally, and the library's readers take an absent map as
 empty.
+
+## The mention universe: `mentionable.ts`
+
+The one derivation both this exemplar and the Topics board build their mention
+universe with. `mentionableIndex` reads three display strings off each member —
+its display name, its title, and its own `shortName` — and returns one document
+of `MentionableRow` copies, each carrying the member itself as an unread
+reference under the `piece` key;
+[the mentionable convention](../../../docs/common/conventions/mentionable.md) is
+what the editors consume it through. `mentionableRowsOf` is the per-member
+projection on its own, over any list of cells.
+
+Copies rather than the members are what bounds the read, and that is what
+separates a universe from an index: a survey index whose rows ARE the members
+costs nothing extra, because a survey reads those members anyway, while the
+universe is read by EVERY member's editor — wiring it to the members would
+multiply the collection by itself.
+
+It is a module of its own rather than part of `naming.ts` because it reads
+THROUGH a member, which is exactly what that module does not do; and it is one
+module rather than a copy per board because a board importing the other board's
+copy would carry that whole board into its own program.
 
 ## The exemplar: `board.tsx` and `item.tsx`
 
@@ -97,11 +121,8 @@ wired. A caller that needs to know which reads the namespace, where the answer
 is: `nameOf` over `namesTable` returns the name for either, and returns
 `undefined` only for the first.
 
-`mentionable` is the board's mention universe: one row per member carrying the
-display name, the title, the board's name for the member as `shortName`, and the
-member itself as an unread reference. Unlike `index`, whose rows ARE the items,
-these rows are copies: the universe is read by every item's editor, so wiring it
-to the items would multiply the board by itself. Every item the board creates is
+`mentionable` is the board's mention universe, derived through
+`mentionableIndex` from `mentionable.ts` above. Every item the board creates is
 wired to it, so an item's body editor completes `#42` over the board's own
 numbering. The query matches a row's copied `shortName`, taken off the member's
 own — the same property a member publishes for itself, and the one `index` shows
@@ -152,15 +173,20 @@ cf piece call --cell /of:<board> backfillNames --json '{"agentName":"Sol"}'
   universe and the name each of its rows carries, the item reading its own name,
   the bound on what a read of the namespace or the universe expands, a board
   given no namespace at all, and the rejections.
-- `topics-shape.test.tsx` — the rehearsal for the Topics board: a test-only
-  board whose members are the real `Topic` pattern, unmodified, wired through
-  the library the way the exemplar is. It proves the board side through the
-  names table and the reverse lookup; an unmodified Topic publishes no
-  `shortName`, so the item side is proven on the exemplar item.
+- `topics-shape.test.tsx` — a test-only board whose members are the real `Topic`
+  pattern, wired through the library the way the exemplar is. It holds the
+  library to a member pattern it does not own — allocation on create, the
+  backfill, the names table, and the reverse lookup, all over topics, through a
+  board that is not the Topics board.
 
 ## Topics
 
-The Topics board (`../topics/`) is the collection this library exists for. It
-adopts the library with the wiring the rehearsal board already carries, and its
-topic gains the item-side display the exemplar item proves, on the schedule in
-[the plan](../../../docs/plans/collection-naming-topics.md).
+The Topics board (`../topics/`) is the collection this library exists for, and
+it calls it: `addTopic` allocates in the same transaction as its append,
+`backfillNames` names what the board held before, each topic reads its own name
+out of `boardNames` and publishes it as `shortName`, and both boards derive
+their mention universe through `mentionable.ts`. What is still to come is in
+[the plan](../../../docs/plans/collection-naming-topics.md): the production
+backfill, which needs the one-time link-bind of `namesTable` onto every topic
+filed before the namespace, and the slug that binds the board's `names` cell as
+`top`.

--- a/packages/patterns/collection-naming/board.tsx
+++ b/packages/patterns/collection-naming/board.tsx
@@ -12,10 +12,8 @@
 import {
   action,
   Default,
-  lift,
   NAME,
   pattern,
-  type ReadonlyCell,
   Stream,
   UI,
   type VNode,
@@ -23,6 +21,7 @@ import {
 } from "commonfabric";
 
 import Item from "./item.tsx";
+import { mentionableIndex, type MentionableRow } from "./mentionable.ts";
 import {
   assignName,
   backfillNames,
@@ -183,9 +182,9 @@ export interface BoardOutput {
    * autocompletes over — what `addItem` wires into each item it creates. One
    * derived document of copies, each holding its item as an unread reference
    * and carrying the board's name for it, so `#42` finds a member without
-   * expanding one; see `ItemMentionableRow`.
+   * expanding one; see `MentionableRow` in `mentionable.ts`.
    */
-  mentionable: ItemMentionableRow[] | Default<[]>;
+  mentionable: MentionableRow[] | Default<[]>;
 
   /** How many items the board holds. */
   itemCount: number;
@@ -206,103 +205,6 @@ export interface BoardOutput {
 const reject = (verb: string, reason: string): never => {
   throw new Error(`${verb} rejected: ${reason}`);
 };
-
-/**
- * One row of the board's mention universe: the display name the editor's
- * autocomplete lists and matches on, the title, the board's name for the
- * member as `shortName`, and the member itself as a reference.
- *
- * The strings are COPIES, and that is what separates this from `index`. An
- * index row IS its item, because a survey reads those items anyway; the
- * universe is read by EVERY item's editor, so wiring it to the items would
- * multiply the board by itself, and one document of copies is what bounds that
- * product.
- *
- * `shortName` is copied off the member's own — the derivation `index`
- * publishes — rather than looked up in the names table a second way, so one
- * fact is derived once and a member's number reads the same wherever the board
- * shows it. A member whose `boardNames` never arrived therefore reads blank
- * here exactly as it does in its index row.
- *
- * `piece` is the item, written as a reference and never read through here:
- * the editor resolves it when a completion is picked, so what a mention
- * stores is the item and never this row (`Mentionable.piece` in
- * `packages/ui/src/v2/core/mentionable.ts` is the consuming contract). It is
- * deliberately not part of `ItemMentionable`, the demand an item declares for
- * itself: a property that demand does not select is invisible to the walks
- * that warm and watch an item's argument, and that invisibility is what keeps
- * one item from reaching every sibling through its mention universe.
- */
-export interface ItemMentionableRow {
-  [NAME]: string;
-  title: string | Default<"">;
-  shortName: string | Default<"">;
-  piece: unknown;
-}
-
-/**
- * Each member's universe row, read once per member. A member whose own
- * `shortName` has produced no value carries the empty name, which is a row no
- * `#42` query matches.
- *
- * Declared structurally for the reason `indexRowsOf` is: a member with
- * nothing behind it yet — one appended a moment ago, still mid-sync — reads
- * as `undefined` here and gets no row rather than a junk one; the row appears
- * on the next run.
- */
-export function mentionableRowsOf(
-  members: readonly (
-    | {
-      get():
-        | { [NAME]?: string; title?: string; shortName?: string }
-        | undefined;
-    }
-    | undefined
-  )[],
-): ItemMentionableRow[] {
-  const rows: ItemMentionableRow[] = [];
-  for (const member of members) {
-    const value = member?.get();
-    if (!member || !value) continue;
-    rows.push({
-      // The display-name chain a reader would otherwise walk the item for: a
-      // cold item has not produced its derived `[NAME]` yet, and its
-      // persisted title is authoritative until it does.
-      [NAME]: value[NAME] || value.title || "",
-      title: value.title ?? "",
-      shortName: value.shortName ?? "",
-      piece: member,
-    });
-  }
-  return rows;
-}
-
-/**
- * The board's mention universe, derived once for the whole board: every
- * item's editor autocompletes over this one document of copies rather than
- * over the items themselves, so a universe read is one document however many
- * items the board holds.
- *
- * The parameter is an array of CELLS for the index's two reasons: the cell is
- * the identity each row's `piece` records, and a cell always writes as a
- * link, so an unchanged board recomputes to the same rows and writes nothing.
- */
-const mentionableIndex = lift(
-  (
-    { members }: {
-      members:
-        | ReadonlyCell<{
-          [NAME]?: string | Default<"">;
-          title: string | Default<"">;
-          shortName: string | Default<""> | undefined;
-        }>[]
-        | Default<[]>;
-    },
-  ): ItemMentionableRow[] =>
-    // A plain array, read once per member: an element read through the
-    // reactive array costs a link resolution per access.
-    mentionableRowsOf(Array.from(members)),
-);
 
 export default pattern<BoardInput, BoardOutput>(({ items, names }) => {
   // `.length` alone is what keeps this cheap: the shrunk schema declares

--- a/packages/patterns/collection-naming/item.tsx
+++ b/packages/patterns/collection-naming/item.tsx
@@ -89,7 +89,7 @@ export interface ItemInput {
   /**
    * The board's mention universe — what the body editor completes over.
    * Wired at creation to the board's mention index, one derived document of
-   * rows (`ItemMentionableRow` in `board.tsx`). Absent, the editor simply
+   * rows (`MentionableRow` in `mentionable.ts`). Absent, the editor simply
    * offers no completions.
    */
   mentionable?: Writable<ItemMentionable[] | Default<[]>>;

--- a/packages/patterns/collection-naming/mentionable.ts
+++ b/packages/patterns/collection-naming/mentionable.ts
@@ -1,0 +1,114 @@
+/**
+ * A collection's mention universe: the rows an editor autocompletes over, and
+ * the one derivation that builds them from the collection's members. Nothing
+ * here knows what kind of piece a member is either — a member is read for three
+ * display strings and carried onward as a reference.
+ *
+ * The universe is one document of COPIES, and that is what separates it from a
+ * survey index whose rows ARE the members. A survey reads its members anyway;
+ * the universe is read by EVERY member's editor, so wiring it to the members
+ * would multiply the collection by itself, and one document of copies is what
+ * bounds that product.
+ *
+ * `shortName` is copied off the member's own — the property `naming.ts` gives
+ * it — so a member's number is derived once and reads the same wherever the
+ * collection shows it. `docs/common/conventions/mentionable.md` is the contract
+ * both editors consume this through.
+ */
+
+import { Default, lift, NAME, type ReadonlyCell } from "commonfabric";
+
+/**
+ * One row of a collection's mention universe: the display name the editor's
+ * autocomplete lists and matches on, the title, the collection's name for the
+ * member as `shortName`, and the member itself as a reference.
+ *
+ * `piece` is the member, written as a reference and never read through here:
+ * the editor resolves it when a completion is picked, so what a mention stores
+ * is the member and never this row (`Mentionable.piece` in
+ * `packages/ui/src/v2/core/mentionable.ts` is the consuming contract). It is
+ * deliberately not part of the demand a member declares for its own universe
+ * input: a property that demand does not select is invisible to the walks that
+ * warm and watch a member's argument, and that invisibility is what keeps one
+ * member from reaching every sibling through its mention universe.
+ */
+export interface MentionableRow {
+  [NAME]: string;
+  title: string | Default<"">;
+  shortName: string | Default<"">;
+  piece: unknown;
+}
+
+/**
+ * Each member's universe row, read once per member. A member whose own
+ * `shortName` has produced no value carries the empty name, which is a row no
+ * `#42` query matches.
+ *
+ * Declared structurally, and that is what makes the mid-sync guard a
+ * compile-checked read: `get()` on a `ReadonlyCell` is declared to return a
+ * value rather than `T | undefined`, so against a cell type omitting the guard
+ * type-checks exactly as well as including it. A member with nothing behind it
+ * yet — one appended a moment ago, still mid-sync — reads as `undefined` here
+ * and gets no row rather than a junk one; the row appears on the next run.
+ */
+export function mentionableRowsOf(
+  members: readonly (
+    | {
+      get():
+        | { [NAME]?: string; title?: string; shortName?: string }
+        | undefined;
+    }
+    | undefined
+  )[],
+): MentionableRow[] {
+  const rows: MentionableRow[] = [];
+  for (const member of members) {
+    const value = member?.get();
+    if (!value) continue;
+    rows.push({
+      // The display-name chain a reader would otherwise walk the member for: a
+      // cold member has not produced its derived `[NAME]` yet, and its
+      // persisted title is authoritative until it does.
+      [NAME]: value[NAME] || value.title || "",
+      title: value.title ?? "",
+      shortName: value.shortName ?? "",
+      piece: member,
+    });
+  }
+  return rows;
+}
+
+/**
+ * A collection's mention universe, derived once for the whole collection:
+ * every member's editor autocompletes over this one document of copies rather
+ * than over the members themselves, so a universe read is one document however
+ * many members the collection holds.
+ *
+ * The parameter is an array of CELLS for two reasons: the cell is the identity
+ * each row's `piece` records, and a cell always writes as a link, so an
+ * unchanged collection recomputes to the same rows and writes nothing. What it
+ * declares is the ceiling on the walk — three display strings per member — so
+ * the derivation expands no member's prose, thread, verbs, or rendered view.
+ *
+ * `shortName` is declared OPTIONAL rather than defaulted so this demand stays
+ * applicable over a collection whose members predate its namespace: a default
+ * below an array constraint is one the compatibility proof cannot show stable
+ * under default insertion. A member that publishes none contributes a row
+ * carrying the empty string, which `mentionableRowsOf` coalesces.
+ */
+export const mentionableIndex = lift(
+  (
+    { members }: {
+      members:
+        | ReadonlyCell<{
+          [NAME]?: string | Default<"">;
+          title: string | Default<"">;
+          shortName?: string;
+        }>[]
+        | Default<[]>;
+    },
+  ): MentionableRow[] =>
+    // A plain array, read once per member: an element read through the
+    // reactive array costs a link resolution per access.
+    mentionableRowsOf(Array.from(members)),
+);

--- a/packages/patterns/collection-naming/topics-shape.test.tsx
+++ b/packages/patterns/collection-naming/topics-shape.test.tsx
@@ -1,11 +1,15 @@
 /**
- * The Topics-shape rehearsal: a test-only board whose members are the real
- * Topic pattern, unmodified, wired through the naming library the way the
- * exemplar board is. What it proves is the board side — allocation on
- * create, the backfill over a list filed before the board numbered anything,
- * the names table giving a topic its name by identity, and a topic's own
- * lookup over that table. An unmodified Topic publishes no `shortName`, so
- * the item side is proven on the exemplar item.
+ * A test-only board whose members are the real Topic pattern, wired through the
+ * naming library the way the exemplar board is. It holds the library to a
+ * member pattern it does not own — allocation on create, the backfill over a
+ * list filed before the board numbered anything, the names table giving a topic
+ * its name by identity, and a topic's own lookup over that table — through a
+ * board that is not the Topics board, so the library keeps its own coverage
+ * over topics however the Topics board changes.
+ *
+ * The lookup here is driven from OUTSIDE the member, over the list position's
+ * cell. What a topic does with its own `shortName` belongs to the Topics board
+ * and is covered in `../topics/naming.test.tsx`.
  */
 
 import {
@@ -133,9 +137,9 @@ export default pattern(() => {
   const topics = new Writable<TopicDemand[] | Default<[]>>([]);
   const names = new Writable<NamesMap>({});
   const board = ShapeBoard({ topics, names });
-  // The item-side lookup the graft gives a topic, driven here against real
-  // topic identities from the outside: the same lift, over the board's table,
-  // with the list position's cell standing where a topic's `[SELF]` will.
+  // The same lift a topic runs over its own `boardNames`, driven here against
+  // real topic identities from the outside: over the board's table, with the
+  // list position's cell standing where a topic's `[SELF]` does.
   const nameOfFirst = ownName({ table: board.namesTable, self: topics.key(0) });
   const nameOfSecond = ownName({
     table: board.namesTable,
@@ -180,7 +184,7 @@ export default pattern(() => {
   // topic, each row's `member` the topic itself — and the reverse lookup
   // returns it for the identity a caller holds, here the list position's
   // cell. The `ownName` lifts are the same lookup as a derivation, which is
-  // what a grafted topic runs over this table.
+  // what a topic wired to this table runs.
   const assert_table_names_each_topic = assert(() =>
     (board.namesTable ?? []).length === 2 &&
     board.namesTable?.[0]?.name === "1" &&

--- a/packages/patterns/index.md
+++ b/packages/patterns/index.md
@@ -227,47 +227,62 @@ assignees. The board publishes a bounded discovery index — the topics
 themselves, declared through a narrow row schema of summary scalars, so a row's
 address IS its topic's and a survey and the follow-up read name one document.
 `addTopic` returns the piece it created, so a caller addresses a new topic
-straight from the create. Topics reference each other by CELL: the board derives
-the whole graph once by scanning what each topic points at with `equals`, and
-each topic reads its own inbound edges out of that pivot. Demonstrates:
-reading-list-style piece-in-list composition, `PerUser` display-name on a shared
-piece, mergeable comment appends, session-scoped drafts, bounding a whole-list
-derivation with a narrow declared `lift` parameter, passing topics through a
-sort so an activity-ordered list keeps the identity its elements already have,
-`multiUserTest` coverage.
+straight from the create. The board owns a member namespace through
+`collection-naming/naming.ts`: `addTopic` allocates the next decimal name in the
+same transaction as the append, each topic reads its own name out of the board's
+names table and publishes it as `shortName`, and `backfillNames` names what the
+board held before it numbered anything. Topics reference each other by CELL: the
+board derives the whole graph once by scanning what each topic points at with
+`equals`, and each topic reads its own inbound edges out of that pivot.
+Demonstrates: reading-list-style piece-in-list composition, profile-native
+browser authorship on a shared piece, mergeable comment appends, session-scoped
+drafts, bounding a whole-list derivation with a narrow declared `lift`
+parameter, passing topics through a sort so an activity-ordered list keeps the
+identity its elements already have, `multiUserTest` coverage.
 
 **Keywords:** topics, issues, tracker, discussion, thread, comments, multi-user,
-PerUser, mergeable, index, discovery, bounded read, row identity, references,
-backlinks, cell identity, equals, mentions
+profile, mergeable, index, discovery, bounded read, row identity, references,
+backlinks, cell identity, equals, mentions, member names, shortName, namespace,
+backfill
 
 ### Input Schema
 
 ```ts
 interface TopicsInput {
-  topics?: Writable<TopicPiece[] | Default<[]>>;
-  myName?: PerUser<Writable<string | Default<"">>>;
+  topics?: Writable<TopicDemand[] | Default<[]>>;
+  // The member namespace: each decimal name to the topic it names, held as an
+  // unread reference
+  names?: Writable<Default<NamesMap, {}>>;
 }
-// TopicInput additionally takes mentionable?: Writable<TopicPiece[]> — the
-// board's own list, wired at creation, as the @-mention universe for the
-// topic's body editor.
+// TopicInput additionally takes the three wirings addTopic gives a child:
+// mentionable (the @-mention universe for the body editor), boardCrossrefs
+// (the reference pivot), and boardNames (the names table it reads its own
+// number out of).
 ```
 
 ### Output Schema
 
 ```ts
 interface TopicsOutput {
-  topics: TopicPiece[];
-  mentionable: TopicPiece[];
+  topics: TopicDemand[];
+  // { [NAME], title, shortName, piece } per topic — one document of copies
+  mentionable: MentionableRow[];
   topicCount: number;
   // The topics, read through { title, createdAt, createdBy, commentCount,
-  //   lastActivityAt } — a row addresses the topic it describes
+  //   lastActivityAt, shortName } — a row addresses the topic it describes
   index: TopicIndexRow[];
   // { topic, mentionedBy } per topic — the reference graph, derived once here
   crossrefs: TopicCrossrefRow[];
-  myName: string;
-  // Returns { topic } — the piece it created
+  // The namespace, the table every topic reads its name out of, and the
+  // policy the names are held to
+  names: Default<NamesMap, {}>;
+  namesTable: NamesTableRow[];
+  naming: NamingDeclaration;
+  // Returns { topic, name } — the piece it created and the name it allocated
   addTopic: Stream<AddTopicEvent, AddTopicResult>;
-  setMyName: Stream<{ name: string }>;
+  // Names every unnamed member in filing order; idempotent
+  backfillNames: Stream<BackfillNamesEvent, BackfillNamesResult>;
+  submitTopic: Stream<void>;
 }
 ```
 
@@ -275,10 +290,13 @@ interface TopicsOutput {
 
 A single #topic piece: the durable object the tracker's list holds. Body edits
 go through an explicit Edit→Save toggle (one whole-value `set` per save keeps
-the concurrent-edit window small); comments and links are mergeable appends. Use
-from `topics/main.tsx` via `navigateTo()`, or standalone.
+the concurrent-edit window small); comments and links are mergeable appends.
+Reads the board's name for itself out of `boardNames` by identity, publishes it
+as `shortName`, and renders it as a badge beside the title; a topic wired to no
+board shows none. Use from `topics/main.tsx` via `navigateTo()`, or standalone.
 
-**Keywords:** topic, detail, thread, comment, links, body, navigateTo
+**Keywords:** topic, detail, thread, comment, links, body, navigateTo,
+shortName, member name, badge
 
 ---
 

--- a/packages/patterns/topics/README.md
+++ b/packages/patterns/topics/README.md
@@ -8,9 +8,15 @@ other topics — URLs in v0).
 
 The board publishes an **index**: one row per topic carrying the topic's
 canonical address, a reference to the topic itself, and the scalars a survey
-reads (`title`, `createdAt`, `createdBy`, `commentCount`, `lastActivityAt`). The
-same rows render the board's cards, so a headless survey and the rendered board
-read one derivation rather than two.
+reads (`title`, `createdAt`, `createdBy`, `commentCount`, `lastActivityAt`,
+`shortName`). The same rows render the board's cards, so a headless survey and
+the rendered board read one derivation rather than two.
+
+The board also **names its members**. It owns a namespace of decimal names,
+dense from `1` and never reused, through the library in
+[`collection-naming/`](../collection-naming/README.md); a topic is cited as
+`top/42`, and the number renders as a badge beside its title rather than in
+place of it.
 
 Topics reference each other. A reference is a **cell**, not a string: picking a
 completion in the body editor stores the destination piece itself, and a link
@@ -59,6 +65,32 @@ lineage: Linear CT-1878, which this pattern exists to absorb).
   current authored-content verb writes structured attribution; the public result
   and mutation contracts contain no mutable "current author" state or
   display-name mirrors.
+- **The board names its members, and every reader reaches a name the same way.**
+  `addTopic` allocates the next name in the same transaction as the append, so
+  no reader observes a topic without its name and two concurrent creates
+  serialize on the map's keys rather than taking the same one; the browser
+  composer allocates through the same call. The namespace is one map cell,
+  `names: { "42": <topic> }`, written one key at a time and holding each topic
+  as an unread reference, so surveying its keys expands no topic. A topic reads
+  its own row out of the board's `namesTable` by identity and publishes the
+  result as `shortName` — one derivation — and the survey row, the mention
+  universe row, and a mention's pill all read that one property. `backfillNames`
+  names what the board held before it numbered anything, in filing order,
+  skipping what is already named; it writes the namespace and nothing else, so
+  on a board whose topics were filed past `addTopic` it has to be paired with a
+  one-time link-bind of `namesTable` onto each of them, the same operator step
+  `mentionable` states for itself. Until that bind the topic is named — `names`
+  and `namesTable` carry it — and its row still carries no name. `naming` is
+  what the board declares about those names, so a consumer reads the promise
+  rather than assuming one.
+
+  Every demand for that property is declared OPTIONAL rather than defaulted, and
+  the spelling is what lets the whole graft be applied over a board deployed
+  before it: a defaulted property moves a row demand's defaults below an array
+  constraint the compatibility proof cannot show stable under default insertion,
+  while an optional one tolerates a topic that publishes none. Universe ROWS are
+  the exception and carry the empty string, because they are copies the board
+  writes rather than a demand on anything stored.
 - **`mentionable` is a derived index, and its copies are the design.** Every
   topic on the board reads the mention universe — each child's editor
   autocompletes over it — so whatever `mentionable` is wired to is multiplied by
@@ -66,9 +98,12 @@ lineage: Linear CT-1878, which this pattern exists to absorb).
   crosses into every other topic, and document-granular delivery ships each
   sibling whole to serve two strings. The index bounds that product:
   `mentionableIndex` derives one small document of rows, each carrying a topic's
-  display name and title as COPIES plus the topic itself as a reference. One
-  derivation pays the board-wide walk, once per change, in place of every reader
-  paying it on every load.
+  display name, title and `shortName` as COPIES plus the topic itself as a
+  reference. One derivation pays the board-wide walk, once per change, in place
+  of every reader paying it on every load. The lift and its row type are shared
+  with the collection-naming exemplar (`../collection-naming/mentionable.ts`):
+  both boards derive their universe through the one derivation, so a member's
+  number reads the same on either.
 
   The reference is what a picked completion stores, and it is deliberately
   outside the demand a topic declares over the universe: a property that demand
@@ -89,12 +124,13 @@ lineage: Linear CT-1878, which this pattern exists to absorb).
   space. So every derivation here is a module-scope `lift`, because a `lift`'s
   declared parameter type is a ceiling an opaque helper cannot widen.
 
-  Three derivations run over the whole board, and each declares only what it
+  Four derivations run over the whole board, and each declares only what it
   reads. `crossrefTable` takes one list of references per topic and builds the
   mention pivot from it; `cardsByActivity` takes a single timestamp per topic
-  and orders the cards by it; `mentionableIndex` takes the two display strings
-  per topic and builds the mention universe. None expands a topic's prose,
-  thread, verbs, or rendered UI.
+  and orders the cards by it; `mentionableIndex` takes the three display strings
+  per topic and builds the mention universe; `namesTable` takes the namespace
+  map and builds one row per named member without reading through any of them.
+  None expands a topic's prose, thread, verbs, or rendered UI.
 
   A lift's parameter and its result look like one type, which seems to force a
   choice: narrow the parameter to bound the read, and what comes out narrows
@@ -106,7 +142,7 @@ lineage: Linear CT-1878, which this pattern exists to absorb).
   that way: it reads one timestamp and gives back the topics themselves.
 
   What each reader of a topic gets is then its own declared schema's business.
-  The published `index` declares the five scalars a survey reads, so a survey
+  The published `index` declares the six scalars a survey reads, so a survey
   cannot expand a topic past them, while the card list's argument schema is
   shrunk to the handful of fields its body renders. Neither widens the topic,
   which is what leaves both free to be that narrow — and it is why every field a
@@ -183,10 +219,18 @@ the contract surface; `--all` additionally shows UI wrappers and deprecated
 verbs. Against a deployed board piece:
 
 ```bash
-cf piece call --piece <board> \
-  --schema '{"properties":{"topic":{"$link":true}}}' addTopic \
-  '{"title":"...","body":"the initial living document","agentName":"Sol"}'
-# -> { "result": { "topic": { "$link": "/of:fid1:..." } } }
+# The read options follow the `--` marker, which closes the verb's own
+# section; before the verb the CLI exits 2. The projection names BOTH results,
+# because one naming only `topic` drops `name` from the envelope.
+cf piece call --piece <board> addTopic \
+  '{"title":"...","body":"the initial living document","agentName":"Sol"}' \
+  -- --schema '{"properties":{"topic":{"$link":true},"name":{"type":"string"}}}'
+# -> { "result": { "name": "1", "topic": { "$link": "/of:fid1:..." } } }
+cf cell get --piece <board> names
+# -> { "1": {} }
+# Idempotent, so a board whose members are all named reports nothing written.
+cf piece call --piece <board> backfillNames '{"agentName":"Sol"}'
+# -> { "result": { "assigned": [] } }
 cf cell get --piece <board> topics --input \
   --select title,createdAt,lastActivityAt,commentCount
 cf piece call --piece <topic> addComment \
@@ -241,9 +285,9 @@ before reference resolution and rejects a bare address.
 
 **A full-board survey is one bounded read of `index`.** Each row IS the topic it
 describes, declared through a schema of scalar summaries (`title`, `createdAt`,
-`createdBy`, `commentCount`, `lastActivityAt`). The declared schema is the
-bound, so the read cannot expand a topic's body, thread, or verbs no matter how
-it is projected.
+`createdBy`, `commentCount`, `lastActivityAt`, `shortName`). The declared schema
+is the bound, so the read cannot expand a topic's body, thread, or verbs no
+matter how it is projected.
 
 ```bash
 cf cell get --piece <board> index --step
@@ -299,13 +343,17 @@ then searching the board for it. The result is declared through the index's row
 schema rather than the full topic: the declared schema bounds the default
 readback, and every name a verb's result publishes is permanent, so the create
 hands back the survey row plus the write-time facts only the pattern could
-resolve (`createdAt`, `createdBy`). `addComment` and `addLink` return the
-appended record, `setBody` the persisted body plus the attribution it wrote,
-`setTitle` the persisted title plus its attribution; each carries fields the
-pattern resolved that a caller cannot compute for itself. Counts are
-deliberately not returned: these appends are mergeable ops, so a length observed
-inside one handling is not a fact about the resulting list — read `commentCount`
-when you want the count.
+resolve (`createdAt`, `createdBy`). `name` rides beside it — the name the create
+allocated, as written to the namespace — because the topic's own `shortName` is
+a lookup that may not have produced a value when the call returns, and a caller
+must not have to wait for a derivation to learn what it just allocated.
+`backfillNames` returns the names it wrote, in filing order, and `[]` on a
+second run. `addComment` and `addLink` return the appended record, `setBody` the
+persisted body plus the attribution it wrote, `setTitle` the persisted title
+plus its attribution; each carries fields the pattern resolved that a caller
+cannot compute for itself. Counts are deliberately not returned: these appends
+are mergeable ops, so a length observed inside one handling is not a fact about
+the resulting list — read `commentCount` when you want the count.
 
 A returned value reaches the caller through the handling's receipt. A result
 carrying a piece (`addTopic`) travels the result-pattern projection path; the
@@ -323,7 +371,8 @@ _update_: `bodyUpdatedBy`/`bodyUpdatedAt` stay unset.
 
 Invalid mutations **throw** instead of silently returning (verb contract rule
 4): an empty title, an empty comment body, a blank or non-http(s) link URL, and
-a blank `agentName` on an authored-content verb all surface as a failed call — a
-nonzero CLI exit — never as apparent success. The UI composer wrappers keep
+a blank `agentName` on an authored-content verb — `backfillNames` included,
+which writes the namespace on someone's behalf — all surface as a failed call —
+a nonzero CLI exit — never as apparent success. The UI composer wrappers keep
 their silent guards: an empty draft is a non-event in a composer, not a headless
 mutation.

--- a/packages/patterns/topics/main.tsx
+++ b/packages/patterns/topics/main.tsx
@@ -15,6 +15,19 @@ import {
   Writable,
 } from "commonfabric";
 
+import {
+  mentionableIndex,
+  type MentionableRow,
+} from "../collection-naming/mentionable.ts";
+import {
+  assignName,
+  backfillNames,
+  type NamesMap,
+  namesTable,
+  type NamesTableRow,
+  type NamingDeclaration,
+  SEQUENCE_NAMING,
+} from "../collection-naming/naming.ts";
 import Topic, {
   rejectMutation,
   snippet,
@@ -62,19 +75,36 @@ export type {
  * This board calls no Topic verb, so the demand names none. Callers take a
  * Topic's address from `index` and reach its verbs on the Topic itself.
  *
- * The eight fields cover the card, compact index, activity sort, reference
+ * The nine fields cover the card, compact index, activity sort, reference
  * pivot, and mention autocomplete. Seven carry defaults so a missing path does
- * not make the whole array unreadable. `createdAt` is the exception: the Topic
- * pattern defaults its input and publishes that path unconditionally.
+ * not make the whole array unreadable. Two do not, for different reasons:
+ * `createdAt` is required, because the Topic pattern defaults its input and
+ * publishes that path unconditionally, and `shortName` is optional, because a
+ * default there cannot be applied over a board deployed before the namespace.
  */
 export interface TopicDemand extends TopicSummary {
   /** The display name, which the board's mention index copies into each
    * topic's row — the label every `@`-mention completion carries. The index
-   * lift states the same two-string demand for itself; this entry is the
+   * lift states the same three-string demand for itself; this entry is the
    * board-level record of it. */
   [NAME]: string | Default<""> | undefined;
   body: string | Default<"">;
   mentions: unknown[] | Default<[]>;
+
+  /** The board's name for the topic, as the topic reads it out of the board's
+   * names table. The card renders it as a badge and the mention index copies
+   * it into the topic's universe row, so `#42` matches without expanding a
+   * topic.
+   *
+   * OPTIONAL rather than defaulted, and the spelling is what keeps this demand
+   * applicable over a board deployed before the namespace: a defaulted
+   * property moves the demand's defaults below an array constraint the
+   * compatibility proof cannot show stable under default insertion, while an
+   * optional one simply tolerates a topic that publishes none. A topic whose
+   * lookup has produced no value — one filed a moment ago, or one from before
+   * the board numbered anything — is absent here rather than blank, and every
+   * consumer treats the two the same. */
+  shortName?: string;
 }
 
 export interface TopicsInput {
@@ -82,6 +112,14 @@ export interface TopicsInput {
    * are legitimate but unattributed, and a whole-array write forfeits the
    * mergeability the verb's append keeps. */
   topics?: Writable<TopicDemand[] | Default<[]>>;
+
+  /** The board's member namespace: each name to the topic it names, held as an
+   * unread reference. `addTopic` writes one key per create and `backfillNames`
+   * one key per member it names; nothing rewrites the map whole. Reads as empty
+   * on a board from before it numbered anything, in the default form `NamesMap`
+   * explains. */
+  // deno-lint-ignore ban-types
+  names?: Writable<Default<NamesMap, {}>>;
 }
 
 export interface AddTopicEvent {
@@ -117,6 +155,25 @@ export interface AddTopicResult {
    * caller already knows plus the write-time facts only the pattern could
    * resolve (`createdAt`, `createdBy`). */
   topic: TopicIndexRow;
+
+  /** The name the create allocated, as it was written to the namespace. The
+   * topic's own `shortName` is a lookup that may not have produced a value
+   * when this returns, so this is the one to read: a caller must not have to
+   * wait for a derivation to learn the name it just allocated. */
+  name: string;
+}
+
+/** What `backfillNames` takes: the agent running it. */
+export interface BackfillNamesEvent {
+  /** The agent running the backfill, checked as `addTopic` checks it. */
+  agentName: string;
+}
+
+/** What `backfillNames` returns. */
+export interface BackfillNamesResult {
+  /** The names this run wrote, in filing order; empty when every member was
+   * already named, which is what a second run returns. */
+  assigned: string[];
 }
 
 /** One row of the board's compact discovery index: the topic itself, declared
@@ -138,6 +195,11 @@ export interface TopicIndexRow {
    * so the row itself never carries the mixed-version undefined. */
   commentCount: number | Default<0> | undefined;
   lastActivityAt: number | Default<0> | undefined;
+
+  /** The board's name for the topic. Optional rather than defaulted, unlike
+   * the two above, for the reason `TopicDemand.shortName` states: a default
+   * here is what makes the row demand inapplicable over a deployed board. */
+  shortName?: string;
 }
 
 /**
@@ -284,93 +346,6 @@ const crossrefTable = lift(
 );
 
 /**
- * One row of the board's mention index: the display name the editor's
- * autocomplete lists and matches on, the title for readers that select it
- * (the editors do not — their schema reads `[NAME]` and `piece` alone),
- * and the topic itself held as a reference.
- *
- * The two strings are COPIES, and the copies are the design rather than a
- * shortcut. The autocomplete needs every row's strings just to open, so a
- * row that pointed at its topic for them would make every reader of the
- * index expand every topic — each a document of its own, shipped whole to
- * serve two strings. Copies make the index one self-contained document;
- * the deriving lift below is the one reader that still pays the board-wide
- * walk, once per change, instead of every reader paying it on every load.
- *
- * `piece` is the topic, written as a reference and never read through
- * here: the editor resolves it when a completion is picked, so what a
- * mention stores is the topic and never this row (`Mentionable.piece` in
- * `packages/ui/src/v2/core/mentionable.ts` is the consuming contract).
- * It is deliberately NOT part of `TopicMentionable`: a property a topic's
- * declared demand does not select is invisible to the walks that warm and
- * watch the topic's argument, and that invisibility is what keeps a
- * topic's resume from reaching any sibling topic through its mention
- * universe.
- */
-export interface TopicMentionableRow {
-  [NAME]: string;
-  title: string | Default<"">;
-  piece: unknown;
-}
-
-/**
- * Each source's index row, read once per source.
- *
- * Declared structurally for the reason `mentionListsOf` is: `get()` on
- * `ReadonlyCell` is declared to return a value, so only the structural
- * parameter makes the mid-sync guard a compile-checked read. An entry with
- * nothing behind it yet gets no row — there is no name to list and no
- * settled identity for `piece` to record — and the row appears on the
- * derivation's next run, once the append has materialized.
- */
-export function mentionableRowsOf(
-  sources: readonly ({ get(): TopicMentionable | undefined } | undefined)[],
-): TopicMentionableRow[] {
-  const rows: TopicMentionableRow[] = [];
-  for (const source of sources) {
-    const value = source?.get();
-    if (!value) continue;
-    rows.push({
-      // The display-name chain a reader would otherwise walk the topic
-      // for: a cold topic has not produced its derived `[NAME]` yet, and
-      // its persisted title is authoritative until it does (`TopicPiece`).
-      [NAME]: value[NAME] || value.title || "",
-      title: value.title ?? "",
-      piece: source,
-    });
-  }
-  return rows;
-}
-
-/**
- * The board's mention index: the whole mention universe as one small
- * document.
- *
- * `mentionable` is read by every topic on the board — each child's editor
- * autocompletes over it — so whatever it is wired to is multiplied by the
- * board's own size. Wired to the topics themselves, every topic's walk
- * crossed into every other topic. The index bounds that product: this
- * derivation reads the two strings out of each topic, and every reader
- * everywhere reads the one document the copies land in.
- *
- * The parameter is an array of CELLS for the pivot's two reasons: the cell
- * is the identity each row's `piece` records, and a cell always writes as
- * a link, so an unchanged board recomputes to the same rows and writes
- * nothing.
- */
-const mentionableIndex = lift(
-  (
-    { sources }: {
-      sources: ReadonlyCell<TopicMentionable>[] | Default<[]>;
-    },
-  ): TopicMentionableRow[] =>
-    // A plain array, read once per topic, as the pivot reads its sources:
-    // an element read through the reactive array costs a link resolution
-    // per access.
-    mentionableRowsOf(Array.from(sources)),
-);
-
-/**
  * The board's cards, most recently active first.
  *
  * Sorts and returns the topics themselves. It does not build a card object per
@@ -427,10 +402,27 @@ export interface TopicsOutput {
 
   /** The board's mention universe, under the name the topic pattern's editor
    * autocompletes over — what `addTopic` wires into each child. One derived
-   * document of two-string rows, each holding its topic as an unread
-   * reference, rather than the topics themselves, so a reader of the
-   * universe expands no topic; see `TopicMentionableRow`. */
-  mentionable: TopicMentionableRow[] | Default<[]>;
+   * document of copies, each holding its topic as an unread reference and
+   * carrying the board's name for it, rather than the topics themselves, so a
+   * reader of the universe expands no topic and `#42` finds a member without
+   * expanding one; see `MentionableRow` in
+   * `../collection-naming/mentionable.ts`. */
+  mentionable: MentionableRow[] | Default<[]>;
+
+  /** The namespace itself: each name to the topic it names. A slug pointing
+   * here is what makes a member addressable as `<collection>/<name>`.
+   * Published under the default its input carries. */
+  // deno-lint-ignore ban-types
+  names: Default<NamesMap, {}>;
+
+  /** The names table, one row per named member, which every topic the board
+   * creates reads its own name from. Published so a topic composed outside
+   * `addTopic` can be wired to the same table. */
+  namesTable: NamesTableRow[] | Default<[]>;
+
+  /** What the board declares about its names, for a consumer deciding whether
+   * a name may be held rather than an identity. */
+  naming: NamingDeclaration;
 
   /** How many topics the board holds, nulls included. */
   topicCount: number;
@@ -457,6 +449,12 @@ export interface TopicsOutput {
    * reference plus the write-time facts the pattern resolved. */
   addTopic: Stream<AddTopicEvent, AddTopicResult>;
 
+  /** Name every unnamed member in filing order. Idempotent. A member filed
+   * past `addTopic` also needs a one-time link-bind of `namesTable` onto it
+   * before its row and its universe entry show the name, the same operator
+   * step `mentionable` states for itself. */
+  backfillNames: Stream<BackfillNamesEvent, BackfillNamesResult>;
+
   /** Submit the footer composer as the current viewer's canonical Profile. */
   submitTopic: Stream<void>;
 }
@@ -467,7 +465,7 @@ export interface TopicsOutput {
 export const submitProfileTopic = handler<void, {
   topics: Writable<TopicDemand[] | Default<[]>>;
 
-  /** Declared at the child's own demand — the two strings a universe
+  /** Declared at the child's own demand — the three strings a universe
    * entry carries — so the board's index rows and a plain list of pieces
    * both satisfy it. */
   mentionable: Writable<TopicMentionable[] | Default<[]>>;
@@ -478,6 +476,16 @@ export const submitProfileTopic = handler<void, {
    * state keeps a cell whole while `StripCell` unwraps the input's. Nothing
    * here writes a row. */
   boardCrossrefs: Writable<TopicCrossrefRow[] | Default<[]>>;
+
+  /** The names table, handed to the composed topic for the same reason and on
+   * the same terms as `boardCrossrefs`. */
+  boardNames: Writable<NamesTableRow[] | Default<[]>>;
+
+  /** The namespace, written one key per create. Read for its keys and written
+   * at one of them inside this handler, so the allocation and the append are
+   * one transaction. */
+  // deno-lint-ignore ban-types
+  names: Writable<Default<NamesMap, {}>>;
   newTitle: Writable<string>;
   profileName: string;
   profileAvatar: string;
@@ -485,6 +493,8 @@ export const submitProfileTopic = handler<void, {
   topics,
   mentionable,
   boardCrossrefs,
+  boardNames,
+  names,
   newTitle,
   profileName,
   profileAvatar,
@@ -497,16 +507,22 @@ export const submitProfileTopic = handler<void, {
     createdAt: Date.now(),
     createdBy: author,
     // Same wiring `addTopic` gives its children: the board's mention index
-    // is the universe the new topic's editor autocompletes over, and the
-    // board's pivot is where it reads its inbound references.
+    // is the universe the new topic's editor autocompletes over, the board's
+    // pivot is where it reads its inbound references, and the board's names
+    // table is where it reads its own number.
     mentionable,
     boardCrossrefs,
+    boardNames,
   });
+  // The name and the append are one transaction, as they are in `addTopic`:
+  // no reader observes the topic without its name, and a concurrent create
+  // serializes on the map's keys rather than taking the same one.
+  assignName(names, piece);
   topics.push(piece);
   newTitle.set("");
 });
 
-export default pattern<TopicsInput, TopicsOutput>(({ topics }) => {
+export default pattern<TopicsInput, TopicsOutput>(({ topics, names }) => {
   const newTitle = new Writable.perSession("");
 
   // `.length` alone is what makes this cheap: the shrunk schema declares
@@ -520,7 +536,10 @@ export default pattern<TopicsInput, TopicsOutput>(({ topics }) => {
   // Also derived once for the whole board: the mention universe every
   // child's editor autocompletes over, as one document of copies instead of
   // the topics themselves.
-  const mentionable = mentionableIndex({ sources: topics });
+  const mentionable = mentionableIndex({ members: topics });
+  // Derived once for the whole board too; every topic reads its own row out
+  // of it to learn the number the board calls it by.
+  const table = namesTable({ names });
   const hasNoTopics = topicCount === 0;
 
   // Browser authorship comes from the current viewer's canonical Profile.
@@ -564,18 +583,36 @@ export default pattern<TopicsInput, TopicsOutput>(({ topics }) => {
       // The board's mention pivot. A topic reads its inbound references out of
       // the row the board already built for it rather than rebuilding the join.
       boardCrossrefs: crossrefs,
+      // The board's names table, so the topic can read its own name out of the
+      // row the board already built for it.
+      boardNames: table,
     });
+    // The name and the append are one transaction: no reader observes the
+    // topic without its name, and a concurrent create serializes on the map's
+    // keys rather than taking the same one.
+    const name = assignName(names, piece);
     // Mergeable append: concurrent creates from different users all land.
     // The session composer draft is `submitTopic`'s to clear; a headless
     // create has no draft.
     topics.push(piece);
-    return { topic: piece };
+    return { topic: piece, name };
   });
+
+  const backfill = action<BackfillNamesEvent, BackfillNamesResult>(
+    ({ agentName }) => {
+      if (!topicAuthorFromAgent(agentName)) {
+        rejectMutation("backfillNames", "agentName must be non-blank");
+      }
+      return { assigned: backfillNames(topics, names) };
+    },
+  );
 
   const submitTopic = submitProfileTopic({
     topics,
     mentionable,
     boardCrossrefs: crossrefs,
+    boardNames: table,
+    names,
     newTitle,
     profileName,
     profileAvatar,
@@ -613,6 +650,13 @@ export default pattern<TopicsInput, TopicsOutput>(({ topics }) => {
             {cards.map((card) => (
               <cf-card>
                 <cf-hstack gap="3" align="center">
+                  {card.shortName
+                    ? (
+                      <cf-badge size="sm" color="primary" data-member-name="">
+                        {card.shortName}
+                      </cf-badge>
+                    )
+                    : null}
                   <cf-vstack gap="0" style="flex: 1; min-width: 0;">
                     <cf-text block style="font-weight: 600;">
                       {card.title || "(untitled topic)"}
@@ -666,6 +710,11 @@ export default pattern<TopicsInput, TopicsOutput>(({ topics }) => {
     ),
     topics,
     mentionable,
+    names,
+    namesTable: table,
+    // The sequence policy, claiming no name for the board: what it is bound
+    // as is decided where the binding is made.
+    naming: SEQUENCE_NAMING,
     topicCount,
     crossrefs,
     // The topics themselves, declared through the index's narrow row schema:
@@ -674,6 +723,7 @@ export default pattern<TopicsInput, TopicsOutput>(({ topics }) => {
     index: topics,
     newTitle,
     addTopic,
+    backfillNames: backfill,
     submitTopic,
   };
 });

--- a/packages/patterns/topics/naming.test.tsx
+++ b/packages/patterns/topics/naming.test.tsx
@@ -1,0 +1,320 @@
+/**
+ * Pattern tests for the member namespace the Topics board owns: allocation in
+ * the same transaction as the create, the names table that gives a topic its
+ * name by identity, a topic reading its own name out of that table and
+ * rendering it beside its title, the survey rows and the mention universe that
+ * carry the copy, the backfill over topics filed before the board numbered
+ * anything, and the bound on what any of those reads expands.
+ *
+ * Separate from topics.test.tsx for the reason render-shape.test.tsx is
+ * separate from it: this file drives one surface end to end and keeps
+ * compiling while a change to the board's other demands is in flight.
+ *
+ * ONE CLAIM HAS NO COVERAGE ANYWHERE, and it is stated rather than left
+ * implicit: the POSITIVE case of a topic's own header badge. Deleting that
+ * JSX reds no test in any lane. Reading a topic's `[UI]` needs a handle the
+ * pattern body holds, and naming that topic needs a verb — but a body-held
+ * piece captured by a verb is materialized through the verb's state schema,
+ * whatever the target's own demand narrows to, so any step that would name a
+ * topic this file could read the header of does not run (`TopicOutput`'s
+ * `editingBody` says why, and what it would cost to change). The shell lane
+ * asserts the equivalent badge for the collection-naming EXEMPLAR's item, in
+ * the exemplar's own space; nothing asserts it for a Topic. Restoring it means
+ * a Topics browser test under `packages/patterns/integration/`, driving the
+ * board's create and opening the created topic.
+ *
+ * What is covered instead: the board's own card badge, the index and universe
+ * rows carrying the name, the negative header case on a topic wired to no
+ * board, and the lookup itself through `ownName`.
+ *
+ * The mixed-vintage case — a topic deployed before `shortName` existed, read
+ * beside one that has it — is NOT here, and deliberately. A fixture of that
+ * shape was written here and measured inert: spelling `shortName` as a
+ * required path on both the demand and the publication, which is the defect it
+ * would guard, left every one of its clauses green. The case that does
+ * discriminate is `assert_explicit_undefined_author_projection` in
+ * topics.test.tsx, which stands a legacy sibling in a live universe and reds
+ * under exactly that mutation.
+ *
+ * Some runs log `sync-load-failure` lines at teardown, and they are acceptable.
+ * Each Topic's `#profile` wish finds no profile in the test space and opens its
+ * profile-create surface, a sidecar pattern the test runtime has no server to
+ * load (`packages/runner/src/builtins/wish.ts`); a topic created late in the
+ * run can still be syncing for that when the harness disposes the runtime. The
+ * run therefore ends on a write-free assertion, and nothing here depends on the
+ * wish.
+ */
+
+import {
+  action,
+  assert,
+  Default,
+  equals,
+  NAME,
+  pattern,
+  TESTS,
+  UI,
+  Writable,
+} from "commonfabric";
+import {
+  backfillNames,
+  nameOf,
+  type NamesMap,
+} from "../collection-naming/naming.ts";
+import {
+  findElement,
+  findElementByExactText,
+  hasText,
+} from "../test/vnode-helpers.ts";
+import Topics, { type TopicDemand } from "./main.tsx";
+import Topic from "./topic.tsx";
+
+export default pattern(() => {
+  const names = new Writable<NamesMap>({});
+  const board = Topics({ names });
+
+  const assert_initial = assert(() =>
+    board.topicCount === 0 &&
+    (board.namesTable ?? []).length === 0 &&
+    Object.keys((board.names ?? {}) as NamesMap).length === 0
+  );
+  // The policy the board publishes beside the names, so a consumer deciding
+  // whether it may hold a name rather than an identity reads the promise
+  // instead of assuming one.
+  const assert_declaration = assert(() =>
+    board.naming?.policy?.allocator === "sequence" &&
+    board.naming?.policy?.unique === "history" &&
+    board.naming?.policy?.permanent === true &&
+    board.naming?.policy?.reuse === false &&
+    board.naming?.compact === true
+  );
+
+  // Allocation on create: the topic is reachable at `names["1"]` the moment it
+  // exists, and the entry names the topic itself rather than a copy of it.
+  // `addTopic`'s returned `name` is not observable here: a verb's result
+  // reaches its caller through the handling's receipt, and `send()` gives a
+  // pattern test nothing. The namespace keys below pin what was allocated;
+  // that the verb hands it back is asserted where a result IS observable, in
+  // `packages/cli/integration/topics-restore-drill.sh`.
+  const action_add_first = action(() => {
+    board.addTopic.send({
+      title: "First topic",
+      body: "The living document.",
+      agentName: "Sol",
+    });
+  });
+  const action_add_second = action(() => {
+    board.addTopic.send({ title: "Second topic", agentName: "Fable" });
+  });
+  const assert_allocated_on_create = assert(() =>
+    board.topicCount === 2 &&
+    Object.keys((board.names ?? {}) as NamesMap).join(",") === "1,2" &&
+    equals(
+      ((board.names ?? {}) as NamesMap)["1"] as object,
+      board.topics?.[0] as object,
+    ) &&
+    equals(
+      ((board.names ?? {}) as NamesMap)["2"] as object,
+      board.topics?.[1] as object,
+    )
+  );
+  // The table the board derives once and hands every topic it creates: one row
+  // per named member, each row addressed by the member it describes, so a
+  // topic looking itself up by identity finds one row.
+  const assert_table_names_each_topic = assert(() =>
+    (board.namesTable ?? []).length === 2 &&
+    board.namesTable?.[0]?.name === "1" &&
+    board.namesTable?.[1]?.name === "2" &&
+    equals(
+      board.namesTable?.[0]?.member as object,
+      board.topics?.[0] as object,
+    ) &&
+    equals(
+      board.namesTable?.[1]?.member as object,
+      board.topics?.[1] as object,
+    )
+  );
+  // A survey row IS its topic, and the name reaches it through the topic's own
+  // `shortName` — the lookup `addTopic`'s `boardNames` wiring makes possible.
+  const assert_index_rows_carry_the_name = assert(() =>
+    (board.index ?? []).length === 2 &&
+    board.index?.[0]?.title === "First topic" &&
+    board.index?.[0]?.shortName === "1" &&
+    board.index?.[1]?.shortName === "2"
+  );
+  // The board's cards render the number beside the title, never in place of
+  // it: both are on screen.
+  const assert_cards_show_the_badge = assert(() =>
+    findElementByExactText(board[UI], "cf-badge", "1") !== undefined &&
+    findElementByExactText(board[UI], "cf-badge", "2") !== undefined &&
+    hasText(board[UI], "First topic") &&
+    hasText(board[UI], "Second topic")
+  );
+  // The mention universe: one row per topic carrying the board's copy of its
+  // name, which is what a `#42` completion matches without reading a topic.
+  const assert_universe_rows_carry_the_name = assert(() =>
+    (board.mentionable ?? []).length === 2 &&
+    board.mentionable?.[0]?.[NAME] === "First topic" &&
+    board.mentionable?.[0]?.title === "First topic" &&
+    board.mentionable?.[0]?.shortName === "1" &&
+    board.mentionable?.[1]?.shortName === "2" &&
+    equals(
+      board.mentionable?.[0]?.piece as object,
+      board.topics?.[0] as object,
+    )
+  );
+  // The bound: topics carry bodies and threads, and neither the namespace nor
+  // the table carries any of it. The universe carries the copied strings and
+  // nothing behind the reference beside them.
+  const assert_reads_expand_no_topic = assert(() => {
+    const namespace = JSON.stringify(board.names);
+    const table = JSON.stringify(board.namesTable);
+    const universe = JSON.stringify(board.mentionable);
+    return !namespace.includes('"title"') &&
+      !namespace.includes('"body"') &&
+      table.includes('"name"') &&
+      !table.includes('"title"') &&
+      !table.includes('"comments"') &&
+      universe.includes('"shortName"') &&
+      !universe.includes("The living document.") &&
+      !universe.includes('"comments"') &&
+      !universe.includes("vnode");
+  });
+
+  // A topic wired to no board has no name, renders no badge, and does not
+  // fail: the number is the collection's, and a topic without one is whole.
+  // The lookup produces nothing, and the demand declares the property
+  // optional, so a reader sees no `shortName` at all rather than a blank one.
+  const solo = Topic({ title: "Solo topic" });
+  const assert_solo_topic_has_no_name = assert(() =>
+    solo.shortName === undefined &&
+    solo[NAME] === "Solo topic"
+  );
+  const assert_solo_topic_renders_no_badge = assert(() =>
+    findElement(solo[UI], "cf-badge") === undefined &&
+    hasText(solo[UI], "Solo topic")
+  );
+
+  // The backfill, on a board that held topics before it numbered anything. The
+  // topics are pushed straight into the list, past `addTopic`, which is how a
+  // board from before the namespace holds its members. They carry the board's
+  // table because a name reaches a row only through the member's own wiring:
+  // they stand for members an operator has link-bound, the step the board
+  // pairs with a backfill, done here at construction because a pattern cannot
+  // reach a member's argument.
+  const olderTopics = new Writable<TopicDemand[] | Default<[]>>([]);
+  const olderNames = new Writable<NamesMap>({});
+  const older = Topics({ topics: olderTopics, names: olderNames });
+
+  const action_file_two_unnamed = action(() => {
+    olderTopics.push(
+      Topic({ title: "Older one", createdAt: 1, boardNames: older.namesTable }),
+    );
+    olderTopics.push(
+      Topic({ title: "Older two", createdAt: 2, boardNames: older.namesTable }),
+    );
+  });
+  // An unnamed member's row reads the default, so the board reads whole before
+  // anything names it, and its universe row is one no `#42` query matches.
+  const assert_unnamed_rows_carry_no_name = assert(() =>
+    older.topicCount === 2 &&
+    (older.index ?? []).length === 2 &&
+    older.index?.[0]?.shortName === undefined &&
+    older.index?.[1]?.shortName === undefined &&
+    (older.namesTable ?? []).length === 0 &&
+    older.mentionable?.[0]?.shortName === "" &&
+    findElement(older[UI], "cf-badge") === undefined
+  );
+  // The library call the verb makes, so its return is observable here: exactly
+  // the names it wrote, in filing order. The VERB's own result is not
+  // observable in this lane — `send()` hands a pattern test nothing, because a
+  // result reaches its caller through the handling's receipt — so it is
+  // asserted in `packages/cli/integration/topics-restore-drill.sh`, as
+  // `addTopic`'s `name` is.
+  const assigned = new Writable<string[][]>([]);
+  const action_backfill = action(() => {
+    assigned.push(backfillNames(olderTopics, olderNames));
+  });
+  const assert_backfilled_in_filing_order = assert(() =>
+    Object.keys((older.names ?? {}) as NamesMap).join(",") === "1,2" &&
+    older.index?.[0]?.shortName === "1" &&
+    older.index?.[1]?.shortName === "2" &&
+    older.mentionable?.[0]?.shortName === "1" &&
+    older.mentionable?.[1]?.shortName === "2" &&
+    equals(
+      ((older.names ?? {}) as NamesMap)["1"] as object,
+      older.topics?.[0] as object,
+    )
+  );
+
+  // A create after the backfill continues the sequence rather than restarting
+  // it, and a member filed past the create keeps reading the default until an
+  // operator link-binds the table onto it — while the name itself is real, and
+  // `namesTable` is where it is.
+  const action_add_after_backfill = action(() => {
+    older.addTopic.send({ title: "Newer one", agentName: "Sol" });
+  });
+  const action_file_a_late_unnamed = action(() => {
+    olderTopics.push(Topic({ title: "Older three", createdAt: 3 }));
+  });
+  const action_backfill_again = action(() => {
+    older.backfillNames.send({ agentName: "Sol" });
+  });
+  const assert_backfill_skips_the_named = assert(() =>
+    older.topicCount === 4 &&
+    Object.keys((older.names ?? {}) as NamesMap).join(",") === "1,2,3,4" &&
+    older.index?.[2]?.title === "Newer one" &&
+    older.index?.[2]?.shortName === "3" &&
+    older.index?.[3]?.title === "Older three" &&
+    older.index?.[3]?.shortName === undefined &&
+    nameOf(olderTopics.key(3), older.namesTable ?? []) === "4"
+  );
+  // Idempotent: a run over a fully named list writes nothing, so the map holds
+  // exactly what the first run and the create left.
+  const action_backfill_a_third_time = action(() => {
+    assigned.push(backfillNames(olderTopics, olderNames));
+  });
+  // The first run reports the two names it wrote; the third reports none,
+  // which is the contract's own statement of idempotence.
+  const assert_backfill_reports_what_it_wrote = assert(() =>
+    assigned.get().length === 2 &&
+    assigned.get()[0]?.join(",") === "1,2" &&
+    assigned.get()[1]?.length === 0
+  );
+  const assert_third_backfill_leaves_the_map = assert(() =>
+    Object.keys((older.names ?? {}) as NamesMap).join(",") === "1,2,3,4" &&
+    (older.namesTable ?? []).length === 4 &&
+    equals(
+      ((older.names ?? {}) as NamesMap)["3"] as object,
+      older.topics?.[2] as object,
+    )
+  );
+
+  return {
+    [TESTS]: [
+      { assertion: assert_initial },
+      { assertion: assert_declaration },
+      { action: action_add_first },
+      { action: action_add_second },
+      { assertion: assert_allocated_on_create },
+      { assertion: assert_table_names_each_topic },
+      { assertion: assert_index_rows_carry_the_name },
+      { assertion: assert_cards_show_the_badge },
+      { assertion: assert_universe_rows_carry_the_name },
+      { assertion: assert_reads_expand_no_topic },
+      { assertion: assert_solo_topic_has_no_name },
+      { assertion: assert_solo_topic_renders_no_badge },
+      { action: action_file_two_unnamed },
+      { assertion: assert_unnamed_rows_carry_no_name },
+      { action: action_backfill },
+      { assertion: assert_backfilled_in_filing_order },
+      { action: action_add_after_backfill },
+      { action: action_file_a_late_unnamed },
+      { action: action_backfill_again },
+      { assertion: assert_backfill_skips_the_named },
+      { action: action_backfill_a_third_time },
+      { assertion: assert_third_backfill_leaves_the_map },
+      { assertion: assert_backfill_reports_what_it_wrote },
+    ],
+  };
+});

--- a/packages/patterns/topics/topic.tsx
+++ b/packages/patterns/topics/topic.tsx
@@ -19,6 +19,8 @@ import {
   Writable,
 } from "commonfabric";
 
+import { type NamesTableRow, ownName } from "../collection-naming/naming.ts";
+
 // ===== Shared types =====
 
 /**
@@ -379,11 +381,12 @@ export interface TopicInput {
 
   /** The board's mention universe — what the body editor autocompletes
    * over. Wired at creation to the board's mention index (one derived
-   * document of two-string rows; `TopicMentionableRow` in `main.tsx`), and
-   * rewired onto a piece from before the index as a one-time link-bind.
-   * A plain list of the pieces themselves also satisfies the demand — a
-   * board not yet rewired, or a composer without a board. Absent, the
-   * editor simply offers no completions. */
+   * document of copies; `MentionableRow` in
+   * `../collection-naming/mentionable.ts`), and rewired onto a piece from
+   * before the index as a one-time link-bind. A plain list of the pieces
+   * themselves also satisfies the demand — a board not yet rewired, or a
+   * composer without a board. Absent, the editor simply offers no
+   * completions. */
   mentionable?: Writable<TopicMentionable[] | Default<[]>>;
 
   /** Where this topic's `[Label][key]` mentions point, keyed by the token that
@@ -415,6 +418,16 @@ export interface TopicInput {
    * has no business writing into it. Declaring the narrower cell says so where
    * a reader can see it, rather than leaving it to convention. */
   boardCrossrefs?: ReadonlyCell<TopicCrossrefRow[] | Default<[]>>;
+
+  /** The board's names table, one row per named topic. The topic reads its own
+   * row out of it and nothing else; absent, the topic shows no number.
+   *
+   * Readable, not writable, for the reason `boardCrossrefs` states: the table
+   * is the board's derivation, and a topic has no business writing into it.
+   * Wired at creation by the board's create, and rewired onto a topic filed
+   * before the namespace as a one-time link-bind — the same operator step
+   * `mentionable` states for itself. */
+  boardNames?: ReadonlyCell<NamesTableRow[] | Default<[]>>;
 }
 
 /**
@@ -488,9 +501,18 @@ export interface TopicCrossrefRow {
 
 /**
  * What the body editor's `@`-mention autocomplete needs of a mention
- * universe entry: the display name it lists and matches on, and the title
- * — the persisted scalar other readers of the universe select, though the
- * editor's own schema does not.
+ * universe entry: the display name it lists and matches on, the title — the
+ * persisted scalar other readers of the universe select, though the editor's
+ * own schema does not — and the board's name for the topic as `shortName`,
+ * which is what a `#42` query matches.
+ *
+ * `shortName` is OPTIONAL rather than defaulted, and the spelling is what
+ * keeps this demand applicable over a topic deployed before the namespace. A
+ * defaulted property moves the demand's defaults below an array constraint the
+ * compatibility proof cannot show stable under default insertion, and dropping
+ * the default without making the property optional makes it a newly required
+ * field. `TopicPiece` publishes it the same way, so a plain list of topics
+ * satisfies this demand as the input documents it may.
  *
  * `[NAME]` is not decoration here. `cf-code-editor` declares its entries as
  * `Mentionable`, whose schema carries `required: [NAME]`
@@ -498,7 +520,7 @@ export interface TopicCrossrefRow {
  * it silently offers no completions — the JSX prop binding is loose enough
  * that TypeScript does not object.
  *
- * Two strings are also deliberately the WHOLE demand. A board's index row
+ * These three are also deliberately the WHOLE demand. A board's universe row
  * carries its topic as a `piece` reference besides them, and leaving that
  * out of this projection is what keeps every walk under a topic's argument
  * out of the sibling topics: a property the declared demand does not select
@@ -509,6 +531,7 @@ export interface TopicCrossrefRow {
 export interface TopicMentionable {
   [NAME]: string | Default<""> | undefined;
   title: string | Default<"">;
+  shortName?: string;
 }
 
 /**
@@ -557,6 +580,27 @@ export interface TopicPiece extends TopicSummary {
    * retained topic may not have produced this path yet; its persisted title
    * remains authoritative until it does. */
   [NAME]: string | Default<""> | undefined;
+
+  /** The name the board calls this topic by, read out of the board's names
+   * table by identity. The display name stays the title — this rides beside
+   * it, under the name a mention pill reads it by (`Mentionable.shortName` in
+   * `packages/ui/src/v2/core/mentionable.ts`), so a mention of this topic
+   * elsewhere gains the number as soon as the board names it.
+   *
+   * Absent for a topic no board has named, or one wired to no board: the
+   * lookup produces nothing and the property is simply not there. Every
+   * consumer treats that as no name — the badge renders nothing, a universe
+   * row matches no `#42` query, and a mention pill shows no number
+   * (`_trackRefShortName` in
+   * `packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts` reads an
+   * absent name exactly as it reads a blank one).
+   *
+   * Optional rather than defaulted, and the difference is the whole reason
+   * this projection still applies over a deployed board: this is what a
+   * board's stored list is validated against, and a defaulted property there
+   * moves the demand's defaults below an array constraint the compatibility
+   * proof cannot show stable under default insertion. */
+  shortName?: string;
 
   /** The living document, verbatim Markdown. `setBody` replaces it whole. */
   body: string | Default<"">;
@@ -669,8 +713,32 @@ export interface TopicOutput extends TopicPiece {
    */
   commentDraft: PerSession<Writable<string>>;
   bodyDraft: PerSession<Writable<string>>;
+
+  /**
+   * Whether the body editor is open.
+   *
+   * A bare session-scoped value rather than a cell-wrapped one, and that
+   * spelling costs a capability worth knowing about before reaching for it: a
+   * verb cannot take a whole Topic as captured state while any required
+   * property is published this way. The piece does not materialize through the
+   * verb's state schema, so the argument arrives undefined and the runtime
+   * declines to run the verb at all — "stream action argument is undefined
+   * (potential schema mismatch)", logged rather than thrown, with the write
+   * silently absent.
+   *
+   * Nothing needs that today. A board names a member by writing the piece into
+   * its namespace, and every path that does so builds the piece inside the
+   * verb (`addTopic`, the browser composer) or writes a list POSITION rather
+   * than a held piece (`backfillNames`). Cell-wrapping these two would buy the
+   * capability at the cost of a `scope changed` break on every deployed Topic,
+   * so it waits for a verb that needs it.
+   */
   editingBody: PerSession<boolean>;
   titleDraft: PerSession<Writable<string>>;
+
+  /** Whether the rename editor is open. Bare for the reason `editingBody`
+   * states, and the constraint is per property: cell-wrapping one and not the
+   * other buys nothing. */
   editingTitle: PerSession<boolean>;
   linkUrlDraft: PerSession<Writable<string>>;
   linkLabelDraft: PerSession<Writable<string>>;
@@ -1272,6 +1340,7 @@ export default pattern<TopicInput, TopicOutput>(
       references,
       mentioned,
       boardCrossrefs,
+      boardNames,
       [SELF]: self,
     },
   ) => {
@@ -1302,6 +1371,9 @@ export default pattern<TopicInput, TopicOutput>(
     const profileAvatar = profileWish.result?.avatar ?? "";
     const hasProfile = profileName.trim().length > 0;
     const createdByView = createdByOf({ createdBy });
+    // The board has already derived the table; this is a lookup by identity,
+    // and it is written as one.
+    const shortName = ownName({ table: boardNames, self });
 
     // --- Streams (external API; also usable headlessly via CLI) ---
 
@@ -1663,12 +1735,25 @@ export default pattern<TopicInput, TopicOutput>(
               )
               : (
                 <cf-hstack gap="2" justify="between" align="center">
-                  <cf-text
-                    block
-                    style="font-size: 1.25rem; font-weight: 600;"
+                  <cf-hstack
+                    gap="2"
+                    align="center"
+                    style="flex: 1; min-width: 0;"
                   >
-                    {topicName}
-                  </cf-text>
+                    {shortName
+                      ? (
+                        <cf-badge size="sm" color="primary" data-member-name="">
+                          {shortName}
+                        </cf-badge>
+                      )
+                      : null}
+                    <cf-text
+                      block
+                      style="font-size: 1.25rem; font-weight: 600;"
+                    >
+                      {topicName}
+                    </cf-text>
+                  </cf-hstack>
                   <cf-button
                     variant="ghost"
                     disabled={!hasProfile}
@@ -2020,6 +2105,7 @@ export default pattern<TopicInput, TopicOutput>(
       links,
       createdAt,
       createdBy: createdByView,
+      shortName,
       bodyUpdatedBy,
       bodyUpdatedAt,
       commentCount,

--- a/packages/patterns/topics/topics-rejections.test.tsx
+++ b/packages/patterns/topics/topics-rejections.test.tsx
@@ -2,20 +2,26 @@
  * Rejection-path tests for the Topics mutating verbs (verb contract rule 4,
  * docs/plans/pattern-verb-contract.md: rejection is a value, never a silent
  * no-op). Every action here makes a verb throw, so the runtime errors are
- * required (`expectRuntimeErrors: 34` — exact count, so a rejection quietly
+ * required (`expectRuntimeErrors: 35` — exact count, so a rejection quietly
  * reverting to a silent return fails the suite); each assertion then verifies
  * the write did NOT land. Happy and legacy paths live in topics.test.tsx — including the UI
  * composer wrappers, whose silent guards are correct behavior (an empty draft
  * is a non-event in a composer, not a headless mutation).
  */
-import { action, assert, TESTS, Writable } from "commonfabric";
+import { action, assert, type Default, TESTS, Writable } from "commonfabric";
 import { pattern } from "commonfabric";
-import Topics from "./main.tsx";
+import Topics, { type TopicDemand } from "./main.tsx";
 import Topic, { type TopicComment, type TopicLink } from "./topic.tsx";
 
 export default pattern(() => {
   const board = Topics({});
-  const legacyBoard = Topics({});
+  // Its list and namespace are held here so an UNNAMED topic can be filed
+  // straight into the list, past `addTopic`. Without one there is nothing a
+  // wrongly-running backfill could name, and the assertion that the namespace
+  // stayed empty would hold however the guard behaved.
+  const legacyTopics = new Writable<TopicDemand[] | Default<[]>>([]);
+  const legacyNames = new Writable<Record<string, unknown>>({});
+  const legacyBoard = Topics({ topics: legacyTopics, names: legacyNames });
 
   // One valid signed topic on the board, so `addTopic`'s own rejections have a
   // board to leave unchanged.
@@ -40,6 +46,28 @@ export default pattern(() => {
   });
   const action_add_blank_legacy_agent = action(() => {
     legacyBoard.addTopic.send({ title: "must not land", agentName: " " });
+  });
+
+  // One unnamed topic, filed straight into the list past `addTopic` and
+  // link-bound to the board's table — the state an operator leaves behind
+  // before a backfill. Both halves earn their place: without the topic there
+  // is nothing a backfill could name, and without the wiring its row reads no
+  // name whether one was written or not.
+  const action_file_an_unnamed_topic = action(() => {
+    legacyTopics.push(
+      Topic({
+        title: "Unnamed",
+        createdAt: 1,
+        boardNames: legacyBoard.namesTable,
+      }),
+    );
+  });
+
+  // backfillNames: blank agentName. It writes the namespace rather than a
+  // topic's content, and it is signed on the same terms — a run nobody signed
+  // is a mutation nobody is accountable for.
+  const action_backfill_unsigned = action(() => {
+    legacyBoard.backfillNames.send({ agentName: "   " });
   });
 
   // addComment: empty body; blank agentName.
@@ -362,13 +390,26 @@ export default pattern(() => {
 
   const assert_legacy_board_empty = assert(() => legacyBoard.topicCount === 0);
 
+  // The refused backfill wrote no name, which is the half a throw alone does
+  // not prove: the verb rejects before it reaches the namespace. The board
+  // holds one unnamed topic, link-bound to its table, so a backfill that ran
+  // would write `1` and the row would show it. Removing the verb's guard reds
+  // every clause here: the count moves only if the create's rejection also
+  // stopped landing, the namespace gains the key the run wrote, and the row
+  // follows the namespace through the member's own wiring.
+  const assert_unnamed_topic_went_unnamed = assert(() =>
+    legacyBoard.topicCount === 1 &&
+    Object.keys(legacyNames.get()).length === 0 &&
+    legacyBoard.index?.[0]?.shortName === undefined
+  );
+
   return {
     // Every rejection below MUST surface as a thrown handler error —
-    // thirty-four throwing actions, thirty-four runtime errors. The exact count
+    // thirty-five throwing actions, thirty-five runtime errors. The exact count
     // means a
     // single verb quietly reverting to a silent early-return fails this suite;
     // the no-write assertions then prove the throw also blocked the write.
-    expectRuntimeErrors: 34,
+    expectRuntimeErrors: 35,
     [TESTS]: [
       { action: action_seed_topic },
       { assertion: assert_seeded },
@@ -378,6 +419,9 @@ export default pattern(() => {
       { assertion: assert_board_unchanged },
       { action: action_add_blank_legacy_agent },
       { assertion: assert_legacy_board_empty },
+      { action: action_file_an_unnamed_topic },
+      { action: action_backfill_unsigned },
+      { assertion: assert_unnamed_topic_went_unnamed },
       { action: action_blank_comment },
       { assertion: assert_seed_topic_untouched },
       { action: action_comment_unsigned },

--- a/packages/patterns/topics/topics.test.tsx
+++ b/packages/patterns/topics/topics.test.tsx
@@ -21,13 +21,19 @@ import {
   Writable,
 } from "commonfabric";
 import { pattern } from "commonfabric";
-import Topics, {
+import {
+  type MentionableRow,
   mentionableRowsOf,
+} from "../collection-naming/mentionable.ts";
+import {
+  type NamesMap,
+  type NamesTableRow,
+} from "../collection-naming/naming.ts";
+import Topics, {
   mentionedBy,
   mentionListsOf,
   submitProfileTopic,
   type TopicCrossrefRow,
-  type TopicMentionableRow,
   type TopicPiece,
 } from "./main.tsx";
 import Topic, {
@@ -226,6 +232,12 @@ export default pattern(() => {
   const profileBoardCrossrefs = new Writable<TopicCrossrefRow[] | Default<[]>>(
     [],
   );
+  // The namespace and the table the composer is handed, standalone for the
+  // same reason: the composer allocates into the one and wires the other onto
+  // the topic it files, so a browser create is named exactly as a headless one
+  // is.
+  const profileBoardNames = new Writable<NamesTableRow[] | Default<[]>>([]);
+  const profileNames = new Writable<NamesMap>({});
   const profileTitleDraft = new Writable("Profile topic");
   const profileComments = new Writable<TopicComment[] | Default<[]>>([]);
   const profileCommentDraft = new Writable("via the profile composer");
@@ -266,6 +278,8 @@ export default pattern(() => {
     topics: profileTopics,
     mentionable: profileTopics,
     boardCrossrefs: profileBoardCrossrefs,
+    boardNames: profileBoardNames,
+    names: profileNames,
     newTitle: profileTitleDraft,
     profileName: " Ada ",
     profileAvatar: " 🦊 ",
@@ -505,6 +519,17 @@ export default pattern(() => {
       profileTitleDraft.get() === "";
   });
 
+  // The browser composer allocates out of the same namespace the headless
+  // create does, in the same transaction as its append: drop the allocation
+  // and the map stays empty while the topic still lands.
+  const assert_profile_topic_named = assert(() =>
+    Object.keys(profileNames.get()).join(",") === "1" &&
+    equals(
+      profileNames.get()["1"] as object,
+      profileTopics.key(0),
+    )
+  );
+
   const assert_profile_comment_submitted = assert(() => {
     const list = profileComments.get() ?? [];
     return list.length === 1 &&
@@ -719,9 +744,13 @@ export default pattern(() => {
   // The derivation's own rules, on sources a board cannot produce mid-run:
   // a mid-sync entry contributes no row, the display name falls back to the
   // persisted title until a topic derives its `[NAME]` (and past a blank
-  // one), and a row records its SOURCE as `piece` — identity, not a copy.
+  // one), the collection's name for a member is copied off the member's own
+  // and reads blank where it has none, and a row records its SOURCE as
+  // `piece` — identity, not a copy.
   const assert_mention_index_rows_pure = assert(() => {
-    const named = { get: () => ({ [NAME]: "Named", title: "Titled" }) };
+    const named = {
+      get: () => ({ [NAME]: "Named", title: "Titled", shortName: "42" }),
+    };
     const cold = {
       get: () => ({ [NAME]: undefined, title: "Cold title" }),
     };
@@ -733,19 +762,21 @@ export default pattern(() => {
     return rows.length === 3 &&
       rows[0]?.[NAME] === "Named" &&
       rows[0]?.title === "Titled" &&
+      rows[0]?.shortName === "42" &&
       rows[0]?.piece === named &&
       rows[1]?.[NAME] === "Cold title" &&
+      rows[1]?.shortName === "" &&
       rows[2]?.[NAME] === "Blank name" &&
       rows[2]?.piece === blankName;
   });
 
   // A topic accepts the index's rows as its mention universe — the exact
   // list the backfill rewires onto every existing topic. The consumer
-  // materializing proves the two-string demand validates a row list; the
+  // materializing proves the three-string demand validates a row list; the
   // read-back proves the row landed with its copies intact and its piece
   // still a reference, not a flattened copy of the cell.
   const rowPieceTarget = new Writable({ title: "Row piece target" });
-  const rowUniverse = new Writable<TopicMentionableRow[] | Default<[]>>([]);
+  const rowUniverse = new Writable<MentionableRow[] | Default<[]>>([]);
   const rowUniverseConsumer = Topic({
     title: "Row universe consumer",
     mentionable: rowUniverse,
@@ -754,12 +785,14 @@ export default pattern(() => {
     rowUniverse.push({
       [NAME]: "Seeded row",
       title: "Seeded row",
+      shortName: "7",
       piece: rowPieceTarget,
     });
   });
   const assert_row_universe_accepted = assert(() =>
     rowUniverse.get().length === 1 &&
     rowUniverse.get()[0]?.[NAME] === "Seeded row" &&
+    rowUniverse.get()[0]?.shortName === "7" &&
     equals(rowUniverse.get()[0]?.piece as object, rowPieceTarget) &&
     rowUniverseConsumer[NAME] === "Row universe consumer"
   );
@@ -1105,6 +1138,7 @@ export default pattern(() => {
       { assertion: assert_explicit_undefined_author_projection },
       { action: action_submit_profile_topic },
       { assertion: assert_profile_topic_submitted },
+      { assertion: assert_profile_topic_named },
       { action: action_submit_profile_comment },
       { assertion: assert_profile_comment_submitted },
       { action: action_save_profile_body },

--- a/scripts/topics-rehearsal-lib.test.ts
+++ b/scripts/topics-rehearsal-lib.test.ts
@@ -226,13 +226,28 @@ describe("topics-rehearsal-lib", () => {
     });
 
     it("routes known link fields aside instead of into the document", () => {
+      // Every wiring input the topic pattern declares, so a new one that never
+      // reached STRUCTURAL_LINK_SOURCES fails here rather than at a restore.
+
       const { doc, structural, legacy } = buildRestoreDocument(
-        { title: "t", mentionable: link, myName: link },
+        {
+          title: "t",
+          mentionable: link,
+          boardCrossrefs: link,
+          boardNames: link,
+          myName: link,
+        },
         resolved,
       );
-      expect(structural).toEqual(["mentionable"]);
+      expect(structural).toEqual([
+        "mentionable",
+        "boardCrossrefs",
+        "boardNames",
+      ]);
       expect(legacy).toEqual(["myName"]);
       expect(doc.mentionable).toBeUndefined();
+      expect(doc.boardCrossrefs).toBeUndefined();
+      expect(doc.boardNames).toBeUndefined();
       expect(doc.myName).toBeUndefined();
     });
 

--- a/scripts/topics-rehearsal-lib.ts
+++ b/scripts/topics-rehearsal-lib.ts
@@ -251,6 +251,10 @@ export interface TopicsExport {
  * one points at. A document write cannot carry a `$link`, so these are routed
  * aside and re-linked after the apply.
  *
+ * Three today: `mentionable` (the board's universe), `boardCrossrefs` (its
+ * reference pivot), and `boardNames` (its names table, which a topic reads its
+ * own member name out of).
+ *
  * Adding a wiring input to the topic pattern means adding it here. Leaving it
  * out is not silent: `buildRestoreDocument` throws on any link-valued field it
  * does not recognize, because writing one as data would corrupt it and
@@ -261,6 +265,7 @@ export interface TopicsExport {
 export const STRUCTURAL_LINK_SOURCES: Record<string, string> = {
   mentionable: "topics",
   boardCrossrefs: "crossrefs",
+  boardNames: "namesTable",
 };
 
 export const STRUCTURAL_LINK_FIELDS = Object.keys(STRUCTURAL_LINK_SOURCES);

--- a/scripts/topics-restore.ts
+++ b/scripts/topics-restore.ts
@@ -30,10 +30,11 @@
  * `cf piece link` against the board recorded in the export.
  *
  * Those wiring links are `STRUCTURAL_LINK_SOURCES`, which maps each one to
- * the board path it points at: `mentionable` to the board's `topics`, and
- * `boardCrossrefs` to its `crossrefs`. A link-valued field absent from that
- * map stops the restore rather than being guessed at, so a wiring input
- * added to the topic pattern announces itself here.
+ * the board path it points at: `mentionable` to the board's `topics`,
+ * `boardCrossrefs` to its `crossrefs`, and `boardNames` to its `namesTable`.
+ * A link-valued field absent from that map stops the restore rather than
+ * being guessed at, so a wiring input added to the topic pattern announces
+ * itself here.
  *
  * Four honest costs. Comment and link elements are re-written as plain
  * values, so their element entities are minted fresh: content, order,

--- a/skills/topics/SKILL.md
+++ b/skills/topics/SKILL.md
@@ -90,18 +90,19 @@ directly.
 
 The current declared contract is:
 
-| Piece | Verb            | Input                                           | Declared result       |
-| ----- | --------------- | ----------------------------------------------- | --------------------- |
-| Board | `addTopic`      | `title`, optional `body`, `agentName`           | created `topic`       |
-| Topic | `addComment`    | `body`, `agentName`                             | appended `comment`    |
-| Topic | `addLink`       | `url`, optional `kind` and `label`, `agentName` | appended `link`       |
-| Topic | `setBody`       | complete `body`, `agentName`                    | body and attribution  |
-| Topic | `setTitle`      | `title`, `agentName`                            | title and attribution |
-| Topic | `mention`       | Topic reference                                 | none                  |
-| Topic | `unmention`     | Topic reference                                 | none                  |
-| Topic | `editComment`   | comment reference, `body`, `agentName`          | body and `editedAt`   |
-| Topic | `removeComment` | comment reference, `agentName`                  | the retraction stamp  |
-| Topic | `removeLink`    | link reference **or** `url`, `agentName`        | url and stamp         |
+| Piece | Verb            | Input                                           | Declared result         |
+| ----- | --------------- | ----------------------------------------------- | ----------------------- |
+| Board | `addTopic`      | `title`, optional `body`, `agentName`           | created `topic`, `name` |
+| Board | `backfillNames` | `agentName`                                     | the names it wrote      |
+| Topic | `addComment`    | `body`, `agentName`                             | appended `comment`      |
+| Topic | `addLink`       | `url`, optional `kind` and `label`, `agentName` | appended `link`         |
+| Topic | `setBody`       | complete `body`, `agentName`                    | body and attribution    |
+| Topic | `setTitle`      | `title`, `agentName`                            | title and attribution   |
+| Topic | `mention`       | Topic reference                                 | none                    |
+| Topic | `unmention`     | Topic reference                                 | none                    |
+| Topic | `editComment`   | comment reference, `body`, `agentName`          | body and `editedAt`     |
+| Topic | `removeComment` | comment reference, `agentName`                  | the retraction stamp    |
+| Topic | `removeLink`    | link reference **or** `url`, `agentName`        | url and stamp           |
 
 A retraction stamps the record rather than deleting it: the comment or link
 stays, carrying what it always said, while readers stop showing it and
@@ -164,6 +165,46 @@ Input reads are the durable source of truth. Use `--step` for computed results
 such as the board's `index` and a Topic's `commentCount`, `lastActivityAt`,
 `mentions`, or `referencedBy`.
 
+## `top/42` — a Topic addressed by the board's name for it
+
+The board gives each Topic a name of its own: a decimal number, dense from `1`,
+allocated when the Topic is filed and never reused. It is not a display name — a
+Topic's display name stays its title, and the number renders as a badge beside
+it. `addTopic` returns the name it allocated as `name` beside the created
+`topic`, and each Topic publishes its own as `shortName`, which the board's
+`index` rows and mention universe carry a copy of. So a survey reads every name
+in one bounded read:
+
+```bash
+cf cell get "$TOPICS_BOARD" index --step --select @,title,shortName
+```
+
+The number is what a short reference is written with. Once the board's `names`
+map is bound as a slug, `<collection>/<member>` names a Topic wherever an
+address is taken — `cf cell get /@<space>/top/42 title`,
+`cf piece describe --cell /@<space>/top/42`,
+`cf piece call --cell /@<space>/top/42 setTitle '{...}'` — and exactly one
+segment reaches a member, so `/@<space>/top/42/title` is that Topic's `title`
+field. A name with no member after it is refused, naming the piece holding the
+collection; and `no member 999 in top` is the refusal for a member the board
+does not hold. `packages/cli/README.md` is the whole grammar, and
+`docs/specs/collection-naming.md` the design.
+
+A member name is the board's, not the fabric's: it means something only through
+the collection that issued it, so a citation carries the collection —
+`/@<space>/top/42`, never a bare `42`. A canonical `/of:` address remains the
+thing to pass in a reference position; the member name is for a person to read
+and type.
+
+**What the Estuary deployment carries.** The verbs and the naming above are what
+the pattern in this checkout declares. The deployed board runs whatever commit
+`/api/meta` reports, and until a pattern update lands there it has no `names`
+map, no `top` slug, and no named Topic — a Topic publishes no `shortName` and
+`/top/42` resolves to nothing. Ask the deployment before citing a number, and
+treat `top/42` as unavailable there until the plan's remaining step is done
+(`docs/plans/collection-naming-topics.md`). Deploying it and naming the Topics
+already on the board are the team's steps, not an agent's.
+
 ## Create and recover the address
 
 Mint one invocation session for the agent run. Replace every angle-bracketed
@@ -177,13 +218,22 @@ CREATE="$(cf piece call --cell "$TOPICS_BOARD" \
   --invocation '<unique-topic-create-id>' \
   addTopic \
   '{"title":"<title>","body":"<initial living document>","agentName":"Sol"}' \
-  -- --schema '{"properties":{"topic":{"$link":true}}}')"
+  -- --schema '{"properties":{"topic":{"$link":true},"name":{"type":"string"}}}')"
 TOPIC="$(printf '%s\n' "$CREATE" | jq -r '.result.topic["$link"] // empty')"
+NAME="$(printf '%s\n' "$CREATE" | jq -r '.result.name // empty')"
 ```
 
-When the result is present, carry `TOPIC` into the next command. Use JSON
-encoding or schema-derived flags for multiline Markdown; do not interpolate
-unescaped content into JSON.
+The projection names BOTH results, and that is load-bearing: a schema listing
+only `topic` drops `name` from the envelope, so `NAME` comes back empty and the
+allocated number is lost. Dropping the projection entirely returns the name and
+the whole created topic with it — a rendered view included, two orders of
+magnitude more payload — which is what the projection exists to avoid.
+
+When the result is present, carry `TOPIC` into the next command. `NAME` is the
+member name the board allocated — read it here rather than from the Topic's own
+`shortName`, which is a derivation that may not have produced a value when the
+call returns. Use JSON encoding or schema-derived flags for multiline Markdown;
+do not interpolate unescaped content into JSON.
 
 Current Estuary calls have a known observation asymmetry. `addTopic` has
 reported an error after committing and has reported success without committing.
@@ -271,6 +321,12 @@ source is a production migration over team-critical data. Before any `setsrc`,
 read `docs/development/space-clone-rehearsal.md` and the latest Topics migration
 record in `docs/history/topics-board-migration-2026-08-28.md`. Do not use
 `--dangerously-allow-incompatible-schema` without explicit team authorization.
+
+Pass `--root` at or above `packages/patterns` on every `piece new` and `setsrc`
+of the board or a Topic. Both import the member-naming library from a sibling
+directory, and the default program root is the entry's own directory, so without
+the flag every such import is refused as escaping the program root and the
+deploy fails before it reaches the server.
 
 Do not substitute `piece ls` for the board index: handler-created Topics need
 not appear in the registry. If a deployed field or verb differs from this map,


### PR DESCRIPTION
## Why

The member namespace has been built and proven on a parallel exemplar for
exactly this moment: Topics gets named members in one graft, from a design
that has already been through five merged stages, rather than being edited
repeatedly while the design settled.

This is S6 items 1, 2, 3 and 5. **Item 4 — the production backfill — is
deliberately not here**, and the reason has grown since the plan was written.

## What changed

- **`topics/main.tsx` adopts `naming.ts`.** `assignName` runs inside
  `addTopic` in the same transaction as the append; `names`, `namesTable` and
  `naming: SEQUENCE_NAMING` are published, and a `backfillNames` verb exists.
  The browser composer allocates through the same call.
- **`topics/topic.tsx` gains the item-side display** — `shortName` on
  `TopicPiece`, and a badge beside (never in place of) the title.
- **The mention fork ends.** `mentionableRowsOf` and `mentionableIndex` had
  forked between the exemplar and Topics, differing only by `shortName`. The
  survivor is Topics' pair, moved to
  `packages/patterns/collection-naming/mentionable.ts` so that neither board
  imports the other — a pattern module carries its imports into its own
  compiled program, so either board importing the other would ship the whole
  of it. It is not in `naming.ts` because that module's stated invariant is
  that it never reads through a member, and this derivation reads three
  display strings off each one.
- **`skills/topics/SKILL.md`** documents `top/42` addressing.

## What the rehearsal could not have predicted

Board-side, the graft was verbatim. Four things only the real shape showed:

1. **`TopicPiece.shortName` needs `Default<"">`.** Without it, one
   legacy-vintage sibling makes the whole `mentionable` array unreadable —
   on the deployed board every existing topic would have broken the list,
   not merely gone nameless.
2. `TopicMentionable.shortName` needs `| undefined` beside the default,
   because Topics documents that a plain topics list satisfies the universe
   demand.
3. **The `PerSession` requirement does not fire on the create path.**
   `addTopic` works with the bare form because it builds its piece inside the
   verb. It fires when a verb writes a Topic it did *not* build into the
   namespace: the whole output becomes the action's captured state, a bare
   `PerSession<boolean>` does not materialize, and the runtime logs a schema
   mismatch and **silently skips the write**. Two fields, measured three ways.
4. The contract breaks below.

## There is no deployment gate — an earlier draft of this said otherwise

An earlier version of this description claimed three contract breaks had no
pattern-side fix, and that deploying therefore needed
`--dangerously-allow-incompatible-schema` and the team authorization the
Topics skill requires for it. **That was wrong, and the error was one
untried spelling.**

`shortName?:` — the optional-property form, rather than the defaulted or
`| undefined` forms that were tried — clears the first break. Following it
through clears the other two: making the shared lift's demand optional
clears the second, and reverting the `PerSession` wrap clears the third.

`pattern-compat` is clean against every recorded baseline: **no accepted
break, no exemption, no dangerous flag, no authorization needed.** The
accepted-breaks registry and the history index are byte-identical to main.

The third break is worth naming, because it was kept on a false premise:
"the other two are unavoidable, so this one costs nothing extra." That
premise was load-bearing and never tested on its own. Measured since, no
product path needs the wrap — `addTopic` and the composer build the piece
inside the verb.

## What the deploy does need

`--root` at or above `packages/patterns`. Not a gate, a flag — but a
required one, and it was found by a real failure rather than by review.

CI's topics restore drill failed with `board deploy printed no fid`. The
board's new cross-directory import escapes the program root, because
`resolveLocalProgram` defaults the root to the entry's own directory. The
browser lane passes an explicit root and so never saw it; the documented
production `setsrc` does not, so a real Topics deploy would have hit the
same refusal. Fixed in the drill, stated in `skills/topics/SKILL.md`, and
recorded in the plan's item 4.

A second defect sat behind it, reachable only once the deploy worked:
`boardNames` is a wiring input and was missing from the restore's
known-link table, whose own doc comment says that adding a wiring input
means adding it there.

## What this cost

One assertion. With the `PerSession` wrap reverted, a verb can no longer
take a held Topic as captured state, so the topic header badge's positive
case is not reachable in the pattern lane — 16 assertions to 14, and one
mutation that previously red now survives. The test file's header states
the claim, why it is out of reach, and that it belongs in the browser lane
beside the shell integration test that reads the exemplar member's badge
the same way.

