### PR TITLE
fix(home-schemas): a favorite's address carries its scope (#6950)

### DIFF
--- a/docs/common/conventions/HOME_SPACE.md
+++ b/docs/common/conventions/HOME_SPACE.md
@@ -56,22 +56,28 @@ Favorites are stored on the home default pattern at
 Favorites are reached through the runtime's favorites manager
 (`FavoritesManager`, exported by `@commonfabric/runtime-client`), which reads
 and writes the home space's default pattern directly. A piece is addressed by
-the space it lives in plus its entity id:
+the space it lives in, its entity id there, and the scope that id resolves in,
+carried as the one `FavoritePieceAddress` value since one id in two scopes is
+two documents:
 
 ```typescript
 // Shown for illustration only.
 const favorites = rt.favorites();
+const piece = { space, pieceId, scope: "space" };
 
-await favorites.addFavorite(space, pieceId);
-await favorites.removeFavorite(space, pieceId);
+await favorites.addFavorite(piece);
+await favorites.removeFavorite(piece);
 
 const entries = await favorites.getFavorites();
 const unsubscribe = favorites.subscribeFavorites((list) => render(list));
 ```
 
-An entry is keyed by the piece's identity, so favoriting the same piece twice
-replaces its entry rather than adding a second one, and removing it reaches
-that entry whatever else the list holds.
+An entry is keyed by that whole address, so favoriting the same piece twice
+replaces its entry rather than adding a second one, removing it reaches that
+entry whatever else the list holds, and one id favorited in two scopes holds
+two entries rather than one. A space-scoped address names no scope in its key,
+that being the scope an address defaults to; only a narrower scope is written,
+and that elision is what keys every favorite in durable storage.
 
 ## Profile
 

--- a/packages/home-schemas/deno.jsonc
+++ b/packages/home-schemas/deno.jsonc
@@ -3,6 +3,7 @@
   "name": "@commonfabric/home-schemas",
   "exports": "./mod.ts",
   "tasks": {
-    "test": "echo 'No tests defined.'"
+    // --no-check: this package is type-checked by `deno task check` (tasks/check.sh).
+    "test": "deno test --no-check"
   }
 }

--- a/packages/home-schemas/favorites.ts
+++ b/packages/home-schemas/favorites.ts
@@ -3,7 +3,7 @@
  * These define the structure of user's favorited pieces.
  */
 
