### PR TITLE
refactor: five stub-by-assignment tests drive seams their classes already offer; `#withSpacePublicationLock`, `#waitForConflictReadRepair`

### DIFF
--- a/packages/memory/test/v2-server.test.ts
+++ b/packages/memory/test/v2-server.test.ts
@@ -244,12 +244,7 @@ const assertCommitBurstBeforeFanout = async (
 
 Deno.test("memory v2 server keeps publication locks independent per space", async () => {
   const server = createServer("memory://memory-v2-publication-lock-spaces");
-  const internals = server as unknown as {
-    withSpacePublicationLock<T>(
-      space: string,
-      run: () => Promise<T>,
-    ): Promise<T>;
-  };
+  const internals = server.accessForTestingOnly;
   const firstEntered = Promise.withResolvers<void>();
   const releaseFirst = Promise.withResolvers<void>();
   let sameSpaceEntered = false;

--- a/packages/memory/test/v2-verdict-catchup.test.ts
+++ b/packages/memory/test/v2-verdict-catchup.test.ts
@@ -658,47 +658,20 @@ Deno.test("memory v2 server: the verdict leaves within the transact's publicatio
   const { server, space, committer, committerMessages, committerSessionId } =
     context;
 
-  // Train-side re-pin of #5529's verdict-precedes-fan-out: main's instrument
-  // gated runPostCommitSchedulerSideEffects, machinery this train deleted, so
-  // this test instruments the publication turn itself. The wrapper extends
-  // the transact's own turn tenure: it resolves `turnHeld` after the turn's
-  // body — including the in-lock verdict publication — finishes, then holds
-  // the lock open until the gate opens. The verdict must already be at the
-  // committing session while the turn is still owned, and fan-out must not
-  // be able to enter the turn until it is released.
-  const gate = Promise.withResolvers<void>();
-  const turnHeld = Promise.withResolvers<void>();
-  const fanoutLockAttempted = Promise.withResolvers<void>();
-  let fanoutEntered = false;
-  let transactTurnSeen = false;
-  const serverInternals = server as unknown as {
-    withSpacePublicationLock<T>(
-      space: string,
-      run: () => Promise<T>,
-    ): Promise<T>;
-  };
-  const originalLock = serverInternals.withSpacePublicationLock.bind(server);
-  serverInternals.withSpacePublicationLock = <T>(
-    lockSpace: string,
-    run: () => Promise<T>,
-  ) => {
-    if (!transactTurnSeen) {
-      transactTurnSeen = true;
-      return originalLock(lockSpace, async () => {
-        const result = await run();
-        turnHeld.resolve();
-        await gate.promise;
-        return result;
-      });
-    }
-    fanoutLockAttempted.resolve();
-    return originalLock(lockSpace, async () => {
-      fanoutEntered = true;
-      return await run();
-    });
-  };
-
-  const commit = committer.receive(encodeMemoryBoundary({
+  // Train-side re-pin of #5529's verdict-precedes-fan-out. The test takes
+  // publication turns of its own on the space's lock: turn A holds the lock
+  // while the transact queues behind it; turn B queues behind the transact,
+  // and fan-out behind B. The lock is first-come, so releasing A runs the
+  // transact's turn, whose verdict must reach the committing session while B
+  // is what stands between it and fan-out; releasing B lets fan-out in.
+  const lock = server.accessForTestingOnly.withSpacePublicationLock;
+  const turnA = Promise.withResolvers<void>();
+  const turnB = Promise.withResolvers<void>();
+  const heldA = lock(space, () => turnA.promise);
+  // Sent to the server directly rather than through the connection, whose
+  // receive path awaits before it reaches the lock; the direct call queues
+  // its turn synchronously, which is what fixes the order.
+  const commit = server.transact({
     type: "transact",
     requestId: "committer-turn",
     space,
@@ -712,37 +685,27 @@ Deno.test("memory v2 server: the verdict leaves within the transact's publicatio
         value: { value: { from: "committer" } },
       }],
     },
-  }));
+  }, (verdict) => committerMessages.push(verdict));
+  const heldB = lock(space, () => turnB.promise);
+  const fanout = server.flushSessions([space]);
 
-  let fanout: Promise<void> | undefined;
-  try {
-    await turnHeld.promise;
-    // The verdict is already at the committing session while its transact
-    // still owns the publication turn.
-    const verdict = assertResponse<{ seq: number }>(
-      shiftMessage(committerMessages),
-    );
-    assertEquals(verdict.ok?.seq, 2);
-    assertEquals(committerMessages.length, 0);
+  turnA.resolve();
+  await heldA;
+  await commit;
+  // The verdict is at the committing session as soon as its transact's turn
+  // is over, and nothing else has reached it.
+  const verdict = assertResponse<{ seq: number }>(
+    shiftMessage(committerMessages),
+  );
+  assertEquals(verdict.ok?.seq, 2);
+  // Fan-out serializes behind turn B: while B is held, no frame reaches the
+  // committer.
+  assertEquals(committerMessages.length, 0);
+  turnB.resolve();
+  await Promise.all([heldB, fanout]);
 
-    // Fan-out serializes behind the held turn: the flush attempts the lock
-    // but cannot enter it, and no frame reaches the committer.
-    fanout = server.flushSessions([space]);
-    await fanoutLockAttempted.promise;
-    assertEquals(fanoutEntered, false);
-    assertEquals(committerMessages.length, 0);
-  } finally {
-    gate.resolve();
-    try {
-      await Promise.all([commit, fanout]);
-    } finally {
-      serverInternals.withSpacePublicationLock = originalLock;
-    }
-  }
-
-  // With the turn released, fan-out enters and delivers the parked novelty;
-  // the committer's own accepted doc:a stays echo-suppressed.
-  assertEquals(fanoutEntered, true);
+  // With the turns released, fan-out delivers the parked novelty; the
+  // committer's own accepted doc:a stays echo-suppressed.
   const effect = assertEffect(shiftMessage(committerMessages));
   const sync = effect.effect as SessionSync;
   assertEquals(sync.caughtUpLocalSeq, 1);

--- a/packages/memory/test/v2-verdict-catchup.test.ts
+++ b/packages/memory/test/v2-verdict-catchup.test.ts
@@ -655,8 +655,7 @@ Deno.test("memory v2 server: the verdict leaves within the transact's publicatio
     subscriptionRefreshDelayMs: 60_000,
     store: "memory://verdict-catchup-publication-turn",
   });
-  const { server, space, committer, committerMessages, committerSessionId } =
-    context;
+  const { server, space, committerMessages, committerSessionId } = context;
 
   // Train-side re-pin of #5529's verdict-precedes-fan-out. The test takes
   // publication turns of its own on the space's lock: turn A holds the lock
@@ -686,7 +685,14 @@ Deno.test("memory v2 server: the verdict leaves within the transact's publicatio
       }],
     },
   }, (verdict) => committerMessages.push(verdict));
