### PR TITLE
fix(cf-harness): a resumed run says where its mode came from

### DIFF
--- a/packages/cf-harness/src/config.ts
+++ b/packages/cf-harness/src/config.ts
@@ -198,6 +198,13 @@ export interface ResolveHarnessConfigOptions {
   handleValueOrigins?: readonly string[];
   artifactRoot?: string;
   cfcEnforcementMode?: CfcEnforcementMode;
+
+  /**
+   * The mode a run this configuration continues was already at. A resume
+   * passes the mode its run state recorded, which is the mode it goes on
+   * executing at. It outranks a run manifest and the harness default, and
+   * is outranked by anything an operator stated.
+   */
   inheritedCfcEnforcementMode?: CfcEnforcementMode;
   cfcEnforcementModeOverride?: string | CfcEnforcementMode;
   fabricSession?: HarnessFabricSessionConfig;

--- a/packages/cf-harness/src/contracts/cfc-policy-snapshot.ts
+++ b/packages/cf-harness/src/contracts/cfc-policy-snapshot.ts
@@ -16,6 +16,7 @@ import type { BuiltinToolId } from "./tool-descriptor.ts";
 export type HarnessCfcEnforcementModeSource =
   | "override"
   | "explicit-config"
+  /** Carried in from a run this one continues: a resumed run's own mode. */
   | "inherited"
   /** Derived from the mode the run's fabric session enforces at. */
   | "fabric-session"

--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -596,6 +596,11 @@ export class CfHarnessEngine {
             options.credentialOwnerKey,
         }
         : {}),
+      // A resumed run goes on executing at the mode it recorded, so that
+      // mode is what this resolution inherits.
+      ...(options.runState !== undefined
+        ? { inheritedCfcEnforcementMode: options.runState.cfcEnforcementMode }
+        : {}),
       ...(options.runState !== undefined && recordedOwner !== undefined
         ? { credentialOwner: recordedOwner }
         : {}),

--- a/packages/cf-harness/test/prompt-loop.test.ts
+++ b/packages/cf-harness/test/prompt-loop.test.ts
@@ -329,6 +329,51 @@ Deno.test("CfHarnessPromptLoop preserves a resumed Codex model binding at runTra
   assertEquals(modelCalls, 0);
 });
 
+Deno.test("CfHarnessPromptLoop reports a resumed run's recorded enforcement mode as inherited", async () => {
+  // The run recorded a mode the configuration does not restate, and the
+  // recorded mode is the one it goes on executing at. The snapshot names that
+  // mode and attributes it to the run state it came from.
+  const resumedState: HarnessRunState = {
+    runId: "run-resumed-enforcement-posture",
+    status: "failed",
+    createdAt: "2026-09-03T18:00:00.000Z",
+    updatedAt: "2026-09-03T18:00:01.000Z",
+    cfcEnforcementMode: "observe",
+    currentDir: "/workspace",
+    model: "gpt-5.4",
+    modelProvider: "openai-compatible-gateway",
+    policyEvents: [],
+    toolOutputs: [],
+    failureRecords: [],
+  };
+  const engine = new CfHarnessEngine({
+    sandboxRuntime: new FakeSandboxRuntime(),
+    runState: resumedState,
+  });
+  const loop = new CfHarnessPromptLoop({
+    engine,
+    modelClient: {
+      providerId: "openai-compatible-gateway",
+      complete: () =>
+        Promise.resolve({
+          assistant: { role: "assistant", content: "Resumed." },
+        }),
+    },
+  });
+
+  const result = await loop.runPrompt({ prompt: "Continue." });
+
+  assertEquals(engine.config.cfcEnforcementMode, "observe");
+  assertEquals(
+    result.runState.cfcPolicySnapshot?.cfc.enforcementMode,
+    "observe",
+  );
+  assertEquals(
+    result.runState.cfcPolicySnapshot?.cfc.enforcementModeSource,
+    "inherited",
+  );
+});
+
 Deno.test("CfHarnessPromptLoop persists a fresh Codex model selection before the first turn", async () => {
   let selectedModel: string | undefined;
   const loop = new CfHarnessPromptLoop({


### PR DESCRIPTION
A run records its enforcement mode in its run state, and a resume goes on executing at the recorded mode: the sandbox transport floor and the tool policy both read it from there. The resolved configuration worked its own mode out from the configuration alone, which on a resume that restates nothing falls through to the harness default.

So a resumed run that recorded `observe` resolved `enforce-explicit`, and the policy snapshot contradicted itself. The snapshot takes its mode from the run state and the source of that mode from the resolved configuration, so it named `observe` and attributed it to a `default` that could not have produced `observe`. An audit reading the snapshot is told that nobody chose the mode the run is at.

The resume now passes the recorded mode to the resolver as the inherited one. The resolver already ranks an inherited mode ahead of a run manifest and ahead of the default, and behind anything an operator stated, so the resolved mode becomes the recorded one and the snapshot says `inherited`.

Nothing enforces off the resolved configuration's mode on a resume, so this changes what the run reports rather than what it does. The new test resumes a run state recording `observe` with no mode in the configuration, and asserts that `observe` reaches the snapshot sourced `inherited`.

The `inheritedCfcEnforcementMode` option and the `inherited` source member had no caller outside the tests until now. The option was declared, ranked by the resolver, and exported through a versioned artifact contract, with nothing setting it, and neither carried any documentation. Both now say what they mean, beside siblings that already do.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6946?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

