### PR TITLE
refactor(html): `WorkerReconciler.#canRenderCellUnderPolicy`; the cell-child test drives the real render policy

### DIFF
--- a/packages/html/src/worker/reconciler.ts
+++ b/packages/html/src/worker/reconciler.ts
@@ -263,14 +263,8 @@ export class WorkerReconciler {
       rootRenderPolicy: this.#rootRenderPolicy,
       atomRenderableUnderPolicy: (atom, policy) =>
         this.#atomRenderableUnderPolicy(atom, policy),
-      // Forwards to the TypeScript-private member so that a test which
-      // replaces it by assignment is honored here too.
-      // TODO(danfuzz): Find a way to make `canRenderCellUnderPolicy()` a `#`
-      // method, which needs `test/worker-reconciler-cell-child.test.ts` to stop
-      // replacing it by assignment: a seam this class offers, or a test written
-      // against the public behavior.
       canRenderCellUnderPolicy: (cell, policy) =>
-        this.canRenderCellUnderPolicy(cell, policy),
+        this.#canRenderCellUnderPolicy(cell, policy),
     };
   }
 
@@ -357,7 +351,7 @@ export class WorkerReconciler {
         // configured) before rendering its resolved content. Checked per
         // update so label changes re-evaluate, mirroring renderCellChild.
         if (
-          !this.canRenderCellUnderPolicy(
+          !this.#canRenderCellUnderPolicy(
             vnode as Cell<unknown>,
             this.#rootRenderPolicy,
           )
@@ -1000,7 +994,7 @@ export class WorkerReconciler {
     }
     const protectedValue = this.#boundaryProtectedValueCell(node);
     return protectedValue !== undefined &&
-      !this.canRenderCellUnderPolicy(protectedValue, policy);
+      !this.#canRenderCellUnderPolicy(protectedValue, policy);
   }
 
   #boundaryProtectedValueCell(
@@ -1142,11 +1136,13 @@ export class WorkerReconciler {
   }
 
   /**
-   * TypeScript-private rather than a `#` name, because
-   * `test/worker-reconciler-cell-child.test.ts` replaces this member by
-   * assignment, which a `#` method does not allow.
+   * Whether `cell` may render under `policy`: every atom of its
+   * confidentiality label (its schema's, when it carries none) sits under
+   * the ceiling or is declassified, resolved through the display-boundary
+   * exchange rules when a resolver is wired and a ceiling is in force. A
+   * label that cannot be read fails closed.
    */
-  private canRenderCellUnderPolicy(
+  #canRenderCellUnderPolicy(
     cell: Cell<unknown>,
     policy: RenderPolicy,
   ): boolean {
@@ -3675,7 +3671,7 @@ export class WorkerReconciler {
         addCancel,
         () => renderResolved(childState.currentValue, true),
       );
-      const blockedByPolicy = !this.canRenderCellUnderPolicy(cell, policy);
+      const blockedByPolicy = !this.#canRenderCellUnderPolicy(cell, policy);
       const blockedByIntegrity = !blockedByPolicy &&
         this.#shouldBlockTextFromCell(resolvedChild, cell, policy);
 

--- a/packages/html/src/worker/reconciler.ts
+++ b/packages/html/src/worker/reconciler.ts
@@ -919,7 +919,7 @@ export class WorkerReconciler {
    * own view, or — when it has none — the resolved (followed) target's view,
    * whose label may carry the `Space(...)` atoms. May throw (each caller
    * decides its own fail-closed handling). The SINGLE source of label
-   * resolution shared by the gate (`canRenderCellUnderPolicy`), the
+   * resolution shared by the gate (`#canRenderCellUnderPolicy`), the
    * represents-principal read, and the Stage-2 membership watcher
    * (`watchCellMembership`), so they can never drift out of lockstep.
    */

--- a/packages/html/test/worker-reconciler-cell-child.test.ts
+++ b/packages/html/test/worker-reconciler-cell-child.test.ts
@@ -128,14 +128,10 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
       return false;
     }
 
-    // A mock names no link, so it resolves to itself and has no schema to
-    // fall back on for a label; a step that needs either overrides it.
+    // A mock names no link, so it resolves to itself; a step that needs
+    // otherwise overrides it on the instance.
     resolveAsCell(): MockCell | Cell<unknown> {
       return this;
-    }
-
-    get schema(): undefined {
-      return undefined;
     }
   }
 

--- a/packages/html/test/worker-reconciler-cell-child.test.ts
+++ b/packages/html/test/worker-reconciler-cell-child.test.ts
@@ -130,7 +130,7 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
 
     // A mock names no link, so it resolves to itself and has no schema to
     // fall back on for a label; a step that needs either overrides it.
-    resolveAsCell() {
+    resolveAsCell(): MockCell | Cell<unknown> {
       return this;
     }
 

--- a/packages/html/test/worker-reconciler-cell-child.test.ts
+++ b/packages/html/test/worker-reconciler-cell-child.test.ts
@@ -15,7 +15,9 @@ import { assertEquals } from "@std/assert";
 import { Identity } from "@commonfabric/identity";
 import { Runtime, UI } from "@commonfabric/runner";
 import type { Cell } from "@commonfabric/runner";
+import type { CfcLabelView } from "@commonfabric/runner/cfc";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { cfcLabelViewSymbol } from "../../runner/src/cfc/label-view-state.ts";
 
 import type { VDomOp } from "../src/vdom-ops.ts";
 import { WorkerReconciler } from "../src/worker/reconciler.ts";
@@ -124,6 +126,16 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
 
     isStream() {
       return false;
+    }
+
+    // A mock names no link, so it resolves to itself and has no schema to
+    // fall back on for a label; a step that needs either overrides it.
+    resolveAsCell() {
+      return this;
+    }
+
+    get schema(): undefined {
+      return undefined;
     }
   }
 
@@ -1888,8 +1900,12 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
     "updates same-key subpatterns and retargets unchanged UI",
     async () => {
       const collector = createOpsCollector();
+      // A public-only ceiling, so that the one output labeled confidential
+      // below is refused by the real render policy while the unlabeled ones
+      // render as before.
       const reconciler = new WorkerReconciler({
         onOps: collector.onOps,
+        renderConfidentialityCeiling: { atoms: [] },
       });
       // A subpattern's output reaches the reconciler as a cell, and a cell
       // keys by the link it names rather than by the payload behind it. That
@@ -1907,6 +1923,14 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
       });
       const outputCell = new MockCell(initialOutput);
       let resolvedOutputId = "of:fid1:nested-pattern";
