### PR TITLE
docs(specs): the sigil question is a reservation, not a live conflict

### DIFF
--- a/docs/specs/collection-naming.md
+++ b/docs/specs/collection-naming.md
@@ -628,11 +628,31 @@ grammar, and it carries the normalization and confusable policy with it.
 a *kind* by searching the reader's own discovery collections — favorites,
 mentionables, profile elements — and may return several candidates and a picker
 (`docs/common/conventions/wish.md`). A citation names one *instance* and
-resolves deterministically through the scope chain. Both would spell themselves
-with `#`. Either they are one system, in which case a tag search is the
+resolves deterministically through the scope chain. Both spell themselves with
+`#`.
+
+They do not meet today, and the difference is where each `#` is read. A wish's
+is a character inside a query string a pattern author writes in source, or
+inside a `#tag` in a JSDoc comment declaring what a schema offers; nothing
+scans prose for it. A citation's is a trigger matched as a person types into a
+document. No reader parses both, so neither spelling is currently ambiguous to
+any code.
+
+What is open is therefore a reservation rather than a conflict: `#` is spent
+twice, and whichever widens first collides. **Step 5 is that widening**, which
+is why it is blocked here and not merely awaiting an answer: sigil parsing
+reads `#` out of prose generally, rather than recording a reference the way the
+editor's trigger does, so a tag and a citation become candidates for the same
+token in the same reader. Answer it before that step, not during. At that point
+either they are one system, in which case a tag search is the
 outermost rung of the same scope chain and the well-known targets that resolve
 by recency need reconciling with the rule that nothing hidden decides what a
 name means; or they are two systems and one of them needs a different sigil.
+
+The cost that exists now is a reader's rather than a parser's: the same mark
+means "search a kind, perhaps pick from several" in one place and "this exact
+member, resolved deterministically" in another, and only context separates
+them.
 
 **Which spelling a renderer prefers** when several are available and all round
 trip — a collection's compact form, its path form, and any space-level name the

--- a/docs/specs/collection-naming.md
+++ b/docs/specs/collection-naming.md
@@ -631,19 +631,21 @@ mentionables, profile elements — and may return several candidates and a picke
 resolves deterministically through the scope chain. Both spell themselves with
 `#`.
 
-They do not meet today, and the difference is where each `#` is read. A wish's
-is a character inside a query string a pattern author writes in source, or
-inside a `#tag` in a JSDoc comment declaring what a schema offers; nothing
-scans prose for it. A citation's is a trigger matched as a person types into a
-document. No reader parses both, so neither spelling is currently ambiguous to
-any code.
+They do not meet today, and the difference is not that one is typed and the
+other is not — both reach a reader from a person. `cf wish '#profile'` takes
+its query as a command argument, and the omnibox passes a user-facing tool's
+`query` straight through. What separates them is that **each input surface has
+exactly one interpretation**: text handed to `cf wish` or to the omnibox is a
+wish query because of where it was entered, and the editor's `#` trigger is a
+citation for the same reason. No surface asks which of the two a token is, so
+neither spelling is currently ambiguous to any code.
 
 What is open is therefore a reservation rather than a conflict: `#` is spent
-twice, and whichever widens first collides. **Step 5 is that widening**, which
-is why it is blocked here and not merely awaiting an answer: sigil parsing
-reads `#` out of prose generally, rather than recording a reference the way the
-editor's trigger does, so a tag and a citation become candidates for the same
-token in the same reader. Answer it before that step, not during. At that point
+twice, and the collision arrives with a surface that accepts both. **Step 5 is
+that surface**, which is why it is blocked here and not merely awaiting an
+answer: sigil parsing reads `#` out of prose generally, rather than taking a
+token from a place that already fixes its meaning, so a tag and a citation
+become candidates for the same token with nothing to separate them. Answer it before that step, not during. At that point
 either they are one system, in which case a tag search is the
 outermost rung of the same scope chain and the well-known targets that resolve
 by recency need reconciling with the rule that nothing hidden decides what a

--- a/docs/specs/collection-naming.md
+++ b/docs/specs/collection-naming.md
@@ -631,28 +631,22 @@ mentionables, profile elements — and may return several candidates and a picke
 resolves deterministically through the scope chain. Both spell themselves with
 `#`.
 
