### PR TITLE
refactor(shell): `XDebuggerView` keeps its handlers and render steps in `#` members behind `accessForTestingOnly`

### DIFF
--- a/packages/shell/src/views/DebuggerView.ts
+++ b/packages/shell/src/views/DebuggerView.ts
@@ -101,15 +101,6 @@ export type SubtopicKey<T extends TopicKey> =
  * Presented as a resizable drawer.
  */
 export class XDebuggerView extends LitElement {
-  // The members below stay TypeScript-private rather than becoming `#` names,
-  // which is the convention elsewhere. `test/disposal-handling.test.ts` and
-  // `test/XDebuggerView.test.ts` call this view's methods off
-  // `XDebuggerView.prototype` against a stand-in receiver: a plain object
-  // supplying `getLoggerRegistry`, `debuggerController`, and the rest as
-  // ordinary properties. A `#` name is scoped to real instances, so each of
-  // those calls would throw. Converting the class means rewriting both suites
-  // to build real views.
-
   static override styles = css`
     :host {
       position: fixed;
@@ -881,7 +872,7 @@ export class XDebuggerView extends LitElement {
   @state()
   private accessor diagnosisDurationMs = 5000;
 
-  private resizeController = new ResizableDrawerController(this, {
+  #resizeController = new ResizableDrawerController(this, {
     initialHeight: 300,
     minHeight: 150,
     maxHeightFactor: 0.8,
@@ -889,17 +880,47 @@ export class XDebuggerView extends LitElement {
     storageKey: "debuggerDrawerHeight",
   });
 
+  /**
+   * The worker-logger metadata, the diagnosis panel's render step, and the
+   * three worker-logger handlers, which a test drives directly.
+   */
+  get accessForTestingOnly(): {
+    workerLoggerMetadata: LoggerMetadata | null;
+    renderDiagnosis(): TemplateResult;
+    resetBaseline(): Promise<void>;
+    toggleLogger(name: string): Promise<void>;
+    setLoggerLevel(
+      name: string,
+      level: "debug" | "info" | "warn" | "error",
+    ): Promise<void>;
+  } {
+    // deno-lint-ignore no-this-alias
+    const outerThis = this;
+    return {
+      get workerLoggerMetadata() {
+        return outerThis.workerLoggerMetadata;
+      },
+      set workerLoggerMetadata(value) {
+        outerThis.workerLoggerMetadata = value;
+      },
+      renderDiagnosis: () => this.#renderDiagnosis(),
+      resetBaseline: () => this.#resetBaseline(),
+      toggleLogger: (name) => this.#toggleLogger(name),
+      setLoggerLevel: (name, level) => this.#setLoggerLevel(name, level),
+    };
+  }
+
   override connectedCallback() {
     super.connectedCallback();
-    document.addEventListener("keydown", this.handleKeyDown);
-    document.addEventListener("click", this.handleDocumentClick);
+    document.addEventListener("keydown", this.#handleKeyDown);
+    document.addEventListener("click", this.#handleDocumentClick);
     // Initialize with all subtopics active
-    this.initializeAllSubtopics();
+    this.#initializeAllSubtopics();
   }
 
   override disconnectedCallback() {
-    document.removeEventListener("keydown", this.handleKeyDown);
-    document.removeEventListener("click", this.handleDocumentClick);
+    document.removeEventListener("keydown", this.#handleKeyDown);
+    document.removeEventListener("click", this.#handleDocumentClick);
     super.disconnectedCallback();
   }
 
@@ -912,7 +933,7 @@ export class XDebuggerView extends LitElement {
     }
   }
 
-  private handleKeyDown = (e: KeyboardEvent) => {
+  #handleKeyDown = (e: KeyboardEvent) => {
     // Clear search on Escape
     if (e.key === "Escape" && this.searchText) {
       e.preventDefault();
@@ -921,11 +942,11 @@ export class XDebuggerView extends LitElement {
     // Toggle pause on Space when debugger is visible
     if (e.key === " " && this.visible && e.target === document.body) {
       e.preventDefault();
-      this.togglePause();
+      this.#togglePause();
     }
   };
 
-  private initializeAllSubtopics() {
+  #initializeAllSubtopics() {
     const allSubtopics = new Set<string>();
     for (const [topicKey, topic] of Object.entries(TOPIC_HIERARCHY)) {
       for (const subtopicKey of Object.keys(topic.subtopics)) {
@@ -935,7 +956,7 @@ export class XDebuggerView extends LitElement {
     this.activeSubtopics = allSubtopics;
   }
 
-  private handleDocumentClick = (e: Event) => {
+  #handleDocumentClick = (e: Event) => {
     // Close dropdowns when clicking outside
     const target = e.target as HTMLElement;
     if (!target.closest(".topic-button-group")) {
@@ -943,7 +964,7 @@ export class XDebuggerView extends LitElement {
     }
   };
 
-  private toggleDropdown(topicKey: TopicKey, e: Event) {
+  #toggleDropdown(topicKey: TopicKey, e: Event) {
     e.stopPropagation();
     const newDropdowns = new Set(this.openDropdowns);
     if (newDropdowns.has(topicKey)) {
@@ -956,7 +977,7 @@ export class XDebuggerView extends LitElement {
     this.openDropdowns = newDropdowns;
   }
 
-  private toggleTopic(topicKey: TopicKey) {
+  #toggleTopic(topicKey: TopicKey) {
     const topic = TOPIC_HIERARCHY[topicKey];
     const subtopicKeys = Object.keys(topic.subtopics);
     const fullKeys = subtopicKeys.map((sk) => `${topicKey}.${sk}`);
@@ -977,7 +998,7 @@ export class XDebuggerView extends LitElement {
     this.activeSubtopics = newSubtopics;
   }
 
-  private toggleSubtopic(topicKey: TopicKey, subtopicKey: string) {
+  #toggleSubtopic(topicKey: TopicKey, subtopicKey: string) {
     const fullKey = `${topicKey}.${subtopicKey}`;
     const newSubtopics = new Set(this.activeSubtopics);
 
@@ -990,7 +1011,7 @@ export class XDebuggerView extends LitElement {
     this.activeSubtopics = newSubtopics;
   }
 
-  private getTopicState(topicKey: TopicKey): "active" | "partial" | "inactive" {
+  #getTopicState(topicKey: TopicKey): "active" | "partial" | "inactive" {
     const topic = TOPIC_HIERARCHY[topicKey];
     const subtopicKeys = Object.keys(topic.subtopics);
     const fullKeys = subtopicKeys.map((sk) => `${topicKey}.${sk}`);
@@ -1002,17 +1023,17 @@ export class XDebuggerView extends LitElement {
     return "partial";
   }
 
-  private toggleAllTopics() {
+  #toggleAllTopics() {
     if (this.activeSubtopics.size > 0) {
       // Some selected, deselect all
       this.activeSubtopics = new Set();
     } else {
       // None selected, select all
-      this.initializeAllSubtopics();
+      this.#initializeAllSubtopics();
     }
   }
 
-  private recreateSpaceRootPattern() {
+  #recreateSpaceRootPattern() {
     if (this._isRecreatingSpaceRootPattern) return;
     this._isRecreatingSpaceRootPattern = true;
     this.dispatchEvent(
@@ -1028,7 +1049,7 @@ export class XDebuggerView extends LitElement {
     );
   }
 
-  private clearEvents() {
+  #clearEvents() {
     // Dispatch event to clear telemetry in runtime
     this.dispatchEvent(
       new CustomEvent("clear-telemetry", {
@@ -1042,7 +1063,7 @@ export class XDebuggerView extends LitElement {
     this.fullHeightEvents.clear();
   }
 
-  private togglePause() {
+  #togglePause() {
     this.isPaused = !this.isPaused;
     if (!this.isPaused) {
       // When unpausing, update to latest markers
@@ -1050,7 +1071,7 @@ export class XDebuggerView extends LitElement {
     }
   }
 
-  private toggleEventExpand(index: number) {
+  #toggleEventExpand(index: number) {
     const newSet = new Set(this.expandedEvents);
     if (newSet.has(index)) {
       newSet.delete(index);
@@ -1064,7 +1085,7 @@ export class XDebuggerView extends LitElement {
     this.expandedEvents = newSet;
   }
 
-  private toggleJsonFullHeight(index: number) {
+  #toggleJsonFullHeight(index: number) {
     const newSet = new Set(this.fullHeightEvents);
     if (newSet.has(index)) {
       newSet.delete(index);
@@ -1074,7 +1095,7 @@ export class XDebuggerView extends LitElement {
     this.fullHeightEvents = newSet;
   }
 
-  private async copyJson(data: RuntimeTelemetryMarkerResult) {
+  async #copyJson(data: RuntimeTelemetryMarkerResult) {
     try {
       const jsonString = JSON.stringify(data, null, 2);
       await navigator.clipboard.writeText(jsonString);
@@ -1083,14 +1104,14 @@ export class XDebuggerView extends LitElement {
     }
   }
 
-  private formatTime(timestamp: number): string {
+  #formatTime(timestamp: number): string {
     const date = new Date(timestamp);
     return `${date.toLocaleTimeString()}.${
       date.getMilliseconds().toString().padStart(3, "0")
     }`;
   }
 
-  private getEventIcon(marker: RuntimeTelemetryMarkerResult): string {
+  #getEventIcon(marker: RuntimeTelemetryMarkerResult): string {
     const type = marker.type;
 
     // Try to find a matching topic
@@ -1106,7 +1127,7 @@ export class XDebuggerView extends LitElement {
     return "📊";
   }
 
-  private getEventColor(marker: RuntimeTelemetryMarkerResult): string {
+  #getEventColor(marker: RuntimeTelemetryMarkerResult): string {
     const type = marker.type;
 
     // Try to find a matching topic
@@ -1122,7 +1143,7 @@ export class XDebuggerView extends LitElement {
     return "#64748b";
   }
 
-  private matchesActiveTopics(marker: RuntimeTelemetryMarkerResult): boolean {
+  #matchesActiveTopics(marker: RuntimeTelemetryMarkerResult): boolean {
     if (this.activeSubtopics.size === 0) return false;
 
     const type = marker.type;
@@ -1142,7 +1163,7 @@ export class XDebuggerView extends LitElement {
     return false;
   }
 
-  private matchesSearch(marker: RuntimeTelemetryMarkerResult): boolean {
+  #matchesSearch(marker: RuntimeTelemetryMarkerResult): boolean {
     if (!this.searchText) return true;
 
     const searchLower = this.searchText.toLowerCase();
@@ -1155,15 +1176,15 @@ export class XDebuggerView extends LitElement {
     return markerStr.includes(searchLower);
   }
 
-  private getFilteredEvents(): RuntimeTelemetryMarkerResult[] {
+  #getFilteredEvents(): RuntimeTelemetryMarkerResult[] {
     const markers = this.isPaused ? this.pausedMarkers : this.telemetryMarkers;
 
     return markers.filter((marker) =>
-      this.matchesActiveTopics(marker) && this.matchesSearch(marker)
+      this.#matchesActiveTopics(marker) && this.#matchesSearch(marker)
     );
   }
 
-  private renderEventDetails(
+  #renderEventDetails(
     marker: RuntimeTelemetryMarkerResult,
   ): TemplateResult[] {
     const details = [];
@@ -1324,14 +1345,14 @@ export class XDebuggerView extends LitElement {
   // Logger stats methods
   //
 
-  private getLoggerRegistry(): Record<string, Logger> {
+  #getLoggerRegistry(): Record<string, Logger> {
     const global = globalThis as unknown as {
       commonfabric?: { logger?: Record<string, Logger> };
     };
     return global.commonfabric?.logger ?? {};
   }
 
-  private getLoggerBreakdown(): Record<string, LoggerBreakdown | number> {
+  #getLoggerBreakdown(): Record<string, LoggerBreakdown | number> {
     const global = globalThis as unknown as {
       commonfabric?: {
         getLoggerCountsBreakdown?: () => Record<
@@ -1343,7 +1364,7 @@ export class XDebuggerView extends LitElement {
     return global.commonfabric?.getLoggerCountsBreakdown?.() ?? { total: 0 };
   }
 
-  private getBreakdownTotal(
+  #getBreakdownTotal(
     breakdown: Record<string, LoggerBreakdown | number> | null,
   ): number {
     if (!breakdown) return 0;
@@ -1351,7 +1372,7 @@ export class XDebuggerView extends LitElement {
     return typeof total === "number" ? total : 0;
   }
 
-  private async getWorkerLoggerBreakdown(): Promise<{
+  async #getWorkerLoggerBreakdown(): Promise<{
     counts: Record<string, LoggerBreakdown | number> | null;
     timing: Record<string, Record<string, TimingStats>> | null;
   }> {
@@ -1372,7 +1393,7 @@ export class XDebuggerView extends LitElement {
     }
   }
 
-  private mergeLoggerBreakdowns(
+  #mergeLoggerBreakdowns(
     main: Record<string, LoggerBreakdown | number>,
     worker: Record<string, LoggerBreakdown | number> | null,
   ): Record<string, LoggerBreakdown | number> {
@@ -1394,7 +1415,7 @@ export class XDebuggerView extends LitElement {
           (typeof workerVal === "number" ? workerVal : 0);
       } else if (mainVal && workerVal) {
         // Both have LoggerBreakdown - merge them
-        merged[key] = this.mergeBreakdown(mainVal, workerVal);
+        merged[key] = this.#mergeBreakdown(mainVal, workerVal);
       } else {
         // Only one has data
         merged[key] = mainVal ?? workerVal;
@@ -1409,7 +1430,7 @@ export class XDebuggerView extends LitElement {
     return merged;
   }
 
-  private mergeBreakdown(
+  #mergeBreakdown(
     a: LoggerBreakdown,
     b: LoggerBreakdown,
   ): LoggerBreakdown {
@@ -1438,7 +1459,7 @@ export class XDebuggerView extends LitElement {
     return merged;
   }
 
-  private getLoggerTiming(): Record<string, Record<string, TimingStats>> {
+  #getLoggerTiming(): Record<string, Record<string, TimingStats>> {
     const global = globalThis as unknown as {
       commonfabric?: {
         getTimingStatsBreakdown?: () => Record<
@@ -1450,7 +1471,7 @@ export class XDebuggerView extends LitElement {
     return global.commonfabric?.getTimingStatsBreakdown?.() ?? {};
   }
 
-  private mergeLoggerTiming(
+  #mergeLoggerTiming(
     main: Record<string, Record<string, TimingStats>>,
     worker: Record<string, Record<string, TimingStats>> | null,
   ): Record<string, Record<string, TimingStats>> {
@@ -1470,17 +1491,17 @@ export class XDebuggerView extends LitElement {
     return merged;
   }
 
-  private async sampleLoggerCounts(): Promise<void> {
-    const mainCounts = this.getLoggerBreakdown();
-    const workerResult = await this.getWorkerLoggerBreakdown();
-    this.loggerSample = this.mergeLoggerBreakdowns(
+  async #sampleLoggerCounts(): Promise<void> {
+    const mainCounts = this.#getLoggerBreakdown();
+    const workerResult = await this.#getWorkerLoggerBreakdown();
+    this.loggerSample = this.#mergeLoggerBreakdowns(
       mainCounts,
       workerResult.counts,
     );
 
     // Merge timing data
-    const mainTiming = this.getLoggerTiming();
-    this.loggerTimingSample = this.mergeLoggerTiming(
+    const mainTiming = this.#getLoggerTiming();
+    this.loggerTimingSample = this.#mergeLoggerTiming(
       mainTiming,
       workerResult.timing,
     );
@@ -1493,7 +1514,7 @@ export class XDebuggerView extends LitElement {
     });
   }
 
-  private async resetBaseline(): Promise<void> {
+  async #resetBaseline(): Promise<void> {
     // Reset counts baseline
     const global = globalThis as unknown as {
       commonfabric?: {
@@ -1514,7 +1535,7 @@ export class XDebuggerView extends LitElement {
       // Clear local baseline tracking
       this.loggerBaseline = null;
       // Sample to get fresh data
-      await this.sampleLoggerCounts();
+      await this.#sampleLoggerCounts();
     } catch (error) {
       // A disposal race (logout, runtime swap) cancels the op; that is
       // cancellation, not a failure — and this runs fire-and-forget, so an
@@ -1524,8 +1545,8 @@ export class XDebuggerView extends LitElement {
     }
   }
 
-  private async toggleLogger(name: string): Promise<void> {
-    const registry = this.getLoggerRegistry();
+  async #toggleLogger(name: string): Promise<void> {
+    const registry = this.#getLoggerRegistry();
     const logger = registry[name];
     if (logger) {
       // Local logger - toggle directly
@@ -1540,7 +1561,7 @@ export class XDebuggerView extends LitElement {
         try {
           await rt.setLoggerEnabled(!currentEnabled, name);
           // Refresh metadata
-          await this.sampleLoggerCounts();
+          await this.#sampleLoggerCounts();
         } catch (error) {
           // A disposal race cancels the op (fire-and-forget — an un-caught
           // rejection would surface as an unhandled rejection).
@@ -1554,11 +1575,11 @@ export class XDebuggerView extends LitElement {
     }
   }
 
-  private async setLoggerLevel(
+  async #setLoggerLevel(
     name: string,
     level: "debug" | "info" | "warn" | "error",
   ): Promise<void> {
-    const registry = this.getLoggerRegistry();
+    const registry = this.#getLoggerRegistry();
     const logger = registry[name];
     if (logger) {
       // Local logger - set directly
@@ -1572,7 +1593,7 @@ export class XDebuggerView extends LitElement {
         try {
           await rt.setLoggerLevel(level, name);
           // Refresh metadata
-          await this.sampleLoggerCounts();
+          await this.#sampleLoggerCounts();
         } catch (error) {
           // A disposal race cancels the op (fire-and-forget — an un-caught
           // rejection would surface as an unhandled rejection).
@@ -1586,7 +1607,7 @@ export class XDebuggerView extends LitElement {
     }
   }
 
-  private toggleExpandLogger(name: string): void {
+  #toggleExpandLogger(name: string): void {
     if (this.expandedLoggers.has(name)) {
       this.expandedLoggers.delete(name);
     } else {
@@ -1595,16 +1616,16 @@ export class XDebuggerView extends LitElement {
     this.requestUpdate();
   }
 
-  private getDelta(current: number, baseline: number | undefined): number {
+  #getDelta(current: number, baseline: number | undefined): number {
     return current - (baseline ?? 0);
   }
 
-  private formatDelta(delta: number): string {
+  #formatDelta(delta: number): string {
     if (delta === 0) return "0";
     return delta > 0 ? `+${delta}` : `${delta}`;
   }
 
-  private renderTimingHistogram(
+  #renderTimingHistogram(
     _loggerName: string,
     timingData: Record<string, TimingStats>,
   ): TemplateResult {
@@ -1626,13 +1647,13 @@ export class XDebuggerView extends LitElement {
             `;
           }
 
