### PR TITLE
cf-harness: a per-run read ceiling the fabric session applies to every db.query

### DIFF
--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -1269,22 +1269,33 @@ summary prints it beside the harness's own `cfcMode`.
 
 The session's runtime can also run under a read ceiling: a flat list of
 confidentiality clauses (the same shape a pattern's `db.query` takes as
-`maxConfidentiality`) that every `db.query` the run issues is bounded by,
-whatever the pattern wrote. A query declaring no ceiling reads under the run's;
-one declaring its own reads under the meet of the two, so a pattern cannot widen
-its run's ceiling from inside. The ceiling comes from
-`--max-confidentiality
-<json>` on the command line, from
+`maxConfidentiality`) that bounds every `db.query` the run issues. The ceiling
+governs only a query whose result is declared per session — `PerSession<>` on
+the result type, the `scope: "session"` query option, `.asScope("session")`, or
+a session-scoped db — and the runtime refuses any other query outright under a
+ceiling, before it is staged, rather than reading it unbounded: a result shared
+by every runtime on the space cannot hold one runtime's filtered rows. So a
+pattern authored for a bounded run declares its query results per session; a
+plain `db.query` fails with an error naming the fix. A session-scoped query
+declaring no ceiling reads under the run's; one declaring its own reads under
+the meet of the two, so a pattern cannot widen its run's ceiling from inside.
+The ceiling comes from the `--max-confidentiality` flag (a JSON array), from
 `cfc.maxConfidentiality` in the run manifest (with `cfc.onExceed`, `fail` or
-`skip`, as the default for a query that says nothing), or from both, met. An
-empty list is refused rather than read as no ceiling, a malformed one refuses
-the manifest rather than being dropped, and either source without a fabric
-session is refused, since a ceiling with nothing bounding reads would read as
-working all run. Absent both, the session reads unbounded — the owner's whole
-view. The effective ceiling is recorded in `fabricSessionCfc` as
-`readMaxConfidentiality`, so a resume under another (or none) is refused like
-any other moved dial; the manifest's declaration is projected into the policy
-snapshot and every invocation context for the audit.
+`skip`, as the default for a query that says nothing), or from both, met — and
+`onExceed` meets toward `fail`, so neither source can turn the other's refusal
+into a release. An empty list is refused rather than read as no ceiling, a
+malformed one refuses the manifest rather than being dropped, and either source
+without a fabric session is refused, since a ceiling with nothing bounding reads
+would read as working all run. Absent both, the session reads unbounded — the
+owner's whole view. The effective ceiling, with its source, is recorded in
+`fabricSessionCfc` as `readMaxConfidentiality`, so a resume under another (or
+none) is refused like any other moved dial, and a resume handed a manifest
+declaring another ceiling is refused too; the session factory refuses a session
+whose runtime is not bounded as configured; the manifest's declaration is
+projected into the policy snapshot and every invocation context for the audit;
+and the operator summary prints the ceiling beside the other session dials. A
+delegated child runs on its parent's session and records the parent's ceiling as
+its own.
 
 The tool takes `sourceText` (inline pattern source, at most 256 KiB — an
 over-cap source is a structured tool error), an optional `inputs` object, and an

--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -1267,6 +1267,25 @@ recorded as `fabricSessionCfc` in `run-state.json` and the run report (with the
 selected bundle, when there is one, as its `posture` field), and the operator
 summary prints it beside the harness's own `cfcMode`.
 
+The session's runtime can also run under a read ceiling: a flat list of
+confidentiality clauses (the same shape a pattern's `db.query` takes as
+`maxConfidentiality`) that every `db.query` the run issues is bounded by,
+whatever the pattern wrote. A query declaring no ceiling reads under the run's;
+one declaring its own reads under the meet of the two, so a pattern cannot widen
+its run's ceiling from inside. The ceiling comes from
+`--max-confidentiality
+<json>` on the command line, from
+`cfc.maxConfidentiality` in the run manifest (with `cfc.onExceed`, `fail` or
+`skip`, as the default for a query that says nothing), or from both, met. An
+empty list is refused rather than read as no ceiling, a malformed one refuses
+the manifest rather than being dropped, and either source without a fabric
+session is refused, since a ceiling with nothing bounding reads would read as
+working all run. Absent both, the session reads unbounded — the owner's whole
+view. The effective ceiling is recorded in `fabricSessionCfc` as
+`readMaxConfidentiality`, so a resume under another (or none) is refused like
+any other moved dial; the manifest's declaration is projected into the policy
+snapshot and every invocation context for the audit.
+
 The tool takes `sourceText` (inline pattern source, at most 256 KiB — an
 over-cap source is a structured tool error), an optional `inputs` object, and an
 optional `resultSchema`. An `inputs` string value that is a whole-string

--- a/packages/cf-harness/docs/CURRENT_STATE.md
+++ b/packages/cf-harness/docs/CURRENT_STATE.md
@@ -230,13 +230,16 @@ The current package provides:
   state and the run report, and printed in the operator summary — the whole
   posture record with it, which a delegated child carries from its parent
   stamped `inherited` because it runs on that parent's session; the session
-  runtime can further run under a read ceiling —
-  `--max-confidentiality
-  <json>`, or `cfc.maxConfidentiality` (with
-  `cfc.onExceed`) in the run manifest, met when both are given — that every
-  `db.query` the run issues is bounded by, a query's own declaration met with it
-  rather than replacing it, refused without a fabric session and recorded as
-  `readMaxConfidentiality` in `fabricSessionCfc`;
+  runtime can further run under a read ceiling — the `--max-confidentiality`
+  flag, or `cfc.maxConfidentiality` (with `cfc.onExceed`) in the run manifest,
+  met when both are given — that bounds every `db.query` the run issues, a
+  query's own declaration met with it rather than replacing it; the ceiling
+  governs only query results declared per session (`PerSession<>`,
+  `scope: "session"`, `.asScope("session")`, or a session-scoped db) and the
+  runtime refuses any other query under it, so a pattern authored for a bounded
+  run declares its results per session; it is refused without a fabric session,
+  recorded with its source as `readMaxConfidentiality` in `fabricSessionCfc`,
+  printed in the operator summary, and inherited unchanged by a delegated child;
 - an opt-in pattern index (`--pattern-index-url`, or its
   `CF_HARNESS_PATTERN_INDEX_URL` environment fallback), which needs the fabric
   session configuration: index requests are signed with the session identity

--- a/packages/cf-harness/docs/CURRENT_STATE.md
+++ b/packages/cf-harness/docs/CURRENT_STATE.md
@@ -229,7 +229,14 @@ The current package provides:
   bundle, or the default supplied it) is recorded as `fabricSessionCfc` in run
   state and the run report, and printed in the operator summary — the whole
   posture record with it, which a delegated child carries from its parent
-  stamped `inherited` because it runs on that parent's session;
+  stamped `inherited` because it runs on that parent's session; the session
+  runtime can further run under a read ceiling —
+  `--max-confidentiality
+  <json>`, or `cfc.maxConfidentiality` (with
+  `cfc.onExceed`) in the run manifest, met when both are given — that every
+  `db.query` the run issues is bounded by, a query's own declaration met with it
+  rather than replacing it, refused without a fabric session and recorded as
+  `readMaxConfidentiality` in `fabricSessionCfc`;
 - an opt-in pattern index (`--pattern-index-url`, or its
   `CF_HARNESS_PATTERN_INDEX_URL` environment fallback), which needs the fabric
   session configuration: index requests are signed with the session identity

--- a/packages/cf-harness/docs/IMPLEMENTATION_PROFILE.md
+++ b/packages/cf-harness/docs/IMPLEMENTATION_PROFILE.md
@@ -325,8 +325,8 @@ in-flight external side effect.
    `cfcReadMaxConfidentiality` — is applied by the runner's `db.query` builtin
    at the query, not at the cell: a query whose result is session-scoped
    (`PerSession<>`, `scope: "session"`, `.asScope("session")`, or a
-   session-scoped db) reads under the meet of its own ceiling and the run's;
-   a query with a space- or user-scoped result is refused before it is staged,
+   session-scoped db) reads under the meet of its own ceiling and the run's; a
+   query with a space- or user-scoped result is refused before it is staged,
    because that result is one cell every runtime on the space resolves and the
    run's runtime cannot narrow it for itself. The refusal reaches the runtime's
    error handlers, so an authored pattern that declares no scope fails on its

--- a/packages/cf-harness/docs/IMPLEMENTATION_PROFILE.md
+++ b/packages/cf-harness/docs/IMPLEMENTATION_PROFILE.md
@@ -319,6 +319,26 @@ in-flight external side effect.
    check consumes, and handle resolution into a child input is rejected when it
    exceeds that ceiling.
 
+9. **The run's read ceiling gates session-scoped query results only.** The
+   ceiling a run carries — `--max-confidentiality`, or `cfc.maxConfidentiality`
+   in the run manifest, met into the fabric session's runtime as
+   `cfcReadMaxConfidentiality` — is applied by the runner's `db.query` builtin
+   at the query, not at the cell: a query whose result is session-scoped
+   (`PerSession<>`, `scope: "session"`, `.asScope("session")`, or a
+   session-scoped db) reads under the meet of its own ceiling and the run's;
+   a query with a space- or user-scoped result is refused before it is staged,
+   because that result is one cell every runtime on the space resolves and the
+   run's runtime cannot narrow it for itself. The refusal reaches the runtime's
+   error handlers, so an authored pattern that declares no scope fails on its
+   first query rather than reading under a wider view. What the option does not
+   reach is a shared cell another runtime already filled: that is protected by
+   the cell's own label under the commit-boundary gates, not by the run's
+   ceiling. Owner: `cf-harness` and the CFC runtime. Retirement: the ceiling is
+   carried into the runtime's cell read path (a labeled cell that does not fit
+   reads as withheld), and the served-execution arm carries a per-session
+   ceiling to the serving runtime, at which point the scope requirement and the
+   OFF-arm-only limit both retire.
+
 ## Test evidence
 
 - `deno task test` — package contract suite.

