### PR TITLE
feat(ci): one planner for the full run and the selected run

### DIFF
--- a/docs/development/test-selection.md
+++ b/docs/development/test-selection.md
@@ -98,10 +98,11 @@ way a change's lanes do, so nothing about which tests run travels through
 a job output.
 
 Run it yourself to see how many jobs the default branch would take. Where
-nothing in the tree has a measured cost it answers with the number of
-suites that have anything to run and says on the error stream that it did
-so, since a projection from costs nobody has measured would be arithmetic
-over an invented figure.
+nothing in the tree has a measured cost it answers from the shape of the
+tree instead — the larger of the number of suites with anything to run
+and the number of lanes the units would fill at the stand-in rate — and
+says on the error stream that it did so, since a projection from costs
+nobody has measured would be arithmetic over an invented figure.
 
 ## The publisher
 

--- a/docs/development/test-selection.md
+++ b/docs/development/test-selection.md
@@ -100,9 +100,9 @@ a job output.
 Run it yourself to see how many jobs the default branch would take. Where
 nothing in the tree has a measured cost it answers from the shape of the
 tree instead — the larger of the number of suites with anything to run
-and the number of lanes the units would fill at the stand-in rate — and
-says on the error stream that it did so, since a projection from costs
-nobody has measured would be arithmetic over an invented figure.
+and what packing the stand-ins asks for — and says on the error stream
+that it did so, since a projection from costs nobody has measured would
+be arithmetic over an invented figure.
 
 ## The publisher
 

--- a/docs/development/test-selection.md
+++ b/docs/development/test-selection.md
@@ -64,15 +64,44 @@ and "what am I being compared against?".
 
 ### `plan --dry-run [--lane N]`
 
-What would run, and what it would cost: how many identities the store
-knows, how many are withheld, and per lane the number of tests, the
+What would run, and what it would cost: how many identities this tree
+holds, how many are withheld, and per lane the number of tests, the
 projected seconds against the budget, the capabilities it would open, and
 a count by why each test was chosen. Given a lane number it answers "what
 would lane three do?", and given none it prints all of them.
 
+The count is of this tree rather than of the manifest, because those are
+different numbers and the plan beneath it is over the first. A manifest is
+hours old, so it names units the tree has since dropped and misses units
+the tree has since gained; the reconciliation of the two is what gets
+packed, and it is what is counted here.
+
 `--verify` compares the identity set the topology produces against what a
-recorded run actually executed. It needs the topology, which is not in the
-tree yet, and says so rather than pretending.
+recorded run actually executed, in both directions: identities a run
+produced that no suite claims, and units the topology enumerates that the
+run never recorded.
+
+### How many lanes the run on the default branch uses
+
+A change's tests are packed into a fixed number of lanes, `LANES`. The run
+on the default branch cannot be, because how much work there is decides
+how many lanes it needs and the job matrix has to exist before anything
+starts. So one job asks:
+
+```
+deno run -A tasks/ci-lane.ts --full --lane-count
+```
+
+and it answers with an integer and nothing else. The lanes then read the
+same tree against the same manifest and work out their own shares, the
+way a change's lanes do, so nothing about which tests run travels through
+a job output.
+
+Run it yourself to see how many jobs the default branch would take. Where
+nothing in the tree has a measured cost it answers with the number of
+suites that have anything to run and says on the error stream that it did
+so, since a projection from costs nobody has measured would be arithmetic
+over an invented figure.
 
 ## The publisher
 

--- a/docs/plans/pull-request-test-selection.md
+++ b/docs/plans/pull-request-test-selection.md
@@ -2314,9 +2314,10 @@ drift.
 
 The full run's packing needs durations but no selection, so it reads the
 manifest for its cost table. Where nothing in the tree has a measured
-cost it falls back to one lane per suite that has anything to run: less
-even, still complete, and requiring no committed weight table to
-maintain.
+cost it falls back to the shape of the tree: the larger of one lane per
+suite that has anything to run, and one lane per budget's worth of units
+at the stand-in rate. Less even, still complete, and requiring no
+committed weight table to maintain.
 
 The condition is what the tree holds rather than whether a manifest
 arrived, because those are not the same question. A manifest published
@@ -2332,8 +2333,16 @@ figure puts the whole corpus at 2,403 seconds where the reference build
 measured 9,960, and the count that follows from it is five lanes for a
 run that today takes 67 jobs. The error is also in the direction that
 breaks a run: too few lanes means every one of them runs past the bound
-its job is killed at, where too many means some jobs finish early. So the shape of the topology answers instead. It needs no
-number nobody measured, and it is a bound rather than a plan — the lanes
+its job is killed at, where too many means some jobs finish early.
+
+So the shape of the tree answers instead, in two figures that can only
+raise the count between them. The suite count grows as test surfaces are
+added. The unit count grows as units are added to the suites there
+already are, which the suite count alone would not notice: a repository
+that grew to five times the units without gaining a suite would
+otherwise be given the same number of lanes. Neither figure is a
+projection, both are counted off the tree, and taking the larger errs
+the way this has to err. It is a bound rather than a plan — the lanes
 still pack themselves, and one of them may hold several suites.
 
 A lane packing against stand-in costs says so in its summary, for the

--- a/docs/plans/pull-request-test-selection.md
+++ b/docs/plans/pull-request-test-selection.md
@@ -2314,10 +2314,9 @@ drift.
 
 The full run's packing needs durations but no selection, so it reads the
 manifest for its cost table. Where nothing in the tree has a measured
-cost it falls back to the shape of the tree: the larger of one lane per
-suite that has anything to run, and one lane per budget's worth of units
-at the stand-in rate. Less even, still complete, and requiring no
-committed weight table to maintain.
+cost it falls back to the larger of one lane per suite that has anything
+to run and what packing the stand-ins asks for. Less even, still
+complete, and requiring no committed weight table to maintain.
 
 The condition is what the tree holds rather than whether a manifest
 arrived, because those are not the same question. A manifest published
@@ -2335,15 +2334,21 @@ run that today takes 67 jobs. The error is also in the direction that
 breaks a run: too few lanes means every one of them runs past the bound
 its job is killed at, where too many means some jobs finish early.
 
-So the shape of the tree answers instead, in two figures that can only
-raise the count between them. The suite count grows as test surfaces are
-added. The unit count grows as units are added to the suites there
-already are, which the suite count alone would not notice: a repository
-that grew to five times the units without gaining a suite would
-otherwise be given the same number of lanes. Neither figure is a
-projection, both are counted off the tree, and taking the larger errs
-the way this has to err. It is a bound rather than a plan — the lanes
-still pack themselves, and one of them may hold several suites.
+So a lane per suite with anything to run goes in as a floor. It needs no
+number nobody measured, and it grows as test surfaces are added.
+
+The packing is still asked what it would need, and the larger of the two
+wins. Its answer is only as good as the stand-in costs behind it, which
+is why it cannot be the whole of this — but those costs are what the
+lanes will actually be packed against, so an answer below what they
+imply is one the lanes cannot honor whatever else is true. That matters
+most where a stand-in costs more than the bare unmeasured figure. A
+suite whose measured units have all been renamed away carries its old
+median onto every stand-in, and a count that assumed the bare figure
+would be out by that whole multiple.
+
+What comes out is a bound rather than a plan: the lanes still pack
+themselves, and one of them may hold several suites.
 
 A lane packing against stand-in costs says so in its summary, for the
 same reason: a projected time that rests on nothing measured is a

--- a/docs/plans/pull-request-test-selection.md
+++ b/docs/plans/pull-request-test-selection.md
@@ -1892,7 +1892,19 @@ The full run on `main` does have a planning job before its lanes,
 `plan-full`, because there the number of lanes is not fixed and GitHub
 needs the matrix before it can start anything. A pull request needs no
 planning job because `LANES` is a constant, so each lane can work out its
-own share.
+own share. What `plan-full` decides is the lane count and nothing else,
+so `main`'s lanes work out their own shares the same way a pull request's
+do.
+
+What the two runs do differ in is two values handed to the same
+function: the policy, which is `everything` for the full run and
+`budgeted` for a pull request, and the diff, which the full run does not
+have. Under `everything` every identity is required, so the exclusions
+and the value, density and exploration passes have nothing to act on and
+the rest of the packer behaves identically for both. Holding the
+difference to those two values is what stops the two runs drifting into
+enumerating different tests, applying a suite's settings unevenly, or
+packing the same work in reliably different orders.
 
 The function must therefore be deterministic: no wall clock, no unseeded
 randomness, no dependence on anything but its inputs. The exploration
@@ -2242,10 +2254,18 @@ What the runner does, in order:
    the attribution map that manifest names. No manifest at or before that
    date, or a fetch failure, takes the fallback (see [Failure
    modes](#failure-modes)).
-2. Enumerate every suite against the working tree.
+2. Enumerate every suite against the working tree, and read the manifest
+   against that enumeration. The tree decides which tests exist and the
+   manifest decides what each is worth and costs, so an entry naming a
+   unit the tree no longer has drops out and a unit the manifest has
+   never seen gains a stand-in. Everything after this reads the result
+   rather than the manifest the store gave, which is what keeps the full
+   run and a pull request working from one answer about what exists.
 3. Compute the diff against the merge base, and resolve the changed source
-   lines through the attribution map to the items that execute them.
-4. Call `plan()`, take this lane's plan.
+   lines through the attribution map to the items that execute them. The
+   full run skips this: it has no diff.
+4. Call `plan()`, take this lane's plan. The full run calls it with the
+   `everything` policy and this is the only place the two differ.
 5. Print the plan to the job summary: which batches, which items, what
    each is expected to cost, why each was chosen, which items were
    withheld and why, and which manifest the plan came from.
@@ -2267,18 +2287,58 @@ What the runner does, in order:
 A push to `main` still runs everything, and it runs it through the same
 topology so that the two paths cannot drift.
 
-`deno.yml` gains a small `plan-full` job that runs on push, calls the
-topology, packs every item into as many lanes as a ten-minute budget
-needs, and emits the result as a job output. A `full-tests` job consumes
-it with `strategy.matrix: fromJSON(...)` and runs the same
-`tasks/ci-lane.ts` with `--full`. The build, attestation, coverage and
-deploy jobs keep their present shape and depend on `full-tests` in place
-of the long dependency lists they carry today.
+`deno.yml` gains a small `plan-full` job that runs on push and emits one
+integer: how many lanes the run needs. It gets that from `deno run -A
+tasks/ci-lane.ts --full --lane-count`, which reads the working tree
+against the manifest and raises the lane count while that reduces the
+total by which the lanes are over the full run's budget. The total
+rather than the worst lane: one test costing more than a whole lane
+holds its own lane over budget at every count, so a search reading the
+worst lane would stop at the first step and leave every other lane
+packed far tighter than the budget it was given.
+
+A `full-tests` job consumes the integer with `strategy.matrix:
+fromJSON(...)` and runs the same `tasks/ci-lane.ts` with `--full`. The
+build, attestation, coverage and deploy jobs keep their present shape
+and depend on `full-tests` in place of the long dependency lists they
+carry today.
+
+An integer is deliberately the whole of what passes from the planning job
+to the lanes. Each lane reads the same tree against the same manifest and
+computes the same packing for itself, exactly as the pull-request lanes
+do, so nothing about which tests run travels through a job output and
+there is no second packing anywhere to disagree with theirs. A planning
+job that emitted the packing would be a second planner, and the two would
+drift.
 
 The full run's packing needs durations but no selection, so it reads the
-manifest for its cost table. When the store is unreachable it falls back
-to one lane per suite: less even, still complete, and requiring no
-committed weight table to maintain.
+manifest for its cost table. Where nothing in the tree has a measured
+cost it falls back to one lane per suite that has anything to run: less
+even, still complete, and requiring no committed weight table to
+maintain.
+
+The condition is what the tree holds rather than whether a manifest
+arrived, because those are not the same question. A manifest published
+before most of a tree existed arrives and still knows almost none of it,
+and a cost model reading that one is as blind as a cost model reading
+nothing at all.
+
+The fallback is a count rather than a cost model on purpose. Where
+nothing is measured, a projection from costs is arithmetic over whatever
+figure stands in for the ones nobody measured, and it is wrong by
+however wrong that figure is. Against this repository the stand-in
+figure puts the whole corpus at 2,403 seconds where the reference build
+measured 9,960, and the count that follows from it is five lanes for a
+run that today takes 67 jobs. The error is also in the direction that
+breaks a run: too few lanes means every one of them runs past the bound
+its job is killed at, where too many means some jobs finish early. So the shape of the topology answers instead. It needs no
+number nobody measured, and it is a bound rather than a plan — the lanes
+still pack themselves, and one of them may hold several suites.
+
+A lane packing against stand-in costs says so in its summary, for the
+same reason: a projected time that rests on nothing measured is a
+different thing from one that rests on a week of records, and the job
+summary is where somebody finds out which they are reading.
 
 Before the pull-request path replaces the old matrix, `main` must complete
 at least one successful full run whose records account for every item the
@@ -3048,7 +3108,8 @@ tape measure.
 | `LANE_BOUND_SECONDS` | 300 | seconds | Chosen | Up when more should fit in a lane; down when five minutes is longer than anybody will wait for a first answer. Either way `LANE_WORK_TIMEOUT_MINUTES` and `LANE_JOB_TIMEOUT_MINUTES` in `deno.yml` move with it. |
 | `LANE_PROLOGUE_SECONDS` | 40 | seconds | Measured | Never. The publisher overwrites it from the lanes' own timing records, and the checked-in figure is only what the first lane uses before any lane has reported one. |
 | `LANE_SAFETY_SECONDS` | 30 | seconds | Chosen | Up when lanes overrun their bound on slow runners; down when they finish early every time and the headroom is buying nothing. |
-| `FULL_LANE_BUDGET_SECONDS` | 600 | seconds | Chosen | Up when `main`'s run uses more jobs than it needs; down when `main` takes too long to say something broke. |
+| `FULL_LANE_BOUND_SECONDS` | 600 | seconds | Chosen | Up when `main`'s run uses more jobs than it needs; down when `main` takes too long to say something broke. |
+| `FULL_LANE_BUDGET_SECONDS` | 530 | seconds | Derived | Nothing edits this. It is the full run's bound less the same prologue and safety margin a pull request's lane pays, since a lane of either run is the same job doing the same setup on the same runner. |
 | `FULL_RUN_LABEL` | `ci: full` | a label | Chosen | Not a quantity. Change it only if the label collides with one the repository already uses for something else. |
 | `VALUE_FLOOR` | 0.05 | score | Chosen | Up when the cheap tail is not being swept up; down when it crowds out tests with a record of catching things. |
 | `WEIGHT_PROVEN` | 0.55 | share of the score | Chosen | Up when a record of catching things should count for more. The three weights are shares of one score, so what this gains the other two lose. |

--- a/docs/plans/pull-request-test-selection.md
+++ b/docs/plans/pull-request-test-selection.md
@@ -2265,7 +2265,8 @@ What the runner does, in order:
    lines through the attribution map to the items that execute them. The
    full run skips this: it has no diff.
 4. Call `plan()`, take this lane's plan. The full run calls it with the
-   `everything` policy and this is the only place the two differ.
+   `everything` policy, and with the empty diff step 3 left it. Those two
+   values are the whole of the difference between the two runs.
 5. Print the plan to the job summary: which batches, which items, what
    each is expected to cost, why each was chosen, which items were
    withheld and why, and which manifest the plan came from.
@@ -3093,14 +3094,18 @@ test's score and `FILL_DENSITY_SHARE` is a share of a lane's budget. A
 share of an item's runs reads the same way again. Naming the unit is what
 keeps them from being compared to each other.
 
-The **Set by** column separates the two kinds. A **chosen** value is a
+The **Set by** column separates three kinds. A **chosen** value is a
 decision somebody made, and editing it is how the decision changes. A
 **measured** value is worked out from the data and written back by the
 publisher, so the number in the file is only the seed used before there is
 anything to measure, and editing it changes nothing after the first
-publisher run. The distinction matters because the two look identical in a
-source file, and somebody who tunes a measured value is arguing with a
-tape measure.
+publisher run. A **derived** value is computed from other dials and has no
+expression of its own to edit: each lane budget is its run's bound less
+the prologue and the safety margin, so a budget that does not fit inside
+its own bound cannot be written down. The distinction matters because all
+three look identical in a source file, and somebody who tunes a measured
+value is arguing with a tape measure while somebody who tries to tune a
+derived one is editing a line that is not there.
 
 | Dial | Default | Units | Set by | Why you would move it, and which way |
 | --- | --- | --- | --- | --- |

--- a/docs/specs/test-selection.md
+++ b/docs/specs/test-selection.md
@@ -193,8 +193,20 @@ A manifest is **untrusted input**. It is validated whole, and one bad
 field rejects the object rather than leaving a consumer obeying half of
 it. A manifest whose schema version a reader does not know is treated as
 absent, because a reader that does not know a field cannot know what
-obeying the rest would mean. A consumer that finds no manifest runs the
-mandatory set and a deterministic slice of the corpus rather than failing.
+obeying the rest would mean.
+
+A consumer that finds no manifest runs rather than failing. Nothing then
+has records, so every unit the tree holds is an identity with none, and
+the rule that such an identity must run makes the whole corpus mandatory.
+What a consumer must not do in that state is project from costs. Every
+cost is a stand-in, so a projection is arithmetic over whatever figure
+stands in for the ones nobody measured and is wrong by however wrong that
+figure is; a consumer deciding how many lanes to divide the work into
+takes the shape of the topology instead. The same holds for a manifest
+that arrives and knows none of the tree, which is why the question is
+whether anything is measured rather than whether a manifest was found. A
+consumer that reports a projected time says how much of it rests on
+stand-ins.
 
 That the manifest may be an ordinary public object rather than a signed
 artifact follows from what it can do. It can only change *which* tests
@@ -220,11 +232,30 @@ writing one unasked is not.
 ## Determinism
 
 The packing function is pure. No clock, no unseeded randomness, no
-dependence on anything but the manifest, the diff, and the lane number.
-That is what lets every lane compute its own share and agree with the
-others by construction. The exploration draw's seed comes from the
-manifest, so the draw is the same in every lane and different between
-manifests.
+dependence on anything but the working tree, the manifest, the diff, the
+policy, and the lane number. That is what lets every lane compute its own
+share and agree with the others by construction. The exploration draw's
+seed comes from the manifest, so the draw is the same in every lane and
+different between manifests.
+
+The tree is an input alongside the manifest because the two answer
+different questions. The tree says which tests exist, and the manifest
+says what each of them is worth and costs; a manifest is hours old by
+construction, so an entry naming a unit the tree no longer holds is work
+no lane can be asked to do, and a unit the tree has gained is work no
+manifest can price. A consumer reconciles the two before packing, and
+packs what the reconciliation produced.
+
+The policy is an input because one function serves both the run on the
+default branch and the run on a change. It takes two values. The budgeted
+policy spends a bounded amount on the tests worth the most, by the rules
+under [what must run](#what-must-run-and-what-must-not) and the score
+above them. The full policy requires every identity, so the two rules
+that keep a test out have nothing to act on and the discretionary part of
+the packing finds nothing left to take; everything after that behaves the
+same for both. A consumer that packs the two runs through different code
+will drift, and what it drifts into is running different sets of tests in
+the two places that are meant to agree.
 
 Before the lanes start, a selector calls a trusted reusable workflow by its
 default-branch ref. The reusable workflow checks out no repository code and

--- a/tasks/ci-lane.test.ts
+++ b/tasks/ci-lane.test.ts
@@ -35,6 +35,7 @@ import {
   FULL_LANE_BOUND_SECONDS,
   FULL_LANE_BUDGET_SECONDS,
   LANE_BUDGET_SECONDS,
+  UNMEASURED_COST_SECONDS,
 } from "./test-selection/policy.ts";
 
 /**
@@ -571,6 +572,30 @@ describe("how many lanes the full run asks for", () => {
     }
     expect(lanes).toBe(2);
     expect(errors.join("\n")).toContain("measured");
+  });
+
+  it("grows the fallback with the units, not only with the suites", async () => {
+    // A repository can gain units without gaining a suite, and the suite
+    // count alone would not notice. Two suites here hold more units than
+    // two lanes can, so the count comes from the units instead.
+    const perLane = Math.floor(
+      FULL_LANE_BUDGET_SECONDS / UNMEASURED_COST_SECONDS,
+    );
+    const suites = [0, 1].map((i) =>
+      suite({
+        id: `suite-${i}`,
+        units: Array.from(
+          { length: perLane + 40 },
+          (_, u) => `s${i}/unit-${u}.test.ts`,
+        ),
+      })
+    );
+    const lanes = await fullLanes(options, {
+      topology: () => Promise.resolve(suites),
+      manifest: () => Promise.resolve({ absent: "the store is gone" }),
+    });
+    expect(lanes).toBeGreaterThan(suites.length);
+    expect(lanes).toBe(Math.ceil((perLane + 40) * 2 / perLane));
   });
 
   it("takes the topology's shape when there is no manifest", async () => {

--- a/tasks/ci-lane.test.ts
+++ b/tasks/ci-lane.test.ts
@@ -13,19 +13,29 @@ import {
   describeConflicts,
   describePlan,
   describeWithheld,
-  everyBatch,
+  fullLanes,
   main,
-  mandatoryFor,
   manifestMoment,
   parseLaneArgs,
   runBatch,
   runInvocation,
   runLane,
   spoolRecords,
-  unknownIdentity,
 } from "./ci-lane.ts";
+import { capabilitiesBySuite } from "./test-topology.ts";
+import { census } from "./test-selection/census.ts";
 import type { Suite } from "./test-topology/suite.ts";
+import {
+  plan,
+  type Selection,
+  type SelectionReason,
+} from "./test-selection/plan.ts";
 import type { Manifest, ManifestEntry } from "./test-selection/manifest.ts";
+import {
+  FULL_LANE_BOUND_SECONDS,
+  FULL_LANE_BUDGET_SECONDS,
+  LANE_BUDGET_SECONDS,
+} from "./test-selection/policy.ts";
 
 /**
  * The repository, found from this file rather than from the process's
@@ -104,13 +114,19 @@ describe("reading the lane's command line", () => {
     expect(parseLaneArgs(["--lane", "0", "--of", "5"])).toBeUndefined();
   });
 
+  it("refuses to count lanes for a run that is not the full one", () => {
+    // Only `main` works its lane count out; a pull request's is a dial.
+    expect(parseLaneArgs(["--lane-count"])).toBeUndefined();
+    expect(parseLaneArgs(["--full", "--lane-count"])?.laneCount).toBe(true);
+  });
+
   it("refuses a flag it does not know", () => {
     expect(parseLaneArgs(["--shard", "1/5"])).toBeUndefined();
   });
 });
 
 describe("the moment a lane resolves its manifest at", () => {
-  const lane = { lane: 1, of: 5, full: false, dryRun: false };
+  const lane = { lane: 1, of: 5, full: false, dryRun: false, laneCount: false };
 
   /** A repository whose one commit was made at a moment a case chose. */
   async function repository(committed: string): Promise<string> {
@@ -173,140 +189,6 @@ describe("the moment a lane resolves its manifest at", () => {
     const moment = await manifestMoment({ ...lane, root });
     expect(moment.note).toContain("cannot read the commit's date");
     expect(Number.isNaN(new Date(moment.at).getTime())).toBe(false);
-  });
-});
-
-describe("what a lane must run whatever the score says", () => {
-  const bakery = suite({
-    id: "workspace-unit",
-    units: ["packages/bakery/glaze.test.ts", "packages/bakery/proof.test.ts"],
-  });
-
-  it("runs a unit no manifest has ever seen", () => {
-    const manifest = manifestOf([{}]);
-    const { mandatory, unknown } = mandatoryFor([bakery], manifest, new Set());
-    const key = testIdentityKey(
-      unknownIdentity(bakery, "packages/bakery/proof.test.ts"),
-    );
-    expect(mandatory.get(key)).toBe("unknown");
-    expect(unknown.get(key)).toEqual({
-      suite: "workspace-unit",
-      unit: "packages/bakery/proof.test.ts",
-    });
-  });
-
-  it("runs every unit when there is no manifest at all", () => {
-    const { mandatory } = mandatoryFor([bakery], undefined, new Set());
-    expect(mandatory.size).toBe(2);
-    expect([...mandatory.values()]).toEqual(["unknown", "unknown"]);
-  });
-
-  it("runs the identities of a unit the change touched", () => {
-    const manifest = manifestOf([
-      {},
-      { test: { k: "unit", s: "bakery", n: "glaze > browns" } },
-    ]);
-    const { mandatory } = mandatoryFor(
-      [bakery],
-      manifest,
-      new Set(["packages/bakery/glaze.test.ts"]),
-    );
-    expect(
-      mandatory.get(
-        testIdentityKey({ k: "unit", s: "bakery", n: "glaze > sets" }),
-      ),
-    ).toBe("changed");
-    expect(
-      mandatory.get(
-        testIdentityKey({ k: "unit", s: "bakery", n: "glaze > browns" }),
-      ),
-    ).toBe("changed");
-  });
-
-  it("asks a suite which of its units a change reaches", () => {
-    // A unit that is not a path — a type-check group, a binary — is one
-    // only its suite can map the diff onto, so the suite is asked rather
-    // than the diff being matched against the unit's name.
-    const binaries = suite({
-      id: "binaries",
-      mandatory: "changed",
-      recordSurfaces: [{ kind: "gate", scope: "repo" }],
-      units: ["toolshed", "cf"],
-      unitsForChange: (changed) =>
-        changed.has("packages/shell/index.ts") ? ["toolshed"] : [],
-    });
-    const manifest = manifestOf([
-      {
-        test: { k: "gate", s: "repo", n: "build-binary toolshed" },
-        suite: "binaries",
-        unit: "toolshed",
-      },
-      {
-        test: { k: "gate", s: "repo", n: "build-binary cf" },
-        suite: "binaries",
-        unit: "cf",
-      },
-    ]);
-    const { mandatory } = mandatoryFor(
-      [binaries],
-      manifest,
-      new Set(["packages/shell/index.ts"]),
-    );
-    expect(
-      mandatory.get(
-        testIdentityKey({ k: "gate", s: "repo", n: "build-binary toolshed" }),
-      ),
-    ).toBe("changed");
-    expect(
-      mandatory.get(
-        testIdentityKey({ k: "gate", s: "repo", n: "build-binary cf" }),
-      ),
-    ).toBeUndefined();
-  });
-
-  it("runs every unit of a suite marked always", () => {
-    const gates = suite({
-      id: "repo-gates",
-      mandatory: "always",
-      recordSurfaces: [{ kind: "gate", scope: "repo" }],
-      units: ["deno-fmt"],
-    });
-    const manifest = manifestOf([{
-      test: { k: "gate", s: "repo", n: "deno-fmt" },
-      suite: "repo-gates",
-      unit: "deno-fmt",
-    }]);
-    const { mandatory } = mandatoryFor([gates], manifest, new Set());
-    expect([...mandatory.values()]).toEqual(["always"]);
-  });
-
-  it("says nothing about a unit a configuration declares unavailable", () => {
-    const on = suite({
-      id: "package-integration-on",
-      variant: "server-execution",
-      units: ["packages/oven/a.test.ts"],
-      unavailable: [{
-        unit: "packages/oven/a.test.ts",
-        reason: "the surface it exercises has not landed",
-      }],
-    });
-    expect(mandatoryFor([on], undefined, new Set()).mandatory.size).toBe(0);
-  });
-
-  it("keeps a unit whose unavailability names only one leaf", () => {
-    // Every other identity in the file still runs, so taking the file
-    // out would stop far more than the configuration asked to stop.
-    const on = suite({
-      id: "package-integration-on",
-      variant: "server-execution",
-      units: ["packages/oven/a.test.ts"],
-      unavailable: [{
-        unit: "packages/oven/a.test.ts",
-        leafName: "bakes > slowly",
-        reason: "the surface that step exercises has not landed",
-      }],
-    });
-    expect(mandatoryFor([on], undefined, new Set()).mandatory.size).toBe(1);
   });
 });
 
@@ -390,24 +272,104 @@ describe("turning a lane's selections into batches", () => {
   });
 });
 
