### PR TITLE
refactor(runner): `Scheduler.execute()` is a `#` method; the load-park test runs the pass it observes

### DIFF
--- a/packages/runner/src/scheduler/facade.ts
+++ b/packages/runner/src/scheduler/facade.ts
@@ -558,13 +558,7 @@ export class Scheduler {
         return outerThis.#settlingTracker;
       },
       clearBackoffForCleanNodes: () => this.#clearBackoffForCleanNodes(),
-      // Forwards to the TypeScript-private member so that a test which
-      // replaces it by assignment is honored here too.
-      // TODO(danfuzz): Make `execute()` a `#` method, which needs
-      // `test/scheduler-event-load-park.test.ts` to observe a pass ending some
-      // other way than by wrapping the method: a hook the scheduler offers, or
-      // the telemetry it already emits at the end of a pass.
-      execute: () => this.execute(),
+      execute: () => this.#execute(),
       getActionId: (action) => this.#getActionId(action),
       isDemandedPullComputation: (action) =>
         this.#isDemandedPullComputation(action),
@@ -946,7 +940,7 @@ export class Scheduler {
         this.runtime.patternManager.pendingPatternWorkSettled().then(recheck);
       } else if (this.#disposed) {
         // Every branch below parks on `#idlePromises`, which only the execute
-        // loop drains — and `execute()` returns immediately once disposed. So
+        // loop drains — and `#execute()` returns immediately once disposed. So
         // parking here would park FOREVER, which is how a caller that disposed
         // the scheduler by hand made `Runtime.dispose()` hang: its teardown
         // awaits `scheduler.idle()`. A disposed scheduler will never run
@@ -1370,7 +1364,7 @@ export class Scheduler {
     }
     this.#pendingQueueTaskTimer = queueTask(() => {
       this.#pendingQueueTaskTimer = null;
-      this.execute();
+      this.#execute();
     });
     this.#scheduled = true;
   }
