### PR TITLE
fix(tasks): bound the publisher's rollup read to a few shards

### DIFF
--- a/docs/development/test-selection.md
+++ b/docs/development/test-selection.md
@@ -170,6 +170,18 @@ name, so shard order does not describe when the runs happened. Same-commit
 disagreement and environmental failures also require evidence from the
 whole day before any failure is classified.
 
+A busy day is about six million observations, so the temporary file for
+one runs to a gigabyte or two. One day is live at a time, and its file is
+removed before the next day is read.
+
+Keeping those observations in memory rather than in a file would fit
+today. Folding the largest day so far peaks a little over a gigabyte with
+the file, and holding what it spooled would add an estimated gigabyte and
+a half to two gigabytes, against a heap V8 caps near four gigabytes. That
+estimate comes from the size of an observation rather than from a measured
+run without the file. The file is what leaves room for the corpus to grow
+into.
+
 The temporary file is removed when the day finishes or the read fails.
 A shard that cannot be read ends the publisher run without writing a
 manifest or aggregate. The previous manifest stays newest. Completed

--- a/docs/development/test-selection.md
+++ b/docs/development/test-selection.md
@@ -161,11 +161,20 @@ choose.
 
 A run reaching a pair nothing is folded from takes that day whole from
 its rollup, which is a manifest and a few tens of shards against the
-day's thousands of raw objects. It reads a day whole or not at all: a
-shard it could not read would leave the day partly folded, and recording
-the day as done would then hide the rest of it from every later run. The
-days it did take are recorded, so no later run over a wide window folds
-their raw objects on top and doubles every catch in them.
+day's thousands of raw objects. The publisher reads four shards at a time
+and writes each run's observations to a temporary file. It keeps an offset
+and timestamp per run in memory. The fold replays that file in time order
+for each evidence pass and the classification pass, holding one run's
+observations at a time. Shards are assigned by a hash of the raw object's
+name, so shard order does not describe when the runs happened. Same-commit
+disagreement and environmental failures also require evidence from the
+whole day before any failure is classified.
+
+The temporary file is removed when the day finishes or the read fails.
+A shard that cannot be read ends the publisher run without writing a
+manifest or aggregate. The previous manifest stays newest. Completed
+days are recorded, so no later run over a wide window folds their raw
+objects on top and doubles every catch in them.
 
 A rollup is written by the one principal here whose credential exists as
 key material, so it carries weaker provenance than the raw records it

--- a/tasks/test-selection-publish.test.ts
+++ b/tasks/test-selection-publish.test.ts
@@ -13,13 +13,19 @@ import {
   writeToken,
 } from "./test-selection-publish.ts";
 import {
+  AliasResolver,
   buildObjectBody,
   gunzipToText,
   parseManifest,
   type RunContext,
   type TestRecord,
 } from "@commonfabric/test-support/records";
-import { reportFromText } from "./test-selection/build.ts";
+import {
+  emptyAggregate,
+  Fold,
+  parseAggregate,
+  reportFromText,
+} from "./test-selection/build.ts";
 import type { Suite } from "./test-topology/suite.ts";
 import { join } from "@std/path";
 
