### PR TITLE
fix(ui): show a source-history origin as the piece records it

### DIFF
--- a/docs/specs/piece-source-lifecycle.md
+++ b/docs/specs/piece-source-lifecycle.md
@@ -1256,11 +1256,13 @@ The piece menu, opened by right-clicking a rendered piece, belongs to
 `cf-piece-menu` in the component package rather than to the shell. Every host
 that renders pieces through `cf-render`, including Loom, therefore receives the
 same lifecycle controls. It names the origin kind and shows the canonical origin
-URL alongside the recorded string when normalization changed it. It says a
-piece is detached when it records no origin. It shows the current pattern
-identity and export symbol, the identity whose setup state was installed, and
-the pattern identity an origin update displaced. It lists the retained
-authored source files.
+URL for the active origin, alongside the recorded string when normalization
+changed it. A history entry instead shows the string that revision recorded,
+with a link to the route it resolves to whenever that route is one a browser can
+address. It says a piece is detached when it records no origin. It shows the
+current pattern identity and export symbol, the identity whose setup state was
+installed, and the pattern identity an origin update displaced. It lists the
+retained authored source files.
 
 The menu's **Clone fresh piece into new space** action creates a copy with
 default input data in a unique named space owned by the current user. **Clone

--- a/packages/ui/src/v2/components/cf-piece-menu/cf-piece-menu.test.ts
+++ b/packages/ui/src/v2/components/cf-piece-menu/cf-piece-menu.test.ts
@@ -3170,14 +3170,67 @@ describe("source history actions", () => {
     expect(rendered).toContain(">open</a>");
   });
 
