### PR TITLE
test(tasks): the type-check gate's coverage claim is derived, not asserted

### DIFF
--- a/.claude/rules/workspace-packages.md
+++ b/.claude/rules/workspace-packages.md
@@ -32,11 +32,18 @@ counts for nothing.
 
 `packages/utils/deno.jsonc` is a correct minimal example.
 
-## A new package is two edits
+## A new package is three edits
 
 Adding the directory is not enough. The package path also goes into the
 `"workspace"` array in the root `deno.jsonc`, or nothing in the repository
 knows it exists.
+
+The third edit is a checked path in `tasks/typecheck.ts`, so `deno task check`
+opens the package at all. `tasks/typecheck.test.ts` walks the members that root
+manifest declares, so the workspace edit is also what puts the package under
+the type check's coverage claim: with no path naming it, and no
+`UNCHECKED_TREES` entry saying why it has none, that test fails and names the
+files. Most packages take a single directory entry.
 
 ## Declare dependencies at the narrowest scope
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,7 +214,7 @@ that package's own `AGENTS.md`.
 
 #### Adding New Packages
 
-A new workspace package needs two edits, and the second one bites hard when it
+A new workspace package needs three edits, and the second one bites hard when it
 is missed:
 
 1. Its path added to the `"workspace"` array in the root `deno.jsonc`.
@@ -226,6 +226,12 @@ is missed:
    runs any of their test tasks, and refuses to start when one has no `"test"`
    entry, so what a missing entry costs is a message naming the member rather
    than a CI timeout. `packages/utils/deno.jsonc` is a correct example.
+3. A checked path in `tasks/typecheck.ts`, usually a single directory entry, so
+   `deno task check` opens the package at all. Naming the package in the
+   `workspace` array is what puts it under the type check's coverage claim, so a
+   package added there and left out here fails `tasks/typecheck.test.ts` with
+   its unchecked files named — unless it earns an `UNCHECKED_TREES` entry
+   recording why it has no path.
 
 When the package needs a dependency, follow `docs/development/DEPENDENCIES.md`.
 
@@ -248,14 +254,55 @@ difficulties getting coverage checks to pass, consider the information in
 
 `deno task check` type-checks a hand-maintained list of paths in
 `tasks/typecheck.ts` (`tasks/check.sh` owns the Deno version gate and delegates
-there), and that list now names every workspace package. Most are covered in
-full; a few are partial by design. The `*.input.ts` transformer fixtures under
-`schema-generator` and `ts-transformers` name ambient wrappers the transformer
-supplies, so they do not compile on their own and are left out. The declaration
-bundles under `packages/static/assets/types` are left out for the same reason:
-they are the ambient types handed to the in-memory pattern compiler, so they
-redeclare what `packages/html` declares and use ambient-context forms that do
-not compile beside the tree they describe.
+there). The list is written by hand; its completeness is not left to hand.
+`UNCHECKED_TREES` beside it records every tree the list leaves out together with
+the reason, and `tasks/typecheck.test.ts` walks the workspace that `deno.jsonc`
+declares and fails — naming the files — on any module that is neither checked
+nor covered by one of those entries. That population is every extension the
+checker opens, JavaScript included: `deno check` type-checks a `.js` file
+carrying `// @ts-check`, so a claim stated over TypeScript alone would be
+narrower than the gate it describes. A directory left out on purpose and one
+left out by accident look identical in a list of paths, so the record is what
+separates them: a tree nobody decided about fails the test rather than passing
+in silence. Adding an exemption means adding an entry that says why.
+
+Four trees are recorded as unchecked. `packages/schema-generator/test/fixtures`
+and `packages/ts-transformers/test/fixtures` are fixture corpora — the inputs
+those tests feed their transformer, and the outputs they compare against — and
+`packages/static/assets/types` is the ambient environment a pattern compiles
+against, handed to the in-memory compiler. What earns all three the exemption is
+holding data rather than modules this repository builds; neither corpus compiles
+as a unit, though files within one may well compile alone. The fourth is
+`packages/patterns`, which the next paragraph covers.
+
+An exemption's reason is held to being true of every file it matches, which is
+what decides how wide the entry may be. Two entries divide `packages/patterns`,
+because two different things happen to the files there. The one pointing at
+`deno task cfcheck` may excuse only files the collector in
+`tasks/pattern-files.ts` hands that gate, and no single entry may span both
+sides of that line; a test cross-checks both against the collector itself. The
+other covers pattern tests, which the lane that runs them also type-checks —
+`deno test` for a `.test.ts`, since `packages/patterns` runs without
+`--no-check`, and `cf test` for a `.test.tsx`, whose harness reports a type
+error as a failed test. That entry is scoped to what those two lanes take, not
+to the test suffix in general. A test module under another extension has no
+lane; a `.browser.test.ts` is kept out of the `deno test` pass and bundled to
+its browser by a step that transpiles without checking; and a nested
+`integration` tree is excluded from that pass by the package's test config while
+the `integration` task names its top-level paths explicitly. Each falls through
+and is reported unless a checked path names it. An entry claiming coverage is
+the one that can mislead most quietly, since a file it wrongly matches is one
+every later reader believes is checked — and where these keep going wrong is a
+predicate matching by a file's shape while the reason beside it names a lane,
+the two agreeing in the middle and parting at the edges.
+
+The reasons that do not name another gate say what a tree _is_ rather than
+asserting a property of each file in it. That is why the three above are
+described as corpora and as an ambient environment: none is a set of modules the
+repository builds, which is what earns the exemption. Individual files in them
+may well compile alone, so a reason claiming that none of them does would be
+false the moment one did — a universal quantifier over a corpus is the shape to
+avoid when writing one of these.
 
 Patterns are the exception `deno task check` does not own. It lists some pattern
 directories and checks them through the automatic-JSX environment the rest of

--- a/tasks/typecheck.test.ts
+++ b/tasks/typecheck.test.ts
@@ -1,30 +1,136 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { walk } from "@std/fs";
-import { dirname, fromFileUrl, join, relative } from "@std/path";
+import { parse as parseJsonc } from "@std/jsonc";
+import { dirname, fromFileUrl, globToRegExp, join, relative } from "@std/path";
 
 import { recordsSpooledBy } from "@commonfabric/test-support/records";
 
 import {
   checkGroup,
   collectPathsByScope,
+  isTestModule,
   main,
   runTypecheck,
   scopeOfPath,
   selectScopes,
+  UNCHECKED_TREES,
+  type UncheckedTree,
 } from "./typecheck.ts";
