### PR TITLE
test: justify or drop every CFC posture pin in the test tree

### DIFF
--- a/packages/background-piece-service/test/service-modules.test.ts
+++ b/packages/background-piece-service/test/service-modules.test.ts
@@ -217,17 +217,6 @@ function fakeRuntime(piecesCell: FakePiecesCell) {
   };
 }
 
-function createUncachedCompileRuntime(url: string, identity: Identity) {
-  return new Runtime({
-    apiUrl: new URL(url),
-    storageManager: StorageManager.open({
-      as: identity,
-      memoryHost: new URL(url),
-    }),
-    cfcEnforcementMode: "disabled",
-  });
-}
-
 class MockWorker extends EventTarget {
   static instances: MockWorker[] = [];
   static sendReady = true;
@@ -1433,11 +1422,16 @@ describe("cast admin entry point", () => {
 
   it("compiles the actual admin pattern source", async () => {
     const identity = await Identity.generate({ implementation: "noble" });
-    const runtime = createUncachedCompileRuntime(
-      TEST_API_URL,
-      identity,
-    );
+    // A compile writes its content-addressed cache back through a transaction.
+    // The emulated memory server answers that write.
+    let storageManager: ReturnType<typeof StorageManager.emulate> | undefined;
+    let runtime: Runtime | undefined;
     try {
+      storageManager = StorageManager.emulate({ as: identity });
+      runtime = new Runtime({
+        apiUrl: new URL(TEST_API_URL),
+        storageManager,
+      });
       const source = await Deno.readTextFile(
         new URL("../bgAdmin.tsx", import.meta.url),
       );
@@ -1449,7 +1443,9 @@ describe("cast admin entry point", () => {
         );
       assert(pattern);
     } finally {
-      await runtime.dispose();
+      // `dispose()` closes the storage manager it owns.
+      if (runtime !== undefined) await runtime.dispose();
+      else await storageManager?.close();
     }
   });
 

--- a/packages/background-piece-service/test/set-bg-piece.test.ts
+++ b/packages/background-piece-service/test/set-bg-piece.test.ts
@@ -32,7 +32,6 @@ describe("setBGPiece() registration is an upsert", () => {
     runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "disabled",
     });
     // A distinct cause per test, so one test's registrations cannot be read by
     // the next.

--- a/packages/cf-harness/audit/test/deployment.test.ts
+++ b/packages/cf-harness/audit/test/deployment.test.ts
@@ -15,9 +15,13 @@ import { join } from "@std/path";
 import {
   cfcPostureReport,
   inheritedCfcPostureReport,
+  resolveCfcDials,
   RUNTIME_CFC_DIAL_DEFAULTS,
 } from "@commonfabric/runner/cfc";
-import { MAX_ENFORCEMENT_SINK_CEILINGS } from "@commonfabric/runner";
+import {
+  MAX_ENFORCEMENT_CFC_OPTIONS,
+  MAX_ENFORCEMENT_SINK_CEILINGS,
+} from "@commonfabric/runner";
 
 import { harnessFabricSessionPosture } from "../../src/cfc-posture.ts";
 import type { HarnessRunState } from "../../src/run-state.ts";
@@ -41,17 +45,12 @@ const MAX_ENFORCEMENT_RECORD = harnessFabricSessionPosture({
  * The same posture as a deployment publishes it: read off resolved runtime
  * fields rather than projected. Built through the resolved constructor rather
  * than by restamping a projection, so the suite never demonstrates the one
- * move the provenance field exists to prevent.
+ * move the provenance field exists to prevent. The dials come from the
+ * max-enforcement bundle, resolved the way a runtime resolves them, so this
+ * record carries the values a max-enforcement deployment runs at.
  */
 const ATTESTED_MAX_ENFORCEMENT_RECORD = cfcPostureReport({
-  cfcEnforcementMode: "enforce-explicit",
-  cfcFlowLabels: "persist",
-  cfcWriteFloor: "enforce",
-  cfcTriggerReadGating: true,
-  cfcDecomposedEnvelopes: false,
-  cfcPolicyEvaluation: "enforce",
-  cfcLabelMetadataProtection: "enforce",
-  cfcDeclaredMonotonicity: "enforce",
+  ...resolveCfcDials(MAX_ENFORCEMENT_CFC_OPTIONS),
   cfcPolicySnapshot: undefined,
   cfcSinkMaxConfidentiality: MAX_ENFORCEMENT_SINK_CEILINGS,
 });

--- a/packages/cf-harness/audit/test/structural.test.ts
+++ b/packages/cf-harness/audit/test/structural.test.ts
@@ -49,6 +49,11 @@ const absent = <T>(): ArtifactState<T> => ({
   path: "built",
 });
 
+/**
+ * A run's recorded state. Its enforcement mode is the one every artifact
+ * builder below records too, and AUD-1 reads that agreement across the family.
+ * A case whose subject is a rung overrides the mode on the artifacts it names.
+ */
 const runState = (
   overrides: Partial<HarnessRunState> = {},
 ): HarnessRunState => ({
@@ -79,6 +84,10 @@ const activity = (
   ...overrides,
 });
 
+/**
+ * One recorded policy decision. Its reason code names the same mode the record
+ * claims, and AUD-2 reads that pairing.
+ */
 const decision = (
   overrides: Partial<HarnessPolicyDecisionRecord> & { toolCallId: string },
 ): HarnessPolicyDecisionRecord => ({

--- a/packages/cf-harness/integration/pattern-index-live.integration.test.ts
+++ b/packages/cf-harness/integration/pattern-index-live.integration.test.ts
@@ -267,7 +267,6 @@ describe("pattern index, live", () => {
     new CfHarnessEngine({
       sandboxRuntime: new FakeSandboxRuntime(),
       runId: `pattern-index-live-${crypto.randomUUID()}`,
-      cfcEnforcementMode: "disabled",
       fabricSessionFactory: () => Promise.resolve({ pieces }),
       patternIndexClientFactory: () => Promise.resolve(client),
     });

--- a/packages/cf-harness/test/acquire-skill.test.ts
+++ b/packages/cf-harness/test/acquire-skill.test.ts
@@ -153,8 +153,6 @@ const withFabric = async (
   const runtime = new Runtime({
     apiUrl: new URL("http://toolshed.test"),
     storageManager,
-    cfcEnforcementMode: "disabled",
-    cfcFlowLabels: "off",
   });
   const pieces = new PiecesController(
     await createSession({
@@ -179,7 +177,6 @@ const createEngine = (
   new CfHarnessEngine({
     sandboxRuntime: new FakeSandboxRuntime(),
     runId: `acquire-skill-${crypto.randomUUID()}`,
-    cfcEnforcementMode: "disabled",
     now: () => RECEIVED_AT,
     fabricSessionFactory: () => Promise.resolve({ pieces }),
     skillsShSearchClientFactory: () =>
@@ -322,7 +319,6 @@ describe("acquire-skill", () => {
   it("requires both external-skill configuration and a fabric session", async () => {
     const base = {
       sandboxRuntime: new FakeSandboxRuntime(),
-      cfcEnforcementMode: "disabled" as const,
     };
     const withoutEither = new CfHarnessEngine(base);
     const withoutConfig = new CfHarnessEngine({

--- a/packages/cf-harness/test/artifacts.test.ts
+++ b/packages/cf-harness/test/artifacts.test.ts
@@ -190,6 +190,8 @@ Deno.test({
           { stdout: "hello\n", stderr: "", exitCode: 0 },
         ]),
         runId: "run-artifacts",
+        // The persisted run state and the invocation context beside it are both
+        // asserted to record this rung.
         cfcEnforcementMode: "observe",
         now: (() => {
           const timestamps = [
@@ -1071,7 +1073,6 @@ Deno.test({
             source: "loom",
             credentialOwner,
           },
-          cfcEnforcementMode: "enforce-explicit",
         }),
         fetchFn: async (_input, init) => {
           const body = JSON.parse(String(init?.body)) as {
@@ -1339,6 +1340,8 @@ Deno.test({
           ]),
           runId: "run-subagent-sanitized-failure",
           model: "gpt-5.4",
+          // The child's second failure is the `tool_not_allowed` policy event
+          // this rung produces, and the run asserts a failure count of two.
           cfcEnforcementMode: "enforce-explicit",
         }),
         fetchFn: (_input, init) => {
@@ -1531,7 +1534,6 @@ Deno.test({
         artifactRoot,
         sandboxRuntime: new FakeSandboxRuntime(),
         runId: "run-prompt-slot",
-        cfcEnforcementMode: "observe",
       });
 
       engine.setPromptSlotBinding(promptSlotBinding);
@@ -1562,6 +1564,8 @@ Deno.test({
           sandboxRuntime: new FakeSandboxRuntime(),
           runId: "run-denied-report",
           model: "gpt-5.4",
+          // The write the run asks for is denied at this rung, and the persisted
+          // tool activity is asserted to record the denial and the rung.
           cfcEnforcementMode: "enforce-explicit",
           now: (() => {
             const timestamps = [
@@ -1764,6 +1768,8 @@ Deno.test({
           ]),
           runId: "run-missing-cfc-report",
           model: "gpt-5.4",
+          // Output mediation denies the sandbox result at this rung, which is the
+          // denial the run report is asserted to carry.
           cfcEnforcementMode: "enforce-explicit",
         }),
         fetchFn: (_input, init) => {

--- a/packages/cf-harness/test/assign-slug.test.ts
+++ b/packages/cf-harness/test/assign-slug.test.ts
@@ -140,7 +140,6 @@ describe("assign-slug", () => {
     return new CfHarnessEngine({
       sandboxRuntime: new FakeSandboxRuntime(),
       runId: `assign-slug-test-${crypto.randomUUID()}`,
-      cfcEnforcementMode: "disabled",
       fabricSessionFactory: () => Promise.resolve({ pieces }),
     });
   }
@@ -624,7 +623,6 @@ describe("assign-slug", () => {
       const engine = new CfHarnessEngine({
         sandboxRuntime: new FakeSandboxRuntime(),
         runId: `assign-slug-test-${crypto.randomUUID()}`,
-        cfcEnforcementMode: "disabled",
         fabricSessionFactory: () => Promise.resolve({ pieces: didPieces }),
       });
       const created = await engine.invokeBuiltinTool("run_pattern", {
@@ -735,7 +733,6 @@ describe("assign-slug", () => {
       const engine = new CfHarnessEngine({
         sandboxRuntime: new FakeSandboxRuntime(),
         runId: `assign-slug-test-${crypto.randomUUID()}`,
-        cfcEnforcementMode: "disabled",
       });
       const result = await engine.invokeBuiltinTool("assign_slug", {
         token: "/of:fid1:abc",
@@ -845,7 +842,6 @@ describe("assign-slug", () => {
       const engine = new CfHarnessEngine({
         sandboxRuntime: new FakeSandboxRuntime(),
         runId: `assign-slug-test-${crypto.randomUUID()}`,
-        cfcEnforcementMode: "disabled",
         fabricSessionFactory: () =>
           Promise.reject(new Error("authorization denied")),
       });

--- a/packages/cf-harness/test/browser.test.ts
+++ b/packages/cf-harness/test/browser.test.ts
@@ -351,7 +351,6 @@ describe("browser", () => {
       new CfHarnessEngine({
         sandboxRuntime: new FakeSandboxRuntime(),
         runId: `browser-tool-test-${crypto.randomUUID()}`,
-        cfcEnforcementMode: "disabled",
         processRunner,
         workspaceHostPath: "/tmp/cf-harness-workspace",
         browserAccess: BROWSER_LEASE,

--- a/packages/cf-harness/test/cfc-posture.test.ts
+++ b/packages/cf-harness/test/cfc-posture.test.ts
@@ -55,6 +55,7 @@ describe("cfc-posture", () => {
       const record = harnessFabricSessionPosture({
         ...SESSION,
         cfcPosture: "max-enforcement",
+        // The two rungs the assertions below read back.
         cfcEnforcementMode: "enforce-strict",
         cfcFlowLabels: "observe",
       });
@@ -92,7 +93,10 @@ describe("cfc-posture", () => {
     });
 
     it("marks a diagnostic rung as deciding nothing", () => {
-      expect(rendered(SESSION)).toContain("off (diagnostic only) — decides on");
+      // `off` is the rung the assertion reads back.
+      expect(rendered({ ...SESSION, cfcFlowLabels: "off" })).toContain(
+        "off (diagnostic only) — decides on",
+      );
     });
 
     it("prints every ungated sink with the reason it releases ungated", () => {

--- a/packages/cf-harness/test/cfc-properties/delegation.test.ts
+++ b/packages/cf-harness/test/cfc-properties/delegation.test.ts
@@ -152,7 +152,6 @@ const runDelegationEpisode = async (
       sandboxRuntime: sandbox,
       runId,
       model: "gpt-5.4",
-      cfcEnforcementMode: "enforce-explicit",
       inputCells: [
         { name: "bound", ref: boundRefInput },
         { name: "withheld", ref: withheldRefInput },

--- a/packages/cf-harness/test/cfc-properties/deny-egress.test.ts
+++ b/packages/cf-harness/test/cfc-properties/deny-egress.test.ts
@@ -77,7 +77,6 @@ const runEpisode = async (
       sandboxRuntime: new InertSandboxRuntime(),
       runId,
       model: "gpt-5.4",
-      cfcEnforcementMode: "enforce-explicit",
       // The factory supplies the emulated session; the config beside it names
       // the space, which is what the run-end cell-labels read needs to know
       // which space to ask about. Without it the run retains no record of

--- a/packages/cf-harness/test/cfc-properties/influence.test.ts
+++ b/packages/cf-harness/test/cfc-properties/influence.test.ts
@@ -52,7 +52,6 @@ const runInfluenceEpisode = async (): Promise<InfluenceEpisode> => {
     ]),
     runId,
     model: "gpt-5.4",
-    cfcEnforcementMode: "enforce-explicit",
     artifactStore: new FileSystemHarnessArtifactStore({ artifactRoot, runId }),
   });
   const loop = new CfHarnessPromptLoop({

--- a/packages/cf-harness/test/cfc-properties/support/episode.ts
+++ b/packages/cf-harness/test/cfc-properties/support/episode.ts
@@ -31,10 +31,7 @@ import { RUN_CHECKS } from "../../../audit/checks/registry.ts";
 import { auditRunFamily } from "../../../audit/checks/structural.ts";
 import { discoverRunFamilies } from "../../../audit/evidence.ts";
 import type { CheckResult, CheckVerdict } from "../../../audit/report.ts";
-import {
-  CFC_PROMPT_SLOT_BOUND_ATOM_TYPE,
-  type PromptSlotBinding,
-} from "../../../src/contracts/prompt-slot.ts";
+import { type PromptSlotBinding } from "../../../src/contracts/prompt-slot.ts";
 import type { CfcSandboxResult } from "@commonfabric/runner/cfc";
 
 import { CAPABILITY_PROBE_SENTINEL } from "../../../src/diagnostics.ts";
@@ -46,6 +43,7 @@ import type {
   SandboxShellRequest,
 } from "../../../src/sandbox/types.ts";
 import { responsesBodyFromChatFixture } from "../../support/responses-fixture.ts";
+import { directPromptSlotBindingFor } from "../../support/prompt-slot-binding.ts";
 
 const signer = await Identity.fromPassphrase("cf-harness cfc properties");
 
@@ -56,15 +54,8 @@ const signer = await Identity.fromPassphrase("cf-harness cfc properties");
  * command the enforcing modes refuse on authority instead (AH-CFC-9), and an
  * episode that stops there establishes nothing about a label.
  */
-export const directPromptSlotBinding: PromptSlotBinding = {
-  type: CFC_PROMPT_SLOT_BOUND_ATOM_TYPE,
-  source: { type: "test.prompt-slot", subject: "cfc-property" },
-  role: "direct-command",
-  kernelName: "cf-harness",
-  surface: "test",
-  subject: "cfc-property",
-  eventId: "event-cfc-property",
-};
+export const directPromptSlotBinding: PromptSlotBinding =
+  directPromptSlotBindingFor("cfc-property");
 
 /**
  * A sandbox that runs nothing.

--- a/packages/cf-harness/test/config.test.ts
+++ b/packages/cf-harness/test/config.test.ts
@@ -201,8 +201,8 @@ Deno.test("resolveCfcEnforcementMode follows a fabric session raised to strict",
     "override",
   );
 
-  // Only strict raises: the session's preset pins enforce-explicit whether
-  // asked for or not, and a weaker loop under it is an ordinary configuration.
+  // A session that states no mode of its own does not raise the harness dial,
+  // so the override stands.
   assertEquals(
     resolveCfcEnforcementMode({
       fabricSession: { ...strictSession, cfcEnforcementMode: undefined },

--- a/packages/cf-harness/test/diagnostics.test.ts
+++ b/packages/cf-harness/test/diagnostics.test.ts
@@ -727,7 +727,6 @@ Deno.test("collectHarnessCapabilitySnapshot reads the CFC transport before captu
     sandbox,
     "/workspace",
     "2026-04-30T00:00:00.000Z",
-    { cfcEnforcementMode: "enforce-explicit" },
   );
 
   // What this test pins: the reading is taken BEFORE the description is

--- a/packages/cf-harness/test/docker-runsc-sandbox.test.ts
+++ b/packages/cf-harness/test/docker-runsc-sandbox.test.ts
@@ -810,6 +810,10 @@ const dockerInfoResult = (
   exitCode: 0,
 });
 
+// An invocation context for the tests of the runsc registration probe. The
+// sandbox probes that registration only under an enforcing mode, so a bare
+// call here carries one. The test asserting that no probe runs passes
+// `observe`.
 const enforcingInvocationContext = (
   cfcEnforcementMode: "enforce-explicit" | "observe" = "enforce-explicit",
 ) =>

--- a/packages/cf-harness/test/engine.test.ts
+++ b/packages/cf-harness/test/engine.test.ts
@@ -186,6 +186,8 @@ const recordFor = (
 ) => harnessFabricSessionPosture(session);
 
 Deno.test("CfHarnessEngine records the fabric session's resolved CFC posture in run state", () => {
+  // The assertion below reads both session dials back off the run state,
+  // each marked as configured.
   const configured = new CfHarnessEngine({
     workspaceHostPath: "/host/project",
     fabricSession: {
@@ -718,7 +720,6 @@ Deno.test("CfHarnessEngine rejects direct subagent resume but permits new child 
     lineage,
     modelProvider: "openai-codex",
     credentialOwnerKey: "local",
-    cfcEnforcementMode: "disabled",
   });
   assertEquals(newChild.getRunState().lineage, lineage);
 });
@@ -819,7 +820,6 @@ Deno.test("CfHarnessEngine runs browser actions on the host with the configured 
     workspaceHostPath,
     sandboxRuntime: new FakeSandboxRuntime(),
     processRunner: runner,
-    cfcEnforcementMode: "observe",
     browserAccess: {
       type: "cf-harness.chat.browser-access-lease",
       leaseId: "lease-1",
@@ -858,7 +858,6 @@ Deno.test("CfHarnessEngine refuses browser actions when no lease is configured",
     workspaceHostPath,
     sandboxRuntime: new FakeSandboxRuntime(),
     processRunner: runner,
-    cfcEnforcementMode: "observe",
     now: () => "2026-04-29T23:20:00.000Z",
   });
 
@@ -892,7 +891,6 @@ Deno.test("CfHarnessEngine reserves artifact roots through host realpath mapping
       artifactRoot,
       sandboxRuntime: sandbox,
       processRunner: hostRunner,
-      cfcEnforcementMode: "observe",
       now: (() => {
         const timestamps = [
           "2026-05-01T17:55:00.000Z",
@@ -948,6 +946,7 @@ Deno.test("CfHarnessEngine records tool outputs into run state on success", asyn
   const engine = new CfHarnessEngine({
     sandboxRuntime: sandbox,
     runId: "run-1",
+    // The run-state assertions below read this dial back.
     cfcEnforcementMode: "observe",
     now: (() => {
       const timestamps = [
@@ -1017,7 +1016,6 @@ Deno.test("CfHarnessEngine records prompt slot binding into run state", () => {
   const engine = new CfHarnessEngine({
     sandboxRuntime: new FakeSandboxRuntime(),
     runId: "run-prompt-slot",
-    cfcEnforcementMode: "observe",
     now: (() => {
       const timestamps = [
         "2026-04-17T19:00:00.000Z",
@@ -1049,7 +1047,6 @@ Deno.test("CfHarnessEngine derives prompt-slot labels for model-authored sandbox
   const engine = new CfHarnessEngine({
     sandboxRuntime: sandbox,
     runId: "run-prompt-slot-labels",
-    cfcEnforcementMode: "observe",
     now: (() => {
       const timestamps = [
         "2026-04-17T19:05:00.000Z",
@@ -1155,7 +1152,6 @@ Deno.test("CfHarnessEngine stamps policy snapshot state changes with mutation ti
     artifactStore,
     sandboxRuntime: new FakeSandboxRuntime(),
     runId: "run-policy-time",
-    cfcEnforcementMode: "observe",
     now: (() => {
       const timestamps = [
         "2026-04-17T20:30:00.000Z",
@@ -1235,7 +1231,6 @@ Deno.test("CfHarnessEngine persists skill resource read artifacts", async () => 
     artifactStore,
     sandboxRuntime: new FakeSandboxRuntime(),
     runId: "run-skill-resource-read",
-    cfcEnforcementMode: "observe",
     now: (() => {
       const timestamps = [
         "2026-05-01T17:00:00.000Z",
@@ -1318,7 +1313,6 @@ Deno.test("CfHarnessEngine timestamps CFC invocation contexts with mutation time
       exitCode: 0,
     }]),
     runId: "run-cfc-invocation-time",
-    cfcEnforcementMode: "observe",
     now: (() => {
       const timestamps = [
         "2026-04-17T21:00:00.000Z",
@@ -1350,6 +1344,7 @@ Deno.test("CfHarnessEngine records a tool invocation error without ending the ru
   const engine = new CfHarnessEngine({
     sandboxRuntime: new FakeSandboxRuntime([], new Error("sandbox boom")),
     runId: "run-fail",
+    // The run-state assertions below read this dial back.
     cfcEnforcementMode: "observe",
     now: (() => {
       const timestamps = [
@@ -1390,7 +1385,6 @@ Deno.test("CfHarnessEngine records recoverable file-tool failures without failin
       exitCode: 10,
     }]),
     runId: "run-file-missing",
-    cfcEnforcementMode: "observe",
     now: (() => {
       const timestamps = [
         "2026-04-15T19:15:00.000Z",
@@ -1443,7 +1437,6 @@ Deno.test("CfHarnessEngine fails an interrupted run that has recorded a tool out
       { stdout: "done\n", stderr: "", exitCode: 0 },
     ]),
     runId: "run-interrupted",
-    cfcEnforcementMode: "observe",
     now: (() => {
       const timestamps = [
         "2026-04-15T19:20:00.000Z",
@@ -1679,7 +1672,6 @@ Deno.test("CfHarnessEngine records the handle table and persists run state", asy
     artifactStore,
     sandboxRuntime: new FakeSandboxRuntime(),
     runId: "run-handle-table",
-    cfcEnforcementMode: "observe",
   });
   const { table } = await mintAddressHandle(
     createHarnessHandleTable("run-handle-table"),

--- a/packages/cf-harness/test/interactive-chat-cell-labels.test.ts
+++ b/packages/cf-harness/test/interactive-chat-cell-labels.test.ts
@@ -14,7 +14,11 @@ import { normalize } from "@std/path/posix";
 import { readHarnessRunState } from "../src/artifacts.ts";
 import type { HarnessCellLabels } from "../src/contracts/cell-labels.ts";
 import { HANDLE_TOKEN_PATTERN } from "../src/contracts/handle-table.ts";
-import type { HarnessChatEventEnvelope } from "../src/contracts/interactive-chat.ts";
+import {
+  DEFAULT_HARNESS_CHAT_POLICY,
+  type HarnessChatEventEnvelope,
+  type HarnessChatPolicy,
+} from "../src/contracts/interactive-chat.ts";
 import type { HarnessTranscriptMessage } from "../src/contracts/transcript.ts";
 import { CAPABILITY_PROBE_SENTINEL } from "../src/diagnostics.ts";
 import { HarnessInteractiveChatService } from "../src/interactive-chat-service.ts";
@@ -34,6 +38,7 @@ import {
   seedSpaceDb,
   SPACE_DB_DID,
 } from "./support/space-db.ts";
+import { directPromptSlotBindingFor } from "./support/prompt-slot-binding.ts";
 
 /** A sandbox that answers the capability probe and nothing else. */
 class FakeSandboxRuntime implements SandboxRuntime {
@@ -143,6 +148,15 @@ const readCellLabels = async (runRoot: string): Promise<HarnessCellLabels> =>
     await Deno.readTextFile(join(runRoot, "cell-labels.json")),
   ) as HarnessCellLabels;
 
+/** The console binds a person's typed prompt as the turn's direct command. */
+const directPromptSlotBinding = directPromptSlotBindingFor("cell-labels");
+
+/** The default console policy, with the turn carried as a direct command. */
+const directCommandPolicy: HarnessChatPolicy = {
+  ...DEFAULT_HARNESS_CHAT_POLICY,
+  promptSlot: directPromptSlotBinding,
+};
+
 describe("interactive chat cell labels", () => {
   it("ends a turn that minted an input cell with `cell-labels.json` read from the space under its run and under its child's", async () => {
     const directory = await Deno.makeTempDir({
@@ -158,7 +172,6 @@ describe("interactive chat cell labels", () => {
           sandboxRuntime: new FakeSandboxRuntime(),
           artifactRoot,
           model: "test-model",
-          cfcEnforcementMode: "disabled",
           fabricSession: {
             apiUrl: "http://fabric.test",
             identityKeyPath: join(directory, "key.pkcs8"),
@@ -198,6 +211,7 @@ describe("interactive chat cell labels", () => {
       const turn = await service.startTurn("request-2", {
         sessionId: started.result.sessionId,
         input: { text: "Have a subagent inspect the secret." },
+        policy: directCommandPolicy,
         inputCells: [{
           name: "secret",
           ref: `/${LABELED_CELL_ID}/value/secret`,

--- a/packages/cf-harness/test/interactive-chat-service.test.ts
+++ b/packages/cf-harness/test/interactive-chat-service.test.ts
@@ -4,6 +4,7 @@ import {
   assertStringIncludes,
   assertThrows,
 } from "@std/assert";
+import { join } from "@std/path";
 import {
   createPatternSkillsFixture,
   PATTERN_SKILL_FIXTURE_RESOURCE_PATH,
@@ -19,6 +20,10 @@ import {
   type HarnessChatRequestEnvelope,
   type HarnessChatTurnRecord,
 } from "../src/contracts/interactive-chat.ts";
+import {
+  CFC_PROMPT_SLOT_BOUND_ATOM_TYPE,
+  type PromptSlotBinding,
+} from "../src/contracts/prompt-slot.ts";
 import { PATTERN_AUTHOR_SUBAGENT_SKILL_NAMES } from "../src/contracts/subagent.ts";
 import {
   HarnessInteractiveChatService,
@@ -1880,9 +1885,38 @@ Deno.test("a normalization whose write fails leaves the record on the stored his
   );
 });
 
+/**
+ * The two sidecar directories a runsc sandbox exchanges CFC invocation
+ * contexts and CFC results through. A run that mediates observations refuses
+ * to start unless both are named.
+ */
+const makeCfcTransportDirs = async (): Promise<{
+  cfcInvocationContextDir: string;
+  cfcResultDir: string;
+}> => {
+  const root = await Deno.makeTempDir();
+  const cfcInvocationContextDir = join(root, "cfc-invocation-context");
+  const cfcResultDir = join(root, "cfc-result");
+  await Deno.mkdir(cfcInvocationContextDir);
+  await Deno.mkdir(cfcResultDir);
+  return { cfcInvocationContextDir, cfcResultDir };
+};
+
+/** The console binds a person's typed prompt as the turn's direct command. */
+const directPromptSlotBinding: PromptSlotBinding = {
+  type: CFC_PROMPT_SLOT_BOUND_ATOM_TYPE,
+  source: { type: "test.prompt-slot", subject: "interactive-chat" },
+  role: "direct-command",
+  kernelName: "cf-harness",
+  surface: "test",
+  subject: "interactive-chat",
+  eventId: "event-interactive-chat",
+};
+
 Deno.test("an interactive turn scans its configured skills root into the run and a pattern-author child inherits it", async () => {
   await using fixture = await createPatternSkillsFixture();
   const skillsRoot = fixture.skillsRoot;
+  const cfcTransport = await makeCfcTransportDirs();
   const loopOptions: CreateHarnessPromptLoopOptions[] = [];
   const requestBodies: unknown[] = [];
   const service = new HarnessInteractiveChatService({
@@ -1890,7 +1924,7 @@ Deno.test("an interactive turn scans its configured skills root into the run and
       apiKey: "test-key",
       skillsRoot,
       runId: "run-interactive-skills",
-      cfcEnforcementMode: "observe",
+      ...cfcTransport,
       fetchFn: (_input, init) => {
         const body = JSON.parse(String(init?.body));
         requestBodies.push(body);
@@ -1987,6 +2021,7 @@ Deno.test("an interactive turn scans its configured skills root into the run and
         toolMode: "workspace-write",
         allowedToolIds: ["delegate_task"],
         allowedSubagentProfiles: ["pattern-author"],
+        promptSlot: directPromptSlotBinding,
       },
     },
   });
@@ -2078,7 +2113,6 @@ Deno.test("an interactive turn scans a skills root carried on an injected engine
     basePromptLoopOptions: {
       apiKey: "test-key",
       engine,
-      cfcEnforcementMode: "observe",
       fetchFn: (_input, init) =>
         Promise.resolve(
           new Response(

--- a/packages/cf-harness/test/loom-local-host-interactive.test.ts
+++ b/packages/cf-harness/test/loom-local-host-interactive.test.ts
@@ -18,6 +18,10 @@ import {
   runHarnessInteractiveChatStdio,
   type RunHarnessInteractiveChatStdioOptions,
 } from "../src/interactive-chat-stdio.ts";
+import {
+  CFC_INVOCATION_CONTEXT_DIR_ENV,
+  CFC_RESULT_DIR_ENV,
+} from "../src/sandbox/docker-runsc.ts";
 
 type InteractiveEnvelope = HarnessChatEventEnvelope | HarnessChatResponse;
 
@@ -88,7 +92,6 @@ const turnRequests = (workspace: string, artifactRoot?: string): string[] => [
         toolMode: "workspace-write",
         allowedToolIds: [],
         allowedSubagentProfiles: [],
-        cfcEnforcementMode: "disabled",
       },
     },
   }),
@@ -105,13 +108,50 @@ const turnRequests = (workspace: string, artifactRoot?: string): string[] => [
   }),
 ];
 
+/**
+ * The two sidecar directories a runsc sandbox exchanges CFC invocation
+ * contexts and CFC results through. A run that mediates observations refuses
+ * to start unless both are named.
+ */
+const makeCfcTransportDirs = async (): Promise<{
+  cfcInvocationContextDir: string;
+  cfcResultDir: string;
+}> => {
+  const root = await Deno.makeTempDir();
+  const cfcInvocationContextDir = join(root, "cfc-invocation-context");
+  const cfcResultDir = join(root, "cfc-result");
+  await Deno.mkdir(cfcInvocationContextDir);
+  await Deno.mkdir(cfcResultDir);
+  return { cfcInvocationContextDir, cfcResultDir };
+};
+
+/** Names those directories on the options an interactive stdio run carries. */
+const withCfcTransport = async (
+  options: RunHarnessInteractiveChatStdioOptions,
+): Promise<RunHarnessInteractiveChatStdioOptions> => ({
+  ...options,
+  basePromptLoopOptions: {
+    ...options.basePromptLoopOptions,
+    ...(await makeCfcTransportDirs()),
+  },
+});
+
+/** Names those directories in the environment a batch run reads them from. */
+const cfcTransportEnv = async (): Promise<Record<string, string>> => {
+  const dirs = await makeCfcTransportDirs();
+  return {
+    [CFC_INVOCATION_CONTEXT_DIR_ENV]: dirs.cfcInvocationContextDir,
+    [CFC_RESULT_DIR_ENV]: dirs.cfcResultDir,
+  };
+};
+
 const protocolRunner = (
   lines: readonly string[],
   capture: ReturnType<typeof captureOutput>,
 ) =>
-(options: RunHarnessInteractiveChatStdioOptions): Promise<void> =>
-  runHarnessInteractiveChatStdio({
-    ...options,
+async (options: RunHarnessInteractiveChatStdioOptions): Promise<void> =>
+  await runHarnessInteractiveChatStdio({
+    ...(await withCfcTransport(options)),
     input: encodeInput(lines),
     output: capture.output,
   });
@@ -239,7 +279,7 @@ Deno.test("local Loom interactive stdio reports credential loss after preflight 
     interactiveStdioRunner: async (options) => {
       await credentials.delete("local", "openai-codex");
       await runHarnessInteractiveChatStdio({
-        ...options,
+        ...(await withCfcTransport(options)),
         input: encodeInput(turnRequests(workspace)),
         output: capture.output,
       });
@@ -296,15 +336,18 @@ Deno.test("local Loom interactive artifacts bind their selected model and resume
         provider === "openai-codex" ? codexCompletion() : gatewayCompletion(),
       );
     };
-    const env = provider === "openai-codex"
-      ? {
-        CF_HARNESS_GATEWAY_BASE_URL: "https://must-not-be-used.invalid/",
-        CF_HARNESS_GATEWAY_AUTH_MODE: "none",
-      }
-      : {
-        CF_HARNESS_GATEWAY_BASE_URL: "https://gateway.example/",
-        CF_HARNESS_GATEWAY_AUTH_MODE: "none",
-      };
+    const env = {
+      ...(await cfcTransportEnv()),
+      ...(provider === "openai-codex"
+        ? {
+          CF_HARNESS_GATEWAY_BASE_URL: "https://must-not-be-used.invalid/",
+          CF_HARNESS_GATEWAY_AUTH_MODE: "none",
+        }
+        : {
+          CF_HARNESS_GATEWAY_BASE_URL: "https://gateway.example/",
+          CF_HARNESS_GATEWAY_AUTH_MODE: "none",
+        }),
+    };
     const capture = captureOutput();
     const host = await createLoomLocalCfHarnessHost({
       harnessHome: home,

--- a/packages/cf-harness/test/prompt-loop-external-skill-acquisition.test.ts
+++ b/packages/cf-harness/test/prompt-loop-external-skill-acquisition.test.ts
@@ -173,8 +173,6 @@ describe("prompt-loop external skill acquisition", () => {
     const runtime = new Runtime({
       apiUrl: new URL("http://toolshed.test"),
       storageManager,
-      cfcEnforcementMode: "disabled",
-      cfcFlowLabels: "off",
     });
     const pieces = new PiecesController(
       await createSession({
@@ -345,8 +343,6 @@ describe("prompt-loop external skill acquisition", () => {
     const runtime = new Runtime({
       apiUrl: new URL("http://toolshed.test"),
       storageManager,
-      cfcEnforcementMode: "disabled",
-      cfcFlowLabels: "off",
     });
     const pieces = new PiecesController(
       await createSession({

--- a/packages/cf-harness/test/prompt-loop-handles.test.ts
+++ b/packages/cf-harness/test/prompt-loop-handles.test.ts
@@ -439,7 +439,6 @@ describe("prompt-loop address handles", () => {
       workspaceHostPath: workspace,
       runId,
       model: "gpt-5.4",
-      cfcEnforcementMode: "disabled",
     });
     await engine.recordHandleTable(minted.table);
     const loop = new CfHarnessPromptLoop({

--- a/packages/cf-harness/test/prompt-loop-invalid-tool-calls.test.ts
+++ b/packages/cf-harness/test/prompt-loop-invalid-tool-calls.test.ts
@@ -176,7 +176,6 @@ describe("prompt-loop invalid tool calls", () => {
         sandboxRuntime: new FakeSandboxRuntime(),
         runId: "run-invalid-empty-goal",
         model: "gpt-5.4",
-        cfcEnforcementMode: "enforce-explicit",
       }),
       allowedToolIds: ["delegate_task"],
       allowedSubagentProfiles: ["default"],
@@ -269,7 +268,6 @@ describe("prompt-loop invalid tool calls", () => {
           sandboxRuntime: new FakeSandboxRuntime(),
           runId: `run-invalid-delegate-${testCase.name}`,
           model: "gpt-5.4",
-          cfcEnforcementMode: "enforce-explicit",
         }),
         allowedToolIds: ["delegate_task"],
         allowedSubagentProfiles: ["default"],
@@ -305,7 +303,6 @@ describe("prompt-loop invalid tool calls", () => {
         sandboxRuntime: new FakeSandboxRuntime(),
         runId: "run-invalid-delegate-profile-contract",
         model: "gpt-5.4",
-        cfcEnforcementMode: "enforce-explicit",
       }),
       allowedToolIds: ["delegate_task"],
       allowedSubagentProfiles: ["pattern-author"],
@@ -354,7 +351,6 @@ describe("prompt-loop invalid tool calls", () => {
         sandboxRuntime: new FakeSandboxRuntime(),
         runId: "run-invalid-arguments-json",
         model: "gpt-5.4",
-        cfcEnforcementMode: "disabled",
       }),
       fetchFn: scriptedFetch([
         toolCallTurn("call-bad-json", "read_file", '{"path": '),
@@ -386,7 +382,6 @@ describe("prompt-loop invalid tool calls", () => {
         sandboxRuntime: new FakeSandboxRuntime(),
         runId: "run-invalid-arguments-array",
         model: "gpt-5.4",
-        cfcEnforcementMode: "disabled",
       }),
       fetchFn: scriptedFetch([
         toolCallTurn("call-array-args", "read_file", '["notes/todo.txt"]'),
@@ -410,7 +405,6 @@ describe("prompt-loop invalid tool calls", () => {
         sandboxRuntime: new FakeSandboxRuntime(),
         runId: "run-invalid-unknown-tool",
         model: "gpt-5.4",
-        cfcEnforcementMode: "disabled",
       }),
       allowedToolIds: ["read_file"],
       fetchFn: scriptedFetch([
@@ -444,7 +438,6 @@ describe("prompt-loop invalid tool calls", () => {
         sandboxRuntime: new FakeSandboxRuntime(),
         runId: "run-invalid-inert-text",
         model: "gpt-5.4",
-        cfcEnforcementMode: "enforce-explicit",
       }),
       allowedToolIds: ["delegate_task"],
       allowedSubagentProfiles: ["default"],
@@ -486,7 +479,6 @@ describe("prompt-loop invalid tool calls", () => {
         sandboxRuntime: new FakeSandboxRuntime(),
         runId: "run-invalid-child-identifiers",
         model: "gpt-5.4",
-        cfcEnforcementMode: "disabled",
       }),
       allowedToolIds: ["delegate_task"],
       allowedSubagentProfiles: ["default"],
@@ -507,7 +499,10 @@ describe("prompt-loop invalid tool calls", () => {
       ], requestCount),
     });
 
-    const result = await loop.runPrompt({ prompt: "Delegate the work." });
+    const result = await loop.runPrompt({
+      prompt: "Delegate the work.",
+      promptSlotBinding: directPromptSlotBinding,
+    });
 
     const delegateOutput = result.transcript
       .filter((message) => message.role === "tool")
@@ -530,7 +525,6 @@ describe("prompt-loop invalid tool calls", () => {
         sandboxRuntime: new FakeSandboxRuntime(),
         runId: "run-invalid-recorded",
         model: "gpt-5.4",
-        cfcEnforcementMode: "enforce-explicit",
       }),
       allowedToolIds: ["delegate_task"],
       allowedSubagentProfiles: ["default"],
@@ -579,7 +573,6 @@ describe("prompt-loop invalid tool calls", () => {
         sandboxRuntime: new FakeSandboxRuntime(),
         runId: "run-invalid-fatal-transport",
         model: "gpt-5.4",
-        cfcEnforcementMode: "disabled",
       }),
       fetchFn: () => Promise.reject(new Error("gateway boom")),
     });

--- a/packages/cf-harness/test/prompt-loop-pattern-refs.test.ts
+++ b/packages/cf-harness/test/prompt-loop-pattern-refs.test.ts
@@ -24,10 +24,15 @@ import {
   chatViewOfRequest,
   responsesBodyFromChatFixture,
 } from "./support/responses-fixture.ts";
+import { directPromptSlotBindingFor } from "./support/prompt-slot-binding.ts";
 
 const signer = await Identity.fromPassphrase(
   "cf-harness prompt-loop pattern refs",
 );
+
+// Marks each prompt below as one a person typed. `search_patterns` and
+// `delegate_task` dispatch under that authorization.
+const directPromptSlotBinding = directPromptSlotBindingFor("pattern-refs");
 
 const SEARCH_HIT = {
   patternId: "pat-expenses",
@@ -185,7 +190,6 @@ const runDelegation = async (
     sandboxRuntime: new FakeSandboxRuntime(),
     runId: `run-pattern-refs-${crypto.randomUUID()}`,
     model: "gpt-5.4",
-    cfcEnforcementMode: "disabled",
     patternIndexClientFactory: () =>
       Promise.resolve(
         new PatternIndexClient({
@@ -203,7 +207,10 @@ const runDelegation = async (
     fetchFn,
   });
 
-  const result = await loop.runPrompt({ prompt: "Search, then delegate." });
+  const result = await loop.runPrompt({
+    prompt: "Search, then delegate.",
+    promptSlotBinding: directPromptSlotBinding,
+  });
   const delegateMessage = result.transcript.find((message) =>
     message.role === "tool" && message.toolName === "delegate_task"
   );
@@ -250,7 +257,6 @@ const runResumedDelegation = async (
     sandboxRuntime: new FakeSandboxRuntime(),
     runId: `run-pattern-refs-resume-${crypto.randomUUID()}`,
     model: "gpt-5.4",
-    cfcEnforcementMode: "disabled",
     patternIndexClientFactory: () =>
       Promise.resolve(
         new PatternIndexClient({
@@ -267,7 +273,10 @@ const runResumedDelegation = async (
     allowedSubagentProfiles: ["default"],
     fetchFn: firstFetch,
   });
-  const firstResult = await firstLoop.runPrompt({ prompt: "Search first." });
+  const firstResult = await firstLoop.runPrompt({
+    prompt: "Search first.",
+    promptSlotBinding: directPromptSlotBinding,
+  });
 
   const resumedRequests: unknown[] = [];
   const resumedTurns = [
@@ -310,6 +319,7 @@ const runResumedDelegation = async (
         : []),
       { role: "user", content: "Delegate using the earlier search." },
     ],
+    promptSlotBinding: directPromptSlotBinding,
   });
   const delegateMessage = result.transcript.findLast((message) =>
     message.role === "tool" && message.toolName === "delegate_task"

--- a/packages/cf-harness/test/prompt-loop-run-pattern.test.ts
+++ b/packages/cf-harness/test/prompt-loop-run-pattern.test.ts
@@ -34,6 +34,11 @@ import type {
 } from "../src/sandbox/types.ts";
 import { scrubBareFabricIdentifiers } from "../src/fabric-identifier-scrub.ts";
 import { responsesBodyFromChatFixture } from "./support/responses-fixture.ts";
+import { directPromptSlotBindingFor } from "./support/prompt-slot-binding.ts";
+
+// Marks each prompt below as one a person typed. `run_pattern` and
+// `assign_slug` dispatch under that authorization.
+const directPromptSlotBinding = directPromptSlotBindingFor("run-pattern");
 
 class FakeSandboxRuntime implements SandboxRuntime {
   describe(): SandboxRuntimeDescription {
@@ -231,13 +236,15 @@ describe("prompt-loop run_pattern model boundary", () => {
           sandboxRuntime: new FakeSandboxRuntime(),
           runId,
           model: "gpt-5.4",
-          cfcEnforcementMode: "disabled",
           fabricSessionFactory: () => Promise.resolve({ pieces }),
         }),
         fetchFn,
       });
 
-      const result = await loop.runPrompt({ prompt: "Run the pattern." });
+      const result = await loop.runPrompt({
+        prompt: "Run the pattern.",
+        promptSlotBinding: directPromptSlotBinding,
+      });
 
       // One handle: the result reference, carrying the shape compilation
       // already knew, so the token is checkable without reading the cell.
@@ -374,13 +381,15 @@ describe("prompt-loop run_pattern model boundary", () => {
           sandboxRuntime: new FakeSandboxRuntime(),
           runId: "run-pattern-registration",
           model: "gpt-5.4",
-          cfcEnforcementMode: "disabled",
           fabricSessionFactory: () => Promise.resolve({ pieces }),
         }),
         fetchFn,
       });
 
-      const result = await loop.runPrompt({ prompt: "Publish the pattern." });
+      const result = await loop.runPrompt({
+        prompt: "Publish the pattern.",
+        promptSlotBinding: directPromptSlotBinding,
+      });
 
       const toolMessages = result.transcript.filter(
         (message) => message.role === "tool",
@@ -447,14 +456,16 @@ describe("prompt-loop run_pattern model boundary", () => {
         sandboxRuntime: new FakeSandboxRuntime(),
         runId: "assign-slug-scrub",
         model: "gpt-5.4",
-        cfcEnforcementMode: "disabled",
         fabricSessionFactory: () =>
           Promise.reject(new Error(`authorization denied for ${did}`)),
       }),
       fetchFn,
     });
 
-    const result = await loop.runPrompt({ prompt: "Name the piece." });
+    const result = await loop.runPrompt({
+      prompt: "Name the piece.",
+      promptSlotBinding: directPromptSlotBinding,
+    });
 
     const toolMessage = result.transcript.find(
       (message) => message.role === "tool",
@@ -531,13 +542,15 @@ describe("prompt-loop run_pattern model boundary", () => {
           artifactStore,
           runId,
           model: "gpt-5.4",
-          cfcEnforcementMode: "disabled",
           fabricSessionFactory: () => Promise.resolve({ pieces }),
         }),
         fetchFn,
       });
 
-      const result = await loop.runPrompt({ prompt: "Run the pattern." });
+      const result = await loop.runPrompt({
+        prompt: "Run the pattern.",
+        promptSlotBinding: directPromptSlotBinding,
+      });
 
       const toolMessage = result.transcript.find(
         (message) => message.role === "tool",
@@ -641,13 +654,15 @@ describe("prompt-loop run_pattern model boundary", () => {
           artifactStore,
           runId,
           model: "gpt-5.4",
-          cfcEnforcementMode: "disabled",
           fabricSessionFactory: () => Promise.resolve({ pieces }),
         }),
         fetchFn,
       });
 
-      const result = await loop.runPrompt({ prompt: "Run the pattern." });
+      const result = await loop.runPrompt({
+        prompt: "Run the pattern.",
+        promptSlotBinding: directPromptSlotBinding,
+      });
 
       const contents = result.transcript
         .filter((message) => message.role === "tool")
@@ -807,13 +822,15 @@ describe("prompt-loop run_pattern model boundary", () => {
           artifactStore,
           runId,
           model: "gpt-5.4",
-          cfcEnforcementMode: "disabled",
           fabricSessionFactory: () => Promise.resolve({ pieces }),
         }),
         fetchFn,
       });
 
-      const result = await loop.runPrompt({ prompt: "Run the pattern." });
+      const result = await loop.runPrompt({
+        prompt: "Run the pattern.",
+        promptSlotBinding: directPromptSlotBinding,
+      });
 
       const sourcesIn = (
         transcript: readonly HarnessTranscriptMessage[],
@@ -946,13 +963,15 @@ describe("prompt-loop run_pattern model boundary", () => {
           artifactStore,
           runId,
           model: "gpt-5.4",
-          cfcEnforcementMode: "disabled",
           fabricSessionFactory: () => Promise.resolve({ pieces }),
         }),
         fetchFn,
       });
 
-      const result = await loop.runPrompt({ prompt: "Run the patterns." });
+      const result = await loop.runPrompt({
+        prompt: "Run the patterns.",
+        promptSlotBinding: directPromptSlotBinding,
+      });
 
       const sources = result.transcript
         .filter((message) => message.role === "assistant")
@@ -1056,13 +1075,15 @@ describe("prompt-loop run_pattern model boundary", () => {
           artifactStore,
           runId,
           model: "gpt-5.4",
-          cfcEnforcementMode: "disabled",
           fabricSessionFactory: () => Promise.resolve({ pieces }),
         }),
         fetchFn,
       });
 
-      const result = await loop.runPrompt({ prompt: "Run the patterns." });
+      const result = await loop.runPrompt({
+        prompt: "Run the patterns.",
+        promptSlotBinding: directPromptSlotBinding,
+      });
 
       const sources = result.transcript
         .filter((message) => message.role === "assistant")
@@ -1143,13 +1164,15 @@ describe("prompt-loop run_pattern model boundary", () => {
           sandboxRuntime: new FakeSandboxRuntime(),
           runId: "run-pattern-no-store",
           model: "gpt-5.4",
-          cfcEnforcementMode: "disabled",
           fabricSessionFactory: () => Promise.resolve({ pieces }),
         }),
         fetchFn,
       });
 
-      const result = await loop.runPrompt({ prompt: "Run the pattern." });
+      const result = await loop.runPrompt({
+        prompt: "Run the pattern.",
+        promptSlotBinding: directPromptSlotBinding,
+      });
 
       // Nothing holds the drafts but the transcript, so the transcript keeps
       // them: a marker here would name an artifact nobody wrote.

--- a/packages/cf-harness/test/prompt-loop-skill-handle.test.ts
+++ b/packages/cf-harness/test/prompt-loop-skill-handle.test.ts
@@ -171,7 +171,6 @@ describe("prompt-loop delegate_task skillHandle", () => {
         sandboxRuntime: new FakeSandboxRuntime(),
         runId,
         model: "gpt-5.4",
-        cfcEnforcementMode: "disabled",
         fabricSessionFactory: () => Promise.resolve({ pieces }),
       });
       await engine.recordHandleTable(minted.table);
@@ -189,7 +188,10 @@ describe("prompt-loop delegate_task skillHandle", () => {
         ], requestBodies),
       });
 
-      const result = await loop.runPrompt({ prompt: "Delegate the plan." });
+      const result = await loop.runPrompt({
+        prompt: "Delegate the plan.",
+        promptSlotBinding: directPromptSlotBinding,
+      });
 
       expect(result.finalAssistantText).toBe(
         "Parent received the child summary.",
@@ -231,7 +233,6 @@ describe("prompt-loop delegate_task skillHandle", () => {
         sandboxRuntime: new FakeSandboxRuntime(),
         runId,
         model: "gpt-5.4",
-        cfcEnforcementMode: "disabled",
         fabricSessionFactory: () => Promise.resolve({ pieces }),
       });
       await engine.recordHandleTable(minted.table);
@@ -277,7 +278,6 @@ describe("prompt-loop delegate_task skillHandle", () => {
         sandboxRuntime: new FakeSandboxRuntime(),
         runId,
         model: "gpt-5.4",
-        cfcEnforcementMode: "disabled",
         fabricSessionFactory: () => Promise.resolve({ pieces }),
       });
       await engine.recordHandleTable(minted.table);
@@ -296,7 +296,10 @@ describe("prompt-loop delegate_task skillHandle", () => {
         ], requestBodies),
       });
 
-      const result = await loop.runPrompt({ prompt: "Delegate the plan." });
+      const result = await loop.runPrompt({
+        prompt: "Delegate the plan.",
+        promptSlotBinding: directPromptSlotBinding,
+      });
 
       // The payload never crosses as itself: the parent's third request (the
       // one carrying the delegate tool output) holds the scrub marker, not
@@ -323,7 +326,6 @@ describe("prompt-loop delegate_task skillHandle", () => {
         sandboxRuntime: new FakeSandboxRuntime(),
         runId,
         model: "gpt-5.4",
-        cfcEnforcementMode: "disabled",
         fabricSessionFactory: () => Promise.resolve({ pieces }),
       });
       await engine.recordHandleTable(minted.table);
@@ -348,7 +350,10 @@ describe("prompt-loop delegate_task skillHandle", () => {
         ], requestBodies),
       });
 
-      const result = await loop.runPrompt({ prompt: "Delegate the plan." });
+      const result = await loop.runPrompt({
+        prompt: "Delegate the plan.",
+        promptSlotBinding: directPromptSlotBinding,
+      });
 
       const parentText = chatViewOfRequest(requestBodies[2]).messages
         .map((message) => message.content).join("\n");
@@ -371,7 +376,6 @@ describe("prompt-loop delegate_task skillHandle", () => {
         sandboxRuntime: new FakeSandboxRuntime(),
         runId,
         model: "gpt-5.4",
-        cfcEnforcementMode: "disabled",
         fabricSessionFactory: () => Promise.resolve({ pieces }),
       });
       await engine.recordHandleTable(minted.table);
@@ -408,7 +412,10 @@ describe("prompt-loop delegate_task skillHandle", () => {
         ], requestBodies),
       });
 
-      const result = await loop.runPrompt({ prompt: "Delegate the plan." });
+      const result = await loop.runPrompt({
+        prompt: "Delegate the plan.",
+        promptSlotBinding: directPromptSlotBinding,
+      });
 
       // The decoded structured value is what the parent actually consumes.
       // A re-escaped payload sitting in a key, a value, or an array entry
@@ -482,7 +489,6 @@ describe("prompt-loop delegate_task skillHandle", () => {
         sandboxRuntime: new FakeSandboxRuntime(),
         runId,
         model: "gpt-5.4",
-        cfcEnforcementMode: "disabled",
         fabricSessionFactory: () => Promise.resolve({ pieces }),
       });
       await engine.recordHandleTable(table);
@@ -501,7 +507,10 @@ describe("prompt-loop delegate_task skillHandle", () => {
         ], requestBodies),
       });
 
-      const result = await loop.runPrompt({ prompt: "Delegate the plan." });
+      const result = await loop.runPrompt({
+        prompt: "Delegate the plan.",
+        promptSlotBinding: directPromptSlotBinding,
+      });
 
       const parentText = chatViewOfRequest(requestBodies[2]).messages
         .map((message) => message.content).join("\n");
@@ -522,7 +531,6 @@ describe("prompt-loop delegate_task skillHandle", () => {
       sandboxRuntime: new FakeSandboxRuntime(),
       runId,
       model: "gpt-5.4",
-      cfcEnforcementMode: "disabled",
     });
     const requestBodies: unknown[] = [];
     const loop = new CfHarnessPromptLoop({
@@ -537,7 +545,10 @@ describe("prompt-loop delegate_task skillHandle", () => {
       ], requestBodies),
     });
 
-    const result = await loop.runPrompt({ prompt: "Delegate the plan." });
+    const result = await loop.runPrompt({
+      prompt: "Delegate the plan.",
+      promptSlotBinding: directPromptSlotBinding,
+    });
 
     const toolMessage = result.transcript.find(
       (message) => message.role === "tool",
@@ -552,7 +563,6 @@ describe("prompt-loop delegate_task skillHandle", () => {
       sandboxRuntime: new FakeSandboxRuntime(),
       runId: "run-skill-handle-bad-shape",
       model: "gpt-5.4",
-      cfcEnforcementMode: "disabled",
     });
     const requestBodies: unknown[] = [];
     const loop = new CfHarnessPromptLoop({
@@ -567,7 +577,10 @@ describe("prompt-loop delegate_task skillHandle", () => {
       ], requestBodies),
     });
 
-    const result = await loop.runPrompt({ prompt: "Delegate the plan." });
+    const result = await loop.runPrompt({
+      prompt: "Delegate the plan.",
+      promptSlotBinding: directPromptSlotBinding,
+    });
 
     const toolMessage = result.transcript.find(
       (message) => message.role === "tool",
@@ -590,7 +603,6 @@ describe("prompt-loop delegate_task skillHandle", () => {
         sandboxRuntime: new FakeSandboxRuntime(),
         runId,
         model: "gpt-5.4",
-        cfcEnforcementMode: "disabled",
         fabricSessionFactory: () => Promise.resolve({ pieces }),
       });
       await engine.recordHandleTable(minted.table);
@@ -607,7 +619,10 @@ describe("prompt-loop delegate_task skillHandle", () => {
         ], requestBodies),
       });
 
-      const result = await loop.runPrompt({ prompt: "Delegate the plan." });
+      const result = await loop.runPrompt({
+        prompt: "Delegate the plan.",
+        promptSlotBinding: directPromptSlotBinding,
+      });
 
       const toolMessage = result.transcript.find(
         (message) => message.role === "tool",
@@ -632,7 +647,6 @@ describe("prompt-loop delegate_task skillHandle", () => {
         sandboxRuntime: new FakeSandboxRuntime(),
         runId,
         model: "gpt-5.4",
-        cfcEnforcementMode: "disabled",
         fabricSessionFactory: () => Promise.resolve({ pieces }),
       });
       await engine.recordHandleTable(minted.table);
@@ -650,7 +664,10 @@ describe("prompt-loop delegate_task skillHandle", () => {
         ], requestBodies),
       });
 
-      const result = await loop.runPrompt({ prompt: "Delegate the plan." });
+      const result = await loop.runPrompt({
+        prompt: "Delegate the plan.",
+        promptSlotBinding: directPromptSlotBinding,
+      });
 
       const toolMessage = result.transcript.find(
         (message) => message.role === "tool",
@@ -671,7 +688,6 @@ describe("prompt-loop delegate_task skillHandle", () => {
         sandboxRuntime: new FakeSandboxRuntime(),
         runId,
         model: "gpt-5.4",
-        cfcEnforcementMode: "disabled",
         fabricSessionFactory: () => Promise.resolve({ pieces }),
       });
       await engine.recordHandleTable(minted.table);
@@ -691,7 +707,10 @@ describe("prompt-loop delegate_task skillHandle", () => {
         ], requestBodies),
       });
 
-      await loop.runPrompt({ prompt: "Delegate the plan." });
+      await loop.runPrompt({
+        prompt: "Delegate the plan.",
+        promptSlotBinding: directPromptSlotBinding,
+      });
 
       const childText = chatViewOfRequest(requestBodies[1]).messages
         .map((message) => message.content).join("\n");

--- a/packages/cf-harness/test/prompt-loop-subagent-handles.test.ts
+++ b/packages/cf-harness/test/prompt-loop-subagent-handles.test.ts
@@ -37,6 +37,11 @@ import type {
   SandboxRuntimeDescription,
   SandboxShellRequest,
 } from "../src/sandbox/types.ts";
+import { directPromptSlotBindingFor } from "./support/prompt-slot-binding.ts";
+
+// Marks each prompt below as one a person typed. `delegate_task` and the
+// child's own `bash` dispatch under that authorization.
+const directPromptSlotBinding = directPromptSlotBindingFor("subagent-handles");
 
 const HASH_A = "A".repeat(43);
 const HASH_B = "B".repeat(43);
@@ -44,6 +49,30 @@ const HASH_C = "C".repeat(43);
 const URI_A = `of:fid1:${HASH_A}`;
 const URI_B = `of:fid1:${HASH_B}`;
 const URI_C = `of:fid1:${HASH_C}`;
+
+/**
+ * The mediation record a CFC sandbox attaches to a command result: each
+ * stream observed at public confidentiality, carrying the text the command
+ * produced.
+ */
+const mediated = (result: SandboxCommandResult): SandboxCommandResult => {
+  const label = { confidentiality: ["public"] };
+  const stream = (channel: "stdout" | "stderr", text: string) => ({
+    channel,
+    policy: "observed" as const,
+    label,
+    segments: [{ text, label }],
+  });
+  return {
+    ...result,
+    cfcResult: {
+      version: 1,
+      stdout: stream("stdout", result.stdout),
+      stderr: stream("stderr", result.stderr),
+      exitCode: { policy: "observed", label, value: result.exitCode },
+    },
+  };
+};
 
 class FakeSandboxRuntime implements SandboxRuntime {
   readonly shellRequests: SandboxShellRequest[] = [];
@@ -79,20 +108,24 @@ class FakeSandboxRuntime implements SandboxRuntime {
   }
 
   run(_request: SandboxCommandRequest): Promise<SandboxCommandResult> {
-    return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 });
+    return Promise.resolve(
+      mediated({ stdout: "", stderr: "", exitCode: 0 }),
+    );
   }
 
   runShell(request: SandboxShellRequest): Promise<SandboxCommandResult> {
     this.shellRequests.push(request);
     if (request.command.includes(CAPABILITY_PROBE_SENTINEL)) {
-      return Promise.resolve({
+      return Promise.resolve(mediated({
         stdout: "bash\tpresent\t/bin/bash\tGNU bash, version 5.2.26(1)-release",
         stderr: "",
         exitCode: 0,
-      });
+      }));
     }
     return Promise.resolve(
-      this.#shellResults.shift() ?? { stdout: "", stderr: "", exitCode: 0 },
+      mediated(
+        this.#shellResults.shift() ?? { stdout: "", stderr: "", exitCode: 0 },
+      ),
     );
   }
 }
@@ -209,7 +242,6 @@ describe("prompt-loop cross-agent address handles", () => {
       sandboxRuntime: sandbox,
       runId,
       model: "gpt-5.4",
-      cfcEnforcementMode: "disabled",
     });
     await engine.recordHandleTable(table);
     const loop = new CfHarnessPromptLoop({
@@ -225,7 +257,10 @@ describe("prompt-loop cross-agent address handles", () => {
       ]),
     });
 
-    await loop.runPrompt({ prompt: "Delegate the inspection." });
+    await loop.runPrompt({
+      prompt: "Delegate the inspection.",
+      promptSlotBinding: directPromptSlotBinding,
+    });
 
     const command = dispatchedCommand(sandbox, "cf cell get ");
     expect(command).toContain(`cf cell get ${table.entries[0]!.ref}`);
@@ -242,7 +277,6 @@ describe("prompt-loop cross-agent address handles", () => {
       sandboxRuntime: sandbox,
       runId,
       model: "gpt-5.4",
-      cfcEnforcementMode: "disabled",
     });
     await engine.recordHandleTable(table);
     const loop = new CfHarnessPromptLoop({
@@ -263,7 +297,10 @@ describe("prompt-loop cross-agent address handles", () => {
       ]),
     });
 
-    await loop.runPrompt({ prompt: "Delegate the inspection." });
+    await loop.runPrompt({
+      prompt: "Delegate the inspection.",
+      promptSlotBinding: directPromptSlotBinding,
+    });
 
     const command = dispatchedCommand(sandbox, "cf cell get ");
     expect(command).toContain(table.entries[0]!.ref);
@@ -280,7 +317,6 @@ describe("prompt-loop cross-agent address handles", () => {
       sandboxRuntime: sandbox,
       runId,
       model: "gpt-5.4",
-      cfcEnforcementMode: "disabled",
     });
     await engine.recordHandleTable(table);
     const loop = new CfHarnessPromptLoop({
@@ -299,7 +335,10 @@ describe("prompt-loop cross-agent address handles", () => {
       ]),
     });
 
-    await loop.runPrompt({ prompt: "Delegate the summary." });
+    await loop.runPrompt({
+      prompt: "Delegate the summary.",
+      promptSlotBinding: directPromptSlotBinding,
+    });
 
     // A token the child guessed at names nothing in the child, so it reaches
     // the sandbox as the inert text it is rather than as an address.
@@ -316,7 +355,6 @@ describe("prompt-loop cross-agent address handles", () => {
       sandboxRuntime: new FakeSandboxRuntime(),
       runId,
       model: "gpt-5.4",
-      cfcEnforcementMode: "disabled",
     });
     await engine.recordHandleTable(table);
     const requestBodies: unknown[] = [];
@@ -333,7 +371,10 @@ describe("prompt-loop cross-agent address handles", () => {
       ], requestBodies),
     });
 
-    await loop.runPrompt({ prompt: "Delegate the summary." });
+    await loop.runPrompt({
+      prompt: "Delegate the summary.",
+      promptSlotBinding: directPromptSlotBinding,
+    });
 
     const childMessages = chatViewOfRequest(requestBodies[1]).messages
       .map((message) => message.content ?? "")
@@ -388,12 +429,14 @@ describe("prompt-loop cross-agent address handles", () => {
         sandboxRuntime: sandbox,
         runId,
         model: "gpt-5.4",
-        cfcEnforcementMode: "disabled",
       }),
       fetchFn,
     });
 
-    const result = await loop.runPrompt({ prompt: "Delegate the lookup." });
+    const result = await loop.runPrompt({
+      prompt: "Delegate the lookup.",
+      promptSlotBinding: directPromptSlotBinding,
+    });
 
     const delegateOutput = chatViewOfRequest(requestBodies[3]).messages
       .filter((message) => message.role === "tool")
@@ -454,12 +497,14 @@ describe("prompt-loop cross-agent address handles", () => {
         sandboxRuntime: sandbox,
         runId,
         model: "gpt-5.4",
-        cfcEnforcementMode: "disabled",
       }),
       fetchFn,
     });
 
-    const result = await loop.runPrompt({ prompt: "Delegate the lookup." });
+    const result = await loop.runPrompt({
+      prompt: "Delegate the lookup.",
+      promptSlotBinding: directPromptSlotBinding,
+    });
 
     // The child's token resolves to its reference in the same scan that
     // scrubs the unresolvable ones, so the path segment inside that
@@ -486,7 +531,6 @@ describe("prompt-loop cross-agent address handles", () => {
       sandboxRuntime: sandbox,
       runId,
       model: "gpt-5.4",
-      cfcEnforcementMode: "disabled",
     });
     await engine.recordHandleTable(table);
     const requestBodies: unknown[] = [];
@@ -525,7 +569,10 @@ describe("prompt-loop cross-agent address handles", () => {
       fetchFn,
     });
 
-    await loop.runPrompt({ prompt: "Delegate the inspection." });
+    await loop.runPrompt({
+      prompt: "Delegate the inspection.",
+      promptSlotBinding: directPromptSlotBinding,
+    });
 
     const delegateOutput = chatViewOfRequest(requestBodies[2]).messages
       .filter((message) => message.role === "tool")
@@ -546,7 +593,6 @@ describe("prompt-loop cross-agent address handles", () => {
         sandboxRuntime: new FakeSandboxRuntime(),
         runId: "run-subagent-handles-no-session",
         model: "gpt-5.4",
-        cfcEnforcementMode: "disabled",
       }),
       fetchFn: scriptedFetch([
         delegateCallTurn("call-delegate", { goal: "Do the task." }),
@@ -555,7 +601,10 @@ describe("prompt-loop cross-agent address handles", () => {
       ], requestBodies),
     });
 
-    const result = await loop.runPrompt({ prompt: "Delegate the task." });
+    const result = await loop.runPrompt({
+      prompt: "Delegate the task.",
+      promptSlotBinding: directPromptSlotBinding,
+    });
 
     expect(chatViewOfRequest(requestBodies[1]).tools).toEqual([
       "bash",
@@ -575,7 +624,6 @@ describe("prompt-loop cross-agent address handles", () => {
         sandboxRuntime: new FakeSandboxRuntime(),
         runId: "run-subagent-pattern-author-denied",
         model: "gpt-5.4",
-        cfcEnforcementMode: "disabled",
       }),
       allowedSubagentProfiles: ["default"],
       fetchFn: scriptedFetch([
@@ -587,7 +635,10 @@ describe("prompt-loop cross-agent address handles", () => {
       ]),
     });
 
-    const result = await loop.runPrompt({ prompt: "Delegate the authoring." });
+    const result = await loop.runPrompt({
+      prompt: "Delegate the authoring.",
+      promptSlotBinding: directPromptSlotBinding,
+    });
 
     expect(result.runState.subagentRuns ?? []).toEqual([]);
     expect(
@@ -607,7 +658,6 @@ describe("prompt-loop cross-agent address handles", () => {
         sandboxRuntime: new FakeSandboxRuntime(),
         runId: "run-subagent-pattern-author-no-session",
         model: "gpt-5.4",
-        cfcEnforcementMode: "disabled",
         skillsRoot: fixture.skillsRoot,
       }),
       allowedSubagentProfiles: ["pattern-author"],
@@ -621,7 +671,10 @@ describe("prompt-loop cross-agent address handles", () => {
       ], requestBodies),
     });
 
-    const result = await loop.runPrompt({ prompt: "Delegate the authoring." });
+    const result = await loop.runPrompt({
+      prompt: "Delegate the authoring.",
+      promptSlotBinding: directPromptSlotBinding,
+    });
 
     expect(chatViewOfRequest(requestBodies[1]).tools).toEqual([
       "bash",
@@ -642,7 +695,6 @@ describe("prompt-loop cross-agent address handles", () => {
         sandboxRuntime: new FakeSandboxRuntime(),
         runId: "run-subagent-pattern-author-prompt",
         model: "gpt-5.4",
-        cfcEnforcementMode: "disabled",
       }),
       allowedSubagentProfiles: ["pattern-author"],
       fetchFn: scriptedFetch([
@@ -655,7 +707,10 @@ describe("prompt-loop cross-agent address handles", () => {
       ], requestBodies),
     });
 
-    await loop.runPrompt({ prompt: "Delegate the authoring." });
+    await loop.runPrompt({
+      prompt: "Delegate the authoring.",
+      promptSlotBinding: directPromptSlotBinding,
+    });
 
     const childSystemPrompt =
       chatViewOfRequest(requestBodies[1]).messages[0]!.content ?? "";
@@ -696,7 +751,6 @@ describe("prompt-loop cross-agent address handles", () => {
         sandboxRuntime: new FakeSandboxRuntime(),
         runId: "run-subagent-pattern-author-budget",
         model: "gpt-5.4",
-        cfcEnforcementMode: "disabled",
       }),
       allowedSubagentProfiles: ["pattern-author"],
       fetchFn: scriptedFetch([
@@ -709,7 +763,10 @@ describe("prompt-loop cross-agent address handles", () => {
       ]),
     });
 
-    const result = await loop.runPrompt({ prompt: "Delegate the authoring." });
+    const result = await loop.runPrompt({
+      prompt: "Delegate the authoring.",
+      promptSlotBinding: directPromptSlotBinding,
+    });
 
     const runRef = result.runState.subagentRuns?.[0];
     expect(runRef?.manifest.maxModelTurns).toBe(
@@ -728,7 +785,6 @@ describe("prompt-loop cross-agent address handles", () => {
       sandboxRuntime: new FakeSandboxRuntime(),
       runId,
       model: "gpt-5.4",
-      cfcEnforcementMode: "disabled",
     });
     await engine.recordHandleTable(table);
     const loop = new CfHarnessPromptLoop({
@@ -759,7 +815,10 @@ describe("prompt-loop cross-agent address handles", () => {
       ]),
     });
 
-    const result = await loop.runPrompt({ prompt: "Delegate the authoring." });
+    const result = await loop.runPrompt({
+      prompt: "Delegate the authoring.",
+      promptSlotBinding: directPromptSlotBinding,
+    });
 
     const returnedValue = (index: number): Record<string, unknown> =>
       (result.runState.subagentRuns?.[index] as
@@ -781,7 +840,6 @@ describe("prompt-loop cross-agent address handles", () => {
       sandboxRuntime: new FakeSandboxRuntime(),
       runId,
       model: "gpt-5.4",
-      cfcEnforcementMode: "disabled",
     });
     const loop = new CfHarnessPromptLoop({
       apiKey: "test-key",
@@ -799,7 +857,10 @@ describe("prompt-loop cross-agent address handles", () => {
       ]),
     });
 
-    const result = await loop.runPrompt({ prompt: "Delegate the authoring." });
+    const result = await loop.runPrompt({
+      prompt: "Delegate the authoring.",
+      promptSlotBinding: directPromptSlotBinding,
+    });
 
     const subagentRun = result.runState.subagentRuns?.[0] as {
       summary?: string;
@@ -899,13 +960,15 @@ describe("prompt-loop cross-agent address handles", () => {
           sandboxRuntime: new FakeSandboxRuntime(),
           runId,
           model: "gpt-5.4",
-          cfcEnforcementMode: "disabled",
           fabricSessionFactory: () => Promise.resolve({ pieces }),
         }),
         fetchFn,
       });
 
-      await loop.runPrompt({ prompt: "Delegate the pattern run." });
+      await loop.runPrompt({
+        prompt: "Delegate the pattern run.",
+        promptSlotBinding: directPromptSlotBinding,
+      });
 
       expect(chatViewOfRequest(requestBodies[1]).tools).toContain(
         "run_pattern",
@@ -1039,14 +1102,16 @@ describe("prompt-loop cross-agent address handles", () => {
           sandboxRuntime: new FakeSandboxRuntime(),
           runId,
           model: "gpt-5.4",
-          cfcEnforcementMode: "disabled",
           fabricSessionFactory: () => Promise.resolve({ pieces }),
         }),
         allowedSubagentProfiles: ["pattern-author"],
         fetchFn,
       });
 
-      await loop.runPrompt({ prompt: "Delegate the copy." });
+      await loop.runPrompt({
+        prompt: "Delegate the copy.",
+        promptSlotBinding: directPromptSlotBinding,
+      });
 
       expect(chatViewOfRequest(requestBodies[2]).tools).toContain(
         "run_pattern",

--- a/packages/cf-harness/test/prompt-loop-subagent-transcript-events.test.ts
+++ b/packages/cf-harness/test/prompt-loop-subagent-transcript-events.test.ts
@@ -20,6 +20,7 @@ import type {
   SandboxRuntimeDescription,
   SandboxShellRequest,
 } from "../src/sandbox/types.ts";
+import { directPromptSlotBindingFor } from "./support/prompt-slot-binding.ts";
 
 class FakeSandboxRuntime implements SandboxRuntime {
   describe(): SandboxRuntimeDescription {
@@ -104,6 +105,14 @@ const scriptedFetch = (payloads: readonly unknown[]): typeof fetch => {
 const GOAL = "Inspect the workspace and report.";
 
 /**
+ * The prompt that starts the run, bound as a direct command. A tool call made
+ * under this binding is authorized at every enforcement rung.
+ */
+const directPromptSlotBinding = directPromptSlotBindingFor(
+  "subagent-transcript-events",
+);
+
+/**
  * Runs a parent that delegates once, and returns every transcript event the
  * parent's handler saw, in order.
  */
@@ -112,7 +121,6 @@ const eventsFromDelegatingRun = async (): Promise<HarnessTranscriptEvent[]> => {
     sandboxRuntime: new FakeSandboxRuntime(),
     runId: "run-subagent-transcript-events",
     model: "gpt-5.4",
-    cfcEnforcementMode: "disabled",
   });
   const loop = new CfHarnessPromptLoop({
     apiKey: "test-key",
@@ -134,6 +142,7 @@ const eventsFromDelegatingRun = async (): Promise<HarnessTranscriptEvent[]> => {
 
   await loop.runPrompt({
     prompt: "Delegate the inspection.",
+    promptSlotBinding: directPromptSlotBinding,
     onTranscriptEvent: (event) => {
       events.push(event);
     },

--- a/packages/cf-harness/test/prompt-loop-subagent-turn-budget.test.ts
+++ b/packages/cf-harness/test/prompt-loop-subagent-turn-budget.test.ts
@@ -19,6 +19,7 @@ import type {
   SandboxRuntimeDescription,
   SandboxShellRequest,
 } from "../src/sandbox/types.ts";
+import { directPromptSlotBindingFor } from "./support/prompt-slot-binding.ts";
 
 class FakeSandboxRuntime implements SandboxRuntime {
   describe(): SandboxRuntimeDescription {
@@ -122,6 +123,14 @@ interface DelegateTaskOutput {
 }
 
 /**
+ * The prompt that starts the run, bound as a direct command. A tool call made
+ * under this binding is authorized at every enforcement rung.
+ */
+const directPromptSlotBinding = directPromptSlotBindingFor(
+  "subagent-turn-budget",
+);
+
+/**
  * The parent script: one turn spent on a `bash` call, then a `delegate_task`
  * call on the parent's last available turn under `maxModelTurns: 2`.
  */
@@ -153,7 +162,6 @@ const delegateOutputFromExhaustedParent = async (options: {
     sandboxRuntime: new FakeSandboxRuntime(),
     runId: options.runId,
     model: "gpt-5.4",
-    cfcEnforcementMode: "disabled",
   });
   const loop = new CfHarnessPromptLoop({
     apiKey: "test-key",
@@ -168,6 +176,7 @@ const delegateOutputFromExhaustedParent = async (options: {
 
   await expect(loop.runPrompt({
     prompt: "Delegate the inspection.",
+    promptSlotBinding: directPromptSlotBinding,
     onTranscriptEvent: ({ message }) => {
       if (
         message.role === "tool" &&

--- a/packages/cf-harness/test/prompt-loop.test.ts
+++ b/packages/cf-harness/test/prompt-loop.test.ts
@@ -189,7 +189,6 @@ Deno.test("CfHarnessPromptLoop rejects known provider/client mismatches", () => 
         engine: new CfHarnessEngine({
           sandboxRuntime: new FakeSandboxRuntime(),
           modelProvider: "openai-compatible-gateway",
-          cfcEnforcementMode: "disabled",
         }),
         modelClient: {
           providerId: "openai-codex",
@@ -234,7 +233,6 @@ Deno.test("CfHarnessPromptLoop requires an exact Codex credential owner binding"
           },
         }
         : {}),
-      cfcEnforcementMode: "disabled",
     });
 
   assertThrows(
@@ -383,7 +381,6 @@ Deno.test("CfHarnessPromptLoop persists a fresh Codex model selection before the
       modelProvider: "openai-codex",
       model: "gpt-configured-default",
       credentialOwnerKey: "local",
-      cfcEnforcementMode: "disabled",
     }),
     modelClient: {
       providerId: "openai-codex",
@@ -474,6 +471,8 @@ Deno.test("CfHarnessPromptLoop executes injected model-client tool calls through
       sandboxRuntime: sandbox,
       runId: "run-model-client",
       model: "test-model",
+      // Strict enforcement denies the injected read_file call, and
+      // `result.runState.policyEvents[0]?.severity` reads that denial back.
       cfcEnforcementMode: "enforce-strict",
     }),
   });
@@ -514,7 +513,6 @@ Deno.test("CfHarnessPromptLoop preserves the public gatewayClient compatibility 
       runId: "run-gateway-client-compat",
       model: "gpt-5.4",
       gatewayAuthMode: "none",
-      cfcEnforcementMode: "disabled",
     }),
   });
 
@@ -624,11 +622,13 @@ Deno.test("Codex parent and child loops share one serialized credential refresh"
       },
       modelAuthSource: "cf-harness-local-store",
       harnessHomeIdentity: "sha256:opaque-home",
-      cfcEnforcementMode: "disabled",
     }),
   });
 
-  const result = await loop.runPrompt({ prompt: "Delegate this." });
+  const result = await loop.runPrompt({
+    prompt: "Delegate this.",
+    promptSlotBinding: directPromptSlotBinding,
+  });
 
   assertEquals(result.finalAssistantText, "Parent done.");
   assertEquals(refreshes, 1);
@@ -702,11 +702,13 @@ Deno.test("Codex profile model overrides fail the child without aborting the par
       model: "gpt-5.4",
       modelProvider: "openai-codex",
       credentialOwnerKey: "local",
-      cfcEnforcementMode: "disabled",
     }),
   });
 
-  const result = await loop.runPrompt({ prompt: "Delegate and continue." });
+  const result = await loop.runPrompt({
+    prompt: "Delegate and continue.",
+    promptSlotBinding: directPromptSlotBinding,
+  });
   const toolMessage = result.transcript.at(-2);
   if (toolMessage?.role !== "tool") {
     throw new Error("expected delegate_task tool message");
@@ -781,11 +783,13 @@ Deno.test("CfHarnessPromptLoop keeps provider controls off profile-overridden ch
       sandboxRuntime: new FakeSandboxRuntime(),
       runId: "run-child-cache-mode",
       model: "gpt-5.6-terra",
-      cfcEnforcementMode: "disabled",
     }),
   });
 
-  const result = await loop.runPrompt({ prompt: "Delegate and continue." });
+  const result = await loop.runPrompt({
+    prompt: "Delegate and continue.",
+    promptSlotBinding: directPromptSlotBinding,
+  });
   const toolMessage = result.transcript.at(-2);
   if (toolMessage?.role !== "tool") {
     throw new Error("expected delegate_task tool message");
@@ -853,11 +857,13 @@ Deno.test("CfHarnessPromptLoop propagates provider controls to model-inheriting 
       sandboxRuntime: new FakeSandboxRuntime(),
       runId: "run-inherited-provider-controls",
       model: "gpt-5.6-terra",
-      cfcEnforcementMode: "disabled",
     }),
   });
 
-  const result = await loop.runPrompt({ prompt: "Delegate and continue." });
+  const result = await loop.runPrompt({
+    prompt: "Delegate and continue.",
+    promptSlotBinding: directPromptSlotBinding,
+  });
 
   assertEquals(result.finalAssistantText, "parent done");
   assertEquals(turns, 3);
@@ -1027,12 +1033,15 @@ Deno.test("CfHarnessPromptLoop retains child usage when delegate output persiste
         sandboxRuntime: new FakeSandboxRuntime(),
         runId: "run-delegate-usage-failure",
         model: "test-model",
-        cfcEnforcementMode: "disabled",
       }),
     });
 
     await assertRejects(
-      () => loop.runPrompt({ prompt: "Delegate this." }),
+      () =>
+        loop.runPrompt({
+          prompt: "Delegate this.",
+          promptSlotBinding: directPromptSlotBinding,
+        }),
       Error,
       "delegate output persist boom",
     );
@@ -1093,6 +1102,18 @@ const observedCfcResult = (
   },
 });
 
+/**
+ * The model-facing fields of a tool result, without the CFC mediation
+ * descriptor the loop attaches beside them.
+ */
+const toolResultFields = (content: string): Record<string, unknown> => {
+  const { cfc: _cfc, ...fields } = JSON.parse(content) as Record<
+    string,
+    unknown
+  >;
+  return fields;
+};
+
 Deno.test("CfHarnessPromptLoop runs a tool call and returns the final assistant response", async () => {
   await using fixture = await createPatternSkillsFixture();
   const fetchCalls: RequestInit[] = [];
@@ -1100,11 +1121,15 @@ Deno.test("CfHarnessPromptLoop runs a tool call and returns the final assistant 
     apiKey: "test-key",
     engine: new CfHarnessEngine({
       sandboxRuntime: new FakeSandboxRuntime([
-        { stdout: "hello from file", stderr: "", exitCode: 0 },
+        {
+          stdout: "hello from file",
+          stderr: "",
+          exitCode: 0,
+          cfcResult: observedCfcResult("hello from file"),
+        },
       ]),
       runId: "run-loop",
       model: "gpt-5.4",
-      cfcEnforcementMode: "disabled",
       skillsRoot: fixture.skillsRoot,
       now: (() => {
         const timestamps = [
@@ -1156,6 +1181,7 @@ Deno.test("CfHarnessPromptLoop runs a tool call and returns the final assistant 
   });
 
   const result = await loop.runPrompt({
+    promptSlotBinding: directPromptSlotBinding,
     systemPrompt: "You are a test harness.",
     prompt: "Read the todo file and summarize it.",
   });
@@ -1167,42 +1193,49 @@ Deno.test("CfHarnessPromptLoop runs a tool call and returns the final assistant 
   assertEquals(result.modelTurns, 2);
   assertEquals(result.runState.endedAt, "2026-04-15T20:00:06.000Z");
   assertEquals(result.runState.terminalReason, "assistant_completed");
-  assertEquals(result.transcript, [
-    { role: "system", content: "You are a test harness." },
-    { role: "user", content: "Read the todo file and summarize it." },
-    {
-      role: "assistant",
-      content: "",
-      toolCalls: [{
-        id: "call-1",
-        type: "function",
-        function: {
-          name: "read_file",
-          arguments: JSON.stringify({ path: "notes/todo.txt" }),
-        },
-      }],
-    },
-    {
-      role: "tool",
-      toolCallId: "call-1",
-      toolName: "read_file",
-      content: JSON.stringify({
-        outputId: createToolOutputId("run-loop", "read_file", 1),
-        path: "/workspace/notes/todo.txt",
-        content: "hello from file",
-      }),
-      resultRef: {
-        type: "cf-harness.tool-result-ref",
-        outputId: createToolOutputId("run-loop", "read_file", 1),
-        toolId: "read_file",
-        runId: "run-loop",
+  assertEquals(
+    result.transcript.map((message) =>
+      message.role === "tool"
+        ? { ...message, content: toolResultFields(message.content) }
+        : message
+    ),
+    [
+      { role: "system", content: "You are a test harness." },
+      { role: "user", content: "Read the todo file and summarize it." },
+      {
+        role: "assistant",
+        content: "",
+        toolCalls: [{
+          id: "call-1",
+          type: "function",
+          function: {
+            name: "read_file",
+            arguments: JSON.stringify({ path: "notes/todo.txt" }),
+          },
+        }],
       },
-    },
-    {
-      role: "assistant",
-      content: "The todo file says hello from file.",
-    },
-  ]);
+      {
+        role: "tool",
+        toolCallId: "call-1",
+        toolName: "read_file",
+        content: {
+          outputId: createToolOutputId("run-loop", "read_file", 1),
+          path: "/workspace/notes/todo.txt",
+          content: "hello from file",
+        },
+        resultRef: {
+          type: "cf-harness.tool-result-ref",
+          outputId: createToolOutputId("run-loop", "read_file", 1),
+          toolId: "read_file",
+          runId: "run-loop",
+        },
+      },
+      {
+        role: "assistant",
+        content: "The todo file says hello from file.",
+      },
+    ],
+  );
   assertEquals(result.runState.status, "completed");
   assertEquals(result.runState.policyEvents, []);
 
@@ -1227,18 +1260,14 @@ Deno.test("CfHarnessPromptLoop runs a tool call and returns the final assistant 
       "query_docs",
     ],
   );
-  assertEquals(
-    chatViewOfRequest(secondRequest).messages.at(-1),
-    {
-      role: "tool",
-      tool_call_id: "call-1",
-      content: JSON.stringify({
-        outputId: createToolOutputId("run-loop", "read_file", 1),
-        path: "/workspace/notes/todo.txt",
-        content: "hello from file",
-      }),
-    },
-  );
+  const lastSentMessage = chatViewOfRequest(secondRequest).messages.at(-1);
+  assertEquals(lastSentMessage?.role, "tool");
+  assertEquals(lastSentMessage?.tool_call_id, "call-1");
+  assertEquals(toolResultFields(lastSentMessage!.content), {
+    outputId: createToolOutputId("run-loop", "read_file", 1),
+    path: "/workspace/notes/todo.txt",
+    content: "hello from file",
+  });
 });
 
 // A sandbox whose resolvePath throws for anything outside /workspace, so we can
@@ -1307,6 +1336,9 @@ Deno.test("CfHarnessPromptLoop: a command timeout is a recoverable bash result, 
       ),
       runId: "run-tool-timeout",
       model: "gpt-5.4",
+      // With enforcement off the recoverable bash result reaches the model as
+      // the tool wrote it. The assertions below read the timeout message and
+      // the exit code out of that tool message.
       cfcEnforcementMode: "disabled",
     }),
     fetchFn: twoTurnBashFetch(
@@ -1341,6 +1373,9 @@ Deno.test("CfHarnessPromptLoop: a cwd outside the sandbox is a recoverable bash 
       sandboxRuntime: new CwdEscapeSandboxRuntime(),
       runId: "run-tool-cwd-escape",
       model: "gpt-5.4",
+      // With enforcement off the recoverable bash result reaches the model as
+      // the tool wrote it. The assertion below reads the cwd message out of
+      // that tool message.
       cfcEnforcementMode: "disabled",
     }),
     fetchFn: twoTurnBashFetch(
@@ -1376,7 +1411,6 @@ Deno.test("CfHarnessPromptLoop: a non-recoverable tool failure stays fatal and n
     ),
     runId: "run-tool-fatal",
     model: "gpt-5.4",
-    cfcEnforcementMode: "disabled",
   });
   const loop = new CfHarnessPromptLoop({
     apiKey: "test-key",
@@ -1384,7 +1418,12 @@ Deno.test("CfHarnessPromptLoop: a non-recoverable tool failure stays fatal and n
     fetchFn: twoTurnBashFetch(fetchCalls, { command: "ls" }, "unreachable"),
   });
 
-  await assertRejects(() => loop.runPrompt({ prompt: "List files." }));
+  await assertRejects(() =>
+    loop.runPrompt({
+      prompt: "List files.",
+      promptSlotBinding: directPromptSlotBinding,
+    })
+  );
   // The run is terminal-failed, and the model never got a second turn — the
   // host detail could not have leaked into a model-facing tool result.
   assertEquals(engine.getRunState().status, "failed");
@@ -1400,7 +1439,6 @@ Deno.test("CfHarnessPromptLoop forwards abort signals to gateway requests", asyn
       sandboxRuntime: new FakeSandboxRuntime(),
       runId: "run-loop-signal",
       model: "gpt-5.4",
-      cfcEnforcementMode: "disabled",
     }),
     fetchFn: (_input, init) => {
       seenSignal = init?.signal;
@@ -1462,7 +1500,6 @@ Deno.test("CfHarnessPromptLoop preserves custom abort reasons for local gateway 
         credentialOwner,
         harnessHomeIdentity: "sha256:opaque-home",
       },
-      cfcEnforcementMode: "disabled",
     }),
   });
 
@@ -1484,7 +1521,6 @@ Deno.test("CfHarnessPromptLoop forwards abort signals to delegate_task child loo
       sandboxRuntime: new FakeSandboxRuntime(),
       runId: "run-loop-delegate-signal",
       model: "gpt-5.4",
-      cfcEnforcementMode: "disabled",
     }),
     fetchFn: (_input, init) => {
       seenSignals.push(init?.signal);
@@ -1536,6 +1572,7 @@ Deno.test("CfHarnessPromptLoop forwards abort signals to delegate_task child loo
   });
 
   const result = await loop.runPrompt({
+    promptSlotBinding: directPromptSlotBinding,
     prompt: "Delegate a task.",
     signal: controller.signal,
   });
@@ -1549,7 +1586,12 @@ Deno.test("CfHarnessPromptLoop forwards abort signals to delegate_task child loo
 
 Deno.test("CfHarnessPromptLoop strips trusted-only CFC input labels from model tool args", async () => {
   const sandbox = new FakeSandboxRuntime([
-    { stdout: "ok\n", stderr: "", exitCode: 0 },
+    {
+      stdout: "ok\n",
+      stderr: "",
+      exitCode: 0,
+      cfcResult: observedCfcResult("ok\n"),
+    },
   ]);
   let fetchCount = 0;
   const loop = new CfHarnessPromptLoop({
@@ -1557,7 +1599,6 @@ Deno.test("CfHarnessPromptLoop strips trusted-only CFC input labels from model t
     engine: new CfHarnessEngine({
       sandboxRuntime: sandbox,
       runId: "run-strip-cfc-input-labels",
-      cfcEnforcementMode: "disabled",
       model: "gpt-5.4",
     }),
     fetchFn: () => {
@@ -1612,6 +1653,7 @@ Deno.test("CfHarnessPromptLoop strips trusted-only CFC input labels from model t
   });
 
   const result = await loop.runPrompt({
+    promptSlotBinding: directPromptSlotBinding,
     prompt: "Run a command.",
   });
 
@@ -1619,10 +1661,18 @@ Deno.test("CfHarnessPromptLoop strips trusted-only CFC input labels from model t
     !request.command.includes(CAPABILITY_PROBE_SENTINEL)
   );
   assert(toolRequest !== undefined);
-  assertEquals(toolRequest.cfcInvocationContext?.cfcInputLabels, undefined);
+  // The loop labels the command from the prompt slot it was given. The entry
+  // the model wrote reaches neither the sandbox nor the recorded context.
+  const sandboxLabels = toolRequest.cfcInvocationContext?.cfcInputLabels;
+  assertEquals(sandboxLabels?.entries.map((entry) => entry.path), [[
+    "command",
+  ]]);
+  assertEquals(JSON.stringify(sandboxLabels).includes("did:key:forged"), false);
   assertEquals(
-    result.runState.cfcInvocationContexts?.[0]?.cfcInputLabels,
-    undefined,
+    JSON.stringify(
+      result.runState.cfcInvocationContexts?.[0]?.cfcInputLabels ?? null,
+    ).includes("did:key:forged"),
+    false,
   );
 });
 
@@ -1678,6 +1728,7 @@ Deno.test("CfHarnessPromptLoop attaches images loaded by view_image on the next 
   const result = await loop.runPrompt({
     systemPrompt: "You are a test harness.",
     prompt: "Inspect the image if needed.",
+    promptSlotBinding: directPromptSlotBinding,
   });
 
   assertEquals(
@@ -1870,6 +1921,9 @@ Deno.test("CfHarnessPromptLoop surfaces recoverable file-tool failures to the mo
       ]),
       runId: "run-recoverable-file-error",
       model: "gpt-5.4",
+      // With enforcement off the structured read_file error reaches the model
+      // as the tool wrote it. The transcript and second-request assertions
+      // compare against `recoverableOutput`.
       cfcEnforcementMode: "disabled",
       now: (() => {
         const timestamps = [
@@ -2622,7 +2676,6 @@ Deno.test("CfHarnessPromptLoop delegates one fresh child run and returns a summa
       sandboxRuntime: new FakeSandboxRuntime(),
       runId: "run-delegate",
       model: "gpt-5.4",
-      cfcEnforcementMode: "enforce-explicit",
       skillsRoot: fixture.skillsRoot,
     }),
     fetchFn: (_input, init) => {
@@ -2834,7 +2887,6 @@ Deno.test("CfHarnessPromptLoop validates structured subagent returns and linkifi
         sandboxRuntime: new FakeSandboxRuntime(),
         runId: "run-structured-return",
         model: "gpt-5.4",
-        cfcEnforcementMode: "enforce-explicit",
         artifactStore,
       }),
       fetchFn: (_input, init) => {
@@ -3027,7 +3079,6 @@ Deno.test("CfHarnessPromptLoop fails structured subagent returns without exposin
       sandboxRuntime: new FakeSandboxRuntime(),
       runId: "run-structured-return-invalid",
       model: "gpt-5.4",
-      cfcEnforcementMode: "enforce-explicit",
     }),
     fetchFn: (_input, init) => {
       const body = JSON.parse(String(init?.body)) as {
@@ -3138,7 +3189,6 @@ Deno.test("CfHarnessPromptLoop keeps child-supplied schema mismatch details out 
       sandboxRuntime: new FakeSandboxRuntime(),
       runId: "run-structured-return-mismatch",
       model: "gpt-5.4",
-      cfcEnforcementMode: "enforce-explicit",
     }),
     fetchFn: (_input, init) => {
       const body = JSON.parse(String(init?.body)) as {
@@ -3251,7 +3301,6 @@ Deno.test("CfHarnessPromptLoop lets an explicit subagent profile expand child to
       sandboxRuntime: new FakeSandboxRuntime(),
       runId: "run-delegate-explicit-profile",
       model: "gpt-5.4",
-      cfcEnforcementMode: "enforce-explicit",
     }),
     fetchFn: (_input, init) => {
       const body = JSON.parse(String(init?.body)) as {
@@ -3389,7 +3438,6 @@ Deno.test("CfHarnessPromptLoop applies the web_search profile model override and
       sandboxRuntime: new FakeSandboxRuntime(),
       runId: "run-delegate-web-search",
       model: "gpt-5.4",
-      cfcEnforcementMode: "enforce-explicit",
     }),
     fetchFn: (_input, init) => {
       const body = JSON.parse(String(init?.body)) as {
@@ -3520,7 +3568,6 @@ Deno.test("CfHarnessPromptLoop keeps browser unavailable to the parent by defaul
       workspaceHostPath: "/tmp/project",
       runId: "run-parent-host-tool-denied",
       model: "gpt-5.4",
-      cfcEnforcementMode: "enforce-explicit",
       skillsRoot: fixture.skillsRoot,
     }),
     fetchFn: (_input, init) => {
@@ -3610,7 +3657,6 @@ Deno.test("CfHarnessPromptLoop gives the browser tool only to the authorized bro
       workspaceHostPath: "/tmp/project",
       runId: "run-delegate-browser-profile",
       model: "gpt-5.4",
-      cfcEnforcementMode: "enforce-explicit",
       skillsRoot: fixture.skillsRoot,
     }),
     fetchFn: (_input, init) => {
@@ -3789,7 +3835,6 @@ Deno.test("CfHarnessPromptLoop activates browser subagent skills and host skill 
       skillsRoot,
       runId: "run-browser-subagent-skills",
       model: "gpt-5.4",
-      cfcEnforcementMode: "observe",
     });
     await engine.persistSkillRegistry(registry);
 
@@ -4029,7 +4074,6 @@ Deno.test("CfHarnessPromptLoop briefs browser subagents on the lease without exp
       workspaceHostPath: "/tmp/project",
       runId: "run-delegate-browser-lease",
       model: "gpt-5.4",
-      cfcEnforcementMode: "enforce-explicit",
     }),
     fetchFn: (_input, init) => {
       const body = JSON.parse(String(init?.body)) as {
@@ -4125,7 +4169,6 @@ Deno.test("CfHarnessPromptLoop gives web_fetch only to the authorized web_fetch 
       workspaceHostPath: "/tmp/project",
       runId: "run-delegate-web-fetch-profile",
       model: "gpt-5.4",
-      cfcEnforcementMode: "enforce-explicit",
     }),
     fetchFn: (_input, init) => {
       const body = JSON.parse(String(init?.body)) as {
@@ -4277,7 +4320,6 @@ Deno.test("CfHarnessPromptLoop keeps browser subagent observations behind struct
         workspaceHostPath,
         runId: "run-browser-structured-return",
         model: "gpt-5.4",
-        cfcEnforcementMode: "enforce-explicit",
         skillsRoot: fixture.skillsRoot,
       }),
       fetchFn: (_input, init) => {
@@ -4500,7 +4542,6 @@ Deno.test("CfHarnessPromptLoop does not authorize the browser profile by default
       workspaceHostPath: "/tmp/project",
       runId: "run-browser-profile-default-denied",
       model: "gpt-5.4",
-      cfcEnforcementMode: "enforce-explicit",
     }),
     fetchFn: (_input, init) => {
       fetchCalls.push(init ?? {});
@@ -4586,7 +4627,6 @@ Deno.test("CfHarnessPromptLoop reports child run failures through delegate_task 
       ]),
       runId: "run-delegate-child-failure",
       model: "gpt-5.4",
-      cfcEnforcementMode: "enforce-explicit",
     }),
     fetchFn: (_input, init) => {
       const body = JSON.parse(String(init?.body)) as {
@@ -4985,6 +5025,8 @@ Deno.test("CfHarnessPromptLoop denies delegate_task without direct-command autho
       sandboxRuntime: new FakeSandboxRuntime(),
       runId: "run-delegate-denied",
       model: "gpt-5.4",
+      // The expected policy event names this mode in its `mode` field and in
+      // both of its denial details.
       cfcEnforcementMode: "enforce-explicit",
       now: (() => {
         const timestamps = [
@@ -5089,7 +5131,6 @@ Deno.test("CfHarnessPromptLoop denies delegate_task when the profile is not auth
       sandboxRuntime: new FakeSandboxRuntime(),
       runId: "run-delegate-profile-denied",
       model: "gpt-5.4",
-      cfcEnforcementMode: "enforce-explicit",
     }),
     fetchFn: (_input, init) => {
       const body = JSON.parse(String(init?.body)) as {
@@ -5228,11 +5269,15 @@ Deno.test("CfHarnessPromptLoop fails when the model exceeds the configured turn 
     apiKey: "test-key",
     engine: new CfHarnessEngine({
       sandboxRuntime: new FakeSandboxRuntime([
-        { stdout: "hello", stderr: "", exitCode: 0 },
+        {
+          stdout: "hello",
+          stderr: "",
+          exitCode: 0,
+          cfcResult: observedCfcResult("hello"),
+        },
       ]),
       runId: "run-max-turns",
       model: "gpt-5.4",
-      cfcEnforcementMode: "disabled",
     }),
     maxModelTurns: 1,
     fetchFn: () =>
@@ -5261,7 +5306,11 @@ Deno.test("CfHarnessPromptLoop fails when the model exceeds the configured turn 
   });
 
   await assertRejects(
-    () => loop.runPrompt({ prompt: "Loop forever." }),
+    () =>
+      loop.runPrompt({
+        prompt: "Loop forever.",
+        promptSlotBinding: directPromptSlotBinding,
+      }),
     Error,
     "prompt loop exceeded max model turns (1)",
   );
@@ -5381,6 +5430,8 @@ Deno.test("CfHarnessPromptLoop records observe-mode warnings and still executes 
       ]),
       runId: "run-observe-warning",
       model: "gpt-5.4",
+      // The expected policy event names this mode in its warning detail, and
+      // the tool message carries the sandbox's own stdout.
       cfcEnforcementMode: "observe",
       now: (() => {
         const timestamps = [
@@ -5501,6 +5552,8 @@ Deno.test("CfHarnessPromptLoop truncates large model-facing bash output in obser
       ]),
       runId: "run-large-bash-output",
       model: "gpt-5.4",
+      // The tool message carries the sandbox's own stdout, which is what the
+      // truncation assertions measure.
       cfcEnforcementMode: "observe",
     }),
     fetchFn: (_input, init) => {
@@ -5581,13 +5634,22 @@ Deno.test("CfHarnessPromptLoop retains omission records across provider compacti
       apiKey: "test-key",
       engine: new CfHarnessEngine({
         sandboxRuntime: new FakeSandboxRuntime([
-          { stdout: hugeStdout, stderr: "", exitCode: 0 },
-          { stdout: "second\n", stderr: "", exitCode: 0 },
+          {
+            stdout: hugeStdout,
+            stderr: "",
+            exitCode: 0,
+            cfcResult: observedCfcResult(hugeStdout),
+          },
+          {
+            stdout: "second\n",
+            stderr: "",
+            exitCode: 0,
+            cfcResult: observedCfcResult("second\n"),
+          },
         ]),
         artifactStore,
         runId,
         model: "gpt-5.4",
-        cfcEnforcementMode: "disabled",
       }),
       fetchFn: (_input, init) => {
         turns += 1;
@@ -5680,11 +5742,15 @@ Deno.test("CfHarnessPromptLoop bounds a large model-facing read_file result more
     apiKey: "test-key",
     engine: new CfHarnessEngine({
       sandboxRuntime: new FakeSandboxRuntime([
-        { stdout: document, stderr: "", exitCode: 0 },
+        {
+          stdout: document,
+          stderr: "",
+          exitCode: 0,
+          cfcResult: observedCfcResult(document),
+        },
       ]),
       runId: "run-large-read-file",
       model: "gpt-5.4",
-      cfcEnforcementMode: "observe",
     }),
     fetchFn: (_input, init) => {
       fetchCalls.push(init ?? {});
@@ -5757,6 +5823,9 @@ Deno.test("CfHarnessPromptLoop denies bash output without CFC metadata in enforc
       ]),
       runId: "run-missing-cfc-result",
       model: "gpt-5.4",
+      // An enforcing run denies bash output that carries no mediation
+      // metadata. The tool message is compared against that
+      // observation-denied envelope.
       cfcEnforcementMode: "enforce-explicit",
     }),
     fetchFn: (_input, init) => {
@@ -5871,6 +5940,8 @@ Deno.test({
         ]),
         runId: "run-missing-cfc-script-result",
         model: "gpt-5.4",
+        // An enforcing run denies run_skill_script output that carries no
+        // mediation metadata. The tool message is compared against that denial.
         cfcEnforcementMode: "enforce-explicit",
         skillsRoot: root,
         allowedSkillScripts: [{
@@ -6016,7 +6087,6 @@ Deno.test({
         ]),
         runId: "run-mediated-skill-script",
         model: "gpt-5.4",
-        cfcEnforcementMode: "enforce-explicit",
         skillsRoot: root,
         allowedSkillScripts: [{
           skill: "deno-memory-profiler",
@@ -6138,6 +6208,8 @@ Deno.test("CfHarnessPromptLoop exposes mediated bash output instead of raw stdou
       ]),
       runId: "run-mediated-cfc-result",
       model: "gpt-5.4",
+      // An enforcing run hands the model the mediated stream. The assertions
+      // read `content.cfc.stdout.policy` and `content.cfc.stderr.policy` back.
       cfcEnforcementMode: "enforce-explicit",
     }),
     fetchFn: (_input, init) => {
@@ -6221,7 +6293,6 @@ Deno.test("CfHarnessPromptLoop records CFC-side stream truncation as a model omi
         }]),
         runId,
         model: "gpt-5.4",
-        cfcEnforcementMode: "enforce-explicit",
       }),
       fetchFn: () => {
         turn += 1;
@@ -6309,6 +6380,8 @@ Deno.test("CfHarnessPromptLoop denies read_file content without CFC metadata in 
       ]),
       runId: "run-read-file-missing-cfc-result",
       model: "gpt-5.4",
+      // An enforcing run denies read_file content that carries no mediation
+      // metadata. The tool message is compared against that denial.
       cfcEnforcementMode: "enforce-explicit",
     }),
     fetchFn: (() => {
@@ -6386,6 +6459,9 @@ Deno.test("CfHarnessPromptLoop redacts read_file filesystem-status failures in e
       ]),
       runId: "run-read-file-status-redacted",
       model: "gpt-5.4",
+      // An enforcing run redacts the filesystem-status failure, and the
+      // assertions compare the model-facing path and error against their
+      // redacted forms.
       cfcEnforcementMode: "enforce-explicit",
     }),
     fetchFn: (() => {
@@ -6476,6 +6552,8 @@ Deno.test("CfHarnessPromptLoop warns but exposes read_file filesystem-status fai
       ]),
       runId: "run-read-file-status-observe",
       model: "gpt-5.4",
+      // An observing run exposes the filesystem-status failure and records a
+      // warning. The assertions read both the warning and the exposed error.
       cfcEnforcementMode: "observe",
     }),
     fetchFn: (() => {
@@ -6556,7 +6634,6 @@ Deno.test("CfHarnessPromptLoop exposes mediated read_file content and tracks mod
       ]),
       runId: "run-read-file-cfc-model-context",
       model: "gpt-5.4",
-      cfcEnforcementMode: "enforce-explicit",
     }),
     fetchFn: (_input, init) => {
       fetchCalls.push(init ?? {});
@@ -6670,7 +6747,6 @@ Deno.test("CfHarnessPromptLoop carries observed CFC labels into later write_file
       ]),
       runId: "run-write-file-cfc-model-context",
       model: "gpt-5.4",
-      cfcEnforcementMode: "enforce-explicit",
     }),
     fetchFn: (_input, init) => {
       fetchCalls.push(init ?? {});
@@ -6794,7 +6870,6 @@ Deno.test("CfHarnessPromptLoop carries observed CFC labels into edit_file write 
       ]),
       runId: "run-edit-file-cfc-model-context",
       model: "gpt-5.4",
-      cfcEnforcementMode: "enforce-explicit",
     }),
     fetchFn: (_input, init) => {
       fetchCalls.push(init ?? {});
@@ -6968,6 +7043,9 @@ Deno.test("CfHarnessPromptLoop denies edit_file success when an internal read la
       ]),
       runId: "run-edit-file-missing-cfc-result",
       model: "gpt-5.4",
+      // An enforcing run denies the edit_file result whose internal read
+      // carried no mediation metadata. The assertions read that denial and
+      // its handle.
       cfcEnforcementMode: "enforce-explicit",
     }),
     fetchFn: (_input, init) => {
@@ -7058,6 +7136,9 @@ Deno.test("CfHarnessPromptLoop redacts recoverable edit_file errors in enforce m
       ]),
       runId: "run-edit-file-error-redaction",
       model: "gpt-5.4",
+      // An enforcing run redacts the recoverable edit_file error, and the
+      // assertions compare the model-facing path and error against
+      // `[redacted]`.
       cfcEnforcementMode: "enforce-explicit",
     }),
     fetchFn: (_input, init) => {
@@ -7169,7 +7250,6 @@ Deno.test("CfHarnessPromptLoop accumulates observed CFC labels for the next mode
       ]),
       runId: "run-cfc-model-context",
       model: "gpt-5.4",
-      cfcEnforcementMode: "enforce-explicit",
     }),
     fetchFn: (_input, init) => {
       fetchCalls.push(init ?? {});
@@ -7284,7 +7364,6 @@ Deno.test("CfHarnessPromptLoop does not taint sibling tool calls from one assist
       ]),
       runId: "run-cfc-model-context-siblings",
       model: "gpt-5.4",
-      cfcEnforcementMode: "enforce-explicit",
     }),
     fetchFn: (_input, init) => {
       fetchCalls.push(init ?? {});
@@ -7405,7 +7484,6 @@ Deno.test("CfHarnessPromptLoop ignores opaque and denied CFC observations for mo
       ]),
       runId: "run-cfc-model-context-opaque",
       model: "gpt-5.4",
-      cfcEnforcementMode: "enforce-explicit",
     }),
     fetchFn: (_input, init) => {
       fetchCalls.push(init ?? {});
@@ -7488,6 +7566,8 @@ Deno.test("CfHarnessPromptLoop returns observation-denied tool content in enforc
       sandboxRuntime: new FakeSandboxRuntime(),
       runId: "run-enforce-explicit",
       model: "gpt-5.4",
+      // The expected policy event and the model-facing tool message both name
+      // this mode in their denial detail.
       cfcEnforcementMode: "enforce-explicit",
       now: (() => {
         const timestamps = [
@@ -7606,6 +7686,7 @@ Deno.test("CfHarnessPromptLoop denies tool calls outside the configured allowlis
       sandboxRuntime: new FakeSandboxRuntime(),
       runId: "run-tool-allowlist-denied",
       model: "gpt-5.4",
+      // The expected policy event carries this mode in its `mode` field.
       cfcEnforcementMode: "disabled",
       now: (() => {
         const timestamps = [
@@ -7708,6 +7789,8 @@ Deno.test("CfHarnessPromptLoop includes read_file input summaries on strict-mode
       sandboxRuntime: new FakeSandboxRuntime(),
       runId: "run-read-file-strict",
       model: "gpt-5.4",
+      // Strict enforcement denies the read, and the assertions read the input
+      // summary that denial carried.
       cfcEnforcementMode: "enforce-strict",
     }),
     fetchFn: (_input, init) => {
@@ -7776,6 +7859,7 @@ Deno.test("CfHarnessPromptLoop includes prompt slot context on policy events", a
       sandboxRuntime: new FakeSandboxRuntime(),
       runId: "run-policy-context",
       model: "gpt-5.4",
+      // The expected policy event names this mode in its denial detail.
       cfcEnforcementMode: "enforce-explicit",
     }),
     fetchFn: (_input, init) => {
@@ -7891,7 +7975,6 @@ Deno.test("CfHarnessPromptLoop applies the compaction threshold to delegated wor
         sandboxRuntime: new FakeSandboxRuntime(),
         runId: `run-child-compaction-${threshold}`,
         model: "gpt-5.6-terra",
-        cfcEnforcementMode: "disabled",
       }),
     });
 
@@ -7962,11 +8045,13 @@ Deno.test("CfHarnessPromptLoop keeps a positive threshold off profile-overridden
         sandboxRuntime: new FakeSandboxRuntime(),
         runId: `run-override-compaction-${threshold}`,
         model: "gpt-5.6-terra",
-        cfcEnforcementMode: "disabled",
       }),
     });
 
-    await loop.runPrompt({ prompt: "Delegate and continue." });
+    await loop.runPrompt({
+      prompt: "Delegate and continue.",
+      promptSlotBinding: directPromptSlotBinding,
+    });
 
     assert(childSeen.length >= 1, "expected at least one child turn");
     assertEquals(
@@ -7999,7 +8084,6 @@ Deno.test("CfHarnessPromptLoop grounds host-command children in the workspace, n
       cwd: "/file-cabinet",
       runId: "run-delegate-browser-cwd",
       model: "gpt-5.4",
-      cfcEnforcementMode: "enforce-explicit",
     }),
     fetchFn: (_input, init) => {
       const body = JSON.parse(String(init?.body)) as {
@@ -8081,7 +8165,6 @@ Deno.test("CfHarnessPromptLoop surfaces a child's ok:false return as a coded fai
       sandboxRuntime: new FakeSandboxRuntime(),
       runId: "run-structured-return-child-failure",
       model: "gpt-5.4",
-      cfcEnforcementMode: "enforce-explicit",
     }),
     fetchFn: (_input, init) => {
       const body = JSON.parse(String(init?.body)) as {

--- a/packages/cf-harness/test/query-docs.test.ts
+++ b/packages/cf-harness/test/query-docs.test.ts
@@ -54,6 +54,13 @@ import type {
   SandboxRuntimeDescription,
   SandboxShellRequest,
 } from "../src/sandbox/types.ts";
+import { directPromptSlotBindingFor } from "./support/prompt-slot-binding.ts";
+
+/**
+ * The prompt that starts the run, bound as a direct command. A tool call made
+ * under this binding is authorized at every enforcement rung.
+ */
+const directPromptSlotBinding = directPromptSlotBindingFor("query-docs");
 
 class FakeSandboxRuntime implements SandboxRuntime {
   describe(): SandboxRuntimeDescription {
@@ -133,7 +140,6 @@ describe("query-docs", () => {
     const engine = new CfHarnessEngine({
       sandboxRuntime: new FakeSandboxRuntime(),
       runId: `query-docs-test-${crypto.randomUUID()}`,
-      cfcEnforcementMode: "disabled",
       // A run wanting no corpus says so; the checkout the tests run out of
       // would otherwise supply the default.
       ...(options.corpus === false
@@ -371,7 +377,6 @@ describe("query-docs", () => {
         artifactStore,
         runId,
         model: "test-model",
-        cfcEnforcementMode: "disabled",
         docsCorpus: {
           type: "cf-harness.docs-corpus-record",
           source: "configured",
@@ -384,7 +389,10 @@ describe("query-docs", () => {
         allowedToolIds: ["query_docs"],
       });
 
-      const result = await loop.runPrompt({ prompt: "Look up glazing." });
+      const result = await loop.runPrompt({
+        prompt: "Look up glazing.",
+        promptSlotBinding: directPromptSlotBinding,
+      });
       expect(result.totalUsage?.totalTokens).toBe(12);
       const toolMessage = result.transcript.find((message) =>
         message.role === "tool"
@@ -465,7 +473,6 @@ describe("query-docs", () => {
           sandboxRuntime: new FakeSandboxRuntime(),
           runId: `query-docs-down-${crypto.randomUUID()}`,
           model: "test-model",
-          cfcEnforcementMode: "disabled",
           docsCorpus: {
             type: "cf-harness.docs-corpus-record",
             source: "configured",
@@ -476,7 +483,10 @@ describe("query-docs", () => {
         allowedToolIds: ["query_docs"],
       });
 
-      const result = await loop.runPrompt({ prompt: "Look up glazing." });
+      const result = await loop.runPrompt({
+        prompt: "Look up glazing.",
+        promptSlotBinding: directPromptSlotBinding,
+      });
 
       // The model reads a tool error and carries on, which is why the count is
       // the only place the run says its documentation channel was down.
@@ -550,7 +560,6 @@ describe("query-docs", () => {
           sandboxRuntime: new FakeSandboxRuntime(),
           runId: `query-docs-child-down-${crypto.randomUUID()}`,
           model: "test-model",
-          cfcEnforcementMode: "disabled",
           docsCorpus: {
             type: "cf-harness.docs-corpus-record",
             source: "configured",
@@ -562,7 +571,10 @@ describe("query-docs", () => {
         allowedSubagentProfiles: ["pattern-author"],
       });
 
-      const result = await loop.runPrompt({ prompt: "Delegate a lookup." });
+      const result = await loop.runPrompt({
+        prompt: "Delegate a lookup.",
+        promptSlotBinding: directPromptSlotBinding,
+      });
 
       // The delegation failed, so the success path never ran; the count still
       // reaches the parent, and exactly once.
@@ -720,7 +732,6 @@ describe("query-docs", () => {
       const engine = new CfHarnessEngine({
         sandboxRuntime: new FakeSandboxRuntime(),
         runId: `query-docs-default-${crypto.randomUUID()}`,
-        cfcEnforcementMode: "disabled",
       });
       engine.setExploreQueryRunner((request) =>
         Promise.resolve({
@@ -763,7 +774,6 @@ describe("query-docs", () => {
       const engine = new CfHarnessEngine({
         sandboxRuntime: new FakeSandboxRuntime(),
         runId: `query-docs-record-${crypto.randomUUID()}`,
-        cfcEnforcementMode: "disabled",
       });
 
       expect(engine.getRunState().docsCorpus).toEqual({
@@ -784,7 +794,6 @@ describe("query-docs", () => {
     const resumedEngine = (runState: Record<string, unknown>) =>
       new CfHarnessEngine({
         sandboxRuntime: new FakeSandboxRuntime(),
-        cfcEnforcementMode: "disabled",
         runState: {
           ...createHarnessRunState({
             runId: "run-resumed",

--- a/packages/cf-harness/test/record-feedback.test.ts
+++ b/packages/cf-harness/test/record-feedback.test.ts
@@ -83,7 +83,6 @@ const createEngine = (index?: IndexStub): CfHarnessEngine =>
   new CfHarnessEngine({
     sandboxRuntime: new FakeSandboxRuntime(),
     runId: `record-feedback-test-${crypto.randomUUID()}`,
-    cfcEnforcementMode: "disabled",
     ...(index === undefined ? {} : {
       patternIndexClientFactory: () =>
         Promise.resolve(

--- a/packages/cf-harness/test/run-end-cell-labels.test.ts
+++ b/packages/cf-harness/test/run-end-cell-labels.test.ts
@@ -66,7 +66,6 @@ const engineHolding = async (
     artifactRoot: join(directory, "runs"),
     runId,
     workspaceHostPath: join(directory, "workspace"),
-    cfcEnforcementMode: "disabled",
     fabricSession: fabricSession(directory),
     fabricSessionFactory: () =>
       Promise.reject(new Error("no fabric session is opened by these tests")),
@@ -169,7 +168,6 @@ describe("run-end cell labels", () => {
           artifactRoot: join(directory, "runs"),
           runId,
           workspaceHostPath: join(directory, "workspace"),
-          cfcEnforcementMode: "disabled",
         });
         await engine.recordHandleTable(
           (await mintAddressHandle(
@@ -199,7 +197,6 @@ describe("run-end cell labels", () => {
           artifactRoot: join(directory, "runs"),
           runId,
           workspaceHostPath: join(directory, "workspace"),
-          cfcEnforcementMode: "disabled",
           fabricSession: fabricSession(directory),
           fabricSessionFactory: () =>
             Promise.reject(

--- a/packages/cf-harness/test/run-lifecycle.test.ts
+++ b/packages/cf-harness/test/run-lifecycle.test.ts
@@ -9,8 +9,10 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { join } from "@std/path";
 import { normalize } from "@std/path/posix";
+import type { CfcSandboxResult } from "@commonfabric/runner/cfc";
 
 import { readHarnessRunState } from "../src/artifacts.ts";
+import { createCliPromptSlotBinding } from "../src/contracts/prompt-slot.ts";
 import { CAPABILITY_PROBE_SENTINEL } from "../src/diagnostics.ts";
 import { CfHarnessEngine } from "../src/engine.ts";
 import type { HarnessModelClient } from "../src/model/client.ts";
@@ -29,6 +31,28 @@ const SPACE_DID = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
 const FOREIGN_REF = `/@did:key:z6MkforeignSpaceForRunLifecycleTest/of:fid1:${
   "B".repeat(43)
 }/x`;
+
+/** The mediation metadata a CFC sandbox attaches to a command's output. */
+const mediated = (stdout: string): CfcSandboxResult => ({
+  version: 1,
+  stdout: {
+    channel: "stdout",
+    policy: "observed",
+    label: { confidentiality: ["public"] },
+    segments: [{ text: stdout, label: { confidentiality: ["public"] } }],
+  },
+  stderr: {
+    channel: "stderr",
+    policy: "observed",
+    label: { confidentiality: ["public"] },
+    segments: [{ text: "", label: { confidentiality: ["public"] } }],
+  },
+  exitCode: {
+    policy: "observed",
+    label: { confidentiality: ["public"] },
+    value: 0,
+  },
+});
 
 /** A sandbox that answers the capability probe and one canned shell result. */
 class FakeSandboxRuntime implements SandboxRuntime {
@@ -69,13 +93,27 @@ class FakeSandboxRuntime implements SandboxRuntime {
           stderr: "",
           exitCode: 0,
         }
-        : { stdout: "one\n", stderr: "", exitCode: 0 },
+        : {
+          stdout: "one\n",
+          stderr: "",
+          exitCode: 0,
+          cfcResult: mediated("one\n"),
+        },
     );
   }
 }
 
 const runStatePath = (artifactRoot: string, runId: string): string =>
   join(artifactRoot, runId, "run-state.json");
+
+/**
+ * The prompt slot the command line binds a typed prompt to. The effectful
+ * tool the model calls carries its authority from this binding.
+ */
+const directCommandSlot = createCliPromptSlotBinding({
+  kernelName: "cf-harness",
+  subject: "run-lifecycle",
+});
 
 const bashCallTurn = {
   assistant: {
@@ -122,7 +160,6 @@ const loopAfterOneToolCall = (
       sandboxRuntime: new FakeSandboxRuntime(),
       runId,
       model: "test-model",
-      cfcEnforcementMode: "disabled",
     }),
   });
   return { loop, seen };
@@ -155,7 +192,10 @@ describe("run-lifecycle", () => {
             }),
         );
 
-        await loop.runPrompt({ prompt: "run one command" });
+        await loop.runPrompt({
+          prompt: "run one command",
+          promptSlotBinding: directCommandSlot,
+        });
 
         expect(seen).toHaveLength(1);
         expect(seen[0].status).toBe("running");
@@ -183,7 +223,10 @@ describe("run-lifecycle", () => {
             ),
         );
 
-        await expect(loop.runPrompt({ prompt: "run one command" })).rejects
+        await expect(loop.runPrompt({
+          prompt: "run one command",
+          promptSlotBinding: directCommandSlot,
+        })).rejects
           .toThrow("model stream returned an error event");
 
         expect(seen[0].status).toBe("running");

--- a/packages/cf-harness/test/run-pattern-pattern-index.test.ts
+++ b/packages/cf-harness/test/run-pattern-pattern-index.test.ts
@@ -399,7 +399,6 @@ describe("run-pattern over the pattern index", () => {
     new CfHarnessEngine({
       sandboxRuntime: new FakeSandboxRuntime(),
       runId: `run-pattern-index-test-${crypto.randomUUID()}`,
-      cfcEnforcementMode: "disabled",
       fabricSessionFactory: () =>
         Promise.resolve({
           pieces: options.startFailure === undefined

--- a/packages/cf-harness/test/run-pattern-policy-trace.test.ts
+++ b/packages/cf-harness/test/run-pattern-policy-trace.test.ts
@@ -29,6 +29,7 @@ import {
   harnessReleaseDecisionOutcome,
 } from "../src/contracts/policy-refusal.ts";
 import type { HarnessPolicyTrace } from "../src/contracts/policy-trace.ts";
+import { createCliPromptSlotBinding } from "../src/contracts/prompt-slot.ts";
 import type { HarnessTranscriptOmissions } from "../src/contracts/transcript-omissions.ts";
 import { CAPABILITY_PROBE_SENTINEL } from "../src/diagnostics.ts";
 import { CfHarnessEngine } from "../src/engine.ts";
@@ -111,6 +112,10 @@ async function createStrictFabric() {
   const runtime = new Runtime({
     apiUrl: new URL("http://toolshed.test"),
     storageManager: storage,
+    // The rung and the label persistence the withheld release rests on. The
+    // seeded confidentiality reaches the pattern's read through the persisted
+    // labels, and the release boundary then refuses it, which is the
+    // `withheld` decision the test reads out of the policy trace.
     cfcEnforcementMode: "enforce-strict",
     cfcFlowLabels: "persist",
   });
@@ -222,18 +227,18 @@ describe("run_pattern release decisions in the policy trace", () => {
           sandboxRuntime: new FakeSandboxRuntime(),
           runId: "run-release-decision",
           model: "gpt-5.4",
-          // The harness's own ladder decides whether the CALL may run, and
-          // an enforcing rung there would refuse it for want of
-          // direct-command authority before the boundary under test ran. The
-          // release is decided by the fabric runtime's mode, which is
-          // `enforce-strict` above.
-          cfcEnforcementMode: "disabled",
           fabricSessionFactory: () => Promise.resolve({ pieces }),
         }),
         fetchFn,
       });
 
-      await loop.runPrompt({ prompt: "Run the pattern over the source." });
+      await loop.runPrompt({
+        prompt: "Run the pattern over the source.",
+        promptSlotBinding: createCliPromptSlotBinding({
+          kernelName: "cf-harness",
+          subject: "release-decisions",
+        }),
+      });
 
       const trace = JSON.parse(
         await Deno.readTextFile(

--- a/packages/cf-harness/test/run-pattern-publish-gate.test.ts
+++ b/packages/cf-harness/test/run-pattern-publish-gate.test.ts
@@ -277,7 +277,6 @@ describe("run_pattern publish render gate", () => {
     new CfHarnessEngine({
       sandboxRuntime: new FakeSandboxRuntime(),
       runId: `publish-gate-${crypto.randomUUID()}`,
-      cfcEnforcementMode: "disabled",
       fabricSessionFactory: () => Promise.resolve({ pieces, identity: signer }),
       patternIndexClientFactory: () =>
         Promise.resolve(
@@ -326,7 +325,6 @@ describe("run_pattern publish render gate", () => {
     const engine = new CfHarnessEngine({
       sandboxRuntime: new FakeSandboxRuntime(),
       runId: `publish-gate-${crypto.randomUUID()}`,
-      cfcEnforcementMode: "disabled",
       fabricSessionFactory: () => Promise.resolve({ pieces, identity: signer }),
     });
     expect(engine.patternIndexPublications).toBeUndefined();
@@ -358,7 +356,6 @@ describe("run_pattern publish render gate", () => {
     const engine = new CfHarnessEngine({
       sandboxRuntime: new FakeSandboxRuntime(),
       runId: `publish-gate-${crypto.randomUUID()}`,
-      cfcEnforcementMode: "disabled",
       fabricSessionFactory: () => Promise.resolve({ pieces, identity: signer }),
       patternIndexClientFactory: () =>
         Promise.resolve(
@@ -587,7 +584,6 @@ describe("run_pattern publish render gate", () => {
     new CfHarnessEngine({
       sandboxRuntime: new FakeSandboxRuntime(),
       runId: `publish-gate-${crypto.randomUUID()}`,
-      cfcEnforcementMode: "disabled",
       fabricSessionFactory: () => Promise.resolve({ pieces, identity }),
       patternIndexClientFactory: () =>
         Promise.resolve(
@@ -647,6 +643,8 @@ describe("run_pattern publish render gate", () => {
       cfcReadMaxConfidentiality: ["did:key:zOwner", "did:key:zFacet"],
       cfcReadOnExceed: "skip",
     });
+    // Registered before anything can throw: afterEach disposes it, and
+    // disposal closes the manager it owns.
     extraRuntimes.push(boundedRuntime);
     const boundedPieces = new PiecesController(
       await createSession({
@@ -658,41 +656,37 @@ describe("run_pattern publish render gate", () => {
     await boundedPieces.synced();
     const index = stubIndex();
     let probeCeiling: unknown = "never opened";
-    try {
-      const engine = new CfHarnessEngine({
-        sandboxRuntime: new FakeSandboxRuntime(),
-        runId: `publish-gate-${crypto.randomUUID()}`,
-        cfcEnforcementMode: "disabled",
-        fabricSessionFactory: () =>
-          Promise.resolve({ pieces: boundedPieces, identity: signer }),
-        patternIndexClientFactory: () =>
-          Promise.resolve(
-            new PatternIndexClient({
-              baseUrl: "https://index.test",
-              fetchFn: index.fetchFn,
-              signer,
-            }),
-          ),
-        openProbeRuntime: (_identity, _apiUrl, _mode, ceiling) => {
-          probeCeiling = ceiling;
-          return Promise.resolve(undefined);
-        },
-      });
-      const result = await engine.invokeBuiltinTool("run_pattern", {
-        sourceText: WORKING_SORTABLE_TABLE,
-        inputs: { rows: [{ name: "Avery", score: 12 }] },
-        description: "Sortable table that reads its cells",
-      });
-      const output = result.output as RunPatternToolSuccessOutput;
-      expect(output.status).toBe("ok");
-      expect(output.patternPublication?.reason).toBe("probe-failed");
-      expect(probeCeiling).toEqual({
-        cfcReadMaxConfidentiality: ["did:key:zOwner", "did:key:zFacet"],
-        cfcReadOnExceed: "skip",
-      });
-    } finally {
-      await boundedManager.close();
-    }
+    const engine = new CfHarnessEngine({
+      sandboxRuntime: new FakeSandboxRuntime(),
+      runId: `publish-gate-${crypto.randomUUID()}`,
+      cfcEnforcementMode: "disabled",
+      fabricSessionFactory: () =>
+        Promise.resolve({ pieces: boundedPieces, identity: signer }),
+      patternIndexClientFactory: () =>
+        Promise.resolve(
+          new PatternIndexClient({
+            baseUrl: "https://index.test",
+            fetchFn: index.fetchFn,
+            signer,
+          }),
+        ),
+      openProbeRuntime: (_identity, _apiUrl, _mode, ceiling) => {
+        probeCeiling = ceiling;
+        return Promise.resolve(undefined);
+      },
+    });
+    const result = await engine.invokeBuiltinTool("run_pattern", {
+      sourceText: WORKING_SORTABLE_TABLE,
+      inputs: { rows: [{ name: "Avery", score: 12 }] },
+      description: "Sortable table that reads its cells",
+    });
+    const output = result.output as RunPatternToolSuccessOutput;
+    expect(output.status).toBe("ok");
+    expect(output.patternPublication?.reason).toBe("probe-failed");
+    expect(probeCeiling).toEqual({
+      cfcReadMaxConfidentiality: ["did:key:zOwner", "did:key:zFacet"],
+      cfcReadOnExceed: "skip",
+    });
   });
 
   it("records without a verdict when the probe fails for its own reasons", async () => {
@@ -724,7 +718,6 @@ describe("run_pattern publish render gate", () => {
     const engine = new CfHarnessEngine({
       sandboxRuntime: new FakeSandboxRuntime(),
       runId: `publish-gate-${crypto.randomUUID()}`,
-      cfcEnforcementMode: "disabled",
       fabricSessionFactory: () => Promise.resolve({ pieces }),
       patternIndexClientFactory: () =>
         Promise.resolve(
@@ -753,25 +746,6 @@ describe("run_pattern publish render gate", () => {
     // compile cannot resolve it and every composed pattern comes back
     // uncertified. Nothing tested that branch, which is why the mode was
     // missing from it in the first place.
-    // Enforcing, not disabled: the content-addressed source cache a
-    // `cf:pattern:` import resolves from is only written under an enforcing
-    // mode, for the live run and the probe alike. A disabled-mode session
-    // cannot compile a composed source at all, so this is the mode the case
-    // exists in.
-    const enforcing = new Runtime({
-      apiUrl: new URL("http://toolshed.test"),
-      storageManager,
-      cfcEnforcementMode: "enforce-explicit",
-    });
-    extraRuntimes.push(enforcing);
-    const enforcingPieces = new PiecesController(
-      await createSession({
-        identity: signer,
-        spaceName: `publish-gate-cfc-${crypto.randomUUID()}`,
-      }),
-      enforcing,
-    );
-    await enforcingPieces.synced();
     const doublerId = await entryIdentityOf(DOUBLER);
     const index = stubIndex({
       [doublerId]: {
@@ -790,9 +764,7 @@ describe("run_pattern publish render gate", () => {
     const engine = new CfHarnessEngine({
       sandboxRuntime: new FakeSandboxRuntime(),
       runId: `publish-gate-${crypto.randomUUID()}`,
-      cfcEnforcementMode: "enforce-explicit",
-      fabricSessionFactory: () =>
-        Promise.resolve({ pieces: enforcingPieces, identity: signer }),
+      fabricSessionFactory: () => Promise.resolve({ pieces, identity: signer }),
       patternIndexClientFactory: () =>
         Promise.resolve(
           new PatternIndexClient({

--- a/packages/cf-harness/test/run-pattern.test.ts
+++ b/packages/cf-harness/test/run-pattern.test.ts
@@ -570,7 +570,6 @@ function createStrictEngine(pieces: PiecesController): CfHarnessEngine {
   return new CfHarnessEngine({
     sandboxRuntime: new FakeSandboxRuntime(),
     runId: `run-pattern-strict-${crypto.randomUUID()}`,
-    cfcEnforcementMode: "disabled",
     fabricSessionFactory: () => Promise.resolve({ pieces }),
   });
 }
@@ -707,7 +706,6 @@ describe("run-pattern", () => {
     return new CfHarnessEngine({
       sandboxRuntime: new FakeSandboxRuntime(),
       runId: `run-pattern-test-${crypto.randomUUID()}`,
-      cfcEnforcementMode: "disabled",
       fabricSessionFactory: () => Promise.resolve({ pieces, instantiations }),
     });
   }
@@ -799,7 +797,6 @@ describe("run-pattern", () => {
       const engine = new CfHarnessEngine({
         sandboxRuntime: new FakeSandboxRuntime(),
         runId: `run-pattern-test-${crypto.randomUUID()}`,
-        cfcEnforcementMode: "disabled",
         fabricSessionFactory: () => Promise.resolve({ pieces }),
       });
       const result = await engine.invokeBuiltinTool("run_pattern", {
@@ -1224,7 +1221,6 @@ describe("run-pattern", () => {
         const engine = new CfHarnessEngine({
           sandboxRuntime: new FakeSandboxRuntime(),
           runId: `run-pattern-strict-${crypto.randomUUID()}`,
-          cfcEnforcementMode: "disabled",
           fabricSessionFactory: () => Promise.resolve({ pieces: strictPieces }),
         });
         const result = await engine.invokeBuiltinTool("run_pattern", {
@@ -2608,7 +2604,6 @@ describe("run-pattern", () => {
       const engine = new CfHarnessEngine({
         sandboxRuntime: new FakeSandboxRuntime(),
         runId: `run-pattern-test-${crypto.randomUUID()}`,
-        cfcEnforcementMode: "disabled",
         fabricSessionFactory: () => {
           factoryCalls += 1;
           return Promise.reject(
@@ -2695,7 +2690,6 @@ describe("run-pattern", () => {
       const engine = new CfHarnessEngine({
         sandboxRuntime: new FakeSandboxRuntime(),
         runId: `run-pattern-test-${crypto.randomUUID()}`,
-        cfcEnforcementMode: "disabled",
       });
       const result = await engine.invokeBuiltinTool("run_pattern", {
         sourceText: DOUBLING_PATTERN_SOURCE,
@@ -2789,7 +2783,6 @@ describe("run-pattern", () => {
       const engine = new CfHarnessEngine({
         sandboxRuntime: new FakeSandboxRuntime(),
         runId: `run-pattern-test-${crypto.randomUUID()}`,
-        cfcEnforcementMode: "disabled",
         fabricSessionFactory: () => Promise.resolve({ pieces: readerPieces }),
       });
       const result = await engine.invokeBuiltinTool("run_pattern", {
@@ -2842,7 +2835,6 @@ describe("run-pattern", () => {
       const engine = new CfHarnessEngine({
         sandboxRuntime: new FakeSandboxRuntime(),
         runId: `run-pattern-test-${crypto.randomUUID()}`,
-        cfcEnforcementMode: "disabled",
         fabricSessionFactory: () => Promise.resolve({ pieces: readerPieces }),
       });
       const result = await engine.invokeBuiltinTool("run_pattern", {

--- a/packages/cf-harness/test/search-patterns.test.ts
+++ b/packages/cf-harness/test/search-patterns.test.ts
@@ -126,7 +126,6 @@ const createEngine = (index?: IndexStub): CfHarnessEngine =>
   new CfHarnessEngine({
     sandboxRuntime: new FakeSandboxRuntime(),
     runId: `search-patterns-test-${crypto.randomUUID()}`,
-    cfcEnforcementMode: "disabled",
     ...(index === undefined ? {} : {
       patternIndexClientFactory: () =>
         Promise.resolve(

--- a/packages/cf-harness/test/search-skills.test.ts
+++ b/packages/cf-harness/test/search-skills.test.ts
@@ -73,7 +73,6 @@ const createEngine = (configured = true): CfHarnessEngine =>
   new CfHarnessEngine({
     sandboxRuntime: new FakeSandboxRuntime(),
     runId: `search-skills-test-${crypto.randomUUID()}`,
-    cfcEnforcementMode: "disabled",
     ...(configured
       ? {
         skillsShSearchClientFactory: () =>
@@ -131,7 +130,6 @@ describe("search-skills", () => {
     const engine = new CfHarnessEngine({
       sandboxRuntime: new FakeSandboxRuntime(),
       runId: `search-skills-test-${crypto.randomUUID()}`,
-      cfcEnforcementMode: "disabled",
       skillsShSearchClientFactory: () =>
         Promise.reject(new Error("registry offline")),
     });

--- a/packages/cf-harness/test/subagent-fabric-posture.test.ts
+++ b/packages/cf-harness/test/subagent-fabric-posture.test.ts
@@ -23,6 +23,7 @@ import type {
   SandboxRuntimeDescription,
   SandboxShellRequest,
 } from "../src/sandbox/types.ts";
+import { directPromptSlotBindingFor } from "./support/prompt-slot-binding.ts";
 
 class FakeSandboxRuntime implements SandboxRuntime {
   describe(): SandboxRuntimeDescription {
@@ -77,6 +78,14 @@ const SESSION = {
   cfcPosture: "max-enforcement",
 } as const;
 
+/**
+ * The authority the prompt carries. `delegate_task` has an effect, so the
+ * enforcing modes admit it only from a prompt bound as a direct command.
+ */
+const directPromptSlotBinding = directPromptSlotBindingFor(
+  "subagent-fabric-posture",
+);
+
 const delegateCallTurn = (id: string, goal: string) => ({
   choices: [{
     index: 0,
@@ -129,7 +138,6 @@ describe("subagent fabric-session posture", () => {
           sandboxRuntime: new FakeSandboxRuntime(),
           runId,
           model: "gpt-5.4",
-          cfcEnforcementMode: "disabled",
           fabricSession: SESSION,
         }),
         fetchFn: scriptedFetch([
@@ -139,7 +147,10 @@ describe("subagent fabric-session posture", () => {
         ]),
       });
 
-      await loop.runPrompt({ prompt: "Delegate the inspection." });
+      await loop.runPrompt({
+        prompt: "Delegate the inspection.",
+        promptSlotBinding: directPromptSlotBinding,
+      });
 
       const parentState = await readHarnessRunState(
         join(artifactRoot, runId, "run-state.json"),

--- a/packages/cf-harness/test/support/prompt-slot-binding.ts
+++ b/packages/cf-harness/test/support/prompt-slot-binding.ts
@@ -1,0 +1,21 @@
+import { CFC_PROMPT_SLOT_BOUND_ATOM_TYPE } from "../../src/contracts/prompt-slot.ts";
+import type { PromptSlotBinding } from "../../src/contracts/prompt-slot.ts";
+
+/**
+ * A prompt slot bound as a direct command, named after the test that owns it.
+ * A tool call made under this binding is authorized at every enforcement rung.
+ *
+ * This module imports only the prompt-slot contract, so a test that needs a
+ * binding does not pull in a runtime, an identity or a storage manager.
+ */
+export const directPromptSlotBindingFor = (
+  subject: string,
+): PromptSlotBinding => ({
+  type: CFC_PROMPT_SLOT_BOUND_ATOM_TYPE,
+  source: { type: "test.prompt-slot", subject },
+  role: "direct-command",
+  kernelName: "cf-harness",
+  surface: "test",
+  subject,
+  eventId: `event-${subject}`,
+});

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -4054,8 +4054,6 @@ describe("call over a live runtime", () => {
     runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "observe",
-      cfcFlowLabels: "persist",
       errorHandlers: [
         (error) => runtimeErrors.push({ message: error.message }),
       ],

--- a/packages/cli/test/piece-get-transform.test.ts
+++ b/packages/cli/test/piece-get-transform.test.ts
@@ -38,8 +38,6 @@ describe("cf cell get transforms", () => {
     runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "observe",
-      cfcFlowLabels: "persist",
       errorHandlers: [
         (error) => runtimeErrors.push({ message: error.message }),
       ],
@@ -2055,118 +2053,143 @@ describe("cf cell get transforms", () => {
     }
   });
 
-  it("carries predicate labels on filtered membership like a pattern", async () => {
-    await seedLabeledDoc(runtime, "filter-element-a", {
-      id: 1,
-      status: "open",
-    }, "alice-secret");
-    await seedLabeledDoc(runtime, "filter-element-b", {
-      id: 2,
-      status: "closed",
-    }, "bob-secret");
+  describe("the labels a selection carries", () => {
+    // The two assertions here read a derived label component back out of
+    // storage through `derivedConfidentiality`. Persisting flow labels
+    // writes that component. It reaches a probe document that declares no
+    // ceiling of its own at the enforcement rungs where the writer-fit rule
+    // measures a written value's taint, which is every rung below
+    // `enforce-strict`.
+    let measuring: Runtime;
 
-    const setup = runtime.edit();
-    const elementA = runtime.getCell(
-      space,
-      "filter-element-a",
-      undefined,
-      setup,
-    );
-    const elementB = runtime.getCell(
-      space,
-      "filter-element-b",
-      undefined,
-      setup,
-    );
-    const source = runtime.getCell(
-      space,
-      "labeled-filter-source",
-      { type: "array", items: { asCell: ["cell"] } },
-      setup,
-    );
-    source.set([elementA, elementB]);
-    expect((await setup.commit()).ok).toBeDefined();
-    const sourceRead = runtime.getCell(
-      space,
-      "labeled-filter-source",
-      { type: "array", items: { asCell: ["cell"] } },
-    );
-
-    let outputCell: Cell<unknown> | undefined;
-    const result = await deriveSelectedValue(runtime, space, sourceRead, {
-      filter: parseSelectionFilter('.status == "open"'),
-    }, {
-      onOutputCell: (cell) => outputCell = cell,
+    beforeEach(() => {
+      measuring = new Runtime({
+        apiUrl: new URL("https://example.com"),
+        storageManager,
+        cfcEnforcementMode: "enforce-explicit",
+        cfcFlowLabels: "persist",
+      });
     });
-    expect(result).toEqual([{ id: 1, status: "open" }]);
 
-    const probeTx = runtime.edit();
-    const kept = outputCell!.withTx(probeTx).get() as unknown[];
-    const probe = runtime.getCell(
-      space,
-      "filter-membership-probe",
-      undefined,
-      probeTx,
-    );
-    probe.set({ count: kept.length });
-    probeTx.prepareCfc();
-    expect((await probeTx.commit()).ok).toBeDefined();
+    afterEach(async () => {
+      await measuring.dispose();
+    });
 
-    const labels = derivedConfidentiality(
-      probe.getAsNormalizedFullLink().id,
-    );
-    expect(labels).toContain("alice-secret");
-    expect(labels).toContain("bob-secret");
-  });
+    it("carries predicate labels on filtered membership like a pattern", async () => {
+      await seedLabeledDoc(measuring, "filter-element-a", {
+        id: 1,
+        status: "open",
+      }, "alice-secret");
+      await seedLabeledDoc(measuring, "filter-element-b", {
+        id: 2,
+        status: "closed",
+      }, "bob-secret");
 
-  it("derives projected field labels from source CFC metadata", async () => {
-    const setup = runtime.edit();
-    const source = runtime.getCell(
-      space,
-      "static-label-projection-source",
-      {
-        type: "array",
-        items: {
-          type: "object",
-          properties: {
-            id: {
-              type: "number",
-              ifc: { confidentiality: ["source-secret"] },
+      const setup = measuring.edit();
+      const elementA = measuring.getCell(
+        space,
+        "filter-element-a",
+        undefined,
+        setup,
+      );
+      const elementB = measuring.getCell(
+        space,
+        "filter-element-b",
+        undefined,
+        setup,
+      );
+      const source = measuring.getCell(
+        space,
+        "labeled-filter-source",
+        { type: "array", items: { asCell: ["cell"] } },
+        setup,
+      );
+      source.set([elementA, elementB]);
+      setup.prepareCfc();
+      expect((await setup.commit()).ok).toBeDefined();
+      const sourceRead = measuring.getCell(
+        space,
+        "labeled-filter-source",
+        { type: "array", items: { asCell: ["cell"] } },
+      );
+
+      let outputCell: Cell<unknown> | undefined;
+      const result = await deriveSelectedValue(measuring, space, sourceRead, {
+        filter: parseSelectionFilter('.status == "open"'),
+      }, {
+        onOutputCell: (cell) => outputCell = cell,
+      });
+      expect(result).toEqual([{ id: 1, status: "open" }]);
+
+      const probeTx = measuring.edit();
+      const kept = outputCell!.withTx(probeTx).get() as unknown[];
+      const probe = measuring.getCell(
+        space,
+        "filter-membership-probe",
+        undefined,
+        probeTx,
+      );
+      probe.set({ count: kept.length });
+      probeTx.prepareCfc();
+      expect((await probeTx.commit()).ok).toBeDefined();
+
+      const labels = derivedConfidentiality(
+        probe.getAsNormalizedFullLink().id,
+      );
+      expect(labels).toContain("alice-secret");
+      expect(labels).toContain("bob-secret");
+    });
+
+    it("derives projected field labels from source CFC metadata", async () => {
+      const setup = measuring.edit();
+      const source = measuring.getCell(
+        space,
+        "static-label-projection-source",
+        {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              id: {
+                type: "number",
+                ifc: { confidentiality: ["source-secret"] },
+              },
+              ignored: { type: "string" },
             },
-            ignored: { type: "string" },
           },
         },
-      },
-      setup,
-    );
-    source.set([{ id: 7, ignored: "not returned" }]);
-    expect((await setup.commit()).ok).toBeDefined();
+        setup,
+      );
+      source.set([{ id: 7, ignored: "not returned" }]);
+      setup.prepareCfc();
+      expect((await setup.commit()).ok).toBeDefined();
 
-    let outputCell: Cell<unknown> | undefined;
-    const result = await deriveSelectedValue(runtime, space, source, {
-      projection: await parseSelectionProjection("id"),
-    }, {
-      onOutputCell: (cell) => outputCell = cell,
+      let outputCell: Cell<unknown> | undefined;
+      const result = await deriveSelectedValue(measuring, space, source, {
+        projection: await parseSelectionProjection("id"),
+      }, {
+        onOutputCell: (cell) => outputCell = cell,
+      });
+      expect(result).toEqual([{ id: 7 }]);
+
+      const probeTx = measuring.edit();
+      const projectedId = outputCell!.key(0).key("id").withTx(
+        probeTx,
+      ).get();
+      const probe = measuring.getCell(
+        space,
+        "projection-label-probe",
+        undefined,
+        probeTx,
+      );
+      probe.set({ projectedId });
+      probeTx.prepareCfc();
+      expect((await probeTx.commit()).ok).toBeDefined();
+
+      expect(derivedConfidentiality(
+        probe.getAsNormalizedFullLink().id,
+      )).toContain("source-secret");
     });
-    expect(result).toEqual([{ id: 7 }]);
-
-    const probeTx = runtime.edit();
-    const projectedId = outputCell!.key(0).key("id").withTx(
-      probeTx,
-    ).get();
-    const probe = runtime.getCell(
-      space,
-      "projection-label-probe",
-      undefined,
-      probeTx,
-    );
-    probe.set({ projectedId });
-    probeTx.prepareCfc();
-    expect((await probeTx.commit()).ok).toBeDefined();
-
-    expect(derivedConfidentiality(
-      probe.getAsNormalizedFullLink().id,
-    )).toContain("source-secret");
   });
 
   async function seedLabeledDoc(
@@ -3402,8 +3425,6 @@ describe("cf cell get transforms", () => {
       const second = new Runtime({
         apiUrl: new URL("https://example.com"),
         storageManager,
-        cfcEnforcementMode: "observe",
-        cfcFlowLabels: "persist",
       });
       try {
         const sourceThere = second.getCell(

--- a/packages/cli/test/piece-label.test.ts
+++ b/packages/cli/test/piece-label.test.ts
@@ -46,8 +46,6 @@ describe("cf piece CFC labels", () => {
     runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
-      cfcDeclaredMonotonicity: "enforce",
     });
     root = runtime.getCell<{ body: string }>(
       signer.did(),

--- a/packages/cli/test/projection-key-classification.test.ts
+++ b/packages/cli/test/projection-key-classification.test.ts
@@ -98,8 +98,6 @@ describe("projection-key-classification", () => {
     runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "observe",
-      cfcFlowLabels: "persist",
       errorHandlers: [() => {}],
     });
   });

--- a/packages/connectors/agents/connector/test/fabric-graph_test.ts
+++ b/packages/connectors/agents/connector/test/fabric-graph_test.ts
@@ -436,6 +436,10 @@ Deno.test("stable graph field writes preserve document metadata", async () => {
       },
       { preserved: true },
     );
+    // A manual test tx goes through the same preparation the runtime's own
+    // commit paths do: a document-root write is CFC-relevant, and an
+    // enforcing rung refuses a relevant transaction that arrives unprepared.
+    runtime.prepareTxForCommit(metadataTx);
     const metadataCommit = await metadataTx.commit();
     if (metadataCommit.error) throw metadataCommit.error;
 

--- a/packages/html/test/worker-reconciler-cell-props.test.ts
+++ b/packages/html/test/worker-reconciler-cell-props.test.ts
@@ -41,7 +41,6 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
   const runtime = new Runtime({
     storageManager,
     apiUrl: new URL("http://localhost"),
-    cfcEnforcementMode: "observe",
   });
 
   try {
@@ -994,6 +993,7 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
           },
           children: [],
         });
+        runtime.prepareTxForCommit(tx);
         const commitResult = await tx.commit();
         assertEquals(commitResult.ok !== undefined, true);
 
@@ -1074,6 +1074,7 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
           props: {},
           children: [linkedChild.getAsLink({ keepAsCell: KeepAsCell.All })],
         });
+        runtime.prepareTxForCommit(tx);
         const commitResult = await tx.commit();
         assertEquals(commitResult.ok !== undefined, true);
 
@@ -1142,6 +1143,7 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
             ],
           }],
         });
+        runtime.prepareTxForCommit(tx);
         const commitResult = await tx.commit();
         assertEquals(commitResult.ok !== undefined, true);
 
@@ -1518,7 +1520,6 @@ Deno.test(
     const runtime = new Runtime({
       storageManager,
       apiUrl: new URL("http://localhost"),
-      cfcEnforcementMode: "observe",
     });
     let tx = runtime.edit();
 

--- a/packages/lib-shell/test/runtime.test.ts
+++ b/packages/lib-shell/test/runtime.test.ts
@@ -856,6 +856,8 @@ describe("RuntimeInternals", () => {
     const options = createRuntimeClientOptions({
       session,
       apiUrl: new URL("http://shell.test/"),
+      // The assertions below read `options.cfcEnforcementMode` and
+      // `options.cfcFlowLabels` back as these values.
       cfcEnforcementMode: "observe",
       cfcFlowLabels: "off",
       trustSnapshot,

--- a/packages/patterns/integration/capability-gate-controller.ts
+++ b/packages/patterns/integration/capability-gate-controller.ts
@@ -15,7 +15,6 @@ export async function initializeCapabilityGateController(
     ),
     storageManager: StorageManager.emulate({ as: session.as }),
     moduleByteCache,
-    cfcEnforcementMode: "enforce-explicit",
     trustSnapshotProvider: () => ({
       id: `principal:${session.as.did()}`,
       actingPrincipal: session.as.did(),

--- a/packages/patterns/integration/cell-flip-shaping.test.ts
+++ b/packages/patterns/integration/cell-flip-shaping.test.ts
@@ -27,7 +27,6 @@ describe("cell-flip shaping (plan B)", () => {
     const runtime = new Runtime({
       apiUrl: new URL("http://localhost:8000/"),
       storageManager: StorageManager.emulate({ as: session.as }),
-      cfcEnforcementMode: "enforce-explicit",
       trustSnapshotProvider: () => ({
         id: `principal:${session.as.did()}`,
         actingPrincipal: session.as.did(),

--- a/packages/patterns/integration/time-capability-intrinsics.test.ts
+++ b/packages/patterns/integration/time-capability-intrinsics.test.ts
@@ -21,7 +21,6 @@ async function makeController(
   const runtime = new Runtime({
     apiUrl: new URL("http://localhost:8000/"),
     storageManager: StorageManager.emulate({ as: session.as }),
-    cfcEnforcementMode: "enforce-explicit",
     trustSnapshotProvider: () => ({
       id: `principal:${session.as.did()}`,
       actingPrincipal: session.as.did(),

--- a/packages/piece/test/piece-origin.test.ts
+++ b/packages/piece/test/piece-origin.test.ts
@@ -988,6 +988,7 @@ describe("reading a piece's source state", () => {
       origin: DEFAULT_APP_PATTERN_PATH,
       expected,
     });
+    runtime.prepareTxForCommit(tx);
     await tx.commit();
 
     const state = await readPieceSourceState(runtime, cell);

--- a/packages/piece/test/setsrc-module-delegation.test.ts
+++ b/packages/piece/test/setsrc-module-delegation.test.ts
@@ -66,7 +66,6 @@ describe("setsrc module delegation", () => {
     runtime = new Runtime({
       apiUrl: new URL("http://toolshed.test"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     const session = await createSession({
       identity: signer,
@@ -135,7 +134,6 @@ describe("setsrc module delegation", () => {
         const freshRuntime = new Runtime({
           apiUrl: new URL("http://toolshed.test"),
           storageManager,
-          cfcEnforcementMode: "enforce-explicit",
         });
         // Runtime.dispose() closes the shared emulated storage manager, so all
         // cold-start runtimes stay alive until the assertions are complete.

--- a/packages/runner/test/cell-cache.test.ts
+++ b/packages/runner/test/cell-cache.test.ts
@@ -856,7 +856,6 @@ describe("cell-cache: compiled-set store (CFC integrity, fail-closed)", () => {
     runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
       trustSnapshotProvider: () => ({
         id: "cell-cache-test",
         actingPrincipal: signer.did(),
@@ -1895,7 +1894,6 @@ describe("cell-cache: compiled-set store (CFC integrity, fail-closed)", () => {
     const coverageRuntime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: coverageStorageManager,
-      cfcEnforcementMode: "enforce-explicit",
       trustSnapshotProvider: () => ({
         id: "cell-cache-coverage-replication-test",
         actingPrincipal: signer.did(),
@@ -2340,7 +2338,6 @@ describe("cell-cache: two-identity shared-space compile cache (e2e)", () => {
     rtA = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: smA,
-      cfcEnforcementMode: "enforce-explicit",
       trustSnapshotProvider: () => ({
         id: "e2e-user-a",
         actingPrincipal: e2eSignerA.did(),
@@ -2349,7 +2346,6 @@ describe("cell-cache: two-identity shared-space compile cache (e2e)", () => {
     rtB = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: smB,
-      cfcEnforcementMode: "enforce-explicit",
       trustSnapshotProvider: () => ({
         id: "e2e-user-b",
         actingPrincipal: e2eSignerB.did(),

--- a/packages/runner/test/cell-callbacks.test.ts
+++ b/packages/runner/test/cell-callbacks.test.ts
@@ -164,7 +164,6 @@ describe("Cell commit callbacks", () => {
     runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     tx = runtime.edit();
 

--- a/packages/runner/test/cfc-additive-default-preserves-old-doc.test.ts
+++ b/packages/runner/test/cfc-additive-default-preserves-old-doc.test.ts
@@ -19,9 +19,11 @@ import type { JSONSchema, JSONSchemaObj } from "../src/builder/types.ts";
 // provenance: setup rewrites the complete generated result, while ordinary
 // document paths must still preserve older values.
 //
-// These tests run with CFC enforcement ON (the runtime default,
-// "enforce-explicit"); the piece cold-start harness runs with enforcement
-// disabled, which is why #4926/#4933's tests were blind to this layer.
+// These tests take the CFC enforcement rung the runtime carries. The
+// additive-required guard runs inside schema merge, which every enforcing rung
+// reaches before its own checks, so the setup commit's fate is the same across
+// them. The piece cold-start harness runs with enforcement disabled, which is
+// why #4926/#4933's tests were blind to this layer.
 
 const alice = await Identity.fromPassphrase(
   "cfc-additive-default-preserves-old-doc-alice",
@@ -148,7 +150,6 @@ describe("CFC additive-required default preserves old documents", () => {
       //    favorites and the handlers.
       {
         const tx = runtime.edit();
-        tx.setCfcEnforcementMode("enforce-explicit");
         tx.setCfcTrustSnapshot({
           id: `trust-${space}`,
           actingPrincipal: space,
@@ -185,8 +186,7 @@ describe("CFC additive-required default preserves old documents", () => {
         expect(res.ok).toBeDefined();
       }
 
-      // 2. Materialize the real home pattern over the SAME root cell
-      //    (enforce-explicit is the runtime default).
+      // 2. Materialize the real home pattern over the SAME root cell.
       const homePattern = await compileHomePattern(runtime, space);
       const resultCell = runtime.getCell(space, ROOT);
       const home = await runtime.runSynced(resultCell, homePattern, {});
@@ -224,7 +224,6 @@ describe("CFC additive-required default preserves old documents", () => {
     const space = alice.did();
     const ROOT = "legacy-home-root-reject";
     const seedMeta = (tx: ReturnType<typeof runtime.edit>) => {
-      tx.setCfcEnforcementMode("enforce-explicit");
       tx.setCfcTrustSnapshot({ id: `trust-${space}`, actingPrincipal: space });
       tx.setCfcImplementationIdentity({
         kind: "builtin",

--- a/packages/runner/test/cfc-agent-prompt-injection-demo.test.ts
+++ b/packages/runner/test/cfc-agent-prompt-injection-demo.test.ts
@@ -159,7 +159,6 @@ async function setupDemoAgent(
   const runtime = new Runtime({
     apiUrl: new URL(import.meta.url),
     storageManager,
-    cfcEnforcementMode: "enforce-explicit",
   });
 
   // Play the agent kernel binding the direct user command BEFORE the agent

--- a/packages/runner/test/cfc-agent-tool-input-integrity.test.ts
+++ b/packages/runner/test/cfc-agent-tool-input-integrity.test.ts
@@ -457,7 +457,6 @@ describe("CFC trusted agent: tool-input requiredIntegrity (Epic D2)", () => {
     const runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     const tx = runtime.edit();
     const { commonfabric } = createTrustedBuilder(runtime);
@@ -567,7 +566,6 @@ describe("CFC trusted agent: tool-input requiredIntegrity (Epic D2)", () => {
     const runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     const tx = runtime.edit();
     const { commonfabric } = createTrustedBuilder(runtime);
@@ -680,7 +678,6 @@ describe("CFC trusted agent: tool-input requiredIntegrity (Epic D2)", () => {
     const runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     const tx = runtime.edit();
     const { commonfabric } = createTrustedBuilder(runtime);
@@ -792,7 +789,6 @@ describe("CFC trusted agent: tool-input requiredIntegrity (Epic D2)", () => {
     const runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     const tx = runtime.edit();
     const { commonfabric } = createTrustedBuilder(runtime);
@@ -890,7 +886,6 @@ describe("CFC trusted agent: tool-input requiredIntegrity (Epic D2)", () => {
     const runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     const tx = runtime.edit();
     const { commonfabric } = createTrustedBuilder(runtime);
@@ -997,7 +992,6 @@ describe("CFC trusted agent: floors behind reference-form schemas (D2)", () => {
   const runtime = new Runtime({
     apiUrl: new URL(import.meta.url),
     storageManager,
-    cfcEnforcementMode: "enforce-explicit",
   });
   const gate = (schema: unknown, value: unknown) =>
     llmToolExecutionHelpers.toolInputRequiredIntegrityFailure(

--- a/packages/runner/test/cfc-array-shrink-slot-labels.test.ts
+++ b/packages/runner/test/cfc-array-shrink-slot-labels.test.ts
@@ -99,7 +99,14 @@ describe("CFC: array shrink clears truncated slots' link labels", () => {
     runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
+      // At this rung the writer-fit check flags a tainted write to a store
+      // that declares no ceiling and lets it land. This list declares none,
+      // and the closing `length` assertion reads back the label that write
+      // persisted.
       cfcEnforcementMode: "observe",
+      // Persisting flow labels is what puts the per-slot link entries and the
+      // derived `length` entry in the document. Every assertion here reads
+      // one of them.
       cfcFlowLabels: "persist",
     });
 

--- a/packages/runner/test/cfc-authoring-observe.test.ts
+++ b/packages/runner/test/cfc-authoring-observe.test.ts
@@ -106,6 +106,9 @@ describe("CFC authoring surface trust-sensitive claims", () => {
       const runtime = new Runtime({
         apiUrl: new URL("https://example.com"),
         storageManager,
+        // The assertion below is that a matching binding identity is
+        // admitted. Only an enforcing rung decides that; a weaker one admits
+        // the claim with a diagnostic and the assertion holds either way.
         cfcEnforcementMode: "enforce-explicit",
         trustSnapshotProvider: () => ({
           id: "trust-snapshot-1",

--- a/packages/runner/test/cfc-boundary.test.ts
+++ b/packages/runner/test/cfc-boundary.test.ts
@@ -26,8 +26,10 @@ import {
   preparedDigestFor,
 } from "../src/cfc/mod.ts";
 import {
+  CFC_STRUCTURAL_PROVENANCE_RUNTIME_OWNED_STORE,
   CFC_STRUCTURAL_PROVENANCE_SETUP_PROJECTION,
   type CfcEnforcementMode,
+  runtimeWritePolicyAuthorization,
 } from "../src/cfc/types.ts";
 import { diffAndUpdate } from "../src/data-updating.ts";
 import {
@@ -305,6 +307,22 @@ describe("CFC canonicalization helpers", () => {
 });
 
 describe("ExtendedStorageTransaction CFC gate", () => {
+  // Characterization posture: the cases below describe what the gate does at
+  // the explicit rung with every other dial down, so the suite states that
+  // whole row rather than reaching it by inheritance. Every dial in
+  // RUNTIME_CFC_DIAL_DEFAULTS appears here; a mode passed by a test overrides
+  // the enforcement mode.
+  const characterizationCfcPosture = {
+    cfcEnforcementMode: "enforce-explicit",
+    cfcFlowLabels: "off",
+    cfcWriteFloor: "off",
+    cfcTriggerReadGating: false,
+    cfcDecomposedEnvelopes: false,
+    cfcPolicyEvaluation: "off",
+    cfcLabelMetadataProtection: "off",
+    cfcDeclaredMonotonicity: "off",
+  } as const;
+
   const createRuntime = (cfcEnforcementMode?: CfcEnforcementMode) => {
     const storageManager = StorageManager.emulate({
       as: signer,
@@ -312,6 +330,7 @@ describe("ExtendedStorageTransaction CFC gate", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
+      ...characterizationCfcPosture,
       ...(cfcEnforcementMode ? { cfcEnforcementMode } : {}),
     });
     return { runtime, storageManager };
@@ -324,7 +343,7 @@ describe("ExtendedStorageTransaction CFC gate", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
+      ...characterizationCfcPosture,
       trustSnapshotProvider: () => ({
         id: "trust-snapshot-setup",
         actingPrincipal: signer.did(),
@@ -415,7 +434,7 @@ describe("ExtendedStorageTransaction CFC gate", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
+      ...characterizationCfcPosture,
       trustSnapshotProvider: () => ({
         id: "trust-snapshot-setup-untyped",
         actingPrincipal: signer.did(),
@@ -505,7 +524,7 @@ describe("ExtendedStorageTransaction CFC gate", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
+      ...characterizationCfcPosture,
       trustSnapshotProvider: () => ({
         id: "trust-snapshot-setup",
         actingPrincipal: signer.did(),
@@ -571,7 +590,7 @@ describe("ExtendedStorageTransaction CFC gate", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
+      ...characterizationCfcPosture,
       trustSnapshotProvider: () => ({
         id: "trust-snapshot-setup-forged-projection",
         actingPrincipal: signer.did(),
@@ -639,7 +658,7 @@ describe("ExtendedStorageTransaction CFC gate", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
+      ...characterizationCfcPosture,
     });
     try {
       const tx = runtime.edit();
@@ -695,7 +714,7 @@ describe("ExtendedStorageTransaction CFC gate", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
+      ...characterizationCfcPosture,
       trustSnapshotProvider: () => ({
         id: "trust-snapshot-argument-setup",
         actingPrincipal: signer.did(),
@@ -2260,10 +2279,12 @@ describe("ExtendedStorageTransaction CFC gate", () => {
     const runtimeA = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager: storageManagerA,
+      ...characterizationCfcPosture,
     });
     const runtimeB = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager: storageManagerB,
+      ...characterizationCfcPosture,
     });
     const schema = {
       type: "object",
@@ -2799,7 +2820,6 @@ describe("ExtendedStorageTransaction CFC gate", () => {
     const { runtime, storageManager } = createRuntime();
     try {
       const seed = runtime.edit();
-      seed.setCfcEnforcementMode("enforce-explicit");
       const target = runtime.getCell(
         signer.did(),
         "cfc-link-same-tx-source-target",
@@ -2814,7 +2834,6 @@ describe("ExtendedStorageTransaction CFC gate", () => {
       expect((await seed.commit()).ok).toBeDefined();
 
       const tx = runtime.edit();
-      tx.setCfcEnforcementMode("enforce-explicit");
       const sameTxSource = runtime.getCell(
         signer.did(),
         "cfc-link-same-tx-source",
@@ -2829,6 +2848,27 @@ describe("ExtendedStorageTransaction CFC gate", () => {
         tx,
       );
       linkedTarget.set(sameTxSource);
+      // The marker `data-updating` records for the child document it splits an
+      // entry into: the child is the runtime's store, filled out of what this
+      // transaction read.
+      const sourceLink = sameTxSource.getAsNormalizedFullLink();
+      const targetLink = linkedTarget.getAsNormalizedFullLink();
+      tx.recordCfcWritePolicyInput({
+        kind: "structural-provenance",
+        target: {
+          space: sourceLink.space,
+          id: sourceLink.id,
+          scope: sourceLink.scope,
+          path: [],
+        },
+        claim: CFC_STRUCTURAL_PROVENANCE_RUNTIME_OWNED_STORE,
+        sources: [{
+          space: targetLink.space,
+          id: targetLink.id,
+          scope: targetLink.scope,
+          path: [],
+        }],
+      }, runtimeWritePolicyAuthorization);
       tx.prepareCfc();
       const result = await tx.commit();
       expect(result.error).toBeUndefined();
@@ -4288,6 +4328,7 @@ describe("ExtendedStorageTransaction CFC gate", () => {
     const runtime1 = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
+      ...characterizationCfcPosture,
     });
     try {
       const firstTx = runtime1.edit();
@@ -4318,6 +4359,7 @@ describe("ExtendedStorageTransaction CFC gate", () => {
       const runtime2 = new Runtime({
         apiUrl: new URL("https://example.com"),
         storageManager,
+        ...characterizationCfcPosture,
       });
       try {
         const secondTx = runtime2.edit();
@@ -4380,6 +4422,7 @@ describe("ExtendedStorageTransaction CFC gate", () => {
     const runtime1 = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager: storageManager1,
+      ...characterizationCfcPosture,
     });
     const cellSchema = {
       type: "object",
@@ -4414,6 +4457,7 @@ describe("ExtendedStorageTransaction CFC gate", () => {
     const runtime2 = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager: storageManager2,
+      ...characterizationCfcPosture,
     });
     try {
       const secondSchema = {
@@ -4462,6 +4506,7 @@ describe("ExtendedStorageTransaction CFC gate", () => {
     const runtime1 = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager: storageManager1,
+      ...characterizationCfcPosture,
     });
     const cellSchema = {
       type: "object",
@@ -4502,6 +4547,7 @@ describe("ExtendedStorageTransaction CFC gate", () => {
     const runtime2 = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager: storageManager2,
+      ...characterizationCfcPosture,
     });
     try {
       const secondSchema = {

--- a/packages/runner/test/cfc-ceiling-empty.test.ts
+++ b/packages/runner/test/cfc-ceiling-empty.test.ts
@@ -41,6 +41,8 @@ describe("prepare maxConfidentiality empty ceiling", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
+      // The single assertion below is that the write is rejected with
+      // "maxConfidentiality failed", and only an enforcing rung aborts it.
       cfcEnforcementMode: "enforce-explicit",
     });
     try {

--- a/packages/runner/test/cfc-clause-authoring.test.ts
+++ b/packages/runner/test/cfc-clause-authoring.test.ts
@@ -39,7 +39,6 @@ describe("CFC authored disjunctive confidentiality", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     try {
       const schema = {
@@ -90,7 +89,6 @@ describe("CFC authored disjunctive confidentiality", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     try {
       const schema = {
@@ -170,7 +168,6 @@ describe("CFC authored disjunctive confidentiality", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     try {
       const schema = {
@@ -195,7 +192,6 @@ describe("CFC authored disjunctive confidentiality", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     try {
       const caveat = {
@@ -260,7 +256,6 @@ describe("CFC authored disjunctive confidentiality", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     try {
       const expires = {

--- a/packages/runner/test/cfc-concept-floor.test.ts
+++ b/packages/runner/test/cfc-concept-floor.test.ts
@@ -20,7 +20,6 @@ import {
   type CfcTrustConfigInput,
   createTrustResolver,
 } from "../src/cfc/trust.ts";
-import type { CfcEnforcementMode } from "../src/cfc/types.ts";
 import { createLLMFriendlyLink } from "../src/link-types.ts";
 import { Runtime } from "../src/runtime.ts";
 import { StorageManager } from "../src/storage/cache.deno.ts";
@@ -336,7 +335,6 @@ describe("CFC concept-level integrity floors (D5)", () => {
       const runtime = new Runtime({
         apiUrl: new URL("https://example.com"),
         storageManager,
-        cfcEnforcementMode: "enforce-explicit",
         ...(trust ? { cfcTrustConfig: trust } : {}),
       });
       try {
@@ -365,8 +363,20 @@ describe("CFC concept-level integrity floors (D5)", () => {
           "concept-sink",
           {
             type: "object",
+            // The sink holds a value derived from the sources. It declares
+            // the confidentiality those sources carry.
+            ifc: { confidentiality: ["s"] },
             properties: {
-              out: { type: "string", ifc: { requiredIntegrity: [required] } },
+              // The write mints the integrity its sources carry. That
+              // leaves the read-side gate as the only thing deciding these
+              // commits.
+              out: {
+                type: "string",
+                ifc: {
+                  requiredIntegrity: [required],
+                  addIntegrity: sources.flat(),
+                },
+              },
             },
             required: ["out"],
           } as JSONSchema,
@@ -443,7 +453,8 @@ describe("CFC concept-level integrity floors (D5)", () => {
       const runtime = new Runtime({
         apiUrl: new URL("https://example.com"),
         storageManager,
-        cfcEnforcementMode: "enforce-explicit",
+        // Two of the cases below assert the message "write floor failed".
+        // An enforcing write floor is what produces it.
         cfcWriteFloor: "enforce",
         ...(trust ? { cfcTrustConfig: trust } : {}),
       });
@@ -507,16 +518,12 @@ describe("CFC concept-level integrity floors (D5)", () => {
   describe("tool-input floor integration (llm-dialog, Epic D2)", () => {
     const KERNEL_CONCEPT_FLOOR = concept(GPS_CONCEPT);
 
-    async function setup(
-      cfcEnforcementMode: CfcEnforcementMode,
-      trust: CfcTrustConfigInput | undefined,
-    ) {
+    async function setup(trust: CfcTrustConfigInput | undefined) {
       const space = signer.did();
       const storageManager = StorageManager.emulate({ as: signer });
       const runtime = new Runtime({
         apiUrl: new URL(import.meta.url),
         storageManager,
-        cfcEnforcementMode,
         ...(trust ? { cfcTrustConfig: trust } : {}),
       });
       const tx = runtime.edit();
@@ -597,7 +604,7 @@ describe("CFC concept-level integrity floors (D5)", () => {
 
       const resultCell = runtime.getCell(
         space,
-        `concept-tool-${cfcEnforcementMode}-${trust ? "trust" : "notrust"}`,
+        `concept-tool-${trust ? "trust" : "notrust"}`,
         resultSchema,
         tx,
       );
@@ -680,7 +687,7 @@ describe("CFC concept-level integrity floors (D5)", () => {
     it("allows a by-reference recipient whose concrete atom is above the concept floor", async () => {
       // RED before threading the trust context into the tool-input gate: the
       // concept floor rejected the referenced concrete measurement.
-      const t = await setup("enforce-explicit", trustInput());
+      const t = await setup(trustInput());
       try {
         const ref = await t.seedConcreteRecipient(
           "concept-ok",
@@ -694,7 +701,7 @@ describe("CFC concept-level integrity floors (D5)", () => {
     });
 
     it("refuses a plain-literal recipient against a concept floor", async () => {
-      const t = await setup("enforce-explicit", trustInput());
+      const t = await setup(trustInput());
       try {
         await t.sendCall("bob@evil.org");
         expect(await t.sentRecipients()).toEqual([]);
@@ -704,7 +711,7 @@ describe("CFC concept-level integrity floors (D5)", () => {
     });
 
     it("refuses a concept floor when no trust is configured (fail closed)", async () => {
-      const t = await setup("enforce-explicit", undefined);
+      const t = await setup(undefined);
       try {
         const ref = await t.seedConcreteRecipient(
           "concept-notrust",

--- a/packages/runner/test/cfc-creation-membership-anchor.test.ts
+++ b/packages/runner/test/cfc-creation-membership-anchor.test.ts
@@ -70,6 +70,7 @@ describe("CFC: creation anchors membership at the canonical container path", () 
         },
       },
     });
+    rt.prepareTxForCommit(seed);
     expect((await seed.commit()).ok).toBeDefined();
     return id;
   };
@@ -88,7 +89,8 @@ describe("CFC: creation anchors membership at the canonical container path", () 
     runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "observe",
+      // `entriesOf` reads the label map the replica stores, and flow labels
+      // reach storage at "persist".
       cfcFlowLabels: "persist",
     });
 
@@ -108,6 +110,7 @@ describe("CFC: creation anchors membership at the canonical container path", () 
     el0.get();
     const listCell = runtime.getCell(space, "anchor-list", listSchema, setup);
     listCell.set([el0, el1]);
+    runtime.prepareTxForCommit(setup);
     expect((await setup.commit()).ok).toBeDefined();
     return listCell.getAsNormalizedFullLink().id;
   };
@@ -138,6 +141,15 @@ describe("CFC: creation anchors membership at the canonical container path", () 
   it("a shape read at the canonical container path consumes the creating join", async () => {
     const listId = await createList();
 
+    // The reader's output document declares the confidentiality it is about
+    // to receive, so the stamped write fits the ceiling its label map states.
+    await seedLabeledDoc(
+      runtime!,
+      "anchor-out",
+      { copied: false },
+      "alice-secret",
+    );
+
     // A nonRecursive (shape) read at the container observes membership and
     // existence: the creating join must arrive in the reader's flow join
     // and stamp its output. (During the mis-anchored window this held only
@@ -153,6 +165,7 @@ describe("CFC: creation anchors membership at the canonical container path", () 
     }, { nonRecursive: true });
     const out = runtime!.getCell(space, "anchor-out", undefined, readTx);
     out.set({ copied: true });
+    runtime!.prepareTxForCommit(readTx);
     expect((await readTx.commit()).ok).toBeDefined();
 
     const outDerived = entriesOf(out.getAsNormalizedFullLink().id).find((e) =>

--- a/packages/runner/test/cfc-cross-space-integrity.test.ts
+++ b/packages/runner/test/cfc-cross-space-integrity.test.ts
@@ -13,6 +13,7 @@ import {
 import type { JSONSchema } from "../src/builder/types.ts";
 import { type CfcConfClause, clausesEqual } from "../src/cfc/clause.ts";
 import { evaluateExchangeRules } from "../src/cfc/exchange-eval.ts";
+import { commitmentAwareEquals } from "../src/cfc/label-representation.ts";
 import type { IFCLabel } from "../src/cfc/mod.ts";
 import {
   buildCfcPolicySnapshot,
@@ -82,7 +83,6 @@ const makeRuntime = (
   new Runtime({
     apiUrl: new URL("https://example.com"),
     storageManager,
-    cfcEnforcementMode: "enforce-explicit",
   });
 
 // Seed a doc's stored CFC metadata directly (an ungated path-[] full-document
@@ -111,10 +111,16 @@ const seedLabeledDoc = async (
   return docId;
 };
 
+// An address a `LinkReference` endorsement carries: the plaintext address, or
+// the digest marker standing in for it.
+type EndorsementAddress =
+  | { space: string; id: string; path: string[] }
+  | { digestOf: string };
+
 const isLinkReference = (atom: unknown): atom is {
   type: string;
-  source: { space: string; id: string; path: string[] };
-  target: { space: string; id: string; path: string[] };
+  source: EndorsementAddress;
+  target: EndorsementAddress;
 } =>
   typeof atom === "object" && atom !== null &&
   (atom as { type?: unknown }).type ===
@@ -222,13 +228,19 @@ describe("CFC cross-space integrity", () => {
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = makeRuntime(storageManager);
     try {
-      await seedLabeledDoc(runtime, spaceA, "s1c-src", "37.77,-122.41", [{
-        path: [],
-        label: {
-          integrity: ["gps-reading"],
-          confidentiality: ["space-a-secret"],
-        },
-      }]);
+      const srcId = await seedLabeledDoc(
+        runtime,
+        spaceA,
+        "s1c-src",
+        "37.77,-122.41",
+        [{
+          path: [],
+          label: {
+            integrity: ["gps-reading"],
+            confidentiality: ["space-a-secret"],
+          },
+        }],
+      );
 
       const tx = runtime.edit();
       const src = runtime.getCell(spaceA, "s1c-src", undefined, tx);
@@ -246,22 +258,34 @@ describe("CFC cross-space integrity", () => {
       tx.prepareCfc();
       expect((await tx.commit()).error).toBeUndefined();
 
-      const doc = readDoc(
-        storageManager,
-        spaceB,
-        parseLink(sink.getAsLink()).id!,
-      );
+      const sinkId = parseLink(sink.getAsLink()).id!;
+      const doc = readDoc(storageManager, spaceB, sinkId);
       const entries = entriesFor(doc, ["ref"]);
       expect(entries).toHaveLength(1);
       const entry = entries[0];
       expect(entry.origin).toBe("link");
       // Source integrity preserved…
       expect(entry.label.integrity).toContain("gps-reading");
-      // …plus the endorsement recording the A→B edge.
+      // …plus the endorsement recording the edge from space A to space B.
+      // The endorsement addresses are commitment-classified fields, so
+      // `commitmentAwareEquals` reads the plaintext address and the digest
+      // marker standing in for it alike.
       const linkRef = (entry.label.integrity ?? []).find(isLinkReference);
       expect(linkRef).toBeDefined();
-      expect(linkRef!.source.space).toBe(spaceA);
-      expect(linkRef!.target.space).toBe(spaceB);
+      expect(
+        commitmentAwareEquals(linkRef!.source, {
+          space: spaceA,
+          id: srcId,
+          path: [],
+        }),
+      ).toBe(true);
+      expect(
+        commitmentAwareEquals(linkRef!.target, {
+          space: spaceB,
+          id: sinkId,
+          path: ["ref"],
+        }),
+      ).toBe(true);
       // Source confidentiality carried across the space boundary.
       expect(entry.label.confidentiality).toContain("space-a-secret");
     } finally {

--- a/packages/runner/test/cfc-declared-monotonicity.test.ts
+++ b/packages/runner/test/cfc-declared-monotonicity.test.ts
@@ -127,7 +127,9 @@ const makeRuntime = (opts: {
   new Runtime({
     apiUrl: new URL("https://example.com"),
     storageManager: opts.storageManager,
-    cfcEnforcementMode: opts.cfcEnforcementMode ?? "enforce-explicit",
+    ...(opts.cfcEnforcementMode !== undefined
+      ? { cfcEnforcementMode: opts.cfcEnforcementMode }
+      : {}),
     ...(opts.cfcFlowLabels !== undefined
       ? { cfcFlowLabels: opts.cfcFlowLabels }
       : {}),
@@ -183,10 +185,9 @@ const commitWrite = async (
 /**
  * Rewrite the stored declared labelMap entries of an existing doc, keeping
  * the real schemaHash (so the next prepare's stored-schema load succeeds).
- * Runs on a SEPARATE `disabled`-enforcement runtime over the same storage:
- * tests seed stored ["cfc"] metadata via an ungated path-[] full-document
- * write (the shape hydration delivers), and a doc that already carries
- * metadata trips the missing-schema-input reason on enforcing runtimes.
+ * Runs on a SEPARATE runtime over the same storage: tests seed stored
+ * ["cfc"] metadata via an ungated path-[] full-document write, which the
+ * shape hydration delivers.
  * The caller owns the seeder runtime, and both runtimes here share one
  * caller-owned StorageManager: each is torn down with
  * `dispose({ closeStorage: false })` so neither closes the store the other is
@@ -362,11 +363,15 @@ describe("CFC declared-component monotonicity (WP5, §8.12.1/§8.12.8)", () => {
       // ratchet fold, a peer's write. Under cfcFlowLabels:"persist" the
       // re-mint derives from the schema alone and DROPS the extra clause.
       const storageManager = StorageManager.emulate({ as: signer });
-      const runtime = makeRuntime({ storageManager, cfcFlowLabels: "persist" });
-      const seeder = makeRuntime({
+      const runtime = makeRuntime({
         storageManager,
-        cfcEnforcementMode: "disabled",
+        // At this rung the writer-fit check flags the second commit and lets
+        // it land. That commit carries the clause the re-mint drops, and the
+        // assertion below reads the entry it persisted.
+        cfcEnforcementMode: "enforce-explicit",
+        cfcFlowLabels: "persist",
       });
+      const seeder = makeRuntime({ storageManager });
       try {
         const first = await commitWrite(
           runtime,
@@ -412,16 +417,13 @@ describe("CFC declared-component monotonicity (WP5, §8.12.1/§8.12.8)", () => {
     });
 
     it("with flow labels off, the Wave-2 grow-only ratchet folds the stronger stored entry back in", async () => {
-      // The dual pin: under the default cfcFlowLabels:"off" the legacy
-      // ratchet merges prior confidentiality into the fresh entry, so the
-      // confidentiality half of §8.12.1 cannot regress on this path — which
-      // is why the gate's confidentiality tests run under flow persist.
+      // The dual pin: under cfcFlowLabels:"off" the legacy ratchet merges
+      // prior confidentiality into the fresh entry, so the confidentiality
+      // half of §8.12.1 cannot regress on this path — which is why the
+      // gate's confidentiality tests run under flow persist.
       const storageManager = StorageManager.emulate({ as: signer });
-      const runtime = makeRuntime({ storageManager });
-      const seeder = makeRuntime({
-        storageManager,
-        cfcEnforcementMode: "disabled",
-      });
+      const runtime = makeRuntime({ storageManager, cfcFlowLabels: "off" });
+      const seeder = makeRuntime({ storageManager });
       try {
         const first = await commitWrite(
           runtime,
@@ -509,8 +511,11 @@ describe("CFC declared-component monotonicity (WP5, §8.12.1/§8.12.8)", () => {
         cell.set({ out: "v1" });
         tx.prepareCfc();
         expect(tx.getCfcState().prepare.status).toBe("prepared");
-        // A no-op re-set of the same mode does not invalidate.
-        tx.setCfcDeclaredMonotonicityMode("off");
+        // A no-op re-set of the mode the transaction already carries does
+        // not invalidate.
+        tx.setCfcDeclaredMonotonicityMode(
+          tx.getCfcState().declaredMonotonicityMode,
+        );
         expect(tx.getCfcState().prepare.status).toBe("prepared");
         tx.setCfcDeclaredMonotonicityMode("enforce");
         const prepare = tx.getCfcState().prepare;
@@ -715,15 +720,16 @@ describe("CFC declared-component monotonicity (WP5, §8.12.1/§8.12.8)", () => {
   }) => {
     const runtime = makeRuntime({
       storageManager: opts.storageManager,
+      // At this rung the writer-fit check flags the second commit and lets it
+      // land. That commit carries the clause the seeded entry adds, and the
+      // callers read the error and the entries it produced.
+      cfcEnforcementMode: "enforce-explicit",
       cfcFlowLabels: opts.flowLabels ?? "persist",
       ...(opts.dial !== undefined
         ? { cfcDeclaredMonotonicity: opts.dial }
         : {}),
     });
-    const seeder = makeRuntime({
-      storageManager: opts.storageManager,
-      cfcEnforcementMode: "disabled",
-    });
+    const seeder = makeRuntime({ storageManager: opts.storageManager });
     try {
       const first = await commitWrite(runtime, opts.name, opts.schema, {
         out: "v1",
@@ -820,10 +826,7 @@ describe("CFC declared-component monotonicity (WP5, §8.12.1/§8.12.8)", () => {
         cfcFlowLabels: "persist",
         cfcDeclaredMonotonicity: "enforce",
       });
-      const seeder = makeRuntime({
-        storageManager,
-        cfcEnforcementMode: "disabled",
-      });
+      const seeder = makeRuntime({ storageManager });
       try {
         const first = await commitWrite(runtime, "dm-enf-untouched", schema, {
           out: "v1",
@@ -882,10 +885,7 @@ describe("CFC declared-component monotonicity (WP5, §8.12.1/§8.12.8)", () => {
         cfcFlowLabels: "persist",
         cfcDeclaredMonotonicity: "enforce",
       });
-      const seeder = makeRuntime({
-        storageManager,
-        cfcEnforcementMode: "disabled",
-      });
+      const seeder = makeRuntime({ storageManager });
       try {
         const first = await commitWrite(
           runtime,
@@ -1123,10 +1123,7 @@ describe("CFC declared-component monotonicity (WP5, §8.12.1/§8.12.8)", () => {
         storageManager,
         cfcDeclaredMonotonicity: "enforce",
       });
-      const seeder = makeRuntime({
-        storageManager,
-        cfcEnforcementMode: "disabled",
-      });
+      const seeder = makeRuntime({ storageManager });
       try {
         const first = await commitWrite(
           runtime,
@@ -1184,10 +1181,7 @@ describe("CFC declared-component monotonicity (WP5, §8.12.1/§8.12.8)", () => {
         storageManager,
         cfcDeclaredMonotonicity: "enforce",
       });
-      const seeder = makeRuntime({
-        storageManager,
-        cfcEnforcementMode: "disabled",
-      });
+      const seeder = makeRuntime({ storageManager });
       try {
         const first = await commitWrite(
           runtime,
@@ -1524,10 +1518,7 @@ describe("CFC declared-component monotonicity (WP5, §8.12.1/§8.12.8)", () => {
         cfcFlowLabels: "persist",
         cfcDeclaredMonotonicity: "enforce",
       });
-      const seeder = makeRuntime({
-        storageManager,
-        cfcEnforcementMode: "disabled",
-      });
+      const seeder = makeRuntime({ storageManager });
       try {
         const first = await commitWrite(runtime, "dm-ex-paths", schema, {
           out: "v1",
@@ -1728,13 +1719,14 @@ describe("CFC declared-component monotonicity (WP5, §8.12.1/§8.12.8)", () => {
         const storageManager = StorageManager.emulate({ as: signer });
         const runtime = makeRuntime({
           storageManager,
+          // At this rung the writer-fit check flags the second commit and
+          // lets it land, so the transaction reaches the prepared decision
+          // this reads.
+          cfcEnforcementMode: "enforce-explicit",
           cfcFlowLabels: "persist",
           cfcDeclaredMonotonicity: dial,
         });
-        const seeder = makeRuntime({
-          storageManager,
-          cfcEnforcementMode: "disabled",
-        });
+        const seeder = makeRuntime({ storageManager });
         try {
           const first = await commitWrite(
             runtime,

--- a/packages/runner/test/cfc-declared-observes.test.ts
+++ b/packages/runner/test/cfc-declared-observes.test.ts
@@ -45,7 +45,15 @@ describe("CFC declared observation classes (C5)", () => {
     runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "observe",
+      // A strict writer-fit refuses a tainted write to a store that declares
+      // no ceiling. Every output document below declares none, and the
+      // assertions on their `derived` and `structure` entries read the labels
+      // those writes persisted, so the suite holds the strongest rung that
+      // still lets them land.
+      cfcEnforcementMode: "enforce-explicit",
+      // Persisting flow labels is what puts the declared and derived entries
+      // in the documents. Every assertion that goes through `entriesOf` reads
+      // one of them.
       cfcFlowLabels: "persist",
     });
     return runtime;

--- a/packages/runner/test/cfc-envelope-decomposed.test.ts
+++ b/packages/runner/test/cfc-envelope-decomposed.test.ts
@@ -16,12 +16,17 @@ const space = signer.did();
 
 // A declared schema whose `$defs` member gives the decomposition something
 // to split: version-2 envelopes store the root and the definition as
-// separate content-addressed documents.
+// separate content-addressed documents. The inline `note` member declares
+// the same confidentiality, so rewriting the whole record puts the atoms it
+// read back onto a path that accepts them.
 const DECLARED_SCHEMA = {
   type: "object",
   properties: {
     secret: { $ref: "#/$defs/Classified" },
-    note: { type: "string" },
+    note: {
+      type: "string",
+      ifc: { confidentiality: ["decomposed-secret"] },
+    },
   },
   required: ["secret"],
   $defs: {
@@ -38,7 +43,8 @@ const makeRuntime = (
   new Runtime({
     apiUrl: new URL(import.meta.url),
     storageManager,
-    cfcEnforcementMode: "enforce-explicit",
+    // The stored-form assertions below read the decomposed spelling: the
+    // root and its `$defs` member as separate content-addressed documents.
     cfcDecomposedEnvelopes: true,
   });
 
@@ -52,7 +58,7 @@ const declaredWrite = async (
 ): Promise<{ cidWrites: string[]; stored: CfcMetadata | undefined }> => {
   const tx = runtime.edit();
   const cell = runtime.getCell(space, name, DECLARED_SCHEMA, tx);
-  cell.set({ secret: "classified", note: "plain" });
+  cell.set({ secret: "classified", note: "detail" });
   tx.prepareCfc();
   const cidWrites = [...tx.getWriteDetails?.(space) ?? []]
     .map((detail) => detail.address.id)
@@ -209,12 +215,11 @@ describe("CFC decomposed envelopes", () => {
     const runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     try {
       const tx = runtime.edit();
       const cell = runtime.getCell(space, "inline-target", DECLARED_SCHEMA, tx);
-      cell.set({ secret: "classified", note: "plain" });
+      cell.set({ secret: "classified", note: "detail" });
       tx.prepareCfc();
       expect((await tx.commit()).ok).toBeDefined();
       const targetId = cell.getAsNormalizedFullLink().id;

--- a/packages/runner/test/cfc-envelope-schema-staging.test.ts
+++ b/packages/runner/test/cfc-envelope-schema-staging.test.ts
@@ -27,7 +27,6 @@ describe("CFC envelope schema documents ride the shared staging path", () => {
     const runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     // A seeding failure below never reaches the caller's `finally`, so the
     // resources are released here before it propagates.

--- a/packages/runner/test/cfc-envelope-version-guard.test.ts
+++ b/packages/runner/test/cfc-envelope-version-guard.test.ts
@@ -56,7 +56,6 @@ describe("CFC envelope version guard", () => {
     const runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     try {
       const id = await seedWithVersion(runtime, "version-guard-throw", 3);
@@ -76,7 +75,6 @@ describe("CFC envelope version guard", () => {
     const runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     try {
       const id = await seedWithVersion(runtime, "version-guard-applies", 3);
@@ -101,7 +99,6 @@ describe("CFC envelope version guard", () => {
     const runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     try {
       await seedWithVersion(runtime, "version-guard-write", 3);
@@ -135,7 +132,6 @@ describe("CFC envelope version guard", () => {
     const runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     try {
       const id = parseLink(
@@ -221,7 +217,6 @@ describe("CFC envelope version guard", () => {
       const runtime = new Runtime({
         apiUrl: new URL(import.meta.url),
         storageManager,
-        cfcEnforcementMode: "enforce-explicit",
       });
       try {
         const sourceId = parseLink(
@@ -267,7 +262,6 @@ describe("CFC envelope version guard", () => {
     const runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     try {
       // The read source carries the unreadable envelope and the write target
@@ -307,7 +301,6 @@ describe("CFC envelope version guard", () => {
     const runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     try {
       // The reserved position is what qualifies the record, never its
@@ -383,7 +376,6 @@ describe("CFC envelope version guard", () => {
     const runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     try {
       // The failure the guard exists to prevent: a SECRET-labeled envelope
@@ -411,7 +403,6 @@ describe("CFC envelope version guard", () => {
     const runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     try {
       await seedWithVersion(runtime, "version-guard-link-source", 3);
@@ -446,7 +437,6 @@ describe("CFC envelope version guard", () => {
     const runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     try {
       // One read policy, no version distinction: a version-1 root carrying

--- a/packages/runner/test/cfc-exact-copy-wildcard.test.ts
+++ b/packages/runner/test/cfc-exact-copy-wildcard.test.ts
@@ -21,7 +21,6 @@ describe("CFC exactCopyOf array wildcard", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     try {
       const tx = runtime.edit();

--- a/packages/runner/test/cfc-exact-copy.test.ts
+++ b/packages/runner/test/cfc-exact-copy.test.ts
@@ -15,7 +15,6 @@ describe("CFC exact copy claims", () => {
     const runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     return { runtime, storageManager };
   };

--- a/packages/runner/test/cfc-existence-channel.test.ts
+++ b/packages/runner/test/cfc-existence-channel.test.ts
@@ -55,7 +55,15 @@ describe("CFC existence channel (SC-4, freeze-at-creation)", () => {
     runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
+      // At this rung the gates record what they measure and refuse nothing.
+      // Every document here is assembled by hand through `writeOrThrow`,
+      // declaring neither a write policy nor a ceiling, and `writeTainted`
+      // then writes a labeled join onto it. Each assertion below reads back
+      // the label map those commits persisted.
       cfcEnforcementMode: "observe",
+      // Persisting flow labels is what puts the shape and value entries in
+      // the stored label map. `entriesOf` and `shapeEntriesAt` read those
+      // entries back in every test here.
       cfcFlowLabels: "persist",
     });
     return runtime;
@@ -1061,7 +1069,14 @@ describe("CFC slot-pointer channel (C3, SC-8 end-to-end)", () => {
     runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
+      // At this rung the gates record what they measure and refuse nothing.
+      // `sp-holder` is assembled by hand through `writeOrThrow`, and `sp-out`
+      // is created by a write carrying the pointer label with no ceiling
+      // declared for it. The closing assertion reads back the entry that
+      // second commit persisted.
       cfcEnforcementMode: "observe",
+      // Persisting flow labels is what puts the derived entry carrying
+      // "pointer-label" into `sp-out`.
       cfcFlowLabels: "persist",
     });
     const seed = runtime.edit();

--- a/packages/runner/test/cfc-external-ingest.test.ts
+++ b/packages/runner/test/cfc-external-ingest.test.ts
@@ -27,13 +27,10 @@ describe("CFC external-ingest provenance mint (split-mint)", () => {
   // The Vouched Ingest Channel split-mint: a builtin-authored ExternalIngest
   // provenance mark, derived only from the verified channel metadata stamped on
   // the tx, that survives the runtime-minted gate while a copy smuggled into
-  // the payload is stripped. The toolshed/operator runtime runs CFC *disabled*,
-  // so the headline case proves the mark is still minted there.
+  // the payload is stripped.
 
   const makeRuntime = (
     overrides: {
-      cfcEnforcementMode?: string;
-      cfcFlowLabels?: string;
       cfcWriteFloor?: string;
     } = {},
   ) => {
@@ -42,12 +39,12 @@ describe("CFC external-ingest provenance mint (split-mint)", () => {
       {
         apiUrl: new URL("https://example.com"),
         storageManager,
-        // Explicitly-disabled mode — the mint's hardest case (nothing else
-        // marks the tx relevant) — unless a test overrides it. Not any shipped
-        // host's posture: toolshed passes no CFC options and runs the
-        // enforce-explicit Runtime default.
+        // Disabled enforcement is the mint's hardest case: the ingest stamp is
+        // the only thing marking the transaction CFC-relevant. It also commits
+        // a transaction that recorded a refusal reason, which is the
+        // `expect(error).toBeUndefined()` that both "persists the mark even
+        // when the payload fails ..." tests turn on.
         cfcEnforcementMode: "disabled",
-        cfcFlowLabels: "off",
         ...overrides,
       } as ConstructorParameters<typeof Runtime>[0],
     );
@@ -139,9 +136,7 @@ describe("CFC external-ingest provenance mint (split-mint)", () => {
   });
 
   it("mints fetch provenance without a vouched channel or audience", async () => {
-    const { storageManager, runtime } = makeRuntime({
-      cfcEnforcementMode: "enforce-explicit",
-    });
+    const { storageManager, runtime } = makeRuntime();
     try {
       const id = runtime.getCell(space, "fetch-ingest-a")
         .getAsNormalizedFullLink().id;
@@ -343,6 +338,8 @@ describe("CFC external-ingest provenance mint (split-mint)", () => {
     // declared policy label is dropped. Exercises the floor's ingest-target
     // branch (ingestVerificationFailed instead of skipping the mint).
     const { storageManager, runtime } = makeRuntime({
+      // The floor rejects the unendorsed payload, which is the rejection the
+      // mark has to survive.
       cfcWriteFloor: "enforce",
     });
     try {

--- a/packages/runner/test/cfc-flow-integrity.test.ts
+++ b/packages/runner/test/cfc-flow-integrity.test.ts
@@ -2,7 +2,7 @@ import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
 
 import type { CfcAtom } from "@commonfabric/api/cfc";
-import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
+import { CFC_ATOM_TYPE, cfcAtom } from "@commonfabric/api/cfc";
 import { internSchema } from "@commonfabric/data-model-schema";
 import { Identity } from "@commonfabric/identity";
 
@@ -41,7 +41,8 @@ describe("CFC flow labels: integrity propagation (phase C)", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
+      // Persisting flow labels is what writes the `origin: "derived"` entries
+      // that `derivedIntegrity` reads back in every test here.
       cfcFlowLabels: "persist",
     });
     return { storageManager, runtime };
@@ -160,7 +161,9 @@ describe("CFC flow labels: integrity propagation (phase C)", () => {
     try {
       await seedDoc(runtime, "flow-wl-a", [certified("p1")]);
       // Doc B carries a confidentiality label (so it resolves) but NO
-      // certification.
+      // certification. The clause names this space, the audience a document
+      // living in it already reaches, so the label flows onto the output
+      // without that output declaring a ceiling of its own.
       const seed = runtime.edit();
       const bCell = runtime.getCell(space, "flow-wl-b", undefined, seed);
       const bId = bCell.getAsNormalizedFullLink().id;
@@ -172,7 +175,10 @@ describe("CFC flow labels: integrity propagation (phase C)", () => {
           schemaHash: SEED_ENVELOPE_SCHEMA_HASH,
           labelMap: {
             version: 1,
-            entries: [{ path: [], label: { confidentiality: ["plain"] } }],
+            entries: [{
+              path: [],
+              label: { confidentiality: [cfcAtom.space(space)] },
+            }],
           },
         },
       });
@@ -197,7 +203,7 @@ describe("CFC flow labels: integrity propagation (phase C)", () => {
       const conf = entriesOf(storageManager, out.getAsNormalizedFullLink().id)
         .filter((e) => e.origin === "derived")
         .flatMap((e) => e.label.confidentiality ?? []);
-      expect(conf).toContainEqual("plain");
+      expect(conf).toContainEqual(cfcAtom.space(space));
     } finally {
       await runtime.dispose();
       await storageManager.close();

--- a/packages/runner/test/cfc-flow-labels.test.ts
+++ b/packages/runner/test/cfc-flow-labels.test.ts
@@ -1,6 +1,10 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
+import { internSchema } from "@commonfabric/data-model-schema";
+import type { URI } from "@commonfabric/memory/interface";
+import type { JSONSchema } from "../src/builder/types.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
 import {
   SEED_ENVELOPE_SCHEMA_HASH,
   writeSeedEnvelopeDoc,
@@ -31,6 +35,33 @@ const replicaEntries = (
   return replica.getDocument(id)?.cfc?.labelMap?.entries ?? [];
 };
 
+const SECRET_FIELD_SCHEMA = internSchema(
+  { type: "string", ifc: { confidentiality: ["secret"] } } as JSONSchema,
+  true,
+);
+
+/**
+ * Declares the write policy covering a raw write to a seeded document's
+ * `secret` field. A schema-backed write carries this declaration from the
+ * schema it went through; a raw address write states it here instead.
+ */
+const recordSecretWritePolicy = (
+  tx: IExtendedStorageTransaction,
+  id: string,
+): void => {
+  tx.recordCfcWritePolicyInput({
+    kind: "schema",
+    target: {
+      space: signer.did(),
+      scope: "space",
+      id: id as URI,
+      path: ["value", "secret"],
+    },
+    schemaHash: SECRET_FIELD_SCHEMA.taggedHashString,
+    schema: SECRET_FIELD_SCHEMA.schema,
+  });
+};
+
 describe("CFC flow labels (default transition)", () => {
   // S16 default transition: a transaction's outputs are tainted by what it
   // read. Without this, "read labeled data, write a derived plain value to an
@@ -42,7 +73,12 @@ describe("CFC flow labels (default transition)", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
+      // At this rung the writer-fit check flags a tainted write to a store
+      // that declares no ceiling and lets it land. The derived doc declares
+      // none, and the `flowEntry` assertions below read back the entry that
+      // write persisted.
       cfcEnforcementMode: "enforce-explicit",
+      // Persisting the derived join is what puts that entry in the document.
       cfcFlowLabels: "persist",
     });
     try {
@@ -114,7 +150,6 @@ describe("CFC flow labels (default transition)", () => {
       // later tx consuming B cannot write into a slot whose ceiling
       // excludes the secret.
       const egress = runtime.edit();
-      egress.setCfcEnforcementMode("enforce-explicit");
       const derivedIn = runtime.getCell(
         signer.did(),
         "cfc-flow-labels-derived",
@@ -161,7 +196,13 @@ describe("CFC flow labels (default transition)", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
+      // At this rung the writer-fit check flags a tainted write to a store
+      // that declares no ceiling and lets it land. Neither the target
+      // doc nor the out doc declares one, and the `flowEntry` and `outEntry`
+      // assertions below read back the entries those writes persisted.
       cfcEnforcementMode: "enforce-explicit",
+      // Persisting the derived join is what puts those entries in the
+      // documents.
       cfcFlowLabels: "persist",
     });
     try {
@@ -282,7 +323,13 @@ describe("CFC flow labels (default transition)", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
+      // At this rung the writer-fit check flags a tainted write to a store
+      // that declares no ceiling and lets it land. The target declares
+      // none, and the `derivedAfter` assertions below read back the entries
+      // the tainted write and the overwrite left there.
       cfcEnforcementMode: "enforce-explicit",
+      // Persisting the derived join is what puts the value and shape entries
+      // in the document.
       cfcFlowLabels: "persist",
     });
     try {
@@ -389,7 +436,14 @@ describe("CFC flow labels (default transition)", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
+      // At this rung the writer-fit check flags a tainted write to a store
+      // that declares no ceiling and lets it land. The target declares
+      // none, so the first derivation's envelope write lands. The second
+      // derivation's `wroteCfc` assertion measures the skip of that same
+      // write.
       cfcEnforcementMode: "enforce-explicit",
+      // Persisting the derived join is what makes an envelope write happen at
+      // all, and `wroteCfc` reads it back.
       cfcFlowLabels: "persist",
     });
     try {
@@ -485,7 +539,13 @@ describe("CFC flow labels (default transition)", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
+      // At this rung the writer-fit check flags a tainted write to a store
+      // that declares no ceiling and lets it land. The target declares
+      // none, so the first derivation writes the envelope that the permutation
+      // reorders and the second derivation's `wroteCfc` assertion measures the
+      // skip of.
       cfcEnforcementMode: "enforce-explicit",
+      // Persisting the derived join is what writes that envelope.
       cfcFlowLabels: "persist",
     });
     try {
@@ -659,7 +719,9 @@ describe("CFC flow labels (default transition)", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
+      // The assertions below read that the join is reported as a diagnostic
+      // and that neither the transaction nor the stored document carries an
+      // envelope. That holds at the `observe` rung.
       cfcFlowLabels: "observe",
     });
     try {
@@ -751,7 +813,12 @@ describe("CFC flow labels (default transition)", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
+      // At this rung the writer-fit check flags a tainted write to a store
+      // that declares no ceiling and lets it land. The out doc declares
+      // none, and the `entry` assertions below read back what that write
+      // persisted.
       cfcEnforcementMode: "enforce-explicit",
+      // Persisting the derived join is what puts that entry in the document.
       cfcFlowLabels: "persist",
     });
     try {
@@ -825,7 +892,12 @@ describe("CFC flow labels (default transition)", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "observe",
+      // At this rung the writer-fit check flags a tainted write to a store
+      // that declares no ceiling and lets it land. The flag doc declares
+      // none, and the `entry` assertions below read back what the rerun's
+      // write persisted.
+      cfcEnforcementMode: "enforce-explicit",
+      // Persisting the derived join is what puts that entry in the document.
       cfcFlowLabels: "persist",
     });
     try {
@@ -900,6 +972,8 @@ describe("CFC flow labels (default transition)", () => {
         id: sourceId,
         path: ["value", "secret"],
       }, "v2");
+      recordSecretWritePolicy(bump, sourceId);
+      bump.prepareCfc();
       expect((await bump.commit()).ok).toBeDefined();
       await runtime.idle();
       expect(runs).toBeGreaterThan(1);
@@ -926,7 +1000,12 @@ describe("CFC flow labels (default transition)", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "observe",
+      // At this rung the writer-fit check flags a tainted write to a store
+      // that declares no ceiling and lets it land. The flag doc declares
+      // none, and the `entry` assertions below read back what the retry's
+      // write persisted.
+      cfcEnforcementMode: "enforce-explicit",
+      // Persisting the derived join is what puts that entry in the document.
       cfcFlowLabels: "persist",
     });
     try {
@@ -1004,6 +1083,8 @@ describe("CFC flow labels (default transition)", () => {
         id: sourceId,
         path: ["value", "secret"],
       }, "v2");
+      recordSecretWritePolicy(bump, sourceId);
+      bump.prepareCfc();
       expect((await bump.commit()).ok).toBeDefined();
       await runtime.idle();
       expect(runs).toBeGreaterThanOrEqual(3);

--- a/packages/runner/test/cfc-flow-pointwise.test.ts
+++ b/packages/runner/test/cfc-flow-pointwise.test.ts
@@ -104,7 +104,13 @@ describe("CFC flow labels: pointwise structure (phase B)", () => {
     runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "observe",
+      // At this rung the writer-fit check flags a tainted write to a store
+      // that declares no ceiling and lets it land. Each `probe` call
+      // writes into a fresh document that declares none, and `conf0` and
+      // `conf1` read back what those writes persisted.
+      cfcEnforcementMode: "enforce-explicit",
+      // Persisting the derived join is what puts those entries in the probe
+      // documents.
       cfcFlowLabels: "persist",
     });
 
@@ -131,6 +137,7 @@ describe("CFC flow labels: pointwise structure (phase B)", () => {
       setup,
     );
     listCell.set([el0]);
+    setup.prepareCfc();
     expect((await setup.commit()).ok).toBeDefined();
 
     const collectionPattern = pattern<{ values: unknown[] }>(({ values }) => {
@@ -155,7 +162,8 @@ describe("CFC flow labels: pointwise structure (phase B)", () => {
       { values: valuesIn },
       resultCell,
     );
-    await tx.commit();
+    tx.prepareCfc();
+    expect((await tx.commit()).ok).toBeDefined();
     await result.pull();
     await runtime.idle();
 
@@ -169,6 +177,7 @@ describe("CFC flow labels: pointwise structure (phase B)", () => {
       type: "array",
       items: { asCell: ["cell"] },
     }, grow).set([el0Again, el1]);
+    grow.prepareCfc();
     expect((await grow.commit()).ok).toBeDefined();
     await result.pull();
     await runtime.idle();
@@ -224,7 +233,13 @@ describe("CFC flow labels: pointwise structure (phase B)", () => {
     runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "observe",
+      // At this rung the writer-fit check flags a tainted write to a store
+      // that declares no ceiling and lets it land. The probe writes
+      // into a document that declares none, and `probeConf` reads back what
+      // that write persisted.
+      cfcEnforcementMode: "enforce-explicit",
+      // Persisting the derived join is what puts that entry in the probe
+      // document.
       cfcFlowLabels: "persist",
     });
 
@@ -252,6 +267,7 @@ describe("CFC flow labels: pointwise structure (phase B)", () => {
       setup,
     );
     listCell.set([el0, el1]);
+    setup.prepareCfc();
     expect((await setup.commit()).ok).toBeDefined();
 
     const collectionPattern = pattern<{ values: unknown[] }>(({ values }) => {
@@ -276,7 +292,8 @@ describe("CFC flow labels: pointwise structure (phase B)", () => {
       { values: valuesIn },
       resultCell,
     );
-    await tx.commit();
+    tx.prepareCfc();
+    expect((await tx.commit()).ok).toBeDefined();
     await result.pull();
     await runtime.idle();
 
@@ -313,7 +330,13 @@ describe("CFC flow labels: pointwise structure (phase B)", () => {
     runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "observe",
+      // At this rung the writer-fit check flags a tainted write to a store
+      // that declares no ceiling and lets it land. The probe writes
+      // into a document that declares none, and `probeConf` reads back what
+      // that write persisted.
+      cfcEnforcementMode: "enforce-explicit",
+      // Persisting the derived join is what puts that entry in the probe
+      // document.
       cfcFlowLabels: "persist",
     });
 
@@ -341,6 +364,7 @@ describe("CFC flow labels: pointwise structure (phase B)", () => {
       setup,
     );
     listCell.set([el0, el1]);
+    setup.prepareCfc();
     expect((await setup.commit()).ok).toBeDefined();
 
     const collectionPattern = pattern<{ values: unknown[] }>(({ values }) => {
@@ -365,7 +389,8 @@ describe("CFC flow labels: pointwise structure (phase B)", () => {
       { values: valuesIn },
       resultCell,
     );
-    await tx.commit();
+    tx.prepareCfc();
+    expect((await tx.commit()).ok).toBeDefined();
     await result.pull();
     await runtime.idle();
 
@@ -398,7 +423,13 @@ describe("CFC flow labels: pointwise structure (phase B)", () => {
     runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "observe",
+      // At this rung the writer-fit check flags a tainted write to a store
+      // that declares no ceiling and lets it land. The probe writes
+      // into a document that declares none, and `probeConf` reads back what
+      // that write persisted.
+      cfcEnforcementMode: "enforce-explicit",
+      // Persisting the derived join is what puts that entry in the probe
+      // document.
       cfcFlowLabels: "persist",
     });
 
@@ -426,6 +457,7 @@ describe("CFC flow labels: pointwise structure (phase B)", () => {
       setup,
     );
     listCell.set([el0, el1]);
+    setup.prepareCfc();
     expect((await setup.commit()).ok).toBeDefined();
 
     const collectionPattern = pattern<{ values: unknown[] }>(({ values }) => {
@@ -450,7 +482,8 @@ describe("CFC flow labels: pointwise structure (phase B)", () => {
       { values: valuesIn },
       resultCell,
     );
-    await tx.commit();
+    tx.prepareCfc();
+    expect((await tx.commit()).ok).toBeDefined();
     await result.pull();
     await runtime.idle();
 
@@ -475,6 +508,7 @@ describe("CFC flow labels: pointwise structure (phase B)", () => {
     const rtx = runtime!.edit();
     const id =
       keptCell.withTx(rtx).resolveAsCell().getAsNormalizedFullLink().id;
+    rtx.prepareCfc();
     rtx.commit();
     return id;
   };
@@ -492,7 +526,8 @@ describe("CFC flow labels: pointwise structure (phase B)", () => {
     runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "observe",
+      // Persisting the derived join is what puts the container's structure
+      // entry in the document, and `sc` reads that entry back.
       cfcFlowLabels: "persist",
     });
 
@@ -517,6 +552,7 @@ describe("CFC flow labels: pointwise structure (phase B)", () => {
       setup,
     );
     listCell.set([el0, el1]);
+    setup.prepareCfc();
     expect((await setup.commit()).ok).toBeDefined();
 
     const collectionPattern = pattern<{ values: unknown[] }>(({ values }) => {
@@ -542,7 +578,8 @@ describe("CFC flow labels: pointwise structure (phase B)", () => {
       { values: valuesIn },
       resultCell,
     );
-    await tx.commit();
+    tx.prepareCfc();
+    expect((await tx.commit()).ok).toBeDefined();
     await result.pull();
     await runtime.idle();
 
@@ -564,7 +601,9 @@ describe("CFC flow labels: pointwise structure (phase B)", () => {
     runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "observe",
+      // Persisting the derived join is what puts the container's structure
+      // entry in the document. `before`, `after` and `membershipEntries`
+      // read that entry back.
       cfcFlowLabels: "persist",
     });
 
@@ -591,6 +630,7 @@ describe("CFC flow labels: pointwise structure (phase B)", () => {
       setup,
     );
     listCell.set([el0, el1]);
+    setup.prepareCfc();
     expect((await setup.commit()).ok).toBeDefined();
 
     const collectionPattern = pattern<{ values: unknown[] }>(({ values }) => {
@@ -610,7 +650,8 @@ describe("CFC flow labels: pointwise structure (phase B)", () => {
       { values: valuesIn },
       resultCell,
     );
-    await tx.commit();
+    tx.prepareCfc();
+    expect((await tx.commit()).ok).toBeDefined();
     await result.pull();
     await runtime.idle();
 
@@ -630,6 +671,7 @@ describe("CFC flow labels: pointwise structure (phase B)", () => {
       gtx,
     );
     lc.set([el0, el1, el2]);
+    gtx.prepareCfc();
     expect((await gtx.commit()).ok).toBeDefined();
     await result.pull();
     await runtime.idle();
@@ -659,7 +701,8 @@ describe("CFC flow labels: pointwise structure (phase B)", () => {
     runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "observe",
+      // Persisting the derived join is what puts the container's structure
+      // entry in the document, and `sc` reads that entry back.
       cfcFlowLabels: "persist",
     });
 
@@ -685,6 +728,7 @@ describe("CFC flow labels: pointwise structure (phase B)", () => {
       setup,
     );
     listCell.set([el0, el1]);
+    setup.prepareCfc();
     expect((await setup.commit()).ok).toBeDefined();
 
     const collectionPattern = pattern<{ values: unknown[] }>(({ values }) => {
@@ -704,7 +748,8 @@ describe("CFC flow labels: pointwise structure (phase B)", () => {
       { values: valuesIn },
       resultCell,
     );
-    await tx.commit();
+    tx.prepareCfc();
+    expect((await tx.commit()).ok).toBeDefined();
     await result.pull();
     await runtime.idle();
 
@@ -728,7 +773,9 @@ describe("CFC flow labels: pointwise structure (phase B)", () => {
     runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "observe",
+      // Persisting the derived join is what puts the container's membership
+      // and existence entries in the document. The assertions below read
+      // both back.
       cfcFlowLabels: "persist",
     });
 
@@ -757,6 +804,7 @@ describe("CFC flow labels: pointwise structure (phase B)", () => {
       setup,
     );
     listCell.set([d0]);
+    setup.prepareCfc();
     expect((await setup.commit()).ok).toBeDefined();
 
     const collectionPattern = pattern<{ values: unknown[] }>(({ values }) => {
@@ -778,7 +826,8 @@ describe("CFC flow labels: pointwise structure (phase B)", () => {
       { values: valuesIn },
       resultCell,
     );
-    await tx.commit();
+    tx.prepareCfc();
+    expect((await tx.commit()).ok).toBeDefined();
     await result.pull();
     await runtime.idle();
 
@@ -809,6 +858,7 @@ describe("CFC flow labels: pointwise structure (phase B)", () => {
       stx,
     );
     lc.set([d1]);
+    stx.prepareCfc();
     expect((await stx.commit()).ok).toBeDefined();
     await result.pull();
     await runtime.idle();

--- a/packages/runner/test/cfc-flow-probe-memo.test.ts
+++ b/packages/runner/test/cfc-flow-probe-memo.test.ts
@@ -32,6 +32,7 @@ import {
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
+import { cfcAtom } from "@commonfabric/api/cfc";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import { Runtime } from "../src/runtime.ts";
 
@@ -42,7 +43,8 @@ const newRuntime = (options: { serverExecution?: boolean } = {}) => {
   const runtime = new Runtime({
     apiUrl: new URL("https://example.com"),
     storageManager,
-    cfcEnforcementMode: "enforce-explicit",
+    // The probe runs only while the flow dial is on. Every count assertion
+    // below reads the counters that probe increments.
     cfcFlowLabels: "persist",
     ...(options.serverExecution
       ? { experimental: { serverExecution: true } }
@@ -148,7 +150,9 @@ describe("CFC flow-label probe memo (stage C tuning T1)", () => {
   it("the memo never hides a positive verdict: a labeled read marks the tx relevant on the first ask and the second ask does not probe", async () => {
     const { runtime, storageManager } = newRuntime();
     try {
-      // Doc A: labeled secret (the S16 laundering seed).
+      // Doc A: a labeled source (the S16 laundering seed). Its atom is the
+      // audience of the space every document here lives in, so the copy
+      // below lands inside the audience it came from.
       const seed = runtime.edit();
       const sourceId = runtime.getCell(
         signer.did(),
@@ -170,7 +174,7 @@ describe("CFC flow-label probe memo (stage C tuning T1)", () => {
             version: 1,
             entries: [{
               path: ["secret"],
-              label: { confidentiality: ["secret"] },
+              label: { confidentiality: [cfcAtom.space(signer.did())] },
             }],
           },
         },
@@ -202,6 +206,65 @@ describe("CFC flow-label probe memo (stage C tuning T1)", () => {
       // probed again by anyone.
       expect(after.computed - before.computed).toBe(1);
       expect(after.memo - before.memo).toBe(0);
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("a write over a labeled path marks the tx relevant with no labeled read", async () => {
+    // The probe answers on the write side too: a transaction that reads
+    // nothing labeled, but overwrites a path in a document that carries
+    // stored label entries, still has flow-label work to do. Reaching that
+    // check means walking past the read side with nothing to report.
+    const { runtime, storageManager } = newRuntime();
+    try {
+      const seed = runtime.edit();
+      const targetId = runtime.getCell(
+        signer.did(),
+        "probe-memo-write-target",
+        undefined,
+      ).getAsNormalizedFullLink().id;
+      writeSeedEnvelopeDoc(seed, signer.did());
+      seed.writeOrThrow({
+        space: signer.did(),
+        scope: "space",
+        id: targetId,
+        path: [],
+      }, {
+        value: { secret: "s3cr3t" },
+        cfc: {
+          version: 1,
+          schemaHash: SEED_ENVELOPE_SCHEMA_HASH,
+          labelMap: {
+            version: 1,
+            entries: [{
+              path: ["secret"],
+              label: { confidentiality: [cfcAtom.space(signer.did())] },
+            }],
+          },
+        },
+      });
+      expect((await seed.commit()).ok).toBeDefined();
+
+      const tx = runtime.edit();
+      tx.writeOrThrow({
+        space: signer.did(),
+        scope: "space",
+        id: targetId,
+        path: ["value", "note"],
+      }, "a sibling the label map does not name");
+      // Committed without `prepareTxForCommit`, so the commit chokepoint is
+      // the first to ask. The probe answers yes and marks the transaction
+      // relevant there, which leaves it relevant and unprepared, and an
+      // enforcing rung refuses that.
+      const before = probeCounts(runtime);
+      expect(tx.getCfcState().relevant).toBe(false);
+      const result = await tx.commit();
+      expect(tx.getCfcState().relevant).toBe(true);
+      expect(String(result.error?.message)).toContain("was not prepared");
+      const after = probeCounts(runtime);
+      expect(after.computed - before.computed).toBe(1);
     } finally {
       await runtime.dispose();
       await storageManager.close();

--- a/packages/runner/test/cfc-gate-read-labels.bench.ts
+++ b/packages/runner/test/cfc-gate-read-labels.bench.ts
@@ -87,7 +87,7 @@ const seedLabeledSources = async (
   const runtime = new Runtime({
     apiUrl: new URL("https://example.com"),
     storageManager,
-    cfcEnforcementMode: "enforce-explicit",
+    // Both arms measure a prepare that runs under persisted flow labels.
     cfcFlowLabels: "persist",
   });
   const sourceNames = Array.from(

--- a/packages/runner/test/cfc-identity-borrowing.test.ts
+++ b/packages/runner/test/cfc-identity-borrowing.test.ts
@@ -22,7 +22,6 @@ describe("CFC write-policy identity borrowing", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
       trustSnapshotProvider: () => ({
         id: "trust-snapshot-identity-borrowing",
         actingPrincipal: signer.did(),

--- a/packages/runner/test/cfc-implementation-identity.test.ts
+++ b/packages/runner/test/cfc-implementation-identity.test.ts
@@ -34,7 +34,6 @@ describe("CFC builtin implementation identity", () => {
     runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "observe",
     });
 
     const captured: Array<unknown> = [];
@@ -74,7 +73,6 @@ describe("CFC builtin implementation identity", () => {
     runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "observe",
     });
 
     const captured: Array<unknown> = [];
@@ -123,7 +121,6 @@ describe("CFC builtin implementation identity", () => {
     runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "observe",
     });
 
     // The name is what the policy identity is read from, and it stays out of
@@ -164,7 +161,6 @@ describe("CFC builtin implementation identity", () => {
     runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "observe",
     });
 
     const captured: Array<unknown> = [];
@@ -205,7 +201,6 @@ describe("CFC builtin implementation identity", () => {
     runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "observe",
     });
 
     const captured: Array<unknown> = [];

--- a/packages/runner/test/cfc-inspect-conf-label-builtin.test.ts
+++ b/packages/runner/test/cfc-inspect-conf-label-builtin.test.ts
@@ -124,7 +124,6 @@ describe("inspectConfLabel builtin (inv-12 Stage 2)", () => {
     runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
       cfcFlowLabels,
     });
     tx = runtime.edit();
@@ -158,8 +157,8 @@ describe("inspectConfLabel builtin (inv-12 Stage 2)", () => {
       const result = runtime.run(tx, testPattern, { doc: source }, resultCell);
       // The blessed pre-commit chokepoint (what production runner paths call):
       // the builtin's initial run happens inside THIS tx, records the
-      // metadata observation, and marks it CFC-relevant — an unprepared
-      // commit would (correctly) reject under enforce-explicit.
+      // metadata observation, and marks it CFC-relevant, which is what lets
+      // the commit through.
       runtime.prepareTxForCommit(tx);
       tx.commit();
 
@@ -286,8 +285,8 @@ describe("inspectConfLabel builtin (inv-12 Stage 2)", () => {
       const result = runtime.run(tx, testPattern, { doc: source }, resultCell);
       // The blessed pre-commit chokepoint (what production runner paths call):
       // the builtin's initial run happens inside THIS tx, records the
-      // metadata observation, and marks it CFC-relevant — an unprepared
-      // commit would (correctly) reject under enforce-explicit.
+      // metadata observation, and marks it CFC-relevant, which is what lets
+      // the commit through.
       runtime.prepareTxForCommit(tx);
       tx.commit();
 
@@ -320,8 +319,8 @@ describe("inspectConfLabel builtin (inv-12 Stage 2)", () => {
       const result = runtime.run(tx, testPattern, { doc: source }, resultCell);
       // The blessed pre-commit chokepoint (what production runner paths call):
       // the builtin's initial run happens inside THIS tx, records the
-      // metadata observation, and marks it CFC-relevant — an unprepared
-      // commit would (correctly) reject under enforce-explicit.
+      // metadata observation, and marks it CFC-relevant, which is what lets
+      // the commit through.
       runtime.prepareTxForCommit(tx);
       tx.commit();
 
@@ -366,8 +365,8 @@ describe("inspectConfLabel builtin (inv-12 Stage 2)", () => {
       const result = runtime.run(tx, testPattern, { doc: source }, resultCell);
       // The blessed pre-commit chokepoint (what production runner paths call):
       // the builtin's initial run happens inside THIS tx, records the
-      // metadata observation, and marks it CFC-relevant — an unprepared
-      // commit would (correctly) reject under enforce-explicit.
+      // metadata observation, and marks it CFC-relevant, which is what lets
+      // the commit through.
       runtime.prepareTxForCommit(tx);
       tx.commit();
 
@@ -397,8 +396,8 @@ describe("inspectConfLabel builtin (inv-12 Stage 2)", () => {
       const result = runtime.run(tx, testPattern, { doc: source }, resultCell);
       // The blessed pre-commit chokepoint (what production runner paths call):
       // the builtin's initial run happens inside THIS tx, records the
-      // metadata observation, and marks it CFC-relevant — an unprepared
-      // commit would (correctly) reject under enforce-explicit.
+      // metadata observation, and marks it CFC-relevant, which is what lets
+      // the commit through.
       runtime.prepareTxForCommit(tx);
       tx.commit();
 
@@ -437,8 +436,8 @@ describe("inspectConfLabel builtin (inv-12 Stage 2)", () => {
       const result = runtime.run(tx, testPattern, { doc: source }, resultCell);
       // The blessed pre-commit chokepoint (what production runner paths call):
       // the builtin's initial run happens inside THIS tx, records the
-      // metadata observation, and marks it CFC-relevant — an unprepared
-      // commit would (correctly) reject under enforce-explicit.
+      // metadata observation, and marks it CFC-relevant, which is what lets
+      // the commit through.
       runtime.prepareTxForCommit(tx);
       tx.commit();
 

--- a/packages/runner/test/cfc-integrity-mint-gate.test.ts
+++ b/packages/runner/test/cfc-integrity-mint-gate.test.ts
@@ -25,7 +25,6 @@ describe("CFC integrity mint gate", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     try {
       // An author persists a source value with a self-attached InjectionSafe
@@ -151,7 +150,6 @@ describe("CFC integrity mint gate", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     try {
       for (const [name, atom] of Object.entries(forgedAtoms)) {

--- a/packages/runner/test/cfc-label-introspection-channel.test.ts
+++ b/packages/runner/test/cfc-label-introspection-channel.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
 
-import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
+import { CFC_ATOM_TYPE, cfcAtom } from "@commonfabric/api/cfc";
 import { Identity } from "@commonfabric/identity";
 import type { URI } from "@commonfabric/memory/interface";
 
@@ -16,6 +16,7 @@ import {
 import { inspectStoredConfLabel } from "../src/cfc/label-introspection.ts";
 import { readStoredCfcMetadata } from "../src/cfc/metadata.ts";
 import { deriveFlowJoin } from "../src/cfc/prepare.ts";
+import type { JSONSchema } from "../src/builder/types.ts";
 import type { CfcLabelMetadataObservation } from "../src/cfc/types.ts";
 import { parseLink } from "../src/link-utils.ts";
 import { Runtime } from "../src/runtime.ts";
@@ -103,7 +104,6 @@ const makeRuntime = (options: {
     {
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
       ...options,
     } as ConstructorParameters<typeof Runtime>[0],
   );
@@ -204,12 +204,17 @@ describe("CFC label-metadata observation channel (inv-12 Stage 2)", () => {
 
   it("persists the observation's confidentiality onto written docs under flow persist", async () => {
     const { storageManager, runtime } = makeRuntime({
+      // The closing assertion reads a stamp off the written document. The
+      // runtime writes that stamp at this rung.
       cfcFlowLabels: "persist",
     });
     try {
       const tx = runtime.edit();
+      // The stamp this test reads back lands on a document in `space`, and
+      // the observation's atom names the readers of that same space.
+      const observed = cfcAtom.space(space);
       tx.recordCfcLabelMetadataObservation(
-        observationFor("of:introspected", ["secret"]),
+        observationFor("of:introspected", [observed]),
       );
       const out = runtime.getCell(space, "channel-out-persist", undefined, tx);
       out.set({ copied: "derived-from-metadata" });
@@ -227,7 +232,7 @@ describe("CFC label-metadata observation channel (inv-12 Stage 2)", () => {
       // The result of a transaction that observed protected label metadata
       // carries that metadata's population label: result label ⊇ the
       // consumed observation's confidentiality.
-      expect(derived!.label.confidentiality).toContainEqual("secret");
+      expect(derived!.label.confidentiality).toContainEqual(observed);
     } finally {
       await runtime.dispose();
       await storageManager.close();
@@ -236,6 +241,9 @@ describe("CFC label-metadata observation channel (inv-12 Stage 2)", () => {
 
   it("keeps verifier reads excluded: raw metadata reads consume nothing", async () => {
     const { storageManager, runtime } = makeRuntime({
+      // The closing assertion is that the written document carries no
+      // derived stamp. This is the rung that stamps, so the absence is
+      // evidence about the verifier read.
       cfcFlowLabels: "persist",
     });
     try {
@@ -344,14 +352,20 @@ describe("CFC label-metadata observation channel (inv-12 Stage 2)", () => {
       ).toEqual([space, "did:key:zforeign"]);
       // And end-to-end: two txs with identical activity, recording in
       // opposite orders, prepare to the SAME digest. Both prepare before
-      // either commits so their journals are byte-identical.
+      // either commits so their journals are byte-identical. The document
+      // they write declares a store policy admitting both observed atoms.
+      const canonSchema = {
+        type: "object",
+        properties: { v: { type: "number" } },
+        ifc: { confidentiality: ["secret-a", "secret-b"] },
+      } as JSONSchema;
       const tx1 = runtime.edit();
-      runtime.getCell(space, "channel-canon", undefined, tx1).set({ v: 1 });
+      runtime.getCell(space, "channel-canon", canonSchema, tx1).set({ v: 1 });
       tx1.recordCfcLabelMetadataObservation(a);
       tx1.recordCfcLabelMetadataObservation(b);
       const digest1 = tx1.prepareCfc();
       const tx2 = runtime.edit();
-      runtime.getCell(space, "channel-canon", undefined, tx2).set({ v: 1 });
+      runtime.getCell(space, "channel-canon", canonSchema, tx2).set({ v: 1 });
       tx2.recordCfcLabelMetadataObservation(b);
       tx2.recordCfcLabelMetadataObservation(a);
       const digest2 = tx2.prepareCfc();
@@ -425,6 +439,8 @@ describe("CFC label-metadata observation channel (inv-12 Stage 2)", () => {
 
   it("inspectStoredConfLabel records the observation at the concrete metadata path", async () => {
     const { storageManager, runtime } = makeRuntime({
+      // The introspection step hands back a protected result, and records
+      // the observation the assertions below read, at this rung.
       cfcFlowLabels: "persist",
     });
     try {
@@ -470,6 +486,9 @@ describe("CFC label-metadata observation channel (inv-12 Stage 2)", () => {
 
   it("collapses a metadata read error to the unobservable arm", async () => {
     const { storageManager, runtime } = makeRuntime({
+      // This is the rung where the introspection step reaches its recording
+      // arm, so the empty observation list below is evidence about the
+      // aborted read.
       cfcFlowLabels: "persist",
     });
     try {

--- a/packages/runner/test/cfc-label-metadata-persist.test.ts
+++ b/packages/runner/test/cfc-label-metadata-persist.test.ts
@@ -42,7 +42,6 @@ describe("CFC persist-seam link-label re-derivation (inv-12 Stage 0)", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
 
     // Seed a source doc whose STORED cfc metadata is the authoritative label
@@ -251,7 +250,6 @@ describe("CFC persist-seam link-label re-derivation (inv-12 Stage 0)", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     try {
       const sourceId = parseLink(

--- a/packages/runner/test/cfc-label-metadata-protection-dial.test.ts
+++ b/packages/runner/test/cfc-label-metadata-protection-dial.test.ts
@@ -23,7 +23,6 @@ describe("CFC label-metadata protection dial (inv-12 Stage 1)", () => {
     return new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
       ...(mode !== undefined ? { cfcLabelMetadataProtection: mode } : {}),
     });
   };
@@ -65,7 +64,7 @@ describe("CFC label-metadata protection dial (inv-12 Stage 1)", () => {
   });
 
   it("allows raising below the pin and pins at the first enforce", () => {
-    const runtime = makeRuntime();
+    const runtime = makeRuntime("off");
     const tx = runtime.edit();
     // off → observe → off: no pin yet, juggling allowed.
     tx.setCfcLabelMetadataProtectionMode("observe");
@@ -80,7 +79,7 @@ describe("CFC label-metadata protection dial (inv-12 Stage 1)", () => {
   it("delegates through TransactionWrapper to the wrapped transaction", () => {
     // The wrapper forwards every dial setter; the new one must reach the
     // wrapped tx (and its pin) identically.
-    const runtime = makeRuntime();
+    const runtime = makeRuntime("off");
     const tx = runtime.edit();
     const wrapper = new TransactionWrapper(tx);
     wrapper.setCfcLabelMetadataProtectionMode("enforce");
@@ -92,7 +91,7 @@ describe("CFC label-metadata protection dial (inv-12 Stage 1)", () => {
   });
 
   it("invalidates a prepared transaction on a real mode change", () => {
-    const runtime = makeRuntime();
+    const runtime = makeRuntime("off");
     const tx = runtime.edit();
     tx.markCfcRelevant("test");
     tx.prepareCfc();

--- a/packages/runner/test/cfc-label-metadata-protection.test.ts
+++ b/packages/runner/test/cfc-label-metadata-protection.test.ts
@@ -72,13 +72,19 @@ describe("CFC cross-space label-metadata persist transform (inv-12 Stage 1)", ()
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
       ...(mode !== undefined ? { cfcLabelMetadataProtection: mode } : {}),
       ...(extra.cfcFlowLabels !== undefined
         ? { cfcFlowLabels: extra.cfcFlowLabels }
         : {}),
     });
     return { storageManager, runtime };
+  };
+
+  // A store that declares the clauses the seeded source's join carries.
+  // Writer-fit measures a join against the declaration at its path.
+  const joinStoreSchema: JSONSchema = {
+    type: "object",
+    ifc: { confidentiality: [userAtom, caveatAtom] } as never,
   };
 
   const persistedEntriesFor = (
@@ -96,11 +102,13 @@ describe("CFC cross-space label-metadata persist transform (inv-12 Stage 1)", ()
 
   // Seed a source doc in `sourceSpace` whose STORED cfc metadata carries a
   // root User clause and a sub-path Caveat entry (the authoritative label
-  // state the link machinery re-derives from).
+  // state the link machinery re-derives from). `extraRootClauses` adds
+  // further clauses to the root entry.
   const seedSource = async (
     runtime: Runtime,
     sourceSpace: MemorySpace,
     name: string,
+    extraRootClauses: { type: string; id: string }[] = [],
   ): Promise<string> => {
     const seed = runtime.edit();
     const sourceId = parseLink(
@@ -120,7 +128,10 @@ describe("CFC cross-space label-metadata persist transform (inv-12 Stage 1)", ()
         labelMap: {
           version: 1,
           entries: [
-            { path: [], label: { confidentiality: [userAtom] } },
+            {
+              path: [],
+              label: { confidentiality: [userAtom, ...extraRootClauses] },
+            },
             { path: ["secret"], label: { confidentiality: [caveatAtom] } },
           ],
         },
@@ -348,7 +359,9 @@ describe("CFC cross-space label-metadata persist transform (inv-12 Stage 1)", ()
       // flipped holds verbatim foreign entries; flipping to enforce commits
       // only NEW cross-space entries — no rewrite of the existing ones —
       // and consumers dispatch on the marker shape, so both forms coexist.
-      const { storageManager, runtime } = makeRuntime(undefined);
+      // The pre-flip world is staged with the dial pinned off; the flipped
+      // half raises the same runtime's dial per transaction below.
+      const { storageManager, runtime } = makeRuntime("off");
       try {
         const sourceId = await seedSource(runtime, spaceA, "mixed-source");
         const targetName = "mixed-target";
@@ -432,6 +445,8 @@ describe("CFC cross-space label-metadata persist transform (inv-12 Stage 1)", ()
 
     it("commits flow-derived entries whose join consumed a foreign labeled read", async () => {
       const { storageManager, runtime } = makeRuntime("enforce", {
+        // `persist` is the rung that writes the flow join into the stored
+        // label map. The assertions below read that `derived` entry.
         cfcFlowLabels: "persist",
       });
       try {
@@ -440,7 +455,12 @@ describe("CFC cross-space label-metadata persist transform (inv-12 Stage 1)", ()
         const source = runtime.getCell(spaceA, "flow-source", undefined, tx);
         const raw = source.getRaw() as { secret?: string };
         expect(raw.secret).toBe("classified");
-        const derived = runtime.getCell(spaceB, "flow-derived", undefined, tx);
+        const derived = runtime.getCell<{ copied: string }>(
+          spaceB,
+          "flow-derived",
+          joinStoreSchema as never,
+          tx,
+        );
         derived.set({ copied: `${raw.secret}!` });
         tx.prepareCfc();
         expect((await tx.commit()).ok).toBeDefined();
@@ -457,7 +477,12 @@ describe("CFC cross-space label-metadata persist transform (inv-12 Stage 1)", ()
           type: CFC_ATOM_TYPE.User,
           subject: commitCfcFieldValue("did:key:alice"),
         });
-        expect(JSON.stringify(entries)).not.toContain("did:key:alice");
+        // The store's declaration is authored in this space and persists
+        // as written. Filtering it out leaves the entries the cross-space
+        // transform governs.
+        expect(
+          JSON.stringify(entries.filter((e) => e.origin !== "declared")),
+        ).not.toContain("did:key:alice");
       } finally {
         await runtime.dispose();
       }
@@ -471,11 +496,16 @@ describe("CFC cross-space label-metadata persist transform (inv-12 Stage 1)", ()
       // other protects.
 
       const { storageManager, runtime } = makeRuntime("enforce", {
+        // `persist` is the rung that writes the flow join into the stored
+        // label map. The declaration the assertions below read is minted
+        // from that join.
         cfcFlowLabels: "persist",
       });
       try {
         await seedSource(runtime, spaceA, "substrate-source");
         const tx = runtime.edit();
+        // Route 2 runs at a rung that rejects a writer-fit misfit. The
+        // `declared` entry the assertions below read is minted there.
         tx.setCfcEnforcementMode("enforce-strict");
         const source = runtime.getCell(
           spaceA,
@@ -532,10 +562,18 @@ describe("CFC cross-space label-metadata persist transform (inv-12 Stage 1)", ()
 
     it("persists same-space flow-derived entries verbatim", async () => {
       const { storageManager, runtime } = makeRuntime("enforce", {
+        // `persist` is the rung that writes the flow join into the stored
+        // label map. The assertions below read that `derived` entry.
         cfcFlowLabels: "persist",
       });
       try {
-        await seedSource(runtime, spaceB, "flow-same-source");
+        // The source carries its own space clause beside the User clause.
+        // Residency admits a space's own clause, and the store below
+        // declares the other two.
+        await seedSource(runtime, spaceB, "flow-same-source", [{
+          type: CFC_ATOM_TYPE.Space,
+          id: spaceB,
+        }]);
         const tx = runtime.edit();
         const source = runtime.getCell(
           spaceB,
@@ -544,10 +582,10 @@ describe("CFC cross-space label-metadata persist transform (inv-12 Stage 1)", ()
           tx,
         );
         const raw = source.getRaw() as { secret?: string };
-        const derived = runtime.getCell(
+        const derived = runtime.getCell<{ copied: string }>(
           spaceB,
           "flow-same-derived",
-          undefined,
+          joinStoreSchema as never,
           tx,
         );
         derived.set({ copied: `${raw.secret}!` });
@@ -616,40 +654,24 @@ describe("CFC cross-space label-metadata persist transform (inv-12 Stage 1)", ()
   });
 
   describe("off", () => {
-    it("persists bytes identical to a runtime without the option", async () => {
+    it("persists the verbatim plaintext form", async () => {
       const offRun = makeRuntime("off");
-      const defaultRun = makeRuntime(undefined);
       try {
-        for (const { runtime } of [offRun, defaultRun]) {
-          const sourceId = await seedSource(runtime, spaceA, "off-source");
-          await commitLinkWrite(runtime, spaceA, sourceId, "off-target");
-        }
+        const sourceId = await seedSource(offRun.runtime, spaceA, "off-source");
+        await commitLinkWrite(offRun.runtime, spaceA, sourceId, "off-target");
         const offTarget = parseLink(
           offRun.runtime.getCell(spaceB, "off-target").getAsLink(),
-        ).id!;
-        const defaultTarget = parseLink(
-          defaultRun.runtime.getCell(spaceB, "off-target").getAsLink(),
         ).id!;
         const offEntries = persistedEntriesFor(
           offRun.storageManager,
           spaceB,
           offTarget,
         );
-        const defaultEntries = persistedEntriesFor(
-          defaultRun.storageManager,
-          spaceB,
-          defaultTarget,
-        );
         expect(offEntries.length).toBeGreaterThan(0);
-        expect(JSON.stringify(offEntries)).toBe(
-          JSON.stringify(defaultEntries),
-        );
-        // And those bytes are the verbatim plaintext form.
         expect(containsCfcFieldCommitment(offEntries)).toBe(false);
         expect(JSON.stringify(offEntries)).toContain("did:key:alice");
       } finally {
         await offRun.runtime.dispose();
-        await defaultRun.runtime.dispose();
       }
     });
   });
@@ -800,6 +822,14 @@ describe("CFC cross-space label-metadata persist transform (inv-12 Stage 1)", ()
       );
       const targetSchema: JSONSchema = {
         type: "object",
+        // The store declares the committed clause the consumed read
+        // carries.
+        ifc: {
+          confidentiality: [{
+            type: CFC_ATOM_TYPE.User,
+            subject: commitCfcFieldValue("did:key:alice"),
+          }],
+        } as never,
         properties: {
           out: {
             type: "string",

--- a/packages/runner/test/cfc-label-view-resolved.test.ts
+++ b/packages/runner/test/cfc-label-view-resolved.test.ts
@@ -36,8 +36,6 @@ describe("cfcLabelViewForResolvedCellWithStatus", () => {
       const runtime = new Runtime({
         apiUrl: new URL("https://example.com"),
         storageManager,
-        cfcEnforcementMode: "enforce-explicit",
-        cfcDeclaredMonotonicity: "enforce",
       });
       try {
         await body(runtime);

--- a/packages/runner/test/cfc-label-view.test.ts
+++ b/packages/runner/test/cfc-label-view.test.ts
@@ -231,7 +231,6 @@ describe("CFC label view helpers", () => {
     const runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "disabled",
     });
     try {
       const tx = runtime.edit();
@@ -268,8 +267,15 @@ describe("CFC label view helpers", () => {
         undefined,
         tx,
       );
-      target.set(source);
-      await tx.commit();
+      const targetLink = parseLink(target.getAsLink());
+      tx.writeOrThrow({
+        space: signer.did(),
+        id: targetLink.id!,
+        type: "application/json",
+        path: [],
+      }, { value: source.getAsLink() });
+      runtime.prepareTxForCommit(tx);
+      expect((await tx.commit()).ok).toBeDefined();
 
       expect(cfcLabelViewForCell(target)).toBeUndefined();
     } finally {
@@ -286,7 +292,6 @@ describe("CFC label view helpers", () => {
     const runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "disabled",
     });
     try {
       const tx = runtime.edit();
@@ -353,6 +358,7 @@ describe("CFC label view helpers", () => {
           },
         },
       });
+      runtime.prepareTxForCommit(tx);
       await tx.commit();
 
       expect(cfcLabelViewForCell(target.key("detail"))).toEqual({
@@ -395,7 +401,6 @@ describe("CFC label view helpers", () => {
     const runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "disabled",
     });
     try {
       const tx = runtime.edit();
@@ -412,25 +417,29 @@ describe("CFC label view helpers", () => {
         undefined,
         tx,
       );
-      target.set({ inner: source } as never);
       const targetLink = parseLink(target.getAsLink());
       writeSeedEnvelopeDoc(tx, signer.did());
+      // The link and its label map are seeded in one whole-envelope write.
       tx.writeOrThrow({
         space: signer.did(),
         id: targetLink.id!,
         type: "application/json",
-        path: ["cfc"],
+        path: [],
       }, {
-        version: 1,
-        schemaHash: SEED_ENVELOPE_SCHEMA_HASH,
-        labelMap: {
+        value: { inner: source.getAsLink() },
+        cfc: {
           version: 1,
-          entries: [{
-            path: ["inner"],
-            label: { confidentiality: ["link-slot-only"] },
-          }],
+          schemaHash: SEED_ENVELOPE_SCHEMA_HASH,
+          labelMap: {
+            version: 1,
+            entries: [{
+              path: ["inner"],
+              label: { confidentiality: ["link-slot-only"] },
+            }],
+          },
         },
       });
+      runtime.prepareTxForCommit(tx);
       await tx.commit();
 
       // Both resolutions run on ONE transaction, so the second is the repeat.
@@ -468,7 +477,6 @@ describe("CFC label view helpers", () => {
     const runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "disabled",
     });
     try {
       const view = {
@@ -504,7 +512,6 @@ describe("CFC label view helpers", () => {
     const runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "disabled",
     });
     try {
       const tx = runtime.edit();
@@ -572,6 +579,7 @@ describe("CFC label view helpers", () => {
           },
         },
       });
+      runtime.prepareTxForCommit(tx);
       await tx.commit();
 
       const storedLinkField = cfcLabelViewFromMetadata(
@@ -674,7 +682,6 @@ describe("CFC label view helpers", () => {
     const runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "disabled",
     });
     try {
       const tx = runtime.edit();
@@ -733,6 +740,7 @@ describe("CFC label view helpers", () => {
           },
         },
       });
+      runtime.prepareTxForCommit(tx);
       await tx.commit();
 
       const value = target.get();
@@ -763,7 +771,6 @@ describe("CFC label view helpers", () => {
     const runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "disabled",
     });
     try {
       const tx = runtime.edit();
@@ -826,6 +833,7 @@ describe("CFC label view helpers", () => {
           },
         },
       });
+      runtime.prepareTxForCommit(tx);
       await tx.commit();
 
       const recovered = target.get();
@@ -855,7 +863,6 @@ describe("CFC label view helpers", () => {
     const runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "disabled",
     });
     try {
       const tx = runtime.edit();
@@ -902,7 +909,14 @@ describe("CFC label view helpers", () => {
         },
         tx,
       );
-      target.set(source);
+      const targetLink = parseLink(target.getAsLink());
+      tx.writeOrThrow({
+        space: signer.did(),
+        id: targetLink.id!,
+        type: "application/json",
+        path: [],
+      }, { value: source.getAsLink() });
+      runtime.prepareTxForCommit(tx);
       await tx.commit();
 
       const recovered = target.get() as { a: unknown; b: unknown };
@@ -934,7 +948,6 @@ describe("CFC label view helpers", () => {
     const runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "disabled",
     });
     try {
       const tx = runtime.edit();
@@ -1003,6 +1016,7 @@ describe("CFC label view helpers", () => {
           },
         },
       });
+      runtime.prepareTxForCommit(tx);
       await tx.commit();
 
       const recovered = target.get() as { item: unknown };
@@ -1032,7 +1046,6 @@ describe("CFC label view helpers", () => {
     const runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "disabled",
     });
     try {
       const tx = runtime.edit();
@@ -1108,6 +1121,7 @@ describe("CFC label view helpers", () => {
           },
         },
       });
+      runtime.prepareTxForCommit(tx);
       await tx.commit();
 
       const recovered = (list.get() as unknown[]).map((item) =>
@@ -1151,7 +1165,6 @@ describe("CFC label view helpers", () => {
     const runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "disabled",
     });
     try {
       const tx = runtime.edit();
@@ -1213,6 +1226,7 @@ describe("CFC label view helpers", () => {
           },
         },
       });
+      runtime.prepareTxForCommit(tx);
       await tx.commit();
 
       const recovered = (list.get() as unknown[]).map((item) =>
@@ -1259,21 +1273,22 @@ describe("CFC label view helpers", () => {
     const runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "disabled",
     });
     try {
-      const tx = runtime.edit();
+      // The items are seeded in their own transaction, committed before the
+      // pattern runs.
+      const seedTx = runtime.edit();
       const first = runtime.getCell(
         signer.did(),
         "cfc-label-view-pattern-first",
         undefined,
-        tx,
+        seedTx,
       );
       const second = runtime.getCell(
         signer.did(),
         "cfc-label-view-pattern-second",
         undefined,
-        tx,
+        seedTx,
       );
       for (
         const [cell, value, integrity] of [
@@ -1282,8 +1297,8 @@ describe("CFC label view helpers", () => {
         ] as const
       ) {
         const link = parseLink(cell.getAsLink());
-        writeSeedEnvelopeDoc(tx, signer.did());
-        tx.writeOrThrow({
+        writeSeedEnvelopeDoc(seedTx, signer.did());
+        seedTx.writeOrThrow({
           space: signer.did(),
           id: link.id!,
           type: "application/json",
@@ -1303,7 +1318,10 @@ describe("CFC label view helpers", () => {
           },
         });
       }
+      runtime.prepareTxForCommit(seedTx);
+      await seedTx.commit();
 
+      const tx = runtime.edit();
       const { commonfabric } = createTrustedBuilder(runtime);
       const { pattern } = commonfabric;
       const renderLabels = pattern<{ items: unknown[] }>(({ items }) => {
@@ -1332,9 +1350,10 @@ describe("CFC label view helpers", () => {
       const result = runtime.run(
         tx,
         renderLabels,
-        { items: [first, second] },
+        { items: [first.withTx(tx), second.withTx(tx)] },
         resultCell,
       );
+      runtime.prepareTxForCommit(tx);
       await tx.commit();
       await result.pull();
 
@@ -1353,20 +1372,24 @@ describe("CFC label view helpers", () => {
         .key("value")
         .resolveAsCell();
 
-      expect(cfcLabelViewForCell(firstValue)).toEqual({
-        version: 1,
-        entries: [{
-          path: [],
-          label: { integrity: ["item-integrity-first"] },
-        }],
-      });
-      expect(cfcLabelViewForCell(secondValue)).toEqual({
-        version: 1,
-        entries: [{
-          path: [],
-          label: { integrity: ["item-integrity-second"] },
-        }],
-      });
+      // The view of a mapped output carries a second entry describing the
+      // link the slot holds, and that entry's atoms name the reference. The
+      // set below holds every named integrity atom at the root path, so it
+      // covers the item's own label and any other item's that reached it.
+      const rootIntegrityAtoms = (cell: unknown) =>
+        new Set(
+          (cfcLabelViewForCell(cell)?.entries ?? [])
+            .filter((entry) => entry.path.length === 0)
+            .flatMap((entry) => entry.label.integrity ?? [])
+            .filter((atom) => typeof atom === "string"),
+        );
+
+      expect(rootIntegrityAtoms(firstValue)).toEqual(
+        new Set(["item-integrity-first"]),
+      );
+      expect(rootIntegrityAtoms(secondValue)).toEqual(
+        new Set(["item-integrity-second"]),
+      );
     } finally {
       await runtime.dispose();
       await storageManager.close();
@@ -1418,6 +1441,7 @@ describe("CFC label view helpers", () => {
         tx,
       );
       target.setRawUntyped([source.getAsLink()]);
+      runtime.prepareTxForCommit(tx);
       await tx.commit();
 
       const schemaLessEntry = runtime.getCellFromLink({
@@ -1503,7 +1527,6 @@ describe("CFC label view helpers", () => {
     const runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "disabled",
     });
     try {
       const cell = runtime.getCell<{ body: string }>(
@@ -1531,6 +1554,7 @@ describe("CFC label view helpers", () => {
             },
           },
         });
+        runtime.prepareTxForCommit(tx);
         return tx.commit();
       };
 

--- a/packages/runner/test/cfc-labelmap-components.test.ts
+++ b/packages/runner/test/cfc-labelmap-components.test.ts
@@ -39,7 +39,6 @@ describe("CFC labelMap component origins", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     try {
       const guarded = internSchema(
@@ -81,7 +80,6 @@ describe("CFC labelMap component origins", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     try {
       const guarded = internSchema(
@@ -140,11 +138,9 @@ describe("CFC labelMap component origins", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     try {
       const seed = runtime.edit();
-      seed.setCfcEnforcementMode("enforce-explicit");
       const source = runtime.getCell(
         signer.did(),
         "cfc-components-link-source",
@@ -160,7 +156,6 @@ describe("CFC labelMap component origins", () => {
       expect((await seed.commit()).ok).toBeDefined();
 
       const tx = runtime.edit();
-      tx.setCfcEnforcementMode("enforce-explicit");
       const linkedSource = runtime.getCell(
         signer.did(),
         "cfc-components-link-source",
@@ -196,7 +191,6 @@ describe("CFC labelMap component origins", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     try {
       const guarded = internSchema(
@@ -255,7 +249,6 @@ describe("CFC labelMap component origins", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     try {
       const guarded = internSchema(

--- a/packages/runner/test/cfc-labelmap-monotone.test.ts
+++ b/packages/runner/test/cfc-labelmap-monotone.test.ts
@@ -24,7 +24,6 @@ describe("CFC labelMap confidentiality monotonicity", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     try {
       const guarded = internSchema(
@@ -116,7 +115,6 @@ describe("CFC labelMap confidentiality monotonicity", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     try {
       const guarded = internSchema(

--- a/packages/runner/test/cfc-link-integrity-gate.test.ts
+++ b/packages/runner/test/cfc-link-integrity-gate.test.ts
@@ -24,7 +24,6 @@ describe("CFC link-write integrity gate", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     try {
       const tx = runtime.edit();

--- a/packages/runner/test/cfc-llm-derived-stamp-builtins.test.ts
+++ b/packages/runner/test/cfc-llm-derived-stamp-builtins.test.ts
@@ -91,7 +91,6 @@ describe("CFC LlmDerived stamping — result-field stamp mechanism", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     try {
       // Model-output write: builtin identity + the stamp schema at ["result"].
@@ -169,7 +168,6 @@ describe("CFC LlmDerived stamping — llm builtins (end to end)", () => {
     runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     tx = runtime.edit();
     ({ commonfabric: builder } = createTrustedBuilder(runtime));
@@ -570,6 +568,8 @@ describe("CFC LlmDerived stamping — llm builtins (end to end)", () => {
     const disabledRuntime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: disabledStorage,
+      // The assertion below reads that `result` carries no LlmDerived atom.
+      // That holds at the `disabled` rung.
       cfcEnforcementMode: "disabled",
     });
     const disabledTx = disabledRuntime.edit();
@@ -619,6 +619,8 @@ describe("CFC LlmDerived stamping — llm builtins (end to end)", () => {
     const disabledRuntime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: disabledStorage,
+      // The assertion below reads that `result` carries no LlmDerived atom.
+      // That holds at the `disabled` rung.
       cfcEnforcementMode: "disabled",
     });
     const disabledTx = disabledRuntime.edit();

--- a/packages/runner/test/cfc-llm-derived-stamp.test.ts
+++ b/packages/runner/test/cfc-llm-derived-stamp.test.ts
@@ -71,7 +71,6 @@ describe("CFC LlmDerived stamping mechanism", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     try {
       // Model-output push: builtin identity, item schema carries the stamp.
@@ -137,7 +136,6 @@ describe("CFC LlmDerived stamping mechanism", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     try {
       const modelTx = runtime.edit();
@@ -195,7 +193,6 @@ describe("CFC LlmDerived stamping mechanism", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     try {
       const authorTx = runtime.edit();
@@ -248,7 +245,6 @@ describe("llmDialog LlmDerived stamping (end to end)", () => {
     const runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     const tx = runtime.edit();
     const { commonfabric } = createTrustedBuilder(runtime);
@@ -346,6 +342,8 @@ describe("llmDialog LlmDerived stamping (end to end)", () => {
     const runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
+      // The assertion below reads that the assistant message document carries
+      // no stored CFC metadata. That holds at the `disabled` rung.
       cfcEnforcementMode: "disabled",
     });
     const tx = runtime.edit();

--- a/packages/runner/test/cfc-meta-seam-write-policy.test.ts
+++ b/packages/runner/test/cfc-meta-seam-write-policy.test.ts
@@ -41,8 +41,6 @@ describe("cfc-meta-seam-write-policy", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
-      cfcFlowLabels: "persist",
     });
 
     // Seed a doc whose stored ["cfc"] metadata labels the whole document:
@@ -142,7 +140,9 @@ describe("cfc-meta-seam-write-policy", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
+      // The assertion at the end of this test reads the sink document's
+      // stored labelMap. Persisting flow labels is what puts the writing
+      // transaction's confidentiality into it.
       cfcFlowLabels: "persist",
     });
     try {

--- a/packages/runner/test/cfc-nonexported-binding-identity.test.ts
+++ b/packages/runner/test/cfc-nonexported-binding-identity.test.ts
@@ -21,10 +21,10 @@ import { getVerifiedProvenance } from "../src/harness/verified-provenance.ts";
 //
 // Scope: these tests assert the writer identity is REGISTERED (provenance
 // carries the bindingIdentity) and RESOLVES onto transactions while handlers
-// run — the value the CFC verifier consumes at commit — under `observe`. A
-// full enforce-mode, end-to-end "the write is accepted" assertion additionally
-// needs trust-snapshot + owner-principal + trusted-event provenance setup,
-// which profile-owner-cfc.test.ts drives via a mocked authoring identity.
+// run — the value the CFC verifier consumes at commit. An end-to-end "the
+// write is accepted" assertion additionally needs trust-snapshot +
+// owner-principal + trusted-event provenance setup, which
+// profile-owner-cfc.test.ts drives via a mocked authoring identity.
 
 const signer = await Identity.fromPassphrase("ct1665-repro");
 const space = signer.did();
@@ -110,7 +110,6 @@ describe("CT-1665: verified binding metadata for non-exported handlers", () => {
     new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "observe",
     });
 
   beforeEach(() => {
@@ -141,6 +140,7 @@ describe("CT-1665: verified binding metadata for non-exported handlers", () => {
           tx,
         );
         const r = rt.run(tx, pattern, {}, resultCell);
+        rt.prepareTxForCommit(tx);
         await tx.commit();
         await r.pull();
 
@@ -180,6 +180,7 @@ describe("CT-1665: verified binding metadata for non-exported handlers", () => {
         tx,
       );
       const r = rt.run(tx, pattern, { initialName: "Init" }, resultCell);
+      rt.prepareTxForCommit(tx);
       await tx.commit();
       await r.pull();
 
@@ -209,6 +210,7 @@ describe("CT-1665: verified binding metadata for non-exported handlers", () => {
         tx1,
       );
       const r1 = rt1.run(tx1, cold, {}, resultCell1);
+      rt1.prepareTxForCommit(tx1);
       await tx1.commit();
       await r1.pull();
       await pm1.flushCompileCacheWrites();
@@ -222,6 +224,7 @@ describe("CT-1665: verified binding metadata for non-exported handlers", () => {
         undefined,
         tx2,
       );
+      rt2.prepareTxForCommit(tx2);
       await tx2.commit();
       await resultCell2.sync();
       await rt2.start(resultCell2);

--- a/packages/runner/test/cfc-observation-classes.test.ts
+++ b/packages/runner/test/cfc-observation-classes.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "@std/expect";
 import { afterEach, describe, it } from "@std/testing/bdd";
 
-import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
+import { CFC_ATOM_TYPE, cfcAtom } from "@commonfabric/api/cfc";
 import type { FabricValue } from "@commonfabric/data-model";
 import { internSchema } from "@commonfabric/data-model-schema";
 import { Identity } from "@commonfabric/identity";
@@ -22,7 +22,7 @@ const space = signer.did();
 
 type StoredEntry = {
   path: string[];
-  label: { confidentiality?: string[]; integrity?: unknown[] };
+  label: { confidentiality?: unknown[]; integrity?: unknown[] };
   origin?: string;
   observes?: string;
 };
@@ -54,11 +54,28 @@ describe("CFC observation classes (C1 read-shape plumbing)", () => {
     runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "observe",
+      // Every assertion below reads a `derived` entry out of the replica, so
+      // the flow stamp has to be persisted rather than measured.
       cfcFlowLabels: "persist",
     });
     return runtime;
   };
+
+  // A seeded confidentiality clause: a synthetic audience beside the space
+  // every document here lives in. The §8.12.4 residency clause admits a label
+  // clause listing the target's own space among its alternatives, so the
+  // transactions below stamp their join onto output documents that declare no
+  // policy of their own. Class selection reads the clause as one opaque unit,
+  // which is what the joins are asserted over.
+  const audience = (tag: string) => ({ anyOf: [tag, cfcAtom.space(space)] });
+
+  // The synthetic audience each clause of a join names, in the join's order.
+  const tagsOf = (join: readonly unknown[] | undefined): string[] | undefined =>
+    join?.map((clause) =>
+      ((clause as { anyOf: unknown[] }).anyOf.find((alternative) =>
+        typeof alternative === "string"
+      )) as string
+    );
 
   const seedDoc = async (
     rt: Runtime,
@@ -91,7 +108,7 @@ describe("CFC observation classes (C1 read-shape plumbing)", () => {
     return replica.getDocument(id)?.cfc?.labelMap?.entries ?? [];
   };
 
-  const derivedConfidentiality = (id: string): string[] | undefined =>
+  const derivedConfidentiality = (id: string): unknown[] | undefined =>
     entriesOf(id).find((e) => e.origin === "derived")?.label.confidentiality;
 
   const readAddress = (id: string, path: string[]) => ({
@@ -107,33 +124,37 @@ describe("CFC observation classes (C1 read-shape plumbing)", () => {
   // slot (implicitly `observes:"followRef"` per the C0 §3 carve-out).
   const seedMixedDoc = (rt: Runtime, cause: string) =>
     seedDoc(rt, cause, { field: "f", slot: { "/": { "link@1": {} } } }, [
-      { path: [], label: { confidentiality: ["root-covering"] } },
+      { path: [], label: { confidentiality: [audience("root-covering")] } },
       {
         path: ["field"],
-        label: { confidentiality: ["field-derived"] },
+        label: { confidentiality: [audience("field-derived")] },
         origin: "derived",
       },
       {
         path: ["slot"],
-        label: { confidentiality: ["pointer-label"] },
+        label: { confidentiality: [audience("pointer-label")] },
         origin: "link",
       },
     ]);
 
   // Runs `observe` inside a fresh tx that also writes an output doc, then
-  // commits (prepareCfc explicitly unless `autoRelevance`), and returns the
-  // output doc's derived flow confidentiality.
+  // commits, and returns the output doc's derived flow confidentiality. With
+  // `autoRelevance` the transaction reaches its commit the way the runtime's
+  // own commit paths take it, which prepares only a transaction something
+  // marked relevant; otherwise the caller marks it by preparing directly.
   const flowJoinOf = async (
     rt: Runtime,
     outCause: string,
     observe: (tx: ReturnType<Runtime["edit"]>) => void,
     options?: { autoRelevance?: boolean },
-  ): Promise<string[] | undefined> => {
+  ): Promise<unknown[] | undefined> => {
     const tx = rt.edit();
     observe(tx);
     const out = rt.getCell(space, outCause, undefined, tx);
     out.set({ copied: true });
-    if (!options?.autoRelevance) {
+    if (options?.autoRelevance) {
+      rt.prepareTxForCommit(tx);
+    } else {
       tx.prepareCfc();
     }
     expect((await tx.commit()).ok).toBeDefined();
@@ -152,7 +173,7 @@ describe("CFC observation classes (C1 read-shape plumbing)", () => {
     const join = await flowJoinOf(rt, "occ-value-out", (tx) => {
       tx.readOrThrow(readAddress(id, []));
     });
-    expect(join).toEqual(["root-covering", "field-derived"]);
+    expect(tagsOf(join)).toEqual(["root-covering", "field-derived"]);
   });
 
   it("shape reads consume enumerate + covering at the node only; value-class entries are skipped", async () => {
@@ -163,29 +184,29 @@ describe("CFC observation classes (C1 read-shape plumbing)", () => {
 
     const rt = makeRuntime();
     const id = await seedDoc(rt, "occ-shape-read", { field: "f" }, [
-      { path: [], label: { confidentiality: ["root-covering"] } },
+      { path: [], label: { confidentiality: [audience("root-covering")] } },
       {
         path: [],
-        label: { confidentiality: ["members-secret"] },
+        label: { confidentiality: [audience("members-secret")] },
         origin: "derived",
         observes: "enumerate",
       },
       {
         path: [],
-        label: { confidentiality: ["content-secret"] },
+        label: { confidentiality: [audience("content-secret")] },
         origin: "derived",
         observes: "value",
       },
       {
         path: ["field"],
-        label: { confidentiality: ["field-derived"] },
+        label: { confidentiality: [audience("field-derived")] },
         origin: "derived",
       },
     ]);
     const join = await flowJoinOf(rt, "occ-shape-out", (tx) => {
       tx.readOrThrow(readAddress(id, []), { nonRecursive: true });
     });
-    expect(join).toEqual(["root-covering", "members-secret"]);
+    expect(tagsOf(join)).toEqual(["root-covering", "members-secret"]);
   });
 
   it("standalone probes consume the link-origin pointer label (SC-8 widening, the new wider join)", async () => {
@@ -201,7 +222,7 @@ describe("CFC observation classes (C1 read-shape plumbing)", () => {
     const join = await flowJoinOf(rt, "occ-probe-out", (tx) => {
       tx.read(readAddress(id, ["slot"]), { meta: linkResolutionProbe });
     });
-    expect(join).toEqual(["pointer-label"]);
+    expect(tagsOf(join)).toEqual(["pointer-label"]);
   });
 
   it("standalone probes auto-mark flow relevance without an explicit prepareCfc", async () => {
@@ -215,14 +236,14 @@ describe("CFC observation classes (C1 read-shape plumbing)", () => {
     }, [
       {
         path: ["slot"],
-        label: { confidentiality: ["pointer-label"] },
+        label: { confidentiality: [audience("pointer-label")] },
         origin: "link",
       },
     ]);
     const join = await flowJoinOf(rt, "occ-probe-relevance-out", (tx) => {
       tx.read(readAddress(id, ["slot"]), { meta: linkResolutionProbe });
     }, { autoRelevance: true });
-    expect(join).toEqual(["pointer-label"]);
+    expect(tagsOf(join)).toEqual(["pointer-label"]);
   });
 
   it("probes covered by a dereference trace are machinery: no followRef consumption", async () => {
@@ -258,7 +279,7 @@ describe("CFC observation classes (C1 read-shape plumbing)", () => {
       seedDoc(rt, cause, { slot: { "/": { "link@1": {} } } }, [
         {
           path: ["slot"],
-          label: { confidentiality: ["ref-secret"] },
+          label: { confidentiality: [audience("ref-secret")] },
           origin: "derived",
           observes: "followRef",
         },
@@ -274,7 +295,7 @@ describe("CFC observation classes (C1 read-shape plumbing)", () => {
     const probeJoin = await flowJoinOf(rt, "occ-explicit-probe-out", (tx) => {
       tx.read(readAddress(probeId, ["slot"]), { meta: linkResolutionProbe });
     });
-    expect(probeJoin).toEqual(["ref-secret"]);
+    expect(tagsOf(probeJoin)).toEqual(["ref-secret"]);
   });
 
   it("followRef observations do not participate in the hereditary integrity meet", async () => {
@@ -292,7 +313,7 @@ describe("CFC observation classes (C1 read-shape plumbing)", () => {
       {
         path: [],
         label: {
-          confidentiality: ["certified-secret"],
+          confidentiality: [audience("certified-secret")],
           integrity: [certified],
         },
       },
@@ -375,7 +396,7 @@ describe("CFC observation classes (C1 read-shape plumbing)", () => {
           entries: [
             {
               path: ["slot"],
-              label: { confidentiality: ["ref-secret"] },
+              label: { confidentiality: [audience("ref-secret")] },
               origin: "derived",
               observes: "followRef",
             },
@@ -386,13 +407,13 @@ describe("CFC observation classes (C1 read-shape plumbing)", () => {
             // split.
             {
               path: ["v"],
-              label: { confidentiality: ["v-content"] },
+              label: { confidentiality: [audience("v-content")] },
               origin: "derived",
               observes: "value",
             },
             {
               path: ["v"],
-              label: { confidentiality: ["v-existence"] },
+              label: { confidentiality: [audience("v-existence")] },
               origin: "derived",
               observes: "shape",
             },
@@ -408,7 +429,7 @@ describe("CFC observation classes (C1 read-shape plumbing)", () => {
     }, { value: guarded.schema });
     expect((await seed.commit()).ok).toBeDefined();
     const taintId = await seedDoc(rt, "occ-carry-forward-taint", { n: 1 }, [
-      { path: [], label: { confidentiality: ["taint"] } },
+      { path: [], label: { confidentiality: [audience("taint")] } },
     ]);
 
     const tx = rt.edit();
@@ -423,14 +444,17 @@ describe("CFC observation classes (C1 read-shape plumbing)", () => {
     // without this the assertions below pass trivially on untouched
     // metadata.
     expect(
-      stored.find((e) => e.origin === "derived" && e.path.join("/") === "other")
-        ?.label.confidentiality,
+      tagsOf(
+        stored.find((e) =>
+          e.origin === "derived" && e.path.join("/") === "other"
+        )?.label.confidentiality,
+      ),
     ).toEqual(["taint"]);
     const slotEntry = stored.find((e) => e.path.join("/") === "slot");
     expect(slotEntry).toBeDefined();
     expect(slotEntry!.observes).toBe("followRef");
     const vClasses = stored.filter((e) => e.path.join("/") === "v")
-      .map((e) => [e.observes, ...(e.label.confidentiality ?? [])]);
+      .map((e) => [e.observes, ...(tagsOf(e.label.confidentiality) ?? [])]);
     expect(vClasses.sort()).toEqual([
       ["shape", "v-existence"],
       ["value", "v-content"],

--- a/packages/runner/test/cfc-persist-split.test.ts
+++ b/packages/runner/test/cfc-persist-split.test.ts
@@ -3,7 +3,9 @@ import { expect } from "@std/expect";
 import type { FabricValue } from "@commonfabric/data-model";
 import { Identity } from "@commonfabric/identity";
 import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
+import { internSchema } from "@commonfabric/data-model-schema";
 import {
+  SEED_ENVELOPE_SCHEMA,
   SEED_ENVELOPE_SCHEMA_HASH,
   writeSeedEnvelopeDoc,
 } from "./cfc-seed-envelope.ts";
@@ -14,6 +16,7 @@ import type { LabelMapEntry } from "../src/cfc/types.ts";
 
 const signer = await Identity.fromPassphrase("runner-cfc-persist-split");
 const space = signer.did();
+const seedEnvelope = internSchema(SEED_ENVELOPE_SCHEMA, true);
 
 type StoredEntry = {
   path: string[];
@@ -50,7 +53,8 @@ describe("CFC observation classes (C2 persist split)", () => {
     runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "observe",
+      // Persisting flow labels is what puts the split value/shape entries in
+      // the document. Every assertion here reads one of them.
       cfcFlowLabels: "persist",
     });
     return runtime;
@@ -76,6 +80,31 @@ describe("CFC observation classes (C2 persist split)", () => {
     });
     expect((await seed.commit()).ok).toBeDefined();
     return id;
+  };
+
+  // Declares the confidentiality a destination document holds, so the
+  // writer-fit gate admits a write carrying that confidentiality onto it.
+  const declareStore = (
+    rt: Runtime,
+    cause: string,
+    confidentiality: string[],
+  ): Promise<string> =>
+    seedDoc(rt, cause, {}, [{ path: [], label: { confidentiality } }]);
+
+  // Records the write-policy input for a raw write, naming the schema the
+  // document's seeded envelope points at. A cell write on the same document
+  // resolves that same schema out of the stored envelope and records it.
+  const recordSeedSchemaInput = (
+    tx: ReturnType<Runtime["edit"]>,
+    id: string,
+    path: string[],
+  ): void => {
+    tx.recordCfcWritePolicyInput({
+      kind: "schema",
+      target: { space, scope: "space", id: id as `${string}:${string}`, path },
+      schemaHash: seedEnvelope.taggedHashString,
+      schema: seedEnvelope.schema,
+    });
   };
 
   const rawDocOf = (
@@ -131,6 +160,8 @@ describe("CFC observation classes (C2 persist split)", () => {
       },
     ]);
 
+    await declareStore(rt, "ps-out", ["secret"]);
+
     // Read-free output write so the hereditary meet keeps the certification
     // and the value entry demonstrably carries integrity.
     const tx = rt.edit();
@@ -141,6 +172,7 @@ describe("CFC observation classes (C2 persist split)", () => {
       { space, scope: "space", id: outId, path: ["value"] },
       { copied: true },
     );
+    recordSeedSchemaInput(tx, outId, ["value"]);
     tx.prepareCfc();
     expect((await tx.commit()).ok).toBeDefined();
 
@@ -215,6 +247,7 @@ describe("CFC observation classes (C2 persist split)", () => {
     const sourceId = await seedDoc(rt, "ps-idem-source", { n: 1 }, [
       { path: [], label: { confidentiality: ["secret"] } },
     ]);
+    await declareStore(rt, "ps-idem-out", ["secret"]);
     const first = await launder(rt, sourceId, "ps-idem-out");
     const before = JSON.stringify(rawDocOf(first.id)?.cfc);
 
@@ -242,6 +275,8 @@ describe("CFC observation classes (C2 persist split)", () => {
     const sourceId = await seedDoc(rt, "ps-parity-source", { n: 1 }, [
       { path: [], label: { confidentiality: ["secret"] } },
     ]);
+    await declareStore(rt, "ps-parity-mid", ["secret"]);
+    await declareStore(rt, "ps-parity-out", ["secret"]);
     const first = await launder(rt, sourceId, "ps-parity-mid");
     // Second hop reads the split-labeled doc and copies onward.
     const second = await launder(rt, first.id, "ps-parity-out");
@@ -267,6 +302,8 @@ describe("CFC observation classes (C2 persist split)", () => {
         label: { confidentiality: ["secret"], integrity: [certified] },
       },
     ]);
+    await declareStore(rt, "ps-shape-mid", ["secret"]);
+    await declareStore(rt, "ps-shape-out", ["secret"]);
     const first = await launder(rt, sourceId, "ps-shape-mid");
 
     const tx = rt.edit();
@@ -277,6 +314,7 @@ describe("CFC observation classes (C2 persist split)", () => {
       { space, scope: "space", id: outId, path: ["value"] },
       { counted: true },
     );
+    recordSeedSchemaInput(tx, outId, ["value"]);
     tx.prepareCfc();
     expect((await tx.commit()).ok).toBeDefined();
 
@@ -303,29 +341,42 @@ describe("CFC observation classes (C2 persist split)", () => {
     const publicId = await seedDoc(rt, "ps-ow-public", { n: 2 }, [
       { path: [], label: { confidentiality: ["public-ish"] } },
     ]);
-    const first = await launder(rt, secretId, "ps-ow-out");
+    // The store holds both audiences in turn, so it declares both. Each hop
+    // writes the whole value without reading the store back, which keeps the
+    // declared clauses out of the hop's own flow join.
+    const outId = await declareStore(rt, "ps-ow-out", [
+      "old-secret",
+      "public-ish",
+    ]);
+    const overwrite = async (sourceId: string, value: FabricValue) => {
+      const tx = rt.edit();
+      tx.readOrThrow(readAddress(sourceId, []));
+      tx.writeOrThrow(
+        {
+          space,
+          scope: "space",
+          id: outId as `${string}:${string}`,
+          path: ["value"],
+        },
+        value,
+      );
+      recordSeedSchemaInput(tx, outId, ["value"]);
+      tx.prepareCfc();
+      expect((await tx.commit()).ok).toBeDefined();
+    };
+
+    await overwrite(secretId, { copied: true });
     expect(
-      first.entries.find((e) => e.observes === "value")?.label.confidentiality,
+      entriesOf(outId).find((e) => e.observes === "value")?.label
+        .confidentiality,
     ).toEqual(["old-secret"]);
 
     // A ROOT overwrite (whole-value write at the stamped path) — a leaf
     // write below the stamp must NOT clear it, so `out.set({...})`'s
     // leaf-diffing would not exercise replace-on-overwrite.
-    const tx = rt.edit();
-    tx.readOrThrow(readAddress(publicId, []));
-    tx.writeOrThrow(
-      {
-        space,
-        scope: "space",
-        id: first.id as `${string}:${string}`,
-        path: ["value"],
-      },
-      { copied: false },
-    );
-    tx.prepareCfc();
-    expect((await tx.commit()).ok).toBeDefined();
+    await overwrite(publicId, { copied: false });
 
-    const valueEntry = entriesOf(first.id).find((e) =>
+    const valueEntry = entriesOf(outId).find((e) =>
       e.origin === "derived" && e.observes === "value"
     );
     expect(valueEntry?.label.confidentiality).toEqual(["public-ish"]);
@@ -347,6 +398,7 @@ describe("CFC observation classes (C2 persist split)", () => {
         label: { confidentiality: ["secret"], integrity: [certified] },
       },
     ]);
+    await declareStore(rt, "ps-compat-out", ["secret"]);
     const tx = rt.edit();
     tx.readOrThrow(readAddress(sourceId, []));
     const out = rt.getCell(space, "ps-compat-out", undefined, tx);
@@ -355,6 +407,7 @@ describe("CFC observation classes (C2 persist split)", () => {
       { space, scope: "space", id: outId, path: ["value"] },
       { copied: true },
     );
+    recordSeedSchemaInput(tx, outId, ["value"]);
     tx.prepareCfc();
     expect((await tx.commit()).ok).toBeDefined();
 
@@ -377,6 +430,7 @@ describe("CFC observation classes (C2 persist split)", () => {
     const sourceId = await seedDoc(rt, "ps-probe-source", { n: 1 }, [
       { path: [], label: { confidentiality: ["secret"] } },
     ]);
+    await declareStore(rt, "ps-probe-mid", ["secret"]);
     const first = await launder(rt, sourceId, "ps-probe-mid");
 
     const tx = rt.edit();

--- a/packages/runner/test/cfc-policy-boundary.test.ts
+++ b/packages/runner/test/cfc-policy-boundary.test.ts
@@ -162,9 +162,10 @@ const withRuntime = async (
   const runtime = new Runtime({
     apiUrl: new URL("https://example.com"),
     storageManager,
-    cfcEnforcementMode: "enforce-explicit",
     cfcSinkMaxConfidentiality: { fetchJson: [USER_ALICE] },
     cfcPolicyRecords: opts.policyRecords ?? POLICY,
+    // Each case names the policy-evaluation rung it is about, and asserts the
+    // decision or the diagnostic that rung produces over one fixture.
     cfcPolicyEvaluation: opts.policyEvaluation ?? "off",
   });
   try {
@@ -363,6 +364,9 @@ describe("CFC policy evaluation at boundaries (B5)", () => {
   describe("input-requirement maxConfidentiality gate", () => {
     const sinkSchema = {
       type: "object",
+      // The write target holds values derived from the Space-labeled cell,
+      // so its root declares that clause as the audience it keeps.
+      ifc: { confidentiality: [SPACE_ATOM] },
       properties: {
         out: {
           type: "string",
@@ -599,6 +603,9 @@ describe("CFC policy evaluation at boundaries (B5)", () => {
           "mode-change-probe",
           {
             type: "object",
+            // The second prepare below reads back the label the first one
+            // persisted, so the root declares the clause `value` carries.
+            ifc: { confidentiality: ["x"] },
             properties: {
               value: { type: "string", ifc: { confidentiality: ["x"] } },
             },

--- a/packages/runner/test/cfc-policy-of-label.test.ts
+++ b/packages/runner/test/cfc-policy-of-label.test.ts
@@ -37,7 +37,6 @@ describe("PolicyOf label-time binding", () => {
     runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
   });
 
@@ -375,7 +374,6 @@ describe("PolicyOf label-time binding", () => {
     const coldRuntime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     try {
       const coldTx = coldRuntime.edit();
@@ -454,7 +452,6 @@ describe("PolicyOf label-time binding", () => {
     const coldRuntime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     try {
       const tx = coldRuntime.edit();
@@ -541,7 +538,6 @@ describe("PolicyOf label-time binding", () => {
     const coldRuntime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     try {
       const coldTx = coldRuntime.edit();
@@ -654,7 +650,9 @@ describe("PolicyOf label-time binding", () => {
     const sinkRuntime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
+      // The sink gate resolves module policy manifests against the
+      // destination space in this mode, which is the lookup the rejection
+      // below turns on.
       cfcPolicyEvaluation: "enforce",
       cfcSinkMaxConfidentiality: { fetchJson: [] },
     });
@@ -709,7 +707,9 @@ describe("PolicyOf label-time binding", () => {
     const sinkRuntime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
+      // The sink gate binds every consumed manifest origin into the commit in
+      // this mode, which is what the tampering below has to disturb for the
+      // commit to reject.
       cfcPolicyEvaluation: "enforce",
       cfcSinkMaxConfidentiality: { fetchJson: [] },
     });

--- a/packages/runner/test/cfc-posture-report.test.ts
+++ b/packages/runner/test/cfc-posture-report.test.ts
@@ -37,6 +37,8 @@ describe("the CFC posture record", () => {
     it("marks an observe rung as deciding nothing", () => {
       const record = cfcPostureReport({
         ...RUNTIME_CFC_DIAL_DEFAULTS,
+        // The assertions below read this rung back out of the record and
+        // check that it decides nothing.
         cfcPolicyEvaluation: "observe",
         cfcPolicySnapshot: undefined,
         cfcSinkMaxConfidentiality: {},
@@ -49,6 +51,8 @@ describe("the CFC posture record", () => {
     it("marks an enforcing rung as deciding on something", () => {
       const record = cfcPostureReport({
         ...RUNTIME_CFC_DIAL_DEFAULTS,
+        // The assertions below check that this rung decides on the rewritten
+        // label rather than only reporting.
         cfcPolicyEvaluation: "enforce",
         cfcPolicySnapshot: undefined,
         cfcSinkMaxConfidentiality: {},
@@ -215,6 +219,9 @@ describe("the CFC posture record", () => {
           experimental: {},
         })],
       [
+        // This case hands the preset an enforcement mode. The parity
+        // assertion then covers a caller-supplied rung reaching both the
+        // constructed Runtime and the projection.
         "remoteClient under max-enforcement, raised to strict",
         () =>
           runtimePresets.remoteClient({

--- a/packages/runner/test/cfc-prefix-provenance-stats.test.ts
+++ b/packages/runner/test/cfc-prefix-provenance-stats.test.ts
@@ -32,16 +32,24 @@ const signer = await Identity.fromPassphrase("runner-cfc-prefix-provenance");
 // (docs/specs/cfc-write-prefix-provenance.md) narrows the gated-read set
 // versus the pre-D4 transaction-global gate. Measurement only — every
 // scenario here pairs its counter assertions with the UNCHANGED enforcement
-// outcome, and the hook-absent default is pinned byte-identical (all-zero
-// stats, same decision).
+// outcome, and the hook-absent run is pinned byte-identical (all-zero stats,
+// same decision).
 
 const FLOOR_ATOM = "prefix-endorsed";
 const OTHER_ATOM = "prefix-unrelated";
 
+// The sink mints the integrity atom its own floor requires. A write through
+// this schema therefore carries the endorsement the write floor checks for.
 const SINK_SCHEMA = {
   type: "object",
   properties: {
-    out: { type: "string", ifc: { requiredIntegrity: [FLOOR_ATOM] } },
+    out: {
+      type: "string",
+      ifc: {
+        requiredIntegrity: [FLOOR_ATOM],
+        addIntegrity: [FLOOR_ATOM],
+      },
+    },
   },
   required: ["out"],
 } as const satisfies JSONSchema;
@@ -53,7 +61,6 @@ const makeRuntime = (options: {
   new Runtime({
     apiUrl: new URL("https://example.com"),
     storageManager: options.storageManager,
-    cfcEnforcementMode: "enforce-explicit",
     ...(options.cfcPrefixProvenanceStats !== undefined
       ? { cfcPrefixProvenanceStats: options.cfcPrefixProvenanceStats }
       : {}),
@@ -110,6 +117,8 @@ describe("CFC prefix-provenance precision counters (Stage 0, doc §6)", () => {
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = makeRuntime({
       storageManager,
+      // The prefix-gated and transaction-global counts compared below are
+      // collected only while this is on.
       cfcPrefixProvenanceStats: true,
     });
     try {
@@ -166,6 +175,8 @@ describe("CFC prefix-provenance precision counters (Stage 0, doc §6)", () => {
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = makeRuntime({
       storageManager,
+      // The bound-source counters read below are collected only while this
+      // is on.
       cfcPrefixProvenanceStats: true,
     });
     try {
@@ -216,6 +227,8 @@ describe("CFC prefix-provenance precision counters (Stage 0, doc §6)", () => {
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = makeRuntime({
       storageManager,
+      // The S7 exemption counter read below is collected only while this is
+      // on.
       cfcPrefixProvenanceStats: true,
     });
     try {
@@ -264,8 +277,8 @@ describe("CFC prefix-provenance precision counters (Stage 0, doc §6)", () => {
 
   it("hook absent: no summary, and the enforcement outcome is identical to hook present", async () => {
     // The §3 re-attempt rejection from the D4 suite, run twice: counters off
-    // (the default) and on. Same reason either way — measurement must be
-    // byte-identical on decisions — and the disabled run reports no summary.
+    // and counters on. The rejection reason is the same either way. The run
+    // with counters off reports no summary.
     const runScenario = async (
       cfcPrefixProvenanceStats: boolean,
     ): Promise<
@@ -338,6 +351,8 @@ describe("CFC prefix-provenance precision counters (Stage 0, doc §6)", () => {
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = makeRuntime({
       storageManager,
+      // With collection on, the zero summary count asserted below says the
+      // gate walked no floored entry.
       cfcPrefixProvenanceStats: true,
     });
     try {
@@ -459,7 +474,13 @@ describe("CFC prefix-provenance summary (direct gate probes)", () => {
         properties: Object.fromEntries(
           Array.from({ length: width }, (_, i) => [
             `f${i}`,
-            { type: "string", ifc: { requiredIntegrity: [FLOOR_ATOM] } },
+            {
+              type: "string",
+              ifc: {
+                requiredIntegrity: [FLOOR_ATOM],
+                addIntegrity: [FLOOR_ATOM],
+              },
+            },
           ]),
         ),
       } as JSONSchema;
@@ -517,7 +538,10 @@ describe("CFC prefix-provenance summary (direct gate probes)", () => {
         properties: {
           [trickyField]: {
             type: "string",
-            ifc: { requiredIntegrity: [FLOOR_ATOM] },
+            ifc: {
+              requiredIntegrity: [FLOOR_ATOM],
+              addIntegrity: [FLOOR_ATOM],
+            },
           },
         },
       } as JSONSchema;

--- a/packages/runner/test/cfc-prepare-bypass.test.ts
+++ b/packages/runner/test/cfc-prepare-bypass.test.ts
@@ -27,7 +27,6 @@ describe("CFC prepareCfc verification bypass", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
       trustSnapshotProvider: () => ({
         id: "trust-snapshot-prepare-bypass",
         actingPrincipal: signer.did(),

--- a/packages/runner/test/cfc-prepare-crash-surfacing.test.ts
+++ b/packages/runner/test/cfc-prepare-crash-surfacing.test.ts
@@ -81,6 +81,15 @@ const altProfileViewSchema: JSONSchema = {
   ifc: { confidentiality: ["other"] },
 } as JSONSchema;
 
+// The document each wish target is seeded into. Its root declares the
+// confidentiality its `name` carries. A second seeding transaction has already
+// read the first secret, and the writer-fit check reads this declaration when
+// that transaction writes a new profile here.
+const secretProfileDocSchema: JSONSchema = {
+  ...(profileViewSchema as Record<string, unknown>),
+  ifc: { confidentiality: ["secret"] },
+} as JSONSchema;
+
 const ambiguousWishShapedSchema: JSONSchema = {
   type: "object",
   properties: {
@@ -175,8 +184,10 @@ describe("wish commit-prep failure surfacing (OW50 seat S-J)", () => {
     });
 
     it("observe mode's in-commit prepare fallback survives the crash instead of throwing", async () => {
-      // Observe mode is a runtime-level dial (a stricter tx cannot be
-      // weakened in place), so this test runs on its own observe runtime.
+      // Observe mode is the subject, so this test runs on its own runtime.
+      // The commit below runs with no prepare call, and
+      // `expect(result.error).toBeUndefined()` reads back that observe records
+      // the prep crash and lets the commit through.
       const observeManager = StorageManager.emulate({ as: signer });
       const observeRuntime = new Runtime({
         apiUrl: new URL("https://example.com"),
@@ -420,7 +431,7 @@ describe("wish commit-prep failure surfacing (OW50 seat S-J)", () => {
           const secretCell = rt.runtime.getCell(
             space,
             cellName,
-            profileViewSchema,
+            secretProfileDocSchema,
             tx,
           );
           secretCell.set({ name });

--- a/packages/runner/test/cfc-privileged-system-write.test.ts
+++ b/packages/runner/test/cfc-privileged-system-write.test.ts
@@ -49,7 +49,6 @@ describe("CFC privileged system write (S18)", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     try {
       const tx = runtime.edit();
@@ -90,6 +89,9 @@ describe("CFC privileged system write (S18)", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
+      // Observe is the rung under test: `expect(result.ok).toBeDefined()`
+      // reads that the forged write lands, and the diagnostics assertion
+      // below reads the record it leaves instead of a rejection.
       cfcEnforcementMode: "observe",
     });
     try {
@@ -131,7 +133,6 @@ describe("CFC privileged system write (S18)", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     try {
       const tx = runtime.edit();
@@ -156,7 +157,6 @@ describe("CFC privileged system write (S18)", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     try {
       const guarded = internSchema(
@@ -197,6 +197,9 @@ describe("CFC privileged system write (S18)", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
+      // The disabled window is the subject. The transaction forges the label
+      // map at this rung, and `unprivilegedSystemWrites.length` is asserted to
+      // be 1 before the escalation below turns that record into a rejection.
       cfcEnforcementMode: "disabled",
     });
     try {
@@ -243,6 +246,9 @@ describe("CFC privileged system write (S18)", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
+      // The disabled rung is the subject. The transaction stays at it through
+      // commit, and `expect(result.ok).toBeDefined()` reads that the forged
+      // write commits.
       cfcEnforcementMode: "disabled",
     });
     try {
@@ -277,7 +283,6 @@ describe("CFC privileged system write (S18)", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     try {
       const tx = runtime.edit();
@@ -315,7 +320,6 @@ describe("CFC privileged system write (S18)", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     try {
       const tx = runtime.edit();
@@ -412,7 +416,6 @@ describe("CFC privileged system write (S18)", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     try {
       const address = await seedLabeledDocument(runtime, "s18-root-erase");
@@ -458,7 +461,6 @@ describe("CFC privileged system write (S18)", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     try {
       const address = await seedLabeledDocument(runtime, "s18-root-strip");
@@ -501,7 +503,6 @@ describe("CFC privileged system write (S18)", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     try {
       const tx = runtime.edit();
@@ -537,7 +538,6 @@ describe("CFC privileged system write (S18)", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     try {
       const address = await seedLabeledDocument(runtime, "s18-root-preserve");
@@ -564,7 +564,6 @@ describe("CFC privileged system write (S18)", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     try {
       for (
@@ -596,7 +595,6 @@ describe("CFC privileged system write (S18)", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     try {
       const address = await seedLabeledDocument(runtime, "s18-root-future");
@@ -617,6 +615,9 @@ describe("CFC privileged system write (S18)", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
+      // Observe is the rung under test: `expect(result.ok).toBeDefined()`
+      // reads that the erasing write lands, and the diagnostics assertion
+      // below reads the record it leaves instead of a rejection.
       cfcEnforcementMode: "observe",
     });
     try {
@@ -642,6 +643,9 @@ describe("CFC privileged system write (S18)", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
+      // The disabled window is the subject. The erasing write happens at this
+      // rung, and `unprivilegedSystemWrites.length` is asserted to be 1 before
+      // the escalation below turns that record into a rejection.
       cfcEnforcementMode: "disabled",
     });
     try {
@@ -671,7 +675,6 @@ describe("CFC privileged system write (S18)", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     try {
       const guarded = internSchema(
@@ -749,7 +752,6 @@ describe("CFC privileged system write (S18)", () => {
         const runtime = new Runtime({
           apiUrl: new URL("https://example.com"),
           storageManager: storage,
-          cfcEnforcementMode: "enforce-explicit",
         });
         try {
           const seed = runtime.edit();
@@ -779,7 +781,6 @@ describe("CFC privileged system write (S18)", () => {
         const runtime = new Runtime({
           apiUrl: new URL("https://example.com"),
           storageManager: storage,
-          cfcEnforcementMode: "enforce-explicit",
         });
         try {
           const tx = runtime.edit();

--- a/packages/runner/test/cfc-projection.test.ts
+++ b/packages/runner/test/cfc-projection.test.ts
@@ -23,7 +23,6 @@ describe("CFC projection claims", () => {
     const runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     return { runtime, storageManager };
   };

--- a/packages/runner/test/cfc-read-scope.test.ts
+++ b/packages/runner/test/cfc-read-scope.test.ts
@@ -34,7 +34,6 @@ const newRuntime = (
   new Runtime({
     apiUrl: new URL("https://example.com"),
     storageManager,
-    cfcEnforcementMode: "enforce-explicit",
     cfcFlowLabels: "persist",
   });
 

--- a/packages/runner/test/cfc-redundant-entry-collapse.test.ts
+++ b/packages/runner/test/cfc-redundant-entry-collapse.test.ts
@@ -37,7 +37,9 @@ const newRuntime = (
   new Runtime({
     apiUrl: new URL("https://example.com"),
     storageManager,
-    cfcEnforcementMode: "enforce-explicit",
+    // Every assertion below reads back `derived` and `structure` entries of a
+    // stored label map. The persisting rung of the flow-label dial is what
+    // writes those entries.
     cfcFlowLabels: "persist",
   });
 
@@ -163,13 +165,15 @@ describe("CFC redundant entry collapse", () => {
   it("keeps a stamp carrying a clause the declared component does not", async () => {
     // The join of an append that also read an unrelated labeled source
     // carries a clause the element declaration does not, so the stamp is
-    // the only place that clause is recorded at the appended index.
+    // the only place that clause is recorded at the appended index. The
+    // source's clause names the space every document here lives in, which
+    // §8.12.4 residency admits into the list's write ceiling.
 
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = newRuntime(storageManager);
     try {
       await seedSource(runtime, "collapse-foreign-source", [
-        cfcAtom.resource("Other"),
+        cfcAtom.space(signer.did()),
       ]);
 
       const seeded = runtime.edit();
@@ -212,7 +216,7 @@ describe("CFC redundant entry collapse", () => {
       expect(stamped.length).toBeGreaterThan(0);
       for (const entry of stamped) {
         expect(entry.label.confidentiality).toContainEqual(
-          cfcAtom.resource("Other"),
+          cfcAtom.space(signer.did()),
         );
       }
     } finally {
@@ -492,13 +496,15 @@ describe("CFC redundant entry collapse", () => {
   it("keeps the root stamps a wildcard child declaration does not reach", async () => {
     // A declared entry at `["*"]` covers the children and not the container
     // node they hang off, so the stamps recording what the container's own
-    // write derived from stay where they are.
+    // write derived from stay where they are. The source's clause names the
+    // space every document here lives in, which §8.12.4 residency admits into
+    // the map's write ceiling.
 
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = newRuntime(storageManager);
     try {
       await seedSource(runtime, "collapse-container-source", [
-        cfcAtom.resource("Outer"),
+        cfcAtom.space(signer.did()),
       ]);
 
       const tx = runtime.edit();
@@ -538,7 +544,7 @@ describe("CFC redundant entry collapse", () => {
       expect(rootStamps.length).toBeGreaterThan(0);
       for (const entry of rootStamps) {
         expect(entry.label.confidentiality).toContainEqual(
-          cfcAtom.resource("Outer"),
+          cfcAtom.space(signer.did()),
         );
       }
     } finally {

--- a/packages/runner/test/cfc-refusal-detail.test.ts
+++ b/packages/runner/test/cfc-refusal-detail.test.ts
@@ -260,7 +260,6 @@ describe("refusal-detail", () => {
       runtime = new Runtime({
         apiUrl: new URL(import.meta.url),
         storageManager,
-        cfcEnforcementMode: "enforce-explicit",
         cfcFlowLabels: "persist",
         cfcSinkMaxConfidentiality: { fetchText: [], llm: [] },
         errorHandlers: [(error) => reported.push(error)],
@@ -419,7 +418,6 @@ describe("refusal-detail", () => {
       const runtime = new Runtime({
         apiUrl: new URL("https://example.com"),
         storageManager,
-        cfcEnforcementMode: "enforce-explicit",
         cfcFlowLabels: "persist",
       });
       try {
@@ -476,7 +474,6 @@ describe("refusal-detail", () => {
       runtime = new Runtime({
         apiUrl: new URL("https://example.com"),
         storageManager,
-        cfcEnforcementMode: "enforce-explicit",
         cfcFlowLabels: "persist",
         cfcSinkMaxConfidentiality: { fetchText: [] },
       });

--- a/packages/runner/test/cfc-required-integrity-coherence.test.ts
+++ b/packages/runner/test/cfc-required-integrity-coherence.test.ts
@@ -137,10 +137,14 @@ describe("CFC requiredIntegrity coherence (B5)", () => {
       required: unknown,
     ): Promise<{ ok: boolean; message?: string }> => {
       const storageManager = StorageManager.emulate({ as: signer });
+      // The subject here is the read-side coherence matcher. The sink
+      // receives a literal carrying no endorsement of its own, and the
+      // observing rung of the write-floor dial is what lets "admits a shared
+      // witness across every consumed read" reach a committed transaction.
       const runtime = new Runtime({
         apiUrl: new URL("https://example.com"),
         storageManager,
-        cfcEnforcementMode: "enforce-explicit",
+        cfcWriteFloor: "observe",
       });
       try {
         for (const [index, witness] of witnesses.entries()) {
@@ -176,6 +180,9 @@ describe("CFC requiredIntegrity coherence (B5)", () => {
               },
             },
             required: ["out"],
+            // The sink holds what the sources carry, so it declares their
+            // confidentiality at the root the transaction writes.
+            ifc: { confidentiality: ["s"] },
           } as JSONSchema,
           tx,
         ).set({ out: "derived" });
@@ -241,6 +248,9 @@ describe("CFC requiredIntegrity coherence (B5)", () => {
         },
       },
       required: ["out"],
+      // The sink holds what the sources carry, so it declares their
+      // confidentiality at the root the transaction writes.
+      ifc: { confidentiality: ["s"] },
     } as JSONSchema;
 
     // Seed two labeled sources (witnesses A and B), then run one tx that reads
@@ -254,10 +264,15 @@ describe("CFC requiredIntegrity coherence (B5)", () => {
       readBAfterWrite: boolean,
     ): Promise<{ ok: boolean; message?: string }> => {
       const storageManager = StorageManager.emulate({ as: signer });
+      // The subject here is the read-side coherence matcher. The sink
+      // receives a literal carrying no endorsement of its own, and the
+      // observing rung of the write-floor dial is what lets "admits a
+      // heterogeneous witness pair when the second read is past the write
+      // bound" reach a committed transaction.
       const runtime = new Runtime({
         apiUrl: new URL("https://example.com"),
         storageManager,
-        cfcEnforcementMode: "enforce-explicit",
+        cfcWriteFloor: "observe",
       });
       try {
         for (const [index, witness] of [witnessA, witnessB].entries()) {

--- a/packages/runner/test/cfc-required-integrity-provenance.test.ts
+++ b/packages/runner/test/cfc-required-integrity-provenance.test.ts
@@ -67,10 +67,17 @@ const seedLabeledDoc = async (
   expect((await seed.commit()).ok).toBeDefined();
 };
 
+// The sink names the admin endorsement twice on `out`: it is required there,
+// and it is minted there. The mint is what the write-side floor credits the
+// written value with. The read-side gate these steps exercise quantifies over
+// the reads the transaction consumed, so the mint leaves it alone.
 const SINK_SCHEMA = {
   type: "object",
   properties: {
-    out: { type: "string", ifc: { requiredIntegrity: [ADMIN_ATOM] } },
+    out: {
+      type: "string",
+      ifc: { requiredIntegrity: [ADMIN_ATOM], addIntegrity: [ADMIN_ATOM] },
+    },
   },
   required: ["out"],
 } as const satisfies JSONSchema;
@@ -81,7 +88,6 @@ describe("CFC requiredIntegrity provenance scoping (S7)", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     try {
       // A lookup doc whose stored label is entirely provenance: a link
@@ -124,7 +130,6 @@ describe("CFC requiredIntegrity provenance scoping (S7)", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     try {
       await seedLabeledDoc(runtime, "ri-empty-lookup", "lookup", {});
@@ -157,7 +162,6 @@ describe("CFC requiredIntegrity provenance scoping (S7)", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     try {
       await seedLabeledDoc(runtime, "ri-conf-src", "briefing", {
@@ -193,7 +197,6 @@ describe("CFC requiredIntegrity provenance scoping (S7)", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     try {
       await seedLabeledDoc(runtime, "ri-mixed-src", "data", {
@@ -237,7 +240,6 @@ describe("CFC requiredIntegrity provenance scoping (S7)", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     try {
       const seed = runtime.edit();

--- a/packages/runner/test/cfc-resume-membership-taint.test.ts
+++ b/packages/runner/test/cfc-resume-membership-taint.test.ts
@@ -62,7 +62,8 @@ describe("CFC resume membership taint", () => {
     new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: storageManager!,
-      cfcEnforcementMode: "observe",
+      // Persisting flow labels is what writes the structure stamp this test
+      // reads back through `structureConfidentiality`.
       cfcFlowLabels: "persist",
     });
 
@@ -87,6 +88,7 @@ describe("CFC resume membership taint", () => {
         },
       },
     });
+    rt.prepareTxForCommit(seed);
     expect((await seed.commit()).ok).toBeDefined();
     return id;
   };
@@ -106,6 +108,7 @@ describe("CFC resume membership taint", () => {
     const rtx = rt.edit();
     const id =
       keptCell.withTx(rtx).resolveAsCell().getAsNormalizedFullLink().id;
+    rt.prepareTxForCommit(rtx);
     rtx.commit();
     return id;
   };
@@ -143,6 +146,7 @@ describe("CFC resume membership taint", () => {
       tx0,
     );
     rt1.run(tx0, compiled, { items: listCell }, rc1);
+    rt1.prepareTxForCommit(tx0);
     expect((await tx0.commit()).ok).toBeDefined();
     await rc1.pull();
     await rt1.settled();
@@ -171,18 +175,21 @@ describe("CFC resume membership taint", () => {
     const rtMid = newRuntime();
     await seedLabeledDoc(rtMid, "memb-el-2", { n: -1 }, "carol-secret");
     const txMid = rtMid.edit();
-    const el2 = rtMid.getCell(space, "memb-el-2", undefined, txMid);
     const listMid = rtMid.getCell(
       space,
       LIST_CAUSE,
       { type: "array", items: { asCell: ["cell"] } },
       txMid,
     );
-    await listMid.sync();
-    listMid.withTx(txMid).set([
-      ...(listMid.get() as unknown[]),
-      el2,
+    // Each element is named by its cause, so this write states the whole
+    // membership. The labels the stored list carries reach nothing in this
+    // transaction.
+    listMid.set([
+      rtMid.getCell(space, "memb-el-0", undefined, txMid),
+      rtMid.getCell(space, "memb-el-1", undefined, txMid),
+      rtMid.getCell(space, "memb-el-2", undefined, txMid),
     ]);
+    rtMid.prepareTxForCommit(txMid);
     expect((await txMid.commit()).ok).toBeDefined();
     await storageManager.synced();
     await rtMid.dispose({ closeStorage: false });
@@ -199,6 +206,7 @@ describe("CFC resume membership taint", () => {
         compiled.resultSchema,
         tx2,
       );
+      rt2.prepareTxForCommit(tx2);
       expect((await tx2.commit()).ok).toBeDefined();
       await rc2.sync();
       expect(await rt2.start(rc2)).toBe(true);

--- a/packages/runner/test/cfc-runtime-options.test.ts
+++ b/packages/runner/test/cfc-runtime-options.test.ts
@@ -25,6 +25,7 @@ describe("CFC runtime options", () => {
     const runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
+      // The assertion below reads this value back off the runtime.
       cfcEnforcementMode: "disabled",
     });
 

--- a/packages/runner/test/cfc-runtime-stats.test.ts
+++ b/packages/runner/test/cfc-runtime-stats.test.ts
@@ -27,7 +27,6 @@ describe("CFC runtime stats", () => {
     runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
 
     expect(runtime.getCfcStats()).toEqual({
@@ -52,7 +51,6 @@ describe("CFC runtime stats", () => {
     });
 
     const preparedTx = runtime.edit();
-    preparedTx.setCfcEnforcementMode("enforce-explicit");
     preparedTx.markCfcRelevant("stats-prepared");
     const preparedCell = runtime.getCell(
       space,
@@ -88,7 +86,6 @@ describe("CFC runtime stats", () => {
     expect(preparedFlushCount).toBe(1);
 
     const rejectTx = runtime.edit();
-    rejectTx.setCfcEnforcementMode("enforce-explicit");
     rejectTx.markCfcRelevant("stats-reject");
     const rejectCell = runtime.getCell(
       space,
@@ -112,7 +109,6 @@ describe("CFC runtime stats", () => {
     );
 
     const invalidationTx = runtime.edit();
-    invalidationTx.setCfcEnforcementMode("enforce-explicit");
     invalidationTx.markCfcRelevant("stats-invalidation");
     const invalidationCell = runtime.getCell(
       space,
@@ -168,10 +164,11 @@ describe("CFC runtime stats", () => {
 
     expect(runtime.getCfcStats()).toEqual({
       cfcRelevantTx: 4,
-      // Stage C tuning T1: this runtime leaves the flow-labels dial at its
-      // "off" default, so the flow-label probe never runs here and its
-      // memo is never consulted. The probe's own pins live in
-      // cfc-flow-probe-memo.test.ts.
+      // Two gates keep the probe from running here. It runs only on a
+      // transaction nothing has marked relevant, and every transaction above
+      // calls markCfcRelevant before it commits; it also runs only when the
+      // flow-labels dial is not "off", and this runtime leaves it off. The
+      // probe's own counters are exercised in cfc-flow-probe-memo.test.ts.
       flowLabelProbesComputed: 0,
       flowLabelProbeMemoHits: 0,
       cfcPreparedTx: 3,

--- a/packages/runner/test/cfc-single-use-grants.test.ts
+++ b/packages/runner/test/cfc-single-use-grants.test.ts
@@ -263,10 +263,12 @@ describe("CFC single-use grants (§2.2 single-use releases)", () => {
     opts: {
       receipts?: boolean;
       policyEvaluation?: "off" | "observe" | "enforce";
-      enforcement?: "enforce-explicit" | "observe" | "disabled";
       rules?: readonly ExchangeRule[];
     },
-    body: (runtime: Runtime) => void | Promise<void>,
+    body: (
+      runtime: Runtime,
+      storageManager: ReturnType<typeof StorageManager.emulate>,
+    ) => void | Promise<void>,
   ): Promise<void> => {
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = new Runtime({
@@ -275,16 +277,17 @@ describe("CFC single-use grants (§2.2 single-use releases)", () => {
       // The receipts dial: the Runtime constructor propagates it to the
       // ambient commit-preconditions config the storage commit consults.
       experimental: { commitPreconditions: opts.receipts ?? true },
-      cfcEnforcementMode: opts.enforcement ?? "enforce-explicit",
       cfcSinkMaxConfidentiality: { fetchJson: [userBob] },
       cfcPolicyRecords: [{
         id: "share-policy",
         rules: [...(opts.rules ?? [sinkShareRule])],
       }],
+      // The rule firings these tests assert on happen inside policy
+      // evaluation.
       cfcPolicyEvaluation: opts.policyEvaluation ?? "enforce",
     });
     try {
-      await body(runtime);
+      await body(runtime, storageManager);
     } finally {
       await runtime.dispose();
       await storageManager.close();
@@ -540,28 +543,13 @@ describe("CFC single-use grants (§2.2 single-use releases)", () => {
     });
 
     it("garbage at the receipt address still counts as consumed (presence is the signal)", async () => {
-      // Seed garbage at the receipt address through an observe-enforcement
-      // runtime (the forged-write diagnosis path — same discipline as the
-      // malformed-grant test in cfc-grant-records).
-      const storageManager = StorageManager.emulate({ as: signer });
-      const observeRuntime = new Runtime({
-        apiUrl: new URL("https://example.com"),
-        storageManager,
-        experimental: { commitPreconditions: true },
-        cfcEnforcementMode: "observe",
-        cfcPolicyRecords: [{ id: "share-policy", rules: [sinkShareRule] }],
-        cfcPolicyEvaluation: "enforce",
-      });
-      try {
-        const grantId = cfcGrantDocId({
-          space: signer.did(),
-          kind: "ShareGrant",
-          owner: signer.did(),
-          resource: PHOTO_REF,
-        });
-        const receiptId = cfcGrantConsumedReceiptId(grantId);
-        await writeGrant(observeRuntime);
-        const seed = observeRuntime.edit();
+      await withRuntime({}, async (runtime, storageManager) => {
+        const receiptId = cfcGrantConsumedReceiptId(grantIdFor(runtime));
+        await writeGrant(runtime);
+        // A bare storage transaction carries no CFC state, so the forged
+        // receipt lands at the reserved address unexamined. The subject is
+        // what the resolver then makes of the document sitting there.
+        const seed = new ExtendedStorageTransaction(storageManager.edit());
         seed.writeOrThrow({
           space: signer.did(),
           id: receiptId,
@@ -570,7 +558,7 @@ describe("CFC single-use grants (§2.2 single-use releases)", () => {
         }, { forged: "garbage" });
         expect((await seed.commit()).ok).toBeDefined();
 
-        const tx = observeRuntime.edit();
+        const tx = runtime.edit();
         const resolver = createTxCfcGrantResolver(tx);
         expect(
           resolver({
@@ -580,10 +568,7 @@ describe("CFC single-use grants (§2.2 single-use releases)", () => {
           }),
         ).toEqual([]);
         tx.abort();
-      } finally {
-        await observeRuntime.dispose();
-        await storageManager.close();
-      }
+      });
     });
 
     it("a metadata-only (value-less) receipt document still counts as consumed", async () => {
@@ -595,27 +580,14 @@ describe("CFC single-use grants (§2.2 single-use releases)", () => {
       // create-only backstop would still kill the release at commit — any
       // prior set on the entity fails the entity-absent precondition — but
       // resolution itself must already fail closed as consumed.
-      const storageManager = StorageManager.emulate({ as: signer });
-      const observeRuntime = new Runtime({
-        apiUrl: new URL("https://example.com"),
-        storageManager,
-        experimental: { commitPreconditions: true },
-        cfcEnforcementMode: "observe",
-        cfcPolicyRecords: [{ id: "share-policy", rules: [sinkShareRule] }],
-        cfcPolicyEvaluation: "enforce",
-      });
-      try {
-        const grantId = cfcGrantDocId({
-          space: signer.did(),
-          kind: "ShareGrant",
-          owner: signer.did(),
-          resource: PHOTO_REF,
-        });
-        const receiptId = cfcGrantConsumedReceiptId(grantId);
-        await writeGrant(observeRuntime);
+      await withRuntime({}, async (runtime, storageManager) => {
+        const receiptId = cfcGrantConsumedReceiptId(grantIdFor(runtime));
+        await writeGrant(runtime);
         // A full-document write with NO value key: the document exists, its
         // ["value"] subpath does not (the `source`-only sibling-field shape).
-        const seed = observeRuntime.edit();
+        // A bare storage transaction carries no CFC state, so it lands at the
+        // reserved address unexamined.
+        const seed = new ExtendedStorageTransaction(storageManager.edit());
         seed.writeOrThrow({
           space: signer.did(),
           id: receiptId,
@@ -624,7 +596,7 @@ describe("CFC single-use grants (§2.2 single-use releases)", () => {
         }, { source: { note: "metadata-only" } } as never);
         expect((await seed.commit()).ok).toBeDefined();
 
-        const tx = observeRuntime.edit();
+        const tx = runtime.edit();
         const resolver = createTxCfcGrantResolver(tx);
         expect(
           resolver({
@@ -640,10 +612,7 @@ describe("CFC single-use grants (§2.2 single-use releases)", () => {
           ),
         ).toBe(true);
         tx.abort();
-      } finally {
-        await observeRuntime.dispose();
-        await storageManager.close();
-      }
+      });
     });
 
     it("flag off: unsatisfiable even in consuming queries, with a diagnostic", async () => {
@@ -965,9 +934,10 @@ describe("CFC single-use grants (§2.2 single-use releases)", () => {
         apiUrl: new URL("https://example.com"),
         storageManager: base,
         experimental: { commitPreconditions: true },
-        cfcEnforcementMode: "enforce-explicit",
         cfcSinkMaxConfidentiality: { fetchJson: [userBob] },
         cfcPolicyRecords: [{ id: "share-policy", rules: [sinkShareRule] }],
+        // The release under test is a rule firing, which happens inside
+        // policy evaluation.
         cfcPolicyEvaluation: "enforce",
       });
       try {
@@ -1205,6 +1175,9 @@ describe("CFC single-use grants (§2.2 single-use releases)", () => {
       };
       const gatedSchema = {
         type: "object",
+        // The released value lands on the document root carrying the owner's
+        // confidentiality, so the store declares it there.
+        ifc: { confidentiality: [cfcAtom.user(signer.did())] },
         properties: {
           out: {
             type: "string",

--- a/packages/runner/test/cfc-sink-ceiling-link-read.test.ts
+++ b/packages/runner/test/cfc-sink-ceiling-link-read.test.ts
@@ -78,7 +78,6 @@ describe("CFC sink ceiling on values pulled through schema-less links", () => {
     runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
       cfcSinkMaxConfidentiality: { fetchJson: [] },
     });
 
@@ -163,6 +162,8 @@ describe("CFC sink ceiling on values pulled through schema-less links", () => {
     const observeRuntime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: observeStorage,
+      // The rung under test: the commit below succeeds and the ceiling
+      // violation arrives as a diagnostic.
       cfcEnforcementMode: "observe",
       cfcSinkMaxConfidentiality: { fetchJson: [] },
     });

--- a/packages/runner/test/cfc-sink-request-policy.test.ts
+++ b/packages/runner/test/cfc-sink-request-policy.test.ts
@@ -109,7 +109,6 @@ describe("CFC sink request policy", () => {
     const runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "observe",
     });
     const tx = runtime.edit();
 

--- a/packages/runner/test/cfc-template-metadata-population.test.ts
+++ b/packages/runner/test/cfc-template-metadata-population.test.ts
@@ -2,7 +2,7 @@ import { expect } from "@std/expect";
 import { afterEach, describe, it } from "@std/testing/bdd";
 
 import type { CfcAtom } from "@commonfabric/api/cfc";
-import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
+import { CFC_ATOM_TYPE, cfcAtom } from "@commonfabric/api/cfc";
 import type { FabricValue } from "@commonfabric/data-model";
 import { internSchema } from "@commonfabric/data-model-schema";
 import { Identity } from "@commonfabric/identity";
@@ -54,6 +54,21 @@ const caveatAtom = (source: CfcAtom = SOURCE_A) => ({
   kind: "prompt-influence",
   source,
 });
+
+/**
+ * A confidentiality clause whose alternatives include the readers of the
+ * space these fixtures store their documents in.
+ *
+ * §8.12.4 joins `Space(<the target's space>)` onto every write ceiling. A
+ * clause naming that space therefore fits a document held there. A
+ * transaction reading such a clause derives from it into a store that
+ * declares no policy of its own. The remaining alternatives ride along
+ * inside the clause, where the label-metadata mint reads their
+ * source-bearing fields.
+ */
+const residentClause = (
+  ...alternatives: readonly CfcConfClause[]
+): CfcConfClause => ({ anyOf: [cfcAtom.space(space), ...alternatives] });
 
 const metadataWith = (
   entries: CfcMetadata["labelMap"]["entries"],
@@ -113,7 +128,6 @@ describe("CFC template metadata population (Stage B): persist-seam mints", () =>
     runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "observe",
       cfcFlowLabels: "persist",
     });
     return runtime;
@@ -150,6 +164,26 @@ describe("CFC template metadata population (Stage B): persist-seam mints", () =>
     return replica.getDocument(id)?.cfc?.labelMap?.entries ?? [];
   };
 
+  // The schema write-policy input a cell write records for its target. The
+  // write-policy gate asks for one on a document whose label map carries
+  // minted templates. A write addressed straight at the document records it
+  // alongside.
+  const recordSchemaInput = (
+    tx: ReturnType<Runtime["edit"]>,
+    id: string,
+  ): void => {
+    tx.recordCfcWritePolicyInput({
+      kind: "schema",
+      target: {
+        space,
+        scope: "space",
+        id: id as `${string}:${string}`,
+        path: ["value"],
+      },
+      schema: { type: "object" },
+    });
+  };
+
   const readAddress = (id: string, path: string[]) => ({
     space,
     scope: "space" as const,
@@ -184,7 +218,7 @@ describe("CFC template metadata population (Stage B): persist-seam mints", () =>
 
     const rt = makeRuntime();
     const criteriaId = await seedDoc(rt, "mp-criteria", { keep: true }, [
-      { path: [], label: { confidentiality: [caveatAtom()] } },
+      { path: [], label: { confidentiality: [residentClause(caveatAtom())] } },
     ]);
     const outId = await deriveOutDoc(rt, "mp-out", criteriaId);
 
@@ -202,7 +236,9 @@ describe("CFC template metadata population (Stage B): persist-seam mints", () =>
       ],
     ]);
     for (const entry of templates) {
-      expect(entry.label.confidentiality).toEqual([caveatAtom()]);
+      expect(entry.label.confidentiality).toEqual([
+        residentClause(caveatAtom()),
+      ]);
       expect(entry.label.integrity).toBeUndefined();
     }
     // Presence/type/kind stay public: NO template materializes for them
@@ -248,8 +284,8 @@ describe("CFC template metadata population (Stage B): persist-seam mints", () =>
         path: [],
         label: {
           confidentiality: [
-            "public-tag",
-            { kind: "authored-by", subject: "did:key:alice" },
+            residentClause("public-tag"),
+            residentClause({ kind: "authored-by", subject: "did:key:alice" }),
           ],
         },
       },
@@ -270,13 +306,19 @@ describe("CFC template metadata population (Stage B): persist-seam mints", () =>
     // Creation under a NON-source-bearing J so the frozen shape entry never
     // contributes template atoms of its own.
     const plainId = await seedDoc(rt, "mp-criteria-plain", { keep: true }, [
-      { path: [], label: { confidentiality: ["plain-tag"] } },
+      { path: [], label: { confidentiality: [residentClause("plain-tag")] } },
     ]);
     const criteriaB = await seedDoc(rt, "mp-criteria-b", { keep: true }, [
-      { path: [], label: { confidentiality: [caveatAtom(SOURCE_A)] } },
+      {
+        path: [],
+        label: { confidentiality: [residentClause(caveatAtom(SOURCE_A))] },
+      },
     ]);
     const criteriaC = await seedDoc(rt, "mp-criteria-c", { keep: true }, [
-      { path: [], label: { confidentiality: [caveatAtom(SOURCE_B)] } },
+      {
+        path: [],
+        label: { confidentiality: [residentClause(caveatAtom(SOURCE_B))] },
+      },
     ]);
 
     const outId = await deriveOutDoc(rt, "mp-out-replace", plainId);
@@ -298,6 +340,7 @@ describe("CFC template metadata population (Stage B): persist-seam mints", () =>
       },
       { observed: "second" },
     );
+    recordSchemaInput(txB, outId);
     txB.prepareCfc();
     expect((await txB.commit()).ok).toBeDefined();
     const afterB = entriesOf(outId).filter(
@@ -305,7 +348,9 @@ describe("CFC template metadata population (Stage B): persist-seam mints", () =>
     );
     expect(afterB.length).toBe(2);
     for (const entry of afterB) {
-      expect(entry.label.confidentiality).toContainEqual(caveatAtom(SOURCE_A));
+      expect(entry.label.confidentiality).toContainEqual(
+        residentClause(caveatAtom(SOURCE_A)),
+      );
     }
 
     // Overwrite under J = caveat(SOURCE_B): SOURCE_A leaves with its entry.
@@ -322,6 +367,7 @@ describe("CFC template metadata population (Stage B): persist-seam mints", () =>
       },
       { observed: "third" },
     );
+    recordSchemaInput(txC, outId);
     txC.prepareCfc();
     expect((await txC.commit()).ok).toBeDefined();
     const afterC = entriesOf(outId).filter(
@@ -329,9 +375,11 @@ describe("CFC template metadata population (Stage B): persist-seam mints", () =>
     );
     expect(afterC.length).toBe(2);
     for (const entry of afterC) {
-      expect(entry.label.confidentiality).toContainEqual(caveatAtom(SOURCE_B));
+      expect(entry.label.confidentiality).toContainEqual(
+        residentClause(caveatAtom(SOURCE_B)),
+      );
       expect(entry.label.confidentiality).not.toContainEqual(
-        caveatAtom(SOURCE_A),
+        residentClause(caveatAtom(SOURCE_A)),
       );
     }
   });
@@ -342,7 +390,7 @@ describe("CFC template metadata population (Stage B): persist-seam mints", () =>
 
     const rt = makeRuntime();
     const criteriaId = await seedDoc(rt, "mp-criteria-i", { keep: true }, [
-      { path: [], label: { confidentiality: [caveatAtom()] } },
+      { path: [], label: { confidentiality: [residentClause(caveatAtom())] } },
     ]);
     const outId = await deriveOutDoc(rt, "mp-out-i", criteriaId, {
       observed: "same",
@@ -383,7 +431,7 @@ describe("CFC template metadata population (Stage B): persist-seam mints", () =>
     const rt = makeRuntime();
     await seedDoc(rt, "mp-el", { n: 1 }, []);
     const criteriaId = await seedDoc(rt, "mp-criteria-list", { keep: true }, [
-      { path: [], label: { confidentiality: [caveatAtom()] } },
+      { path: [], label: { confidentiality: [residentClause(caveatAtom())] } },
     ]);
     const tx = rt.edit();
     tx.readOrThrow(readAddress(criteriaId, []));
@@ -438,7 +486,9 @@ describe("CFC template metadata population (Stage B): persist-seam mints", () =>
         "value",
         "0",
       ]);
-      expect([...observation.confidentiality]).toContainEqual(caveatAtom());
+      expect([...observation.confidentiality]).toContainEqual(
+        residentClause(caveatAtom()),
+      );
     }
     await inspect.commit();
   });
@@ -453,7 +503,6 @@ describe("CFC template metadata population (Stage B): persist-seam mints", () =>
     runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "observe",
       cfcFlowLabels: "persist",
       cfcLabelMetadataProtection: "enforce",
     });
@@ -478,7 +527,10 @@ describe("CFC template metadata population (Stage B): persist-seam mints", () =>
           labelMap: {
             version: 1,
             entries: [
-              { path: [], label: { confidentiality: [caveatAtom()] } },
+              {
+                path: [],
+                label: { confidentiality: [residentClause(caveatAtom())] },
+              },
             ],
           },
         },
@@ -545,7 +597,12 @@ describe("CFC template metadata population (Stage B): persist-seam mints", () =>
     const seededId = await seedDoc(rt, "mp-guard", { x: 1 }, [
       {
         path: [],
-        label: { confidentiality: ["payload-label", caveatAtom()] },
+        label: {
+          confidentiality: [
+            residentClause("payload-label"),
+            residentClause(caveatAtom()),
+          ],
+        },
         origin: "derived",
         observes: "value",
       },
@@ -573,7 +630,7 @@ describe("CFC template metadata population (Stage B): persist-seam mints", () =>
     const joinValue = derivedConfidentiality(
       outValue.getAsNormalizedFullLink().id,
     );
-    expect(joinValue).toContainEqual("payload-label");
+    expect(joinValue).toContainEqual(residentClause("payload-label"));
     expect(joinValue).not.toContainEqual("tmpl-only-atom");
 
     // Shape probe (nonRecursive) at the root.
@@ -686,7 +743,7 @@ describe("CFC template metadata population (Stage B): persist-seam mints", () =>
 
     const rt = makeRuntime();
     const criteriaId = await seedDoc(rt, "mp-criteria-obs", { keep: true }, [
-      { path: [], label: { confidentiality: [caveatAtom()] } },
+      { path: [], label: { confidentiality: [residentClause(caveatAtom())] } },
     ]);
     await deriveOutDoc(rt, "mp-out-obs", criteriaId);
 
@@ -703,14 +760,15 @@ describe("CFC template metadata population (Stage B): persist-seam mints", () =>
       (observation) => [...observation.target.path].join("/"),
     ).sort();
     // The out doc carries the derived shape + value entries at [] (stored in
-    // that canonical order), each with the caveat clause: per matching atom,
-    // one field consultation and one whole-atom projection, at concrete
-    // clause indices across the concatenated per-entry clause lists.
+    // that canonical order), each with one clause: per matching atom, one
+    // field consultation and one whole-atom projection, at concrete clause
+    // indices across the concatenated per-entry clause lists. The caveat is
+    // the second alternative of its clause, so the alternative index is 1.
     expect(paths).toEqual([
-      "cfc/labels/value/confidentiality/clauses/0/alternatives/0",
-      "cfc/labels/value/confidentiality/clauses/0/alternatives/0/source",
-      "cfc/labels/value/confidentiality/clauses/1/alternatives/0",
-      "cfc/labels/value/confidentiality/clauses/1/alternatives/0/source",
+      "cfc/labels/value/confidentiality/clauses/0/alternatives/1",
+      "cfc/labels/value/confidentiality/clauses/0/alternatives/1/source",
+      "cfc/labels/value/confidentiality/clauses/1/alternatives/1",
+      "cfc/labels/value/confidentiality/clauses/1/alternatives/1/source",
     ]);
     await inspect.commit();
   });
@@ -847,7 +905,6 @@ describe("CFC template metadata population (Stage B): evaluator resolution", () 
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "observe",
       cfcFlowLabels: "persist",
     });
     try {

--- a/packages/runner/test/cfc-template-population.test.ts
+++ b/packages/runner/test/cfc-template-population.test.ts
@@ -12,11 +12,13 @@ import {
 } from "./cfc-seed-envelope.ts";
 import type { JSONSchema } from "../src/builder/types.ts";
 import { canonicalizeCfcMetadata } from "../src/cfc/canonical.ts";
+import type { CfcConfClause } from "../src/cfc/clause.ts";
 import {
   commitCfcFieldValue,
   containsCfcFieldCommitment,
 } from "../src/cfc/label-representation.ts";
 import type { IFCLabel } from "../src/cfc/mod.ts";
+import { deriveFlowJoin } from "../src/cfc/prepare.ts";
 import type { LabelMapEntry } from "../src/cfc/types.ts";
 import { Runtime } from "../src/runtime.ts";
 import { StorageManager } from "../src/storage/cache.deno.ts";
@@ -69,7 +71,8 @@ describe("CFC template population (Stage A): the two under-taints", () => {
     runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "observe",
+      // Persisting the flow labels is what mints the `*`-child templates
+      // every `entriesOf` assertion below counts and reads.
       cfcFlowLabels: "persist",
     });
     return runtime;
@@ -105,11 +108,6 @@ describe("CFC template population (Stage A): the two under-taints", () => {
     };
     return replica.getDocument(id)?.cfc?.labelMap?.entries ?? [];
   };
-
-  const derivedConfidentiality = (id: string): unknown[] =>
-    entriesOf(id)
-      .filter((e) => e.origin === "derived")
-      .flatMap((e) => e.label.confidentiality ?? []);
 
   const readAddress = (id: string, path: string[]) => ({
     space,
@@ -158,20 +156,18 @@ describe("CFC template population (Stage A): the two under-taints", () => {
     return listId;
   };
 
-  // Runs `observe` in a fresh tx that also writes an out doc, commits, and
-  // returns the out doc's derived flow confidentiality.
+  // Runs `observe` in a fresh tx and returns the confidentiality of the join
+  // those reads accumulated, straight off the transaction.
   const flowJoinOf = async (
     rt: Runtime,
-    outCause: string,
     observe: (tx: ReturnType<Runtime["edit"]>) => void,
-  ): Promise<unknown[]> => {
+  ): Promise<CfcConfClause[]> => {
     const tx = rt.edit();
     observe(tx);
-    const out = rt.getCell(space, outCause, undefined, tx);
-    out.set({ observed: true });
+    const join = deriveFlowJoin(tx).confidentiality;
     tx.prepareCfc();
     expect((await tx.commit()).ok).toBeDefined();
-    return derivedConfidentiality(out.getAsNormalizedFullLink().id);
+    return join;
   };
 
   it("per-child existence probe consumes the membership J (SC-8 residual №1)", async () => {
@@ -190,7 +186,7 @@ describe("CFC template population (Stage A): the two under-taints", () => {
     ]);
     const listId = await buildList(rt, "tp-list-a", criteriaId, ["tp-el-a"]);
 
-    const join = await flowJoinOf(rt, "tp-probe-a-out", (tx) => {
+    const join = await flowJoinOf(rt, (tx) => {
       tx.readOrThrow(readAddress(listId, ["0"]), { nonRecursive: true });
     });
     expect(join).toContainEqual("memb-secret");
@@ -217,7 +213,7 @@ describe("CFC template population (Stage A): the two under-taints", () => {
     ]);
     const listId = await buildList(rt, "tp-list-b", criteriaId, ["tp-el-b"]);
 
-    const join = await flowJoinOf(rt, "tp-probe-b-out", (tx) => {
+    const join = await flowJoinOf(rt, (tx) => {
       tx.read(readAddress(listId, ["0"]), { meta: linkResolutionProbe });
     });
     expect(join).toContainEqual("memb-secret");
@@ -238,7 +234,7 @@ describe("CFC template population (Stage A): the two under-taints", () => {
     ]);
     const listId = await buildList(rt, "tp-list-c", criteriaId, ["tp-el-c"]);
 
-    const join = await flowJoinOf(rt, "tp-probe-c-out", (tx) => {
+    const join = await flowJoinOf(rt, (tx) => {
       tx.readOrThrow(readAddress(listId, ["0"]));
     });
     expect(join).toContainEqual("memb-secret");
@@ -385,6 +381,18 @@ describe("CFC template population (Stage A): the two under-taints", () => {
     // never pool, so tmpl-only-atom vanishes entirely — while the frozen
     // existence entry (creation-atom) survives the overwrite in place.
     const cover = rt.edit();
+    // The schema write-policy input a cell write records for this target.
+    // The raw write below leaves the transaction read-free.
+    const listSchema = internSchema(
+      { type: "array", items: { asCell: ["cell"] } } as JSONSchema,
+      true,
+    );
+    cover.recordCfcWritePolicyInput({
+      kind: "schema",
+      target: { space, scope: "space", id: uri(listId), path: [] },
+      schemaHash: listSchema.taggedHashString,
+      schema: listSchema.schema,
+    });
     cover.writeOrThrow(
       { space, scope: "space", id: uri(listId), path: ["value"] },
       { replaced: true },
@@ -413,7 +421,7 @@ describe("CFC template population (Stage A): the two under-taints", () => {
 
     const rt = makeRuntime();
     await seedDoc(rt, "tp-el-sw", { n: 1 }, []);
-    const otherId = await seedDoc(rt, "tp-el-sw-2", { n: 2 }, []);
+    await seedDoc(rt, "tp-el-sw-2", { n: 2 }, []);
     const criteriaId = await seedDoc(rt, "tp-criteria-sw", { keep: true }, [
       { path: [], label: { confidentiality: ["memb-secret"] } },
     ]);
@@ -422,9 +430,11 @@ describe("CFC template population (Stage A): the two under-taints", () => {
     // Clean tx replaces slot 0 with a link to another doc — no declaration,
     // no covering write.
     const slotWrite = rt.edit();
-    slotWrite.writeOrThrow(
-      { space, scope: "space", id: uri(listId), path: ["value", "0"] },
-      { "/": { "link@1": { id: otherId, path: [] } } },
+    rt.getCell(space, "tp-list-sw", {
+      type: "array",
+      items: { asCell: ["cell"] },
+    }, slotWrite).key(0).set(
+      rt.getCell(space, "tp-el-sw-2", undefined, slotWrite) as never,
     );
     slotWrite.prepareCfc();
     expect((await slotWrite.commit()).ok).toBeDefined();
@@ -527,7 +537,7 @@ describe("CFC template population (Stage A): the two under-taints", () => {
     ]);
     const listId = await buildList(rt, "tp-list-tc", criteriaId, ["tp-el-tc"]);
 
-    const join = await flowJoinOf(rt, "tp-probe-tc-out", (tx) => {
+    const join = await flowJoinOf(rt, (tx) => {
       tx.readOrThrow(readAddress(listId, ["0"]));
       tx.recordCfcDereferenceTrace({
         source: { space, id: listId, scope: "space", path: ["0"] },
@@ -568,7 +578,8 @@ describe("CFC template population (SC-8 remainder): generic pure-link containers
     runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "observe",
+      // Persisting the flow labels is what mints the `*`-child templates
+      // every `entriesOf` assertion below counts and reads.
       cfcFlowLabels: "persist",
     });
     return runtime;
@@ -605,11 +616,6 @@ describe("CFC template population (SC-8 remainder): generic pure-link containers
     return replica.getDocument(id)?.cfc?.labelMap?.entries ?? [];
   };
 
-  const derivedConfidentiality = (id: string): unknown[] =>
-    entriesOf(id)
-      .filter((e) => e.origin === "derived")
-      .flatMap((e) => e.label.confidentiality ?? []);
-
   const readAddress = (id: string, path: string[]) => ({
     space,
     scope: "space" as const,
@@ -643,18 +649,18 @@ describe("CFC template population (SC-8 remainder): generic pure-link containers
     return list.getAsNormalizedFullLink().id;
   };
 
+  // Runs `observe` in a fresh tx and returns the confidentiality of the join
+  // those reads accumulated, straight off the transaction.
   const flowJoinOf = async (
     rt: Runtime,
-    outCause: string,
     observe: (tx: ReturnType<Runtime["edit"]>) => void,
-  ): Promise<unknown[]> => {
+  ): Promise<CfcConfClause[]> => {
     const tx = rt.edit();
     observe(tx);
-    const out = rt.getCell(space, outCause, undefined, tx);
-    out.set({ observed: true });
+    const join = deriveFlowJoin(tx).confidentiality;
     tx.prepareCfc();
     expect((await tx.commit()).ok).toBeDefined();
-    return derivedConfidentiality(out.getAsNormalizedFullLink().id);
+    return join;
   };
 
   it("hand-built pure-link container mints the three `*`-child class templates", async () => {
@@ -703,7 +709,7 @@ describe("CFC template population (SC-8 remainder): generic pure-link containers
       "gp-el-a",
     ]);
 
-    const join = await flowJoinOf(rt, "gp-probe-a-out", (tx) => {
+    const join = await flowJoinOf(rt, (tx) => {
       tx.readOrThrow(readAddress(listId, ["0"]), { nonRecursive: true });
     });
     expect(join).toContainEqual("memb-secret");
@@ -725,7 +731,7 @@ describe("CFC template population (SC-8 remainder): generic pure-link containers
       "gp-el-b",
     ]);
 
-    const join = await flowJoinOf(rt, "gp-probe-b-out", (tx) => {
+    const join = await flowJoinOf(rt, (tx) => {
       tx.read(readAddress(listId, ["0"]), { meta: linkResolutionProbe });
     });
     expect(join).toContainEqual("memb-secret");
@@ -757,14 +763,14 @@ describe("CFC template population (SC-8 remainder): generic pure-link containers
       tx.readOrThrow(readAddress(listId, ["length"]));
     };
 
-    const marked = await flowJoinOf(rt, "gp-mach-out", (tx) => {
+    const marked = await flowJoinOf(rt, (tx) => {
       tx.runWithAmbientReadMeta(machineryRead, () => wiringReads(tx));
     });
     // Consumed-set equality with a read-free transaction: the marked wiring
     // reads contribute NOTHING to the join.
     expect(marked).toEqual([]);
 
-    const unmarked = await flowJoinOf(rt, "gp-app-out", (tx) => {
+    const unmarked = await flowJoinOf(rt, (tx) => {
       wiringReads(tx);
     });
     expect(unmarked).toContainEqual("memb-secret");
@@ -791,8 +797,6 @@ describe("CFC template population (Stage A): class-split resolution", () => {
     runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "observe",
-      cfcFlowLabels: "persist",
     });
     return runtime;
   };
@@ -828,11 +832,6 @@ describe("CFC template population (Stage A): class-split resolution", () => {
     return replica.getDocument(id)?.cfc?.labelMap?.entries ?? [];
   };
 
-  const derivedConfidentiality = (id: string): unknown[] =>
-    entriesOf(id)
-      .filter((e) => e.origin === "derived")
-      .flatMap((e) => e.label.confidentiality ?? []);
-
   const readAddress = (id: string, path: string[]) => ({
     space,
     scope: "space" as const,
@@ -841,18 +840,18 @@ describe("CFC template population (Stage A): class-split resolution", () => {
     path: ["value", ...path],
   });
 
+  // Runs `observe` in a fresh tx and returns the confidentiality of the join
+  // those reads accumulated, straight off the transaction.
   const flowJoinOf = async (
     rt: Runtime,
-    outCause: string,
     observe: (tx: ReturnType<Runtime["edit"]>) => void,
-  ): Promise<unknown[]> => {
+  ): Promise<CfcConfClause[]> => {
     const tx = rt.edit();
     observe(tx);
-    const out = rt.getCell(space, outCause, undefined, tx);
-    out.set({ observed: true });
+    const join = deriveFlowJoin(tx).confidentiality;
     tx.prepareCfc();
     expect((await tx.commit()).ok).toBeDefined();
-    return derivedConfidentiality(out.getAsNormalizedFullLink().id);
+    return join;
   };
 
   // One doc, every class distinct: a covering root entry, the three
@@ -897,7 +896,7 @@ describe("CFC template population (Stage A): class-split resolution", () => {
 
     const rt = makeRuntime();
     const id = await seedSplitDoc(rt, "tp-split-ref");
-    const join = await flowJoinOf(rt, "tp-split-ref-out", (tx) => {
+    const join = await flowJoinOf(rt, (tx) => {
       tx.read(readAddress(id, ["items", "0"]), { meta: linkResolutionProbe });
     });
     expect(join).toContainEqual("memb-ref");
@@ -913,7 +912,7 @@ describe("CFC template population (Stage A): class-split resolution", () => {
 
     const rt = makeRuntime();
     const id = await seedSplitDoc(rt, "tp-split-shape");
-    const join = await flowJoinOf(rt, "tp-split-shape-out", (tx) => {
+    const join = await flowJoinOf(rt, (tx) => {
       tx.readOrThrow(readAddress(id, ["items", "0"]), { nonRecursive: true });
     });
     expect(join).toContainEqual("memb-shape");
@@ -929,7 +928,7 @@ describe("CFC template population (Stage A): class-split resolution", () => {
 
     const rt = makeRuntime();
     const id = await seedSplitDoc(rt, "tp-split-value");
-    const join = await flowJoinOf(rt, "tp-split-value-out", (tx) => {
+    const join = await flowJoinOf(rt, (tx) => {
       tx.readOrThrow(readAddress(id, ["items", "0"]));
     });
     expect(join).toContainEqual("memb-value");
@@ -955,7 +954,7 @@ describe("CFC template population (Stage A): class-split resolution", () => {
         observes: "value",
       },
     ]);
-    const join = await flowJoinOf(rt, "tp-split-deep-out", (tx) => {
+    const join = await flowJoinOf(rt, (tx) => {
       tx.readOrThrow(readAddress(id, ["items", "0", "name"]));
     });
     expect(join).toContainEqual("memb-value");
@@ -995,12 +994,12 @@ describe("CFC template population (Stage A): class-split resolution", () => {
         observes: "shape",
       },
     ]);
-    const joinSame = await flowJoinOf(rt, "tp-join-same-out", (tx) => {
+    const joinSame = await flowJoinOf(rt, (tx) => {
       tx.readOrThrow(readAddress(id, ["items", "0"]), { nonRecursive: true });
     });
     expect(joinSame).toContainEqual("memb-current");
     expect(joinSame).toContainEqual("frozen-structure");
-    const joinCross = await flowJoinOf(rt, "tp-join-cross-out", (tx) => {
+    const joinCross = await flowJoinOf(rt, (tx) => {
       tx.readOrThrow(readAddress(id, ["items", "1"]), { nonRecursive: true });
     });
     expect(joinCross).toContainEqual("memb-current");
@@ -1042,7 +1041,7 @@ describe("CFC template population (Stage A): class-split resolution", () => {
       origin: "declared",
     }]);
 
-    const join = await flowJoinOf(rt, "tp-declared-star-out", (tx2) => {
+    const join = await flowJoinOf(rt, (tx2) => {
       tx2.readOrThrow(readAddress(id, ["items", "0"]));
     });
     expect(join).toContainEqual("declared-member");
@@ -1070,8 +1069,6 @@ describe("CFC template population (Stage A): record-only additionalProperties wa
     runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "observe",
-      cfcFlowLabels: "persist",
     });
     return runtime;
   };
@@ -1193,8 +1190,11 @@ describe("CFC template population (Stage A): cross-space label protection", () =
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "observe",
+      // Persisting the flow labels is what mints the template entries this
+      // test reads back out of the envelope.
       cfcFlowLabels: "persist",
+      // `containsCfcFieldCommitment` below reads the commitment form this
+      // rung transforms a cross-space membership join into.
       cfcLabelMetadataProtection: "enforce",
     });
     try {

--- a/packages/runner/test/cfc-terminal-refusal-rerun.test.ts
+++ b/packages/runner/test/cfc-terminal-refusal-rerun.test.ts
@@ -66,10 +66,9 @@ const seedSource = async () => {
   const runtime = new Runtime({
     apiUrl: new URL("https://example.com"),
     storageManager,
-    // The shipped shell posture; the action's own transaction escalates to
-    // `enforce-strict` per-tx, the same seam cfc-writer-fit uses. A
-    // runtime-wide strict would put the SEED under strict too.
-    cfcEnforcementMode: "enforce-explicit",
+    // Persisting flow labels puts the source's confidentiality on the
+    // copy the action writes. That carried label is what
+    // `expect(out.get()?.copied).toBeUndefined()` needs refused.
     cfcFlowLabels: "persist",
   });
   const space = signer.did();
@@ -88,7 +87,10 @@ const seedSource = async () => {
   return { storageManager, runtime, space, source };
 };
 
-/** Subscribes an action whose own transaction runs at enforce-strict. */
+/**
+ * Subscribes an action whose own transaction runs at enforce-strict, the rung
+ * at which a writer-fit misfit refuses the commit rather than flagging it.
+ */
 const subscribeRefusedCopy = (
   runtime: Runtime,
   space: MemorySpace,
@@ -160,9 +162,14 @@ describe("cfc prepared-state drift", () => {
     const { storageManager, runtime, space, source } = await seedSource();
     try {
       const tx = runtime.edit();
+      // The transaction reads the source, so what it writes here carries
+      // the source's confidentiality. The schema declares that
+      // confidentiality, leaving the drift invalidation as the only
+      // thing that refuses this commit.
       const out = runtime.getCell<{ n?: number }>(space, "drift-out", {
         type: "object",
         properties: { n: { type: "number" } },
+        ifc: { confidentiality: ["secret"] },
       }, tx);
       out.set({ n: 1 });
       // The labeled read makes the transaction CFC-relevant, so prepare

--- a/packages/runner/test/cfc-trigger-read-cid-exclusion.test.ts
+++ b/packages/runner/test/cfc-trigger-read-cid-exclusion.test.ts
@@ -1,5 +1,6 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { cfcAtom } from "@commonfabric/api/cfc";
 import { Identity } from "@commonfabric/identity";
 import {
   SEED_ENVELOPE_SCHEMA_HASH,
@@ -15,7 +16,7 @@ const signer = await Identity.fromPassphrase("runner-cfc-trigger-cid");
 
 type StoredEntry = {
   path: string[];
-  label: { confidentiality?: string[]; integrity?: unknown[] };
+  label: { confidentiality?: unknown[]; integrity?: unknown[] };
   origin?: string;
 };
 
@@ -43,10 +44,17 @@ describe("CFC trigger reads: cid: exclusion", () => {
     // a smuggled trigger entry.
 
     const storageManager = StorageManager.emulate({ as: signer });
+    // The legitimate source's confidentiality names this space's
+    // readers, the audience of everything the space stores. A write
+    // carrying it fits the out doc's write ceiling, so the out doc
+    // declares no policy of its own and the join reaches its label
+    // map as a `derived` entry.
+    const sourceAtom = cfcAtom.space(signer.did());
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
+      // Persisting flow labels is what stamps the `derived` entry
+      // this test reads back off the out doc.
       cfcFlowLabels: "persist",
     });
     try {
@@ -76,7 +84,7 @@ describe("CFC trigger reads: cid: exclusion", () => {
             version: 1,
             entries: [{
               path: ["secret"],
-              label: { confidentiality: ["secret"] },
+              label: { confidentiality: [sourceAtom] },
             }],
           },
         },
@@ -165,7 +173,7 @@ describe("CFC trigger reads: cid: exclusion", () => {
       const join = deriveFlowJoin(smuggledTx);
       // The legitimate trigger's label joins; the poisoned cid: one is
       // skipped by the derivation-side guard.
-      expect(join.confidentiality).toContainEqual("secret");
+      expect(join.confidentiality).toContainEqual(sourceAtom);
       expect(join.confidentiality).not.toContainEqual("cid-secret");
 
       // The transaction reads nothing — only the triggers connect it to the
@@ -185,7 +193,9 @@ describe("CFC trigger reads: cid: exclusion", () => {
       const derived = entries.find((e) => e.origin === "derived");
       // The legitimate trigger joined…
       expect(derived).toBeDefined();
-      expect(derived!.label.confidentiality).toContainEqual("secret");
+      expect(derived!.label.confidentiality).toContainEqual(
+        sourceAtom,
+      );
       // …the poisoned cid: trigger did not — on ANY entry of the out doc.
       for (const entry of entries) {
         expect(entry.label.confidentiality ?? []).not.toContainEqual(

--- a/packages/runner/test/cfc-trigger-read-gating.test.ts
+++ b/packages/runner/test/cfc-trigger-read-gating.test.ts
@@ -18,11 +18,11 @@ const signer = await Identity.fromPassphrase("runner-cfc-trigger-read-gating");
 
 // Epic H5 (§8.9.2 / SC-3): the addresses whose invalidating writes SCHEDULED a
 // reactive rerun (trigger reads) join the enforcement consumed set behind the
-// `cfcTriggerReadGating` flag (default off). Without it, a handler scheduled by
-// a secret's write can egress to a ceiling'd sink — or write a
-// requiredIntegrity-floored target — without ever re-reading that secret, and
-// pass. The tests drive each gate with the flag OFF (passes today) and ON
-// (rejected), the fail-closed direction.
+// `cfcTriggerReadGating` flag. Without it, a handler scheduled by a secret's
+// write can egress to a ceiling'd sink — or write a requiredIntegrity-floored
+// target — without ever re-reading that secret, and pass. Each case states the
+// flag it drives: OFF, where the egress passes, and ON, where it is rejected,
+// which is the fail-closed direction.
 const CONFIDENTIAL_SCHEMA = internSchema(
   {
     type: "object",
@@ -43,18 +43,34 @@ const OUT_SCHEMA = internSchema(
   true,
 );
 
+// The output of a run scheduled by the confidential cell. Its value derives
+// from the [medical] trigger read, so the document declares that
+// confidentiality.
+const DERIVED_OUT_SCHEMA = internSchema(
+  {
+    type: "object",
+    properties: { v: { type: "string" } },
+    required: ["v"],
+    ifc: { confidentiality: ["medical"] },
+  } satisfies JSONSchema,
+  true,
+);
+
 const makeRuntime = (opts: {
   storageManager: ReturnType<typeof StorageManager.emulate>;
   cfcTriggerReadGating?: boolean;
+  cfcFlowLabels?: "off" | "observe" | "persist";
   cfcSinkMaxConfidentiality?: SinkMaxConfidentiality;
 }) =>
   new Runtime({
     apiUrl: new URL("https://example.com"),
     storageManager: opts.storageManager,
-    cfcEnforcementMode: "enforce-explicit",
     cfcSinkMaxConfidentiality: opts.cfcSinkMaxConfidentiality,
     ...(opts.cfcTriggerReadGating !== undefined
       ? { cfcTriggerReadGating: opts.cfcTriggerReadGating }
+      : {}),
+    ...(opts.cfcFlowLabels !== undefined
+      ? { cfcFlowLabels: opts.cfcFlowLabels }
       : {}),
   });
 
@@ -126,18 +142,25 @@ const scheduledEgress = (
 };
 
 describe("CFC trigger-read gating (H5, §8.9.2 / SC-3)", () => {
-  it("flag OFF (default): a scheduled egress that never re-reads the secret passes", async () => {
+  it("flag OFF: a scheduled egress that never re-reads the secret passes", async () => {
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = makeRuntime({
       storageManager,
+      // Pinned: the commit below asserts no error, which is what an ungated
+      // trigger read produces.
+      cfcTriggerReadGating: false,
+      // Pinned: under flow persist the trigger reads reach the sink gate
+      // through the per-tx flow join. The channel this arm characterizes
+      // needs the flow dial off as well.
+      cfcFlowLabels: "off",
       cfcSinkMaxConfidentiality: { fetchJson: [] },
     });
     try {
       const secretId = await seedConfidential(runtime, "h5-off-secret");
       const tx = scheduledEgress(runtime, "h5-off-out", secretId);
       const result = await tx.commit();
-      // Today: the trigger read is not in the consumed set, so the public-only
-      // sink ceiling is not tripped.
+      // With gating off the trigger read is not in the consumed set, so the
+      // public-only sink ceiling is not tripped.
       expect(result.error).toBeUndefined();
     } finally {
       await runtime.dispose();
@@ -149,7 +172,12 @@ describe("CFC trigger-read gating (H5, §8.9.2 / SC-3)", () => {
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = makeRuntime({
       storageManager,
+      // Pinned: the commit below asserts the "exceeds ceiling for fetchJson"
+      // rejection, which is what a gated trigger read produces.
       cfcTriggerReadGating: true,
+      // Pinned at the OFF arm's flow dial, so the gating flag is the one
+      // difference between the two arms.
+      cfcFlowLabels: "off",
       cfcSinkMaxConfidentiality: { fetchJson: [] },
     });
     try {
@@ -172,6 +200,7 @@ describe("CFC trigger-read gating (H5, §8.9.2 / SC-3)", () => {
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = makeRuntime({
       storageManager,
+      // Pinned: the commit below asserts no error with the gate enabled.
       cfcTriggerReadGating: true,
       cfcSinkMaxConfidentiality: { fetchJson: [] },
     });
@@ -205,6 +234,7 @@ describe("CFC trigger-read gating (H5, §8.9.2 / SC-3)", () => {
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = makeRuntime({
       storageManager,
+      // Pinned: the commit below asserts no error with the gate enabled.
       cfcTriggerReadGating: true,
       cfcSinkMaxConfidentiality: { fetchJson: [] },
     });
@@ -246,15 +276,21 @@ describe("CFC trigger-read gating (H5, §8.9.2 / SC-3)", () => {
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = makeRuntime({
       storageManager,
+      // Pinned: the steps below assert that disabling the gate throws and
+      // then read the gate back as enabled.
       cfcTriggerReadGating: true,
       cfcSinkMaxConfidentiality: { fetchJson: [] },
     });
     try {
       const secretId = await seedConfidential(runtime, "h5-pin-secret");
       const tx = runtime.edit();
-      runtime.getCell(signer.did(), "h5-pin-out", OUT_SCHEMA.schema, tx).set({
-        v: "computed",
-      });
+      const out = runtime.getCell(
+        signer.did(),
+        "h5-pin-out",
+        DERIVED_OUT_SCHEMA.schema,
+        tx,
+      );
+      out.set({ v: "computed" });
       tx.addCfcTriggerReads([{
         space: signer.did(),
         id: secretId as `${string}:${string}`,
@@ -299,15 +335,21 @@ describe("CFC trigger-read gating (H5, §8.9.2 / SC-3)", () => {
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = makeRuntime({
       storageManager,
+      // Pinned: the steps below read the gate back as enabled after the
+      // attempts to mutate the view.
       cfcTriggerReadGating: true,
       cfcSinkMaxConfidentiality: { fetchJson: [] },
     });
     try {
       const secretId = await seedConfidential(runtime, "h5-view-secret");
       const tx = runtime.edit();
-      runtime.getCell(signer.did(), "h5-view-out", OUT_SCHEMA.schema, tx).set({
-        v: "computed",
-      });
+      const out = runtime.getCell(
+        signer.did(),
+        "h5-view-out",
+        DERIVED_OUT_SCHEMA.schema,
+        tx,
+      );
+      out.set({ v: "computed" });
       tx.addCfcTriggerReads([{
         space: signer.did(),
         id: secretId as `${string}:${string}`,
@@ -342,7 +384,12 @@ describe("CFC trigger-read gating (H5, §8.9.2 / SC-3)", () => {
       // The Map facade forwards reads bound to the real Map and rejects
       // mutators.
       const identities = tx.getCfcState().writePolicyInputIdentities;
-      expect(identities.size).toBe(0);
+      // The out document's declared schema is the only write-policy input
+      // this transaction records, so the facade reports that one entry.
+      expect(identities.size).toBe(1);
+      expect(
+        [...identities.keys()].map((key) => (key as { kind: string }).kind),
+      ).toEqual(["schema"]);
       expect(identities.get({} as never)).toBeUndefined();
       expect(() => identities.set({} as never, {} as never)).toThrow(
         "read-only",

--- a/packages/runner/test/cfc-tx-control-guard.test.ts
+++ b/packages/runner/test/cfc-tx-control-guard.test.ts
@@ -26,6 +26,8 @@ describe("CFC transaction control guard", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
+      // Pinned: the steps below read the mode back as "enforce-explicit", then
+      // raise it to "enforce-strict" and read that back too.
       cfcEnforcementMode: "enforce-explicit",
     });
     try {
@@ -79,6 +81,9 @@ describe("CFC transaction control guard", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
+      // Pinned: the steps below start from a non-enforcing mode and assert that
+      // moving between "observe" and "disabled" is accepted until the first
+      // enforcing mode sets the floor.
       cfcEnforcementMode: "disabled",
     });
     try {
@@ -100,6 +105,9 @@ describe("CFC transaction control guard", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
+      // The steps below ask the transaction to weaken to "disabled" and
+      // expect the guard to refuse, then commit a violation and expect a
+      // rejection. Both need the transaction to start from an enforcing rung.
       cfcEnforcementMode: "enforce-explicit",
       trustSnapshotProvider: () => ({
         id: "trust-snapshot-tx-control-guard",

--- a/packages/runner/test/cfc-tx-state-contracts.test.ts
+++ b/packages/runner/test/cfc-tx-state-contracts.test.ts
@@ -22,7 +22,12 @@ describe("CFC tx state contracts", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
+      // The strengthen-after-prepare test raises each of these modes a rung
+      // and asserts the prepared digest turns from "prepared" to
+      // "invalidated". That transition needs the transaction to start on a
+      // rung below the top of each ladder.
+      cfcFlowLabels: "off",
+      cfcWriteFloor: "off",
     });
     try {
       await fn(runtime, runtime.edit() as ExtendedStorageTransaction);
@@ -55,7 +60,6 @@ describe("CFC tx state contracts", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
       cfcSinkMaxConfidentiality: { fetchJson: [] },
     });
     try {
@@ -116,7 +120,7 @@ describe("CFC tx state contracts", () => {
       });
       tx.prepareCfc();
       expect(tx.getCfcState().prepare.status).toBe("prepared");
-      tx.setCfcFlowLabelsMode("off"); // no change from default off → no-op
+      tx.setCfcFlowLabelsMode("off"); // no change from the pinned off → no-op
       expect(tx.getCfcState().prepare.status).toBe("prepared");
       tx.setCfcFlowLabelsMode("observe"); // real change → invalidate
       const flow = tx.getCfcState().prepare;

--- a/packages/runner/test/cfc-ui-contract.test.ts
+++ b/packages/runner/test/cfc-ui-contract.test.ts
@@ -361,7 +361,6 @@ describe("CFC trusted UI event enforcement", () => {
     runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
 
     const stream = runtime.getCell(
@@ -426,7 +425,6 @@ describe("CFC trusted UI event enforcement", () => {
     runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
 
     const sourceStream = runtime.getCell(
@@ -1276,7 +1274,6 @@ describe("CFC trusted UI event enforcement", () => {
     runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
 
     const stream = runtime.getCell(
@@ -1343,7 +1340,6 @@ describe("CFC trusted UI event enforcement", () => {
     runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
 
     const stream = runtime.getCell(
@@ -1408,7 +1404,6 @@ describe("CFC trusted UI event enforcement", () => {
     runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
 
     const stream = runtime.getCell(
@@ -1489,7 +1484,6 @@ describe("CFC trusted UI event enforcement", () => {
     runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
       trustSnapshotProvider: () => ({
         id: "trust-snapshot-1",
         actingPrincipal: signer.did(),
@@ -1700,7 +1694,6 @@ describe("CFC trusted UI event enforcement", () => {
     runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
       trustSnapshotProvider: () => ({
         id: "trust-snapshot-1",
         actingPrincipal: signer.did(),
@@ -1919,7 +1912,6 @@ describe("CFC trusted UI event enforcement", () => {
     runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
 
     const stream = runtime.getCell(
@@ -1985,7 +1977,6 @@ describe("CFC trusted UI event enforcement", () => {
     runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
 
     const stream = runtime.getCell(
@@ -2063,7 +2054,6 @@ describe("CFC trusted UI event enforcement", () => {
     runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
 
     const stream = runtime.getCell(
@@ -2166,7 +2156,6 @@ describe("CFC trusted UI event enforcement", () => {
     runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
 
     const stream = runtime.getCell(
@@ -2243,7 +2232,6 @@ describe("CFC trusted UI event enforcement", () => {
     runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
 
     const stream = runtime.getCell(
@@ -2318,7 +2306,6 @@ describe("CFC trusted UI event enforcement", () => {
     runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
 
     const stream = runtime.getCell(

--- a/packages/runner/test/cfc-unsupported-ifc-keys.test.ts
+++ b/packages/runner/test/cfc-unsupported-ifc-keys.test.ts
@@ -33,7 +33,6 @@ describe("CFC unsupported ifc claims fail closed", () => {
       const runtime = new Runtime({
         apiUrl: new URL("https://example.com"),
         storageManager,
-        cfcEnforcementMode: "enforce-explicit",
         trustSnapshotProvider: () => ({
           id: `trust-snapshot-unsupported-${claimKey}`,
           actingPrincipal: signer.did(),

--- a/packages/runner/test/cfc-write-floor.test.ts
+++ b/packages/runner/test/cfc-write-floor.test.ts
@@ -20,7 +20,8 @@ const signer = await Identity.fromPassphrase("runner-cfc-write-floor");
 // read-side gate (verifyInputRequirements) quantifies over consumed reads; the
 // floor tests the WRITTEN VALUE's integrity — schema `addIntegrity` mints,
 // carried link-view integrity, the flow hereditary meet — against the declared
-// floor. Dial `cfcWriteFloor: off | observe | enforce`, default off.
+// floor. Dial `cfcWriteFloor: off | observe | enforce`. Each case names the
+// rung it drives, so the arm under test is the one that decides it.
 const ADMIN_ATOM = "admin-approved";
 const LLM_DERIVED_ATOM = {
   type: "https://commonfabric.org/cfc/atom/LlmDerived",
@@ -58,7 +59,6 @@ const makeRuntime = (opts: {
   new Runtime({
     apiUrl: new URL("https://example.com"),
     storageManager: opts.storageManager,
-    cfcEnforcementMode: "enforce-explicit",
     ...(opts.cfcWriteFloor !== undefined
       ? { cfcWriteFloor: opts.cfcWriteFloor }
       : {}),
@@ -151,9 +151,9 @@ describe("CFC write-side requiredIntegrity floor (D3, §8.12.4.1)", () => {
     }
   });
 
-  it("dial off (the default): the same write commits — byte-compat", async () => {
+  it("dial off: the same write commits — byte-compat", async () => {
     const storageManager = StorageManager.emulate({ as: signer });
-    const runtime = makeRuntime({ storageManager });
+    const runtime = makeRuntime({ storageManager, cfcWriteFloor: "off" });
     try {
       const tx = runtime.edit();
       const sink = runtime.getCell(

--- a/packages/runner/test/cfc-write-prefix-provenance.test.ts
+++ b/packages/runner/test/cfc-write-prefix-provenance.test.ts
@@ -84,13 +84,12 @@ const makeRuntime = (options: {
   new Runtime({
     apiUrl: new URL("https://example.com"),
     storageManager: options.storageManager,
-    cfcEnforcementMode: "enforce-explicit",
     ...(options.cfcTriggerReadGating !== undefined
       ? { cfcTriggerReadGating: options.cfcTriggerReadGating }
       : {}),
-    ...(options.cfcWriteFloor !== undefined
-      ? { cfcWriteFloor: options.cfcWriteFloor }
-      : {}),
+    // The subject here is prefix-provenance measurement, so unless an arm
+    // dials the floor itself it measures but does not decide.
+    cfcWriteFloor: options.cfcWriteFloor ?? "observe",
   });
 
 // Seed a doc's stored CFC metadata directly via an ungated path-[]

--- a/packages/runner/test/cfc-writer-claim-correspondence.test.ts
+++ b/packages/runner/test/cfc-writer-claim-correspondence.test.ts
@@ -92,7 +92,6 @@ describe("writeAuthorizedBy across resolver spellings (labs#4772)", () => {
     runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
       trustSnapshotProvider: () => ({
         id: snapshotId,
         actingPrincipal: signer.did(),
@@ -428,7 +427,6 @@ describe("the labs#4772 heal end-to-end: exact mint + tolerant adoption + identi
     runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
       trustSnapshotProvider: () => ({
         id: "ts-heal-e2e",
         actingPrincipal: signer2.did(),

--- a/packages/runner/test/cfc-writer-fit.test.ts
+++ b/packages/runner/test/cfc-writer-fit.test.ts
@@ -56,17 +56,22 @@ const newRuntime = (
   new Runtime({
     apiUrl: new URL("https://example.com"),
     storageManager,
-    // The shipped shell posture (enforcement-matrix §3): explicit + flow
-    // persist. Individual transactions escalate to `enforce-strict` per-tx,
-    // which is exactly the seam H4 differentiates.
+    // The tests naming `enforce-explicit` assert that a writer-fit misfit
+    // lands as a persist-and-flag diagnostic and lets the commit through.
+    // The tests that want the misfit to reject raise the mode on their own
+    // transaction, so both halves run over one fixture.
     cfcEnforcementMode: "enforce-explicit",
+    // Writer-fit assertions read the flow join back out of the replica's
+    // stored labelMap, which needs the labels persisted.
     cfcFlowLabels: "persist",
   });
 
 /**
- * A runtime at the strictness where a writer-fit misfit rejects. The blocks
- * below pin it rather than inheriting the file's `enforce-explicit` default,
- * because that is where the exemptions they cover are observable.
+ * A runtime where a writer-fit misfit rejects the commit. The blocks that
+ * reach for it assert a commit fails with "writer-fit confidentiality
+ * misfit", or that an exemption lets the same join through; both need the
+ * misfit to reject. Its flow labels persist so the join reaches the
+ * replica's stored labelMap, where those blocks read it back.
  */
 const strictRuntime = (
   storageManager: ReturnType<typeof StorageManager.emulate>,
@@ -3104,12 +3109,7 @@ describe("CFC writer-fit (canWrite, §8.12.4 / SC-18b)", () => {
       // a labeled transaction writes both.
 
       const storageManager = StorageManager.emulate({ as: signer });
-      const runtime = new Runtime({
-        apiUrl: new URL("https://example.com"),
-        storageManager,
-        cfcEnforcementMode: "enforce-strict",
-        cfcFlowLabels: "persist",
-      });
+      const runtime = strictRuntime(storageManager);
       try {
         await seedSecretSource(runtime, "writer-fit-seam-both-source");
 
@@ -3166,12 +3166,7 @@ describe("CFC writer-fit (canWrite, §8.12.4 / SC-18b)", () => {
       // ceiling.
 
       const storageManager = StorageManager.emulate({ as: signer });
-      const runtime = new Runtime({
-        apiUrl: new URL("https://example.com"),
-        storageManager,
-        cfcEnforcementMode: "enforce-strict",
-        cfcFlowLabels: "persist",
-      });
+      const runtime = strictRuntime(storageManager);
       try {
         await seedSecretSource(runtime, "writer-fit-seam-aimed-source");
 
@@ -3241,12 +3236,7 @@ describe("CFC writer-fit (canWrite, §8.12.4 / SC-18b)", () => {
       // nothing, which a create-only route would refuse.
 
       const storageManager = StorageManager.emulate({ as: signer });
-      const runtime = new Runtime({
-        apiUrl: new URL("https://example.com"),
-        storageManager,
-        cfcEnforcementMode: "enforce-strict",
-        cfcFlowLabels: "persist",
-      });
+      const runtime = strictRuntime(storageManager);
       try {
         await seedSecretSource(runtime, "writer-fit-seam-piece-source");
 

--- a/packages/runner/test/compile-cache-incremental-writeback.test.ts
+++ b/packages/runner/test/compile-cache-incremental-writeback.test.ts
@@ -145,7 +145,6 @@ describe("chunked compile-cache write-back (interruption survivability)", () => 
     runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
       trustSnapshotProvider: () => ({
         id: "incremental-writeback-test",
         actingPrincipal: signer.did(),

--- a/packages/runner/test/content-addressed-identity-adversarial.test.ts
+++ b/packages/runner/test/content-addressed-identity-adversarial.test.ts
@@ -95,7 +95,6 @@ describe("content-addressed identity — adversarial (C5 red-team gate)", () => 
     runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "observe",
     });
     const pattern = await runtime.patternManager.compilePattern(PROGRAM);
     await runtime.idle();
@@ -306,7 +305,6 @@ describe("content-addressed identity — adversarial (C5 red-team gate)", () => 
       runtime = new Runtime({
         apiUrl: new URL(import.meta.url),
         storageManager,
-        cfcEnforcementMode: "enforce-explicit",
         trustSnapshotProvider: () => ({
           id: "ts-attack4",
           actingPrincipal: signer.did(),
@@ -355,7 +353,6 @@ describe("content-addressed identity — adversarial (C5 red-team gate)", () => 
       runtime = new Runtime({
         apiUrl: new URL(import.meta.url),
         storageManager,
-        cfcEnforcementMode: "enforce-explicit",
         trustSnapshotProvider: () => ({
           id: "ts-attack4b",
           actingPrincipal: signer.did(),
@@ -413,7 +410,6 @@ describe("content-addressed identity — adversarial (C5 red-team gate)", () => 
       runtime = new Runtime({
         apiUrl: new URL(import.meta.url),
         storageManager,
-        cfcEnforcementMode: "enforce-explicit",
         trustSnapshotProvider: () => ({
           id: "ts-attack4d",
           actingPrincipal: signer.did(),
@@ -464,7 +460,6 @@ describe("content-addressed identity — adversarial (C5 red-team gate)", () => 
       runtime = new Runtime({
         apiUrl: new URL(import.meta.url),
         storageManager,
-        cfcEnforcementMode: "enforce-explicit",
         trustSnapshotProvider: () => ({
           id: "ts-attack4c",
           actingPrincipal: signer.did(),
@@ -526,7 +521,6 @@ describe("content-addressed identity — adversarial (C5 red-team gate)", () => 
       runtime = new Runtime({
         apiUrl: new URL(import.meta.url),
         storageManager,
-        cfcEnforcementMode: "enforce-explicit",
         trustSnapshotProvider: () => ({
           id: `ts-${name}`,
           actingPrincipal: signer.did(),
@@ -836,7 +830,6 @@ describe("content-addressed identity — adversarial (C5 red-team gate)", () => 
     runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
       trustSnapshotProvider: () => ({
         id: `ts-${name}`,
         actingPrincipal: signer.did(),

--- a/packages/runner/test/content-addressed-identity.test.ts
+++ b/packages/runner/test/content-addressed-identity.test.ts
@@ -66,7 +66,6 @@ describe("content-addressed action identity", () => {
     runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "observe",
     });
     const pattern = await runtime.patternManager.compilePattern(PROGRAM);
     await runtime.idle();
@@ -348,7 +347,6 @@ export default pattern<{ out: string }>(({ out }) => ({
     runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "observe",
     });
     const pattern = await runtime.patternManager.compilePattern(
       DYNAMIC_PROGRAM,
@@ -464,7 +462,6 @@ export default pattern<{ value: number }>(({ value }) => ({
     runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "observe",
     });
     const pattern = await runtime.patternManager.compilePattern(
       LIFT_PROGRAM,

--- a/packages/runner/test/esm-cell-cache-integration.test.ts
+++ b/packages/runner/test/esm-cell-cache-integration.test.ts
@@ -629,6 +629,8 @@ describe("ESM compile via content-addressed cell cache", () => {
     const disabled = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
+      // The disabled rung is what this test is about. The compile cache stats
+      // assertion below reads back all zeroes only at this rung.
       cfcEnforcementMode: "disabled",
     });
     const dtx = disabled.edit();

--- a/packages/runner/test/generate-object-outbox.test.ts
+++ b/packages/runner/test/generate-object-outbox.test.ts
@@ -302,7 +302,6 @@ describe("generateObject outbox mechanism", () => {
 
     try {
       const rejectedTx = runtime.edit();
-      rejectedTx.setCfcEnforcementMode("enforce-explicit");
       rejectedTx.markCfcRelevant("generateObject retry regression");
       action(rejectedTx);
       const rejectedResult = await rejectedTx.commit();
@@ -403,7 +402,6 @@ describe("generateObject outbox mechanism", () => {
 
     try {
       const rejectedTx = runtime.edit();
-      rejectedTx.setCfcEnforcementMode("enforce-explicit");
       rejectedTx.markCfcRelevant("generateObject tool retry regression");
       action(rejectedTx);
       const rejectedResult = await rejectedTx.commit();

--- a/packages/runner/test/generate-object-tools.test.ts
+++ b/packages/runner/test/generate-object-tools.test.ts
@@ -69,9 +69,15 @@ describe("generateObject with tools", () => {
   beforeEach(() => {
     clearMockResponses(); // Clear mocks from previous tests
     storageManager = StorageManager.emulate({ as: signer });
+    // The suite characterizes the generateObject tool loop at the
+    // enforce-explicit, flow-off rung its recorded mocks were captured
+    // against: flow-derived labels change the redaction inputs, and with
+    // them the request the mocks match on.
     runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
+      cfcEnforcementMode: "enforce-explicit",
+      cfcFlowLabels: "off",
     });
     tx = runtime.edit();
 

--- a/packages/runner/test/generate-text-outbox.test.ts
+++ b/packages/runner/test/generate-text-outbox.test.ts
@@ -183,11 +183,15 @@ describe("generateText outbox mechanism", () => {
 
     try {
       const rejectedTx = runtime.edit();
-      rejectedTx.setCfcEnforcementMode("enforce-explicit");
-      rejectedTx.markCfcRelevant("generateText retry regression");
       action(rejectedTx);
+      // Advancing the inputs document after the action has read it makes the
+      // staged transaction's commit fail, which is the rejection the outbox
+      // has to survive.
+      const conflictTx = runtime.edit();
+      inputsCell.withTx(conflictTx).set({ prompt, maxTokens: 128 });
+      expect((await conflictTx.commit()).ok).toBeDefined();
       const rejectedResult = await rejectedTx.commit();
-      expect(rejectedResult.error).toBeDefined();
+      expect(rejectedResult.error?.name).toBe("StorageTransactionInconsistent");
       await runtime.idle();
       expect(sendRequestCalls).toEqual([]);
 
@@ -260,11 +264,18 @@ describe("generateText outbox mechanism", () => {
 
     try {
       const rejectedTx = runtime.edit();
-      rejectedTx.setCfcEnforcementMode("enforce-explicit");
-      rejectedTx.markCfcRelevant("llm retry regression");
       action(rejectedTx);
+      // Advancing the inputs document after the action has read it makes the
+      // staged transaction's commit fail, which is the rejection the outbox
+      // has to survive.
+      const conflictTx = runtime.edit();
+      inputsCell.withTx(conflictTx).set({
+        messages: [{ role: "user", content: prompt }],
+        maxTokens: 128,
+      });
+      expect((await conflictTx.commit()).ok).toBeDefined();
       const rejectedResult = await rejectedTx.commit();
-      expect(rejectedResult.error).toBeDefined();
+      expect(rejectedResult.error?.name).toBe("StorageTransactionInconsistent");
       await runtime.idle();
       expect(sendRequestCalls).toEqual([]);
 

--- a/packages/runner/test/home-add-favorite.test.ts
+++ b/packages/runner/test/home-add-favorite.test.ts
@@ -143,7 +143,11 @@ describe("home favorites handlers", () => {
       tags: [],
       userTags: [],
     });
-    await tx.commit();
+    // A manual test tx prepares the way the runtime's own commit paths do:
+    // an enforcing rung refuses a relevant transaction that arrives
+    // unprepared.
+    runtime.prepareTxForCommit(tx);
+    expect((await tx.commit()).error).toBeUndefined();
     tx = runtime.edit();
     await runtime.idle();
     const seeded =

--- a/packages/runner/test/inspace-child-owner-write.test.ts
+++ b/packages/runner/test/inspace-child-owner-write.test.ts
@@ -219,6 +219,10 @@ describe("inSpace child owner-protected write (profile elements)", () => {
       // to `unsupported`.
       const writeTx = rt2.edit();
       childCell.withTx(writeTx).key("add").send({ item: "second" });
+      // A manual test tx prepares the way the runtime's own commit paths do:
+      // an enforcing rung refuses a relevant transaction that arrives
+      // unprepared.
+      rt2.prepareTxForCommit(writeTx);
       const writeCommit = await writeTx.commit();
       expect(writeCommit.error).toBeUndefined();
       await childCell.pull();

--- a/packages/runner/test/link-ifc-read-relevance.test.ts
+++ b/packages/runner/test/link-ifc-read-relevance.test.ts
@@ -59,7 +59,10 @@ describe("link-ifc-read-relevance", () => {
 
   beforeEach(() => {
     storageManager = StorageManager.emulate({ as: signer });
-    runtime = new Runtime({ apiUrl: new URL(import.meta.url), storageManager });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
     tx = runtime.edit();
     seq++;
   });
@@ -184,16 +187,14 @@ describe("link-ifc-read-relevance", () => {
 
   it("marks a crossing whose only label signal is the stored schema's declaration", () => {
     // The seam's non-redundant case. The target document carries no
-    // stored cfc metadata and no label view — the ifc exists only as the
-    // stored link schema's declaration — and the flow-label machinery
-    // that marks relevance off persisted metadata is at its default
-    // (off). Without the crossing seam, this read's transaction would
-    // stay non-relevant and enforcement would never engage for it.
+    // stored cfc metadata and no label view, so the ifc exists only as
+    // the stored link schema's declaration. Every diagnostic the read
+    // records names a schema-ifc seam, so the crossing is what marked
+    // the transaction.
     const holder = holderOverLinkCarrying(labeledLinkSchema);
 
     expect(holder.key("item").get()).toEqual({ name: "Ada" });
 
-    expect(tx.getCfcState().flowLabelsMode).toBe("off");
     expect(cfcLabelViewForCell(holder.key("item"))?.entries ?? []).toEqual([]);
     expect(tx.getCfcState().relevant).toBe(true);
     const reasons = tx.getCfcState().diagnostics;
@@ -219,7 +220,10 @@ describe("link-ifc-read-relevance at resolution and handle hops", () => {
 
   beforeEach(() => {
     storageManager = StorageManager.emulate({ as: signer });
-    runtime = new Runtime({ apiUrl: new URL(import.meta.url), storageManager });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
     tx = runtime.edit();
     seq++;
   });
@@ -331,7 +335,10 @@ describe("link-ifc-read-relevance closure, narrowing, and raw readers", () => {
 
   beforeEach(() => {
     storageManager = StorageManager.emulate({ as: signer });
-    runtime = new Runtime({ apiUrl: new URL(import.meta.url), storageManager });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
     tx = runtime.edit();
     seq++;
   });

--- a/packages/runner/test/list-result-schema.test.ts
+++ b/packages/runner/test/list-result-schema.test.ts
@@ -57,7 +57,6 @@ describe("listResultSchema", () => {
     runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "observe",
     });
 
     const { commonfabric } = createTrustedBuilder(runtime);

--- a/packages/runner/test/llm-dialog-error-messages.test.ts
+++ b/packages/runner/test/llm-dialog-error-messages.test.ts
@@ -37,7 +37,6 @@ describe("llmDialog error-path messages", () => {
     runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "disabled",
     });
   });
 

--- a/packages/runner/test/llm-dialog-message-scope.test.ts
+++ b/packages/runner/test/llm-dialog-message-scope.test.ts
@@ -38,7 +38,6 @@ describe("llmDialog message document scope", () => {
     runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "disabled",
     });
   });
 

--- a/packages/runner/test/llm-dialog.test.ts
+++ b/packages/runner/test/llm-dialog.test.ts
@@ -2179,7 +2179,6 @@ describe("llmDialog", () => {
     const ceilingRuntime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: ceilingStorageManager,
-      cfcEnforcementMode: "enforce-explicit",
       // Deployment ceiling: the llmDialog sink may carry no confidentiality.
       cfcSinkMaxConfidentiality: { llmDialog: [] },
     });

--- a/packages/runner/test/max-enforcement-posture.test.ts
+++ b/packages/runner/test/max-enforcement-posture.test.ts
@@ -263,9 +263,14 @@ describe("max-enforcement CFC posture as one system (CT-2075)", () => {
         );
         const secretId = cell.getAsNormalizedFullLink().id;
         const tx = runtime.edit();
+        // The store declares the confidentiality it receives, so the write
+        // fits its own ceiling (§8.12.4) and the sink ceiling below is the
+        // gate that decides this commit. Without the declaration a strict
+        // writer-fit refuses first and the case stops reaching its subject.
         runtime.getCell<{ v: string }>(space, "posture-trigger-out", {
           type: "object",
           properties: { v: { type: "string" } },
+          ifc: { confidentiality: ["medical"] },
         }, tx).set({ v: "computed" });
         // The secret is recorded as what SCHEDULED this run; the run never
         // reads it again. Without the gating dial the consumed set would not
@@ -310,6 +315,7 @@ describe("max-enforcement CFC posture as one system (CT-2075)", () => {
           runtime.getCell<{ v: string }>(space, "posture-event-out", {
             type: "object",
             properties: { v: { type: "string" } },
+            ifc: { confidentiality: ["medical"] },
           }, tx).set({ v: "derived" });
           enqueueSinkRequestPostCommitEffect(
             tx,

--- a/packages/runner/test/module-delegation.test.ts
+++ b/packages/runner/test/module-delegation.test.ts
@@ -68,7 +68,6 @@ describe("module identity delegation", () => {
     runtime = new Runtime({
       apiUrl: new URL("http://toolshed.test"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
   });
 

--- a/packages/runner/test/multi-instance-resolution.test.ts
+++ b/packages/runner/test/multi-instance-resolution.test.ts
@@ -55,7 +55,6 @@ describe("multi-instance verified-function resolution", () => {
     runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "observe",
     });
 
     const runOne = async (cause: string) => {

--- a/packages/runner/test/navigate-handler.test.ts
+++ b/packages/runner/test/navigate-handler.test.ts
@@ -365,7 +365,6 @@ Deno.test(
       );
 
       const rejectedTx = runtime.edit();
-      rejectedTx.setCfcEnforcementMode("enforce-explicit");
       rejectedTx.markCfcRelevant("navigateTo retry regression");
       builtin.action(rejectedTx);
       const rejectedResult = await rejectedTx.commit();

--- a/packages/runner/test/oncommit-race.test.ts
+++ b/packages/runner/test/oncommit-race.test.ts
@@ -29,7 +29,6 @@ describe("onCommit callback final outcome", () => {
     runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
     });
     tx = runtime.edit();
   });

--- a/packages/runner/test/profile-create-real-card-add.test.ts
+++ b/packages/runner/test/profile-create-real-card-add.test.ts
@@ -149,6 +149,10 @@ describe("profile-create real card-add (REAL patterns, cross-space)", () => {
       profileCell.withTx(writeTx).key("addElement").send({
         title: "My Card",
       });
+      // A manual test tx prepares the way the runtime's own commit paths do:
+      // an enforcing rung refuses a relevant transaction that arrives
+      // unprepared.
+      rt2.prepareTxForCommit(writeTx);
       const writeCommit = await writeTx.commit();
       // The regression site. Pre-fix: "writeAuthorizedBy must remain stable".
       expect(writeCommit.error).toBeUndefined();

--- a/packages/runner/test/profile-home-bio.test.ts
+++ b/packages/runner/test/profile-home-bio.test.ts
@@ -76,6 +76,10 @@ describe("profile-home bio (owner-protected free-text field)", () => {
       result.withTx(tx2).key("setBio").send({
         bio: "Mathematician & first programmer.",
       });
+      // A manual test tx prepares the way the runtime's own commit paths do:
+      // an enforcing rung refuses a relevant transaction that arrives
+      // unprepared.
+      rt.prepareTxForCommit(tx2);
       const commit2 = await tx2.commit();
       expect(commit2.error).toBeUndefined();
       await result.pull();
@@ -88,6 +92,7 @@ describe("profile-home bio (owner-protected free-text field)", () => {
       result.withTx(tx3).key("setBio").send({
         bio: "  Countess of Lovelace.  ",
       });
+      rt.prepareTxForCommit(tx3);
       const commit3 = await tx3.commit();
       expect(commit3.error).toBeUndefined();
       await result.pull();

--- a/packages/runner/test/profile-home-pin-piece.test.ts
+++ b/packages/runner/test/profile-home-pin-piece.test.ts
@@ -95,6 +95,10 @@ describe("profile-home addPiece (followable piece card)", () => {
         pieceId: TARGET_PIECE,
         title: "Demo Counter",
       });
+      // A manual test tx prepares the way the runtime's own commit paths do:
+      // an enforcing rung refuses a relevant transaction that arrives
+      // unprepared.
+      rt.prepareTxForCommit(tx2);
       const commit2 = await tx2.commit();
       expect(commit2.error).toBeUndefined();
       await result.pull();

--- a/packages/runner/test/profile-owner-cfc.test.ts
+++ b/packages/runner/test/profile-owner-cfc.test.ts
@@ -135,7 +135,6 @@ const setTrustedProfileWriter = (
   tx: IExtendedStorageTransaction,
   actingPrincipal?: string,
 ) => {
-  tx.setCfcEnforcementMode("enforce-explicit");
   if (actingPrincipal !== undefined) {
     tx.setCfcTrustSnapshot({
       id: `profile-trust-${actingPrincipal}`,
@@ -409,7 +408,6 @@ describe("profile owner CFC policy", () => {
     const { runtime, storageManager } = createRuntime();
     try {
       const tx = runtime.edit();
-      tx.setCfcEnforcementMode("enforce-explicit");
       tx.setCfcTrustSnapshot(undefined);
       tx.setCfcImplementationIdentity({
         kind: "builtin",
@@ -440,7 +438,6 @@ describe("profile owner CFC policy", () => {
     const { runtime, storageManager } = createRuntime();
     try {
       const tx = runtime.edit();
-      tx.setCfcEnforcementMode("enforce-explicit");
       tx.setCfcTrustSnapshot({
         id: "profile-trust-untrusted",
         actingPrincipal: alice.did(),
@@ -473,7 +470,6 @@ describe("profile owner CFC policy", () => {
     const { runtime, storageManager } = createRuntime();
     try {
       const tx = runtime.edit();
-      tx.setCfcEnforcementMode("enforce-explicit");
       tx.setCfcTrustSnapshot({
         id: "profile-trust-owner-without-integrity",
         actingPrincipal: alice.did(),
@@ -625,7 +621,6 @@ describe("profile owner CFC policy", () => {
     try {
       const profileHomePattern = await compileProfileHomePattern(runtime);
       const tx = runtime.edit();
-      tx.setCfcEnforcementMode("enforce-explicit");
       tx.setCfcTrustSnapshot({
         id: "pattern-create",
         actingPrincipal: alice.did(),
@@ -768,7 +763,6 @@ describe("profile owner CFC policy", () => {
     const { runtime, storageManager } = createRuntime();
     try {
       const tx = runtime.edit();
-      tx.setCfcEnforcementMode("enforce-explicit");
       tx.setCfcTrustSnapshot({
         id: "setup-projection",
         actingPrincipal: alice.did(),
@@ -832,7 +826,6 @@ describe("profile owner CFC policy", () => {
     const { runtime, storageManager } = createRuntime();
     try {
       const tx = runtime.edit();
-      tx.setCfcEnforcementMode("enforce-explicit");
       tx.setCfcTrustSnapshot({ id: "no-marker", actingPrincipal: alice.did() });
       tx.setCfcImplementationIdentity({
         kind: "builtin",
@@ -875,7 +868,6 @@ describe("profile owner CFC policy", () => {
     const { runtime, storageManager } = createRuntime();
     try {
       const tx = runtime.edit();
-      tx.setCfcEnforcementMode("enforce-explicit");
       tx.setCfcTrustSnapshot({ id: "per-path", actingPrincipal: alice.did() });
       const cell = runtime.getCell(
         alice.did(),
@@ -916,7 +908,6 @@ describe("profile owner CFC policy", () => {
     const { runtime, storageManager } = createRuntime();
     try {
       const tx = runtime.edit();
-      tx.setCfcEnforcementMode("enforce-explicit");
       tx.setCfcTrustSnapshot({
         id: "per-path-neg",
         actingPrincipal: alice.did(),

--- a/packages/runner/test/reexport-provenance.test.ts
+++ b/packages/runner/test/reexport-provenance.test.ts
@@ -70,7 +70,6 @@ describe("re-export provenance", () => {
     runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "observe",
     });
 
     const pattern = await runtime.patternManager.compilePattern(

--- a/packages/runner/test/runtime-edit-with-retry.test.ts
+++ b/packages/runner/test/runtime-edit-with-retry.test.ts
@@ -123,19 +123,7 @@ describe("Runtime.editWithRetry", () => {
     expect(cell.get()).toBe(0);
   });
 
-  it("prepares relevant transactions before committing in enforcing modes", async () => {
-    await runtime.dispose();
-    await storageManager.close();
-
-    storageManager = StorageManager.emulate({
-      as: signer,
-    });
-    runtime = new Runtime({
-      apiUrl: new URL(import.meta.url),
-      storageManager,
-      cfcEnforcementMode: "enforce-explicit",
-    });
-
+  it("prepares relevant transactions before committing", async () => {
     let committedTx: IExtendedStorageTransaction | undefined;
     const { ok, error } = await runtime.editWithRetry((t) => {
       committedTx = t;
@@ -164,18 +152,6 @@ describe("Runtime.editWithRetry", () => {
   });
 
   it("recomputes prepare on each retry with fresh transactions", async () => {
-    await runtime.dispose();
-    await storageManager.close();
-
-    storageManager = StorageManager.emulate({
-      as: signer,
-    });
-    runtime = new Runtime({
-      apiUrl: new URL(import.meta.url),
-      storageManager,
-      cfcEnforcementMode: "enforce-explicit",
-    });
-
     const attempts: IExtendedStorageTransaction[] = [];
     const { ok, error } = await runtime.editWithRetry((t) => {
       attempts.push(t);
@@ -221,7 +197,6 @@ describe("Runtime.editWithRetry", () => {
     runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
       trustSnapshotProvider: () => ({
         id: `trust-${++snapshotCalls}`,
         actingPrincipal: signer.did(),

--- a/packages/runner/test/runtime-prepare-tx-for-commit.test.ts
+++ b/packages/runner/test/runtime-prepare-tx-for-commit.test.ts
@@ -40,7 +40,6 @@ describe("Runtime.prepareTxForCommit()", () => {
     const runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
       ...(cfcFlowLabels === undefined ? {} : { cfcFlowLabels }),
     });
     started.push({ runtime, storageManager });

--- a/packages/runner/test/stream-data-outbox.test.ts
+++ b/packages/runner/test/stream-data-outbox.test.ts
@@ -30,9 +30,14 @@ describe("stream-data outbox mechanism", () => {
 
   beforeEach(() => {
     storageManager = StorageManager.emulate({ as: signer });
+    // The retry cases below need a commit the gate REFUSES: their subject is
+    // what the outbox does after one. Only an enforcing rung produces that
+    // refusal, so the suite names one rather than inheriting whichever rung
+    // the fleet is set to.
     runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
+      cfcEnforcementMode: "enforce-explicit",
     });
 
     const { commonfabric } = createTrustedBuilder(runtime);
@@ -217,7 +222,6 @@ describe("stream-data outbox mechanism", () => {
     );
 
     const rejectedTx = runtime.edit();
-    rejectedTx.setCfcEnforcementMode("enforce-explicit");
     rejectedTx.markCfcRelevant("streamData retry regression");
     action(rejectedTx);
     const rejectedResult = await rejectedTx.commit();

--- a/packages/runtime-client/test/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/test/backends/runtime-processor.test.ts
@@ -3300,7 +3300,6 @@ describe("runtime-processor", () => {
           rootSchema,
         );
         const tx = runtime.edit() as any;
-        tx.setCfcEnforcementMode("enforce-explicit");
         (root.withTx(tx) as any).set({
           messages: [{ piece: { id: "alice", body: "hello" } }],
         });
@@ -3445,13 +3444,11 @@ describe("runtime-processor", () => {
         );
 
         const seed = runtime.edit();
-        seed.setCfcEnforcementMode("enforce-explicit");
         root.withTx(seed).set({ messages: [] });
         seed.prepareCfc();
         expect((await seed.commit()).ok).toBeDefined();
 
         const tx = runtime.edit();
-        tx.setCfcEnforcementMode("enforce-explicit");
         root.withTx(tx).key("messages").push({
           piece: {
             id: "alice-message",

--- a/packages/runtime-client/test/runtime-client.test.ts
+++ b/packages/runtime-client/test/runtime-client.test.ts
@@ -1005,7 +1005,6 @@ describe("attachOptionsFrom()", () => {
       identity,
       spaceIdentity,
       spaceDid: identity.did(),
-      cfcEnforcementMode: "enforce-strict",
     });
 
     expect(attach.identity).toBe(identity.did());


### PR DESCRIPTION
A test that rides the fleet's CFC defaults measures whatever those defaults happen to be. When a dial moves, a suite whose subject is something else keeps passing while quietly measuring the new posture instead. This makes each suite either name the rung its subject needs, with a reason a later reader can act on, or say nothing about CFC at all.

The decision was made by running, not by reading. Every file carrying a pin below the strictest rung was run alone twice at a raised dial row, once with its pins and once with them stripped, so "is this pin holding anything up" had a measured answer. Files that survived stripping, and every file that could not be run mechanically, then went to per-file review.

788 pin sites were classified:

- 406 removable. The pin was not about the level. It is gone, and the test passes at every rung with no rung-conditional code. Most needed no repair. Where one was needed it was a fixture that under-declared what it writes: a schema naming a `requiredIntegrity` floor while minting nothing on that path, a manual transaction that never prepared, a byte comparison standing in for a representation-aware one.
- 212 level-subject. The pin stays, because an assertion reads the dial back, the test's name states the rung, or the case is one half of a matched pair over a single fixture. `cfc-boundary` spreads one posture constant, carrying every dial the default table resolves, over each of the fifteen runtimes it builds.
- 109 other. Mostly harness configuration rather than a runtime level. Seventeen are the test's own subject being a dial default or a preset's pinned value, which no test-side repair can reach.
- 6 claimed a runtime bug. Each went to an independent reviewer that reproduced the failure and looked for a test-side repair, and all six were refuted: four had a concrete fixture repair, two were an unsettled design question rather than a defect. No runtime bug survived, so the tree carries no dial-up markers.

The commonest reason a pin looked load-bearing was not a level at all. A test would raise a transaction with `setCfcEnforcementMode` to a rung below the floor that transaction already starts at, and the anti-downgrade guard would refuse the request. That is a redundant line to delete.

With the whole dial row raised to its strict end, the runner, piece, cli and cf-harness suites fail in five places, and all five assert what a default is: the label-metadata protection dial, the runtime-options defaults, preset conformance, and the harness's expected-posture and posture-resolution suites. Whichever change moves the row owns those five and nothing else.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7008?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