--- a/packages/cf-harness/docs/system-map/README.md
+++ b/packages/cf-harness/docs/system-map/README.md
@@ -105,6 +105,18 @@ block `file:` navigation from automation:
 cd packages/cf-harness/docs/system-map && python3 -m http.server 8765 --bind 127.0.0.1
 ```
 
+## Since the snapshot
+
+The map predates the run read ceiling (`--max-confidentiality` /
+`cfc.maxConfidentiality`, [CURRENT_STATE.md](../CURRENT_STATE.md) "Fabric
+session" and deviation 9 in
+[IMPLEMENTATION_PROFILE.md](../IMPLEMENTATION_PROFILE.md)). It still draws the
+harness's fixed answer ceiling as the only read boundary. The ceiling a run
+carries is enforced by the runner's `db.query` builtin, on session-scoped
+query results only, with a space-scoped query refused; a shared cell another
+runtime filled is outside it. Redraw that boundary the next time the map is
+regenerated.
+
 ## Relation to the other documents here
 
 The map is a reading aid, not a source of truth. Where it and

--- a/packages/cf-harness/docs/system-map/README.md
+++ b/packages/cf-harness/docs/system-map/README.md
@@ -112,10 +112,9 @@ The map predates the run read ceiling (`--max-confidentiality` /
 session" and deviation 9 in
 [IMPLEMENTATION_PROFILE.md](../IMPLEMENTATION_PROFILE.md)). It still draws the
 harness's fixed answer ceiling as the only read boundary. The ceiling a run
-carries is enforced by the runner's `db.query` builtin, on session-scoped
-query results only, with a space-scoped query refused; a shared cell another
-runtime filled is outside it. Redraw that boundary the next time the map is
-regenerated.
+carries is enforced by the runner's `db.query` builtin, on session-scoped query
+results only, with a space-scoped query refused; a shared cell another runtime
+filled is outside it. Redraw that boundary the next time the map is regenerated.
 
 ## Relation to the other documents here
 

--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -10,6 +10,10 @@ import {
 import { normalize as normalizeSandboxPath } from "@std/path/posix";
 import type { JSONSchema } from "@commonfabric/api";
 import {
+  type CfcConfClause,
+  normalizeCfcReadCeiling,
+} from "@commonfabric/runner/cfc";
+import {
   DEFAULT_GATEWAY_BASE_URL,
   type HarnessFabricSessionConfig,
   type HarnessGatewayAuthMode,
@@ -204,6 +208,7 @@ const CLI_STRING_FLAGS = [
   "fabric-cfc-enforcement-mode",
   "fabric-cfc-flow-labels",
   "fabric-cfc-posture",
+  "max-confidentiality",
   "space-db",
   "pattern-index-url",
   "host-mount",
@@ -548,6 +553,10 @@ Options:
                                 into the named CFC posture bundle (every staged
                                 enforcement dial on); the two dials above still
                                 apply over the bundle
+  --max-confidentiality <json>  Read ceiling for the fabric session's runtime: a
+                                JSON array of confidentiality clauses every
+                                db.query the run issues is bounded by, met with
+                                any the run manifest declares (never widened)
   --space-db <path>             The space database the run's per-cell label
                                 snapshot reads. Give it when this run's working
                                 directory shares no ancestor with the server's,
@@ -1702,6 +1711,26 @@ export const parseCfHarnessCliArgs = async (
       `--fabric-cfc-posture must be max-enforcement: ${fabricCfcPosture}`,
     );
   }
+  const rawMaxConfidentiality = typeof args["max-confidentiality"] === "string"
+    ? args["max-confidentiality"].trim()
+    : undefined;
+  let maxConfidentiality: CfcConfClause[] | undefined;
+  if (rawMaxConfidentiality !== undefined) {
+    let parsedCeiling: unknown;
+    try {
+      parsedCeiling = JSON.parse(rawMaxConfidentiality);
+    } catch (error) {
+      throw new Error(
+        `--max-confidentiality must be JSON: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+    maxConfidentiality = normalizeCfcReadCeiling(
+      parsedCeiling,
+      "--max-confidentiality",
+    );
+  }
   let fabricSession: HarnessFabricSessionConfig | undefined;
   if (
     fabricApiUrl !== undefined || fabricIdentity !== undefined ||
@@ -1737,6 +1766,9 @@ export const parseCfHarnessCliArgs = async (
       ...(fabricCfcPosture !== undefined
         ? { cfcPosture: fabricCfcPosture }
         : {}),
+      ...(maxConfidentiality !== undefined
+        ? { cfcReadMaxConfidentiality: maxConfidentiality }
+        : {}),
     };
   } else if (
     fabricCfcEnforcementMode !== undefined ||
@@ -1744,6 +1776,12 @@ export const parseCfHarnessCliArgs = async (
   ) {
     throw new Error(
       "--fabric-cfc-enforcement-mode, --fabric-cfc-flow-labels, and --fabric-cfc-posture configure the fabric session's runtime and need --fabric-api-url, --fabric-identity, and --fabric-space",
+    );
+  } else if (maxConfidentiality !== undefined) {
+    // A ceiling with no session bounds nothing, and one accepted here would
+    // read as working all run.
+    throw new Error(
+      "--max-confidentiality bounds the fabric session's reads and needs --fabric-api-url, --fabric-identity, and --fabric-space",
     );
   }
   const rawSpaceDb = typeof args["space-db"] === "string"

--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -2659,6 +2659,12 @@ export const formatCfHarnessCliResult = (
     lines.push(
       `fabricSessionCfc: ${posture.enforcementMode} (${posture.enforcementModeSource}), flow-labels ${posture.flowLabels} (${posture.flowLabelsSource})${
         posture.posture !== undefined ? `, posture ${posture.posture}` : ""
+      }${
+        posture.readMaxConfidentiality !== undefined
+          ? `, read-ceiling ${posture.readMaxConfidentiality.length} clause(s) onExceed ${
+            posture.readOnExceed ?? "fail"
+          } (${posture.readMaxConfidentialitySource ?? "unknown"})`
+          : ""
       }`,
     );
     if (posture.record !== undefined) {
@@ -3335,6 +3341,24 @@ export const runCfHarnessCli = async (
         throw new HarnessControlError(
           "provider-mismatch",
           "resume credential owner mismatch: requested owner does not match the recorded run",
+        );
+      }
+      // A manifest handed to a resume must agree with the recorded one on
+      // the read ceiling, as it must on the model and the credential owner:
+      // the recorded manifest is what the run resumes under, and a different
+      // ceiling silently set aside would leave the operator believing the
+      // run reads under the one they passed.
+      if (
+        runManifest !== undefined && recordedRunManifest !== undefined &&
+        (JSON.stringify(runManifest.cfc?.maxConfidentiality) !==
+            JSON.stringify(recordedRunManifest.cfc?.maxConfidentiality) ||
+          runManifest.cfc?.onExceed !== recordedRunManifest.cfc?.onExceed)
+      ) {
+        throw new HarnessControlError(
+          "provider-mismatch",
+          "resume read ceiling mismatch: the requested manifest's " +
+            "cfc.maxConfidentiality or cfc.onExceed does not match the " +
+            "recorded run's",
         );
       }
       const credentialOwnerKey = credentialOwner.ownerKey;

--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -9,10 +9,7 @@ import {
 } from "@std/path";
 import { normalize as normalizeSandboxPath } from "@std/path/posix";
 import type { JSONSchema } from "@commonfabric/api";
-import {
-  type CfcConfClause,
-  normalizeCfcReadCeiling,
-} from "@commonfabric/runner/cfc";
+import type { CfcConfClause } from "@commonfabric/runner/cfc";
 import {
   DEFAULT_GATEWAY_BASE_URL,
   type HarnessFabricSessionConfig,
@@ -53,6 +50,7 @@ import {
   type HarnessRunManifest,
   type LoomLocalHostBinding,
   parseLoomRunManifestJson,
+  readCeilingFromInput,
 } from "./contracts/run-manifest.ts";
 import type { HarnessFetch } from "./contracts/http-fetch.ts";
 import {
@@ -1714,7 +1712,7 @@ export const parseCfHarnessCliArgs = async (
   const rawMaxConfidentiality = typeof args["max-confidentiality"] === "string"
     ? args["max-confidentiality"].trim()
     : undefined;
-  let maxConfidentiality: CfcConfClause[] | undefined;
+  let maxConfidentiality: readonly CfcConfClause[] | undefined;
   if (rawMaxConfidentiality !== undefined) {
     let parsedCeiling: unknown;
     try {
@@ -1726,10 +1724,11 @@ export const parseCfHarnessCliArgs = async (
         }`,
       );
     }
-    maxConfidentiality = normalizeCfcReadCeiling(
+    maxConfidentiality = readCeilingFromInput(
       parsedCeiling,
-      "--max-confidentiality",
-    );
+      undefined,
+      { ceiling: "--max-confidentiality", onExceed: "--max-confidentiality" },
+    ).maxConfidentiality;
   }
   let fabricSession: HarnessFabricSessionConfig | undefined;
   if (

--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -20,6 +20,7 @@ import {
   isHarnessModelProviderId,
   parseCfcEnforcementMode,
   parseHarnessGatewayAuthMode,
+  readCeilingsEqual,
 } from "./config.ts";
 import {
   createHarnessImageAttachment,
@@ -3350,8 +3351,10 @@ export const runCfHarnessCli = async (
       // run reads under the one they passed.
       if (
         runManifest !== undefined && recordedRunManifest !== undefined &&
-        (JSON.stringify(runManifest.cfc?.maxConfidentiality) !==
-            JSON.stringify(recordedRunManifest.cfc?.maxConfidentiality) ||
+        (!readCeilingsEqual(
+          runManifest.cfc?.maxConfidentiality,
+          recordedRunManifest.cfc?.maxConfidentiality,
+        ) ||
           runManifest.cfc?.onExceed !== recordedRunManifest.cfc?.onExceed)
       ) {
         throw new HarnessControlError(

--- a/packages/cf-harness/src/config.ts
+++ b/packages/cf-harness/src/config.ts
@@ -72,6 +72,25 @@ export interface HarnessFabricSessionConfig {
   cfcReadOnExceed?: CfcReadOnExceed;
 }
 
+/** Where a resolved session's read ceiling came from. */
+export type HarnessFabricReadCeilingSource =
+  | "none"
+  | "session"
+  | "run-manifest"
+  | "both";
+
+/**
+ * A session config whose read ceiling has been resolved: the run manifest's
+ * ceiling folded in once, by `resolveFabricSessionConfig`. The source marks
+ * it as resolved, so a config handed onward — a delegating parent's, to the
+ * child that shares its session — is never folded a second time, which
+ * would record a ceiling the runtime does not hold.
+ */
+export interface ResolvedHarnessFabricSessionConfig
+  extends HarnessFabricSessionConfig {
+  readCeilingSource: HarnessFabricReadCeilingSource;
+}
+
 /**
  * Connection settings for the deployed pattern index: the base URL its
  * functions are served under. When present, the run offers `search_patterns`
@@ -155,7 +174,7 @@ interface HarnessCommonConfig {
   artifactRoot?: string;
   cfcEnforcementMode: CfcEnforcementMode;
   cfcEnforcementModeSource: HarnessCfcEnforcementModeSource;
-  fabricSession?: HarnessFabricSessionConfig;
+  fabricSession?: ResolvedHarnessFabricSessionConfig;
   patternIndex?: HarnessPatternIndexConfig;
   skillsSh?: HarnessSkillsShConfig;
   sandbox?: DockerRunscSandboxConfig;
@@ -219,7 +238,9 @@ export interface ResolveHarnessConfigOptions {
    */
   inheritedCfcEnforcementMode?: CfcEnforcementMode;
   cfcEnforcementModeOverride?: string | CfcEnforcementMode;
-  fabricSession?: HarnessFabricSessionConfig;
+  fabricSession?:
+    | HarnessFabricSessionConfig
+    | ResolvedHarnessFabricSessionConfig;
   patternIndex?: HarnessPatternIndexConfig;
   skillsSh?: HarnessSkillsShConfig;
   sandbox?: DockerRunscSandboxConfig;
@@ -403,12 +424,31 @@ export const resolveGatewayAuthMode = (
     "bearer";
 };
 
+const isResolvedFabricSessionConfig = (
+  config: HarnessFabricSessionConfig | ResolvedHarnessFabricSessionConfig,
+): config is ResolvedHarnessFabricSessionConfig =>
+  "readCeilingSource" in config;
+
+/**
+ * The stricter of two `onExceed` modes: `fail` refuses the whole query where
+ * `skip` releases the fact that rows were withheld, so `fail` wins whenever
+ * either side says it. Absent on both sides is absent.
+ */
+const meetReadOnExceed = (
+  a: CfcReadOnExceed | undefined,
+  b: CfcReadOnExceed | undefined,
+): CfcReadOnExceed | undefined =>
+  a === "fail" || b === "fail" ? "fail" : (a ?? b);
+
 /**
  * The fabric session the run executes under, bounded by the run manifest's
  * read ceiling. A ceiling the session config carries and one the manifest
  * carries are met, so a query fits the result only if it fits both: neither
  * the operator's session nor Loom's dispatch can widen what the other
- * declared. The session's own `onExceed` stands over the manifest's.
+ * declared, and `onExceed` meets toward `fail` on the same terms. The fold
+ * happens once: a config already resolved passes through unchanged, so a
+ * child built from its parent's resolved config and the same manifest records
+ * the ceiling its parent's runtime holds.
  *
  * @throws Error when the manifest declares a ceiling and the run has no
  * fabric session to apply it to — a ceiling accepted with nothing bounding
@@ -416,10 +456,22 @@ export const resolveGatewayAuthMode = (
  */
 export const resolveFabricSessionConfig = (
   options: Pick<ResolveHarnessConfigOptions, "fabricSession" | "runManifest">,
-): HarnessFabricSessionConfig | undefined => {
+): ResolvedHarnessFabricSessionConfig | undefined => {
   const manifestCeiling = options.runManifest?.cfc?.maxConfidentiality;
-  if (manifestCeiling === undefined) {
+  if (
+    options.fabricSession !== undefined &&
+    isResolvedFabricSessionConfig(options.fabricSession)
+  ) {
     return options.fabricSession;
+  }
+  if (manifestCeiling === undefined) {
+    return options.fabricSession === undefined ? undefined : {
+      ...options.fabricSession,
+      readCeilingSource:
+        options.fabricSession.cfcReadMaxConfidentiality !== undefined
+          ? "session"
+          : "none",
+    };
   }
   if (options.fabricSession === undefined) {
     throw new Error(
@@ -427,8 +479,10 @@ export const resolveFabricSessionConfig = (
         "fabric session's runtime, and the run has no fabric session",
     );
   }
-  const onExceed = options.fabricSession.cfcReadOnExceed ??
-    options.runManifest?.cfc?.onExceed;
+  const onExceed = meetReadOnExceed(
+    options.fabricSession.cfcReadOnExceed,
+    options.runManifest?.cfc?.onExceed,
+  );
   return {
     ...options.fabricSession,
     cfcReadMaxConfidentiality: meetCfcObservationCeilings(
@@ -436,6 +490,10 @@ export const resolveFabricSessionConfig = (
       manifestCeiling,
     ) as readonly CfcConfClause[],
     ...(onExceed !== undefined ? { cfcReadOnExceed: onExceed } : {}),
+    readCeilingSource:
+      options.fabricSession.cfcReadMaxConfidentiality !== undefined
+        ? "both"
+        : "run-manifest",
   };
 };
 

--- a/packages/cf-harness/src/config.ts
+++ b/packages/cf-harness/src/config.ts
@@ -511,16 +511,19 @@ export const resolveFabricSessionConfig = (
   );
   return {
     ...options.fabricSession,
-    cfcReadMaxConfidentiality: meetCfcObservationCeilings(
+    // Snapshots, not references: the session is built lazily on the first
+    // tool call, and a manifest array mutated in between must not widen
+    // what that session is built under.
+    cfcReadMaxConfidentiality: structuredClone(meetCfcObservationCeilings(
       options.fabricSession.cfcReadMaxConfidentiality,
       manifestCeiling,
-    ) as readonly CfcConfClause[],
+    )) as readonly CfcConfClause[],
     ...(onExceed !== undefined ? { cfcReadOnExceed: onExceed } : {}),
     readCeilingSource:
       options.fabricSession.cfcReadMaxConfidentiality !== undefined
         ? "both"
         : "run-manifest",
-    manifestReadMaxConfidentiality: manifestCeiling,
+    manifestReadMaxConfidentiality: structuredClone(manifestCeiling),
     ...(options.runManifest?.cfc?.onExceed !== undefined
       ? { manifestReadOnExceed: options.runManifest.cfc.onExceed }
       : {}),

--- a/packages/cf-harness/src/config.ts
+++ b/packages/cf-harness/src/config.ts
@@ -1,8 +1,11 @@
 import {
+  type CfcConfClause,
   type CfcEnforcementMode,
   cfcEnforcementStrictness,
   type CfcFlowLabelsMode,
+  type CfcReadOnExceed,
   isCfcEnforcementMode,
+  meetCfcObservationCeilings,
 } from "@commonfabric/runner/cfc";
 import type { CfcPosture } from "@commonfabric/runner";
 import type { HarnessCfcEnforcementModeSource } from "./contracts/cfc-policy-snapshot.ts";
@@ -58,6 +61,15 @@ export interface HarnessFabricSessionConfig {
   cfcEnforcementMode?: HarnessFabricCfcEnforcementMode;
   cfcFlowLabels?: HarnessFabricCfcFlowLabelsMode;
   cfcPosture?: CfcPosture;
+
+  /**
+   * The read ceiling the session's runtime bounds every `sqliteQuery` by
+   * (`RuntimeOptions.cfcReadMaxConfidentiality`). Absent is no ceiling.
+   */
+  cfcReadMaxConfidentiality?: readonly CfcConfClause[];
+
+  /** Its `onExceed` default (`RuntimeOptions.cfcReadOnExceed`). */
+  cfcReadOnExceed?: CfcReadOnExceed;
 }
 
 /**
@@ -391,6 +403,42 @@ export const resolveGatewayAuthMode = (
     "bearer";
 };
 
+/**
+ * The fabric session the run executes under, bounded by the run manifest's
+ * read ceiling. A ceiling the session config carries and one the manifest
+ * carries are met, so a query fits the result only if it fits both: neither
+ * the operator's session nor Loom's dispatch can widen what the other
+ * declared. The session's own `onExceed` stands over the manifest's.
+ *
+ * @throws Error when the manifest declares a ceiling and the run has no
+ * fabric session to apply it to — a ceiling accepted with nothing bounding
+ * reads would read as working while doing nothing.
+ */
+export const resolveFabricSessionConfig = (
+  options: Pick<ResolveHarnessConfigOptions, "fabricSession" | "runManifest">,
+): HarnessFabricSessionConfig | undefined => {
+  const manifestCeiling = options.runManifest?.cfc?.maxConfidentiality;
+  if (manifestCeiling === undefined) {
+    return options.fabricSession;
+  }
+  if (options.fabricSession === undefined) {
+    throw new Error(
+      "run manifest cfc.maxConfidentiality names a read ceiling for the " +
+        "fabric session's runtime, and the run has no fabric session",
+    );
+  }
+  const onExceed = options.fabricSession.cfcReadOnExceed ??
+    options.runManifest?.cfc?.onExceed;
+  return {
+    ...options.fabricSession,
+    cfcReadMaxConfidentiality: meetCfcObservationCeilings(
+      options.fabricSession.cfcReadMaxConfidentiality,
+      manifestCeiling,
+    ) as readonly CfcConfClause[],
+    ...(onExceed !== undefined ? { cfcReadOnExceed: onExceed } : {}),
+  };
+};
+
 export const resolveHarnessConfig = (
   options: ResolveHarnessConfigOptions = {},
 ): ResolvedHarnessConfig => {
@@ -455,6 +503,7 @@ export const resolveHarnessConfig = (
   // relabelling an inherited default as something the operator configured.
   const skillsRootRecord = options.skillsRootRecord ??
     resolveHarnessSkillsRoot(options.skillsRoot);
+  const fabricSession = resolveFabricSessionConfig(options);
   const common: HarnessCommonConfig = {
     ...(options.cwd !== undefined ? { cwd: options.cwd } : {}),
     ...(options.model !== undefined ? { model: options.model } : {}),
@@ -487,9 +536,7 @@ export const resolveHarnessConfig = (
       : {}),
     cfcEnforcementMode: resolveCfcEnforcementMode(options),
     cfcEnforcementModeSource: resolveCfcEnforcementModeSource(options),
-    ...(options.fabricSession !== undefined
-      ? { fabricSession: options.fabricSession }
-      : {}),
+    ...(fabricSession !== undefined ? { fabricSession } : {}),
     ...(options.patternIndex !== undefined
       ? { patternIndex: options.patternIndex }
       : {}),

--- a/packages/cf-harness/src/config.ts
+++ b/packages/cf-harness/src/config.ts
@@ -5,6 +5,7 @@ import {
   type CfcFlowLabelsMode,
   type CfcReadOnExceed,
   isCfcEnforcementMode,
+  clausesEqual,
   meetCfcObservationCeilings,
 } from "@commonfabric/runner/cfc";
 import type { CfcPosture } from "@commonfabric/runner";
@@ -110,6 +111,32 @@ export interface ResolvedHarnessFabricSessionConfig
  * Requests carry the fabric session's identity, so this configuration goes
  * with a fabric session and is refused without one.
  */
+/**
+ * Two read ceilings say the same thing: the same clauses, each compared
+ * with the runner's structural equality, which is insensitive to the order
+ * of an `anyOf`'s alternatives. Clause order is not significant either — a
+ * ceiling is a conjunction — so the comparison is a multiset match, never a
+ * `JSON.stringify` of the two, which would call `[A ∨ B]` and `[B ∨ A]`
+ * different ceilings and refuse a resume or a session over spelling. Absent
+ * equals absent only.
+ */
+export const readCeilingsEqual = (
+  left: readonly CfcConfClause[] | undefined,
+  right: readonly CfcConfClause[] | undefined,
+): boolean => {
+  if (left === undefined || right === undefined) return left === right;
+  if (left.length !== right.length) return false;
+  const used = new Array<boolean>(right.length).fill(false);
+  for (const clause of left) {
+    const at = right.findIndex((candidate, i) =>
+      !used[i] && clausesEqual(clause, candidate)
+    );
+    if (at === -1) return false;
+    used[at] = true;
+  }
+  return true;
+};
+
 export interface HarnessPatternIndexConfig {
   baseUrl: string;
 
@@ -184,7 +211,7 @@ interface HarnessCommonConfig {
   artifactRoot?: string;
   cfcEnforcementMode: CfcEnforcementMode;
   cfcEnforcementModeSource: HarnessCfcEnforcementModeSource;
-  fabricSession?: ResolvedHarnessFabricSessionConfig;
+  fabricSession?: HarnessFabricSessionConfig;
   patternIndex?: HarnessPatternIndexConfig;
   skillsSh?: HarnessSkillsShConfig;
   sandbox?: DockerRunscSandboxConfig;
@@ -200,9 +227,15 @@ export interface HarnessConfig extends HarnessCommonConfig {
   credentialOwnerKey?: string;
 }
 
-/** Fully resolved configuration used by the engine. */
+/** Fully resolved configuration used by the engine. The fabric session is
+ *  the resolved shape here and the raw one on `HarnessConfig`: the resolver's
+ *  fold-once brand is its own, never a field a caller supplies. */
+type ResolvedHarnessCommonConfig =
+  & Omit<HarnessCommonConfig, "fabricSession">
+  & { fabricSession?: ResolvedHarnessFabricSessionConfig };
+
 export type ResolvedHarnessConfig =
-  & HarnessCommonConfig
+  & ResolvedHarnessCommonConfig
   & (
     | {
       modelProvider: "openai-compatible-gateway";
@@ -476,10 +509,16 @@ export const resolveFabricSessionConfig = (
     // under: a resolved config beside a manifest ceiling it never folded
     // would either run unbounded under a manifest that asked for a bound or
     // attest a ceiling that manifest never declared.
+    // Compared whenever EITHER side declares one: a config folded under a
+    // manifest ceiling arriving beside a manifest that now declares none
+    // would attest a ceiling that manifest never carried.
     if (
-      manifestCeiling !== undefined &&
-      (JSON.stringify(options.fabricSession.manifestReadMaxConfidentiality) !==
-          JSON.stringify(manifestCeiling) ||
+      (manifestCeiling !== undefined ||
+        options.fabricSession.manifestReadMaxConfidentiality !== undefined) &&
+      (!readCeilingsEqual(
+        options.fabricSession.manifestReadMaxConfidentiality,
+        manifestCeiling,
+      ) ||
         options.fabricSession.manifestReadOnExceed !==
           options.runManifest?.cfc?.onExceed)
     ) {
@@ -595,7 +634,7 @@ export const resolveHarnessConfig = (
   const skillsRootRecord = options.skillsRootRecord ??
     resolveHarnessSkillsRoot(options.skillsRoot);
   const fabricSession = resolveFabricSessionConfig(options);
-  const common: HarnessCommonConfig = {
+  const common: ResolvedHarnessCommonConfig = {
     ...(options.cwd !== undefined ? { cwd: options.cwd } : {}),
     ...(options.model !== undefined ? { model: options.model } : {}),
     ...(modelAuthSource !== undefined ? { modelAuthSource } : {}),

--- a/packages/cf-harness/src/config.ts
+++ b/packages/cf-harness/src/config.ts
@@ -89,6 +89,16 @@ export type HarnessFabricReadCeilingSource =
 export interface ResolvedHarnessFabricSessionConfig
   extends HarnessFabricSessionConfig {
   readCeilingSource: HarnessFabricReadCeilingSource;
+
+  /**
+   * The run manifest's ceiling this config folded, when it folded one. What
+   * a second resolution checks the manifest beside it against: a resolved
+   * config passes through only beside the manifest it was resolved under.
+   */
+  manifestReadMaxConfidentiality?: readonly CfcConfClause[];
+
+  /** The manifest's `onExceed` that was folded, when it declared one. */
+  manifestReadOnExceed?: CfcReadOnExceed;
 }
 
 /**
@@ -462,6 +472,22 @@ export const resolveFabricSessionConfig = (
     options.fabricSession !== undefined &&
     isResolvedFabricSessionConfig(options.fabricSession)
   ) {
+    // Resolved once, and only ever beside the manifest it was resolved
+    // under: a resolved config beside a manifest ceiling it never folded
+    // would either run unbounded under a manifest that asked for a bound or
+    // attest a ceiling that manifest never declared.
+    if (
+      manifestCeiling !== undefined &&
+      (JSON.stringify(options.fabricSession.manifestReadMaxConfidentiality) !==
+          JSON.stringify(manifestCeiling) ||
+        options.fabricSession.manifestReadOnExceed !==
+          options.runManifest?.cfc?.onExceed)
+    ) {
+      throw new Error(
+        "resolved fabric session did not fold the run manifest's read " +
+          "ceiling beside it; resolve the session under this manifest",
+      );
+    }
     return options.fabricSession;
   }
   if (manifestCeiling === undefined) {
@@ -494,6 +520,10 @@ export const resolveFabricSessionConfig = (
       options.fabricSession.cfcReadMaxConfidentiality !== undefined
         ? "both"
         : "run-manifest",
+    manifestReadMaxConfidentiality: manifestCeiling,
+    ...(options.runManifest?.cfc?.onExceed !== undefined
+      ? { manifestReadOnExceed: options.runManifest.cfc.onExceed }
+      : {}),
   };
 };
 

--- a/packages/cf-harness/src/config.ts
+++ b/packages/cf-harness/src/config.ts
@@ -4,8 +4,8 @@ import {
   cfcEnforcementStrictness,
   type CfcFlowLabelsMode,
   type CfcReadOnExceed,
-  isCfcEnforcementMode,
   clausesEqual,
+  isCfcEnforcementMode,
   meetCfcObservationCeilings,
 } from "@commonfabric/runner/cfc";
 import type { CfcPosture } from "@commonfabric/runner";

--- a/packages/cf-harness/src/contracts/cfc-invocation-context.ts
+++ b/packages/cf-harness/src/contracts/cfc-invocation-context.ts
@@ -3,8 +3,10 @@ import {
   type CfcPromptSlotInfluenceAtom,
 } from "@commonfabric/api/cfc";
 import type {
+  CfcConfClause,
   CfcEnforcementMode,
   CfcLabelView,
+  CfcReadOnExceed,
 } from "@commonfabric/runner/cfc";
 import { mergeCfcLabelViews } from "@commonfabric/runner/cfc";
 import {
@@ -70,6 +72,13 @@ export interface HarnessCfcInvocationRunManifestSummary {
   wishId?: string;
   dispatchClass?: string;
   cfcEnforcementMode?: CfcEnforcementMode;
+
+  /** The read ceiling the manifest declared for the run's fabric session. */
+  cfcReadMaxConfidentiality?: readonly CfcConfClause[];
+
+  /** Its `onExceed`, when the manifest declared one. */
+  cfcReadOnExceed?: CfcReadOnExceed;
+
   promptSlotPresent?: boolean;
 }
 
@@ -185,6 +194,12 @@ export const summarizeCfcInvocationRunManifest = (
         : {}),
       ...(manifest.cfc?.enforcementMode !== undefined
         ? { cfcEnforcementMode: manifest.cfc.enforcementMode }
+        : {}),
+      ...(manifest.cfc?.maxConfidentiality !== undefined
+        ? { cfcReadMaxConfidentiality: manifest.cfc.maxConfidentiality }
+        : {}),
+      ...(manifest.cfc?.onExceed !== undefined
+        ? { cfcReadOnExceed: manifest.cfc.onExceed }
         : {}),
       promptSlotPresent: manifest.promptSlot !== undefined,
     }

--- a/packages/cf-harness/src/contracts/cfc-policy-snapshot.ts
+++ b/packages/cf-harness/src/contracts/cfc-policy-snapshot.ts
@@ -1,4 +1,8 @@
-import type { CfcEnforcementMode } from "@commonfabric/runner/cfc";
+import type {
+  CfcConfClause,
+  CfcEnforcementMode,
+  CfcReadOnExceed,
+} from "@commonfabric/runner/cfc";
 import type {
   HarnessCfcAbsenceBehavior,
   HarnessCfcSubstrateStatus,
@@ -41,6 +45,13 @@ export interface HarnessCfcPolicySnapshotRunManifestSummary {
   capabilityProfile?: string;
   cfcEnforcementMode?: CfcEnforcementMode;
   labelSource?: string;
+
+  /** The read ceiling the manifest declared for the run's fabric session. */
+  cfcReadMaxConfidentiality?: readonly CfcConfClause[];
+
+  /** Its `onExceed`, when the manifest declared one. */
+  cfcReadOnExceed?: CfcReadOnExceed;
+
   promptSlotPresent?: boolean;
 }
 
@@ -144,6 +155,15 @@ export const createHarnessCfcPolicySnapshot = (
           : {}),
         ...(options.runManifest.cfc?.labelSource !== undefined
           ? { labelSource: options.runManifest.cfc.labelSource }
+          : {}),
+        ...(options.runManifest.cfc?.maxConfidentiality !== undefined
+          ? {
+            cfcReadMaxConfidentiality:
+              options.runManifest.cfc.maxConfidentiality,
+          }
+          : {}),
+        ...(options.runManifest.cfc?.onExceed !== undefined
+          ? { cfcReadOnExceed: options.runManifest.cfc.onExceed }
           : {}),
         promptSlotPresent: options.runManifest.promptSlot !== undefined,
       }

--- a/packages/cf-harness/src/contracts/run-manifest.ts
+++ b/packages/cf-harness/src/contracts/run-manifest.ts
@@ -1,6 +1,10 @@
 import {
+  type CfcConfClause,
   type CfcEnforcementMode,
+  type CfcReadOnExceed,
   isCfcEnforcementMode,
+  normalizeCfcReadCeiling,
+  normalizeCfcReadOnExceed,
 } from "@commonfabric/runner/cfc";
 import { isObjectNotArray } from "@commonfabric/utils/types";
 import {
@@ -19,6 +23,23 @@ export interface LoomRunManifestWorkspace {
 export interface LoomRunManifestCfc {
   enforcementMode?: CfcEnforcementMode;
   labelSource?: "loom-run-manifest";
+
+  /**
+   * The read ceiling this run's fabric session applies to every
+   * `sqliteQuery` the run issues: a flat list of confidentiality clauses,
+   * the shape the builtin's own `maxConfidentiality` option takes. A query
+   * declaring its own ceiling is bounded by both. Absent is no ceiling —
+   * the owner's whole view; an empty list is refused at normalization
+   * rather than read either way.
+   */
+  maxConfidentiality?: CfcConfClause[];
+
+  /**
+   * What a bounded read does with a row the ceiling does not admit when the
+   * query says nothing itself: `fail` refuses the query, `skip` withholds
+   * the row. Needs `maxConfidentiality` beside it.
+   */
+  onExceed?: CfcReadOnExceed;
 }
 
 export const HARNESS_CREDENTIAL_OWNER_REF_TYPE =
@@ -162,6 +183,21 @@ const normalizeLoomRunManifestCfc = (
       `unsupported run manifest cfc.labelSource: ${String(input.labelSource)}`,
     );
   }
+  // Validated rather than projected: a ceiling this projection dropped would
+  // read as no ceiling, the widest posture there is.
+  const maxConfidentiality = normalizeCfcReadCeiling(
+    input.maxConfidentiality,
+    "run manifest cfc.maxConfidentiality",
+  );
+  const onExceed = normalizeCfcReadOnExceed(
+    input.onExceed,
+    "run manifest cfc.onExceed",
+  );
+  if (onExceed !== undefined && maxConfidentiality === undefined) {
+    throw new Error(
+      "run manifest cfc.onExceed needs a cfc.maxConfidentiality to apply to",
+    );
+  }
   return {
     ...(input.enforcementMode !== undefined
       ? { enforcementMode: input.enforcementMode }
@@ -169,6 +205,8 @@ const normalizeLoomRunManifestCfc = (
     ...(input.labelSource !== undefined
       ? { labelSource: input.labelSource }
       : {}),
+    ...(maxConfidentiality !== undefined ? { maxConfidentiality } : {}),
+    ...(onExceed !== undefined ? { onExceed } : {}),
   };
 };
 

--- a/packages/cf-harness/src/contracts/run-manifest.ts
+++ b/packages/cf-harness/src/contracts/run-manifest.ts
@@ -1,10 +1,10 @@
 import {
+  buildCfcReadCeiling,
   type CfcConfClause,
   type CfcEnforcementMode,
+  type CfcReadCeiling,
   type CfcReadOnExceed,
   isCfcEnforcementMode,
-  normalizeCfcReadCeiling,
-  normalizeCfcReadOnExceed,
 } from "@commonfabric/runner/cfc";
 import { isObjectNotArray } from "@commonfabric/utils/types";
 import {
@@ -32,7 +32,7 @@ export interface LoomRunManifestCfc {
    * the owner's whole view; an empty list is refused at normalization
    * rather than read either way.
    */
-  maxConfidentiality?: CfcConfClause[];
+  maxConfidentiality?: readonly CfcConfClause[];
 
   /**
    * What a bounded read does with a row the ceiling does not admit when the
@@ -41,6 +41,28 @@ export interface LoomRunManifestCfc {
    */
   onExceed?: CfcReadOnExceed;
 }
+
+/**
+ * Validates a read ceiling written by a caller — a manifest field, a command
+ * line flag — through the runner's own `buildCfcReadCeiling`, so what the
+ * harness accepts is exactly what the runtime accepts, and returns the
+ * frozen form. A refusal names the caller's fields, since the reader fixing
+ * it is looking at those rather than at the runtime option behind them.
+ *
+ * @throws Error when the ceiling or its `onExceed` is malformed, or when
+ * `onExceed` is given without a ceiling.
+ */
+export const readCeilingFromInput = (
+  maxConfidentiality: unknown,
+  onExceed: unknown,
+  labels: { ceiling: string; onExceed: string },
+): CfcReadCeiling =>
+  buildCfcReadCeiling({
+    cfcReadMaxConfidentiality: maxConfidentiality as
+      | readonly CfcConfClause[]
+      | undefined,
+    cfcReadOnExceed: onExceed as CfcReadOnExceed | undefined,
+  }, labels);
 
 export const HARNESS_CREDENTIAL_OWNER_REF_TYPE =
   "cf-harness.credential-owner-ref" as const;
@@ -185,19 +207,14 @@ const normalizeLoomRunManifestCfc = (
   }
   // Validated rather than projected: a ceiling this projection dropped would
   // read as no ceiling, the widest posture there is.
-  const maxConfidentiality = normalizeCfcReadCeiling(
+  const { maxConfidentiality, onExceed } = readCeilingFromInput(
     input.maxConfidentiality,
-    "run manifest cfc.maxConfidentiality",
-  );
-  const onExceed = normalizeCfcReadOnExceed(
     input.onExceed,
-    "run manifest cfc.onExceed",
+    {
+      ceiling: "run manifest cfc.maxConfidentiality",
+      onExceed: "run manifest cfc.onExceed",
+    },
   );
-  if (onExceed !== undefined && maxConfidentiality === undefined) {
-    throw new Error(
-      "run manifest cfc.onExceed needs a cfc.maxConfidentiality to apply to",
-    );
-  }
   return {
     ...(input.enforcementMode !== undefined
       ? { enforcementMode: input.enforcementMode }

--- a/packages/cf-harness/src/contracts/run-manifest.ts
+++ b/packages/cf-harness/src/contracts/run-manifest.ts
@@ -31,6 +31,11 @@ export interface LoomRunManifestCfc {
    * declaring its own ceiling is bounded by both. Absent is no ceiling —
    * the owner's whole view; an empty list is refused at normalization
    * rather than read either way.
+   *
+   * A v0 carrier: the ceiling is an assertion the dispatcher writes, fixed
+   * at prepare time the way spec §19.6.1 has a context read bounded, and not
+   * yet a posture the runtime mints from a delegation record (§19.5). The
+   * field is what a delegation-record integration replaces.
    */
   maxConfidentiality?: readonly CfcConfClause[];
 

--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -29,6 +29,7 @@ import {
   loadHarnessDocsCorpus,
 } from "./docs-corpus/corpus.ts";
 import type { HarnessExploreQueryRunner } from "./docs-corpus/explore.ts";
+import type { HarnessToolContext } from "./tools/types.ts";
 import type { HarnessDocsCorpusRecord } from "./contracts/docs-corpus.ts";
 import {
   createHarnessCfcInvocationContext,
@@ -303,6 +304,13 @@ export interface CreateHarnessEngineOptions
   inheritedFabricSessionPosture?: CfcPostureReport;
 
   /**
+   * Injection seam for the render gate's probe runtime, mirroring
+   * `fabricSessionFactory`: a test supplies one to see what the gate opens
+   * the probe under. When absent, the gate opens a real isolated runtime.
+   */
+  openProbeRuntime?: HarnessToolContext["openProbeRuntime"];
+
+  /**
    * Injection seam for the pattern-index client, mirroring
    * `fabricSessionFactory`. When absent, a factory is built from
    * `patternIndex` in the resolved config; when both are absent, the run has
@@ -470,6 +478,7 @@ export class CfHarnessEngine {
   #outputSequence: number;
   readonly #now: () => string;
   readonly #fabricSessionFactory?: HarnessFabricSessionFactory;
+  readonly #openProbeRuntime?: HarnessToolContext["openProbeRuntime"];
   readonly #patternIndexClientFactory?: HarnessPatternIndexClientFactory;
   readonly #skillsShSearchClientFactory?: HarnessSkillsShSearchClientFactory;
   readonly #skillsShAcquisitionClientFactory?:
@@ -633,6 +642,7 @@ export class CfHarnessEngine {
           this.config.fabricSession.identityKeyPath,
         )
         : undefined);
+    this.#openProbeRuntime = options.openProbeRuntime;
     this.#patternIndexClientFactory = patternIndexClientFactory === undefined
       ? undefined
       : cacheHarnessPatternIndexClientFactory(patternIndexClientFactory);
@@ -784,6 +794,12 @@ export class CfHarnessEngine {
           : {}),
         ...(this.config.fabricSession.cfcReadOnExceed !== undefined
           ? { readOnExceed: this.config.fabricSession.cfcReadOnExceed }
+          : {}),
+        ...(this.config.fabricSession.readCeilingSource !== "none"
+          ? {
+            readMaxConfidentialitySource:
+              this.config.fabricSession.readCeilingSource,
+          }
           : {}),
         ...(sessionRecord !== undefined ? { record: sessionRecord } : {}),
       }
@@ -2079,6 +2095,9 @@ export class CfHarnessEngine {
       handleTable: this.handleTable,
       ...(this.#fabricSessionFactory !== undefined
         ? { getFabricSession: this.#fabricSessionFactory }
+        : {}),
+      ...(this.#openProbeRuntime !== undefined
+        ? { openProbeRuntime: this.#openProbeRuntime }
         : {}),
       ...(this.#patternIndexClientFactory !== undefined
         ? {

--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -776,6 +776,15 @@ export class CfHarnessEngine {
         ...(this.config.fabricSession.cfcPosture !== undefined
           ? { posture: this.config.fabricSession.cfcPosture }
           : {}),
+        ...(this.config.fabricSession.cfcReadMaxConfidentiality !== undefined
+          ? {
+            readMaxConfidentiality:
+              this.config.fabricSession.cfcReadMaxConfidentiality,
+          }
+          : {}),
+        ...(this.config.fabricSession.cfcReadOnExceed !== undefined
+          ? { readOnExceed: this.config.fabricSession.cfcReadOnExceed }
+          : {}),
         ...(sessionRecord !== undefined ? { record: sessionRecord } : {}),
       }
       : undefined;
@@ -806,6 +815,12 @@ export class CfHarnessEngine {
         recorded.enforcementMode !== fabricSessionCfc.enforcementMode ||
         recorded.flowLabels !== fabricSessionCfc.flowLabels ||
         recorded.posture !== fabricSessionCfc.posture ||
+        // The read ceiling too: a resume that would read wider (or under
+        // another ceiling) than the artifacts attest is the same
+        // contradiction as a moved dial.
+        JSON.stringify(recorded.readMaxConfidentiality) !==
+          JSON.stringify(fabricSessionCfc.readMaxConfidentiality) ||
+        recorded.readOnExceed !== fabricSessionCfc.readOnExceed ||
         // The whole record too, where the run recorded one. The two dials
         // above can agree while a dial neither of them names has moved under
         // the run — a changed runtime default, a changed posture bundle — and

--- a/packages/cf-harness/src/fabric-session.ts
+++ b/packages/cf-harness/src/fabric-session.ts
@@ -83,36 +83,71 @@ export const harnessFabricSessionControllerOptions = (
 });
 
 /**
+ * The two steps of building a session that a test replaces: loading the
+ * identity the session acts as, and connecting the controller. Production
+ * reads the PKCS#8 key from disk and calls `PiecesController.initialize`.
+ */
+export interface HarnessFabricSessionFactoryDeps {
+  /** Loads the identity named by the config's `identityKeyPath`. */
+  loadIdentity?: (identityKeyPath: string) => Promise<Identity>;
+
+  /** Connects the controller; `PiecesController.initialize` by default. */
+  initialize?: (
+    options: Parameters<typeof PiecesController.initialize>[0],
+  ) => Promise<PiecesController>;
+}
+
+/**
+ * Whether `runtime` is bounded by exactly the read ceiling `options` asked
+ * for. The controller's options and the runtime's own fields are two
+ * declarations that can drift apart, and a session whose runtime holds a
+ * different ceiling than the one the config asked for — or none — would read
+ * under one posture while its artifacts attest another.
+ */
+export const fabricSessionRuntimeBoundedAsConfigured = (
+  runtime: Pick<
+    PiecesController["runtime"],
+    "cfcReadMaxConfidentiality" | "cfcReadOnExceed"
+  >,
+  options: Pick<
+    ReturnType<typeof harnessFabricSessionControllerOptions>,
+    "cfcReadMaxConfidentiality" | "cfcReadOnExceed"
+  >,
+): boolean =>
+  JSON.stringify(runtime.cfcReadMaxConfidentiality) ===
+    JSON.stringify(options.cfcReadMaxConfidentiality) &&
+  runtime.cfcReadOnExceed === options.cfcReadOnExceed;
+
+/**
  * Default factory over `config`: loads the PKCS#8 identity from disk and
  * connects a `PiecesController` to the deployed API. An unauthorized space
  * fails construction rather than yielding a session whose every read is a
  * silent absence. The controller's runtime is given an instantiation recorder,
  * whose read side rides along on the session — the observer is a runtime
  * constructor option, so this is the only point at which it can be installed.
+ *
+ * The session is refused, and its runtime disposed, when the runtime is not
+ * bounded by the read ceiling the config asked for
+ * (`fabricSessionRuntimeBoundedAsConfigured`).
  */
 export const createHarnessFabricSessionFactory = (
   config: HarnessFabricSessionConfig,
+  deps: HarnessFabricSessionFactoryDeps = {},
 ): HarnessFabricSessionFactory =>
 async () => {
-  const identity = await Identity.fromPkcs8(
-    await Deno.readFile(config.identityKeyPath),
-  );
+  const loadIdentity = deps.loadIdentity ??
+    (async (path: string) => Identity.fromPkcs8(await Deno.readFile(path)));
+  const initialize = deps.initialize ??
+    ((options) => PiecesController.initialize(options));
+  const identity = await loadIdentity(config.identityKeyPath);
   const recorder = createFabricInstantiationRecorder();
   const options = harnessFabricSessionControllerOptions(config);
-  const pieces = await PiecesController.initialize({
+  const pieces = await initialize({
     ...options,
     identity,
     onPatternInstantiated: recorder.observe,
   });
-  // The runtime this session hands out must be bounded as the config asked,
-  // or the run reads unbounded while its artifacts attest a ceiling. Checked
-  // here rather than trusted, since the controller's options and the
-  // runtime's are two declarations that can drift apart.
-  if (
-    JSON.stringify(pieces.runtime.cfcReadMaxConfidentiality) !==
-      JSON.stringify(options.cfcReadMaxConfidentiality) ||
-    pieces.runtime.cfcReadOnExceed !== options.cfcReadOnExceed
-  ) {
+  if (!fabricSessionRuntimeBoundedAsConfigured(pieces.runtime, options)) {
     await pieces.runtime.dispose().catch(() => {});
     throw new Error(
       "fabric session runtime is not bounded by the configured read " +

--- a/packages/cf-harness/src/fabric-session.ts
+++ b/packages/cf-harness/src/fabric-session.ts
@@ -98,11 +98,27 @@ async () => {
     await Deno.readFile(config.identityKeyPath),
   );
   const recorder = createFabricInstantiationRecorder();
+  const options = harnessFabricSessionControllerOptions(config);
   const pieces = await PiecesController.initialize({
-    ...harnessFabricSessionControllerOptions(config),
+    ...options,
     identity,
     onPatternInstantiated: recorder.observe,
   });
+  // The runtime this session hands out must be bounded as the config asked,
+  // or the run reads unbounded while its artifacts attest a ceiling. Checked
+  // here rather than trusted, since the controller's options and the
+  // runtime's are two declarations that can drift apart.
+  if (
+    JSON.stringify(pieces.runtime.cfcReadMaxConfidentiality) !==
+      JSON.stringify(options.cfcReadMaxConfidentiality) ||
+    pieces.runtime.cfcReadOnExceed !== options.cfcReadOnExceed
+  ) {
+    await pieces.runtime.dispose().catch(() => {});
+    throw new Error(
+      "fabric session runtime is not bounded by the configured read " +
+        "ceiling; refusing to run under it",
+    );
+  }
   return { pieces, identity, instantiations: recorder.instantiations };
 };
 

--- a/packages/cf-harness/src/fabric-session.ts
+++ b/packages/cf-harness/src/fabric-session.ts
@@ -60,6 +60,10 @@ export const harnessFabricSessionControllerOptions = (
   cfcEnforcementMode?: HarnessFabricSessionConfig["cfcEnforcementMode"];
   cfcFlowLabels?: HarnessFabricSessionConfig["cfcFlowLabels"];
   cfcPosture?: HarnessFabricSessionConfig["cfcPosture"];
+  cfcReadMaxConfidentiality?: HarnessFabricSessionConfig[
+    "cfcReadMaxConfidentiality"
+  ];
+  cfcReadOnExceed?: HarnessFabricSessionConfig["cfcReadOnExceed"];
 } => ({
   apiUrl: new URL(config.apiUrl),
   space: config.space,
@@ -70,6 +74,12 @@ export const harnessFabricSessionControllerOptions = (
     ? { cfcFlowLabels: config.cfcFlowLabels }
     : {}),
   ...(config.cfcPosture !== undefined ? { cfcPosture: config.cfcPosture } : {}),
+  ...(config.cfcReadMaxConfidentiality !== undefined
+    ? { cfcReadMaxConfidentiality: config.cfcReadMaxConfidentiality }
+    : {}),
+  ...(config.cfcReadOnExceed !== undefined
+    ? { cfcReadOnExceed: config.cfcReadOnExceed }
+    : {}),
 });
 
 /**

--- a/packages/cf-harness/src/pattern-index/probe-runtime.ts
+++ b/packages/cf-harness/src/pattern-index/probe-runtime.ts
@@ -1,4 +1,8 @@
-import type { CfcEnforcementMode } from "@commonfabric/runner/cfc";
+import type {
+  CfcConfClause,
+  CfcEnforcementMode,
+  CfcReadOnExceed,
+} from "@commonfabric/runner/cfc";
 import type { Identity } from "@commonfabric/identity";
 import { createSession } from "@commonfabric/identity";
 import { PiecesController } from "@commonfabric/piece/ops";
@@ -52,6 +56,15 @@ export const openProbeRuntime = async (
   identity: Identity | undefined,
   apiUrl: URL,
   cfcEnforcementMode: CfcEnforcementMode,
+  /**
+   * The read ceiling the session's runtime is bounded by, which the probe's
+   * runtime is bounded by too: a probe reads the same space the session
+   * does, so it reads under the same posture.
+   */
+  readCeiling: {
+    cfcReadMaxConfidentiality?: readonly CfcConfClause[];
+    cfcReadOnExceed?: CfcReadOnExceed;
+  } = {},
 ): Promise<ProbeRuntime | undefined> => {
   if (identity === undefined) return undefined;
   // Imported here rather than at module scope on purpose. `cache.deno` reaches
@@ -75,7 +88,17 @@ export const openProbeRuntime = async (
     // is only written under an enforcing mode, so a probe in a default-mode
     // runtime cannot resolve a composed import at all and every composed
     // pattern would quietly come back with no verdict.
-    runtime = new Runtime({ apiUrl, storageManager, cfcEnforcementMode });
+    runtime = new Runtime({
+      apiUrl,
+      storageManager,
+      cfcEnforcementMode,
+      ...(readCeiling.cfcReadMaxConfidentiality !== undefined
+        ? { cfcReadMaxConfidentiality: readCeiling.cfcReadMaxConfidentiality }
+        : {}),
+      ...(readCeiling.cfcReadOnExceed !== undefined
+        ? { cfcReadOnExceed: readCeiling.cfcReadOnExceed }
+        : {}),
+    });
     const pieces = new PiecesController(
       await createSession({
         identity,

--- a/packages/cf-harness/src/run-state.ts
+++ b/packages/cf-harness/src/run-state.ts
@@ -113,12 +113,19 @@ export interface HarnessFabricSessionCfcPosture {
   readOnExceed?: CfcReadOnExceed;
 
   /**
+   * Where the ceiling came from: the operator's session config, the run
+   * manifest, or both met. Absent with the ceiling.
+   */
+  readMaxConfidentialitySource?: "session" | "run-manifest" | "both";
+
+  /**
    * The session runtime's whole posture, as the shared record every surface
-   * publishes (`cfc-posture.ts`). The itemized fields above are the two dials
-   * an operator sets and where each came from; this is what those dials, the
-   * named bundle, and the runtime's own defaults resolve to — every dial, the
-   * policy digest, every known sink governed or explicitly not, and every
-   * published deviation.
+   * publishes (`cfc-posture.ts`). The itemized fields above are the dials an
+   * operator or a run manifest sets and where each came from; this is what
+   * the enforcement and flow-label dials, the named bundle, and the runtime's
+   * own defaults resolve to — every dial, the policy digest, every known sink
+   * governed or explicitly not, and every published deviation. The read
+   * ceiling is not part of the record; the itemized fields carry it.
    *
    * Absent on a run recorded before the record existed. Such a run stays
    * frozen as history rather than being backfilled: the values would be this

--- a/packages/cf-harness/src/run-state.ts
+++ b/packages/cf-harness/src/run-state.ts
@@ -1,6 +1,8 @@
 import type {
+  CfcConfClause,
   CfcEnforcementMode,
   CfcPostureReport,
+  CfcReadOnExceed,
 } from "@commonfabric/runner/cfc";
 import type { HarnessCfcInvocationContext } from "./contracts/cfc-invocation-context.ts";
 import {
@@ -99,6 +101,16 @@ export interface HarnessFabricSessionCfcPosture {
    * `MAX_ENFORCEMENT_CFC_OPTIONS` in the runner's presets.
    */
   posture?: "max-enforcement";
+
+  /**
+   * The read ceiling the session's runtime bounds every `sqliteQuery` by:
+   * the run manifest's, met with any the operator configured. Absent when
+   * the session reads unbounded.
+   */
+  readMaxConfidentiality?: readonly CfcConfClause[];
+
+  /** The ceiling's `onExceed` default, when one was configured. */
+  readOnExceed?: CfcReadOnExceed;
 
   /**
    * The session runtime's whole posture, as the shared record every surface

--- a/packages/cf-harness/src/tools/run-pattern.ts
+++ b/packages/cf-harness/src/tools/run-pattern.ts
@@ -341,7 +341,7 @@ export const runPatternToolDescriptor: HarnessToolDescriptor = {
   toolId: "run_pattern",
   title: "Run Pattern",
   description:
-    `Compile and run a Common Fabric pattern in the configured space, returning a reference to its live result cell. Give it either your own sourceText or the patternId of a pattern search_patterns found. Source you write imports the runtime from "${RUNTIME_MODULE_SPECIFIER}" and from no other module — every pattern opens with a line of the form ${RUNTIME_MODULE_IMPORT_LINE} — and no package named after the product resolves. The piece stays out of the space's piece list; assign_slug names and lists it when it deserves a public address.`,
+    `Compile and run a Common Fabric pattern in the configured space, returning a reference to its live result cell. Give it either your own sourceText or the patternId of a pattern search_patterns found. Source you write imports the runtime from "${RUNTIME_MODULE_SPECIFIER}" and from no other module — every pattern opens with a line of the form ${RUNTIME_MODULE_IMPORT_LINE} — and no package named after the product resolves. When the run's session reads under a confidentiality ceiling, every db.query result must be declared per session (PerSession<> on the result type, or the query's { scope: "session" } option); a query left space-scoped is refused under a ceiling rather than read. The piece stays out of the space's piece list; assign_slug names and lists it when it deserves a public address.`,
   effectClass: "side-effect",
   inputSchema: {
     type: "object",
@@ -1850,7 +1850,7 @@ export const runPatternTool: HarnessToolDefinition<
       // and its result graph there, `stop()` does not delete them, and the
       // orphan is reachable from the sandbox's Fabric mount.
       const probe = async () => {
-        const opened = await openProbeRuntime(
+        const opened = await (context.openProbeRuntime ?? openProbeRuntime)(
           session.identity,
           pieces.runtime.apiUrl,
           context.cfcEnforcementMode,

--- a/packages/cf-harness/src/tools/run-pattern.ts
+++ b/packages/cf-harness/src/tools/run-pattern.ts
@@ -1854,6 +1854,17 @@ export const runPatternTool: HarnessToolDefinition<
           session.identity,
           pieces.runtime.apiUrl,
           context.cfcEnforcementMode,
+          {
+            ...(pieces.runtime.cfcReadMaxConfidentiality !== undefined
+              ? {
+                cfcReadMaxConfidentiality:
+                  pieces.runtime.cfcReadMaxConfidentiality,
+              }
+              : {}),
+            ...(pieces.runtime.cfcReadOnExceed !== undefined
+              ? { cfcReadOnExceed: pieces.runtime.cfcReadOnExceed }
+              : {}),
+          },
         );
         // No identity, no isolated runtime, and therefore no probe. Falling
         // back to the live space would re-enter the leak this exists to close

--- a/packages/cf-harness/src/tools/types.ts
+++ b/packages/cf-harness/src/tools/types.ts
@@ -21,6 +21,7 @@ import type { HarnessDocsCorpus } from "../docs-corpus/corpus.ts";
 import type { HarnessExploreQueryRunner } from "../docs-corpus/explore.ts";
 import type { HarnessHandleTable } from "../contracts/handle-table.ts";
 import type { HarnessFabricSession } from "../fabric-session.ts";
+import type { openProbeRuntime } from "../pattern-index/probe-runtime.ts";
 import type { PatternIndexClient } from "../pattern-index/client.ts";
 import type { PatternIndexPublicationLedger } from "../pattern-index/publish-ledger.ts";
 import type { SkillsShAcquisitionClient } from "../skills-sh/acquisition.ts";
@@ -62,6 +63,12 @@ export interface HarnessToolContext {
    * keeps `run_pattern` and `acquire_skill` out of the tool surface.
    */
   getFabricSession?: () => Promise<HarnessFabricSession>;
+
+  /**
+   * Opens the render gate's probe runtime; `openProbeRuntime` by default. A
+   * test replaces it to see what the gate opens the probe under.
+   */
+  openProbeRuntime?: typeof openProbeRuntime;
 
   /**
    * The run's pattern-index client, lazy and cached by the engine.

--- a/packages/cf-harness/test/cfc-invocation-context.test.ts
+++ b/packages/cf-harness/test/cfc-invocation-context.test.ts
@@ -5,6 +5,7 @@ import type { CfcLabelView } from "@commonfabric/runner/cfc";
 import {
   CF_HARNESS_PROMPT_SLOT_INFLUENCE_ATOM_TYPE,
   createHarnessCfcInvocationContext,
+  summarizeCfcInvocationRunManifest,
   summarizeCfcInvocationSequence,
   summarizeCfcInvocationText,
 } from "../src/contracts/cfc-invocation-context.ts";
@@ -307,4 +308,31 @@ Deno.test("createHarnessCfcInvocationContext merges explicit trusted labels with
       },
     }],
   });
+});
+
+Deno.test("summarizeCfcInvocationRunManifest carries the manifest's read ceiling", () => {
+  assertEquals(
+    summarizeCfcInvocationRunManifest(
+      {
+        type: "cf-harness.loom-run-manifest",
+        version: 1,
+        source: "loom",
+        wishId: "W-2201",
+        cfc: {
+          maxConfidentiality: ["did:key:zOwner", "did:key:zFacet"],
+          onExceed: "skip",
+        },
+      },
+      "/runs/W-2201/manifest.json",
+    ),
+    {
+      present: true,
+      path: "/runs/W-2201/manifest.json",
+      source: "loom",
+      wishId: "W-2201",
+      cfcReadMaxConfidentiality: ["did:key:zOwner", "did:key:zFacet"],
+      cfcReadOnExceed: "skip",
+      promptSlotPresent: false,
+    },
+  );
 });

--- a/packages/cf-harness/test/cfc-policy-snapshot.test.ts
+++ b/packages/cf-harness/test/cfc-policy-snapshot.test.ts
@@ -1,0 +1,54 @@
+import { assertEquals } from "@std/assert";
+import { createHarnessCfcPolicySnapshot } from "../src/contracts/cfc-policy-snapshot.ts";
+
+const base = {
+  runId: "run-ceiling",
+  generatedAt: "2026-09-04T20:00:00.000Z",
+  cfcEnforcementMode: "enforce-explicit" as const,
+  cfcEnforcementModeSource: "run-manifest" as const,
+  promptSlotBindingSource: "absent" as const,
+  parentToolAllowance: "restricted" as const,
+  allowedToolIds: ["read_file" as const],
+  allowedSubagentProfiles: [],
+  subagentProfileConfigs: [],
+};
+
+Deno.test("createHarnessCfcPolicySnapshot projects the run manifest's read ceiling", () => {
+  const snapshot = createHarnessCfcPolicySnapshot({
+    ...base,
+    runManifest: {
+      type: "cf-harness.loom-run-manifest",
+      version: 1,
+      source: "loom",
+      wishId: "W-2201",
+      cfc: {
+        enforcementMode: "enforce-explicit",
+        maxConfidentiality: ["did:key:zOwner", "did:key:zFacet"],
+        onExceed: "skip",
+      },
+    },
+  });
+  assertEquals(snapshot.runManifest, {
+    present: true,
+    type: "cf-harness.loom-run-manifest",
+    source: "loom",
+    wishId: "W-2201",
+    cfcEnforcementMode: "enforce-explicit",
+    cfcReadMaxConfidentiality: ["did:key:zOwner", "did:key:zFacet"],
+    cfcReadOnExceed: "skip",
+    promptSlotPresent: false,
+  });
+});
+
+Deno.test("createHarnessCfcPolicySnapshot projects no ceiling from a manifest that declares none", () => {
+  const snapshot = createHarnessCfcPolicySnapshot({
+    ...base,
+    runManifest: {
+      type: "cf-harness.loom-run-manifest",
+      version: 1,
+      source: "loom",
+    },
+  });
+  assertEquals("cfcReadMaxConfidentiality" in snapshot.runManifest, false);
+  assertEquals("cfcReadOnExceed" in snapshot.runManifest, false);
+});

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -7259,3 +7259,89 @@ Deno.test("parseCfHarnessCliArgs rejects --allow-tool record_feedback without a 
     "missing --pattern-index-url",
   );
 });
+
+Deno.test("parseCfHarnessCliArgs carries --max-confidentiality into the fabric session as its read ceiling", async () => {
+  const parsed = await parseCfHarnessCliArgs(
+    [
+      "--prompt",
+      "hi",
+      "--fabric-api-url",
+      "https://toolshed.example/",
+      "--fabric-identity",
+      "keys/agent.pkcs8",
+      "--fabric-space",
+      "my-space",
+      "--max-confidentiality",
+      JSON.stringify([
+        "did:key:zOwner",
+        { type: "Facet", owner: "did:key:zOwner", id: "work" },
+      ]),
+    ],
+    { cwd: "/tmp/project", env: {} },
+  );
+
+  if ("help" in parsed) {
+    throw new Error("expected config result");
+  }
+  assertEquals(parsed.fabricSession, {
+    apiUrl: "https://toolshed.example/",
+    identityKeyPath: "/tmp/project/keys/agent.pkcs8",
+    space: "my-space",
+    cfcReadMaxConfidentiality: [
+      "did:key:zOwner",
+      { type: "Facet", owner: "did:key:zOwner", id: "work" },
+    ],
+  });
+});
+
+Deno.test("parseCfHarnessCliArgs refuses a --max-confidentiality that is not a ceiling", async () => {
+  const fabric = [
+    "--prompt",
+    "hi",
+    "--fabric-api-url",
+    "https://toolshed.example/",
+    "--fabric-identity",
+    "keys/agent.pkcs8",
+    "--fabric-space",
+    "my-space",
+  ];
+  await assertRejects(
+    () =>
+      parseCfHarnessCliArgs(
+        [...fabric, "--max-confidentiality", "did:key:zOwner"],
+        { cwd: "/tmp/project", env: {} },
+      ),
+    Error,
+    "--max-confidentiality must be JSON",
+  );
+  await assertRejects(
+    () =>
+      parseCfHarnessCliArgs(
+        [...fabric, "--max-confidentiality", "[]"],
+        { cwd: "/tmp/project", env: {} },
+      ),
+    Error,
+    "--max-confidentiality is empty",
+  );
+  await assertRejects(
+    () =>
+      parseCfHarnessCliArgs(
+        [...fabric, "--max-confidentiality", '{"anyOf":["did:key:zOwner"]}'],
+        { cwd: "/tmp/project", env: {} },
+      ),
+    Error,
+    "--max-confidentiality must be a JSON array",
+  );
+});
+
+Deno.test("parseCfHarnessCliArgs refuses --max-confidentiality without a fabric session", async () => {
+  await assertRejects(
+    () =>
+      parseCfHarnessCliArgs(
+        ["--prompt", "hi", "--max-confidentiality", '["did:key:zOwner"]'],
+        { cwd: "/tmp/project", env: {} },
+      ),
+    Error,
+    "--max-confidentiality bounds the fabric session's reads and needs --fabric-api-url, --fabric-identity, and --fabric-space",
+  );
+});

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -7419,6 +7419,85 @@ Deno.test("a resume whose manifest declares another read ceiling is refused as a
   assertStringIncludes(failure.error.message, "resume read ceiling mismatch");
 });
 
+
+Deno.test("a resume whose manifest respells the recorded ceiling (anyOf reordered) is not a mismatch", async () => {
+  const buffers = createIoBuffers();
+  let promptLoopsCreated = 0;
+  const recordedManifest = {
+    type: "cf-harness.loom-run-manifest",
+    version: 1,
+    source: "loom",
+    cfc: { maxConfidentiality: [{ anyOf: ["did:key:zOwner", "did:key:zFacet"] }] },
+  } as const;
+  const exitCode = await runCfHarnessCli(
+    [
+      "--resume-run",
+      "/tmp/project/.cf-harness-artifacts/run-1/run-state.json",
+      "--run-manifest",
+      "/tmp/loom-run-manifest.json",
+      "--fabric-api-url",
+      "https://toolshed.example/",
+      "--fabric-identity",
+      "keys/agent.pkcs8",
+      "--fabric-space",
+      "my-space",
+    ],
+    {
+      cwd: "/tmp/project",
+      env: { CF_HARNESS_API_KEY: "test-key" },
+      io: buffers.io,
+      structuredHostFailures: true,
+      fabricSessionFactory: () =>
+        Promise.reject(new Error("factory is forwarded, not invoked")),
+      readTextFile: () =>
+        Promise.resolve(JSON.stringify({
+          ...recordedManifest,
+          cfc: { maxConfidentiality: [{ anyOf: ["did:key:zFacet", "did:key:zOwner"] }] },
+        })),
+      readRunArtifacts: () =>
+        Promise.resolve({
+          runRoot: "/tmp/project/.cf-harness-artifacts/run-1",
+          runStatePath:
+            "/tmp/project/.cf-harness-artifacts/run-1/run-state.json",
+          transcriptPath:
+            "/tmp/project/.cf-harness-artifacts/run-1/transcript.json",
+          runState: {
+            runId: "run-1",
+            status: "failed",
+            createdAt: "2026-04-15T22:10:00.000Z",
+            updatedAt: "2026-04-15T22:10:01.000Z",
+            cfcEnforcementMode: "disabled",
+            currentDir: "/workspace",
+            model: "gpt-5.4",
+            artifactRoot: "/tmp/project/.cf-harness-artifacts/run-1",
+            transcriptPath:
+              "/tmp/project/.cf-harness-artifacts/run-1/transcript.json",
+            policyEvents: [],
+            toolOutputs: [],
+            runManifest: recordedManifest,
+          },
+          transcript: [{ role: "user", content: "Continue." }],
+        }),
+      createPromptLoop: () => {
+        promptLoopsCreated += 1;
+        throw new Error("must not construct a prompt loop");
+      },
+    },
+  );
+  // The mismatch guard let it through, so the resume reached the prompt
+  // loop the fixture refuses to build; that refusal, not the ceiling, is
+  // what failed the run.
+  assertEquals(promptLoopsCreated, 1);
+  assertEquals(exitCode, 1);
+  const failure = JSON.parse(buffers.stderr[0]);
+  assertEquals(
+    String(failure.error?.message ?? failure.error).includes(
+      "resume read ceiling mismatch",
+    ),
+    false,
+  );
+});
+
 Deno.test("parseCfHarnessCliArgs refuses a present --max-confidentiality with no value rather than running unbounded", async () => {
   const fabric = [
     "--prompt",

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -7321,7 +7321,7 @@ Deno.test("parseCfHarnessCliArgs refuses a --max-confidentiality that is not a c
         { cwd: "/tmp/project", env: {} },
       ),
     Error,
-    "--max-confidentiality is empty",
+    "--max-confidentiality: an empty ceiling admits",
   );
   await assertRejects(
     () =>
@@ -7330,7 +7330,7 @@ Deno.test("parseCfHarnessCliArgs refuses a --max-confidentiality that is not a c
         { cwd: "/tmp/project", env: {} },
       ),
     Error,
-    "--max-confidentiality must be a JSON array",
+    "--max-confidentiality: expected an array of clauses",
   );
 });
 

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -1,5 +1,9 @@
-import { assertEquals, assertRejects,
-  assertMatch, assertStringIncludes } from "@std/assert";
+import {
+  assertEquals,
+  assertMatch,
+  assertRejects,
+  assertStringIncludes,
+} from "@std/assert";
 import { decodeBase64 } from "@std/encoding/base64";
 import { join } from "@std/path";
 
@@ -7419,7 +7423,6 @@ Deno.test("a resume whose manifest declares another read ceiling is refused as a
   assertStringIncludes(failure.error.message, "resume read ceiling mismatch");
 });
 
-
 Deno.test("a resume whose manifest respells the recorded ceiling (anyOf reordered) is not a mismatch", async () => {
   const buffers = createIoBuffers();
   let promptLoopsCreated = 0;
@@ -7427,7 +7430,9 @@ Deno.test("a resume whose manifest respells the recorded ceiling (anyOf reordere
     type: "cf-harness.loom-run-manifest",
     version: 1,
     source: "loom",
-    cfc: { maxConfidentiality: [{ anyOf: ["did:key:zOwner", "did:key:zFacet"] }] },
+    cfc: {
+      maxConfidentiality: [{ anyOf: ["did:key:zOwner", "did:key:zFacet"] }],
+    },
   } as const;
   const exitCode = await runCfHarnessCli(
     [
@@ -7452,7 +7457,11 @@ Deno.test("a resume whose manifest respells the recorded ceiling (anyOf reordere
       readTextFile: () =>
         Promise.resolve(JSON.stringify({
           ...recordedManifest,
-          cfc: { maxConfidentiality: [{ anyOf: ["did:key:zFacet", "did:key:zOwner"] }] },
+          cfc: {
+            maxConfidentiality: [{
+              anyOf: ["did:key:zFacet", "did:key:zOwner"],
+            }],
+          },
         })),
       readRunArtifacts: () =>
         Promise.resolve({
@@ -7527,6 +7536,9 @@ Deno.test("parseCfHarnessCliArgs refuses a present --max-confidentiality with no
       () => parseCfHarnessCliArgs(args, { cwd: "/tmp/project", env: {} }),
       Error,
     );
-    assertMatch(err.message, /--max-confidentiality (requires a JSON array|must be JSON)/);
+    assertMatch(
+      err.message,
+      /--max-confidentiality (requires a JSON array|must be JSON)/,
+    );
   }
 });

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -7345,3 +7345,75 @@ Deno.test("parseCfHarnessCliArgs refuses --max-confidentiality without a fabric 
     "--max-confidentiality bounds the fabric session's reads and needs --fabric-api-url, --fabric-identity, and --fabric-space",
   );
 });
+
+Deno.test("a resume whose manifest declares another read ceiling is refused as a structured mismatch", async () => {
+  const buffers = createIoBuffers();
+  let promptLoopsCreated = 0;
+  const recordedManifest = {
+    type: "cf-harness.loom-run-manifest",
+    version: 1,
+    source: "loom",
+    cfc: { maxConfidentiality: ["did:key:zOwner", "did:key:zFacet"] },
+  } as const;
+  const exitCode = await runCfHarnessCli(
+    [
+      "--resume-run",
+      "/tmp/project/.cf-harness-artifacts/run-1/run-state.json",
+      "--run-manifest",
+      "/tmp/loom-run-manifest.json",
+      "--fabric-api-url",
+      "https://toolshed.example/",
+      "--fabric-identity",
+      "keys/agent.pkcs8",
+      "--fabric-space",
+      "my-space",
+    ],
+    {
+      cwd: "/tmp/project",
+      env: { CF_HARNESS_API_KEY: "test-key" },
+      io: buffers.io,
+      structuredHostFailures: true,
+      fabricSessionFactory: () =>
+        Promise.reject(new Error("factory is forwarded, not invoked")),
+      readTextFile: () =>
+        Promise.resolve(JSON.stringify({
+          ...recordedManifest,
+          cfc: { maxConfidentiality: ["did:key:zOwner"] },
+        })),
+      readRunArtifacts: () =>
+        Promise.resolve({
+          runRoot: "/tmp/project/.cf-harness-artifacts/run-1",
+          runStatePath:
+            "/tmp/project/.cf-harness-artifacts/run-1/run-state.json",
+          transcriptPath:
+            "/tmp/project/.cf-harness-artifacts/run-1/transcript.json",
+          runState: {
+            runId: "run-1",
+            status: "failed",
+            createdAt: "2026-04-15T22:10:00.000Z",
+            updatedAt: "2026-04-15T22:10:01.000Z",
+            cfcEnforcementMode: "disabled",
+            currentDir: "/workspace",
+            model: "gpt-5.4",
+            artifactRoot: "/tmp/project/.cf-harness-artifacts/run-1",
+            transcriptPath:
+              "/tmp/project/.cf-harness-artifacts/run-1/transcript.json",
+            policyEvents: [],
+            toolOutputs: [],
+            runManifest: recordedManifest,
+          },
+          transcript: [{ role: "user", content: "Continue." }],
+        }),
+      createPromptLoop: () => {
+        promptLoopsCreated += 1;
+        throw new Error("must not construct a prompt loop");
+      },
+    },
+  );
+  assertEquals(exitCode, 1);
+  assertEquals(promptLoopsCreated, 0);
+  const failure = JSON.parse(buffers.stderr[0]);
+  assertEquals(failure.type, "cf-harness.host-failure");
+  assertEquals(failure.error.code, "provider-mismatch");
+  assertStringIncludes(failure.error.message, "resume read ceiling mismatch");
+});

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -1,4 +1,5 @@
-import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
+import { assertEquals, assertRejects,
+  assertMatch, assertStringIncludes } from "@std/assert";
 import { decodeBase64 } from "@std/encoding/base64";
 import { join } from "@std/path";
 
@@ -7416,4 +7417,37 @@ Deno.test("a resume whose manifest declares another read ceiling is refused as a
   assertEquals(failure.type, "cf-harness.host-failure");
   assertEquals(failure.error.code, "provider-mismatch");
   assertStringIncludes(failure.error.message, "resume read ceiling mismatch");
+});
+
+Deno.test("parseCfHarnessCliArgs refuses a present --max-confidentiality with no value rather than running unbounded", async () => {
+  const fabric = [
+    "--prompt",
+    "hi",
+    "--fabric-api-url",
+    "https://toolshed.example/",
+    "--fabric-identity",
+    "keys/agent.pkcs8",
+    "--fabric-space",
+    "my-space",
+  ];
+  // Bare at the end of the line, bare before another flag, and with an
+  // empty value: each is a ceiling the operator meant to state and did not,
+  // never a run with no ceiling.
+  for (
+    const args of [
+      [...fabric, "--max-confidentiality"],
+      [...fabric, "--max-confidentiality", "--print-transcript"],
+      [...fabric, "--max-confidentiality="],
+      [...fabric, "--max-confidentiality", "   "],
+    ]
+  ) {
+    // Two refusals cover the shapes: the parser reads a bare flag as an
+    // empty string, which the JSON step refuses; a non-string value is
+    // refused before it. Either way the run never starts unbounded.
+    const err = await assertRejects(
+      () => parseCfHarnessCliArgs(args, { cwd: "/tmp/project", env: {} }),
+      Error,
+    );
+    assertMatch(err.message, /--max-confidentiality (requires a JSON array|must be JSON)/);
+  }
 });

--- a/packages/cf-harness/test/config.test.ts
+++ b/packages/cf-harness/test/config.test.ts
@@ -486,6 +486,8 @@ Deno.test("resolveHarnessConfig bounds the fabric session by the run manifest's 
     cfcReadMaxConfidentiality: ["did:key:zOwner", "did:key:zFacet"],
     cfcReadOnExceed: "skip",
     readCeilingSource: "run-manifest",
+    manifestReadMaxConfidentiality: ["did:key:zOwner", "did:key:zFacet"],
+    manifestReadOnExceed: "skip",
   });
 });
 
@@ -637,5 +639,62 @@ Deno.test("resolveHarnessConfig meets onExceed toward the stricter mode", () => 
       skillScriptExecutionTarget: "sandbox",
     }).fabricSession?.cfcReadOnExceed,
     "skip",
+  );
+});
+
+Deno.test("resolveHarnessConfig refuses a resolved session beside a manifest ceiling it did not fold", () => {
+  const session = {
+    apiUrl: "https://toolshed.example/",
+    identityKeyPath: "/keys/agent.pkcs8",
+    space: "my-space",
+  };
+  const manifestWith = (ceiling: string[]) => ({
+    type: "cf-harness.loom-run-manifest" as const,
+    version: 1 as const,
+    source: "loom" as const,
+    cfc: { maxConfidentiality: ceiling },
+  });
+  // A config resolved with no manifest, then handed on beside a manifest
+  // that declares a ceiling: passing it through would run unbounded under a
+  // manifest that asked for a bound.
+  const unbounded = resolveHarnessConfig({
+    fabricSession: session,
+    skillScriptExecutionTarget: "sandbox",
+  }).fabricSession;
+  assertThrows(
+    () =>
+      resolveHarnessConfig({
+        fabricSession: unbounded,
+        runManifest: manifestWith(["did:key:zO"]),
+        skillScriptExecutionTarget: "sandbox",
+      }),
+    Error,
+    "resolved fabric session did not fold the run manifest's read ceiling",
+  );
+  // A config resolved under one manifest, handed on beside another: passing
+  // it through would attest a ceiling the manifest beside it never declared.
+  const underA = resolveHarnessConfig({
+    fabricSession: session,
+    runManifest: manifestWith(["did:key:zO", "did:key:zA"]),
+    skillScriptExecutionTarget: "sandbox",
+  }).fabricSession;
+  assertThrows(
+    () =>
+      resolveHarnessConfig({
+        fabricSession: underA,
+        runManifest: manifestWith(["did:key:zO", "did:key:zB"]),
+        skillScriptExecutionTarget: "sandbox",
+      }),
+    Error,
+    "resolved fabric session did not fold the run manifest's read ceiling",
+  );
+  // The same manifest it folded passes through unchanged.
+  assertEquals(
+    resolveHarnessConfig({
+      fabricSession: underA,
+      runManifest: manifestWith(["did:key:zO", "did:key:zA"]),
+      skillScriptExecutionTarget: "sandbox",
+    }).fabricSession,
+    underA,
   );
 });

--- a/packages/cf-harness/test/config.test.ts
+++ b/packages/cf-harness/test/config.test.ts
@@ -698,3 +698,31 @@ Deno.test("resolveHarnessConfig refuses a resolved session beside a manifest cei
     underA,
   );
 });
+
+Deno.test("resolveHarnessConfig snapshots the run manifest's read ceiling rather than holding it by reference", () => {
+  const ceiling: string[] = ["did:key:zOwner"];
+  const runManifest = {
+    type: "cf-harness.loom-run-manifest" as const,
+    version: 1 as const,
+    source: "loom" as const,
+    cfc: { maxConfidentiality: ceiling },
+  };
+  const config = resolveHarnessConfig({
+    fabricSession: {
+      apiUrl: "https://toolshed.example/",
+      identityKeyPath: "/keys/agent.pkcs8",
+      space: "my-space",
+    },
+    runManifest,
+    skillScriptExecutionTarget: "sandbox",
+  });
+  // The session is built lazily, on the first tool call; a manifest object
+  // mutated in between must not widen what that session is built under.
+  ceiling.push("did:key:zEveryone");
+  assertEquals(config.fabricSession?.cfcReadMaxConfidentiality, [
+    "did:key:zOwner",
+  ]);
+  assertEquals(config.fabricSession?.manifestReadMaxConfidentiality, [
+    "did:key:zOwner",
+  ]);
+});

--- a/packages/cf-harness/test/config.test.ts
+++ b/packages/cf-harness/test/config.test.ts
@@ -485,6 +485,7 @@ Deno.test("resolveHarnessConfig bounds the fabric session by the run manifest's 
     space: "my-space",
     cfcReadMaxConfidentiality: ["did:key:zOwner", "did:key:zFacet"],
     cfcReadOnExceed: "skip",
+    readCeilingSource: "run-manifest",
   });
 });
 
@@ -537,6 +538,7 @@ Deno.test("resolveHarnessConfig leaves a session with no ceiling unbounded when 
     apiUrl: "https://toolshed.example/",
     identityKeyPath: "/keys/agent.pkcs8",
     space: "my-space",
+    readCeilingSource: "none",
   });
 });
 
@@ -554,5 +556,86 @@ Deno.test("resolveHarnessConfig refuses a run manifest read ceiling with no fabr
       }),
     Error,
     "run manifest cfc.maxConfidentiality names a read ceiling for the fabric session's runtime, and the run has no fabric session",
+  );
+});
+
+Deno.test("resolveHarnessConfig folds the run manifest's read ceiling once: a resolved session passes through unchanged", () => {
+  const runManifest = {
+    type: "cf-harness.loom-run-manifest" as const,
+    version: 1 as const,
+    source: "loom" as const,
+    cfc: {
+      maxConfidentiality: [
+        "did:key:zO",
+        { type: "Facet", owner: "did:key:zO", id: "work" },
+      ],
+    },
+  };
+  const parent = resolveHarnessConfig({
+    fabricSession: {
+      apiUrl: "https://toolshed.example/",
+      identityKeyPath: "/keys/agent.pkcs8",
+      space: "my-space",
+      cfcReadMaxConfidentiality: ["did:key:zO", "did:key:zX"],
+    },
+    runManifest,
+    skillScriptExecutionTarget: "sandbox",
+  });
+  // A delegated child is built from its parent's resolved session and the
+  // same manifest; it must record the ceiling its parent's runtime holds,
+  // byte for byte, not a second meet of it.
+  const child = resolveHarnessConfig({
+    fabricSession: parent.fabricSession,
+    runManifest,
+    skillScriptExecutionTarget: "sandbox",
+  });
+  assertEquals(child.fabricSession, parent.fabricSession);
+});
+
+Deno.test("resolveHarnessConfig meets onExceed toward the stricter mode", () => {
+  const session = {
+    apiUrl: "https://toolshed.example/",
+    identityKeyPath: "/keys/agent.pkcs8",
+    space: "my-space",
+  };
+  const manifestWith = (onExceed: "fail" | "skip") => ({
+    type: "cf-harness.loom-run-manifest" as const,
+    version: 1 as const,
+    source: "loom" as const,
+    cfc: { maxConfidentiality: ["did:key:zO"], onExceed },
+  });
+  // A session's `skip` is a wider release than the manifest's `fail`, and
+  // the operator cannot widen what the dispatch declared.
+  assertEquals(
+    resolveHarnessConfig({
+      fabricSession: {
+        ...session,
+        cfcReadMaxConfidentiality: ["did:key:zO"],
+        cfcReadOnExceed: "skip",
+      },
+      runManifest: manifestWith("fail"),
+      skillScriptExecutionTarget: "sandbox",
+    }).fabricSession?.cfcReadOnExceed,
+    "fail",
+  );
+  assertEquals(
+    resolveHarnessConfig({
+      fabricSession: {
+        ...session,
+        cfcReadMaxConfidentiality: ["did:key:zO"],
+        cfcReadOnExceed: "skip",
+      },
+      runManifest: manifestWith("skip"),
+      skillScriptExecutionTarget: "sandbox",
+    }).fabricSession?.cfcReadOnExceed,
+    "skip",
+  );
+  assertEquals(
+    resolveHarnessConfig({
+      fabricSession: session,
+      runManifest: manifestWith("skip"),
+      skillScriptExecutionTarget: "sandbox",
+    }).fabricSession?.cfcReadOnExceed,
+    "skip",
   );
 });

--- a/packages/cf-harness/test/config.test.ts
+++ b/packages/cf-harness/test/config.test.ts
@@ -4,6 +4,7 @@ import { assert, assertEquals, assertExists, assertThrows } from "@std/assert";
 import {
   type CfcEnforcementMode,
   cfcEnforcementStrictness,
+  cfcObservationFitsCeiling,
 } from "@commonfabric/runner/cfc";
 import { presetCfcOptions } from "@commonfabric/runner";
 import {
@@ -458,4 +459,100 @@ Deno.test("resolveHarnessConfig carries a skills.sh discovery registry", () => {
     skillScriptExecutionTarget: "sandbox",
   });
   assertEquals(config.skillsSh, { baseUrl: "https://registry.example/" });
+});
+
+Deno.test("resolveHarnessConfig bounds the fabric session by the run manifest's read ceiling", () => {
+  const config = resolveHarnessConfig({
+    fabricSession: {
+      apiUrl: "https://toolshed.example/",
+      identityKeyPath: "/keys/agent.pkcs8",
+      space: "my-space",
+    },
+    runManifest: {
+      type: "cf-harness.loom-run-manifest",
+      version: 1,
+      source: "loom",
+      cfc: {
+        maxConfidentiality: ["did:key:zOwner", "did:key:zFacet"],
+        onExceed: "skip",
+      },
+    },
+    skillScriptExecutionTarget: "sandbox",
+  });
+  assertEquals(config.fabricSession, {
+    apiUrl: "https://toolshed.example/",
+    identityKeyPath: "/keys/agent.pkcs8",
+    space: "my-space",
+    cfcReadMaxConfidentiality: ["did:key:zOwner", "did:key:zFacet"],
+    cfcReadOnExceed: "skip",
+  });
+});
+
+Deno.test("resolveHarnessConfig meets the run manifest's read ceiling with the session's own", () => {
+  const config = resolveHarnessConfig({
+    fabricSession: {
+      apiUrl: "https://toolshed.example/",
+      identityKeyPath: "/keys/agent.pkcs8",
+      space: "my-space",
+      cfcReadMaxConfidentiality: ["did:key:zA", "did:key:zB"],
+      cfcReadOnExceed: "fail",
+    },
+    runManifest: {
+      type: "cf-harness.loom-run-manifest",
+      version: 1,
+      source: "loom",
+      cfc: {
+        maxConfidentiality: ["did:key:zB", "did:key:zC"],
+        onExceed: "skip",
+      },
+    },
+    skillScriptExecutionTarget: "sandbox",
+  });
+  const ceiling = config.fabricSession?.cfcReadMaxConfidentiality;
+  // Only what both admit fits the result: neither side's ceiling replaced
+  // the other's.
+  assertEquals(cfcObservationFitsCeiling(["did:key:zB"], ceiling), true);
+  assertEquals(cfcObservationFitsCeiling(["did:key:zA"], ceiling), false);
+  assertEquals(cfcObservationFitsCeiling(["did:key:zC"], ceiling), false);
+  // The session's own onExceed stands over the manifest's.
+  assertEquals(config.fabricSession?.cfcReadOnExceed, "fail");
+});
+
+Deno.test("resolveHarnessConfig leaves a session with no ceiling unbounded when the manifest declares none", () => {
+  const config = resolveHarnessConfig({
+    fabricSession: {
+      apiUrl: "https://toolshed.example/",
+      identityKeyPath: "/keys/agent.pkcs8",
+      space: "my-space",
+    },
+    runManifest: {
+      type: "cf-harness.loom-run-manifest",
+      version: 1,
+      source: "loom",
+      cfc: { enforcementMode: "observe" },
+    },
+    skillScriptExecutionTarget: "sandbox",
+  });
+  assertEquals(config.fabricSession, {
+    apiUrl: "https://toolshed.example/",
+    identityKeyPath: "/keys/agent.pkcs8",
+    space: "my-space",
+  });
+});
+
+Deno.test("resolveHarnessConfig refuses a run manifest read ceiling with no fabric session to apply it", () => {
+  assertThrows(
+    () =>
+      resolveHarnessConfig({
+        runManifest: {
+          type: "cf-harness.loom-run-manifest",
+          version: 1,
+          source: "loom",
+          cfc: { maxConfidentiality: ["did:key:zOwner"] },
+        },
+        skillScriptExecutionTarget: "sandbox",
+      }),
+    Error,
+    "run manifest cfc.maxConfidentiality names a read ceiling for the fabric session's runtime, and the run has no fabric session",
+  );
 });

--- a/packages/cf-harness/test/config.test.ts
+++ b/packages/cf-harness/test/config.test.ts
@@ -1,6 +1,7 @@
 import { checkoutDocsCorpusRoots } from "../src/docs-corpus/corpus.ts";
 import { resolveHarnessSkillsRoot } from "../src/skills/root.ts";
 import { assert, assertEquals, assertExists, assertThrows } from "@std/assert";
+import type { CfcConfClause } from "@commonfabric/runner/cfc";
 import {
   type CfcEnforcementMode,
   cfcEnforcementStrictness,
@@ -8,6 +9,7 @@ import {
 } from "@commonfabric/runner/cfc";
 import { presetCfcOptions } from "@commonfabric/runner";
 import {
+  readCeilingsEqual,
   DEFAULT_GATEWAY_BASE_URL,
   DEFAULT_HARNESS_CFC_ENFORCEMENT_MODE,
   fabricSessionCfcEnforcementMode,
@@ -725,4 +727,58 @@ Deno.test("resolveHarnessConfig snapshots the run manifest's read ceiling rather
   assertEquals(config.fabricSession?.manifestReadMaxConfidentiality, [
     "did:key:zOwner",
   ]);
+});
+
+
+Deno.test("readCeilingsEqual is a multiset match with order-insensitive alternatives, never a string compare", () => {
+  const A = "did:key:zA";
+  const B = "did:key:zB";
+  const O = "did:key:zO";
+  assertEquals(readCeilingsEqual([{ anyOf: [A, B] }, O], [O, { anyOf: [B, A] }]), true);
+  assertEquals(readCeilingsEqual([{ anyOf: [A, B] }], [{ anyOf: [A] }]), false);
+  assertEquals(readCeilingsEqual([O], [O, O]), false);
+  assertEquals(readCeilingsEqual(undefined, undefined), true);
+  assertEquals(readCeilingsEqual(undefined, [O]), false);
+  assertEquals(readCeilingsEqual([O], undefined), false);
+});
+
+Deno.test("resolveHarnessConfig refuses a resolved session beside a manifest that dropped its ceiling, and passes through the same ceiling respelled", () => {
+  const session = {
+    apiUrl: "https://toolshed.example/",
+    identityKeyPath: "/keys/agent.pkcs8",
+    space: "my-space",
+  };
+  const manifestWith = (ceiling: CfcConfClause[] | undefined) => ({
+    type: "cf-harness.loom-run-manifest" as const,
+    version: 1 as const,
+    source: "loom" as const,
+    ...(ceiling !== undefined ? { cfc: { maxConfidentiality: ceiling } } : {}),
+  });
+  const underAB = resolveHarnessConfig({
+    fabricSession: session,
+    runManifest: manifestWith([{ anyOf: ["did:key:zA", "did:key:zB"] }]),
+    skillScriptExecutionTarget: "sandbox",
+  }).fabricSession;
+  // Folded under a ceiling, handed on beside a manifest that now declares
+  // none: the config would attest a ceiling this manifest never carried.
+  assertThrows(
+    () =>
+      resolveHarnessConfig({
+        fabricSession: underAB,
+        runManifest: manifestWith(undefined),
+        skillScriptExecutionTarget: "sandbox",
+      }),
+    Error,
+    "resolved fabric session did not fold the run manifest's read ceiling",
+  );
+  // The same ceiling with its alternatives in another order is the same
+  // ceiling: passed through, not refused over spelling.
+  assertEquals(
+    resolveHarnessConfig({
+      fabricSession: underAB,
+      runManifest: manifestWith([{ anyOf: ["did:key:zB", "did:key:zA"] }]),
+      skillScriptExecutionTarget: "sandbox",
+    }).fabricSession,
+    underAB,
+  );
 });

--- a/packages/cf-harness/test/config.test.ts
+++ b/packages/cf-harness/test/config.test.ts
@@ -9,13 +9,13 @@ import {
 } from "@commonfabric/runner/cfc";
 import { presetCfcOptions } from "@commonfabric/runner";
 import {
-  readCeilingsEqual,
   DEFAULT_GATEWAY_BASE_URL,
   DEFAULT_HARNESS_CFC_ENFORCEMENT_MODE,
   fabricSessionCfcEnforcementMode,
   type HarnessConfig,
   parseCfcEnforcementMode,
   parseHarnessGatewayAuthMode,
+  readCeilingsEqual,
   resolveCfcEnforcementMode,
   resolveCfcEnforcementModeSource,
   resolveGatewayAuthMode,
@@ -729,12 +729,14 @@ Deno.test("resolveHarnessConfig snapshots the run manifest's read ceiling rather
   ]);
 });
 
-
 Deno.test("readCeilingsEqual is a multiset match with order-insensitive alternatives, never a string compare", () => {
   const A = "did:key:zA";
   const B = "did:key:zB";
   const O = "did:key:zO";
-  assertEquals(readCeilingsEqual([{ anyOf: [A, B] }, O], [O, { anyOf: [B, A] }]), true);
+  assertEquals(
+    readCeilingsEqual([{ anyOf: [A, B] }, O], [O, { anyOf: [B, A] }]),
+    true,
+  );
   assertEquals(readCeilingsEqual([{ anyOf: [A, B] }], [{ anyOf: [A] }]), false);
   assertEquals(readCeilingsEqual([O], [O, O]), false);
   assertEquals(readCeilingsEqual(undefined, undefined), true);

--- a/packages/cf-harness/test/engine.test.ts
+++ b/packages/cf-harness/test/engine.test.ts
@@ -1718,3 +1718,77 @@ Deno.test("CfHarnessEngine exposes a handle table carried by a resumed run state
 
   assertEquals(resumed.handleTable, table);
 });
+
+Deno.test("CfHarnessEngine records the fabric session's read ceiling in run state and refuses to resume under another", () => {
+  const boundedSession = {
+    apiUrl: "https://toolshed.example/",
+    identityKeyPath: "/keys/agent.pkcs8",
+    space: "my-space",
+    cfcReadMaxConfidentiality: ["did:key:zOwner", "did:key:zFacet"],
+    cfcReadOnExceed: "skip",
+  } as const;
+  const runState = new CfHarnessEngine({
+    workspaceHostPath: "/host/project",
+    fabricSession: boundedSession,
+  }).getRunState();
+  assertEquals(runState.fabricSessionCfc, {
+    enforcementMode: "enforce-explicit",
+    enforcementModeSource: "preset-pin",
+    flowLabels: "off",
+    flowLabelsSource: "default",
+    readMaxConfidentiality: ["did:key:zOwner", "did:key:zFacet"],
+    readOnExceed: "skip",
+    record: recordFor(boundedSession),
+  });
+
+  // The same bounded session resumes cleanly.
+  const resumed = new CfHarnessEngine({
+    workspaceHostPath: "/host/project",
+    fabricSession: boundedSession,
+    runState,
+  });
+  assertEquals(
+    resumed.getRunState().fabricSessionCfc?.readMaxConfidentiality,
+    ["did:key:zOwner", "did:key:zFacet"],
+  );
+
+  // A resume that would run the session unbounded, or under another ceiling,
+  // contradicts what the artifacts attest.
+  assertThrows(
+    () =>
+      new CfHarnessEngine({
+        workspaceHostPath: "/host/project",
+        fabricSession: {
+          apiUrl: boundedSession.apiUrl,
+          identityKeyPath: boundedSession.identityKeyPath,
+          space: boundedSession.space,
+        },
+        runState,
+      }),
+    Error,
+    "fabric session CFC posture mismatch on resume",
+  );
+  assertThrows(
+    () =>
+      new CfHarnessEngine({
+        workspaceHostPath: "/host/project",
+        fabricSession: {
+          ...boundedSession,
+          cfcReadMaxConfidentiality: ["did:key:zOwner"],
+        },
+        runState,
+      }),
+    Error,
+    "fabric session CFC posture mismatch on resume",
+  );
+  assertThrows(
+    () =>
+      new CfHarnessEngine({
+        workspaceHostPath: "/host/project",
+        fabricSession: { ...boundedSession, cfcReadOnExceed: "fail" },
+        runState,
+      }),
+    Error,
+    "fabric session CFC posture mismatch on resume",
+  );
+});

--- a/packages/cf-harness/test/engine.test.ts
+++ b/packages/cf-harness/test/engine.test.ts
@@ -1738,6 +1738,7 @@ Deno.test("CfHarnessEngine records the fabric session's read ceiling in run stat
     flowLabelsSource: "default",
     readMaxConfidentiality: ["did:key:zOwner", "did:key:zFacet"],
     readOnExceed: "skip",
+    readMaxConfidentialitySource: "session",
     record: recordFor(boundedSession),
   });
 
@@ -1791,4 +1792,58 @@ Deno.test("CfHarnessEngine records the fabric session's read ceiling in run stat
     Error,
     "fabric session CFC posture mismatch on resume",
   );
+});
+
+Deno.test("CfHarnessEngine records the same read ceiling in a delegated child as in its parent", () => {
+  const runManifest = {
+    type: "cf-harness.loom-run-manifest" as const,
+    version: 1 as const,
+    source: "loom" as const,
+    cfc: {
+      maxConfidentiality: [
+        "did:key:zO",
+        { type: "Facet", owner: "did:key:zO", id: "work" },
+      ],
+      onExceed: "skip" as const,
+    },
+  };
+  const parent = new CfHarnessEngine({
+    workspaceHostPath: "/host/project",
+    fabricSession: {
+      apiUrl: "https://toolshed.example/",
+      identityKeyPath: "/keys/agent.pkcs8",
+      space: "my-space",
+      cfcReadMaxConfidentiality: ["did:key:zO", "did:key:zX"],
+    },
+    runManifest,
+  });
+  // The shape a delegating parent builds its child with: the parent's
+  // resolved session config beside the shared session factory, and the
+  // same manifest.
+  const child = new CfHarnessEngine({
+    workspaceHostPath: "/host/project",
+    fabricSession: parent.config.fabricSession,
+    fabricSessionFactory: () =>
+      Promise.reject(new Error("never built in this test")),
+    inheritedFabricSessionPosture: parent.getRunState().fabricSessionCfc!
+      .record,
+    runManifest,
+  });
+  const grandchild = new CfHarnessEngine({
+    workspaceHostPath: "/host/project",
+    fabricSession: child.config.fabricSession,
+    fabricSessionFactory: () =>
+      Promise.reject(new Error("never built in this test")),
+    runManifest,
+  });
+  const recorded = parent.getRunState().fabricSessionCfc!;
+  assertEquals(
+    child.getRunState().fabricSessionCfc?.readMaxConfidentiality,
+    recorded.readMaxConfidentiality,
+  );
+  assertEquals(
+    grandchild.getRunState().fabricSessionCfc?.readMaxConfidentiality,
+    recorded.readMaxConfidentiality,
+  );
+  assertEquals(child.getRunState().fabricSessionCfc?.readOnExceed, "skip");
 });

--- a/packages/cf-harness/test/fabric-session.test.ts
+++ b/packages/cf-harness/test/fabric-session.test.ts
@@ -21,6 +21,21 @@ describe("fabric-session", () => {
       expect("cfcEnforcementMode" in options).toBe(false);
       expect("cfcFlowLabels" in options).toBe(false);
       expect("cfcPosture" in options).toBe(false);
+      expect("cfcReadMaxConfidentiality" in options).toBe(false);
+      expect("cfcReadOnExceed" in options).toBe(false);
+    });
+
+    it("carries the read ceiling the config sets, with its onExceed", () => {
+      const options = harnessFabricSessionControllerOptions({
+        ...base,
+        cfcReadMaxConfidentiality: ["did:key:zOwner", "did:key:zFacet"],
+        cfcReadOnExceed: "skip",
+      });
+      expect(options.cfcReadMaxConfidentiality).toEqual([
+        "did:key:zOwner",
+        "did:key:zFacet",
+      ]);
+      expect(options.cfcReadOnExceed).toBe("skip");
     });
 
     it("carries every dial the config sets, posture included", () => {

--- a/packages/cf-harness/test/fabric-session.test.ts
+++ b/packages/cf-harness/test/fabric-session.test.ts
@@ -1,10 +1,34 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import type { PiecesController } from "@commonfabric/piece/ops";
 import {
   cacheHarnessFabricSessionFactory,
+  createHarnessFabricSessionFactory,
   type HarnessFabricSession,
   harnessFabricSessionControllerOptions,
 } from "../src/fabric-session.ts";
+
+const identity = await Identity.fromPassphrase("fabric-session factory");
+
+/** A controller whose runtime reports the given read ceiling. */
+const controllerBoundedBy = (
+  ceiling: {
+    cfcReadMaxConfidentiality?: readonly unknown[];
+    cfcReadOnExceed?: "fail" | "skip";
+  },
+  disposed: string[],
+): PiecesController =>
+  ({
+    runtime: {
+      cfcReadMaxConfidentiality: ceiling.cfcReadMaxConfidentiality,
+      cfcReadOnExceed: ceiling.cfcReadOnExceed,
+      dispose: () => {
+        disposed.push("runtime");
+        return Promise.resolve();
+      },
+    },
+  }) as unknown as PiecesController;
 
 describe("fabric-session", () => {
   describe("harnessFabricSessionControllerOptions()", () => {
@@ -48,6 +72,65 @@ describe("fabric-session", () => {
       expect(options.cfcEnforcementMode).toBe("enforce-strict");
       expect(options.cfcFlowLabels).toBe("persist");
       expect(options.cfcPosture).toBe("max-enforcement");
+    });
+  });
+
+  describe("createHarnessFabricSessionFactory()", () => {
+    const bounded = {
+      apiUrl: "https://toolshed.example/",
+      identityKeyPath: "/keys/agent.pkcs8",
+      space: "my-space",
+      cfcReadMaxConfidentiality: ["did:key:zOwner", "did:key:zFacet"],
+      cfcReadOnExceed: "skip" as const,
+    };
+
+    it("hands the controller the read ceiling and returns the bounded session", async () => {
+      const disposed: string[] = [];
+      let received: Record<string, unknown> | undefined;
+      const factory = createHarnessFabricSessionFactory(bounded, {
+        loadIdentity: () => Promise.resolve(identity),
+        initialize: (options) => {
+          received = options as Record<string, unknown>;
+          return Promise.resolve(controllerBoundedBy(bounded, disposed));
+        },
+      });
+      const session = await factory();
+      expect(received?.cfcReadMaxConfidentiality).toEqual(
+        bounded.cfcReadMaxConfidentiality,
+      );
+      expect(received?.cfcReadOnExceed).toBe("skip");
+      expect(session.identity).toBe(identity);
+      expect(disposed).toEqual([]);
+    });
+
+    it("refuses a session whose runtime is not bounded as configured, and disposes it", async () => {
+      const disposed: string[] = [];
+      const factory = createHarnessFabricSessionFactory(bounded, {
+        loadIdentity: () => Promise.resolve(identity),
+        initialize: () => Promise.resolve(controllerBoundedBy({}, disposed)),
+      });
+      await expect(factory()).rejects.toThrow(
+        /not bounded by the configured read ceiling/,
+      );
+      expect(disposed).toEqual(["runtime"]);
+    });
+
+    it("refuses a session whose runtime is bounded by another ceiling", async () => {
+      const disposed: string[] = [];
+      const factory = createHarnessFabricSessionFactory(bounded, {
+        loadIdentity: () => Promise.resolve(identity),
+        initialize: () =>
+          Promise.resolve(
+            controllerBoundedBy({
+              cfcReadMaxConfidentiality: ["did:key:zOwner"],
+              cfcReadOnExceed: "skip",
+            }, disposed),
+          ),
+      });
+      await expect(factory()).rejects.toThrow(
+        /not bounded by the configured read ceiling/,
+      );
+      expect(disposed).toEqual(["runtime"]);
     });
   });
 

--- a/packages/cf-harness/test/pattern-index/probe-runtime.test.ts
+++ b/packages/cf-harness/test/pattern-index/probe-runtime.test.ts
@@ -1,0 +1,44 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { openProbeRuntime } from "../../src/pattern-index/probe-runtime.ts";
+
+describe("openProbeRuntime()", () => {
+  it("abstains without an identity to act as", async () => {
+    expect(
+      await openProbeRuntime(
+        undefined,
+        new URL("https://toolshed.example/"),
+        "enforce-explicit",
+      ),
+    ).toBeUndefined();
+  });
+
+  it({
+    name: "runs the probe under the session runtime's read ceiling",
+    // The emulated storage reaches SQLite through FFI, which stays loaded
+    // for the process.
+    sanitizeResources: false,
+  }, async () => {
+    const identity = await Identity.fromPassphrase("probe-runtime ceiling");
+    const opened = await openProbeRuntime(
+      identity,
+      new URL("https://toolshed.example/"),
+      "enforce-explicit",
+      {
+        cfcReadMaxConfidentiality: ["did:key:zOwner", "did:key:zFacet"],
+        cfcReadOnExceed: "skip",
+      },
+    );
+    expect(opened).toBeDefined();
+    try {
+      expect(opened!.pieces.runtime.cfcReadMaxConfidentiality).toEqual([
+        "did:key:zOwner",
+        "did:key:zFacet",
+      ]);
+      expect(opened!.pieces.runtime.cfcReadOnExceed).toBe("skip");
+    } finally {
+      await opened!.close();
+    }
+  });
+});

--- a/packages/cf-harness/test/run-manifest.test.ts
+++ b/packages/cf-harness/test/run-manifest.test.ts
@@ -348,29 +348,30 @@ Deno.test("parseLoomRunManifestJson refuses a malformed read ceiling rather than
   const cases: { cfc: unknown; message: string }[] = [
     {
       cfc: { maxConfidentiality: [] },
-      message: "run manifest cfc.maxConfidentiality is empty",
+      message: "run manifest cfc.maxConfidentiality: an empty ceiling admits",
     },
     {
       cfc: { maxConfidentiality: "did:key:zOwner" },
-      message: "run manifest cfc.maxConfidentiality must be a JSON array",
+      message:
+        "run manifest cfc.maxConfidentiality: expected an array of clauses",
     },
     {
       cfc: { maxConfidentiality: ["did:key:zOwner", 7] },
-      message:
-        "run manifest cfc.maxConfidentiality[1] is not a confidentiality clause",
+      message: "run manifest cfc.maxConfidentiality[1]: expected an atom",
     },
     {
       cfc: { maxConfidentiality: [{ anyOf: [] }] },
       message:
-        "run manifest cfc.maxConfidentiality[0] is an OR-clause with no alternatives",
+        "run manifest cfc.maxConfidentiality[0]: an `anyOf` with no alternatives",
     },
     {
       cfc: { maxConfidentiality: ["did:key:zOwner"], onExceed: "drop" },
-      message: "run manifest cfc.onExceed must be fail or skip",
+      message: 'run manifest cfc.onExceed: expected "fail" or "skip"',
     },
     {
       cfc: { onExceed: "skip" },
-      message: "run manifest cfc.onExceed needs a cfc.maxConfidentiality",
+      message:
+        "run manifest cfc.onExceed: qualifies `run manifest cfc.maxConfidentiality`",
     },
   ];
   for (const testCase of cases) {

--- a/packages/cf-harness/test/run-manifest.test.ts
+++ b/packages/cf-harness/test/run-manifest.test.ts
@@ -1,4 +1,5 @@
 import { assertEquals, assertThrows } from "@std/assert";
+import type { CfcConfClause } from "@commonfabric/runner/cfc";
 import { CFC_PROMPT_SLOT_BOUND_ATOM_TYPE } from "../src/contracts/prompt-slot.ts";
 import {
   bindLoomLocalRunManifest,
@@ -305,4 +306,78 @@ Deno.test("bindLoomLocalRunManifest rejects every conflicting caller binding", (
   assertEquals(bound.credentialOwner, binding.credentialOwner);
   owner.ownerKey = "mutated-after-bind";
   assertEquals(bound.credentialOwner?.ownerKey, "local");
+});
+
+const manifestWithCfc = (cfc: unknown): string =>
+  JSON.stringify({
+    type: "cf-harness.loom-run-manifest",
+    version: 1,
+    source: "loom",
+    wishId: "W-2201",
+    cfc,
+  });
+
+Deno.test("parseLoomRunManifestJson carries a read ceiling through normalization", () => {
+  const ceiling: CfcConfClause[] = [
+    "did:key:zOwner",
+    { type: "Facet", owner: "did:key:zOwner", id: "work" },
+    { anyOf: ["did:key:zOwner", "did:key:zOther"] },
+  ];
+  const manifest = parseLoomRunManifestJson(
+    manifestWithCfc({
+      enforcementMode: "enforce-strict",
+      maxConfidentiality: ceiling,
+      onExceed: "skip",
+    }),
+  );
+  assertEquals(manifest.cfc, {
+    enforcementMode: "enforce-strict",
+    maxConfidentiality: ceiling,
+    onExceed: "skip",
+  });
+});
+
+Deno.test("parseLoomRunManifestJson still drops a cfc key it does not know", () => {
+  const manifest = parseLoomRunManifestJson(
+    manifestWithCfc({ enforcementMode: "observe", ceiling: ["did:key:zX"] }),
+  );
+  assertEquals(manifest.cfc, { enforcementMode: "observe" });
+});
+
+Deno.test("parseLoomRunManifestJson refuses a malformed read ceiling rather than dropping it", () => {
+  const cases: { cfc: unknown; message: string }[] = [
+    {
+      cfc: { maxConfidentiality: [] },
+      message: "run manifest cfc.maxConfidentiality is empty",
+    },
+    {
+      cfc: { maxConfidentiality: "did:key:zOwner" },
+      message: "run manifest cfc.maxConfidentiality must be a JSON array",
+    },
+    {
+      cfc: { maxConfidentiality: ["did:key:zOwner", 7] },
+      message:
+        "run manifest cfc.maxConfidentiality[1] is not a confidentiality clause",
+    },
+    {
+      cfc: { maxConfidentiality: [{ anyOf: [] }] },
+      message:
+        "run manifest cfc.maxConfidentiality[0] is an OR-clause with no alternatives",
+    },
+    {
+      cfc: { maxConfidentiality: ["did:key:zOwner"], onExceed: "drop" },
+      message: "run manifest cfc.onExceed must be fail or skip",
+    },
+    {
+      cfc: { onExceed: "skip" },
+      message: "run manifest cfc.onExceed needs a cfc.maxConfidentiality",
+    },
+  ];
+  for (const testCase of cases) {
+    assertThrows(
+      () => parseLoomRunManifestJson(manifestWithCfc(testCase.cfc)),
+      Error,
+      testCase.message,
+    );
+  }
 });

--- a/packages/cf-harness/test/run-pattern-publish-gate.test.ts
+++ b/packages/cf-harness/test/run-pattern-publish-gate.test.ts
@@ -636,6 +636,65 @@ describe("run_pattern publish render gate", () => {
     expect(published(index)).toEqual([]);
   });
 
+  it("opens the render-gate probe under the session runtime's read ceiling", async () => {
+    // The probe reads the same space the session does, so it reads under the
+    // same ceiling; a probe opened unbounded against the live API would be
+    // the leak the ceiling exists to close, through the render path.
+    const boundedManager = StorageManager.emulate({ as: signer });
+    const boundedRuntime = new Runtime({
+      apiUrl: new URL("http://toolshed.test"),
+      storageManager: boundedManager,
+      cfcReadMaxConfidentiality: ["did:key:zOwner", "did:key:zFacet"],
+      cfcReadOnExceed: "skip",
+    });
+    extraRuntimes.push(boundedRuntime);
+    const boundedPieces = new PiecesController(
+      await createSession({
+        identity: signer,
+        spaceName: `publish-gate-bounded-${crypto.randomUUID()}`,
+      }),
+      boundedRuntime,
+    );
+    await boundedPieces.synced();
+    const index = stubIndex();
+    let probeCeiling: unknown = "never opened";
+    try {
+      const engine = new CfHarnessEngine({
+        sandboxRuntime: new FakeSandboxRuntime(),
+        runId: `publish-gate-${crypto.randomUUID()}`,
+        cfcEnforcementMode: "disabled",
+        fabricSessionFactory: () =>
+          Promise.resolve({ pieces: boundedPieces, identity: signer }),
+        patternIndexClientFactory: () =>
+          Promise.resolve(
+            new PatternIndexClient({
+              baseUrl: "https://index.test",
+              fetchFn: index.fetchFn,
+              signer,
+            }),
+          ),
+        openProbeRuntime: (_identity, _apiUrl, _mode, ceiling) => {
+          probeCeiling = ceiling;
+          return Promise.resolve(undefined);
+        },
+      });
+      const result = await engine.invokeBuiltinTool("run_pattern", {
+        sourceText: WORKING_SORTABLE_TABLE,
+        inputs: { rows: [{ name: "Avery", score: 12 }] },
+        description: "Sortable table that reads its cells",
+      });
+      const output = result.output as RunPatternToolSuccessOutput;
+      expect(output.status).toBe("ok");
+      expect(output.patternPublication?.reason).toBe("probe-failed");
+      expect(probeCeiling).toEqual({
+        cfcReadMaxConfidentiality: ["did:key:zOwner", "did:key:zFacet"],
+        cfcReadOnExceed: "skip",
+      });
+    } finally {
+      await boundedManager.close();
+    }
+  });
+
   it("records without a verdict when the probe fails for its own reasons", async () => {
     // No abort: the failure is the probe's, and it is no evidence about the
     // rendering either way. The run still succeeds and the entry is recorded.


### PR DESCRIPTION
> **Base:** #6943 (the runner half) landed as 872ea1014; this PR is rebased onto main and retargeted. Its runner-side dependency is the merged `buildCfcReadCeiling` / `meetCfcObservationCeilings` / `cfcReadMaxConfidentiality` option.

> **Stacked** on `cfc-runtime-read-ceiling` (the runner's runtime-wide read ceiling: `RuntimeOptions.cfcReadMaxConfidentiality` / `cfcReadOnExceed`, `buildCfcReadCeiling`, the `sqliteQuery` meet, per-session result instancing, the `PiecesController.initialize` pass-through). This PR is the cf-harness half only and consumes those exports by name; its base will be retargeted to `main` once that branch's PR lands. Until then the diff view shows only the harness commits.

## Why

Loom dispatches an agent run under a facet — one slice of its owner's data — and can render that facet's read ceiling into the harness prompt. Nothing applies it. `LoomRunManifestCfc` carries posture and labels for a run but no ceiling, and `normalizeLoomRunManifestCfc` is an allowlist projection that silently drops unknown keys, so a `maxConfidentiality` written into a manifest today reads as working while doing nothing. Facet scoping of a run is therefore an instruction the authored pattern must obey, not a gate — and an audit over result-cell labels passes exactly when the leak happened, since an unceilinged summary is unlabeled.

The gap has two halves that only work together: the manifest has to carry the ceiling without dropping it, and the runtime the harness runs the pattern under has to apply it to every `db.query` the run issues, meeting it with whatever the pattern declared rather than replacing it, so a run cannot widen its own ceiling from inside. The runtime half is the base branch. This PR is the harness half: the manifest carries the ceiling, validated; the fabric session's runtime is built under it; run state and the audit surfaces record it; an operator can set it from the command line. The consumer is Loom's connector-CFC-labels arc — commontoolsinc/loom#5450 — which stops rendering the ceiling as a prompt instruction once both land (its `docs/development/projects/connector-cfc-labels/labs-asks.md` §1).

## What changed

**The manifest carries it, validated.** `LoomRunManifestCfc.maxConfidentiality?: readonly CfcConfClause[]` and `onExceed?: "fail" | "skip"`, normalized through the runner's own `buildCfcReadCeiling` (labels naming the manifest fields) rather than dropped: a malformed or empty ceiling refuses the manifest, and `onExceed` without a ceiling is refused.

**The fabric session applies it.** `resolveHarnessConfig` folds the manifest's ceiling into the session config's `cfcReadMaxConfidentiality`, met with any ceiling the session config already carries through `meetCfcObservationCeilings`, so neither Loom's dispatch nor the operator can widen what the other declared; `onExceed` meets toward `fail` on the same terms. The fold happens once: the resolved config (`ResolvedHarnessFabricSessionConfig`, marked by its `readCeilingSource` and carrying the manifest ceiling it folded) passes through a second resolution unchanged when the manifest beside it is the one it folded, and is refused beside any other — or beside a manifest ceiling when it folded none — so a delegated child built from its parent's resolved config and the same manifest records the ceiling its parent's runtime holds, byte for byte, at every delegation level, and no resolved config can run unbounded under a manifest that asked for a bound. A manifest ceiling with no fabric session is refused. The session's controller options thread it to `PiecesController.initialize`, and the session factory checks that the runtime it got back is bounded as asked (`fabricSessionRuntimeBoundedAsConfigured`), disposing and refusing the session otherwise. The render gate's probe runtime inherits the session runtime's ceiling. Run state records the ceiling, its `onExceed`, and its source in `fabricSessionCfc` so a resume under another ceiling, or none, is refused like any other moved dial; a resume handed a `--run-manifest` whose ceiling differs from the recorded one is refused as a structured mismatch, as a differing model or credential owner is. The policy snapshot and every invocation context project the manifest's declaration for the audit, and the operator summary prints the ceiling beside the other session dials.

**Only session-scoped results are governed.** The runtime half applies the ceiling to a query whose result is declared per session (`PerSession<>`, `scope: "session"`, `.asScope("session")`, or a session-scoped db) and refuses any other query under a ceiling before it is staged, since a space-shared result cannot hold one runtime's filtered rows. The README, `CURRENT_STATE.md`, and the `run_pattern` tool description say so; a pattern authored for a bounded run declares its results per session, and a plain `db.query` fails with an error naming the fix. The harness renders no fabric-session posture into the system prompt today, so there is no prompt-side render point to carry the requirement; the tool description is the model-facing surface. Turning the runtime's refusal into a legible tool error is a follow-up.

**`--max-confidentiality <json>`.** The operator form, validated the same way, carried on the session config and met with the manifest's. Refused without a fabric session. It lands on the session config rather than in a synthesized manifest because a `LoomRunManifest` can only say `source: "loom"`, and that field decides credential-owner requirements for a Codex run.

Semantics preserved: absent ceiling is unlimited (the owner view); `[]` is refused at every entry point, never read as no ceiling; a ceiling is a flat clause list and a ceiling-side `anyOf` tightens; `onExceed: "skip"` on an aggregate projection is refused as the builtin has it.

## Test plan

Every behavior change carries a test that failed before the change:

- `packages/cf-harness/test/run-manifest.test.ts`: the ceiling survives normalization; unknown cfc keys are still dropped; `[]`, a non-array, a bad entry, an empty `anyOf`, a bad `onExceed`, and `onExceed` without a ceiling are each refused with a message naming the manifest field.
- `packages/cf-harness/test/config.test.ts`: the manifest ceiling bounds the session; the meet with a session ceiling admits only what both admit (checked by fit, not by bytes, so a manifest-wins or session-wins implementation each fail); no manifest ceiling leaves the session as it was; a manifest ceiling with no session is refused.
- `packages/cf-harness/test/engine.test.ts`: run state records the ceiling; the same session resumes; an unbounded, a differently bounded, and a different-`onExceed` resume are each refused.
- `packages/cf-harness/test/fabric-session.test.ts`: the controller-options pass-through; and, through an injected identity loader and controller initializer, the factory handing the controller the ceiling and refusing (and disposing) a session whose runtime is unbounded or bounded by another ceiling.
- `packages/cf-harness/test/run-pattern-publish-gate.test.ts`: through an injected probe opener, the render gate opens the probe under the session runtime's ceiling.
- `packages/cf-harness/test/cfc-policy-snapshot.test.ts` (new): the manifest's ceiling is projected, and absent when none is declared.
- `packages/cf-harness/test/config.test.ts`, `test/engine.test.ts`: a resolved session config passes through a second resolution unchanged beside the manifest it folded, and is refused beside a manifest ceiling it did not fold (resolved unbounded, or resolved under another manifest); a delegated child and grandchild record their parent's ceiling byte for byte; `onExceed` meets toward `fail` in both directions.
- `packages/cf-harness/test/cli.test.ts`: the flag's parse and its three refusals, and a resume handed a manifest with another ceiling failing as a structured mismatch.
- `test/pattern-index/probe-runtime.test.ts` (new), `test/cfc-invocation-context.test.ts`: the remaining pass-throughs.

Mutation-checked: deleting the factory's bound check, the probe pass-through, or the snapshot projection each reddens its test; the double-fold and the onExceed precedence each reddened before their fix.

Lanes run locally on the stacked branch: `deno task check` at the root (green); `deno lint` on every touched file (clean); `packages/cf-harness` `deno task test` (989 passed, audit tests included); the CFC properties lane as `cfc-properties.yml` runs it — `deno test -A test/cfc-properties/` into one artifact root, then `deno task cfc-audit` over it with `--corpus --expect-refusals --expected-posture audit/profiles/max-enforcement.json --fail-on warn --expected-failures audit/expected-failures.json` (both exit 0); and the root `deno task test` (all 48 packages ok) on the pre-stack revision of the same harness commits.

Not in this PR, named so nobody reads "enforced" over it: the ceiling governs the sqlite read surface (`db.query`) through the session's runtime and the probe runtime. Cell reads through a `--fabric-mount` are governed by the commit-boundary label gates, not by this ceiling. A client under server execution refuses the ceiling (base branch) rather than running silently unbounded. No `withheld` count is emitted on the `skip` path (labs ask 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011nwVm6QJd7tDeXtT5zAqvT