-  const heldB = lock(space, () => turnB.promise);
+  // B's body runs as soon as the transact's turn ends: a verdict published
+  // inside that turn is at the committer by then, one published after any
+  // later await is not.
+  let verdictsAtB = -1;
+  const heldB = lock(space, () => {
+    verdictsAtB = committerMessages.length;
+    return turnB.promise;
+  });
   const fanout = server.flushSessions([space]);
 
   turnA.resolve();
@@ -698,6 +704,7 @@ Deno.test("memory v2 server: the verdict leaves within the transact's publicatio
     shiftMessage(committerMessages),
   );
   assertEquals(verdict.ok?.seq, 2);
+  assertEquals(verdictsAtB, 1);
   // Fan-out serializes behind turn B: while B is held, no frame reaches the
   // committer.
   assertEquals(committerMessages.length, 0);

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -1611,13 +1611,20 @@ export class Server {
   }
 
   /**
-   * The timer-driven refresh pass, which a test drives directly.
+   * The timer-driven refresh pass and the per-space publication lock, which
+   * a test drives directly.
    */
   get accessForTestingOnly(): {
     flushScheduledSessions(): Promise<void>;
+    withSpacePublicationLock<T>(
+      space: string,
+      run: () => Promise<T>,
+    ): Promise<T>;
   } {
     return {
       flushScheduledSessions: () => this.#flushScheduledSessions(),
+      withSpacePublicationLock: (space, run) =>
+        this.#withSpacePublicationLock(space, run),
     };
   }
 