-          return this.renderCDFForKey(key, stats);
+          return this.#renderCDFForKey(key, stats);
         })}
       </div>
     `;
   }
 
-  private handleChartMouseMove(
+  #handleChartMouseMove(
     e: MouseEvent,
     cumulativePointsBlue: Array<{
       latency: number;
@@ -1737,11 +1758,11 @@ export class XDebuggerView extends LitElement {
     }
   }
 
-  private handleChartMouseLeave(): void {
+  #handleChartMouseLeave(): void {
     this.tooltipData = null;
   }
 
-  private renderCDFForKey(
+  #renderCDFForKey(
     key: string,
     stats: TimingStats,
   ): TemplateResult {
@@ -1925,7 +1946,7 @@ export class XDebuggerView extends LitElement {
           height="${height}"
           style="background-color: #0f172a; border-radius: 0.25rem; cursor: crosshair;"
           @mousemove="${(e: MouseEvent) =>
-            this.handleChartMouseMove(
+            this.#handleChartMouseMove(
               e,
               cumulativePoints,
               cumulativePointsDelta,
@@ -1937,7 +1958,7 @@ export class XDebuggerView extends LitElement {
               plotWidth,
               plotHeight,
             )}"
-          @mouseleave="${() => this.handleChartMouseLeave()}"
+          @mouseleave="${() => this.#handleChartMouseLeave()}"
         >
           <!-- Y-axis grid lines and labels -->
           ${yTicks.map((y) => {
@@ -2226,10 +2247,10 @@ export class XDebuggerView extends LitElement {
     `;
   }
 