-  it("shows no open link when the origin needed no resolving", async () => {
-    const menu = openMenu(pieceCell(() => Promise.resolve(historySource)));
+  it("offers the route only where it is not already the string on show", async () => {
+    const menu = openMenu(pieceCell(() =>
+      Promise.resolve({
+        ...historySource,
+        history: [
+          {
+            revisionId: "recorded",
+            timestamp: 1,
+            pattern: SOURCE.pattern!,
+            origin: {
+              url: "https://toolshed.test/api/patterns/system/home.tsx",
+              kind: "system" as const,
+              recorded: "system:system/home.tsx",
+            },
+            operation: "baseline" as const,
+          },
+          {
+            revisionId: "canonical",
+            timestamp: 2,
+            pattern: SOURCE.pattern!,
+            origin: SOURCE.origin,
+            operation: "repoint" as const,
+          },
+        ],
+      })
+    ));
     await menu.showPanel("origin");
 
+    // Both entries name their origin; only the one whose recorded form differs
+    // from the route it resolves to carries a link to that route.
     const rendered = shows(menu);
+    expect(rendered).toContain("<code>system:system/home.tsx</code>");
     expect(rendered).toContain(
       "<code>https://toolshed.test/api/patterns/recipe.tsx</code>",
     );
+    expect(rendered.split(">open</a>").length - 1).toBe(1);
+  });
+
+  it("offers no route for an origin resolving to a fabric reference", async () => {
+    const menu = openMenu(pieceCell(() =>
+      Promise.resolve({
+        ...historySource,
+        history: [{
+          revisionId: "pinned",
+          timestamp: 1,
+          pattern: SOURCE.pattern!,
+          origin: {
+            url: `cf:pattern:${"A".repeat(43)}`,
+            kind: "fabric-pattern" as const,
+            recorded: "cf:pattern:an-earlier-spelling",
+          },
+          operation: "baseline" as const,
+        }],
+      })
+    ));
+    await menu.showPanel("origin");
+
+    // Nothing a browser can open resolves from a fabric reference, so the
+    // entry names what the piece recorded and stops there.
+    const rendered = shows(menu);
+    expect(rendered).toContain("<code>cf:pattern:an-earlier-spelling</code>");
     expect(rendered).not.toContain(">open</a>");
   });
 

--- a/packages/ui/src/v2/components/cf-piece-menu/cf-piece-menu.test.ts
+++ b/packages/ui/src/v2/components/cf-piece-menu/cf-piece-menu.test.ts
@@ -3143,6 +3143,44 @@ describe("source history actions", () => {
     expect(shows(menu)).toBe("");
   });
 
+  it("keeps a history origin as recorded and links to where it resolves", async () => {
+    const menu = openMenu(pieceCell(() =>
+      Promise.resolve({
+        ...historySource,
+        history: [{
+          revisionId: "system",
+          timestamp: 1,
+          pattern: SOURCE.pattern!,
+          origin: {
+            url: "https://toolshed.test/api/patterns/system/home.tsx",
+            kind: "system",
+            recorded: "system:system/home.tsx",
+          },
+          operation: "baseline",
+        }],
+      })
+    ));
+    await menu.showPanel("origin");
+
+    const rendered = shows(menu);
+    expect(rendered).toContain("<code>system:system/home.tsx</code>");
+    expect(rendered).toContain(
+      'href="https://toolshed.test/api/patterns/system/home.tsx"',
+    );
+    expect(rendered).toContain(">open</a>");
+  });
+
+  it("shows no open link when the origin needed no resolving", async () => {
+    const menu = openMenu(pieceCell(() => Promise.resolve(historySource)));
+    await menu.showPanel("origin");
+
+    const rendered = shows(menu);
+    expect(rendered).toContain(
+      "<code>https://toolshed.test/api/patterns/recipe.tsx</code>",
+    );
+    expect(rendered).not.toContain(">open</a>");
+  });
+
   it("shows the exact retained source for a history entry", async () => {
     const requests: unknown[] = [];
     const menu = openMenu(pieceCell(

--- a/packages/ui/src/v2/components/cf-piece-menu/cf-piece-menu.ts
+++ b/packages/ui/src/v2/components/cf-piece-menu/cf-piece-menu.ts
@@ -3091,7 +3091,18 @@ export class CFPieceMenu extends BaseElement {
                 ><code>${revision.origin.url}</code></a>
               `
               : html`
-                — <code>${revision.origin.url}</code>
+                — <code>${revision.origin.recorded ??
+                  revision.origin.url}</code>${revision.origin.recorded
+                  ? html`
+                    <a
+                      class="text-link"
+                      href="${revision.origin.url}"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      test-id="piece-source-origin-open-${revision.revisionId}"
+                    >open</a>
+                  `
+                  : nothing}
               `
             : nothing}
         </div>

--- a/packages/ui/src/v2/components/cf-piece-menu/cf-piece-menu.ts
+++ b/packages/ui/src/v2/components/cf-piece-menu/cf-piece-menu.ts
@@ -3054,6 +3054,15 @@ export class CFPieceMenu extends BaseElement {
     const originView = revision.origin?.kind === "fabric-piece"
       ? fabricPieceNavigation(revision.origin.url, source.space)
       : undefined;
+    // The entry shows the string the piece recorded. A deployment-served
+    // origin is the only kind that resolves to a URL a browser can open, so
+    // only that kind offers the route beside the string, and only when the
+    // route is not already the string on show.
+    const recordedForm = revision.origin?.recorded ?? revision.origin?.url;
+    const openableRoute = revision.origin?.kind === "system" &&
+        recordedForm !== revision.origin.url
+      ? revision.origin.url
+      : undefined;
     return html`
       <article class="revision" test-id="piece-source-revision">
         <div class="revision-head">
@@ -3091,12 +3100,12 @@ export class CFPieceMenu extends BaseElement {
                 ><code>${revision.origin.url}</code></a>
               `
               : html`
-                — <code>${revision.origin.recorded ??
-                  revision.origin.url}</code>${revision.origin.recorded
+                — <code>${recordedForm}</code>${openableRoute
                   ? html`
+                    ·
                     <a
                       class="text-link"
-                      href="${revision.origin.url}"
+                      href="${openableRoute}"
                       target="_blank"
                       rel="noopener noreferrer"
                       test-id="piece-source-origin-open-${revision.revisionId}"


### PR DESCRIPTION
The source history in the "Origin and history" panel showed each revision's origin as the URL that origin resolves to, not as the string the piece actually stores. For a `system:` ref — the form a system space root is stamped with, naming a pattern this deployment's toolshed serves from its patterns route — that meant the panel printed `https://toolshed.example/api/patterns/system/home.tsx` where the piece holds `system:system/home.tsx`. Someone reading the history could not tell which of the two forms was recorded, and the resolved URL is host-dependent, so the same revision reads differently depending on which host the space is served from.

The origin classifier already keeps both forms: it reports the resolved route as `url` and, whenever resolving changed the string, the stored one as `recorded`. The panel's own "Origin" section shows the stored form on a "Recorded as" row, but the history entries never used it.

Each history entry now prints the recorded form when there is one, with an "open" link after it pointing at the resolved URL, so the stored ref is what you read and the place it resolves to is still one click away. Entries whose origin needed no resolving are unchanged: they print the one URL and get no link. Keying off the recorded form rather than off the `system:` scheme covers both spellings a deployment-served origin can carry — the ref, and the rooted path that spelling had before the scheme existed — because both reach the panel through that one field.

Fabric origins are untouched. They are never rewritten, so they carry no recorded form, and the entry keeps the in-app navigation link it already had.

Two tests cover this: that a revision storing a `system:` ref shows the ref and links to the route it resolves to, and that a revision needing no resolving gets no link. Verified by running the piece menu's suite, 23 tests over 171 steps with none failing, and by checking that removing the rendering turns the first test red on the assertion that the entry shows the stored ref.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7005?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