@@ -2194,7 +2201,7 @@ export class Server {
     id: string,
     value: EntityDocument["value"],
   ): Promise<Engine.AppliedCommit> {
-    return await this.withSpacePublicationLock(space, async () => {
+    return await this.#withSpacePublicationLock(space, async () => {
       const engine = await this.openEngine(space);
       if (this.#aclMode() !== "off") {
         if (id === aclDocId(space)) {
@@ -3234,7 +3241,7 @@ export class Server {
     publishVerdict?: PublishTransactVerdict,
   ): Promise<ResponseMessage<Engine.AppliedCommit>> {
     const requestedAt = performance.now();
-    return await this.withSpacePublicationLock(message.space, async () => {
+    return await this.#withSpacePublicationLock(message.space, async () => {
       const lockWaitMs = performance.now() - requestedAt;
       let outcome = "threw";
       try {
@@ -3289,7 +3296,7 @@ export class Server {
   async resolveEventAttention(
     message: EventAttentionResolveRequest,
   ): Promise<ResponseMessage<EventAttentionResolveResult>> {
-    return await this.withSpacePublicationLock(message.space, async () => {
+    return await this.#withSpacePublicationLock(message.space, async () => {
       try {
         const session = this.#sessions.get(message.space, message.sessionId);
         if (session === null) {
@@ -6448,12 +6455,8 @@ export class Server {
    * A transaction arriving during fan-out waits for that turn to finish. Locks
    * for other spaces remain independent, so the latency coupling is local to
    * one space.
-   *
-   * TypeScript-private rather than a `#` name, because
-   * `test/v2-verdict-catchup.test.ts` replaces this member by assignment,
-   * which a `#` method does not allow.
    */
-  private async withSpacePublicationLock<T>(
+  async #withSpacePublicationLock<T>(
     space: string,
     run: () => Promise<T>,
   ): Promise<T> {
@@ -6513,7 +6516,7 @@ export class Server {
       });
 
       for (const space of spaces) {
-        await this.withSpacePublicationLock(space, async () => {
+        await this.#withSpacePublicationLock(space, async () => {
           // Removed at its own processing turn (CT-1927): pre-deleting the
           // whole selection meant a failure mid-batch stranded every
           // not-yet-processed space — dirty maps intact but the space no

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -1102,8 +1102,8 @@ export class PatternManager {
    * the space whose cache documents attest it. The ordinary save path still
    * preserves any authenticated delegation already present in `toSpace`.
    *
-   * TypeScript-private rather than a `#` name, because `test/cell-cache.test.ts`
-   * and `test/pattern-replication-sibling-race.test.ts` replace this member by
+   * TypeScript-private rather than a `#` name, because
+   * `test/pattern-replication-sibling-race.test.ts` replaces this member by
    * assignment, which a `#` method does not allow.
    */
   private async replicateClosures(

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -3413,13 +3413,13 @@ export class SpaceReplica
       buildReads: (source, localSeq, identity) =>
         this.#buildReads(source, localSeq, identity),
       consumeUpdates: (iterator) => this.#consumeUpdates(iterator),
-      // The next three forward to TypeScript-private members so that a test
+      // The next two forward to TypeScript-private members so that a test
       // which replaces one by assignment is honored here too.
       refreshWatchSet: (entries, type, watchBranch) =>
         this.refreshWatchSet(entries, type, watchBranch),
       applySessionSync: (sync, type) => this.applySessionSync(sync, type),
       waitForConflictReadRepair: (rejection) =>
-        this.waitForConflictReadRepair(rejection),
+        this.#waitForConflictReadRepair(rejection),
     };
   }
 
@@ -6163,7 +6163,7 @@ export class SpaceReplica
           this.#scopeKeyIdentity(),
         )
         : undefined;
-      await this.waitForConflictReadRepair(rejection);
+      await this.#waitForConflictReadRepair(rejection);
       this.#dropPending(localSeq);
       // Every drop funnels through here (server conflict, preempt, cascade,
       // reset — this is dropPending's only call site), so scanning right
@@ -7406,11 +7406,10 @@ export class SpaceReplica
   }
 
   /**
-   * TypeScript-private rather than a `#` name, because
-   * `test/memory-v2-subscription.test.ts` replaces this member by
-   * assignment, which a `#` method does not allow.
+   * Waits out the read repair a server conflict names, so that a retry of
+   * the rejected commit starts from the repaired base.
    */
-  private async waitForConflictReadRepair(
+  async #waitForConflictReadRepair(
     rejection: StorageTransactionRejected,
   ): Promise<void> {
     if (rejection.name !== "ConflictError") {

--- a/packages/runner/test/cell-cache.test.ts
+++ b/packages/runner/test/cell-cache.test.ts
@@ -1618,32 +1618,19 @@ describe("cell-cache: compiled-set store (CFC integrity, fail-closed)", () => {
     expect(runtime.patternManager.getArtifactEntryRef(keyed)).toEqual(ref);
     expect(runtime.patternManager.getArtifactEntryRef(keyless)).toBeUndefined();
 
-    const manager = runtime.patternManager as unknown as {
-      replicateClosures(
-        entryIdentity: string,
-        fromSpace: string,
-        toSpace: string,
-      ): Promise<void>;
-    };
-    const originalReplicateClosures = manager.replicateClosures;
-    let replicationCalls = 0;
-    manager.replicateClosures = () => {
-      replicationCalls++;
-      return Promise.resolve();
-    };
-    try {
-      runtime.patternManager.replicatePatternToSpace(keyed, spaceA, spaceA);
-      runtime.patternManager.replicatePatternToSpace(
-        keyless,
-        "did:key:z6MkCellCacheKeylessReplicationTarget",
-        spaceA,
-      );
-
-      await runtime.patternManager.flushCompileCacheWrites();
-      expect(replicationCalls).toBe(0);
-    } finally {
-      manager.replicateClosures = originalReplicateClosures;
-    }
+    // An issued replication registers in the manager's write set at once,
+    // so the set's size says whether either call issued one.
+    const writes =
+      runtime.patternManager.accessForTestingOnly.compileCacheWrites;
+    const before = writes.size;
+    runtime.patternManager.replicatePatternToSpace(keyed, spaceA, spaceA);
+    runtime.patternManager.replicatePatternToSpace(
+      keyless,
+      "did:key:z6MkCellCacheKeylessReplicationTarget",
+      spaceA,
+    );
+    expect(writes.size).toBe(before);
+    await runtime.patternManager.flushCompileCacheWrites();
   });
 
   it("replicates fabric dependencies without importing authority", async () => {

--- a/packages/runner/test/executor-space-root-ensure.test.ts
+++ b/packages/runner/test/executor-space-root-ensure.test.ts
@@ -32,11 +32,21 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
-import type { SessionSync } from "@commonfabric/memory/v2";
+import type { FabricValue } from "@commonfabric/api";
+import type { Signer, URI } from "@commonfabric/memory/interface";
+import {
+  encodeMemoryBoundary,
+  type SessionSync,
+} from "@commonfabric/memory/v2";
+import * as MemoryV2Client from "@commonfabric/memory/v2/client";
 import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 import * as Engine from "@commonfabric/memory/v2/engine";
 import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
-import type { SpaceReplica } from "../src/storage/v2.ts";
+import {
+  type Options as V2Options,
+  type SessionFactory,
+  type SpaceReplica,
+} from "../src/storage/v2.ts";
 import { Runtime, type RuntimeFetch } from "../src/runtime.ts";
 import type {
   IExtendedStorageTransaction,
@@ -61,7 +71,7 @@ import {
   getPatternSource,
   resolveEntryIdentity,
 } from "../src/index.ts";
-import { newSharedServer } from "./memory-v2-test-utils.ts";
+import { newSharedServer, TestStorageManager } from "./memory-v2-test-utils.ts";
 import { waitUntil } from "./support/wait-until.ts";
 
 const spaceSigner = await Identity.fromPassphrase("space root ensure space");
@@ -83,6 +93,100 @@ function rootSource(marker: string): string {
     "export default Root;",
     "",
   ].join("\n");
+}
+
+/**
+ * A loopback session factory whose frames reach the client with every `cid:`
+ * upsert dropped, the absorb defect placed at the wire: the replica applies
+ * exactly the frames a defective client would hand it. Counts what it
+ * dropped and records the `computed:` documents it let through.
+ */
+class CidDroppingSessionFactory implements SessionFactory {
+  droppedCids = 0;
+  readonly computedSeen = new Set<string>();
+  readonly #getServer: () => MemoryV2Server.Server;
+
+  constructor(getServer: () => MemoryV2Server.Server) {
+    this.#getServer = getServer;
+  }
+
+  async create(
+    space: MemorySpace,
+    signer?: Signer,
+    mountOptions: MemoryV2Client.MountOptions = {},
+  ) {
+    const client = await MemoryV2Client.connect({
+      transport: this.#transport(),
+    });
+    const session = await client.mount(
+      space,
+      mountOptions,
+      (_space, _session, context) => ({
+        invocation: {
+          aud: context.audience,
+          challenge: context.challenge.value,
+        },
+        authorization: {
+          principal: signer?.did(),
+        },
+      }),
+    );
+    return { client, session };
+  }
+
+  #transport(): MemoryV2Client.Transport {
+    let receiver: (payload: string) => void = () => {};
+    const connection = this.#getServer().connect((message) => {
+      receiver(
+        encodeMemoryBoundary(this.#filter(message) as unknown as FabricValue),
+      );
+    });
+    return {
+      async send(payload: string) {
+        await connection.receive(payload);
+      },
+      close() {
+        connection.close();
+        return Promise.resolve();
+      },
+      setReceiver(next) {
+        receiver = next;
+      },
+      setCloseReceiver() {},
+    };
+  }
+
+  #filter(message: unknown): unknown {
+    const frame = message as {
+      type?: string;
+      effect?: SessionSync;
+      ok?: { sync?: SessionSync };
+    };
+    if (frame.type === "session/effect" && frame.effect?.type === "sync") {
+      return { ...frame, effect: this.#filterSync(frame.effect) };
+    }
+    if (frame.type === "response" && frame.ok?.sync?.type === "sync") {
+      return {
+        ...frame,
+        ok: { ...frame.ok, sync: this.#filterSync(frame.ok.sync) },
+      };
+    }
+    return message;
+  }
+
+  #filterSync(sync: SessionSync): SessionSync {
+    const kept = sync.upserts.filter((upsert) => {
+      if (upsert.id.startsWith("computed:")) this.computedSeen.add(upsert.id);
+      if (upsert.id.startsWith("cid:")) {
+        this.droppedCids += 1;
+        return false;
+      }
+      return true;
+    });
+    return kept.length === sync.upserts.length
+      ? sync
+      : { ...sync, upserts: kept };
+  }
 }
 
 describe("SpaceServer space-root ensure (OW45 arm-B stage 1)", () => {
@@ -365,41 +469,26 @@ describe("SpaceServer space-root ensure (OW45 arm-B stage 1)", () => {
     await seedAcl({ [space]: "OWNER" });
     const created = newSpaceServer();
 
-    const reader = clientRuntime(readerSigner);
-    // The simulated absorb defect: DROP every cid: upsert before the
-    // frame applies. Installed on the reader's replica before its
-    // space-cell subscription (the suite's established instance-patch
-    // seam).
-    const replica = (reader.storageManager.open(space) as unknown as {
-      replica: {
-        applySessionSync: SpaceReplica["accessForTestingOnly"][
-          "applySessionSync"
-        ];
-        getDocument(uri: string): unknown;
-      };
-    }).replica;
-    let droppedCids = 0;
-    const computedSeen = new Set<string>();
-    const originalApply = replica.applySessionSync.bind(replica);
-    replica.applySessionSync = (sync, type) => {
-      const frame = sync as { upserts?: Array<{ id?: unknown }> };
-      const upserts = Array.isArray(frame?.upserts) ? frame.upserts : [];
-      const kept = upserts.filter((upsert) => {
-        if (typeof upsert?.id !== "string") return true;
-        if (upsert.id.startsWith("computed:")) computedSeen.add(upsert.id);
-        if (upsert.id.startsWith("cid:")) {
-          droppedCids += 1;
-          return false;
-        }
-        return true;
-      });
-      return originalApply(
-        kept.length === upserts.length
-          ? sync
-          : { ...sync, upserts: kept } as SessionSync,
-        type,
-      );
-    };
+    // The simulated absorb defect: every cid: upsert is DROPPED at the
+    // wire, before the reader's replica sees the frame, so the replica
+    // applies exactly what a defective client would hand it.
+    const dropping = new CidDroppingSessionFactory(() => server);
+    const readerManager = TestStorageManager.create({
+      as: readerSigner,
+      memoryHost: new URL("memory://"),
+    } as V2Options, dropping);
+    const reader = new Runtime({
+      apiUrl: new URL("http://toolshed.test"),
+      storageManager: readerManager,
+      fetch: fetchStub,
+    });
+    cleanups.push(async () => {
+      await reader.dispose();
+      await readerManager.close();
+    });
+    const replica = readerManager.open(space).replica as SpaceReplica;
+    const droppedCids = () => dropping.droppedCids;
+    const computedSeen = dropping.computedSeen;
 
     // Subscribe FIRST (this starts the background consumer), activate
     // SECOND: everything the ensure materializes reaches this replica
@@ -424,7 +513,7 @@ describe("SpaceServer space-root ensure (OW45 arm-B stage 1)", () => {
       "the ensured root's computed cell riding the plain subscription",
     );
     await waitUntil(
-      () => droppedCids > 0,
+      () => droppedCids() > 0,
       "the simulated absorb defect dropping a cid delivery",
     );
     await waitUntil(
@@ -440,7 +529,7 @@ describe("SpaceServer space-root ensure (OW45 arm-B stage 1)", () => {
     await waitUntil(
       () => {
         quarantinedId = [...computedSeen].find((id) =>
-          replica.getDocument(id) === undefined
+          replica.getDocument(id as URI) === undefined
         );
         return quarantinedId !== undefined;
       },
@@ -511,7 +600,7 @@ describe("SpaceServer space-root ensure (OW45 arm-B stage 1)", () => {
     // The request path exercised the exact quarantined doc, and the
     // quarantine held through it (its cid rode the response and was
     // dropped by the simulated defect again).
-    expect(replica.getDocument(quarantinedId!)).toBeUndefined();
+    expect(replica.getDocument(quarantinedId! as URI)).toBeUndefined();
     const witness = reader.getCell<{ n?: number }>(
       space,
       "ow61-containment-witness",

--- a/packages/runner/test/executor-space-root-ensure.test.ts
+++ b/packages/runner/test/executor-space-root-ensure.test.ts
@@ -35,18 +35,16 @@ import { Identity } from "@commonfabric/identity";
 import type { FabricValue } from "@commonfabric/api";
 import type { Signer, URI } from "@commonfabric/memory/interface";
 import {
+  decodeMemoryBoundary,
   encodeMemoryBoundary,
+  type ServerMessage,
   type SessionSync,
 } from "@commonfabric/memory/v2";
 import * as MemoryV2Client from "@commonfabric/memory/v2/client";
 import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 import * as Engine from "@commonfabric/memory/v2/engine";
 import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
-import {
-  type Options as V2Options,
-  type SessionFactory,
-  type SpaceReplica,
-} from "../src/storage/v2.ts";
+import type { SessionFactory, SpaceReplica } from "../src/storage/v2.ts";
 import { Runtime, type RuntimeFetch } from "../src/runtime.ts";
 import type {
   IExtendedStorageTransaction,
@@ -134,42 +132,44 @@ class CidDroppingSessionFactory implements SessionFactory {
     return { client, session };
   }
 
+  /**
+   * The real loopback, with each frame decoded, filtered, and re-encoded on
+   * its way to the client, so the client keeps loopback's one-frame-per-turn
+   * delivery and sees only what the filter lets through.
+   */
   #transport(): MemoryV2Client.Transport {
-    let receiver: (payload: string) => void = () => {};
-    const connection = this.#getServer().connect((message) => {
-      receiver(
-        encodeMemoryBoundary(this.#filter(message) as unknown as FabricValue),
-      );
-    });
+    const inner = MemoryV2Client.loopback(this.#getServer());
     return {
-      async send(payload: string) {
-        await connection.receive(payload);
-      },
-      close() {
-        connection.close();
-        return Promise.resolve();
-      },
-      setReceiver(next) {
-        receiver = next;
-      },
-      setCloseReceiver() {},
+      ...inner,
+      setReceiver: (next) =>
+        inner.setReceiver((payload) =>
+          next(
+            encodeMemoryBoundary(
+              this.#filter(
+                decodeMemoryBoundary(payload) as unknown as ServerMessage,
+              ) as unknown as FabricValue,
+            ),
+          )
+        ),
     };
   }
 
-  #filter(message: unknown): unknown {
-    const frame = message as {
-      type?: string;
+  #filter(message: ServerMessage): ServerMessage {
+    const frame = message as ServerMessage & {
       effect?: SessionSync;
       ok?: { sync?: SessionSync };
     };
     if (frame.type === "session/effect" && frame.effect?.type === "sync") {
-      return { ...frame, effect: this.#filterSync(frame.effect) };
+      return {
+        ...(frame as object),
+        effect: this.#filterSync(frame.effect),
+      } as unknown as ServerMessage;
     }
     if (frame.type === "response" && frame.ok?.sync?.type === "sync") {
       return {
-        ...frame,
-        ok: { ...frame.ok, sync: this.#filterSync(frame.ok.sync) },
-      };
+        ...(frame as object),
+        ok: { ...(frame.ok as object), sync: this.#filterSync(frame.ok.sync) },
+      } as unknown as ServerMessage;
     }
     return message;
   }
@@ -476,7 +476,7 @@ describe("SpaceServer space-root ensure (OW45 arm-B stage 1)", () => {
     const readerManager = TestStorageManager.create({
       as: readerSigner,
       memoryHost: new URL("memory://"),
-    } as V2Options, dropping);
+    }, dropping);
     const reader = new Runtime({
       apiUrl: new URL("http://toolshed.test"),
       storageManager: readerManager,

--- a/packages/runner/test/memory-v2-subscription.test.ts
+++ b/packages/runner/test/memory-v2-subscription.test.ts
@@ -15,6 +15,7 @@ import { defer } from "@commonfabric/utils/defer";
 
 import { Runtime } from "../src/runtime.ts";
 import { StorageManager } from "../src/storage/cache.deno.ts";
+import { registerCommitRejectionListener } from "../src/storage/reactivity-log.ts";
 import type {
   IExtendedStorageTransaction,
   IReadActivity,
@@ -565,19 +566,6 @@ describe("Memory v2 storage notifications", () => {
       ) => Promise<{ ok?: unknown; error?: unknown }>;
     };
     const repairStarted = defer<void>();
-    // Replaced by assignment below, which its `private` rather than `#` name
-    // allows; the cast reaches only it.
-    const stubbed = replica as unknown as {
-      waitForConflictReadRepair(
-        rejection: StorageTransactionRejected,
-      ): Promise<void>;
-    };
-    const originalWaitForConflictReadRepair = stubbed
-      .waitForConflictReadRepair.bind(stubbed);
-    stubbed.waitForConflictReadRepair = async (rejection) => {
-      repairStarted.resolve();
-      await originalWaitForConflictReadRepair(rejection);
-    };
     const firstUri = `of:memory-v2-close-retry-a-${Date.now()}` as URI;
     const secondUri = `of:memory-v2-close-retry-b-${Date.now()}` as URI;
     const factAddress = { id: firstUri, type: "application/json" as MIME };
@@ -608,6 +596,11 @@ describe("Memory v2 storage notifications", () => {
       ],
     });
 
+    // The replica notifies the commit's source of the rejection just before
+    // it waits out the read repair, so the listener fires as the repair
+    // starts.
+    const source = staleReadSource(firstUri, 1);
+    registerCommitRejectionListener(source, () => repairStarted.resolve());
     const commitPromise = replica.commitNative({
       operations: [{
         op: "set",
@@ -615,7 +608,7 @@ describe("Memory v2 storage notifications", () => {
         type: "application/json",
         value: { value: { version: 3 } },
       }],
-    }, staleReadSource(firstUri, 1));
+    }, source);
     expect(replica.get(factAddress)?.is).toEqual({ value: { version: 3 } });
 
     // Close only after the server conflict has reached the read-repair path.

--- a/packages/runner/test/memory-v2-subscription.test.ts
+++ b/packages/runner/test/memory-v2-subscription.test.ts
@@ -596,9 +596,9 @@ describe("Memory v2 storage notifications", () => {
       ],
     });
 
-    // The replica notifies the commit's source of the rejection just before
-    // it waits out the read repair, so the listener fires as the repair
-    // starts.
+    // The push path notifies the rejection's sources and then finalizes the
+    // rejection, which reaches the read-repair wait with no await between,
+    // so the listener fires as the repair starts.
     const source = staleReadSource(firstUri, 1);
     registerCommitRejectionListener(source, () => repairStarted.resolve());
     const commitPromise = replica.commitNative({

--- a/packages/runner/test/memory-v2-watch-remove-coverage.test.ts
+++ b/packages/runner/test/memory-v2-watch-remove-coverage.test.ts
@@ -113,6 +113,13 @@ class WatchAddRemoveTransport extends ScriptedSessionTransport {
 class FailFirstWatchRemovalTransport extends ScriptedSessionTransport {
   watchRemovalAttempts = 0;
   onWatchAdded?: () => void;
+
+  /**
+   * How many successful removal responses to send without their `sync`,
+   * which the session's apply then throws on; a client-side apply failure
+   * rather than a wire refusal.
+   */
+  malformedRemovalSyncs = 0;
   readonly #failuresBeforeSuccess: number;
   readonly #precedingId?: URI;
   #serverSeq = 1;
@@ -157,6 +164,15 @@ class FailFirstWatchRemovalTransport extends ScriptedSessionTransport {
       }
       case "session.watch.set":
         this.watchRemovalAttempts++;
+        if (this.malformedRemovalSyncs > 0) {
+          this.malformedRemovalSyncs--;
+          this.respond({
+            type: "response",
+            requestId: message.requestId!,
+            ok: { serverSeq: this.#serverSeq },
+          });
+          return;
+        }
         if (this.watchRemovalAttempts <= this.#failuresBeforeSuccess) {
           this.respond({
             type: "response",
@@ -395,21 +411,9 @@ Deno.test("absence reconciliation retries when applying a watch removal sync fai
     storageManager,
   });
   const provider = storageManager.open(space);
-  // The member is replaced by assignment, which its `private` rather than
-  // `#` name allows; the cast reaches only it, typed as the class types it.
-  const replica = provider.replica as unknown as {
-    applySessionSync: SpaceReplica["accessForTestingOnly"]["applySessionSync"];
-  };
-  const originalApply = replica.applySessionSync.bind(replica);
-  let applyCalls = 0;
-  replica.applySessionSync = (sync, type) => {
-    applyCalls++;
-    if (applyCalls === 2) {
-      replica.applySessionSync = originalApply;
-      throw new Error("synthetic watch removal apply failure");
-    }
-    originalApply(sync, type);
-  };
+  // The first removal's response arrives without its `sync`, so applying it
+  // fails on the client side after the wire accepted it.
+  transport.malformedRemovalSyncs = 1;
   const tx = runtime.edit();
   tx.read({
     space,
@@ -423,7 +427,6 @@ Deno.test("absence reconciliation retries when applying a watch removal sync fai
     assertEquals(await provider.loadUnexaminedAbsences!(tx.tx), 0);
     assertEquals(transport.watchRemovalAttempts, 2);
   } finally {
-    replica.applySessionSync = originalApply;
     tx.abort("inspection only");
     await runtime.dispose();
     await storageManager.close();

--- a/packages/runner/test/schema-doc-sync.test.ts
+++ b/packages/runner/test/schema-doc-sync.test.ts
@@ -666,33 +666,16 @@ describe("schema-doc-sync", () => {
   it("the background consumer survives a frame that fails to apply and keeps consuming", async () => {
     const provider = readerStorage.open(space);
     const replica = provider.replica as SpaceReplica;
-    // Throw once from applySessionSync itself (any non-validation apply
-    // bug), self-restoring: the belt in consumeUpdates must swallow it,
-    // keep the loop alive, and apply the NEXT frame. The member is replaced
-    // by assignment, which its `private` rather than `#` name allows; the
-    // cast reaches only it.
-    const stubbed = replica as unknown as {
-      applySessionSync(sync: SessionSync, type: "pull" | "integrate"): void;
-    };
-    const original = stubbed.applySessionSync.bind(stubbed);
-    stubbed.applySessionSync = () => {
-      stubbed.applySessionSync = original;
-      throw new Error("synthetic apply failure");
-    };
+    // The first frame has no `upserts`, which the apply reads at once and
+    // throws on: the belt in consumeUpdates must swallow that, keep the loop
+    // alive, and apply the NEXT frame.
     const frames: SessionSync[] = [
       {
         type: "sync",
         fromSeq: 600_000,
         toSeq: 600_001,
-        upserts: [{
-          branch: "",
-          id: "of:survivor-1",
-          scope: "space",
-          seq: 1,
-          doc: { value: { n: 1 } },
-        }],
         removes: [],
-      },
+      } as unknown as SessionSync,
       {
         type: "sync",
         fromSeq: 600_001,


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Fable 5.1)

The first slice of the stub-by-assignment tail: every case where the test
could drive a seam the class already offers, in one PR as ruled. Each test
replaced a TypeScript-`private` method by assignment; each now reaches the
same behavior another way, and where that was the member's last stub, the
member is a `#` name.

## The six rewrites

- **`Server.withSpacePublicationLock`** (`memory/test/v2-verdict-catchup.test.ts`).
  The test took the lock's turn hostage from inside a wrapper. It now
  takes publication turns of its own through the accessor: turn A holds
  the lock while the transact queues behind it, turn B queues behind the
  transact, and fan-out behind B, which is the lock's own first-come
  order. The transact goes to `server.transact()` directly, because the
  connection's receive path awaits before it reaches the lock and would
  make the queue order a race. The pin is unchanged: the verdict is at the
  committing session as soon as the transact's turn ends, and no frame
  reaches it until the turn ahead of fan-out is released. `#` now; the
  per-space independence test in `v2-server.test.ts`, which called the lock
  through a cast the census had not counted, calls it through the
  accessor.
- **`SpaceReplica.waitForConflictReadRepair`** (`runner/test/memory-v2-subscription.test.ts`).
  The replica notifies the commit's source of the rejection synchronously
  just before it waits out the repair, so the test registers a
  commit-rejection listener on its own read source. `#` now.
- **`PatternManager.replicateClosures`**, the cell-cache case. An issued
  replication registers in the compile-cache write set synchronously, and
  the accessor already hands that set over; the test asserts the set did
  not grow. The member stays `private` for its other stub, whose
  synchronous throw no real path produces (that case is for the next
  slice).
- **`SpaceReplica.applySessionSync`**, three of four sites. The
  consumer-survival test feeds a frame with no `upserts` through the
  iterator it owns, which the apply throws on at once. The watch-removal
  retry test has its scripted transport answer the first removal without
  its `sync`, which the session's apply throws on, so the retry is driven
  by a client-side apply failure as before, now from the wire. The OW61
  containment test drops `cid:` upserts at the wire, through a loopback
  session factory that filters frames before the client sees them, so the
  replica applies exactly what a defective client would hand it; the
  counters it asserts on move to that factory. The member stays `private`
  for its fourth site, a validation failure no real path produces (next
  slice).

## Not in this PR

- **`Runner.startWithTx`**: the plan was to recognize a start transaction
  by the `piece-start/` run stamp the runner puts on it. The flag-OFF arm
  of the deferred-start suite never applies that stamp, so the injector
  cannot tell a start commit apart there; tried, reverted. It needs a
  different seam.
- The four unreachable-outcome cases, the two collaborators, the two
  telemetry markers, and the four `CellBridge` real-path rewrites, per the
  seams opinion recorded beside BL-093.

## Review

Reviewed by a `cf-review` pass: request changes, on two blockers, both
applied in the second commit. The cid-drop session factory had replaced
loopback with a synchronous delivery, losing the one-frame-per-turn
discipline the real loopback keeps; it now wraps `MemoryV2Client.loopback`
and filters at the payload boundary. An unused binding failed lint. Its
improvements are taken too: the publication-lock test records how many
verdicts the committer holds as turn B enters, which a verdict published
after the transact's turn could not satisfy; the subscription test's
comment names the push path's notification, the one that fires; and the
watch-removal retry test is noted below. Both nits taken.

The watch-removal retry now drives the retry from the client's apply (the
session rejects a removal response with no `sync`), which is the same
branch the wire-refusal test above it covers; the replica's own inner
`view.close()` branch, which the old stub reached, is uncovered until the
fourth `applySessionSync` site is settled. Recorded beside BL-093.

## Coverage

The gate reports three lines over the runner baseline: the replica's
inner `view.close(); throw` branch in `#removeWatchIds`, which the old
stub reached by making the replica's own apply throw and which the
client-side failure no longer does. Uncovered until the fourth
`applySessionSync` site is settled, as the Review section says.

ACCEPT_COVERAGE_DEBT: packages/runner +3 lines

## Gates

`deno fmt --check`, `deno lint`, `deno task check`, the memory suite, and
the runner suite.
