### PR TITLE
tasks: a lint rule keeping `accessForTestingOnly` to the tests

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -151,6 +151,7 @@
       ]
     },
     "plugins": [
+      "./tasks/lint-access-for-testing-only.ts",
       "./tasks/lint-bench-console.ts",
       "./tasks/lint-inline-imports.ts",
       "./tasks/lint-self-import.ts"

--- a/docs/development/DEVELOPMENT.md
+++ b/docs/development/DEVELOPMENT.md
@@ -242,7 +242,11 @@ The way is a public getter named `accessForTestingOnly`, which hands over
 exactly what a test needs and nothing else. The name is the documentation:
 everything behind it is internals free to change, and a reader who sees it in
 a test knows the test is written against them. Its doc comment says what it
-exposes, and the name says the rest.
+exposes, and the name says the rest. The `cf-source/no-access-for-testing-only`
+lint rule (`tasks/lint-access-for-testing-only.ts`, registered in the root
+`deno.jsonc`) reports a read of the getter from anywhere but a test, a
+benchmark, or a file under a `test/`, `integration/`, or `bench/` directory, so
+a plain `deno lint` catches source that has come to depend on it.
 
 - Instance members go behind an instance getter; static members behind a
   static one. A class may have both, and never more than one of each.

--- a/tasks/lint-access-for-testing-only.test.ts
+++ b/tasks/lint-access-for-testing-only.test.ts
@@ -1,0 +1,187 @@
+/// <reference lib="deno.unstable" />
+
+/**
+ * Runs the `cf-source/no-access-for-testing-only` rule over short files and
+ * checks what it reports. `Deno.lint.runPlugin` takes the file name, which is
+ * what puts a case in or out of the rule's scope.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { dirname, fromFileUrl, resolve } from "@std/path";
+import plugin from "./lint-access-for-testing-only.ts";
+
+const REPO_ROOT = dirname(dirname(fromFileUrl(import.meta.url)));
+
+/** A source file's name, which puts every case in scope unless it says. */
+const SOURCE = "packages/fryer/src/fryer.ts";
+
+/** Lints `source` as the file at `fileName`, returning the messages. */
+function diagnose(source: string, fileName = SOURCE): string[] {
+  return Deno.lint.runPlugin(plugin, fileName, source).map((d) => d.message);
+}
+
+/** Distinguishing phrase of the rule's one message. */
+const REPORTED = "only a test, a benchmark, or a file serving one may read it";
+
+/** A class declaring the getter both ways, with an instance to reach. */
+const DECLARATION = `
+  class Fryer {
+    #temperature = 190;
+    get accessForTestingOnly(): { readonly temperature: number } {
+      return { temperature: this.#temperature };
+    }
+    static get accessForTestingOnly(): { readonly count: number } {
+      return { count: 1 };
+    }
+  }
+  const fryer = new Fryer();
+`;
+
+describe("lint-access-for-testing-only", () => {
+  it("reports a dot access", () => {
+    const messages = diagnose(`
+      ${DECLARATION}
+      fryer.accessForTestingOnly.temperature;
+    `);
+    expect(messages.length).toBe(1);
+    expect(messages[0]).toContain(REPORTED);
+  });
+
+  it("reports an access on the class", () => {
+    expect(
+      diagnose(`
+      ${DECLARATION}
+      Fryer.accessForTestingOnly.count;
+    `).length,
+    ).toBe(1);
+  });
+
+  it("reports an optional-chain access", () => {
+    expect(
+      diagnose(`
+      ${DECLARATION}
+      fryer?.accessForTestingOnly?.temperature;
+    `).length,
+    ).toBe(1);
+  });
+
+  it("reports a bracket access with the name as a string", () => {
+    expect(
+      diagnose(`
+      ${DECLARATION}
+      fryer["accessForTestingOnly"].temperature;
+    `).length,
+    ).toBe(1);
+  });
+
+  it("reports a destructuring of the name, plain and renamed", () => {
+    expect(
+      diagnose(`
+      ${DECLARATION}
+      const { accessForTestingOnly } = fryer;
+    `).length,
+    ).toBe(1);
+    expect(
+      diagnose(`
+      ${DECLARATION}
+      const { accessForTestingOnly: internals } = fryer;
+    `).length,
+    ).toBe(1);
+    expect(
+      diagnose(`
+      ${DECLARATION}
+      const { "accessForTestingOnly": internals } = fryer;
+    `).length,
+    ).toBe(1);
+  });
+
+  it("reports the declaring class reading its own getter", () => {
+    expect(
+      diagnose(`
+      class Fryer {
+        #temperature = 190;
+        get accessForTestingOnly(): { readonly temperature: number } {
+          return { temperature: this.#temperature };
+        }
+        fry(): number {
+          return this.accessForTestingOnly.temperature;
+        }
+      }
+    `).length,
+    ).toBe(1);
+  });
+
+  it("reports each access in a file once", () => {
+    expect(
+      diagnose(`
+      ${DECLARATION}
+      fryer.accessForTestingOnly.temperature;
+      Fryer.accessForTestingOnly.count;
+    `).length,
+    ).toBe(2);
+  });
+
+  it("returns nothing for the getter's declaration", () => {
+    expect(diagnose(DECLARATION)).toEqual([]);
+  });
+
+  it("returns nothing for an object literal with a property of the name", () => {
+    expect(diagnose(`
+      const shape = { accessForTestingOnly: { temperature: 190 } };
+    `)).toEqual([]);
+  });
+
+  it("returns nothing for a type naming the getter", () => {
+    expect(diagnose(`
+      ${DECLARATION}
+      type Internals = Fryer["accessForTestingOnly"];
+    `)).toEqual([]);
+  });
+
+  it("returns nothing for a computed access through a variable", () => {
+    expect(diagnose(`
+      ${DECLARATION}
+      const accessForTestingOnly = "temperature";
+      fryer[accessForTestingOnly];
+    `)).toEqual([]);
+  });
+
+  it("returns nothing for another member of a similar name", () => {
+    expect(diagnose(`
+      ${DECLARATION}
+      fryer.accessForTesting;
+      fryer.accessForTestingOnlyLater;
+    `)).toEqual([]);
+  });
+
+  it("returns nothing in a test, a benchmark, or a file serving one", () => {
+    const access = `
+      ${DECLARATION}
+      fryer.accessForTestingOnly.temperature;
+    `;
+    for (
+      const fileName of [
+        "packages/fryer/test/fryer.test.ts",
+        "packages/fryer/fryer.test.ts",
+        "packages/fryer/src/fryer.test.tsx",
+        "packages/fryer/bench/fryer.bench.ts",
+        "packages/fryer/test/helper.ts",
+        "packages/fryer/integration/harness.ts",
+        "packages/fryer/bench/fixtures/far-side.ts",
+      ]
+    ) {
+      expect(diagnose(access, fileName)).toEqual([]);
+    }
+  });
+
+  it("reads an absolute path relative to the repository root", () => {
+    const access = `
+      ${DECLARATION}
+      fryer.accessForTestingOnly.temperature;
+    `;
+    expect(diagnose(access, resolve(REPO_ROOT, SOURCE)).length).toBe(1);
+    expect(diagnose(access, resolve(REPO_ROOT, "packages/fryer/test/x.ts")))
+      .toEqual([]);
+  });
+});

--- a/tasks/lint-access-for-testing-only.ts
+++ b/tasks/lint-access-for-testing-only.ts
@@ -1,0 +1,81 @@
+/// <reference lib="deno.unstable" />
+
+/**
+ * A lint rule that keeps `accessForTestingOnly` to the tests.
+ *
+ * The getter hands a test the `#` members a class otherwise keeps to itself;
+ * "Making a private member reachable from a test" in
+ * docs/development/DEVELOPMENT.md is where it is defined. The name is the
+ * contract: what sits behind it is internals, free to change whenever the
+ * class does, and the only code entitled to depend on them is the test written
+ * against them. A read from anywhere else turns the getter into public API
+ * under a name that says it is not. So the rule reports every access to the
+ * name in a file that is not a test: `x.accessForTestingOnly`,
+ * `x?.accessForTestingOnly`, `x["accessForTestingOnly"]`, and a destructuring
+ * `{ accessForTestingOnly }`, the class's own methods included.
+ *
+ * A test, a benchmark, and the helpers and fixtures serving either are what
+ * `test-files.ts` says they are, and the rule reads nothing in those. It also
+ * reads nothing in the getter's own declaration, or in a type written
+ * `C["accessForTestingOnly"]`, which is erased before anything runs. The rule
+ * matches the name where it is written, and a reach that builds the name
+ * rather than writing it — `Reflect.get(x, "accessFor" + "TestingOnly")` —
+ * passes.
+ */
+
+import { dirname, fromFileUrl } from "@std/path";
+import { isTestFile } from "./test-files.ts";
+
+const REPO_ROOT = dirname(dirname(fromFileUrl(import.meta.url)));
+
+/** The getter's name, which is the whole of what the rule matches on. */
+const ACCESSOR = "accessForTestingOnly";
+
+const MESSAGE = "`accessForTestingOnly` hands a test a class's internals, " +
+  "and only a test, a benchmark, or a file serving one may read it. Reach " +
+  "what this needs through the class's public surface instead. See " +
+  '"Making a private member reachable from a test" in ' +
+  "docs/development/DEVELOPMENT.md.";
+
+/** The shape this rule reads off a member name or a property key. */
+interface KeyNode {
+  readonly type: string;
+  readonly name?: string;
+  readonly value?: unknown;
+}
+
+/**
+ * True when `key` is the getter's name as written: the identifier `x.name`
+ * and `{ name }` use, or the string literal `x["name"]` and `{ "name": y }`
+ * use. A computed identifier, `x[name]`, is a variable and not the name.
+ */
+function namesAccessor(key: KeyNode, computed: boolean): boolean {
+  if (key.type === "Literal") return key.value === ACCESSOR;
+  return !computed && key.type === "Identifier" && key.name === ACCESSOR;
+}
+
+export default {
+  name: "cf-source",
+  rules: {
+    "no-access-for-testing-only": {
+      create(context) {
+        if (isTestFile(REPO_ROOT, context.filename)) return {};
+
+        return {
+          MemberExpression(node) {
+            if (namesAccessor(node.property, node.computed)) {
+              context.report({ node, message: MESSAGE });
+            }
+          },
+
+          Property(node) {
+            if (node.parent.type !== "ObjectPattern") return;
+            if (namesAccessor(node.key, node.computed)) {
+              context.report({ node, message: MESSAGE });
+            }
+          },
+        };
+      },
+    },
+  },
+} satisfies Deno.lint.Plugin;

--- a/tasks/lint-self-import.ts
+++ b/tasks/lint-self-import.ts
@@ -25,31 +25,21 @@
  * because it is expected — `cf-imports/no-inline-type-import` rejects the form
  * outright, so one reaches here only in a file that has suppressed that rule.
  *
- * A file under a package's `test/` or `integration/` directory is exempt, as is
- * one named `*.test.ts` or `*.bench.ts` anywhere in the package. A test that
- * names its own package is reaching for the surface a consumer sees, which is
- * the thing it is there to check.
+ * A file under a package's `test/`, `integration/`, or `bench/` directory is
+ * exempt, as is one named `*.test.ts` or `*.bench.ts` anywhere in the package;
+ * `test-files.ts` is what draws that line. A test that names its own package
+ * is reaching for the surface a consumer sees, which is the thing it is there
+ * to check.
  *
  * See docs/development/DEVELOPMENT.md.
  */
 
 import { parse as parseJsonc } from "@std/jsonc";
 import { dirname, relative, resolve } from "@std/path";
+import { isTestFile } from "./test-files.ts";
 
 /** The file names a Deno configuration is allowed to take. */
 const CONFIG_FILE_NAMES = ["deno.json", "deno.jsonc"] as const;
-
-/** The directories of a package that hold its tests rather than its source. */
-const TEST_DIRECTORY_NAMES: ReadonlySet<string> = new Set([
-  "test",
-  "integration",
-]);
-
-/** The file names that are a test wherever in a package they sit. */
-const TEST_FILE_PATTERN = /\.(?:test|bench)\.tsx?$/;
-
-/** Either separator `relative()` can return, the host deciding which. */
-const PATH_SEPARATOR = /[/\\]/;
 
 /**
  * A type written `import("...").Name`, which holds its specifier inside a
@@ -140,14 +130,6 @@ function computeOwner(directory: string): OwningPackage | null {
   const name = config.name;
   if (typeof name !== "string" || name === "") return null;
   return { root: directory, name, exports: exportMap(config.exports) };
-}
-
-/** True when `filename` is one of its package's tests rather than its source. */
-function isTestFile(root: string, filename: string): boolean {
-  const parts = relative(root, filename).split(PATH_SEPARATOR);
-  const base = parts.pop() ?? "";
-  return TEST_FILE_PATTERN.test(base) ||
-    parts.some((part) => TEST_DIRECTORY_NAMES.has(part));
 }
 
 /** The specifier that reaches `to` from the file at `from`. */

--- a/tasks/test-files.test.ts
+++ b/tasks/test-files.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Pins which paths `isTestFile()` takes for a test, by file name and by the
+ * directories between the root and the file.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { isTestFile } from "./test-files.ts";
+
+const ROOT = "/repo";
+
+describe("isTestFile()", () => {
+  it("returns true for a `.test.ts` file beside its source", () => {
+    expect(isTestFile(ROOT, "/repo/packages/fuse/tree.test.ts")).toBe(true);
+  });
+
+  it("returns true for a `.test.tsx` and a `.bench.ts` file", () => {
+    expect(isTestFile(ROOT, "/repo/packages/p/src/view.test.tsx")).toBe(true);
+    expect(isTestFile(ROOT, "/repo/packages/p/src/stack.bench.ts")).toBe(true);
+  });
+
+  it("returns true for a helper under `test/`, `integration/`, or `bench/`", () => {
+    expect(isTestFile(ROOT, "/repo/packages/p/test/helper.ts")).toBe(true);
+    expect(isTestFile(ROOT, "/repo/packages/p/integration/harness.ts")).toBe(
+      true,
+    );
+    expect(isTestFile(ROOT, "/repo/packages/p/bench/fixtures/far.ts")).toBe(
+      true,
+    );
+  });
+
+  it("returns true for a `test` directory at any depth under the root", () => {
+    expect(isTestFile(ROOT, "/repo/packages/a/b/test/c/d.ts")).toBe(true);
+  });
+
+  it("returns false for a source file", () => {
+    expect(isTestFile(ROOT, "/repo/packages/p/src/stack.ts")).toBe(false);
+  });
+
+  it("returns false for a directory whose name only contains `test`", () => {
+    expect(isTestFile(ROOT, "/repo/packages/test-support/src/records.ts"))
+      .toBe(false);
+    expect(isTestFile(ROOT, "/repo/packages/p/tests/x.ts")).toBe(false);
+  });
+
+  it("returns false for a file whose name only contains `test`", () => {
+    expect(isTestFile(ROOT, "/repo/packages/p/src/test-runner.ts")).toBe(false);
+    expect(isTestFile(ROOT, "/repo/packages/p/src/contest.ts")).toBe(false);
+  });
+
+  it("counts only the directories between the root and the file", () => {
+    expect(isTestFile("/home/test/repo", "/home/test/repo/src/x.ts")).toBe(
+      false,
+    );
+    expect(isTestFile("/repo/pkg/test", "/repo/pkg/test/x.ts")).toBe(false);
+  });
+});

--- a/tasks/test-files.ts
+++ b/tasks/test-files.ts
@@ -1,0 +1,34 @@
+/**
+ * Which files of this repository are tests rather than source, for the lint
+ * rules that hold source to a rule and exempt the tests from it. A test, a
+ * benchmark, and the helpers and fixtures serving either all count: a file
+ * named `*.test.ts` or `*.bench.ts` (or `.tsx`) wherever it sits, and every
+ * file under a `test/`, `integration/`, or `bench/` directory.
+ */
+
+import { relative } from "@std/path";
+
+/** The directories that hold tests and benchmarks rather than source. */
+export const TEST_DIRECTORY_NAMES: ReadonlySet<string> = new Set([
+  "bench",
+  "integration",
+  "test",
+]);
+
+/** The file names that are a test or a benchmark wherever they sit. */
+export const TEST_FILE_PATTERN = /\.(?:test|bench)\.tsx?$/;
+
+/** Either separator `relative()` can return, the host deciding which. */
+export const PATH_SEPARATOR = /[/\\]/;
+
+/**
+ * True when the file at `path` is a test rather than source. Only the
+ * directories between `root` and the file are read, so a `test` directory
+ * above `root` does not make everything under it a test.
+ */
+export function isTestFile(root: string, path: string): boolean {
+  const parts = relative(root, path).split(PATH_SEPARATOR);
+  const base = parts.pop() ?? "";
+  return TEST_FILE_PATTERN.test(base) ||
+    parts.some((part) => TEST_DIRECTORY_NAMES.has(part));
+}


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Fable 5.1)

