### PR TITLE
fix(ui): name a pattern's export as an identifier in the piece menu

### DIFF
--- a/packages/ui/src/v2/components/cf-piece-menu/cf-piece-menu.test.ts
+++ b/packages/ui/src/v2/components/cf-piece-menu/cf-piece-menu.test.ts
@@ -21,7 +21,7 @@ import {
   describeOrigin,
   describeSourceFailure,
   formatTimestamp,
-  shortIdentity,
+  patternRefLabel,
 } from "./origin-view.ts";
 import {
   clearPieceBoundary,
@@ -1799,7 +1799,12 @@ describe("the origin and history panel", () => {
     expect(rendered).toContain(
       "https://toolshed.test/api/patterns/recipe.tsx",
     );
-    expect(rendered).toContain(shortIdentity("pattern-identity-value"));
+    expect(rendered).toContain(
+      patternRefLabel({
+        identity: "pattern-identity-value",
+        symbol: "default",
+      }),
+    );
     expect(rendered).toContain("/main.tsx");
     expect(rendered).toContain("of:fid1:piece");
     expect(rendered).toContain(SPACE);
@@ -2019,7 +2024,9 @@ describe("the origin and history panel", () => {
     expect(rendered).toContain(formatTimestamp(at));
     expect(rendered).toContain("Reason:");
     expect(rendered).toContain("inputs or outputs do not match");
-    expect(rendered).toContain(shortIdentity("offered-identity"));
+    expect(rendered).toContain(
+      patternRefLabel({ identity: "offered-identity", symbol: "default" }),
+    );
     expect(rendered).toContain("Update from the origin now");
     expect(rendered).toContain("Update, ignoring the compatibility check");
   });
@@ -3180,6 +3187,34 @@ describe("source history actions", () => {
     expect(shows(menu)).not.toContain("the main file");
   });
 
+  it("names the revision's pattern whole in the panel subject", async () => {
+    const menu = openMenu(pieceCell(
+      () =>
+        Promise.resolve({
+          ...historySource,
+          history: [{
+            revisionId: "older",
+            timestamp: 1,
+            pattern: SOURCE.pattern!,
+            operation: "baseline",
+          }],
+        }),
+      {
+        readRevision: () =>
+          Promise.resolve({
+            pattern: SOURCE.pattern!,
+            files: [{ name: "/main.tsx", contents: "the older source" }],
+          }),
+      },
+    ));
+    await menu.showPanel("origin");
+    await clickTestId(menu, "piece-source-view-older");
+
+    expect(shows(menu)).toContain(
+      'Pattern pattern-identity-value (export symbol "default")',
+    );
+  });
+
   it("starts one revision read for rapid repeated activations", async () => {
     let finish!: (source: PieceSourceRevisionSourceView) => void;
     let reads = 0;
@@ -4044,10 +4079,19 @@ describe("describeOrigin", () => {
   });
 });
 
-describe("shortIdentity", () => {
-  it("abbreviates a content identity but keeps short values whole", () => {
-    expect(shortIdentity("abcdefghijklmnopqrstuvwxyz")).toBe("abcdefghijkl…");
-    expect(shortIdentity("abcdef")).toBe("abcdef");
+describe("patternRefLabel", () => {
+  it("names the export as an identifier rather than as prose", () => {
+    expect(patternRefLabel({ identity: "short", symbol: "default" })).toBe(
+      'short (export symbol "default")',
+    );
+  });
+
+  it("abbreviates the identity unless the whole value is asked for", () => {
+    const ref = { identity: "abcdefghijklmnopqrstuvwxyz", symbol: "main" };
+    expect(patternRefLabel(ref)).toBe('abcdefghijkl… (export symbol "main")');
+    expect(patternRefLabel(ref, { whole: true })).toBe(
+      'abcdefghijklmnopqrstuvwxyz (export symbol "main")',
+    );
   });
 });
 

--- a/packages/ui/src/v2/components/cf-piece-menu/cf-piece-menu.ts
+++ b/packages/ui/src/v2/components/cf-piece-menu/cf-piece-menu.ts
@@ -46,7 +46,7 @@ import {
   describeSourceFailure,
   type FollowDescription,
   formatTimestamp,
-  shortIdentity,
+  patternRefLabel,
 } from "./origin-view.ts";
 
 /** The marker on the rendered piece while its built-in menu is open. */
@@ -2262,7 +2262,9 @@ export class CFPieceMenu extends BaseElement {
       ? this.space ?? ""
       : panel !== "source" || this.sourceRevision === undefined
       ? this.source?.name ?? this.cell?.id() ?? ""
-      : `Pattern ${this.sourceRevision.pattern.identity} · ${this.sourceRevision.pattern.symbol}`;
+      : `Pattern ${
+        patternRefLabel(this.sourceRevision.pattern, { whole: true })
+      }`;
     return html`
       <div class="backdrop dimmed" @click="${() => this.close()}"></div>
       <div
@@ -2713,8 +2715,7 @@ export class CFPieceMenu extends BaseElement {
           ? html`
             <dt>Pattern</dt>
             <dd title="${source.pattern.identity}">
-              ${shortIdentity(source.pattern.identity)} · ${source.pattern
-                .symbol}
+              ${patternRefLabel(source.pattern)}
             </dd>
           `
           : nothing} ${source.setupPattern &&
@@ -2723,16 +2724,15 @@ export class CFPieceMenu extends BaseElement {
           ? html`
             <dt>Setup applied for</dt>
             <dd title="${source.setupPattern.identity}">
-              ${shortIdentity(source.setupPattern.identity)} · ${source
-                .setupPattern.symbol}
+              ${patternRefLabel(source.setupPattern)}
             </dd>
           `
           : nothing} ${source.displacedPattern
           ? html`
             <dt>Previously ran</dt>
             <dd title="${source.displacedPattern.identity}">
-              ${shortIdentity(source.displacedPattern.identity)} · ${source
-                .displacedPattern.symbol}${source.displacedPattern.displacedAt
+              ${patternRefLabel(source.displacedPattern)}${source
+                  .displacedPattern.displacedAt
                 ? ` · replaced ${
                   formatTimestamp(source.displacedPattern.displacedAt)
                 }`
@@ -2830,8 +2830,7 @@ export class CFPieceMenu extends BaseElement {
           : nothing} ${offered
           ? html`
             <p title="${offered.identity}">
-              The origin is offering ${shortIdentity(offered.identity)} ·
-              ${offered.symbol}.
+              The origin is offering ${patternRefLabel(offered)}.
             </p>
           `
           : nothing}
@@ -3065,8 +3064,7 @@ export class CFPieceMenu extends BaseElement {
           <span>${formatTimestamp(revision.timestamp)}</span>
         </div>
         <div class="revision-details">
-          Pattern ${shortIdentity(revision.pattern.identity)} · ${revision
-            .pattern.symbol} ·
+          Pattern ${patternRefLabel(revision.pattern)} ·
           <button
             type="button"
             class="text-link"

--- a/packages/ui/src/v2/components/cf-piece-menu/origin-view.ts
+++ b/packages/ui/src/v2/components/cf-piece-menu/origin-view.ts
@@ -58,8 +58,22 @@ export function describeOrigin(
 }
 
 /** A content identity abbreviated for display; the full value stays in a title. */
-export function shortIdentity(identity: string): string {
+function shortIdentity(identity: string): string {
   return identity.length > 14 ? `${identity.slice(0, 12)}…` : identity;
+}
+
+/**
+ * A pattern named for display: its content identity, abbreviated unless the
+ * whole value is asked for, and the export within it that is the pattern.
+ * Naming the export as one and quoting it marks the name as an identifier
+ * taken from the source.
+ */
+export function patternRefLabel(
+  ref: { identity: string; symbol: string },
+  options?: { whole?: boolean },
+): string {
+  const identity = options?.whole ? ref.identity : shortIdentity(ref.identity);
+  return `${identity} (export symbol "${ref.symbol}")`;
 }
 
 /** A recorded timestamp as a readable local time. */


### PR DESCRIPTION
The "Origin and history" panel of the piece context menu names the pattern a piece runs by joining two facts with a middle dot: the pattern's content identity, abbreviated, and the name of the export within that module which is the pattern. A typical row read:

    Pattern    bafy1234abcd… · default

Almost every pattern is its module's default export, so the second half of that pair is the word "default" nearly all the time. Read in a panel whose other rows are ordinary English, "default" looks like a description of the pattern's status rather than what it is: the name of a JavaScript export, taken verbatim out of the source. Someone reading the panel to find out where their piece's code comes from has no way to tell which of the two it is.

Name the export as an export and put its name in quotation marks, so the row now reads:

    Pattern    bafy1234abcd… (export symbol "default")

"Export symbol" is the term the piece source lifecycle specification already uses for this field, and the quotation marks mark the value as a literal name rather than prose.

The pair was assembled by hand at each of the six places that show one: the current pattern, the pattern a setup was applied for, a pattern an update displaced, the pattern an origin is offering, each entry in the revision history, and the subject line of the dialog that shows a historical revision's source. They now go through one `patternRefLabel` helper beside `shortIdentity`, so the form is decided in a single place.

That helper takes the pattern reference rather than a pair of strings, and abbreviates the identity itself. Passing the two strings separately would have made every call site repeat the same abbreviation call, and would have given each of them a way to transpose the identity and the export name with nothing to catch it. The dialog subject is the one caller that wants the whole identity, which it now asks for; that is the behavior it already had. Abbreviating inside the helper leaves `shortIdentity` with a single caller in the same module, so it stops being exported, and its own test goes with it — the label's test covers both sides of the abbreviation rule, an identity long enough to be cut and one short enough to be kept whole.

The dialog subject was the one place the label appears that no test read. It has one now, which is also what holds the whole-identity request in place.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7003?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

