### PR TITLE
fix(integration): the shell harness pins a desktop viewport (#6910)

### DIFF
--- a/docs/development/UI_TESTING.md
+++ b/docs/development/UI_TESTING.md
@@ -89,6 +89,22 @@ composite web component; use a flattened-tree tool or the pierce fallback below.
    so a navigation that settled on `load` would otherwise hand back a page
    whose shell is still booting.
 
+   Every such page is also opened at a fixed viewport, `SHELL_VIEWPORT` in
+   `packages/integration/shell-utils.ts`, wide enough for the shell's desktop
+   header layout. The header switches layouts on the viewport width, and a
+   browser left to its own default picks a width that varies by platform, so
+   without the pin which layout a suite drives would be a property of the
+   machine running it. A test that means to drive the narrow layout sets a
+   viewport of its own with `page.setViewportSize()`.
+
+   Pinning the width settles which layout is rendered; it does not settle
+   whether a control in it is there to be clicked. A wait that asks only whether
+   an element exists is satisfied by one laid out at no size, and the failure
+   then surfaces one step later as a click that cannot land. Ask
+   `probe.isRendered` in the wait, as
+   [`waiting-in-tests.md`](waiting-in-tests.md) requires of a wait that
+   precedes a click.
+
 ## Why This Works
 
 - **Host roles** give single-control `cf-*` components one stable semantic

--- a/packages/integration/shell-utils.ts
+++ b/packages/integration/shell-utils.ts
@@ -201,6 +201,19 @@ export async function describeStateWaitFailure(
   return lines.join("\n");
 }
 
+/**
+ * The viewport size every page a {@link ShellIntegration} opens is set to.
+ *
+ * The shell's header has a narrow layout and a wide one, and lays out its
+ * breadcrumbs — the piece switcher among them — only in the wide one, from a
+ * viewport width of 769px up. A browser left to its own default picks a width
+ * that varies by platform, so pinning the size is what makes which of the two
+ * a suite drives a property of the harness rather than of the machine running
+ * it. A suite that means to drive the narrow layout sets a viewport of its own
+ * with `Page.setViewportSize`.
+ */
+export const SHELL_VIEWPORT = { width: 1024, height: 768 };
+
 export interface ShellIntegrationConfig {
   pipeConsole?: boolean;
 
@@ -277,6 +290,7 @@ export class ShellIntegration {
   async newPage(url?: string): Promise<Page> {
     this.#checkIsOk();
     const page = await this.#browser!.newPage(url);
+    await page.setViewportSize(SHELL_VIEWPORT);
     this.#attachPage(page);
     // Astral navigates to `url` inside its own `newPage`, before this wrapper
     // exists for an after-navigation hook to run on, so the wait that
@@ -417,6 +431,7 @@ export class ShellIntegration {
   #beforeAll = async () => {
     this.#browser = await Browser.launch({ headless: env.HEADLESS });
     this.#page = await this.#browser.newPage();
+    await this.#page.setViewportSize(SHELL_VIEWPORT);
     this.#attachPage(this.#page);
     await getPresentationSession()?.register(this.#page, this.#presentation);
   };

--- a/packages/shell/integration/header-menu.test.ts
+++ b/packages/shell/integration/header-menu.test.ts
@@ -94,11 +94,14 @@ describe("header menu tests", () => {
     const page = shell.page();
     await loginAndGoto();
 
+    // Rendered, not merely present: `deepText` reads the text of an element
+    // laid out at no size just as it reads a visible one, so without this the
+    // check holds under the narrow header layout, which lays out no breadcrumb.
     await waitForCondition(
       page,
       (probe, name) =>
         probe.collect(".header-space").some((el) =>
-          probe.deepText(el).trim() === name
+          probe.isRendered(el) && probe.deepText(el).trim() === name
         ),
       { args: [SPACE_NAME] },
     );
@@ -177,21 +180,26 @@ describe("header menu tests", () => {
     const page = shell.page();
     await loginAndGoto();
 
-    // Wait for the piece trigger to appear in the header breadcrumb
-    await waitForCondition(
-      page,
-      (probe) => probe.collect(".header-piece-trigger").length > 0,
-    );
+    // Wait for the piece trigger to be laid out in the header breadcrumb.
+    // Existence alone is a weaker condition than the click needs: the
+    // breadcrumbs are laid out only in the header's wide layout, and in the
+    // narrow one the trigger is in the DOM with no box to aim a click at.
+    await waitForCondition(page, (probe) => {
+      const triggers = probe.collect(".header-piece-trigger");
+      return triggers.length > 0 &&
+        triggers.every((el) => probe.isRendered(el));
+    });
 
     // Click the piece trigger to open the dropdown
     const trigger = await pierce(page, ".header-piece-trigger");
     await trigger.click();
 
-    // Dropdown should appear
-    await waitForCondition(
-      page,
-      (probe) => probe.collect(".header-piece-dropdown").length > 0,
-    );
+    // Dropdown should appear, laid out rather than merely present
+    await waitForCondition(page, (probe) => {
+      const dropdowns = probe.collect(".header-piece-dropdown");
+      return dropdowns.length > 0 &&
+        dropdowns.every((el) => probe.isRendered(el));
+    });
 
     // Re-query trigger since Lit may have re-rendered
     const updatedTrigger = await pierce(page, ".header-piece-trigger");


### PR DESCRIPTION
## Why

`opens and closes the desktop piece switcher` has failed on every branch, with
`Cannot click button inside <x-header-view>: it has no layout box`. It is not
a flake — it reproduces at a fresh base, and the cause is that **nothing names
a window size.**

`Browser.launch` passes only `--user-data-dir` and `headless`, and astral emits
`--window-size` only when given one. So the width is whatever the platform's
Chrome defaults to: **756px on macOS here, and something ≥769 on Linux CI**,
where the same test at the same SHA passes (run 33987672414). The presentation
path already pins 1280x720 on register; the test path was the half that did
not.

The mechanism is slightly different from the issue's wording, and the
difference matters: `.header-breadcrumbs` is not merely `min-width`
constrained — it is `display: none` by default and `display: flex` only inside
`@media (min-width: 769px)`. The **ancestor** is `display: none`, which is why
the trigger's own computed `display` still reads `flex` in the click error.

## What changed

`SHELL_VIEWPORT = { width: 1024, height: 768 }`, applied in
`ShellIntegration`'s setup and in `newPage`. Demo mode still wins, since the
presentation session registers afterward.

Both waits in the switcher test now require `probe.isRendered` rather than
`.length > 0` — an element that exists at 0x0 satisfied the old wait, so a
layout condition surfaced one step later as a click error.

**The same shape was fixed one test up**: `shows space name in desktop
breadcrumb` used `probe.deepText`, which reads `textContent` inside a
`display: none` subtree — so it passed at 756px while asserting nothing about
the desktop breadcrumb.

## Instrument check

With the viewport set to 768 — one pixel below the breakpoint — and everything
else as committed:

- the switcher test reds on the **wait**, not the click (`grep -c "Cannot
  click"` = 0), which is the point of the second fix;
- `shows space name in desktop breadcrumb` reds, where at the base run on the
  same side of the breakpoint it was **green** — that is the clause-level
  evidence for the `isRendered` added there.

One clause has no independent mutant and is not claimed to: under a narrow
viewport the test never reaches the dropdown wait, so its redness is carried by
the wait above it.

## Blast radius, stated rather than assumed

32 files under `packages/patterns/integration` also construct
`ShellIntegration`, so the `Pattern Integration Tests` job gets 1024x768 too.
Three UI-driving ones were sampled locally and pass; the 10 CI shards are the
real check. Linux's default width is unmeasured — CI only proves it is ≥769.

Browser lanes that do not go through `ShellIntegration` keep the same
platform-dependence; widening to those was left alone.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6976?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


