### PR TITLE
test(data-model): a `value-debug` case file binds the options its cases render under

### DIFF
--- a/packages/data-model/test/value-debug-cases.test.ts
+++ b/packages/data-model/test/value-debug-cases.test.ts
@@ -1,19 +1,23 @@
 /**
  * The debug renderers, run over the cases recorded as files in
  * `value-debug-cases/`. A file opens with a JavaScript expression which
- * produces a plain object, each of whose properties is one case: the key
- * labels it, and the value is what gets rendered, on its own. After a blank
- * line, the file records one section per property, the sections separated by
- * blank lines: the label followed by a colon on a line of its own, then three
- * renderings of the value, each starting on a line of its own. The first is
- * its `toCompactDebugString()` rendering, whole. The second is its
+ * produces a plain object, each of whose properties is one case: the key labels
+ * it, and the value is what gets rendered, on its own. The one property that is
+ * not a case is `/options`, which holds the options every case in the file is
+ * rendered with; a file that binds none renders its cases with the defaults.
+ * After a blank line, the file records one section per case, the sections
+ * separated by blank lines: the label followed by a colon on a line of its own,
+ * then three renderings of the value, each starting on a line of its own. The
+ * first is its `toCompactDebugString()` rendering, whole. The second is its
  * `toIndentedDebugString()` rendering, which can run to several lines. The
- * third is its `toStructuredDebugValue()` result, the structure the two
- * strings were rendered from, rendered by `toIndentedDebugString()` with every
- * limit at `Infinity` so that it shows whole; where a string rendering
- * interprets a form of the structured value, this rendering shows the form
- * itself. A recorded rendering is a fact about the renderer, to be read as
- * such when it changes. What `maxLength` does to a compact rendering is
+ * third is its `toStructuredDebugValue()` result, the structure the two strings
+ * were rendered from, rendered by `toIndentedDebugString()` with every limit at
+ * `Infinity` so that it shows whole; where a string rendering interprets a form
+ * of the structured value, this rendering shows the form itself. The file's
+ * options reach all three calls, and the two that only the compact rendering
+ * reads, `maxLength` and `backtickQuote`, therefore reach the compact rendering
+ * alone. A recorded rendering is a fact about the renderer, to be read as such
+ * when it changes. What `maxLength` does to a compact rendering is
  * `value-debug.test.ts`'s to check, so no case here is cut by one.
  *
  * The expression is evaluated with every `FabricInstance` and
@@ -40,6 +44,7 @@ import { REALM_CODEC } from "@/codec-interface/interface.ts";
 import * as fabricInstances from "@/fabric-instances/index.ts";
 import * as fabricPrimitives from "@/fabric-primitives/index.ts";
 import {
+  type CompactDebugStringOptions,
   type DebugValueOptions,
   FabricInstance,
   FabricPrimitive,
@@ -53,6 +58,9 @@ import {
 
 /** Directory holding the case files. */
 const CASES_DIR = new URL("./value-debug-cases/", import.meta.url);
+
+/** Key under which a case file's expression binds its rendering options. */
+const OPTIONS_KEY = "/options";
 
 /**
  * Options for rendering a structured value whole: every limit at `Infinity`,
@@ -93,11 +101,17 @@ const SCOPE: Record<string, unknown> = Object.fromEntries([
 ]);
 
 /**
- * Evaluates a case's expression, producing the cases it describes.
+ * Evaluates a case file's expression, producing the cases it describes and
+ * the options they are to be rendered with, the latter `undefined` when the
+ * expression binds none.
  *
- * @throws {Error} if the expression produces other than a plain object.
+ * @throws {Error} if the expression produces other than a plain object, or if
+ * it binds `/options` to other than a plain object.
  */
