### PR TITLE
feat(shuttle): `cd` settles against the fabric, and the place holds the piece

### DIFF
--- a/docs/plans/shuttle/README.md
+++ b/docs/plans/shuttle/README.md
@@ -139,14 +139,46 @@ invisible, the prompt renders the whole ambient record — place and scope
 11. **A space root lists facets, never pieces directly** — `slugs/` and
     `pieces/` in v1; the `fuse/` facet (the FUSE layout mirrored,
     leveraging `packages/fuse` rather than reinventing it) is designed and
-    deferred ([`futures.md`](futures.md)). Facet names are reserved at
-    the space root only.
+    deferred ([`futures.md`](futures.md)). Facet names are reserved
+    wherever a walk from the root begins: as a segment at the space root,
+    and as the first segment of a **rooted** reference, so `/slugs/todo`
+    names what `cd /` then `cd slugs/todo` names. The shell teaches
+    `cd slugs` at the root in its first minute and the natural next
+    spelling is the rooted one, so a rooted `/slugs/…` that named a piece
+    slugged `slugs` would be one character from the facet rendering and
+    would name another cell entirely. Inside a piece nothing is reserved.
+
+    **The reservation diverges from the canonical grammar, for two slug
+    values.** The rooted spelling is not shuttle's — `/[@space/]<piece>…`
+    is the canonical cell reference, the runner's `parseReferenceParts`,
+    the same structure in patterns and at every `cf` intake seam, and this
+    CLI resolves the piece segment by slug as well as by handle
+    (`packages/cli/lib/llm-friendly-ref.ts`). The facets are the
+    shuttle-only half: a browsing overlay on the space root. So shuttle
+    reads `/slugs/x` and `/pieces/x` differently from the way `cf` reads
+    the same strings, and identically for every other slug. That is the
+    current state and it is what decision 11 costs: a piece slugged
+    `slugs` or `pieces` has no rooted slug spelling in shuttle, and is
+    reached by handle or by a complete reference carrying its space.
+    Issue [#6992](https://github.com/commontoolsinc/labs/issues/6992)
+    retires the divergence by having `set-slug` refuse those two values,
+    after which no piece can carry them and the two grammars agree
+    everywhere.
 12. **A view is not necessarily a place.** Pagination and search produce
     views to look at and pick from; they need no path-shaped address unless
     one earns it (the virtual-places extension of decision 5).
 13. **Prompt and naming: checked names only, fabric's mechanisms only.**
-    Space names and slugs are shown when an index confirms them, shortened
-    unique ids otherwise; shuttle introduces no naming layer of its own.
+    Space names and slugs are shown when an index confirms them, and the
+    whole handle otherwise; shuttle introduces no naming layer of its own.
+    The prompt shortens nothing but the space, for two reasons that hold
+    on their own. A prefix of a handle is spelled exactly as a whole handle
+    is, so nothing in it says which it is, and `pwd` is ruled to be what a
+    person copies — a prompt handing out something that looks like an
+    address and is not is the silent wrongness decision 11 ends. And a
+    prefix is only useful if it is unique, which is knowing every other
+    handle in the space: an index read, per prompt line, where a name is
+    read once at the `cd` that adopted it and the handle needs no read at
+    all.
 14. **Writes: inline value, editor, explicit links.** `set` takes a JSON
     value on the line (stdin via `-`); `edit` opens `$EDITOR` on the current
     value; `link` is the only spelling that creates a reference rather than
@@ -189,14 +221,26 @@ invisible, the prompt renders the whole ambient record — place and scope
     (`@user`, `@session`) are a way of seeing every place, so the cwd is
     the pair (position, scope): both stick across navigation, both render
     in the prompt, and `pwd` prints both. `cd` is the door to both —
-    `cd board@session` moves both, `cd @session` scope alone, `cd @space`
+    `cd board@session` moves both, `cd .@session` scope alone, `cd .@space`
     back to the base — there is no separate scope verb, and an explicit
-    suffix on an operand overrides the ambient scope for that operand. All
-    three scope words are canonical, and a suffix on a reference is
-    verified against the canonical parser; a scope-only `@scope` is
-    shuttle navigation syntax, accepted by `cd` and `where` and printed by
-    `pwd`, and it sits alongside `/`, `..` and `-`, the other spellings
-    `cd` takes and the canonical grammar does not parse. A suffix names the
+    qualifier on an operand overrides the ambient scope for that operand. A
+    scope moved alone still moves onto a place: the same id under two
+    scopes is two documents, so `cd .@session` settles against the fabric
+    as every other move `cd` adopts does. All
+    three scope words are canonical, and a qualifier on a reference is
+    verified against the canonical parser. A scope on its own is written
+    `.@scope`: `.` is the context's own cell and the qualifier hangs off
+    it, which is the reference grammar's own relative spelling rather than
+    a navigation word beside `/`, `..` and `-`. `@` therefore carries one
+    meaning — a qualifier on the piece — and is an ordinary character
+    everywhere else, so `cd @session` reaches a key of that name and a
+    refusal that finds none offers `.@session` instead.
+
+    This tracks
+    [#6814](https://github.com/commontoolsinc/labs/issues/6814), which is
+    proposed rather than merged. Shuttle ships conforming to it because
+    the alternative is migrating the spelling later, and a shell's
+    navigation words are what a person's fingers learn first. A qualifier names the
     base scope or the reading identity's own
     overlays, never another identity's; standing in another identity's
     overlay is a canonical-grammar extension, out of v1.
@@ -283,13 +327,32 @@ The ambient context is one record:
 - **External working location**, **invocation session**.
 
 `cd` accepts relative path segments, `..`, `-`, `/`, rooted and complete
-canonical references, slugs, wish targets, and scope suffixes. A space
+canonical references, slugs, wish targets, and scope qualifiers. A space
 named by name inside a reference is accepted and settled in two steps,
 since deriving a DID from a name needs a session: the move comes back
 carrying the name, and landing it means handing it over again with the
 space that name resolved to, which is refused when that is not the
 connected space. A space name as an operand of its own joins when
-multi-space sessions do. Every
+multi-space sessions do.
+
+**A move onto a piece is settled the same way, against the fabric**, so
+that `cd` is the one verb whose success means something. Three questions
+are asked, and what the prompt promises is exactly their answers: a slug
+resolves through the space's index, a handle is looked up in that same
+index, and a path is walked against one read of the level above it. Each
+failure is refused in shuttle's words — the path carrying the keys that
+are there — rather than reported one command later in the runtime's. One
+spelling escapes, and it is worth naming rather than surveying: a handle
+read against a server that does not advertise the identifier lookup gets
+neither a yes nor a no, and is taken as written.
+[`grammar.md`](grammar.md) records that bound.
+
+The place holds the piece the index pointed at rather than the slug,
+which is what keeps an index repointed mid-session from moving a place a
+write then lands in; the slug stays beside it as the name the prompt
+shows (decision 13), and `pwd` prints the piece. `get` settles nothing:
+where an operand points is the operand's own fact, and a read of a cell
+that is not there fails on its own account. Every
 reference a command takes resolves against the cwd, and how much of the
 cwd it needs varies: a rooted `/of:…` fixes the piece and path but draws
 its space and its scope from the place, a complete `/@did:key:…/of:…`

--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -122,7 +122,8 @@ Landed:
 - **B1a — the place value and its owner module**
   (`packages/cli/lib/shuttle/place.ts`). The whole pair, position *and* scope,
   because scope is half of what a place is (decision 20): `cd` over relative
-  segments, `..`, `-`, `/`, a scope-only `@scope`, and rooted and complete
+  segments, `..`, `-`, `/`, `.` and the `.@scope` qualifier, and rooted and
+  complete
   references; the `slugs/` and `pieces/` facets a space root reserves, and
   nothing else there; the rendering `pwd` prints of both halves, the position
   line carrying the scope so that it denotes one cell wherever it is read; and
@@ -288,9 +289,10 @@ Landed:
   The prompt carries the place short, and the only shortening it does is
   leaving the space out: one connection serves one space, so that part is the
   same on every line of a run and `where` prints it. Nothing else is
-  abbreviated, which leaves decision 13's checked names and the shortened-id
-  question they raise exactly where [`grammar.md`](grammar.md) has them — the
-  prompt is no address, and `pwd` is what to copy.
+  abbreviated. A piece with no checked name prints its handle whole, which is
+  decision 13's rule and not a gap in it: a prefix is spelled exactly as a
+  whole handle is, so it would read as an address and name nothing, and a
+  prefix worth printing is a unique one, which is an index read per line.
 
   The launcher is decision 19's pair. `cf sh` is a command in the `cf`
   tree, with the three flags every command taking a space and an identity
@@ -335,6 +337,64 @@ Landed:
   `cd -- -x` reaches such a key — and what a listing owes is the name rather
   than the route. `operandForChild` asks the option grammar rather than making
   the move, that reading being one layer above a place.
+
+- **B1e — `cd` settles against the fabric, and the place holds the piece.**
+  A shell's `cd` is the one verb whose success means something, so a move
+  that reaches a piece comes back from `place.ts` pending and `verbs.ts`
+  reads before the place is adopted: the slug resolved through
+  `resolvePieceReference`, which is the resolution a read makes and given the
+  same path, so a slug naming a collection reaches its member and `cd` cannot
+  refuse a reference `get` accepts; the handle looked up through
+  `entityIdExists` — the
+  space's own identifier index, which a value read cannot stand in for, an
+  absent piece reading as nothing and an empty one reading the same — and the
+  path found by one read of the level already stood at, walked segment by
+  segment. None of the three is asked where there is no question. A move that
+  spells the piece already stood on, at the scope it was settled at, resolves
+  and looks up nothing, that piece having come through a settle of its own —
+  and what the skip rests on is a projection the compiler closes, so a field
+  added to a position cannot widen the decision without widening the key; a slug needs no lookup, its
+  resolution having reached the document; and a move that adds no segment to a
+  level already confirmed reads nothing. What the settle costs is one identifier
+  lookup on a `cd` onto a piece named by handle, on top of the path read, and
+  nothing on any other move. The refusal a path that is not there gets is
+  shuttle's own and carries the keys that are — the runtime's
+  `Available keys:` hint said in the shell's words, at the command that was
+  wrong rather than at the next one. It is the two-step protocol B1a left for
+  a `#name` target and a space written as a name, with a third spelling on
+  it; the recursion is two deep at most, since a settled space-named move is
+  a place standing on a piece and a confirmed piece lands or refuses.
+
+  The place holds the piece the slug resolved to, and the slug stands beside
+  it as the name. A slug is a redirect, so a place holding one moves when the
+  index is repointed and B2's `set` writes where it points now; a place
+  holding the piece cannot move, and `samePosition` compares pieces, so two
+  arrivals at one cell are one position as [`grammar.md`](grammar.md)
+  promises. The name is decision 13's checked name: the prompt shows it
+  because a read confirmed it, and `pwd` prints the piece — a resolution
+  answers with a piece's own id, which is the form `namesResolvedParts` takes
+  for a durable link. `enter` is the one door
+  that lands a piece without a read, the fabric having resolved the target
+  already, and it refuses an address naming its piece by slug so that the
+  place holds a piece whichever door reached it.
+
+  The facet names are reserved in a rooted reference too, so `/slugs/todo`
+  is the walk `cd /` and `cd slugs/todo` make. Decision 11 and
+  [`grammar.md`](grammar.md) carry the rule and what it costs. It closes the
+  gap the short form left open: the prompt writes a facet as `/slugs/`, and
+  the claim that the leading separator reads as the walk down from the root
+  was one only the rule makes true. The rooted spelling is the canonical
+  reference grammar rather than shuttle's, and it resolves a piece by slug,
+  so the reservation is a divergence from what `cf` reads — at two slug
+  values and no others. Issue
+  [#6992](https://github.com/commontoolsinc/labs/issues/6992) retires it by
+  refusing those two as slugs at `set-slug`.
+
+  `get` settles nothing, and that is the same asymmetry `#argument` has.
+  `CurrentPlace.aim` and `CurrentPlace.resolveNamedSpace` answer where an
+  operand points, so neither hands back a pending move: a `cd` waits because
+  the prompt would go on promising the place, and a read of a cell that is
+  not there fails on its own account and in its own words.
 
 Still to come:
 

--- a/docs/plans/shuttle/grammar.md
+++ b/docs/plans/shuttle/grammar.md
@@ -78,7 +78,8 @@ quoted wherever in the value it sits — a printer is handed a value and no
 position, so it quotes on the character rather than on the reading.
 
 The characters an operand writes an address with — the `/` between segments,
-the `@` of a scope suffix, `-`, `..` — are deliberately not in that set, and
+the `@` of a scope qualifier, `-`, `..` — are deliberately not in that set,
+and
 that exclusion is what makes the output rule worth having rather than a
 detail of it. Those characters are read inside a token by the place
 resolution below rather than by the split, so quoting on them would buy the
@@ -178,7 +179,9 @@ as the canonical grammar's context rule already works:
 - `/of:…` — a **rooted** reference: it names the piece and path from the
   root, so no part of the position is read from the place — but it omits
   the space and the scope, and the place supplies both. Rooted is not
-  place-independent.
+  place-independent. A rooted operand whose first segment names a facet is
+  the walk down from the space root instead, the facet names being
+  reserved there too (below).
 - `/@did:key:…/of:…` — a **complete** reference: piece, path and space are
   its own, and the scope is still the place's. It is place-independent in
   one dimension and not in the other, so the same string read at `@user`
@@ -193,11 +196,20 @@ as the canonical grammar's context rule already works:
   link should be, and it is what `pwd` prints, for that reason.
 
   The scope a complete reference omits is not a hole in it. Canonically an
-  absent suffix *means* the base, which is why the serializer writes none
+  absent qualifier *means* the base, which is why the serializer writes none
   for a base-scoped link. The two layers read the same absence differently
   — canonical says base, shuttle fills it from the place, the way a shell
   reads a relative path — and that difference is why `pwd` writes the
-  suffix rather than trusting it to be inferred.
+  qualifier rather than trusting it to be inferred.
+
+  Shuttle composes the space prefix itself, in `renderPosition`
+  (`packages/cli/lib/shuttle/place.ts`), writing `@<space>` as a segment of
+  the pointer. That spelling is the alias form under
+  [#6814](https://github.com/commontoolsinc/labs/issues/6814), whose writer
+  step replaces it with `//<space>/` and after which no writer emits the
+  alias — it stays readable for strings already rendered into harness refs,
+  stored messages and markdown. `renderPosition` is the one place shuttle
+  writes a reference, so that step has a single site to visit here.
 - `#…` — a wish target (entry point), resolvable from anywhere within
   the connected space. A target anchored elsewhere — profile and
   favorites resolve against the reading identity's home space regardless
@@ -220,13 +232,21 @@ one; it is the piece and path it fixes, not the space.
 How a reading is matched says where it holds.
 `-` and a lone `/` are matched against the whole operand exactly, so
 neither governs a segment: a key named `-` is reachable relatively
-wherever it is not the whole operand. `@scope` and a lone leading `#` are
-matched against the operand's head, and each takes the whole operand with
-it: `cd @user/board` refuses rather than moving the scope and descending,
-and `cd #favorites/topics` hands on the whole string as one target. So
-each is an ordinary data character in every later segment that is data —
-inside a piece. A later segment naming a piece is read by the canonical
-grammar instead, so a scope suffix there moves the scope. A fragment there
+wherever it is not the whole operand. `.` alone is matched that way as well, being
+the context's own cell. `./` and `.@` are **heads** rather than whole
+operands: each is read before the walk splits what follows, and governs it
+— `./items@user` is the key `items@user` and never a walk through a key
+called `.`, and `.@user` moves the scope. So a key named `.` has no bare
+spelling, the trade `-` and `/` already make, and keeps the two that
+matter: `./.` reaches it, and so does the reference a listing prints for
+it. A lone leading `#` is matched
+against the operand's head too and takes the whole operand with it:
+`cd #favorites/topics` hands on the whole string as one target. So `#` is
+an ordinary data character in every later segment that is data — inside a
+piece — and so is `@` in every segment that is data. Where a qualifier is
+read is where a segment names a cell: the `.` head, and a segment naming a
+piece, which the canonical grammar reads and which therefore takes the
+qualifier `board@session` carries. A fragment there
 is refused too, but by shuttle rather than by that grammar, which carries
 the `#argument` suffix on a piece designation and would take one. `..` is
 matched segment by segment as the walk splits them, so it is reserved in
@@ -258,11 +278,12 @@ since what a person copies off the screen is what the terminal did with it.
 terminal prints them, and the printer quotes them, being whitespace to the
 split.
 
-Of what a rendering loses, only the newline reaches a piece that has one. The scope suffix the
+Of what a rendering loses, only the newline reaches a piece that has one. The
+scope qualifier the
 rendering always writes sits between the piece and the end of the string,
-so the trim takes the suffix rather than the piece, and the parse's split
-at the last `@` takes the suffix's own. An empty piece is the exception,
-and one fact generates it: its rendered id segment is the suffix and
+so the trim takes the qualifier rather than the piece, and the parse's split
+at the last `@` takes the qualifier's own. An empty piece is the exception,
+and one fact generates it: its rendered id segment is the qualifier and
 nothing else, so the split finds no id in front of it and the parse refuses
 the whole reference rather than handing anything back.
 
@@ -287,8 +308,8 @@ is the canonical parse's own — `validatePieceSegment`
 (`packages/cli/lib/llm-friendly-ref.ts`), called rather than copied, so that a
 name in neither vocabulary is refused with one sentence whichever door read
 it. The doors are the reference, a walk into a piece, a target the fabric
-resolved, and a settled move, which is every door a piece reaches a place
-through:
+resolved, a settled move, and the piece a read resolved, which is every door
+a piece reaches a place through:
 `cd slugs/Board` is refused, and the reason it gives is the reason `cd /Board`
 gives. That is what makes a listing's job possible: a name printed as an
 operand is one `cd` takes, and a name the rule refuses is one nothing offers
@@ -340,6 +361,94 @@ reached per operand instead — `get topics/3#argument`, and `--input` on
 the `cf` verbs that take it — so the choice is one visible token at each
 use.
 
+## What `cd` reads before it moves
+
+A shell's `cd` is the one verb whose success means something, so a move
+that reaches a piece is asked of the fabric before the place is adopted,
+and the refusal a place that is not there gets is shuttle's own rather
+than the runtime error whichever verb read next would have raised.
+
+Three questions, each asked only where there is one to ask:
+
+- **The piece**, where the move reaches one it is not already standing on.
+  A slug resolves through the space's index (`resolvePieceReference`,
+  `packages/piece/src/slugs.ts`) — the same resolution a read makes, given
+  the same path, so a slug naming a *collection* spends leading segments
+  reaching its member and `cd /tasks/first/title` lands where
+  `get /tasks/first/title` reads. Two verbs disagreeing about whether a
+  reference names anything would be worse than either answer. The place
+  takes the path the resolution left and the scope it was reached through,
+  a member held through a narrowed link being a different document from
+  the one its id alone names. **The place holds the piece it resolved
+  to**, with the slug beside it as the name the prompt shows —
+  decision 13's checked name, read once at the move rather than trusted
+  per command. A slug is a redirect: a place holding one would follow the
+  index to another piece without moving, and B2's `set` would write where
+  the index points now. A place holding the piece cannot move. A slug the
+  index names nothing for is refused here, carrying the resolution's own
+  sentence. A move that spells the piece already stood on — a key under
+  it, or a reference naming it — resolves nothing: that piece came through
+  a settle of its own, so the question is answered, and the move changes
+  the path rather than the piece. What counts as already settled is the
+  place and not the position: a move to the same path at another scope is
+  a move to another document, and reads again.
+
+  The place a settle adopts is the route's as well as the destination's. A
+  trail is made of positions `..` walks back through and `-` restores, so
+  every one of them is a place shuttle can stand at, and each is landed
+  with the piece the resolution answered. Where the resolution spent
+  segments, the levels it walked *through* are levels of the collection
+  rather than of what it held and go with it; the level the member itself
+  sits at is the member's, and lands with the member's piece. A route
+  records how shuttle reached a place, so `cd a/b/c` and `cd a/b` then
+  `cd c` are one walk written two ways and leave the same route.
+- **The handle**, where the resolution reached one without proving it. A
+  handle is a spelling and not a lookup — the resolution hands one
+  straight back, `isPieceHandle` being a length rule — so the space's own
+  identifier index is asked whether it holds that piece (`entityIdExists`,
+  `PiecesController`, which tests one identifier without selecting a
+  stored value). A value read cannot stand in for it: a piece the space
+  does not hold reads as nothing, and so does an empty one. A slug needs
+  no such lookup, its resolution having reached the document to take an id
+  from it, and neither does the piece a move already stands on.
+- **The path.** One read of the cell at the deepest level already stood
+  at, walked segment by segment through the value it returned. The first
+  segment that is not a key of the level above it is refused by name, with
+  the keys that are — the sentence the runtime's `Available keys:` hint
+  carries, in shuttle's words and as a refusal rather than as a failure.
+
+What that costs is one identifier lookup on a `cd` onto a piece named by
+handle, on top of the path read, and nothing on any other move: not on a
+slug, whose resolution is its own proof; not on a key under the piece
+already stood on; not on a move that reaches a container. The lookup reads
+an index rather than a value, which is what makes it affordable at a
+prompt.
+
+The read is aimed one level above the destination and never at it, and
+that is what keeps every miss a refusal. A read aimed at a path the fabric
+does not hold raises, which is what tells a server that went away from a
+line that was wrong; aimed one level up it reads a cell that is there, and
+what it finds is data.
+
+The lookup is a server capability, and there the promise stops. A server
+that does not advertise it (`entityIdLookup`, `packages/memory/v2.ts`)
+answers neither yes nor no, and a handle read against one is taken as
+written — the one spelling `cd` adopts without having settled it. Every
+current server advertises the lookup; the bound is what an older one
+leaves.
+
+A move that reaches no piece waits on nothing: a facet is a closed set of
+names, and `..`, `-` and `/` each reach a place already stood at. A scope
+on its own is not among them and settles like any other move onto a piece:
+it leaves the position where it was and changes which document that
+position's id names, so the place it reaches is one nothing has read.
+
+`get` waits on nothing either, though its operand goes through the same
+readings: where an operand points is a fact about the operand, and a read
+of a cell that is not there fails on its own account and in its own words.
+That asymmetry is the same one `#argument` has — the two doors differ
+exactly where standing somewhere differs from reading it.
+
 ## The space root and facets
 
 A space root lists **facets**, never pieces directly — a populated space is
@@ -352,13 +461,67 @@ A `fuse/` facet mirroring the FUSE layout is designed and deferred past v1
 ([`futures.md`](futures.md)); shuttle leverages `packages/fuse`'s naming
 and hydration work regardless of when that facet lands.
 
-Facet names are reserved segments at the space root only; inside a piece
-no name is reserved at all, and a facet name is an ordinary data key
-there. The readings above are spellings rather than names, and are what
-they are wherever a piece's path admits them. A piece's callables need
-no reserved name: they surface inline in listings, annotated as
-callable, exactly as the FUSE layout marks a handler an executable file
-inside the piece's tree (and the `verbs` verb lists them on demand).
+Facet names are reserved wherever a walk from the root begins: as a
+segment at the space root, and as the first segment of a **rooted**
+reference, so `/slugs/todo` names what `cd /` then `cd slugs/todo`
+names. Inside a piece no name is reserved at all, and a facet name is an
+ordinary data key there. The readings above are spellings rather than
+names, and are what they are wherever a piece's path admits them. A
+piece's callables need no reserved name: they surface inline in
+listings, annotated as callable, exactly as the FUSE layout marks a
+handler an executable file inside the piece's tree (and the `verbs` verb
+lists them on demand).
+
+What the reservation buys is the property every rendering here is held
+to. The prompt writes a facet as `/slugs/` and the shell teaches
+`cd slugs` in its first minute, so the rooted spelling is the one a
+person reaches for next; read as a reference it would name a piece one
+character from the facet rendering, and read as a walk it names the facet
+the prompt printed.
+
+**What it costs is a divergence from the canonical grammar, at two slug
+values.** The rooted spelling is not shuttle's own. `/[@space/]<piece>…`
+is the canonical way to name a cell — the runner's `parseReferenceParts`,
+the same structure in patterns, in the shell and at every `cf` intake
+seam — and this CLI, which opens a session before it reads anything,
+resolves that piece segment by slug as well as by handle
+(`packages/cli/lib/llm-friendly-ref.ts`). `slugs/` and `pieces/` are the
+shuttle-only half: facets, a browsing overlay on the space root. So a
+rooted reference whose first segment is a slug is the canonical grammar
+and predates shuttle, and reserving two values in that position means
+shuttle reads `/slugs/x` and `/pieces/x` differently from the way `cf`
+reads the same strings — and identically for every other slug. Issue
+[#6992](https://github.com/commontoolsinc/labs/issues/6992) retires the
+divergence by having `set-slug` refuse those two values as slugs, after
+which no piece can carry them and the two grammars agree everywhere.
+
+The reservation reaches the rooted form and no further. A complete
+reference carries its own space and is the canonical grammar's outright,
+so `/@did:key:…/slugs/todo` still names a piece slugged `slugs` — which
+is what leaves such a piece nameable at all until #6992 lands, beside its
+handle. The root already paid the same cost: `cd slugs` at the root has
+never reached a piece by that name.
+
+The reading is matched against the operand as written, as every reading
+above is, and **an operand that would be rooted only once its leading
+whitespace came off is refused**. Such an operand has two readings that
+name different cells: as written it is a relative walk whose first segment
+is whitespace, and to the reference grammar — which trims the string it is
+given (`isReference`, `packages/cli/lib/llm-friendly-ref.ts`) — it is
+rooted. Left to fall through, the rooted reading takes it, and the facet
+names a rooted spelling reserves are not reserved in that one, so
+`cd " /slugs/todo"` would reach a piece slugged `slugs`. Reaching it is
+not what the refusal is for; reaching it *silently* is. A wrong place a
+`cd` adopts is a promise the prompt goes on making, which is the thing
+decision 11 ends, and a refusal cannot make it.
+
+The rule is exactly that wide. Leading whitespace costs a name nothing
+anywhere else — `cd " foo"` reaches the key `" foo"` — so only an operand
+that trimming would *root* is refused, and one that trimming leaves
+relative is read as it is written. A rooted operand carrying trailing
+whitespace is rooted as written and is read that way: the walk keeps its
+edges, so `cd "/slugs/todo "` is refused for a piece ending in whitespace,
+by the rule any part ending in whitespace answers to.
 
 The facet set stays deliberately small; growing it is a design decision,
 not a convenience.
@@ -469,46 +632,59 @@ no computation, stored reads labeled — is designed and deferred past v1
 
 A cell can carry per-identity overlays — `@user`, `@session` — so the same
 piece reads differently per identity (`cf inspect scopes <space>` shows that
-ground truth offline). Scope is a way of seeing every place, not a
-location, so the cwd is a **pair**: position and scope. Both stick while
-you navigate, both render in the prompt, and `pwd` prints both.
+ground truth offline). A scope applies at every place rather than nesting
+inside one, so the cwd is a **pair**: position and scope. Both stick while
+you navigate, both render in the prompt, and `pwd` prints both — and each
+decides which cell the pair names, one id under two scopes being two
+documents.
 
 `cd` is the door to both dimensions, applying whatever components its
 operand carries: `cd board@session` is a full reference and moves position
-and scope in one step, `cd topics/3` moves position alone, and `cd @session`
-moves scope alone. There is no separate scope verb; the general door is
-`where scope …`, like any other ambient dimension. The active scope fills
-the omitted `@scope` of every reference as the place fills omitted
-position levels, and an explicit suffix on an operand overrides it for
-that operand alone.
+and scope in one step, `cd topics/3` moves position alone, and
+`cd .@session` moves scope alone. There is no separate scope verb; the
+general door is `where scope …`, like any other ambient dimension. The
+active scope fills the omitted qualifier of every reference as the place
+fills omitted position levels, and an explicit one on an operand overrides
+it for that operand alone.
 
-A scope-only `@scope` is shuttle **navigation syntax**, not a reference. It
-sits with `/`, `..` and `-`: spellings that `cd` accepts to move the cwd,
-and that the canonical grammar does not parse. `parseScopedIdSegment`
-(`packages/runner/src/link-types.ts`) requires an id in front of the
-suffix and throws without one, so `@session` alone addresses nothing, and
-`parseReferenceParts` in the same module throws on a lone `/`, which names
-no piece handle, so the space root has no canonical spelling either. The
-no-growth rule holds because the scope spelling never leaves the verbs that
-move and print the cwd — `cd`, `where`, and `pwd`: an operand and a full
-reference always carry an id, no link endpoint can hold a scope-only
-suffix, and nothing serializes one. Setting the ambient scope
-is all `cd @session` does, and ordinary references pick it up from there.
+A scope on its own is written `.@scope`, which is the reference grammar's
+own relative spelling rather than a navigation word of shuttle's: `.` is
+the context's own cell, and `.` at the head of a relative reference is
+where that reference takes a member or a qualifier
+([#6814](https://github.com/commontoolsinc/labs/issues/6814)) — `./items`
+the member, `.@user` the qualifier. The head is read before the walk
+splits what follows it, so it governs the rest rather than standing as a
+segment. So `@` carries one meaning, a qualifier on the piece, and is an
+ordinary character everywhere else — `cd @session` reaches a key called
+`@session`, and `cd ./items@user` a key called `items@user`, the `@` there
+sitting on `items` rather than on the head.
 
-The canonical grammar bounds what a suffix on a reference can say
+That the bare word is data is what the reading costs and what it buys. A
+key named for a scope word was unreachable while the bare form was
+navigation, and is reachable now; in exchange a person who types
+`cd @session` meaning the scope is told so, the refusal naming `.@session`
+where the operand named no key and the word is a scope word. The offer is
+a hint on a refusal and never a reading: a place that holds the key lands
+on it and says nothing.
+
+The spelling tracks #6814, which is proposed rather than merged. Shuttle
+conforms to it now because migrating a navigation spelling later costs
+more than adopting it early.
+
+The canonical grammar bounds what a qualifier on a reference can say
 (verified against `parseScopedIdSegment` in
 `packages/runner/src/link-types.ts`):
 
-- The suffix is a `CellScope` word — `@space`, `@user`, `@session` — with
+- The qualifier is a `CellScope` word — `@space`, `@user`, `@session` — with
   no identity component; those are never spelled in a reference. `@session`
   and `@user` therefore mean the **reading identity's own** overlays,
   composed with the caller's identity at resolution.
 - `@space` is a canonical scope value, not shuttle's addition:
   `CELL_SCOPE_VALUES` holds it beside `user` and `session`, the parser's
   rejection text names all three, and `piece1@space/path` parses to
-  `scope: "space"` distinct from an omitted suffix
+  `scope: "space"` distinct from an omitted qualifier
   (`packages/cli/test/piece.test.ts`). The base is therefore nameable, and
-  `cd @space` sets the ambient scope back to it.
+  `cd .@space` sets the ambient scope back to it.
 - The serializer never emits `@space` (the base renders as a bare id), so
   the prompt and `pwd` render the scope dimension themselves rather than
   round-tripping through the reference serializer.
@@ -535,21 +711,28 @@ merely seed the initial record.
 ## Prompt
 
 The prompt shows the position with checked names only: a space by the name
-fabric knows it by, a piece by its slug when the slug index confirms it, a
-shortened unique id otherwise, then the path. Shuttle uses the naming
+fabric knows it by, a piece by its slug when the slug index confirms it,
+the whole handle otherwise, then the path. Shuttle uses the naming
 mechanisms the fabric supports and introduces none of its own; user-managed
 legible space names arrive when the fabric grows them.
 
-A shortened id is a prefix rather than an address, and it is spelled the
-way a whole handle is, so nothing in it says which it is. A prompt meant to
-be pasteable has to make that fallback visibly distinct, or leave it out.
+The space is the only thing the prompt shortens, and a handle prints whole.
+A prefix of one is spelled exactly as a whole handle is, so nothing in it
+says which it is, and what a reader copies off the screen would look like
+an address and name nothing — the same silent wrongness the reserved facet
+names above are there to end. A prefix is also only useful where it is
+unique, and knowing that is knowing every other handle in the space: an
+index read, on every line the prompt draws. The name beside a handle costs
+no such read, being the one the `cd` that adopted the place confirmed, and
+the handle costs none at all.
 
 `pwd` is the complete address and has no short form. It writes the scope
 even when it is the base, so what it prints denotes one cell wherever it is
-read, where an omitted suffix would denote whatever the reader's own scope
+read, where an omitted qualifier would denote whatever the reader's own scope
 selects — shuttle writes absolutely and reads ambiently, the asymmetry a
-shell has between `pwd` and a relative path. Emitting the suffix only for a
-non-base scope would leave the common case contextual, since a suffix-less
+shell has between `pwd` and a relative path. Emitting the qualifier only for
+a non-base scope would leave the common case contextual, since an
+unqualified
 address read in a `@session` shuttle lands at session. The prompt is the
 short surface and is on screen continuously; what `pwd` is for is the thing
 you copy, so a form that cannot be pasted is the one output it should not
@@ -662,9 +845,8 @@ spelling reaches any of them. Adding one item to a collection is therefore
 first-class to avoid.
 
 **The `@` sigil carries two meanings.** It is the space slot of a reference
-and the scope suffix on a piece: `@user` alone is the scope word,
-`/@user/<handle>` is a space *named* user, and `/@user/<handle>@session` is
-both at once — and space names are unvalidated, so the collision is live
+and the qualifier on a piece: `/@user/<handle>` is a space *named* user,
+and `/@user/<handle>@session` is both at once — and space names are unvalidated, so the collision is live
 rather than hypothetical. Shuttle cannot resolve it: decision 13 forbids
 inventing a spelling, and a second scope spelling would be worse than the
 ambiguity. Issue
@@ -673,11 +855,7 @@ v1 a space named by name is refused unless it resolves to the connected
 space, which is what keeps it dormant; multi-space sessions are where it
 wakes.
 
-**A shortened id is not an address.** The prompt falls back to one where no
-slug is confirmed, and it is spelled exactly as a whole handle is, so
-nothing in it says which it is. Whether the prompt stays pasteable, and how
-that fallback is marked if it does, is open — see the Prompt section above.
-
-The base-overlay spelling is settled above. One further open item for
-shuttle overall (shallow-sink expressibility) lives in
-[`views.md`](views.md).
+The base-overlay spelling is settled above, and so is what the prompt shows
+where no slug is confirmed: the whole handle, for the reasons the Prompt
+section carries. One further open item for shuttle overall (shallow-sink
+expressibility) lives in [`views.md`](views.md).

--- a/docs/plans/shuttle/pathref.md
+++ b/docs/plans/shuttle/pathref.md
@@ -187,9 +187,10 @@ walking and for saying where you are while you walk.
 Three couplings are worth stating so they are not discovered later:
 
 - **The renderer.** `renderPosition` is the single function in shuttle that
-  composes a reference. A route's rendering must go through the same seam
-  rather than compose its own, or the two forms drift and the migration to
-  `//<space>/` has two places to visit instead of one.
+  composes a reference, and what it writes is described in
+  [`grammar.md`](grammar.md) with the migration that reaches it. A route's
+  rendering must go through the same seam rather than compose its own, or the
+  two forms drift and that migration has two places to visit instead of one.
 - **The round trip.** The property that every name a listing prints is one `cd`
   takes back to that row must extend over routes, not just addresses. It is the
   test that would prove a route's spelling correct, and it exists already.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -118,19 +118,34 @@ shuttle board @space> get title
 
 The prompt names shuttle rather than the command, the product being what a
 prompt says it is. It is the short surface: it leaves the space out, since one
-shuttle serves one space for its whole run, and shortens nothing else. `pwd` is
-the complete address — every level, the scope written even when it is the base —
-which is what to copy.
+shuttle serves one space for its whole run, and shortens nothing else. A piece
+shows by the name the space's index confirmed for it, and by its handle where no
+name was confirmed. `pwd` is the complete address — every level, the piece by
+handle, the scope written even when it is the base — which is what to copy.
 
-| Verb            | What it does                                                                                                                                      |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `cd <ref>`      | Moves the place. Takes relative segments, `..`, `-`, `/`, a scope-only `@scope`, rooted and complete references, slugs, and `#name` entry points. |
-| `ls`            | Lists what stands where you are: a space root's facets, the slugs the index records, the space's pieces, or the keys under a cell.                |
-| `pwd`           | The complete address of the place, both dimensions.                                                                                               |
-| `get [<ref>]`   | Reads the value at a cell, defaulting to where you stand. A trailing `#argument` reads the piece's arguments cell.                                |
-| `wish <#name>`  | Resolves a named entry point, exactly as `cf wish` does.                                                                                          |
-| `where`         | The whole ambient record: the connection, and the place `pwd` prints.                                                                             |
-| `help [<verb>]` | Lists the verbs, or writes one verb's page. `<verb> --help` writes the same page.                                                                 |
+`cd` reads before it moves: a slug resolves to the piece it names, a handle is
+looked up in the space's identifier index, and a path that is not there is
+refused with the keys that are. A scope on its own is read the same way — the
+same id under two scopes is two documents, so `cd .@session` is a move onto a
+place like any other. `@` is data off that head, so `cd @session` reaches a key
+of that name, and a refusal that finds none offers `.@session`. The place holds
+the piece rather than the slug, so a slug repointed mid-session moves the name
+and never the place. `slugs` and `pieces` are reserved as the first segment of a
+rooted reference as well as at the root, so `cd /slugs/board` is the same as
+`cd /` then `cd slugs/board`. That is the one place the shell reads a reference
+differently from the rest of `cf`, which takes those two as ordinary slugs;
+[#6992](https://github.com/commontoolsinc/labs/issues/6992) retires the
+difference by refusing them as slug values.
+
+| Verb            | What it does                                                                                                                                                                                                                              |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `cd <ref>`      | Moves the place, once the fabric says it is there. Takes relative segments, `..`, `-`, `/`, `.` for where you stand, `./<ref>` for a member and `.@scope` for the scope, rooted and complete references, slugs, and `#name` entry points. |
+| `ls`            | Lists what stands where you are: a space root's facets, the slugs the index records, the space's pieces, or the keys under a cell.                                                                                                        |
+| `pwd`           | The complete address of the place, both dimensions.                                                                                                                                                                                       |
+| `get [<ref>]`   | Reads the value at a cell, defaulting to where you stand. A trailing `#argument` reads the piece's arguments cell.                                                                                                                        |
+| `wish <#name>`  | Resolves a named entry point, exactly as `cf wish` does.                                                                                                                                                                                  |
+| `where`         | The whole ambient record: the connection, and the place `pwd` prints.                                                                                                                                                                     |
+| `help [<verb>]` | Lists the verbs, or writes one verb's page. `<verb> --help` writes the same page.                                                                                                                                                         |
 
 A line is split POSIX-style — whitespace separates, quotes group — so a value
 holding a space is one operand when it is quoted, and anything shuttle prints as

--- a/packages/cli/lib/shuttle/place.ts
+++ b/packages/cli/lib/shuttle/place.ts
@@ -7,11 +7,19 @@
  * nothing read. The address grammar belongs to the fabric
  * (`normalizeLLMFriendlyRef` over the runner's `parseReferenceParts`) and this
  * module consumes it; what it adds is the navigation spellings that grammar
- * has no room for — `..`, `-`, `/`, and a scope-only `@scope` — the refusals a
+ * has no room for — `..`, `-`, `/`, `.` for the position, and the `./` and
+ * `.@` heads a relative reference takes a member or a qualifier on — the
+ * facet
+ * names a rooted operand reserves for the walk from the root, the refusals a
  * place is subject to, the operand that reaches a child, which is those same
  * readings asked in the other direction, and the one reading that differs
  * between moving somewhere and reading it: a place cannot stand in an
  * arguments cell, and an operand may still name one.
+ *
+ * Where a value stops is the moves that reach a piece. Whether the fabric
+ * holds one, and what a slug names, are reads, so those come back pending and
+ * `verbs.ts` settles them: `cd` is the one verb whose success is a promise
+ * that the place is there, so the read happens before the place is adopted.
  */
 
 import type { CellScope } from "@commonfabric/api";
@@ -23,6 +31,7 @@ import {
   linkPathSegmentToCellPathSegment,
   parseScopedIdSegment,
 } from "@commonfabric/runner/shared";
+import { isSlugAddress } from "@commonfabric/runner/slugs";
 
 import {
   type NormalizedLLMFriendlyRef,
@@ -37,9 +46,19 @@ export type PathSegment = string | number;
 
 /**
  * The facets a space root lists. A populated space is too large for a flat
- * root, so the root offers these and never pieces directly, and these names
- * are reserved at the root alone — inside a piece a facet name is an
- * ordinary data key.
+ * root, so the root offers these and never pieces directly.
+ *
+ * These names are reserved wherever a walk from the root begins: as a segment
+ * at the root, and as the first segment of a rooted reference, so that
+ * `/slugs/board` is the walk `cd /` and `cd slugs/board` make. Inside a piece
+ * no name is reserved at all and a facet name is an ordinary data key.
+ *
+ * The second half of that is a divergence from the canonical grammar and
+ * `docs/plans/shuttle/grammar.md` says so. A rooted reference is the runner's
+ * `parseReferenceParts` form rather than shuttle's, and `packages/cli` resolves
+ * its piece segment by slug, so shuttle reads `/slugs/x` and `/pieces/x`
+ * differently from the way `cf` reads them — at these two values and no
+ * others. Issue #6992 retires it by refusing them as slugs at `set-slug`.
  */
 export const FACETS = ["slugs", "pieces"] as const;
 
@@ -75,8 +94,31 @@ export interface PiecePosition {
   /** The space, which one connection fixes for a shuttle's whole run. */
   readonly space: MemorySpace;
 
-  /** The piece as the operand named it: a handle or a slug. */
+  /**
+   * The piece, by the handle a read resolved it to.
+   *
+   * A slug is a redirect, so a place holding one would follow the index to
+   * another piece without moving, and the write a later verb makes would land
+   * where the index points now. {@link CurrentPlace.confirm} is where the
+   * resolution lands, and every position shuttle stands at came through it.
+   * The exception is a position that says where an operand *points* rather
+   * than where shuttle stands ({@link CurrentPlace.aim}): nothing resolved
+   * that one, so it carries the operand's own spelling and the read it feeds
+   * resolves it the way `--cell` does.
+   */
   readonly piece: string;
+
+  /**
+   * The name the index confirmed for {@link PiecePosition.piece}, absent
+   * where the operand named the piece by handle.
+   *
+   * It is what the prompt shows and what nothing addresses: decision 13
+   * (`docs/plans/shuttle/README.md`) shows a slug an index confirms, and the
+   * handle beside it is what `pwd` prints and what every read goes to. A
+   * piece named by handle keeps no name here even where the space has a slug
+   * for it — a name is shown because a read confirmed it, and no read asked.
+   */
+  readonly name?: string;
 
   /**
    * Path inside the piece's result; empty while standing at the piece.
@@ -101,8 +143,11 @@ export type Position = SpaceRootPosition | FacetPosition | PiecePosition;
 
 /**
  * The cwd pair: the position shuttle reads from, and the scope it reads
- * through. A scope is a way of seeing every position rather than a location of
- * its own, which is why it sits beside the position instead of inside it.
+ * through. A scope applies at every position rather than nesting inside one,
+ * which is why it sits beside the position instead of among its levels — and
+ * the pair is what names a cell, each half deciding which: one id read at
+ * `@space` and at `@session` is two documents, so a move that changes either
+ * half reaches a cell of its own.
  */
 export interface Place {
   /** Where shuttle stands. */
@@ -110,6 +155,88 @@ export interface Place {
 
   /** The overlay every read goes through while this place holds. */
   readonly scope: CellScope;
+}
+
+/**
+ * A place standing on a piece, which is what a move a read has still to
+ * confirm lands on: a root and a facet are decided by the value readings
+ * alone, and only a piece and a path inside one are things the fabric may not
+ * hold.
+ */
+export interface PiecePlace {
+  /** Where shuttle would stand. */
+  readonly position: PiecePosition;
+
+  /** The overlay every read goes through while this place holds. */
+  readonly scope: CellScope;
+}
+
+/**
+ * The levels walked through to reach a place, outermost first, each the
+ * position one descent came from.
+ *
+ * `..` walks back out through it, which is what lets `cd slugs`, `cd board`,
+ * `cd ..` return to `slugs/` while the piece itself stays one position however
+ * it was reached. Three moves replace it wholesale rather than pushing: a
+ * reference and a resolved target carry no route, and `-` restores the route
+ * that came with the place it returns to.
+ */
+export type Trail = readonly Position[];
+
+/**
+ * A move that reached a piece the fabric has still to be asked about: what a
+ * slug names, whether the space holds the piece, and whether a path inside it
+ * is there. Reading that and handing this back to
+ * {@link CurrentPlace.confirm} with the {@link ResolvedPlace} it resolved to
+ * is what lands it.
+ *
+ * It carries the route as well as the place, which a landed move does not. A
+ * trail is how shuttle reached where it stands, so it stops at
+ * {@link CurrentPlace} for a move that is over; this one is a step still being
+ * taken, and dropping the route would land `cd slugs/board` with no way back
+ * to `slugs/`.
+ */
+export interface PendingMove {
+  /** Names this arm of {@link Move}. */
+  readonly kind: "pending";
+
+  /** Where the move lands, with the piece as the operand spelled it. */
+  readonly place: PiecePlace;
+
+  /** The operand that named it, which a refusal quotes. */
+  readonly operand: string;
+
+  /** The levels walked to reach it, which `confirm` lands beside the place. */
+  readonly route: Trail;
+}
+
+/**
+ * What a read resolved a {@link PendingMove} to, which
+ * {@link CurrentPlace.confirm} lands.
+ *
+ * The path is the resolution's own and not the move's, because a slug naming a
+ * collection spends leading segments reaching its member: `/tasks/first/title`
+ * resolves to the member's piece with `title` left inside it. That is the
+ * resolution every read here already makes (`resolvePieceReference`,
+ * `packages/piece/src/slugs.ts`), so a place lands on the cell a read of the
+ * same reference reaches, and `cd` and `get` cannot disagree about whether a
+ * reference names anything.
+ */
+export interface ResolvedPlace {
+  /** The piece, by the handle it resolved to. */
+  readonly piece: string;
+
+  /** The path left inside that piece once the resolution spent what it spent. */
+  readonly path: readonly PathSegment[];
+
+  /**
+   * The scope the piece was reached through, where that narrows the place's.
+   *
+   * A member held through a narrowed link is a different document from the one
+   * its id alone names, so a place keeping the ambient scope would denote a
+   * cell the read does not.
+   */
+  readonly scope?: CellScope;
 }
 
 /**
@@ -130,6 +257,9 @@ export interface SpaceNamedMove {
   /** The space name the reference carried. */
   readonly name: string;
 
+  /** The reference that named it, which a refusal quotes. */
+  readonly operand: string;
+
   /** The piece as the reference spelled it: a handle or a slug. */
   readonly piece: string;
 
@@ -146,17 +276,29 @@ type Unlanded =
   | { readonly kind: "refused"; readonly reason: string }
   /** The operand is a wish target, which the connected space resolves. */
   | { readonly kind: "wish"; readonly target: string }
-  | SpaceNamedMove;
+  | SpaceNamedMove
+  | PendingMove;
 
 /**
  * What a move did. It either lands, is refused, or names something only the
- * connection can settle: a wish target to resolve, or a space written as a
- * name.
+ * connection can settle: a wish target to resolve, a space written as a name,
+ * or a piece and a path the fabric has still to be asked about.
  */
 export type Move =
   /** The move landed, and `place` is where shuttle now stands. */
   | { readonly kind: "moved"; readonly place: Place }
   | Unlanded;
+
+/**
+ * What an operand named for a door that says where it points rather than
+ * going there: every arm of a {@link Move} but the pending one.
+ *
+ * A pending move is where the operand points already. What the read behind it
+ * settles is whether the fabric holds anything there, and that is a question
+ * about standing somewhere rather than about reading it — a read of a cell
+ * that is not there fails on its own account, and says so in its own words.
+ */
+export type Aimed = Exclude<Move, PendingMove>;
 
 /**
  * What an operand named when it was read rather than moved to: where it
@@ -173,7 +315,7 @@ export interface Aim {
   readonly input: boolean;
 
   /** Where the operand points, with any `#argument` suffix off it. */
-  readonly move: Move;
+  readonly move: Aimed;
 }
 
 /** What resolving a named entry point against the fabric produced. */
@@ -291,6 +433,11 @@ export function placeAtSpaceRoot(space: MemorySpace): Place {
  * token opening with `-` reaches a verb as an option and never as an operand
  * (`readsAsOption`, `options.ts`), so a candidate the option grammar takes is
  * not offered and the reference is what names such a child.
+ *
+ * A move a read would confirm counts as reaching the child. What that read
+ * decides is whether the fabric holds anything there, and a listing is asking
+ * about a row it has just read: the question here is which spelling names the
+ * row, not whether the row is one.
  */
 export function operandForChild(
   place: Place,
@@ -302,10 +449,8 @@ export function operandForChild(
   const from: Standing = { place, trail: [] };
   for (const candidate of [child, renderPosition(goal)]) {
     if (readsAsOption(candidate)) continue;
-    const step = movePlace(from, candidate);
-    if (step.kind === "moved" && samePlace(step.to.place, goal)) {
-      return candidate;
-    }
+    const reach = reached(movePlace(from, candidate));
+    if (reach !== undefined && samePlace(reach.place, goal)) return candidate;
   }
   return undefined;
 }
@@ -330,14 +475,14 @@ export function operandForChild(
  *
  * The scope is written on the piece even when it is the base, which is what
  * makes "read from anywhere" true rather than nearly so. Scope is part of a
- * cell's identity, and an omitted suffix is filled from wherever the reader
+ * cell's identity, and an omitted qualifier is filled from wherever the reader
  * stands, so a rendering without one denotes whatever cell the reader's own
  * scope selects. Writing it absolutely and reading it ambiently is the
  * asymmetry a shell has between what `pwd` prints and what a relative path
  * means. The reference serializer omits a base scope for the opposite
- * convention, that an omitted suffix means the base, so this writes the
- * suffix itself. The split that reads it back takes the last `@`, and this
- * writes one after the piece, so the suffix it reads is always the one this
+ * convention, that an omitted qualifier means the base, so this writes the
+ * qualifier itself. The split that reads it back takes the last `@`, and this
+ * writes one after the piece, so the qualifier it reads is always the one this
  * wrote — whatever the piece holds, and independently of any rule about
  * what a piece may hold.
  */
@@ -392,6 +537,16 @@ export class CurrentPlace {
    * Moves as `operand` says, and returns what that did. The place changes only
    * where the move lands, so a refusal and an unsettled operand both leave
    * shuttle where it was.
+   *
+   * An operand that reaches a piece comes back pending rather than landed,
+   * because whether the fabric holds that place is what no value knows. What
+   * `cd` promises is that the place it moved to is there, so the read that
+   * says so has to happen before the move is adopted and not on the next
+   * line; {@link CurrentPlace.confirm} is where it lands. A scope on its own
+   * is such an operand: it reaches a place at a scope nothing read, the same
+   * id under two scopes being two cells. What lands here is a move that
+   * reaches a container, and one that returns to a place already stood at —
+   * `..`, `-`, and `/` — nothing about either being a read's to decide.
    */
   cd(operand: string): Move {
     return this.#commit(movePlace(this.#here, operand, this.#previous));
@@ -413,15 +568,21 @@ export class CurrentPlace {
    * actually stands rather than from a standing built for the occasion. That
    * is what makes the two agree about `..`, which walks the trail shuttle
    * took and not the levels a position happens to name.
+   *
+   * There is a third way it differs and it follows from the first: nothing
+   * comes back pending. A `cd` waits on a read because standing somewhere the
+   * fabric does not hold is a promise the prompt would go on making; a read
+   * aimed at such a cell fails on its own account, in the read's own words,
+   * and there is nothing left for a check in front of it to add.
    */
   aim(operand: string): Aim {
     if (operand === ARGUMENT_SUFFIX) {
-      return { input: false, move: outcomeOf(refuse(SUFFIX_NAMES_NO_TARGET)) };
+      return { input: false, move: pointing(refuse(SUFFIX_NAMES_NO_TARGET)) };
     }
     const stripped = argumentSuffixOff(operand);
     return {
       input: stripped !== undefined,
-      move: outcomeOf(
+      move: pointing(
         movePlace(this.#here, stripped ?? operand, this.#previous),
       ),
     };
@@ -437,13 +598,19 @@ export class CurrentPlace {
   }
 
   /**
-   * Lands a {@link SpaceNamedMove}, `confirmed` being the space its name
+   * Settles a {@link SpaceNamedMove}, `confirmed` being the space its name
    * resolved to. A name that resolved to any space but the connected one is
    * refused here, so the comparison the reference deferred is made where the
    * place would be adopted rather than left to the caller. The place is built
    * from the connected space and the move's own piece, path and scope, which
-   * is what carries an `@scope` suffix through a reference that named its
-   * space by name.
+   * is what carries a qualifier through a reference that named its space by
+   * name.
+   *
+   * What comes back is a {@link PendingMove} rather than a landing: the place
+   * it names stands on a piece, which is a place a read has still to confirm
+   * like any other, so {@link CurrentPlace.confirm} is where it lands. The
+   * name being settled and the place being settled are two questions, and this
+   * answers the first.
    */
   settle(move: SpaceNamedMove, confirmed: MemorySpace): Move {
     return this.#commit(this.#settled(move, confirmed));
@@ -452,9 +619,42 @@ export class CurrentPlace {
   /**
    * Like {@link CurrentPlace.settle}, except that it moves nothing: what comes
    * back is where the settled move names, and shuttle stays where it stood.
+   *
+   * Nothing comes back pending, for {@link CurrentPlace.aim}'s reason: this is
+   * the door a read goes through, and where a read points is not a thing
+   * another read decides.
    */
-  resolveNamedSpace(move: SpaceNamedMove, confirmed: MemorySpace): Move {
-    return outcomeOf(this.#settled(move, confirmed));
+  resolveNamedSpace(move: SpaceNamedMove, confirmed: MemorySpace): Aimed {
+    return pointing(this.#settled(move, confirmed));
+  }
+
+  /**
+   * Lands a {@link PendingMove} a read confirmed, `resolved` being what the
+   * read resolved it to.
+   *
+   * The handle is what the place adopts and the operand's own spelling stays
+   * beside it as the name, where the two differ — which is what makes the
+   * prompt show a slug an index confirmed while every read goes to the piece
+   * that index pointed at, and not to whichever piece it points at next.
+   *
+   * The route is landed with the same piece, not only the place on top of it.
+   * A trail is made of positions `..` walks back through and `-` restores, so
+   * every one of them is a place shuttle can stand at, and a position holding
+   * an unresolved slug is one a later read would follow to wherever the index
+   * points then. Resolving the destination alone would put the invariant one
+   * level deep.
+   *
+   * The handle came from the fabric rather than from an operand, so it is held
+   * to the rules a piece is held to at every other door: a name no rendering
+   * would give back, and a name in neither vocabulary, are refused here as
+   * they are on the way in. It is not held to being a handle, where
+   * {@link CurrentPlace.enter} holds a target's piece to one, and the
+   * difference is what each is handed. A target's piece comes out of a parse
+   * of an address, a grammar that reads a slug as readily as a handle; this
+   * one comes out of a resolution, whose answer is a piece's own id.
+   */
+  confirm(move: PendingMove, resolved: ResolvedPlace): Move {
+    return this.#commit(confirmed(move, resolved));
   }
 
   /**
@@ -503,10 +703,14 @@ export class CurrentPlace {
 
   /**
    * Helper for {@link CurrentPlace.settle} and
-   * {@link CurrentPlace.resolveNamedSpace}, which is where `move` lands once
+   * {@link CurrentPlace.resolveNamedSpace}, which is where `move` reaches once
    * `confirmed` is known. The comparison the reference deferred is made here
    * rather than left to the caller, so a name that resolved to any space but
    * the connected one is refused whichever of the two asked.
+   *
+   * What it reaches is a piece, so the step comes back pending: `settle` hands
+   * that on for a read, and `resolveNamedSpace` reads it as where the operand
+   * points, neither of which is a landing this makes.
    */
   #settled(move: SpaceNamedMove, confirmed: MemorySpace): Step {
     const connected = this.#here.place.position.space;
@@ -526,38 +730,30 @@ export class CurrentPlace {
     }
     const outside = outsideVocabulary(move.piece);
     if (outside !== undefined) return outside;
-    return land({
-      position: {
-        kind: "piece",
-        space: connected,
-        piece: move.piece,
-        // Normalized the way every other door normalizes, so that a
-        // position names its cell the same however it was reached, which is
-        // what {@link Position} promises. A move `cd` minted carries a path
-        // the reference grammar already converted; one a caller built does
-        // not, and this is a public door.
-        path: move.path.map((segment) =>
-          typeof segment === "number"
-            ? segment
-            : linkPathSegmentToCellPathSegment(segment)
-        ),
+    return pend(
+      {
+        position: {
+          kind: "piece",
+          space: connected,
+          piece: move.piece,
+          // Normalized the way every other door normalizes, so that a
+          // position names its cell the same however it was reached, which is
+          // what {@link Position} promises. A move `cd` minted carries a path
+          // the reference grammar already converted; one a caller built does
+          // not, and this is a public door.
+          path: move.path.map((segment) =>
+            typeof segment === "number"
+              ? segment
+              : linkPathSegmentToCellPathSegment(segment)
+          ),
+        },
+        scope: move.scope,
       },
-      scope: move.scope,
-    }, []);
+      [],
+      move.operand,
+    );
   }
 }
-
-/**
- * The levels walked through to reach where shuttle stands, outermost first,
- * each the position one descent came from.
- *
- * `..` walks back out through it, which is what lets `cd slugs`, `cd board`,
- * `cd ..` return to `slugs/` while the piece itself stays one position however
- * it was reached. Three moves replace it wholesale rather than pushing: a
- * reference and a resolved target carry no route, and `-` restores the route
- * that came with the place it returns to.
- */
-type Trail = readonly Position[];
 
 /** Where shuttle stands, and the trail it walked to get there. */
 interface Standing {
@@ -568,7 +764,13 @@ interface Standing {
   readonly trail: Trail;
 }
 
-/** A move as the movers pass it around, a landing carrying its trail. */
+/**
+ * A move as the movers pass it around, a landing carrying its trail.
+ *
+ * A pending move carries one too, in the fields {@link PendingMove} declares,
+ * so a walk composes a pending step with the steps around it the way it
+ * composes a landed one.
+ */
 type Step =
   /** The move landed on `to`. */
   | { readonly kind: "moved"; readonly to: Standing }
@@ -579,9 +781,10 @@ type Step =
  * to.
  *
  * The operand is read in the order the spellings can be told apart: `-`, a
- * scope-only `@scope`, and `/` are shuttle's own navigation syntax, any other
- * string starting with `/` is a reference for the fabric's grammar to parse,
- * whichever rung of it, a leading
+ * `.` and its `./` and `.@` heads, and `/` are shuttle's own, a rooted
+ * string whose first segment names a facet is a walk from the space root, any
+ * other string starting with `/` is a reference for the fabric's grammar to
+ * parse, whichever rung of it, a leading
  * `#` is a wish target, and anything else is a relative walk from where
  * shuttle stands.
  *
@@ -605,17 +808,40 @@ function movePlace(
       ? refuse("There is no previous place to return to.")
       : land(previous.place, previous.trail);
   }
-  if (operand.startsWith("@")) return moveScope(from, operand.slice(1));
+  // `.` is the context's own cell, and the head a relative reference takes a
+  // member or a qualifier on. The head is read before the walk splits the
+  // operand, so it governs what follows it rather than standing as a segment:
+  // `./items@user` is the key `items@user` and never a walk through a key
+  // called `.`. What that costs is the bare spelling of such a key, the trade
+  // `..`, `-` and `/` already make here — `./.` and the reference a listing
+  // prints both reach it.
+  if (operand === RELATIVE_HEAD) return land(place, from.trail);
+  if (operand.startsWith(SCOPE_HEAD)) return moveScope(from, operand);
+  if (operand.startsWith(MEMBER_HEAD)) {
+    return moveBySegments(from, operand.slice(MEMBER_HEAD.length), operand);
+  }
 
   // A leading `/` roots a reference, and `/` alone roots one and names
   // nothing further: the space's own root, which the grammar has no id
   // segment to spell.
-  if (operand === "/") {
-    return land(
-      { ...place, position: { kind: "root", space: place.position.space } },
-      [],
-    );
-  }
+  const root: Standing = {
+    place: {
+      ...place,
+      position: { kind: "root", space: place.position.space },
+    },
+    trail: [],
+  };
+  if (operand === "/") return land(root.place, root.trail);
+
+  // Before the parse, because the parse would read the facet name as a piece
+  // and the walk is what the segment means. A rooted operand and a walk from
+  // the root split on the same separator here, so `/slugs/board` is what `cd
+  // /` and `cd slugs/board` are together, down to the trail it leaves.
+  const walk = rootedFacetWalk(operand);
+  if (walk !== undefined) return moveBySegments(root, walk, operand);
+
+  const edged = rootedOnlyByTrim(operand);
+  if (edged !== undefined) return edged;
 
   let reference;
   try {
@@ -630,28 +856,108 @@ function movePlace(
   }
 
   if (operand.startsWith("#")) return { kind: "wish", target: operand };
-  return moveBySegments(from, operand);
+  return moveBySegments(from, operand, operand);
 }
 
 /**
- * Where a `@scope` operand moves `from` to. `word` is the suffix without its
- * `@`, and the scopes it may name are the canonical grammar's own, so no
- * reference can carry a scope this refuses. The position does not move, so the
- * trail comes through untouched.
+ * Helper for {@link movePlace}, which is the walk a rooted operand stands for
+ * where its first segment names a facet, and nothing where it names none.
+ *
+ * The rooted form only. A complete reference carries its own space and is the
+ * canonical grammar's outright, so `/@did:key:…/slugs/board` still names a
+ * piece slugged `slugs` — which is what leaves such a piece reachable by name
+ * at all while one can exist, the rooted spelling being the walk
+ * ({@link FACETS} carries what that costs and what retires it).
+ *
+ * The operand is matched as it was written, as every reading here is, so an
+ * operand that would be rooted only once trimmed is not one this reads.
+ * {@link rootedOnlyByTrim} refuses that operand rather than letting it fall
+ * to a reading of its own.
  */
-function moveScope(from: Standing, word: string): Step {
-  if (word.includes("/")) {
-    return refuse(
-      `\`@${word}\` names no scope: a scope word holds no \`/\`. What ` +
-        `\`pwd\` prints for a space root or a facet is spelled this way and ` +
-        `names no cell — reach one by its facet or its piece.`,
-    );
-  }
-  if (!CELL_SCOPE_VALUES.has(word)) return refuseUnknownScope(word);
-  return land({ ...from.place, scope: word as CellScope }, from.trail);
+function rootedFacetWalk(operand: string): string | undefined {
+  if (!operand.startsWith("/")) return undefined;
+  const walk = operand.slice(1);
+  return isFacet(walk.split("/", 1)[0]) ? walk : undefined;
 }
 
-/** Helper for the movers, which refuses `@word` for naming no scope. */
+/**
+ * Helper for {@link movePlace}, which refuses an operand that is rooted only
+ * once its leading whitespace comes off, and returns nothing for any other.
+ *
+ * Such an operand has two readings that name different cells. Every reading
+ * here matches the operand as written, so as written this one is a relative
+ * walk whose first segment is whitespace; the reference grammar trims what it
+ * is given (`isReference`, `packages/cli/lib/llm-friendly-ref.ts`), so to that
+ * grammar it is rooted. Left to fall through, the rooted reading takes it —
+ * and the facet names a rooted spelling reserves ({@link FACETS}) are not
+ * reserved in that one, so `cd " /slugs/todo"` would reach a piece slugged
+ * `slugs`. Reaching it is not the point; reaching it *silently* is. A wrong
+ * place a `cd` adopts is a promise the prompt goes on making, which is what
+ * decision 11 ends, and a refusal cannot make it.
+ *
+ * The rule is exactly as wide as that and no wider. Leading whitespace costs a
+ * name nothing anywhere else — `cd " foo"` reaches the key `" foo"` — so only
+ * an operand that trimming would *root* is refused, and an operand trimming
+ * leaves relative is read as it is written.
+ *
+ * The trim here is a test and never a strip, which is the distinction a search
+ * for one in this module wants: no reading consumes what it produces. An
+ * operand this returns nothing for goes on to every later reading as it was
+ * written, and the trimmed spelling leaves only inside the refusal, as the
+ * thing to type instead.
+ */
+function rootedOnlyByTrim(operand: string): Step | undefined {
+  const trimmed = operand.trim();
+  if (operand.startsWith("/") || !trimmed.startsWith("/")) return undefined;
+  return refuse(
+    `\`${operand}\` is rooted only with its leading whitespace taken off, ` +
+      `and the two readings name different cells. \`${trimmed}\` is the one ` +
+      `that reaches the place it names.`,
+  );
+}
+
+/**
+ * Where a `.@scope` operand moves `from` to. `operand` is the whole of it, and
+ * the scopes it may name are the canonical grammar's own, so no reference can
+ * carry a scope this refuses. The position does not move, so the trail comes
+ * through untouched.
+ *
+ * The head is {@link SCOPE_HEAD}: `.` is the context's own cell and the
+ * qualifier hangs off it, which is the relative spelling of a qualifier the
+ * reference grammar gives
+ * ([#6814](https://github.com/commontoolsinc/labs/issues/6814)). A qualifier
+ * on a piece segment — `board@session` — is the same `@` on a different head,
+ * and is read where that segment is.
+ *
+ * It comes back pending from a piece, like any other move onto one. A scope
+ * selects which document a piece's id names, so the same id at `@space` and at
+ * `@session` are two cells and a path found in one is not a path in the other:
+ * the place a scope move reaches is one nothing has read. From a root or a
+ * facet it lands, a container being a list of names rather than a cell for an
+ * overlay to select within.
+ */
+function moveScope(from: Standing, operand: string): Step {
+  const word = operand.slice(SCOPE_HEAD.length);
+  if (!CELL_SCOPE_VALUES.has(word)) {
+    return refuse(
+      `\`${operand}\` names no scope. The scopes are \`.@space\`, ` +
+        `\`.@user\`, and \`.@session\`.`,
+    );
+  }
+  const place = { ...from.place, scope: word as CellScope };
+  const position = place.position;
+  return position.kind === "piece"
+    ? pend({ ...place, position }, from.trail, operand)
+    : land(place, from.trail);
+}
+
+/**
+ * Helper for the movers, which refuses `@word` riding a piece id for naming no
+ * scope. The spellings it offers are the piece qualifier's, which is where
+ * this fires:
+ * `board@session` qualifies the piece, and {@link SCOPE_HEAD} is the head a
+ * qualifier takes with no piece in front of it.
+ */
 function refuseUnknownScope(word: string): Step {
   return refuse(
     `\`@${word}\` names no scope. The scopes are \`@space\`, \`@user\`, ` +
@@ -664,7 +970,7 @@ function refuseUnknownScope(word: string): Step {
  *
  * A rooted reference fixes the piece and the path and takes both its space
  * and its scope from the place; a `@did:key:…` prefix supplies the space, and
- * an `@scope` suffix the scope. The parse refuses a
+ * an `@scope` qualifier the scope. The parse refuses a
  * space whose DID differs from the place's, and hands one written as a name
  * back for a session to settle, since deriving a DID from a name needs one.
  */
@@ -685,20 +991,25 @@ function moveByReference(
     return {
       kind: "space-by-name",
       name: reference.embeddedSpace,
+      operand,
       piece: reference.pieceId,
       path: reference.path,
       scope,
     };
   }
-  return land({
-    position: {
-      kind: "piece",
-      space: place.position.space,
-      piece: reference.pieceId,
-      path: reference.path,
+  return pend(
+    {
+      position: {
+        kind: "piece",
+        space: place.position.space,
+        piece: reference.pieceId,
+        path: reference.path,
+      },
+      scope,
     },
-    scope,
-  }, []);
+    [],
+    operand,
+  );
 }
 
 /**
@@ -706,19 +1017,39 @@ function moveByReference(
  * segment is read against the level the one before it landed on, so `..` and a
  * descent compose in one operand.
  *
- * The operand's own edges are the outer edges of the first and last segments,
- * the operand reaching here as it was written: `cd " a"` reaches the key
- * `" a"`, and `cd "a "` is refused, a part ending in whitespace being
- * refused wherever it sits. Between those edges a segment is taken literally —
- * the reference grammar's `~1` escaping belongs to a reference, which a
- * relative operand is not, so `~1` here is two characters of a key and a key
- * holding the separator has no relative spelling at all.
+ * `walk` is the segments to take and `operand` is what was written, which a
+ * refusal quotes. The two are one string for a relative operand and differ for
+ * a rooted one read as a walk from the root, the walk there being the operand
+ * without the separator that rooted it.
+ *
+ * The walk's own edges are the outer edges of the first and last segments, it
+ * reaching here as it was written: `cd " a"` reaches the key `" a"`, and
+ * `cd "a "` is refused, a part ending in whitespace being refused wherever it
+ * sits. Between those edges a segment is taken literally — the reference
+ * grammar's `~1` escaping belongs to a reference, which a relative operand is
+ * not, so `~1` here is two characters of a key and a key holding the separator
+ * has no relative spelling at all.
+ *
+ * The walk is one move and comes back pending once, not per segment: a
+ * descent inside the operand is a level nothing has read, so the whole walk
+ * waits on the read the last of them needs. Sticky rather than last-step,
+ * because a walk can climb back out of what it descended into and still end
+ * somewhere unread — `a/b/..` ends at `a`, which nothing looked at.
+ *
+ * Two walks land all the same. One that climbed back out of the piece has no
+ * piece left to ask about, and one that ends exactly where it started reaches
+ * a place already stood at, settled when shuttle arrived there.
  */
-function moveBySegments(from: Standing, operand: string): Step {
-  const segments = operand.split("/");
+function moveBySegments(
+  from: Standing,
+  walk: string,
+  operand: string,
+): Step {
+  const segments = walk.split("/");
   if (segments[segments.length - 1] === "") segments.pop();
 
   let moved = from;
+  let descended = false;
   for (const segment of segments) {
     // No fault check here: which rule a segment answers to depends on what it
     // is about to become, and only `moveDown` knows that. A segment naming a
@@ -727,10 +1058,16 @@ function moveBySegments(from: Standing, operand: string): Step {
     const step = segment === ".."
       ? moveUp(moved)
       : moveDown(moved, segment, operand);
-    if (step.kind !== "moved") return step;
-    moved = step.to;
+    const reach = reached(step);
+    if (reach === undefined) return step;
+    moved = reach;
+    descended ||= step.kind === "pending";
   }
-  return land(moved.place, moved.trail);
+  const position = moved.place.position;
+  return descended && position.kind === "piece" &&
+      !samePlace(moved.place, from.place)
+    ? pend({ ...moved.place, position }, moved.trail, operand)
+    : land(moved.place, moved.trail);
 }
 
 /**
@@ -760,6 +1097,10 @@ function enclosing(position: Position): Position {
  * Where one relative segment moves `from` to: a facet at a space root, a piece
  * inside a facet, and a data key or index inside a piece. A descent pushes the
  * level it left onto the trail, which is what `..` walks back out.
+ *
+ * A facet is a closed set and lands; the other two reach the fabric and come
+ * back pending, a piece having still to resolve and a key having still to be
+ * found.
  */
 function moveDown(from: Standing, segment: string, operand: string): Step {
   const place = from.place;
@@ -774,28 +1115,33 @@ function moveDown(from: Standing, segment: string, operand: string): Step {
         }, trail)
         : refuse(
           `A space root lists facets, and \`${segment}\` names none. The ` +
-            `facets are \`slugs/\` and \`pieces/\`.`,
+            `facets are \`slugs/\` and \`pieces/\`.` +
+            scopeMoveHint(operand),
         );
     case "facet":
       return moveIntoPiece(place, position, segment, trail, operand);
     case "piece": {
       const fault = unnameableSegment(segment);
       if (fault !== undefined) return refuseUnnameable(operand, fault);
-      return land({
-        ...place,
-        position: {
-          ...position,
-          path: [...position.path, linkPathSegmentToCellPathSegment(segment)],
+      return pend(
+        {
+          ...place,
+          position: {
+            ...position,
+            path: [...position.path, linkPathSegmentToCellPathSegment(segment)],
+          },
         },
-      }, trail);
+        trail,
+        operand,
+      );
     }
   }
 }
 
 /**
  * Where a segment naming a piece inside `facet` moves `place` to. The segment
- * is the one a scope suffix may ride, since that is where the canonical
- * grammar carries it, and a suffix here moves the scope half of the place.
+ * is the one a scope qualifier may ride, since that is where the canonical
+ * grammar carries it, and a qualifier here moves the scope half of the place.
  *
  * A `#` is refused rather than taken as part of the id, for one of two
  * reasons. `#argument` is refused for the reason it is refused on a
@@ -823,15 +1169,15 @@ function moveIntoPiece(
   }
   if (segment.startsWith("@")) {
     return refuse(
-      `\`${segment}\` names no piece. A scope suffix rides a piece id, and ` +
-        `a scope on its own is a whole operand rather than a segment.`,
+      `\`${segment}\` names no piece. A qualifier rides a piece id, and a ` +
+        `facet holds pieces rather than keys.` + scopeMoveHint(operand),
     );
   }
   let scoped;
   try {
     scoped = parseScopedIdSegment(segment);
   } catch {
-    // The one throw left: the suffix names no scope, `@` with no piece in
+    // The one throw left: the qualifier names no scope, `@` with no piece in
     // front of it having been refused above.
     return refuseUnknownScope(segment.slice(segment.lastIndexOf("@") + 1));
   }
@@ -839,15 +1185,19 @@ function moveIntoPiece(
   if (fault !== undefined) return refuseUnnameable(operand, fault);
   const outside = outsideVocabulary(scoped.id);
   if (outside !== undefined) return outside;
-  return land({
-    position: {
-      kind: "piece",
-      space: facet.space,
-      piece: scoped.id,
-      path: [],
+  return pend(
+    {
+      position: {
+        kind: "piece",
+        space: facet.space,
+        piece: scoped.id,
+        path: [],
+      },
+      scope: scoped.scope ?? place.scope,
     },
-    scope: scoped.scope ?? place.scope,
-  }, trail);
+    trail,
+    operand,
+  );
 }
 
 /**
@@ -859,6 +1209,13 @@ function moveIntoPiece(
  * The path is normalized the way a reference's and a relative walk's are, so
  * that a position names its cell the same however it was reached, which is
  * what {@link Position} promises.
+ *
+ * It lands rather than coming back for a read, alone among the doors that
+ * reach a piece: the fabric resolved this target, so the piece and the path
+ * are what a read would have gone and asked it. A piece named by slug is
+ * refused for the same reason — a place holds the handle a name resolved to,
+ * and an address the fabric wrote carries one — which is what keeps that
+ * true of a position reached this way as well as of one `confirm` landed.
  */
 function enterTarget(
   place: Place,
@@ -886,6 +1243,13 @@ function enterTarget(
   }
   const outside = outsideVocabulary(target.piece);
   if (outside !== undefined) return outside;
+  if (isSlugAddress(target.piece)) {
+    return refuse(
+      `\`${operand}\` resolves to slug \`${target.piece}\`, and a place holds ` +
+        `the handle a name resolved to. An address the fabric wrote names ` +
+        `its piece by handle.`,
+    );
+  }
   return land({
     ...place,
     position: {
@@ -951,6 +1315,10 @@ function samePlace(one: Place, other: Place): boolean {
  * space for a shuttle's whole run and every door refuses a position outside
  * it, so the pair this is handed carries one space and a comparison of it
  * could only ever hold.
+ *
+ * The name is not among them either, and for the opposite reason: it is not a
+ * level. A piece reached by slug and the same piece reached by handle are one
+ * cell, which is exactly what resolving the piece before adopting it is for.
  */
 function samePosition(one: Position, other: Position): boolean {
   switch (one.kind) {
@@ -963,6 +1331,40 @@ function samePosition(one: Position, other: Position): boolean {
         one.path.length === other.path.length &&
         one.path.every((segment, index) => segment === other.path[index]);
   }
+}
+
+/**
+ * The head of a relative reference: `.` is the context's own cell, and `.` at
+ * the head is where the reference takes a member or a qualifier
+ * ([#6814](https://github.com/commontoolsinc/labs/issues/6814)).
+ *
+ * It is a head and not a whole operand, so `./items` reaches the member and
+ * `./items@user` the key `items@user` — the `@` there sits on `items` rather
+ * than on the head, and `@` is a qualifier only on the head. That is the whole
+ * of what makes `@` one meaning: everywhere else it is an ordinary character,
+ * so `cd @session` reaches a key called `@session`.
+ */
+const RELATIVE_HEAD = ".";
+
+/** {@link RELATIVE_HEAD} with the member separator after it. */
+const MEMBER_HEAD = `${RELATIVE_HEAD}/`;
+
+/** {@link RELATIVE_HEAD} with a qualifier after it, which moves the scope. */
+const SCOPE_HEAD = `${RELATIVE_HEAD}@`;
+
+/**
+ * The sentence a refusal adds where `operand` is a scope word written with no
+ * head, and nothing for every other operand.
+ *
+ * It is a hint on a refusal rather than a reading of its own, and the
+ * difference is the point: `@session` is an ordinary key name, so a place that
+ * holds one reaches it and never sees this. What the hint answers is the
+ * operand that named no key *and* looks like an attempt at the scope.
+ */
+export function scopeMoveHint(operand: string): string {
+  return operand.startsWith("@") && CELL_SCOPE_VALUES.has(operand.slice(1))
+    ? ` \`${SCOPE_HEAD}${operand.slice(1)}\` is what moves the scope.`
+    : "";
 }
 
 /**
@@ -1270,12 +1672,119 @@ function land(place: Place, trail: Trail): Step {
 }
 
 /**
+ * Helper for the movers, which builds a step that reached `place` and waits on
+ * the read that says the fabric holds it, `operand` being what named it.
+ */
+function pend(place: PiecePlace, trail: Trail, operand: string): Step {
+  return { kind: "pending", place, operand, route: trail };
+}
+
+/**
+ * Helper for the movers, which is where `step` reached, and nothing where it
+ * reached nowhere. A step that landed and one waiting on a read have both
+ * reached somewhere; what divides them is whether anything may yet turn them
+ * down.
+ */
+function reached(step: Step): Standing | undefined {
+  switch (step.kind) {
+    case "moved":
+      return step.to;
+    case "pending":
+      return { place: step.place, trail: step.route };
+    default:
+      return undefined;
+  }
+}
+
+/**
  * Helper for the movers, which is what a caller sees of `step`. The trail is
  * navigation history rather than part of a place, so it stops here whether or
  * not the step was adopted.
  */
 function outcomeOf(step: Step): Move {
   return step.kind === "moved" ? { kind: "moved", place: step.to.place } : step;
+}
+
+/**
+ * Helper for the doors that say where an operand points rather than going
+ * there, which is what a caller of one sees of `step`.
+ *
+ * It is {@link outcomeOf} with the one difference those doors have: a step
+ * waiting on a read has already said where the operand points, so it comes
+ * back as the answer it is rather than as a question for the caller to
+ * settle.
+ */
+function pointing(step: Step): Aimed {
+  if (step.kind === "pending") return { kind: "moved", place: step.place };
+  return step.kind === "moved" ? { kind: "moved", place: step.to.place } : step;
+}
+
+/**
+ * Helper for {@link CurrentPlace.confirm}, which is where `move` lands once
+ * `piece` is known: the handle in the position, and the operand's own
+ * spelling beside it as the name where the two differ.
+ *
+ * The two differ exactly when the operand named the piece by slug, a handle
+ * resolving to itself. So the name is a name a read confirmed and never one
+ * this made up, and there is no vocabulary test here for a rule the
+ * resolution already answered.
+ */
+function confirmed(move: PendingMove, resolved: ResolvedPlace): Step {
+  const fault = unnameablePiece(resolved.piece) ??
+    firstUnnameableSegment(resolved.path);
+  if (fault !== undefined) {
+    return refuse(
+      `\`${move.operand}\` resolves to ${fault.what}, so ${fault.so}.`,
+    );
+  }
+  const outside = outsideVocabulary(resolved.piece);
+  if (outside !== undefined) return outside;
+  const spelled = move.place.position.piece;
+  // A resolution that spent path segments walked through something else to
+  // find the piece — a slug naming a collection reaching its member — so the
+  // operand's own name is not this piece's name, and the levels the walk
+  // recorded are the way into the collection rather than into what it held.
+  // A move that carries no route already behaves this way, and a reference is
+  // where such a resolution mostly arrives.
+  // How many leading segments the resolution spent reaching the piece. A slug
+  // naming a collection spends the ones that select its member; every other
+  // resolution spends none, and then the arithmetic below is the identity.
+  const spent = move.place.position.path.length - resolved.path.length;
+  const named = spelled === resolved.piece || spent > 0
+    ? {}
+    : { name: spelled };
+  const landed = (position: PiecePosition): PiecePosition => ({
+    ...position,
+    ...named,
+    piece: resolved.piece,
+  });
+  return land(
+    {
+      position: landed({
+        ...move.place.position,
+        path: resolved.path.map((segment) =>
+          typeof segment === "number"
+            ? segment
+            : linkPathSegmentToCellPathSegment(segment)
+        ),
+      }),
+      scope: resolved.scope ?? move.place.scope,
+    },
+    // A route entry the resolution walked *through* is a level of the
+    // collection rather than of what it held, and goes; one at or below the
+    // member is a level of the member, and lands with the member's own piece
+    // and the spent segments off its path. The levels above the piece — the
+    // root, the facet — are how shuttle reached the collection at all, and
+    // are nobody's to drop.
+    move.route.flatMap((position) => {
+      if (position.kind !== "piece" || position.piece !== spelled) {
+        return [position];
+      }
+      return position.path.length < spent
+        ? []
+        : [landed({ ...position, path: position.path.slice(spent) })];
+    }),
+  );
 }
 
 /**
@@ -1333,6 +1842,12 @@ function renderPosition(place: Place): string {
  * Helper for {@link CurrentPlace.label}, which writes the position half of the
  * short form: everything the position holds except the space.
  *
+ * A piece is written by the name the index confirmed for it, and by its handle
+ * where no name was confirmed. That is decision 13
+ * (`docs/plans/shuttle/README.md`) read as a rendering: a name is shown
+ * because a read said the space knows the piece by it, and the alternative is
+ * the id itself rather than a guess.
+ *
  * The separator is escaped in every segment, as it is in the rendering `pwd`
  * prints, so a key holding one is one segment here too. What differs is the
  * leading separator: it marks a cell in a place's rendering and marks nothing
@@ -1347,7 +1862,7 @@ function labelPosition(position: Position): string {
       return encodeJsonPointer(["", position.facet, ""]);
     case "piece":
       return encodeJsonPointer([
-        position.piece,
+        position.name ?? position.piece,
         ...position.path.map(String),
       ]);
   }

--- a/packages/cli/lib/shuttle/prompt.ts
+++ b/packages/cli/lib/shuttle/prompt.ts
@@ -167,7 +167,7 @@ const BINDINGS: ReadonlyMap<string, (buffer: EditBuffer) => void> = new Map([
  *
  * So the prompt is not an address, and `pwd` is what to copy. The two halves
  * are separated by a space rather than joined, which is what keeps each of
- * them a word of its own: the scope suffix sits last on every form here,
+ * them a word of its own: the scope qualifier sits last on every form here,
  * where a reference carries it on the piece, because a prompt wants it in the
  * same column on every line and a reference wants it where its grammar puts
  * it.

--- a/packages/cli/lib/shuttle/verbs.ts
+++ b/packages/cli/lib/shuttle/verbs.ts
@@ -13,17 +13,32 @@
  * connection through `deps.loadPieces`, which is the seam a held connection
  * fills.
  *
- * Two spellings come back off a `cd` or a `get` unsettled, because settling
- * them is a read: a `#name` target, which the fabric resolves to an address,
- * and a space written as a name, which the connection is asked about. Settling
- * each and asking the place again is what this module adds to `place.ts`,
- * which decides everything about a place that a value can decide and stops
- * exactly there.
+ * Three spellings come back off a `cd` unsettled, because settling each is a
+ * read: a `#name` target, which the fabric resolves to an address; a space
+ * written as a name, which the connection is asked about; and a place standing
+ * on a piece, which the fabric is asked to resolve and to find. Settling each
+ * and asking the place again is what this module adds to `place.ts`, which
+ * decides everything about a place that a value can decide and stops exactly
+ * there.
+ *
+ * The last of those is what makes `cd` worth its name. A shell's `cd` is the
+ * one verb whose success says something, so the slug, the handle and the path
+ * are each asked about before the place moves, and each refused in shuttle's
+ * own words rather than left for the next verb to report in the runtime's.
+ * What the prompt promises after it is exactly those three answers; the one
+ * that can come back unanswered is the handle lookup, against a server that
+ * does not advertise it. `get` waits on nothing: where an operand points is the
+ * operand's own fact, and a read of a cell that is not there says so.
  */
 
 import { isDID } from "@commonfabric/identity";
 import type { MemorySpace } from "@commonfabric/memory/interface";
+import {
+  resolvePieceReference,
+  SlugResolutionError,
+} from "@commonfabric/piece";
 
+import { keysOf } from "../cell-listing.ts";
 import {
   LINK_MARKER_KEY,
   parseCellSelectionOptions,
@@ -37,12 +52,19 @@ import { splitLine } from "./line.ts";
 import { type ListingDeps, listPlace, renderListing } from "./listing.ts";
 import { readOptions } from "./options.ts";
 import {
+  type Aimed,
   CurrentPlace,
   type FacetPosition,
   messageOf,
   type Move,
+  type PathSegment,
+  type PendingMove,
+  type PiecePlace,
+  type PiecePosition,
   type Place,
+  type ResolvedPlace,
   type ResolvedTarget,
+  scopeMoveHint,
   type SpaceRootPosition,
 } from "./place.ts";
 import { renderRecord } from "./record.ts";
@@ -94,6 +116,13 @@ export interface VerbDeps {
   /** Resolves a named entry point, for `wish` and for `cd` into one. */
   readonly readWish?: typeof readWish;
 
+  /**
+   * Resolves the piece and path an operand named, which is what `cd` settles.
+   * It is the resolution a read makes too (`pieceReferenceResolver`,
+   * `lib/piece.ts`), so the two verbs reach the same cell for one reference.
+   */
+  readonly resolvePieceReference?: typeof resolvePieceReference;
+
   /** The reads `ls` composes. */
   readonly listing?: ListingDeps;
 }
@@ -115,10 +144,11 @@ export interface VerbDeps {
  * here and no verb states one of its own.
  *
  * A refusal is a fact about the line — a verb nobody defined, an option nobody
- * declared, an operand a place will not take, a target that resolves elsewhere
- * — and every one carries the reason. A read that failed is a different fact
- * and is not one of these: it raises, so that a server that cannot be reached
- * is told apart from a line that was wrong.
+ * declared, an operand a place will not take, a target that resolves
+ * elsewhere, a place the fabric does not hold — and every one carries the
+ * reason. A read that failed is a different fact and is not one of these: it
+ * raises, so that a server that cannot be reached is told apart from a line
+ * that was wrong.
  *
  * @throws Whatever a read throws — an unreachable server, an identity that
  * will not load, a path the piece refuses.
@@ -195,10 +225,12 @@ interface VerbEntry extends VerbHelp {
 /**
  * Moves the place as `operands` say, and returns where shuttle now stands.
  *
- * The operand is `place.ts`'s to read, and the two spellings it hands back
- * unsettled are settled here: a `#name` target resolves against the fabric,
- * and a space written as a name is held against the name the connection was
- * opened under.
+ * The operand is `place.ts`'s to read, and the spellings it hands back
+ * unsettled are settled here: a `#name` target resolves against the fabric, a
+ * space written as a name is held against the name the connection was opened
+ * under, and a place standing on a piece is asked of the fabric before it is
+ * adopted — the slug resolved to the handle the place then holds, and the path
+ * found or refused with the keys that are there.
  */
 async function cd(
   shuttle: Shuttle,
@@ -357,11 +389,18 @@ const VERBS: ReadonlyMap<string, VerbEntry> = new Map<string, VerbEntry>([
     summary: "Moves the place, which fills in what a reference omits.",
     detail:
       "The operand is a relative segment, `..` for one level up, `-` for " +
-      "the\nprevious place, `/` for the space root, a scope-only `@scope`, " +
+      "the\nprevious place, `/` for the space root, `.` for where you " +
+      "stand, `./<ref>`\nfor a member and `.@scope` for the scope, " +
       "a rooted\nor complete reference, a slug, or a `#name` entry " +
-      "point.\n\nA target carrying `#argument` is refused: a place roots at " +
-      "a result, and\n`get <ref>#argument` is how an operand reads a " +
-      "piece's arguments cell.",
+      "point.\n\nA move onto a piece is read before it is taken: the slug " +
+      "resolved, the\nhandle looked up in the space's index, and the path " +
+      "found. A slug that\nnames nothing, a handle the index says the space " +
+      "does not hold, and a path\nthat is not there are each refused here " +
+      "rather than one command later, the\npath with the keys that are. A " +
+      "server that does not answer the handle\nlookup leaves that one " +
+      "unsettled.\n\nA target carrying `#argument` is refused: a place " +
+      "roots at a result, and\n`get <ref>#argument` is how an operand reads " +
+      "a piece's arguments cell.",
   }],
   ["get", {
     run: get,
@@ -433,10 +472,13 @@ const VERBS: ReadonlyMap<string, VerbEntry> = new Map<string, VerbEntry>([
 /**
  * Helper for {@link cd}, which finishes `move`.
  *
- * A landing and a refusal are the answer already. The two arms only a read can
- * settle are settled and the place asked again, which answers: a resolved
- * target and a confirmed space each land or refuse, so neither second ask
- * comes back with another arm to settle.
+ * A landing and a refusal are the answer already. The arms only a read can
+ * settle are settled and the place asked again, which answers or hands back
+ * the one arm a settled one can still reach: a resolved target lands or
+ * refuses, and a settled space name is a place standing on a piece, which is
+ * settled the way any other is. A confirmed piece lands or refuses, so this
+ * calls itself twice at most, and a space named by name is the operand that
+ * takes both.
  */
 async function landing(
   shuttle: Shuttle,
@@ -464,6 +506,14 @@ async function landing(
         deps,
       );
     }
+    case "pending": {
+      const settled = await settlePiece(shuttle, move, deps);
+      return settled.kind === "refused" ? settled : await landing(
+        shuttle,
+        shuttle.place.confirm(move, settled.place),
+        deps,
+      );
+    }
   }
 }
 
@@ -481,6 +531,329 @@ type Targeting =
   /** The target resolved to the address `target` names. */
   | { readonly kind: "target"; readonly target: ResolvedTarget }
   | Refusal;
+
+/** What settling a place against the fabric produced. */
+type Settling =
+  /** The fabric holds the place, as `place` resolved it. */
+  | { readonly kind: "settled"; readonly place: ResolvedPlace }
+  | Refusal;
+
+/** What the piece and path a pending move spelled turned out to be. */
+type Resolved =
+  | {
+    /** Names this arm of {@link Resolved}. */
+    readonly kind: "piece";
+
+    /** Where the move lands, as the resolution answered it. */
+    readonly place: ResolvedPlace;
+
+    /**
+     * Whether reaching it proved the space holds it. A slug reached its piece
+     * through the index and a place already stood on one was settled before,
+     * so both are held; a handle is a spelling and proves nothing on its own.
+     */
+    readonly held: boolean;
+  }
+  | Refusal;
+
+/**
+ * Helper for {@link landing}, which asks the fabric whether it holds the place
+ * `move` reached, and is the handle its piece resolved to where it does.
+ *
+ * Two questions, and each is asked only where there is one. The piece is
+ * {@link resolvedPiece}'s. Then the path: one read of the cell at the deepest
+ * level already stood at, walked segment by segment through the value it
+ * returned, which names the first segment that is not there and the keys that
+ * are — and no read at all where the move added no segment to a level already
+ * confirmed, there being nothing left to look for.
+ *
+ * The read is the level above, never the destination, and that is what makes
+ * every miss a refusal rather than a throw. A read aimed at a path the fabric
+ * does not hold raises — that is what `get` reports and what tells a server
+ * that went away from a line that was wrong — so a check aimed there would
+ * report a wrong operand as a failed read. Aimed one level up it reads a cell
+ * that is there, and what it finds is data rather than an error.
+ *
+ * A piece the resolution reached without proving — a handle, which is a
+ * spelling and not a lookup — is looked up. `entityIdExists`
+ * (`PiecesController`) tests one identifier against the space's own index
+ * without selecting a stored value, which is what makes it affordable here,
+ * and it is the same call `packages/fuse` asks before it projects an entity a
+ * path named. A value read cannot stand in for it: a piece the space does not
+ * hold reads as `undefined`, which is what an empty one reads as too.
+ *
+ * The lookup is a server capability and answers `undefined` where the server
+ * does not advertise it (`entityIdLookup`, `packages/memory/v2.ts`). Then
+ * nothing was learned and the move goes on, which is the one case left where
+ * a handle the space does not hold is adopted — the bound `grammar.md`
+ * records.
+ *
+ * @throws Whatever the read throws — an unreachable server, an identity that
+ * will not load. A slug that names nothing is not one of those: it is a fact
+ * about the line, so it comes back as a refusal.
+ */
+async function settlePiece(
+  shuttle: Shuttle,
+  move: PendingMove,
+  deps: VerbDeps,
+): Promise<Settling> {
+  const resolved = await resolvedPiece(shuttle, move, deps);
+  if (resolved.kind === "refused") return resolved;
+  const place = resolved.place;
+  const settled: Settling = { kind: "settled", place };
+  if (!resolved.held) {
+    const pieces = await shuttle.connection.pieces();
+    if (await pieces.entityIdExists(place.piece) === false) {
+      return refuse(
+        `\`${move.operand}\` reaches no piece: this space holds none by the ` +
+          `handle \`${place.piece}\`.`,
+      );
+    }
+  }
+  const path = place.path;
+  const scope = place.scope ?? move.place.scope;
+  const from = alreadyStoodAt(shuttle.place.place, {
+    position: { ...move.place.position, piece: place.piece, path },
+    scope,
+  });
+  if (from.length === path.length) return settled;
+  let level = await (deps.getCellValue ?? getCellValue)(
+    { ...shuttle.config, piece: place.piece, pieceScope: scope },
+    [...from],
+    {},
+    { loadPieces: () => shuttle.connection.pieces() },
+  );
+  for (const segment of path.slice(from.length).map(String)) {
+    const keys = keysOf(level);
+    if (!keys.includes(segment)) {
+      return refuse(noSuchKey(move.operand, segment, keys));
+    }
+    level = (level as Record<string, unknown>)[segment];
+  }
+  return settled;
+}
+
+/**
+ * Helper for {@link settlePiece}, which is the piece `move` reached.
+ *
+ * A move that reaches the cell shuttle already stands at has no piece to
+ * resolve, and none to look up either: that piece came through a settle of its
+ * own. What counts as the same cell is {@link sameCell}'s, so the scope bears
+ * on it as much as the id — a move to the same id under another scope is a
+ * document nothing has asked about, and it resolves and looks up like any
+ * other. A move spelling that same cell again, a key under it or a reference
+ * naming it, moves the path and leaves the piece where it was.
+ *
+ * What the skip saves is a question rather than a round trip, and the
+ * difference is worth stating because the cost argument for settling at all
+ * was a read per `cd`. `resolvePieceReference` reads nothing for a handle: a
+ * slug is a token with no colon in it, so the resolution hands a handle
+ * straight back without reaching the runtime (`packages/piece/src/slugs.ts`).
+ * The saving is that the seam is not reached where it has nothing to do —
+ * which is a fact a caller standing its own resolution in can see, and one
+ * this module should not make such a caller work around.
+ *
+ * Every other move resolves: a slug is a name the space's index holds, and
+ * `resolvePieceReference` is what turns one into the piece it points at, given
+ * the path so a slug naming a collection reaches its member — the resolution
+ * every read here already makes per command, made once at the move instead, so
+ * that what the place adopts is a piece the index cannot repoint underneath
+ * it.
+ */
+async function resolvedPiece(
+  shuttle: Shuttle,
+  move: PendingMove,
+  deps: VerbDeps,
+): Promise<Resolved> {
+  const spelled = move.place.position.piece;
+  const path = move.place.position.path;
+  const standing = shuttle.place.place;
+  if (
+    standing.position.kind === "piece" &&
+    sameCell({ position: standing.position, scope: standing.scope }, move.place)
+  ) {
+    return { kind: "piece", place: { piece: spelled, path }, held: true };
+  }
+  let reference;
+  try {
+    reference = await (deps.resolvePieceReference ?? resolvePieceReference)(
+      await shuttle.connection.pieces(),
+      spelled,
+      path,
+    );
+  } catch (thrown) {
+    if (!(thrown instanceof SlugResolutionError)) throw thrown;
+    return refuse(
+      `\`${move.operand}\` reaches no piece: ${messageOf(thrown)}`,
+    );
+  }
+  return {
+    kind: "piece",
+    place: {
+      piece: reference.piece,
+      path: reference.pathAfter,
+      ...(reference.scope === undefined ? {} : { scope: reference.scope }),
+    },
+    // The two differ exactly where a slug resolved, a handle being handed back
+    // as it stands — so what the resolution reached is also what it proved.
+    held: reference.piece !== spelled,
+  };
+}
+
+/**
+ * How one field of a place bears on whether a read has already confirmed it.
+ *
+ * Three roles rather than two, because the settle asks two questions of one
+ * key and they divide the fields differently: whether the destination is the
+ * *same cell* shuttle stands at, which decides that its piece needs no lookup,
+ * and how much of its *path* is already read, which decides where the read
+ * starts. A field is classified once and both questions pick it up.
+ */
+type Bearing =
+  /** Equal, or the two are different cells. */
+  | "same"
+  /** The standing one must be a prefix of the destination's. */
+  | "prefix"
+  /** Neither: two places differing only here are one place. */
+  | "neither";
+
+/**
+ * Which parts of a place decide that a read has already confirmed it.
+ *
+ * Every field of a piece position is classified here and the `satisfies` is
+ * what makes that exhaustive: a field added to {@link PiecePosition} without a
+ * line here does not compile. A key naming fewer fields than the decision
+ * rests on calls two different places one, and the skip it drives then hands
+ * back a place nothing read — which is the failure this whole settle exists to
+ * end. Classifying one `false` is a decision a reviewer sees rather than an
+ * absence nobody notices.
+ *
+ * - `kind` — a container is no place a piece's path descends from.
+ * - `space` — one connection fixes it for a run, and every door refuses a
+ *   position outside it, so a comparison could only ever hold.
+ * - `piece` — which piece the path is inside. Two ids are two documents.
+ * - `name` — not a level. A piece reached by slug and the same piece reached
+ *   by handle are one cell, which is what resolving before adopting is for.
+ * - `path` — how far in. This is the one field the comparison reads as a
+ *   prefix rather than for equality, the destination being truncated to the
+ *   standing depth before the two keys are built.
+ */
+const CONFIRMED_BY_POSITION = {
+  kind: "same",
+  space: "neither",
+  piece: "same",
+  name: "neither",
+  path: "prefix",
+} satisfies Record<keyof Required<PiecePosition>, Bearing>;
+
+/**
+ * The same classification for the place around the position, closed the same
+ * way against {@link Place}.
+ *
+ * - `position` — expanded by {@link CONFIRMED_BY_POSITION}.
+ * - `scope` — which document the piece's id names. One id at `@space` and the
+ *   same id at `@session` are two, so a place confirmed at one is not
+ *   confirmed at the other and the read has to happen again.
+ */
+const CONFIRMED_BY_PLACE = {
+  position: "byField",
+  scope: "same",
+} satisfies Record<keyof Place, Bearing | "byField">;
+
+/**
+ * Helper for {@link settlePiece}, which is the deepest path a read may start
+ * from: where shuttle stands, where `reached` extends it, and the piece's own
+ * root otherwise.
+ *
+ * Where shuttle stands is a place a read already confirmed — every position
+ * came through one — so the levels it names need no second read, and a `cd`
+ * one key deeper reads that key's own level rather than the whole piece. A
+ * move to another piece, to another scope, or one that went up before it came
+ * down has nothing confirmed under it and starts at the root, which is where a
+ * rooted reference has to start anyway.
+ *
+ * The prefix is tested by truncating the destination to the standing depth and
+ * comparing the two keys, so every part of the decision is one the projections
+ * classify and none of it is a comparison written out beside them.
+ */
+function alreadyStoodAt(
+  standing: Place,
+  reached: PiecePlace,
+): readonly PathSegment[] {
+  const from = standing.position;
+  if (from.kind !== "piece") return [];
+  const stood: PiecePlace = { position: from, scope: standing.scope };
+  if (!sameCell(stood, reached)) return [];
+  // The `prefix` fields. A standing longer than the destination's meets an
+  // `undefined` where a segment would be, and no segment is one.
+  const prefix = (Object.keys(CONFIRMED_BY_POSITION) as PositionField[])
+    .filter((field) => CONFIRMED_BY_POSITION[field] === "prefix")
+    .every((field) => {
+      const one = from[field] as readonly PathSegment[];
+      const other = reached.position[field] as readonly PathSegment[];
+      return one.length <= other.length &&
+        one.every((segment, index) => segment === other[index]);
+    });
+  return prefix ? from.path : [];
+}
+
+/**
+ * Helper for {@link settlePiece} and {@link alreadyStoodAt}, which is whether
+ * two places are the same cell by the fields the projections mark `same`.
+ *
+ * It is the question the piece's own lookup rests on. A destination that is
+ * the cell shuttle already stands at was settled when shuttle arrived, so its
+ * piece needs no second lookup; one that differs anywhere the projections call
+ * decisive — the piece, the scope — is a document nothing has asked about.
+ */
+function sameCell(standing: PiecePlace, reached: PiecePlace): boolean {
+  return confirmedKey(standing) === confirmedKey(reached);
+}
+
+/** The fields {@link CONFIRMED_BY_POSITION} classifies. */
+type PositionField = keyof Required<PiecePosition>;
+
+/**
+ * Helper for {@link sameCell}, which is `place` reduced to the parts the
+ * projections mark `same`, in a fixed order.
+ */
+function confirmedKey(place: PiecePlace): string {
+  const parts: unknown[] = [];
+  if (CONFIRMED_BY_PLACE.position === "byField") {
+    const position = place.position;
+    parts.push(
+      (Object.keys(CONFIRMED_BY_POSITION) as PositionField[])
+        .sort()
+        .filter((field) => CONFIRMED_BY_POSITION[field] === "same")
+        .map((field) => [field, position[field]]),
+    );
+  }
+  if (CONFIRMED_BY_PLACE.scope === "same") parts.push(place.scope);
+  return JSON.stringify(parts);
+}
+
+/**
+ * Helper for {@link settlePiece}, which is the reason `segment` reaches no
+ * cell, `keys` being what the level above it holds.
+ *
+ * Shuttle's own sentence rather than the runtime's, which the read one level
+ * further down would have raised. What it says is what the runtime's says —
+ * the key is not there, and here is what is — in the words the rest of the
+ * shell refuses a line in, and as a refusal rather than as a failure, because
+ * a place that is not there is a fact about the operand.
+ */
+function noSuchKey(
+  operand: string,
+  segment: string,
+  keys: readonly string[],
+): string {
+  return `\`${operand}\` reaches no cell: \`${segment}\` is no key of the ` +
+    `cell above it, ` +
+    (keys.length === 0
+      ? `which holds no keys at all.`
+      : `whose keys are ${listed(keys)}.`) +
+    scopeMoveHint(operand);
+}
 
 /**
  * Helper for {@link get}, which finishes `move` without moving.
@@ -502,7 +875,7 @@ type Targeting =
  */
 async function reading(
   shuttle: Shuttle,
-  move: Move,
+  move: Aimed,
   deps: VerbDeps,
 ): Promise<Reading> {
   switch (move.kind) {
@@ -610,7 +983,7 @@ async function resolveTarget(
     };
   }
   const carried = reference.scope !== undefined
-    ? `an \`@${reference.scope}\` suffix`
+    ? `an \`@${reference.scope}\` qualifier`
     : reference.input === true
     ? "the `#argument` suffix"
     : undefined;

--- a/packages/cli/test/shuttle-listing.test.ts
+++ b/packages/cli/test/shuttle-listing.test.ts
@@ -39,6 +39,7 @@ import {
   renderListing,
 } from "../lib/shuttle/listing.ts";
 import { CurrentPlace, type Facet, type Place } from "../lib/shuttle/place.ts";
+import { moved } from "./shuttle-place-helpers.ts";
 
 const SPACE = "did:key:z6MkConnectedSpace" as MemorySpace;
 const HANDLE = "of:fid1:abcdefghijklmnop";
@@ -71,15 +72,15 @@ function atSpaceRoot(): CurrentPlace {
 /** Helper for the cases below, which stands inside `facet`. */
 function inFacet(facet: Facet): CurrentPlace {
   const place = atSpaceRoot();
-  place.cd(facet);
+  moved(place, facet);
   return place;
 }
 
 /** Helper for the cases below, which stands at a piece, at `path` inside it. */
 function atPiece(...path: string[]): CurrentPlace {
   const place = atSpaceRoot();
-  place.cd(`/${HANDLE}`);
-  for (const segment of path) place.cd(segment);
+  moved(place, `/${HANDLE}`);
+  for (const segment of path) moved(place, segment);
   return place;
 }
 
@@ -285,7 +286,7 @@ describe("listing", () => {
         // the slug — which is what makes a name typed back off a listing reach
         // the piece it names, the read resolving it the way `--cell` does.
         const place = inFacet("slugs");
-        place.cd("board");
+        moved(place, "board");
         let piece: string | undefined;
         await list(place, {
           ...READS_NOTHING,
@@ -299,7 +300,7 @@ describe("listing", () => {
 
       it("reads at the scope the place reads through", async () => {
         const place = atPiece();
-        place.cd("@session");
+        moved(place, ".@session");
         let scope: string | undefined;
         await list(place, {
           ...READS_NOTHING,
@@ -678,7 +679,7 @@ describe("listing", () => {
         const tokens = split.kind === "split" ? split.tokens : [];
         expect(tokens.length).toBe(1);
         expect(readsAsOption(tokens[0])).toBe(false);
-        expect(standing.cd(tokens[0]).kind).toBe("moved");
+        expect(moved(standing, tokens[0]).kind).toBe("moved");
         expect(standing.place).toEqual(childOf(from, row.name));
         named++;
       }

--- a/packages/cli/test/shuttle-place-helpers.ts
+++ b/packages/cli/test/shuttle-place-helpers.ts
@@ -1,0 +1,36 @@
+/**
+ * Standing a place somewhere, for the cases that need one already there.
+ *
+ * A `cd` onto a piece comes back for a read rather than landing
+ * (`PendingMove`, `lib/shuttle/place.ts`), so a case that wants a place
+ * standing at a piece has to land it. What these stand in for the resolution
+ * is the piece the operand itself named — which is what the fabric hands back
+ * for a handle, and leaves a slug spelled as it was written.
+ *
+ * That is the point of them: a case built this way says what it says about the
+ * reading and nothing about a resolution. What a resolution does to a place —
+ * the handle it adopts, the name it leaves beside it, and the refusal a path
+ * that is not there gets — is pinned where it happens, in `confirm()`'s block
+ * in `shuttle-place.test.ts` and in `cd`'s in `shuttle-verbs.test.ts`.
+ */
+
+import type { CurrentPlace, Move } from "../lib/shuttle/place.ts";
+
+/**
+ * Lands `move` on `place` where it came back for a read, standing the piece
+ * the operand named in for the handle a resolution would hand back, and passes
+ * every other move through.
+ */
+export function landed(place: CurrentPlace, move: Move): Move {
+  return move.kind === "pending"
+    ? place.confirm(move, {
+      piece: move.place.position.piece,
+      path: move.place.position.path,
+    })
+    : move;
+}
+
+/** {@link landed} over a `cd`, which is how a case moves a place. */
+export function moved(place: CurrentPlace, operand: string): Move {
+  return landed(place, place.cd(operand));
+}

--- a/packages/cli/test/shuttle-place.test.ts
+++ b/packages/cli/test/shuttle-place.test.ts
@@ -7,11 +7,18 @@
  * rendering and per refusal affordable.
  *
  * The returned outcome is the half to read first, because only two of the
- * four arms a `Move` has are verdicts: the move landed, or it is refused. The
- * other two report that the operand is one this module does not settle — a
- * `#name` wish target, and a reference naming its space by name — since
- * settling either needs a connection to resolve against. Their cases pin what
- * gets handed on, and that the place did not move.
+ * five arms a `Move` has are verdicts: the move landed, or it is refused. The
+ * other three report that the operand is one this module does not settle — a
+ * `#name` wish target, a reference naming its space by name, and a place
+ * standing on a piece, which the fabric has still to be asked to resolve and
+ * to find — since settling any of them needs a connection to read over. Their
+ * cases pin what gets handed on, and that the place did not move.
+ *
+ * The pending arm is the one nearly every case meets, a piece being where
+ * navigation goes, so `moved()` (`shuttle-place-helpers.ts`) lands one with
+ * the piece the operand itself named. That leaves each case saying what it
+ * says about the reading and nothing about a resolution; the resolution has a
+ * block of its own.
  *
  * A refusal's text is pinned whole, and four of them are somebody else's
  * words. Shuttle consumes the reference grammar rather than forking it, so a
@@ -45,9 +52,12 @@ import {
   FACETS,
   type Move,
   operandForChild,
+  type PendingMove,
   placeAtSpaceRoot,
+  type ResolvedPlace,
 } from "../lib/shuttle/place.ts";
 import { RECORD_LABEL_WIDTH } from "../lib/shuttle/record.ts";
+import { landed, moved } from "./shuttle-place-helpers.ts";
 
 const SPACE = "did:key:z6MkConnectedSpace" as MemorySpace;
 const OTHER_SPACE = "did:key:z6MkOtherSpace" as MemorySpace;
@@ -61,7 +71,7 @@ function atSpaceRoot(): CurrentPlace {
 /** Helper for the cases below, which stands an instance inside `slugs/`. */
 function inSlugs(): CurrentPlace {
   const place = atSpaceRoot();
-  place.cd("slugs");
+  moved(place, "slugs");
   return place;
 }
 
@@ -79,14 +89,14 @@ function printedPosition(place: CurrentPlace): string {
 /** Helper for the cases below, which stands an instance at a named piece. */
 function atReferencedPiece(): CurrentPlace {
   const place = atSpaceRoot();
-  place.cd(`/${HANDLE}`);
+  moved(place, `/${HANDLE}`);
   return place;
 }
 
 /** Helper for the cases below, which stands an instance at a piece. */
 function atPiece(): CurrentPlace {
   const place = inSlugs();
-  place.cd("board");
+  moved(place, "board");
   return place;
 }
 
@@ -184,7 +194,7 @@ describe("place", () => {
       const place = atReferencedPiece();
       const operand = operandForChild(place.place, "..");
       expect(operand).toBeDefined();
-      place.cd(operand as string);
+      moved(place, operand as string);
       expect(place.place.position).toEqual({
         kind: "piece",
         space: SPACE,
@@ -209,8 +219,8 @@ describe("place", () => {
 
     it("returns a piece and its path as a fully qualified reference", () => {
       const place = atPiece();
-      place.cd("topics/3");
-      place.cd("@session");
+      moved(place, "topics/3");
+      moved(place, ".@session");
       expect(place.render()).toBe(
         "position  /@did:key:z6MkConnectedSpace/board@session/topics/3\n" +
           "scope     @session",
@@ -230,29 +240,29 @@ describe("place", () => {
 
       it("returns a piece rendering `cd` takes back to the same place, pasted whole", () => {
         const place = atPiece();
-        place.cd("topics/3");
+        moved(place, "topics/3");
         const elsewhere = atSpaceRoot();
-        elsewhere.cd(printedPosition(place));
+        moved(elsewhere, printedPosition(place));
         expect(elsewhere.place).toEqual(place.place);
       });
 
       it("escapes a `/` in a key, and takes that rendering back whole", () => {
         const place = atSpaceRoot();
-        place.cd(`/${HANDLE}/a~1b`);
+        moved(place, `/${HANDLE}/a~1b`);
         const printed = printedPosition(place);
         expect(printed).toBe(
           "/@did:key:z6MkConnectedSpace/of:fid1:abcdefghijklmnop@space/a~1b",
         );
         const elsewhere = atSpaceRoot();
-        elsewhere.cd(printed);
+        moved(elsewhere, printed);
         expect(elsewhere.place).toEqual(place.place);
       });
 
       it("returns a rendering `cd` refuses where a key holds a `#`", () => {
         const place = atReferencedPiece();
-        place.cd("a#b");
+        moved(place, "a#b");
         const elsewhere = atSpaceRoot();
-        expect(elsewhere.cd(printedPosition(place)).kind).toBe("refused");
+        expect(moved(elsewhere, printedPosition(place)).kind).toBe("refused");
         expect(elsewhere.place).toEqual(placeAtSpaceRoot(SPACE));
       });
 
@@ -338,8 +348,8 @@ describe("place", () => {
               return;
             }
             const elsewhere = atSpaceRoot();
-            elsewhere.cd(`@${reader}`);
-            if (elsewhere.cd(printedPosition(place)).kind !== "moved") {
+            moved(elsewhere, `.@${reader}`);
+            if (moved(elsewhere, printedPosition(place)).kind !== "moved") {
               refusedRendering++;
               return;
             }
@@ -368,31 +378,39 @@ describe("place", () => {
             {
               door: "settle",
               piece: (at, v) =>
-                at.settle({
-                  kind: "space-by-name",
-                  name: "estuary",
-                  piece: v,
-                  path: [],
-                  scope: at.place.scope,
-                }, SPACE),
+                landed(
+                  at,
+                  at.settle({
+                    kind: "space-by-name",
+                    name: "estuary",
+                    operand: `/@estuary/${v}`,
+                    piece: v,
+                    path: [],
+                    scope: at.place.scope,
+                  }, SPACE),
+                ),
               segment: (at, v) =>
-                at.settle({
-                  kind: "space-by-name",
-                  name: "estuary",
-                  piece: HANDLE,
-                  path: [v],
-                  scope: at.place.scope,
-                }, SPACE),
+                landed(
+                  at,
+                  at.settle({
+                    kind: "space-by-name",
+                    name: "estuary",
+                    operand: `/@estuary/${HANDLE}/${v}`,
+                    piece: HANDLE,
+                    path: [v],
+                    scope: at.place.scope,
+                  }, SPACE),
+                ),
             },
             {
               door: "walk",
-              piece: (at, v) => (at.cd("slugs"), at.cd(v)),
-              segment: (at, v) => (at.cd(`/${HANDLE}`), at.cd(v)),
+              piece: (at, v) => (moved(at, "slugs"), moved(at, v)),
+              segment: (at, v) => (moved(at, `/${HANDLE}`), moved(at, v)),
             },
             {
               door: "reference",
-              piece: (at, v) => at.cd(`/${v}`),
-              segment: (at, v) => at.cd(`/${HANDLE}/${v}`),
+              piece: (at, v) => moved(at, `/${v}`),
+              segment: (at, v) => moved(at, `/${HANDLE}/${v}`),
             },
           ];
 
@@ -404,7 +422,7 @@ describe("place", () => {
             /** Helper for this case, which stands at `scope` to begin with. */
             const standing = (): CurrentPlace => {
               const place = atSpaceRoot();
-              place.cd(`@${scope}`);
+              moved(place, `.@${scope}`);
               return place;
             };
 
@@ -449,37 +467,36 @@ describe("place", () => {
         const place = atPiece();
         expect(place.place.scope).toBe("space");
         const elsewhere = atSpaceRoot();
-        elsewhere.cd("@user");
-        elsewhere.cd(printedPosition(place));
+        moved(elsewhere, ".@user");
+        moved(elsewhere, printedPosition(place));
         expect(elsewhere.place).toEqual(place.place);
       });
 
       it("returns a container rendering whose refusal names the right fault", () => {
-        // A container's rendering starts with the space's `@`, so pasting
-        // one back reaches the scope reading. The refusal has to be about
-        // what was pasted rather than about a scope word nobody wrote.
+        // A container's rendering opens with the space's `@`, which is data
+        // rather than a reading, so pasting one back is a walk from where it
+        // is pasted. The refusal has to be about what was pasted.
 
         const place = inSlugs();
-        const move = atSpaceRoot().cd(printedPosition(place));
+        const move = moved(atSpaceRoot(), printedPosition(place));
         expect(move).toEqual({
           kind: "refused",
-          reason: "`@did:key:z6MkConnectedSpace/slugs/` names no scope: a " +
-            "scope word holds no `/`. What `pwd` prints for a space root " +
-            "or a facet is spelled this way and names no cell — reach one " +
-            "by its facet or its piece.",
+          reason: "A space root lists facets, and " +
+            "`@did:key:z6MkConnectedSpace` names none. The facets are " +
+            "`slugs/` and `pieces/`.",
         });
       });
 
       it("returns a space root rendering `cd` refuses", () => {
         const place = atSpaceRoot();
-        expect(place.cd(printedPosition(place)).kind).toBe("refused");
+        expect(moved(place, printedPosition(place)).kind).toBe("refused");
         expect(place.place).toEqual(placeAtSpaceRoot(SPACE));
       });
 
       it("returns a facet rendering `cd` refuses", () => {
         const place = inSlugs();
         const facet = place.place;
-        expect(place.cd(printedPosition(place)).kind).toBe("refused");
+        expect(moved(place, printedPosition(place)).kind).toBe("refused");
         expect(place.place).toEqual(facet);
       });
     });
@@ -500,13 +517,13 @@ describe("place", () => {
 
     it("returns a piece and its path without the space in front", () => {
       const place = atPiece();
-      place.cd("topics/3");
+      moved(place, "topics/3");
       expect(place.label()).toBe("board/topics/3 @space");
     });
 
     it("returns the scope the place reads through", () => {
       const place = atPiece();
-      place.cd("@session");
+      moved(place, ".@session");
       expect(place.label()).toBe("board @session");
     });
 
@@ -520,7 +537,7 @@ describe("place", () => {
 
     it("returns a key holding the separator as one segment", () => {
       const place = atPiece();
-      place.cd("/board/a~1b");
+      moved(place, "/board/a~1b");
       expect(place.label()).toBe("board/a~1b @space");
     });
   });
@@ -552,7 +569,7 @@ describe("place", () => {
     it("refuses a segment holding one, whichever door reads it", () => {
       for (const [mark] of ACTED_ON) {
         const walked = atPiece();
-        expect(walked.cd(`b${mark}c`)).toEqual({
+        expect(moved(walked, `b${mark}c`)).toEqual({
           kind: "refused",
           reason: `\`b${mark}c\` has a segment holding a control ` +
             "character, so a terminal would act on it rather than print it.",
@@ -574,7 +591,7 @@ describe("place", () => {
 
       for (const [mark] of ACTED_ON) {
         const piece = `of:fid1:aaaaaaaaaa${mark}aaaaaaaaa`;
-        expect(atSpaceRoot().cd(`/${piece}`)).toEqual({
+        expect(moved(atSpaceRoot(), `/${piece}`)).toEqual({
           kind: "refused",
           reason: `\`/${piece}\` has a piece holding a control character, ` +
             "so no piece carries that name: a slug is lowercase letters, " +
@@ -591,7 +608,7 @@ describe("place", () => {
 
       for (const [mark] of PRINTED) {
         const at = atPiece();
-        expect(at.cd(`b${mark}c`).kind).toBe("moved");
+        expect(moved(at, `b${mark}c`).kind).toBe("moved");
         expect(at.place.position).toEqual({
           kind: "piece",
           space: SPACE,
@@ -607,7 +624,7 @@ describe("place", () => {
       // reference would name another cell. What a person is told is the reason
       // that describes what would actually go wrong.
 
-      expect(atPiece().cd("b\nc")).toEqual({
+      expect(moved(atPiece(), "b\nc")).toEqual({
         kind: "refused",
         reason: "`b\nc` has a segment holding a line break, so a rendering " +
           "of the place would name a different cell.",
@@ -633,7 +650,7 @@ describe("place", () => {
       describe("place", () => {
         it("returns the place a landed move moved to", () => {
           const place = atSpaceRoot();
-          place.cd("pieces");
+          moved(place, "pieces");
           expect(place.place).toEqual({
             position: { kind: "facet", space: SPACE, facet: "pieces" },
             scope: "space",
@@ -642,19 +659,19 @@ describe("place", () => {
 
         it("returns the place shuttle stood at when a move is refused", () => {
           const place = atSpaceRoot();
-          place.cd("board");
+          moved(place, "board");
           expect(place.place).toEqual(placeAtSpaceRoot(SPACE));
         });
 
         it("returns the place shuttle stood at for a wish target", () => {
           const place = atSpaceRoot();
-          place.cd("#favorites");
+          moved(place, "#favorites");
           expect(place.place).toEqual(placeAtSpaceRoot(SPACE));
         });
 
         it("returns the place shuttle stood at for a space named by name", () => {
           const place = atSpaceRoot();
-          place.cd(`/@estuary/${HANDLE}`);
+          moved(place, `/@estuary/${HANDLE}`);
           expect(place.place).toEqual(placeAtSpaceRoot(SPACE));
         });
       });
@@ -662,20 +679,20 @@ describe("place", () => {
       describe("previous", () => {
         it("returns the place a landed move moved out of", () => {
           const place = atSpaceRoot();
-          place.cd("slugs");
+          moved(place, "slugs");
           expect(place.previous).toEqual(placeAtSpaceRoot(SPACE));
         });
 
         it("returns nothing after a refused move", () => {
           const place = atSpaceRoot();
-          place.cd("board");
+          moved(place, "board");
           expect(place.previous).toBeUndefined();
         });
       });
 
       describe("cd()", () => {
         it("refuses an empty operand", () => {
-          expect(atSpaceRoot().cd("")).toEqual({
+          expect(moved(atSpaceRoot(), "")).toEqual({
             kind: "refused",
             reason: "`cd` takes a place to move to.",
           });
@@ -687,18 +704,320 @@ describe("place", () => {
           // only a space. A name reaches the rule the position's own children
           // answer to, which at a space root is the closed set of facets.
 
-          expect(atSpaceRoot().cd(" ")).toEqual({
+          expect(moved(atSpaceRoot(), " ")).toEqual({
             kind: "refused",
             reason: "A space root lists facets, and ` ` names none. The " +
               "facets are `slugs/` and `pieces/`.",
           });
         });
 
+        describe("what comes back for a read", () => {
+          // Which moves wait on the fabric and which do not. A move onto a
+          // piece waits, because whether the space holds one is nothing a
+          // value knows; a move to a container, and one back to a place
+          // already stood at, does not.
+
+          /** Helper for the cases below, which is `operand` moved, unlanded. */
+          function step(place: CurrentPlace, operand: string): Move {
+            return place.cd(operand);
+          }
+
+          it("hands back a piece a walk reached, with the route it walked", () => {
+            const place = inSlugs();
+            expect(step(place, "board")).toEqual({
+              kind: "pending",
+              place: {
+                position: {
+                  kind: "piece",
+                  space: SPACE,
+                  piece: "board",
+                  path: [],
+                },
+                scope: "space",
+              },
+              operand: "board",
+              route: [
+                { kind: "root", space: SPACE },
+                { kind: "facet", space: SPACE, facet: "slugs" },
+              ],
+            });
+          });
+
+          it("leaves shuttle where it stood while the read is outstanding", () => {
+            const place = inSlugs();
+            const before = place.place;
+            step(place, "board");
+            expect(place.place).toBe(before);
+          });
+
+          it("hands back a piece a reference reached, with no route", () => {
+            expect(step(atSpaceRoot(), `/${HANDLE}/title`)).toEqual({
+              kind: "pending",
+              place: {
+                position: {
+                  kind: "piece",
+                  space: SPACE,
+                  piece: HANDLE,
+                  path: ["title"],
+                },
+                scope: "space",
+              },
+              operand: `/${HANDLE}/title`,
+              route: [],
+            });
+          });
+
+          it("hands back a key a walk inside a piece reached", () => {
+            expect(step(atReferencedPiece(), "topics").kind).toBe("pending");
+          });
+
+          it("lands a facet, which is a name rather than a thing to find", () => {
+            expect(step(atSpaceRoot(), "slugs").kind).toBe("moved");
+          });
+
+          it("lands `..`, `-` and `/`, each a place already stood at", () => {
+            // One case for the three, because what they share is the whole
+            // claim: none of them reaches anywhere a read has not been.
+
+            const place = atPiece();
+            moved(place, "topics");
+            for (const operand of ["..", "-", "/"]) {
+              expect(step(place, operand).kind).toBe("moved");
+            }
+          });
+
+          it("hands back a scope on its own, the place at it being unread", () => {
+            // A scope selects which document a piece's id names, so the same
+            // path at another scope is another cell and nothing has read it.
+            // The position does not move, and the trail comes through whole.
+
+            const place = atPiece();
+            moved(place, "topics");
+            expect(step(place, ".@session")).toEqual({
+              kind: "pending",
+              place: {
+                position: {
+                  kind: "piece",
+                  space: SPACE,
+                  piece: "board",
+                  path: ["topics"],
+                },
+                scope: "session",
+              },
+              operand: ".@session",
+              route: [
+                { kind: "root", space: SPACE },
+                { kind: "facet", space: SPACE, facet: "slugs" },
+                {
+                  kind: "piece",
+                  space: SPACE,
+                  piece: "board",
+                  path: [],
+                },
+              ],
+            });
+          });
+
+          it("lands a scope on its own at a container, which is no cell", () => {
+            // A root and a facet are lists of names rather than cells, so
+            // there is nothing for an overlay to select within and nothing to
+            // read.
+
+            expect(step(inSlugs(), ".@session").kind).toBe("moved");
+            expect(step(atSpaceRoot(), ".@user").kind).toBe("moved");
+          });
+
+          it("lands a walk that descended and climbed back out of the piece", () => {
+            // `board` waits on a read and `..` leaves it behind, so what the
+            // operand reaches is the facet, and a facet is not a thing to
+            // find.
+
+            expect(step(inSlugs(), "board/..").kind).toBe("moved");
+          });
+
+          it("hands back a walk that climbed back to a level nothing read", () => {
+            // Sticky rather than last-step: the walk climbs out of `3` and
+            // stops at `topics`, which no read has looked at either.
+
+            expect(step(atReferencedPiece(), "topics/3/..").kind)
+              .toBe("pending");
+          });
+
+          it("lands a walk that ends exactly where it started", () => {
+            // Down and back up again reaches the place shuttle was standing
+            // at, and that was settled when shuttle arrived — there is
+            // nothing left for a read to check.
+
+            const place = atReferencedPiece();
+            const before = place.place;
+            expect(step(place, "topics/..")).toEqual({
+              kind: "moved",
+              place: before,
+            });
+          });
+        });
+
+        describe("a rooted operand naming a facet", () => {
+          // The facet names are reserved as the first segment of a rooted
+          // reference as well as at the root, so `/slugs/board` is the walk
+          // `cd /` and `cd slugs/board` make rather than a piece slugged
+          // `slugs` with `board` inside it.
+
+          it("walks from the root for `/slugs/<slug>`", () => {
+            const place = atSpaceRoot();
+            moved(place, `/slugs/board`);
+            expect(place.place.position).toEqual({
+              kind: "piece",
+              space: SPACE,
+              piece: "board",
+              path: [],
+            });
+          });
+
+          it("leaves the route the walk leaves, so `..` reaches the facet", () => {
+            const place = atSpaceRoot();
+            moved(place, "/slugs/board");
+            moved(place, "..");
+            expect(place.place.position).toEqual({
+              kind: "facet",
+              space: SPACE,
+              facet: "slugs",
+            });
+          });
+
+          it("reaches the facet itself for `/slugs`", () => {
+            expect(moved(atPiece(), "/slugs")).toEqual({
+              kind: "moved",
+              place: {
+                position: { kind: "facet", space: SPACE, facet: "slugs" },
+                scope: "space",
+              },
+            });
+          });
+
+          it("walks from the root for `/pieces/<handle>`", () => {
+            const place = atSpaceRoot();
+            moved(place, `/pieces/${HANDLE}`);
+            expect(place.place.position).toEqual({
+              kind: "piece",
+              space: SPACE,
+              piece: HANDLE,
+              path: [],
+            });
+          });
+
+          it("takes the facet form the prompt prints back to that facet", () => {
+            // The short form writes a container with the leading separator,
+            // and the claim it makes is that the separator reads as the walk
+            // down from the root. This is that claim.
+
+            const place = inSlugs();
+            const printed = place.label().split(" ")[0];
+            expect(printed).toBe("/slugs/");
+            const elsewhere = atSpaceRoot();
+            moved(elsewhere, printed);
+            expect(elsewhere.place).toEqual(place.place);
+          });
+
+          it("quotes what was written, not the walk it was read as", () => {
+            // The walk drops the separator that rooted the operand, and a
+            // refusal names what a person typed rather than what the reading
+            // made of it.
+
+            expect(moved(atSpaceRoot(), `/pieces/${HANDLE}/a /b`)).toEqual({
+              kind: "refused",
+              reason: `\`/pieces/${HANDLE}/a /b\` has a segment ending in ` +
+                "whitespace, so a rendering of the place would name a " +
+                "different cell.",
+            });
+          });
+
+          it("refuses a walk whose piece ends in whitespace", () => {
+            // The walk keeps the operand's edges, the operand reaching the
+            // split as it was written, so the piece here answers to the piece
+            // rule rather than to the reference grammar's trim.
+
+            expect(moved(atSpaceRoot(), "/slugs/board ")).toEqual({
+              kind: "refused",
+              reason: "`/slugs/board ` has a piece ending in whitespace, so " +
+                "no piece carries that name: a slug is lowercase letters, " +
+                "numbers, and single hyphens between words, and a handle is " +
+                "`of:fid1:` and unpadded base64url.",
+            });
+          });
+
+          it("refuses an operand rooted only once its leading edge comes off", () => {
+            // The reading a leading space would otherwise hand to the
+            // reference grammar, which trims what it is given: `slugs` as a
+            // piece rather than the facet, and reached without a word said.
+            // The refusal is what stops that being silent.
+
+            const place = atSpaceRoot();
+            expect(moved(place, " /slugs/board")).toEqual({
+              kind: "refused",
+              reason: "` /slugs/board` is rooted only with its leading " +
+                "whitespace taken off, and the two readings name different " +
+                "cells. `/slugs/board` is the one that reaches the place it " +
+                "names.",
+            });
+            expect(place.place).toEqual(placeAtSpaceRoot(SPACE));
+          });
+
+          it("refuses a rooted reference behind whitespace, facet or not", () => {
+            // The rule is about the rooting rather than about the facets: a
+            // reference reached only by a trim has the same two readings.
+
+            expect(moved(atSpaceRoot(), ` /${HANDLE}`).kind).toBe("refused");
+          });
+
+          it("reaches a key behind whitespace that trimming leaves relative", () => {
+            // The other side of the boundary, and the one a wider rule would
+            // quietly take: leading whitespace costs a name nothing unless
+            // trimming would root the operand, so a relative name keeps its
+            // edge and the key it names.
+
+            const place = atReferencedPiece();
+            moved(place, " foo");
+            expect(place.place.position).toEqual({
+              kind: "piece",
+              space: SPACE,
+              piece: HANDLE,
+              path: [" foo"],
+            });
+          });
+
+          it("reads a facet name after a space as the piece a reference names", () => {
+            // The rooted form only. A complete reference carries its own
+            // space and is the canonical grammar's outright, which is what
+            // leaves a piece slugged `slugs` reachable by name at all.
+
+            const place = atSpaceRoot();
+            moved(place, `/@${SPACE}/slugs/board`);
+            expect(place.place.position).toEqual({
+              kind: "piece",
+              space: SPACE,
+              piece: "slugs",
+              path: ["board"],
+            });
+          });
+
+          it("reads a facet name inside a piece as an ordinary key", () => {
+            const place = atReferencedPiece();
+            moved(place, "slugs");
+            expect(place.place.position).toEqual({
+              kind: "piece",
+              space: SPACE,
+              piece: HANDLE,
+              path: ["slugs"],
+            });
+          });
+        });
+
         describe("the previous place", () => {
           it("returns to the previous place for `-`", () => {
             const place = atPiece();
-            place.cd("topics");
-            expect(place.cd("-")).toEqual({
+            moved(place, "topics");
+            expect(moved(place, "-")).toEqual({
               kind: "moved",
               place: {
                 position: {
@@ -714,9 +1033,9 @@ describe("place", () => {
 
           it("swaps the two places, so a second `-` goes back again", () => {
             const place = atPiece();
-            place.cd("topics");
-            place.cd("-");
-            place.cd("-");
+            moved(place, "topics");
+            moved(place, "-");
+            moved(place, "-");
             expect(place.place.position).toEqual({
               kind: "piece",
               space: SPACE,
@@ -727,9 +1046,9 @@ describe("place", () => {
 
           it("restores the route, so `..` backs out the way it came", () => {
             const place = atPiece();
-            place.cd("..");
-            place.cd("-");
-            place.cd("..");
+            moved(place, "..");
+            moved(place, "-");
+            moved(place, "..");
             expect(place.place.position).toEqual({
               kind: "facet",
               space: SPACE,
@@ -738,7 +1057,7 @@ describe("place", () => {
           });
 
           it("refuses `-` while there is no previous place", () => {
-            expect(atSpaceRoot().cd("-")).toEqual({
+            expect(moved(atSpaceRoot(), "-")).toEqual({
               kind: "refused",
               reason: "There is no previous place to return to.",
             });
@@ -746,9 +1065,9 @@ describe("place", () => {
         });
 
         describe("scope", () => {
-          it("moves the scope alone for `@session`", () => {
+          it("moves the scope alone for `.@session`", () => {
             const place = atPiece();
-            expect(place.cd("@session")).toEqual({
+            expect(moved(place, ".@session")).toEqual({
               kind: "moved",
               place: {
                 position: {
@@ -762,17 +1081,23 @@ describe("place", () => {
             });
           });
 
-          it("moves the scope back to the base for `@space`", () => {
+          it("moves the scope back to the base for `.@space`", () => {
+            // The trip out is asserted as well as the trip back: a place that
+            // starts at the base and ends there says nothing about either
+            // move unless it is seen away from it in between.
+
             const place = atSpaceRoot();
-            place.cd("@user");
-            place.cd("@space");
+            expect(place.place.scope).toBe("space");
+            moved(place, ".@user");
+            expect(place.place.scope).toBe("user");
+            moved(place, ".@space");
             expect(place.place.scope).toBe("space");
           });
 
           it("keeps the route, so `..` still backs out to the facet", () => {
             const place = atPiece();
-            place.cd("@session");
-            place.cd("..");
+            moved(place, ".@session");
+            moved(place, "..");
             expect(place.place.position).toEqual({
               kind: "facet",
               space: SPACE,
@@ -780,17 +1105,17 @@ describe("place", () => {
             });
           });
 
-          it("refuses a suffix naming no scope", () => {
-            expect(atSpaceRoot().cd("@overlay")).toEqual({
+          it("refuses a qualifier naming no scope", () => {
+            expect(moved(atSpaceRoot(), ".@overlay")).toEqual({
               kind: "refused",
-              reason: "`@overlay` names no scope. The scopes are `@space`, " +
-                "`@user`, and `@session`.",
+              reason: "`.@overlay` names no scope. The scopes are `.@space`, " +
+                "`.@user`, and `.@session`.",
             });
           });
 
           it("moves position and scope together for `board@session`", () => {
             const place = inSlugs();
-            expect(place.cd("board@session")).toEqual({
+            expect(moved(place, "board@session")).toEqual({
               kind: "moved",
               place: {
                 position: {
@@ -804,13 +1129,13 @@ describe("place", () => {
             });
           });
 
-          it("refuses a piece left ending in whitespace by a scope suffix", () => {
+          it("refuses a piece left ending in whitespace by a scope qualifier", () => {
             // `cd board @space` is an ordinary typo. The suffix splits off
             // cleanly and what remains is a piece the rendering would not
             // name back, so the check runs on the piece the split produced
             // rather than on the segment that carried it.
 
-            expect(inSlugs().cd("board @space")).toEqual({
+            expect(moved(inSlugs(), "board @space")).toEqual({
               kind: "refused",
               reason: "`board @space` has a piece ending in whitespace, " +
                 "so no piece carries that name: a slug is lowercase " +
@@ -824,7 +1149,7 @@ describe("place", () => {
             // one is read back shortened. No slug or handle carries the
             // character, so nothing nameable is lost.
 
-            expect(inSlugs().cd("board@session@session")).toEqual({
+            expect(moved(inSlugs(), "board@session@session")).toEqual({
               kind: "refused",
               reason: "`board@session@session` has a piece holding `@`, " +
                 "so no piece carries that name: a slug is lowercase " +
@@ -833,22 +1158,25 @@ describe("place", () => {
             });
           });
 
-          it("refuses a segment that is only a scope suffix", () => {
-            expect(atSpaceRoot().cd("slugs/@user")).toEqual({
+          it("refuses a segment that is only a qualifier", () => {
+            // The hint is absent here, and that is the claim: the operand is
+            // a walk into a facet rather than a scope word written bare, so
+            // there is no `.@user` for it to have meant.
+
+            expect(moved(atSpaceRoot(), "slugs/@user")).toEqual({
               kind: "refused",
-              reason: "`@user` names no piece. A scope suffix rides a piece " +
-                "id, and a scope on its own is a whole operand rather than " +
-                "a segment.",
+              reason: "`@user` names no piece. A qualifier rides a piece id, " +
+                "and a facet holds pieces rather than keys.",
             });
           });
 
-          it("refuses a suffix on a piece segment naming no scope", () => {
+          it("refuses a qualifier on a piece segment naming no scope", () => {
             // The same refusal a scope-only operand gets, since it is the
             // same fault: shuttle owns the scope words, so the wording is
             // its own rather than the parser's, which speaks of link
             // handles a reader never typed.
 
-            expect(inSlugs().cd("board@overlay")).toEqual({
+            expect(moved(inSlugs(), "board@overlay")).toEqual({
               kind: "refused",
               reason: "`@overlay` names no scope. The scopes are `@space`, " +
                 "`@user`, and `@session`.",
@@ -858,7 +1186,7 @@ describe("place", () => {
 
         describe("references", () => {
           it("takes the space from the place for a rooted reference", () => {
-            expect(atPiece().cd(`/${HANDLE}/topics/3`)).toEqual({
+            expect(moved(atPiece(), `/${HANDLE}/topics/3`)).toEqual({
               kind: "moved",
               place: {
                 position: {
@@ -873,7 +1201,7 @@ describe("place", () => {
           });
 
           it("moves for a complete reference naming the connected space", () => {
-            expect(atSpaceRoot().cd(`/@${SPACE}/${HANDLE}`)).toEqual({
+            expect(moved(atSpaceRoot(), `/@${SPACE}/${HANDLE}`)).toEqual({
               kind: "moved",
               place: {
                 position: {
@@ -893,12 +1221,12 @@ describe("place", () => {
             // reference omits.
 
             const place = atSpaceRoot();
-            place.cd("@session");
-            place.cd(`/${HANDLE}/title`);
+            moved(place, ".@session");
+            moved(place, `/${HANDLE}/title`);
             expect(place.place.scope).toBe("session");
           });
 
-          it("names two cells for one suffix-less string read at two scopes", () => {
+          it("names two cells for one unqualified string read at two scopes", () => {
             // The observable the always-emit ruling rests on, and the one
             // the taxonomy turns on: a complete reference carries its space
             // and not its scope, so the reader supplies the level it does
@@ -909,8 +1237,8 @@ describe("place", () => {
             const reference = `/@${SPACE}/${HANDLE}/title`;
             const reader = (scope: CellScope): CurrentPlace => {
               const place = atSpaceRoot();
-              place.cd(`@${scope}`);
-              place.cd(reference);
+              moved(place, `.@${scope}`);
+              moved(place, reference);
               return place;
             };
             expect(reader("user").place.scope).toBe("user");
@@ -922,8 +1250,8 @@ describe("place", () => {
             const reference = `/@${SPACE}/${HANDLE}@user/title`;
             const reader = (scope: CellScope): CurrentPlace => {
               const place = atSpaceRoot();
-              place.cd(`@${scope}`);
-              place.cd(reference);
+              moved(place, `.@${scope}`);
+              moved(place, reference);
               return place;
             };
             expect(reader("space").place).toEqual(reader("session").place);
@@ -934,15 +1262,15 @@ describe("place", () => {
             // Relayed: the canonical layer's sentence, not shuttle's
             // to choose. See the file header.
 
-            expect(atSpaceRoot().cd(`/@${OTHER_SPACE}/${HANDLE}`)).toEqual({
+            expect(moved(atSpaceRoot(), `/@${OTHER_SPACE}/${HANDLE}`)).toEqual({
               kind: "refused",
               reason: `Reference names space "${OTHER_SPACE}" but the ` +
                 `command targets space "${SPACE}".`,
             });
           });
 
-          it("takes the scope from an `@scope` suffix on the piece", () => {
-            expect(atSpaceRoot().cd(`/${HANDLE}@user/title`)).toEqual({
+          it("takes the scope from an `@scope` qualifier on the piece", () => {
+            expect(moved(atSpaceRoot(), `/${HANDLE}@user/title`)).toEqual({
               kind: "moved",
               place: {
                 position: {
@@ -957,7 +1285,7 @@ describe("place", () => {
           });
 
           it("refuses a reference carrying `#argument`", () => {
-            expect(atSpaceRoot().cd(`/${HANDLE}#argument`)).toEqual({
+            expect(moved(atSpaceRoot(), `/${HANDLE}#argument`)).toEqual({
               kind: "refused",
               reason:
                 "A place is result-rooted, so `cd` takes no `#argument` " +
@@ -972,7 +1300,7 @@ describe("place", () => {
             // Relayed: the canonical layer's sentence, not shuttle's
             // to choose. See the file header.
 
-            const move = atSpaceRoot().cd(`/${HANDLE}#result`);
+            const move = moved(atSpaceRoot(), `/${HANDLE}#result`);
             expect(move).toEqual({
               kind: "refused",
               reason: 'Unknown suffix "#result". The one supported suffix ' +
@@ -989,7 +1317,7 @@ describe("place", () => {
             // refuses the spelling; this is the same refusal at the other
             // door, and it costs the empty key its only spelling.
 
-            expect(atSpaceRoot().cd(`/${HANDLE}//`)).toEqual({
+            expect(moved(atSpaceRoot(), `/${HANDLE}//`)).toEqual({
               kind: "refused",
               reason: `\`/${HANDLE}//\` has an empty segment, ` +
                 `so a rendering of the place would name a different cell.`,
@@ -997,7 +1325,7 @@ describe("place", () => {
           });
 
           it("refuses a reference holding an empty segment mid-path", () => {
-            expect(atSpaceRoot().cd(`/${HANDLE}/a//b`)).toEqual({
+            expect(moved(atSpaceRoot(), `/${HANDLE}/a//b`)).toEqual({
               kind: "refused",
               reason: `\`/${HANDLE}/a//b\` has an empty segment, ` +
                 `so a rendering of the place would name a different cell.`,
@@ -1006,7 +1334,7 @@ describe("place", () => {
 
           it("reads a trailing slash as the piece itself", () => {
             const place = atSpaceRoot();
-            place.cd(`/${HANDLE}/`);
+            moved(place, `/${HANDLE}/`);
             expect(place.place.position).toEqual({
               kind: "piece",
               space: SPACE,
@@ -1020,16 +1348,18 @@ describe("place", () => {
             // reference can carry a piece the rendering would not name back
             // even after the canonical parse has accepted it.
 
-            expect(atSpaceRoot().cd("/of:fid1:abc\ndefghijklmnop")).toEqual({
-              kind: "refused",
-              reason: "`/of:fid1:abc\ndefghijklmnop` has a piece holding a " +
-                "line break, so a rendering of the place would name a " +
-                "different cell.",
-            });
+            expect(moved(atSpaceRoot(), "/of:fid1:abc\ndefghijklmnop")).toEqual(
+              {
+                kind: "refused",
+                reason: "`/of:fid1:abc\ndefghijklmnop` has a piece holding a " +
+                  "line break, so a rendering of the place would name a " +
+                  "different cell.",
+              },
+            );
           });
 
           it("refuses a reference holding a segment that ends in whitespace", () => {
-            expect(atSpaceRoot().cd(`/${HANDLE}/a /b`)).toEqual({
+            expect(moved(atSpaceRoot(), `/${HANDLE}/a /b`)).toEqual({
               kind: "refused",
               reason: `\`/${HANDLE}/a /b\` has a segment ending in ` +
                 `whitespace, so a rendering of the place would name a different cell.`,
@@ -1042,7 +1372,7 @@ describe("place", () => {
             // survives the round trip and is admitted.
 
             const place = atSpaceRoot();
-            place.cd(`/${HANDLE}/ a/b`);
+            moved(place, `/${HANDLE}/ a/b`);
             expect(place.place.position).toEqual({
               kind: "piece",
               space: SPACE,
@@ -1055,7 +1385,7 @@ describe("place", () => {
             // Relayed: the canonical layer's sentence, not shuttle's
             // to choose. See the file header.
 
-            expect(atSpaceRoot().cd("//")).toEqual({
+            expect(moved(atSpaceRoot(), "//")).toEqual({
               kind: "refused",
               reason:
                 'Target must include a piece handle, e.g. "/of:fid1:abc123/path".',
@@ -1067,9 +1397,10 @@ describe("place", () => {
             // connected one is what is not yet known, so there is nothing
             // for a space field to hold that would not be a guess.
 
-            expect(atSpaceRoot().cd(`/@estuary/${HANDLE}/title`)).toEqual({
+            expect(moved(atSpaceRoot(), `/@estuary/${HANDLE}/title`)).toEqual({
               kind: "space-by-name",
               name: "estuary",
+              operand: `/@estuary/${HANDLE}/title`,
               piece: HANDLE,
               path: ["title"],
               scope: "space",
@@ -1079,7 +1410,7 @@ describe("place", () => {
 
         describe("the space root", () => {
           it("moves to the space root for `/` from a piece", () => {
-            expect(atPiece().cd("/")).toEqual({
+            expect(moved(atPiece(), "/")).toEqual({
               kind: "moved",
               place: {
                 position: { kind: "root", space: SPACE },
@@ -1090,8 +1421,8 @@ describe("place", () => {
 
           it("moves to the space root for `/` from a path in a piece", () => {
             const place = atPiece();
-            place.cd("topics/3");
-            place.cd("/");
+            moved(place, "topics/3");
+            moved(place, "/");
             expect(place.place.position).toEqual({
               kind: "root",
               space: SPACE,
@@ -1100,7 +1431,7 @@ describe("place", () => {
 
           it("moves to the space root for `/` from a facet", () => {
             const place = inSlugs();
-            place.cd("/");
+            moved(place, "/");
             expect(place.place.position).toEqual({
               kind: "root",
               space: SPACE,
@@ -1109,15 +1440,15 @@ describe("place", () => {
 
           it("leaves the scope alone for `/`", () => {
             const place = atPiece();
-            place.cd("@session");
-            place.cd("/");
+            moved(place, ".@session");
+            moved(place, "/");
             expect(place.place.scope).toBe("session");
           });
         });
 
         describe("wish targets", () => {
           it("hands back a `#name` target for the connection to resolve", () => {
-            expect(atSpaceRoot().cd("#favorites")).toEqual({
+            expect(moved(atSpaceRoot(), "#favorites")).toEqual({
               kind: "wish",
               target: "#favorites",
             });
@@ -1131,14 +1462,14 @@ describe("place", () => {
             // is what discovers there is none. The case below drives the
             // same point through a spelling a reference refuses outright.
 
-            expect(atSpaceRoot().cd("#argument")).toEqual({
+            expect(moved(atSpaceRoot(), "#argument")).toEqual({
               kind: "wish",
               target: "#argument",
             });
           });
 
           it("hands back a target holding a second `#`", () => {
-            expect(atSpaceRoot().cd("#a#b")).toEqual({
+            expect(moved(atSpaceRoot(), "#a#b")).toEqual({
               kind: "wish",
               target: "#a#b",
             });
@@ -1147,7 +1478,7 @@ describe("place", () => {
 
         describe("relative segments", () => {
           it("moves into a facet named at the space root", () => {
-            expect(atSpaceRoot().cd("slugs")).toEqual({
+            expect(moved(atSpaceRoot(), "slugs")).toEqual({
               kind: "moved",
               place: {
                 position: { kind: "facet", space: SPACE, facet: "slugs" },
@@ -1157,7 +1488,7 @@ describe("place", () => {
           });
 
           it("refuses a segment at the space root naming no facet", () => {
-            expect(atSpaceRoot().cd("board")).toEqual({
+            expect(moved(atSpaceRoot(), "board")).toEqual({
               kind: "refused",
               reason: "A space root lists facets, and `board` names none. " +
                 "The facets are `slugs/` and `pieces/`.",
@@ -1165,7 +1496,7 @@ describe("place", () => {
           });
 
           it("moves to a piece named inside a facet", () => {
-            expect(inSlugs().cd("board")).toEqual({
+            expect(moved(inSlugs(), "board")).toEqual({
               kind: "moved",
               place: {
                 position: {
@@ -1183,7 +1514,7 @@ describe("place", () => {
             // Relayed: `validatePieceSegment`'s own sentence, which the walk
             // calls rather than copies.
 
-            expect(inSlugs().cd("Board")).toEqual({
+            expect(moved(inSlugs(), "Board")).toEqual({
               kind: "refused",
               reason: '"Board" is not a slug: a slug is lowercase letters, ' +
                 "numbers, and single hyphens between words.",
@@ -1195,12 +1526,14 @@ describe("place", () => {
             // vocabularies whichever door reached it, so a name a listing
             // cannot print as an operand is one no door takes.
 
-            expect(inSlugs().cd("Board")).toEqual(atSpaceRoot().cd("/Board"));
+            expect(moved(inSlugs(), "Board")).toEqual(
+              moved(atSpaceRoot(), "/Board"),
+            );
           });
 
           it("reads a canonical index inside a piece as a number", () => {
             const place = atPiece();
-            place.cd("topics/3");
+            moved(place, "topics/3");
             expect(place.place.position).toEqual({
               kind: "piece",
               space: SPACE,
@@ -1216,13 +1549,13 @@ describe("place", () => {
             // reference form — which `cd` refuses in turn — out of this
             // one.
 
-            expect(inSlugs().cd("board#argument")).toEqual(
-              atSpaceRoot().cd(`/${HANDLE}#argument`),
+            expect(moved(inSlugs(), "board#argument")).toEqual(
+              moved(atSpaceRoot(), `/${HANDLE}#argument`),
             );
           });
 
           it("refuses any other fragment for carrying no suffix at all", () => {
-            expect(inSlugs().cd("board#result")).toEqual({
+            expect(moved(inSlugs(), "board#result")).toEqual({
               kind: "refused",
               reason: 'Unknown suffix "#result". The one supported suffix ' +
                 'is "#argument", which selects the piece\'s arguments cell ' +
@@ -1236,13 +1569,13 @@ describe("place", () => {
             // pinning them equal makes a reword that moves one and not the
             // other fail here rather than diverge quietly.
 
-            expect(inSlugs().cd("board#result")).toEqual(
-              atSpaceRoot().cd(`/${HANDLE}#result`),
+            expect(moved(inSlugs(), "board#result")).toEqual(
+              moved(atSpaceRoot(), `/${HANDLE}#result`),
             );
           });
 
           it("names the whole fragment, not the part before a second `#`", () => {
-            expect(inSlugs().cd("board#argument#x")).toEqual({
+            expect(moved(inSlugs(), "board#argument#x")).toEqual({
               kind: "refused",
               reason: 'Unknown suffix "#argument#x". The one supported ' +
                 'suffix is "#argument", which selects the piece\'s ' +
@@ -1251,7 +1584,7 @@ describe("place", () => {
           });
 
           it("refuses a facet segment carrying a fragment for naming no facet", () => {
-            expect(atSpaceRoot().cd("slugs#argument")).toEqual({
+            expect(moved(atSpaceRoot(), "slugs#argument")).toEqual({
               kind: "refused",
               reason: "A space root lists facets, and `slugs#argument` " +
                 "names none. The facets are `slugs/` and `pieces/`.",
@@ -1260,7 +1593,7 @@ describe("place", () => {
 
           it("reads `#` inside a piece as part of a data key", () => {
             const place = atPiece();
-            place.cd("topics#argument");
+            moved(place, "topics#argument");
             expect(place.place.position).toEqual({
               kind: "piece",
               space: SPACE,
@@ -1271,7 +1604,7 @@ describe("place", () => {
 
           it("reads `@` inside a segment as part of a data key", () => {
             const place = atPiece();
-            place.cd("mail@example");
+            moved(place, "mail@example");
             expect(place.place.position).toEqual({
               kind: "piece",
               space: SPACE,
@@ -1280,11 +1613,117 @@ describe("place", () => {
             });
           });
 
-          it("refuses a leading `@` inside a piece, reading it as a scope word", () => {
-            expect(atPiece().cd("@foo")).toEqual({
+          it("moves to the position itself for `.`", () => {
+            // The context's own cell, and the head a qualifier hangs off. It
+            // needs a reading of its own for `.@scope` to have one.
+
+            const place = atPiece();
+            moved(place, "topics");
+            const before = place.place;
+            expect(moved(place, ".")).toEqual({ kind: "moved", place: before });
+            expect(place.place).toEqual(before);
+          });
+
+          it("reads `./items@user` as the key `items@user`", () => {
+            // The head governs what follows it rather than standing as a
+            // segment, so the `@` here sits on `items` and is data. This is
+            // the operand the one-meaning rule is stated on.
+
+            const place = atReferencedPiece();
+            moved(place, "./items@user");
+            expect(place.place.position).toEqual({
+              kind: "piece",
+              space: SPACE,
+              piece: HANDLE,
+              path: ["items@user"],
+            });
+            expect(place.place.scope).toBe("space");
+          });
+
+          it("reads `./items` as the member, not as a walk through a key", () => {
+            const place = atReferencedPiece();
+            moved(place, "./items");
+            expect(place.place.position).toEqual({
+              kind: "piece",
+              space: SPACE,
+              piece: HANDLE,
+              path: ["items"],
+            });
+          });
+
+          it("reaches a key named `.` through the head, and by what a listing offers", () => {
+            // What the head costs: a key named `.` has no bare spelling, the
+            // trade `..`, `-` and `/` already make here. It keeps two
+            // spellings — the head, and the reference a listing prints for it,
+            // which is what makes every name a listing prints one `cd` takes.
+
+            const place = atReferencedPiece();
+            moved(place, "./.");
+            expect(place.place.position).toEqual({
+              kind: "piece",
+              space: SPACE,
+              piece: HANDLE,
+              path: ["."],
+            });
+
+            const offered = operandForChild(atReferencedPiece().place, ".");
+            expect(offered).toBeDefined();
+            expect(offered).not.toBe(".");
+            const elsewhere = atReferencedPiece();
+            moved(elsewhere, offered as string);
+            expect(elsewhere.place).toEqual(place.place);
+          });
+
+          it("reads a bare `@session` as a key, `@` being data off the head", () => {
+            // The whole of what makes `@` one meaning: everywhere but on the
+            // `.` head it is an ordinary character, so a key called
+            // `@session` is reached by typing it.
+
+            const place = atReferencedPiece();
+            moved(place, "@session");
+            expect(place.place.position).toEqual({
+              kind: "piece",
+              space: SPACE,
+              piece: HANDLE,
+              path: ["@session"],
+            });
+            expect(place.place.scope).toBe("space");
+          });
+
+          it("offers the `.@` spelling where a bare scope word names no facet", () => {
+            expect(moved(atSpaceRoot(), "@session")).toEqual({
               kind: "refused",
-              reason: "`@foo` names no scope. The scopes are `@space`, " +
-                "`@user`, and `@session`.",
+              reason: "A space root lists facets, and `@session` names none. " +
+                "The facets are `slugs/` and `pieces/`. `.@session` is what " +
+                "moves the scope.",
+            });
+          });
+
+          it("offers it where a bare scope word names no piece", () => {
+            expect(moved(inSlugs(), "@user")).toEqual({
+              kind: "refused",
+              reason: "`@user` names no piece. A qualifier rides a piece id, " +
+                "and a facet holds pieces rather than keys. `.@user` is what " +
+                "moves the scope.",
+            });
+          });
+
+          it("offers it for no word that is not a scope", () => {
+            // The hint is the scope words and nothing wider: a bare `@thing`
+            // is a name that missed, and there is no `.@thing` to suggest.
+
+            expect(moved(atSpaceRoot(), "@thing")).toEqual({
+              kind: "refused",
+              reason: "A space root lists facets, and `@thing` names none. " +
+                "The facets are `slugs/` and `pieces/`.",
+            });
+          });
+
+          it("refuses a `.@` head naming no scope, wherever it stands", () => {
+            expect(moved(atPiece(), ".@foo")).toEqual({
+              kind: "refused",
+              reason: "`.@foo` names no scope. The scopes are `.@space`, " +
+                "`.@user`, and `.@session`.",
             });
           });
 
@@ -1300,7 +1739,7 @@ describe("place", () => {
             // that is the spelling `operandForChild` offers for it.
 
             const place = atReferencedPiece();
-            place.cd("a~1b");
+            moved(place, "a~1b");
             expect(place.place.position).toEqual({
               kind: "piece",
               space: SPACE,
@@ -1311,7 +1750,7 @@ describe("place", () => {
 
           it("splits at every `/`, giving two keys rather than one holding it", () => {
             const place = atReferencedPiece();
-            place.cd("a/b");
+            moved(place, "a/b");
             expect(place.place.position).toEqual({
               kind: "piece",
               space: SPACE,
@@ -1330,7 +1769,7 @@ describe("place", () => {
 
             it("reads `-` as a data key in a later segment", () => {
               const place = atReferencedPiece();
-              place.cd("a/-");
+              moved(place, "a/-");
               expect(place.place.position).toEqual({
                 kind: "piece",
                 space: SPACE,
@@ -1341,7 +1780,7 @@ describe("place", () => {
 
             it("reads `@foo` as a data key in a later segment", () => {
               const place = atReferencedPiece();
-              place.cd("a/@foo");
+              moved(place, "a/@foo");
               expect(place.place.position).toEqual({
                 kind: "piece",
                 space: SPACE,
@@ -1352,7 +1791,7 @@ describe("place", () => {
 
             it("reads `#b` as a data key in a later segment", () => {
               const place = atReferencedPiece();
-              place.cd("a/#b");
+              moved(place, "a/#b");
               expect(place.place.position).toEqual({
                 kind: "piece",
                 space: SPACE,
@@ -1367,7 +1806,7 @@ describe("place", () => {
               // named `-` is spellable first and those two are not.
 
               const place = atReferencedPiece();
-              place.cd("-/b");
+              moved(place, "-/b");
               expect(place.place.position).toEqual({
                 kind: "piece",
                 space: SPACE,
@@ -1384,7 +1823,7 @@ describe("place", () => {
               // it the character the writer meant.
 
               const place = atReferencedPiece();
-              place.cd(" -");
+              moved(place, " -");
               expect(place.place.position).toEqual({
                 kind: "piece",
                 space: SPACE,
@@ -1395,7 +1834,7 @@ describe("place", () => {
 
             it("reads `@user` as a data key where whitespace precedes it", () => {
               const place = atReferencedPiece();
-              place.cd(" @user");
+              moved(place, " @user");
               expect(place.place.position).toEqual({
                 kind: "piece",
                 space: SPACE,
@@ -1406,7 +1845,7 @@ describe("place", () => {
 
             it("reads `#favorites` as a data key where whitespace precedes it", () => {
               const place = atReferencedPiece();
-              place.cd(" #favorites");
+              moved(place, " #favorites");
               expect(place.place.position).toEqual({
                 kind: "piece",
                 space: SPACE,
@@ -1416,15 +1855,16 @@ describe("place", () => {
             });
 
             it("refuses `/` where whitespace precedes it, rather than reading it as the space root", () => {
-              // Relayed: the canonical layer's sentence, not shuttle's. The
-              // space-root reading is the operand exactly, so `" /"` falls
-              // through to the reference grammar, which is the door that
-              // reports it.
+              // The space-root reading is the operand exactly, so `" /"` is
+              // not it. What the operand is instead is rooted only once its
+              // edge comes off, and shuttle refuses that rather than letting
+              // the reference grammar trim it into a reading of its own.
 
-              expect(atReferencedPiece().cd(" /")).toEqual({
+              expect(moved(atReferencedPiece(), " /")).toEqual({
                 kind: "refused",
-                reason: "Target must include a piece handle, e.g. " +
-                  '"/of:fid1:abc123/path".',
+                reason: "` /` is rooted only with its leading whitespace " +
+                  "taken off, and the two readings name different cells. " +
+                  "`/` is the one that reaches the place it names.",
               });
             });
 
@@ -1434,7 +1874,7 @@ describe("place", () => {
               // the only spelling a key named `..` has.
 
               const place = atSpaceRoot();
-              place.cd(`/${HANDLE}/..`);
+              moved(place, `/${HANDLE}/..`);
               expect(place.place.position).toEqual({
                 kind: "piece",
                 space: SPACE,
@@ -1445,7 +1885,7 @@ describe("place", () => {
 
             it("reads `..` as a level to leave in a later segment", () => {
               const place = atReferencedPiece();
-              place.cd("a/..");
+              moved(place, "a/..");
               expect(place.place.position).toEqual({
                 kind: "piece",
                 space: SPACE,
@@ -1457,7 +1897,7 @@ describe("place", () => {
 
           it("walks every level of a multi-segment operand", () => {
             const place = atSpaceRoot();
-            place.cd("slugs/board/topics/3");
+            moved(place, "slugs/board/topics/3");
             expect(place.place.position).toEqual({
               kind: "piece",
               space: SPACE,
@@ -1468,7 +1908,7 @@ describe("place", () => {
 
           it("ignores a trailing slash", () => {
             const place = atSpaceRoot();
-            place.cd("slugs/");
+            moved(place, "slugs/");
             expect(place.place.position).toEqual({
               kind: "facet",
               space: SPACE,
@@ -1482,7 +1922,7 @@ describe("place", () => {
             // at the operand's own edge answers to the same rule, under
             // `whitespace at an operand's edges` below.
 
-            expect(atReferencedPiece().cd("a /b")).toEqual({
+            expect(moved(atReferencedPiece(), "a /b")).toEqual({
               kind: "refused",
               reason: "`a /b` has a segment ending in whitespace, so a " +
                 "rendering of the place would name a different cell.",
@@ -1496,7 +1936,7 @@ describe("place", () => {
             // suffix stands between it and the trim — so it must not be
             // told that it does.
 
-            expect(inSlugs().cd("board /x")).toEqual({
+            expect(moved(inSlugs(), "board /x")).toEqual({
               kind: "refused",
               reason: "`board /x` has a piece ending in whitespace, so no " +
                 "piece carries that name: a slug is lowercase letters, " +
@@ -1510,7 +1950,7 @@ describe("place", () => {
             // the piece rule and told the piece's reason. A segment is
             // faulted by what it is about to become, not by its position.
 
-            expect(atSpaceRoot().cd("slugs//board")).toEqual({
+            expect(moved(atSpaceRoot(), "slugs//board")).toEqual({
               kind: "refused",
               reason: "`slugs//board` has an empty piece, so no piece " +
                 "carries that name: a slug is lowercase letters, numbers, " +
@@ -1528,7 +1968,7 @@ describe("place", () => {
             // one position stripping the operand would strip a name.
 
             it("refuses a key ending in whitespace", () => {
-              expect(atReferencedPiece().cd("board ")).toEqual({
+              expect(moved(atReferencedPiece(), "board ")).toEqual({
                 kind: "refused",
                 reason: "`board ` has a segment ending in whitespace, so a " +
                   "rendering of the place would name a different cell.",
@@ -1536,7 +1976,7 @@ describe("place", () => {
             });
 
             it("refuses a key ending in a tab", () => {
-              expect(atReferencedPiece().cd("board\t")).toEqual({
+              expect(moved(atReferencedPiece(), "board\t")).toEqual({
                 kind: "refused",
                 reason: "`board\t` has a segment ending in whitespace, so a " +
                   "rendering of the place would name a different cell.",
@@ -1544,7 +1984,7 @@ describe("place", () => {
             });
 
             it("refuses a key padded on both sides", () => {
-              expect(atReferencedPiece().cd(" board ")).toEqual({
+              expect(moved(atReferencedPiece(), " board ")).toEqual({
                 kind: "refused",
                 reason: "` board ` has a segment ending in whitespace, so a " +
                   "rendering of the place would name a different cell.",
@@ -1557,7 +1997,7 @@ describe("place", () => {
               // such a key. The trailing edge is the one a rendering loses.
 
               const place = atReferencedPiece();
-              place.cd(" board");
+              moved(place, " board");
               expect(place.place.position).toEqual({
                 kind: "piece",
                 space: SPACE,
@@ -1571,7 +2011,7 @@ describe("place", () => {
               // are the same characters, which is the whole of what makes
               // this case different from `a /b` above.
 
-              expect(atReferencedPiece().cd("a/b ")).toEqual({
+              expect(moved(atReferencedPiece(), "a/b ")).toEqual({
                 kind: "refused",
                 reason: "`a/b ` has a segment ending in whitespace, so a " +
                   "rendering of the place would name a different cell.",
@@ -1579,7 +2019,7 @@ describe("place", () => {
             });
 
             it("refuses an operand that is only whitespace inside a piece", () => {
-              expect(atReferencedPiece().cd(" ")).toEqual({
+              expect(moved(atReferencedPiece(), " ")).toEqual({
                 kind: "refused",
                 reason: "` ` has a segment ending in whitespace, so a " +
                   "rendering of the place would name a different cell.",
@@ -1587,7 +2027,7 @@ describe("place", () => {
             });
 
             it("refuses a piece ending in whitespace", () => {
-              expect(inSlugs().cd("board ")).toEqual({
+              expect(moved(inSlugs(), "board ")).toEqual({
                 kind: "refused",
                 reason:
                   "`board ` has a piece ending in whitespace, so no piece " +
@@ -1598,7 +2038,7 @@ describe("place", () => {
             });
 
             it("refuses a piece ending in a tab", () => {
-              expect(inSlugs().cd("board\t")).toEqual({
+              expect(moved(inSlugs(), "board\t")).toEqual({
                 kind: "refused",
                 reason:
                   "`board\t` has a piece ending in whitespace, so no piece " +
@@ -1609,7 +2049,7 @@ describe("place", () => {
             });
 
             it("refuses a piece padded on both sides", () => {
-              expect(inSlugs().cd(" board ")).toEqual({
+              expect(moved(inSlugs(), " board ")).toEqual({
                 kind: "refused",
                 reason:
                   "` board ` has a piece ending in whitespace, so no piece " +
@@ -1625,7 +2065,7 @@ describe("place", () => {
               // is the vocabulary rather than the rendering rule — a
               // different reason from the one the same edge gets on a key.
 
-              expect(inSlugs().cd(" board")).toEqual({
+              expect(moved(inSlugs(), " board")).toEqual({
                 kind: "refused",
                 reason: '" board" is not a slug: a slug is lowercase ' +
                   "letters, numbers, and single hyphens between words.",
@@ -1633,7 +2073,7 @@ describe("place", () => {
             });
 
             it("refuses an operand that is only whitespace inside a facet", () => {
-              expect(inSlugs().cd(" ")).toEqual({
+              expect(moved(inSlugs(), " ")).toEqual({
                 kind: "refused",
                 reason: "` ` has a piece ending in whitespace, so no piece " +
                   "carries that name: a slug is lowercase letters, numbers, " +
@@ -1643,7 +2083,7 @@ describe("place", () => {
             });
 
             it("refuses a facet name ending in whitespace", () => {
-              expect(atSpaceRoot().cd("slugs ")).toEqual({
+              expect(moved(atSpaceRoot(), "slugs ")).toEqual({
                 kind: "refused",
                 reason: "A space root lists facets, and `slugs ` names none. " +
                   "The facets are `slugs/` and `pieces/`.",
@@ -1655,7 +2095,7 @@ describe("place", () => {
         describe("`..`", () => {
           it("stays at the space root", () => {
             const place = atSpaceRoot();
-            expect(place.cd("..")).toEqual({
+            expect(moved(place, "..")).toEqual({
               kind: "moved",
               place: placeAtSpaceRoot(SPACE),
             });
@@ -1663,8 +2103,8 @@ describe("place", () => {
 
           it("walks out one level per `..`", () => {
             const place = atPiece();
-            place.cd("..");
-            place.cd("..");
+            moved(place, "..");
+            moved(place, "..");
             expect(place.place.position).toEqual({
               kind: "root",
               space: SPACE,
@@ -1673,14 +2113,14 @@ describe("place", () => {
 
           it("keeps the scope backing out of a piece a reference named", () => {
             const place = atSpaceRoot();
-            place.cd(`/${HANDLE}@user`);
-            place.cd("..");
+            moved(place, `/${HANDLE}@user`);
+            moved(place, "..");
             expect(place.place.scope).toBe("user");
           });
 
           it("moves from a facet to the space root", () => {
             const place = inSlugs();
-            place.cd("..");
+            moved(place, "..");
             expect(place.place.position).toEqual({
               kind: "root",
               space: SPACE,
@@ -1689,8 +2129,8 @@ describe("place", () => {
 
           it("drops the last path segment inside a piece", () => {
             const place = atPiece();
-            place.cd("topics/3");
-            place.cd("..");
+            moved(place, "topics/3");
+            moved(place, "..");
             expect(place.place.position).toEqual({
               kind: "piece",
               space: SPACE,
@@ -1701,7 +2141,7 @@ describe("place", () => {
 
           it("moves from a piece back out to the facet it came through", () => {
             const place = atPiece();
-            place.cd("..");
+            moved(place, "..");
             expect(place.place.position).toEqual({
               kind: "facet",
               space: SPACE,
@@ -1711,8 +2151,8 @@ describe("place", () => {
 
           it("drops a path segment inside a piece a reference named", () => {
             const place = atSpaceRoot();
-            place.cd(`/${HANDLE}/topics/3`);
-            place.cd("..");
+            moved(place, `/${HANDLE}/topics/3`);
+            moved(place, "..");
             expect(place.place.position).toEqual({
               kind: "piece",
               space: SPACE,
@@ -1723,8 +2163,8 @@ describe("place", () => {
 
           it("moves from a piece a reference named to the space root", () => {
             const place = atSpaceRoot();
-            place.cd(`/${HANDLE}`);
-            place.cd("..");
+            moved(place, `/${HANDLE}`);
+            moved(place, "..");
             expect(place.place.position).toEqual({
               kind: "root",
               space: SPACE,
@@ -1733,8 +2173,8 @@ describe("place", () => {
 
           it("keeps the scope while the position moves", () => {
             const place = atPiece();
-            place.cd("@session");
-            place.cd("..");
+            moved(place, ".@session");
+            moved(place, "..");
             expect(place.place.scope).toBe("session");
           });
         });
@@ -1797,7 +2237,7 @@ describe("place", () => {
             input: true,
             move: pointsAt(inSlugs(), "board"),
           });
-          expect(inSlugs().cd("board#argument").kind).toBe("refused");
+          expect(moved(inSlugs(), "board#argument").kind).toBe("refused");
         });
 
         it("reads the suffix off a rooted reference", () => {
@@ -1959,7 +2399,7 @@ describe("place", () => {
           const entered = atSpaceRoot();
           entered.enter({ space: SPACE, piece: HANDLE, path: ["3"] }, "#x");
           const referenced = atSpaceRoot();
-          referenced.cd(`/${HANDLE}/3`);
+          moved(referenced, `/${HANDLE}/3`);
           expect(entered.place).toEqual(referenced.place);
           expect(entered.place.position).toEqual({
             kind: "piece",
@@ -1972,7 +2412,7 @@ describe("place", () => {
         it("carries no route, so `..` lands on the piece it entered", () => {
           const entered = atSpaceRoot();
           entered.enter({ space: SPACE, piece: HANDLE, path: ["3"] }, "#x");
-          entered.cd("..");
+          moved(entered, "..");
           expect(entered.place.position).toEqual({
             kind: "piece",
             space: SPACE,
@@ -2109,7 +2549,7 @@ describe("place", () => {
           // through.
 
           const place = atSpaceRoot();
-          place.cd("@session");
+          moved(place, ".@session");
           place.enter({ space: SPACE, piece: HANDLE }, "#favorites");
           expect(place.place.scope).toBe("session");
         });
@@ -2133,14 +2573,175 @@ describe("place", () => {
           place.enter({ space: OTHER_SPACE, piece: HANDLE }, "#profile");
           expect(place.place).toEqual(placeAtSpaceRoot(SPACE));
         });
+
+        it("refuses a target naming its piece by slug", () => {
+          // A place holds the handle a name resolved to, and this door is the
+          // one that lands a piece without resolving anything — the fabric
+          // resolved the target already. So the address it hands over has to
+          // carry a handle, and a slug in that slot is refused rather than
+          // adopted as a piece the index could repoint.
+
+          expect(
+            atSpaceRoot().enter(
+              { space: SPACE, piece: "board", path: ["title"] },
+              "#favorites",
+            ),
+          ).toEqual({
+            kind: "refused",
+            reason: "`#favorites` resolves to slug `board`, and a place " +
+              "holds the handle a name resolved to. An address the fabric " +
+              "wrote names its piece by handle.",
+          });
+        });
+      });
+
+      describe("confirm()", () => {
+        // The door a read comes back through. What it lands is the handle,
+        // and what it leaves beside it is the name the operand spelled — the
+        // two differing exactly where a slug resolved, since a handle
+        // resolves to itself.
+
+        /** The handle the space's index points the slug `board` at. */
+        const BOARD = "of:fid1:qrstuvwxyz012345";
+
+        /**
+         * Helper for the cases below, which is what a resolution answering
+         * with `piece` and spending no path segment hands back: the move's own
+         * path, which is what a plain slug or a handle resolves to. A
+         * resolution that spends a segment is a collection slug, and has cases
+         * of its own.
+         */
+        function resolving(move: PendingMove, piece: string): ResolvedPlace {
+          return { piece, path: move.place.position.path };
+        }
+
+        /**
+         * Helper for the cases below, which moves `operand` and lands it with
+         * such a resolution.
+         */
+        function confirming(
+          place: CurrentPlace,
+          operand: string,
+          piece: string,
+        ): Move {
+          const move = pending(place, operand);
+          return place.confirm(move, resolving(move, piece));
+        }
+
+        /**
+         * Helper for the cases below, which is the move `operand` came back
+         * with, and fails the case where it came back landed instead.
+         */
+        function pending(place: CurrentPlace, operand: string): PendingMove {
+          const move = place.cd(operand);
+          if (move.kind !== "pending") {
+            throw new Error(`\`${operand}\` came back ${move.kind}`);
+          }
+          return move;
+        }
+
+        it("lands the handle the piece resolved to, with the slug as the name", () => {
+          const place = inSlugs();
+          expect(confirming(place, "board", BOARD))
+            .toEqual({
+              kind: "moved",
+              place: {
+                position: {
+                  kind: "piece",
+                  space: SPACE,
+                  piece: BOARD,
+                  name: "board",
+                  path: [],
+                },
+                scope: "space",
+              },
+            });
+        });
+
+        it("leaves no name where the operand named the piece by handle", () => {
+          const place = atSpaceRoot();
+          confirming(place, `/${HANDLE}`, HANDLE);
+          expect(place.place.position).toEqual({
+            kind: "piece",
+            space: SPACE,
+            piece: HANDLE,
+            path: [],
+          });
+        });
+
+        it("lands the route, so `..` backs out the way the walk came", () => {
+          const place = inSlugs();
+          confirming(place, "board", BOARD);
+          moved(place, "..");
+          expect(place.place.position).toEqual({
+            kind: "facet",
+            space: SPACE,
+            facet: "slugs",
+          });
+        });
+
+        it("keeps the name through a descent inside the piece", () => {
+          const place = inSlugs();
+          confirming(place, "board", BOARD);
+          confirming(place, "topics", BOARD);
+          expect(place.place.position).toEqual({
+            kind: "piece",
+            space: SPACE,
+            piece: BOARD,
+            name: "board",
+            path: ["topics"],
+          });
+        });
+
+        it("writes the name in the prompt and the handle in the address", () => {
+          // Decision 13 read as two renderings: the prompt shows a name an
+          // index confirmed, and `pwd` is what to copy, so it writes the
+          // handle every read goes to.
+
+          const place = inSlugs();
+          confirming(place, "board", BOARD);
+          expect(place.label()).toBe("board @space");
+          expect(printedPosition(place)).toBe(
+            `/@${SPACE}/${BOARD}@space`,
+          );
+        });
+
+        it("refuses a piece in neither vocabulary, and moves nowhere", () => {
+          // Relayed: `validatePieceSegment`'s own sentence. The handle came
+          // from the fabric rather than from an operand, and this door holds
+          // it to what every other door holds a piece to.
+
+          const place = inSlugs();
+          const facet = place.place;
+          expect(confirming(place, "board", "Board"))
+            .toEqual({
+              kind: "refused",
+              reason: '"Board" is not a slug: a slug is lowercase letters, ' +
+                "numbers, and single hyphens between words.",
+            });
+          expect(place.place).toBe(facet);
+        });
+
+        it("refuses a piece no rendering would name back", () => {
+          const place = inSlugs();
+          expect(
+            confirming(place, "board", `${HANDLE} `),
+          ).toEqual({
+            kind: "refused",
+            reason: "`board` resolves to a piece ending in whitespace, so no " +
+              "piece carries that name: a slug is lowercase letters, " +
+              "numbers, and single hyphens between words, and a handle is " +
+              "`of:fid1:` and unpadded base64url.",
+          });
+        });
       });
 
       describe("settle()", () => {
         it("builds the place from the connected space", () => {
           const place = atSpaceRoot();
-          const move = place.cd(`/@estuary/${HANDLE}/title`);
+          const move = moved(place, `/@estuary/${HANDLE}/title`);
           if (move.kind !== "space-by-name") throw new Error("not handed on");
-          expect(place.settle(move, SPACE)).toEqual({
+          expect(landed(place, place.settle(move, SPACE))).toEqual({
             kind: "moved",
             place: {
               position: {
@@ -2156,9 +2757,9 @@ describe("place", () => {
 
         it("keeps the scope a space-named reference asked for", () => {
           const place = atSpaceRoot();
-          const move = place.cd(`/@estuary/${HANDLE}@user`);
+          const move = moved(place, `/@estuary/${HANDLE}@user`);
           if (move.kind !== "space-by-name") throw new Error("not handed on");
-          place.settle(move, SPACE);
+          landed(place, place.settle(move, SPACE));
           expect(place.place.scope).toBe("user");
         });
 
@@ -2169,9 +2770,9 @@ describe("place", () => {
           // the caller's to supply and this module's to check.
 
           const place = atSpaceRoot();
-          const move = place.cd(`/@estuary/${HANDLE}`);
+          const move = moved(place, `/@estuary/${HANDLE}`);
           if (move.kind !== "space-by-name") throw new Error("not handed on");
-          expect(place.settle(move, OTHER_SPACE)).toEqual({
+          expect(landed(place, place.settle(move, OTHER_SPACE))).toEqual({
             kind: "refused",
             reason: "`estuary` resolves to space `did:key:z6MkOtherSpace`, " +
               "and this shuttle is connected to " +
@@ -2188,13 +2789,17 @@ describe("place", () => {
           // a move arrives on.
 
           const place = atSpaceRoot();
-          place.settle({
-            kind: "space-by-name",
-            name: "estuary",
-            piece: HANDLE,
-            path: [3],
-            scope: "space",
-          }, SPACE);
+          landed(
+            place,
+            place.settle({
+              kind: "space-by-name",
+              name: "estuary",
+              operand: `/@estuary/${HANDLE}`,
+              piece: HANDLE,
+              path: [3],
+              scope: "space",
+            }, SPACE),
+          );
           expect(place.place.position).toEqual({
             kind: "piece",
             space: SPACE,
@@ -2210,13 +2815,17 @@ describe("place", () => {
           // a path arrives.
 
           const place = atSpaceRoot();
-          expect(place.settle({
-            kind: "space-by-name",
-            name: "estuary",
-            piece: HANDLE,
-            path: [1.5],
-            scope: "space",
-          }, SPACE)).toEqual({
+          expect(landed(
+            place,
+            place.settle({
+              kind: "space-by-name",
+              name: "estuary",
+              operand: `/@estuary/${HANDLE}`,
+              piece: HANDLE,
+              path: [1.5],
+              scope: "space",
+            }, SPACE),
+          )).toEqual({
             kind: "refused",
             reason: "The reference naming space `estuary` has a segment " +
               "that is no canonical index, so a rendering of the place " +
@@ -2231,13 +2840,17 @@ describe("place", () => {
           // `enter` builds one from a resolved target.
 
           const place = atSpaceRoot();
-          expect(place.settle({
-            kind: "space-by-name",
-            name: "estuary",
-            piece: HANDLE,
-            path: ["a "],
-            scope: "space",
-          }, SPACE)).toEqual({
+          expect(landed(
+            place,
+            place.settle({
+              kind: "space-by-name",
+              name: "estuary",
+              operand: `/@estuary/${HANDLE}`,
+              piece: HANDLE,
+              path: ["a "],
+              scope: "space",
+            }, SPACE),
+          )).toEqual({
             kind: "refused",
             reason: `The reference naming space \`estuary\` has a segment ` +
               `ending in whitespace, so a rendering of the place would name a different cell.`,
@@ -2252,13 +2865,17 @@ describe("place", () => {
           // given, and this door holds that to them too.
 
           const place = atSpaceRoot();
-          expect(place.settle({
-            kind: "space-by-name",
-            name: "estuary",
-            piece: "Board",
-            path: [],
-            scope: "space",
-          }, SPACE)).toEqual({
+          expect(landed(
+            place,
+            place.settle({
+              kind: "space-by-name",
+              name: "estuary",
+              operand: `/@estuary/${HANDLE}`,
+              piece: "Board",
+              path: [],
+              scope: "space",
+            }, SPACE),
+          )).toEqual({
             kind: "refused",
             reason: '"Board" is not a slug: a slug is lowercase letters, ' +
               "numbers, and single hyphens between words.",
@@ -2268,10 +2885,10 @@ describe("place", () => {
 
         it("carries no route, so `..` leaves the piece for the root", () => {
           const place = inSlugs();
-          const move = place.cd(`/@estuary/${HANDLE}`);
+          const move = moved(place, `/@estuary/${HANDLE}`);
           if (move.kind !== "space-by-name") throw new Error("not handed on");
-          place.settle(move, SPACE);
-          place.cd("..");
+          landed(place, place.settle(move, SPACE));
+          moved(place, "..");
           expect(place.place.position).toEqual({
             kind: "root",
             space: SPACE,
@@ -2282,7 +2899,7 @@ describe("place", () => {
       describe("render()", () => {
         it("returns both halves of the place it stands at", () => {
           const place = atPiece();
-          place.cd("topics/3");
+          moved(place, "topics/3");
           expect(place.render()).toBe(
             "position  /@did:key:z6MkConnectedSpace/board@space/topics/3\n" +
               "scope     @space",

--- a/packages/cli/test/shuttle-prompt.test.ts
+++ b/packages/cli/test/shuttle-prompt.test.ts
@@ -21,6 +21,7 @@ import type { SpaceConfig } from "../lib/piece.ts";
 import { safeStringify } from "../lib/render.ts";
 import { HeldConnection } from "../lib/shuttle/connection.ts";
 import { CurrentPlace } from "../lib/shuttle/place.ts";
+import { moved } from "./shuttle-place-helpers.ts";
 import { type PromptTerminal, runPrompt } from "../lib/shuttle/prompt.ts";
 import type { Shuttle, VerbDeps } from "../lib/shuttle/verbs.ts";
 import type { Key } from "../lib/view/keys.ts";
@@ -63,7 +64,7 @@ function shuttleIn(): Shuttle {
 /** Helper for the cases below, which stands a shuttle at a piece. */
 function atPiece(): Shuttle {
   const shuttle = shuttleIn();
-  shuttle.place.cd(`/${HANDLE}`);
+  moved(shuttle.place, `/${HANDLE}`);
   return shuttle;
 }
 

--- a/packages/cli/test/shuttle-verbs.test.ts
+++ b/packages/cli/test/shuttle-verbs.test.ts
@@ -26,6 +26,7 @@ import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
 
 import type { MemorySpace } from "@commonfabric/memory/interface";
+import { SlugResolutionError } from "@commonfabric/piece";
 import type { PiecesController } from "@commonfabric/piece/ops";
 
 import { LINK_MARKER_KEY } from "../lib/cell-selection.ts";
@@ -36,6 +37,7 @@ import type {
 } from "../lib/piece.ts";
 import { HeldConnection } from "../lib/shuttle/connection.ts";
 import { CurrentPlace, operandForChild } from "../lib/shuttle/place.ts";
+import { moved } from "./shuttle-place-helpers.ts";
 import {
   type Outcome,
   runLine,
@@ -47,6 +49,9 @@ import type { WishReadConfig } from "../lib/wish.ts";
 const SPACE = "did:key:z6MkConnectedSpace" as MemorySpace;
 const OTHER_SPACE = "did:key:z6MkHomeSpace" as MemorySpace;
 const HANDLE = "of:fid1:abcdefghijklmnop";
+
+/** The handle the space's index points the slug `board` at. */
+const BOARD = "of:fid1:qrstuvwxyz012345";
 
 const CONFIG: SpaceConfig = {
   apiUrl: "https://toolshed.example/",
@@ -75,6 +80,26 @@ function controller(
     dispose: () => Promise.resolve(),
     getSpace: () => space,
     getSpaceName: () => name,
+    entityIdExists: () => Promise.resolve(true),
+  } as unknown as PiecesController;
+}
+
+/**
+ * Helper for the cases below, which is a controller whose space answers
+ * `holds` when a handle is looked up in it.
+ *
+ * The three answers are the lookup's own: `true` where the space holds the
+ * piece, `false` where it does not, and `undefined` where the server does not
+ * advertise the lookup and so says nothing either way. It takes no default for
+ * the reason {@link controller}'s `name` takes none — `undefined` is one of
+ * the answers rather than the absence of one.
+ */
+function lookingUp(holds: boolean | undefined): PiecesController {
+  return {
+    dispose: () => Promise.resolve(),
+    getSpace: () => SPACE,
+    getSpaceName: () => SPACE_NAME,
+    entityIdExists: () => Promise.resolve(holds),
   } as unknown as PiecesController;
 }
 
@@ -88,6 +113,9 @@ const READS_NOTHING: VerbDeps = {
   },
   readWish: () => {
     throw new Error("A wish was resolved.");
+  },
+  resolvePieceReference: () => {
+    throw new Error("A piece was resolved.");
   },
   listing: {
     listSpaceSlugs: () => {
@@ -117,14 +145,113 @@ function shuttleIn(pieces: PiecesController = PIECES): Shuttle {
 /** Helper for the cases below, which stands at a piece, at `path` inside it. */
 function atPiece(...path: string[]): Shuttle {
   const shuttle = shuttleIn();
-  shuttle.place.cd(`/${HANDLE}`);
-  for (const segment of path) shuttle.place.cd(segment);
+  moved(shuttle.place, `/${HANDLE}`);
+  for (const segment of path) moved(shuttle.place, segment);
   return shuttle;
 }
 
 /** Helper for the cases below, which stands `value` in for a cell's value. */
 function cellValue(value: unknown): VerbDeps {
   return { ...READS_NOTHING, getCellValue: () => Promise.resolve(value) };
+}
+
+/**
+ * Helper for the cases below, which stands in the two answers a `cd` onto a
+ * piece reads: the piece an address resolves to, and `value` for the cell the
+ * path is checked against.
+ *
+ * `resolves` names the pieces the index points a slug at, and a token it has
+ * no entry for resolves to itself — which is what the fabric does with a
+ * handle, and what makes a case that is not about the resolution read as it
+ * would have before there was one.
+ */
+function settling(
+  value: unknown,
+  resolves: Readonly<Record<string, string>> = {},
+): VerbDeps {
+  return {
+    ...READS_NOTHING,
+    resolvePieceReference: (_pieces, token, path) =>
+      Promise.resolve({
+        piece: resolves[token] ?? token,
+        pathAfter: [...path],
+      }),
+    getCellValue: () => Promise.resolve(value),
+  };
+}
+
+/**
+ * Helper for the cases below, which stands `value` in for the cell a `cd`
+ * checks its path against, and resolves no piece.
+ *
+ * The piece is left unresolved on purpose. A `cd` that spells the piece
+ * shuttle already stands on has none to resolve, so a case standing at one
+ * keeps `READS_NOTHING`'s resolution and fails if the settle reaches for it.
+ * A case that moves onto another piece wants {@link settling} instead.
+ */
+function holding(value: unknown): VerbDeps {
+  return { ...READS_NOTHING, getCellValue: () => Promise.resolve(value) };
+}
+
+/**
+ * Helper for the cases below, which serves a different document per scope and
+ * raises on a path it does not hold, the way a cell read does.
+ *
+ * The raise is the point: `getCellValue` throws where a path is not there
+ * (`resolveCellPath`, `packages/runner/src/piece-helpers.ts`), so a fixture
+ * that answered `undefined` instead would turn the failure a settle exists to
+ * prevent into a quiet refusal and hide it.
+ */
+function atScopes(documents: Record<string, unknown>): VerbDeps {
+  return {
+    ...READS_NOTHING,
+    resolvePieceReference: (_pieces, token, path) =>
+      Promise.resolve({ piece: token, pathAfter: [...path] }),
+    getCellValue: (config, path) => {
+      let at: unknown = documents[config.pieceScope ?? "space"];
+      for (const segment of path) {
+        const key = String(segment);
+        if (at === null || typeof at !== "object" || !(key in at)) {
+          throw new Error(
+            `Cannot access path "${path.join("/")}" - property "${key}" not ` +
+              `found`,
+          );
+        }
+        at = (at as Record<string, unknown>)[key];
+      }
+      return Promise.resolve(at);
+    },
+  };
+}
+
+/**
+ * Helper for the cases below, which resolves `slug` as a collection — its
+ * first path segment selecting the member — and answers a read by walking the
+ * value below, so a walk of more than one segment is answered as the fabric
+ * would answer it rather than by one stub value at every depth.
+ */
+function collectionAt(slug: string): VerbDeps {
+  const value: Record<string, unknown> = {
+    title: "a",
+    topics: { 0: "x" },
+    first: { title: "a" },
+  };
+  return {
+    ...READS_NOTHING,
+    resolvePieceReference: (_pieces, token, path) =>
+      Promise.resolve(
+        token === slug
+          ? { piece: BOARD, pathAfter: [...path].slice(1) }
+          : { piece: token, pathAfter: [...path] },
+      ),
+    getCellValue: (_config, path) => {
+      let at: unknown = value;
+      for (const segment of path) {
+        at = (at as Record<string, unknown> | undefined)?.[String(segment)];
+      }
+      return Promise.resolve(at);
+    },
+  };
 }
 
 /** Helper for the cases below, which stands `keys` in for a cell's keys. */
@@ -337,7 +464,7 @@ describe("verbs", () => {
       const shuttle = atPiece();
       const operand = operandForChild(shuttle.place.place, "-x");
       expect(operand).toBeDefined();
-      await runLine(`cd ${operand}`, shuttle, READS_NOTHING);
+      await runLine(`cd ${operand}`, shuttle, holding({ "-x": 1 }));
       expect(shuttle.place.place.position).toEqual({
         kind: "piece",
         space: SPACE,
@@ -352,7 +479,7 @@ describe("verbs", () => {
       // name; the line below is what a person can type for it either way.
 
       const shuttle = atPiece();
-      await runLine("cd -- --", shuttle, READS_NOTHING);
+      await runLine("cd -- --", shuttle, holding({ "--": 1 }));
       expect(shuttle.place.place.position).toEqual({
         kind: "piece",
         space: SPACE,
@@ -502,7 +629,7 @@ describe("verbs", () => {
       // The asymmetry `get`'s own door turns on: `cd` refuses the suffix in
       // every spelling that takes one, and `get` reads it.
       const shuttle = shuttleIn();
-      shuttle.place.cd("slugs");
+      moved(shuttle.place, "slugs");
       expect(
         reasonOf(await runLine("cd board#argument", shuttle, READS_NOTHING)),
       )
@@ -513,6 +640,743 @@ describe("verbs", () => {
             "addressed. Reach arguments per operand instead, as in " +
             "`get topics/3#argument`.",
         );
+    });
+
+    describe("the read that settles a move", () => {
+      // What makes `cd` a promise. A move onto a piece is asked of the fabric
+      // before the place is adopted — the piece resolved, and the path found —
+      // so the prompt after a `cd` names a place that is there, and a place
+      // that is not there is refused here rather than reported by whichever
+      // verb reads next.
+
+      /** Helper for the cases below, which is a second piece to move onto. */
+      const OTHER = "of:fid1:0123456789abcdef";
+
+      /**
+       * Helper for the cases below, which is where a settle read, and the
+       * piece it read through.
+       */
+      async function read(
+        shuttle: Shuttle,
+        line: string,
+        value: unknown,
+      ): Promise<{ config?: PieceConfig; path?: (string | number)[] }> {
+        const seen: { config?: PieceConfig; path?: (string | number)[] } = {};
+        await runLine(line, shuttle, {
+          ...settling(value),
+          getCellValue: (config, path) => {
+            seen.config = config;
+            seen.path = path;
+            return Promise.resolve(value);
+          },
+        });
+        return seen;
+      }
+
+      it("lands the handle the piece resolved to, with the slug as the name", async () => {
+        const shuttle = shuttleIn();
+        moved(shuttle.place, "slugs");
+        await runLine("cd board", shuttle, settling(null, { board: BOARD }));
+        expect(shuttle.place.place.position).toEqual({
+          kind: "piece",
+          space: SPACE,
+          piece: BOARD,
+          name: "board",
+          path: [],
+        });
+      });
+
+      it("hands the resolution the connection this process holds", async () => {
+        const shuttle = shuttleIn();
+        moved(shuttle.place, "slugs");
+        let asked: unknown;
+        await runLine("cd board", shuttle, {
+          ...READS_NOTHING,
+          resolvePieceReference: (pieces, token, path) => {
+            asked = pieces;
+            return Promise.resolve({ piece: token, pathAfter: [...path] });
+          },
+        });
+        expect(asked).toBe(PIECES);
+      });
+
+      it("refuses a slug the index names nothing for, and moves nowhere", async () => {
+        const shuttle = shuttleIn();
+        moved(shuttle.place, "slugs");
+        const before = shuttle.place.place;
+        const outcome = await runLine("cd todo", shuttle, {
+          ...READS_NOTHING,
+          resolvePieceReference: () => {
+            throw new SlugResolutionError('Slug "todo" not found.', "missing");
+          },
+        });
+        expect(reasonOf(outcome)).toBe(
+          '`todo` reaches no piece: Slug "todo" not found.',
+        );
+        expect(shuttle.place.place).toBe(before);
+      });
+
+      it("raises what a resolution that failed for another reason raised", async () => {
+        // A slug that names nothing is a fact about the line. A connection
+        // that went away is not, and the two have to stay told apart.
+
+        const shuttle = shuttleIn();
+        moved(shuttle.place, "slugs");
+        await expect(runLine("cd todo", shuttle, READS_NOTHING)).rejects
+          .toThrow("A piece was resolved.");
+      });
+
+      it("refuses a handle the space does not hold, and moves nowhere", async () => {
+        // A handle is a spelling and not a lookup, so the resolution hands one
+        // back unread. The space's own index is what tells a piece it holds
+        // from one it does not, where a value read cannot: an absent piece
+        // reads as nothing, and so does an empty one.
+
+        const shuttle = shuttleIn(lookingUp(false));
+        moved(shuttle.place, "pieces");
+        const before = shuttle.place.place;
+        expect(reasonOf(await runLine(`cd ${HANDLE}`, shuttle, settling(null))))
+          .toBe(
+            `\`${HANDLE}\` reaches no piece: this space holds none by the ` +
+              `handle \`${HANDLE}\`.`,
+          );
+        expect(shuttle.place.place).toBe(before);
+      });
+
+      it("lands a handle the space holds", async () => {
+        const shuttle = shuttleIn(lookingUp(true));
+        moved(shuttle.place, "pieces");
+        const outcome = await runLine(`cd ${HANDLE}`, shuttle, settling(null));
+        expect(outcome).toEqual({ kind: "moved", place: shuttle.place.place });
+      });
+
+      it("lands a handle where the server does not answer the lookup", async () => {
+        // The lookup is a server capability, and `undefined` is what a server
+        // that does not advertise it says. Nothing was learned, so the move
+        // goes on — which is the one case left where a handle the space does
+        // not hold is adopted.
+
+        const shuttle = shuttleIn(lookingUp(undefined));
+        moved(shuttle.place, "pieces");
+        const outcome = await runLine(`cd ${HANDLE}`, shuttle, settling(null));
+        expect(outcome).toEqual({ kind: "moved", place: shuttle.place.place });
+      });
+
+      it("looks up no handle for a slug, the index having reached the piece", async () => {
+        // A slug resolved through the index, which read the document to take
+        // its id, so the resolution is the existence proof and a second one
+        // would ask what is answered.
+
+        const shuttle = shuttleIn(lookingUp(false));
+        moved(shuttle.place, "slugs");
+        const outcome = await runLine(
+          "cd board",
+          shuttle,
+          settling(null, { board: BOARD }),
+        );
+        expect(outcome).toEqual({ kind: "moved", place: shuttle.place.place });
+      });
+
+      it("looks up no handle for a key under the piece already stood at", async () => {
+        const shuttle: Shuttle = {
+          config: CONFIG,
+          place: new CurrentPlace(SPACE),
+          connection: new HeldConnection({
+            kind: "borrowed",
+            pieces: lookingUp(false),
+          }),
+        };
+        moved(shuttle.place, `/${HANDLE}`);
+        const outcome = await runLine(
+          "cd topics",
+          shuttle,
+          holding({ topics: [] }),
+        );
+        expect(outcome).toEqual({ kind: "moved", place: shuttle.place.place });
+      });
+
+      it("lands the resolved piece in the route, not only on top of it", async () => {
+        // A trail is made of positions `..` walks back through, so a route
+        // entry holding an unresolved slug is a place shuttle returns to and
+        // reads through the index as it points then. The invariant is the
+        // route's as much as the destination's.
+
+        const shuttle = shuttleIn();
+        await runLine(
+          "cd /slugs/board/topics",
+          shuttle,
+          settling({ topics: [] }, { board: BOARD }),
+        );
+        await runLine("cd ..", shuttle, READS_NOTHING);
+        expect(shuttle.place.place.position).toEqual({
+          kind: "piece",
+          space: SPACE,
+          piece: BOARD,
+          name: "board",
+          path: [],
+        });
+      });
+
+      it("takes `./items@user` to that key though the piece holds one named `.`", async () => {
+        // The silent wrong landing the head reading ends. Read as a walk, the
+        // operand descends through a key called `.` — and where the piece
+        // holds one, that walk *succeeds*, so the settle confirms it and the
+        // place adopts a cell nobody named. The head is read first, so the
+        // cell reached is the one the operand names whatever the piece holds.
+
+        const shuttle = atPiece();
+        const outcome = await runLine(
+          "cd ./items@user",
+          shuttle,
+          settling({ ".": { "items@user": 99 }, "items@user": 1 }),
+        );
+        expect(outcome).toEqual({ kind: "moved", place: shuttle.place.place });
+        expect(shuttle.place.place.position).toEqual({
+          kind: "piece",
+          space: SPACE,
+          piece: HANDLE,
+          path: ["items@user"],
+        });
+      });
+
+      it("offers the `.@` spelling where a bare scope word names no key", async () => {
+        // Inside a piece a bare `@session` is an ordinary key name, so this
+        // is the read finding no such key — and the operand looks enough like
+        // an attempt at the scope to say what would have moved it.
+
+        expect(
+          reasonOf(
+            await runLine("cd @session", atPiece(), settling({ topics: 1 })),
+          ),
+        ).toBe(
+          "`@session` reaches no cell: `@session` is no key of the cell " +
+            "above it, whose keys are `topics`. `.@session` is what moves " +
+            "the scope.",
+        );
+      });
+
+      it("reaches a key genuinely named `@session`, with no offer made", async () => {
+        // The condition the offer hangs on. A place that holds the key lands
+        // on it, and nothing is suggested, because nothing went wrong.
+
+        const shuttle = atPiece();
+        const outcome = await runLine(
+          "cd @session",
+          shuttle,
+          settling({ "@session": 1 }),
+        );
+        expect(outcome).toEqual({ kind: "moved", place: shuttle.place.place });
+        expect(shuttle.place.place.position).toEqual({
+          kind: "piece",
+          space: SPACE,
+          piece: HANDLE,
+          path: ["@session"],
+        });
+        expect(shuttle.place.place.scope).toBe("space");
+      });
+
+      it("settles a scope on its own, reading the place at the scope it moves to", async () => {
+        // A scope selects which document a piece's id names, so the place a
+        // scope move reaches is one nothing has read. It settles like any
+        // other move onto a piece, and the read goes to the new scope.
+
+        const shuttle = shuttleIn();
+        await runLine(`cd /${HANDLE}/topics`, shuttle, settling({ topics: 1 }));
+        let scope: string | undefined;
+        const outcome = await runLine("cd .@session", shuttle, {
+          ...settling({ topics: 1 }),
+          getCellValue: (config) => {
+            scope = config.pieceScope;
+            return Promise.resolve({ topics: 1 });
+          },
+        });
+        expect(outcome).toEqual({ kind: "moved", place: shuttle.place.place });
+        expect(scope).toBe("session");
+      });
+
+      it("refuses a scope whose document does not hold the path, and moves nowhere", async () => {
+        // The chain the settle exists for, in one line rather than two: the
+        // place at `@space` holds `topics`, the one at `@session` does not,
+        // and the move that would have adopted it is refused instead.
+
+        const shuttle = shuttleIn();
+        await runLine(`cd /${HANDLE}/topics`, shuttle, settling({ topics: 1 }));
+        const before = shuttle.place.place;
+        const outcome = await runLine("cd .@session", shuttle, settling({}));
+        expect(reasonOf(outcome)).toBe(
+          "`.@session` reaches no cell: `topics` is no key of the cell above " +
+            "it, which holds no keys at all.",
+        );
+        expect(shuttle.place.place).toBe(before);
+      });
+
+      it("descends after a refused scope move without meeting the runtime", async () => {
+        // The chain rather than the unit: settle at one scope, change scope,
+        // descend. The piece holds `topics/child` at `@space` and nothing at
+        // `@session`, so the scope move is refused and the descent runs from
+        // the place that was never left — reading a level that is there.
+        //
+        // A scope move that landed instead would leave the place at
+        // `@session/topics`, which no read confirmed, and the descent would
+        // read that parent and raise. So the third line is the assertion: it
+        // lands, rather than rejecting with the runtime's sentence.
+
+        const deps = atScopes({
+          space: { topics: { child: 1 } },
+          session: {},
+        });
+        const shuttle = shuttleIn();
+        await runLine(`cd /${HANDLE}/topics`, shuttle, deps);
+        expect(reasonOf(await runLine("cd .@session", shuttle, deps))).toBe(
+          "`.@session` reaches no cell: `topics` is no key of the cell above " +
+            "it, which holds no keys at all.",
+        );
+        const descended = await runLine("cd child", shuttle, deps);
+        expect(descended).toEqual({
+          kind: "moved",
+          place: shuttle.place.place,
+        });
+        expect(shuttle.place.place).toEqual({
+          position: {
+            kind: "piece",
+            space: SPACE,
+            piece: HANDLE,
+            path: ["topics", "child"],
+          },
+          scope: "space",
+        });
+      });
+
+      it("looks the handle up again where the move changes only the scope", async () => {
+        // The lookup's own skip, keyed the same way as the read's: one id at
+        // two scopes is two documents, so a move to the second has a piece
+        // nothing has asked about even though the id is one shuttle stands on.
+
+        // Standing is set through the place directly, which makes no lookup,
+        // so the one the case is about is the only one the controller sees.
+        const shuttle = shuttleIn(lookingUp(false));
+        moved(shuttle.place, `/${HANDLE}`);
+        const before = shuttle.place.place;
+        expect(reasonOf(
+          await runLine(`cd /${HANDLE}@session`, shuttle, settling(null)),
+        )).toBe(
+          `\`/${HANDLE}@session\` reaches no piece: this space holds none ` +
+            `by the handle \`${HANDLE}\`.`,
+        );
+        expect(shuttle.place.place).toBe(before);
+      });
+
+      it("looks the handle up once for the cell it already stands at", async () => {
+        // The other side of that key: same id, same scope, so the piece was
+        // settled when shuttle arrived and a move naming it again asks
+        // nothing. The controller refuses every lookup, so one being made
+        // would fail the case.
+
+        const shuttle = shuttleIn(lookingUp(false));
+        moved(shuttle.place, `/${HANDLE}`);
+        const outcome = await runLine(
+          `cd /${HANDLE}`,
+          shuttle,
+          settling(null),
+        );
+        expect(outcome).toEqual({ kind: "moved", place: shuttle.place.place });
+      });
+
+      it("reads again where the move changes only the scope", async () => {
+        // One id at `@space` and the same id at `@session` are two documents,
+        // so a place confirmed at one is not confirmed at the other. A skip
+        // that compared the position alone would land here having read
+        // nothing.
+
+        const shuttle = shuttleIn();
+        await runLine(`cd /${HANDLE}/topics`, shuttle, settling({ topics: 1 }));
+        const outcome = await runLine(
+          `cd /${HANDLE}@session/topics`,
+          shuttle,
+          settling({ other: 1 }),
+        );
+        expect(reasonOf(outcome)).toBe(
+          "`/of:fid1:abcdefghijklmnop@session/topics` reaches no cell: " +
+            "`topics` is no key of the cell above it, whose keys are `other`.",
+        );
+      });
+
+      it("reads at the level stood at where only the path goes deeper", async () => {
+        // The other side of every boundary above: same piece, same scope, one
+        // key deeper. Where shuttle stands is a place a read already
+        // confirmed, so what the settle has to find is the segment past it
+        // rather than the whole piece.
+
+        const seen = await read(atPiece("topics"), "cd 0", ["a"]);
+        expect(seen.path).toEqual(["topics"]);
+      });
+
+      it("settles a slug that names a collection, as a read of it would", async () => {
+        // The canonical resolution spends leading segments reaching a
+        // collection's member, so `/tasks/first/title` names the member's
+        // piece with `title` left inside it. Settling the head as a bare piece
+        // would refuse a cell `get` reads, and two verbs disagreeing about
+        // whether a reference names anything is worse than either answer.
+
+        const shuttle = shuttleIn();
+        await runLine(`cd /tasks/first/title`, shuttle, {
+          ...READS_NOTHING,
+          resolvePieceReference: (_pieces, token, path) =>
+            Promise.resolve(
+              token === "tasks"
+                ? { piece: BOARD, pathAfter: [...path].slice(1) }
+                : { piece: token, pathAfter: [...path] },
+            ),
+          getCellValue: () => Promise.resolve({ title: "a" }),
+        });
+        expect(shuttle.place.place.position).toEqual({
+          kind: "piece",
+          space: SPACE,
+          piece: BOARD,
+          path: ["title"],
+        });
+      });
+
+      it("keeps the member's own levels in a route a collection resolved through", async () => {
+        // The resolution spends the levels that select the member, and those
+        // are levels of the collection rather than of what it held. The level
+        // the member itself sits at is the member's, and lands with the
+        // member's piece — so `..` reaches the member's root, not the facet
+        // two levels above it.
+
+        const shuttle = shuttleIn();
+        await runLine(
+          "cd slugs/tasks/first/title",
+          shuttle,
+          collectionAt("tasks"),
+        );
+        expect(shuttle.place.place.position).toEqual({
+          kind: "piece",
+          space: SPACE,
+          piece: BOARD,
+          path: ["title"],
+        });
+        await runLine("cd ..", shuttle, READS_NOTHING);
+        expect(shuttle.place.place.position).toEqual({
+          kind: "piece",
+          space: SPACE,
+          piece: BOARD,
+          path: [],
+        });
+        await runLine("cd ..", shuttle, READS_NOTHING);
+        expect(shuttle.place.place.position).toEqual({
+          kind: "facet",
+          space: SPACE,
+          facet: "slugs",
+        });
+      });
+
+      it("routes one walk the same whether it is typed whole or in steps", async () => {
+        // A route records how shuttle reached a place, and `cd a/b/c` and
+        // `cd a/b` then `cd c` are one walk written two ways. So they leave
+        // the same route, and `..` lands the same sequence from either — the
+        // property that catches a resolution spending segments and taking the
+        // levels below them with it.
+
+        /** Every `..` landing from `lines`, after where they end. */
+        const landings = async (lines: string[]): Promise<unknown[]> => {
+          const shuttle = shuttleIn();
+          for (const line of lines) {
+            await runLine(line, shuttle, collectionAt("tasks"));
+          }
+          const seen: unknown[] = [shuttle.place.place.position];
+          for (let step = 0; step < 3; step++) {
+            await runLine("cd ..", shuttle, READS_NOTHING);
+            seen.push(shuttle.place.place.position);
+          }
+          return seen;
+        };
+
+        expect(await landings(["cd slugs/tasks/first/title"]))
+          .toEqual(await landings(["cd slugs/tasks/first", "cd title"]));
+        expect(await landings(["cd slugs/board/topics"]))
+          .toEqual(await landings(["cd slugs/board", "cd topics"]));
+      });
+
+      it("takes the scope a narrowed link was reached through", async () => {
+        // A member held through a narrowed link is a different document from
+        // the one its id alone names, so the place has to read through the
+        // scope the resolution reached it at.
+
+        const shuttle = shuttleIn();
+        await runLine(`cd /tasks/first`, shuttle, {
+          ...READS_NOTHING,
+          resolvePieceReference: (_pieces, _token, path) =>
+            Promise.resolve({
+              piece: BOARD,
+              pathAfter: [...path].slice(1),
+              scope: "session",
+            }),
+        });
+        expect(shuttle.place.place.scope).toBe("session");
+      });
+
+      it("reads the path through the scope the resolution reached it at", async () => {
+        // The place's scope and the read's are the same scope, and the read
+        // has to use it: a member held through a narrowed link is a different
+        // document, so checking its path at the ambient scope would look for
+        // the key in a cell the place does not name.
+
+        const shuttle = shuttleIn();
+        let scope: string | undefined;
+        await runLine(`cd /tasks/first/title`, shuttle, {
+          ...READS_NOTHING,
+          resolvePieceReference: (_pieces, _token, path) =>
+            Promise.resolve({
+              piece: BOARD,
+              pathAfter: [...path].slice(1),
+              scope: "session",
+            }),
+          getCellValue: (config) => {
+            scope = config.pieceScope;
+            return Promise.resolve({ title: "a" });
+          },
+        });
+        expect(scope).toBe("session");
+        expect(shuttle.place.place.scope).toBe("session");
+      });
+
+      it("resolves a slug reached from inside another piece", async () => {
+        // Standing at a piece is not standing at *this* piece. The skip above
+        // is for the one the place already holds, and a move onto any other
+        // resolves — which is the whole of what keeps a repointed slug from
+        // walking the place onto a piece it did not name.
+
+        const shuttle = atPiece("topics");
+        await runLine(
+          "cd /slugs/board",
+          shuttle,
+          settling(null, { board: BOARD }),
+        );
+        expect(shuttle.place.place.position).toEqual({
+          kind: "piece",
+          space: SPACE,
+          piece: BOARD,
+          name: "board",
+          path: [],
+        });
+      });
+
+      it("resolves nothing for a key under the piece already stood at", async () => {
+        // The piece is the one shuttle stands on, which came through a settle
+        // of its own, so a descent has none left to ask about. `READS_NOTHING`
+        // resolves none, and the case fails if the settle reaches for one.
+
+        const shuttle = atPiece();
+        await runLine("cd topics", shuttle, holding({ topics: [] }));
+        expect(shuttle.place.place.position).toEqual({
+          kind: "piece",
+          space: SPACE,
+          piece: HANDLE,
+          path: ["topics"],
+        });
+      });
+
+      it("resolves nothing for a reference naming the piece already stood at", async () => {
+        const shuttle = atPiece("topics");
+        await runLine(
+          `cd /${HANDLE}/title`,
+          shuttle,
+          holding({ title: "a" }),
+        );
+        expect(shuttle.place.place.position).toEqual({
+          kind: "piece",
+          space: SPACE,
+          piece: HANDLE,
+          path: ["title"],
+        });
+      });
+
+      it("raises what the read that checks the path raised", async () => {
+        // The seam's own distinction, on the door this slice added. A slug
+        // the index names nothing for is a fact about the line and comes back
+        // refused; a read that failed is a server that went away, and it
+        // raises so a shell whose server is gone is still a shell. The
+        // message is asserted because both stubs in `READS_NOTHING` throw,
+        // and only one of them is the read.
+
+        await expect(runLine("cd title", atPiece(), READS_NOTHING)).rejects
+          .toThrow("A cell was read.");
+      });
+
+      it("refuses a segment that is no key, naming the keys that are", async () => {
+        const shuttle = atPiece();
+        const before = shuttle.place.place;
+        const outcome = await runLine(
+          "cd nosuchkey",
+          shuttle,
+          settling({ value: 0, increment: null, decrement: null }),
+        );
+        expect(reasonOf(outcome)).toBe(
+          "`nosuchkey` reaches no cell: `nosuchkey` is no key of the cell " +
+            "above it, whose keys are `value`, `increment`, and `decrement`.",
+        );
+        expect(shuttle.place.place).toBe(before);
+      });
+
+      it("refuses a segment where the cell above it holds no keys at all", async () => {
+        expect(
+          reasonOf(await runLine("cd title", atPiece(), settling(7))),
+        ).toBe(
+          "`title` reaches no cell: `title` is no key of the cell above it, " +
+            "which holds no keys at all.",
+        );
+      });
+
+      it("names the segment that is missing rather than the operand's last", async () => {
+        expect(
+          reasonOf(
+            await runLine(
+              "cd nosuchkey/title",
+              atPiece(),
+              settling({ topics: [] }),
+            ),
+          ),
+        ).toBe(
+          "`nosuchkey/title` reaches no cell: `nosuchkey` is no key of the " +
+            "cell above it, whose keys are `topics`.",
+        );
+      });
+
+      it("lands a key the read found", async () => {
+        const shuttle = atPiece();
+        const outcome = await runLine(
+          "cd topics",
+          shuttle,
+          settling({ topics: [] }),
+        );
+        expect(outcome).toEqual({ kind: "moved", place: shuttle.place.place });
+        expect(shuttle.place.place.position).toEqual({
+          kind: "piece",
+          space: SPACE,
+          piece: HANDLE,
+          path: ["topics"],
+        });
+      });
+
+      it("reads an index a walk into an array reached", async () => {
+        const shuttle = atPiece("topics");
+        const outcome = await runLine(
+          "cd 3",
+          shuttle,
+          settling(["a", 1, 2, 3]),
+        );
+        expect(outcome).toEqual({ kind: "moved", place: shuttle.place.place });
+      });
+
+      it("reads at the piece's root where the move went up before it came down", async () => {
+        const seen = await read(atPiece("topics"), "cd ../items", {
+          items: {},
+        });
+        expect(seen.path).toEqual([]);
+      });
+
+      it("reads at the piece's root for a move onto another piece", async () => {
+        // The path a move onto another piece extends is a path in that
+        // piece, so a standing that spells the same segments has confirmed
+        // nothing about it. The operand shares its first segment with where
+        // shuttle stands, which is what makes the piece the thing deciding.
+
+        const seen = await read(atPiece("topics"), `cd /${OTHER}/topics/3`, {
+          topics: ["a", "b", "c", "d"],
+        });
+        expect(seen.path).toEqual([]);
+        expect(seen.config?.piece).toBe(OTHER);
+      });
+
+      it("reads at the scope the move lands at, not the one it left", async () => {
+        // A reference carrying a suffix moves both halves of the place, and
+        // the cell the read has to find is the one that scope selects.
+
+        const seen = await read(
+          atPiece(),
+          `cd /${HANDLE}@session/title`,
+          { title: 1 },
+        );
+        expect(seen.config?.pieceScope).toBe("session");
+      });
+
+      it("reads nothing at all for a move onto a piece with no path", async () => {
+        // Nothing is left to find: the resolution answered for the piece, and
+        // there is no path under it for a read to look for.
+
+        const shuttle = shuttleIn();
+        moved(shuttle.place, "pieces");
+        const outcome = await runLine(`cd ${HANDLE}`, shuttle, {
+          ...READS_NOTHING,
+          resolvePieceReference: (_pieces, token, path) =>
+            Promise.resolve({ piece: token, pathAfter: [...path] }),
+        });
+        expect(outcome).toEqual({ kind: "moved", place: shuttle.place.place });
+      });
+
+      it("reads through the piece the resolution handed back", async () => {
+        const shuttle = shuttleIn();
+        moved(shuttle.place, "slugs");
+        let piece: string | undefined;
+        await runLine("cd board/title", shuttle, {
+          ...settling({ title: 1 }, { board: BOARD }),
+          getCellValue: (config) => {
+            piece = config.piece;
+            return Promise.resolve({ title: 1 });
+          },
+        });
+        expect(piece).toBe(BOARD);
+      });
+
+      it("writes the name in the prompt and the handle in what `pwd` prints", async () => {
+        const shuttle = shuttleIn();
+        moved(shuttle.place, "slugs");
+        await runLine("cd board", shuttle, settling(null, { board: BOARD }));
+        expect(shuttle.place.label()).toBe("board @space");
+        expect(textOf(await runLine("pwd", shuttle, READS_NOTHING))).toBe(
+          `position  /@${SPACE}/${BOARD}@space\nscope     @space`,
+        );
+      });
+
+      it("settles a space written as a name before it settles the piece", async () => {
+        const shuttle = shuttleIn();
+        await runLine(
+          `cd /@${SPACE_NAME}/board/title`,
+          shuttle,
+          settling({ title: 1 }, { board: BOARD }),
+        );
+        expect(shuttle.place.place.position).toEqual({
+          kind: "piece",
+          space: SPACE,
+          piece: BOARD,
+          name: "board",
+          path: ["title"],
+        });
+      });
+
+      it("refuses an entry point resolving to an address naming its piece by slug", async () => {
+        expect(
+          reasonOf(
+            await runLine("cd #favorites", shuttleIn(), addressed("/board")),
+          ),
+        ).toBe(
+          "`#favorites` resolves to slug `board`, and a place holds the " +
+            "handle a name resolved to. An address the fabric wrote names " +
+            "its piece by handle.",
+        );
+      });
+
+      it("settles nothing for `get`, whose own read is what finds the cell", async () => {
+        // The asymmetry the two doors have. A `cd` waits because the prompt
+        // would go on promising the place; a read of a cell that is not there
+        // fails on its own account, so there is nothing for a check in front
+        // of it to add — and `READS_NOTHING` resolves no piece, which is what
+        // shows that none was asked for.
+
+        expect(await runLine("get title", atPiece(), cellValue("read")))
+          .toEqual({ kind: "value", value: "read" });
+      });
     });
 
     describe("a `#name` target", () => {
@@ -576,7 +1440,7 @@ describe("verbs", () => {
         expect(shuttle.place.place.position.kind).toBe("root");
       });
 
-      it("refuses a target whose address carries a scope suffix", async () => {
+      it("refuses a target whose address carries a scope qualifier", async () => {
         const outcome = await runLine(
           "cd #favorites",
           shuttleIn(),
@@ -584,7 +1448,8 @@ describe("verbs", () => {
         );
         expect(reasonOf(outcome)).toBe(
           "`#favorites` resolved to an address carrying an `@session` " +
-            "suffix, which a place reached through a target does not keep: a " +
+            "qualifier, which a place reached through a target does not " +
+            "keep: a " +
             "place holds one scope and roots at a result. Reach that cell by " +
             `its own reference, \`/${HANDLE}@session/title\`.`,
         );
@@ -673,7 +1538,7 @@ describe("verbs", () => {
         const outcome = await runLine(
           `cd /@${SPACE_NAME}/${HANDLE}/title`,
           shuttle,
-          READS_NOTHING,
+          settling({ title: "t" }),
         );
         expect(outcome).toEqual({ kind: "moved", place: shuttle.place.place });
         expect(shuttle.place.place.position).toEqual({
@@ -742,7 +1607,7 @@ describe("verbs", () => {
         const outcome = await runLine(
           `cd /@east~1west/${HANDLE}`,
           shuttle,
-          READS_NOTHING,
+          settling(null),
         );
         expect(outcome).toEqual({ kind: "moved", place: shuttle.place.place });
       });
@@ -799,7 +1664,7 @@ describe("verbs", () => {
 
     it("lists where shuttle stands rather than where it started", async () => {
       const shuttle = shuttleIn();
-      shuttle.place.cd("pieces");
+      moved(shuttle.place, "pieces");
       let listed = 0;
       await runLine("ls", shuttle, {
         ...READS_NOTHING,
@@ -923,8 +1788,8 @@ describe("verbs", () => {
       // slug — the same thing a listing hands on, and what makes a name typed
       // back off one reach the piece it names.
       const shuttle = shuttleIn();
-      shuttle.place.cd("slugs");
-      shuttle.place.cd("board");
+      moved(shuttle.place, "slugs");
+      moved(shuttle.place, "board");
       let config: PieceConfig | undefined;
       await runLine("get", shuttle, {
         ...READS_NOTHING,
@@ -938,7 +1803,7 @@ describe("verbs", () => {
 
     it("reads at the scope the place reads through", async () => {
       const shuttle = atPiece();
-      shuttle.place.cd("@session");
+      moved(shuttle.place, ".@session");
       let config: PieceConfig | undefined;
       await runLine("get", shuttle, {
         ...READS_NOTHING,
@@ -1009,8 +1874,8 @@ describe("verbs", () => {
       // two agree.
 
       const shuttle = shuttleIn();
-      shuttle.place.cd("slugs");
-      shuttle.place.cd("board");
+      moved(shuttle.place, "slugs");
+      moved(shuttle.place, "board");
       const refused = await runLine("get ..", shuttle, READS_NOTHING);
       expect(reasonOf(refused)).toBe(
         "`slugs/` is a list of what stands inside it rather than a cell, so " +
@@ -1043,7 +1908,7 @@ describe("verbs", () => {
 
     it("refuses a facet, naming it", async () => {
       const shuttle = shuttleIn();
-      shuttle.place.cd("pieces");
+      moved(shuttle.place, "pieces");
       expect(reasonOf(await runLine("get", shuttle, READS_NOTHING))).toBe(
         "`pieces/` is a list of what stands inside it rather than a cell, so " +
           "it holds no value. `ls` lists it.",
@@ -1130,7 +1995,7 @@ describe("verbs", () => {
 
       it("reads the arguments cell a bare piece designation selects", async () => {
         const shuttle = shuttleIn();
-        shuttle.place.cd("slugs");
+        moved(shuttle.place, "slugs");
         const seen = await reads(shuttle, "get board#argument");
         expect(seen.config?.piece).toBe("board");
         expect(seen.path).toEqual([]);


### PR DESCRIPTION
## Why

`cd` was the one verb whose success meant nothing. From a piece,
`cd nosuchkey` landed, the prompt read `counter/nosuchkey`, and the failure
surfaced one command later as the runtime's own message. From the root,
`cd /slugs/todo` landed on a piece *slugged* `slugs` — one character from
the `slugs/` facet rendering — and every later command reported
`Slug "slugs" not found`.

A shell's `cd` is the command whose success is a promise: after it, the
prompt names a place that is there. For an operator debugging a misbehaving
space, a prompt that promises nothing inverts the tool's purpose — the tool
now needs debugging.

It also bears directly on the writing verbs coming next. `set` and `call`
would be issued against places `cd` never checked, and a slug is a redirect:
if the index is repointed mid-session, a place held by slug silently moves to
another piece and the next write lands there. A place holding a resolved
handle cannot move.

Three findings of an architecture review of the built shell — 1, 2 and 7 —
which are one change.

## What Changed

**`cd` settles against the fabric before adopting a move.** A `pending` arm on
`Move` carries the position to verify; `verbs.ts` settles it through the
existing deps and refuses in shuttle's own words, naming the sibling keys
where the read has them. `CurrentPlace.aim` stays value-only — `get` reads
anyway, and its failure is the read's.

**The place holds a resolved piece, and the prompt a checked name.** `cd`
resolves to the handle and stores it, keeping the slug beside it as the name
the prompt shows while the index confirms it (decision 13). `pwd` prints the
handle form, which is the only form `namesResolvedParts` accepts for a
durable link.

**Facet names are reserved in a rooted reference too** (decision 11, amended
in this change). `/slugs/<x>` and `/pieces/<x>` now read as walks from the
root, so `cd /slugs/todo` means what `cd /` then `cd slugs/todo` means.

The amendment records what it costs, plainly: the rooted spelling is the
canonical cell reference grammar — the runner's `parseReferenceParts`, shared
with patterns and every `cf` intake seam, which resolves a piece segment by
slug as well as by handle. The facets are shuttle's own overlay. So shuttle
reads `/slugs/x` and `/pieces/x` differently from `cf`, and identically for
every other slug. Issue #6992 retires that divergence by having `set-slug`
refuse the two values.

### Design calls, flagged

- **The settle read is aimed one level above the destination, never at it.**
  A read at a path the fabric does not hold *raises*, and a raise means "the
  server went away" here. Aimed one level up, a miss is data, so every miss
  becomes a refusal rather than an error. This is the load-bearing decision.
- **The read starts where shuttle already stands** when the move extends it on
  the same piece, and at the piece root otherwise.
- **`enter` refuses a target naming its piece by slug** — new behavior the
  review did not ask for. It is what keeps "a position holds a piece, never a
  slug" total without a read.
- **The name is a snapshot taken at `cd`**, not re-read per prompt line, and
  there is no reverse lookup: `cd pieces/<handle>` shows the handle even where
  the piece has a slug, because decision 13 shows a name an index confirmed
  and no read asked.

### Known bounds, recorded rather than papered over

- A handle the space does not hold, **with no path after it**, still lands:
  `resolvePieceAddress` looks a handle up nowhere, and reading its cell
  answers empty rather than failing, so absent and present-but-empty are the
  same observation. A handle with a path is caught.
- `cd " /slugs/board"` — a *quoted* leading space — reads as a reference and
  lands on a piece slugged `slugs`. The walk keeps its edges (#6975) while the
  reference grammar trims, so the two layers disagree about whether the string
  is rooted. Closing it means either trimming the walk, which reverts #6975's
  property, or a new rule. Both cases are pinned by tests and named in
  `grammar.md`.

## Test plan

- `deno task test` in `packages/cli`: **parallel 1807 / 0 failed, serial
  215 / 0 failed**, exit 0. `deno fmt --check`, `deno lint`, `deno task check`
  all 0, plus `check-docs`, `check-control-characters`, `check-command-docs`,
  `check-completion-slots`, `check-skill-facts`, `check-docs-history-index`,
  `check-no-waitfor`, `check-package-cycles`.
- **29 designated mutations, each run, each redding the case designated for
  it.** Two were discarded as unsound rather than counted: one fixture did not
  straddle the boundary it tested, and an appended `.catch()` never took
  effect because the stub throws synchronously.
- **A surviving mutation found a real gap.** Weakening the resolution skip
  from `standing.piece === spelled` to `standing.kind === "piece"` killed
  nothing: no case moved from one piece onto a *different* piece by slug,
  which is exactly the hazard the resolution exists for. A case for it now
  closes that, and the mutation reds on it alone.
- **This branch rebased across #6975**, which deleted two `operand.trim()`
  calls at the place layer. Resolution verified rather than assumed:
  `grep -rn 'trim()' packages/cli/lib/shuttle/` is empty, all 25 test cases
  that #6975 added are present in the merged file, and the one case it
  *deleted* is confirmed still absent — that hunk is the one that would have
  silently reverted the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BPyjSx5WXYepE9JsK4rBx3


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7009?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



---

## Added after review

Two rulings landed on this branch after the first review rounds.

**A scope-only move settles.** `cd .@session` reads like any other move onto a
place. The premise it was breaking is stated in this change's own code: one id
at `@space` and the same id at `@session` are two documents, so a place
confirmed at one is not confirmed at the other. Leaving the scope move
unsettled meant a later `cd child` skipped verification against a place nobody
had checked, and surfaced the runtime's error — the failure this slice exists
to end. Found by codex with a read-only probe.

**The scope is written `.@scope`, adopting the cell reference grammar proposed
in #6814.** That grammar gives `@` exactly one meaning — a qualifier on the
piece — and makes `.` at the head of a relative reference the place a
qualifier attaches. A bare `@` is therefore data: `cd @session` reaches a key
of that name, and `cd ./items@user` reaches `items@user`. Where a bare scope
word names no key, the refusal offers `.@session` as the spelling that moves
the scope — a hint on a refusal, never a reading, so a key genuinely named
`@session` stays reachable.

Decision 20 is amended and cites #6814, recording plainly that it is proposed
rather than merged: shuttle conforms now because migrating a navigation
spelling later costs more than adopting it before anyone learns the other one.

**The settle needed no new code.** Once the scope move pends, the
compiler-closed key added in the previous round already sees the scope differ
and reads the whole path.

### What the review rounds found

Nine correctness findings across two reviewers, none repeated, none disputed:

- The unheld-handle bound, **closed** by `entityIdExists` rather than
  documented — it tests an identifier against the server's index without
  loading its value.
- An unqualified promise about what `cd` guarantees, in three places.
- The prompt's naming rule contradicting decision 13 in two live documents.
- The route keeping the slug that reached it rather than the resolved handle,
  so `..` could land on an unresolved position.
- A settle-skip key narrower than the decision it made, now a projection the
  compiler closes over both `Position` and `Place`.
- `cd` refusing collection-slug references that `get` reads, because the two
  verbs resolved through different calls.
- The scope-only settle gap above.

