### PR TITLE
refactor(fuse): `CellBridge` keeps its tables and tree-building steps in `#` members behind `accessForTestingOnly`

### DIFF
--- a/packages/fuse/cell-bridge.test.ts
+++ b/packages/fuse/cell-bridge.test.ts
@@ -23,9 +23,11 @@ import {
 import { FsTree } from "./tree.ts";
 import {
   CellBridge,
+  type EntityProjectionLookupOwner,
   type HandlerTarget,
   type SourceWritePath,
   type SpaceState,
+  type UnhydratedEntityRootInfo,
   type WritePath,
 } from "./cell-bridge.ts";
 import {
@@ -292,41 +294,7 @@ async function openDirectorySnapshot(
   );
 }
 
-type AddPieceToSpace = (
-  state: SpaceState,
-  piece: unknown,
-  spaceName: string,
-) => Promise<string>;
-
-type LoadPieceTree = (
-  piece: unknown,
-  parentIno: bigint,
-  name: string,
-  spaceName: string,
-  existingIno?: bigint,
-) => Promise<bigint>;
-
 type UpdateIndexJson = (state: SpaceState) => void;
-
-type UpdatePiecesJson = (state: SpaceState) => void;
-
-type SyncPieceListOnce = (
-  state: SpaceState,
-  spaceName: string,
-) => Promise<void>;
-
-type SubscribePiece = (
-  piece: unknown,
-  pieceIno: bigint,
-  pieceName: string,
-  spaceName: string,
-  state: unknown,
-) => Promise<Array<() => void>>;
-
-type HydratePieceProp = (
-  pieceIno: bigint,
-  propName: "input" | "result",
-) => Promise<boolean>;
 
 type RebuildPieceProp = (args: {
   cell: FakeCell;
@@ -339,32 +307,11 @@ type RebuildPieceProp = (args: {
   spaceName: string;
 }) => Promise<void>;
 
-type EnqueuePiecePropRebuild = RebuildPieceProp;
-
-type BuildSourceTree = (
-  pieceIno: bigint,
-  piece: unknown,
-  state: SpaceState,
-  pieceName: string,
-) => Promise<void>;
-
 type RefreshPiecePatternMetadata = (
   state: SpaceState,
   piece: unknown,
   pieceIno: bigint,
 ) => Promise<void>;
-
-type WriteFsFile = (
-  writePath: unknown,
-  text: string,
-) => Promise<boolean>;
-
-type BuildSpaceTree = (
-  spaceName: string,
-  spacePieces: SpaceState["pieces"],
-) => SpaceState;
-
-type AttemptReconnect = () => Promise<void>;
 
 Deno.test("CellBridge reconnect validates the existing piece registry", async () => {
   const tree = new FsTree();
@@ -406,10 +353,9 @@ Deno.test("CellBridge reconnect validates the existing piece registry", async ()
       },
     } as unknown as SpaceState["pieces"],
   );
-  (bridge as unknown as { _disconnected: boolean })._disconnected = true;
+  bridge.accessForTestingOnly.disconnected = true;
 
-  await (bridge as unknown as { _attemptReconnect: AttemptReconnect })
-    ._attemptReconnect();
+  await bridge.accessForTestingOnly.attemptReconnect();
 
   assertEquals(piecesSyncs, 1);
   assertEquals(registeredPieceReads, 1);
@@ -443,9 +389,10 @@ Deno.test("CellBridge materializes /pieces from pieceRegistry", async () => {
     },
   } as unknown as SpaceState["pieces"];
 
-  const state = (bridge as unknown as {
-    buildSpaceTree: BuildSpaceTree;
-  }).buildSpaceTree("registry-space", spacePieces);
+  const state = bridge.accessForTestingOnly.buildSpaceTree(
+    "registry-space",
+    spacePieces,
+  );
 
   assertEquals(registeredPieceReads, 0);
   assertEquals(registryReads, 0);
@@ -589,45 +536,46 @@ Deno.test("CellBridge removes partial state after a late connection failure", as
   });
   bridge.init({ apiUrl: "https://example.invalid", identity: "test" });
 
-  const internals = bridge as unknown as {
-    updateIndexJson(state: SpaceState): void;
-    entitySubscriptions: Map<bigint, Array<() => void>>;
-    unhydratedEntityRoots: Map<bigint, unknown>;
-    pendingEntityHydrations: Map<bigint, Promise<boolean>>;
-    entityProjectionLru: Map<bigint, unknown>;
-    entityProjectionEvictionCandidates: Map<bigint, unknown>;
-    entityProjectionUseOrder: Map<bigint, number>;
-    pendingEntityRemovals: Map<bigint, unknown>;
-    pendingPieceHydrations: Map<string, Promise<void>>;
-    pieceSyncs: Map<string, Promise<void>>;
-    syncAgain: Set<string>;
-  };
+  const internals = bridge.accessForTestingOnly;
   const connectionFailure = new Error("manifest generation failed");
   let partialEntityIno = 0n;
-  internals.updateIndexJson = (state) => {
-    const cancel = () => {
-      cancellations++;
+  (bridge as unknown as { updateIndexJson: UpdateIndexJson })
+    .updateIndexJson = (state) => {
+      const cancel = () => {
+        cancellations++;
+      };
+      state.unsubscribes.push(cancel);
+      state.pieceSubs.set("partial-piece", [cancel]);
+      tree.addDir(state.piecesIno, "partial-piece");
+      const entityIno = tree.addDir(state.entitiesIno, "partial-entity");
+      partialEntityIno = entityIno;
+      internals.entitySubscriptions.set(entityIno, [cancel]);
+      internals.unhydratedEntityRoots.set(
+        entityIno,
+        {} as UnhydratedEntityRootInfo,
+      );
+      internals.pendingEntityHydrations.set(
+        entityIno,
+        Promise.resolve(false),
+      );
+      internals.entityProjectionLru.set(
+        entityIno,
+        {} as UnhydratedEntityRootInfo,
+      );
+      internals.entityProjectionEvictionCandidates.set(
+        entityIno,
+        {} as UnhydratedEntityRootInfo,
+      );
+      internals.entityProjectionUseOrder.set(entityIno, 1);
+      internals.pendingEntityRemovals.set(
+        entityIno,
+        {} as UnhydratedEntityRootInfo,
+      );
+      internals.pendingPieceHydrations.set("home", Promise.resolve());
+      internals.pieceSyncs.set("home", Promise.resolve());
+      internals.syncAgain.add("home");
+      throw connectionFailure;
     };
-    state.unsubscribes.push(cancel);
-    state.pieceSubs.set("partial-piece", [cancel]);
-    tree.addDir(state.piecesIno, "partial-piece");
-    const entityIno = tree.addDir(state.entitiesIno, "partial-entity");
-    partialEntityIno = entityIno;
-    internals.entitySubscriptions.set(entityIno, [cancel]);
-    internals.unhydratedEntityRoots.set(entityIno, {});
-    internals.pendingEntityHydrations.set(
-      entityIno,
-      Promise.resolve(false),
-    );
-    internals.entityProjectionLru.set(entityIno, {});
-    internals.entityProjectionEvictionCandidates.set(entityIno, {});
-    internals.entityProjectionUseOrder.set(entityIno, 1);
-    internals.pendingEntityRemovals.set(entityIno, {});
-    internals.pendingPieceHydrations.set("home", Promise.resolve());
-    internals.pieceSyncs.set("home", Promise.resolve());
-    internals.syncAgain.add("home");
-    throw connectionFailure;
-  };
 
   const warnings: unknown[][] = [];
   const originalWarn = console.warn;
@@ -1054,14 +1002,16 @@ Deno.test("CellBridge cache work stays linear while lookup references remain", a
       ),
     maxEntityProjections: 1,
   });
-  const lru = new IterationCountingMap<bigint, unknown>();
-  const candidates = new IterationCountingMap<bigint, unknown>();
-  const lookupOwners = new IterationCountingMap<bigint, unknown>();
-  const internals = bridge as unknown as {
-    entityProjectionLru: Map<bigint, unknown>;
-    entityProjectionEvictionCandidates: Map<bigint, unknown>;
-    entityProjectionLookupOwners: Map<bigint, unknown>;
-  };
+  const lru = new IterationCountingMap<bigint, UnhydratedEntityRootInfo>();
+  const candidates = new IterationCountingMap<
+    bigint,
+    UnhydratedEntityRootInfo
+  >();
+  const lookupOwners = new IterationCountingMap<
+    bigint,
+    EntityProjectionLookupOwner
+  >();
+  const internals = bridge.accessForTestingOnly;
   internals.entityProjectionLru = lru;
   internals.entityProjectionEvictionCandidates = candidates;
   internals.entityProjectionLookupOwners = lookupOwners;
@@ -1155,13 +1105,7 @@ Deno.test("CellBridge balances repeated lookup and open references", async () =>
   assertEquals(await bridge.prepareLookup(state.entitiesIno, encodedId), true);
   const entityIno = tree.lookup(state.entitiesIno, encodedId)!;
   const childIno = tree.addFile(entityIno, "child", "value", "string");
-  const internals = bridge as unknown as {
-    entityProjectionLookupOwners: Map<
-      bigint,
-      { rootIno: bigint; count: bigint }
-    >;
-    entityProjectionLookupRefs: Map<bigint, bigint>;
-  };
+  const internals = bridge.accessForTestingOnly;
 
   bridge.retainEntityProjectionLookup(childIno, 2n);
   bridge.retainEntityProjectionOpen(childIno);
@@ -1469,14 +1413,11 @@ Deno.test("CellBridge reconnect does not require entity listing support", async 
     } as unknown as SpaceState["pieces"],
   );
 
-  const reconnectable = bridge as unknown as {
-    _disconnected: boolean;
-    _attemptReconnect(): Promise<void>;
-  };
-  reconnectable._disconnected = true;
-  await reconnectable._attemptReconnect();
+  const reconnectable = bridge.accessForTestingOnly;
+  reconnectable.disconnected = true;
+  await reconnectable.attemptReconnect();
 
-  assertEquals(reconnectable._disconnected, false);
+  assertEquals(reconnectable.disconnected, false);
   assertEquals(sessionProbes, 1);
   assertEquals(pieceListRequests, 0);
   assertEquals(disposedManagers, 1);
@@ -1530,19 +1471,15 @@ Deno.test("CellBridge reconnect checks every space before resuming writes", asyn
     );
   }
 
-  const reconnectable = bridge as unknown as {
-    _disconnected: boolean;
-    _reconnectTimer: ReturnType<typeof setTimeout> | null;
-    _attemptReconnect(): Promise<void>;
-  };
-  reconnectable._disconnected = true;
-  await reconnectable._attemptReconnect();
-  if (reconnectable._reconnectTimer !== null) {
-    clearTimeout(reconnectable._reconnectTimer);
-    reconnectable._reconnectTimer = null;
+  const reconnectable = bridge.accessForTestingOnly;
+  reconnectable.disconnected = true;
+  await reconnectable.attemptReconnect();
+  if (reconnectable.reconnectTimer !== null) {
+    clearTimeout(reconnectable.reconnectTimer);
+    reconnectable.reconnectTimer = null;
   }
 
-  assertEquals(reconnectable._disconnected, true);
+  assertEquals(reconnectable.disconnected, true);
   assertEquals(sessionProbes, ["authorized", "revoked"]);
   assertEquals(piecesSyncs, ["authorized", "revoked"]);
   assertEquals(disposedManagers, ["authorized", "revoked"]);
@@ -2061,8 +1998,12 @@ Deno.test("CellBridge.loadPieceTree creates meta.json with a pattern reference",
     },
   };
 
-  const pieceIno = await (bridge as unknown as { loadPieceTree: LoadPieceTree })
-    .loadPieceTree(piece, tree.rootIno, "My Note", "home");
+  const pieceIno = await bridge.accessForTestingOnly.loadPieceTree(
+    piece as never,
+    tree.rootIno,
+    "My Note",
+    "home",
+  );
 
   const metaIno = tree.lookup(pieceIno, "meta.json");
   assertEquals(metaIno !== undefined, true, "meta.json should exist");
@@ -2103,8 +2044,12 @@ Deno.test("CellBridge.loadPieceTree creates stable input/result stubs without ea
     },
   };
 
-  const pieceIno = await (bridge as unknown as { loadPieceTree: LoadPieceTree })
-    .loadPieceTree(piece, tree.rootIno, "Article", "home");
+  const pieceIno = await bridge.accessForTestingOnly.loadPieceTree(
+    piece as never,
+    tree.rootIno,
+    "Article",
+    "home",
+  );
 
   const inputIno = tree.lookup(pieceIno, "input");
   const resultIno = tree.lookup(pieceIno, "result");
@@ -2144,10 +2089,13 @@ Deno.test("CellBridge CFC annotations attach to hydrated JSON projections and fa
     },
   };
 
-  const pieceIno = await (bridge as unknown as { loadPieceTree: LoadPieceTree })
-    .loadPieceTree(piece, state.piecesIno, "Annotated Fixture", "home");
-  await (bridge as unknown as { hydratePieceProp: HydratePieceProp })
-    .hydratePieceProp.call(bridge, pieceIno, "result");
+  const pieceIno = await bridge.accessForTestingOnly.loadPieceTree(
+    piece as never,
+    state.piecesIno,
+    "Annotated Fixture",
+    "home",
+  );
+  await bridge.accessForTestingOnly.hydratePieceProp(pieceIno, "result");
 
   const resultIno = tree.lookup(pieceIno, "result");
   assertEquals(resultIno !== undefined, true);
@@ -2231,10 +2179,13 @@ Deno.test("CellBridge derives CFC projection generation for hydrated CFC mounts"
     },
   };
 
-  const pieceIno = await (bridge as unknown as { loadPieceTree: LoadPieceTree })
-    .loadPieceTree(piece, state.piecesIno, "Derived Generation", "home");
-  await (bridge as unknown as { hydratePieceProp: HydratePieceProp })
-    .hydratePieceProp.call(bridge, pieceIno, "result");
+  const pieceIno = await bridge.accessForTestingOnly.loadPieceTree(
+    piece as never,
+    state.piecesIno,
+    "Derived Generation",
+    "home",
+  );
+  await bridge.accessForTestingOnly.hydratePieceProp(pieceIno, "result");
 
   const resultIno = tree.lookup(pieceIno, "result");
   assertEquals(resultIno !== undefined, true);
@@ -2259,17 +2210,16 @@ Deno.test("CellBridge derives CFC projection generation for hydrated CFC mounts"
   );
 
   const rebuiltResultCell = makeResultCell("two");
-  await (bridge as unknown as { rebuildPieceProp: RebuildPieceProp })
-    .rebuildPieceProp.call(bridge, {
-      cell: rebuiltResultCell,
-      newValue: rebuiltResultCell.get(),
-      pieceId: piece.id,
-      pieceIno,
-      pieceName: "Derived Generation",
-      propName: "result",
-      resolveLink: () => null,
-      spaceName: "home",
-    });
+  await bridge.accessForTestingOnly.rebuildPieceProp({
+    cell: rebuiltResultCell as never,
+    newValue: rebuiltResultCell.get(),
+    pieceId: piece.id,
+    pieceIno,
+    pieceName: "Derived Generation",
+    propName: "result",
+    resolveLink: () => null,
+    spaceName: "home",
+  });
 
   const rebuiltResultIno = tree.lookup(pieceIno, "result");
   const rebuiltTitleIno = tree.lookup(rebuiltResultIno!, "title");
@@ -2333,13 +2283,16 @@ Deno.test("CellBridge finalizes CFC annotations after committed writeback", asyn
     piece as unknown as SpaceState["pieceControllers"] extends
       Map<string, infer T> ? T : never,
   );
-  const pieceIno = await (bridge as unknown as { loadPieceTree: LoadPieceTree })
-    .loadPieceTree(piece, state.piecesIno, "Finalize Generation", "home");
+  const pieceIno = await bridge.accessForTestingOnly.loadPieceTree(
+    piece as never,
+    state.piecesIno,
+    "Finalize Generation",
+    "home",
+  );
   state.pieceMap.set("Finalize Generation", piece.id);
   state.pieceInos.set("Finalize Generation", pieceIno);
 
