### PR TITLE
refactor(runner): `PatternManager` takes a compile-cache writer through `accessForTestingOnly`; `#writeBackCompileCache`

### DIFF
--- a/docs/development/TESTING.md
+++ b/docs/development/TESTING.md
@@ -335,7 +335,7 @@ which the documents a compile-cache write-back writes do not. See
 check.
 
 Forcing that row on refuses the write-back of the debug-view deployment's own
-compile. `writeBackCompileCache` rethrows the refusal, so the deployment
+compile. `PatternManager.#writeBackCompileCache` rethrows the refusal, so the deployment
 promise rejects. A case waiting for a commit further along the deployment then
 waits forever, and the reason string names documents the case never mentions.
 

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -63,20 +63,6 @@ import type { MemorySpace, Runtime, ServerRunInfo } from "./runtime.ts";
  * FOREIGN to the serving manager's home space. */
 export type WritebackDelegation = NonNullable<ServerRunInfo["delegated"]>;
 
-/**
- * Writes a compiled closure back to a space's compile cache: the shape of
- * `PatternManager`'s own write-back, and of the writer a test supplies in
- * its place.
- */
-export type CompileCacheWriter = (
-  space: MemorySpace,
-  modules: CacheableModule[],
-  entryIdentity: string,
-  opts: { runtimeVersion: string },
-  moduleDelegations?: ModuleDelegationMap,
-  delegated?: WritebackDelegation,
-) => Promise<void>;
-
 import {
   isFabricImportSpecifier,
   parseFabricRef,
@@ -92,6 +78,20 @@ import type {
   IExtendedStorageTransaction,
 } from "./storage/interface.ts";
 import { fromURI, toURI } from "./uri-utils.ts";
+
+/**
+ * Writes a compiled closure back to a space's compile cache: the shape of
+ * `PatternManager`'s own write-back, and of the writer a test supplies in
+ * its place.
+ */
+export type CompileCacheWriter = (
+  space: MemorySpace,
+  modules: CacheableModule[],
+  entryIdentity: string,
+  opts: { runtimeVersion: string },
+  moduleDelegations?: ModuleDelegationMap,
+  delegated?: WritebackDelegation,
+) => Promise<void>;
 
 const logger = getLogger("pattern-manager");
 
@@ -432,10 +432,6 @@ export class PatternManager {
   // misses recover through the async storage-backed load. Instance field so
   // tests can shrink it.
   #maxEvaluatedModuleCacheSize = MAX_EVALUATED_MODULE_CACHE_SIZE;
-
-  // The writer a test supplies in place of the compile-cache write-back;
-  // undefined means the manager's own.
-  #compileCacheWriter: CompileCacheWriter | undefined = undefined;
   // ESM content-addressed compile-cache instrumentation.
   #esmCacheStats = { hits: 0, misses: 0, byIdentityHits: 0 };
   // In-memory identity -> module-namespace cache (CT-1623). Populated for EVERY
@@ -677,6 +673,9 @@ export class PatternManager {
     string,
     { closureSignature: string; persistence: Promise<void> }
   >();
+  // The writer a test supplies in place of the compile-cache write-back;
+  // undefined means the manager's own.
+  #compileCacheWriter: CompileCacheWriter | undefined = undefined;
   // A best-effort identity recovery that failed to persist skips the in-memory
   // artifact shortcuts on the next load so storage recovery runs again.
   #failedCompileCacheRecoveries = new Set<string>();
@@ -684,11 +683,13 @@ export class PatternManager {
   constructor(readonly runtime: Runtime) {}
 
   /**
-   * The in-flight and cached compilation tables, the module-cache bound, and
-   * the three closure steps that a test drives directly.
+   * The in-flight and cached compilation tables, the module-cache bound, the
+   * compile-cache writer a test may supply, and the three closure steps that
+   * a test drives directly.
    */
   get accessForTestingOnly(): {
     readonly addressableByIdentity: Map<string, Map<string, unknown>>;
+    compileCacheWriter: CompileCacheWriter | undefined;
     readonly compileCacheWrites: Set<Promise<unknown>>;
     readonly inProgressByIdentityLoads: Map<
       string,
@@ -696,7 +697,6 @@ export class PatternManager {
     >;
     readonly inProgressCompilations: Map<string, Promise<Pattern>>;
     maxEvaluatedModuleCacheSize: number;
-    compileCacheWriter: CompileCacheWriter | undefined;
     readonly modulesByIdentity: Map<string, { exports: Exports }>;
     readonly pendingCacheWriteBacks: Set<Promise<unknown>>;
     readonly persistedCompileCacheClosures: Map<string, string>;
@@ -724,6 +724,12 @@ export class PatternManager {
     const outerThis = this;
     return {
       addressableByIdentity: this.#addressableByIdentity,
+      get compileCacheWriter() {
+        return outerThis.#compileCacheWriter;
+      },
+      set compileCacheWriter(value) {
+        outerThis.#compileCacheWriter = value;
+      },
       compileCacheWrites: this.#compileCacheWrites,
       inProgressByIdentityLoads: this.#inProgressByIdentityLoads,
       inProgressCompilations: this.#inProgressCompilations,
@@ -732,12 +738,6 @@ export class PatternManager {
       },
       set maxEvaluatedModuleCacheSize(value) {
         outerThis.#maxEvaluatedModuleCacheSize = value;
-      },
-      get compileCacheWriter() {
-        return outerThis.#compileCacheWriter;
-      },
-      set compileCacheWriter(value) {
-        outerThis.#compileCacheWriter = value;
       },
       modulesByIdentity: this.#modulesByIdentity,
       pendingCacheWriteBacks: this.#pendingCacheWriteBacks,
@@ -2656,23 +2656,16 @@ export class PatternManager {
       }
 
       // A writer a test supplied stands in for the write-back.
-      await (this.#compileCacheWriter === undefined
-        ? this.#writeBackCompileCache(
-          space,
-          modules,
-          entryIdentity,
-          opts,
-          moduleDelegations,
-          delegated,
-        )
-        : this.#compileCacheWriter(
-          space,
-          modules,
-          entryIdentity,
-          opts,
-          moduleDelegations,
-          delegated,
-        ));
+      const write: CompileCacheWriter = this.#compileCacheWriter ??
+        ((...args) => this.#writeBackCompileCache(...args));
+      await write(
+        space,
+        modules,
+        entryIdentity,
+        opts,
+        moduleDelegations,
+        delegated,
+      );
       this.#persistedCompileCacheClosures.set(
         persistenceSlotKey,
         closureSignature,
@@ -2943,7 +2936,7 @@ export class PatternManager {
   // them blind and conflicts one engine round per edge (the CT-1824 loop).
   // With the edge docs materialized up front the write-back diffs against
   // true state and commits on the first attempt; the retry budget in
-  // writeBackCompileCache remains as a backstop. Same-microtask syncs batch
+  // `#writeBackCompileCache` remains as a backstop. Same-microtask syncs batch
   // into a single server round trip.
   async #syncSourceCacheWriteTargets(
     space: MemorySpace,

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -63,6 +63,20 @@ import type { MemorySpace, Runtime, ServerRunInfo } from "./runtime.ts";
  * FOREIGN to the serving manager's home space. */
 export type WritebackDelegation = NonNullable<ServerRunInfo["delegated"]>;
 
+/**
+ * Writes a compiled closure back to a space's compile cache: the shape of
+ * `PatternManager`'s own write-back, and of the writer a test supplies in
+ * its place.
+ */
+export type CompileCacheWriter = (
+  space: MemorySpace,
+  modules: CacheableModule[],
+  entryIdentity: string,
+  opts: { runtimeVersion: string },
+  moduleDelegations?: ModuleDelegationMap,
+  delegated?: WritebackDelegation,
+) => Promise<void>;
+
 import {
   isFabricImportSpecifier,
   parseFabricRef,
@@ -418,6 +432,10 @@ export class PatternManager {
   // misses recover through the async storage-backed load. Instance field so
   // tests can shrink it.
   #maxEvaluatedModuleCacheSize = MAX_EVALUATED_MODULE_CACHE_SIZE;
+
+  // The writer a test supplies in place of the compile-cache write-back;
+  // undefined means the manager's own.
+  #compileCacheWriter: CompileCacheWriter | undefined = undefined;
   // ESM content-addressed compile-cache instrumentation.
   #esmCacheStats = { hits: 0, misses: 0, byIdentityHits: 0 };
   // In-memory identity -> module-namespace cache (CT-1623). Populated for EVERY
@@ -678,6 +696,7 @@ export class PatternManager {
     >;
     readonly inProgressCompilations: Map<string, Promise<Pattern>>;
     maxEvaluatedModuleCacheSize: number;
+    compileCacheWriter: CompileCacheWriter | undefined;
     readonly modulesByIdentity: Map<string, { exports: Exports }>;
     readonly pendingCacheWriteBacks: Set<Promise<unknown>>;
     readonly persistedCompileCacheClosures: Map<string, string>;
@@ -713,6 +732,12 @@ export class PatternManager {
       },
       set maxEvaluatedModuleCacheSize(value) {
         outerThis.#maxEvaluatedModuleCacheSize = value;
+      },
+      get compileCacheWriter() {
+        return outerThis.#compileCacheWriter;
+      },
+      set compileCacheWriter(value) {
+        outerThis.#compileCacheWriter = value;
       },
       modulesByIdentity: this.#modulesByIdentity,
       pendingCacheWriteBacks: this.#pendingCacheWriteBacks,
@@ -2630,14 +2655,24 @@ export class PatternManager {
         this.#persistedCompileCacheClosures.delete(persistenceSlotKey);
       }
 
-      await this.writeBackCompileCache(
-        space,
-        modules,
-        entryIdentity,
-        opts,
-        moduleDelegations,
-        delegated,
-      );
+      // A writer a test supplied stands in for the write-back.
+      await (this.#compileCacheWriter === undefined
+        ? this.#writeBackCompileCache(
+          space,
+          modules,
+          entryIdentity,
+          opts,
+          moduleDelegations,
+          delegated,
+        )
+        : this.#compileCacheWriter(
+          space,
+          modules,
+          entryIdentity,
+          opts,
+          moduleDelegations,
+          delegated,
+        ));
       this.#persistedCompileCacheClosures.set(
         persistenceSlotKey,
         closureSignature,
@@ -2800,11 +2835,8 @@ export class PatternManager {
    * pattern's own space writes) retries rather than silently dropping the
    * entry. A final failure throws because persisted refs-only pattern JSON
    * requires a durable closure behind every `$patternRef`.
-   *
-   * TypeScript-private rather than a `#` name, because `test/cell-cache.test.ts`
-   * replaces this member by assignment, which a `#` method does not allow.
    */
-  private async writeBackCompileCache(
+  async #writeBackCompileCache(
     space: MemorySpace,
     modules: CacheableModule[],
     entryIdentity: string,

--- a/packages/runner/test/cell-cache.test.ts
+++ b/packages/runner/test/cell-cache.test.ts
@@ -2160,17 +2160,6 @@ describe("cell-cache: compiled-set store (CFC integrity, fail-closed)", () => {
       ],
     });
     const manager = runtime.patternManager.accessForTestingOnly;
-    // Replaced by assignment below, which only a TypeScript-private member
-    // allows, so it is reached the old way.
-    const stubbed = runtime.patternManager as unknown as {
-      writeBackCompileCache(
-        space: string,
-        modules: CacheableModule[],
-        entryIdentity: string,
-        opts: { runtimeVersion: string },
-      ): Promise<void>;
-    };
-    const originalWriteBack = stubbed.writeBackCompileCache;
     const firstStarted = Promise.withResolvers<void>();
     const releaseFirst = Promise.withResolvers<void>();
     const secondStarted = Promise.withResolvers<void>();
@@ -2178,7 +2167,7 @@ describe("cell-cache: compiled-set store (CFC integrity, fail-closed)", () => {
     let writeCount = 0;
     let firstWrite: Promise<void> | undefined;
     let secondWrite: Promise<void> | undefined;
-    stubbed.writeBackCompileCache = async () => {
+    manager.compileCacheWriter = async () => {
       writeCount++;
       if (writeCount === 1) {
         firstStarted.resolve();
@@ -2218,25 +2207,14 @@ describe("cell-cache: compiled-set store (CFC integrity, fail-closed)", () => {
           (write): write is Promise<void> => write !== undefined,
         ),
       );
-      stubbed.writeBackCompileCache = originalWriteBack;
+      manager.compileCacheWriter = undefined;
     }
   });
 
   it("retains persistence entries for the runner session", async () => {
     const { modules, entryIdentity } = toModules(PROGRAM);
     const manager = runtime.patternManager.accessForTestingOnly;
-    // Replaced by assignment below, which only a TypeScript-private member
-    // allows, so it is reached the old way.
-    const stubbed = runtime.patternManager as unknown as {
-      writeBackCompileCache(
-        space: string,
-        modules: CacheableModule[],
-        entryIdentity: string,
-        opts: { runtimeVersion: string },
-      ): Promise<void>;
-    };
-    const originalWriteBack = stubbed.writeBackCompileCache;
-    stubbed.writeBackCompileCache = () => Promise.resolve();
+    manager.compileCacheWriter = () => Promise.resolve();
     try {
       for (let index = 0; index <= 1000; index++) {
         await manager.persistCompileCacheTracked(
@@ -2247,7 +2225,7 @@ describe("cell-cache: compiled-set store (CFC integrity, fail-closed)", () => {
         );
       }
     } finally {
-      stubbed.writeBackCompileCache = originalWriteBack;
+      manager.compileCacheWriter = undefined;
     }
 
     expect(manager.persistedCompileCacheClosures.size).toBe(1001);

--- a/packages/runner/test/compile-cache-writeback-conflict.test.ts
+++ b/packages/runner/test/compile-cache-writeback-conflict.test.ts
@@ -313,7 +313,7 @@ describe("editWithRetry sequential conflict discovery", () => {
   // makes progress, and (b) survive a pull or catch-up failure without giving
   // up the round (the retry's commit is the definitive outcome). Convergence
   // takes one round per pre-existing derived doc, which is why
-  // writeBackCompileCache passes a budget sized to its write set instead of
+  // `#writeBackCompileCache` passes a budget sized to its write set instead of
   // DEFAULT_MAX_RETRIES.
 
   it("pulls each named doc and converges one doc per round", async () => {
@@ -425,7 +425,7 @@ describe("editWithRetry sequential conflict discovery", () => {
     try {
       // With the general default (5 retries = 6 attempts), a write set with
       // more never-read derived docs than that cannot converge — the CT-1824
-      // cold-boot loop. This is the behavior writeBackCompileCache's larger
+      // cold-boot loop. This is the behavior `#writeBackCompileCache`'s larger
       // budget exists to clear.
       const result = await runtime.editWithRetry(() => {});
       expect(result.error).toBeDefined();


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Fable 5.1)

@seefeldb, for your radar: this adds a test-settable collaborator to
`PatternManager` so two cache tests stop replacing a method by assignment.
It will likely merge before you get to it; a later objection is welcome
all the same.

The fourth of the stub-by-assignment seams. `PatternManager.writeBackCompileCache`
stayed TypeScript-`private` after #6955 because two `cell-cache` tests
replaced it by assignment: one gates two concurrent write-backs and
counts them, one skips a thousand real writes while filling the
persistence table.

## What changed

The manager offers the seam those stubs stood in for. A
`compileCacheWriter` lives behind `accessForTestingOnly` as a getter and
setter, `undefined` unless a test sets it, and the tracked persist step
calls it in place of the manager's own write-back when it is set. The
`CompileCacheWriter` type names the shape the write-back and a supplied
writer share. Nothing in production sets it, so the production path is
the manager's own write-back as before.

The two tests set the writer where they replaced the method and clear it
where they restored it; their assertions are unchanged.

With nothing replacing it, the write-back is `#writeBackCompileCache`,
and its note goes.

## Why a settable collaborator rather than a constructor argument

The manager is constructed by the runtime, so a constructor argument
would thread a test-only option through `Runtime`. The accessor is
already the one place a test reaches the manager's internals, and a
setter there keeps the seam next to the rest of what tests drive.

## Review

Reviewed by a `cf-review` pass: approve, no blocking findings. Its three
improvements and three nits are applied: the accessor's doc comment names
the writer, the persist step picks its callee once, the prose that named
the write-back bare now names it as `#writeBackCompileCache` (in the
manager, in `TESTING.md`, and in the writeback-conflict test), the field
sits with the other compile-cache persistence state, the type follows the
import block, and the accessor lists the writer alphabetically.

## Gates

`deno fmt --check`, `deno lint`, and `deno check` on the two files, and
the cache tests (`cell-cache`, `pattern-replication-sibling-race`:
7 passed, 60 steps, 0 failed). The full runner suite runs in CI.

## Coverage

The Coverage Check counts three lines: the `compileCacheWriter` getter in
the accessor. The two tests that use the seam assign the writer and clear
it; nothing reads it back, and a read-back would only re-light the lines.
Accepted below.

ACCEPT_COVERAGE_DEBT: packages/runner +3 lines
