### PR TITLE
fix(runner): a CFC enforcement mode off the ladder is refused

### DIFF
--- a/docs/specs/cfc-enforcement-matrix.md
+++ b/docs/specs/cfc-enforcement-matrix.md
@@ -67,6 +67,20 @@ conforming, and the conforming ones are reachable only along a partial order.
   future checks that want a persist-and-flag grace under explicit put their
   reject here, same shape.
 
+The ladder is closed, and both places a mode is installed refuse a name off it
+rather than land on no rung. `resolveCfcDials`
+([posture-report.ts](../../packages/runner/src/cfc/posture-report.ts)) is where
+every `Runtime` resolves its dials, and it throws when `cfcEnforcementMode` is
+stated and is not one of the four names above; `setCfcEnforcementMode`
+([extended-storage-transaction.ts](../../packages/runner/src/storage/extended-storage-transaction.ts))
+throws the same way for the mid-transaction lever, which is on the public
+transaction interface and so reachable from pattern code. A transaction holding
+any other name would be on no rung: `cfcEnforcementStrictness` has no answer for
+such a name and returns `undefined`, so every floor comparison against it reads
+false — including the audit-S3 anti-downgrade floor, which therefore never
+rises — while the commit gate, which asks only whether the name is one of
+`disabled` and `observe`, reads the same name as enforcing.
+
 ## 2. Rollout ordering (the partial order)
 
 Two hard ordering constraints (SC-13), plus one that D3 adds and one that H5

--- a/packages/runner/src/cfc/posture-report.ts
+++ b/packages/runner/src/cfc/posture-report.ts
@@ -52,6 +52,7 @@ import {
   SINK_UNGATED_RATIONALES,
   type SinkMaxConfidentiality,
 } from "./sink-inventory.ts";
