### PR TITLE
fix(test-selection): resolve a manifest by when the store created it

### DIFF
--- a/docs/plans/pull-request-test-selection.md
+++ b/docs/plans/pull-request-test-selection.md
@@ -1936,9 +1936,11 @@ failure path where the request is refused. It is also the same value on a
 workstation as in a job, so `plan --dry-run` answers the question a lane
 would answer instead of resolving against the clock. And it is the better
 anchor on its own terms: the manifest worth reading is the one that was
-current when the tree under test came into being. The committer date
-rather than the author's, because a rebased or cherry-picked commit keeps
-the date it was first written.
+current when the tree under test came into being.
+
+The committer date rather than the author date. A rebased or
+cherry-picked commit keeps the author date it was first written at, which
+can be arbitrarily old, while the committer date moves with the tree.
 
 ## What the census can project
 
@@ -2017,14 +2019,19 @@ labs/test-selection/v1/state/<yyyy-mm-dd>-<ULID>.json.gz
 Write-once naming is not a stylistic choice: the store's writer
 credentials hold `objectCreator` and nothing else, cannot overwrite, and
 that is the property that makes the whole store trustworthy. So there is
-no `current.json`. The leading timestamp keeps object names
-chronologically useful, but it does not decide publication order. When a
-lane resolves a manifest, it lists object metadata once and takes the
-newest object generated at or before the commit under test, using the
-object name to break a tie. A manifest published while the run is going
-is generated after that date, so it cannot change the answer, and every
-lane and every later attempt reads the same commit and reaches the same
-object. What the answer does depend on is retention: the manifests a
+no `current.json`. The timestamp leading an object's name is the moment
+its publisher started, and it keeps a listing chronologically readable
+without deciding what a resolution compares. When a lane resolves a
+manifest, it lists once and takes the newest object the store had created
+at or before the commit under test, using the full object name to break a
+tie between two created in the same instant. The creation time rather than
+the name, because the publisher names its manifest at the start of a run
+that creates the object at the end, and a lane listing inside that gap
+would otherwise disagree with one listing after it. Every lane and every
+later attempt reads the same commit, and a manifest the store creates
+while the run is going is created after that date and cannot change the
+answer. [The specification](../specs/test-selection.md#determinism) says
+what a commit dated ahead of the store's clock costs. What the answer does depend on is retention: the manifests a
 commit can resolve have to outlive the window in which that run may be
 re-run, which is a retention setting on the bucket rather than anything
 this reads.
@@ -2921,7 +2928,7 @@ is pinned to the commit's date. And if none of that settles it,
 
 | What goes wrong | What happens |
 | --- | --- |
-| The store is unreachable from a lane | The lane runs the mandatory set plus a deterministic slice of the corpus sized to its budget, prints that it is running unselected, and passes or fails on that. Pull requests keep flowing. |
+| The store is unreachable from a lane | The lane reads its share from the tree instead. Nothing has records, so the whole corpus is mandatory and the lanes divide it between them, printing that they are running everything. Pull requests keep flowing, and slower. |
 | The publisher has not run for a day | Lanes use the last manifest. Selection quality decays slowly; nothing fails. |
 | The manifest is malformed or a newer schema | Rejected whole, treated as absent, same path as unreachable. |
 | A selected item no longer exists in the tree | Dropped with a line in the summary. A renamed test is simultaneously an unknown item, so it runs anyway. |
@@ -3252,10 +3259,10 @@ dispatch, not days.
 
 Pull requests in that window are already handled. A lane that finds no
 manifest takes the same path as a lane that cannot reach the store: it
-runs the mandatory set plus a deterministic slice of the corpus sized to
-its budget, and prints that it is running unselected. Feedback is weaker
-than selection for one afternoon and no worse than a coin toss about which
-tests run, which is what the old shard layout was anyway.
+nothing has records, so every unit the tree holds is an identity with none
+and the whole corpus is mandatory. The lanes divide it between them and
+print that they are running everything. Feedback costs the time selection
+would have saved for one afternoon, and it misses nothing.
 
 The calibration numbers converge over the days after that, from the lanes'
 own timing records, which is what they were always going to do.

--- a/docs/plans/pull-request-test-selection.md
+++ b/docs/plans/pull-request-test-selection.md
@@ -3258,7 +3258,7 @@ selection have data. That window is one `main` run and one manual
 dispatch, not days.
 
 Pull requests in that window are already handled. A lane that finds no
-manifest takes the same path as a lane that cannot reach the store: it
+manifest takes the same path as a lane that cannot reach the store:
 nothing has records, so every unit the tree holds is an identity with none
 and the whole corpus is mandatory. The lanes divide it between them and
 print that they are running everything. Feedback costs the time selection

--- a/docs/specs/test-records.md
+++ b/docs/specs/test-records.md
@@ -189,28 +189,31 @@ test-selection publisher rather than by anything recording:
 ```
 <repo>/test-selection/v1/manifest-<ISO 8601 timestamp>-<ULID>.json.gz
 <repo>/test-selection/v1/state/<yyyy-mm-dd>-<ULID>.json.gz
-<repo>/test-selection/v1/pins/<workflow-run-id>.json.gz
 ```
 
-The leading timestamp keeps manifest names chronologically useful, but it
-does not decide publication order. A workflow without a manifest pin lists
-object metadata once on its first attempt, chooses the object with the
-newest server-assigned `timeCreated`, using the object name to break a tie,
-and stores its exact object name, generation, and validated contents in a
-create-only run pin. The generation is a canonical digits-only decimal
-string, not a JSON number. An empty or failed listing stores an explicit
-unselected result. An absent pin on a later attempt also produces
-unselected rather than another listing. Pin retention exceeds the full
-workflow rerun period. Readers and later workflow attempts use the embedded
-result rather than resolving "newest" or depending on source-manifest
-retention. There is no object name meaning "the current one": writers hold
+The timestamp leading a manifest's name is the moment its publisher
+generated it, which keeps a listing chronologically readable but is not
+what a reader compares. A publisher names its manifest when it starts and
+creates the object when it finishes, so a reader takes the newest object
+the store had created at or before the moment it is resolving for, using
+the full object name to break a tie between two created in the same
+instant. There is no object name meaning "the current one": writers hold
 create and nothing else, so nothing can be overwritten, and that is the
 property the whole store rests on.
+[The selection spec](test-selection.md#determinism) says which moment a
+consumer resolves for and why.
+
+The selection area is the one part of this store that expires. A bucket
+lifecycle rule deletes its objects at a fixed age, and that age has to
+exceed the window in which a continuous-integration run may still be
+re-run, because a re-run resolves the same moment as the attempt it
+repeats and has to find the same manifest. Records carry no retention and
+must not acquire one.
 
 A local object's date partition comes from its run's start. The CI relay
 currently takes the date from the workflow run's `run_started_at`. That
 field is the current attempt's start and GitHub advances it when another
-attempt starts. Re-shipping an earlier artifact after a rerun can therefore
+attempt starts. Re-shipping an earlier artifact after a re-run can therefore
 move it to the new attempt's date and create a second object instead of
 colliding with its first shipment.
 

--- a/docs/specs/test-selection.md
+++ b/docs/specs/test-selection.md
@@ -257,36 +257,67 @@ same for both. A consumer that packs the two runs through different code
 will drift, and what it drifts into is running different sets of tests in
 the two places that are meant to agree.
 
-Before the lanes start, a selector calls a trusted reusable workflow by its
-default-branch ref. The reusable workflow checks out no repository code and
-has a Workload Identity credential with create-only access restricted to
-the pin prefix. The identity condition also requires the Labs repository's
-immutable GitHub `repository_id`, so another repository cannot invoke the
-workflow to obtain the credential. The reusable workflow derives the
-repository and workflow run id from GitHub's trusted context, not caller
-inputs. It recovers the public create-only object for that run id. On the
-first attempt only, no pin makes it list the public manifest objects once,
-choose the object with the newest server-assigned storage creation time,
-and create a compressed envelope containing the selected object's name,
-generation, and complete validated manifest. A failed or empty listing
-creates an explicit unselected envelope. No pin on a later attempt also
-creates unselected instead of selecting again.
+Every lane has to resolve the same manifest, and so does every later
+attempt of the same run. A lane resolves the newest manifest generated at
+or before the moment the commit under test was made, reading the committer
+date out of its own checkout.
 
-Pin retention exceeds the full workflow rerun period. Embedding the
-manifest makes source-manifest deletion irrelevant. The selector completes
-successfully only after a valid selected or unselected pin exists. If it
-cannot read an existing pin or create a new one, it fails and dependent
-lanes do not start. Pull-request jobs have no credential that can write or
-replace pin objects.
+What that moment has to be is stable rather than exact. Nothing the
+scheduling service reports about when a run happened is stable, because it
+reports a start per attempt rather than per run, and an attempt resolving
+at its own start would pack the lanes differently from the attempt it
+repeats. The commit is stable by construction, and it needs nothing from
+that service: no credential, no request, and no failure path where a
+request is refused. It is also the same value on a workstation as in a
+job, so a dry run answers the question a lane would answer.
 
-A pin is untrusted input when read. Its workflow run id must match the
-reader. A selected pin must carry a source name under the trusted manifest
-prefix, an object generation encoded as a canonical digits-only decimal
-string, and a manifest that passes the normal whole-object validation. The
-generation is never coerced to a JavaScript number. Any mismatch rejects
-the pin.
+The committer date rather than the author date. A rebased or cherry-picked
+commit keeps the author date it was first written at, which can be
+arbitrarily old, while the committer date moves with the tree.
 
-The workflow run id is stable across attempts. A later attempt with its pin
-available therefore runs the same set rather than resolving newest again.
-A missing later pin deliberately creates an unselected result. Neither path
-depends on an ordering between GitHub's clock and Cloud Storage's clock.
+Resolution lists the manifests once and takes the newest the store had
+created at or before the moment, breaking a tie between two created in the
+same instant with the full object name. What it compares is the creation
+time the store assigns, not the timestamp leading the object's name. The
+two are different moments: a publisher names its manifest from the moment
+it started and creates the object when it finishes, so the name carries a
+moment at which the object was not yet there to be read. A listing that
+will not say when it created an object fails rather than standing a value
+in, and the lane goes on with no manifest.
+
+That difference is what keeps the eligible set closed. Every manifest is
+created at a real moment, and the lanes list after the commit was made, so
+by the time any lane lists, no manifest that the store had not already
+created can ever become eligible. Ordering on the name instead would leave
+a manifest whose publisher is still running eligible before it exists: a
+lane listing during that gap and a lane listing after it would resolve
+different manifests and pack the corpus differently.
+
+Two clocks still meet in the comparison, one on the machine that writes
+the commit and one in the store. A commit dated behind the store's clock
+resolves an older manifest than the tree deserves, which costs selection
+quality and nothing else. A commit dated ahead of it reopens the window
+above, because manifests created between the real moment and that date are
+eligible while the lanes are listing. What bounds that is where the
+committer date comes from: a lane resolving against a
+provider-generated merge commit is comparing the continuous-integration
+provider's clock against the store's. A branch commit authored on a
+workstation whose clock runs far enough ahead is what escapes the bound.
+
+One condition outside this repository has to hold. The manifests a commit
+can resolve have to outlive the window in which the scheduling service
+still permits that run to be re-run, which is a lifecycle rule on the
+bucket rather than anything a reader controls. Where the re-run window is
+the longer of the two, the retention is what to raise.
+
+A lane that resolves no manifest still agrees with its siblings, because
+what it packs is decided by the tree rather than by what it failed to
+read. Nothing has records in that state, so every unit the tree holds is
+an identity with none and the whole corpus is mandatory. The lanes divide
+that between them and say what they are doing.
+
+A consumer with no commit to read falls back to the newest manifest there
+is and reports that it has done so. That is the answer for a tool invoked
+outside a checkout, where there is no tree under test and no other lane to
+agree with. A lane holds a checkout by construction, so the moment it
+resolves for comes from the commit rather than from this fallback.

--- a/packages/test-support/src/records/mod.ts
+++ b/packages/test-support/src/records/mod.ts
@@ -104,6 +104,7 @@ export type { CreateObjectOptions, CreateObjectResult } from "./store.ts";
 export {
   listObjects,
   listObjectSizes,
+  listObjectTimes,
   objectUrl,
   parseReportGroups,
   readObject,
@@ -112,6 +113,7 @@ export type {
   ListedObject,
   StoredReport,
   StoredReportGroup,
+  TimedObject,
 } from "./store-reader.ts";
 export { recordsSpooledBy } from "./testing.ts";
 export {

--- a/packages/test-support/src/records/store-reader.ts
+++ b/packages/test-support/src/records/store-reader.ts
@@ -92,12 +92,22 @@ export async function listObjectTimes(options: {
   fetch?: typeof fetch;
 }): Promise<TimedObject[]> {
   return (await listItems(options, "name,timeCreated")).map((item) => {
-    if (item.timeCreated === undefined) {
+    const createdAt = item.timeCreated;
+    // The listing is a parsed network response rather than a value this
+    // process built, so the field can be absent, empty, or something that
+    // is not a time at all. Each of those orders a resolution by a key
+    // that means nothing, and an empty string sorts below every real
+    // moment, so they are one rejection rather than three.
+    if (
+      typeof createdAt !== "string" ||
+      Number.isNaN(Date.parse(createdAt))
+    ) {
       throw new Error(
-        `listing ${options.prefix} gave no creation time for ${item.name}`,
+        `listing ${options.prefix} gave no usable creation time for ` +
+          `${item.name}`,
       );
     }
-    return { name: item.name, createdAt: item.timeCreated };
+    return { name: item.name, createdAt };
   });
 }
 

--- a/packages/test-support/src/records/store-reader.ts
+++ b/packages/test-support/src/records/store-reader.ts
@@ -23,13 +23,24 @@ export interface ListedObject {
   size: number;
 }
 
+/** One object in a listing: its name and when the store created it. */
+export interface TimedObject {
+  name: string;
+
+  /**
+   * The store's own creation time, which is the moment the object became
+   * visible to a reader.
+   */
+  createdAt: string;
+}
+
 /** Every item under a prefix, in name order, paginating as needed. */
 async function listItems(
   options: { bucket: string; prefix: string; fetch?: typeof fetch },
   fields: string,
-): Promise<{ name: string; size?: string }[]> {
+): Promise<{ name: string; size?: string; timeCreated?: string }[]> {
   const doFetch = options.fetch ?? fetch;
-  const items: { name: string; size?: string }[] = [];
+  const items: { name: string; size?: string; timeCreated?: string }[] = [];
   let pageToken: string | undefined;
   do {
     const url = new URL(
@@ -46,20 +57,48 @@ async function listItems(
       );
     }
     const page = await res.json() as {
-      items?: { name?: string; size?: string }[];
+      items?: { name?: string; size?: string; timeCreated?: string }[];
       nextPageToken?: string;
     };
     for (const item of page.items ?? []) {
       if (typeof item.name !== "string") continue;
-      items.push(
-        item.size === undefined
-          ? { name: item.name }
-          : { name: item.name, size: item.size },
-      );
+      items.push({
+        name: item.name,
+        ...(item.size === undefined ? {} : { size: item.size }),
+        ...(item.timeCreated === undefined
+          ? {}
+          : { timeCreated: item.timeCreated }),
+      });
     }
     pageToken = page.nextPageToken;
   } while (pageToken !== undefined);
   return items.sort((a, b) => a.name < b.name ? -1 : a.name > b.name ? 1 : 0);
+}
+
+/**
+ * Lists every object under a prefix with the time the store created it.
+ *
+ * A writer names an object before it has finished building it, so the
+ * timestamp a name carries is a moment at which the object was not yet
+ * there to be read. The creation time is when it became visible, which is
+ * the only one of the two that orders a listing the same way however long
+ * after the write it is taken. A listing that names an object without
+ * timing it has not answered the question asked, and standing in a value
+ * would decide a resolution on a guess, so it throws instead.
+ */
+export async function listObjectTimes(options: {
+  bucket: string;
+  prefix: string;
+  fetch?: typeof fetch;
+}): Promise<TimedObject[]> {
+  return (await listItems(options, "name,timeCreated")).map((item) => {
+    if (item.timeCreated === undefined) {
+      throw new Error(
+        `listing ${options.prefix} gave no creation time for ${item.name}`,
+      );
+    }
+    return { name: item.name, createdAt: item.timeCreated };
+  });
 }
 
 /** Lists every object name under a prefix. */

--- a/tasks/test-selection/store.test.ts
+++ b/tasks/test-selection/store.test.ts
@@ -205,20 +205,29 @@ describe("store", () => {
       expect(found.objectName).toBe(name);
     });
 
-    it("treats a listing that will not say when it created an object as absent", async () => {
-      // Standing in a creation time would decide the resolution on a
-      // guess, so the listing fails and the lane runs unselected.
-      const found = await fetchManifest({
-        at,
-        env: NO_ENV,
-        fetch: storeOf(
-          { [name]: serializeManifest(sampleManifest()) },
-          { [name]: undefined },
-        ),
+    for (
+      const [what, timeCreated] of [
+        ["says nothing about a creation time", undefined],
+        ["gives an empty creation time", ""],
+        ["gives an unparseable creation time", "the other day"],
+      ] as const
+    ) {
+      it(`treats a listing that ${what} as absent`, async () => {
+        // Any of these would order the resolution by a key that means
+        // nothing, so the listing fails and the lane goes on without a
+        // manifest rather than obeying one it picked by accident.
+        const found = await fetchManifest({
+          at,
+          env: NO_ENV,
+          fetch: storeOf(
+            { [name]: serializeManifest(sampleManifest()) },
+            { [name]: timeCreated },
+          ),
+        });
+        expect(found.manifest).toBeUndefined();
+        expect(found.absent).toContain("no usable creation time");
       });
-      expect(found.manifest).toBeUndefined();
-      expect(found.absent).toContain("gave no creation time");
-    });
+    }
 
     it("treats an unreachable store as absent", async () => {
       const found = await fetchManifest({

--- a/tasks/test-selection/store.test.ts
+++ b/tasks/test-selection/store.test.ts
@@ -16,15 +16,31 @@ import { sampleManifest } from "./testing.ts";
 
 const NO_ENV = () => undefined;
 
-/** A fetch that answers a listing and one object, and nothing else. */
-function storeOf(objects: Record<string, Uint8Array | string>): typeof fetch {
+/**
+ * A fetch that answers a listing and one object, and nothing else.
+ *
+ * An object's creation time defaults to the moment its name carries, which
+ * is the ordinary case where a publisher finished in the instant it
+ * started. `createdAt` names the two apart for a test about the gap
+ * between them, and a name mapped to undefined lists without a creation
+ * time at all.
+ */
+function storeOf(
+  objects: Record<string, Uint8Array | string>,
+  createdAt: Record<string, string | undefined> = {},
+): typeof fetch {
   return ((input: string | URL | Request) => {
     const url = new URL(String(input instanceof Request ? input.url : input));
     if (url.pathname.endsWith("/o")) {
       const prefix = url.searchParams.get("prefix") ?? "";
       const items = Object.keys(objects)
         .filter((name) => name.startsWith(prefix))
-        .map((name) => ({ name }));
+        .map((name) => {
+          const timeCreated = name in createdAt
+            ? createdAt[name]
+            : generatedAtOf(name);
+          return timeCreated === undefined ? { name } : { name, timeCreated };
+        });
       return Promise.resolve(
         new Response(JSON.stringify({ items }), { status: 200 }),
       );
@@ -87,12 +103,18 @@ describe("store", () => {
   });
 
   describe("newestAtOrBefore()", () => {
-    const names = [
+    /** A listing whose objects were created at the moment they name. */
+    const listed = (...names: string[]) =>
+      names.map((name) => ({
+        name,
+        createdAt: generatedAtOf(name) ?? "2026-08-20T00:00:00.000Z",
+      }));
+    const names = listed(
       "p/manifest-2026-08-20T00:00:00.000Z-a.json.gz",
       "p/manifest-2026-08-20T04:00:00.000Z-b.json.gz",
       "p/manifest-2026-08-20T08:00:00.000Z-c.json.gz",
       "p/state/2026-08-20-d.json.gz",
-    ];
+    );
 
     it("takes the newest that is not after the moment asked about", () => {
       expect(newestAtOrBefore(names, "2026-08-20T05:00:00.000Z")).toBe(
@@ -104,7 +126,7 @@ describe("store", () => {
       const at = "2026-08-20T05:00:00.000Z";
       const later = [
         ...names,
-        "p/manifest-2026-08-20T12:00:00.000Z-e.json.gz",
+        ...listed("p/manifest-2026-08-20T12:00:00.000Z-e.json.gz"),
       ];
       expect(newestAtOrBefore(later, at)).toBe(newestAtOrBefore(names, at));
     });
@@ -112,6 +134,20 @@ describe("store", () => {
     it("returns undefined when every manifest is newer", () => {
       expect(newestAtOrBefore(names, "2026-08-19T00:00:00.000Z"))
         .toBeUndefined();
+    });
+
+    it("passes over a manifest the store had not created yet", () => {
+      // A publisher names its manifest when it starts and creates the
+      // object when it finishes. A run whose commit falls in that gap must
+      // not resolve the manifest on one listing and miss it on another,
+      // which is what ordering on the name would do.
+      const at = "2026-08-20T08:30:00.000Z";
+      const building = {
+        name: "p/manifest-2026-08-20T08:17:00.000Z-e.json.gz",
+        createdAt: "2026-08-20T08:47:00.000Z",
+      };
+      expect(newestAtOrBefore([...names, building], at))
+        .toBe(newestAtOrBefore(names, at));
     });
   });
 
@@ -149,6 +185,39 @@ describe("store", () => {
       });
       expect(found.manifest).toBeUndefined();
       expect(found.absent).toContain("not a manifest this reader understands");
+    });
+
+    it("ignores a manifest created after the moment it is asked about", async () => {
+      // The whole listing is visible to a lane that lists late enough;
+      // what keeps every lane and every attempt on one manifest is that a
+      // manifest created after the commit is never eligible.
+      const building =
+        "labs/test-selection/v1/manifest-2026-08-20T04:30:00.000Z-c.json.gz";
+      const manifest = sampleManifest();
+      const found = await fetchManifest({
+        at,
+        env: NO_ENV,
+        fetch: storeOf({
+          [name]: serializeManifest(manifest),
+          [building]: serializeManifest(manifest),
+        }, { [building]: "2026-08-20T06:00:00.000Z" }),
+      });
+      expect(found.objectName).toBe(name);
+    });
+
+    it("treats a listing that will not say when it created an object as absent", async () => {
+      // Standing in a creation time would decide the resolution on a
+      // guess, so the listing fails and the lane runs unselected.
+      const found = await fetchManifest({
+        at,
+        env: NO_ENV,
+        fetch: storeOf(
+          { [name]: serializeManifest(sampleManifest()) },
+          { [name]: undefined },
+        ),
+      });
+      expect(found.manifest).toBeUndefined();
+      expect(found.absent).toContain("gave no creation time");
     });
 
     it("treats an unreachable store as absent", async () => {

--- a/tasks/test-selection/store.ts
+++ b/tasks/test-selection/store.ts
@@ -4,17 +4,19 @@
  * The store's writer credentials hold `objectCreator` and nothing else,
  * so an object cannot be overwritten once created. That is what makes the
  * whole store trustworthy, and it is why there is no `current.json`: a
- * reader lists the prefix, which sorts by timestamp because the timestamp
- * leads the name, and takes the newest that is not after the time it is
- * asking about.
+ * reader lists the prefix and takes the newest object the store had
+ * created at or before the time it is asking about. The timestamp leading
+ * a name keeps a listing chronologically readable; what a resolution
+ * compares is the creation time the store assigns.
  */
 
 import {
   type Environment,
   gzipText,
-  listObjects,
+  listObjectTimes,
   objectUrl,
   readEnv,
+  type TimedObject,
 } from "@commonfabric/test-support/records";
 import { storeBucket, storePrefix } from "../test-records-config.ts";
 import {
@@ -88,30 +90,35 @@ export function generatedAtOf(objectName: string): string | undefined {
 }
 
 /**
- * The newest manifest object created at or before a moment, from a
- * listing. Resolving by the workflow run's start time rather than by
- * "now" is what makes a re-run of one failed lane run the same set as the
- * lane it replaces.
+ * The newest manifest the store had created at or before a moment, from a
+ * listing.
+ *
+ * The ordering is on the store's own creation time rather than on the
+ * timestamp in the name. A publisher names its manifest from the moment it
+ * started and creates the object when it finishes, so a name carries a
+ * moment at which the object was not yet there to be read. Ordering on the
+ * name would hand a lane that lists during that gap a different manifest
+ * from one that lists after it, and the two would pack the corpus
+ * differently.
  */
 export function newestAtOrBefore(
-  objectNames: readonly string[],
+  objects: readonly TimedObject[],
   at: string,
 ): string | undefined {
   let best: string | undefined;
   let bestAt = "";
-  for (const name of objectNames) {
-    const generatedAt = generatedAtOf(name);
-    if (generatedAt === undefined || generatedAt > at) continue;
-    // Two publishers can start in the same millisecond, and then the
-    // timestamp does not order them. The name does, and every reader
+  for (const { name, createdAt } of objects) {
+    if (generatedAtOf(name) === undefined || createdAt > at) continue;
+    // Two manifests can be created in the same millisecond, and then the
+    // creation time does not order them. The name does, and every reader
     // sorts it the same way, so the lanes and the wall obey one manifest
     // rather than two that happen to share an instant.
     if (
-      best === undefined || generatedAt > bestAt ||
-      (generatedAt === bestAt && name > best)
+      best === undefined || createdAt > bestAt ||
+      (createdAt === bestAt && name > best)
     ) {
       best = name;
-      bestAt = generatedAt;
+      bestAt = createdAt;
     }
   }
   return best;
@@ -144,9 +151,9 @@ export async function fetchManifest(options: {
   const env = options.env ?? Deno.env.get;
   const bucket = options.bucket ?? storeBucket(env);
   const prefix = options.prefix ?? manifestPrefix(env);
-  let names: string[];
+  let objects: TimedObject[];
   try {
-    names = await listObjects({
+    objects = await listObjectTimes({
       bucket,
       // The trailing slash keeps the listing inside this version: a bare
       // "v1" prefix also matches "v10", whose manifests would sort above
@@ -157,7 +164,7 @@ export async function fetchManifest(options: {
   } catch (error) {
     return { absent: `listing ${prefix} failed: ${error}` };
   }
-  const objectName = newestAtOrBefore(names, options.at);
+  const objectName = newestAtOrBefore(objects, options.at);
   if (objectName === undefined) {
     return { absent: `no manifest under ${prefix} at or before ${options.at}` };
   }


### PR DESCRIPTION
A lane resolves the newest manifest at or before the moment the commit under test was made. Every lane of a run, and every later attempt of it, have to reach the same one, or a test the first attempt placed in the lane that failed can move to a lane a re-run does not run, and every check goes green over a set no attempt ran whole.

Resolution compared the timestamp leading the object's name. The publisher takes that timestamp when it starts and creates the object when it finishes, folding days of records and building a manifest of some megabytes in between, so the name carries a moment at which the object was not yet there to be read.

A commit dated inside that gap resolves differently depending on when the reader lists. A publisher running from 08:17 to 08:47 creates `manifest-08:17`. A commit dated 08:30 resolves the previous manifest on any listing before 08:47 and `manifest-08:17` on any listing after it. The lanes of one attempt can straddle that boundary, and a re-run hours later straddles it every time. No clock is skewed in this; the gap alone is enough.

Order on the creation time the store assigns instead. That is when an object became visible, so a manifest created after the commit is never eligible and the eligible set is closed before any lane lists. The listing asks for one more field on the request it already makes, so this costs no extra round trip and no credential. A listing that will not say when it created an object throws rather than standing a value in.

This does not close the case where the clock that dated the commit runs ahead of the store's, since manifests created between the real moment and that date are eligible while the lanes list. The specification says so rather than claiming otherwise, and the topics board carries the rest.

## The documentation this corrects

The two specifications described a mechanism that was never built: a selector job calling a trusted reusable workflow before the lanes, which chose a manifest and wrote it into a create-only object keyed by the workflow run id. No such job, credential, or object prefix exists anywhere in the tree. Describe the committer-date mechanism the lane actually implements, in both specifications and in the plan.

Three further corrections come with it. The specifications said resolution reads server-assigned object metadata, which is now what it does but was not; the sentence saying the name's timestamp does not decide order is true again and stays. The reason for preferring the committer date to the author date was stated so that it could be read as attributing the wrong behavior to the committer date. And the account of a lane that finds no manifest still described a deterministic slice of the corpus, where the census makes every unrecorded identity mandatory and the whole corpus runs.

Verified by running the two new tests against the previous ordering, where both fail on the manifest they resolve rather than on an error, and with repository-wide formatting, lint and type checks, the documentation checker, and the test-selection, lane and test-support suites.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

