### PR TITLE
fix(tasks): the no-share lane test holds the store's manifest out of the lane

### DIFF
--- a/tasks/ci-lane.test.ts
+++ b/tasks/ci-lane.test.ts
@@ -1282,6 +1282,13 @@ describe("the lane's own housekeeping", () => {
         dryRun: false,
         laneCount: false,
         root,
+      }, {
+        // What this pins is the path with nothing in it, so the store's
+        // manifest is held out: with one, even a lane this far down the
+        // count draws a few unmeasured tests, and the lane then opens
+        // their capabilities and runs them.
+        manifest: (at) =>
+          Promise.resolve({ absent: `no manifest at ${at}: held out here` }),
       });
     } finally {
       console.log = log;


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Fable 5.1)

@hixie, this is in your test-selection lane, found while chasing red CI
on unrelated PRs.

`Test (8/8)` has timed out on every CI run since this morning, on `main`
and on every open PR. The shard runs `tasks (3/3)` first, and that shard
never finishes: `tasks/ci-lane.test.ts`, in "runs a lane that was given
no share of the work", calls the real `runLane()` for lane 9999 of 10000
with the store's real manifest. Until 16:24Z today the store held no
manifest, so the lane drew nothing and the test passed. The first
manifest (`manifest-2026-09-06T16:24:57.864Z-...`) changed that: with
one, the planner hands even lane 9999 a few unmeasured tests (2
`runner-unit`, 5 `workspace-unit` at the moment I looked), so the lane
opens `browser`, `deno`, and `fuse`, runs `sudo apt-get` for the FUSE
packages, and runs the batches, inside the test. Locally that is a
`sudo` password prompt; in CI it is the 30-minute step timeout.

Verified by bisection: the last green `main` run (`0f14ac118`, committed
08:06Z) resolves its manifest at a moment before the first one exists;
`main` at `a98426fe1` (16:58Z) and after resolves to it. Running
`ci-lane.ts --full --lane 9999 --of 10000 --dry-run` at either commit
shows the difference, and pinning `--at 2026-09-06T00:00:00Z` on current
`main` gives the empty lane back. The code did not change; the store did.

## The fix

The test pins the path with nothing in it, so it now hands `runLane()` a
`manifest` dependency that reports the manifest absent, the seam
`LaneDeps` offers for saying what the store holds. `ci-lane.test.ts`
passes unsandboxed on this branch (15 passed, 0 failed).

Whether a lane that far down the count SHOULD draw unmeasured tests is a
planner question I have not touched.

## Gates

`deno fmt --check`, `deno lint`, `deno task check --scope=tasks`, and
`tasks/ci-lane.test.ts`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7018?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