+import { CFC_ENFORCEMENT_MODES, isCfcEnforcementMode } from "./types.ts";
 import type {
   CfcDeclaredMonotonicityMode,
   CfcDecomposedEnvelopes,
@@ -291,16 +292,6 @@ export interface ResolvedCfcDials {
 }
 
 /**
- * The dial values a runtime constructed with `options` runs at.
- *
- * The `Runtime` constructor resolves its own fields through this, so a host
- * that has not built its runtime yet — a console printing its posture at
- * startup, a harness recording the posture a lazily-built session will run
- * at — projects the same values rather than restating the default table in
- * its own words. One table: a default moved here moves everywhere at once,
- * and a host cannot fall behind it silently.
- */
-/**
  * What each dial resolves to when a construction leaves it unset.
  *
  * The Runtime's defaults, in one place, rather than eight `??` arms inside a
@@ -328,27 +319,49 @@ export const RUNTIME_CFC_DIAL_DEFAULTS: ResolvedCfcDials = Object.freeze({
  * at — projects the same values rather than restating the default table in
  * its own words. One table: a default moved here moves everywhere at once,
  * and a host cannot fall behind it silently.
+ *
+ * `cfcEnforcementMode` is a closed set. A stated one must be a member of
+ * `CFC_ENFORCEMENT_MODES`; any other name is refused rather than resolved, so
+ * no runtime holds a mode `cfcEnforcementStrictness` cannot rank. The type
+ * says this too, and the check is what holds it for a name that reached the
+ * options as plain data — a worker's initialization message crosses
+ * `postMessage` untyped.
+ *
+ * @throws Error when `options.cfcEnforcementMode` is stated and is not a
+ * member of `CFC_ENFORCEMENT_MODES`.
  */
 export const resolveCfcDials = (
   options: CfcDialOptions,
-): ResolvedCfcDials => ({
-  cfcEnforcementMode: options.cfcEnforcementMode ??
-    RUNTIME_CFC_DIAL_DEFAULTS.cfcEnforcementMode,
-  cfcFlowLabels: options.cfcFlowLabels ??
-    RUNTIME_CFC_DIAL_DEFAULTS.cfcFlowLabels,
-  cfcWriteFloor: options.cfcWriteFloor ??
-    RUNTIME_CFC_DIAL_DEFAULTS.cfcWriteFloor,
-  cfcTriggerReadGating: options.cfcTriggerReadGating ??
-    RUNTIME_CFC_DIAL_DEFAULTS.cfcTriggerReadGating,
-  cfcDecomposedEnvelopes: options.cfcDecomposedEnvelopes ??
-    RUNTIME_CFC_DIAL_DEFAULTS.cfcDecomposedEnvelopes,
-  cfcPolicyEvaluation: options.cfcPolicyEvaluation ??
-    RUNTIME_CFC_DIAL_DEFAULTS.cfcPolicyEvaluation,
-  cfcLabelMetadataProtection: options.cfcLabelMetadataProtection ??
-    RUNTIME_CFC_DIAL_DEFAULTS.cfcLabelMetadataProtection,
-  cfcDeclaredMonotonicity: options.cfcDeclaredMonotonicity ??
-    RUNTIME_CFC_DIAL_DEFAULTS.cfcDeclaredMonotonicity,
-});
+): ResolvedCfcDials => {
+  if (
+    options.cfcEnforcementMode !== undefined &&
+    !isCfcEnforcementMode(options.cfcEnforcementMode)
+  ) {
+    throw new Error(
+      `Runtime \`cfcEnforcementMode\` is ` +
+        `${String(options.cfcEnforcementMode)}, not one of ` +
+        CFC_ENFORCEMENT_MODES.join(", "),
+    );
+  }
+  return {
+    cfcEnforcementMode: options.cfcEnforcementMode ??
+      RUNTIME_CFC_DIAL_DEFAULTS.cfcEnforcementMode,
+    cfcFlowLabels: options.cfcFlowLabels ??
+      RUNTIME_CFC_DIAL_DEFAULTS.cfcFlowLabels,
+    cfcWriteFloor: options.cfcWriteFloor ??
+      RUNTIME_CFC_DIAL_DEFAULTS.cfcWriteFloor,
+    cfcTriggerReadGating: options.cfcTriggerReadGating ??
+      RUNTIME_CFC_DIAL_DEFAULTS.cfcTriggerReadGating,
+    cfcDecomposedEnvelopes: options.cfcDecomposedEnvelopes ??
+      RUNTIME_CFC_DIAL_DEFAULTS.cfcDecomposedEnvelopes,
+    cfcPolicyEvaluation: options.cfcPolicyEvaluation ??
+      RUNTIME_CFC_DIAL_DEFAULTS.cfcPolicyEvaluation,
+    cfcLabelMetadataProtection: options.cfcLabelMetadataProtection ??
+      RUNTIME_CFC_DIAL_DEFAULTS.cfcLabelMetadataProtection,
+    cfcDeclaredMonotonicity: options.cfcDeclaredMonotonicity ??
+      RUNTIME_CFC_DIAL_DEFAULTS.cfcDeclaredMonotonicity,
+  };
+};
 
 /** The values of a record, whichever way its provenance was arrived at. */
 const buildReport = (

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -54,6 +54,7 @@ import type { CellScope } from "../builder/types.ts";
 import {
   type AttemptedWrite,
   canonicalizeLogicalPath,
+  CFC_ENFORCEMENT_MODES,
   CFC_ENFORCING_STRICTNESS,
   CFC_GRANT_ID_PREFIX,
   type CfcAddress,
@@ -91,6 +92,7 @@ import {
   flowReadExcluded,
   gatedSinkRequestExists,
   type ImplementationIdentity,
+  isCfcEnforcementMode,
   type OrderedWriteAttempt,
   type PolicySnapshot,
   type PostCommitSideEffect,
@@ -648,6 +650,17 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
   }
 
   setCfcEnforcementMode(mode: CfcEnforcementMode): void {
+    // The floor below is a comparison of ranks, and `cfcEnforcementStrictness`
+    // ranks the members of `CFC_ENFORCEMENT_MODES` and nothing else. A name it
+    // cannot rank is refused here, so the comparison always has two ranks to
+    // compare. The surface is public and cell.tx is reachable, so the argument
+    // arrives from code the type checker may never have seen.
+    if (!isCfcEnforcementMode(mode)) {
+      throw new Error(
+        `CFC enforcement mode ${String(mode)} is not one of ` +
+          CFC_ENFORCEMENT_MODES.join(", "),
+      );
+    }
     // Enforcement may be raised but never weakened below the highest enforcing
     // level set on this transaction (audit S3). The control surface is on the
     // public transaction interface and cell.tx is reachable, so this prevents

--- a/packages/runner/test/cfc-posture-report.test.ts
+++ b/packages/runner/test/cfc-posture-report.test.ts
@@ -15,10 +15,13 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
 import {
+  CFC_ENFORCEMENT_MODES,
+  type CfcEnforcementMode,
   cfcPostureReport,
   inheritedCfcPostureReport,
   KNOWN_SINKS,
   projectedCfcPostureReport,
+  resolveCfcDials,
   RUNTIME_CFC_DIAL_DEFAULTS,
 } from "../src/cfc/mod.ts";
 import type { RuntimeOptions } from "../src/runtime.ts";
@@ -135,6 +138,59 @@ describe("the CFC posture record", () => {
           what.includes("`llm`") || what.includes("`llmDialog`")
         ),
       ).toEqual([]);
+    });
+  });
+
+  describe("the enforcement-mode ladder", () => {
+    const offLadder = "enforce-strictly" as CfcEnforcementMode;
+
+    it("refuses a name off the ladder, naming it and the ladder", () => {
+      const refusal = expect(() =>
+        resolveCfcDials({ cfcEnforcementMode: offLadder })
+      );
+      refusal.toThrow(offLadder);
+      refusal.toThrow(CFC_ENFORCEMENT_MODES.join(", "));
+    });
+
+    it("resolves every name on the ladder", () => {
+      for (const mode of CFC_ENFORCEMENT_MODES) {
+        expect(resolveCfcDials({ cfcEnforcementMode: mode }))
+          .toMatchObject({ cfcEnforcementMode: mode });
+      }
+    });
+
+    it("defaults a construction that names no mode", () => {
+      expect(resolveCfcDials({}).cfcEnforcementMode).toBe(
+        RUNTIME_CFC_DIAL_DEFAULTS.cfcEnforcementMode,
+      );
+    });
+
+    it("refuses a null, which names no member of the ladder", () => {
+      expect(() =>
+        resolveCfcDials({ cfcEnforcementMode: null as unknown as undefined })
+      ).toThrow(CFC_ENFORCEMENT_MODES.join(", "));
+    });
+
+    it("refuses to construct a Runtime on a name off the ladder", async () => {
+      const storageManager = StorageManager.emulate({ as: signer });
+      try {
+        expect(() =>
+          new Runtime({
+            apiUrl: new URL(import.meta.url),
+            storageManager,
+            cfcEnforcementMode: offLadder,
+          })
+        ).toThrow(offLadder);
+      } finally {
+        await storageManager.close();
+      }
+    });
+
+    it("refuses to project a posture on a name off the ladder", () => {
+      // A posture record is published before its runtime exists, so a
+      // projection that answered here would announce a rung nothing runs at.
+      expect(() => projectedCfcPostureReport({ cfcEnforcementMode: offLadder }))
+        .toThrow(offLadder);
     });
   });
 

