### PR TITLE
refactor(runtime-client): `RuntimeProcessor` keeps its collaborators and tables in `#` members behind `accessForTestingOnly`; its suites build real instances

### DIFF
--- a/packages/runtime-client/src/backends/runtime-processor.ts
+++ b/packages/runtime-client/src/backends/runtime-processor.ts
@@ -709,26 +709,17 @@ type RuntimeOperationSession = {
 };
 
 export class RuntimeProcessor {
-  // These members stay TypeScript-private rather than becoming `#` names, which
-  // is the convention elsewhere. `test/backends/runtime-processor.test.ts`
-  // drives this class by calling methods off `RuntimeProcessor.prototype`
-  // against a stand-in receiver — in places a plain object literal holding just
-  // the one field a handler reads. A `#` name is scoped to real instances, so
-  // every such call would throw `Receiver must be an instance of class
-  // RuntimeProcessor`. Converting the class means rewriting that suite to build
-  // real instances.
-
-  private runtime: Runtime;
-  private cc: PiecesController;
-  private spaces = new Map<DID, PiecesController>();
-  private identity: Identity;
-  private _isDisposed = false;
-  private disposingPromise: Promise<void> | undefined;
+  #runtime: Runtime;
+  #cc: PiecesController;
+  #spaces = new Map<DID, PiecesController>();
+  #identity: Identity;
+  #isDisposed = false;
+  #disposingPromise: Promise<void> | undefined;
   // Cell subscriptions, by the subscribing client's scoped cell key. Two
   // clients watching one cell are two subscriptions, so that one client's
   // unsubscribe stops its own feed and no one else's.
-  private subscriptions = new Map<string, Cancel>();
-  private operationSubscriptions = new Map<
+  #subscriptions = new Map<string, Cancel>();
+  #operationSubscriptions = new Map<
     string,
     {
       cancel?: Cancel;
@@ -737,12 +728,12 @@ export class RuntimeProcessor {
       client: WorkerClient;
     }
   >();
-  private operationSessions = new Map<string, RuntimeOperationSession>();
-  private pieceSourceConfirmations = new Map<
+  #operationSessions = new Map<string, RuntimeOperationSession>();
+  #pieceSourceConfirmations = new Map<
     string,
     { token: string; prepared: PreparedPieceSourceChange }
   >();
-  private telemetry: RuntimeTelemetry;
+  #telemetry: RuntimeTelemetry;
   // Whom this runtime acts as and under which enforcement configuration,
   // fixed by the client that initialized it. A runtime carries exactly one,
   // and every client attached to it is checked against this one.
@@ -753,27 +744,27 @@ export class RuntimeProcessor {
   // VDOM mounts, by the mounting client's scoped mount id. A mount id comes
   // from a counter that starts at 1 in each client's own document, so the id
   // alone names a mount only while there is one client.
-  private vdomMounts = new Map<
+  #vdomMounts = new Map<
     string,
     { reconciler: WorkerReconciler; cancel: Cancel; client: WorkerClient }
   >();
-  private vdomBatchIdCounter = 0;
+  #vdomBatchIdCounter = 0;
   // Render-boundary declassification policy applied to every mount's
   // reconciler. Set from InitializationData; "allow" preserves prior behavior.
-  private renderDeclassificationPolicy: RenderDeclassificationPolicy = "allow";
+  #renderDeclassificationPolicy: RenderDeclassificationPolicy = "allow";
   // Host-supplied default render ceiling applied to every mount's
   // reconciler. Undefined preserves prior behavior (no ceiling).
-  private renderConfidentialityCeiling?: RenderConfidentialityCeiling;
+  #renderConfidentialityCeiling?: RenderConfidentialityCeiling;
   // Runner-side display-boundary resolver (Epic H3b) built once from the
   // runtime's trust config + acting principal when a ceiling is in force.
   // Rewrites a cell's label through the exchange rules so `Space(...)`-via-
   // `HasRole` principal forms resolve before the reconciler's ceiling fit.
-  private renderConfidentialityResolver?: RenderConfidentialityResolver;
+  #renderConfidentialityResolver?: RenderConfidentialityResolver;
   // §4.9.3 Stage 2: the membership provider shared with the resolver above and
   // handed to every mount's reconciler, so a `Space(X)`-labeled cell blocked
   // before X's ACL synced re-renders once the ACL grants READ. Undefined when
   // no ceiling is in force.
-  private renderMembershipProvider?: SpaceMembershipProvider;
+  #renderMembershipProvider?: SpaceMembershipProvider;
 
   private constructor(
     runtime: Runtime,
@@ -783,13 +774,169 @@ export class RuntimeProcessor {
     telemetry: RuntimeTelemetry,
     securityContext: RuntimeSecurityContext,
   ) {
-    this.runtime = runtime;
-    this.cc = cc;
-    this.spaces.set(initSpace, cc);
-    this.identity = identity;
-    this.telemetry = telemetry;
-    this.telemetry.addEventListener("telemetry", this.#onTelemetry);
+    this.#runtime = runtime;
+    this.#cc = cc;
+    this.#spaces.set(initSpace, cc);
+    this.#identity = identity;
+    this.#telemetry = telemetry;
+    this.#telemetry.addEventListener("telemetry", this.#onTelemetry);
     this.#securityContext = securityContext;
+  }
+
+  /**
+   * The collaborators this processor was built over, the tables it keeps by
+   * client and by session, the render policy a mount inherits, and the
+   * per-space context step, which a test drives directly.
+   */
+  get accessForTestingOnly(): {
+    runtime: Runtime;
+    cc: PiecesController;
+    readonly spaces: Map<DID, PiecesController>;
+    identity: Identity;
+    subscriptions: Map<string, Cancel>;
+    operationSubscriptions: Map<
+      string,
+      {
+        cancel?: Cancel;
+        cancelled: boolean;
+        sessionKey?: string;
+        client: WorkerClient;
+      }
+    >;
+    operationSessions: Map<string, RuntimeOperationSession>;
+    pieceSourceConfirmations: Map<
+      string,
+      { token: string; prepared: PreparedPieceSourceChange }
+    >;
+    telemetry: RuntimeTelemetry;
+    isDisposed: boolean;
+    vdomMounts: Map<
+      string,
+      { reconciler: WorkerReconciler; cancel: Cancel; client: WorkerClient }
+    >;
+    vdomBatchIdCounter: number;
+    renderDeclassificationPolicy: RenderDeclassificationPolicy;
+    renderConfidentialityCeiling: RenderConfidentialityCeiling | undefined;
+    getSpaceCtx(space: DID): PiecesController;
+  } {
+    // deno-lint-ignore no-this-alias
+    const outerThis = this;
+    return {
+      get runtime() {
+        return outerThis.#runtime;
+      },
+      set runtime(value) {
+        outerThis.#runtime = value;
+      },
+      get cc() {
+        return outerThis.#cc;
+      },
+      set cc(value) {
+        outerThis.#cc = value;
+      },
+      spaces: this.#spaces,
+      get identity() {
+        return outerThis.#identity;
+      },
+      set identity(value) {
+        outerThis.#identity = value;
+      },
+      get subscriptions() {
+        return outerThis.#subscriptions;
+      },
+      set subscriptions(value) {
+        outerThis.#subscriptions = value;
+      },
+      get operationSubscriptions() {
+        return outerThis.#operationSubscriptions;
+      },
+      set operationSubscriptions(value) {
+        outerThis.#operationSubscriptions = value;
+      },
+      get operationSessions() {
+        return outerThis.#operationSessions;
+      },
+      set operationSessions(value) {
+        outerThis.#operationSessions = value;
+      },
+      get pieceSourceConfirmations() {
+        return outerThis.#pieceSourceConfirmations;
+      },
+      set pieceSourceConfirmations(value) {
+        outerThis.#pieceSourceConfirmations = value;
+      },
+      get telemetry() {
+        return outerThis.#telemetry;
+      },
+      set telemetry(value) {
+        outerThis.#telemetry = value;
+      },
+      get isDisposed() {
+        return outerThis.#isDisposed;
+      },
+      set isDisposed(value) {
+        outerThis.#isDisposed = value;
+      },
+      get vdomMounts() {
+        return outerThis.#vdomMounts;
+      },
+      set vdomMounts(value) {
+        outerThis.#vdomMounts = value;
+      },
+      get vdomBatchIdCounter() {
+        return outerThis.#vdomBatchIdCounter;
+      },
+      set vdomBatchIdCounter(value) {
+        outerThis.#vdomBatchIdCounter = value;
+      },
+      get renderDeclassificationPolicy() {
+        return outerThis.#renderDeclassificationPolicy;
+      },
+      set renderDeclassificationPolicy(value) {
+        outerThis.#renderDeclassificationPolicy = value;
+      },
+      get renderConfidentialityCeiling() {
+        return outerThis.#renderConfidentialityCeiling;
+      },
+      set renderConfidentialityCeiling(value) {
+        outerThis.#renderConfidentialityCeiling = value;
+      },
+      getSpaceCtx: (space) => this.#getSpaceCtx(space),
+    };
+  }
+
+  /**
+   * The constructor, which `initialize()` otherwise keeps to itself, so that
+   * a test builds a real instance over the collaborators it supplies.
+   */
+  static get accessForTestingOnly(): {
+    construct(
+      runtime: Runtime,
+      cc: PiecesController,
+      initSpace: DID,
+      identity: Identity,
+      telemetry: RuntimeTelemetry,
+      securityContext: RuntimeSecurityContext,
+    ): RuntimeProcessor;
+  } {
+    return {
+      construct: (
+        runtime,
+        cc,
+        initSpace,
+        identity,
+        telemetry,
+        securityContext,
+      ) =>
+        new RuntimeProcessor(
+          runtime,
+          cc,
+          initSpace,
+          identity,
+          telemetry,
+          securityContext,
+        ),
+    };
   }
 
   static async initialize(data: InitializationData): Promise<RuntimeProcessor> {
@@ -917,21 +1064,21 @@ export class RuntimeProcessor {
     // InitializationData crosses postMessage with no runtime validation, so a
     // typo'd host config or version-skewed peer must fail CLOSED, not open:
     // any present-but-unknown value becomes "deny"; absent stays "allow".
-    processor.renderDeclassificationPolicy =
+    processor.#renderDeclassificationPolicy =
       normalizeRenderDeclassificationPolicy(data.renderDeclassificationPolicy);
-    processor.renderConfidentialityCeiling =
+    processor.#renderConfidentialityCeiling =
       normalizeRenderConfidentialityCeiling(data.renderConfidentialityCeiling);
-    processor.renderMembershipProvider = renderMembershipProviderFor(
+    processor.#renderMembershipProvider = renderMembershipProviderFor(
       runtime,
       identity,
-      processor.renderConfidentialityCeiling,
+      processor.#renderConfidentialityCeiling,
     );
-    processor.renderConfidentialityResolver = renderConfidentialityResolverFor(
+    processor.#renderConfidentialityResolver = renderConfidentialityResolverFor(
       runtime,
       identity,
-      processor.renderConfidentialityCeiling,
+      processor.#renderConfidentialityCeiling,
       space,
-      processor.renderMembershipProvider,
+      processor.#renderMembershipProvider,
     );
     processor.#intentOutcomeCancel = subscribeEventAttentionNotifications(
       runtime,
@@ -962,8 +1109,8 @@ export class RuntimeProcessor {
    */
   watchSiteTable(): void {
     try {
-      const userDid = this.runtime.userIdentityDID;
-      const table = this.runtime.getCell(
+      const userDid = this.#runtime.userIdentityDID;
+      const table = this.#runtime.getCell(
         userDid,
         siteTableCause(userDid),
         siteTableSchema,
@@ -971,7 +1118,7 @@ export class RuntimeProcessor {
       Promise.resolve(table.sync()).then(() => {
         // dispose() may have run while sync was in flight — installing
         // the sink then would leak a live subscription past disposal.
-        if (this._isDisposed) return;
+        if (this.#isDisposed) return;
         this.#siteTableCancel = table.sink(
           (entries: Readonly<SiteTable> | undefined) => {
             const latestEntries = new Map<
@@ -1005,7 +1152,7 @@ export class RuntimeProcessor {
             }
             for (const entry of latestEntries.values()) {
               try {
-                const accepted = this.runtime.registerSpaceHost(
+                const accepted = this.#runtime.registerSpaceHost(
                   entry.did,
                   entry.host,
                 );
@@ -1013,7 +1160,7 @@ export class RuntimeProcessor {
                 // accepted hint can fix a different host.
                 if (!accepted) {
                   const key = `${entry.did}|${entry.host}`;
-                  const effective = this.runtime.hostForSpace(
+                  const effective = this.#runtime.hostForSpace(
                     entry.did,
                   ).toString();
                   if (
@@ -1057,49 +1204,49 @@ export class RuntimeProcessor {
    * created by a pattern some existing context started).
    */
   piecesFor(space: DID): PiecesController | undefined {
-    return this.spaces.get(space);
+    return this.#spaces.get(space);
   }
 
   dispose(): Promise<void> {
-    if (this.disposingPromise) return this.disposingPromise;
-    this._isDisposed = true;
-    this.disposingPromise = (async () => {
-      this.telemetry.removeEventListener("telemetry", this.#onTelemetry);
+    if (this.#disposingPromise) return this.#disposingPromise;
+    this.#isDisposed = true;
+    this.#disposingPromise = (async () => {
+      this.#telemetry.removeEventListener("telemetry", this.#onTelemetry);
       try {
         this.#intentOutcomeCancel?.();
         this.#intentOutcomeCancel = undefined;
         this.#siteTableCancel?.();
         this.#siteTableCancel = undefined;
-        for (const cancel of this.subscriptions.values()) {
+        for (const cancel of this.#subscriptions.values()) {
           cancel();
         }
-        this.subscriptions.clear();
-        for (const subscription of this.operationSubscriptions.values()) {
+        this.#subscriptions.clear();
+        for (const subscription of this.#operationSubscriptions.values()) {
           subscription.cancelled = true;
           subscription.cancel?.();
         }
-        this.operationSubscriptions.clear();
-        this.operationSessions.clear();
-        this.pieceSourceConfirmations.clear();
+        this.#operationSubscriptions.clear();
+        this.#operationSessions.clear();
+        this.#pieceSourceConfirmations.clear();
 
         // Clean up VDOM mounts
-        for (const { reconciler, cancel } of this.vdomMounts.values()) {
+        for (const { reconciler, cancel } of this.#vdomMounts.values()) {
           cancel();
           reconciler.unmount();
         }
-        this.vdomMounts.clear();
+        this.#vdomMounts.clear();
 
-        await this.runtime.storageManager.synced();
-        await this.runtime.dispose();
+        await this.#runtime.storageManager.synced();
+        await this.#runtime.dispose();
       } catch (e) {
         console.error(`Failure during WorkerRuntime disposal: ${e}`);
       }
     })();
-    return this.disposingPromise;
+    return this.#disposingPromise;
   }
 
   isDisposed(): boolean {
-    return this._isDisposed;
+    return this.#isDisposed;
   }
 
   /**
@@ -1151,15 +1298,15 @@ export class RuntimeProcessor {
   disposeClient(client: WorkerClient): void {
     const prefix = clientKeyPrefix(client);
 
-    for (const [key, cancel] of [...this.subscriptions]) {
+    for (const [key, cancel] of [...this.#subscriptions]) {
       if (!key.startsWith(prefix)) continue;
       cancel();
-      this.subscriptions.delete(key);
+      this.#subscriptions.delete(key);
     }
 
     for (
       const [subscriptionId, subscription] of [
-        ...this.operationSubscriptions,
+        ...this.#operationSubscriptions,
       ]
     ) {
       if (subscription.client.id !== client.id) continue;
@@ -1169,16 +1316,16 @@ export class RuntimeProcessor {
       }, client);
     }
 
-    for (const [key, mount] of [...this.vdomMounts]) {
+    for (const [key, mount] of [...this.#vdomMounts]) {
       if (!key.startsWith(prefix)) continue;
       mount.cancel();
       mount.reconciler.unmount();
-      this.vdomMounts.delete(key);
+      this.#vdomMounts.delete(key);
     }
 
-    for (const [sessionId, session] of [...this.operationSessions]) {
+    for (const [sessionId, session] of [...this.#operationSessions]) {
       if (session.clientId !== client.id) continue;
-      this.operationSessions.delete(sessionId);
+      this.#operationSessions.delete(sessionId);
     }
   }
 
@@ -1194,27 +1341,27 @@ export class RuntimeProcessor {
    * with no implicit default at this layer. (The runtime guard catches
    * out-of-date callers that still omit it.)
    */
-  private getSpaceCtx(space: DID): PiecesController {
+  #getSpaceCtx(space: DID): PiecesController {
     const target: DID | undefined = space;
     if (!target) {
       throw new Error("Piece operations must name a space explicitly.");
     }
-    let ctx = this.spaces.get(target);
+    let ctx = this.#spaces.get(target);
     if (!ctx) {
       const created = new PiecesController(
-        { as: this.identity, space: target },
-        this.runtime,
+        { as: this.#identity, space: target },
+        this.#runtime,
       );
       ctx = created;
-      this.spaces.set(target, ctx);
+      this.#spaces.set(target, ctx);
       // The constructor kicks the space-cell sync into `ready` without
       // awaiting it. Observe the failure and evict, so a transient
       // error (unreachable host, bad space) doesn't poison this space
       // for the worker's lifetime — the next request rebuilds the
       // context — and doesn't surface as an unhandled rejection.
       created.ready.catch((error: unknown) => {
-        if (this.spaces.get(target) === created) {
-          this.spaces.delete(target);
+        if (this.#spaces.get(target) === created) {
+          this.#spaces.delete(target);
         }
         console.error(
           `[RuntimeProcessor] Space context for ${target} failed to sync:`,
@@ -1240,18 +1387,18 @@ export class RuntimeProcessor {
           "use getCfcLabel for the redacted display view",
       );
     }
-    let cell = getCell(this.runtime, request.cell);
+    let cell = getCell(this.#runtime, request.cell);
     if (request.meta !== undefined) {
-      const rootCell = getCell(this.runtime, { ...request.cell, path: [] });
+      const rootCell = getCell(this.#runtime, { ...request.cell, path: [] });
       if (
         request.meta === "pattern" || request.meta === "argument" ||
         request.meta === "result"
       ) {
         // For the meta link fields, use the meta linked cell instead
-        const rootCell = getCell(this.runtime, { ...request.cell, path: [] });
+        const rootCell = getCell(this.#runtime, { ...request.cell, path: [] });
         const link = getMetaLink(rootCell, request.meta);
         if (link === undefined) return { value: undefined };
-        cell = this.runtime.getCellFromLink({
+        cell = this.#runtime.getCellFromLink({
           ...link,
           path: [...link.path, ...request.cell.path],
         });
@@ -1294,13 +1441,13 @@ export class RuntimeProcessor {
   async handleCellPull(
     request: CellPullRequest,
   ): Promise<CellGetResponse> {
-    await getCell(this.runtime, request.cell).pull();
+    await getCell(this.#runtime, request.cell).pull();
     // A client pull is the freshness barrier, not a cache sample. Reactive
     // quiescence can expose a lazy scoped target before the commit that creates
     // its value has registered or landed. Cross the commit-aware fixpoint in
     // the same request so the returned value and subsequent operations observe
     // all work causally demanded by this pull.
-    await this.runtime.scheduler.idleWithPendingCommits();
+    await this.#runtime.scheduler.idleWithPendingCommits();
     return this.handleCellGet({
       type: RequestType.CellGet,
       cell: request.cell,
@@ -1315,8 +1462,8 @@ export class RuntimeProcessor {
       throw new TypeError("Cell initialize requires a defined value.");
     }
     const initial = mapCellRefsToSigilLinks(request.value);
-    const result = await this.runtime.editWithRetry((tx) => {
-      const cell = getCell(this.runtime, request.cell).withTx(tx);
+    const result = await this.#runtime.editWithRetry((tx) => {
+      const cell = getCell(this.#runtime, request.cell).withTx(tx);
       // Initialization materializes the same backing value a whole-cell write
       // targets. A schema default is a readable fallback, not proof that the
       // cell has been stored, and a write redirect is an address rather than
@@ -1351,7 +1498,7 @@ export class RuntimeProcessor {
   // the value's shape.
   handleCellSet(request: CellSetRequest): void | Promise<void> {
     const commit = this.applyCellSet(request);
-    if (request.awaitCommit) return this.requireCellCommit(commit);
+    if (request.awaitCommit) return this.#requireCellCommit(commit);
     void commit.catch((error) => {
       console.error(
         "[RuntimeProcessor] Cell set commit failed:",
@@ -1361,30 +1508,30 @@ export class RuntimeProcessor {
   }
 
   handleCellPush(request: CellPushRequest): void | Promise<void> {
-    const tx = this.runtime.edit();
+    const tx = this.#runtime.edit();
     // A frame ordinal distinguishes members within one append. The operation
     // cause distinguishes first members minted by independent client runtimes.
     const frame = pushFrame({
       cause: `runtime-client cell push ${crypto.randomUUID()}`,
-      runtime: this.runtime,
+      runtime: this.#runtime,
       tx,
       space: request.cell.space,
       generatedIdCounter: 0,
     });
     try {
-      const cell = getCell(this.runtime, request.cell) as Cell<FabricValue[]>;
+      const cell = getCell(this.#runtime, request.cell) as Cell<FabricValue[]>;
       const values = request.values.map(mapCellRefsToSigilLinks);
       cell.withTx(tx).push(...values);
     } finally {
       popFrame(frame);
     }
-    this.runtime.prepareTxForCommit(tx);
+    this.#runtime.prepareTxForCommit(tx);
     const commit = tx.commit();
-    if (request.awaitCommit) return this.requireCellCommit(commit);
-    this.observeCellCommit(commit, "push");
+    if (request.awaitCommit) return this.#requireCellCommit(commit);
+    this.#observeCellCommit(commit, "push");
   }
 
-  private operationSessionKey(cell: CellGetRequest["cell"]): string {
+  #operationSessionKey(cell: CellGetRequest["cell"]): string {
     return JSON.stringify([
       cell.space,
       cell.id,
@@ -1393,7 +1540,7 @@ export class RuntimeProcessor {
     ]);
   }
 
-  private operationTarget(
+  #operationTarget(
     cell: CellGetRequest["cell"],
     operationSessionId: string | undefined,
     client: WorkerClient,
@@ -1404,24 +1551,24 @@ export class RuntimeProcessor {
     ) {
       throw new Error("operation session id is malformed");
     }
-    const cellKey = this.operationSessionKey(cell);
+    const cellKey = this.#operationSessionKey(cell);
     const sessionKey = operationSessionId;
     // A few unit harnesses construct the processor from its prototype. Keep
     // this lazy initialization in addition to the class field so those
     // read-only protocol harnesses exercise the same session behavior.
-    this.operationSessions ??= new Map();
+    this.#operationSessions ??= new Map();
     const existing = sessionKey === undefined
       ? undefined
-      : this.operationSessions.get(sessionKey);
+      : this.#operationSessions.get(sessionKey);
     if (existing !== undefined) {
       if (existing.cellKey !== cellKey) {
         throw new Error("operation session cannot change its source cell");
       }
       return { ...existing.target, sessionKey, session: existing };
     }
-    const link = getCell(this.runtime, cell).resolveAsCell()
+    const link = getCell(this.#runtime, cell).resolveAsCell()
       .getAsNormalizedFullLink();
-    const provider = this.runtime.storageManager.open(link.space);
+    const provider = this.#runtime.storageManager.open(link.space);
     const capability = hasOperationStorageCapability(provider)
       ? provider
       : provider.replica;
@@ -1447,7 +1594,7 @@ export class RuntimeProcessor {
       subscriptions: new Set<string>(),
       clientId: client.id,
     };
-    this.operationSessions.set(sessionKey, session);
+    this.#operationSessions.set(sessionKey, session);
     return { ...target, sessionKey, session };
   }
 
@@ -1455,7 +1602,7 @@ export class RuntimeProcessor {
     request: OperationCapabilitiesRequest,
     client: WorkerClient = ownerClient,
   ): Promise<OperationCapabilitiesResponse> {
-    const { capability } = this.operationTarget(
+    const { capability } = this.#operationTarget(
       request.cell,
       request.operationSessionId,
       client,
@@ -1467,7 +1614,7 @@ export class RuntimeProcessor {
     request: OperationQueryRequest,
     client: WorkerClient = ownerClient,
   ): Promise<OperationFieldResponse> {
-    const { capability, address } = this.operationTarget(
+    const { capability, address } = this.#operationTarget(
       request.cell,
       request.operationSessionId,
       client,
@@ -1483,7 +1630,7 @@ export class RuntimeProcessor {
     request: OperationApplyRequest,
     client: WorkerClient = ownerClient,
   ): Promise<OperationApplyResponse> {
-    const { capability, address } = this.operationTarget(
+    const { capability, address } = this.#operationTarget(
       request.cell,
       request.operationSessionId,
       client,
@@ -1506,10 +1653,10 @@ export class RuntimeProcessor {
     request: OperationSubscribeRequest,
     client: WorkerClient = ownerClient,
   ): Promise<BooleanResponse> {
-    if (this.operationSubscriptions.has(request.subscriptionId)) {
+    if (this.#operationSubscriptions.has(request.subscriptionId)) {
       return { value: false };
     }
-    const { capability, address, sessionKey, session } = this.operationTarget(
+    const { capability, address, sessionKey, session } = this.#operationTarget(
       request.cell,
       request.operationSessionId,
       client,
@@ -1527,7 +1674,7 @@ export class RuntimeProcessor {
       client,
       ...(sessionKey === undefined ? {} : { sessionKey }),
     };
-    this.operationSubscriptions.set(request.subscriptionId, subscription);
+    this.#operationSubscriptions.set(request.subscriptionId, subscription);
     session?.subscriptions.add(request.subscriptionId);
     let cancel: Cancel;
     try {
@@ -1536,7 +1683,7 @@ export class RuntimeProcessor {
         ...(request.after === undefined ? {} : { after: request.after }),
       }, (field) => {
         if (
-          this.operationSubscriptions.get(request.subscriptionId) !==
+          this.#operationSubscriptions.get(request.subscriptionId) !==
             subscription
         ) return;
         queueMicrotask(() =>
@@ -1549,22 +1696,23 @@ export class RuntimeProcessor {
       });
     } catch (error) {
       if (
-        this.operationSubscriptions.get(request.subscriptionId) === subscription
+        this.#operationSubscriptions.get(request.subscriptionId) ===
+          subscription
       ) {
-        this.operationSubscriptions.delete(request.subscriptionId);
+        this.#operationSubscriptions.delete(request.subscriptionId);
         session?.subscriptions.delete(request.subscriptionId);
         if (
           sessionKey !== undefined && session?.subscriptions.size === 0 &&
-          this.operationSessions.get(sessionKey) === session
+          this.#operationSessions.get(sessionKey) === session
         ) {
-          this.operationSessions.delete(sessionKey);
+          this.#operationSessions.delete(sessionKey);
         }
       }
       throw error;
     }
     if (
-      this._isDisposed || subscription.cancelled ||
-      this.operationSubscriptions.get(request.subscriptionId) !== subscription
+      this.#isDisposed || subscription.cancelled ||
+      this.#operationSubscriptions.get(request.subscriptionId) !== subscription
     ) {
       cancel();
       return { value: false };
@@ -1577,7 +1725,7 @@ export class RuntimeProcessor {
     request: OperationReleaseRequest,
     client: WorkerClient = ownerClient,
   ): Promise<BooleanResponse> {
-    const { capability, address } = this.operationTarget(
+    const { capability, address } = this.#operationTarget(
       request.cell,
       request.operationSessionId,
       client,
@@ -1595,7 +1743,7 @@ export class RuntimeProcessor {
     request: OperationUnsubscribeRequest,
     client: WorkerClient = ownerClient,
   ): BooleanResponse {
-    const subscription = this.operationSubscriptions.get(
+    const subscription = this.#operationSubscriptions.get(
       request.subscriptionId,
     );
     // A subscription is its subscriber's to stop, and no one else's. The id
@@ -1605,14 +1753,14 @@ export class RuntimeProcessor {
     if (subscription === undefined || subscription.client.id !== client.id) {
       return { value: false };
     }
-    this.operationSubscriptions.delete(request.subscriptionId);
+    this.#operationSubscriptions.delete(request.subscriptionId);
     subscription.cancelled = true;
     subscription.cancel?.();
     if (subscription.sessionKey !== undefined) {
-      const session = this.operationSessions?.get(subscription.sessionKey);
+      const session = this.#operationSessions?.get(subscription.sessionKey);
       session?.subscriptions.delete(request.subscriptionId);
       if (session?.subscriptions.size === 0) {
-        this.operationSessions.delete(subscription.sessionKey);
+        this.#operationSessions.delete(subscription.sessionKey);
       }
     }
     return { value: true };
@@ -1622,12 +1770,12 @@ export class RuntimeProcessor {
     request: OperationSessionCloseRequest,
     client: WorkerClient = ownerClient,
   ): BooleanResponse {
-    const session = this.operationSessions?.get(request.operationSessionId);
+    const session = this.#operationSessions?.get(request.operationSessionId);
     if (session === undefined || session.clientId !== client.id) {
       return { value: false };
     }
     return {
-      value: this.operationSessions.delete(request.operationSessionId),
+      value: this.#operationSessions.delete(request.operationSessionId),
     };
   }
 
@@ -1636,25 +1784,25 @@ export class RuntimeProcessor {
   // Ordinary UI writes remain fire-and-forget, while strict capability writes
   // can await the same outcome through handleCellSet.
   applyCellSet(request: CellSetRequest) {
-    const cell = getCell(this.runtime, request.cell);
+    const cell = getCell(this.#runtime, request.cell);
     const value = mapCellRefsToSigilLinks(request.value);
-    return this.runtime.commitUiCellWrite(cell, value, {
+    return this.#runtime.commitUiCellWrite(cell, value, {
       blind: true,
-      supersedeKey: this.operationSessionKey(request.cell),
+      supersedeKey: this.#operationSessionKey(request.cell),
     });
   }
 
   handleCellSend(request: CellSendRequest): void | Promise<void> {
-    const tx = this.runtime.edit();
-    const cell = getCell(this.runtime, request.cell);
+    const tx = this.#runtime.edit();
+    const cell = getCell(this.#runtime, request.cell);
     cell.withTx(tx).send(mapCellRefsToSigilLinks(request.event));
-    this.runtime.prepareTxForCommit(tx);
+    this.#runtime.prepareTxForCommit(tx);
     const commit = tx.commit();
-    if (request.awaitCommit) return this.requireCellCommit(commit);
-    this.observeCellCommit(commit, "send");
+    if (request.awaitCommit) return this.#requireCellCommit(commit);
+    this.#observeCellCommit(commit, "send");
   }
 
-  private observeCellCommit(
+  #observeCellCommit(
     commit: ReturnType<ReturnType<Runtime["edit"]>["commit"]>,
     operation: "set" | "push" | "send",
   ): void {
@@ -1676,7 +1824,7 @@ export class RuntimeProcessor {
     );
   }
 
-  private async requireCellCommit(
+  async #requireCellCommit(
     commit: ReturnType<ReturnType<Runtime["edit"]>["commit"]>,
   ): Promise<void> {
     const result = await commit;
@@ -1689,11 +1837,11 @@ export class RuntimeProcessor {
   ): BooleanResponse {
     const key = clientScopedKey(client, cellRefToKey(request.cell));
 
-    if (this.subscriptions.has(key)) {
+    if (this.#subscriptions.has(key)) {
       return { value: false };
     }
 
-    const cell = getCell(this.runtime, request.cell);
+    const cell = getCell(this.#runtime, request.cell);
 
     const cancel = cell.sink((value, cfcLabel) => {
       // Log empty-schema subscriptions that produce CellResult proxies.
@@ -1731,7 +1879,7 @@ export class RuntimeProcessor {
       );
     }, { includeCfcLabel: request.includeCfcLabel === true });
 
-    this.subscriptions.set(key, cancel);
+    this.#subscriptions.set(key, cancel);
     return { value: true };
   }
 
@@ -1740,17 +1888,17 @@ export class RuntimeProcessor {
     client: WorkerClient = ownerClient,
   ): BooleanResponse {
     const key = clientScopedKey(client, cellRefToKey(request.cell));
-    const cancel = this.subscriptions.get(key);
+    const cancel = this.#subscriptions.get(key);
     if (cancel) {
       cancel();
-      this.subscriptions.delete(key);
+      this.#subscriptions.delete(key);
       return { value: true };
     }
     return { value: false };
   }
 
   handleCellResolveAsCell(request: CellResolveAsCellRequest): CellResponse {
-    const cell = getCell(this.runtime, request.cell);
+    const cell = getCell(this.#runtime, request.cell);
     const resolved = cell.resolveAsCell();
     const ref = createCellRef(resolved);
     if (
@@ -1780,7 +1928,7 @@ export class RuntimeProcessor {
     // Label reads must use the runtime's stored cell identity. The request
     // schema is client-supplied view context, not trusted label provenance.
     const { schema: _schema, ...cellRef } = request.cell;
-    const cell = getCell(this.runtime, cellRef);
+    const cell = getCell(this.#runtime, cellRef);
     // Pure, non-blocking read of the CURRENT local store — no sync. getCfcLabel
     // is the display-label seam, and its only callers are reactive UI components
     // (cf-cfc-label, cf-cfc-authorship, cf-profile-badge) that subscribe to the
@@ -1806,8 +1954,8 @@ export class RuntimeProcessor {
   async handleSqliteQuery(
     request: SqliteQueryRequest,
   ): Promise<SqliteQueryResponse> {
-    const cell = getCell(this.runtime, request.cell);
-    const db = await this.pullSqliteDbRef(cell);
+    const cell = getCell(this.#runtime, request.cell);
+    const db = await this.#pullSqliteDbRef(cell);
     // A direct IPC query has no runner result cell on which to persist the
     // label derived from result-column provenance. Refuse that database shape
     // instead of returning rows with their CFC labels silently stripped.
@@ -1817,7 +1965,7 @@ export class RuntimeProcessor {
           "tables; query them inside a pattern so result labels propagate.",
       );
     }
-    const provider = this.runtime.storageManager.open(request.cell.space);
+    const provider = this.#runtime.storageManager.open(request.cell.space);
     if (!provider.sqliteQuery) {
       throw new Error(
         "sqlite: storage provider does not support queries " +
@@ -1828,7 +1976,7 @@ export class RuntimeProcessor {
       ? undefined
       : encodeSqliteParams(
         request.sql,
-        sqliteParamsForRuntime(this.runtime, request.params),
+        sqliteParamsForRuntime(this.#runtime, request.params),
       );
     const result = await provider.sqliteQuery(db, request.sql, params);
     return {
@@ -1844,14 +1992,14 @@ export class RuntimeProcessor {
   }
 
   async handleSqliteExec(request: SqliteExecRequest): Promise<void> {
-    const source = getCell(this.runtime, request.cell);
-    const db = await this.pullSqliteDbRef(source);
-    const result = await this.runtime.editWithRetry((tx) => {
+    const source = getCell(this.#runtime, request.cell);
+    const db = await this.#pullSqliteDbRef(source);
+    const result = await this.#runtime.editWithRetry((tx) => {
       markDurableReadTx(tx);
       const params = request.params === undefined
         ? undefined
-        : sqliteParamsForRuntime(this.runtime, request.params, tx);
-      const cell = getCell(this.runtime, request.cell).withTx(
+        : sqliteParamsForRuntime(this.#runtime, request.params, tx);
+      const cell = getCell(this.#runtime, request.cell).withTx(
         tx,
       ) as unknown as Cell<unknown> & {
         exec(
@@ -1870,7 +2018,7 @@ export class RuntimeProcessor {
     if (result.error) throw new Error(result.error.message);
   }
 
-  private async pullSqliteDbRef(cell: Cell<unknown>): Promise<SqliteDbRef> {
+  async #pullSqliteDbRef(cell: Cell<unknown>): Promise<SqliteDbRef> {
     await cell.pull();
     const raw = cell.getRaw({ lastNode: "value" });
     const missing = raw === undefined ||
@@ -1885,13 +2033,13 @@ export class RuntimeProcessor {
       // replica. Cross the commit-aware barrier before loading only that first
       // missing value. Non-empty malformed handles still fail immediately in
       // readSqliteDbRef instead of being mistaken for a pending factory.
-      await this.runtime.scheduler.idleWithPendingCommits();
+      await this.#runtime.scheduler.idleWithPendingCommits();
       await cell.sync();
     }
-    return this.readSqliteDbRef(cell);
+    return this.#readSqliteDbRef(cell);
   }
 
-  private readSqliteDbRef(cell: Cell<unknown>): SqliteDbRef {
+  #readSqliteDbRef(cell: Cell<unknown>): SqliteDbRef {
     const raw = cell.getRaw({ lastNode: "value" }) as
       | {
         id?: unknown;
@@ -1934,7 +2082,7 @@ export class RuntimeProcessor {
   }
 
   handleGetCell(request: GetCellRequest): CellResponse {
-    const cell = this.runtime.getCell(
+    const cell = this.#runtime.getCell(
       request.space,
       request.cause,
       request.schema,
@@ -1946,7 +2094,7 @@ export class RuntimeProcessor {
   }
 
   handleGetHomeSpaceCell(_request: GetHomeSpaceCellRequest): CellResponse {
-    const homeSpaceCell = this.runtime.getHomeSpaceCell();
+    const homeSpaceCell = this.#runtime.getHomeSpaceCell();
     return {
       cell: createCellRef(homeSpaceCell),
     };
@@ -1960,7 +2108,7 @@ export class RuntimeProcessor {
   async handleEnsureHomePatternRunning(
     _request: EnsureHomePatternRunningRequest,
   ): Promise<CellResponse> {
-    const homeSpaceCell = this.runtime.getHomeSpaceCell();
+    const homeSpaceCell = this.#runtime.getHomeSpaceCell();
     await homeSpaceCell.sync();
 
     // Always the PiecesController path: ensureDefaultPattern() follows the
@@ -1969,10 +2117,10 @@ export class RuntimeProcessor {
     // nothing else heals the root — so no fast path belongs in front of the
     // controller.
     const homeSession: Session = {
-      as: this.identity,
-      space: this.runtime.userIdentityDID,
+      as: this.#identity,
+      space: this.#runtime.userIdentityDID,
     };
-    const homeCC = new PiecesController(homeSession, this.runtime);
+    const homeCC = new PiecesController(homeSession, this.#runtime);
     await homeCC.synced();
 
     const homePattern = await homeCC.ensureDefaultPattern();
@@ -1990,13 +2138,13 @@ export class RuntimeProcessor {
     // the storage manager, covering event handlers, direct cell IPC writes,
     // and reactive write-backs alike). Internal callers that only need
     // reactive quiescence use runtime.idle() and are unaffected.
-    await this.runtime.scheduler.idleWithPendingCommits();
+    await this.#runtime.scheduler.idleWithPendingCommits();
   }
 
   async handleListEventAttention(
     request: ListEventAttentionRequest,
   ): Promise<EventAttentionListResponse> {
-    const provider = this.runtime.storageManager.open(request.space);
+    const provider = this.#runtime.storageManager.open(request.space);
     const indexSync = await provider.sync(
       SERVER_EXECUTION_ATTENTION_DOC_ID as never,
       undefined,
@@ -2044,7 +2192,7 @@ export class RuntimeProcessor {
           entry?.status !== "needs-attention" ||
           entry.attention === undefined ||
           entry.resolution !== undefined ||
-          (actingUser !== undefined && actingUser !== this.identity.did())
+          (actingUser !== undefined && actingUser !== this.#identity.did())
         ) continue;
         notices.push({
           space: request.space,
@@ -2063,12 +2211,12 @@ export class RuntimeProcessor {
   async handleResolveEventAttention(
     request: ResolveEventAttentionRequest,
   ): Promise<EventAttentionResolveResponse> {
-    const resolve = this.runtime.storageManager.resolveEventAttention;
+    const resolve = this.#runtime.storageManager.resolveEventAttention;
     if (resolve === undefined) {
       throw new Error("storage manager does not support event attention");
     }
     const result = await resolve.call(
-      this.runtime.storageManager,
+      this.#runtime.storageManager,
       request.space,
       request.eventId,
       request.seq,
@@ -2082,13 +2230,13 @@ export class RuntimeProcessor {
   // awaits in-flight compile-cache write-backs so a subsequent load reads the
   // freshly-written entry instead of recompiling.
   async handleFlushCompileCacheWrites(): Promise<void> {
-    await this.runtime.patternManager.flushCompileCacheWrites();
+    await this.#runtime.patternManager.flushCompileCacheWrites();
   }
 
   async handlePieceCreate(
     request: PieceCreateRequest,
   ): Promise<PieceResponse> {
-    const cc = this.getSpaceCtx(request.space);
+    const cc = this.#getSpaceCtx(request.space);
     let program: Program | undefined;
     if ("url" in request.source && request.source.url) {
       const sourceUrl = new URL(request.source.url);
@@ -2136,7 +2284,7 @@ export class RuntimeProcessor {
   async handleGetSpaceRootPattern(
     request: PatternGetSpaceRoot,
   ): Promise<PieceResponse> {
-    const cc = this.getSpaceCtx(request.space);
+    const cc = this.#getSpaceCtx(request.space);
     if (request.start === false) {
       // The caller reads the root's exports rather than rendering it, so
       // resolving what is stored answers it — reconciled, so what it reads
@@ -2158,7 +2306,7 @@ export class RuntimeProcessor {
   async handleRecreateSpaceRootPattern(
     request: RecreateSpaceRootPatternRequest,
   ): Promise<PieceResponse> {
-    const cc = this.getSpaceCtx(request.space);
+    const cc = this.#getSpaceCtx(request.space);
     const piece = await cc.recreateDefaultPattern();
     return {
       piece: createPieceRef(piece.getCell()),
@@ -2179,11 +2327,11 @@ export class RuntimeProcessor {
   async handlePieceGet(
     request: PieceGetRequest,
   ): Promise<PieceResponse> {
-    const cc = this.getSpaceCtx(request.space);
+    const cc = this.#getSpaceCtx(request.space);
     // Probed in the scope the request names, because the id alone names a
     // different document in every other scope: reading the default one would
     // ask whether some unrelated document is a redirect.
-    const requestedCell = this.runtime.getCellFromEntityId(
+    const requestedCell = this.#runtime.getCellFromEntityId(
       cc.getSpace(),
       entityIdFrom(request.pieceId),
       [],
@@ -2197,7 +2345,7 @@ export class RuntimeProcessor {
       requestedCell.getAsNormalizedFullLink(),
     );
     if (redirect?.overwrite === "redirect") {
-      const target = this.runtime.getCellFromLink({
+      const target = this.#runtime.getCellFromLink({
         ...redirect,
         space: redirect.space ?? cc.getSpace(),
         scope: redirect.scope ?? "space",
@@ -2240,8 +2388,8 @@ export class RuntimeProcessor {
   async handlePieceGetSlug(
     request: PieceGetSlugRequest,
   ): Promise<SlugResponse> {
-    const pieces = this.getSpaceCtx(request.space);
-    const cell = this.runtime.getCellFromEntityId(
+    const pieces = this.#getSpaceCtx(request.space);
+    const cell = this.#runtime.getCellFromEntityId(
       pieces.getSpace(),
       entityIdFrom(request.pieceId),
       [],
@@ -2278,19 +2426,19 @@ export class RuntimeProcessor {
   async handleSlugResolve(
     request: SlugResolveRequest,
   ): Promise<SlugReferenceResponse> {
-    const cc = this.getSpaceCtx(request.space);
+    const cc = this.#getSpaceCtx(request.space);
     const space = cc.getSpace();
     try {
       if (request.member === undefined) {
         const { piece } = await resolveSlugTargetInPiece(
-          this.runtime,
+          this.#runtime,
           space,
           request.slug,
         );
         return { piece: createPieceRef(piece), pathAfter: [] };
       }
       const { piece, pathAfter } = await resolveSlugReference(
-        this.runtime,
+        this.#runtime,
         space,
         request.slug,
         [request.member],
@@ -2313,14 +2461,14 @@ export class RuntimeProcessor {
   async handlePieceRemove(
     request: PieceRemoveRequest,
   ): Promise<BooleanResponse> {
-    const cc = this.getSpaceCtx(request.space);
+    const cc = this.#getSpaceCtx(request.space);
     return { value: await cc.remove(request.pieceId, request.scope) };
   }
 
   async handlePieceStart(
     request: PieceStartRequest,
   ): Promise<BooleanResponse> {
-    const cc = this.getSpaceCtx(request.space);
+    const cc = this.#getSpaceCtx(request.space);
     await cc.startPiece(request.pieceId, request.scope);
     // @TODO(runtime-worker-refactor): Return status based on if
     // pattern was actually found and stopped
@@ -2330,7 +2478,7 @@ export class RuntimeProcessor {
   async handlePieceStop(
     request: PieceStopRequest,
   ): Promise<BooleanResponse> {
-    const cc = this.getSpaceCtx(request.space);
+    const cc = this.#getSpaceCtx(request.space);
     await cc.stopPiece(request.pieceId, request.scope);
     // @TODO(runtime-worker-refactor): Return status based on if
     // pattern was actually found and stopped
@@ -2338,7 +2486,7 @@ export class RuntimeProcessor {
   }
 
   async handlePieceGetAll(request: PieceGetAllRequest): Promise<CellResponse> {
-    const pieces = this.getSpaceCtx(request.space);
+    const pieces = this.#getSpaceCtx(request.space);
     const piecesCell = await pieces.getPieceRegistry();
     return {
       cell: createCellRef(piecesCell),
@@ -2346,16 +2494,16 @@ export class RuntimeProcessor {
   }
 
   async handlePieceSynced(request: PieceSyncedRequest): Promise<void> {
-    const pieces = this.getSpaceCtx(request.space);
+    const pieces = this.#getSpaceCtx(request.space);
     await pieces.synced();
   }
 
   async handlePieceGetSource(
     request: PieceGetSourceRequest,
   ): Promise<PieceSourceResponse> {
-    const pieces = this.getSpaceCtx(request.space);
+    const pieces = this.#getSpaceCtx(request.space);
     // The reader syncs the piece itself, as its first step.
-    const cell = this.runtime.getCellFromEntityId(
+    const cell = this.#runtime.getCellFromEntityId(
       pieces.getSpace(),
       entityIdFrom(request.pieceId),
       [],
@@ -2363,15 +2511,15 @@ export class RuntimeProcessor {
       undefined,
       request.scope,
     );
-    const state = await readPieceSourceState(this.runtime, cell);
+    const state = await readPieceSourceState(this.#runtime, cell);
     return { source: { ...state, space: state.space as DID } };
   }
 
   async handlePieceGetSourceRevision(
     request: PieceGetSourceRevisionRequest,
   ): Promise<PieceSourceRevisionResponse> {
-    const pieces = this.getSpaceCtx(request.space);
-    const cell = this.runtime.getCellFromEntityId(
+    const pieces = this.#getSpaceCtx(request.space);
+    const cell = this.#runtime.getCellFromEntityId(
       pieces.getSpace(),
       entityIdFrom(request.pieceId),
       [],
@@ -2381,7 +2529,7 @@ export class RuntimeProcessor {
     );
     return {
       source: await readPieceSourceRevision(
-        this.runtime,
+        this.#runtime,
         cell,
         request.revisionId,
       ),
@@ -2390,8 +2538,8 @@ export class RuntimeProcessor {
 
   /** Clone a source piece into another space. */
   async handlePieceClone(request: PieceCloneRequest): Promise<PieceResponse> {
-    const sourcePieces = this.getSpaceCtx(request.sourceSpace);
-    const sourceCell = this.runtime.getCellFromEntityId(
+    const sourcePieces = this.#getSpaceCtx(request.sourceSpace);
+    const sourceCell = this.#runtime.getCellFromEntityId(
       sourcePieces.getSpace(),
       entityIdFrom(request.pieceId),
       [],
@@ -2401,7 +2549,7 @@ export class RuntimeProcessor {
     );
     const source = new PieceController(sourcePieces, sourceCell);
     const clone = await source.cloneTo(
-      this.getSpaceCtx(request.destinationSpace),
+      this.#getSpaceCtx(request.destinationSpace),
       { copyData: request.copyData === true },
     );
     return { piece: createPieceRef(clone.getCell()) };
@@ -2417,7 +2565,7 @@ export class RuntimeProcessor {
     ) {
       throw new Error("confirmationToken must be a non-empty string");
     }
-    const pieces = this.getSpaceCtx(request.space);
+    const pieces = this.#getSpaceCtx(request.space);
     // Keyed on the piece's whole address, and on its bare hash rather than on
     // the request's spelling of it: a caller may prepare a change under one
     // accepted address form and confirm it under the other, and both must
@@ -2429,10 +2577,10 @@ export class RuntimeProcessor {
     }\u0000${hashStringForEntityAddress(request.pieceId)}`;
     let confirmedChange: PreparedPieceSourceChange | undefined;
     if (request.confirmationToken === undefined) {
-      this.pieceSourceConfirmations.delete(confirmationKey);
+      this.#pieceSourceConfirmations.delete(confirmationKey);
     } else {
-      const pending = this.pieceSourceConfirmations.get(confirmationKey);
-      this.pieceSourceConfirmations.delete(confirmationKey);
+      const pending = this.#pieceSourceConfirmations.get(confirmationKey);
+      this.#pieceSourceConfirmations.delete(confirmationKey);
       if (
         pending === undefined ||
         pending.token !== request.confirmationToken
@@ -2443,7 +2591,7 @@ export class RuntimeProcessor {
       }
       confirmedChange = pending.prepared;
     }
-    const cell = this.runtime.getCellFromEntityId(
+    const cell = this.#runtime.getCellFromEntityId(
       pieces.getSpace(),
       entityIdFrom(request.pieceId),
       [],
@@ -2458,18 +2606,18 @@ export class RuntimeProcessor {
     let confirmationToken: string | undefined;
     if (result.status === "incompatible") {
       confirmationToken = crypto.randomUUID();
-      this.pieceSourceConfirmations.set(confirmationKey, {
+      this.#pieceSourceConfirmations.set(confirmationKey, {
         token: confirmationToken,
         prepared: result.prepared,
       });
     }
     const appliedState = result.status === "applied"
-      ? readPieceSourceMetadata(this.runtime, cell)
+      ? readPieceSourceMetadata(this.#runtime, cell)
       : undefined;
     let state;
     let sourceReadWarning: string | undefined;
     try {
-      state = await readPieceSourceState(this.runtime, cell);
+      state = await readPieceSourceState(this.#runtime, cell);
     } catch (error) {
       if (result.status !== "applied") throw error;
       state = appliedState!;
@@ -2500,9 +2648,9 @@ export class RuntimeProcessor {
   async handleSpaceGetAcl(
     request: SpaceGetAclRequest,
   ): Promise<SpaceAclResponse> {
-    this.getSpaceCtx(request.space);
-    const acl = await new ACLManager(this.runtime, request.space).get();
-    return spaceAclResponse(this.runtime, request.space, acl);
+    this.#getSpaceCtx(request.space);
+    const acl = await new ACLManager(this.#runtime, request.space).get();
+    return spaceAclResponse(this.#runtime, request.space, acl);
   }
 
   async handleSpaceSetAclEntry(
@@ -2514,11 +2662,11 @@ export class RuntimeProcessor {
     if (!isCapability(request.capability)) {
       throw new Error("capability must be `READ`, `WRITE`, or `OWNER`");
     }
-    this.getSpaceCtx(request.space);
-    const manager = new ACLManager(this.runtime, request.space);
+    this.#getSpaceCtx(request.space);
+    const manager = new ACLManager(this.#runtime, request.space);
     const acl = await manager.set(request.user, request.capability);
     return spaceAclResponse(
-      this.runtime,
+      this.#runtime,
       request.space,
       acl,
     );
@@ -2530,11 +2678,11 @@ export class RuntimeProcessor {
     if (!isACLUser(request.user)) {
       throw new Error("user must be `*` or a valid DID");
     }
-    this.getSpaceCtx(request.space);
-    const manager = new ACLManager(this.runtime, request.space);
+    this.#getSpaceCtx(request.space);
+    const manager = new ACLManager(this.#runtime, request.space);
     const acl = await manager.remove(request.user);
     return spaceAclResponse(
-      this.runtime,
+      this.#runtime,
       request.space,
       acl,
     );
@@ -2544,25 +2692,25 @@ export class RuntimeProcessor {
     request: RegisterSpaceHostRequest,
   ): BooleanResponse {
     return {
-      value: this.runtime.registerSpaceHost(request.space, request.host),
+      value: this.#runtime.registerSpaceHost(request.space, request.host),
     };
   }
 
   async handleResolveSpaceName(
     request: ResolveSpaceNameRequest,
   ): Promise<SpaceResponse> {
-    return { space: await this.runtime.resolveSpaceName(request.name) };
+    return { space: await this.#runtime.resolveSpaceName(request.name) };
   }
 
   /** Convergence across every opened space — no space named, none implied. */
   async handleRuntimeSynced(): Promise<void> {
     await Promise.all(
-      [...this.spaces.values()].map((pieces) => pieces.synced()),
+      [...this.#spaces.values()].map((pieces) => pieces.synced()),
     );
   }
 
   getGraphSnapshot(_: GetGraphSnapshotRequest): GraphSnapshotResponse {
-    return { snapshot: this.runtime.scheduler.getGraphSnapshot() };
+    return { snapshot: this.#runtime.scheduler.getGraphSnapshot() };
   }
 
   getLoggerCounts(_: GetLoggerCountsRequest): LoggerCountsResponse {
@@ -2590,14 +2738,14 @@ export class RuntimeProcessor {
 
   setTelemetryEnabled(request: SetTelemetryEnabledRequest): void {
     this.#telemetryEnabled = request.enabled;
-    this.runtime.scheduler.setEventPreflightTelemetryEnabled(request.enabled);
+    this.#runtime.scheduler.setEventPreflightTelemetryEnabled(request.enabled);
   }
 
   /** Changes memory-message compression for every remote storage session. */
   async setMemoryMessageCompression(
     request: SetMemoryMessageCompressionRequest,
   ): Promise<void> {
-    await this.runtime.storageManager.setMessageCompressionEnabled?.(
+    await this.#runtime.storageManager.setMessageCompressionEnabled?.(
       request.enabled,
     );
   }
@@ -2633,7 +2781,7 @@ export class RuntimeProcessor {
   getPatternSources(
     _request: GetPatternSourcesRequest,
   ): PatternSourcesResponse {
-    const snapshot = this.runtime.scheduler.getGraphSnapshot();
+    const snapshot = this.#runtime.scheduler.getGraphSnapshot();
     const seen = new Set<string>();
     const patterns: PatternSourceInfo[] = [];
 
@@ -2646,7 +2794,7 @@ export class RuntimeProcessor {
       // module, so the symbol only selects a representative artifact). A
       // source-free by-identity reload carries no program — omit it (same
       // graceful degradation as the prior meta-cell read's try/catch).
-      const program = this.runtime.patternManager.getPatternProgramBySync(
+      const program = this.#runtime.patternManager.getPatternProgramBySync(
         ref.identity,
         ref.symbol,
       );
@@ -2667,7 +2815,7 @@ export class RuntimeProcessor {
   }
 
   setBreakpoints(request: SetBreakpointsRequest): void {
-    this.runtime.scheduler.setBreakpoints(request.actionIds);
+    this.#runtime.scheduler.setBreakpoints(request.actionIds);
   }
 
   async handleUploadBlob(
@@ -2682,7 +2830,7 @@ export class RuntimeProcessor {
     const suffix = (request.suffix ?? "bin").replace(/^\./, "") || "bin";
     // The blob belongs to the named space, so it uploads to — and its
     // returned URL resolves against — THAT space's host.
-    const host = this.runtime.hostForSpace(request.space);
+    const host = this.#runtime.hostForSpace(request.space);
     const target = new URL(
       `/${request.space}/blobs/upload.${encodeURIComponent(suffix)}`,
       host,
@@ -2725,21 +2873,21 @@ export class RuntimeProcessor {
   async detectNonIdempotent(
     request: DetectNonIdempotentRequest,
   ): Promise<DetectNonIdempotentResponse> {
-    const result = await this.runtime.scheduler.runDiagnosis(
+    const result = await this.#runtime.scheduler.runDiagnosis(
       request.durationMs,
     );
     return { result };
   }
 
   getPatternCoverage(_: GetPatternCoverageRequest): PatternCoverageResponse {
-    return { data: this.runtime.patternCoverage?.toData() ?? null };
+    return { data: this.#runtime.patternCoverage?.toData() ?? null };
   }
 
   getSettleStats(
     _request: GetSettleStatsRequest,
   ): SettleStatsResponse {
     return {
-      stats: this.runtime.scheduler.getSettleStats(),
+      stats: this.#runtime.scheduler.getSettleStats(),
     };
   }
 
@@ -2747,56 +2895,56 @@ export class RuntimeProcessor {
     _request: GetSettleStatsHistoryRequest,
   ): SettleStatsHistoryResponse {
     return {
-      history: this.runtime.scheduler.getSettleStatsHistory(),
+      history: this.#runtime.scheduler.getSettleStatsHistory(),
     };
   }
 
   setSettleStatsEnabled(
     request: SetSettleStatsEnabledRequest,
   ): void {
-    this.runtime.scheduler.setSettleStatsEnabled(request.enabled);
+    this.#runtime.scheduler.setSettleStatsEnabled(request.enabled);
   }
 
   getActionRunTrace(
     _request: GetActionRunTraceRequest,
   ): ActionRunTraceResponse {
     return {
-      trace: this.runtime.scheduler.getActionRunTrace(),
+      trace: this.#runtime.scheduler.getActionRunTrace(),
     };
   }
 
   setActionRunTraceEnabled(
     request: SetActionRunTraceEnabledRequest,
   ): void {
-    this.runtime.scheduler.setActionRunTraceEnabled(request.enabled);
+    this.#runtime.scheduler.setActionRunTraceEnabled(request.enabled);
   }
 
   getTriggerTrace(
     _request: GetTriggerTraceRequest,
   ): TriggerTraceResponse {
     return {
-      trace: this.runtime.scheduler.getTriggerTrace(),
+      trace: this.#runtime.scheduler.getTriggerTrace(),
     };
   }
 
   setTriggerTraceEnabled(
     request: SetTriggerTraceEnabledRequest,
   ): void {
-    this.runtime.scheduler.setTriggerTraceEnabled(request.enabled);
+    this.#runtime.scheduler.setTriggerTraceEnabled(request.enabled);
   }
 
   getWriteStackTrace(
     _request: GetWriteStackTraceRequest,
   ): WriteStackTraceResponse {
     return {
-      trace: this.runtime.getWriteStackTrace(),
+      trace: this.#runtime.getWriteStackTrace(),
     };
   }
 
   setWriteStackTraceMatchers(
     request: SetWriteStackTraceMatchersRequest,
   ): void {
-    this.runtime.setWriteStackTraceMatchers(request.matchers);
+    this.#runtime.setWriteStackTraceMatchers(request.matchers);
   }
 
   async handleRequest(
@@ -2989,7 +3137,7 @@ export class RuntimeProcessor {
     request: VDomEventNotification,
     client: WorkerClient = ownerClient,
   ): void {
-    const mount = this.vdomMounts.get(
+    const mount = this.#vdomMounts.get(
       clientScopedKey(client, request.mountId),
     );
     if (!mount) {
@@ -3027,7 +3175,7 @@ export class RuntimeProcessor {
 
     // Check if already mounted. Scoped to this client, so a second client
     // mounting under the same id mounts rather than displacing the first.
-    if (this.vdomMounts.has(key)) {
+    if (this.#vdomMounts.has(key)) {
       this.handleVDomUnmount(
         { type: RequestType.VDomUnmount, mountId },
         client,
@@ -3036,17 +3184,17 @@ export class RuntimeProcessor {
 
     // Get the cell from the runtime and apply rendererVDOMSchema
     // The schema has a [UI] property definition that handles VDOM unwrapping
-    const rawCell = getCell(this.runtime, cellRef);
+    const rawCell = getCell(this.#runtime, cellRef);
     const cell = rawCell.asSchema(rendererVDOMSchema);
 
     // Create a reconciler that sends ops to the main thread
     const reconciler = new WorkerReconciler({
-      renderDeclassificationPolicy: this.renderDeclassificationPolicy,
-      renderConfidentialityCeiling: this.renderConfidentialityCeiling,
-      resolveRenderConfidentiality: this.renderConfidentialityResolver,
-      membershipProvider: this.renderMembershipProvider,
+      renderDeclassificationPolicy: this.#renderDeclassificationPolicy,
+      renderConfidentialityCeiling: this.#renderConfidentialityCeiling,
+      resolveRenderConfidentiality: this.#renderConfidentialityResolver,
+      membershipProvider: this.#renderMembershipProvider,
       onOps: (ops: VDomOp[]) => {
-        const batchId = this.vdomBatchIdCounter++;
+        const batchId = this.#vdomBatchIdCounter++;
         // `mountId` as the client sent it: the scoping is this worker's
         // bookkeeping, and the client knows its mounts by its own ids.
         client.post({
@@ -3065,7 +3213,7 @@ export class RuntimeProcessor {
     const cancel = reconciler.mount(cell);
 
     // Track this mount
-    this.vdomMounts.set(key, { reconciler, cancel, client });
+    this.#vdomMounts.set(key, { reconciler, cancel, client });
 
     return { rootId: reconciler.getRootNodeId() };
   }
@@ -3079,7 +3227,7 @@ export class RuntimeProcessor {
   ): void {
     const { mountId } = request;
 
-    const mount = this.vdomMounts.get(clientScopedKey(client, mountId));
+    const mount = this.#vdomMounts.get(clientScopedKey(client, mountId));
     if (!mount) {
       console.warn(`[RuntimeProcessor] Mount ${mountId} not found for unmount`);
       return;
@@ -3088,14 +3236,14 @@ export class RuntimeProcessor {
     // Cancel subscriptions and clean up
     mount.cancel();
     mount.reconciler.unmount();
-    this.vdomMounts.delete(clientScopedKey(client, mountId));
+    this.#vdomMounts.delete(clientScopedKey(client, mountId));
   }
 
   handleVDomBatchApplied(
     request: VDomBatchAppliedNotification,
     client: WorkerClient = ownerClient,
   ): void {
-    const mount = this.vdomMounts.get(
+    const mount = this.#vdomMounts.get(
       clientScopedKey(client, request.mountId),
     );
     if (!mount) {

--- a/packages/runtime-client/src/backends/runtime-processor.ts
+++ b/packages/runtime-client/src/backends/runtime-processor.ts
@@ -784,15 +784,15 @@ export class RuntimeProcessor {
   }
 
   /**
-   * The collaborators this processor was built over, the tables it keeps by
-   * client and by session, the render policy a mount inherits, and the
-   * per-space context step, which a test drives directly.
+   * The runtime and home context this processor was built over, the tables
+   * it keeps by space, by client, and by session, the disposed flag, the
+   * render ceiling a mount inherits, and the per-space context step, which a
+   * test drives directly.
    */
   get accessForTestingOnly(): {
     runtime: Runtime;
-    cc: PiecesController;
+    readonly cc: PiecesController;
     readonly spaces: Map<DID, PiecesController>;
-    identity: Identity;
     subscriptions: Map<string, Cancel>;
     operationSubscriptions: Map<
       string,
@@ -808,14 +808,11 @@ export class RuntimeProcessor {
       string,
       { token: string; prepared: PreparedPieceSourceChange }
     >;
-    telemetry: RuntimeTelemetry;
     isDisposed: boolean;
     vdomMounts: Map<
       string,
       { reconciler: WorkerReconciler; cancel: Cancel; client: WorkerClient }
     >;
-    vdomBatchIdCounter: number;
-    renderDeclassificationPolicy: RenderDeclassificationPolicy;
     renderConfidentialityCeiling: RenderConfidentialityCeiling | undefined;
     getSpaceCtx(space: DID): PiecesController;
   } {
@@ -828,19 +825,8 @@ export class RuntimeProcessor {
       set runtime(value) {
         outerThis.#runtime = value;
       },
-      get cc() {
-        return outerThis.#cc;
-      },
-      set cc(value) {
-        outerThis.#cc = value;
-      },
+      cc: this.#cc,
       spaces: this.#spaces,
-      get identity() {
-        return outerThis.#identity;
-      },
-      set identity(value) {
-        outerThis.#identity = value;
-      },
       get subscriptions() {
         return outerThis.#subscriptions;
       },
@@ -865,12 +851,6 @@ export class RuntimeProcessor {
       set pieceSourceConfirmations(value) {
         outerThis.#pieceSourceConfirmations = value;
       },
-      get telemetry() {
-        return outerThis.#telemetry;
-      },
-      set telemetry(value) {
-        outerThis.#telemetry = value;
-      },
       get isDisposed() {
         return outerThis.#isDisposed;
       },
@@ -882,18 +862,6 @@ export class RuntimeProcessor {
       },
       set vdomMounts(value) {
         outerThis.#vdomMounts = value;
-      },
-      get vdomBatchIdCounter() {
-        return outerThis.#vdomBatchIdCounter;
-      },
-      set vdomBatchIdCounter(value) {
-        outerThis.#vdomBatchIdCounter = value;
-      },
-      get renderDeclassificationPolicy() {
-        return outerThis.#renderDeclassificationPolicy;
-      },
-      set renderDeclassificationPolicy(value) {
-        outerThis.#renderDeclassificationPolicy = value;
       },
       get renderConfidentialityCeiling() {
         return outerThis.#renderConfidentialityCeiling;
@@ -1553,10 +1521,6 @@ export class RuntimeProcessor {
     }
     const cellKey = this.#operationSessionKey(cell);
     const sessionKey = operationSessionId;
-    // A few unit harnesses construct the processor from its prototype. Keep
-    // this lazy initialization in addition to the class field so those
-    // read-only protocol harnesses exercise the same session behavior.
-    this.#operationSessions ??= new Map();
     const existing = sessionKey === undefined
       ? undefined
       : this.#operationSessions.get(sessionKey);
@@ -1757,7 +1721,7 @@ export class RuntimeProcessor {
     subscription.cancelled = true;
     subscription.cancel?.();
     if (subscription.sessionKey !== undefined) {
-      const session = this.#operationSessions?.get(subscription.sessionKey);
+      const session = this.#operationSessions.get(subscription.sessionKey);
       session?.subscriptions.delete(request.subscriptionId);
       if (session?.subscriptions.size === 0) {
         this.#operationSessions.delete(subscription.sessionKey);
@@ -1770,7 +1734,7 @@ export class RuntimeProcessor {
     request: OperationSessionCloseRequest,
     client: WorkerClient = ownerClient,
   ): BooleanResponse {
-    const session = this.#operationSessions?.get(request.operationSessionId);
+    const session = this.#operationSessions.get(request.operationSessionId);
     if (session === undefined || session.clientId !== client.id) {
       return { value: false };
     }

--- a/packages/runtime-client/test/backends/build-processor.ts
+++ b/packages/runtime-client/test/backends/build-processor.ts
@@ -1,0 +1,45 @@
+/**
+ * A `RuntimeProcessor` built over stand-ins, for a test that drives one
+ * handler at a time. It goes through the constructor the class keeps to
+ * itself, so that what a test gets is a real instance, and what a test does
+ * not supply is inert: an empty object where a handler never touches the
+ * collaborator, a fresh telemetry hub, and a signer minted for these tests.
+ */
+
+import { Identity } from "@commonfabric/identity";
+import type { MemorySpace } from "@commonfabric/memory/interface";
+import { PiecesController } from "@commonfabric/piece/ops";
+import { Runtime, RuntimeTelemetry } from "@commonfabric/runner";
+import { RuntimeProcessor } from "@/backends/runtime-processor.ts";
+
+/** The signer a processor acts as when a test supplies no identity. */
+export const standInSigner = await Identity.fromPassphrase(
+  "runtime-processor-stand-in",
+);
+
+/**
+ * Builds a processor over `parts`. Each part is declared as what the class
+ * holds where it is handed over; `cc` is the piece context of `space`, the
+ * home space, which is where a handler naming that space finds it.
+ */
+export function buildProcessor(parts: {
+  runtime?: unknown;
+  cc?: unknown;
+  space?: MemorySpace;
+  identity?: unknown;
+  telemetry?: RuntimeTelemetry;
+} = {}): RuntimeProcessor {
+  const space = parts.space ?? standInSigner.did();
+  return RuntimeProcessor.accessForTestingOnly.construct(
+    (parts.runtime ?? {}) as Runtime,
+    (parts.cc ?? {}) as PiecesController,
+    space,
+    (parts.identity ?? standInSigner) as Identity,
+    parts.telemetry ?? new RuntimeTelemetry(),
+    {
+      identity: standInSigner.did(),
+      apiUrl: "http://localhost/",
+      spaceDid: space,
+    },
+  );
+}

--- a/packages/runtime-client/test/backends/build-processor.ts
+++ b/packages/runtime-client/test/backends/build-processor.ts
@@ -13,7 +13,7 @@ import { Runtime, RuntimeTelemetry } from "@commonfabric/runner";
 import { RuntimeProcessor } from "@/backends/runtime-processor.ts";
 
 /** The signer a processor acts as when a test supplies no identity. */
-export const standInSigner = await Identity.fromPassphrase(
+const standInSigner = await Identity.fromPassphrase(
   "runtime-processor-stand-in",
 );
 
@@ -21,6 +21,11 @@ export const standInSigner = await Identity.fromPassphrase(
  * Builds a processor over `parts`. Each part is declared as what the class
  * holds where it is handed over; `cc` is the piece context of `space`, the
  * home space, which is where a handler naming that space finds it.
+ *
+ * The parts are `unknown` rather than `Partial<Runtime>` and the like: a
+ * stand-in here fakes one or two members with signatures of its own, which
+ * a `Partial` of the real type would refuse. The cost is that a stand-in
+ * drifting from the shape a handler reads is found by the handler, not here.
  */
 export function buildProcessor(parts: {
   runtime?: unknown;
@@ -30,14 +35,15 @@ export function buildProcessor(parts: {
   telemetry?: RuntimeTelemetry;
 } = {}): RuntimeProcessor {
   const space = parts.space ?? standInSigner.did();
+  const identity = (parts.identity ?? standInSigner) as Identity;
   return RuntimeProcessor.accessForTestingOnly.construct(
     (parts.runtime ?? {}) as Runtime,
     (parts.cc ?? {}) as PiecesController,
     space,
-    (parts.identity ?? standInSigner) as Identity,
+    identity,
     parts.telemetry ?? new RuntimeTelemetry(),
     {
-      identity: standInSigner.did(),
+      identity: identity.did(),
       apiUrl: "http://localhost/",
       spaceDid: space,
     },

--- a/packages/runtime-client/test/backends/cell-set-echo-race.test.ts
+++ b/packages/runtime-client/test/backends/cell-set-echo-race.test.ts
@@ -26,10 +26,11 @@ import * as MemoryV2Client from "@commonfabric/memory/v2/client";
 import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 import { Runtime } from "@commonfabric/runner";
 import * as V2Storage from "@commonfabric/runner/storage/v2";
-import { RuntimeProcessor } from "@/backends/runtime-processor.ts";
+import type { RuntimeProcessor } from "@/backends/runtime-processor.ts";
 import { createCellRef } from "@/backends/utils.ts";
 import { $conn, CellHandle, type RuntimeClient } from "@/mod.ts";
 import { RuntimeConnection } from "@/client/connection.ts";
+import { buildProcessor } from "./build-processor.ts";
 import { EventEmitter } from "@/client/emitter.ts";
 import type {
   RuntimeTransport,
@@ -149,9 +150,7 @@ class InProcessWorkerTransport extends EventEmitter<RuntimeTransportEvents>
       return;
     }
     void Promise.resolve()
-      .then(() =>
-        RuntimeProcessor.prototype.handleRequest.call(this.#processor, data)
-      )
+      .then(() => this.#processor.handleRequest(data))
       .then(
         (response) =>
           this.outbox.push(
@@ -208,13 +207,8 @@ describe("CellSet / CellUpdate echo race over IPC", () => {
       await seed.commit();
       await runtime.idle();
 
-      // A real RuntimeProcessor over that runtime (fields the cell handlers
-      // touch; the private ctor is bypassed the same way the processor's own
-      // test suite does).
-      const processor = Object.assign(
-        Object.create(RuntimeProcessor.prototype) as RuntimeProcessor,
-        { runtime, subscriptions: new Map() },
-      );
+      // A real `RuntimeProcessor` over that runtime.
+      const processor = buildProcessor({ runtime });
       const transport = new InProcessWorkerTransport(processor);
       (globalThis as { postMessage?: unknown }).postMessage = (m: unknown) =>
         transport.outbox.push(

--- a/packages/runtime-client/test/backends/cell-set-echo-race.test.ts
+++ b/packages/runtime-client/test/backends/cell-set-echo-race.test.ts
@@ -30,7 +30,6 @@ import type { RuntimeProcessor } from "@/backends/runtime-processor.ts";
 import { createCellRef } from "@/backends/utils.ts";
 import { $conn, CellHandle, type RuntimeClient } from "@/mod.ts";
 import { RuntimeConnection } from "@/client/connection.ts";
-import { buildProcessor } from "./build-processor.ts";
 import { EventEmitter } from "@/client/emitter.ts";
 import type {
   RuntimeTransport,
@@ -47,6 +46,7 @@ import {
   fabricFromRealmValue,
   realmFromFabricValue,
 } from "@commonfabric/data-model/codecs";
+import { buildProcessor } from "./build-processor.ts";
 
 const signer = await Identity.fromPassphrase("cell-set-echo-race");
 const space = signer.did();

--- a/packages/runtime-client/test/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/test/backends/runtime-processor.test.ts
@@ -83,6 +83,7 @@ import {
   mapCellRefsToSigilLinks,
 } from "@/backends/utils.ts";
 import type { WorkerClient } from "@/backends/worker-client.ts";
+import { buildProcessor } from "./build-processor.ts";
 
 const cfcSigner = await Identity.fromPassphrase(
   "runtime-processor-cfc-label-tests",
@@ -144,13 +145,6 @@ const createRuntime = () => {
   });
   return { runtime, storageManager };
 };
-
-// Handlers resolve their per-space piece context via getSpaceCtx
-// (federation PR2). The duck-typed processors below are single-space:
-// their context is always the home pieces controller.
-function homeSpaceCtx(this: { cc?: unknown }) {
-  return this.cc;
-}
 
 // A valid `fid1:` piece id from a readable seed (handlers parse pieceId via
 // `entityIdFrom`, which requires a real tagged-hash string).
@@ -370,8 +364,9 @@ describe("runtime-processor", () => {
         getAsNormalizedFullLink: () => ({ id: "of:fid1:sourced" }),
         asSchema: () => ({ get: () => ({}) }),
       };
-      const processor = {
-        getSpaceCtx: (requested: string) => ({ getSpace: () => requested }),
+      const processor = buildProcessor({
+        cc: { getSpace: () => space },
+        space,
         runtime: {
           // Stands in for readPieceSourceState's reads: the handler's own job is
           // to address the right cell and hand back what the reader produced.
@@ -387,14 +382,13 @@ describe("runtime-processor", () => {
           },
           hostForSpace: () => new URL("https://toolshed.test"),
         },
-      };
+      });
 
-      const result = await (RuntimeProcessor.prototype as any)
-        .handlePieceGetSource.call(processor, {
-          type: RequestType.PieceGetSource,
-          space,
-          pieceId: fid("sourced-piece"),
-        });
+      const result = await processor.handlePieceGetSource({
+        type: RequestType.PieceGetSource,
+        space,
+        pieceId: fid("sourced-piece"),
+      });
 
       expect(synced).toEqual(["cell"]);
       // The handler addresses the cell by the entity id `entityIdFrom` builds
@@ -414,22 +408,19 @@ describe("runtime-processor", () => {
 
     it("rejects an unknown compatibility confirmation before changing a piece", async () => {
       const space = "did:key:z6Mk-runtime-processor-source" as const;
-      const processor = {
-        getSpaceCtx: () => ({ getSpace: () => space }),
-        pieceSourceConfirmations: new Map(),
-      };
+      const processor = buildProcessor({
+        cc: { getSpace: () => space },
+        space: space,
+      });
 
       await expect(
-        (RuntimeProcessor.prototype as any).handlePieceUpdateSource.call(
-          processor,
-          {
-            type: RequestType.PieceUpdateSource,
-            space,
-            pieceId: fid("sourced-piece"),
-            action: { kind: "restore", revisionId: "older" },
-            confirmationToken: "unknown-confirmation",
-          },
-        ),
+        processor.handlePieceUpdateSource({
+          type: RequestType.PieceUpdateSource,
+          space,
+          pieceId: fid("sourced-piece"),
+          action: { kind: "restore", revisionId: "older" },
+          confirmationToken: "unknown-confirmation",
+        }),
       ).rejects.toThrow(
         "the piece source compatibility confirmation is no longer valid",
       );
@@ -438,16 +429,14 @@ describe("runtime-processor", () => {
     it("rejects empty and non-string compatibility confirmations", async () => {
       for (const confirmationToken of ["", 42]) {
         await expect(
-          (RuntimeProcessor.prototype as any).handlePieceUpdateSource.call(
-            { pieceSourceConfirmations: new Map() },
-            {
+          buildProcessor()
+            .handlePieceUpdateSource({
               type: RequestType.PieceUpdateSource,
               space: "did:key:z6Mk-runtime-processor-source",
               pieceId: fid("sourced-piece"),
               action: { kind: "restore", revisionId: "older" },
-              confirmationToken,
-            },
-          ),
+              confirmationToken: confirmationToken as never,
+            }),
         ).rejects.toThrow("confirmationToken must be a non-empty string");
       }
     });
@@ -463,9 +452,9 @@ describe("runtime-processor", () => {
         getAsNormalizedFullLink: () => ({ id: `of:${pieceId}`, path: [] }),
         asSchema: () => ({ get: () => ({}) }),
       };
-      const processor = {
-        getSpaceCtx: () => ({ getSpace: () => space }),
-        pieceSourceConfirmations: new Map(),
+      const processor = buildProcessor({
+        cc: { getSpace: () => space },
+        space: space,
         runtime: {
           getCellFromEntityId: () => cell,
           patternManager: {
@@ -473,7 +462,7 @@ describe("runtime-processor", () => {
           },
           hostForSpace: () => new URL("https://toolshed.test"),
         },
-      };
+      });
       const action = { kind: "restore", revisionId: "older" } as const;
       const prepared = {
         action,
@@ -508,40 +497,37 @@ describe("runtime-processor", () => {
       }) as typeof changeSource;
 
       try {
-        const first = await (RuntimeProcessor.prototype as any)
-          .handlePieceUpdateSource.call(processor, {
-            type: RequestType.PieceUpdateSource,
-            space,
-            pieceId,
-            action,
-          });
+        const first = await processor.handlePieceUpdateSource({
+          type: RequestType.PieceUpdateSource,
+          space,
+          pieceId,
+          action,
+        });
         expect(first.compatibilityWarning).toBe("result schema narrowed");
         expect(first.confirmationToken).toBeDefined();
-        expect(processor.pieceSourceConfirmations.size).toBe(1);
+        expect(processor.accessForTestingOnly.pieceSourceConfirmations.size)
+          .toBe(1);
 
-        const second = await (RuntimeProcessor.prototype as any)
-          .handlePieceUpdateSource.call(processor, {
+        const second = await processor.handlePieceUpdateSource({
+          type: RequestType.PieceUpdateSource,
+          space,
+          pieceId,
+          action,
+          confirmationToken: first.confirmationToken,
+        });
+        expect(receivedConfirmation).toBe(prepared);
+        expect(second.compatibilityWarning).toBeUndefined();
+        expect(processor.accessForTestingOnly.pieceSourceConfirmations.size)
+          .toBe(0);
+
+        await expect(
+          processor.handlePieceUpdateSource({
             type: RequestType.PieceUpdateSource,
             space,
             pieceId,
             action,
             confirmationToken: first.confirmationToken,
-          });
-        expect(receivedConfirmation).toBe(prepared);
-        expect(second.compatibilityWarning).toBeUndefined();
-        expect(processor.pieceSourceConfirmations.size).toBe(0);
-
-        await expect(
-          (RuntimeProcessor.prototype as any).handlePieceUpdateSource.call(
-            processor,
-            {
-              type: RequestType.PieceUpdateSource,
-              space,
-              pieceId,
-              action,
-              confirmationToken: first.confirmationToken,
-            },
-          ),
+          }),
         ).rejects.toThrow(
           "the piece source compatibility confirmation is no longer valid",
         );
@@ -553,9 +539,9 @@ describe("runtime-processor", () => {
     it("does not hide a source-read failure for an incompatible change", async () => {
       const space = "did:key:z6Mk-runtime-processor-source" as const;
       const pieceId = fid("sourced-piece");
-      const processor = {
-        getSpaceCtx: () => ({ getSpace: () => space }),
-        pieceSourceConfirmations: new Map(),
+      const processor = buildProcessor({
+        cc: { getSpace: () => space },
+        space: space,
         runtime: {
           getCellFromEntityId: () => ({
             space,
@@ -566,7 +552,7 @@ describe("runtime-processor", () => {
             asSchema: () => ({ get: () => ({}) }),
           }),
         },
-      };
+      });
       const changeSource = PieceController.prototype.changeSource;
       PieceController.prototype.changeSource = (() =>
         Promise.resolve({
@@ -577,15 +563,12 @@ describe("runtime-processor", () => {
 
       let reason: unknown;
       try {
-        await (RuntimeProcessor.prototype as any).handlePieceUpdateSource.call(
-          processor,
-          {
-            type: RequestType.PieceUpdateSource,
-            space,
-            pieceId,
-            action: { kind: "restore", revisionId: "older" },
-          },
-        );
+        await processor.handlePieceUpdateSource({
+          type: RequestType.PieceUpdateSource,
+          space,
+          pieceId,
+          action: { kind: "restore", revisionId: "older" },
+        });
       } catch (error) {
         reason = error;
       } finally {
@@ -607,22 +590,21 @@ describe("runtime-processor", () => {
       cell.sync = () => Promise.reject(new Error("refresh unavailable"));
       const getCellFromEntityId = runtime.getCellFromEntityId.bind(runtime);
       runtime.getCellFromEntityId = (() => cell) as typeof getCellFromEntityId;
-      const processor = {
-        getSpaceCtx: () => ({ getSpace: () => space }),
-        pieceSourceConfirmations: new Map(),
+      const processor = buildProcessor({
+        cc: { getSpace: () => space },
+        space: space,
         runtime,
-      };
+      });
       const changeSource = PieceController.prototype.changeSource;
       PieceController.prototype.changeSource =
         (() => Promise.resolve({ status: "applied" })) as typeof changeSource;
       try {
-        const result = await (RuntimeProcessor.prototype as any)
-          .handlePieceUpdateSource.call(processor, {
-            type: RequestType.PieceUpdateSource,
-            space,
-            pieceId: fid("sourced-piece"),
-            action: { kind: "detach" },
-          });
+        const result = await processor.handlePieceUpdateSource({
+          type: RequestType.PieceUpdateSource,
+          space,
+          pieceId: fid("sourced-piece"),
+          action: { kind: "detach" },
+        });
 
         expect(result.source.history).toEqual([]);
         expect(result.executionWarning).toContain(
@@ -646,19 +628,15 @@ describe("runtime-processor", () => {
       // message exists to explain the refusal, so it names the value.
 
       const space = "did:key:z6Mk-runtime-processor-create" as const;
-      const processor = { getSpaceCtx: () => ({}) };
+      const processor = buildProcessor({ cc: {}, space });
       const refusalFor = async (argument: unknown) => {
         try {
-          // deno-lint-ignore no-explicit-any
-          await (RuntimeProcessor.prototype as any).handlePieceCreate.call(
-            processor,
-            {
-              type: RequestType.PieceCreate,
-              space,
-              source: { program: { main: "/main.tsx", files: [] } },
-              argument,
-            },
-          );
+          await processor.handlePieceCreate({
+            type: RequestType.PieceCreate,
+            space,
+            source: { program: { main: "/main.tsx", files: [] } },
+            argument: argument as never,
+          });
         } catch (error) {
           return (error as Error).message;
         }
@@ -681,11 +659,10 @@ describe("runtime-processor", () => {
       // entire input is not one value, whatever that value is.
 
       const space = "did:key:z6Mk-runtime-processor-create" as const;
-      const processor = { getSpaceCtx: () => ({}) };
+      const processor = buildProcessor({ cc: {}, space });
 
       await expect(
-        // deno-lint-ignore no-explicit-any
-        (RuntimeProcessor.prototype as any).handlePieceCreate.call(processor, {
+        processor.handlePieceCreate({
           type: RequestType.PieceCreate,
           space,
           source: { program: { main: "/main.tsx", files: [] } },
@@ -696,8 +673,7 @@ describe("runtime-processor", () => {
       // The other branch of the fabric class hierarchy, which reaches the
       // guard by the same route.
       await expect(
-        // deno-lint-ignore no-explicit-any
-        (RuntimeProcessor.prototype as any).handlePieceCreate.call(processor, {
+        processor.handlePieceCreate({
           type: RequestType.PieceCreate,
           space,
           source: { program: { main: "/main.tsx", files: [] } },
@@ -717,19 +693,19 @@ describe("runtime-processor", () => {
 
       const space = "did:key:z6Mk-runtime-processor-create" as const;
       const created: unknown[] = [];
-      const processor = {
-        getSpaceCtx: () => ({
+      const processor = buildProcessor({
+        cc: {
           create: (_program: unknown, options: { input?: unknown }) => {
             created.push(options.input);
             throw new Error("stop after the guard");
           },
-        }),
-      };
+        },
+        space,
+      });
       const bytes = new FabricBytes(new Uint8Array([1, 2, 3]));
 
       await expect(
-        // deno-lint-ignore no-explicit-any
-        (RuntimeProcessor.prototype as any).handlePieceCreate.call(processor, {
+        processor.handlePieceCreate({
           type: RequestType.PieceCreate,
           space,
           source: { program: { main: "/main.tsx", files: [] } },
@@ -752,16 +728,16 @@ describe("runtime-processor", () => {
           get: () => ({ [owner]: "OWNER", "*": "WRITE" }),
         }),
       };
-      const processor = {
-        getSpaceCtx: () => ({ getSpace: () => space }),
+      const processor = buildProcessor({
+        cc: { getSpace: () => space },
+        space: space,
         runtime,
-      };
+      });
 
-      const response = await (RuntimeProcessor.prototype as any)
-        .handleSpaceGetAcl.call(processor, {
-          type: RequestType.SpaceGetAcl,
-          space,
-        });
+      const response = await processor.handleSpaceGetAcl({
+        type: RequestType.SpaceGetAcl,
+        space,
+      });
 
       expect(response.access).toEqual({
         space,
@@ -775,8 +751,9 @@ describe("runtime-processor", () => {
       const space = "did:key:z6Mk-runtime-processor-acl" as const;
       const owner = "did:key:z6Mk-runtime-processor-owner" as const;
       const writer = "did:key:z6Mk-runtime-processor-writer" as const;
-      const processor = {
-        getSpaceCtx: () => ({ getSpace: () => space }),
+      const processor = buildProcessor({
+        cc: { getSpace: () => space },
+        space: space,
         runtime: {
           userIdentityDID: writer,
           storageManager: { synced: () => Promise.resolve() },
@@ -785,13 +762,12 @@ describe("runtime-processor", () => {
             get: () => ({ [owner]: "OWNER", "*": "WRITE" }),
           }),
         },
-      };
+      });
 
-      const response = await (RuntimeProcessor.prototype as any)
-        .handleSpaceGetAcl.call(processor, {
-          type: RequestType.SpaceGetAcl,
-          space,
-        });
+      const response = await processor.handleSpaceGetAcl({
+        type: RequestType.SpaceGetAcl,
+        space,
+      });
 
       expect(response.access.canEdit).toBe(false);
     });
@@ -816,25 +792,18 @@ describe("runtime-processor", () => {
         await runtime.idle();
         await storageManager.synced();
 
-        const processor = {
+        const processor = buildProcessor({
           runtime,
-          getSpaceCtx: () => ({ getSpace: () => space }),
-          handleSpaceGetAcl: RuntimeProcessor.prototype.handleSpaceGetAcl,
-          handleSpaceSetAclEntry:
-            RuntimeProcessor.prototype.handleSpaceSetAclEntry,
-          handleSpaceRemoveAclEntry:
-            RuntimeProcessor.prototype.handleSpaceRemoveAclEntry,
-        } as unknown as RuntimeProcessor;
+          cc: { getSpace: () => space },
+          space,
+        });
 
-        const added = await RuntimeProcessor.prototype.handleRequest.call(
-          processor,
-          {
-            type: RequestType.SpaceSetAclEntry,
-            space,
-            user: writer,
-            capability: "WRITE",
-          },
-        );
+        const added = await processor.handleRequest({
+          type: RequestType.SpaceSetAclEntry,
+          space,
+          user: writer,
+          capability: "WRITE",
+        });
         expect(added).toEqual({
           access: {
             space,
@@ -844,20 +813,17 @@ describe("runtime-processor", () => {
           },
         });
 
-        const read = await RuntimeProcessor.prototype.handleRequest.call(
-          processor,
-          { type: RequestType.SpaceGetAcl, space },
-        );
+        const read = await processor.handleRequest({
+          type: RequestType.SpaceGetAcl,
+          space,
+        });
         expect(read).toEqual(added);
 
-        const removed = await RuntimeProcessor.prototype.handleRequest.call(
-          processor,
-          {
-            type: RequestType.SpaceRemoveAclEntry,
-            space,
-            user: writer,
-          },
-        );
+        const removed = await processor.handleRequest({
+          type: RequestType.SpaceRemoveAclEntry,
+          space,
+          user: writer,
+        });
         expect(removed).toEqual({
           access: {
             space,
@@ -873,43 +839,39 @@ describe("runtime-processor", () => {
     });
 
     it("rejects malformed ACL mutations before opening the space", async () => {
-      const processor = {
-        getSpaceCtx: () => {
-          throw new Error("space must not be opened");
-        },
-      };
+      // A context that refuses every touch: the handler validates the entry
+      // before it opens the space.
+      const processor = buildProcessor({
+        cc: new Proxy({}, {
+          get: () => {
+            throw new Error("space must not be opened");
+          },
+        }),
+        space: "did:key:z6Mk-runtime-processor-acl",
+      });
 
       await expect(
-        (RuntimeProcessor.prototype as any).handleSpaceSetAclEntry.call(
-          processor,
-          {
-            type: RequestType.SpaceSetAclEntry,
-            space: "did:key:z6Mk-runtime-processor-acl",
-            user: "not-a-did",
-            capability: "WRITE",
-          },
-        ),
+        processor.handleSpaceSetAclEntry({
+          type: RequestType.SpaceSetAclEntry,
+          space: "did:key:z6Mk-runtime-processor-acl",
+          user: "not-a-did",
+          capability: "WRITE",
+        }),
       ).rejects.toThrow("user must be `*` or a valid DID");
       await expect(
-        (RuntimeProcessor.prototype as any).handleSpaceSetAclEntry.call(
-          processor,
-          {
-            type: RequestType.SpaceSetAclEntry,
-            space: "did:key:z6Mk-runtime-processor-acl",
-            user: "did:key:z6Mk-runtime-processor-reader",
-            capability: "ADMIN",
-          },
-        ),
+        processor.handleSpaceSetAclEntry({
+          type: RequestType.SpaceSetAclEntry,
+          space: "did:key:z6Mk-runtime-processor-acl",
+          user: "did:key:z6Mk-runtime-processor-reader",
+          capability: "ADMIN" as never,
+        }),
       ).rejects.toThrow("capability must be `READ`, `WRITE`, or `OWNER`");
       await expect(
-        (RuntimeProcessor.prototype as any).handleSpaceRemoveAclEntry.call(
-          processor,
-          {
-            type: RequestType.SpaceRemoveAclEntry,
-            space: "did:key:z6Mk-runtime-processor-acl",
-            user: "not-a-did",
-          },
-        ),
+        processor.handleSpaceRemoveAclEntry({
+          type: RequestType.SpaceRemoveAclEntry,
+          space: "did:key:z6Mk-runtime-processor-acl",
+          user: "not-a-did",
+        }),
       ).rejects.toThrow("user must be `*` or a valid DID");
     });
   });
@@ -917,8 +879,7 @@ describe("runtime-processor", () => {
   describe("piece slug metadata", () => {
     it("reads slug metadata from the piece document root", async () => {
       const reads: unknown[] = [];
-      const processor = {
-        getSpaceCtx: homeSpaceCtx,
+      const processor = buildProcessor({
         runtime: {
           getCellFromEntityId: () => ({
             sync: () => Promise.resolve(),
@@ -936,14 +897,14 @@ describe("runtime-processor", () => {
         cc: {
           getSpace: () => "did:key:z6Mk-runtime-processor-slug",
         },
-      };
+        space: "did:key:z6Mk-runtime-processor-slug",
+      });
 
-      const result = await (RuntimeProcessor.prototype as any)
-        .handlePieceGetSlug
-        .call(processor, {
-          type: RequestType.PieceGetSlug,
-          pieceId: fid("slugged-piece"),
-        });
+      const result = await processor.handlePieceGetSlug({
+        type: RequestType.PieceGetSlug,
+        space: "did:key:z6Mk-runtime-processor-slug",
+        pieceId: fid("slugged-piece"),
+      });
 
       expect(result).toEqual({ slug: "demo" });
       expect(reads).toEqual([{
@@ -955,8 +916,7 @@ describe("runtime-processor", () => {
     });
 
     it("ignores non-string slug metadata", async () => {
-      const processor = {
-        getSpaceCtx: homeSpaceCtx,
+      const processor = buildProcessor({
         runtime: {
           getCellFromEntityId: () => ({
             sync: () => Promise.resolve(),
@@ -967,14 +927,14 @@ describe("runtime-processor", () => {
         cc: {
           getSpace: () => "did:key:z6Mk-runtime-processor-slug",
         },
-      };
+        space: "did:key:z6Mk-runtime-processor-slug",
+      });
 
-      const result = await (RuntimeProcessor.prototype as any)
-        .handlePieceGetSlug
-        .call(processor, {
-          type: RequestType.PieceGetSlug,
-          pieceId: fid("slugged-piece"),
-        });
+      const result = await processor.handlePieceGetSlug({
+        type: RequestType.PieceGetSlug,
+        space: "did:key:z6Mk-runtime-processor-slug",
+        pieceId: fid("slugged-piece"),
+      });
 
       expect(result).toEqual({ slug: undefined });
     });
@@ -986,8 +946,7 @@ describe("runtime-processor", () => {
       // is "of:fid1" and silently addresses the nonexistent of:of:fid1:H.
 
       const received: string[] = [];
-      const processor = {
-        getSpaceCtx: homeSpaceCtx,
+      const processor = buildProcessor({
         runtime: {
           getCellFromEntityId: (_space: unknown, entityId: unknown) => {
             received.push(String(entityId));
@@ -1000,20 +959,23 @@ describe("runtime-processor", () => {
         cc: {
           getSpace: () => "did:key:z6Mk-runtime-processor-slug",
         },
-      };
+        space: "did:key:z6Mk-runtime-processor-slug",
+      });
 
       const bare = fid("schemed-piece");
       for (const pieceId of [bare, `of:${bare}`]) {
-        await (RuntimeProcessor.prototype as any).handlePieceGetSlug
-          .call(processor, { type: RequestType.PieceGetSlug, pieceId });
+        await processor.handlePieceGetSlug({
+          type: RequestType.PieceGetSlug,
+          space: "did:key:z6Mk-runtime-processor-slug",
+          pieceId,
+        });
       }
 
       expect(received).toEqual([bare, bare]);
     });
 
     it("throws for a `computed:` piece id, naming the address", async () => {
-      const processor = {
-        getSpaceCtx: homeSpaceCtx,
+      const processor = buildProcessor({
         runtime: {
           getCellFromEntityId: () => {
             throw new Error("computed piece id reached the runtime lookup");
@@ -1022,12 +984,14 @@ describe("runtime-processor", () => {
         cc: {
           getSpace: () => "did:key:z6Mk-runtime-processor-slug",
         },
-      };
+        space: "did:key:z6Mk-runtime-processor-slug",
+      });
 
       const computed = `computed:${fid("not-a-piece")}`;
       await expect(
-        (RuntimeProcessor.prototype as any).handlePieceGetSlug.call(processor, {
+        processor.handlePieceGetSlug({
           type: RequestType.PieceGetSlug,
+          space: "did:key:z6Mk-runtime-processor-slug",
           pieceId: computed,
         }),
       ).rejects.toThrow(`Kinded entity id \`${computed}\``);
@@ -1098,32 +1062,30 @@ describe("runtime-processor", () => {
       const resultCell = mockCell(resultRef);
       const managerCalls: unknown[][] = [];
       const lookedUp: string[] = [];
-      const processor = {
-        getSpaceCtx: () => ({
+      const processor = buildProcessor({
+        cc: {
           getSpace: () => space,
           getPieceCell: (...args: unknown[]) => {
             managerCalls.push(args);
             return Promise.resolve(resultCell);
           },
-        }),
+        },
         runtime: {
           getCellFromEntityId: (_space: unknown, entityId: unknown) => {
             lookedUp.push(String(entityId));
             return requestedCell;
           },
         },
-      };
+        space,
+      });
 
       for (const pieceId of [bare, `of:${bare}`]) {
-        await (RuntimeProcessor.prototype as any).handlePieceGet.call(
-          processor,
-          {
-            type: RequestType.PieceGet,
-            pieceId,
-            runIt: true,
-            space,
-          },
-        );
+        await processor.handlePieceGet({
+          type: RequestType.PieceGet,
+          pieceId,
+          runIt: true,
+          space,
+        });
       }
 
       expect(lookedUp).toEqual([bare, bare]);
@@ -1163,21 +1125,21 @@ describe("runtime-processor", () => {
           );
         },
       };
-      const processor = {
-        getSpaceCtx: homeSpaceCtx,
+      const processor = buildProcessor({
         runtime: {
           getCellFromEntityId: () => slugCell,
           getCellFromLink: () => targetCell,
         },
         cc: pieces,
-      };
+        space,
+      });
 
-      const result = await (RuntimeProcessor.prototype as any).handlePieceGet
-        .call(processor, {
-          type: RequestType.PieceGet,
-          pieceId: fid("slug-doc"),
-          runIt: true,
-        });
+      const result = await processor.handlePieceGet({
+        type: RequestType.PieceGet,
+        pieceId: fid("slug-doc"),
+        space,
+        runIt: true,
+      });
 
       expect(targetSynced).toBe(true);
       expect(result.piece.cell).toMatchObject(targetRef);
@@ -1236,21 +1198,21 @@ describe("runtime-processor", () => {
           );
         },
       };
-      const processor = {
-        getSpaceCtx: homeSpaceCtx,
+      const processor = buildProcessor({
         runtime: {
           getCellFromEntityId: () => slugCell,
           getCellFromLink: () => targetCell,
         },
         cc: pieces,
-      };
+        space,
+      });
 
-      const result = await (RuntimeProcessor.prototype as any).handlePieceGet
-        .call(processor, {
-          type: RequestType.PieceGet,
-          pieceId: fid("slug-doc"),
-          runIt: true,
-        });
+      const result = await processor.handlePieceGet({
+        type: RequestType.PieceGet,
+        pieceId: fid("slug-doc"),
+        space,
+        runIt: true,
+      });
 
       expect(targetSynced).toBe(true);
       expect(schemaPulled).toBe(true);
@@ -1292,21 +1254,21 @@ describe("runtime-processor", () => {
           return Promise.resolve(resultCell);
         },
       };
-      const processor = {
-        getSpaceCtx: homeSpaceCtx,
+      const processor = buildProcessor({
         runtime: {
           getCellFromEntityId: () => slugCell,
           getCellFromLink: () => pieceCell,
         },
         cc: pieces,
-      };
+        space,
+      });
 
-      const result = await (RuntimeProcessor.prototype as any).handlePieceGet
-        .call(processor, {
-          type: RequestType.PieceGet,
-          pieceId: fid("slug-doc"),
-          runIt: true,
-        });
+      const result = await processor.handlePieceGet({
+        type: RequestType.PieceGet,
+        pieceId: fid("slug-doc"),
+        space,
+        runIt: true,
+      });
 
       expect(calls).toEqual([[pieceCell, true]]);
       expect(result.piece.cell).toMatchObject(resultRef);
@@ -1339,8 +1301,7 @@ describe("runtime-processor", () => {
         scopes.push(scope);
         throw new Error(REFUSED);
       };
-      const processor = {
-        getSpaceCtx: homeSpaceCtx,
+      const processor = buildProcessor({
         runtime: {
           getCellFromEntityId: (
             _space: unknown,
@@ -1363,8 +1324,8 @@ describe("runtime-processor", () => {
           startPiece: (_id: string, scope?: CellScope) => refuse(scope),
           stopPiece: (_id: string, scope?: CellScope) => refuse(scope),
         },
-        pieceSourceConfirmations: new Map(),
-      };
+        space,
+      });
       return { processor, scopes };
     }
 
@@ -1468,18 +1429,16 @@ describe("runtime-processor", () => {
       async function keyFor(scope?: CellScope): Promise<string> {
         const { processor } = makeProcessor();
         const confirmations = new RecordingConfirmations();
-        processor.pieceSourceConfirmations = confirmations;
+        processor.accessForTestingOnly.pieceSourceConfirmations =
+          confirmations as never;
         await expect(
-          (RuntimeProcessor.prototype as any).handlePieceUpdateSource.call(
-            processor,
-            {
-              type: RequestType.PieceUpdateSource,
-              pieceId,
-              space,
-              action: { kind: "detach" },
-              ...(scope === undefined ? {} : { scope }),
-            },
-          ),
+          processor.handlePieceUpdateSource({
+            type: RequestType.PieceUpdateSource,
+            pieceId,
+            space,
+            action: { kind: "detach" },
+            ...(scope === undefined ? {} : { scope }),
+          }),
         ).rejects.toThrow(REFUSED);
         expect(confirmations.keysAddressed.length).toBe(1);
         return confirmations.keysAddressed[0];
@@ -1993,7 +1952,7 @@ describe("runtime-processor", () => {
         busyTime: 123,
       };
       let receivedDuration: number | undefined;
-      const processor = {
+      const processor = buildProcessor({
         runtime: {
           scheduler: {
             runDiagnosis: (durationMs?: number) => {
@@ -2002,16 +1961,12 @@ describe("runtime-processor", () => {
             },
           },
         },
-      } as unknown as RuntimeProcessor;
+      });
 
-      const response = await RuntimeProcessor.prototype.detectNonIdempotent
-        .call(
-          processor,
-          {
-            type: RequestType.DetectNonIdempotent,
-            durationMs: 2500,
-          },
-        );
+      const response = await processor.detectNonIdempotent({
+        type: RequestType.DetectNonIdempotent,
+        durationMs: 2500,
+      });
 
       expect(receivedDuration).toBe(2500);
       expect(response).toEqual({ result: expected });
@@ -2089,7 +2044,7 @@ describe("runtime-processor", () => {
         valueKind: "object" as const,
         stack: "Error\n  at writeValueOrThrow",
       }];
-      const processor = {
+      const processor = buildProcessor({
         runtime: {
           scheduler: {
             setSettleStatsEnabled: (enabled: boolean) => {
@@ -2111,49 +2066,36 @@ describe("runtime-processor", () => {
             writeTraceMatchers.push(matchers);
           },
         },
-      } as unknown as RuntimeProcessor;
+      });
 
-      RuntimeProcessor.prototype.setSettleStatsEnabled.call(processor, {
+      processor.setSettleStatsEnabled({
         type: RequestType.SetSettleStatsEnabled,
         enabled: true,
       });
-      RuntimeProcessor.prototype.setActionRunTraceEnabled.call(processor, {
+      processor.setActionRunTraceEnabled({
         type: RequestType.SetActionRunTraceEnabled,
         enabled: true,
       });
-      RuntimeProcessor.prototype.setTriggerTraceEnabled.call(processor, {
+      processor.setTriggerTraceEnabled({
         type: RequestType.SetTriggerTraceEnabled,
         enabled: true,
       });
 
-      const response = RuntimeProcessor.prototype.getSettleStats.call(
-        processor,
-        {
-          type: RequestType.GetSettleStats,
-        },
-      );
-      const historyResponse = RuntimeProcessor.prototype.getSettleStatsHistory
-        .call(processor, {
-          type: RequestType.GetSettleStatsHistory,
-        });
-      const actionTraceResponse = RuntimeProcessor.prototype.getActionRunTrace
-        .call(processor, {
-          type: RequestType.GetActionRunTrace,
-        });
-      const triggerTraceResponse = RuntimeProcessor.prototype.getTriggerTrace
-        .call(
-          processor,
-          {
-            type: RequestType.GetTriggerTrace,
-          },
-        );
-      const writeTraceResponse = RuntimeProcessor.prototype.getWriteStackTrace
-        .call(
-          processor,
-          {
-            type: RequestType.GetWriteStackTrace,
-          },
-        );
+      const response = processor.getSettleStats({
+        type: RequestType.GetSettleStats,
+      });
+      const historyResponse = processor.getSettleStatsHistory({
+        type: RequestType.GetSettleStatsHistory,
+      });
+      const actionTraceResponse = processor.getActionRunTrace({
+        type: RequestType.GetActionRunTrace,
+      });
+      const triggerTraceResponse = processor.getTriggerTrace({
+        type: RequestType.GetTriggerTrace,
+      });
+      const writeTraceResponse = processor.getWriteStackTrace({
+        type: RequestType.GetWriteStackTrace,
+      });
 
       expect(settleEnabledValues).toEqual([true]);
       expect(actionRunEnabledValues).toEqual([true]);
@@ -2166,13 +2108,10 @@ describe("runtime-processor", () => {
         trace: writeTrace,
       });
 
-      RuntimeProcessor.prototype.setWriteStackTraceMatchers.call(
-        processor,
-        {
-          type: RequestType.SetWriteStackTraceMatchers,
-          matchers: [],
-        },
-      );
+      processor.setWriteStackTraceMatchers({
+        type: RequestType.SetWriteStackTraceMatchers,
+        matchers: [],
+      });
       expect(writeTraceMatchers).toEqual([[]]);
     });
   });
@@ -2202,14 +2141,14 @@ describe("runtime-processor", () => {
       // The constructor performs full runtime initialization; this focused unit
       // test calls the handler with the fields it reads directly.
       const hostForSpaceCalls: string[] = [];
-      const processor = {
+      const processor = buildProcessor({
         runtime: {
           hostForSpace: (space: string) => {
             hostForSpaceCalls.push(space);
             return new URL("http://toolshed.test/base");
           },
         },
-      } as unknown as RuntimeProcessor;
+      });
 
       // The bytes as the transport's decode delivers them: the handler owns
       // its request's payload. Kept here so the test can check what became of it.
@@ -2217,7 +2156,7 @@ describe("runtime-processor", () => {
 
       try {
         await expect(
-          RuntimeProcessor.prototype.handleUploadBlob.call(processor, {
+          processor.handleUploadBlob({
             type: RequestType.UploadBlob,
             space: "did:key:test-space" as never,
             contentType: "image/png",
@@ -2293,10 +2232,10 @@ describe("runtime-processor", () => {
           return Promise.resolve(true);
         },
       };
-      const processor = {
+      const processor = buildProcessor({
         identity: cfcSigner,
         runtime,
-      } as unknown as RuntimeProcessor;
+      });
 
       const originalEnsure = PiecesController.prototype.ensureDefaultPattern;
       let ensured = false;
@@ -2308,10 +2247,9 @@ describe("runtime-processor", () => {
       };
       try {
         await expect(
-          RuntimeProcessor.prototype.handleEnsureHomePatternRunning.call(
-            processor,
-            { type: RequestType.EnsureHomePatternRunning },
-          ),
+          processor.handleEnsureHomePatternRunning({
+            type: RequestType.EnsureHomePatternRunning,
+          }),
         ).resolves.toEqual({ cell: defaultPatternRef });
       } finally {
         PiecesController.prototype.ensureDefaultPattern = originalEnsure;
@@ -2336,16 +2274,15 @@ describe("runtime-processor", () => {
           ensureDefaultPattern: () =>
             Promise.resolve({ getCell: () => rootCell }),
         };
-        const processor = {
-          getSpaceCtx: () => cc,
-        } as unknown as RuntimeProcessor;
+        const processor = buildProcessor({
+          cc,
+          space: "did:key:test-space",
+        });
 
-        const result = await RuntimeProcessor.prototype
-          .handleGetSpaceRootPattern
-          .call(processor, {
-            type: RequestType.GetSpaceRootPattern,
-            space: "did:key:test-space",
-          });
+        const result = await processor.handleGetSpaceRootPattern({
+          type: RequestType.GetSpaceRootPattern,
+          space: "did:key:test-space",
+        });
         expect(result.piece.cell).toEqual(ref);
       });
 
@@ -2369,17 +2306,16 @@ describe("runtime-processor", () => {
             return Promise.reject(new Error("must not run the root"));
           },
         };
-        const processor = {
-          getSpaceCtx: () => cc,
-        } as unknown as RuntimeProcessor;
+        const processor = buildProcessor({
+          cc,
+          space: "did:key:test-space",
+        });
 
-        const result = await RuntimeProcessor.prototype
-          .handleGetSpaceRootPattern
-          .call(processor, {
-            type: RequestType.GetSpaceRootPattern,
-            space: "did:key:test-space",
-            start: false,
-          });
+        const result = await processor.handleGetSpaceRootPattern({
+          type: RequestType.GetSpaceRootPattern,
+          space: "did:key:test-space",
+          start: false,
+        });
 
         expect(result.piece.cell).toEqual(ref);
         // Reconciled but not started: a read of what the root exported still
@@ -2410,17 +2346,16 @@ describe("runtime-processor", () => {
             });
           },
         };
-        const processor = {
-          getSpaceCtx: () => cc,
-        } as unknown as RuntimeProcessor;
+        const processor = buildProcessor({
+          cc,
+          space: "did:key:test-space",
+        });
 
-        const result = await RuntimeProcessor.prototype
-          .handleGetSpaceRootPattern
-          .call(processor, {
-            type: RequestType.GetSpaceRootPattern,
-            space: "did:key:test-space",
-            start: false,
-          });
+        const result = await processor.handleGetSpaceRootPattern({
+          type: RequestType.GetSpaceRootPattern,
+          space: "did:key:test-space",
+          start: false,
+        });
 
         expect(result.piece.cell).toEqual(ref);
         expect(calls).toEqual(["getDefaultPattern", "ensureDefaultPattern"]);
@@ -2438,29 +2373,24 @@ describe("runtime-processor", () => {
       };
       const calls: string[] = [];
       let durable = false;
-      const processor = Object.assign(
-        Object.create(
-          RuntimeProcessor.prototype,
-        ),
-        {
-          runtime: {
-            getCellFromLink: () => ({
-              pull: () => {
-                calls.push("pull");
-                return Promise.resolve();
-              },
-              get: () => durable ? { ready: true } : undefined,
-            }),
-            scheduler: {
-              idleWithPendingCommits: () => {
-                calls.push("commits");
-                durable = true;
-                return Promise.resolve();
-              },
+      const processor = buildProcessor({
+        runtime: {
+          getCellFromLink: () => ({
+            pull: () => {
+              calls.push("pull");
+              return Promise.resolve();
+            },
+            get: () => durable ? { ready: true } : undefined,
+          }),
+          scheduler: {
+            idleWithPendingCommits: () => {
+              calls.push("commits");
+              durable = true;
+              return Promise.resolve();
             },
           },
         },
-      ) as RuntimeProcessor;
+      });
 
       await expect(
         processor.handleRequest({
@@ -2540,19 +2470,19 @@ describe("runtime-processor", () => {
           }],
         },
       };
-      const processor = {
+      const processor = buildProcessor({
         runtime: {
           getCellFromLink: () => ({
             get: () => "labeled data",
             getMetaRaw: () => rawEnvelope,
           }),
         },
-      } as unknown as RuntimeProcessor;
+      });
 
       // "cfc" is no longer a MetaField, but the wire is untyped JSON — a request
       // that still sends it must get an error, never the raw metadata.
       expect(() =>
-        RuntimeProcessor.prototype.handleCellGet.call(processor, {
+        processor.handleCellGet({
           type: RequestType.CellGet,
           cell: ref,
           meta: "cfc" as never,
@@ -2567,7 +2497,7 @@ describe("runtime-processor", () => {
         scope: "space",
         path: [],
       };
-      const processor = {
+      const processor = buildProcessor({
         runtime: {
           getCellFromLink: () => ({
             runtime: {
@@ -2592,10 +2522,10 @@ describe("runtime-processor", () => {
             getMetaRaw: () => undefined,
           }),
         },
-      } as unknown as RuntimeProcessor;
+      });
 
       expect(
-        RuntimeProcessor.prototype.handleCellGetCfcLabel.call(processor, {
+        processor.handleCellGetCfcLabel({
           type: RequestType.CellGetCfcLabel,
           cell: ref,
         }),
@@ -2617,7 +2547,7 @@ describe("runtime-processor", () => {
         scope: "space",
         path: [],
       };
-      const processor = {
+      const processor = buildProcessor({
         runtime: {
           getCellFromLink: () => ({
             runtime: {
@@ -2649,13 +2579,12 @@ describe("runtime-processor", () => {
             sync: () => Promise.resolve(),
           }),
         },
-      } as unknown as RuntimeProcessor;
+      });
 
-      const response = await RuntimeProcessor.prototype.handleCellGetCfcLabel
-        .call(
-          processor,
-          { type: RequestType.CellGetCfcLabel, cell: ref },
-        );
+      const response = await processor.handleCellGetCfcLabel({
+        type: RequestType.CellGetCfcLabel,
+        cell: ref,
+      });
       const atom = response.cfcLabel?.entries[0].label.confidentiality
         ?.[0] as Record<string, unknown>;
       // The caveat survives with its kind/type, but the source identity is gone.
@@ -2681,21 +2610,18 @@ describe("runtime-processor", () => {
           runtime,
           "cfc-value-view-linked",
         );
-        const processor = {
+        const processor = buildProcessor({
           runtime: {
             getCellFromLink: () => ({
               get: () => ({ nested: carrier }),
             }),
           },
-        } as unknown as RuntimeProcessor;
+        });
 
-        const response = RuntimeProcessor.prototype.handleCellGet.call(
-          processor,
-          {
-            type: RequestType.CellGet,
-            cell: ref,
-          },
-        );
+        const response = processor.handleCellGet({
+          type: RequestType.CellGet,
+          cell: ref,
+        });
         const atom = sourcedCaveatOf(
           (response.value as { nested: SigilLink }).nested,
         );
@@ -2715,7 +2641,7 @@ describe("runtime-processor", () => {
         scope: "space",
         path: [],
       };
-      const processor = {
+      const processor = buildProcessor({
         runtime: {
           getCellFromLink: () => ({
             get: () => "plain value",
@@ -2731,9 +2657,9 @@ describe("runtime-processor", () => {
             }),
           }),
         },
-      } as unknown as RuntimeProcessor;
+      });
 
-      const withRef = RuntimeProcessor.prototype.handleCellGet.call(processor, {
+      const withRef = processor.handleCellGet({
         type: RequestType.CellGet,
         cell: ref,
         includeRef: true,
@@ -2742,7 +2668,7 @@ describe("runtime-processor", () => {
       expect(withRef.cell?.schema).toEqual({ type: "string" });
 
       // Not requested: not returned.
-      const without = RuntimeProcessor.prototype.handleCellGet.call(processor, {
+      const without = processor.handleCellGet({
         type: RequestType.CellGet,
         cell: ref,
       });
@@ -2756,7 +2682,7 @@ describe("runtime-processor", () => {
         scope: "space",
         path: [],
       };
-      const processor = {
+      const processor = buildProcessor({
         runtime: {
           getCellFromLink: () => ({
             get: () => "plain value",
@@ -2778,17 +2704,14 @@ describe("runtime-processor", () => {
             getMetaRaw: () => undefined,
           }),
         },
-      } as unknown as RuntimeProcessor;
+      });
 
-      const response = RuntimeProcessor.prototype.handleCellGet.call(
-        processor,
-        {
-          type: RequestType.CellGet,
-          cell: ref,
-          includeRef: true,
-          includeCfcLabel: true,
-        },
-      );
+      const response = processor.handleCellGet({
+        type: RequestType.CellGet,
+        cell: ref,
+        includeRef: true,
+        includeCfcLabel: true,
+      });
       expect(response.cell?.id).toBe("of:include-ref-label-cell");
       // The cell carries no label; the field is present-but-undefined.
       expect(response.cfcLabel).toBeUndefined();
@@ -2832,21 +2755,18 @@ describe("runtime-processor", () => {
           },
         },
       };
-      const processor = {
+      const processor = buildProcessor({
         runtime: {
           getCellFromLink: () => ({
             get: () => ({ nested: linkWithView }),
           }),
         },
-      } as unknown as RuntimeProcessor;
+      });
 
-      const response = RuntimeProcessor.prototype.handleCellGet.call(
-        processor,
-        {
-          type: RequestType.CellGet,
-          cell: ref,
-        },
-      );
+      const response = processor.handleCellGet({
+        type: RequestType.CellGet,
+        cell: ref,
+      });
       const atom = sourcedCaveatOf(
         (response.value as { nested: SigilLink }).nested,
       );
@@ -2871,8 +2791,7 @@ describe("runtime-processor", () => {
           runtime,
           "cfc-subscribe-view-linked",
         );
-        const processor = {
-          subscriptions: new Map(),
+        const processor = buildProcessor({
           runtime: {
             getCellFromLink: () => ({
               sink: (
@@ -2883,7 +2802,7 @@ describe("runtime-processor", () => {
               },
             }),
           },
-        } as unknown as RuntimeProcessor;
+        });
 
         const posted: Array<{ value?: unknown }> = [];
         const orig = self.postMessage;
@@ -2894,7 +2813,7 @@ describe("runtime-processor", () => {
             fabricFromRealmValue(m as never) as { value?: unknown },
           );
         try {
-          RuntimeProcessor.prototype.handleCellSubscribe.call(processor, {
+          processor.handleCellSubscribe({
             type: RequestType.CellSubscribe,
             cell: ref,
           });
@@ -2961,16 +2880,16 @@ describe("runtime-processor", () => {
           }),
         },
       };
-      const processor = {
+      const processor = buildProcessor({
         runtime: {
           getCellFromLink: () => ({ resolveAsCell: () => resolvedCell }),
         },
-      } as unknown as RuntimeProcessor;
+      });
 
-      const response = RuntimeProcessor.prototype.handleCellResolveAsCell.call(
-        processor,
-        { type: RequestType.CellResolveAsCell, cell: sourceRef },
-      );
+      const response = processor.handleCellResolveAsCell({
+        type: RequestType.CellResolveAsCell,
+        cell: sourceRef,
+      });
       const atom = response.cell.cfcLabelView?.entries[0].label
         .confidentiality?.[0] as Record<string, unknown>;
       expect(atom.type).toBe(CFC_ATOM_TYPE.Caveat);
@@ -3019,14 +2938,14 @@ describe("runtime-processor", () => {
       const sourceCell = {
         resolveAsCell: () => resolvedCell,
       };
-      const processor = {
+      const processor = buildProcessor({
         runtime: {
           getCellFromLink: () => sourceCell,
         },
-      } as unknown as RuntimeProcessor;
+      });
 
       expect(
-        RuntimeProcessor.prototype.handleCellResolveAsCell.call(processor, {
+        processor.handleCellResolveAsCell({
           type: RequestType.CellResolveAsCell,
           cell: sourceRef,
         }),
@@ -3072,16 +2991,16 @@ describe("runtime-processor", () => {
           }),
         },
       };
-      const processor = {
+      const processor = buildProcessor({
         runtime: {
           getCellFromLink: () => ({ resolveAsCell: () => resolvedCell }),
         },
-      } as unknown as RuntimeProcessor;
+      });
 
-      const response = RuntimeProcessor.prototype.handleCellResolveAsCell.call(
-        processor,
-        { type: RequestType.CellResolveAsCell, cell: sourceRef },
-      );
+      const response = processor.handleCellResolveAsCell({
+        type: RequestType.CellResolveAsCell,
+        cell: sourceRef,
+      });
 
       expect(response.cell).toEqual({
         ...resolvedRef,
@@ -3153,10 +3072,10 @@ describe("runtime-processor", () => {
           return Promise.resolve();
         },
       };
-      const processor = { runtime } as unknown as RuntimeProcessor;
+      const processor = buildProcessor({ runtime });
 
       expect(
-        RuntimeProcessor.prototype.handleCellGetCfcLabel.call(processor, {
+        processor.handleCellGetCfcLabel({
           type: RequestType.CellGetCfcLabel,
           cell: resultRef,
         }),
@@ -3204,12 +3123,12 @@ describe("runtime-processor", () => {
           return Promise.resolve();
         },
       };
-      const processor = {
+      const processor = buildProcessor({
         runtime: { getCellFromLink: () => cell },
-      } as unknown as RuntimeProcessor;
+      });
 
       expect(
-        RuntimeProcessor.prototype.handleCellGetCfcLabel.call(processor, {
+        processor.handleCellGetCfcLabel({
           type: RequestType.CellGetCfcLabel,
           cell: ref,
         }),
@@ -3317,22 +3236,18 @@ describe("runtime-processor", () => {
         const nestedId = parseLink(
           replica.getDocument(rootId)?.value?.messages?.[0],
         )!.id!;
-        const processor = { runtime } as unknown as RuntimeProcessor;
+        const processor = buildProcessor({ runtime });
 
-        const response = await RuntimeProcessor.prototype.handleCellGetCfcLabel
-          .call(
-            processor,
-            {
-              type: RequestType.CellGetCfcLabel,
-              cell: {
-                id: nestedId as CellRef["id"],
-                space: cfcSigner.did() as CellRef["space"],
-                scope: "space",
-                path: ["piece"],
-                schema: pieceSchema,
-              },
-            },
-          );
+        const response = await processor.handleCellGetCfcLabel({
+          type: RequestType.CellGetCfcLabel,
+          cell: {
+            id: nestedId as CellRef["id"],
+            space: cfcSigner.did() as CellRef["space"],
+            scope: "space",
+            path: ["piece"],
+            schema: pieceSchema,
+          },
+        });
         expect(response.cfcLabel).toBeDefined();
         expect(response.cfcLabel?.version).toBe(1);
         expect(response.cfcLabel?.entries).toEqual([{
@@ -3471,22 +3386,18 @@ describe("runtime-processor", () => {
         const nestedId = parseLink(
           replica.getDocument(rootId)?.value?.messages?.[0],
         )!.id!;
-        const processor = { runtime } as unknown as RuntimeProcessor;
+        const processor = buildProcessor({ runtime });
 
-        const response = await RuntimeProcessor.prototype.handleCellGetCfcLabel
-          .call(
-            processor,
-            {
-              type: RequestType.CellGetCfcLabel,
-              cell: {
-                id: nestedId as CellRef["id"],
-                space: cfcSigner.did() as CellRef["space"],
-                scope: "space",
-                path: ["piece"],
-                schema: { $ref: "#/$defs/TrustedMessage" },
-              },
-            },
-          );
+        const response = await processor.handleCellGetCfcLabel({
+          type: RequestType.CellGetCfcLabel,
+          cell: {
+            id: nestedId as CellRef["id"],
+            space: cfcSigner.did() as CellRef["space"],
+            scope: "space",
+            path: ["piece"],
+            schema: { $ref: "#/$defs/TrustedMessage" },
+          },
+        });
         expect(response.cfcLabel).toEqual({
           version: 1,
           entries: [{
@@ -3553,7 +3464,7 @@ describe("runtime-processor", () => {
       return {
         calls,
         resolvedCell,
-        processor: Object.assign(Object.create(RuntimeProcessor.prototype), {
+        processor: buildProcessor({
           runtime: {
             edit: () => tx,
             prepareTxForCommit: (candidate: unknown) => {
@@ -3574,14 +3485,14 @@ describe("runtime-processor", () => {
               return Promise.resolve(commitResult);
             },
           },
-        }) as RuntimeProcessor,
+        }),
       };
     };
 
     it("routes a cell set through the blind supersede lane", () => {
       const { processor, calls, resolvedCell } = createProcessor();
 
-      RuntimeProcessor.prototype.handleCellSet.call(processor, {
+      processor.handleCellSet({
         type: RequestType.CellSet,
         cell: ref,
         value: "new value",
@@ -3605,7 +3516,7 @@ describe("runtime-processor", () => {
     it("prepares mergeable cell append transactions before committing", async () => {
       const { processor } = createProcessor();
 
-      await RuntimeProcessor.prototype.handleCellPush.call(processor, {
+      await processor.handleCellPush({
         type: RequestType.CellPush,
         cell: ref,
         values: ["new value"],
@@ -3615,7 +3526,7 @@ describe("runtime-processor", () => {
     it("prepares cell send transactions before committing", async () => {
       const { processor } = createProcessor();
 
-      await RuntimeProcessor.prototype.handleCellSend.call(processor, {
+      await processor.handleCellSend({
         type: RequestType.CellSend,
         cell: ref,
         event: "new value",
@@ -3640,17 +3551,17 @@ describe("runtime-processor", () => {
           new Error("send commit rejected"),
         );
 
-        RuntimeProcessor.prototype.handleCellSet.call(set.processor, {
+        set.processor.handleCellSet({
           type: RequestType.CellSet,
           cell: ref,
           value: "new value",
         });
-        RuntimeProcessor.prototype.handleCellPush.call(push.processor, {
+        push.processor.handleCellPush({
           type: RequestType.CellPush,
           cell: ref,
           values: ["new value"],
         });
-        RuntimeProcessor.prototype.handleCellSend.call(send.processor, {
+        send.processor.handleCellSend({
           type: RequestType.CellSend,
           cell: ref,
           event: "new value",
@@ -3676,17 +3587,17 @@ describe("runtime-processor", () => {
         const push = createProcessor({ error: { message: "push refused" } });
         const send = createProcessor({ error: { message: "send refused" } });
 
-        RuntimeProcessor.prototype.handleCellSet.call(set.processor, {
+        set.processor.handleCellSet({
           type: RequestType.CellSet,
           cell: ref,
           value: "new value",
         });
-        RuntimeProcessor.prototype.handleCellPush.call(push.processor, {
+        push.processor.handleCellPush({
           type: RequestType.CellPush,
           cell: ref,
           values: ["new value"],
         });
-        RuntimeProcessor.prototype.handleCellSend.call(send.processor, {
+        send.processor.handleCellSend({
           type: RequestType.CellSend,
           cell: ref,
           event: "new value",
@@ -3707,7 +3618,7 @@ describe("runtime-processor", () => {
         error: { message: "set refused" },
       });
 
-      await expect(RuntimeProcessor.prototype.handleCellSet.call(processor, {
+      await expect(processor.handleCellSet({
         type: RequestType.CellSet,
         cell: ref,
         value: "new value",
@@ -3721,7 +3632,7 @@ describe("runtime-processor", () => {
       });
 
       await expect(
-        RuntimeProcessor.prototype.handleCellPush.call(processor, {
+        processor.handleCellPush({
           type: RequestType.CellPush,
           cell: ref,
           values: ["new value"],
@@ -3735,7 +3646,7 @@ describe("runtime-processor", () => {
         error: { message: "send refused" },
       });
 
-      await expect(RuntimeProcessor.prototype.handleCellSend.call(processor, {
+      await expect(processor.handleCellSend({
         type: RequestType.CellSend,
         cell: ref,
         event: "new value",
@@ -3777,10 +3688,7 @@ describe("runtime-processor", () => {
         cell.withTx(seed).set([]);
         expect((await seed.commit()).error).toBeUndefined();
 
-        const processor = Object.assign(
-          Object.create(RuntimeProcessor.prototype),
-          { runtime },
-        ) as RuntimeProcessor;
+        const processor = buildProcessor({ runtime }) as RuntimeProcessor;
         const append = async (value: { optionId: string }) => {
           const callerFrame = pushFrame({
             runtime,
@@ -3818,15 +3726,12 @@ describe("runtime-processor", () => {
 
   describe("direct cell initialization", () => {
     it("rejects malformed initializers and surfaces transaction failures", async () => {
-      const failed = Object.assign(
-        Object.create(RuntimeProcessor.prototype),
-        {
-          runtime: {
-            editWithRetry: () =>
-              Promise.resolve({ error: new Error("initialize failed") }),
-          },
+      const failed = buildProcessor({
+        runtime: {
+          editWithRetry: () =>
+            Promise.resolve({ error: new Error("initialize failed") }),
         },
-      ) as RuntimeProcessor;
+      });
       const ref = {
         space: "did:key:test" as CellRef["space"],
         id: "of:initialize-failure" as CellRef["id"],
@@ -3900,10 +3805,9 @@ describe("runtime-processor", () => {
           "user",
         );
         expect(readerCell.get()).toBeUndefined();
-        const processor = Object.assign(
-          Object.create(RuntimeProcessor.prototype),
-          { runtime: readerRuntime },
-        ) as RuntimeProcessor;
+        const processor = buildProcessor({
+          runtime: readerRuntime,
+        }) as RuntimeProcessor;
 
         const selected = await processor.handleCellInitialize({
           type: RequestType.CellInitialize,
@@ -3943,10 +3847,7 @@ describe("runtime-processor", () => {
           },
         );
         await cell.sync();
-        const processor = Object.assign(
-          Object.create(RuntimeProcessor.prototype),
-          { runtime },
-        ) as RuntimeProcessor;
+        const processor = buildProcessor({ runtime }) as RuntimeProcessor;
         const ref = createCellRef(cell);
 
         const [first, second] = await Promise.all([
@@ -4009,10 +3910,7 @@ describe("runtime-processor", () => {
           required: ["bars"],
           default: initial,
         } as const;
-        const processor = Object.assign(
-          Object.create(RuntimeProcessor.prototype),
-          { runtime },
-        ) as RuntimeProcessor;
+        const processor = buildProcessor({ runtime }) as RuntimeProcessor;
         for (const scope of ["user", "session"] as const) {
           const cell = runtime.getCell<typeof initial>(
             space,
@@ -4099,10 +3997,7 @@ describe("runtime-processor", () => {
         expect(alias.get()).toEqual(initial);
         expect(target.asSchema(undefined).getRaw()).toBeUndefined();
 
-        const processor = Object.assign(
-          Object.create(RuntimeProcessor.prototype),
-          { runtime },
-        ) as RuntimeProcessor;
+        const processor = buildProcessor({ runtime }) as RuntimeProcessor;
         await expect(processor.handleCellInitialize({
           type: RequestType.CellInitialize,
           cell: createCellRef(alias),
@@ -4140,10 +4035,7 @@ describe("runtime-processor", () => {
           default: { n: 1 },
           scope: "space",
         } as const;
-        const processor = Object.assign(
-          Object.create(RuntimeProcessor.prototype),
-          { runtime },
-        ) as RuntimeProcessor;
+        const processor = buildProcessor({ runtime }) as RuntimeProcessor;
 
         for (const existing of [undefined, { n: 7 }] as const) {
           const target = runtime.getCell<{ n: number }>(
@@ -4203,10 +4095,7 @@ describe("runtime-processor", () => {
           required: ["n"],
           default: { n: 1 },
         });
-        const processor = Object.assign(
-          Object.create(RuntimeProcessor.prototype),
-          { runtime },
-        ) as RuntimeProcessor;
+        const processor = buildProcessor({ runtime }) as RuntimeProcessor;
 
         await expect(processor.handleCellInitialize({
           type: RequestType.CellInitialize,
@@ -4240,10 +4129,7 @@ describe("runtime-processor", () => {
           `direct-linked-initializer-${crypto.randomUUID()}`,
         );
         await target.sync();
-        const processor = Object.assign(
-          Object.create(RuntimeProcessor.prototype),
-          { runtime },
-        ) as RuntimeProcessor;
+        const processor = buildProcessor({ runtime }) as RuntimeProcessor;
         const linkedRef = createCellRef(linked);
 
         const selected = await processor.handleRequest({
@@ -4441,13 +4327,12 @@ describe("runtime-processor", () => {
     it("carries a raised flag's metadata through to the response", () => {
       // No `this` is read, so the handler runs against a bare receiver.
 
-      const processor = {} as unknown as RuntimeProcessor;
+      const processor = buildProcessor();
 
       withFlag({ a: 1 }, () => {
-        const response = RuntimeProcessor.prototype.getLoggerCounts.call(
-          processor,
-          { type: RequestType.GetLoggerCounts },
-        );
+        const response = processor.getLoggerCounts({
+          type: RequestType.GetLoggerCounts,
+        });
 
         expect(Object.keys(response).sort()).toEqual([
           "counts",
@@ -4465,14 +4350,11 @@ describe("runtime-processor", () => {
       // The assertion is wired into the handler, not merely available beside it:
       // a `Date` raised anywhere in the process stops this read.
 
-      const processor = {} as unknown as RuntimeProcessor;
+      const processor = buildProcessor();
 
       withFlag({ when: new Date(0) }, () => {
         expect(() =>
-          RuntimeProcessor.prototype.getLoggerCounts.call(
-            processor,
-            { type: RequestType.GetLoggerCounts },
-          )
+          processor.getLoggerCounts({ type: RequestType.GetLoggerCounts })
         ).toThrow(/not being a `FabricValue`/);
       });
     });
@@ -4552,21 +4434,20 @@ describe("runtime-processor", () => {
       // worker strips inbound views at this ingress too (codex/cubic review).
 
       const dispatched: unknown[] = [];
-      const processor = {
-        vdomMounts: new Map([[
-          "0 mount-1",
-          {
-            reconciler: {
-              dispatchEvent: (_handlerId: string, event: unknown) => {
-                dispatched.push(event);
-                return true;
-              },
+      const processor = buildProcessor({});
+      processor.accessForTestingOnly.vdomMounts = new Map([[
+        "0 mount-1",
+        {
+          reconciler: {
+            dispatchEvent: (_handlerId: string, event: unknown) => {
+              dispatched.push(event);
+              return true;
             },
           },
-        ]]),
-      } as unknown as RuntimeProcessor;
+        },
+      ]]) as never;
 
-      RuntimeProcessor.prototype.handleVDomEvent.call(processor, {
+      processor.handleVDomEvent({
         type: ClientNotificationType.VDomEvent,
         mountId: "mount-1",
         handlerId: "handler-1",
@@ -4617,34 +4498,33 @@ describe("runtime-processor", () => {
     };
 
     it("returns the worker collector's report", () => {
-      const processor = {
+      const processor = buildProcessor({
         runtime: { patternCoverage: { toData: () => report } },
-      } as unknown as RuntimeProcessor;
+      });
       expect(
-        RuntimeProcessor.prototype.getPatternCoverage.call(processor, {
+        processor.getPatternCoverage({
           type: RequestType.GetPatternCoverage,
         }),
       ).toEqual({ data: report });
     });
 
     it("reports null when the worker was built without a collector", () => {
-      const processor = { runtime: {} } as unknown as RuntimeProcessor;
+      const processor = buildProcessor();
       expect(
-        RuntimeProcessor.prototype.getPatternCoverage.call(processor, {
+        processor.getPatternCoverage({
           type: RequestType.GetPatternCoverage,
         }),
       ).toEqual({ data: null });
     });
 
     it("routes a GetPatternCoverage request through the dispatcher", async () => {
-      const processor = {
+      const processor = buildProcessor({
         runtime: { patternCoverage: { toData: () => report } },
         // handleRequest dispatches to this.getPatternCoverage; the stub carries
         // the real method so the routing case executes it.
-        getPatternCoverage: RuntimeProcessor.prototype.getPatternCoverage,
-      } as unknown as RuntimeProcessor;
+      });
       expect(
-        await RuntimeProcessor.prototype.handleRequest.call(processor, {
+        await processor.handleRequest({
           type: RequestType.GetPatternCoverage,
         }),
       ).toEqual({ data: report });
@@ -4841,7 +4721,7 @@ describe("runtime-processor", () => {
         },
       };
       const resolveCalls: unknown[] = [];
-      const processor = {
+      const processor = buildProcessor({
         runtime: {
           storageManager: {
             open: () => provider,
@@ -4858,20 +4738,16 @@ describe("runtime-processor", () => {
                 seq,
                 requestSidecarId,
                 action,
-              ]);
+              ]) as never;
               return Promise.resolve({ resolution: { kind: "dismissed" } });
             },
           },
         },
         identity: cfcSigner,
-        handleListEventAttention:
-          RuntimeProcessor.prototype.handleListEventAttention,
-        handleResolveEventAttention:
-          RuntimeProcessor.prototype.handleResolveEventAttention,
-      } as unknown as RuntimeProcessor;
+      });
 
       expect(
-        await RuntimeProcessor.prototype.handleRequest.call(processor, {
+        await processor.handleRequest({
           type: RequestType.ListEventAttention,
           space,
         }),
@@ -4903,7 +4779,7 @@ describe("runtime-processor", () => {
         }],
       });
       expect(
-        await RuntimeProcessor.prototype.handleRequest.call(processor, {
+        await processor.handleRequest({
           type: RequestType.ResolveEventAttention,
           space,
           eventId: "evt-valid",
@@ -4918,7 +4794,7 @@ describe("runtime-processor", () => {
         41,
         sidecarId,
         "dismiss",
-      ]]);
+      ]]) as never;
     });
 
     it("surfaces attention index and sidecar synchronization failures", async () => {
@@ -4934,10 +4810,13 @@ describe("runtime-processor", () => {
         firstFailureAt: attention.firstFailureAt,
       };
       const invoke = (provider: unknown) =>
-        RuntimeProcessor.prototype.handleListEventAttention.call({
+        buildProcessor({
           runtime: { storageManager: { open: () => provider } },
           identity: cfcSigner,
-        } as never, { type: RequestType.ListEventAttention, space });
+        }).handleListEventAttention({
+          type: RequestType.ListEventAttention,
+          space,
+        });
 
       await expect(invoke({
         sync: () => Promise.resolve({ error: indexError }),
@@ -4968,9 +4847,9 @@ describe("runtime-processor", () => {
 
     it("rejects resolution when the storage capability is absent", async () => {
       await expect(
-        RuntimeProcessor.prototype.handleResolveEventAttention.call({
+        buildProcessor({
           runtime: { storageManager: {} },
-        } as never, {
+        }).handleResolveEventAttention({
           type: RequestType.ResolveEventAttention,
           space,
           eventId: "evt-unsupported",
@@ -5169,8 +5048,6 @@ describe("runtime-processor", () => {
     // getSpaceCtx resolves the per-space PiecesController, lazily for
     // foreign spaces, over the shared runtime/storage.
 
-    const getSpaceCtx = (RuntimeProcessor.prototype as any).getSpaceCtx;
-
     function makeProcessorState() {
       const { runtime } = createRuntime();
       const homeSpace = cfcSigner.did();
@@ -5178,27 +5055,28 @@ describe("runtime-processor", () => {
         { as: cfcSigner, space: homeSpace },
         runtime,
       );
-      const processor = {
+      const processor = buildProcessor({
         runtime,
         identity: cfcSigner,
         space: homeSpace,
-        spaces: new Map([[homeSpace, cc]]),
         cc,
-        getSpaceCtx,
-      };
+      });
       return { processor, runtime, homeSpace };
     }
 
     it("resolves the home space to the initialize-time context and rejects a missing space", async () => {
       const { processor, runtime, homeSpace } = makeProcessorState();
       try {
-        expect(processor.getSpaceCtx(homeSpace)).toBe(
-          processor.spaces.get(homeSpace),
+        expect(processor.accessForTestingOnly.getSpaceCtx(homeSpace)).toBe(
+          processor.accessForTestingOnly.spaces.get(homeSpace),
         );
-        expect(processor.getSpaceCtx(homeSpace)).toBe(processor.cc);
+        expect(processor.accessForTestingOnly.getSpaceCtx(homeSpace)).toBe(
+          processor.accessForTestingOnly.cc,
+        );
         expect(() =>
-          (processor as { getSpaceCtx: (s?: string) => unknown })
-            .getSpaceCtx()
+          (processor.accessForTestingOnly.getSpaceCtx as (
+            s?: string,
+          ) => unknown)()
         ).toThrow("name a space");
       } finally {
         await runtime.dispose();
@@ -5211,12 +5089,14 @@ describe("runtime-processor", () => {
         "runtime-processor-space-b",
       )).did();
       try {
-        const ctxB = processor.getSpaceCtx(spaceB);
-        expect(ctxB).not.toBe(processor.cc);
+        const ctxB = processor.accessForTestingOnly.getSpaceCtx(spaceB);
+        expect(ctxB).not.toBe(processor.accessForTestingOnly.cc);
         expect(ctxB.getSpace()).toBe(spaceB);
         // Cached: the same context comes back, and the home context is intact.
-        expect(processor.getSpaceCtx(spaceB)).toBe(ctxB);
-        expect(processor.getSpaceCtx(homeSpace)).toBe(processor.cc);
+        expect(processor.accessForTestingOnly.getSpaceCtx(spaceB)).toBe(ctxB);
+        expect(processor.accessForTestingOnly.getSpaceCtx(homeSpace)).toBe(
+          processor.accessForTestingOnly.cc,
+        );
       } finally {
         await runtime.dispose();
       }
@@ -5228,16 +5108,14 @@ describe("runtime-processor", () => {
         const spaceB = (await Identity.fromPassphrase(
           "runtime-processor-space-b",
         )).did();
-        const handlePieceGet =
-          (RuntimeProcessor.prototype as any).handlePieceGet;
         try {
-          const resHome = await handlePieceGet.call(processor, {
+          const resHome = await processor.handlePieceGet({
             type: RequestType.PieceGet,
             pieceId: fid("cross-space-probe"),
             runIt: false,
             space: homeSpace,
           });
-          const resB = await handlePieceGet.call(processor, {
+          const resB = await processor.handlePieceGet({
             type: RequestType.PieceGet,
             pieceId: fid("cross-space-probe"),
             runIt: false,
@@ -5257,13 +5135,11 @@ describe("runtime-processor", () => {
         const spaceB = (await Identity.fromPassphrase(
           "runtime-processor-space-b",
         )).did();
-        const handleRuntimeSynced =
-          (RuntimeProcessor.prototype as any).handleRuntimeSynced;
         try {
-          processor.getSpaceCtx(spaceB);
+          processor.accessForTestingOnly.getSpaceCtx(spaceB);
           // Resolves across home + spaceB over loopback storage; the request
           // carries no space at all.
-          await handleRuntimeSynced.call(processor);
+          await processor.handleRuntimeSynced();
         } finally {
           await runtime.dispose();
         }
@@ -5278,9 +5154,8 @@ describe("runtime-processor", () => {
         // only). A fake exposing ONLY idleWithPendingCommits pins the wiring: a
         // regression to runtime.idle() throws here.
 
-        const handleIdle = (RuntimeProcessor.prototype as any).handleIdle;
         let calls = 0;
-        const fake = {
+        const fake = buildProcessor({
           runtime: {
             scheduler: {
               idleWithPendingCommits: () => {
@@ -5289,8 +5164,8 @@ describe("runtime-processor", () => {
               },
             },
           },
-        };
-        await handleIdle.call(fake);
+        });
+        await fake.handleIdle();
         expect(calls).toBe(1);
       });
     });
@@ -5386,25 +5261,20 @@ describe("runtime-processor", () => {
     describe("handleRegisterSpaceHost()", () => {
       it("forwards to the runtime and reports the verdict", () => {
         const calls: Array<[string, string]> = [];
-        const processor = {
+        const processor = buildProcessor({
           runtime: {
             registerSpaceHost: (space: string, host: string) => {
               calls.push([space, host]);
               return host === "http://accepted.test/";
             },
           },
-        } as unknown as RuntimeProcessor;
-        const handle = (RuntimeProcessor.prototype as unknown as {
-          handleRegisterSpaceHost(
-            r: { type: RequestType; space: string; host: string },
-          ): { value: boolean };
-        }).handleRegisterSpaceHost;
-        expect(handle.call(processor, {
+        });
+        expect(processor.handleRegisterSpaceHost({
           type: RequestType.RegisterSpaceHost,
           space: "did:key:z6Mk-ipc-a",
           host: "http://accepted.test/",
         })).toEqual({ value: true });
-        expect(handle.call(processor, {
+        expect(processor.handleRegisterSpaceHost({
           type: RequestType.RegisterSpaceHost,
           space: "did:key:z6Mk-ipc-b",
           host: "http://refused.test/",
@@ -5416,7 +5286,7 @@ describe("runtime-processor", () => {
     describe("setMemoryMessageCompression()", () => {
       it("forwards the requested mode to storage", async () => {
         const modes: boolean[] = [];
-        const processor = {
+        const processor = buildProcessor({
           runtime: {
             storageManager: {
               setMessageCompressionEnabled: (enabled: boolean) => {
@@ -5425,16 +5295,11 @@ describe("runtime-processor", () => {
               },
             },
           },
-          setMemoryMessageCompression:
-            RuntimeProcessor.prototype.setMemoryMessageCompression,
-        } as unknown as RuntimeProcessor;
-        await RuntimeProcessor.prototype.handleRequest.call(
-          processor,
-          {
-            type: RequestType.SetMemoryMessageCompression,
-            enabled: false,
-          },
-        );
+        });
+        await processor.handleRequest({
+          type: RequestType.SetMemoryMessageCompression,
+          enabled: false,
+        });
 
         expect(modes).toEqual([false]);
       });
@@ -5446,12 +5311,13 @@ describe("runtime-processor", () => {
         const spaceB = (await Identity.fromPassphrase(
           "runtime-processor-space-b",
         )).did();
-        const piecesFor = (RuntimeProcessor.prototype as any).piecesFor;
         try {
-          expect(piecesFor.call(processor, homeSpace)).toBe(processor.cc);
-          expect(piecesFor.call(processor, spaceB)).toBeUndefined();
-          const ctxB = processor.getSpaceCtx(spaceB);
-          expect(piecesFor.call(processor, spaceB)).toBe(ctxB);
+          expect(processor.piecesFor(homeSpace)).toBe(
+            processor.accessForTestingOnly.cc,
+          );
+          expect(processor.piecesFor(spaceB)).toBeUndefined();
+          const ctxB = processor.accessForTestingOnly.getSpaceCtx(spaceB);
+          expect(processor.piecesFor(spaceB)).toBe(ctxB);
         } finally {
           await runtime.dispose();
         }
@@ -5463,10 +5329,6 @@ describe("runtime-processor", () => {
     // S16 phase D: the host's render confidentiality ceiling must reach every
     // mount's reconciler — a ceiling configured at initialization that never
     // arrives at the egress surface is silently unbounded rendering.
-
-    const handleVDomMount = (RuntimeProcessor.prototype as any).handleVDomMount;
-    const handleVDomUnmount =
-      (RuntimeProcessor.prototype as any).handleVDomUnmount;
 
     type RootRenderPolicy =
       WorkerReconciler["accessForTestingOnly"]["rootRenderPolicy"];
@@ -5489,35 +5351,25 @@ describe("runtime-processor", () => {
       const commit = await tx.commit();
       expect(commit.ok !== undefined).toBe(true);
 
-      const state = {
-        runtime,
-        // Keyed as the processor keys a mount: by the mounting client's
-        // scoped mount id, which for a call naming no client is the owner's.
-        vdomMounts: new Map<
-          string,
-          { reconciler: unknown; cancel: () => void }
-        >(),
-        vdomBatchIdCounter: 0,
-        renderDeclassificationPolicy: "allow",
-        renderConfidentialityCeiling,
-        handleVDomUnmount,
-      };
+      const state = buildProcessor({ runtime });
+      state.accessForTestingOnly.renderConfidentialityCeiling =
+        renderConfidentialityCeiling as never;
       // handleVDomMount's onOps/onError callbacks post to the worker scope;
       // stub postMessage for the main-thread test.
       const hadPostMessage = "postMessage" in globalThis;
       const originalPostMessage = (globalThis as any).postMessage;
       (globalThis as any).postMessage = () => {};
       try {
-        handleVDomMount.call(state, {
+        state.handleVDomMount({
           type: RequestType.VDomMount,
           mountId: 1,
           cell: cell.getAsNormalizedFullLink() as unknown as CellRef,
         });
-        const mount = state.vdomMounts.get("0 1");
+        const mount = state.accessForTestingOnly.vdomMounts.get("0 1");
         expect(mount).toBeDefined();
         const policy = (mount!.reconciler as WorkerReconciler)
           .accessForTestingOnly.rootRenderPolicy;
-        handleVDomUnmount.call(state, {
+        state.handleVDomUnmount({
           type: RequestType.VDomUnmount,
           mountId: 1,
         });
@@ -5565,24 +5417,22 @@ describe("runtime-processor", () => {
     // processor surfaces that drop as a console.warn carrying the mountId and
     // handlerId so a silently-dropped click is traceable.
 
-    const handleVDomEvent = (RuntimeProcessor.prototype as any).handleVDomEvent;
-
     function makeState(dispatchResult: boolean, calls: unknown[][]) {
-      return {
-        vdomMounts: new Map<string, { reconciler: unknown }>([
-          [
-            "0 7",
-            {
-              reconciler: {
-                dispatchEvent(handlerId: number, event: unknown): boolean {
-                  calls.push([handlerId, event]);
-                  return dispatchResult;
-                },
+      const state = buildProcessor();
+      state.accessForTestingOnly.vdomMounts = new Map([
+        [
+          "0 7",
+          {
+            reconciler: {
+              dispatchEvent(handlerId: number, event: unknown): boolean {
+                calls.push([handlerId, event]);
+                return dispatchResult;
               },
             },
-          ],
-        ]),
-      };
+          },
+        ],
+      ]) as never;
+      return state;
     }
 
     function captureWarn(run: () => void): string[] {
@@ -5603,7 +5453,7 @@ describe("runtime-processor", () => {
       const calls: unknown[][] = [];
       const state = makeState(false, calls);
       const warnings = captureWarn(() =>
-        handleVDomEvent.call(state, {
+        state.handleVDomEvent({
           type: ClientNotificationType.VDomEvent,
           mountId: 7,
           handlerId: 42,
@@ -5621,7 +5471,7 @@ describe("runtime-processor", () => {
       const calls: unknown[][] = [];
       const state = makeState(true, calls);
       const warnings = captureWarn(() =>
-        handleVDomEvent.call(state, {
+        state.handleVDomEvent({
           type: ClientNotificationType.VDomEvent,
           mountId: 7,
           handlerId: 99,
@@ -5637,7 +5487,7 @@ describe("runtime-processor", () => {
       const calls: unknown[][] = [];
       const state = makeState(true, calls);
       const warnings = captureWarn(() =>
-        handleVDomEvent.call(state, {
+        state.handleVDomEvent({
           type: ClientNotificationType.VDomEvent,
           mountId: 404,
           handlerId: 1,
@@ -5659,10 +5509,8 @@ describe("runtime-processor", () => {
     function fakeProcessor() {
       const events: Array<{ handlerId: number; event: unknown }> = [];
       const acks: number[] = [];
-      const processor = Object.create(
-        RuntimeProcessor.prototype,
-      ) as RuntimeProcessor;
-      (processor as unknown as { vdomMounts: unknown }).vdomMounts = new Map([[
+      const processor = buildProcessor();
+      processor.accessForTestingOnly.vdomMounts = new Map([[
         "0 1",
         {
           reconciler: {
@@ -5671,7 +5519,7 @@ describe("runtime-processor", () => {
             acknowledgeBatchApplied: (batchId: number) => acks.push(batchId),
           },
         },
-      ]]);
+      ]]) as never;
       return { processor, events, acks };
     }
 
@@ -5723,7 +5571,7 @@ describe("runtime-processor", () => {
     const processorOver = (
       programs: Record<string, unknown>,
     ): RuntimeProcessor =>
-      ({
+      buildProcessor({
         runtime: {
           scheduler: {
             getGraphSnapshot: () => ({
@@ -5736,10 +5584,10 @@ describe("runtime-processor", () => {
             getPatternProgramBySync: (identity: string) => programs[identity],
           },
         },
-      }) as unknown as RuntimeProcessor;
+      });
 
     const sourcesOf = (processor: RuntimeProcessor) =>
-      RuntimeProcessor.prototype.getPatternSources.call(processor, {
+      processor.getPatternSources({
         type: RequestType.GetPatternSources,
       } as GetPatternSourcesRequest);
 
@@ -5758,7 +5606,7 @@ describe("runtime-processor", () => {
       expect(patterns[0].files.map((file) => file.name)).toEqual([
         "/main.tsx",
         "/data/cities.json",
-      ]);
+      ]) as never;
       // Without this the view cannot tell the lookup table from the module.
       expect(patterns[0].dataFiles).toEqual(["/data/cities.json"]);
     });
@@ -5806,9 +5654,9 @@ describe("runtime-processor", () => {
         getCellFromLink: () => cell,
         storageManager: { open: () => ({ sqliteQuery }) },
       };
-      return Object.assign(Object.create(RuntimeProcessor.prototype), {
+      return buildProcessor({
         runtime,
-      }) as RuntimeProcessor;
+      });
     };
 
     it("queries an unlabeled database through its storage provider", async () => {
@@ -5857,29 +5705,26 @@ describe("runtime-processor", () => {
         getRaw: () => loaded ? db : {},
         asSchema: () => ({ get: () => loaded ? db : undefined }),
       };
-      const processor = Object.assign(
-        Object.create(RuntimeProcessor.prototype),
-        {
-          runtime: {
-            getCellFromLink: () => cell,
-            scheduler: {
-              idleWithPendingCommits: () => {
-                calls.push("commits");
-                committed = true;
-                return Promise.resolve();
-              },
-            },
-            storageManager: {
-              open: () => ({
-                sqliteQuery: () => {
-                  calls.push("query");
-                  return Promise.resolve({ rows: [] });
-                },
-              }),
+      const processor = buildProcessor({
+        runtime: {
+          getCellFromLink: () => cell,
+          scheduler: {
+            idleWithPendingCommits: () => {
+              calls.push("commits");
+              committed = true;
+              return Promise.resolve();
             },
           },
+          storageManager: {
+            open: () => ({
+              sqliteQuery: () => {
+                calls.push("query");
+                return Promise.resolve({ rows: [] });
+              },
+            }),
+          },
         },
-      ) as RuntimeProcessor;
+      });
 
       await processor.handleSqliteQuery({
         type: RequestType.SqliteQuery,
@@ -5960,10 +5805,7 @@ describe("runtime-processor", () => {
             }),
           },
         };
-        const processor = Object.assign(
-          Object.create(RuntimeProcessor.prototype),
-          { runtime },
-        ) as RuntimeProcessor;
+        const processor = buildProcessor({ runtime }) as RuntimeProcessor;
         const bytes = new FabricBytes(new Uint8Array([7, 8, 9]));
 
         await processor.handleSqliteQuery({
@@ -6061,9 +5903,8 @@ describe("runtime-processor", () => {
         { id: "db-1", tables: { notes: {} } },
         () => Promise.resolve({ rows: [] }),
       );
-      (processor as unknown as {
-        runtime: { storageManager: { open(): object } };
-      }).runtime.storageManager.open = () => ({});
+      processor.accessForTestingOnly.runtime.storageManager.open = () =>
+        ({}) as never;
 
       await expect(processor.handleSqliteQuery({
         type: RequestType.SqliteQuery,
@@ -6104,18 +5945,15 @@ describe("runtime-processor", () => {
         getRaw: () => db,
         asSchema: () => ({ get: () => db }),
       };
-      const execProcessor = Object.assign(
-        Object.create(RuntimeProcessor.prototype),
-        {
-          runtime: {
-            getCellFromLink: () => cell,
-            editWithRetry: () => {
-              edited = true;
-              return Promise.resolve({ ok: undefined });
-            },
+      const execProcessor = buildProcessor({
+        runtime: {
+          getCellFromLink: () => cell,
+          editWithRetry: () => {
+            edited = true;
+            return Promise.resolve({ ok: undefined });
           },
         },
-      ) as RuntimeProcessor;
+      });
       await expect(execProcessor.handleSqliteExec({
         type: RequestType.SqliteExec,
         cell: ref,
@@ -6160,10 +5998,7 @@ describe("runtime-processor", () => {
           return Promise.resolve({ ok: undefined });
         },
       };
-      const processor = Object.assign(
-        Object.create(RuntimeProcessor.prototype),
-        { runtime },
-      ) as RuntimeProcessor;
+      const processor = buildProcessor({ runtime }) as RuntimeProcessor;
 
       await processor.handleSqliteExec({
         type: RequestType.SqliteExec,
@@ -6239,10 +6074,7 @@ describe("runtime-processor", () => {
         }
         await storageManager.synced();
 
-        const processor = Object.assign(
-          Object.create(RuntimeProcessor.prototype),
-          { runtime },
-        ) as RuntimeProcessor;
+        const processor = buildProcessor({ runtime }) as RuntimeProcessor;
         const exec = (id: number) =>
           processor.handleSqliteExec({
             type: RequestType.SqliteExec,
@@ -6329,18 +6161,15 @@ describe("runtime-processor", () => {
         }),
       };
       const tx = { id: "transaction" };
-      const processor = Object.assign(
-        Object.create(RuntimeProcessor.prototype),
-        {
-          runtime: {
-            getCellFromLink: () => cell,
-            editWithRetry: (edit: (tx: unknown) => void) => {
-              edit(tx);
-              return Promise.resolve({ ok: undefined });
-            },
+      const processor = buildProcessor({
+        runtime: {
+          getCellFromLink: () => cell,
+          editWithRetry: (edit: (tx: unknown) => void) => {
+            edit(tx);
+            return Promise.resolve({ ok: undefined });
           },
         },
-      ) as RuntimeProcessor;
+      });
 
       await processor.handleSqliteExec({
         type: RequestType.SqliteExec,
@@ -6371,16 +6200,13 @@ describe("runtime-processor", () => {
         asSchema: () => ({ get: () => db }),
         withTx: () => ({ getRaw: () => db, exec: () => {} }),
       };
-      const processor = Object.assign(
-        Object.create(RuntimeProcessor.prototype),
-        {
-          runtime: {
-            getCellFromLink: () => cell,
-            editWithRetry: () =>
-              Promise.resolve({ error: { message: "write refused" } }),
-          },
+      const processor = buildProcessor({
+        runtime: {
+          getCellFromLink: () => cell,
+          editWithRetry: () =>
+            Promise.resolve({ error: { message: "write refused" } }),
         },
-      ) as RuntimeProcessor;
+      });
 
       await expect(processor.handleSqliteExec({
         type: RequestType.SqliteExec,
@@ -6390,13 +6216,10 @@ describe("runtime-processor", () => {
     });
 
     it("routes SQLite requests through the processor dispatch", async () => {
-      const processor = Object.assign(
-        Object.create(RuntimeProcessor.prototype),
-        {
-          handleSqliteQuery: () => Promise.resolve({ rows: [{ value: 1 }] }),
-          handleSqliteExec: () => Promise.resolve(),
-        },
-      ) as RuntimeProcessor;
+      const processor = buildProcessor();
+      processor.handleSqliteQuery = () =>
+        Promise.resolve({ rows: [{ value: 1 }] } as never);
+      processor.handleSqliteExec = () => Promise.resolve();
 
       await expect(processor.handleRequest({
         type: RequestType.SqliteQuery,
@@ -6445,8 +6268,7 @@ describe("runtime-processor", () => {
       function subscriptionHarness() {
         const cancelled: number[] = [];
         const sinks: Array<(value: unknown, cfcLabel: unknown) => void> = [];
-        const processor = {
-          subscriptions: new Map<string, () => void>(),
+        const processor = buildProcessor({
           runtime: {
             getCellFromLink: () => ({
               sink: (
@@ -6457,7 +6279,7 @@ describe("runtime-processor", () => {
               },
             }),
           },
-        } as unknown as RuntimeProcessor;
+        });
         return { processor, sinks, cancelled };
       }
 
@@ -6465,7 +6287,7 @@ describe("runtime-processor", () => {
         processor: RuntimeProcessor,
         client: WorkerClient,
       ) =>
-        RuntimeProcessor.prototype.handleCellSubscribe.call(processor, {
+        processor.handleCellSubscribe({
           type: RequestType.CellSubscribe,
           cell: cellRef,
         }, client);
@@ -6474,7 +6296,7 @@ describe("runtime-processor", () => {
         processor: RuntimeProcessor,
         client: WorkerClient,
       ) =>
-        RuntimeProcessor.prototype.handleCellUnsubscribe.call(processor, {
+        processor.handleCellUnsubscribe({
           type: RequestType.CellUnsubscribe,
           cell: cellRef,
         }, client);
@@ -6529,15 +6351,6 @@ describe("runtime-processor", () => {
     });
 
     describe("VDOM mounts", () => {
-      const handleVDomMount = (RuntimeProcessor.prototype as unknown as {
-        handleVDomMount: (
-          this: unknown,
-          request: unknown,
-          client: WorkerClient,
-        ) => unknown;
-      }).handleVDomMount;
-      const handleVDomUnmount = RuntimeProcessor.prototype.handleVDomUnmount;
-
       async function mountState() {
         const { runtime } = createRuntime();
         const space = cfcSigner.did();
@@ -6552,23 +6365,13 @@ describe("runtime-processor", () => {
         const commit = await tx.commit();
         expect(commit.ok !== undefined).toBe(true);
 
-        const state = {
-          runtime,
-          vdomMounts: new Map<
-            string,
-            { reconciler: unknown; cancel: () => void }
-          >(),
-          vdomBatchIdCounter: 0,
-          renderDeclassificationPolicy: "allow",
-          renderConfidentialityCeiling: undefined,
-          handleVDomUnmount,
-        };
+        const processor = buildProcessor({ runtime });
         const link = cell.getAsNormalizedFullLink() as unknown as CellRef;
-        return { runtime, state, link };
+        return { runtime, processor, link };
       }
 
       it("keeps one client's mount when another mounts under the same mount id", async () => {
-        const { runtime, state, link } = await mountState();
+        const { runtime, processor, link } = await mountState();
         const first = testClient(1);
         const second = testClient(2);
         const hadPostMessage = "postMessage" in globalThis;
@@ -6576,18 +6379,18 @@ describe("runtime-processor", () => {
           (globalThis as { postMessage?: unknown }).postMessage;
         (globalThis as { postMessage?: unknown }).postMessage = () => {};
         try {
-          handleVDomMount.call(state, {
+          processor.handleVDomMount({
             type: RequestType.VDomMount,
             mountId: 1,
             cell: link,
           }, first.client);
-          handleVDomMount.call(state, {
+          processor.handleVDomMount({
             type: RequestType.VDomMount,
             mountId: 1,
             cell: link,
           }, second.client);
 
-          expect(state.vdomMounts.size).toBe(2);
+          expect(processor.accessForTestingOnly.vdomMounts.size).toBe(2);
         } finally {
           await runtime.dispose();
           if (hadPostMessage) {
@@ -6603,27 +6406,29 @@ describe("runtime-processor", () => {
         // Scoping the key changed which mounts collide, not what a collision
         // does: one client re-using its own mount id still replaces what was
         // there, and is left holding one mount rather than two.
-        const { runtime, state, link } = await mountState();
+        const { runtime, processor, link } = await mountState();
         const { client } = testClient(1);
         const hadPostMessage = "postMessage" in globalThis;
         const originalPostMessage =
           (globalThis as { postMessage?: unknown }).postMessage;
         (globalThis as { postMessage?: unknown }).postMessage = () => {};
         try {
-          handleVDomMount.call(state, {
+          processor.handleVDomMount({
             type: RequestType.VDomMount,
             mountId: 1,
             cell: link,
           }, client);
-          const first = state.vdomMounts.get("1 1");
-          handleVDomMount.call(state, {
+          const first = processor.accessForTestingOnly.vdomMounts.get("1 1");
+          processor.handleVDomMount({
             type: RequestType.VDomMount,
             mountId: 1,
             cell: link,
           }, client);
 
-          expect(state.vdomMounts.size).toBe(1);
-          expect(state.vdomMounts.get("1 1")).not.toBe(first);
+          expect(processor.accessForTestingOnly.vdomMounts.size).toBe(1);
+          expect(processor.accessForTestingOnly.vdomMounts.get("1 1")).not.toBe(
+            first,
+          );
         } finally {
           await runtime.dispose();
           if (hadPostMessage) {
@@ -6636,7 +6441,7 @@ describe("runtime-processor", () => {
       });
 
       it("sends each mount's batches to the client that mounted it", async () => {
-        const { runtime, state, link } = await mountState();
+        const { runtime, processor, link } = await mountState();
         const first = testClient(1);
         const second = testClient(2);
         const hadPostMessage = "postMessage" in globalThis;
@@ -6649,12 +6454,12 @@ describe("runtime-processor", () => {
           strayPosts.push(message);
         };
         try {
-          handleVDomMount.call(state, {
+          processor.handleVDomMount({
             type: RequestType.VDomMount,
             mountId: 1,
             cell: link,
           }, first.client);
-          handleVDomMount.call(state, {
+          processor.handleVDomMount({
             type: RequestType.VDomMount,
             mountId: 1,
             cell: link,
@@ -6718,13 +6523,11 @@ describe("runtime-processor", () => {
           },
           unmount: () => {},
         });
-        const processor = Object.create(
-          RuntimeProcessor.prototype,
-        ) as RuntimeProcessor;
-        (processor as unknown as { vdomMounts: unknown }).vdomMounts = new Map([
+        const processor = buildProcessor();
+        processor.accessForTestingOnly.vdomMounts = new Map([
           ["1 1", { reconciler: reconciler("first"), cancel: () => {} }],
           ["2 1", { reconciler: reconciler("second"), cancel: () => {} }],
-        ]);
+        ]) as never;
         return { processor, dispatched, acknowledged };
       }
 
@@ -6758,13 +6561,8 @@ describe("runtime-processor", () => {
 
       function operationState() {
         const cancelled: string[] = [];
-        const processor = Object.create(
-          RuntimeProcessor.prototype,
-        ) as RuntimeProcessor;
-        const state = processor as unknown as {
-          operationSubscriptions: Map<string, unknown>;
-          operationSessions: Map<string, unknown>;
-        };
+        const processor = buildProcessor();
+        const state = processor.accessForTestingOnly;
         state.operationSubscriptions = new Map([
           ["sub-of-first", {
             cancelled: false,
@@ -6776,7 +6574,7 @@ describe("runtime-processor", () => {
         state.operationSessions = new Map([
           ["session-of-first", {
             cellKey: "cell",
-            target: {},
+            target: {} as never,
             subscriptions: new Set(["sub-of-first"]),
             clientId: 1,
           }],
@@ -6835,21 +6633,8 @@ describe("runtime-processor", () => {
       function departureState() {
         const cancelled: string[] = [];
         const unmounted: string[] = [];
-        const processor = Object.create(
-          RuntimeProcessor.prototype,
-        ) as RuntimeProcessor;
-        const state = processor as unknown as {
-          subscriptions: Map<string, () => void>;
-          operationSubscriptions: Map<string, unknown>;
-          operationSessions: Map<string, {
-            cellKey: string;
-            target: unknown;
-            subscriptions: Set<string>;
-            clientId: number;
-          }>;
-          vdomMounts: Map<string, unknown>;
-          runtime: unknown;
-        };
+        const processor = buildProcessor();
+        const state = processor.accessForTestingOnly;
         state.subscriptions = new Map([
           ["1 cell-a", () => cancelled.push("first/cell-a")],
           ["2 cell-a", () => cancelled.push("second/cell-a")],
@@ -6871,13 +6656,13 @@ describe("runtime-processor", () => {
         state.operationSessions = new Map([
           ["session-of-first", {
             cellKey: "cell",
-            target: {},
+            target: {} as never,
             subscriptions: new Set(["op-of-first"]),
             clientId: 1,
           }],
           ["session-of-second", {
             cellKey: "cell",
-            target: {},
+            target: {} as never,
             subscriptions: new Set(["op-of-second"]),
             clientId: 2,
           }],
@@ -6891,12 +6676,12 @@ describe("runtime-processor", () => {
             reconciler: { unmount: () => unmounted.push("second/1") },
             cancel: () => cancelled.push("second/mount-1"),
           }],
-        ]);
+        ]) as never;
         state.runtime = {
           dispose: () => {
             throw new Error("the runtime must outlive a departing client");
           },
-        };
+        } as never;
         return { processor, state, cancelled, unmounted };
       }
 
@@ -6936,7 +6721,7 @@ describe("runtime-processor", () => {
         const { processor, state } = departureState();
         state.operationSessions.set("session-never-used", {
           cellKey: "cell",
-          target: {},
+          target: {} as never,
           subscriptions: new Set<string>(),
           clientId: 1,
         });

--- a/packages/runtime-client/test/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/test/backends/runtime-processor.test.ts
@@ -41,7 +41,6 @@ import {
   Runtime,
   type RuntimeFetch,
   runtimePresets,
-  RuntimeTelemetry,
   type SigilLink,
 } from "@commonfabric/runner";
 import {
@@ -839,15 +838,11 @@ describe("runtime-processor", () => {
     });
 
     it("rejects malformed ACL mutations before opening the space", async () => {
-      // A context that refuses every touch: the handler validates the entry
-      // before it opens the space.
+      // The processor's home space is not the one the requests name, so a
+      // handler that opened the space before validating the entry would
+      // leave a context for it in `spaces`.
       const processor = buildProcessor({
-        cc: new Proxy({}, {
-          get: () => {
-            throw new Error("space must not be opened");
-          },
-        }),
-        space: "did:key:z6Mk-runtime-processor-acl",
+        space: "did:key:z6Mk-runtime-processor-acl-home",
       });
 
       await expect(
@@ -873,6 +868,11 @@ describe("runtime-processor", () => {
           user: "not-a-did",
         }),
       ).rejects.toThrow("user must be `*` or a valid DID");
+      expect(
+        processor.accessForTestingOnly.spaces.has(
+          "did:key:z6Mk-runtime-processor-acl",
+        ),
+      ).toBe(false);
     });
   });
 
@@ -1388,10 +1388,7 @@ describe("runtime-processor", () => {
       it(`${handler}() resolves the piece in the scope the request names`, async () => {
         const { processor, scopes } = makeProcessor();
         await expect(
-          (RuntimeProcessor.prototype as any)[handler].call(processor, {
-            ...request,
-            scope: "user",
-          }),
+          processor[handler]({ ...request, scope: "user" } as never),
         ).rejects.toThrow(REFUSED);
         expect(scopes).toEqual(["user"]);
       });
@@ -1404,7 +1401,7 @@ describe("runtime-processor", () => {
       for (const { handler, request } of cases) {
         const { processor, scopes } = makeProcessor();
         await expect(
-          (RuntimeProcessor.prototype as any)[handler].call(processor, request),
+          processor[handler](request as never),
         ).rejects.toThrow(REFUSED);
         expect(scopes).toEqual([undefined]);
       }
@@ -2138,8 +2135,7 @@ describe("runtime-processor", () => {
         );
       };
       globalThis.fetch = blobFetch as typeof globalThis.fetch;
-      // The constructor performs full runtime initialization; this focused unit
-      // test calls the handler with the fields it reads directly.
+      // A processor over only the fields the handler reads.
       const hostForSpaceCalls: string[] = [];
       const processor = buildProcessor({
         runtime: {
@@ -3688,7 +3684,7 @@ describe("runtime-processor", () => {
         cell.withTx(seed).set([]);
         expect((await seed.commit()).error).toBeUndefined();
 
-        const processor = buildProcessor({ runtime }) as RuntimeProcessor;
+        const processor = buildProcessor({ runtime });
         const append = async (value: { optionId: string }) => {
           const callerFrame = pushFrame({
             runtime,
@@ -3847,7 +3843,7 @@ describe("runtime-processor", () => {
           },
         );
         await cell.sync();
-        const processor = buildProcessor({ runtime }) as RuntimeProcessor;
+        const processor = buildProcessor({ runtime });
         const ref = createCellRef(cell);
 
         const [first, second] = await Promise.all([
@@ -3910,7 +3906,7 @@ describe("runtime-processor", () => {
           required: ["bars"],
           default: initial,
         } as const;
-        const processor = buildProcessor({ runtime }) as RuntimeProcessor;
+        const processor = buildProcessor({ runtime });
         for (const scope of ["user", "session"] as const) {
           const cell = runtime.getCell<typeof initial>(
             space,
@@ -3997,7 +3993,7 @@ describe("runtime-processor", () => {
         expect(alias.get()).toEqual(initial);
         expect(target.asSchema(undefined).getRaw()).toBeUndefined();
 
-        const processor = buildProcessor({ runtime }) as RuntimeProcessor;
+        const processor = buildProcessor({ runtime });
         await expect(processor.handleCellInitialize({
           type: RequestType.CellInitialize,
           cell: createCellRef(alias),
@@ -4035,7 +4031,7 @@ describe("runtime-processor", () => {
           default: { n: 1 },
           scope: "space",
         } as const;
-        const processor = buildProcessor({ runtime }) as RuntimeProcessor;
+        const processor = buildProcessor({ runtime });
 
         for (const existing of [undefined, { n: 7 }] as const) {
           const target = runtime.getCell<{ n: number }>(
@@ -4095,7 +4091,7 @@ describe("runtime-processor", () => {
           required: ["n"],
           default: { n: 1 },
         });
-        const processor = buildProcessor({ runtime }) as RuntimeProcessor;
+        const processor = buildProcessor({ runtime });
 
         await expect(processor.handleCellInitialize({
           type: RequestType.CellInitialize,
@@ -4129,7 +4125,7 @@ describe("runtime-processor", () => {
           `direct-linked-initializer-${crypto.randomUUID()}`,
         );
         await target.sync();
-        const processor = buildProcessor({ runtime }) as RuntimeProcessor;
+        const processor = buildProcessor({ runtime });
         const linkedRef = createCellRef(linked);
 
         const selected = await processor.handleRequest({
@@ -4325,8 +4321,6 @@ describe("runtime-processor", () => {
     }
 
     it("carries a raised flag's metadata through to the response", () => {
-      // No `this` is read, so the handler runs against a bare receiver.
-
       const processor = buildProcessor();
 
       withFlag({ a: 1 }, () => {
@@ -4434,7 +4428,7 @@ describe("runtime-processor", () => {
       // worker strips inbound views at this ingress too (codex/cubic review).
 
       const dispatched: unknown[] = [];
-      const processor = buildProcessor({});
+      const processor = buildProcessor();
       processor.accessForTestingOnly.vdomMounts = new Map([[
         "0 mount-1",
         {
@@ -4738,7 +4732,7 @@ describe("runtime-processor", () => {
                 seq,
                 requestSidecarId,
                 action,
-              ]) as never;
+              ]);
               return Promise.resolve({ resolution: { kind: "dismissed" } });
             },
           },
@@ -4794,7 +4788,7 @@ describe("runtime-processor", () => {
         41,
         sidecarId,
         "dismiss",
-      ]]) as never;
+      ]]);
     });
 
     it("surfaces attention index and sidecar synchronization failures", async () => {
@@ -5221,20 +5215,12 @@ describe("runtime-processor", () => {
           { as: cfcSigner, space: userDid },
           runtime,
         );
-        const ProcessorConstructor = RuntimeProcessor as unknown as new (
-          runtime: Runtime,
-          cc: PiecesController,
-          initSpace: MemorySpace,
-          identity: Identity,
-          telemetry: RuntimeTelemetry,
-        ) => RuntimeProcessor;
-        const processor = new ProcessorConstructor(
+        const processor = buildProcessor({
           runtime,
           cc,
-          userDid,
-          cfcSigner,
-          new RuntimeTelemetry(),
-        );
+          space: userDid,
+          identity: cfcSigner,
+        });
         try {
           processor.watchSiteTable();
           await entriesRegistered;
@@ -5502,9 +5488,8 @@ describe("runtime-processor", () => {
   });
 
   describe("RuntimeProcessor.handleNotification", () => {
-    // Base the fake on the real prototype so handleNotification's delegation to
-    // handleVDomEvent / handleVDomBatchApplied resolves, while vdomMounts is a
-    // stub that records what the reconciler is asked to do.
+    // A real processor whose `vdomMounts` holds a stub that records what the
+    // reconciler is asked to do.
 
     function fakeProcessor() {
       const events: Array<{ handlerId: number; event: unknown }> = [];
@@ -5606,7 +5591,7 @@ describe("runtime-processor", () => {
       expect(patterns[0].files.map((file) => file.name)).toEqual([
         "/main.tsx",
         "/data/cities.json",
-      ]) as never;
+      ]);
       // Without this the view cannot tell the lookup table from the module.
       expect(patterns[0].dataFiles).toEqual(["/data/cities.json"]);
     });
@@ -5805,7 +5790,7 @@ describe("runtime-processor", () => {
             }),
           },
         };
-        const processor = buildProcessor({ runtime }) as RuntimeProcessor;
+        const processor = buildProcessor({ runtime });
         const bytes = new FabricBytes(new Uint8Array([7, 8, 9]));
 
         await processor.handleSqliteQuery({
@@ -5998,7 +5983,7 @@ describe("runtime-processor", () => {
           return Promise.resolve({ ok: undefined });
         },
       };
-      const processor = buildProcessor({ runtime }) as RuntimeProcessor;
+      const processor = buildProcessor({ runtime });
 
       await processor.handleSqliteExec({
         type: RequestType.SqliteExec,
@@ -6074,7 +6059,7 @@ describe("runtime-processor", () => {
         }
         await storageManager.synced();
 
-        const processor = buildProcessor({ runtime }) as RuntimeProcessor;
+        const processor = buildProcessor({ runtime });
         const exec = (id: number) =>
           processor.handleSqliteExec({
             type: RequestType.SqliteExec,

--- a/packages/runtime-client/test/backends/slug-resolve.test.ts
+++ b/packages/runtime-client/test/backends/slug-resolve.test.ts
@@ -22,7 +22,7 @@ import {
 import { rawMetaWriteAuthorization } from "@commonfabric/runner/meta-seam";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 
-import { RuntimeProcessor } from "@/backends/runtime-processor.ts";
+import { buildProcessor } from "./build-processor.ts";
 import { RequestType } from "@/protocol/mod.ts";
 
 const signer = await Identity.fromPassphrase("runtime-client slug resolve");
@@ -67,20 +67,13 @@ describe("handleSlugResolve()", () => {
   }
 
   /** Call the handler over a processor that is nothing but this space. */
-  function resolve(
-    slug: string,
-    member?: string,
-  ): Promise<{ piece: { cell: unknown } }> {
-    const processor = {
-      getSpaceCtx: () => ({ getSpace: () => space }),
+  function resolve(slug: string, member?: string) {
+    const processor = buildProcessor({
+      cc: { getSpace: () => space },
+      space,
       runtime,
-    };
-    return (RuntimeProcessor.prototype as unknown as {
-      handleSlugResolve(
-        this: unknown,
-        request: unknown,
-      ): Promise<{ piece: { cell: unknown } }>;
-    }).handleSlugResolve.call(processor, {
+    });
+    return processor.handleSlugResolve({
       type: RequestType.SlugResolve,
       space,
       slug,
@@ -200,18 +193,17 @@ describe("handleSlugResolve()", () => {
     // or a document that will not decode says nothing about whether the name
     // is bound, and folding it into a refusal would tell a reader "no such
     // member" about a collection nobody managed to read.
-    const processor = {
-      getSpaceCtx: () => ({ getSpace: () => space }),
+    const processor = buildProcessor({
+      cc: { getSpace: () => space },
+      space,
       runtime: {
         getCellFromEntityId: () => {
           throw new Error("the socket went away");
         },
       },
-    };
+    });
     await expect(
-      (RuntimeProcessor.prototype as unknown as {
-        handleSlugResolve(this: unknown, request: unknown): Promise<unknown>;
-      }).handleSlugResolve.call(processor, {
+      processor.handleSlugResolve({
         type: RequestType.SlugResolve,
         space,
         slug: "top",
@@ -225,21 +217,12 @@ describe("handleSlugResolve()", () => {
     // map, and every one of those can be right while the dispatch switch has
     // no arm for it — in which case the worker answers nothing and the shell
     // waits forever. Only driving the dispatcher proves the wiring.
-    const processor = {
-      getSpaceCtx: () => ({ getSpace: () => space }),
+    const processor = buildProcessor({
+      cc: { getSpace: () => space },
+      space,
       runtime,
-      // The dispatch calls the handler through `this`, so the stub carries
-      // the real one: what is under test is which method the arm reaches.
-      handleSlugResolve: (RuntimeProcessor.prototype as unknown as {
-        handleSlugResolve: unknown;
-      }).handleSlugResolve,
-    };
-    const response = await (RuntimeProcessor.prototype as unknown as {
-      handleRequest(
-        this: unknown,
-        request: unknown,
-      ): Promise<{ piece: { cell: unknown }; pathAfter: string[] }>;
-    }).handleRequest.call(processor, {
+    });
+    const response = await processor.handleRequest({
       type: RequestType.SlugResolve,
       space,
       slug: "top",

--- a/packages/runtime-client/test/operation-collaboration.test.ts
+++ b/packages/runtime-client/test/operation-collaboration.test.ts
@@ -7,7 +7,7 @@ import { Identity } from "@commonfabric/identity";
 import type { OperationFieldSnapshot } from "@commonfabric/memory/v2";
 import { Runtime } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { RuntimeProcessor } from "../src/backends/runtime-processor.ts";
+import { buildProcessor } from "./backends/build-processor.ts";
 import type { CellHandle } from "../src/cell-handle.ts";
 import { RuntimeClient } from "../src/runtime-client.ts";
 import {
@@ -333,24 +333,22 @@ describe("RuntimeClient operation collaboration", () => {
       releaseOperationField: () => Promise.resolve(),
       subscribeOperationField: () => Promise.resolve(() => {}),
     };
-    const processor = Object.assign(Object.create(RuntimeProcessor.prototype), {
+    const processor = buildProcessor({
       runtime: operationRuntime(replica),
-    }) as RuntimeProcessor;
+    });
     const cell = {
       space: "did:key:z6Mk-operation-client",
       id: "of:bytes",
       path: [],
     };
 
-    const queried = await RuntimeProcessor.prototype.handleOperationQuery.call(
-      processor,
+    const queried = await processor.handleOperationQuery(
       { type: RequestType.OperationQuery, cell } as never,
     );
     expect(
       (queried.field.materialized as FabricBytes).slice(),
     ).toEqual(new Uint8Array([1, 2, 3]));
-    const applied = await RuntimeProcessor.prototype.handleOperationApply.call(
-      processor,
+    const applied = await processor.handleOperationApply(
       {
         type: RequestType.OperationApply,
         cell,
@@ -396,11 +394,9 @@ describe("RuntimeClient operation collaboration", () => {
         return Promise.resolve(() => cancellations++);
       },
     };
-    const processor = Object.assign(Object.create(RuntimeProcessor.prototype), {
+    const processor = buildProcessor({
       runtime: operationRuntime(replica),
-      operationSubscriptions: new Map(),
-      _isDisposed: false,
-    }) as RuntimeProcessor;
+    });
     const cell = {
       space: "did:key:z6Mk-runtime",
       id: "of:lifecycle",
@@ -533,7 +529,7 @@ describe("RuntimeClient operation collaboration", () => {
     ).toEqual({ value: false });
     expect(cancellations).toBe(2);
 
-    (processor as any)._isDisposed = true;
+    processor.accessForTestingOnly.isDisposed = true;
     expect(
       await processor.handleOperationSubscribe({
         cell,
@@ -542,12 +538,7 @@ describe("RuntimeClient operation collaboration", () => {
     ).toEqual({ value: false });
     expect(cancellations).toBe(3);
 
-    const unsupported = Object.assign(
-      Object.create(RuntimeProcessor.prototype),
-      {
-        runtime: operationRuntime({}),
-      },
-    ) as RuntimeProcessor;
+    const unsupported = buildProcessor({ runtime: operationRuntime({}) });
     await expect(unsupported.handleOperationCapabilities({ cell } as never))
       .rejects.toThrow("does not support");
     await expect(processor.handleOperationCapabilities({
@@ -566,11 +557,9 @@ describe("RuntimeClient operation collaboration", () => {
       subscribeOperationField: () =>
         Promise.reject(new Error("watch installation failed")),
     };
-    const processor = Object.assign(Object.create(RuntimeProcessor.prototype), {
+    const processor = buildProcessor({
       runtime: operationRuntime(capability),
-      operationSubscriptions: new Map(),
-      _isDisposed: false,
-    }) as RuntimeProcessor;
+    });
     const request = {
       cell: {
         space: "did:key:z6Mk-runtime",
@@ -583,8 +572,8 @@ describe("RuntimeClient operation collaboration", () => {
 
     await expect(processor.handleOperationSubscribe(request as never)).rejects
       .toThrow("watch installation failed");
-    expect((processor as any).operationSubscriptions.size).toBe(0);
-    expect((processor as any).operationSessions.size).toBe(0);
+    expect(processor.accessForTestingOnly.operationSubscriptions.size).toBe(0);
+    expect(processor.accessForTestingOnly.operationSessions.size).toBe(0);
   });
 
   it("cancels operation subscriptions during worker disposal", async () => {
@@ -597,18 +586,14 @@ describe("RuntimeClient operation collaboration", () => {
       storageManager: { synced: () => Promise.resolve() },
       dispose: () => Promise.resolve(),
     };
-    const processor = new (RuntimeProcessor as unknown as {
-      new (
-        runtime: unknown,
-        controller: unknown,
-        space: unknown,
-        identity: unknown,
-        telemetry: unknown,
-      ): RuntimeProcessor;
-    })(runtime, {}, "did:key:z6Mk-dispose", {}, telemetry);
-    (processor as any).operationSubscriptions.set(
+    const processor = buildProcessor({
+      runtime,
+      space: "did:key:z6Mk-dispose",
+      telemetry: telemetry as never,
+    });
+    processor.accessForTestingOnly.operationSubscriptions.set(
       "subscription:dispose",
-      { cancelled: false, cancel: () => cancellations++ },
+      { cancelled: false, cancel: () => cancellations++ } as never,
     );
 
     await processor.dispose();
@@ -626,11 +611,9 @@ describe("RuntimeClient operation collaboration", () => {
       releaseOperationField: () => Promise.resolve(),
       subscribeOperationField: () => installed.promise,
     };
-    const processor = Object.assign(Object.create(RuntimeProcessor.prototype), {
+    const processor = buildProcessor({
       runtime: operationRuntime(capability),
-      operationSubscriptions: new Map(),
-      _isDisposed: false,
-    }) as RuntimeProcessor;
+    });
     const request = {
       cell: {
         space: "did:key:z6Mk-runtime",
@@ -648,7 +631,7 @@ describe("RuntimeClient operation collaboration", () => {
 
     await expect(subscribing).resolves.toEqual({ value: false });
     expect(cancellations).toBe(1);
-    expect((processor as any).operationSubscriptions.size).toBe(0);
+    expect(processor.accessForTestingOnly.operationSubscriptions.size).toBe(0);
   });
 
   it("pins one resolved target for an operation session", async () => {
@@ -722,11 +705,9 @@ describe("RuntimeClient operation collaboration", () => {
         open: () => ({ ...capability, replica: capability }),
       },
     };
-    const processor = Object.assign(Object.create(RuntimeProcessor.prototype), {
+    const processor = buildProcessor({
       runtime,
-      operationSubscriptions: new Map(),
-      _isDisposed: false,
-    }) as RuntimeProcessor;
+    });
 
     await processor.handleOperationQuery({
       cell: alias,
@@ -827,10 +808,7 @@ describe("RuntimeClient operation collaboration", () => {
       expect((await tx.commit()).error).toBeUndefined();
       const targetId = target.resolveAsCell().getAsNormalizedFullLink().id;
 
-      const processor = Object.assign(
-        Object.create(RuntimeProcessor.prototype),
-        { runtime },
-      ) as RuntimeProcessor;
+      const processor = buildProcessor({ runtime });
       const field = await processor.handleOperationQuery({
         cell: alias.getAsNormalizedFullLink() as unknown as CellRef,
       } as never);

--- a/packages/runtime-client/test/operation-collaboration.test.ts
+++ b/packages/runtime-client/test/operation-collaboration.test.ts
@@ -7,7 +7,6 @@ import { Identity } from "@commonfabric/identity";
 import type { OperationFieldSnapshot } from "@commonfabric/memory/v2";
 import { Runtime } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { buildProcessor } from "./backends/build-processor.ts";
 import type { CellHandle } from "../src/cell-handle.ts";
 import { RuntimeClient } from "../src/runtime-client.ts";
 import {
@@ -15,6 +14,7 @@ import {
   NotificationType,
   RequestType,
 } from "../src/protocol/mod.ts";
+import { buildProcessor } from "./backends/build-processor.ts";
 
 const operationRuntime = (
   capability: Record<string, unknown>,


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Fable 5.1)

`RuntimeProcessor` was the class the `accessForTestingOnly` series set
aside at its start: twenty-five TypeScript-`private` members under a
note saying `test/backends/runtime-processor.test.ts` drives the class by
calling handlers off `RuntimeProcessor.prototype` against plain-object
stand-ins, the reach `docs/development/DEVELOPMENT.md` § Classes says
wants the test rewritten to build a real instance. `XDebuggerView` had
the same shape and converted that way in #6957, so this PR does the same
here, across the four suites that reach the class.

## The design worth a look

The constructor is private, and `initialize()` builds a processor only
from real initialization data. A test wants a real instance over fakes,
so the class gains a static `accessForTestingOnly` whose one entry,
`construct()`, reaches the constructor typed as the class types it. That
is the step the debugger view did not need, and the one to weigh: it
makes the private constructor reachable from a test, through the getter
whose name says so, rather than through the `RuntimeProcessor as unknown
as new (...)` cast one test already made.

## The instance accessor

- `runtime` with a setter; `cc` and `spaces` as the references.
- `subscriptions`, `operationSubscriptions`, `operationSessions`,
  `pieceSourceConfirmations`, `vdomMounts` with setters, since the
  multi-client tests seed whole maps.
- `isDisposed` and `renderConfidentialityCeiling`: getter and setter each.
- `getSpaceCtx()`, an arrow, for the per-space tests that drive it.

## What the tests do now

`test/backends/build-processor.ts` holds `buildProcessor(parts)`, the one
helper the suites share: it constructs through the static accessor,
declares each stand-in as what the class holds where it is handed over,
and seeds the home space with the supplied `cc`. That seeding is what
replaces the eighteen fakes of `getSpaceCtx` the stand-ins carried: the
real step finds the fake in the `spaces` map.

Every handler is called on a real instance. Every table is read or seeded
through the accessor. A stand-in that the class cannot accept whole (a
mount with only a reconciler, a session with no target) says so with
`as never` where it is assigned. Two tests that fake a public handler for
a dispatch test replace it on the instance, which a public member allows.
The one prototype reach left is the site that replaces the public
`watchSiteTable()` around `initialize()`, which is outside this series.

## Review

Reviewed by a `cf-review` pass: request changes, on one blocking finding
and six improvements, all applied in the second commit. The blocking one:
the malformed-ACL test had seeded a throwing stand-in context, which the
real `#getSpaceCtx()` returns from the map without touching, so the test
no longer pinned that the handler validates before opening the space. It
now builds over a different home space and asserts through the accessor
that the requested space never gains a context. The improvements: the
lazy `??=` on `#operationSessions` and its comment about prototype-built
harnesses were dead once this PR removed those harnesses; the constructor
cast one test still made goes through `buildProcessor()`; the accessor
drops four entries no test reads and the `cc` setter; the scope loop
calls the handler on the instance; three stale comments, three misplaced
casts, and ten redundant ones are gone. Of its nits, the import placement
and the helper's doc comment are taken; the whole-map setters stay, since
the multi-client tests assign whole maps. Its pre-existing debts are
recorded for the series' tidy-up.

## Coverage

The Coverage Check counts the accessor's unread getters and setters as
uncovered lines; the group is six lines over its baseline.

ACCEPT_COVERAGE_DEBT: packages/runtime-client +6 lines

## Gates

`deno fmt --check`, `deno lint`, `deno task check`, and the
`runtime-client` suite (28 passed, 0 failed). No other package names a
converted member.
