### PR TITLE
fix(shell): navigating to the view already showing adds no history

### DIFF
--- a/packages/shell/src/lib/navigation.ts
+++ b/packages/shell/src/lib/navigation.ts
@@ -1,5 +1,6 @@
 import {
   appViewToUrlPath,
+  isAppViewEqual,
   NAVIGATE_EVENT,
   type NavigationCommand,
   preserveAppViewMode,
@@ -84,11 +85,26 @@ export class Navigation {
   #onNavigate = (e: Event) => {
     let command = (e as CustomEvent<NavigationCommand>).detail;
     logger.log("Navigate", command);
+    const currentView = this.#app.state().view;
     command = mapNavigationView(this.#app, command);
-    this.#push(command);
+    // A navigation that arrives at the view already showing adds no history
+    // entry: two entries for one destination make the first press of Back
+    // return to the page it was already on. Links inside a piece reach this
+    // case routinely, a cell reference naming its space by DID rather than by
+    // the name the address bar carries.
+    //
+    // The comparison uses the mapped command, which is what `#push` stores:
+    // mapping rewrites a DID naming the running space as that space's name,
+    // and carries embed mode into a command that omits it.
+    //
+    // The application hears the command either way. `setView` closes the
+    // shell's piece list on the way to a piece, open or not.
+    if (!isAppViewEqual(currentView, command)) this.#push(command);
     this.#apply(command);
   };
 
+  // Rewrites the entry the page is standing on rather than adding one, so a
+  // navigation to the view already showing leaves the history length alone.
   #onReplaceNavigate = (e: Event) => {
     let command = (e as CustomEvent<NavigationCommand>).detail;
     logger.log("ReplaceNavigate", command);

--- a/packages/shell/src/lib/navigation.ts
+++ b/packages/shell/src/lib/navigation.ts
@@ -1,6 +1,5 @@
 import {
   appViewToUrlPath,
-  isAppViewEqual,
   NAVIGATE_EVENT,
   type NavigationCommand,
   preserveAppViewMode,
@@ -85,26 +84,25 @@ export class Navigation {
   #onNavigate = (e: Event) => {
     let command = (e as CustomEvent<NavigationCommand>).detail;
     logger.log("Navigate", command);
-    const currentView = this.#app.state().view;
     command = mapNavigationView(this.#app, command);
-    // A navigation that arrives at the view already showing adds no history
-    // entry: two entries for one destination make the first press of Back
-    // return to the page it was already on. Links inside a piece reach this
-    // case routinely, a cell reference naming its space by DID rather than by
-    // the name the address bar carries.
+    // A navigation to the address the page is already at rewrites the entry
+    // it is standing on rather than adding one. Two entries for one address
+    // make the first press of Back return to the page it was already on.
     //
-    // The comparison uses the mapped command, which is what `#push` stores:
-    // mapping rewrites a DID naming the running space as that space's name,
-    // and carries embed mode into a command that omits it.
-    //
-    // The application hears the command either way. `setView` closes the
-    // shell's piece list on the way to a piece, open or not.
-    if (!isAppViewEqual(currentView, command)) this.#push(command);
+    // The address decides, and it is settled after the mapping: a DID that
+    // names the running space is rewritten as that space's name, and embed
+    // mode is carried into a command that omits it, so the same destination
+    // reaches this comparison written one way. A view also holds `openPath`,
+    // which no address carries, and an entry rewritten from one that held it
+    // holds it no longer.
+    if (appViewToUrlPath(command) === globalThis.location.pathname) {
+      this.#replace(command);
+    } else {
+      this.#push(command);
+    }
     this.#apply(command);
   };
 
-  // Rewrites the entry the page is standing on rather than adding one, so a
-  // navigation to the view already showing leaves the history length alone.
   #onReplaceNavigate = (e: Event) => {
     let command = (e as CustomEvent<NavigationCommand>).detail;
     logger.log("ReplaceNavigate", command);

--- a/packages/shell/src/lib/navigation.ts
+++ b/packages/shell/src/lib/navigation.ts
@@ -85,17 +85,21 @@ export class Navigation {
     let command = (e as CustomEvent<NavigationCommand>).detail;
     logger.log("Navigate", command);
     command = mapNavigationView(this.#app, command);
-    // A navigation to the address the page is already at rewrites the entry
-    // it is standing on rather than adding one. Two entries for one address
-    // make the first press of Back return to the page it was already on.
+    // A navigation to the address the page is already at rewrites the entry it
+    // is standing on rather than adding one. Two entries for one address make
+    // the first press of Back return to the page it was already on.
     //
-    // The address decides, and it is settled after the mapping: a DID that
-    // names the running space is rewritten as that space's name, and embed
-    // mode is carried into a command that omits it, so the same destination
-    // reaches this comparison written one way. A view also holds `openPath`,
-    // which no address carries, and an entry rewritten from one that held it
-    // holds it no longer.
-    if (appViewToUrlPath(command) === globalThis.location.pathname) {
+    // The address is settled after the mapping, which writes a DID naming the
+    // running space as that space's name and carries embed mode into a command
+    // that omits it. It goes through `URL` to reach the percent-encoded form
+    // `location.pathname` holds, a space name being free to hold a character a
+    // path reserves. A view's `openPath` reaches no address, so an entry
+    // rewritten from one that held it holds it no longer.
+    const address = new URL(
+      appViewToUrlPath(command),
+      globalThis.location.href,
+    );
+    if (address.pathname === globalThis.location.pathname) {
       this.#replace(command);
     } else {
       this.#push(command);

--- a/packages/shell/test/navigation.test.ts
+++ b/packages/shell/test/navigation.test.ts
@@ -136,6 +136,100 @@ describe("navigation", () => {
     );
   });
 
+  it("adds no history entry for a navigation to the view already showing", () => {
+    withNavigation(
+      "http://common.test/my-space/fid1:abc",
+      { view: { spaceName: "my-space", pieceId: "fid1:abc" } },
+      (_navigation, recorded) => {
+        globalThis.dispatchEvent(
+          new CustomEvent("cf-navigate", {
+            detail: { spaceName: "my-space", pieceId: "fid1:abc" },
+          }),
+        );
+        expect(recorded.push).toEqual([]);
+        // The application still hears it: `setView` closes the shell's piece
+        // list on the way to a piece, open or not.
+        expect(recorded.views.at(-1)).toEqual({
+          spaceName: "my-space",
+          pieceId: "fid1:abc",
+        });
+      },
+    );
+  });
+
+  it("adds no history entry for a DID link to the piece already open", () => {
+    withNavigation(
+      "http://common.test/my-space/fid1:abc",
+      {
+        view: { spaceName: "my-space", pieceId: "fid1:abc" },
+        runtimeSpace: SPACE_DID as DID,
+      },
+      (_navigation, recorded) => {
+        globalThis.dispatchEvent(
+          new CustomEvent("cf-navigate", {
+            detail: { spaceDid: SPACE_DID, pieceId: "fid1:abc" },
+          }),
+        );
+        expect(recorded.push).toEqual([]);
+      },
+    );
+  });
+
+  it("adds no history entry for a link to the collection member already open", () => {
+    withNavigation(
+      "http://common.test/my-space/top/42",
+      {
+        view: { spaceName: "my-space", pieceSlug: "top", pieceMember: "42" },
+        runtimeSpace: SPACE_DID as DID,
+      },
+      (_navigation, recorded) => {
+        globalThis.dispatchEvent(
+          new CustomEvent("cf-navigate", {
+            detail: {
+              spaceDid: SPACE_DID,
+              pieceSlug: "top",
+              pieceMember: "42",
+            },
+          }),
+        );
+        expect(recorded.push).toEqual([]);
+      },
+    );
+  });
+
+  it("adds no history entry when carried-over embed mode makes the destination the current view", () => {
+    withNavigation(
+      "http://common.test/.embed/my-space/fid1:abc",
+      { view: { spaceName: "my-space", pieceId: "fid1:abc", mode: "embed" } },
+      (_navigation, recorded) => {
+        globalThis.dispatchEvent(
+          new CustomEvent("cf-navigate", {
+            detail: { spaceName: "my-space", pieceId: "fid1:abc" },
+          }),
+        );
+        expect(recorded.push).toEqual([]);
+      },
+    );
+  });
+
+  it("adds a history entry for a navigation to a different piece", () => {
+    withNavigation(
+      "http://common.test/my-space/fid1:abc",
+      { view: { spaceName: "my-space", pieceId: "fid1:abc" } },
+      (_navigation, recorded) => {
+        globalThis.dispatchEvent(
+          new CustomEvent("cf-navigate", {
+            detail: { spaceName: "my-space", pieceId: "fid1:def" },
+          }),
+        );
+        expect(recorded.push).toEqual([{
+          state: { spaceName: "my-space", pieceId: "fid1:def" },
+          url: "/my-space/fid1:def",
+        }]);
+      },
+    );
+  });
+
   it("replaces the current entry for a cf-replace-navigation event", () => {
     withNavigation(
       "http://common.test/",

--- a/packages/shell/test/navigation.test.ts
+++ b/packages/shell/test/navigation.test.ts
@@ -70,12 +70,26 @@ function withNavigation<T>(
   const views: AppView[] = [];
   let title = "";
 
-  setGlobal("location", { href });
+  // A history entry is an address as much as it is a state, and `Navigation`
+  // reads the address it is standing on to decide whether a command would add
+  // a second entry for it. Writing an entry moves the address here, as it does
+  // in a browser.
+  const location = { href, pathname: new URL(href).pathname };
+  const arriveAt = (url: string) => {
+    const arrived = new URL(url, href);
+    location.href = arrived.href;
+    location.pathname = arrived.pathname;
+  };
+  setGlobal("location", location);
   setGlobal("history", {
-    pushState: (state: unknown, _title: string, url: string) =>
-      push.push({ state, url }),
-    replaceState: (state: unknown, _title: string, url: string) =>
-      replace.push({ state, url }),
+    pushState: (state: unknown, _title: string, url: string) => {
+      push.push({ state, url });
+      arriveAt(url);
+    },
+    replaceState: (state: unknown, _title: string, url: string) => {
+      replace.push({ state, url });
+      arriveAt(url);
+    },
   });
   setGlobal("document", {
     set title(value: string) {
@@ -136,7 +150,7 @@ describe("navigation", () => {
     );
   });
 
-  it("adds no history entry for a navigation to the view already showing", () => {
+  it("adds no history entry for a navigation to the address already showing", () => {
     withNavigation(
       "http://common.test/my-space/fid1:abc",
       { view: { spaceName: "my-space", pieceId: "fid1:abc" } },
@@ -147,8 +161,29 @@ describe("navigation", () => {
           }),
         );
         expect(recorded.push).toEqual([]);
-        // The application still hears it: `setView` closes the shell's piece
-        // list on the way to a piece, open or not.
+        expect(recorded.replace.at(-1)).toEqual({
+          state: { spaceName: "my-space", pieceId: "fid1:abc" },
+          url: "/my-space/fid1:abc",
+        });
+      },
+    );
+  });
+
+  it("applies a navigation to the address already showing", () => {
+    // The application hears the command whether or not it adds an entry:
+    // `setView` closes the shell's piece list on the way to a piece, and the
+    // piece already open is reached the same way as any other.
+    withNavigation(
+      "http://common.test/my-space/fid1:abc",
+      { view: { spaceName: "my-space", pieceId: "fid1:abc" } },
+      (_navigation, recorded) => {
+        const applied = recorded.views.length;
+        globalThis.dispatchEvent(
+          new CustomEvent("cf-navigate", {
+            detail: { spaceName: "my-space", pieceId: "fid1:abc" },
+          }),
+        );
+        expect(recorded.views.length).toBe(applied + 1);
         expect(recorded.views.at(-1)).toEqual({
           spaceName: "my-space",
           pieceId: "fid1:abc",
@@ -175,7 +210,7 @@ describe("navigation", () => {
     );
   });
 
-  it("adds no history entry for a link to the collection member already open", () => {
+  it("adds no history entry for a DID link to the collection member already open", () => {
     withNavigation(
       "http://common.test/my-space/top/42",
       {
@@ -197,7 +232,7 @@ describe("navigation", () => {
     );
   });
 
-  it("adds no history entry when carried-over embed mode makes the destination the current view", () => {
+  it("adds no history entry when carried-over embed mode names the address already showing", () => {
     withNavigation(
       "http://common.test/.embed/my-space/fid1:abc",
       { view: { spaceName: "my-space", pieceId: "fid1:abc", mode: "embed" } },
@@ -208,6 +243,33 @@ describe("navigation", () => {
           }),
         );
         expect(recorded.push).toEqual([]);
+      },
+    );
+  });
+
+  it("drops a consumed deep link from the entry it rewrites", () => {
+    // `?path=` reaches the view at boot and stays there, and no address
+    // carries it, so the entry the page stands on holds a field the address
+    // it names does not. The rewrite is what takes it back out.
+    withNavigation(
+      "http://common.test/my-space/fid1:abc?path=People/Zora/about.md",
+      { view: { builtin: "home" } },
+      (_navigation, recorded) => {
+        expect(recorded.replace.at(-1)?.state).toEqual({
+          spaceName: "my-space",
+          pieceId: "fid1:abc",
+          openPath: "People/Zora/about.md",
+        });
+        globalThis.dispatchEvent(
+          new CustomEvent("cf-navigate", {
+            detail: { spaceName: "my-space", pieceId: "fid1:abc" },
+          }),
+        );
+        expect(recorded.push).toEqual([]);
+        expect(recorded.replace.at(-1)).toEqual({
+          state: { spaceName: "my-space", pieceId: "fid1:abc" },
+          url: "/my-space/fid1:abc",
+        });
       },
     );
   });

--- a/packages/shell/test/navigation.test.ts
+++ b/packages/shell/test/navigation.test.ts
@@ -76,7 +76,7 @@ function withNavigation<T>(
   // in a browser.
   const location = { href, pathname: new URL(href).pathname };
   const arriveAt = (url: string) => {
-    const arrived = new URL(url, href);
+    const arrived = new URL(url, location.href);
     location.href = arrived.href;
     location.pathname = arrived.pathname;
   };
@@ -270,6 +270,23 @@ describe("navigation", () => {
           state: { spaceName: "my-space", pieceId: "fid1:abc" },
           url: "/my-space/fid1:abc",
         });
+      },
+    );
+  });
+
+  it("adds no history entry when the address needs percent-encoding", () => {
+    // `location.pathname` holds the encoded form of a name holding a character
+    // a path reserves, where the view holds the name as it is written.
+    withNavigation(
+      "http://common.test/my%20space/fid1:abc",
+      { view: { builtin: "home" } },
+      (_navigation, recorded) => {
+        globalThis.dispatchEvent(
+          new CustomEvent("cf-navigate", {
+            detail: { spaceName: "my space", pieceId: "fid1:abc" },
+          }),
+        );
+        expect(recorded.push).toEqual([]);
       },
     );
   });


### PR DESCRIPTION
`Navigation.onNavigate` pushed a history entry for every `cf-navigate` event, including one whose destination is the view the user is already looking at. That produced two history entries for one destination, so the first press of Back returned the user to the page they were already on and appeared to do nothing.

Links inside a piece reach this case routinely. A cell reference names its space by a DID, so a link that leads back to the piece already open arrives as a navigation to the current view under a different spelling of the same address.

`onNavigate` now compares the incoming command against the current view and skips the push when they name the same destination. The comparison happens after `mapNavigationView`, which is what makes the two spellings comparable at all: it rewrites a DID that names the running space as that space's name, and, through `preserveAppViewMode`, carries embed mode into a command that omits it. Comparing before either of those runs would miss the case this change is about. `isAppViewEqual` answers the question, so the shell decides that a view changed in one place; it compares fields rather than serializations, which is what lets it see past the field order the mapping rebuilds a view in.

The command still reaches the application. `setView` does more than set the view -- it closes the shell's piece list whenever the destination addresses a piece -- so a user who opens that list while viewing a piece and then picks the piece they are already on still sees it close.

Nothing else downstream needs the push. `willUpdate` already treats a view that did not change as no change, `syncViewSpace` resolves to the space the shell has resolved, and the runtime is recreated on a change of identity or host rather than of view.

`onReplaceNavigate` is left as it was. It calls `replaceState`, which rewrites the entry the page is standing on rather than adding one, so repeating a destination through it never grows the history.

Five cases cover the guard, four of which push a second entry for one destination without it: the same view named the same way, the same piece reached by a DID that names the running space, a member of a collection reached the same way, and a destination that only the carried-over embed mode completes into the current view. The fifth is the control, a navigation to a different piece, which still adds its entry.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7004?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

