### PR TITLE
fix(collection-naming): a backfilled name records the member, not its slot

### DIFF
--- a/packages/patterns/baselines/topics/topic.tsx/20260906T050633Z-d6Et9xqrHqjlhlzA.json
+++ b/packages/patterns/baselines/topics/topic.tsx/20260906T050633Z-d6Et9xqrHqjlhlzA.json
@@ -1,0 +1,1037 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "NamesTableRow": {
+        "properties": {
+          "member": {
+            "description": "The member. `unknown` because it is written as a reference and only ever\ncompared; anything wider would read the member back whole.",
+            "type": "unknown"
+          },
+          "name": {
+            "description": "The member's name.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "member",
+          "name"
+        ],
+        "type": "object"
+      },
+      "TopicAuthor": {
+        "properties": {
+          "avatar": {
+            "type": "string"
+          },
+          "kind": {
+            "description": "Open for the same reason `TopicLinkKind` is: this is provided data, so a\nclosed set here could never gain `\"service\"` or whatever acts next.\nWell-known values are `\"person\"` and `\"agent\"`, the latter marking an\nagent acting with its human user's key.",
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "name"
+        ],
+        "type": "object"
+      },
+      "TopicComment": {
+        "properties": {
+          "author": {
+            "$ref": "#/$defs/TopicAuthor",
+            "description": "Snapshot taken at write time (profile enrichment comes later; never gate\nauthorship on a profile wish — CT-1879). Comments carry no minted id:\narray elements have stable entity identity; future editing addresses\nelements by reference (`equals()`), not by a synthetic key.\n\nOptional because durable Topics may contain a comment without structured\nauthorship. Current `addComment` calls require `agentName` and always write\nthis snapshot."
+          },
+          "body": {
+            "default": "",
+            "type": "string"
+          },
+          "editedAt": {
+            "description": "When the body was last revised, absent on a comment never edited. The\noriginal `sentAt` and `author` are left alone: an edit changes what was\nsaid, not who said it or when the thread reached this point.",
+            "type": "number"
+          },
+          "removedAt": {
+            "description": "Set when the comment was retracted, and the retraction is the whole of\nit — the record stays, carrying what it always said. A reader hides it;\n`commentCount` stops counting it; `lastActivityOf` keeps reading its\n`sentAt`, which is what stops a retraction moving a topic backwards in\nthe board's ordering.",
+            "type": "number"
+          },
+          "removedBy": {
+            "$ref": "#/$defs/TopicAuthor"
+          },
+          "sentAt": {
+            "default": 0,
+            "type": "number"
+          }
+        },
+        "required": [
+          "body",
+          "sentAt"
+        ],
+        "type": "object"
+      },
+      "TopicCrossrefRow": {
+        "properties": {
+          "mentionedBy": {
+            "items": {
+              "type": "unknown"
+            },
+            "type": "array"
+          },
+          "topic": {
+            "description": "The topic this row is about. `unknown` because it is written as a\nreference and only ever compared — `equals` takes the raw link. Anything\nwider retrieves the piece instead of pointing at it: declared `object`,\nthis field reads back as the whole expanded topic, `$UI` tree included.",
+            "type": "unknown"
+          }
+        },
+        "required": [
+          "topic",
+          "mentionedBy"
+        ],
+        "type": "object"
+      },
+      "TopicLink": {
+        "properties": {
+          "addedAt": {
+            "type": "number"
+          },
+          "addedBy": {
+            "$ref": "#/$defs/TopicAuthor"
+          },
+          "kind": {
+            "default": "web",
+            "type": "string"
+          },
+          "label": {
+            "default": "",
+            "type": "string"
+          },
+          "removedAt": {
+            "description": "As on a comment, and with one consequence of its own: a retracted link\nstops resolving into `mentions`, so the reference it contributed goes\nwith it rather than outliving the link that made it.",
+            "type": "number"
+          },
+          "removedBy": {
+            "$ref": "#/$defs/TopicAuthor"
+          },
+          "url": {
+            "default": "",
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "url",
+          "label"
+        ],
+        "type": "object"
+      },
+      "TopicMentionRef": {
+        "properties": {
+          "destination": {
+            "type": "unknown"
+          },
+          "modifiedTitle": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "destination",
+          "modifiedTitle"
+        ],
+        "type": "object"
+      },
+      "TopicMentionRefMap": {
+        "additionalProperties": {
+          "$ref": "#/$defs/TopicMentionRef"
+        },
+        "properties": {},
+        "type": "object"
+      },
+      "TopicMentionable": {
+        "properties": {
+          "$NAME": {
+            "default": "",
+            "type": [
+              "string",
+              "undefined"
+            ]
+          },
+          "shortName": {
+            "type": "string"
+          },
+          "title": {
+            "default": "",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "$NAME"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "boardCrossrefs": {
+        "asCell": [
+          "readonly"
+        ],
+        "default": [],
+        "description": "The board's mention pivot, one row per topic. A topic reads its own row\nout of it and nothing else; see `backlinksOf`. Absent, a topic simply shows\nno inbound references.\n\nReadable, not writable: the pivot is the board's derivation, and a topic\nhas no business writing into it. Declaring the narrower cell says so where\na reader can see it, rather than leaving it to convention.",
+        "items": {
+          "$ref": "#/$defs/TopicCrossrefRow"
+        },
+        "type": "array"
+      },
+      "boardNames": {
+        "asCell": [
+          "readonly"
+        ],
+        "default": [],
+        "description": "The board's names table, one row per named topic. The topic reads its own\nrow out of it and nothing else; absent, the topic shows no number.\n\nReadable, not writable, for the reason `boardCrossrefs` states: the table\nis the board's derivation, and a topic has no business writing into it.\nWired at creation by the board's create, and rewired onto a topic filed\nbefore the namespace as a one-time link-bind — the same operator step\n`mentionable` states for itself.",
+        "items": {
+          "$ref": "#/$defs/NamesTableRow"
+        },
+        "type": "array"
+      },
+      "body": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "description": "The topic's living document: durable conclusions get folded up into the\nbody; the comment thread below holds the deliberation.",
+        "type": "string"
+      },
+      "bodyUpdatedAt": {
+        "asCell": [
+          "cell"
+        ],
+        "default": 0,
+        "type": "number"
+      },
+      "bodyUpdatedBy": {
+        "$ref": "#/$defs/TopicAuthor",
+        "asCell": [
+          "cell"
+        ],
+        "default": {
+          "kind": "person",
+          "name": ""
+        }
+      },
+      "comments": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/TopicComment"
+        },
+        "type": "array"
+      },
+      "createdAt": {
+        "default": 0,
+        "type": "number"
+      },
+      "createdBy": {
+        "$ref": "#/$defs/TopicAuthor"
+      },
+      "links": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/TopicLink"
+        },
+        "type": "array"
+      },
+      "mentionable": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "description": "The board's mention universe — what the body editor autocompletes\nover. Wired at creation to the board's mention index (one derived\ndocument of copies; `MentionableRow` in\n`../collection-naming/mentionable.ts`), and rewired onto a piece from\nbefore the index as a one-time link-bind. A plain list of the pieces\nthemselves also satisfies the demand — a board not yet rewired, or a\ncomposer without a board. Absent, the editor simply offers no\ncompletions.",
+        "items": {
+          "$ref": "#/$defs/TopicMentionable"
+        },
+        "type": "array"
+      },
+      "mentioned": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "description": "Pieces this topic references outside its prose — what `mention` records.\n\nIts own list rather than an entry in `references`, because that map belongs\nto the body editor: the editor mints its keys, rewrites its labels, and\ncollects entries whose token has left the document. A verb writing there\nwould be writing into somebody else's bookkeeping. Here there is nothing to\nkey by, because there is nothing to point back at from the prose — a\nreference outside a sentence is just a link in a list.",
+        "items": {
+          "type": "unknown"
+        },
+        "type": "array"
+      },
+      "references": {
+        "$ref": "#/$defs/TopicMentionRefMap",
+        "asCell": [
+          "cell"
+        ],
+        "default": {},
+        "description": "Where this topic's `[Label][key]` mentions point, keyed by the token that\nappears in the body. The editor owns the contents; this pattern owns the\ncell, which is what makes a mention durable and — because each entry holds\nthe destination as a REFERENCE — what makes the reference graph a question\nabout cell identity rather than about text.\n\nThe default has to match the one `TopicOutput` publishes. A map published\nunder a different default than its input carries cannot be materialized."
+      },
+      "title": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "type": "string"
+      },
+      "titleUpdatedAt": {
+        "asCell": [
+          "cell"
+        ],
+        "default": 0,
+        "type": "number"
+      },
+      "titleUpdatedBy": {
+        "$ref": "#/$defs/TopicAuthor",
+        "asCell": [
+          "cell"
+        ],
+        "default": {
+          "kind": "person",
+          "name": ""
+        },
+        "description": "Attribution of the last rename, stamped by `setTitle` — the same pair\nthe body keeps, because a title is the other editable scalar."
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "topics/topic.tsx",
+  "resultSchema": {
+    "$defs": {
+      "AddCommentEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Fabric authenticates the write with that key; this says\nwhich agent acted under it.\n\nRequired so every authored-content call carries structured attribution.\nAuthenticated execution provenance can supersede the field by relaxing it\nto optional without breaking existing callers.",
+            "type": "string"
+          },
+          "body": {
+            "description": "The comment text, appended verbatim after trimming. Must be non-empty:\nan empty body rejects rather than recording a blank thread entry.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "body",
+          "agentName"
+        ],
+        "type": "object"
+      },
+      "AddLinkEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Fabric authenticates the write with that key; this says\nwhich agent acted under it.\n\nRequired so every authored-content call carries structured attribution.\nAuthenticated execution provenance can supersede the field by relaxing it\nto optional without breaking existing callers.",
+            "type": "string"
+          },
+          "kind": {
+            "description": "What the link points at — a rendering hint, not a behavior switch.\nOptional because the handler defaults it to `\"web\"`, and a caller should\nnot be made to supply a field the verb never needed.",
+            "type": "string"
+          },
+          "label": {
+            "description": "Display label. Optional, and a blank one falls back to the URL.",
+            "type": "string"
+          },
+          "url": {
+            "description": "The link target. Must be http(s): anything else rejects, because a\nuser-supplied scheme on a shared surface is script execution in every\nviewer's session.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "url",
+          "agentName"
+        ],
+        "type": "object"
+      },
+      "EditCommentEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Fabric authenticates the write with that key; this says\nwhich agent acted under it.\n\nRequired so every authored-content call carries structured attribution.\nAuthenticated execution provenance can supersede the field by relaxing it\nto optional without breaking existing callers.",
+            "type": "string"
+          },
+          "body": {
+            "description": "The complete replacement text, trimmed. Must be non-empty: emptying a\ncomment is a retraction, and `removeComment` is what says so.",
+            "type": "string"
+          },
+          "comment": {
+            "description": "The comment to revise, named and checked as in `RemoveCommentEvent`,\nand additionally naming `body`, which this verb writes.",
+            "properties": {
+              "body": {
+                "default": "",
+                "type": "string"
+              },
+              "editedAt": {
+                "type": "number"
+              },
+              "removedAt": {
+                "type": "number"
+              },
+              "sentAt": {
+                "default": 0,
+                "type": "number"
+              }
+            },
+            "required": [
+              "sentAt",
+              "body"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "comment",
+          "body",
+          "agentName"
+        ],
+        "type": "object"
+      },
+      "MentionEvent": {
+        "properties": {
+          "topic": {
+            "description": "The piece to reference — the piece itself, not an address. Identity here\nis the cell, so this is what a caller passes and what gets stored.\n\nDeclared through the one field every Topic has rather than `unknown`. The\ncell declaration marks this as a reference position, so the CLI resolves a\ncanonical `/of:...` value from an inline JSON event into the live piece\nlink. It also bounds the validation read: `topic.get()` is `undefined` for\na value that is not a reference and an object for any piece, and `mention`\nchecks it before storing anything.\n\n`title` is also the most this can safely name: this schema reaches every\ntopic in `mentionable`, so a property without a default would be demanded\nof topics written before it existed and refuse their update. `title`\ncarries one, and that default does double duty — it is also why the check\nadmits a piece that is not a topic at all, which reads back `{ title: \"\" }`\nrather than `undefined`. `deno task pattern-vintage` proves the update side\nby replaying a real board.\n\nNothing reads THROUGH it beyond that one field — the value is stored and\ncompared.",
+            "properties": {
+              "title": {
+                "default": "",
+                "type": "string"
+              }
+            },
+            "required": [
+              "title"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "RemoveCommentEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Fabric authenticates the write with that key; this says\nwhich agent acted under it.\n\nRequired so every authored-content call carries structured attribution.\nAuthenticated execution provenance can supersede the field by relaxing it\nto optional without breaking existing callers.",
+            "type": "string"
+          },
+          "comment": {
+            "description": "The comment to retract — the stored element, not a copy of its fields.\nNames only what this verb reads and writes, for the reason\n`MentionEvent.topic` names only `title`: the declaration bounds the\nvalidation read, and a payload that is not a reference reads back\n`undefined` and is refused rather than silently matching nothing.\n`sentAt` carries a default, so it is what makes a real element read back\nas an object; the stamp fields are optional, which is what lets this\nschema reach comments written before they existed.",
+            "properties": {
+              "removedAt": {
+                "type": "number"
+              },
+              "removedBy": {
+                "$ref": "#/$defs/TopicAuthor"
+              },
+              "sentAt": {
+                "default": 0,
+                "type": "number"
+              }
+            },
+            "required": [
+              "sentAt"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "comment",
+          "agentName"
+        ],
+        "type": "object"
+      },
+      "RemoveLinkEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Fabric authenticates the write with that key; this says\nwhich agent acted under it.\n\nRequired so every authored-content call carries structured attribution.\nAuthenticated execution provenance can supersede the field by relaxing it\nto optional without breaking existing callers.",
+            "type": "string"
+          },
+          "link": {
+            "description": "The stored link element. What a reader passes, from the row it renders.\nNamed as in `RemoveCommentEvent`, with `url` playing the defaulted-field\nrole `sentAt` plays there.",
+            "properties": {
+              "removedAt": {
+                "type": "number"
+              },
+              "removedBy": {
+                "$ref": "#/$defs/TopicAuthor"
+              },
+              "url": {
+                "default": "",
+                "type": "string"
+              }
+            },
+            "required": [
+              "url"
+            ],
+            "type": "object"
+          },
+          "url": {
+            "description": "The link's URL, for a caller that cannot pass a reference. Retracts the\nmost recently added link still present with this URL, so retracting twice\nretracts two rather than re-stamping one.\n\nSequentially. Two concurrent retractions naming the same URL both resolve\nthe same newest-present element and merge into one stamped record, so\nthey retract one link between them rather than two. Naming the link by\nreference is what makes a caller's target unambiguous under concurrency;\nthis spelling trades that for being reachable at all.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "agentName"
+        ],
+        "type": "object"
+      },
+      "SetBodyEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Fabric authenticates the write with that key; this says\nwhich agent acted under it.\n\nRequired so every authored-content call carries structured attribution.\nAuthenticated execution provenance can supersede the field by relaxing it\nto optional without breaking existing callers.",
+            "type": "string"
+          },
+          "body": {
+            "description": "The complete replacement body, persisted verbatim — no trimming, so\nwhitespace-sensitive Markdown survives. An empty body is legal: clearing\na living document is an edit, not an error.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "body",
+          "agentName"
+        ],
+        "type": "object"
+      },
+      "SetTitleEvent": {
+        "properties": {
+          "agentName": {
+            "description": "The agent making this mutation, stored as structured attribution beside\nthe write time. Required so every successful rename is attributed.",
+            "type": "string"
+          },
+          "title": {
+            "description": "The new title, trimmed before it is stored. Must be non-empty.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "agentName"
+        ],
+        "type": "object"
+      },
+      "TopicAuthor": {
+        "properties": {
+          "avatar": {
+            "type": "string"
+          },
+          "kind": {
+            "description": "Open for the same reason `TopicLinkKind` is: this is provided data, so a\nclosed set here could never gain `\"service\"` or whatever acts next.\nWell-known values are `\"person\"` and `\"agent\"`, the latter marking an\nagent acting with its human user's key.",
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "name"
+        ],
+        "type": "object"
+      },
+      "TopicComment": {
+        "properties": {
+          "author": {
+            "$ref": "#/$defs/TopicAuthor",
+            "description": "Snapshot taken at write time (profile enrichment comes later; never gate\nauthorship on a profile wish — CT-1879). Comments carry no minted id:\narray elements have stable entity identity; future editing addresses\nelements by reference (`equals()`), not by a synthetic key.\n\nOptional because durable Topics may contain a comment without structured\nauthorship. Current `addComment` calls require `agentName` and always write\nthis snapshot."
+          },
+          "body": {
+            "default": "",
+            "type": "string"
+          },
+          "editedAt": {
+            "description": "When the body was last revised, absent on a comment never edited. The\noriginal `sentAt` and `author` are left alone: an edit changes what was\nsaid, not who said it or when the thread reached this point.",
+            "type": "number"
+          },
+          "removedAt": {
+            "description": "Set when the comment was retracted, and the retraction is the whole of\nit — the record stays, carrying what it always said. A reader hides it;\n`commentCount` stops counting it; `lastActivityOf` keeps reading its\n`sentAt`, which is what stops a retraction moving a topic backwards in\nthe board's ordering.",
+            "type": "number"
+          },
+          "removedBy": {
+            "$ref": "#/$defs/TopicAuthor"
+          },
+          "sentAt": {
+            "default": 0,
+            "type": "number"
+          }
+        },
+        "required": [
+          "body",
+          "sentAt"
+        ],
+        "type": "object"
+      },
+      "TopicLink": {
+        "properties": {
+          "addedAt": {
+            "type": "number"
+          },
+          "addedBy": {
+            "$ref": "#/$defs/TopicAuthor"
+          },
+          "kind": {
+            "default": "web",
+            "type": "string"
+          },
+          "label": {
+            "default": "",
+            "type": "string"
+          },
+          "removedAt": {
+            "description": "As on a comment, and with one consequence of its own: a retracted link\nstops resolving into `mentions`, so the reference it contributed goes\nwith it rather than outliving the link that made it.",
+            "type": "number"
+          },
+          "removedBy": {
+            "$ref": "#/$defs/TopicAuthor"
+          },
+          "url": {
+            "default": "",
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "url",
+          "label"
+        ],
+        "type": "object"
+      },
+      "TopicMentionRef": {
+        "properties": {
+          "destination": {
+            "type": "unknown"
+          },
+          "modifiedTitle": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "destination",
+          "modifiedTitle"
+        ],
+        "type": "object"
+      },
+      "TopicMentionRefMap": {
+        "additionalProperties": {
+          "$ref": "#/$defs/TopicMentionRef"
+        },
+        "properties": {},
+        "type": "object"
+      },
+      "TopicSummary": {
+        "properties": {
+          "commentCount": {
+            "default": 0,
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "createdAt": {
+            "description": "When the topic was filed (epoch milliseconds), stamped at create.",
+            "type": "number"
+          },
+          "createdBy": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/TopicAuthor"
+              },
+              {
+                "type": "undefined"
+              }
+            ],
+            "default": {
+              "kind": "person",
+              "name": ""
+            }
+          },
+          "lastActivityAt": {
+            "default": 0,
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "title": {
+            "default": "",
+            "description": "The topic's title. Defaulted rather than required, like every other\nfield a board card renders: the card list is a mapped sub-pattern, so\nthis type reaches a piece holding topics written before the field\nexisted as the argument schema its update is checked against, and a\nrequired property those topics lack refuses that update outright.\n`deno task pattern-vintage` is what catches it, by replaying a real\ndeployed board.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "createdAt",
+          "commentCount",
+          "lastActivityAt"
+        ],
+        "type": "object"
+      },
+      "UnmentionEvent": {
+        "properties": {
+          "topic": {
+            "description": "Declared and checked exactly as `MentionEvent.topic` is, and for the same\nreason: a payload that is not a reference matches no stored entry, so\nwithout the check it would remove nothing and report success.",
+            "properties": {
+              "title": {
+                "default": "",
+                "type": "string"
+              }
+            },
+            "required": [
+              "title"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      }
+    },
+    "description": "A #topic — one durable unit of shared attention: a title, a living body\ndocument, a flat chronological comment thread, typed links out to other\ncore objects (PRs, agent sessions, web pages), and the references it makes\nto sibling pieces.\n\nDurable conclusions get folded up into the body — revise it whole with\n`setBody`; the thread holds the deliberation as point-in-time `addComment`\nrecords. The thread only ever grows: `removeComment` and `removeLink` stamp\na record as retracted and leave it where it is, and `editComment` revises a\nbody in place, so what a reader shows is the array filtered rather than the\narray itself. Sign every authored-content mutation with `agentName`:\nFabric records the human principal behind the key; the name says which\nagent acted under it. Reference-only `mention` and `unmention` calls carry\nno content signature. The session-draft cells and `submit*` streams below\nbelong to the rendered page, not the headless contract — they read state\nonly this session holds.",
+    "properties": {
+      "$NAME": {
+        "default": "",
+        "description": "The topic's display name. Like the other derived display fields, a cold\nretained topic may not have produced this path yet; its persisted title\nremains authoritative until it does.",
+        "type": [
+          "string",
+          "undefined"
+        ]
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "addComment": {
+        "$ref": "#/$defs/AddCommentEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Append to the thread — a point-in-time record of progress or\ndeliberation; durable conclusions belong in the body. Returns the\ncomment as recorded, resolved author and `sentAt` included."
+      },
+      "addLink": {
+        "$ref": "#/$defs/AddLinkEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Attach a typed outbound link — a PR, an agent session, a web page.\nReturns the link as recorded, resolved `addedBy` and `addedAt`\nincluded. Appends merge and nothing dedupes: a repeated URL is two\nentries."
+      },
+      "body": {
+        "default": "",
+        "description": "The living document, verbatim Markdown. `setBody` replaces it whole.",
+        "type": "string"
+      },
+      "bodyDraft": {
+        "type": "string"
+      },
+      "bodyUpdatedAt": {
+        "type": [
+          "number",
+          "undefined"
+        ]
+      },
+      "bodyUpdatedBy": {
+        "anyOf": [
+          {
+            "type": "undefined"
+          },
+          {
+            "$ref": "#/$defs/TopicAuthor"
+          }
+        ]
+      },
+      "cancelEditBody": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI wrapper: close the body editor; the session drafts are the discard.",
+        "tier": "wrapper"
+      },
+      "cancelEditTitle": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI wrapper: close the rename editor; the session draft is the discard.",
+        "tier": "wrapper"
+      },
+      "commentCount": {
+        "default": 0,
+        "type": [
+          "number",
+          "undefined"
+        ]
+      },
+      "commentDraft": {
+        "description": "Session-local composer/edit state. These controls belong to a direct Topic\ninstance, not the shared TopicPiece projection used by the tracker's list.",
+        "type": "string"
+      },
+      "comments": {
+        "description": "The thread, in arrival order, each record carrying its author snapshot\nand `sentAt`.\n\nMEMBERSHIP is append-only; a record is not. Nothing is ever removed from\nthis array — `removeComment` stamps `removedAt` and leaves the record in\nplace, and `editComment` revises a body and stamps `editedAt` — so a\nreader that wants the live thread filters on `removedAt` rather than\ntaking the array as it stands. `commentCount` is that filtered count.",
+        "items": {
+          "$ref": "#/$defs/TopicComment"
+        },
+        "type": "array"
+      },
+      "createdAt": {
+        "description": "When the topic was filed (epoch milliseconds), stamped at create.",
+        "type": "number"
+      },
+      "createdBy": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/TopicAuthor"
+          },
+          {
+            "type": "undefined"
+          }
+        ],
+        "default": {
+          "kind": "person",
+          "name": ""
+        }
+      },
+      "editComment": {
+        "$ref": "#/$defs/EditCommentEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Revise a comment's body in place, naming it by reference. Stamps\n`editedAt` and leaves `author` and `sentAt` as they were. Outside the\nprojection for the reason `removeComment` states."
+      },
+      "editingBody": {
+        "description": "Whether the body editor is open.\n\nA bare session-scoped value rather than a cell-wrapped one, and that\nspelling costs a capability worth knowing about before reaching for it: a\nverb cannot take a whole Topic as captured state while any required\nproperty is published this way. The piece does not materialize through the\nverb's state schema, so the argument arrives undefined and the runtime\ndeclines to run the verb at all — \"stream action argument is undefined\n(potential schema mismatch)\", logged rather than thrown, with the write\nsilently absent.\n\nNothing needs that today. A board names a member by writing the piece into\nits namespace, and every path that does so builds the piece inside the\nverb (`addTopic`, the browser composer) or resolves it out of the board's\nown list (`backfillNames`); none of them takes a Topic as an argument, so\nnone reads one through a state schema. Cell-wrapping these two would buy\nthe capability at the cost of a `scope changed` break on every deployed\nTopic, so it waits for a verb that needs it.",
+        "scope": "session",
+        "type": "boolean"
+      },
+      "editingTitle": {
+        "description": "Whether the rename editor is open. Bare for the reason `editingBody`\nstates, and the constraint is per property: cell-wrapping one and not the\nother buys nothing.",
+        "scope": "session",
+        "type": "boolean"
+      },
+      "lastActivityAt": {
+        "default": 0,
+        "type": [
+          "number",
+          "undefined"
+        ]
+      },
+      "linkKindDraft": {
+        "type": "string"
+      },
+      "linkLabelDraft": {
+        "type": "string"
+      },
+      "linkUrlDraft": {
+        "type": "string"
+      },
+      "links": {
+        "description": "Typed outbound links, in arrival order, each carrying its author snapshot\nand `addedAt`. Append-only in membership on the same terms as `comments`:\n`removeLink` stamps rather than removes, and a stamped link additionally\nstops resolving into `mentions`.",
+        "items": {
+          "$ref": "#/$defs/TopicLink"
+        },
+        "type": "array"
+      },
+      "mention": {
+        "$ref": "#/$defs/MentionEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Reference another piece from this topic — the payload is the piece\nitself, stored as a reference. Takes no `agentName` and returns no value;\nFabric retains the authenticated principal behind the edge."
+      },
+      "mentioned": {
+        "default": [],
+        "description": "Pieces referenced outside the prose, recorded by `mention`.",
+        "items": {
+          "type": "unknown"
+        },
+        "type": "array"
+      },
+      "mentions": {
+        "default": [],
+        "description": "Every piece this topic's prose and links point at, as references.\n\nThe board's pivot is declared over this and nothing else, so what one topic\ncosts a full-board scan is exactly this list of identities. Declared\n`unknown[]` because these are references, and comparing them never reads\nwhat is behind them.\n\nThe cell annotation that makes them comparable belongs to the READER, not\nhere: the pivot declares its own view of this list as\n`TopicMentionSource.mentions: ComparableCell<unknown>[]`, and that is what\nmakes its graph settle rather than depend on load order. A published\n`unknown[]` is what each reader annotates for itself.\n\nThe default stands alone: a declared default and `| undefined` collide,\nand the default is what a topic deployed before this path existed\nmaterializes against.",
+        "items": {
+          "type": "unknown"
+        },
+        "type": "array"
+      },
+      "referencedBy": {
+        "default": [],
+        "description": "The topics that mention this one, read out of the board's pivot.\n\nDeclared through `TopicSummary` rather than `TopicPiece`, and that is\nload-bearing rather than stingy: a topic whose backlinks were topics would\nbe a type that contains itself, and resolving one from a list would walk\nthe graph. The summary carries no reference of its own, so it terminates.\nA reader that wants more follows the link, which resolves whole.",
+        "items": {
+          "$ref": "#/$defs/TopicSummary"
+        },
+        "type": "array"
+      },
+      "references": {
+        "$ref": "#/$defs/TopicMentionRefMap",
+        "default": {},
+        "description": "Where this topic's `[Label][key]` mentions point. Durable content, like\n`links`. The body editor works on a session copy of this map, which a save\npublishes here whole, beside the prose whose tokens name its entries."
+      },
+      "referencesDraft": {
+        "$ref": "#/$defs/TopicMentionRefMap",
+        "description": "The body draft's mention map, staged so Cancel can discard it.\n\n`cf-code-editor` writes an entry the moment a mention is inserted and\ndrops one the moment its token leaves the document, neither of them\nwaiting for Save. Pointed at the durable map while `$value` holds a\nsession draft, those writes would outlive a discarded edit: a canceled\ninsertion would leave an edge no token names, and a canceled deletion\nwould strip the destination from a token the durable body still carries.\nThe editor's own ordering assumes its two bindings share a lifetime, so\nthis gives them one."
+      },
+      "removeComment": {
+        "$ref": "#/$defs/RemoveCommentEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Retract a comment, naming it by reference. The record is stamped rather\nthan deleted, so the thread keeps its evidence while a reader stops\nshowing it and `commentCount` stops counting it.\n\nHere rather than on `TopicPiece`, for the reason `setTitle` is: boards\nstore that projection, so it is a demand on every topic they already\nhold, and a required verb added to it would refuse every one deployed\nbefore the verb existed. A verb has no default to be rescued by, so there\nis no compatible way to demand a new one. Addressing the topic directly\nreaches all three of these."
+      },
+      "removeLink": {
+        "$ref": "#/$defs/RemoveLinkEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Retract a link, by reference or by `url`. Stamped like a comment, and a\nretracted link stops resolving into `mentions`. The url spelling exists\nbecause a link record carries no fid for a CLI caller to name. Outside\nthe projection for the reason `removeComment` states."
+      },
+      "saveBody": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI wrapper: publish the session body and mention-map drafts whole,\nattributed to the viewer's Profile — the contract verb is `setBody`.",
+        "tier": "wrapper"
+      },
+      "saveTitle": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI wrapper: save the session title draft under the viewer's Profile —\nthe contract verb is `setTitle`, and both land through the same core, so\na browser rename stamps the same attribution and moves the same activity\nclock.",
+        "tier": "wrapper"
+      },
+      "setBody": {
+        "$ref": "#/$defs/SetBodyEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Replace the living document whole — read it, revise it, write it back\ncomplete; the body is one value with whole-value conflict semantics.\nRequires `agentName` and returns the persisted body with its attribution."
+      },
+      "setTitle": {
+        "$ref": "#/$defs/SetTitleEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Rename the topic. Requires `agentName` and returns the persisted title\nwith its attribution. This direct-address verb stays outside the board's\nnarrow `TopicPiece` demand."
+      },
+      "shortName": {
+        "description": "The name the board calls this topic by, read out of the board's names\ntable by identity. The display name stays the title — this rides beside\nit, under the name a mention pill reads it by (`Mentionable.shortName` in\n`packages/ui/src/v2/core/mentionable.ts`), so a mention of this topic\nelsewhere gains the number as soon as the board names it.\n\nAbsent for a topic no board has named, or one wired to no board: the\nlookup produces nothing and the property is simply not there. Every\nconsumer treats that as no name — the badge renders nothing, a universe\nrow matches no `#42` query, and a mention pill shows no number\n(`_trackRefShortName` in\n`packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts` reads an\nabsent name exactly as it reads a blank one).\n\nOptional rather than defaulted, and the difference is the whole reason\nthis projection still applies over a deployed board: this is what a\nboard's stored list is validated against, and a defaulted property there\nmoves the demand's defaults below an array constraint the compatibility\nproof cannot show stable under default insertion.",
+        "tags": [
+          "42"
+        ],
+        "type": "string"
+      },
+      "startEditBody": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI wrapper: open the body editor, seeding the session drafts from the\ndurable body and mention map.",
+        "tier": "wrapper"
+      },
+      "startEditTitle": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI wrapper: open the rename editor, seeding the session draft from the\ndurable title.",
+        "tier": "wrapper"
+      },
+      "submitComment": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI wrapper: append the session comment draft under the viewer's\nProfile. Reads session-local state, so it is a silent no-op headless —\nthe contract verb is `addComment`.",
+        "tier": "wrapper"
+      },
+      "submitLink": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI wrapper: append the session link drafts under the viewer's Profile —\nthe contract verb is `addLink`.",
+        "tier": "wrapper"
+      },
+      "title": {
+        "default": "",
+        "description": "The topic's title. Defaulted rather than required, like every other\nfield a board card renders: the card list is a mapped sub-pattern, so\nthis type reaches a piece holding topics written before the field\nexisted as the argument schema its update is checked against, and a\nrequired property those topics lack refuses that update outright.\n`deno task pattern-vintage` is what catches it, by replaying a real\ndeployed board.",
+        "type": "string"
+      },
+      "titleDraft": {
+        "type": "string"
+      },
+      "titleUpdatedAt": {
+        "type": [
+          "number",
+          "undefined"
+        ]
+      },
+      "titleUpdatedBy": {
+        "anyOf": [
+          {
+            "type": "undefined"
+          },
+          {
+            "$ref": "#/$defs/TopicAuthor"
+          }
+        ],
+        "description": "Attribution of the last rename; unset until the first `setTitle`.\nBeside `setTitle` rather than on the projection, for the same reason."
+      },
+      "unmention": {
+        "$ref": "#/$defs/UnmentionEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Stop referencing a piece: removes every `mention`-made entry naming it.\nReferences made in the prose are retracted by editing the prose, not by\nthis. Takes no `agentName` and returns no value."
+      }
+    },
+    "required": [
+      "commentDraft",
+      "bodyDraft",
+      "editingBody",
+      "titleDraft",
+      "editingTitle",
+      "linkUrlDraft",
+      "linkLabelDraft",
+      "linkKindDraft",
+      "referencesDraft",
+      "setTitle",
+      "removeComment",
+      "editComment",
+      "removeLink",
+      "startEditTitle",
+      "saveTitle",
+      "cancelEditTitle",
+      "submitComment",
+      "startEditBody",
+      "saveBody",
+      "cancelEditBody",
+      "submitLink",
+      "$UI",
+      "body",
+      "comments",
+      "links",
+      "mentions",
+      "references",
+      "mentioned",
+      "referencedBy",
+      "addComment",
+      "addLink",
+      "setBody",
+      "mention",
+      "unmention",
+      "$NAME",
+      "title",
+      "createdAt",
+      "commentCount",
+      "lastActivityAt"
+    ],
+    "tags": [
+      "topic"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/collection-naming/board.test.tsx
+++ b/packages/patterns/collection-naming/board.test.tsx
@@ -2,7 +2,7 @@
  * Pattern tests for the exemplar board and its item: allocation on create,
  * density, a name never reused, a name kept whatever happens to its item, the
  * backfill, its idempotence, a backfilled name following its member when the
- * list shifts under it and an empty position naming nothing, index rows that
+ * list shifts under it and only a member taking a name, index rows that
  * are the members and the default an unnamed member's `shortName` reads as,
  * the mention universe and the name each of its rows carries, the item reading
  * its own name out of the board's table, the declaration, the bound on what a
@@ -532,33 +532,38 @@ export default pattern(() => {
       equals(map["2"] as object, shiftItems.key(0));
   });
 
-  // A position holding nothing names nothing, `null` as much as `undefined`.
-  // Both sit ahead of the member so that skipping only one of them is visible:
-  // the member takes the first name, and a run that named either value would
-  // show up in what it returned as well as in what it wrote. The list declares
-  // the two so the case needs no cast, and the library is called directly
-  // because no board admits that shape — `Board` demands `ItemDemand` of every
-  // position, which neither value satisfies.
-  const holeItems = new Writable<
-    (ItemDemand | null | undefined)[] | Default<[]>
+  // Only a position holding a member takes a name. Four values that are not
+  // one sit ahead of the member, one per way the guard could be narrowed:
+  // `undefined` and `null` for the two halves of "holds nothing", and a
+  // truthy number and a truthy string so that a truthiness test is no
+  // substitute either. The member behind them takes the FIRST name, so any
+  // value named ahead of it shows up in what the run returned as much as in
+  // what it wrote. The list declares the four so the case needs no cast, and
+  // the library is called directly because no board admits that shape —
+  // `Board` demands `ItemDemand` of every position, which none of them
+  // satisfies.
+  const nonMemberItems = new Writable<
+    (ItemDemand | null | undefined | number | string)[] | Default<[]>
   >([]);
-  const holeNames = new Writable<NamesMap>({});
-  const action_file_behind_two_empty_positions = action(() => {
-    holeItems.set([
+  const nonMemberNames = new Writable<NamesMap>({});
+  const action_file_behind_non_members = action(() => {
+    nonMemberItems.set([
       undefined,
       null,
-      Item({ title: "Behind the empty positions", createdAt: 1 }),
+      42,
+      "not a member",
+      Item({ title: "Behind the non-members", createdAt: 1 }),
     ]);
   });
-  const action_backfill_over_the_empty_positions = action(() => {
-    assigned.set(backfillNames(holeItems, holeNames));
+  const action_backfill_over_non_members = action(() => {
+    assigned.set(backfillNames(nonMemberItems, nonMemberNames));
   });
-  const assert_an_empty_position_names_nothing = assert(() =>
+  const assert_only_a_member_takes_a_name = assert(() =>
     assigned.get().join(",") === "1" &&
-    Object.keys((holeNames.get() ?? {}) as NamesMap).join(",") === "1" &&
+    Object.keys((nonMemberNames.get() ?? {}) as NamesMap).join(",") === "1" &&
     equals(
-      ((holeNames.get() ?? {}) as NamesMap)["1"] as object,
-      holeItems.key(2),
+      ((nonMemberNames.get() ?? {}) as NamesMap)["1"] as object,
+      nonMemberItems.key(4),
     )
   );
 
@@ -704,9 +709,9 @@ export default pattern(() => {
       { assertion: assert_the_shifting_pair_is_named },
       { action: action_remove_the_first_that_shifts },
       { assertion: assert_a_backfilled_name_follows_its_member },
-      { action: action_file_behind_two_empty_positions },
-      { action: action_backfill_over_the_empty_positions },
-      { assertion: assert_an_empty_position_names_nothing },
+      { action: action_file_behind_non_members },
+      { action: action_backfill_over_non_members },
+      { assertion: assert_only_a_member_takes_a_name },
       { assertion: assert_bare_board_has_no_items },
       { assertion: assert_bare_board_names_read_empty },
       { action: action_bare_board_creates },

--- a/packages/patterns/collection-naming/board.test.tsx
+++ b/packages/patterns/collection-naming/board.test.tsx
@@ -532,28 +532,33 @@ export default pattern(() => {
       equals(map["2"] as object, shiftItems.key(0));
   });
 
-  // A position holding nothing names nothing. The list declares an empty
-  // position so the case needs no cast, and the library is called directly
-  // because no board demands that shape of its items. The member behind the
-  // hole takes the first name, so a run that named the position would show up
-  // in what it returned as well as in what it wrote.
-  const holeItems = new Writable<(ItemDemand | undefined)[] | Default<[]>>([]);
+  // A position holding nothing names nothing, `null` as much as `undefined`.
+  // Both sit ahead of the member so that skipping only one of them is visible:
+  // the member takes the first name, and a run that named either value would
+  // show up in what it returned as well as in what it wrote. The list declares
+  // the two so the case needs no cast, and the library is called directly
+  // because no board admits that shape — `Board` demands `ItemDemand` of every
+  // position, which neither value satisfies.
+  const holeItems = new Writable<
+    (ItemDemand | null | undefined)[] | Default<[]>
+  >([]);
   const holeNames = new Writable<NamesMap>({});
-  const action_file_behind_a_hole = action(() => {
+  const action_file_behind_two_empty_positions = action(() => {
     holeItems.set([
       undefined,
-      Item({ title: "Behind the hole", createdAt: 1 }),
+      null,
+      Item({ title: "Behind the empty positions", createdAt: 1 }),
     ]);
   });
-  const action_backfill_over_the_hole = action(() => {
+  const action_backfill_over_the_empty_positions = action(() => {
     assigned.set(backfillNames(holeItems, holeNames));
   });
-  const assert_a_hole_names_nothing = assert(() =>
+  const assert_an_empty_position_names_nothing = assert(() =>
     assigned.get().join(",") === "1" &&
     Object.keys((holeNames.get() ?? {}) as NamesMap).join(",") === "1" &&
     equals(
       ((holeNames.get() ?? {}) as NamesMap)["1"] as object,
-      holeItems.key(1),
+      holeItems.key(2),
     )
   );
 
@@ -699,9 +704,9 @@ export default pattern(() => {
       { assertion: assert_the_shifting_pair_is_named },
       { action: action_remove_the_first_that_shifts },
       { assertion: assert_a_backfilled_name_follows_its_member },
-      { action: action_file_behind_a_hole },
-      { action: action_backfill_over_the_hole },
-      { assertion: assert_a_hole_names_nothing },
+      { action: action_file_behind_two_empty_positions },
+      { action: action_backfill_over_the_empty_positions },
+      { assertion: assert_an_empty_position_names_nothing },
       { assertion: assert_bare_board_has_no_items },
       { assertion: assert_bare_board_names_read_empty },
       { action: action_bare_board_creates },

--- a/packages/patterns/collection-naming/board.test.tsx
+++ b/packages/patterns/collection-naming/board.test.tsx
@@ -1,13 +1,15 @@
 /**
  * Pattern tests for the exemplar board and its item: allocation on create,
  * density, a name never reused, a name kept whatever happens to its item, the
- * backfill and its idempotence, index rows that are the members and the
- * default an unnamed member's `shortName` reads as, the mention universe and
- * the name each of its rows carries, the item reading its own name out of the
- * board's table, the declaration, the bound on what a read of the namespace or
- * the universe expands, and the rejections. Every rejection here is a thrown
- * verb, so the runtime errors are required, and the count is exact: a guard
- * quietly reverting to a silent return fails the suite.
+ * backfill, its idempotence, a backfilled name following its member when the
+ * list shifts under it and an empty position naming nothing, index rows that
+ * are the members and the default an unnamed member's `shortName` reads as,
+ * the mention universe and the name each of its rows carries, the item reading
+ * its own name out of the board's table, the declaration, the bound on what a
+ * read of the namespace or the universe expands, and the rejections. Every
+ * rejection here is a thrown verb, so the runtime errors are required, and the
+ * count is exact: a guard quietly reverting to a silent return fails the
+ * suite.
  *
  * A property worth knowing before adding another guard test here: a guard that
  * PREVENTS a write can only be caught where the value it would have written
@@ -479,6 +481,82 @@ export default pattern(() => {
     twinBoard.index?.[1]?.shortName === "1"
   );
 
+  // A backfilled name records the member, not the place it sat. Removing the
+  // first of two shifts the second into position 0, so a name recorded as a
+  // position would retarget there: `1` would follow the shift onto the member
+  // that arrived, and `2` would point at a slot the list no longer has.
+  const shiftItems = new Writable<ItemDemand[] | Default<[]>>([]);
+  const shiftNames = new Writable<NamesMap>({});
+  const shiftBoard = Board({ items: shiftItems, names: shiftNames });
+  // A handle on the first member that outlives its place in the list, which is
+  // what lets the assertion below name it once it has left. Held in a map for
+  // the reason the namespace is one: an `unknown` value is stored as a link
+  // and read back as one, so the handle expands no member.
+  const departed = new Writable<NamesMap>({});
+  const action_file_two_that_shift = action(() => {
+    const first = Item({
+      title: "Shifting one",
+      createdAt: 1,
+      boardNames: shiftBoard.namesTable,
+    });
+    departed.key("first").set(first);
+    shiftItems.push(first);
+    shiftItems.push(
+      Item({
+        title: "Shifting two",
+        createdAt: 2,
+        boardNames: shiftBoard.namesTable,
+      }),
+    );
+  });
+  const action_backfill_the_shifting_pair = action(() => {
+    assigned.set(backfillNames(shiftItems, shiftNames));
+  });
+  const assert_the_shifting_pair_is_named = assert(() =>
+    assigned.get().join(",") === "1,2" &&
+    shiftBoard.index?.[0]?.shortName === "1" &&
+    shiftBoard.index?.[1]?.shortName === "2"
+  );
+  const action_remove_the_first_that_shifts = action(() => {
+    shiftItems.removeByValue(shiftItems.key(0));
+  });
+  const assert_a_backfilled_name_follows_its_member = assert(() => {
+    const map = (shiftBoard.names ?? {}) as NamesMap;
+    return shiftBoard.itemCount === 1 &&
+      shiftBoard.index?.[0]?.title === "Shifting two" &&
+      equals(
+        map["1"] as object,
+        ((departed.get() ?? {}) as NamesMap)["first"] as object,
+      ) &&
+      !equals(map["1"] as object, shiftItems.key(0)) &&
+      equals(map["2"] as object, shiftItems.key(0));
+  });
+
+  // A position holding nothing names nothing. The list declares an empty
+  // position so the case needs no cast, and the library is called directly
+  // because no board demands that shape of its items. The member behind the
+  // hole takes the first name, so a run that named the position would show up
+  // in what it returned as well as in what it wrote.
+  const holeItems = new Writable<(ItemDemand | undefined)[] | Default<[]>>([]);
+  const holeNames = new Writable<NamesMap>({});
+  const action_file_behind_a_hole = action(() => {
+    holeItems.set([
+      undefined,
+      Item({ title: "Behind the hole", createdAt: 1 }),
+    ]);
+  });
+  const action_backfill_over_the_hole = action(() => {
+    assigned.set(backfillNames(holeItems, holeNames));
+  });
+  const assert_a_hole_names_nothing = assert(() =>
+    assigned.get().join(",") === "1" &&
+    Object.keys((holeNames.get() ?? {}) as NamesMap).join(",") === "1" &&
+    equals(
+      ((holeNames.get() ?? {}) as NamesMap)["1"] as object,
+      holeItems.key(1),
+    )
+  );
+
   // A board given no namespace at all — the shape of one deployed before it
   // numbered anything — reads as having no names, and its first create
   // materializes the map with the first name.
@@ -616,6 +694,14 @@ export default pattern(() => {
       { action: action_list_one_item_twice },
       { action: action_backfill_the_twins },
       { assertion: assert_twin_is_named_once },
+      { action: action_file_two_that_shift },
+      { action: action_backfill_the_shifting_pair },
+      { assertion: assert_the_shifting_pair_is_named },
+      { action: action_remove_the_first_that_shifts },
+      { assertion: assert_a_backfilled_name_follows_its_member },
+      { action: action_file_behind_a_hole },
+      { action: action_backfill_over_the_hole },
+      { assertion: assert_a_hole_names_nothing },
       { assertion: assert_bare_board_has_no_items },
       { assertion: assert_bare_board_names_read_empty },
       { action: action_bare_board_creates },

--- a/packages/patterns/collection-naming/naming.ts
+++ b/packages/patterns/collection-naming/naming.ts
@@ -263,31 +263,41 @@ export const namesTable = lift(
 /**
  * Names every member of `members` that has no name, in filing order, and
  * returns the names it wrote — exactly the keys it added to `names`, in the
- * order it added them. A member already named is skipped, whatever position
- * it holds, and a member listed at two positions is named once: membership
- * is asked of IDENTITY, never of position. Idempotent: a run over a fully
- * named list writes nothing and returns `[]`.
+ * order it added them. An entry records the member a position holds rather
+ * than the position, so it names that member still once the list has shifted
+ * under it; a position holding nothing is skipped and names nothing. A member
+ * already named is skipped, whatever position it holds, and a member listed at
+ * two positions is named once: membership is asked of IDENTITY, never of
+ * position. Idempotent: a run over a fully named list writes nothing and
+ * returns `[]`.
  *
  * Called from a verb body for the reason `assignName()` is: the keyset read
  * and the key writes are one transaction, so a create that lands while a
  * backfill runs serializes with it rather than colliding on a name.
  */
 export function backfillNames(
-  members: { get(): readonly unknown[]; key(index: number): object },
+  members: {
+    get(): readonly unknown[];
+    key(index: number): { resolveAsCell(): object };
+  },
   names: NamesMapCell,
 ): string[] {
   const map = names.get() ?? {};
   // The members with a name: those the map already holds, and — as the walk
   // goes — those this run names, so a member met again is not named again.
   const named = Object.values(map) as (object | undefined)[];
-  const count = members.get().length;
+  const listed = members.get();
   const written: string[] = [];
   let next = nextNameAmong(Object.keys(map));
-  for (let index = 0; index < count; index++) {
-    // The cell at the position rather than the value read out of it: a cell
-    // is an identity `equals` can match against the map's links, and it is
-    // what the map stores.
-    const member = members.key(index);
+  for (let index = 0; index < listed.length; index++) {
+    // A position holding nothing has no member to name.
+    if (listed[index] === undefined) continue;
+    // The member the position holds, pinned to its own document. An entry
+    // outlives its member's place in the list, so what the map records has to
+    // be the member; the cell at a position is an address in the list, which
+    // names whoever sits there when the entry is read. The pinned cell is
+    // also the identity `equals` matches against the map's links.
+    const member = members.key(index).resolveAsCell();
     if (named.some((other) => equals(member, other))) continue;
     names.key(next).set(member);
     written.push(next);

--- a/packages/patterns/collection-naming/naming.ts
+++ b/packages/patterns/collection-naming/naming.ts
@@ -261,13 +261,33 @@ export const namesTable = lift(
 );
 
 /**
+ * Whether `value` is an object, which is what a position has to hold for a
+ * member to be there: a member is a document, and a document reads as an
+ * object whatever schema it arrived through — a materialized value, a query
+ * proxy, a cell.
+ *
+ * `Object(value) === value` is the whole test, and it is one expression on
+ * purpose: coercing a primitive yields a fresh wrapper that fails the
+ * comparison, coercing an object yields the object itself, and there is no
+ * arm to drop. A `typeof` test does not decide this, because `typeof null` is
+ * `object`. A function is an object here and a member never is one, which
+ * costs nothing: `FabricValue` holds no function, so no stored position can.
+ *
+ * The bound is that an object is not necessarily a member. An array passes,
+ * and so does any object a foreign writer left at a position; telling either
+ * apart from a member would mean reading through the member.
+ */
+const isObject = (value: unknown): boolean => Object(value) === value;
+
+/**
  * Names every member of `members` that has no name, in filing order, and
  * returns the names it wrote — exactly the keys it added to `names`, in the
  * order it added them. An entry records the member a position holds rather
  * than the position, so it names that member still once the list has shifted
- * under it; a position holding `null` or `undefined` is skipped and names
- * nothing, while a position holding any other value is named whether or not
- * it is a member. A member already named is skipped, whatever position it
+ * under it; only a position holding an object is named, so `undefined`,
+ * `null` and every other primitive name nothing, while an object that is no
+ * member — an array, or whatever a foreign writer left there — is named as
+ * though it were one. A member already named is skipped, whatever position it
  * holds, and a member listed at two positions is named once: membership is
  * asked of IDENTITY, never of position. Idempotent: a run over a fully named
  * list writes nothing and returns `[]`.
@@ -291,9 +311,11 @@ export function backfillNames(
   const written: string[] = [];
   let next = nextNameAmong(Object.keys(map));
   for (let index = 0; index < listed.length; index++) {
-    // A position holding nothing has no member to name. `== null` is the
-    // whole of that: it admits `null` and `undefined` and no other value.
-    if (listed[index] == null) continue;
+    // Only a position holding an object can hold a member. At one holding
+    // `undefined`, `null`, or any other primitive there is no member link for
+    // `resolveAsCell()` to follow, so an entry written for it would address
+    // the position itself — the thing this walk exists to not do.
+    if (!isObject(listed[index])) continue;
     // The member the position holds, pinned to its own document. An entry
     // outlives its member's place in the list, so what the map records has to
     // be the member; the cell at a position is an address in the list, which

--- a/packages/patterns/collection-naming/naming.ts
+++ b/packages/patterns/collection-naming/naming.ts
@@ -265,11 +265,12 @@ export const namesTable = lift(
  * returns the names it wrote — exactly the keys it added to `names`, in the
  * order it added them. An entry records the member a position holds rather
  * than the position, so it names that member still once the list has shifted
- * under it; a position holding nothing is skipped and names nothing. A member
- * already named is skipped, whatever position it holds, and a member listed at
- * two positions is named once: membership is asked of IDENTITY, never of
- * position. Idempotent: a run over a fully named list writes nothing and
- * returns `[]`.
+ * under it; a position holding `null` or `undefined` is skipped and names
+ * nothing, while a position holding any other value is named whether or not
+ * it is a member. A member already named is skipped, whatever position it
+ * holds, and a member listed at two positions is named once: membership is
+ * asked of IDENTITY, never of position. Idempotent: a run over a fully named
+ * list writes nothing and returns `[]`.
  *
  * Called from a verb body for the reason `assignName()` is: the keyset read
  * and the key writes are one transaction, so a create that lands while a
@@ -290,8 +291,9 @@ export function backfillNames(
   const written: string[] = [];
   let next = nextNameAmong(Object.keys(map));
   for (let index = 0; index < listed.length; index++) {
-    // A position holding nothing has no member to name.
-    if (listed[index] === undefined) continue;
+    // A position holding nothing has no member to name. `== null` is the
+    // whole of that: it admits `null` and `undefined` and no other value.
+    if (listed[index] == null) continue;
     // The member the position holds, pinned to its own document. An entry
     // outlives its member's place in the list, so what the map records has to
     // be the member; the cell at a position is an address in the list, which

--- a/packages/patterns/topics/topic.tsx
+++ b/packages/patterns/topics/topic.tsx
@@ -728,10 +728,11 @@ export interface TopicOutput extends TopicPiece {
    *
    * Nothing needs that today. A board names a member by writing the piece into
    * its namespace, and every path that does so builds the piece inside the
-   * verb (`addTopic`, the browser composer) or writes a list POSITION rather
-   * than a held piece (`backfillNames`). Cell-wrapping these two would buy the
-   * capability at the cost of a `scope changed` break on every deployed Topic,
-   * so it waits for a verb that needs it.
+   * verb (`addTopic`, the browser composer) or resolves it out of the board's
+   * own list (`backfillNames`); none of them takes a Topic as an argument, so
+   * none reads one through a state schema. Cell-wrapping these two would buy
+   * the capability at the cost of a `scope changed` break on every deployed
+   * Topic, so it waits for a verb that needs it.
    */
   editingBody: PerSession<boolean>;
   titleDraft: PerSession<Writable<string>>;


### PR DESCRIPTION
## Why

`backfillNames` stored the cell at a **list position** rather than the member that position holds. `assignName` — the path `addItem` takes — already stored the member, so the two ways a name gets written disagreed about what a name holds.

That breaks the library's own contract, which is that a member keeps its name whatever happens to it. Measured on a fixture, after removing the first member of a two-member board:

- name `1` retargeted onto the member that shifted into position 0
- name `2`, whose slot left the list, resolved to nothing at all and dropped out of `namesTable` entirely, so `nameOf` returned `undefined` for a member that has a name

The defect was invisible to every existing assertion because `equals` resolves links before comparing: while a list is unshifted, a positional link and the member cell resolve to the same document. Only a removal separates them.

This blocks the Estuary backfill — it would have written 125 links to slots — and it also means the clone rehearsal's `/top/<n>` observations were made through these links, so that evidence has to be recollected after this lands.

Found by the architecture review of the collection-naming arc.

## What Changed

- `backfillNames` pins the member a position holds with `resolveAsCell()`, which is the documented idiom for this shape (`packages/patterns/cfc/README.md`: "pin the terminal cell with `resolveAsCell()` before storing one, or what gets stored is 'whoever the reader resolves'").
- A position holding nothing is skipped rather than named.
- The `//` comment asserting the positional cell "is what the map stores" was false; it now says why the pin is needed.
- `topic.tsx`'s `editingBody` doc comment asserted the positional behavior as a reason. That sentence is now false, so it is corrected. Doc comments on schema-generator types become schema `description`, so this changes Topics' contract hash — hence the one appended baseline.

## Test plan

- New case in `board.test.tsx`: backfill, remove the first member by value, assert name `1` still resolves to the member it named and **not** to the one that shifted into position 0.
- Verified failing before the fix and passing after. Conjuncts were reordered twice to prove each is independently load-bearing rather than short-circuited past.
- The hole-skip guard was mutated out to confirm it is not decoration: without it an empty position gets named `1`.
- `cf test collection-naming/` 67 passed · `cf test topics/` 122 passed · patterns lane-1 62 passed · `deno task cfcheck` 409 pattern files · `pattern-compat` clean over topics and collection-naming.

Note on gate coverage: `deno task check` does **not** cover these files — `tasks/typecheck.ts` lists 15 `packages/patterns/*` subdirectories and neither `collection-naming` nor `topics` is among them. `cfcheck` covers the sources; `board.test.tsx` is type-checked by no repo-wide gate, only by `cf check`/`cf test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kp8NcNXPougGPyJCEyYtob

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6987?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