--- a/packages/runner/test/cfc-tx-control-guard.test.ts
+++ b/packages/runner/test/cfc-tx-control-guard.test.ts
@@ -4,6 +4,10 @@ import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import { Runtime } from "../src/runtime.ts";
 import type { JSONSchema } from "../src/builder/types.ts";
+import {
+  CFC_ENFORCEMENT_MODES,
+  type CfcEnforcementMode,
+} from "../src/cfc/mod.ts";
 
 const signer = await Identity.fromPassphrase("runner-cfc-tx-control-guard");
 
@@ -41,6 +45,29 @@ describe("CFC transaction control guard", () => {
 
       // ...and cannot then be lowered back to a weaker enforcing level.
       expect(() => tx.setCfcEnforcementMode("enforce-explicit")).toThrow();
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("refuses a mode that is not on the ladder", async () => {
+    // A name the strictness ranking cannot rank passes the floor comparison
+    // whatever the floor is, so the anti-downgrade pin would not hold against
+    // it.
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "enforce-strict",
+    });
+    try {
+      const tx = runtime.edit();
+      const offLadder = "enforce-strictly" as CfcEnforcementMode;
+      expect(() => tx.setCfcEnforcementMode(offLadder)).toThrow(
+        CFC_ENFORCEMENT_MODES.join(", "),
+      );
+      expect(tx.getCfcState().enforcementMode).toBe("enforce-strict");
     } finally {
       await runtime.dispose();
       await storageManager.close();

--- a/packages/runtime-client/test/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/test/backends/runtime-processor.test.ts
@@ -46,6 +46,7 @@ import {
 } from "@commonfabric/runner";
 import {
   atomsOutsideCeiling,
+  CFC_ENFORCEMENT_MODES,
   cfcLabelViewForCell,
   linkCfcLabelView,
   setLinkCfcLabelView,
@@ -5084,6 +5085,34 @@ describe("runtime-processor", () => {
       expect(options.patternEnvironment?.apiUrl.href).toBe(
         "http://worker.test/",
       );
+    });
+
+    it("refuses to build the worker runtime on a mode off the ladder", async () => {
+      // The host states this dial in a message, so the name arrives as plain
+      // data and the protocol type says nothing about what came over.
+      const storageManager = StorageManager.emulate({ as: cfcSigner });
+      try {
+        expect(() =>
+          new Runtime(runtimePresets.browserWorker(
+            browserWorkerParamsFromInitializationData(
+              {
+                apiUrl: "http://worker.test/",
+                identity: {} as never,
+                spaceDid: "did:key:space",
+                cfcEnforcementMode: "enforce-strictly",
+              } as unknown as Parameters<
+                typeof browserWorkerParamsFromInitializationData
+              >[0],
+              storageManager,
+              { marker() {} } as unknown as Parameters<
+                typeof browserWorkerParamsFromInitializationData
+              >[2],
+            ),
+          ))
+        ).toThrow(CFC_ENFORCEMENT_MODES.join(", "));
+      } finally {
+        await storageManager.close();
+      }
     });
 
     it("falls back to the shared CFC pin when the host sends no dial", () => {


### PR DESCRIPTION
The four names of the CFC enforcement ladder are a closed set, and neither place a mode is installed checked a name against it. A runtime or a transaction holding any other name is on no rung, because the parts of the runtime that read the mode disagree about what it means.

`cfcEnforcementStrictness` is a switch over the four names with no default clause, so it returns `undefined` for anything else, and `undefined` compares false against every rank. The commit gate in `extended-storage-transaction.ts` asks only whether the mode is one of `disabled` and `observe`, so it reads the same name as enforcing. One part of the runtime therefore treats such a name as enforcing while another treats it as meeting no floor.

Two funnels install a mode, and both now refuse a name off the ladder, using the `isCfcEnforcementMode` guard and the `CFC_ENFORCEMENT_MODES` list that already exist in `cfc/types.ts`.

`resolveCfcDials` is the first. Every `Runtime` in the tree resolves its dials there, so one check covers the browser worker, the shell, the pattern-test workers and the harness rather than each of them repeating it. `projectedCfcPostureReport` resolves through the same function, so a surface that publishes a posture before its runtime exists cannot announce a rung the construction is going to refuse. The type restricts the name at compile time, which is no help at the boundary that matters: the shell states the worker runtime's dial in its initialization message, and `runtime-processor.ts` took that value across the worker boundary and passed it into the runtime options unchecked.

`setCfcEnforcementMode` is the second, and the hole there is worse. The mid-transaction lever carries an anti-downgrade control (audit S3): a mode may be raised but never lowered below the highest enforcing rank set on the transaction, because the surface is on the public transaction interface and `cell.tx` is reachable, so pattern code holding a `Cell` must not be able to disable enforcement mid-transaction and commit a policy violation. That control is a comparison of ranks, so it did not hold against a name the ranking cannot rank. A transaction pinned at `enforce-strict` refused `disabled` and accepted `enforce-strictly`: the weakening check did not fire, the floor was never raised, and the transaction's mode became that name. From there the writer-fit check read it as not strict, so the strict-only fail-closed rejects degraded to diagnostics, while the commit gate read it as enforcing. Pattern code reaches this, because `dev.ts` compiles with `noCheck` unless the caller asks for checking, so the argument arrives from source the type checker never saw. The ladder check runs before the floor comparison, so that comparison always has two ranks to compare.

Both throw rather than falling back to a default. There is no rung to put the runtime on, and a quiet fall back would turn a misspelled `enforce-strict` into a weaker posture nobody asked for. The `Runtime` constructor already runs its configuration checks inside a `try` that releases the process-global server-execution enabler and rethrows, so a refusal there leaves nothing claimed. A `null` is refused rather than read as unset: the option type has no `null` member, and the two boundary checks already in the tree, in the run manifest and in the multi-user test worker's `init`, read the same way.

Two decisions about what did not change:

The `init` parse in the multi-user test worker stays. Deleting it would replace a check with an unchecked cast of `args.cfcEnforcementMode`, which is the shape of the problem rather than the fix. It also reads the name before the handler derives an identity, opens a session and opens the storage cache, so a mistyped mode is reported without any of that work and without a server or a space; its test relies on exactly that.

`parseCfcEnforcementMode` in cf-harness still returns `undefined` for an unrecognized value. Its only caller that can be handed an unvetted string is the harness CLI, which already distinguishes "the operator named a mode" from "the operator named nothing" and reports an unrecognized name along with the ladder. Every other caller passes a value the types already restrict to the ladder: a run manifest's `cfc.enforcementMode` is rejected by `normalizeLoomRunManifest` before it gets there. Making the parse throw would fire nowhere and would split it from `parseHarnessGatewayAuthMode`, which has the same shape beside it.

The enforcement matrix records that the ladder is closed, since it is the document that lists the four rungs and says what each one means.

Tests cover the shell path as well as the runner unit path, since the shell path is the unguarded one in the product: a `Runtime` built the way `runtime-processor.ts` builds the browser worker's, from an `InitializationData` carrying a name off the ladder, is refused. Without the change that construction succeeds and the runtime runs on no rung.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7007?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

