### PR TITLE
feat(shuttle): one option grammar for every verb, and `help`

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -2839,6 +2839,7 @@
       },
       "packages/cli": {
         "dependencies": [
+          "jsr:@cliffy/flags@1.0.0-rc.8",
           "jsr:@cliffy/table@1.0.0-rc.8",
           "jsr:@db/sqlite@0.13.0",
           "jsr:@std/fmt@~1.0.2",

--- a/docs/development/DEPENDENCIES.md
+++ b/docs/development/DEPENDENCIES.md
@@ -410,15 +410,23 @@ and inspect the generated HTML before accepting a new release.
 
 ### Cliffy
 
-The CLI uses three declarations that have to remain compatible:
+The CLI uses four declarations that have to remain compatible:
 
 - The root import map pins `@cliffy/command` at `1.0.0-rc.8`.
-- `packages/cli/deno.jsonc` pins `@cliffy/table` at the same release.
+- `packages/cli/deno.jsonc` pins `@cliffy/flags` at the same release. It is
+  `@cliffy/command`'s own option parser, read directly by the shuttle shell so
+  that a shell verb's flags are spelled and refused as a command's are.
+- That CLI config pins `@cliffy/table` at the same release.
 - That CLI config pins `@std/fmt/colors` to the range used by Cliffy.
 
-The two Cliffy packages share internal packages and resolve as a set. They are
-held at the release candidate because Cliffy 1.2.1 changes how a required
-argument followed by a variadic argument is parsed. With that release,
+`@cliffy/command` and `@cliffy/table` share internal packages, and
+`@cliffy/flags` is `@cliffy/command`'s own dependency, so all three resolve as
+a set. A `@cliffy/flags` pinned here to anything but the release
+`@cliffy/command` resolves puts two copies of the option parser in the
+workspace: the one a `cf` command parses through, and the one the shell does.
+
+They are held at the release candidate because Cliffy 1.2.1 changes how a
+required argument followed by a variadic argument is parsed. With that release,
 `cf piece call` stops receiving its first argument.
 
 The `@std/fmt/colors` pin has a separate single-copy requirement.
@@ -427,7 +435,8 @@ different copy from Cliffy, disabling color does not affect Cliffy's version,
 error, and usage output. `packages/cli/test/color-mode.test.ts` guards that
 shared state.
 
-When rolling Cliffy, update `@cliffy/command` and `@cliffy/table` together.
+When rolling Cliffy, update `@cliffy/command`, `@cliffy/flags` and
+`@cliffy/table` together.
 Inspect the new command package's `@std/fmt` dependency and update the CLI alias
 to a compatible range that resolves to the same copy. Refresh the lockfile and
 run the complete CLI test task:

--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -299,6 +299,43 @@ Landed:
   own code. `bin/cfsh` forwards to `cf sh` and carries no checkout logic
   of its own.
 
+- **B1d — the option grammar, and `help`**
+  (`packages/cli/lib/shuttle/options.ts`). What a token after the verb is for.
+  The split says where a token ends; this says whether it is an option or an
+  operand, and the rule is POSIX's: a token opening with `-` is an option up to
+  a bare `--`, `-` on its own is an operand — the previous place and the stdin
+  sentinel — and every token after the `--` is an operand whatever it opens
+  with. The parse is `cf`'s own: `parseFlags` is what `Command` reads a `cf`
+  line's flags through and it takes a bare token array, so a verb mirroring a
+  `cf` command spells and refuses a flag as that command does rather than in a
+  second dialect that has to be kept in step with one — with the two section
+  commands as the bound, `cf piece call` and `cf exec` declaring `stopEarly()`,
+  so a verb mirroring either carries the call section
+  ([`grammar.md`](grammar.md)) rather than this rule. Arity is the same
+  reading's: an entry declares both bounds, and the noun phrase its refusal
+  calls a missing operand by, so the count is applied in one place while each
+  verb keeps its own sentence. A verb that reads a meaning into having no
+  operand declares that instead — `get` reads where it stands and `help` lists
+  the verbs — which is what tells a default apart from too few.
+
+  `--help` is the option the reading puts in front of whatever a verb declared,
+  so no verb can be without one, and it carries the declaration `cf` gives its
+  own — standalone, so a verb whose required options a line has not supplied
+  still answers what it takes. `help` is the verb beside it. The list and the
+  page read the same strings, which sit in the dispatch table beside what
+  running each verb does, so a verb added is a verb `help` lists. Decision 3
+  names help as part of what serves the audience it puts second, and a shell
+  whose only account of itself is the refusal a mistyped word gets serves
+  nobody who does not already know it.
+
+  What the rule costs is one shape, recorded in [`grammar.md`](grammar.md)
+  beside the readings it joins: a key whose name opens with `-` is not reached
+  by that name standing alone, so a listing prints the reference that names it,
+  exactly as it does for a key called `..`. The typed spelling stays open —
+  `cd -- -x` reaches such a key — and what a listing owes is the name rather
+  than the route. `operandForChild` asks the option grammar rather than making
+  the move, that reading being one layer above a place.
+
 Still to come:
 
 - **Liveness, in two halves.** Recovery of an *established* connection needs

--- a/docs/plans/shuttle/grammar.md
+++ b/docs/plans/shuttle/grammar.md
@@ -107,6 +107,69 @@ start carrying which parts of a token were quoted, which grows the value it
 returns rather than adding a layer over it, and every reading that consults
 quoting reads that value.
 
+## Options and operands
+
+The split says where a token ends; what a token is *for* is the second
+reading, and it is POSIX's too. After the verb, **a token opening with `-` is
+an option up to a bare `--`, and every other token is an operand**, the options
+being the table that verb declares. Two tokens the rule turns on are the two
+this grammar already spends the character on:
+
+- **`-` on its own is an operand** — `cd`'s previous place and `set`'s stdin
+  sentinel — so the one reading that would make it a flag is the one it does
+  not get.
+- **A bare `--` ends the options.** Every token after the first one is an
+  operand whatever it opens with, and that first `--` is neither an option nor
+  an operand. So a key called `-x` is reached by `cd -- -x`, and one called
+  `--` by `cd -- --`.
+
+Options may sit anywhere among the operands, which is what a `cf` command
+reads unless it declares a section: `cf piece call` and `cf exec` are
+`stopEarly()`, and everything past their first operand belongs to the callable.
+So the line shape at the top of this document says where options usually go
+rather than where they must, and a shuttle verb mirroring either of those two
+carries the call section below rather than this rule.
+
+How many operands a verb takes is part of the same table. A verb declares both
+bounds, and the noun phrase its refusal calls a missing operand by, and the
+reading that divides the line enforces them: the count is applied in one place
+while the wording stays each verb's own — `cd` says it takes a place to move
+to where `wish` says it takes the target to resolve. A verb that takes an
+operand it can do without declares that too, since what it does with none is a
+reading of its own rather than a line for the dispatch to answer: `get` reads
+where it stands, and `help` lists the verbs.
+
+The parse is `cf`'s own: `parseFlags` (`@cliffy/flags`) is what `Command`
+reads a `cf` line's flags through, and it reads a bare token array, so a flag
+is spelled, defaulted and refused here exactly as the same flag is on a `cf`
+command line. That is what keeps decision 7's "data verbs are exactly the
+`cf` ones" true of the flags as well as of the words — `--select` here is
+`--select` there, and a misspelling gets the sentence `cf` gives it, with one
+naming the verb's own page after it.
+
+**`--help` is an option every verb takes**, put in front of whatever a verb
+declares rather than declared by each, so a verb has no way to be without one;
+a line carrying it writes that verb's page instead of running the verb. It
+carries the declaration `cf` gives its own, standalone included, so a verb
+whose required options a line has not supplied still answers what it takes —
+and `--help` written beside another option is refused rather than answered,
+exactly as on a `cf` line. `help`
+is the verb beside it: `help` lists every verb with its one-line summary, and
+`help <verb>` writes the page `<verb> --help` writes. Decision 3 puts
+teammates second and names help as part of what serves them, and a shell whose
+only account of itself is the refusal a mistyped word gets serves nobody who
+does not already know it.
+
+The option reading costs a listing one shape, and it is the shape the quoting
+ruling above already costs one of. Every name a listing prints is one `cd`
+takes back, and a name opening with `-` is read as an option when it stands as
+a token of its own, so such a key is offered as the reference that names it
+rather than as itself — the answer a key called `..` gets, for the same reason
+one layer up. What a listing offers and what can be typed are two questions:
+`cd -- -x` reaches that key and `cd -- --` reaches one called `--`, a bare `--`
+ending the options, and what a listing prints is the name rather than the
+route.
+
 ## Place resolution
 
 A reference on the line resolves against the place, right-anchored, exactly
@@ -320,9 +383,9 @@ that implied completeness would be false.
 it has no name for prints none at all. Most rows print their own name,
 written as a token by the rule above — a slug, a handle and an ordinary key
 each print as themselves. A row whose name's own characters are readings —
-a key called `..` or `-`, one holding the separator, one beginning with `@` —
-prints the reference that names it instead, which reads none of them and
-unescapes `~1`.
+a key called `..` or `-`, one holding the separator, one beginning with `@` or
+with `-` — prints the reference that names it instead, which reads none of
+them and unescapes `~1`.
 
 The name is the first thing on its line, and the whole of it where the row
 has nothing else to report. What a reader copies off the front is therefore

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -122,20 +122,29 @@ shuttle serves one space for its whole run, and shortens nothing else. `pwd` is
 the complete address — every level, the scope written even when it is the base —
 which is what to copy.
 
-| Verb           | What it does                                                                                                                                      |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `cd <ref>`     | Moves the place. Takes relative segments, `..`, `-`, `/`, a scope-only `@scope`, rooted and complete references, slugs, and `#name` entry points. |
-| `ls`           | Lists what stands where you are: a space root's facets, the slugs the index records, the space's pieces, or the keys under a cell.                |
-| `pwd`          | The complete address of the place, both dimensions.                                                                                               |
-| `get [<ref>]`  | Reads the value at a cell, defaulting to where you stand. A trailing `#argument` reads the piece's arguments cell.                                |
-| `wish <#name>` | Resolves a named entry point, exactly as `cf wish` does.                                                                                          |
-| `where`        | The whole ambient record: the connection, and the place `pwd` prints.                                                                             |
+| Verb            | What it does                                                                                                                                      |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `cd <ref>`      | Moves the place. Takes relative segments, `..`, `-`, `/`, a scope-only `@scope`, rooted and complete references, slugs, and `#name` entry points. |
+| `ls`            | Lists what stands where you are: a space root's facets, the slugs the index records, the space's pieces, or the keys under a cell.                |
+| `pwd`           | The complete address of the place, both dimensions.                                                                                               |
+| `get [<ref>]`   | Reads the value at a cell, defaulting to where you stand. A trailing `#argument` reads the piece's arguments cell.                                |
+| `wish <#name>`  | Resolves a named entry point, exactly as `cf wish` does.                                                                                          |
+| `where`         | The whole ambient record: the connection, and the place `pwd` prints.                                                                             |
+| `help [<verb>]` | Lists the verbs, or writes one verb's page. `<verb> --help` writes the same page.                                                                 |
 
 A line is split POSIX-style — whitespace separates, quotes group — so a value
 holding a space is one operand when it is quoted, and anything shuttle prints as
 an operand is quoted where it has to be. Every refusal carries its reason. A
 read that failed is different: it is reported and the prompt reads the next
 line, since a shell whose server went away is still a shell.
+
+After the split, a token opening with `-` is an option up to a bare `--`, and
+every other token is an operand. `-` on its own stays an operand, being the
+previous place and the stdin sentinel, and a bare `--` ends the options, so a
+key called `-x` is reached by `cd -- -x` or by the reference a listing prints
+for it. The parse is `cf`'s own — the one a `cf` command reads its flags through
+— so a flag is spelled and refused here as it is on a `cf` command line, and
+`--help` is the option every verb takes.
 
 The line editor is `lib/view`'s `EditBuffer` over its own key decoder, bound to
 Emacs keys: `ctrl-a`/`ctrl-e` and `home`/`end` for the ends of the line,
@@ -148,9 +157,11 @@ line, and `ctrl-d` on an empty line to end the session.
 The code is `lib/shuttle/`: `run.ts` composes a session, `place.ts` holds the
 place and what `cd` refuses, `connection.ts` the one `PiecesController` a
 process holds, `line.ts` the split and the printing that inverts it,
-`listing.ts` what `ls` reads, `verbs.ts` the dispatch — which writes nothing —
-`prompt.ts` the loop that does, `record.ts` the form `where` and `pwd` share,
-and `paint.ts` and `terminal.ts` the escape sequences and the raw mode under it.
+`options.ts` the option grammar over the tokens after a verb, `listing.ts` what
+`ls` reads, `verbs.ts` the dispatch — which writes nothing — `help.ts` the form
+a verb's account of itself prints in, `prompt.ts` the loop that writes,
+`record.ts` the form `where` and `pwd` share, and `paint.ts` and `terminal.ts`
+the escape sequences and the raw mode under it.
 
 ## Cell references
 

--- a/packages/cli/commands/sh.ts
+++ b/packages/cli/commands/sh.ts
@@ -53,7 +53,8 @@ Shuttle holds one connection and one place — the space, piece and path its
 prompt shows — and reads lines against them: cd, ls, pwd, get, wish, and
 where, which prints the whole ambient record. The place fills in what a
 reference leaves out, so a line names what it acts on rather than repeating
-the address.
+the address. Type help at the prompt for the verbs, and <verb> --help for what
+one of them takes.
 
 The connection is fixed for the run: one shuttle serves one space, and
 restarting is how to reach another.`),

--- a/packages/cli/deno.jsonc
+++ b/packages/cli/deno.jsonc
@@ -19,6 +19,7 @@
   "imports": {
     // Dependency guide: ../../docs/development/DEPENDENCIES.md
     // Cliffy and @std/fmt/colors roll as one set; see "Cliffy" there.
+    "@cliffy/flags": "jsr:@cliffy/flags@1.0.0-rc.8",
     "@cliffy/table": "jsr:@cliffy/table@1.0.0-rc.8",
     "@node/child_process": "node:child_process",
     "@std/fmt/colors": "jsr:@std/fmt@~1.0.2/colors",

--- a/packages/cli/lib/shuttle/help.ts
+++ b/packages/cli/lib/shuttle/help.ts
@@ -1,0 +1,68 @@
+/**
+ * How the verbs are written down: the one line `help` lists a verb on, and the
+ * page `<verb> --help` writes.
+ *
+ * A shell whose only account of itself is the refusal a mistyped word gets
+ * serves the person who already knows it and nobody else, which is why the
+ * text a verb carries is part of the verb rather than something a document
+ * elsewhere has to be kept in step with. What each verb says is `verbs.ts`'s;
+ * how it is laid out is here, so the list and the page agree about a verb's
+ * one-line summary by reading the same string.
+ */
+
+/**
+ * The column a summary starts at, past the longest usage in `verbs`, so that
+ * every summary in a list begins in the same place and a reader runs their eye
+ * down them.
+ */
+const SUMMARY_GAP = 2;
+
+/**
+ * What the options block writes, which is the option every verb takes. It is
+ * every verb's because `readOptions` (`options.ts`) puts it in front of
+ * whatever a verb declared, rather than each verb offering one.
+ */
+const OPTIONS_BLOCK = "Options:\n  -h, --help   Write this page instead of " +
+  "running the verb.";
+
+/** What `help` says about one verb. */
+export interface VerbHelp {
+  /** The verb and its operands as one line, which opens the verb's page. */
+  readonly usage: string;
+
+  /** What the verb does, in the one line `help` lists it by. */
+  readonly summary: string;
+
+  /** What the verb's page says past the summary. */
+  readonly detail: string;
+}
+
+/**
+ * Returns `verbs` written as `help` lists them: one to a line, its usage
+ * first and its summary in a column past the longest of them, with no
+ * trailing break.
+ *
+ * The closing line names the option that says more, which is the whole of
+ * what the list can carry about a verb it gives one line to.
+ */
+export function renderVerbList(verbs: readonly VerbHelp[]): string {
+  const column = Math.max(...verbs.map((verb) => verb.usage.length)) +
+    SUMMARY_GAP;
+  const lines = verbs.map((verb) =>
+    `${verb.usage.padEnd(column)}${verb.summary}`
+  );
+  return `${lines.join("\n")}\n\n\`<verb> --help\` says more about one verb.`;
+}
+
+/**
+ * Returns the page `verb` writes for `<verb> --help`: what the verb and its
+ * operands are written as, what it does, what it does with them, and the
+ * option every verb takes, with no trailing break.
+ *
+ * The options block is a constant, so what it lists is that one option and
+ * nothing a verb declared of its own.
+ */
+export function renderVerbPage(verb: VerbHelp): string {
+  return `Usage: ${verb.usage}\n\n${verb.summary}\n\n${verb.detail}\n\n` +
+    OPTIONS_BLOCK;
+}

--- a/packages/cli/lib/shuttle/options.ts
+++ b/packages/cli/lib/shuttle/options.ts
@@ -1,0 +1,126 @@
+/**
+ * How the tokens after a verb divide into options and operands, and the
+ * `--help` every verb takes.
+ *
+ * `line.ts` says where a token ends; this says what a token is for. A token
+ * opening with `-` is an option up to a bare `--`, and every other token is an
+ * operand — the rule a shell already has, and the rule `cf` reads its own
+ * flags by, since the parse here is `parseFlags` (`@cliffy/flags`), which
+ * `Command` calls to read the flags on a `cf` line. A verb's options are
+ * therefore spelled, defaulted and refused exactly as the same flag is on a
+ * `cf` command line, rather than in a second dialect that would have to be
+ * kept in step with one.
+ *
+ * Two tokens the rule turns on are the two a shell already spends the
+ * character on. `-` alone is an operand — `cd`'s previous place and the stdin
+ * sentinel — and a bare `--` ends the options, so every token after it is an
+ * operand whatever it opens with. Neither is this module's addition: the
+ * parser reads both that way, and {@link readsAsOption} is the same rule
+ * written as a predicate for the one caller that has to ask without parsing.
+ *
+ * `--help` is added to every table here rather than declared by each verb,
+ * which is what makes it an option every verb takes rather than one each verb
+ * remembered to offer.
+ */
+
+import { type FlagOptions, parseFlags, ValidationError } from "@cliffy/flags";
+
+/**
+ * The option every verb takes, declared as `cf` declares its own: the
+ * `-h, --help` spelling, and standalone.
+ *
+ * It is held here rather than by a verb because it is every verb's:
+ * {@link readOptions} puts it in front of whatever the verb declared, so a
+ * verb has no way to be without it.
+ *
+ * Standalone is what makes the page reachable from a verb whose table the line
+ * does not satisfy. A required option the line leaves out refuses the whole
+ * parse, and somebody asking what a verb takes has by definition not supplied
+ * it yet, so the one line that would answer them is the line the table would
+ * otherwise turn down. What it costs is that `--help` written beside another
+ * option is refused rather than answered — which is what the same line gets
+ * from `cf`, whose help option is standalone for this reason.
+ */
+const HELP_OPTION: FlagOptions = {
+  name: "help",
+  aliases: ["h"],
+  standalone: true,
+};
+
+/** What one option a verb declares looks like, which is what `cf` declares. */
+export type VerbOption = FlagOptions;
+
+/** What reading a verb's tokens produced. */
+export type OptionReading =
+  /** The line asked for the verb's help page and said nothing else. */
+  | { readonly kind: "help" }
+  /** The options the line set, by name, and the operands after them. */
+  | {
+    readonly kind: "read";
+    readonly options: Readonly<Record<string, unknown>>;
+    readonly operands: readonly string[];
+  }
+  /** The line is refused, for the reason given. */
+  | { readonly kind: "refused"; readonly reason: string };
+
+/**
+ * Divides `tokens` into the options `declared` names and the operands after
+ * them, for the verb called `verb`, or refuses them with the reason.
+ *
+ * `--help` is read whether or not `declared` names it, and whether or not the
+ * line supplies what `declared` requires, and it takes the whole reading: what
+ * comes back says the page was asked for and carries no operands to act on.
+ * Anything else that parses comes back as the options by name and
+ * the operands in the order they were written, with the bare `--` taken off
+ * and every token after it an operand.
+ *
+ * A refusal is the parser's own sentence, which is the sentence the same flag
+ * gets on a `cf` command line, plus one naming the verb's page. What the
+ * parser refuses is what `cf` refuses: an option nothing declared, one written
+ * as no option can be, a value missing from an option that takes one, and a
+ * value given to one that does not.
+ *
+ * @throws Whatever the parser throws that is not a refusal of the line — a
+ * table naming a type nothing registered, which is a fault in the verb rather
+ * than in what was typed.
+ */
+export function readOptions(
+  verb: string,
+  tokens: readonly string[],
+  declared: readonly VerbOption[] = [],
+): OptionReading {
+  let parsed;
+  try {
+    parsed = parseFlags([...tokens], { flags: [HELP_OPTION, ...declared] });
+  } catch (thrown) {
+    if (!(thrown instanceof ValidationError)) throw thrown;
+    return {
+      kind: "refused",
+      reason: `${thrown.message} \`${verb} --help\` says what \`${verb}\` ` +
+        `takes.`,
+    };
+  }
+  if (parsed.flags.help === true) return { kind: "help" };
+  return {
+    kind: "read",
+    options: parsed.flags,
+    // The two arrays are the operands before the bare `--` and the ones after
+    // it, and nothing after it can be written before one before it, so joining
+    // them keeps the order the line was written in.
+    operands: [...parsed.unknown, ...parsed.literal],
+  };
+}
+
+/**
+ * Whether {@link readOptions} reads `token` as an option rather than as an
+ * operand: it opens with `-` and is longer than that one character.
+ *
+ * The predicate exists for a caller that has to know without parsing —
+ * `operandForChild` (`place.ts`), which offers a name as the token `cd` takes
+ * and may offer none this would eat. It answers about one token in isolation,
+ * so it says nothing about a token standing after a bare `--`, which is an
+ * operand whatever it opens with.
+ */
+export function readsAsOption(token: string): boolean {
+  return token.startsWith("-") && token !== "-";
+}

--- a/packages/cli/lib/shuttle/place.ts
+++ b/packages/cli/lib/shuttle/place.ts
@@ -29,6 +29,7 @@ import {
   normalizeLLMFriendlyRef,
   validatePieceSegment,
 } from "../llm-friendly-ref.ts";
+import { readsAsOption } from "./options.ts";
 import { type RecordEntry, renderRecord } from "./record.ts";
 
 /** One segment of a path inside a piece, in the form cell traversal takes. */
@@ -285,6 +286,11 @@ export function placeAtSpaceRoot(space: MemorySpace): Place {
  * in one direction only: `-` is never offered, even where shuttle's own
  * history would make it reach the child, and what is offered reaches the child
  * whatever that history holds.
+ *
+ * One reading is asked rather than made, being one layer above a place: a
+ * token opening with `-` reaches a verb as an option and never as an operand
+ * (`readsAsOption`, `options.ts`), so a candidate the option grammar takes is
+ * not offered and the reference is what names such a child.
  */
 export function operandForChild(
   place: Place,
@@ -295,6 +301,7 @@ export function operandForChild(
   const goal: Place = { ...place, position };
   const from: Standing = { place, trail: [] };
   for (const candidate of [child, renderPosition(goal)]) {
+    if (readsAsOption(candidate)) continue;
     const step = movePlace(from, candidate);
     if (step.kind === "moved" && samePlace(step.to.place, goal)) {
       return candidate;

--- a/packages/cli/lib/shuttle/verbs.ts
+++ b/packages/cli/lib/shuttle/verbs.ts
@@ -32,8 +32,10 @@ import { normalizeLLMFriendlyRef } from "../llm-friendly-ref.ts";
 import { getCellValue, type PieceConfig, type SpaceConfig } from "../piece.ts";
 import { projectWishValue, readWish } from "../wish.ts";
 import { connectionEntries, type HeldConnection } from "./connection.ts";
+import { renderVerbList, renderVerbPage, type VerbHelp } from "./help.ts";
 import { splitLine } from "./line.ts";
 import { type ListingDeps, listPlace, renderListing } from "./listing.ts";
+import { readOptions } from "./options.ts";
 import {
   CurrentPlace,
   type FacetPosition,
@@ -99,16 +101,24 @@ export interface VerbDeps {
 /**
  * Runs `line` against `shuttle` and returns what that did.
  *
- * The line splits by `splitLine`, its first token names a verb, and the rest
- * are that verb's operands. A line with no token at all did nothing; one whose
- * first token names no verb is refused, and the refusal names it and lists
- * what would have been taken.
+ * The line splits by `splitLine`, its first token names a verb, and the tokens
+ * after it are divided by `readOptions`: one opening with `-` is an option up
+ * to a bare `--`, and every other one is an operand the verb reads. A line
+ * with no token at all did nothing; one whose first token names no verb is
+ * refused, and the refusal names it and lists what would have been taken.
  *
- * A refusal is a fact about the line — a verb nobody defined, an operand a
- * place will not take, a target that resolves elsewhere — and every one
- * carries the reason. A read that failed is a different fact and is not one
- * of these: it raises, so that a server that cannot be reached is told apart
- * from a line that was wrong.
+ * `--help` is an option every verb takes, and a line carrying it writes that
+ * verb's page instead of running it, which is the same page `help <verb>`
+ * writes.
+ *
+ * How many operands a verb takes is the table's too, so the count is held
+ * here and no verb states one of its own.
+ *
+ * A refusal is a fact about the line — a verb nobody defined, an option nobody
+ * declared, an operand a place will not take, a target that resolves elsewhere
+ * — and every one carries the reason. A read that failed is a different fact
+ * and is not one of these: it raises, so that a server that cannot be reached
+ * is told apart from a line that was wrong.
  *
  * @throws Whatever a read throws — an unreachable server, an identity that
  * will not load, a path the piece refuses.
@@ -120,16 +130,44 @@ export async function runLine(
 ): Promise<Outcome> {
   const split = splitLine(line);
   if (split.kind === "refused") return refuse(split.reason);
-  const [word, ...operands] = split.tokens;
+  const [word, ...tokens] = split.tokens;
   if (word === undefined) return { kind: "nothing" };
-  const verb = VERBS.get(word);
-  if (verb === undefined) {
-    return refuse(
-      `\`${word}\` is not a verb. The verbs are ${listed([...VERBS.keys()])}.`,
-    );
+  const entry = VERBS.get(word);
+  if (entry === undefined) return refuse(notAVerb(word));
+  const reading = readOptions(word, tokens);
+  switch (reading.kind) {
+    case "refused":
+      return reading;
+    case "help":
+      return { kind: "text", text: renderVerbPage(entry) };
+    case "read": {
+      const wrong = wrongOperandCount(word, entry.arity, reading.operands);
+      return wrong ?? await entry.run(shuttle, reading.operands, deps);
+    }
   }
-  return await verb(shuttle, operands, deps);
 }
+
+/**
+ * How many operands a verb takes, and what one that needs an operand calls the
+ * one it needs.
+ *
+ * The noun phrase rides the arity because the refusal for a missing operand is
+ * the verb's own sentence and the count is the dispatch's rule: declaring them
+ * together is what lets one reader enforce every verb's arity without every
+ * verb's refusal collapsing into one wording.
+ *
+ * Taking no operand and taking an optional one are told apart by what a verb
+ * does with none, which is why `optional` is an arm rather than the absence of
+ * one: `get` reads where it stands and `help` lists the verbs, and neither is
+ * a verb that was given too few.
+ */
+type Arity =
+  /** No operand at all, so any is too many. */
+  | { readonly operands: "none" }
+  /** One at most, and what no operand means is the verb's own. */
+  | { readonly operands: "optional" }
+  /** One, needed, `names` being what the refusal for none calls it. */
+  | { readonly operands: "required"; readonly names: string };
 
 /** What a verb does with the operands written after its name. */
 type Verb = (
@@ -137,6 +175,22 @@ type Verb = (
   operands: readonly string[],
   deps: VerbDeps,
 ) => Outcome | Promise<Outcome>;
+
+/**
+ * One verb: what running it does, how many operands it takes, and what `help`
+ * says about it.
+ */
+interface VerbEntry extends VerbHelp {
+  /** Runs the verb over the operands its line carried. */
+  readonly run: Verb;
+
+  /**
+   * How many operands the verb takes, which the dispatch holds it to before
+   * running it. A verb declares this and counts nothing itself, so one added
+   * to the table is one whose operands are already counted at both ends.
+   */
+  readonly arity: Arity;
+}
 
 /**
  * Moves the place as `operands` say, and returns where shuttle now stands.
@@ -151,12 +205,11 @@ async function cd(
   operands: readonly string[],
   deps: VerbDeps,
 ): Promise<Outcome> {
-  const tooMany = takesAtMostOne("cd", operands);
-  if (tooMany !== undefined) return tooMany;
-  // The empty operand rather than a refusal of this module's own: `cd` with
-  // nothing after it and `cd ''` are one operand by the time a place reads
-  // them, and the place says what it takes.
-  return await landing(shuttle, shuttle.place.cd(operands[0] ?? ""), deps);
+  // `cd ''` is one operand, so the dispatch passes it on and the place is what
+  // answers it — in the sentence the dispatch composes for no operand at all,
+  // so the two spellings read alike. That guard is `movePlace`'s own and
+  // stands for the callers this one is not.
+  return await landing(shuttle, shuttle.place.cd(operands[0]), deps);
 }
 
 /**
@@ -176,8 +229,6 @@ async function get(
   operands: readonly string[],
   deps: VerbDeps,
 ): Promise<Outcome> {
-  const tooMany = takesAtMostOne("get", operands);
-  if (tooMany !== undefined) return tooMany;
   const operand = operands[0];
   if (operand === undefined) {
     return await read(shuttle, shuttle.place.place, false, deps);
@@ -189,14 +240,32 @@ async function get(
     : await read(shuttle, at.place, aim.input, deps);
 }
 
+/**
+ * Lists the verbs, or writes the page of the one `operands` names.
+ *
+ * The list and the page read the same strings — each verb's own, held beside
+ * what it does — so a verb's one-line summary is one string wherever it is
+ * shown. A word that names no verb is refused in the sentence the dispatch
+ * refuses one in: `help` is where a person goes when they are unsure what the
+ * words are, so it is the door most likely to be given one that is not.
+ */
+function help(_shuttle: Shuttle, operands: readonly string[]): Outcome {
+  const word = operands[0];
+  if (word === undefined) {
+    return { kind: "text", text: renderVerbList([...VERBS.values()]) };
+  }
+  const entry = VERBS.get(word);
+  return entry === undefined
+    ? refuse(notAVerb(word))
+    : { kind: "text", text: renderVerbPage(entry) };
+}
+
 /** Lists what stands where shuttle stands. */
 async function ls(
   shuttle: Shuttle,
-  operands: readonly string[],
+  _operands: readonly string[],
   deps: VerbDeps,
 ): Promise<Outcome> {
-  const tooMany = takesNothing("ls", operands);
-  if (tooMany !== undefined) return tooMany;
   const listing = await listPlace(
     shuttle.config,
     shuttle.place.place,
@@ -207,9 +276,8 @@ async function ls(
 }
 
 /** Returns where shuttle stands, both halves of the pair. */
-function pwd(shuttle: Shuttle, operands: readonly string[]): Outcome {
-  const tooMany = takesNothing("pwd", operands);
-  return tooMany ?? { kind: "text", text: shuttle.place.render() };
+function pwd(shuttle: Shuttle): Outcome {
+  return { kind: "text", text: shuttle.place.render() };
 }
 
 /**
@@ -225,14 +293,7 @@ async function wish(
   operands: readonly string[],
   deps: VerbDeps,
 ): Promise<Outcome> {
-  const tooMany = takesAtMostOne("wish", operands);
-  if (tooMany !== undefined) return tooMany;
   const target = operands[0];
-  if (target === undefined) {
-    return refuse(
-      "`wish` takes the target to resolve, as in `wish #favorites`.",
-    );
-  }
   const { result, error } = await (deps.readWish ?? readWish)({
     ...shuttle.config,
     query: target,
@@ -260,9 +321,8 @@ async function wish(
  * launched as and where it stands — which is what a verb for saying where you
  * are should do.
  */
-function where(shuttle: Shuttle, operands: readonly string[]): Outcome {
-  const tooMany = takesNothing("where", operands);
-  return tooMany ?? {
+function where(shuttle: Shuttle): Outcome {
+  return {
     kind: "text",
     text: renderRecord([
       ...connectionEntries(shuttle.config),
@@ -273,7 +333,14 @@ function where(shuttle: Shuttle, operands: readonly string[]): Outcome {
 
 /**
  * The verbs, by the word that names one. It is the one record of what a line
- * may say, so the refusal listing them lists exactly what the dispatch takes.
+ * may say, so the refusal listing them lists exactly what the dispatch takes,
+ * and `help` lists exactly the same set from the same entries.
+ *
+ * Each entry carries how many operands the verb takes, and what `help` says
+ * about it, beside what running it does. So the three cannot drift: a verb
+ * added here is a verb `help` lists and a verb the dispatch already refuses
+ * too many operands for, and one whose behavior changes has its account of
+ * itself in the same place.
  *
  * A `Map` rather than an object, because an object answers for every key
  * `Object.prototype` carries as well as for its own: `toString` and
@@ -282,13 +349,85 @@ function where(shuttle: Shuttle, operands: readonly string[]): Outcome {
  * holds what was put in it and nothing else, so the word that names no verb
  * has no answer to give rather than one that has to be guarded against.
  */
-const VERBS: ReadonlyMap<string, Verb> = new Map<string, Verb>([
-  ["cd", cd],
-  ["get", get],
-  ["ls", ls],
-  ["pwd", pwd],
-  ["where", where],
-  ["wish", wish],
+const VERBS: ReadonlyMap<string, VerbEntry> = new Map<string, VerbEntry>([
+  ["cd", {
+    run: cd,
+    arity: { operands: "required", names: "a place to move to" },
+    usage: "cd <ref>",
+    summary: "Moves the place, which fills in what a reference omits.",
+    detail:
+      "The operand is a relative segment, `..` for one level up, `-` for " +
+      "the\nprevious place, `/` for the space root, a scope-only `@scope`, " +
+      "a rooted\nor complete reference, a slug, or a `#name` entry " +
+      "point.\n\nA target carrying `#argument` is refused: a place roots at " +
+      "a result, and\n`get <ref>#argument` is how an operand reads a " +
+      "piece's arguments cell.",
+  }],
+  ["get", {
+    run: get,
+    arity: { operands: "optional" },
+    usage: "get [<ref>]",
+    summary: "Reads the value at a cell, defaulting to where you stand.",
+    detail: "The operand takes everything `cd` takes, plus the `#argument` " +
+      "suffix\n`cd` turns down, which reads the piece's arguments cell " +
+      "rather than its\nresult. A `#name` entry point is the one spelling " +
+      "it does not take,\n`wish` being the verb that reads one.\n\nA space " +
+      "root and a facet hold no value of their own and are refused;\n`ls` " +
+      "lists what stands inside them.",
+  }],
+  ["help", {
+    run: help,
+    arity: { operands: "optional" },
+    usage: "help [<verb>]",
+    summary: "Lists the verbs, or writes the page of the one named.",
+    detail: "`<verb> --help` writes the same page, and every verb takes that " +
+      "option.",
+  }],
+  ["ls", {
+    run: ls,
+    arity: { operands: "none" },
+    usage: "ls",
+    summary: "Lists what stands where shuttle stands.",
+    detail: "A space root lists its facets, `slugs/` the names the space's " +
+      "index\nrecords, `pieces/` the space's pieces, and a cell the keys " +
+      "directly\nunder it. A row that failed on its own account is still a " +
+      "row and\ncarries what went wrong, where a read that failed outright " +
+      "is no\nlisting at all and is reported as the failure it is.",
+  }],
+  ["pwd", {
+    run: pwd,
+    arity: { operands: "none" },
+    usage: "pwd",
+    summary: "Writes the complete address of the place, both dimensions.",
+    detail:
+      "It writes the scope even where it is the base, so what it prints " +
+      "denotes\none cell wherever it is read. The prompt is the short " +
+      "surface, and this\nis what to copy.",
+  }],
+  ["where", {
+    run: where,
+    arity: { operands: "none" },
+    usage: "where",
+    summary: "Writes the whole ambient record: connection and place.",
+    detail:
+      "Every dimension this process holds prints, one to a line: what it " +
+      "connects\nas, and the two halves of the place `pwd` prints. Nothing " +
+      "here reads, so\na shuttle whose connection will not open still says " +
+      "what it was launched\nas and where it stands.",
+  }],
+  ["wish", {
+    run: wish,
+    arity: {
+      operands: "required",
+      names: "the target to resolve, as in `wish #favorites`",
+    },
+    usage: "wish <#name>",
+    summary: "Resolves a named entry point, as `cf wish` does.",
+    detail: "The resolution is the fabric's own, so a target this answers is " +
+      "one\n`cf wish` answers. A target that resolved in another space is " +
+      "answered\nrather than refused: reading across spaces costs nothing, " +
+      "where\nstanding in one is what a single connection cannot do.",
+  }],
 ]);
 
 /**
@@ -583,33 +722,60 @@ function container(position: SpaceRootPosition | FacetPosition): string {
 }
 
 /**
- * Helper for the verbs, which refuses `operands` where `verb` takes none, and
- * returns nothing where it takes what it was given.
+ * Helper for {@link runLine}, which refuses `operands` where a verb called
+ * `verb` was given a number of them its `arity` does not take, and returns
+ * nothing where it was given a number it does.
+ *
+ * The arms are written out one each and closed by a `never`, so an arm added
+ * to {@link Arity} reds the type checker here rather than falling through to
+ * a sentence written for a different one.
  */
-function takesNothing(
+function wrongOperandCount(
   verb: string,
+  arity: Arity,
   operands: readonly string[],
 ): Outcome | undefined {
-  return operands.length === 0 ? undefined : refuse(
-    `\`${verb}\` takes no operand, and was given ${operands.length}.`,
-  );
+  const given = operands.length;
+  switch (arity.operands) {
+    case "none":
+      return given === 0 ? undefined : tooMany(verb, "no operand", given);
+    case "optional":
+      return given <= 1 ? undefined : tooMany(verb, "one operand", given);
+    case "required":
+      if (given === 1) return undefined;
+      return given === 0
+        ? refuse(`\`${verb}\` takes ${arity.names}.`)
+        : tooMany(verb, "one operand", given);
+    default: {
+      const unreached: never = arity;
+      return unreached;
+    }
+  }
 }
 
 /**
- * Helper for the verbs, which refuses `operands` where `verb` takes at most
- * one, and returns nothing where it takes what it was given.
+ * Helper for {@link wrongOperandCount}, which refuses `given` operands for a
+ * verb called `verb` that takes what `takes` names.
  */
-function takesAtMostOne(
-  verb: string,
-  operands: readonly string[],
-): Outcome | undefined {
-  return operands.length <= 1 ? undefined : refuse(
-    `\`${verb}\` takes one operand, and was given ${operands.length}.`,
-  );
+function tooMany(verb: string, takes: string, given: number): Outcome {
+  return refuse(`\`${verb}\` takes ${takes}, and was given ${given}.`);
 }
 
 /**
- * Helper for {@link runLine}, which writes `words` as the English list a
+ * Helper for {@link runLine} and {@link help}, which is the reason `word`
+ * names no verb, listing the words that do.
+ *
+ * One sentence for both doors, because they ask one question of a word: the
+ * dispatch reads the first token of a line and `help` reads its operand, and
+ * what is wrong with a word that names no verb is the same either way.
+ */
+function notAVerb(word: string): string {
+  return `\`${word}\` is not a verb. The verbs are ` +
+    `${listed([...VERBS.keys()])}.`;
+}
+
+/**
+ * Helper for {@link notAVerb}, which writes `words` as the English list a
  * refusal reads them in.
  */
 function listed(words: readonly string[]): string {

--- a/packages/cli/test/shuttle-help.test.ts
+++ b/packages/cli/test/shuttle-help.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Unit tests for how the verbs are written down: the line `help` lists one on,
+ * and the page `<verb> --help` writes.
+ *
+ * Every case drives the layout over verbs of its own rather than over the ones
+ * shuttle has, so what is under test is the form and not the wording of any
+ * verb: a summary reworded moves nothing here, and a column that stopped
+ * lining up moves everything. What the real verbs say is asked in
+ * `shuttle-verbs.test.ts`, where the table that holds it is.
+ */
+
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import {
+  renderVerbList,
+  renderVerbPage,
+  type VerbHelp,
+} from "../lib/shuttle/help.ts";
+
+/**
+ * The verbs every case below lays out. `help [<verb>]` is the longest usage of
+ * the three, which is what the column is measured from, and no summary is a
+ * substring of a usage, so a case reading one off a line reads it where it was
+ * written.
+ */
+const VERBS: readonly VerbHelp[] = [
+  { usage: "ls", summary: "Lists.", detail: "One." },
+  { usage: "cd <ref>", summary: "Moves.", detail: "Two." },
+  { usage: "help [<verb>]", summary: "Explains.", detail: "Three." },
+];
+
+/** The column {@link VERBS} puts a summary in: the longest usage, and a gap. */
+const COLUMN = "help [<verb>]".length + 2;
+
+describe("help", () => {
+  describe("renderVerbList()", () => {
+    const LINES = renderVerbList(VERBS).split("\n");
+    const ROWS = LINES.slice(0, VERBS.length);
+
+    it("returns one row per verb, in the order given", () => {
+      expect(ROWS.map((row) => row.split("  ")[0]))
+        .toEqual(["ls", "cd <ref>", "help [<verb>]"]);
+    });
+
+    it("returns every summary starting at the one column", () => {
+      expect(ROWS.map((row) => row.slice(COLUMN)))
+        .toEqual(["Lists.", "Moves.", "Explains."]);
+    });
+
+    it("returns a column measured from the longest usage, so a longer one moves every summary", () => {
+      const wider = [...VERBS, {
+        usage: "describe <ref>!",
+        summary: "Describes.",
+        detail: "Four.",
+      }];
+      expect(renderVerbList(wider).split("\n")[0])
+        .toBe(`ls${" ".repeat("describe <ref>!".length)}Lists.`);
+    });
+
+    it("returns the line naming `<verb> --help` last", () => {
+      expect(LINES.at(-1)).toBe("`<verb> --help` says more about one verb.");
+    });
+
+    it("returns a blank line between the rows and that last line", () => {
+      expect(LINES.at(-2)).toBe("");
+    });
+
+    it("returns no trailing line break, which leaves the caller ending the last line", () => {
+      expect(renderVerbList(VERBS).endsWith("\n")).toBe(false);
+    });
+  });
+
+  describe("renderVerbPage()", () => {
+    const LINES = renderVerbPage(VERBS[1]).split("\n");
+
+    it("returns the usage on the first line, under `Usage:`", () => {
+      expect(LINES[0]).toBe("Usage: cd <ref>");
+    });
+
+    it("returns the summary under the usage, a blank line between them", () => {
+      expect(LINES.slice(1, 3)).toEqual(["", "Moves."]);
+    });
+
+    it("returns the detail under the summary, a blank line between them", () => {
+      expect(LINES.slice(3, 5)).toEqual(["", "Two."]);
+    });
+
+    it("returns the options block last, naming the `--help` every verb takes", () => {
+      expect(LINES.slice(5)).toEqual([
+        "",
+        "Options:",
+        "  -h, --help   Write this page instead of running the verb.",
+      ]);
+    });
+
+    it("returns no trailing line break, which leaves the caller ending the last line", () => {
+      expect(renderVerbPage(VERBS[1]).endsWith("\n")).toBe(false);
+    });
+  });
+});

--- a/packages/cli/test/shuttle-listing.test.ts
+++ b/packages/cli/test/shuttle-listing.test.ts
@@ -30,6 +30,7 @@ import { linkPathSegmentToCellPathSegment } from "@commonfabric/runner/shared";
 import type { SlugSummary, SpaceConfig } from "../lib/piece.ts";
 import { HeldConnection } from "../lib/shuttle/connection.ts";
 import { splitLine } from "../lib/shuttle/line.ts";
+import { readsAsOption } from "../lib/shuttle/options.ts";
 import {
   type Listing,
   type ListingDeps,
@@ -522,6 +523,13 @@ describe("listing", () => {
     // the row, and that anything after it is separated from it — which is what
     // "copied off the front" means and all it can mean.
     //
+    // A name is read twice on the way back, and both readings are asked. The
+    // option grammar reads it first — a token opening with `-` reaches a verb
+    // as a flag and never as an operand — and the place reads what is left. A
+    // name the first reading takes therefore fails the property however well
+    // it moves, which is why the operand is held against `readsAsOption`
+    // beside being moved with.
+    //
     // What varies is as load-bearing as the property. Both kinds of row a
     // listing can name vary — the piece a facet lists and the key a piece
     // holds — and each candidate is driven through the read that produces that
@@ -669,6 +677,7 @@ describe("listing", () => {
         expect(split.kind).toBe("split");
         const tokens = split.kind === "split" ? split.tokens : [];
         expect(tokens.length).toBe(1);
+        expect(readsAsOption(tokens[0])).toBe(false);
         expect(standing.cd(tokens[0]).kind).toBe("moved");
         expect(standing.place).toEqual(childOf(from, row.name));
         named++;

--- a/packages/cli/test/shuttle-options.test.ts
+++ b/packages/cli/test/shuttle-options.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Unit tests for how the tokens after a verb divide into options and operands.
+ *
+ * The parse itself is `cf`'s — `parseFlags` is what `Command` reads a flag on
+ * a `cf` line through — so what these cases pin is the composition around it:
+ * which table the parse is handed, which of its three answers become the
+ * operands and in what order, and what a refusal says past the parser's own
+ * sentence. A case that looks as though it tests the parser is testing that
+ * the parser is the one reading the line, which is the decision this module
+ * carries.
+ *
+ * The predicate beside the parse is asked against the parse in every case that
+ * uses it. Two readings of a token that disagreed would put a name on a
+ * listing that `cd` no longer takes, and the pair is the only place that can
+ * be seen.
+ */
+
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import {
+  type OptionReading,
+  readOptions,
+  readsAsOption,
+  type VerbOption,
+} from "../lib/shuttle/options.ts";
+
+/** A verb that declares one option taking a value, for the cases that need one. */
+const SELECT: VerbOption = { name: "select", type: "string" };
+
+/** A verb that declares one option taking none. */
+const ALL: VerbOption = { name: "all" };
+
+/**
+ * A verb that declares one option it requires, which is the shape the shared
+ * help row has to answer over. A line leaving a required option out is refused
+ * whole, and a line asking what a verb takes is exactly such a line, so this is
+ * the only declaration under which the row's standalone half can be seen.
+ */
+const REQUIRED_SELECT: VerbOption = {
+  name: "select",
+  type: "string",
+  required: true,
+};
+
+/**
+ * Helper for the cases below, which is the operands `tokens` came back as, and
+ * nothing where the reading was not a read.
+ */
+function operandsOf(reading: OptionReading): readonly string[] | undefined {
+  return reading.kind === "read" ? reading.operands : undefined;
+}
+
+/**
+ * Helper for the cases below, which is the reason `tokens` were refused for,
+ * and nothing where they were not refused.
+ */
+function reasonOf(reading: OptionReading): string | undefined {
+  return reading.kind === "refused" ? reading.reason : undefined;
+}
+
+describe("options", () => {
+  describe("readOptions()", () => {
+    it("returns every token as an operand where none opens with `-`", () => {
+      expect(operandsOf(readOptions("get", ["topics/3", "title"])))
+        .toEqual(["topics/3", "title"]);
+    });
+
+    it("returns `-` on its own as an operand", () => {
+      expect(operandsOf(readOptions("cd", ["-"]))).toEqual(["-"]);
+    });
+
+    it("returns the operands in the order written, with an option between them removed", () => {
+      expect(
+        operandsOf(readOptions("get", ["a", "--select", "x", "b"], [SELECT])),
+      ).toEqual(["a", "b"]);
+    });
+
+    it("returns a declared option's value under the name it was declared by", () => {
+      const reading = readOptions("get", ["--select", "title"], [SELECT]);
+      expect(reading.kind === "read" ? reading.options : undefined)
+        .toEqual({ select: "title" });
+    });
+
+    it("returns a token after a bare `--` as an operand though it opens with `-`", () => {
+      expect(operandsOf(readOptions("cd", ["--", "-x"]))).toEqual(["-x"]);
+    });
+
+    it("returns the operands before and after a bare `--` in the order written", () => {
+      expect(operandsOf(readOptions("cd", ["a", "--", "-x"])))
+        .toEqual(["a", "-x"]);
+    });
+
+    it("returns no operand for a bare `--` on its own, the token being the terminator", () => {
+      expect(operandsOf(readOptions("cd", ["--"]))).toEqual([]);
+    });
+
+    it("returns a second `--` as an operand, only the first ending the options", () => {
+      expect(operandsOf(readOptions("cd", ["--", "--"]))).toEqual(["--"]);
+    });
+
+    it("returns the help reading for `--help`, which no verb declared", () => {
+      expect(readOptions("cd", ["--help"])).toEqual({ kind: "help" });
+    });
+
+    it("returns the help reading for `-h`", () => {
+      expect(readOptions("cd", ["-h"])).toEqual({ kind: "help" });
+    });
+
+    it("returns the help reading carrying no operand, where operands were written beside it", () => {
+      expect(readOptions("cd", ["--help", "slugs"])).toEqual({ kind: "help" });
+    });
+
+    it("returns the help reading though a declared option the line leaves out is required", () => {
+      expect(readOptions("get", ["--help"], [REQUIRED_SELECT]))
+        .toEqual({ kind: "help" });
+    });
+
+    it("returns a refusal for `--help` written beside another option, which is what `cf` answers", () => {
+      expect(
+        reasonOf(readOptions("get", ["--select", "x", "--help"], [SELECT])),
+      )
+        .toContain('Option "--help" cannot be combined with other options.');
+    });
+
+    it("returns a refusal naming the option nobody declared", () => {
+      expect(reasonOf(readOptions("get", ["-x"])))
+        .toBe(
+          'Unknown option "-x". Did you mean option "-h"? `get --help` says ' +
+            "what `get` takes.",
+        );
+    });
+
+    it("returns a refusal naming the verb's page, for the verb the line named", () => {
+      expect(reasonOf(readOptions("ls", ["-x"])))
+        .toContain("`ls --help` says what `ls` takes.");
+    });
+
+    it("returns a refusal where a declared option that takes a value is given none", () => {
+      expect(reasonOf(readOptions("get", ["--select"], [SELECT])))
+        .toContain('Missing value for option "--select".');
+    });
+
+    it("returns a refusal where a declared option that takes no value is given one", () => {
+      expect(reasonOf(readOptions("verbs", ["--all=yes"], [ALL])))
+        .toContain('Option "--all" doesn\'t take a value, but got "yes".');
+    });
+
+    it("returns a refusal for a token no option can be written as", () => {
+      expect(reasonOf(readOptions("cd", ["---"])))
+        .toContain('Invalid option "---".');
+    });
+
+    it("raises where the verb's table names a type nothing registered, which is no fact about the line", () => {
+      expect(() =>
+        readOptions("get", ["--pick", "1"], [{ name: "pick", type: "nope" }])
+      ).toThrow('Unknown type "nope"');
+    });
+  });
+
+  describe("readsAsOption()", () => {
+    // The predicate and the parse have to agree about a token standing on its
+    // own, since `operandForChild` offers a name on the predicate's word and
+    // the dispatch reads that name back on the parse's. Each case asks both,
+    // and what makes the pair a real question is that the two are separate
+    // readings of one rule.
+
+    const AGREEMENTS: readonly (readonly [string, boolean])[] = [
+      ["-", false],
+      ["", false],
+      ["ordinary", false],
+      ["..", false],
+      ["x-", false],
+      ["/@did:key:z6Mk/of:fid1:abcdefghijklmnop@space/-x", false],
+      ["--", true],
+      ["-x", true],
+      ["-1", true],
+      ["-h", true],
+      ["---", true],
+    ];
+
+    for (const [token, option] of AGREEMENTS) {
+      it(
+        `returns \`${option}\` for \`${token}\`, which the parse ${
+          option ? "keeps out of" : "returns among"
+        } the operands`,
+        () => {
+          expect(readsAsOption(token)).toBe(option);
+          const sole = operandsOf(readOptions("cd", [token]))?.[0];
+          expect(sole).toBe(option ? undefined : token);
+        },
+      );
+    }
+  });
+});

--- a/packages/cli/test/shuttle-place.test.ts
+++ b/packages/cli/test/shuttle-place.test.ts
@@ -112,6 +112,11 @@ describe("place", () => {
     // are is reached by the reference the child renders as, which reads none of
     // them; and a child no rendering names back is reached by neither.
     //
+    // One of the readings is not this module's. A token opening with `-`
+    // reaches a verb as an option rather than as an operand, so a name spelled
+    // that way is offered as its reference too, and the case for it turns on
+    // `readsAsOption` (`options.ts`) rather than on any move made here.
+    //
     // Two clauses of the comparison behind it have no case, and both are
     // unreachable from this door rather than untested. Neither spelling tried
     // moves the scope: the reference is rendered carrying the place's own, and
@@ -142,6 +147,18 @@ describe("place", () => {
     it("returns a reference for a key called `..`", () => {
       expect(operandForChild(atReferencedPiece().place, "..")).toBe(
         `/@${SPACE}/${HANDLE}@space/..`,
+      );
+    });
+
+    it("returns a reference for a key opening with `-`, which the option grammar reads as an option", () => {
+      expect(operandForChild(atReferencedPiece().place, "-x")).toBe(
+        `/@${SPACE}/${HANDLE}@space/-x`,
+      );
+    });
+
+    it("returns a reference for a key called `--`, the token that ends the options", () => {
+      expect(operandForChild(atReferencedPiece().place, "--")).toBe(
+        `/@${SPACE}/${HANDLE}@space/--`,
       );
     });
 

--- a/packages/cli/test/shuttle-prompt.test.ts
+++ b/packages/cli/test/shuttle-prompt.test.ts
@@ -142,8 +142,8 @@ describe("prompt", () => {
         { kind: "edit", text: `${AT_ROOT}pw`, column: 20 },
         {
           kind: "finish",
-          text: "`pw` is not a verb. The verbs are `cd`, `get`, `ls`, `pwd`, " +
-            "`where`, and `wish`.",
+          text: "`pw` is not a verb. The verbs are `cd`, `get`, `help`, " +
+            "`ls`, `pwd`, `where`, and `wish`.",
         },
         { kind: "edit", text: AT_ROOT, column: 18 },
         { kind: "finish", text: "" },

--- a/packages/cli/test/shuttle-verbs.test.ts
+++ b/packages/cli/test/shuttle-verbs.test.ts
@@ -35,7 +35,7 @@ import type {
   SpaceConfig,
 } from "../lib/piece.ts";
 import { HeldConnection } from "../lib/shuttle/connection.ts";
-import { CurrentPlace } from "../lib/shuttle/place.ts";
+import { CurrentPlace, operandForChild } from "../lib/shuttle/place.ts";
 import {
   type Outcome,
   runLine,
@@ -171,6 +171,41 @@ function reasonOf(outcome: Outcome): string {
     : `not refused: ${outcome.kind}`;
 }
 
+/**
+ * Helper for the cases below, which is every verb the dispatch takes, in the
+ * order it lists them, with how many operands each one takes.
+ *
+ * It is written out rather than read off the table, so that a verb added
+ * without a page, or with an arity nobody meant, fails a case here instead of
+ * passing one that walks whatever it finds. What holds it to the table is the
+ * case asserting that `help` lists exactly these and nothing else.
+ */
+const VERB_ARITY: readonly (readonly [
+  string,
+  "none" | "optional" | "required",
+])[] = [
+  ["cd", "required"],
+  ["get", "optional"],
+  ["help", "optional"],
+  ["ls", "none"],
+  ["pwd", "none"],
+  ["where", "none"],
+  ["wish", "required"],
+];
+
+/**
+ * Helper for the cases below, which is what a verb needing an operand refuses
+ * a line naming none with. A verb absent from this either takes no operand at
+ * all or reads its own meaning into having none.
+ */
+const NEEDS_ONE: ReadonlyMap<string, string> = new Map([
+  ["cd", "`cd` takes a place to move to."],
+  ["wish", "`wish` takes the target to resolve, as in `wish #favorites`."],
+]);
+
+/** Helper for the cases below, which is every verb, in that same order. */
+const VERB_WORDS = VERB_ARITY.map(([word]) => word);
+
 describe("verbs", () => {
   describe("the dispatch", () => {
     it("returns nothing for a line naming no verb", async () => {
@@ -182,8 +217,8 @@ describe("verbs", () => {
     it("returns a refusal naming a word that is no verb, and listing the verbs", async () => {
       expect(await runLine("frob x", shuttleIn(), READS_NOTHING)).toEqual({
         kind: "refused",
-        reason: "`frob` is not a verb. The verbs are `cd`, `get`, `ls`, " +
-          "`pwd`, `where`, and `wish`.",
+        reason: "`frob` is not a verb. The verbs are `cd`, `get`, `help`, " +
+          "`ls`, `pwd`, `where`, and `wish`.",
       });
     });
 
@@ -209,7 +244,7 @@ describe("verbs", () => {
         expect(await runLine(word, shuttleIn(), READS_NOTHING)).toEqual({
           kind: "refused",
           reason: `\`${word}\` is not a verb. The verbs are \`cd\`, \`get\`, ` +
-            "`ls`, `pwd`, `where`, and `wish`.",
+            "`help`, `ls`, `pwd`, `where`, and `wish`.",
         });
       }
     });
@@ -218,13 +253,6 @@ describe("verbs", () => {
       expect(await runLine("get 'a", shuttleIn(), READS_NOTHING)).toEqual({
         kind: "refused",
         reason: "The `'` opened at column 5 is never closed.",
-      });
-    });
-
-    it("hands the tokens after the verb on as its operands", async () => {
-      expect(await runLine("pwd here", shuttleIn(), READS_NOTHING)).toEqual({
-        kind: "refused",
-        reason: "`pwd` takes no operand, and was given 1.",
       });
     });
 
@@ -262,6 +290,7 @@ describe("verbs", () => {
             "get",
             "wish #favorites",
             "cd ..",
+            "help",
           ]
         ) {
           await runLine(line, shuttle, answers);
@@ -271,6 +300,169 @@ describe("verbs", () => {
         Deno.stderr.writeSync = stderr;
       }
       expect(written).toEqual([]);
+    });
+  });
+
+  describe("the option grammar", () => {
+    it("hands a token opening with `-` to no verb, and refuses it as an option nobody declared", async () => {
+      expect(reasonOf(await runLine("ls -x", shuttleIn(), READS_NOTHING)))
+        .toBe(
+          'Unknown option "-x". Did you mean option "-h"? `ls --help` says ' +
+            "what `ls` takes.",
+        );
+    });
+
+    it("hands `-` on its own to the verb as an operand, it being the previous place", async () => {
+      // The one token the rule turns on that a shipped verb already spends:
+      // read as an option it would refuse here as `-x` does, and the reason
+      // it gives instead is the place's own.
+
+      expect(reasonOf(await runLine("cd -", shuttleIn(), READS_NOTHING)))
+        .toBe("There is no previous place to return to.");
+    });
+
+    it("hands a token after a bare `--` on as an operand, though it opens with `-`", async () => {
+      expect(reasonOf(await runLine("cd -- -x", shuttleIn(), READS_NOTHING)))
+        .toBe(
+          "A space root lists facets, and `-x` names none. The facets are " +
+            "`slugs/` and `pieces/`.",
+        );
+    });
+
+    it("takes back the operand a listing offers for a key it would otherwise eat", async () => {
+      // The composed claim the rule puts at risk: a listing prints a name to
+      // be typed back, and a token opening with `-` never reaches a verb as an
+      // operand. What closes it is the reference, which opens with `/`.
+
+      const shuttle = atPiece();
+      const operand = operandForChild(shuttle.place.place, "-x");
+      expect(operand).toBeDefined();
+      await runLine(`cd ${operand}`, shuttle, READS_NOTHING);
+      expect(shuttle.place.place.position).toEqual({
+        kind: "piece",
+        space: SPACE,
+        piece: HANDLE,
+        path: ["-x"],
+      });
+    });
+
+    it("takes a key called `--` by the second one, only the first ending the options", async () => {
+      // The typed spelling and what a listing offers are two questions. The
+      // listing prints the reference for this key, `readsAsOption` taking the
+      // name; the line below is what a person can type for it either way.
+
+      const shuttle = atPiece();
+      await runLine("cd -- --", shuttle, READS_NOTHING);
+      expect(shuttle.place.place.position).toEqual({
+        kind: "piece",
+        space: SPACE,
+        piece: HANDLE,
+        path: ["--"],
+      });
+    });
+
+    it("counts the operands rather than the tokens, a bare `--` being neither", async () => {
+      const shuttle = shuttleIn();
+      expect(await runLine("cd -- slugs", shuttle, READS_NOTHING))
+        .toEqual({ kind: "moved", place: shuttle.place.place });
+    });
+  });
+
+  describe("`--help`", () => {
+    // One case per verb rather than one case walking them, because what is
+    // claimed is of each: the dispatch puts the option in front of whatever a
+    // verb declared, so a verb that stopped taking it names itself here.
+
+    for (const word of VERB_WORDS) {
+      it(`writes \`${word}\`'s page, which \`help ${word}\` writes too`, async () => {
+        const opening = `Usage: ${word}`;
+        const byOption = textOf(
+          await runLine(`${word} --help`, shuttleIn(), READS_NOTHING),
+        );
+        expect(byOption.slice(0, opening.length)).toBe(opening);
+        expect(
+          textOf(await runLine(`help ${word}`, shuttleIn(), READS_NOTHING)),
+        )
+          .toBe(byOption);
+      });
+    }
+
+    it("writes the page though an operand was written beside the option", async () => {
+      // The option takes the whole reading, so the operand beside it reaches
+      // no verb. What each case above shows is the other half: a verb that ran
+      // instead would answer with its own refusal for the operands it was not
+      // given, and none of these would be text at all.
+
+      expect(
+        textOf(await runLine("cd --help slugs", shuttleIn(), READS_NOTHING))
+          .split("\n")[0],
+      ).toBe("Usage: cd <ref>");
+    });
+  });
+
+  describe("arity", () => {
+    // How many operands a verb takes is the dispatch table's, and the dispatch
+    // is what holds a verb to it, so there is one case per verb here rather
+    // than one in each verb's own block. What a case turns on is the entry it
+    // reads, so a count changed there names the verb it was changed for.
+
+    for (const [word, arity] of VERB_ARITY) {
+      const given = arity === "none" ? 1 : 2;
+      it(`refuses ${given} operand${given === 1 ? "" : "s"}, one more than \`${word}\` takes`, async () => {
+        const line = [word, ...["a", "b"].slice(0, given)].join(" ");
+        expect(reasonOf(await runLine(line, shuttleIn(), READS_NOTHING)))
+          .toBe(
+            arity === "none"
+              ? `\`${word}\` takes no operand, and was given 1.`
+              : `\`${word}\` takes one operand, and was given 2.`,
+          );
+      });
+    }
+
+    for (const [word, arity] of VERB_ARITY) {
+      if (arity !== "required") continue;
+      it(`refuses a line naming no operand, \`${word}\` needing one`, async () => {
+        expect(reasonOf(await runLine(word, shuttleIn(), READS_NOTHING)))
+          .toBe(NEEDS_ONE.get(word));
+      });
+    }
+
+    for (const [word, arity] of VERB_ARITY) {
+      if (arity !== "optional") continue;
+      it(`runs \`${word}\` given no operand, which is a default and not too few`, async () => {
+        // The half a maximum alone cannot express. `get` reads where it stands
+        // and `help` lists the verbs, so neither is a line the dispatch may
+        // answer for, and a count refusing none would take both readings away.
+
+        const outcome = await runLine(word, atPiece(), cellValue("a value"));
+        expect(outcome.kind).not.toBe("refused");
+      });
+    }
+
+    it("counts the operands it was given rather than the count the verb takes", async () => {
+      expect(reasonOf(await runLine("pwd a b c", shuttleIn(), READS_NOTHING)))
+        .toBe("`pwd` takes no operand, and was given 3.");
+    });
+  });
+
+  describe("help", () => {
+    it("lists every verb, one to a row, and nothing else", async () => {
+      // The list and the dispatch read one table, so a verb the dispatch
+      // takes and this does not list is a verb a person has no way to find.
+      // The last two lines are the blank and the line naming the option.
+
+      const lines = textOf(await runLine("help", shuttleIn(), READS_NOTHING))
+        .split("\n");
+      expect(lines.slice(0, -2).map((row) => row.split(" ")[0]))
+        .toEqual(VERB_WORDS);
+    });
+
+    it("refuses a word that names no verb, in the sentence the dispatch refuses one in", async () => {
+      expect(reasonOf(await runLine("help frob", shuttleIn(), READS_NOTHING)))
+        .toBe(
+          "`frob` is not a verb. The verbs are `cd`, `get`, `help`, `ls`, " +
+            "`pwd`, `where`, and `wish`.",
+        );
     });
   });
 
@@ -297,16 +489,13 @@ describe("verbs", () => {
       expect(shuttle.place.place).toBe(before);
     });
 
-    it("returns the reason a place gave no operand at all", async () => {
-      expect(reasonOf(await runLine("cd", shuttleIn(), READS_NOTHING))).toBe(
-        "`cd` takes a place to move to.",
-      );
-    });
+    it("returns the place's own refusal for an operand that is the empty string", async () => {
+      // One operand, so the dispatch hands it on and `movePlace`'s guard is
+      // what answers — in the sentence the dispatch composes for a line naming
+      // no operand at all, so the two spellings read alike.
 
-    it("refuses two operands", async () => {
-      expect(
-        reasonOf(await runLine("cd a b", shuttleIn(), READS_NOTHING)),
-      ).toBe("`cd` takes one operand, and was given 2.");
+      expect(reasonOf(await runLine("cd ''", shuttleIn(), READS_NOTHING)))
+        .toBe("`cd` takes a place to move to.");
     });
 
     it("refuses an operand ending in `#argument`, a place being result-rooted", async () => {
@@ -625,13 +814,6 @@ describe("verbs", () => {
       expect(listed).toBe(1);
     });
 
-    it("refuses an operand", async () => {
-      expect(reasonOf(await runLine("ls title", atPiece(), READS_NOTHING)))
-        .toBe(
-          "`ls` takes no operand, and was given 1.",
-        );
-    });
-
     it("raises what a read that failed outright raised", async () => {
       await expect(runLine("ls", atPiece(), READS_NOTHING)).rejects.toThrow(
         "The cell was listed.",
@@ -645,12 +827,6 @@ describe("verbs", () => {
         kind: "text",
         text: `position  /@${SPACE}/${HANDLE}@space/title\nscope     @space`,
       });
-    });
-
-    it("refuses an operand", async () => {
-      expect(reasonOf(await runLine("pwd /", shuttleIn(), READS_NOTHING))).toBe(
-        "`pwd` takes no operand, and was given 1.",
-      );
     });
   });
 
@@ -731,14 +907,6 @@ describe("verbs", () => {
       expect(text).toContain("space     boa␦rd");
       expect(text).toContain("identity  /k␡ey");
       expect(/\p{Cc}/u.test(text.replaceAll("\n", ""))).toBe(false);
-    });
-
-    it("refuses an operand", async () => {
-      expect(
-        reasonOf(
-          await runLine("where scope @user", shuttleIn(), READS_NOTHING),
-        ),
-      ).toBe("`where` takes no operand, and was given 2.");
     });
   });
 
@@ -1008,12 +1176,6 @@ describe("verbs", () => {
         "A cell was read.",
       );
     });
-
-    it("refuses two operands", async () => {
-      expect(reasonOf(await runLine("get a b", atPiece(), READS_NOTHING))).toBe(
-        "`get` takes one operand, and was given 2.",
-      );
-    });
   });
 
   describe("wish", () => {
@@ -1090,18 +1252,6 @@ describe("verbs", () => {
       expect(
         await runLine("wish #profile", shuttleIn(), wishing(null)),
       ).toEqual({ kind: "value", value: null });
-    });
-
-    it("refuses a line naming no target", async () => {
-      expect(reasonOf(await runLine("wish", shuttleIn(), READS_NOTHING))).toBe(
-        "`wish` takes the target to resolve, as in `wish #favorites`.",
-      );
-    });
-
-    it("refuses two operands", async () => {
-      expect(
-        reasonOf(await runLine("wish #a #b", shuttleIn(), READS_NOTHING)),
-      ).toBe("`wish` takes one operand, and was given 2.");
     });
   });
 });


### PR DESCRIPTION
## Why

Shuttle's verbs each read their own line. `cd` took at most one operand,
`get` took at most one, `ls` took none, and each said so with its own
ad-hoc check — three small parsers with three spellings of the same idea,
and no `--help` anywhere. A person who learned one verb's line had learned
nothing about the next one's.

An architecture review of the built shell (finding 6) called this before
B2 makes it worse: the writing verbs add `set`, `call` and `link`, each of
which wants options, and each of which would otherwise invent its own
reading of `-`. Deciding the grammar once, now, is the difference between
one rule every verb reads through and six parsers that disagree at the
edges.

The rule chosen is `cf`'s, not a new one. `parseFlags` from `@cliffy/flags`
is the same function `@cliffy/command`'s `Command` calls to read the flags
on a `cf` line, so a flag spelled at shuttle's prompt is parsed, defaulted
and refused by the code that parses a flag on the command line — including
the two subtleties nobody wants to re-derive: `-` alone is an operand, and
a bare `--` moves everything after it out of option position.

## What Changed

- **`lib/shuttle/options.ts`** — `readOptions(verb, tokens, declared)`
  splits a line into options and operands, with the help row pushed in
  front of whatever the verb declared, so no verb can omit `--help`.
  Operands come back in written order. Cliffy's refusals are relayed
  verbatim with one shuttle sentence appended naming `<verb> --help`.
- **`lib/shuttle/help.ts`** — `help` lists the verbs, `help <verb>` writes
  the page `<verb> --help` writes. Both read strings held beside each
  verb's `run` in the dispatch table, so a verb added is a verb `help`
  lists.
- **`verbs.ts`** — `runLine` answers `--help` centrally; no verb implements
  help.
- **`place.ts`** — `operandForChild` no longer offers a bare `-x` for a key
  named `-x`, since `cd -x` now refuses. It asks `readsAsOption` and falls
  through to the reference, which is what names such a child.
- Documents: `grammar.md` gains the option reading, `build-sequence.md`
  records it, `DEPENDENCIES.md`'s Cliffy set grows from three declarations
  to four, `packages/cli/README.md` and `cf sh --help` point at `help`.

`@cliffy/flags@1.0.0-rc.8` is declared in `packages/cli/deno.jsonc` rather
than the root, per `DEPENDENCIES.md`'s narrowest-scope rule — `@cliffy/table`
is the precedent. It was already a transitive pin, so `deno.lock` grew one
line.

### Three design calls taken conservatively

1. **Options may sit anywhere among the operands**, because that is where
   `cf` reads them. `grammar.md` says that is where they usually go, not
   where they must.
2. **A bare `--help` line is refused as "not a verb"**, with the refusal
   listing `help`. It does not print general help.
3. **No verb declares an option yet.** `get`'s projection is finding 5 and
   out of scope here, so `declared` is a tested parameter with no caller in
   the table. **The author adding the first flag decides how a verb receives
   the parsed options** — that seam is deliberately unstated rather than
   guessed at.

## Test plan

- `deno fmt --check` (5748 files), `deno lint` (5594), `deno task check`
  (`ok cli`) all clean.
- `packages/cli`: 1807 parallel + 215 serial passed, 0 failed.
- `check-docs`, `check-control-characters`, `check-command-docs`,
  `check-completion-slots`, `check-unused-deps`, `check-single-copy-deps`,
  `check-deno-pins`, `check-package-cycles`, `check-skill-facts` pass.
  `check-docs` is reported as run, not as coverage: the documentation edits
  here added no TypeScript blocks, so it is not evidence about this change.
- **Instruments proved before their silence was believed.** A deliberate
  type error in `options.ts` produced `FAILED cli`; a staged `\x01` produced
  `check-control-characters`' refusal. Both were restored and re-run.
- **15 mutations, one per contract clause, applied one at a time.** 14 red
  the case they were designated for. The 15th — "writes the page rather than
  running the verb" — could not fail, because a help reading carries no
  operands and the dispatch structurally cannot run the verb with them. That
  case was replaced with one asserting the page comes back though an operand
  stood beside the option, and the dropped-help-row mutation reds it.
- Four contract clauses have no case, named in the commit rather than left
  implicit: Cliffy's provenance (verified by reading the cached source),
  `readsAsOption`'s stated bound, `defaulted` (no verb declares a default),
  and the options block listing only `--help`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BPyjSx5WXYepE9JsK4rBx3


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6982?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



## Coverage

The three lines are `wrongOperandCount`'s `default` arm — `verbs.ts:750–752`,
the `const unreached: never = arity` assertion and its braces. Measured, not
inferred: an LCOV run over the three shuttle test files reports uncovered
lines `[750, 751, 752]` in that file and no others.

The arm is unreachable by construction, which is its entire purpose. Every
member of `Arity` is handled by a preceding case and the type checker proves
the set exhausted, so an arm added to `Arity` reds the compiler here rather
than falling through to a sentence written for a different one. B2 widening
this for `set` and `call` is the case it exists to catch.

Reaching it from a test would mean casting past the type checker to fabricate
a value the union forbids — a case asserting something that cannot happen,
which is the vacuous shape that has no business being written to move a
number.

ACCEPT_COVERAGE_DEBT: packages/cli +3 lines
