### PR TITLE
docs: check-no-waitfor names the tests it actually reads

### DIFF
--- a/.claude/rules/tests.md
+++ b/.claude/rules/tests.md
@@ -121,8 +121,10 @@ value such as a `FabricHash`.
 
 ## Wait on an event, never on a poll
 
-`deno task check-no-waitfor` fails the build when a test imports the polling
-`waitFor` from `@commonfabric/integration`. Reach for the primitive that
+`deno task check-no-waitfor` fails the build when an integration test imports
+the polling `waitFor` from `@commonfabric/integration`. Only `integration/`
+directories under `packages/` are in scope; a unit test's poll has no gate, and
+the rule below is what holds it. Reach for the primitive that
 resolves on the thing actually happening:
 
 - In a browser test: `awaitViewSettled(page)` for "the view is interactive",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -315,8 +315,9 @@ pattern type-check. Run `deno task test` in every package you touched.
 Each of these gates fails CI on its own, and none of them run as part of
 `deno task check`:
 
-- `deno task check-no-waitfor` — a test that polls instead of waiting on a real
-  event
+- `deno task check-no-waitfor` — an integration test that imports the polling
+  `waitFor`. It reads only `integration/` directories under `packages/`, so its
+  green says nothing about a poll in a unit test
 - `deno task check-docs` — a TypeScript block under `docs/` that stopped
   compiling
 - `deno task check-docs-history-index` — an entry in `docs/history/INDEX.md`


### PR DESCRIPTION
## Why

`AGENTS.md` is loaded into every agent's context, and its entry for this
gate says it catches "a test that polls instead of waiting on a real event."
That overstates the gate twice.

`tasks/check-no-waitfor.ts` reads only the `.ts` files under an
`integration/` directory beneath `packages/`, and it fails on one thing: an
import taking `waitFor` as a value from `@commonfabric/integration`. A unit
test that polls with `setTimeout`, or that spins on a condition, is invisible
to it.

The cost is a green that reads as evidence about files the check never
opened. That happened in this repository today: an agent was told the gate
"matters more here than anywhere" for a slice whose files are all unit tests,
and it established that by adding a `waitFor` call and watching the check
pass anyway. It then verified the absence of every polling primitive by hand,
which is the work the misleading summary had implied was unnecessary.

## What Changed

Two summaries brought in line with the gate they describe.

- **`AGENTS.md`** — names what fails (an integration test importing the
  polling `waitFor`), the directories in scope, and states plainly that its
  green says nothing about a poll in a unit test.
- **`.claude/rules/tests.md`** — said "a test" where it meant an integration
  test. Now says which, and points at the rule that governs a unit test's
  poll, since that is the question a reader who just learned the scope will
  have next.

Three other descriptions were checked and left alone, being already correct:
`docs/development/waiting-in-tests.md` (the canonical one, which states the
scope in full), `docs/development/UI_TESTING.md`, and
`docs/development/TESTING.md`.

## Test plan

- `deno task check-skill-facts` — passes, 50 documents.
- **The instrument was proved rather than trusted.** Replacing a cited path
  in `AGENTS.md` with a nonexistent one produced
  `AGENTS.md:119  path does not exist: docs/development/no-such-file.md` and
  exit 1; restoring it returned to exit 0. So the file is genuinely in scope.
  Reported precisely: that check validates **path citations, not prose**, so
  its green is evidence the links resolve and not that the description is
  true. The description itself was checked against the header comment of
  `tasks/check-no-waitfor.ts`, which states the scope directly.
- `deno fmt --check` on both paths exits 0, reporting one file checked — the
  other is outside its scope, so that result covers one of the two edits.
- No added line exceeds 80 characters, measured in characters. The one long
  line in `AGENTS.md` is pre-existing and untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BPyjSx5WXYepE9JsK4rBx3


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7011?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