-  await (bridge as unknown as { hydratePieceProp: HydratePieceProp })
-    .hydratePieceProp.call(bridge, pieceIno, "result");
+  await bridge.accessForTestingOnly.hydratePieceProp(pieceIno, "result");
   const initialResultIno = tree.lookup(pieceIno, "result")!;
   const initialTitleIno = tree.lookup(initialResultIno, "title")!;
   const initialGeneration = tree.getCfcAnnotation(initialTitleIno)?.generation;
@@ -2468,13 +2421,16 @@ Deno.test("CellBridge finalizes CFC annotations after namespace mutation writeba
     piece as unknown as SpaceState["pieceControllers"] extends
       Map<string, infer T> ? T : never,
   );
-  const pieceIno = await (bridge as unknown as { loadPieceTree: LoadPieceTree })
-    .loadPieceTree(piece, state.piecesIno, "Finalize Namespace", "home");
+  const pieceIno = await bridge.accessForTestingOnly.loadPieceTree(
+    piece as never,
+    state.piecesIno,
+    "Finalize Namespace",
+    "home",
+  );
   state.pieceMap.set("Finalize Namespace", piece.id);
   state.pieceInos.set("Finalize Namespace", pieceIno);
 
-  await (bridge as unknown as { hydratePieceProp: HydratePieceProp })
-    .hydratePieceProp.call(bridge, pieceIno, "result");
+  await bridge.accessForTestingOnly.hydratePieceProp(pieceIno, "result");
   const rootPath: WritePath = {
     spaceName: "home",
     pieceName: "Finalize Namespace",
@@ -2583,15 +2539,17 @@ Deno.test("CellBridge.prepareLookup hydrates result.json on direct lookup", asyn
     },
   };
 
-  const pieceIno = await (bridge as unknown as { loadPieceTree: LoadPieceTree })
-    .loadPieceTree(piece, tree.rootIno, "Lookup JSON", "home");
+  const pieceIno = await bridge.accessForTestingOnly.loadPieceTree(
+    piece as never,
+    tree.rootIno,
+    "Lookup JSON",
+    "home",
+  );
 
   // result.json exists as a stub placeholder before hydration
   assertEquals(tree.lookup(pieceIno, "result.json") !== undefined, true);
 
-  const prepared = await (bridge as unknown as {
-    prepareLookup: (parentIno: bigint, name: string) => Promise<boolean>;
-  }).prepareLookup(pieceIno, "result.json");
+  const prepared = await bridge.prepareLookup(pieceIno, "result.json");
 
   assertEquals(prepared, true);
   assertEquals(tree.lookup(pieceIno, "result.json") !== undefined, true);
@@ -2660,11 +2618,16 @@ Deno.test("CellBridge.hydratePieceProp renders link-backed handlers only at disc
     },
   };
 
-  const pieceIno = await (bridge as unknown as { loadPieceTree: LoadPieceTree })
-    .loadPieceTree(piece, state.piecesIno, "Link-Handler", "home");
-  const hydrated = await (bridge as unknown as {
-    hydratePieceProp: HydratePieceProp;
-  }).hydratePieceProp(pieceIno, "result");
+  const pieceIno = await bridge.accessForTestingOnly.loadPieceTree(
+    piece as never,
+    state.piecesIno,
+    "Link-Handler",
+    "home",
+  );
+  const hydrated = await bridge.accessForTestingOnly.hydratePieceProp(
+    pieceIno,
+    "result",
+  );
 
   assertEquals(hydrated, true);
   const resultIno = tree.lookup(pieceIno, "result");
@@ -2755,11 +2718,16 @@ Deno.test("CellBridge bakes a handler's content-addressed schema into the shim e
     },
   };
 
-  const pieceIno = await (bridge as unknown as { loadPieceTree: LoadPieceTree })
-    .loadPieceTree(piece, state.piecesIno, "Ref-Schema-Handler", "home");
-  const hydrated = await (bridge as unknown as {
-    hydratePieceProp: HydratePieceProp;
-  }).hydratePieceProp(pieceIno, "result");
+  const pieceIno = await bridge.accessForTestingOnly.loadPieceTree(
+    piece as never,
+    state.piecesIno,
+    "Ref-Schema-Handler",
+    "home",
+  );
+  const hydrated = await bridge.accessForTestingOnly.hydratePieceProp(
+    pieceIno,
+    "result",
+  );
   assertEquals(hydrated, true);
 
   const resultIno = tree.lookup(pieceIno, "result");
@@ -2812,13 +2780,16 @@ Deno.test("CellBridge.hydratePieceProp materializes input and result on demand",
     piece as unknown as SpaceState["pieceControllers"] extends
       Map<string, infer T> ? T : never,
   );
-  const pieceIno = await (bridge as unknown as { loadPieceTree: LoadPieceTree })
-    .loadPieceTree(piece, state.piecesIno, "Post", "home");
+  const pieceIno = await bridge.accessForTestingOnly.loadPieceTree(
+    piece as never,
+    state.piecesIno,
+    "Post",
+    "home",
+  );
   state.pieceMap.set("Post", piece.id);
   state.pieceInos.set("Post", pieceIno);
 
-  await (bridge as unknown as { hydratePieceProp: HydratePieceProp })
-    .hydratePieceProp.call(bridge, pieceIno, "input");
+  await bridge.accessForTestingOnly.hydratePieceProp(pieceIno, "input");
   const inputIno = tree.lookup(pieceIno, "input");
   assertEquals(
     inputIno !== undefined,
@@ -2827,8 +2798,7 @@ Deno.test("CellBridge.hydratePieceProp materializes input and result on demand",
   );
   assertEquals(getFileContent(tree, inputIno!, "title"), "hello");
 
-  await (bridge as unknown as { hydratePieceProp: HydratePieceProp })
-    .hydratePieceProp.call(bridge, pieceIno, "result");
+  await bridge.accessForTestingOnly.hydratePieceProp(pieceIno, "result");
   const resultIno = tree.lookup(pieceIno, "result");
   assertEquals(
     resultIno !== undefined,
@@ -2870,17 +2840,14 @@ Deno.test("CellBridge.hydratePieceProp returns early when a prop is already hydr
     },
   };
 
-  const addPiece = (bridge as unknown as { addPieceToSpace: AddPieceToSpace })
-    .addPieceToSpace.bind(bridge);
-  await addPiece(state, piece, "home");
+  const addPiece = bridge.accessForTestingOnly.addPieceToSpace;
+  await addPiece(state, piece as never, "home");
 
   const pieceIno = tree.lookup(state.piecesIno, "Cached-Piece")!;
   const initialResultCellGets = resultCellGets;
   const initialResultGets = resultGets;
-  await (bridge as unknown as { hydratePieceProp: HydratePieceProp })
-    .hydratePieceProp.call(bridge, pieceIno, "result");
-  await (bridge as unknown as { hydratePieceProp: HydratePieceProp })
-    .hydratePieceProp.call(bridge, pieceIno, "result");
+  await bridge.accessForTestingOnly.hydratePieceProp(pieceIno, "result");
+  await bridge.accessForTestingOnly.hydratePieceProp(pieceIno, "result");
 
   assertEquals(resultCellGets - initialResultCellGets, 1);
   assertEquals(resultGets - initialResultGets, 1);
@@ -2938,13 +2905,16 @@ Deno.test("CellBridge.rebuildPieceProp reuses a callable's inode across a rebuil
     piece as unknown as SpaceState["pieceControllers"] extends
       Map<string, infer T> ? T : never,
   );
-  const pieceIno = await (bridge as unknown as { loadPieceTree: LoadPieceTree })
-    .loadPieceTree(piece, state.piecesIno, "Callable Fixture", "home");
+  const pieceIno = await bridge.accessForTestingOnly.loadPieceTree(
+    piece as never,
+    state.piecesIno,
+    "Callable Fixture",
+    "home",
+  );
   state.pieceMap.set("Callable Fixture", piece.id);
   state.pieceInos.set("Callable Fixture", pieceIno);
 
-  await (bridge as unknown as { hydratePieceProp: HydratePieceProp })
-    .hydratePieceProp.call(bridge, pieceIno, "result");
+  await bridge.accessForTestingOnly.hydratePieceProp(pieceIno, "result");
 
   const initialResultIno = tree.lookup(pieceIno, "result");
   assertEquals(initialResultIno !== undefined, true);
@@ -2978,17 +2948,16 @@ Deno.test("CellBridge.rebuildPieceProp reuses a callable's inode across a rebuil
     { search: rebuiltToolCell },
   );
 
-  await (bridge as unknown as { rebuildPieceProp: RebuildPieceProp })
-    .rebuildPieceProp.call(bridge, {
-      cell: rebuiltResultCell,
-      newValue: rebuiltResultCell.get(),
-      pieceId: piece.id,
-      pieceIno,
-      pieceName: "Callable Fixture",
-      propName: "result",
-      resolveLink: () => null,
-      spaceName: "home",
-    });
+  await bridge.accessForTestingOnly.rebuildPieceProp({
+    cell: rebuiltResultCell as never,
+    newValue: rebuiltResultCell.get(),
+    pieceId: piece.id,
+    pieceIno,
+    pieceName: "Callable Fixture",
+    propName: "result",
+    resolveLink: () => null,
+    spaceName: "home",
+  });
 
   // The result directory and the callable inside it both still exist at the
   // same path with the same kind, so the rebuild adopts their inodes rather
@@ -3029,13 +2998,16 @@ Deno.test("CellBridge.rebuildPieceProp keeps inodes stable and invalidates only 
     piece as unknown as SpaceState["pieceControllers"] extends
       Map<string, infer T> ? T : never,
   );
-  const pieceIno = await (bridge as unknown as { loadPieceTree: LoadPieceTree })
-    .loadPieceTree(piece, state.piecesIno, "Stable Piece", "home");
+  const pieceIno = await bridge.accessForTestingOnly.loadPieceTree(
+    piece as never,
+    state.piecesIno,
+    "Stable Piece",
+    "home",
+  );
   state.pieceMap.set("Stable Piece", piece.id);
   state.pieceInos.set("Stable Piece", pieceIno);
 
-  await (bridge as unknown as { hydratePieceProp: HydratePieceProp })
-    .hydratePieceProp.call(bridge, pieceIno, "input");
+  await bridge.accessForTestingOnly.hydratePieceProp(pieceIno, "input");
 
   const inputIno = tree.lookup(pieceIno, "input")!;
   const titleIno = tree.lookup(inputIno, "title")!;
@@ -3044,17 +3016,16 @@ Deno.test("CellBridge.rebuildPieceProp keeps inodes stable and invalidates only 
   const invalidatedInodes: bigint[] = [];
   bridge.onInvalidateInode = (ino) => invalidatedInodes.push(ino);
 
-  await (bridge as unknown as { rebuildPieceProp: RebuildPieceProp })
-    .rebuildPieceProp.call(bridge, {
-      cell: makeCell({ title: "after", count: 1 }, inputSchema),
-      newValue: { title: "after", count: 1 },
-      pieceId: piece.id,
-      pieceIno,
-      pieceName: "Stable Piece",
-      propName: "input",
-      resolveLink: () => null,
-      spaceName: "home",
-    });
+  await bridge.accessForTestingOnly.rebuildPieceProp({
+    cell: makeCell({ title: "after", count: 1 }, inputSchema) as never,
+    newValue: { title: "after", count: 1 },
+    pieceId: piece.id,
+    pieceIno,
+    pieceName: "Stable Piece",
+    propName: "input",
+    resolveLink: () => null,
+    spaceName: "home",
+  });
 
   // Same paths, same kinds: the inodes are reused, not reallocated.
   assertEquals(tree.lookup(pieceIno, "input"), inputIno);
@@ -3093,12 +3064,10 @@ Deno.test("CellBridge queues piece prop rebuilds for the same prop", async () =>
       active--;
     };
 
-  const enqueue = (bridge as unknown as {
-    enqueuePiecePropRebuild: EnqueuePiecePropRebuild;
-  }).enqueuePiecePropRebuild.bind(bridge);
+  const enqueue = bridge.accessForTestingOnly.enqueuePiecePropRebuild;
 
   const baseJob = {
-    cell,
+    cell: cell as never,
     pieceId: "of:queued-prop",
     pieceIno: 42n,
     pieceName: "Queued Prop",
@@ -3159,30 +3128,32 @@ Deno.test("CellBridge.rebuildPieceProp clears stale result mounts when value bec
     piece as unknown as SpaceState["pieceControllers"] extends
       Map<string, infer T> ? T : never,
   );
-  const pieceIno = await (bridge as unknown as { loadPieceTree: LoadPieceTree })
-    .loadPieceTree(piece, state.piecesIno, "Null Result Fixture", "home");
+  const pieceIno = await bridge.accessForTestingOnly.loadPieceTree(
+    piece as never,
+    state.piecesIno,
+    "Null Result Fixture",
+    "home",
+  );
   state.pieceMap.set("Null Result Fixture", piece.id);
   state.pieceInos.set("Null Result Fixture", pieceIno);
 
-  await (bridge as unknown as { hydratePieceProp: HydratePieceProp })
-    .hydratePieceProp.call(bridge, pieceIno, "result");
+  await bridge.accessForTestingOnly.hydratePieceProp(pieceIno, "result");
 
   const initialResultIno = tree.lookup(pieceIno, "result");
   assertEquals(initialResultIno !== undefined, true);
   assertEquals(getFileContent(tree, initialResultIno!, "title"), "before");
   assertEquals(tree.lookup(pieceIno, "result.json") !== undefined, true);
 
-  await (bridge as unknown as { rebuildPieceProp: RebuildPieceProp })
-    .rebuildPieceProp.call(bridge, {
-      cell: makeCell(null, undefined),
-      newValue: null,
-      pieceId: piece.id,
-      pieceIno,
-      pieceName: "Null Result Fixture",
-      propName: "result",
-      resolveLink: () => null,
-      spaceName: "home",
-    });
+  await bridge.accessForTestingOnly.rebuildPieceProp({
+    cell: makeCell(null, undefined) as never,
+    newValue: null,
+    pieceId: piece.id,
+    pieceIno,
+    pieceName: "Null Result Fixture",
+    propName: "result",
+    resolveLink: () => null,
+    spaceName: "home",
+  });
 
   assertEquals(tree.lookup(pieceIno, "result"), undefined);
   assertEquals(tree.lookup(pieceIno, "result.json"), undefined);
@@ -3219,29 +3190,26 @@ Deno.test("CellBridge.rebuildPieceProp clears stale FS projection mounts when va
     },
   };
 
-  const addPiece = (bridge as unknown as { addPieceToSpace: AddPieceToSpace })
-    .addPieceToSpace.bind(bridge);
-  await addPiece(state, piece, "home");
+  const addPiece = bridge.accessForTestingOnly.addPieceToSpace;
+  await addPiece(state, piece as never, "home");
 
   const pieceIno = tree.lookup(state.piecesIno, "Null-FS-Fixture")!;
 
-  await (bridge as unknown as { hydratePieceProp: HydratePieceProp })
-    .hydratePieceProp.call(bridge, pieceIno, "result");
+  await bridge.accessForTestingOnly.hydratePieceProp(pieceIno, "result");
 
   assertEquals(tree.lookup(pieceIno, "index.md") !== undefined, true);
   assertEquals(tree.lookup(pieceIno, "meta") !== undefined, true);
 
-  await (bridge as unknown as { rebuildPieceProp: RebuildPieceProp })
-    .rebuildPieceProp.call(bridge, {
-      cell: makeCell(null, undefined),
-      newValue: null,
-      pieceId: piece.id,
-      pieceIno,
-      pieceName: "Null FS Fixture",
-      propName: "result",
-      resolveLink: () => null,
-      spaceName: "home",
-    });
+  await bridge.accessForTestingOnly.rebuildPieceProp({
+    cell: makeCell(null, undefined) as never,
+    newValue: null,
+    pieceId: piece.id,
+    pieceIno,
+    pieceName: "Null FS Fixture",
+    propName: "result",
+    resolveLink: () => null,
+    spaceName: "home",
+  });
 
   assertEquals(tree.lookup(pieceIno, "index.md"), undefined);
   assertEquals(tree.lookup(pieceIno, "index.json"), undefined);
@@ -3277,13 +3245,16 @@ Deno.test("CellBridge.rebuildPieceProp keeps the FS projection index inode stabl
     piece as unknown as SpaceState["pieceControllers"] extends
       Map<string, infer T> ? T : never,
   );
-  const pieceIno = await (bridge as unknown as { loadPieceTree: LoadPieceTree })
-    .loadPieceTree(piece, state.piecesIno, "Stable FS Fixture", "home");
+  const pieceIno = await bridge.accessForTestingOnly.loadPieceTree(
+    piece as never,
+    state.piecesIno,
+    "Stable FS Fixture",
+    "home",
+  );
   state.pieceMap.set("Stable FS Fixture", piece.id);
   state.pieceInos.set("Stable FS Fixture", pieceIno);
 
-  await (bridge as unknown as { hydratePieceProp: HydratePieceProp })
-    .hydratePieceProp.call(bridge, pieceIno, "result");
+  await bridge.accessForTestingOnly.hydratePieceProp(pieceIno, "result");
 
   const indexIno = tree.lookup(pieceIno, "index.md")!;
   assertEquals(indexIno !== undefined, true);
@@ -3296,17 +3267,16 @@ Deno.test("CellBridge.rebuildPieceProp keeps the FS projection index inode stabl
   bridge.onInvalidateInode = (ino) => invalidatedInodes.push(ino);
 
   resultCell.set(makeFsResult("Goodbye"));
-  await (bridge as unknown as { rebuildPieceProp: RebuildPieceProp })
-    .rebuildPieceProp.call(bridge, {
-      cell: resultCell as unknown as ReturnType<typeof makeCell>,
-      newValue: resultCell.get(),
-      pieceId: piece.id,
-      pieceIno,
-      pieceName: "Stable FS Fixture",
-      propName: "result",
-      resolveLink: () => null,
-      spaceName: "home",
-    });
+  await bridge.accessForTestingOnly.rebuildPieceProp({
+    cell: resultCell as never,
+    newValue: resultCell.get(),
+    pieceId: piece.id,
+    pieceIno,
+    pieceName: "Stable FS Fixture",
+    propName: "result",
+    resolveLink: () => null,
+    spaceName: "home",
+  });
 
   // The projection index survives with the same inode and updated content, and
   // its stale data cache is dropped.
@@ -3345,30 +3315,32 @@ Deno.test("CellBridge.rebuildPieceProp reconciles a prop changing from an object
     piece as unknown as SpaceState["pieceControllers"] extends
       Map<string, infer T> ? T : never,
   );
-  const pieceIno = await (bridge as unknown as { loadPieceTree: LoadPieceTree })
-    .loadPieceTree(piece, state.piecesIno, "Object To Scalar", "home");
+  const pieceIno = await bridge.accessForTestingOnly.loadPieceTree(
+    piece as never,
+    state.piecesIno,
+    "Object To Scalar",
+    "home",
+  );
   state.pieceMap.set("Object To Scalar", piece.id);
   state.pieceInos.set("Object To Scalar", pieceIno);
 
-  await (bridge as unknown as { hydratePieceProp: HydratePieceProp })
-    .hydratePieceProp.call(bridge, pieceIno, "result");
+  await bridge.accessForTestingOnly.hydratePieceProp(pieceIno, "result");
   assertEquals(tree.getNode(tree.lookup(pieceIno, "result")!)?.kind, "dir");
   assertEquals(tree.lookup(pieceIno, "result.json") !== undefined, true);
 
   // The result becomes a bare string: `result` changes kind from a directory
   // to a file (its inode is replaced), and its `.json` sibling disappears
   // because a scalar has no aggregate form.
-  await (bridge as unknown as { rebuildPieceProp: RebuildPieceProp })
-    .rebuildPieceProp.call(bridge, {
-      cell: makeCell("y", undefined),
-      newValue: "y",
-      pieceId: piece.id,
-      pieceIno,
-      pieceName: "Object To Scalar",
-      propName: "result",
-      resolveLink: () => null,
-      spaceName: "home",
-    });
+  await bridge.accessForTestingOnly.rebuildPieceProp({
+    cell: makeCell("y", undefined) as never,
+    newValue: "y",
+    pieceId: piece.id,
+    pieceIno,
+    pieceName: "Object To Scalar",
+    propName: "result",
+    resolveLink: () => null,
+    spaceName: "home",
+  });
 
   const resultIno = tree.lookup(pieceIno, "result");
   assertEquals(tree.getNode(resultIno!)?.kind, "file");
@@ -3402,13 +3374,16 @@ Deno.test("CellBridge.rebuildPieceProp invalidates the index dentry when an FS p
     piece as unknown as SpaceState["pieceControllers"] extends
       Map<string, infer T> ? T : never,
   );
-  const pieceIno = await (bridge as unknown as { loadPieceTree: LoadPieceTree })
-    .loadPieceTree(piece, state.piecesIno, "FS Removed Fixture", "home");
+  const pieceIno = await bridge.accessForTestingOnly.loadPieceTree(
+    piece as never,
+    state.piecesIno,
+    "FS Removed Fixture",
+    "home",
+  );
   state.pieceMap.set("FS Removed Fixture", piece.id);
   state.pieceInos.set("FS Removed Fixture", pieceIno);
 
-  await (bridge as unknown as { hydratePieceProp: HydratePieceProp })
-    .hydratePieceProp.call(bridge, pieceIno, "result");
+  await bridge.accessForTestingOnly.hydratePieceProp(pieceIno, "result");
   assertEquals(tree.lookup(pieceIno, "index.md") !== undefined, true);
 
   const entryInvalidations: string[] = [];
@@ -3417,17 +3392,16 @@ Deno.test("CellBridge.rebuildPieceProp invalidates the index dentry when an FS p
   };
 
   resultCell.set(null);
-  await (bridge as unknown as { rebuildPieceProp: RebuildPieceProp })
-    .rebuildPieceProp.call(bridge, {
-      cell: resultCell as unknown as ReturnType<typeof makeCell>,
-      newValue: null,
-      pieceId: piece.id,
-      pieceIno,
-      pieceName: "FS Removed Fixture",
-      propName: "result",
-      resolveLink: () => null,
-      spaceName: "home",
-    });
+  await bridge.accessForTestingOnly.rebuildPieceProp({
+    cell: resultCell as never,
+    newValue: null,
+    pieceId: piece.id,
+    pieceIno,
+    pieceName: "FS Removed Fixture",
+    propName: "result",
+    resolveLink: () => null,
+    spaceName: "home",
+  });
 
   // The projection is gone from the tree, and its `index.md` dentry is
   // invalidated so a client drops the entry instead of resolving a freed inode.
@@ -3464,45 +3438,46 @@ Deno.test("CellBridge.rebuildPieceProp advances the piece dir mtime only when it
     piece as unknown as SpaceState["pieceControllers"] extends
       Map<string, infer T> ? T : never,
   );
-  const pieceIno = await (bridge as unknown as { loadPieceTree: LoadPieceTree })
-    .loadPieceTree(piece, state.piecesIno, "Dir Mtime Fixture", "home");
+  const pieceIno = await bridge.accessForTestingOnly.loadPieceTree(
+    piece as never,
+    state.piecesIno,
+    "Dir Mtime Fixture",
+    "home",
+  );
   state.pieceMap.set("Dir Mtime Fixture", piece.id);
   state.pieceInos.set("Dir Mtime Fixture", pieceIno);
 
-  await (bridge as unknown as { hydratePieceProp: HydratePieceProp })
-    .hydratePieceProp.call(bridge, pieceIno, "result");
+  await bridge.accessForTestingOnly.hydratePieceProp(pieceIno, "result");
   const afterHydrate = tree.getNode(pieceIno)!.mtime;
 
   // A content-only rebuild leaves the piece directory's entry set unchanged, so
   // its mtime is preserved.
   clock = 2_000;
-  await (bridge as unknown as { rebuildPieceProp: RebuildPieceProp })
-    .rebuildPieceProp.call(bridge, {
-      cell: makeCell({ title: "b", count: 1 }, resultSchema),
-      newValue: { title: "b", count: 1 },
-      pieceId: piece.id,
-      pieceIno,
-      pieceName: "Dir Mtime Fixture",
-      propName: "result",
-      resolveLink: () => null,
-      spaceName: "home",
-    });
+  await bridge.accessForTestingOnly.rebuildPieceProp({
+    cell: makeCell({ title: "b", count: 1 }, resultSchema) as never,
+    newValue: { title: "b", count: 1 },
+    pieceId: piece.id,
+    pieceIno,
+    pieceName: "Dir Mtime Fixture",
+    propName: "result",
+    resolveLink: () => null,
+    spaceName: "home",
+  });
   assertEquals(tree.getNode(pieceIno)!.mtime, afterHydrate);
 
   // Removing the result drops result/, result.json and .handlers from the piece
   // directory, so its mtime advances.
   clock = 3_000;
-  await (bridge as unknown as { rebuildPieceProp: RebuildPieceProp })
-    .rebuildPieceProp.call(bridge, {
-      cell: makeCell(null, undefined),
-      newValue: null,
-      pieceId: piece.id,
-      pieceIno,
-      pieceName: "Dir Mtime Fixture",
-      propName: "result",
-      resolveLink: () => null,
-      spaceName: "home",
-    });
+  await bridge.accessForTestingOnly.rebuildPieceProp({
+    cell: makeCell(null, undefined) as never,
+    newValue: null,
+    pieceId: piece.id,
+    pieceIno,
+    pieceName: "Dir Mtime Fixture",
+    propName: "result",
+    resolveLink: () => null,
+    spaceName: "home",
+  });
   assertEquals(tree.getNode(pieceIno)!.mtime, 3_000);
 });
 
@@ -3527,8 +3502,11 @@ Deno.test("CellBridge.addPieceToSpace advances the pieces directory mtime", asyn
     },
   };
   clock = 5_000;