-They do not meet today, and the difference is not that one is typed and the
-other is not — both reach a reader from a person. `cf wish '#profile'` takes
-its query as a command argument, and a model calling `wishAndNavigate` supplies
-one from a conversation. What separates them is that **nothing routes a token
-on the strength of its `#`**: a query reaches `wish` because a command was
-invoked or a tool was called with it, and the editor's trigger produces a
-citation because of where it was typed. Omnibox text is not itself a wish —
-it is a message to a dialog whose tools include one, so `#42` entered there is
-a string in a conversation until a model chooses to pass it somewhere. No
-reader today takes a `#` token and asks which of the two it is, so neither
-spelling is ambiguous to any code.
+One surface already routes on the mark alone: Shuttle's `cd` classifies an
+operand beginning `#` as a wish and resolves it as one (`place.ts`,
+`verbs.ts`), so `cd #favorites` is a wish query without the `wish` verb being
+named. Nothing routes a `#` token to a citation the same way — the editor's
+trigger produces one while a person types, and decides what is a reference by
+membership in its map rather than by the token's shape.
 
-What is open is therefore a reservation rather than a conflict: `#` is spent
-twice, and the collision arrives with a surface that accepts both. **Step 5 is
-that surface**, which is why it is blocked here and not merely awaiting an
-answer: sigil parsing reads `#` out of prose generally, rather than taking a
-token from a place that already fixes its meaning, so a tag and a citation
-become candidates for the same token with nothing to separate them. Answer it before that step, not during. At that point
-either they are one system, in which case a tag search is the
-outermost rung of the same scope chain and the well-known targets that resolve
-by recency need reconciling with the rule that nothing hidden decides what a
-name means; or they are two systems and one of them needs a different sigil.
+So the mark is already load-bearing in one direction and not the other, and
+what is unsettled is what a surface should do when it must choose. **Step 5 is
+where that arises**, which is why it is blocked here rather than merely
+awaiting an answer: sigil parsing reads `#` out of prose generally, and a
+reader that resolves both kinds has to decide which a token is. Until then
+either they are one system, in which case a tag search is the outermost rung
+of the same scope chain and the well-known targets that resolve by recency
+need reconciling with the rule that nothing hidden decides what a name means;
+or they are two systems and one of them needs a different sigil.
 
 The cost that exists now is a reader's rather than a parser's: the same mark
 means "search a kind, perhaps pick from several" in one place and "this exact

--- a/docs/specs/collection-naming.md
+++ b/docs/specs/collection-naming.md
@@ -633,12 +633,15 @@ resolves deterministically through the scope chain. Both spell themselves with
 
 They do not meet today, and the difference is not that one is typed and the
 other is not — both reach a reader from a person. `cf wish '#profile'` takes
-its query as a command argument, and the omnibox passes a user-facing tool's
-`query` straight through. What separates them is that **each input surface has
-exactly one interpretation**: text handed to `cf wish` or to the omnibox is a
-wish query because of where it was entered, and the editor's `#` trigger is a
-citation for the same reason. No surface asks which of the two a token is, so
-neither spelling is currently ambiguous to any code.
+its query as a command argument, and a model calling `wishAndNavigate` supplies
+one from a conversation. What separates them is that **nothing routes a token
+on the strength of its `#`**: a query reaches `wish` because a command was
+invoked or a tool was called with it, and the editor's trigger produces a
+citation because of where it was typed. Omnibox text is not itself a wish —
+it is a message to a dialog whose tools include one, so `#42` entered there is
+a string in a conversation until a model chooses to pass it somewhere. No
+reader today takes a `#` token and asks which of the two it is, so neither
+spelling is ambiguous to any code.
 
 What is open is therefore a reservation rather than a conflict: `#` is spent
 twice, and the collision arrives with a surface that accepts both. **Step 5 is


### PR DESCRIPTION
## Why

The spec's open-questions entry for tags-versus-citations read as though the
two were already ambiguous to something. They are not, and the entry was
making a reserved character look like a blocker.

Checked before rewriting: every `wish({ query: "#…" })` in the tree is a
string literal in pattern **source**, or a `#tag` inside a JSDoc comment
declaring what a schema offers. Nothing scans prose for it. A citation's `#`
is a trigger matched as a person types, and the editor decides what is a
reference by membership in its map rather than by the token's shape.

**No reader parses both.** So neither spelling is ambiguous to any code today.

## What changed

The entry now says what is true: `#` is spent twice, and whichever use widens
first collides. It also names the widening event rather than leaving the
reader to infer it — **step 5 is that event**, because sigil parsing reads `#`
out of prose generally, so a tag and a citation become candidates for the same
token in the same reader. That is why the preamble lists this as blocking
step 5 rather than merely awaiting an answer, and the two passages now agree.

The cost that exists today is stated as what it is: a reader's rather than a
parser's. One mark means "search a kind, perhaps pick from several" in one
place and "this exact member, resolved deterministically" in another.

## Test plan

Documentation only. `deno fmt --check`, `deno task check-docs` (590 blocks),
`check-skill-facts` (50 documents) all pass. Every added line is within 80
columns; the three over-80 lines in the file predate this change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6962?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

