### PR TITLE
fix(shuttle): read an operand as written, edges and all

### DIFF
--- a/packages/cli/lib/shuttle/place.ts
+++ b/packages/cli/lib/shuttle/place.ts
@@ -408,15 +408,14 @@ export class CurrentPlace {
    * took and not the levels a position happens to name.
    */
   aim(operand: string): Aim {
-    const trimmed = operand.trim();
-    if (trimmed === ARGUMENT_SUFFIX) {
+    if (operand === ARGUMENT_SUFFIX) {
       return { input: false, move: outcomeOf(refuse(SUFFIX_NAMES_NO_TARGET)) };
     }
-    const stripped = argumentSuffixOff(trimmed);
+    const stripped = argumentSuffixOff(operand);
     return {
       input: stripped !== undefined,
       move: outcomeOf(
-        movePlace(this.#here, stripped ?? trimmed, this.#previous),
+        movePlace(this.#here, stripped ?? operand, this.#previous),
       ),
     };
   }
@@ -578,6 +577,14 @@ type Step =
  * whichever rung of it, a leading
  * `#` is a wish target, and anything else is a relative walk from where
  * shuttle stands.
+ *
+ * Each reading is matched against the operand as it was written, edges
+ * included, so none of them reads a string that merely resembles the
+ * spelling: `cd " -"` walks to the key `" -"` rather than returning to the
+ * previous place. Whitespace reaches an edge only through a quote, the split
+ * that produced the operand separating on it (`line.ts`), so it is a
+ * character of the part it sits in and the part is held to the rule that part
+ * answers to.
  */
 function movePlace(
   from: Standing,
@@ -585,19 +592,18 @@ function movePlace(
   previous?: Standing,
 ): Step {
   const place = from.place;
-  const trimmed = operand.trim();
-  if (trimmed === "") return refuse("`cd` takes a place to move to.");
-  if (trimmed === "-") {
+  if (operand === "") return refuse("`cd` takes a place to move to.");
+  if (operand === "-") {
     return previous === undefined
       ? refuse("There is no previous place to return to.")
       : land(previous.place, previous.trail);
   }
-  if (trimmed.startsWith("@")) return moveScope(from, trimmed.slice(1));
+  if (operand.startsWith("@")) return moveScope(from, operand.slice(1));
 
   // A leading `/` roots a reference, and `/` alone roots one and names
   // nothing further: the space's own root, which the grammar has no id
   // segment to spell.
-  if (trimmed === "/") {
+  if (operand === "/") {
     return land(
       { ...place, position: { kind: "root", space: place.position.space } },
       [],
@@ -606,18 +612,18 @@ function movePlace(
 
   let reference;
   try {
-    reference = normalizeLLMFriendlyRef(trimmed, {
+    reference = normalizeLLMFriendlyRef(operand, {
       space: place.position.space,
     });
   } catch (error) {
     return refuse(messageOf(error));
   }
   if (reference !== undefined) {
-    return moveByReference(place, reference, trimmed);
+    return moveByReference(place, reference, operand);
   }
 
-  if (trimmed.startsWith("#")) return { kind: "wish", target: trimmed };
-  return moveBySegments(from, trimmed);
+  if (operand.startsWith("#")) return { kind: "wish", target: operand };
+  return moveBySegments(from, operand);
 }
 
 /**
@@ -693,13 +699,13 @@ function moveByReference(
  * segment is read against the level the one before it landed on, so `..` and a
  * descent compose in one operand.
  *
- * The operand is trimmed before it is split, so the outer edges of the first
- * and last segments are lost here where a reference keeps them: `cd " a"`
- * reaches the key `a`, and a key actually named `" a"` has no relative
- * spelling, only a rooted one. Between those edges a segment is taken
- * literally — the reference grammar's `~1` escaping belongs to a reference,
- * which a relative operand is not, so `~1` here is two characters of a key
- * and a key holding the separator has no relative spelling at all.
+ * The operand's own edges are the outer edges of the first and last segments,
+ * the operand reaching here as it was written: `cd " a"` reaches the key
+ * `" a"`, and `cd "a "` is refused, a part ending in whitespace being
+ * refused wherever it sits. Between those edges a segment is taken literally —
+ * the reference grammar's `~1` escaping belongs to a reference, which a
+ * relative operand is not, so `~1` here is two characters of a key and a key
+ * holding the separator has no relative spelling at all.
  */
 function moveBySegments(from: Standing, operand: string): Step {
   const segments = operand.split("/");

--- a/packages/cli/test/shuttle-place.test.ts
+++ b/packages/cli/test/shuttle-place.test.ts
@@ -658,9 +658,22 @@ describe("place", () => {
 
       describe("cd()", () => {
         it("refuses an empty operand", () => {
-          expect(atSpaceRoot().cd("  ")).toEqual({
+          expect(atSpaceRoot().cd("")).toEqual({
             kind: "refused",
             reason: "`cd` takes a place to move to.",
+          });
+        });
+
+        it("refuses an operand that is only whitespace for naming no child", () => {
+          // An empty operand and a quoted space are two mistakes rather than
+          // one: the first gave nothing, and the second gave a name that is
+          // only a space. A name reaches the rule the position's own children
+          // answer to, which at a space root is the closed set of facets.
+
+          expect(atSpaceRoot().cd(" ")).toEqual({
+            kind: "refused",
+            reason: "A space root lists facets, and ` ` names none. The " +
+              "facets are `slugs/` and `pieces/`.",
           });
         });
 
@@ -1258,23 +1271,6 @@ describe("place", () => {
             });
           });
 
-          it("trims the outer edges of an operand before splitting it", () => {
-            // A reference keeps what the walk drops here, and the walk is
-            // the only door that drops it — so a key named `" a"` is
-            // reachable by reference and not by walking to it. Landing on
-            // the trimmed key rather than refusing is what makes this
-            // worth pinning: nothing says the edge was lost.
-
-            const place = atReferencedPiece();
-            place.cd(" a ");
-            expect(place.place.position).toEqual({
-              kind: "piece",
-              space: SPACE,
-              piece: HANDLE,
-              path: ["a"],
-            });
-          });
-
           it("reads `~1` in a segment as two characters of a data key", () => {
             // A relative operand is not a reference, so the reference
             // grammar's `~1` escaping does not reach it: `~1` is literal
@@ -1363,6 +1359,58 @@ describe("place", () => {
               });
             });
 
+            it("reads `-` as a data key where whitespace precedes it", () => {
+              // The readings above are matched against the operand as it
+              // was written, so a leading space is a character of the first
+              // segment rather than something the reading looks past.
+              // Whitespace reaches an edge only through a quote, which makes
+              // it the character the writer meant.
+
+              const place = atReferencedPiece();
+              place.cd(" -");
+              expect(place.place.position).toEqual({
+                kind: "piece",
+                space: SPACE,
+                piece: HANDLE,
+                path: [" -"],
+              });
+            });
+
+            it("reads `@user` as a data key where whitespace precedes it", () => {
+              const place = atReferencedPiece();
+              place.cd(" @user");
+              expect(place.place.position).toEqual({
+                kind: "piece",
+                space: SPACE,
+                piece: HANDLE,
+                path: [" @user"],
+              });
+            });
+
+            it("reads `#favorites` as a data key where whitespace precedes it", () => {
+              const place = atReferencedPiece();
+              place.cd(" #favorites");
+              expect(place.place.position).toEqual({
+                kind: "piece",
+                space: SPACE,
+                piece: HANDLE,
+                path: [" #favorites"],
+              });
+            });
+
+            it("refuses `/` where whitespace precedes it, rather than reading it as the space root", () => {
+              // Relayed: the canonical layer's sentence, not shuttle's. The
+              // space-root reading is the operand exactly, so `" /"` falls
+              // through to the reference grammar, which is the door that
+              // reports it.
+
+              expect(atReferencedPiece().cd(" /")).toEqual({
+                kind: "refused",
+                reason: "Target must include a piece handle, e.g. " +
+                  '"/of:fid1:abc123/path".',
+              });
+            });
+
             it("reads `..` as a data key through a reference", () => {
               // `..` is read segment by segment by the walk and by nothing
               // else, so the reference door carries one as data. That is
@@ -1412,9 +1460,10 @@ describe("place", () => {
           });
 
           it("refuses an operand with a segment ending in whitespace", () => {
-            // The operand is trimmed before it is split, so only a segment
-            // with something after it can carry trailing whitespace this
-            // far.
+            // A segment with something after it in the operand, where the
+            // trailing whitespace is plainly the segment's own. One sitting
+            // at the operand's own edge answers to the same rule, under
+            // `whitespace at an operand's edges` below.
 
             expect(atReferencedPiece().cd("a /b")).toEqual({
               kind: "refused",
@@ -1450,6 +1499,138 @@ describe("place", () => {
                 "carries that name: a slug is lowercase letters, numbers, " +
                 "and single hyphens between words, and a handle is " +
                 "`of:fid1:` and unpadded base64url.",
+            });
+          });
+
+          describe("whitespace at an operand's edges", () => {
+            // The split separates tokens on whitespace (`line.ts`), so
+            // whitespace reaches an operand's edge only through a quote
+            // somebody wrote. Nothing strips it, which is what puts the outer
+            // parts of an operand under the same rule as every part between
+            // them: the operand's edges are those parts' edges, and at that
+            // one position stripping the operand would strip a name.
+
+            it("refuses a key ending in whitespace", () => {
+              expect(atReferencedPiece().cd("board ")).toEqual({
+                kind: "refused",
+                reason: "`board ` has a segment ending in whitespace, so a " +
+                  "rendering of the place would name a different cell.",
+              });
+            });
+
+            it("refuses a key ending in a tab", () => {
+              expect(atReferencedPiece().cd("board\t")).toEqual({
+                kind: "refused",
+                reason: "`board\t` has a segment ending in whitespace, so a " +
+                  "rendering of the place would name a different cell.",
+              });
+            });
+
+            it("refuses a key padded on both sides", () => {
+              expect(atReferencedPiece().cd(" board ")).toEqual({
+                kind: "refused",
+                reason: "` board ` has a segment ending in whitespace, so a " +
+                  "rendering of the place would name a different cell.",
+              });
+            });
+
+            it("reaches a key whose name starts with whitespace", () => {
+              // Leading whitespace survives a rendering and the parse that
+              // reads one back, so it costs a key no name and the walk spells
+              // such a key. The trailing edge is the one a rendering loses.
+
+              const place = atReferencedPiece();
+              place.cd(" board");
+              expect(place.place.position).toEqual({
+                kind: "piece",
+                space: SPACE,
+                piece: HANDLE,
+                path: [" board"],
+              });
+            });
+
+            it("refuses a multi-segment operand whose last segment ends in whitespace", () => {
+              // The one position where the operand's edge and a part's edge
+              // are the same characters, which is the whole of what makes
+              // this case different from `a /b` above.
+
+              expect(atReferencedPiece().cd("a/b ")).toEqual({
+                kind: "refused",
+                reason: "`a/b ` has a segment ending in whitespace, so a " +
+                  "rendering of the place would name a different cell.",
+              });
+            });
+
+            it("refuses an operand that is only whitespace inside a piece", () => {
+              expect(atReferencedPiece().cd(" ")).toEqual({
+                kind: "refused",
+                reason: "` ` has a segment ending in whitespace, so a " +
+                  "rendering of the place would name a different cell.",
+              });
+            });
+
+            it("refuses a piece ending in whitespace", () => {
+              expect(inSlugs().cd("board ")).toEqual({
+                kind: "refused",
+                reason:
+                  "`board ` has a piece ending in whitespace, so no piece " +
+                  "carries that name: a slug is lowercase letters, numbers, " +
+                  "and single hyphens between words, and a handle is " +
+                  "`of:fid1:` and unpadded base64url.",
+              });
+            });
+
+            it("refuses a piece ending in a tab", () => {
+              expect(inSlugs().cd("board\t")).toEqual({
+                kind: "refused",
+                reason:
+                  "`board\t` has a piece ending in whitespace, so no piece " +
+                  "carries that name: a slug is lowercase letters, numbers, " +
+                  "and single hyphens between words, and a handle is " +
+                  "`of:fid1:` and unpadded base64url.",
+              });
+            });
+
+            it("refuses a piece padded on both sides", () => {
+              expect(inSlugs().cd(" board ")).toEqual({
+                kind: "refused",
+                reason:
+                  "` board ` has a piece ending in whitespace, so no piece " +
+                  "carries that name: a slug is lowercase letters, numbers, " +
+                  "and single hyphens between words, and a handle is " +
+                  "`of:fid1:` and unpadded base64url.",
+              });
+            });
+
+            it("refuses a piece whose name starts with whitespace for naming no slug", () => {
+              // Relayed: the canonical layer's sentence, not shuttle's. A
+              // leading space costs a piece no rendering, so what refuses it
+              // is the vocabulary rather than the rendering rule — a
+              // different reason from the one the same edge gets on a key.
+
+              expect(inSlugs().cd(" board")).toEqual({
+                kind: "refused",
+                reason: '" board" is not a slug: a slug is lowercase ' +
+                  "letters, numbers, and single hyphens between words.",
+              });
+            });
+
+            it("refuses an operand that is only whitespace inside a facet", () => {
+              expect(inSlugs().cd(" ")).toEqual({
+                kind: "refused",
+                reason: "` ` has a piece ending in whitespace, so no piece " +
+                  "carries that name: a slug is lowercase letters, numbers, " +
+                  "and single hyphens between words, and a handle is " +
+                  "`of:fid1:` and unpadded base64url.",
+              });
+            });
+
+            it("refuses a facet name ending in whitespace", () => {
+              expect(atSpaceRoot().cd("slugs ")).toEqual({
+                kind: "refused",
+                reason: "A space root lists facets, and `slugs ` names none. " +
+                  "The facets are `slugs/` and `pieces/`.",
+              });
             });
           });
         });
@@ -1620,6 +1801,17 @@ describe("place", () => {
           });
         });
 
+        it("hands `#argument` followed by whitespace on as a target", () => {
+          // The suffix reading is the operand exactly, so a trailing space
+          // leaves the head reading to decide, and the head reading is the
+          // wish target.
+
+          expect(atPiece().aim("#argument ")).toEqual({
+            input: false,
+            move: { kind: "wish", target: "#argument " },
+          });
+        });
+
         it("hands a `#name` target on whole, the head reading being another one", () => {
           expect(atPiece().aim("#favorites")).toEqual({
             input: false,
@@ -1636,6 +1828,63 @@ describe("place", () => {
             move: pointsAt(atPiece(), "a#b"),
           });
           expect(pointsAt(atPiece(), "a#b").kind).toBe("moved");
+        });
+
+        it("refuses a key ending in whitespace inside a piece", () => {
+          expect(atPiece().aim("topics ")).toEqual({
+            input: false,
+            move: {
+              kind: "refused",
+              reason: "`topics ` has a segment ending in whitespace, so a " +
+                "rendering of the place would name a different cell.",
+            },
+          });
+        });
+
+        it("returns the key a leading space names inside a piece", () => {
+          expect(atPiece().aim(" topics")).toEqual({
+            input: false,
+            move: {
+              kind: "moved",
+              place: {
+                position: {
+                  kind: "piece",
+                  space: SPACE,
+                  piece: "board",
+                  path: [" topics"],
+                },
+                scope: "space",
+              },
+            },
+          });
+        });
+
+        it("refuses a piece ending in whitespace inside a facet", () => {
+          expect(inSlugs().aim("board ")).toEqual({
+            input: false,
+            move: {
+              kind: "refused",
+              reason: "`board ` has a piece ending in whitespace, so no " +
+                "piece carries that name: a slug is lowercase letters, " +
+                "numbers, and single hyphens between words, and a handle is " +
+                "`of:fid1:` and unpadded base64url.",
+            },
+          });
+        });
+
+        it("returns two reasons for an empty operand and one that is only whitespace", () => {
+          // The read door keeps the two apart the way the move door does: one
+          // named nothing, and one named a key that is only a space.
+
+          expect(atPiece().aim("").move).toEqual({
+            kind: "refused",
+            reason: "`cd` takes a place to move to.",
+          });
+          expect(atPiece().aim(" ").move).toEqual({
+            kind: "refused",
+            reason: "` ` has a segment ending in whitespace, so a rendering " +
+              "of the place would name a different cell.",
+          });
         });
 
         it("carries the reason a reference gave a fragment that is no suffix", () => {


### PR DESCRIPTION
## Why

`cd "/board/title "` and `cd "board/title "` land on the key `title`. They should be refused.

The doors' rule is that a part ending in whitespace is refused **wherever it sits** — "because `..` makes any segment the last one" — since a rendering of such a place would not read back to the same cell. Two `operand.trim()` calls defeat that rule at the one position where they can: `trim()` cannot tell the operand's edges from the last part's edges, and at that position they are the same characters.

The control makes the mechanism exact. `cd "/board /title"` — the same whitespace one segment earlier — **is** refused, and `cd "/board/ title"` correctly keeps its leading space. So this is not "whitespace is mishandled"; it is precisely that a whole-string trim strips characters belonging to a part.

Every instance is deliberate on the user's side: `splitLine` separates tokens on whitespace, so an unquoted token cannot contain any. The only way whitespace reaches an operand's edge is a quote somebody wrote on purpose — the case where a silent strip is least defensible.

Both sites are merged code, not this branch's: `movePlace`'s trim came from #6756 and `aim`'s from #6884, which copied the shape.

## What Changed

Both trims deleted. Every relative spelling is now refused at both doors — `cd`'s and `get`'s:

| standing | operand | before | after |
| --- | --- | --- | --- |
| `slugs/` | `board/title ` | lands | refused |
| `slugs/` | `board ` | lands | refused |
| a piece | `title ` | lands | refused |
| any | `/board/title ` | lands | **still lands** — see below |

**The rooted spelling is unchanged, and that is measured rather than assumed.** `normalizeLLMFriendlyRef` trims again at `lib/llm-friendly-ref.ts:227`, and `isReference` at `:77`, so these two trims were redundant on that route. Diffing every `/board*` operand across three standings and both doors before and after: zero lines differ. Fixing that reaches `cf`'s shared reference intake — six call sites across the CLI — and wants its own change with its own review. Recorded in `futures.md` with the two candidate fixes and the question that makes it more than a one-liner: what a trailing edge means when the last part is an `@scope` suffix or `#argument` rather than a path segment.

**What bounds the residue**: `operandForChild` returns nothing for such a child, because it makes the move and compares where it landed rather than trusting the spelling. So a listing offers no name for one of these rows — the wrong cell is reachable only by typing a rooted reference with deliberate trailing whitespace, never by copying a name off a listing.

**One refusal message changes**, per the ruling on this: `cd " "` no longer answers "`cd` takes a place to move to" (which is what `cd` with no operand says) but the position's own rule, because they are different mistakes. That is three position-dependent messages rather than one — a space root's facet rule catches it before the unnameable rule runs — and all three are pinned.

## Test plan

```
deno fmt --check     5718 files      deno lint      5568 files
deno task check      Type check complete
deno task check-docs 589 blocks      check-control-characters  clean
packages/cli         1804 passed (2447 steps) + 1 + 214 (334 steps), 0 failed
```

125 → 146 cases in `shuttle-place.test.ts`. **12 designated mutations, 0 survivors** — every one mutating a predicate, and two of them *narrowing* the rule rather than removing it, so the cases bear on where the line sits rather than only that a line exists.

Per-reading verification that the trim did no other work: each of the five readings it preceded (`""`, `"-"`, `"/"`, `@`, `#`) was exercised unpadded at three standings through both doors, and no unpadded spelling changed. One wart is pinned rather than hidden: `cd " /"` gets a relayed message from the fabric grammar rather than one shuttle wrote, because `isReference` trims internally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BPyjSx5WXYepE9JsK4rBx3


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6975?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

