### PR TITLE
fix(cf-harness): only a stated session dial raises the loop

### DIFF
--- a/packages/cf-harness/src/config.ts
+++ b/packages/cf-harness/src/config.ts
@@ -258,11 +258,12 @@ const statedCfcEnforcementMode = (
 /**
  * Whether the session's dial decides this run's harness dial.
  *
- * Only `enforce-strict` does. The session's preset pins `enforce-explicit`
- * whether an operator asked for it or not, and a harness loop deliberately run
- * weaker than that pin is an ordinary configuration; a loop left weaker than a
- * session an operator raised to strict is the pair nobody stated, and the one
- * an audit reads as an enforcing run that did not enforce.
+ * Only an operator naming `enforce-strict` on the session does. The session's
+ * preset pins a rung whether an operator asked for it or not, and a harness
+ * loop deliberately run weaker than the pin is an ordinary configuration; a
+ * loop left weaker than a session an operator raised to strict is the pair
+ * nobody stated, and the one an audit reads as an enforcing run that did not
+ * enforce.
  */
 const fabricSessionRaisesCfcEnforcement = (
   options: Pick<
@@ -277,7 +278,7 @@ const fabricSessionRaisesCfcEnforcement = (
   if (options.fabricSession === undefined) {
     return undefined;
   }
-  const session = fabricSessionCfcEnforcementMode(options.fabricSession);
+  const session = options.fabricSession.cfcEnforcementMode;
   if (session !== "enforce-strict") {
     return undefined;
   }

--- a/packages/cf-harness/test/config.test.ts
+++ b/packages/cf-harness/test/config.test.ts
@@ -1,10 +1,15 @@
 import { checkoutDocsCorpusRoots } from "../src/docs-corpus/corpus.ts";
 import { resolveHarnessSkillsRoot } from "../src/skills/root.ts";
-import { assertEquals, assertThrows } from "@std/assert";
-import type { CfcEnforcementMode } from "@commonfabric/runner/cfc";
+import { assert, assertEquals, assertExists, assertThrows } from "@std/assert";
+import {
+  type CfcEnforcementMode,
+  cfcEnforcementStrictness,
+} from "@commonfabric/runner/cfc";
+import { presetCfcOptions } from "@commonfabric/runner";
 import {
   DEFAULT_GATEWAY_BASE_URL,
   DEFAULT_HARNESS_CFC_ENFORCEMENT_MODE,
+  fabricSessionCfcEnforcementMode,
   type HarnessConfig,
   parseCfcEnforcementMode,
   parseHarnessGatewayAuthMode,
@@ -201,6 +206,52 @@ Deno.test("resolveCfcEnforcementMode follows a fabric session raised to strict",
       cfcEnforcementModeOverride: "observe",
     }),
     "observe",
+  );
+});
+
+Deno.test("resolveCfcEnforcementMode leaves the loop alone under a session nobody stated a mode on", () => {
+  const unstatedSession = {
+    apiUrl: "https://fabric.test",
+    identityKeyPath: "/keys/identity.pkcs8",
+    space: "demo",
+  };
+
+  // The session enforces at whatever rung its preset pins, and that rung is
+  // not an operator raise: a loop weaker than the pin is what every run that
+  // states neither dial is. The loop keeps its own default and names it,
+  // whatever `fabricSessionCfcEnforcementMode` reports the session to be at.
+  assertEquals(
+    resolveCfcEnforcementMode({ fabricSession: unstatedSession }),
+    DEFAULT_HARNESS_CFC_ENFORCEMENT_MODE,
+  );
+  assertEquals(
+    resolveCfcEnforcementModeSource({ fabricSession: unstatedSession }),
+    "default",
+  );
+});
+
+Deno.test("the harness loop's own default matches the rung an unstated fabric session enforces at", () => {
+  const unstatedSession = {
+    apiUrl: "https://fabric.test",
+    identityKeyPath: "/keys/identity.pkcs8",
+    space: "demo",
+  };
+
+  // The rung a session nobody stated a dial on runs at, read from the runner's
+  // preset rather than from anything this package writes down.
+  const pinned = presetCfcOptions({}).cfcEnforcementMode;
+  assertExists(pinned, "the session runtime preset pins no enforcement mode");
+
+  assertEquals(
+    fabricSessionCfcEnforcementMode(unstatedSession),
+    pinned,
+    "`fabricSessionCfcEnforcementMode` restates the rung `presetCfcOptions` pins, and the two have parted; move the fallback in `config.ts` to the rung the preset now pins",
+  );
+
+  assert(
+    cfcEnforcementStrictness(DEFAULT_HARNESS_CFC_ENFORCEMENT_MODE) >=
+      cfcEnforcementStrictness(pinned),
+    `the harness loop defaults to ${DEFAULT_HARNESS_CFC_ENFORCEMENT_MODE} while an unstated fabric session enforces at ${pinned}, so a run stating neither dial enforces less than the session it writes through, which AUD-15 fails; raise DEFAULT_HARNESS_CFC_ENFORCEMENT_MODE to the pinned rung`,
   );
 });
 


### PR DESCRIPTION
The harness loop's enforcement dial follows the fabric session's when an operator raised the session to `enforce-strict`. A loop weaker than a session someone deliberately raised is the pair nobody stated, and the one an audit reads as an enforcing run that did not enforce.

The rule read the mode the session resolves to rather than the mode an operator stated on it. Those are different, because the session's preset pins a rung whether anyone asked for it or not, so a session nobody stated a mode on resolves to the pin. A pin is not an operator raise. Reading the resolved mode makes every run that states neither dial look like the dangerous pair: it would pull such a loop silently up to the session's rung, and it would refuse outright any run that deliberately states a weaker loop dial, naming a flag that run never set. The rule now reads the stated dial.

`fabricSessionCfcEnforcementMode` still answers what the session enforces at, pin included, which is what a run records as the session's posture. That is the wrong question for this rule.

Reading the stated dial also takes the rule off a constant it does not own. The pin belongs to `presetCfcOptions` in the runner, and cf-harness restates it in that fallback. A safety branch hanging off a restatement fails open the moment the two part.

AUD-15 is where "the loop must not be weaker than its session" belongs, and it cannot fire today: the check needs a `default`-sourced mode weaker than the session's claim, and no combination of dials on a fresh run reaches that pair. The old reading is part of why. Under it, a run that stated neither dial was pulled up to the session's rung and its source relabelled `fabric-session`, so the check returned not-applicable: the run was changed rather than reported. Under this one the loop keeps its own default and its `default` source, so the check has something to say once the pin moves.

This is behavior-preserving while the pin sits below strict, since a session nobody stated a mode on then resolves to a rung the rule ignores either way. No test can distinguish the two readings today. It stops being behavior-preserving the moment the pin moves, which is what makes it worth landing before then.

Two tests state what that move would break. The first is the invariant this reading rests on: a session nobody stated a mode on leaves the loop at its own default, sourced `default` rather than `fabric-session`. Reverting this change and moving the pin to `enforce-strict` fails it, and fails the neighbouring case that states a weaker loop dial by refusing it.

The second pins the pairing that makes the first safe: the loop's own default sits no lower than the rung an unstated session enforces at. It reads that rung from `presetCfcOptions` rather than from cf-harness's restatement of it, so it also catches the restatement going stale. Raising the runner's pin alone fails it, raising the restatement alone fails it, lowering the harness default alone fails it, and moving all three together leaves it green.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6948?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

