### PR TITLE
memory: a row rule may gate on a whole INTEGER, not only on TEXT

### DIFF
--- a/docs/specs/sqlite-builtin/06-cfc.md
+++ b/docs/specs/sqlite-builtin/06-cfc.md
@@ -255,14 +255,15 @@ so a whole value stored in a REAL column also shows its integer spelling
 the column's declared type. Everything else refuses at evaluation, and each
 refusal names the value's **class** only, never the value (invariant 14):
 
-- a **REAL** with a fraction, and an infinity. SQLite renders a REAL from its
-  own decoded digits, which stop at the round-trip point and round up from
-  there — it shows `-0.009598882198146955` as `-0.00959888219814696` where
-  the correctly rounded 15-digit value ends `…695`. The rendering is
-  therefore not a function of the double the evaluator holds, and a gate is
-  an anchored comparison against the text SQLite *would* show: a text we
-  could only nearly reproduce is a gate that silently fails to fire on some
-  rows, dropping a confidentiality clause.
+- a **REAL** with a fraction, and an infinity. SQLite renders a REAL with
+  `%!.15g` over its own decoded digits, and the rendering is not a function
+  of the double the evaluator holds: the prebuilt SQLite libraries the driver
+  loads on macOS and on Linux disagree about the last digit of
+  `-0.009598882198146955` (`…696` against the correctly rounded `…695`), so
+  no formatter is right on both. A gate is an anchored comparison against the
+  text SQLite *would* show, and a text we could only nearly reproduce is a
+  gate that silently fails to fire on some rows, dropping a confidentiality
+  clause.
 - a whole number past 2^53, where a double no longer names one int64 (a large
   INTEGER read into one has already lost its low digits), and a bigint
   outside int64.

--- a/docs/specs/sqlite-builtin/06-cfc.md
+++ b/docs/specs/sqlite-builtin/06-cfc.md
@@ -248,40 +248,67 @@ argument of `match` / `whenMatches`.
 **What a regex may read.** TEXT, and a **whole INTEGER** by its decimal
 digits — the ordinary key column a rule wants to gate on (msgvault's
 per-mailbox `source_id`), written as `whenMatches(f.source_id, /^7$/, …)`.
-The digits are the text SQLite shows for that INTEGER, so the gate compares
-what an operator reads off the row. A JS number carries no INTEGER/REAL tag,
-so a whole value stored in a REAL column also shows its integer spelling
-(`7`, where `CAST(col AS TEXT)` would say `7.0`): gate on the digits, not on
-the column's declared type. Everything else refuses at evaluation, and each
-refusal names the value's **class** only, never the value (invariant 14):
+The digits are the ones SQLite shows for that INTEGER, so a rule is written
+from the row. Everything else refuses at evaluation, and each refusal names
+the value's **class** only, never the value (invariant 14):
 
 - a **REAL** with a fraction, and an infinity. SQLite renders a REAL with
   `%!.15g` over its own decoded digits, and the rendering is not a function
-  of the double the evaluator holds: the prebuilt SQLite libraries the driver
-  loads on macOS and on Linux disagree about the last digit of
-  `-0.009598882198146955` (`…696` against the correctly rounded `…695`), so
-  no formatter is right on both. A gate is an anchored comparison against the
-  text SQLite *would* show, and a text we could only nearly reproduce is a
-  gate that silently fails to fire on some rows, dropping a confidentiality
-  clause.
-- a whole number past 2^53, where a double no longer names one int64 (a large
-  INTEGER read into one has already lost its low digits), and a bigint
-  outside int64.
+  of the double the evaluator holds: the SQLite builds behind the driver
+  disagree about the last digit of `-0.009598882198146955` (`…696` against
+  the correctly rounded `…695`, the split following the architecture, whose
+  long double the decoder uses where it is wider than a double), so no
+  formatter is right on both. A gate is an anchored comparison against the
+  text SQLite *would* show, and a text that can only be nearly reproduced is
+  a gate that silently fails to fire on some rows, dropping a
+  confidentiality clause.
+- a whole number past 2^53, and a bigint outside int64: past there a JS
+  number no longer names one integer, so no text derived from it is
+  honestly the row's.
 - NaN (SQLite stores one as NULL, so it never came out of a row), a boolean
   (not a SQLite value), and a BLOB.
 
 NULL and the empty string are not refusals: a gate stays quiet and an
-extractor yields nothing, as they always have (`min` still applies).
+extractor yields nothing, as they always have (`min` still applies). A zero
+is a value, not an absence.
 
