### PR TITLE
refactor(runner): `StorageManager` takes a CFC schema document syncer through `accessForTestingOnly`; `#syncCfcSchemaDocument`

### DIFF
--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -8562,7 +8562,7 @@ supply; OW29/OW32/OW34 closed):
     referenced `cid:` document as arrived metadata integrates
     (deferred, deduped, failure-retried on a later frame), the
     standing-watch sibling of the explicit-sync path's existing
-    `syncCfcSchemaDocument` hydration; not unit-pinnable in the
+    `StorageManager.#syncCfcSchemaDocument` hydration; not unit-pinnable in the
     emulated harness (loopback frames already carry refs — a pin
     there is vacuous by construction), so the ON gate below is its
     red-first bench. (4) The verifier read's commit-set entry is

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -156,6 +156,17 @@ import {
   watchIdForEntry,
 } from "./v2-watch.ts";
 
+/**
+ * Syncs the CFC schema document a document's `cfc.schemaHash` names, and
+ * resolves to the sync's error if it had one: the shape of
+ * `StorageManager`'s own step, and of the syncer a test supplies in its
+ * place.
+ */
+export type CfcSchemaDocumentSyncer = (
+  space: MemorySpace,
+  document: EntityDocument | undefined,
+) => Promise<Error | undefined>;
+
 // A cell's CFC write-policy label lives at ["cfc"]. A mergeable write reads it as
 // part of the write; that read is dropped from its conflict set.
 const isCfcLabelPath = (path: readonly string[]): boolean =>
