### PR TITLE
describe_handle discloses an injected database's tables and its columns' labels

### DIFF
--- a/docs/common/README.md
+++ b/docs/common/README.md
@@ -85,6 +85,7 @@ on the Common Fabric runtime.
 
 - [capabilities/llm.md](capabilities/llm.md) — `generateText` / `generateObject`; reactive results, no `await`
 - [capabilities/fetch.md](capabilities/fetch.md) — `fetchJson` / `fetchText` / `fetchJsonUnchecked` / `fetchBinary`; reactive results, no `await`
+- [capabilities/sqlite.md](capabilities/sqlite.md) — reading a `SqliteDb` a pattern was given as an input: `db.query`, one statement per database, session-scoped results under a read ceiling
 
 ### workflows/ — CLI and testing mechanics
 

--- a/docs/common/capabilities/sqlite.md
+++ b/docs/common/capabilities/sqlite.md
@@ -1,0 +1,123 @@
+# Reading a SQLite Database
+
+A pattern can be handed a SQLite database the way it is handed any other input:
+by reference. The input is typed `SqliteDb`, and the pattern reads it with
+`db.query`. It never opens a file, never names a path, and never picks a source
+— whoever wired the input chose those.
+
+The handle's readable value is a small descriptor, not the data. Reading it as
+a value tells a pattern nothing it can compute over; the rows come back only
+from a query.
+
+## Declaring the input
+
+Type the input `SqliteDb`, imported from `commonfabric`:
+
+```tsx
+// Shown at module scope.
+import { pattern, type SqliteDb } from "commonfabric";
+
+interface Input {
+  orders: SqliteDb;
+}
+
+export default pattern<Input>(({ orders }) => ({
+  count: orders.query<{ n: number }>("SELECT count(*) AS n FROM orders"),
+}));
+```
+
+`SqliteDb` is the whole declaration. A pattern that widens it — to `any`, or to
+a hand-written object type with a `query` method on it — compiles and then
+receives the handle's descriptor value rather than the handle, so `query` is
+missing at run time. What makes the input arrive as a handle is the declared
+type: `SqliteDb` is what the compiler lowers to the cell-shaped input the
+runtime binds a database to.
+
+## db.query
+
+`db.query<Row>(sql, options?)` is a reactive read, not a promise. Never `await`
+it. Call it in the pattern body and read `pending` / `error` / `result`
+reactively; it re-runs when its inputs change, and results are memoized per
+request.
+
+```tsx
+// Shown at module scope.
+export default pattern<{ orders: SqliteDb }>(({ orders }) => {
+  const pending = orders.query<{ id: number; glaze: string; boxes: number }>(
+    "SELECT id, glaze, boxes FROM orders WHERE shipped = 0 ORDER BY id",
+  );
+
+  return lift((rows?: Array<{ glaze: string; boxes: number }>) =>
+    (rows ?? []).map((row) => `${row.boxes} × ${row.glaze}`).join(", ")
+  )(pending.result);
+});
+```
+
+The `<Row>` type argument names the columns the statement projects, and is what
+turns a result into something typed. Without it the rows come back as
+`Record<string, unknown>`, and a `_cf_link` column comes back as a raw link
+string rather than a live cell.
+
+The tables are declared on the database rather than on the pattern, so a
+pattern reading an input database does not restate them. What it needs to know
+is which tables and columns are there — the shape of the contract it is
+querying against — and that is a property of the handle it was given.
+
+Where a pattern also writes to the database, pass `{ reactOn: db }` so the read
+re-runs after a committed write. An input a pattern only reads has nothing to
+react to.
+
+## One statement, one database
+
+A query is a single read-only `SELECT` (a read-only CTE counts). Multiple
+statements, DML, DDL, `PRAGMA`, `ATTACH` and `DETACH` are refused, and so is a
+schema-qualified table name. The consequence worth planning around: one
+statement reads the tables of the one database it was issued on, and no
+statement can join across two handles. Two databases means two queries and a
+join expressed in the pattern.
+
+## Session-scoped results
+
+Where the runtime carries a read ceiling — a lens on what this particular run
+may observe — the result of every query it issues has to be **session-scoped**,
+and a query whose result is broader is refused before anything is written. A
+space- or user-shared result is one cell that every runtime on the space
+resolves, so one runtime cannot narrow it for itself; a session-scoped result
+is the run's own.
+
+Declare the scope on the query:
+
+```tsx
+// Shown at module scope.
+export const recentOrders = (orders: SqliteDb) =>
+  orders.query<{ id: number; glaze: string }>(
+    "SELECT id, glaze FROM orders ORDER BY id DESC LIMIT 20",
+    { scope: "session" },
+  );
+```
+
+`PerSession<>` on the result field and `.asScope("session")` on the query do
+the same thing, and a session-scoped database makes its queries session-scoped
+without a declaration. A run under a ceiling that gets a refusal instead of
+rows is usually a query that declared no scope.
+
+## Labeled columns
+
+A column may declare an `ifc` label on the database's table schema, and that
+label rides into the result: a row read out of a labeled column carries what
+the column requires, and code downstream of the read is held to it. Two
+options bound a read against such a column — `maxConfidentiality` for a ceiling
+the result may not exceed, and `onExceed` to choose between failing the query
+and dropping the rows that exceed it.
+
+## The rest of the API
+
+[`docs/specs/sqlite-builtin/`](../../specs/sqlite-builtin/README.md) is the full
+specification: the handle type and the method surface in
+[01](../../specs/sqlite-builtin/01-api.md), links in columns in
+[02](../../specs/sqlite-builtin/02-cf-link-encoding.md), where a database comes
+from in [03](../../specs/sqlite-builtin/03-database-sources.md), the statement
+guard and transactions in
+[04](../../specs/sqlite-builtin/04-server-execution-and-transactions.md),
+reactivity in [05](../../specs/sqlite-builtin/05-reactivity.md), and the label
+rules in [06](../../specs/sqlite-builtin/06-cfc.md).

