### PR TITLE
refactor(cli): a resurrectable line's hunk header always parses, so `adjustHunkCounts` is a `#` method

### DIFF
--- a/packages/cli/lib/view/session.ts
+++ b/packages/cli/lib/view/session.ts
@@ -490,16 +490,8 @@ export class Session {
       revealMatch: () => this.#revealMatch(),
       handleOverlayKey: (key) => this.#handleOverlayKey(key),
       prepareContextEdit: () => this.#prepareContextEdit(),
-      // Forwards to the TypeScript-private member so that a test which
-      // replaces it by assignment is honored here too.
-      // TODO(danfuzz): Make `adjustHunkCounts()` a `#` method. That needs
-      // `test/view-diffedit.test.ts` to stop replacing it by assignment, and
-      // the refusal it stands in for is reachable from the public surface: a
-      // malformed `@@` header makes the real method return `false`, and the
-      // `doctoredDiffSession()` helper in `test/view-session-cov2.test.ts`
-      // already builds a session with such a header.
       adjustHunkCounts: (oldDelta, newDelta, hunkHeader) =>
-        this.adjustHunkCounts(oldDelta, newDelta, hunkHeader),
+        this.#adjustHunkCounts(oldDelta, newDelta, hunkHeader),
       editStart: () => this.#editStart(),
       ensureCursorVisible: () => this.#ensureCursorVisible(),
       computeEditedFiles: () => this.#computeEditedFiles(),
@@ -2648,7 +2640,7 @@ export class Session {
             } else {
               this.#splitDiffLine(prefix);
             }
-            this.adjustHunkCounts(0, 1, hunkHeader);
+            this.#adjustHunkCounts(0, 1, hunkHeader);
             this.#afterEdit();
           }
         } else {
@@ -2782,9 +2774,13 @@ export class Session {
     const newSideBom = carriesNewUtf8Bom && parsed
       ? this.#newSideBomCarrier(parsed.model, parsed.hunk)
       : null;
-    if (!this.adjustHunkCounts(0, 1, hunkHeader)) {
-      this.#message = "This hunk could not be updated.";
-      return true;
+    if (!this.#adjustHunkCounts(0, 1, hunkHeader)) {
+      // A resurrectable line sits inside a parsed hunk, and the adjuster's
+      // header pattern accepts every header the parser's does, so a header
+      // that stops parsing here is a broken invariant, not a refusal.
+      throw new Error(
+        "the hunk header of a resurrectable line did not parse",
+      );
     }
     const decodedContent = [...line].slice(oldHasUtf8Bom ? 2 : 1).join("");
     const newContent = `${carriesNewUtf8Bom ? "\uFEFF" : ""}${decodedContent}`;
@@ -2899,13 +2895,10 @@ export class Session {
 
   /** Grow or shrink a parsed hunk header after its body changes. A zero-count
    * unified-diff range names the line before its insertion point, so crossing
-   * zero also moves the range start.
-   *
-   * TypeScript-private rather than a `#` name, because
-   * `test/view-diffedit.test.ts` replaces this member by assignment, which a
-   * `#` method does not allow.
-   */
-  private adjustHunkCounts(
+   * zero also moves the range start. Returns whether a header was rewritten:
+   * false with no diff policy or buffer, with nothing to change, with no
+   * header row, or with a header row the pattern does not match. */
+  #adjustHunkCounts(
     oldDelta: number,
     newDelta: number,
     hunkHeader = this.#hunkHeaderAt(this.#buffer?.row ?? -1),
@@ -3113,7 +3106,7 @@ export class Session {
     if (context) {
       b.lines[b.row] = `-${b.lines[b.row].slice(1)}`;
       b.place(b.row, 1);
-      this.adjustHunkCounts(0, -1, hunkHeader);
+      this.#adjustHunkCounts(0, -1, hunkHeader);
       return;
     }
     const previousEnding = b.lineEndingProvenance()[b.row - 1];
@@ -3123,7 +3116,7 @@ export class Session {
     const lineEndings = [...b.lineEndingProvenance()];
     lineEndings[b.row] = previousEnding;
     b.setLineEndingProvenance(lineEndings);
-    this.adjustHunkCounts(
+    this.#adjustHunkCounts(
       marker === " " || marker === "-" ? -1 : 0,
       marker === " " || marker === "+" ? -1 : 0,
       hunkHeader,

--- a/packages/cli/lib/view/session.ts
+++ b/packages/cli/lib/view/session.ts
@@ -2775,9 +2775,7 @@ export class Session {
       ? this.#newSideBomCarrier(parsed.model, parsed.hunk)
       : null;
     if (!this.#adjustHunkCounts(0, 1, hunkHeader)) {
-      // A resurrectable line sits inside a parsed hunk, and the adjuster's
-      // header pattern accepts every header the parser's does, so a header
-      // that stops parsing here is a broken invariant, not a refusal.
+      // Cannot happen for a resurrectable line; see `#adjustHunkCounts`.
       throw new Error(
         "the hunk header of a resurrectable line did not parse",
       );

--- a/packages/cli/test/view-diffedit.test.ts
+++ b/packages/cli/test/view-diffedit.test.ts
@@ -760,35 +760,6 @@ const extra = answer + 1;
   }
 });
 
-Deno.test("diffedit: a refused hunk update leaves the removed line intact", () => {
-  const { root, ws, done } = tempWorkspace();
-  try {
-    const s = diffSession(ws);
-    toLine(s, 8); // the "-export const answer = 42;" line
-    const before = s.doc.text;
-    const internals = s as unknown as {
-      adjustHunkCounts(
-        oldDelta: number,
-        newDelta: number,
-        hunkHeader?: number | null,
-      ): boolean;
-    };
-    internals.adjustHunkCounts = () => false;
-
-    press(s, "R");
-
-    assertEquals(s.doc.text, before, "the removed line was not changed");
-    assertEquals(s.view().message, "This hunk could not be updated.");
-    assertEquals(
-      Deno.readTextFileSync(join(root, "m.ts")),
-      FILE_TEXT,
-      "the workspace file was not changed",
-    );
-  } finally {
-    done();
-  }
-});
-
 Deno.test("diffedit: R remains a typed character on an editable diff line", () => {
   const { ws, done } = tempWorkspace();
   try {


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Fable 5.1)

@hixie, for your radar: this turns a refusal branch in the diff editor
into a thrown invariant, on the argument below. It will likely merge before
you get to it; a later objection is welcome all the same.

The second of the stub-by-assignment seams. `Session.adjustHunkCounts`
stayed TypeScript-`private` after #6918 because
`test/view-diffedit.test.ts` replaced it by assignment with a stub that
returns `false`, to reach the resurrect key's "This hunk could not be
updated." branch.

## Why the branch is an invariant

The resurrect key runs the adjuster only after `#canResurrectRemovedLine`
has placed the cursor's line inside a parsed hunk, through the diff
policy's `regionKind`. That placement and the adjuster read the same
buffer; both take hunk ranges from the header's counts; and the
adjuster's header pattern (`@@ -a,b +c,d @@…` with a lax tail) accepts
every header the parser's stricter pattern does. So in a real session
the adjuster cannot return `false` from that call: the only path to it
was the stub.

## What changed

- The branch now throws an `Error` naming the invariant, rather than
  showing a message for a state that cannot arise.
- The stub test goes. The other diffedit tests still cover the resurrect
  key's real outcomes, and `view-session-cov2.test.ts` still drives the
  adjuster's own refusals (a malformed explicit header, a body with no
  header above it) through the accessor.
- With nothing replacing it, the method is `#adjustHunkCounts`, still
  forwarded through `accessForTestingOnly` for those direct calls; its
  note and the accessor's `TODO(danfuzz)` go. Its doc comment now says
  when it returns `false`.

## Review

Reviewed by a `cf-review` pass: approve, no blocking findings and no
improvements. The reviewer read the parser, the policy, and the adjuster
and confirmed the invariant argument above, including that the adjuster's
header pattern is a strict superset of the parser's. Its one nit, the
note above the throw restating the adjuster's doc comment, is applied.

## Gates

`deno fmt --check` and `deno lint` on the two files, `deno check` on
them, and the cli view tests that touch the adjuster (diffedit,
session-cov, session-cov2, session-gate2: 295 passed, 0 failed). The
full cli suite runs in CI.

## Coverage

The Coverage Check counts three lines: the thrown invariant that replaced
the refusal branch. Nothing reaches it, by the argument above, and a test
that could would refute that argument. Accepted below.

ACCEPT_COVERAGE_DEBT: packages/cli +3 lines