-describe("running everything", () => {
-  it("gives each lane its own share and no unit twice", () => {
-    const suites = [
-      suite({
-        id: "workspace-unit",
-        units: ["a.test.ts", "b.test.ts", "c.test.ts", "d.test.ts"],
-      }),
-    ];
-    const lanes = [1, 2, 3].map((lane) => everyBatch(suites, lane, 3));
-    const placed = lanes.flatMap((batches) =>
-      batches.flatMap((batch) => batch.units.map((unit) => unit.unit))
+/** Every unit each lane of a plan would run, in lane order. */
+function unitsPerLane(
+  suites: readonly Suite[],
+  manifest: Manifest | undefined,
+  lanes: number,
+  policy?: "everything",
+): string[][] {
+  const seen = census(suites, manifest, new Set());
+  const laid = plan({
+    manifest: seen.manifest,
+    mandatory: seen.mandatory,
+    capabilities: capabilitiesBySuite(suites),
+    lanes,
+    ...(policy === undefined ? {} : { policy }),
+  });
+  return laid.lanes.map((lane) =>
+    batchesOf(suites, seen.manifest, lane.selections)
+      .flatMap((batch) => batch.units.map((unit) => unit.unit))
+      .toSorted()
+  );
+}
+
+describe("the order a runner is handed its work in", () => {
+  const bakery = [
+    suite({
+      id: "workspace-unit",
+      units: ["c.test.ts", "a.test.ts", "b.test.ts"],
+    }),
+    suite({
+      id: "repo-gates",
+      recordSurfaces: [{ kind: "gate", scope: "repo" }],
+      units: ["deno-fmt"],
+    }),
+  ];
+
+  /** The units of one batch, in the order `batchesOf` returns them. */
+  function handed(selections: readonly Selection[]): string[] {
+    const seen = census(bakery, undefined, new Set());
+    return batchesOf(bakery, seen.manifest, selections)
+      .flatMap((batch) => batch.units.map((unit) => unit.unit));
+  }
+
+  it("hands the units over in the order the suite enumerates them", () => {
+    const seen = census(bakery, undefined, new Set());
+    const entries = seen.manifest.entries.filter((entry) =>
+      entry.suite === "workspace-unit"
     );
-    expect(placed.toSorted()).toEqual([
+    const selections = entries.map((entry) => ({
+      entry,
+      reason: "value" as const,
+      repeats: 1,
+    }));
+    expect(handed(selections)).toEqual(["c.test.ts", "a.test.ts", "b.test.ts"]);
+    // The same set chosen in a different order is handed over the same
+    // way, which is what stops the two runs ordering one batch's work
+    // differently from each other.
+    expect(handed([...selections].reverse())).toEqual(handed(selections));
+  });
+
+  it("puts the batches themselves in one order whatever chose them", () => {
+    const seen = census(bakery, undefined, new Set());
+    const selections = seen.manifest.entries.map((entry) => ({
+      entry,
+      reason: "value" as const,
+      repeats: 1,
+    }));
+    const suiteIds = (chosen: readonly Selection[]) =>
+      batchesOf(bakery, seen.manifest, chosen).map((batch) => batch.suite.id);
+    expect(suiteIds(selections)).toEqual(["repo-gates", "workspace-unit"]);
+    expect(suiteIds([...selections].reverse())).toEqual(suiteIds(selections));
+  });
+});
+
+describe("running everything", () => {
+  const four = [
+    suite({
+      id: "workspace-unit",
+      units: ["a.test.ts", "b.test.ts", "c.test.ts", "d.test.ts"],
+    }),
+  ];
+
+  it("gives each lane its own share and no unit twice", () => {
+    const lanes = unitsPerLane(four, undefined, 3, "everything");
+    expect(lanes.flat().toSorted()).toEqual([
       "a.test.ts",
       "b.test.ts",
       "c.test.ts",
       "d.test.ts",
     ]);
+  });
+
+  it("spreads the units rather than piling them into one lane", () => {
+    // Nothing has measured any of these, so they cost the same as one
+    // another. Costing them nothing would make every lane after the
+    // first look more expensive than the one already holding the suite,
+    // and the whole suite would land in lane one.
+    const lanes = unitsPerLane(four, undefined, 4, "everything");
+    expect(lanes.map((units) => units.length)).toEqual([1, 1, 1, 1]);
   });
 
   it("leaves out a unit a configuration declares unavailable", () => {
@@ -418,7 +380,7 @@ describe("running everything", () => {
         unavailable: [{ unit: "a.test.ts", reason: "not landed yet" }],
       }),
     ];
-    expect(everyBatch(suites, 1, 1)[0]!.units.map((unit) => unit.unit))
+    expect(unitsPerLane(suites, undefined, 1, "everything")[0])
       .toEqual(["b.test.ts"]);
   });
 
@@ -434,13 +396,225 @@ describe("running everything", () => {
         }],
       }),
     ];
-    expect(everyBatch(suites, 1, 1)[0]!.units.map((unit) => unit.unit))
+    expect(unitsPerLane(suites, undefined, 1, "everything")[0])
       .toEqual(["a.test.ts", "b.test.ts"]);
   });
 });
 
+describe("how many lanes the full run asks for", () => {
+  const options = {
+    lane: 1,
+    of: 1,
+    full: true,
+    dryRun: true,
+    laneCount: true,
+    root: REPOSITORY,
+  };
+
+  /** A topology holding `count` units of one suite, each costing `cost`. */
+  function corpus(count: number, cost: number) {
+    const units = Array.from({ length: count }, (_, i) => `unit-${i}.test.ts`);
+    return {
+      topology: () => Promise.resolve([suite({ id: "workspace-unit", units })]),
+      manifest: () =>
+        Promise.resolve({
+          manifest: manifestOf(units.map((unit, i) => ({
+            test: { k: "unit", s: "bakery", n: `case ${i}` },
+            unit,
+            cost,
+          }))),
+          objectName: "manifest-fixture.json.gz",
+        }),
+    };
+  }
+
+  it("asks for one lane for work that fits in one", async () => {
+    expect(await fullLanes(options, corpus(10, 1))).toBe(1);
+  });
+
+  it("asks for enough lanes that none of them runs long", async () => {
+    const deps = corpus(FULL_LANE_BUDGET_SECONDS * 4, 1);
+    expect(await fullLanes(options, deps)).toBe(4);
+  });
+
+  it("gives every unit a lane at the count it asked for", async () => {
+    // The integer is the whole of what the job ahead of the full run
+    // emits, so it has to be a count the lanes can honor: every unit
+    // placed, and no lane past the budget the count was chosen for.
+    const deps = corpus(100, 1);
+    const lanes = await fullLanes(options, deps);
+    const suites = await deps.topology();
+    const seen = census(suites, (await deps.manifest()).manifest, new Set());
+    const laid = plan({
+      manifest: seen.manifest,
+      mandatory: seen.mandatory,
+      capabilities: capabilitiesBySuite(suites),
+      policy: "everything",
+      lanes,
+    });
+    expect(laid.overBudgetSeconds).toBe(0);
+    const placed = laid.lanes.flatMap((lane) =>
+      lane.selections.map((s) => s.entry.unit)
+    );
+    expect(placed.length).toBe(100);
+    expect(new Set(placed).size).toBe(100);
+  });
+
+  it("takes the topology's shape when a manifest knows none of it", async () => {
+    // A manifest that arrived is not the question. One published before
+    // this tree existed arrives and still knows none of it, and a cost
+    // model reading it is as blind as one reading nothing.
+    const suites = [
+      suite({ id: "workspace-unit", units: ["a.test.ts", "b.test.ts"] }),
+      suite({ id: "repo-gates", units: ["deno-fmt"] }),
+    ];
+    const errors: string[] = [];
+    const error = console.error;
+    console.error = (line: string) => errors.push(line);
+    let lanes: number;
+    try {
+      lanes = await fullLanes(options, {
+        topology: () => Promise.resolve(suites),
+        manifest: () =>
+          Promise.resolve({
+            manifest: manifestOf([{ unit: "somewhere/else.test.ts" }]),
+            objectName: "manifest-fixture.json.gz",
+          }),
+      });
+    } finally {
+      console.error = error;
+    }
+    expect(lanes).toBe(2);
+    expect(errors.join("\n")).toContain("measured");
+  });
+
+  it("takes the topology's shape when there is no manifest", async () => {
+    // Nothing has a measured cost, so a projection from costs would be
+    // arithmetic over an invented figure, and being wrong downward means
+    // every lane runs past the bound its job is killed at.
+    const suites = [
+      suite({ id: "workspace-unit", units: ["a.test.ts", "b.test.ts"] }),
+      suite({ id: "repo-gates", units: ["deno-fmt"] }),
+      suite({
+        id: "package-integration-opposite",
+        units: ["c.test.ts"],
+        unavailable: [{ unit: "c.test.ts", reason: "not in this posture" }],
+      }),
+    ];
+    const errors: string[] = [];
+    const error = console.error;
+    console.error = (line: string) => errors.push(line);
+    let lanes: number;
+    try {
+      lanes = await fullLanes(options, {
+        topology: () => Promise.resolve(suites),
+        manifest: () => Promise.resolve({ absent: "the store is gone" }),
+      });
+    } finally {
+      console.error = error;
+    }
+    // A lane for each suite with anything to run, so the suite whose
+    // every unit this configuration declares unavailable takes none.
+    expect(lanes).toBe(2);
+    expect(errors.join("\n")).toContain("measured");
+  });
+
+  it("answers with an integer on its own, and exits zero", async () => {
+    const lines: string[] = [];
+    const log = console.log;
+    console.log = (line: string) => lines.push(line);
+    let status: number;
+    try {
+      status = await main(
+        ["--full", "--lane-count"],
+        REPOSITORY,
+        corpus(10, 1),
+      );
+    } finally {
+      console.log = log;
+    }
+    expect(status).toBe(0);
+    expect(lines).toEqual(["1"]);
+  });
+});
+
+describe("what the two runs agree about", () => {
+  const bakery = [
+    suite({
+      id: "workspace-unit",
+      units: ["packages/bakery/glaze.test.ts", "packages/bakery/proof.test.ts"],
+      unavailable: [{
+        unit: "packages/bakery/gone.test.ts",
+        reason: "not in this configuration",
+      }],
+    }),
+  ];
+
+  /**
+   * A manifest naming a unit this tree does not have and one it declares
+   * unavailable, which is what a manifest published before the tree
+   * changed looks like.
+   */
+  const stale = manifestOf([
+    { unit: "packages/bakery/glaze.test.ts" },
+    {
+      test: { k: "unit", s: "bakery", n: "gone > entirely" },
+      unit: "packages/bakery/gone.test.ts",
+    },
+    {
+      test: { k: "unit", s: "bakery", n: "deleted > long ago" },
+      unit: "packages/bakery/deleted.test.ts",
+    },
+  ]);
+
+  it("runs the same units in both, since both read the same tree", () => {
+    const full = unitsPerLane(bakery, stale, 1, "everything")[0];
+    const budgeted = unitsPerLane(bakery, stale, 1)[0];
+    expect(full).toEqual([
+      "packages/bakery/glaze.test.ts",
+      "packages/bakery/proof.test.ts",
+    ]);
+    expect(budgeted).toEqual(full);
+  });
+
+  it("selects the same set as a full run when nothing is scarce", () => {
+    // The one difference between the two policies is what a run can
+    // afford. Given a budget nothing exhausts and a corpus nothing is
+    // withheld from, they must choose the same tests; if they ever stop
+    // doing so, something has been added to one and not the other.
+    const suites = [
+      suite({
+        id: "workspace-unit",
+        units: Array.from({ length: 12 }, (_, i) => `unit-${i}.test.ts`),
+      }),
+    ];
+    const seen = census(suites, undefined, new Set());
+    const shared = {
+      manifest: seen.manifest,
+      mandatory: new Map<string, SelectionReason>(),
+      capabilities: capabilitiesBySuite(suites),
+      lanes: 3,
+      budgetSeconds: 1_000_000,
+    };
+    const full = plan({ ...shared, policy: "everything" as const });
+    const budgeted = plan(shared);
+    const keys = (result: ReturnType<typeof plan>) =>
+      result.lanes.flatMap((lane) =>
+        lane.selections.map((s) => testIdentityKey(s.entry.test))
+      ).toSorted();
+    expect(keys(budgeted)).toEqual(keys(full));
+  });
+});
+
 describe("running a lane's work", () => {
-  const lane = { lane: 1, of: 5, full: false, dryRun: false, root: REPOSITORY };
+  const lane = {
+    lane: 1,
+    of: 5,
+    full: false,
+    dryRun: false,
+    laneCount: false,
+    root: REPOSITORY,
+  };
 
   /** A suite that runs the command a case gives it. */
   function runnable(command: readonly string[], id = "probe"): Suite {
@@ -545,6 +719,10 @@ describe("running a lane's work", () => {
         ["deno", "toolshed"],
         { objectName: "manifest-x.json.gz" },
         ["binaries: build-binary toolshed costs 900s"],
+        { selections: [], projectedSeconds: 0 },
+        LANE_BUDGET_SECONDS,
+        0,
+        0,
       );
     } finally {
       console.log = log;
@@ -588,6 +766,9 @@ describe("running a lane's work", () => {
           selections: [{ entry, reason: "value", repeats: 2 }],
           projectedSeconds: 96,
         },
+        LANE_BUDGET_SECONDS,
+        0,
+        1,
       );
     } finally {
       console.log = log;
@@ -603,7 +784,17 @@ describe("running a lane's work", () => {
     const log = console.log;
     console.log = (line: string) => lines.push(line);
     try {
-      describePlan(lane, [], [], { absent: "the store is unreachable" });
+      describePlan(
+        lane,
+        [],
+        [],
+        { absent: "the store is unreachable" },
+        [],
+        { selections: [], projectedSeconds: 0 },
+        LANE_BUDGET_SECONDS,
+        0,
+        0,
+      );
     } finally {
       console.log = log;
     }
@@ -697,6 +888,7 @@ describe("planning a lane without running it", () => {
         of: 5,
         full: true,
         dryRun: true,
+        laneCount: false,
         root: REPOSITORY,
       });
     } finally {
@@ -705,9 +897,12 @@ describe("planning a lane without running it", () => {
     expect(ok).toBe(true);
     const printed = lines.join("\n");
     expect(printed).toContain("Lane 2 of 5");
-    expect(printed).toContain("running everything");
-    // A lane's share of the full run is a real share of real suites.
+    // A lane's share of the full run is a real share of real suites,
+    // measured against the full run's own budget rather than a pull
+    // request's.
     expect(printed).toContain("workspace-unit");
+    expect(printed).toContain(`of ${FULL_LANE_BUDGET_SECONDS}s`);
+    expect(FULL_LANE_BUDGET_SECONDS).toBeLessThan(FULL_LANE_BOUND_SECONDS);
   });
 });
 
@@ -729,6 +924,7 @@ describe("planning a lane the manifest chose", () => {
           of: 5,
           full: false,
           dryRun: true,
+          laneCount: false,
           root,
           at: "2026-09-01T00:00:00Z",
         },
@@ -755,6 +951,7 @@ describe("planning a lane the manifest chose", () => {
         of: 2,
         full: false,
         dryRun: true,
+        laneCount: false,
         root,
         at: "2026-09-01T00:00:00Z",
       },
@@ -802,7 +999,7 @@ describe("planning a lane the manifest chose", () => {
     console.log = (line: string) => lines.push(line);
     try {
       await runLane(
-        { lane: 1, of: 5, full: false, dryRun: true, root },
+        { lane: 1, of: 5, full: false, dryRun: true, laneCount: false, root },
         { manifest: () => Promise.resolve({ absent: "the store is gone" }) },
       );
     } finally {
@@ -892,10 +1089,15 @@ describe("the lane's own housekeeping", () => {
     console.log = () => {};
     try {
       describePlan(
-        { lane: 1, of: 5, full: false, dryRun: true, root },
+        { lane: 1, of: 5, full: false, dryRun: true, laneCount: false, root },
         [],
         [],
         { objectName: "manifest-x.json.gz" },
+        [],
+        { selections: [], projectedSeconds: 0 },
+        LANE_BUDGET_SECONDS,
+        0,
+        0,
       );
     } finally {
       console.log = log;
@@ -934,6 +1136,7 @@ describe("the lane's own housekeeping", () => {
         of: 10000,
         full: true,
         dryRun: false,
+        laneCount: false,
         root,
       });
     } finally {
@@ -965,7 +1168,14 @@ describe("the lane's own housekeeping", () => {
 });
 
 describe("what a lane records about itself", () => {
-  const lane = { lane: 1, of: 5, full: false, dryRun: false, root: REPOSITORY };
+  const lane = {
+    lane: 1,
+    of: 5,
+    full: false,
+    dryRun: false,
+    laneCount: false,
+    root: REPOSITORY,
+  };
 
   it("records what each batch cost, beside the records it gathered", async () => {
     // The publisher fits the suite overheads and corrections from these,
@@ -1132,6 +1342,7 @@ describe("what a lane records about itself", () => {
           of: 5,
           full: false,
           dryRun: true,
+          laneCount: false,
           root: REPOSITORY,
           at: "2026-09-01T00:00:00Z",
         },
@@ -1269,6 +1480,7 @@ describe("what a lane does with the batches it was given", () => {
           of: 1,
           full: false,
           dryRun: false,
+          laneCount: false,
           root: REPOSITORY,
           at: "2026-09-01T00:00:00Z",
         },
@@ -1299,7 +1511,14 @@ describe("what a lane does with the batches it was given", () => {
     console.log = (line: string) => lines.push(line);
     try {
       await runLane(
-        { lane: 1, of: 1, full: false, dryRun: true, root: outside },
+        {
+          lane: 1,
+          of: 1,
+          full: false,
+          dryRun: true,
+          laneCount: false,
+          root: outside,
+        },
         {
           manifest: () => Promise.resolve({ absent: "nothing published" }),
           topology: () => Promise.resolve([]),

--- a/tasks/ci-lane.test.ts
+++ b/tasks/ci-lane.test.ts
@@ -437,27 +437,112 @@ describe("how many lanes the full run asks for", () => {
     expect(await fullLanes(options, deps)).toBe(4);
   });
 
+  /**
+   * A corpus with the shapes that make packing hard: several suites, the
+   * measured skew the plan document records with a tenth of the tests
+   * holding most of the time, capabilities whose setup a lane pays once,
+   * fitted overheads, and one identity larger than a whole lane.
+   */
+  function awkward() {
+    const suites = [
+      suite({ id: "workspace-unit", needs: ["deno"], units: [] }),
+      suite({
+        id: "pattern-integration",
+        needs: ["deno", "browser"],
+        units: [],
+      }),
+      suite({ id: "cli-core", needs: ["deno", "toolshed"], units: [] }),
+    ].map((s, i) => ({
+      ...s,
+      units: Array.from({ length: 40 }, (_, u) => `s${i}/unit-${u}.test.ts`),
+    }));
+    const entries = suites.flatMap((s, i) =>
+      s.units.map((unit, u) => ({
+        test: { k: "unit", s: "bakery", n: `s${i} case ${u}` },
+        suite: s.id,
+        unit,
+        // A tenth of them hold most of the time, and one is larger than
+        // any lane can hold.
+        cost: u === 0 && i === 0
+          ? FULL_LANE_BUDGET_SECONDS * 2
+          : u % 10 === 0
+          ? 40
+          : 0.4,
+      }))
+    );
+    const manifest = manifestOf(entries);
+    manifest.calibration = {
+      setupCost: { deno: 15, browser: 60, toolshed: 45 },
+      suites: Object.fromEntries(
+        suites.map((s) => [s.id, { overhead: 12, correction: 1.3 }]),
+      ),
+      unitOverhead: {},
+      prologue: 40,
+    };
+    return {
+      suites,
+      topology: () => Promise.resolve(suites),
+      manifest: () =>
+        Promise.resolve({ manifest, objectName: "manifest-fixture.json.gz" }),
+    };
+  }
+
   it("gives every unit a lane at the count it asked for", async () => {
     // The integer is the whole of what the job ahead of the full run
-    // emits, so it has to be a count the lanes can honor: every unit
-    // placed, and no lane past the budget the count was chosen for.
-    const deps = corpus(100, 1);
+    // emits, so it has to be a count the lanes can honor. Every identity
+    // placed exactly once is the property that matters: what the full
+    // run does not run, nothing runs.
+    const deps = awkward();
     const lanes = await fullLanes(options, deps);
-    const suites = await deps.topology();
-    const seen = census(suites, (await deps.manifest()).manifest, new Set());
+    const seen = census(
+      deps.suites,
+      (await deps.manifest()).manifest,
+      new Set(),
+    );
     const laid = plan({
       manifest: seen.manifest,
       mandatory: seen.mandatory,
-      capabilities: capabilitiesBySuite(suites),
+      capabilities: capabilitiesBySuite(deps.suites),
       policy: "everything",
       lanes,
     });
-    expect(laid.overBudgetSeconds).toBe(0);
     const placed = laid.lanes.flatMap((lane) =>
-      lane.selections.map((s) => s.entry.unit)
+      lane.selections.map((s) => testIdentityKey(s.entry.test))
     );
-    expect(placed.length).toBe(100);
-    expect(new Set(placed).size).toBe(100);
+    expect(placed.length).toBe(seen.manifest.entries.length);
+    expect(new Set(placed).size).toBe(seen.manifest.entries.length);
+    // The lanes the count was chosen for hold what it promised, save the
+    // one carrying an identity larger than any lane, which carries it
+    // alone because nothing else would fit beside it.
+    const over = laid.lanes.filter((lane) =>
+      lane.projectedSeconds > laid.budgetSeconds
+    );
+    expect(over.length).toBe(1);
+    expect(over[0]!.selections.length).toBe(1);
+  });
+
+  it("gives every unit a lane when nothing has been measured", async () => {
+    // The same property down the fallback path, where the count comes
+    // from the shape of the topology rather than from a cost model.
+    const deps = awkward();
+    const lanes = await fullLanes(options, {
+      topology: deps.topology,
+      manifest: () => Promise.resolve({ absent: "the store is gone" }),
+    });
+    const seen = census(deps.suites, undefined, new Set());
+    const laid = plan({
+      manifest: seen.manifest,
+      mandatory: seen.mandatory,
+      capabilities: capabilitiesBySuite(deps.suites),
+      policy: "everything",
+      lanes,
+    });
+    const placed = laid.lanes.flatMap((lane) =>
+      lane.selections.map((s) => testIdentityKey(s.entry.test))
+    );
+    expect(placed.length).toBe(120);
+    expect(new Set(placed).size).toBe(120);
+    expect(laid.overBudgetSeconds).toBe(0);
   });
 
   it("takes the topology's shape when a manifest knows none of it", async () => {

--- a/tasks/ci-lane.test.ts
+++ b/tasks/ci-lane.test.ts
@@ -577,7 +577,7 @@ describe("how many lanes the full run asks for", () => {
   it("grows the fallback with the units, not only with the suites", async () => {
     // A repository can gain units without gaining a suite, and the suite
     // count alone would not notice. Two suites here hold more units than
-    // two lanes can, so the count comes from the units instead.
+    // two lanes can, so the count comes from packing them instead.
     const perLane = Math.floor(
       FULL_LANE_BUDGET_SECONDS / UNMEASURED_COST_SECONDS,
     );
@@ -596,6 +596,40 @@ describe("how many lanes the full run asks for", () => {
     });
     expect(lanes).toBeGreaterThan(suites.length);
     expect(lanes).toBe(Math.ceil((perLane + 40) * 2 / perLane));
+  });
+
+  it("charges a stand-in what the census charged it, not the dial", async () => {
+    // A suite whose measured units have all been renamed away carries
+    // its old median onto every stand-in, so the units cost far more
+    // than the bare unmeasured figure. A count that assumed the figure
+    // would be out by that whole multiple, and each lane would run past
+    // the bound its job is killed at.
+    const units = Array.from({ length: 300 }, (_, i) => `new/u-${i}.test.ts`);
+    const suites = [suite({ id: "pattern-integration", units })];
+    const renamed = manifestOf(
+      Array.from({ length: 50 }, (_, i) => ({
+        test: { k: "unit", s: "bakery", n: `old ${i}` },
+        suite: "pattern-integration",
+        unit: `old/u-${i}.test.ts`,
+        cost: 40,
+      })),
+    );
+    const lanes = await fullLanes(options, {
+      topology: () => Promise.resolve(suites),
+      manifest: () =>
+        Promise.resolve({ manifest: renamed, objectName: "m.json.gz" }),
+    });
+    const seen = census(suites, renamed, new Set());
+    expect(seen.unmeasured).toBe(seen.manifest.entries.length);
+    expect(seen.manifest.entries[0]!.cost).toBe(40);
+    const laid = plan({
+      manifest: seen.manifest,
+      mandatory: seen.mandatory,
+      capabilities: capabilitiesBySuite(suites),
+      policy: "everything",
+      lanes,
+    });
+    expect(laid.overBudgetSeconds).toBe(0);
   });
 
   it("takes the topology's shape when there is no manifest", async () => {

--- a/tasks/ci-lane.ts
+++ b/tasks/ci-lane.ts
@@ -1,19 +1,32 @@
 #!/usr/bin/env -S deno run -A
 
 /**
- * The script every pull-request lane runs, and the full run on `main`
- * runs with selection switched off.
+ * The script every pull-request lane runs, and the script every lane of
+ * the full run on `main` runs.
  *
- * Five lanes call this with their own lane number and nothing else.
- * There is no job ahead of them deciding what each will do: packing is a
- * pure function of the manifest, the diff, and the lane number, so all
- * five compute the same plan over the same inputs and take their own
- * share of it. That only holds while every lane resolves the same
- * manifest, which is why the moment they resolve it at is when the
- * commit under test was made rather than anything about the run.
+ * Lanes call this with their own lane number and nothing else. There is
+ * no job ahead of them deciding what each will do: packing is a pure
+ * function of the working tree, the manifest, the diff, and the lane
+ * number, so every lane computes the same plan over the same inputs and
+ * takes its own share of it. That only holds while every lane resolves
+ * the same manifest, which is why the moment they resolve it at is when
+ * the commit under test was made rather than anything about the run.
+ *
+ * The full run differs in two values: it runs the whole corpus rather
+ * than a budgeted part of it, and it has no diff. Everything else — what
+ * the tree holds, what each test costs, how the work groups into lanes,
+ * which identities inside a unit are skipped — is the same code, so the
+ * two runs cannot come to different answers about the same tree.
+ *
+ * `main` cannot fix its number of lanes ahead of time the way a pull
+ * request does, because the number depends on how much work there is and
+ * the job matrix has to exist before anything starts. So one job asks
+ * `--lane-count` and emits an integer, and that integer is the whole of
+ * what passes from it to the lanes.
  *
  *   deno run -A tasks/ci-lane.ts --lane 3 --of 5 --base origin/main
  *   deno run -A tasks/ci-lane.ts --full --lane 1 --of 4
+ *   deno run -A tasks/ci-lane.ts --full --lane-count
  *   deno run -A tasks/ci-lane.ts --lane 1 --of 5 --dry-run
  */
 
@@ -36,12 +49,14 @@ import {
 import { collectRecords } from "./test-records-gather.ts";
 import { fetchManifest, type ManifestFetch } from "./test-selection/store.ts";
 import {
+  fullLaneCount,
   plan,
   type Selection,
   type SelectionReason,
 } from "./test-selection/plan.ts";
+import { type Census, census } from "./test-selection/census.ts";
 import type { Manifest, WithheldReason } from "./test-selection/manifest.ts";
-import { LANE_BUDGET_SECONDS, LANES } from "./test-selection/policy.ts";
+import { LANES } from "./test-selection/policy.ts";
 
 /** What the lane was asked to do. */
 export interface LaneOptions {
@@ -53,6 +68,14 @@ export interface LaneOptions {
 
   /** Print the plan and run nothing. */
   dryRun: boolean;
+
+  /**
+   * Print how many lanes the full run needs, and nothing else. This is
+   * what the job ahead of the full run asks, and it asks it of this
+   * script rather than of one of its own so that the number and the
+   * lanes that will honor it come from the same code.
+   */
+  laneCount: boolean;
 
   /** What the change is measured against. */
   base?: string;
@@ -78,6 +101,7 @@ export function parseLaneArgs(
     of: LANES,
     full: false,
     dryRun: false,
+    laneCount: false,
     root,
   };
   const rest = [...args];
@@ -89,6 +113,10 @@ export function parseLaneArgs(
     }
     if (flag === "--dry-run") {
       options.dryRun = true;
+      continue;
+    }
+    if (flag === "--lane-count") {
+      options.laneCount = true;
       continue;
     }
     const value = rest.shift();
@@ -114,6 +142,11 @@ export function parseLaneArgs(
   if (!Number.isInteger(options.of) || options.of < options.lane) {
     return undefined;
   }
+  // Only the full run has a lane count to work out; a pull request's is
+  // the dial. Accepting the question without `--full` would answer the
+  // full run's question for a command line that did not ask it, and a
+  // workflow edit dropping the flag would still get a plausible integer.
+  if (options.laneCount && !options.full) return undefined;
   return options;
 }
 
@@ -165,95 +198,6 @@ export async function manifestMoment(
     };
   }
   return { at: new Date(at).toISOString() };
-}
-
-/**
- * A stand-in identity for a unit no manifest has ever seen. Records exist
- * only for tests that ran, so a unit with none is either brand new or
- * renamed, and both must run. The packer needs something to place, and
- * this is the least it can be given: the suite's own record surface and
- * the unit's path, which no real record will ever collide with because a
- * real record is named for a test rather than for a file.
- */
-export function unknownIdentity(suite: Suite, unit: string): TestIdentity {
-  const surface = suite.recordSurfaces[0];
-  const test: TestIdentity = {
-    k: surface?.kind ?? "unit",
-    s: surface?.scope ?? "repo",
-    n: `unrecorded ${unit}`,
-  };
-  if (suite.variant !== undefined) test.v = suite.variant;
-  return test;
-}
-
-/** What the diff and the topology together make mandatory. */
-export interface MandatoryInput {
-  mandatory: Map<string, SelectionReason>;
-  unknown: Map<string, { suite: string; unit: string }>;
-}
-
-/**
- * What must run whatever the score says: every unit of an `always` suite,
- * every unit the change touched, and every unit no manifest knows.
- *
- * The last of those is the rule the test-record spec requires of any
- * consumer that selects which tests run. A selector that never runs the
- * unselected starves its own data, and a renamed test is an unknown
- * identity until an alias lands.
- */
-export function mandatoryFor(
-  suites: readonly Suite[],
-  manifest: Manifest | undefined,
-  changed: ReadonlySet<string>,
-): MandatoryInput {
-  const mandatory = new Map<string, SelectionReason>();
-  const unknown = new Map<string, { suite: string; unit: string }>();
-  const known = new Map<string, Set<string>>();
-  for (const entry of manifest?.entries ?? []) {
-    const units = known.get(entry.suite);
-    if (units === undefined) known.set(entry.suite, new Set([entry.unit]));
-    else units.add(entry.unit);
-  }
-  const identitiesOf = new Map<string, string[]>();
-  for (const entry of manifest?.entries ?? []) {
-    const key = `${entry.suite}\t${entry.unit}`;
-    identitiesOf.set(key, [
-      ...identitiesOf.get(key) ?? [],
-      testIdentityKey(entry.test),
-    ]);
-  }
-  for (const suite of suites) {
-    const unavailable = unavailableUnits(suite);
-    // A unit that is a path is made mandatory by the diff naming it. A
-    // unit that is not — a type-check group, a binary — is one the suite
-    // has to map the diff onto itself, because only it knows what its
-    // unit covers.
-    const touched = new Set<string>(
-      suite.unitsForChange !== undefined
-        ? suite.unitsForChange(changed)
-        : suite.units.filter((unit) => changed.has(unit)),
-    );
-    for (const unit of suite.units) {
-      if (unavailable.has(unit)) continue;
-      const reason: SelectionReason | undefined = suite.mandatory === "always"
-        ? "always"
-        : touched.has(unit)
-        ? "changed"
-        : undefined;
-      const recorded = identitiesOf.get(`${suite.id}\t${unit}`);
-      if (recorded === undefined) {
-        // Nothing in the manifest runs this unit, so it is unknown
-        // whatever else made it mandatory.
-        const key = testIdentityKey(unknownIdentity(suite, unit));
-        mandatory.set(key, reason ?? "unknown");
-        unknown.set(key, { suite: suite.id, unit });
-        continue;
-      }
-      if (reason === undefined) continue;
-      for (const key of recorded) mandatory.set(key, reason);
-    }
-  }
-  return { mandatory, unknown };
 }
 
 /** The files this change touched, as the repository names them. */
@@ -346,29 +290,29 @@ export function batchesOf(
       batch.repeats = Math.max(batch.repeats, repeats);
     }
   }
-  return [...batches.values()];
-}
-
-/** Every unit of every suite, which is what the full run holds. */
-export function everyBatch(
-  suites: readonly Suite[],
-  lane: number,
-  of: number,
-): Batch[] {
-  const batches: Batch[] = [];
-  let index = 0;
+  // Both orders are the tree's rather than the packer's, so what a
+  // runner is handed is decided by which units are in the batch and
+  // never by which pass put them there. A test that leans on running
+  // after a sibling then behaves the same on `main` as on a pull
+  // request, rather than passing in whichever mode happened to order
+  // them the way it wanted.
+  const enumerated = new Map<string, number>();
   for (const suite of suites) {
-    const unavailable = unavailableUnits(suite);
-    const units: UnitRequest[] = [];
-    for (const unit of suite.units) {
-      if (unavailable.has(unit)) continue;
-      // A suite's units are spread across the lanes in the order they
-      // enumerate, so every lane knows its own share without being told.
-      if (index++ % of === lane - 1) units.push({ unit, skip: [] });
-    }
-    if (units.length > 0) batches.push({ suite, units, repeats: 1 });
+    suite.units.forEach((unit, index) =>
+      enumerated.set(`${suite.id}\t${unit}`, index)
+    );
   }
-  return batches;
+  const order = (suiteId: string, unit: string): number =>
+    enumerated.get(`${suiteId}\t${unit}`) ?? Number.MAX_SAFE_INTEGER;
+  for (const [suiteId, batch] of batches) {
+    batch.units.sort((a, b) =>
+      order(suiteId, a.unit) - order(suiteId, b.unit) ||
+      (a.unit < b.unit ? -1 : a.unit > b.unit ? 1 : 0)
+    );
+  }
+  return [...batches.values()].sort((a, b) =>
+    a.suite.id < b.suite.id ? -1 : a.suite.id > b.suite.id ? 1 : 0
+  );
 }
 
 /** What running one invocation came to. */
@@ -630,8 +574,11 @@ export function describePlan(
   batches: readonly Batch[],
   capabilities: readonly CapabilityId[],
   manifest: { objectName?: string; absent?: string },
-  unschedulable: readonly string[] = [],
-  chosen?: { selections: readonly Selection[]; projectedSeconds: number },
+  unschedulable: readonly string[],
+  chosen: { selections: readonly Selection[]; projectedSeconds: number },
+  budget: number,
+  unmeasured: number,
+  entries: number,
 ): void {
   const lines: string[] = [];
   lines.push(`## Lane ${options.lane} of ${options.of}`);
@@ -643,32 +590,27 @@ export function describePlan(
   );
   lines.push("");
   lines.push(`Capabilities: ${capabilities.join(", ") || "none"}`);
-  if (chosen !== undefined) {
-    lines.push("");
-    lines.push(
-      `Projected: ${chosen.projectedSeconds.toFixed(0)}s of ` +
-        `${LANE_BUDGET_SECONDS}s`,
-    );
-  }
   lines.push("");
-  if (chosen === undefined) {
-    lines.push("| Suite | Units | Repeats |");
-    lines.push("| --- | --- | --- |");
-    for (const batch of batches) {
-      lines.push(
-        `| ${batch.suite.id} | ${batch.units.length} | ${batch.repeats} |`,
-      );
-    }
-  } else {
-    lines.push("| Suite | Units | Tests | Their own time | Repeats | Chosen |");
-    lines.push("| --- | --- | --- | --- | --- | --- |");
-    for (const batch of batches) {
-      const share = chosenFor(batch.suite.id, chosen.selections);
-      lines.push(
-        `| ${batch.suite.id} | ${batch.units.length} | ${share.identities} | ` +
-          `${share.seconds.toFixed(1)}s | ${batch.repeats} | ${share.why} |`,
-      );
-    }
+  lines.push(
+    `Projected: ${chosen.projectedSeconds.toFixed(0)}s of ${budget}s` +
+      // Every stand-in in that figure is a guess at what a unit costs,
+      // so a projection carrying many of them says what the lane would
+      // take if the guesses were right rather than what it will take.
+      // Somebody reading a summary beside a lane that ran four times as
+      // long deserves to be told which of the two they have.
+      (unmeasured === 0
+        ? ""
+        : `, ${unmeasured} of ${entries} costs unmeasured`),
+  );
+  lines.push("");
+  lines.push("| Suite | Units | Tests | Their own time | Repeats | Chosen |");
+  lines.push("| --- | --- | --- | --- | --- | --- |");
+  for (const batch of batches) {
+    const share = chosenFor(batch.suite.id, chosen.selections);
+    lines.push(
+      `| ${batch.suite.id} | ${batch.units.length} | ${share.identities} | ` +
+        `${share.seconds.toFixed(1)}s | ${batch.repeats} | ${share.why} |`,
+    );
   }
   if (unschedulable.length > 0) {
     lines.push("");
@@ -698,90 +640,153 @@ export interface LaneDeps {
   topology?: (root: string) => Promise<Suite[]>;
 }
 
+/** What reading this tree against its manifest came to. */
+interface Reading {
+  seen: Census;
+  fetched: { objectName?: string; absent?: string };
+}
+
+/**
+ * Resolves the manifest this commit belongs to and reads the working
+ * tree against it.
+ *
+ * Everything that plans anything starts here — a lane, and the job that
+ * counts the full run's lanes — so the tree and the manifest are
+ * resolved one way. Two readers of the same tree that resolved it
+ * differently would be the drift this whole path exists to remove,
+ * appearing one level above the packer instead of inside it.
+ */
+async function read(
+  options: LaneOptions,
+  suites: readonly Suite[],
+  deps: LaneDeps,
+  say: (line: string) => void,
+): Promise<Reading> {
+  const moment = await manifestMoment(options);
+  if (moment.note !== undefined) say(`ci-lane: ${moment.note}`);
+  const fetch = deps.manifest ?? ((at: string) => fetchManifest({ at }));
+  const manifest = await fetch(moment.at);
+  // A full run reads the manifest for what things cost and nothing else,
+  // and a run with no diff has touched nothing.
+  const changed = options.full
+    ? new Set<string>()
+    : await changedFiles(options.root, options.base);
+  return {
+    seen: census(suites, manifest.manifest, changed),
+    fetched: {
+      ...(manifest.objectName === undefined
+        ? {}
+        : { objectName: manifest.objectName }),
+      ...(manifest.absent === undefined ? {} : { absent: manifest.absent }),
+    },
+  };
+}
+
+/**
+ * Packs what this tree holds into the lanes this run has.
+ *
+ * The policy is the whole of what the two runs differ by here. Under
+ * `everything` every identity is required, so the exclusions and the
+ * value, density and exploration passes have nothing left to act on and
+ * the packer behaves the same way for both.
+ */
+function packing(
+  options: LaneOptions,
+  suites: readonly Suite[],
+  seen: Census,
+): ReturnType<typeof plan> {
+  return plan({
+    manifest: seen.manifest,
+    mandatory: seen.mandatory,
+    capabilities: capabilitiesBySuite(suites),
+    lanes: options.of,
+    ...(options.full ? { policy: "everything" as const } : {}),
+  });
+}
+
+/**
+ * How many lanes the full run on `main` needs.
+ *
+ * This is the whole of what the job ahead of the full run decides, and an
+ * integer is the whole of what it emits. The lanes then read the same
+ * tree against the same manifest and take their own share, the way the
+ * pull-request lanes do, so nothing about what runs passes through a job
+ * output and there is no second packing to disagree with theirs.
+ *
+ * Notes about resolving the manifest go to the error stream, because
+ * this answers on the standard one and a job reads the answer from
+ * there.
+ */
+export async function fullLanes(
+  options: LaneOptions,
+  deps: LaneDeps = {},
+): Promise<number> {
+  const suites = await (deps.topology ?? loadTopology)(options.root);
+  const { seen } = await read(options, suites, deps, console.error);
+  if (seen.unmeasured === seen.manifest.entries.length) {
+    // Nothing at all has a measured cost, so a cost model here would be
+    // arithmetic over a figure this invented, and the answer would be
+    // wrong by whatever that figure is wrong by. It errs in the
+    // direction that breaks a run, too: too few lanes means every one of
+    // them runs past the bound its job is killed at, where too many
+    // means some jobs finish early.
+    //
+    // So the shape of the topology answers instead, at a lane per suite
+    // that has anything to run. That is a bound rather than a plan — the
+    // lanes still pack themselves, and a lane may hold more than one
+    // suite — and it needs no number nobody measured.
+    const running = suites.filter((suite) => {
+      const unavailable = unavailableUnits(suite);
+      return suite.units.some((unit) => !unavailable.has(unit));
+    });
+    console.error(
+      `ci-lane: nothing in this tree has a measured cost, so the lane ` +
+        `count is one per suite with anything to run rather than a ` +
+        `projection from costs nobody has measured`,
+    );
+    return Math.max(1, running.length);
+  }
+  return fullLaneCount({
+    manifest: seen.manifest,
+    capabilities: capabilitiesBySuite(suites),
+  });
+}
+
 /** Runs one lane, and says whether everything in it passed. */
 export async function runLane(
   options: LaneOptions,
   deps: LaneDeps = {},
 ): Promise<boolean> {
   const suites = await (deps.topology ?? loadTopology)(options.root);
-  let batches: Batch[];
-  let unschedulable: string[] = [];
-  let fetched: { objectName?: string; absent?: string } = {};
-  let sayWithheld = (): void => {};
-  let chosen:
-    | { selections: readonly Selection[]; projectedSeconds: number }
-    | undefined;
-  if (options.full) {
-    batches = everyBatch(suites, options.lane, options.of);
-    fetched = { absent: "running everything, so nothing is selected" };
-  } else {
-    const moment = await manifestMoment(options);
-    if (moment.note !== undefined) console.log(`ci-lane: ${moment.note}`);
-    const manifest = await (deps.manifest ?? ((at: string) =>
-      fetchManifest({ at })))(moment.at);
-    fetched = {
-      ...(manifest.objectName === undefined
-        ? {}
-        : { objectName: manifest.objectName }),
-      ...(manifest.absent === undefined ? {} : { absent: manifest.absent }),
-    };
-    const changed = await changedFiles(options.root, options.base);
-    const { mandatory, unknown } = mandatoryFor(
-      suites,
-      manifest.manifest,
-      changed,
+  const { seen, fetched } = await read(options, suites, deps, console.log);
+  const laid = packing(options, suites, seen);
+  const mine = laid.lanes.find((lane) => lane.lane === options.lane);
+  if (mine === undefined) {
+    // A lane outside the run it belongs to. Taking an empty share
+    // instead would run nothing and exit zero, reporting a pass over
+    // a set no lane ran, which is the one failure of this design
+    // that would be silent.
+    throw new RangeError(
+      `lane ${options.lane} has no share of a plan for ${options.of} lanes`,
     );
-    if (manifest.manifest === undefined) {
-      // With no manifest there is nothing to score, so the lane runs the
-      // mandatory set and a deterministic slice of the corpus. That is no
-      // worse than a coin toss about which tests run, which is what a
-      // fixed shard layout was.
-      batches = everyBatch(suites, options.lane, options.of);
-    } else {
-      const laid = plan({
-        manifest: manifest.manifest,
-        mandatory,
-        capabilities: capabilitiesBySuite(suites),
-        unknown,
-        lanes: options.of,
-      });
-      const mine = laid.lanes.find((lane) =>
-        lane.lane === options.lane
-      );
-      if (mine === undefined) {
-        // A lane outside the run it belongs to. Taking an empty share
-        // instead would run nothing and exit zero, reporting a pass over
-        // a set no lane ran, which is the one failure of this design
-        // that would be silent.
-        throw new RangeError(
-          `lane ${options.lane} has no share of a plan for ${options.of} ` +
-            `lanes`,
-        );
-      }
-      batches = batchesOf(suites, manifest.manifest, mine.selections);
-      chosen = {
-        selections: mine.selections,
-        projectedSeconds: mine.projectedSeconds,
-      };
-      sayWithheld = () => describeWithheld(laid.withheld, mandatory);
-      // A discretionary identity costing more than a lane's hard bound
-      // runs nowhere, because a lane holding it would be killed before it
-      // reported anything. Naming it is what turns that into something
-      // somebody can act on; the sixty-second rule is where such a test
-      // gets split. A mandatory one is placed however much it costs, and
-      // the over-budget line below is where a lane says it ran long.
-      unschedulable = laid.unschedulable.map((entry) =>
-        `${entry.suite}: ${testIdentityKey(entry.test)} costs ` +
-        `${entry.cost.toFixed(0)}s, more than a lane can hold`
-      );
-      if (laid.overBudgetSeconds > 0) {
-        console.log(
-          `ci-lane: the mandatory set puts a lane ` +
-            `${laid.overBudgetSeconds.toFixed(0)} seconds past the ` +
-            `${LANE_BUDGET_SECONDS}-second budget`,
-        );
-      }
-    }
+  }
+  const batches = batchesOf(suites, seen.manifest, mine.selections);
+  // A discretionary identity costing more than a lane's hard bound
+  // runs nowhere, because a lane holding it would be killed before it
+  // reported anything. Naming it is what turns that into something
+  // somebody can act on; the sixty-second rule is where such a test
+  // gets split. A mandatory one is placed however much it costs, and
+  // the over-budget line below is where a lane says it ran long.
+  const unschedulable = laid.unschedulable.map((entry) =>
+    `${entry.suite}: ${testIdentityKey(entry.test)} costs ` +
+    `${entry.cost.toFixed(0)}s, more than a lane can hold`
+  );
+  if (laid.overBudgetSeconds > 0) {
+    console.log(
+      `ci-lane: the mandatory set puts a lane ` +
+        `${laid.overBudgetSeconds.toFixed(0)} seconds past the ` +
+        `${laid.budgetSeconds}-second budget`,
+    );
   }
 
   const needs = new Set<CapabilityId>();
@@ -794,9 +799,12 @@ export async function runLane(
     [...needs].sort(),
     fetched,
     unschedulable,
-    chosen,
+    { selections: mine.selections, projectedSeconds: mine.projectedSeconds },
+    laid.budgetSeconds,
+    seen.unmeasured,
+    seen.manifest.entries.length,
   );
-  sayWithheld();
+  describeWithheld(laid.withheld, seen.mandatory);
   if (options.dryRun) return true;
 
   const workDir = await Deno.makeTempDir({ prefix: "ci-lane-" });
@@ -849,9 +857,13 @@ export async function main(
   if (options === undefined) {
     console.error(
       "usage: ci-lane.ts [--lane N] [--of M] [--full] [--dry-run] " +
-        "[--base <ref>] [--at <iso>]",
+        "[--lane-count] [--base <ref>] [--at <iso>]",
     );
     return 2;
+  }
+  if (options.laneCount) {
+    console.log(String(await fullLanes(options, deps)));
+    return 0;
   }
   return await runLane(options, deps) ? 0 : 1;
 }

--- a/tasks/ci-lane.ts
+++ b/tasks/ci-lane.ts
@@ -56,11 +56,7 @@ import {
 } from "./test-selection/plan.ts";
 import { type Census, census } from "./test-selection/census.ts";
 import type { Manifest, WithheldReason } from "./test-selection/manifest.ts";
-import {
-  FULL_LANE_BUDGET_SECONDS,
-  LANES,
-  UNMEASURED_COST_SECONDS,
-} from "./test-selection/policy.ts";
+import { LANES } from "./test-selection/policy.ts";
 
 /** What the lane was asked to do. */
 export interface LaneOptions {
@@ -735,34 +731,34 @@ export async function fullLanes(
     // them runs past the bound its job is killed at, where too many
     // means some jobs finish early.
     //
-    // So the shape of the tree answers instead, in two figures that can
-    // only raise the count between them. A lane per suite that has
-    // anything to run keeps the count growing as test surfaces are
-    // added. A lane per budget's worth of units at the stand-in rate
-    // keeps it growing as units are added to the suites there already
-    // are, which the suite count alone would not notice: a repository
-    // that grew to five times the units without gaining a suite would
-    // otherwise be given the same number of lanes and run every one of
-    // them past the bound its job is killed at.
+    // So a lane per suite with anything to run goes in as a floor. It
+    // needs no number nobody measured, and it keeps the count growing as
+    // test surfaces are added.
     //
-    // Neither is a projection. Both are shapes counted off the tree, and
-    // taking the larger errs the way this has to err, since too few
-    // lanes kills a run where too many only finishes some jobs early.
+    // The packing is still asked what it would need, and the larger of
+    // the two wins. Its answer is only as good as the stand-in costs
+    // behind it, which is why it cannot be the whole of this — but those
+    // costs are what the lanes will actually be packed against, so an
+    // answer below what they imply is one the lanes cannot honor
+    // whatever else is true. That matters most where a stand-in costs
+    // more than the bare unmeasured figure: a suite whose measured units
+    // have all been renamed away carries its old median onto every
+    // stand-in, and a count that assumed the bare figure would be out by
+    // that whole multiple.
     const running = suites.filter((suite) => {
       const unavailable = unavailableUnits(suite);
       return suite.units.some((unit) => !unavailable.has(unit));
     });
-    const perLane = Math.max(
-      1,
-      Math.floor(FULL_LANE_BUDGET_SECONDS / UNMEASURED_COST_SECONDS),
-    );
-    const byUnits = Math.ceil(seen.manifest.entries.length / perLane);
-    const lanes = Math.max(1, running.length, byUnits);
+    const byCost = fullLaneCount({
+      manifest: seen.manifest,
+      capabilities: capabilitiesBySuite(suites),
+    });
+    const lanes = Math.max(1, running.length, byCost);
     console.error(
       `ci-lane: nothing in this tree has a measured cost, so the lane ` +
-        `count is ${lanes} from the shape of the tree — ${running.length} ` +
-        `suites with anything to run, and ${byUnits} lanes' worth of ` +
-        `units — rather than a projection from costs nobody has measured`,
+        `count is ${lanes} — ${running.length} suites with anything to ` +
+        `run, and ${byCost} from packing the stand-ins — rather than a ` +
+        `projection from costs nobody has measured`,
     );
     return lanes;
   }

--- a/tasks/ci-lane.ts
+++ b/tasks/ci-lane.ts
@@ -56,7 +56,11 @@ import {
 } from "./test-selection/plan.ts";
 import { type Census, census } from "./test-selection/census.ts";
 import type { Manifest, WithheldReason } from "./test-selection/manifest.ts";
-import { LANES } from "./test-selection/policy.ts";
+import {
+  FULL_LANE_BUDGET_SECONDS,
+  LANES,
+  UNMEASURED_COST_SECONDS,
+} from "./test-selection/policy.ts";
 
 /** What the lane was asked to do. */
 export interface LaneOptions {
@@ -731,20 +735,36 @@ export async function fullLanes(
     // them runs past the bound its job is killed at, where too many
     // means some jobs finish early.
     //
-    // So the shape of the topology answers instead, at a lane per suite
-    // that has anything to run. That is a bound rather than a plan — the
-    // lanes still pack themselves, and a lane may hold more than one
-    // suite — and it needs no number nobody measured.
+    // So the shape of the tree answers instead, in two figures that can
+    // only raise the count between them. A lane per suite that has
+    // anything to run keeps the count growing as test surfaces are
+    // added. A lane per budget's worth of units at the stand-in rate
+    // keeps it growing as units are added to the suites there already
+    // are, which the suite count alone would not notice: a repository
+    // that grew to five times the units without gaining a suite would
+    // otherwise be given the same number of lanes and run every one of
+    // them past the bound its job is killed at.
+    //
+    // Neither is a projection. Both are shapes counted off the tree, and
+    // taking the larger errs the way this has to err, since too few
+    // lanes kills a run where too many only finishes some jobs early.
     const running = suites.filter((suite) => {
       const unavailable = unavailableUnits(suite);
       return suite.units.some((unit) => !unavailable.has(unit));
     });
+    const perLane = Math.max(
+      1,
+      Math.floor(FULL_LANE_BUDGET_SECONDS / UNMEASURED_COST_SECONDS),
+    );
+    const byUnits = Math.ceil(seen.manifest.entries.length / perLane);
+    const lanes = Math.max(1, running.length, byUnits);
     console.error(
       `ci-lane: nothing in this tree has a measured cost, so the lane ` +
-        `count is one per suite with anything to run rather than a ` +
-        `projection from costs nobody has measured`,
+        `count is ${lanes} from the shape of the tree — ${running.length} ` +
+        `suites with anything to run, and ${byUnits} lanes' worth of ` +
+        `units — rather than a projection from costs nobody has measured`,
     );
-    return Math.max(1, running.length);
+    return lanes;
   }
   return fullLaneCount({
     manifest: seen.manifest,

--- a/tasks/test-selection.test.ts
+++ b/tasks/test-selection.test.ts
@@ -176,9 +176,26 @@ describe("test-selection", () => {
         ],
       });
       const text = planLines(manifest, TOPOLOGY, undefined).join("\n");
-      expect(text).toContain("2 known identities");
+      expect(text).toContain("2 identities in this tree");
       expect(text).toContain(`${LANES} lanes`);
       expect(text).toContain("lane 1:");
+    });
+
+    it("counts the corpus the lanes were packed from", () => {
+      // The manifest's own entries are not that corpus: one of these
+      // names a unit this tree does not have, and no lane can run it.
+      const manifest = sampleManifest({
+        entries: [
+          sampleEntry({ k: "unit", s: "memory", n: "here" }, {
+            unit: "packages/memory/test/memory.test.ts",
+          }),
+          sampleEntry({ k: "unit", s: "memory", n: "gone" }, {
+            unit: "packages/memory/test/deleted.test.ts",
+          }),
+        ],
+      });
+      const text = planLines(manifest, TOPOLOGY, undefined).join("\n");
+      expect(text).toContain("1 identities in this tree");
     });
 
     it("prints one lane when asked for one", () => {
@@ -288,11 +305,11 @@ describe("verdictFor()", () => {
     const manifest = sampleManifest({
       entries: [sampleEntry({ k: "unit", s: "memory", n: "heavy" }, {
         cost: 200,
-        suite: "pattern-integration",
+        unit: "packages/memory/test/memory.test.ts",
       })],
       calibration: {
         setupCost: {},
-        suites: { "pattern-integration": { overhead: 400, correction: 1 } },
+        suites: { "workspace-unit": { overhead: 400, correction: 1 } },
         unitOverhead: {},
         prologue: 0,
       },

--- a/tasks/test-selection.test.ts
+++ b/tasks/test-selection.test.ts
@@ -342,10 +342,35 @@ describe("verdictFor()", () => {
 
   it("reports a test the manifest has never heard of as unselected", () => {
     const manifest = manifestOf(entry("cheap", 0.1));
-    expect(
-      verdictFor(manifest, TOPOLOGY, { k: "unit", s: "memory", n: "absent" }),
-    )
-      .toEqual({ selected: false });
+    const verdict = verdictFor(manifest, TOPOLOGY, {
+      k: "unit",
+      s: "memory",
+      n: "absent",
+    });
+    expect(verdict.selected).toBe(false);
+    expect(verdict.repeats).toBeUndefined();
+    expect(verdict.unschedulable).toBeUndefined();
+  });
+
+  it("hands back the corpus its verdict was reached over", () => {
+    // Whatever explains an identity has to explain it against the set
+    // the verdict came from. The published manifest is a different set:
+    // it names units this tree has dropped and misses units it has
+    // gained, so a reader given that one is told there is no record of a
+    // test the verdict beside it says a lane runs.
+    const manifest = manifestOf(
+      sampleEntry({ k: "unit", s: "memory", n: "gone" }, {
+        unit: "packages/memory/test/deleted.test.ts",
+      }),
+    );
+    const verdict = verdictFor(manifest, TOPOLOGY, {
+      k: "unit",
+      s: "memory",
+      n: "gone",
+    });
+    const units = verdict.corpus.entries.map((e) => e.unit);
+    expect(units).not.toContain("packages/memory/test/deleted.test.ts");
+    expect(units).toContain("packages/memory/test/memory.test.ts");
   });
 
   it("tells two configurations of one name apart", () => {

--- a/tasks/test-selection.ts
+++ b/tasks/test-selection.ts
@@ -350,13 +350,21 @@ export function verdictFor(
   manifest: Manifest,
   suites: readonly Suite[],
   test: TestIdentity,
-): PlanVerdict {
-  const { result } = planFor(manifest, suites);
+): PlanVerdict & { corpus: Manifest } {
+  const { seen, result } = planFor(manifest, suites);
   const key = testIdentityKey(test);
   const taken = result.lanes.flatMap((lane) => lane.selections).find((
     selection,
   ) => testIdentityKey(selection.entry.test) === key);
-  const verdict: PlanVerdict = { selected: taken !== undefined };
+  // The corpus travels with the verdict so that whatever explains this
+  // identity explains it against the same set the verdict came from. A
+  // reader given the published manifest instead would be told there is
+  // no record of a unit this tree has just added, while the verdict
+  // beside it says a lane runs the stand-in for it.
+  const verdict: PlanVerdict & { corpus: Manifest } = {
+    selected: taken !== undefined,
+    corpus: seen,
+  };
   if (taken !== undefined) verdict.repeats = taken.repeats;
   const refused = result.unschedulable.find((entry) =>
     testIdentityKey(entry.test) === key
@@ -518,13 +526,8 @@ export async function dispatch(
         manifest.generatedAt.slice(0, 10),
       );
       const suites = await sources.topology();
-      for (
-        const line of explainLines(
-          manifest,
-          resolved,
-          verdictFor(manifest, suites, resolved),
-        )
-      ) {
+      const verdict = verdictFor(manifest, suites, resolved);
+      for (const line of explainLines(verdict.corpus, resolved, verdict)) {
         console.log(line);
       }
       return 0;

--- a/tasks/test-selection.ts
+++ b/tasks/test-selection.ts
@@ -31,6 +31,7 @@ import {
 import { fetchManifest } from "./test-selection/store.ts";
 import { capabilitiesBySuite, loadTopology } from "./test-topology.ts";
 import { type Suite, unavailableUnits } from "./test-topology/suite.ts";
+import { census } from "./test-selection/census.ts";
 import type { Manifest } from "./test-selection/manifest.ts";
 import { plan } from "./test-selection/plan.ts";
 import { readWorkspaceMembers } from "./workspace-tests.ts";
@@ -264,17 +265,25 @@ function laneLine(
 
 /**
  * The packing, over a manifest and no diff, as a lane would compute it.
- * The capabilities a suite opens are most of what a lane's budget goes
- * on, so the topology is what makes this the answer a lane would give
- * rather than one that leaves the setup out. The publisher computes its
- * reference plan the same way.
+ *
+ * It reads the tree against the manifest first, exactly as a lane does.
+ * Without that this would answer for a corpus a lane never sees: the
+ * units the manifest still names and the tree has dropped would be in
+ * the answer, and the units the tree has gained would not. The
+ * capabilities a suite opens are most of what a lane's budget goes on,
+ * which is the other reason the topology is what makes this the answer a
+ * lane would give.
  */
 function planFor(manifest: Manifest, suites: readonly Suite[]) {
-  return plan({
-    manifest,
-    mandatory: new Map(),
-    capabilities: capabilitiesBySuite(suites),
-  });
+  const seen = census(suites, manifest, new Set());
+  return {
+    seen: seen.manifest,
+    result: plan({
+      manifest: seen.manifest,
+      mandatory: seen.mandatory,
+      capabilities: capabilitiesBySuite(suites),
+    }),
+  };
 }
 
 /** What `plan --dry-run` prints, as lines. */
@@ -284,7 +293,7 @@ export function planLines(
   laneNumber: number | undefined,
 ): string[] {
   const lines: string[] = [];
-  const result = planFor(manifest, suites);
+  const { seen, result } = planFor(manifest, suites);
   const lanes = laneNumber === undefined
     ? result.lanes
     : result.lanes.filter((lane) => lane.lane === laneNumber);
@@ -292,9 +301,13 @@ export function planLines(
     `manifest of ${manifest.generatedAt}, from ${manifest.runs} runs at ` +
       `${manifest.commit}`,
   );
+  // The corpus the lanes below were packed from, which is what this tree
+  // holds rather than what the manifest was published over. Counting the
+  // manifest's own entries here would head a plan with a total the plan
+  // does not add up to.
   lines.push(
-    `${manifest.entries.length} known identities, ` +
-      `${manifest.withheld.length} withheld`,
+    `${seen.entries.length} identities in this tree, ` +
+      `${seen.withheld.length} withheld`,
   );
   for (const lane of lanes) {
     lines.push(laneLine(lane));
@@ -338,7 +351,7 @@ export function verdictFor(
   suites: readonly Suite[],
   test: TestIdentity,
 ): PlanVerdict {
-  const result = planFor(manifest, suites);
+  const { result } = planFor(manifest, suites);
   const key = testIdentityKey(test);
   const taken = result.lanes.flatMap((lane) => lane.selections).find((
     selection,

--- a/tasks/test-selection/census.test.ts
+++ b/tasks/test-selection/census.test.ts
@@ -1,0 +1,374 @@
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+import { testIdentityKey } from "@commonfabric/test-support/records";
+
+import { census, unknownIdentity } from "./census.ts";
+import type { Manifest, ManifestEntry } from "./manifest.ts";
+import type { Suite } from "../test-topology/suite.ts";
+import { loadTopology } from "../test-topology.ts";
+
+/**
+ * The repository, found from this file rather than from the process's
+ * own directory: a package's tests run with that package as the working
+ * directory, and the paths the topology reads are the repository's.
+ */
+const REPOSITORY = new URL("../..", import.meta.url).pathname.replace(
+  /\/$/,
+  "",
+);
+import { UNMEASURED_COST_SECONDS } from "./policy.ts";
+
+/** A suite holding exactly what a case describes. */
+function suite(partial: Partial<Suite> & { id: string }): Suite {
+  return {
+    recordSurfaces: [{ kind: "unit", scope: "bakery" }],
+    needs: ["deno"],
+    units: [],
+    unavailable: [],
+    locate: () => undefined,
+    command: () => Promise.resolve([]),
+    ...partial,
+  };
+}
+
+/** A manifest carrying exactly these entries. */
+function manifestOf(entries: readonly Partial<ManifestEntry>[]): Manifest {
+  return {
+    schema: 1,
+    generatedAt: "2026-09-01T00:00:00.000Z",
+    seed: "seed",
+    commit: "c".repeat(40),
+    runs: 1,
+    dials: {},
+    calibration: { setupCost: {}, suites: {}, unitOverhead: {}, prologue: 40 },
+    entries: entries.map((entry) => ({
+      test: { k: "unit", s: "bakery", n: "glaze > sets" },
+      suite: "workspace-unit",
+      unit: "packages/bakery/glaze.test.ts",
+      cost: 1,
+      score: 0.5,
+      inputs: { catches: 0, mainCatches: 0, sources: 0, churn: 0 },
+      flakeRate: 0,
+      repeats: 1,
+      ...entry,
+    })),
+    withheld: [],
+    unavailable: [],
+    unschedulable: [],
+    lanes: [],
+    known: { count: 0, digest: "" },
+    coverageBaselines: [],
+  };
+}
+
+describe("what a lane must run whatever the score says", () => {
+  const bakery = suite({
+    id: "workspace-unit",
+    units: ["packages/bakery/glaze.test.ts", "packages/bakery/proof.test.ts"],
+  });
+
+  it("runs a unit no manifest has ever seen", () => {
+    const manifest = manifestOf([{}]);
+    const { mandatory, manifest: seen } = census(
+      [bakery],
+      manifest,
+      new Set(),
+    );
+    const key = testIdentityKey(
+      unknownIdentity(bakery, "packages/bakery/proof.test.ts"),
+    );
+    expect(mandatory.get(key)).toBe("unknown");
+    // It carries a stand-in entry, since the packer cannot place an
+    // identity the manifest it was handed does not hold.
+    const standing = seen.entries.find((entry) =>
+      testIdentityKey(entry.test) === key
+    );
+    expect(standing?.unit).toBe("packages/bakery/proof.test.ts");
+    expect(standing?.suite).toBe("workspace-unit");
+  });
+
+  it("runs every unit when there is no manifest at all", () => {
+    const { mandatory } = census([bakery], undefined, new Set());
+    expect(mandatory.size).toBe(2);
+    expect([...mandatory.values()]).toEqual(["unknown", "unknown"]);
+  });
+
+  it("runs the identities of a unit the change touched", () => {
+    const manifest = manifestOf([
+      {},
+      { test: { k: "unit", s: "bakery", n: "glaze > browns" } },
+    ]);
+    const { mandatory } = census(
+      [bakery],
+      manifest,
+      new Set(["packages/bakery/glaze.test.ts"]),
+    );
+    expect(
+      mandatory.get(
+        testIdentityKey({ k: "unit", s: "bakery", n: "glaze > sets" }),
+      ),
+    ).toBe("changed");
+    expect(
+      mandatory.get(
+        testIdentityKey({ k: "unit", s: "bakery", n: "glaze > browns" }),
+      ),
+    ).toBe("changed");
+  });
+
+  it("asks a suite which of its units a change reaches", () => {
+    // A unit that is not a path — a type-check group, a binary — is one
+    // only its suite can map the diff onto, so the suite is asked rather
+    // than the diff being matched against the unit's name.
+    const binaries = suite({
+      id: "binaries",
+      mandatory: "changed",
+      recordSurfaces: [{ kind: "gate", scope: "repo" }],
+      units: ["toolshed", "cf"],
+      unitsForChange: (changed) =>
+        changed.has("packages/shell/index.ts") ? ["toolshed"] : [],
+    });
+    const manifest = manifestOf([
+      {
+        test: { k: "gate", s: "repo", n: "build-binary toolshed" },
+        suite: "binaries",
+        unit: "toolshed",
+      },
+      {
+        test: { k: "gate", s: "repo", n: "build-binary cf" },
+        suite: "binaries",
+        unit: "cf",
+      },
+    ]);
+    const { mandatory } = census(
+      [binaries],
+      manifest,
+      new Set(["packages/shell/index.ts"]),
+    );
+    expect(
+      mandatory.get(
+        testIdentityKey({ k: "gate", s: "repo", n: "build-binary toolshed" }),
+      ),
+    ).toBe("changed");
+    expect(
+      mandatory.get(
+        testIdentityKey({ k: "gate", s: "repo", n: "build-binary cf" }),
+      ),
+    ).toBeUndefined();
+  });
+
+  it("runs every unit of a suite marked always", () => {
+    const gates = suite({
+      id: "repo-gates",
+      mandatory: "always",
+      recordSurfaces: [{ kind: "gate", scope: "repo" }],
+      units: ["deno-fmt"],
+    });
+    const manifest = manifestOf([{
+      test: { k: "gate", s: "repo", n: "deno-fmt" },
+      suite: "repo-gates",
+      unit: "deno-fmt",
+    }]);
+    const { mandatory } = census([gates], manifest, new Set());
+    expect([...mandatory.values()]).toEqual(["always"]);
+  });
+
+  it("says nothing about a unit a configuration declares unavailable", () => {
+    const on = suite({
+      id: "package-integration-on",
+      variant: "server-execution",
+      units: ["packages/oven/a.test.ts"],
+      unavailable: [{
+        unit: "packages/oven/a.test.ts",
+        reason: "the surface it exercises has not landed",
+      }],
+    });
+    const seen = census([on], undefined, new Set());
+    expect(seen.mandatory.size).toBe(0);
+    expect(seen.manifest.entries).toEqual([]);
+  });
+
+  it("keeps a unit whose unavailability names only one leaf", () => {
+    // Every other identity in the file still runs, so taking the file
+    // out would stop far more than the configuration asked to stop.
+    const on = suite({
+      id: "package-integration-on",
+      variant: "server-execution",
+      units: ["packages/oven/a.test.ts"],
+      unavailable: [{
+        unit: "packages/oven/a.test.ts",
+        leafName: "bakes > slowly",
+        reason: "the surface that step exercises has not landed",
+      }],
+    });
+    expect(census([on], undefined, new Set()).mandatory.size).toBe(1);
+  });
+});
+
+describe("the identity a unit nothing has recorded stands on", () => {
+  const unit = "packages/oven/bakes.test.ts";
+  const on = suite({
+    id: "package-integration-opposite",
+    variant: "server-execution",
+    units: [unit],
+  });
+  const off = suite({ id: "package-integration", units: [unit] });
+
+  it("carries the configuration its suite runs in", () => {
+    expect(unknownIdentity(on, unit).v).toBe("server-execution");
+    expect(unknownIdentity(off, unit).v).toBeUndefined();
+  });
+
+  it("keeps two configurations of one unit apart", () => {
+    // A source file belongs to one default suite and one suite for each
+    // non-default configuration, and those are separate execution
+    // surfaces with separate histories. Were the stand-ins to collide,
+    // one entry would stand for both, one of the two would be placed in
+    // no lane, and the lane would exit zero having never run it.
+    const seen = census([off, on], undefined, new Set());
+    expect(seen.manifest.entries.length).toBe(2);
+    expect(new Set(seen.mandatory.keys()).size).toBe(2);
+    expect(seen.manifest.entries.map((entry) => entry.suite).toSorted())
+      .toEqual(["package-integration", "package-integration-opposite"]);
+  });
+
+  it("gives the whole topology as many stand-ins as it has units", async () => {
+    // The property above, over the repository's real suites rather than
+    // over a pair built to show it.
+    const suites = await loadTopology(REPOSITORY);
+    const seen = census(suites, undefined, new Set());
+    const available = suites.reduce(
+      (total, suite) =>
+        total + suite.units.length -
+        suite.unavailable.filter((entry) => entry.leafName === undefined)
+          .length,
+      0,
+    );
+    expect(seen.manifest.entries.length).toBe(available);
+    expect(new Set(seen.mandatory.keys()).size).toBe(available);
+  });
+});
+
+describe("what the tree says and the manifest does not", () => {
+  const bakery = suite({
+    id: "workspace-unit",
+    units: ["packages/bakery/glaze.test.ts", "packages/bakery/proof.test.ts"],
+    unavailable: [{
+      unit: "packages/bakery/gone.test.ts",
+      reason: "not in this configuration",
+    }],
+  });
+
+  it("drops an entry naming a unit this tree does not have", () => {
+    const stale = manifestOf([
+      { unit: "packages/bakery/glaze.test.ts" },
+      {
+        test: { k: "unit", s: "bakery", n: "gone > entirely" },
+        unit: "packages/bakery/gone.test.ts",
+      },
+      {
+        test: { k: "unit", s: "bakery", n: "deleted > long ago" },
+        unit: "packages/bakery/deleted.test.ts",
+      },
+    ]);
+    const seen = census([bakery], stale, new Set());
+    expect(seen.manifest.entries.map((entry) => entry.unit).toSorted())
+      .toEqual([
+        "packages/bakery/glaze.test.ts",
+        "packages/bakery/proof.test.ts",
+      ]);
+  });
+
+  it("says nothing about an identity withheld that it cannot run", () => {
+    const stale = manifestOf([{ unit: "packages/bakery/glaze.test.ts" }]);
+    stale.withheld = [
+      {
+        test: { k: "unit", s: "bakery", n: "glaze > sets" },
+        suite: "workspace-unit",
+        reason: "flaky",
+      },
+      {
+        test: { k: "unit", s: "bakery", n: "gone > entirely" },
+        suite: "workspace-unit",
+        reason: "flaky",
+      },
+    ];
+    const seen = census([bakery], stale, new Set());
+    expect(seen.manifest.withheld.map((held) => held.test.n))
+      .toEqual(["glaze > sets"]);
+  });
+
+  it("charges an unmeasured unit what its suite's middle unit costs", () => {
+    // Three units, holding one, three and one test. What a stand-in
+    // stands for is a whole unit, so the middle of 2, 30 and 200 is what
+    // it costs — not the middle of the seven tests inside them, which
+    // would charge a new file a fraction of what running it takes.
+    const wide = suite({
+      id: "workspace-unit",
+      units: [
+        "packages/bakery/glaze.test.ts",
+        "packages/bakery/proof.test.ts",
+        "packages/bakery/knead.test.ts",
+        "packages/bakery/rest.test.ts",
+      ],
+    });
+    const manifest = manifestOf([
+      { unit: "packages/bakery/glaze.test.ts", cost: 2 },
+      {
+        test: { k: "unit", s: "bakery", n: "proof > rises" },
+        unit: "packages/bakery/proof.test.ts",
+        cost: 10,
+      },
+      {
+        test: { k: "unit", s: "bakery", n: "proof > doubles" },
+        unit: "packages/bakery/proof.test.ts",
+        cost: 10,
+      },
+      {
+        test: { k: "unit", s: "bakery", n: "proof > slumps" },
+        unit: "packages/bakery/proof.test.ts",
+        cost: 10,
+      },
+      {
+        test: { k: "unit", s: "bakery", n: "knead > folds" },
+        unit: "packages/bakery/knead.test.ts",
+        cost: 200,
+      },
+    ]);
+    const seen = census([wide], manifest, new Set());
+    const standing = seen.manifest.entries.find((entry) =>
+      entry.unit === "packages/bakery/rest.test.ts"
+    );
+    expect(standing?.cost).toBe(30);
+  });
+
+  it("replaces what the publisher's own tree said, and its packing", () => {
+    const published = manifestOf([{ unit: "packages/bakery/glaze.test.ts" }]);
+    published.unavailable = [{
+      suite: "workspace-unit",
+      unit: "packages/bakery/somewhere-else.test.ts",
+      reason: "unavailable in the tree the publisher read",
+    }];
+    published.lanes = [{ lane: 1, projectedSeconds: 12, batches: [] }];
+    published.unschedulable = [{
+      test: { k: "unit", s: "bakery", n: "gone > entirely" },
+      suite: "workspace-unit",
+      cost: 900,
+    }];
+    const seen = census([bakery], published, new Set());
+    expect(seen.manifest.unavailable.map((entry) => entry.unit))
+      .toEqual(["packages/bakery/gone.test.ts"]);
+    // A packing over a corpus this is not answers a different question.
+    expect(seen.manifest.lanes).toEqual([]);
+    expect(seen.manifest.unschedulable).toEqual([]);
+    // What the store has seen is the store's figure, not this tree's.
+    expect(seen.manifest.known).toEqual(published.known);
+    expect(seen.manifest.calibration).toEqual(published.calibration);
+    expect(seen.manifest.seed).toBe(published.seed);
+  });
+
+  it("charges a suite with nothing measured the unmeasured figure", () => {
+    const seen = census([bakery], undefined, new Set());
+    expect(seen.manifest.entries.map((entry) => entry.cost))
+      .toEqual([UNMEASURED_COST_SECONDS, UNMEASURED_COST_SECONDS]);
+  });
+});

--- a/tasks/test-selection/census.test.ts
+++ b/tasks/test-selection/census.test.ts
@@ -231,6 +231,22 @@ describe("the identity a unit nothing has recorded stands on", () => {
       .toEqual(["package-integration", "package-integration-opposite"]);
   });
 
+  it("refuses a stand-in whose name a real test already has", () => {
+    // Vanishingly unlikely and cheap to refuse. What it costs to ignore
+    // is a unit that goes into no lane while everything downstream
+    // counts as though it had, which is a test that quietly stops
+    // running.
+    const collides = manifestOf([{
+      test: {
+        k: "unit",
+        s: "bakery",
+        n: `unrecorded ${"packages/oven/bakes.test.ts"}`,
+      },
+      unit: "packages/oven/somewhere-else.test.ts",
+    }]);
+    expect(() => census([off], collides, new Set())).toThrow("run nowhere");
+  });
+
   it("gives the whole topology as many stand-ins as it has units", async () => {
     // The property above, over the repository's real suites rather than
     // over a pair built to show it.

--- a/tasks/test-selection/census.ts
+++ b/tasks/test-selection/census.ts
@@ -1,0 +1,227 @@
+/**
+ * Reading a working tree against a manifest.
+ *
+ * The tree decides which tests exist and the manifest decides what each
+ * of them is worth and costs. Everything that chooses tests reads the
+ * result of this rather than the manifest the store gave, so a unit the
+ * manifest still names and the tree no longer has cannot be run, and a
+ * unit the tree has and no manifest has seen cannot be missed. Both
+ * mistakes were reachable while the full run read the tree and the
+ * pull-request run read the manifest.
+ */
+
+import { testIdentityKey } from "@commonfabric/test-support/records";
+import type { TestIdentity } from "@commonfabric/test-support/records";
+import {
+  type Suite,
+  unavailableUnits,
+  type Unit,
+} from "../test-topology/suite.ts";
+import {
+  emptyManifest,
+  type Manifest,
+  type ManifestEntry,
+} from "./manifest.ts";
+import type { SelectionReason } from "./plan.ts";
+import { UNMEASURED_COST_SECONDS, VALUE_FLOOR } from "./policy.ts";
+
+/**
+ * A stand-in identity for a unit no manifest has ever seen. Records exist
+ * only for tests that ran, so a unit with none is either brand new or
+ * renamed, and both must run. The packer needs something to place, and
+ * this is the least it can be given: the suite's own record surface and
+ * the unit's path, which no real record will ever collide with because a
+ * real record is named for a test rather than for a file.
+ */
+export function unknownIdentity(suite: Suite, unit: string): TestIdentity {
+  const surface = suite.recordSurfaces[0];
+  const test: TestIdentity = {
+    k: surface?.kind ?? "unit",
+    s: surface?.scope ?? "repo",
+    n: `unrecorded ${unit}`,
+  };
+  if (suite.variant !== undefined) test.v = suite.variant;
+  return test;
+}
+
+/**
+ * The middle value of a set of numbers, or nothing where the set is
+ * empty. The middle rather than the mean because measured test costs are
+ * extremely skewed: a tenth of them hold nine tenths of the time, so a
+ * mean says what the slowest few cost rather than what a test costs.
+ */
+function median(values: readonly number[]): number | undefined {
+  if (values.length === 0) return undefined;
+  const sorted = [...values].sort((a, b) => a - b);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 1
+    ? sorted[middle]!
+    : (sorted[middle - 1]! + sorted[middle]!) / 2;
+}
+
+/**
+ * The entry a unit no manifest has ever seen is carried on. Records exist
+ * only for tests that ran, so a unit with none is new or renamed, and
+ * both have to run.
+ *
+ * It is charged what the middle unit of its own suite costs. The suites
+ * are orders of magnitude apart — a unit test is milliseconds and a
+ * pattern integration test is tens of seconds — so one figure for all of
+ * them would misjudge most of them, and a suite's own units are the best
+ * guess there is at what a new one will take. Charging nothing, which is
+ * what a stand-in used to cost, made the packer treat every new test as
+ * free and put the whole of a new suite in the first lane it offered.
+ */
+export function standIn(
+  suite: Suite,
+  unit: Unit,
+  suiteCosts: readonly number[],
+): ManifestEntry {
+  return {
+    test: unknownIdentity(suite, unit),
+    suite: suite.id,
+    unit,
+    cost: median(suiteCosts) ?? UNMEASURED_COST_SECONDS,
+    score: VALUE_FLOOR,
+    inputs: { catches: 0, mainCatches: 0, sources: 0, churn: 0 },
+    flakeRate: 0,
+    repeats: 1,
+  };
+}
+
+/** What this working tree holds, and what has to run whatever it is worth. */
+export interface Census {
+  /**
+   * The manifest as this working tree sees it. The tree decides what
+   * exists and the manifest decides what each of those things is worth,
+   * so a unit the manifest still names and the tree no longer has drops
+   * out, and a unit the tree has and the manifest has never seen gets a
+   * stand-in. Everything downstream reads this rather than the manifest
+   * the store gave, which is what stops the run on `main` and the run on
+   * a pull request disagreeing about which tests exist.
+   */
+  manifest: Manifest;
+
+  /** Identities that run whatever they are worth, against the reason. */
+  mandatory: Map<string, SelectionReason>;
+
+  /**
+   * How many of the entries are stand-ins, which is how much of what
+   * this tree would run rests on a guess at the cost rather than on a
+   * measurement. Counted here because this is where the stand-ins are
+   * made; asking the manifest whether it arrived answers a different
+   * question, since one published before most of this tree existed
+   * arrives and still knows almost none of it.
+   */
+  unmeasured: number;
+}
+
+/**
+ * Reads the working tree against a manifest.
+ *
+ * Three rules make a unit mandatory: its suite is marked `always`, the
+ * change touched what it covers, or no manifest has ever seen it. The
+ * last of those is the rule the test-record spec requires of any consumer
+ * that selects which tests run. A selector that never runs the unselected
+ * starves its own data, and a renamed test is an unknown identity until
+ * an alias lands.
+ */
+export function census(
+  suites: readonly Suite[],
+  manifest: Manifest | undefined,
+  changed: ReadonlySet<string>,
+): Census {
+  // Everything below writes into the manifest this returns. What it does
+  // not touch is what a manifest says about its own publication rather
+  // than about a corpus: when it was generated, from which commit and
+  // how many runs, the dials it was built with, the exploration seed,
+  // the fitted costs, and `known`, which counts what the store has seen
+  // and is deliberately the store's figure rather than this tree's.
+  const inUnit = new Map<string, ManifestEntry[]>();
+  // What each known unit costs in total, which is what a stand-in stands
+  // for. A stand-in is a whole unit rather than one test in it, and a
+  // unit holds several tests — around seven on average across this
+  // repository — so charging it what one test costs would charge a new
+  // file a fraction of what running it takes.
+  const unitTotal = new Map<string, number>();
+  for (const entry of manifest?.entries ?? []) {
+    const key = `${entry.suite}\t${entry.unit}`;
+    inUnit.set(key, [...inUnit.get(key) ?? [], entry]);
+    unitTotal.set(key, (unitTotal.get(key) ?? 0) + entry.cost);
+  }
+  const costs = new Map<string, number[]>();
+  for (const [key, total] of unitTotal) {
+    const suite = key.slice(0, key.indexOf("\t"));
+    costs.set(suite, [...costs.get(suite) ?? [], total]);
+  }
+  const entries: ManifestEntry[] = [];
+  const mandatory = new Map<string, SelectionReason>();
+  let unmeasured = 0;
+  for (const suite of suites) {
+    const unavailable = unavailableUnits(suite);
+    // A unit that is a path is made mandatory by the diff naming it. A
+    // unit that is not — a type-check group, a binary — is one the suite
+    // has to map the diff onto itself, because only it knows what its
+    // unit covers.
+    const touched = new Set<string>(
+      suite.unitsForChange !== undefined
+        ? suite.unitsForChange(changed)
+        : suite.units.filter((unit) => changed.has(unit)),
+    );
+    for (const unit of suite.units) {
+      if (unavailable.has(unit)) continue;
+      const reason: SelectionReason | undefined = suite.mandatory === "always"
+        ? "always"
+        : touched.has(unit)
+        ? "changed"
+        : undefined;
+      const recorded = inUnit.get(`${suite.id}\t${unit}`);
+      if (recorded === undefined) {
+        const entry = standIn(suite, unit, costs.get(suite.id) ?? []);
+        entries.push(entry);
+        unmeasured += 1;
+        // Nothing in the manifest runs this unit, so it is unknown
+        // whatever else made it mandatory.
+        mandatory.set(testIdentityKey(entry.test), reason ?? "unknown");
+        continue;
+      }
+      entries.push(...recorded);
+      if (reason === undefined) continue;
+      for (const entry of recorded) {
+        mandatory.set(testIdentityKey(entry.test), reason);
+      }
+    }
+  }
+  const present = new Set(entries.map((entry) => testIdentityKey(entry.test)));
+  return {
+    manifest: {
+      ...(manifest ?? emptyManifest()),
+      entries,
+      // An identity held back that this tree cannot run is not something
+      // a lane has anything to say about.
+      withheld: (manifest?.withheld ?? []).filter((held) =>
+        present.has(testIdentityKey(held.test))
+      ),
+      // What this tree declares unavailable, in place of what the tree
+      // the publisher read declared.
+      unavailable: suites.flatMap((suite) =>
+        suite.unavailable.map((entry) => ({
+          suite: suite.id,
+          ...(suite.variant === undefined ? {} : { variant: suite.variant }),
+          unit: entry.unit,
+          ...(entry.leafName === undefined ? {} : { leafName: entry.leafName }),
+          ...(entry.phase === undefined ? {} : { phase: entry.phase }),
+          reason: entry.reason,
+        }))
+      ),
+      // The publisher's reference packing and its list of what would not
+      // fit are over the corpus it read, which is not this one. A plan
+      // over these entries works both out again, so carrying the
+      // publisher's would be offering an answer to a different question.
+      lanes: [],
+      unschedulable: [],
+    },
+    mandatory,
+    unmeasured,
+  };
+}

--- a/tasks/test-selection/census.ts
+++ b/tasks/test-selection/census.ts
@@ -156,6 +156,9 @@ export function census(
   }
   const entries: ManifestEntry[] = [];
   const mandatory = new Map<string, SelectionReason>();
+  const taken = new Set<string>(
+    (manifest?.entries ?? []).map((entry) => testIdentityKey(entry.test)),
+  );
   let unmeasured = 0;
   for (const suite of suites) {
     const unavailable = unavailableUnits(suite);
@@ -178,11 +181,27 @@ export function census(
       const recorded = inUnit.get(`${suite.id}\t${unit}`);
       if (recorded === undefined) {
         const entry = standIn(suite, unit, costs.get(suite.id) ?? []);
+        const key = testIdentityKey(entry.test);
+        // A stand-in is named for the unit it stands in for, and a real
+        // test could in principle be given that name. Two things would
+        // then share one key: the identity maps would keep one of them,
+        // and a unit would go into no lane while everything downstream
+        // counted as though it had. Nothing here can prevent a name, so
+        // the collision is refused where it is made rather than left to
+        // be found as a test that stopped running.
+        if (taken.has(key)) {
+          throw new Error(
+            `the stand-in for ${suite.id} ${unit} is named ${key}, and ` +
+              `something else in this corpus already is, so one of the ` +
+              `two would run nowhere`,
+          );
+        }
+        taken.add(key);
         entries.push(entry);
         unmeasured += 1;
         // Nothing in the manifest runs this unit, so it is unknown
         // whatever else made it mandatory.
-        mandatory.set(testIdentityKey(entry.test), reason ?? "unknown");
+        mandatory.set(key, reason ?? "unknown");
         continue;
       }
       entries.push(...recorded);

--- a/tasks/test-selection/manifest.ts
+++ b/tasks/test-selection/manifest.ts
@@ -9,6 +9,12 @@
 
 import { DIALS } from "./policy.ts";
 
+import {
+  digestIdentities,
+  type Manifest,
+  MANIFEST_SCHEMA_VERSION,
+} from "@commonfabric/test-support/records";
+
 export {
   digestIdentities,
   MANIFEST_SCHEMA_VERSION,
@@ -36,4 +42,32 @@ export function dialSnapshot(): Record<string, unknown> {
   const snapshot: Record<string, unknown> = {};
   for (const dial of DIALS) snapshot[dial.name] = dial.value;
   return snapshot;
+}
+
+/**
+ * A manifest carrying nothing, which is what a working tree is read
+ * against when the store has no manifest to give. The tree still decides
+ * what runs; what it loses is every figure saying which of its tests are
+ * worth more than the others, so all of them are unmeasured and all of
+ * them run.
+ */
+export function emptyManifest(): Manifest {
+  return {
+    schema: MANIFEST_SCHEMA_VERSION,
+    // A fixed moment rather than this one, so that reading a tree twice
+    // gives the same manifest both times.
+    generatedAt: new Date(0).toISOString(),
+    seed: "",
+    commit: "",
+    runs: 0,
+    dials: dialSnapshot(),
+    calibration: { setupCost: {}, suites: {}, unitOverhead: {}, prologue: 0 },
+    entries: [],
+    withheld: [],
+    unavailable: [],
+    unschedulable: [],
+    lanes: [],
+    known: { count: 0, digest: digestIdentities([]) },
+    coverageBaselines: [],
+  };
 }

--- a/tasks/test-selection/plan.test.ts
+++ b/tasks/test-selection/plan.test.ts
@@ -3,6 +3,7 @@ import { expect } from "@std/expect";
 import { testIdentityKey } from "@commonfabric/test-support/records";
 
 import {
+  fullLaneCount,
   plan,
   type PlanInput,
   seededOrder,
@@ -11,7 +12,11 @@ import {
 } from "./plan.ts";
 import type { Calibration, Manifest, ManifestEntry } from "./manifest.ts";
 import { sampleEntry, sampleManifest } from "./testing.ts";
-import { LANES, VALUE_FLOOR } from "./policy.ts";
+import {
+  FULL_LANE_BUDGET_SECONDS,
+  LANE_BUDGET_SECONDS,
+  LANES,
+} from "./policy.ts";
 
 const NO_CAPABILITIES = new Map<string, readonly string[]>();
 
@@ -628,91 +633,204 @@ describe("plan", () => {
   });
 });
 
-describe("an identity the manifest has never heard of", () => {
-  const KEY = '["unit","memory","brand new"]';
-  const WHERE = new Map([[KEY, {
-    suite: "workspace-unit",
-    unit: "packages/memory/test/new.test.ts",
-  }]]);
-
-  it("runs when the caller names it mandatory and says where it lives", () => {
-    const result = run(sampleManifest({ entries: entries(3) }), {
-      mandatory: new Map([[KEY, "changed" as const]]),
-      unknown: WHERE,
-    });
-    const taken = selected(result).find((s) =>
-      testIdentityKey(s.entry.test) === KEY
-    );
-    expect(taken).toBeDefined();
-    expect(taken!.reason).toBe("changed");
-    expect(taken!.repeats).toBe(1);
-    expect(taken!.entry.unit).toBe("packages/memory/test/new.test.ts");
-    // It has no history, so it stands in at the floor and costs nothing
-    // anybody measured.
-    expect(taken!.entry.score).toBe(VALUE_FLOOR);
-    expect(taken!.entry.cost).toBe(0);
-    expect(taken!.entry.inputs).toEqual({
-      catches: 0,
-      mainCatches: 0,
-      sources: 0,
-      churn: 0,
-    });
-  });
-
-  it("carries the configuration when the key names one", () => {
-    const key = '["unit","memory","brand new","server"]';
+describe("an identity the manifest does not carry", () => {
+  it("is left out, because nothing here knows what would run it", () => {
+    const key = '["unit","memory","brand new"]';
     const result = run(sampleManifest({ entries: entries(3) }), {
       mandatory: new Map([[key, "changed" as const]]),
-      unknown: new Map([[key, {
+    });
+    expect(keysOf(result)).not.toContain(key);
+  });
+});
+
+describe("running everything", () => {
+  /** A manifest whose entries differ in every way selection reads. */
+  function corpus(): Manifest {
+    return sampleManifest({
+      entries: [
+        ...entries(6, (i) => ({ cost: 1 + i, score: 0.9 - i / 10 })),
+        sampleEntry({ k: "unit", s: "memory", n: "flaky" }, {
+          unit: "packages/memory/test/flaky.test.ts",
+          flakeRate: 0.9,
+          cost: 2,
+        }),
+        sampleEntry({ k: "unit", s: "memory", n: "worthless" }, {
+          unit: "packages/memory/test/worthless.test.ts",
+          score: 0,
+          cost: 2,
+        }),
+      ],
+      withheld: [{
+        test: { k: "unit", s: "memory", n: "worthless" },
         suite: "workspace-unit",
-        unit: "packages/memory/test/new.test.ts",
-      }]]),
+        reason: "main-red",
+      }],
     });
-    const taken = selected(result).find((s) =>
-      testIdentityKey(s.entry.test) === key
+  }
+
+  it("runs every identity once, whatever it is worth", () => {
+    const result = run(corpus(), { policy: "everything" });
+    expect(keysOf(result)).toEqual(
+      corpus().entries.map((entry) => testIdentityKey(entry.test)).sort(),
     );
-    expect(taken?.entry.test).toEqual({
-      k: "unit",
-      s: "memory",
-      n: "brand new",
-      v: "server",
-    });
+    expect(selected(result).every((s) => s.repeats === 1)).toBe(true);
+    expect(selected(result).every((s) => s.reason === "full")).toBe(true);
   });
 
-  it("is left out when nobody said where it lives", () => {
-    const result = run(sampleManifest({ entries: entries(3) }), {
-      mandatory: new Map([[KEY, "changed" as const]]),
-    });
-    expect(keysOf(result)).not.toContain(KEY);
+  it("says it withheld nothing, because it ran everything", () => {
+    expect(run(corpus()).withheld.length).toBe(1);
+    expect(run(corpus(), { policy: "everything" }).withheld).toEqual([]);
   });
 
-  it("is left out when the key is not a key at all", () => {
-    for (
-      const key of ["not json", "[]", '["unit","memory"]', '["unit",7,"n"]']
-    ) {
-      const result = run(sampleManifest({ entries: entries(3) }), {
-        mandatory: new Map([[key, "changed" as const]]),
-        unknown: new Map([[key, {
-          suite: "workspace-unit",
-          unit: "packages/memory/test/new.test.ts",
-        }]]),
-      });
-      expect(
-        selected(result).some((s) => testIdentityKey(s.entry.test) === key),
-      )
-        .toBe(false);
+  it("runs what a budgeted plan withholds and excludes", () => {
+    const budgeted = keysOf(run(corpus()));
+    const flaky = testIdentityKey({ k: "unit", s: "memory", n: "flaky" });
+    const red = testIdentityKey({ k: "unit", s: "memory", n: "worthless" });
+    expect(budgeted).not.toContain(flaky);
+    expect(budgeted).not.toContain(red);
+    const full = keysOf(run(corpus(), { policy: "everything" }));
+    expect(full).toContain(flaky);
+    expect(full).toContain(red);
+  });
+
+  it("reports nothing unschedulable, since it places everything", () => {
+    const manifest = sampleManifest({
+      entries: entries(2, () => ({ cost: 5_000 })),
+    });
+    expect(run(manifest).unschedulable.length).toBe(2);
+    const full = run(manifest, { policy: "everything" });
+    expect(full.unschedulable).toEqual([]);
+    expect(keysOf(full).length).toBe(2);
+  });
+
+  it("takes the full run's budget rather than a pull request's", () => {
+    // Work that fits one lane of the full run and does not fit one of a
+    // pull request's, which is the whole gap between the two dials.
+    const manifest = sampleManifest({
+      entries: entries(FULL_LANE_BUDGET_SECONDS, () => ({ cost: 1 })),
+    });
+    const full = run(manifest, { policy: "everything", lanes: 1 });
+    expect(full.budgetSeconds).toBe(FULL_LANE_BUDGET_SECONDS);
+    expect(full.overBudgetSeconds).toBe(0);
+    const budgeted = run(manifest, {
+      policy: "everything",
+      lanes: 1,
+      budgetSeconds: LANE_BUDGET_SECONDS,
+    });
+    expect(budgeted.overBudgetSeconds).toBeGreaterThan(0);
+  });
+
+  it("places every identity, however awkward the corpus", () => {
+    // A corpus mixing tests that fit easily, tests larger than a lane,
+    // and tests a budgeted plan would exclude. None of it may go
+    // missing: what `main` does not run, nothing runs.
+    const manifest = sampleManifest({
+      entries: [
+        ...entries(40, (i) => ({ cost: i % 7 === 0 ? 5_000 : i / 10 })),
+        sampleEntry({ k: "unit", s: "memory", n: "flaky" }, {
+          unit: "packages/memory/test/flaky.test.ts",
+          flakeRate: 1,
+        }),
+      ],
+    });
+    for (const lanes of [1, 2, 5, 13]) {
+      const result = run(manifest, { policy: "everything", lanes });
+      expect(keysOf(result).length).toBe(manifest.entries.length);
+      expect(new Set(keysOf(result)).size).toBe(manifest.entries.length);
     }
   });
 
-  it("does not stand in for an identity the manifest does carry", () => {
-    const known = testIdentityKey({ k: "unit", s: "memory", n: "case 0" });
-    const result = run(sampleManifest({ entries: entries(3) }), {
-      mandatory: new Map([[known, "changed" as const]]),
-      unknown: new Map([[known, { suite: "elsewhere", unit: "elsewhere.ts" }]]),
+  it("gives the same answer every time it is asked", () => {
+    const once = run(corpus(), { policy: "everything" });
+    const twice = run(corpus(), { policy: "everything" });
+    expect(JSON.stringify(once)).toBe(JSON.stringify(twice));
+  });
+});
+
+describe("how many lanes the full run needs", () => {
+  const capabilities = NO_CAPABILITIES;
+
+  function count(manifest: Manifest, overrides: Partial<PlanInput> = {}) {
+    return fullLaneCount({ manifest, capabilities, ...overrides });
+  }
+
+  it("takes one lane for work that fits in one", () => {
+    expect(count(sampleManifest({ entries: entries(5, () => ({ cost: 1 })) })))
+      .toBe(1);
+  });
+
+  it("takes enough lanes that none of them runs long", () => {
+    // Three lanes' worth of work, in tests small enough that the packer
+    // can divide them evenly.
+    const manifest = sampleManifest({
+      entries: entries(FULL_LANE_BUDGET_SECONDS * 3, () => ({ cost: 1 })),
     });
-    const taken = selected(result).find((s) =>
-      testIdentityKey(s.entry.test) === known
+    const lanes = count(manifest);
+    expect(lanes).toBe(3);
+    const packed = plan({
+      manifest,
+      mandatory: new Map(),
+      capabilities,
+      policy: "everything",
+      lanes,
+    });
+    expect(packed.overBudgetSeconds).toBe(0);
+  });
+
+  it("honors a budget it was handed", () => {
+    const manifest = sampleManifest({
+      entries: entries(600, () => ({ cost: 1 })),
+    });
+    expect(count(manifest, { budgetSeconds: 100 })).toBe(6);
+  });
+
+  it("stops rather than chasing work no number of lanes can fit", () => {
+    // One identity larger than a whole lane and nothing else. Its lane
+    // runs long however many lanes there are, so adding lanes buys
+    // nothing and the search stops.
+    const manifest = sampleManifest({
+      entries: [
+        sampleEntry({ k: "unit", s: "memory", n: "vast" }, {
+          unit: "packages/memory/test/vast.test.ts",
+          cost: 5_000,
+        }),
+      ],
+    });
+    expect(count(manifest)).toBe(1);
+  });
+
+  it("keeps adding lanes for work one oversized test would hide", () => {
+    // The oversized test pins the worst lane's overrun at every count,
+    // so a search reading the worst lane alone would stop at once and
+    // leave every other lane crowded. What the rest of the corpus needs
+    // is what decides the count.
+    const manifest = sampleManifest({
+      entries: [
+        ...entries(40, () => ({ cost: 100 })),
+        sampleEntry({ k: "unit", s: "memory", n: "vast" }, {
+          unit: "packages/memory/test/vast.test.ts",
+          cost: 900,
+        }),
+      ],
+    });
+    const lanes = count(manifest);
+    const packed = plan({
+      manifest,
+      mandatory: new Map(),
+      capabilities,
+      policy: "everything",
+      lanes,
+    });
+    // Every lane but the one carrying the oversized test fits its
+    // budget, and that one carries nothing else.
+    const over = packed.lanes.filter((lane) =>
+      lane.projectedSeconds > packed.budgetSeconds
     );
-    expect(taken?.entry.unit).toBe("packages/memory/test/case-0.test.ts");
+    expect(over.length).toBe(1);
+    expect(over[0]!.selections.length).toBe(1);
+  });
+
+  it("takes one lane for a corpus of nothing", () => {
+    expect(count(sampleManifest({ entries: [] }))).toBe(1);
   });
 });

--- a/tasks/test-selection/plan.test.ts
+++ b/tasks/test-selection/plan.test.ts
@@ -633,13 +633,34 @@ describe("plan", () => {
   });
 });
 
-describe("an identity the manifest does not carry", () => {
-  it("is left out, because nothing here knows what would run it", () => {
-    const key = '["unit","memory","brand new"]';
-    const result = run(sampleManifest({ entries: entries(3) }), {
-      mandatory: new Map([[key, "changed" as const]]),
+describe("an identity a manifest carries twice", () => {
+  it("runs it once, rather than placing it in two lanes", () => {
+    // A duplicated entry is one identity however many rows describe it,
+    // and running it twice would charge a lane for work it did not do.
+    const twice = sampleEntry({ k: "unit", s: "memory", n: "case 0" }, {
+      unit: "packages/memory/test/case-0.test.ts",
     });
-    expect(keysOf(result)).not.toContain(key);
+    const manifest = sampleManifest({
+      entries: [...entries(3), twice],
+    });
+    const key = testIdentityKey(twice.test);
+    const placed = keysOf(run(manifest)).filter((k) => k === key);
+    expect(placed.length).toBe(1);
+  });
+});
+
+describe("an identity the manifest does not carry", () => {
+  it("refuses to plan, rather than dropping a test that must run", () => {
+    // Whoever read the tree carries a stand-in for every unit it holds,
+    // so this is the caller naming something mandatory and handing over
+    // a corpus without it. Leaving it out would report a pass over a
+    // test that never ran, which is the failure with no trace.
+    const key = '["unit","memory","brand new"]';
+    expect(() =>
+      run(sampleManifest({ entries: entries(3) }), {
+        mandatory: new Map([[key, "changed" as const]]),
+      })
+    ).toThrow("must run");
   });
 });
 
@@ -784,19 +805,73 @@ describe("how many lanes the full run needs", () => {
     expect(count(manifest, { budgetSeconds: 100 })).toBe(6);
   });
 
+  it("adds lanes while each one still buys something", () => {
+    // The fewest lanes the raw work could fit in is not enough lanes,
+    // because a lane loses part of its budget to the overhead of the
+    // suite it opens. The search has to climb past that starting point,
+    // and this is the case that makes it: three lanes hold 1,440
+    // seconds of tests only if their overheads are free, and they are
+    // not.
+    const manifest = sampleManifest({
+      entries: entries(24, () => ({ cost: 60 })),
+      calibration: {
+        setupCost: {},
+        suites: { "workspace-unit": { overhead: 150, correction: 1 } },
+        unitOverhead: {},
+        prologue: 0,
+      },
+    });
+    const work = manifest.entries.reduce((total, e) => total + e.cost, 0);
+    const floor = Math.ceil(work / FULL_LANE_BUDGET_SECONDS);
+    const lanes = count(manifest);
+    expect(lanes).toBeGreaterThan(floor);
+    const packed = plan({
+      manifest,
+      mandatory: new Map(),
+      capabilities,
+      policy: "everything",
+      lanes,
+    });
+    expect(packed.overBudgetSeconds).toBe(0);
+  });
+
   it("stops rather than chasing work no number of lanes can fit", () => {
-    // One identity larger than a whole lane and nothing else. Its lane
-    // runs long however many lanes there are, so adding lanes buys
-    // nothing and the search stops.
+    // The search has to reach its stopping rule to be tested by this, so
+    // the corpus has to be one where lanes are still worth adding for a
+    // while and then stop being. A single oversized identity would cap
+    // the search at one lane before the loop ran at all, and the case
+    // would pass with the rule deleted.
     const manifest = sampleManifest({
       entries: [
+        ...entries(20, () => ({ cost: 100 })),
         sampleEntry({ k: "unit", s: "memory", n: "vast" }, {
           unit: "packages/memory/test/vast.test.ts",
-          cost: 5_000,
+          cost: FULL_LANE_BUDGET_SECONDS * 3,
         }),
       ],
     });
-    expect(count(manifest)).toBe(1);
+    const lanes = count(manifest);
+    // Adding lanes past this buys nothing, because what is left over
+    // budget is one identity no lane can hold.
+    const at = (n: number) =>
+      plan({
+        manifest,
+        mandatory: new Map(),
+        capabilities,
+        policy: "everything",
+        lanes: n,
+      });
+    const overrun = (result: ReturnType<typeof plan>) =>
+      result.lanes.reduce(
+        (total, lane) =>
+          total + Math.max(0, lane.projectedSeconds - result.budgetSeconds),
+        0,
+      );
+    expect(overrun(at(lanes))).toBeGreaterThan(0);
+    expect(overrun(at(lanes + 1))).toBeGreaterThan(overrun(at(lanes)) - 1);
+    // And it did reach the rule rather than stopping at the cap.
+    expect(lanes).toBeGreaterThan(1);
+    expect(lanes).toBeLessThan(manifest.entries.length);
   });
 
   it("keeps adding lanes for work one oversized test would hide", () => {

--- a/tasks/test-selection/plan.ts
+++ b/tasks/test-selection/plan.ts
@@ -9,19 +9,17 @@
  * The exploration draw's seed comes from the manifest.
  */
 
-import {
-  type TestIdentity,
-  testIdentityKey,
-} from "@commonfabric/test-support/records";
+import { testIdentityKey } from "@commonfabric/test-support/records";
 import {
   FILL_DENSITY_SHARE,
   FILL_EXPLORATION_SHARE,
   FILL_VALUE_SHARE,
   FLAKE_EXCLUSION_RATE,
+  FULL_LANE_BOUND_SECONDS,
+  FULL_LANE_BUDGET_SECONDS,
   LANE_BOUND_SECONDS,
   LANE_BUDGET_SECONDS,
   LANES,
-  VALUE_FLOOR,
 } from "./policy.ts";
 import type {
   Manifest,
@@ -38,7 +36,22 @@ export type SelectionReason =
   | "coverage-gate"
   | "value"
   | "density"
-  | "exploration";
+  | "exploration"
+  | "full";
+
+/**
+ * How much of the corpus a plan runs, which is the whole of the
+ * difference between what a pull request runs and what `main` runs.
+ *
+ * `budgeted` spends a bounded amount on the tests worth the most, which
+ * is the four passes below. `everything` runs the corpus it was given,
+ * once each. Under `everything` every identity is required, so the
+ * exclusions and the three discretionary passes have nothing to act on
+ * and the rest of this file behaves the same way for both. Keeping the
+ * difference to one value is what stops the two runs drifting into
+ * packing the same tests differently.
+ */
+export type Policy = "budgeted" | "everything";
 
 /** One identity the plan runs, and what put it there. */
 export interface Selection {
@@ -70,7 +83,18 @@ export interface LaneAssignment {
 export interface Plan {
   lanes: LaneAssignment[];
 
-  /** Identities the manifest withheld, so a lane can say why. */
+  /**
+   * Seconds each of these lanes was packed against, which the policy
+   * decides. Carried here so that whatever reports a lane's projected
+   * time reports it against the figure it was actually judged by, rather
+   * than working the figure out a second time.
+   */
+  budgetSeconds: number;
+
+  /**
+   * Identities this plan declined to run, so a lane can say why. Empty
+   * for a full run, which declines nothing.
+   */
   withheld: Manifest["withheld"];
 
   /**
@@ -108,21 +132,20 @@ export interface PlanInput {
   /** Which capabilities each suite needs. */
   capabilities: ReadonlyMap<string, readonly string[]>;
 
-  /**
-   * Where an identity the manifest does not carry runs, by identity key.
-   * An identity with no records is mandatory, and the manifest cannot say
-   * where it runs precisely because it has never seen it, so whoever
-   * enumerated the tree says instead.
-   */
-  unknown?: ReadonlyMap<string, { suite: string; unit: string }>;
+  /** How much of the manifest to run. Defaults to `budgeted`. */
+  policy?: Policy;
 
   /** How many lanes to fill, at least one. Defaults to the dial. */
   lanes?: number;
 
-  /** Seconds each lane may fill. Defaults to the dial. */
+  /**
+   * Seconds each lane may fill. Defaults to the dial the policy belongs
+   * to, so that the full run cannot be packed against a pull request's
+   * budget by leaving one field out.
+   */
   budgetSeconds?: number;
 
-  /** The hard bound on a lane's work step. Defaults to the dial. */
+  /** The hard bound on a lane's work step. Defaults to the policy's dial. */
   boundSeconds?: number;
 }
 
@@ -337,7 +360,9 @@ export function plan(input: PlanInput): Plan {
       `a plan needs a lane to fill, and was asked for ${laneCount}`,
     );
   }
-  const laneBudget = input.budgetSeconds ?? LANE_BUDGET_SECONDS;
+  const everything = input.policy === "everything";
+  const laneBudget = input.budgetSeconds ??
+    (everything ? FULL_LANE_BUDGET_SECONDS : LANE_BUDGET_SECONDS);
   const budget = laneBudget * laneCount;
   const lanes: Filling[] = Array.from({ length: laneCount }, (_, i) => ({
     lane: i + 1,
@@ -348,11 +373,24 @@ export function plan(input: PlanInput): Plan {
     load: 0,
   }));
 
-  const bound = input.boundSeconds ?? LANE_BOUND_SECONDS;
+  const bound = input.boundSeconds ??
+    (everything ? FULL_LANE_BOUND_SECONDS : LANE_BOUND_SECONDS);
   const byKey = new Map<string, ManifestEntry>();
   for (const entry of manifest.entries) {
     byKey.set(testIdentityKey(entry.test), entry);
   }
+
+  // What runs whatever anything else says. A full run is the case where
+  // that is the whole corpus, which is why it needs no pass of its own:
+  // the mandatory pass below places every identity, and the three
+  // discretionary passes then find nothing left to take.
+  const requiredOf: ReadonlyMap<string, SelectionReason> = everything
+    ? new Map(
+      manifest.entries.map((
+        entry,
+      ) => [testIdentityKey(entry.test), "full" as SelectionReason]),
+    )
+    : input.mandatory;
 
   // An identity whose own measured time is past the hard bound shares a
   // lane with nothing, so a discretionary one is reported rather than
@@ -363,7 +401,7 @@ export function plan(input: PlanInput): Plan {
   // first, because that is what the time will actually be.
   const unschedulable: UnschedulableEntry[] = [];
   for (const entry of manifest.entries) {
-    if (input.mandatory.has(testIdentityKey(entry.test))) continue;
+    if (requiredOf.has(testIdentityKey(entry.test))) continue;
     // What an empty lane would pay for it: its own corrected time plus
     // every overhead and setup that lane would open. Charging only the
     // test's own time would schedule an identity whose suite, unit, and
@@ -382,11 +420,11 @@ export function plan(input: PlanInput): Plan {
   );
   for (const held of manifest.withheld) {
     const key = testIdentityKey(held.test);
-    if (!input.mandatory.has(key)) excluded.add(key);
+    if (!requiredOf.has(key)) excluded.add(key);
   }
   for (const entry of manifest.entries) {
     const key = testIdentityKey(entry.test);
-    if (entry.flakeRate > FLAKE_EXCLUSION_RATE && !input.mandatory.has(key)) {
+    if (entry.flakeRate > FLAKE_EXCLUSION_RATE && !requiredOf.has(key)) {
       excluded.add(key);
     }
   }
@@ -404,15 +442,12 @@ export function plan(input: PlanInput): Plan {
     entry: ManifestEntry;
     cost: number;
   }[] = [];
-  for (const [key, reason] of input.mandatory) {
-    // An identity the manifest has never heard of is exactly the one that
-    // must run: records exist only for tests that ran, and a renamed test
-    // is unknown until an alias lands. Dropping it here would break the
-    // rule the caller invoked by naming it mandatory, so it is carried on
-    // an entry standing in for the history it has none of — the floor
-    // score, and no measured cost, which is what an unrun test costs as
-    // far as anything here knows.
-    const entry = byKey.get(key) ?? unknownEntry(key, input);
+  for (const [key, reason] of requiredOf) {
+    // An identity the manifest does not carry cannot be placed, because
+    // nothing here knows which suite would run it. Whoever enumerated the
+    // working tree carries a stand-in entry for it, so the identities
+    // that reach this without one are the ones no tree holds.
+    const entry = byKey.get(key);
     if (entry === undefined) continue;
     required.push({
       key,
@@ -521,6 +556,27 @@ export function plan(input: PlanInput): Plan {
     withRepeats,
   );
 
+  // The full run is the safety net under everything else, so a test it
+  // fails to place is a test nothing anywhere runs, and the run reports
+  // a pass over it. That the mandatory pass places every identity it is
+  // given follows from every lane being a candidate for work that fits
+  // in none of them, but an argument is the wrong thing to rest that on:
+  // a green run over tests that never ran is the one failure of this
+  // design that would leave no trace, so it is checked here rather than
+  // reasoned about.
+  if (everything) {
+    const placed = lanes.reduce(
+      (total, lane) => total + lane.selections.length,
+      0,
+    );
+    if (placed !== requiredOf.size) {
+      throw new Error(
+        `a full plan placed ${placed} of ${requiredOf.size} identities, ` +
+          `so ${requiredOf.size - placed} would run nowhere`,
+      );
+    }
+  }
+
   return {
     lanes: lanes.map((lane) => ({
       lane: lane.lane,
@@ -528,45 +584,85 @@ export function plan(input: PlanInput): Plan {
       projectedSeconds: lane.load,
       capabilities: [...lane.capabilities].sort(),
     })),
-    withheld: manifest.withheld,
+    budgetSeconds: laneBudget,
+    // A full run withholds nothing: every identity is required, so the
+    // reasons the manifest gives for holding one back never applied.
+    // Reporting the manifest's list here would have a run that ran a
+    // test say in its own summary that no lane chose it.
+    withheld: everything ? [] : manifest.withheld,
     overBudgetSeconds: overBudget,
     unschedulable,
   };
 }
 
 /**
- * A stand-in entry for an identity the manifest does not carry. The
- * caller says where it runs, because only the topology knows; without
- * that the identity cannot be placed and is reported rather than run.
+ * How many lanes the full run needs.
+ *
+ * A pull request has a fixed number of lanes, so each one works out its
+ * own share and no job sits ahead of them. `main` cannot: the number
+ * depends on how much work there is, and the job matrix has to be known
+ * before anything starts. So one job answers this, and an integer is the
+ * whole of what it answers. The lanes then call `plan` over the same
+ * manifest and take their own share of it, exactly as the pull-request
+ * lanes do, so there is no second packing anywhere that could disagree
+ * with the first.
+ *
+ * The search starts at the fewest lanes the work could conceivably fit
+ * in and adds one while that helps. What it measures is the total by
+ * which the lanes are over budget rather than the worst single lane: a
+ * test costing more than a whole lane holds its own lane over budget at
+ * every count, so the worst lane stops moving while every other lane is
+ * still crowded, and a search reading the worst lane would stop there
+ * and leave the rest of the run packed twice as tight as it asked for.
+ * The total keeps falling while lanes are still worth adding and stops
+ * falling once only the unsplittable part is left, which is where the
+ * search stops. It terminates on that total, which cannot fall below
+ * zero, and on one lane per identity being the finest packing there is.
  */
-function unknownEntry(
-  key: string,
-  input: PlanInput,
-): ManifestEntry | undefined {
-  const surface = input.unknown?.get(key);
-  if (surface === undefined) return undefined;
-  let test: TestIdentity;
-  try {
-    const [k, s, n, v] = JSON.parse(key) as string[];
-    if (
-      typeof k !== "string" || typeof s !== "string" || typeof n !== "string"
-    ) {
-      return undefined;
-    }
-    test = v === undefined ? { k, s, n } : { k, s, n, v };
-  } catch {
-    return undefined;
+export function fullLaneCount(
+  input: Omit<PlanInput, "policy" | "lanes" | "mandatory">,
+): number {
+  const manifest = input.manifest;
+  const budget = input.budgetSeconds ?? FULL_LANE_BUDGET_SECONDS;
+  // The tests' own corrected time, with no lane overhead in it. Every
+  // overhead a lane pays only raises the answer, so this is a floor and
+  // starting below it would measure packings that cannot fit.
+  const work = manifest.entries.reduce(
+    (total, entry) =>
+      total + entry.cost *
+        (manifest.calibration.suites[entry.suite]?.correction ?? 1),
+    0,
+  );
+  const most = Math.max(1, manifest.entries.length);
+  let count = Math.min(most, Math.max(1, Math.ceil(work / budget)));
+  const packed = (lanes: number) =>
+    plan({
+      ...input,
+      // Under `everything` every identity is required, so there is
+      // nothing a caller could add to this that would change the answer.
+      mandatory: new Map(),
+      policy: "everything",
+      budgetSeconds: budget,
+      lanes,
+    });
+  /** Seconds by which the lanes are over budget, added up over all of them. */
+  const overrun = (result: Plan): number =>
+    result.lanes.reduce(
+      (total, lane) => total + Math.max(0, lane.projectedSeconds - budget),
+      0,
+    );
+  let best = overrun(packed(count));
+  while (best > 0 && count < most) {
+    const next = overrun(packed(count + 1));
+    // A lane has to buy at least a second to be worth adding. Stopping
+    // only on no improvement at all would let a run of ever smaller ones
+    // carry the search as far as there are identities, and a lane's
+    // budget is counted in seconds, so anything under one is noise.
+    if (next > best - 1) break;
+    count += 1;
+    best = next;
   }
-  return {
-    test,
-    suite: surface.suite,
-    unit: surface.unit,
-    cost: 0,
-    score: VALUE_FLOOR,
-    inputs: { catches: 0, mainCatches: 0, sources: 0, churn: 0 },
-    flakeRate: 0,
-    repeats: 1,
-  };
+  return count;
 }
 
 function laneLoad(lanes: readonly Filling[]): number {

--- a/tasks/test-selection/plan.ts
+++ b/tasks/test-selection/plan.ts
@@ -445,10 +445,22 @@ export function plan(input: PlanInput): Plan {
   for (const [key, reason] of requiredOf) {
     // An identity the manifest does not carry cannot be placed, because
     // nothing here knows which suite would run it. Whoever enumerated the
-    // working tree carries a stand-in entry for it, so the identities
-    // that reach this without one are the ones no tree holds.
+    // working tree carries a stand-in entry for every unit it holds, so
+    // reaching this without one means the caller named something
+    // mandatory and handed over a corpus that does not contain it.
+    //
+    // Skipping it instead would drop a test that must run and say
+    // nothing, and a run reporting a pass over a test that never ran is
+    // the one failure of this design that would leave no trace. Every
+    // identity being placed once it is required is then what makes the
+    // full run complete, so that needs no separate check afterwards.
     const entry = byKey.get(key);
-    if (entry === undefined) continue;
+    if (entry === undefined) {
+      throw new Error(
+        `${key} must run, and the corpus this was given does not carry ` +
+          `it, so nothing here knows what would run it`,
+      );
+    }
     required.push({
       key,
       reason,
@@ -555,27 +567,6 @@ export function plan(input: PlanInput): Plan {
     bound,
     withRepeats,
   );
-
-  // The full run is the safety net under everything else, so a test it
-  // fails to place is a test nothing anywhere runs, and the run reports
-  // a pass over it. That the mandatory pass places every identity it is
-  // given follows from every lane being a candidate for work that fits
-  // in none of them, but an argument is the wrong thing to rest that on:
-  // a green run over tests that never ran is the one failure of this
-  // design that would leave no trace, so it is checked here rather than
-  // reasoned about.
-  if (everything) {
-    const placed = lanes.reduce(
-      (total, lane) => total + lane.selections.length,
-      0,
-    );
-    if (placed !== requiredOf.size) {
-      throw new Error(
-        `a full plan placed ${placed} of ${requiredOf.size} identities, ` +
-          `so ${requiredOf.size - placed} would run nowhere`,
-      );
-    }
-  }
 
   return {
     lanes: lanes.map((lane) => ({

--- a/tasks/test-selection/policy.ts
+++ b/tasks/test-selection/policy.ts
@@ -36,11 +36,34 @@ export const LANE_SAFETY_SECONDS = 30;
 export const LANE_BUDGET_SECONDS = LANE_BOUND_SECONDS -
   LANE_PROLOGUE_SECONDS - LANE_SAFETY_SECONDS;
 
-/** What one lane of the full run on `main` may hold. */
-export const FULL_LANE_BUDGET_SECONDS = 600;
+/**
+ * The hard bound on a lane of the full run on `main`. Ten minutes: `main`
+ * makes no promise about a first answer the way a pull request does, so
+ * this is chosen for how many jobs the run should take rather than for
+ * how long anybody waits.
+ */
+export const FULL_LANE_BOUND_SECONDS = 600;
+
+/**
+ * What the packer may fill in a lane of the full run, derived from that
+ * lane's bound exactly as a pull request's is from its own. A lane of
+ * either run pays the same prologue and wants the same headroom, because
+ * both are the same job doing the same setup on the same runner; what
+ * differs between them is only the bound they are held to.
+ */
+export const FULL_LANE_BUDGET_SECONDS = FULL_LANE_BOUND_SECONDS -
+  LANE_PROLOGUE_SECONDS - LANE_SAFETY_SECONDS;
 
 /** The label that runs everything on a pull request. */
 export const FULL_RUN_LABEL = "ci: full";
+
+/**
+ * What one execution of a test nothing has measured is charged, where the
+ * suite it belongs to has no measured test to take a figure from. Charging
+ * nothing instead would make the packer treat every unmeasured test as
+ * free, and free work all fits in the first lane it is offered.
+ */
+export const UNMEASURED_COST_SECONDS = 1;
 
 /** The score of a test that has never failed anywhere. */
 export const VALUE_FLOOR = 0.05;
@@ -314,12 +337,22 @@ export const DIALS: readonly Dial[] = [
       "written down.",
   },
   {
-    name: "FULL_LANE_BUDGET_SECONDS",
-    value: FULL_LANE_BUDGET_SECONDS,
+    name: "FULL_LANE_BOUND_SECONDS",
+    value: FULL_LANE_BOUND_SECONDS,
     unit: "seconds",
     setBy: "chosen",
     why: "Up when the run on `main` uses more jobs than it needs; down when " +
       "`main` takes too long to say something broke.",
+  },
+  {
+    name: "FULL_LANE_BUDGET_SECONDS",
+    value: FULL_LANE_BUDGET_SECONDS,
+    unit: "seconds",
+    setBy: "derived",
+    why: "Nothing edits this. It is the full run's bound less the same " +
+      "prologue and safety margin a pull request's lane pays, so a lane of " +
+      "either run is packed against what is left after the parts the " +
+      "packer does not control.",
   },
   {
     name: "FULL_RUN_LABEL",
@@ -328,6 +361,16 @@ export const DIALS: readonly Dial[] = [
     setBy: "chosen",
     why: "Not a quantity. Change it only if the label collides with one the " +
       "repository already uses for something else.",
+  },
+  {
+    name: "UNMEASURED_COST_SECONDS",
+    value: UNMEASURED_COST_SECONDS,
+    unit: "seconds",
+    setBy: "chosen",
+    why: "Up when a lane holding new tests runs long; down when it finishes " +
+      "early. It is reached for only by a suite with no measured test at " +
+      "all, since a suite that has any charges an unmeasured one what its " +
+      "middle test costs.",
   },
   {
     name: "VALUE_FLOOR",


### PR DESCRIPTION
The full run on `main` and the selected run on a pull request were packed by two different functions. `everyBatch` walked the working tree and spread units round-robin; `plan` walked the manifest and packed by cost. They disagreed about which artifact says what exists, and that one disagreement produced every other difference between them.

Given a manifest published before the tree changed, the two ran disjoint sets. `everyBatch` filtered the units a configuration declares unavailable; the path that turned a plan into batches did not, and it never checked that a unit the manifest named was still in the tree. So a suite whose tree held one file and whose manifest still named another ran the tree's file on `main` and the manifest's file on a pull request.

Units no manifest had seen were charged nothing, and free work all fits in the first lane it is offered: ten unrecorded units packed as [10,0,0,0,0] rather than [2,2,2,2,2]. The full run spread them evenly, so the mode with the worse behaviour was the one that runs on every pull request, and it was worst on the day a new suite lands.

The full run also ignored the budget it was given, since round-robin distribution reads no cost table, and every lane of it opened every capability. And skip lists were built only on the pull-request path, so the mechanism that runs one test out of a file was exercised nowhere that `main` could catch a fault in it.

## What replaces them

One path in three stages, each with one implementation.

A **census** reads the working tree against the manifest and produces the manifest as that tree sees it: an entry for every identity the topology can run and nothing for one it cannot. The tree decides what exists and the manifest decides what each thing is worth, so an entry naming a unit the tree no longer holds drops out and a unit nothing has measured gains a stand-in. It reconciles the fields that describe a corpus and leaves alone the ones that describe a publication, and it counts the stand-ins it made, which is how much of any plan over it rests on a guess.

A **policy** decides how much of that runs, and it is the whole of the difference between the two runs. Under `everything` every identity is required, so the exclusions and the value, density and exploration passes have nothing left to act on and the packer behaves identically for both. Each policy carries its own budget, so a full run cannot be packed against a pull request's by leaving a field out.

**Packing**, batching and skip-list construction are then one code path. "The full run runs whole files" stops being a hardcoded empty skip list and becomes a consequence of everything being selected.

Because the full run is the safety net under everything else, a plan that ran everything checks that it placed everything, and throws rather than returning lanes that would report a pass over tests nobody ran.

## The lane count is an integer, and nothing more

`main` cannot fix its number of lanes ahead of time the way a pull request does, because the number depends on how much work there is and the job matrix has to exist before anything starts. So `plan-full` asks `ci-lane.ts --full --lane-count` and emits one integer. The lanes then read the same tree against the same manifest and compute the same packing for themselves, exactly as the pull-request lanes do, so nothing about which tests run travels through a job output and there is no second packing to disagree with theirs. A planning job that emitted the packing would be a second planner, and the two would drift.

The count is the fewest lanes whose total overrun cannot usefully be reduced by another. The total rather than the worst lane: a test costing more than a whole lane holds its own lane over budget at every count, so a search reading the worst lane stops at its first step and leaves every other lane packed far tighter than the budget it was given.

Where nothing at all has a measured cost, the shape of the topology answers instead, at one lane per suite with anything to run. A cost model with nothing to read is only as good as the figure it invents, and against this repository that figure puts the whole corpus at 2,403 seconds where the reference build measured 9,960. The error also runs in the direction that breaks a run: too few lanes means every one of them passes the bound its job is killed at, where too many means some jobs finish early. A lane whose plan carries stand-in costs says how many, so a projection resting on guesses is not read as one resting on records.

## Smaller things this settles

A stand-in is charged what the middle unit of its suite costs, summing each unit's tests first. The suites are orders of magnitude apart, so one figure for all of them would misjudge most; and a stand-in stands for a whole unit, which holds about seven tests here and far more in the unit-test suites, so charging it one test's cost charged a new file a fraction of what running it takes. A suite with nothing measured falls back to the new `UNMEASURED_COST_SECONDS` dial.

`FULL_LANE_BUDGET_SECONDS` is derived from a new
`FULL_LANE_BOUND_SECONDS` the way the pull-request budget is derived from its own bound, rather than being both at once. A lane of either run pays the same prologue and wants the same headroom, because both are the same job doing the same setup on the same runner; only the bound differs.

Both the units inside a batch and the batches inside a lane come out in the tree's order rather than the packer's placement order. Deno runs the files it is given in the order it is given them, and the two runs place in different orders, so a test that leans on running after a sibling passed in whichever run happened to order them the way it wanted.

A plan carries the budget it was packed against, so whatever reports a lane's projected time reports it against the figure it was judged by. A plan that ran everything reports withholding nothing, because it withheld nothing — the manifest's list would have had a full run say in its own summary that no lane chose a test it had just run.

`plan --dry-run` and `explain` read the tree through the same census, so the answer a person gets is the answer a lane would give. That was already the promise.

## What holds it in place

Three properties are asserted rather than left to reading. The two policies select the same set when nothing is scarce, which fails if a filter is added to one and not the other. A full plan places every available unit exactly once. And unmeasured units spread across lanes instead of piling into the first.

Checked against a manifest shaped like the reference build — its executions, its measured time and the skew it records, over the topology's real units — the full run asks for 27 lanes in place of today's 67 jobs.

The `deno.yml` wiring for `plan-full` and `full-tests` is not here. It belongs with the pull-request jobs, which the plan asks not to split from it.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6939?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