-  await (bridge as unknown as { addPieceToSpace: AddPieceToSpace })
-    .addPieceToSpace(state, piece, "home");
+  await bridge.accessForTestingOnly.addPieceToSpace(
+    state,
+    piece as never,
+    "home",
+  );
 
   // The pieces directory gained an entry, so its mtime advances past its value
   // at space construction.
@@ -3576,13 +3554,16 @@ Deno.test("CellBridge.hydratePieceProp labels void handlers as no-arg callables 
     piece as unknown as SpaceState["pieceControllers"] extends
       Map<string, infer T> ? T : never,
   );
-  const pieceIno = await (bridge as unknown as { loadPieceTree: LoadPieceTree })
-    .loadPieceTree(piece, state.piecesIno, "Contact Book", "home");
+  const pieceIno = await bridge.accessForTestingOnly.loadPieceTree(
+    piece as never,
+    state.piecesIno,
+    "Contact Book",
+    "home",
+  );
   state.pieceMap.set("Contact Book", piece.id);
   state.pieceInos.set("Contact Book", pieceIno);
 
-  await (bridge as unknown as { hydratePieceProp: HydratePieceProp })
-    .hydratePieceProp.call(bridge, pieceIno, "result");
+  await bridge.accessForTestingOnly.hydratePieceProp(pieceIno, "result");
 
   const handlers = getFileContent(tree, pieceIno, ".handlers");
   assertEquals(
@@ -3614,11 +3595,18 @@ Deno.test("CellBridge.addPieceToSpace assigns -2 suffix on name collision", asyn
     },
   });
 
-  const addPiece = (bridge as unknown as { addPieceToSpace: AddPieceToSpace })
-    .addPieceToSpace.bind(bridge);
+  const addPiece = bridge.accessForTestingOnly.addPieceToSpace;
 
-  const name1 = await addPiece(state, makeNotePiece("of:id-1"), "home");
-  const name2 = await addPiece(state, makeNotePiece("of:id-2"), "home");
+  const name1 = await addPiece(
+    state,
+    makeNotePiece("of:id-1") as never,
+    "home",
+  );
+  const name2 = await addPiece(
+    state,
+    makeNotePiece("of:id-2") as never,
+    "home",
+  );
 
   assertEquals(name1, "My-Note");
   assertEquals(name2, "My-Note-2");
@@ -3669,9 +3657,8 @@ Deno.test("CellBridge.addPieceToSpace syncs a late-loading name before naming th
     },
   };
 
-  const addPiece = (bridge as unknown as { addPieceToSpace: AddPieceToSpace })
-    .addPieceToSpace.bind(bridge);
-  const name = await addPiece(state, piece, "home");
+  const addPiece = bridge.accessForTestingOnly.addPieceToSpace;
+  const name = await addPiece(state, piece as never, "home");
 
   assertEquals(name, "Fuse-Exec-Fixture");
   assertEquals(
@@ -3700,12 +3687,23 @@ Deno.test("CellBridge.addPieceToSpace assigns -2 and -3 suffixes for three colli
     },
   });
 
-  const addPiece = (bridge as unknown as { addPieceToSpace: AddPieceToSpace })
-    .addPieceToSpace.bind(bridge);
+  const addPiece = bridge.accessForTestingOnly.addPieceToSpace;
 
-  const name1 = await addPiece(state, makeStandupPiece("of:su-1"), "home");
-  const name2 = await addPiece(state, makeStandupPiece("of:su-2"), "home");
-  const name3 = await addPiece(state, makeStandupPiece("of:su-3"), "home");
+  const name1 = await addPiece(
+    state,
+    makeStandupPiece("of:su-1") as never,
+    "home",
+  );
+  const name2 = await addPiece(
+    state,
+    makeStandupPiece("of:su-2") as never,
+    "home",
+  );
+  const name3 = await addPiece(
+    state,
+    makeStandupPiece("of:su-3") as never,
+    "home",
+  );
 
   assertEquals(name1, "Standup");
   assertEquals(name2, "Standup-2");
@@ -3725,8 +3723,7 @@ Deno.test("CellBridge.updateIndexJson writes .index.json mapping names to entity
   const bridge = new CellBridge(tree, "/tmp/cf-exec");
   const state = buildTestSpace(bridge, "home", []);
 
-  const addPiece = (bridge as unknown as { addPieceToSpace: AddPieceToSpace })
-    .addPieceToSpace.bind(bridge);
+  const addPiece = bridge.accessForTestingOnly.addPieceToSpace;
 
   await addPiece(
     state,
@@ -3742,7 +3739,7 @@ Deno.test("CellBridge.updateIndexJson writes .index.json mapping names to entity
         getCell: () => Promise.resolve(makeCell({}, undefined)),
         get: () => Promise.resolve({}),
       },
-    },
+    } as never,
     "home",
   );
 
@@ -3760,12 +3757,11 @@ Deno.test("CellBridge.updateIndexJson writes .index.json mapping names to entity
         getCell: () => Promise.resolve(makeCell({}, undefined)),
         get: () => Promise.resolve({}),
       },
-    },
+    } as never,
     "home",
   );
 
-  (bridge as unknown as { updateIndexJson: UpdateIndexJson }).updateIndexJson
-    .call(bridge, state);
+  bridge.accessForTestingOnly.updateIndexJson(state);
 
   const indexJson = JSON.parse(
     getFileContent(tree, state.piecesIno, ".index.json"),
@@ -3797,8 +3793,7 @@ Deno.test("CellBridge.updatePiecesJson writes cached manifest data without piece
     summary: "beta summary",
   });
 
-  (bridge as unknown as { updatePiecesJson: UpdatePiecesJson }).updatePiecesJson
-    .call(bridge, state);
+  bridge.accessForTestingOnly.updatePiecesJson(state);
 
   const piecesJson = JSON.parse(
     getFileContent(tree, state.piecesIno, "pieces.json"),
@@ -3847,12 +3842,10 @@ Deno.test("CellBridge result hydration updates pieces.json summary from current 
     },
   };
 
