### PR TITLE
docs: three loose ends left by the browser-process wait

### DIFF
--- a/packages/deno-web-test/README.md
+++ b/packages/deno-web-test/README.md
@@ -97,13 +97,17 @@ which the crash handler and the rendering processes outlive.
 
 The harness spawns Chrome itself and attaches astral to the running browser with
 `connect()`. Every process Chrome starts inherits the two pipes the browser was
-spawned with, so their read ends reach end of file once the last of them has
-exited, and spawning the browser here is what keeps those pipes in reach. Both
-are read to the end: what a browser writes says nothing the run acts on, but a
-pipe nobody reads fills up and stops the process writing into it. Closing the
-browser returns on that end of file, and the removal follows. The spawning and
-the wait are [`BrowserProcess`](../integration/browser-process.ts), which the
-browser integration tests use for the same reason.
+spawned with, and holds a pipe until it exits or closes that pipe, so spawning
+the browser here is what keeps those pipes in reach. The wait is for the read
+ends of both to reach end of file, which is once the last process holding either
+of them has gone, whichever of the two it held. Piping standard output as well
+keeps what the browser writes out of the harness's own output, which a spawn
+leaves inherited for any stream it asks no pipe for. Both pipes are read to the
+end rather than left alone, because a pipe nobody reads fills up and stops the
+process writing into it, and what a browser writes says nothing the run acts on.
+Closing the browser returns on that end of file, and the removal follows. The
+spawning and the wait are [`BrowserProcess`](../integration/browser-process.ts),
+which the browser integration tests use for the same reason.
 
 ## Support
 

--- a/packages/deno-web-test/test/browser.test.ts
+++ b/packages/deno-web-test/test/browser.test.ts
@@ -1,7 +1,10 @@
 import { assertEquals, assertRejects } from "@std/assert";
 
 import type { LaunchOptions } from "@astral/astral";
-import type { BrowserProcess } from "@commonfabric/integration/browser-process";
+import {
+  BOOT_FAILURE_MESSAGE,
+  type BrowserProcess,
+} from "@commonfabric/integration/browser-process";
 
 import { isRetryableAstralLaunchError, launchWithRetry } from "../browser.ts";
 
@@ -13,16 +16,12 @@ Deno.test("isRetryableAstralLaunchError matches transient browser-launch failure
     true,
   );
   assertEquals(
-    isRetryableAstralLaunchError(
-      new Error("Your binary refused to boot"),
-    ),
+    isRetryableAstralLaunchError(new Error(BOOT_FAILURE_MESSAGE)),
     true,
   );
   assertEquals(
     isRetryableAstralLaunchError(
-      new Error(
-        "Your binary refused to boot due to missing system dependencies",
-      ),
+      new Error(`${BOOT_FAILURE_MESSAGE} due to missing system dependencies`),
     ),
     false,
   );

--- a/packages/deno-web-test/test/temporary-directories.test.ts
+++ b/packages/deno-web-test/test/temporary-directories.test.ts
@@ -3,13 +3,17 @@
  *
  * The run is given a `TMPDIR` of this test's own, and does not have it to
  * itself: Chrome writes its own scratch files into the directory `TMPDIR`
- * names and leaves some of them behind, files and directories alike, and its
- * crash handler, zygote, and GPU processes are re-parented when the browser
- * process goes, so more can land there after the run has ended and a run that
- * has ended cannot be waited for. What the run makes for itself carries the
- * prefix `Manifest.create()` gives it, and the assertion reads that.
- * `manifest.test.ts` is what pins the prefix onto the directory, so that a run
- * making no such directory would fail there rather than pass silently here.
+ * names and leaves some of them behind, files and directories alike. What the
+ * run makes for itself carries the prefix `Manifest.create()` gives it, and
+ * that prefix is what the assertion reads rather than the directory being
+ * empty. `manifest.test.ts` is what pins the prefix onto the directory, so
+ * that a run making no such directory would fail there rather than pass
+ * silently here.
+ *
+ * `BrowserProcess.close()` returns once every process holding the browser's
+ * output pipes has gone, and the run closes the browser before it returns.
+ * Nothing the run started is writing into the directory while it is read
+ * below.
  */
 
 import { describe, it } from "@std/testing/bdd";

--- a/packages/integration/browser-process.ts
+++ b/packages/integration/browser-process.ts
@@ -10,9 +10,12 @@
  * `Deno.ChildProcess.status` covers one process.
  *
  * Every process in the tree inherits the two pipes the browser was spawned
