### PR TITLE
refactor(runner): `StorageManager` and `SpaceReplica` keep their test-driven members in `#` members behind `accessForTestingOnly`

### DIFF
--- a/docs/plans/shuttle/runtime-integration.md
+++ b/docs/plans/shuttle/runtime-integration.md
@@ -74,7 +74,7 @@ One near-miss worth pinning: `Provider.#syncRequests` and `#replaySync`
 on route replacement — the reconnect replay is `SpaceSession`'s, above.
 
 Two gaps around it. **Initial** construction is not retried —
-`SpaceReplica.sessionHandle()` clears its memo on failure and re-attempts
+`SpaceReplica.#memoizedSessionHandle()` clears its memo on failure and re-attempts
 only when a caller next asks for a session, which is the case cf-harness's
 cache exists for. And a **permanent** failure stops the loop rather than
 retrying: `isPermanentConnectionFailure` (a protocol-flag mismatch) sets

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -7493,7 +7493,7 @@ supply; OW29/OW32/OW34 closed):
     an admitted commit touches `of:<space>`
     (`#rootEnsureAwaitingOwner`). The session analog: `SpaceReplica`
     latches an ACL-doc admission (`noteAclChanged`) and consumes it at
-    `sessionHandle()` (`consumeOwedSessionRemount`) — the one place
+    `#memoizedSessionHandle()` (`#consumeOwedSessionRemount`) — the one place
     every read and commit reaches a session — dropping a mount that
     `SessionRevokedError` or `AuthorizationError` terminated so the
     next load re-opens. `ExecutorHost.#onCommitAdmitted` fans an

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -7476,7 +7476,7 @@ supply; OW29/OW32/OW34 closed):
     profile program materialized fine (not OW45's write path). The
     refused doc is PRESENT and durable: "sync completed without data"
     was an AUTHORIZATION outcome, not an absence.
-    **The mechanism.** `SpaceReplica.sessionHandle()` (storage/v2.ts)
+    **The mechanism.** `SpaceReplica.#memoizedSessionHandle()` (storage/v2.ts)
     memoized the mount and dropped it only in `close()`, and
     `terminateSession` (memory/v2/client.ts) is terminal for a
     session — so every re-drain's load reused the very session the

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -2666,7 +2666,7 @@ export interface ISpaceReplica extends ISpace {
    * on (RULED 2026-08-21; verification-coverage.md OW47, second
    * producer): the verifier verifies the durable policy state the
    * server will enforce against — a speculation layer never reaches
-   * the wire — and the value read here matches the basis `buildReads`
+   * the wire — and the value read here matches the basis `SpaceReplica.#buildReads`
    * names for such reads (speculative layers excluded). Optional:
    * implementations without a speculation overlay may omit it, and
    * readers fall back to {@link getDocument}, whose view is then

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -2666,8 +2666,9 @@ export interface ISpaceReplica extends ISpace {
    * on (RULED 2026-08-21; verification-coverage.md OW47, second
    * producer): the verifier verifies the durable policy state the
    * server will enforce against — a speculation layer never reaches
-   * the wire — and the value read here matches the basis `SpaceReplica.#buildReads`
-   * names for such reads (speculative layers excluded). Optional:
+   * the wire — and the value read here matches the basis
+   * `SpaceReplica.#buildReads` names for such reads (speculative layers
+   * excluded). Optional:
    * implementations without a speculation overlay may omit it, and
    * readers fall back to {@link getDocument}, whose view is then
    * identical.

--- a/packages/runner/src/storage/rejection.ts
+++ b/packages/runner/src/storage/rejection.ts
@@ -217,7 +217,7 @@ export function isStorageTransactionInconsistent(
  * error: it is the same "never evaluated" shape as a `ConnectionError`, but the
  * re-established session its convergence argument needs never arrives. Nothing
  * between two `editWithRetry` attempts clears or remounts one:
- *  - `SpaceReplica.sessionHandle()` (storage/v2.ts) memoizes the mount and drops
+ *  - `SpaceReplica.#memoizedSessionHandle()` (storage/v2.ts) memoizes the mount and drops
  *    it only in `close()`/`closeNow()` — and, since 2026-08-26, when an admitted
  *    commit touches the space's ACL doc (`consumeOwedSessionRemount`, the READ
  *    path's fix for the profile-starvation fifth face). Nothing an `editWithRetry`

--- a/packages/runner/src/storage/rejection.ts
+++ b/packages/runner/src/storage/rejection.ts
@@ -217,8 +217,9 @@ export function isStorageTransactionInconsistent(
  * error: it is the same "never evaluated" shape as a `ConnectionError`, but the
  * re-established session its convergence argument needs never arrives. Nothing
  * between two `editWithRetry` attempts clears or remounts one:
- *  - `SpaceReplica.#memoizedSessionHandle()` (storage/v2.ts) memoizes the mount and drops
- *    it only in `close()`/`closeNow()` — and, since 2026-08-26, when an admitted
+ *  - `SpaceReplica.#memoizedSessionHandle()` (storage/v2.ts) memoizes the
+ *    mount and drops it only in `close()`/`closeNow()` — and, since
+ *    2026-08-26, when an admitted
  *    commit touches the space's ACL doc (`consumeOwedSessionRemount`, the READ
  *    path's fix for the profile-starvation fifth face). Nothing an `editWithRetry`
  *    ATTEMPT does clears it, so every attempt still reuses the very handle the

--- a/packages/runner/src/storage/v2-transaction.ts
+++ b/packages/runner/src/storage/v2-transaction.ts
@@ -1605,8 +1605,9 @@ export class V2StorageTransaction implements IStorageTransaction {
       // same docs server-side). Serving "durably absent" here turned
       // the user's fill into the silent stored-schemaHash-missing
       // prepare failure. Their layers stay excluded from the blind tx's
-      // verifier basis in `SpaceReplica.#buildReads` — consistent by construction:
-      // the value equals the durable content whichever layer serves it.
+      // verifier basis in `SpaceReplica.#buildReads` — consistent by
+      // construction: the value equals the durable content whichever layer
+      // serves it.
       !address.id.startsWith("cid:") &&
       getBlindStructuralTarget(this) !== undefined &&
       // A replica without a speculation overlay serves no separate
@@ -3368,8 +3369,9 @@ export class V2StorageTransaction implements IStorageTransaction {
 
   // Abandons every mergeable intent a document recorded, for a commit that
   // emits the document whole. An intent narrows the reads incidental to its op
-  // out of the commit's read set (`SpaceReplica.#commitReadActivities` in ./v2.ts), which is
-  // sound only while the op is what carries that region: a mergeable op
+  // out of the commit's read set (`SpaceReplica.#commitReadActivities` in
+  // ./v2.ts), which is sound only while the op is what carries that region:
+  // a mergeable op
   // resolves against durable state, so the value it read does not constrain
   // it. A whole-document set carries the region instead, and it is the value
   // the run computed from what it read — so those reads are real dependencies

--- a/packages/runner/src/storage/v2-transaction.ts
+++ b/packages/runner/src/storage/v2-transaction.ts
@@ -1576,7 +1576,7 @@ export class V2StorageTransaction implements IStorageTransaction {
     // will enforce against — a client speculation layer never reaches
     // the wire, so deriving from it verified state the server can never
     // see, and the basis it contributed made the §6 export refusal
-    // terminal on the user's own typed input. `buildReads`
+    // terminal on the user's own typed input. `SpaceReplica.#buildReads`
     // (storage/v2.ts) names the same durable layer set for these reads,
     // so verify-durable and name-durable travel together. Scoped tight:
     // only the blind-write tx shape (the structural target survives the
@@ -1605,7 +1605,7 @@ export class V2StorageTransaction implements IStorageTransaction {
       // same docs server-side). Serving "durably absent" here turned
       // the user's fill into the silent stored-schemaHash-missing
       // prepare failure. Their layers stay excluded from the blind tx's
-      // verifier basis in `buildReads` — consistent by construction:
+      // verifier basis in `SpaceReplica.#buildReads` — consistent by construction:
       // the value equals the durable content whichever layer serves it.
       !address.id.startsWith("cid:") &&
       getBlindStructuralTarget(this) !== undefined &&
@@ -3368,7 +3368,7 @@ export class V2StorageTransaction implements IStorageTransaction {
 
   // Abandons every mergeable intent a document recorded, for a commit that
   // emits the document whole. An intent narrows the reads incidental to its op
-  // out of the commit's read set (`commitReadActivities` in ./v2.ts), which is
+  // out of the commit's read set (`SpaceReplica.#commitReadActivities` in ./v2.ts), which is
   // sound only while the op is what carries that region: a mergeable op
   // resolves against durable state, so the value it read does not constrain
   // it. A whole-document set carries the region instead, and it is the value

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -1004,6 +1004,32 @@ export class StorageManager implements IStorageManager {
   #telemetry?: TelemetrySink;
 
   /**
+   * The pending-load registration step and the linked-cell sync collector,
+   * which a test drives directly.
+   */
+  get accessForTestingOnly(): {
+    registerPendingLoad(address: {
+      space: MemorySpace;
+      scope: CellScope;
+      id: URI;
+      scopeKey?: ScopeKey;
+    }): (failure?: unknown) => void;
+    collectLinkedCellSyncs(
+      value: unknown,
+      base: NormalizedLink,
+      schema: JSONSchema | undefined,
+      promises: Promise<unknown>[],
+      seen: Set<unknown>,
+    ): void;
+  } {
+    return {
+      registerPendingLoad: (address) => this.#registerPendingLoad(address),
+      collectLinkedCellSyncs: (value, base, schema, promises, seen) =>
+        this.#collectLinkedCellSyncs(value, base, schema, promises, seen),
+    };
+  }
+
+  /**
    * Attach the runtime's telemetry bus so replicas can emit the
    * `storage.push/pull.*` markers. Late-bound and optional: the manager is
    * constructed before (and independently of) the Runtime, and providers read
@@ -1979,10 +2005,13 @@ export class StorageManager implements IStorageManager {
   #loggedSyncFailures = new Set<string>();
 
   /**
-   * TypeScript-private rather than a `#` name:
-   * `test/array-ref-defs-propagation.test.ts` drives this member directly.
+   * Registers one pending load of `address` and returns its release step,
+   * which takes the load's failure if it had one. The release that brings
+   * the key's count back to zero settles the key's waiters and, when no
+   * failure was recorded, reports the recovery epoch to
+   * `loadRecoveryObserver`.
    */
-  private registerPendingLoad(
+  #registerPendingLoad(
     address: {
       space: MemorySpace;
       scope: CellScope;
@@ -2150,7 +2179,7 @@ export class StorageManager implements IStorageManager {
     // instance. Own-identity loads (every client, the OFF arm) name
     // nothing and take exactly the pre-stage-A path.
     const instance = this.#foreignInstanceKey(scope, options?.scopeKeyIdentity);
-    const releaseLoad = this.registerPendingLoad({
+    const releaseLoad = this.#registerPendingLoad({
       space,
       scope: normalizeCellScope(scope),
       id,
@@ -2210,7 +2239,7 @@ export class StorageManager implements IStorageManager {
     const scope = normalizeCellScope(address.scope);
     const instance = this.#foreignInstanceKey(scope, identity);
     const provider = this.open(address.space);
-    const releaseLoad = this.registerPendingLoad({
+    const releaseLoad = this.#registerPendingLoad({
       space: address.space,
       scope,
       id: address.id,
@@ -2239,8 +2268,9 @@ export class StorageManager implements IStorageManager {
   }
 
   /**
-   * TypeScript-private rather than a `#` name:
-   * `test/array-ref-defs-propagation.test.ts` drives this member directly.
+   * TypeScript-private rather than a `#` name, because
+   * `test/storage-pending-load.test.ts` replaces this member by assignment,
+   * which a `#` method does not allow.
    */
   private async syncCfcSchemaDocument(
     space: MemorySpace,
@@ -2259,14 +2289,15 @@ export class StorageManager implements IStorageManager {
   }
 
   /**
-   * TypeScript-private rather than a `#` name:
-   * `test/array-ref-defs-propagation.test.ts` drives this member directly.
+   * Runs `start` as a pending load of `address`: the load is registered
+   * before `start` is called and released when its result settles, with a
+   * resolved error counted as the load's failure and logged.
    */
-  private trackPendingProviderSync(
+  #trackPendingProviderSync(
     address: { space: MemorySpace; scope: CellScope; id: URI },
     start: () => Promise<Result<Unit, Error>>,
   ): Promise<Result<Unit, Error>> {
-    const releaseLoad = this.registerPendingLoad(address);
+    const releaseLoad = this.#registerPendingLoad(address);
     let work: Promise<Result<Unit, Error>>;
     try {
       work = start();
@@ -2353,7 +2384,7 @@ export class StorageManager implements IStorageManager {
       path: [],
     };
     const promises: Promise<unknown>[] = [];
-    this.collectLinkedCellSyncs(
+    this.#collectLinkedCellSyncs(
       value,
       base,
       schema,
@@ -2366,10 +2397,11 @@ export class StorageManager implements IStorageManager {
   }
 
   /**
-   * TypeScript-private rather than a `#` name:
-   * `test/array-ref-defs-propagation.test.ts` drives this member directly.
+   * Walks `value` for cell links and pushes a pending provider sync of each
+   * linked document onto `promises`, under the schema that the link's place
+   * in `schema` selects. `seen` holds the objects already walked.
    */
-  private collectLinkedCellSyncs(
+  #collectLinkedCellSyncs(
     value: unknown,
     base: NormalizedLink,
     schema: JSONSchema | undefined,
@@ -2392,7 +2424,7 @@ export class StorageManager implements IStorageManager {
           link.scope as CellScope | undefined,
         );
         promises.push(
-          this.trackPendingProviderSync(
+          this.#trackPendingProviderSync(
             { space, scope, id: link.id },
             () =>
               this.open(space).sync(link.id!, {
@@ -2411,7 +2443,7 @@ export class StorageManager implements IStorageManager {
         const itemSchema = schema
           ? ContextualFlowControl.getSchemaAtPath(schema, [String(i)])
           : undefined;
-        this.collectLinkedCellSyncs(
+        this.#collectLinkedCellSyncs(
           item,
           base,
           itemSchema,
@@ -2438,7 +2470,7 @@ export class StorageManager implements IStorageManager {
         const childSchema = schema
           ? ContextualFlowControl.getSchemaAtPath(schema, [key])
           : undefined;
-        this.collectLinkedCellSyncs(
+        this.#collectLinkedCellSyncs(
           child,
           base,
           childSchema,
@@ -3008,7 +3040,8 @@ const docKey = (id: URI, instance: string): string => `${instance}\0${id}`;
  * caller knows it, the explicit instance key. */
 type LocalDocAddress = { id: URI; scope?: CellScope; scopeKey?: ScopeKey };
 
-class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
+export class SpaceReplica
+  implements ISpaceReplica, IOperationStorageCapability {
   // A member below declared `private` rather than `#` is one the storage
   // suites reach and drive directly; a `#` name would put it out of their
   // reach.
@@ -3096,7 +3129,7 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
   >();
   readonly #operationWatchRemovals = new Map<string, Promise<void>>();
   #watchView: MemoryV2Client.WatchView | null = null;
-  // The specific view instance that `consumeUpdates` is iterating. This can
+  // The specific view instance that `#consumeUpdates` is iterating. This can
   // diverge from `#watchView` (the client may hand back a fresh view instance
   // on a later refresh while the original consumer keeps running), so teardown
   // must close *this* view to settle the consumer's pending `next()`. Closing
@@ -3295,6 +3328,63 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
     // load kicks the drain iff rows exist; an empty load is inert (no
     // session is established until something discharges).
     this.#ensureEventAppendQueue();
+  }
+
+  /**
+   * The caught-up and stale-floor bookkeeping, the read builder, the
+   * session-sync consumer, the watch-set refresh, the session-sync apply
+   * step, and the conflict read repair, which a test drives directly.
+   */
+  get accessForTestingOnly(): {
+    noteCaughtUpLocalSeq(localSeq: number | undefined): void;
+    waitForCaughtUpLocalSeq(localSeq: number): Promise<void>;
+    recordStaleFloor(commit: ClientCommit, localSeq: number): void;
+    preemptThreshold(commit: ClientCommit): number | undefined;
+    buildReads(
+      source: IStorageTransaction | undefined,
+      localSeq: number,
+      identity?: ScopeKeyIdentity,
+    ): ClientCommit["reads"];
+    consumeUpdates(iterator: AsyncIterator<SessionSync>): Promise<void>;
+    refreshWatchSet(
+      entries: Iterable<[WatchAddress, SchemaPathSelector]>,
+      type?: "pull" | "integrate",
+      watchBranch?: string,
+    ): Promise<Result<Unit, PullError>>;
+    applySessionSync(sync: SessionSync, type: "pull" | "integrate"): void;
+    waitForConflictReadRepair(
+      rejection: StorageTransactionRejected,
+    ): Promise<void>;
+  } {
+    return {
+      noteCaughtUpLocalSeq: (localSeq) => this.#noteCaughtUpLocalSeq(localSeq),
+      waitForCaughtUpLocalSeq: (localSeq) =>
+        this.#waitForCaughtUpLocalSeq(localSeq),
+      recordStaleFloor: (commit, localSeq) =>
+        this.#recordStaleFloor(commit, localSeq),
+      preemptThreshold: (commit) => this.#preemptThreshold(commit),
+      buildReads: (source, localSeq, identity) =>
+        this.#buildReads(source, localSeq, identity),
+      consumeUpdates: (iterator) => this.#consumeUpdates(iterator),
+      // The next three forward to TypeScript-private members so that a test
+      // which replaces one by assignment is honored here too.
+      // TODO(danfuzz): Make `refreshWatchSet()` a `#` method, which needs
+      // `test/memory-v2-watch-remove-coverage.test.ts` to make a refresh fail
+      // some other way than by replacing the method: a transport whose watch
+      // call rejects.
+      refreshWatchSet: (entries, type, watchBranch) =>
+        this.refreshWatchSet(entries, type, watchBranch),
+      // TODO(danfuzz): Make `applySessionSync()` a `#` method, which needs the
+      // three tests that wrap it to observe or fail a frame's apply some other
+      // way: a hook the replica offers around applying a frame.
+      applySessionSync: (sync, type) => this.applySessionSync(sync, type),
+      // TODO(danfuzz): Make `waitForConflictReadRepair()` a `#` method, which
+      // needs `test/memory-v2-subscription.test.ts` to learn that a repair
+      // started some other way than by wrapping the method: a hook the replica
+      // offers, or the telemetry it emits.
+      waitForConflictReadRepair: (rejection) =>
+        this.waitForConflictReadRepair(rejection),
+    };
   }
 
   did(): MemorySpace {
@@ -3548,7 +3638,7 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
    *
    * An admitted commit touched this space's ACL document, so the
    * AUTHORIZATION VERDICT that terminated this replica's session may have
-   * changed. Record it; `sessionHandle()` consumes it on the next load.
+   * changed. Record it; `#memoizedSessionHandle()` consumes it on the next load.
    *
    * Why a latch instead of tearing the session down right here: the memory
    * server emits the admitted-commit notice BEFORE it runs
@@ -3561,7 +3651,7 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
    * dependent on it.
    *
    * Consumption is event-driven, not timed: the next load attempt calls
-   * `sessionHandle()`, and the serving loop already re-attempts a deferred
+   * `#memoizedSessionHandle()`, and the serving loop already re-attempts a deferred
    * event's load every drain (see the scheduler's `failHeadEventLoadPark`
    * and the SpaceServer's deferral backstop), so the heal arrives on the
    * cadence the deferral machinery already runs at.
@@ -3573,13 +3663,13 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
 
   /**
    * THE SESSION REMOUNT itself. Drop a memoized session that an ACL verdict
-   * terminated, so the next `sessionHandle()` opens a fresh one.
+   * terminated, so the next `#memoizedSessionHandle()` opens a fresh one.
    *
    * A revoked (or permanently denied) space session is TERMINAL for that
    * session object: `terminateSession` (memory/v2/client.ts) closes it,
    * clears its watch specs, and stores the verdict in `closeError`, which
    * `#assertOpen()` then rethrows for every later call. Nothing on the read
-   * or commit path ever dropped the memoized mount — `sessionHandle()`
+   * or commit path ever dropped the memoized mount — `#memoizedSessionHandle()`
    * clears it only in `close()`/`closeNow()` — so every subsequent pull
    * reused the same dead session and the space read `unauthorized` forever.
    * `storage/rejection.ts`'s `SessionError` note named this gap when it was
@@ -3606,7 +3696,7 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
    *     `{user: OWNER}` de-authorized it by design. The re-open binds the
    *     user, who is OWNER, and is admitted.
    *   - a GENUINE de-authorization (the user removed, ownership moved): the
-   *     re-open is DENIED at `session.open`. `sessionHandle()`'s catch drops
+   *     re-open is DENIED at `session.open`. `#memoizedSessionHandle()`'s catch drops
    *     the failed handle, the load keeps failing, and the served event
    *     keeps deferring — the ratified wedge, which OW54's give-up arm
    *     covers. Fail-closed, and loud.
@@ -3943,7 +4033,7 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
    * over confirmed state plus only its DURABLE pending layers,
    * skipping the client speculation overlay (#speculativeLocalSeqs).
    * The value side of the blind-write verifier-read basis — the same
-   * layers `buildReads` names for such reads. */
+   * layers `#buildReads` names for such reads. */
   getNonSpeculativeDocument(
     uri: URI,
     scope?: CellScope,
@@ -4163,7 +4253,7 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
     this.#closeSignal.resolve();
     this.#eventAppendQueue?.close();
     this.#resetConflictAdmissionState();
-    this.rejectCaughtUpLocalSeqWaiters(new Error("memory replica closed"));
+    this.#rejectCaughtUpLocalSeqWaiters(new Error("memory replica closed"));
     // Settle any queued (not-yet-sent) watch refresh first so its pull promise
     // cannot outlive close(); `#closed` also makes refreshWatchSet fail closed
     // for any refresh already in flight.
@@ -4242,7 +4332,7 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
     this.#ackedSeqsByLocalSeq.clear();
   }
 
-  private noteCaughtUpLocalSeq(localSeq: number | undefined): void {
+  #noteCaughtUpLocalSeq(localSeq: number | undefined): void {
     if (localSeq === undefined) {
       return;
     }
@@ -4303,7 +4393,7 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
     }
   }
 
-  private waitForCaughtUpLocalSeq(localSeq: number): Promise<void> {
+  #waitForCaughtUpLocalSeq(localSeq: number): Promise<void> {
     if (this.#closed) {
       return Promise.reject(new Error("memory replica closed"));
     }
@@ -4315,7 +4405,7 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
     return pending.promise;
   }
 
-  private rejectCaughtUpLocalSeqWaiters(error: Error): void {
+  #rejectCaughtUpLocalSeqWaiters(error: Error): void {
     const waiters = this.#caughtUpLocalSeqWaiters;
     this.#caughtUpLocalSeqWaiters = [];
     for (const waiter of waiters) {
@@ -4348,7 +4438,7 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
     void Promise.allSettled([...this.#operationWatchRemovals.values()]);
     this.#operationWatchRemovals.clear();
     void Promise.allSettled([...this.#suppressedVerdicts]);
-    this.rejectCaughtUpLocalSeqWaiters(new Error("memory replica closed"));
+    this.#rejectCaughtUpLocalSeqWaiters(new Error("memory replica closed"));
     this.#syncTasks.clear();
     this.#watchSelectorTracker = new SelectorTracker<Result<Unit, PullError>>(
       () => this.#scopeKeyIdentity(),
@@ -4378,7 +4468,7 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
       return { ok: {} };
     }
     // The owed session remount, consumed BEFORE the watch-selector tracker
-    // is consulted below — not only at `sessionHandle()`. A selector the
+    // is consulted below — not only at `#memoizedSessionHandle()`. A selector the
     // tracker already covers is answered from it and never reaches a
     // session at all, so consuming only at the mount point leaves precisely
     // the docs the replica had successfully read being served out of a
@@ -4691,7 +4781,7 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
     }
     const commit: ClientCommit = {
       localSeq,
-      reads: this.buildReads(source, localSeq, identity),
+      reads: this.#buildReads(source, localSeq, identity),
       // Cell ops first, folded SQLite ops last — the same commit shape
       // commitOperations builds, so the wave batch is made of ordinary
       // client commits.
@@ -4959,7 +5049,7 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
     this.#watchedIds.clear();
     this.#delivered.clear();
     this.#resetConflictAdmissionState();
-    this.rejectCaughtUpLocalSeqWaiters(new Error("memory replica reset"));
+    this.#rejectCaughtUpLocalSeqWaiters(new Error("memory replica reset"));
     this.#cancelQueuedWatchRefresh();
     this.#watchSelectorTracker = new SelectorTracker<Result<Unit, PullError>>(
       () => this.#scopeKeyIdentity(),
@@ -4970,6 +5060,11 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
     });
   }
 
+  /**
+   * TypeScript-private rather than a `#` name, because
+   * `test/memory-v2-watch-remove-coverage.test.ts` replaces this member by
+   * assignment, which a `#` method does not allow.
+   */
   private async refreshWatchSet(
     entries: Iterable<[WatchAddress, SchemaPathSelector]>,
     type: "pull" | "integrate" = "pull",
@@ -5127,7 +5222,7 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
     const previous = this.#subscribedWatchView;
     this.#subscribedWatchView = view;
     previous?.close();
-    const updates = this.consumeUpdates(view.subscribeSync())
+    const updates = this.#consumeUpdates(view.subscribeSync())
       .finally(() => {
         this.#updatePromises.delete(updates);
         if (this.#subscribedWatchView === view) {
@@ -5239,7 +5334,7 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
     }
   }
 
-  private async consumeUpdates(
+  async #consumeUpdates(
     iterator: AsyncIterator<SessionSync>,
   ): Promise<void> {
     while (true) {
@@ -5290,7 +5385,7 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
       ["commitOperations", "buildCommit"],
       (): ClientCommit => ({
         localSeq,
-        reads: this.buildReads(source, localSeq),
+        reads: this.#buildReads(source, localSeq),
         // Cell ops first, folded SQLite ops last (applied in array order by the
         // engine; sqlite ops are not entity revisions and carry no id/scope).
         operations: [
@@ -5616,7 +5711,7 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
       // Strategy 1: a commit whose read set lands on a still-catching-up id.
       const admissionMode = conflictAdmissionMode();
       if (admissionMode !== "off") {
-        const threshold = this.preemptThreshold(commit);
+        const threshold = this.#preemptThreshold(commit);
         if (threshold !== undefined) {
           // Coarse mode: assume conflict and pre-empt without sending.
           const rejection = this.#makePreemptRejection(commit, threshold);
@@ -5830,7 +5925,7 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
         if (schedulerDependencyRejection === undefined) {
           this.#attachProviderReadyToRetry(rejection, localSeq);
           if (admissionMode !== "off" && rejection.name === "ConflictError") {
-            this.recordStaleFloor(commit, localSeq);
+            this.#recordStaleFloor(commit, localSeq);
           }
         }
         // Counted (even while silent) so multi-writer churn can be read back via
@@ -5896,7 +5991,7 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
     } catch (error) {
       return Promise.reject(error);
     }
-    const handle = this.sessionHandle();
+    const handle = this.#memoizedSessionHandle();
     if (this.#sessionClient !== undefined) {
       return handle;
     }
@@ -6049,7 +6144,7 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
    * read that buildReads later drops can spend a retry on an observation the
    * server would never validate.
    */
-  private commitReadActivities(
+  #commitReadActivities(
     source: IStorageTransaction,
     reads: Iterable<IReadActivity>,
   ): IReadActivity[] {
@@ -6160,7 +6255,7 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
       ownWrites.add(docKey(write.id, this.instanceKey(write.scope, identity)));
     }
     const unexamined = new Map<string, WatchAddress>();
-    for (const read of this.commitReadActivities(source, reads)) {
+    for (const read of this.#commitReadActivities(source, reads)) {
       const scope = normalizeCellScope(read.scope);
       // A malformed/incomplete served identity cannot name the instance on
       // the wire. Leave its claim for commit admission rather than pulling a
@@ -6264,13 +6359,13 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
     })();
   }
 
-  private buildReads(
+  #buildReads(
     source: IStorageTransaction | undefined,
     localSeq: number,
     // The reading run's identity (a served per-instance seal): each read's
     // pending layers and confirmed seq come from THAT instance's record.
     identity?: ScopeKeyIdentity,
-  ) {
+  ): ClientCommit["reads"] {
     const confirmed: ConfirmedCommitRead[] = [];
     const pending: PendingCommitRead[] = [];
     if (!source) {
@@ -6386,7 +6481,7 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
       }
     };
 
-    for (const read of this.commitReadActivities(source, reads)) {
+    for (const read of this.#commitReadActivities(source, reads)) {
       const scope = normalizeCellScope(read.scope);
       pushCommitRead(
         read.id as URI,
@@ -6463,7 +6558,7 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
    * cannot verify never applies, and an unverifiable schema document
    * never registers, so no unverified schema is ever used. Contained for
    * the PROCESS: this ran on the background consume path
-   * (`consumeUpdates`), where the previous frame-wide throw was an
+   * (`#consumeUpdates`), where the previous frame-wide throw was an
    * unhandled rejection that killed the consuming worker wholesale on
    * one bad document — a robustness hole against any producer bug (the
    * OW61 board: 13 file-level failures from one delivery race). The
@@ -6663,6 +6758,13 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
       internSchemaAsTaggedHashString(value as JSONSchema) === hash;
   }
 
+  /**
+   * TypeScript-private rather than a `#` name, because
+   * `test/executor-space-root-ensure.test.ts`,
+   * `test/schema-doc-sync.test.ts`, and
+   * `test/memory-v2-watch-remove-coverage.test.ts` replace this member by
+   * assignment, which a `#` method does not allow.
+   */
   private applySessionSync(
     sync: SessionSync,
     type: "pull" | "integrate",
@@ -6680,7 +6782,7 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
       sync.upserts.length === 0 &&
       sync.removes.length === 0
     ) {
-      this.noteCaughtUpLocalSeq(sync.caughtUpLocalSeq);
+      this.#noteCaughtUpLocalSeq(sync.caughtUpLocalSeq);
       return;
     }
 
@@ -6870,7 +6972,7 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
     // and the notification must reflect the post-promotion view — not a
     // transient double-apply of a still-standing overlay that the parked
     // application then silently removes.
-    this.noteCaughtUpLocalSeq(sync.caughtUpLocalSeq);
+    this.#noteCaughtUpLocalSeq(sync.caughtUpLocalSeq);
 
     if (before !== undefined) {
       const changes = before.compare(this);
@@ -6985,7 +7087,7 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
   // Mark every id this conflicted commit touched (reads + writes) stale until
   // the runner observes caughtUpLocalSeq >= the commit's localSeq — the seq the
   // server stages as the post-conflict catch-up point for these ids.
-  private recordStaleFloor(commit: ClientCommit, localSeq: number): void {
+  #recordStaleFloor(commit: ClientCommit, localSeq: number): void {
     const mark = (id: string, scope?: CellScope) => {
       const key = this.#docKeyOf({ id: id as URI, scope });
       const current = this.#staleFloor.get(key);
@@ -7009,7 +7111,7 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
   // current caught-up seq), return the highest such floor — the seq we must
   // reach before a retry can succeed. Only reads gate admission: a stale read
   // precondition is what the server rejects.
-  private preemptThreshold(commit: ClientCommit): number | undefined {
+  #preemptThreshold(commit: ClientCommit): number | undefined {
     if (this.#staleFloor.size === 0) {
       return undefined;
     }
@@ -7050,7 +7152,7 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
       // The catch-up that clears `threshold` is already in flight from the
       // earlier conflict; gate the retry directly on it (no provider round trip
       // to wrap, so we do NOT call attachProviderReadyToRetry here).
-      readyToRetry: () => this.waitForCaughtUpLocalSeq(threshold),
+      readyToRetry: () => this.#waitForCaughtUpLocalSeq(threshold),
     };
   }
 
@@ -7237,10 +7339,15 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
     }
     rejection.readyToRetry = async () => {
       await readyToRetry();
-      await this.waitForCaughtUpLocalSeq(localSeq);
+      await this.#waitForCaughtUpLocalSeq(localSeq);
     };
   }
 
+  /**
+   * TypeScript-private rather than a `#` name, because
+   * `test/memory-v2-subscription.test.ts` replaces this member by
+   * assignment, which a `#` method does not allow.
+   */
   private async waitForConflictReadRepair(
     rejection: StorageTransactionRejected,
   ): Promise<void> {
@@ -7791,7 +7898,7 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
     return false;
   }
 
-  private sessionHandle(): Promise<{
+  #memoizedSessionHandle(): Promise<{
     client: MemoryV2Client.Client;
     session: MemoryV2Client.SpaceSession;
   }> {
@@ -8020,7 +8127,7 @@ const toRejectedError = (
   //  - `SessionError`: the commit was routed to a session the server no longer
   //    knows. Classified TERMINAL by the retry allow-list — not because the
   //    commit was evaluated (it was not), but because nothing on the retry path
-  //    remounts the session: `sessionHandle()` memoizes the mount and clears it
+  //    remounts the session: `#memoizedSessionHandle()` memoizes the mount and clears it
   //    on close, and (since 2026-08-26) when the space's ACL CHANGES — which a
   //    commit retry is not. The name still has to survive normalization here,
   //    or the caller sees a generic TransactionError instead of the real cause.

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -1004,32 +1004,6 @@ export class StorageManager implements IStorageManager {
   #telemetry?: TelemetrySink;
 
   /**
-   * The pending-load registration step and the linked-cell sync collector,
-   * which a test drives directly.
-   */
-  get accessForTestingOnly(): {
-    registerPendingLoad(address: {
-      space: MemorySpace;
-      scope: CellScope;
-      id: URI;
-      scopeKey?: ScopeKey;
-    }): (failure?: unknown) => void;
-    collectLinkedCellSyncs(
-      value: unknown,
-      base: NormalizedLink,
-      schema: JSONSchema | undefined,
-      promises: Promise<unknown>[],
-      seen: Set<unknown>,
-    ): void;
-  } {
-    return {
-      registerPendingLoad: (address) => this.#registerPendingLoad(address),
-      collectLinkedCellSyncs: (value, base, schema, promises, seen) =>
-        this.#collectLinkedCellSyncs(value, base, schema, promises, seen),
-    };
-  }
-
-  /**
    * Attach the runtime's telemetry bus so replicas can emit the
    * `storage.push/pull.*` markers. Late-bound and optional: the manager is
    * constructed before (and independently of) the Runtime, and providers read
@@ -1089,6 +1063,32 @@ export class StorageManager implements IStorageManager {
     // caller mutating their map object must not desynchronize them.
     this.#seedHosts = Object.freeze({ ...(options.spaceHostMap ?? {}) });
     this.#memoryHost = String(options.memoryHost);
+  }
+
+  /**
+   * The pending-load registration step and the linked-cell sync collector,
+   * which a test drives directly.
+   */
+  get accessForTestingOnly(): {
+    registerPendingLoad(address: {
+      space: MemorySpace;
+      scope: CellScope;
+      id: URI;
+      scopeKey?: ScopeKey;
+    }): (failure?: unknown) => void;
+    collectLinkedCellSyncs(
+      value: unknown,
+      base: NormalizedLink,
+      schema: JSONSchema | undefined,
+      promises: Promise<unknown>[],
+      seen: Set<unknown>,
+    ): void;
+  } {
+    return {
+      registerPendingLoad: (address) => this.#registerPendingLoad(address),
+      collectLinkedCellSyncs: (value, base, schema, promises, seen) =>
+        this.#collectLinkedCellSyncs(value, base, schema, promises, seen),
+    };
   }
 
   /**
@@ -3040,12 +3040,14 @@ const docKey = (id: URI, instance: string): string => `${instance}\0${id}`;
  * caller knows it, the explicit instance key. */
 type LocalDocAddress = { id: URI; scope?: CellScope; scopeKey?: ScopeKey };
 
+/**
+ * One space's local replica: the documents the server has confirmed, the
+ * local writes pending on them, and the session that keeps the two in step.
+ * Exported so that a test holding one as `ISpaceReplica` can narrow to the
+ * class.
+ */
 export class SpaceReplica
   implements ISpaceReplica, IOperationStorageCapability {
-  // A member below declared `private` rather than `#` is one the storage
-  // suites reach and drive directly; a `#` name would put it out of their
-  // reach.
-
   readonly #space: MemorySpace;
   readonly #subscription: IStorageSubscription;
   readonly #scopeKeyIdentity: () => ScopeKeyIdentity;
@@ -3638,7 +3640,8 @@ export class SpaceReplica
    *
    * An admitted commit touched this space's ACL document, so the
    * AUTHORIZATION VERDICT that terminated this replica's session may have
-   * changed. Record it; `#memoizedSessionHandle()` consumes it on the next load.
+   * changed. Record it; `#memoizedSessionHandle()` consumes it on the next
+   * load.
    *
    * Why a latch instead of tearing the session down right here: the memory
    * server emits the admitted-commit notice BEFORE it runs
@@ -3651,8 +3654,8 @@ export class SpaceReplica
    * dependent on it.
    *
    * Consumption is event-driven, not timed: the next load attempt calls
-   * `#memoizedSessionHandle()`, and the serving loop already re-attempts a deferred
-   * event's load every drain (see the scheduler's `failHeadEventLoadPark`
+   * `#memoizedSessionHandle()`, and the serving loop already re-attempts a
+   * deferred event's load every drain (see the scheduler's `failHeadEventLoadPark`
    * and the SpaceServer's deferral backstop), so the heal arrives on the
    * cadence the deferral machinery already runs at.
    */
@@ -3669,8 +3672,9 @@ export class SpaceReplica
    * session object: `terminateSession` (memory/v2/client.ts) closes it,
    * clears its watch specs, and stores the verdict in `closeError`, which
    * `#assertOpen()` then rethrows for every later call. Nothing on the read
-   * or commit path ever dropped the memoized mount — `#memoizedSessionHandle()`
-   * clears it only in `close()`/`closeNow()` — so every subsequent pull
+   * or commit path ever dropped the memoized mount —
+   * `#memoizedSessionHandle()` clears it only in `close()`/`closeNow()` — so
+   * every subsequent pull
    * reused the same dead session and the space read `unauthorized` forever.
    * `storage/rejection.ts`'s `SessionError` note named this gap when it was
    * written: "the convergence argument is sound, only the remount is
@@ -3696,8 +3700,9 @@ export class SpaceReplica
    *     `{user: OWNER}` de-authorized it by design. The re-open binds the
    *     user, who is OWNER, and is admitted.
    *   - a GENUINE de-authorization (the user removed, ownership moved): the
-   *     re-open is DENIED at `session.open`. `#memoizedSessionHandle()`'s catch drops
-   *     the failed handle, the load keeps failing, and the served event
+   *     re-open is DENIED at `session.open`. `#memoizedSessionHandle()`'s
+   *     catch drops the failed handle, the load keeps failing, and the
+   *     served event
    *     keeps deferring — the ratified wedge, which OW54's give-up arm
    *     covers. Fail-closed, and loud.
    */
@@ -4468,8 +4473,9 @@ export class SpaceReplica
       return { ok: {} };
     }
     // The owed session remount, consumed BEFORE the watch-selector tracker
-    // is consulted below — not only at `#memoizedSessionHandle()`. A selector the
-    // tracker already covers is answered from it and never reaches a
+    // is consulted below — not only at `#memoizedSessionHandle()`. A
+    // selector the tracker already covers is answered from it and never
+    // reaches a
     // session at all, so consuming only at the mount point leaves precisely
     // the docs the replica had successfully read being served out of a
     // subscription the revocation killed. Found by independent review
@@ -8127,8 +8133,9 @@ const toRejectedError = (
   //  - `SessionError`: the commit was routed to a session the server no longer
   //    knows. Classified TERMINAL by the retry allow-list — not because the
   //    commit was evaluated (it was not), but because nothing on the retry path
-  //    remounts the session: `#memoizedSessionHandle()` memoizes the mount and clears it
-  //    on close, and (since 2026-08-26) when the space's ACL CHANGES — which a
+  //    remounts the session: `#memoizedSessionHandle()` memoizes the mount
+  //    and clears it on close, and (since 2026-08-26) when the space's ACL
+  //    CHANGES — which a
   //    commit retry is not. The name still has to survive normalization here,
   //    or the caller sees a generic TransactionError instead of the real cause.
   //  - `InvalidMessageError`: a frame off the wire would not decode, and the

--- a/packages/runner/test/array-ref-defs-propagation.test.ts
+++ b/packages/runner/test/array-ref-defs-propagation.test.ts
@@ -16,7 +16,8 @@ import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { StorageManager as V2StorageManager } from "../src/storage/v2.ts";
+import type { IStorageProvider } from "../src/storage/interface.ts";
+import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
 import type { JSONSchema } from "../src/builder/types.ts";
 import type { NormalizedLink } from "../src/link-types.ts";
 
@@ -89,7 +90,7 @@ describe("$defs propagation in array item schema extraction", () => {
     // The sync call itself won't find data (fake ID), but it will
     // call pull() which calls joinSchema() on the schema — and that's
     // where the crash happens.
-    (storageManager as any).collectLinkedCellSyncs(
+    storageManager.accessForTestingOnly.collectLinkedCellSyncs(
       value,
       base,
       arraySchema,
@@ -106,7 +107,7 @@ describe("$defs propagation in array item schema extraction", () => {
     }
   });
 
-  it("v2 collectLinkedCellSyncs carries parent $defs into array item schemas", () => {
+  it("v2 collectLinkedCellSyncs carries parent $defs into array item schemas", async () => {
     const cellLink = {
       "/": {
         "link@1": {
@@ -122,30 +123,30 @@ describe("$defs propagation in array item schema extraction", () => {
       path: [],
     };
     const capturedSchemas: unknown[] = [];
-    const collectLinkedCellSyncs =
-      (V2StorageManager.prototype as any).collectLinkedCellSyncs;
-    const trackPendingProviderSync =
-      (V2StorageManager.prototype as any).trackPendingProviderSync;
-    const fakeStorage = {
-      collectLinkedCellSyncs,
-      trackPendingProviderSync,
-      registerPendingLoad: () => () => {},
-      open: () => ({
-        sync: (_id: string, selector: { schema: unknown }) => {
-          capturedSchemas.push(selector.schema);
-          return Promise.resolve({ ok: {} });
-        },
-      }),
-    };
-
-    collectLinkedCellSyncs.call(
-      fakeStorage,
-      [cellLink],
-      base,
-      arraySchema,
-      [],
-      new Set(),
-    );
+    // A manager whose providers only record the schema each sync is asked
+    // for, which is the collector's one output this test reads.
+    class SchemaCapturingStorageManager extends EmulatedStorageManager {
+      override open(): IStorageProvider {
+        return {
+          sync: (_id: string, selector: { schema: unknown }) => {
+            capturedSchemas.push(selector.schema);
+            return Promise.resolve({ ok: {} });
+          },
+        } as unknown as IStorageProvider;
+      }
+    }
+    const capturing = SchemaCapturingStorageManager.emulate({ as: signer });
+    try {
+      capturing.accessForTestingOnly.collectLinkedCellSyncs(
+        [cellLink],
+        base,
+        arraySchema,
+        [],
+        new Set(),
+      );
+    } finally {
+      await capturing.close();
+    }
 
     expect(capturedSchemas).toEqual([
       {

--- a/packages/runner/test/ascell-link-read-through-conflict.test.ts
+++ b/packages/runner/test/ascell-link-read-through-conflict.test.ts
@@ -16,6 +16,7 @@ import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "../src/storage/cache.deno.ts";
+import type { SpaceReplica } from "../src/storage/v2.ts";
 import { Runtime } from "../src/runtime.ts";
 import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
 import type { JSONSchema } from "../src/builder/types.ts";
@@ -74,12 +75,9 @@ describe("asCell link: value read-through stays a commit-conflict dependency", (
     };
     expect(holder.isAdmin.get()).toBe(true);
 
-    const replica = storage.open(space).replica as unknown as {
-      buildReads(source: unknown, localSeq: number): {
-        confirmed: Array<{ id: string; path: string[] }>;
-      };
-    };
-    const confirmed = replica.buildReads(tx.tx, 1).confirmed;
+    const replica = storage.open(space).replica as SpaceReplica;
+    const confirmed = replica.accessForTestingOnly.buildReads(tx.tx, 1)
+      .confirmed;
     const cellBId = cellB.getAsNormalizedFullLink().id;
     assert(
       confirmed.some((r) => r.id === cellBId && r.path.includes("isAdmin")),

--- a/packages/runner/test/edit-with-retry-classification.test.ts
+++ b/packages/runner/test/edit-with-retry-classification.test.ts
@@ -391,8 +391,9 @@ Deno.test("a server ProtocolError reaches editWithRetry by name, once", async ()
 // `ConnectionError`'s — the commit was never evaluated, so a re-established
 // session could land it. It fails on a fact about the RETRY PATH, not about the
 // error: nothing between two `editWithRetry` attempts remounts the session.
-// `SpaceReplica.#memoizedSessionHandle()` memoizes the mount and clears it only in
-// `close()`/`closeNow()` (storage/v2.ts), and `SpaceSession.#reopen()` runs
+// `SpaceReplica.#memoizedSessionHandle()` memoizes the mount and clears it
+// only in `close()`/`closeNow()` (storage/v2.ts), and `SpaceSession.#reopen()`
+// runs
 // only from `restore()`, which only the client's transport `reconnect()` calls
 // (memory/v2/client.ts). So every attempt re-sends over the very handle the
 // server just refused.

--- a/packages/runner/test/edit-with-retry-classification.test.ts
+++ b/packages/runner/test/edit-with-retry-classification.test.ts
@@ -391,7 +391,7 @@ Deno.test("a server ProtocolError reaches editWithRetry by name, once", async ()
 // `ConnectionError`'s — the commit was never evaluated, so a re-established
 // session could land it. It fails on a fact about the RETRY PATH, not about the
 // error: nothing between two `editWithRetry` attempts remounts the session.
-// `SpaceReplica.sessionHandle()` memoizes the mount and clears it only in
+// `SpaceReplica.#memoizedSessionHandle()` memoizes the mount and clears it only in
 // `close()`/`closeNow()` (storage/v2.ts), and `SpaceSession.#reopen()` runs
 // only from `restore()`, which only the client's transport `reconnect()` calls
 // (memory/v2/client.ts). So every attempt re-sends over the very handle the

--- a/packages/runner/test/executor-session-remount.test.ts
+++ b/packages/runner/test/executor-session-remount.test.ts
@@ -441,8 +441,8 @@ describe("the session remount (profile-starvation fifth face)", () => {
   it("a doc watched on the DEAD session is refetched after the remount, not answered stale from the watch tracker", async () => {
     // Cubic P1 (three violations, one property). A pull whose selector the
     // watch tracker already covers returns WITHOUT reaching
-    // `#memoizedSessionHandle()` — so for such a doc the remount's latch is never
-    // consumed, and worse, the read is answered from a replica whose
+    // `#memoizedSessionHandle()` — so for such a doc the remount's latch is
+    // never consumed, and worse, the read is answered from a replica whose
     // watch died with the revoked session. My first pass flagged this as
     // a residual and claimed "each address re-installs on its next pull";
     // that claim was FALSE for exactly the tracker-covered case, which is

--- a/packages/runner/test/executor-session-remount.test.ts
+++ b/packages/runner/test/executor-session-remount.test.ts
@@ -8,7 +8,7 @@
 // authorizes that pre-genesis session BY DESIGN — the service principal
 // holds no READ under the landed ACL, and there is no `"*"` grant.
 //
-// Nothing then re-established it. `SpaceReplica.sessionHandle()`
+// Nothing then re-established it. `SpaceReplica.#memoizedSessionHandle()`
 // memoizes the mount and drops it only in close(), so every later
 // cross-space read into that space reused the dead session and failed
 // `ConnectionError: memory session revoked: unauthorized`, forever. In
@@ -441,7 +441,7 @@ describe("the session remount (profile-starvation fifth face)", () => {
   it("a doc watched on the DEAD session is refetched after the remount, not answered stale from the watch tracker", async () => {
     // Cubic P1 (three violations, one property). A pull whose selector the
     // watch tracker already covers returns WITHOUT reaching
-    // `sessionHandle()` — so for such a doc the remount's latch is never
+    // `#memoizedSessionHandle()` — so for such a doc the remount's latch is never
     // consumed, and worse, the read is answered from a replica whose
     // watch died with the revoked session. My first pass flagged this as
     // a residual and claimed "each address re-installs on its next pull";

--- a/packages/runner/test/memory-v2-read-compaction.test.ts
+++ b/packages/runner/test/memory-v2-read-compaction.test.ts
@@ -1,7 +1,9 @@
+import { toDocumentPath } from "@commonfabric/memory/v2";
 import { assert, assertEquals } from "@std/assert";
 import { dataUriFromValue } from "@commonfabric/data-model/codec-data-uri";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "../src/storage/cache.deno.ts";
+import type { SpaceReplica } from "../src/storage/v2.ts";
 import { Runtime } from "../src/runtime.ts";
 import { excludeReadFromConflict } from "../src/storage/reactivity-log.ts";
 import { txToReactivityLog } from "../src/scheduler.ts";
@@ -50,17 +52,12 @@ Deno.test("memory v2 compacts descendant confirmed reads under a recursive ances
     path: ["section0", "field0"],
   });
 
-  const replica = storage.open(space).replica as unknown as {
-    buildReads(source: unknown, localSeq: number): {
-      confirmed: Array<{ path: string[]; seq: number }>;
-      pending: Array<{ path: string[]; localSeq: number }>;
-    };
-  };
-  const reads = replica.buildReads(tx.tx, 1);
+  const replica = storage.open(space).replica as SpaceReplica;
+  const reads = replica.accessForTestingOnly.buildReads(tx.tx, 1);
 
   assertEquals(reads.pending, []);
   assertEquals(reads.confirmed.length, 1);
-  assertEquals(reads.confirmed[0].path, ["value"]);
+  assertEquals<readonly string[]>(reads.confirmed[0].path, ["value"]);
 
   await runtime.dispose();
   await storage.close();
@@ -93,16 +90,11 @@ Deno.test("memory v2 keeps descendant reads when the ancestor is non-recursive",
     path: ["section0", "field0"],
   });
 
-  const replica = storage.open(space).replica as unknown as {
-    buildReads(source: unknown, localSeq: number): {
-      confirmed: Array<{ path: string[]; seq: number }>;
-      pending: Array<{ path: string[]; localSeq: number }>;
-    };
-  };
-  const reads = replica.buildReads(tx.tx, 1);
+  const replica = storage.open(space).replica as SpaceReplica;
+  const reads = replica.accessForTestingOnly.buildReads(tx.tx, 1);
 
   assertEquals(reads.pending, []);
-  assertEquals(
+  assertEquals<readonly (readonly string[])[]>(
     reads.confirmed.map((read) => read.path).toSorted((left, right) =>
       JSON.stringify(left).localeCompare(JSON.stringify(right))
     ),
@@ -142,23 +134,18 @@ Deno.test("memory v2 excludes inline data URI reads from tracked commit dependen
     path: [],
   });
 
-  const replica = storage.open(space).replica as unknown as {
-    buildReads(source: unknown, localSeq: number): {
-      confirmed: Array<{ id: string; path: string[]; seq: number }>;
-      pending: Array<{ id: string; path: string[]; localSeq: number }>;
-    };
-  };
+  const replica = storage.open(space).replica as SpaceReplica;
   const directReads = [...(tx.tx.getReadActivities?.() ?? [])];
-  const reads = replica.buildReads(tx.tx, 1);
+  const reads = replica.accessForTestingOnly.buildReads(tx.tx, 1);
 
   assertEquals(
     directReads.map((read) => ({ id: read.id, path: read.path })),
-    [{ id: DOCUMENT_ADDRESS.id, path: ["value", "live"] }],
+    [{ id: DOCUMENT_ADDRESS.id, path: toDocumentPath(["value", "live"]) }],
   );
   assertEquals(reads.pending, []);
   assertEquals(
     reads.confirmed.map((read) => ({ id: read.id, path: read.path })),
-    [{ id: DOCUMENT_ADDRESS.id, path: ["value", "live"] }],
+    [{ id: DOCUMENT_ADDRESS.id, path: toDocumentPath(["value", "live"]) }],
   );
 
   await runtime.dispose();
@@ -196,13 +183,8 @@ Deno.test("memory v2 excludeReadFromConflict drops ONLY marked nonRecursive (ref
     { nonRecursive: true },
   );
 
-  const replica = storage.open(space).replica as unknown as {
-    buildReads(source: unknown, localSeq: number): {
-      confirmed: Array<{ path: string[]; seq: number }>;
-      pending: Array<{ path: string[]; localSeq: number }>;
-    };
-  };
-  const reads = replica.buildReads(tx.tx, 1);
+  const replica = storage.open(space).replica as SpaceReplica;
+  const reads = replica.accessForTestingOnly.buildReads(tx.tx, 1);
   const paths = reads.confirmed.map((read) => read.path.join("."));
 
   assert(
@@ -248,17 +230,11 @@ Deno.test("memory v2 excludeReadFromConflict reads STAY in the reactivity log (a
     { meta: excludeReadFromConflict, nonRecursive: true },
   );
 
-  const replica = storage.open(space).replica as unknown as {
-    buildReads(source: unknown, localSeq: number): {
-      confirmed: Array<{ path: string[]; seq: number }>;
-      pending: Array<{ path: string[]; localSeq: number }>;
-    };
-  };
+  const replica = storage.open(space).replica as SpaceReplica;
 
   // Conflict set DROPS the link read (no spurious collision with disjoint writers).
-  const conflictPaths = replica.buildReads(tx.tx, 1).confirmed.map((read) =>
-    read.path.join(".")
-  );
+  const conflictPaths = replica.accessForTestingOnly.buildReads(tx.tx, 1)
+    .confirmed.map((read) => read.path.join("."));
   assert(
     !conflictPaths.some((p) => p.endsWith("refShape")),
     `reference read must be excluded from the conflict set; got ${conflictPaths}`,

--- a/packages/runner/test/memory-v2-stacked-commit.test.ts
+++ b/packages/runner/test/memory-v2-stacked-commit.test.ts
@@ -21,6 +21,7 @@ import {
   type PatchOp,
   type SessionSync,
   type SqliteOperation,
+  toDocumentPath,
 } from "@commonfabric/memory/v2";
 import type {
   ClientCommit,
@@ -47,9 +48,13 @@ import {
 } from "../../memory/v2/path.ts";
 import type {
   IStorageProvider,
+  IStorageTransaction,
   StorageNotification,
 } from "../src/storage/interface.ts";
-import { setConflictAdmissionMode } from "../src/storage/v2.ts";
+import {
+  setConflictAdmissionMode,
+  type SpaceReplica,
+} from "../src/storage/v2.ts";
 import type { RuntimeTelemetryMarker } from "../src/telemetry.ts";
 import {
   NotificationRecorder,
@@ -641,13 +646,7 @@ const createHarness = (
         error: { name?: string; message?: string };
       }
     >;
-    buildReads(
-      source: unknown,
-      localSeq: number,
-    ): {
-      confirmed: ConfirmedRead[];
-      pending: PendingRead[];
-    };
+    accessForTestingOnly: SpaceReplica["accessForTestingOnly"];
     get(address: {
       id: URI;
       type: MIME;
@@ -736,11 +735,13 @@ const sourceFromReads = (
     ...(read.nonRecursive === true ? { nonRecursive: true } : {}),
     meta: read.seq === undefined ? {} : { seq: read.seq },
   }));
+  // A stand-in for the transaction whose reads the replica builds from,
+  // declared as one here so the callers pass it as the class types it.
   return {
     getReadActivities() {
       return activities;
     },
-  };
+  } as unknown as IStorageTransaction;
 };
 
 const visibleValue = (provider: TestProvider, id: URI) => {
@@ -910,7 +911,7 @@ const notificationLog = (notifications: StorageNotification[]) =>
 const topPendingSurface = (
   harness: Harness,
 ) => {
-  const reads = harness.replica.buildReads(
+  const reads = harness.replica.accessForTestingOnly.buildReads(
     sourceFromReads(Object.values(DOCS).map((id) => ({ id }))),
     10_000,
   );
@@ -1874,7 +1875,7 @@ Deno.test("memory v2 stacked commits: pending-read compaction keeps localSeq bou
     const c2 = beginSet(harness, DOCS.A, valueFor("c2"));
     harness.model.setOutcome(c2.localSeq, { kind: "accept" });
 
-    const reads = harness.replica.buildReads(
+    const reads = harness.replica.accessForTestingOnly.buildReads(
       sourceFromReads([
         { id: DOCS.A },
         { id: DOCS.A, path: ["nested"] },
@@ -1996,7 +1997,7 @@ Deno.test("memory v2 stacked commits: divergent basis overrides survive pending-
     // higher basis claim the pinned read's interval (0, confirmedBasis],
     // hiding a foreign write there from the server's staleness scan.
     const confirmedBasis = harness.model.applied.get(c1.localSeq)!.applied.seq;
-    const reads = harness.replica.buildReads(
+    const reads = harness.replica.accessForTestingOnly.buildReads(
       sourceFromReads([
         { id: DOCS.A },
         { id: DOCS.A, seq: 0 },
@@ -3730,11 +3731,6 @@ Deno.test("memory v2 stacked commits: replica reset locally rejects in-flight de
   }
 });
 
-type AdmissionReplica = {
-  recordStaleFloor(commit: unknown, localSeq: number): void;
-  noteCaughtUpLocalSeq(localSeq: number | undefined): void;
-};
-
 //
 // Read repair, and commits minted against it
 //
@@ -3749,10 +3745,13 @@ Deno.test("memory v2 stacked commits: preempt-mode admission rejects a floored c
   const previousLevel = storageLogger.level;
   storageLogger.level = "debug";
   try {
-    const replica = harness.replica as unknown as AdmissionReplica;
+    const replica = harness.replica.accessForTestingOnly;
     replica.recordStaleFloor({
       localSeq: 50,
-      reads: { confirmed: [{ id: DOCS.A, path: [], seq: 0 }], pending: [] },
+      reads: {
+        confirmed: [{ id: DOCS.A, path: toDocumentPath([]), seq: 0 }],
+        pending: [],
+      },
       operations: [],
     }, 50);
     const t = beginSet(
@@ -3985,7 +3984,7 @@ Deno.test("memory v2 stacked commits: a commit minted during the read repair is 
       return result;
     });
     assertEquals(
-      harness.replica.buildReads(
+      harness.replica.accessForTestingOnly.buildReads(
         sourceFromReads([{ id: DOCS.A }]),
         follower.localSeq + 1,
       ).pending.map((read) => read.localSeq),

--- a/packages/runner/test/memory-v2-subscription.test.ts
+++ b/packages/runner/test/memory-v2-subscription.test.ts
@@ -4,7 +4,11 @@ import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 
 import { Identity } from "@commonfabric/identity";
 import type { MIME, URI } from "@commonfabric/memory/interface";
-import type { SessionSync } from "@commonfabric/memory/v2";
+import {
+  type ClientCommit,
+  type SessionSync,
+  toDocumentPath,
+} from "@commonfabric/memory/v2";
 import * as MemoryV2Client from "@commonfabric/memory/v2/client";
 import type { Server as MemoryV2Server } from "@commonfabric/memory/v2/server";
 import { defer } from "@commonfabric/utils/defer";
@@ -21,6 +25,7 @@ import type {
 import {
   type SessionFactory,
   setConflictAdmissionEnabled,
+  type SpaceReplica,
   StorageManager as V2StorageManager,
 } from "../src/storage/v2.ts";
 import { createGraphFixture } from "./memory-v2-graph.fixture.ts";
@@ -102,29 +107,6 @@ const staleReadSource = (uri: URI, seq: number) => ({
     }];
   },
 });
-
-type RetryRepairHarness = {
-  noteCaughtUpLocalSeq(localSeq: number | undefined): void;
-  waitForCaughtUpLocalSeq(localSeq: number): Promise<void>;
-  rejectCaughtUpLocalSeqWaiters(error: Error): void;
-  closeNow(): void;
-  waitForConflictReadRepair(
-    rejection: StorageTransactionRejected,
-  ): Promise<void>;
-};
-
-type WatchRefreshHarness = {
-  closeNow(): void;
-  refreshWatchSet(
-    entries: Iterable<[
-      { id: URI; type: MIME; scope?: string },
-      { path: string[]; schema: false },
-    ]>,
-  ): Promise<{ ok?: unknown; error?: { message?: string } }>;
-};
-
-const retryRepairHarness = (replica: unknown): RetryRepairHarness =>
-  replica as RetryRepairHarness;
 
 const syntheticConflict = (
   uri: URI,
@@ -583,10 +565,16 @@ describe("Memory v2 storage notifications", () => {
       ) => Promise<{ ok?: unknown; error?: unknown }>;
     };
     const repairStarted = defer<void>();
-    const repairHarness = retryRepairHarness(replica);
-    const originalWaitForConflictReadRepair = repairHarness
-      .waitForConflictReadRepair.bind(repairHarness);
-    repairHarness.waitForConflictReadRepair = async (rejection) => {
+    // Replaced by assignment below, which only a TypeScript-private member
+    // allows, so it is reached the old way.
+    const stubbed = replica as unknown as {
+      waitForConflictReadRepair(
+        rejection: StorageTransactionRejected,
+      ): Promise<void>;
+    };
+    const originalWaitForConflictReadRepair = stubbed
+      .waitForConflictReadRepair.bind(stubbed);
+    stubbed.waitForConflictReadRepair = async (rejection) => {
       repairStarted.resolve();
       await originalWaitForConflictReadRepair(rejection);
     };
@@ -650,7 +638,8 @@ describe("Memory v2 storage notifications", () => {
 
   it("rejects pending caught-up waiters when storage closes", async () => {
     const provider = storageManager.open(space);
-    const harness = retryRepairHarness(provider.replica);
+    const replica = provider.replica as SpaceReplica;
+    const harness = replica.accessForTestingOnly;
 
     const readyAtTwo = harness.waitForCaughtUpLocalSeq(2);
     const readyAtThree = harness.waitForCaughtUpLocalSeq(3);
@@ -658,7 +647,7 @@ describe("Memory v2 storage notifications", () => {
 
     harness.noteCaughtUpLocalSeq(2);
     await readyAtTwo;
-    harness.closeNow();
+    replica.closeNow();
     await rejectsAtThree;
 
     await assertRejects(
@@ -670,7 +659,7 @@ describe("Memory v2 storage notifications", () => {
 
   it("swallows a rejecting readyToRetry during read repair", async () => {
     const provider = storageManager.open(space);
-    const harness = retryRepairHarness(provider.replica);
+    const harness = (provider.replica as SpaceReplica).accessForTestingOnly;
     const retryError = new Error("retry unavailable");
     let called = 0;
 
@@ -724,9 +713,9 @@ describe("Memory v2 storage notifications", () => {
     }
     const testStorageManager = new TestStorageManager();
     const provider = testStorageManager.open(space);
-    const replica = provider.replica as unknown as WatchRefreshHarness;
+    const replica = provider.replica as SpaceReplica;
 
-    const refresh = replica.refreshWatchSet([[
+    const refresh = replica.accessForTestingOnly.refreshWatchSet([[
       { id: "of:late-refresh" as URI, type: "application/json" as MIME },
       { path: [], schema: false },
     ]]);
@@ -742,46 +731,42 @@ describe("Memory v2 storage notifications", () => {
 
   it("admission control records, thresholds, and prunes a stale floor", () => {
     const provider = storageManager.open(space);
-    const replica = provider.replica as unknown as {
-      recordStaleFloor: (commit: unknown, localSeq: number) => void;
-      preemptThreshold: (commit: unknown) => number | undefined;
-      noteCaughtUpLocalSeq: (localSeq: number | undefined) => void;
-      reset: () => void;
-    };
-    const uri = `of:admission-floor-${Date.now()}`;
-    const reading = {
+    const replica = provider.replica as SpaceReplica;
+    const admission = replica.accessForTestingOnly;
+    const uri = `of:admission-floor-${Date.now()}` as URI;
+    const reading: ClientCommit = {
       localSeq: 9,
-      reads: { confirmed: [{ id: uri, path: [], seq: 0 }], pending: [] },
+      reads: {
+        confirmed: [{ id: uri, path: toDocumentPath([]), seq: 0 }],
+        pending: [],
+      },
       operations: [{ op: "set", id: uri, value: { value: { v: 2 } } }],
     };
 
     // Nothing stale yet -> the read is admitted.
-    expect(replica.preemptThreshold(reading)).toBeUndefined();
+    expect(admission.preemptThreshold(reading)).toBeUndefined();
 
     // A conflict at localSeq 7 marks uri stale until caughtUpLocalSeq >= 7.
-    replica.recordStaleFloor(reading, 7);
-    expect(replica.preemptThreshold(reading)).toBe(7);
+    admission.recordStaleFloor(reading, 7);
+    expect(admission.preemptThreshold(reading)).toBe(7);
 
     // Catching up to the floor makes the id fresh again -> admitted.
-    replica.noteCaughtUpLocalSeq(7);
-    expect(replica.preemptThreshold(reading)).toBeUndefined();
+    admission.noteCaughtUpLocalSeq(7);
+    expect(admission.preemptThreshold(reading)).toBeUndefined();
 
     // A reset starts a new replica epoch; stale floors from the old epoch must
     // not hold or pre-empt post-reset commits that read the same id.
-    replica.recordStaleFloor(reading, 8);
-    expect(replica.preemptThreshold(reading)).toBe(8);
+    admission.recordStaleFloor(reading, 8);
+    expect(admission.preemptThreshold(reading)).toBe(8);
     replica.reset();
-    expect(replica.preemptThreshold(reading)).toBeUndefined();
+    expect(admission.preemptThreshold(reading)).toBeUndefined();
   });
 
   it("reset rejects caught-up waiters from the previous replica epoch", async () => {
     const provider = storageManager.open(space);
-    const replica = provider.replica as unknown as {
-      waitForCaughtUpLocalSeq: (localSeq: number) => Promise<void>;
-      reset: () => void;
-    };
+    const replica = provider.replica as SpaceReplica;
 
-    const wait = replica.waitForCaughtUpLocalSeq(3);
+    const wait = replica.accessForTestingOnly.waitForCaughtUpLocalSeq(3);
     replica.reset();
 
     await expect(wait).rejects.toThrow("memory replica reset");
@@ -798,15 +783,17 @@ describe("Memory v2 storage notifications", () => {
         ) => Promise<
           { ok?: unknown; error?: { name?: string; message?: string } }
         >;
-        recordStaleFloor: (commit: unknown, localSeq: number) => void;
-        noteCaughtUpLocalSeq: (localSeq: number | undefined) => void;
+        accessForTestingOnly: SpaceReplica["accessForTestingOnly"];
       };
       const uri = `of:admission-preempt-${Date.now()}` as URI;
 
       // Simulate a prior conflict that marked uri stale until caughtUpLocalSeq>=5.
-      replica.recordStaleFloor({
+      replica.accessForTestingOnly.recordStaleFloor({
         localSeq: 5,
-        reads: { confirmed: [{ id: uri, path: [], seq: 0 }], pending: [] },
+        reads: {
+          confirmed: [{ id: uri, path: toDocumentPath([]), seq: 0 }],
+          pending: [],
+        },
         operations: [{ op: "set", id: uri, value: { value: { version: 1 } } }],
       }, 5);
 
@@ -829,7 +816,7 @@ describe("Memory v2 storage notifications", () => {
       await Promise.resolve();
       expect(settled).toBe(false);
 
-      replica.noteCaughtUpLocalSeq(5);
+      replica.accessForTestingOnly.noteCaughtUpLocalSeq(5);
       const result = await commitPromise;
       expect(result.ok).toBeFalsy();
       expect(result.error?.name).toBe("ConflictError");

--- a/packages/runner/test/memory-v2-subscription.test.ts
+++ b/packages/runner/test/memory-v2-subscription.test.ts
@@ -565,8 +565,8 @@ describe("Memory v2 storage notifications", () => {
       ) => Promise<{ ok?: unknown; error?: unknown }>;
     };
     const repairStarted = defer<void>();
-    // Replaced by assignment below, which only a TypeScript-private member
-    // allows, so it is reached the old way.
+    // Replaced by assignment below, which its `private` rather than `#` name
+    // allows; the cast reaches only it.
     const stubbed = replica as unknown as {
       waitForConflictReadRepair(
         rejection: StorageTransactionRejected,

--- a/packages/runner/test/schema-doc-sync.test.ts
+++ b/packages/runner/test/schema-doc-sync.test.ts
@@ -3,6 +3,7 @@ import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import type { FabricValue, JSONSchema, JSONSchemaObj } from "@commonfabric/api";
 import type { MemorySpace } from "@commonfabric/memory/interface";
+import type { SessionSync } from "@commonfabric/memory/v2";
 import type * as MemoryV2Server from "@commonfabric/memory/v2/server";
 import { internSchemaAsTaggedHashString } from "@commonfabric/data-model-schema";
 import {
@@ -10,6 +11,7 @@ import {
   newLoopbackServer,
 } from "../src/storage/cache.deno.ts";
 import { Runtime } from "../src/runtime.ts";
+import type { SpaceReplica } from "../src/storage/v2.ts";
 import {
   type DecomposedSchema,
   decomposeSchema,
@@ -503,7 +505,7 @@ describe("schema-doc-sync", () => {
     // the ARRIVING copy — no throw (a throw here killed the background
     // consumer wholesale, verification-coverage.md OW61) — and the stored,
     // verified document stays.
-    const forged = {
+    const forged: SessionSync = {
       type: "sync",
       fromSeq: 900_000,
       toSeq: 900_001,
@@ -516,11 +518,8 @@ describe("schema-doc-sync", () => {
       }],
       removes: [],
     };
-    const replica = provider.replica as unknown as {
-      applySessionSync(sync: unknown, type: string): void;
-      getDocument(uri: string): unknown;
-    };
-    replica.applySessionSync(forged, "integrate");
+    const replica = provider.replica as SpaceReplica;
+    replica.accessForTestingOnly.applySessionSync(forged, "integrate");
     expect(
       (replica.getDocument(`cid:${hash}`) as { value?: unknown })?.value,
     ).toEqual(schema);
@@ -580,11 +579,13 @@ describe("schema-doc-sync", () => {
       ],
       removes: [],
     };
-    const replica = provider.replica as unknown as {
-      applySessionSync(sync: unknown, type: string): void;
-      getDocument(uri: string): unknown;
-    };
-    replica.applySessionSync(frame, "integrate");
+    const replica = provider.replica as SpaceReplica;
+    // The frame is malformed on purpose, so it declares itself a frame only
+    // where it is handed over.
+    replica.accessForTestingOnly.applySessionSync(
+      frame as unknown as SessionSync,
+      "integrate",
+    );
     expect(replica.getDocument("of:frame-innocent-sibling")).toEqual({
       value: { fine: true },
     });
@@ -598,10 +599,7 @@ describe("schema-doc-sync", () => {
     } as const;
     const depHash = internSchemaAsTaggedHashString(depSchema);
     const provider = readerStorage.open(space);
-    const replica = provider.replica as unknown as {
-      applySessionSync(sync: unknown, type: string): void;
-      getDocument(uri: string): unknown;
-    };
+    const replica = provider.replica as SpaceReplica;
     const carrierDoc = {
       value: {
         linked: {
@@ -620,7 +618,7 @@ describe("schema-doc-sync", () => {
     // sees (the OW61 client-side defect class; the server's elision of
     // already-delivered cid docs is the design). Quarantined, replica
     // untouched for it.
-    replica.applySessionSync({
+    replica.accessForTestingOnly.applySessionSync({
       type: "sync",
       fromSeq: 700_000,
       toSeq: 700_001,
@@ -640,7 +638,7 @@ describe("schema-doc-sync", () => {
     // shape a FULL evaluation produces (watch.set / reconnect ship the
     // whole assembled closure; per-frame resend was reversed, OW61
     // RULED 2026-08-24). The doc applies: quarantine heals there.
-    replica.applySessionSync({
+    replica.accessForTestingOnly.applySessionSync({
       type: "sync",
       fromSeq: 700_001,
       toSeq: 700_002,
@@ -667,20 +665,21 @@ describe("schema-doc-sync", () => {
 
   it("the background consumer survives a frame that fails to apply and keeps consuming", async () => {
     const provider = readerStorage.open(space);
-    const replica = provider.replica as unknown as {
-      applySessionSync(sync: unknown, type: string): void;
-      consumeUpdates(iterator: AsyncIterator<unknown>): Promise<void>;
-      getDocument(uri: string): unknown;
-    };
+    const replica = provider.replica as SpaceReplica;
     // Throw once from applySessionSync itself (any non-validation apply
     // bug), self-restoring: the belt in consumeUpdates must swallow it,
-    // keep the loop alive, and apply the NEXT frame.
-    const original = replica.applySessionSync.bind(replica);
-    replica.applySessionSync = (_sync: unknown, _type: string) => {
-      replica.applySessionSync = original;
+    // keep the loop alive, and apply the NEXT frame. The member is replaced
+    // by assignment, which its `private` rather than `#` name allows; the
+    // cast reaches only it.
+    const stubbed = replica as unknown as {
+      applySessionSync(sync: SessionSync, type: "pull" | "integrate"): void;
+    };
+    const original = stubbed.applySessionSync.bind(stubbed);
+    stubbed.applySessionSync = () => {
+      stubbed.applySessionSync = original;
       throw new Error("synthetic apply failure");
     };
-    const frames = [
+    const frames: SessionSync[] = [
       {
         type: "sync",
         fromSeq: 600_000,
@@ -709,7 +708,7 @@ describe("schema-doc-sync", () => {
       },
     ];
     let index = 0;
-    const iterator: AsyncIterator<unknown> = {
+    const iterator: AsyncIterator<SessionSync> = {
       next: () =>
         Promise.resolve(
           index < frames.length
@@ -719,18 +718,20 @@ describe("schema-doc-sync", () => {
     };
     // Must resolve (not reject): a rejection here was the unhandled
     // rejection that killed consuming workers wholesale (OW61).
-    await replica.consumeUpdates(iterator);
+    await replica.accessForTestingOnly.consumeUpdates(iterator);
     expect(replica.getDocument("of:survivor-1")).toBeUndefined();
     expect(replica.getDocument("of:survivor-2")).toEqual({ value: { n: 2 } });
   });
 
   it("closes the staged watch view when a frame fails validation", async () => {
     const provider = readerStorage.open(space);
-    const replica = provider.replica as unknown as {
-      applySessionSync(sync: unknown, type: string): void;
+    // The member is replaced by assignment, which its `private` rather than
+    // `#` name allows; the cast reaches only it.
+    const stubbed = provider.replica as unknown as {
+      applySessionSync(sync: SessionSync, type: "pull" | "integrate"): void;
     };
-    const original = replica.applySessionSync.bind(replica);
-    replica.applySessionSync = () => {
+    const original = stubbed.applySessionSync.bind(stubbed);
+    stubbed.applySessionSync = () => {
       throw new Error("synthetic frame validation failure");
     };
     try {
@@ -742,7 +743,7 @@ describe("schema-doc-sync", () => {
         "synthetic frame validation failure",
       );
     } finally {
-      replica.applySessionSync = original;
+      stubbed.applySessionSync = original;
     }
   });
 

--- a/packages/runner/test/speculation-arrival-gate.test.ts
+++ b/packages/runner/test/speculation-arrival-gate.test.ts
@@ -1244,8 +1244,8 @@ describe("speculation arrival gate (speculation.md §4, RULED 2026-08-16)", () =
       // mixed window: a pre-predicate frame, or one from before this
       // client learned the class).
       sync(upsert(5));
-      const wakes: Array<Array<{ id: string; scope?: string }>> = [];
-      replica.speculationArrivalObserver = (docs) => wakes.push([...docs]);
+      const wakes: Array<readonly { id: string; scope?: string }[]> = [];
+      replica.speculationArrivalObserver = (docs) => wakes.push(docs);
       // A same-seq echo still without a class: nothing changed, no wake.
       sync(upsert(5));
       expect(wakes.length).toBe(0);

--- a/packages/runner/test/speculation-arrival-gate.test.ts
+++ b/packages/runner/test/speculation-arrival-gate.test.ts
@@ -56,8 +56,10 @@ import {
   type CommitClass,
   resolveScopeKey,
   SERVER_EXECUTION_WATERMARK_DOC_ID,
+  type SessionSync,
 } from "@commonfabric/memory/v2";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import type { SpaceReplica } from "../src/storage/v2.ts";
 import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
 import { Runtime } from "../src/runtime.ts";
 import type {
@@ -1160,36 +1162,22 @@ describe("speculation arrival gate (speculation.md §4, RULED 2026-08-16)", () =
       experimental: { serverExecution: true },
     });
     try {
-      const replica = runtime.storageManager.open(space).replica as unknown as {
-        applySessionSync(
-          sync: {
-            type: "sync";
-            fromSeq: number;
-            toSeq: number;
-            upserts: Array<Record<string, unknown>>;
-            removes: Array<Record<string, unknown>>;
-          },
-          type: "pull" | "integrate",
-        ): void;
-        speculationRetirementView(
-          id: string,
-          scope?: string,
-        ): { confirmedSeq: number; coverClass?: CommitClass };
-      };
+      const replica = runtime.storageManager.open(space)
+        .replica as SpaceReplica;
       const upsert = (
         seq: number,
         coverClass?: CommitClass,
       ) => ({
         branch: "",
         id: "of:threading-doc",
-        scope: "space",
+        scope: "space" as const,
         seq,
         doc: { value: { n: seq } },
         ...(coverClass === undefined ? {} : { coverClass }),
       });
       const view = () =>
         replica.speculationRetirementView("of:threading-doc", "space");
-      replica.applySessionSync({
+      replica.accessForTestingOnly.applySessionSync({
         type: "sync",
         fromSeq: 0,
         toSeq: 5,
@@ -1200,7 +1188,7 @@ describe("speculation arrival gate (speculation.md §4, RULED 2026-08-16)", () =
       // A same-seq re-upsert WITHOUT a class (a watch-refresh replay, an
       // OFF-arm or pre-predicate frame echo) preserves the known class —
       // the cover is the same commit.
-      replica.applySessionSync({
+      replica.accessForTestingOnly.applySessionSync({
         type: "sync",
         fromSeq: 5,
         toSeq: 5,
@@ -1210,7 +1198,7 @@ describe("speculation arrival gate (speculation.md §4, RULED 2026-08-16)", () =
       expect(view()).toMatchObject({ confirmedSeq: 5, coverClass: "derived" });
       // A FORWARD move without a class is a different commit: the stale
       // class must not survive onto it.
-      replica.applySessionSync({
+      replica.accessForTestingOnly.applySessionSync({
         type: "sync",
         fromSeq: 5,
         toSeq: 6,
@@ -1234,31 +1222,18 @@ describe("speculation arrival gate (speculation.md §4, RULED 2026-08-16)", () =
       experimental: { serverExecution: true },
     });
     try {
-      const replica = runtime.storageManager.open(space).replica as unknown as {
-        applySessionSync(
-          sync: {
-            type: "sync";
-            fromSeq: number;
-            toSeq: number;
-            upserts: Array<Record<string, unknown>>;
-            removes: Array<Record<string, unknown>>;
-          },
-          type: "pull" | "integrate",
-        ): void;
-        speculationArrivalObserver:
-          | ((docs: Array<{ id: string; scope?: string }>) => void)
-          | undefined;
-      };
+      const replica = runtime.storageManager.open(space)
+        .replica as SpaceReplica;
       const upsert = (seq: number, coverClass?: CommitClass) => ({
         branch: "",
         id: "of:wake-doc",
-        scope: "space",
+        scope: "space" as const,
         seq,
         doc: { value: { n: seq } },
         ...(coverClass === undefined ? {} : { coverClass }),
       });
-      const sync = (up: Record<string, unknown>) =>
-        replica.applySessionSync({
+      const sync = (up: SessionSync["upserts"][number]) =>
+        replica.accessForTestingOnly.applySessionSync({
           type: "sync",
           fromSeq: 0,
           toSeq: 5,
@@ -1270,7 +1245,7 @@ describe("speculation arrival gate (speculation.md §4, RULED 2026-08-16)", () =
       // client learned the class).
       sync(upsert(5));
       const wakes: Array<Array<{ id: string; scope?: string }>> = [];
-      replica.speculationArrivalObserver = (docs) => wakes.push(docs);
+      replica.speculationArrivalObserver = (docs) => wakes.push([...docs]);
       // A same-seq echo still without a class: nothing changed, no wake.
       sync(upsert(5));
       expect(wakes.length).toBe(0);

--- a/packages/runner/test/storage-instance-keying.test.ts
+++ b/packages/runner/test/storage-instance-keying.test.ts
@@ -38,6 +38,7 @@ import { Runtime, type ServerRunInfo } from "../src/runtime.ts";
 import { stampWaveRunContext } from "../src/executor/wave.ts";
 import { entityKey, entityNameKey } from "../src/scheduler/keys.ts";
 import { sortAndCompactPaths } from "../src/reactive-dependencies.ts";
+import type { SpaceReplica } from "../src/storage/v2.ts";
 import { watchIdForEntry } from "../src/storage/v2-watch.ts";
 import type {
   IExtendedStorageTransaction,
@@ -277,14 +278,7 @@ describe("stage A: instance keying — unit pins", () => {
     // unkeyed one to the own instance — so both halves together are what
     // keeps the own doc intact.
 
-    const replica = storageManager.open(space).replica as unknown as {
-      getDocument: (
-        id: string,
-        scope?: string,
-        identity?: ScopeKeyIdentity,
-      ) => { value?: unknown } | undefined;
-      applySessionSync: (sync: unknown, type: "pull" | "integrate") => void;
-    };
+    const replica = storageManager.open(space).replica as SpaceReplica;
     const ownCell = runtime.getCell<{ value: string }>(
       space,
       "stagea-keyed-retraction-cell",
@@ -304,7 +298,7 @@ describe("stage A: instance keying — unit pins", () => {
     expect(readAs(undefined)).toBe("own");
 
     // A KEYED lease-holder frame delivers Alice's instance.
-    replica.applySessionSync({
+    replica.accessForTestingOnly.applySessionSync({
       type: "sync",
       fromSeq: 0,
       toSeq: 5,
@@ -325,7 +319,7 @@ describe("stage A: instance keying — unit pins", () => {
     // instance is untouched. (Mutation: `applySessionSync` ignoring
     // `remove.scopeKey` wipes the own instance and keeps Alice's stale
     // one — the exact inverse.)
-    replica.applySessionSync({
+    replica.accessForTestingOnly.applySessionSync({
       type: "sync",
       fromSeq: 5,
       toSeq: 6,
@@ -341,7 +335,7 @@ describe("stage A: instance keying — unit pins", () => {
     // is exactly why the memory server keys every retraction on a keyed
     // wire (the pre-fix former-holder catch-up sent this frame for
     // ALICE's entry and wiped the own doc: `own: undefined, alice: alice`).
-    replica.applySessionSync({
+    replica.accessForTestingOnly.applySessionSync({
       type: "sync",
       fromSeq: 6,
       toSeq: 7,
@@ -356,7 +350,7 @@ describe("stage A: instance keying — unit pins", () => {
       removes: [],
     }, "integrate");
     expect(readAs(alice)).toBe("alice-2");
-    replica.applySessionSync({
+    replica.accessForTestingOnly.applySessionSync({
       type: "sync",
       fromSeq: 7,
       toSeq: 8,
@@ -735,9 +729,7 @@ describe("stage A: instance keying — unit pins", () => {
     const docId = scoped.getAsNormalizedFullLink().id;
     // Alice's instance arrives KEYED at seq 5; the replica's own instance
     // of the doc is never loaded (seq 0).
-    (replica as unknown as {
-      applySessionSync: (sync: unknown, type: "pull" | "integrate") => void;
-    }).applySessionSync({
+    (replica as SpaceReplica).accessForTestingOnly.applySessionSync({
       type: "sync",
       fromSeq: 0,
       toSeq: 5,

--- a/packages/runner/test/storage-pending-load.test.ts
+++ b/packages/runner/test/storage-pending-load.test.ts
@@ -1,7 +1,11 @@
 import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import type { NormalizedLink } from "../src/link-types.ts";
-import { ReplicaLoadFailureError } from "../src/storage/interface.ts";
+import {
+  type MemorySpace,
+  ReplicaLoadFailureError,
+  type URI,
+} from "../src/storage/interface.ts";
 import { StorageManager } from "../src/storage/v2.ts";
 import {
   createSchedulerTestRuntime,
@@ -43,10 +47,15 @@ describe("storage pending-load generations", () => {
     await tx.commit();
     env.tx = runtime.edit();
 
-    const storage = runtime.storageManager as any;
+    const storage = runtime.storageManager as StorageManager;
     const schemaStarted = Promise.withResolvers<void>();
     const releaseSchema = Promise.withResolvers<void>();
-    storage.syncCfcSchemaDocument = async () => {
+    // Replaced by assignment below, which only a TypeScript-private member
+    // allows, so it is reached the old way.
+    const stubbed = storage as unknown as {
+      syncCfcSchemaDocument(): Promise<Error | undefined>;
+    };
+    stubbed.syncCfcSchemaDocument = async () => {
       schemaStarted.resolve();
       await releaseSchema.promise;
       return undefined;
@@ -74,12 +83,12 @@ describe("storage pending-load generations", () => {
 
   it("tracks linked-document pulls kicked from data values", async () => {
     const { runtime } = env;
-    const storage = runtime.storageManager as any;
+    const storage = runtime.storageManager as StorageManager;
     const targetId = "of:pending-linked-target";
     const syncStarted = Promise.withResolvers<void>();
     const releaseSync = Promise.withResolvers<void>();
     const originalOpen = storage.open.bind(storage);
-    storage.open = (openSpace: string) => {
+    storage.open = (openSpace: MemorySpace) => {
       const provider = originalOpen(openSpace);
       return new Proxy(provider, {
         get(target, property, receiver) {
@@ -116,7 +125,7 @@ describe("storage pending-load generations", () => {
       },
     };
     const promises: Promise<unknown>[] = [];
-    storage.collectLinkedCellSyncs(
+    storage.accessForTestingOnly.collectLinkedCellSyncs(
       value,
       base,
       undefined,
@@ -134,11 +143,11 @@ describe("storage pending-load generations", () => {
 
   it("releases the pending generation when syncCell rejects", async () => {
     const { runtime } = env;
-    const storage = runtime.storageManager as any;
+    const storage = runtime.storageManager as StorageManager;
     const id = "of:pending-sync-rejection";
     const cell = runtime.getCell(space, id);
     const originalOpen = storage.open.bind(storage);
-    storage.open = (openSpace: string) => {
+    storage.open = (openSpace: MemorySpace) => {
       const provider = originalOpen(openSpace);
       return new Proxy(provider, {
         get(target, property, receiver) {
@@ -165,10 +174,10 @@ describe("storage pending-load generations", () => {
   });
 
   it("releases linked-document loads when provider sync throws synchronously", () => {
-    const storage = env.runtime.storageManager as any;
+    const storage = env.runtime.storageManager as StorageManager;
     const targetId = "of:pending-linked-sync-throw";
     const originalOpen = storage.open.bind(storage);
-    storage.open = (openSpace: string) => {
+    storage.open = (openSpace: MemorySpace) => {
       const provider = originalOpen(openSpace);
       return new Proxy(provider, {
         get(target, property, receiver) {
@@ -194,7 +203,7 @@ describe("storage pending-load generations", () => {
         "/": { "link@1": { id: targetId, path: [], space } },
       };
       expect(() =>
-        storage.collectLinkedCellSyncs(
+        storage.accessForTestingOnly.collectLinkedCellSyncs(
           value,
           base,
           undefined,
@@ -210,10 +219,10 @@ describe("storage pending-load generations", () => {
   });
 
   it("rejects linked-document loads when provider sync rejects", async () => {
-    const storage = env.runtime.storageManager as any;
+    const storage = env.runtime.storageManager as StorageManager;
     const targetId = "of:pending-linked-sync-rejection";
     const originalOpen = storage.open.bind(storage);
-    storage.open = (openSpace: string) => {
+    storage.open = (openSpace: MemorySpace) => {
       const provider = originalOpen(openSpace);
       return new Proxy(provider, {
         get(target, property, receiver) {
@@ -237,7 +246,7 @@ describe("storage pending-load generations", () => {
         "/": { "link@1": { id: targetId, path: [], space } },
       };
       const promises: Promise<unknown>[] = [];
-      storage.collectLinkedCellSyncs(
+      storage.accessForTestingOnly.collectLinkedCellSyncs(
         value,
         base,
         undefined,
@@ -257,8 +266,12 @@ describe("storage pending-load generations", () => {
   });
 
   it("rejects failed generations and gives a later load a new identity", async () => {
-    const storage = env.runtime.storageManager as any;
-    const address = { space, scope: "space", id: "of:generation" };
+    const storage = env.runtime.storageManager as StorageManager;
+    const address = {
+      space,
+      scope: "space" as const,
+      id: "of:generation" as URI,
+    };
     const key = `${address.space}/${address.scope}/${address.id}`;
     const recoveries: Array<{
       failedEpoch: string;
@@ -268,17 +281,22 @@ describe("storage pending-load generations", () => {
       recoveries.push(recovery);
     };
 
-    const releaseFirst = storage.registerPendingLoad(address);
+    const releaseFirst = storage.accessForTestingOnly.registerPendingLoad(
+      address,
+    );
     const firstGeneration = storage.pendingLoadGeneration(key);
+    expect(firstGeneration).toBeDefined();
     expect(recoveries).toEqual([]);
     const firstSettled = storage.loadsSettled([key]);
     releaseFirst(new Error("transport failed"));
     await expect(firstSettled).rejects.toThrow("transport failed");
     expect(recoveries).toEqual([]);
 
-    const releaseSecond = storage.registerPendingLoad(address);
+    const releaseSecond = storage.accessForTestingOnly.registerPendingLoad(
+      address,
+    );
     const secondGeneration = storage.pendingLoadGeneration(key);
-    expect(secondGeneration).toBeGreaterThan(firstGeneration);
+    expect(secondGeneration).toBeGreaterThan(firstGeneration!);
     expect(recoveries).toEqual([]);
     releaseSecond();
     await storage.loadsSettled([key]);
@@ -289,10 +307,16 @@ describe("storage pending-load generations", () => {
   });
 
   it("matches a failed load after the storage manager is recreated", async () => {
-    const first = env.runtime.storageManager as any;
-    const address = { space, scope: "space", id: "of:recreated-generation" };
+    const first = env.runtime.storageManager as StorageManager;
+    const address = {
+      space,
+      scope: "space" as const,
+      id: "of:recreated-generation" as URI,
+    };
     const key = `${address.space}/${address.scope}/${address.id}`;
-    const releaseFirst = first.registerPendingLoad(address);
+    const releaseFirst = first.accessForTestingOnly.registerPendingLoad(
+      address,
+    );
     const firstSettled = first.loadsSettled([key]);
     releaseFirst(new Error("transport failed before recreation"));
 
@@ -307,14 +331,16 @@ describe("storage pending-load generations", () => {
 
     const replacementEnv = createSchedulerTestRuntime(import.meta.url);
     try {
-      const replacement = replacementEnv.runtime.storageManager as any;
+      const replacement = replacementEnv.runtime
+        .storageManager as StorageManager;
       let recovery:
         | { failedEpoch: string; recoveryEpoch: string }
         | undefined;
       replacement.loadRecoveryObserver = (value: typeof recovery) => {
         recovery = value;
       };
-      const releaseReplacement = replacement.registerPendingLoad(address);
+      const releaseReplacement = replacement.accessForTestingOnly
+        .registerPendingLoad(address);
       expect(recovery).toBeUndefined();
       releaseReplacement();
       expect(recovery?.failedEpoch).toBe(failedEpoch);

--- a/packages/runner/test/storage-pending-load.test.ts
+++ b/packages/runner/test/storage-pending-load.test.ts
@@ -50,8 +50,8 @@ describe("storage pending-load generations", () => {
     const storage = runtime.storageManager as StorageManager;
     const schemaStarted = Promise.withResolvers<void>();
     const releaseSchema = Promise.withResolvers<void>();
-    // Replaced by assignment below, which only a TypeScript-private member
-    // allows, so it is reached the old way.
+    // Replaced by assignment below, which its `private` rather than `#` name
+    // allows; the cast reaches only it.
     const stubbed = storage as unknown as {
       syncCfcSchemaDocument(): Promise<Error | undefined>;
     };


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Fable 5.1)

`storage/v2.ts` held sixteen members as TypeScript `private` across
`StorageManager` and `SpaceReplica`, each under a note naming the test
that reached it, or with no note at all. Twelve are `#` names now, behind
an `accessForTestingOnly` getter per class, as
`docs/development/DEVELOPMENT.md` § Classes prescribes; four stay
`private` because tests replace them by assignment.

## The two accessors

`StorageManager`: `registerPendingLoad` and `collectLinkedCellSyncs`, as
forwarding arrows. `trackPendingProviderSync` had one reach, a call off
the prototype against a stand-in, which the guideline answers by building
a real instance; with that test rewritten it has no reach and is a plain
`#` method.

`SpaceReplica`: `noteCaughtUpLocalSeq`, `waitForCaughtUpLocalSeq`,
`recordStaleFloor`, `preemptThreshold`, `buildReads`, and
`consumeUpdates` as forwarding arrows, plus the three members that stay
`private` (below) forwarded through the accessor for the tests that only
call them. `rejectCaughtUpLocalSeqWaiters` and `commitReadActivities` have
no test reach and get no entry. `buildReads` had an inferred return type;
it is now written as `ClientCommit["reads"]` so the accessor can name it.

Two things a reader should know:

- `SpaceReplica` is now exported. `IStorageProvider.replica` is typed as
  the `ISpaceReplica` interface, and the guideline's route to a getter on
  the class is to narrow to the class, which needs its name in scope.
- The memoizing session-mount step is `#memoizedSessionHandle()`. It was
  `sessionHandle()`, and the field it memoizes into is `#sessionHandle`, so
  the two could not share the name. The prose naming it (three test
  comments, `rejection.ts`, two documents) follows.

## What stays `private`, and why

`StorageManager.syncCfcSchemaDocument` (`storage-pending-load`),
`SpaceReplica.refreshWatchSet` (`memory-v2-watch-remove-coverage`),
`SpaceReplica.applySessionSync` (`executor-space-root-ensure`,
`schema-doc-sync`, `memory-v2-watch-remove-coverage`), and
`SpaceReplica.waitForConflictReadRepair` (`memory-v2-subscription`) are
each replaced by assignment, which a `#` name cannot support. Each keeps
a note naming the tests; the three replica ones are forwarded through the
accessor under a `TODO(danfuzz)` naming the seam that would let them go
`#`. The stubbing sites keep one cast each, narrowed to the stubbed
member.

## What the tests do now

Eleven test files drop their casts for the accessor. Hand-built values
that now meet the class's types declare themselves where the guideline
says: a document path through `toDocumentPath`, a session-sync frame by
contextual typing at its declaration, a read source as the transaction it
stands in for (inside the one helper that builds it), and one
deliberately malformed frame with an `as` where it is handed over. Two
comparisons of a branded path against a literal pick their comparison
type on `assertEquals` instead of casting the actual value.

`array-ref-defs-propagation.test.ts` called `collectLinkedCellSyncs` and
`trackPendingProviderSync` off `StorageManager.prototype` against a
plain-object stand-in. It now builds a real manager: a subclass of
`EmulatedStorageManager` whose `open()` returns a provider that records
the schema each sync is asked for, which is the one output the test
reads. `emulate()` constructs with `new this`, so the subclass comes back
from it.

## Review

Reviewed by a `cf-review` pass: approve, no blocking findings. Four of its
five improvements are applied in a follow-up commit: the stale class-head
note on `SpaceReplica` is gone, the exported class has a doc comment,
`StorageManager.accessForTestingOnly` sits after the constructor, and the
twelve comment lines the renames pushed past 80 columns are reflowed. The
fifth, a second bare `sessionHandle()` in the coverage record, was also
cubic's one finding and is fixed. Of its nits, the stub-site wording and
the arrival-gate wake log's typing are taken; dropping the `unknown` hop
from the read-source stand-in's cast does not compile and stays.

## Gates

`deno fmt --check`, `deno lint`, `deno task check`, and the `runner`
suite (1390 passed, 0 failed). Three documents and two sibling source files name the
renamed session step.
