### PR TITLE
refactor(runner): `PatternManager` keeps its tables and closure steps in `#` members behind `accessForTestingOnly`

### DIFF
--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -363,15 +363,12 @@ type ParkedReplication = {
 };
 
 export class PatternManager {
-  // A member below declared `private` rather than `#` is one the pattern-manager and cell-cache suites
-  // reach and drive directly; a `#` name would put it out of their reach.
-
   // Single-flight dedup + in-memory result cache for `compileOrGetPattern`,
   // keyed by a content hash of the program (NOT a cell id, NOT the retired
   // patternId) so identical source returns one shared, already-compiled pattern
   // instance. The hash is computed with `createRef` purely as a stable digest
   // function — no `pattern:` cell is ever minted. Bounded FIFO to cap memory.
-  private inProgressCompilations = new Map<string, Promise<Pattern>>();
+  readonly #inProgressCompilations = new Map<string, Promise<Pattern>>();
   // Single-flight dedup for the expensive tail of `loadPatternByIdentity`
   // (storage closure read + SES evaluation), keyed by `${space}\0${identity}`.
   // Boot references the same entry several times at once (one load per
@@ -381,7 +378,7 @@ export class PatternManager {
   // boot-floor buckets. Followers await the leader and then resolve their own
   // symbol from the indexes the leader's evaluation populated — the same path
   // a load arriving after completion takes.
-  private inProgressByIdentityLoads = new Map<
+  readonly #inProgressByIdentityLoads = new Map<
     string,
     Promise<Pattern | undefined>
   >();
@@ -416,11 +413,11 @@ export class PatternManager {
   // evaluated this session. Entries are live builder artifacts of evaluated
   // modules — the same order of retention the engine's strong implementation
   // index (E1) already committed to for their implementation functions.
-  private addressableByIdentity = new Map<string, Map<string, unknown>>();
+  readonly #addressableByIdentity = new Map<string, Map<string, unknown>>();
   // Bound for the module-NAMESPACE cache below (`modulesByIdentity`) only; its
   // misses recover through the async storage-backed load. Instance field so
   // tests can shrink it.
-  private maxEvaluatedModuleCacheSize = MAX_EVALUATED_MODULE_CACHE_SIZE;
+  #maxEvaluatedModuleCacheSize = MAX_EVALUATED_MODULE_CACHE_SIZE;
   // ESM content-addressed compile-cache instrumentation.
   #esmCacheStats = { hits: 0, misses: 0, byIdentityHits: 0 };
   // In-memory identity -> module-namespace cache (CT-1623). Populated for EVERY
@@ -429,16 +426,16 @@ export class PatternManager {
   // its parent's bundle instead of re-reading the closure from storage and
   // re-evaluating it in SES. Content-addressed, so a hit is always the same
   // bytes — never stale. Bounded (FIFO) to cap memory.
-  private modulesByIdentity = new Map<string, { exports: Exports }>();
+  readonly #modulesByIdentity = new Map<string, { exports: Exports }>();
   // In-flight compiled-cache write-backs; awaited by flushCompileCacheWrites()
   // for graceful shutdown / deterministic tests. Cold compile write-backs are
   // awaited by compilePattern; recovery/replication paths may still run in the
   // background.
-  private compileCacheWrites = new Set<Promise<unknown>>();
+  readonly #compileCacheWrites = new Set<Promise<unknown>>();
   // Closure write-backs that replication must observe before reading its
   // origin space. Tracked separately because the replication promise also
   // lives in `compileCacheWrites` and cannot await itself.
-  private pendingCacheWriteBacks = new Set<Promise<unknown>>();
+  readonly #pendingCacheWriteBacks = new Set<Promise<unknown>>();
   // In-flight replications keyed by TARGET space, ordered by a monotonic
   // ticket. A replication's origin may itself be mid-supply by an earlier
   // replication INTO it (e.g. the content-cache hit's fire-and-forget
@@ -655,7 +652,7 @@ export class PatternManager {
 
   // Maps each storage slot written during this PatternManager session to its
   // complete module set. One slot can hold only one closure shape at a time.
-  private persistedCompileCacheClosures = new Map<string, string>();
+  readonly #persistedCompileCacheClosures = new Map<string, string>();
   // Writes to one storage slot are serialized. Requests for the same closure
   // share the write that is already running.
   #inProgressCompileCacheWrites = new Map<
@@ -667,6 +664,93 @@ export class PatternManager {
   #failedCompileCacheRecoveries = new Set<string>();
 
   constructor(readonly runtime: Runtime) {}
+
+  /**
+   * The in-flight and cached compilation tables, the module-cache bound, and
+   * the three closure steps that a test drives directly.
+   */
+  get accessForTestingOnly(): {
+    readonly addressableByIdentity: Map<string, Map<string, unknown>>;
+    readonly compileCacheWrites: Set<Promise<unknown>>;
+    readonly inProgressByIdentityLoads: Map<
+      string,
+      Promise<Pattern | undefined>
+    >;
+    readonly inProgressCompilations: Map<string, Promise<Pattern>>;
+    maxEvaluatedModuleCacheSize: number;
+    readonly modulesByIdentity: Map<string, { exports: Exports }>;
+    readonly pendingCacheWriteBacks: Set<Promise<unknown>>;
+    readonly persistedCompileCacheClosures: Map<string, string>;
+    hasStoredCompileCacheClosure(
+      space: MemorySpace,
+      modules: readonly CacheableModule[],
+      entryIdentity: string,
+      opts: { runtimeVersion: string },
+      moduleDelegations?: ModuleDelegationMap,
+    ): Promise<boolean>;
+    loadPreviousSourceClosure(
+      space: MemorySpace,
+      entryIdentity: string,
+    ): Promise<Map<string, SourceDoc>>;
+    persistCompileCacheTracked(
+      space: MemorySpace,
+      modules: CacheableModule[],
+      entryIdentity: string,
+      opts: { runtimeVersion: string },
+      moduleDelegations?: ModuleDelegationMap,
+      delegated?: WritebackDelegation,
+    ): Promise<void>;
+  } {
+    // deno-lint-ignore no-this-alias
+    const outerThis = this;
+    return {
+      addressableByIdentity: this.#addressableByIdentity,
+      compileCacheWrites: this.#compileCacheWrites,
+      inProgressByIdentityLoads: this.#inProgressByIdentityLoads,
+      inProgressCompilations: this.#inProgressCompilations,
+      get maxEvaluatedModuleCacheSize() {
+        return outerThis.#maxEvaluatedModuleCacheSize;
+      },
+      set maxEvaluatedModuleCacheSize(value) {
+        outerThis.#maxEvaluatedModuleCacheSize = value;
+      },
+      modulesByIdentity: this.#modulesByIdentity,
+      pendingCacheWriteBacks: this.#pendingCacheWriteBacks,
+      persistedCompileCacheClosures: this.#persistedCompileCacheClosures,
+      hasStoredCompileCacheClosure: (
+        space,
+        modules,
+        entryIdentity,
+        opts,
+        moduleDelegations,
+      ) =>
+        this.#hasStoredCompileCacheClosure(
+          space,
+          modules,
+          entryIdentity,
+          opts,
+          moduleDelegations,
+        ),
+      loadPreviousSourceClosure: (space, entryIdentity) =>
+        this.#loadPreviousSourceClosure(space, entryIdentity),
+      persistCompileCacheTracked: (
+        space,
+        modules,
+        entryIdentity,
+        opts,
+        moduleDelegations,
+        delegated,
+      ) =>
+        this.#persistCompileCacheTracked(
+          space,
+          modules,
+          entryIdentity,
+          opts,
+          moduleDelegations,
+          delegated,
+        ),
+    };
+  }
 
   /**
    * Counters for the ESM content-addressed compile cache:
@@ -686,7 +770,7 @@ export class PatternManager {
 
   /** Resolve once all in-flight compiled-cache write-backs have settled. */
   async flushCompileCacheWrites(): Promise<void> {
-    await Promise.allSettled([...this.compileCacheWrites]);
+    await Promise.allSettled([...this.#compileCacheWrites]);
   }
 
   /**
@@ -712,9 +796,9 @@ export class PatternManager {
    * currently holds it.
    */
   hasPendingPatternWork(): boolean {
-    return this.inProgressCompilations.size > 0 ||
-      this.inProgressByIdentityLoads.size > 0 ||
-      this.compileCacheWrites.size > 0;
+    return this.#inProgressCompilations.size > 0 ||
+      this.#inProgressByIdentityLoads.size > 0 ||
+      this.#compileCacheWrites.size > 0;
   }
 
   /**
@@ -730,9 +814,9 @@ export class PatternManager {
    */
   async pendingPatternWorkSettled(): Promise<void> {
     await Promise.allSettled([
-      ...this.inProgressCompilations.values(),
-      ...this.inProgressByIdentityLoads.values(),
-      ...this.compileCacheWrites,
+      ...this.#inProgressCompilations.values(),
+      ...this.#inProgressByIdentityLoads.values(),
+      ...this.#compileCacheWrites,
     ]);
   }
 
@@ -982,8 +1066,8 @@ export class PatternManager {
       entries.delete(registration);
       if (entries.size === 0) this.#replicationsIntoSpace.delete(toSpace);
     });
-    this.compileCacheWrites.add(replication);
-    replication.finally(() => this.compileCacheWrites.delete(replication));
+    this.#compileCacheWrites.add(replication);
+    replication.finally(() => this.#compileCacheWrites.delete(replication));
   }
 
   /**
@@ -995,6 +1079,10 @@ export class PatternManager {
    * not copied across spaces: it carries writer authority and is valid only in
    * the space whose cache documents attest it. The ordinary save path still
    * preserves any authenticated delegation already present in `toSpace`.
+   *
+   * TypeScript-private rather than a `#` name, because `test/cell-cache.test.ts`
+   * and `test/pattern-replication-sibling-race.test.ts` replace this member by
+   * assignment, which a `#` method does not allow.
    */
   private async replicateClosures(
     entryIdentity: string,
@@ -1018,7 +1106,7 @@ export class PatternManager {
     // is about to become available. Await write-backs first. Use their own set,
     // not flushCompileCacheWrites: this replication promise is tracked there and
     // would await itself.
-    await Promise.allSettled([...this.pendingCacheWriteBacks]);
+    await Promise.allSettled([...this.#pendingCacheWriteBacks]);
     // Then the SIBLING suppliers (see `#replicationsIntoSpace`): the origin
     // may itself be mid-supply by an earlier-registered replication INTO
     // it. Await strictly older tickets only — acyclic by construction —
@@ -1203,8 +1291,8 @@ export class PatternManager {
       // `#parkedFailedReplications` and the register's RULING block), so
       // the short-circuit stays exactly as cheap and mask-free as
       // designed while no rescueable interleaving is lost.
-      const inFlightCompilations = [...this.inProgressCompilations.values()];
-      const inFlightLoads = [...this.inProgressByIdentityLoads.values()];
+      const inFlightCompilations = [...this.#inProgressCompilations.values()];
+      const inFlightLoads = [...this.#inProgressByIdentityLoads.values()];
       if (inFlightCompilations.length > 0 || inFlightLoads.length > 0) {
         logger.warn("closure-replication-await-inflight", () => [
           `entry=${entryIdentity}`,
@@ -1220,7 +1308,7 @@ export class PatternManager {
         // FRESH snapshot of that set (replications are never in it — no
         // self-await) so the persist has recorded before the re-read
         // consults the map.
-        await Promise.allSettled([...this.pendingCacheWriteBacks]);
+        await Promise.allSettled([...this.#pendingCacheWriteBacks]);
         origin = await readOriginWithFallbacks();
       }
     }
@@ -1287,7 +1375,7 @@ export class PatternManager {
         delegated,
       );
     } else {
-      await this.persistCompileCacheTracked(
+      await this.#persistCompileCacheTracked(
         toSpace,
         modules,
         entryIdentity,
@@ -1309,7 +1397,7 @@ export class PatternManager {
     }
   }
 
-  private async loadPreviousSourceClosure(
+  async #loadPreviousSourceClosure(
     space: MemorySpace,
     entryIdentity: string,
   ): Promise<Map<string, SourceDoc>> {
@@ -1486,7 +1574,7 @@ export class PatternManager {
     const { space } = cacheCtx;
     const previousSourceDocs = cacheCtx.previousEntryIdentity === undefined
       ? undefined
-      : await this.loadPreviousSourceClosure(
+      : await this.#loadPreviousSourceClosure(
         space,
         cacheCtx.previousEntryIdentity,
       );
@@ -1646,7 +1734,7 @@ export class PatternManager {
           // A storage miss makes any remembered success for this slot stale.
           // The process cache can still skip compilation, but the resulting
           // closure must be written back into the space again.
-          this.persistedCompileCacheClosures.delete(
+          this.#persistedCompileCacheClosures.delete(
             compileCachePersistenceSlotKey(space, entryIdentity, cacheOpts),
           );
           if (storageBodiesNeedingRepair !== undefined) {
@@ -1722,7 +1810,7 @@ export class PatternManager {
       // needs the closure here. A failed write fails the compile: persisted
       // refs-only pattern JSON would otherwise point at a closure that is not
       // durable in `space`.
-      await this.persistCompileCacheTracked(
+      await this.#persistCompileCacheTracked(
         space,
         modules,
         entryIdentity,
@@ -1779,7 +1867,7 @@ export class PatternManager {
       (patternCoverage !== undefined &&
         !cacheEntriesIncludePatternCoverage(closure.values()))
     ) {
-      this.persistedCompileCacheClosures.delete(
+      this.#persistedCompileCacheClosures.delete(
         compileCachePersistenceSlotKey(space, entryIdentity, cacheOpts),
       );
       return undefined;
@@ -1880,7 +1968,7 @@ export class PatternManager {
     // pointer via `associatePatternIdentity`. This path is independent of the
     // compiled cache (and of CFC enforcement), so it serves the same artifact
     // `artifactFromIdentitySync` would return.
-    const indexed = this.addressableByIdentity.get(entryIdentity)?.get(symbol);
+    const indexed = this.#addressableByIdentity.get(entryIdentity)?.get(symbol);
     if (
       !retryFailedRecovery && indexed !== undefined && isTrustedPattern(indexed)
     ) {
@@ -1927,14 +2015,14 @@ export class PatternManager {
       return undefined;
     }
     // Single-flight the expensive tail (see `inProgressByIdentityLoads`).
-    const pending = this.inProgressByIdentityLoads.get(key);
+    const pending = this.#inProgressByIdentityLoads.get(key);
     if (pending === undefined) {
       const load = this.#loadPatternByIdentityFromStorage(
         entryIdentity,
         symbol,
         space,
-      ).finally(() => this.inProgressByIdentityLoads.delete(key));
-      this.inProgressByIdentityLoads.set(key, load);
+      ).finally(() => this.#inProgressByIdentityLoads.delete(key));
+      this.#inProgressByIdentityLoads.set(key, load);
       return await load;
     }
     // Follower: the leader's evaluation indexes every symbol of the closure,
@@ -1995,7 +2083,7 @@ export class PatternManager {
       (patternCoverage !== undefined &&
         !cacheEntriesIncludePatternCoverage(closure.values()))
     ) {
-      this.persistedCompileCacheClosures.delete(
+      this.#persistedCompileCacheClosures.delete(
         compileCachePersistenceSlotKey(space, entryIdentity, cacheOpts),
       );
       return await this.#tryColdLoadByIdentity(
@@ -2190,7 +2278,7 @@ export class PatternManager {
       const pattern = this.#patternFromMain(result, symbol, entryIdentity);
       if (cacheOpts !== undefined) {
         const recoveryKey = compileCacheRecoveryKey(space, entryIdentity);
-        const repair = this.persistCompileCacheTracked(
+        const repair = this.#persistCompileCacheTracked(
           space,
           compiled.modules,
           entryIdentity,
@@ -2206,8 +2294,8 @@ export class PatternManager {
             String(error),
           ]);
         });
-        this.compileCacheWrites.add(repair);
-        repair.finally(() => this.compileCacheWrites.delete(repair));
+        this.#compileCacheWrites.add(repair);
+        repair.finally(() => this.#compileCacheWrites.delete(repair));
       }
       return pattern;
     } catch (error) {
@@ -2259,7 +2347,7 @@ export class PatternManager {
     const pattern =
       (symbol in main
         ? main[symbol]
-        : this.addressableByIdentity.get(entryIdentity)?.get(symbol)) as
+        : this.#addressableByIdentity.get(entryIdentity)?.get(symbol)) as
           | Pattern
           | undefined;
     if (!pattern) {
@@ -2306,8 +2394,8 @@ export class PatternManager {
         // `modulesByIdentity` keeps the whole namespace for MODULE reuse on a
         // by-identity reload (a separate concern from artifact addressing).
         // Refresh insertion order (Map is FIFO-ordered) so eviction is ~LRU.
-        this.modulesByIdentity.delete(identity);
-        this.modulesByIdentity.set(identity, { exports });
+        this.#modulesByIdentity.delete(identity);
+        this.#modulesByIdentity.set(identity, { exports });
         // Index each exported builder artifact for addressing by its export name.
         // (Reload relies on this so a sub-pattern's result cell loads BY IDENTITY
         // instead of cold-recompiling — CT-1623.)
@@ -2324,10 +2412,10 @@ export class PatternManager {
           }
         }
       }
-      while (this.modulesByIdentity.size > this.maxEvaluatedModuleCacheSize) {
-        const oldest = this.modulesByIdentity.keys().next().value;
+      while (this.#modulesByIdentity.size > this.#maxEvaluatedModuleCacheSize) {
+        const oldest = this.#modulesByIdentity.keys().next().value;
         if (oldest === undefined) break;
-        this.modulesByIdentity.delete(oldest);
+        this.#modulesByIdentity.delete(oldest);
       }
     }
 
@@ -2371,10 +2459,10 @@ export class PatternManager {
     // Reverse index. Overwrite an existing symbol so a re-evaluation of the
     // same identity resolves to the FRESH artifact instance, not a stale one
     // from a prior eval.
-    let bucket = this.addressableByIdentity.get(identity);
+    let bucket = this.#addressableByIdentity.get(identity);
     if (!bucket) {
       bucket = new Map<string, unknown>();
-      this.addressableByIdentity.set(identity, bucket);
+      this.#addressableByIdentity.set(identity, bucket);
     }
     bucket.set(symbol, value);
     // Forward map is FIRST-WRITE-WINS, deliberately, on two grounds:
@@ -2410,7 +2498,7 @@ export class PatternManager {
   ): unknown {
     // Returns the live builder artifact (pattern / lift / handler). Callers know
     // the kind they expect from the symbol's origin and cast accordingly.
-    return this.addressableByIdentity.get(identity)?.get(symbol);
+    return this.#addressableByIdentity.get(identity)?.get(symbol);
   }
 
   /**
@@ -2443,7 +2531,7 @@ export class PatternManager {
     entryIdentity: string,
     symbol: string,
   ): Pattern | undefined {
-    const cached = this.modulesByIdentity.get(entryIdentity);
+    const cached = this.#modulesByIdentity.get(entryIdentity);
     if (!cached) return undefined;
     // The symbol is usually an authored export, but a map/filter/flatMap `op`
     // result cell references a transformer HOIST (`__cfReg`, e.g. `__cfPattern_1`)
@@ -2453,13 +2541,13 @@ export class PatternManager {
     const pattern =
       (symbol in cached.exports
         ? cached.exports[symbol]
-        : this.addressableByIdentity.get(entryIdentity)?.get(symbol)) as
+        : this.#addressableByIdentity.get(entryIdentity)?.get(symbol)) as
           | Pattern
           | undefined;
     if (!pattern || !isTrustedPattern(pattern)) return undefined;
     // Refresh recency.
-    this.modulesByIdentity.delete(entryIdentity);
-    this.modulesByIdentity.set(entryIdentity, cached);
+    this.#modulesByIdentity.delete(entryIdentity);
+    this.#modulesByIdentity.set(entryIdentity, cached);
     setArtifactEntryRef(pattern, { identity: entryIdentity, symbol });
     return pattern;
   }
@@ -2486,7 +2574,7 @@ export class PatternManager {
       : {};
   }
 
-  private async persistCompileCacheTracked(
+  async #persistCompileCacheTracked(
     space: MemorySpace,
     modules: CacheableModule[],
     entryIdentity: string,
@@ -2519,10 +2607,10 @@ export class PatternManager {
 
       if (
         predecessor === undefined &&
-        this.persistedCompileCacheClosures.get(persistenceSlotKey) ===
+        this.#persistedCompileCacheClosures.get(persistenceSlotKey) ===
           closureSignature
       ) {
-        const stored = await this.hasStoredCompileCacheClosure(
+        const stored = await this.#hasStoredCompileCacheClosure(
           space,
           modules,
           entryIdentity,
@@ -2539,7 +2627,7 @@ export class PatternManager {
           );
           return;
         }
-        this.persistedCompileCacheClosures.delete(persistenceSlotKey);
+        this.#persistedCompileCacheClosures.delete(persistenceSlotKey);
       }
 
       await this.writeBackCompileCache(
@@ -2550,7 +2638,7 @@ export class PatternManager {
         moduleDelegations,
         delegated,
       );
-      this.persistedCompileCacheClosures.set(
+      this.#persistedCompileCacheClosures.set(
         persistenceSlotKey,
         closureSignature,
       );
@@ -2566,8 +2654,8 @@ export class PatternManager {
       closureSignature,
       persistence,
     });
-    this.compileCacheWrites.add(persistence);
-    this.pendingCacheWriteBacks.add(persistence);
+    this.#compileCacheWrites.add(persistence);
+    this.#pendingCacheWriteBacks.add(persistence);
     try {
       await persistence;
     } finally {
@@ -2577,12 +2665,12 @@ export class PatternManager {
       if (current?.persistence === persistence) {
         this.#inProgressCompileCacheWrites.delete(persistenceSlotKey);
       }
-      this.compileCacheWrites.delete(persistence);
-      this.pendingCacheWriteBacks.delete(persistence);
+      this.#compileCacheWrites.delete(persistence);
+      this.#pendingCacheWriteBacks.delete(persistence);
     }
   }
 
-  private async hasStoredCompileCacheClosure(
+  async #hasStoredCompileCacheClosure(
     space: MemorySpace,
     modules: readonly CacheableModule[],
     entryIdentity: string,
@@ -2646,8 +2734,8 @@ export class PatternManager {
       moduleDelegations,
       delegated,
     );
-    this.compileCacheWrites.add(writeBack);
-    this.pendingCacheWriteBacks.add(writeBack);
+    this.#compileCacheWrites.add(writeBack);
+    this.#pendingCacheWriteBacks.add(writeBack);
     try {
       await writeBack;
       this.#recordPersistedClosureSpaces(
@@ -2655,8 +2743,8 @@ export class PatternManager {
         space,
       );
     } finally {
-      this.compileCacheWrites.delete(writeBack);
-      this.pendingCacheWriteBacks.delete(writeBack);
+      this.#compileCacheWrites.delete(writeBack);
+      this.#pendingCacheWriteBacks.delete(writeBack);
     }
   }
 
@@ -2712,6 +2800,9 @@ export class PatternManager {
    * pattern's own space writes) retries rather than silently dropping the
    * entry. A final failure throws because persisted refs-only pattern JSON
    * requires a durable closure behind every `$patternRef`.
+   *
+   * TypeScript-private rather than a `#` name, because `test/cell-cache.test.ts`
+   * replaces this member by assignment, which a `#` method does not allow.
    */
   private async writeBackCompileCache(
     space: MemorySpace,
@@ -2955,7 +3046,7 @@ export class PatternManager {
       return Promise.resolve(cached.pattern);
     }
 
-    const inProgress = this.inProgressCompilations.get(dedupeKey);
+    const inProgress = this.#inProgressCompilations.get(dedupeKey);
     if (inProgress) return inProgress;
 
     // Pass the cell-cache context when a space is available so nested/dynamic
@@ -2974,10 +3065,10 @@ export class PatternManager {
         return pattern;
       })
       .finally(() => {
-        this.inProgressCompilations.delete(dedupeKey);
+        this.#inProgressCompilations.delete(dedupeKey);
       });
 
-    this.inProgressCompilations.set(dedupeKey, compilationPromise);
+    this.#inProgressCompilations.set(dedupeKey, compilationPromise);
     return compilationPromise;
   }
 

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -414,7 +414,7 @@ export class PatternManager {
   // modules — the same order of retention the engine's strong implementation
   // index (E1) already committed to for their implementation functions.
   readonly #addressableByIdentity = new Map<string, Map<string, unknown>>();
-  // Bound for the module-NAMESPACE cache below (`modulesByIdentity`) only; its
+  // Bound for the module-NAMESPACE cache below (`#modulesByIdentity`) only; its
   // misses recover through the async storage-backed load. Instance field so
   // tests can shrink it.
   #maxEvaluatedModuleCacheSize = MAX_EVALUATED_MODULE_CACHE_SIZE;
@@ -434,7 +434,7 @@ export class PatternManager {
   readonly #compileCacheWrites = new Set<Promise<unknown>>();
   // Closure write-backs that replication must observe before reading its
   // origin space. Tracked separately because the replication promise also
-  // lives in `compileCacheWrites` and cannot await itself.
+  // lives in `#compileCacheWrites` and cannot await itself.
   readonly #pendingCacheWriteBacks = new Set<Promise<unknown>>();
   // In-flight replications keyed by TARGET space, ordered by a monotonic
   // ticket. A replication's origin may itself be mid-supply by an earlier
@@ -444,7 +444,7 @@ export class PatternManager {
   // ever re-issuing it, and the target space's demanded roots park
   // `pattern-unloadable` forever (verification-coverage.md OW45, the
   // lunch forever-park — the incident evidence lives there). The sibling
-  // lives in `compileCacheWrites`, the one set the origin read must NOT
+  // lives in `#compileCacheWrites`, the one set the origin read must NOT
   // await wholesale (it would await itself), so replications also
   // register HERE and the read awaits only the STRICTLY OLDER entries
   // targeting its origin — registration order keeps the await graph
@@ -784,14 +784,14 @@ export class PatternManager {
    * tearing the page down loses no writes", and a program commit
    * issued from a post-arrival load chain is exactly a write a reload
    * would otherwise kill (the home-profile program-write loss). Three
-   * registries cover the chains end to end: `inProgressCompilations`
+   * registries cover the chains end to end: `#inProgressCompilations`
    * registers SYNCHRONOUSLY at `compileOrGetPattern` — which
    * `compile-and-run` launches as a FLOATING promise, so nothing else
    * holds the scheduler while TypeScript compiles — and its promise
    * resolves only after `compilePattern` has awaited persistence; the
    * single-flight load slot registers in the load's first awaits
    * (before any storage read); and the persistence slot registers at
-   * `persistCompileCacheTracked` entry. A chain running when the
+   * `#persistCompileCacheTracked` entry. A chain running when the
    * barrier's fixpoint drains is visible through whichever registry
    * currently holds it.
    */
@@ -971,7 +971,7 @@ export class PatternManager {
    * when the pattern carries an artifact entry ref (the by-identity reload path
    * — the only one a `{ identity, symbol }` piece pointer can take).
    *
-   * Closure replication is fire-and-forget (tracked in `compileCacheWrites`,
+   * Closure replication is fire-and-forget (tracked in `#compileCacheWrites`,
    * awaited by `flushCompileCacheWrites`): the child is loadable in-session
    * regardless, this only affects fresh runtimes. A failure is logged and
    * retried on the next child creation and on the next persist event —
@@ -999,7 +999,7 @@ export class PatternManager {
    * registration in `#replicationsIntoSpace` BEFORE the async body starts
    * (so a replication issued later in the same synchronous stretch
    * observes this entry when it awaits its origin's suppliers) and in
-   * `compileCacheWrites` (so `flushCompileCacheWrites` and the durability
+   * `#compileCacheWrites` (so `flushCompileCacheWrites` and the durability
    * barrier observe it). Shared by `replicatePatternToSpace` and the 3b
    * heal's re-issues, so a re-issued replication is a FULL fresh
    * replication — same ticket discipline, same acyclicity (the ticket
@@ -1262,7 +1262,7 @@ export class PatternManager {
       // neither hang nor reject this replication; entries registered
       // after the snapshot are the next consult's business), covering
       // BOTH cold compiles AND by-identity loads (a supplier can be a
-      // load's recovery compile) but NEVER `compileCacheWrites`: this
+      // load's recovery compile) but NEVER `#compileCacheWrites`: this
       // replication promise lives there and would await itself. Acyclic:
       // compiles and loads never await replications (their only
       // replication call is fire-and-forget), and a compile promise
@@ -1272,7 +1272,7 @@ export class PatternManager {
       // EMPTY SNAPSHOT → NO RETRY, byte-identical one-shot throw below.
       // Deliberate, twice over: (a) with nothing in the registries there
       // is no supplier whose completion the await could observe — every
-      // `pendingCacheWriteBacks` member belongs to a compile or load
+      // `#pendingCacheWriteBacks` member belongs to a compile or load
       // (registry-covered here) or to a sibling replication, which the
       // strictly-older-ticket await above already covers at registration
       // time, so an empty-registry retry adds no coverage the design
@@ -1304,7 +1304,7 @@ export class PatternManager {
         await Promise.allSettled([...inFlightCompilations, ...inFlightLoads]);
         // A settled by-identity load's recovery persist is fire-and-forget:
         // the load resolves after REGISTERING it in
-        // `pendingCacheWriteBacks`, not after completing it. Observe a
+        // `#pendingCacheWriteBacks`, not after completing it. Observe a
         // FRESH snapshot of that set (replications are never in it — no
         // self-await) so the persist has recorded before the re-read
         // consults the map.
@@ -2014,7 +2014,7 @@ export class PatternManager {
     if (this.#coldLoadNegativeMemo.suppresses(key, runtimeVersion)) {
       return undefined;
     }
-    // Single-flight the expensive tail (see `inProgressByIdentityLoads`).
+    // Single-flight the expensive tail (see `#inProgressByIdentityLoads`).
     const pending = this.#inProgressByIdentityLoads.get(key);
     if (pending === undefined) {
       const load = this.#loadPatternByIdentityFromStorage(
@@ -2391,7 +2391,7 @@ export class PatternManager {
     if (byId) {
       assertNoReservedHoistExports(byId);
       for (const [identity, exports] of byId) {
-        // `modulesByIdentity` keeps the whole namespace for MODULE reuse on a
+        // `#modulesByIdentity` keeps the whole namespace for MODULE reuse on a
         // by-identity reload (a separate concern from artifact addressing).
         // Refresh insertion order (Map is FIFO-ordered) so eviction is ~LRU.
         this.#modulesByIdentity.delete(identity);
@@ -2432,14 +2432,14 @@ export class PatternManager {
       }
     }
 
-    // No eviction for `addressableByIdentity` — the artifact index is
+    // No eviction for `#addressableByIdentity` — the artifact index is
     // session-lifetime (see its declaration): sync by-identity resolution
     // must keep working for every module evaluated this session.
   }
 
   /**
    * Index one content-addressed builder artifact `{ identity, symbol } -> value`,
-   * the single path that populates both the reverse `addressableByIdentity` and
+   * the single path that populates both the reverse `#addressableByIdentity` and
    * forward `valueToEntryRef` maps — whether the value came from a module's
    * `__cfReg` registration (hoists + non-exported top-level) or its exports.
    *
@@ -2554,7 +2554,7 @@ export class PatternManager {
 
   /**
    * Write the module set into `space` and AWAIT it, tracking the in-flight
-   * promise in `compileCacheWrites` + `pendingCacheWriteBacks` (so graceful
+   * promise in `#compileCacheWrites` + `#pendingCacheWriteBacks` (so graceful
    * shutdown and closure replication can observe it). A failure PROPAGATES and
    * fails the compile: refs-only pattern JSON makes a durable closure in `space`
    * part of the compilation contract.
@@ -2600,7 +2600,7 @@ export class PatternManager {
     }
 
     // Install the successor as the slot's tail before waiting for its
-    // predecessor. Replication snapshots `pendingCacheWriteBacks`, so every
+    // predecessor. Replication snapshots `#pendingCacheWriteBacks`, so every
     // write already requested when that snapshot is taken must be represented.
     const persistence = (async () => {
       await predecessor?.persistence.catch(() => {});
@@ -3039,7 +3039,7 @@ export class PatternManager {
       // { identity, symbol } in a fresh runtime (the meta-cell fallback is
       // gone). When this hit serves a different space than the one we first
       // compiled into, replicate the closure there — cheap (no TS recompile),
-      // with persistence writes deduplicated and tracked in compileCacheWrites.
+      // with persistence writes deduplicated and tracked in `#compileCacheWrites`.
       if (space && cached.space && space !== cached.space) {
         this.replicatePatternToSpace(cached.pattern, space, cached.space);
       }

--- a/packages/runner/test/artifact-index-pinning.test.ts
+++ b/packages/runner/test/artifact-index-pinning.test.ts
@@ -58,8 +58,7 @@ describe("artifact index pinning (session-lifetime)", () => {
     const pm = runtime.patternManager;
     // Shrink the bounded module-namespace cache so three compiles overflow it.
     // The ARTIFACT index must not be governed by this bound.
-    (pm as unknown as { maxEvaluatedModuleCacheSize: number })
-      .maxEvaluatedModuleCacheSize = 1;
+    pm.accessForTestingOnly.maxEvaluatedModuleCacheSize = 1;
 
     const first = await pm.compilePattern(program(1));
     const firstRef = pm.getArtifactEntryRef(first);
@@ -93,8 +92,7 @@ describe("artifact index pinning (session-lifetime)", () => {
     const tx = runtime.edit();
     await pm.compilePattern(program(7), { space: signer.did(), tx });
     await tx.commit();
-    const pending = (pm as unknown as { pendingCacheWriteBacks: Set<unknown> })
-      .pendingCacheWriteBacks;
+    const pending = pm.accessForTestingOnly.pendingCacheWriteBacks;
     expect(pending.size).toBe(0);
   });
 });

--- a/packages/runner/test/cell-cache.test.ts
+++ b/packages/runner/test/cell-cache.test.ts
@@ -1948,15 +1948,7 @@ describe("cell-cache: compiled-set store (CFC integrity, fail-closed)", () => {
     const requiredDelegations = new Map([
       [entryIdentity, new Set(["required-predecessor"])],
     ]);
-    const manager = runtime.patternManager as unknown as {
-      hasStoredCompileCacheClosure(
-        space: string,
-        modules: readonly CacheableModule[],
-        entryIdentity: string,
-        opts: { runtimeVersion: string },
-        moduleDelegations: ReadonlyMap<string, ReadonlySet<string>>,
-      ): Promise<boolean>;
-    };
+    const manager = runtime.patternManager.accessForTestingOnly;
 
     const initialWrite = runtime.edit();
     writeSourceDocs(
@@ -2096,14 +2088,7 @@ describe("cell-cache: compiled-set store (CFC integrity, fail-closed)", () => {
     });
     expect(second.entryIdentity).toBe(first.entryIdentity);
 
-    const manager = runtime.patternManager as unknown as {
-      persistCompileCacheTracked(
-        space: string,
-        modules: CacheableModule[],
-        entryIdentity: string,
-        opts: { runtimeVersion: string },
-      ): Promise<void>;
-    };
+    const manager = runtime.patternManager.accessForTestingOnly;
     await manager.persistCompileCacheTracked(
       targetSpace,
       first.modules,
@@ -2174,22 +2159,18 @@ describe("cell-cache: compiled-set store (CFC integrity, fail-closed)", () => {
         { name: "/second.ts", contents: "export const second = 2;" },
       ],
     });
-    const manager = runtime.patternManager as unknown as {
-      persistCompileCacheTracked(
-        space: string,
-        modules: CacheableModule[],
-        entryIdentity: string,
-        opts: { runtimeVersion: string },
-      ): Promise<void>;
+    const manager = runtime.patternManager.accessForTestingOnly;
+    // Replaced by assignment below, which only a TypeScript-private member
+    // allows, so it is reached the old way.
+    const stubbed = runtime.patternManager as unknown as {
       writeBackCompileCache(
         space: string,
         modules: CacheableModule[],
         entryIdentity: string,
         opts: { runtimeVersion: string },
       ): Promise<void>;
-      pendingCacheWriteBacks: Set<Promise<unknown>>;
     };
-    const originalWriteBack = manager.writeBackCompileCache;
+    const originalWriteBack = stubbed.writeBackCompileCache;
     const firstStarted = Promise.withResolvers<void>();
     const releaseFirst = Promise.withResolvers<void>();
     const secondStarted = Promise.withResolvers<void>();
@@ -2197,7 +2178,7 @@ describe("cell-cache: compiled-set store (CFC integrity, fail-closed)", () => {
     let writeCount = 0;
     let firstWrite: Promise<void> | undefined;
     let secondWrite: Promise<void> | undefined;
-    manager.writeBackCompileCache = async () => {
+    stubbed.writeBackCompileCache = async () => {
       writeCount++;
       if (writeCount === 1) {
         firstStarted.resolve();
@@ -2237,29 +2218,25 @@ describe("cell-cache: compiled-set store (CFC integrity, fail-closed)", () => {
           (write): write is Promise<void> => write !== undefined,
         ),
       );
-      manager.writeBackCompileCache = originalWriteBack;
+      stubbed.writeBackCompileCache = originalWriteBack;
     }
   });
 
   it("retains persistence entries for the runner session", async () => {
     const { modules, entryIdentity } = toModules(PROGRAM);
-    const manager = runtime.patternManager as unknown as {
-      persistCompileCacheTracked(
-        space: string,
-        modules: CacheableModule[],
-        entryIdentity: string,
-        opts: { runtimeVersion: string },
-      ): Promise<void>;
+    const manager = runtime.patternManager.accessForTestingOnly;
+    // Replaced by assignment below, which only a TypeScript-private member
+    // allows, so it is reached the old way.
+    const stubbed = runtime.patternManager as unknown as {
       writeBackCompileCache(
         space: string,
         modules: CacheableModule[],
         entryIdentity: string,
         opts: { runtimeVersion: string },
       ): Promise<void>;
-      persistedCompileCacheClosures: Map<string, string>;
     };
-    const originalWriteBack = manager.writeBackCompileCache;
-    manager.writeBackCompileCache = () => Promise.resolve();
+    const originalWriteBack = stubbed.writeBackCompileCache;
+    stubbed.writeBackCompileCache = () => Promise.resolve();
     try {
       for (let index = 0; index <= 1000; index++) {
         await manager.persistCompileCacheTracked(
@@ -2270,7 +2247,7 @@ describe("cell-cache: compiled-set store (CFC integrity, fail-closed)", () => {
         );
       }
     } finally {
-      manager.writeBackCompileCache = originalWriteBack;
+      stubbed.writeBackCompileCache = originalWriteBack;
     }
 
     expect(manager.persistedCompileCacheClosures.size).toBe(1001);

--- a/packages/runner/test/cfreg-builder-identity.test.ts
+++ b/packages/runner/test/cfreg-builder-identity.test.ts
@@ -111,9 +111,9 @@ export default pattern<State>((state) => {
       const { identity } = entryRef!;
 
       // Reach into the reverse index to enumerate what this module registered.
-      const hoists = (pm as unknown as {
-        addressableByIdentity: Map<string, Map<string, unknown>>;
-      }).addressableByIdentity.get(identity);
+      const hoists = pm.accessForTestingOnly.addressableByIdentity.get(
+        identity,
+      );
       const symbols = [...(hoists?.keys() ?? [])];
 
       // A pattern (map op) and a non-pattern artifact (lift) were both hoisted

--- a/packages/runner/test/content-addressed-identity.test.ts
+++ b/packages/runner/test/content-addressed-identity.test.ts
@@ -175,10 +175,7 @@ describe("content-addressed action identity", () => {
     // Simulate the bounded artifact index rolling the module out mid-session
     // (FIFO eviction after ~1000 other identities) — the worst case for a
     // `$implRef`-only stored graph, which has no legacy ref and no body.
-    const manager = runtime!.patternManager as unknown as {
-      addressableByIdentity: Map<string, unknown>;
-      modulesByIdentity: Map<string, unknown>;
-    };
+    const manager = runtime!.patternManager.accessForTestingOnly;
     manager.addressableByIdentity.clear();
     manager.modulesByIdentity.clear();
     expect(

--- a/packages/runner/test/module-delegation.test.ts
+++ b/packages/runner/test/module-delegation.test.ts
@@ -126,12 +126,7 @@ describe("module identity delegation", () => {
   });
 
   it("rejects an update when the predecessor source closure is unavailable", async () => {
-    const manager = runtime.patternManager as unknown as {
-      loadPreviousSourceClosure(
-        space: string,
-        entryIdentity: string,
-      ): Promise<Map<string, SourceDoc>>;
-    };
+    const manager = runtime.patternManager.accessForTestingOnly;
 
     await expect(
       manager.loadPreviousSourceClosure(space, "missing-predecessor"),

--- a/packages/runner/test/scheduler-idle-pattern-work.test.ts
+++ b/packages/runner/test/scheduler-idle-pattern-work.test.ts
@@ -29,6 +29,7 @@ import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { Runtime } from "../src/runtime.ts";
+import type { Pattern } from "../src/builder/types.ts";
 
 const signer = await Identity.fromPassphrase("scheduler idle pattern work");
 const space = signer.did();
@@ -100,10 +101,10 @@ describe("idleWithPendingCommits covers pattern work (OW45 S-B)", () => {
     // the accessor must reflect): an entry present ⇒ pattern work
     // pending ⇒ the commit-aware barrier holds until it settles.
     const manager = runtime.patternManager.accessForTestingOnly;
-    const gate = Promise.withResolvers<void>();
+    const gate = Promise.withResolvers<Pattern | undefined>();
     manager.inProgressByIdentityLoads.set(
       `${space}\0ow45-synthetic-load`,
-      gate.promise as Promise<never>,
+      gate.promise,
     );
     expect(runtime.patternManager.hasPendingPatternWork()).toBe(true);
     let loadBarrierResolved = false;
@@ -115,7 +116,7 @@ describe("idleWithPendingCommits covers pattern work (OW45 S-B)", () => {
     }
     expect(loadBarrierResolved).toBe(false);
     manager.inProgressByIdentityLoads.delete(`${space}\0ow45-synthetic-load`);
-    gate.resolve();
+    gate.resolve(undefined);
     await loadBarrier;
     expect(runtime.patternManager.hasPendingPatternWork()).toBe(false);
 

--- a/packages/runner/test/scheduler-idle-pattern-work.test.ts
+++ b/packages/runner/test/scheduler-idle-pattern-work.test.ts
@@ -99,13 +99,11 @@ describe("idleWithPendingCommits covers pattern work (OW45 S-B)", () => {
     // is racy by construction; the registry entry IS the registration
     // the accessor must reflect): an entry present ⇒ pattern work
     // pending ⇒ the commit-aware barrier holds until it settles.
-    const manager = runtime.patternManager as unknown as {
-      inProgressByIdentityLoads: Map<string, Promise<unknown>>;
-    };
+    const manager = runtime.patternManager.accessForTestingOnly;
     const gate = Promise.withResolvers<void>();
     manager.inProgressByIdentityLoads.set(
       `${space}\0ow45-synthetic-load`,
-      gate.promise,
+      gate.promise as Promise<never>,
     );
     expect(runtime.patternManager.hasPendingPatternWork()).toBe(true);
     let loadBarrierResolved = false;
@@ -130,9 +128,7 @@ describe("idleWithPendingCommits covers pattern work (OW45 S-B)", () => {
     // is not driven here: under the suite's fake clock the compiler's
     // real I/O and the logical timers cannot be sequenced
     // deterministically from outside.)
-    const writeManager = runtime.patternManager as unknown as {
-      compileCacheWrites: Set<Promise<unknown>>;
-    };
+    const writeManager = runtime.patternManager.accessForTestingOnly;
     const writeGate = Promise.withResolvers<void>();
     writeManager.compileCacheWrites.add(writeGate.promise);
     expect(runtime.patternManager.hasPendingPatternWork()).toBe(true);
@@ -157,9 +153,7 @@ describe("idleWithPendingCommits covers pattern work (OW45 S-B)", () => {
     // scheduler — `inProgressCompilations` (registered synchronously at
     // compileOrGetPattern, resolved only after persistence) is the only
     // visibility that phase has, and the barrier must consult it.
-    const compileManager = runtime.patternManager as unknown as {
-      inProgressCompilations: Map<string, Promise<unknown>>;
-    };
+    const compileManager = runtime.patternManager.accessForTestingOnly;
     const compileGate = Promise.withResolvers<unknown>();
     compileManager.inProgressCompilations.set(
       "ow45-synthetic-compile",
@@ -197,9 +191,7 @@ describe("idleWithPendingCommits covers pattern work (OW45 S-B)", () => {
     // registered beyond its cleanup microtask, which is also what
     // keeps the barrier's recheck fixpoint from spinning on a
     // settled-but-registered entry.
-    const manager = runtime.patternManager as unknown as {
-      inProgressCompilations: Map<string, Promise<unknown>>;
-    };
+    const manager = runtime.patternManager.accessForTestingOnly;
     const failing = Promise.withResolvers<unknown>();
     const tracked = failing.promise.finally(() => {
       manager.inProgressCompilations.delete("ow45-rejecting-compile");


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Fable 5.1)

`PatternManager` held eleven members as TypeScript `private` under notes
naming the tests that reach them. Nine are `#` names now, behind an
`accessForTestingOnly` getter, as `docs/development/DEVELOPMENT.md`
§ Classes prescribes; two stay `private` because tests replace them by
assignment.

## The accessor

- Eight fields the class never reassigns (`addressableByIdentity`,
  `compileCacheWrites`, `inProgressByIdentityLoads`,
  `inProgressCompilations`, `modulesByIdentity`, `pendingCacheWriteBacks`,
  `persistedCompileCacheClosures`, and the like) are `readonly #` members
  handed over as plain properties.
- `maxEvaluatedModuleCacheSize` is assigned by a test, so it has a getter
  and a setter.
- `loadPreviousSourceClosure`, `persistCompileCacheTracked`, and
  `hasStoredCompileCacheClosure` are `#` methods behind arrow entries.

## What stays `private`, and why

`replicateClosures` and `writeBackCompileCache` are each replaced by
assignment (`cell-cache.test.ts` and
`pattern-replication-sibling-race.test.ts`), which a `#` name cannot
support. Each keeps a note naming that test. Neither is forwarded through
the accessor: `cell-cache` calls `replicateClosures` with three arguments
against a signature whose `delegated` and `ticket` are required, so a
typed entry would break those calls. The seams are catalogued for a later
pass.

## What the tests do now

Six test files drop their casts for the accessor. The two `cell-cache`
blocks that mix a stubbed member with convertible ones keep one cast,
narrowed to the stubbed member alone, and take the rest from the
accessor. One synthetic gate promise typed `void` needed
`as Promise<never>`, the file's own idiom.

## Review

Reviewed by a `cf-review` pass: approve, no blocking findings. Its one
improvement is applied: sixteen comments in `pattern-manager.ts` that
named converted members bare now name them with the `#`, as the file's
other `#` members are named. Its nit on the idle-pattern-work test is
applied too: the synthetic load gate is typed as the map types its values,
so the `Promise<never>` cast goes.

## Gates

`deno fmt --check`, `deno lint`, `deno task check`, and the `runner`
suite (1362 passed, 1 failed in `executor-serving-loop.test.ts`, a file
this branch does not touch, which passed on an isolated rerun; the
failing run had two type-checks alongside it). No other package names a
converted member.

## Coverage

The Coverage Check counts three lines: the `maxEvaluatedModuleCacheSize`
getter in the accessor. The one test that touches that entry assigns it,
and the guideline pairs a setter with a getter, so nothing reads those
lines. Read out of the run's coverage artifacts; accepted below.

ACCEPT_COVERAGE_DEBT: packages/runner +3 lines