-  private renderLoggers(): TemplateResult {
-    const sample = this.loggerSample ?? this.getLoggerBreakdown();
+  #renderLoggers(): TemplateResult {
+    const sample = this.loggerSample ?? this.#getLoggerBreakdown();
     const baseline = this.loggerBaseline;
-    const registry = this.getLoggerRegistry();
+    const registry = this.#getLoggerRegistry();
     const loggerNames = Object.keys(sample).filter((k) => k !== "total");
 
     if (loggerNames.length === 0) {
@@ -2240,16 +2261,16 @@ export class XDebuggerView extends LitElement {
       `;
     }
 
-    const sampleTotal = this.getBreakdownTotal(sample);
-    const baselineTotal = this.getBreakdownTotal(baseline);
-    const totalDelta = this.getDelta(sampleTotal, baselineTotal);
+    const sampleTotal = this.#getBreakdownTotal(sample);
+    const baselineTotal = this.#getBreakdownTotal(baseline);
+    const totalDelta = this.#getDelta(sampleTotal, baselineTotal);
 
     return html`
       <div class="loggers-toolbar">
         <button
           type="button"
           class="action-button"
-          @click="${() => this.resetBaseline()}"
+          @click="${() => this.#resetBaseline()}"
           title="Reset baseline to current counts"
         >
           Reset Baseline
@@ -2257,7 +2278,7 @@ export class XDebuggerView extends LitElement {
         <button
           type="button"
           class="action-button"
-          @click="${() => this.sampleLoggerCounts()}"
+          @click="${() => this.#sampleLoggerCounts()}"
           title="Sample current counts"
         >
           Sample
@@ -2269,7 +2290,7 @@ export class XDebuggerView extends LitElement {
                 ? "positive"
                 : totalDelta < 0
                 ? "negative"
-                : ""}">(${this.formatDelta(totalDelta)})</span>
+                : ""}">(${this.#formatDelta(totalDelta)})</span>
             `
             : ""}
         </span>
@@ -2288,12 +2309,12 @@ export class XDebuggerView extends LitElement {
             ? !workerMeta.enabled
             : false;
           const currentLevel = logger?.level ?? workerMeta?.level ?? "info";
-          const delta = this.getDelta(loggerData.total, baselineData?.total);
+          const delta = this.#getDelta(loggerData.total, baselineData?.total);
 
           return html`
             <div class="logger-item ${isDisabled ? "disabled" : ""}">
               <div class="logger-header" @click="${() =>
-                this.toggleExpandLogger(name)}">
+                this.#toggleExpandLogger(name)}">
                 <span class="logger-expand">${isExpanded ? "▼" : "▶"}</span>
                 <span class="logger-name">${name}</span>
                 <span class="logger-count">
@@ -2303,7 +2324,7 @@ export class XDebuggerView extends LitElement {
                         ? "positive"
                         : delta < 0
                         ? "negative"
-                        : ""}">(${this.formatDelta(delta)})</span>
+                        : ""}">(${this.#formatDelta(delta)})</span>
                     `
                     : ""}
                 </span>
@@ -2314,7 +2335,7 @@ export class XDebuggerView extends LitElement {
                     .value="${currentLevel}"
                     @change="${(e: Event) => {
                       const select = e.target as HTMLSelectElement;
-                      this.setLoggerLevel(
+                      this.#setLoggerLevel(
                         name,
                         select.value as "debug" | "info" | "warn" | "error",
                       );
@@ -2333,7 +2354,7 @@ export class XDebuggerView extends LitElement {
                   <button
                     type="button"
                     class="logger-toggle ${isDisabled ? "off" : "on"}"
-                    @click="${() => this.toggleLogger(name)}"
+                    @click="${() => this.#toggleLogger(name)}"
                     title="${isDisabled
                       ? "Logger disabled - click to enable"
                       : "Logger enabled - click to disable"}"
@@ -2362,7 +2383,7 @@ export class XDebuggerView extends LitElement {
                         const baselineCounts = baselineData?.[key] as
                           | typeof c
                           | undefined;
-                        const keyDelta = this.getDelta(
+                        const keyDelta = this.#getDelta(
                           c.total,
                           baselineCounts?.total,
                         );
@@ -2385,7 +2406,7 @@ export class XDebuggerView extends LitElement {
                                       ? "positive"
                                       : keyDelta < 0
                                       ? "negative"
-                                      : ""}">(${this.formatDelta(
+                                      : ""}">(${this.#formatDelta(
                                         keyDelta,
                                       )})</span>
                                   `
@@ -2399,7 +2420,7 @@ export class XDebuggerView extends LitElement {
 
                   ${/* Show timing histogram if available */
                   this.loggerTimingSample?.[name]
-                    ? this.renderTimingHistogram(
+                    ? this.#renderTimingHistogram(
                       name,
                       this.loggerTimingSample[name],
                     )
@@ -2413,7 +2434,7 @@ export class XDebuggerView extends LitElement {
     `;
   }
 
-  private renderTabs() {
+  #renderTabs() {
     return html`
       <div class="tabs-container">
         <button
@@ -2440,7 +2461,7 @@ export class XDebuggerView extends LitElement {
           @click="${() => {
             this._activeTab = "loggers";
             // Sample current counts when tab is opened
-            this.sampleLoggerCounts();
+            this.#sampleLoggerCounts();
           }}"
         >
           Loggers
@@ -2456,7 +2477,7 @@ export class XDebuggerView extends LitElement {
     `;
   }
 
-  private renderDiagnosis(): TemplateResult {
+  #renderDiagnosis(): TemplateResult {
     const isDiagnosing = this.debuggerController?.getIsDiagnosing() ?? false;
     const result = this.debuggerController?.getDiagnosisResult() ?? null;
 
@@ -2625,8 +2646,8 @@ export class XDebuggerView extends LitElement {
     `;
   }
 
-  private renderEvents() {
-    const events = this.getFilteredEvents();
+  #renderEvents() {
+    const events = this.#getFilteredEvents();
 
     if (events.length === 0) {
       return html`
@@ -2646,27 +2667,27 @@ export class XDebuggerView extends LitElement {
         ${reversedEvents.map((marker, index) => {
           const actualIndex = events.length - 1 - index;
           const isExpanded = this.expandedEvents.has(actualIndex);
-          const color = this.getEventColor(marker);
+          const color = this.#getEventColor(marker);
 
           return html`
             <div
               class="event-item ${isExpanded ? "expanded" : ""}"
-              @click="${() => this.toggleEventExpand(actualIndex)}"
+              @click="${() => this.#toggleEventExpand(actualIndex)}"
             >
               <div class="event-header">
                 <div class="event-main">
                   <span class="event-icon" style="color: ${color}">
-                    ${this.getEventIcon(marker)}
+                    ${this.#getEventIcon(marker)}
                   </span>
                   <div class="event-content">
                     <div class="event-type">${marker.type}</div>
                     <div class="event-details">
-                      ${this.renderEventDetails(marker)}
+                      ${this.#renderEventDetails(marker)}
                     </div>
                   </div>
                 </div>
                 <div class="event-time">
-                  ${this.formatTime(marker.timeStamp)}
+                  ${this.#formatTime(marker.timeStamp)}
                 </div>
               </div>
 
@@ -2683,7 +2704,7 @@ export class XDebuggerView extends LitElement {
                         class="json-control-btn"
                         @click="${(e: Event) => {
                           e.stopPropagation();
-                          this.toggleJsonFullHeight(actualIndex);
+                          this.#toggleJsonFullHeight(actualIndex);
                         }}"
                       >
                         ${this.fullHeightEvents.has(actualIndex)
@@ -2696,7 +2717,7 @@ export class XDebuggerView extends LitElement {
                         title="Copy full untruncated JSON to clipboard"
                         @click="${(e: Event) => {
                           e.stopPropagation();
-                          this.copyJson(marker);
+                          this.#copyJson(marker);
                         }}"
                       >
                         Copy Full
@@ -2717,11 +2738,11 @@ export class XDebuggerView extends LitElement {
   }
 
   override render() {
-    const containerStyle = `height: ${this.resizeController.drawerHeight}px`;
+    const containerStyle = `height: ${this.#resizeController.drawerHeight}px`;
     const allEvents = this.isPaused
       ? this.pausedMarkers
       : this.telemetryMarkers;
-    const filteredCount = this.visible ? this.getFilteredEvents().length : 0;
+    const filteredCount = this.visible ? this.#getFilteredEvents().length : 0;
 
     return html`
       ${this.visible
@@ -2729,8 +2750,8 @@ export class XDebuggerView extends LitElement {
           <div class="debugger-container" style="${containerStyle}">
             <div
               class="resize-handle"
-              @mousedown="${this.resizeController.handleResizeStart}"
-              @touchstart="${this.resizeController.handleTouchResizeStart}"
+              @mousedown="${this.#resizeController.handleResizeStart}"
+              @touchstart="${this.#resizeController.handleTouchResizeStart}"
             >
               <div class="resize-grip"></div>
             </div>
@@ -2758,7 +2779,7 @@ export class XDebuggerView extends LitElement {
                   type="button"
                   class="action-button"
                   style="background-color: #dc2626; color: white;"
-                  @click="${this.recreateSpaceRootPattern}"
+                  @click="${this.#recreateSpaceRootPattern}"
                   ?disabled="${this._isRecreatingSpaceRootPattern}"
                 >
                   ${this._isRecreatingSpaceRootPattern
@@ -2768,7 +2789,7 @@ export class XDebuggerView extends LitElement {
               </div>
             </div>
 
-            ${this.renderTabs()} ${this._activeTab === "scheduler"
+            ${this.#renderTabs()} ${this._activeTab === "scheduler"
               ? html`
                 <x-scheduler-graph
                   .debuggerController="${this.debuggerController}"
@@ -2779,18 +2800,18 @@ export class XDebuggerView extends LitElement {
               `
               : this._activeTab === "loggers"
               ? html`
-                <div class="content-area ${this.resizeController.isResizing
+                <div class="content-area ${this.#resizeController.isResizing
                   ? "resizing"
                   : ""}">
-                  ${this.renderLoggers()}
+                  ${this.#renderLoggers()}
                 </div>
               `
               : this._activeTab === "diagnosis"
               ? html`
-                <div class="content-area ${this.resizeController.isResizing
+                <div class="content-area ${this.#resizeController.isResizing
                   ? "resizing"
                   : ""}">
-                  ${this.renderDiagnosis()}
+                  ${this.#renderDiagnosis()}
                 </div>
               `
               : html`
@@ -2798,7 +2819,7 @@ export class XDebuggerView extends LitElement {
                   <div class="topics-filter">
                     ${Object.entries(TOPIC_HIERARCHY).map(([key, topic]) => {
                       const topicKey = key as TopicKey;
-                      const state = this.getTopicState(topicKey);
+                      const state = this.#getTopicState(topicKey);
                       const subtopicKeys = Object.keys(topic.subtopics);
                       const hasDropdown = subtopicKeys.length > 0; // Show dropdown even for single subtopic
                       const isDropdownOpen = this.openDropdowns.has(topicKey);
@@ -2809,7 +2830,7 @@ export class XDebuggerView extends LitElement {
                             type="button"
                             class="topic-toggle ${state}"
                             style="--topic-color: ${topic.color}"
-                            @click="${() => this.toggleTopic(topicKey)}"
+                            @click="${() => this.#toggleTopic(topicKey)}"
                             title="${topic.label}"
                           >
                             <span class="topic-icon">${topic.icon}</span>
@@ -2832,7 +2853,7 @@ export class XDebuggerView extends LitElement {
                                 class="dropdown-trigger"
                                 style="--topic-color: ${topic.color}"
                                 @click="${(e: Event) =>
-                                  this.toggleDropdown(topicKey, e)}"
+                                  this.#toggleDropdown(topicKey, e)}"
                                 title="Filter subtopics"
                               >
                                 ${isDropdownOpen ? "▲" : "▼"}
@@ -2856,7 +2877,7 @@ export class XDebuggerView extends LitElement {
                                               .checked="${isChecked}"
                                               @change="${(e: Event) => {
                                                 e.stopPropagation();
-                                                this.toggleSubtopic(
+                                                this.#toggleSubtopic(
                                                   topicKey,
                                                   subKey,
                                                 );
@@ -2925,7 +2946,7 @@ export class XDebuggerView extends LitElement {
                     <button
                       type="button"
                       class="action-button"
-                      @click="${this.toggleAllTopics}"
+                      @click="${this.#toggleAllTopics}"
                       title="Toggle all topics"
                     >
                       ${this.activeSubtopics.size > 0 ? "☐" : "☑"}
@@ -2934,7 +2955,7 @@ export class XDebuggerView extends LitElement {
                     <button
                       type="button"
                       class="action-button"
-                      @click="${this.togglePause}"
+                      @click="${this.#togglePause}"
                       title="${this.isPaused ? "Resume" : "Pause"} (Space)"
                     >
                       ${this.isPaused ? "▶" : "⏸"}
@@ -2943,7 +2964,7 @@ export class XDebuggerView extends LitElement {
                     <button
                       type="button"
                       class="action-button"
-                      @click="${this.clearEvents}"
+                      @click="${this.#clearEvents}"
                       title="Clear events"
                     >
                       Clear
@@ -2951,10 +2972,10 @@ export class XDebuggerView extends LitElement {
                   </div>
                 </div>
 
-                <div class="content-area ${this.resizeController.isResizing
+                <div class="content-area ${this.#resizeController.isResizing
                   ? "resizing"
                   : ""}">
-                  ${this.renderEvents()}
+                  ${this.#renderEvents()}
                 </div>
               `}
           </div>

--- a/packages/shell/test/XDebuggerView.test.ts
+++ b/packages/shell/test/XDebuggerView.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
+import type { DebuggerController } from "../src/lib/debugger-controller.ts";
 import { XDebuggerView } from "../src/views/DebuggerView.ts";
 import { templateMarkup } from "./lit-template-markup.ts";
 
@@ -10,7 +11,8 @@ describe("XDebuggerView", () => {
       it("renders every run of a non-idempotent report and every cell it wrote, a `bigint` included", () => {
         // A run's reads and writes are `FabricValue`s, which a `bigint` is.
         // The method reads the controller's result and the duration off
-        // `this`, so a stand-in carrying those two is enough to render it.
+        // `this`; the controller stand-in offers the two reads it makes, and
+        // the duration is the view's default.
         // The run count and the write count both exceed the debugger's usual
         // array and property limits, so the panel showing the last of each
         // is what the assertions pin.
@@ -33,18 +35,15 @@ describe("XDebuggerView", () => {
             differingWriteKeys: ["out0"],
           }],
         };
-        const view = {
-          debuggerController: {
-            getIsDiagnosing: () => false,
-            getDiagnosisResult: () => result,
-          },
-          diagnosisDurationMs: 5000,
-        };
-        const render = (XDebuggerView.prototype as unknown as {
-          renderDiagnosis(this: unknown): unknown;
-        }).renderDiagnosis;
+        const view = new XDebuggerView();
+        view.debuggerController = {
+          getIsDiagnosing: () => false,
+          getDiagnosisResult: () => result,
+        } as unknown as DebuggerController;
 
-        const markup = templateMarkup(render.call(view));
+        const markup = templateMarkup(
+          view.accessForTestingOnly.renderDiagnosis(),
+        );
         expect(markup).toContain("timestamp: 7");
         expect(markup).toContain("out24: 24n");
         expect(markup).not.toContain("... length:");

--- a/packages/shell/test/disposal-handling.test.ts
+++ b/packages/shell/test/disposal-handling.test.ts
@@ -1,5 +1,6 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import type { DebuggerController } from "../src/lib/debugger-controller.ts";
 import { XDebuggerView } from "../src/views/DebuggerView.ts";
 
 // Shell components log when a runtime operation fails. When the failure is a
@@ -16,10 +17,10 @@ function captureConsoleError(): { calls: unknown[][]; restore(): void } {
 describe("DebuggerView worker-logger disposal handling", () => {
   // These handlers run fire-and-forget from @click; a disposal-raced rejection
   // must neither log nor escape as an unhandled rejection.
-  function debuggerThis(
+  function debuggerView(
     aborted: boolean,
     rejecting: () => Promise<void>,
-  ): Record<string, unknown> {
+  ): XDebuggerView {
     const rt = {
       signal: { aborted },
       resetLoggerBaselines: rejecting,
@@ -27,36 +28,39 @@ describe("DebuggerView worker-logger disposal handling", () => {
       setLoggerLevel: rejecting,
       getLoggerCounts: rejecting,
     };
-    return {
-      loggerBaseline: null,
-      workerLoggerMetadata: { worker: { enabled: false } },
-      getLoggerRegistry: () => ({}),
-      debuggerController: { getRuntime: () => ({ runtime: () => rt }) },
-      sampleLoggerCounts: () => Promise.resolve(),
+    const view = new XDebuggerView();
+    // The controller stand-in offers only the runtime lookup, which is all
+    // the three handlers read from it. Naming `worker` in the metadata is
+    // what sends the toggle and level handlers down the worker path.
+    view.debuggerController = {
+      getRuntime: () => ({ runtime: () => rt }),
+    } as unknown as DebuggerController;
+    view.accessForTestingOnly.workerLoggerMetadata = {
+      worker: { enabled: false, level: "info" },
     };
+    return view;
   }
 
   const reject = () =>
     Promise.reject(new DOMException("aborted", "AbortError"));
 
-  function method(name: string) {
-    return (XDebuggerView.prototype as unknown as Record<
-      string,
-      (this: unknown, ...args: unknown[]) => Promise<void>
-    >)[name];
-  }
+  const handlers: Array<[string, (view: XDebuggerView) => Promise<void>]> = [
+    ["resetBaseline", (view) => view.accessForTestingOnly.resetBaseline()],
+    [
+      "toggleLogger",
+      (view) => view.accessForTestingOnly.toggleLogger("worker"),
+    ],
+    [
+      "setLoggerLevel",
+      (view) => view.accessForTestingOnly.setLoggerLevel("worker", "info"),
+    ],
+  ];
 
-  for (
-    const [label, name, args] of [
-      ["resetBaseline", "resetBaseline", []],
-      ["toggleLogger", "toggleLogger", ["worker"]],
-      ["setLoggerLevel", "setLoggerLevel", ["worker", "info"]],
-    ] as Array<[string, string, unknown[]]>
-  ) {
+  for (const [label, call] of handlers) {
     it(`${label} logs a failure while the runtime is alive`, async () => {
       const spy = captureConsoleError();
       try {
-        await method(name).call(debuggerThis(false, reject), ...args);
+        await call(debuggerView(false, reject));
       } finally {
         spy.restore();
       }
@@ -66,7 +70,7 @@ describe("DebuggerView worker-logger disposal handling", () => {
     it(`${label} stays silent when the runtime is disposed`, async () => {
       const spy = captureConsoleError();
       try {
-        await method(name).call(debuggerThis(true, reject), ...args);
+        await call(debuggerView(true, reject));
       } finally {
         spy.restore();
       }

--- a/packages/shell/test/disposal-handling.test.ts
+++ b/packages/shell/test/disposal-handling.test.ts
@@ -1,5 +1,6 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+
 import type { DebuggerController } from "../src/lib/debugger-controller.ts";
 import { XDebuggerView } from "../src/views/DebuggerView.ts";
 


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Fable 5.1)

`XDebuggerView` was the shell view the `#`-member series had not reached.
Its class note said why: `test/disposal-handling.test.ts` and
`test/XDebuggerView.test.ts` called its methods off
`XDebuggerView.prototype` against a plain-object stand-in, the reach
`docs/development/DEVELOPMENT.md` § Classes says wants the test rewritten
to build a real instance. This PR does that, and the forty-five
TypeScript-`private` methods and plain fields become `#` names.

## The accessor

- `workerLoggerMetadata`, a getter and a setter: the disposal test seeds
  one worker entry to send the toggle and level handlers down the worker
  path. It is a Lit `private accessor` state field, which stays as it is;
  the accessor reaches it as the class does.
- `renderDiagnosis()`, `resetBaseline()`, `toggleLogger()`, and
  `setLoggerLevel()`, arrows forwarding to the `#` methods.

Nothing else is exposed. The stand-ins' other properties
(`getLoggerRegistry`, `sampleLoggerCounts`, `loggerBaseline`,
`diagnosisDurationMs`) were standing in for what a real instance already
has: the registry reads an absent global as empty, the sampler is never
reached on the tested paths, and the other two are at their defaults.

## What the tests do now

A real `XDebuggerView` constructs under plain Deno (Lit's DOM shim
supplies `HTMLElement`), so neither suite needs a browser-globals harness.
Each sets its controller stand-in on the public `debuggerController`
property, declared as `DebuggerController` where it is assigned, and
drives the member through the accessor. The disposal suite's table of
three handlers is now three typed calls rather than three method names
looked up by string.

## Review

Reviewed by a `cf-review` pass: approve, no blocking findings and no
improvements. Of its two nits, the import grouping in the disposal test is
applied; the other, that the disposal test's handler table could be three
plain `it()` blocks, is left as the table the reviewer called acceptable.

## Gates

`deno fmt --check`, `deno lint`, `deno task check`, and the `shell` suite
(60 passed, 0 failed). No other package names a converted member.