-import type { JSONSchema } from "@commonfabric/api";
+import type { CellScope, JSONSchema } from "@commonfabric/api";
 import type { Schema } from "@commonfabric/api/schema";
 
 export const favoriteEntrySchema = {
@@ -34,16 +34,44 @@ export const favoriteListSchema = {
 export type FavoriteList = Schema<typeof favoriteListSchema>;
 
 /**
- * The key a favorite is addressed by: the favorited piece's address — its
- * space, entity id, and value path. Computed by the caller that adds or removes
- * the favorite (which holds the piece's address as strings) and stored on the
- * entry as `id`, so the home handlers reach the same favorite entity with
- * `favorites.elementById(id)`. Pattern code cannot introspect a cell's link, so
- * the key is derived here and passed in as event data rather than recomputed in
- * the handler.
+ * A favorited piece's address: the space its document lives in, the scope its
+ * id resolves in there, that id, and the path to the favorited value.
+ *
+ * The four are one value so that an id and the scope completing it cannot be
+ * declared apart. One id in two scopes is two documents, so an id travelling
+ * on its own reaches whichever of them its reader defaults to.
  */
-export function favoriteKey(
-  ref: { space: string; id: string; path?: readonly unknown[] },
-): string {
-  return JSON.stringify([ref.space, ref.id, ref.path ?? []]);
+export type FavoriteAddress = {
+  /** The space the piece's document lives in. */
+  space: string;
+
+  /** The scope the id resolves in within that space. */
+  scope: CellScope;
+
+  /** The piece's entity id, its URI scheme included. */
+  id: string;
+
+  /** Path to the favorited value, defaulting to the document root. */
+  path?: readonly unknown[];
+};
+
+/**
+ * The key a favorite is addressed by, built from the whole of `address`.
+ * Computed by the caller that adds or removes the favorite (which holds the
+ * piece's address) and stored on the entry as `id`, so the home handlers reach
+ * the same favorite entity with `favorites.elementById(id)`. Pattern code
+ * cannot introspect a cell's link, so the key is derived here and passed in as
+ * event data rather than recomputed in the handler.
+ *
+ * A space-scoped address names no scope in its key, that being the scope an
+ * address defaults to; only a narrower scope is written. The elision is what
+ * every favorite in durable storage is keyed by, so it is a compatibility
+ * constraint and not a spelling preference: naming the space scope here would
+ * put each of those entries past the reach of its own address.
+ */
+export function favoriteKey(address: FavoriteAddress): string {
+  const { id, path = [], scope, space } = address;
+  return scope === "space"
+    ? JSON.stringify([space, id, path])
+    : JSON.stringify([space, id, path, scope]);
 }

--- a/packages/home-schemas/mod.ts
+++ b/packages/home-schemas/mod.ts
@@ -16,6 +16,7 @@ import { JSONSchema } from "@commonfabric/api";
 import { Schema } from "@commonfabric/api/schema";
 
 export {
+  type FavoriteAddress,
   type FavoriteEntry,
   favoriteEntrySchema,
   favoriteKey,

--- a/packages/home-schemas/test/favorites.test.ts
+++ b/packages/home-schemas/test/favorites.test.ts
@@ -1,0 +1,56 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { type FavoriteAddress, favoriteKey } from "@commonfabric/home-schemas";
+
+const space = "did:key:test-space";
+const id = "of:piece-1";
+
+/** The address of `id` in `space`, resolved in `scope`. */
+function address(scope: FavoriteAddress["scope"]): FavoriteAddress {
+  return { space, scope, id, path: [] };
+}
+
+describe("favoriteKey()", () => {
+  it("returns a key that names no scope for a space-scoped address", () => {
+    // A key addresses an entity in durable storage, so the spelling below is a
+    // contract with what is already stored rather than a formatting choice:
+    // every favorite there is keyed by an address in the space scope, written
+    // without one.
+
+    expect(favoriteKey(address("space"))).toBe(
+      JSON.stringify([space, id, []]),
+    );
+  });
+
+  it("returns a key naming the scope for a narrower-scoped address", () => {
+    expect(favoriteKey(address("user"))).toBe(
+      JSON.stringify([space, id, [], "user"]),
+    );
+  });
+
+  it("returns a distinct key for each scope one id resolves in", () => {
+    const keys = new Set(
+      (["space", "user", "session"] as const).map((scope) =>
+        favoriteKey(address(scope))
+      ),
+    );
+    expect(keys.size).toBe(3);
+  });
+
+  it("returns a distinct key for each space one id lives in", () => {
+    expect(favoriteKey({ ...address("space"), space: "did:key:other" }))
+      .not.toBe(favoriteKey(address("space")));
+  });
+
+  it("returns the same key for an omitted path as for an empty one", () => {
+    expect(favoriteKey({ space, scope: "space", id })).toBe(
+      favoriteKey(address("space")),
+    );
+  });
+
+  it("returns a distinct key for each path within one document", () => {
+    expect(favoriteKey({ space, scope: "space", id, path: ["inner"] }))
+      .not.toBe(favoriteKey(address("space")));
+  });
+});

--- a/packages/runtime-client/src/favorites-manager.ts
+++ b/packages/runtime-client/src/favorites-manager.ts
@@ -5,6 +5,7 @@
  * defaultPattern through cell operations, without requiring specialized IPC messages.
  */
 
+import type { CellScope } from "@commonfabric/api";
 import {
   FavoriteEntry,
   favoriteKey,
@@ -19,6 +20,26 @@ import type { CellRef } from "./protocol/types.ts";
 import { RuntimeClient } from "./runtime-client.ts";
 import { tagsFromSchema } from "./schema-tags.ts";
 import { describeFailure } from "@/shared/utils.ts";
+
+/**
+ * Which piece a favorite names: the space it lives in, its routing id there,
+ * and the scope that id resolves in.
+ *
+ * The three are one value so that an id and the scope completing it cannot be
+ * declared apart. A piece reached through a link into a narrower scope is
+ * addressed by its id and that scope together; the id alone names the
+ * space-scoped document, which is a different one.
+ */
+export type FavoritePieceAddress = {
+  /** The space the piece lives in. */
+  space: DID;
+
+  /** The piece's routing id, carrying no entity-URI scheme. */
+  pieceId: string;
+
+  /** The scope that id resolves in within the space. */
+  scope: CellScope;
+};
 
 type HandlerName = "addFavorite" | "removeFavorite";
 
@@ -39,20 +60,18 @@ export class FavoritesManager {
    * the piece's authored schema. An explicit `tag` overrides the derived
    * tags.
    *
-   * @param space - The space the piece lives in (part of its address)
-   * @param pieceId - The entity ID of the piece to add
+   * @param piece - The piece to add, addressed by space, id and scope
    * @param tag - Optional explicit discovery tag (overrides schema tags)
    * @param spaceName - Optional human-readable name of the space
    */
   async addFavorite(
-    space: DID,
-    pieceId: string,
+    piece: FavoritePieceAddress,
     tag?: string,
     spaceName?: string,
   ): Promise<void> {
     const handler = await this.#getHandler("addFavorite");
-    const pieceCellRef = this.#createPieceRef(space, pieceId);
-    const tags = await this.#deriveTags(space, pieceId, tag);
+    const pieceCellRef = this.#createPieceRef(piece);
+    const tags = await this.#deriveTags(piece, tag);
     // The favorite is addressed by the piece's identity, so a re-favorite dedups
     // and an unfavorite removes by identity. Pattern code cannot introspect the
     // piece cell's link, so the key is computed here from the piece address.
@@ -67,8 +86,7 @@ export class FavoritesManager {
    * favorite that later code can heal.
    */
   async #deriveTags(
-    space: DID,
-    pieceId: string,
+    piece: FavoritePieceAddress,
     explicitTag?: string,
   ): Promise<string[]> {
     if (explicitTag) return [explicitTag.toLowerCase().replace(/^#/, "")];
@@ -77,9 +95,16 @@ export class FavoritesManager {
       // with its result schema (`getAsLink({ includeSchema: true })`). It does
       // not start the piece (runIt defaults to false), so a piece that is not
       // already running may resolve without a schema and yield no tags — a
-      // tagless favorite that later code can heal.
-      const piece = await this.#rt.getPiece(pieceId, space);
-      const schema = piece?.cell().ref().schema;
+      // tagless favorite that later code can heal. The scope goes with the id:
+      // the schema read in the wrong scope is another document's, and would
+      // tag this favorite with that document's tags.
+      const handle = await this.#rt.getPiece(
+        piece.pieceId,
+        piece.space,
+        undefined,
+        piece.scope,
+      );
+      const schema = handle?.cell().ref().schema;
       return schema ? tagsFromSchema(schema) : [];
     } catch {
       // A missing or unreadable piece schema yields no tags, not a failure.
@@ -89,12 +114,11 @@ export class FavoritesManager {
 
   /**
    * Remove a piece from favorites.
-   * @param space - The space the piece lives in
-   * @param pieceId - The entity ID of the piece to remove
+   * @param piece - The piece to remove, addressed by space, id and scope
    */
-  async removeFavorite(space: DID, pieceId: string): Promise<void> {
+  async removeFavorite(piece: FavoritePieceAddress): Promise<void> {
     const handler = await this.#getHandler("removeFavorite");
-    const pieceCellRef = this.#createPieceRef(space, pieceId);
+    const pieceCellRef = this.#createPieceRef(piece);
     // Address the favorite entity by the same key add used, so the removal
     // reaches it regardless of the whole list's contents.
     const id = favoriteKey(pieceCellRef);
@@ -213,13 +237,14 @@ export class FavoritesManager {
   }
 
   /**
-   * Create a CellRef for a piece — an address of (space, id).
+   * Create a `CellRef` for a piece: its routing id under the `of:` scheme, in
+   * the space and scope its address names.
    */
-  #createPieceRef(space: DID, pieceId: string): CellRef {
+  #createPieceRef(piece: FavoritePieceAddress): CellRef {
     return {
-      id: `of:${pieceId}`,
-      space,
-      scope: "space",
+      id: `of:${piece.pieceId}`,
+      space: piece.space,
+      scope: piece.scope,
       path: [],
     };
   }

--- a/packages/runtime-client/test/favorites-manager.test.ts
+++ b/packages/runtime-client/test/favorites-manager.test.ts
@@ -1,12 +1,23 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import type { JSONSchema } from "@commonfabric/api";
+import type { CellScope, JSONSchema } from "@commonfabric/api";
 import type { DID } from "@commonfabric/identity";
 import { favoriteKey } from "@commonfabric/home-schemas";
-import { FavoritesManager } from "@/favorites-manager.ts";
+import {
+  type FavoritePieceAddress,
+  FavoritesManager,
+} from "@/favorites-manager.ts";
 import type { RuntimeClient } from "@/runtime-client.ts";
 
 const space = "did:key:test-space" as DID;
+
+/** The address of `pieceId` in the test space, resolved in `scope`. */
+function pieceAt(
+  pieceId: string,
+  scope: CellScope = "space",
+): FavoritePieceAddress {
+  return { space, pieceId, scope };
+}
 
 interface StubOptions {
   schema?: JSONSchema; // schema carried on the resolved piece ref
@@ -24,7 +35,7 @@ function makeStub(opts: StubOptions = {}) {
   const sent: Array<Record<string, unknown>> = [];
   let subscribeCb: ((v: unknown) => void) | undefined;
   let unsubscribed = false;
-  let getPieceCalls = 0;
+  const getPieceArgs: unknown[][] = [];
 
   const handler = { send: (p: Record<string, unknown>) => sent.push(p) };
   const favoritesCell: Record<string, unknown> = {
@@ -51,8 +62,8 @@ function makeStub(opts: StubOptions = {}) {
         : opts.ensureThrows
         ? Promise.reject(new Error("ensure failed"))
         : Promise.resolve(homeHandle),
-    getPiece: () => {
-      getPieceCalls++;
+    getPiece: (...args: unknown[]) => {
+      getPieceArgs.push(args);
       return opts.getPieceThrows
         ? Promise.reject(new Error("getPiece failed"))
         : Promise.resolve({
@@ -67,7 +78,8 @@ function makeStub(opts: StubOptions = {}) {
     invokeSubscribe: (v: unknown) => subscribeCb?.(v),
     hasSubscriber: () => subscribeCb !== undefined,
     wasUnsubscribed: () => unsubscribed,
-    getPieceCalls: () => getPieceCalls,
+    getPieceCalls: () => getPieceArgs.length,
+    lastGetPiece: () => getPieceArgs.at(-1),
   };
 }
 
@@ -83,13 +95,13 @@ describe("FavoritesManager", () => {
           tags: ["search", "go"],
         },
       });
-      await new FavoritesManager(stub.rt).addFavorite(space, "piece-1");
+      await new FavoritesManager(stub.rt).addFavorite(pieceAt("piece-1"));
       expect(stub.sent[0].tags).toEqual(["search", "go"]);
       expect(stub.sent[0].piece).toMatchObject({ id: "of:piece-1", space });
       // The favorite is addressed by the piece's identity so the handler can dedup
       // a re-favorite and remove by identity.
       expect(stub.sent[0].id).toBe(
-        favoriteKey({ space, id: "of:piece-1", path: [] }),
+        favoriteKey({ space, scope: "space", id: "of:piece-1", path: [] }),
       );
     });
 
@@ -98,8 +110,7 @@ describe("FavoritesManager", () => {
         schema: { type: "object", tags: ["schema-tag"] },
       });
       await new FavoritesManager(stub.rt).addFavorite(
-        space,
-        "p",
+        pieceAt("p"),
         "#Custom-Tag",
       );
       expect(stub.sent[0].tags).toEqual(["custom-tag"]);
@@ -108,14 +119,52 @@ describe("FavoritesManager", () => {
 
     it("stores no tags when the piece has no readable schema", async () => {
       const stub = makeStub({ schema: undefined });
-      await new FavoritesManager(stub.rt).addFavorite(space, "p");
+      await new FavoritesManager(stub.rt).addFavorite(pieceAt("p"));
       expect(stub.sent[0].tags).toEqual([]);
     });
 
     it("stores no tags when the schema read fails", async () => {
       const stub = makeStub({ getPieceThrows: true });
-      await new FavoritesManager(stub.rt).addFavorite(space, "p");
+      await new FavoritesManager(stub.rt).addFavorite(pieceAt("p"));
       expect(stub.sent[0].tags).toEqual([]);
+    });
+
+    it("reads the schema in the scope the piece's address names", async () => {
+      const stub = makeStub({ schema: { type: "object", tags: ["deep"] } });
+      await new FavoritesManager(stub.rt).addFavorite(pieceAt("p", "user"));
+      // The id and the scope together say which document to read: the same id
+      // in the space scope is a different one, whose tags are not this
+      // piece's.
+      expect(stub.lastGetPiece()).toEqual(["p", space, undefined, "user"]);
+    });
+  });
+
+  describe("the scope a favorite is taken in", () => {
+    it("sends the piece reference in the scope its address names", async () => {
+      const stub = makeStub();
+      await new FavoritesManager(stub.rt).addFavorite(pieceAt("p", "user"));
+      expect(stub.sent[0].piece).toMatchObject({
+        id: "of:p",
+        space,
+        scope: "user",
+      });
+    });
+
+    it("keys one id resolved in two scopes as two favorites", async () => {
+      const stub = makeStub();
+      const favorites = new FavoritesManager(stub.rt);
+      await favorites.addFavorite(pieceAt("p", "space"));
+      await favorites.addFavorite(pieceAt("p", "user"));
+      expect(stub.sent[0].id).not.toBe(stub.sent[1].id);
+    });
+
+    it("removes a scoped favorite by the key adding it used", async () => {
+      const stub = makeStub();
+      const favorites = new FavoritesManager(stub.rt);
+      await favorites.addFavorite(pieceAt("p", "session"));
+      await favorites.removeFavorite(pieceAt("p", "session"));
+      expect(stub.sent[1].id).toBe(stub.sent[0].id);
+      expect(stub.sent[1].piece).toMatchObject({ scope: "session" });
     });
   });
 
@@ -123,13 +172,13 @@ describe("FavoritesManager", () => {
     describe("removeFavorite()", () => {
       it("sends the piece reference and its key", async () => {
         const stub = makeStub();
-        await new FavoritesManager(stub.rt).removeFavorite(space, "piece-x");
+        await new FavoritesManager(stub.rt).removeFavorite(pieceAt("piece-x"));
         expect(stub.sent[0]).toMatchObject({
           piece: { id: "of:piece-x", space },
         });
         // The same key add uses, so the removal reaches the same favorite entity.
         expect(stub.sent[0].id).toBe(
-          favoriteKey({ space, id: "of:piece-x", path: [] }),
+          favoriteKey({ space, scope: "space", id: "of:piece-x", path: [] }),
         );
       });
     });

--- a/packages/shell/src/views/AppView.ts
+++ b/packages/shell/src/views/AppView.ts
@@ -10,6 +10,7 @@ import { slugIdForSpace, validateSlug } from "@commonfabric/runner/slugs";
 import {
   type Cancel,
   type ErrorNotification,
+  type FavoritePieceAddress,
   NAME,
   PieceHandle,
 } from "@commonfabric/runtime-client";
@@ -903,6 +904,22 @@ export class XAppView extends BaseView {
   }
 
   /**
+   * The whole address of the piece on screen — its space, its id there, and
+   * the scope that id resolves in — taken from the loaded pattern's own cell,
+   * which is the thing that was reached and so carries all three.
+   *
+   * Undefined until that pattern loads. The two placeholders
+   * `#getActivePatternId()` falls back to carry an id and no scope, and an id
+   * under a guessed scope addresses whichever document the guess lands on.
+   */
+  #getActivePieceAddress(): FavoritePieceAddress | undefined {
+    const activePattern = this._patterns.value?.activePattern;
+    if (!activePattern) return;
+    const ref = activePattern.cell().ref();
+    return { space: ref.space, pieceId: activePattern.id(), scope: ref.scope };
+  }
+
+  /**
    * How the piece this view addresses is cited from anywhere:
    * `/@<space>/<collection>/<member>`, the spelling this shell's own URLs and
    * `cf` both read and which depends on no binding of the reader's; a
@@ -1041,6 +1058,7 @@ export class XAppView extends BaseView {
             .keyStore="${this.keyStore}"
             .pieceTitle="${this.pieceTitle}"
             .pieceId="${pieceId}"
+            .pieceAddress="${this.#getActivePieceAddress()}"
             .pieceReference="${this.#getPieceReference()}"
             .isViewingDefaultPattern="${isViewingDefaultPattern}"
             .showDebuggerView="${config.showDebuggerView ?? false}"

--- a/packages/shell/src/views/HeaderView.ts
+++ b/packages/shell/src/views/HeaderView.ts
@@ -2,7 +2,10 @@ import type { FavoriteEntry } from "@commonfabric/home-schemas";
 import { type DID, KeyStore } from "@commonfabric/identity";
 import { navigate } from "@commonfabric/navigation";
 import { hasEntityUriScheme } from "@commonfabric/runner/entity-kind";
-import { type CellHandle } from "@commonfabric/runtime-client";
+import {
+  type CellHandle,
+  type FavoritePieceAddress,
+} from "@commonfabric/runtime-client";
 import { Task } from "@lit/task";
 import { css, html, nothing, type PropertyValues } from "lit";
 import { property, state } from "lit/decorators.js";
@@ -33,6 +36,18 @@ type ConnectionStatus =
   | "disconnected"
   | "error"
   | "conflict";
+
+/**
+ * Whether two addresses name the same document. Compared by value rather than
+ * by identity, an address arriving as a fresh object on each update, so that
+ * two objects standing for one document are the ordinary case.
+ */
+function samePieceAddress(
+  a: FavoritePieceAddress,
+  b: FavoritePieceAddress,
+): boolean {
+  return a.space === b.space && a.pieceId === b.pieceId && a.scope === b.scope;
+}
 
 export class XHeaderView extends BaseView {
   static override styles = css`
@@ -502,6 +517,17 @@ export class XHeaderView extends BaseView {
   accessor pieceId: string | undefined = undefined;
 
   /**
+   * The whole address of the piece on screen: its space, its id there, and the
+   * scope that id resolves in. This is what a favorite is taken at and matched
+   * against, `pieceId` alone naming a different document in each scope.
+   *
+   * Undefined until the piece resolves, which is when its scope is known, so
+   * the favorite row appears with the address rather than with the id.
+   */
+  @property({ attribute: false })
+  accessor pieceAddress: FavoritePieceAddress | undefined = undefined;
+
+  /**
    * How this piece is cited from anywhere, when it is a member of a named
    * collection: `/@<space>/<collection>/<member>`. Undefined for a piece
    * reached any other way, whose identity is already portable.
@@ -540,8 +566,17 @@ export class XHeaderView extends BaseView {
   @state()
   private accessor _serverFavorites: readonly FavoriteEntry[] = [];
 
+  /**
+   * What a click just asserted about a favorite, and the address it asserted
+   * it at. The value means nothing apart from that address, answering for a
+   * different document under any other one, so the two travel together and a
+   * read under a different address takes the server's answer instead.
+   */
   @state()
-  private accessor _localIsFavorite: boolean | undefined = undefined;
+  private accessor _localFavorite: {
+    readonly address: FavoritePieceAddress;
+    readonly isFavorite: boolean;
+  } | undefined = undefined;
 
   #unsubscribeFavorites: (() => void) | undefined;
 
@@ -556,7 +591,7 @@ export class XHeaderView extends BaseView {
       .favorites()
       .subscribeFavorites((favorites) => {
         this._serverFavorites = favorites;
-        this._localIsFavorite = undefined;
+        this._localFavorite = undefined;
         this.requestUpdate();
       });
   }
@@ -588,33 +623,43 @@ export class XHeaderView extends BaseView {
   }
 
   /**
-   * Derive whether the current piece is favorited. Prefers optimistic
-   * local state (set immediately on click) over server state.
+   * Derive whether the piece on screen is favorited. An optimistic value a
+   * click set wins over server state, but only where that click was about
+   * this same address.
    */
   #isFavorite(): boolean {
-    if (this._localIsFavorite !== undefined) {
-      return this._localIsFavorite;
+    const address = this.pieceAddress;
+    if (!address) return false;
+    const local = this._localFavorite;
+    if (local && samePieceAddress(local.address, address)) {
+      return local.isFavorite;
     }
-    if (!this.pieceId) return false;
     // CellHandle.id() is the full schemed id; the routing pieceId is bare
     // (piece roots are always of:). Normalize the bare side for equality.
-    const pieceUri = hasEntityUriScheme(this.pieceId)
-      ? this.pieceId
-      : `of:${this.pieceId}`;
-    return this._serverFavorites.some(
-      (f) => (f.cell as unknown as CellHandle<unknown>).id() === pieceUri,
-    );
+    const pieceUri = hasEntityUriScheme(address.pieceId)
+      ? address.pieceId
+      : `of:${address.pieceId}`;
+    // The whole address decides. Favorites are one list across every space, and
+    // one id names a different document in each space and in each scope, so a
+    // match on the id alone reports another piece's favorite as this one's.
+    return this._serverFavorites.some((f) => {
+      const ref = (f.cell as unknown as CellHandle<unknown>).ref();
+      return ref.id === pieceUri && ref.space === address.space &&
+        ref.scope === address.scope;
+    });
   }
 
   #resizeTimer?: ReturnType<typeof setTimeout>;
 
   /**
-   * The favorites subscription step, the favorite-toggle guard, and the three
-   * click handlers, which a test drives directly.
+   * The favorites subscription step, the favorite-toggle guard, the
+   * favorited-piece test, and the three click handlers, which a test drives
+   * directly.
    */
   get accessForTestingOnly(): {
     readonly isFavoriteLoading: boolean;
     ensureFavoritesSubscription(): void;
+    isFavorite(): boolean;
     handleLogoClick(e: Event): void;
     handleToggleFavorite(e: Event): Promise<void>;
     copyReference(e: Event): Promise<void>;
@@ -626,6 +671,7 @@ export class XHeaderView extends BaseView {
         return outerThis.#isFavoriteLoading;
       },
       ensureFavoritesSubscription: () => this.#ensureFavoritesSubscription(),
+      isFavorite: () => this.#isFavorite(),
       handleLogoClick: (e) => this.#handleLogoClick(e),
       handleToggleFavorite: (e) => this.#handleToggleFavorite(e),
       copyReference: (e) => this.#handleCopyReference(e),
@@ -682,7 +728,9 @@ export class XHeaderView extends BaseView {
   protected override willUpdate(changedProperties: PropertyValues): void {
     if (changedProperties.has("rt")) {
       this._serverFavorites = [];
-      this._localIsFavorite = undefined;
+      // The write this value records went to a runtime that is gone, and the
+      // server list it would stand in front of has been dropped with it.
+      this._localFavorite = undefined;
       this.#piecesCache = undefined;
       this.#cleanupFavoritesSubscription();
       // If the menu is already open when a runtime arrives, the favorites
@@ -694,9 +742,6 @@ export class XHeaderView extends BaseView {
     // space itself.
     if (changedProperties.has("space")) {
       this.#piecesCache = undefined;
-    }
-    if (changedProperties.has("pieceId")) {
-      this._localIsFavorite = undefined;
     }
   }
 
@@ -960,13 +1005,13 @@ export class XHeaderView extends BaseView {
   async #handleToggleFavorite(e: Event) {
     e.preventDefault();
     e.stopPropagation();
-    const space = this.space;
-    if (!this.rt || !space || !this.pieceId || this.#isFavoriteLoading) {
+    const piece = this.pieceAddress;
+    if (!this.rt || !piece || this.#isFavoriteLoading) {
       return;
     }
 
     const currentlyFavorite = this.#isFavorite();
-    this._localIsFavorite = !currentlyFavorite;
+    this._localFavorite = { address: piece, isFavorite: !currentlyFavorite };
     this.#isFavoriteLoading = true;
     // Favoriting touches the home pattern anyway; start reflecting server
     // state from here on if the menu was never opened.
@@ -974,18 +1019,18 @@ export class XHeaderView extends BaseView {
 
     try {
       if (currentlyFavorite) {
-        await this.rt.favorites().removeFavorite(space, this.pieceId);
+        await this.rt.favorites().removeFavorite(piece);
       } else {
         await this.rt
           .favorites()
-          .addFavorite(space, this.pieceId, undefined, this.spaceName);
+          .addFavorite(piece, undefined, this.spaceName);
       }
     } catch (err) {
       // A disposal race (logout, runtime swap) cancels the write; that is not
       // a toggle failure to surface.
       if (this.rt?.signal.aborted) return;
       console.error("[HeaderView] Error toggling favorite:", err);
-      this._localIsFavorite = undefined;
+      this._localFavorite = undefined;
     } finally {
       this.#isFavoriteLoading = false;
     }
@@ -1134,7 +1179,7 @@ export class XHeaderView extends BaseView {
 
               <div class="divider"><div class="divider-line"></div></div>
 
-              ${this.pieceId
+              ${this.pieceAddress
                 ? html`
                   <button
                     class="menu-item"

--- a/packages/shell/test/header-view-favorites.test.ts
+++ b/packages/shell/test/header-view-favorites.test.ts
@@ -17,6 +17,7 @@ interface HeaderViewLike {
   rt: unknown;
   space: unknown;
   pieceId: unknown;
+  pieceAddress: unknown;
   menuOpen: boolean;
   accessForTestingOnly: HeaderViewClass["accessForTestingOnly"];
   willUpdate(changed: Map<string, unknown>): void;
@@ -74,36 +75,59 @@ function installBrowserGlobals(): () => void {
   };
 }
 
+/** A stored favorite as the header reads one: an entry over a cell handle. */
+function favoriteOf(ref: { id: string; space: string; scope: string }) {
+  return { cell: { ref: () => ref } };
+}
+
+/** A write the header made: which one, and the address it named. */
+interface FavoriteWrite {
+  op: "add" | "remove";
+  piece: { space: string; pieceId: string; scope: string };
+}
+
 /**
  * A stand-in for the runtime's favorites surface. Counts subscriptions so a
- * test can assert when (and how often) the header asks for favorites, and can
- * reject writes to simulate a disposed runtime.
+ * test can assert when (and how often) the header asks for favorites, delivers
+ * `entries` as the stored favorites, records each write with the address it
+ * named, and can reject writes to simulate a disposed runtime.
  */
-function makeRuntime(opts: { aborted?: boolean; failWrite?: boolean } = {}) {
+function makeRuntime(
+  opts: {
+    aborted?: boolean;
+    failWrite?: boolean;
+    entries?: readonly unknown[];
+  } = {},
+) {
   let subscribeCount = 0;
   let unsubscribeCount = 0;
+  const writes: FavoriteWrite[] = [];
+  const write = (op: FavoriteWrite["op"]) => (piece: unknown) => {
+    writes.push({ op, piece: piece as FavoriteWrite["piece"] });
+    return opts.failWrite
+      ? Promise.reject(new Error("write cancelled"))
+      : Promise.resolve();
+  };
   const favorites = {
     subscribeFavorites(cb: (favorites: readonly unknown[]) => void) {
       subscribeCount++;
-      cb([]);
+      cb(opts.entries ?? []);
       return () => {
         unsubscribeCount++;
       };
     },
-    addFavorite: () =>
-      opts.failWrite
-        ? Promise.reject(new Error("write cancelled"))
-        : Promise.resolve(),
-    removeFavorite: () =>
-      opts.failWrite
-        ? Promise.reject(new Error("write cancelled"))
-        : Promise.resolve(),
+    addFavorite: write("add"),
+    removeFavorite: write("remove"),
   };
   return {
     favorites: () => favorites,
     signal: { aborted: opts.aborted ?? false },
+    writes,
     get subscribeCount() {
       return subscribeCount;
+    },
+    get writeCount() {
+      return writes.length;
     },
     get unsubscribeCount() {
       return unsubscribeCount;
@@ -194,20 +218,141 @@ Deno.test("toggling a favorite requests the subscription and swallows a disposal
     const ok = new XHeaderView() as unknown as HeaderViewLike;
     const okRt = makeRuntime();
     ok.rt = okRt;
-    ok.space = "did:key:test";
-    ok.pieceId = "piece-1";
+    ok.pieceAddress = {
+      space: "did:key:test",
+      pieceId: "piece-1",
+      scope: "space",
+    };
     await ok.accessForTestingOnly.handleToggleFavorite(fakeEvent());
     assertEquals(okRt.subscribeCount, 1);
+    assertEquals(okRt.writeCount, 1);
     assertFalse(ok.accessForTestingOnly.isFavoriteLoading);
 
     // A write cancelled by a disposed runtime is swallowed, not surfaced.
     const racing = new XHeaderView() as unknown as HeaderViewLike;
     const racingRt = makeRuntime({ failWrite: true, aborted: true });
     racing.rt = racingRt;
-    racing.space = "did:key:test";
-    racing.pieceId = "piece-2";
+    racing.pieceAddress = {
+      space: "did:key:test",
+      pieceId: "piece-2",
+      scope: "space",
+    };
     await racing.accessForTestingOnly.handleToggleFavorite(fakeEvent());
     assertFalse(racing.accessForTestingOnly.isFavoriteLoading);
+
+    // A piece whose scope the view does not yet know has no address to be
+    // favorited at, and the toggle writes nothing rather than favoriting
+    // whichever document the space scope holds.
+    const unresolved = new XHeaderView() as unknown as HeaderViewLike;
+    const unresolvedRt = makeRuntime();
+    unresolved.rt = unresolvedRt;
+    unresolved.space = "did:key:test";
+    unresolved.pieceId = "piece-3";
+    await unresolved.accessForTestingOnly.handleToggleFavorite(fakeEvent());
+    assertEquals(unresolvedRt.writeCount, 0);
+  } finally {
+    restore();
+  }
+});
+
+Deno.test("an optimistic favorite says nothing about another scope of the same id", async () => {
+  const restore = installBrowserGlobals();
+  try {
+    const { XHeaderView } = await import("../src/views/HeaderView.ts");
+    const view = new XHeaderView() as unknown as HeaderViewLike;
+    const rt = makeRuntime();
+    view.rt = rt;
+    // Subscribed up front so that the toggle's own request is a no-op: what
+    // this pins is the window before any server list arrives.
+    view.accessForTestingOnly.ensureFavoritesSubscription();
+
+    const userScoped = { space: "did:key:test", pieceId: "p", scope: "user" };
+    view.pieceId = "p";
+    view.pieceAddress = userScoped;
+    await view.accessForTestingOnly.handleToggleFavorite(fakeEvent());
+    assertEquals(rt.writes.length, 1);
+    assertEquals(rt.writes[0].op, "add");
+    assert(view.accessForTestingOnly.isFavorite());
+
+    // The header moves to the space-scoped document of that same id, which is
+    // the update a scope change makes: the address changed and the id did not.
+    view.pieceAddress = { space: "did:key:test", pieceId: "p", scope: "space" };
+    view.willUpdate(new Map([["pieceAddress", userScoped]]));
+
+    // The click above was about the user-scoped document, so it answers for
+    // that one alone...
+    assertFalse(view.accessForTestingOnly.isFavorite());
+
+    // ...and the next toggle adds the document now on screen rather than
+    // removing it.
+    await view.accessForTestingOnly.handleToggleFavorite(fakeEvent());
+    assertEquals(rt.writes.length, 2);
+    assertEquals(rt.writes[1].op, "add");
+    assertEquals(rt.writes[1].piece.scope, "space");
+  } finally {
+    restore();
+  }
+});
+
+Deno.test("a favorite matches only in the scope the piece's address names", async () => {
+  const restore = installBrowserGlobals();
+  try {
+    const { XHeaderView } = await import("../src/views/HeaderView.ts");
+    const view = new XHeaderView() as unknown as HeaderViewLike;
+    view.rt = makeRuntime({
+      entries: [
+        favoriteOf({ id: "of:p", space: "did:key:test", scope: "user" }),
+      ],
+    });
+    view.accessForTestingOnly.ensureFavoritesSubscription();
+
+    view.pieceAddress = {
+      space: "did:key:test",
+      pieceId: "p",
+      scope: "user",
+    };
+    assert(view.accessForTestingOnly.isFavorite());
+
+    // The same id in the space scope is another document, whose favorite this
+    // one's is not.
+    view.pieceAddress = {
+      space: "did:key:test",
+      pieceId: "p",
+      scope: "space",
+    };
+    assertFalse(view.accessForTestingOnly.isFavorite());
+  } finally {
+    restore();
+  }
+});
+
+Deno.test("a favorite matches only in the space the piece's address names", async () => {
+  const restore = installBrowserGlobals();
+  try {
+    const { XHeaderView } = await import("../src/views/HeaderView.ts");
+    const view = new XHeaderView() as unknown as HeaderViewLike;
+    view.rt = makeRuntime({
+      entries: [
+        favoriteOf({ id: "of:p", space: "did:key:test", scope: "space" }),
+      ],
+    });
+    view.accessForTestingOnly.ensureFavoritesSubscription();
+
+    view.pieceAddress = {
+      space: "did:key:test",
+      pieceId: "p",
+      scope: "space",
+    };
+    assert(view.accessForTestingOnly.isFavorite());
+
+    // Favorites are one list across every space, so an id favorited in one
+    // says nothing about the same id in another.
+    view.pieceAddress = {
+      space: "did:key:other",
+      pieceId: "p",
+      scope: "space",
+    };
+    assertFalse(view.accessForTestingOnly.isFavorite());
   } finally {
     restore();
   }


### PR DESCRIPTION
## Why

Favoriting a scoped piece stored a reference to the **space-scoped document**,
and two scopes' favorites collided into one entry. Three places dropped the
scope, not the two the issue names — the third,
`FavoritesManager.#deriveTags`, reads the piece's result schema without one,
so a scoped favorite could be tagged from a different document.

Same shape as #6912, which landed earlier: an address split from the scope
that completes it.

## The migration question, and why it needed no ruling

`favoriteKey` shapes stored data, so widening it normally re-keys every
existing favorite. That is why the issue held it back for the favorites owner.

It turns out not to need them, and the reason is by construction rather than
by inference: **every key in durable storage was produced by
`#createPieceRef`, which hardcoded `scope: "space"`.** Those are the only two
production call sites.

So: a space-scoped address writes no scope, and only a narrower one is
appended. **Every stored key is byte-identical under the new spelling.** No
favorite is re-keyed, dedup and keyed removal keep holding for entries already
written, and the two scopes that used to collide now key apart.

Rejected, with reasons: *always naming the scope* re-keys every stored
favorite and breaks the two properties the key exists for, for a cosmetic
gain. *A re-keying migration pass* has no machinery here, and this codebase's
demonstrated response to a changed stored shape is tolerance of the old one,
not rewriting.

## Why not #6912's derived invariant

I looked for the analogue and there isn't an honest one. That check works
because `IPCClientRequest` is an enumerable population and membership is
"declares a `pieceId`". This path is four functions, not a union. The one
population worth deriving from lives in `runner`, which imports
`home-schemas`, so importing it back is a cycle `check-package-cycles` would
fail. A `keyof` assertion here would be a hand-list in the costume of a
derivation — **and it would not have caught this bug**, because the parameter
type was narrower than the address, so `keyof` never saw a scope to demand.

What does enforce it is the type: `scope` is required on both address types,
so a caller holding an id and no scope fails `deno task check` at its own call
site.

## Behavior change worth review

The favorite menu row is now gated on the resolved address rather than on
`pieceId`, so it is absent during the window before the pattern loads, where
the id has no scope. Favoriting under a guessed scope was the bug; refusing to
guess is the fix, but it is visible.

## Test plan

Every assertion has a named mutation that reds it, run in isolation, with the
clause as the unit. **One instrument was inert and was fixed**: the "writes
nothing when the scope is unknown" clause first passed against the mutation it
was written for, because its fixture never straddled the boundary that
mutation draws.

The type-check instrument was verified too — a deliberate surplus property in
the new test file makes `deno check packages/home-schemas` exit 1 naming it,
confirming the new tree is inside the coverage the gate claims.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6973?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

