### PR TITLE
fix(shell): a runtime error names the piece the address points at (#6938)

### DIFF
--- a/packages/shell/src/views/AppView.ts
+++ b/packages/shell/src/views/AppView.ts
@@ -109,14 +109,39 @@ function project<T extends object>(
 }
 
 /**
- * One live watch on a slug reference: the reference itself, the runtime and
- * space it is read in, and everything whose lifetime is this watch's — the
- * subscription it opens, the poll it schedules, and the pair of flags that
- * keep its re-resolutions to one at a time.
+ * A reference a page address carries: the slug at its head, the member it
+ * selects where it names one, and the space both are read in.
  *
- * The reference, the runtime and the space are every input the watch is built
- * from, so comparing them is what decides whether a running watch already
- * covers what the view now addresses.
+ * The runtime is not part of one. Which piece a reference names is a question
+ * about the space, and a replacement runtime asks it of that same space — so
+ * a hand-off leaves what the address names untouched, and the piece already
+ * reached stays on screen across the hand-off.
+ */
+interface SlugReference {
+  /** The space the reference is read in. */
+  readonly space: DID;
+
+  /** The name at the head of the reference. */
+  readonly slug: string;
+
+  /** The member the reference selects, where it names one. */
+  readonly member: string | undefined;
+}
+
+/** Whether `a` and `b` are the same reference. */
+function sameSlugReference(a: SlugReference, b: SlugReference): boolean {
+  return a.space === b.space && a.slug === b.slug && a.member === b.member;
+}
+
+/**
+ * One live watch on a slug reference: the reference, the runtime it is read
+ * through, and everything whose lifetime is this watch's — the subscription
+ * it opens, the poll it schedules, and the pair of flags that keep its
+ * re-resolutions to one at a time.
+ *
+ * The reference and the runtime are every input the watch is built from, so
+ * comparing them is what decides whether a running watch already covers what
+ * the view now addresses.
  *
  * A callback arriving after a view change checks itself by identity against
  * the watch the view is running, so replacing the watch invalidates every
@@ -128,14 +153,8 @@ class SlugWatch {
   /** The runtime the reference is read through. */
   readonly rt: RuntimeInternals;
 
-  /** The space the reference is read in. */
-  readonly space: DID;
-
-  /** The name at the head of the reference. */
-  readonly slug: string;
-
-  /** The member the reference selects, where it names one. */
-  readonly member: string | undefined;
+  /** The reference this watch follows. */
+  readonly reference: SlugReference;
 
   /** Cancels the subscription on the slug document, once it is open. */
   cancel: Cancel | undefined = undefined;
@@ -149,20 +168,10 @@ class SlugWatch {
   /** Whether something asked to re-resolve while one was running. */
   refreshRequested = false;
 
-  /**
-   * Constructs a watch on what `slug` and `member` name in `space`, read
-   * through `rt`.
-   */
-  constructor(
-    rt: RuntimeInternals,
-    space: DID,
-    slug: string,
-    member: string | undefined,
-  ) {
+  /** Constructs a watch on `reference`, read through `rt`. */
+  constructor(rt: RuntimeInternals, reference: SlugReference) {
     this.rt = rt;
-    this.space = space;
-    this.slug = slug;
-    this.member = member;
+    this.reference = reference;
   }
 
   /** Stops this watch, cancelling its subscription and clearing its poll. */
@@ -174,6 +183,15 @@ class SlugWatch {
       this.pollInterval = undefined;
     }
   }
+}
+
+/** What one run of the selection came to show, and for which reference. */
+interface ShownResolution {
+  /** The reference the run that recorded this was resolving. */
+  readonly reference: SlugReference;
+
+  /** What that run reached, or `undefined` where it reached nothing. */
+  readonly answer: SlugReferenceTarget | SlugReferenceRefusal | undefined;
 }
 
 export class XAppView extends BaseView {
@@ -240,9 +258,11 @@ export class XAppView extends BaseView {
   #slugWatch: SlugWatch | undefined = undefined;
 
   /**
-   * The answer the view is SHOWING: the resolution whose piece is on screen,
-   * or whose refusal is the error on screen. Undefined where neither holds —
-   * before the first of them, and after a load that could not finish.
+   * The answer the view is SHOWING and the reference it answers: the
+   * resolution whose piece is on screen, or whose refusal is the error on
+   * screen, under the address that reached it. Undefined before the first run
+   * of the selection reports; the answer within it is undefined where a run
+   * reached nothing to show, a load that could not finish among them.
    *
    * One fact, not several about one thing. What was resolved, whether it was
    * applied, which piece it reached, and which answer is newest are all read
@@ -258,20 +278,18 @@ export class XAppView extends BaseView {
    * lifetime is the view's display rather than any watch's, so a watch
    * stopping leaves it standing and the selection is what moves it on.
    *
-   * That lifetime qualifies the first sentence. Only the selection moves this
-   * on, and the selection reports only for an address that names a reference
-   * — so on an address naming none, and between an address changing and the
-   * run for the new one reporting, this names what the view came to show LAST
-   * rather than anything on screen. Both readers are bounded by that same
-   * condition, so neither sees the first state:
-   * {@link XAppView.#resolveAgainst} compares against this only through a
-   * watch, which is built only for an address that names a reference, and
-   * {@link XAppView.#shownPieceId} is read only under one. In the second
-   * state a runtime error naming the previous piece is attributed to this
-   * view, which the run reporting ends however it went.
+   * That lifetime is what the reference is here for. Only the selection moves
+   * this on, and it reports only for an address that names a reference — so
+   * between an address changing and the run for the new one reporting, this
+   * carries the OLD address's answer while nothing is on screen. Its two
+   * readers ask different questions of it there, and the reference is what
+   * separates them. {@link XAppView.#resolveAgainst} asks whether the answer
+   * just resolved is the one the view is showing, which the reference does
+   * not decide: a piece already on screen wants no reload however the view
+   * came to be showing it. {@link XAppView.#shownPieceId} asks what the
+   * address the view now carries has come to show, and answers for no other.
    */
-  #shownResolution: SlugReferenceTarget | SlugReferenceRefusal | undefined =
-    undefined;
+  #shownResolution: ShownResolution | undefined = undefined;
 
   #selectedPatternTargetId: string | undefined = undefined;
 
@@ -378,6 +396,14 @@ export class XAppView extends BaseView {
           const member = "pieceMember" in app.view
             ? app.view.pieceMember
             : undefined;
+          // This run's own address, held for as long as the run takes: what
+          // it reports is what THIS reference reached, and the address may
+          // have moved on by the time it reports.
+          const reference: SlugReference = {
+            space,
+            slug: app.view.pieceSlug,
+            member,
+          };
           const landed = await rt.resolveSlug(
             space,
             app.view.pieceSlug,
@@ -389,7 +415,7 @@ export class XAppView extends BaseView {
             // is where a reader is told it, in the refusal's own words. That
             // surface IS the view showing this answer, so it is shown before
             // it is thrown.
-            this.#markShown(landed, signal);
+            this.#markShown(reference, landed, signal);
             throw new Error(landed.refusal.message);
           }
           const { pieceId, scope, pathAfter } = landed;
@@ -410,13 +436,13 @@ export class XAppView extends BaseView {
             // refusal's own throw, and recording nothing there would undo
             // the mark a refusal just made — leaving every poll to re-resolve
             // an answer the view is already showing.
-            this.#markShown(undefined, signal);
+            this.#markShown(reference, undefined, signal);
             throw error;
           }
           // `landed` and not whatever is current: this run finished THIS
           // answer, and saying so with another's identity is how a slow load
           // came to claim a newer answer was on screen.
-          this.#markShown(landed, signal);
+          this.#markShown(reference, landed, signal);
           if (!signal.aborted) this.#maybeDeliverOpenPath(pattern);
           return pattern;
         }
@@ -487,30 +513,24 @@ export class XAppView extends BaseView {
 
   #syncSlugSubscription() {
     const rt = this.rt;
-    const space = this.space;
-    const slug = "pieceSlug" in this.app.view
-      ? this.app.view.pieceSlug
-      : undefined;
-    const member = "pieceMember" in this.app.view
-      ? this.app.view.pieceMember
-      : undefined;
+    const reference = this.#addressedReference;
     // Every input the watch is built from is compared, the runtime among
     // them: a reference reads the same and reaches a different answer under a
     // replacement runtime, and two members of one collection are two
     // references reaching two pieces.
     const running = this.#slugWatch;
     if (
-      running && running.rt === rt && running.space === space &&
-      running.slug === slug && running.member === member
+      running && running.rt === rt && reference &&
+      sameSlugReference(running.reference, reference)
     ) {
       return;
     }
     this.#stopSlugWatch();
-    if (!rt || !space || !slug) return;
+    if (!rt || !reference) return;
 
-    const watch = new SlugWatch(rt, space, slug, member);
+    const watch = new SlugWatch(rt, reference);
     this.#slugWatch = watch;
-    rt.getSlugCell(space, slug).then(async (cell) => {
+    rt.getSlugCell(reference.space, reference.slug).then(async (cell) => {
       if (!this.#isCurrentSlugWatch(watch)) return;
 
       // Asks like every later resolution, and needs no flag saying it is
@@ -572,12 +592,31 @@ export class XAppView extends BaseView {
   }
 
   /**
-   * Record that the view has come to show `answer`, or `undefined` where the
-   * run reached nothing for it to show.
+   * The reference the view's address names, where it names one.
+   *
+   * The address is the one source of a reference: a watch is built for what
+   * it names, and a recorded answer is held against what it names. Both read
+   * it through here, so the two cannot disagree about what the address says.
+   */
+  get #addressedReference(): SlugReference | undefined {
+    const space = this.space;
+    const view = this.app.view;
+    if (!space || !("pieceSlug" in view) || !view.pieceSlug) return undefined;
+    return {
+      space,
+      slug: view.pieceSlug,
+      member: "pieceMember" in view ? view.pieceMember : undefined,
+    };
+  }
+
+  /**
+   * Record that the view has come to show `answer` for `reference`, or
+   * nothing for it where the run reached nothing to show.
    *
    * The only writer of {@link XAppView.#shownResolution}, and it takes the
    * signal of the run that resolved `answer` so a run the view has moved on
-   * from cannot report what it finished as what is on screen.
+   * from cannot report what it finished as what is on screen. `reference` is
+   * that same run's, for the same reason.
    *
    * Every outcome of a run is reported through here — the piece it loaded,
    * the refusal it was given, and the load it could not finish. That is what
@@ -586,17 +625,29 @@ export class XAppView extends BaseView {
    * the view had settled on.
    */
   #markShown(
+    reference: SlugReference,
     answer: SlugReferenceTarget | SlugReferenceRefusal | undefined,
     signal: AbortSignal,
   ): void {
     if (signal.aborted) return;
-    this.#shownResolution = answer;
+    this.#shownResolution = { reference, answer };
   }
 
-  /** The piece the view is showing, when a slug reference reached one. */
+  /**
+   * The piece the view is showing, when the reference its address names
+   * reached one.
+   *
+   * A record made under another address is the answer to a question this
+   * address did not ask, so it names no piece here — which leaves the window
+   * before the run for a new address reports with no piece to name at all.
+   */
   get #shownPieceId(): string | undefined {
     const shown = this.#shownResolution;
-    return shown && !shown.refusal ? shown.pieceId : undefined;
+    const addressed = this.#addressedReference;
+    if (!shown || !addressed) return undefined;
+    if (!sameSlugReference(shown.reference, addressed)) return undefined;
+    const answer = shown.answer;
+    return answer && !answer.refusal ? answer.pieceId : undefined;
   }
 
   /** Whether `watch` is still the watch this view is running. */
@@ -642,9 +693,9 @@ export class XAppView extends BaseView {
     let landed: SlugReferenceTarget | SlugReferenceRefusal;
     try {
       landed = await watch.rt.resolveSlug(
-        watch.space,
-        watch.slug,
-        watch.member,
+        watch.reference.space,
+        watch.reference.slug,
+        watch.reference.member,
       );
     } catch (error) {
       if (watch.rt.signal.aborted) {
@@ -662,28 +713,26 @@ export class XAppView extends BaseView {
       return;
     }
     if (!this.#isCurrentSlugWatch(watch)) return;
-    // The one question, asked of what the selection recorded. A difference
-    // covers every reason the view could be behind — the reference moved, a
-    // member arrived, a refusal changed, a load failed and left the view on
-    // an error — because each of them is the same fact: what the view
-    // settled on is not this. That holds because every outcome of a run is
-    // recorded, a load that could not finish among them; an outcome that
-    // recorded nothing would leave the answer before it reading as settled,
-    // and the retry it needs would never be asked for.
-    const shown = this.#shownResolution;
+    // The one question, asked of the answer the selection recorded and not of
+    // the reference beside it: a piece already on screen wants no reload
+    // however the view came to be showing it. A difference covers every
+    // reason the view could be behind — the reference moved, a member
+    // arrived, a refusal changed, a load failed and left the view on an error
+    // — because each of them is the same fact: what the view settled on is
+    // not this. That holds because every outcome of a run is recorded, a load
+    // that could not finish among them; an outcome that recorded nothing
+    // would leave the answer before it reading as settled, and the retry it
+    // needs would never be asked for.
+    const shown = this.#shownResolution?.answer;
     if (shown && slugResolutionKey(shown) === slugResolutionKey(landed)) return;
     this.#handleSlugCellUpdate(watch);
   }
 
   #handleSlugCellUpdate(watch: SlugWatch) {
-    const member = "pieceMember" in this.app.view
-      ? this.app.view.pieceMember
-      : undefined;
+    const addressed = this.#addressedReference;
     if (
-      this.rt !== watch.rt ||
-      !("pieceSlug" in this.app.view) ||
-      this.app.view.pieceSlug !== watch.slug ||
-      member !== watch.member
+      this.rt !== watch.rt || !addressed ||
+      !sameSlugReference(addressed, watch.reference)
     ) {
       return;
     }

--- a/packages/shell/test/app-view-collection-member.test.ts
+++ b/packages/shell/test/app-view-collection-member.test.ts
@@ -4,8 +4,9 @@
 
 /**
  * What the shell does with `/<space>/<collection>/<member>`: which piece it
- * selects, which address it settles on, what it offers to cite, and how the
- * watch behind it behaves as the reference stops and starts resolving.
+ * selects, which address it settles on, what it offers to cite, which runtime
+ * error it shows as its own, and how the watch behind it behaves as the
+ * reference stops and starts resolving.
  *
  * The view is driven directly rather than through a runtime. Every fact these
  * tests are about is settled between a resolution's answer and the view's own
@@ -123,6 +124,36 @@ function templateText(value: unknown): string {
   return text;
 }
 
+/**
+ * Every value bound to the property `name` across nested Lit template
+ * results, in the order the walk reaches them.
+ *
+ * A template result carries its literal text in `strings` and its bound
+ * values in `values`, in step, so the chunk before a value ends with that
+ * binding's own `.name="`. Reading a binding by name is what keeps this off
+ * counting positions, which a template gains and loses. Returning every match
+ * rather than the first is what tells a binding holding `undefined` from a
+ * name nothing binds: the first is `[undefined]` and the second is `[]`.
+ */
+function templateBindings(value: unknown, name: string): unknown[] {
+  if (value == null || typeof value !== "object") return [];
+  if (Array.isArray(value)) {
+    return value.flatMap((entry) => templateBindings(entry, name));
+  }
+  const template = value as {
+    strings?: readonly string[];
+    values?: readonly unknown[];
+  };
+  const strings = template.strings ?? [];
+  const values = template.values ?? [];
+  const bound: unknown[] = [];
+  for (let index = 0; index < values.length; index++) {
+    if (strings[index]?.endsWith(`.${name}="`)) bound.push(values[index]);
+    else bound.push(...templateBindings(values[index], name));
+  }
+  return bound;
+}
+
 /** Where a resolution lands, as the runtime answers it. */
 interface Resolved {
   pieceId: string;
@@ -138,6 +169,17 @@ interface Resolved {
  */
 interface Refused {
   refusal: { code: string; message: string };
+}
+
+/**
+ * A runtime error as the view reads one: the space it happened in, the piece
+ * it names, and what to tell a reader. The notification a worker sends
+ * carries more, and none of the rest decides which view shows it.
+ */
+interface Reported {
+  space: DID;
+  pieceId: string;
+  message: string;
 }
 
 /**
@@ -330,6 +372,9 @@ function stubRuntime(
 
 const SPACE = "did:key:z6Mk-shell-collection-member" as DID;
 
+/** A second space, for the cases that turn on which space is being read. */
+const OTHER_SPACE = "did:key:z6Mk-shell-collection-member-other" as DID;
+
 /**
  * The timer functions as this module found them, before any test ran. Every
  * test here replaces them, and they are process-wide.
@@ -373,6 +418,7 @@ interface AppViewLike {
   app: unknown;
   space: DID | undefined;
   rt: unknown;
+  runtimeLoadErrors: readonly Reported[];
   render(): unknown;
   updated(changed: Map<string, unknown>): void;
   _selectedPattern: { run(): void; taskComplete: Promise<unknown> };
@@ -1038,6 +1084,73 @@ describe("AppView collection members", () => {
     }
   });
 
+  it("watches each slug separately", async () => {
+    const restore = installBrowserGlobals();
+    try {
+      const { XAppView } = await import("../src/views/AppView.ts");
+      const stub = stubRuntime({ pieceId: "fid1:member-1", pathAfter: [] });
+      const view = appViewOver(
+        XAppView as never,
+        stub,
+        viewOf({ pieceSlug: "top", pieceMember: "1" }),
+      );
+
+      view.updated(new Map([["app", undefined]]));
+      await stub.poll();
+
+      // A different collection is a different reference, whatever the member
+      // after it is called.
+      view.app = {
+        identity: {},
+        config: {},
+        view: viewOf({ pieceSlug: "side", pieceMember: "1" }),
+      };
+      view.updated(new Map([["app", undefined]]));
+      await stub.poll();
+
+      expect(stub.cancels).toBe(1);
+      expect(stub.resolved.map((call) => call[1])).toContain("side");
+    } finally {
+      restore();
+    }
+  });
+
+  it("watches each space separately", async () => {
+    const restore = installBrowserGlobals();
+    try {
+      const { XAppView } = await import("../src/views/AppView.ts");
+      const stub = stubRuntime({ pieceId: "fid1:member-1", pathAfter: [] });
+      const view = appViewOver(
+        XAppView as never,
+        stub,
+        viewOf({ pieceSlug: "top", pieceMember: "1" }),
+      );
+
+      view.updated(new Map([["app", undefined]]));
+      await stub.poll();
+
+      // One name reads to one piece in one space and to another elsewhere,
+      // so the space the reference is read in is part of what it names.
+      view.space = OTHER_SPACE;
+      view.app = {
+        identity: {},
+        config: {},
+        view: viewOf({
+          spaceName: "other-demo",
+          pieceSlug: "top",
+          pieceMember: "1",
+        }),
+      };
+      view.updated(new Map([["app", undefined], ["space", undefined]]));
+      await stub.poll();
+
+      expect(stub.cancels).toBe(1);
+      expect(stub.resolved.map((call) => call[0])).toContain(OTHER_SPACE);
+    } finally {
+      restore();
+    }
+  });
+
   it("watches each reference through a slug separately", async () => {
     const restore = installBrowserGlobals();
     try {
@@ -1136,6 +1249,99 @@ describe("AppView collection members", () => {
       expect(errors.lines).toEqual([]);
     } finally {
       errors.restore();
+      restore();
+    }
+  });
+
+  it("asks for no reload from a poll fired while the selection is loading", async () => {
+    const restore = installBrowserGlobals();
+    try {
+      const { XAppView } = await import("../src/views/AppView.ts");
+      const stub = stubRuntime({ pieceId: "fid1:member-42", pathAfter: [] });
+      const view = appViewOver(
+        XAppView as never,
+        stub,
+        viewOf({ pieceSlug: "top", pieceMember: "42" }),
+      );
+
+      view.updated(new Map([["app", undefined], ["rt", undefined]]));
+      await stub.settle();
+      view._selectedPattern.run();
+      await view._selectedPattern.taskComplete;
+
+      // The selection runs again and stops in the load, which is where a run
+      // spends most of its time. What the view came to show is the piece the
+      // last run reached, and the run in flight is on its way to the same
+      // answer.
+      stub.holdLoads();
+      view._selectedPattern.run();
+      await stub.settle();
+      const before = view.accessForTestingOnly.slugRevision;
+
+      // A poll lands there. It reaches the answer the view is showing, so
+      // there is nothing to reload — and a reload here aborts the run in
+      // flight in favor of an identical one, which the next poll does again
+      // for as long as a load outlasts the interval.
+      await stub.poll();
+
+      expect(view.accessForTestingOnly.slugRevision).toBe(before);
+
+      await stub.releaseLoads();
+    } finally {
+      restore();
+    }
+  });
+
+  it("shows no runtime error naming the piece a changed address left behind", async () => {
+    const restore = installBrowserGlobals();
+    try {
+      const { XAppView } = await import("../src/views/AppView.ts");
+      const stub = stubRuntime({ pieceId: "fid1:member-42", pathAfter: [] });
+      const view = appViewOver(
+        XAppView as never,
+        stub,
+        viewOf({ pieceSlug: "top", pieceMember: "42" }),
+      );
+
+      view.updated(new Map([["app", undefined], ["rt", undefined]]));
+      await stub.settle();
+      view._selectedPattern.run();
+      await view._selectedPattern.taskComplete;
+
+      // Member 42 is what the view came to show, so an error the worker
+      // reports against that piece is this view's to show — and reading the
+      // binding at all is what the case below rests on.
+      const reported: Reported = {
+        space: SPACE,
+        pieceId: "of:fid1:member-42",
+        message: "the piece threw",
+      };
+      view.runtimeLoadErrors = [reported];
+      expect(templateBindings(view.render(), "runtimeError")).toEqual([{
+        kind: "piece",
+        error: reported,
+      }]);
+
+      // The address moves to member 43, and every answer is held: the
+      // selection for the new reference is still resolving, so nothing is on
+      // screen and no run has said what replaced 42.
+      stub.answer({ pieceId: "fid1:member-43", pathAfter: [] });
+      stub.hold();
+      view.app = {
+        identity: {},
+        config: {},
+        view: viewOf({ pieceSlug: "top", pieceMember: "43" }),
+      };
+      view.updated(new Map([["app", undefined]]));
+      view._selectedPattern.run();
+      await stub.settle();
+
+      // 42 is the answer to a reference this address does not carry, and the
+      // error naming it belongs to no view the reader is looking at.
+      expect(templateBindings(view.render(), "runtimeError")).toEqual([
+        undefined,
+      ]);
+    } finally {
       restore();
     }
   });


### PR DESCRIPTION
## Why

#6936 stopped teardown clearing the record of what a slug view came to show,
for a good reason — the clear was a live counterexample to a single-writer
invariant the file documents in two places. #6938 is that change's residue.

There is a window between an address changing and the selection answering the
new one: nothing is on screen, but the record still names the previous
answer, and `#runtimeErrorMatchesView` reads it first. A runtime error
arriving in that window is attributed to a piece the view is no longer
showing. No wrong piece renders — this is attribution, not display — and load
errors are emptied on view change, so only an error arriving *inside* the
window reaches it.

## What changed, and what it deliberately does not touch

The record becomes `{ reference, answer }`. `#shownPieceId` returns a piece
only where that reference is the one the view and space now name.

**`#resolveAgainst`'s comparison is untouched** and still reads the answer
alone. That is deliberate: it asks whether the answer just resolved is the one
on screen, and a piece already on screen wants no reload however the view came
to be showing it. The issue anticipated that this fix might change the watch's
own comparison; it does not.

A reference is now one type rather than three fields in two places —
`SlugReference`, held by the watch, read off the view by one getter, compared
by one function at all three sites.

## The alternative, and why not

Clearing the record at the selection's start **passes every test this file had
before this change**, so its cost needed a test rather than a paragraph. It is
real: a poll landing while a run is out sees "nothing shown", bumps the
revision, and aborts that run in favour of an identical one — repeating every
second for as long as a load outlasts the poll interval. That case is now
pinned.

## Test plan

Each new assertion has a mutation that reds it, and the four load-bearing ones
were re-run in isolation. Two of them close a gap that predates this change:
before them, dropping `slug` or `space` from the reference comparison reddened
nothing, because the member was the only one of a reference's three fields any
test turned on.

One choice carries no mutation and does not claim one: the mark takes the run's
own reference rather than the address current when it finishes. A run whose
address has moved has already been aborted, so no test can separate the two.

`deno task check` was verified to reach the changed files by planting a type
error, since `packages/shell`'s test task runs `--no-check`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6940?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