@@ -217,6 +223,7 @@ function object(
   commit: string,
   outcome: TestRecord["outcome"],
   at: string,
+  branch = "main",
 ): string {
   const context: RunContext = {
     schema: 1,
@@ -225,14 +232,14 @@ function object(
     repo: "commontoolsinc/labs",
     commit,
     dirty: false,
-    branch: "main",
+    branch,
     env: "ci",
     ci: {
       workflowRunId: commit,
       runAttempt: 1,
       workflow: "deno.yml",
       job: "Test (1/8)",
-      event: "push",
+      event: branch === "main" ? "push" : "pull_request",
     },
     os: "linux",
     arch: "x86_64",
@@ -663,20 +670,22 @@ describe("publish() over a day that has been compacted", () => {
   });
 
   it("ends the run when a shard of its rollup will not read", async () => {
-    // The shards that did read are in the fold already, and a rollup
-    // carries no record of which arrivals it covers, so nothing could
-    // tell a later run which part of the day it still owes.
-    const objects = {
-      ...seed(),
-      [ROLLUP]: object("c3", "fail", "2026-08-20T03:00:00.000Z"),
-    };
+    const shards = Array.from(
+      { length: SHARD_CHUNK + 1 },
+      (_, index) =>
+        `labs/test-records/aggregated/v1/${DAY}/shard-${index}.ndjson`,
+    );
+    const objects = Object.fromEntries(shards.map((shard) => [
+      shard,
+      object("c3", "fail", "2026-08-20T03:00:00.000Z"),
+    ]));
     const { store, created } = fakeStore(objects, {
-      [DAY]: [ROLLUP, `labs/test-records/aggregated/v1/${DAY}/shard-1.ndjson`],
+      [DAY]: shards,
     });
     const broken: StoreAccess = {
       ...store,
       read: (name) =>
-        name.endsWith("shard-1.ndjson")
+        name === shards.at(-1)
           ? Promise.reject(new Error("that shard is gone"))
           : store.read(name),
     };
@@ -685,9 +694,55 @@ describe("publish() over a day that has been compacted", () => {
     expect(created.size).toBe(0);
   });
 
-  it("holds a few of a day's shards at a time rather than the day", async () => {
-    // A day is written as up to two dozen shards, and one decompresses to
-    // some tens of megabytes of text.
+  for (
+    const { name, first, last } of [
+      {
+        name: "orders main runs across shard batches",
+        first: object("c2", "pass", "2026-08-20T02:00:00.000Z"),
+        last: object("c1", "fail", "2026-08-20T01:00:00.000Z"),
+      },
+      {
+        name:
+          "classifies same-commit disagreement across shard batches as a flake",
+        first: object("c1", "fail", "2026-08-20T01:00:00.000Z", "feature"),
+        last: object("c1", "pass", "2026-08-20T02:00:00.000Z", "feature"),
+      },
+    ]
+  ) {
+    it(name, async () => {
+      const shards = Array.from(
+        { length: SHARD_CHUNK + 1 },
+        (_, index) =>
+          `labs/test-records/aggregated/v1/${DAY}/shard-${index}.ndjson`,
+      );
+      const objects = Object.fromEntries(shards.map((shard, index) => [
+        shard,
+        index === 0
+          ? first
+          : index === SHARD_CHUNK
+          ? last
+          : object(`skip-${index}`, "skip", "2026-08-20T01:30:00.000Z"),
+      ]));
+      const whole = new Fold(
+        emptyAggregate("2026-08-20"),
+        new AliasResolver([]),
+        "2026-08-20",
+      );
+      whole.add(shards.map((shard) => reportFromText(shard, objects[shard]!)));
+      const { store, created } = fakeStore(objects, { [DAY]: shards });
+      expect(await publish(["--bootstrap", "--days", "1"], store, NOW, suites))
+        .toBe(0);
+      const stateName = [...created.keys()].find((name) =>
+        name.includes("/state/")
+      )!;
+      const state = parseAggregate(await gunzipToText(created.get(stateName)!));
+      expect(state?.states).toEqual(whole.finish().aggregate.states);
+      expect(state?.folded).toEqual(shards);
+      expect(state?.compacted).toEqual([`ci\t${DAY}`]);
+    });
+  }
+
+  it("consumes each batch before requesting the next shards", async () => {
     const shards = Array.from(
       { length: SHARD_CHUNK * 2 + 1 },
       (_, index) =>
@@ -701,14 +756,26 @@ describe("publish() over a day that has been compacted", () => {
     const read: string[] = [];
     let live = 0;
     let peak = 0;
+    const consumed = new Set<string>();
     const watched: StoreAccess = {
       ...store,
       read: async (name) => {
+        expect(read.length - consumed.size).toBeLessThan(SHARD_CHUNK);
         read.push(name);
         live++;
         peak = Math.max(peak, live);
         try {
-          return await store.read(name);
+          const report = await store.read(name);
+          return {
+            ...report,
+            reports: report.reports.map((group) => ({
+              ...group,
+              get records() {
+                consumed.add(name);
+                return group.records;
+              },
+            })),
+          };
         } finally {
           live--;
         }

--- a/tasks/test-selection-publish.test.ts
+++ b/tasks/test-selection-publish.test.ts
@@ -8,6 +8,7 @@ import {
   parseArgs,
   partitionOf,
   publish,
+  SHARD_CHUNK,
   type StoreAccess,
   writeToken,
 } from "./test-selection-publish.ts";
@@ -661,9 +662,10 @@ describe("publish() over a day that has been compacted", () => {
     expect(read).toContain(local);
   });
 
-  it("leaves a day open when a shard of its rollup will not read", async () => {
-    // Folded half, the day would be marked compacted and the rest of it
-    // would be hidden from every later run.
+  it("ends the run when a shard of its rollup will not read", async () => {
+    // The shards that did read are in the fold already, and a rollup
+    // carries no record of which arrivals it covers, so nothing could
+    // tell a later run which part of the day it still owes.
     const objects = {
       ...seed(),
       [ROLLUP]: object("c3", "fail", "2026-08-20T03:00:00.000Z"),
@@ -671,22 +673,51 @@ describe("publish() over a day that has been compacted", () => {
     const { store, created } = fakeStore(objects, {
       [DAY]: [ROLLUP, `labs/test-records/aggregated/v1/${DAY}/shard-1.ndjson`],
     });
-    const read: string[] = [];
     const broken: StoreAccess = {
       ...store,
-      read: (name) => {
-        read.push(name);
-        return name.endsWith("shard-1.ndjson")
+      read: (name) =>
+        name.endsWith("shard-1.ndjson")
           ? Promise.reject(new Error("that shard is gone"))
-          : store.read(name);
-      },
+          : store.read(name),
     };
     expect(await publish(["--bootstrap", "--days", "1"], broken, NOW, suites))
+      .toBe(1);
+    expect(created.size).toBe(0);
+  });
+
+  it("holds a few of a day's shards at a time rather than the day", async () => {
+    // A day is written as up to two dozen shards, and one decompresses to
+    // some tens of megabytes of text.
+    const shards = Array.from(
+      { length: SHARD_CHUNK * 2 + 1 },
+      (_, index) =>
+        `labs/test-records/aggregated/v1/${DAY}/shard-${index}.ndjson`,
+    );
+    const objects: Record<string, string> = { ...seed() };
+    for (const shard of shards) {
+      objects[shard] = object("c3", "fail", "2026-08-20T03:00:00.000Z");
+    }
+    const { store } = fakeStore(objects, { [DAY]: shards });
+    const read: string[] = [];
+    let live = 0;
+    let peak = 0;
+    const watched: StoreAccess = {
+      ...store,
+      read: async (name) => {
+        read.push(name);
+        live++;
+        peak = Math.max(peak, live);
+        try {
+          return await store.read(name);
+        } finally {
+          live--;
+        }
+      },
+    };
+    expect(await publish(["--bootstrap", "--days", "1"], watched, NOW, suites))
       .toBe(0);
-    // The run carried on and folded the day's raw objects instead.
-    expect(read).toContain(CI(DAY, "1"));
-    expect(read).toContain(CI(DAY, "2"));
-    expect(created.size).toBeGreaterThan(0);
+    expect(read).toEqual(shards);
+    expect(peak).toBeLessThanOrEqual(SHARD_CHUNK);
   });
 });
 

--- a/tasks/test-selection-publish.ts
+++ b/tasks/test-selection-publish.ts
@@ -151,11 +151,8 @@ const BOOTSTRAP_DAYS = 60;
 const CHUNK = 200;
 
 /**
- * Rollup shards read and folded before the next batch is fetched. A shard
- * is eight mebibytes stored and some tens of megabytes of text, holding a
- * few hundred thousand records, and a day is written as up to two dozen
- * of them. The compactor sizes a shard so that a reader holds one at a
- * time, and this is what holds a reader to that.
+ * Rollup shards read and spooled before the next batch is fetched.
+ * Each shard targets eight mebibytes compressed.
  */
 export const SHARD_CHUNK = 4;
 
@@ -477,37 +474,34 @@ export async function publish(
     }
   }
 
+  /** Reads and consumes each batch before fetching the next shards. */
+  async function* readRollup(shards: readonly string[], concurrency: number) {
+    for (let at = 0; at < shards.length; at += SHARD_CHUNK) {
+      const reports = await mapConcurrent(
+        shards.slice(at, at + SHARD_CHUNK),
+        concurrency,
+        (objectName) => store.read(objectName),
+      );
+      for (const report of reports) {
+        noteReport(report);
+        yield report;
+      }
+    }
+  }
+
   let settled = 0;
   for (const [date, shards] of rollups) {
-    // A few shards at a time, for the reason the raw path reads in
-    // chunks: a day's worth of parsed records held at once is gigabytes.
-    //
-    // The receipt is written after the whole day, so a run that stops
-    // partway leaves the pair still owing what it owed. What the fold
-    // already took cannot be given back, though, and a rollup carries no
-    // record of which arrivals it covers, so nothing could tell a later
-    // run which part of the day it still owes. A shard that fails to read
-    // ends the run, and the previous manifest stays newest.
-    for (let at = 0; at < shards.length; at += SHARD_CHUNK) {
-      let reports: StoredReport[];
-      try {
-        reports = await mapConcurrent(
-          shards.slice(at, at + SHARD_CHUNK),
-          options.concurrency,
-          (objectName) => store.read(objectName),
-        );
-      } catch (error) {
-        console.warn(
-          `test selection: reading the rollup of ${date} failed: ${error}`,
-        );
-        console.warn(
-          "test selection: refusing to publish from part of the window. " +
-            "The previous manifest is still the newest one.",
-        );
-        return 1;
-      }
-      for (const report of reports) noteReport(report);
-      fold.add(reports);
+    try {
+      await fold.addUnordered(readRollup(shards, options.concurrency));
+    } catch (error) {
+      console.warn(
+        `test selection: reading the rollup of ${date} failed: ${error}`,
+      );
+      console.warn(
+        "test selection: refusing to publish from part of the window. " +
+          "The previous manifest is still the newest one.",
+      );
+      return 1;
     }
     fold.markSettled(CI_SOURCE, date);
     settled++;

--- a/tasks/test-selection-publish.ts
+++ b/tasks/test-selection-publish.ts
@@ -150,6 +150,15 @@ const BOOTSTRAP_DAYS = 60;
 /** Objects read and folded before the next batch is fetched. */
 const CHUNK = 200;
 
+/**
+ * Rollup shards read and folded before the next batch is fetched. A shard
+ * is eight mebibytes stored and some tens of megabytes of text, holding a
+ * few hundred thousand records, and a day is written as up to two dozen
+ * of them. The compactor sizes a shard so that a reader holds one at a
+ * time, and this is what holds a reader to that.
+ */
+export const SHARD_CHUNK = 4;
+
 /** What the command line asked for. */
 export interface Options {
   days: number;
@@ -470,27 +479,38 @@ export async function publish(
 
   let settled = 0;
   for (const [date, shards] of rollups) {
-    try {
-      // A pair is folded whole or not at all: a shard that failed to read
-      // would leave it partly folded, and writing its receipt would then
-      // hide the rest of it from every later run.
-      const reports = await mapConcurrent(
-        shards,
-        options.concurrency,
-        (objectName) => store.read(objectName),
-      );
+    // A few shards at a time, for the reason the raw path reads in
+    // chunks: a day's worth of parsed records held at once is gigabytes.
+    //
+    // The receipt is written after the whole day, so a run that stops
+    // partway leaves the pair still owing what it owed. What the fold
+    // already took cannot be given back, though, and a rollup carries no
+    // record of which arrivals it covers, so nothing could tell a later
+    // run which part of the day it still owes. A shard that fails to read
+    // ends the run, and the previous manifest stays newest.
+    for (let at = 0; at < shards.length; at += SHARD_CHUNK) {
+      let reports: StoredReport[];
+      try {
+        reports = await mapConcurrent(
+          shards.slice(at, at + SHARD_CHUNK),
+          options.concurrency,
+          (objectName) => store.read(objectName),
+        );
+      } catch (error) {
+        console.warn(
+          `test selection: reading the rollup of ${date} failed: ${error}`,
+        );
+        console.warn(
+          "test selection: refusing to publish from part of the window. " +
+            "The previous manifest is still the newest one.",
+        );
+        return 1;
+      }
       for (const report of reports) noteReport(report);
       fold.add(reports);
-      fold.markSettled(CI_SOURCE, date);
-      settled++;
-    } catch (error) {
-      console.warn(
-        `test selection: reading the rollup of ${date} failed: ${error}`,
-      );
-      // No receipt was written, so the pair still owes what it owed, and
-      // the raw path is what is left to read it by.
-      ciDays.push(date);
     }
+    fold.markSettled(CI_SOURCE, date);
+    settled++;
   }
   if (rollups.size > 0) {
     console.log(

--- a/tasks/test-selection/build.test.ts
+++ b/tasks/test-selection/build.test.ts
@@ -234,6 +234,19 @@ describe("build", () => {
       expect(byDay.get("2026-08-20")).toEqual([10, 90]);
     });
 
+    it("reads nothing from a group whose start time is not a time", () => {
+      // Every rule reads along the order these are sorted into, and a
+      // start time that will not parse has no place in it.
+      expect(
+        readReport(
+          stored(CI_NAME, context({ startedAt: "2026-08-20Tnonsense" }), [
+            record(),
+          ]),
+          NO_ALIASES,
+        ).observations,
+      ).toEqual([]);
+    });
+
     it("reads nothing from a fork run", () => {
       const forked = context();
       forked.ci!.fork = true;

--- a/tasks/test-selection/build.ts
+++ b/tasks/test-selection/build.ts
@@ -241,8 +241,9 @@ export interface ReadReport {
 
 /**
  * Reads one stored object. A report a decision must not read contributes
- * nothing: a fork run's records are authored by the fork, and a group
- * with no context cannot say where it came from.
+ * nothing: a fork run's records are authored by the fork, a group with no
+ * context cannot say where it came from, and a group whose start time is
+ * not a time has no place in the order the rules read along.
  */
 export function readReport(
   report: StoredReport,
@@ -253,7 +254,12 @@ export function readReport(
   const durations = new Map<string, Map<string, number[]>>();
   for (const group of report.reports) {
     const where = provenance(group.context, report.objectName);
-    if (where === undefined || group.context === undefined) continue;
+    if (
+      where === undefined || group.context === undefined ||
+      !Number.isFinite(Date.parse(group.context.startedAt))
+    ) {
+      continue;
+    }
     const day = dayOf(group.context.startedAt);
     for (const record of group.records) {
       const test = resolver.resolve(record.test, day);

--- a/tasks/test-selection/build.ts
+++ b/tasks/test-selection/build.ts
@@ -50,6 +50,7 @@ import {
   type ManifestEntry,
   type WithheldEntry,
 } from "./manifest.ts";
+import { ObservationSpool } from "./observation-spool.ts";
 import {
   COST_WINDOW_DAYS,
   FLAKE_EXCLUSION_RATE,
@@ -620,31 +621,7 @@ export class Fold {
       for (const observation of read.observations) {
         observations.push(observation);
       }
-      for (const [key, surface] of read.surfaces) {
-        // A file names something a runner can be pointed at, and an
-        // identity's own name does not. A record with no file arriving in
-        // a later report must not replace one that had it.
-        const known = this.#surfaces.get(key);
-        if (known === undefined || isFileBacked(surface)) {
-          this.#surfaces.set(key, surface);
-        }
-      }
-      for (const [key, byDay] of read.durations) {
-        let known = this.#samples.get(key);
-        for (const [day, sampled] of byDay) {
-          // A day past the cost window is sealed and then dropped again
-          // by the same `finish` that sealed it, so sampling it buys
-          // nothing and a bootstrap holds sixty days of it at once.
-          if (daysBetween(day, this.#today) > COST_WINDOW_DAYS) continue;
-          if (known === undefined) {
-            known = new Map();
-            this.#samples.set(key, known);
-          }
-          const into = known.get(day) ?? emptySamples();
-          for (const durationMs of sampled) sampleDuration(into, durationMs);
-          known.set(day, into);
-        }
-      }
+      this.#remember(read);
       this.#folded.push(report.objectName);
       this.#foldedIndex.add(report.objectName);
     }
@@ -669,6 +646,37 @@ export class Fold {
     // through a bootstrap's whole read.
     const newest = observations.at(-1)?.day;
     if (newest !== undefined) trimContext(this.#context, newest);
+  }
+
+  /**
+   * Folds one logical batch from reports arriving in arbitrary order.
+   * Each run is spooled to disk, then replayed in time order for every
+   * evidence pass and the final classification pass.
+   */
+  async addUnordered(reports: AsyncIterable<StoredReport>): Promise<void> {
+    using observations = new ObservationSpool();
+    for await (const report of reports) {
+      for (const group of report.reports) {
+        const read = readReport({
+          objectName: report.objectName,
+          context: group.context,
+          records: group.records,
+          reports: [group],
+        }, this.#resolver);
+        observations.add(read.observations);
+        this.#remember(read);
+      }
+      this.#folded.push(report.objectName);
+      this.#foldedIndex.add(report.objectName);
+    }
+    this.#observations += observations.count;
+    foldObservations(observations, {
+      prior: this.#states,
+      context: this.#context,
+    });
+    if (observations.newestDay !== undefined) {
+      trimContext(this.#context, observations.newestDay);
+    }
   }
 
   /** Closes the fold, sealing each day's cost and aging the counters. */
@@ -699,6 +707,35 @@ export class Fold {
       surfaces: this.#surfaces,
       observations: this.#observations,
     };
+  }
+
+  /** Records invocation surfaces and bounded duration samples. */
+  #remember(read: ReadReport): void {
+    for (const [key, surface] of read.surfaces) {
+      // A file names something a runner can be pointed at, and an
+      // identity's own name does not. A record with no file arriving in
+      // a later report must not replace one that had it.
+      const known = this.#surfaces.get(key);
+      if (known === undefined || isFileBacked(surface)) {
+        this.#surfaces.set(key, surface);
+      }
+    }
+    for (const [key, byDay] of read.durations) {
+      let known = this.#samples.get(key);
+      for (const [day, sampled] of byDay) {
+        // A day past the cost window is sealed and then dropped again
+        // by the same `finish` that sealed it, so sampling it buys
+        // nothing and a bootstrap holds sixty days of it at once.
+        if (daysBetween(day, this.#today) > COST_WINDOW_DAYS) continue;
+        if (known === undefined) {
+          known = new Map();
+          this.#samples.set(key, known);
+        }
+        const into = known.get(day) ?? emptySamples();
+        for (const durationMs of sampled) sampleDuration(into, durationMs);
+        known.set(day, into);
+      }
+    }
   }
 }
 

--- a/tasks/test-selection/observation-spool.test.ts
+++ b/tasks/test-selection/observation-spool.test.ts
@@ -1,0 +1,105 @@
+/** Verifies replay order, payload storage, and temporary-file cleanup. */
+
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+import { spy, stub } from "@std/testing/mock";
+
+import { ObservationSpool } from "./observation-spool.ts";
+import type { Observation } from "./score.ts";
+
+/** One execution with a distinct name and the given start time. */
+function observation(name: string, startedAt: string): Observation {
+  return {
+    test: { k: "unit", s: "example", n: name },
+    outcome: "pass",
+    durationMs: 1,
+    day: startedAt.slice(0, 10),
+    startedAt,
+    commit: name,
+    source: "main",
+    place: "main",
+  };
+}
+
+describe("ObservationSpool", () => {
+  describe("constructor()", () => {
+    it("removes the temporary file when opening it fails", () => {
+      const created = spy(Deno, "makeTempFileSync");
+      const opened = stub(Deno, "openSync", () => {
+        throw new Error("open failed");
+      });
+      try {
+        expect(() => new ObservationSpool()).toThrow("open failed");
+        const path = created.calls[0]!.returned!;
+        expect(() => Deno.statSync(path)).toThrow(Deno.errors.NotFound);
+      } finally {
+        opened.restore();
+        created.restore();
+      }
+    });
+  });
+
+  describe("instance members", () => {
+    it("replays stored runs in time order on every iteration", () => {
+      using spool = new ObservationSpool();
+      const later = observation("later", "2026-08-21T01:00:00.100Z");
+      const earlier = observation("earlier", "2026-08-20T01:00:00Z");
+      const tied = observation("tied", earlier.startedAt);
+      spool.add([later]);
+      spool.add([earlier, tied]);
+      const expected = [earlier, tied, { ...later }];
+      later.outcome = "fail";
+      later.day = "2026-08-19";
+      expect([...spool]).toEqual(expected);
+      expect([...spool]).toEqual(expected);
+      expect(spool.count).toBe(3);
+      expect(spool.newestDay).toBe("2026-08-21");
+    });
+
+    it("orders fractional timestamps by instant", () => {
+      using spool = new ObservationSpool();
+      const later = observation("later", "2026-08-20T01:00:00.100Z");
+      const earlier = observation("earlier", "2026-08-20T01:00:00Z");
+      spool.add([later]);
+      spool.add([earlier]);
+      expect([...spool]).toEqual([earlier, later]);
+    });
+
+    it("replays nothing when no run has observations", () => {
+      using spool = new ObservationSpool();
+      spool.add([]);
+      expect([...spool]).toEqual([]);
+      expect(spool.count).toBe(0);
+      expect(spool.newestDay).toBeUndefined();
+    });
+
+    it("refuses a run with invalid or differing start times", () => {
+      using spool = new ObservationSpool();
+      expect(() => spool.add([observation("invalid", "not a date")]))
+        .toThrow("one valid start time");
+      expect(() =>
+        spool.add([
+          observation("earlier", "2026-08-20T01:00:00Z"),
+          observation("later", "2026-08-20T02:00:00Z"),
+        ])
+      ).toThrow("one valid start time");
+      expect(spool.count).toBe(0);
+    });
+
+    it("refuses a truncated payload and removes it on disposal", () => {
+      const created = spy(Deno, "makeTempFileSync");
+      try {
+        {
+          using spool = new ObservationSpool();
+          spool.add([observation("stored", "2026-08-20T01:00:00Z")]);
+          Deno.truncateSync(created.calls[0]!.returned!, 1);
+          expect(() => [...spool]).toThrow("observation spool is truncated");
+        }
+        expect(() => Deno.statSync(created.calls[0]!.returned!))
+          .toThrow(Deno.errors.NotFound);
+      } finally {
+        created.restore();
+      }
+    });
+  });
+});

--- a/tasks/test-selection/observation-spool.test.ts
+++ b/tasks/test-selection/observation-spool.test.ts
@@ -147,6 +147,21 @@ describe("ObservationSpool", () => {
       expect(spool.count).toBe(0);
     });
 
+    it("refuses a replay started while another is running", () => {
+      // Both would move the one file cursor these share.
+      using spool = new ObservationSpool();
+      spool.add([observation("stored", "2026-08-20T01:00:00Z")]);
+      expect(() => {
+        for (const _ of spool) for (const __ of spool);
+      }).toThrow("already being replayed");
+    });
+
+    it("replays again once the previous replay has finished", () => {
+      using spool = new ObservationSpool();
+      spool.add([observation("stored", "2026-08-20T01:00:00Z")]);
+      expect([...spool]).toEqual([...spool]);
+    });
+
     it("refuses a truncated payload and removes it on disposal", () => {
       const created = spy(Deno, "makeTempFileSync");
       try {

--- a/tasks/test-selection/observation-spool.test.ts
+++ b/tasks/test-selection/observation-spool.test.ts
@@ -40,6 +40,67 @@ describe("ObservationSpool", () => {
   });
 
   describe("instance members", () => {
+    for (const operation of ["readSync", "writeSync"] as const) {
+      for (const bytes of [0, -1]) {
+        it(`throws after \`${operation}()\` returns \`${bytes}\``, () => {
+          const opened = spy(Deno, "openSync");
+          try {
+            using spool = new ObservationSpool();
+            const run = [observation("stored", "2026-08-20T01:00:00Z")];
+            if (operation === "readSync") spool.add(run);
+            let attempts = 0;
+            const io = stub(opened.calls[0]!.returned!, operation, () => {
+              if (++attempts === 1) return bytes;
+              throw new Error("I/O was repeated without progress");
+            });
+            try {
+              expect(() => {
+                if (operation === "writeSync") spool.add(run);
+                else [...spool];
+              }).toThrow("observation spool made no progress");
+              expect(io.calls.length).toBe(1);
+            } finally {
+              io.restore();
+            }
+          } finally {
+            opened.restore();
+          }
+        });
+      }
+    }
+
+    it("completes partial reads and writes across byte boundaries", () => {
+      const opened = spy(Deno, "openSync");
+      try {
+        using spool = new ObservationSpool();
+        const file = opened.calls[0]!.returned!;
+        const read = file.readSync.bind(file);
+        const write = file.writeSync.bind(file);
+        const reader = stub(
+          file,
+          "readSync",
+          (bytes) => read(bytes.subarray(0, 7)),
+        );
+        const writer = stub(
+          file,
+          "writeSync",
+          (bytes) => write(bytes.subarray(0, 7)),
+        );
+        try {
+          const run = [observation("donut 🍩", "2026-08-20T01:00:00Z")];
+          spool.add(run);
+          expect([...spool]).toEqual(run);
+          expect(reader.calls.length).toBeGreaterThan(1);
+          expect(writer.calls.length).toBeGreaterThan(1);
+        } finally {
+          reader.restore();
+          writer.restore();
+        }
+      } finally {
+        opened.restore();
+      }
+    });
+
     it("replays stored runs in time order on every iteration", () => {
       using spool = new ObservationSpool();
       const later = observation("later", "2026-08-21T01:00:00.100Z");

--- a/tasks/test-selection/observation-spool.ts
+++ b/tasks/test-selection/observation-spool.ts
@@ -1,5 +1,8 @@
 import type { Observation } from "./score.ts";
 
+const ENCODER = new TextEncoder();
+const DECODER = new TextDecoder();
+
 /**
  * A replayable batch in time order. Observations live in a temporary file;
  * memory holds one run's payload and an offset and timestamp per run.
@@ -9,6 +12,7 @@ export class ObservationSpool implements Disposable, Iterable<Observation> {
   readonly #file: Deno.FsFile;
   readonly #runs: { at: number; offset: number; length: number }[] = [];
   #length = 0;
+  #replaying = false;
   #count = 0;
   #latest: { at: number; day: string } | undefined;
 
@@ -46,7 +50,7 @@ export class ObservationSpool implements Disposable, Iterable<Observation> {
     ) {
       throw new Error("An observation run must have one valid start time.");
     }
-    const bytes = new TextEncoder().encode(JSON.stringify(observations));
+    const bytes = ENCODER.encode(JSON.stringify(observations));
     this.#file.seekSync(this.#length, Deno.SeekMode.Start);
     for (let written = 0; written < bytes.length;) {
       const count = this.#file.writeSync(bytes.subarray(written));
@@ -63,10 +67,39 @@ export class ObservationSpool implements Disposable, Iterable<Observation> {
     }
   }
 
-  /** Replays the complete batch, preserving insertion order at equal times. */
+  /**
+   * Replays the complete batch, preserving insertion order at equal times.
+   *
+   * One replay at a time: every replay moves the one file cursor these
+   * share, so two running at once would each read from where the other
+   * left off and yield whatever those bytes happened to be.
+   */
   *[Symbol.iterator](): Generator<Observation> {
-    this.#runs.sort((a, b) => a.at - b.at);
-    for (const run of this.#runs) {
+    if (this.#replaying) {
+      throw new Error("The observation spool is already being replayed.");
+    }
+    this.#replaying = true;
+    try {
+      yield* this.#replay();
+    } finally {
+      this.#replaying = false;
+    }
+  }
+
+  /** Closes and removes the temporary file. */
+  [Symbol.dispose](): void {
+    try {
+      this.#file.close();
+    } finally {
+      Deno.removeSync(this.#path);
+    }
+  }
+
+  /** Reads every run back, oldest first. */
+  *#replay(): Generator<Observation> {
+    // A copy, so that reading the batch does not reorder it.
+    const runs = [...this.#runs].sort((a, b) => a.at - b.at);
+    for (const run of runs) {
       this.#file.seekSync(run.offset, Deno.SeekMode.Start);
       const bytes = new Uint8Array(run.length);
       for (let read = 0; read < bytes.length;) {
@@ -79,19 +112,8 @@ export class ObservationSpool implements Disposable, Iterable<Observation> {
         }
         read += count;
       }
-      const observations = JSON.parse(
-        new TextDecoder().decode(bytes),
-      ) as Observation[];
+      const observations = JSON.parse(DECODER.decode(bytes)) as Observation[];
       yield* observations;
-    }
-  }
-
-  /** Closes and removes the temporary file. */
-  [Symbol.dispose](): void {
-    try {
-      this.#file.close();
-    } finally {
-      Deno.removeSync(this.#path);
     }
   }
 }

--- a/tasks/test-selection/observation-spool.ts
+++ b/tasks/test-selection/observation-spool.ts
@@ -49,7 +49,11 @@ export class ObservationSpool implements Disposable, Iterable<Observation> {
     const bytes = new TextEncoder().encode(JSON.stringify(observations));
     this.#file.seekSync(this.#length, Deno.SeekMode.Start);
     for (let written = 0; written < bytes.length;) {
-      written += this.#file.writeSync(bytes.subarray(written));
+      const count = this.#file.writeSync(bytes.subarray(written));
+      if (count <= 0) {
+        throw new Error("Writing the observation spool made no progress.");
+      }
+      written += count;
     }
     this.#runs.push({ at, offset: this.#length, length: bytes.length });
     this.#length += bytes.length;
@@ -69,6 +73,9 @@ export class ObservationSpool implements Disposable, Iterable<Observation> {
         const count = this.#file.readSync(bytes.subarray(read));
         if (count === null) {
           throw new Error("The observation spool is truncated.");
+        }
+        if (count <= 0) {
+          throw new Error("Reading the observation spool made no progress.");
         }
         read += count;
       }

--- a/tasks/test-selection/observation-spool.ts
+++ b/tasks/test-selection/observation-spool.ts
@@ -1,0 +1,90 @@
+import type { Observation } from "./score.ts";
+
+/**
+ * A replayable batch in time order. Observations live in a temporary file;
+ * memory holds one run's payload and an offset and timestamp per run.
+ */
+export class ObservationSpool implements Disposable, Iterable<Observation> {
+  readonly #path: string;
+  readonly #file: Deno.FsFile;
+  readonly #runs: { at: number; offset: number; length: number }[] = [];
+  #length = 0;
+  #count = 0;
+  #latest: { at: number; day: string } | undefined;
+
+  /** Constructs an instance backed by an empty temporary file. */
+  constructor() {
+    this.#path = Deno.makeTempFileSync({ prefix: "test-selection-" });
+    try {
+      this.#file = Deno.openSync(this.#path, { read: true, write: true });
+    } catch (error) {
+      Deno.removeSync(this.#path);
+      throw error;
+    }
+  }
+
+  /** The number of observations appended. */
+  get count(): number {
+    return this.#count;
+  }
+
+  /** The day of the latest run, absent for an empty batch. */
+  get newestDay(): string | undefined {
+    return this.#latest?.day;
+  }
+
+  /** Appends one run. Every observation must have the same start time. */
+  add(observations: readonly Observation[]): void {
+    const first = observations[0];
+    if (first === undefined) return;
+    const at = Date.parse(first.startedAt);
+    if (
+      !Number.isFinite(at) ||
+      observations.some((observation) =>
+        observation.startedAt !== first.startedAt
+      )
+    ) {
+      throw new Error("An observation run must have one valid start time.");
+    }
+    const bytes = new TextEncoder().encode(JSON.stringify(observations));
+    this.#file.seekSync(this.#length, Deno.SeekMode.Start);
+    for (let written = 0; written < bytes.length;) {
+      written += this.#file.writeSync(bytes.subarray(written));
+    }
+    this.#runs.push({ at, offset: this.#length, length: bytes.length });
+    this.#length += bytes.length;
+    this.#count += observations.length;
+    if (this.#latest === undefined || at > this.#latest.at) {
+      this.#latest = { at, day: first.day };
+    }
+  }
+
+  /** Replays the complete batch, preserving insertion order at equal times. */
+  *[Symbol.iterator](): Generator<Observation> {
+    this.#runs.sort((a, b) => a.at - b.at);
+    for (const run of this.#runs) {
+      this.#file.seekSync(run.offset, Deno.SeekMode.Start);
+      const bytes = new Uint8Array(run.length);
+      for (let read = 0; read < bytes.length;) {
+        const count = this.#file.readSync(bytes.subarray(read));
+        if (count === null) {
+          throw new Error("The observation spool is truncated.");
+        }
+        read += count;
+      }
+      const observations = JSON.parse(
+        new TextDecoder().decode(bytes),
+      ) as Observation[];
+      yield* observations;
+    }
+  }
+
+  /** Closes and removes the temporary file. */
+  [Symbol.dispose](): void {
+    try {
+      this.#file.close();
+    } finally {
+      Deno.removeSync(this.#path);
+    }
+  }
+}

--- a/tasks/test-selection/score.test.ts
+++ b/tasks/test-selection/score.test.ts
@@ -236,6 +236,27 @@ describe("score", () => {
     });
   });
 
+  describe("the batch it is handed", () => {
+    it("refuses an iterator, which replays nothing after the first pass", () => {
+      function* once(): Generator<Observation> {
+        yield saw("fail", { commit: "c1" });
+      }
+      expect(() => foldObservations(once())).toThrow(
+        "needs an iterable that replays",
+      );
+    });
+
+    it("takes an iterable that hands out a fresh iterator each time", () => {
+      const batch = [saw("fail", { commit: "c1" })];
+      expect(foldObservations({
+        *[Symbol.iterator]() {
+          yield* batch;
+        },
+      }))
+        .toEqual(foldObservations(batch));
+    });
+  });
+
   describe("what counts as a catch", () => {
     it("counts a failure on a branch where main was green", () => {
       const state = stateFrom([

--- a/tasks/test-selection/score.ts
+++ b/tasks/test-selection/score.ts
@@ -465,12 +465,23 @@ export interface FoldOptions {
  * last said and forwards at what it says next. Observations at one commit
  * are considered together: an identity that both passed and failed there
  * disagreed with itself, which is a flake observation and never a catch.
- * The iterable must replay the complete batch on each iteration.
+ *
+ * Both of those need the whole batch in view before any one observation is
+ * judged, so this walks the batch more than once and the iterable has to
+ * replay it each time. A one-shot iterator would leave every pass after
+ * the first with nothing to read and score the batch as though most of it
+ * had never run, so one is refused rather than folded.
  */
 export function foldObservations(
   observations: Iterable<Observation>,
   options: FoldOptions = {},
 ): FoldResult {
+  // An iterator is its own iterable, which is what tells the two apart.
+  if (Object.is(observations[Symbol.iterator](), observations)) {
+    throw new Error(
+      "foldObservations needs an iterable that replays, not an iterator.",
+    );
+  }
   const states = options.prior ?? new Map<string, IdentityState>();
   const coveredChanged = options.coveredChanged ?? (() => true);
   const context = options.context ?? emptyContext();
@@ -490,14 +501,30 @@ export function foldObservations(
   const failures = context.failures;
   const recent = context.recentCommits;
 
-  // The failure witness first, so that the pass below can tell a test
-  // that has failed from one that never has.
+  // The failure witness first, so that the pass below can tell a test that
+  // has failed from one that never has. What the default branch said at
+  // each commit is gathered alongside it: only the classification pass
+  // reads that, and it depends on nothing gathered here, so it rides along
+  // rather than walking the batch again. Gathering it before anything is
+  // judged is what stops a failure elsewhere at one commit being weighed
+  // against whatever `main` happened to say last in this batch.
+  const mainAtCommit = new Map<string, "pass" | "fail" | "skip">();
   for (const observation of observations) {
-    if (observation.outcome !== "fail") continue;
     const key = testIdentityKey(observation.test);
-    const list = failures.get(key) ?? [];
-    list.push({ day: observation.day, source: observation.source });
-    failures.set(key, list);
+    if (observation.outcome === "fail") {
+      const list = failures.get(key) ?? [];
+      list.push({ day: observation.day, source: observation.source });
+      failures.set(key, list);
+    }
+    if (observation.place !== "main" || observation.outcome === "skip") {
+      continue;
+    }
+    const at = `${key} ${observation.commit}`;
+    // A failure anywhere at one commit is the commit being broken; a pass
+    // beside it does not clear that.
+    if (observation.outcome === "fail" || !mainAtCommit.has(at)) {
+      mainAtCommit.set(at, observation.outcome);
+    }
   }
 
   // Outcomes at a commit, for as long as they can still be asked about.
@@ -536,23 +563,6 @@ export function foldObservations(
     const outcomes = seen.identities.get(key) ?? new Set<string>();
     outcomes.add(observation.outcome);
     seen.identities.set(key, outcomes);
-  }
-
-  // What the default branch said at each commit, gathered before anything
-  // is judged. Otherwise a failure elsewhere at the same commit is
-  // classified against whatever `main` had said *last*, which depends on
-  // whether this batch happened to list the `main` run first.
-  const mainAtCommit = new Map<string, "pass" | "fail" | "skip">();
-  for (const observation of observations) {
-    if (observation.place !== "main" || observation.outcome === "skip") {
-      continue;
-    }
-    const at = `${testIdentityKey(observation.test)} ${observation.commit}`;
-    // A failure anywhere at one commit is the commit being broken; a pass
-    // beside it does not clear that.
-    if (observation.outcome === "fail" || !mainAtCommit.has(at)) {
-      mainAtCommit.set(at, observation.outcome);
-    }
   }
 
   const environmental = (key: string, day: string, source: string): boolean => {

--- a/tasks/test-selection/score.ts
+++ b/tasks/test-selection/score.ts
@@ -465,9 +465,10 @@ export interface FoldOptions {
  * last said and forwards at what it says next. Observations at one commit
  * are considered together: an identity that both passed and failed there
  * disagreed with itself, which is a flake observation and never a catch.
+ * The iterable must replay the complete batch on each iteration.
  */
 export function foldObservations(
-  observations: readonly Observation[],
+  observations: Iterable<Observation>,
   options: FoldOptions = {},
 ): FoldResult {
   const states = options.prior ?? new Map<string, IdentityState>();


### PR DESCRIPTION
The test-selection publisher read a compacted day by fetching every shard of that day at once and keeping all of them until the whole day had been folded. A shard is eight mebibytes stored and decompresses to around sixty megabytes of text holding a few hundred thousand records, and a busy day is written as more than twenty shards, so one day came to well over a gigabyte of text and several gigabytes of parsed records.

The first cold start of this repository's store ran out of JavaScript heap partway through the ten compacted days it had to read. It had printed nothing by then, because the only line the rollup pass writes comes after every day of it, and V8 killed the process rather than the program returning a status.

The raw path immediately below already reads and folds in chunks of two hundred objects for this reason. The rollup path now does the same with a chunk of four shards, which is the bound the compactor was written against: it sizes a shard so that a reader can hold what one decompresses to, one at a time.

Folding as it reads changes what a shard that will not read means. Reading a day whole and folding it in one step left the aggregate untouched when a shard failed, so the day could be read from its raw objects instead. Now the shards that did read are already in the fold, and a rollup carries no record of which arrivals it covers, so nothing could tell a later run which part of the day it still owes, and reading the day raw would count the folded part twice. A shard that fails to read now ends the run, which is what every other partial read in this program does. The previous manifest stays the newest one and the lanes keep using it.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6996?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