-function evaluateExpression(expression: string): Record<string, unknown> {
+function evaluateExpression(expression: string): {
+  cases: Record<string, unknown>;
+  options: CompactDebugStringOptions | undefined;
+} {
   const names = Object.keys(SCOPE);
   const values = names.map((name) => SCOPE[name]);
   const fn = new Function(
@@ -116,7 +130,19 @@ function evaluateExpression(expression: string): Record<string, unknown> {
     );
   }
 
-  return result;
+  const { [OPTIONS_KEY]: options, ...cases } = result;
+
+  if ((options !== undefined) && !isPlainObject(options, false)) {
+    const rendered = toCompactDebugString(options, {
+      maxLength: 60,
+      backtickQuote: true,
+    });
+    throw new Error(
+      `\`${OPTIONS_KEY}\` must be a plain object; got ${rendered}`,
+    );
+  }
+
+  return { cases, options: options as CompactDebugStringOptions | undefined };
 }
 
 /**
@@ -144,13 +170,18 @@ function parseCaseFile(text: string): {
 /**
  * Renders one case as its recorded section: the label and a colon, the
  * compact rendering, the indented rendering, and the structured value
- * rendered whole, each starting on a line of its own.
+ * rendered whole, each starting on a line of its own. `options` are the
+ * file's, passed to each of the three calls that render `value`.
  */
-function renderSection(label: string, value: unknown): string {
-  const compact = toCompactDebugString(value);
-  const indented = toIndentedDebugString(value);
+function renderSection(
+  label: string,
+  value: unknown,
+  options: CompactDebugStringOptions | undefined,
+): string {
+  const compact = toCompactDebugString(value, options);
+  const indented = toIndentedDebugString(value, options);
   const structured = toIndentedDebugString(
-    toStructuredDebugValue(value),
+    toStructuredDebugValue(value, options),
     WHOLE_RENDERING_OPTIONS,
   );
   return `${label}:\n${compact}\n${indented}\n${structured}`;
@@ -167,9 +198,9 @@ describe("value-debug-cases", () => {
     it(`renders \`${name}\` as recorded`, async () => {
       const url = new URL(`${name}.txt`, CASES_DIR);
       const recorded = parseCaseFile(await Deno.readTextFile(url));
-      const cases = evaluateExpression(recorded.expression);
+      const { cases, options } = evaluateExpression(recorded.expression);
       const actual = Object.entries(cases).map(([label, value]) =>
-        renderSection(label, value)
+        renderSection(label, value, options)
       );
 
       if (UPDATE_GOLDENS) {

--- a/packages/data-model/test/value-debug-cases/backtick-quote.txt
+++ b/packages/data-model/test/value-debug-cases/backtick-quote.txt
@@ -1,0 +1,28 @@
+{
+  // The compact rendering is quoted as a Markdown code span, with a delimiter
+  // longer than any backtick run inside it. The indented rendering does not
+  // read the option.
+  "/options": { backtickQuote: true },
+  object: { a: 1 },
+  "with a backtick": "a`b",
+  "with a run of backticks": "a``b",
+}
+
+object:
+`{a:1}`
+{
+  a: 1
+}
+{
+  a: 1
+}
+
+with a backtick:
+``"a`b"``
+"a`b"
+"a`b"
+
+with a run of backticks:
+```"a``b"```
+"a``b"
+"a``b"

--- a/packages/data-model/test/value-debug-cases/forms-at-depth-limit.txt
+++ b/packages/data-model/test/value-debug-cases/forms-at-depth-limit.txt
@@ -1,0 +1,133 @@
+{
+  // An elision form which lands at the depth limit is carried whole, though
+  // it nests further than the limit leaves room for. A container or an
+  // instance there is elided.
+  "/options": {
+    maxDepth: 3,
+    maxArrayLength: 1,
+    maxProperties: 1,
+    maxStringLength: 3,
+  },
+  "array length": { a: [1, 2, 3] },
+  "property count": { o: { a: 1, b: 2 } },
+  "partial string": { o: { s: "abcdef" } },
+  "unique symbol": { o: { s: Symbol("desc") } },
+  function: { o: { f: function foo() {} } },
+  "class instance": { o: { m: new Map() } },
+  "elided object": { o: { p: { q: 1 } } },
+}
+
+array length:
+{a:[1,...length:3]}
+{
+  a: [
+    1,
+    ... length: 3
+  ]
+}
+{
+  a: [
+    1,
+    {
+      "/...": {
+        length: 3
+      }
+    }
+  ]
+}
+
+property count:
+{o:{a:1,...count:2}}
+{
+  o: {
+    a: 1,
+    ... count: 2
+  }
+}
+{
+  o: {
+    a: 1,
+    "/...": {
+      count: 2
+    }
+  }
+}
+
+partial string:
+{o:{s:"abc"+...length:6}}
+{
+  o: {
+    s: "abc" +
+      ... length: 6
+  }
+}
+{
+  o: {
+    s: {
+      "/partialString": {
+        length: 6,
+        excerpt: "abc"
+      }
+    }
+  }
+}
+
+unique symbol:
+{o:{s:Symbol("desc")}}
+{
+  o: {
+    s: Symbol("desc")
+  }
+}
+{
+  o: {
+    s: {
+      "/uniqueSymbol": "desc"
+    }
+  }
+}
+
+function:
+{o:{f:function foo(...){...}}}
+{
+  o: {
+    f: function foo(...) {...}
+  }
+}
+{
+  o: {
+    f: {
+      "/function": "foo(...)"
+    }
+  }
+}
+
+class instance:
+{o:{m:...}}
+{
+  o: {
+    m: ...
+  }
+}
+{
+  o: {
+    m: {
+      "/...": "Map"
+    }
+  }
+}
+
+elided object:
+{o:{p:...}}
+{
+  o: {
+    p: ...
+  }
+}
+{
+  o: {
+    p: {
+      "/...": "object"
+    }
+  }
+}

--- a/packages/data-model/test/value-debug-cases/max-array-length.txt
+++ b/packages/data-model/test/value-debug-cases/max-array-length.txt
@@ -1,0 +1,174 @@
+{
+  // An array with more elements than the limit renders the elements below
+  // it, and then its actual length in place of the rest.
+  "/options": { maxArrayLength: 3 },
+  "past the limit": [1, 2, 3, 4, 5],
+  "at the limit": [1, 2, 3],
+  "below the limit": [1],
+  "with a converting element": [1, new Map(), 3, 4, 5],
+  "in an object": { a: [1, 2, 3, 4] },
+  // A run of holes which crosses the limit renders only the holes below it.
+  "holes crossing the limit": [1, , , , , 6],
+  "holes below the limit": [, , 3, 4],
+  "holes among the elements": [1, , 3, , , , 7],
+  "sparse, with `length` alone past the limit": (() => {
+    const value = [1];
+    value.length = 500;
+    return value;
+  })(),
+}
+
+past the limit:
+[1,2,3,...length:5]
+[
+  1,
+  2,
+  3,
+  ... length: 5
+]
+[
+  1,
+  2,
+  3,
+  {
+    "/...": {
+      length: 5
+    }
+  }
+]
+
+at the limit:
+[1,2,3]
+[
+  1,
+  2,
+  3
+]
+[
+  1,
+  2,
+  3
+]
+
+below the limit:
+[1]
+[
+  1
+]
+[
+  1
+]
+
+with a converting element:
+[1,/Map(...),3,...length:5]
+[
+  1,
+  /Map(...),
+  3,
+  ... length: 5
+]
+[
+  1,
+  {
+    "/Map": "/..."
+  },
+  3,
+  {
+    "/...": {
+      length: 5
+    }
+  }
+]
+
+in an object:
+{a:[1,2,3,...length:4]}
+{
+  a: [
+    1,
+    2,
+    3,
+    ... length: 4
+  ]
+}
+{
+  a: [
+    1,
+    2,
+    3,
+    {
+      "/...": {
+        length: 4
+      }
+    }
+  ]
+}
+
+holes crossing the limit:
+[1,void*2,...length:6]
+[
+  1,
+  void * 2,
+  ... length: 6
+]
+[
+  1,
+  void * 2,
+  {
+    "/...": {
+      length: 6
+    }
+  }
+]
+
+holes below the limit:
+[void*2,3,...length:4]
+[
+  void * 2,
+  3,
+  ... length: 4
+]
+[
+  void * 2,
+  3,
+  {
+    "/...": {
+      length: 4
+    }
+  }
+]
+
+holes among the elements:
+[1,void,3,...length:7]
+[
+  1,
+  void,
+  3,
+  ... length: 7
+]
+[
+  1,
+  void,
+  3,
+  {
+    "/...": {
+      length: 7
+    }
+  }
+]
+
+sparse, with `length` alone past the limit:
+[1,void*2,...length:500]
+[
+  1,
+  void * 2,
+  ... length: 500
+]
+[
+  1,
+  void * 2,
+  {
+    "/...": {
+      length: 500
+    }
+  }
+]

--- a/packages/data-model/test/value-debug-cases/max-depth-1.txt
+++ b/packages/data-model/test/value-debug-cases/max-depth-1.txt
@@ -1,0 +1,71 @@
+{
+  // At a depth limit of one, a container renders as its elision alone, while
+  // a scalar and a primitive are carried whole.
+  "/options": { maxDepth: 1 },
+  object: { a: 1 },
+  "empty object": {},
+  array: [1, 2],
+  "empty array": [],
+  scalar: 42,
+  string: "str",
+  primitive: new FabricEpochNsec(123n),
+  instance: new FabricLink({ id: "of:fid1:abc", path: ["x"] }),
+  "class instance": /ab+c/gi,
+}
+
+object:
+...
+...
+{
+  "/...": "object"
+}
+
+empty object:
+...
+...
+{
+  "/...": "object"
+}
+
+array:
+...
+...
+{
+  "/...": "array"
+}
+
+empty array:
+...
+...
+{
+  "/...": "array"
+}
+
+scalar:
+42
+42
+42
+
+string:
+"str"
+"str"
+"str"
+
+primitive:
+/EpochNsec(123n)
+/EpochNsec(123n)
+/EpochNsec(123n)
+
+instance:
+...
+...
+{
+  "/...": "FabricInstance (FabricLink)"
+}
+
+class instance:
+...
+...
+{
+  "/...": "RegExp"
+}

--- a/packages/data-model/test/value-debug-cases/max-depth-infinity.txt
+++ b/packages/data-model/test/value-debug-cases/max-depth-infinity.txt
@@ -1,0 +1,64 @@
+{
+  // A limit of `Infinity` renders past the default depth of ten levels.
+  "/options": { maxDepth: Infinity },
+  "twelve levels": (() => {
+    let value = "bottom";
+    for (let i = 0; i < 12; i++) {
+      value = { d: value };
+    }
+    return value;
+  })(),
+}
+
+twelve levels:
+{d:{d:{d:{d:{d:{d:{d:{d:{d:{d:{d:{d:"bottom"}}}}}}}}}}}}
+{
+  d: {
+    d: {
+      d: {
+        d: {
+          d: {
+            d: {
+              d: {
+                d: {
+                  d: {
+                    d: {
+                      d: {
+                        d: "bottom"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+{
+  d: {
+    d: {
+      d: {
+        d: {
+          d: {
+            d: {
+              d: {
+                d: {
+                  d: {
+                    d: {
+                      d: {
+                        d: "bottom"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/data-model/test/value-debug-cases/max-depth.txt
+++ b/packages/data-model/test/value-debug-cases/max-depth.txt
@@ -1,0 +1,126 @@
+{
+  // The rendering stops descending at its depth limit, and whatever lies
+  // below is elided, with its kind in its place. A scalar, a primitive, and
+  // an elision form at the limit are not containers, and are carried whole.
+  "/options": { maxDepth: 2 },
+  "object within the limit": { a: 1, b: "two" },
+  "object at the limit": { a: { b: 1 } },
+  "array at the limit": { a: [1, 2] },
+  "nested arrays": [[1, [2]]],
+  "unique symbol at the limit": { s: Symbol("leaf") },
+  "function at the limit": { f: function foo() {} },
+  "primitive at the limit": { t: new FabricEpochNsec(123n) },
+  "instance at the limit": {
+    e: FabricError.fromNativeError(new Error("boom")),
+  },
+  "class instance at the limit": { r: /ab+c/gi },
+  "map at the limit": { m: new Map([["a", 1]]) },
+}
+
+object within the limit:
+{a:1,b:"two"}
+{
+  a: 1,
+  b: "two"
+}
+{
+  a: 1,
+  b: "two"
+}
+
+object at the limit:
+{a:...}
+{
+  a: ...
+}
+{
+  a: {
+    "/...": "object"
+  }
+}
+
+array at the limit:
+{a:...}
+{
+  a: ...
+}
+{
+  a: {
+    "/...": "array"
+  }
+}
+
+nested arrays:
+[...]
+[
+  ...
+]
+[
+  {
+    "/...": "array"
+  }
+]
+
+unique symbol at the limit:
+{s:Symbol("leaf")}
+{
+  s: Symbol("leaf")
+}
+{
+  s: {
+    "/uniqueSymbol": "leaf"
+  }
+}
+
+function at the limit:
+{f:function foo(...){...}}
+{
+  f: function foo(...) {...}
+}
+{
+  f: {
+    "/function": "foo(...)"
+  }
+}
+
+primitive at the limit:
+{t:/EpochNsec(123n)}
+{
+  t: /EpochNsec(123n)
+}
+{
+  t: /EpochNsec(123n)
+}
+
+instance at the limit:
+{e:...}
+{
+  e: ...
+}
+{
+  e: {
+    "/...": "FabricInstance (FabricError)"
+  }
+}
+
+class instance at the limit:
+{r:...}
+{
+  r: ...
+}
+{
+  r: {
+    "/...": "RegExp"
+  }
+}
+
+map at the limit:
+{m:...}
+{
+  m: ...
+}
+{
+  m: {
+    "/...": "Map"
+  }
+}

--- a/packages/data-model/test/value-debug-cases/max-properties.txt
+++ b/packages/data-model/test/value-debug-cases/max-properties.txt
@@ -1,0 +1,164 @@
+{
+  // An object with more properties than the limit renders the first that
+  // many, in key order, and then its actual property count in place of the
+  // rest. The limit applies wherever properties are laid out: a plain
+  // object, a class instance's own properties, a primitive's realm state,
+  // and an instance's contents.
+  "/options": { maxProperties: 2 },
+  "past the limit": { a: 1, b: 2, c: 3, d: 4 },
+  "at the limit": { a: 1, b: 2 },
+  "below the limit": { a: 1 },
+  "in an object": { o: { a: 1, b: 2, c: 3 } },
+  "in an array": [{ a: 1, b: 2, c: 3 }],
+  "class instance": new (class Data {
+    a = 1;
+    b = 2;
+    c = 3;
+  })(),
+  "primitive's realm state": new (class Wide extends FabricPrimitive {
+    static get [REALM_CODEC]() {
+      return {
+        tagForValue: () => "Wide@1",
+        encode: () => ({ p: 1, q: 2, r: 3 }),
+      };
+    }
+  })(),
+  "instance's contents": new FabricLink({ id: "of:fid1:abc", a: 1, b: 2 }),
+  // A key of `/...` is escaped, and so is told apart from the count form.
+  "with a `/...` key": { "/...": 1, b: 2, c: 3 },
+}
+
+past the limit:
+{a:1,b:2,...count:4}
+{
+  a: 1,
+  b: 2,
+  ... count: 4
+}
+{
+  a: 1,
+  b: 2,
+  "/...": {
+    count: 4
+  }
+}
+
+at the limit:
+{a:1,b:2}
+{
+  a: 1,
+  b: 2
+}
+{
+  a: 1,
+  b: 2
+}
+
+below the limit:
+{a:1}
+{
+  a: 1
+}
+{
+  a: 1
+}
+
+in an object:
+{o:{a:1,b:2,...count:3}}
+{
+  o: {
+    a: 1,
+    b: 2,
+    ... count: 3
+  }
+}
+{
+  o: {
+    a: 1,
+    b: 2,
+    "/...": {
+      count: 3
+    }
+  }
+}
+
+in an array:
+[{a:1,b:2,...count:3}]
+[
+  {
+    a: 1,
+    b: 2,
+    ... count: 3
+  }
+]
+[
+  {
+    a: 1,
+    b: 2,
+    "/...": {
+      count: 3
+    }
+  }
+]
+
+class instance:
+/Data(a:1,b:2,...count:3)
+/Data(
+  a: 1,
+  b: 2,
+  ... count: 3
+)
+{
+  "/Data": {
+    a: 1,
+    b: 2,
+    "/...": {
+      count: 3
+    }
+  }
+}
+
+primitive's realm state:
+/Wide(p:1,q:2,...count:3)
+/Wide(
+  p: 1,
+  q: 2,
+  ... count: 3
+)
+/Wide(
+  p: 1,
+  q: 2,
+  r: 3
+)
+
+instance's contents:
+/Link(id:"of:fid1:abc",a:1,...count:3)
+/Link(
+  id: "of:fid1:abc",
+  a: 1,
+  ... count: 3
+)
+{
+  "/Link@1": {
+    id: "of:fid1:abc",
+    a: 1,
+    "/...": {
+      count: 3
+    }
+  }
+}
+
+with a `/...` key:
+{"/...":1,b:2,...count:3}
+{
+  "/...": 1,
+  b: 2,
+  ... count: 3
+}
+{
+  "//...": 1,
+  b: 2,
+  "/...": {
+    count: 3
+  }
+}

--- a/packages/data-model/test/value-debug-cases/max-string-both.txt
+++ b/packages/data-model/test/value-debug-cases/max-string-both.txt
@@ -1,0 +1,39 @@
+{
+  // When both string limits are given, the excerpt is the shorter of the
+  // two.
+  "/options": { maxStringLines: 2, maxStringLength: 8 },
+  "cut by the length": "abcdefghij\nkl\nmn",
+  "cut by the lines": "ab\ncd\nef",
+  "within both": "ab\ncd",
+}
+
+cut by the length:
+"abcdefgh"+...length:16
+"abcdefgh" +
+  ... length: 16
+{
+  "/partialString": {
+    length: 16,
+    excerpt: "abcdefgh"
+  }
+}
+
+cut by the lines:
+"ab\ncd\n"+...length:8
+"ab\n" +
+  "cd\n" +
+  ... length: 8
+{
+  "/partialString": {
+    length: 8,
+    excerpt: "ab\n" +
+      "cd\n"
+  }
+}
+
+within both:
+"ab\ncd"
+"ab\n" +
+  "cd"
+"ab\n" +
+  "cd"

--- a/packages/data-model/test/value-debug-cases/max-string-length.txt
+++ b/packages/data-model/test/value-debug-cases/max-string-length.txt
@@ -1,0 +1,115 @@
+{
+  // A string longer than the limit renders as an excerpt of that length, and
+  // then its actual length.
+  "/options": { maxStringLength: 5 },
+  "past the limit": "abcdefgh",
+  "at the limit": "abcde",
+  "in an object": { s: "abcdefgh" },
+  "in an array": ["abcdefgh"],
+  "class instance's `toString()` form": new (class Foo {
+    toString() {
+      return "abcdefgh";
+    }
+  })(),
+  // A multi-line string cut by the limit renders the cut line's excerpt with
+  // a ` +` of its own, and then the length.
+  "cut inside the second line": "abc\ndef",
+  // An excerpt never ends in half of a surrogate pair: a pair the limit
+  // would split is dropped, and one the limit ends after is kept.
+  "surrogate pair split by the limit": "abcd\u{1F600}x",
+  "surrogate pair ending at the limit": "abc\u{1F600}xy",
+}
+
+past the limit:
+"abcde"+...length:8
+"abcde" +
+  ... length: 8
+{
+  "/partialString": {
+    length: 8,
+    excerpt: "abcde"
+  }
+}
+
+at the limit:
+"abcde"
+"abcde"
+"abcde"
+
+in an object:
+{s:"abcde"+...length:8}
+{
+  s: "abcde" +
+    ... length: 8
+}
+{
+  s: {
+    "/partialString": {
+      length: 8,
+      excerpt: "abcde"
+    }
+  }
+}
+
+in an array:
+["abcde"+...length:8]
+[
+  "abcde" +
+    ... length: 8
+]
+[
+  {
+    "/partialString": {
+      length: 8,
+      excerpt: "abcde"
+    }
+  }
+]
+
+class instance's `toString()` form:
+/Foo("abcde"+...length:8)
+/Foo("abcde" +
+  ... length: 8)
+{
+  "/Foo": {
+    "/partialString": {
+      length: 8,
+      excerpt: "abcde"
+    }
+  }
+}
+
+cut inside the second line:
+"abc\nd"+...length:7
+"abc\n" +
+  "d" +
+  ... length: 7
+{
+  "/partialString": {
+    length: 7,
+    excerpt: "abc\n" +
+      "d"
+  }
+}
+
+surrogate pair split by the limit:
+"abcd"+...length:7
+"abcd" +
+  ... length: 7
+{
+  "/partialString": {
+    length: 7,
+    excerpt: "abcd"
+  }
+}
+
+surrogate pair ending at the limit:
+"abc😀"+...length:7
+"abc😀" +
+  ... length: 7
+{
+  "/partialString": {
+    length: 7,
+    excerpt: "abc😀"
+  }
+}

--- a/packages/data-model/test/value-debug-cases/max-string-lines.txt
+++ b/packages/data-model/test/value-debug-cases/max-string-lines.txt
@@ -1,0 +1,107 @@
+{
+  // A string of more lines than the limit renders as an excerpt of that many
+  // lines, line breaks included, and then its actual length.
+  "/options": { maxStringLines: 2 },
+  "past the limit": "a\nb\nc\nd",
+  "at the limit": "a\nb",
+  "in an object": { s: "a\nb\nc" },
+  // A line break is a newline, a carriage return, or the two together.
+  "carriage returns": "a\r\nb\rc\nd",
+  // A line break at the end of the string ends its last line rather than
+  // starting another.
+  "ending in a line break, at the limit": "a\nb\n",
+  "ending in an empty line, past the limit": "a\nb\n\n",
+  // A line cut keeps a lone high surrogate ahead of the line break, where a
+  // length cut would drop it.
+  "high surrogate before the break": "a\nb\ud800\nc",
+  // The length limit is not applied when only the line limit is given.
+  "210 characters on one line": "x".repeat(210),
+}
+
+past the limit:
+"a\nb\n"+...length:7
+"a\n" +
+  "b\n" +
+  ... length: 7
+{
+  "/partialString": {
+    length: 7,
+    excerpt: "a\n" +
+      "b\n"
+  }
+}
+
+at the limit:
+"a\nb"
+"a\n" +
+  "b"
+"a\n" +
+  "b"
+
+in an object:
+{s:"a\nb\n"+...length:5}
+{
+  s: "a\n" +
+    "b\n" +
+    ... length: 5
+}
+{
+  s: {
+    "/partialString": {
+      length: 5,
+      excerpt: "a\n" +
+        "b\n"
+    }
+  }
+}
+
+carriage returns:
+"a\r\nb\r"+...length:8
+"a\r\n" +
+  "b\r" +
+  ... length: 8
+{
+  "/partialString": {
+    length: 8,
+    excerpt: "a\r\n" +
+      "b\r"
+  }
+}
+
+ending in a line break, at the limit:
+"a\nb\n"
+"a\n" +
+  "b\n"
+"a\n" +
+  "b\n"
+
+ending in an empty line, past the limit:
+"a\nb\n"+...length:5
+"a\n" +
+  "b\n" +
+  ... length: 5
+{
+  "/partialString": {
+    length: 5,
+    excerpt: "a\n" +
+      "b\n"
+  }
+}
+
+high surrogate before the break:
+"a\nb\ud800\n"+...length:6
+"a\n" +
+  "b\ud800\n" +
+  ... length: 6
+{
+  "/partialString": {
+    length: 6,
+    excerpt: "a\n" +
+      "b\ud800\n"
+  }
+}
+
+210 characters on one line:
+"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"

--- a/packages/data-model/test/value-debug-cases/replacer.txt
+++ b/packages/data-model/test/value-debug-cases/replacer.txt
@@ -1,0 +1,58 @@
+{
+  // The replacer is called on every value, top-level and nested alike, and
+  // its replacement re-enters the conversion in the original's place. A
+  // replacer which throws is taken to have declined.
+  "/options": {
+    replacer: (value) => {
+      if (value === 1) return "one";
+      if (value === 2) return new Map();
+      if (value === 3) throw new Error("no thanks");
+      if (value?.whole === true) return "replaced";
+      return value;
+    },
+  },
+  "in place": { a: 1, b: 5 },
+  "converted, not verbatim": { a: 2 },
+  "declined by a throw": { a: 3, m: new Map() },
+  "top level": { whole: true, a: 1 },
+}
+
+in place:
+{a:"one",b:5}
+{
+  a: "one",
+  b: 5
+}
+{
+  a: "one",
+  b: 5
+}
+
+converted, not verbatim:
+{a:/Map(...)}
+{
+  a: /Map(...)
+}
+{
+  a: {
+    "/Map": "/..."
+  }
+}
+
+declined by a throw:
+{a:3,m:/Map(...)}
+{
+  a: 3,
+  m: /Map(...)
+}
+{
+  a: 3,
+  m: {
+    "/Map": "/..."
+  }
+}
+
+top level:
+"replaced"
+"replaced"
+"replaced"

--- a/packages/data-model/test/value-debug-structured.test.ts
+++ b/packages/data-model/test/value-debug-structured.test.ts
@@ -6,8 +6,10 @@
  * already wrong, so the two properties that matter most are pinned throughout:
  * the result is always a valid `FabricValue`, and a subvalue that cannot be
  * converted costs only itself rather than the whole result. The cases here are
- * arranged by what the input is, and then by the two knobs -- `maxDepth` and
- * `replacer` -- that change what comes back.
+ * arranged by what the input is, and then by the limit options, whose
+ * defaults and caps are pinned here while the conversions under other limits
+ * are recorded as case files under `value-debug-cases/`, each file's
+ * `/options` binding naming the limits its cases convert under.
  *
  * The marker vocabulary (`/circle`, `/...`, `/function`, `/uniqueSymbol`,
  * `/unconvertible`, and the leading-slash key escape) is deliberately not
@@ -347,49 +349,6 @@ describe("toStructuredDebugValue()", () => {
   });
 
   describe("with `maxDepth`", () => {
-    it("returns `/...` and the elided value's kind at the limit", () => {
-      expect(toStructuredDebugValue({ a: { b: 1 } }, { maxDepth: 2 }))
-        .toEqual({ a: { "/...": "object" } });
-      expect(toStructuredDebugValue({ a: [1, 2] }, { maxDepth: 2 }))
-        .toEqual({ a: { "/...": "array" } });
-    });
-
-    it("returns the elision at the top level given a `maxDepth` of `1`", () => {
-      expect(toStructuredDebugValue({ a: 1 }, { maxDepth: 1 }))
-        .toEqual({ "/...": "object" });
-    });
-
-    it("returns content within the limit unelided", () => {
-      // The converting leaf makes this say that conversion reached the
-      // bottom, not merely that nothing was elided on the way.
-
-      expect(
-        toStructuredDebugValue({ a: { b: Symbol("leaf") } }, { maxDepth: 3 }),
-      ).toEqual({ a: { b: { "/uniqueSymbol": "leaf" } } });
-    });
-
-    it("returns a `FabricPrimitive` at the limit rather than eliding it", () => {
-      // A primitive is atomic, so including it adds no nesting to the result.
-
-      const value = new FabricEpochNsec(123n);
-      const result = toStructuredDebugValue({ t: value }, { maxDepth: 2 });
-      expect((result as { t: unknown }).t).toBe(value);
-    });
-
-    it("returns a bounded result for a structure deeper than the default", () => {
-      let value: unknown = 1;
-      for (let i = 0; i < 300; i++) value = { o: value };
-
-      let at = toStructuredDebugValue(value) as Record<string, unknown>;
-      let levels = 0;
-      while (at && (typeof at === "object") && ("o" in at)) {
-        at = at.o as Record<string, unknown>;
-        levels++;
-      }
-      expect(levels).toBe(9);
-      expect(at).toEqual({ "/...": "object" });
-    });
-
     it("returns a result as deep as the conversion allows given `Infinity`", () => {
       let value: unknown = 1;
       for (let i = 0; i < 300; i++) value = { o: value };
@@ -423,57 +382,6 @@ describe("toStructuredDebugValue()", () => {
   });
 
   describe("with `maxArrayLength`", () => {
-    it("returns the elements below the limit, and `/...` carrying the length at it", () => {
-      const result = toStructuredDebugValue(
-        [1, new Map(), 3, 4, 5],
-        { maxArrayLength: 2 },
-      ) as unknown[];
-      expect(result).toEqual([
-        1,
-        { "/Map": "/..." },
-        { "/...": { length: 5 } },
-      ]);
-      expect(result.length).toBe(3);
-    });
-
-    it("returns an array whose length is the limit whole", () => {
-      expect(toStructuredDebugValue([1, 2, new Map()], { maxArrayLength: 3 }))
-        .toEqual([1, 2, { "/Map": "/..." }]);
-    });
-
-    it("returns the holes below the limit as holes, and none of the run past it", () => {
-      // The run of holes crosses the limit, so only the part of it below the
-      // limit is in the result.
-
-      const result = toStructuredDebugValue(
-        [1, , , , , new Map()],
-        { maxArrayLength: 3 },
-      ) as unknown[];
-      expect(result.length).toBe(4);
-      expect(Object.keys(result)).toEqual(["0", "3"]);
-      expect(result[3]).toEqual({ "/...": { length: 6 } });
-    });
-
-    it("returns the length form for a sparse array whose `length` alone is past the limit", () => {
-      const value: unknown[] = [new Map()];
-      value.length = 500;
-      const result = toStructuredDebugValue(
-        value,
-        { maxArrayLength: 3 },
-      ) as unknown[];
-      expect(result.length).toBe(4);
-      expect(Object.keys(result)).toEqual(["0", "3"]);
-      expect(result[3]).toEqual({ "/...": { length: 500 } });
-    });
-
-    it("returns no more than 100 elements when the limit is not given", () => {
-      const value = Array.from({ length: 150 }, (_, i) => i);
-      const result = toStructuredDebugValue(value) as unknown[];
-      expect(result.length).toBe(101);
-      expect(result[99]).toBe(99);
-      expect(result[100]).toEqual({ "/...": { length: 150 } });
-    });
-
     it("returns no more than 10000 elements given a larger limit", () => {
       const value = Array.from({ length: 20000 }, (_, i) => i);
       for (const limit of [50000, Infinity]) {
@@ -487,17 +395,6 @@ describe("toStructuredDebugValue()", () => {
       }
     });
 
-    it("returns the length form whole where it lands at the depth limit", () => {
-      // The form nests two levels, which is one more than the depth limit
-      // leaves room for, and it is carried whole regardless.
-
-      const result = toStructuredDebugValue(
-        { a: [1, 2, 3] },
-        { maxArrayLength: 1, maxDepth: 3 },
-      );
-      expect(result).toEqual({ a: [1, { "/...": { length: 3 } }] });
-    });
-
     it("throws given a `maxArrayLength` that is not a positive integer", () => {
       for (const bad of [0, -1, 1.5, -Infinity, NaN, "3", null, {}]) {
         const options = { maxArrayLength: bad as unknown as number };
@@ -509,62 +406,6 @@ describe("toStructuredDebugValue()", () => {
   });
 
   describe("with `maxProperties`", () => {
-    it("returns the first properties in key order, and `/...` with the count last", () => {
-      const value = { a: 1, b: 2, c: 3, d: 4 };
-      const result = toStructuredDebugValue(value, { maxProperties: 2 });
-      expect(result).toEqual({ a: 1, b: 2, "/...": { count: 4 } });
-      expect(Object.keys(result as object)).toEqual(["a", "b", "/..."]);
-    });
-
-    it("returns an object with as many properties as the limit whole", () => {
-      expect(toStructuredDebugValue({ a: 1, b: 2 }, { maxProperties: 2 }))
-        .toEqual({ a: 1, b: 2 });
-    });
-
-    it("returns the form in place of the properties of a nested object", () => {
-      expect(
-        toStructuredDebugValue(
-          { o: { a: 1, b: 2, c: 3 }, l: [{ a: 1, b: 2, c: 3 }] },
-          { maxProperties: 4 },
-        ),
-      ).toEqual({
-        o: { a: 1, b: 2, c: 3 },
-        l: [{ a: 1, b: 2, c: 3 }],
-      });
-      expect(
-        toStructuredDebugValue({ o: { a: 1, b: 2, c: 3 } }, {
-          maxProperties: 2,
-        }),
-      ).toEqual({ o: { a: 1, b: 2, "/...": { count: 3 } } });
-    });
-
-    it("returns the form in place of a class instance's properties past the limit", () => {
-      class Data {
-        a = 1;
-        b = 2;
-        c = 3;
-      }
-      expect(toStructuredDebugValue(new Data(), { maxProperties: 2 }))
-        .toEqual({ "/Data": { a: 1, b: 2, "/...": { count: 3 } } });
-    });
-
-    it("returns a user's `/...` key escaped, beside the form", () => {
-      expect(
-        toStructuredDebugValue({ "/...": 1, b: 2 }, { maxProperties: 1 }),
-      ).toEqual({ "//...": 1, "/...": { count: 2 } });
-    });
-
-    it("returns no more than 100 properties when the limit is not given", () => {
-      const value = Object.fromEntries(
-        Array.from({ length: 150 }, (_, i) => [`k${i}`, i]),
-      );
-      const result = toStructuredDebugValue(value) as Record<string, unknown>;
-      const keys = Object.keys(result);
-      expect(keys.length).toBe(101);
-      expect(keys[99]).toBe("k99");
-      expect(result["/..."]).toEqual({ count: 150 });
-    });
-
     it("returns no more than 10000 properties given a larger limit", () => {
       const value = Object.fromEntries(
         Array.from({ length: 10500 }, (_, i) => [`k${i}`, i]),
@@ -590,57 +431,6 @@ describe("toStructuredDebugValue()", () => {
   });
 
   describe("with `maxStringLength`", () => {
-    it("returns `/partialString` with the length and an excerpt for a string past the limit", () => {
-      expect(toStructuredDebugValue("abcdefgh", { maxStringLength: 5 }))
-        .toEqual({ "/partialString": { length: 8, excerpt: "abcde" } });
-    });
-
-    it("returns a string whose length is the limit whole", () => {
-      expect(toStructuredDebugValue("abcde", { maxStringLength: 5 }))
-        .toBe("abcde");
-    });
-
-    it("returns the form in place of a string inside a container", () => {
-      const partial = { "/partialString": { length: 8, excerpt: "abcde" } };
-      expect(
-        toStructuredDebugValue(
-          { s: "abcdefgh", a: ["abcdefgh"] },
-          { maxStringLength: 5 },
-        ),
-      ).toEqual({ s: partial, a: [partial] });
-    });
-
-    it("returns the form in place of a class instance's `toString()` form", () => {
-      class Foo {
-        toString() {
-          return "abcdefgh";
-        }
-      }
-      expect(toStructuredDebugValue(new Foo(), { maxStringLength: 5 }))
-        .toEqual({
-          "/Foo": { "/partialString": { length: 8, excerpt: "abcde" } },
-        });
-    });
-
-    it("returns an excerpt which does not end in half of a surrogate pair", () => {
-      // The emoji is two UTF-16 units, at indices 2 and 3; a limit of 3 cuts
-      // it in half, and the excerpt stops short of it instead.
-
-      const value = "ab\u{1F600}cd";
-      expect(toStructuredDebugValue(value, { maxStringLength: 3 }))
-        .toEqual({ "/partialString": { length: 6, excerpt: "ab" } });
-      expect(toStructuredDebugValue(value, { maxStringLength: 4 }))
-        .toEqual({ "/partialString": { length: 6, excerpt: "ab\u{1F600}" } });
-    });
-
-    it("returns no more than 200 characters when the limit is not given", () => {
-      const result = toStructuredDebugValue("x".repeat(250)) as {
-        "/partialString": { length: number; excerpt: string };
-      };
-      expect(result["/partialString"].length).toBe(250);
-      expect(result["/partialString"].excerpt).toBe("x".repeat(200));
-    });
-
     it("returns no more than 100000 characters given a larger limit", () => {
       const value = "x".repeat(150000);
       for (const limit of [200000, Infinity]) {
@@ -664,57 +454,6 @@ describe("toStructuredDebugValue()", () => {
   });
 
   describe("with `maxStringLines`", () => {
-    it("returns `/partialString` with the length and the first lines for a string past the limit", () => {
-      expect(toStructuredDebugValue("a\nb\nc\nd", { maxStringLines: 2 }))
-        .toEqual({ "/partialString": { length: 7, excerpt: "a\nb\n" } });
-    });
-
-    it("returns a string whose line count is the limit whole", () => {
-      expect(toStructuredDebugValue("a\nb", { maxStringLines: 2 }))
-        .toBe("a\nb");
-    });
-
-    it("counts a newline, a carriage return, and the two together as one line break each", () => {
-      expect(toStructuredDebugValue("a\r\nb\rc\nd", { maxStringLines: 3 }))
-        .toEqual({ "/partialString": { length: 8, excerpt: "a\r\nb\rc\n" } });
-    });
-
-    it("counts a final line break as ending the last line rather than starting another", () => {
-      expect(toStructuredDebugValue("a\nb\n", { maxStringLines: 2 }))
-        .toBe("a\nb\n");
-      expect(toStructuredDebugValue("a\nb\n\n", { maxStringLines: 2 }))
-        .toEqual({ "/partialString": { length: 5, excerpt: "a\nb\n" } });
-    });
-
-    it("returns whichever excerpt of the two limits is shorter", () => {
-      const value = "abcdefgh\nij";
-      const options = { maxStringLines: 1, maxStringLength: 5 };
-      expect(toStructuredDebugValue(value, options))
-        .toEqual({ "/partialString": { length: 11, excerpt: "abcde" } });
-      expect(
-        toStructuredDebugValue(value, { ...options, maxStringLength: 100 }),
-      )
-        .toEqual({ "/partialString": { length: 11, excerpt: "abcdefgh\n" } });
-    });
-
-    it("returns a line-cut excerpt ending in a high surrogate and its line break", () => {
-      expect(toStructuredDebugValue("a\ud800\nb", { maxStringLines: 1 }))
-        .toEqual({ "/partialString": { length: 4, excerpt: "a\ud800\n" } });
-    });
-
-    it("returns a string of any length whole when only the line limit is given", () => {
-      const value = "x".repeat(250);
-      expect(toStructuredDebugValue(value, { maxStringLines: 1 })).toBe(value);
-    });
-
-    it("returns no more than 5 lines when the limit is not given", () => {
-      const value = "a\nb\nc\nd\ne\nf";
-      expect(toStructuredDebugValue(value))
-        .toEqual({
-          "/partialString": { length: 11, excerpt: "a\nb\nc\nd\ne\n" },
-        });
-    });
-
     it("returns no more than 1000 lines given a larger limit", () => {
       const value = "x\n".repeat(1500) + "x";
       for (const limit of [2000, Infinity]) {
@@ -744,45 +483,6 @@ describe("toStructuredDebugValue()", () => {
           toStructuredDebugValue({}, bad as unknown as DebugValueOptions)
         ).toThrow("`options` must be a plain object or `undefined`; got `");
       }
-    });
-  });
-
-  describe("with a `replacer`", () => {
-    it("returns the replacement in place of the original value", () => {
-      const result = toStructuredDebugValue({ a: 1, b: 2 }, {
-        replacer: (value) => (value === 1 ? "one" : value),
-      });
-      expect(result).toEqual({ a: "one", b: 2 });
-    });
-
-    it("returns a replacement offered for the top-level value", () => {
-      const result = toStructuredDebugValue({ a: 1 }, {
-        replacer: (value) => (typeof value === "object" ? "replaced" : value),
-      });
-      expect(result).toBe("replaced");
-    });
-
-    it("returns the converted replacement, not the replacement verbatim", () => {
-      // The replacement re-enters conversion, so a value the replacer hands
-      // back still gets escaped, tagged, and depth-limited like any other.
-
-      const result = toStructuredDebugValue({ a: 1 }, {
-        replacer: (value) => (value === 1 ? new Map() : value),
-      });
-      expect(result).toEqual({ a: { "/Map": "/..." } });
-    });
-
-    it("returns the original value when the `replacer` throws", () => {
-      // A failed replacement reads as a refusal to replace rather than as a
-      // conversion error, so the rest of the result is unaffected.
-
-      const result = toStructuredDebugValue({ a: 1, m: new Map() }, {
-        replacer: (value) => {
-          if (value === 1) throw new Error("no thanks");
-          return value;
-        },
-      });
-      expect(result).toEqual({ a: 1, m: { "/Map": "/..." } });
     });
   });
 

--- a/packages/data-model/test/value-debug.test.ts
+++ b/packages/data-model/test/value-debug.test.ts
@@ -12,18 +12,17 @@
  * names what a value is without rendering it at all. The custom inspector is
  * how all of this reaches a `console.log()`. The renderings themselves are
  * recorded as case files under `value-debug-cases/`, which
- * `value-debug-cases.test.ts` checks; what is tested here is what a case
- * file cannot express.
+ * `value-debug-cases.test.ts` checks, a file's `/options` binding covering the
+ * renderings under other than the default options; what is tested here is
+ * what a case file cannot express.
  */
 
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
-import { REALM_CODEC } from "@/codec-interface/interface.ts";
 import {
   type CompactDebugStringOptions,
   type DebugValueOptions,
-  FabricPrimitive,
 } from "@/interface.ts";
 import {
   toCompactDebugString,
@@ -41,8 +40,8 @@ describe("value-debug", () => {
   describe("toCompactDebugString", () => {
     // The renderings themselves are recorded as case files in
     // `value-debug-cases/`. What is here is what a case file cannot express:
-    // a value at the top level, and the `maxLength` behavior at more than one
-    // length.
+    // a value at the top level against the same value nested, the `maxLength`
+    // behavior at more than one length, and the options that are refused.
 
     it("renders a top-level value the same as it renders that value in an array", () => {
       function foo() {}
@@ -65,10 +64,6 @@ describe("value-debug", () => {
         const nested = toCompactDebugString([value]);
         expect(toCompactDebugString(value)).toBe(nested.slice(1, -1));
       }
-    });
-
-    it("renders a string holding a line break on one line, the break escaped", () => {
-      expect(toCompactDebugString({ s: "a\nb" })).toBe('{s:"a\\nb"}');
     });
 
     describe("with `maxLength`", () => {
@@ -100,16 +95,6 @@ describe("value-debug", () => {
     });
 
     describe("with `backtickQuote`", () => {
-      it("renders the result as a code span", () => {
-        expect(toCompactDebugString({ a: 1 }, { backtickQuote: true }))
-          .toBe("`{a:1}`");
-      });
-
-      it("renders a result holding backticks with a longer delimiter", () => {
-        expect(toCompactDebugString("a`b", { backtickQuote: true }))
-          .toBe('``"a`b"``');
-      });
-
       it("renders the truncated result as the code span, when both are asked for", () => {
         const options = { maxLength: 8, backtickQuote: true };
         expect(toCompactDebugString({ abc: "defghij" }, options))
@@ -123,177 +108,19 @@ describe("value-debug", () => {
       });
     });
 
-    describe("with `maxDepth`", () => {
-      it("renders to the given depth rather than to the default", () => {
-        const value = { a: { b: { c: 1 } } };
-        expect(toCompactDebugString(value, { maxDepth: 2 })).toBe("{a:...}");
-        expect(toCompactDebugString(value, { maxDepth: 3 })).toBe(
-          "{a:{b:...}}",
+    it("throws given a limit that is not a positive integer", () => {
+      const names = [
+        "maxDepth",
+        "maxArrayLength",
+        "maxProperties",
+        "maxStringLength",
+        "maxStringLines",
+      ];
+      for (const name of names) {
+        expect(() => toCompactDebugString({}, { [name]: 0 })).toThrow(
+          `\`${name}\` must be a positive integer, \`Infinity\`, or`,
         );
-      });
-
-      it("renders past the default depth given `Infinity`", () => {
-        let value: unknown = "leaf";
-        for (let i = 0; i < 20; i++) value = { o: value };
-        expect(toCompactDebugString(value, { maxDepth: Infinity }))
-          .toContain('"leaf"');
-        expect(toIndentedDebugString(value, { maxDepth: Infinity }))
-          .toContain('"leaf"');
-      });
-
-      it("throws given a `maxDepth` that is not a positive integer", () => {
-        expect(() => toCompactDebugString({}, { maxDepth: 0 }))
-          .toThrow("`maxDepth` must be a positive integer, `Infinity`, or");
-      });
-    });
-
-    describe("with `maxArrayLength`", () => {
-      it("renders the elements below the limit, and the array's length in place of the rest", () => {
-        expect(toCompactDebugString([1, 2, 3, 4, 5], { maxArrayLength: 3 }))
-          .toBe("[1,2,3,...length:5]");
-        expect(toCompactDebugString({ a: [1, 2, 3] }, { maxArrayLength: 2 }))
-          .toBe("{a:[1,2,...length:3]}");
-      });
-
-      it("renders an array whose length is the limit whole", () => {
-        expect(toCompactDebugString([1, 2, 3], { maxArrayLength: 3 }))
-          .toBe("[1,2,3]");
-      });
-
-      it("renders only the holes below the limit of a run of holes which crosses it", () => {
-        expect(toCompactDebugString([1, , , , , 6], { maxArrayLength: 3 }))
-          .toBe("[1,void*2,...length:6]");
-        expect(toCompactDebugString([1, , , , , 6], { maxArrayLength: 2 }))
-          .toBe("[1,void,...length:6]");
-        expect(toCompactDebugString([1, , 3, , , , 7], { maxArrayLength: 4 }))
-          .toBe("[1,void,3,void,...length:7]");
-      });
-
-      it("renders no more than 100 elements when the limit is not given", () => {
-        const value = Array.from({ length: 101 }, (_, i) => i);
-        expect(toCompactDebugString(value)).toMatch(
-          /,99,\.\.\.length:101\]$/,
-        );
-      });
-
-      it("throws given a `maxArrayLength` that is not a positive integer", () => {
-        expect(() => toCompactDebugString([], { maxArrayLength: 0 })).toThrow(
-          "`maxArrayLength` must be a positive integer, `Infinity`, or",
-        );
-      });
-    });
-
-    describe("with `maxProperties`", () => {
-      it("renders the first properties, and the object's property count in place of the rest", () => {
-        const value = { a: 1, b: 2, c: 3 };
-        expect(toCompactDebugString(value, { maxProperties: 2 }))
-          .toBe("{a:1,b:2,...count:3}");
-        expect(toCompactDebugString({ o: value }, { maxProperties: 2 }))
-          .toBe("{o:{a:1,b:2,...count:3}}");
-      });
-
-      it("renders an object with as many properties as the limit whole", () => {
-        expect(toCompactDebugString({ a: 1, b: 2 }, { maxProperties: 2 }))
-          .toBe("{a:1,b:2}");
-      });
-
-      it("renders a `FabricPrimitive`'s realm state to the limit as well", () => {
-        class Wide extends FabricPrimitive {
-          static get [REALM_CODEC]() {
-            return {
-              tagForValue: () => "Wide@1",
-              encode: () => ({ p: 1, q: 2, r: 3 }),
-            };
-          }
-        }
-        expect(toCompactDebugString(new Wide(), { maxProperties: 2 }))
-          .toBe("/Wide(p:1,q:2,...count:3)");
-        expect(toIndentedDebugString(new Wide(), { maxProperties: 2 }))
-          .toBe("/Wide(\n  p: 1,\n  q: 2,\n  ... count: 3\n)");
-      });
-
-      it("renders a `FabricInstance`'s contents to the limit as well", () => {
-        const link = new FabricLink({ id: "of:fid1:abc", a: 1, b: 2 });
-        expect(toCompactDebugString(link, { maxProperties: 2 }))
-          .toBe('/Link(id:"of:fid1:abc",a:1,...count:3)');
-        expect(toIndentedDebugString(link, { maxProperties: 2 }))
-          .toBe('/Link(\n  id: "of:fid1:abc",\n  a: 1,\n  ... count: 3\n)');
-      });
-
-      it("renders no more than 100 properties when the limit is not given", () => {
-        const value = Object.fromEntries(
-          Array.from({ length: 101 }, (_, i) => [`k${i}`, i]),
-        );
-        expect(toCompactDebugString(value)).toMatch(
-          /,k99:99,\.\.\.count:101\}$/,
-        );
-      });
-
-      it("throws given a `maxProperties` that is not a positive integer", () => {
-        expect(() => toCompactDebugString({}, { maxProperties: 0 })).toThrow(
-          "`maxProperties` must be a positive integer, `Infinity`, or",
-        );
-      });
-    });
-
-    describe("with `maxStringLength`", () => {
-      it("renders an excerpt of the string, and the string's length after it", () => {
-        expect(toCompactDebugString("abcdefgh", { maxStringLength: 5 }))
-          .toBe('"abcde"+...length:8');
-        expect(toCompactDebugString({ s: "abcdefgh" }, { maxStringLength: 5 }))
-          .toBe('{s:"abcde"+...length:8}');
-      });
-
-      it("renders a string whose length is the limit whole", () => {
-        expect(toCompactDebugString("abcde", { maxStringLength: 5 }))
-          .toBe('"abcde"');
-      });
-
-      it("renders no more than 200 characters when the limit is not given", () => {
-        expect(toCompactDebugString("x".repeat(250)))
-          .toMatch(/^"x{200}"\+\.\.\.length:250$/);
-      });
-
-      it("throws given a `maxStringLength` that is not a positive integer", () => {
-        expect(() => toCompactDebugString("", { maxStringLength: 0 })).toThrow(
-          "`maxStringLength` must be a positive integer, `Infinity`, or",
-        );
-      });
-    });
-
-    describe("with `maxStringLines`", () => {
-      it("renders the string's first lines, and the string's length after them", () => {
-        expect(toCompactDebugString("a\nb\nc", { maxStringLines: 2 }))
-          .toBe('"a\\nb\\n"+...length:5');
-        expect(toCompactDebugString({ s: "a\nb\nc" }, { maxStringLines: 2 }))
-          .toBe('{s:"a\\nb\\n"+...length:5}');
-      });
-
-      it("renders a string whose line count is the limit whole", () => {
-        expect(toCompactDebugString("a\nb", { maxStringLines: 2 }))
-          .toBe('"a\\nb"');
-      });
-
-      it("renders no more than 5 lines when the limit is not given", () => {
-        expect(toCompactDebugString("a\nb\nc\nd\ne\nf"))
-          .toBe('"a\\nb\\nc\\nd\\ne\\n"+...length:11');
-      });
-
-      it("throws given a `maxStringLines` that is not a positive integer", () => {
-        expect(() => toCompactDebugString("", { maxStringLines: 0 })).toThrow(
-          "`maxStringLines` must be a positive integer, `Infinity`, or",
-        );
-      });
-    });
-
-    describe("with a `replacer`", () => {
-      it("renders the replacement in place of the original value", () => {
-        const options: CompactDebugStringOptions = {
-          replacer: (value) => (value === 1 ? "one" : value),
-        };
-        expect(toCompactDebugString({ a: 1, b: 2 }, options))
-          .toBe('{a:"one",b:2}');
-      });
+      }
     });
 
     it("throws given `options` that are not a plain object", () => {
@@ -323,32 +150,6 @@ describe("value-debug", () => {
       }
     });
 
-    it("renders to the given depth rather than to the default", () => {
-      const value = { a: { b: 1 } };
-      expect(toIndentedDebugString(value, { maxDepth: 2 }))
-        .toBe("{\n  a: ...\n}");
-    });
-
-    it("renders the array's length on its own line in place of the elements past the limit", () => {
-      expect(toIndentedDebugString([1, , , 4, 5], { maxArrayLength: 3 }))
-        .toBe("[\n  1,\n  void * 2,\n  ... length: 5\n]");
-    });
-
-    it("renders the object's property count on its own line in place of the properties past the limit", () => {
-      expect(toIndentedDebugString({ a: 1, b: 2, c: 3 }, { maxProperties: 2 }))
-        .toBe("{\n  a: 1,\n  b: 2,\n  ... count: 3\n}");
-    });
-
-    it("renders a string's excerpt and length in the string's place", () => {
-      expect(toIndentedDebugString({ s: "abcdefgh" }, { maxStringLength: 5 }))
-        .toBe('{\n  s: "abcde" +\n    ... length: 8\n}');
-    });
-
-    it("renders a string's first lines and length in the string's place", () => {
-      expect(toIndentedDebugString({ s: "a\nb\nc" }, { maxStringLines: 2 }))
-        .toBe('{\n  s: "a\\n" +\n    "b\\n" +\n    ... length: 5\n}');
-    });
-
     describe("with a string holding a line break", () => {
       it("renders each line quoted on a line of its own, joined by ` +`", () => {
         expect(toIndentedDebugString("a\nb\nc"))
@@ -374,18 +175,6 @@ describe("value-debug", () => {
         expect(toIndentedDebugString("a\n")).toBe('"a\\n"');
       });
 
-      it("renders a partial string's length on a line of its own", () => {
-        expect(toIndentedDebugString("a\nb\nc", { maxStringLines: 2 }))
-          .toBe('"a\\n" +\n  "b\\n" +\n  ... length: 5');
-        expect(toIndentedDebugString("abc\ndef", { maxStringLength: 5 }))
-          .toBe('"abc\\n" +\n  "d" +\n  ... length: 7');
-      });
-
-      it("renders a partial string's one-line excerpt with the length on the line after", () => {
-        expect(toIndentedDebugString("abc\ndef", { maxStringLines: 1 }))
-          .toBe('"abc\\n" +\n  ... length: 7');
-      });
-
       it("renders a class instance's `toString()` form the same way", () => {
         class Foo {
           toString() {
@@ -395,13 +184,6 @@ describe("value-debug", () => {
         expect(toIndentedDebugString({ foo: new Foo() }))
           .toBe('{\n  foo: /Foo("a\\n" +\n    "b")\n}');
       });
-    });
-
-    it("renders the replacement in place of the original value", () => {
-      const options: DebugValueOptions = {
-        replacer: (value) => (value === 1 ? "one" : value),
-      };
-      expect(toIndentedDebugString({ a: 1 }, options)).toBe('{\n  a: "one"\n}');
     });
 
     it("throws given `options` that are not a plain object", () => {


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Fable 5.1)

## What

The `value-debug` golden harness recognizes a `/options` property on a case
file's top-level object. When present, it is the options passed to all three
renderers (`toCompactDebugString()`, `toIndentedDebugString()`,
`toStructuredDebugValue()`) for every case in the file; a file that binds none
renders with the defaults, as before. The structured value's own whole
rendering keeps its every-limit-at-`Infinity` options, so where a string
rendering interprets a form, the third rendering still shows the form itself.
A `/options` bound to other than a plain object is refused with a message
naming it.

Eleven new case files record the renderings under other than the defaults,
one per subject:

- `max-depth` (limit 2), `max-depth-1` (a container at the top level renders
  as its elision alone), `max-depth-infinity` (past the default ten levels).
- `max-array-length`, `max-properties`, `max-string-length`,
  `max-string-lines`, and `max-string-both` (both string limits, whichever
  excerpt is shorter).
- `forms-at-depth-limit`: each elision form landing at the depth limit is
  carried whole, beside a container there, which is elided.
- `replacer` and `backtick-quote`.

The unit tests that asserted those same renderings by hand are removed from
`value-debug.test.ts` and `value-debug-structured.test.ts`. Every recorded
rendering was read against the assertion it replaces before the assertion
went; they agree. What stays in the unit tests is what a case file cannot
express: the `maxLength` relation at several lengths, the top-level-versus-
nested identity, the caps on a limit past its absolute maximum, and the
refusals of invalid options. The five one-value refusal tests in
`value-debug.test.ts` collapse into one loop over the limit names.

Also removed, called out because it reaches past the option-dependent tests:
the tests pinning the default limits (100 elements, 100 properties, 200
characters, 5 lines) and the escaped line break in a compact string, which
`array-long`, `object-long`, and `omnibus-string` already record.

## Verification

- Regenerating every case file with `UPDATE_GOLDENS=1` leaves the 49
  existing files byte-identical, so the harness change is neutral without
  `/options`.
- Control: a copy of the harness that drops the options fails exactly the 11
  new files and passes the 49 old ones.
- `deno task test` in `packages/data-model`: 49 passed (2765 steps), 0
  failed. `deno fmt --check`, `deno lint`, and `deno check` on the three
  edited test files: clean.