+import { collectPatternFiles, isPatternSource } from "./pattern-files.ts";
+import { readWorkspaceMembers } from "./workspace-tests.ts";
 
 const REPO_ROOT = dirname(dirname(fromFileUrl(import.meta.url)));
 
 /**
- * Trees the task checks in full. What a package's own test run checks is
- * whatever its test files happen to import, and the `tasks` run passes
- * `--no-check`, so coverage here is what the repository actually relies
- * on. A tree checked only in part belongs elsewhere:
- * `packages/static/assets/types` holds declaration bundles that do not
- * compile on their own, and patterns answer to `deno task cfcheck`.
+ * The extensions a checked path can put in front of the type checker.
+ *
+ * JavaScript earns its place here: `deno check` opens a `.js` or `.jsx` file
+ * a checked path names, and type-checks the ones carrying `// @ts-check`,
+ * which is a diagnostic this repository would want and would otherwise lose
+ * in silence. A coverage claim stated over a narrower population than the
+ * gate actually reads is the defect this whole test exists to catch, so the
+ * population is every module extension the checker accepts rather than the
+ * ones the tree happens to hold today.
  */
-const FULLY_CHECKED_TREES = ["packages/ui", "tasks"];
+const CHECKABLE_EXTENSIONS = [
+  ".ts",
+  ".tsx",
+  ".mts",
+  ".cts",
+  ".js",
+  ".jsx",
+  ".mjs",
+  ".cjs",
+];
+
+/** Whether a checked path or unchecked tree covers a repository file. */
+function covers(tree: string, file: string): boolean {
+  return file === tree || file.startsWith(`${tree}/`);
+}
+
+/**
+ * The paths a manifest's `exclude` keeps `deno check` from opening.
+ *
+ * A checked path names a directory, and this test reads that as covering the
+ * tree beneath it — which is true only of the files the checker itself would
+ * reach. Deno drops these before it walks, so a module under one is opened by
+ * nothing however a path above it reads. Every manifest is consulted rather
+ * than the root alone, because a member declares its own and the checker
+ * honors it.
+ *
+ * These are matched against a repository-relative path, so they filter the
+ * walk's results rather than steering it: `walk()` takes a `skip`, but it
+ * tests the absolute path an entry carries, which an anchored pattern from
+ * `globToRegExp` never matches, and the exclusion would quietly stop firing.
+ *
+ * Only the top-level `exclude` counts. A `fmt`, `lint` or `test` block
+ * carries one for its own subcommand, and reading such a block as though it
+ * reached the type check would drop files the checker does open — the same
+ * defect pointed the other way, and the worse direction, since it shrinks
+ * what the gate is held to rather than widening it.
+ */
+async function excludedByManifest(
+  root: string,
+  members: readonly string[],
+): Promise<RegExp[]> {
+  const patterns: RegExp[] = [];
+  for (const directory of ["", ...members]) {
+    // `deno.json` wins where both exist, and Deno ignores the other whole.
+    let text: string | undefined;
+    for (const name of ["deno.json", "deno.jsonc"]) {
+      text = await Deno.readTextFile(join(root, directory, name))
+        .catch(() => undefined);
+      if (text !== undefined) break;
+    }
+    if (text === undefined) continue;
+    const manifest = parseJsonc(text) as { exclude?: string[] };
+    for (const pattern of manifest.exclude ?? []) {
+      const stripped = pattern.replace(/^\.\//, "");
+      const scoped = directory === "" ? stripped : `${directory}/${stripped}`;
+      patterns.push(
+        globToRegExp(scoped.endsWith("/") ? `${scoped}**` : scoped, {
+          globstar: true,
+        }),
+      );
+    }
+  }
+  return patterns;
+}
+
+/**
+ * The declared members, less any that another member already contains.
+ *
+ * The workspace nests: `packages/patterns/auth` is a member and so is the
+ * tree above it. Walking both reaches the inner modules twice, and while a
+ * set of paths absorbs that, a count of them does not — which is how two
+ * honest censuses of this repository come to disagree. Reducing the forest
+ * first makes the population walked the same thing as the population counted.
+ */
+function outermost(members: readonly string[]): string[] {
+  const paths = members.map((member) => member.replace(/^\.\//, ""));
+  return paths.filter((path) =>
+    !paths.some((other) => other !== path && path.startsWith(`${other}/`))
+  );
+}
+
+/**
+ * Every recorded entry excusing a file, not merely the first.
+ *
+ * Entries are allowed to overlap, so stopping at the first match would leave
+ * a later one unexamined: its reason would go unread by anything checking
+ * whether reasons are true, and an entry can hide behind one written earlier.
+ */
+function excusedBy(file: string): UncheckedTree[] {
+  return UNCHECKED_TREES.filter((entry) =>
+    covers(entry.tree, file) && (entry.matches?.(file) ?? true)
+  );
+}
+
+/** Whether a recorded entry excuses a file from the check. */
+function excuses(file: string): boolean {
+  return excusedBy(file).length > 0;
+}
 
 describe("typecheck", () => {
   describe("scopeOfPath()", () => {
@@ -68,53 +174,203 @@ describe("typecheck", () => {
       }
     });
 
-    it("covers every TypeScript file in the trees it checks in full", async () => {
-      // An entry naming part of a tree type-checks that part and reports
-      // a clean run over the rest, so what this asserts is coverage
-      // rather than the shape of the entry that gives it. These trees
-      // are read from disk rather than from a fixture, so a directory
-      // added to one later is held to the same claim.
+    it("names every workspace module no recorded tree excuses", async () => {
+      // The membership this walks is the workspace the repository declares,
+      // not a list restated here, so a package added to `deno.jsonc` is held
+      // to the claim on the day it arrives rather than on the day somebody
+      // remembers to add it. What the assertion buys is the distinction the
+      // checked paths cannot draw on their own: a tree left out on purpose
+      // and a tree left out by accident are both simply absent from the
+      // list, and this fails on the second while `UNCHECKED_TREES` excuses
+      // the first. Naming the files is the point of the failure — the
+      // defect this guards against is a gate reporting a clean run over
+      // code it never opened, which no green result can reveal.
 
       const checked = [...(await collectPathsByScope(REPO_ROOT)).values()]
         .flat();
+      const declared = await readWorkspaceMembers(
+        join(REPO_ROOT, "deno.jsonc"),
+      );
+      const members = outermost(declared);
+      // Every declared member, not the outermost ones: a nested member's
+      // manifest carries its own `exclude` and the checker reads it.
+      const dropped = await excludedByManifest(
+        REPO_ROOT,
+        declared.map((member) => member.replace(/^\.\//, "")),
+      );
       const uncovered: string[] = [];
-      for (const tree of FULLY_CHECKED_TREES) {
+      for (const member of members) {
         for await (
-          const entry of walk(join(REPO_ROOT, tree), {
+          const entry of walk(join(REPO_ROOT, member), {
             includeDirs: false,
-            exts: [".ts", ".tsx"],
+            exts: CHECKABLE_EXTENSIONS,
           })
         ) {
           const file = relative(REPO_ROOT, entry.path);
-          const covered = checked.some((checkPath) =>
-            file === checkPath || file.startsWith(`${checkPath}/`)
-          );
-          if (!covered) uncovered.push(file);
+          if (dropped.some((pattern) => pattern.test(file))) continue;
+          if (checked.some((checkPath) => covers(checkPath, file))) continue;
+          if (excuses(file)) continue;
+          uncovered.push(file);
         }
       }
-      expect(uncovered).toEqual([]);
+      expect([...new Set(uncovered)].sort()).toEqual([]);
     });
 
-    it("includes iframe guests of either extension under arbitrary names", async () => {
+    it("splits the patterns tree where cfcheck's own population splits", async () => {
+      // Two entries divide this tree, and only one of them points at
+      // `deno task cfcheck`. That is the one worth pinning: it reads as
+      // coverage, so a file it wrongly matches is a file every later reader
+      // believes is checked. It is held to that gate's own collector rather
+      // than to prose, so a change in cfcheck's population fails here
+      // instead of leaving the reason quietly false.
+      //
+      // The other direction — that no file cfcheck walks is a pattern test
+      // — is not asserted here, because it cannot fail. `isPatternSource()`
+      // filters test files out before the collector returns, so a walk of
+      // the tree can only ever confirm it. The test below pins that
+      // exclusion at its source instead.
+
+      // Rooted at an absolute directory, since `collectPatternFiles()`
+      // otherwise resolves its default against the working directory, which
+      // for a test run is the package rather than the repository.
+      const patternsRoot = join(REPO_ROOT, "packages", "patterns");
+      const owned = new Set(
+        (await collectPatternFiles(patternsRoot)).map((file) =>
+          relative(REPO_ROOT, file)
+        ),
+      );
+      const checkedPaths = [...(await collectPathsByScope(REPO_ROOT)).values()]
+        .flat();
+      const unchecked: string[] = [];
+      const straddling = new Set<string>();
+      const excusedOwned = new Map<UncheckedTree, boolean>();
+      for await (
+        const entry of walk(join(REPO_ROOT, "packages", "patterns"), {
+          includeDirs: false,
+          exts: CHECKABLE_EXTENSIONS,
+        })
+      ) {
+        const file = relative(REPO_ROOT, entry.path);
+        if (checkedPaths.some((checkPath) => covers(checkPath, file))) continue;
+        // A non-test file left to cfcheck has to be one cfcheck walks.
+        if (!isTestModule(file) && !owned.has(file)) unchecked.push(file);
+        // And no entry may speak for files on both sides of that line,
+        // because a single reason cannot be true of both. Without this, an
+        // entry widened back into a blanket would excuse the tests under the
+        // reason written for the sources, which is the failure this split
+        // exists to prevent and the one no coverage count would show. Every
+        // entry matching the file is examined rather than the first, so a
+        // widened one cannot shelter behind a narrower entry declared above
+        // it and never be looked at.
+        for (const excuse of excusedBy(file)) {
+          const seen = excusedOwned.get(excuse);
+          if (seen !== undefined && seen !== owned.has(file)) {
+            straddling.add(excuse.because);
+          }
+          excusedOwned.set(excuse, owned.has(file));
+        }
+      }
+      expect(unchecked.sort()).toEqual([]);
+      expect([...straddling]).toEqual([]);
+    });
+
+    it("pins the collector exclusion the pattern-test entry rests on", () => {
+      // That entry says cfcheck never walks a pattern test. Nothing in this
+      // package maintains that — it holds only while `isPatternSource()`
+      // excludes test files — so it is asserted at its source, where it
+      // can fail, rather than over a tree the collector has already
+      // filtered. If cfcheck starts type-checking pattern tests, this is
+      // what says so, and the entry needs rewriting.
+
+      for (
+        const file of [
+          "packages/patterns/example/main.test.ts",
+          "packages/patterns/example/main.test.tsx",
+        ]
+      ) {
+        expect(isPatternSource(file), file).toBe(false);
+      }
+      // Paired with the other direction, so a predicate that rejected
+      // everything would not pass as an exclusion.
+      expect(isPatternSource("packages/patterns/example/main.tsx")).toBe(true);
+    });
+
+    it("records no entry that matches nothing in the tree", async () => {
+      // A `matches` narrowed past the files it was written for leaves an
+      // entry that excuses nobody, which reads as a live exemption and is
+      // not one. The stale-tree test above catches a directory that went
+      // away; this catches a predicate that did.
+
+      const matched = new Map<UncheckedTree, number>(
+        UNCHECKED_TREES.map((entry) => [entry, 0]),
+      );
+      for (const entry of UNCHECKED_TREES) {
+        for await (
+          const found of walk(join(REPO_ROOT, entry.tree), {
+            includeDirs: false,
+            exts: CHECKABLE_EXTENSIONS,
+          })
+        ) {
+          const file = relative(REPO_ROOT, found.path);
+          if (entry.matches?.(file) ?? true) {
+            matched.set(entry, matched.get(entry)! + 1);
+          }
+        }
+      }
+      const empty = [...matched].filter(([, count]) => count === 0);
+      expect(empty.map(([entry]) => entry.because)).toEqual([]);
+    });
+
+    it("records no tree that has left the repository", async () => {
+      // An entry outliving its tree excuses a path nothing occupies, and
+      // would go on excusing whatever later took the name.
+
+      for (const { tree } of UNCHECKED_TREES) {
+        const stat = await Deno.stat(join(REPO_ROOT, tree)).catch(() => null);
+        expect(stat?.isDirectory, tree).toBe(true);
+      }
+    });
+
+    it("takes an iframe guest at any depth and leaves other guests to cfcheck", async () => {
+      // `isPatternSource()` sets a guest or contract aside only under an
+      // `iframe-` directory, so that prefix is the condition this task's
+      // claim on them rests on. A same-named file elsewhere is a pattern
+      // source cfcheck compiles, and taking it here too would put one file
+      // through two JSX environments that disagree.
+
       const root = await Deno.makeTempDir({ prefix: "typecheck-guests-" });
       try {
         for (
-          const [name, guest] of [
-            ["custom-board", "guest.ts"],
-            ["plain-name", "guest.tsx"],
+          const [directory, file] of [
+            ["iframe-board", "guest.ts"],
+            ["iframe-board/nested-canvas", "guest.tsx"],
+            ["iframe-board", "contract.ts"],
+            ["plain-name", "guest.ts"],
+            ["plain-name", "contract.ts"],
           ]
         ) {
-          const directory = join(root, "packages", "patterns", name);
-          await Deno.mkdir(directory, { recursive: true });
-          await Deno.writeTextFile(join(directory, guest), "export {};\n");
+          const path = join(
+            root,
+            "packages",
+            "patterns",
+            ...directory.split("/"),
+          );
+          await Deno.mkdir(path, { recursive: true });
+          await Deno.writeTextFile(join(path, file), "export {};\n");
         }
 
-        const byScope = await collectPathsByScope(root);
-        expect(byScope.get("patterns")).toContain(
-          "packages/patterns/custom-board/guest.ts",
+        const patterns = (await collectPathsByScope(root)).get("patterns") ??
+          [];
+        expect(patterns).toContain("packages/patterns/iframe-board/guest.ts");
+        expect(patterns).toContain(
+          "packages/patterns/iframe-board/nested-canvas/guest.tsx",
         );
-        expect(byScope.get("patterns")).toContain(
-          "packages/patterns/plain-name/guest.tsx",
+        expect(patterns).toContain(
+          "packages/patterns/iframe-board/contract.ts",
+        );
+        expect(patterns).not.toContain("packages/patterns/plain-name/guest.ts");
+        expect(patterns).not.toContain(
+          "packages/patterns/plain-name/contract.ts",
         );
       } finally {
         await Deno.remove(root, { recursive: true });
@@ -252,6 +508,100 @@ describe("typecheck", () => {
         true,
       );
     });
+  });
+});
+
+describe("excludedByManifest()", () => {
+  it("drops what the manifest excludes and keeps everything else", async () => {
+    // Over-matching here shrinks the population silently, which is the one
+    // direction that turns this file's whole subject into a false green, so
+    // the lookalikes are asserted beside the matches.
+
+    const declared = await readWorkspaceMembers(join(REPO_ROOT, "deno.jsonc"));
+    const dropped = await excludedByManifest(
+      REPO_ROOT,
+      declared.map((member) => member.replace(/^\.\//, "")),
+    );
+    const matches = (file: string) =>
+      dropped.some((pattern) => pattern.test(file));
+
+    expect(matches("packages/shell/dist/bundle.ts")).toBe(true);
+    expect(matches("packages/x/node_modules/dep/index.js")).toBe(true);
+    expect(matches("docs/history/old-plan.ts")).toBe(true);
+    expect(matches("packages/runner/src/runner.ts")).toBe(false);
+    // A directory whose name merely starts with an excluded one stays.
+    expect(matches("packages/x/distribution/index.ts")).toBe(false);
+    expect(matches("docs/history-of-things/note.ts")).toBe(false);
+    // And a subcommand's own exclusion is not the type check's. These two
+    // trees are named by `test` and `fmt` blocks in their members, and
+    // `deno check` opens both, so dropping them would leave the gate
+    // claiming less than it covers.
+    expect(matches("packages/patterns/integration/all.test.ts")).toBe(false);
+    expect(matches("packages/js-compiler/test/fixtures/program.ts")).toBe(
+      false,
+    );
+  });
+
+  it("reads a member's own exclude, resolved against that member", async () => {
+    // Stated over a fixture because no member of this workspace declares a
+    // top-level `exclude` today. Asserted against the tree, reading the
+    // members would be indistinguishable from reading only the root, and an
+    // assertion that cannot tell the two apart is not evidence for either.
+
+    const root = await Deno.makeTempDir({ prefix: "typecheck-excludes-" });
+    try {
+      await Deno.writeTextFile(
+        join(root, "deno.jsonc"),
+        `{ "workspace": ["./packages/thing"], "exclude": ["**/dist/"] }`,
+      );
+      await Deno.mkdir(join(root, "packages", "thing"), { recursive: true });
+      await Deno.writeTextFile(
+        join(root, "packages", "thing", "deno.jsonc"),
+        `{ "exclude": ["generated/"] }`,
+      );
+
+      const dropped = await excludedByManifest(root, ["packages/thing"]);
+      const matches = (file: string) =>
+        dropped.some((pattern) => pattern.test(file));
+
+      expect(matches("packages/thing/generated/schema.ts")).toBe(true);
+      // Resolved against the member, so the same name elsewhere survives.
+      expect(matches("packages/other/generated/schema.ts")).toBe(false);
+      expect(matches("generated/schema.ts")).toBe(false);
+      // And the root's own exclusions still apply everywhere.
+      expect(matches("packages/thing/dist/out.js")).toBe(true);
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  });
+});
+
+describe("outermost()", () => {
+  it("drops a member another member contains, and keeps the rest", () => {
+    // Dropping too much is the dangerous direction: a member wrongly
+    // removed here is a tree the coverage walk stops visiting, which is
+    // the silence this file exists to break. So the sibling and the
+    // lookalike prefix are asserted alongside the nesting.
+
+    expect(outermost([
+      "./packages/patterns",
+      "./packages/patterns/auth",
+      "./packages/patterns-adjacent",
+      "./packages/runner",
+      "./tasks",
+    ])).toEqual([
+      "packages/patterns",
+      "packages/patterns-adjacent",
+      "packages/runner",
+      "tasks",
+    ]);
+  });
+
+  it("keeps every member when the workspace nests nowhere", () => {
+    expect(outermost(["./packages/api", "./scripts"])).toEqual([
+      "packages/api",
+      "scripts",
+    ]);
   });
 });
 

--- a/tasks/typecheck.test.ts
+++ b/tasks/typecheck.test.ts
@@ -509,99 +509,101 @@ describe("typecheck", () => {
       );
     });
   });
-});
 
-describe("excludedByManifest()", () => {
-  it("drops what the manifest excludes and keeps everything else", async () => {
-    // Over-matching here shrinks the population silently, which is the one
-    // direction that turns this file's whole subject into a false green, so
-    // the lookalikes are asserted beside the matches.
+  describe("excludedByManifest()", () => {
+    it("drops what the manifest excludes and keeps everything else", async () => {
+      // Over-matching here shrinks the population silently, which is the one
+      // direction that turns this file's whole subject into a false green, so
+      // the lookalikes are asserted beside the matches.
 
-    const declared = await readWorkspaceMembers(join(REPO_ROOT, "deno.jsonc"));
-    const dropped = await excludedByManifest(
-      REPO_ROOT,
-      declared.map((member) => member.replace(/^\.\//, "")),
-    );
-    const matches = (file: string) =>
-      dropped.some((pattern) => pattern.test(file));
-
-    expect(matches("packages/shell/dist/bundle.ts")).toBe(true);
-    expect(matches("packages/x/node_modules/dep/index.js")).toBe(true);
-    expect(matches("docs/history/old-plan.ts")).toBe(true);
-    expect(matches("packages/runner/src/runner.ts")).toBe(false);
-    // A directory whose name merely starts with an excluded one stays.
-    expect(matches("packages/x/distribution/index.ts")).toBe(false);
-    expect(matches("docs/history-of-things/note.ts")).toBe(false);
-    // And a subcommand's own exclusion is not the type check's. These two
-    // trees are named by `test` and `fmt` blocks in their members, and
-    // `deno check` opens both, so dropping them would leave the gate
-    // claiming less than it covers.
-    expect(matches("packages/patterns/integration/all.test.ts")).toBe(false);
-    expect(matches("packages/js-compiler/test/fixtures/program.ts")).toBe(
-      false,
-    );
-  });
-
-  it("reads a member's own exclude, resolved against that member", async () => {
-    // Stated over a fixture because no member of this workspace declares a
-    // top-level `exclude` today. Asserted against the tree, reading the
-    // members would be indistinguishable from reading only the root, and an
-    // assertion that cannot tell the two apart is not evidence for either.
-
-    const root = await Deno.makeTempDir({ prefix: "typecheck-excludes-" });
-    try {
-      await Deno.writeTextFile(
-        join(root, "deno.jsonc"),
-        `{ "workspace": ["./packages/thing"], "exclude": ["**/dist/"] }`,
+      const declared = await readWorkspaceMembers(
+        join(REPO_ROOT, "deno.jsonc"),
       );
-      await Deno.mkdir(join(root, "packages", "thing"), { recursive: true });
-      await Deno.writeTextFile(
-        join(root, "packages", "thing", "deno.jsonc"),
-        `{ "exclude": ["generated/"] }`,
+      const dropped = await excludedByManifest(
+        REPO_ROOT,
+        declared.map((member) => member.replace(/^\.\//, "")),
       );
-
-      const dropped = await excludedByManifest(root, ["packages/thing"]);
       const matches = (file: string) =>
         dropped.some((pattern) => pattern.test(file));
 
-      expect(matches("packages/thing/generated/schema.ts")).toBe(true);
-      // Resolved against the member, so the same name elsewhere survives.
-      expect(matches("packages/other/generated/schema.ts")).toBe(false);
-      expect(matches("generated/schema.ts")).toBe(false);
-      // And the root's own exclusions still apply everywhere.
-      expect(matches("packages/thing/dist/out.js")).toBe(true);
-    } finally {
-      await Deno.remove(root, { recursive: true });
-    }
+      expect(matches("packages/shell/dist/bundle.ts")).toBe(true);
+      expect(matches("packages/x/node_modules/dep/index.js")).toBe(true);
+      expect(matches("docs/history/old-plan.ts")).toBe(true);
+      expect(matches("packages/runner/src/runner.ts")).toBe(false);
+      // A directory whose name merely starts with an excluded one stays.
+      expect(matches("packages/x/distribution/index.ts")).toBe(false);
+      expect(matches("docs/history-of-things/note.ts")).toBe(false);
+      // And a subcommand's own exclusion is not the type check's. These two
+      // trees are named by `test` and `fmt` blocks in their members, and
+      // `deno check` opens both, so dropping them would leave the gate
+      // claiming less than it covers.
+      expect(matches("packages/patterns/integration/all.test.ts")).toBe(false);
+      expect(matches("packages/js-compiler/test/fixtures/program.ts")).toBe(
+        false,
+      );
+    });
+
+    it("reads a member's own exclude, resolved against that member", async () => {
+      // Stated over a fixture because no member of this workspace declares a
+      // top-level `exclude` today. Asserted against the tree, reading the
+      // members would be indistinguishable from reading only the root, and an
+      // assertion that cannot tell the two apart is not evidence for either.
+
+      const root = await Deno.makeTempDir({ prefix: "typecheck-excludes-" });
+      try {
+        await Deno.writeTextFile(
+          join(root, "deno.jsonc"),
+          `{ "workspace": ["./packages/thing"], "exclude": ["**/dist/"] }`,
+        );
+        await Deno.mkdir(join(root, "packages", "thing"), { recursive: true });
+        await Deno.writeTextFile(
+          join(root, "packages", "thing", "deno.jsonc"),
+          `{ "exclude": ["generated/"] }`,
+        );
+
+        const dropped = await excludedByManifest(root, ["packages/thing"]);
+        const matches = (file: string) =>
+          dropped.some((pattern) => pattern.test(file));
+
+        expect(matches("packages/thing/generated/schema.ts")).toBe(true);
+        // Resolved against the member, so the same name elsewhere survives.
+        expect(matches("packages/other/generated/schema.ts")).toBe(false);
+        expect(matches("generated/schema.ts")).toBe(false);
+        // And the root's own exclusions still apply everywhere.
+        expect(matches("packages/thing/dist/out.js")).toBe(true);
+      } finally {
+        await Deno.remove(root, { recursive: true });
+      }
+    });
   });
-});
 
-describe("outermost()", () => {
-  it("drops a member another member contains, and keeps the rest", () => {
-    // Dropping too much is the dangerous direction: a member wrongly
-    // removed here is a tree the coverage walk stops visiting, which is
-    // the silence this file exists to break. So the sibling and the
-    // lookalike prefix are asserted alongside the nesting.
+  describe("outermost()", () => {
+    it("drops a member another member contains, and keeps the rest", () => {
+      // Dropping too much is the dangerous direction: a member wrongly
+      // removed here is a tree the coverage walk stops visiting, which is
+      // the silence this file exists to break. So the sibling and the
+      // lookalike prefix are asserted alongside the nesting.
 
-    expect(outermost([
-      "./packages/patterns",
-      "./packages/patterns/auth",
-      "./packages/patterns-adjacent",
-      "./packages/runner",
-      "./tasks",
-    ])).toEqual([
-      "packages/patterns",
-      "packages/patterns-adjacent",
-      "packages/runner",
-      "tasks",
-    ]);
-  });
+      expect(outermost([
+        "./packages/patterns",
+        "./packages/patterns/auth",
+        "./packages/patterns-adjacent",
+        "./packages/runner",
+        "./tasks",
+      ])).toEqual([
+        "packages/patterns",
+        "packages/patterns-adjacent",
+        "packages/runner",
+        "tasks",
+      ]);
+    });
 
-  it("keeps every member when the workspace nests nowhere", () => {
-    expect(outermost(["./packages/api", "./scripts"])).toEqual([
-      "packages/api",
-      "scripts",
-    ]);
+    it("keeps every member when the workspace nests nowhere", () => {
+      expect(outermost(["./packages/api", "./scripts"])).toEqual([
+        "packages/api",
+        "scripts",
+      ]);
+    });
   });
 });
 

--- a/tasks/typecheck.test.ts
+++ b/tasks/typecheck.test.ts
@@ -86,20 +86,23 @@ async function excludedByManifest(
     if (text === undefined) continue;
     const manifest = parseJsonc(text) as { exclude?: string[] };
     for (const pattern of manifest.exclude ?? []) {
-      const stripped = pattern.replace(/^\.\//, "");
-      // Deno reads a leading `!` as un-excluding what a broader entry took,
-      // and `globToRegExp` reads it as a literal character. The mismatch is
-      // silent and lands on the shrinking side: the entry never matches, the
+      // Deno un-excludes on a bare leading `!` and on nothing else: measured
+      // against 2.9.4, `!build/keep.ts` restores that file to the check while
+      // `./!build/keep.ts` restores nothing and matches nothing, so the prefix
+      // is not stripped before the negation is looked for. `globToRegExp`
+      // reads `!` as a literal either way, which for the spelling Deno
+      // negates lands on the shrinking side: the entry matches nothing, the
       // broader exclusion goes on firing, and a file the checker opens is
-      // counted as excused. Refusing it fails this file instead. Read after
-      // the prefix strip, so that `./!build/` is refused as `!build/` is.
-      if (stripped.startsWith("!")) {
+      // counted as excused. Refusing it fails this file instead. Read on the
+      // pattern as written, which is what Deno reads.
+      if (pattern.startsWith("!")) {
         throw new Error(
           `${join(directory, "deno.json(c)")} un-excludes ${pattern}, which ` +
             `this check cannot read; teach it the negation or the census is ` +
             `short by whatever the entry restores.`,
         );
       }
+      const stripped = pattern.replace(/^\.\//, "");
       const scoped = directory === "" ? stripped : `${directory}/${stripped}`;
       patterns.push(
         globToRegExp(scoped.endsWith("/") ? `${scoped}**` : scoped, {
@@ -576,17 +579,18 @@ describe("typecheck", () => {
           /un-excludes/,
         );
 
-        // The same entry written with the `./` prefix the loop strips. Read
-        // before the strip, this spelling passes the guard and reaches
-        // `globToRegExp` as a literal.
+        // The lookalike Deno does not negate. `./!build/keep.ts` restores
+        // nothing and matches nothing, so it is an ordinary entry and this
+        // check has no reason to refuse it — the boundary the guard draws is
+        // the one Deno draws, and a fixture on each side is what says so.
         await Deno.writeTextFile(
           join(root, "deno.jsonc"),
           `{ "workspace": [], "exclude": ["**/build/", "./!build/keep.ts"] }`,
         );
 
-        await expect(excludedByManifest(root, [])).rejects.toThrow(
-          /un-excludes/,
-        );
+        const dropped = await excludedByManifest(root, []);
+        expect(dropped.some((pattern) => pattern.test("build/keep.ts")))
+          .toBe(true);
       } finally {
         await Deno.remove(root, { recursive: true });
       }

--- a/tasks/typecheck.test.ts
+++ b/tasks/typecheck.test.ts
@@ -86,6 +86,18 @@ async function excludedByManifest(
     if (text === undefined) continue;
     const manifest = parseJsonc(text) as { exclude?: string[] };
     for (const pattern of manifest.exclude ?? []) {
+      // Deno reads a leading `!` as un-excluding what a broader entry took,
+      // and `globToRegExp` reads it as a literal character. The mismatch is
+      // silent and lands on the shrinking side: the entry never matches, the
+      // broader exclusion goes on firing, and a file the checker opens is
+      // counted as excused. Refusing it fails this file instead.
+      if (pattern.startsWith("!")) {
+        throw new Error(
+          `${join(directory, "deno.json(c)")} un-excludes ${pattern}, which ` +
+            `this check cannot read; teach it the negation or the census is ` +
+            `short by whatever the entry restores.`,
+        );
+      }
       const stripped = pattern.replace(/^\.\//, "");
       const scoped = directory === "" ? stripped : `${directory}/${stripped}`;
       patterns.push(
@@ -346,6 +358,7 @@ describe("typecheck", () => {
             ["iframe-board/nested-canvas", "guest.tsx"],
             ["iframe-board", "contract.ts"],
             ["plain-name", "guest.ts"],
+            ["plain-name", "guest.tsx"],
             ["plain-name", "contract.ts"],
           ]
         ) {
@@ -369,6 +382,9 @@ describe("typecheck", () => {
           "packages/patterns/iframe-board/contract.ts",
         );
         expect(patterns).not.toContain("packages/patterns/plain-name/guest.ts");
+        expect(patterns).not.toContain(
+          "packages/patterns/plain-name/guest.tsx",
+        );
         expect(patterns).not.toContain(
           "packages/patterns/plain-name/contract.ts",
         );
@@ -541,6 +557,26 @@ describe("typecheck", () => {
       expect(matches("packages/js-compiler/test/fixtures/program.ts")).toBe(
         false,
       );
+    });
+
+    it("refuses an un-exclusion rather than reading it as a literal", async () => {
+      // The failure this guards is silent and one-directional: the negated
+      // entry matches nothing, the broader one it was written to cancel goes
+      // on firing, and the census comes back short a file the checker opens.
+
+      const root = await Deno.makeTempDir({ prefix: "typecheck-unexclude-" });
+      try {
+        await Deno.writeTextFile(
+          join(root, "deno.jsonc"),
+          `{ "workspace": [], "exclude": ["**/build/", "!build/keep.ts"] }`,
+        );
+
+        await expect(excludedByManifest(root, [])).rejects.toThrow(
+          /un-excludes/,
+        );
+      } finally {
+        await Deno.remove(root, { recursive: true });
+      }
     });
 
     it("reads a member's own exclude, resolved against that member", async () => {

--- a/tasks/typecheck.test.ts
+++ b/tasks/typecheck.test.ts
@@ -86,19 +86,20 @@ async function excludedByManifest(
     if (text === undefined) continue;
     const manifest = parseJsonc(text) as { exclude?: string[] };
     for (const pattern of manifest.exclude ?? []) {
+      const stripped = pattern.replace(/^\.\//, "");
       // Deno reads a leading `!` as un-excluding what a broader entry took,
       // and `globToRegExp` reads it as a literal character. The mismatch is
       // silent and lands on the shrinking side: the entry never matches, the
       // broader exclusion goes on firing, and a file the checker opens is
-      // counted as excused. Refusing it fails this file instead.
-      if (pattern.startsWith("!")) {
+      // counted as excused. Refusing it fails this file instead. Read after
+      // the prefix strip, so that `./!build/` is refused as `!build/` is.
+      if (stripped.startsWith("!")) {
         throw new Error(
           `${join(directory, "deno.json(c)")} un-excludes ${pattern}, which ` +
             `this check cannot read; teach it the negation or the census is ` +
             `short by whatever the entry restores.`,
         );
       }
-      const stripped = pattern.replace(/^\.\//, "");
       const scoped = directory === "" ? stripped : `${directory}/${stripped}`;
       patterns.push(
         globToRegExp(scoped.endsWith("/") ? `${scoped}**` : scoped, {
@@ -569,6 +570,18 @@ describe("typecheck", () => {
         await Deno.writeTextFile(
           join(root, "deno.jsonc"),
           `{ "workspace": [], "exclude": ["**/build/", "!build/keep.ts"] }`,
+        );
+
+        await expect(excludedByManifest(root, [])).rejects.toThrow(
+          /un-excludes/,
+        );
+
+        // The same entry written with the `./` prefix the loop strips. Read
+        // before the strip, this spelling passes the guard and reaches
+        // `globToRegExp` as a literal.
+        await Deno.writeTextFile(
+          join(root, "deno.jsonc"),
+          `{ "workspace": [], "exclude": ["**/build/", "./!build/keep.ts"] }`,
         );
 
         await expect(excludedByManifest(root, [])).rejects.toThrow(

--- a/tasks/typecheck.ts
+++ b/tasks/typecheck.ts
@@ -6,12 +6,14 @@
  * the whole task. tasks/check.sh owns the Deno version gate and delegates
  * here.
  *
- * This list is the single type-checking point for the paths it names: the
- * CI test jobs and the package test tasks that cover these paths run
- * `deno test --no-check` and rely on this task (via the Check job's
- * "Type check codebase" step) for type safety. Before adding --no-check to
- * a test invocation, make sure every file it loads is under a path listed
- * here. Removing a path from this list removes its type checking entirely.
+ * This list is the only type check a path gets whose tests run under
+ * `--no-check`: those runs lean on this task, via the Check job's "Type
+ * check codebase" step, for type safety. A package whose test task checks
+ * its own files instead — `packages/patterns` among them — is reached both
+ * ways. Before adding `--no-check` to a test invocation, make sure every
+ * file it loads is under a path listed here, because that flag is what
+ * moves the file's type checking here. Removing a path removes the checking
+ * this task gives it.
  */
 
 import { expandGlob } from "@std/fs";
@@ -22,10 +24,7 @@ const DIRS = [
   "packages/api",
   "packages/background-piece-service",
   "packages/cf-harness",
-  "packages/cli/commands",
-  "packages/cli/lib",
-  "packages/cli/support",
-  "packages/cli/test",
+  "packages/cli",
   "packages/connectors/agents/connector",
   "packages/connectors/agents/debug-view",
   "packages/connectors/agents/host",
@@ -79,32 +78,49 @@ const DIRS = [
   "packages/static/test",
   "packages/test-support",
   "packages/toolshed",
+  "packages/ts-transformers/lint-plugins",
   "packages/ts-transformers/src",
+  "packages/ts-transformers/test/diagnostics",
+  "packages/ts-transformers/test/reactive",
   "packages/ui",
   "packages/utils",
   "tasks",
 ];
 
-// Glob patterns, expanded the way the shell used to expand them.
+// Paths reached by pattern rather than named outright.
 const GLOBS = [
   "scripts/*.ts",
-  "packages/cli/*.ts",
   "packages/static/*.ts",
   "packages/patterns/*.ts",
   "packages/patterns/*.tsx",
-  // Iframe guests compile as ordinary browser modules. Their generated
+  // Iframe guests and the contracts they are written against compile as
+  // ordinary browser modules, and `isPatternSource()` excludes them for
+  // exactly that reason, so this task is what checks them. Their generated
   // pattern wrappers remain under the classic JSX environment owned by
-  // `deno task cfcheck`.
-  "packages/patterns/*/guest.ts",
-  "packages/patterns/*/guest.tsx",
+  // `deno task cfcheck`. The depth is open because a guest sits wherever the
+  // pattern that hosts it puts it; the `iframe-` prefix is not, because that
+  // is the condition under which the exclusion applies. A file of the same
+  // name elsewhere is a pattern source cfcheck compiles, and checking it here
+  // as well would put one file through two incompatible JSX environments.
+  "packages/patterns/iframe-*/**/guest.ts",
+  "packages/patterns/iframe-*/**/guest.tsx",
+  "packages/patterns/iframe-*/**/contract.ts",
+  // A `.browser.test.ts` reaches the browser through `deno bundle`, which
+  // transpiles rather than type-checks, and `packages/patterns` keeps it out
+  // of the `deno test` pass that would have. This task is the only thing that
+  // opens it.
+  "packages/patterns/**/*.browser.test.ts",
+  // `deno check` takes no exclusion, so a tree holding a `test/fixtures`
+  // subtree it must not open is reached by glob rather than as one directory
+  // entry: per tree, a pattern for the test files at any depth and another
+  // for the helper modules beside them at the top level. A subtree holding no
+  // fixtures needs none of that and is named in `DIRS` above, which is where
+  // the transformer's `test/diagnostics` and `test/reactive` sit;
+  // `UNCHECKED_TREES` records the fixtures these patterns leave behind.
+  "packages/ts-transformers/test/*.ts",
   "packages/ts-transformers/test/**/*.test.ts",
-  // schema-generator tests, excluding test/fixtures: the `*.input.ts`
-  // fixtures name ambient wrappers (Cell, Stream, Writable) without
-  // importing them, since the transformer supplies those, so they do not
-  // type-check on their own. The test-file suffix keeps them out.
+  "packages/schema-generator/test/*.ts",
   "packages/schema-generator/test/**/*.test.ts",
-  // Google patterns (previously checked individually to avoid OOM, now
-  // included with the increased heap limit).
   "packages/patterns/google/core/*.ts",
   "packages/patterns/google/core/*.tsx",
   "packages/patterns/google/core/experimental/*.ts",
@@ -113,6 +129,119 @@ const GLOBS = [
   "packages/patterns/google/extractors/*.tsx",
   "packages/patterns/google/WIP/*.ts",
   "packages/patterns/google/WIP/*.tsx",
+];
+
+/** Whether a repository-relative path is a test rather than a source file. */
+export function isTestModule(file: string): boolean {
+  return /\.test\.[cm]?[jt]sx?$/.test(file);
+}
+
+/**
+ * Whether a path is a pattern test that one of the two lanes type-checks.
+ *
+ * `packages/patterns` runs a `.test.ts` under `deno test` without
+ * `--no-check`, and `cf test` compiles a `.test.tsx` through the runtime
+ * harness. The exclusions are the places where a file's shape and those lanes
+ * part company, and each leaves a file for a checked path to name instead: an
+ * extension outside the two has no lane at all; a `.browser.test.ts` is kept
+ * out of the `deno test` pass and bundled to its browser by a step that
+ * transpiles without checking; and a nested `integration` tree is excluded
+ * from that pass by the package's own test config, while the `integration`
+ * task names top-level paths explicitly rather than globbing for them.
+ */
+function isPatternTest(file: string): boolean {
+  if (file.includes("/integration/")) return false;
+  if (file.endsWith(".browser.test.ts")) return false;
+  return file.endsWith(".test.ts") || file.endsWith(".test.tsx");
+}
+
+/** A tree of modules the checked paths leave out, and why. */
+export interface UncheckedTree {
+  /** Repository-relative directory no checked path names. */
+  readonly tree: string;
+
+  /** Why this task does not type-check it. */
+  readonly because: string;
+
+  /**
+   * Which of the tree's modules this entry accounts for; all of them when
+   * omitted. Two entries dividing one tree each carry one, so that no file
+   * is excused by an entry whose reason is untrue of it — the reasons differ
+   * where what happens to the files differs.
+   */
+  readonly matches?: (file: string) => boolean;
+}
+
+/**
+ * Every tree the checked paths deliberately leave out.
+ *
+ * A list of what is checked cannot on its own distinguish a tree somebody
+ * decided to leave out from one the list forgot: both are simply absent, and
+ * the task reports a clean run over either. Recording the decision is what
+ * tells them apart, and `typecheck.test.ts` holds the pair to being
+ * exhaustive — a workspace file that is neither checked nor named by an entry
+ * here fails that test, naming the file.
+ */
+export const UNCHECKED_TREES: readonly UncheckedTree[] = [
+  {
+    tree: "packages/patterns",
+    matches: (file) => !isTestModule(file),
+    because:
+      "authored patterns compile under the classic-`h` JSX runtime rather " +
+      "than the automatic-JSX environment this task uses, and the two " +
+      "disagree on some pattern types, so `deno task cfcheck` type-checks " +
+      "them instead. `typecheck.test.ts` holds this entry to excusing only " +
+      "files the collector in `tasks/pattern-files.ts` hands that gate, so " +
+      "a claim that coverage lives elsewhere cannot drift from where it is.",
+  },
+  {
+    tree: "packages/patterns",
+    matches: isPatternTest,
+    because: "a file under `packages/patterns` shaped like what the test " +
+      "lanes take, whatever it holds — many are patterns driven through " +
+      "`action(...)`, and others are plain `Deno.test` unit tests of a " +
+      "pattern's helpers. What decides is the suffix rather than the " +
+      "contents: `isPatternSource()` in `tasks/pattern-files.ts` turns a " +
+      "file away on the test suffix alone, so `deno task cfcheck` walks " +
+      "none of them. The lane that runs one type-checks it instead: " +
+      "`packages/patterns` runs a `.test.ts` under `deno test` without " +
+      "`--no-check`, and `cf test` compiles a `.test.tsx` through the " +
+      "runtime harness, which reports a type error as a failed test. This " +
+      "reaches only what those lanes take, which is why the predicate turns " +
+      "three cases away: another extension has no lane at all; a " +
+      "`.browser.test.ts` is excluded from the `deno test` pass and bundled " +
+      "to its browser by a step that transpiles without checking; and a " +
+      "nested `integration` tree is excluded from that pass by the package's " +
+      "test config while the `integration` tasks name their top-level paths " +
+      "outright. The last two are checked because paths above name them, and " +
+      "anything else in those shapes is reported rather than excused here.",
+  },
+  {
+    tree: "packages/schema-generator/test/fixtures",
+    because:
+      "the generator's fixture corpus: inputs the tests feed it, and the " +
+      "outputs they compare against. These are data for the tests beside " +
+      "them rather than modules the repository builds, and the corpus does " +
+      "not compile as a unit, because inputs among them name the ambient " +
+      "wrappers (Cell, Stream, Writable) the generator supplies rather than " +
+      "importing them. Individual files here may well compile alone; what " +
+      "earns the exemption is being corpus, not being uncompilable.",
+  },
+  {
+    tree: "packages/ts-transformers/test/fixtures",
+    because: "the transformer's fixture corpus, exempt for the reason the " +
+      "generator's is: inputs and expected outputs that are data for the " +
+      "tests beside them, not modules the repository builds.",
+  },
+  {
+    tree: "packages/static/assets/types",
+    because:
+      "the declaration bundles handed to the in-memory pattern compiler. " +
+      "The set is the ambient environment a pattern compiles against rather " +
+      "than modules this repository builds, and it does not compile beside " +
+      "the tree it describes, since it redeclares what `packages/html` " +
+      "declares.",
+  },
 ];
 
 /** The owning scope of a checked path: the workspace member's name. */


### PR DESCRIPTION
## Why

Issue #6893 — `new Set("outliner")` excluding 70 of 118 UI component
directories — **was already fixed** by #6894 and #6897 before this branch
started. This does not redo that.

What it does is the part those fixes left open. #6894 replaced a character
class with a **hand-maintained list of strings in a test**
(`FULLY_CHECKED_TREES = ["packages/ui", "tasks"]`), a coverage claim for 2 of
48 workspace members — while `AGENTS.md` asserted that the checked list "now
names every workspace package" and that "a few are partial by design", and
**nothing checked either claim**.

That is the original defect one layer up: a coverage claim maintained by hand,
believed because it is written down.

## What the measurement found

Directory counts understate this, because `deno check` follows imports. Running
the pre-fix root set and resolving the whole module graph:

- **316 of 382** `packages/ui` files were reached transitively; **66 by
  nothing** (63 test files, 3 `.figma.ts`).
- Repo-wide: **43 of 48** members fully covered, and **750 of 5,575** workspace
  files reached by nothing. Of those, 454 transformer fixtures, 261 patterns
  and 7 static bundles are documented — and **28 files were documented by
  nothing and reached by nothing**. All 28 type-check clean, so they are now
  covered.

`deno task check` goes from **323 to 398 paths across 47 groups**.

## The instrument was verified, because a green run proves nothing

Three deliberate type errors were planted in previously-missed files; the gate
failed naming all three. The counterfactual is the useful half: replayed
against the pre-fix ui roots, only **two** were caught. The third —
`cf-code-editor/features/backlinks.ts`, the file the issue-filer was actually
editing — was reachable only because an unrelated package imported it. Its
coverage was incidental and could have vanished silently.

## What changed

`UNCHECKED_TREES` records each excluded tree **with its reason**, and the test
walks the workspace as `deno.jsonc` declares it, failing and naming files for
anything neither checked nor excused. The claim is derived from the manifest
rather than restated, so a new package is held to it the day it lands —
verified by adding a real member and watching the invariant name its file.

The path list stays hand-written on purpose: five members need sub-paths or
fail wholesale, `deno check` takes no exclusion, and the fixture trees
genuinely fail. Only its *completeness* stops being a matter of trust.

## Known and left alone

**104 pattern test files** are named by neither gate — `deno task check` does
not list them and cfcheck's `isPatternSource()` excludes test files. They sit
under the `packages/patterns` exemption, so the invariant excuses rather than
flags them. Honest, but the next instance of this shape.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6972?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

