### PR TITLE
fix(piece): read a writer claim the same way wherever it sits

### DIFF
--- a/docs/specs/schema-generator/ts_to_json_schema_mapping.md
+++ b/docs/specs/schema-generator/ts_to_json_schema_mapping.md
@@ -656,7 +656,13 @@ Mechanics:
   anchors on `moduleIdentity` plus the binding `path`. So the comparison holds
   only the binding `path` and the `uiContract` fixed, and the runner still
   verifies the live writer's `moduleIdentity` against the claim at write time,
-  so this narrows nothing.
+  so this narrows nothing. Where the claim sits in the schema makes no
+  difference to that: the checker descends every keyword that holds schemas —
+  `allOf`, `oneOf`, `if`/`then`, and `not` among them — and normalizes a claim
+  it finds there the same way it normalizes one written onto a property. This
+  package emits none of those keywords, so nothing it produces exercises that
+  today. The checker sees schemas from elsewhere as well, and holds them to the
+  same reading.
 - `SchemaGeneratorTransformer.resolvePolicyOfMarkers` replaces a valid policy
   marker with the compiled module identity, exported symbol, and policy digest.
   If it cannot match a compiler-verified exported `exchangeRules()` binding,

--- a/packages/piece/src/schema-compatibility.ts
+++ b/packages/piece/src/schema-compatibility.ts
@@ -1529,14 +1529,8 @@ const keywordValuesEqual = (
   if (
     SUBSCHEMA_LIST_KEYS.has(key) && Array.isArray(left) && Array.isArray(right)
   ) {
-    if (left.length !== right.length) return false;
-    for (let index = 0; index < left.length; index++) {
-      // A hole and a stored `undefined` are different values, the way
-      // `valueEqual` reads them.
-      if ((index in left) !== (index in right)) return false;
-      if (!schemaSubtreesEqual(left[index], right[index])) return false;
-    }
-    return true;
+    return left.length === right.length &&
+      left.every((entry, index) => schemaSubtreesEqual(entry, right[index]));
   }
   if (
     SUBSCHEMA_MAP_KEYS.has(key) && isPlainObject(left) && isPlainObject(right)

--- a/packages/piece/src/schema-compatibility.ts
+++ b/packages/piece/src/schema-compatibility.ts
@@ -1529,8 +1529,17 @@ const keywordValuesEqual = (
   if (
     SUBSCHEMA_LIST_KEYS.has(key) && Array.isArray(left) && Array.isArray(right)
   ) {
-    return left.length === right.length &&
-      left.every((entry, index) => schemaSubtreesEqual(entry, right[index]));
+    if (left.length !== right.length) return false;
+    for (let index = 0; index < left.length; index++) {
+      // A hole and a stored `undefined` are different values, the way
+      // `valueEqual` reads them, and the array iteration methods skip a hole
+      // rather than report it. `validateSchemaDefinition` requires a dense
+      // array for the four list keywords it names, but this walk descends
+      // keywords it has no rule for, so a hole can still arrive here.
+      if ((index in left) !== (index in right)) return false;
+      if (!schemaSubtreesEqual(left[index], right[index])) return false;
+    }
+    return true;
   }
   if (
     SUBSCHEMA_MAP_KEYS.has(key) && isPlainObject(left) && isPlainObject(right)

--- a/packages/piece/src/schema-compatibility.ts
+++ b/packages/piece/src/schema-compatibility.ts
@@ -14,6 +14,15 @@ import {
   validateSchemaValue,
 } from "@commonfabric/runner/cfc";
 import { isFabricPrimitiveSchemaType } from "@commonfabric/api";
+import { isPlainObject } from "@commonfabric/utils/types";
+import {
+  ARRAY_SUBSCHEMA_KEYS,
+  DEFS_KEYS,
+  RECORD_SUBSCHEMA_KEYS,
+  SINGLE_SUBSCHEMA_KEYS,
+  UNUSED_RECORD_SUBSCHEMA_KEYS,
+  UNUSED_SINGLE_SUBSCHEMA_KEYS,
+} from "@commonfabric/runner/schema-walk";
 import { internSchema } from "@commonfabric/data-model-schema";
 import { type FabricValue, valueEqual } from "@commonfabric/data-model";
 
@@ -147,6 +156,46 @@ const SEMANTIC_EXTENSION_KEYS = [
   "writeOnly",
 ] as const;
 
+/**
+ * The keywords whose value is one nested schema. Together with
+ * {@link SUBSCHEMA_LIST_KEYS} and {@link SUBSCHEMA_MAP_KEYS} these are the
+ * edges a walk follows to reach every schema written inside another one.
+ *
+ * The vocabulary comes from `@commonfabric/runner/schema-walk`, which is where
+ * this repository keeps it. Both walks here need it complete rather than
+ * limited to what the generator emits: a schema reaching this gate may have
+ * been written into a space by anything, and `validateSchemaDefinition` accepts
+ * every keyword named below. So both tiers of the shared vocabulary are taken,
+ * the ones the generator emits and the ones it does not.
+ *
+ * `definitions`, the pre-2019 spelling of `$defs`, is the one addition. The
+ * shared vocabulary leaves it out because nothing in this repository writes it;
+ * {@link ANNOTATION_KEYS} classifies it and `resolveCfcSchemaRefs` resolves
+ * through it, so a schema that arrives carrying one is read here.
+ */
+const SUBSCHEMA_KEYS: ReadonlySet<string> = new Set<string>([
+  ...SINGLE_SUBSCHEMA_KEYS,
+  ...UNUSED_SINGLE_SUBSCHEMA_KEYS,
+]);
+
+/** The keywords whose value is an array of nested schemas. */
+const SUBSCHEMA_LIST_KEYS: ReadonlySet<string> = new Set<string>(
+  ARRAY_SUBSCHEMA_KEYS,
+);
+
+/** The keywords whose value is a record of nested schemas. */
+const SUBSCHEMA_MAP_KEYS: ReadonlySet<string> = new Set<string>([
+  ...RECORD_SUBSCHEMA_KEYS,
+  ...UNUSED_RECORD_SUBSCHEMA_KEYS,
+  ...DEFS_KEYS,
+  "definitions",
+]);
+
+/** Whether a keyword leads to a nested schema, in any of the three shapes. */
+const holdsSubschemas = (key: string): boolean =>
+  SUBSCHEMA_KEYS.has(key) || SUBSCHEMA_LIST_KEYS.has(key) ||
+  SUBSCHEMA_MAP_KEYS.has(key);
+
 const fabricAwareEqual = (left: unknown, right: unknown): boolean => {
   try {
     return valueEqual(left as FabricValue, right as FabricValue);
@@ -210,12 +259,11 @@ const WRITER_IDENTITY_VOLATILE_KEYS: ReadonlySet<string> = new Set([
  * `writeAuthorizedBy` names trusted builtins rather than a compiled module, so
  * it carries no writer identity and is returned unchanged.
  *
- * This runs where the `ifc` extension is compared as a semantic-extension key,
- * which the per-node recursion reaches for a claim placed directly on a
- * property, behind a `$defs` reference, or in an `anyOf` branch. A claim
- * reached only through a composite keyword (`allOf`, `oneOf`, `if`/`then`,
- * `not`) is compared by whole-value equality instead, so its volatile identity
- * still participates and a recompile there is reported as a change.
+ * This runs wherever an `ifc` is compared, which `keywordValuesEqual` makes one
+ * rule: a claim written directly on a property, one behind a `$defs`
+ * reference, and one under any keyword that holds schemas — `allOf`, `oneOf`,
+ * `if`/`then`, and `not` among them — are all read the same way, so recompiling
+ * the authoring module reads as a contract change in none of them.
  */
 const writerClaimWithoutVolatileIdentity = (claim: unknown): unknown => {
   if (typeof claim !== "object" || claim === null || Array.isArray(claim)) {
@@ -353,12 +401,10 @@ const representsPrincipalAtoms = (value: unknown): readonly unknown[] => {
  * derived per-value keys dropped, and a write authorization's volatile identity
  * normalized. Returns the input unchanged when neither applies.
  *
- * This runs where `ifc` is compared as a semantic-extension key, which the
- * per-node recursion reaches for a node written directly on a property, behind
- * a `$defs` reference, or in an `anyOf` branch. An `ifc` reached only through a
- * composite keyword (`allOf`, `oneOf`, `if`/`then`, `not`) is compared by whole
- * value instead, so a mint there still reads as a change — the same scope the
- * writer-identity normalization has.
+ * `keywordValuesEqual` calls this at every `ifc` it meets, so the reduction has
+ * the same reach whether the node is written directly on a property, sits
+ * behind a `$defs` reference, or is nested under a keyword that holds schemas —
+ * `allOf`, `oneOf`, `if`/`then`, and `not` among them.
  *
  * An extension with no keys left comes back as `undefined`, the same as no
  * extension at all, and so does one that arrived empty. A path that carried no
@@ -482,6 +528,16 @@ const comparableIfc = (ifc: unknown): unknown => {
  * the whole `uiContract` are still compared, and the runtime enforcement is
  * untouched, so this narrows nothing.
  *
+ * The reduction reaches every `ifc` in the schema, not only one written on the
+ * node being checked. A comparison that meets a keyword holding schemas —
+ * `allOf`, `oneOf`, `if`/`then`, and `not` among them — descends into it and
+ * reduces the `ifc` it finds there the same way. The schemas this gate compares
+ * do not all come from the schema generator, which emits none of those
+ * keywords: one can be written into a space by anything, and
+ * `validateSchemaDefinition` admits every keyword the walk descends. The walk
+ * stops at every keyword that holds a value rather than a schema, so a
+ * `default`, a `const`, and an `enum` entry are compared whole.
+ *
  * The `ifc` comparison drops one key as well. `addIntegrity` names the derived
  * per-value label rather than the store's declared policy, so a path gaining or
  * losing a mint is not a change to the contract between two versions of the
@@ -563,6 +619,18 @@ export function assertPatternSchemasBackwardCompatible(
  * Conservatively prove that every value described by `source` is accepted by
  * `target`. This is used for durable links: validating only their current
  * materialization is insufficient because the linked cell can change later.
+ *
+ * The `ifc` reduction {@link comparableIfc} performs applies here as well, and
+ * this entry point puts it to a different question. A pattern update compares
+ * two versions of one contract, where a changed writer identity is the same
+ * module recompiled. A link joins two separate pieces, where a differing
+ * `moduleIdentity` names a different authoring module. What holds either way is
+ * the reason the reduction exists: the runtime authorizes a write against the
+ * claim on the location being written, re-verifying the live writer's
+ * `moduleIdentity` there (`writeAuthorizedByReason`,
+ * `packages/runner/src/cfc/prepare.ts`). Proving a link neither performs that
+ * check nor stands in for it, and the binding `path` and the whole `uiContract`
+ * are compared here as they are for an update.
  */
 export function assertSchemaSubset(
   source: JSONSchema,
@@ -724,14 +792,9 @@ function schemaSubsetIssue(
       // and its resolver-dependent file spelling, which the runtime does not
       // hold fixed either — and the derived per-value label annotations, which
       // describe the label a write produces rather than the policy the store
-      // declares. `comparableIfc` removes both.
-      const sourceValue = key === "ifc"
-        ? comparableIfc(source[key])
-        : source[key];
-      const targetValue = key === "ifc"
-        ? comparableIfc(target[key])
-        : target[key];
-      if (!fabricAwareEqual(sourceValue, targetValue)) {
+      // declares. `keywordValuesEqual` applies that reduction, the same one it
+      // applies to an `ifc` nested below a composite keyword.
+      if (!keywordValuesEqual(key, source[key], target[key])) {
         return `${path}: ${key} changed`;
       }
     }
@@ -781,7 +844,7 @@ function schemaSubsetIssue(
       if (arrayIssue) return arrayIssue;
     }
 
-    return unknownKeywordIssue(source, target, path);
+    return unknownKeywordIssue(source, target, path, context);
   } finally {
     unmarkPairActive(source, target, context);
   }
@@ -1438,12 +1501,90 @@ function schemaTypes(schema: SchemaObject): readonly string[] | undefined {
   return typeof schema.type === "string" ? [schema.type] : schema.type;
 }
 
+/**
+ * Whether one keyword says the same thing on both sides.
+ *
+ * An `ifc` is compared through {@link comparableIfc}, so a nested extension
+ * carries the same reduction as one written on the node being checked: the
+ * derived per-value keys dropped, and a write authorization's volatile identity
+ * normalized. An absent `ifc` and one the reduction empties both come back as
+ * `undefined` and compare equal, which is why this keyword is the one whose
+ * presence is not compared before its value is.
+ *
+ * A keyword that holds nested schemas recurses into them. Every other keyword
+ * holds a value, and is compared as it stands. So is a keyword that names
+ * nested schemas but arrives in some other shape: an `allOf` that is not a
+ * list, or a `properties` that is not a record, is not a schema this comparison
+ * can read into.
+ */
+const keywordValuesEqual = (
+  key: string,
+  left: unknown,
+  right: unknown,
+): boolean => {
+  if (key === "ifc") {
+    return fabricAwareEqual(comparableIfc(left), comparableIfc(right));
+  }
+  if (SUBSCHEMA_KEYS.has(key)) return schemaSubtreesEqual(left, right);
+  if (
+    SUBSCHEMA_LIST_KEYS.has(key) && Array.isArray(left) && Array.isArray(right)
+  ) {
+    if (left.length !== right.length) return false;
+    for (let index = 0; index < left.length; index++) {
+      // A hole and a stored `undefined` are different values, the way
+      // `valueEqual` reads them.
+      if ((index in left) !== (index in right)) return false;
+      if (!schemaSubtreesEqual(left[index], right[index])) return false;
+    }
+    return true;
+  }
+  if (
+    SUBSCHEMA_MAP_KEYS.has(key) && isPlainObject(left) && isPlainObject(right)
+  ) {
+    const names = Object.keys(left);
+    return names.length === Object.keys(right).length &&
+      names.every((name) =>
+        Object.hasOwn(right, name) &&
+        schemaSubtreesEqual(left[name], right[name])
+      );
+  }
+  return fabricAwareEqual(left, right);
+};
+
+/**
+ * Whether two schemas say the same thing, reading every `ifc` either of them
+ * carries — at any depth, under any keyword — the way this comparison reads
+ * one written on the node being checked.
+ *
+ * Two schemas that are equal as they stand settle on the first line. Past that
+ * the walk descends the keywords that hold nested schemas, so an `ifc` reached
+ * only through a composite keyword (`allOf`, `oneOf`, `if`/`then`, `not`) gets
+ * the same reduction as one the per-node recursion reaches directly.
+ *
+ * The walk stops at every keyword that holds a value rather than a schema, so a
+ * `default`, a `const`, or an `enum` entry is compared whole by
+ * {@link fabricAwareEqual}, which reads a fabric value by content hash.
+ */
+function schemaSubtreesEqual(left: unknown, right: unknown): boolean {
+  if (fabricAwareEqual(left, right)) return true;
+  if (!isPlainObject(left) || !isPlainObject(right)) return false;
+  for (const key of new Set([...Object.keys(left), ...Object.keys(right)])) {
+    if (
+      key !== "ifc" && Object.hasOwn(left, key) !== Object.hasOwn(right, key)
+    ) {
+      return false;
+    }
+    if (!keywordValuesEqual(key, left[key], right[key])) return false;
+  }
+  return true;
+}
+
 function schemasResolveEqually(
   source: unknown,
   target: unknown,
   context: CompatibilityContext,
 ): boolean {
-  if (!fabricAwareEqual(source, target)) return false;
+  if (!schemaSubtreesEqual(source, target)) return false;
 
   const refs = new Set<string>();
   collectSchemaReferences(source, refs, new WeakSet());
@@ -1458,7 +1599,7 @@ function schemasResolveEqually(
     );
     if (
       sourceResolved === undefined || targetResolved === undefined ||
-      !fabricAwareEqual(sourceResolved, targetResolved)
+      !schemaSubtreesEqual(sourceResolved, targetResolved)
     ) {
       return false;
     }
@@ -1571,22 +1712,10 @@ function collectSchemaReferences(
   const record = value as Record<string, unknown>;
   if (typeof record.$ref === "string") refs.add(record.$ref);
 
-  for (
-    const key of [
-      "additionalProperties",
-      "contains",
-      "contentSchema",
-      "else",
-      "if",
-      "items",
-      "not",
-      "propertyNames",
-      "then",
-    ]
-  ) {
+  for (const key of SUBSCHEMA_KEYS) {
     collectSchemaReferences(record[key], refs, seen);
   }
-  for (const key of ["allOf", "anyOf", "oneOf", "prefixItems"]) {
+  for (const key of SUBSCHEMA_LIST_KEYS) {
     const children = record[key];
     if (Array.isArray(children)) {
       for (const child of children) {
@@ -1594,15 +1723,7 @@ function collectSchemaReferences(
       }
     }
   }
-  for (
-    const key of [
-      "$defs",
-      "definitions",
-      "dependentSchemas",
-      "patternProperties",
-      "properties",
-    ]
-  ) {
+  for (const key of SUBSCHEMA_MAP_KEYS) {
     const children = record[key];
     if (children !== null && typeof children === "object") {
       for (const child of Object.values(children)) {
@@ -1712,6 +1833,7 @@ function unknownKeywordIssue(
   source: SchemaObject,
   target: SchemaObject,
   path: string,
+  context: CompatibilityContext,
 ): string | undefined {
   const handled = new Set([
     ...ANNOTATION_KEYS,
@@ -1746,10 +1868,26 @@ function unknownKeywordIssue(
   const sourceRecord = source as Record<string, unknown>;
   const targetRecord = target as Record<string, unknown>;
   for (const key of keys) {
-    if (
-      !handled.has(key) &&
-      !fabricAwareEqual(sourceRecord[key], targetRecord[key])
-    ) {
+    if (handled.has(key)) continue;
+    // A keyword that holds nested schemas is compared with its references
+    // resolved, the way the constraints above are. Comparing the value alone
+    // would read two identical `$ref`s as the same constraint while the
+    // definitions they name had changed underneath, and nothing further down
+    // would look at that definition, so the update would land.
+    //
+    // For a keyword that holds no schema — the genuinely unknown one this
+    // function exists for — the comparison is exact equality, so an extension
+    // this checker cannot read is held to what it says. A reference is not
+    // resolved there either: a record that carries a `$ref` key as ordinary
+    // data is data, not a reference.
+    const equal = holdsSubschemas(key)
+      ? schemasResolveEqually(
+        { [key]: sourceRecord[key] },
+        { [key]: targetRecord[key] },
+        context,
+      )
+      : keywordValuesEqual(key, sourceRecord[key], targetRecord[key]);
+    if (!equal) {
       return `${path}: ${key} changed in a way compatibility checking cannot prove safe`;
     }
   }

--- a/packages/piece/test/schema-compatibility.test.ts
+++ b/packages/piece/test/schema-compatibility.test.ts
@@ -112,7 +112,7 @@ describe("piece schema compatibility", () => {
     path: ["setFlag"],
     moduleIdentity: "UVJh2ChHuLkknYrVet0Iu",
   };
-  const baselineUiContract = {
+  const baselineUiContract: Record<string, unknown> = {
     helper: "UiAction",
     action: "SetFlag",
     trustedPattern: "DemoSurface",
@@ -484,6 +484,415 @@ describe("piece schema compatibility", () => {
         pattern({ type: "object" }, withBuiltins(["trustedBuiltin"])),
       )
     ).toThrow(/flag: ifc changed/);
+  });
+
+  // `allOf` and `oneOf` are not taken apart by the subset proof, so what
+  // decides them is whether the two sides say the same thing. A write
+  // authorization under one of them is read with the same reduction the
+  // comparison applies to one written on a property, so a recompile of the
+  // authoring module is accepted wherever the authorization sits. Without
+  // that, a pattern carrying a claim there would freeze on the first edit to
+  // the module that authorizes it.
+  //
+  // The schema generator emits neither keyword — an intersection merges into
+  // one object schema and a union emits `anyOf` — so nothing reaches these
+  // through that route today. The gate does not only see generated schemas:
+  // one can be written into a space by anything, and `validateSchemaDefinition`
+  // admits both keywords, which is what these pin.
+  const compositeWrite = (
+    keyword: "allOf" | "oneOf",
+    identity: Record<string, unknown>,
+    uiContract: Record<string, unknown> = baselineUiContract,
+  ): JSONSchema => ({
+    type: "object",
+    properties: {
+      flag: {
+        [keyword]: [{
+          type: "boolean",
+          ifc: {
+            writeAuthorizedBy: { __ctWriterIdentityOf: identity },
+            uiContract,
+          },
+        }],
+      },
+    },
+  });
+
+  for (const keyword of ["allOf", "oneOf"] as const) {
+    it(`accepts a recompile under ${keyword}`, () => {
+      expect(() =>
+        assertPatternSchemasBackwardCompatible(
+          pattern(
+            { type: "object" },
+            compositeWrite(keyword, baselineIdentity),
+          ),
+          pattern(
+            { type: "object" },
+            compositeWrite(keyword, {
+              ...baselineIdentity,
+              moduleIdentity: "DCTZZ89BogydamlP301Qx",
+            }),
+          ),
+        )
+      ).not.toThrow();
+    });
+
+    it(`accepts a cross-resolver re-spelling under ${keyword}`, () => {
+      expect(() =>
+        assertPatternSchemasBackwardCompatible(
+          pattern(
+            { type: "object" },
+            compositeWrite(keyword, baselineIdentity),
+          ),
+          pattern(
+            { type: "object" },
+            compositeWrite(keyword, {
+              ...baselineIdentity,
+              file: "/api/patterns/demo/main.tsx",
+            }),
+          ),
+        )
+      ).not.toThrow();
+    });
+
+    it(`still rejects a binding path change under ${keyword}`, () => {
+      expect(() =>
+        assertPatternSchemasBackwardCompatible(
+          pattern(
+            { type: "object" },
+            compositeWrite(keyword, baselineIdentity),
+          ),
+          pattern(
+            { type: "object" },
+            compositeWrite(keyword, {
+              ...baselineIdentity,
+              path: ["setOtherFlag"],
+            }),
+          ),
+        )
+      ).toThrow(new RegExp(`flag: ${keyword} changed`));
+    });
+
+    it(`still rejects a uiContract change under ${keyword}`, () => {
+      expect(() =>
+        assertPatternSchemasBackwardCompatible(
+          pattern(
+            { type: "object" },
+            compositeWrite(keyword, baselineIdentity),
+          ),
+          pattern(
+            { type: "object" },
+            compositeWrite(keyword, baselineIdentity, {
+              ...baselineUiContract,
+              action: "ClearFlag",
+            }),
+          ),
+        )
+      ).toThrow(new RegExp(`flag: ${keyword} changed`));
+    });
+  }
+
+  it("reads a nested ifc the same way under every keyword that holds schemas", () => {
+    // The keywords the subset proof cannot take apart are not only `allOf` and
+    // `oneOf`. `if`/`then` and `not` are compared whole as well, and each is
+    // read with the same reduction, so a recompile is accepted there too.
+    const conditional = (
+      identity: Record<string, unknown>,
+      uiContract: Record<string, unknown> = baselineUiContract,
+    ): JSONSchema => ({
+      type: "object",
+      properties: {
+        flag: {
+          if: { type: "boolean" },
+          then: {
+            ifc: {
+              writeAuthorizedBy: { __ctWriterIdentityOf: identity },
+              uiContract,
+            },
+          },
+          not: {
+            const: null,
+            ifc: { writeAuthorizedBy: { __ctWriterIdentityOf: identity } },
+          },
+        },
+      },
+    });
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        pattern({ type: "object" }, conditional(baselineIdentity)),
+        pattern(
+          { type: "object" },
+          conditional({
+            ...baselineIdentity,
+            moduleIdentity: "DCTZZ89BogydamlP301Qx",
+          }),
+        ),
+      )
+    ).not.toThrow();
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        pattern({ type: "object" }, conditional(baselineIdentity)),
+        pattern(
+          { type: "object" },
+          conditional(baselineIdentity, {
+            ...baselineUiContract,
+            action: "ClearFlag",
+          }),
+        ),
+      )
+    ).toThrow(/flag: (if|then|not) changed/);
+  });
+
+  it("reads a claim reached through a recursive definition", () => {
+    // A definition that names itself is what the walk has to terminate on, and
+    // the claim sits under `allOf` inside it, so reaching it means descending
+    // both the reference and the composite keyword. The recompile is accepted
+    // and the binding path change is not.
+    const recursive = (identity: Record<string, unknown>): JSONSchema => ({
+      type: "object",
+      $defs: {
+        Node: {
+          type: "object",
+          properties: {
+            child: { $ref: "#/$defs/Node" },
+            flag: {
+              allOf: [{
+                type: "boolean",
+                ifc: {
+                  writeAuthorizedBy: { __ctWriterIdentityOf: identity },
+                  uiContract: baselineUiContract,
+                },
+              }],
+            },
+          },
+        },
+      },
+      properties: { root: { $ref: "#/$defs/Node" } },
+    });
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        pattern({ type: "object" }, recursive(baselineIdentity)),
+        pattern(
+          { type: "object" },
+          recursive({
+            ...baselineIdentity,
+            moduleIdentity: "DCTZZ89BogydamlP301Qx",
+          }),
+        ),
+      )
+    ).not.toThrow();
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        pattern({ type: "object" }, recursive(baselineIdentity)),
+        pattern(
+          { type: "object" },
+          recursive({ ...baselineIdentity, path: ["setOtherFlag"] }),
+        ),
+      )
+    ).toThrow(/allOf changed/);
+  });
+
+  it("reads a claim under a composite keyword when proving a link", () => {
+    // `assertSchemaSubset` proves a durable link between two separate pieces
+    // rather than two versions of one contract, and it reaches the same
+    // comparison. A differing writer identity is read the same way there as it
+    // is on a property, while the binding path is still compared.
+    const linked = (identity: Record<string, unknown>): JSONSchema => ({
+      allOf: [{
+        type: "boolean",
+        ifc: {
+          writeAuthorizedBy: { __ctWriterIdentityOf: identity },
+          uiContract: baselineUiContract,
+        },
+      }],
+    });
+    expect(() =>
+      assertSchemaSubset(
+        linked(baselineIdentity),
+        linked({
+          ...baselineIdentity,
+          moduleIdentity: "DCTZZ89BogydamlP301Qx",
+        }),
+      )
+    ).not.toThrow();
+    expect(() =>
+      assertSchemaSubset(
+        linked(baselineIdentity),
+        linked({ ...baselineIdentity, path: ["setOtherFlag"] }),
+      )
+    ).toThrow(/allOf changed/);
+  });
+
+  it("reads a claim under a keyword the checker has no other rule for", () => {
+    // `unevaluatedProperties` holds a schema, but no rule in this comparison
+    // names it, so a difference in it is reported by the unknown-keyword check
+    // at the end. That check reads it with the same rule as everything else, so
+    // a recompile under it is accepted and a binding path change under it is
+    // not.
+    const unevaluated = (identity: Record<string, unknown>): JSONSchema => ({
+      type: "object",
+      properties: {
+        bag: {
+          type: "object",
+          unevaluatedProperties: {
+            type: "string",
+            ifc: {
+              writeAuthorizedBy: { __ctWriterIdentityOf: identity },
+            },
+          },
+        },
+      },
+    } as unknown as JSONSchema);
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        pattern({ type: "object" }, unevaluated(baselineIdentity)),
+        pattern(
+          { type: "object" },
+          unevaluated({
+            ...baselineIdentity,
+            moduleIdentity: "DCTZZ89BogydamlP301Qx",
+          }),
+        ),
+      )
+    ).not.toThrow();
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        pattern({ type: "object" }, unevaluated(baselineIdentity)),
+        pattern(
+          { type: "object" },
+          unevaluated({ ...baselineIdentity, path: ["setOtherFlag"] }),
+        ),
+      )
+    ).toThrow(/bag: unevaluatedProperties changed/);
+  });
+
+  it("resolves a reference under a keyword it has no other rule for", () => {
+    // `unevaluatedProperties` holds a schema that this comparison has no
+    // subset rule for, so the unknown-keyword check decides it. Two identical
+    // `$ref`s say the same thing only while the definitions they name do; the
+    // check resolves them against each contract's own root rather than reading
+    // the reference string as the constraint.
+    const referenced = (definition: string): JSONSchema => ({
+      type: "object",
+      $defs: { Entry: { type: definition } },
+      properties: {
+        bag: {
+          type: "object",
+          unevaluatedProperties: { $ref: "#/$defs/Entry" },
+        },
+      },
+    } as unknown as JSONSchema);
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        pattern({ type: "object" }, referenced("string")),
+        pattern({ type: "object" }, referenced("string")),
+      )
+    ).not.toThrow();
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        pattern({ type: "object" }, referenced("string")),
+        pattern({ type: "object" }, referenced("number")),
+      )
+    ).toThrow(/bag: unevaluatedProperties changed/);
+  });
+
+  it("still rejects a constraint change beside a nested writer claim", () => {
+    // The reduction reaches the `ifc` and nothing else. A branch that narrows
+    // what it accepts is still a narrowed contract, whether or not the same
+    // branch carries a write authorization.
+    const narrowing = (maxLength: number): JSONSchema => ({
+      type: "object",
+      properties: {
+        label: {
+          allOf: [{
+            type: "string",
+            maxLength,
+            ifc: {
+              writeAuthorizedBy: { __ctWriterIdentityOf: baselineIdentity },
+            },
+          }],
+        },
+      },
+    });
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        pattern(narrowing(64), { type: "object" }),
+        pattern(narrowing(32), { type: "object" }),
+      )
+    ).toThrow(/label: allOf changed/);
+  });
+
+  it("compares a Fabric default beside a nested writer claim by content", () => {
+    // The reduction is applied in place: the comparison walks both schemas and
+    // reads the `ifc` it meets, and never rebuilds a node. A `default` holding
+    // a Fabric value is compared as it stands, by content hash, so two such
+    // values that differ are still a change and two that agree are still not
+    // one — beside a writer claim whose module was recompiled or not.
+    const seeded = (
+      seed: FabricBytes,
+      moduleIdentity: string,
+    ): JSONSchema => ({
+      type: "object",
+      properties: {
+        token: {
+          allOf: [{
+            type: "FabricBytes",
+            default: seed,
+            ifc: {
+              writeAuthorizedBy: {
+                __ctWriterIdentityOf: { ...baselineIdentity, moduleIdentity },
+              },
+            },
+          }],
+        },
+      },
+    } as unknown as JSONSchema);
+    const seed = () => new FabricBytes(new Uint8Array([1, 2, 3]));
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        pattern({ type: "object" }, seeded(seed(), "UVJh2ChHuLkknYrVet0Iu")),
+        pattern({ type: "object" }, seeded(seed(), "DCTZZ89BogydamlP301Qx")),
+      )
+    ).not.toThrow();
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        pattern({ type: "object" }, seeded(seed(), "UVJh2ChHuLkknYrVet0Iu")),
+        pattern(
+          { type: "object" },
+          seeded(new FabricBytes(new Uint8Array([9])), "UVJh2ChHuLkknYrVet0Iu"),
+        ),
+      )
+    ).toThrow(/token: allOf changed/);
+  });
+
+  it("accepts a mint gained under a keyword the subset proof compares whole", () => {
+    // The `ifc` reduction drops the derived per-value keys as well, and it
+    // drops them wherever the extension sits. A floored path that gains the
+    // mint its own floor names is not a contract change under `allOf` any more
+    // than it is on the property itself.
+    const floored = (ifc: Record<string, unknown>): JSONSchema => ({
+      type: "object",
+      properties: {
+        admins: {
+          allOf: [{ type: "array", items: { type: "string" }, ifc }],
+        },
+      },
+    });
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        pattern(floored(floorOnly), { type: "object" }),
+        pattern(floored(floorAndMint), { type: "object" }),
+      )
+    ).not.toThrow();
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        pattern(floored(floorOnly), { type: "object" }),
+        pattern(
+          floored({ requiredIntegrity: ["group-chat-owner"] }),
+          { type: "object" },
+        ),
+      )
+    ).toThrow(/admins: allOf changed/);
   });
 
   it("accepts named Fabric projection fields through an open link target", () => {

--- a/packages/piece/test/schema-compatibility.test.ts
+++ b/packages/piece/test/schema-compatibility.test.ts
@@ -796,12 +796,52 @@ describe("piece schema compatibility", () => {
     ).toThrow(/bag: unevaluatedProperties changed/);
   });
 
-  it("still rejects a conjunct added beside a nested writer claim", () => {
+  it("compares a sparse subschema list by index", () => {
+    // `validateSchemaDefinition` requires a dense array for the four list
+    // keywords it names, so a hole reaches this comparison only under a
+    // keyword it has no rule for. `unevaluatedProperties` is such a keyword,
+    // and the walk descends it. A hole and a stored `undefined` are different
+    // values, so a list whose missing entry the candidate fills carries a
+    // constraint the baseline did not, and the array iteration methods would
+    // step over exactly that difference.
+    const list = (holed: boolean): unknown[] => {
+      const entries: unknown[] = [];
+      if (!holed) entries[0] = { type: "string" };
+      entries[1] = { type: "string" };
+      return entries;
+    };
+    const bag = (holed: boolean): JSONSchema => ({
+      type: "object",
+      properties: {
+        a: {
+          type: "object",
+          unevaluatedProperties: { allOf: list(holed) },
+        },
+      },
+    } as unknown as JSONSchema);
+    // Refused whichever side carries the hole, so the answer does not depend
+    // on which contract is named first.
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        pattern(bag(true), { type: "object" }),
+        pattern(bag(false), { type: "object" }),
+      )
+    ).toThrow(/a: unevaluatedProperties changed/);
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        pattern(bag(false), { type: "object" }),
+        pattern(bag(true), { type: "object" }),
+      )
+    ).toThrow(/a: unevaluatedProperties changed/);
+  });
+
+  it("still rejects a conjunct added or removed beside a nested writer claim", () => {
     // Reading the `ifc` inside an `allOf` means comparing the two lists, and
-    // a list that gains an entry has gained a constraint every value must now
-    // satisfy. The added conjunct is a narrowing whether or not the entry
-    // beside it carries a write authorization, so the lengths decide it before
-    // any entry is read.
+    // a list of a different length is a different list. Both directions are
+    // refused, because this comparison proves nothing about `allOf` either
+    // way: it decides the keyword by whether the two sides say the same thing,
+    // so a candidate that widens by dropping a conjunct is refused alongside
+    // one that narrows by adding one.
     const conjuncts = (extra: boolean): JSONSchema => ({
       type: "object",
       properties: {

--- a/packages/piece/test/schema-compatibility.test.ts
+++ b/packages/piece/test/schema-compatibility.test.ts
@@ -796,6 +796,42 @@ describe("piece schema compatibility", () => {
     ).toThrow(/bag: unevaluatedProperties changed/);
   });
 
+  it("still rejects a conjunct added beside a nested writer claim", () => {
+    // Reading the `ifc` inside an `allOf` means comparing the two lists, and
+    // a list that gains an entry has gained a constraint every value must now
+    // satisfy. The added conjunct is a narrowing whether or not the entry
+    // beside it carries a write authorization, so the lengths decide it before
+    // any entry is read.
+    const conjuncts = (extra: boolean): JSONSchema => ({
+      type: "object",
+      properties: {
+        label: {
+          allOf: [
+            {
+              type: "string",
+              ifc: {
+                writeAuthorizedBy: { __ctWriterIdentityOf: baselineIdentity },
+              },
+            },
+            ...(extra ? [{ maxLength: 32 }] : []),
+          ],
+        },
+      },
+    });
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        pattern(conjuncts(false), { type: "object" }),
+        pattern(conjuncts(true), { type: "object" }),
+      )
+    ).toThrow(/label: allOf changed/);
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        pattern(conjuncts(true), { type: "object" }),
+        pattern(conjuncts(false), { type: "object" }),
+      )
+    ).toThrow(/label: allOf changed/);
+  });
+
   it("still rejects a constraint change beside a nested writer claim", () => {
     // The reduction reaches the `ifc` and nothing else. A branch that narrows
     // what it accepts is still a narrowed contract, whether or not the same

--- a/packages/runner/deno.jsonc
+++ b/packages/runner/deno.jsonc
@@ -55,6 +55,7 @@
     "./executor/watermark": "./src/executor/watermark.ts",
     "./cfc/migration-reason": "./src/cfc/migration-reason.ts",
     "./cfc/schema-sanitization": "./src/cfc/schema-sanitization.ts",
-    "./cfc/schema-refs": "./src/cfc/schema-refs.ts"
+    "./cfc/schema-refs": "./src/cfc/schema-refs.ts",
+    "./schema-walk": "./src/schema-walk.ts"
   }
 }


### PR DESCRIPTION
A CFC write authorization lowers to an `ifc.writeAuthorizedBy` claim carrying the content-addressed hash of the authoring module. That hash rehashes on any edit to the module, so the piece compatibility gate normalizes it out before comparing two `ifc` extensions, along with the resolver-dependent `file` spelling and the derived per-value label keys. Without that normalization, editing a module that authorizes a write would read as a contract change and freeze the pattern.

The normalization only reached an `ifc` the per-node recursion compared as a semantic-extension key: one written on a property, one behind a `$defs` reference, one in an `anyOf` branch. The subset proof cannot take apart `allOf`, `oneOf`, `if`/`then`, or `not`, so it decides those by asking whether the two sides say the same thing, and that question was asked of the values as they stand. A claim under one of them was therefore held to its module hash, and a recompile was reported as "allOf changed in a way compatibility checking cannot prove safe".

Nothing produces such a schema here today. The generator emits neither `allOf` nor `oneOf` at all: an intersection merges into a single object schema, a union emits `anyOf`, and a conditional type emits `{}`. A scan of all 434 pattern baselines finds no claim under a composite keyword. But the gate does not only see generated schemas — one can be written into a space by anything — and `validateSchemaDefinition` admits every one of those keywords, so a claim can arrive under one and has to be read the same way there.

Compare schemas with a walk that reads every `ifc` it meets through the same reduction, so where the claim sits stops mattering. Two schemas that are equal as they stand still settle on the first comparison, so the walk runs only where a difference has already been found.

Comparing in place is the point. A `default` holding a fabric value is compared by content hash, the way `valueEqual` compares it, because the walk never takes such a value apart and rebuilds it. The runner's `stripWriterIdentityStamp` normalizes the same claim by cloning, and its rebuild of a record node turns a fabric-valued `default` into `{}`; nothing here does that.

The walk descends the keywords that hold nested schemas, and takes that vocabulary from `packages/runner/src/schema-walk.ts`, which states that it is the single source of truth for it and says why: several hand-rolled walkers had each re-encoded the list and silently skipped `prefixItems`. `collectSchemaReferences` had a copy of its own, which now reads the same sets; `schema-walk` gains an export entry for the purpose. Both of its tiers are taken, the keywords the generator emits and the ones it does not, which adds `unevaluatedProperties` and `unevaluatedItems`. `definitions`, the pre-2019 spelling of `$defs`, is added on top: `schema-walk` leaves it out because nothing here writes it, while `ANNOTATION_KEYS` classifies it and `resolveCfcSchemaRefs` resolves through it.

That vocabulary also closes a way the gate could accept a narrowing. A node comparison ends by checking every keyword no earlier rule named, and it checked them by whole-value equality. Such a keyword can hold a `$ref`, and two identical reference strings say the same thing only while the definitions they name do, so a contract could move a definition from `string` to `number` and the gate would read the two unchanged reference strings as an unchanged constraint. Nothing further down looked at the definition, because the constraints that do resolve references are the ones with subset rules. A keyword the walk knows holds schemas is now compared through `schemasResolveEqually`, which resolves each reference against its own contract's root. A keyword that holds no schema keeps exact equality, references and all: a record carrying a `$ref` key as ordinary data is data.

Runtime enforcement is untouched. `writeAuthorizedByReason` still re-verifies the live writer's `moduleIdentity` against the claim at write time, and the binding `path` and the whole `uiContract` are still compared here.

`assertSchemaSubset` reaches the same comparison, and puts the reduction to a different question: it proves a durable link between two separate pieces rather than two versions of one contract, so a differing `moduleIdentity` there names a different authoring module rather than a recompile. Its doc comment now records that, and what carries the reduction either way — the runtime authorizes a write against the claim on the location being written, which proving a link neither performs nor stands in for.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7006?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

