### PR TITLE
fix(shell): the reference the header hands out opens in the shell (#6920)

### DIFF
--- a/docs/specs/collection-naming.md
+++ b/docs/specs/collection-naming.md
@@ -569,6 +569,14 @@ it. Walking into a collection is that kind of work — it syncs and reads a cell
 — so the walk sits beside the parse rather than inside it, and every reader of
 these URLs keeps reading the segments apart from resolving them.
 
+That split is also what bounds who resolves a fully qualified reference. The
+shell reads it and `cf` reads it, both holding a session that can turn a space
+name into a DID and walk a collection. The pattern-facing reader, the
+`cellFromUrl` builtin, does not: it is the pure and synchronous contract
+above, its rooted-path branch wants an entity id where a collection's name
+sits, and giving a pattern this grammar is a decision about that builtin
+rather than a gap in this step.
+
 **5. Add the prose layer.** Sigil parsing, canonicalize-on-write,
 context-computed rendering with round-trip verification, the two render modes,
 and the clipboard flavors.

--- a/docs/specs/collection-naming.md
+++ b/docs/specs/collection-naming.md
@@ -572,10 +572,13 @@ these URLs keeps reading the segments apart from resolving them.
 That split is also what bounds who resolves a fully qualified reference. The
 shell reads it and `cf` reads it, both holding a session that can turn a space
 name into a DID and walk a collection. The pattern-facing reader, the
-`cellFromUrl` builtin, does not: it is the pure and synchronous contract
-above, its rooted-path branch wants an entity id where a collection's name
-sits, and giving a pattern this grammar is a decision about that builtin
-rather than a gap in this step.
+`cellFromUrl` builtin (`packages/runner/src/builtins/cell-from-url.ts`), does
+not, and what refuses it is the parse rather than the builtin: it reads
+through `parseFabricUrl`, whose rooted-path branch wants an entity id where a
+collection's name sits. The builtin is not that pure contract itself — it
+holds a runtime and a transaction, resolves a space name through one, and
+reaches a cell — so what it lacks is the collection walk, and giving a pattern
+one is a decision about that builtin rather than a gap in this step.
 
 **5. Add the prose layer.** Sigil parsing, canonicalize-on-write,
 context-computed rendering with round-trip verification, the two render modes,

--- a/docs/specs/collection-naming.md
+++ b/docs/specs/collection-naming.md
@@ -546,11 +546,14 @@ inside it. Resolving the two together is what the split is for — the path is
 the part that says which member, so a resolver handed the address on its own
 has nothing to walk with.
 
-**4. Walk segments in the URL layer.** Built for the shell's page URLs, in
-review. `urlToAppView` (`packages/navigation/src/view.ts`) reads the segment
-after a slug as the member name and carries it in the view, which serializes
-back to `<space>/<collection>/<member>`. Resolution is a separate worker round
-trip, `slug:resolve`
+**4. Walk segments in the URL layer.** Built for the shell's page URLs.
+`urlToAppView` (`packages/navigation/src/view.ts`) reads the segment after a
+slug as the member name and carries it in the view, which serializes back to
+`<space>/<collection>/<member>`. It reads a leading `@` on the first segment as
+the mark on the space, so the fully qualified reference and the page URL are
+one address written two ways: the mark is what a reference carries and is no
+part of the space, so the shell opens `/@<space>/top/42` and settles on
+`/<space>/top/42`. Resolution is a separate worker round trip, `slug:resolve`
 (`packages/runtime-client/src/backends/runtime-processor.ts`), which hands the
 reference to the runner's walk and answers with the piece and whatever the walk
 did not spend. A name with no member after it is a different question of the

--- a/packages/integration/shell-utils.ts
+++ b/packages/integration/shell-utils.ts
@@ -364,19 +364,25 @@ export class ShellIntegration {
   // `spaceName`, and `pieceId`. Waits for state to settle
   // reflecting these properties.
   //
+  // `urlPath` sends a different spelling of the same address: the rooted path
+  // to navigate to, where the caller is checking a form the shell reads but
+  // does not write. `view` remains the state this waits for, so such a caller
+  // states what it sends and what that has to reach as two separate things.
+  //
   // If `identity` provided, logs in with the identity
   // after navigation.
   async goto(
-    { frontendUrl, view, identity }: {
+    { frontendUrl, view, urlPath, identity }: {
       frontendUrl: string;
       view: AppView;
+      urlPath?: `/${string}`;
       identity?: Identity;
     },
   ): Promise<void> {
     this.#checkIsOk();
 
     // Strip the proceeding "/" in the url path
-    const path = appViewToUrlPath(view).substring(1);
+    const path = (urlPath ?? appViewToUrlPath(view)).substring(1);
 
     const url = `${frontendUrl}${path}`;
     const page = this.page();

--- a/packages/navigation/src/view.ts
+++ b/packages/navigation/src/view.ts
@@ -1,4 +1,5 @@
 import { DID, isDID } from "@commonfabric/identity";
+import { asSpaceSegment } from "@commonfabric/runner/fabric-url";
 import { isSlugAddress, isValidSlug } from "@commonfabric/runner/slugs";
 
 export type AppBuiltInView = "home";
@@ -178,7 +179,16 @@ export function urlToAppView(url: URL): AppView {
   segments.shift(); // shift off the pathnames' prefix "/";
   const mode = segments[0] === EMBED_PATH_PREFIX ? "embed" : undefined;
   if (mode) segments.shift();
-  const [first, pieceId] = [segments[0], segments[1]];
+  // A leading `@` marks the space, which is how a reference that travels is
+  // written: `/@<space>/<collection>/<member>` is the spelling the header
+  // hands out, and it addresses what `/<space>/<collection>/<member>` does.
+  // The mark is the whole difference, so it comes off and the segment reads
+  // as any other space does — which leaves a segment that is nothing but the
+  // mark naming no space, the address a bare origin already carries.
+  const first = segments[0] === undefined
+    ? undefined
+    : asSpaceSegment(segments[0]) ?? segments[0];
+  const pieceId = segments[1];
   const modeRef: AppViewModeRef = mode ? { mode } : {};
   // The segment after a slug selects a member of the collection it names.
   // Reading it apart from resolving it is what keeps this pure: whether the

--- a/packages/navigation/test/view.test.ts
+++ b/packages/navigation/test/view.test.ts
@@ -102,6 +102,26 @@ describe("view", () => {
     });
   });
 
+  it("decodes the space segment and no other", () => {
+    // Reading the mark means reading through an escape of it, so `%40space`
+    // reaches the space `@space` reaches — and the decoding stops there.
+    // Every other segment is carried in the spelling the URL wrote, because
+    // holding one to a grammar is the resolver's question and not this one's.
+    // One URL states both halves: the space loses its escape, the member
+    // keeps its own.
+    expect(urlToAppView(new URL("http://common.test/%40space/top/4%32")))
+      .toEqual({
+        spaceName: "space",
+        pieceSlug: "top",
+        pieceMember: "4%32",
+      });
+    // An unmarked space is carried whole, so the two differ only by the mark.
+    expect(urlToAppView(new URL("http://common.test/%40space%20x/demo")))
+      .toEqual({ spaceName: "space x", pieceSlug: "demo" });
+    expect(urlToAppView(new URL("http://common.test/space%20x/demo")))
+      .toEqual({ spaceName: "space%20x", pieceSlug: "demo" });
+  });
+
   it("reads one segment after a slug as the member", () => {
     // A member's own fields are a cell path inside the piece it resolves to,
     // so nothing past the first segment is part of the address.

--- a/packages/navigation/test/view.test.ts
+++ b/packages/navigation/test/view.test.ts
@@ -54,6 +54,54 @@ describe("view", () => {
     ).toBe(`/${SPACE_DID}/top/42`);
   });
 
+  it("parses a space written with the reference's leading mark", () => {
+    // `/@<space>/<collection>/<member>` is the reference the shell's header
+    // hands out, so the shell reads back what it gives away. A name and a DID
+    // both answer to the mark, and the mark reaches a space naming no piece
+    // as well as one naming a member.
+    expect(urlToAppView(new URL("http://common.test/@space/top/42"))).toEqual({
+      spaceName: "space",
+      pieceSlug: "top",
+      pieceMember: "42",
+    });
+    expect(urlToAppView(new URL(`http://common.test/@${SPACE_DID}/top/42`)))
+      .toEqual({ spaceDid: SPACE_DID, pieceSlug: "top", pieceMember: "42" });
+    expect(urlToAppView(new URL("http://common.test/@space/demo"))).toEqual({
+      spaceName: "space",
+      pieceSlug: "demo",
+    });
+    expect(urlToAppView(new URL("http://common.test/@space"))).toEqual({
+      spaceName: "space",
+    });
+    // Embed mode belongs to the route rather than to the space, so the two
+    // prefixes compose.
+    expect(urlToAppView(new URL("http://common.test/.embed/@space/top/42")))
+      .toEqual({
+        spaceName: "space",
+        pieceSlug: "top",
+        pieceMember: "42",
+        mode: "embed",
+      });
+    // The mark is no part of the space, so a page URL built from the route
+    // carries the space in its segments and nothing else.
+    expect(
+      appViewToUrlPath(
+        urlToAppView(new URL("http://common.test/@space/top/42")),
+      ),
+    ).toBe("/space/top/42");
+  });
+
+  it("routes a mark naming no space to the home view", () => {
+    // A segment that is nothing but the mark names no space, which is the
+    // address a bare origin already carries.
+    expect(urlToAppView(new URL("http://common.test/@"))).toEqual({
+      builtin: "home",
+    });
+    expect(urlToAppView(new URL("http://common.test/.embed/@"))).toEqual({
+      builtin: "home",
+    });
+  });
+
   it("reads one segment after a slug as the member", () => {
     // A member's own fields are a cell path inside the piece it resolves to,
     // so nothing past the first segment is part of the address.

--- a/packages/runner/src/fabric-url.ts
+++ b/packages/runner/src/fabric-url.ts
@@ -73,8 +73,16 @@ function asEntityId(segment: string): string | undefined {
   return undefined;
 }
 
-/** A `@did:key:…` segment, as the LLM-friendly link form writes a space. */
-function asSpaceSegment(segment: string): string | undefined {
+/**
+ * The space a path segment names, or `undefined` where it names none.
+ *
+ * A leading `@` is what marks a segment as the space, in every reference this
+ * repository writes: it keeps a space from competing for the slot the piece
+ * would otherwise hold. What the `@` carries is only held to a form by the
+ * reader — a DID resolves from the string alone, a name needs a session — so
+ * the segment is returned as it was written, minus the mark.
+ */
+export function asSpaceSegment(segment: string): string | undefined {
   const decoded = decode(segment);
   return decoded?.startsWith("@") ? decoded.slice(1) : undefined;
 }

--- a/packages/runner/src/fabric-url.ts
+++ b/packages/runner/src/fabric-url.ts
@@ -74,13 +74,22 @@ function asEntityId(segment: string): string | undefined {
 }
 
 /**
- * The space a path segment names, or `undefined` where it names none.
+ * The space a marked path segment carries, or `undefined` where the segment
+ * carries no mark and so is not the space at all.
  *
  * A leading `@` is what marks a segment as the space, in every reference this
  * repository writes: it keeps a space from competing for the slot the piece
- * would otherwise hold. What the `@` carries is only held to a form by the
+ * would otherwise hold. What the mark carries is only held to a form by the
  * reader — a DID resolves from the string alone, a name needs a session — so
- * the segment is returned as it was written, minus the mark.
+ * the rest of the segment comes back unexamined.
+ *
+ * The segment is percent-decoded first, so a mark or a name that arrived
+ * escaped reads as what it stands for and `%40space` carries what `@space`
+ * carries; a segment holding a malformed escape is one this cannot read, and
+ * carries no space. A segment that is nothing but the mark returns the empty
+ * string rather than `undefined`, which is the distinction a caller needs: it
+ * says it is the space while naming none, where an unmarked segment never
+ * said it was one.
  */
 export function asSpaceSegment(segment: string): string | undefined {
   const decoded = decode(segment);

--- a/packages/runner/test/fabric-url.test.ts
+++ b/packages/runner/test/fabric-url.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { parseFabricUrl } from "../src/fabric-url.ts";
+import { asSpaceSegment, parseFabricUrl } from "../src/fabric-url.ts";
 
 const HASH = "V2tROHl4KsExx5M0fYnkQaOryFwjVUkqXIlcdMWz7SQ";
 const SPACE = "did:key:z6MkpXpeKbhbddoVvxQndKtnNZmGfpSbXXmVw88bswFy2hHh";
@@ -182,6 +182,45 @@ describe("fabric-url", () => {
       it("returns undefined for a malformed URL", () => {
         expect(parseFabricUrl("https://")).toBeUndefined();
       });
+    });
+  });
+
+  describe("asSpaceSegment()", () => {
+    // Exported for `urlToAppView` (`packages/navigation/src/view.ts`), which
+    // reads the same mark out of a page URL. Both of the answers below that a
+    // caller could mistake for each other — the empty string and `undefined`
+    // — are load-bearing there, so both are pinned here rather than left to
+    // whichever caller happens to depend on them.
+
+    it("returns the space behind the mark", () => {
+      expect(asSpaceSegment("@space")).toBe("space");
+      expect(asSpaceSegment(`@${SPACE}`)).toBe(SPACE);
+    });
+
+    it("returns undefined for a segment carrying no mark", () => {
+      expect(asSpaceSegment("space")).toBeUndefined();
+      expect(asSpaceSegment("")).toBeUndefined();
+    });
+
+    it("returns the space for a mark that arrived percent-encoded", () => {
+      // `%40` is an equivalent encoding of a path `@`, so it marks the space
+      // the same way, and what it marks is decoded along with it.
+      expect(asSpaceSegment("%40space")).toBe("space");
+      expect(asSpaceSegment("@a%20b")).toBe("a b");
+    });
+
+    it("returns undefined for a malformed percent escape", () => {
+      // The contract the rest of this module holds: a segment this cannot
+      // read carries no space, rather than asking about it throwing.
+      expect(asSpaceSegment("%ZZ")).toBeUndefined();
+      expect(asSpaceSegment("@%ZZ")).toBeUndefined();
+    });
+
+    it("returns the empty string for a segment that is nothing but the mark", () => {
+      // Not `undefined`: the segment says it is the space and names none,
+      // which is what lets a caller tell it from one that never said it was.
+      expect(asSpaceSegment("@")).toBe("");
+      expect(asSpaceSegment("%40")).toBe("");
     });
   });
 });

--- a/packages/shell/README.md
+++ b/packages/shell/README.md
@@ -26,13 +26,14 @@ The shell supports these browser URL forms:
   Where the slug names a piece rather than a collection there are no members to
   name, so the segment is dropped and the address settles on the piece the page
   is showing.
-- `/@<space-name-or-did>/...`: any of the forms above, written with the mark
-  that says which segment is the space. This is the spelling the portable
-  reference above is written in, so what one page copies is what another opens;
-  `cf` reads it too, while a pattern's `cellFromUrl` is the reader that does
-  not. The mark is no part of the space, so a page opened this way settles on
-  the URL the shell would have written for that address, and a segment that is
-  nothing but the mark names no space and opens the home view.
+- `/@<space-name-or-did>/...`: any of the other forms, `.embed` included,
+  written with the mark that says which segment is the space. This is the
+  spelling the portable reference above is written in, so what one page copies
+  is what another opens; `cf` reads it too, and a pattern's `cellFromUrl` does
+  not — it reads through `parseFabricUrl`, which wants an entity id where a
+  collection's name sits. The mark is no part of the space, so a page opened
+  this way settles on the URL the shell would have written for that address, and
+  a segment that is nothing but the mark names no space and opens the home view.
 - `/.embed/<space-name-or-did>/<piece-id-or-slug>`: opens the same piece in
   embed mode.
 

--- a/packages/shell/README.md
+++ b/packages/shell/README.md
@@ -22,11 +22,17 @@ The shell supports these browser URL forms:
   fields never answer to the collection's namespace. A member the collection
   does not hold is reported by name, alongside the collection's. The header
   offers the member's portable reference, `/@<space>/<collection>/<member>`,
-  which carries its own space and so depends on no binding of the reader's. `cf`
-  resolves it; this shell's own URLs and a pattern's `cellFromUrl` do not read
-  that grammar. Where the slug names a piece rather than a collection there are
-  no members to name, so the segment is dropped and the address settles on the
-  piece the page is showing.
+  which carries its own space and so depends on no binding of the reader's.
+  Where the slug names a piece rather than a collection there are no members to
+  name, so the segment is dropped and the address settles on the piece the page
+  is showing.
+- `/@<space-name-or-did>/...`: any of the forms above, written with the mark
+  that says which segment is the space. This is the spelling the portable
+  reference above is written in, so what one page copies is what another opens;
+  `cf` reads it too, while a pattern's `cellFromUrl` is the reader that does
+  not. The mark is no part of the space, so a page opened this way settles on
+  the URL the shell would have written for that address, and a segment that is
+  nothing but the mark names no space and opens the home view.
 - `/.embed/<space-name-or-did>/<piece-id-or-slug>`: opens the same piece in
   embed mode.
 

--- a/packages/shell/integration/collection-member.test.ts
+++ b/packages/shell/integration/collection-member.test.ts
@@ -7,6 +7,7 @@
  * and a rendered page that is the member rather than the board.
  */
 
+import { expect } from "@std/expect";
 import { join, resolve } from "@std/path";
 import { describe, it } from "@std/testing/bdd";
 
@@ -141,6 +142,40 @@ describe("shell collection members", () => {
         shell.page(),
         () => document.title === "Oven schedule",
       );
+    });
+
+    it("opens the reference the header hands out", async () => {
+      await using tempIdentity = await writeTempIdentity({
+        implementation: "noble",
+      });
+      const { identity, path: identityPath } = tempIdentity;
+      const slug = `portable-${crypto.randomUUID()}`;
+      await fileBoardWithMembers(identityPath, slug, [
+        "Glaze recipes",
+        "Oven schedule",
+      ]);
+
+      // `/@<space>/<collection>/<member>` is what "Copy reference" copies, and
+      // a page served at that URL is the only place its whole trip is
+      // visible: through the server that routes it, the browser that sends
+      // it, and the shell that reads it back.
+      await shell.goto({
+        frontendUrl: FRONTEND_URL,
+        view: { spaceName: SPACE_NAME, pieceSlug: slug, pieceMember: "2" },
+        urlPath: `/@${SPACE_NAME}/${slug}/2`,
+        identity,
+      });
+
+      await waitForCondition(shell.page(), (probe) => {
+        const badges = probe.collect("[data-member-name]");
+        return badges.length === 1 && probe.deepText(badges[0]).trim() === "2";
+      });
+      // The mark says which segment is the space and is no part of it, so the
+      // page the shell settles on is the one it would have written itself.
+      const pathname = await shell.page().evaluate(() =>
+        globalThis.location.pathname
+      );
+      expect(pathname).toBe(`/${SPACE_NAME}/${slug}/2`);
     });
   });
 

--- a/packages/shell/src/views/AppView.ts
+++ b/packages/shell/src/views/AppView.ts
@@ -904,9 +904,9 @@ export class XAppView extends BaseView {
 
   /**
    * How the piece this view addresses is cited from anywhere:
-   * `/@<space>/<collection>/<member>`, the spelling `cf` resolves and which
-   * depends on no binding of the reader's. Only a member of a named
-   * collection has one — a piece
+   * `/@<space>/<collection>/<member>`, the spelling this shell's own URLs and
+   * `cf` both read and which depends on no binding of the reader's. Only a
+   * member of a named collection has one — a piece
    * reached by identity carries its own, a collection's name with no member
    * after it names no piece at all, and a segment the walk did not spend
    * named nothing to cite.

--- a/packages/shell/src/views/AppView.ts
+++ b/packages/shell/src/views/AppView.ts
@@ -905,7 +905,8 @@ export class XAppView extends BaseView {
   /**
    * How the piece this view addresses is cited from anywhere:
    * `/@<space>/<collection>/<member>`, the spelling this shell's own URLs and
-   * `cf` both read and which depends on no binding of the reader's. Only a
+   * `cf` both read and which depends on no binding of the reader's; a
+   * pattern's `cellFromUrl` is the one reader that does not read it. Only a
    * member of a named collection has one — a piece
    * reached by identity carries its own, a collection's name with no member
    * after it names no piece at all, and a segment the walk did not spend

--- a/packages/shell/src/views/AppView.ts
+++ b/packages/shell/src/views/AppView.ts
@@ -906,7 +906,7 @@ export class XAppView extends BaseView {
    * How the piece this view addresses is cited from anywhere:
    * `/@<space>/<collection>/<member>`, the spelling this shell's own URLs and
    * `cf` both read and which depends on no binding of the reader's; a
-   * pattern's `cellFromUrl` is the one reader that does not read it. Only a
+   * pattern's `cellFromUrl` does not read it. Only a
    * member of a named collection has one — a piece
    * reached by identity carries its own, a collection's name with no member
    * after it names no piece at all, and a segment the walk did not spend

--- a/packages/shell/src/views/HeaderView.ts
+++ b/packages/shell/src/views/HeaderView.ts
@@ -933,9 +933,10 @@ export class XHeaderView extends BaseView {
   /**
    * Copy this piece's portable reference to the clipboard. It carries its own
    * space, so it depends on no binding of the copier's and resolves for
-   * whoever receives it — in this shell's own URLs, in `cf`, and in anything
-   * else that opens a session before it reads. A pattern's `cellFromUrl` does
-   * not read this grammar.
+   * whoever receives it — in this shell's own URLs and in `cf`, each of which
+   * reads this grammar and walks the collection it names. A pattern's
+   * `cellFromUrl` does not: it reads through `parseFabricUrl`, which wants an
+   * entity id where the collection's name sits.
    */
   async #handleCopyReference(e: Event) {
     e.preventDefault();

--- a/packages/shell/src/views/HeaderView.ts
+++ b/packages/shell/src/views/HeaderView.ts
@@ -933,9 +933,9 @@ export class XHeaderView extends BaseView {
   /**
    * Copy this piece's portable reference to the clipboard. It carries its own
    * space, so it depends on no binding of the copier's and resolves for
-   * whoever receives it — in `cf`, and in anything else that opens a session
-   * before it reads. Neither this shell's own URLs nor a pattern's
-   * `cellFromUrl` reads this grammar today.
+   * whoever receives it — in this shell's own URLs, in `cf`, and in anything
+   * else that opens a session before it reads. A pattern's `cellFromUrl` does
+   * not read this grammar.
    */
   async #handleCopyReference(e: Event) {
     e.preventDefault();


### PR DESCRIPTION
## Why

The header's **Copy reference** control hands out `/@<space>/<slug>/<member>`.
`cf` resolves it. The shell did not: `urlToAppView` took the first path
segment as the space, so `/@naming-demo/top/42` parsed its space as
`"@naming-demo"`. A control in the product copied a reference the product
could not open.

Verified by running it rather than reading it, which also turned up something
the issue did not mention: the `@`-form **DID** never read as a DID either.

```
/@naming-demo/top/42      =>  spaceName: "@naming-demo"
/@did:key:z6Mkg…/top/42   =>  spaceName: "@did:key:z6Mkg…"
```

## What changed

`urlToAppView` takes the mark off the first segment through `asSpaceSegment` —
the function that already recognises the `@` form — in the same place and
shape as the existing `.embed` test, and after it, so the two prefixes
compose. Nothing downstream changed: a stripped DID reaches the `isDID`
branch, a stripped name the other, and a first segment that is only `@` names
no space and routes to `home`.

`asSpaceSegment` moves from module-private to exported, with a doc comment
written for a contract rather than a local.

## Out of scope, deliberately

`cellFromUrl` is untouched, and still refuses this grammar — confirmed by
running `parseFabricUrl`, not by repeating the issue. That reader is pure and
synchronous by contract while slug resolution is neither, which is a design
question about the builtin rather than plumbing.

**Four documents claimed the shell could not read this grammar. All four now
name `cellFromUrl` as the exception** instead of implying the reference
resolves everywhere.

## Test plan

Two unit tests, eight assertions, plus one browser test navigating to the
literal URL and asserting both the badge and that the address bar settles on
the canonical form.

The browser test needed `goto` to accept an optional `urlPath`, which is
exactly the shape where a typo'd field is dropped, the canonical URL is
navigated to instead, and the test passes proving nothing. So the whole
feature was reverted against the browser lane: the new test fails on its
state wait while its canonical-spelling sibling stays green, and both restore.

## One thing flagged rather than settled

`asSpaceSegment` percent-decodes, so `/%40space/top/42` now reads as space
`space`, while a non-`@` segment stays verbatim. That asymmetry is inherited
from the reused function, not introduced here. Two cases in
`packages/runner/test/fabric-url.test.ts` would pin it — `%40space` decoding,
and a malformed escape returning `undefined` — and that file already holds
the equivalent cases for every other decoded segment. They are left out
deliberately: whether decoding the mark is right is a decision to make, not
one to inherit from a test written to make a green run greener.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6952?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