--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -124,8 +124,9 @@ What works today:
   - `edit_file`
   - `write_file`
   - `delegate_task`
-  - `describe_handle` (shape and labels of a handle's referent, never its value;
-    see [Inspecting a handle's shape](#inspecting-a-handles-shape))
+  - `describe_handle` (shape and labels of a handle's referent, and the tables
+    of one that is a database, never its data; see
+    [Inspecting a handle's shape](#inspecting-a-handles-shape))
   - `run_pattern` (present only when the run configures a fabric session; see
     [Running patterns against a Fabric space](#running-patterns-against-a-fabric-space))
   - `search_patterns` (present only when the run configures a pattern index with
@@ -929,6 +930,28 @@ table, so shape stays inspectable in every run that has handles at all. A token
 the run's table does not hold comes back `known: false` rather than as an error,
 since a token from another run simply names nothing here.
 
+**A referent that declares nothing and is a database is the third source, and
+the one place the tool reads a value.** Some referents state their contract in
+their value rather than in their metadata, and a SQLite database handle is the
+case that matters: an injected connector database arrives as a cell nothing
+declared a schema for, whose value carries the table schemas the database was
+created under. The rows are in the database file, which nothing here opens. So
+where no schema was declared and the value is a database handle, the reply
+carries `database` instead of `schema`: `tables`, one property per table whose
+own properties are that table's columns with their types, and `labels`, one
+entry per column that declares an `ifc`, addressed by table name and column
+name. The tables go through the same reduction every disclosed schema does, so
+the table- and column-name channels are bounded exactly as a property-name
+channel is and the columns' annotations, prose and defaults do not ride out on
+the schema. The read is conditional on nothing being declared, so a referent
+that states its own shape is never opened.
+
+Without it a database reads as an opaque value, and the code an agent writes
+over an opaque value is code that treats it as one — stringifying a handle and
+handing it to a language model rather than issuing a query against it.
+[`docs/common/capabilities/sqlite.md`](../../docs/common/capabilities/sqlite.md)
+is what a pattern does with the answer.
+
 **What is disclosed is structure and only structure**: property names, types,
 nesting, required-ness, array and object composition, a `type` from the schema
 vocabulary, a `format` from the small known set, and a local `$ref` with the
@@ -1000,9 +1023,10 @@ and never the path taken from it, and that whatever comes back is reduced to
 structure before any of it crosses. An address the session can state no shape
 for is reported as shapeless rather than as a failed call.
 
-`describe_handle` is declared `effectClass: "read"` and reads no value, but
-answering from the fabric establishes the run's fabric session — loading the
-identity key and opening a remote connection. The first call in a run therefore
+`describe_handle` is declared `effectClass: "read"`. It reads no value except a
+database handle's own table declaration, and it reports no datum from any of
+them. Answering from the fabric establishes the run's fabric session — loading
+the identity key and opening a remote connection — so the first call in a run
 carries that cost and that effect.
 
 Shape is also what makes a chain of steps checkable. An orchestrator that passes

--- a/packages/cf-harness/docs/CURRENT_STATE.md
+++ b/packages/cf-harness/docs/CURRENT_STATE.md
@@ -172,12 +172,19 @@ The current package provides:
   `const`, `enum`, `default`, `examples`, and free-text annotations never leave
   the tool. Property names do cross, since code cannot be written over data
   without them, so they are bounded in count and length and the model-facing
-  reply is scrubbed of bare fabric identifiers at every depth, keys included.
-  Disclosure is permissive and fixed rather than configurable — no setting
-  narrows it — and is bounded to addresses in the session's own space; that
-  bound is on the handle's own address rather than on everything the document
-  reaches from it. Answering from the fabric establishes the run's fabric
-  session despite the tool's `read` effect class;
+  reply is scrubbed of bare fabric identifiers at every depth, keys included. A
+  referent that declares no schema and whose value is a SQLite database handle
+  reports `database` instead: its tables, one property per table whose own
+  properties are that table's columns with their types, reduced by the same
+  allowlist, and one label entry per column that declares an `ifc`, addressed by
+  table name and column name. That is the one place the tool reads a value, and
+  it is conditional on nothing being declared — a database's tables are the
+  contract it was created under, its rows are in the database file, and nothing
+  here opens one. Disclosure is permissive and fixed rather than configurable —
+  no setting narrows it — and is bounded to addresses in the session's own
+  space; that bound is on the handle's own address rather than on everything the
+  document reaches from it. Answering from the fabric establishes the run's
+  fabric session despite the tool's `read` effect class;
 - bounded request-attribution headers on OpenAI-compatible gateway traffic,
   using persisted operational provenance rather than request content or personal
   identifiers;

--- a/packages/cf-harness/docs/IMPLEMENTATION_PROFILE.md
+++ b/packages/cf-harness/docs/IMPLEMENTATION_PROFILE.md
@@ -179,11 +179,14 @@ with the Browser Access CDP endpoint attached by the harness rather than written
 by the model.
 
 `describe_handle` reports the referent's structural schema and path segments,
-never its value. It prefers the session Fabric's declared shape when available
+never its data. It prefers the session Fabric's declared shape when available
 and otherwise uses a harness-captured schema, recursively removes value-bearing
 and descriptive schema fields, bounds disclosed property names, and scrubs bare
-Fabric identifiers. An unknown or shapeless token remains an ordinary bounded
-tool result rather than a dereference path.
+Fabric identifiers. A referent that declares no schema and holds a SQLite
+database handle reports that database's tables and its columns' labels through
+the same reduction, which is the one value the tool reads. An unknown or
+shapeless token remains an ordinary bounded tool result rather than a
+dereference path.
 
 `run_pattern` accepts at most 256 KiB of inline source. It resolves whole-string
 LLM-friendly link inputs to live cells only within the configured space and

--- a/packages/cf-harness/docs/system-map/cfc-system-map.html
+++ b/packages/cf-harness/docs/system-map/cfc-system-map.html
@@ -669,7 +669,7 @@
     // ------------------------------------------------------------------ layout data
     // The state of this repository the map describes. Bump both when the
     // map is re-verified; the stamp is drawn in the canvas's top-left corner.
-    const SNAPSHOT = { date: "2026-09-04", sha: "38ef88a585" };
+    const SNAPSHOT = { date: "2026-09-07", sha: "8f3c431193" };
     const W = 2760, H = 1840;
     const bands = [
       {
@@ -1977,7 +1977,7 @@
         threats: ["t7"],
         close: [
           "Injection seeds <code>tables: {}</code> and treats injected files as unlabeled, so connector rows carry no labels yet. Decide how a connector's schema and row-label rules reach the handle (CT-2189 gap 2, shared loom + labs).",
-          "<code>describe_handle</code> can tell the model nothing about an injected table until the handle cell declares a schema (gap 4, ours, small).",
+          "<code>describe_handle</code> reports an injected database's tables, its columns and their <code>ifc</code> labels, read off the handle value where the cell declares no schema (gap 4, ours, closed). What the model can be told is therefore bounded by what injection puts on the handle, which is gap 2 above.",
         ],
       },
       connectors: {
@@ -2431,7 +2431,7 @@
             ],
             sel: "handles",
             h: "Mint the handle",
-            t: "The input cell becomes cfh:a:… in the model's world. The model sees the cell's schema and label through describe_handle, never the rows.",
+            t: "The input cell becomes cfh:a:… in the model's world. The model sees the cell's schema and label through describe_handle — or, for a database, its tables and its columns' labels — never the rows.",
           },
           {
             f: ["parent", "e_parent_child", "g_deleg", "child_pa"],

--- a/packages/cf-harness/src/tools/describe-handle.ts
+++ b/packages/cf-harness/src/tools/describe-handle.ts
@@ -1,4 +1,5 @@
 import type { JSONSchema } from "@commonfabric/api";
+import { columnDeclaresIfc, isSqliteDbRef } from "@commonfabric/memory/v2";
 import type { Cell } from "@commonfabric/runner";
 import { cfcLabelViewForCellFailClosed } from "@commonfabric/runner/cfc";
 import { parseLLMFriendlyLink } from "@commonfabric/runner/shared";
@@ -46,6 +47,41 @@ export interface DescribeHandleToolOutput {
    * says the space holds none, which is a different answer.
    */
   labels?: DescribeHandleLabel[];
+
+  /**
+   * The table contract of a referent that is a SQLite database, reported
+   * where the referent declares no schema of its own. Without it a database
+   * handed to a run is indistinguishable from an opaque value, and the code
+   * an agent can write over it is code that treats it as one.
+   */
+  database?: DescribeHandleDatabase;
+}
+
+/**
+ * What a SQLite database handle states about itself: the shape of a row of
+ * each of its tables, and what handling each column demands. Rows are not
+ * part of it. They live in the database rather than in the handle, and
+ * nothing here opens one — the tables are the contract the database was
+ * created under, which is a declaration in exactly the sense a schema is.
+ */
+export interface DescribeHandleDatabase {
+  /**
+   * One property per table, whose own properties are that table's columns
+   * with their declared types. Reduced like every other disclosed schema, so
+   * column annotations, prose and defaults do not ride out on it, and the
+   * table- and column-name channels are bounded exactly as any other
+   * property-name channel is.
+   */
+  tables: JSONSchema;
+
+  /**
+   * The columns that declare a CFC label, each addressed by its table name
+   * and its column name. Atom types and nothing else, the same line
+   * {@link DescribeHandleLabel} draws for a cell's own labels — so an entry
+   * with no atoms says the column declares a label this cannot name, which is
+   * a different fact from a column that declares none and has no entry.
+   */
+  labels: DescribeHandleLabel[];
 }
 
 /** The label at one path inside a referent, as atom types and nothing else. */
@@ -67,9 +103,9 @@ export interface DescribeHandleLabel {
 
 /**
  * Describes the SHAPE of a handle's referent and nothing else: property
- * names, types, nesting, and required-ness. No value is ever read and none is
- * ever reported, so an answer here says what a reference is, never what it
- * holds. This is what lets an agent write code over a reference it was handed
+ * names, types, nesting, and required-ness. No datum is ever reported, so a
+ * reply here says what a reference is, never what it holds. This is what lets
+ * an agent write code over a reference it was handed
  * — you cannot compute over data whose shape you do not know — and what lets
  * an orchestrator verify a chain of transformations without reading the data
  * flowing through it.
@@ -105,6 +141,20 @@ export interface DescribeHandleLabel {
  * data without them — so they are the one channel of author-chosen text this
  * tool knowingly accepts.
  *
+ * A referent that declares no schema gets a third read, and it is the one
+ * place this tool reads a value. Some referents state their contract in their
+ * value rather than in their metadata, and a SQLite database handle is the
+ * case that matters: what the handle holds is the set of table schemas the
+ * database was created under, and the rows live in the database file, which
+ * nothing here opens. So where no schema was declared and the value is a
+ * database handle, its tables are reported as {@link DescribeHandleDatabase}
+ * — reduced by the same {@link schemaShapeOnly} pass, with the columns' own
+ * `ifc` annotations reported beside them as labels rather than left on the
+ * schema. Without that a database reads as an opaque value, and the code an
+ * agent writes over an opaque value is code that treats it as one. The read
+ * is conditional on there being no declared schema, so a referent that states
+ * its own shape is never opened.
+ *
  * A run with no fabric session still answers from its own table, so shape
  * stays inspectable in every run that has handles at all.
  *
@@ -123,7 +173,7 @@ export const describeHandleToolDescriptor: HarnessToolDescriptor = {
   toolId: "describe_handle",
   title: "Describe Handle",
   description:
-    "Report the shape of a general handle's referent and the CFC labels it carries: its recorded schema, path and label atom types, never its value. A capability-restricted handle returns a named refusal. Use it to check that a reference is the kind of thing a step expects, and what handling it demands, before passing it on.",
+    "Report the shape of a general handle's referent and the CFC labels it carries: its recorded schema, path and label atom types, never its data. A referent that is a SQLite database reports its tables instead of a schema, under `database`: the columns of each table with their types, and the labels those columns carry. Read such a referent with `db.query` over the handle rather than as a value. A capability-restricted handle returns a named refusal. Use it to check that a reference is the kind of thing a step expects, and what handling it demands, before passing it on.",
   effectClass: "read",
   inputSchema: {
     type: "object",
@@ -160,6 +210,30 @@ export const describeHandleToolDescriptor: HarnessToolDescriptor = {
           required: ["confidentiality", "integrity"],
           additionalProperties: false,
         },
+      },
+      database: {
+        type: "object",
+        properties: {
+          tables: {},
+          labels: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                path: { type: "array", items: { type: "string" } },
+                confidentiality: {
+                  type: "array",
+                  items: { type: "array", items: { type: "string" } },
+                },
+                integrity: { type: "array", items: { type: "string" } },
+              },
+              required: ["confidentiality", "integrity"],
+              additionalProperties: false,
+            },
+          },
+        },
+        required: ["tables", "labels"],
+        additionalProperties: false,
       },
       error: { type: "string" },
     },
@@ -208,26 +282,121 @@ const clauseTypes = (clause: unknown): string[] => {
 };
 
 /**
- * The labels the referent carries, read live through the session. Only atom
- * TYPES cross: an atom's other fields are whatever minted it wrote, and a
- * label is disclosed here so a run can tell what it is holding, not so it can
- * read what a label was computed from.
+ * One stored label as atom types alone. Only atom TYPES cross: an atom's
+ * other fields are whatever minted it wrote, and a label is disclosed here so
+ * a run can tell what it is holding, not so it can read what a label was
+ * computed from. The same projection serves a cell's own labels and a
+ * database column's `ifc`, which are the same structure stored in two places.
  */
+const labelAtomTypes = (
+  label: { confidentiality?: unknown[]; integrity?: unknown[] },
+): Omit<DescribeHandleLabel, "path"> => ({
+  confidentiality: (label.confidentiality ?? [])
+    .map(clauseTypes)
+    .filter((clause) => clause.length > 0),
+  integrity: (label.integrity ?? [])
+    .map(atomType)
+    .filter((type): type is string => type !== undefined),
+});
+
+/** The labels the referent carries, read live through the session. */
 const describedLabels = (cell: Cell<unknown>): DescribeHandleLabel[] =>
   (cfcLabelViewForCellFailClosed(cell)?.entries ?? []).map((entry) => ({
     ...(entry.path.length > 0 ? { path: [...entry.path] } : {}),
-    confidentiality: (entry.label.confidentiality ?? [])
-      .map(clauseTypes)
-      .filter((clause) => clause.length > 0),
-    integrity: (entry.label.integrity ?? [])
-      .map(atomType)
-      .filter((type): type is string => type !== undefined),
+    ...labelAtomTypes(entry.label),
   }));
+
+/**
+ * The table contract `value` states, or nothing when it is not a SQLite
+ * database handle or names no tables. A handle's tables are the schemas the
+ * database was created under — a declaration, in the same sense a document's
+ * schema is one — so what leaves here is the same structure every other
+ * disclosure is reduced to, plus the columns' labels.
+ */
+const describedDatabase = (
+  value: unknown,
+): DescribeHandleDatabase | undefined => {
+  if (!isSqliteDbRef(value)) {
+    return undefined;
+  }
+  const tables = value.tables;
+  if (tables === null || typeof tables !== "object") {
+    return undefined;
+  }
+  const labels: DescribeHandleLabel[] = [];
+  for (const [table, spec] of Object.entries(tables)) {
+    const columns =
+      (spec as { properties?: Record<string, { ifc?: unknown }> } | null)
+        ?.properties;
+    for (const [column, declaration] of Object.entries(columns ?? {})) {
+      const ifc = declaration?.ifc;
+      if (columnDeclaresIfc(ifc)) {
+        labels.push({
+          path: [table, column],
+          ...labelAtomTypes(ifc as Parameters<typeof labelAtomTypes>[0]),
+        });
+      }
+    }
+  }
+  // Wrapping the tables as one schema's properties is what puts the table
+  // names through the same bound and the same reduction the column names
+  // already go through: a table is an object whose properties are its
+  // columns, which is what the reduction already knows how to walk.
+  return {
+    tables: schemaShapeOnly({
+      type: "object",
+      properties: tables as Record<string, JSONSchema>,
+    }),
+    labels,
+  };
+};
+
+/**
+ * The schema declared for the referent at `path`, or nothing when none is.
+ * A document's declared schema narrowed by a path is a walk over the schema
+ * rather than a read of the data, so nothing here goes near a value; the
+ * referent's own schema is the last resort, since with no declared schema
+ * there is nothing to walk.
+ */
+const declaredSchema = async (
+  root: Cell<unknown>,
+  referent: Cell<unknown>,
+  path: readonly (string | number)[],
+  documentSchema: JSONSchema | undefined,
+): Promise<JSONSchema | undefined> => {
+  if (path.length === 0) {
+    return documentSchema ?? root.schema;
+  }
+  if (documentSchema !== undefined) {
+    return ((root.asSchema(documentSchema) as Cell<unknown>).key(
+      ...path,
+    ) as Cell<unknown>).schema;
+  }
+  await referent.sync();
+  return referent.schema;
+};
+
+/**
+ * The referent's table contract as a fragment to spread, empty where it has
+ * none. The read is permissive-schema and resolving because a handle written
+ * before the sqlite builtin stored it inline can hold links where its table
+ * schemas belong, and the SqliteDb shape declares no properties, so a shaped
+ * read would reduce the handle to `{}`.
+ */
+const databaseOf = (
+  referent: Cell<unknown>,
+): Pick<DescribedReferent, "database"> => {
+  const database = describedDatabase(
+    referent.asSchema({ type: "object", additionalProperties: true }).get(),
+  );
+  return database === undefined ? {} : { database };
+};
 
 /** What the session can state about `ref`: its declared shape, and its labels. */
 interface DescribedReferent {
   schema?: JSONSchema;
   labels?: DescribeHandleLabel[];
+  database?: DescribeHandleDatabase;
 }
 
 /**
@@ -274,23 +443,18 @@ const describeInFabric = async (
       (link.path.length === 0 ? root : root.key(...link.path)) as Cell<unknown>;
     const labels = describedLabels(referent);
     const documentSchema = root.getMetaRaw("schema") as JSONSchema | undefined;
-    if (link.path.length === 0) {
-      const schema = documentSchema ?? root.schema;
-      return { labels, ...(schema !== undefined ? { schema } : {}) };
+    const declared = await declaredSchema(
+      root,
+      referent,
+      link.path,
+      documentSchema,
+    );
+    if (declared !== undefined) {
+      return { labels, schema: declared };
     }
-    if (documentSchema !== undefined) {
-      // Narrowing a declared schema by a path is a walk over the schema, so
-      // the referent's shape is in hand without going near its value.
-      const schema = ((root.asSchema(documentSchema) as Cell<unknown>).key(
-        ...link.path,
-      ) as Cell<unknown>).schema;
-      return { labels, ...(schema !== undefined ? { schema } : {}) };
-    }
-    // With no declared schema there is nothing to walk, and only the referent
-    // itself can state a shape.
-    await referent.sync();
-    const schema = referent.schema;
-    return { labels, ...(schema !== undefined ? { schema } : {}) };
+    // Nothing was declared, so the referent's own value is the only place a
+    // contract can still be stated, and a database handle states one there.
+    return { labels, ...databaseOf(referent) };
   } catch {
     return {};
   }
@@ -360,6 +524,9 @@ export const describeHandleTool: HarnessToolDefinition<
       ...(disclosed !== undefined ? { schema: disclosed } : {}),
       ...(path !== undefined ? { path } : {}),
       ...(described.labels !== undefined ? { labels: described.labels } : {}),
+      ...(described.database !== undefined
+        ? { database: described.database }
+        : {}),
     };
   },
 };

--- a/packages/cf-harness/src/tools/describe-handle.ts
+++ b/packages/cf-harness/src/tools/describe-handle.ts
@@ -79,7 +79,10 @@ export interface DescribeHandleDatabase {
    * and its column name. Atom types and nothing else, the same line
    * {@link DescribeHandleLabel} draws for a cell's own labels — so an entry
    * with no atoms says the column declares a label this cannot name, which is
-   * a different fact from a column that declares none and has no entry.
+   * a different fact from a column that declares none and has no entry. A
+   * path names a column only where {@link tables} names it too: the bound on
+   * the property-name channel holds across both, so a column the reduction
+   * refused is absent from this list as well.
    */
   labels: DescribeHandleLabel[];
 }
@@ -306,6 +309,37 @@ const describedLabels = (cell: Cell<unknown>): DescribeHandleLabel[] =>
     ...labelAtomTypes(entry.label),
   }));
 
+/** The properties `schema` declares, empty when it declares none. */
+const schemaProperties = (
+  schema: JSONSchema | undefined,
+): Record<string, JSONSchema> =>
+  schema !== undefined && typeof schema === "object" && !Array.isArray(schema)
+    ? (schema.properties ?? {}) as Record<string, JSONSchema>
+    : {};
+
+/**
+ * Every `(table, column)` a reduced table schema still names. The reduction
+ * has already dropped whatever it refused, so walking its output rather than
+ * its input is what holds a second disclosure to the first one's bound.
+ */
+function* disclosedColumns(
+  reduced: JSONSchema,
+): Generator<[string, string]> {
+  for (const [table, spec] of Object.entries(schemaProperties(reduced))) {
+    for (const column of Object.keys(schemaProperties(spec))) {
+      yield [table, column];
+    }
+  }
+}
+
+/** The columns `table` declares in the handle's own tables, as authored. */
+const declaredColumns = (
+  tables: object,
+  table: string,
+): Record<string, { ifc?: unknown } | undefined> =>
+  ((tables as Record<string, { properties?: unknown } | undefined>)[table]
+    ?.properties ?? {}) as Record<string, { ifc?: unknown } | undefined>;
+
 /**
  * The table contract `value` states, or nothing when it is not a SQLite
  * database handle or names no tables. A handle's tables are the schemas the
@@ -323,32 +357,29 @@ const describedDatabase = (
   if (tables === null || typeof tables !== "object") {
     return undefined;
   }
-  const labels: DescribeHandleLabel[] = [];
-  for (const [table, spec] of Object.entries(tables)) {
-    const columns =
-      (spec as { properties?: Record<string, { ifc?: unknown }> } | null)
-        ?.properties;
-    for (const [column, declaration] of Object.entries(columns ?? {})) {
-      const ifc = declaration?.ifc;
-      if (columnDeclaresIfc(ifc)) {
-        labels.push({
-          path: [table, column],
-          ...labelAtomTypes(ifc as Parameters<typeof labelAtomTypes>[0]),
-        });
-      }
-    }
-  }
   // Wrapping the tables as one schema's properties is what puts the table
   // names through the same bound and the same reduction the column names
   // already go through: a table is an object whose properties are its
   // columns, which is what the reduction already knows how to walk.
-  return {
-    tables: schemaShapeOnly({
-      type: "object",
-      properties: tables as Record<string, JSONSchema>,
-    }),
-    labels,
-  };
+  const reduced = schemaShapeOnly({
+    type: "object",
+    properties: tables as Record<string, JSONSchema>,
+  });
+  // A label names the column it came off, so its path is the same
+  // property-name channel the reduction bounds — which is why the names it
+  // reports are read back off the reduced schema rather than off the tables.
+  // A column the reduction refused is a column no label may name either.
+  const labels: DescribeHandleLabel[] = [];
+  for (const [table, column] of disclosedColumns(reduced)) {
+    const ifc = declaredColumns(tables, table)[column]?.ifc;
+    if (columnDeclaresIfc(ifc)) {
+      labels.push({
+        path: [table, column],
+        ...labelAtomTypes(ifc as Parameters<typeof labelAtomTypes>[0]),
+      });
+    }
+  }
+  return { tables: reduced, labels };
 };
 
 /**

--- a/packages/cf-harness/test/describe-handle.test.ts
+++ b/packages/cf-harness/test/describe-handle.test.ts
@@ -1015,6 +1015,45 @@ describe("describe_handle", () => {
         expect(reply).not.toContain("The Inbox");
       });
 
+      it("bounds a column name in a label the way it bounds it in the tables", async () => {
+        // A column name is disclosed through two channels: the reduced table
+        // schema, which bounds it, and a label's path, which names the column
+        // it came off. A name the reduction refused has to be refused in both,
+        // or the label path is the prose channel the reduction exists to close.
+
+        const longColumn = "c".repeat(MAX_PROPERTY_NAME_LENGTH + 1);
+        const ref = await seedUndeclaredCell({
+          id: "db-long-column",
+          tables: {
+            messages: {
+              type: "object",
+              properties: {
+                [longColumn]: {
+                  type: "string",
+                  ifc: {
+                    confidentiality: ["https://cfc.test/atom/email"],
+                  },
+                },
+              },
+            },
+          },
+        });
+        const minted = await mintAddressHandle(
+          createHarnessHandleTable("run-describe"),
+          ref,
+        );
+
+        const output = await describeHandleTool.invoke(
+          contextWith(minted.table, session),
+          { token: minted.token },
+        );
+
+        expect(JSON.stringify(output.database?.tables)).not.toContain(
+          longColumn,
+        );
+        expect(JSON.stringify(output)).not.toContain(longColumn);
+      });
+
       it("reports nothing about a database whose handle names no tables", async () => {
         const ref = await seedUndeclaredCell({ id: "db-with-no-tables" });
         const minted = await mintAddressHandle(

--- a/packages/cf-harness/test/describe-handle.test.ts
+++ b/packages/cf-harness/test/describe-handle.test.ts
@@ -159,6 +159,48 @@ const SPENDING_PATTERN_SOURCE = [
 ].join("\n");
 
 /**
+ * A SQLite database handle in the shape one arrives in when a connector
+ * injects it: the tables it was created under, carried in the handle's own
+ * value, with nothing declaring a schema for the cell that holds it. The
+ * table title, the column description and the column default are the prose
+ * and values a reduction has to drop; the `ifc` annotations are what a reader
+ * has to be told.
+ */
+const MAIL_DB_HANDLE = {
+  id: "db-mail",
+  rev: 3,
+  tables: {
+    messages: {
+      type: "object",
+      title: "The Inbox",
+      properties: {
+        sender: {
+          type: "string",
+          default: "noreply@example.test",
+          ifc: {
+            confidentiality: ["https://cfc.test/atom/email"],
+            integrity: ["https://cfc.test/atom/connector-observed"],
+          },
+        },
+        body: {
+          type: "string",
+          description: "every message this connector observed",
+          ifc: {
+            confidentiality: [{
+              anyOf: [
+                "https://cfc.test/atom/email",
+                "https://cfc.test/atom/screened",
+              ],
+            }],
+          },
+        },
+        received: { type: "integer" },
+      },
+    },
+  },
+};
+
+/**
  * The context members `describe_handle` reads. Everything else on a tool
  * context — sandbox, host runner — is deliberately unused by this tool, so a
  * stub that supplies more would misstate what it can reach.
@@ -305,6 +347,11 @@ describe("describe_handle", () => {
     expect(output.known).toBe(false);
     expect(output.hasSchema).toBe(false);
     expect(output.token).toBe("cfh:a:zzzzz");
+    // A token that names nothing has nothing to report about, database
+    // handles included: the reply's fields are these four and no others.
+    expect(Object.keys(output).sort()).toEqual(
+      ["hasSchema", "known", "outputId", "token"],
+    );
   });
 
   it("reports any token as unknown in a run that has minted none", async () => {
@@ -870,6 +917,138 @@ describe("describe_handle", () => {
 
       expect(output.known).toBe(true);
       expect(output.hasSchema).toBe(false);
+    });
+
+    describe("a referent that is a database", () => {
+      /**
+       * Seeds a cell holding `value` and declaring no schema, and returns a
+       * reference to it — the shape a database injected by a connector
+       * arrives in, where the shape is in the value and nothing declares it.
+       */
+      const seedUndeclaredCell = async (value: unknown): Promise<string> => {
+        const space = session.pieces.getSpace();
+        const seed = runtime.edit();
+        const cell = runtime.getCell(
+          space,
+          `describe-handle-db-${crypto.randomUUID()}`,
+          undefined,
+          seed,
+        );
+        const id = cell.getAsNormalizedFullLink().id;
+        seed.writeOrThrow({ space, scope: "space", id, path: [] }, {
+          value,
+        } as FabricValue);
+        expect((await seed.commit()).ok).toBeDefined();
+        return `/${id}`;
+      };
+
+      it("discloses the tables and the columns' labels of a database that declares no schema", async () => {
+        const ref = await seedUndeclaredCell(MAIL_DB_HANDLE);
+        const minted = await mintAddressHandle(
+          createHarnessHandleTable("run-describe"),
+          ref,
+        );
+
+        const output = await describeHandleTool.invoke(
+          contextWith(minted.table, session),
+          { token: minted.token },
+        );
+
+        expect(output.hasSchema).toBe(false);
+        expect(output.database?.tables).toEqual({
+          type: "object",
+          properties: {
+            messages: {
+              type: "object",
+              properties: {
+                sender: { type: "string" },
+                body: { type: "string" },
+                received: { type: "integer" },
+              },
+            },
+          },
+        });
+        // Ordered by column here, since the order the columns come back in is
+        // the storage layer's business rather than part of the disclosure.
+        const labels = [...(output.database?.labels ?? [])].sort((a, b) =>
+          (a.path ?? []).join(".").localeCompare((b.path ?? []).join("."))
+        );
+        expect(labels).toEqual([
+          {
+            path: ["messages", "body"],
+            confidentiality: [[
+              "https://cfc.test/atom/email",
+              "https://cfc.test/atom/screened",
+            ]],
+            integrity: [],
+          },
+          {
+            path: ["messages", "sender"],
+            confidentiality: [["https://cfc.test/atom/email"]],
+            integrity: ["https://cfc.test/atom/connector-observed"],
+          },
+        ]);
+      });
+
+      it("reports no row of the database and no prose off its table schemas", async () => {
+        // The tables are a declaration, so what the reduction does to a
+        // declared schema it must do here: the column default, the column
+        // description and the table title are all author-chosen text on the
+        // one structure this tool now reads out of a value.
+        const ref = await seedUndeclaredCell(MAIL_DB_HANDLE);
+        const minted = await mintAddressHandle(
+          createHarnessHandleTable("run-describe"),
+          ref,
+        );
+
+        const output = await describeHandleTool.invoke(
+          contextWith(minted.table, session),
+          { token: minted.token },
+        );
+
+        // Stated first, so the checks below cannot pass on a reply that
+        // disclosed nothing at all.
+        expect(output.database?.labels).toHaveLength(2);
+        const reply = JSON.stringify(output);
+        expect(reply).not.toContain("every message this connector observed");
+        expect(reply).not.toContain("noreply@example.test");
+        expect(reply).not.toContain("The Inbox");
+      });
+
+      it("reports nothing about a database whose handle names no tables", async () => {
+        const ref = await seedUndeclaredCell({ id: "db-with-no-tables" });
+        const minted = await mintAddressHandle(
+          createHarnessHandleTable("run-describe"),
+          ref,
+        );
+
+        const output = await describeHandleTool.invoke(
+          contextWith(minted.table, session),
+          { token: minted.token },
+        );
+
+        expect(output.known).toBe(true);
+        expect(output.database).toBeUndefined();
+      });
+
+      it("does not read the value of a referent that declares a schema", async () => {
+        // The value read is conditional on nothing being declared. A piece
+        // states its own shape, so the reply is the shape and the database
+        // field is absent — which is also what says a value was never opened.
+        const resultRef = await createPiece();
+        const minted = await mintAddressHandle(
+          createHarnessHandleTable("run-describe"),
+          resultRef,
+        );
+
+        const output = await describeHandleTool.invoke(
+          contextWith(minted.table, session),
+          { token: minted.token },
+        );
+
+        expect(output.hasSchema).toBe(true);
+        expect(output.database).toBeUndefined();
+      });
     });
   });
 

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -1526,6 +1526,16 @@ export type SqliteDbRef = {
   owner?: string;
 };
 
+/** Whether `value` is a SQLite db handle. The `id` is the whole of the test:
+ *  it is the one field every consumer needs and the one the runner's own
+ *  handle read validates, and the rest of the shape is optional. Shared so
+ *  that a reader deciding "is this a database?" and the runner deciding "may
+ *  I query it?" cannot drift apart. */
+export function isSqliteDbRef(value: unknown): value is SqliteDbRef {
+  return !!value && typeof value === "object" &&
+    typeof (value as SqliteDbRef).id === "string";
+}
+
 export type SqliteQueryRequest = {
   type: "sqlite.query";
   requestId: string;

--- a/packages/runner/src/builtins/sqlite-builtins.ts
+++ b/packages/runner/src/builtins/sqlite-builtins.ts
@@ -52,6 +52,7 @@ import {
 import { validateRowLabelSpec } from "@commonfabric/memory/sqlite/row-label";
 import {
   columnDeclaresIfc,
+  isSqliteDbRef,
   type SqliteDbRef as WireSqliteDbRef,
   type SqliteParamsWire,
   sqliteRowToWire,
@@ -158,10 +159,7 @@ function makeResultCell<T>(
 }
 
 function readDbRef(value: unknown): SqliteDbRef {
-  if (
-    value && typeof value === "object" &&
-    typeof (value as SqliteDbRef).id === "string"
-  ) {
+  if (isSqliteDbRef(value)) {
     const ref = value as SqliteDbRef;
     return {
       id: ref.id,


### PR DESCRIPTION
## What changed

**1. `describe_handle` discloses an injected database's table contract.**

A cell holding a SQLite database handle declares no schema, so `describe_handle`
had nothing to report about one. Where a referent declares no schema and its
value is a database handle, the reply now carries a new `database` field:

- `tables` — one property per table, whose own properties are that table's
  columns with their declared types;
- `labels` — one entry per column that declares an `ifc`, addressed by
  `[table, column]`, as atom types and nothing else.

**Why a new field rather than `schema` or `labels`.** Putting the tables in
`schema` would state a shape the referent does not have: a model reading
`{properties: {messages: {...}}}` has every reason to try `mail.messages`, and
the handle is not an object with a `messages` property — it is a database you
read with `db.query`. Putting the columns' `ifc` in `labels` would mix two
different facts under one key: `labels` is what the *cell* carries, read from
its CFC metadata, while a column's `ifc` is part of the table contract stored
in the handle's value. A field named `database` says what the referent is, which
is the one thing the model needed and could not previously learn. The tool
descriptor's `outputSchema` declares it, and the tool description tells the
model to read such a referent with `db.query`.

**The disclosure boundary moves, and the documents move with it.** This is the
one place the tool reads a value, so:

- it is conditional on the referent declaring no schema — a referent that states
  its own shape is never opened;
- no row is ever reached: `tables` is the contract the database was *created
  under*, and the rows live in the database file, which nothing here opens;
- the tables go through the same `schemaShapeOnly` reduction every disclosed
  schema does, so the table- and column-name channels are bounded exactly as a
  property-name channel is, and column defaults, descriptions and table titles
  do not ride out. The existing deep bare-fabric-identifier scrub at the
  prompt-loop boundary already covers the new field.

`isSqliteDbRef` is added beside `SqliteDbRef` in `@commonfabric/memory/v2`, next
to `columnDeclaresIfc` and `dbNeedsColumnProvenance`, and the runner's own
`readDbRef` uses it — so the reader deciding "is this a database?" and the
runner deciding "may I query it?" cannot drift apart.

Live documents updated in the same change: `packages/cf-harness/README.md` (the
"Inspecting a handle's shape" section, the tool list, and the `effectClass:
"read"` paragraph that said the tool reads no value), `docs/CURRENT_STATE.md`,
`docs/IMPLEMENTATION_PROFILE.md`, and the system map — its gap-4 `close` entry,
the demo-2 walk caption, and `SNAPSHOT`, per
`docs/system-map/README.md`'s update procedure.

**2. `docs/common/capabilities/sqlite.md`.**

`query_docs`'s corpus roots are `docs/common`, `docs/development` and `skills`;
`docs/specs/sqlite-builtin/` — the only place `db.query` is documented — is not
among them. Rather than widen the roots, this adds one live document under
`docs/common/capabilities/` (beside `llm.md` and `fetch.md`, which are the same
kind of thing: a built-in reactive read) covering `db.query` over a handle
input, one statement per database, session-scoped results under a runtime read
ceiling, labeled columns, and a pointer to the spec for the rest. Indexed in
`docs/common/README.md`.

## The receipt that motivated it

Probe A (2026-09-07, CT-2189 gap 4; run `f2e48c15…`): a cf-harness session over
a real Gmail connector handle never issued a `db.query`. `describe_handle` on
the injected handle returned `{"known":true,"hasSchema":false,"labels":[]}`,
while `cf cell get` on the same ref returns a SqliteDb handle value with 30
tables and per-column `ifc`. The model treated the database as a blob and fed
the stringified handle to `generateObject`. Separately, 7 of 10 `query_docs`
calls answered that no section describes querying an injected SQLite handle.

## Gates run

`deno fmt --check`, `deno lint`, `deno task check`, `deno task test` in
`packages/cf-harness` (1004 passed / 0 failed), `packages/memory` (602 passed),
the runner's sqlite tests (29 passed), `deno task check-docs`,
`check-skill-facts`, `check-package-cycles`, `check-docs-history-index`,
`check-command-docs`. Self-reviewed with the `cf-review` skill.

## Re-run

Probe A re-run from this branch (run `451f8f07…`), identical task text, input
cell, environment and posture. **The question it was run to answer — does a
model that can see the tables issue a `db.query`? — is answered yes, on the
first attempt.** The pattern-author subagent's first `run_pattern` declared
`type Input = { mail: SqliteDb }` and issued a real CTE `SELECT` over
`messages` / `participants` / `message_bodies`, filtered to the current month,
with `{ scope: "session" }` — the session-scope fact the new doc supplies, and
one it had no way to know before.

Nothing landed, and the reason has moved. The delivered handle is a plain
`{id, rev, tables}` value with no method surface, and the branded type cannot
be named in a pattern signature:

- `run_pattern:16` → `rawCauseMessage: "mail.query is not a function"`;
- `Default export of the module has or is using private name '__sqliteDb'`,
  four times, whenever `SqliteDb` is used in the exported `Input` type;
- 36 of subagent 2's attempts were runtime shape probes of the handle, which
  returned `hasQuery: false`, `keyCount: 3`, `tableCount: 30`.

The run then failed on `provider-unavailable — OpenAI Codex usage limit
reached`. Totals against probe A: **79 turns / 1.57M tokens / 15m20s / 61
`run_pattern` attempts**, versus probe A's 19 / 5m09s / 5. `deno task
cfc-audit`: 54 checks over 3 runs — FAIL 6, WARN 6, PASS 33, N/A 9; every one a
declared known defect (CT-2175 H9, CT-2216 H2, CT-2217 H8), none new.
`query_docs`: 10 calls, 5 answered substantively, and
`common/capabilities/sqlite.md` is cited in 4 of them and is the sole citation
of 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