-  const addPiece = (bridge as unknown as { addPieceToSpace: AddPieceToSpace })
-    .addPieceToSpace.bind(bridge);
-  await addPiece(state, piece, "home");
+  const addPiece = bridge.accessForTestingOnly.addPieceToSpace;
+  await addPiece(state, piece as never, "home");
 
-  (bridge as unknown as { updatePiecesJson: UpdatePiecesJson }).updatePiecesJson
-    .call(bridge, state);
+  bridge.accessForTestingOnly.updatePiecesJson(state);
   let piecesJson = JSON.parse(
     getFileContent(tree, state.piecesIno, "pieces.json"),
   );
@@ -3892,13 +3885,11 @@ Deno.test("CellBridge reactive rebuild keeps inodes stable across a cell change"
       },
     };
 
-    const addPiece = (bridge as unknown as { addPieceToSpace: AddPieceToSpace })
-      .addPieceToSpace.bind(bridge);
-    await addPiece(state, piece, "home");
+    const addPiece = bridge.accessForTestingOnly.addPieceToSpace;
+    await addPiece(state, piece as never, "home");
 
     const pieceIno = tree.lookup(state.piecesIno, "Reactive-Stable")!;
-    await (bridge as unknown as { hydratePieceProp: HydratePieceProp })
-      .hydratePieceProp.call(bridge, pieceIno, "result");
+    await bridge.accessForTestingOnly.hydratePieceProp(pieceIno, "result");
 
     const resultIno = tree.lookup(pieceIno, "result")!;
     const titleIno = tree.lookup(resultIno, "title")!;
@@ -3953,17 +3944,18 @@ Deno.test("CellBridge refreshes pattern references after an in-place swap", asyn
     },
   };
 
-  const projectedName = await (bridge as unknown as {
-    addPieceToSpace: AddPieceToSpace;
-  }).addPieceToSpace(state, piece, "home");
+  const projectedName = await bridge.accessForTestingOnly.addPieceToSpace(
+    state,
+    piece as never,
+    "home",
+  );
   const entityName = encodeFuseComponent(piece.id);
   assertEquals(await bridge.resolveEntity(state.entitiesIno, entityName), true);
   const entityIno = tree.lookup(state.entitiesIno, entityName)!;
   assertEquals(await bridge.prepareLookup(entityIno, "meta.json"), true);
-  (bridge as unknown as { updatePiecesJson: UpdatePiecesJson })
-    .updatePiecesJson(
-      state,
-    );
+  bridge.accessForTestingOnly.updatePiecesJson(
+    state,
+  );
 
   patternRef = {
     identity: "B".repeat(43),
@@ -4034,13 +4026,11 @@ Deno.test("CellBridge pattern reference refresh fails closed", async () => {
         ? Promise.reject(new Error("unavailable"))
         : Promise.resolve(undefined),
   };
-  const refresh = (bridge as unknown as {
-    refreshPiecePatternMetadata: RefreshPiecePatternMetadata;
-  }).refreshPiecePatternMetadata.bind(bridge);
+  const refresh = bridge.accessForTestingOnly.refreshPiecePatternMetadata;
 
-  await refresh(state, piece, pieceIno);
+  await refresh(state, piece as never, pieceIno);
   shouldReject = false;
-  await refresh(state, piece, pieceIno);
+  await refresh(state, piece as never, pieceIno);
 
   assertEquals(state.pieceManifest.size, 0);
 });
