### PR TITLE
refactor(runner): `Runner` keeps its tables, sets, and start steps in `#` members behind `accessForTestingOnly`

### DIFF
--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -6566,7 +6566,7 @@ supply; OW29/OW32/OW34 closed):
     contract's own shape): (i) the pattern POINTER for
     separate-start/resume/stop-restart flows and (ii) the
     setup-completion MARKER for `storedSetupMarker`'s reuse decision —
-    both via `Runner.sessionPatternPointers`, written exactly where the
+    both via `Runner.#sessionPatternPointers`, written exactly where the
     stamps are skipped; and (iii) the intra-session CHANGE SIGNAL for
     RUNNING sub-pieces: a lift re-deriving its returned pattern used to
     reach the running piece's swap machinery THROUGH the stamp (setup

--- a/packages/runner/src/harness/verified-provenance.ts
+++ b/packages/runner/src/harness/verified-provenance.ts
@@ -12,7 +12,7 @@ import { VERIFIED_BINDING_METADATA_FIELD } from "@commonfabric/utils/sandbox-con
  * registration channel: a builder artifact minted DURING a running action has
  * no content-addressed identity, and the runner fails closed at creation time
  * instead of admitting it (identity E5 — see
- * `Runner.invokeJavaScriptImplementation` / `builder/action-context.ts`).
+ * `Runner.#invokeJavaScriptImplementation` / `builder/action-context.ts`).
  *
  * The WeakMap itself is the anti-spoof proof for CFC: an attacker-supplied
  * function — even with byte-identical source text — was never registered

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -1825,7 +1825,7 @@ interface SetupStateReuse {
 type StoredSetupMarker = "matches" | "other" | "absent";
 
 // `sessionRef` is a KEYLESS piece's session-side stand-in for the durable
-// completion marker (see `Runner.sessionPatternPointers`): the never-durable
+// completion marker (see `Runner.#sessionPatternPointers`): the never-durable
 // contract skips the `patternSetupIdentity` stamp for a keyless piece, and
 // without a marker every re-setup of a re-derived sub-piece (a lift
 // returning a pattern) would read "absent" and restage its own running
@@ -1910,11 +1910,11 @@ export class Runner {
   // a missing entry costs a slower start, never a wrong one. They are bounded
   // for that reason — a result key names one result document, and a pattern
   // that keeps starting and stopping children adds keys it will never revisit.
-  private locallyPreparedResults = new BoundedKeyMap<
+  readonly #locallyPreparedResults = new BoundedKeyMap<
     `${MemorySpace}/${ScopeKey}/${URI}`,
     string
   >(RESULT_SHORTCUT_LIMIT);
-  private locallyStoppedResults = new BoundedKeyMap<
+  readonly #locallyStoppedResults = new BoundedKeyMap<
     `${MemorySpace}/${ScopeKey}/${URI}`,
     string
   >(RESULT_SHORTCUT_LIMIT);
@@ -1980,7 +1980,7 @@ export class Runner {
   // read as the fresh-session ZERO-EVIDENCE state and skip the restage
   // validation, so evictions leave a tombstone (above) and the exemption
   // treats "evicted" as evidence-unknown → restage.
-  private sessionPatternPointers = new BoundedKeyMap<
+  readonly #sessionPatternPointers = new BoundedKeyMap<
     `${MemorySpace}/${ScopeKey}/${URI}`,
     { identity: string; symbol: string }
   >(RESULT_SHORTCUT_LIMIT, {
@@ -1999,7 +1999,7 @@ export class Runner {
   sessionPatternPointerFor(
     resultCell: Cell<unknown>,
   ): { identity: string; symbol: string } | undefined {
-    return this.sessionPatternPointers.get(this.getDocKey(resultCell));
+    return this.#sessionPatternPointers.get(this.#getDocKey(resultCell));
   }
 
   // SESSION-side pattern-swap channel for RUNNING pieces, the third stamp
@@ -2019,7 +2019,7 @@ export class Runner {
   >();
   // Commit-gated starts that have not installed a registration yet, indexed by
   // result so an explicit stop can tombstone them before installation.
-  private pendingDeferredStarts = new Map<
+  readonly #pendingDeferredStarts = new Map<
     `${MemorySpace}/${ScopeKey}/${URI}`,
     Set<DeferredCancelOwnership>
   >();
@@ -2036,7 +2036,7 @@ export class Runner {
   // NAME, which cannot address per-run instances), so eviction drops
   // the whole doc's entry -- over-eviction across instances is safe:
   // re-preparing an unchanged pattern is idempotent.
-  private resultPatternCache = new Map<
+  readonly #resultPatternCache = new Map<
     `${MemorySpace}/${URI}`,
     Map<ScopeKey, string>
   >();
@@ -2051,7 +2051,7 @@ export class Runner {
   #activeStartAttemptsByDoc = new Map<string, Set<StartAttempt>>();
   // Covers the pre-resolution window where a link attempt does not know its
   // eventual target doc and therefore cannot appear in the per-doc index yet.
-  private activeStartAttempts = new Set<StartAttempt>();
+  readonly #activeStartAttempts = new Set<StartAttempt>();
   // The attempt a concurrent start() of the same doc joins, keyed by the doc
   // the call entered through. One entry per doc: the newest attempt that is
   // still current. Entries are removed when their attempt settles; a stale
@@ -2069,8 +2069,177 @@ export class Runner {
   readonly #storageSubscription: IStorageSubscription;
 
   constructor(readonly runtime: Runtime) {
-    this.#storageSubscription = this.createStorageSubscription();
+    this.#storageSubscription = this.#createStorageSubscription();
     this.runtime.storageManager.subscribe(this.#storageSubscription);
+  }
+
+  /**
+   * The result and pointer tables, the deferred-start and start-attempt
+   * sets, the setup, storage-subscription, commit-gated run, ownership,
+   * key, sync, walk, and retry steps, and the implementation invoker, which
+   * a test drives directly.
+   */
+  get accessForTestingOnly(): {
+    readonly locallyPreparedResults: BoundedKeyMap<
+      `${MemorySpace}/${ScopeKey}/${URI}`,
+      string
+    >;
+    readonly locallyStoppedResults: BoundedKeyMap<
+      `${MemorySpace}/${ScopeKey}/${URI}`,
+      string
+    >;
+    readonly sessionPatternPointers: BoundedKeyMap<
+      `${MemorySpace}/${ScopeKey}/${URI}`,
+      { identity: string; symbol: string }
+    >;
+    readonly pendingDeferredStarts: Map<
+      `${MemorySpace}/${ScopeKey}/${URI}`,
+      Set<DeferredCancelOwnership>
+    >;
+    readonly resultPatternCache: Map<
+      `${MemorySpace}/${URI}`,
+      Map<ScopeKey, string>
+    >;
+    readonly activeStartAttempts: Set<StartAttempt>;
+    createStorageSubscription(): IStorageSubscription;
+    setupInternal<T, R>(
+      providedTx: IExtendedStorageTransaction | undefined,
+      patternOrModule: Pattern | Module | undefined,
+      argument: T,
+      resultCell: Cell<R>,
+      validationOptions?: SetupValidationOptions,
+    ): SetupResult<R>;
+    runPatternAfterSuccessfulCommit<T>(
+      tx: IExtendedStorageTransaction,
+      resultCell: Cell<T>,
+      pattern: Pattern,
+      inputs: FabricValue,
+      pullOnceAfterStart?: boolean,
+      markCreateOnlyResult?: boolean,
+      speculativeConsequence?: { eventId: string },
+    ): Cancel;
+    runWithStartOwnership<T, R>(
+      providedTx: IExtendedStorageTransaction | undefined,
+      patternOrModule: Pattern | Module | undefined,
+      argument: T,
+      resultCell: Cell<R>,
+      options?: RunnerRunOptions,
+    ): RunResult<R>;
+    getDocKey(cell: Cell<any>): `${MemorySpace}/${ScopeKey}/${URI}`;
+    syncArgumentLinkTargets(
+      roots: readonly ArgumentLinkRoot[],
+      timingLabel:
+        | "resumeArgumentLinkTargetSync"
+        | "setupArgumentLinkTargetSync",
+      initialValues?: readonly (FabricValue | undefined)[],
+    ): Promise<void>;
+    collectWritableCellArgumentLinks(
+      argumentSchema: JSONSchema | undefined,
+      value: unknown,
+      resultCell: Cell<any>,
+      writeInputPaths?: readonly (readonly string[])[],
+    ): NormalizedFullLink[];
+    collectArgumentSchedulerReadLinks(
+      argumentSchema: JSONSchema | undefined,
+      value: unknown,
+      resultCell: Cell<any>,
+    ): NormalizedFullLink[];
+    resolvePendingSpaceNamesAndRetry(
+      frame: Frame,
+      tx?: IExtendedStorageTransaction,
+    ): Promise<never>;
+    invokeJavaScriptImplementation(
+      module: Module,
+      fn: (...args: any[]) => any,
+      argument: unknown,
+    ): unknown;
+  } {
+    return {
+      locallyPreparedResults: this.#locallyPreparedResults,
+      locallyStoppedResults: this.#locallyStoppedResults,
+      sessionPatternPointers: this.#sessionPatternPointers,
+      pendingDeferredStarts: this.#pendingDeferredStarts,
+      resultPatternCache: this.#resultPatternCache,
+      activeStartAttempts: this.#activeStartAttempts,
+      createStorageSubscription: () => this.#createStorageSubscription(),
+      // Forwards to the TypeScript-private member so that a test which
+      // replaces it by assignment is honored here too.
+      // TODO(danfuzz): Make `setupInternal()` a `#` method, which needs
+      // `test/runner.test.ts` to make a setup report no pattern identity some
+      // other way than by replacing the method: a pattern whose setup records
+      // none, or a seam the runner offers around recording it.
+      setupInternal: (
+        providedTx,
+        patternOrModule,
+        argument,
+        resultCell,
+        validationOptions,
+      ) =>
+        this.setupInternal(
+          providedTx,
+          patternOrModule,
+          argument,
+          resultCell,
+          validationOptions,
+        ),
+      runPatternAfterSuccessfulCommit: (
+        tx,
+        resultCell,
+        pattern,
+        inputs,
+        pullOnceAfterStart,
+        markCreateOnlyResult,
+        speculativeConsequence,
+      ) =>
+        this.#runPatternAfterSuccessfulCommit(
+          tx,
+          resultCell,
+          pattern,
+          inputs,
+          pullOnceAfterStart,
+          markCreateOnlyResult,
+          speculativeConsequence,
+        ),
+      runWithStartOwnership: (
+        providedTx,
+        patternOrModule,
+        argument,
+        resultCell,
+        options,
+      ) =>
+        this.#runWithStartOwnership(
+          providedTx,
+          patternOrModule,
+          argument,
+          resultCell,
+          options,
+        ),
+      getDocKey: (cell) => this.#getDocKey(cell),
+      syncArgumentLinkTargets: (roots, timingLabel, initialValues) =>
+        this.#syncArgumentLinkTargets(roots, timingLabel, initialValues),
+      collectWritableCellArgumentLinks: (
+        argumentSchema,
+        value,
+        resultCell,
+        writeInputPaths,
+      ) =>
+        this.#collectWritableCellArgumentLinks(
+          argumentSchema,
+          value,
+          resultCell,
+          writeInputPaths,
+        ),
+      collectArgumentSchedulerReadLinks: (argumentSchema, value, resultCell) =>
+        this.#collectArgumentSchedulerReadLinks(
+          argumentSchema,
+          value,
+          resultCell,
+        ),
+      resolvePendingSpaceNamesAndRetry: (frame, tx) =>
+        this.#resolvePendingSpaceNamesAndRetry(frame, tx),
+      invokeJavaScriptImplementation: (module, fn, argument) =>
+        this.#invokeJavaScriptImplementation(module, fn, argument),
+    };
   }
 
   /**
@@ -2099,7 +2268,7 @@ export class Runner {
    *
    * @returns A new IStorageSubscription instance
    */
-  private createStorageSubscription(): IStorageSubscription {
+  #createStorageSubscription(): IStorageSubscription {
     return {
       next: (notification) => {
         const space = notification.space;
@@ -2118,15 +2287,15 @@ export class Runner {
             // eviction-on-notification CONTRACT is what the storage
             // subscription exists for and is pinned by the "clears
             // cached patterns when storage notifies of changes" test.
-            this.resultPatternCache.delete(
+            this.#resultPatternCache.delete(
               `${space}/${change.address.id}`,
             );
           }
         } else if (notification.type === "reset") {
           // copy keys, since we'll mutate the collection while iterating
-          const cacheKeys = [...this.resultPatternCache.keys()];
+          const cacheKeys = [...this.#resultPatternCache.keys()];
           cacheKeys.filter((key) => key.startsWith(`${notification.space}/`))
-            .forEach((key) => this.resultPatternCache.delete(key));
+            .forEach((key) => this.#resultPatternCache.delete(key));
         }
         return { done: false };
       },
@@ -2506,7 +2675,7 @@ export class Runner {
     patternRef: { identity: string; symbol: string },
     setupState: SetupStateReuse,
   ): SetupResult<R> | undefined {
-    const key = this.getDocKey(resultCell);
+    const key = this.#getDocKey(resultCell);
     if (!this.cancels.has(key)) return undefined;
 
     // Record the result schema for BOTH reuse branches below, on the one
@@ -2952,15 +3121,15 @@ export class Runner {
       // fails (its stamps roll back; the delete would not). The
       // unchanged-value guard keeps a re-setup staged after this one
       // authoritative — its own bookkeeping then owns the entry.
-      const key = this.getDocKey(resultCell);
-      const priorPointer = this.sessionPatternPointers.get(key);
+      const key = this.#getDocKey(resultCell);
+      const priorPointer = this.#sessionPatternPointers.get(key);
       if (priorPointer !== undefined) {
         tx.addCommitCallback((_tx, result) => {
           if (
             !result.error &&
-            this.sessionPatternPointers.get(key) === priorPointer
+            this.#sessionPatternPointers.get(key) === priorPointer
           ) {
-            this.sessionPatternPointers.delete(key);
+            this.#sessionPatternPointers.delete(key);
           }
         });
       }
@@ -3006,16 +3175,16 @@ export class Runner {
       // stagings interleaved on one doc — the restore resurrects a staged
       // value; recording per-key committed state would close that residue
       // and is not worth its weight here.)
-      const key = this.getDocKey(resultCell);
-      const priorPointer = this.sessionPatternPointers.get(key);
-      this.sessionPatternPointers.set(key, entryRef);
+      const key = this.#getDocKey(resultCell);
+      const priorPointer = this.#sessionPatternPointers.get(key);
+      this.#sessionPatternPointers.set(key, entryRef);
       tx.addCommitCallback((_tx, result) => {
         if (!result.error) return;
-        if (this.sessionPatternPointers.get(key) === entryRef) {
+        if (this.#sessionPatternPointers.get(key) === entryRef) {
           if (priorPointer !== undefined) {
-            this.sessionPatternPointers.set(key, priorPointer);
+            this.#sessionPatternPointers.set(key, priorPointer);
           } else {
-            this.sessionPatternPointers.delete(key);
+            this.#sessionPatternPointers.delete(key);
           }
         } else if (
           this.#evictedSessionPatternPointers.get(key) === entryRef
@@ -3039,6 +3208,10 @@ export class Runner {
 
   /**
    * Internal setup that returns whether scheduling is required.
+   *
+   * TypeScript-private rather than a `#` name, because
+   * `test/runner.test.ts` replaces this member by
+   * assignment, which a `#` method does not allow.
    */
   private setupInternal<T, R = any>(
     providedTx: IExtendedStorageTransaction | undefined,
@@ -3057,7 +3230,7 @@ export class Runner {
     // session-side pointer map (its `keyless:` ref is never stamped
     // durably); a fresh session correctly finds nothing.
     const previousIdentityRef = getPatternIdentityRef(resultCell.withTx(tx)) ??
-      this.sessionPatternPointers.get(this.getDocKey(resultCell));
+      this.#sessionPatternPointers.get(this.#getDocKey(resultCell));
     const resolvedPattern = this.#resolveSetupPattern(
       patternOrModule,
       previousIdentityRef,
@@ -3067,7 +3240,7 @@ export class Runner {
       console.warn(
         "No pattern provided and no pattern found in result metadata. Not running.",
       );
-      this.locallyPreparedResults.delete(this.getDocKey(resultCell));
+      this.#locallyPreparedResults.delete(this.#getDocKey(resultCell));
       return { resultCell, needsStart: false };
     }
 
@@ -3097,12 +3270,12 @@ export class Runner {
     const marker = storedSetupMarker(
       resultCell.withTx(tx),
       entryRef,
-      this.sessionPatternPointers.get(this.getDocKey(resultCell)),
+      this.#sessionPatternPointers.get(this.#getDocKey(resultCell)),
     );
     // What a capacity eviction dropped for this doc, if anything — the
     // evidence the exemption below weighs when the live pointer is gone.
     const evictedPointer = this.#evictedSessionPatternPointers.get(
-      this.getDocKey(resultCell),
+      this.#getDocKey(resultCell),
     );
     const setupState: SetupStateReuse = {
       sameStoredSetup,
@@ -3239,15 +3412,15 @@ export class Runner {
     }
 
     if (!validationOptions.prepareForResume) {
-      const key = this.getDocKey(resultCell);
+      const key = this.#getDocKey(resultCell);
       const preparedPatternKey = patternIdentityKey(entryRef);
-      this.locallyPreparedResults.set(key, preparedPatternKey);
+      this.#locallyPreparedResults.set(key, preparedPatternKey);
       tx.addCommitCallback((_tx, result) => {
         if (
           result.error &&
-          this.locallyPreparedResults.get(key) === preparedPatternKey
+          this.#locallyPreparedResults.get(key) === preparedPatternKey
         ) {
-          this.locallyPreparedResults.delete(key);
+          this.#locallyPreparedResults.delete(key);
         }
       });
       // ALREADY-RUNNING piece, full setup staged, KEYLESS pattern: the
@@ -3298,7 +3471,7 @@ export class Runner {
    * before instantiation.
    */
   start<T = any>(resultCell: Cell<T>): Promise<boolean> {
-    const startKey = this.getDocKey(resultCell);
+    const startKey = this.#getDocKey(resultCell);
     const inFlight = this.#inFlightStartsByDoc.get(startKey);
     if (
       inFlight?.settled !== undefined && this.#isStartAttemptCurrent(inFlight)
@@ -3310,7 +3483,7 @@ export class Runner {
       generationsByDoc: new Map(),
       preResolutionStopKeys: new Set(),
     };
-    this.activeStartAttempts.add(attempt);
+    this.#activeStartAttempts.add(attempt);
     this.#trackStartAttempt(attempt, startKey);
     try {
       const settled = this.#doStart(resultCell, new Set(), attempt)
@@ -3354,7 +3527,7 @@ export class Runner {
     resultCell: Cell<T>,
     installedCancel: Cancel | undefined,
   ): void {
-    const key = this.getDocKey(resultCell);
+    const key = this.#getDocKey(resultCell);
     const registration = this.cancels.get(key);
     if (installedCancel !== undefined && registration !== installedCancel) {
       return;
@@ -3456,6 +3629,10 @@ export class Runner {
    * @param options.tx - Transaction to use for initial setup (optional)
    * @param options.givenPattern - Pattern to use instead of looking up by ID
    * @returns The exact cancel registration installed for this start
+   *
+   * TypeScript-private rather than a `#` name, because
+   * `test/deferred-start-catchup-start.test.ts` replaces this member by
+   * assignment, which a `#` method does not allow.
    */
   private startCore<T = any>(
     resultCell: Cell<T>,
@@ -3476,8 +3653,8 @@ export class Runner {
       givenPattern,
       doNotUpdateOnPatternChange,
     } = options;
-    const key = this.getDocKey(resultCell);
-    this.locallyStoppedResults.delete(key);
+    const key = this.#getDocKey(resultCell);
+    this.#locallyStoppedResults.delete(key);
 
     // Create cancel group early, before wiring pattern/node sinks.
     const [cancelGroup, addCancel] = useCancelGroup();
@@ -4264,7 +4441,7 @@ export class Runner {
     // Durable pointer first; a keyless piece set up by this session has only
     // the session-side entry (the never-durable contract).
     const initialRef = getPatternIdentityRef(resultCellForRead) ??
-      this.sessionPatternPointers.get(key);
+      this.#sessionPatternPointers.get(key);
 
     // Determine initial pattern
     if (givenPattern) {
@@ -4374,7 +4551,7 @@ export class Runner {
       ? this.runtime.getCellFromLink({ ...link, path: [] })
       : resultCell;
 
-    const key = this.getDocKey(rootCell);
+    const key = this.#getDocKey(rootCell);
     attempt.targetKey = key;
     // Step 2: Already started? Return success
     if (this.cancels.has(key)) return Promise.resolve(true);
@@ -4398,7 +4575,7 @@ export class Runner {
     // keyless piece carries no durable pointer (never-durable contract); its
     // pointer, when this session set it up, is the session-side entry.
     const identityRef = getPatternIdentityRef(rootCell) ??
-      this.sessionPatternPointers.get(key);
+      this.#sessionPatternPointers.get(key);
     if (!identityRef) {
       // We may have a slug instead of a resultCell, so try the link.
       const maybeLink = parseLink(rootCell.getRaw(), rootCell);
@@ -4412,7 +4589,7 @@ export class Runner {
         // target doc must invalidate any asynchronous work that follows.
         // Track that doc and capture its current generation before entering
         // the target's start cascade.
-        const nextStartKey = this.getDocKey(nextCell);
+        const nextStartKey = this.#getDocKey(nextCell);
         this.#trackStartAttempt(attempt, nextStartKey);
         return this.#doStart(nextCell, seenCells, attempt);
       }
@@ -4422,15 +4599,15 @@ export class Runner {
       );
     }
     const currentPatternKey = patternIdentityKey(identityRef);
-    const preparedPatternKey = this.locallyPreparedResults.get(key);
-    const stoppedPatternKey = this.locallyStoppedResults.get(key);
+    const preparedPatternKey = this.#locallyPreparedResults.get(key);
+    const stoppedPatternKey = this.#locallyStoppedResults.get(key);
     const wasPreparedLocally = preparedPatternKey === currentPatternKey;
     const wasStoppedLocally = stoppedPatternKey === currentPatternKey;
     if (preparedPatternKey !== undefined && !wasPreparedLocally) {
-      this.locallyPreparedResults.delete(key);
+      this.#locallyPreparedResults.delete(key);
     }
     if (stoppedPatternKey !== undefined && !wasStoppedLocally) {
-      this.locallyStoppedResults.delete(key);
+      this.#locallyStoppedResults.delete(key);
     }
     return this.#startAvailablePattern(
       rootCell,
@@ -4547,7 +4724,7 @@ export class Runner {
       // "no longer current" forever and restart the resolution cascade in an
       // unbounded loop.
       const current = getPatternIdentityRef(rootCell) ??
-        this.sessionPatternPointers.get(this.getDocKey(rootCell));
+        this.#sessionPatternPointers.get(this.#getDocKey(rootCell));
       return current !== undefined &&
         patternIdentityKey(current) === expectedPatternKey;
     };
@@ -4566,7 +4743,7 @@ export class Runner {
       // get here, so the remaining writers of this race are an identity-change
       // restart within this same attempt and an attempt that entered through a
       // different doc whose links resolve to this piece.
-      if (this.cancels.has(this.getDocKey(rootCell))) {
+      if (this.cancels.has(this.#getDocKey(rootCell))) {
         return true;
       }
 
@@ -4594,13 +4771,18 @@ export class Runner {
     })();
   }
 
+  /**
+   * TypeScript-private rather than a `#` name, because
+   * `test/deferred-start-catchup-start.test.ts` replaces this member by
+   * assignment, which a `#` method does not allow.
+   */
   private startWithTx<T = any>(
     tx: IExtendedStorageTransaction,
     resultCell: Cell<T>,
     givenPattern?: Pattern,
     options: RunnerRunOptions = {},
   ): Cancel | undefined {
-    const key = this.getDocKey(resultCell);
+    const key = this.#getDocKey(resultCell);
     if (this.cancels.has(key)) return undefined;
 
     return this.startCore(resultCell, {
@@ -4615,7 +4797,7 @@ export class Runner {
   #createDeferredStartOwnership<T>(
     resultCell: Cell<T>,
   ): DeferredCancelOwnership {
-    const key = this.getDocKey(resultCell);
+    const key = this.#getDocKey(resultCell);
     const base = useDeferredCancelOwnership((installedCancel) => {
       // A result key can be stopped and restarted while deferred startup is
       // re-entering runner code. Only stop if this attempt's exact cancel
@@ -4640,15 +4822,15 @@ export class Runner {
       },
     };
     const unregister = () => {
-      const pending = this.pendingDeferredStarts.get(key);
+      const pending = this.#pendingDeferredStarts.get(key);
       if (pending === undefined) return;
       pending.delete(ownership);
-      if (pending.size === 0) this.pendingDeferredStarts.delete(key);
+      if (pending.size === 0) this.#pendingDeferredStarts.delete(key);
     };
-    let pending = this.pendingDeferredStarts.get(key);
+    let pending = this.#pendingDeferredStarts.get(key);
     if (pending === undefined) {
       pending = new Set();
-      this.pendingDeferredStarts.set(key, pending);
+      this.#pendingDeferredStarts.set(key, pending);
     }
     pending.add(ownership);
     return ownership;
@@ -4657,9 +4839,9 @@ export class Runner {
   #cancelPendingDeferredStarts(
     key: `${MemorySpace}/${ScopeKey}/${URI}`,
   ): void {
-    const pending = this.pendingDeferredStarts.get(key);
+    const pending = this.#pendingDeferredStarts.get(key);
     if (pending === undefined) return;
-    this.pendingDeferredStarts.delete(key);
+    this.#pendingDeferredStarts.delete(key);
     for (const ownership of pending) ownership.cancel();
   }
 
@@ -4873,6 +5055,10 @@ export class Runner {
    * token settles without touching it. The lifecycle epoch still covers
    * the one window no token can: a teardown that ran before the
    * refusal's continuation, whose sweep could not see this scheduling.
+   *
+   * TypeScript-private rather than a `#` name, because
+   * `test/deferred-start-catchup-start.test.ts` replaces this member by
+   * assignment, which a `#` method does not allow.
    */
   private catchUpAndStartOnStaleRead<T>(
     error: { name?: string; message?: string },
@@ -4887,7 +5073,7 @@ export class Runner {
     if (!isStaleReadConflict(error)) return false;
     if (scheduledLifecycleEpoch !== this.#lifecycleEpoch) return false;
     if (ownership.isCancelled()) return false;
-    const key = this.getDocKey(resultCell);
+    const key = this.#getDocKey(resultCell);
     // The cancellation-authority gate: recover only an attempt whose
     // install is still the current registration as the refusal lands. A
     // stop or release during the commit round trip removed it; a
@@ -4927,10 +5113,10 @@ export class Runner {
     // the same path that tombstones a pending first attempt. (The
     // markInstalled above also unregistered the token — a no-op, it was
     // not registered — so this add is the token's one live entry.)
-    let pending = this.pendingDeferredStarts.get(key);
+    let pending = this.#pendingDeferredStarts.get(key);
     if (pending === undefined) {
       pending = new Set();
-      this.pendingDeferredStarts.set(key, pending);
+      this.#pendingDeferredStarts.set(key, pending);
     }
     pending.add(ownership);
     const recovery = this.runtime.awaitCommitRetryReadiness(error)
@@ -5044,8 +5230,8 @@ export class Runner {
       generationsByDoc: new Map(),
       preResolutionStopKeys: new Set(),
     };
-    this.activeStartAttempts.add(attempt);
-    this.#trackStartAttempt(attempt, this.getDocKey(resultCell));
+    this.#activeStartAttempts.add(attempt);
+    this.#trackStartAttempt(attempt, this.#getDocKey(resultCell));
     try {
       return this.#doStart(resultCell, new Set(), attempt)
         .then((started) => {
@@ -5093,7 +5279,7 @@ export class Runner {
     }
   }
 
-  private runPatternAfterSuccessfulCommit<T = any>(
+  #runPatternAfterSuccessfulCommit<T = any>(
     tx: IExtendedStorageTransaction,
     resultCell: Cell<T>,
     pattern: Pattern,
@@ -5146,7 +5332,7 @@ export class Runner {
         startTx,
       );
       try {
-        const installedRegistration = this.runWithStartOwnership(
+        const installedRegistration = this.#runWithStartOwnership(
           startTx,
           pattern,
           inputs,
@@ -5255,7 +5441,7 @@ export class Runner {
     resultCell: Cell<R>,
     options: RunnerRunOptions = {},
   ): Cell<R> {
-    return this.runWithStartOwnership(
+    return this.#runWithStartOwnership(
       providedTx,
       patternOrModule,
       argument,
@@ -5271,7 +5457,7 @@ export class Runner {
    * duplicate event can reuse a winner's deterministic result cell, and must
    * never stop that shared winner when its create-only receipt loses.
    */
-  private runWithStartOwnership<T, R = any>(
+  #runWithStartOwnership<T, R = any>(
     providedTx: IExtendedStorageTransaction | undefined,
     patternOrModule: Pattern | Module | undefined,
     argument: T,
@@ -5523,7 +5709,7 @@ export class Runner {
       // contract), so the currency check reads through the session map when
       // the durable meta is absent.
       const current = getPatternIdentityRef(cell) ??
-        this.sessionPatternPointers.get(this.getDocKey(resultCell));
+        this.#sessionPatternPointers.get(this.#getDocKey(resultCell));
       if (
         current === undefined ||
         patternIdentityKey(current) !== patternIdentityKey(expected)
@@ -5704,7 +5890,7 @@ export class Runner {
   // site 2): two instances of one doc may resolve to different patterns,
   // so the key carries the shared scope_key, resolved against the
   // runtime's own session (the OFF arm's one identity).
-  private getDocKey(cell: Cell<any>): `${MemorySpace}/${ScopeKey}/${URI}` {
+  #getDocKey(cell: Cell<any>): `${MemorySpace}/${ScopeKey}/${URI}` {
     const { space, id, scope } = cell.getAsNormalizedFullLink();
     return `${space}/${
       resolveScopeKey(scope, this.runtime.scopeKeyIdentity)
@@ -5779,7 +5965,7 @@ export class Runner {
     return chain;
   }
 
-  private schedulerObservationIdentity(
+  #schedulerObservationIdentity(
     resultCell: Cell<any>,
     parentPieceRootId?: string,
   ) {
@@ -5804,7 +5990,7 @@ export class Runner {
     parentPieceRootId?: string,
   ): SchedulerRehydrationSubscriptionOptions {
     const { space } = resultCell.getAsNormalizedFullLink();
-    const observationIdentity = this.schedulerObservationIdentity(
+    const observationIdentity = this.#schedulerObservationIdentity(
       resultCell,
       parentPieceRootId,
     );
@@ -5832,7 +6018,7 @@ export class Runner {
     const argumentValue = argumentCell.getRawUntyped();
     // No declared schema here: the setup path scans the stored argument in
     // full, the undeclared-root form of the method below.
-    await this.syncArgumentLinkTargets(
+    await this.#syncArgumentLinkTargets(
       [{ cell: argumentCell }],
       "setupArgumentLinkTargetSync",
       [argumentValue],
@@ -5854,6 +6040,13 @@ export class Runner {
     };
   }
 
+  /**
+   * TypeScript-private rather than a `#` name, because
+   * `test/runner.test.ts`, `test/deferred-start-catchup-start.test.ts`,
+   * and the `piece` package's `pull-materialization` and
+   * `setsrc-commit-receipt` tests replace this member by assignment, which a `#`
+   * method does not allow.
+   */
   private async syncCellsForRunningPattern(
     resultCell: Cell<any>,
     pattern: Module | Pattern,
@@ -6055,7 +6248,7 @@ export class Runner {
     // commit). Each root's declared schema bounds its scan — see the method
     // for the exact rules and the fallback where a declaration runs out.
     await Promise.all([
-      this.syncArgumentLinkTargets(
+      this.#syncArgumentLinkTargets(
         argumentRoots,
         "resumeArgumentLinkTargetSync",
       ),
@@ -6097,7 +6290,7 @@ export class Runner {
    * only, and an unloadable target is skipped rather than failing the
    * resume.
    */
-  private async syncArgumentLinkTargets(
+  async #syncArgumentLinkTargets(
     roots: readonly ArgumentLinkRoot[],
     timingLabel: "resumeArgumentLinkTargetSync" | "setupArgumentLinkTargetSync",
     initialValues?: readonly (FabricValue | undefined)[],
@@ -6715,7 +6908,7 @@ export class Runner {
    * @param resultCell - The result doc or cell of the piece to ask about.
    */
   pieceGraphIsInstalled<T>(resultCell: Cell<T>): boolean {
-    return this.cancels.get(this.getDocKey(resultCell))?.graphIsInstalled() ===
+    return this.cancels.get(this.#getDocKey(resultCell))?.graphIsInstalled() ===
       true;
   }
 
@@ -6738,8 +6931,8 @@ export class Runner {
     // settles. This step is what makes a stop authoritative over a start still
     // resolving; releaseChild() calls stopResult() directly and leaves such a
     // start to resolve into a result of its own.
-    const key = this.getDocKey(resultCell);
-    for (const attempt of this.activeStartAttempts) {
+    const key = this.#getDocKey(resultCell);
+    for (const attempt of this.#activeStartAttempts) {
       if (!attempt.generationsByDoc.has(key)) {
         attempt.preResolutionStopKeys.add(key);
       }
@@ -6749,7 +6942,7 @@ export class Runner {
 
   #stopResult<T>(resultCell: Cell<T>): void {
     this.runtime.sourceReconciler.unwatch(resultCell);
-    const key = this.getDocKey(resultCell);
+    const key = this.#getDocKey(resultCell);
     this.#independentlyStartedResults.delete(key);
     // TODO(hixie): This reaches every pending commit-gated start for the result,
     // which is wider than a release's authority: one that another launch
@@ -6782,14 +6975,14 @@ export class Runner {
         // A keyless piece's pointer is session-side (never stamped durably),
         // so fall through to it.
         const stoppedIdentity = getPatternIdentityRef(resultCell) ??
-          this.sessionPatternPointers.get(key);
+          this.#sessionPatternPointers.get(key);
         if (stoppedIdentity !== undefined) {
-          this.locallyStoppedResults.set(
+          this.#locallyStoppedResults.set(
             key,
             patternIdentityKey(stoppedIdentity),
           );
         } else {
-          this.locallyStoppedResults.delete(key);
+          this.#locallyStoppedResults.delete(key);
         }
       }
     }
@@ -6810,7 +7003,7 @@ export class Runner {
   }
 
   #finishStartAttempt(attempt: StartAttempt): void {
-    this.activeStartAttempts.delete(attempt);
+    this.#activeStartAttempts.delete(attempt);
     for (const key of attempt.generationsByDoc.keys()) {
       if (this.#inFlightStartsByDoc.get(key) === attempt) {
         this.#inFlightStartsByDoc.delete(key);
@@ -6929,10 +7122,10 @@ export class Runner {
     // later start can join one; dropping the index releases the attempts too.
     this.#inFlightStartsByDoc.clear();
     this.#independentlyStartedResults.clear();
-    for (const key of [...this.pendingDeferredStarts.keys()]) {
+    for (const key of [...this.#pendingDeferredStarts.keys()]) {
       this.#cancelPendingDeferredStarts(key);
     }
-    this.pendingDeferredStarts.clear();
+    this.#pendingDeferredStarts.clear();
     // Cancel all tracked operations
     for (const cancel of this.#allCancels) {
       try {
@@ -6945,17 +7138,17 @@ export class Runner {
     this.cancels.clear();
     // Clear the result pattern cache as well, since the actions have been
     // canceled
-    this.resultPatternCache.clear();
-    this.locallyPreparedResults.clear();
-    this.locallyStoppedResults.clear();
+    this.#resultPatternCache.clear();
+    this.#locallyPreparedResults.clear();
+    this.#locallyStoppedResults.clear();
     this.#locallyCommittedHandlerResultStarts.clear();
     this.#startGenerationByDoc.clear();
     this.#activeStartAttemptsByDoc.clear();
-    for (const attempt of this.activeStartAttempts) {
+    for (const attempt of this.#activeStartAttempts) {
       attempt.generationsByDoc.clear();
       attempt.preResolutionStopKeys.clear();
     }
-    this.activeStartAttempts.clear();
+    this.#activeStartAttempts.clear();
   }
 
   #instantiateNode(
@@ -7240,7 +7433,7 @@ export class Runner {
     });
   }
 
-  private collectWritableCellArgumentLinks(
+  #collectWritableCellArgumentLinks(
     argumentSchema: JSONSchema | undefined,
     value: unknown,
     resultCell: Cell<any>,
@@ -7388,7 +7581,7 @@ export class Runner {
       resultSchema.asCell.includes("opaque");
   }
 
-  private collectArgumentSchedulerReadLinks(
+  #collectArgumentSchedulerReadLinks(
     argumentSchema: JSONSchema | undefined,
     value: unknown,
     resultCell: Cell<any>,
@@ -7955,7 +8148,7 @@ export class Runner {
       return result;
     }
 
-    const receiptKey = this.getDocKey(receiptCell);
+    const receiptKey = this.#getDocKey(receiptCell);
     if (
       receiptsEnabled &&
       this.#locallyCommittedHandlerResultStarts.has(receiptKey) &&
@@ -8013,7 +8206,7 @@ export class Runner {
     if (deferForNavigate && result === undefined) {
       // navigateTo results are commit-gated (startAfterSuccessfulCommit);
       // the receipt precondition rides the deferred start's own create.
-      const cancelDeferredStart = this.runPatternAfterSuccessfulCommit(
+      const cancelDeferredStart = this.#runPatternAfterSuccessfulCommit(
         tx,
         receiptCell,
         resultPattern,
@@ -8046,7 +8239,7 @@ export class Runner {
         return setup.resultCell;
       })()
       : (() => {
-        const run = this.runWithStartOwnership(
+        const run = this.#runWithStartOwnership(
           tx,
           resultPattern,
           undefined,
@@ -8096,7 +8289,7 @@ export class Runner {
       const cancelOwnedStart = cancelDeferredStart ?? (() => {
         if (cancelled) return;
         cancelled = true;
-        const key = this.getDocKey(resultCell);
+        const key = this.#getDocKey(resultCell);
         if (this.cancels.get(key) !== installedCancel) return;
         this.stop(resultCell);
       });
@@ -8145,7 +8338,7 @@ export class Runner {
    * never grants. On a client (`!servingPosture`) no owner is supplied
    * and the genesis names the active user — byte-identical to before.
    */
-  private async resolvePendingSpaceNamesAndRetry(
+  async #resolvePendingSpaceNamesAndRetry(
     frame: Frame,
     tx?: IExtendedStorageTransaction,
   ): Promise<never> {
@@ -8354,15 +8547,15 @@ export class Runner {
     const resultDocLink = resultCell.getAsNormalizedFullLink();
     const cacheDocKey =
       `${resultDocLink.space}/${resultDocLink.id}` as `${MemorySpace}/${URI}`;
-    const previousResultPatternKey = this.resultPatternCache.get(cacheDocKey)
+    const previousResultPatternKey = this.#resultPatternCache.get(cacheDocKey)
       ?.get(effectiveOutputScopeKey);
     const patternUnchanged = previousResultPatternKey === resultPatternKey;
 
     if (!patternUnchanged) {
-      let instanceMemos = this.resultPatternCache.get(cacheDocKey);
+      let instanceMemos = this.#resultPatternCache.get(cacheDocKey);
       if (instanceMemos === undefined) {
         instanceMemos = new Map();
-        this.resultPatternCache.set(cacheDocKey, instanceMemos);
+        this.#resultPatternCache.set(cacheDocKey, instanceMemos);
       }
       instanceMemos.set(effectiveOutputScopeKey, resultPatternKey);
 
@@ -8390,10 +8583,10 @@ export class Runner {
         // A rollback carries a release's authority, not a stop's: it lets go
         // of the registration this materialization installed and is not
         // authoritative over a lifetime or a start it does not own.
-        const memos = this.resultPatternCache.get(cacheDocKey);
+        const memos = this.#resultPatternCache.get(cacheDocKey);
         if (memos?.get(effectiveOutputScopeKey) === resultPatternKey) {
           memos.delete(effectiveOutputScopeKey);
-          if (memos.size === 0) this.resultPatternCache.delete(cacheDocKey);
+          if (memos.size === 0) this.#resultPatternCache.delete(cacheDocKey);
         }
         this.releaseChild(resultCell, undefined);
       });
@@ -8547,7 +8740,7 @@ export class Runner {
         if (isValidArgument) {
           logger.timeStart("stream", "invokeJavaScriptImplementation");
           try {
-            result = this.invokeJavaScriptImplementation(
+            result = this.#invokeJavaScriptImplementation(
               module,
               fn,
               argument,
@@ -8568,7 +8761,7 @@ export class Runner {
           logger.timeStart("stream", "postRun");
           try {
             if (frame.pendingSpaceNames && frame.pendingSpaceNames.size > 0) {
-              return this.resolvePendingSpaceNamesAndRetry(frame, tx);
+              return this.#resolvePendingSpaceNamesAndRetry(frame, tx);
             }
             const normalized = normalizeSandboxResult(result, name);
             return this.#handleJavaScriptHandlerResult(
@@ -8603,7 +8796,7 @@ export class Runner {
           frame.pendingSpaceNames && frame.pendingSpaceNames.size > 0
         ) {
           popFrameAfterReturn = false;
-          return this.resolvePendingSpaceNamesAndRetry(frame, tx)
+          return this.#resolvePendingSpaceNamesAndRetry(frame, tx)
             .finally(() => popFrame(frame));
         }
         (error as Error & { frame?: Frame }).frame = frame;
@@ -8702,7 +8895,7 @@ export class Runner {
       ...(presyncInputs !== undefined && { presyncInputs }),
     });
 
-    const schedulerReads = this.collectArgumentSchedulerReadLinks(
+    const schedulerReads = this.#collectArgumentSchedulerReadLinks(
       module.argumentSchema,
       inputs,
       resultCell,
@@ -8900,7 +9093,7 @@ export class Runner {
         if (isValidArgument) {
           logger.timeStart("action", "invokeJavaScriptImplementation");
           try {
-            result = this.invokeJavaScriptImplementation(
+            result = this.#invokeJavaScriptImplementation(
               module,
               fn,
               argument,
@@ -8941,7 +9134,7 @@ export class Runner {
               result = undefined;
             }
             if (frame.pendingSpaceNames && frame.pendingSpaceNames.size > 0) {
-              return this.resolvePendingSpaceNamesAndRetry(frame, tx);
+              return this.#resolvePendingSpaceNamesAndRetry(frame, tx);
             }
             const normalized = normalizeSandboxResult(result, name);
             return this.#writeJavaScriptActionResult(
@@ -8990,7 +9183,7 @@ export class Runner {
           frame.pendingSpaceNames && frame.pendingSpaceNames.size > 0
         ) {
           popFrameAfterReturn = false;
-          return this.resolvePendingSpaceNamesAndRetry(frame, tx)
+          return this.#resolvePendingSpaceNamesAndRetry(frame, tx)
             .finally(() => popFrame(frame));
         }
         // A refusal that escaped the body takes the same disposition as one it
@@ -9039,14 +9232,14 @@ export class Runner {
     // that do not carry that metadata.
     const materializerWriteEnvelopes = module.materializerWriteEnvelopes ??
       (module.materializerWriteInputPaths !== undefined
-        ? this.collectWritableCellArgumentLinks(
+        ? this.#collectWritableCellArgumentLinks(
           module.argumentSchema,
           inputs,
           resultCell,
           module.materializerWriteInputPaths,
         )
         : this.#moduleHasOpaqueResult(module)
-        ? this.collectWritableCellArgumentLinks(
+        ? this.#collectWritableCellArgumentLinks(
           module.argumentSchema,
           inputs,
           resultCell,
@@ -9237,7 +9430,7 @@ export class Runner {
     );
   }
 
-  private invokeJavaScriptImplementation(
+  #invokeJavaScriptImplementation(
     module: Module,
     fn: (...args: any[]) => any,
     argument: unknown,
@@ -9965,7 +10158,7 @@ export class Runner {
           : undefined,
       );
     }
-    const childRun = this.runWithStartOwnership(
+    const childRun = this.#runWithStartOwnership(
       tx,
       patternImpl,
       inputs,

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -4772,6 +4772,9 @@ export class Runner {
   }
 
   /**
+   * Starts the pattern behind `resultCell` inside `tx`, returning the
+   * registration's cancel, or nothing when there was nothing to start.
+   *
    * TypeScript-private rather than a `#` name, because
    * `test/deferred-start-catchup-start.test.ts` replaces this member by
    * assignment, which a `#` method does not allow.

--- a/packages/runner/test/argument-scheduler-read-links.test.ts
+++ b/packages/runner/test/argument-scheduler-read-links.test.ts
@@ -13,6 +13,8 @@ import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { Runtime } from "../src/runtime.ts";
 import type { NormalizedFullLink } from "../src/link-utils.ts";
+import type { JSONSchema } from "../src/builder/types.ts";
+import type { Cell } from "../src/cell.ts";
 
 const signer = await Identity.fromPassphrase("argument scheduler read links");
 const space = signer.did();
@@ -34,14 +36,15 @@ describe("argument scheduler read links", () => {
     await storageManager?.close();
   });
 
+  // The fixtures' schemas are plain literals; they declare themselves here,
+  // where the walk is handed them.
   const collect = (
     argumentSchema: unknown,
     value: unknown,
-    resultCell: unknown,
+    resultCell: Cell<any>,
   ): NormalizedFullLink[] =>
-    // deno-lint-ignore no-explicit-any
-    (runtime.runner as any).collectArgumentSchedulerReadLinks(
-      argumentSchema,
+    runtime.runner.accessForTestingOnly.collectArgumentSchedulerReadLinks(
+      argumentSchema as JSONSchema | undefined,
       value,
       resultCell,
     );

--- a/packages/runner/test/child-run-ownership.test.ts
+++ b/packages/runner/test/child-run-ownership.test.ts
@@ -359,9 +359,7 @@ describe("child run ownership", () => {
     );
     runtime.run(tx, Piece, { value: 3 }, result.withTx(tx));
 
-    const pending = (runtime.runner as unknown as {
-      pendingDeferredStarts: Map<string, Set<unknown>>;
-    }).pendingDeferredStarts;
+    const pending = runtime.runner.accessForTestingOnly.pendingDeferredStarts;
     expect(pending.size).toBe(1);
 
     expect((await tx.commit()).error).toBeUndefined();
@@ -391,9 +389,7 @@ describe("child run ownership", () => {
     );
     runtime.run(tx, Piece, { value: 3 }, result.withTx(tx));
 
-    const pending = (runtime.runner as unknown as {
-      pendingDeferredStarts: Map<string, Set<unknown>>;
-    }).pendingDeferredStarts;
+    const pending = runtime.runner.accessForTestingOnly.pendingDeferredStarts;
     expect(pending.size).toBe(1);
 
     expect(tx.abort("setup rejected").error).toBeUndefined();
@@ -414,17 +410,7 @@ describe("child run ownership", () => {
     // entry point, reached here directly: driving it through a handler would
     // mean failing whichever storage transaction the dispatch happened to
     // land on.
-    const harness = runtime.runner as unknown as {
-      runPatternAfterSuccessfulCommit(
-        tx: unknown,
-        resultCell: unknown,
-        pattern: unknown,
-        inputs: unknown,
-        pullOnceAfterStart?: boolean,
-        markCreateOnlyResult?: boolean,
-      ): () => void;
-      pendingDeferredStarts: Map<string, Set<unknown>>;
-    };
+    const harness = runtime.runner.accessForTestingOnly;
     const tx = runtime.edit();
     const receipt = runtime.getCell<Record<string, unknown>>(
       space,

--- a/packages/runner/test/deferred-start-catchup-start.test.ts
+++ b/packages/runner/test/deferred-start-catchup-start.test.ts
@@ -484,15 +484,7 @@ describe("a deferred start refused for a stale confirmed read, flag-ON", () => {
     const Piece = pattern<{ value: number }>(({ value }) => ({
       doubled: lift((input: number) => input * 2)(value),
     }));
-    const harness = runtime.runner as unknown as {
-      runWithStartOwnership(
-        tx: unknown,
-        pattern: unknown,
-        argument: unknown,
-        resultCell: unknown,
-        options?: unknown,
-      ): { cancelDeferredStart?: () => void };
-    };
+    const harness = runtime.runner.accessForTestingOnly;
     const tx = gatedTxOn(runtime);
     const result = runtime.getCell<{ doubled?: number }>(
       space,
@@ -556,17 +548,11 @@ describe("a deferred start refused for a stale confirmed read, flag-ON", () => {
     const Piece = pattern<{ value: number }>(({ value }) => ({
       doubled: lift((input: number) => input * 2)(value),
     }));
-    const harness = runtime.runner as unknown as {
-      runWithStartOwnership(
-        tx: unknown,
-        pattern: unknown,
-        argument: unknown,
-        resultCell: unknown,
-        options?: unknown,
-      ): { cancelDeferredStart?: () => void };
+    const harness = runtime.runner.accessForTestingOnly;
+    // Replaced by assignment below, which only a TypeScript-private member
+    // allows, so it is reached the old way.
+    const stubbed = runtime.runner as unknown as {
       syncCellsForRunningPattern(...args: unknown[]): Promise<unknown>;
-      locallyStoppedResults: { delete(key: string): void };
-      locallyPreparedResults: { delete(key: string): void };
     };
     const tx = gatedTxOn(runtime);
     const result = runtime.getCell<{ doubled?: number }>(
@@ -592,9 +578,9 @@ describe("a deferred start refused for a stale confirmed read, flag-ON", () => {
     // The competitor: a second, independent public start of the same
     // result (the navigate landing flow), fired inside the recovery
     // walk's dependency-sync await.
-    const originalSync = harness.syncCellsForRunningPattern;
+    const originalSync = stubbed.syncCellsForRunningPattern;
     let competitorRan = false;
-    harness.syncCellsForRunningPattern = async function (...args: unknown[]) {
+    stubbed.syncCellsForRunningPattern = async function (...args: unknown[]) {
       if (
         !competitorRan &&
         key(args[0] as Cell<unknown>) === key(result)
@@ -636,7 +622,7 @@ describe("a deferred start refused for a stale confirmed read, flag-ON", () => {
       cancelDeferredStart!();
       expect(runtime.runner.cancels.has(key(result))).toBe(true);
     } finally {
-      harness.syncCellsForRunningPattern = originalSync;
+      stubbed.syncCellsForRunningPattern = originalSync;
       injector.restore();
     }
   });
@@ -657,14 +643,10 @@ describe("a deferred start refused for a stale confirmed read, flag-ON", () => {
     const Piece = pattern<{ value: number }>(({ value }) => ({
       doubled: lift((input: number) => input * 2)(value),
     }));
-    const harness = runtime.runner as unknown as {
-      runWithStartOwnership(
-        tx: unknown,
-        pattern: unknown,
-        argument: unknown,
-        resultCell: unknown,
-        options?: unknown,
-      ): { cancelDeferredStart?: () => void };
+    const harness = runtime.runner.accessForTestingOnly;
+    // Replaced by assignment below, which only a TypeScript-private member
+    // allows, so it is reached the old way.
+    const stubbed = runtime.runner as unknown as {
       startCore: (...args: unknown[]) => () => void;
     };
     const tx = gatedTxOn(runtime);
@@ -682,8 +664,8 @@ describe("a deferred start refused for a stale confirmed read, flag-ON", () => {
     // assembly — the widest point of the walk window.
     let parentCancel: (() => void) | undefined;
     let assemblies = 0;
-    const originalStartCore = harness.startCore;
-    harness.startCore = (...args: unknown[]) => {
+    const originalStartCore = stubbed.startCore;
+    stubbed.startCore = (...args: unknown[]) => {
       if (key(args[0] as Cell<unknown>) === key(result)) {
         assemblies++;
         if (assemblies === 2) parentCancel?.();
@@ -716,7 +698,7 @@ describe("a deferred start refused for a stale confirmed read, flag-ON", () => {
       expect(assemblies).toBe(2);
       expect(runtime.runner.cancels.has(key(result))).toBe(false);
     } finally {
-      harness.startCore = originalStartCore;
+      stubbed.startCore = originalStartCore;
       injector.restore();
     }
   });
@@ -1105,15 +1087,10 @@ describe("a deferred start refused for a stale confirmed read, flag-ON", () => {
     const Piece = pattern<{ value: number }>(({ value }) => ({
       doubled: lift((input: number) => input * 2)(value),
     }));
-    const harness = runtime.runner as unknown as {
-      runPatternAfterSuccessfulCommit(
-        tx: unknown,
-        resultCell: unknown,
-        pattern: unknown,
-        inputs: unknown,
-        pullOnceAfterStart?: boolean,
-        markCreateOnlyResult?: boolean,
-      ): () => void;
+    const harness = runtime.runner.accessForTestingOnly;
+    // Replaced by assignment below, which only a TypeScript-private member
+    // allows, so it is reached the old way.
+    const stubbed = runtime.runner as unknown as {
       catchUpAndStartOnStaleRead(...args: unknown[]): boolean;
     };
     const tx = runtime.edit();
@@ -1174,10 +1151,10 @@ describe("a deferred start refused for a stale confirmed read, flag-ON", () => {
     // demands the error arm actually ROUTED here and the recovery was
     // SCHEDULED — deleting the call site from
     // runPatternAfterSuccessfulCommit reds this, where it used to pass.
-    const originalEntry = harness.catchUpAndStartOnStaleRead;
+    const originalEntry = stubbed.catchUpAndStartOnStaleRead;
     let routed = 0;
     let scheduled = 0;
-    harness.catchUpAndStartOnStaleRead = function (...args: unknown[]) {
+    stubbed.catchUpAndStartOnStaleRead = function (...args: unknown[]) {
       const took = Reflect.apply(
         originalEntry,
         runtime.runner,
@@ -1217,7 +1194,7 @@ describe("a deferred start refused for a stale confirmed read, flag-ON", () => {
       expect(refusals).toBe(1);
       expect(runtime.runner.cancels.has(key(receipt))).toBe(false);
     } finally {
-      harness.catchUpAndStartOnStaleRead = originalEntry;
+      stubbed.catchUpAndStartOnStaleRead = originalEntry;
       replica.commitNative = originalCommitNative;
       runnerForMark.startWithTx = originalStartWithTx;
     }

--- a/packages/runner/test/executor-cross-space.test.ts
+++ b/packages/runner/test/executor-cross-space.test.ts
@@ -51,7 +51,7 @@ import {
   streamEntriesDocId,
   type StreamEventsDocValue,
 } from "@commonfabric/memory/v2";
-import { UI } from "../src/builder/types.ts";
+import { type Frame, UI } from "../src/builder/types.ts";
 import { resolveEntryIdentity } from "../src/index.ts";
 import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
 import { waitUntil } from "./support/wait-until.ts";
@@ -394,12 +394,8 @@ describe("Phase 5 cross-space serving", () => {
       // a provisioning crossing without acting would be refused
       // carriage-less anyway and the orphaned genesis would name a
       // principal the grant probe never sees.
-      const resolvePending = (serving.runner as unknown as {
-        resolvePendingSpaceNamesAndRetry(
-          frame: unknown,
-          tx?: IExtendedStorageTransaction,
-        ): Promise<never>;
-      }).resolvePendingSpaceNamesAndRetry.bind(serving.runner);
+      const resolvePending =
+        serving.runner.accessForTestingOnly.resolvePendingSpaceNamesAndRetry;
       const scaffolding = serving.edit();
       stampWaveRunContext(scaffolding, {
         actionId: "f1/scaffolding-only",
@@ -411,7 +407,7 @@ describe("Phase 5 cross-space serving", () => {
       });
       await expect(
         resolvePending(
-          { pendingSpaceNames: new Set(["ow31-f1-scaffolding"]) },
+          { pendingSpaceNames: new Set(["ow31-f1-scaffolding"]) } as Frame,
           scaffolding,
         ),
       ).rejects.toThrow("acting identity as genesis owner");
@@ -430,7 +426,7 @@ describe("Phase 5 cross-space serving", () => {
       });
       await expect(
         resolvePending(
-          { pendingSpaceNames: new Set(["ow31-f1-acting"]) },
+          { pendingSpaceNames: new Set(["ow31-f1-acting"]) } as Frame,
           actingTx,
         ),
       ).rejects.toThrow("Resolving in-space target spaces");

--- a/packages/runner/test/keyless-never-durable.test.ts
+++ b/packages/runner/test/keyless-never-durable.test.ts
@@ -56,6 +56,11 @@ import {
 const signer = await Identity.fromPassphrase("keyless-never-durable");
 const space = signer.did();
 
+// Synthetic churn keys, declared as the keys the pointer table holds.
+type PointerKey = Parameters<
+  Runtime["runner"]["accessForTestingOnly"]["sessionPatternPointers"]["set"]
+>[0];
+
 // A minimal map-over-pattern program. Bare-evaluated (non-registering), its
 // op pattern carries no content-addressed entry ref, so node instantiation
 // mints the op's `keyless:` session identity (the CT-1812 keyless-op path).
@@ -788,18 +793,14 @@ describe("keyless identities never land durably (L3(a), RULED 2026-08-27)", () =
 
     // Capacity-evict the piece's pointer with synthetic churn — the map's
     // REAL eviction path, just fed faster than a server would.
-    const pointers = (runtime.runner as unknown as {
-      sessionPatternPointers: {
-        set(key: string, value: { identity: string; symbol: string }): void;
-      };
-    }).sessionPatternPointers;
+    const pointers = runtime.runner.accessForTestingOnly.sessionPatternPointers;
     for (
       let i = 0;
       runtime.runner.sessionPatternPointerFor(cell) !== undefined;
       i++
     ) {
       if (i > 100_000) throw new Error("the pointer never evicted");
-      pointers.set(`synthetic/${i}`, {
+      pointers.set(`synthetic/${i}` as PointerKey, {
         identity: `keyless:churn-${i}`,
         symbol: "default",
       });
@@ -878,18 +879,14 @@ describe("keyless identities never land durably (L3(a), RULED 2026-08-27)", () =
     runtime.runner.stop(cell);
 
     // Capacity-evict the pointer (same churn as above).
-    const pointers = (runtime.runner as unknown as {
-      sessionPatternPointers: {
-        set(key: string, value: { identity: string; symbol: string }): void;
-      };
-    }).sessionPatternPointers;
+    const pointers = runtime.runner.accessForTestingOnly.sessionPatternPointers;
     for (
       let i = 0;
       runtime.runner.sessionPatternPointerFor(cell) !== undefined;
       i++
     ) {
       if (i > 100_000) throw new Error("the pointer never evicted");
-      pointers.set(`same-synthetic/${i}`, {
+      pointers.set(`same-synthetic/${i}` as PointerKey, {
         identity: `keyless:churn-${i}`,
         symbol: "default",
       });
@@ -982,18 +979,14 @@ describe("keyless identities never land durably (L3(a), RULED 2026-08-27)", () =
     void rerun;
     // …then a capacity wave evicts the STAGED pointer inside its own
     // staging window…
-    const pointers = (runtime.runner as unknown as {
-      sessionPatternPointers: {
-        set(key: string, value: { identity: string; symbol: string }): void;
-      };
-    }).sessionPatternPointers;
+    const pointers = runtime.runner.accessForTestingOnly.sessionPatternPointers;
     for (
       let i = 0;
       runtime.runner.sessionPatternPointerFor(cell) !== undefined;
       i++
     ) {
       if (i > 100_000) throw new Error("the pointer never evicted");
-      pointers.set(`uncommitted-synthetic/${i}`, {
+      pointers.set(`uncommitted-synthetic/${i}` as PointerKey, {
         identity: `keyless:churn-${i}`,
         symbol: "default",
       });
@@ -1110,18 +1103,15 @@ describe("keyless identities never land durably (L3(a), RULED 2026-08-27)", () =
       // deno-lint-ignore no-explicit-any
       runtime.run(tx2, handBuiltPattern() as any, undefined, cell2);
       expect(runtime.runner.sessionPatternPointerFor(cell2)).toBeDefined();
-      const pointers = (runtime.runner as unknown as {
-        sessionPatternPointers: {
-          set(key: string, value: { identity: string; symbol: string }): void;
-        };
-      }).sessionPatternPointers;
+      const pointers =
+        runtime.runner.accessForTestingOnly.sessionPatternPointers;
       for (
         let i = 0;
         runtime.runner.sessionPatternPointerFor(cell2) !== undefined;
         i++
       ) {
         if (i > 100_000) throw new Error("the pointer never evicted");
-        pointers.set(`first-staging-synthetic/${i}`, {
+        pointers.set(`first-staging-synthetic/${i}` as PointerKey, {
           identity: `keyless:churn-${i}`,
           symbol: "default",
         });

--- a/packages/runner/test/materializer-envelope-collection.test.ts
+++ b/packages/runner/test/materializer-envelope-collection.test.ts
@@ -17,6 +17,8 @@ import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { Runtime } from "../src/runtime.ts";
 import type { NormalizedFullLink } from "../src/link-utils.ts";
 import { trustExecutable } from "./support/trusted-builder.ts";
+import type { JSONSchema } from "../src/builder/types.ts";
+import type { Cell } from "../src/cell.ts";
 
 const signer = await Identity.fromPassphrase(
   "materializer envelope collection",
@@ -40,15 +42,16 @@ describe("materializer envelope collection", () => {
     await storageManager?.close();
   });
 
+  // The fixtures' schemas are plain literals; they declare themselves here,
+  // where the walk is handed them.
   const collect = (
     argumentSchema: unknown,
     inputs: unknown,
-    resultCell: unknown,
+    resultCell: Cell<any>,
     writeInputPaths?: readonly (readonly string[])[],
   ): NormalizedFullLink[] =>
-    // deno-lint-ignore no-explicit-any
-    (runtime.runner as any).collectWritableCellArgumentLinks(
-      argumentSchema,
+    runtime.runner.accessForTestingOnly.collectWritableCellArgumentLinks(
+      argumentSchema as JSONSchema | undefined,
       inputs,
       resultCell,
       writeInputPaths,

--- a/packages/runner/test/patterns-regressions.test.ts
+++ b/packages/runner/test/patterns-regressions.test.ts
@@ -248,7 +248,7 @@ describe("Pattern Runner - Regressions", () => {
       tx,
     );
 
-    const runner = runtime.runner as any;
+    const runner = runtime.runner.accessForTestingOnly;
     runner.setupInternal(tx, echoPattern, { title: "draft" }, resultCell);
     const key = runner.getDocKey(resultCell);
     expect(runner.locallyPreparedResults.has(key)).toBe(true);

--- a/packages/runner/test/release-vs-stop-link-resolution.test.ts
+++ b/packages/runner/test/release-vs-stop-link-resolution.test.ts
@@ -83,9 +83,7 @@ Deno.test("releasing a target before link resolution preserves the held start", 
       });
     }) as typeof link.sync;
 
-    const lifecycleState = runtime.runner as unknown as {
-      activeStartAttempts: Set<{ preResolutionStopKeys: Set<string> }>;
-    };
+    const lifecycleState = runtime.runner.accessForTestingOnly;
     const start = runtime.start(link);
     await syncStarted.promise;
     // The release stops the child registration it owns, and leaves the start

--- a/packages/runner/test/runner-argument-walks.test.ts
+++ b/packages/runner/test/runner-argument-walks.test.ts
@@ -26,27 +26,14 @@ import { FabricError } from "@commonfabric/data-model/fabric-instances";
 
 import { Runtime } from "../src/runtime.ts";
 import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+import type { JSONSchema } from "../src/builder/types.ts";
 
 const signer = await Identity.fromPassphrase("test runner argument walks");
 const space = signer.did();
 
-/**
- * The two walks are `private` rather than `#private` on `Runner`, so a test can
- * address them through `runtime.runner`. Reaching them through a running action
- * would drag in module setup that has nothing to do with what is pinned here.
- */
-type WalkAccess = {
-  collectArgumentSchedulerReadLinks(
-    argumentSchema: unknown,
-    value: unknown,
-    resultCell: unknown,
-  ): unknown[];
-  collectWritableCellArgumentLinks(
-    argumentSchema: unknown,
-    value: unknown,
-    resultCell: unknown,
-  ): unknown[];
-};
+// The two walks are reached through `accessForTestingOnly`: driving them
+// through a running action would drag in module setup that has nothing to do
+// with what is pinned here.
 
 describe("runner-argument-walks", () => {
   let runtime: Runtime;
@@ -73,7 +60,7 @@ describe("runner-argument-walks", () => {
    * reaching a `FabricBytes` there tries to index INTO it -- the shape that
    * would expose a walk mistaking a special object for a container.
    */
-  const argumentSchema = {
+  const argumentSchema: JSONSchema = {
     type: "object",
     properties: {
       payload: {
@@ -124,7 +111,7 @@ describe("runner-argument-walks", () => {
       // schema position when it sits in a plain record, so what changes the
       // outcome is the wrapper.
       const { resultCell, value } = fixture();
-      const walks = runtime.runner as unknown as WalkAccess;
+      const walks = runtime.runner.accessForTestingOnly;
       const nested = { payload: { inner: value.ref } };
 
       expect(
@@ -153,7 +140,7 @@ describe("runner-argument-walks", () => {
       // nothing, and carry on to `ref` -- rather than throwing, or stopping.
       const { resultCell, value } = fixture();
 
-      const links = (runtime.runner as unknown as WalkAccess)
+      const links = runtime.runner.accessForTestingOnly
         .collectArgumentSchedulerReadLinks(argumentSchema, value, resultCell);
 
       expect(links.length).toBe(1);
@@ -167,8 +154,8 @@ describe("runner-argument-walks", () => {
       // would be missed while the walk reported success. This pins that the
       // guard runs first.
       const { resultCell, value } = fixture();
-      const walks = runtime.runner as unknown as WalkAccess;
-      const asCellSchema = {
+      const walks = runtime.runner.accessForTestingOnly;
+      const asCellSchema: JSONSchema = {
         type: "object",
         properties: { payload: { type: "object", asCell: ["cell"] } },
       };
@@ -195,7 +182,7 @@ describe("runner-argument-walks", () => {
 
     it("throws for a `FabricError` rather than missing a link inside it", () => {
       const { resultCell, value } = fixture();
-      const walks = runtime.runner as unknown as WalkAccess;
+      const walks = runtime.runner.accessForTestingOnly;
 
       expect(
         walks.collectWritableCellArgumentLinks(
@@ -220,7 +207,7 @@ describe("runner-argument-walks", () => {
     it("collects a sibling write-redirect link past a `FabricBytes`", () => {
       const { resultCell, value } = fixture();
 
-      const links = (runtime.runner as unknown as WalkAccess)
+      const links = runtime.runner.accessForTestingOnly
         .collectWritableCellArgumentLinks(argumentSchema, value, resultCell);
 
       expect(links.length).toBe(1);

--- a/packages/runner/test/runner.test.ts
+++ b/packages/runner/test/runner.test.ts
@@ -42,7 +42,6 @@ import {
 import {
   type ICommitNotification,
   type IExtendedStorageTransaction,
-  type IStorageSubscription,
   type MediaType,
   type URI,
 } from "../src/storage/interface.ts";
@@ -1347,10 +1346,7 @@ describe("storage subscription", () => {
   });
 
   it("clears cached patterns when storage notifies of changes — every scope INSTANCE of the changed doc (r3739139481)", () => {
-    const internals = runtime.runner as unknown as {
-      resultPatternCache: Map<string, Map<string, string>>;
-      createStorageSubscription(): IStorageSubscription;
-    };
+    const internals = runtime.runner.accessForTestingOnly;
 
     const uri = "pattern-cache-test" as URI;
     // The memo is keyed doc-then-instance: notifications name the DOC
@@ -3970,9 +3966,13 @@ describe("runner utils", () => {
       // Simulate a persisted piece being resumed. In that path start() syncs
       // dependencies before registering handlers, which is where this race
       // used to allow duplicate starts for the same result cell.
-      (runtime.runner as any).locallyPreparedResults.clear();
+      runtime.runner.accessForTestingOnly.locallyPreparedResults.clear();
 
-      const runner = runtime.runner as any;
+      // Replaced by assignment below, which only a TypeScript-private member
+      // allows, so it is reached the old way.
+      const runner = runtime.runner as unknown as {
+        syncCellsForRunningPattern: (...args: any[]) => Promise<boolean>;
+      };
       let dependencySyncRuns = 0;
       const originalSync = runner.syncCellsForRunningPattern.bind(runner);
       runner.syncCellsForRunningPattern = async (...args: any[]) => {
@@ -4031,7 +4031,9 @@ describe("runner utils", () => {
       const started = runtime.start(resultCell);
       // Should be running now (check via runner.cancels having the key)
       expect(
-        runtime.runner["cancels"].has(runtime.runner["getDocKey"](resultCell)),
+        runtime.runner.cancels.has(
+          runtime.runner.accessForTestingOnly.getDocKey(resultCell),
+        ),
       ).toBe(true);
 
       expect(await started).toBe(true);
@@ -4080,7 +4082,9 @@ describe("runner utils", () => {
 
       // Verify root cell is running
       expect(
-        runtime.runner["cancels"].has(runtime.runner["getDocKey"](resultCell)),
+        runtime.runner.cancels.has(
+          runtime.runner.accessForTestingOnly.getDocKey(resultCell),
+        ),
       ).toBe(true);
     });
 

--- a/packages/runner/test/security.test.ts
+++ b/packages/runner/test/security.test.ts
@@ -10,6 +10,7 @@ import { createModuleCompartmentGlobals } from "../src/sandbox/mod.ts";
 import { createCallbackCompartmentGlobals } from "../src/sandbox/compartment-globals.ts";
 import { evaluateFunctionSourceInSES } from "../src/sandbox/ses-runtime.ts";
 import { createBuilder } from "../src/builder/factory.ts";
+import type { Module } from "../src/builder/types.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 
@@ -341,14 +342,8 @@ describe("SES security regressions", () => {
     // succeeds — no invocation-time blessing is needed, and the index stays
     // consistent (load-time blessing covered every nested callback).
     expect(() =>
-      (runtime.runner as unknown as {
-        invokeJavaScriptImplementation(
-          module: { wrapper?: string },
-          fn: (...args: any[]) => unknown,
-          argument: unknown,
-        ): unknown;
-      }).invokeJavaScriptImplementation(
-        main?.makeNested as { wrapper?: string },
+      runtime.runner.accessForTestingOnly.invokeJavaScriptImplementation(
+        main?.makeNested as Module,
         (main?.makeNested as { implementation: (...args: any[]) => unknown })
           .implementation,
         { $event: undefined, $ctx: undefined },

--- a/packages/runner/test/sync-argument-link-targets.test.ts
+++ b/packages/runner/test/sync-argument-link-targets.test.ts
@@ -113,12 +113,7 @@ describe("syncArgumentLinkTargets", () => {
     // reads and syncs never count toward an assertion about it.
     syncedIds.length = 0;
     walkedIds.length = 0;
-    await (runtime.runner as unknown as {
-      syncArgumentLinkTargets(
-        roots: readonly { cell: Cell<unknown>; schema?: JSONSchema }[],
-        label: string,
-      ): Promise<void>;
-    }).syncArgumentLinkTargets(
+    await runtime.runner.accessForTestingOnly.syncArgumentLinkTargets(
       [{ cell: root, schema }],
       "resumeArgumentLinkTargetSync",
     );

--- a/packages/runner/test/transactional-setup-ownership.test.ts
+++ b/packages/runner/test/transactional-setup-ownership.test.ts
@@ -37,10 +37,7 @@ describe("transactional setup ownership", () => {
     // The requirement is that the child comes back and stays reactive, not that
     // any particular bookkeeping survives the abort untouched.
 
-    type RegistrationKey = Parameters<typeof runtime.runner.cancels.has>[0];
-    const internals = runtime.runner as unknown as {
-      resultPatternCache: Map<RegistrationKey, string>;
-    };
+    const internals = runtime.runner.accessForTestingOnly;
     const originalEdit = runtime.edit.bind(runtime);
     type TestTx = ReturnType<typeof originalEdit>;
     type CommitResult = Awaited<ReturnType<TestTx["commit"]>>;


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Fable 5.1)

`Runner` held twenty-one members as TypeScript `private`, and some twenty
test files across `runner`, `piece`, and the pattern integration suite
reached them by cast. Sixteen are `#` names now, behind an
`accessForTestingOnly` getter, as `docs/development/DEVELOPMENT.md`
§ Classes prescribes; five stay `private` because tests replace them by
assignment.

## The accessor

- Six tables and sets the class never reassigns, as `readonly` plain
  properties: `locallyPreparedResults`, `locallyStoppedResults`,
  `sessionPatternPointers`, `pendingDeferredStarts`, `resultPatternCache`,
  `activeStartAttempts`.
- Nine methods as forwarding arrows: `createStorageSubscription`,
  `runPatternAfterSuccessfulCommit`, `runWithStartOwnership`, `getDocKey`,
  `syncArgumentLinkTargets`, `collectWritableCellArgumentLinks`,
  `collectArgumentSchedulerReadLinks`, `resolvePendingSpaceNamesAndRetry`,
  `invokeJavaScriptImplementation`.
- `setupInternal`, which stays `private` (below), forwarded for the one
  test that calls it directly.

`schedulerObservationIdentity` had no test reach at all: every mention in
a test is a property on an action or an options object, not the method.
It is a plain `#` method with no entry.

## What stays `private`, and why

`setupInternal` (`runner.test.ts`), `startCore`, `startWithTx`, and
`catchUpAndStartOnStaleRead` (`deferred-start-catchup-start.test.ts`), and
`syncCellsForRunningPattern` (those two files plus the `piece` package's
`pull-materialization` and `setsrc-commit-receipt` tests) are each
wrapped or replaced by assignment, which a `#` name cannot support. Each
keeps a note naming the tests. `setupInternal` is also named in a stack
trace the pattern integration suite classifies, which a `#` rename would
change; it stays as it is either way.

## What the tests do now

Thirteen test files drop their casts for the accessor; the two `piece`
tests and the integration suite are untouched, since they reach only the
members that stay `private`. Values that now meet the class's types
declare themselves where the guideline says:

- The two argument-walk test wrappers take their fixtures' schema as
  `unknown` and declare it a `JSONSchema` once, where the walk is handed
  it, rather than annotating every fixture.
- The cross-space test's `{ pendingSpaceNames }` stand-ins declare
  themselves as the `Frame` they stand in for.
- The keyless test's synthetic churn keys declare themselves as the
  pointer table's key type, derived from the accessor.
- The argument-walks test's file comment, which said the walks were
  `private` so a test could address them, now says they come through the
  accessor.

Sites that replace a member by assignment keep one cast, narrowed to that
member, beside the accessor for everything else.

## Review

Reviewed by a `cf-review` pass: approve, no blocking findings and no
improvements. Of its nits, `startWithTx` now has a line saying what it
does ahead of the note on why it stays `private`; the lone `TODO(danfuzz)`
on the forwarded `setupInternal` stays where it is, since that entry is
the one place the accessor forwards a `private` member.

## Gates

`deno fmt --check`, `deno lint`, `deno task check`, and the `runner`
suite (1390 passed, 0 failed). One document and one sibling source file name the
converted members with their `#`.