+      // The one output the render policy refuses: while the resolved output
+      // is this one, it carries a confidentiality label no public-only
+      // ceiling admits; otherwise it carries none.
+      const deniedOutputId = "of:fid1:retargeted-to-blocked";
+      const deniedLabelView: CfcLabelView = {
+        version: 1,
+        entries: [{ path: [], label: { confidentiality: ["secret"] } }],
+      };
       outputCell.getAsNormalizedFullLink = () => ({
         id: "of:fid1:stable-link-container",
         space: signer.did(),
@@ -1927,6 +1951,8 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
           field === "patternIdentity"
             ? { identity: "nested-pattern", symbol: "default" }
             : undefined,
+        [cfcLabelViewSymbol]: () =>
+          resolvedOutputId === deniedOutputId ? deniedLabelView : undefined,
       } as unknown as Cell<unknown>;
       outputCell.resolveAsCell = () => resolvedOutputCell;
 
@@ -2062,10 +2088,6 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
         props: { "data-row": "blocked" },
         children: ["blocked"],
       });
-      const deniedOutputId = "of:fid1:retargeted-to-blocked";
-      (reconciler as unknown as {
-        canRenderCellUnderPolicy: () => boolean;
-      }).canRenderCellUnderPolicy = () => resolvedOutputId !== deniedOutputId;
       resolvedOutputId = deniedOutputId;
       outputCell.set(blockedCandidate);
       await t.settle();


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Fable 5.1)

The third of the stub-by-assignment seams. `WorkerReconciler.canRenderCellUnderPolicy`
stayed TypeScript-`private` after #6927 because
`test/worker-reconciler-cell-child.test.ts` replaced it by assignment,
refusing one retargeted output by id and admitting the next.

## What changed

The test drives the real check instead. The step's reconciler is built
with a public-only confidentiality ceiling (`renderConfidentialityCeiling:
{ atoms: [] }`), and the resolved output cell carries a confidentiality
label through the runner's carried-label protocol while it is the refused
output, and none otherwise. So the same deny-allow-deny sequence runs
through the policy itself: a labeled cell under a ceiling that admits
nothing is refused, an unlabeled one renders, and the assertions the step
made before (no hidden piece boundary on the blocked placeholder; a
same-UI retarget re-runs the policy) hold unchanged.

One consequence in the file's mock cell, which extends the real cell
class with no link: a ceiling makes the reconciler check the root cell
too, and the mock's inherited `resolveAsCell` threw on a cell with no
link. The mock now resolves to itself, which is what a cell that names no
link is, and steps that need otherwise override it on the instance, as
before.

With nothing replacing it, the check is `#canRenderCellUnderPolicy`, with
the doc comment it lacked; its note and the accessor's `TODO(danfuzz)` go.
The accessor still forwards it for the tests that call it directly.

## Review

Reviewed by a `cf-review` pass: changes requested on one finding, a
type error in the mock's new `resolveAsCell`, which was already fixed in
the second commit; otherwise approve. Its improvement is applied: the
mock's `schema` override was dead, since a link-less cell already reports
no schema, so it goes, and the claim about it below is corrected. Its
nit, a doc comment naming the gate bare, is applied. The reviewer
confirmed with mutated copies that removing the ceiling, never carrying
the label, always carrying it, or dropping the mock's `resolveAsCell`
each fails the step, so both assertions are live.

## Gates

`deno fmt --check` and `deno lint` on the two files, and the reconciler
tests around the policy and the cell child (cell-child, cfc-render-policy,
cfc-atom-admission, alias-child: 5 passed, 99 steps, 0 failed). The full
html suite runs in CI.