- * with, so their read ends reach end of file once the last of them has
- * exited. The browser is spawned here and astral attached to the running
- * browser, which is what keeps those pipes in reach.
+ * with, and holds a pipe until it exits or closes that pipe. Both read ends
+ * are waited for, so the wait ends once the last process holding either of
+ * them has gone. Piping both also keeps the browser's output out of the
+ * caller's own, which a spawn leaves inherited for any stream it asks no pipe
+ * for. The browser is spawned here and astral attached to the running browser,
+ * which is what keeps those pipes in reach.
  */
 
 import {

--- a/packages/integration/test/browser-process.test.ts
+++ b/packages/integration/test/browser-process.test.ts
@@ -14,6 +14,7 @@ import { expect } from "@std/expect";
 import { afterEach, describe, it } from "@std/testing/bdd";
 
 import {
+  BOOT_FAILURE_MESSAGE,
   BrowserProcess,
   readToEnd,
   stopBrowserProcess,
@@ -223,7 +224,7 @@ describe("browser-process", () => {
           const options = await fakeBrowser("no endpoint", 1);
 
           await expect(BrowserProcess.start(options)).rejects.toThrow(
-            "Your binary refused to boot",
+            BOOT_FAILURE_MESSAGE,
           );
         });
 
@@ -256,7 +257,7 @@ describe("browser-process", () => {
           // A launch that left standard output unread would stop here, with
           // the stand-in blocked on a pipe nobody is emptying.
           await expect(BrowserProcess.start(options)).rejects.toThrow(
-            "Your binary refused to boot",
+            BOOT_FAILURE_MESSAGE,
           );
         });
 
@@ -265,7 +266,7 @@ describe("browser-process", () => {
           astralBinaryPathIs(options.path);
 
           await expect(BrowserProcess.start({ args: options.args })).rejects
-            .toThrow("Your binary refused to boot");
+            .toThrow(BOOT_FAILURE_MESSAGE);
         });
 
         it("throws when the launch names no `--user-data-dir`", async () => {


### PR DESCRIPTION
Three things the change that landed the browser-process wait left behind, each independent of the others. None of them changes behavior.

## The comment describing the system as it was

The header of
`packages/deno-web-test/test/temporary-directories.test.ts` told the reader that Chrome's crash handler, zygote, and GPU processes are re-parented when the browser process goes, so more files can land in the temporary directory after the run has ended, and that a run which has ended cannot be waited for. That described the harness the test was written against. `BrowserProcess.close()` returns once every process holding the browser's output pipes has gone, and `Runner.run()` closes the browser in a `finally`, so the claim is false now.

That comment is also the only account a reader gets of why the test looks for a name prefix rather than for the directory being empty, so the reason it carries has to survive the correction. The reason is the other half of the same sentence, and it still holds: Chrome writes its own scratch files into the directory `TMPDIR` names and leaves some of them behind. What is left is platform-dependent. The first continuous-integration run of the branch that added this test found three entries on Linux, two files and a directory, each named for Chrome; four runs on macOS while writing this change left the directory empty, matching what was measured there before. So the assertion reads only for the prefix `Manifest.create()` gives the run's own directory, and what Chrome leaves decides nothing.

The header states that reason once, and adds a paragraph for the wait. That paragraph names what the code names, every process holding the browser's output pipes, rather than naming Chrome's helper processes, since which of those hold a pipe is not something anything here establishes.

## The retry message, spelled out again in the tests

`BOOT_FAILURE_MESSAGE` is the message a launch throws when the browser exited without naming a developer-tools endpoint.
`isRetryableAstralLaunchError()` compares against it to decide whether a failed launch is worth another attempt, and the throw and the comparison already read the one constant, so a reworded message cannot stop the retry silently. Five spellings of the literal remained, across two test files. Both files now read the constant.

`packages/integration/test/browser-process.test.ts` drives `BrowserProcess.start()` against stand-ins for a browser and asserts on the rejection. What those assertions are for is telling one rejection from the others the same call produces: the missing-dependency variant, a protocol version astral does not speak, a launch naming no `--user-data-dir`. Naming the constant says which of them is expected.

`packages/deno-web-test/test/browser.test.ts` pins the boundary `isRetryableAstralLaunchError()` draws: the message on its own is worth another attempt, and the message followed by "due to missing system dependencies" is not. Building both cases from the constant is what states that boundary.

What this gives up is that a rewording no longer fails a test. Nothing depends on the wording. Astral's `launch()`, which the message was taken from, is on no path any more, since `Browser.launch()` and the deno-web-test harness both start their browser through `BrowserProcess`, and no caller matches on the message except through the constant. It also leaves the non-retryable case stronger rather than weaker. Written as a literal, that case asserts `false`, and any string that stopped matching would still yield `false`, so a reworded message would leave it passing while covering nothing.

## Both of the browser's pipes

`spawnBrowser()` pipes the browser's standard output and standard error and waits for the read ends of both to reach end of file. Waiting for one of the two would report the same moment given that every process in the tree holds both until it exits, and that premise is the part nothing here establishes. It is a claim about which descriptors Chrome's crash handler, zygote, and GPU processes keep open, and nothing measured for this tree says whether one of them ever keeps one pipe and closes the other. What rests on the answer is the removal of the profile directory, which follows the wait: a process the wait missed is a process that can put the directory back after it has gone. Waiting for both ends once the last process holding either of them has gone, so the removal does not rest on the premise at all.

Piping both also decides where the browser's own output goes. Deno leaves a stream inherited for a spawn that asks no pipe for it, so a standard output left unpiped would be the caller's. For the test harness that is the stream its reporter writes and its own tests parse, and a browser writing into it would be read as harness output.

So the two pipes stay. The module header of
`packages/integration/browser-process.ts` states both of these, and so does "The browser's lifetime" in `packages/deno-web-test/README.md`, which is the live document for the wait and carried only the half about a pipe nobody reads filling up.

## Verification

`deno fmt --check`, `deno lint`, and `deno check` on the touched files are clean, as are the `check-skill-facts`, `check-command-docs`, `check-no-waitfor`, `check-conflict-markers`, and
`check-control-characters` gates. `packages/deno-web-test` and `packages/integration` both pass with `HEADLESS=1`, at 38 and 61 tests. Weakening the equality in `isRetryableAstralLaunchError()` to a containment check fails the missing-dependency case, which expects false and gets true, so that case is not passing vacuously.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6947?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