-A rule reads the value **as it reaches the evaluator**, which is the bound
-value at the write gate and the stored value everywhere else. SQLite's type
-affinity can convert one into the other — a `"7.0"` bound into an INTEGER
-column stores as `7` — and the two texts then differ, so the runner's
-prospective label and the re-derived one disagree for that row. The
-re-derived label is the one that protects the row (the server's commit
-evaluation and the read side both compute it from the post-image); what the
-disagreement costs is the accuracy of the write gate's no-laundering check.
-Bind a rule-input column the value it stores.
+**A rule input's column is declared, and two declarations settle the
+question before any rule runs.** A column whose declared type gives it REAL
+affinity, or names BLOB, is refused a rule at declaration — by `table()`,
+and again wherever a wire-supplied `db.tables` is re-validated. Every value a
+REAL-affinity column holds is a REAL, so a rule there is dead (the fractional
+values refuse) or misleading (a whole one shows `7` where `CAST` says `7.0`,
+so a rule written from the column's type never fires); a BLOB has no text at
+all. SQLite's dynamic typing would allow either column to hold text, and this
+refuses it anyway: declare a column that holds text as TEXT.
+
+**The digits have to be the stored ones.** `@db/sqlite` reads an INTEGER
+column through `sqlite3_column_int`, the 32-bit accessor, unless the
+connection sets `int64` — so a stored `4294967303` arrives as `7`, and a
+label derived from that is a label for another key's rows. Two paths read
+rule inputs, and each answers it where it reads:
+
+- the **read** side runs labeled queries (`queryWithOrigins`, issued only for
+  a db that declares `ifc` or a row rule) on an `int64` connection, where a
+  value past 2^53 arrives as a `bigint`. Ordinary reads keep the connection
+  and the values they have always had.
+- **commit evaluation** runs on the engine connection, which serves
+  everything and cannot flip mode for this, so SQLite renders instead: the
+  affected rowid as text (the read-back addresses the row that was written
+  rather than whichever row shares its low 32 bits), and a rule input as text
+  only when its storage class is INTEGER — a rendered REAL would reach the
+  evaluator as a string and be gated on, where the read side refuses it.
+
+**The write gate evaluates what the column will store.** A rule's prospective
+label is computed from the BOUND values, and everything else re-derives it
+from the stored ones; SQLite's affinity sits between the two. A rule input
+bound a string that a numeric-affinity column would store as a number
+(`"007"` into an INTEGER column) is refused at the gate, because the label
+the gate computes for it is not the label the row will carry — and the check
+that rides on it, no-laundering, is the one the server cannot redo (it is
+the only place the inputs' own labels are known). No other pairing converts:
+a number bound to a TEXT column is stored as the text the evaluator already
+renders it to.
 
 **No acting-principal term in rules.** `currentUser()` is deliberately not a
 helper: a rule must compute the **same** label at the write gate, the server
@@ -568,15 +595,17 @@ re-derives.
 ### Fail-closed rules (consolidated)
 
 1. **Authoring:** unknown column, unknown op, unsafe regex, an integrity/
-   confidentiality op in the wrong position, or a malformed `any()` alternative
-   (a nested `all()`/`any()`) ⟶ `table()` throws. A well-formed `any(...)` is
+   confidentiality op in the wrong position, a malformed `any()` alternative
+   (a nested `all()`/`any()`), or a rule input declared REAL or BLOB ⟶
+   `table()` throws. A well-formed `any(...)` is
    accepted as an authored OR-clause (Epic E1). The same validation re-runs on
    wire-supplied specs before evaluation.
 2. **Read, unresolvable input:** a rule input missing from the projection by
    origin, or ambiguous (two columns, same origin) ⟶ refuse the query.
-3. **Read, bad data:** evaluator `{error}` (a regex input SQLite has no
-   reproducible text for, strict-if-present zero match, `min` miss,
-   multi-match integrity subject) ⟶ refuse the query.
+3. **Read, bad data:** evaluator `{error}` (a regex input with no text this
+   evaluator can honestly show — a REAL, a BLOB, a number past 2^53 —
+   strict-if-present zero match, `min` miss, multi-match integrity subject) ⟶
+   refuse the query.
 4. **Read, unattributable output:** a null-origin column on a rule-bearing query
    lifts by the common-alternative property (rule 2 / CFC spec §8.17.4) when a
    reader is a static unconditional reader of every row; otherwise ⟶ refuse.

--- a/docs/specs/sqlite-builtin/06-cfc.md
+++ b/docs/specs/sqlite-builtin/06-cfc.md
@@ -245,6 +245,43 @@ returns a plain-JSON AST node):
 `f.<col>` is the only way to name data and may appear **only** as the field
 argument of `match` / `whenMatches`.
 
+**What a regex may read.** TEXT, and a **whole INTEGER** by its decimal
+digits — the ordinary key column a rule wants to gate on (msgvault's
+per-mailbox `source_id`), written as `whenMatches(f.source_id, /^7$/, …)`.
+The digits are the text SQLite shows for that INTEGER, so the gate compares
+what an operator reads off the row. A JS number carries no INTEGER/REAL tag,
+so a whole value stored in a REAL column also shows its integer spelling
+(`7`, where `CAST(col AS TEXT)` would say `7.0`): gate on the digits, not on
+the column's declared type. Everything else refuses at evaluation, and each
+refusal names the value's **class** only, never the value (invariant 14):
+
+- a **REAL** with a fraction, and an infinity. SQLite renders a REAL from its
+  own decoded digits, which stop at the round-trip point and round up from
+  there — it shows `-0.009598882198146955` as `-0.00959888219814696` where
+  the correctly rounded 15-digit value ends `…695`. The rendering is
+  therefore not a function of the double the evaluator holds, and a gate is
+  an anchored comparison against the text SQLite *would* show: a text we
+  could only nearly reproduce is a gate that silently fails to fire on some
+  rows, dropping a confidentiality clause.
+- a whole number past 2^53, where a double no longer names one int64 (a large
+  INTEGER read into one has already lost its low digits), and a bigint
+  outside int64.
+- NaN (SQLite stores one as NULL, so it never came out of a row), a boolean
+  (not a SQLite value), and a BLOB.
+
+NULL and the empty string are not refusals: a gate stays quiet and an
+extractor yields nothing, as they always have (`min` still applies).
+
+A rule reads the value **as it reaches the evaluator**, which is the bound
+value at the write gate and the stored value everywhere else. SQLite's type
+affinity can convert one into the other — a `"7.0"` bound into an INTEGER
+column stores as `7` — and the two texts then differ, so the runner's
+prospective label and the re-derived one disagree for that row. The
+re-derived label is the one that protects the row (the server's commit
+evaluation and the read side both compute it from the post-image); what the
+disagreement costs is the accuracy of the write gate's no-laundering check.
+Bind a rule-input column the value it stores.
+
 **No acting-principal term in rules.** `currentUser()` is deliberately not a
 helper: a rule must compute the **same** label at the write gate, the server
 commit, and read re-derivation — re-derived at read time an acting-principal
@@ -289,8 +326,9 @@ One pure evaluator —
 `packages/memory` beside `table()` — is shared by the write gate, read
 re-derivation, and (future) server-side commit evaluation, so the sides can
 never drift: the audit property holds by construction. It is fail-closed end
-to end: an absent rule-input field, a non-string value where a regex needs
-text, a `dbOwner()` with no owner in context, a strict-if-present zero match,
+to end: an absent rule-input field, a value class a regex cannot read (a
+REAL, a BLOB — see above), a `dbOwner()` with no owner in context, a
+strict-if-present zero match,
 a `min` violation, a multi-match integrity subject, an unknown op — each
 returns `{error}`, never a partial label; callers turn `{error}` into a
 refused query / rejected write.
@@ -535,9 +573,9 @@ re-derives.
    wire-supplied specs before evaluation.
 2. **Read, unresolvable input:** a rule input missing from the projection by
    origin, or ambiguous (two columns, same origin) ⟶ refuse the query.
-3. **Read, bad data:** evaluator `{error}` (non-string regex input,
-   strict-if-present zero match, `min` miss, multi-match integrity subject) ⟶
-   refuse the query.
+3. **Read, bad data:** evaluator `{error}` (a regex input SQLite has no
+   reproducible text for, strict-if-present zero match, `min` miss,
+   multi-match integrity subject) ⟶ refuse the query.
 4. **Read, unattributable output:** a null-origin column on a rule-bearing query
    lifts by the common-alternative property (rule 2 / CFC spec §8.17.4) when a
    reader is a static unconditional reader of every row; otherwise ⟶ refuse.

--- a/packages/memory/test/v2-sqlite-commit-eval.test.ts
+++ b/packages/memory/test/v2-sqlite-commit-eval.test.ts
@@ -83,7 +83,21 @@ const rtab = table(
   () => ({ confidentiality: all(dbOwner()) }),
 );
 
-const TABLES = { emails, staging, ownerOnly, rtab };
+// A mailbox-keyed table: the rule reads an INTEGER column, and the driver
+// reads an INTEGER column through a 32-bit accessor unless the read renders it
+// as text. `/^7$/` under `min: 1` refuses every other id, so a truncated read
+// is the difference between a refusal and a silent pass.
+const mailboxes = table(
+  { id: "integer primary key", source_id: "integer" },
+  (f) => ({
+    confidentiality: all(
+      principal("mailbox", match(f.source_id, /^7$/, { min: 1 })),
+      dbOwner(),
+    ),
+  }),
+);
+
+const TABLES = { emails, staging, ownerOnly, rtab, mailboxes };
 const DB_ID = "of:commit-eval-db";
 const OWNER = "did:key:owner";
 
@@ -596,6 +610,63 @@ Deno.test("commit eval fails closed on the shapes it cannot attribute", () => {
         ),
       RowLabelCommitError,
       "invalid rowLabel rule",
+    );
+  } finally {
+    db.close();
+  }
+});
+
+Deno.test("commit eval judges an INTEGER column by its stored digits", () => {
+  // 4294967303 is 7 in the low 32 bits, which is exactly the id the rule
+  // admits. Read as 7 the violating row commits; read as itself it refuses.
+  const db = bareDb();
+  try {
+    assertEquals(
+      applySqliteCommitWrite(
+        db,
+        bareOp("INSERT INTO mailboxes (id, source_id) VALUES (?, ?)", [1, 7]),
+      ).changes,
+      1,
+    );
+    assertThrows(
+      () =>
+        applySqliteCommitWrite(
+          db,
+          bareOp("INSERT INTO mailboxes (id, source_id) VALUES (?, ?)", [
+            2,
+            4294967303,
+          ]),
+        ),
+      RowLabelCommitError,
+      "matched nothing",
+    );
+  } finally {
+    db.close();
+  }
+});
+
+Deno.test("commit eval reads back the row it wrote, whatever its rowid", () => {
+  // The affected row is identified by rowid, and a rowid past 2^31 truncates
+  // into the range of one already stored: rowid 4294967303 collides with 7.
+  // Reading back the wrong row judges a violating write by a valid row's
+  // values, so the write lands unevaluated.
+  const db = bareDb();
+  try {
+    applySqliteCommitWrite(
+      db,
+      bareOp("INSERT INTO mailboxes (id, source_id) VALUES (?, ?)", [7, 7]),
+    );
+    assertThrows(
+      () =>
+        applySqliteCommitWrite(
+          db,
+          bareOp("INSERT INTO mailboxes (id, source_id) VALUES (?, ?)", [
+            4294967303,
+            999,
+          ]),
+        ),
+      RowLabelCommitError,
+      "matched nothing",
     );
   } finally {
     db.close();

--- a/packages/memory/test/v2-sqlite-row-label-integer-roundtrip.test.ts
+++ b/packages/memory/test/v2-sqlite-row-label-integer-roundtrip.test.ts
@@ -1,0 +1,177 @@
+/**
+ * A row rule gates on the INTEGER the row actually holds, read through the
+ * pooled connection a labeled query really runs on.
+ *
+ * The evaluator's own tests establish what text a JS number shows a regex.
+ * They cannot establish that the number is the stored one: `@db/sqlite` reads
+ * an INTEGER column through `sqlite3_column_int` — the 32-bit accessor —
+ * unless the connection is opened with `int64`, so a stored 4294967303
+ * arrives as 7 and a gate meant for mailbox 7 admits a row from another
+ * mailbox entirely. Nothing about that is visible to the evaluator: 7 and a
+ * wrapped 7 are the same JS value. So the guarantee has to be established
+ * here, at the driver, with values stored on disk and read back out.
+ *
+ * Spec: docs/specs/sqlite-builtin/06-cfc.md ("Per-row labels").
+ */
+
+import { Database } from "@db/sqlite";
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+import {
+  columnOriginAvailable,
+  columnOriginUnavailableReason,
+  ensureColumnOriginAvailable,
+} from "../v2/sqlite/column-origin.ts";
+import { ReadConnectionPool } from "../v2/sqlite/read-pool.ts";
+import {
+  all,
+  constant,
+  dbOwner,
+  evaluateRowLabel,
+  match,
+  principal,
+  regexInputText,
+  type RowLabelSpec,
+  whenMatches,
+} from "../v2/sqlite/row-label.ts";
+import { table } from "../v2/sqlite/schema.ts";
+
+// The labeled read path resolves column origins over FFI, so a labeled query
+// cannot run at all without it (production binds it once before issuing one).
+await ensureColumnOriginAvailable();
+
+const OWNER = "did:key:zOwner";
+const SEVEN = "did:mailbox:seven";
+const BIG = "did:mailbox:big";
+const ERA = "did:era:2024";
+
+// Three stored ids: one small, one past 2^31 (where the 32-bit accessor wraps),
+// one past 2^53 (where a double cannot name the integer at all). The timestamp
+// is an ordinary epoch-millisecond value, which is itself past 2^31.
+const ROWS = [
+  { id: 1, source_id: "7" },
+  { id: 2, source_id: "4294967303" },
+  { id: 3, source_id: "9007199254740993" },
+];
+const TS = "1725000000000";
+
+function spec(): RowLabelSpec {
+  const schema = table(
+    { id: "integer primary key", source_id: "integer", ts: "integer" },
+    (f) => ({
+      confidentiality: all(
+        whenMatches(f.source_id, /^7$/, constant(SEVEN)),
+        whenMatches(f.source_id, /^4294967303$/, constant(BIG)),
+        whenMatches(f.ts, new RegExp(`^${TS}$`), constant(ERA)),
+        principal("mailbox", match(f.source_id, /\d+/, { min: 1 })),
+        dbOwner(),
+      ),
+    }),
+  );
+  return schema.rowLabel as RowLabelSpec;
+}
+
+function withStore<T>(run: (path: string) => T): T {
+  const path = Deno.makeTempFileSync({ suffix: ".sqlite" });
+  const db = new Database(path);
+  try {
+    db.exec(
+      "CREATE TABLE messages (id integer primary key, source_id integer, " +
+        "ts integer)",
+    );
+    for (const row of ROWS) {
+      db.exec(
+        `INSERT INTO messages VALUES (${row.id}, ${row.source_id}, ${TS})`,
+      );
+    }
+  } finally {
+    db.close();
+  }
+  try {
+    return run(path);
+  } finally {
+    Deno.removeSync(path);
+  }
+}
+
+describe("row-label over a stored INTEGER", () => {
+  it("binds the column-origin symbols a labeled query needs", () => {
+    expect(columnOriginUnavailableReason()).toBeUndefined();
+    expect(columnOriginAvailable()).toBe(true);
+  });
+
+  it("shows the regex the digits SQLite stored, not the low 32 bits", () => {
+    withStore((path) => {
+      const pool = new ReadConnectionPool();
+      try {
+        const { rows } = pool.queryWithOrigins(
+          path,
+          "SELECT id, source_id, ts FROM messages ORDER BY id",
+        );
+        expect(rows.map((row) => regexInputText(row.source_id))).toEqual(
+          ROWS.map((row) => row.source_id),
+        );
+        expect(rows.map((row) => regexInputText(row.ts))).toEqual([
+          TS,
+          TS,
+          TS,
+        ]);
+      } finally {
+        pool.close();
+      }
+    });
+  });
+
+  it("gates each row on its own mailbox", () => {
+    withStore((path) => {
+      const pool = new ReadConnectionPool();
+      try {
+        const { rows } = pool.queryWithOrigins(
+          path,
+          "SELECT id, source_id, ts FROM messages ORDER BY id",
+        );
+        const labels = rows.map((row) =>
+          evaluateRowLabel(spec(), row, { dbOwner: OWNER })
+        );
+        expect(labels).toEqual([
+          {
+            confidentiality: [SEVEN, ERA, "did:mailbox:7", OWNER],
+            integrity: [],
+          },
+          {
+            confidentiality: [BIG, ERA, "did:mailbox:4294967303", OWNER],
+            integrity: [],
+          },
+          {
+            confidentiality: [ERA, "did:mailbox:9007199254740993", OWNER],
+            integrity: [],
+          },
+        ]);
+      } finally {
+        pool.close();
+      }
+    });
+  });
+
+  it("leaves an ordinary read on the connection it always used", () => {
+    // The labeled path is the one that has to see whole integers. An
+    // unlabeled `query()` keeps whatever the driver gave it before, so a
+    // consumer reading rows outside CFC sees no change from this.
+    withStore((path) => {
+      const pool = new ReadConnectionPool();
+      try {
+        const rows = pool.query(
+          path,
+          "SELECT source_id FROM messages ORDER BY id",
+        );
+        expect(rows.map((row) => typeof row.source_id)).toEqual([
+          "number",
+          "number",
+          "number",
+        ]);
+      } finally {
+        pool.close();
+      }
+    });
+  });
+});

--- a/packages/memory/test/v2-sqlite-row-label-number-text.test.ts
+++ b/packages/memory/test/v2-sqlite-row-label-number-text.test.ts
@@ -1,0 +1,301 @@
+/**
+ * CFC Phase 3: what a NON-TEXT row value presents to a row-rule regex.
+ *
+ * A rule's `match()`/`whenMatches()` regexes read a column's text, and a
+ * column keyed by an INTEGER — a per-mailbox `source_id`, a per-account id —
+ * is the ordinary case a rule wants to gate on. These tests pin the text the
+ * evaluator hands the regex against SQLite's own conversion, and pin the
+ * value classes that stay refused — the REAL among them, for a reason only a
+ * real database can establish.
+ *
+ * Unlike its neighbor `v2-sqlite-row-label.test.ts`, this file opens a real
+ * database: the claim under test is "the text SQLite would show", and only
+ * SQLite can settle it.
+ *
+ * Spec: docs/specs/sqlite-builtin/06-cfc.md ("Per-row labels").
+ */
+
+import { Database } from "@db/sqlite";
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+import {
+  all,
+  constant,
+  dbOwner,
+  evaluateRowLabel,
+  match,
+  principal,
+  regexInputText,
+  type RowLabelSpec,
+  whenMatches,
+} from "../v2/sqlite/row-label.ts";
+import { table } from "../v2/sqlite/schema.ts";
+
+const OWNER = "did:key:zOwner";
+const GATED = "did:mailto:seven@example.com";
+
+/** A rule whose only data-dependent clause is a gate on column `v`. */
+function gateSpec(re: RegExp, sqlType = "integer"): RowLabelSpec {
+  const schema = table(
+    { id: "integer primary key", v: sqlType },
+    (f) => ({
+      confidentiality: all(whenMatches(f.v, re, constant(GATED)), dbOwner()),
+    }),
+  );
+  return schema.rowLabel as RowLabelSpec;
+}
+
+/** Whether the gate fired for `value`, or the refusal it produced. */
+function gate(
+  re: RegExp,
+  value: unknown,
+  sqlType?: string,
+): { fired: boolean } | { error: string } {
+  const res = evaluateRowLabel(gateSpec(re, sqlType), { id: 1, v: value }, {
+    dbOwner: OWNER,
+  });
+  if ("error" in res) return res;
+  return { fired: res.confidentiality.includes(GATED) };
+}
+
+/** The refusal a value produces, or `undefined` when it produced a label. */
+function refusal(value: unknown): string | undefined {
+  const res = gate(/^7$/, value);
+  return "error" in res ? res.error : undefined;
+}
+
+describe("row-label numeric regex input", () => {
+  describe("a gate on an INTEGER column", () => {
+    it("fires on the digits SQLite shows for the value", () => {
+      // The msgvault case: every mailbox keyed by an INTEGER `source_id`, and
+      // the per-mailbox facet rule written as the natural `/^7$/`.
+      expect(gate(/^7$/, 7)).toEqual({ fired: true });
+    });
+
+    it("stays quiet for a different integer", () => {
+      expect(gate(/^7$/, 8)).toEqual({ fired: false });
+      expect(gate(/^7$/, 71)).toEqual({ fired: false });
+      expect(gate(/^7$/, -7)).toEqual({ fired: false });
+    });
+
+    it("shows a negative integer with its sign", () => {
+      expect(gate(/^-7$/, -7)).toEqual({ fired: true });
+    });
+
+    it('shows zero as "0", negative zero included', () => {
+      expect(gate(/^0$/, 0)).toEqual({ fired: true });
+      expect(gate(/^0$/, -0)).toEqual({ fired: true });
+    });
+
+    it("shows a bigint by its digits, for a driver in int64 mode", () => {
+      expect(gate(/^9007199254740993$/, 9007199254740993n)).toEqual({
+        fired: true,
+      });
+    });
+  });
+
+  describe("a gate on a REAL column", () => {
+    it("refuses a fractional value rather than approximating its text", () => {
+      // Not squeamishness about floats: SQLite's own REAL text is not a
+      // function of the double (see "the text SQLite shows" below), and a
+      // gate that nearly reproduces it is a gate that silently misses rows.
+      const res = gate(/^7\.5$/, 7.5, "real");
+      expect(res).toEqual({ error: expect.stringContaining("REAL") });
+    });
+
+    it("refuses an infinity", () => {
+      expect(refusal(Infinity)).toMatch(/infinity/);
+      expect(refusal(-Infinity)).toMatch(/infinity/);
+    });
+
+    it("takes a whole value stored in a REAL column", () => {
+      // What the driver hands over for a REAL 7.0 is the JS number 7, and a
+      // whole number is exactly what does coerce.
+      expect(gate(/^7$/, 7, "real")).toEqual({ fired: true });
+    });
+  });
+
+  describe("the value classes that stay refused", () => {
+    it("refuses NaN, which SQLite has no value for", () => {
+      expect(refusal(NaN)).toMatch(/NaN/);
+    });
+
+    it("refuses a whole number too large to name one INTEGER", () => {
+      // Past 2^53 a JS number no longer names one int64, and an INTEGER
+      // column read into a double has already lost the stored digits: any
+      // text we produced could name a different row.
+      expect(refusal(1e21)).toMatch(/too large/);
+      expect(refusal(2 ** 53)).toMatch(/too large/);
+      expect(refusal(-(2 ** 53))).toMatch(/too large/);
+    });
+
+    it("refuses a bigint outside the int64 range SQLite stores", () => {
+      expect(refusal(2n ** 63n)).toMatch(/regex input/);
+    });
+
+    it("refuses a boolean, which is not a SQLite value", () => {
+      expect(refusal(true)).toMatch(/boolean/);
+      expect(refusal(false)).toMatch(/boolean/);
+    });
+
+    it("refuses a BLOB", () => {
+      expect(refusal(new Uint8Array([1, 2]))).toMatch(/regex input/);
+    });
+
+    it("names no value in the refusal, only its class", () => {
+      // A refusal reaches a model-facing consumer, so it must not carry the
+      // row's own data (CFC spec invariant 14: no existence channel).
+      const reason = refusal(1234567890123456789012);
+      expect(reason).toBeDefined();
+      expect(reason).not.toMatch(/1234567890123456789/);
+    });
+  });
+
+  describe("the NULL rule, which this change leaves alone", () => {
+    it("keeps a NULL gate quiet rather than refusing", () => {
+      expect(gate(/^7$/, null)).toEqual({ fired: false });
+      expect(gate(/^7$/, undefined)).toEqual({ fired: false });
+      expect(gate(/^7$/, "")).toEqual({ fired: false });
+    });
+
+    it("distinguishes a zero from a NULL", () => {
+      // `0` is a value SQLite shows as "0"; NULL shows nothing. An evaluator
+      // that treated falsy-as-absent would collapse the two.
+      expect(gate(/^0$/, 0)).toEqual({ fired: true });
+      expect(gate(/^0$/, null)).toEqual({ fired: false });
+    });
+  });
+
+  describe("match(), the extractor", () => {
+    it("extracts from a number the same text a gate compares", () => {
+      const schema = table(
+        { id: "integer primary key", source_id: "integer" },
+        (f) => ({
+          confidentiality: all(
+            principal("mailbox", match(f.source_id, /\d+/, { min: 1 })),
+          ),
+        }),
+      );
+      const res = evaluateRowLabel(
+        schema.rowLabel as RowLabelSpec,
+        { id: 1, source_id: 7 },
+        { dbOwner: OWNER },
+      );
+      expect(res).toEqual({
+        confidentiality: ["did:mailbox:7"],
+        integrity: [],
+      });
+    });
+
+    it("still fails closed when a populated number matches nothing", () => {
+      // Strict-if-present is unchanged: a value that yields no match under-
+      // labels the row, so it refuses rather than dropping the principal.
+      const schema = table(
+        { id: "integer primary key", source_id: "integer" },
+        (f) => ({
+          confidentiality: all(
+            principal("mailbox", match(f.source_id, /[a-z]+/)),
+          ),
+        }),
+      );
+      const res = evaluateRowLabel(
+        schema.rowLabel as RowLabelSpec,
+        { id: 1, source_id: 7 },
+        { dbOwner: OWNER },
+      );
+      expect(res).toEqual({
+        error: expect.stringContaining("matched nothing"),
+      });
+    });
+  });
+
+  describe("the text SQLite shows", () => {
+    it("is what regexInputText() returns for every INTEGER", () => {
+      const corpus = [
+        0,
+        7,
+        -7,
+        42,
+        1000000,
+        -9007199254740991,
+        9007199254740991,
+        9007199254740993n,
+        -9007199254740993n,
+        9223372036854775807n,
+        -9223372036854775808n,
+      ];
+      const db = new Database(":memory:");
+      try {
+        const cast = db.prepare("SELECT CAST(?1 AS TEXT) AS text");
+        for (const value of corpus) {
+          const shown = cast.get<{ text: string }>(value as never)?.text;
+          expect({ value: String(value), text: regexInputText(value) })
+            .toEqual({ value: String(value), text: shown });
+        }
+      } finally {
+        db.close();
+      }
+    });
+
+    it("is not a function of the double, for a REAL", () => {
+      // The evidence behind refusing a REAL. SQLite renders one from its own
+      // decoded digits, which stop at the round-trip point and round up from
+      // there; the correctly rounded 15-digit value differs in the last
+      // place. Reproducing SQLite here would mean reimplementing its
+      // decoder's approximation, quirks included — and a gate compares the
+      // text SQLite would show, so "close" is a gate that misses rows.
+      const value = -0.009598882198146955;
+      const db = new Database(":memory:");
+      try {
+        const shown = db.prepare("SELECT CAST(?1 AS TEXT) AS text")
+          .get<{ text: string }>(value)?.text;
+        expect(shown).toBe("-0.00959888219814696");
+        expect(value.toPrecision(15)).toBe("-0.00959888219814695");
+        expect(regexInputText(value)).toBeUndefined();
+      } finally {
+        db.close();
+      }
+    });
+
+    it("diverges only where a JS number has lost the storage class", () => {
+      // The one documented gap for a value that DOES coerce: SQLite writes a
+      // REAL 7.0 as "7.0", and the driver hands that same row value to the
+      // evaluator as the JS number 7, which carries no REAL/INTEGER tag. The
+      // evaluator shows the integer spelling, so a gate is written against
+      // the digits rather than against the column's declared type.
+      const db = new Database(":memory:");
+      try {
+        db.exec("CREATE TABLE t (r real, i integer)");
+        db.exec("INSERT INTO t VALUES (7.0, 7)");
+        const shown = db.prepare(
+          "SELECT CAST(r AS TEXT) AS r, CAST(i AS TEXT) AS i FROM t",
+        ).get<{ r: string; i: string }>();
+        expect(shown).toEqual({ r: "7.0", i: "7" });
+
+        const stored = db.prepare("SELECT r, i FROM t").get<
+          { r: unknown; i: unknown }
+        >();
+        expect(stored).toEqual({ r: 7, i: 7 });
+        expect(regexInputText(stored?.r)).toBe("7");
+        expect(regexInputText(stored?.i)).toBe("7");
+      } finally {
+        db.close();
+      }
+    });
+  });
+
+  describe("declaring the rule", () => {
+    it("takes a gate on a non-TEXT column without complaint", () => {
+      // The refusal was only ever at evaluation: no validator reads a
+      // column's declared type, so nothing had to change at declaration.
+      expect(() =>
+        table({ id: "integer primary key", source_id: "integer" }, (f) => ({
+          confidentiality: all(
+            whenMatches(f.source_id, /^7$/, constant(GATED)),
+            dbOwner(),
+          ),
+        }))
+      ).not.toThrow();
+    });
+  });
+});

--- a/packages/memory/test/v2-sqlite-row-label-number-text.test.ts
+++ b/packages/memory/test/v2-sqlite-row-label-number-text.test.ts
@@ -170,7 +170,7 @@ describe("row-label numeric regex input", () => {
     });
   });
 
-  describe("the NULL rule, which this change leaves alone", () => {
+  describe("a NULL, an absent value, and a zero", () => {
     it("keeps a NULL gate quiet rather than refusing", () => {
       expect(gate(/^7$/, null)).toEqual({ fired: false });
       expect(gate(/^7$/, undefined)).toEqual({ fired: false });
@@ -280,24 +280,25 @@ describe("row-label numeric regex input", () => {
     it("is not a function of the double, for a REAL", () => {
       // The evidence behind refusing a REAL, and it is stronger than one
       // build can show: SQLite renders a REAL from its own decoded digits,
-      // and the two prebuilt libraries this driver loads disagree about the
-      // last one. For -0.009598882198146955 the macOS library says
-      // "-0.00959888219814696" while the Linux library says
-      // "-0.00959888219814695", which is the correctly rounded value. So the
-      // rendering is not a function of the double the evaluator holds, and no
-      // formatter is right on both platforms. A gate compares the text SQLite
-      // would show, so "close" is a gate that misses rows — this asserts the
-      // disagreement rather than either build's answer.
+      // and the builds behind this driver disagree about the last one. For
+      // -0.009598882198146955 the arm64 build returns
+      // "-0.00959888219814696" and the x86-64 build the correctly rounded
+      // "-0.00959888219814695" — the decoder uses a long double where that is
+      // wider than a double, so the split follows the architecture. The
+      // rendering is therefore not a function of the double the evaluator
+      // holds, and no formatter is right on both. A gate compares the text
+      // SQLite would show, so "close" is a gate that misses rows: this
+      // asserts the disagreement rather than either build's answer.
       const value = -0.009598882198146955;
       const correctlyRounded = "-0.00959888219814695";
-      const macOsLibrary = "-0.00959888219814696";
+      const longDoubleBuild = "-0.00959888219814696";
       expect(value.toPrecision(15)).toBe(correctlyRounded);
 
       const db = new Database(":memory:");
       try {
         const shown = db.prepare("SELECT CAST(?1 AS TEXT) AS text")
           .get<{ text: string }>(value)?.text;
-        expect([correctlyRounded, macOsLibrary]).toContain(shown);
+        expect([correctlyRounded, longDoubleBuild]).toContain(shown);
         expect(regexInputText(value)).toBeUndefined();
       } finally {
         db.close();

--- a/packages/memory/test/v2-sqlite-row-label-number-text.test.ts
+++ b/packages/memory/test/v2-sqlite-row-label-number-text.test.ts
@@ -361,6 +361,16 @@ describe("row-label numeric regex input", () => {
       ).toThrow(/BLOB/);
     });
 
+    it("reads a column whose declared type says BLOB but is INTEGER to SQLite", () => {
+      // Affinity, not substring: `INT BLOB` has INTEGER affinity (INT matches
+      // first), so the rule reads whole integers as it does from `integer`.
+      expect(() =>
+        table({ id: "integer primary key", source_id: "int blob" }, (f) => ({
+          confidentiality: principal("mailbox", match(f.source_id, /^\d+$/)),
+        }))
+      ).not.toThrow();
+    });
+
     it("re-runs that refusal on a wire-supplied spec", () => {
       // `db.tables` arrives over the wire, so a spec that never went through
       // `table()` reaches the same refusal before anything is evaluated.

--- a/packages/memory/test/v2-sqlite-row-label-number-text.test.ts
+++ b/packages/memory/test/v2-sqlite-row-label-number-text.test.ts
@@ -64,6 +64,26 @@ function refusal(value: unknown): string | undefined {
   return "error" in res ? res.error : undefined;
 }
 
+/** A rule whose only clause extracts principals from column `v`. */
+function extractorSpec(re: RegExp): RowLabelSpec {
+  const schema = table(
+    { id: "integer primary key", v: "integer" },
+    (f) => ({ confidentiality: all(principal("acct", match(f.v, re))) }),
+  );
+  return schema.rowLabel as RowLabelSpec;
+}
+
+/** What `match()` extracts from `value`, or the refusal it produced. */
+function extract(
+  re: RegExp,
+  value: unknown,
+): { atoms: unknown[] } | { error: string } {
+  const res = evaluateRowLabel(extractorSpec(re), { id: 1, v: value }, {
+    dbOwner: OWNER,
+  });
+  return "error" in res ? res : { atoms: res.confidentiality };
+}
+
 describe("row-label numeric regex input", () => {
   describe("a gate on an INTEGER column", () => {
     it("fires on the digits SQLite shows for the value", () => {
@@ -167,6 +187,27 @@ describe("row-label numeric regex input", () => {
   });
 
   describe("match(), the extractor", () => {
+    // The gate and the extractor read a column through one function, so what
+    // one refuses the other refuses. These assert that on the extractor
+    // directly: an extractor that rendered values its own way would mint
+    // principals from a REAL's digits, from a BLOB's bytes, and from an
+    // integer too large to be the one stored — silently, since a minted
+    // principal looks like any other.
+    it("refuses every value class the gate refuses", () => {
+      for (const value of [7.5, Infinity, NaN, 2 ** 53, true, 2n ** 63n]) {
+        expect(extract(/\d+/, value)).toEqual({
+          error: expect.stringContaining("regex input"),
+        });
+      }
+      expect(extract(/\d+/, new Uint8Array([1, 2]))).toEqual({
+        error: expect.stringContaining("BLOB"),
+      });
+    });
+
+    it("extracts from a zero, which is a value and not an absence", () => {
+      expect(extract(/\d+/, 0)).toEqual({ atoms: ["did:acct:0"] });
+    });
+
     it("extracts from a number the same text a gate compares", () => {
       const schema = table(
         { id: "integer primary key", source_id: "integer" },

--- a/packages/memory/test/v2-sqlite-row-label-number-text.test.ts
+++ b/packages/memory/test/v2-sqlite-row-label-number-text.test.ts
@@ -27,6 +27,7 @@ import {
   principal,
   regexInputText,
   type RowLabelSpec,
+  validateRowLabelSpec,
   whenMatches,
 } from "../v2/sqlite/row-label.ts";
 import { table } from "../v2/sqlite/schema.ts";
@@ -114,24 +115,22 @@ describe("row-label numeric regex input", () => {
     });
   });
 
-  describe("a gate on a REAL column", () => {
+  describe("a REAL a column happens to hold", () => {
+    // A rule cannot name a REAL-declared column at all (see "declaring the
+    // rule"), but affinity is not a type: an INTEGER-affinity column keeps a
+    // value it cannot convert losslessly, so a REAL still reaches a rule.
     it("refuses a fractional value rather than approximating its text", () => {
-      // Not squeamishness about floats: SQLite's own REAL text is not a
-      // function of the double (see "the text SQLite shows" below), and a
-      // gate that nearly reproduces it is a gate that silently misses rows.
-      const res = gate(/^7\.5$/, 7.5, "real");
-      expect(res).toEqual({ error: expect.stringContaining("REAL") });
+      // SQLite's own REAL text is not a function of the double (see "the text
+      // SQLite shows" below), and a gate that nearly reproduces it is a gate
+      // that silently misses rows.
+      expect(gate(/^7\.5$/, 7.5)).toEqual({
+        error: expect.stringContaining("REAL"),
+      });
     });
 
     it("refuses an infinity", () => {
       expect(refusal(Infinity)).toMatch(/infinity/);
       expect(refusal(-Infinity)).toMatch(/infinity/);
-    });
-
-    it("takes a whole value stored in a REAL column", () => {
-      // What the driver hands over for a REAL 7.0 is the JS number 7, and a
-      // whole number is exactly what does coerce.
-      expect(gate(/^7$/, 7, "real")).toEqual({ fired: true });
     });
   });
 
@@ -333,6 +332,52 @@ describe("row-label numeric regex input", () => {
   });
 
   describe("declaring the rule", () => {
+    it("refuses a rule that reads a REAL column", () => {
+      // Every value a REAL-affinity column holds is a REAL, and this
+      // evaluator will not render one. A rule there is either dead (the
+      // fractional values refuse) or misleading (a whole value shows "7"
+      // where SQLite shows "7.0", so a rule written from the column's type
+      // never fires, and a gate that never fires drops a clause). Refusing
+      // at declaration is the only place that can be said out loud.
+      expect(() =>
+        table({ id: "integer primary key", score: "real" }, (f) => ({
+          confidentiality: all(
+            whenMatches(f.score, /^7$/, constant(GATED)),
+            dbOwner(),
+          ),
+        }))
+      ).toThrow(/REAL/);
+    });
+
+    it("refuses a rule that reads a BLOB column", () => {
+      expect(() =>
+        table({ id: "integer primary key", raw: "blob" }, (f) => ({
+          confidentiality: all(
+            principal("acct", match(f.raw, /\d+/)),
+            dbOwner(),
+          ),
+        }))
+      ).toThrow(/BLOB/);
+    });
+
+    it("re-runs that refusal on a wire-supplied spec", () => {
+      // `db.tables` arrives over the wire, so a spec that never went through
+      // `table()` reaches the same refusal before anything is evaluated.
+      const spec = table({ id: "integer primary key", score: "text" }, (f) => ({
+        confidentiality: all(
+          whenMatches(f.score, /^7$/, constant(GATED)),
+          dbOwner(),
+        ),
+      })).rowLabel as RowLabelSpec;
+      expect(validateRowLabelSpec(spec, ["id", "score"])).toBeUndefined();
+      expect(
+        validateRowLabelSpec(spec, ["id", "score"], {
+          id: { sqlType: "integer primary key" },
+          score: { sqlType: "double precision" },
+        }),
+      ).toMatch(/REAL/);
+    });
+
     it("takes a gate on a non-TEXT column without complaint", () => {
       // The refusal was only ever at evaluation: no validator reads a
       // column's declared type, so nothing had to change at declaration.

--- a/packages/memory/test/v2-sqlite-row-label-number-text.test.ts
+++ b/packages/memory/test/v2-sqlite-row-label-number-text.test.ts
@@ -238,19 +238,26 @@ describe("row-label numeric regex input", () => {
     });
 
     it("is not a function of the double, for a REAL", () => {
-      // The evidence behind refusing a REAL. SQLite renders one from its own
-      // decoded digits, which stop at the round-trip point and round up from
-      // there; the correctly rounded 15-digit value differs in the last
-      // place. Reproducing SQLite here would mean reimplementing its
-      // decoder's approximation, quirks included — and a gate compares the
-      // text SQLite would show, so "close" is a gate that misses rows.
+      // The evidence behind refusing a REAL, and it is stronger than one
+      // build can show: SQLite renders a REAL from its own decoded digits,
+      // and the two prebuilt libraries this driver loads disagree about the
+      // last one. For -0.009598882198146955 the macOS library says
+      // "-0.00959888219814696" while the Linux library says
+      // "-0.00959888219814695", which is the correctly rounded value. So the
+      // rendering is not a function of the double the evaluator holds, and no
+      // formatter is right on both platforms. A gate compares the text SQLite
+      // would show, so "close" is a gate that misses rows — this asserts the
+      // disagreement rather than either build's answer.
       const value = -0.009598882198146955;
+      const correctlyRounded = "-0.00959888219814695";
+      const macOsLibrary = "-0.00959888219814696";
+      expect(value.toPrecision(15)).toBe(correctlyRounded);
+
       const db = new Database(":memory:");
       try {
         const shown = db.prepare("SELECT CAST(?1 AS TEXT) AS text")
           .get<{ text: string }>(value)?.text;
-        expect(shown).toBe("-0.00959888219814696");
-        expect(value.toPrecision(15)).toBe("-0.00959888219814695");
+        expect([correctlyRounded, macOsLibrary]).toContain(shown);
         expect(regexInputText(value)).toBeUndefined();
       } finally {
         db.close();

--- a/packages/memory/v2/sqlite/columns.ts
+++ b/packages/memory/v2/sqlite/columns.ts
@@ -8,3 +8,26 @@ export const CF_LINK_SUFFIX = "_cf_link";
 export function isCfLinkColumn(name: string): boolean {
   return name.length > CF_LINK_SUFFIX.length && name.endsWith(CF_LINK_SUFFIX);
 }
+
+/** The five column affinities SQLite derives from a declared type name. */
+export type SqlAffinity = "integer" | "text" | "blob" | "real" | "numeric";
+
+/**
+ * The affinity SQLite gives a column declared `sqlType`, by the rules in its
+ * datatype documentation (§3.1): the first matching substring wins, and a
+ * type naming none of them is NUMERIC. Callers use it to reason about what a
+ * column will do to a value on the way in — a rule gate reads what was
+ * STORED, and affinity is what decides whether that is what was bound.
+ */
+export function sqlAffinity(sqlType: string): SqlAffinity {
+  const type = sqlType.toUpperCase();
+  if (type.includes("INT")) return "integer";
+  if (type.includes("CHAR") || type.includes("CLOB") || type.includes("TEXT")) {
+    return "text";
+  }
+  if (type.includes("BLOB") || type.trim() === "") return "blob";
+  if (type.includes("REAL") || type.includes("FLOA") || type.includes("DOUB")) {
+    return "real";
+  }
+  return "numeric";
+}

--- a/packages/memory/v2/sqlite/commit-eval.ts
+++ b/packages/memory/v2/sqlite/commit-eval.ts
@@ -85,11 +85,32 @@ const fail = (message: string): never => {
 
 const quoteIdent = (id: string) => `"${id.replace(/"/g, '""')}"`;
 
-// The engine connection runs with int64:false (integers surface as JS
-// numbers), but tolerate bigint in case that ever flips. Key by String for
-// dedup; bind values pass through as-is.
-const isRowidValue = (v: unknown): v is number | bigint =>
-  typeof v === "number" || typeof v === "bigint";
+// Rowids and rule inputs both cross into JS as TEXT, rendered by SQLite —
+// see `rowidText` and `renderedInput` below for why. A rowid is therefore a
+// string of digits here; anything else means the render did not happen.
+const isRowidValue = (v: unknown): v is string =>
+  typeof v === "string" && /^-?\d+$/.test(v);
+
+// The engine connection reads an INTEGER column through `sqlite3_column_int`,
+// the 32-bit accessor (`@db/sqlite` uses `sqlite3_column_int64` only under
+// `int64`, which the engine does not set — flipping it would change every
+// value the engine hands anyone). So a stored 4294967303 arrives as 7, and a
+// label derived from that is a label for a different row's key. SQLite renders
+// the value instead, which is exact whatever the accessor would have done:
+//   - the rowid, so the read-back addresses the row that was written rather
+//     than whichever row shares its low 32 bits;
+//   - a rule input holding an INTEGER, so the evaluator sees the digits it
+//     would see on the read side, which reads whole integers already.
+// Only the INTEGER storage class is rendered: a REAL rendered to text would
+// reach the evaluator as a string and be gated on, where the read side refuses
+// it, and the two sides deriving different labels is the thing this evaluator
+// exists to prevent.
+const rowidText = (rowid: string) => `CAST(${rowid} AS TEXT)`;
+const renderedInput = (column: string) => {
+  const id = quoteIdent(column);
+  return `CASE WHEN typeof(${id}) = 'integer' THEN CAST(${id} AS TEXT) ` +
+    `ELSE ${id} END AS ${id}`;
+};
 
 /**
  * Execute a commit-folded `sqlite` write. Plain `runWrite` unless the db
@@ -205,7 +226,7 @@ export function applySqliteCommitWrite(
   // take effect (e.g. the statement ends inside an unterminated block comment
   // that swallowed it), so fail closed rather than under-evaluate.
   const execSql = op.sql.replace(/[\s;]+$/, "") +
-    `\nRETURNING ${rowidName} AS __cf_rowid`;
+    `\nRETURNING ${rowidText(rowidName)} AS __cf_rowid`;
   let returned: Record<string, unknown>[];
   let changes: number;
   const stmt = db.prepare(execSql);
@@ -232,7 +253,7 @@ export function applySqliteCommitWrite(
     );
   }
 
-  const rowids: (number | bigint)[] = [];
+  const rowids: string[] = [];
   const seen = new Set<string>();
   for (const row of returned) {
     const id = row.__cf_rowid;
@@ -242,9 +263,8 @@ export function applySqliteCommitWrite(
           `"${declaredKey}"`,
       );
     }
-    const key = String(id);
-    if (seen.has(key)) continue; // same row touched twice by one statement
-    seen.add(key);
+    if (seen.has(id)) continue; // same row touched twice by one statement
+    seen.add(id);
     rowids.push(id);
   }
 
@@ -267,12 +287,15 @@ export function applySqliteCommitWrite(
   // evolved after the file was created — additive DDL creates tables only)
   // makes this SELECT throw: fail closed, matching the read side, which
   // refuses queries over the same gap.
-  const selectCols = inputFields.map(quoteIdent).join(", ");
+  const selectCols = inputFields.map(renderedInput).join(", ");
   for (let at = 0; at < rowids.length; at += READ_BACK_CHUNK) {
     const chunk = rowids.slice(at, at + READ_BACK_CHUNK);
-    const readSql = `SELECT ${rowidName} AS __cf_rowid, ${selectCols} FROM ${
-      quoteIdent(declaredKey)
-    } WHERE ${rowidName} IN (${chunk.map(() => "?").join(", ")})`;
+    // The digits bind as text and cast back to the integer inside SQL, so the
+    // comparison is still rowid-to-rowid and still takes the rowid index.
+    const readSql = `SELECT ${rowidText(rowidName)} AS __cf_rowid, ` +
+      `${selectCols} FROM ${quoteIdent(declaredKey)} WHERE ${rowidName} IN (${
+        chunk.map(() => "CAST(? AS INTEGER)").join(", ")
+      })`;
     const readStmt = db.prepare(readSql);
     let rows: Record<string, unknown>[];
     try {

--- a/packages/memory/v2/sqlite/commit-eval.ts
+++ b/packages/memory/v2/sqlite/commit-eval.ts
@@ -172,12 +172,12 @@ export function applySqliteCommitWrite(
   }
 
   const spec = (declared as { rowLabel: RowLabelSpec }).rowLabel;
-  const columnNames = Object.keys(
-    (declared as { properties?: Record<string, unknown> }).properties ?? {},
-  );
+  const properties =
+    (declared as { properties?: Record<string, unknown> }).properties ?? {};
+  const columnNames = Object.keys(properties);
   // `db.tables` is wire-supplied: re-validate before evaluating anything —
   // "couldn't validate" is never "no label".
-  const invalid = validateRowLabelSpec(spec, columnNames);
+  const invalid = validateRowLabelSpec(spec, columnNames, properties);
   if (invalid) {
     return fail(
       `table "${declaredKey}" declares an invalid rowLabel rule — ${invalid}`,

--- a/packages/memory/v2/sqlite/read-pool.ts
+++ b/packages/memory/v2/sqlite/read-pool.ts
@@ -1,4 +1,5 @@
-// A small LRU pool of read-only SQLite connections keyed by canonical file path.
+// A small LRU pool of read-only SQLite connections keyed by canonical file path
+// and by integer mode.
 //
 // Reads (injected on-disk sources, and — once routed — cell-derived dbs) run
 // here: each connection is opened `readonly` directly on the db file and is
@@ -13,6 +14,18 @@
 // The statement guard still applies (via `runQuery`): SELECT-only, no
 // ATTACH/PRAGMA/multi-statement, so a read can't use its connection to reach
 // other files.
+//
+// Two connections per file, opened in different integer modes, because CFC
+// labeling needs whole integers and nothing else may change under it.
+// `@db/sqlite` reads an INTEGER column through the 32-bit
+// `sqlite3_column_int` unless `int64` is set, so a stored 4294967303 arrives
+// as 7 — and a per-row label derived from that gates the row as mailbox 7.
+// The labeled reads (`queryWithOrigins`, issued only for a db that declares
+// `ifc` or a row rule) therefore run on an `int64` connection, where a value
+// past 2^53 arrives as a `bigint` rather than a rounded number. Ordinary
+// reads keep the connection and the values they have always had: widening
+// them is a change to every consumer's data, which belongs to its own
+// change rather than riding in on a labeling fix.
 
 import { Database } from "@db/sqlite";
 import type { SqliteNativeRow } from "../../v2.ts";
@@ -31,22 +44,25 @@ export class ReadConnectionPool {
     this.#max = max;
   }
 
-  #connection(path: string): Database {
-    const existing = this.#byPath.get(path);
+  // Keyed by mode as well as path: the two modes return different JS values
+  // for the same stored row, so one connection cannot serve both.
+  #connection(path: string, int64: boolean): Database {
+    const key = int64 ? `int64\n${path}` : `plain\n${path}`;
+    const existing = this.#byPath.get(key);
     if (existing) {
       // LRU bump: re-insert so this path is most-recently-used.
-      this.#byPath.delete(path);
-      this.#byPath.set(path, existing);
+      this.#byPath.delete(key);
+      this.#byPath.set(key, existing);
       return existing;
     }
-    const db = new Database(path, { readonly: true });
+    const db = new Database(path, { readonly: true, int64 });
     // Match the engine connection's busy_timeout (engine.ts PRAGMAS). A pooled
     // read uses a SEPARATE OS connection from the writer's engine connection, so
     // a read that races a writer holding the file lock (another process over the
     // same store, or an external writer to a `cf link`ed disk source) would hit
     // an immediate SQLITE_BUSY at the default timeout of 0 — wait instead.
     db.exec("PRAGMA busy_timeout = 5000");
-    this.#byPath.set(path, db);
+    this.#byPath.set(key, db);
     if (this.#byPath.size > this.#max) {
       const oldest = this.#byPath.keys().next().value as string | undefined;
       if (oldest !== undefined) {
@@ -67,18 +83,25 @@ export class ReadConnectionPool {
     sql: string,
     params?: SqliteParams,
   ): Row[] {
-    return runQuery<Row>(this.#connection(path), sql, params);
+    return runQuery<Row>(this.#connection(path, false), sql, params);
   }
 
-  /** Like {@link query} but also returns each result column's TRUE origin
-   *  `(table, column)`, for CFC read-labeling. Used only when the db declares
-   *  per-column `ifc`. */
+  /**
+   * Like {@link query} but also returns each result column's TRUE origin
+   * `(table, column)`, for CFC read-labeling. Used only when the db declares
+   * per-column `ifc` or a row rule.
+   *
+   * Runs on the `int64` connection, so a label derived from an INTEGER column
+   * is derived from the integer the row holds: see the note at the top of
+   * this file for what the other mode does to one. A value past 2^53 arrives
+   * as a `bigint`, which is a `FabricValue` the JSON codec carries.
+   */
   queryWithOrigins<Row extends SqliteNativeRow = SqliteNativeRow>(
     path: string,
     sql: string,
     params?: SqliteParams,
   ): { rows: Row[]; columns: QueryColumn[] } {
-    return runQueryWithOrigins<Row>(this.#connection(path), sql, params);
+    return runQueryWithOrigins<Row>(this.#connection(path, true), sql, params);
   }
 
   close(): void {

--- a/packages/memory/v2/sqlite/row-label.ts
+++ b/packages/memory/v2/sqlite/row-label.ts
@@ -21,6 +21,7 @@
 import type { FabricPlainObject, FabricValue } from "@commonfabric/api";
 import type { MutableFabricPlainObjectLayer } from "@commonfabric/data-model";
 import { isObjectNotArray } from "@commonfabric/utils/types";
+import { sqlAffinity } from "./columns.ts";
 
 /** A reference to a declared column, handed to the rule as `f.<col>`. */
 export type FieldRef = {
@@ -489,15 +490,46 @@ function validateIntegTerm(
   return unknownOp(node, "integrity");
 }
 
+// A rule reads a column as text, and two declared types settle what the column
+// holds before any rule sees it. A REAL-affinity column forces every value it
+// stores to a float, and this evaluator renders none: the fractional ones
+// refuse (its rendering is not reproducible — see `regexInputText`) and a
+// whole one shows "7" where SQLite shows "7.0", so a rule written from the
+// column's declared type never fires, and a gate that never fires drops a
+// confidentiality clause. A BLOB column's bytes are refused outright. Neither
+// is a rule anyone can write correctly, so neither is accepted — declare a
+// column that carries text as TEXT.
+function unreadableRuleInput(
+  field: string,
+  sqlType: unknown,
+): string | undefined {
+  if (typeof sqlType !== "string") return undefined; // no declared type
+  if (/blob/i.test(sqlType)) {
+    return `rule input "${field}" is declared ${sqlType} — a rule reads a ` +
+      "column as text, and a BLOB has none";
+  }
+  if (sqlAffinity(sqlType) === "real") {
+    return `rule input "${field}" is declared ${sqlType}, which gives it ` +
+      "REAL affinity — a rule reads a column as text, and this evaluator " +
+      "renders no REAL (declare a column holding text as TEXT)";
+  }
+  return undefined;
+}
+
 /**
  * Validate a rowLabel spec against the declared column names. Returns the
  * failure reason, or undefined when valid. Used by `table()` at authoring
  * (throws) and MUST be re-run on wire-supplied specs before evaluation —
  * "couldn't validate" is never "no label".
+ *
+ * `properties` is the table schema's column map, when the caller holds one:
+ * with it, a rule reading a column whose declared type settles its storage
+ * class against the rule is refused here rather than at evaluation.
  */
 export function validateRowLabelSpec(
   spec: unknown,
   columns: readonly string[],
+  properties?: Readonly<Record<string, unknown>>,
 ): string | undefined {
   if (!isObjectNotArray(spec)) return "rowLabel spec must be an object";
   if (spec.version !== 1) {
@@ -515,6 +547,18 @@ export function validateRowLabelSpec(
     const r = validateIntegTerm(spec.integrity, cols);
     if (r) return r;
   }
+  if (properties !== undefined) {
+    // After the structural pass, so the walk reads a spec whose match nodes
+    // are known to be well formed.
+    for (const field of ruleInputFields(spec as RowLabelSpec)) {
+      const column = properties[field];
+      const reason = unreadableRuleInput(
+        field,
+        isObjectNotArray(column) ? column.sqlType : undefined,
+      );
+      if (reason) return reason;
+    }
+  }
   return undefined;
 }
 
@@ -523,6 +567,7 @@ export function validateRowLabelSpec(
 export function buildRowLabelSpec<C extends Record<string, unknown>>(
   columns: readonly string[],
   rule: RowLabelRule<C>,
+  properties?: Readonly<Record<string, unknown>>,
 ): RowLabelSpec {
   const handles = Object.fromEntries(
     columns.map((name) => [name, { field: name }]),
@@ -538,7 +583,7 @@ export function buildRowLabelSpec<C extends Record<string, unknown>>(
     spec.confidentiality = out.confidentiality;
   }
   if (out.integrity !== undefined) spec.integrity = out.integrity;
-  const reason = validateRowLabelSpec(spec, columns);
+  const reason = validateRowLabelSpec(spec, columns, properties);
   if (reason) {
     throw new TypeError(`table(): invalid rowLabel rule — ${reason}`);
   }

--- a/packages/memory/v2/sqlite/row-label.ts
+++ b/packages/memory/v2/sqlite/row-label.ts
@@ -504,7 +504,11 @@ function unreadableRuleInput(
   sqlType: unknown,
 ): string | undefined {
   if (typeof sqlType !== "string") return undefined; // no declared type
-  if (/blob/i.test(sqlType)) {
+  // By affinity, not by substring: `INT BLOB` is an INTEGER column to
+  // SQLite (INT matches first), and only a type SQLite itself reads as BLOB
+  // is refused. An empty declared type also has BLOB affinity but stores
+  // each value as bound, so text stays text; it is left readable.
+  if (sqlAffinity(sqlType) === "blob" && sqlType.trim() !== "") {
     return `rule input "${field}" is declared ${sqlType} — a rule reads a ` +
       "column as text, and a BLOB has none";
   }

--- a/packages/memory/v2/sqlite/row-label.ts
+++ b/packages/memory/v2/sqlite/row-label.ts
@@ -655,28 +655,31 @@ const INT64_MAX = 2n ** 63n - 1n;
  *
  * A rule gates on stored data, and a column keyed by an INTEGER — a mailbox
  * id, an account id — is the ordinary thing to gate on, so a whole integer
- * shows the regex its decimal digits: the same text SQLite shows for that
- * INTEGER, and the text an operator reads off the row. One value has one
- * text, so the write gate, the server commit, and read re-derivation still
+ * shows the regex its decimal digits. Those are the digits SQLite shows for
+ * that INTEGER, which is what makes a rule writable from the row: the read
+ * side reads whole integers (`read-pool.ts` opens the labeled reads with
+ * `int64`) and commit evaluation renders them (`commit-eval.ts`), so the
+ * digits here are the stored ones rather than a truncation of them. One value
+ * has one text, so the write gate, the server commit, and read re-derivation
  * derive one label from one row.
  *
- * A REAL does NOT coerce, and the reason is not squeamishness about floats:
- * SQLite renders one with "%!.15g" over its OWN decoded digits, and that
- * rendering is not a function of the double this evaluator holds. The two
- * prebuilt libraries this driver loads disagree about the last digit of
- * -0.009598882198146955 — the macOS one shows "-0.00959888219814696", the
- * Linux one the correctly rounded "-0.00959888219814695" — so no formatter
- * written here is right on both. A gate is an anchored comparison against the
- * text SQLite would show, so a text we can only nearly reproduce is a gate
- * that silently fails to fire on some rows, dropping a confidentiality
- * clause. Refusing is the fail-closed half of that choice, and it is what a
- * REAL did before this coercion existed.
+ * A REAL does not coerce. SQLite renders one with "%!.15g" over its OWN
+ * decoded digits, and that rendering is not a function of the double this
+ * evaluator holds: the SQLite builds behind this driver disagree about the
+ * last digit of -0.009598882198146955, which one returns as
+ * "-0.00959888219814696" and another as the correctly rounded
+ * "-0.00959888219814695" (the split follows the architecture, whose long
+ * double the decoder uses where it is wider than a double). A gate is an
+ * anchored comparison against the text SQLite would show, so a text that can
+ * only be nearly reproduced is a gate that silently fails to fire on some
+ * rows, dropping a confidentiality clause.
  * (`v2-sqlite-row-label-number-text.test.ts` pins the disagreement.)
  *
- * The one place an INTEGER's text is not literally `CAST(col AS TEXT)`: a JS
- * number carries no INTEGER/REAL tag, so a whole value stored in a REAL
- * column shows its integer spelling ("7") where SQLite would show "7.0".
- * Gate on a column that holds whole numbers, and write the digits.
+ * A column declared REAL or BLOB is refused a rule outright, at declaration —
+ * see `validateRowLabelSpec`. What reaches here is a REAL a column of some
+ * other affinity happens to hold, and one exception to the digits being
+ * SQLite's: a whole REAL in a column with no affinity arrives as a JS number
+ * carrying no storage class, and shows "7" where SQLite shows "7.0".
  */
 export function regexInputText(value: unknown): string | undefined {
   if (typeof value === "string") return value;

--- a/packages/memory/v2/sqlite/row-label.ts
+++ b/packages/memory/v2/sqlite/row-label.ts
@@ -592,13 +592,83 @@ function normalizeForProtocol(protocol: string, v: string): string {
   }
 }
 
+//
+// Regex input — the text a row value shows a rule's regex.
+//
+
+// An INTEGER is an int64; a JS number carries 53 bits of integer precision.
+// Past that a number no longer names one integer — a large INTEGER read into
+// a double has already lost its low digits, and the driver's own bind wraps
+// on the way back (1e21 binds as 3875820019684212736) — so no text we
+// produced would honestly be the row's.
+const INT64_MIN = -(2n ** 63n);
+const INT64_MAX = 2n ** 63n - 1n;
+
 /**
- * The text a row value presents to a rule's regex, or `undefined` for a value
- * class this evaluator refuses. Today only TEXT has a text form here; a
- * number refuses, which is what the coercion below replaces.
+ * The text a row value shows a rule's regex, or `undefined` for a value class
+ * the evaluator refuses (the caller fails closed on it).
+ *
+ * A rule gates on stored data, and a column keyed by an INTEGER — a mailbox
+ * id, an account id — is the ordinary thing to gate on, so a whole integer
+ * shows the regex its decimal digits: the same text SQLite shows for that
+ * INTEGER, and the text an operator reads off the row. One value has one
+ * text, so the write gate, the server commit, and read re-derivation still
+ * derive one label from one row.
+ *
+ * A REAL does NOT coerce, and the reason is not squeamishness about floats:
+ * SQLite renders one with "%!.15g" over its OWN decoded digits, and that
+ * rendering is not a function of the double this evaluator holds. SQLite
+ * shows -0.009598882198146955 as "-0.00959888219814696" where the value
+ * correctly rounded to 15 digits is "-0.00959888219814695" — its decoder
+ * stops at the round-trip digits and rounds up from there. A gate is an
+ * anchored comparison against the text SQLite would show, so a text we can
+ * only nearly reproduce is a gate that silently fails to fire on some rows,
+ * dropping a confidentiality clause. Refusing is the fail-closed half of
+ * that choice, and it is what a REAL did before this coercion existed.
+ * (`v2-sqlite-row-label-number-text.test.ts` pins the counterexample.)
+ *
+ * The one place an INTEGER's text is not literally `CAST(col AS TEXT)`: a JS
+ * number carries no INTEGER/REAL tag, so a whole value stored in a REAL
+ * column shows its integer spelling ("7") where SQLite would show "7.0".
+ * Gate on a column that holds whole numbers, and write the digits.
  */
 export function regexInputText(value: unknown): string | undefined {
-  return typeof value === "string" ? value : undefined;
+  if (typeof value === "string") return value;
+  // `Number.isSafeInteger` also rejects NaN and the infinities, which are not
+  // SQLite INTEGERs either (SQLite stores a NaN as NULL).
+  if (typeof value === "number") {
+    return Number.isSafeInteger(value) ? String(value) : undefined;
+  }
+  // A driver in int64 mode hands large INTEGERs over as bigints, whose digits
+  // ARE exact; one outside int64 never came out of a row.
+  if (typeof value === "bigint") {
+    return value >= INT64_MIN && value <= INT64_MAX ? String(value) : undefined;
+  }
+  return undefined;
+}
+
+/** Why a value has no regex text — its CLASS only. The refusal reaches a
+ *  model-facing consumer, so it carries nothing of the row itself. */
+function regexInputRefusal(field: string, value: unknown): string {
+  const kind = typeof value === "number"
+    ? (Number.isNaN(value)
+      ? "NaN, which SQLite stores as NULL"
+      : !Number.isFinite(value)
+      ? "an infinity, which is a REAL"
+      : Number.isInteger(value)
+      ? "a whole number too large to name one SQLite INTEGER exactly"
+      : "a REAL, whose SQLite text this evaluator cannot reproduce")
+    : typeof value === "bigint"
+    ? "a bigint outside SQLite's int64 range"
+    : ArrayBuffer.isView(value) || value instanceof ArrayBuffer
+    ? "a BLOB"
+    : typeof value === "boolean"
+    ? "a boolean, which is not a SQLite value (bind 1 or 0)"
+    : typeof value === "object"
+    ? "an object"
+    : `a ${typeof value}`;
+  return `field "${field}" is ${kind} — regex input must be TEXT or a whole ` +
+    "INTEGER";
 }
 
 /** Extract the match list for a field per the strict-if-present contract. */
@@ -614,11 +684,7 @@ function evalMatch(
   const values: string[] = [];
   if (value !== null && value !== undefined && value !== "") {
     const text = regexInputText(value);
-    if (text === undefined) {
-      return fail(
-        `field "${field}" is ${typeof value}, not a string — regex input`,
-      );
-    }
+    if (text === undefined) return fail(regexInputRefusal(field, value));
     // Force the global flag like match() does at authoring: matchAll throws
     // on non-global regexes, and a hostile/legacy wire spec must degrade to
     // the documented split semantics, not an uncaught exception.
@@ -663,11 +729,7 @@ function evalTest(
   const value = row[field];
   if (value === null || value === undefined || value === "") return false;
   const text = regexInputText(value);
-  if (text === undefined) {
-    return fail(
-      `field "${field}" is ${typeof value}, not a string — regex input`,
-    );
-  }
+  if (text === undefined) return fail(regexInputRefusal(field, value));
   return new RegExp(source as string, (flags as string) ?? "").test(text);
 }
 

--- a/packages/memory/v2/sqlite/row-label.ts
+++ b/packages/memory/v2/sqlite/row-label.ts
@@ -617,15 +617,16 @@ const INT64_MAX = 2n ** 63n - 1n;
  *
  * A REAL does NOT coerce, and the reason is not squeamishness about floats:
  * SQLite renders one with "%!.15g" over its OWN decoded digits, and that
- * rendering is not a function of the double this evaluator holds. SQLite
- * shows -0.009598882198146955 as "-0.00959888219814696" where the value
- * correctly rounded to 15 digits is "-0.00959888219814695" — its decoder
- * stops at the round-trip digits and rounds up from there. A gate is an
- * anchored comparison against the text SQLite would show, so a text we can
- * only nearly reproduce is a gate that silently fails to fire on some rows,
- * dropping a confidentiality clause. Refusing is the fail-closed half of
- * that choice, and it is what a REAL did before this coercion existed.
- * (`v2-sqlite-row-label-number-text.test.ts` pins the counterexample.)
+ * rendering is not a function of the double this evaluator holds. The two
+ * prebuilt libraries this driver loads disagree about the last digit of
+ * -0.009598882198146955 — the macOS one shows "-0.00959888219814696", the
+ * Linux one the correctly rounded "-0.00959888219814695" — so no formatter
+ * written here is right on both. A gate is an anchored comparison against the
+ * text SQLite would show, so a text we can only nearly reproduce is a gate
+ * that silently fails to fire on some rows, dropping a confidentiality
+ * clause. Refusing is the fail-closed half of that choice, and it is what a
+ * REAL did before this coercion existed.
+ * (`v2-sqlite-row-label-number-text.test.ts` pins the disagreement.)
  *
  * The one place an INTEGER's text is not literally `CAST(col AS TEXT)`: a JS
  * number carries no INTEGER/REAL tag, so a whole value stored in a REAL

--- a/packages/memory/v2/sqlite/row-label.ts
+++ b/packages/memory/v2/sqlite/row-label.ts
@@ -592,6 +592,15 @@ function normalizeForProtocol(protocol: string, v: string): string {
   }
 }
 
+/**
+ * The text a row value presents to a rule's regex, or `undefined` for a value
+ * class this evaluator refuses. Today only TEXT has a text form here; a
+ * number refuses, which is what the coercion below replaces.
+ */
+export function regexInputText(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
 /** Extract the match list for a field per the strict-if-present contract. */
 function evalMatch(
   node: Record<string, unknown>,
@@ -604,7 +613,8 @@ function evalMatch(
   const value = row[field];
   const values: string[] = [];
   if (value !== null && value !== undefined && value !== "") {
-    if (typeof value !== "string") {
+    const text = regexInputText(value);
+    if (text === undefined) {
       return fail(
         `field "${field}" is ${typeof value}, not a string — regex input`,
       );
@@ -616,7 +626,7 @@ function evalMatch(
     const flags = rawFlags.includes("g") ? rawFlags : rawFlags + "g";
     const re = new RegExp(node.source as string, flags);
     const group = node.group as number | undefined;
-    for (const m of value.matchAll(re)) {
+    for (const m of text.matchAll(re)) {
       const picked = group !== undefined ? m[group] : m[0];
       if (typeof picked === "string") values.push(picked);
     }
@@ -652,12 +662,13 @@ function evalTest(
   }
   const value = row[field];
   if (value === null || value === undefined || value === "") return false;
-  if (typeof value !== "string") {
+  const text = regexInputText(value);
+  if (text === undefined) {
     return fail(
       `field "${field}" is ${typeof value}, not a string — regex input`,
     );
   }
-  return new RegExp(source as string, (flags as string) ?? "").test(value);
+  return new RegExp(source as string, (flags as string) ?? "").test(text);
 }
 
 function evalPrincipal(

--- a/packages/memory/v2/sqlite/schema.ts
+++ b/packages/memory/v2/sqlite/schema.ts
@@ -63,6 +63,29 @@ export function assertSafeColumn(name: string, sqlType: string): void {
   }
 }
 
+/** The five column affinities SQLite derives from a declared type name. */
+export type SqlAffinity = "integer" | "text" | "blob" | "real" | "numeric";
+
+/**
+ * The affinity SQLite gives a column declared `sqlType`, by the rules in its
+ * datatype documentation (§3.1): the first matching substring wins, and a
+ * type naming none of them is NUMERIC. Callers use it to reason about what a
+ * column will do to a value on the way in — a rule gate reads what was
+ * STORED, and affinity is what decides whether that is what was bound.
+ */
+export function sqlAffinity(sqlType: string): SqlAffinity {
+  const type = sqlType.toUpperCase();
+  if (type.includes("INT")) return "integer";
+  if (type.includes("CHAR") || type.includes("CLOB") || type.includes("TEXT")) {
+    return "text";
+  }
+  if (type.includes("BLOB") || type.trim() === "") return "blob";
+  if (type.includes("REAL") || type.includes("FLOA") || type.includes("DOUB")) {
+    return "real";
+  }
+  return "numeric";
+}
+
 // Map the leading SQL type word to a JSON Schema `type`.
 function jsonTypeForSql(sqlType: string): JSONSchemaTypes {
   const head = sqlType.trim().toLowerCase().split(/\s+/)[0] ?? "";

--- a/packages/memory/v2/sqlite/schema.ts
+++ b/packages/memory/v2/sqlite/schema.ts
@@ -63,29 +63,6 @@ export function assertSafeColumn(name: string, sqlType: string): void {
   }
 }
 
-/** The five column affinities SQLite derives from a declared type name. */
-export type SqlAffinity = "integer" | "text" | "blob" | "real" | "numeric";
-
-/**
- * The affinity SQLite gives a column declared `sqlType`, by the rules in its
- * datatype documentation (§3.1): the first matching substring wins, and a
- * type naming none of them is NUMERIC. Callers use it to reason about what a
- * column will do to a value on the way in — a rule gate reads what was
- * STORED, and affinity is what decides whether that is what was bound.
- */
-export function sqlAffinity(sqlType: string): SqlAffinity {
-  const type = sqlType.toUpperCase();
-  if (type.includes("INT")) return "integer";
-  if (type.includes("CHAR") || type.includes("CLOB") || type.includes("TEXT")) {
-    return "text";
-  }
-  if (type.includes("BLOB") || type.trim() === "") return "blob";
-  if (type.includes("REAL") || type.includes("FLOA") || type.includes("DOUB")) {
-    return "real";
-  }
-  return "numeric";
-}
-
 // Map the leading SQL type word to a JSON Schema `type`.
 function jsonTypeForSql(sqlType: string): JSONSchemaTypes {
   const head = sqlType.trim().toLowerCase().split(/\s+/)[0] ?? "";
@@ -165,7 +142,11 @@ export function table<C extends Record<string, ColumnSpec>>(
   }
   const schema: TableSchema = { type: "object", properties, required };
   if (rule !== undefined) {
-    schema.rowLabel = buildRowLabelSpec(Object.keys(columns), rule);
+    schema.rowLabel = buildRowLabelSpec(
+      Object.keys(columns),
+      rule,
+      properties,
+    );
   }
   if (opts?.allowReadClearance) {
     if (rule === undefined) {

--- a/packages/runner/src/builtins/sqlite/row-label-read.ts
+++ b/packages/runner/src/builtins/sqlite/row-label-read.ts
@@ -183,10 +183,10 @@ export function computeRowLabelRead(
   for (const [name, t] of Object.entries(tables ?? {})) {
     if (!tableDeclaresRowLabel(t)) continue;
     const spec = (t as { rowLabel: RowLabelSpec }).rowLabel;
-    const columnNames = Object.keys(
-      (t as { properties?: Record<string, unknown> }).properties ?? {},
-    );
-    const reason = validateRowLabelSpec(spec, columnNames);
+    const properties =
+      (t as { properties?: Record<string, unknown> }).properties ?? {};
+    const columnNames = Object.keys(properties);
+    const reason = validateRowLabelSpec(spec, columnNames, properties);
     if (reason) {
       return {
         error: `sqlite: table "${name}" declares an invalid rowLabel rule — ` +

--- a/packages/runner/src/builtins/sqlite/row-label-write.ts
+++ b/packages/runner/src/builtins/sqlite/row-label-write.ts
@@ -28,7 +28,7 @@ import {
   ruleInputFields,
   validateRowLabelSpec,
 } from "@commonfabric/memory/sqlite/row-label";
-import { sqlAffinity } from "@commonfabric/memory/sqlite/schema";
+import { sqlAffinity } from "@commonfabric/memory/sqlite/columns";
 import {
   blankWriteSql,
   parseUpdateSetColumns,
@@ -160,7 +160,7 @@ export function checkSqliteRowLabelWrite(
   const properties =
     (declared as { properties?: Record<string, unknown> }).properties ?? {};
   const columnNames = Object.keys(properties);
-  const invalid = validateRowLabelSpec(spec, columnNames);
+  const invalid = validateRowLabelSpec(spec, columnNames, properties);
   if (invalid) {
     return {
       error: `sqlite: table "${declaredKey}" declares an invalid rowLabel ` +

--- a/packages/runner/src/builtins/sqlite/row-label-write.ts
+++ b/packages/runner/src/builtins/sqlite/row-label-write.ts
@@ -43,15 +43,20 @@ import {
 import type { CfcConfClause } from "../../cfc/clause.ts";
 import { cfcObservationFitsCeiling } from "../../cfc/observation.ts";
 
-// Whether a numeric-affinity column would convert this bound string on the way
-// in. SQLite converts text that is a well-formed integer or real literal and
-// leaves everything else as TEXT, so this asks the same question one step more
-// broadly: anything JS reads as a finite number counts, which over-refuses a
-// spelling SQLite would have kept (`0x10`) rather than admitting one it
-// converts.
-function storesAsANumber(value: string): boolean {
+// Whether a numeric-affinity column would store this bound string as a
+// number whose text differs from the string bound. SQLite converts text that
+// is a well-formed integer or real literal and leaves everything else as
+// TEXT; a spelling that already IS the canonical text of a safe integer
+// (`"7"`, `"-12"`) converts to a number whose text is the same string, so the
+// gate and the read side agree and nothing is refused. Anything else JS reads
+// as a finite number is refused — a real change of representation (`"007"`,
+// `"7.0"`, `" 7"`, `"-0"`) as well as a spelling SQLite would have kept
+// (`"0x10"`), over-refusing rather than admitting one it converts.
+function storesAsADifferentNumber(value: string): boolean {
   const trimmed = value.trim();
-  return trimmed !== "" && Number.isFinite(Number(trimmed));
+  if (trimmed === "" || !Number.isFinite(Number(trimmed))) return false;
+  const n = Number(value);
+  return !(Number.isSafeInteger(n) && String(n) === value);
 }
 
 /**
@@ -60,24 +65,40 @@ function storesAsANumber(value: string): boolean {
  * evaluation reads what was stored, so a value the column converts on the way
  * in gives the two sides different text — and the check that rides on the
  * gate's label, no-laundering, is the one the server cannot redo: it is the
- * only place the inputs' own labels are known. A string bound to a numeric
- * column is the case that converts; a number bound to a TEXT column renders
- * the same text the evaluator would show it, and no other pairing converts.
+ * only place the inputs' own labels are known. Two bindings convert: a string
+ * a numeric column stores as a number of another text, and a JS number too
+ * large to name one INTEGER exactly, which the driver binds as a double and
+ * SQLite may store wrapped — the commit-time read-back then renders the
+ * wrapped digits and accepts what the evaluator refuses here. A number bound
+ * to a TEXT column renders the same text the evaluator would show it, and no
+ * other pairing converts. (A `Cell` bound to a rule input never reaches the
+ * store: the encoder admits a cell into a `_cf_link` column only, and the
+ * evaluator refuses the object before that.)
  */
 function boundValueMismatch(
   column: string,
   value: unknown,
   sqlType: unknown,
 ): string | undefined {
-  if (typeof value !== "string" || !storesAsANumber(value)) return undefined;
+  if (
+    typeof value === "number" && Number.isInteger(value) &&
+    !Number.isSafeInteger(value)
+  ) {
+    return `a whole number too large to name one SQLite INTEGER exactly is ` +
+      `bound to rule input "${column}" — the store may wrap it, and the ` +
+      "label would be derived from another row's digits; bind a bigint";
+  }
+  if (typeof value !== "string" || !storesAsADifferentNumber(value)) {
+    return undefined;
+  }
   const affinity = sqlAffinity(typeof sqlType === "string" ? sqlType : "");
   if (affinity !== "integer" && affinity !== "real" && affinity !== "numeric") {
     return undefined;
   }
   return `a number written as text is bound to rule input "${column}", ` +
     `which has ${affinity.toUpperCase()} affinity and stores it as a ` +
-    "number — the rule would be evaluated over text the row will not hold; " +
-    "bind the number";
+    "number of another text — the rule would be evaluated over text the " +
+    "row will not hold; bind the number";
 }
 
 /** One written row's computed label — recorded as the write's CFC policy

--- a/packages/runner/src/builtins/sqlite/row-label-write.ts
+++ b/packages/runner/src/builtins/sqlite/row-label-write.ts
@@ -28,6 +28,7 @@ import {
   ruleInputFields,
   validateRowLabelSpec,
 } from "@commonfabric/memory/sqlite/row-label";
+import { sqlAffinity } from "@commonfabric/memory/sqlite/schema";
 import {
   blankWriteSql,
   parseUpdateSetColumns,
@@ -41,6 +42,43 @@ import {
 
 import type { CfcConfClause } from "../../cfc/clause.ts";
 import { cfcObservationFitsCeiling } from "../../cfc/observation.ts";
+
+// Whether a numeric-affinity column would convert this bound string on the way
+// in. SQLite converts text that is a well-formed integer or real literal and
+// leaves everything else as TEXT, so this asks the same question one step more
+// broadly: anything JS reads as a finite number counts, which over-refuses a
+// spelling SQLite would have kept (`0x10`) rather than admitting one it
+// converts.
+function storesAsANumber(value: string): boolean {
+  const trimmed = value.trim();
+  return trimmed !== "" && Number.isFinite(Number(trimmed));
+}
+
+/**
+ * Why a bound value cannot stand in for the stored one, or undefined when it
+ * can. The gate evaluates the rule over BOUND values while every other
+ * evaluation reads what was stored, so a value the column converts on the way
+ * in gives the two sides different text — and the check that rides on the
+ * gate's label, no-laundering, is the one the server cannot redo: it is the
+ * only place the inputs' own labels are known. A string bound to a numeric
+ * column is the case that converts; a number bound to a TEXT column renders
+ * the same text the evaluator would show it, and no other pairing converts.
+ */
+function boundValueMismatch(
+  column: string,
+  value: unknown,
+  sqlType: unknown,
+): string | undefined {
+  if (typeof value !== "string" || !storesAsANumber(value)) return undefined;
+  const affinity = sqlAffinity(typeof sqlType === "string" ? sqlType : "");
+  if (affinity !== "integer" && affinity !== "real" && affinity !== "numeric") {
+    return undefined;
+  }
+  return `a number written as text is bound to rule input "${column}", ` +
+    `which has ${affinity.toUpperCase()} affinity and stores it as a ` +
+    "number — the rule would be evaluated over text the row will not hold; " +
+    "bind the number";
+}
 
 /** One written row's computed label — recorded as the write's CFC policy
  *  input (sink-request) before the commit. */
@@ -119,9 +157,9 @@ export function checkSqliteRowLabelWrite(
   if (!tableDeclaresRowLabel(declared)) return {}; // rule-less target table
 
   const spec = (declared as { rowLabel: RowLabelSpec }).rowLabel;
-  const columnNames = Object.keys(
-    (declared as { properties?: Record<string, unknown> }).properties ?? {},
-  );
+  const properties =
+    (declared as { properties?: Record<string, unknown> }).properties ?? {};
+  const columnNames = Object.keys(properties);
   const invalid = validateRowLabelSpec(spec, columnNames);
   if (invalid) {
     return {
@@ -269,6 +307,17 @@ export function checkSqliteRowLabelWrite(
         const field = inputFields.find(
           (f) => f.toLowerCase() === col.toLowerCase(),
         )!;
+        const mismatch = boundValueMismatch(
+          field,
+          value,
+          (properties[field] as { sqlType?: unknown } | undefined)?.sqlType,
+        );
+        if (mismatch) {
+          return {
+            error: `sqlite: the INSERT into rule-bearing table ` +
+              `"${declaredKey}" (row ${r}) cannot be evaluated — ${mismatch}`,
+          };
+        }
         rowValues[field] = value;
       }
     }

--- a/packages/runner/test/sqlite-row-label-read.test.ts
+++ b/packages/runner/test/sqlite-row-label-read.test.ts
@@ -454,6 +454,41 @@ describe("computeRowLabelRead — per-row labels from origins", () => {
     });
     expectError(res, "from");
   });
+
+  it("gates a row on an INTEGER column — the per-mailbox facet shape", () => {
+    // The read side hands the evaluator whatever the driver returned, and for
+    // the column a mailbox table keys its rows by that is a number. Each
+    // mailbox's rows come back labeled for that mailbox alone.
+    const tables = {
+      messages: table(
+        { id: "integer", source_id: "integer", body: "text" },
+        (f) => ({
+          confidentiality: all(
+            whenMatches(f.source_id, /^7$/, constant("did:mailbox:seven")),
+            whenMatches(f.source_id, /^8$/, constant("did:mailbox:eight")),
+            dbOwner(),
+          ),
+        }),
+      ),
+    };
+    const res = expectOk(computeRowLabelRead({
+      tables,
+      columns: [
+        col("id", "messages", "id"),
+        col("source_id", "messages", "source_id"),
+        col("body", "messages", "body"),
+      ],
+      rows: [
+        { id: 1, source_id: 7, body: "hi" },
+        { id: 2, source_id: 8, body: "yo" },
+      ],
+      owner: OWNER,
+    }));
+    assertEquals(res.labels, [
+      { confidentiality: ["did:mailbox:seven", OWNER] },
+      { confidentiality: ["did:mailbox:eight", OWNER] },
+    ]);
+  });
 });
 
 describe("computeRowLabelRead — output ceiling + onExceed", () => {

--- a/packages/runner/test/sqlite-row-label-write.test.ts
+++ b/packages/runner/test/sqlite-row-label-write.test.ts
@@ -6,7 +6,7 @@
 // follow-up that lifts this).
 // Spec: docs/specs/sqlite-builtin/06-cfc.md ("Write — the runner gate").
 
-import { assert, assertEquals } from "@std/assert";
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
 import { describe, it } from "@std/testing/bdd";
 
 import {
@@ -129,9 +129,67 @@ describe("checkSqliteRowLabelWrite — the value the column will store", () => {
     assertEquals(res.policies?.[0].label.confidentiality, [OWNER]);
   });
 
-  it("leaves a TEXT column alone", () => {
-    // TEXT affinity renders a bound number the same way the evaluator does,
-    // so there is nothing for the two sides to disagree about.
+  it("binds the canonical text of an integer to an INTEGER column: same text either side", () => {
+    // "7" stored under INTEGER affinity is 7, whose text is "7" again, so the
+    // gate and the read side agree and nothing is refused.
+    const res = expectOk(checkSqliteRowLabelWrite({
+      sql: "INSERT INTO mailboxes (source_id, note) VALUES (?, ?)",
+      params: ["7", "n"],
+      tables,
+      owner: OWNER,
+      confidentialityOf: unlabeled,
+    }));
+    assertEquals(res.policies?.[0].label.confidentiality, [
+      "did:mailbox:seven",
+      OWNER,
+    ]);
+  });
+
+  it("refuses a spelling the column would store as another text", () => {
+    for (const bound of ["007", "7.0", " 7", "-0", "7e0"]) {
+      const res = checkSqliteRowLabelWrite({
+        sql: "INSERT INTO mailboxes (source_id, note) VALUES (?, ?)",
+        params: [bound, "n"],
+        tables,
+        owner: OWNER,
+        confidentialityOf: unlabeled,
+      });
+      assert("error" in res, `${JSON.stringify(bound)} was admitted`);
+      assertStringIncludes(res.error, "another text");
+    }
+  });
+
+  it("refuses a whole number too large to name one INTEGER exactly", () => {
+    // Bound as a double, stored possibly wrapped; the commit read-back would
+    // render the wrapped digits and accept what the evaluator refuses.
+    const res = checkSqliteRowLabelWrite({
+      sql: "INSERT INTO mailboxes (source_id, note) VALUES (?, ?)",
+      params: [2 ** 53 + 2, "n"],
+      tables,
+      owner: OWNER,
+      confidentialityOf: unlabeled,
+    });
+    assert("error" in res);
+    assertStringIncludes(res.error, "bind a bigint");
+  });
+
+  it("refuses an object (a Cell, say) bound to a rule input before any conversion", () => {
+    const res = checkSqliteRowLabelWrite({
+      sql: "INSERT INTO mailboxes (source_id, note) VALUES (?, ?)",
+      params: [{ get: () => "7" }, "n"],
+      tables,
+      owner: OWNER,
+      confidentialityOf: unlabeled,
+    });
+    assert("error" in res);
+    assertStringIncludes(res.error, "an object");
+  });
+
+  it("a number bound to a TEXT rule input renders the same text on both sides", () => {
+    // TEXT affinity keeps a bound number as its text, which is what the
+    // evaluator renders for it too; nothing to refuse. (The `note` column is
+    // not a rule input, so the gate never inspects it — this test binds the
+    // number where the rule reads.)
     const res = expectOk(checkSqliteRowLabelWrite({
       sql: "INSERT INTO mailboxes (source_id, note) VALUES (?, ?)",
       params: [7, 7],

--- a/packages/runner/test/sqlite-row-label-write.test.ts
+++ b/packages/runner/test/sqlite-row-label-write.test.ts
@@ -48,6 +48,18 @@ const tables = {
     }),
   ),
   notes: table({ id: "integer primary key", body: "text" }),
+  // A mailbox-keyed table, for what a numeric-affinity column does to a bound
+  // value on the way in.
+  mailboxes: table(
+    { id: "integer primary key", source_id: "integer", note: "text" },
+    (f) => ({
+      confidentiality: all(
+        whenMatches(f.source_id, /^007$/, constant("did:mailbox:007")),
+        whenMatches(f.source_id, /^7$/, constant("did:mailbox:seven")),
+        dbOwner(),
+      ),
+    }),
+  ),
 };
 
 const unlabeled = (_v: unknown): readonly unknown[] => [];
@@ -69,6 +81,70 @@ function expectOk(
   if ("error" in res) throw new Error(`unexpected error: ${res.error}`);
   return res;
 }
+
+describe("checkSqliteRowLabelWrite — the value the column will store", () => {
+  it("refuses a numeric string bound to a numeric-affinity rule input", () => {
+    // The gate reads the BOUND value and the store re-derives from the
+    // STORED one. INTEGER affinity turns "007" into 7, so the gate would
+    // compute [did:mailbox:007, owner] for a row that reads back as
+    // [did:mailbox:seven, owner] — and the no-laundering check, the one
+    // thing the server cannot redo, would have run against a label the row
+    // never carries.
+    expectError(
+      checkSqliteRowLabelWrite({
+        sql: "INSERT INTO mailboxes (source_id) VALUES (?)",
+        params: ["007"],
+        tables,
+        owner: OWNER,
+        confidentialityOf: unlabeled,
+      }),
+      "source_id",
+    );
+  });
+
+  it("takes the number itself", () => {
+    const res = expectOk(checkSqliteRowLabelWrite({
+      sql: "INSERT INTO mailboxes (source_id) VALUES (?)",
+      params: [7],
+      tables,
+      owner: OWNER,
+      confidentialityOf: unlabeled,
+    }));
+    assertEquals(res.policies?.[0].label.confidentiality, [
+      "did:mailbox:seven",
+      OWNER,
+    ]);
+  });
+
+  it("takes a string the column will store as it stands", () => {
+    // Affinity only converts text that is a well-formed number, so "later"
+    // reaches the row unchanged and the gate reads what the store will.
+    const res = expectOk(checkSqliteRowLabelWrite({
+      sql: "INSERT INTO mailboxes (source_id) VALUES (?)",
+      params: ["later"],
+      tables,
+      owner: OWNER,
+      confidentialityOf: unlabeled,
+    }));
+    assertEquals(res.policies?.[0].label.confidentiality, [OWNER]);
+  });
+
+  it("leaves a TEXT column alone", () => {
+    // TEXT affinity renders a bound number the same way the evaluator does,
+    // so there is nothing for the two sides to disagree about.
+    const res = expectOk(checkSqliteRowLabelWrite({
+      sql: "INSERT INTO mailboxes (source_id, note) VALUES (?, ?)",
+      params: [7, 7],
+      tables,
+      owner: OWNER,
+      confidentialityOf: unlabeled,
+    }));
+    assertEquals(res.policies?.[0].label.confidentiality, [
+      "did:mailbox:seven",
+      OWNER,
+    ]);
+  });
+});
 
 describe("checkSqliteRowLabelWrite — INSERT evaluates the rule", () => {
   it("computes the prospective row label from the bound values", () => {


### PR DESCRIPTION
## Why

A row-label rule gates on stored columns, and the column a real table keys its
rows by is an INTEGER. msgvault keys every mailbox by `source_id`, so the
per-mailbox facet rule an author reaches for is
`whenMatches(f.source_id, /^7$/, …)` — and the evaluator refused it with
"field is number, not a string", on every read, forever. Nothing about the
label model wanted that; the number simply had no text. Loom's consumer works
around it today with one facet per handle plus a refusal whenever two mailboxes
disagree (loom PR #5450, `docs/development/projects/connector-cfc-labels/`),
which is a data model bent around a missing conversion.

A whole number now shows the regex its decimal digits — the digits SQLite
shows for that INTEGER, and the ones an operator reads off the row. One value
has one text, so the write gate, the server commit, and read re-derivation
derive one label from one row.

**Giving a number a text turned out to be the smaller half of the work.** An
adversarial review of the first four commits found that the digits were not
the stored ones, and the last five commits are what makes them so. The
findings, and what each cost:

**The driver hands over the low 32 bits of an INTEGER.** `@db/sqlite` reads an
INTEGER column through `sqlite3_column_int` unless the connection sets
`int64`, and nothing here set it. A stored `source_id` of 4294967303 arrives
as 7 — so the new gate admitted a row from another mailbox to mailbox seven's
facet; an id past 2^53 arrives as 1 and mints a principal for it; an
epoch-millisecond timestamp arrives negative, so a gate on it never fires and
its clause silently drops. The 2^53 boundary this PR first reasoned from
describes a mode that is not in use: the real one is 2^31, and the failure is
a wrapped SAFE integer admitted rather than an unsafe one refused. The
evaluator cannot tell 7 from a wrapped 7, so the fix is where the value is
read, not in the evaluator. Before this branch a number in a rule input
refused the read, so no label was ever derived from a truncated value; that
property is restored, by making the value whole rather than by refusing it.

**The write gate evaluated a value the column would not store.** A rule gating
`/^007$/` computed `[G, owner]` from the bound string `"007"` for a row that
INTEGER affinity stores as `7` and re-derives as `[owner]` — and a bound value
carrying `G` passed the no-laundering check against a label the row never
carries. That check is the one the server cannot redo, and the same INSERT was
rolled back before this branch.

**A rule on a REAL or BLOB column can never be written correctly**, which the
PR previously documented and left to the reader.

## What changed

- `regexInputText()` in `packages/memory/v2/sqlite/row-label.ts` is the single
  place deciding what a regex may read; `evalMatch` and `evalTest` both go
  through it. Coerced: TEXT; a JS number that is a safe integer, by its digits;
  a bigint inside int64. Refused, as before: a fractional REAL, an infinity, a
  number past 2^53, an out-of-range bigint, NaN, a boolean, a BLOB. NULL and
  the empty string keep their "no match" meaning; a zero is a value.
- **Labeled reads run on an `int64` connection.** The read pool keys
  connections by integer mode as well as path, and `queryWithOrigins` — issued
  only for a db that declares `ifc` or a row rule — takes the `int64` one, so a
  value past 2^53 arrives as a `bigint` (a `FabricValue` the JSON codec
  carries, and one the evaluator renders exactly). Ordinary `query()` reads
  keep the connection and the values they have always had: widening those
  changes every consumer's data and belongs to its own change. The boundary is
  every CFC-labeled db, not only rule-bearing ones, because that is where the
  provenance path already forks.
- **Commit evaluation renders instead**, since the engine connection serves
  everything and cannot flip mode for this: the affected rowid as text (the
  read-back now addresses the row that was written, rather than whichever row
  shares its low 32 bits — a collision that judged a violating write by a valid
  row's values), and a rule input as text only when its storage class is
  INTEGER. A rendered REAL would reach the evaluator as a string and be gated
  on, where the read side refuses it.
- **The write gate refuses a rule-input string a numeric-affinity column would
  store as a number**, naming the column and the affinity. No other pairing
  converts: a number bound to a TEXT column is stored as the text the evaluator
  already renders it to.
- **A rule input declared REAL or BLOB is refused at declaration** — by
  `table()`, and again wherever a wire-supplied `db.tables` is re-validated.
  The cost, stated plainly: a REAL- or BLOB-declared column that in fact holds
  text can no longer carry a rule. Declare such a column TEXT.
- A REAL still refuses, and the argument is unchanged: SQLite renders one from
  its own decoded digits, and the builds behind this driver disagree about the
  last digit of `-0.009598882198146955` (`…696` against the correctly rounded
  `…695`). The split follows the architecture, whose long double the decoder
  uses where it is wider than a double — Cubic's objection was raised from the
  other side of it. A gate is an anchored comparison, so a text that can only
  be nearly reproduced is a gate that silently misses rows.
- `docs/specs/sqlite-builtin/06-cfc.md` says all of the above.

One divergence from `CAST(col AS TEXT)` survives, and it is now narrow: a
whole REAL in a column with no affinity arrives as a JS number carrying no
storage class, and shows `7` where SQLite shows `7.0`.


**A consequence for `ifc`-only dbs (reviewer note).** `queryWithOrigins` is the labeled-read path for a db that declares per-column `ifc` with no row rule too, so those consumers now receive the correct value for an INTEGER in [2^31, 2^53) and a `bigint` past 2^53 where the 32-bit read used to hand them a wrapped number. Better data, and a value-type change at the top of the range; the plain `query()` path is untouched. The server serializes a `bigint` through the fabric codec (`{"/BigInt@1": …}`), round-tripped by the adversarial pass.

## Test plan

Every behavior change was watched red first.

- `v2-sqlite-row-label-number-text.test.ts` (33 steps) opens a real database,
  because the claim under test is the text SQLite would show. With the
  coercion absent, 16 steps failed and the 8 fail-closed ones passed.
- `v2-sqlite-row-label-integer-roundtrip.test.ts` stores 7, 4294967303 and
  9007199254740993 in an INTEGER column and reads them back through the pooled
  connection a labeled query really uses. Red first: row two came back labeled
  for mailbox seven, row three minted `did:mailbox:1`, and the timestamp gate
  fired for no row at all.
- Two commit-eval cases, red first: a violating row whose `source_id`
  truncates onto the admitted id, and one whose ROWID truncates onto a stored
  valid row's.
- Four write-gate cases, the `"007"` laundering shape red first.
- Extractor-side refusals and the zero case, which close two mutations that
  survived every suite: `match()` rendering with `String()` (which mints
  principals from a REAL's digits and a BLOB's bytes) and `match()` treating 0
  as absent.
- Three declaration cases, red first, plus the same spec re-validated against a
  `double precision` column map.
- Mutation checks: `Number.isSafeInteger` → `Number.isInteger` reddens only the
  too-large test; removing the number branch reddens the read-path test;
  both extractor mutations now redden.

Lanes run locally, all green: `packages/memory` (602 passed), `packages/runner`
(1386 passed) plus its CFC integration tests, `packages/cf-harness`
`test/cfc-properties/`, root `deno task check`, `deno task check-docs`,
`deno lint`, `deno fmt --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011nwVm6QJd7tDeXtT5zAqvT




Coverage ratchet: the runner group rose by two uncovered lines against a 5,441-line baseline (the write gate's new refusal branches); accepted per the ratchet's own mechanism.

ACCEPT_COVERAGE_DEBT: packages/runner +2 lines