@@ -1784,7 +1778,7 @@ export class Scheduler {
   }
 
   /**
-   * Enables collection of per-iteration settle stats during execute().
+   * Enables collection of per-iteration settle stats during `#execute()`.
    * Call this once before running patterns to opt in to the overhead.
    */
   enableSettleStats(): void {
@@ -1792,7 +1786,7 @@ export class Scheduler {
   }
 
   /**
-   * Enables or disables collection of per-iteration settle stats during execute().
+   * Enables or disables collection of per-iteration settle stats during `#execute()`.
    * Disabling also clears the last collected stats to avoid outdated reads.
    */
   setSettleStatsEnabled(enabled: boolean): void {
@@ -1804,14 +1798,14 @@ export class Scheduler {
   }
 
   /**
-   * Returns settle stats from the last execute() call, or null if not enabled/collected.
+   * Returns settle stats from the last `#execute()` call, or null if not enabled/collected.
    */
   getSettleStats(): SettleStats | null {
     return this.#lastSettleStats;
   }
 
   /**
-   * Returns recent settle stats history from execute() calls, oldest first.
+   * Returns recent settle stats history from `#execute()` calls, oldest first.
    */
   getSettleStatsHistory(): SettleStatsHistoryEntry[] {
     return [...this.#settleStatsHistory];
@@ -1859,7 +1853,7 @@ export class Scheduler {
 
   /**
    * Returns whether the scheduler has detected a non-settling condition.
-   * This means execute() is consuming a high fraction of wall-clock time,
+   * This means `#execute()` is consuming a high fraction of wall-clock time,
    * indicating the system is churning.
    */
   isNonSettling(): boolean {
@@ -1933,7 +1927,7 @@ export class Scheduler {
     this.#wakeShaper.dispose();
     // Release waiters already parked when dispose arrived. The branch in
     // waitForQuiescence covers idle() calls made AFTER this point; it cannot
-    // reach these, and nothing else will — `execute()` is the only other drain
+    // reach these, and nothing else will — `#execute()` is the only other drain
     // and it is now a no-op. Same contract the wake shaper's own dispose keeps
     // for its drain waiters, one line up. Drained in place rather than by
     // reassigning the field: createExecuteContinuationState() hands this exact
@@ -1941,7 +1935,7 @@ export class Scheduler {
     // detached one.
     //
     // Routed back through waitForQuiescence rather than resolved here, because
-    // dispose does NOT cancel a run already under way — `execute()` tests
+    // dispose does NOT cancel a run already under way — `#execute()` tests
     // `#disposed` only on entry. Every parking branch is reached with
     // `runningPromise` unset, so a waiter parked while execution was merely
     // SCHEDULED is still parked once the run begins; resolving it directly
@@ -1978,14 +1972,8 @@ export class Scheduler {
     );
   }
 
-  /**
-   * Runs one scheduler pass.
-   *
-   * TypeScript-private rather than a `#` name, because
-   * `test/scheduler-event-load-park.test.ts` replaces this member by
-   * assignment, which a `#` method does not allow.
-   */
-  private async execute(): Promise<void> {
+  /** Runs one scheduler pass. */
+  async #execute(): Promise<void> {
     if (this.#disposed) return;
     logger.timeStart("scheduler", "execute");
     // Each execute pass starts in a fresh macrotask (queueTask): restart
@@ -2014,7 +2002,7 @@ export class Scheduler {
       record.passRuns = 0;
     }
 
-    // Non-settling heuristic: record execute() start
+    // Non-settling heuristic: record `#execute()` start
     markExecuteStart(this.#settlingTracker);
   }
 
@@ -2161,7 +2149,7 @@ export class Scheduler {
   }
 
   #recordExecuteEndTelemetry(): void {
-    // Non-settling heuristic: accumulate busy time at end of execute()
+    // Non-settling heuristic: accumulate busy time at end of `#execute()`
     const executeEnd = recordExecuteEnd(this.#settlingTracker);
     if (this.#diagnosisEnabled) {
       this.#diagnosisBusyTime += executeEnd.diagnosisBusyTimeMs;
@@ -2597,7 +2585,7 @@ export class Scheduler {
       setPendingQueueTaskTimer: (timer) => {
         this.#pendingQueueTaskTimer = timer;
       },
-      execute: () => this.execute(),
+      execute: () => this.#execute(),
     };
   }
 

--- a/packages/runner/test/scheduler-event-load-park.test.ts
+++ b/packages/runner/test/scheduler-event-load-park.test.ts
@@ -207,25 +207,9 @@ describe("event dispatch parks on in-flight closure loads", () => {
 
     // An unrelated scheduler wake while the load is still pending must observe
     // the parked head rather than re-running its dependency preflight or
-    // dispatching through it.
-    const schedulerHarness = runtime.scheduler as unknown as {
-      execute(): Promise<void>;
-    };
-    const originalExecute = schedulerHarness.execute.bind(runtime.scheduler);
-    const rerunCompleted = Promise.withResolvers<void>();
-    schedulerHarness.execute = async () => {
-      try {
-        await originalExecute();
-      } finally {
-        rerunCompleted.resolve();
-      }
-    };
-    try {
-      runtime.scheduler.queueExecution();
-      await rerunCompleted.promise;
-    } finally {
-      schedulerHarness.execute = originalExecute;
-    }
+    // dispatching through it. The pass is run directly, which is what a queued
+    // wake does once its task fires, so its end is the pass's own promise.
+    await runtime.scheduler.accessForTestingOnly.execute();
     expect(handlerRuns, "a scheduler re-tick must keep the parked head blocked")
       .toBe(0);
 

--- a/packages/runner/test/scheduler-event-load-park.test.ts
+++ b/packages/runner/test/scheduler-event-load-park.test.ts
@@ -9,6 +9,7 @@ import type {
 } from "../src/storage/interface.ts";
 import { ReplicaLoadFailureError } from "../src/storage/interface.ts";
 import { toMemorySpaceAddress } from "../src/link-utils.ts";
+import type { RuntimeTelemetryEvent } from "../src/telemetry.ts";
 import {
   createSchedulerTestRuntime,
   disposeSchedulerTestRuntime,
@@ -180,7 +181,21 @@ describe("event dispatch parks on in-flight closure loads", () => {
     const release = holdSyncFor(coldDoc.getAsNormalizedFullLink().id);
     const loadInFlight = runtime.storageManager.syncCell(coldDoc)
       .catch(() => {});
-    const loadParkObserved = observeNextLoadPark();
+    // The park is observed from inside the event phase of the pass that
+    // registers it, and that pass goes on to settle. Its settle marker is
+    // the first one after the park, so listen from before the event.
+    let parkObserved = false;
+    const parkingPassSettled = Promise.withResolvers<void>();
+    const onTelemetry = (event: Event) => {
+      const { marker } = (event as RuntimeTelemetryEvent).detail;
+      if (parkObserved && marker.type === "scheduler.settle") {
+        parkingPassSettled.resolve();
+      }
+    };
+    runtime.telemetry.addEventListener("telemetry", onTelemetry);
+    const loadParkObserved = observeNextLoadPark().then(() => {
+      parkObserved = true;
+    });
 
     runtime.scheduler.queueEvent(eventCell.getAsNormalizedFullLink(), 1);
 
@@ -207,8 +222,14 @@ describe("event dispatch parks on in-flight closure loads", () => {
 
     // An unrelated scheduler wake while the load is still pending must observe
     // the parked head rather than re-running its dependency preflight or
-    // dispatching through it. The pass is run directly, which is what a queued
-    // wake does once its task fires, so its end is the pass's own promise.
+    // dispatching through it. A queued wake runs only after the pass that
+    // parked the head has settled, so wait for that, then run the pass
+    // directly: its end is the pass's own promise.
+    try {
+      await parkingPassSettled.promise;
+    } finally {
+      runtime.telemetry.removeEventListener("telemetry", onTelemetry);
+    }
     await runtime.scheduler.accessForTestingOnly.execute();
     expect(handlerRuns, "a scheduler re-tick must keep the parked head blocked")
       .toBe(0);


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Fable 5.1)

The first of the stub-by-assignment seams. `Scheduler.execute()` stayed
TypeScript-`private` after #6956 because `scheduler-event-load-park.test.ts`
wrapped it by assignment, and a `#` method cannot be wrapped. The wrap
existed only to learn when a queued re-tick's pass had ended.

## What changed

The accessor already forwards the pass, and a queued wake is nothing more
than the pass run once its task fires. So the test runs the pass directly
through `accessForTestingOnly.execute()` and awaits the promise the pass
itself returns, which is the same observation with nothing replaced. The
assertion it guards is unchanged: a scheduler re-tick while a required
load is in flight keeps the parked head blocked.

With no test replacing it, `execute()` is `#execute()`; its note and the
accessor's `TODO(danfuzz)` go, and the ten comments in `facade.ts` that
named it bare now name it as `#execute()`.

## Review

Reviewed by a `cf-review` pass: approve, with one improvement, applied.
The park is observed from inside the event phase of the pass that
registers it, so the direct pass had overlapped a settle loop still
running, which a queued wake never does: it would run after that pass. The
test now waits for the parking pass's settle marker on the runtime's
telemetry, then runs the pass. The reviewer confirmed by probing the
scheduler's flags that the earlier ordering overlapped.

## Gates

`deno fmt --check` and `deno lint` on the two files, `deno check` on them,
and the scheduler tests around the pass (event-load-park, convergence,
idle-parked-event, timing, settling-telemetry: 6 passed, 0 failed). The
full runner suite runs in CI.