@@ -4083,8 +4073,11 @@ Deno.test("CellBridge reports pattern metadata subscription failures", async () 
     Promise.reject(new Error("refresh failed"));
 
   try {
-    await (bridge as unknown as { addPieceToSpace: AddPieceToSpace })
-      .addPieceToSpace(state, piece, "home");
+    await bridge.accessForTestingOnly.addPieceToSpace(
+      state,
+      piece as never,
+      "home",
+    );
     await Promise.resolve();
   } finally {
     console.error = originalError;
@@ -4121,8 +4114,11 @@ Deno.test("CellBridge reports pattern metadata setup failures", async () => {
   };
 
   try {
-    await (bridge as unknown as { addPieceToSpace: AddPieceToSpace })
-      .addPieceToSpace(state, piece, "home");
+    await bridge.accessForTestingOnly.addPieceToSpace(
+      state,
+      piece as never,
+      "home",
+    );
   } finally {
     console.error = originalError;
   }
@@ -4140,24 +4136,23 @@ Deno.test("CellBridge.writeFsFile writes markdown frontmatter and body to FS pat
   const bridge = new CellBridge(tree, "/tmp/cf-exec");
   const writes: Array<{ path: (string | number)[]; value: unknown }> = [];
 
-  const ok = await (bridge as unknown as { writeFsFile: WriteFsFile })
-    .writeFsFile(
-      {
-        fsProjection: "markdown",
-        piece: {
-          result: {
-            set: (
-              value: unknown,
-              path?: (string | number)[],
-            ) => {
-              writes.push({ path: path ?? [], value });
-              return Promise.resolve();
-            },
+  const ok = await bridge.writeFsFile(
+    {
+      fsProjection: "markdown",
+      piece: {
+        result: {
+          set: (
+            value: unknown,
+            path?: (string | number)[],
+          ) => {
+            writes.push({ path: path ?? [], value });
+            return Promise.resolve();
           },
         },
       },
-      "---\ntitle: Updated Title\n---\n\nUpdated body",
-    );
+    } as WritePath,
+    "---\ntitle: Updated Title\n---\n\nUpdated body",
+  );
 
   assertEquals(ok, true);
   assertEquals(writes, [
@@ -4171,33 +4166,32 @@ Deno.test("CellBridge.writeFsFile removes deleted markdown frontmatter keys and 
   const bridge = new CellBridge(tree, "/tmp/cf-exec");
   const writes: Array<{ path: (string | number)[]; value: unknown }> = [];
 
-  const ok = await (bridge as unknown as { writeFsFile: WriteFsFile })
-    .writeFsFile(
-      {
-        fsProjection: "markdown",
-        piece: {
-          result: {
-            get: (path?: (string | number)[]) => {
-              if (path?.join("/") === "$FS/frontmatter") {
-                return Promise.resolve({
-                  title: "Old Title",
-                  stale: true,
-                });
-              }
-              return Promise.resolve(undefined);
-            },
-            set: (
-              value: unknown,
-              path?: (string | number)[],
-            ) => {
-              writes.push({ path: path ?? [], value });
-              return Promise.resolve();
-            },
+  const ok = await bridge.writeFsFile(
+    {
+      fsProjection: "markdown",
+      piece: {
+        result: {
+          get: (path?: (string | number)[]) => {
+            if (path?.join("/") === "$FS/frontmatter") {
+              return Promise.resolve({
+                title: "Old Title",
+                stale: true,
+              });
+            }
+            return Promise.resolve(undefined);
+          },
+          set: (
+            value: unknown,
+            path?: (string | number)[],
+          ) => {
+            writes.push({ path: path ?? [], value });
+            return Promise.resolve();
           },
         },
       },
-      "---\ntitle: Updated Title\ncount: 42\npublished: true\n---\n\nUpdated body",
-    );
+    } as WritePath,
+    "---\ntitle: Updated Title\ncount: 42\npublished: true\n---\n\nUpdated body",
+  );
 
   assertEquals(ok, true);
   assertEquals(writes, [
@@ -4214,36 +4208,35 @@ Deno.test("CellBridge.writeFsFile removes deleted keys from application/json pro
   const bridge = new CellBridge(tree, "/tmp/cf-exec");
   const writes: Array<{ path: (string | number)[]; value: unknown }> = [];
 
-  const ok = await (bridge as unknown as { writeFsFile: WriteFsFile })
-    .writeFsFile(
-      {
-        fsProjection: "json",
-        piece: {
-          result: {
-            get: (path?: (string | number)[]) => {
-              if (path?.join("/") === "$FS") {
-                return Promise.resolve({
-                  type: "application/json",
-                  content: { title: "Old", stale: true },
-                });
-              }
-              if (path?.join("/") === "$FS/content") {
-                return Promise.resolve({ title: "Old", stale: true });
-              }
-              return Promise.resolve(undefined);
-            },
-            set: (
-              value: unknown,
-              path?: (string | number)[],
-            ) => {
-              writes.push({ path: path ?? [], value });
-              return Promise.resolve();
-            },
+  const ok = await bridge.writeFsFile(
+    {
+      fsProjection: "json",
+      piece: {
+        result: {
+          get: (path?: (string | number)[]) => {
+            if (path?.join("/") === "$FS") {
+              return Promise.resolve({
+                type: "application/json",
+                content: { title: "Old", stale: true },
+              });
+            }
+            if (path?.join("/") === "$FS/content") {
+              return Promise.resolve({ title: "Old", stale: true });
+            }
+            return Promise.resolve(undefined);
+          },
+          set: (
+            value: unknown,
+            path?: (string | number)[],
+          ) => {
+            writes.push({ path: path ?? [], value });
+            return Promise.resolve();
           },
         },
       },
-      '{"title":"New"}',
-    );
+    } as WritePath,
+    '{"title":"New"}',
+  );
 
   assertEquals(ok, true);
   assertEquals(writes, [
@@ -4270,8 +4263,12 @@ Deno.test("CellBridge.buildSourceTree encodes source path segments and decodes w
   state.pieceControllers.set("notes", piece as never);
   state.srcInos.set("notes", pieceIno);
 
-  await (bridge as unknown as { buildSourceTree: BuildSourceTree })
-    .buildSourceTree(pieceIno, piece, state, "notes");
+  await bridge.accessForTestingOnly.buildSourceTree(
+    pieceIno,
+    piece as never,
+    state,
+    "notes",
+  );
 
   const srcIno = tree.lookup(pieceIno, ".src")!;
   const srcDirIno = tree.lookup(srcIno, "src")!;
@@ -4358,8 +4355,12 @@ Deno.test("CellBridge decodes encoded space directory names for source write pat
   state.pieceInos.set("notes", pieceIno);
   state.srcInos.set("notes", pieceIno);
 
-  await (bridge as unknown as { buildSourceTree: BuildSourceTree })
-    .buildSourceTree(pieceIno, piece, state, "notes");
+  await bridge.accessForTestingOnly.buildSourceTree(
+    pieceIno,
+    piece as never,
+    state,
+    "notes",
+  );
 
   const srcIno = tree.lookup(pieceIno, ".src")!;
   const srcDirIno = tree.lookup(srcIno, "src")!;
@@ -4413,13 +4414,11 @@ Deno.test("CellBridge.syncPieceListOnce adds a new piece to the tree", async () 
   // Build the space with only the first piece already added
   const state = buildTestSpace(bridge, "home", [existingPiece, newPiece]);
 
-  const addPiece = (bridge as unknown as { addPieceToSpace: AddPieceToSpace })
-    .addPieceToSpace.bind(bridge);
-  await addPiece(state, existingPiece, "home");
+  const addPiece = bridge.accessForTestingOnly.addPieceToSpace;
+  await addPiece(state, existingPiece as never, "home");
 
   // The registry mock now returns both pieces, so sync should add p2.
-  await (bridge as unknown as { syncPieceListOnce: SyncPieceListOnce })
-    .syncPieceListOnce.call(bridge, state, "home");
+  await bridge.accessForTestingOnly.syncPieceListOnce(state, "home");
 
   assertEquals(
     tree.lookup(state.piecesIno, "Piece-Two") !== undefined,
@@ -4450,9 +4449,8 @@ Deno.test("CellBridge.syncPieceListOnce removes a deleted piece from the tree", 
   // Start with one piece in the tree
   const state = buildTestSpace(bridge, "home", []);
 
-  const addPiece = (bridge as unknown as { addPieceToSpace: AddPieceToSpace })
-    .addPieceToSpace.bind(bridge);
-  await addPiece(state, piece, "home");
+  const addPiece = bridge.accessForTestingOnly.addPieceToSpace;
+  await addPiece(state, piece as never, "home");
 
   // Verify it was added
   assertEquals(
@@ -4469,8 +4467,7 @@ Deno.test("CellBridge.syncPieceListOnce removes a deleted piece from the tree", 
     } as unknown as SpaceState["pieces"],
   );
 
-  await (bridge as unknown as { syncPieceListOnce: SyncPieceListOnce })
-    .syncPieceListOnce.call(bridge, state, "home");
+  await bridge.accessForTestingOnly.syncPieceListOnce(state, "home");
 
   assertEquals(
     tree.lookup(state.piecesIno, "Gone-Piece"),
@@ -4512,9 +4509,8 @@ Deno.test({
     };
 
     // First, add the piece to the space to set up the directory and state maps
-    const addPiece = (bridge as unknown as { addPieceToSpace: AddPieceToSpace })
-      .addPieceToSpace.bind(bridge);
-    await addPiece(state, piece, "home");
+    const addPiece = bridge.accessForTestingOnly.addPieceToSpace;
+    await addPiece(state, piece as never, "home");
 
     // Verify initial state
     assertEquals(
@@ -4528,15 +4524,13 @@ Deno.test({
     if (addedSubs) { for (const cancel of addedSubs) cancel(); }
 
     // Now call subscribePiece separately to attach the rename sink
-    const subs = await (bridge as unknown as { subscribePiece: SubscribePiece })
-      .subscribePiece.call(
-        bridge,
-        piece,
-        tree.lookup(state.piecesIno, "Old-Name")!,
-        "Old-Name",
-        "home",
-        state,
-      );
+    const subs = await bridge.accessForTestingOnly.subscribePiece(
+      piece as never,
+      tree.lookup(state.piecesIno, "Old-Name")!,
+      "Old-Name",
+      "home",
+      state,
+    );
 
     // Store updated subs
     state.pieceSubs.set("Old-Name", subs);
@@ -4588,9 +4582,8 @@ Deno.test("CellBridge.addPieceToSpace normalizes projected piece directory names
     },
   };
 
-  const addPiece = (bridge as unknown as { addPieceToSpace: AddPieceToSpace })
-    .addPieceToSpace.bind(bridge);
-  const projectedName = await addPiece(state, piece, "home");
+  const addPiece = bridge.accessForTestingOnly.addPieceToSpace;
+  const projectedName = await addPiece(state, piece as never, "home");
 
   assertEquals(projectedName, "Hello-world-notes");
   assertEquals(
@@ -4628,9 +4621,8 @@ Deno.test("CellBridge.addPieceToSpace falls back to a normalized piece id for sy
     },
   };
 
-  const addPiece = (bridge as unknown as { addPieceToSpace: AddPieceToSpace })
-    .addPieceToSpace.bind(bridge);
-  const projectedName = await addPiece(state, piece, "home");
+  const addPiece = bridge.accessForTestingOnly.addPieceToSpace;
+  const projectedName = await addPiece(state, piece as never, "home");
 
   assertEquals(projectedName, "of-emoji-piece");
   assertEquals(
@@ -4664,23 +4656,20 @@ Deno.test({
       },
     };
 
-    const addPiece = (bridge as unknown as { addPieceToSpace: AddPieceToSpace })
-      .addPieceToSpace.bind(bridge);
-    await addPiece(state, piece, "home");
+    const addPiece = bridge.accessForTestingOnly.addPieceToSpace;
+    await addPiece(state, piece as never, "home");
 
     // Cancel the addPieceToSpace subs before creating new ones
     const addedSubs = state.pieceSubs.get("Start-Here");
     if (addedSubs) { for (const cancel of addedSubs) cancel(); }
 
-    const subs = await (bridge as unknown as { subscribePiece: SubscribePiece })
-      .subscribePiece.call(
-        bridge,
-        piece,
-        tree.lookup(state.piecesIno, "Start-Here")!,
-        "Start-Here",
-        "home",
-        state,
-      );
+    const subs = await bridge.accessForTestingOnly.subscribePiece(
+      piece as never,
+      tree.lookup(state.piecesIno, "Start-Here")!,
+      "Start-Here",
+      "home",
+      state,
+    );
 
     state.pieceSubs.set("Start-Here", subs);
 
@@ -4734,13 +4723,11 @@ Deno.test("CellBridge.subscribePiece clears stale FS root entries when result sw
     },
   };
 
-  const addPiece = (bridge as unknown as { addPieceToSpace: AddPieceToSpace })
-    .addPieceToSpace.bind(bridge);
-  await addPiece(state, piece, "home");
+  const addPiece = bridge.accessForTestingOnly.addPieceToSpace;
+  await addPiece(state, piece as never, "home");
 
   const pieceIno = tree.lookup(state.piecesIno, "FS-Piece")!;
-  await (bridge as unknown as { hydratePieceProp: HydratePieceProp })
-    .hydratePieceProp.call(bridge, pieceIno, "result");
+  await bridge.accessForTestingOnly.hydratePieceProp(pieceIno, "result");
   assertEquals(tree.lookup(pieceIno, "index.md") !== undefined, true);
   assertEquals(tree.lookup(pieceIno, "meta") !== undefined, true);
   assertEquals(tree.lookup(pieceIno, "result"), undefined);
@@ -4755,8 +4742,7 @@ Deno.test("CellBridge.subscribePiece clears stale FS root entries when result sw
     isJsonFile: false,
     piece: piece as unknown as WritePath["piece"],
   });
-  await (bridge as unknown as { hydratePieceProp: HydratePieceProp })
-    .hydratePieceProp.call(bridge, pieceIno, "result");
+  await bridge.accessForTestingOnly.hydratePieceProp(pieceIno, "result");
 
   const resultIno = tree.lookup(pieceIno, "result");
   assertEquals(resultIno !== undefined, true, "result/ dir should exist");
@@ -4825,13 +4811,11 @@ Deno.test("CellBridge hydrates and writes back markdown FS projection scalars", 
     },
   };
 
-  const addPiece = (bridge as unknown as { addPieceToSpace: AddPieceToSpace })
-    .addPieceToSpace.bind(bridge);
-  await addPiece(state, piece, "home");
+  const addPiece = bridge.accessForTestingOnly.addPieceToSpace;
+  await addPiece(state, piece as never, "home");
 
   const pieceIno = tree.lookup(state.piecesIno, "FS-Roundtrip")!;
-  await (bridge as unknown as { hydratePieceProp: HydratePieceProp })
-    .hydratePieceProp.call(bridge, pieceIno, "result");
+  await bridge.accessForTestingOnly.hydratePieceProp(pieceIno, "result");
 
   const index = getFileContent(tree, pieceIno, "index.md");
   assertEquals(
@@ -4844,14 +4828,13 @@ Deno.test("CellBridge hydrates and writes back markdown FS projection scalars", 
   const metaIno = tree.lookup(pieceIno, "meta")!;
   assertEquals(getFileContent(tree, metaIno, "pinned"), "true");
 
-  const ok = await (bridge as unknown as { writeFsFile: WriteFsFile })
-    .writeFsFile(
-      {
-        fsProjection: "markdown",
-        piece: piece as unknown as WritePath["piece"],
-      },
-      "---\nentityId: attacker\ntitle: Updated\ncount: 8\npublished: true\n---\n\nUpdated body",
-    );
+  const ok = await bridge.writeFsFile(
+    {
+      fsProjection: "markdown",
+      piece: piece as unknown as WritePath["piece"],
+    } as WritePath,
+    "---\nentityId: attacker\ntitle: Updated\ncount: 8\npublished: true\n---\n\nUpdated body",
+  );
 
   assertEquals(ok, true);
   assertEquals(writes, [
@@ -4906,9 +4889,8 @@ Deno.test({
       },
     };
 
-    const addPiece = (bridge as unknown as { addPieceToSpace: AddPieceToSpace })
-      .addPieceToSpace.bind(bridge);
-    await addPiece(state, piece, "home");
+    const addPiece = bridge.accessForTestingOnly.addPieceToSpace;
+    await addPiece(state, piece as never, "home");
 
     const pieceIno = tree.lookup(state.piecesIno, "Status-Piece")!;
     assertEquals(tree.lookup(pieceIno, "result") !== undefined, true);
@@ -5052,13 +5034,11 @@ Deno.test({
       },
     };
 
-    const addPiece = (bridge as unknown as { addPieceToSpace: AddPieceToSpace })
-      .addPieceToSpace.bind(bridge);
-    await addPiece(state, piece, "home");
+    const addPiece = bridge.accessForTestingOnly.addPieceToSpace;
+    await addPiece(state, piece as never, "home");
 
     const pieceIno = tree.lookup(state.piecesIno, "Undefined-Sink-Piece")!;
-    await (bridge as unknown as { hydratePieceProp: HydratePieceProp })
-      .hydratePieceProp.call(bridge, pieceIno, "result");
+    await bridge.accessForTestingOnly.hydratePieceProp(pieceIno, "result");
     resultCell.set(undefined);
     await new Promise((r) => setTimeout(r, 250));
 
@@ -5101,13 +5081,11 @@ Deno.test({
       },
     };
 
-    const addPiece = (bridge as unknown as { addPieceToSpace: AddPieceToSpace })
-      .addPieceToSpace.bind(bridge);
-    await addPiece(state, piece, "home");
+    const addPiece = bridge.accessForTestingOnly.addPieceToSpace;
+    await addPiece(state, piece as never, "home");
 
     const pieceIno = tree.lookup(state.piecesIno, "Undefined-Transient-Piece")!;
-    await (bridge as unknown as { hydratePieceProp: HydratePieceProp })
-      .hydratePieceProp.call(bridge, pieceIno, "result");
+    await bridge.accessForTestingOnly.hydratePieceProp(pieceIno, "result");
 
     getterValue = undefined;
     resultCell.set(undefined);
@@ -5145,13 +5123,11 @@ Deno.test("CellBridge.invalidateWritePath clears hydrated piece result cache", a
     },
   };
 
-  const addPiece = (bridge as unknown as { addPieceToSpace: AddPieceToSpace })
-    .addPieceToSpace.bind(bridge);
-  await addPiece(state, piece, "home");
+  const addPiece = bridge.accessForTestingOnly.addPieceToSpace;
+  await addPiece(state, piece as never, "home");
 
   const pieceIno = tree.lookup(state.piecesIno, "Invalidate-Piece")!;
-  await (bridge as unknown as { hydratePieceProp: HydratePieceProp })
-    .hydratePieceProp.call(bridge, pieceIno, "result");
+  await bridge.accessForTestingOnly.hydratePieceProp(pieceIno, "result");
   assertEquals(tree.lookup(pieceIno, "result") !== undefined, true);
 
   bridge.invalidateWritePath({
@@ -5199,9 +5175,8 @@ Deno.test("CellBridge.invalidateHandlerTarget clears hydrated entity result cach
     }),
   };
 
-  const addPiece = (bridge as unknown as { addPieceToSpace: AddPieceToSpace })
-    .addPieceToSpace.bind(bridge);
-  await addPiece(state, piece, "home");
+  const addPiece = bridge.accessForTestingOnly.addPieceToSpace;
+  await addPiece(state, piece as never, "home");
 
   await bridge.resolveEntity(state.entitiesIno, "of%3Aentity-handler-piece");
   const entityIno = tree.lookup(
@@ -5313,14 +5288,14 @@ Deno.test("CellBridge.invalidateWritePath does not spawn concurrent hydrations f
     },
   };
 
-  const addPiece = (bridge as unknown as { addPieceToSpace: AddPieceToSpace })
-    .addPieceToSpace.bind(bridge);
-  await addPiece(state, piece, "home");
+  const addPiece = bridge.accessForTestingOnly.addPieceToSpace;
+  await addPiece(state, piece as never, "home");
 
   const pieceIno = tree.lookup(state.piecesIno, "Race-Piece")!;
-  const firstHydration = (bridge as unknown as {
-    hydratePieceProp: HydratePieceProp;
-  }).hydratePieceProp.call(bridge, pieceIno, "result");
+  const firstHydration = bridge.accessForTestingOnly.hydratePieceProp(
+    pieceIno,
+    "result",
+  );
 
   await Promise.resolve();
   bridge.invalidateWritePath({
@@ -5331,9 +5306,10 @@ Deno.test("CellBridge.invalidateWritePath does not spawn concurrent hydrations f
     isJsonFile: false,
     piece: piece as unknown as WritePath["piece"],
   });
-  const secondHydration = (bridge as unknown as {
-    hydratePieceProp: HydratePieceProp;
-  }).hydratePieceProp.call(bridge, pieceIno, "result");
+  const secondHydration = bridge.accessForTestingOnly.hydratePieceProp(
+    pieceIno,
+    "result",
+  );
 
   if (resolveFirstGet) resolveFirstGet();
   await Promise.all([firstHydration, secondHydration]);
@@ -5519,8 +5495,12 @@ Deno.test("CellBridge stops tracking a synthetic error.log the source takes over
   };
   state.pieceControllers.set("notes", piece as never);
   const build = () =>
-    (bridge as unknown as { buildSourceTree: BuildSourceTree })
-      .buildSourceTree(pieceIno, piece, state, "notes");
+    bridge.accessForTestingOnly.buildSourceTree(
+      pieceIno,
+      piece as never,
+      state,
+      "notes",
+    );
 
   // First rebuild: nothing claims the name, so the synthetic log exists.
   await build();

--- a/packages/fuse/cell-bridge.ts
+++ b/packages/fuse/cell-bridge.ts
@@ -318,13 +318,15 @@ interface PiecePropRootInfo {
   propName: "input" | "result";
 }
 
-interface UnhydratedEntityRootInfo {
+/** What the bridge knows about an entity root it has not yet hydrated. */
+export interface UnhydratedEntityRootInfo {
   state: SpaceState;
   spaceName: string;
   entityId: string;
 }
 
-interface EntityProjectionLookupOwner {
+/** The root an entity-projection lookup pin belongs to, and its pin count. */
+export interface EntityProjectionLookupOwner {
   rootIno: bigint;
   count: bigint;
 }
@@ -361,11 +363,12 @@ interface PropRebuildJob {
 }
 
 export class CellBridge {
-  // A member below declared `private` rather than `#` is one
-  // `cell-bridge.test.ts` reaches and drives directly; a `#` name would put
-  // it out of that test's reach. Three also keep a leading `_` that this
-  // convention otherwise drops, `_attemptReconnect`, `_disconnected`, and
-  // `_reconnectTimer` being the names the test uses.
+  // Four methods below stay TypeScript-`private` rather than `#`, which is
+  // the convention elsewhere in this class: `cell-bridge.test.ts` replaces
+  // each by assignment, which a `#` method does not allow. They are
+  // `refreshPiecePatternMetadata()`, `rebuildPieceProp()`,
+  // `updateIndexJson()`, and `buildSourceTree()`, and each carries a note
+  // naming the test that replaces it.
 
   tree: FsTree;
   spaces: Map<string, SpaceState> = new Map();
@@ -382,12 +385,12 @@ export class CellBridge {
   #connecting = new Map<string, Promise<SpaceState>>();
 
   /** In-flight piece-list synchronization keyed by space name. */
-  private pieceSyncs = new Map<string, Promise<void>>();
+  #pieceSyncs = new Map<string, Promise<void>>();
 
   /** Flag: re-run sync after current pass completes. */
-  private syncAgain: Set<string> = new Set();
+  #syncAgain: Set<string> = new Set();
 
-  private pendingPieceHydrations = new Map<string, Promise<void>>();
+  #pendingPieceHydrations = new Map<string, Promise<void>>();
 
   /** Coalesced subtree rebuilds keyed by piece inode + prop name. */
   #pendingPropRebuilds = new Map<
@@ -408,30 +411,30 @@ export class CellBridge {
   #execCli: string;
   #pieceRoots = new Map<bigint, PieceRootInfo>();
 
-  private unhydratedEntityRoots = new Map<
+  #unhydratedEntityRoots = new Map<
     bigint,
     UnhydratedEntityRootInfo
   >();
 
-  private pendingEntityHydrations = new Map<bigint, Promise<boolean>>();
+  #pendingEntityHydrations = new Map<bigint, Promise<boolean>>();
   #pendingEntityDirectorySnapshots = new Map<
     SpaceState,
     Promise<readonly DirectorySnapshotEntry[]>
   >();
 
-  private entityProjectionLru = new Map<bigint, UnhydratedEntityRootInfo>();
+  #entityProjectionLru = new Map<bigint, UnhydratedEntityRootInfo>();
 
-  private entityProjectionEvictionCandidates = new Map<
+  #entityProjectionEvictionCandidates = new Map<
     bigint,
     UnhydratedEntityRootInfo
   >();
 
-  private entityProjectionUseOrder = new Map<bigint, number>();
+  #entityProjectionUseOrder = new Map<bigint, number>();
   #nextEntityProjectionUseOrder = 0;
 
-  private entityProjectionLookupRefs = new Map<bigint, bigint>();
+  #entityProjectionLookupRefs = new Map<bigint, bigint>();
 
-  private entityProjectionLookupOwners = new Map<
+  #entityProjectionLookupOwners = new Map<
     bigint,
     EntityProjectionLookupOwner
   >();
@@ -443,9 +446,9 @@ export class CellBridge {
   >();
   #entityProjectionOpenOwnerInodes = new Map<bigint, Set<bigint>>();
 
-  private pendingEntityRemovals = new Map<bigint, UnhydratedEntityRootInfo>();
+  #pendingEntityRemovals = new Map<bigint, UnhydratedEntityRootInfo>();
 
-  private entitySubscriptions = new Map<bigint, Cancel[]>();
+  #entitySubscriptions = new Map<bigint, Cancel[]>();
   #piecePropRoots = new Map<bigint, PiecePropRootInfo>();
   #hydratedPieceProps = new Map<bigint, Set<"input" | "result">>();
 
@@ -479,21 +482,169 @@ export class CellBridge {
    * so agents get immediate feedback rather than silent data loss.
    * Reconnection is attempted automatically with exponential backoff.
    */
-  private _disconnected = false;
+  #disconnected = false;
 
   #disconnectCount = 0;
   #lastDisconnectReason: string | null = null;
 
-  private _reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  #reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+
+  /**
+   * The synchronization and hydration tables, the entity-projection tables,
+   * the disconnection state, and the tree-building steps this bridge keeps to
+   * itself, which a test drives directly.
+   */
+  get accessForTestingOnly(): {
+    readonly pieceSyncs: Map<string, Promise<void>>;
+    readonly syncAgain: Set<string>;
+    readonly pendingPieceHydrations: Map<string, Promise<void>>;
+    readonly unhydratedEntityRoots: Map<bigint, UnhydratedEntityRootInfo>;
+    readonly pendingEntityHydrations: Map<bigint, Promise<boolean>>;
+    entityProjectionLru: Map<bigint, UnhydratedEntityRootInfo>;
+    entityProjectionEvictionCandidates: Map<bigint, UnhydratedEntityRootInfo>;
+    readonly entityProjectionUseOrder: Map<bigint, number>;
+    readonly entityProjectionLookupRefs: Map<bigint, bigint>;
+    entityProjectionLookupOwners: Map<bigint, EntityProjectionLookupOwner>;
+    readonly pendingEntityRemovals: Map<bigint, UnhydratedEntityRootInfo>;
+    readonly entitySubscriptions: Map<bigint, Cancel[]>;
+    disconnected: boolean;
+    reconnectTimer: ReturnType<typeof setTimeout> | null;
+    attemptReconnect(): Promise<void>;
+    enqueuePiecePropRebuild(args: PropRebuildJob): Promise<void>;
+    hydratePieceProp(
+      pieceIno: bigint,
+      propName: "input" | "result",
+      retries?: number,
+    ): Promise<boolean>;
+    buildSpaceTree(spaceName: string, pieces: PiecesController): SpaceState;
+    addPieceToSpace(
+      state: SpaceState,
+      piece: PieceController,
+      spaceName: string,
+    ): Promise<string>;
+    syncPieceListOnce(state: SpaceState, spaceName: string): Promise<void>;
+    updatePiecesJson(state: SpaceState): void;
+    subscribePiece(
+      piece: PieceController,
+      pieceIno: bigint,
+      pieceName: string,
+      spaceName: string,
+      state: SpaceState,
+    ): Promise<Cancel[]>;
+    makeLinkResolver(spaceName: string): ResolveLink;
+    loadPieceTree(
+      piece: PieceController,
+      parentIno: bigint,
+      name: string,
+      spaceName: string,
+      existingIno?: bigint,
+      rootKind?: "pieces" | "entities",
+    ): Promise<bigint>;
+    refreshPiecePatternMetadata(
+      state: SpaceState,
+      piece: PieceController,
+      pieceIno: bigint,
+    ): Promise<void>;
+    rebuildPieceProp(args: PropRebuildJob): Promise<void>;
+    updateIndexJson(state: SpaceState): void;
+    buildSourceTree(
+      pieceIno: bigint,
+      piece: PieceController,
+      state: SpaceState,
+      pieceName: string,
+    ): Promise<void>;
+  } {
+    // deno-lint-ignore no-this-alias
+    const outerThis = this;
+    return {
+      pieceSyncs: this.#pieceSyncs,
+      syncAgain: this.#syncAgain,
+      pendingPieceHydrations: this.#pendingPieceHydrations,
+      unhydratedEntityRoots: this.#unhydratedEntityRoots,
+      pendingEntityHydrations: this.#pendingEntityHydrations,
+      get entityProjectionLru() {
+        return outerThis.#entityProjectionLru;
+      },
+      set entityProjectionLru(value) {
+        outerThis.#entityProjectionLru = value;
+      },
+      get entityProjectionEvictionCandidates() {
+        return outerThis.#entityProjectionEvictionCandidates;
+      },
+      set entityProjectionEvictionCandidates(value) {
+        outerThis.#entityProjectionEvictionCandidates = value;
+      },
+      entityProjectionUseOrder: this.#entityProjectionUseOrder,
+      entityProjectionLookupRefs: this.#entityProjectionLookupRefs,
+      get entityProjectionLookupOwners() {
+        return outerThis.#entityProjectionLookupOwners;
+      },
+      set entityProjectionLookupOwners(value) {
+        outerThis.#entityProjectionLookupOwners = value;
+      },
+      pendingEntityRemovals: this.#pendingEntityRemovals,
+      entitySubscriptions: this.#entitySubscriptions,
+      get disconnected() {
+        return outerThis.#disconnected;
+      },
+      set disconnected(value) {
+        outerThis.#disconnected = value;
+      },
+      get reconnectTimer() {
+        return outerThis.#reconnectTimer;
+      },
+      set reconnectTimer(value) {
+        outerThis.#reconnectTimer = value;
+      },
+      attemptReconnect: () => this.#attemptReconnect(),
+      enqueuePiecePropRebuild: (args) => this.#enqueuePiecePropRebuild(args),
+      hydratePieceProp: (pieceIno, propName, retries) =>
+        this.#hydratePieceProp(pieceIno, propName, retries),
+      buildSpaceTree: (spaceName, pieces) =>
+        this.#buildSpaceTree(spaceName, pieces),
+      addPieceToSpace: (state, piece, spaceName) =>
+        this.#addPieceToSpace(state, piece, spaceName),
+      syncPieceListOnce: (state, spaceName) =>
+        this.#syncPieceListOnce(state, spaceName),
+      updatePiecesJson: (state) => this.#updatePiecesJson(state),
+      subscribePiece: (piece, pieceIno, pieceName, spaceName, state) =>
+        this.#subscribePiece(piece, pieceIno, pieceName, spaceName, state),
+      makeLinkResolver: (spaceName) => this.#makeLinkResolver(spaceName),
+      loadPieceTree: (
+        piece,
+        parentIno,
+        name,
+        spaceName,
+        existingIno,
+        rootKind,
+      ) =>
+        this.#loadPieceTree(
+          piece,
+          parentIno,
+          name,
+          spaceName,
+          existingIno,
+          rootKind,
+        ),
+      // The next four forward to TypeScript-private members so that a test
+      // which replaces one by assignment is honored here too.
+      refreshPiecePatternMetadata: (state, piece, pieceIno) =>
+        this.refreshPiecePatternMetadata(state, piece, pieceIno),
+      rebuildPieceProp: (args) => this.rebuildPieceProp(args),
+      updateIndexJson: (state) => this.updateIndexJson(state),
+      buildSourceTree: (pieceIno, piece, state, pieceName) =>
+        this.buildSourceTree(pieceIno, piece, state, pieceName),
+    };
+  }
 
   get disconnected(): boolean {
-    return this._disconnected;
+    return this.#disconnected;
   }
 
   /** Mark the bridge as disconnected and schedule reconnection. */
   markDisconnected(reason: string): void {
-    if (this._disconnected) return;
-    this._disconnected = true;
+    if (this.#disconnected) return;
+    this.#disconnected = true;
     this.#disconnectCount++;
     this.#lastDisconnectReason = reason;
     console.error(
@@ -509,17 +660,17 @@ export class CellBridge {
   }
 
   #scheduleReconnect(): void {
-    if (this._reconnectTimer !== null) clearTimeout(this._reconnectTimer);
+    if (this.#reconnectTimer !== null) clearTimeout(this.#reconnectTimer);
     const timerId = setTimeout(() => {
-      this._reconnectTimer = null;
-      this._attemptReconnect();
+      this.#reconnectTimer = null;
+      this.#attemptReconnect();
     }, this.#reconnectDelayMs());
     // Don't prevent Deno process from exiting while waiting to reconnect
     Deno.unrefTimer(timerId);
-    this._reconnectTimer = timerId;
+    this.#reconnectTimer = timerId;
   }
 
-  private async _attemptReconnect(): Promise<void> {
+  async #attemptReconnect(): Promise<void> {
     const spaces = [...this.spaces];
     let allSpacesRestored = spaces.length > 0;
     for (const [spaceName, state] of spaces) {
@@ -559,7 +710,7 @@ export class CellBridge {
       }
     }
     if (allSpacesRestored) {
-      this._disconnected = false;
+      this.#disconnected = false;
       this.#disconnectCount = 0;
       console.error(
         `[FUSE] Backend connection restored — write access resumed.`,
@@ -753,7 +904,7 @@ export class CellBridge {
         startedAt: this.#startedAt,
         spaces,
         connection: {
-          disconnected: this._disconnected,
+          disconnected: this.#disconnected,
           disconnectCount: this.#disconnectCount,
           lastDisconnectReason: this.#lastDisconnectReason,
         },
@@ -806,7 +957,13 @@ export class CellBridge {
     this.#updatePieceManifest(state, piece.id, { summary, patternRef });
   }
 
-  /** Refresh synthetic pattern metadata after an in-place pattern swap. */
+  /**
+   * Refreshes synthetic pattern metadata after an in-place pattern swap.
+   *
+   * TypeScript-private rather than a `#` name, because
+   * `cell-bridge.test.ts` replaces this member by assignment, which a `#`
+   * method does not allow.
+   */
   private async refreshPiecePatternMetadata(
     state: SpaceState,
     piece: PieceController,
@@ -834,7 +991,7 @@ export class CellBridge {
     }
 
     if (manifestChanged) {
-      this.updatePiecesJson(state);
+      this.#updatePiecesJson(state);
     }
     if (this.onInvalidate) {
       this.onInvalidate(pieceIno, ["meta.json"]);
@@ -923,10 +1080,10 @@ export class CellBridge {
     try {
       pieces = await this.#createSpacePieces(spaceName);
       await this.#verifyPiecesConnection(pieces);
-      state = this.buildSpaceTree(spaceName, pieces);
+      state = this.#buildSpaceTree(spaceName, pieces);
 
       this.updateIndexJson(state);
-      this.updatePiecesJson(state);
+      this.#updatePiecesJson(state);
       this.spaces.set(spaceName, state);
       this.knownSpaces.set(spaceName, state.did);
       this.#updateSpacesJson();
@@ -967,19 +1124,19 @@ export class CellBridge {
     }
     for (const [, ino] of this.tree.getChildren(state.entitiesIno)) {
       this.#cancelEntitySubscriptions(ino);
-      this.unhydratedEntityRoots.delete(ino);
-      this.pendingEntityHydrations.delete(ino);
-      this.entityProjectionLru.delete(ino);
-      this.entityProjectionEvictionCandidates.delete(ino);
-      this.entityProjectionUseOrder.delete(ino);
+      this.#unhydratedEntityRoots.delete(ino);
+      this.#pendingEntityHydrations.delete(ino);
+      this.#entityProjectionLru.delete(ino);
+      this.#entityProjectionEvictionCandidates.delete(ino);
+      this.#entityProjectionUseOrder.delete(ino);
       this.#clearEntityProjectionReferences(ino);
-      this.pendingEntityRemovals.delete(ino);
+      this.#pendingEntityRemovals.delete(ino);
       this.#unregisterPieceRoot(ino);
     }
-    this.pendingPieceHydrations.delete(spaceName);
+    this.#pendingPieceHydrations.delete(spaceName);
     this.#pendingEntityDirectorySnapshots.delete(state);
-    this.pieceSyncs.delete(spaceName);
-    this.syncAgain.delete(spaceName);
+    this.#pieceSyncs.delete(spaceName);
+    this.#syncAgain.delete(spaceName);
     this.tree.removeChild(
       this.tree.rootIno,
       encodeSpaceDirectoryName(spaceName),
@@ -1073,8 +1230,8 @@ export class CellBridge {
   }
 
   #isEntityProjectionRoot(ino: bigint): boolean {
-    return this.unhydratedEntityRoots.has(ino) ||
-      this.pendingEntityRemovals.has(ino) ||
+    return this.#unhydratedEntityRoots.has(ino) ||
+      this.#pendingEntityRemovals.has(ino) ||
       this.#pieceRoots.get(ino)?.rootKind === "entities";
   }
 
@@ -1089,7 +1246,7 @@ export class CellBridge {
 
   retainEntityProjectionLookup(ino: bigint, count = 1n): void {
     if (count <= 0n) return;
-    const owner = this.entityProjectionLookupOwners.get(ino);
+    const owner = this.#entityProjectionLookupOwners.get(ino);
     const rootIno = owner?.rootIno ?? this.#entityProjectionRootForInode(ino);
     if (rootIno === undefined) return;
     if (owner === undefined) {
@@ -1099,30 +1256,30 @@ export class CellBridge {
         ino,
       );
     }
-    this.entityProjectionLookupOwners.set(ino, {
+    this.#entityProjectionLookupOwners.set(ino, {
       rootIno,
       count: (owner?.count ?? 0n) + count,
     });
-    this.entityProjectionLookupRefs.set(
+    this.#entityProjectionLookupRefs.set(
       rootIno,
-      (this.entityProjectionLookupRefs.get(rootIno) ?? 0n) + count,
+      (this.#entityProjectionLookupRefs.get(rootIno) ?? 0n) + count,
     );
-    this.entityProjectionEvictionCandidates.delete(rootIno);
+    this.#entityProjectionEvictionCandidates.delete(rootIno);
   }
 
   releaseEntityProjectionLookup(ino: bigint, count = 1n): void {
     if (count <= 0n) return;
-    const owner = this.entityProjectionLookupOwners.get(ino);
+    const owner = this.#entityProjectionLookupOwners.get(ino);
     if (owner === undefined) return;
     const released = count > owner.count ? owner.count : count;
     const ownerRemaining = owner.count - released;
     if (ownerRemaining > 0n) {
-      this.entityProjectionLookupOwners.set(ino, {
+      this.#entityProjectionLookupOwners.set(ino, {
         rootIno: owner.rootIno,
         count: ownerRemaining,
       });
     } else {
-      this.entityProjectionLookupOwners.delete(ino);
+      this.#entityProjectionLookupOwners.delete(ino);
       this.#unindexEntityProjectionOwner(
         this.#entityProjectionLookupOwnerInodes,
         owner.rootIno,
@@ -1130,11 +1287,11 @@ export class CellBridge {
       );
     }
     const remaining =
-      (this.entityProjectionLookupRefs.get(owner.rootIno) ?? 0n) - released;
+      (this.#entityProjectionLookupRefs.get(owner.rootIno) ?? 0n) - released;
     if (remaining > 0n) {
-      this.entityProjectionLookupRefs.set(owner.rootIno, remaining);
+      this.#entityProjectionLookupRefs.set(owner.rootIno, remaining);
     } else {
-      this.entityProjectionLookupRefs.delete(owner.rootIno);
+      this.#entityProjectionLookupRefs.delete(owner.rootIno);
     }
     this.#finishPendingEntityRemoval(owner.rootIno);
     this.#refreshEntityProjectionEvictionCandidate(owner.rootIno);
@@ -1160,7 +1317,7 @@ export class CellBridge {
       rootIno,
       (this.#entityProjectionOpenRefs.get(rootIno) ?? 0) + 1,
     );
-    this.entityProjectionEvictionCandidates.delete(rootIno);
+    this.#entityProjectionEvictionCandidates.delete(rootIno);
   }
 
   releaseEntityProjectionOpen(ino: bigint): void {
@@ -1216,13 +1373,13 @@ export class CellBridge {
   }
 
   #clearEntityProjectionReferences(rootIno: bigint): void {
-    this.entityProjectionLookupRefs.delete(rootIno);
+    this.#entityProjectionLookupRefs.delete(rootIno);
     this.#entityProjectionOpenRefs.delete(rootIno);
     for (
       const ino of this.#entityProjectionLookupOwnerInodes.get(rootIno) ??
         []
     ) {
-      this.entityProjectionLookupOwners.delete(ino);
+      this.#entityProjectionLookupOwners.delete(ino);
     }
     this.#entityProjectionLookupOwnerInodes.delete(rootIno);
     for (
@@ -1243,7 +1400,7 @@ export class CellBridge {
     if (this.#stateForPiecesDir(parentIno)) return true;
     if (name.startsWith(".") && name !== ".handlers") return false;
     if (this.isEntitiesDir(parentIno)) return true;
-    if (this.unhydratedEntityRoots.has(parentIno)) return true;
+    if (this.#unhydratedEntityRoots.has(parentIno)) return true;
     if (this.#pieceRoots.has(parentIno)) return true;
     if (this.#piecePropRoots.has(parentIno)) return true;
     return false;
@@ -1251,7 +1408,7 @@ export class CellBridge {
 
   shouldPrepareDirectory(ino: bigint): boolean {
     return this.#stateForPiecesDir(ino) !== undefined ||
-      this.isEntitiesDir(ino) || this.unhydratedEntityRoots.has(ino) ||
+      this.isEntitiesDir(ino) || this.#unhydratedEntityRoots.has(ino) ||
       this.#pieceRoots.has(ino) || this.#piecePropRoots.has(ino);
   }
 
@@ -1273,21 +1430,21 @@ export class CellBridge {
       return await this.resolveEntity(parentIno, name);
     }
 
-    if (this.unhydratedEntityRoots.has(parentIno)) {
+    if (this.#unhydratedEntityRoots.has(parentIno)) {
       if (!await this.#hydrateEntityRoot(parentIno)) return false;
     }
 
     const pieceInfo = this.#getPieceInfo(parentIno);
     if (pieceInfo) {
       if (name === "input" || name === "input.json") {
-        await this.hydratePieceProp(parentIno, "input");
+        await this.#hydratePieceProp(parentIno, "input");
         return true;
       }
       if (
         name === "result" || name === "result.json" ||
         name === "index.md" || name === "index.json" || name === ".handlers"
       ) {
-        await this.hydratePieceProp(parentIno, "result");
+        await this.#hydratePieceProp(parentIno, "result");
         return true;
       }
       return this.tree.lookup(parentIno, name) !== undefined;
@@ -1295,7 +1452,7 @@ export class CellBridge {
 
     const propInfo = this.#piecePropRoots.get(parentIno);
     if (propInfo) {
-      await this.hydratePieceProp(propInfo.pieceIno, propInfo.propName);
+      await this.#hydratePieceProp(propInfo.pieceIno, propInfo.propName);
       return true;
     }
 
@@ -1339,14 +1496,14 @@ export class CellBridge {
 
     const pieceInfo = this.#getPieceInfo(ino);
     if (pieceInfo) {
-      await this.hydratePieceProp(ino, "input");
-      await this.hydratePieceProp(ino, "result");
+      await this.#hydratePieceProp(ino, "input");
+      await this.#hydratePieceProp(ino, "result");
       return true;
     }
 
     const propInfo = this.#piecePropRoots.get(ino);
     if (propInfo) {
-      await this.hydratePieceProp(propInfo.pieceIno, propInfo.propName);
+      await this.#hydratePieceProp(propInfo.pieceIno, propInfo.propName);
       return true;
     }
 
@@ -1653,7 +1810,7 @@ export class CellBridge {
       timer: setTimeout(() => {
         this.#pendingPropRebuilds.delete(key);
         this.#activePropRebuilds.add(key);
-        void this.enqueuePiecePropRebuild({
+        void this.#enqueuePiecePropRebuild({
           cell: entry.cell,
           newValue: entry.latestValue,
           pieceId: entry.pieceId,
@@ -1820,6 +1977,14 @@ export class CellBridge {
     this.#hydrationEpochs.set(key, (this.#hydrationEpochs.get(key) ?? 0) + 1);
   }
 
+  /**
+   * Rebuilds the mounted subtree of one piece prop from a new cell value, in
+   * place.
+   *
+   * TypeScript-private rather than a `#` name, because
+   * `cell-bridge.test.ts` replaces this member by assignment, which a `#`
+   * method does not allow.
+   */
   private async rebuildPieceProp(args: {
     cell: Cell<unknown>;
     newValue: unknown;
@@ -1959,7 +2124,7 @@ export class CellBridge {
               summary: this.#extractSummary(treeValue),
             });
             if (summaryChanged) {
-              this.updatePiecesJson(state);
+              this.#updatePiecesJson(state);
               if (this.onInvalidate) {
                 this.onInvalidate(state.piecesIno, ["pieces.json"]);
               }
@@ -2072,7 +2237,7 @@ export class CellBridge {
           summary: this.#extractSummary(treeValue),
         });
         if (summaryChanged) {
-          this.updatePiecesJson(state);
+          this.#updatePiecesJson(state);
           if (this.onInvalidate) {
             this.onInvalidate(state.piecesIno, ["pieces.json"]);
           }
@@ -2086,7 +2251,7 @@ export class CellBridge {
     this.#debugLog(`[${spaceName}] Updated ${pieceName}/${propName}`);
   }
 
-  private async enqueuePiecePropRebuild(args: PropRebuildJob): Promise<void> {
+  async #enqueuePiecePropRebuild(args: PropRebuildJob): Promise<void> {
     const key = this.#propRebuildKey(args.pieceIno, args.propName);
     const previous = this.#pendingPropRebuildQueues.get(key) ??
       Promise.resolve();
@@ -2105,7 +2270,7 @@ export class CellBridge {
 
   static readonly #MAX_HYDRATION_RETRIES = 3;
 
-  private hydratePieceProp(
+  #hydratePieceProp(
     pieceIno: bigint,
     propName: "input" | "result",
     retries = 0,
@@ -2131,14 +2296,14 @@ export class CellBridge {
         try {
           const cell = await info.piece[propName].getCell();
           const newValue = await info.piece[propName].get();
-          await this.enqueuePiecePropRebuild({
+          await this.#enqueuePiecePropRebuild({
             cell,
             newValue,
             pieceId: info.piece.id,
             pieceIno,
             pieceName: info.rootName,
             propName,
-            resolveLink: this.makeLinkResolver(info.spaceName),
+            resolveLink: this.#makeLinkResolver(info.spaceName),
             spaceName: info.spaceName,
           });
           const currentEpoch = this.#hydrationEpochs.get(key) ?? 0;
@@ -2149,7 +2314,7 @@ export class CellBridge {
             if (retries >= CellBridge.#MAX_HYDRATION_RETRIES) {
               return false;
             }
-            return await this.hydratePieceProp(
+            return await this.#hydratePieceProp(
               pieceIno,
               propName,
               retries + 1,
@@ -2274,14 +2439,14 @@ export class CellBridge {
     }
     const cell = await writePath.piece[writePath.cell].getCell();
     const newValue = await writePath.piece[writePath.cell].get();
-    await this.enqueuePiecePropRebuild({
+    await this.#enqueuePiecePropRebuild({
       cell,
       newValue,
       pieceId: writePath.piece.id,
       pieceIno,
       pieceName: writePath.pieceName,
       propName: writePath.cell,
-      resolveLink: this.makeLinkResolver(writePath.spaceName),
+      resolveLink: this.#makeLinkResolver(writePath.spaceName),
       spaceName: writePath.spaceName,
     });
   }
@@ -2594,7 +2759,7 @@ export class CellBridge {
     );
   }
 
-  private buildSpaceTree(
+  #buildSpaceTree(
     spaceName: string,
     pieces: PiecesController,
   ): SpaceState {
@@ -2694,7 +2859,7 @@ export class CellBridge {
     state: SpaceState,
     spaceName: string,
   ): Promise<void> {
-    const existing = this.pendingPieceHydrations.get(spaceName);
+    const existing = this.#pendingPieceHydrations.get(spaceName);
     if (existing) return existing;
     if (state.piecesHydrated) return Promise.resolve();
 
@@ -2708,11 +2873,11 @@ export class CellBridge {
         state.piecesMaterializing = false;
       }
     })().finally(() => {
-      if (this.pendingPieceHydrations.get(spaceName) === pending) {
-        this.pendingPieceHydrations.delete(spaceName);
+      if (this.#pendingPieceHydrations.get(spaceName) === pending) {
+        this.#pendingPieceHydrations.delete(spaceName);
       }
     });
-    this.pendingPieceHydrations.set(spaceName, pending);
+    this.#pendingPieceHydrations.set(spaceName, pending);
     return pending;
   }
 
@@ -2744,7 +2909,7 @@ export class CellBridge {
     const existingIno = this.tree.lookup(state.entitiesIno, entityName);
     if (existingIno !== undefined) {
       if (!this.#pieceRoots.has(existingIno)) {
-        this.unhydratedEntityRoots.set(existingIno, info);
+        this.#unhydratedEntityRoots.set(existingIno, info);
       }
       state.entityIds.add(entityId);
       this.#touchEntityProjection(existingIno, info);
@@ -2761,7 +2926,7 @@ export class CellBridge {
     });
     annotator?.annotateJsonDirectory(entityIno, [], {});
     annotator?.annotateEntry(state.entitiesIno, entityName, entityIno);
-    this.unhydratedEntityRoots.set(entityIno, info);
+    this.#unhydratedEntityRoots.set(entityIno, info);
     state.entityIds.add(entityId);
     this.#touchEntityProjection(entityIno, info);
     return entityIno;
@@ -2771,9 +2936,9 @@ export class CellBridge {
     ino: bigint,
     info: UnhydratedEntityRootInfo,
   ): void {
-    this.entityProjectionLru.delete(ino);
-    this.entityProjectionLru.set(ino, info);
-    this.entityProjectionUseOrder.set(
+    this.#entityProjectionLru.delete(ino);
+    this.#entityProjectionLru.set(ino, info);
+    this.#entityProjectionUseOrder.set(
       ino,
       ++this.#nextEntityProjectionUseOrder,
     );
@@ -2782,25 +2947,25 @@ export class CellBridge {
   }
 
   #refreshEntityProjectionEvictionCandidate(ino: bigint): void {
-    this.entityProjectionEvictionCandidates.delete(ino);
-    const info = this.entityProjectionLru.get(ino);
+    this.#entityProjectionEvictionCandidates.delete(ino);
+    const info = this.#entityProjectionLru.get(ino);
     if (
-      info === undefined || this.pendingEntityHydrations.has(ino) ||
+      info === undefined || this.#pendingEntityHydrations.has(ino) ||
       this.#entityProjectionHasReferences(ino)
     ) {
       return;
     }
-    this.entityProjectionEvictionCandidates.set(ino, info);
+    this.#entityProjectionEvictionCandidates.set(ino, info);
   }
 
   #trimEntityProjectionCache(protectedIno?: bigint): void {
-    while (this.entityProjectionLru.size > this.#maxEntityProjections) {
+    while (this.#entityProjectionLru.size > this.#maxEntityProjections) {
       let oldestIno: bigint | undefined;
       let oldestInfo: UnhydratedEntityRootInfo | undefined;
       let oldestUseOrder = Number.POSITIVE_INFINITY;
-      for (const [ino, info] of this.entityProjectionEvictionCandidates) {
+      for (const [ino, info] of this.#entityProjectionEvictionCandidates) {
         if (ino === protectedIno) continue;
-        const useOrder = this.entityProjectionUseOrder.get(ino);
+        const useOrder = this.#entityProjectionUseOrder.get(ino);
         if (useOrder !== undefined && useOrder < oldestUseOrder) {
           oldestIno = ino;
           oldestInfo = info;
@@ -2813,31 +2978,31 @@ export class CellBridge {
   }
 
   #entityProjectionHasReferences(ino: bigint): boolean {
-    return (this.entityProjectionLookupRefs.get(ino) ?? 0n) > 0n ||
+    return (this.#entityProjectionLookupRefs.get(ino) ?? 0n) > 0n ||
       (this.#entityProjectionOpenRefs.get(ino) ?? 0) > 0;
   }
 
   #cancelEntitySubscriptions(ino: bigint): void {
-    const subscriptions = this.entitySubscriptions.get(ino);
+    const subscriptions = this.#entitySubscriptions.get(ino);
     if (!subscriptions) return;
-    this.entitySubscriptions.delete(ino);
+    this.#entitySubscriptions.delete(ino);
     for (const cancel of subscriptions) cancel();
   }
 
   #finishPendingEntityRemoval(ino: bigint): void {
-    const info = this.pendingEntityRemovals.get(ino);
+    const info = this.#pendingEntityRemovals.get(ino);
     if (
-      !info || this.pendingEntityHydrations.has(ino) ||
+      !info || this.#pendingEntityHydrations.has(ino) ||
       this.#entityProjectionHasReferences(ino)
     ) {
       return;
     }
 
-    this.pendingEntityRemovals.delete(ino);
-    this.entityProjectionLru.delete(ino);
-    this.entityProjectionEvictionCandidates.delete(ino);
-    this.entityProjectionUseOrder.delete(ino);
-    this.unhydratedEntityRoots.delete(ino);
+    this.#pendingEntityRemovals.delete(ino);
+    this.#entityProjectionLru.delete(ino);
+    this.#entityProjectionEvictionCandidates.delete(ino);
+    this.#entityProjectionUseOrder.delete(ino);
+    this.#unhydratedEntityRoots.delete(ino);
     this.#cancelEntitySubscriptions(ino);
     this.#unregisterPieceRoot(ino);
     this.#fsProjectionEntries.delete(ino);
@@ -2865,18 +3030,18 @@ export class CellBridge {
       return undefined;
     }
 
-    const info = this.entityProjectionLru.get(entityIno) ??
-      this.unhydratedEntityRoots.get(entityIno) ?? {
+    const info = this.#entityProjectionLru.get(entityIno) ??
+      this.#unhydratedEntityRoots.get(entityIno) ?? {
       state,
       spaceName: this.#pieceRoots.get(entityIno)?.spaceName ?? "",
       entityId,
     };
-    this.entityProjectionLru.delete(entityIno);
-    this.entityProjectionEvictionCandidates.delete(entityIno);
-    this.entityProjectionUseOrder.delete(entityIno);
-    this.unhydratedEntityRoots.delete(entityIno);
+    this.#entityProjectionLru.delete(entityIno);
+    this.#entityProjectionEvictionCandidates.delete(entityIno);
+    this.#entityProjectionUseOrder.delete(entityIno);
+    this.#unhydratedEntityRoots.delete(entityIno);
     this.#cancelEntitySubscriptions(entityIno);
-    this.pendingEntityRemovals.set(entityIno, info);
+    this.#pendingEntityRemovals.set(entityIno, info);
     this.tree.detachChild(state.entitiesIno, entityName);
     state.entityIds.delete(entityId);
     if (invalidate) {
@@ -2996,22 +3161,22 @@ export class CellBridge {
 
   #hydrateEntityRoot(entityIno: bigint): Promise<boolean> {
     if (this.#pieceRoots.has(entityIno)) {
-      const info = this.entityProjectionLru.get(entityIno);
+      const info = this.#entityProjectionLru.get(entityIno);
       if (info) this.#touchEntityProjection(entityIno, info);
       return Promise.resolve(true);
     }
-    const existing = this.pendingEntityHydrations.get(entityIno);
+    const existing = this.#pendingEntityHydrations.get(entityIno);
     if (existing) return existing;
-    const info = this.unhydratedEntityRoots.get(entityIno);
+    const info = this.#unhydratedEntityRoots.get(entityIno);
     if (!info) return Promise.resolve(false);
     this.#touchEntityProjection(entityIno, info);
 
     const pending = (async () => {
       const piece = info.state.entityControllers.get(info.entityId) ??
         await info.state.pieces.get(info.entityId, false);
-      if (this.unhydratedEntityRoots.get(entityIno) !== info) return false;
+      if (this.#unhydratedEntityRoots.get(entityIno) !== info) return false;
       info.state.entityControllers.set(info.entityId, piece);
-      await this.loadPieceTree(
+      await this.#loadPieceTree(
         piece,
         info.state.entitiesIno,
         encodeFuseComponent(info.entityId),
@@ -3019,31 +3184,31 @@ export class CellBridge {
         entityIno,
         "entities",
       );
-      if (this.unhydratedEntityRoots.get(entityIno) !== info) return false;
-      const subscriptions = await this.subscribePiece(
+      if (this.#unhydratedEntityRoots.get(entityIno) !== info) return false;
+      const subscriptions = await this.#subscribePiece(
         piece,
         entityIno,
         encodeFuseComponent(info.entityId),
         info.spaceName,
         info.state,
       );
-      if (this.unhydratedEntityRoots.get(entityIno) !== info) {
+      if (this.#unhydratedEntityRoots.get(entityIno) !== info) {
         for (const cancel of subscriptions) cancel();
         return false;
       }
-      this.entitySubscriptions.set(entityIno, subscriptions);
-      this.unhydratedEntityRoots.delete(entityIno);
+      this.#entitySubscriptions.set(entityIno, subscriptions);
+      this.#unhydratedEntityRoots.delete(entityIno);
       return true;
     })().finally(() => {
-      if (this.pendingEntityHydrations.get(entityIno) === pending) {
-        this.pendingEntityHydrations.delete(entityIno);
+      if (this.#pendingEntityHydrations.get(entityIno) === pending) {
+        this.#pendingEntityHydrations.delete(entityIno);
       }
       this.#finishPendingEntityRemoval(entityIno);
       this.#refreshEntityProjectionEvictionCandidate(entityIno);
       this.#trimEntityProjectionCache();
     });
-    this.pendingEntityHydrations.set(entityIno, pending);
-    this.entityProjectionEvictionCandidates.delete(entityIno);
+    this.#pendingEntityHydrations.set(entityIno, pending);
+    this.#entityProjectionEvictionCandidates.delete(entityIno);
     return pending;
   }
 
@@ -3079,9 +3244,11 @@ export class CellBridge {
     if (exists === false) {
       if (
         existingIno !== undefined &&
-        this.pendingEntityHydrations.has(existingIno)
+        this.#pendingEntityHydrations.has(existingIno)
       ) {
-        await this.pendingEntityHydrations.get(existingIno)?.catch(() => false);
+        await this.#pendingEntityHydrations.get(existingIno)?.catch(() =>
+          false
+        );
       }
       this.#removeEntityProjection(entities.state, decodedEntityId);
       return undefined;
@@ -3137,7 +3304,7 @@ export class CellBridge {
     try {
       await (piece.getCell() as Cell<unknown>).asSchema(nameSchema).sync();
     } catch {
-      // Name stays unavailable; addPieceToSpace falls back to the piece id.
+      // Name stays unavailable; `#addPieceToSpace()` falls back to the piece id.
     }
   }
 
@@ -3145,7 +3312,7 @@ export class CellBridge {
    * Add a single piece to a space's tree.
    * Returns the assigned display name.
    */
-  private async addPieceToSpace(
+  async #addPieceToSpace(
     state: SpaceState,
     piece: PieceController,
     spaceName: string,
@@ -3174,7 +3341,7 @@ export class CellBridge {
     state.pieceMap.set(name, piece.id);
     state.pieceControllers.set(name, piece);
 
-    const pieceIno = await this.loadPieceTree(
+    const pieceIno = await this.#loadPieceTree(
       piece,
       state.piecesIno,
       name,
@@ -3186,7 +3353,7 @@ export class CellBridge {
     await this.buildSourceTree(pieceIno, piece, state, name);
     await this.#refreshPieceManifest(state, piece);
 
-    const subs = await this.subscribePiece(
+    const subs = await this.#subscribePiece(
       piece,
       pieceIno,
       name,
@@ -3248,18 +3415,18 @@ export class CellBridge {
     state: SpaceState,
     spaceName: string,
   ): Promise<void> {
-    const existing = this.pieceSyncs.get(spaceName);
+    const existing = this.#pieceSyncs.get(spaceName);
     if (existing) {
-      this.syncAgain.add(spaceName);
+      this.#syncAgain.add(spaceName);
       return existing;
     }
 
     const pending = this.#runPieceListSync(state, spaceName).finally(() => {
-      if (this.pieceSyncs.get(spaceName) === pending) {
-        this.pieceSyncs.delete(spaceName);
+      if (this.#pieceSyncs.get(spaceName) === pending) {
+        this.#pieceSyncs.delete(spaceName);
       }
     });
-    this.pieceSyncs.set(spaceName, pending);
+    this.#pieceSyncs.set(spaceName, pending);
     return pending;
   }
 
@@ -3268,13 +3435,13 @@ export class CellBridge {
     spaceName: string,
   ): Promise<void> {
     do {
-      this.syncAgain.delete(spaceName);
-      await this.syncPieceListOnce(state, spaceName);
-    } while (this.syncAgain.has(spaceName));
+      this.#syncAgain.delete(spaceName);
+      await this.#syncPieceListOnce(state, spaceName);
+    } while (this.#syncAgain.has(spaceName));
   }
 
   /** Single pass of piece list sync (called by guarded syncPieceList). */
-  private async syncPieceListOnce(
+  async #syncPieceListOnce(
     state: SpaceState,
     spaceName: string,
   ): Promise<void> {
@@ -3307,13 +3474,13 @@ export class CellBridge {
     }
 
     for (const piece of toAdd) {
-      const name = await this.addPieceToSpace(state, piece, spaceName);
+      const name = await this.#addPieceToSpace(state, piece, spaceName);
       this.#debugLog(`[${spaceName}] Added piece: ${name}`);
     }
 
     // Update index and invalidate
     this.updateIndexJson(state);
-    this.updatePiecesJson(state);
+    this.#updatePiecesJson(state);
     if (this.onInvalidate) {
       // Invalidate child entries under pieces/
       const invalidNames = [
@@ -3338,7 +3505,7 @@ export class CellBridge {
   }
 
   /** Update the pieces/pieces.json manifest for a space. */
-  private updatePiecesJson(state: SpaceState): void {
+  #updatePiecesJson(state: SpaceState): void {
     const entries = this.#buildPiecesManifestEntries(state);
     const existingIno = this.tree.lookup(state.piecesIno, "pieces.json");
     if (existingIno !== undefined) {
@@ -3365,7 +3532,13 @@ export class CellBridge {
     );
   }
 
-  /** Update the pieces/.index.json file for a space. */
+  /**
+   * Updates the `pieces/.index.json` file for a space.
+   *
+   * TypeScript-private rather than a `#` name, because
+   * `cell-bridge.test.ts` replaces this member by assignment, which a `#`
+   * method does not allow.
+   */
   private updateIndexJson(state: SpaceState): void {
     const existingIno = this.tree.lookup(state.piecesIno, ".index.json");
     if (existingIno !== undefined) {
@@ -3975,7 +4148,7 @@ export class CellBridge {
    * Subscribe to cell changes for hydration-cache invalidation and
    * projected name changes for a piece.
    */
-  private async subscribePiece(
+  async #subscribePiece(
     piece: PieceController,
     pieceIno: bigint,
     pieceName: string,
@@ -3988,7 +4161,7 @@ export class CellBridge {
     // invalidated when external mutations arrive (background recomputes,
     // remote writes, etc.). The invalidation is debounced: the reactive
     // graph may fire multiple intermediate updates before settling.
-    const resolveLink = this.makeLinkResolver(spaceName);
+    const resolveLink = this.#makeLinkResolver(spaceName);
     for (const propName of ["input", "result"] as const) {
       try {
         const cell = await piece[propName].getCell();
@@ -4021,7 +4194,7 @@ export class CellBridge {
               // tree is not torn down first; advancing the hydration epoch is
               // enough to make an in-flight hydration re-read the new value.
               this.#bumpHydrationEpoch(pieceIno, propName);
-              await this.enqueuePiecePropRebuild({
+              await this.#enqueuePiecePropRebuild({
                 cell,
                 newValue: rebuildValue,
                 pieceId: piece.id,
@@ -4103,7 +4276,7 @@ export class CellBridge {
         setTimeout(() => {
           try {
             // Use the state captured at subscription time, NOT
-            // this.spaces.get(): during the initial buildSpaceTree the space
+            // this.spaces.get(): during the initial `#buildSpaceTree()` the space
             // isn't registered in this.spaces yet, so a lookup would silently
             // drop every name event that fires while the tree is being built
             // (and a static piece may never fire again). Only bail if the
@@ -4219,7 +4392,7 @@ export class CellBridge {
 
             // Rebuild .index.json and pieces.json.
             this.updateIndexJson(state);
-            this.updatePiecesJson(state);
+            this.#updatePiecesJson(state);
 
             // Invalidate kernel cache.
             if (this.onInvalidate) {
@@ -4268,7 +4441,7 @@ export class CellBridge {
    *   Cross-space:      "../".repeat(depth+3) + "<spaceName>/entities/<hash>[/<path>]"
    *   Self-ref (no id): relative path within the same piece
    */
-  private makeLinkResolver(
+  #makeLinkResolver(
     spaceName: string,
   ): (value: unknown, depth: number) => string | null {
     return (value: unknown, depth: number): string | null => {
@@ -4331,7 +4504,7 @@ export class CellBridge {
     };
   }
 
-  private async loadPieceTree(
+  async #loadPieceTree(
     piece: PieceController,
     parentIno: bigint,
     name: string,
@@ -4418,6 +4591,10 @@ export class CellBridge {
    * authored source files (recovered from the content-addressed
    * `pattern:<identity>` source-doc closure). Skips system pieces that have no
    * recoverable source.
+   *
+   * TypeScript-private rather than a `#` name, because
+   * `cell-bridge.test.ts` replaces this member by assignment, which a `#`
+   * method does not allow.
    */
   private async buildSourceTree(
     pieceIno: bigint,

--- a/packages/fuse/cell-bridge.ts
+++ b/packages/fuse/cell-bridge.ts
@@ -320,14 +320,22 @@ interface PiecePropRootInfo {
 
 /** What the bridge knows about an entity root it has not yet hydrated. */
 export interface UnhydratedEntityRootInfo {
+  /** The space the entity lives in. */
   state: SpaceState;
+
+  /** Name of that space, as its directory is named. */
   spaceName: string;
+
+  /** Id of the entity. */
   entityId: string;
 }
 
 /** The root an entity-projection lookup pin belongs to, and its pin count. */
 export interface EntityProjectionLookupOwner {
+  /** Inode of the projection root the pin holds. */
   rootIno: bigint;
+
+  /** How many pins the root holds through this owner. */
   count: bigint;
 }
 
@@ -3304,7 +3312,8 @@ export class CellBridge {
     try {
       await (piece.getCell() as Cell<unknown>).asSchema(nameSchema).sync();
     } catch {
-      // Name stays unavailable; `#addPieceToSpace()` falls back to the piece id.
+      // Name stays unavailable; `#addPieceToSpace()` falls back to the piece
+      // id.
     }
   }
 
@@ -4276,11 +4285,11 @@ export class CellBridge {
         setTimeout(() => {
           try {
             // Use the state captured at subscription time, NOT
-            // this.spaces.get(): during the initial `#buildSpaceTree()` the space
-            // isn't registered in this.spaces yet, so a lookup would silently
-            // drop every name event that fires while the tree is being built
-            // (and a static piece may never fire again). Only bail if the
-            // space has since been disconnected or replaced.
+            // this.spaces.get(): during the initial `#buildSpaceTree()` the
+            // space isn't registered in this.spaces yet, so a lookup would
+            // silently drop every name event that fires while the tree is
+            // being built (and a static piece may never fire again). Only bail
+            // if the space has since been disconnected or replaced.
             const registered = this.spaces.get(spaceName);
             if (registered !== undefined && registered !== state) return;
 

--- a/packages/fuse/tree-builder.test.ts
+++ b/packages/fuse/tree-builder.test.ts
@@ -1374,22 +1374,13 @@ Deno.test("CellBridge.loadPieceTree materializes callable dirs from sparse resul
     };
   }
 
-  type LoadPieceTree = (
-    piece: SparsePiece,
-    parentIno: bigint,
-    name: string,
-    spaceName: string,
-  ) => Promise<bigint>;
-  type HydratePieceProp = (
-    pieceIno: bigint,
-    propName: "input" | "result",
-  ) => Promise<boolean>;
-
-  const pieceIno = await (bridge as unknown as {
-    loadPieceTree: LoadPieceTree;
-  }).loadPieceTree(piece, tree.rootIno, "Sparse Fixture", "home");
-  await (bridge as unknown as { hydratePieceProp: HydratePieceProp })
-    .hydratePieceProp.call(bridge, pieceIno, "result");
+  const pieceIno = await bridge.accessForTestingOnly.loadPieceTree(
+    piece as never,
+    tree.rootIno,
+    "Sparse Fixture",
+    "home",
+  );
+  await bridge.accessForTestingOnly.hydratePieceProp(pieceIno, "result");
 
   const resultIno = tree.lookup(pieceIno, "result");
   assertEquals(resultIno !== undefined, true);
@@ -1499,22 +1490,13 @@ Deno.test("CellBridge.loadPieceTree keeps schema-backed callables beside populat
     };
   }
 
-  type LoadPieceTree = (
-    piece: MixedPiece,
-    parentIno: bigint,
-    name: string,
-    spaceName: string,
-  ) => Promise<bigint>;
-  type HydratePieceProp = (
-    pieceIno: bigint,
-    propName: "input" | "result",
-  ) => Promise<boolean>;
-
-  const pieceIno = await (bridge as unknown as {
-    loadPieceTree: LoadPieceTree;
-  }).loadPieceTree(piece, tree.rootIno, "Mixed Fixture", "home");
-  await (bridge as unknown as { hydratePieceProp: HydratePieceProp })
-    .hydratePieceProp.call(bridge, pieceIno, "result");
+  const pieceIno = await bridge.accessForTestingOnly.loadPieceTree(
+    piece as never,
+    tree.rootIno,
+    "Mixed Fixture",
+    "home",
+  );
+  await bridge.accessForTestingOnly.hydratePieceProp(pieceIno, "result");
 
   const resultIno = tree.lookup(pieceIno, "result");
   assertEquals(resultIno !== undefined, true);
@@ -1661,15 +1643,9 @@ Deno.test("parseSymlinkTarget - unknown cross-space uses name as fallback", () =
   assertEquals(result, { id: "abc", space: "unknown" });
 });
 
-type MakeLinkResolver = (
-  spaceName: string,
-) => (value: unknown, depth: number) => string | null;
-
 Deno.test("makeLinkResolver encodes unsafe link components", () => {
   const bridge = new CellBridge(new FsTree());
-  const resolveLink =
-    (bridge as unknown as { makeLinkResolver: MakeLinkResolver })
-      .makeLinkResolver("home");
+  const resolveLink = bridge.accessForTestingOnly.makeLinkResolver("home");
 
   assertEquals(
     resolveLink({
@@ -1687,9 +1663,7 @@ Deno.test("makeLinkResolver encodes unsafe link components", () => {
 
 Deno.test("makeLinkResolver leaves malformed link paths inert", () => {
   const bridge = new CellBridge(new FsTree());
-  const resolveLink =
-    (bridge as unknown as { makeLinkResolver: MakeLinkResolver })
-      .makeLinkResolver("home");
+  const resolveLink = bridge.accessForTestingOnly.makeLinkResolver("home");
 
   assertEquals(
     resolveLink({


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Fable 5.1)

`CellBridge` is the class the `accessForTestingOnly` series had not
reached: twenty-eight TypeScript-`private` members under a class note
saying `cell-bridge.test.ts` reaches them through receiver casts. This PR
converts it the way the series converted the others, per
`docs/development/DEVELOPMENT.md` § Classes, "Making a private member
reachable from a test".

## The accessor

- The synchronization and hydration tables (`pieceSyncs`, `syncAgain`,
  `pendingPieceHydrations`, `unhydratedEntityRoots`,
  `pendingEntityHydrations`, `pendingEntityRemovals`,
  `entitySubscriptions`, `entityProjectionUseOrder`,
  `entityProjectionLookupRefs`) as plain properties holding the
  reference, which the class mutates in place.
- `entityProjectionLru`, `entityProjectionEvictionCandidates`, and
  `entityProjectionLookupOwners` with setters: the eviction test swaps in
  maps that count their own iteration.
- `disconnected` and `reconnectTimer` with setters, and
  `attemptReconnect()`; the `_` prefix the test's names carried is gone.
- Arrows for `enqueuePiecePropRebuild()`, `hydratePieceProp()`,
  `buildSpaceTree()`, `addPieceToSpace()`, `syncPieceListOnce()`,
  `updatePiecesJson()`, `subscribePiece()`, `makeLinkResolver()`, and
  `loadPieceTree()`, typed as the class types them.

## What stays `private`, and why

`refreshPiecePatternMetadata()`, `rebuildPieceProp()`,
`updateIndexJson()`, and `buildSourceTree()` are each replaced by
assignment at one site in `cell-bridge.test.ts`, the stub-by-assignment
shape a `#` method cannot take. Each keeps a doc-comment note naming the
test, and the accessor forwards to them so their calling sites are typed
and a replacement is honored through the accessor too. They join the
tail of members whose seams are to be looked at once the rest of the
series is done.

## What the tests do now

Every reach goes through `bridge.accessForTestingOnly`, in
`cell-bridge.test.ts` and in `tree-builder.test.ts`. A fake piece or fake
cell declares itself where it is passed, with the `as never` the file
already used for `pieceControllers`; the iteration-counting maps are
typed by `UnhydratedEntityRootInfo` and `EntityProjectionLookupOwner`,
exported as types for that reason; a partial `WritePath` says so where it
is passed. Two casts that reached the public `prepareLookup()` and
`writeFsFile()` are gone. The eleven local function-type aliases the
casts needed are gone with them.

Left alone: the `Deno.test` names that say `CellBridge.hydratePieceProp`
and the like, since renaming a test renames its identity.

## Review

Reviewed by a `cf-review` pass: approve, no blocking findings. Its one
improvement, two comment lines the `#` names pushed past 80 columns, is
applied, as is its nit that the two newly exported interfaces' members
carried no doc comments. Two nits are left as they are: the `as never`
the fakes declare themselves with is the file's existing idiom and a
`Partial<PieceController>` helper is follow-up material; and the
accessor's `hydratePieceProp()` entry keeps the `retries?` parameter,
typed as the class types it. Its pre-existing debts are recorded for the
series' tidy-up.

## Gates

`deno fmt --check`, `deno lint`, `deno task check`, and the `fuse` suite
(382 passed, 0 failed, 1 ignored). No other package names a converted
member.

## Coverage

The Coverage Check counts the accessor's unread getters and setters as
uncovered lines; the group is one line over its baseline.

ACCEPT_COVERAGE_DEBT: packages/fuse +1 lines