@@ -1066,10 +1077,12 @@ export class StorageManager implements IStorageManager {
   }
 
   /**
-   * The pending-load registration step and the linked-cell sync collector,
-   * which a test drives directly.
+   * The CFC schema document syncer a test may supply, the pending-load
+   * registration step, and the linked-cell sync collector, which a test
+   * drives directly.
    */
   get accessForTestingOnly(): {
+    cfcSchemaDocumentSyncer: CfcSchemaDocumentSyncer | undefined;
     registerPendingLoad(address: {
       space: MemorySpace;
       scope: CellScope;
@@ -1084,7 +1097,15 @@ export class StorageManager implements IStorageManager {
       seen: Set<unknown>,
     ): void;
   } {
+    // deno-lint-ignore no-this-alias
+    const outerThis = this;
     return {
+      get cfcSchemaDocumentSyncer() {
+        return outerThis.#cfcSchemaDocumentSyncer;
+      },
+      set cfcSchemaDocumentSyncer(value) {
+        outerThis.#cfcSchemaDocumentSyncer = value;
+      },
       registerPendingLoad: (address) => this.#registerPendingLoad(address),
       collectLinkedCellSyncs: (value, base, schema, promises, seen) =>
         this.#collectLinkedCellSyncs(value, base, schema, promises, seen),
@@ -1396,7 +1417,7 @@ export class StorageManager implements IStorageManager {
               ...this.#servingActingAs(),
             }, routeSignal),
         syncReplayDependencies: (document) =>
-          this.syncCfcSchemaDocument(space, document),
+          this.#syncCfcSchemaDocument(space, document),
         getTelemetry: () => this.#telemetry,
         eventAppendQueueStore: this.#eventAppendQueueStore,
         eventAppendPacing: this.#eventAppendPacing,
@@ -2003,6 +2024,9 @@ export class StorageManager implements IStorageManager {
   // per distinct failure keeps the surfacing readable. Bounded: at the cap the
   // set resets, trading a repeated line for an unbounded set.
   #loggedSyncFailures = new Set<string>();
+  // The syncer a test supplies in place of the CFC schema document sync;
+  // undefined means the manager's own.
+  #cfcSchemaDocumentSyncer: CfcSchemaDocumentSyncer | undefined = undefined;
 
   /**
    * Registers one pending load of `address` and returns its release step,
@@ -2197,7 +2221,7 @@ export class StorageManager implements IStorageManager {
         instance,
       );
       loadFailure = result.error;
-      const schemaFailure = await this.syncCfcSchemaDocument(
+      const schemaFailure = await this.#syncCfcSchemaDocument(
         space,
         (provider as {
           get?: (uri: URI, scope?: CellScope) => EntityDocument | undefined;
@@ -2268,14 +2292,18 @@ export class StorageManager implements IStorageManager {
   }
 
   /**
-   * TypeScript-private rather than a `#` name, because
-   * `test/storage-pending-load.test.ts` replaces this member by assignment,
-   * which a `#` method does not allow.
+   * Syncs the CFC schema document `document`'s `cfc.schemaHash` names, and
+   * resolves to the sync's error if it had one; a document naming none
+   * resolves at once. A syncer a test supplied stands in for the whole step.
    */
-  private async syncCfcSchemaDocument(
+  async #syncCfcSchemaDocument(
     space: MemorySpace,
     document: EntityDocument | undefined,
   ): Promise<Error | undefined> {
+    const syncer = this.#cfcSchemaDocumentSyncer;
+    if (syncer !== undefined) {
+      return syncer(space, document);
+    }
     const cfc = isObjectNotArray(document?.cfc) ? document.cfc : undefined;
     const schemaHash = cfc?.schemaHash;
     if (typeof schemaHash !== "string" || schemaHash.length === 0) {

--- a/packages/runner/test/storage-pending-load.test.ts
+++ b/packages/runner/test/storage-pending-load.test.ts
@@ -50,12 +50,7 @@ describe("storage pending-load generations", () => {
     const storage = runtime.storageManager as StorageManager;
     const schemaStarted = Promise.withResolvers<void>();
     const releaseSchema = Promise.withResolvers<void>();
-    // Replaced by assignment below, which its `private` rather than `#` name
-    // allows; the cast reaches only it.
-    const stubbed = storage as unknown as {
-      syncCfcSchemaDocument(): Promise<Error | undefined>;
-    };
-    stubbed.syncCfcSchemaDocument = async () => {
+    storage.accessForTestingOnly.cfcSchemaDocumentSyncer = async () => {
       schemaStarted.resolve();
       await releaseSchema.promise;
       return undefined;


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Fable 5.1)

The fifth of the stub-by-assignment seams, the same shape as #6967.
`StorageManager.syncCfcSchemaDocument` stayed TypeScript-`private` after
#6958 because `test/storage-pending-load.test.ts` replaced it by
assignment, holding a document pending until its schema load settled.

## What changed

The manager offers the seam the stub stood in for. A
`cfcSchemaDocumentSyncer` lives behind `accessForTestingOnly` as a getter
and setter, `undefined` unless a test sets it, and the sync step hands
the whole step to it when set. Two call sites reach the step (a
provider's replay-dependency sync, and the document sync itself), so the
choice lives at the head of the step rather than at each call. The
`CfcSchemaDocumentSyncer` type names the shape the step and a supplied
syncer share. Nothing in production sets it.

The test sets the syncer where it replaced the method; its assertions are
unchanged.

With nothing replacing it, the step is `#syncCfcSchemaDocument`, with the
doc comment it lacked, and the one live document that named it bare names
it with its class.

## Review

Reviewed by a `cf-review` pass: approve, no blocking findings and no
improvements. Its two nits are noted and left: the test does not clear the
syncer afterward, since the runtime is disposed per test; and the exported
syncer type has no importer beyond the accessor's own type, as with
#6967's writer.

## Gates

`deno fmt --check`, `deno lint`, and `deno check` on the two files, and
the schema-sync tests (`storage-pending-load`, `schema-doc-sync`:
2 passed, 27 steps, 0 failed). The full runner suite runs in CI.

## Coverage

The Coverage Check counts three lines: the `cfcSchemaDocumentSyncer`
getter in the accessor. The test that uses the seam assigns the syncer;
nothing reads it back, and a read-back would only re-light the lines.
Accepted below.

ACCEPT_COVERAGE_DEBT: packages/runner +3 lines