## What

A `deno lint` plugin rule, `cf-source/no-access-for-testing-only`, that reports a read of an `accessForTestingOnly` getter from any file that is not a test, a benchmark, or a helper or fixture serving one. The getter's name is its contract: everything behind it is internals, and only a test may depend on them. Source that reads it has turned the getter into public API under a name that says it is not.

The rule matches the name as written, at the AST level: `x.accessForTestingOnly`, `x?.accessForTestingOnly`, `x["accessForTestingOnly"]`, and a destructuring `{ accessForTestingOnly }`, including a class reading its own getter. The getter's declaration, a type written `C["accessForTestingOnly"]`, and a name built at run time (`Reflect.get` with a concatenated string, a computed access through a variable) pass. The prohibition is deliberately not airtight; it holds the name where it is written.

## Which files count as tests

`lint-self-import.ts` already carried a test-file classifier: `*.test.ts(x)` and `*.bench.ts(x)` anywhere, plus anything under a `test/` or `integration/` directory. That moves into `tasks/test-files.ts`, which both rules now read, and the directory set gains `bench/`. Benchmarks count as testing, and the five `bench/fixtures/*.ts` files (worker far-sides and codec fixtures) are bench support the same way `test/` helpers are test support.

The `bench/` addition is the one behavior change to `no-self-import`: those five fixtures become exempt from it. None of them names its own package, so no diagnostic changes today.

Paths are read relative to the repository root, so a `test` directory above the checkout does not put every file in scope of the exemption. `test-support` and `tests` are not `test`; a segment has to match whole.

## Measured

Run over the whole tree at `43f8cda85`:

| Scope | Diagnostics |
| --- | --- |
| Rule as landed (benchmarks exempt) | 0 |
| Same rule with benchmarks in scope | 1, `packages/utils/bench/index-tracking-stack.bench.ts:51` |

All 27 getter declarations across 26 source files are silent. A planted access in `packages/utils/src/` is reported by a real `deno lint` run under the rule's name, and with the matched name deliberately altered, 8 of the test's 14 steps fail.

## Gates

`deno lint` (5577 files), `deno fmt --check`, `deno check` on the five task files, `deno task check-docs development` (143 blocks), and the `tasks` suite: 786 passed, 0 failed.

## Docs

The "Making a private member reachable from a test" section of `DEVELOPMENT.md` gains a sentence naming the rule, its file, and what it exempts.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6971?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

